### PR TITLE
fix(plugin-dashboard): await the requested-fetch assertion, not the rendered cell (#4487)

### DIFF
--- a/.changeset/dataset-widget-dotted-dimension-race.md
+++ b/.changeset/dataset-widget-dotted-dimension-race.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: fixed a flaky race in `plugin-dashboard`'s DatasetWidget dotted-dimension
+tests, where `waitFor` was bound to a rendered cell while the assertion checked a
+separately-resolving metadata fetch recording (objectui#4487). No published behaviour
+changes.

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimension.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimension.test.tsx
@@ -266,6 +266,11 @@ describe('DatasetWidget dotted-path dimension label resolution (objectui#4053)',
 
     await waitFor(() => expect(categoriesOf('bogus')).toEqual(['education']));
     // Only the base object was ever asked for.
-    expect(requested).toEqual(['crm_opportunity']);
+    //
+    // Bare (objectui#4487): `bogus` never resolves — the raw value renders BY
+    // IDENTITY regardless of whether the base-object read has even been
+    // issued yet, so the category wait above is only incidentally ordered
+    // before the read. Wait on `requested` itself, not on the category.
+    await waitFor(() => expect(requested).toEqual(['crm_opportunity']));
   });
 });

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimensionTable.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimensionTable.test.tsx
@@ -204,7 +204,11 @@ describe('DatasetWidget dotted-dimension labels on table / pivot (objectui#4263,
     );
 
     await waitFor(() => expect(firstRowCells()[0]).toBe('Education'));
