### PR TITLE
test(app-shell): stub useMetadataClient in metadata-admin inspector suites

### DIFF
--- a/.changeset/metadata-admin-inspector-client-doubles.md
+++ b/.changeset/metadata-admin-inspector-client-doubles.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only change: stub `useMetadataClient` in the app-shell metadata-admin
+inspector suites so `useObjectFields`/`useObjectOptions` no longer escape to
+the real network under happy-dom (ECONNREFUSED noise, no behaviour change).

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.celGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.celGate.test.tsx
@@ -25,6 +25,18 @@ import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
 
+// objectui#4697 — ActionDefaultInspector calls useObjectOptions() and
+// useObjectFields(objectName) unconditionally (the object/field pickers behind
+// its two ConditionBuilders). Stub the shared client so that mount-time fetch
+// doesn't escape to the real network; see PageBlockInspector.i18n.test.tsx for
+// the full mechanism.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
 import { ActionDefaultInspector } from './ActionDefaultInspector';
 import { __setCelFormulaLoader } from '../celAuthoring';
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.celGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.celGate.test.tsx
@@ -31,6 +31,18 @@ import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 
+// objectui#4697 — ConditionBuilder calls useObjectFields(objectName)
+// unconditionally even when a `fields` prop is supplied (the prop only
+// overrides the VALUE used, not whether the hook's own effect fetches). Stub
+// the shared client so that mount-time fetch doesn't escape to the real
+// network; see PageBlockInspector.i18n.test.tsx for the full mechanism.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
 import { ConditionBuilder } from './ConditionBuilder';
 import { __setCelFormulaLoader } from '../celAuthoring';
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.test.tsx
@@ -11,9 +11,22 @@
  */
 
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+// objectui#4697 — ConditionBuilder calls useObjectFields(objectName)
+// unconditionally even when a `fields` prop is supplied (the prop only
+// overrides the VALUE used, not whether the hook's own effect fetches). Stub
+// the shared client so that mount-time fetch doesn't escape to the real
+// network; see PageBlockInspector.i18n.test.tsx for the full mechanism.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
 import { ConditionBuilder } from './ConditionBuilder';
 import { __setCelFormulaLoader } from '../celAuthoring';
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.celGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.celGate.test.tsx
@@ -21,6 +21,18 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { HookSchema } from '@objectstack/spec/data';
 
+// objectui#4697 — HookDefaultInspector calls useObjectOptions() unconditionally
+// (the "Object(s) this hook fires on" picker) even though every fixture here
+// uses `object: '*'` and never renders the picker's options. Stub the shared
+// client so that mount-time fetch doesn't escape to the real network; see
+// PageBlockInspector.i18n.test.tsx for the full mechanism.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
 import { HookDefaultInspector } from './HookDefaultInspector';
 import { __setCelFormulaLoader } from '../celAuthoring';
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.condition.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.condition.test.tsx
@@ -30,6 +30,19 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { HookSchema } from '@objectstack/spec/data';
+
+// objectui#4697 — HookDefaultInspector calls useObjectOptions() unconditionally
+// (the "Object(s) this hook fires on" picker) even though every fixture here
+// uses `object: '*'` and never renders the picker's options. Stub the shared
+// client so that mount-time fetch doesn't escape to the real network; see
+// PageBlockInspector.i18n.test.tsx for the full mechanism.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
 import { HookDefaultInspector } from './HookDefaultInspector';
 
 afterEach(cleanup);

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
@@ -19,14 +19,35 @@
  * translation exists" but "this panel does not ask for one".
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PageSchema } from '@objectstack/spec/ui';
-import { PageBlockInspector } from './PageBlockInspector';
 import { t } from '../i18n';
+
+/**
+ * objectui#4697 — PageBlockInspector reaches `useObjectFields`/`useObjectOptions`
+ * unconditionally (ObjectPickerField, FieldPickerField, and the ConditionBuilder
+ * it mounts for `visibleWhen`), and both fire a mount-time fetch with no
+ * override. Under happy-dom with no server listening that is a real, failing
+ * network call (ECONNREFUSED noise) — harmless (both hooks degrade to an empty
+ * list on any transport error, the same end state this stub produces) but
+ * loud. A STABLE stub client (never a fresh object per call: the hooks' effects
+ * key off `[client, ...]`, so a new identity every render would re-fire them
+ * forever — see FlowReferenceField.lookup.test.tsx, the in-package precedent)
+ * short-circuits the fetch instead. No assertion in this file reads the
+ * fetched object list/fields.
+ */
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
+import { PageBlockInspector } from './PageBlockInspector';
 
 afterEach(cleanup);
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.sectionName.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.sectionName.test.tsx
@@ -42,6 +42,17 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { PageSchema } from '@objectstack/spec/ui';
+
+// objectui#4697 — see PageBlockInspector.i18n.test.tsx for the full mechanism;
+// same stub, short-circuiting useObjectFields/useObjectOptions's mount-time
+// fetch instead of letting it escape to the real network.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
 import { PageBlockInspector } from './PageBlockInspector';
 
 afterEach(cleanup);

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.celGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.celGate.test.tsx
@@ -29,6 +29,19 @@ import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 
+// objectui#4697 — ViewVariantInspector calls useObjectOptions() (the object
+// picker) unconditionally, and useObjectFields(binding.value, override) skips
+// its fetch only when an override is supplied — the `viaViewInspector` path
+// below reaches ViewInspector, which forwards no override, so that leg still
+// fetches for real. Stub the shared client so neither escapes to the real
+// network; see PageBlockInspector.i18n.test.tsx for the full mechanism.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
 import { ViewVariantInspector } from './ViewVariantInspector';
 import { ViewInspector } from './ViewInspector';
 import { __setCelFormulaLoader } from '../celAuthoring';

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.homeGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.homeGate.test.tsx
@@ -22,9 +22,21 @@ import '@testing-library/jest-dom/vitest';
 import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
