### PR TITLE
fix(components,plugin-list,app-shell): keep a value-less filter row instead of dropping it as incomplete

### DIFF
--- a/.changeset/valueless-filter-row-drop.md
+++ b/.changeset/valueless-filter-row-drop.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/components': patch
+'@object-ui/plugin-list': patch
+'@object-ui/app-shell': patch
+---
+
+Fix a list filter that silently applied nothing when the first thing you picked was **Is null** or **Is not null**.
+
+Adding a filter seeds the row with no value, and changing the operator keeps it that way — which is correct for an operator that takes no value, since the panel draws no input for one. The live grid read that row as unfinished and dropped it: the filter appeared in the panel, the query went out without it, and every record came back with no error to explain it. Only `Is empty` / `Is not empty` were exempt; the builder renders six operators value-less.
+
+Which operators are complete without a value now has a single owner — `VALUELESS_FILTER_BUILDER_OPERATORS`, exported from `@object-ui/components` beside the code that decides it. The live grid and the saved-view fold both read it instead of keeping their own lists, so the two halves of one interaction can no longer disagree about whether a row is finished.

--- a/packages/app-shell/src/views/viewFilterFold.emptyValue.test.ts
+++ b/packages/app-shell/src/views/viewFilterFold.emptyValue.test.ts
@@ -34,9 +34,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { VALUELESS_FILTER_BUILDER_OPERATORS } from '@object-ui/components';
 import { foldFilterGroupToSpecRules, VALUELESS_FILTER_OPERATORS } from './viewFilterFold';
 
 const group = (conditions: unknown[], logic = 'and') => ({ id: 'root', logic, conditions });
@@ -127,25 +125,43 @@ describe('foldFilterGroupToSpecRules — incomplete rows are not persisted (#415
     });
 });
 
