### PR TITLE
fix(scripts): bound shadcn-sync registry requests with a 10s timeout

### DIFF
--- a/scripts/__tests__/shadcn-sync-fetch-cache.test.ts
+++ b/scripts/__tests__/shadcn-sync-fetch-cache.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import http from 'node:http';
+import { EventEmitter } from 'node:events';
 import type { AddressInfo } from 'node:net';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
@@ -158,6 +159,107 @@ describe('fetchUrl — the response status is part of the contract', () => {
     };
     await expect(fetchUrl(url(), { get: http.get })).resolves.toEqual(entry);
   });
+});
+
+describe('fetchUrl — a request with no response ever times out (objectstack#5968 / objectui#4031)', () => {
+  /**
+   * A hung registry request used to have nothing bounding it: `https.get`
+   * only ever wired up `error` and `end`, and a black-holed connection fires
+   * neither. `--check` runs 46 of these in series, so one hang stalled the
+   * whole command until something outside the script (a CI job timeout, a
+   * person hitting Ctrl-C) gave up, with no line in the log naming which URL
+   * stuck.
+   *
+   * Two distinct network conditions produce that hang — a dropped SYN (the
+   * connection itself never completes) and a peer that completes the TCP
+   * handshake and then never writes a byte. Both are covered by the SAME
+   * `req.setTimeout` callback in `fetchUrl`, because Node arms that idle
+   * timer as soon as a socket is assigned to the request, before the
+   * handshake resolves — there is no separate "connecting" branch to test.
+   *
+   * Both are exercised below with a `get` double that mimics a `ClientRequest`
+   * stuck before its response ever arrives — same wiring (`setTimeout(ms, cb)`
+   * + `destroy(error)` + the request's own `error` listener) `fetchUrl`
+   * actually depends on, deterministic, and independent of real network
+   * timing.
+   *
+   * A REAL socket was used first, and deliberately is not the committed test:
+   * a raw `net` server that accepts the connection and never writes back
+   * (`http.get` injected as `get`) reproduces the hang correctly outside
+   * vitest — confirmed clean and fast (rejects in ~40-50ms against a 40ms
+   * `timeoutMs`, twice in a row, matching this file's cache/registry
+   * assertions) both as a standalone Node script and inside a `worker_threads`
+   * Worker, including while this shared container had a sibling agent's
+   * `pnpm --filter @object-ui/console^... build` pegging multiple cores. The
+   * SAME code, run through Vitest's `threads` pool under that same load,
+   * reliably failed to observe the timeout at all — not slow, genuinely
+   * silent for the full 20s `it()` bound, reproducing identically with
+   * `-t` isolating the one test and with `--maxWorkers=1`. That is a
+   * Vitest-threads-pool-under-contention interaction with the real socket
+   * timer, not a defect in `fetchUrl`: this repo's own flaky-test discipline
+   * (AGENTS.md, "flaky 测试") is explicit that widening a budget to paper
+   * over a race is the wrong fix, and here even a 20s budget did not turn a
+   * genuine non-event into a passing one. A real socket cannot honestly be
+   * asserted on on this platform without that risk, so the committed
+   * coverage stays on the double above (see also `fetchRegistry propagates
+   * timeoutMs`, same shape, one level up the call stack) plus the manual
+   * verification recorded here and in the PR description.
+   */
+
+  it('rejects, naming the URL, when the connection itself never completes', async () => {
+    // Models a dropped SYN, and equally the "TCP connects, then the peer
+    // never writes a byte" case (from `fetchUrl`'s perspective the two are
+    // indistinguishable: neither ever invokes the response callback) — see
+    // describe-level comment for why a real socket isn't used here.
+    const neverConnects = (_reqUrl: string, _cb: unknown) => {
+      const req = new EventEmitter() as EventEmitter & {
+        setTimeout: (ms: number, cb: () => void) => void;
+        destroy: (err: Error) => void;
+      };
+      req.setTimeout = (ms, cb) => {
+        setTimeout(cb, ms);
+      };
+      req.destroy = (err) => {
+        req.emit('error', err);
+      };
+      return req;
+    };
+
+    const stuckUrl = 'http://192.0.2.1/r/styles/default/button.json';
+    await expect(
+      fetchUrl(stuckUrl, { get: neverConnects as unknown as typeof http.get, timeoutMs: 200 }),
+    ).rejects.toThrow(/shadcn-sync: registry request timed out after 200ms: /);
+    await expect(
+      fetchUrl(stuckUrl, { get: neverConnects as unknown as typeof http.get, timeoutMs: 200 }),
+    ).rejects.toThrow(stuckUrl);
+  }, 20_000);
+
+  it('does not fire on a request that responds well inside timeoutMs (no false positives)', async () => {
+    respond = respondJson(REGISTRY_ENTRY);
+    await expect(fetchUrl(url(), { get: http.get, timeoutMs: 2000 })).resolves.toEqual(REGISTRY_ENTRY);
+  });
+
+  it('fetchRegistry propagates timeoutMs through to fetchUrl and writes nothing to the cache on a hang', async () => {
+    const neverConnects = (_reqUrl: string, _cb: unknown) => {
+      const req = new EventEmitter() as EventEmitter & {
+        setTimeout: (ms: number, cb: () => void) => void;
+        destroy: (err: Error) => void;
+      };
+      req.setTimeout = (ms, cb) => {
+        setTimeout(cb, ms);
+      };
+      req.destroy = (err) => {
+        req.emit('error', err);
+      };
+      return req;
+    };
+
+    await expect(
+      registry('button', { get: neverConnects as unknown as typeof http.get, allowCache: true, timeoutMs: 200 }),
+    ).rejects.toThrow(/registry request timed out after 200ms/);
+    expect(await readCacheDir()).toEqual([]);
+    expect(cacheStats.failures).toBe(1);
+  }, 20_000);
 });
 
 describe('isRegistryEntry — what is allowed onto disk', () => {

--- a/scripts/shadcn-sync.js
+++ b/scripts/shadcn-sync.js
@@ -135,8 +135,32 @@ function bodySnippet(body, max = 120) {
  *
  * `get` is injectable so the tests can drive a real fixture server over plain
  * `http` — the status/parse logic under test is transport-independent.
+ *
+ * ## No response at all (objectstack#5968 / objectui#4031)
+ *
+ * The two failure modes above are both *response-shaped* — something came
+ * back and was wrong. A black-holed connection (a dropped SYN, or a peer that
+ * completes the TCP handshake and then never writes a byte) produces neither
+ * `error` nor `end`; the request just sits there forever. `--check` fires 46
+ * of these in series, so one hang stalls the whole command until whatever
+ * wraps it (a CI job timeout, a person hitting Ctrl-C) gives up — with
+ * nothing in the log naming which of the 46 URLs was the one that stuck.
+ *
+ * `req.setTimeout` is armed unconditionally and fires on `timeoutMs` of
+ * inactivity on the request's socket. Node arms that idle timer as soon as a
+ * socket is assigned to the request — which happens before the TCP handshake
+ * resolves — so the same callback covers both a connection that never
+ * completes and one that completes and then goes quiet; there is no distinct
+ * "connecting" vs "connected" case to branch on here. On fire it calls
+ * `req.destroy(error)`, which the existing `req.on('error', reject)` below
+ * already catches (`destroy(error)` re-emits `error` on the request) — so the
+ * timeout reuses the same rejection path as a transport failure, rather than
+ * adding a second one. Deliberately no retry: a black hole does not resolve
+ * itself in seconds, so retrying only doubles the worst-case wait while
+ * every caller's error path already degrades gracefully (`--check` marks the
+ * component, `--update` refuses to write).
  */
-async function fetchUrl(url, { get = https.get } = {}) {
+async function fetchUrl(url, { get = https.get, timeoutMs = 10_000 } = {}) {
   return new Promise((resolve, reject) => {
     const req = get(url, (res) => {
       const status = res.statusCode ?? 0;
@@ -162,6 +186,9 @@ async function fetchUrl(url, { get = https.get } = {}) {
       });
     });
     req.on('error', reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`shadcn-sync: registry request timed out after ${timeoutMs}ms: ${url}`));
+    });
   });
 }
 
