### PR TITLE
fix(permissions): preserve absent-vs-empty systemPermissions through the capability gate

### DIFF
--- a/.changeset/permissions-capabilities-reported.md
+++ b/.changeset/permissions-capabilities-reported.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/permissions': patch
+'@object-ui/app-shell': patch
+---
+
+`MePermissionsProvider` distinguishes an unreported `systemPermissions` (a
+backend predating ADR-0066, which omits the field from `/me/permissions`
+entirely) from a genuinely empty one (a real answer: "this session holds zero
+system capabilities").
+
+Both used to collapse into the same `[]`, so `hasCapabilities` consumers could
+not gate strictly on a real empty answer without also stripping
+capability-gated UI from every user on a non-reporting deployment
+(objectstack#8270) — the only way around it was a per-call-site "empty ⇒
+treat as unreported" heuristic (`HomePage.tsx`'s `useCanAuthorMetadata`).
+
+`systemPermissions` on `PermissionContextValue` is now `string[] | undefined`
+(same shape `@object-ui/react`'s `useCapabilityGate` already uses for the
+ADR-0066 D4 action gate), and `hasCapabilities` itself fails OPEN when it is
+`undefined` and gates strictly on a reported empty array. The call-site
+heuristic in `HomePage.tsx` retires in favor of the centralized signal.
+
+Two more call sites that fed `systemPermissions` into the ADR-0066 D4 action
+gate (`RecordDetailView`'s `resolveActionUser`, and the shell-level
+`useConsoleActionRuntime`) used to default a loaded-but-`undefined` answer to
+`[]` before forwarding it, which silently re-collapsed the same distinction
+one layer down and gated every `requiredPermissions` action closed on a
+non-reporting deployment instead of open. Both now forward the value as-is.

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -84,19 +84,18 @@ const AUTHORING_CAPABILITY = 'manage_metadata';
  * **Unknown → fail OPEN**, the same doctrine `useCapabilityGate` states for
  * ADR-0066 gates (framework#3923): the server enforces regardless, and hiding a
  * permitted user's primary CTA on missing client data is the worse failure.
- * `hasCapabilities` alone cannot express that here — `MePermissionsProvider`
- * collapses an ABSENT `systemPermissions` (a backend predating ADR-0066) and a
- * genuinely empty one into the same `[]`, so gating on it bare would strip the
- * product's front door from every admin on such a deployment. An empty set is
- * therefore read as "this backend does not report capabilities" and opens the
- * gate. The ruled case is unaffected: the EE owner's set is non-empty
- * (`manage_org_users`, `setup.access`, `setup.write`), so it gates closed.
- * Hosts with no permission provider at all already fail open inside
- * `usePermissions`.
+ * `MePermissionsProvider` now preserves the absent-vs-empty distinction
+ * natively (objectui#4656) — `hasCapabilities` itself returns `true` when the
+ * backend never reported `systemPermissions` at all (a deployment predating
+ * ADR-0066), and gates normally on a real answer, including a genuinely
+ * EMPTY one. This hook no longer re-derives that heuristic locally; it just
+ * asks the centralized signal. The ruled case is unaffected: the EE owner's
+ * set is non-empty (`manage_org_users`, `setup.access`, `setup.write`), so it
+ * gates closed. Hosts with no permission provider at all already fail open
+ * inside `usePermissions`.
  */
 function useCanAuthorMetadata(): boolean {
-  const { hasCapabilities, systemPermissions } = usePermissions();
-  if (!Array.isArray(systemPermissions) || systemPermissions.length === 0) return true;
+  const { hasCapabilities } = usePermissions();
   return hasCapabilities([AUTHORING_CAPABILITY]);
 }
 

--- a/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
@@ -203,17 +203,36 @@ describe('HomePage authoring-CTA capability gate (objectstack#8270)', () => {
 
   describe('unknown capabilities fail OPEN', () => {
     it('keeps the CTAs live when the backend reports no capabilities at all', () => {
-      // A deployment predating ADR-0066 sends no `systemPermissions`, and
-      // `MePermissionsProvider` collapses that absence into `[]` — the same
-      // value a genuinely capability-less user produces. Reading it as "denied"
-      // would strip the product's front door from every admin on such a
-      // deployment; the server still refuses the write either way, so unknown
-      // opens (the doctrine `useCapabilityGate` states for ADR-0066 gates).
+      // A deployment predating ADR-0066 sends no `systemPermissions` at all —
+      // the key is OMITTED from the response. `MePermissionsProvider` now
+      // preserves that as `undefined`, distinct from a genuinely empty grant,
+      // and `hasCapabilities` fails OPEN on it. Reading it as "denied" would
+      // strip the product's front door from every admin on such a deployment;
+      // the server still refuses the write either way, so unknown opens (the
+      // doctrine `useCapabilityGate` states for ADR-0066 gates).
       renderHome(eePayload(undefined));
 
       expect(screen.getByTestId('home-build-app')).toBeEnabled();
       expect(screen.getByTestId('home-start-template')).toBeEnabled();
       expect(screen.queryByTestId('home-authoring-gate-reason')).toBeNull();
+    });
+  });
+
+  describe('a REPORTED empty systemPermissions is not confused with absent (objectui#4656)', () => {
+    it('disables the CTAs when the backend explicitly reports zero capabilities', () => {
+      // Distinct from the case above: `systemPermissions` is PRESENT here —
+      // literally `[]` — meaning the server gave a real answer: this session
+      // holds no system capabilities at all. Before objectui#4656 this was
+      // indistinguishable from the omitted-field case (both collapsed to `[]`
+      // upstream) and so incorrectly fell open too; a real empty grant must
+      // gate exactly like any other reported set that lacks the capability.
+      renderHome(eePayload([]));
+
+      expect(screen.getByTestId('home-build-app')).toBeDisabled();
+      expect(screen.getByTestId('home-start-template')).toBeDisabled();
+      expect(screen.getByTestId('home-authoring-gate-reason')).toHaveTextContent(
+        '«home.build.noCapability»',
+      );
     });
   });
 

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -127,8 +127,15 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   const { dataSource, objects, objectName, onRefresh } = opts;
   const navigate = useNavigate();
   const { user, activeOrganization } = useAuth();
-  // [ADR-0066 D4] System capabilities for the action capability gate (fail-open
-  // when no PermissionProvider is mounted — usePermissions returns []).
+  // [ADR-0066 D4] System capabilities for the action capability gate. Forwarded
+  // AS-IS below (no `?? []`) — `undefined` here means either no
+  // PermissionProvider is mounted, or the backend never reported
+  // `systemPermissions` at all (a deployment predating ADR-0066), and
+  // `ActionEngine`'s own `Array.isArray(held)` check already fails OPEN on
+  // that (framework#3923). Defaulting it to `[]` here used to silently
+  // collapse "unknown" into "holds nothing" and gate every
+  // `requiredPermissions` action closed on exactly the deployments this
+  // doctrine exists to protect (objectui#4656).
   const { systemPermissions } = usePermissions();
   const { fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel, actionDescription, actionResultDialog } = useObjectLabel();
   // Entitlement 403s render as a dialog, not a toast — its copy is localized
@@ -235,8 +242,8 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   }, [objectName, objectDef, objects, fieldLabel, fieldOptionLabel, actionParamText, actionParamOptionLabel]);
 
   const currentUser = user
-    ? { id: user.id, name: user.name, avatar: user.image, isPlatformAdmin: (user as any)?.isPlatformAdmin ?? false, systemPermissions: systemPermissions ?? [] }
-    : { ...FALLBACK_USER, systemPermissions: systemPermissions ?? [] };
+    ? { id: user.id, name: user.name, avatar: user.image, isPlatformAdmin: (user as any)?.isPlatformAdmin ?? false, systemPermissions }
+    : { ...FALLBACK_USER, systemPermissions };
 
   const toastHandler = useCallback<ToastHandler>((message, options) => {
     if (options?.type === 'error') { toast.error(message); return; }

--- a/packages/app-shell/src/views/RecordDetailView.actionUser.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.actionUser.test.tsx
@@ -17,10 +17,20 @@
  * `record_header` / `record_more` action's `requiredPermissions` was silently
  * unenforced on the one surface those locations exist on.
  *
- * Two properties are pinned here, and they pull in opposite directions:
+ * Three properties are pinned here, and they pull in different directions:
  *   • loaded permissions MUST reach the engine (otherwise: no gate at all);
  *   • unloaded permissions MUST NOT be forwarded as `[]` (otherwise: every gated
- *     action hides in a standalone embed that never mounts a PermissionProvider).
+ *     action hides in a standalone embed that never mounts a PermissionProvider);
+ *   • [objectui#4656] a LOADED-but-`undefined` answer MUST NOT be forwarded as
+ *     `[]` either — `undefined` here means the backend never reported
+ *     `systemPermissions` at all (a deployment predating ADR-0066), which
+ *     `MePermissionsProvider` now preserves rather than collapsing to `[]`.
+ *     Re-collapsing it at this call site would silently re-introduce the
+ *     exact bug this ADR-0066 D4 seeding exists to prevent, just gated closed
+ *     instead of open: every `requiredPermissions` action on the record
+ *     surface would hide on such a deployment instead of showing (the server
+ *     still 403s regardless — the UI-only failure is hiding a button a
+ *     permitted user could have clicked).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -51,8 +61,18 @@ describe('resolveActionUser — ADR-0066 D4 capability gate seeding (#3923)', ()
     expect('systemPermissions' in resolved).toBe(false);
   });
 
-  it('treats a loaded-but-undefined set as "holds nothing", not as unknown', () => {
-    expect(resolveActionUser(user, true, undefined).systemPermissions).toEqual([]);
+  it('forwards a loaded-but-undefined set AS unknown, not as "holds nothing" (objectui#4656)', () => {
+    // Superseded assertion (pre-#4656): this used to collapse to `[]`, on the
+    // premise that `usePermissions().systemPermissions` was NEVER undefined
+    // while loaded — `MePermissionsProvider` always defaulted it via `?? []`.
+    // That premise is gone: the provider now preserves `undefined` for "this
+    // backend never reported systemPermissions", and `resolveActionUser` must
+    // forward it unchanged so `ActionEngine`'s own `Array.isArray(held)` check
+    // reads it as unknown and fails OPEN — collapsing it here would silently
+    // flip that to fail-CLOSED for every record_header/record_more action.
+    const resolved = resolveActionUser(user, true, undefined);
+    expect(resolved.systemPermissions).toBeUndefined();
+    expect(Array.isArray(resolved.systemPermissions)).toBe(false);
   });
 
   it('keeps the anonymous fallback identity and still carries the gate', () => {

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -103,11 +103,22 @@ const FALLBACK_USER = { id: 'current-user', name: 'Demo User' };
  * `requiredPermissions` — the button rendered, and only the server's 403 stopped
  * it (and only for platform action routes at that).
  *
- * The `permissionsLoaded` gate keeps the two states apart: `usePermissions()`
- * returns `[]` both for "holds no capabilities" and for "no PermissionProvider /
- * still resolving". Forwarding the latter as `[]` would flip the gate fail-CLOSED
- * and hide gated actions in a standalone embed, so it stays `undefined` until the
- * answer is real.
+ * The `permissionsLoaded` gate keeps "no answer yet" apart from "an answer,
+ * whatever it is": while `!permissionsLoaded` (no PermissionProvider mounted,
+ * or still resolving), `systemPermissions` is omitted entirely so the engine's
+ * own fail-open applies. Forwarding `[]` in that window would flip the gate
+ * fail-CLOSED and hide gated actions in a standalone embed.
+ *
+ * [objectui#4656] Once loaded, `systemPermissions` is forwarded AS-IS,
+ * `undefined` included — it is NOT collapsed to `[]`. `MePermissionsProvider`
+ * now preserves the distinction the engine already keys off: `undefined`
+ * means the backend never reported `systemPermissions` at all (a deployment
+ * predating ADR-0066), which is exactly the "unknown" case the engine's own
+ * `Array.isArray(held)` check fails OPEN on — not "holds nothing". Defaulting
+ * it to `[]` here would silently re-introduce the same collapse at this one
+ * call site and gate every `record_header` / `record_more` action closed on
+ * such a deployment. A REPORTED empty array still forwards as `[]` and gates
+ * strictly, unchanged.
  */
 export function resolveActionUser(
   user: { id: string; name: string; image?: string } | null | undefined,
@@ -118,7 +129,7 @@ export function resolveActionUser(
     ? { id: user.id, name: user.name, avatar: user.image }
     : FALLBACK_USER;
   return permissionsLoaded
-    ? { ...identity, systemPermissions: systemPermissions ?? [] }
+    ? { ...identity, systemPermissions }
     : identity;
 }
 

--- a/packages/permissions/src/MePermissionsProvider.tsx
+++ b/packages/permissions/src/MePermissionsProvider.tsx
@@ -290,9 +290,18 @@ export function MePermissionsProvider({
       getRowFilter,
       getObjectApiOperations,
       roles: data?.roles ?? [],
-      systemPermissions: data?.systemPermissions ?? [],
+      // [objectui#4656] Forward the raw signal — do NOT `?? []` this. A
+      // backend predating ADR-0066 omits `systemPermissions` from the
+      // response entirely, and defaulting that to `[]` here made it
+      // indistinguishable from a genuinely empty grant to every consumer
+      // downstream (this provider's own `hasCapabilities` included).
+      systemPermissions: data?.systemPermissions,
       hasCapabilities: (required: string[]) => {
-        const held = new Set(data?.systemPermissions ?? []);
+        const perms = data?.systemPermissions;
+        // Unknown (backend never reported systemPermissions) fails OPEN — see
+        // the doctrine on `PermissionContextValue.hasCapabilities`.
+        if (!Array.isArray(perms)) return true;
+        const held = new Set(perms);
         return required.every((p) => held.has(p));
       },
       isLoaded: !loading && !error && data !== null,

--- a/packages/permissions/src/PermissionContext.ts
+++ b/packages/permissions/src/PermissionContext.ts
@@ -28,9 +28,36 @@ export interface PermissionContextValue {
   getObjectApiOperations: (object: string) => string[] | undefined;
   /** Current user roles */
   roles: string[];
-  /** [ADR-0066] System capabilities held by the user (union of permission-set systemPermissions). */
-  systemPermissions: string[];
-  /** [ADR-0066] True when the user holds ALL of `required` capabilities (subset check). */
+  /**
+   * [ADR-0066] System capabilities held by the user (union of permission-set
+   * `systemPermissions`), when the backend actually reports them.
+   *
+   * [objectui#4656] `undefined` means no answer was ever reported — a backend
+   * predating ADR-0066 (the `/me/permissions` response omits the field
+   * entirely), or no permission provider mounted at all — and is NOT the same
+   * as a genuinely empty grant (`[]`, "reported, holds nothing"). A provider
+   * that cannot tell the two apart must not collapse them into the same
+   * value: doing so is exactly what silently stripped capability-gated UI
+   * from every admin on a non-reporting deployment. Callers that need the raw
+   * signal (rather than a specific capability check) read this directly;
+   * `hasCapabilities` below already resolves the right verdict for either
+   * case, so most callers never need to.
+   */
+  systemPermissions: string[] | undefined;
+  /**
+   * [ADR-0066] True when the user holds ALL of `required` capabilities.
+   *
+   * [objectui#4656] Fails OPEN (`true`) when `systemPermissions` is
+   * `undefined` — an unreported answer is not a denial, the server still
+   * enforces the capability regardless of what the UI shows, and hiding a
+   * permitted user's UI on missing client data is the worse failure. This is
+   * the same doctrine `useCapabilityGate` (`@object-ui/react`) already states
+   * for the ADR-0066 D4 action gate (framework#3923), centralized here so
+   * every `hasCapabilities` call site gets it for free instead of
+   * re-deriving a "treat an empty set as unreported" heuristic locally. A
+   * REPORTED empty array gates strictly: "holds nothing" is a real,
+   * enforceable answer and must not be read as "unknown".
+   */
   hasCapabilities: (required: string[]) => boolean;
   /** Whether permissions are loaded */
   isLoaded: boolean;

--- a/packages/permissions/src/PermissionProvider.tsx
+++ b/packages/permissions/src/PermissionProvider.tsx
@@ -123,11 +123,14 @@ export function PermissionProvider({
       // operation set — return undefined so consumers keep current behavior.
       getObjectApiOperations: () => undefined,
       roles: userRoles,
-      // This role-based provider does not model ADR-0066 system capabilities;
-      // expose an empty set + a fail-open capability check to satisfy the
-      // contract. The console uses MePermissionsProvider, which wires the real
-      // systemPermissions from /me/permissions.
-      systemPermissions: [],
+      // This role-based provider has no backend answer to give — it never
+      // fetches /me/permissions — so ADR-0066 system capabilities are simply
+      // unreported here: `undefined`, not `[]` (objectui#4656; a literal `[]`
+      // would claim "reported, holds nothing", which this provider cannot
+      // back up). `hasCapabilities` stays fail-open to match. The console
+      // uses MePermissionsProvider, which wires the real systemPermissions
+      // from /me/permissions.
+      systemPermissions: undefined,
       hasCapabilities: () => true,
       isLoaded: true,
     }),

--- a/packages/permissions/src/__tests__/MePermissionsProvider.capabilitiesReported.test.tsx
+++ b/packages/permissions/src/__tests__/MePermissionsProvider.capabilitiesReported.test.tsx
@@ -180,4 +180,54 @@ describe('objectui#4656 — absent-vs-empty systemPermissions truth table', () =
       expect(screen.getByTestId('has').textContent).toBe('true');
     });
   });
+
+  describe('the sidebar nav OR-fallback pattern needs no call-site change (objectui#4656)', () => {
+    // `UnifiedSidebar`/`AppSidebar` gate a bare `requiredPermissions` name with
+    // `hasCapabilities([perm]) || can(perm, 'read')` — not a heuristic that
+    // reads `systemPermissions` itself, so there is nothing there to migrate.
+    // This reproduces that exact expression against the real provider to show
+    // it is fixed for free: on an unreported backend `hasCapabilities` alone
+    // now opens the gate, where before this fix it fell through to the
+    // `can(perm, 'read')` object-permission check — which reads a bare
+    // capability name as an OBJECT name and denies for an authenticated
+    // session with no matching object entry (#2926 ④), stripping every
+    // bare-capability nav item on exactly the deployments this doctrine
+    // exists to protect.
+    function NavProbe({ perm }: { perm: string }) {
+      const { hasCapabilities, can } = usePermissions();
+      return <span data-testid="nav-shows">{String(hasCapabilities([perm]) || can(perm, 'read'))}</span>;
+    }
+
+    it('shows a bare-capability nav item on an UNREPORTED backend (fails open via hasCapabilities alone)', () => {
+      render(
+        <MePermissionsProvider
+          initialPermissions={{
+            authenticated: true, userId: 'u1', tenantId: 't1',
+            roles: ['org_owner'], permissionSets: ['organization_admin'],
+            // `systemPermissions` omitted — pre-ADR-0066 shape.
+            objects: {}, fields: {},
+          }}
+        >
+          <NavProbe perm="manage_metadata" />
+        </MePermissionsProvider>,
+      );
+      expect(screen.getByTestId('nav-shows').textContent).toBe('true');
+    });
+
+    it('hides a bare-capability nav item on a REPORTED-empty backend lacking it and no matching object', () => {
+      render(
+        <MePermissionsProvider
+          initialPermissions={{
+            authenticated: true, userId: 'u1', tenantId: 't1',
+            roles: ['org_owner'], permissionSets: ['organization_admin'],
+            systemPermissions: [], // real answer: holds nothing
+            objects: {}, fields: {},
+          }}
+        >
+          <NavProbe perm="manage_metadata" />
+        </MePermissionsProvider>,
+      );
+      expect(screen.getByTestId('nav-shows').textContent).toBe('false');
+    });
+  });
 });

--- a/packages/permissions/src/__tests__/MePermissionsProvider.capabilitiesReported.test.tsx
+++ b/packages/permissions/src/__tests__/MePermissionsProvider.capabilitiesReported.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#4656 — `MePermissionsProvider` used to collapse an ABSENT
+ * `systemPermissions` (a backend predating ADR-0066, which omits the field
+ * from the `/me/permissions` response entirely) and a genuinely EMPTY one
+ * (a real answer: "you hold zero system capabilities") into the same `[]`.
+ * Every `hasCapabilities` consumer downstream could not tell "no answer" from
+ * "no grants" and had to either gate strictly (stripping UI from every admin
+ * on a non-reporting deployment — objectstack#8270) or invent its own
+ * call-site "empty ⇒ treat as unreported" heuristic (`HomePage.tsx`'s
+ * `useCanAuthorMetadata`, before this fix).
+ *
+ * This pins the truth table the centralized fix promises:
+ *   - field OMITTED (unreported backend)  → `systemPermissions` is
+ *     `undefined`, `hasCapabilities` fails OPEN (`true`) regardless of what
+ *     is required.
+ *   - field REPORTED as `[]` (real, empty grant) → `systemPermissions` is
+ *     `[]`, `hasCapabilities` gates STRICTLY — false unless `required` is
+ *     empty too.
+ *   - field REPORTED with real grants → ordinary subset check (positive AND
+ *     negative control), unchanged from before this fix.
+ *
+ * Also pins the same "no report ⇒ undefined, not []" signal on the two other
+ * `PermissionContextValue` sources: `PermissionProvider` (the role-based
+ * provider, which never fetches `/me/permissions` and so can never claim a
+ * real answer) and `usePermissions()`'s own no-context fallback (no provider
+ * mounted at all).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MePermissionsProvider } from '../MePermissionsProvider';
+import { PermissionProvider } from '../PermissionProvider';
+import { usePermissions } from '../usePermissions';
+
+function Probe({ required }: { required: string[] }) {
+  const { hasCapabilities, systemPermissions } = usePermissions();
+  return (
+    <div>
+      <span data-testid="reported">{String(Array.isArray(systemPermissions))}</span>
+      <span data-testid="raw">{JSON.stringify(systemPermissions)}</span>
+      <span data-testid="has">{String(hasCapabilities(required))}</span>
+    </div>
+  );
+}
+
+describe('objectui#4656 — absent-vs-empty systemPermissions truth table', () => {
+  describe('MePermissionsProvider', () => {
+    it('UNREPORTED (field omitted): systemPermissions undefined, hasCapabilities fails OPEN', () => {
+      render(
+        <MePermissionsProvider
+          initialPermissions={{
+            authenticated: true,
+            userId: 'u1',
+            tenantId: 't1',
+            roles: ['org_owner'],
+            permissionSets: ['organization_admin'],
+            // No `systemPermissions` key at all — pre-ADR-0066 shape.
+            objects: {},
+            fields: {},
+          }}
+        >
+          <Probe required={['manage_metadata']} />
+        </MePermissionsProvider>,
+      );
+      expect(screen.getByTestId('reported').textContent).toBe('false');
+      // `JSON.stringify(undefined)` is the JS value `undefined`, which React
+      // renders as no text at all — so an unreported answer leaves this node
+      // empty, distinct from the reported-empty case below rendering `[]`.
+      expect(screen.getByTestId('raw').textContent).toBe('');
+      expect(screen.getByTestId('has').textContent).toBe('true');
+    });
+
+    it('REPORTED empty ([]): systemPermissions is [], hasCapabilities gates STRICTLY', () => {
+      render(
+        <MePermissionsProvider
+          initialPermissions={{
+            authenticated: true,
+            userId: 'u1',
+            tenantId: 't1',
+            roles: ['org_owner'],
+            permissionSets: ['organization_admin'],
+            systemPermissions: [], // a REAL answer: holds zero capabilities
+            objects: {},
+            fields: {},
+          }}
+        >
+          <Probe required={['manage_metadata']} />
+        </MePermissionsProvider>,
+      );
+      expect(screen.getByTestId('reported').textContent).toBe('true');
+      expect(screen.getByTestId('raw').textContent).toBe('[]');
+      // The bug this card fixes: before it, an empty-but-REPORTED answer was
+      // indistinguishable from "unreported" and fell open too.
+      expect(screen.getByTestId('has').textContent).toBe('false');
+    });
+
+    it('REPORTED empty ([]) with an empty `required` list still passes (vacuous subset)', () => {
+      render(
+        <MePermissionsProvider
+          initialPermissions={{
+            authenticated: true,
+            userId: 'u1',
+            tenantId: 't1',
+            roles: [],
+            permissionSets: [],
+            systemPermissions: [],
+            objects: {},
+            fields: {},
+          }}
+        >
+          <Probe required={[]} />
+        </MePermissionsProvider>,
+      );
+      expect(screen.getByTestId('has').textContent).toBe('true');
+    });
+
+    it('REPORTED with real grants — positive control: holds the required capability', () => {
+      render(
+        <MePermissionsProvider
+          initialPermissions={{
+            authenticated: true,
+            userId: 'u1',
+            tenantId: 't1',
+            roles: ['org_owner'],
+            permissionSets: ['organization_admin'],
+            systemPermissions: ['manage_org_users', 'setup.access', 'manage_metadata'],
+            objects: {},
+            fields: {},
+          }}
+        >
+          <Probe required={['manage_metadata']} />
+        </MePermissionsProvider>,
+      );
+      expect(screen.getByTestId('reported').textContent).toBe('true');
+      expect(screen.getByTestId('has').textContent).toBe('true');
+    });
+
+    it('REPORTED with real grants — negative control: a non-empty set missing the required capability still gates', () => {
+      render(
+        <MePermissionsProvider
+          initialPermissions={{
+            authenticated: true,
+            userId: 'u1',
+            tenantId: 't1',
+            roles: ['org_owner'],
+            permissionSets: ['organization_admin'],
+            // The objectstack#8270 EE owner's exact set — non-empty, no manage_metadata.
+            systemPermissions: ['manage_org_users', 'setup.access', 'setup.write'],
+            objects: {},
+            fields: {},
+          }}
+        >
+          <Probe required={['manage_metadata']} />
+        </MePermissionsProvider>,
+      );
+      expect(screen.getByTestId('reported').textContent).toBe('true');
+      expect(screen.getByTestId('has').textContent).toBe('false');
+    });
+  });
+
+  describe('sibling PermissionContextValue sources also signal "unreported" as undefined, not []', () => {
+    it('PermissionProvider (role-based, no /me/permissions fetch) never claims a real answer', () => {
+      render(
+        <PermissionProvider roles={[]} permissions={[]} userRoles={['admin']}>
+          <Probe required={['manage_metadata']} />
+        </PermissionProvider>,
+      );
+      expect(screen.getByTestId('reported').textContent).toBe('false');
+      // Fail-open by design — this provider has nothing to enforce with.
+      expect(screen.getByTestId('has').textContent).toBe('true');
+    });
+
+    it('usePermissions() with no provider mounted at all', () => {
+      render(<Probe required={['manage_metadata']} />);
+      expect(screen.getByTestId('reported').textContent).toBe('false');
+      expect(screen.getByTestId('has').textContent).toBe('true');
+    });
+  });
+});

--- a/packages/permissions/src/usePermissions.ts
+++ b/packages/permissions/src/usePermissions.ts
@@ -36,7 +36,10 @@ export function usePermissions(): PermissionContextValue & {
         getRowFilter: () => undefined,
         getObjectApiOperations: () => undefined,
         roles: [],
-        systemPermissions: [],
+        // [objectui#4656] No provider mounted at all → no answer, not "holds
+        // nothing". `undefined` matches MePermissionsProvider's own signal
+        // for an unreported backend and keeps `hasCapabilities` fail-open.
+        systemPermissions: undefined,
         hasCapabilities: () => true,
         isLoaded: false,
         can: () => true,


### PR DESCRIPTION
Fixes #4656

Implements the graded scope verbatim: `MePermissionsProvider` preserves the
absent-vs-empty distinction on `systemPermissions`, every `hasCapabilities(`
consumer's call-site fail-open heuristic retires in favor of the centralized
signal, and `HomePage.authoringCapabilityGate.test.tsx` (the objectstack#8270
pin) stays green.

## Premise: verified, still valid

Read `MePermissionsProvider` (`packages/permissions/src/MePermissionsProvider.tsx`)
against `origin/main` at `fec06835e`: the collapse is real, at
`systemPermissions: data?.systemPermissions ?? []` and the `hasCapabilities`
closure built from the same default. Grepping `hasCapabilities(` repo-wide
(excluding tests/CHANGELOGs) turns up exactly three consumers —
`HomePage.tsx`, `UnifiedSidebar.tsx`, `AppSidebar.tsx` — and only `HomePage.tsx`
carries the named call-site heuristic (`useCanAuthorMetadata`'s
`if (!Array.isArray(systemPermissions) || systemPermissions.length === 0) return true;`).

## Shape chosen: `systemPermissions: string[] | undefined` (carry `undefined` through)

The card offered two candidates: an added `capabilitiesReported: boolean`, or
carrying the array as `string[] | undefined`. I measured the second is not a
new invention — it is **already** this repo's established doctrine for the
exact same distinction one layer down, in `@object-ui/react`'s
`useCapabilityGate.ts` (`useHeldCapabilities(): string[] | undefined`, whose
own doc comment states: *"undefined when the host never supplied them (→
callers must fail open)... An EMPTY array is not unknown"*). Matching that
shape instead of inventing a sibling `capabilitiesReported` flag:

- lets `hasCapabilities` absorb the fail-open decision itself (mirroring
  `useCapabilityGate()`'s own `if (!Array.isArray(held)) return true;`), so
  call sites don't need to consult a second field at all — `useCanAuthorMetadata`
  drops to a one-line `return hasCapabilities([AUTHORING_CAPABILITY]);` and the
  heuristic **retires**, not relocates;
- gives every raw-`systemPermissions` reader (below) the same undefined-means-
  unknown contract they'd already expect from the sibling mechanism.

## The sweep — every `hasCapabilities(`/`systemPermissions` consumer, named

**Definition sites** (`packages/permissions/`):
- `MePermissionsProvider.tsx` — the core fix: `systemPermissions` forwarded
  as-is (no `?? []`); `hasCapabilities` fails OPEN when it is `undefined`,
  gates strictly on a reported array (empty included).
- `PermissionProvider.tsx` (role-based provider, never fetches
  `/me/permissions`) — `systemPermissions: []` → `undefined`: it has no real
  answer to give, so it must not claim "reported, holds nothing" either.
  `hasCapabilities: () => true` unchanged (still fail-open by design).
- `usePermissions.ts`'s no-context fallback (no provider mounted at all) —
  same `[]` → `undefined` correction, same reasoning.
- `PermissionContext.ts` — type + doctrine comment on both fields.

**Direct `hasCapabilities(` consumers:**
- `HomePage.tsx`'s `useCanAuthorMetadata` — local heuristic **deleted**; now
  asks the centralized signal directly. Outward behavior for the three cases
  the pin file already covered is unchanged (verified below); a fourth case
  the pin file could not previously express — a REPORTED, genuinely empty
  `systemPermissions: []` — now correctly gates closed instead of falling
  open (new test, "a REPORTED empty systemPermissions is not confused with
  absent").
- `UnifiedSidebar.tsx` / `AppSidebar.tsx`'s `checkPerm` — **no code change**.
  Their `hasCapabilities([perm]) || can(perm, 'read')` is not an
  absent-vs-empty heuristic (it ORs a capability check with an unrelated
  object-read fallback for nav items authored as a plain object name), so
  there is nothing to migrate — but it silently inherits a real fix: before
  this PR, a bare-capability nav item on an unreported backend fell all the
  way to `can(perm, 'read')`, which reads the capability name as an object
  name and denies for an authenticated session with no matching object entry
  (#2926 ④) — stripping the nav item on exactly the deployments this doctrine
  protects. Reproduced against the real provider in the new test file
  ("the sidebar nav OR-fallback pattern needs no call-site change").

**Two more call sites, found by tracing where `systemPermissions` itself
(not `hasCapabilities`) flows, not named in the card's own grep instruction
but the same defect class one layer down** — both feed the ADR-0066 D4
*action* capability gate (`ActionEngine`/`useCapabilityGate`, framework#3923),
which already implements the fail-open-on-undefined doctrine correctly; the
bug was these two call sites re-collapsing the signal to `[]` before handing
it to that already-correct engine:
- `RecordDetailView.tsx`'s `resolveActionUser` — `systemPermissions ?? []` →
  forwards as-is. Its own pin test (`RecordDetailView.actionUser.test.tsx`)
  asserted the OLD, now-wrong premise ("a loaded-but-undefined set" collapses
  to "holds nothing"); that premise held only because the OLD provider could
  never actually produce `undefined` while loaded. Updated the test's
  assertion and doc comment to the new premise (see "pin equivalence" below).
- `useConsoleActionRuntime.tsx` (the shell-level `ActionProvider`, which most
  action surfaces mount, including `EnvironmentListToolbar`'s
  `useCapabilityGate()` transitively) — same `?? []` at `currentUser`
  construction, same fix. Its own comment claimed "fail-open when no
  PermissionProvider is mounted" while the code actually failed CLOSED (an
  array, even empty, is never `undefined` to the engine's
  `Array.isArray(held)` check) — a live, previously undiscovered instance of
  this exact bug, now fixed by the same one-line change.

I did not find any other `systemPermissions` reader (checked every
`usePermissions()` call site repo-wide); `PermissionMatrixEditor.tsx` /
`PermissionPreview.tsx` / `permission-slice*.ts` read a *different*
`draft.systemPermissions` — the metadata-admin's authored `PermissionSetDraft`,
unrelated to this context value.

## Pin equivalence — `HomePage.authoringCapabilityGate.test.tsx`

All four existing cases stay green, byte-for-byte the same assertions,
because the payloads they use only ever exercise the two ends of the truth
table this fix actually changes the boundary of:
- "ruled case" / "capability present": `systemPermissions` reported
  **non-empty** either way — `hasCapabilities` takes the same strict branch
  before and after (`Array.isArray` was already true).
- "unknown capabilities fail OPEN": `eePayload(undefined)` omits the
  `systemPermissions` key entirely — `data.systemPermissions` is `undefined`
  in both the old (`?? []` default kicks in downstream) and new provider;
  observably the CTAs stay enabled either way, only the *mechanism* moved
  (was: call-site `.length === 0` check after defaulting; now: centralized
  `Array.isArray` check on the raw value).

None of the four exercises a REPORTED-but-empty payload, which is exactly the
case the OLD heuristic got wrong (`.length === 0` cannot tell "empty and
reported" from "absent") — that gap is what the new
"a REPORTED empty systemPermissions is not confused with absent" describe
block fills, using `eePayload([])` (truthy in JS, so the key IS present).

`RecordDetailView.actionUser.test.tsx`'s superseded case is not
equivalent — it is corrected, because it pinned the old (now-wrong) premise
directly. Full old→new reasoning is in the test file's own comment; the short
version: `resolveActionUser(user, true, undefined)` used to assert
`systemPermissions` collapses to `[]` on the premise that
`usePermissions().systemPermissions` was NEVER undefined while loaded. That
premise is gone — the provider now genuinely returns `undefined` while
loaded, for the unreported case — so the test now asserts the value forwards
unchanged (`undefined`), matching what `ActionEngine`'s own
`Array.isArray(held)` check needs to fail open correctly.

## Truth table (new tests)

`packages/permissions/src/__tests__/MePermissionsProvider.capabilitiesReported.test.tsx`
pins the full table against the REAL `MePermissionsProvider` /
`PermissionProvider` / no-context fallback:

| backend `systemPermissions` | `systemPermissions` in context | `hasCapabilities(['x'])` |
|---|---|---|
| key omitted (pre-ADR-0066) | `undefined` | `true` (fail open) |
| `[]` (real, empty grant) | `[]` | `false` (gates strictly) |
| `[]` + `required: []` | `[]` | `true` (vacuous subset) |
| non-empty, holds `'x'` | the array | `true` (positive control) |
| non-empty, missing `'x'` (the objectstack#8270 EE owner's exact set) | the array | `false` (negative control) |
| `PermissionProvider` (no `/me/permissions` fetch) | `undefined` | `true` |
| no provider mounted | `undefined` | `true` |

## Reverse verification

Direction predicted before running: reverting only `MePermissionsProvider.tsx`
to its pre-fix `?? []` collapse, with the rest of the fix (including the
now-simplified `HomePage.tsx`) left in place, should redden the new
"UNREPORTED" truth-table case AND the pre-existing HomePage "unknown
capabilities fail OPEN" case (since `useCanAuthorMetadata` no longer has its
own fallback to paper over the reverted provider) — everything else stays
green. Observed exactly that: `2 failed | 14 passed` across the two files,
both failures on the predicted tests, nothing else moved. Restored via
`git checkout claude/issue-4656-capabilities-reported -- packages/permissions/src/MePermissionsProvider.tsx`
from the already-committed fix; `git diff HEAD` after restore was empty
(byte-identical) and the full suite below re-ran green from that state.

## Verification — all at `1ff99a4da` (the final commit)

```
pnpm exec vitest run packages/permissions/ packages/app-shell/src/console/home \
    packages/app-shell/src/views/RecordDetailView \
    packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx \
    packages/app-shell/src/layout/__tests__ --maxWorkers=2
  → 49 files, 415 passed

pnpm --filter '@object-ui/app-shell^...' --workspace-concurrency=2 build   → exit 0 (builds @object-ui/permissions too)
pnpm --filter @object-ui/permissions type-check                            → Done
pnpm --filter @object-ui/app-shell type-check                              → Done
node scripts/check-changeset-presence.mjs     → 1 changeset declared for the 2 released packages touched
node scripts/check-control-bytes.mjs          → OK (4245 files)
node scripts/check-phantom-dependencies.mjs   → OK
node scripts/check-changeset-no-major.mjs     → OK
eslint (touched files)                        → 0 errors, 163 pre-existing warnings (unchanged count before/after)
```

Gate re-derivation note: this repo has no `scripts/pm/dispatch-gates.mjs` (that
tool lives in the `objectstack` repo); the local families run above were
chosen from AGENTS.md's own "housekeeping" / "check:*" list against the actual
changed paths — no action-schema, i18n, or spec-symbol surface is touched, so
`check:action-forward-parity` / `check:i18n-*` / `check:spec-symbols` are not
implicated.

## Changeset

`@object-ui/permissions` and `@object-ui/app-shell`, both `patch` — see
`.changeset/permissions-capabilities-reported.md`.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_