### PR TITLE
fix(plugin-kanban): the board's row cap reaches the wire as a top-level $top

### DIFF
--- a/.changeset/kanban-row-cap-top-level-top.md
+++ b/.changeset/kanban-row-cap-top-level-top.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-kanban': patch
+'@object-ui/fields': patch
+---
+
+`object-kanban` now caps its fetch with a real top-level `$top`, and honours `limit`.
+
+The board's row cap was written `dataSource.find(objectName, { options: { $top: 100 }, $filter: … })`
+— `$filter` at the top level, where the adapters read it, and the cap one level
+down under `options`, which is not a `QueryParams` key. Nothing in this repo
+reads `params.options` (`convertQueryParams` in `@object-ui/data-objectstack` and
+`ApiDataSource` both read `params.$top`), so the intended cap never reached the
+wire: a board over a large object fetched every row the server would return and
+grouped all of it into lanes client-side. The author's 100 was never live.
+
+The cap is now `$top: schema.limit ?? 100`, the shape `object-timeline` took for
+the identical defect. Two consequences worth reading before upgrading:
+
+- **A board that used to fetch unbounded now fetches 100 rows by default.** That
+  is the previously-declared intent taking effect, not a new limit — but a board
+  over an object with more than 100 matching records will show fewer cards than
+  it did. Authors who want the old behaviour should declare the window they
+  actually want (`limit: 500`), not rely on the absence of one.
+- **`limit` is now mapped from the `dataSource` binding** (`object-kanban`'s
+  `ElementDataSourceMapping` gains `limit: 'limit'`). A board bound to a saved
+  view is capped by that view's `pagination.pageSize`, and the binding's own
+  `limit` overrides it. The flag comes with the read site: it stayed unmapped
+  until now on the rationale that the board had a "fixed window", which is the
+  claim this change falsifies. `sort` remains unmapped — the board still has no
+  `$orderby` read site — and `columns` remains unmapped because a board's columns
+  are its swimlanes, not a field projection.
+
+`KanbanSchema` gains `limit?: number` (the board's row cap; distinct from a
+column's `limit`, which is that lane's WIP limit and never reaches the query),
+and the guide's per-block table in `content/docs/guide/data-source.md` no longer
+claims a fixed window for `object-kanban`.
+
+`@object-ui/fields` carried the same nesting in the lookup-name fallback
+(`find(referenceTo, { $filter: { id }, options: { $top: 1 } })`) where it was
+harmless — a primary-key equality returns at most one row with or without a cap.
+It is spelled `$top: 1` now, so no live instance of the dead nesting is left in
+the repo to read as precedent. No behaviour change there.

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -249,7 +249,7 @@ ignores would be accepted and dropped, which is the defect this binding removes.
 | `element:record_picker` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `record:related_list` | ✅ | columns / filter / sort / limit | ✅ | ✅ | ✅ |
 | `object-calendar` | ✅ | filter / sort | ✅ | ✅ | — no row cap |
-| `object-kanban` | ✅ | filter | ✅ | — no ordering | — fixed window |
+| `object-kanban` | ✅ | filter / limit | ✅ | — no ordering | ✅ (`limit`) |
 | `object-chart` | ✅ | filter | ✅ | — engine orders | — no page |
 | `object-metric` | ✅ | filter | ✅ | — single value | — single value |
 | `object-gantt` | ✅ | filter / sort | ✅ | ✅ | — no row cap |
@@ -300,6 +300,23 @@ came with that:
 - `record:line_items` still does **not** take a view's `columns`: they are editable
   `GridColumn` objects (`{ field, type, … }`) rather than a field-name projection,
   so a view's column list would be the wrong *shape*, not merely a wider answer.
