### PR TITLE
feat(fields,components,i18n): author the spec's $icontains from FilterConditionField

### DIFF
--- a/.changeset/filter-builder-icontains-operator.md
+++ b/.changeset/filter-builder-icontains-operator.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/components': patch
+'@object-ui/fields': patch
+'@object-ui/i18n': patch
+---
+
+FilterConditionField can author the spec's `$icontains` — case-insensitive contains is reachable from the filter UI.
+
+`@objectstack/spec`'s `FieldOperatorsSchema` gained `$icontains` between
+`17.0.0-rc.2` and `rc.5`, and every driver and evaluation face the platform
+ships now executes it. `FilterConditionField` had no builder operator that could
+author it, so the capability was unreachable from the sharing-rule criteria
+builder and sat in that widget's parity test as an explicit `KNOWN_UNREACHABLE`
+entry.
+
+The FilterBuilder gains a `containsCaseInsensitive` operator ("Contains (ignore
+case)", translated in all ten locale packs). `condToMongo` emits
+`{ field: { $icontains: value } }` and `kvToCondition` reads it back, so a saved
+criteria reopens in the visual builder instead of falling into the raw-JSON
+editor. Today's `contains` is unchanged and still emits the case-SENSITIVE
+`$contains`; whether it should have been case-insensitive all along is a product
+question that stays open, and stored filter views keep meaning what they meant.
+
+The fold is ASCII-only by contract — `café` does not match `CAFÉ`.
+
+The new operator is **opt-in per consumer**: `FilterBuilder` takes an
+`extraOperators` prop, and only `FilterConditionField` passes it. The one
+dropdown feeds three at-rest dialects and only the MongoDB-style criteria this
+widget writes can carry the operator — the spec's `VIEW_FILTER_OPERATORS` (saved
+views) and `VALID_AST_OPERATORS` (the live grid's filter AST) have no
+case-insensitive contains, so offering it there would author a filter those
+paths cannot execute. Every other FilterBuilder is unchanged.

--- a/packages/components/src/__tests__/filter-builder-opt-in-operators.test.ts
+++ b/packages/components/src/__tests__/filter-builder-opt-in-operators.test.ts
@@ -1,0 +1,71 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The opt-in half of the FilterBuilder's operator vocabulary (objectui#4023).
+ *
+ * `containsCaseInsensitive` authors the spec's `$icontains`, which the MongoDB-
+ * style `FieldOperatorsSchema` dialect carries and the OTHER two dialects this
+ * one dropdown feeds do not: `VIEW_FILTER_OPERATORS` (what a saved view stores)
+ * and `VALID_AST_OPERATORS` (what the live grid sends) have no case-insensitive
+ * contains at all. Offering it unconditionally would hand users a filter two of
+ * three consumers cannot execute — the same hazard that held objectui#4023
+ * blocked while no driver implemented the operator, moved from the drivers to
+ * this repo's own bridges.
+ *
+ * So the default answer is "not offered", and these tests pin BOTH directions:
+ * withheld unless asked for, and actually reachable once asked for. A gate that
+ * only checked the second would go green on a component that offers everything
+ * to everybody.
+ */
+import { describe, it, expect } from 'vitest';
+import { FILTER_BUILDER_OPERATORS, operatorsForFieldType } from '../custom/filter-builder';
+
+const idsFor = (type: string | undefined, extra?: readonly string[]) =>
+  operatorsForFieldType(type, extra).map((op) => op.value);
+
+describe('FilterBuilder opt-in operators', () => {
+  it('withholds containsCaseInsensitive from a consumer that did not ask', () => {
+    expect(idsFor('text')).not.toContain('containsCaseInsensitive');
+    expect(idsFor(undefined)).not.toContain('containsCaseInsensitive');
+  });
+
+  it('offers it to a text field once the consumer opts in', () => {
+    const ids = idsFor('text', ['containsCaseInsensitive']);
+    expect(ids).toContain('containsCaseInsensitive');
+    // Beside its case-sensitive twin, not instead of it: `contains` keeps its
+    // own row and its own meaning.
+    expect(ids).toContain('contains');
+    expect(ids.indexOf('containsCaseInsensitive')).toBe(ids.indexOf('contains') + 1);
+  });
+
+  it('does not offer it on types whose operators are not string matching', () => {
+    // Opting in widens the TEXT bucket, not every bucket — a number or boolean
+    // field gains no substring operator it never had.
+    for (const type of ['number', 'currency', 'boolean', 'date', 'select', 'lookup']) {
+      expect(idsFor(type, ['containsCaseInsensitive']), type).not.toContain(
+        'containsCaseInsensitive',
+      );
+    }
+  });
+
+  it('ignores an opt-in id that is not an operator at all', () => {
+    // A consumer's typo must not smuggle a row into the dropdown; the operator
+    // list stays the intersection with what this component actually defines.
+    expect(idsFor('text', ['totallyMadeUp'])).toEqual(idsFor('text'));
+  });
+
+  it('counts opt-in ids as operators the builder can draw', () => {
+    // `FILTER_BUILDER_OPERATORS` answers "which ids can this dropdown render",
+    // and the spec→builder parity guards in plugin-view read it that way. An
+    // opt-in operator is drawable, so leaving it out would understate the
+    // vocabulary and let a future spec operator look unreachable when it is not.
+    expect(FILTER_BUILDER_OPERATORS).toContain('containsCaseInsensitive');
+    expect(new Set(FILTER_BUILDER_OPERATORS).size).toBe(FILTER_BUILDER_OPERATORS.length);
+  });
+});

--- a/packages/components/src/custom/filter-builder.tsx
+++ b/packages/components/src/custom/filter-builder.tsx
@@ -66,6 +66,17 @@ export interface FilterBuilderProps {
   onChange?: (value: FilterGroup) => void
   className?: string
   showClearAll?: boolean
+  /**
+   * Opt-in operator ids ({@link OPT_IN_OPERATORS}) this instance may offer, on
+   * top of the ones every FilterBuilder draws.
+   *
+   * The dropdown is shared by consumers that persist a filter into DIFFERENT
+   * dialects, and an operator one dialect can carry is not automatically
+   * storable in another — so whether an opt-in operator is offered is the
+   * consumer's answer, not this component's. See {@link OPT_IN_OPERATORS} for
+   * the measurement that made this a prop instead of one global list.
+   */
+  extraOperators?: readonly string[]
 }
 
 // `label` is the English fallback; the actual rendered text comes from
@@ -75,6 +86,9 @@ const defaultOperators = [
   { value: "equals", label: "Equals" },
   { value: "notEquals", label: "Does not equal" },
   { value: "contains", label: "Contains" },
+  // Case-insensitive `contains` — the spec's `$icontains` (objectui#4023).
+  // OPT-IN: see `OPT_IN_OPERATORS` below for why it is not offered everywhere.
+  { value: "containsCaseInsensitive", label: "Contains (ignore case)" },
   { value: "notContains", label: "Does not contain" },
   { value: "isEmpty", label: "Is empty" },
   { value: "isNotEmpty", label: "Is not empty" },
@@ -100,8 +114,49 @@ const defaultOperators = [
 ] as const
 
 /**
+ * Operator ids the dropdown draws ONLY when the consumer names them in
+ * `extraOperators`. Every other id in `defaultOperators` is offered to every
+ * consumer.
+ *
+ * ## Why an operator would ever be opt-in (objectui#4023)
+ *
+ * This one dropdown feeds three different at-rest dialects, and they do not
+ * accept the same operators:
+ *
+ *   - **MongoDB-style `FieldOperatorsSchema` criteria** — what
+ *     `FilterConditionField` writes into a sharing rule's `criteria_json`,
+ *     evaluated by the server's engine. It has `$icontains`, and every driver
+ *     and evaluation face the platform ships executes it
+ *     (objectstack#5702 + objectstack#6520).
+ *   - **`ViewFilterRule[]`** — what `viewFilterFold` persists for a saved view.
+ *     Its vocabulary is the spec's `VIEW_FILTER_OPERATORS`, which has **no**
+ *     case-insensitive contains, so the rule is refused by the schema's enum.
+ *   - **The array/triplet filter AST** — what `ListView` sends for the live
+ *     grid, via `mapOperator`. Its vocabulary is the spec's
+ *     `VALID_AST_OPERATORS`, which also has no case-insensitive contains: an
+ *     unmapped operator is emitted verbatim and the query comes back broken
+ *     (see `packages/data-objectstack/src/filter-operator-ast-parity.test.ts`
+ *     for what "broken" costs — an unfiltered read or a 400, either way not the
+ *     filter the user asked for).
+ *
+ * So offering `containsCaseInsensitive` to every FilterBuilder would put a
+ * filter in users' hands that two of the three consumers cannot execute —
+ * which is the exact hazard objectui#4023 was held blocked over, relocated from
+ * the drivers to this repo's own bridges. Mapping it onto plain `contains`
+ * there is NOT the alternative: that is a different question silently answered
+ * (the same reason `view-operator-builder-parity.test.ts` refuses to map
+ * `is_null` onto `isEmpty`).
+ *
+ * The lasting fix is upstream — the spec's view and AST vocabularies gaining a
+ * case-insensitive contains — at which point the entry below is deleted and the
+ * operator becomes ordinary. Until then the consumer that CAN store it says so.
+ */
+const OPT_IN_OPERATORS = new Set<string>(["containsCaseInsensitive"])
+
+/**
  * The FilterBuilder's own operator vocabulary — every id its dropdown can
- * hold, derived from the operators it actually renders.
+ * hold, derived from the operators it actually renders. Includes the opt-in
+ * ids: they are drawable, just not offered unconditionally.
  *
  * Exported because several translation tables map an external vocabulary
  * (the spec's `VIEW_FILTER_OPERATORS`, Mongo `$`-tokens) *onto* this one, and
@@ -135,6 +190,7 @@ const useSafeFilterTranslation = createSafeTranslation(
     'filterBuilder.operators.equals': 'Equals',
     'filterBuilder.operators.notEquals': 'Does not equal',
     'filterBuilder.operators.contains': 'Contains',
+    'filterBuilder.operators.containsCaseInsensitive': 'Contains (ignore case)',
     'filterBuilder.operators.notContains': 'Does not contain',
     'filterBuilder.operators.isEmpty': 'Is empty',
     'filterBuilder.operators.isNotEmpty': 'Is not empty',
@@ -158,7 +214,7 @@ const useSafeFilterTranslation = createSafeTranslation(
 )
 
 const NULLNESS_OPERATORS = ["isNull", "isNotNull", "exists", "notExists"]
-const textOperators = ["equals", "notEquals", "contains", "notContains", "startsWith", "endsWith", "isEmpty", "isNotEmpty", ...NULLNESS_OPERATORS]
+const textOperators = ["equals", "notEquals", "contains", "containsCaseInsensitive", "notContains", "startsWith", "endsWith", "isEmpty", "isNotEmpty", ...NULLNESS_OPERATORS]
 const numberOperators = ["equals", "notEquals", "greaterThan", "lessThan", "greaterOrEqual", "lessOrEqual", "isEmpty", "isNotEmpty", ...NULLNESS_OPERATORS]
 const booleanOperators = ["equals", "notEquals"]
 const dateOperators = ["equals", "notEquals", "before", "after", "between", "isEmpty", "isNotEmpty", ...NULLNESS_OPERATORS]
@@ -173,6 +229,40 @@ const dateLikeTypes = ["date", "datetime", "time"]
 const selectLikeTypes = ["select", "status"]
 /** Relational/reference field types that use lookup operators (equals/in/notIn) and render dropdown or checkbox list when options provided */
 const lookupLikeTypes = ["lookup", "master_detail", "user", "owner"]
+
+/**
+ * The operators the dropdown offers for a field of `fieldType`, given the
+ * opt-in ids this instance was granted.
+ *
+ * A pure function rather than a closure so the selection rule — and above all
+ * the {@link OPT_IN_OPERATORS} gate, whose whole job is to keep an operator OFF
+ * the surfaces that cannot store it — is assertable without driving a Radix
+ * popover open in jsdom.
+ *
+ * @internal exported for tests
+ */
+export function operatorsForFieldType(
+  fieldType: string | undefined,
+  extraOperators: readonly string[] = [],
+): ReadonlyArray<{ value: string; label: string }> {
+  const type = fieldType || "text"
+  const bucket = numberLikeTypes.includes(type)
+    ? numberOperators
+    : type === "boolean"
+      ? booleanOperators
+      : dateLikeTypes.includes(type)
+        ? dateOperators
+        : selectLikeTypes.includes(type)
+          ? selectOperators
+          : lookupLikeTypes.includes(type)
+            ? lookupOperators
+            : textOperators
+
+  const granted = new Set(extraOperators)
+  return defaultOperators.filter(
+    (op) => bucket.includes(op.value) && (!OPT_IN_OPERATORS.has(op.value) || granted.has(op.value)),
+  )
+}
 
 /** Normalize a filter value into an array for multi-select scenarios */
 function normalizeToArray(value: FilterBuilderCondition["value"]): (string | number | boolean)[] {
@@ -205,6 +295,7 @@ function FilterBuilder({
   onChange,
   className,
   showClearAll = true,
+  extraOperators,
 }: FilterBuilderProps) {
   const { t } = useSafeFilterTranslation()
   const [filterGroup, setFilterGroup] = React.useState<FilterGroup>(
@@ -268,24 +359,7 @@ function FilterBuilder({
 
   const getOperatorsForField = (fieldValue: string) => {
     const field = fields.find((f) => f.value === fieldValue)
-    const fieldType = field?.type || "text"
-
-    if (numberLikeTypes.includes(fieldType)) {
-      return defaultOperators.filter((op) => numberOperators.includes(op.value))
-    }
-    if (fieldType === "boolean") {
-      return defaultOperators.filter((op) => booleanOperators.includes(op.value))
-    }
-    if (dateLikeTypes.includes(fieldType)) {
-      return defaultOperators.filter((op) => dateOperators.includes(op.value))
-    }
-    if (selectLikeTypes.includes(fieldType)) {
-      return defaultOperators.filter((op) => selectOperators.includes(op.value))
-    }
-    if (lookupLikeTypes.includes(fieldType)) {
-      return defaultOperators.filter((op) => lookupOperators.includes(op.value))
-    }
-    return defaultOperators.filter((op) => textOperators.includes(op.value))
+    return operatorsForFieldType(field?.type, extraOperators)
   }
 
   const needsValueInput = (operator: string) => {

--- a/packages/fields/src/widgets/FilterConditionField.tsx
+++ b/packages/fields/src/widgets/FilterConditionField.tsx
@@ -47,6 +47,24 @@ interface BuilderGroup {
 
 const EMPTY_GROUP: BuilderGroup = { id: 'root', logic: 'and', conditions: [] };
 
+/**
+ * Opt-in FilterBuilder operators this widget offers (objectui#4023).
+ *
+ * The shared dropdown withholds these because two of its three consumers
+ * persist into dialects that cannot carry them (see `OPT_IN_OPERATORS` in
+ * `@object-ui/components`'s `filter-builder.tsx`). THIS widget can: its value
+ * is a MongoDB-style `FieldOperatorsSchema` criteria that the server's engine
+ * evaluates directly — never lowered through the array/triplet AST — and
+ * `$icontains` is executable on every driver and evaluation face the platform
+ * ships (objectstack#5702 + objectstack#6520).
+ *
+ * Module scope, not an inline literal: a fresh array each render would reset
+ * `FilterBuilder`'s memo inputs on every keystroke.
+ *
+ * @internal exported for tests
+ */
+export const FILTER_CONDITION_EXTRA_OPERATORS: readonly string[] = ['containsCaseInsensitive'];
+
 /** Field types that are not meaningfully filterable in a simple builder. */
 const NON_FILTERABLE = new Set([
   'object', 'vector', 'file', 'image', 'avatar', 'signature',
@@ -118,6 +136,13 @@ export function condToMongo(c: BuilderCondition, typeOf: (f: string) => string |
     case 'equals': return { [field]: cv };
     case 'notEquals': return { [field]: { $ne: cv } };
     case 'contains': return { [field]: { $contains: value } };
+    // Case-insensitive contains (objectui#4023). `$contains` and its ASCII-case-
+    // folding twin are two operators, not one with a flag: `contains` keeps
+    // emitting `$contains` so stored criteria keep meaning what they meant.
+    // The fold is ASCII-only by contract (objectstack#4706 Q1 = A) — `café` does
+    // NOT match `CAFÉ` — which is why the label says "ignore case" rather than
+    // promising an accent-blind search.
+    case 'containsCaseInsensitive': return { [field]: { $icontains: value } };
     // `$notContains` is the spec spelling (FieldOperatorsSchema, data/filter.zod.ts).
     // This emitted `$ncontains` — a token that appears nowhere in @objectstack/spec and
     // that convertFiltersToAST throws on, so every "does not contain" rule authored here
@@ -189,6 +214,10 @@ export function kvToCondition(field: string, v: any, idx: number): BuilderCondit
     switch (op) {
       case '$ne': return { id, field, operator: 'notEquals', value: val };
       case '$contains': return { id, field, operator: 'contains', value: val };
+      // Without this arm a criteria the builder itself just wrote would fail to
+      // load on reopen ("criteria can't be represented") and drop the admin into
+      // the raw-JSON editor — the degradation objectui#4023 deliverable 2 names.
+      case '$icontains': return { id, field, operator: 'containsCaseInsensitive', value: val };
       // `$ncontains` is the pre-fix spelling this widget used to emit. Criteria saved
       // before the fix still carry it, so keep reading it — dropping it here would make
       // those rules fail to load ("criteria can't be represented") instead of migrating.
@@ -422,6 +451,7 @@ export function FilterConditionField({
           fields={fields ?? []}
           value={(group ?? EMPTY_GROUP) as any}
           onChange={handleBuilderChange as any}
+          extraOperators={FILTER_CONDITION_EXTRA_OPERATORS}
         />
       )}
       {/*

--- a/packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts
+++ b/packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts
@@ -22,7 +22,12 @@
  */
 import { describe, it, expect } from 'vitest';
 import { FieldOperatorsSchema } from '@objectstack/spec/data';
-import { condToMongo, kvToCondition } from '../FilterConditionField';
+import { FILTER_BUILDER_OPERATORS, operatorsForFieldType } from '@object-ui/components';
+import {
+  condToMongo,
+  kvToCondition,
+  FILTER_CONDITION_EXTRA_OPERATORS,
+} from '../FilterConditionField';
 
 /**
  * The `$`-prefixed operator keys of the spec's `FieldOperatorsSchema` —
@@ -35,6 +40,27 @@ const SPEC_OPERATORS = new Set(
 
 const noTypes = () => undefined;
 
+/**
+ * Spec `$`-tokens no builder operator emits, each for a stated reason.
+ *
+ * Module scope, and the ONE list — the ratchet below reads this same Set rather
+ * than restating its members. Two copies is how an exclusion outlives its
+ * reason: removing `$icontains` from a hand-repeated ratchet list is a separate
+ * edit nothing forces, so the ratchet would have gone on vouching for an entry
+ * the parity assertion no longer holds (objectui#4023).
+ *
+ * `$eq` is the spec's IMPLICIT equality form — `equals` deliberately emits the
+ * bare `{ field: value }` shape, never an explicit `$eq`. `$between` stays
+ * covered by the `$gte`+`$lte` pair `between` emits (kvToCondition reads that
+ * pair back as `between`).
+ *
+ * `$icontains` was here from objectui#3560 until objectui#4023: the spec gained
+ * it between @objectstack/spec 17.0.0-rc.2 and rc.5, and no builder operator
+ * could author it. `containsCaseInsensitive` now does, so the entry is gone and
+ * the parity assertion below is what holds that honest.
+ */
+const KNOWN_UNREACHABLE = new Set(['$eq', '$between']);
+
 /** Pull the operator keys out of a `{ field: { $op: v } }` fragment. */
 function operatorsOf(frag: Record<string, any> | null): string[] {
   if (!frag) return [];
@@ -45,7 +71,8 @@ function operatorsOf(frag: Record<string, any> | null): string[] {
 
 describe('condToMongo emits only spec operator spellings', () => {
   const builderOperators = [
-    'equals', 'notEquals', 'contains', 'notContains', 'isEmpty', 'isNotEmpty',
+    'equals', 'notEquals', 'contains', 'containsCaseInsensitive', 'notContains',
+    'isEmpty', 'isNotEmpty',
     'greaterThan', 'lessThan', 'greaterOrEqual', 'lessOrEqual', 'in', 'notIn',
     'before', 'after',
     'startsWith', 'endsWith', 'isNull', 'isNotNull', 'exists', 'notExists',
@@ -58,6 +85,18 @@ describe('condToMongo emits only spec operator spellings', () => {
     );
     const unknown = operatorsOf(frag).filter((op) => !SPEC_OPERATORS.has(op));
     expect(unknown, `${operator} emits an operator @objectstack/spec does not define`).toEqual([]);
+  });
+
+  it('containsCaseInsensitive emits $icontains, and contains still emits $contains', () => {
+    // The pair, in one assertion: objectui#4023's recorded default is a NEW
+    // operator, so `contains` keeping its case-SENSITIVE spelling is half of
+    // what shipped. Flipping it would silently change every stored filter view.
+    expect(
+      condToMongo({ id: 'c1', field: 'name', operator: 'containsCaseInsensitive', value: 'acme' } as any, noTypes),
+    ).toEqual({ name: { $icontains: 'acme' } });
+    expect(
+      condToMongo({ id: 'c2', field: 'name', operator: 'contains', value: 'acme' } as any, noTypes),
+    ).toEqual({ name: { $contains: 'acme' } });
   });
 
   it('notContains emits $notContains, not the pre-fix $ncontains', () => {
@@ -77,34 +116,15 @@ describe('every spec field operator is reachable from the builder (#2942)', () =
   });
 
   it('some builder operator emits every spec $-token', () => {
-    const builderOperators = [
-      'equals', 'notEquals', 'contains', 'notContains', 'isEmpty', 'isNotEmpty',
-      'greaterThan', 'lessThan', 'greaterOrEqual', 'lessOrEqual', 'in', 'notIn',
-      'before', 'after', 'between',
-      'startsWith', 'endsWith', 'isNull', 'isNotNull', 'exists', 'notExists',
-    ];
+    // Every id the dropdown can draw, opt-in ones included — DERIVED, so a
+    // builder operator that `condToMongo` forgot cannot quietly leave this
+    // sweep and take a spec token's only route to the UI with it.
     const emitted = new Set<string>();
-    for (const operator of builderOperators) {
+    for (const operator of FILTER_BUILDER_OPERATORS) {
       const value = operator === 'in' || operator === 'notIn' ? ['a'] : operator === 'between' ? [1, 5] : 'a';
       const frag = condToMongo({ id: 'c1', field: 'f', operator, value } as any, noTypes);
       for (const op of operatorsOf(frag)) emitted.add(op);
     }
-    // `$eq` is the spec's IMPLICIT equality form — `equals` deliberately
-    // emits the bare `{ field: value }` shape, never an explicit `$eq`.
-    // `$between` stays covered by the `$gte`+`$lte` pair `between` emits
-    // (kvToCondition reads that pair back as `between`).
-    //
-    // `$icontains` is a GENUINE GAP, not a modelling nuance, and is excluded
-    // here rather than silently dropped from the vocabulary. `FieldOperatorsSchema`
-    // gained it between @objectstack/spec 17.0.0-rc.2 and rc.5 (it folds ASCII
-    // case, i.e. case-insensitive contains): the server accepts the token, and no
-    // builder operator can author it, so the capability is unreachable from the
-    // filter UI. Closing it needs a new builder operator with a user-visible
-    // label — a new key in all ten locale packs — which is feature work and
-    // deliberately NOT carried by the dependency bump that surfaced it
-    // (objectui#3560). Tracked as objectui#3567; delete this exclusion when it
-    // lands, and the assertion below will hold it honest.
-    const KNOWN_UNREACHABLE = new Set(['$eq', '$between', '$icontains']);
     const unreachable = [...SPEC_OPERATORS].filter(
       (op) => !KNOWN_UNREACHABLE.has(op) && !emitted.has(op),
     );
@@ -117,13 +137,34 @@ describe('every spec field operator is reachable from the builder (#2942)', () =
   it('every KNOWN_UNREACHABLE token is still a spec operator (the exclusion ratchet)', () => {
     // A stale exclusion is how a parity test rots into a tautology: if the spec
     // ever drops one of these, the entry must go too rather than sit there
-    // excusing a token nobody ships. `$eq` / `$between` / `$icontains` are all
-    // real `FieldOperatorsSchema` keys today.
-    for (const op of ['$eq', '$between', '$icontains']) {
+    // excusing a token nobody ships. `$eq` / `$between` are real
+    // `FieldOperatorsSchema` keys today.
+    for (const op of KNOWN_UNREACHABLE) {
       expect(SPEC_OPERATORS.has(op), `'${op}' is excluded but no longer a spec operator`).toBe(
         true,
       );
     }
+  });
+
+  /**
+   * Emitting the token is only half of "reachable from the filter UI" — the
+   * other half is a dropdown row an admin can actually click. `condToMongo`
+   * answers to any string it is handed, so a spec token whose only builder
+   * operator was never added to the vocabulary would pass the sweep above and
+   * still be unauthorable, which is precisely the state objectui#4023 found.
+   */
+  it('the $icontains operator is one the builder can draw, and this widget offers it', () => {
+    expect(FILTER_BUILDER_OPERATORS).toContain('containsCaseInsensitive');
+    expect(FILTER_CONDITION_EXTRA_OPERATORS).toContain('containsCaseInsensitive');
+    // Every opt-in this widget asks for must be an id the dropdown knows;
+    // a typo here is a row that never renders and never fails anything else.
+    for (const id of FILTER_CONDITION_EXTRA_OPERATORS) {
+      expect(FILTER_BUILDER_OPERATORS, `${id} is not a FilterBuilder operator id`).toContain(id);
+    }
+    // …and it reaches a text field's dropdown once this widget opts in.
+    const offered = operatorsForFieldType('text', FILTER_CONDITION_EXTRA_OPERATORS).map((o) => o.value);
+    expect(offered).toContain('containsCaseInsensitive');
+    expect(offered).toContain('contains');
   });
 });
 
@@ -131,6 +172,10 @@ describe('kvToCondition round-trips what condToMongo writes', () => {
   const cases: Array<[string, unknown]> = [
     ['notEquals', 'a'],
     ['contains', 'a'],
+    // objectui#4023 deliverable 2: a saved filter view must not degrade on
+    // reopen. Without the `$icontains` arm in kvToCondition, criteria this very
+    // builder wrote comes back "not representable" and forces the JSON editor.
+    ['containsCaseInsensitive', 'a'],
     ['notContains', 'a'],
     ['greaterThan', 1],
     ['lessThan', 1],

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -3387,6 +3387,7 @@ const ar = {
       equals: "يساوي",
       notEquals: "لا يساوي",
       contains: "يحتوي",
+      containsCaseInsensitive: "يحتوي (مع تجاهل حالة الأحرف)",
       notContains: "لا يحتوي",
       isEmpty: "فارغ",
       isNotEmpty: "غير فارغ",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -3380,6 +3380,7 @@ const de = {
       equals: "Gleich",
       notEquals: "Ungleich",
       contains: "Enthält",
+      containsCaseInsensitive: "Enthält (Groß-/Kleinschreibung ignorieren)",
       notContains: "Enthält nicht",
       isEmpty: "Ist leer",
       isNotEmpty: "Ist nicht leer",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -3606,6 +3606,7 @@ const en = {
       equals: 'Equals',
       notEquals: 'Does not equal',
       contains: 'Contains',
+      containsCaseInsensitive: 'Contains (ignore case)',
       notContains: 'Does not contain',
       isEmpty: 'Is empty',
       isNotEmpty: 'Is not empty',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -3384,6 +3384,7 @@ const es = {
       equals: "Igual a",
       notEquals: "Distinto de",
       contains: "Contiene",
+      containsCaseInsensitive: "Contiene (ignorar mayúsculas)",
       notContains: "No contiene",
       isEmpty: "Está vacío",
       isNotEmpty: "No está vacío",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -3382,6 +3382,7 @@ const fr = {
       equals: "Égal à",
       notEquals: "Différent de",
       contains: "Contient",
+      containsCaseInsensitive: "Contient (ignorer la casse)",
       notContains: "Ne contient pas",
       isEmpty: "Est vide",
       isNotEmpty: "N'est pas vide",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -3380,6 +3380,7 @@ const ja = {
       equals: "等しい",
       notEquals: "等しくない",
       contains: "含む",
+      containsCaseInsensitive: "含む（大文字小文字を区別しない）",
       notContains: "含まない",
       isEmpty: "空である",
       isNotEmpty: "空でない",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -3379,6 +3379,7 @@ const ko = {
       equals: "같음",
       notEquals: "같지 않음",
       contains: "포함",
+      containsCaseInsensitive: "포함 (대소문자 무시)",
       notContains: "포함하지 않음",
       isEmpty: "비어 있음",
       isNotEmpty: "비어 있지 않음",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -3379,6 +3379,7 @@ const pt = {
       equals: "Igual a",
       notEquals: "Diferente de",
       contains: "Contém",
+      containsCaseInsensitive: "Contém (ignorar maiúsculas)",
       notContains: "Não contém",
       isEmpty: "Está vazio",
       isNotEmpty: "Não está vazio",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -3391,6 +3391,7 @@ const ru = {
       equals: "Равно",
       notEquals: "Не равно",
       contains: "Содержит",
+      containsCaseInsensitive: "Содержит (без учёта регистра)",
       notContains: "Не содержит",
       isEmpty: "Пусто",
       isNotEmpty: "Не пусто",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -3435,6 +3435,7 @@ const zh = {
       equals: '等于',
       notEquals: '不等于',
       contains: '包含',
+      containsCaseInsensitive: '包含（忽略大小写）',
       notContains: '不包含',
       isEmpty: '为空',
       isNotEmpty: '不为空',


### PR DESCRIPTION
Fixes #4023

Part of objectstack-ai/objectui#3567 — the card's four deliverables, implementing its recorded DEFAULT: a **new** case-insensitive contains operator, with today's `contains` semantics untouched. Whether `contains` should have been case-insensitive all along stays a maintainer question and is not taken here.

Blocker re-check: objectstack-ai/objectstack#5702 (SQL family) and objectstack-ai/objectstack#6520 (every JS evaluation face, driver-memory and driver-mongodb included) both landed, and the pinned `@objectstack/spec@17.0.0-rc.6` docblock states the operator is executable on every backend and evaluation face the platform ships. Neither of those numbers carries a closing keyword here; they are context, not this PR's business.

## What changed

1. **A `containsCaseInsensitive` builder operator** — label "Contains (ignore case)", offered beside `contains` for text fields.
2. **`condToMongo` emits `{ field: { $icontains: value } }`.** `contains` still emits the case-SENSITIVE `$contains`, so stored criteria keep meaning what they meant.
3. **`kvToCondition` reads `$icontains` back**, so a saved criteria reopens in the visual builder instead of degrading into the raw-JSON editor. Round-trip pinned by the existing `cases` table.
4. **Ten locale packs gain `filterBuilder.operators.containsCaseInsensitive`.** Single-brace convention is not involved — the value has no interpolation hole.
5. **`$icontains` is out of `KNOWN_UNREACHABLE`** in `FilterConditionField.operators.test.ts`; the parity assertion now covers it.

The fold is ASCII-only by contract (objectstack-ai/objectstack#4706 Q1 = A): `café` does not match `CAFÉ`. That boundary is stated in code comments and in the changeset — deliberately NOT as a new UI help surface, since no existing operator has one.

## The one design decision this PR makes, and the measurement behind it

**The operator ships opt-in per consumer.** `FilterBuilder` takes an `extraOperators` prop and only `FilterConditionField` passes it; every other FilterBuilder is byte-for-byte unchanged in what it offers.

The card's deliverable 1 reads "add to the FilterConditionField builder vocabulary", and FilterConditionField renders the SHARED `FilterBuilder` — so the naive implementation adds the operator to one global list and hands it to every consumer. Measured, that list feeds three different at-rest dialects and only one of them can carry the operator:

| consumer | at-rest dialect | can it store `$icontains`? |
|---|---|---|
| `FilterConditionField` (sharing-rule `criteria_json`) | MongoDB-style `FieldOperatorsSchema`, evaluated by the server engine | **yes** — every driver and face executes it |
| `viewFilterFold` (saved view) | `ViewFilterRule[]` over the spec's `VIEW_FILTER_OPERATORS` | no — the vocabulary has no case-insensitive contains, the enum refuses the rule |
| `ListView` filter popover (the live grid) | the array/triplet AST over `VALID_AST_OPERATORS` | no — `mapOperator` has no row, the id goes out verbatim |

For the third row, `packages/data-objectstack/src/filter-operator-ast-parity.test.ts` already states the cost of an operator outside `VALID_AST_OPERATORS`: an unfiltered read or a 400, "Both are a broken query." So offering the operator unconditionally would put a filter in users' hands that two of three consumers cannot execute — which is the exact hazard #4023 was held blocked over, relocated from the drivers to this repo's own bridges. Mapping it onto plain `contains` in those bridges is not the alternative: case sensitivity is contract as of the 2026-08-06 ruling on objectstack-ai/objectstack#5701, so that is a different question silently answered — the same reason `view-operator-builder-parity.test.ts` refuses to collapse `is_null` onto `isEmpty`.

The lasting fix is upstream, and it is filed rather than assumed: **objectstack-ai/objectstack#8934** — the spec's view and AST vocabularies have no counterpart to `$icontains`. When that lands, `OPT_IN_OPERATORS` loses its entry and the operator becomes ordinary.

## Beyond the card's four deliverables

Three small things, each named rather than slipped in:

- **`KNOWN_UNREACHABLE` is hoisted to module scope and the ratchet reads it.** The ratchet previously restated its members as a literal array, so removing `$icontains` from the Set would have left the ratchet vouching for an entry the parity assertion no longer holds — a second edit nothing forces. One list now.
- **The parity sweep iterates `FILTER_BUILDER_OPERATORS` instead of a hand-written copy.** A builder operator `condToMongo` forgot can no longer leave the sweep quietly and take a spec token's only route to the UI with it.
- **`getOperatorsForField`'s type-bucket selection is extracted as `operatorsForFieldType(fieldType, extraOperators)`** — a pure function, so the opt-in gate is assertable without driving a Radix popover open in jsdom. Behaviour for existing field types is unchanged; the new tests pin both directions (withheld unless asked for, reachable once asked for).

## Verification

All at `67f441280`, the head commit.

```
pnpm --filter '@object-ui/components^...' --filter '@object-ui/fields^...' build   # closure first
vitest run packages/i18n packages/fields          136 files, 2224 tests passed
vitest run packages/components packages/plugin-view  142 files, 1232 tests passed
pnpm --filter components --filter fields --filter i18n type-check    Done
pnpm --filter app-shell --filter plugin-list --filter plugin-view type-check   Done  (downstream consumers of @object-ui/components)
pnpm --filter components --filter fields --filter i18n lint          0 errors
node scripts/check-changeset-presence.mjs   14 source files of 3 released packages, 1 changeset
node scripts/check-i18n-call-site-keys.mjs  2407/2407 literal keys resolve
node scripts/check-i18n-en-drift.mjs        0 en values changed (1 key added)
node scripts/check-control-bytes.mjs        OK (4250 files)
node scripts/check-changeset-fixed.mjs / check-changeset-no-major.mjs / check-lint-coverage.mjs / check-type-check-coverage.mjs   all green
```

**Reverse verification** (from the committed state, then restored by `git checkout`): deleting the `containsCaseInsensitive` arm from `condToMongo` turns the suite red in the predicted direction — 3 failures, including the parity sweep reporting `expected [ '$icontains' ] to deeply equal []`, i.e. exactly the assertion deliverable 4 hands the ratchet.

Not a cross-package type NARROWING: `extraOperators` is an added optional prop and `FilterBuilderOperator` gained a member, so there is no key the new types reject and the paste-a-rejected-key check has nothing to assert here.

## Filed, not fixed

- objectstack-ai/objectstack#8934 — `$icontains` has no counterpart in `VIEW_FILTER_OPERATORS` / `VALID_AST_OPERATORS` (the root cause of the opt-in design above).
- #4736 — the list filter builder already offers `exists` / `notExists`, which `ListView.mapOperator` cannot express. Pre-existing since #2942; this PR does not widen it, and the `extraOperators` mechanism it adds is one of the two candidate fixes.

Neither is addressed in this PR.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_