### PR TITLE
fix(plugin-dashboard): bind chart-bucket drill assertion to content, not a cumulative render count

### DIFF
--- a/.changeset/dataset-widget-chart-bucket-drill-render-count.md
+++ b/.changeset/dataset-widget-chart-bucket-drill-render-count.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only: fixed a flaky overshoot in `plugin-dashboard`'s DatasetWidget chart-bucket
+drill test, where `waitFor` pinned a cumulative drill-filter render count that a late,
+unrelated dimension-metadata re-render could push past 1 with no way to recover
+(objectui#4718, same defect class as objectui#4706 / PR #4708). The assertion now waits
+for the drill to have opened at least once and keeps its content check (which records
+the drawer filtered on) as the substantive assertion. No published behaviour changes.

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartBucketIdentity.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartBucketIdentity.test.tsx
@@ -148,7 +148,17 @@ describe('DatasetWidget — a bucket drills to ITS OWN rows (objectui#4508)', ()
     expect(chartRows().map((r) => r.owner_name)).toEqual([NULL_CATEGORY_LABEL, NULL_CATEGORY_LABEL]);
 
     clickBar(0);
-    await waitFor(() => expect(drillFilters.length).toBe(1));
+    // Bound to the drill having opened AT LEAST once (objectui#4706/#4718), not
+    // to an exact cumulative render count: `drillFilters` only ever grows, and
+    // a late, unrelated `setMeta` from the dimension-metadata fetch (issued by
+    // `useDatasetDimensionMeta`, resolving independently of the click) can land
+    // a SECOND identical render after this one click — an overshoot `waitFor`
+    // can never recover from once it happens, since the array never shrinks.
+    // The case is about WHICH records the drawer filters on, not how many
+    // times React chose to render it, so `lastFilter()` — the content check
+    // below — is what carries the assertion; the count only needs to confirm
+    // the drawer opened at all.
+    await waitFor(() => expect(drillFilters.length).toBeGreaterThan(0));
     expect(lastFilter()).toEqual({ owner_id: 'user-literal' });
 
     clickBar(1);


### PR DESCRIPTION
Fixes #4718

## What was wrong

`DatasetWidget.chartBucketIdentity.test.tsx` pinned `drillFilters.length` to exactly `1`
after a single bar click. `drillFilters` is a recording array of the mocked
`DrillDownDrawer`'s render props — it only ever grows. `useDatasetDimensionMeta` issues
its own dimension-metadata fetch independently of the click; when that fetch's `setMeta`
lands its React commit strictly AFTER the click's own commit (a real possibility under a
saturated event loop, since the two updates are only incidentally ordered),
`DrillDownDrawer` renders a second time with the SAME filter, and `drillFilters.length`
overshoots to `2`. Once it overshoots, `waitFor` can never recover — nothing shrinks the
array.

This is the same defect class PR #4708 fixed in `drillTitleLabel.test.tsx` for card
objectui#4706, and card #4718 reports it observed on a shard 2 red against an unrelated
PR (data-objectstack test-only change), same causality argument as the earlier sibling.

## The fix

The one site (`:151`, the issue's named site) now waits for the drill to have opened AT
LEAST once (`toBeGreaterThan(0)`) instead of pinning the exact cumulative count. The
content assertion immediately after (`lastFilter()`) is unchanged and remains the
substantive check — the case is about which records the drawer filters on, not how many
times React chose to render it. A drawer that never opens still times out exactly as
before; only the overshoot-vulnerable exact-count pin is relaxed.

## Family-wide sweep (`packages/plugin-dashboard/src/__tests__/`, all files)

Per the card's direction, every `waitFor(() => expect(recordingArray.length).toBe(N))`-
shaped site in the directory was surveyed, not just the two files already known. Grepped
for `.length).toBe(`, `toHaveLength(`, and every `vi.mock('../DrillDownDrawer', …)` /
`.push(` usage across the whole directory.

**Relaxed (this PR):**
- `DatasetWidget.chartBucketIdentity.test.tsx:151` — `drillFilters.length).toBe(1)` →
  `toBeGreaterThan(0)`. Same overshoot mechanism as objectui#4706: `drillFilters` is a
  push-based recording array (mocked `DrillDownDrawer`), and this file's widget uses
  `useDatasetDimensionMeta`, which is the only hook in this package whose independently-
  resolving fetch can land a late, unrelated re-render.

**Already relaxed (pre-existing, untouched by this PR):**
- `DatasetWidget.nullCategoryI18n.test.tsx:190,215` — `drillFilters.length` already
  `toBeGreaterThan(0)`.
- `DatasetWidget.optionLabelI18n.test.tsx:302` — same, already relaxed.
- `DatasetWidget.localSelectI18n.test.tsx:342` — same, already relaxed.

**Kept exact-count, with a stated causal reason (untouched):**
- `DatasetWidget.chartBucketIdentity.test.tsx:145,173,199,218,243` —
  `chartRows().length).toBe(2)`. `chartRows()` reads `capturedChartProps`, which the
  mocked chart component OVERWRITES (`capturedChartProps = props`) on every render, not
  pushes. It is a snapshot of the latest render, not a cumulative recording — a late,
  unrelated re-render re-assigns the same reference and cannot grow the array beyond the
  actual row count the chart was given. No overshoot is structurally possible.
- `DatasetWidget.drillTitleLabel.test.tsx:172,218,244,270,314` — `chartSeries()`/
  `chartData()`, same `capturedChartProps`-snapshot idiom as above. Also
  `DatasetWidget.nullCategoryI18n.test.tsx:158,169,202,227,236` (`categories()`, same
  idiom). All snapshot reads, not recording arrays — safe to keep exact.
- `DatasetWidget.test.tsx:93` — `screen.getAllByText('100.0%').length).toBe(2)`. A live
  testing-library DOM query re-evaluated by `waitFor`, not a recording array — cannot
  accumulate past the actual DOM's current match count.
- `DatasetWidget.test.tsx:794`, `DatasetWidget.dottedDimensionTable.test.tsx:352`,
  `DatasetWidget.compareTo.test.tsx:460`, `DatasetWidget.localSelectI18n.test.tsx:375` —
  `blobs`/`calls` recording arrays from a stubbed `URL.createObjectURL`, but each is
  checked SYNCHRONOUSLY immediately after a synchronous `fireEvent.click`, never inside a
  `waitFor` polling loop — there is no repeated re-evaluation window in which a
  transient/overshot state could be caught, so this idiom's specific vulnerability (a
  polling assertion that can observe a later, larger value) does not apply.
- `PivotTable.drill.test.tsx:32,38` — `queryAllByRole('button').length).toBe(0)`, live DOM
  queries, synchronous (no `waitFor`), and `PivotTable` takes its data as a prop with no
  internal async fetch (no `useDatasetDimensionMeta` usage) — no race exists to overshoot.
- `DatasetWidget.queryOptions.test.tsx`, `DashboardFilterBar.options.test.tsx`,
  `DashboardFilterBar.optionsFromRawValue.test.tsx`, `DashboardRenderer.headerActions.
  test.tsx`, `ObjectMetricWidget.compareTo.test.tsx` — various
  `waitFor(() => expect(mock).toHaveBeenCalledTimes(N))` sites. Different defect class:
  these count calls to the widget's OWN primary data-fetch mock (`queryDataset`/
  `aggregate`/`find`/`onWidgetClick` handler), driven deterministically by the test's own
  actions and effect-dependency changes, not by an incidental re-render from an unrelated
  hook. None of the components under test in these files use `useDatasetDimensionMeta`
  (confirmed: `grep -rl useDatasetDimensionMeta packages/plugin-dashboard/src/*.tsx`
  returns only `DatasetWidget.tsx`), so the specific race this card is about cannot reach
  these counts.

