### PR TITLE
fix(console,plugin-detail): retire permission_change/export/restore audit actions

### DIFF
--- a/.changeset/audit-log-action-retirement.md
+++ b/.changeset/audit-log-action-retirement.md
@@ -1,0 +1,6 @@
+---
+"@object-ui/console": patch
+"@object-ui/plugin-detail": patch
+---
+
+Retire `permission_change`, `export`, and `restore` from the audit-log action filter (`AuditLogPage`'s `ACTION_OPTIONS`) and badge maps (`AuditLogPage` and `HistoryTimeline`'s `ACTION_VARIANT`). These three values never had a writer anywhere on the platform, so the filter always returned zero rows for them and the badges never rendered — a visible product defect (audit surface should be narrow-but-honest, not broad-but-lying). `import`, `login`, and `config_change` are kept: `import` has a real writer (`plugin-auth`'s `admin-import-users.ts`) and is still declared by the server enum and filtered by the `config_changes` list view; `login`/`config_change` gained real writers in objectstack#8144/#8145.

--- a/apps/console/src/pages/system/AuditLogPage.tsx
+++ b/apps/console/src/pages/system/AuditLogPage.tsx
@@ -54,29 +54,10 @@ import {
   Separator,
 } from '@object-ui/components';
 import { RefreshCw, Search, X, AlertCircle, ScrollText } from 'lucide-react';
+import { ACTION_OPTIONS, ACTION_VARIANT } from './auditLogActions';
 
 const SERVER_URL = (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, '');
 const API_BASE = `${SERVER_URL}/api/v1`;
-
-const ACTION_OPTIONS = [
-  'create', 'update', 'delete', 'restore',
-  'login', 'logout',
-  'permission_change', 'config_change',
-  'export', 'import',
-] as const;
-
-const ACTION_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
-  create: 'default',
-  update: 'secondary',
-  delete: 'destructive',
-  restore: 'outline',
-  login: 'outline',
-  logout: 'outline',
-  permission_change: 'secondary',
-  config_change: 'secondary',
-  export: 'outline',
-  import: 'outline',
-};
 
 interface AuditRow {
   id: string;

--- a/apps/console/src/pages/system/auditLogActions.test.ts
+++ b/apps/console/src/pages/system/auditLogActions.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Guards `ACTION_OPTIONS` against drifting from the server-declared
+ * `sys_audit_log.action` enum (objectstack
+ * packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts).
+ *
+ * objectui#4476: this console filter list previously carried three values
+ * (`permission_change`, `export`, `restore`) the server never wrote or, by
+ * the time this landed, no longer declared — an audit filter that always
+ * returns zero rows is a visible product defect ("审计面宁窄勿谎" — narrow
+ * but honest beats broad but lying). The corrected member set was itself
+ * revised twice mid-flight (see issue comments 2026-08-13/14): `import`
+ * turned out to have a real writer (plugin-auth's admin-import-users.ts)
+ * and stayed; `restore` turned out to have none and was added to the
+ * retirement list after the server enum dropped it in objectstack#8315
+ * (landed as `4827e915d`, verified again on objectstack@a5262d5 below).
+ *
+ * The expected list below is written as an INDEPENDENT literal — not
+ * derived from `ACTION_OPTIONS` — on purpose. A test that compares a
+ * constant to itself (e.g. via a shared source) cannot fail no matter how
+ * far the two drift apart; objectstack's own sibling card for this
+ * retirement (objectstack#8148) hit exactly that shape of blind spot with
+ * a stale prose comment that had been wrong since the day it was written.
+ * Keeping this list hand-written means a future edit to either side (a
+ * console dev adding an option back, or a server dev changing the enum
+ * without checking here) actually turns this test red.
+ */
+import { describe, expect, it } from 'vitest';
+import { ACTION_OPTIONS } from './auditLogActions';
+
+// Last verified directly against
+// objectstack packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts
+// at objectstack@a5262d5 (2026-08-15). Update this literal by hand whenever
+// the server enum changes — that is the point of the guard.
+const SERVER_ACTION_ENUM = [
+  'create',
+  'update',
+  'delete',
+  'login',
+  'logout',
+  'config_change',
+  'import',
+];
+
+describe('ACTION_OPTIONS', () => {
+  it('matches the server-declared sys_audit_log.action enum exactly', () => {
+    expect([...ACTION_OPTIONS].sort()).toEqual([...SERVER_ACTION_ENUM].sort());
+  });
+
+  it('does not carry any of the retired action values', () => {
+    for (const retired of ['permission_change', 'export', 'restore']) {
+      expect(ACTION_OPTIONS).not.toContain(retired);
+    }
+  });
+});

--- a/apps/console/src/pages/system/auditLogActions.ts
+++ b/apps/console/src/pages/system/auditLogActions.ts
@@ -1,0 +1,31 @@
+/**
+ * `sys_audit_log.action` values recognized by the console (filter dropdown +
+ * badge coloring), split into their own module — rather than living inline
+ * in AuditLogPage.tsx — so they can be imported by AuditLogPage.test.ts
+ * without pulling a component export into a non-component file (React Fast
+ * Refresh wants component files to only export components).
+ *
+ * Kept options mirror the server-declared `sys_audit_log.action` enum
+ * (packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts in
+ * objectstack): `permission_change`, `export`, and `restore` were retired
+ * because no writer anywhere in the platform ever produces them (audit
+ * surface principle: narrow-but-honest over broad-but-lying — objectui#4476).
+ * `import` stays: it has a real writer (plugin-auth's admin-import-users.ts)
+ * and the server enum + the config_changes list view both still use it.
+ */
+
+export const ACTION_OPTIONS = [
+  'create', 'update', 'delete',
+  'login', 'logout',
+  'config_change', 'import',
+] as const;
+
+export const ACTION_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  create: 'default',
+  update: 'secondary',
+  delete: 'destructive',
+  login: 'outline',
+  logout: 'outline',
+  config_change: 'secondary',
+  import: 'outline',
+};

--- a/packages/plugin-detail/src/HistoryTimeline.tsx
+++ b/packages/plugin-detail/src/HistoryTimeline.tsx
@@ -61,16 +61,20 @@ export interface HistoryTimelineProps {
   locale?: string;
 }
 
+// Kept keys mirror the server-declared `sys_audit_log.action` enum
+// (packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts in
+// objectstack): 'permission_change', 'export', and 'restore' were retired
+// because no writer anywhere in the platform ever produces them (audit
+// surface principle: narrow-but-honest over broad-but-lying — objectui#4476).
+// 'import' stays: it has a real writer (plugin-auth's admin-import-users.ts)
+// and the server enum + the config_changes list view both still use it.
 const ACTION_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
   create: 'default',
   update: 'secondary',
   delete: 'destructive',
-  restore: 'outline',
   login: 'outline',
   logout: 'outline',
-  permission_change: 'secondary',
   config_change: 'secondary',
-  export: 'outline',
   import: 'outline',
 };
 

--- a/packages/plugin-detail/src/__tests__/HistoryTimeline.test.tsx
+++ b/packages/plugin-detail/src/__tests__/HistoryTimeline.test.tsx
@@ -80,4 +80,30 @@ describe('HistoryTimeline', () => {
     render(<HistoryTimeline entries={[]} emptyText="Nothing here yet" />);
     expect(screen.getByText('Nothing here yet')).toBeTruthy();
   });
+
+  // objectui#4476: ACTION_VARIANT no longer has a 'restore' entry (the value
+  // was retired — no writer anywhere ever produces it). Before removal it
+  // mapped to 'outline', which is also the `?? 'outline'` fallback used for
+  // any unrecognized action — so dropping the key is a pure no-op for
+  // rendering. This test locks that reading in: the badge for a (now
+  // unrecognized) 'restore' action must render with exactly the classes the
+  // 'outline' variant contributes (see packages/components/src/ui/badge.tsx),
+  // and none of the classes unique to the other named variants.
+  it('renders the retired "restore" action badge identically to the outline fallback (confirms removing the key changed no rendering)', () => {
+    const entries: HistoryEntry[] = [
+      {
+        id: 6,
+        action: 'restore',
+        user_name: 'Jane Doe',
+        created_at: new Date().toISOString(),
+      },
+    ];
+    render(<HistoryTimeline entries={entries} />);
+    const badge = screen.getByText('restore');
+    expect(badge.className).toContain('text-foreground');
+    expect(badge.className).not.toContain('bg-secondary');
+    expect(badge.className).not.toContain('bg-primary');
+    expect(badge.className).not.toContain('bg-destructive');
+    expect(badge.className).not.toContain('border-transparent');
+  });
 });


