### PR TITLE
feat(lint): ban OData query params nested under a dead `options` key

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -5,6 +5,7 @@ import noSyntheticEventTrigger from './no-synthetic-event-trigger.js';
 import noInlineSpecConfig from './no-inline-spec-config.js';
 import noTryCatchAroundHook from './no-try-catch-around-hook.js';
 import noDynamicImportInTestHook from './no-dynamic-import-in-test-hook.js';
+import noQueryParamsUnderOptions from './no-query-params-under-options.js';
 import buttonHasType from './button-has-type.js';
 
 export default {
@@ -13,6 +14,7 @@ export default {
     'no-inline-spec-config': noInlineSpecConfig,
     'no-try-catch-around-hook': noTryCatchAroundHook,
     'no-dynamic-import-in-test-hook': noDynamicImportInTestHook,
+    'no-query-params-under-options': noQueryParamsUnderOptions,
     'button-has-type': buttonHasType,
   },
 };

--- a/eslint-rules/no-query-params-under-options.js
+++ b/eslint-rules/no-query-params-under-options.js
@@ -1,0 +1,123 @@
+/**
+ * ObjectUI ESLint rule: no-query-params-under-options
+ *
+ * Bans `$`-prefixed query keys nested under an `options` key —
+ * `find(obj, { options: { $top: 100 } })` instead of `find(obj, { $top: 100 })`.
+ *
+ * `QueryParams` (`packages/types/src/data.ts`) declares `$top`/`$skip`/
+ * `$filter`/`$orderby`/`$select`/`$expand`/`$search` at the TOP level, and
+ * `options` is not one of its keys. No adapter in this repo reads
+ * `params.options` — `convertQueryParams` in `@object-ui/data-objectstack` and
+ * `ApiDataSource` both read `params.$top` — so a cap written under `options`
+ * never reaches the wire and the query silently runs unbounded.
+ *
+ * Nothing else catches this. `QueryParams` carries `[key: string]: any`, which
+ * is deliberate (adapters accept adapter-specific params) but means the type
+ * system accepts both spellings equally: `{ options: { $top: 100 } }`
+ * type-checks exactly as well as `{ $top: 100 }`, and the two mean completely
+ * different things — the first means nothing at all.
+ *
+ * Two live instances existed, written by different people at different times:
+ *
+ *  - `object-timeline` — the whole fetch was
+ *    `find(objectName, { options: { $top: 100 } })` (fixed in objectui#4009 /
+ *    objectstack#7137).
+ *  - `object-kanban` — `$filter` at the top level, the cap under `options`, so
+ *    a board over a large object fetched every row the server would return for
+ *    as long as the block existed (fixed for objectui#4025).
+ *
+ * That is the reason this is mechanical rather than a review item: the shape
+ * reads as a deliberate grouping ("query options"), it type-checks, it
+ * publishes, and the symptom (too many rows) looks like a data problem rather
+ * than a code problem — so a review catches it once and then misses the next
+ * one. Error level, at write time: the editor squiggle interrupts at the moment
+ * the grouping is typed, which is where both authors made the mistake.
+ * objectui#4734.
+ *
+ * Scope, deliberately narrow so it discriminates rather than blanket-matches
+ * (measured on the repo at the time of writing: 47 object literals carry an
+ * `options` object property, and NOT ONE of them holds a `$`-prefixed key —
+ * `options: { data }`, `options: { kanban, calendar }`, `options: { sortBy,
+ * limit }` and so on are all normal and must stay silent):
+ *
+ *  - Only a `$`-prefixed key makes it a hit. `options` on its own is a
+ *    perfectly good key in this repo and always will be.
+ *  - Only STATIC key names — an identifier or a string literal. A computed key
+ *    (`{ [k]: v }`) cannot be judged without running the code, and a spread
+ *    (`{ ...params }`) hides its keys, so neither reports.
+ *  - Only an object-literal `options` property whose initializer is itself an
+ *    object literal. Prose gets this for free: every remaining textual match in
+ *    the repo is a comment or a test header describing the history, and an AST
+ *    rule never sees those.
+ *
+ * A known and deliberate boundary: the rule does not look at what the object
+ * is passed to, so a data field literally named `options` filtered with a
+ * Mongo-style operator (`$filter: { options: { $in: [...] } }`) would report.
+ * No such site exists in the repo — the census above found none — so the rule
+ * is not narrowed for it. If one ever appears, the narrowing that fits is
+ * "skip when the `options` property sits inside a `$`-prefixed property's
+ * value", which loses nothing real: nobody writes the dead spelling inside a
+ * filter.
+ *
+ * No autofixer on purpose. Hoisting the keys means merging them into the
+ * enclosing object, which can collide with a key already there (kanban had a
+ * top-level `$filter` beside the dead `options`), and dropping the now-empty
+ * wrapper is only safe when it held nothing else. Both are judgement calls.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+
+/** The key whose object value is dead weight on a `QueryParams`. */
+const DEAD_KEY = 'options';
+
+/**
+ * Static name of a property key, or null when it cannot be read off the AST
+ * (computed keys, spreads). Null always means "say nothing".
+ */
+function staticKeyName(node) {
+  if (node.type === 'SpreadElement' || node.type === 'ExperimentalSpreadProperty') return null;
+  if (node.computed) return null;
+  const key = node.key;
+  if (key.type === 'Identifier') return key.name;
+  if (key.type === 'Literal' && typeof key.value === 'string') return key.value;
+  return null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow `$`-prefixed query keys nested under an `options` key — `QueryParams` declares them at the top level and no adapter reads `params.options`, so the value never reaches the wire (objectui#4734).',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      deadOptionsKey:
+        '{{keys}} {{verb}} nested under `options`, where nothing reads {{them}}. `options` is not a `QueryParams` key and no data adapter in this repo reads `params.options`, so a cap or filter written there never reaches the wire — the query silently runs unbounded, which reads as a data problem rather than a code problem. `QueryParams` (@object-ui/types) declares these keys at the TOP level of the params object: write `find(obj, { $top: 100 })`, not `find(obj, { options: { $top: 100 } })`. Two blocks lost their row caps to exactly this spelling (objectui#4009, objectui#4025); see objectui#4734.',
+    },
+  },
+  create(context) {
+    return {
+      Property(node) {
+        if (staticKeyName(node) !== DEAD_KEY) return;
+        if (node.value.type !== 'ObjectExpression') return;
+
+        const dead = node.value.properties
+          .map((prop) => staticKeyName(prop))
+          .filter((name) => name !== null && name.startsWith('$'));
+        if (dead.length === 0) return;
+
+        context.report({
+          node: node.key,
+          messageId: 'deadOptionsKey',
+          data: {
+            keys: dead.map((name) => `\`${name}\``).join(', '),
+            verb: dead.length === 1 ? 'is' : 'are',
+            them: dead.length === 1 ? 'it' : 'them',
+          },
+        });
+      },
+    };
+  },
+};

