### PR TITLE
fix(app-shell): no Retry for an api-disabled attachments list

### DIFF
--- a/.changeset/attachments-api-disabled-no-retry.md
+++ b/.changeset/attachments-api-disabled-no-retry.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/i18n': patch
+'@object-ui/plugin-list': patch
+'@object-ui/react': patch
+---
+
+RecordAttachmentsPanel no longer offers a Retry for an api-disabled `sys_attachment` read.
+
+`OBJECT_API_DISABLED` (404, `enable.apiEnabled: false`) and its sibling
+`OBJECT_API_METHOD_NOT_ALLOWED` (405, the operation is absent from
+`enable.apiMethods`) are pure functions of the object's metadata — no user, no
+session, no request body — so every retry of every persona re-fetches the
+identical refusal. Before this change both landed in `RecordAttachmentsPanel`'s
+`unavailable` state and offered a Retry that was guaranteed to change nothing,
+the same wrong advice `ListView`'s error panel already stops giving for list
+reads.
+
+The panel gains a fifth status, `api-unavailable`: no Retry button, and honest
+copy ("The attachments list is not available on this object.", new
+`detail.attachmentsApiUnavailable` key in all ten locale packs) instead of
+"We couldn't load the attachments for this record." The pre-existing `denied`
+(authorization) and `unavailable` (network/5xx/expired-session) states and
+their affordances are unchanged.
+
+`ListView.classifyLoadError` — the classifier that already separated this case
+into its own `api-disabled` kind for list views — is lifted out of
+`packages/plugin-list/src/ListView.tsx`'s module scope into
+`@object-ui/react` (`classifyLoadError`, `LoadErrorKind`), so both surfaces
+consume one classification instead of `RecordAttachmentsPanel` re-deriving it.
+`ListView`'s own behavior is unchanged — it now imports the function it
+previously defined locally. The classifier delegates its api-disabled check to
+`isApiAccessDeniedError` (`@object-ui/data-objectstack`), removing a second,
+independently-maintained copy of the same code list.

--- a/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
+++ b/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
@@ -16,11 +16,12 @@ import {
   Loader2,
   Lock,
   AlertTriangle,
+  Ban,
   RefreshCw,
 } from 'lucide-react';
 import { createObjectStackUploadAdapter } from '@object-ui/providers';
 import { createAuthenticatedFetch } from '@object-ui/auth';
-import { useObjectTranslation, isPermissionError } from '@object-ui/react';
+import { useObjectTranslation, isPermissionError, classifyLoadError } from '@object-ui/react';
 
 /**
  * RecordAttachmentsPanel — generic record Attachments surface (#2727,
@@ -61,40 +62,59 @@ export interface RecordAttachmentsPanelProps {
 
 /**
  * What the panel actually KNOWS about this record's `sys_attachment` list
- * (#4684) — the same four-way vocabulary the sibling surfaces settled on.
+ * (#4684, #4693) — the five-way vocabulary the sibling surfaces settled on.
  *
- *   - `loading`     — the read is in flight (or has not been issued yet). The
- *                     panel knows nothing and asserts nothing.
- *   - `loaded`      — the read ANSWERED. Only in this state is `rows.length`
- *                     a fact about the record, and only here may the panel say
- *                     "No attachments yet".
- *   - `denied`      — refused for AUTHORIZATION reasons (#4269 / PR #4685):
- *                     403 / `PERMISSION_DENIED` / `FORBIDDEN` / an RLS denial.
- *                     The caller may not look; the record's contents are
- *                     unknown.
- *   - `unavailable` — the read FAILED for any other reason: a network failure
- *                     (server unreachable, DNS, aborted request), a 5xx, or a
- *                     401 / `AUTH_REQUIRED` (an expired session is
- *                     authentication, not authorization, so the `denied`
- *                     predicate deliberately does not claim it). Also unknown.
+ *   - `loading`         — the read is in flight (or has not been issued yet).
+ *                         The panel knows nothing and asserts nothing.
+ *   - `loaded`          — the read ANSWERED. Only in this state is
+ *                         `rows.length` a fact about the record, and only
+ *                         here may the panel say "No attachments yet".
+ *   - `denied`          — refused for AUTHORIZATION reasons (#4269 / PR
+ *                         #4685): 403 / `PERMISSION_DENIED` / `FORBIDDEN` /
+ *                         an RLS denial. The caller may not look; the
+ *                         record's contents are unknown.
+ *   - `api-unavailable` — refused because the OBJECT withholds the API
+ *                         entirely (#4693): `OBJECT_API_DISABLED` (404,
+ *                         `enable.apiEnabled: false`) or
+ *                         `OBJECT_API_METHOD_NOT_ALLOWED` (405, the
+ *                         operation is absent from `enable.apiMethods`).
+ *                         Both are pure functions of the object's metadata —
+ *                         no user, no session, no request body — so unlike
+ *                         `denied` this is not something any permission
+ *                         grant fixes, and unlike `unavailable` below no
+ *                         retry changes the answer either.
+ *   - `unavailable`     — the read FAILED for any other reason: a network
+ *                         failure (server unreachable, DNS, aborted
+ *                         request), a 5xx, or a 401 / `AUTH_REQUIRED` (an
+ *                         expired session is authentication, not
+ *                         authorization, so the `denied` predicate
+ *                         deliberately does not claim it). Also unknown, and
+ *                         — unlike `api-unavailable` — genuinely retryable.
  *
- * The split that matters is assert-vs-don't-assert. Before #4684 the last two
- * both collapsed into `rows = []`, so a panel that never got an answer told the
- * user "No attachments yet. Upload a file to get started." — an affirmative
- * claim about the record's contents, made from no evidence, over a record that
- * may hold thousands. The house rule this restores landed twice already as a
- * bug fix: `HomeActionCenter` (#4235) may only say "You're all caught up" once
- * the inbox has answered, and an unloadable app list (#4300) is UNKNOWN rather
- * than "no default app".
+ * The split that matters is assert-vs-don't-assert. Before #4684 `denied` and
+ * `unavailable` both collapsed into `rows = []`, so a panel that never got an
+ * answer told the user "No attachments yet. Upload a file to get started." —
+ * an affirmative claim about the record's contents, made from no evidence,
+ * over a record that may hold thousands. The house rule this restores landed
+ * twice already as a bug fix: `HomeActionCenter` (#4235) may only say "You're
+ * all caught up" once the inbox has answered, and an unloadable app list
+ * (#4300) is UNKNOWN rather than "no default app".
  *
- * `denied` and `unavailable` are kept apart rather than merged into one
- * "couldn't read" because they need different copy and different affordances:
- * a denial is permanent for this caller and retrying it just re-earns the same
- * 403, while an outage or an expired session is exactly the case a Retry is
- * for. `unavailable` therefore keeps a retry; `denied` (unchanged from #4685)
- * does not.
+ * `api-unavailable` was split out of `unavailable` because the same
+ * assert-vs-don't-assert reasoning applies to the AFFORDANCE, not just the
+ * copy: `unavailable` offers a Retry because an outage or an expired session is
+ * exactly what a second attempt can fix, but `OBJECT_API_DISABLED` /
+ * `OBJECT_API_METHOD_NOT_ALLOWED` are retry-invariant — every retry of every
+ * persona re-fetches the identical refusal, so the button was the same wrong
+ * advice as "check your connection", just spelled as a control. Classified
+ * with `classifyLoadError` (`@object-ui/react`), the same "is this
+ * retry-invariant" verdict `ListView`'s error panel already renders for list
+ * views — `classifyLoadError` was lifted out of `ListView.tsx`'s module scope
+ * for exactly this reuse. `denied` and `unavailable` keep their pre-#4693
+ * meaning (`isPermissionError`, unchanged) — `api-unavailable` is the one new
+ * fork, checked before that split.
  */
