### PR TITLE
test(data-objectstack): re-point v3-compat's vacuous PaginatedResult block at real ObjectStackAdapter.find()

### DIFF
--- a/.changeset/paginated-result-vacuous-block-4712.md
+++ b/.changeset/paginated-result-vacuous-block-4712.md
@@ -1,0 +1,14 @@
+---
+---
+
+Test-only: `data-objectstack`'s `v3-compat.test.ts` `PaginatedResult API` block asserted
+only on an inline object literal it constructed itself, with no import from `./index` or
+anywhere else — it could not fail in a way that signalled anything about production code
+(objectui#4712). Measured: no interface or export named `PaginatedResult` exists anywhere
+in `packages/`; the real production shape it meant to describe is `QueryResult<T>`
+(`packages/types/src/data.ts`), returned by `ObjectStackAdapter.find()` via the private
+`normalizeQueryResult()`, whose `total`/`hasMore`/`page`/`pageSize` computation had zero
+coverage anywhere else in this package. The block now drives `ObjectStackAdapter.find()`
+through a mocked transport and asserts on its real returned `QueryResult`, including the
+`hasMore` fallback (`records.length === $top`) and the `page` calculation from
+`$skip`/`$top` — both previously unexercised. No published behaviour changes.

--- a/packages/data-objectstack/src/v3-compat.test.ts
+++ b/packages/data-objectstack/src/v3-compat.test.ts
@@ -33,21 +33,97 @@
  *
  * What is left below never depended on any of the five and does not claim a
  * v3 of anything, so it keeps this file rather than moving.
+ *
+ * objectui#4712 — the surviving `PaginatedResult API` block asserted only on
+ * an inline object literal it constructed itself (`const result = {...};
+ * expect(result.total).toBe(10)`), with no import from `./index` or anywhere
+ * else. It could not fail in a way that signals anything about production
+ * code — real syntax, real `expect()` calls, zero coverage. Measured before
+ * fixing: `grep -rn "PaginatedResult"` under `packages/` finds no interface
+ * or export by that name anywhere in this repo; the real production shape it
+ * meant to describe is `QueryResult<T>` (`packages/types/src/data.ts`),
+ * returned by `ObjectStackAdapter.find()` via the private
+ * `normalizeQueryResult()` (`index.ts`) — which had ZERO coverage of its
+ * `total`/`hasMore`/`page`/`pageSize` computation anywhere else in this
+ * package (`queryDataset.test.ts` / `listViews.test.ts` exercise other
+ * fields of the adapter's return shape, never these). The block below now
+ * drives that real method through `ObjectStackAdapter.find()` with a mocked
+ * transport, so a change to the server-envelope parsing or the
+ * page/hasMore fallback logic turns it red.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
 
-describe('PaginatedResult API (records/total/hasMore)', () => {
-  it('supports the records/total/hasMore shape', () => {
-    // Verify the QueryResult type supports records/total/hasMore
-    const result = {
-      data: [{ id: '1' }],
-      total: 10,
-      page: 1,
-      pageSize: 5,
-      hasMore: true,
-    };
+/** An adapter whose data-fetch response is fully controlled by the caller. */
+function makeAdapter(dataResponse: unknown) {
+  const fetchImpl = vi.fn(async (url: any) => {
+    const u = String(url);
+    if (u.includes('/api/v1/discovery')) {
+      return {
+        ok: true, status: 200, statusText: 'OK',
+        json: async () => ({ success: true, data: { version: 'v1', routes: {} } }),
+      } as any;
+    }
+    return { ok: true, status: 200, statusText: 'OK', json: async () => dataResponse } as any;
+  });
+  return new ObjectStackAdapter({
+    baseUrl: 'http://localhost:3000', token: 't', autoReconnect: false, fetch: fetchImpl as any,
+  });
+}
+
+describe('ObjectStackAdapter.find() pagination result (QueryResult: data/total/hasMore)', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('normalizes the server records/total/hasMore envelope into QueryResult', async () => {
+    const adapter = makeAdapter({
+      success: true,
+      data: { object: 'account', records: [{ id: '1' }], total: 10, hasMore: true },
+    });
+
+    const result = await adapter.find('account', { $top: 5 });
+
     expect(result.data).toHaveLength(1);
     expect(result.total).toBe(10);
     expect(result.hasMore).toBe(true);
+    expect(result.pageSize).toBe(5);
+    expect(result.page).toBe(1);
+  });
+
+  it('computes page from $skip/$top', async () => {
+    const adapter = makeAdapter({
+      success: true,
+      data: { object: 'account', records: [{ id: '3' }], total: 30, hasMore: true },
+    });
+
+    const result = await adapter.find('account', { $skip: 20, $top: 10 });
+
+    // normalizeQueryResult: page = floor($skip / $top) + 1
+    expect(result.page).toBe(3);
+    expect(result.pageSize).toBe(10);
+  });
+
+  it('falls back to a page-local hasMore estimate when the server omits it', async () => {
+    const adapter = makeAdapter({
+      success: true,
+      // A full page with no server-reported `hasMore`.
+      data: { object: 'account', records: [{ id: '1' }, { id: '2' }], total: 2 },
+    });
+
+    const result = await adapter.find('account', { $top: 2 });
+
+    // records.length === $top ⇒ treated as "there may be more" — the
+    // fallback normalizeQueryResult uses when the server doesn't say.
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('reports hasMore false for a short (non-full) page with no server hint', async () => {
+    const adapter = makeAdapter({
+      success: true,
+      data: { object: 'account', records: [{ id: '1' }], total: 1 },
+    });
+
+    const result = await adapter.find('account', { $top: 5 });
+
+    expect(result.hasMore).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #4712

## What was wrong

`packages/data-objectstack/src/v3-compat.test.ts`'s `PaginatedResult API` block asserted only on an inline object literal it constructed itself, with no import from `./index` or anywhere else in the package:

```ts
const result = { data: [{ id: '1' }], total: 10, page: 1, pageSize: 5, hasMore: true };
expect(result.data).toHaveLength(1);
expect(result.total).toBe(10);
expect(result.hasMore).toBe(true);
```

This passes unconditionally regardless of what production code does — it is unreachable from any real query path and cannot fail in a way that signals anything about the codebase (dormant/tautological coverage).

## Measurement (route A vs B)

- `grep -rn "PaginatedResult"` under `packages/` finds no interface, type, or export literally named `PaginatedResult` anywhere in this repo (only prose hits in `CHANGELOG.md` referencing an old upstream `@objectstack` v3.0.0 migration note).
- The real production shape the block's comment was gesturing at is `QueryResult` (generic over T), exported from `@object-ui/types` (`packages/types/src/data.ts:109`) with exactly the `data`/`total`/`page`/`pageSize`/`hasMore` fields the literal hand-copied.
- `QueryResult` is returned by `ObjectStackAdapter.find()` (`packages/data-objectstack/src/index.ts:1418`), via the private `normalizeQueryResult()` (`index.ts:2565`), which computes `total` (`total ?? count ?? records.length`), the `hasMore` fallback (prefers the server's `hasMore`, else `records.length === $top`), and `page` (`floor($skip / $top) + 1`).
- That computation had **zero coverage anywhere else in this package** — `queryDataset.test.ts` and `listViews.test.ts` (cited by the issue) exercise other parts of the adapter's return shape but never `total`/`hasMore`/`page`/`pageSize` on `.find()`.

⇒ **Route A**: a real production surface exists to pin, and it was genuinely uncovered, so the block is re-pointed rather than deleted.

## What changed

The block now constructs an `ObjectStackAdapter` with a mocked `fetch` (same pattern as `orderby-serialization.test.ts` / `queryDataset.test.ts` in this package) and drives the **real** `find()` to `normalizeQueryResult()` path:

- normalizes a server `records`/`total`/`hasMore` envelope into the returned `QueryResult` (`data`/`total`/`hasMore`/`pageSize`/`page`)
- computes `page` from `$skip`/`$top`
- falls back to the page-local `hasMore` estimate (`records.length === $top`) when the server omits it
- reports `hasMore: false` for a short (non-full) page with no server hint

## Positive control (route A requires one)

Before pushing, I temporarily hardcoded `hasMore = false` and `page = 1` in `normalizeQueryResult()` as an uncommitted local edit (reverted afterward with `git checkout` against the already-committed branch, pointed at `packages/data-objectstack/src/index.ts` — the fix commit went in first per this repo's reverse-verification discipline), and re-ran the suite:

```
FAIL  packages/data-objectstack/src/v3-compat.test.ts (4 tests | 3 failed)
 × normalizes the server records/total/hasMore envelope into QueryResult
 × computes page from $skip/$top
 × falls back to a page-local hasMore estimate when the server omits it
```

3 of 4 new assertions went red (the 4th — "reports hasMore false for a short page" — stayed green because the mutation coincidentally also produced `hasMore: false`, which is expected and not a gap: that test is there to guard against `hasMore` defaulting to `true`, the opposite direction). Reverting restored all 4 green, confirming the block now actually exercises and can detect drift in production code, unlike the block it replaces.

## Tests

At final commit `820b4d716`:

```
pnpm --filter '@object-ui/data-objectstack^...' build   # deps built (types, core)
pnpm exec vitest run packages/data-objectstack/ --maxWorkers=2
  Test Files  37 passed (37)
       Tests  526 passed (526)

pnpm --filter @object-ui/data-objectstack type-check     # tsc --noEmit — clean
pnpm --filter @object-ui/data-objectstack lint            # 0 errors, 396 pre-existing no-explicit-any warnings (unrelated to this change)

node scripts/check-changeset-presence.mjs   # empty-frontmatter changeset declared
node scripts/check-changeset-no-major.mjs   # pass
node scripts/check-control-bytes.mjs        # pass, 4237 files scanned
```

## Changeset

Test-only change — added `.changeset/paginated-result-vacuous-block-4712.md` with empty frontmatter (declares "releases nothing", the repo's explicit first-class pass for internal-only changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_
