### PR TITLE
fix(components,i18n): translate the config panel footer's Save / Discard

### DIFF
--- a/.changeset/config-panel-footer-i18n.md
+++ b/.changeset/config-panel-footer-i18n.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/components': patch
+'@object-ui/i18n': patch
+---
+
+The config panel footer translates: `ConfigPanelRenderer`'s Save / Discard labels come from the locale pack.
+
+`saveLabel` and `discardLabel` carried the English literals `'Save'` and
+`'Discard'` as parameter defaults, and no caller in the repo passes either prop,
+so the sticky footer that appears the moment a config draft is dirty stayed
+English in every locale — inside panels whose every other string had already
+been routed through `t()`. The fix is in the renderer rather than per-caller:
+the footer is the renderer's own chrome, so a caller-side fix would translate
+one panel's footer and leave the next host's English.
+
+Both labels now resolve through `createSafeTranslation` — the mechanism this
+package already uses for its built-in copy in `form.tsx`,
+`fullscreen-editor.tsx`, `data-table.tsx` and friends. An explicitly passed
+`saveLabel` / `discardLabel` still wins, unchanged and untranslated.
+
+`common.save` is reused rather than twinned: it already ships `Save` in all ten
+packs and is what the console's other save buttons read. `common.discard` is
+new, because the packs carried no shared spelling of the word — the three that
+existed are each scoped to one surface (`form.discard`,
+`console.settingsView.discard`, `console.objectView.discard`) and the last of
+them diverges from the other two in zh/ko/fr. Its ten values are the majority
+spelling, byte-identical to `form.discard` and `console.settingsView.discard`.
+
+Both English defaults are byte-identical to the literals they replace, so a
+host that mounts no `I18nProvider` renders exactly what it did before.

