### PR TITLE
fix(i18n,auth): converge downstream-filled holes on single braces

### DIFF
--- a/.changeset/single-brace-downstream-holes-4135.md
+++ b/.changeset/single-brace-downstream-holes-4135.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/i18n': patch
+'@object-ui/auth': patch
+'@object-ui/console': patch
+---
+
+`auth.forgotPassword.successDescription`'s address hole is now spelled with
+single braces (`{email}`) instead of i18next's double braces (`{{email}}`),
+in all ten locale packs.
+
+This is a spelling-only change — rendered output is byte-identical in every
+language, because the hole was never filled by i18next in the first place:
+`ForgotPasswordForm` substitutes the address itself once the user submits
+the form (the label renders before the address exists, so `t()` cannot do
+it). `{{email}}` and a genuinely unfilled i18next hole were indistinguishable
+at the call site, and passing `email` as an interpolation argument — the
+natural "fix" for what looks like a missing argument — would let i18next
+consume the hole and cause the address to be appended a second time
+(objectui#4135).
+
+Converging on `{x}` for every hole a component fills downstream of `t()`
+(the convention `resendOtpCountdownText`'s `{seconds}` already used) puts
+this hole outside i18next's `{{…}}` syntax entirely, so the ambiguity is
+gone by construction rather than fenced by an exemption. Accordingly,
+`scripts/check-i18n-call-site-keys.mjs`'s `EXTERNALLY_INTERPOLATED_HOLES`
+registry entry for this key is retired — the gate needs no exemption for a
+hole i18next was never going to touch.
+
+`ForgotPasswordForm.tsx`'s replacement marker and its own built-in default
+label move to the same spelling in the same change, as does the inline
+`defaultValue` at `apps/console/src/pages/auth/ForgotPasswordPage.tsx`'s
+call site.

--- a/apps/console/src/pages/auth/ForgotPasswordPage.tsx
+++ b/apps/console/src/pages/auth/ForgotPasswordPage.tsx
@@ -44,7 +44,7 @@ export function ForgotPasswordPage() {
             defaultValue: 'Check your email',
           }),
           successDescription: t('auth.forgotPassword.successDescription', {
-            defaultValue: "We've sent a password reset link to {{email}}. Please check your inbox.",
+            defaultValue: "We've sent a password reset link to {email}. Please check your inbox.",
           }),
           backToSignInText: t('auth.forgotPassword.backToSignInText', {
             defaultValue: 'Back to sign in',

--- a/packages/auth/src/ForgotPasswordForm.tsx
+++ b/packages/auth/src/ForgotPasswordForm.tsx
@@ -178,7 +178,7 @@ export function ForgotPasswordForm({
     successTitle: labels.successTitle ?? 'Check your email',
     successDescription:
       labels.successDescription ??
-      "We've sent a password reset link to {{email}}. Please check your inbox.",
+      "We've sent a password reset link to {email}. Please check your inbox.",
     backToSignInText: labels.backToSignInText ?? 'Back to sign in',
     rememberPasswordText: labels.rememberPasswordText ?? 'Remember your password?',
     signInText: labels.signInText ?? 'Sign in',
@@ -283,8 +283,8 @@ export function ForgotPasswordForm({
   }
 
   if (submitted) {
-    const successMsg = l.successDescription.includes('{{email}}')
-      ? l.successDescription.replace('{{email}}', email)
+    const successMsg = l.successDescription.includes('{email}')
+      ? l.successDescription.replace('{email}', email)
       : `${l.successDescription} ${email}`;
     return (
       <div className="mx-auto flex w-full flex-col justify-center space-y-7 sm:w-[400px]">

--- a/packages/auth/src/__tests__/forgot-password-success-message.test.tsx
+++ b/packages/auth/src/__tests__/forgot-password-success-message.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * objectui#4135 — the maintainer's 2026-08-11 ruling converged
+ * `auth.forgotPassword.successDescription`'s downstream-filled hole on
+ * SINGLE braces (`{email}`), matching the repo-wide convention that `{{x}}`
+ * is reserved for i18next and any hole a component fills itself (after
+ * `t()` has already returned) is spelled `{x}` — outside i18next's syntax,
+ * safe by construction.
+ *
+ * This pins `ForgotPasswordForm`'s two-stage substitution itself: the
+ * `{email}` marker is filled exactly once, on both label paths the
+ * component can reach (its own built-in default, and a caller-supplied
+ * translated label), and a label with no marker at all falls back to the
+ * append branch — also exactly once. The regression this guards against is
+ * the one the issue named: a call site that mistakenly passes `email` as
+ * an i18next interpolation argument would (with the old `{{email}}`
+ * spelling) let i18next consume the hole, so `includes('{{email}}')` would
+ * then miss and the fallback branch would append the address a SECOND
+ * time — `...link to a@b.com. Please check your inbox. a@b.com`. With the
+ * single-brace spelling this is no longer reachable: `{email}` is not
+ * i18next syntax, so i18next never touches it regardless of what argument
+ * a call site passes, and the marker always survives to the component.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AuthProvider } from '../AuthProvider';
+import { ForgotPasswordForm } from '../ForgotPasswordForm';
+import type { AuthClient, AuthPublicConfig } from '../types';
+
+function createMockClient(overrides: Partial<AuthClient> = {}): AuthClient {
+  return {
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn(),
+    getSession: vi.fn().mockResolvedValue(null),
+    forgotPassword: vi.fn().mockResolvedValue(undefined),
+    resetPassword: vi.fn().mockResolvedValue(undefined),
+    getConfig: vi.fn().mockResolvedValue({} as AuthPublicConfig),
+    ...overrides,
+  } as unknown as AuthClient;
+}
+
+function renderForgotPassword(props: React.ComponentProps<typeof ForgotPasswordForm> = {}) {
+  return render(
+    <AuthProvider authUrl="/api/auth" client={createMockClient()}>
+      <ForgotPasswordForm {...props} />
+    </AuthProvider>,
+  );
+}
+
+async function submit(email: string) {
+  fireEvent.change(await screen.findByLabelText('Email'), { target: { value: email } });
+  fireEvent.click(screen.getByRole('button', { name: 'Send Reset Link' }));
+}
+
+/** Every occurrence of `needle` in `haystack` — a double-append shows up as 2. */
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe('ForgotPasswordForm — success message substitution (objectui#4135)', () => {
+  it("fills the component's own built-in {email} marker exactly once (no labels prop)", async () => {
+    renderForgotPassword();
+    await submit('user@example.com');
+
+    const description = await screen.findByText(/password reset link/i);
+    expect(occurrences(description.textContent ?? '', 'user@example.com')).toBe(1);
+    // No leftover marker in either spelling.
+    expect(description.textContent).not.toMatch(/\{email\}|\{\{email\}\}/);
+  });
+
+  it('fills a caller-supplied translated {email} marker exactly once', async () => {
+    renderForgotPassword({
+      labels: {
+        successDescription: 'We mailed a reset link to {email} — check your inbox.',
+      },
+    });
+    await submit('translated@example.com');
+
+    const description = await screen.findByText(/we mailed a reset link/i);
+    expect(occurrences(description.textContent ?? '', 'translated@example.com')).toBe(1);
+    expect(description.textContent).not.toMatch(/\{email\}/);
+  });
+
+  it('appends the address exactly once when the label carries no marker at all', async () => {
+    renderForgotPassword({
+      labels: { successDescription: 'Check your inbox for the reset link.' },
+    });
+    await submit('noholes@example.com');
+
+    const description = await screen.findByText(/check your inbox/i);
+    expect(occurrences(description.textContent ?? '', 'noholes@example.com')).toBe(1);
+  });
+
+  it('positive control: never pastes the address twice, the double-append shape the issue described', async () => {
+    // The failure mode objectui#4135 named: a label whose hole i18next has
+    // already consumed carries no marker of any kind by the time it reaches
+    // the component (exactly what "passing `email` to `t()`" would produce
+    // under the OLD `{{email}}` spelling). That falls to the append branch —
+    // which must still paste the address only once, not zero and not twice.
+    renderForgotPassword({
+      labels: {
+        successDescription: "We've already sent a link — no marker left to fill here.",
+      },
+    });
+    await submit('control@example.com');
+
+    const description = await screen.findByText(/no marker left to fill/i);
+    expect(occurrences(description.textContent ?? '', 'control@example.com')).toBe(1);
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -2019,7 +2019,7 @@ const ar = {
       submitButton: "إرسال رابط إعادة التعيين",
       submittingButton: "جارٍ الإرسال…",
       successTitle: "تحقق من بريدك الإلكتروني",
-      successDescription: "لقد أرسلنا رابط إعادة تعيين كلمة المرور إلى {{email}}. يرجى التحقق من بريدك الوارد.",
+      successDescription: "لقد أرسلنا رابط إعادة تعيين كلمة المرور إلى {email}. يرجى التحقق من بريدك الوارد.",
       backToSignInText: "العودة إلى تسجيل الدخول",
       rememberPasswordText: "تتذكر كلمة المرور؟",
       signInText: "تسجيل الدخول",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -2012,7 +2012,7 @@ const de = {
       submitButton: "Link zum Zurücksetzen senden",
       submittingButton: "Wird gesendet…",
       successTitle: "Überprüfen Sie Ihre E-Mails",
-      successDescription: "Wir haben einen Link zum Zurücksetzen des Passworts an {{email}} gesendet. Bitte überprüfen Sie Ihren Posteingang.",
+      successDescription: "Wir haben einen Link zum Zurücksetzen des Passworts an {email} gesendet. Bitte überprüfen Sie Ihren Posteingang.",
       backToSignInText: "Zurück zur Anmeldung",
       rememberPasswordText: "Passwort doch bekannt?",
       signInText: "Anmelden",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -2192,7 +2192,7 @@ const en = {
       submitButton: 'Send Reset Link',
       submittingButton: 'Sending…',
       successTitle: 'Check your email',
-      successDescription: "We've sent a password reset link to {{email}}. Please check your inbox.",
+      successDescription: "We've sent a password reset link to {email}. Please check your inbox.",
       backToSignInText: 'Back to sign in',
       rememberPasswordText: 'Remember your password?',
       signInText: 'Sign in',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -2016,7 +2016,7 @@ const es = {
       submitButton: "Enviar enlace de restablecimiento",
       submittingButton: "Enviando…",
       successTitle: "Revisa tu correo electrónico",
-      successDescription: "Hemos enviado un enlace para restablecer la contraseña a {{email}}. Por favor revisa tu bandeja de entrada.",
+      successDescription: "Hemos enviado un enlace para restablecer la contraseña a {email}. Por favor revisa tu bandeja de entrada.",
       backToSignInText: "Volver a iniciar sesión",
       rememberPasswordText: "¿Recuerdas tu contraseña?",
       signInText: "Iniciar sesión",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -2014,7 +2014,7 @@ const fr = {
       submitButton: "Envoyer le lien de réinitialisation",
       submittingButton: "Envoi en cours…",
       successTitle: "Vérifiez vos e-mails",
-      successDescription: "Nous avons envoyé un lien de réinitialisation du mot de passe à {{email}}. Veuillez vérifier votre boîte de réception.",
+      successDescription: "Nous avons envoyé un lien de réinitialisation du mot de passe à {email}. Veuillez vérifier votre boîte de réception.",
       backToSignInText: "Retour à la connexion",
       rememberPasswordText: "Vous vous souvenez de votre mot de passe ?",
       signInText: "Se connecter",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -2012,7 +2012,7 @@ const ja = {
       submitButton: "リセットリンクを送信",
       submittingButton: "送信中…",
       successTitle: "メールをご確認ください",
-      successDescription: "{{email}} にパスワードリセットリンクを送信しました。受信箱をご確認ください。",
+      successDescription: "{email} にパスワードリセットリンクを送信しました。受信箱をご確認ください。",
       backToSignInText: "サインインに戻る",
       rememberPasswordText: "パスワードを覚えていますか？",
       signInText: "サインイン",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -2012,7 +2012,7 @@ const ko = {
       submitButton: "재설정 링크 보내기",
       submittingButton: "전송 중…",
       successTitle: "이메일을 확인하세요",
-      successDescription: "{{email}}(으)로 비밀번호 재설정 링크를 전송했습니다. 수신함을 확인해주세요.",
+      successDescription: "{email}(으)로 비밀번호 재설정 링크를 전송했습니다. 수신함을 확인해주세요.",
       backToSignInText: "로그인으로 돌아가기",
       rememberPasswordText: "비밀번호가 기억나시나요?",
       signInText: "로그인",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -2011,7 +2011,7 @@ const pt = {
       submitButton: "Enviar link de redefinição",
       submittingButton: "Enviando…",
       successTitle: "Verifique seu e-mail",
-      successDescription: "Enviamos um link para redefinição de senha para {{email}}. Por favor verifique sua caixa de entrada.",
+      successDescription: "Enviamos um link para redefinição de senha para {email}. Por favor verifique sua caixa de entrada.",
       backToSignInText: "Voltar para o login",
       rememberPasswordText: "Lembra da sua senha?",
       signInText: "Entrar",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -2022,7 +2022,7 @@ const ru = {
       submitButton: "Отправить ссылку для сброса",
       submittingButton: "Отправка…",
       successTitle: "Проверьте почту",
-      successDescription: "Мы отправили ссылку для сброса пароля на {{email}}. Пожалуйста, проверьте свою почту.",
+      successDescription: "Мы отправили ссылку для сброса пароля на {email}. Пожалуйста, проверьте свою почту.",
       backToSignInText: "Вернуться к входу",
       rememberPasswordText: "Помните свой пароль?",
       signInText: "Войти",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -2073,7 +2073,7 @@ const zh = {
       submitButton: '发送重置链接',
       submittingButton: '发送中…',
       successTitle: '请查看您的邮箱',
-      successDescription: '我们已将密码重置链接发送至 {{email}}，请检查您的收件箱。',
+      successDescription: '我们已将密码重置链接发送至 {email}，请检查您的收件箱。',
       backToSignInText: '返回登录',
       rememberPasswordText: '记住密码了？',
       signInText: '登录',

--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -145,10 +145,6 @@ const EN_FIXTURE = `const en = {
   // The one shape that makes a non-optional \`t()\` falsy, so \`||\` really can
   // reach its right operand. \`en\` has no such leaf today (objectui#4117).
   edge: { blank: '' },
-  // The real key registered in EXTERNALLY_INTERPOLATED_HOLES, so the registry's
-  // effect can be exercised against a synthetic repo rather than only observed
-  // on \`main\`. The registry is keyed by NAME, so a fixture is enough.
-  auth: { forgotPassword: { successDescription: 'Sent a reset link to {{email}}.' } },
 } as const;
 export default en;
 `;
@@ -728,26 +724,37 @@ export const A = (rest: Record<string, unknown>, key: string, opts: Record<strin
     expect([...holesOf('Resend in {seconds}s')].sort()).toEqual([]);
   });
 
-  describe('holes filled by the CONSUMER of the string, not by i18next', () => {
-    it('does not demand an argument for a registered hole', () => {
-      const root = repoWith(callSite("t('auth.forgotPassword.successDescription')"));
-      expect(parityOf(root)).toEqual([]);
+  describe('the EXTERNALLY_INTERPOLATED_HOLES registry — retired for auth.forgotPassword.successDescription (objectui#4135)', () => {
+    it('is empty: the maintainer\'s 2026-08-11 ruling converged on single-brace `{x}` for every hole filled downstream of `t()`, which sits outside i18next\'s `{{…}}` syntax and needs no exemption', () => {
+      expect(EXTERNALLY_INTERPOLATED_HOLES).toEqual([]);
     });
 
-    it('still reports the argument if someone passes it — that is the real defect here', () => {
-      // Passing it lets i18next consume the hole, `ForgotPasswordForm`'s
-      // `includes('{{email}}')` guard then misses, and its fallback branch appends
-      // the address a SECOND time. So the registry silences one direction only.
-      const root = repoWith(callSite("t('auth.forgotPassword.successDescription', { email: name })"));
-      expect(parityOf(root)).toEqual(['auth.forgotPassword.successDescription: inert=[email] unfilled=[]']);
+    it('so an argument-less `{{email}}` on that exact key is now judged like any other unfilled hole, not silenced', () => {
+      // Before the retirement this exact call site (no `email` argument) was
+      // silenced by the registry — `parityOf(root)` returned `[]`. A synthetic
+      // pack is used here (not the repo's real, now single-brace, value) to
+      // pin the GENERAL mechanism: whatever `en` happens to say, a bare
+      // double-brace hole with no argument is always reported.
+      const root = repoWith({
+        'packages/i18n/src/locales/en.ts': EN_FIXTURE.replace(
+          "edge: { blank: '' },",
+          "edge: { blank: '' },\n  auth: { forgotPassword: { successDescription: 'Sent a reset link to {{email}}.' } },",
+        ),
+        'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = () => { const { t } = useObjectTranslation(); return t('auth.forgotPassword.successDescription'); };
+`,
+      });
+      expect(parityOf(root)).toEqual(['auth.forgotPassword.successDescription: inert=[] unfilled=[email]']);
     });
 
-    it('every registered entry still describes something real, in en AND in the source', () => {
-      // An exemption that outlives the substitution it describes is an allowlist.
-      // Both halves of each entry's premise are checked against `main`: the pack
-      // really has the hole, and the named file really fills it.
+    it('every entry the registry DOES hold still describes something real, in en AND in the source', () => {
+      // Future-proofing: the registry mechanism stays in place, empty, for the
+      // day a genuinely unavoidable double-brace hole is registered again. An
+      // exemption that outlives the substitution it describes is an allowlist,
+      // so both halves of each entry's premise (if any) are checked against
+      // `main`: the pack really has the hole, and the named file really fills
+      // it. Trivially true today because the loop runs zero times.
       const parsed = collectEnKeys(repoRoot);
-      expect(EXTERNALLY_INTERPOLATED_HOLES.length).toBeGreaterThan(0);
       for (const entry of EXTERNALLY_INTERPOLATED_HOLES) {
         const value = parsed.values.get(entry.key);
         expect(value, `en does not define ${entry.key} as a string`).toBeTypeOf('string');

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -368,34 +368,24 @@ export const RESERVED_OPTION_NAMES = new Set([
  *
  * i18next leaves an unmatched `{{name}}` in the output verbatim, which is what
  * makes a second substitution stage possible at all: the string travels through
- * `t()` with its hole intact and the component fills it afterwards. That is a
- * deliberate design here, not an oversight — the sister label three lines away
- * in `apps/console/src/pages/auth/ForgotPasswordPage.tsx` spells the same
- * pattern with SINGLE braces (`Resend in {seconds}s`) precisely to stay out of
- * i18next's way, and the inconsistency between the two spellings is filed as
- * objectui#4135.
+ * `t()` with its hole intact and the component fills it afterwards. That used
+ * to require this registry, because a call-site-filled `{{hole}}` is otherwise
+ * indistinguishable from an i18next hole somebody forgot to pass an argument
+ * for — `auth.forgotPassword.successDescription` was the one entry, exempted
+ * from the `unfilled` check while `ForgotPasswordForm.tsx` filled it downstream.
  *
- * The listed hole names are removed from the hole set, so the `unfilled`
- * direction stays silent — and the `inert` direction keeps judging them, which
- * is the direction that matters here: passing `email` to `t()` would let
- * i18next consume the hole, `ForgotPasswordForm`'s `includes('{{email}}')`
- * guard would then miss, and its fallback branch would append the address a
- * SECOND time. So for these keys the argument must not be passed, and the gate
- * still says so.
+ * objectui#4135's 2026-08-11 maintainer ruling retired that entry by fixing the
+ * ambiguity at its source instead of fencing it: a hole filled downstream of
+ * `t()` is now ALWAYS spelled with SINGLE braces (`{x}`), which sits outside
+ * i18next's `{{…}}` syntax and is therefore invisible to `holesOf()` — safe by
+ * construction, no exemption needed. `resendOtpCountdownText`'s `{seconds}`
+ * (`apps/console/src/pages/auth/ForgotPasswordPage.tsx`) was already this
+ * shape; `successDescription` now matches it. The registry mechanism stays in
+ * place, empty, for the day a future case genuinely cannot avoid a
+ * double-brace hole filled outside i18next — the self-test below still checks
+ * every entry it holds, whatever that count is.
  */
-export const EXTERNALLY_INTERPOLATED_HOLES = [
-  {
-    key: 'auth.forgotPassword.successDescription',
-    holes: ['email'],
-    filledBy: 'packages/auth/src/ForgotPasswordForm.tsx',
-    marker: "successDescription.replace('{{email}}', email)",
-    reason:
-      'the label is a PROP of `ForgotPasswordForm`, which substitutes the address itself ' +
-      'once the form knows it — the call site cannot, because it renders before the user ' +
-      'has typed anything. All ten packs carry the hole, so this is the shape in every ' +
-      'language, not an en-only quirk.',
-  },
-];
+export const EXTERNALLY_INTERPOLATED_HOLES = [];
 
 /**
  * The interpolation names an `en` value has holes for (objectui#3845).


### PR DESCRIPTION
Fixes #4135

## What this does

Implements the maintainer's **2026-08-11 ruling** verbatim (Option A, established as a repo-wide authoring convention):

> `{{x}}` (double braces) is reserved exclusively for i18next holes — a `{{x}}` at a call site MUST have an argument passed. A hole filled downstream of `t()` (component-side substitution) is ALWAYS spelled `{x}` (single braces), which is outside i18next's syntax and therefore safe by construction.

One atomic change, three parts:

1. **All ten locale packs** (`en`, `zh`, `ar`, `de`, `es`, `fr`, `ja`, `ko`, `pt`, `ru`): `auth.forgotPassword.successDescription`'s address hole moves from `{{email}}` to `{email}`.
2. **`packages/auth/src/ForgotPasswordForm.tsx`**: the replacement marker (`includes('{{email}}')` / `replace('{{email}}', …)`) and the component's own built-in default label move to the same spelling, in the same commit — the marker check must never disagree with what it's checking.
3. **`scripts/check-i18n-call-site-keys.mjs`**: the `EXTERNALLY_INTERPOLATED_HOLES` registry entry for this key is **retired** (kept as an empty array for a future case) — the ambiguity it fenced is now eliminated at the source, so the gate needs no exemption for a hole i18next was never going to touch. Its self-test is updated to pin the retirement and to prove the gate reports an argument-less `{{hole}}` on this key loudly again.

Also updated in the same change, to keep the `default-value-drift` gate honest: the inline `defaultValue` at `apps/console/src/pages/auth/ForgotPasswordPage.tsx`'s call site (must byte-match the pack value it's a fallback for).

## Why this is safe

`{{email}}` is a literal *substring* of `{email}` is not the same relationship the other way, so — before this PR — a stray legacy `{{email}}` anywhere would have partially confused the marker check. After this PR, no shipped code path (ten packs, the component's default, or either console call site) produces `{{email}}` for this key anywhere in the repo; the gate's `interpolation-parity` class now judges this key like any other (see reverse verification below).

## Rendered output — byte-identical in all ten languages

This is a spelling-only change. For each of the ten packs, `oldValue.replace('{{email}}', email)` (pre-PR) and `newValue.replace('{email}', email)` (post-PR) were computed and diffed — all ten are byte-identical. (See `tests` in the dev report below for the script and its output.)

## Reverse verification

Committed the fix first, then temporarily reintroduced `{{email}}` into `packages/i18n/src/locales/en.ts` only (uncommitted) and re-ran `node scripts/check-i18n-call-site-keys.mjs` against the real repo:

- Before this PR (registry exempted the key): this mutation would have stayed silent.
- After this PR (registry retired): the gate went **red** (`EXIT=1`), reporting `default-value-drift` on `apps/console/src/pages/auth/ForgotPasswordPage.tsx` **and** `interpolation-parity: unfilled=[email]` on **both** call sites that reference the key (`apps/console` and `packages/app-shell`'s `ForgotPasswordPage.tsx`).

Restored via `git checkout claude/issue-4135-single-brace-convention -- packages/i18n/src/locales/en.ts` (clean diff after restore, confirmed).

## Tests

- New `packages/auth/src/__tests__/forgot-password-success-message.test.tsx` (4 tests): the `{email}` marker fills exactly once via the component's built-in default, via a caller-supplied translated label, and a label with no marker at all falls to the append branch exactly once — plus a positive control for the double-append shape the issue described.
- Full gate + test union at the final commit — see the dev report.

## Scope note

`#4206` also touches `scripts/check-i18n-call-site-keys.mjs` (in `RESERVED_OPTION_NAMES`) and is deliberately queued after this PR merges — not addressed here, and this PR does not touch that section.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_