### PR TITLE
fix(i18n): apply the count reservation per direction in the interpolation-parity gate

### DIFF
--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -652,19 +652,30 @@ export const A = (name: string, n: number, idx: number) => {
     expect(parityOf(root)).toEqual(['interp.imageAlt: inert=[wrong] unfilled=[index]']);
   });
 
-  it('subtracts reserved names from BOTH sides, which is the only way `count` works', () => {
-    // `count` is an i18next control option AND the value of a `{{count}}` hole.
-    // Dropping it from the call site's names only would report every counted
-    // string in the repo as unfilled; dropping it from the holes only would
-    // report every `count` passed to a plural key as inert.
+  it('the reservation protects `inert`: passing a control option is never flagged, holed key or not', () => {
+    // `count` is an i18next control option, legitimate to PASS even when the
+    // `en` value shows no visible `{{count}}` hole to receive it. The
+    // reservation drops it from the names judged for `inert` — see the RED
+    // case right below for the direction this must NOT also silence.
     const root = repoWith(
       callSite(
-        "[t('interp.counted', { count: n }), t('interp.counted'), t('interp.bare', { ns: 'x', lng: 'en', defaultValue: 'Update' })]",
+        "[t('interp.counted', { count: n }), t('interp.bare', { ns: 'x', lng: 'en', defaultValue: 'Update' })]",
       ),
     );
     expect(parityOf(root)).toEqual([]);
     expect(RESERVED_OPTION_NAMES.has('count')).toBe(true);
     expect(RESERVED_OPTION_NAMES.has('version')).toBe(false);
+  });
+
+  it('RED: the reservation must NOT also protect `unfilled` — a real {{count}} miss is still reported (objectui#4206)', () => {
+    // Before objectui#4206, the reservation was subtracted from the shared
+    // `holes` set BEFORE either direction was derived, so a `{{count}}` hole
+    // was removed from the comparison entirely and `unfilled` could
+    // structurally never contain `count` — this is objectui#4157's exact
+    // shape: a call site passing no options against an `en` value that reads
+    // `Deleted {{count}} rows`.
+    const root = repoWith(callSite("t('interp.counted')"));
+    expect(parityOf(root)).toEqual(['interp.counted: inert=[] unfilled=[count]']);
   });
 
   it('never judges a plural family, where there is no single value to read holes off', () => {

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -181,10 +181,16 @@
  *        the interpolation data from when it is present, making the top-level
  *        names not interpolation at all. Today the repo has none of these; the
  *        abstention is what stops the first one becoming a false red.
- *      - RESERVED names are removed from BOTH sides before comparing, not just
- *        from the call site's. `count` is the reason: it is an i18next control
- *        option AND the value of a `{{count}}` hole, so subtracting it from one
- *        side only would report every counted string as unfilled.
+ *      - RESERVED names are removed from the call site's own option names ONLY
+ *        when judging **inert**, and kept for **unfilled** (objectui#4206).
+ *        `count` is the reason both directions need a different answer: it is
+ *        an i18next control option AND the value of a `{{count}}` hole, so
+ *        dropping it before judging `inert` keeps a passed `count` from
+ *        reading as an inert argument, while KEEPING it for `unfilled` lets
+ *        the rule tell "passed `count`" apart from "passed nothing" and still
+ *        catch a real `{{count}}` miss (objectui#4157) — dropping it from both
+ *        directions, as the rule did before #4206, made `unfilled`
+ *        structurally unable to ever contain `count`, whether filled or not.
  *
  *    Nested `t()` inside the options object is not a special case here and must
  *    not become one: the arguments of an inner call are not properties of the
@@ -315,8 +321,17 @@ export const PROBE_FLAG_NAMES = /I18N_PROBE_FLAG|__ouiLabelProbe/;
 
 /**
  * i18next option names that CONTROL the lookup rather than fill a hole
- * (objectui#3845). Subtracted from both sides of the interpolation comparison —
- * see the header for why `count` in particular must leave the hole set too.
+ * (objectui#3845). `interpolationOptions()` reports a call site's option names
+ * RAW, this set unfiltered — the filtering happens at the comparison, PER
+ * DIRECTION (objectui#4206), and the two directions want opposite answers:
+ * subtracted from the call site's names when judging `inert` (a reserved name
+ * like `count`, i18next's plural selector, must never itself be called inert),
+ * but left IN when judging `unfilled` (a call site that DOES pass `count` must
+ * still be recognised as having filled a `{{count}}` hole — `count` is also
+ * its own hole's name, and dropping it from both directions, as the rule did
+ * before #4206, made `unfilled` structurally unable to ever contain `count`,
+ * hiding real misses like objectui#4157). See the header (class 4) for the
+ * worked example.
  *
  * `replace` is absent on purpose: it does not merely fail to be interpolation
  * data, it REDIRECTS where the data comes from, so a call site carrying one is
@@ -775,9 +790,14 @@ function inlineDefaultValue(node, source) {
 /**
  * The interpolation option names a call site passes (objectui#3845).
  *
- * `{ readable: true, names }`  — the full name set, reserved names already
- *                                removed. An empty set is a real answer: it says
- *                                this call passes nothing to interpolate.
+ * `{ readable: true, names }`  — the full name set, RESERVED NAMES INCLUDED
+ *                                (objectui#4206 — the caller decides whether to
+ *                                filter, and which direction to filter it for;
+ *                                doing it here would make it impossible to tell
+ *                                "passed `count`" from "passed nothing" once a
+ *                                key doubles as a hole name). An empty set is a
+ *                                real answer: it says this call passes nothing
+ *                                to interpolate.
  * `{ readable: false }`        — the name set is not statically knowable, so the
  *                                rule abstains rather than guessing at it.
  *
@@ -808,7 +828,9 @@ function interpolationOptions(node, source) {
 
   for (const property of object.properties) {
     if (ts.isShorthandPropertyAssignment(property)) {
-      if (!RESERVED_OPTION_NAMES.has(property.name.text)) names.add(property.name.text);
+      // Reserved names are NOT filtered here (objectui#4206) — see the doc
+      // comment above.
+      names.add(property.name.text);
       continue;
     }
     // A spread, a method, an accessor: the name set is open, so do not judge it.
@@ -826,7 +848,8 @@ function interpolationOptions(node, source) {
     // i18next reads interpolation data OUT of `replace` when it is present, so
     // the top-level names stop being the answer to this question entirely.
     if (name === 'replace') return { readable: false };
-    if (RESERVED_OPTION_NAMES.has(name)) continue;
+    // Reserved names are NOT filtered here (objectui#4206) — see the doc
+    // comment above.
     names.add(name);
   }
   return { readable: true, names };
@@ -1089,10 +1112,18 @@ export function analyze(root) {
               counters.opaqueOptions += 1;
             } else {
               const downstream = externallyFilled.get(key) ?? new Set();
-              const holes = new Set(
-                [...holesOf(enValue)].filter((hole) => !RESERVED_OPTION_NAMES.has(hole) && !downstream.has(hole)),
-              );
-              const inert = [...options.names].filter((option) => !holes.has(option)).sort();
+              const holes = new Set([...holesOf(enValue)].filter((hole) => !downstream.has(hole)));
+              // objectui#4206 — the reservation applies PER DIRECTION, not to a
+              // shared set on either side. `count` is legitimate to PASS without
+              // a visible `{{count}}` hole (i18next's plural selector), so
+              // `namesForInert` drops it — a reserved option can never itself be
+              // called inert. It stays IN the raw `options.names` used for
+              // `unfilled`, because that direction needs to know whether `count`
+              // was actually passed: dropping it there too (as before #4206)
+              // made a real `{{count}}` miss (objectui#4157) indistinguishable
+              // from a call site that filled it.
+              const namesForInert = new Set([...options.names].filter((name) => !RESERVED_OPTION_NAMES.has(name)));
+              const inert = [...namesForInert].filter((option) => !holes.has(option)).sort();
               const unfilled = [...holes].filter((hole) => !options.names.has(hole)).sort();
               counters.judgedInterpolation += 1;
               if (inert.length > 0 || unfilled.length > 0) {


### PR DESCRIPTION
Fixes #4206

## What changed

`scripts/check-i18n-call-site-keys.mjs`'s interpolation-parity check (the objectui#3845 gate family) compares what a call site passes against the `{{hole}}` names its `en` value has, in two directions: `inert` (an argument with no hole to receive it) and `unfilled` (a hole with no argument to fill it).

`RESERVED_OPTION_NAMES` (`count`, `ns`, `lng`, …) used to be subtracted from the shared `holes` set before either direction was derived. Since `count` is both an i18next control option and the name of its own `{{count}}` hole, that made a `{{count}}` hole structurally invisible to `unfilled` — the exact blind spot that let objectui#4157 (a call site with no options against an en value reading `…Auto-reschedule {{count}} affected task(s)?`) pass the gate green. The narrower fix is scoped to this class only; objectui#4135's `EXTERNALLY_INTERPOLATED_HOLES` registry and any `.replace()`-chain reading stay out of scope here, per the 2026-08-11 triage promotion on this card.

The change applies the reservation per direction instead of to one shared set:

- `interpolationOptions()` now reports a call site's option names **raw** (reserved names included) — filtering them there made it impossible to tell "passed `count`" from "passed nothing" once a name doubles as a hole name.
- The comparison drops reserved names from the option-name set only when judging `inert` (a reserved option must never itself read as inert).
- It keeps them when judging `unfilled`, so the rule can tell whether `count` was actually passed and still catches a real `{{count}}` miss.

Plural families (`t(k, { count })` resolving through `_one`/`_other`) are unaffected: they have no single `en` value to compare against, so `enValue === undefined` keeps them out of this comparison entirely, upstream of the change.

## Testing

At `5da80f105`:

- `pnpm exec vitest run scripts/__tests__/check-i18n-call-site-keys.test.ts --maxWorkers=2` — 65/65 passed, including two new direction-specific cases: a call site passing `count` against a holed key stays silent (`inert` protection), and a call site passing nothing against the same key now reports `unfilled=[count]` (the objectui#4157 shape, pinned red).
- `node scripts/check-i18n-call-site-keys.mjs` (whole-repo gate) — **0** interpolation-parity findings across 2383 judged call sites:
  > Every in-scope call-site key resolves against the en pack (2932 keys), every literal inline defaultValue matches the value the pack serves, every call site passes exactly the arguments that value has holes for, and no call site carries a literal fallback beside itself.
- Positive control: temporarily stripped `{ count: pendingConflict.length }` from `packages/plugin-gantt/src/GanttView.tsx:5058` (uncommitted, reverted after) — the gate went red: `packages/plugin-gantt/src/GanttView.tsx:5058:16 [interpolation-parity] gantt.conflict.body … unfilled (hole, no argument): count`. Reverted; the gate returned to 0 findings.
- `pnpm exec eslint scripts/__tests__/check-i18n-call-site-keys.test.ts scripts/check-i18n-call-site-keys.mjs` — clean.
- `pnpm run type-check:scripts` (`tsc -p tsconfig.scripts.json`) — clean.
- `node scripts/check-control-bytes.mjs` — OK.
- `node scripts/check-changeset-presence.mjs` — no changeset owed (scripts-only change, not under a released package's `src/`).

## Scope

Deliberately narrow, per the 2026-08-11 triage promotion: the `count` reservation direction only. Not extended to read `.replace()` chains — that is objectui#4135's territory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_