### PR TITLE
fix(examples): add required value keys to basic-accordion.json items

### DIFF
--- a/examples/schema-catalog/src/schemas/components-disclosure-accordion/basic-accordion.json
+++ b/examples/schema-catalog/src/schemas/components-disclosure-accordion/basic-accordion.json
@@ -2,15 +2,18 @@
   "type": "accordion",
   "items": [
     {
+      "value": "section-1",
       "title": "Section 1",
       "content": "Content for section 1"
     },
     {
+      "value": "section-2",
       "title": "Section 2",
       "content": "Content for section 2",
       "disabled": true
     },
     {
+      "value": "section-3",
       "title": "Section 3",
       "content": "Content for section 3"
     }


### PR DESCRIPTION
Fixes #4726

## What changed

`examples/schema-catalog/src/schemas/components-disclosure-accordion/basic-accordion.json`'s
three items all omitted `value`, which `AccordionItemSchema` (`packages/types/src/zod/
disclosure.zod.ts`) and the `AccordionItem` TS interface (`packages/types/src/disclosure.ts`)
both declare as a required `string` (no `.optional()`, no `?`). Added a semantic-slug `value`
to each item, matching its `title`:

```json
{ "value": "section-1", "title": "Section 1", "content": "Content for section 1" }
{ "value": "section-2", "title": "Section 2", "content": "Content for section 2", "disabled": true }
{ "value": "section-3", "title": "Section 3", "content": "Content for section 3" }
```

## Sweep — every accordion-shaped entry in the catalog

`grep -rl '"type": "accordion"' examples/schema-catalog/src/schemas/` returns exactly one
file: `components-disclosure-accordion/basic-accordion.json`. That is the only catalog entry
of this type, so no sibling entries carried the same omission. For comparison, the sibling
`components-disclosure-toggle-group/*.json` entries — same `value: z.string()` (no
`.optional()`) requirement on `ToggleGroupItemSchema` — already supply `value` on every item,
so this file was the one outlier.

## Renderer fallback — reading only, not touched

`packages/components/src/renderers/disclosure/accordion.tsx:23` falls back to
`item.value || \`item-${index}\`` when `value` is missing, which is why the un-fixed example
still rendered without error. Per the dispatched scope this PR does **not** touch the
renderer; whether that fallback should tighten (reject/warn on a missing `value` instead of
synthesizing one) is a separate contract question for another card.

## Schema-validation guard — none exists yet for this category

Unlike `plugin-dashboard` (which objectui#4356 gave a dedicated
`plugin-dashboard-global-filters-spec.test.ts` that runs entries through the real
`GlobalFilterSchema`), the `components-disclosure-accordion` category has no equivalent
`AccordionItemSchema`-backed test today — `examples/schema-catalog/test/smoke.test.tsx` only
asserts each entry is an object with a non-empty `type` string (structural, by its own
header). This PR does not add that guard (out of scope for this S-sized card per the
dispatch); recorded here as a reading, not acted on.

## Verification

Reverse-checked both directions against the real built `AccordionSchema`/
`AccordionItemSchema` from `@object-ui/types/zod`:
- The fixed file's items all `safeParse` successfully against `AccordionItemSchema` and the
  whole schema parses against `AccordionSchema`.
- The original (pre-fix) item shape (`{ title, content }`, no `value`) fails with
  `[value] Invalid input: expected string, received undefined` — confirming the premise and
  that the fix addresses exactly that gap.

```
pnpm --filter '@object-ui/example-schema-catalog^...' build         # dependency closure
pnpm exec vitest run examples/schema-catalog/ --maxWorkers=2         # 8 files / 1576 tests passed
pnpm --filter '@object-ui/example-schema-catalog' type-check         # clean
pnpm --filter '@object-ui/example-schema-catalog' lint               # 0 errors (2 pre-existing warnings, unrelated)
node scripts/check-control-bytes.mjs                                 # OK
node scripts/check-changeset-presence.mjs                            # no changeset owed
python3 scripts/regenerate-catalog-index.py --check                  # index up to date
```

All re-run at the final commit, HEAD `9468cf79e`.

## Changeset

Not added. `@object-ui/example-schema-catalog` matches the `@object-ui/example-*` glob in
`.changeset/config.json`'s `ignore` list, and `node scripts/check-changeset-presence.mjs`
confirms: "0 of them under the src/ of a package the release covers... No source of a
released package changed in this range, so no changeset is owed."


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_