### PR TITLE
test(app-shell): stub the automation/actions fetch in flow-canvas-seeds.spec-parse.test.tsx

### DIFF
--- a/.changeset/flowcanvas-seeds-network-double.md
+++ b/.changeset/flowcanvas-seeds-network-double.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: stub `fetch` for the `automation/actions` endpoint in
+`flow-canvas-seeds.spec-parse.test.tsx` so the suite no longer escapes to the
+real network (`ECONNRESET`/"socket hang up" noise from happy-dom's own
+`http`-backed fetch polyfill); no published behaviour changes.

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx
@@ -44,13 +44,41 @@
  */
 
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import * as Automation from '@objectstack/spec/automation';
 import { FlowCanvas } from './FlowCanvas';
 import { NODE_PALETTE, defaultNodeExtras, defaultNodeLabel } from './flow-canvas-parts';
 
 afterEach(cleanup);
+
+/**
+ * objectui#4701 — same escape as objectui#4699 (`FlowCanvas.test.tsx`),
+ * different file: the single `render(<FlowCanvas />)` below (in the
+ * revision-loop describe block) pulls in `useFlowNodePalette` →
+ * `useActionDescriptors`, which fires a real `GET ${apiBase()}/automation/
+ * actions` on mount and aborts it on unmount. This vitest `dom` project's
+ * happy-dom answers `fetch` with its own `http`-core-backed polyfill (not
+ * undici), so with nothing listening the abort races a real socket and Node
+ * prints an unhandled `Error: socket hang up` / `ECONNRESET`. None of the
+ * assertions in this file exercise the server overlay, so answer the
+ * endpoint with "engine absent" (404) — the same degrade
+ * `useActionDescriptors` already falls back from — instead of letting a
+ * real connection open.
+ */
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      expect(String(url)).toBe('/api/v1/automation/actions');
+      return new Response('not found', { status: 404 });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 interface ZodIssue {
   path: PropertyKey[];


### PR DESCRIPTION
Fixes #4701

Same mechanism and remedy as #4702 (`FlowCanvas.test.tsx`): the single `render()` call in this file's `FlowCanvas one-click revision loop` describe block mounts FlowCanvas, which pulls in `useFlowNodePalette` -> `useActionDescriptors`. That hook fires a real `GET /api/v1/automation/actions` on mount and aborts it (AbortController) on unmount. Under this repo's vitest `dom` project, `fetch` resolves to happy-dom's own polyfill, backed by Node's `http`/`https` core client (not undici), so with nothing listening the abort races a real socket and Node prints an unhandled `Error: socket hang up` / `ECONNRESET`.

## Fix

Added the same `beforeEach`/`afterEach` `vi.stubGlobal('fetch', ...)` pair as #4702's `FlowCanvas.test.tsx` fix, answering `/api/v1/automation/actions` with a 404 ("engine absent") so `useActionDescriptors` falls back to its hardcoded `NODE_PALETTE` -- the same behaviour the test already implicitly exercised, just without a real socket. No production source touched; test-only.

## Verification (worktree objectui-issue-4701, HEAD `ec8773f3a`)

Baseline (pre-fix, isolated, `--maxWorkers=1`):
```
Error: socket hang up
    at _destroy (node:_http_client:959:15)
    ...
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

Post-fix (isolated, `--maxWorkers=1`):
```
 Test Files  1 passed (1)
      Tests  25 passed (25)
```
0 noise lines, 25 assertions unchanged -- matches the issue's acceptance criteria.

Full `previews/` directory (`--maxWorkers=2`):
```
 Test Files  37 passed (37)
      Tests  441 passed (441)
```
0 `socket hang up` lines total (previously 1 residual line from this file).

Reverse verification: committed the fix first, then reverted the stub with `git checkout` against the pre-fix commit (HEAD~1) -- isolated run showed the 1-line noise return with the same `25 passed (25)`; restored the fix by checking the branch tip back out over the file, re-ran green with 0 noise.

Gates at HEAD `ec8773f3a`:
- `eslint --quiet` on the file: clean
- `pnpm --filter @object-ui/app-shell run type-check` (build closure built first via `pnpm --filter '@object-ui/app-shell^...' build`): clean
- `node scripts/check-changeset-presence.mjs`: green, declares `.changeset/flowcanvas-seeds-network-double.md` (empty frontmatter -- tests-only, releases nothing)
- `pnpm run check:control-bytes`: clean

## Scope

Tests-only: `packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx` plus the empty-frontmatter changeset. No production source changed.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_