--- a/packages/components/src/__tests__/config-panel-footer-i18n-4750.test.tsx
+++ b/packages/components/src/__tests__/config-panel-footer-i18n-4750.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ConfigPanelRenderer`'s footer buttons speak the session language —
+ * objectui#4750.
+ *
+ * `saveLabel` / `discardLabel` were English literals sitting in the component's
+ * PARAMETER DEFAULTS (`saveLabel = 'Save'`, `discardLabel = 'Discard'`), and no
+ * caller in the repo passes either prop. So the sticky footer that appears the
+ * moment a config draft is dirty read `Save` / `Discard` in every locale, inside
+ * panels whose every other string had already been routed through `t()`
+ * (objectui#4748).
+ *
+ * ── Measured reverse-verification direction ──────────────────────────────
+ * This file is RED before the fix and GREEN after: restoring the two parameter
+ * defaults makes both locale cases render the English literals, which is
+ * exactly what the assertions below name. The provider-less byte-identity leg
+ * — GREEN on both sides, because the English bytes must not move — lives in
+ * `config-panel-footer-no-provider-4750.test.tsx`.
+ *
+ * ── Two locales, chosen for what each can decide ──────────────────────────
+ *  - **zh** — a non-Latin pack, where a value byte-identical to `en` is
+ *    decidable evidence of an untranslated string.
+ *  - **de** — a Latin pack, where identity CAN be genuine, so the assertions
+ *    name the German words explicitly rather than merely checking "not
+ *    English".
+ *
+ * Values are asserted as literals rather than read back out of the pack: a test
+ * that resolves its expectation through the same table it is testing passes on
+ * any pack, including an empty one.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` registers its instance as react-i18next's module-global default
+ * and the registration survives unmount and `cleanup()`, so a "no provider"
+ * assertion placed in THIS file would silently resolve against whichever
+ * language ran last. That leg is a separate file, which mounts no provider at
+ * all.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { ConfigPanelRenderer } from '../custom/config-panel-renderer';
+import type { ConfigPanelSchema } from '../types/config-panel';
+
+afterEach(cleanup);
+
+const schema: ConfigPanelSchema = {
+  breadcrumb: ['Settings'],
+  sections: [
+    {
+      key: 'basic',
+      title: 'Basic',
+      fields: [{ key: 'name', label: 'Name', type: 'input' }],
+    },
+  ],
+};
+
+/** The footer only exists while the draft is dirty — that is the whole surface. */
+function renderIn(language: string, over: Record<string, unknown> = {}) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <ConfigPanelRenderer
+        open
+        onClose={vi.fn()}
+        schema={schema}
+        draft={{ name: 'x' }}
+        isDirty
+        onFieldChange={vi.fn()}
+        onSave={vi.fn()}
+        onDiscard={vi.fn()}
+        {...over}
+      />
+    </I18nProvider>,
+  );
+}
+
+const footerText = () => ({
+  save: screen.getByTestId('config-panel-save').textContent?.trim(),
+  discard: screen.getByTestId('config-panel-discard').textContent?.trim(),
+});
+
+describe('ConfigPanelRenderer footer — the defaults translate (objectui#4750)', () => {
+  it('renders the Chinese words under zh', () => {
+    renderIn('zh');
+
+    expect(footerText()).toEqual({ save: '保存', discard: '放弃' });
+    // Falsifier: the English literals this fix removed are gone, not merely
+    // joined by translations somewhere else in the panel.
+    expect(screen.queryByText('Save')).toBeNull();
+    expect(screen.queryByText('Discard')).toBeNull();
+  });
+
+  it('renders the German words under de', () => {
+    renderIn('de');
+
+    expect(footerText()).toEqual({ save: 'Speichern', discard: 'Verwerfen' });
+  });
+
+  it('never leaks a raw pack key', () => {
+    renderIn('zh');
+
+    expect(screen.queryByText('common.save')).toBeNull();
+    expect(screen.queryByText('common.discard')).toBeNull();
+  });
+});
+
+describe('ConfigPanelRenderer footer — an explicit prop still wins (objectui#4750)', () => {
+  it('renders a caller-supplied label verbatim, untranslated, under zh', () => {
+    renderIn('zh', { saveLabel: 'Apply', discardLabel: 'Reset' });
+
+    expect(footerText()).toEqual({ save: 'Apply', discard: 'Reset' });
+    // The pack words must not appear anywhere: a prop that merely won the
+    // *button* while the default also rendered would be a different bug.
+    expect(screen.queryByText('保存')).toBeNull();
+    expect(screen.queryByText('放弃')).toBeNull();
+  });
+
+  it('lets each label be overridden independently — the other still translates', () => {
+    renderIn('zh', { saveLabel: 'Apply' });
+
+    expect(footerText()).toEqual({ save: 'Apply', discard: '放弃' });
+  });
+
+  it('treats an explicit empty string as a caller decision, not a missing prop', () => {
+    // `??` and not `||`: a caller that deliberately blanks a label (icon-only
+    // footer) gets a blank one. `||` would silently substitute the pack word.
+    renderIn('zh', { saveLabel: '' });
+
+    expect(footerText()).toEqual({ save: '', discard: '放弃' });
+  });
+});