+
+`object-kanban` carried the same nesting, and until objectui#4025 this table read
+`— fixed window` in its `limit` cell. There was no window: the board's cap was
+written `{ options: { $top: 100 } }` — `$filter` at the top level where the
+adapters read it, the cap one level down under a key that is not a `QueryParams`
+field — so a board over a large object fetched every row the server would return
+and grouped all of it into lanes, client-side. The cap is now a real `$top`,
+defaulting to 100, and the `limit` cell is ✅ because the read site exists: a
+`limit` authored on the block, the binding's `limit`, or the named view's
+`pagination.pageSize` all set it. The board's `sort` cell still reads `— no
+ordering` — lanes come from `groupBy` and the fetch declares no `$orderby`, so
+mapping `sort` would be the accepted-and-dropped defect one block over.
+
+Note the two `limit`s on a board are different keys at different levels: the row
+cap above is `limit` on the **board**, while `limit` on a **column** is that
+lane's WIP limit (how many cards it may hold before it warns), which is display
+behaviour and never touches the query.
 
 Remaining gap, recorded rather than papered over:
 

--- a/content/docs/plugins/plugin-kanban.mdx
+++ b/content/docs/plugins/plugin-kanban.mdx
@@ -94,6 +94,7 @@ interface KanbanCard {
 | Property | Type | Description |
 |----------|------|-------------|
 | `columns` | KanbanColumn[] | Array of column definitions |
+| `limit` | number | Rows fetched by an object-driven board (default 100) |
 | `onCardMove` | function | Callback when a card is moved |
 | `className` | string | Additional Tailwind CSS classes |
 
@@ -135,6 +136,31 @@ rendered on each card resolve in priority order:
 
 Defaulting to `highlightFields` keeps a card's contents consistent with the
 object's other views without every kanban view having to re-declare its fields.
+
+### Row cap (object-driven boards)
+
+An object-driven board fetches at most `limit` records, defaulting to **100**. A
+board renders every fetched record into a lane and offers no pagination control,
+so this is the author's window on the object rather than a page size:
+
+```tsx
+{
+  type: 'object-kanban',
+  objectName: 'opportunity',
+  groupBy: 'stage',
+  limit: 250,          // rows fetched; omit for the default 100
+}
+```
+
+The `dataSource` binding sets it too — its own `limit`, or the
+`pagination.pageSize` of the view it names (see
+[Data source](/docs/guide/data-source)).
+
+<Callout type="info">
+  This is the **board's** `limit`, not a column's. `limit` on a *column* is that
+  lane's WIP limit — the card count at which the lane warns — and has no effect
+  on the query.
+</Callout>
 
 ## Examples
 

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -231,9 +231,15 @@ function useLookupName(
         if (typeof (dataSource as any).findOne === 'function') {
           record = await (dataSource as any).findOne(referenceTo, value);
         } else {
+          // Top-level `$top`, not `{ options: { $top: 1 } }` (objectui#4025):
+          // `options` is not a `QueryParams` key and no adapter reads it. Here
+          // the nesting was harmless — the filter is primary-key equality, so
+          // the answer is at most one row with or without a cap — but it is the
+          // same spelling that cost `object-kanban` its row cap, and leaving one
+          // live instance in the repo is what makes the next one look precedented.
           const result = await (dataSource as any).find(referenceTo, {
             $filter: { id: value },
-            options: { $top: 1 },
+            $top: 1,
           });
           const records: any[] = Array.isArray(result)
             ? result

--- a/packages/plugin-kanban/src/ObjectKanban.elementDataSource.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.elementDataSource.test.tsx
@@ -16,14 +16,24 @@
  * A board's `columns` are its SWIMLANES (`{ id, title }` per `groupBy` value),
  * not a field projection. A saved view's `columns: ['name','rating']` written
  * there would render two empty lanes named after fields — a wrong answer that
- * looks like a rendered board. The mapping therefore takes only `object` and
- * `filter`, and the third test pins that the authored lanes survive.
+ * looks like a rendered board. The mapping therefore takes `object`, `filter`
+ * and `limit`, and the third test pins that the authored lanes survive.
+ *
+ * ## The row cap (objectui#4025)
+ *
+ * The board's cap was written `{ options: { $top: 100 } }`: `$filter` at the top
+ * level where the adapters read it, the cap one level down under `options`, which
+ * is not a `QueryParams` key and which no adapter in this repo reads. So the
+ * board had no row cap at all, and `limit` stayed unmapped on the strength of a
+ * "fixed window" that did not exist. The last describe block below pins the cap
+ * as a real top-level `$top` and pins every source that can set it.
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import { DEFAULT_KANBAN_LIMIT } from './ObjectKanban';
 // Registers `object-kanban` (and the ElementDataSourceGate wiring under test).
 import './index';
 // The lane titles asserted below render INSIDE `KanbanRenderer`'s `React.lazy`
@@ -125,7 +135,7 @@ describe('object-kanban — dataSource: { object, view } (objectstack#6953)', ()
     expect(adapter.find).not.toHaveBeenCalled();
   });
 
-  it('leaves a board with NO dataSource exactly as it was', async () => {
+  it('leaves a board with NO dataSource querying its own object and filter', async () => {
     const adapter = makeAdapter();
     renderBlock(
       {
@@ -142,5 +152,89 @@ describe('object-kanban — dataSource: { object, view } (objectstack#6953)', ()
     const [object, params] = adapter.find.mock.calls[0] as [string, any];
     expect(object).toBe('account');
     expect(params.$filter).toEqual([['owner', '=', 'me']]);
+  });
+});
+
+/**
+ * The row cap (objectui#4025).
+ *
+ * Every assertion here also pins the ABSENCE of `params.options`: the defect was
+ * not a wrong number, it was a right number written where nothing reads it, and
+ * a test that only checked `$top` would stay green if someone re-added the dead
+ * nesting beside it.
+ */
+describe('object-kanban — the row cap reaches the wire (objectui#4025)', () => {
+  const firstQuery = async (adapter: ReturnType<typeof makeAdapter>) => {
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    return adapter.find.mock.calls[0] as [string, any];
+  };
+
+  it('caps an uncapped board at the default window, as a REAL $top', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      { type: 'object-kanban', objectName: 'account', groupBy: 'status', columns: LANES },
+      adapter,
+    );
+
+    const [object, params] = await firstQuery(adapter);
+    expect(object).toBe('account');
+    // The number is the one the board always intended; it just reaches the
+    // adapter now (`convertQueryParams` in `@object-ui/data-objectstack` and
+    // `ApiDataSource` both read `params.$top`, neither reads `params.options`).
+    expect(params.$top).toBe(DEFAULT_KANBAN_LIMIT);
+    expect(params.$top).toBe(100);
+    expect(params.options).toBeUndefined();
+  });
+
+  it('honours a `limit` authored directly on the block', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      { type: 'object-kanban', objectName: 'account', groupBy: 'status', columns: LANES, limit: 20 },
+      adapter,
+    );
+
+    const [, params] = await firstQuery(adapter);
+    expect(params.$top).toBe(20);
+    expect(params.options).toBeUndefined();
+  });
+
+  it('takes a named view’s page size as the board’s window', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      {
+        type: 'object-kanban',
+        groupBy: 'status',
+        columns: LANES,
+        dataSource: { object: 'account', view: 'hot' },
+      },
+      adapter,
+    );
+
+    const [object, params] = await firstQuery(adapter);
+    expect(object).toBe('account');
+    // `hot` declares `pagination: { pageSize: 7 }` — a view's row cap.
+    expect(params.$top).toBe(7);
+    // The view's filter still arrives: the cap did not displace it.
+    expect(params.$filter).toEqual([['rating', '=', 'hot']]);
+    expect(params.options).toBeUndefined();
+  });
+
+  it('lets the binding’s own `limit` override the view’s page size', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      {
+        type: 'object-kanban',
+        groupBy: 'status',
+        columns: LANES,
+        dataSource: { object: 'account', view: 'hot', limit: 3 },
+      },
+      adapter,
+    );
+
+    const [, params] = await firstQuery(adapter);
+    // `limit` overrides rather than combines — the binding is the narrower,
+    // more local statement (see `composeElementDataSource`).
+    expect(params.$top).toBe(3);
+    expect(params.options).toBeUndefined();
   });
 });

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -51,6 +51,20 @@ const KANBAN_DEFAULT_TRANSLATIONS: Record<string, string> = {
 };
 
 /**
+ * Rows fetched when the author declared no `limit`.
+ *
+ * The number is the one this board has always intended: until objectui#4025 the
+ * fetch passed `{ options: { $top: 100 } }`, and `options` is not a `QueryParams`
+ * key — no adapter in this repo reads `params.options` (`convertQueryParams` in
+ * `@object-ui/data-objectstack` and `ApiDataSource` both read `params.$top`), so
+ * the cap never reached the wire and a board over a large object fetched whatever
+ * the server chose to return, then grouped all of it into lanes client-side. The
+ * window is now real, and authorable — same shape `object-timeline` took in
+ * objectui#4009 for the identical defect.
+ */
+export const DEFAULT_KANBAN_LIMIT = 100;
+
+/**
  * Safe wrapper for useObjectTranslation that falls back to the English defaults
  * above when no `I18nProvider` is mounted (standalone board, tests).
  * Delegates to `@object-ui/i18n`'s `createSafeTranslation`.
@@ -209,9 +223,15 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
         try {
             // Auto-inject $expand for lookup/master_detail fields
             const expand = buildExpandFields(objectDef?.fields);
+            // The row cap is a REAL `$top` (objectui#4025). It used to be
+            // `{ options: { $top: 100 } }` — `$filter` at the top level where the
+            // adapters read it, the cap one level down under a key that is not a
+            // `QueryParams` field and that nothing in this repo reads. The number
+            // is unchanged; it just reaches the wire now, and `limit` (authored,
+            // or a bound view's `pagination.pageSize`) can set it.
             const results = await dataSource.find(schema.objectName, {
-                options: { $top: 100 },
                 $filter: schema.filter,
+                $top: schema.limit ?? DEFAULT_KANBAN_LIMIT,
                 ...(expand.length > 0 ? { $expand: expand } : {}),
             });
             
@@ -234,7 +254,7 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
         fetchData();
     }
     return () => { isMounted = false; };
-  }, [schema.objectName, dataSource, boundData, schema.data, schema.filter, hasExternalData, objectDef, refreshKey]);
+  }, [schema.objectName, dataSource, boundData, schema.data, schema.filter, schema.limit, hasExternalData, objectDef, refreshKey]);
 
   // Determine which data to use: external -> bound -> inline -> fetched
   const rawData = (hasExternalData ? externalData : undefined) || boundData || schema.data || fetchedData;

--- a/packages/plugin-kanban/src/index.tsx
+++ b/packages/plugin-kanban/src/index.tsx
@@ -369,19 +369,32 @@ ComponentRegistry.register(
 );
 
 /**
- * What `ObjectKanban` reads for its own query: `objectName` and `filter`
- * (`ObjectKanban.tsx`, the `dataSource.find` call — `$filter: schema.filter`).
+ * What `ObjectKanban` reads for its own query: `objectName`, `filter` and
+ * `limit` (`ObjectKanban.tsx`, the `dataSource.find` call — `$filter:
+ * schema.filter`, `$top: schema.limit ?? DEFAULT_KANBAN_LIMIT`).
  *
- * `columns` is deliberately NOT mapped. A board's `columns` are its SWIMLANES
- * (`{ id, title }` per `groupBy` value), not a field projection — writing a
- * saved view's field list there would render a board with one empty lane per
- * field name. Nor is `sort` or `limit`: the board fetches with a fixed
- * `$top: 100` and no ordering, so there is no key to write them to. Mapping
- * either onto something plausible would re-create the defect this wiring
- * removes — a value accepted and dropped — one layer deeper.
+ * `limit` was unmapped until objectui#4025, on the rationale that the board
+ * "fetches with a fixed `$top: 100`, so there is no key to write it to". That
+ * rationale was false in a way nobody could see from here: the cap was written
+ * `{ options: { $top: 100 } }`, and `options` is not a `QueryParams` key — no
+ * adapter reads it, so the window was not fixed, it did not exist. #4025 moved
+ * the cap to a real top-level `$top` and made it read `schema.limit`, so the
+ * flag comes with the read site (the order `object-timeline` did it in, #4009)
+ * and a bound view's `pagination.pageSize` now actually caps the board.
+ *
+ * Still deliberately NOT mapped:
+ *
+ * - `columns` — a board's `columns` are its SWIMLANES (`{ id, title }` per
+ *   `groupBy` value), not a field projection; a saved view's field list written
+ *   there would render one empty lane per field name.
+ * - `sort` — the board has no `$orderby` read site: cards are grouped into lanes
+ *   by `groupBy`, and the fetch declares no ordering. Mapping it onto something
+ *   plausible would re-create the defect this wiring removes — a value accepted
+ *   and dropped — one layer deeper.
  */
 const OBJECT_KANBAN_DATA_SOURCE: ElementDataSourceMapping = {
   filter: true,
+  limit: 'limit',
 };
 
 // Register object-kanban for ListView integration

--- a/packages/plugin-kanban/src/types.ts
+++ b/packages/plugin-kanban/src/types.ts
@@ -78,6 +78,19 @@ export interface KanbanSchema extends BaseSchema {
   data?: any[];
 
   /**
+   * Row cap for the fetch. Defaults to `DEFAULT_KANBAN_LIMIT` (100); a board
+   * renders every fetched record into a lane and has no pagination control, so
+   * this is the author's window rather than a page size. A bound `dataSource`
+   * writes it here too — the binding's own `limit`, or the named view's
+   * `pagination.pageSize`.
+   *
+   * Not to be confused with {@link KanbanColumn.limit}, one level down: that is
+   * a lane's WIP limit (the card count at which the lane warns) and never
+   * reaches the query.
+   */
+  limit?: number;
+
+  /**
    * Array of columns to display in the kanban board.
    * Each column contains an array of cards.
    */


### PR DESCRIPTION
Fixes #4025

`object-kanban` fetched with `find(objectName, { options: { $top: 100 }, $filter: schema.filter })`: `$filter` at the top level where the adapters read it, the row cap one level down under `options`, which is not a `QueryParams` key. Nothing in this repo reads `params.options` — `convertQueryParams` in `@object-ui/data-objectstack` and `ApiDataSource` both read `params.$top` — so the author's 100 never reached the wire. A board over a large object fetched every row the server would return and grouped all of it into lanes client-side.

## What changed

- **`packages/plugin-kanban/src/ObjectKanban.tsx`** — the fetch sends `$top: schema.limit ?? DEFAULT_KANBAN_LIMIT` (100), a real top-level key. `schema.limit` joins the effect's dependency list so a changed window refetches. The default is exported as `DEFAULT_KANBAN_LIMIT` for the test to assert against, matching `DEFAULT_TIMELINE_LIMIT` in `plugin-timeline`; it is not added to the package barrel (neither is the timeline's).
- **`packages/plugin-kanban/src/index.tsx`** — the `ElementDataSourceMapping` gains `limit: 'limit'`. It omitted `limit` on the rationale that "the board fetches with a fixed `$top: 100`, so there is no key to write it to" — the rationale this card falsifies: the window was not fixed, it did not exist. The flag comes with the read site, the order PR #4009 used for `object-timeline`. `sort` stays unmapped (the board still has no `$orderby` read site) and `columns` stays unmapped (a board's columns are its swimlanes, not a field projection); the comment now says which of the three is which and why.
- **`packages/plugin-kanban/src/types.ts`** — `KanbanSchema` gains `limit?: number`, documented as the board's row cap and explicitly distinguished from `KanbanColumn.limit`, one level down, which is a lane's WIP limit and never touches the query.
- **`packages/fields/src/index.tsx`** — the same nesting in the lookup-name fallback, adjudicated harmless on the card. Verified harmless (the filter is `{ id: value }`, primary-key equality, so the answer is at most one row with or without a cap) and taken anyway as the zero-cost top-level move, so **no live instance of the dead spelling is left in the repo** to read as precedent. No behaviour change.
- **Docs** — `content/docs/guide/data-source.md`'s per-block table said `— fixed window` in the `object-kanban` `limit` cell; that is the sentence this card exists to falsify. The cell is now checked, the `view` column lists `filter / limit`, and a paragraph records what was actually wrong and why `sort` still reads `— no ordering`. `content/docs/plugins/plugin-kanban.mdx` documents the board's `limit`, its default, and the collision with a column's WIP `limit`.
- **Changeset** — `plugin-kanban` and `fields`, both patch (`objectui` has no skip-changeset mechanism; `node scripts/check-changeset-presence.mjs` is green on this tree).

## Behaviour change worth reading before merging

A board that previously fetched unbounded now fetches **100 rows by default**. That is the previously-declared intent taking effect rather than a new limit, but a board over an object with more than 100 matching records will show fewer cards than it did today. The changeset says so in those words. Authors who want the old reach should declare the window they want (`limit: 500`), not rely on the absence of one.

Boards hosted inside `ListView` are unaffected: they receive pre-fetched records through the `data` prop and never run this fetch.

## Verification

All commands run from the repo root on `b0fb625fd`, the head of this branch:

- `pnpm exec vitest run packages/plugin-kanban/ packages/fields/ --maxWorkers=2` — `Test Files 104 passed (104)`, `Tests 1493 passed (1493)`.
- `pnpm --workspace-concurrency=2 --filter @object-ui/plugin-kanban --filter @object-ui/fields run type-check` — both `Done` (after `pnpm --filter '@object-ui/fields^...' --filter '@object-ui/plugin-kanban^...' run build`, which a fresh worktree needs before any of this means anything).
- `pnpm --workspace-concurrency=2 --filter @object-ui/plugin-kanban --filter @object-ui/fields run lint` — `0 errors` (103 pre-existing warnings, unchanged).
- `node scripts/check-changeset-presence.mjs`, `node scripts/check-changeset-no-major.mjs`, `node scripts/check-control-bytes.mjs`, `node scripts/check-doc-links.mjs` — all green.

**Reverse verification** (fix committed first, then reverted with `git checkout origin/main -- ...`, then restored from the branch): the four new assertions go **red** — `expected undefined to be 100 / 20 / 7 / 3` — while the four pre-existing tests in the file stay green. So the new tests fail for the reason they claim to and not because the file merely exercises the board.

## Tests

`packages/plugin-kanban/src/ObjectKanban.elementDataSource.test.tsx` gains a describe block with the four sources a window can come from: the default (a real `$top`, not a nested one), a `limit` authored on the block, a bound view's `pagination.pageSize`, and a binding `limit` overriding that view. Every one of them also asserts `params.options` is `undefined` — the defect was a right number written where nothing reads it, so a test that only checked `$top` would stay green if the dead nesting were re-added beside it.

## The card's fourth item, deferred

The suggested mechanical defence (something that makes a third occurrence of `options: { $top: … }` fail CI) is filed as #4734 instead of riding along here. In this repo a new gate is a script plus a pin test in `scripts/__tests__/` plus a step in `ci.yml` — or an `eslint-rules/` rule plus its RuleTester test — and choosing between those two is a real trade-off with different reach. That decision deserves its own review rather than being settled inside a behaviour fix. The follow-up records the AST signature that needs no allowlist, and notes that after this PR the repo is at zero live instances, which is the cheapest moment to install it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_