-type AttachmentListStatus = 'loading' | 'loaded' | 'denied' | 'unavailable';
+type AttachmentListStatus = 'loading' | 'loaded' | 'denied' | 'api-unavailable' | 'unavailable';
 
 function formatSize(bytes?: number | null): string {
   if (bytes == null || !Number.isFinite(bytes)) return '';
@@ -202,9 +222,18 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
       setStatus('loaded');
     } catch (err) {
       setRows([]);
-      // The read did NOT answer. Which of the two unknown states applies turns
-      // on one question — is this caller forbidden, or did the request simply
-      // not get through?
+      // The read did NOT answer. Which of the three unknown states applies
+      // turns on two questions, checked in order — is the object's API
+      // withheld entirely, and if not, is this caller forbidden?
+      //
+      // `api-unavailable` (#4693) is checked FIRST, on the CODE alone (via
+      // `classifyLoadError`, shared with `ListView`'s error panel):
+      // `OBJECT_API_DISABLED` (404) / `OBJECT_API_METHOD_NOT_ALLOWED` (405).
+      // Both are pure functions of the object's `enable` block — no user, no
+      // session — so no persona and no retry changes the answer, and it must
+      // run before the `denied` check below: a 404/405 carries no status this
+      // predicate would confuse with a real permission refusal, but checking
+      // order still matters for future codes that could overlap.
       //
       // `denied` (#4269 / PR #4685) uses the same house predicate the
       // kanban/calendar/form surfaces branch on: HTTP 403,
@@ -222,12 +251,18 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
       // still renders the empty state. It never depended on this catch
       // swallowing it.
       //
-      // Nothing from the error is rendered in either state — both show their
-      // i18n sentence and nothing else. objectui#2532's failure mode (raw
-      // dump / status code / leaked row count) must stay absent, and
+      // Nothing from the error is rendered in any of the three states — each
+      // shows its i18n sentence and nothing else. objectui#2532's failure mode
+      // (raw dump / status code / leaked row count) must stay absent, and
       // `setError` is deliberately NOT called here: a failed LIST is a state
       // of the panel, not an error banner about an action the user took.
-      setStatus(isPermissionError(err) ? 'denied' : 'unavailable');
+      setStatus(
+        classifyLoadError(err) === 'api-disabled'
+          ? 'api-unavailable'
+          : isPermissionError(err)
+            ? 'denied'
+            : 'unavailable',
+      );
     }
   }, [dataSource, objectName, recordId]);
 
@@ -359,9 +394,14 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
           presigned flow would fail on the same outage. Retry first; the
           Upload returns with the answer.
 
+          `api-unavailable` withdraws it too (#4693), for a stronger reason
+          than either: the object's `enable` block refuses this operation for
+          every caller, so an upload attempt here is not merely unverified —
+          it is guaranteed to fail the same way the list read just did.
+
           Still shown while `loading` and while `loaded`, exactly as before.
         */}
