### PR TITLE
docs(accordion): rewrite Schema block to match the real AccordionSchema/AccordionItem interface

### DIFF
--- a/content/docs/components/disclosure/accordion.mdx
+++ b/content/docs/components/disclosure/accordion.mdx
@@ -13,13 +13,21 @@ only — the rest of the accordion stays interactive.
 ## Schema
 
 ```plaintext
+interface AccordionItem {
+  value: string;                        // Unique item identifier
+  title: string;                        // Item title/trigger
+  content: SchemaNode | SchemaNode[];   // Item content
+  disabled?: boolean;                   // Disables this item only
+}
+
 interface AccordionSchema {
   type: 'accordion';
-  items: Array<{
-    title: string;
-    content: string | SchemaNode;
-  }>;
-  defaultOpen?: number[];
-  multiple?: boolean;
+  items: AccordionItem[];
+  accordionType?: 'single' | 'multiple';    // Selection mode; default 'single'
+  collapsible?: boolean;                    // Whether items can be collapsed; default true
+  defaultValue?: string | string[];         // Default expanded item value(s)
+  value?: string | string[];                // Controlled expanded item value(s)
+  onValueChange?: (value: string | string[]) => void;
+  variant?: 'default' | 'bordered' | 'separated';  // default 'default'
 }
 ```


### PR DESCRIPTION
Fixes #4722

## What changed

`content/docs/components/disclosure/accordion.mdx`'s "Schema" code block taught a
fictional shape that never existed on the real interface. Rewrote it to match
`packages/types/src/disclosure.ts`'s `AccordionSchema`/`AccordionItem` field-for-field,
post-#4723 (which retired `icon`):

| Docs said (before) | Reality (`packages/types/src/disclosure.ts`) |
|---|---|
| `items: Array< { title, content } >` | `items: AccordionItem[]` — `AccordionItem` requires `value: string` (missing from docs entirely) |
| `content: string \| SchemaNode` | `content: SchemaNode \| SchemaNode[]` |
| `defaultOpen?: number[]` | doesn't exist — real key is `defaultValue?: string \| string[]` |
| `multiple?: boolean` | doesn't exist — real key is `accordionType?: 'single' \| 'multiple'` |
| (missing) | `collapsible?: boolean`, `value?: string \| string[]`, `onValueChange?: (value) => void`, `variant?: 'default' \| 'bordered' \| 'separated'`, item-level `disabled?: boolean` |

`defaultOpen`/`multiple` never existed on the real interface — this was an early draft of
the component that was never updated as the interface evolved, not a two-name rename.

## Same-page drift sweep

Per the card's sweep instruction, checked every other code block on the page. The page has
exactly one other block: the `SchemaExample` demo component (id
`components-disclosure-accordion/basic-accordion`), which is a live-rendered demo, not an
inline fenced code block, and the prose above it ("The second item sets `disabled: true`
...") is already accurate against the real, now-honored `AccordionItem.disabled`. No
further drift found on this page.

## Out of scope (filed, not fixed here)

While reading the renderer to confirm the real interface, found that the schema-catalog's
own `basic-accordion.json` — the JSON backing that `SchemaExample` demo — omits the
required `value` key on every item, silently tolerated by a renderer-side fallback
(`item.value || item-${index}`). Different file, different defect class (a required-key
omission in an authored example vs. this card's stale-prose-in-docs), so filed separately
rather than folded in here: #4726.

## Verification

Docs-only change (`content/`), no interface/renderer edits, no `content/docs/releases/`
touched.

- `node scripts/check-doc-links.mjs` — `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` — `OK (scanned 4250 tracked text file(s); skipped 85 binary).`
- `node scripts/check-changeset-presence.mjs` — `No source of a released package changed in this range, so no changeset is owed.` (`content/` is not under a released package's `src/`; no changeset added, per the gate's own verdict.)

All three re-run at the final commit, HEAD `9e4735e5f`.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_
