### PR TITLE
docs(plugin-form): drop the doubled `/**` opener on the foldFormButtons comment

### DIFF
--- a/.changeset/issue-4661-doubled-doc-opener.md
+++ b/.changeset/issue-4661-doubled-doc-opener.md
@@ -1,0 +1,10 @@
+---
+---
+
+Comment-only cleanup in `@object-ui/plugin-form`: the doc comment above `foldFormButtons`
+in `ObjectForm.tsx` opened with two `/**` lines in a row, so the stray second opener was
+rendered as the first line of the JSDoc body. Removed the redundant opener.
+
+Declares no release: `foldFormButtons` is module-private, so it appears in no published
+type declaration, and comments are stripped from the emitted JavaScript — the built output
+is unchanged and no published behaviour differs.

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -80,7 +80,6 @@ export interface ObjectFormComponentProps {
 }
 
 /**
-/**
  * Fold the structured, spec-aligned `buttons`/`defaults` surface
  * (`@objectstack/spec` FormViewSchema; framework#1894 / #2998) down onto the
  * flat renderer props ObjectForm and its variants read


### PR DESCRIPTION
Fixes #4661

Deletes the one redundant `/**` opener line above `foldFormButtons` in `packages/plugin-form/src/ObjectForm.tsx`. The doc comment opened with two `/**` lines in a row, so the stray second opener was rendered as the first line of the JSDoc body.

Nothing was broken and nothing rendered wrong — the card said as much when it filed this as observation-class. The only cost was to a reader meeting a malformed-looking opener and stopping to work out whether a bad merge had eaten something.

## Scope

One line deleted, nothing else in the file touched:

```
 packages/plugin-form/src/ObjectForm.tsx | 1 -
 1 file changed, 1 deletion(-)
```

Anchored by the `foldFormButtons` declaration rather than by line number, as both the card and the dispatch note asked. On this branch's merge-base (`baa89a1ea`) the doubled opener sat at lines 82-83 with the declaration at line 96 — the card recorded line 67 and the dispatch note 82-83, the drift being exactly the churn they predicted.

## Repo-wide sweep: one instance total, zero remaining

Ran the requested cheap repo-wide grep for consecutive `/**` opener lines. **This was the only instance in the repository.** The post-fix sweep over every tracked file returns zero hits, so there is no follow-up finding issue to file — the sweep and the one-file fix happen to coincide here.

The pattern was self-checked before its emptiness was trusted, since an empty grep result is otherwise indistinguishable from a silently broken pattern. Run against the pre-fix `origin/main` blob, the same pattern does report the pair:

```
82:/**
83:/**
```

## Release impact: none, and declared

`node scripts/check-changeset-presence.mjs` requires a changeset for any edit under a released package's `src/`, comment-only or not — it failed this branch until one was added, and its word is final. Complied with the empty-frontmatter form that AGENTS.md defines as the first-class "declares no release" answer, because that is what is true here: `foldFormButtons` is module-private so it reaches no published type declaration, and comments are stripped from the emitted JavaScript, leaving the built output unchanged.

objectui has no `skip-changeset` mechanism, and none was used.

## Gates — all run at head `00825b5a5`, after the final commit

| Gate | Command | Result |
| --- | --- | --- |
| plugin-form tests | `pnpm exec vitest run packages/plugin-form/` | 43 files / 422 tests passed, exit 0 |
| type-check | `pnpm exec turbo run type-check --filter=@object-ui/plugin-form` | 13 tasks successful, exit 0 |
| lint | `pnpm exec turbo run lint --filter=@object-ui/plugin-form` | 2 tasks successful, exit 0 — 0 errors (550 pre-existing `no-explicit-any` warnings, untouched by this diff) |
| changeset presence | `node scripts/check-changeset-presence.mjs` | pass — 1 changeset, empty frontmatter |
| changeset no-major | `node scripts/check-changeset-no-major.mjs` | pass |
| control bytes | `node scripts/check-control-bytes.mjs` | pass — 4249 tracked text files scanned |

Tests were invoked in the repo-root path-filter form AGENTS.md mandates, not `pnpm --filter @object-ui/plugin-form test` — the latter is the documented cwd trap that silently runs another package's suite and reports green.

## Provenance

Recorded while renaming `ObjectFormProps` for #4650 (PR #4660), and deliberately not swept in there. Neither of those is addressed by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_