-        {status !== 'denied' && status !== 'unavailable' && (
+        {status !== 'denied' && status !== 'api-unavailable' && status !== 'unavailable' && (
           <div className="flex items-center gap-2">
             <input
               ref={inputRef}
@@ -421,6 +461,22 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
           <Lock className="h-4 w-4 shrink-0" />
           {t('detail.attachmentsAccessDenied', {
             defaultValue: "You don't have access to these attachments.",
+          })}
+        </div>
+      ) : status === 'api-unavailable' ? (
+        // `OBJECT_API_DISABLED` / `OBJECT_API_METHOD_NOT_ALLOWED` (#4693): a
+        // pure function of the object's `enable` block, not a permission and
+        // not an outage — no persona and no retry changes the answer. Like
+        // the other two failure states this renders ONLY the i18n sentence
+        // (#2532), and — unlike `unavailable` below — deliberately offers NO
+        // Retry: the button would re-fetch the identical refusal every time.
+        <div
+          className="px-4 py-6 text-sm text-muted-foreground flex items-center gap-2"
+          data-testid="record-attachments-api-unavailable"
+        >
+          <Ban className="h-4 w-4 shrink-0" />
+          {t('detail.attachmentsApiUnavailable', {
+            defaultValue: 'The attachments list is not available on this object.',
           })}
         </div>
       ) : status === 'unavailable' ? (

--- a/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
@@ -422,6 +422,159 @@ describe('RecordAttachmentsPanel — unavailable vs empty list (#4684)', () => {
   });
 });
 
+/**
+ * An api-disabled object is not an outage (#4693).
+ *
+ * `OBJECT_API_DISABLED` (404, `enable.apiEnabled: false`) and its sibling
+ * `OBJECT_API_METHOD_NOT_ALLOWED` (405, the operation is absent from
+ * `enable.apiMethods`) are pure functions of the object's metadata — no user,
+ * no session, no request body — so every retry of every persona re-fetches
+ * the identical refusal. Before this card both landed in `unavailable` and
+ * offered a Retry that was guaranteed to change nothing: the same wrong
+ * advice ("try again") `ListView`'s error panel already stopped giving for
+ * list reads, one surface over. Classified with the shared `classifyLoadError`
+ * (`@object-ui/react`, lifted out of `ListView.tsx`'s module scope for this
+ * reuse), checked BEFORE the `denied`/`unavailable` split so it cannot be
+ * shadowed by either.
+ */
+describe('RecordAttachmentsPanel — api-unavailable vs denied vs unavailable (#4693)', () => {
+  it('renders api-unavailable for a 404 OBJECT_API_DISABLED, with no Retry', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('Object API is disabled'), {
+            httpStatus: 404,
+            code: 'OBJECT_API_DISABLED',
+          });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-api-unavailable')).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText('The attachments list is not available on this object.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('record-attachments-denied')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('record-attachments-unavailable')).not.toBeInTheDocument();
+  });
+
+  it('renders the same state for the 405 sibling OBJECT_API_METHOD_NOT_ALLOWED', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('Method not allowed'), {
+            httpStatus: 405,
+            code: 'OBJECT_API_METHOD_NOT_ALLOWED',
+          });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-api-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+
+  it('classifies on the code alone, with no numeric status', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          const err: any = new Error('disabled');
+          err.code = 'OBJECT_API_DISABLED';
+          throw err;
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-api-unavailable')).toBeInTheDocument(),
+    );
+  });
+
+  it('withdraws the Upload affordance under api-unavailable', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('disabled'), {
+            httpStatus: 404,
+            code: 'OBJECT_API_DISABLED',
+          });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-api-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: 'Upload' })).not.toBeInTheDocument();
+  });
+
+  // Same no-leak bar as the other two failure states (#2532).
+  it('leaks nothing from the error — no status code, no server text', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('Object API is disabled for att_case'), {
+            httpStatus: 404,
+            code: 'OBJECT_API_DISABLED',
+          });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-api-unavailable')).toBeInTheDocument(),
+    );
+    const panel = screen.getByTestId('record-attachments-panel');
+    expect(panel.textContent).not.toMatch(/404/);
+    expect(panel.textContent).not.toMatch(/OBJECT_API_DISABLED/);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // POSITIVE CONTROL: the sibling `unavailable` state (5xx / network) must
+  // keep its Retry — this card narrows exactly one code pair, not the general
+  // "read failed" case.
+  it('CONTROL: a 500 still renders unavailable WITH a Retry, not api-unavailable', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('Internal Server Error'), { httpStatus: 500 });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.queryByTestId('record-attachments-api-unavailable')).not.toBeInTheDocument();
+  });
+
+  // POSITIVE CONTROL: a genuine 403 still reaches `denied`, unaffected by the
+  // new fork checked ahead of it.
+  it('CONTROL: a 403 still renders denied, not api-unavailable', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('refused'), {
+            httpStatus: 403,
+            code: 'PERMISSION_DENIED',
+          });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-denied')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('record-attachments-api-unavailable')).not.toBeInTheDocument();
+  });
+});
+
 describe('RecordAttachmentsPanel — authenticated signed-URL download (#2970)', () => {
   it('fetches /files/:id/url with auth and opens the signed URL', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -902,6 +902,7 @@ const ar = {
     attachmentPermissionDenied: "ليس لديك إذن للقيام بذلك.",
     attachmentsAccessDenied: "ليس لديك حق الوصول إلى هذه المرفقات.",
     attachmentsLoadFailed: "تعذر تحميل مرفقات هذا السجل.",
+    attachmentsApiUnavailable: "قائمة المرفقات غير متاحة على هذا الكائن.",
     retryLoadAttachments: "إعادة المحاولة",
     unifiedDiff: "عرض موحد",
     sideBySideDiff: "عرض جنباً إلى جنب",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -896,6 +896,7 @@ const de = {
     attachmentPermissionDenied: "Sie haben keine Berechtigung für diese Aktion.",
     attachmentsAccessDenied: "Sie haben keinen Zugriff auf diese Anhänge.",
     attachmentsLoadFailed: "Die Anhänge dieses Datensatzes konnten nicht geladen werden.",
+    attachmentsApiUnavailable: "Die Anhangsliste ist für dieses Objekt nicht verfügbar.",
     retryLoadAttachments: "Erneut versuchen",
     unifiedDiff: "Einheitliche Ansicht",
     sideBySideDiff: "Nebeneinander-Ansicht",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1032,6 +1032,7 @@ const en = {
     attachmentPermissionDenied: "You don't have permission to do that.",
     attachmentsAccessDenied: "You don't have access to these attachments.",
     attachmentsLoadFailed: "We couldn't load the attachments for this record.",
+    attachmentsApiUnavailable: 'The attachments list is not available on this object.',
     retryLoadAttachments: 'Retry',
     // Diff
     unifiedDiff: 'Unified diff',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -900,6 +900,7 @@ const es = {
     attachmentPermissionDenied: "No tiene permiso para hacer eso.",
     attachmentsAccessDenied: "No tiene acceso a estos adjuntos.",
     attachmentsLoadFailed: "No se pudieron cargar los adjuntos de este registro.",
+    attachmentsApiUnavailable: "La lista de adjuntos no está disponible en este objeto.",
     retryLoadAttachments: "Reintentar",
     unifiedDiff: "Vista unificada",
     sideBySideDiff: "Vista lado a lado",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -898,6 +898,7 @@ const fr = {
     attachmentPermissionDenied: "Vous n'avez pas la permission de faire cela.",
     attachmentsAccessDenied: "Vous n'avez pas accès à ces pièces jointes.",
     attachmentsLoadFailed: "Impossible de charger les pièces jointes de cet enregistrement.",
+    attachmentsApiUnavailable: "La liste des pièces jointes n'est pas disponible sur cet objet.",
     retryLoadAttachments: "Réessayer",
     unifiedDiff: "Vue unifiée",
     sideBySideDiff: "Vue côte à côte",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -907,6 +907,7 @@ const ja = {
     attachmentPermissionDenied: "この操作を行う権限がありません。",
     attachmentsAccessDenied: "これらの添付ファイルにアクセスする権限がありません。",
     attachmentsLoadFailed: "このレコードの添付ファイルを読み込めませんでした。",
+    attachmentsApiUnavailable: "このオブジェクトでは添付ファイルの一覧を利用できません。",
     retryLoadAttachments: "再試行",
     unifiedDiff: "統合差分",
     sideBySideDiff: "横並び差分",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -896,6 +896,7 @@ const ko = {
     attachmentPermissionDenied: "이 작업을 수행할 권한이 없습니다.",
     attachmentsAccessDenied: "이 첨부파일에 접근할 권한이 없습니다.",
     attachmentsLoadFailed: "이 레코드의 첨부파일을 불러오지 못했습니다.",
+    attachmentsApiUnavailable: "이 객체에서는 첨부 파일 목록을 사용할 수 없습니다.",
     retryLoadAttachments: "다시 시도",
     unifiedDiff: "통합 보기",
     sideBySideDiff: "나란히 보기",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -897,6 +897,7 @@ const pt = {
     attachmentPermissionDenied: "Você não tem permissão para fazer isso.",
     attachmentsAccessDenied: "Você não tem acesso a estes anexos.",
     attachmentsLoadFailed: "Não foi possível carregar os anexos deste registro.",
+    attachmentsApiUnavailable: "A lista de anexos não está disponível neste objeto.",
     retryLoadAttachments: "Tentar novamente",
     unifiedDiff: "Visualização unificada",
     sideBySideDiff: "Visualização lado a lado",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -915,6 +915,7 @@ const ru = {
     attachmentPermissionDenied: "У вас нет разрешения на это действие.",
     attachmentsAccessDenied: "У вас нет доступа к этим вложениям.",
     attachmentsLoadFailed: "Не удалось загрузить вложения этой записи.",
+    attachmentsApiUnavailable: "Список вложений недоступен для этого объекта.",
     retryLoadAttachments: "Повторить",
     unifiedDiff: "Единое представление",
     sideBySideDiff: "Параллельное представление",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -976,6 +976,7 @@ const zh = {
     attachmentPermissionDenied: '您没有执行此操作的权限。',
     attachmentsAccessDenied: '您没有访问这些附件的权限。',
     attachmentsLoadFailed: '无法加载此记录的附件。',
+    attachmentsApiUnavailable: '此对象上的附件列表不可用。',
     retryLoadAttachments: '重试',
     // Diff
     unifiedDiff: '统一视图',

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -14,7 +14,8 @@ import type { FilterGroup } from '@object-ui/components';
 import { ViewSwitcherDropdown, ViewType } from './ViewSwitcher';
 import { ViewSettingsPopover } from './components/ViewSettingsPopover';
 import { UserFilters } from './UserFilters';
-import { SchemaRenderer, useNavigationOverlay } from '@object-ui/react';
+import { SchemaRenderer, useNavigationOverlay, classifyLoadError } from '@object-ui/react';
+import type { LoadErrorKind } from '@object-ui/react';
 import { useDensityMode } from '@object-ui/react';
 import type { ListViewSchema } from '@object-ui/types';
 import { detectStatusField } from '@object-ui/types';
@@ -438,71 +439,6 @@ export function evaluateConditionalFormatting(
   return resolveConditionalFormatting(record, rules as any, scope, fields as never) as React.CSSProperties;
 }
 
-/**
- * Classify a failed data fetch by HTTP status / error code so the error panel
- * can say what actually happened. A 403 rendered as "check your connection"
- * is indistinguishable from a real outage — users were told to debug their
- * network when the server had (correctly) denied them access.
- */
-function classifyLoadError(
-  err: unknown,
-): 'api-disabled' | 'forbidden' | 'unauthorized' | 'rejected' | 'network' {
-  const e = err as any;
-  // The ObjectStack client decorates errors with `httpStatus`; raw fetch
-  // wrappers surface `status` / `statusCode`; some adapters only embed the
-  // status in the message ("HTTP 403 Forbidden — …").
-  let status = [e?.httpStatus, e?.status, e?.statusCode]
-    .find((s: unknown): s is number => typeof s === 'number');
-  if (status === undefined) {
-    const m = /HTTP (\d{3})\b/.exec(String(e?.message ?? ''));
-    if (m) status = Number(m[1]);
-  }
-  const code = typeof e?.code === 'string' ? e.code.toUpperCase() : '';
-  // The object's `enable` block withholds this operation — checked FIRST, and
-  // on the CODE alone. Status cannot carry this verdict: the denial is a 404,
-  // the same status a missing collection and a missing record answer with, and
-  // its 405 sibling is the same status any other method rejection uses. Unlike
-  // every kind below it this one is not about the request, the session or the
-  // network — it is a permanent property of the object, identical for every
-  // persona and every retry (objectui#4408).
-  if (API_ACCESS_DENIED_CODES.has(code)) return 'api-disabled';
-  if (status === 403 || code === 'PERMISSION_DENIED' || code === 'FORBIDDEN') return 'forbidden';
-  if (status === 401 || code === 'UNAUTHORIZED' || code === 'UNAUTHENTICATED') return 'unauthorized';
-  // The server understood the request and refused it as malformed. Retrying
-  // sends the identical bad request, so "check your connection and try again"
-  // is the same wrong advice this function exists to stop giving — one status
-  // code over. The server now rejects a `$filter` that is not a filter AST
-  // (objectstack#4121) and an unsupported `$`-parameter, both as 400.
-  if (status === 400 || REJECTED_REQUEST_CODES.has(code)) return 'rejected';
-  return 'network';
-}
-
-/** 400-class error codes the data API returns for a request it will never accept. */
-const REJECTED_REQUEST_CODES = new Set([
-  'INVALID_FILTER',
-  'UNSUPPORTED_QUERY_PARAM',
-  'INVALID_QUERY',
-]);
-
-/**
- * The denials the server derives from the object's `enable` block —
- * `apiAccessDenialFromEnable` in objectstack's REST server.
- *
- *   - `OBJECT_API_DISABLED` (404) — `enable.apiEnabled: false`; the object is
- *     not exposed over the data API at all.
- *   - `OBJECT_API_METHOD_NOT_ALLOWED` (405) — the operation is absent from the
- *     `enable.apiMethods` whitelist.
- *
- * Both are pure functions of the object's metadata: no user, no permission, no
- * request body. So the honest copy for them is neither "try again" (nothing
- * will change) nor "ask your administrator for access" (this is not a
- * permission grant — the object is not published to the API at all).
- */
-const API_ACCESS_DENIED_CODES = new Set([
-  'OBJECT_API_DISABLED',
-  'OBJECT_API_METHOD_NOT_ALLOWED',
-]);
-
 // Default English translations for fallback when I18nProvider is not available.
 //
 // Every row whose key the `en` pack also defines must stay byte-identical to it,
@@ -850,7 +786,10 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // failed. Captured here so the render can show a retryable error panel.
   const [loadError, setLoadError] = React.useState<string | null>(null);
   // What KIND of failure `loadError` is — drives which error panel copy shows.
-  const [loadErrorKind, setLoadErrorKind] = React.useState<'api-disabled' | 'forbidden' | 'unauthorized' | 'rejected' | 'network'>('network');
+  // Classified by the shared `classifyLoadError` (`@object-ui/react`,
+  // objectui#4693 — lifted from this file so `RecordAttachmentsPanel` can
+  // reuse the same "api-disabled is retry-invariant" verdict).
+  const [loadErrorKind, setLoadErrorKind] = React.useState<LoadErrorKind>('network');
   // Start in loading state when we will fetch from a dataSource so the empty
   // state doesn't flash before the first effect runs. Inline data (schema.data
   // as an array or a `value` provider) starts as not-loading.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -22,8 +22,8 @@ export { resolveKeyedI18nLabel } from './utils/i18n';
 
 // Write-error surfacing utilities (shared by drag-write plugins so a failed
 // PATCH — e.g. an RLS 403 — is never silently swallowed).
-export { extractWriteErrorMessage, isPermissionError, extractFieldErrors } from './utils/error-message';
-export type { WriteFieldError } from './utils/error-message';
+export { extractWriteErrorMessage, isPermissionError, extractFieldErrors, classifyLoadError } from './utils/error-message';
+export type { WriteFieldError, LoadErrorKind } from './utils/error-message';
 
 // Built-in i18n support
 export {

--- a/packages/react/src/utils/error-message.test.ts
+++ b/packages/react/src/utils/error-message.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { extractFieldErrors } from './error-message';
+import { extractFieldErrors, classifyLoadError } from './error-message';
 
 describe('extractFieldErrors', () => {
   // The wire shape the server actually sends: `@objectstack/rest` serves a
@@ -85,5 +85,81 @@ describe('extractFieldErrors', () => {
     expect(extractFieldErrors(undefined)).toBeNull();
     expect(extractFieldErrors('a string')).toBeNull();
     expect(extractFieldErrors(new Error('plain'))).toBeNull();
+  });
+});
+
+/**
+ * `classifyLoadError` — lifted from `ListView`'s module scope (objectui#4693)
+ * so `RecordAttachmentsPanel` can reuse the same "is this retry-invariant"
+ * verdict. This is the unit-level pin at the shared home; `ListView` and
+ * `RecordAttachmentsPanel` each pin their own consumption of it end-to-end in
+ * their own test suites (`ListView.loadErrorKind.test.tsx`,
+ * `RecordAttachmentsPanel.test.tsx`).
+ */
+describe('classifyLoadError', () => {
+  it('classifies the enable-block denials as api-disabled, on the code alone', () => {
+    expect(
+      classifyLoadError(
+        Object.assign(new Error('disabled'), { httpStatus: 404, code: 'OBJECT_API_DISABLED' }),
+      ),
+    ).toBe('api-disabled');
+    expect(
+      classifyLoadError(
+        Object.assign(new Error('not allowed'), {
+          httpStatus: 405,
+          code: 'OBJECT_API_METHOD_NOT_ALLOWED',
+        }),
+      ),
+    ).toBe('api-disabled');
+    // No numeric status at all — the code alone must carry the verdict.
+    expect(classifyLoadError(Object.assign(new Error('x'), { code: 'OBJECT_API_DISABLED' }))).toBe(
+      'api-disabled',
+    );
+  });
+
+  it('classifies 403 / PERMISSION_DENIED / FORBIDDEN as forbidden', () => {
+    expect(classifyLoadError(Object.assign(new Error('x'), { httpStatus: 403 }))).toBe('forbidden');
+    expect(classifyLoadError(Object.assign(new Error('x'), { code: 'PERMISSION_DENIED' }))).toBe(
+      'forbidden',
+    );
+    expect(classifyLoadError(Object.assign(new Error('x'), { code: 'FORBIDDEN' }))).toBe('forbidden');
+  });
+
+  it('classifies 401 / UNAUTHORIZED / UNAUTHENTICATED as unauthorized', () => {
+    expect(classifyLoadError(Object.assign(new Error('x'), { httpStatus: 401 }))).toBe(
+      'unauthorized',
+    );
+    expect(classifyLoadError(Object.assign(new Error('x'), { code: 'UNAUTHENTICATED' }))).toBe(
+      'unauthorized',
+    );
+  });
+
+  it('classifies 400 and the known malformed-request codes as rejected', () => {
+    expect(classifyLoadError(Object.assign(new Error('x'), { httpStatus: 400 }))).toBe('rejected');
+    expect(classifyLoadError(Object.assign(new Error('x'), { code: 'INVALID_FILTER' }))).toBe(
+      'rejected',
+    );
+    expect(
+      classifyLoadError(Object.assign(new Error('x'), { code: 'UNSUPPORTED_QUERY_PARAM' })),
+    ).toBe('rejected');
+  });
+
+  it('falls back to network for a bare failure or an unrecognized 404', () => {
+    expect(classifyLoadError(new TypeError('Failed to fetch'))).toBe('network');
+    // A bare 404 (missing record / unprovisioned collection) is NOT an
+    // enable-block denial — status alone must never reach `api-disabled`.
+    expect(classifyLoadError(Object.assign(new Error('x'), { httpStatus: 404 }))).toBe('network');
+  });
+
+  it('reads a status embedded in the message text ("HTTP 403 …")', () => {
+    expect(classifyLoadError(new Error('ApiDataSource: HTTP 403 Forbidden — {}'))).toBe(
+      'forbidden',
+    );
+  });
+
+  it('prefers 403/401 over the 400 branch', () => {
+    expect(
+      classifyLoadError(Object.assign(new Error('x'), { httpStatus: 403, code: 'INVALID_FILTER' })),
+    ).toBe('forbidden');
   });
 });

--- a/packages/react/src/utils/error-message.ts
+++ b/packages/react/src/utils/error-message.ts
@@ -7,7 +7,8 @@
  */
 
 /**
- * Helpers for turning a failed data-source write into user-facing feedback.
+ * Helpers for turning a failed data-source read or write into user-facing
+ * feedback.
  *
  * Different DataSource adapters throw differently shaped errors:
  *   - the ObjectStack adapter (`@object-ui/data-objectstack`) decorates the
@@ -19,6 +20,8 @@
  * These helpers normalise across both so a caller's `catch` can surface the
  * real reason (e.g. a row-level-security denial) instead of swallowing it.
  */
+
+import { isApiAccessDeniedError } from '@object-ui/data-objectstack';
 
 function firstString(...vals: unknown[]): string | null {
   for (const v of vals) {
@@ -149,4 +152,69 @@ export function isPermissionError(err: unknown): boolean {
   return /row-level security|access denied|permission denied|not permitted/i.test(
     text,
   );
+}
+
+/** 400-class error codes the data API returns for a request it will never accept. */
+const REJECTED_REQUEST_CODES = new Set([
+  'INVALID_FILTER',
+  'UNSUPPORTED_QUERY_PARAM',
+  'INVALID_QUERY',
+]);
+
+/** What {@link classifyLoadError} answers. */
+export type LoadErrorKind = 'api-disabled' | 'forbidden' | 'unauthorized' | 'rejected' | 'network';
+
+/**
+ * Classify a failed data FETCH (as opposed to a failed write, above) by HTTP
+ * status / error code, so an error panel can say what actually happened. A
+ * 403 rendered as "check your connection" is indistinguishable from a real
+ * outage — users were told to debug their network when the server had
+ * (correctly) denied them access.
+ *
+ * Originally `ListView`'s module-local `classifyLoadError`
+ * (`packages/plugin-list/src/ListView.tsx`); lifted here (objectui#4693) so
+ * `RecordAttachmentsPanel` can reuse the same "is this retry-invariant"
+ * verdict for the `sys_attachment` list read instead of re-deriving it. Both
+ * `@object-ui/plugin-list` and `@object-ui/app-shell` already depend on this
+ * package, so the lift adds no new dependency edge to either.
+ *
+ * Purely a classifier — it returns a KIND, never rendered text. Each caller
+ * owns its own copy for what a kind means on its surface (`ListView` shows a
+ * title + message per kind and a Retry for every kind but `api-disabled`;
+ * `RecordAttachmentsPanel` only distinguishes `api-disabled` from everything
+ * else, folding `forbidden`/`unauthorized`/`rejected`/`network` into its own
+ * coarser `denied`/`unavailable` split via {@link isPermissionError}) — so
+ * lifting this function does not couple the two surfaces' i18n or copy.
+ */
+export function classifyLoadError(err: unknown): LoadErrorKind {
+  const e = err as any;
+  // The ObjectStack client decorates errors with `httpStatus`; raw fetch
+  // wrappers surface `status` / `statusCode`; some adapters only embed the
+  // status in the message ("HTTP 403 Forbidden — …").
+  let status = [e?.httpStatus, e?.status, e?.statusCode]
+    .find((s: unknown): s is number => typeof s === 'number');
+  if (status === undefined) {
+    const m = /HTTP (\d{3})\b/.exec(String(e?.message ?? ''));
+    if (m) status = Number(m[1]);
+  }
+  const code = typeof e?.code === 'string' ? e.code.toUpperCase() : '';
+  // The object's `enable` block withholds this operation — checked FIRST, on
+  // the CODE alone (delegated to the shared predicate so this file and
+  // `@object-ui/data-objectstack` cannot drift on which codes count). Status
+  // cannot carry this verdict: the denial is a 404, the same status a missing
+  // collection and a missing record answer with, and its 405 sibling is the
+  // same status any other method rejection uses. Unlike every kind below it
+  // this one is not about the request, the session or the network — it is a
+  // permanent property of the object, identical for every persona and every
+  // retry (objectui#4408).
+  if (isApiAccessDeniedError(err)) return 'api-disabled';
+  if (status === 403 || code === 'PERMISSION_DENIED' || code === 'FORBIDDEN') return 'forbidden';
+  if (status === 401 || code === 'UNAUTHORIZED' || code === 'UNAUTHENTICATED') return 'unauthorized';
+  // The server understood the request and refused it as malformed. Retrying
+  // sends the identical bad request, so "check your connection and try again"
+  // is the same wrong advice this function exists to stop giving — one status
+  // code over. The server now rejects a `$filter` that is not a filter AST
+  // (objectstack#4121) and an unsupported `$`-parameter, both as 400.
+  if (status === 400 || REJECTED_REQUEST_CODES.has(code)) return 'rejected';
+  return 'network';
 }


### PR DESCRIPTION
Fixes #4693

## What

`RecordAttachmentsPanel` offered a Retry for a `sys_attachment` list read that
failed with `OBJECT_API_DISABLED` (404, `enable.apiEnabled: false`) or
`OBJECT_API_METHOD_NOT_ALLOWED` (405, the operation absent from
`enable.apiMethods`). Both are pure functions of the object's metadata — no
user, no session, no request body — so every retry of every persona
re-fetches the identical refusal. The button was the same wrong advice
("try again") that `ListView`'s error panel already stops giving for list
reads, one surface over (issue #4408).

The panel gains a fifth status, `api-unavailable`: no Retry button, honest
copy ("The attachments list is not available on this object.", new
`detail.attachmentsApiUnavailable` key, synced to all ten locale packs). The
pre-existing `denied` (authorization, issue #4269 / PR #4685) and
`unavailable` (network/5xx/expired-session, issue #4684) states keep their
exact meaning and affordances — this only inserts one new fork ahead of them.

## Classifier home: `@object-ui/react`, not a new dependency edge either way

Followed the ruling's preferred half of the card's suggested shape: lifted
`ListView.classifyLoadError` out of `packages/plugin-list/src/ListView.tsx`'s
module scope into a shared home, rather than growing a second,
independently-hand-rolled `api-disabled` check on the panel.

Checked the function itself before picking a home: it is a pure classifier —
takes an `unknown` error, returns a `LoadErrorKind` string, never renders
anything. All the i18n/copy is owned separately by each caller (`ListView`'s
own title/message-per-kind ternaries; the panel's own single sentence per
status). So there is no list-specific text tangled into the function, and the
whole thing could move as-is — no split into "kernel vs. copy" was needed.

Landed it in `@object-ui/react` (`packages/react/src/utils/error-message.ts`,
next to the existing `isPermissionError` the panel already imports from
there), not `@object-ui/data-objectstack` or a new export from `plugin-list`:

- **Zero new dependency edges either direction.** Both
  `@object-ui/plugin-list` and `@object-ui/app-shell` already depend on
  `@object-ui/react` (confirmed in both `package.json`s before touching
  anything) — `plugin-list` already imports `SchemaRenderer`/
  `useNavigationOverlay` from it, `app-shell`'s `RecordAttachmentsPanel`
  already imports `isPermissionError` from it. Landing in
  `@object-ui/data-objectstack` would have needed a brand-new dependency
  edge from `plugin-list` (not currently a consumer — several sibling
  `plugin-*` packages are, but not this one), for zero benefit over reusing
  an edge both sides already have.
- **Sibling to the function it most resembles.** `isPermissionError` is the
  same shape of thing — classify an error into a UI-relevant verdict — and
  already lives there; `RecordAttachmentsPanel` was already calling it from
  the same import line I'm extending.
- **No cycle risk.** `@object-ui/react` already depends on
  `@object-ui/data-objectstack` (declared in `package.json`, and already used
  by `AppShellContext.tsx`), so `classifyLoadError` can delegate its
  `api-disabled` check to the already-exported `isApiAccessDeniedError`
  there — removing a second, independently-maintained copy of the same
  `OBJECT_API_DISABLED`/`OBJECT_API_METHOD_NOT_ALLOWED` code list that
  `ListView` used to hand-roll as its own local `Set`.

`ListView`'s own behavior is byte-for-byte unchanged — it now imports the
function it used to define locally, and its existing
`ListView.loadErrorKind.test.tsx` suite (unedited) is the pin for that.

## Truth table (what I actually ran, not what the card presumed)

All four via `RecordAttachmentsPanel.test.tsx`, real `dataSource.find()`
rejections (recorded-double style — no global fetch mock, no swallowed
console error):

| Failure | Status | Retry? |
|---|---|---|
| 403 `PERMISSION_DENIED` | `denied` | no (unchanged pin) |
| 500 / `TypeError('Failed to fetch')` | `unavailable` | **yes** (positive control — this card narrows one code pair, not the general case) |
| 404 `OBJECT_API_DISABLED` | `api-unavailable` | no (new) |
| 405 `OBJECT_API_METHOD_NOT_ALLOWED` | `api-unavailable` | no (new) |

Plus: code-alone classification (no numeric status), no-leak assertions (no
status code / server text in the rendered sentence, matching the sibling
states' bar from issue #2532), and Upload-affordance withdrawal under the new
state. `classifyLoadError` itself gets a direct unit-level pin at its new home
in `error-message.test.ts` (api-disabled / forbidden / unauthorized /
rejected / network, plus the message-embedded-status and 403-over-400
ordering cases already pinned for `ListView`).

## Locales

`detail.attachmentsApiUnavailable` added to all ten packs (`en`, `zh`, `ar`,
`de`, `es`, `fr`, `ja`, `ko`, `pt`, `ru`), following the pattern the sibling
`attachmentsAccessDenied`/`attachmentsLoadFailed` keys already use in the
same file. `all-locales-key-parity`, `check-i18n-call-site-keys` and
`check-i18n-en-drift` all green (output quoted below).

## Changeset

One changeset, `patch` for all four touched publishable packages
(`@object-ui/app-shell`, `@object-ui/i18n`, `@object-ui/plugin-list`,
`@object-ui/react`) — judged by publish status (none is `private`), not by
how user-visible each individual package's slice looks.

## Gates (all at `7e1701bbd`, the commit this PR carries)

- `pnpm exec turbo run build --filter='@object-ui/app-shell...' --filter='@object-ui/plugin-list...'` — 29/29 tasks successful (full dependency closure: types, core, i18n, data-objectstack, react, components, plugin-list, app-shell, …).
- `pnpm exec turbo run type-check --filter='@object-ui/app-shell' --filter='@object-ui/plugin-list' --filter='@object-ui/react' --filter='@object-ui/i18n' --filter='@object-ui/data-objectstack'` — 34/34 successful.
- `pnpm exec turbo run lint --filter='@object-ui/app-shell' --filter='@object-ui/plugin-list' --filter='@object-ui/react' --filter='@object-ui/i18n'` — 5/5 successful, 0 errors (pre-existing warnings only, none in the files this PR touches beyond a pre-existing `react-hooks/set-state-in-effect` warning on an untouched line the diff merely shifted).
- `pnpm exec vitest run packages/react/` — 593 passed (44 files).
- `pnpm exec vitest run packages/plugin-list/` — 549 passed (40 files).
- `pnpm exec vitest run packages/app-shell/src/views/__tests__/` — 106 passed (11 files).
- `pnpm exec vitest run packages/i18n/` — 804 passed (45 files).
- `node scripts/check-i18n-call-site-keys.mjs` — every call-site key resolves, every inline default matches its `en` value.
- `node scripts/check-i18n-en-drift.mjs` — 0 `en` values changed, 1 key added (parity-covered).
- `node scripts/check-control-bytes.mjs` — OK.
- `node scripts/check-phantom-dependencies.mjs` — every import declared by the package that publishes it (confirms the "zero new dependency edges" claim above).
- `node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs` / `check-changeset-fixed.mjs` — all green.
- `node scripts/check-lint-coverage.mjs` / `check-type-check-coverage.mjs` — all green.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_