--- a/packages/components/src/__tests__/config-panel-footer-no-provider-4750.test.tsx
+++ b/packages/components/src/__tests__/config-panel-footer-no-provider-4750.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ConfigPanelRenderer`'s footer still renders the SAME English bytes with no
+ * `I18nProvider` mounted — objectui#4750.
+ *
+ * Routing a literal through `t()` without a working default is exactly how a
+ * provider-less consumer breaks, and this primitive has them: embedded hosts
+ * mount it bare, the preview gallery does, and so do this package's own
+ * `config-panel-renderer.test.tsx` suites. A missing defaults-map row would
+ * surface here as the raw key `common.save` / `common.discard` in the DOM.
+ *
+ * ── Measured reverse-verification direction ──────────────────────────────
+ * GREEN before the fix and GREEN after — deliberately. The two labels replaced
+ * were the literals `'Save'` and `'Discard'`, and the pack values and defaults
+ * map are byte-identical to them, so no English byte moves. What this file
+ * catches is the two ways that identity can be broken later: a defaults row
+ * dropped or misspelled (the DOM assertions), and an `en` pack value edited out
+ * from under the map (the pack assertions). Measured by emptying the defaults
+ * map: the buttons then render the literal text `common.save` / `common.discard`
+ * and the first case fails.
+ *
+ * The translated direction — the fix proper — is asserted in
+ * `config-panel-footer-i18n-4750.test.tsx`.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, which registers that
+ * instance as react-i18next's module-global default, and the registration
+ * survives unmount and `cleanup()`. The moment any test in a file mounts an
+ * `I18nProvider`, every later "no provider" render in that same file silently
+ * resolves against that instance — a green-looking file asserting nothing about
+ * the fallback. The `dom` project runs with `isolate: true`, so a file that
+ * never mounts a provider gets a genuinely clean global. Keep it that way:
+ * **do not import or mount `I18nProvider` here.**
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { en } from '@object-ui/i18n';
+import { ConfigPanelRenderer } from '../custom/config-panel-renderer';
+import type { ConfigPanelSchema } from '../types/config-panel';
+
+afterEach(cleanup);
+
+/**
+ * The English the footer shipped BEFORE objectui#4750, frozen here as literals.
+ * Read from nothing — a table sourced from the pack would agree with the pack
+ * by construction and could not detect the pack moving.
+ */
+const PRE_4750_FOOTER_LITERALS = {
+  save: 'Save',
+  discard: 'Discard',
+} as const;
+
+const schema: ConfigPanelSchema = {
+  breadcrumb: ['Settings'],
+  sections: [
+    {
+      key: 'basic',
+      title: 'Basic',
+      fields: [{ key: 'name', label: 'Name', type: 'input' }],
+    },
+  ],
+};
+
+function renderPanel(over: Record<string, unknown> = {}) {
+  return render(
+    <ConfigPanelRenderer
+      open
+      onClose={vi.fn()}
+      schema={schema}
+      draft={{ name: 'x' }}
+      isDirty
+      onFieldChange={vi.fn()}
+      onSave={vi.fn()}
+      onDiscard={vi.fn()}
+      {...over}
+    />,
+  );
+}
+
+const footerText = () => ({
+  save: screen.getByTestId('config-panel-save').textContent?.trim(),
+  discard: screen.getByTestId('config-panel-discard').textContent?.trim(),
+});
+
+describe('ConfigPanelRenderer footer — provider-less bytes are unchanged (objectui#4750)', () => {
+  it('renders the pre-change English literals, never a raw key', () => {
+    renderPanel();
+
+    expect(footerText()).toEqual({
+      save: PRE_4750_FOOTER_LITERALS.save,
+      discard: PRE_4750_FOOTER_LITERALS.discard,
+    });
+    expect(screen.queryByText('common.save')).toBeNull();
+    expect(screen.queryByText('common.discard')).toBeNull();
+  });
+
+  it('still lets an explicit prop win with no provider mounted', () => {
+    renderPanel({ saveLabel: 'Apply', discardLabel: 'Reset' });
+
+    expect(footerText()).toEqual({ save: 'Apply', discard: 'Reset' });
+  });
+});
+
+describe('the `en` pack says what the footer used to say (objectui#4750)', () => {
+  it('carries the two keys with the replaced literals as their values', () => {
+    // Positive byte-identity, both keys: the defaults map served without a
+    // provider and the `en` pack served with one must be the same string, or
+    // the same button reads two different words depending on the host.
+    expect(en.common.save).toBe(PRE_4750_FOOTER_LITERALS.save);
+    expect(en.common.discard).toBe(PRE_4750_FOOTER_LITERALS.discard);
+  });
+
+  it('keeps `common.discard` byte-identical to the spelling the packs already agreed on', () => {
+    // `common.discard` is the key this change ADDED. Its value is the majority
+    // spelling already in the packs — `form.discard` (plugin-form's discard
+    // dialog) and `console.settingsView.discard` — which agree in all ten. The
+    // third older spelling, `console.objectView.discard`, deliberately is NOT
+    // asserted equal: it diverges in zh/ko/fr, which is why the shared
+    // component got its own key instead of borrowing one.
+    expect(en.common.discard).toBe(en.form.discard);
+    expect(en.common.discard).toBe(en.console.settingsView.discard);
+  });
+});

--- a/packages/components/src/custom/config-panel-renderer.tsx
+++ b/packages/components/src/custom/config-panel-renderer.tsx
@@ -9,6 +9,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { X, Save, RotateCcw, ChevronRight, Undo2, Redo2 } from 'lucide-react';
+import { createSafeTranslation } from '@object-ui/i18n';
 
 import { cn } from '../lib/utils';
 import { Button } from '../ui/button';
@@ -16,6 +17,70 @@ import { Separator } from '../ui/separator';
 import { SectionHeader } from './section-header';
 import { ConfigFieldRenderer } from './config-field-renderer';
 import type { ConfigPanelSchema } from '../types/config-panel';
+
+/**
+ * The footer's own copy — objectui#4750.
+ *
+ * `saveLabel` / `discardLabel` used to carry the English literals `'Save'` and
+ * `'Discard'` as PARAMETER DEFAULTS, and no caller in the repo passes either
+ * prop. So the sticky footer that appears the moment a config draft is dirty
+ * said `Save` / `Discard` in every locale, inside panels whose every other
+ * string (breadcrumb, sections, field labels — objectui#4748) translates. The
+ * fix belongs here rather than in each panel: the footer is the RENDERER's own
+ * chrome, so a per-caller fix would translate one panel's footer and leave the
+ * next one's English.
+ *
+ * ## Mechanism: `createSafeTranslation`, the one this package already uses
+ *
+ * Measured, not chosen: `form.tsx`, `fullscreen-editor.tsx`,
+ * `action-param-dialog.tsx`, `data-table.tsx`, `containers.tsx`,
+ * `filter-builder.tsx`, `sort-builder.tsx`, `navigation-overlay.tsx` and
+ * `lib/close-label.tsx` all reach their built-in copy through a
+ * `createSafeTranslation` defaults map. The safe hook rather than a bare
+ * `useObjectTranslation` because this primitive has provider-less consumers —
+ * embedded hosts, the preview gallery, and this package's own bare-render
+ * tests — where the bare hook returns the raw KEY.
+ *
+ * ## Keys: `common.save` reused, `common.discard` added
+ *
+ * `common.save` already ships `Save` in all ten packs and is what the console's
+ * other save buttons read (`app-shell`'s `ReportConfigPanel` footer,
+ * `plugin-view`'s `ManageViewsDialog`), so a `configPanel.save` twin would be
+ * exactly the one-word drift `form.tsx` documents having had to undo — and
+ * `configPanel.*` is also the block objectui#4746 just deleted as dead.
+ *
+ * `common.discard` is NEW because the packs carried no SHARED spelling of the
+ * word: the three that existed are all surface-scoped — `form.discard` (the
+ * confirm button of plugin-form's "Discard changes?" alert dialog),
+ * `console.settingsView.discard` and `console.objectView.discard` (two
+ * app-shell/console view footers) — and they do not even agree with each other
+ * across packs (`console.objectView.discard` is zh 丢弃 / ko 취소 / fr Annuler
+ * where the other two are zh 放弃 / ko 버리기 / fr Abandonner). Borrowing one
+ * of them would bind this shared primitive's copy to another surface's wording.
+ * The new key's ten values are the dominant spelling — byte-identical to
+ * `form.discard` and `console.settingsView.discard`, which agree in all ten
+ * packs.
+ *
+ * Both defaults below are byte-identical to the literals they replaced, so a
+ * provider-less host renders exactly what it did before. Pinned positively in
+ * `__tests__/config-panel-footer-no-provider-4750.test.tsx` (DOM bytes + the
+ * `en` pack), and the translated direction in
+ * `__tests__/config-panel-footer-i18n-4750.test.tsx`.
+ */
+const FOOTER_DEFAULT_TRANSLATIONS: Record<string, string> = {
+  'common.save': 'Save',
+  'common.discard': 'Discard',
+};
+
+/**
+ * Probe key: one this component itself consumes, so it cannot rot into pointing
+ * at a key no caller reads. With no translations configured `t('common.save')`
+ * returns the key itself, which is the signal to serve the defaults above.
+ */
+const useSafeConfigPanelTranslation = createSafeTranslation(
+  FOOTER_DEFAULT_TRANSLATIONS,
+  'common.save',
+);
 
 export interface ConfigPanelRendererProps {
   /** Whether the panel is visible */
@@ -42,9 +107,9 @@ export interface ConfigPanelRendererProps {
   className?: string;
   /** Additional inline styles applied to the panel root (e.g. to override `--config-panel-width`). */
   style?: React.CSSProperties;
-  /** Label for save button (default: "Save") */
+  /** Label for save button (default: the locale pack's `common.save`) */
   saveLabel?: string;
-  /** Label for discard button (default: "Discard") */
+  /** Label for discard button (default: the locale pack's `common.discard`) */
   discardLabel?: string;
   /** Ref for the panel root element */
   panelRef?: React.Ref<HTMLDivElement>;
@@ -104,8 +169,11 @@ export function ConfigPanelRenderer({
   objectDef,
   className,
   style,
-  saveLabel = 'Save',
-  discardLabel = 'Discard',
+  // No parameter defaults: the fallback is a TRANSLATION, resolved at render
+  // time from the active language (objectui#4750). An explicitly passed label
+  // still wins — see the `??` at each button below.
+  saveLabel,
+  discardLabel,
   panelRef,
   role,
   ariaLabel,
@@ -124,6 +192,9 @@ export function ConfigPanelRenderer({
   redoLabel = 'Redo',
 }: ConfigPanelRendererProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  // Above the `open` early return: a hook may not sit behind a conditional
+  // return, or the hook order changes the render the panel is opened.
+  const { t } = useSafeConfigPanelTranslation();
 
   if (!open) return null;
 
@@ -292,7 +363,7 @@ export function ConfigPanelRenderer({
         <div className="px-4 py-2 border-t flex gap-2 shrink-0" data-testid={footerTestId ?? 'config-panel-footer'}>
           <Button size="sm" onClick={onSave} data-testid={saveTestId ?? 'config-panel-save'}>
             <Save className="h-3.5 w-3.5 mr-1" />
-            {saveLabel}
+            {saveLabel ?? t('common.save')}
           </Button>
           <Button
             size="sm"
@@ -301,7 +372,7 @@ export function ConfigPanelRenderer({
             data-testid={discardTestId ?? 'config-panel-discard'}
           >
             <RotateCcw className="h-3.5 w-3.5 mr-1" />
-            {discardLabel}
+            {discardLabel ?? t('common.discard')}
           </Button>
         </div>
       )}

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -86,6 +86,7 @@ const ar = {
     removeFromFavorites: "إزالة من المفضلة",
     loading: "جاري التحميل…",
     save: "حفظ",
+    discard: "تجاهل",
     cancel: "إلغاء",
     delete: "حذف",
     edit: "تعديل",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -82,6 +82,7 @@ const de = {
     removeFromFavorites: "Aus Favoriten entfernen",
     loading: "Wird geladen…",
     save: "Speichern",
+    discard: "Verwerfen",
     cancel: "Abbrechen",
     delete: "Löschen",
     edit: "Bearbeiten",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -94,6 +94,15 @@ const en = {
   common: {
     loading: 'Loading…',
     save: 'Save',
+    // The SHARED "throw away the unsaved draft" verb, read by
+    // `@object-ui/components`' `ConfigPanelRenderer` footer (objectui#4750).
+    // The three older spellings stay where they are because each belongs to one
+    // surface's wording: `form.discard` is the confirm button of plugin-form's
+    // "Discard changes?" alert dialog, `console.settingsView.discard` and
+    // `console.objectView.discard` are two console view footers — and the last
+    // of those already disagrees with the other two in zh/ko/fr. This one is
+    // the shared component's, and its ten values are the majority spelling.
+    discard: 'Discard',
     cancel: 'Cancel',
     delete: 'Delete',
     edit: 'Edit',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -81,6 +81,7 @@ const es = {
     removeFromFavorites: "Quitar de favoritos",
     loading: "Cargando…",
     save: "Guardar",
+    discard: "Descartar",
     cancel: "Cancelar",
     delete: "Eliminar",
     edit: "Editar",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -82,6 +82,7 @@ const fr = {
     removeFromFavorites: "Retirer des favoris",
     loading: "Chargement…",
     save: "Enregistrer",
+    discard: "Abandonner",
     cancel: "Annuler",
     delete: "Supprimer",
     edit: "Modifier",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -82,6 +82,7 @@ const ja = {
     removeFromFavorites: "お気に入りから削除",
     loading: "読み込み中…",
     save: "保存",
+    discard: "破棄",
     cancel: "キャンセル",
     delete: "削除",
     edit: "編集",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -82,6 +82,7 @@ const ko = {
     removeFromFavorites: "즐겨찾기에서 제거",
     loading: "로딩 중…",
     save: "저장",
+    discard: "버리기",
     cancel: "취소",
     delete: "삭제",
     edit: "편집",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -81,6 +81,7 @@ const pt = {
     removeFromFavorites: "Remover dos favoritos",
     loading: "Carregando…",
     save: "Salvar",
+    discard: "Descartar",
     cancel: "Cancelar",
     delete: "Excluir",
     edit: "Editar",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -88,6 +88,7 @@ const ru = {
     removeFromFavorites: "Удалить из избранного",
     loading: "Загрузка…",
     save: "Сохранить",
+    discard: "Отменить",
     cancel: "Отмена",
     delete: "Удалить",
     edit: "Редактировать",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -87,6 +87,7 @@ const zh = {
   common: {
     loading: '加载中…',
     save: '保存',
+    discard: '放弃',
     cancel: '取消',
     delete: '删除',
     edit: '编辑',

--- a/packages/plugin-dashboard/src/__tests__/ConfigPanel.footerLabels.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ConfigPanel.footerLabels.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The dashboard config sidebar's FOOTER translates too — objectui#4750, with no
+ * change to either panel.
+ *
+ * objectui#4748 routed everything these two panels own — breadcrumb, section
+ * titles, field labels, placeholders, option labels — through `t()`. The two
+ * words it could not reach were the footer's: `Save` and `Discard` are
+ * `ConfigPanelRenderer`'s own chrome in `@object-ui/components`, handed to it as
+ * PARAMETER DEFAULTS, and neither panel passes `saveLabel` / `discardLabel`.
+ * The fix landed one package down, in the renderer.
+ *
+ * That is exactly what this file pins: both panels are mounted UNMODIFIED — no
+ * label prop, nothing added to their schemas — and their footers still come out
+ * Chinese. A future "fix" that translated the footer by making each caller pass
+ * a label would keep the cases below green while re-opening the class for the
+ * next `ConfigPanelRenderer` host, so the assertions are deliberately paired
+ * with the components-package suites
+ * (`config-panel-footer-i18n-4750.test.tsx`) rather than replacing them.
+ *
+ * Direction, predicted before running: RED before the renderer fix (both
+ * footers read `Save` / `Discard` under a zh provider), GREEN after.
+ *
+ * The footer only exists while the draft is dirty, so each case makes one real
+ * edit first — the same way `WidgetConfigPanel.retiredActionKeys.test.tsx`
+ * reaches the save button.
+ *
+ * Provider-less rendering of these panels is asserted in
+ * `ConfigPanel.noProviderLabels.test.tsx`; do not add a no-provider case here —
+ * `createI18n`'s instance is registered module-globally and survives
+ * `cleanup()`, so it would silently resolve against the zh instance above.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+import { WidgetConfigPanel } from '../WidgetConfigPanel';
+import { DashboardConfigPanel } from '../DashboardConfigPanel';
+import type { WidgetDatasetCatalogEntry } from '../dataset-catalog';
+
+afterEach(cleanup);
+
+const catalog: WidgetDatasetCatalogEntry[] = [
+  {
+    name: 'sales_pipeline',
+    label: 'Sales Pipeline',
+    dimensions: [{ name: 'stage' }],
+    measures: [{ name: 'revenue', aggregate: 'sum' }],
+  },
+];
+
+const footerText = () => ({
+  save: screen.getByTestId('config-panel-save').textContent?.trim(),
+  discard: screen.getByTestId('config-panel-discard').textContent?.trim(),
+});
+
+describe('WidgetConfigPanel footer under zh (objectui#4750)', () => {
+  it('renders the translated save/discard words with no caller change', () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <WidgetConfigPanel
+          open
+          onClose={vi.fn()}
+          config={{ id: 'w1', type: 'bar', dataset: 'sales_pipeline', dimensions: ['stage'], values: ['revenue'] }}
+          onSave={vi.fn()}
+          datasets={catalog}
+        />
+      </I18nProvider>,
+    );
+
+    // No footer until the draft is dirty — mirror a real edit.
+    expect(screen.queryByTestId('config-panel-footer')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('config-field-title'), { target: { value: '营收' } });
+
+    expect(footerText()).toEqual({ save: '保存', discard: '放弃' });
+    expect(screen.queryByText('Save')).not.toBeInTheDocument();
+    expect(screen.queryByText('Discard')).not.toBeInTheDocument();
+  });
+});
+
+describe('DashboardConfigPanel footer under zh (objectui#4750)', () => {
+  it('renders the translated save/discard words with no caller change', () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <DashboardConfigPanel
+          open
+          onClose={vi.fn()}
+          config={{ columns: 3, gap: 4, rowHeight: 120 }}
+          onSave={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    // `appearance` is `defaultCollapsed`, so its title input has to be revealed
+    // before it can be edited.
+    fireEvent.click(screen.getByTestId('section-header-appearance'));
+    fireEvent.change(screen.getByTestId('config-field-title'), { target: { value: '销售看板' } });
+
+    expect(footerText()).toEqual({ save: '保存', discard: '放弃' });
+    expect(screen.queryByText('Save')).not.toBeInTheDocument();
+    expect(screen.queryByText('Discard')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #4750

`ConfigPanelRenderer` gave `saveLabel` / `discardLabel` the English literals `'Save'` and `'Discard'` as **parameter defaults**, and no caller in the repo passes either prop — so the sticky footer that appears the moment a config draft is dirty read `Save` / `Discard` in every locale, inside panels whose every other string had already been routed through `t()`.

The fix is in the **renderer**, not per-caller: the footer is the renderer's own chrome, so a caller-side fix would translate one panel's footer and leave the next host's English.

## What changed

- `packages/components/src/custom/config-panel-renderer.tsx` — both labels now resolve through `createSafeTranslation`, the mechanism this package already uses for its built-in copy (`form.tsx`, `fullscreen-editor.tsx`, `action-param-dialog.tsx`, `data-table.tsx`, `containers.tsx`, `filter-builder.tsx`, `sort-builder.tsx`, `navigation-overlay.tsx`, `lib/close-label.tsx` — measured, not invented). The parameter defaults are gone; each button renders `saveLabel ?? t('common.save')` / `discardLabel ?? t('common.discard')`, so an explicitly passed label still wins, verbatim and untranslated. `??` and not `||`, which preserves the old parameter-default semantics exactly: an explicit empty string stays empty.
- Ten locale packs gain **`common.discard`**. `common.save` is **reused**, not twinned.
- Tests: two new files in `@object-ui/components` (translated direction; provider-less byte identity) and one in `@object-ui/plugin-dashboard` (the two real callers, unmodified).
- `.changeset/config-panel-footer-i18n.md` — `@object-ui/components` + `@object-ui/i18n`, both `patch`.

## Key choice, measured

`common.save` already ships `Save` in all ten packs and is what the console's other save buttons read (`app-shell`'s `ReportConfigPanel` footer, `plugin-view`'s `ManageViewsDialog`). A `configPanel.save` twin would be the one-word drift `form.tsx` documents having had to undo — and `configPanel.*` is the block #4746 just deleted as dead.

`common.discard` is **new** because the packs carried no *shared* spelling of the word. The three that existed are each scoped to one surface, and they do not agree with each other:

| key | en | zh | ko | fr |
|---|---|---|---|---|
| `form.discard` (plugin-form's "Discard changes?" dialog) | Discard | 放弃 | 버리기 | Abandonner |
| `console.settingsView.discard` (console settings footer) | Discard | 放弃 | 버리기 | Abandonner |
| `console.objectView.discard` (object view footer) | Discard | 丢弃 | 취소 | Annuler |

Borrowing one of them would bind a shared primitive's copy to another surface's wording. The new key's ten values are the majority spelling — byte-identical to `form.discard` and `console.settingsView.discard`, which agree in all ten packs (asserted in the test).

## Premise correction — the caller list in the issue

The card names three `ConfigPanelRenderer` mounts. Measured on `origin/main` at `ef0d1502f`, there are **two**: `plugin-dashboard`'s `WidgetConfigPanel` and `DashboardConfigPanel`. `app-shell`'s `ReportConfigPanel` was migrated onto the spec-driven `ReportDefaultInspector` some releases ago (its only remaining mention of `ConfigPanelRenderer` is the doc comment recording that migration) and renders its own footer through `t('common.save')` / `t('common.cancel')` — already translated. The defect, the route and the fix are unchanged by this; only the blast radius is two panels rather than three, and `ReportConfigPanel`'s existing `t('common.save')` is corroborating evidence for the key choice above.

Also noted, not fixed here: the same file's `undoLabel = 'Undo'` / `redoLabel = 'Redo'` **do** have English parameter defaults (the card states they have none). They are dormant — the buttons render only when a caller passes `onUndo` / `onRedo`, and none does — and picking their keys is a fresh decision rather than a mechanical one (the packs have no `common.undo` / `common.redo`; the four spellings that exist are all surface-scoped). Filed separately as #4752; this PR deliberately leaves those two lines alone.

## Verification

All at `03f7fa248`, the head of this branch.

Reverse verification, direction predicted before running, run from the committed state:

- **Ablation A — restore the two parameter defaults (removes the fix).** Predicted RED on the translated pins, GREEN on the provider-less pin. Observed exactly that: `config-panel-footer-i18n-4750.test.tsx` 4 of 6 red (`expected { save: 'Save', discard: 'Discard' } to deeply equal { save: '保存', discard: '放弃' }`; the two that stay green are the raw-key case and the both-props-overridden case, neither of which consults a default), `ConfigPanel.footerLabels.test.tsx` 2 of 2 red, `config-panel-footer-no-provider-4750.test.tsx` 4 of 4 **green** — the English bytes do not move, which is the point of that file.
- **Ablation B — empty the defaults map, keep the wiring.** Predicted RED on the provider-less pin with raw keys in the DOM. Observed: `expected { save: 'common.save', …(1) } to deeply equal { save: 'Save', discard: 'Discard' }`. This is the claim the no-provider file's header makes, so it is measured rather than asserted.

Both ablations were reverted with `git checkout` of the branch ref at the affected path, from the committed state (never `git stash`), and the tree was confirmed byte-identical to `03f7fa248` (`git status --porcelain` empty) before the runs below.

| gate | result |
|---|---|
| `vitest run` over the four config-panel files + the three #4748 suites + three i18n parity suites | 10 files, 185 tests passed |
| `vitest run packages/components/` | 134 files, 1142 tests passed |
| `vitest run packages/i18n/ packages/plugin-dashboard/` | 107 files, 1370 tests passed |
| `vitest run packages/app-shell/` | 402 files, 3823 passed, 1 skipped |
| `turbo run type-check` (components, i18n, plugin-dashboard) | 15 tasks successful |
| `turbo run lint` (components, i18n, plugin-dashboard) | 0 errors (warnings pre-existing) |
| `check:i18n-keys` | 2497/2497 literal keys resolve; 0 findings |
| `check:i18n-drift` | 1 key added, 0 en values changed |
| `check:i18n-dead-keys` (report-only) | neither `common.save` nor `common.discard` appears as a candidate |
| `check:control-bytes` | OK, 4275 tracked text files |
| `check-changeset-presence` / `check-changeset-no-major` | OK / no major |

The three full package suites ran on a tree byte-identical to `03f7fa248`; the targeted run, all five gate scripts and the clean-status check were re-run at that commit afterwards.

Context, no closing keywords intended: the dashboard sidebar wiring is #4748 (PR #4751), the retired `configPanel.*` namespace is #4746, and the same defect class appears in #4024 and #4386.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_