+
+// objectui#4697 — ViewDefaultInspector renders ViewVariantInspector with no
+// `objectFieldsOverride`, so useObjectFields(binding.value) and
+// useObjectOptions() both fetch for real. Stub the shared client so neither
+// escapes to the real network; see PageBlockInspector.i18n.test.tsx for the
+// full mechanism.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
 
 import { ViewDefaultInspector } from './ViewInspector';
-import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
 import { __setCelFormulaLoader } from '../celAuthoring';
 
 /**


### PR DESCRIPTION
Fixes #4697

## What

`packages/app-shell/src/views/metadata-admin/previews/useObjectFields.ts` and
`useObjectOptions.ts` both call `useMetadataClient()` unconditionally in a
mount-time `useEffect`, which escapes to the real network under happy-dom
(`ECONNREFUSED 127.0.0.1:3000` — harmless noise, since both hooks already
degrade to an empty result on any transport error). Stubs `useMetadataClient`
in the 9 files the card named, in
`packages/app-shell/src/views/metadata-admin/inspectors/`:

- `PageBlockInspector.i18n.test.tsx`
- `PageBlockInspector.sectionName.test.tsx`
- `ConditionBuilder.celGate.test.tsx`
- `HookDefaultInspector.condition.test.tsx`
- `ViewVariantInspector.celGate.test.tsx`
- `ViewVariantInspector.homeGate.test.tsx`
- `ActionDefaultInspector.celGate.test.tsx`
- `ConditionBuilder.test.tsx`
- `HookDefaultInspector.celGate.test.tsx`

Each file gets its own `vi.hoisted()` + `vi.mock('../useMetadata', …)` block
(mirroring the in-package precedent, `FlowReferenceField.lookup.test.tsx`),
with a **stable** stub client (`{ get, list }` both resolving to an empty
result) — stable identity matters because the hooks' effects key off
`[client, …]`, so a fresh object per call would re-fire them every render.
No shared helper file: 9 short, self-contained blocks stayed easier to review
than a new cross-file abstraction for this size of change.

Tests-only — no production source touched. `.changeset/metadata-admin-inspector-client-doubles.md`
declares an empty-frontmatter release (test-only, precedent #4641/#4666/#4671).

## Acceptance = measured zero

Every file re-run **isolated** (`pnpm exec vitest run <file> --maxWorkers=1`
— batched runs undercount, per the card):

| file | ECONNREFUSED before | after |
| --- | --- | --- |
| `PageBlockInspector.i18n.test.tsx` | 70 | 0 |
| `PageBlockInspector.sectionName.test.tsx` | 40 | 0 |
| `ConditionBuilder.celGate.test.tsx` | 12 | 0 |
| `HookDefaultInspector.condition.test.tsx` | 12 | 0 |
| `ViewVariantInspector.celGate.test.tsx` | 12 | 0 |
| `ViewVariantInspector.homeGate.test.tsx` | 12 | 0 |
| `ActionDefaultInspector.celGate.test.tsx` | 8 | 0 |
| `ConditionBuilder.test.tsx` | 8 | 0 |
| `HookDefaultInspector.celGate.test.tsx` | 6 | 0 |

Sum 180 → 0, exactly matching the card's baseline. Every assertion unchanged
(same pass counts before/after: 22, 9, 6, 6, 4, 2, 4, 4, 3 — 60 tests total).

Full directory suites also re-run clean:
`packages/app-shell/src/views/metadata-admin/inspectors/` → 53 files, 590
passed | 1 skipped (pre-existing skip, unrelated), 0 ECONNREFUSED.
`packages/app-shell/src/views/metadata-admin/` (the whole area) → 167 files,
1671 passed | 1 skipped, 0 ECONNREFUSED.

**Reverse verification** (direction predicted first: reverting the stub
should return the count to baseline with tests still green — proving the stub,
not something else, is what silences the noise): committed the fix, then
`git checkout HEAD~1 -- .../PageBlockInspector.i18n.test.tsx` (the biggest
file) → re-ran isolated → **70** ECONNREFUSED, 22/22 still passing, confirming
prediction. Restored with `git checkout <fix-sha> -- <path>` → back to 0.

## Out-of-scope finding

While measuring the full `metadata-admin/` suite for step 2 of the verification,
found a **different** escape (`ECONNRESET`/"socket hang up", not
`ECONNREFUSED` — a different transport mechanism) in
`previews/FlowCanvas.test.tsx` (19 lines isolated). Filed unassigned as #4699,
not touched here — out of scope for this card.

## Local gate union at HEAD `b65801b2d`

- `pnpm --filter '@object-ui/app-shell^...' build` — dependency closure built first (green).
- `pnpm --filter @object-ui/app-shell run type-check` — `tsc --noEmit && tsc -p tsconfig.test.json` — green.
- `pnpm exec eslint --quiet <the 9 files>` — clean, no output.
- The 9 files isolated + the `inspectors/` and full `metadata-admin/` directory suites (above).
- `node scripts/check-changeset-presence.mjs` — green (empty-frontmatter changeset declared).
- `pnpm run check:control-bytes` — green.

`scripts/pm/dispatch-gates.mjs` does not exist in this repo (checked — it
appears to be an `objectstack` script, not `objectui`); re-derived the
implicated gate families by hand against the actual diff (9 `.test.tsx` files
under `packages/app-shell/src/views/metadata-admin/inspectors/` + one
changeset) — no new error codes, no `.claude/agents/**` changes, no new fake
engine, no `t()` call-site changes, no doc changes, so no family beyond the
ones already named/run above is implicated.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_