### PR TITLE
fix(plugin-dashboard): bind drill-title drawer assertions to content, not a cumulative render count

### DIFF
--- a/.changeset/dataset-widget-drill-title-render-count.md
+++ b/.changeset/dataset-widget-drill-title-render-count.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only: fixed a flaky overshoot in `plugin-dashboard`'s DatasetWidget drill-title
+tests, where `waitFor` pinned a cumulative drawer-render count that a late, unrelated
+dimension-metadata re-render could push past 1 with no way to recover (objectui#4706).
+The assertions now wait for the drawer to have opened at least once and keep their
+content check (the drawer title/filter) as the substantive assertion. No published
+behaviour changes.

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.drillTitleLabel.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.drillTitleLabel.test.tsx
@@ -180,7 +180,17 @@ describe('DatasetWidget — the drill title reads the series LABEL (objectui#468
     const ev = clickSegment(1, 0);
     expect(ev.series).toBe('[null]');
 
-    await waitFor(() => expect(drawerProps.length).toBe(1));
+    // Bound to the drawer having opened AT LEAST once (objectui#4706), not to
+    // an exact cumulative render count: `drawerProps` only ever grows, and a
+    // late, unrelated `setMeta` from the dimension-metadata fetch (issued by
+    // `useDatasetDimensionMeta`, resolving independently of the click) can
+    // land a SECOND identical render after this one click — an overshoot
+    // `waitFor` can never recover from once it happens, since the array never
+    // shrinks. The case is about WHICH title the drawer shows, not how many
+    // times React chose to render it, so `lastDrawer()` — the content check
+    // below — is what carries the assertion; the count only needs to confirm
+    // the drawer opened at all.
+    await waitFor(() => expect(drawerProps.length).toBeGreaterThan(0));
     // The KEY did the lookup — the right records, which is what objectui#4673
     // already guaranteed and what must not move…
     expect(lastDrawer().filter).toEqual({ status_id: 'st-backlog', priority_id: null });
@@ -208,7 +218,9 @@ describe('DatasetWidget — the drill title reads the series LABEL (objectui#468
     await waitFor(() => expect(chartSeries().length).toBe(2));
 
     clickSegment(0, 0);
-    await waitFor(() => expect(drawerProps.length).toBe(1));
+    // At-least-once, not exact-once (objectui#4706) — see the first case in
+    // this file for why a cumulative count overshoots.
+    await waitFor(() => expect(drawerProps.length).toBeGreaterThan(0));
     expect(lastDrawer().title).toBe(`Backlog / ${NULL_CATEGORY_LABEL}`);
     expect(lastDrawer().filter).toEqual({ status_id: 'st-backlog', priority_id: 'pri-literal' });
   });
@@ -236,7 +248,9 @@ describe('DatasetWidget — the drill title reads the series LABEL (objectui#468
     ]);
 
     clickSegment(1, 0);
-    await waitFor(() => expect(drawerProps.length).toBe(1));
+    // At-least-once, not exact-once (objectui#4706) — see the first case in
+    // this file for why a cumulative count overshoots.
+    await waitFor(() => expect(drawerProps.length).toBeGreaterThan(0));
     expect(lastDrawer().title).toBe('Backlog / Low');
     expect(lastDrawer().filter).toEqual({ status_id: 'st-backlog', priority_id: 'pri-low' });
   });
@@ -261,7 +275,9 @@ describe('DatasetWidget — the drill title reads the series LABEL (objectui#468
       series: 'High',
     });
 
-    await waitFor(() => expect(drawerProps.length).toBe(1));
+    // At-least-once, not exact-once (objectui#4706) — see the first case in
+    // this file for why a cumulative count overshoots.
+    await waitFor(() => expect(drawerProps.length).toBeGreaterThan(0));
     expect(lastDrawer().title).toBe('Backlog / High');
   });
 
@@ -303,7 +319,9 @@ describe('DatasetWidget — the drill title reads the series LABEL (objectui#468
       seriesLabel: 'Hours',
     });
 
-    await waitFor(() => expect(drawerProps.length).toBe(1));
+    // At-least-once, not exact-once (objectui#4706) — see the first case in
+    // this file for why a cumulative count overshoots.
+    await waitFor(() => expect(drawerProps.length).toBeGreaterThan(0));
     expect(lastDrawer().title).toBe('Backlog');
   });
 });


### PR DESCRIPTION
Fixes #4706

## What was wrong

