### PR TITLE
fix(fields,i18n): translate AddressField sub-labels, drop US placeholders, localize read-only part order

### DIFF
--- a/.changeset/address-field-locale-labels-and-order.md
+++ b/.changeset/address-field-locale-labels-and-order.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/fields': patch
+'@object-ui/i18n': patch
+---
+
+`AddressField` is translatable, shows no US example placeholders, and formats its readonly line in the reader's address order.
+
+The five sub-labels ("Street Address", "City", "State / Province", "ZIP /
+Postal Code", "Country") were English string literals with no i18n key. On a
+non-English console every address field showed five English words in the middle
+of an otherwise fully translated form, and an app had no way to reach them: the
+parts are not fields on the object (`billing_address` is a single `address`
+column), so a translation bundle had nothing to key on, there is no `subLabels`
+property to declare, and the widget cannot be replaced from metadata. They now
+resolve through `fields.address.street` / `.city` / `.state` / `.postalCode` /
+`.country`, added to all ten locale packs. The `en` values are byte-identical to
+the literals they replace, and `FIELD_DEFAULTS` carries the same five, so
+English and provider-less rendering are unchanged.
+
+The five input placeholders (`123 Main St`, `San Francisco`, `CA`, `94102`,
+`United States`) are **removed** rather than keyed. They were untranslated and
+US-specific — a zh/ja/ar user was shown an American address as the example of
+what to type — and the right example is a function of the address's country,
+not the reader's language, which no channel in the stored value can supply
+today. Each box keeps the visible label that names it.
+
+The readonly line's part order now follows the reader's display locale
+(`useDisplayLocale()`): `zh`, `ja` and `ko` read largest-first (`Country, ZIP
+State, City, Street`), every other locale keeps the unchanged small-to-large
+order (`Street, City, State ZIP, Country`). The display cell renderer takes the
+same locale through the same shared `formatAddress`, so a stored address reads
+identically in a readonly form and in a grid cell.

--- a/packages/fields/src/__tests__/AddressCellRenderer.locale-order.test.tsx
+++ b/packages/fields/src/__tests__/AddressCellRenderer.locale-order.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The display cell renderer orders address parts the same way the input
+ * widget's readonly branch does, in every locale — objectui#4028 over
+ * objectui#4037's shared formatter.
+ *
+ * objectui#4037 pulled the one-line rule out into `address-format` so that a
+ * readonly form and the detail page could not spell one stored address two
+ * ways. objectui#4028 makes that rule locale-aware. Passing the locale on only
+ * ONE of the formatter's two callers would re-open the exact drift #4037
+ * closed — a `zh` console showing `中国, 310000 浙江, 杭州, 中策路 1 号` in the
+ * record's readonly form and the US-ordered line in the grid cell beside it —
+ * so the two surfaces are asserted here against the SAME expectations
+ * `AddressField.i18n.test.tsx` uses for the widget.
+ *
+ * Resolution goes through `getCellRenderer`, not a direct import, for the same
+ * reason the sibling suite does it: the assertion must fail if the display
+ * registry entry regresses, not merely if the formatter changes.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+
+import { getCellRenderer, resolveCellRendererType } from '../index';
+
+/** The record from the issue's evidence table. */
+const CN_ADDRESS = {
+  street: '中策路 1 号',
+  city: '杭州',
+  state: '浙江',
+  postalCode: '310000',
+  country: '中国',
+};
+
+function renderAddressIn(language: string, value: unknown) {
+  const Renderer = getCellRenderer(resolveCellRendererType({ type: 'address' }) || 'address');
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <Renderer value={value as any} field={{ type: 'address' } as any} />
+    </I18nProvider>,
+  );
+}
+
+describe('address cell renderer follows the locale part order (objectui#4028)', () => {
+  it('reads largest-first under zh', () => {
+    const { container } = renderAddressIn('zh', CN_ADDRESS);
+    expect(container.textContent).toBe('中国, 310000 浙江, 杭州, 中策路 1 号');
+  });
+
+  it('reads largest-first under ja and ko too', () => {
+    expect(renderAddressIn('ja', CN_ADDRESS).container.textContent).toBe(
+      '中国, 310000 浙江, 杭州, 中策路 1 号',
+    );
+    expect(renderAddressIn('ko', CN_ADDRESS).container.textContent).toBe(
+      '中国, 310000 浙江, 杭州, 中策路 1 号',
+    );
+  });
+
+  it('keeps the small-to-large order under de — the Latin control', () => {
+    const { container } = renderAddressIn('de', CN_ADDRESS);
+    expect(container.textContent).toBe('中策路 1 号, 杭州, 浙江 310000, 中国');
+  });
+
+  it('keeps the small-to-large order under en', () => {
+    const { container } = renderAddressIn('en', CN_ADDRESS);
+    expect(container.textContent).toBe('中策路 1 号, 杭州, 浙江 310000, 中国');
+  });
+
+  it('still drops missing parts, in the localized order', () => {
+    const { container } = renderAddressIn('zh', { city: '杭州', postalCode: '310000' });
+    expect(container.textContent).toBe('310000, 杭州');
+  });
+
+  it('leaves the non-address branches alone under a zh provider', () => {
+    // A plain string passes through, `{}` is empty, an unrecognized shape
+    // keeps its JSON — none of which the order rule may touch.
+    expect(renderAddressIn('zh', '中策路 1 号').container.textContent).toBe('中策路 1 号');
+    expect(renderAddressIn('zh', {}).container.textContent).not.toMatch(/[{}]/);
+    expect(renderAddressIn('zh', { foo: 1 }).container.textContent).toContain('foo');
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -2072,11 +2072,23 @@ export function LocationCellRenderer({ value }: CellRendererProps): React.ReactE
  * is never silently swallowed by the fix.
  */
 export function AddressCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  // Part order follows the reader's display locale (objectui#4028). This is
+  // the SAME `formatAddress` the input widget's readonly branch calls, and
+  // that shared definition is the whole point of objectui#4037 — so passing
+  // the locale on only one of the two callers would re-open exactly the drift
+  // that change closed: one stored address, largest-first in a readonly form
+  // and US-ordered in the grid cell next to it. Measured on this branch, not
+  // assumed: `formatAddress` has these two callers and no others.
+  //
+  // `useDisplayLocale()` is the same resolver every other locale-aware cell
+  // renderer in this file already uses, and it is provider-safe (it resolves
+  // to `'en'` — the unchanged small-to-large order — with nothing mounted).
+  const locale = useDisplayLocale();
   if (value == null || value === '') return <EmptyValue />;
   // A plain string address (some apps store one) is already display-ready.
   if (typeof value === 'string') return <TruncatedText text={value} className="text-sm" />;
   if (typeof value === 'object' && !Array.isArray(value)) {
-    const formatted = formatAddress(value as AddressValue);
+    const formatted = formatAddress(value as AddressValue, locale);
     if (formatted) return <TruncatedText text={formatted} className="text-sm" />;
     // An object carrying no recognized part: `{}` reads as empty, while
     // `{ foo: 1 }` keeps its JSON so real data is never hidden.

--- a/packages/fields/src/widgets/AddressField.tsx
+++ b/packages/fields/src/widgets/AddressField.tsx
@@ -1,8 +1,10 @@
 import React, { useId } from 'react';
 import { Input, Label, EmptyValue } from '@object-ui/components';
+import { useDisplayLocale } from '@object-ui/i18n';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { toHostGroupProps } from './toHostGroupProps';
+import { useFieldTranslation } from './useFieldTranslation';
 // The value shape and the single-line formatting rule now live in a pure module
 // so the display (read) cell renderer formats a stored address exactly the way
 // this widget's readonly branch does — one rule, not two copies that drift
@@ -66,6 +68,16 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
   const groupId = useId();
   const subId = (name: keyof AddressValue) => `${groupId}-${name}`;
 
+  // Sub-labels and the readonly line's part order are the two halves of
+  // objectui#4028 — the five boxes were English string literals with no key at
+  // all, so a fully translated form showed five English words in the middle of
+  // it, and an app had nothing to key a translation bundle on (the parts are
+  // not fields on the object). Both hooks are called unconditionally, ABOVE the
+  // readonly early return: the readonly branch reads the locale, and a hook
+  // that ran only on one branch would desync hook order between the two.
+  const { t } = useFieldTranslation();
+  const displayLocale = useDisplayLocale();
+
   // Read through the legacy key, write only the canonical one (objectstack#5143).
   const postalCode = readPostalCode(address);
 
@@ -91,7 +103,12 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
     // placeholder's own `aria-label` ("No value") is outranked by
     // `aria-labelledby` per accname, and on its `generic` role an author name was
     // never exposed anyway.
-    const formatted = formatAddress(address);
+    // Part order follows the reader's display locale (objectui#4028): the line
+    // used to be US-ordered for everyone, so a Chinese address on a Chinese
+    // console read backwards. `formatAddress` owns the rule and the display
+    // cell renderer passes the same locale, so the two surfaces cannot drift
+    // (the very thing objectui#4037 unified them for).
+    const formatted = formatAddress(address, displayLocale);
     return formatted ? (
       <span {...hostGroupProps} className="text-sm">{formatted}</span>
     ) : (
@@ -106,72 +123,89 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
     // byte-identical to what it was before. That condition now lives in
     // `toHostGroupProps` so this container and the readonly line above cannot
     // answer differently (objectui#3990).
+    // The five sub-inputs carry NO placeholder any more (objectui#4028). They
+    // used to hold `123 Main St` / `San Francisco` / `CA` / `94102` / `United
+    // States` — untranslated AND US-specific, so a zh/ja/ar user was shown an
+    // American address as the example of what to type.
+    //
+    // Dropped rather than keyed, measured against the packs' own precedent:
+    //
+    //  1. Every example-data placeholder the packs DO carry teaches a FORMAT
+    //     its label cannot — `name@example.com` (local@domain), `+1 555 000
+    //     0000` (dial prefix), `Icon name (e.g. Users)` (which identifier).
+    //     Each box here already has a visible label naming exactly what it
+    //     wants, so its example added nothing but a country — and a US postal
+    //     code's SHAPE actively misinforms anyone whose own is a different one.
+    //  2. The right example is a function of the address's COUNTRY, not the
+    //     reader's language. Nothing in the stored value can pick one (this
+    //     widget writes no `countryCode`), and keying by UI language would be
+    //     wrong for every cross-border address — precisely the CRM case this
+    //     was reported from.
+    //  3. Keying costs 50 pack entries of invented fictional address fragments,
+    //     bound from then on by `check:i18n-drift`, and each Latin-script one
+    //     inside zh/ja/ko/ru/ar would need an `untranslated-identity-4376`
+    //     allowlist entry — an explicit admission the "translation" is not one.
     <div className="space-y-3" {...hostGroupProps}>
       <div>
-        <Label htmlFor={subId('street')} className="text-xs">Street Address</Label>
+        <Label htmlFor={subId('street')} className="text-xs">{t('fields.address.street')}</Label>
         <Input
           {...domProps}
           id={subId('street')}
           type="text"
           value={address.street || ''}
           onChange={(e) => handleFieldChange('street', e.target.value)}
-          placeholder="123 Main St"
           disabled={readonly || props.disabled}
           className={props.className}
           aria-invalid={!!error}
         />
       </div>
-      
+
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <Label htmlFor={subId('city')} className="text-xs">City</Label>
+          <Label htmlFor={subId('city')} className="text-xs">{t('fields.address.city')}</Label>
           <Input
             id={subId('city')}
             type="text"
             value={address.city || ''}
             onChange={(e) => handleFieldChange('city', e.target.value)}
-            placeholder="San Francisco"
             disabled={readonly || props.disabled}
             aria-invalid={!!error}
           />
         </div>
-        
+
         <div>
-          <Label htmlFor={subId('state')} className="text-xs">State / Province</Label>
+          <Label htmlFor={subId('state')} className="text-xs">{t('fields.address.state')}</Label>
           <Input
             id={subId('state')}
             type="text"
             value={address.state || ''}
             onChange={(e) => handleFieldChange('state', e.target.value)}
-            placeholder="CA"
             disabled={readonly || props.disabled}
             aria-invalid={!!error}
           />
         </div>
       </div>
-      
+
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <Label htmlFor={subId('postalCode')} className="text-xs">ZIP / Postal Code</Label>
+          <Label htmlFor={subId('postalCode')} className="text-xs">{t('fields.address.postalCode')}</Label>
           <Input
             id={subId('postalCode')}
             type="text"
             value={postalCode || ''}
             onChange={(e) => handleFieldChange('postalCode', e.target.value)}
-            placeholder="94102"
             disabled={readonly || props.disabled}
             aria-invalid={!!error}
           />
         </div>
-        
+
         <div>
-          <Label htmlFor={subId('country')} className="text-xs">Country</Label>
+          <Label htmlFor={subId('country')} className="text-xs">{t('fields.address.country')}</Label>
           <Input
             id={subId('country')}
             type="text"
             value={address.country || ''}
             onChange={(e) => handleFieldChange('country', e.target.value)}
-            placeholder="United States"
             disabled={readonly || props.disabled}
             aria-invalid={!!error}
           />

--- a/packages/fields/src/widgets/__tests__/AddressField.i18n.test.tsx
+++ b/packages/fields/src/widgets/__tests__/AddressField.i18n.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `AddressField` is translatable, and its readonly line reads in the reader's
+ * own address order — objectui#4028.
+ *
+ * The report was measured on a zh-CN console: every label on the account
+ * dialog was Chinese except the five inside the address field, which were
+ * English string literals with no i18n key at all. Nothing an app could do
+ * reached them — the parts are not fields on the object (`billing_address` is
+ * one `address` column), so a translation bundle had nothing to key on, there
+ * is no `subLabels` property to declare, and the widget cannot be replaced
+ * from metadata. The only workaround was to abandon `Field.address()` for five
+ * text fields, losing the structured value, geocoding and the map view.
+ *
+ * ## What each group asserts, and why in this shape
+ *
+ * - **Labels: non-`en` positive AND English-literal negative, together.** A
+ *   positive-only assertion stays green when one label is re-inlined next to
+ *   four translated siblings, which is precisely how this defect looked in the
+ *   first place — four Chinese labels around one English one would have read
+ *   as "not translated yet".
+ * - **`en` is a NO-OP pin, not a defect reproducer.** The five pack values are
+ *   byte-identical to the literals they replace, so English was green before
+ *   this change too. Only a positive assertion can see that the swap left
+ *   English alone, and `AddressField.no-provider.test.tsx` pins the other half
+ *   of that equality (what renders with no `I18nProvider` at all).
+ * - **Placeholders are asserted ABSENT, per locale.** They were `123 Main St`
+ *   / `San Francisco` / `CA` / `94102` / `United States`: untranslated and
+ *   US-specific, so a zh/ja/ar user was shown an American address as the
+ *   example of what to type. They are dropped rather than keyed — see the
+ *   widget for the measurement — and an absence needs a test precisely because
+ *   nothing else would notice one creeping back: a re-added `placeholder=` is
+ *   invisible to every i18n gate, which only ever look at keys.
+ * - **Readonly ORDER, zh against a Latin locale.** The line used to be
+ *   US-ordered for everyone. `zh` is the reported case (largest-first) and
+ *   `es` is the control that must NOT move — an implementation that reversed
+ *   unconditionally, or that keyed off "not English", passes a zh-only check
+ *   and fails here.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+
+import { AddressField } from '../AddressField';
+import type { FieldMetadata } from '@object-ui/types';
+
+const addressField = { name: 'billing_address', type: 'address' } as unknown as FieldMetadata;
+
+/** The record from the issue's evidence, in the locale it was reported from. */
+const CN_ADDRESS = {
+  street: '中策路 1 号',
+  city: '杭州',
+  state: '浙江',
+  postalCode: '310000',
+  country: '中国',
+};
+
+/** A US address — the shape the old hardcoded order was built around. */
+const US_ADDRESS = {
+  street: '123 Main St',
+  city: 'San Francisco',
+  state: 'CA',
+  postalCode: '94102',
+  country: 'United States',
+};
+
+function renderIn(language: string, element: React.ReactElement) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      {element}
+    </I18nProvider>,
+  );
+}
+
+const editable = (value: Record<string, string> = {}) => (
+  <AddressField value={value} onChange={vi.fn()} field={addressField} />
+);
+
+/** Every English literal the five sub-labels used to be. */
+const ENGLISH_SUB_LABELS = [
+  'Street Address',
+  'City',
+  'State / Province',
+  'ZIP / Postal Code',
+  'Country',
+];
+
+describe('AddressField sub-labels are translated (objectui#4028)', () => {
+  it('renders the English labels under an en provider', () => {
+    renderIn('en', editable());
+    for (const label of ENGLISH_SUB_LABELS) {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('renders Chinese labels — and NO English literal — under a zh provider', () => {
+    const { container } = renderIn('zh', editable());
+    expect(screen.getByLabelText('街道地址')).toBeInTheDocument();
+    expect(screen.getByLabelText('城市')).toBeInTheDocument();
+    expect(screen.getByLabelText('省 / 州')).toBeInTheDocument();
+    expect(screen.getByLabelText('邮政编码')).toBeInTheDocument();
+    expect(screen.getByLabelText('国家 / 地区')).toBeInTheDocument();
+    // The negative half: not one of the five may survive as English.
+    for (const label of ENGLISH_SUB_LABELS) {
+      expect(container.textContent).not.toContain(label);
+    }
+  });
+
+  it('renders Japanese labels — and NO English literal — under a ja provider', () => {
+    const { container } = renderIn('ja', editable());
+    expect(screen.getByLabelText('番地・建物名')).toBeInTheDocument();
+    expect(screen.getByLabelText('市区町村')).toBeInTheDocument();
+    expect(screen.getByLabelText('都道府県')).toBeInTheDocument();
+    expect(screen.getByLabelText('郵便番号')).toBeInTheDocument();
+    expect(screen.getByLabelText('国')).toBeInTheDocument();
+    for (const label of ENGLISH_SUB_LABELS) {
+      expect(container.textContent).not.toContain(label);
+    }
+  });
+
+  it('renders Arabic labels under an ar provider (RTL pack, same keys)', () => {
+    renderIn('ar', editable());
+    expect(screen.getByLabelText('عنوان الشارع')).toBeInTheDocument();
+    expect(screen.getByLabelText('المدينة')).toBeInTheDocument();
+    expect(screen.getByLabelText('الرمز البريدي')).toBeInTheDocument();
+  });
+
+  it('keeps every sub-label bound to its own input (htmlFor survives the swap)', () => {
+    renderIn('zh', editable(CN_ADDRESS));
+    // Each label resolves to the box holding that part's stored value — the
+    // association objectui#3343 established, re-checked through translated
+    // label text rather than the old literals.
+    expect(screen.getByLabelText('街道地址')).toHaveValue('中策路 1 号');
+    expect(screen.getByLabelText('城市')).toHaveValue('杭州');
+    expect(screen.getByLabelText('邮政编码')).toHaveValue('310000');
+  });
+});
+
+describe('AddressField shows no US example placeholders (objectui#4028)', () => {
+  const US_EXAMPLES = ['123 Main St', 'San Francisco', 'CA', '94102', 'United States'];
+
+  for (const language of ['en', 'zh', 'ja', 'ar']) {
+    it(`renders no placeholder at all under a ${language} provider`, () => {
+      const { container } = renderIn(language, editable());
+      const boxes = Array.from(container.querySelectorAll('input'));
+      expect(boxes).toHaveLength(5);
+      for (const box of boxes) {
+        expect(box.getAttribute('placeholder')).toBeNull();
+      }
+    });
+  }
+
+  it('leaves no US example text anywhere in the rendered zh form', () => {
+    const { container } = renderIn('zh', editable());
+    for (const example of US_EXAMPLES) {
+      expect(container.textContent).not.toContain(example);
+      expect(container.innerHTML).not.toContain(`placeholder="${example}"`);
+    }
+  });
+});
+
+describe('AddressField readonly line follows the locale part order (objectui#4028)', () => {
+  it('reads largest-first under zh — the reported case', () => {
+    const { container } = renderIn(
+      'zh',
+      <AddressField value={CN_ADDRESS} onChange={vi.fn()} field={addressField} readonly />,
+    );
+    expect(container.textContent).toBe('中国, 310000 浙江, 杭州, 中策路 1 号');
+  });
+
+  it('keeps the small-to-large order under es — the Latin control', () => {
+    const { container } = renderIn(
+      'es',
+      <AddressField value={CN_ADDRESS} onChange={vi.fn()} field={addressField} readonly />,
+    );
+    expect(container.textContent).toBe('中策路 1 号, 杭州, 浙江 310000, 中国');
+  });
+
+  it('leaves the English line byte-identical to what it always was', () => {
+    const { container } = renderIn(
+      'en',
+      <AddressField value={US_ADDRESS} onChange={vi.fn()} field={addressField} readonly />,
+    );
+    expect(container.textContent).toBe('123 Main St, San Francisco, CA 94102, United States');
+  });
+
+  it('orders a US address by the READER, not by the address — the stated limit', () => {
+    // Not an endorsement, a pin: the channel is the display locale, because
+    // this widget writes no `countryCode` for an address-driven rule to read.
+    // If that ever changes, this expectation is the thing that must move, and
+    // moving it deliberately is the point of writing it down.
+    const { container } = renderIn(
+      'zh',
+      <AddressField value={US_ADDRESS} onChange={vi.fn()} field={addressField} readonly />,
+    );
+    expect(container.textContent).toBe('United States, 94102 CA, San Francisco, 123 Main St');
+  });
+
+  it('drops missing parts in the localized order too, with no dangling separators', () => {
+    const { container } = renderIn(
+      'zh',
+      <AddressField
+        value={{ street: '中策路 1 号', country: '中国' }}
+        onChange={vi.fn()}
+        field={addressField}
+        readonly
+      />,
+    );
+    expect(container.textContent).toBe('中国, 中策路 1 号');
+  });
+});

--- a/packages/fields/src/widgets/__tests__/AddressField.no-provider.test.tsx
+++ b/packages/fields/src/widgets/__tests__/AddressField.no-provider.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `AddressField` with NO `I18nProvider` mounted — the other half of
+ * objectui#4028's equality, and the half a provider-mounted test cannot see.
+ *
+ * `AddressField.i18n.test.tsx` renders under providers and asserts the ten
+ * packs serve the five sub-labels. This file asserts what a host that mounts
+ * no provider at all renders: `createSafeTranslation`'s `FIELD_DEFAULTS`
+ * English, byte-identical to the literals the widget used to hold — not a raw
+ * `fields.address.street` key, which is what a bare `useObjectTranslation()`
+ * would have put on screen. Standalone SDUI nodes and the inline grid editor
+ * are real hosts of exactly this shape, so this is a shipped path, not a test
+ * artifact.
+ *
+ * Same split, same reason as `TextAreaField.characterCount.no-provider.test.tsx`
+ * and `FullscreenFieldEditor.no-provider.test.tsx`.
+ *
+ * The readonly line is here too: with no provider `useDisplayLocale()` resolves
+ * to its concrete `'en'` last resort, so the formatted address must stay
+ * byte-identical to what it was before the locale parameter existed. That is
+ * the no-regression floor for every existing consumer of this widget.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { AddressField } from '../AddressField';
+import type { FieldMetadata } from '@object-ui/types';
+
+const addressField = { name: 'billing_address', type: 'address' } as unknown as FieldMetadata;
+
+describe('AddressField with no i18n configured (objectui#4028)', () => {
+  it('renders the English sub-labels, not raw keys', () => {
+    render(<AddressField value={{}} onChange={vi.fn()} field={addressField} />);
+
+    // Byte-identical to the literals this change replaced.
+    expect(screen.getByLabelText('Street Address')).toBeInTheDocument();
+    expect(screen.getByLabelText('City')).toBeInTheDocument();
+    expect(screen.getByLabelText('State / Province')).toBeInTheDocument();
+    expect(screen.getByLabelText('ZIP / Postal Code')).toBeInTheDocument();
+    expect(screen.getByLabelText('Country')).toBeInTheDocument();
+  });
+
+  it('never leaks a translation key to the user', () => {
+    const { container } = render(
+      <AddressField value={{}} onChange={vi.fn()} field={addressField} />,
+    );
+    expect(container.textContent).not.toMatch(/fields\.address/);
+  });
+
+  it('carries no placeholder on any of the five boxes', () => {
+    const { container } = render(
+      <AddressField value={{}} onChange={vi.fn()} field={addressField} />,
+    );
+    const boxes = Array.from(container.querySelectorAll('input'));
+    expect(boxes).toHaveLength(5);
+    expect(boxes.map((b) => b.getAttribute('placeholder'))).toEqual([
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it('formats the readonly line exactly as it did before the locale parameter', () => {
+    const { container } = render(
+      <AddressField
+        value={{
+          street: '中策路 1 号',
+          city: '杭州',
+          state: '浙江',
+          postalCode: '310000',
+          country: '中国',
+        }}
+        onChange={vi.fn()}
+        field={addressField}
+        readonly
+      />,
+    );
+    expect(container.textContent).toBe('中策路 1 号, 杭州, 浙江 310000, 中国');
+  });
+});

--- a/packages/fields/src/widgets/address-format.ts
+++ b/packages/fields/src/widgets/address-format.ts
@@ -95,26 +95,86 @@ function part(value: unknown): string {
 }
 
 /**
- * Formats a stored address as a single line: `Street, City, State ZIP, Country`.
+ * Language subtags whose addresses are conventionally written LARGEST-FIRST —
+ * country, then region, then city, then street (objectui#4028).
  *
- * Ordering and separators are NOT invented here — they are the rule
- * `AddressField` already applied in its readonly branch, and the sub-field set
- * its inputs expose (street / city / state / postalCode / country). Missing
- * parts are dropped rather than spaced over, so a street-only address is
- * `"中策路 1 号"` and never `", , ,"`.
+ * Deliberately a language-subtag set and not a country table. The two candidate
+ * channels were compared before picking this one:
+ *
+ *   - The ADDRESS's own country (`countryCode`) would be the more correct
+ *     channel — an address format is a property of where the mail goes, not of
+ *     who is reading — but `AddressField` exposes no `countryCode` input and
+ *     never writes one, so on data this widget produces that channel is empty.
+ *     A `country` free-text match ("中国" / "China" / "PRC") would be a
+ *     name-guessing table, invented here rather than derived from anything.
+ *   - The reader's DISPLAY LOCALE is the channel this repo already resolves
+ *     once, for every display formatter, through `useDisplayLocale()` (tenant
+ *     regional default -> active UI language -> `'en'`; objectui#4033/#4468).
+ *     Both callers pass that, so a stored address reads the same way in a
+ *     readonly form and in a grid cell.
+ *
+ * The limit is stated rather than hidden: a `zh` reader looking at a US address
+ * gets it largest-first. That is the reading order their own locale writes
+ * addresses in, and it is the trade the empty `countryCode` channel forces
+ * today; the refinement is a follow-up, not a silent assumption.
+ *
+ * Region subtags are ignored (`zh-CN`, `zh-Hant-TW` and `zh` all match) — the
+ * convention here follows the language, and `useDisplayLocale()` can serve any
+ * of those spellings.
+ */
+const LARGE_TO_SMALL_LANGUAGES = new Set(['zh', 'ja', 'ko']);
+
+/** Primary language subtag of a BCP-47 tag, lowercased (`'zh-CN'` -> `'zh'`). */
+function languageOf(locale: string | undefined): string {
+  return (locale || '').split(/[-_]/)[0].toLowerCase();
+}
+
+/**
+ * Formats a stored address as a single line, in the part order the reader's
+ * locale writes addresses in.
+ *
+ * Two orders, and the second is exactly the first reversed:
+ *
+ *   - **small-to-large** (default; `en` and every Latin/Cyrillic/Arabic locale
+ *     this repo ships) — `Street, City, State ZIP, Country`. Unchanged from
+ *     what `AddressField`'s readonly branch has always produced, so English and
+ *     provider-less rendering are byte-identical to before.
+ *   - **large-to-small** ({@link LARGE_TO_SMALL_LANGUAGES}) — `Country, ZIP
+ *     State, City, Street`. A `zh` console rendering a Chinese address
+ *     largest-first is the whole point of objectui#4028: `中国, 310000 浙江,
+ *     杭州, 中策路 1 号` rather than the US-ordered line it produced before.
+ *
+ * Only the ORDER varies. The separator stays `', '` in both, because that is
+ * not what the issue reports and because these lines carry mixed-script data —
+ * a US address read on a `zh` console would look stranger under fullwidth
+ * punctuation than under the comma it already has.
+ *
+ * The state/postal-code pair keeps its one comma-delimited group in both
+ * orders, space-separated inside it ("CA 94102" / "310000 浙江"); either part
+ * alone occupies the group by itself. Missing parts are dropped rather than
+ * spaced over, so a street-only address is `"中策路 1 号"` and never `", , ,"`.
  *
  * Returns `''` when no part is usable — callers decide what an empty address
  * looks like (an `EmptyValue` placeholder for the cell renderer), and a value
  * carrying no recognized part at all is NOT silently blanked: see
  * `AddressCellRenderer`, which falls back to JSON so unknown data stays visible.
+ *
+ * @param locale - BCP-47 tag from `useDisplayLocale()`. Omitted (tests, and any
+ *   caller with no React context) means the small-to-large default, which is
+ *   what this function did unconditionally before objectui#4028.
  */
-export function formatAddress(addr: AddressValue): string {
-  // State and postal code share one comma-delimited group, space-separated
-  // inside it ("CA 94102"); either one alone occupies the group by itself.
-  const stateAndPostal = [part(addr.state), part(readPostalCode(addr))]
-    .filter(Boolean)
-    .join(' ');
-  return [part(addr.street), part(addr.city), stateAndPostal, part(addr.country)]
-    .filter(Boolean)
-    .join(', ');
+export function formatAddress(addr: AddressValue, locale?: string): string {
+  const street = part(addr.street);
+  const city = part(addr.city);
+  const state = part(addr.state);
+  const postalCode = part(readPostalCode(addr));
+  const country = part(addr.country);
+
+  if (LARGE_TO_SMALL_LANGUAGES.has(languageOf(locale))) {
+    const postalAndState = [postalCode, state].filter(Boolean).join(' ');
+    return [country, postalAndState, city, street].filter(Boolean).join(', ');
+  }
+
+  const stateAndPostal = [state, postalCode].filter(Boolean).join(' ');
+  return [street, city, stateAndPostal, country].filter(Boolean).join(', ');
 }

--- a/packages/fields/src/widgets/useFieldTranslation.ts
+++ b/packages/fields/src/widgets/useFieldTranslation.ts
@@ -77,6 +77,16 @@ const FIELD_DEFAULTS: Record<string, string> = {
   // objectui#3342 — the tags widget's input hint. Used only when the field
   // author declared no `placeholder` of their own (author declaration wins).
   'fields.tags.placeholder': 'Type and press Enter to add…',
+  // objectui#4028 — `AddressField`'s five sub-labels. The parts of an address
+  // are NOT fields on the object (`billing_address` is one column), so no
+  // translation bundle could ever key them and an app had no workaround short
+  // of abandoning `Field.address()`. Byte-identical to the literals they
+  // replace, so English and provider-less rendering are unchanged.
+  'fields.address.street': 'Street Address',
+  'fields.address.city': 'City',
+  'fields.address.state': 'State / Province',
+  'fields.address.postalCode': 'ZIP / Postal Code',
+  'fields.address.country': 'Country',
   // objectui#3406 — the accessible name of `TextAreaField`'s character
   // counter, rendered only when the field declares `maxLength`. The visible
   // `{n}/{max}` is digits; this sentence is what a screen reader speaks, and

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -265,6 +265,14 @@ const ar = {
     tags: {
       placeholder: "اكتب واضغط Enter للإضافة…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "عنوان الشارع",
+      city: "المدينة",
+      state: "الولاية / المحافظة",
+      postalCode: "الرمز البريدي",
+      country: "الدولة",
+    },
     textarea: {
       characterCount: "عدد الأحرف: {{count}} من {{max}}",
       charactersRemaining: "الأحرف المتبقية: {{count}}",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -261,6 +261,14 @@ const de = {
     tags: {
       placeholder: "Tippen und mit der Eingabetaste hinzufügen…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "Straße und Hausnummer",
+      city: "Stadt",
+      state: "Bundesland / Provinz",
+      postalCode: "Postleitzahl",
+      country: "Land",
+    },
     textarea: {
       characterCount: "Zeichenanzahl: {{count}} von {{max}}",
       charactersRemaining: "Verbleibende Zeichen: {{count}}",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -291,6 +291,30 @@ const en = {
     tags: {
       placeholder: 'Type and press Enter to add…',
     },
+    // objectui#4028 — `AddressField`'s five sub-labels, previously English
+    // string literals with no key at all: on a Chinese console every address
+    // field showed five English words in the middle of an otherwise fully
+    // translated form, and an app had NO way to reach them. The parts are not
+    // fields on the object (`billing_address` is a single `address` column),
+    // so there was nothing for a translation bundle to key on and no
+    // `subLabels` property to declare — the only workaround left was to stop
+    // using `Field.address()` and author five text fields, losing the
+    // structured value, geocoding and map view.
+    //
+    // Values are byte-identical to the literals they replace, so English and
+    // provider-less rendering are unchanged (`FIELD_DEFAULTS` in
+    // `packages/fields/src/widgets/useFieldTranslation.ts` carries the same
+    // five, which is what a host with no `I18nProvider` renders).
+    //
+    // The five INPUT PLACEHOLDERS that sat next to these labels are gone
+    // rather than keyed — see the widget for that measurement.
+    address: {
+      street: 'Street Address',
+      city: 'City',
+      state: 'State / Province',
+      postalCode: 'ZIP / Postal Code',
+      country: 'Country',
+    },
     // objectui#3406 — the accessible sentence of the textarea character
     // counter, rendered only when the field declares `maxLength`. The visible
     // text is `{count}/{max}` digits and needs no locale. ONE interpolated key

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -265,6 +265,14 @@ const es = {
     tags: {
       placeholder: "Escriba y pulse Intro para añadir…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "Dirección (calle)",
+      city: "Ciudad",
+      state: "Estado / Provincia",
+      postalCode: "Código postal",
+      country: "País",
+    },
     textarea: {
       characterCount: "Recuento de caracteres: {{count}} de {{max}}",
       charactersRemaining: "Caracteres restantes: {{count}}",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -261,6 +261,14 @@ const fr = {
     tags: {
       placeholder: "Saisissez puis appuyez sur Entrée pour ajouter…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "Adresse (rue)",
+      city: "Ville",
+      state: "État / Province",
+      postalCode: "Code postal",
+      country: "Pays",
+    },
     textarea: {
       characterCount: "Nombre de caractères : {{count}} sur {{max}}",
       charactersRemaining: "Caractères restants : {{count}}",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -261,6 +261,14 @@ const ja = {
     tags: {
       placeholder: "入力してEnterキーで追加…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "番地・建物名",
+      city: "市区町村",
+      state: "都道府県",
+      postalCode: "郵便番号",
+      country: "国",
+    },
     textarea: {
       characterCount: "文字数: {{max}} 文字中 {{count}} 文字",
       charactersRemaining: "残り {{count}} 文字",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -261,6 +261,14 @@ const ko = {
     tags: {
       placeholder: "입력 후 Enter 키로 추가…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "도로명 주소",
+      city: "시/군/구",
+      state: "시/도",
+      postalCode: "우편번호",
+      country: "국가",
+    },
     textarea: {
       characterCount: "글자 수: {{max}}자 중 {{count}}자",
       charactersRemaining: "{{count}}자 남음",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -260,6 +260,14 @@ const pt = {
     tags: {
       placeholder: "Digite e pressione Enter para adicionar…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "Endereço (rua)",
+      city: "Cidade",
+      state: "Estado / Província",
+      postalCode: "Código postal",
+      country: "País",
+    },
     textarea: {
       characterCount: "Contagem de caracteres: {{count}} de {{max}}",
       charactersRemaining: "Caracteres restantes: {{count}}",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -267,6 +267,14 @@ const ru = {
     tags: {
       placeholder: "Введите и нажмите Enter, чтобы добавить…",
     },
+    // objectui#4028 — `AddressField`'s five sub-labels.
+    address: {
+      street: "Улица и дом",
+      city: "Город",
+      state: "Область / штат",
+      postalCode: "Почтовый индекс",
+      country: "Страна",
+    },
     textarea: {
       characterCount: "Количество символов: {{count}} из {{max}}",
       charactersRemaining: "Осталось символов: {{count}}",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -268,6 +268,17 @@ const zh = {
     tags: {
       placeholder: '输入后回车添加…',
     },
+    // objectui#4028 — `AddressField`'s five sub-labels. These were English
+    // string literals with no key, and this pack is the one the issue was
+    // reported against: a zh-CN console showed five English words in the
+    // middle of an otherwise fully translated address form.
+    address: {
+      street: '街道地址',
+      city: '城市',
+      state: '省 / 州',
+      postalCode: '邮政编码',
+      country: '国家 / 地区',
+    },
     textarea: {
       characterCount: '已输入 {{count}} 个字符，最多 {{max}} 个',
       charactersRemaining: '还可输入 {{count}} 个字符',

--- a/packages/plugin-detail/src/__tests__/InlineFieldInput.composite.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineFieldInput.composite.test.tsx
@@ -150,8 +150,15 @@ describe('InlineFieldInput — structured composite values (objectui#4216)', () 
       );
       // The composite is still the editor when there is nothing stored yet —
       // that is how an address gets authored inline in the first place.
-      expect(screen.getByPlaceholderText('123 Main St')).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('San Francisco')).toBeInTheDocument();
+      //
+      // Located by LABEL, not by placeholder (objectui#4028). The sub-inputs
+      // used to be reachable as `getByPlaceholderText('123 Main St')`, but
+      // those placeholders were hardcoded US example text shown to every
+      // locale and are gone. The labels are the durable handle and the better
+      // one: they are what names each empty box for a user, and this suite is
+      // provider-free, so they resolve through `FIELD_DEFAULTS`' English.
+      expect(screen.getByLabelText('Street Address')).toBeInTheDocument();
+      expect(screen.getByLabelText('City')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Fixes #4028

## Premise re-check first — the dispatch's "already fixed" half was not fixed

The dispatch re-scoped this card on the finding that the five sub-labels "no longer exist as literals in `AddressField.tsx` — they were keyed by the composite-group-label work". **They still existed.** Measured on `origin/main` at `baa89a1ea` (the tip this branch forks from, and the same tree whose placeholder line numbers the dispatch quotes correctly at L118/133/146/161/174):

```
packages/fields/src/widgets/AddressField.tsx
111:  < Label htmlFor={subId('street')} className="text-xs">Street Address< /Label>
127:    < Label htmlFor={subId('city')} className="text-xs">City< /Label>
140:    < Label htmlFor={subId('state')} className="text-xs">State / Province< /Label>
155:    < Label htmlFor={subId('postalCode')} className="text-xs">ZIP / Postal Code< /Label>
168:    < Label htmlFor={subId('country')} className="text-xs">Country< /Label>
```

(The space after each angle bracket is a GitHub-sanitizer workaround, not part of the source.) Inline JSX children, no `t()` call, no key — exactly what the issue reports. What the composite-group-label work (objectui#3961 / #3990) did touch is the group **container's** naming (`toHostGroupProps`, the host `id` / `aria-labelledby` pair); it never went near the five sub-labels. The literals in `composite-group-label-e2e.test.tsx` that read like "keyed already" are that suite asserting `getByLabelText('Street Address')` provider-free — the English default, not a pack lookup.

So this PR implements the **whole** card, not the remainder: the sub-labels are keyed here for the first time, and that is a deviation from the dispatch's scope, taken because the premise excluding them was false and the issue's acceptance criteria include them.

## 1. Sub-labels are keyed (`fields.address.*`)

New keys in all ten packs and in `FIELD_DEFAULTS`:

| key | en |
|---|---|
| `fields.address.street` | Street Address |
| `fields.address.city` | City |
| `fields.address.state` | State / Province |
| `fields.address.postalCode` | ZIP / Postal Code |
| `fields.address.country` | Country |

`en` values are byte-identical to the literals they replace, and `FIELD_DEFAULTS` carries the same five, so English rendering and provider-less rendering are unchanged (pinned positively in `AddressField.no-provider.test.tsx`, not merely assumed). A `fields.address.*` namespace slots into the existing `fields.tags.*` / `fields.textarea.*` / `fields.options.*` shape with no new mechanism.

## 2. Placeholders: DROPPED, not keyed

`123 Main St` / `San Francisco` / `CA` / `94102` / `United States` are gone. The measurement behind choosing removal over ten-pack keys:

1. **Precedent, read from the packs themselves.** Every example-data placeholder the packs carry teaches a FORMAT its label cannot: `name@example.com` (local@domain), `+1 555 000 0000` (dial prefix), `Icon name (e.g. Users)` (which identifier). Each address box already has a visible label naming exactly what it wants, so its example added nothing but a country — and a US postal code's shape actively misinforms anyone whose own is a different length.
2. **The channel is wrong in principle.** The right example follows the address's COUNTRY, not the reader's language. Nothing in the stored value can supply one (this widget writes no `countryCode` — see the follow-up below), and a UI-language-keyed example is wrong for every cross-border address, which is the CRM case this was reported from. A Japanese example address shown to a zh user entering a US customer's address is the same defect with a different flag on it.
3. **Cost if keyed.** 50 pack entries of invented fictional address fragments, bound from then on by `check:i18n-drift`; each Latin-script one inside zh/ja/ko/ru/ar would additionally need an `untranslated-identity-4376` allowlist entry — an explicit written admission that the "translation" is not one.

Consistent with the dispatch's own instruction that US example text shown to a zh/ja/ar user is worse than no placeholder. Absence is asserted per locale, because a re-added `placeholder=` attribute is invisible to every i18n gate (they only ever look at keys).

## 3. Read-only part order is locale-aware

`formatAddress(addr, locale)` now has two orders, the second being exactly the first reversed:

- **small-to-large** (default; `en` and every Latin/Cyrillic/Arabic locale shipped) — `Street, City, State ZIP, Country`. Unchanged.
- **large-to-small** (`zh`, `ja`, `ko`) — `Country, ZIP State, City, Street`. The reported case: `中国, 310000 浙江, 杭州, 中策路 1 号`.

Only the ORDER varies. The separator stays `', '` in both — not what the issue reports, and these lines carry mixed-script data, where fullwidth punctuation would read stranger than the comma already there. The state/postal pair keeps its single comma group in both directions, and missing parts are still dropped rather than spaced over.

### AddressCellRenderer: touched, and here is the measurement that says it had to be

The dispatch permits touching it only if it provably shares the formatter and unification is measured. It does, and it is:

- `formatAddress` has exactly **two** callers on this branch — `AddressField`'s readonly branch and `AddressCellRenderer` (`grep -rn formatAddress packages/ apps/`). Their sharing one definition is not incidental; it is the entire point of objectui#4037, which exists because that rule previously had two spellings.
- Passing the locale on only one caller re-opens that exact drift, one build after it was closed: a `zh` console would show `中国, 310000 浙江, 杭州, 中策路 1 号` in a record's readonly form and the US-ordered line in the grid cell beside it — one stored address, two spellings, on two surfaces of one app.

The change there is two lines (`useDisplayLocale()` plus passing it), using the same resolver every other locale-aware cell renderer in that file already uses. Nothing else about the renderer moves: string / `{}` / unrecognized-shape branches are pinned unchanged under a `zh` provider.

## Tests

New: `AddressField.i18n.test.tsx` (labels under en/zh/ja/ar with an English-literal negative; placeholder absence per locale; readonly order zh vs the `es` Latin control vs `en`), `AddressField.no-provider.test.tsx` (the `FIELD_DEFAULTS` half — English, no raw key, unchanged readonly line), `AddressCellRenderer.locale-order.test.tsx` (the display side, resolved through `getCellRenderer` so a registry regression fails it too).

Changed: `InlineFieldInput.composite.test.tsx` located two sub-inputs by placeholder text; re-spelled to `getByLabelText`. The suite is provider-free, so the labels resolve through `FIELD_DEFAULTS` — a more durable handle than the example text, and the one that names each empty box for a real user.

**Reverse verification** (fix committed first, then `git checkout origin/main --` the three source files, re-run, restore): **16 failed / 9 passed**. The nine that stay green are the intended no-op pins — `en` labels, the `es` / `de` / `en` order controls, and the non-address branches — which is the direction to expect here: this change is designed to leave English and Latin locales byte-identical, so a reverse run that went fully red would have meant the controls were not controlling anything.

## Gates run locally (at `c22a9a87e`, the final commit)

| gate | result |
|---|---|
| `vitest packages/fields/` | 94 files, 1441 tests passed |
| `vitest packages/i18n/` | 45 files, 804 tests passed |
| `vitest` plugin-detail InlineFieldInput composite + delegation | 2 files, 51 tests passed |
| `type-check` fields / i18n / plugin-detail | Done (after building the dependency closure) |
| `lint` fields / i18n / plugin-detail | 0 errors (warnings pre-existing) |
| `check-changeset-presence.mjs` | 1 changeset declared for 15 changed source files |
| `check:i18n-keys` | 2932 en keys, every call-site key resolves |
| `check:i18n-drift` | 0 en values changed (5 keys added — parity's business, not drift's) |
| `check:i18n-dead-keys` | the 5 new keys are not among the candidates |
| `check:control-bytes` | OK, 4248 files |
| `check:spec-symbols`, `check:phantom-deps`, `changeset:check` | pass |

`@object-ui/fields` patch + `@object-ui/i18n` patch changeset added. (objectui has no `skip-changeset` mechanism; none was applied.)

## Follow-up filed

- #4738 (`finding`, unassigned) — the stated limit of this fix: part order follows the READER's locale because `AddressField` writes no `countryCode`, so nothing carries the address's own country. Also records that `de` / `fr` / `es` write the postal code before the city, which the current two-profile rule does not model. The test named `orders a US address by the READER, not by the address — the stated limit` exists to make that decision visible rather than silent, and is the pin that must move if #4738 is taken.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_