--- a/eslint-rules/no-query-params-under-options.test.js
+++ b/eslint-rules/no-query-params-under-options.test.js
@@ -1,0 +1,198 @@
+/**
+ * Pins `no-query-params-under-options` in BOTH directions, because the rule is
+ * only worth having if it discriminates: `options` is a normal key in this repo
+ * (measured at the time of writing: 47 object literals carry an `options`
+ * object property, none of them with a `$`-prefixed key), so a rule that
+ * blanket-matched on the name would be uninstallable.
+ *
+ * The valid cases are therefore real shapes lifted from the repo —
+ * `options: { data }` (plugin-dashboard fixtures), `options: { kanban,
+ * calendar }` (ObjectView / ListView view registries), `options: { sortBy,
+ * sortOrder, limit }` (DatasetWidget), `options: { empty, selectFirst }` (every
+ * i18n locale) — plus the shapes the rule deliberately cannot judge (computed
+ * keys, spreads) and the correct spelling it exists to leave alone.
+ *
+ * The invalid cases are the two live instances this rule was written for, in
+ * the exact form they shipped: `object-timeline`'s whole fetch
+ * (`find(objectName, { options: { $top: 100 } })`, objectui#4009 /
+ * objectstack#7137) and `object-kanban`'s split spelling (`$filter` at the top
+ * level, the cap under `options`, objectui#4025) — the second being the one
+ * that made a board fetch every row the server would return.
+ *
+ * The prose direction needs no case here and deliberately has none: every
+ * remaining textual match in the repo is a comment or a test header describing
+ * that history, and an AST rule cannot see a comment. That is the whole reason
+ * the card chose an AST signature over a text scan.
+ */
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import rule from './no-query-params-under-options.js';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-query-params-under-options', rule, {
+  valid: [
+    // The correct spelling — the whole point of the rule.
+    `dataSource.find(objectName, { $top: 100 });`,
+    `dataSource.find(objectName, { $filter: filter, $top: 100, $orderby: 'name asc' });`,
+    // A primary-key lookup capped at the top level (packages/fields).
+    `dataSource.find(objectName, { $filter: { _id: id }, $top: 1 });`,
+
+    // `options` objects with no `$`-prefixed key at all — all real repo shapes.
+    `renderWidget(widget, { options: { data: rows } });`,
+    `const schema = { options: { kanban: {}, calendar: {}, timeline: {} } };`,
+    `const widget = { type: 'table', options: { sortBy: 'amount', sortOrder: 'desc', limit: 5 } };`,
+    `const strings = { options: { empty: 'No options', selectFirst: 'Select first' } };`,
+    `const view = { options: {} };`,
+
+    // A `$`-prefixed key at the top level, beside a legitimate `options` object:
+    // the sibling is not what makes the mistake.
+    `dataSource.find(objectName, { $top: 100 }, { options: { density: 'compact' } });`,
+
+    // Not an object literal on the right-hand side — nothing to read.
+    `const params = { options };`,
+    `const params = { options: buildOptions() };`,
+    `const params = { options: existingOptions };`,
+    `const params = { options: null };`,
+
+    // Keys the AST cannot resolve. Both directions of "say nothing" rather than
+    // guess: a computed key may or may not be `$top`, a spread hides its keys.
+    `const params = { options: { [key]: 100 } };`,
+    `const params = { options: { ...queryParams } };`,
+    `const params = { [wrapper]: { $top: 100 } };`,
+
+    // A different wrapper name is a different question — this rule is about the
+    // one spelling that has already cost two blocks their row caps.
+    `const params = { config: { $top: 100 } };`,
+    `const params = { query: { $top: 100 } };`,
+
+    // `$`-prefixed keys nested one level deeper under a legitimate `options`
+    // object are somebody else's structure, not a misplaced query param.
+    `const params = { options: { filter: { $gt: 5 } } };`,
+
+    // A Mongo-style operator object under a NON-`options` field name is exactly
+    // how `$filter` is written repo-wide, and must stay silent.
+    `dataSource.find(objectName, { $filter: { amount: { $gte: 100 } }, $top: 50 });`,
+  ],
+  invalid: [
+    // objectui#4009 / objectstack#7137 — object-timeline's entire fetch.
+    {
+      code: `const result = await dataSource.find(objectName, { options: { $top: 100 } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // objectui#4025 — object-kanban: `$filter` top level, the cap stranded
+    // under `options`. The board fetched every row the server would return.
+    {
+      code: `const result = await dataSource.find(objectName, { $filter: filter, options: { $top: 100 } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // Any `$`-prefixed key, not just the paging pair — the whole OData surface
+    // is declared at the top level.
+    {
+      code: `find(obj, { options: { $filter: { status: 'open' } } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    {
+      code: `find(obj, { options: { $orderby: 'name asc' } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    {
+      code: `find(obj, { options: { $select: ['id', 'name'] } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    {
+      code: `find(obj, { options: { $expand: ['owner'] } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // An adapter-specific `$`-prefixed key is dead there for the same reason.
+    {
+      code: `find(obj, { options: { $customAdapterKey: true } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // Quoted keys are the same keys.
+    {
+      code: `find(obj, { 'options': { '$top': 100 } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // One mistake, one report — the wrapper is the defect, not each key. A
+    // per-key report would put three squiggles on one grouping.
+    {
+      code: `find(obj, { options: { $top: 100, $skip: 20, $orderby: 'name' } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // A spread hides its own keys but does not excuse the visible one.
+    {
+      code: `find(obj, { options: { ...base, $top: 100 } });`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // The params object need not be written at the call site — the type system
+    // accepts this spelling just as readily one variable away.
+    {
+      code: `const params = { options: { $top: 100 } }; dataSource.find(objectName, params);`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // Nested anywhere, at any depth.
+    {
+      code: `const config = { data: { query: { options: { $top: 100 } } } };`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    // Two separate wrappers are two separate mistakes.
+    {
+      code: `const a = { options: { $top: 100 } }; const b = { options: { $skip: 20 } };`,
+      errors: [{ messageId: 'deadOptionsKey' }, { messageId: 'deadOptionsKey' }],
+    },
+    // The message has to say where the key belongs, or the author is left to
+    // guess the correct spelling — which is how the second instance happened.
+    {
+      code: `find(obj, { options: { $top: 100 } });`,
+      errors: [
+        {
+          message: /`\$top` is nested under `options`.+declares these keys at the TOP level.+find\(obj, \{ \$top: 100 \}\)/s,
+        },
+      ],
+    },
+  ],
+});
+
+/**
+ * The same rule under the parser it actually runs with. `eslint.config.js`
+ * applies it to every `.ts`/`.tsx` file through typescript-eslint, and
+ * TypeScript adds shapes espree cannot express — one of which MUST stay silent.
+ */
+const tsRuleTester = new RuleTester({
+  languageOptions: { parser: tseslint.parser },
+});
+
+tsRuleTester.run('no-query-params-under-options (typescript)', rule, {
+  valid: [
+    // A TYPE declaration is not a value. `QueryParams` itself, and every
+    // adapter option type in the repo, declares object-shaped members this way;
+    // a rule that reported here would be unusable in `packages/types`.
+    `interface FetchConfig { options?: { $top?: number; $skip?: number } }`,
+    `type FetchConfig = { options?: { $top?: number } };`,
+    `declare function find(obj: string, params?: { options?: { $top?: number } }): void;`,
+    // A typed but correct call.
+    `const params: QueryParams = { $top: 100, $filter: { status: 'open' } };`,
+  ],
+  invalid: [
+    // A cast does not change the shape, and `satisfies` is where the index
+    // signature's tolerance is most visible: this passes type-checking.
+    {
+      code: `const params = { options: { $top: 100 } } as QueryParams;`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    {
+      code: `const params = { options: { $top: 100 } } satisfies QueryParams;`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+    {
+      code: `const params: QueryParams = { options: { $top: 100 } };`,
+      errors: [{ messageId: 'deadOptionsKey' }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,6 +71,19 @@ export default tseslint.config({
     // Error so a tenth copy fails CI; all known sites were converted first, so
     // this lints clean today.
     'object-ui/no-try-catch-around-hook': 'error',
+    // objectui#4734 ratchet — `find(obj, { options: { $top: 100 } })`. The
+    // paging/filter keys are declared at the TOP level of `QueryParams`, no
+    // adapter reads `params.options`, and `QueryParams`'s deliberate
+    // `[key: string]: any` means the misplaced spelling type-checks exactly as
+    // well as the correct one — so nothing rejected it. Two blocks shipped it
+    // (object-timeline, objectui#4009/objectstack#7137; object-kanban,
+    // objectui#4025) and each fetched every row the server would return, a
+    // symptom that reads as a data problem rather than a code problem. Error so
+    // the next one fails at write time; the repo is at zero live instances, so
+    // this lints clean today with no allowlist. Unscoped on purpose: the
+    // signature needs no exemptions — 47 legitimate `options` objects exist
+    // repo-wide and not one carries a `$`-prefixed key.
+    'object-ui/no-query-params-under-options': 'error',
     // objectui#3090 tripwire — the spec's FormField/FormFieldSchema are the
     // form-VIEW vocabulary (`field` = object-field reference), a DIFFERENT
     // layer from objectui's runtime form-field contract (`name` = data path);


### PR DESCRIPTION
Fixes #4734

Installs `object-ui/no-query-params-under-options` — the ESLint rule the card's A/B fork was adjudicated to (Option B, error level, the `eslint-rules/` house pattern of `no-dynamic-import-in-test-hook`: rule + RuleTester test). The `check:*` script of Option A is deliberately not built.

## The defect it nets

`find(obj, { options: { $top: 100 } })` type-checks exactly as well as `find(obj, { $top: 100 })` and means nothing at all. `QueryParams` (`packages/types/src/data.ts`) declares its paging and filter keys at the **top level**, `options` is not one of them, and no adapter in this repo reads `params.options` — `convertQueryParams` in `@object-ui/data-objectstack` and `ApiDataSource` both read `params.$top`. So a cap written under `options` never reaches the wire and the query silently runs unbounded.

Nothing rejected it before this PR. `QueryParams` carries `[key: string]: any`, which is deliberate (adapters accept adapter-specific params) and means the type system accepts both spellings equally. Two blocks shipped the dead one, written by different people at different times — `object-timeline` (#4009, the whole fetch) and `object-kanban` (#4025, `$filter` at the top level with the cap one level down) — and the second fetched every row the server would return for as long as the block existed. The shape reads as a deliberate grouping ("query options"), it type-checks, it publishes, and the symptom (too many rows) reads as a data problem rather than a code problem, so review catches it once and misses the next one.

## The rule

Signature, exactly as the card specifies it: an object-literal property named `options` whose initializer is an object literal holding at least one property whose name starts with `$`. It reports once per wrapper (the wrapper is the mistake, not each key), on the `options` key itself, and the message says where the key belongs:

```
`$top` is nested under `options`, where nothing reads it. `options` is not a
`QueryParams` key and no data adapter in this repo reads `params.options`, so a
cap or filter written there never reaches the wire — the query silently runs
unbounded, which reads as a data problem rather than a code problem.
`QueryParams` (@object-ui/types) declares these keys at the TOP level of the
params object: write `find(obj, { $top: 100 })`, not
`find(obj, { options: { $top: 100 } })`. …
```

Wired in `eslint.config.js` at `error`, unscoped, alongside the other repo-wide `object-ui/*` ratchets. Deliberately silent on what it cannot judge: computed keys (`{ [k]: v }`), spreads (`{ ...params }`), a non-object initializer, and TypeScript type declarations (a `TSPropertySignature` is not a value). Comments come free — every remaining textual match in the repo is a comment or test header describing this history, and an AST rule cannot see a comment. That is why the card chose an AST signature over a text scan. No autofixer: hoisting the keys can collide with a key already in the enclosing object (kanban had a top-level `$filter` beside the dead `options`), and dropping the emptied wrapper is only safe when it held nothing else.

## No allowlist, and the census behind that claim

The rule ships green with no allowlist and no debt entry. An AST census over `packages`/`apps`/`examples`/`e2e`/`scripts` (3059 `.ts`/`.tsx` files) found **47** object literals carrying an `options` object property and **not one** with a `$`-prefixed key — `options: { data }`, `options: { kanban, calendar }`, `options: { sortBy, sortOrder, limit }`, `options: { empty, selectFirst }` and so on. Those real shapes are the RuleTester's valid cases, so the rule is pinned to discriminate rather than blanket-match on the name.

One boundary is documented in the rule rather than coded around: the rule does not look at what the object is passed to, so a data field literally named `options` filtered with a Mongo-style operator (`$filter: { options: { $in: [...] } }`) would report. The census found no such site, so it is not narrowed for one — the narrowing that would fit is recorded in the rule's docblock for whoever meets it first.

## Verification (all at `b4c77bc2a`, the head of this branch)

- **Full-workspace lint** — `pnpm lint --concurrency=2`: `47 successful, 47 total`, `0 cached, 47 total` (the new rule file is inside turbo's `lint` inputs, so nothing replayed a pre-rule verdict), **0 errors** repo-wide; every package summary reads `0 errors`, the warnings are the pre-existing `no-explicit-any` population.
- **Reverse verification** — reintroduced the exact historical spelling into `packages/plugin-kanban/src/ObjectKanban.tsx` (`options: { $top: schema.limit ?? DEFAULT_KANBAN_LIMIT }`) on top of the committed rule: `234:17  error  … object-ui/no-query-params-under-options`, `1 error, 33 warnings`, exit 1. Restored from the branch, back to `0 errors, 33 warnings`, exit 0.
- **RuleTester** — `pnpm exec vitest run eslint-rules/no-query-params-under-options.test.js`: 41 tests, both directions (17 invalid shapes including both historical instances, quoted keys, spreads and casts; 24 valid including the census shapes and the correct top-level spelling). Whole `eslint-rules/` suite plus the lint-config guards: `9 passed`, `180 tests`.
- **`scripts/`** — `pnpm exec vitest run scripts/`: `44 passed`, `983 tests` (includes `turbo-lint-inputs`, which derives turbo's `lint` inputs from the ESLint program, and `lint-workflow`, which forbids re-enumerating the ratchets outside the config).
- **`node scripts/check-changeset-presence.mjs`** — `No source of a released package changed in this range, so no changeset is owed`, exit 0. `check-control-bytes` and `check-lint-coverage` (46/46 packages linted) also green.

No type-check run: the change is four `.js` files and no config typing.

Out of scope, unchanged here: the wider "unknown `QueryParams` key" question. The index signature is deliberate, so tightening it is a separate design decision — #4734 covers the one spelling that has already cost two blocks their row caps.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_