No third file needed the treatment — the two files the card flagged as "possibly a third"
turned out to already carry the relaxed form.

## Verification

**Deterministic reproduction (pre-fix, red).** Temporarily gated `chartBucketIdentity.
test.tsx`'s meta-fetch mock behind a manually-releasable promise, wrapped the bar click in
its own `act()` so its commit lands alone, then released the gate and flushed inside a
second `act()` — forcing the click's commit and the metadata commit into two separate
React passes (same technique as PR #4708's body). With the OLD assertion, this reproduced
the exact CI failure text: `AssertionError: expected 2 to be 1`, with `drillFilters.length`
observed at `2` after the forced late commit.

**Fix re-verified under the same forced race.** With the fix applied and the forced
overshoot still active, the test passes.

**Positive control (assertion bite-check).** With the fix in place, temporarily forced
`handleChartDrill`'s `bucketId: ev?.categoryId` to `bucketId: undefined` in
`DatasetWidget.tsx` (simulating the identity carrying nothing, i.e. the pre-objectui#4508
behavior). The touched test's second click correctly went red on the wrong records
(`{ owner_id: 'user-literal' }` instead of the expected `{ owner_id: 'user-absent' }` —
the exact defect objectui#4508 fixed), while the three BOUNDARY cases in the file stayed
green. (Note, for completeness: the file's other collision case, "an empty-string group
drills to itself," stayed green under this particular override — that collision is
evidently guarded by something beyond the `bucketId` parameter alone, so this override
doesn't reach it; it wasn't the site this PR touches.) Confirms the relaxed count
assertion does not mask a real regression of the underlying drill-identity feature — the
content assertion right after it still carries the real check.

All temporary repro/gate/positive-control changes were reverted before the commit in this
PR (verified byte-identical to `origin/main` before re-applying only the real fix) —
`git diff` against `origin/main` is the fix alone (test file + changeset).

## Gates run (final HEAD `00d868d5e`)

- `pnpm --filter '@object-ui/plugin-dashboard' lint` — 0 errors (334 pre-existing
  `any`/fast-refresh warnings, none introduced by this change)
- `pnpm --filter '@object-ui/plugin-dashboard' type-check` — clean
- `pnpm exec vitest run packages/plugin-dashboard/` — **58 files / 462 tests passed**
- `node scripts/check-control-bytes.mjs` — OK
- `node scripts/check-changeset-presence.mjs` — OK (empty-frontmatter changeset declared)
- `node scripts/check-changeset-fixed.mjs` / `check-changeset-no-major.mjs` — OK

`scripts/pm/dispatch-gates.mjs` does not exist in this repo; the gate set above is the one
the dispatch prompt named, matching PR #4708's own gate list for the same class of change.

## Changeset

Test-only change → empty-frontmatter changeset
(`.changeset/dataset-widget-chart-bucket-drill-render-count.md`). No published behaviour
changes.

## Not in scope

Card #4717 (the data-objectstack PR whose shard-2 red surfaced this) and card #4508 (the
chart-bucket-identity feature this file pins) are unrelated to this change beyond being
named for context above; neither is addressed or closed by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_