### PR TITLE
test(app-shell): stub the automation/actions fetch in FlowCanvas.test.tsx

### DIFF
--- a/.changeset/flowcanvas-network-double.md
+++ b/.changeset/flowcanvas-network-double.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: stub `fetch` for the `automation/actions` endpoint in
+`FlowCanvas.test.tsx` so the suite no longer escapes to the real network
+(`ECONNRESET`/"socket hang up" noise from happy-dom's own `http`-backed fetch
+polyfill); no published behaviour changes.

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import * as React from 'react';
-import { describe, it, expect, afterEach, vi, type Mock } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi, type Mock } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { FlowCanvas } from './FlowCanvas';
 import { extractRegions, NODE_H } from './flow-canvas-layout';
@@ -9,6 +9,36 @@ import { predictExpandedNodeHeight } from './flow-region-metrics';
 import type { FlowProblem } from './flow-problems';
 
 afterEach(cleanup);
+
+/**
+ * objectui#4699 — every `<FlowCanvas>` mount pulls in `useFlowNodePalette` →
+ * `useActionDescriptors`, which fires a real `GET ${apiBase()}/automation/
+ * actions` on mount and aborts it (AbortController) on unmount — the engine's
+ * server-published node-palette overlay, source-controlled offline fallback
+ * `NODE_PALETTE`. This vitest `dom` project's happy-dom environment answers
+ * `fetch` with its OWN polyfill (backed by Node's `http`/`https` core client,
+ * not undici — see `happy-dom/lib/fetch/Fetch.js`'s `import HTTP from
+ * 'http'`), so with nothing listening the abort races a REAL socket and Node
+ * prints an unhandled `Error: socket hang up` / `ECONNRESET` per mount (19
+ * lines isolating this file — a different transport than the plain-fetch
+ * `ECONNREFUSED` family in #4688/#4697, which goes through undici's global
+ * fetch instead). None of the assertions below exercise the server overlay,
+ * so answer the endpoint with "engine absent" (404) — the exact degrade the
+ * hook already falls back from — instead of letting a real connection open.
+ */
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      expect(String(url)).toBe('/api/v1/automation/actions');
+      return new Response('not found', { status: 404 });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 /**
  * ADR-0044: an un-declared cycle is surfaced INLINE on the canvas — the


### PR DESCRIPTION
Fixes #4699

## Mechanism (measured, not assumed)

`FlowCanvas.tsx` (line 169) calls `useFlowNodePalette()` → `useActionDescriptors()`
(`useFlowNodePalette.ts`), which fires a real `GET ${apiBase()}/automation/actions`
(`apiBase()` resolves to `/api/v1` with `VITE_SERVER_URL` unset in tests) in a
mount-time `useEffect` and aborts it via `AbortController` on unmount.

This repo's vitest `dom` project (`environment: 'happy-dom'`,
`vitest.setup.dom-light.tsx` — no fetch mock) resolves the global `fetch` to
**happy-dom's own polyfill**, which is backed by Node's `http`/`https` **core**
client, not undici (`node_modules/happy-dom/lib/fetch/Fetch.js`:
`import HTTP from 'http'`). That's a genuinely different transport than the
plain-fetch `ECONNREFUSED` family in #4688/#4697 (undici's global fetch,
instant refusal) — here nothing is listening, but the abort races a real
in-flight `http.ClientRequest` socket, so Node prints an unhandled
`Error: socket hang up` / `ECONNRESET` (stack frames in `node:_http_client`)
instead of an instant connection-refused.

Confirmed by instrumenting `global.fetch` (`vi.stubGlobal('fetch', …)` +
`process.stderr.write`, the #4697-card technique): exactly **19** calls to
`"/api/v1/automation/actions"` — one per test, matching the 19 tests in the
file exactly — and stubbing it away brings the noise to 0.

## Fix

Stub `global.fetch` for this exact endpoint in `FlowCanvas.test.tsx`
(`beforeEach`/`afterEach` with `vi.stubGlobal('fetch', …)` /
`vi.unstubAllGlobals()`), degrading with a 404 — the same "engine absent"
response `useActionDescriptors` already falls back from in production, so
`useFlowNodePalette` keeps returning the hardcoded `NODE_PALETTE` exactly as
it already effectively did via the swallowed real-network failure. This
matches the family precedent already in this same directory
(`FlowRunsPanel.test.ts`'s `mockFetch` helper for the sibling
`automation/<flow>/runs` endpoint).

## Measured (isolated, `--maxWorkers=1`, worktree `objectui-issue-4699`)

| | before | after |
|---|---|---|
| `socket hang up` lines | 19 | **0** |
| `Tests` | 19 passed (19) | 19 passed (19) — every assertion unchanged |

Full `previews/` directory suite stays green: `Test Files 37 passed (37)`,
`Tests 441 passed (441)` (one residual `socket hang up` line remains from a
**different, sibling** test file — `flow-canvas-seeds.spec-parse.test.tsx`,
which independently renders `<FlowCanvas>` with no stub of its own — filed as
a separate, unassigned finding: objectui#4701; out of scope here, `#4699` is
addressed).

**Reverse verification** (predicted direction: red/noise-returns — confirmed):
fix committed first, then `git checkout origin/main -- <path>` restored the
pre-fix file → re-ran isolated → 19 `socket hang up` lines returned, `19
passed (19)` (same green, confirming the fix silences noise without changing
behavior) → restored via `git checkout claude/issue-4699-flowcanvas-network-double
-- <path>` → re-ran → back to 0 noise / 19 passed.

## Local gates (all at HEAD `b4eac2291`)

- `pnpm exec eslint --quiet packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx` → clean
- `pnpm --filter @object-ui/app-shell run type-check` (dependency closure built first via `pnpm --filter '@object-ui/app-shell^...' build`) → clean
- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx --maxWorkers=1` → 0 noise, 19/19 passed
- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/previews/ --maxWorkers=2` → 37 files / 441 tests passed
- `node scripts/check-changeset-presence.mjs` → passes (empty-frontmatter changeset added, tests-only)
- `node scripts/check-changeset-no-major.mjs` → passes
- `pnpm run check:control-bytes` → OK

## Scope

`packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx` +
`.changeset/flowcanvas-network-double.md` (empty frontmatter — tests-only, no
published behaviour change). No production source touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_