@@ -223,8 +250,12 @@ function cacheFileFor(url, cacheDir = CACHE_DIR) {
  * option with no default is absent from this function's INFERRED signature, so
  * passing it from a `.ts` caller is a hard error. Declaring the injection point
  * is the fix; suppressing it at the call site would not be.
+ *
+ * `timeoutMs` passes straight through to `fetchUrl` (see its doc comment for
+ * why a black-holed connection is now bounded) — declared here too so tests
+ * can drive it down to milliseconds without waiting out the real 10s default.
  */
-async function fetchRegistry(url, { allowCache = false, cacheDir = CACHE_DIR, get = https.get } = {}) {
+async function fetchRegistry(url, { allowCache = false, cacheDir = CACHE_DIR, get = https.get, timeoutMs = 10_000 } = {}) {
   const cacheFile = cacheFileFor(url, cacheDir);
 
   if (allowCache) {
@@ -257,7 +288,7 @@ async function fetchRegistry(url, { allowCache = false, cacheDir = CACHE_DIR, ge
 
   let data;
   try {
-    data = await fetchUrl(url, { get });
+    data = await fetchUrl(url, { get, timeoutMs });
   } catch (error) {
     // Counted, then rethrown untouched: the caller decides what a failed fetch
     // means (`--check` reports the component, `--update` refuses to write).


### PR DESCRIPTION
Fixes #4031

## What

`fetchUrl()` in `scripts/shadcn-sync.js` used `https.get` with only `error`/`end` wired up, so a black-holed connection — a dropped SYN, or a peer that completes the TCP handshake and then never writes a byte — hung forever. `--check` fires 46 of these in series, so one hang stalled the whole command, bounded by nothing but the CI job's `timeout-minutes: 20` backstop from #4174.

`req.setTimeout(10_000, () => req.destroy(new Error(...)))` now bounds every request: on fire it destroys the request with an error naming the URL that hung, and the existing `req.on('error', reject)` picks it up — reusing the same rejection path `--check` (marks the component `error`) and `--update` (refuses to write) already had, rather than adding a second one. `timeoutMs` is threaded through `fetchRegistry` too, defaulting to the same 10s, so tests can drive it down without waiting out the real value.

Per the delegated adjudication on the issue thread (2026-08-10 measurements: healthy path ~37ms/request, 10s ≈ 270x headroom, all 30 historical runs complete in 19-49s): **10s per request, no retry** — a black hole doesn't resolve in seconds, so a retry only doubles the worst-case wait while the existing error path already degrades gracefully. The 20-minute job backstop from #4174 is unchanged; this is the real fix it was standing in for.

## Why both a real socket and a double are in the test file

Two network conditions produce the hang — a dropped SYN (connection never completes) and a peer that completes the handshake and then never responds — and both are covered by the *same* `req.setTimeout` callback (Node arms that idle timer as soon as a socket is assigned to the request, before the handshake resolves).

The committed coverage uses a `get` double that mimics a stuck `ClientRequest` (deterministic, exercises the exact `setTimeout`/`destroy(error)`/`error`-listener wiring `fetchUrl` depends on). A **real** raw-`net` hung-socket server was also used and is *not* committed: it reproduced correctly and fast (~40-50ms against a 40ms `timeoutMs`) as a standalone Node script and inside a `worker_threads` Worker, including while this shared dev container had a sibling agent's heavy `pnpm build` pegging multiple cores — but the identical code run through Vitest's `threads` pool under that same load reliably failed to observe the timeout at all (not slow — silent for a 20s `it()` bound, reproducing with `-t` isolating the one test and with `--maxWorkers=1`). That's a Vitest-threads-pool-under-contention interaction with the real socket timer, not a defect in `fetchUrl`, and this repo's own flaky-test discipline (AGENTS.md, "flaky 测试") is explicit that widening a budget to paper over a race is the wrong fix — here even 20s didn't turn a genuine non-event into a passing one. So the real-socket path is verified manually (below) instead of committed.

## Manual end-to-end verification (real CLI, real hang)

Temporarily pointed the `accordion` entry in `packages/components/shadcn-components.json` at a local raw-`net` server that accepts the connection and never responds (reverted before commit — `git status` confirms the manifest is unchanged in this PR):

```
$ time node scripts/shadcn-sync.js --check
✗ accordion   Error fetching from registry: shadcn-sync: registry request timed out after 10000ms: https://127.0.0.1:45231/hang.json
[... other 45 components: real HTTP 403 from the sandbox's egress block, unaffected ...]
exit=0

$ time node scripts/shadcn-sync.js --update accordion
✗ Error updating accordion: shadcn-sync: registry request timed out after 10000ms: https://127.0.0.1:45231/hang.json
```

`md5sum packages/components/src/ui/accordion.tsx` before/after `--update` is identical, and `git status` shows no write — `--update` refuses exactly as before. Both commands: fast-fail after the real 10s default, error text names the exact URL that hung, exit code and error marking unchanged from the existing error path.

## Healthy-path regression check

The sandbox's egress blocker returns `HTTP 403` immediately (not a black hole) for the real `ui.shadcn.com`, so `pnpm shadcn:check`'s 46 requests can't hit the real registry here — but that's itself the useful check: all 46 fail via immediate `403`, total wall time **0.481s**, zero timeouts triggered. The new `req.setTimeout` doesn't interfere with or slow down the existing fast-response error path.

## Tests

`scripts/__tests__/shadcn-sync-fetch-cache.test.ts` — new `describe` block: a `get` double that never invokes its response callback times out at the configured `timeoutMs`, names the URL, and propagates through `fetchRegistry` without writing to the cache; a false-positive guard confirms a normal fast response is unaffected.

```
pnpm exec vitest run scripts/__tests__/shadcn-sync-fetch-cache.test.ts --maxWorkers=2
 Test Files  1 passed (1)
      Tests  26 passed (26)
   Duration  766ms (at 995a6fdad)

pnpm run type-check:scripts   # tsc -p tsconfig.scripts.json — 0 errors
node scripts/check-control-bytes.mjs   # ✅ OK (4238 files scanned)
pnpm run lint:root   # 0 errors, 22 pre-existing warnings, none in changed files
node scripts/check-changeset-presence.mjs   # ✅ no changeset owed (scripts/ isn't a released package)
```

All at `995a6fdad` (`git rev-parse --short HEAD` after the final commit).

## Scope

Only `scripts/shadcn-sync.js` and its test file changed. No changeset: `scripts/` is repo tooling, not part of the `.changeset/config.json` `fixed` release group — `check-changeset-presence.mjs` confirms none is owed. This repo has no `skip-changeset` label, so none is applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_