-    expect(requested).toEqual(['crm_opportunity']);
+    // Bare (objectui#4487): the LOCAL cell renders BY IDENTITY — it does not
+    // depend on the metadata read having resolved, or even having been issued
+    // yet — so the two are only incidentally ordered. Wait on `requested`
+    // itself, not on the cell that happens to precede it.
+    await waitFor(() => expect(requested).toEqual(['crm_opportunity']));
   });
 
   it('resolves BOTH the row and the column dimension of a dotted pivot, keeping server totals aligned', async () => {

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.localSelectI18n.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.localSelectI18n.test.tsx
@@ -301,7 +301,13 @@ describe('DatasetWidget table — a LOCAL select dimension is localized (objectu
     );
 
     await waitFor(() => expect(rowCells(0)[0]).toBe('renewal risk'));
-    expect(requested).toEqual(['crm_opportunity']);
+    // Bare (objectui#4487): per the file header, this cell's RENDERED half is
+    // green in both directions ('renewal risk' either way, since the field
+    // carries no options to resolve) — it does not depend on the metadata
+    // read having resolved, or even having been issued yet, so the wait above
+    // is only incidentally ordered before the read. Wait on `requested`
+    // itself, not on the cell.
+    await waitFor(() => expect(requested).toEqual(['crm_opportunity']));
   });
 
   it('a drilled row still filters by the STORED value, AFTER the relabel', async () => {


### PR DESCRIPTION
Fixes #4487

## What

Three `DatasetWidget` tests in `packages/plugin-dashboard/src/__tests__/` had the
shape this card names: a `waitFor` on rendered content, immediately followed by a
BARE `expect(requested)...` assertion on `installMetaRouter`'s recorded fetch list.
The awaited content in each case renders BY IDENTITY (the raw/already-resolved value
survives untouched whether or not the metadata read has settled — or even been
issued yet), so the two statements are only incidentally ordered. Under a saturated
event loop, the render can commit before the metadata-fetch effect has fired at all,
and the very next synchronous line sees an empty/partial `requested` array.

Confirmed from `useDatasetDimensionMeta` (`packages/react/src/hooks/useDatasetDimensionLabels.ts`):
the metadata fetch is issued from an effect gated on `state.object`, which is only
populated by the SAME `setState` that also makes the rows visible — so the DOM commit
and the fetch-triggering effect are only "usually" ordered close together, never
causally coupled, for a dimension whose displayed value doesn't depend on the fetch's
result.

## Sites fixed (the sweep, not just the named line)

- `DatasetWidget.dottedDimensionTable.test.tsx:207` — the issue's named site
  (`renders a LOCAL-only table exactly as the server sent it, and issues the ONE
  read (#4330)`).
- `DatasetWidget.dottedDimension.test.tsx:269` — the second site attached to this
  issue on 2026-08-15 (`falls through gracefully when the relationship segment is
  not a relationship`).
- `DatasetWidget.localSelectI18n.test.tsx:304` — found sweeping the file family
  (`BOUNDARY — a dimension whose field carries no options renders untouched`); the
  file's own header already documents the mechanism in prose ("the RENDERED half is
  green in both directions... and the read-count half is not").

Every other `installMetaRouter`/`requested` site in the same file family (10 more,
across `DatasetWidget.dottedDimensionTable.test.tsx`, `.dottedDimension.test.tsx`,
`.optionLabelI18n.test.tsx`, `.localSelectI18n.test.tsx`) was checked and left as-is:
in each of those the awaited content is a value the widget can only produce AFTER
the metadata read has resolved (a dotted-path label, a locale-bundle translation, or
a multi-hop walk), so the read is causally required before the wait can pass — not
racy. The METRIC case (`dottedDimensionTable.test.tsx:389`) asserts `requested` is
permanently `[]`, and `useDatasetDimensionMeta` is passed `enabled: !isMetric`, so no
fetch is ever issued on that branch regardless of timing — also not racy.

## Fix

Wrap each `requested` assertion in its own `waitFor`, mirroring the repo's existing
idiom for asserting on a recorded fetch mock (`await waitFor(() =>
expect(fetchMock)...)`, used in `plugin-chatbot`, `plugin-grid`, `app-shell`, `auth`,
`plugin-detail`). The assertions keep their exact-set substance (`toEqual`, not
`toContain`/`toBeGreaterThan`) — the "exactly ONE read" invariant these pins exist
for still fails if a regression adds a second fetch.

## Verification

- **Premise reproduced locally**: a loop of 25 isolated runs of the three affected
  files against the PRE-FIX content (temporarily restored from `origin/main`,
  committed fix left intact on the branch) hit the exact failure CI reported:
  `DatasetWidget.dottedDimension.test.tsx:269` failed on run 14/25 with
  `AssertionError: expected [] to deeply equal [ 'crm_opportunity' ]` — byte-identical
  to the failure text quoted in both the issue and its 2026-08-15 comment. The SAME
  loop against the fixed code (40 runs) was 0/40 failures.
- **Reverse verification (deterministic)**: temporarily widened the race window by
  adding a 20ms delay to `installMetaRouter`'s mock (test-double only) at the issue's
  named site, then ran 5x with the OLD bare-assertion form (5/5 failed, same
  assertion text) and 5x with the NEW `waitFor` form under the identical delay (5/5
  passed). The delay and the temporary form-swap were never committed — the pushed
  diff is only the three `await waitFor(...)` wraps plus their comments.
- `pnpm --filter '@object-ui/plugin-dashboard^...' build` (dependency closure,
  fresh worktree) — green.
- `pnpm --filter @object-ui/plugin-dashboard run type-check` — green, no errors.
- `pnpm exec vitest run packages/plugin-dashboard/` (full package) —
  `Test Files 58 passed (58)`, `Tests 462 passed (462)`.
- `pnpm exec eslint --quiet` on the three touched files — clean.
- `node scripts/check-changeset-presence.mjs` — green (empty-frontmatter changeset
  declared, tests-only).
- `pnpm run check:control-bytes` — green.
- HEAD for all of the above: `d321dd08c`.

## Scope

Tests-only, `packages/plugin-dashboard/src/__tests__/` + one empty-frontmatter
changeset. No production source touched, no `skip-changeset` label applied (this PR
releases nothing, so the changeset itself is the correct declaration).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_