### PR DESCRIPTION
Fixes #4476

## What changed

Retired `permission_change`, `export`, and `restore` from:
- `apps/console/src/pages/system/AuditLogPage.tsx` — `ACTION_OPTIONS` (the audit-log filter dropdown) and `ACTION_VARIANT` (badge color map)
- `packages/plugin-detail/src/HistoryTimeline.tsx` — `ACTION_VARIANT` (badge color map)

`login`, `config_change`, and **`import`** are kept. `ACTION_OPTIONS`/`ACTION_VARIANT` were moved out of `AuditLogPage.tsx` into a new `apps/console/src/pages/system/auditLogActions.ts` so a guard test could import them without mixing a non-component export into a component file (avoids an ESLint `react-refresh/only-export-components` warning).

## Why the member set is not the card's original three

The card's own body carries a ruling naming `export` / `import` / `permission_change` as the three retired values. That premise was falsified during implementation of the server-side prerequisite and corrected through the card's comment thread before this PR was dispatched — I did not re-adjudicate anything, only followed the corrected set the PM dispatched with:

1. **2026-08-13 04:37** ([comment](https://github.com/objectstack-ai/objectui/issues/4476#issuecomment-5276022041)) — `import` has a real writer, `plugin-auth/src/admin-import-users.ts:515`, and objectstack#8147's landed enum (`344a22a82`) kept it; the `config_changes` list view actively filters `['config_change', 'import']`. Removing it from the console would create the inverse defect the ruling's own principle warns against: an action the server can produce that the UI can't show.
2. **2026-08-13 05:52** ([comment](https://github.com/objectstack-ai/objectui/issues/4476#issuecomment-5276501753)) — `restore` is the same defect shape (declared, translated, filtered by a list view, but zero writers — `audit-writers.ts`'s `actionFor()` return type doesn't include it) and was queued for retirement server-side as objectstack#8315.
3. **2026-08-13 12:31** ([comment](https://github.com/objectstack-ai/objectui/issues/4476#issuecomment-5280429269)) — objectstack#8315 / PR #8325 merged (`4827e915d`), removing `restore` from the server enum. Contract-first precondition satisfied; console-side change unblocked.
4. **2026-08-14 16:51** ([comment](https://github.com/objectstack-ai/objectui/issues/4476#issuecomment-5295907824)) — independent cross-repo re-measurement converged on the same corrected set.
5. **2026-08-15 13:32** ([comment](https://github.com/objectstack-ai/objectui/issues/4476#issuecomment-5302458899)) — PM dispatch claim, re-verifying the above on `origin/main` and dispatching with the corrected member set.

Net: still three values retired, but `import` swapped out for `restore`.

| value | disposition | basis |
|---|---|---|
| `permission_change` | retired | original ruling, unchanged |
| `export` | retired | original ruling, unchanged |
| `import` | **kept** | real writer + server enum + `config_changes` view all still use it |
| `restore` | retired | server retired it in objectstack#8315 / PR #8325 (`4827e915d`) |
| `login` / `config_change` | kept | writers landed (objectstack#8144 / #8145) |

Verified directly against `objectstack@a5262d5` today — `packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts`'s `action` enum is exactly `['create', 'update', 'delete', 'login', 'logout', 'config_change', 'import']`, matching this PR's `ACTION_OPTIONS`.

## Sweep for residual references

Grepped both files plus `packages/i18n/src/locales/*.ts` for the three retired values. Neither `AuditLogPage.tsx` nor `HistoryTimeline.tsx` translates the action value (both render the raw string), so there are no i18n keys keyed on these action names — `check:i18n-call-site-keys` and `check:i18n-en-drift` both pass clean on this diff. No other console or plugin-detail file references these three values.

## `restore` badge removal is a no-op (confirmed by test, not just read)

`HistoryTimeline`'s `ACTION_VARIANT['restore']` mapped to `'outline'`, and the `?? 'outline'` fallback used for any unrecognized action is also `'outline'` — so dropping the key changes no rendering. `AuditLogPage.tsx`'s equivalent map used the same value + same `|| 'outline'` fallback pattern. Added a test (`HistoryTimeline.test.tsx`) that renders a `'restore'`-actioned entry and asserts the badge carries exactly the `outline`-variant classes (`text-foreground`, none of `bg-secondary`/`bg-primary`/`bg-destructive`/`border-transparent`) — locking in that this specific removal changed no visible output. `permission_change`'s removal is *not* a no-op (it mapped to `'secondary'`), which is the expected/intended behavior change for a genuinely-retired value.

## Guard test decision

Added `auditLogActions.test.ts` pinning `ACTION_OPTIONS` against an **independently hand-written literal** copy of the server's `sys_audit_log.action` enum (not derived from `ACTION_OPTIONS` itself — a self-referential comparison can't fail no matter how far the two drift). Decided to add it because: (a) this exact card is the third round of a multi-comment correction thread caused by nobody having a mechanical check that the console's option list tracks the server enum; (b) the cost is one small test file, no new runtime dependency, no cross-repo build coupling; (c) it directly encodes the "audit surface narrow-but-honest" principle this card exists to restore. Trade-off acknowledged: this is a manual-sync pin, not a live cross-repo check (objectui doesn't depend on objectstack's plugin-audit package at build/test time) — a future server enum change won't fail this test automatically, only a console-side edit that forgets to also touch the literal will. Comment on the literal names the exact source line and the sha it was last verified against.

## Tests

Local verification at `7a9e5f24a` (final commit head, matches this PR):

```
pnpm --filter '@object-ui/console^...' --workspace-concurrency=2 build   # dependency closure, PASS
pnpm --filter '@object-ui/plugin-detail' --filter '@object-ui/console' --workspace-concurrency=2 type-check   # PASS, 0 errors
pnpm --filter '@object-ui/plugin-detail' --filter '@object-ui/console' --workspace-concurrency=2 lint          # PASS, 0 errors (204 pre-existing unrelated warnings)
pnpm exec vitest run apps/console/src/pages/system/auditLogActions.test.ts packages/plugin-detail/src/__tests__/HistoryTimeline.test.tsx --maxWorkers=2
  # Test Files  2 passed (2)
  # Tests       8 passed (8)
node scripts/check-control-bytes.mjs        # PASS
node scripts/check-i18n-call-site-keys.mjs  # PASS, unaffected
node scripts/check-i18n-en-drift.mjs        # PASS, unaffected
node scripts/check-changeset-presence.mjs   # PASS, 1 changeset declared
node scripts/check-changeset-no-major.mjs   # PASS
```

## Changeset

`.changeset/audit-log-action-retirement.md` — `patch` bump for `@object-ui/console` and `@object-ui/plugin-detail` (both in the `fixed` release group, neither `private`). User-visible: the audit-log filter dropdown loses three options that always returned zero rows.

## Not in scope here

- objectstack#7675 (upstream census, tracks this card + objectstack#8148 as its two remaining open items) — not addressed here.
- objectstack#8148 (dashboard widget / translations side, objectstack repo) — not addressed here, out of scope: separate repo.
- cloud#1274 (`service-cloud`'s hand-mirrored action union still lists `restore` and `export`) — not addressed here, out of scope: different repo, different write path (bypasses schema), flagged cross-reference only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_