### PR TITLE
fix(components): retire AccordionItem.icon, honor item-level disabled

### DIFF
--- a/.changeset/settle-accordion-item-keys.md
+++ b/.changeset/settle-accordion-item-keys.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+---
+
+Settle the two declared-but-unread keys on `AccordionItem`: retire `icon`, wire
+`disabled` (objectui#4652).
+
+The same defect as objectui#4632 (PR #4651), one interface up in the same file.
+`AccordionItem` declared `disabled?: boolean` and `icon?: string` while the
+`accordion` renderer read neither — it mapped items to `value`/`title`/`content`
+and dropped the rest. Nothing went red: an author who declared either key got a
+correctly rendered accordion with the key silently ignored.
+
+The two keys are settled in opposite directions, by measurement rather than by
+symmetry. A full corpus sweep (schema catalog, docs, example apps, and this
+repo's `objectstack` sibling checkout) found **zero** sites authoring either key
+on an `AccordionItem`:
+
+- **`icon` is retired** from the TypeScript interface and from the
+  `AccordionItemSchema` Zod mirror. It had zero measured pull anywhere in the
+  corpus and no established convention to lean on, so under this platform's
+  declared=enforced doctrine it is removed rather than speculatively
+  implemented.
+- **`disabled` is honored**, despite also having zero catalog pull today.
+  Item-level `disabled` is already established live convention in this
+  codebase — `tabs`, `select`, `dropdown-menu`, `menubar`, `context-menu` and
+  (objectui#4632) `toggle-group` all forward it, and `accordion` was the next
+  outlier. The underlying Radix accordion item supports `disabled` natively, so
+  the renderer forwarding one prop is the whole change; the synced
+  `ui/accordion.tsx` primitive is untouched. The schema catalog's
+  `basic-accordion` example now demonstrates a disabled item.
+
+**Breaking for TypeScript authors of `icon` only** (marked `minor` per this
+repo's version-alignment rule, which reserves `major` for following
+`@objectstack` across a major — see AGENTS.md's 版本号策略 and the identical
+classification PR #4651 used for `ToggleGroupItem.icon`). Runtime behaviour of
+an authored `icon` is unchanged — it rendered nothing before and renders
+nothing now; what changes is that the contract no longer claims otherwise, so
+the mistake surfaces at authoring time. Authored `disabled` changes from
+silently ignored to actually disabling that one item (and blocking its
+expand/collapse).

--- a/content/docs/components/disclosure/accordion.mdx
+++ b/content/docs/components/disclosure/accordion.mdx
@@ -5,6 +5,9 @@ description: "Expandable content sections"
 
 ## Examples
 
+The second item sets `disabled: true`, which the renderer forwards to that item
+only — the rest of the accordion stays interactive.
+
   <SchemaExample id="components-disclosure-accordion/basic-accordion" />
 
 ## Schema

--- a/examples/schema-catalog/src/schemas/components-disclosure-accordion/basic-accordion.json
+++ b/examples/schema-catalog/src/schemas/components-disclosure-accordion/basic-accordion.json
@@ -7,7 +7,8 @@
     },
     {
       "title": "Section 2",
-      "content": "Content for section 2"
+      "content": "Content for section 2",
+      "disabled": true
     },
     {
       "title": "Section 3",

--- a/packages/components/src/__tests__/accordion-item-disabled.test.tsx
+++ b/packages/components/src/__tests__/accordion-item-disabled.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `accordion` renderer honors item-level `disabled` (objectui#4652).
+ *
+ * The same defect as objectui#4632 (PR #4651), one interface up in the same
+ * file. `AccordionItem` declared `disabled?` and `icon?` while this renderer
+ * read NEITHER — it mapped items to `value`/`title`/`content` only. The
+ * finding settled the two keys in opposite directions: `icon` is retired
+ * (zero measured pull anywhere in this repo, including the `objectstack`
+ * sibling checkout), `disabled` is wired despite also having zero catalog
+ * pull today, because item-level `disabled` is already established live
+ * convention across `tabs`, `select`, `dropdown-menu`, `menubar`,
+ * `context-menu` and (objectui#4632) `toggle-group`, and the underlying
+ * Radix item supports it natively.
+ *
+ * That native support is why this needed no edit to `src/ui/accordion.tsx`:
+ * `AccordionItem` there spreads `...props` onto `AccordionPrimitive.Item`,
+ * whose `disabled` reaches the trigger's real `<button disabled>` through
+ * `@radix-ui/react-collapsible`'s `CollapsibleTrigger` — so the renderer
+ * forwarding one prop is the whole fix. `ui/**` is a synced no-touch zone
+ * (AGENTS.md #7) and a fix that required editing it would have been the
+ * wrong shape.
+ *
+ * The declaration half — `icon` gone from the interface and the Zod mirror,
+ * `disabled` kept — is pinned in
+ * `packages/types/src/__tests__/accordion-item-authorable-keys.test.ts`.
+ *
+ * Both the static `disabled` attribute AND the click-driven expand behavior
+ * are asserted here: a disabled trigger carrying `disabled` in the DOM but
+ * still expanding on click would be a broken forward (Radix's own attribute,
+ * not this renderer's), and asserting only the attribute would miss that.
+ * Positive control included throughout: an item that does NOT declare
+ * `disabled` must remain clickable/expandable, so the assertions mean
+ * "forwarded per item" rather than "the whole accordion is disabled".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import type { AccordionSchema } from '@object-ui/types';
+// Module scope, not a hook: this import IS the registration, and an unbounded
+// module load must never be billed to a bounded window (AGENTS.md §测试纪律).
+import '../renderers';
+
+function renderAccordion(schema: AccordionSchema) {
+  const Component = ComponentRegistry.get('accordion');
+  if (!Component) {
+    throw new Error('Component "accordion" is not registered');
+  }
+  return render(<Component schema={schema} />);
+}
+
+const schema = (): AccordionSchema => ({
+  type: 'accordion',
+  items: [
+    { value: 'one', title: 'Section 1', content: 'Content for section 1' },
+    { value: 'two', title: 'Section 2', content: 'Content for section 2', disabled: true },
+    { value: 'three', title: 'Section 3', content: 'Content for section 3' },
+  ],
+});
+
+describe('accordion renderer forwards item-level `disabled` (objectui#4652)', () => {
+  it('disables exactly the item that declares it', () => {
+    renderAccordion(schema());
+
+    expect(screen.getByRole('button', { name: 'Section 2' })).toBeDisabled();
+    // The reverse direction, which is what makes the assertion above mean
+    // "forwarded per item" rather than "the whole accordion is disabled".
+    expect(screen.getByRole('button', { name: 'Section 1' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Section 3' })).not.toBeDisabled();
+  });
+
+  it('does not expand the disabled item on click', () => {
+    renderAccordion(schema());
+
+    const disabledTrigger = screen.getByRole('button', { name: 'Section 2' });
+    expect(disabledTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(disabledTrigger);
+
+    expect(disabledTrigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('positive control: expands a non-disabled item on click', () => {
+    renderAccordion(schema());
+
+    const enabledTrigger = screen.getByRole('button', { name: 'Section 1' });
+    expect(enabledTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(enabledTrigger);
+
+    expect(enabledTrigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('leaves every item enabled and expandable when none declares `disabled`', () => {
+    renderAccordion({
+      type: 'accordion',
+      items: [
+        { value: 'one', title: 'Section 1', content: 'Content for section 1' },
+        { value: 'two', title: 'Section 2', content: 'Content for section 2' },
+      ],
+    });
+
+    const trigger = screen.getByRole('button', { name: 'Section 1' });
+    expect(trigger).not.toBeDisabled();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('still renders each item title', () => {
+    renderAccordion(schema());
+
+    expect(screen.getByText('Section 1')).toBeInTheDocument();
+    expect(screen.getByText('Section 2')).toBeInTheDocument();
+    expect(screen.getByText('Section 3')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/disclosure/accordion.tsx
+++ b/packages/components/src/renderers/disclosure/accordion.tsx
@@ -20,7 +20,7 @@ ComponentRegistry.register('accordion',
   ({ schema, className, ...props }: { schema: AccordionSchema; className?: string; [key: string]: any }) => (
     <Accordion type={schema.accordionType || 'single'} collapsible={schema.collapsible} className={className} {...props}>
       {schema.items?.map((item, index: number) => (
-        <AccordionItem key={item.value || index} value={item.value || `item-${index}`}>
+        <AccordionItem key={item.value || index} value={item.value || `item-${index}`} disabled={item.disabled}>
           <AccordionTrigger>{item.title}</AccordionTrigger>
           <AccordionContent>
             {renderChildren(item.content)}

--- a/packages/types/src/__tests__/accordion-item-authorable-keys.test.ts
+++ b/packages/types/src/__tests__/accordion-item-authorable-keys.test.ts
@@ -1,0 +1,145 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `AccordionItem` declares only keys a renderer actually reads (objectui#4652).
+ *
+ * The same defect as objectui#4632 (PR #4651), one interface up in the same
+ * file. The interface declared `disabled?: boolean` and `icon?: string` while
+ * `packages/components/src/renderers/disclosure/accordion.tsx` read NEITHER —
+ * it mapped items to `value`/`title`/`content` only. An author who declared
+ * either key got a correctly rendered accordion with the key silently
+ * dropped, and nothing went red.
+ *
+ * Corpus sweep (schema catalog, docs, example apps, this repo's `objectstack`
+ * sibling checkout) found **zero** sites authoring either key on an
+ * `AccordionItem`. The two keys are still settled in opposite directions,
+ * because the deciding signal is measured pull, not catalog authorship count
+ * alone:
+ *
+ *   `icon` — RETIRED. Zero pull and no established convention to lean on
+ *   (unlike `disabled` below), so under the platform's declared=enforced
+ *   doctrine it is removed rather than speculatively implemented.
+ *
+ *   `disabled` — WIRED, despite zero catalog pull. Item-level `disabled` is
+ *   an established live convention in this codebase — `tabs`, `select`,
+ *   `dropdown-menu`, `menubar`, `context-menu` and (as of #4632) `toggle-group`
+ *   all forward it. `accordion` was the next outlier, and Radix's
+ *   `Accordion.Item` supports `disabled` natively (it forwards a real `disabled`
+ *   attribute onto the trigger `<button>`, per `@radix-ui/react-collapsible`'s
+ *   `CollapsibleTrigger`), so honoring it needed no new mechanism and no edit
+ *   to the synced `ui/accordion.tsx` primitive (AGENTS.md #7).
+ *
+ * This file pins BOTH directions on the declaration surfaces — the TypeScript
+ * interface and the Zod mirror, two separate hand-maintained declarations of
+ * one contract. The behavior half — that a disabled item actually renders
+ * disabled and cannot be expanded — is pinned in
+ * `packages/components/src/__tests__/accordion-item-disabled.test.tsx`.
+ *
+ * The `@ts-expect-error` below is REAL enforcement here, not decoration: this
+ * package type-checks its tests through `tsconfig.test.json` (`type-check` =
+ * `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`),
+ * so re-adding `icon?` to the interface fails the build on the unused directive.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { AccordionItem } from '../disclosure';
+import { AccordionItemSchema } from '../zod/disclosure.zod';
+
+describe('AccordionItem: `icon` is retired from the authoring surface (objectui#4652)', () => {
+  it('does not declare `icon` on the TypeScript interface', () => {
+    const item: AccordionItem = {
+      value: 'section-1',
+      title: 'Section 1',
+      content: 'Content for section 1',
+      // @ts-expect-error `icon` is retired — zero measured pull and no
+      // renderer ever read it, and excess-property checking on this literal
+      // is what makes the retirement reach authors writing TypeScript.
+      icon: 'chevron',
+    };
+
+    // Runtime shape is unaffected by the type-level assertion above; the
+    // assertion that matters is that the file compiles only while `icon` is
+    // absent from the interface.
+    expect(item.value).toBe('section-1');
+  });
+
+  it('drops `icon` when parsing through the Zod mirror', () => {
+    // `z.object` is non-strict, so an authored `icon` is not an error — it is
+    // simply not part of the declared surface any more, and parse output is
+    // the observable statement of what that surface contains.
+    const parsed = AccordionItemSchema.parse({
+      value: 'section-1',
+      title: 'Section 1',
+      content: 'Content for section 1',
+      icon: 'chevron',
+    });
+
+    expect(parsed).toEqual({
+      value: 'section-1',
+      title: 'Section 1',
+      content: 'Content for section 1',
+    });
+    expect('icon' in parsed).toBe(false);
+  });
+
+  it('keeps `icon` out of the Zod schema shape', () => {
+    expect(Object.keys(AccordionItemSchema.shape).sort()).toEqual([
+      'content',
+      'disabled',
+      'title',
+      'value',
+    ]);
+  });
+});
+
+describe('AccordionItem: `disabled` stays declared, now that it is honored (objectui#4652)', () => {
+  it('declares `disabled` on the TypeScript interface as an optional boolean', () => {
+    const item: AccordionItem = {
+      value: 'section-1',
+      title: 'Section 1',
+      content: 'Content for section 1',
+      disabled: true,
+    };
+    expect(item.disabled).toBe(true);
+
+    const withoutDisabled: AccordionItem = {
+      value: 'section-2',
+      title: 'Section 2',
+      content: 'Content for section 2',
+    };
+    expect(withoutDisabled.disabled).toBeUndefined();
+  });
+
+  it('preserves `disabled` through the Zod mirror', () => {
+    expect(
+      AccordionItemSchema.parse({
+        value: 'section-1',
+        title: 'Section 1',
+        content: 'Content for section 1',
+        disabled: true,
+      }),
+    ).toEqual({
+      value: 'section-1',
+      title: 'Section 1',
+      content: 'Content for section 1',
+      disabled: true,
+    });
+  });
+
+  it('rejects a non-boolean `disabled`', () => {
+    expect(
+      AccordionItemSchema.safeParse({
+        value: 'section-1',
+        title: 'Section 1',
+        content: 'Content for section 1',
+        disabled: 'yes',
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/types/src/disclosure.ts
+++ b/packages/types/src/disclosure.ts
@@ -35,12 +35,12 @@ export interface AccordionItem {
   content: SchemaNode | SchemaNode[];
   /**
    * Whether item is disabled
+   *
+   * Forwarded to the underlying accordion item by the `accordion` renderer,
+   * matching the item-level `disabled` that `tabs`, `select`, `dropdown-menu`,
+   * `menubar`, `context-menu` and `toggle-group` already honor.
    */
   disabled?: boolean;
-  /**
-   * Item icon
-   */
-  icon?: string;
 }
 
 /**

--- a/packages/types/src/zod/disclosure.zod.ts
+++ b/packages/types/src/zod/disclosure.zod.ts
@@ -27,7 +27,6 @@ export const AccordionItemSchema = z.object({
   title: z.string().describe('Accordion item title'),
   content: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).describe('Accordion item content'),
   disabled: z.boolean().optional().describe('Whether item is disabled'),
-  icon: z.string().optional().describe('Item icon'),
 });
 
 /**


### PR DESCRIPTION
Fixes #4652

`AccordionItem` declared `disabled?: boolean` and `icon?: string` while the `accordion`
renderer read **neither** — it mapped items to `value`/`title`/`content` only. Premise
re-verified against `origin/main` (`fec06835e`): both keys declared at
`packages/types/src/disclosure.ts:39,43` and its Zod mirror
`packages/types/src/zod/disclosure.zod.ts`; neither read at
`packages/components/src/renderers/disclosure/accordion.tsx`. Radix's underlying
`AccordionPrimitive.Item` (spread via `packages/components/src/ui/accordion.tsx`) supports
`disabled` natively. The mechanism hypothesis held in full — same shape as objectui#4632
(PR #4651), one interface up in the same file.

## The measurement (per the inherited #4632/#4651 framing)

Enforce-or-remove, decided per key by measured pull, not by symmetry. Full corpus sweep:
schema catalog (`examples/schema-catalog`), docs (`content/docs`), example/application
code (`apps/console`, `apps/site`), and this repo's `objectstack` sibling checkout.

| key | sites authoring it | code reading it | direction |
|---|---|---|---|
| `icon` | **0** | none | **retire** |
| `disabled` | **0** | none *in accordion* — but honored by **6 sibling components** | **wire** |

- **`icon` — retired.** Zero measured pull anywhere in the sweep, including the
  `objectstack` sibling checkout (no `AccordionItem`/`page:accordion` icon authoring
  found there at all — `page:accordion` items are a separate, unrelated interface, see
  Notes). Under declared=enforced it is removed rather than speculatively implemented.
- **`disabled` — wired**, despite also having zero direct catalog pull today. Item-level
  `disabled` is established live convention in this codebase: `tabs`, `select`,
  `dropdown-menu`, `menubar`, `context-menu` and (objectui#4632) `toggle-group` all
  forward it. `accordion` was the next outlier, and the underlying Radix item supports
  `disabled` natively, so forwarding one prop is the whole change — the synced no-touch
  `ui/accordion.tsx` (AGENTS.md #7) is **untouched**.

## Surfaces changed

- `packages/types/src/disclosure.ts` — `icon` removed from `AccordionItem`; `disabled`
  kept and documented as forwarded.
- `packages/types/src/zod/disclosure.zod.ts` — `AccordionItemSchema` declared `icon` too;
  removed in the same commit so the retirement closes on both hand-maintained
  declarations together.
- `packages/components/src/renderers/disclosure/accordion.tsx` — forwards `disabled` per
  item to the `AccordionItem` primitive.
- `examples/schema-catalog/.../basic-accordion.json` — one item now demonstrates
  `disabled: true`, so the corpus teaches a key that actually works. Contents-only edit,
  no index regeneration (`examples/schema-catalog/src/index.ts` imports the file by path;
  per #4637's own model).
- `content/docs/components/disclosure/accordion.mdx` — one line of prose above the
  `SchemaExample` describing the new disabled-item demo. The page's "Schema" code block
  underneath is **pre-existing, unrelated drift** (missing `value`, wrong root field names
  `defaultOpen`/`multiple` vs. the real `accordionType`/`defaultValue`/etc.) — left alone
  and filed separately as #4722, since fixing it is a different defect class than this
  card's declared-but-unenforced-key settlement.

## Tests, all at `015360404`

Full verification ran **after** the final commit, tree clean.

- New: `packages/types/src/__tests__/accordion-item-authorable-keys.test.ts` (declaration
  surfaces — `icon` retired via `@ts-expect-error` + Zod-drop + Zod-shape pins; `disabled`
  stays declared, preserved through the Zod mirror, rejects non-boolean).
- New: `packages/components/src/__tests__/accordion-item-disabled.test.tsx` (behavior — the
  disabled item's trigger carries a real `disabled` attribute and does **not** expand on
  click; positive control: a non-disabled item **does** expand on click; leaves every item
  enabled when none declares `disabled`; still renders each title).
- `pnpm exec vitest run --maxWorkers=2 packages/types/ packages/components/
  examples/schema-catalog/` — **173 files / 3114 tests passed**.
- `pnpm --filter @object-ui/types type-check` and `pnpm --filter @object-ui/components
  type-check` — clean (dependency closure built first via
  `pnpm --filter '@object-ui/components^...' build`, a fresh worktree fails type-check on
  unresolved workspace deps otherwise).
- `check-changeset-presence` / `check-changeset-no-major` / `check-control-bytes` /
  `check-doc-links` — all green. ESLint on the changed files: 0 errors (1 pre-existing
  `no-explicit-any` warning on an untouched line, confirmed present on `origin/main`).

**Reverse verification, direction predicted before each run:**

1. Ablate the renderer's `disabled` forward (drop `disabled={item.disabled}`) ⇒ predicted
   the two behavior pins asserting the forward go red, the rest of the file stays green.
   Observed exactly that: `disables exactly the item that declares it` and `does not expand
   the disabled item on click` failed (dump showed `aria-expanded="true"` and no `disabled`
   attribute on the trigger button); the positive-control test, the no-`disabled`-declared
   test, and the title-render test stayed green (2 failed / 3 passed).
2. Cross-package: authored `icon` in a `@object-ui/components`-side scratch test against
   the **rebuilt** `@object-ui/types` d.ts ⇒ `error TS2353: Object literal may only specify
   known properties, and 'icon' does not exist in type 'AccordionItem'`. Observed exactly
   that; the retirement reaches consumers, and the verdict came from the rebuilt
   declaration, not a cached one. Scratch file removed afterward, type-check re-confirmed
   green.

Each ablation was restored with `git checkout` from the committed state and confirmed
byte-clean (`git status --porcelain` empty).

## Notes

- Changeset marks `minor` for both packages, matching PR #4651's classification for the
  identical defect class: breaking for TypeScript authors of `icon` (excess-property
  checking), per this repo's version-alignment rule (AGENTS.md 版本号策略) reserving `major`
  for following `@objectstack` across a major. Runtime behavior of an authored `icon` is
  unchanged — it rendered nothing before and renders nothing now.
- Out of scope, filed separately (unassigned, `finding` label):
  - #4721 — `PageAccordionItem.icon` (a **different** component, `page:accordion` in
    `packages/components/src/renderers/layout/containers.tsx`, not `AccordionItem`/
    `ui:accordion`) is declared and never read — same defect shape, different file/claim.
  - #4722 — `content/docs/components/disclosure/accordion.mdx`'s schema code block is
    stale against the real `AccordionSchema`/`AccordionItem` interface (predates this
    card, different defect class).
- #4632 / PR #4651 remain the origin ruling this card inherited; #4631 is the broader
  three-surface reconciliation instrument this is one more measured instance of, not a
  blocker for either.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_