`DatasetWidget.drillTitleLabel.test.tsx` pinned `drawerProps.length` to exactly `1`
after a single drill click, in five places. `drawerProps` is a recording array of the
mocked `DrillDownDrawer`'s render props — it only ever grows. `useDatasetDimensionMeta`
issues its own dimension-metadata fetch independently of the click; when that fetch's
`setMeta` lands its React commit strictly AFTER the click's own commit (a real
possibility under a saturated event loop, since the two updates are only incidentally
ordered), `DrillDownDrawer` renders a second time with the SAME title/filter, and
`drawerProps.length` overshoots to `2`. Once it overshoots, `waitFor` can never recover
— nothing shrinks the array. This is what CI observed on an unrelated PR's shard 2
(run 31885228851): `expected 2 to be 1`.

## The fix

Each site now waits for the drawer to have opened AT LEAST once
(`toBeGreaterThan(0)`) instead of pinning the exact cumulative count. The content
assertions immediately after (`lastDrawer().title` / `.filter`) are unchanged and
remain the substantive check — each case's own name states what it verifies (which
title the drawer shows), never how many times React chose to render it. A drawer that
never opens still times out exactly as before; only the overshoot-vulnerable exact-count
pin is relaxed.

Sites fixed (all in `DatasetWidget.drillTitleLabel.test.tsx`, same isomorphic
`await waitFor(() => expect(drawerProps.length).toBe(1))` idiom immediately followed by
content assertions):
- `:193` — "titles an identity-keyed group…" (the issue's named site)
- `:223` — "titles the OTHER colliding group…"
- `:253` — BOUNDARY "an ordinary group's title is byte-identical to before"
- `:280` — BOUNDARY "a click carrying no label still titles from the key"
- `:324` — BOUNDARY "a NON-pivoted widget still omits the series from its title"

All five share byte-identical exposure (confirmed empirically, not just by inspection —
see Verification below), so all five were fixed the same way.

## Verification

**Deterministic reproduction (pre-fix, all 5 sites red).** Temporarily gated the
dimension-metadata `fetch` mock behind a manually-releasable promise, wrapped the drill
click in its own `act()` so its render fully commits first, then released the gate and
flushed inside a second `act()` — forcing the click's commit and the metadata commit
into two SEPARATE React passes instead of letting React 18 automatic batching coalesce
them into one (which is why a naive forced-delay attempt without the `act()` boundary
did not reproduce it: both updates landed in the same commit). With the OLD assertion,
all 5 sites failed with the exact CI failure text — `expected 2 to be 1`.

**Fix re-verified under the same forced race.** With the fix applied and the forced
overshoot still active, all 7 tests in the file pass.

**Positive control (assertion bite-check).** With the fix in place, temporarily reverted
objectui#4682's production fix (`ev?.seriesLabel ?? ev?.series` → `ev?.series`) in
`DatasetWidget.tsx`'s `handleChartDrill`. The two identity-collision cases correctly
went red on the WRONG title (`Backlog / [null]` / `Backlog / ["(None)"]` instead of
`Backlog / (None)`), while the three ordinary-group boundary cases correctly stayed
green (label equals key there, so the reverted line can't move their title) —
confirming the rebound assertions still catch the real defect the file exists to pin.

All temporary repro/gate/positive-control changes were reverted before the commit in
this PR — `git diff` against `origin/main` is the fix alone (test file + changeset).

## Gates run (final HEAD `83da6212d`)

- `pnpm --filter '@object-ui/plugin-dashboard' lint` — 0 errors (334 pre-existing
  `any`/fast-refresh warnings, none introduced by this change; the changed file's own
  warnings are all pre-existing, outside the edited lines)
- `pnpm --filter '@object-ui/plugin-dashboard' type-check` — clean
- `pnpm exec vitest run packages/plugin-dashboard/` — **58 files / 462 tests passed**
- `node scripts/check-control-bytes.mjs` — OK
- `node scripts/check-changeset-presence.mjs` — OK (empty-frontmatter changeset declared)
- `node scripts/check-changeset-fixed.mjs` / `check-changeset-no-major.mjs` — OK

## Changeset

Test-only change → empty-frontmatter changeset
(`.changeset/dataset-widget-drill-title-render-count.md`). No published behaviour
changes.

## Not in scope

#4705 and #4682 are unrelated to this change (#4705 only triggered the shard-2 red that
surfaced this issue; #4682 is the drill-title feature these tests pin, untouched here
beyond the temporary, reverted positive control). #4694 is also unrelated. None of them
are addressed or closed by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_