### PR TITLE
lint: add repo-root no-console rule

### DIFF
--- a/.changeset/no-console-debug-infra-comments.md
+++ b/.changeset/no-console-debug-infra-comments.md
@@ -1,0 +1,12 @@
+---
+---
+
+objectui#4029 — no behavior change, so no version bump. Adds
+`eslint-disable-next-line no-console` plus an explanatory comment to
+`@object-ui/core`'s `debugLog`/`debugTime`/`debugTimeEnd` (the repo's opt-in
+debug channel, gated behind `globalThis.OBJECTUI_DEBUG`) and
+`@object-ui/data-objectstack`'s `createQuietHttpLogger` (a Logger-interface
+implementation whose methods deliberately forward to the matching
+`console.*` method), so the repo-root `no-console` lint rule added in this
+same change does not flag infrastructure that exists specifically to call
+`console.*`.

--- a/.changeset/no-console-lint-rule.md
+++ b/.changeset/no-console-lint-rule.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/fields': patch
+'@object-ui/plugin-detail': patch
+'@object-ui/runner': patch
+'object-ui': patch
+---
+
+objectui#4029 — the repo root now lints `no-console` (`error`, allowing
+`warn`/`error`) so a stray module- or function-scope `console.log`/`info`/
+`debug` fails CI instead of shipping silently (as `console.log('Registering
+object-map...')` did in #7139, caught only by hand). Landing the rule meant
+individually judging every real hit outside the tooling exemptions
+(`scripts/**`, `**/examples/**`, test files, `packages/cli/src/**`,
+`packages/create-plugin/src/**`) — this changeset covers the published
+packages whose call sites changed:
+
+- `@object-ui/app-shell`: `ObjectDataPage`'s dropped-URL-filter message is a
+  real diagnostic (data silently discarded), so it moves from `console.debug`
+  to `console.warn` to match the house convention.
+- `@object-ui/plugin-detail`: `DetailView`'s Web Share API failure now reports
+  via `console.error` (it is a real failure, not debug noise); a redundant
+  "Link copied to clipboard" success log is removed.
+- `@object-ui/fields`: `MasterDetailField`'s `handleView` stub no longer logs
+  the item it does nothing with.
+- `@object-ui/runner`: `App`'s loader-selection debug prints, `LayoutRenderer`'s
+  unused click-handler stub log, and `MockDataSource`'s per-call narration
+  (`find`/`create`/`getObjectSchema`) are removed — none diagnosed a problem,
+  they only echoed the happy path.
+- `object-ui` (VS Code extension): the "extension is now active!" activation
+  log is removed.
+
+No behavior changes beyond console output. `@object-ui/core` and
+`@object-ui/data-objectstack` also touch `no-console`-adjacent lines
+(`debugLog`/`debugTime`/`debugTimeEnd`, `createQuietHttpLogger`) but only to
+add `eslint-disable-next-line` documentation — those ARE the repo's
+deliberate debug/logger infrastructure, not leaked residue, so their own
+changeset carries empty frontmatter.

--- a/apps/site/app/components/ObjectUIProvider.tsx
+++ b/apps/site/app/components/ObjectUIProvider.tsx
@@ -11,20 +11,13 @@ import { initializeComponents } from '@object-ui/components';
 // (`{ type: 'form', fields: [...] }`) and the real form renderer owns the label
 // and the value state (objectui#3910).
 import '@object-ui/fields';
-import { ComponentRegistry } from '@object-ui/core';
 import { useEffect } from 'react';
 
 export function ObjectUIProvider({ children }: { children: React.ReactNode }) {
   // Explicitly call init to ensure components are registered
   useEffect(() => {
     initializeComponents();
-
-    // Wait a bit for plugins to register, then log
-    setTimeout(() => {
-      const componentTypes = ComponentRegistry.getAllTypes();
-      console.log('[ObjectUIProvider] Registered components:', componentTypes);
-    }, 100);
   }, []);
-  
+
   return <>{children}</>;
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,18 @@ export default tseslint.config({
     ],
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    // objectui#4029 — importing a package must not write noise to the
+    // consumer's console. House convention (measured, not invented): the
+    // one known leak used `console.log`, while every deliberate diagnostic
+    // already used `warn`/`error` (packages/plugin-map/src/ObjectMap.tsx,
+    // packages/core/src/registry/Registry.ts). Error so a new module/
+    // function-scope `console.log`/`info`/`debug` fails CI instead of
+    // waiting for a human read; `warn`/`error` stay allowed for intentional
+    // diagnostics. See the override block below for the carve-outs a blanket
+    // rule needs (CLI stdout, per-package examples, deliberate debug/logger
+    // infrastructure) and eslint.config.js's own PR history for the full
+    // hit-census accounting behind each one.
+    'no-console': ['error', { allow: ['warn', 'error'] }],
     // Downgrade new React Compiler rules to warnings (codebase predates these rules)
     'react-hooks/refs': 'warn',
     'react-hooks/immutability': 'warn',
@@ -78,6 +90,35 @@ export default tseslint.config({
           '`normalizeSectionField` (@object-ui/plugin-form). See objectui#3090.',
       }],
     }],
+  },
+}, {
+  // objectui#4029 — no-console exemption zones. None of these are "a
+  // package's console" from a consumer's perspective:
+  //  - root scripts/** is repo tooling that runs standalone, never as part
+  //    of a published package's import graph.
+  //  - examples/** at ANY depth (root AND per-package, hence **/ prefix —
+  //    measured objectui#4029: packages/types/examples/*.ts alone carried 18
+  //    hits the root-anchored examples/** glob never reached) is
+  //    documentation code, not a runtime import surface.
+  //  - test files assert against console output themselves (spying on it)
+  //    rather than leaking it to a real consumer.
+  //  - packages/cli and packages/create-plugin are CLI tools whose entire
+  //    job is terminal stdout/stderr — running a bin is not "importing a
+  //    package and getting noise you didn't ask for". @object-ui/cli's
+  //    index.ts does re-export a couple of commands for programmatic use,
+  //    but their console output is the documented behavior of calling them,
+  //    not an accidental module-scope leak — the #7139 bug class this rule
+  //    exists to net.
+  files: [
+    'scripts/**/*.{ts,tsx}',
+    '**/examples/**/*.{ts,tsx}',
+    '**/*.test.{ts,tsx}',
+    '**/__tests__/**/*.{ts,tsx}',
+    'packages/cli/src/**/*.{ts,tsx}',
+    'packages/create-plugin/src/**/*.{ts,tsx}',
+  ],
+  rules: {
+    'no-console': 'off',
   },
 }, {
   // objectui#3010/#3021 ratchet — a module loaded inside beforeAll/beforeEach

--- a/packages/app-shell/src/views/ObjectDataPage.saveAsViewFilterFold.test.ts
+++ b/packages/app-shell/src/views/ObjectDataPage.saveAsViewFilterFold.test.ts
@@ -128,20 +128,23 @@ describe('Save as view folds URL drill triples to spec rules (objectui#3419)', (
   it('drops a triple with no canonical operator instead of persisting it off-spec', () => {
     // Defence in depth: `parseUrlFilterTriples` cannot emit `~=` today. If the
     // URL contract ever grows an operator the spec has no word for, the saved
-    // view loses that one condition (with a debug note) rather than becoming a
-    // body the record gate rejects whole.
-    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    // view loses that one condition (with a warning) rather than becoming a
+    // body the record gate rejects whole. objectui#4029 promoted this from
+    // `console.debug` to `console.warn` — it is a real diagnostic (data
+    // silently dropped), not debug noise, so it must survive the repo's
+    // `no-console` allowlist.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { spec, gate } = saveAsView([
       ['stage', '=', 'open'],
       ['score', '~=', '10'],
     ]);
     expect(spec.filter).toEqual([{ field: 'stage', operator: 'equals', value: 'open' }]);
     expect(gate.success).toBe(true);
-    expect(debug).toHaveBeenCalledWith(expect.stringContaining('score'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('score'));
   });
 
   it('omits `filter` entirely when every triple was dropped', () => {
-    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { spec, gate } = saveAsView([['score', '~=', '10']]);
     expect('filter' in spec).toBe(false);
     expect(gate.success).toBe(true);

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -139,7 +139,9 @@ function foldUrlFilterTriplesToSpecRules(triples: FilterTriple[]): ViewFilterRul
     if (value !== undefined) rule.value = value;
     const parsed = ViewFilterRuleSchema.safeParse(rule);
     if (!parsed.success) {
-      console.debug(
+      // objectui#4029 — this is a real diagnostic (data silently dropped),
+      // not debug noise, so it goes through the allowed warn channel.
+      console.warn(
         `[ObjectDataPage] Dropped URL filter on "${field}" from the saved view:` +
           ` operator "${op}" has no canonical ViewFilterRule form.`,
       );

--- a/packages/core/src/utils/debug.ts
+++ b/packages/core/src/utils/debug.ts
@@ -118,8 +118,14 @@ export function isDebugEnabled(): boolean {
 export function debugLog(category: DebugCategory, message: string, data?: unknown): void {
   if (!isDebugEnabled()) return;
   if (data !== undefined) {
+    // objectui#4029 — this IS the repo's debug channel (opt-in via
+    // globalThis.OBJECTUI_DEBUG, gated by isDebugEnabled() above), not a
+    // leaked module-scope log; no-console's blanket ban would otherwise
+    // block the function whose entire job is to console.log.
+    // eslint-disable-next-line no-console
     console.log(`[ObjectUI Debug][${category}] ${message}`, data);
   } else {
+    // eslint-disable-next-line no-console -- see comment above
     console.log(`[ObjectUI Debug][${category}] ${message}`);
   }
 }
@@ -142,6 +148,7 @@ export function debugTimeEnd(label: string): void {
   const start = timers.get(label);
   if (start !== undefined) {
     const elapsed = (performance.now() - start).toFixed(2);
+    // eslint-disable-next-line no-console -- objectui#4029, see debugLog above
     console.log(`[ObjectUI Debug][perf] ${label}: ${elapsed}ms`);
     timers.delete(label);
   }

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -827,15 +827,23 @@ export function createQuietHttpLogger(): any {
     }
     return false;
   };
+  // objectui#4029 — this object IS the console binding for the spec Logger
+  // interface, not leaked debug residue: every method here deliberately
+  // forwards to the matching console.* method by design, so no-console's
+  // blanket ban is disabled line-by-line for the methods outside its
+  // warn/error allowlist.
   const logger: any = {
     debug: (message: string, meta?: Record<string, any>) =>
+      // eslint-disable-next-line no-console -- objectui#4029, see comment above
       console.debug(message, meta ?? ''),
     info: (message: string, meta?: Record<string, any>) =>
+      // eslint-disable-next-line no-console -- objectui#4029, see comment above
       console.info(message, meta ?? ''),
     warn: (message: string, meta?: Record<string, any>) =>
       console.warn(message, meta ?? ''),
     error: (message: string, error?: Error, meta?: Record<string, any>) => {
       if (isExpected404(meta)) {
+        // eslint-disable-next-line no-console -- objectui#4029, see comment above
         console.debug(
           `[ObjectStack] ${formatHttpFailureMessage(message, meta) ?? message} (suppressed expected 404)`,
           meta,
@@ -846,6 +854,7 @@ export function createQuietHttpLogger(): any {
     },
     fatal: (message: string, error?: Error, meta?: Record<string, any>) =>
       console.error(formatHttpFailureMessage(message, meta) ?? message, error ?? '', meta ?? ''),
+    // eslint-disable-next-line no-console -- objectui#4029, see comment above
     log: (message: string, ...args: any[]) => console.log(message, ...args),
     child: () => logger,
     withTrace: () => logger,

--- a/packages/fields/src/widgets/MasterDetailField.tsx
+++ b/packages/fields/src/widgets/MasterDetailField.tsx
@@ -41,9 +41,8 @@ export function MasterDetailField({
     onChange(items.filter(item => item.id !== id));
   };
 
-  const handleView = (item: MasterDetailValue) => {
+  const handleView = (_item: MasterDetailValue) => {
     // This would typically navigate to the detail view
-    console.log('View detail:', item);
   };
 
   if (readonly) {

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -687,12 +687,13 @@ export const DetailView: React.FC<DetailViewProps> = ({
         title: schema.title || t('detail.details'),
         text: `${schema.objectName} #${schema.resourceId}`,
         url: window.location.href,
-      }).catch((err) => console.log('Share failed:', err));
+      }).catch((err) => {
+        // objectui#4029 — a real failure of the Share API, not debug noise.
+        console.error('Share failed:', err);
+      });
     } else {
       // Fallback: copy link to clipboard
-      navigator.clipboard.writeText(window.location.href).then(() => {
-        console.log('Link copied to clipboard');
-      });
+      navigator.clipboard.writeText(window.location.href);
     }
   }, [schema]);
 

--- a/packages/plugin-gantt/demo/main.tsx
+++ b/packages/plugin-gantt/demo/main.tsx
@@ -596,9 +596,9 @@ function App() {
           // 制造排班示例: 启用班次分段 (白班/夜班), 排班日 08:00 起算。
           shiftSegments={mfg ? shifts : undefined}
           persistLayoutKey={mfg ? undefined : "demo-project"}
-          onLayoutChange={(l) => console.log('[gantt-demo] layout saved', l)}
+          onLayoutChange={() => {}}
           inlineEdit
-          onTaskClick={(t) => console.log('[gantt-demo] click', t.id)}
+          onTaskClick={() => {}}
           onTaskUpdate={(t, changes) => patch(t.id, changes)}
           onTaskDelete={(t) => setTasks((prev) => prev.filter((x) => x.id !== t.id))}
           onDependencyCreate={(source, target, type) =>

--- a/packages/runner/src/App.tsx
+++ b/packages/runner/src/App.tsx
@@ -91,12 +91,10 @@ export default function RunnerApp() {
     
     // IF ?api=... is present, use Network Loader
     if (apiUrl) {
-      console.log('🔌 Using Network Loader:', apiUrl);
       return new NetworkLoader(apiUrl);
     }
-    
+
     // ELSE use bundled files (Local Development)
-    console.log('📦 Using Local Bundle Loader');
     return new LocalBundleLoader();
   }, []);
 

--- a/packages/runner/src/LayoutRenderer.tsx
+++ b/packages/runner/src/LayoutRenderer.tsx
@@ -306,7 +306,6 @@ export const LayoutRenderer = ({ app, children, currentPath, onNavigate }: Layou
                                     <DropdownMenuItem key={idx} onSelect={() => {
                                         if ((item as any).onClick) {
                                             // Handle click logic
-                                            console.log('Clicked', item.label);
                                         }
                                     }}>
                                         {item.label}

--- a/packages/runner/src/lib/mockDataSource.ts
+++ b/packages/runner/src/lib/mockDataSource.ts
@@ -19,8 +19,7 @@ import { emulateBatchTransaction } from '@object-ui/core';
  * 在真实项目中，你会在这里使用 fetch/axios 调用你的 API。
  */
 export class MockDataSource implements DataSource {
-  async find(resource: string, params?: QueryParams): Promise<QueryResult> {
-    console.log(`[DataSource] Querying ${resource}`, params);
+  async find(_resource: string, _params?: QueryParams): Promise<QueryResult> {
     // `find` returns an envelope, not a bare array — consumers read `.data`
     // and `.total` (see QueryResult). Returning `[]` here would leave every
     // caller with `undefined` data.
@@ -34,8 +33,7 @@ export class MockDataSource implements DataSource {
   async create(resource: string, data: any): Promise<any> {
     // 模拟网络请求
     await new Promise(resolve => setTimeout(resolve, 800));
-    
-    console.log(`[DataSource] Created ${resource}:`, data);
+
     alert(`Success! Created record in "${resource}":\n${JSON.stringify(data, null, 2)}`);
     
     return { id: Math.random().toString(), ...data };
@@ -59,8 +57,7 @@ export class MockDataSource implements DataSource {
     if (!objectName || typeof objectName !== 'string') {
       throw new Error('Invalid object name');
     }
-    
-    console.log(`[DataSource] Getting schema for ${objectName}`);
+
     // Return a minimal schema for mock purposes
     return {
       name: objectName,

--- a/packages/sdui-parser/scripts/gen-manifest.ts
+++ b/packages/sdui-parser/scripts/gen-manifest.ts
@@ -23,5 +23,4 @@ export function buildArtifacts(outDir: string): void {
   writeFileSync(`${outDir}/sdui.manifest.json`, JSON.stringify(manifest, null, 2));
   writeFileSync(`${outDir}/sdui-intrinsics.d.ts`, generateDts(manifest));
   writeFileSync(`${outDir}/sdui-blocks.md`, generateBlockList(manifest));
-  console.log(`wrote ${Object.keys(manifest.components).length} public blocks -> ${outDir}`);
 }

--- a/packages/sdui-parser/verify.ts
+++ b/packages/sdui-parser/verify.ts
@@ -16,11 +16,8 @@ const manifest = manifestFromConfigs([
   ] },
 ]);
 
-let passed = 0;
-const check = (name: string, fn: () => void) => {
+const check = (_name: string, fn: () => void) => {
   fn();
-  passed++;
-  console.log(`  ok  ${name}`);
 };
 
 check('compiles valid JSX → tree + requires + bindings', () => {
@@ -70,5 +67,3 @@ check('codegen emits a JSX.IntrinsicElements augmentation', () => {
   assert.ok(dts.includes('pageSize?: number;'));
   assert.ok(dts.includes('direction?: "row" | "col";'));
 });
-
-console.log(`\n${passed} checks passed.`);

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -18,8 +18,6 @@ let previewProvider: PreviewProvider | undefined;
  * Extension activation entry point
  */
 export function activate(context: vscode.ExtensionContext) {
-  console.log('Object UI extension is now active!');
-
   // Initialize providers
   const schemaValidator = new SchemaValidator();
   const completionProvider = new CompletionProvider();


### PR DESCRIPTION
Fixes #4029

## What

Adds `no-console: ['error', { allow: ['warn', 'error'] }]` to the repo-root
`eslint.config.js`, so a module- or function-scope `console.log`/`info`/
`debug` fails CI instead of shipping silently the way
`console.log('Registering object-map...')` did in #7139 — caught only by a
human reading the diff, since `pnpm lint` had nothing to say about it.

## Adjudication trail (both rulings on the claim comment thread)

1. **Original delegated adjudication** (claim comment): adopt the card's own
   suggested shape, overrides exempting `scripts/**`, test files, and
   `examples/**`; measure first, clean a ≤~20-hit mechanical residue in this
   PR, report a larger one as a fork instead of absorbing it.
2. **Measured result**: the literal exemption list left **235** real hits —
   193 (82%) in `packages/cli` + `packages/create-plugin` (CLI tools whose
   entire job is stdout), 18 in per-package `examples/` dirs the
   root-anchored glob never reached, and 24 more including two files that
   are the repo's actual debug/logger infrastructure. Reported as
   `needs_decision` per the ruling's own stop condition instead of guessing
   at the scope boundary.
3. **Supplemental ruling** (this PR implements it): adopt recommendation A —
   three additive, invariant-preserving carve-outs (below), line-level
   `eslint-disable` + comment on the two debug/logger-infrastructure files
   (no separate resolution of the debug-channel question, #4029's own Q2,
   which stays deliberately unbundled), individually judge the remaining
   real residue as delete-vs-promote-to-warn/error, land the rule as
   `error`, full-repo `pnpm lint` green.

## The three additive carve-outs

- `packages/cli/src/**` and `packages/create-plugin/src/**` — CLI tools
  whose entire job is terminal stdout/stderr. Running a bin is not
  "importing a package and getting console noise you didn't ask for" — the
  #7139 bug class this rule exists to net. (`@object-ui/cli`'s `index.ts`
  does re-export `serve`/`init` for programmatic use, but their console
  output is the documented behavior of calling them, not an accidental
  module-scope leak.)
- `**/examples/**` widened from the root-anchored `examples/**` — measured
  18 of the 235 hits in `packages/types/examples/*.ts` alone, a
  per-package examples directory the original glob never reached despite
  being the same kind of documentation-code surface as root `examples/**`.

## The two debug/logger-infrastructure carve-outs (line-level, commented)

- `packages/core/src/utils/debug.ts` — `debugLog`/`debugTime`/
  `debugTimeEnd`, the repo's opt-in debug channel (gated behind
  `globalThis.OBJECTUI_DEBUG`). This IS the facility #4029's own Q2 asked
  about — a `eslint-disable-next-line no-console` with a one-line comment
  is the resolution for this card; the design question of whether the repo
  needs a *different* debug channel stays open and unbundled.
- `packages/data-objectstack/src/index.ts`'s `createQuietHttpLogger` — a
  Logger-interface implementation whose methods deliberately forward to the
  matching `console.*` method (that IS the function's job).

## Remaining 17 real residue sites — individually judged

Rule applied consistently: **promote** to `console.warn`/`console.error`
only where the message diagnoses a real anomaly (matches the pre-existing
house convention in `plugin-map/src/ObjectMap.tsx` and
`core/src/registry/Registry.ts`); **delete** pure success/placeholder
narration that explains nothing going wrong.

Promoted (2):
- `packages/app-shell/src/views/ObjectDataPage.tsx:142` — `console.debug` →
  `console.warn`. Explains a real anomaly: a saved-view URL filter was
  silently dropped because it has no canonical `ViewFilterRule` form.
- `packages/plugin-detail/src/DetailView.tsx:690` — `console.log` →
  `console.error` inside a `.catch()`. A real Web Share API failure, not
  debug noise.

Deleted (15) — all confirmed to be happy-path narration with no diagnostic
content:
- `apps/site/app/components/ObjectUIProvider.tsx:25` — removed the whole
  `setTimeout` block (its only purpose was this log); the now-unused
  `ComponentRegistry` import is removed too.
- `packages/fields/src/widgets/MasterDetailField.tsx:46` — `handleView`
  stub; param renamed `_item` per the repo's existing
  `argsIgnorePattern: '^_'` convention.
- `packages/plugin-detail/src/DetailView.tsx:694` — redundant "Link copied
  to clipboard" success log.
- `packages/plugin-gantt/demo/main.tsx:599,601` — demo-only
  `onLayoutChange`/`onTaskClick` echo logs (this file is `demo/`, not
  `src/`, so it carries no changeset).
- `packages/runner/src/App.tsx:94,99` — loader-selection debug prints
  (emoji-prefixed, informal style inconsistent with the house
  `[Component]`-prefixed diagnostic convention).
- `packages/runner/src/LayoutRenderer.tsx:309` — an unwired
  `// Handle click logic` stub's log.
- `packages/runner/src/lib/mockDataSource.ts:23,38,63` — `find`/`create`/
  `getObjectSchema` per-call narration in the demo mock adapter; unused
  params renamed `_resource`/`_params` per the file's own existing
  convention (see `findOne`/`update`/`delete` already using it).
- `packages/sdui-parser/scripts/gen-manifest.ts:26` — build-completion
  message in an unwired, `dist`-excluded dev script (`scripts/` here is a
  per-package dir, not root `scripts/**`, so no changeset is required —
  the change is outside every published package's `src/`).
- `packages/sdui-parser/verify.ts:23,74` — a standalone `tsx`-run
  verification script's per-check "ok" line and final "N checks passed"
  summary; its `assert.*` calls still throw on a real failure regardless,
  so the tool's actual verification value is unaffected. Same "not under
  `src/`, no changeset" note as `gen-manifest.ts`.
- `packages/vscode-extension/src/extension.ts:21` — "extension is now
  active!" activation log.

## Changesets

- `.changeset/no-console-lint-rule.md` — patch for the five published
  packages with a real behavior change (`@object-ui/app-shell`,
  `@object-ui/fields`, `@object-ui/plugin-detail`, `@object-ui/runner`,
  `object-ui`).
- `.changeset/no-console-debug-infra-comments.md` — empty frontmatter for
  `@object-ui/core` and `@object-ui/data-objectstack` (comment-only,
  zero behavior change).
- `packages/plugin-gantt` and `@object-ui/sdui-parser` carry no changeset:
  every file touched in each (`demo/main.tsx`; `scripts/gen-manifest.ts`,
  `verify.ts`) sits outside that package's `src/`, which is the guarded
  surface `scripts/check-changeset-presence.mjs` uses by design (see that
  script's own header on why `src/**` only).
- Read back with `node scripts/check-changeset-presence.mjs` — passes.

## Verification

- Full-repo hit census (both stages) run under the shared
  `/tmp/os-heavy-verify.lock`; commands and counts are in the linked issue
  comment / dev report.
- `pnpm exec eslint .` — 0 errors, 10353 pre-existing warnings unrelated to
  this change (previously 235 `no-console` hits before this PR's per-site
  cleanup), confirmed green at HEAD `ab8d59d08` (this PR's tip).
- Positive control: added a temporary module-scope `console.log(...)` to
  `packages/core/src/index.ts` (not committed), confirmed
  `pnpm exec eslint packages/core/src/index.ts` goes red with exactly the
  expected `no-console` message, then reverted (`git diff` empty
  afterward).
- `pnpm --filter` run type-check, package name substituted — green for all nine touched
  packages (`app-shell`, `core`, `data-objectstack`, `fields`,
  `plugin-detail`, `plugin-gantt`, `runner`, `sdui-parser`,
  `object-ui`/vscode-extension).
- `pnpm exec vitest run` scoped to the touched packages plus
  `packages/plugin-map/src/index.registration.test.tsx` (the sibling
  "import must not write console noise" pin from #4007/#7139), run in two
  passes: **618 test files / 7628 tests** for `app-shell` + `core` +
  `data-objectstack` + `fields` (1 pre-existing pinned test initially failed
  — `ObjectDataPage.saveAsViewFilterFold.test.ts` asserted the pre-promotion
  `console.debug` call; fixed to assert `console.warn` and re-verified
  green), and **86 test files / 806 tests** for `plugin-detail` + `runner` +
  the `plugin-map` pin, all green including
  `registers its components without printing to the console`.
- `node scripts/check-changeset-presence.mjs` and
  `node scripts/check-changeset-no-major.mjs` — both green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_