### PR TITLE
fix(components): wire item-level icon into page:accordion trigger

### DIFF
--- a/.changeset/page-accordion-item-icon.md
+++ b/.changeset/page-accordion-item-icon.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/components': patch
+---
+
+`page:accordion` now renders an item's `icon` in its panel trigger.
+
+`PageAccordionItem` (`packages/components/src/renderers/layout/containers.tsx`)
+has always declared `icon?: string`, but `PageAccordionRenderer` never read it
+— an authored icon reached the trigger and was silently dropped. The
+`objectstack` spec's `PageAccordionProps.items[].icon` already treats this as
+legitimate, undeprecated authorable surface (unlike the neighboring `value`
+key, which the same schema explicitly flags as dead), so the renderer was the
+side out of sync. It now renders the Lucide icon before the panel label,
+following the same convention `page:tabs` items already use in this file.

--- a/packages/components/src/__tests__/page-accordion-icon.test.tsx
+++ b/packages/components/src/__tests__/page-accordion-icon.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `page:accordion` honors item-level `icon` (objectui#4721).
+ *
+ * The local `PageAccordionItem` interface (`renderers/layout/containers.tsx`)
+ * has always declared `icon?: string`, but `PageAccordionRenderer` read only
+ * `label`/`collapsed`/`children` — an authored icon reached the trigger and
+ * was silently dropped. Same defect *shape* as objectui#4632/#4652
+ * (`AccordionItem.icon`/`.disabled`), a different component: `page:accordion`
+ * (namespace `page`, a layout container) vs. `ui:accordion` (namespace `ui`,
+ * the disclosure primitive `AccordionItemSchema` declares).
+ *
+ * That sibling case retired `icon` after measuring zero pull anywhere,
+ * including the `objectstack` corpus. This one measured the same zero pull
+ * in objectui's own catalog/docs/apps — but the `objectstack` sibling
+ * checkout tells a different story: `packages/spec/src/ui/component.zod.ts`
+ * declares `PageAccordionProps.items[].icon` as `z.string().optional()`,
+ * added 2026-08-13 (`6b441a8`), the SAME schema block that goes out of its
+ * way to explain why the neighboring `value` key is deliberately NOT
+ * declared (an extensive comment citing containers.tsx:793 and objectui#7973)
+ * — `icon` carries no such warning. The spec, the more authoritative side of
+ * this contract (AGENTS.md #0/#0.1), already treats `icon` as legitimate,
+ * undeprecated authorable surface; the renderer was the side out of sync.
+ * Per #0.1 ("is this spec-compliant? if so, fix it at the renderer"), the fix
+ * is to wire the read, not delete the declaration — deleting it would only
+ * widen the objectui/spec gap this defect already is.
+ *
+ * Follows the `page:tabs` sibling trigger's established icon convention
+ * (same file, `mr-1.5 h-3.5 w-3.5 shrink-0 opacity-70` + `aria-hidden`):
+ * icon optional, rendered before the label, absent when not declared.
+ *
+ * `../lib/lazy-icon` is mocked to a plain `<svg>` carrying the resolved name
+ * as a data attribute — the same technique `record-alert.test.tsx` uses —
+ * so the assertion is about "the renderer forwarded this icon name to
+ * LazyIcon", not about `lucide-react/dynamic.mjs`'s own chunk-loading path,
+ * which is neither this renderer's contract nor worth the async flakiness
+ * budget (AGENTS.md 测试纪律).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+vi.mock('../lib/lazy-icon', () => ({
+  LazyIcon: ({ name, className }: { name?: string; className?: string }) => (
+    <svg data-testid="page-accordion-icon" data-name={name} className={className} />
+  ),
+}));
+
+const textChild = (content: string) => [{ type: 'element:text', properties: { content } }];
+
+const accordionSchema = (items: any[]) => ({ type: 'page:accordion', id: 'acc', items });
+
+function renderAccordion(items: any[]) {
+  return render(<SchemaRenderer schema={accordionSchema(items)} />);
+}
+
+afterEach(() => cleanup());
+
+describe('page:accordion item icon (objectui#4721)', () => {
+  it('renders the declared Lucide icon name for the panel that authors it', () => {
+    const { getAllByTestId } = renderAccordion([
+      { label: 'Details', icon: 'user', children: textChild('DETAILS BODY') },
+      { label: 'Notes', children: textChild('NOTES BODY') },
+    ]);
+
+    const icons = getAllByTestId('page-accordion-icon');
+    expect(icons).toHaveLength(1);
+    expect(icons[0].getAttribute('data-name')).toBe('user');
+  });
+
+  it('renders no icon element for a panel that does not declare one (positive control)', () => {
+    const { getAllByTestId } = renderAccordion([
+      { label: 'Alpha', icon: 'settings', children: textChild('ALPHA BODY') },
+      { label: 'Beta', children: textChild('BETA BODY') },
+      { label: 'Gamma', icon: 'star', children: textChild('GAMMA BODY') },
+    ]);
+
+    // Exactly the two panels that declared an icon get one — proves the icon
+    // is forwarded per-item, not accordion-wide.
+    const icons = getAllByTestId('page-accordion-icon');
+    expect(icons.map((el) => el.getAttribute('data-name'))).toEqual(['settings', 'star']);
+  });
+
+  it('still renders every panel label alongside its icon', () => {
+    const { getByText } = renderAccordion([
+      { label: 'Details', icon: 'user', children: textChild('DETAILS BODY') },
+      { label: 'Notes', children: textChild('NOTES BODY') },
+    ]);
+
+    expect(getByText('Details')).toBeInTheDocument();
+    expect(getByText('Notes')).toBeInTheDocument();
+  });
+
+  it('renders no icon element at all when no panel declares one', () => {
+    const { queryByTestId } = renderAccordion([
+      { label: 'Details', children: textChild('DETAILS BODY') },
+      { label: 'Notes', children: textChild('NOTES BODY') },
+    ]);
+
+    expect(queryByTestId('page-accordion-icon')).toBeNull();
+  });
+});

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -805,7 +805,23 @@ const PageAccordionRenderer: React.FC<any> = ({ schema, className, ...props }) =
   const commonChildren = itemsWithValue.map((item) => (
     <AccordionItem key={item.value} value={item.value} className={itemClass}>
       <AccordionTrigger className="text-sm font-semibold tracking-tight hover:no-underline">
-        {item.labelStr}
+        {/* One wrapping element, not two siblings — AccordionTrigger's
+            underlying primitive (`ui/accordion.tsx`, no-touch zone) lays its
+            children out with `justify-between` against the auto-appended
+            ChevronDown, so an icon + label passed as separate flex children
+            would be spread apart instead of grouped (same pattern as the
+            `page:tabs` trigger below, minus this wrapper — that trigger's
+            own class list uses `justify-center`, not `justify-between`). */}
+        <span className="flex items-center gap-1.5">
+          {item.icon && (
+            <LazyIcon
+              name={item.icon}
+              className="h-3.5 w-3.5 shrink-0 opacity-70"
+              aria-hidden
+            />
+          )}
+          <span>{item.labelStr}</span>
+        </span>
       </AccordionTrigger>
       <AccordionContent>{renderChildren(item.children)}</AccordionContent>
     </AccordionItem>
@@ -844,7 +860,7 @@ ComponentRegistry.register('accordion', PageAccordionRenderer, {
   category: 'layout',
   isContainer: true,
   inputs: [
-    { name: 'items', type: 'array', label: 'Panels', required: true, description: 'Panel definitions [{ label, collapsed?, children }] — collapsed: false opens a panel by default' },
+    { name: 'items', type: 'array', label: 'Panels', required: true, description: 'Panel definitions [{ label, icon?, collapsed?, children }] — collapsed: false opens a panel by default' },
     { name: 'allowMultiple', type: 'boolean', label: 'Allow Multiple Open', defaultValue: false },
     { name: 'variant', type: 'enum', label: 'Variant', enum: ['flush', 'card'], defaultValue: 'flush' },
   ],


### PR DESCRIPTION
Fixes #4721

`PageAccordionItem` (`packages/components/src/renderers/layout/containers.tsx:771-776`)
declared `icon?: string`, but `PageAccordionRenderer` read only `label`/`collapsed`/
`children` — an authored icon reached the trigger and was silently dropped. Same defect
*shape* as objectui#4632/#4652 (`AccordionItem.icon`/`.disabled`), a different component:
`page:accordion` (namespace `page`, a layout container) vs. `ui:accordion` (namespace `ui`,
the disclosure primitive `AccordionItemSchema` declares).

## Premise re-verified, and it changed the disposition

Mechanism assumption 1 held: `PageAccordionRenderer` never reads `item.icon` (confirmed
against `origin/main` at `56070921b`). Mechanism assumption 2 ("no Zod mirror, so this may
be a two-surface case") did **not** hold as stated: the objectui-local interface has no
Zod mirror in *this* repo, but the `objectstack` sibling repo's spec —
`packages/spec/src/ui/component.zod.ts`, `PageAccordionProps.items[].icon` — already
declares `icon: z.string().optional()`. That block was added 2026-08-13 (`6b441a8`) by the
same author who, in the same schema, wrote an extensive comment explaining why the
neighboring `value` key is deliberately **NOT** declared (citing `containers.tsx:793` and
objectui#7973 by line number). `icon` carries no such warning — the spec treats it as
legitimate, undeprecated authorable surface.

Per AGENTS.md #0.1 ("is this spec-compliant? if so, fix it at the renderer — do not add a
lenient fallback, and change the spec only when it is genuinely wrong"), a spec-declared,
undeprecated key that the renderer drops is the renderer's bug to fix, not a declaration to
delete. Retiring the local interface field would only have widened the objectui/spec gap
this defect already is, and would need a spec-side change in a sibling repo that is out of
this issue's scope (`@objectstack/spec` is not edited from this repo — AGENTS.md #0).

**Full corpus sweep** (re-verified independently of the filing issue's own sweep):
schema catalog (`examples/schema-catalog`), docs (`content/docs`), `apps/console`,
`apps/site`, and this repo's `objectstack` sibling checkout (source, tests, spec) — zero
sites author `icon` on a `page:accordion` item anywhere. That measured-pull result matches
the filing issue's prediction, but the spec's own deliberate, undeprecated declaration
outweighs a zero-authoring measurement the same way objectui#4652's `disabled` key did
(wired despite zero pull, because established convention already backed it) — here the
"established convention" is the authoritative spec contract itself, landed two days ago.

**Disposition: wire, not retire.**

## The fix

`PageAccordionRenderer`'s trigger now renders `item.icon` via `LazyIcon`, following the
`page:tabs` sibling trigger's established convention in the same file (same
`h-3.5 w-3.5 shrink-0 opacity-70` sizing, `aria-hidden`). One wrapping span element groups
the icon+label into a single flex child — `AccordionTrigger`'s underlying primitive
(`ui/accordion.tsx`, no-touch zone, untouched here) lays its children out with
`justify-between` against its own auto-appended `ChevronDown`, so icon and label passed as
two separate top-level children would have been spread apart instead of grouped (`page:tabs`
avoids this because its own trigger class list uses `justify-center`, not `justify-between`,
and has no auto-appended sibling).

Also updated the `items` input's `description` string (registry metadata surfaced to the
Studio inspector) to list `icon?` in the bracket shape, matching `page:tabs`'s own
description. No change to `packages/app-shell/.../block-config.ts` (the visual designer's
`itemFields` for `page:accordion.items` — currently `value`/`label` only) — adding an
`icon` field there is a separate, designer-surface concern out of this card's scope.

## Surfaces changed

- `packages/components/src/renderers/layout/containers.tsx` — `PageAccordionRenderer`
  trigger renders `item.icon`; `items` input description mentions `icon?`.
- `packages/components/src/__tests__/page-accordion-icon.test.tsx` — new behavior tests.

No `@object-ui/types` / Zod mirror change: `PageAccordionItem` is a page-container-local
interface (not a `@object-ui/types` export) and already declared `icon?: string` — nothing
to add there.

## Tests, all at `e8d5f5b71`

Full verification ran **after** the final commit, tree clean.

- New: `packages/components/src/__tests__/page-accordion-icon.test.tsx` — renders the
  declared icon name for the panel that authors it; renders icons for exactly the panels
  that declare one (per-item, not accordion-wide) with a positive control; still renders
  every panel label; renders no icon element at all when none is declared.
  `../lib/lazy-icon` is mocked to a plain svg stub carrying the resolved name as a
  `data-name` attribute (same technique `record-alert.test.tsx` uses) so the assertion is
  about the renderer forwarding the icon name, not about `lucide-react/dynamic.mjs`'s own
  chunk-loading path.
- `pnpm exec vitest run --maxWorkers=2 packages/components/` — **130 files / 1116 tests
  passed**.
- `pnpm exec vitest run --maxWorkers=2 apps/console/src/__tests__/registry-inputs-spec-parity.test.ts apps/console/src/__tests__/public-contract.test.ts`
  — **2 files / 64 tests passed** (the `items` input's `name` set is unchanged; only its
  description string grew, which these parity tests don't assert on).
- `pnpm --filter '@object-ui/components^...' build` (dependency closure) then
  `pnpm --filter @object-ui/components type-check` — clean.
- `pnpm check:phantom-deps`, `pnpm check:spec-symbols` — both green (pre-existing
  untriaged-collision/unbacked-claim counts unaffected by this diff).
- `node scripts/check-control-bytes.mjs`, `node scripts/check-changeset-presence.mjs`,
  `node scripts/check-changeset-no-major.mjs` — all green.
- `pnpm exec eslint packages/components/src/renderers/layout/containers.tsx
  packages/components/src/__tests__/page-accordion-icon.test.tsx` — 0 errors, 87
  pre-existing `no-explicit-any`/fast-refresh warnings elsewhere in the file, none on the
  changed lines.

**Reverse verification** (direction predicted before running: the two icon-asserting tests
red, the two icon-agnostic tests green): committed the fix first, then ablated the render
(dropped the `LazyIcon` block, kept the plain label span), reran the same test file.
Observed exactly that — `renders the declared Lucide icon name...` and `renders no icon
element for a panel that does not declare one (positive control)` failed (`getAllByTestId`
found 0 elements); `still renders every panel label alongside its icon` and `renders no icon
element at all when no panel declares one` stayed green (2 failed / 2 passed). Restored with
`git checkout claude/issue-4721-page-accordion-icon -- packages/components/src/renderers/layout/containers.tsx`,
confirmed byte-clean (`git status --porcelain` empty), reran the full file green (4/4).

## Notes

- Changeset marks `patch` for `@object-ui/components`: purely additive rendering behavior
  for an already-declared, already-optional key — no existing authored schema changes
  meaning, nothing was reading `icon` before so nothing regresses.
- Did not touch `AccordionItem`/`ui:accordion` (objectui#4632/#4652's settled surface) or
  `content/docs/releases/`.
- Not filing a new upstream issue against the `objectstack` spec's `PageAccordionProps`
  declaration: the spec's `icon` declaration is exactly what this PR now honors, so there
  is nothing to flag there — the mismatch it created is what this PR closes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_