-describe('VALUELESS_FILTER_OPERATORS — parity with the builder’s own list', () => {
+/**
+ * This pin used to read `filter-builder.tsx` as TEXT and scrape the operator
+ * list out of `needsValueInput` with a regex, because the builder kept that
+ * list as an inline literal and there was nothing to import. objectui#4744
+ * gave it a name — `VALUELESS_FILTER_BUILDER_OPERATORS`, which `needsValueInput`
+ * is now defined as the complement OF — so the parity check reads the value
+ * itself. Same guarantee, minus a regex that goes quietly non-matching the day
+ * someone reformats the function it parses.
+ *
+ * What this file no longer has to assert is that the builder actually RENDERS
+ * no value input for each id: that is a fact about the component, and it is
+ * pinned where the component lives —
+ * `components/src/__tests__/filter-builder-valueless-operators.test.tsx`
+ * drives the real render for every member of the set.
+ */
+describe('VALUELESS_FILTER_OPERATORS — parity with the builder’s own set', () => {
     it('covers every operator for which the FilterBuilder renders no value input', () => {
-        const builderSrc = readFileSync(
-            path.join(
-                path.dirname(fileURLToPath(import.meta.url)),
-                '../../../components/src/custom/filter-builder.tsx',
-            ),
-            'utf8',
-        );
-        // `const needsValueInput = (operator: string) => { return ![...].includes(operator) }`
-        const match = builderSrc.match(/needsValueInput\s*=\s*\(operator: string\)\s*=>\s*\{\s*return\s*!\[([^\]]*)\]/);
-        expect(match, 'the builder’s needsValueInput list moved — re-point this parity check').not.toBeNull();
-        const builderValueless = [...match![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-        expect(builderValueless.length).toBeGreaterThan(0);
-        for (const operator of builderValueless) {
+        expect(VALUELESS_FILTER_BUILDER_OPERATORS.size).toBeGreaterThan(0);
+        for (const operator of VALUELESS_FILTER_BUILDER_OPERATORS) {
             expect(
                 VALUELESS_FILTER_OPERATORS.has(operator),
                 `the builder renders no value input for "${operator}", so the fold must not drop it as incomplete`,
             ).toBe(true);
+        }
+    });
+
+    it('adds the canonical spec spellings the builder never sees', () => {
+        // The fold reads a stored `ViewFilterRule`, whose operator has been
+        // through `normalizeFilterOperator`; those spellings are this layer's
+        // own addition and belong to no dropdown.
+        for (const operator of ['is_empty', 'is_not_empty', 'is_null', 'is_not_null']) {
+            expect(VALUELESS_FILTER_OPERATORS.has(operator), operator).toBe(true);
+            expect(
+                VALUELESS_FILTER_BUILDER_OPERATORS.has(operator),
+                `"${operator}" is a canonical spec spelling, not a builder id — it must not `
+                    + 'have crept into the shared set',
+            ).toBe(false);
         }
     });
 });

--- a/packages/app-shell/src/views/viewFilterFold.ts
+++ b/packages/app-shell/src/views/viewFilterFold.ts
@@ -31,6 +31,7 @@
 
 import { normalizeFilterOperator } from '@objectstack/spec/ui';
 import type { ViewFilterRule } from '@objectstack/spec/ui';
+import { VALUELESS_FILTER_BUILDER_OPERATORS } from '@object-ui/components';
 
 /** Why a group could not be folded to a flat spec rule list. */
 export type FilterFoldRefusal =
@@ -67,17 +68,23 @@ interface FilterGroupLike {
  * Since objectui#4736 the dropdown no longer OFFERS them to any consumer that
  * folds through here (they moved behind `OPT_IN_OPERATORS`, and only
  * `FilterConditionField` — which writes MongoDB-style criteria, never a view
- * rule — opts in), so the live path stopped producing them. They stay because
- * `needsValueInput` still draws them value-less for that widget, and because
- * stored metadata may carry one; the parity test below is what forces that.
+ * rule — opts in), so the live path stopped producing them. They are still in
+ * the set because `needsValueInput` still draws them value-less for that
+ * widget, and because stored metadata may carry one — and they now arrive by
+ * IMPORT rather than by being re-listed here, so that reasoning lives at the
+ * one place that owns it.
  *
- * `viewFilterFold.emptyValue.test.ts` pins this set against the builder's own
- * list so the two cannot drift apart unnoticed.
+ * The builder half is no longer restated here: it is imported from
+ * `@object-ui/components`, the module whose `needsValueInput` decides it
+ * (objectui#4744). This layer only ADDS what the builder never sees — the
+ * canonical spec spellings a stored `ViewFilterRule` carries.
+ * `viewFilterFold.emptyValue.test.ts` pins the union against that import so a
+ * new value-less operator upstream cannot land here half-applied.
  */
 export const VALUELESS_FILTER_OPERATORS: ReadonlySet<string> = new Set([
-    // FilterBuilder vocabulary
-    'isEmpty', 'isNotEmpty', 'isNull', 'isNotNull', 'exists', 'notExists',
-    // …and their canonical spec spellings
+    // FilterBuilder vocabulary — the one shared set, not a copy of it.
+    ...VALUELESS_FILTER_BUILDER_OPERATORS,
+    // …and their canonical spec spellings, which only this layer sees.
     'is_empty', 'is_not_empty', 'is_null', 'is_not_null',
 ]);
 

--- a/packages/components/src/__tests__/filter-builder-valueless-operators.test.tsx
+++ b/packages/components/src/__tests__/filter-builder-valueless-operators.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `VALUELESS_FILTER_BUILDER_OPERATORS` states a fact about this component:
+ * these are the operator ids for which it renders no value input, so a row
+ * carrying one is COMPLETE with no value (objectui#4744).
+ *
+ * Two other packages act on that fact — `plugin-list`'s
+ * `convertFilterGroupToAST` decides whether to QUERY such a row, `app-shell`'s
+ * `foldFilterGroupToSpecRules` decides whether to PERSIST it — and both now
+ * import the set rather than restating it. That import makes them agree with
+ * the set; it does not make the set true. This file is what makes it true: it
+ * drives the real render for every member and asserts the value input is
+ * actually absent.
+ *
+ * Why that matters and is not ceremony: the previous parity check for this
+ * lived in `app-shell` and read `filter-builder.tsx` as TEXT, regex-scraping
+ * the literal out of `needsValueInput`. It could only ever see what the list
+ * SAID. A `needsValueInput` that grew a second condition — a field type that
+ * suppresses the input, an early return — would have left the scrape green and
+ * the set wrong, and the consumers would have kept a row the user has no way
+ * to fill in.
+ *
+ * DIRECTION, predicted before running: green on the fix, and green before it
+ * too — this pins what must NOT change about the component. Its discriminating
+ * power is the control case below (an operator NOT in the set must render an
+ * input), which is what stops the sweep from passing on a builder that renders
+ * no value input for anything.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  FilterBuilder,
+  VALUELESS_FILTER_BUILDER_OPERATORS,
+  FILTER_BUILDER_OPERATORS,
+} from '../custom/filter-builder';
+
+const FIELDS = [{ value: 'title', label: 'Title', type: 'text' }];
+
+/** One row, one operator — the shape the panel holds while the user edits. */
+function renderRow(operator: string) {
+  return render(
+    <FilterBuilder
+      fields={FIELDS as any}
+      value={{
+        id: 'root',
+        logic: 'and',
+        // `value: ''` deliberately: the seed `addCondition` writes, and what a
+        // row still carries after the operator dropdown is changed (it updates
+        // `operator` alone). This is the exact state that was being discarded.
+        conditions: [{ id: 'c1', field: 'title', operator, value: '' }],
+      } as any}
+      onChange={vi.fn()}
+    />,
+  );
+}
+
+/**
+ * The value input is the only `<input>` the row draws — the field and operator
+ * pickers are Radix selects, i.e. buttons. Counting elements rather than
+ * matching a placeholder keeps this independent of the active locale.
+ */
+const valueInputCount = (container: HTMLElement) =>
+  container.querySelectorAll('input').length;
+
+describe('VALUELESS_FILTER_BUILDER_OPERATORS is what the builder actually draws', () => {
+  it('names a non-empty set of ids the builder can draw', () => {
+    // Guards the sweep below against passing on an empty set, and the set
+    // against drifting off the vocabulary entirely.
+    expect(VALUELESS_FILTER_BUILDER_OPERATORS.size).toBeGreaterThan(0);
+    for (const operator of VALUELESS_FILTER_BUILDER_OPERATORS) {
+      expect(
+        FILTER_BUILDER_OPERATORS,
+        `"${operator}" is in the value-less set but is not an id this builder can draw`,
+      ).toContain(operator);
+    }
+  });
+
+  it.each([...VALUELESS_FILTER_BUILDER_OPERATORS])(
+    'renders no value input for %s',
+    (operator) => {
+      const { container } = renderRow(operator);
+      expect(
+        valueInputCount(container),
+        `the builder drew a value input for "${operator}", so it is NOT value-less. `
+          + 'Consumers reading VALUELESS_FILTER_BUILDER_OPERATORS will keep a row the '
+          + 'user was given a field to fill in and left empty — an unfinished row '
+          + 'treated as finished',
+      ).toBe(0);
+    },
+  );
+
+  // The control. Without it the sweep above is satisfied by a builder that
+  // renders no value input at all, for any operator.
+  it('renders exactly one value input for an operator that takes a value', () => {
+    expect(VALUELESS_FILTER_BUILDER_OPERATORS.has('equals')).toBe(false);
+    const { container } = renderRow('equals');
+    expect(valueInputCount(container)).toBe(1);
+  });
+});

--- a/packages/components/src/custom/filter-builder.tsx
+++ b/packages/components/src/custom/filter-builder.tsx
@@ -211,6 +211,48 @@ export const FILTER_BUILDER_OPERATORS = defaultOperators.map(o => o.value)
 /** An operator id the FilterBuilder can render. */
 export type FilterBuilderOperator = (typeof defaultOperators)[number]['value']
 
+/**
+ * Operator ids for which this builder renders NO value input — so "no value"
+ * is the row's FINISHED state, not an unfinished one (objectui#4744).
+ *
+ * This is the source of truth for that distinction, and it lives here because
+ * this component is the thing that decides it: `needsValueInput` below is
+ * defined as the complement of this set, so the two cannot say different
+ * things. Every consumer that has to tell a complete value-less row from a
+ * half-filled one reads it FROM here rather than restating it:
+ *
+ *   - `plugin-list`'s `convertFilterGroupToAST` — what the live grid QUERIES;
+ *   - `app-shell`'s `foldFilterGroupToSpecRules` — what a saved view PERSISTS
+ *     (its `VALUELESS_FILTER_OPERATORS` is this set plus the canonical spec
+ *     spellings, which only that layer sees).
+ *
+ * Placement is forced by the dependency graph — `app-shell` depends on
+ * `plugin-list` depends on this package, so this is the only module all three
+ * can reach — and it is also where the set belongs on the merits: the fact it
+ * states is a fact about what this dropdown draws.
+ *
+ * Why it exists at all: each consumer used to keep its own copy, and the
+ * live-grid copy listed only `isEmpty`/`isNotEmpty`. A fresh row is seeded
+ * `{ operator: 'equals', value: '' }` and the operator dropdown preserves
+ * `value`, so picking **Is null** as the first action left `value: ''` — the
+ * grid read that as an unfinished row, dropped it, and applied NO filter at
+ * all while the panel showed one. Silent, and every record came back.
+ *
+ * `exists` / `notExists` stay listed even though `OPT_IN_OPERATORS` withholds
+ * them from most consumers (objectui#4736): the builder still draws them
+ * value-less for `FilterConditionField`, which is exactly what this set
+ * describes. Whether a consumer can EXPRESS an operator is a separate
+ * question, answered by `OPT_IN_OPERATORS` and by each consumer's parity test.
+ */
+export const VALUELESS_FILTER_BUILDER_OPERATORS: ReadonlySet<string> = new Set([
+  "isEmpty",
+  "isNotEmpty",
+  "isNull",
+  "isNotNull",
+  "exists",
+  "notExists",
+])
+
 const useSafeFilterTranslation = createSafeTranslation(
   {
     'filterBuilder.where': 'Where',
@@ -403,8 +445,11 @@ function FilterBuilder({
     return operatorsForFieldType(field?.type, extraOperators)
   }
 
+  // The complement of the exported set, never a second literal beside it:
+  // that set's whole job is to let other layers know which rows this builder
+  // leaves value-less, and a hand-kept copy here is how they drifted apart.
   const needsValueInput = (operator: string) => {
-    return !["isEmpty", "isNotEmpty", "isNull", "isNotNull", "exists", "notExists"].includes(operator)
+    return !VALUELESS_FILTER_BUILDER_OPERATORS.has(operator)
   }
 
   const getInputType = (fieldValue: string) => {

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -11,6 +11,7 @@ import { cn, Button, Input, Popover, PopoverContent, PopoverTrigger, FilterBuild
 import type { SortItem } from '@object-ui/components';
 import { Search, SlidersHorizontal, ArrowUpDown, X, EyeOff, Pencil, Group, Paintbrush, Ruler, Inbox, Download, AlignJustify, Rows4, Rows3, Rows2, Share2, Printer, Plus, Trash2, CheckSquare, AlertTriangle, ShieldAlert, RotateCw, Loader2, icons, type LucideIcon } from 'lucide-react';
 import type { FilterGroup } from '@object-ui/components';
+import { VALUELESS_FILTER_BUILDER_OPERATORS } from '@object-ui/components';
 import { ViewSwitcherDropdown, ViewType } from './ViewSwitcher';
 import { ViewSettingsPopover } from './components/ViewSettingsPopover';
 import { UserFilters } from './UserFilters';
@@ -411,8 +412,15 @@ export function convertFilterGroupToAST(group: FilterGroup): any[] {
 
   const conditions = group.conditions
     .filter(c => {
-      // isEmpty/isNotEmpty carry no value input — always keep them.
-      if (c.operator === 'isEmpty' || c.operator === 'isNotEmpty') return true;
+      // A value-less OPERATOR is complete without a value — the builder draws
+      // no value input for it, so "no value" is the row's finished state
+      // (objectui#4744). Read from `@object-ui/components`, which is the thing
+      // that decides it; the two-operator literal that used to stand here
+      // listed `isEmpty`/`isNotEmpty` only, so a fresh `Is null` row — seeded
+      // `value: ''` by `addCondition`, and left that way because the operator
+      // dropdown preserves `value` — was dropped as unfinished. The grid then
+      // applied NO filter while the panel showed one.
+      if (VALUELESS_FILTER_BUILDER_OPERATORS.has(c.operator)) return true;
       // Skip incomplete rows (no value entered yet). Emitting `[field, op, '']`
       // would be a silently-wrong filter (matches only empty) rather than
       // "no filter", excluding all rows. Matches groupToCondition in
@@ -423,6 +431,17 @@ export function convertFilterGroupToAST(group: FilterGroup): any[] {
     .map(c => {
       if (c.operator === 'isEmpty') return [c.field, '=', null];
       if (c.operator === 'isNotEmpty') return [c.field, '!=', null];
+      // A value-less row's third slot is emitted as `null` rather than as
+      // whatever `c.value` still holds: the operator dropdown PRESERVES the
+      // previous operator's value, so an `Is null` row can carry a leftover
+      // `'abc'` the user can no longer see or edit. The spec's own lowering
+      // (`convertComparison`, `@objectstack/spec/data`) ignores the third slot
+      // for `isnull`/`isnotnull` — it emits `{ [field]: { $null: true|false } }`
+      // — so `null` is inert on the wire and keeps the emission a function of
+      // the operator alone. Same shape the `isEmpty` arms above already use.
+      if (VALUELESS_FILTER_BUILDER_OPERATORS.has(c.operator)) {
+        return [c.field, mapOperator(c.operator), null];
+      }
       return [c.field, mapOperator(c.operator), c.value];
     });
 

--- a/packages/plugin-list/src/__tests__/convertFilterGroupToAST.test.ts
+++ b/packages/plugin-list/src/__tests__/convertFilterGroupToAST.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { VALID_AST_OPERATORS, isFilterAST } from '@objectstack/spec/data';
+import { VALUELESS_FILTER_BUILDER_OPERATORS } from '@object-ui/components';
 import { convertFilterGroupToAST } from '../ListView';
 import type { FilterGroup } from '@object-ui/components';
 
@@ -36,6 +38,20 @@ describe('convertFilterGroupToAST', () => {
     expect(convertFilterGroupToAST(group)).toEqual(['x', '=', null]);
   });
 
+  it('keeps a fresh `Is null` row — no value is that row’s finished state', () => {
+    // objectui#4744. The reachable sequence, in three clicks: `Add filter`
+    // seeds `{ field: <first column>, operator: 'equals', value: '' }`, the
+    // operator dropdown updates `operator` ALONE (so `value` stays `''`), and
+    // the builder draws no value input for `isNull` — there is nothing left
+    // for the user to do. This emitted `[]` before the fix: no filter at all,
+    // no error, every record returned while the panel showed a condition.
+    const group: FilterGroup = {
+      logic: 'and',
+      conditions: [{ field: 'closed_at', operator: 'isNull', value: '' }],
+    } as FilterGroup;
+    expect(convertFilterGroupToAST(group)).toEqual(['closed_at', 'isnull', null]);
+  });
+
   it('drops only the incomplete row in a mixed group', () => {
     const group: FilterGroup = {
       logic: 'and',
@@ -46,5 +62,116 @@ describe('convertFilterGroupToAST', () => {
     } as FilterGroup;
     // Single surviving condition unwraps to the bare triplet.
     expect(convertFilterGroupToAST(group)).toEqual(['a', '=', 'foo']);
+  });
+});
+
+/**
+ * The fresh-row emission table (objectui#4744).
+ *
+ * This is the measurement that opened the issue, turned into a pin. One
+ * condition per value-less operator, each with the `value: ''` a fresh row
+ * carries, and the exact node it must produce. Measured against the code this
+ * fixes, four of the six emitted `[]` — "no filter":
+ *
+ *   isEmpty    -> ["name","=",null]      isNull     -> []   ← the defect
+ *   isNotEmpty -> ["name","!=",null]     isNotNull  -> []   ← the defect
+ *                                        exists     -> []
+ *                                        notExists  -> []
+ *
+ * It is a table over the SET rather than a list of four cases on purpose: the
+ * totality check below fails if a new value-less operator appears upstream and
+ * nobody comes here to say what the live grid emits for it. That is the same
+ * silence this bug lived in — the set grew from two to six over three issues
+ * and this function was never told.
+ */
+describe('convertFilterGroupToAST — every value-less operator emits a real node', () => {
+  /** The node each value-less operator must emit for a row that has no value. */
+  const EMITTED: Record<string, unknown[]> = {
+    // Resolved to a null comparison before `mapOperator` is consulted — these
+    // two already worked, and are pinned so the fix cannot regress them.
+    isEmpty: ['f', '=', null],
+    isNotEmpty: ['f', '!=', null],
+    // The defect. `mapOperator` has had these rows all along and both spellings
+    // are members of `VALID_AST_OPERATORS`; the row simply never reached it.
+    isNull: ['f', 'isnull', null],
+    isNotNull: ['f', 'isnotnull', null],
+    // Kept for the same reason as the rest — the builder draws them value-less
+    // — and NOT expressible on this dialect: `mapOperator` has no row, so the
+    // id passes through verbatim and the AST gate refuses the whole filter.
+    // That is why they are withheld from this toolbar entirely (objectui#4736,
+    // `OPT_IN_OPERATORS`); `list-offered-operator-expressible-parity.test.ts`
+    // is what keeps them off it. Unreachable here, pinned here so a future
+    // decision to offer them lands as a red test rather than as a broken query.
+    exists: ['f', 'exists', null],
+    notExists: ['f', 'notExists', null],
+  };
+
+  const emit = (operator: string) =>
+    convertFilterGroupToAST({
+      logic: 'and',
+      conditions: [{ field: 'f', operator, value: '' }],
+    } as unknown as FilterGroup);
+
+  it('pins exactly the shared value-less set, no more and no less', () => {
+    expect(VALUELESS_FILTER_BUILDER_OPERATORS.size).toBeGreaterThan(0);
+    expect([...VALUELESS_FILTER_BUILDER_OPERATORS].sort())
+      .toEqual(Object.keys(EMITTED).sort());
+  });
+
+  it.each(Object.entries(EMITTED))('%s emits %j', (operator, expected) => {
+    expect(
+      emit(operator),
+      `a fresh "${operator}" row emitted nothing, so the grid queries without it: `
+        + 'the panel shows a filter and every record comes back',
+    ).toEqual(expected);
+  });
+
+  // The half that makes the emission worth having. A non-empty node that the
+  // AST gate rejects is no better than `[]` — worse, since it takes the rest of
+  // the filter down with it — so the four operators this toolbar OFFERS are
+  // checked through the gate the server uses.
+  it.each(['isEmpty', 'isNotEmpty', 'isNull', 'isNotNull'])(
+    '%s survives isFilterAST, the gate that decides if the filter is parsed at all',
+    (operator) => {
+      const node = emit(operator);
+      expect(node.length, `${operator} emitted no node`).toBeGreaterThan(0);
+      expect(
+        isFilterAST(node),
+        `${JSON.stringify(node)} is rejected by isFilterAST(); the filter reaches the `
+          + 'wire in a spelling the server will not compile',
+      ).toBe(true);
+    },
+  );
+
+  it('the two null predicates land on AST operators the spec defines', () => {
+    // Asserted against the spec's own set rather than assumed: if upstream ever
+    // retires these spellings, the emission above becomes a silent drop and
+    // `mapOperator` needs new targets.
+    for (const op of ['isnull', 'isnotnull']) {
+      expect(VALID_AST_OPERATORS.has(op), `VALID_AST_OPERATORS no longer has '${op}'`).toBe(true);
+    }
+  });
+
+  it('emits the same node whatever stale value the row still carries', () => {
+    // The operator dropdown preserves `value`, so an `Is null` row can hold the
+    // text typed under the previous operator — invisible, because no value
+    // input is drawn for it. The emission must be a function of the operator.
+    const stale = convertFilterGroupToAST({
+      logic: 'and',
+      conditions: [{ field: 'f', operator: 'isNull', value: 'typed under equals' }],
+    } as unknown as FilterGroup);
+    expect(stale).toEqual(['f', 'isnull', null]);
+  });
+
+  it('keeps a value-less row alongside a complete one', () => {
+    const both = convertFilterGroupToAST({
+      logic: 'and',
+      conditions: [
+        { field: 'stage', operator: 'equals', value: 'won' },
+        { field: 'closed_at', operator: 'isNull', value: '' },
+      ],
+    } as unknown as FilterGroup);
+    expect(both).toEqual(['and', ['stage', '=', 'won'], ['closed_at', 'isnull', null]]);
+    expect(isFilterAST(both)).toBe(true);
   });
 });

--- a/packages/plugin-list/src/__tests__/list-offered-operator-expressible-parity.test.ts
+++ b/packages/plugin-list/src/__tests__/list-offered-operator-expressible-parity.test.ts
@@ -61,7 +61,11 @@ import {
   ViewFilterRuleSchema,
   normalizeFilterOperator,
 } from '@objectstack/spec/ui';
-import { FILTER_BUILDER_OPERATORS, operatorsForFieldType } from '@object-ui/components';
+import {
+  FILTER_BUILDER_OPERATORS,
+  VALUELESS_FILTER_BUILDER_OPERATORS,
+  operatorsForFieldType,
+} from '@object-ui/components';
 import {
   LIST_VIEW_EXTRA_OPERATORS,
   convertFilterGroupToAST,
@@ -153,8 +157,14 @@ function liveGridResult(operator: string): { ok: boolean; emitted: unknown } {
  * the spec's own map, then hand the rule to the schema the server validates
  * with. `value` is included exactly when the operator takes one, matching the
  * fold's `VALUELESS_FILTER_OPERATORS` treatment.
+ *
+ * That "which operators take a value" used to be a fourth hand-written copy of
+ * the same list, sitting one import away from the component that decides it.
+ * It reads the shared set now (objectui#4744) — a mirror of the fold that
+ * disagreed with the fold about which rows are complete would be measuring the
+ * wrong thing while looking right.
  */
-const VALUELESS = new Set(['isEmpty', 'isNotEmpty', 'isNull', 'isNotNull', 'exists', 'notExists']);
+const VALUELESS = VALUELESS_FILTER_BUILDER_OPERATORS;
 
 function savedViewResult(operator: string): { ok: boolean; canonical: string } {
   const canonical = String(normalizeFilterOperator(operator));


### PR DESCRIPTION
Fixes #4744

## The defect

`convertFilterGroupToAST` (`packages/plugin-list/src/ListView.tsx`) drops any condition whose value is `null` / `''` / `[]` as an unfinished row, and exempted exactly two operators. The FilterBuilder renders no value input for **six**. For the other four, "no value" is the row's *finished* state and it was being discarded.

Reachable in three clicks: `addCondition` seeds `{ field: fields[0].value, operator: 'equals', value: '' }`, the operator dropdown's `onValueChange` updates `operator` alone so `value` stays `''`, and picking **Is null** as the first action therefore always produced the dropped shape. Result: the panel shows a filter, the query goes out without it, no error, every row returned.

Reproduced on this branch by ablation (numbers below), matching the card's measurement exactly.

## The shape

One set, three consumers, and the set lives with the code that decides it.

`VALUELESS_FILTER_BUILDER_OPERATORS` is exported from `@object-ui/components`, next to `needsValueInput` — which is now defined as its complement, so no copy can drift from it. Placement is forced by the dependency graph (`app-shell` -> `plugin-list` -> `components`, so `plugin-list` cannot import `app-shell`'s set) and is also right on the merits: the fact stated is a fact about what this dropdown draws.

- **`plugin-list` / `convertFilterGroupToAST`** — the inline two-operator literal is replaced by the shared set, so a fresh row for any value-less operator survives.
- **`app-shell` / `VALUELESS_FILTER_OPERATORS`** — now the shared set spread plus the four canonical spec spellings only that layer sees (`is_null`, `is_not_null`, …). Its public name and behaviour are unchanged.
- **`list-offered-operator-expressible-parity.test.ts`** — its private `VALUELESS` const was a further hand-written copy of the same six ids, used to mirror the fold. It reads the shared set now. Called out explicitly rather than folded in silently: a mirror that disagrees with the thing it mirrors measures the wrong thing while looking right.

## What the live grid emits

`mapOperator` has had `isnull` / `isnotnull` all along and both are members of the spec's `VALID_AST_OPERATORS` — the row simply never reached it. The full table, pinned per operator:

| operator | before | after |
|---|---|---|
| `isEmpty` | `["name","=",null]` | unchanged |
| `isNotEmpty` | `["name","!=",null]` | unchanged |
| `isNull` | `[]` | `["closed_at","isnull",null]` |
| `isNotNull` | `[]` | `["closed_at","isnotnull",null]` |
| `exists` | `[]` | `["f","exists",null]` |
| `notExists` | `[]` | `["f","notExists",null]` |

The third slot is `null` rather than `c.value`: the operator dropdown preserves the previous operator's value, so an `Is null` row can carry a leftover `'abc'` the user can no longer see or edit. The spec's own lowering (`convertComparison`) ignores that slot for `$null`, so `null` is inert on the wire and makes the emission a function of the operator alone. Same shape the `isEmpty` arms already used.

`exists` / `notExists` are not offered on this toolbar — #4745 moved them behind `OPT_IN_OPERATORS`, and `list-offered-operator-expressible-parity.test.ts` forces that equality. They stay in the shared set because `FilterConditionField` still draws them value-less, and their emission is pinned here so a future decision to offer them lands as a red test rather than as a broken query.

## Tests

New coverage, all at `dfc67673e`:

- `convertFilterGroupToAST.test.ts` — the card's fresh-row emission table as a pin, total over the shared set (a new value-less operator upstream now fails here until someone says what the grid emits for it), plus an `isFilterAST` leg for the four reachable operators, the stale-value case, and a mixed group.
- `components/src/__tests__/filter-builder-valueless-operators.test.tsx` — drives the real render for every member of the set and asserts the value input is absent, with a control case that renders one. This is what makes the set *true* rather than merely agreed-with.
- `viewFilterFold.emptyValue.test.ts` — its parity check used to read `filter-builder.tsx` as text and regex-scrape the literal out of `needsValueInput`, because there was nothing to import. It reads the value now. The half a scrape could never assert — that the builder really draws no input — moved to the render test above.

### Reverse verification (two legs, both predicted before running)

**Leg A — restore the two-operator literal in `ListView`.** Predicted red in `convertFilterGroupToAST.test.ts` only. Observed: 9 failed / 74 passed, and the pre-fix table reproduced verbatim — `expected [] to deeply equal [ 'closed_at', 'isnull', null ]`, same for `isNotNull` / `exists` / `notExists`; the stale-value case emitted `[ 'f', 'isnull', 'typed under equals' ]`; the mixed group collapsed to `[ 'stage', '=', 'won' ]`.

The reportable half: **`list-offered-operator-expressible-parity.test.ts` stayed green through leg A.** Its probe supplies a value per operator, so the row was never incomplete and the drop it exercises never fired. That is the measured reason a guard written for this exact surface could not see this bug.

**Leg B — give `needsValueInput` a second condition (`|| operator === "isNull"`), the class the old regex scrape could not see.** Predicted red in the new components render test, green in app-shell's set-comparison. Observed exactly that: 1 failed / 16 passed, `the builder drew a value input for "isNull", so it is NOT value-less`.

Both legs restored from the committed branch; no `git stash` at any point.

### Gates at `dfc67673e`

- `pnpm exec vitest run packages/components/ packages/plugin-list/` plus the app-shell fold surface (`viewFilterFold.test.ts`, `viewFilterFold.emptyValue.test.ts`, `view-filter-fold.ratchet.test.ts`, `runtime-metadata-persistence.viewItemSpec.test.ts`), `FilterConditionField.operators.test.ts` and `view-operator-builder-parity.test.ts` -> **179 files, 1849 tests passed**
- `turbo run type-check` (components, plugin-list, app-shell) -> 32 tasks successful
- `turbo run lint` (same three) -> 0 errors
- `check:control-bytes`, `check:phantom-deps`, `check:spec-symbols`, `check:i18n-keys`, `check:i18n-drift`, `check:i18n-dead-keys`, `lint:coverage`, `type-check:coverage` -> all pass
- `check-changeset-presence` -> 7 source files across 3 released packages, 1 changeset declared (patch; no `major`)

PR #4745 and #4736 are context for the `exists` / `notExists` note above; neither is addressed here. #2942 is where those two operators entered the builder.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_