### PR TITLE
fix(app-shell): 动作对话框把自己的在途 param 值作为选项谓词的 record (#3765)

### DIFF
--- a/.changeset/action-dialog-param-values-as-option-record.md
+++ b/.changeset/action-dialog-param-values-as-option-record.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/app-shell': patch
+---
+
+An action dialog's per-option `visibleWhen` predicates now read the dialog's own in-progress param values.
+
+A field's per-option `visibleWhen` reaches a dialog param's control (objectui#3559),
+but the dialog supplied no record to evaluate it against: it passed no
+`dependentValues`, so the shared cascading-options evaluator fell through its
+chain (`dependentValues ?? formValues ?? data`) to the host page's record, or to
+nothing at all. A predicate written against a SIBLING PARAM — `record.country ==
+'cn'` on a province option, next to a `country` param in the same dialog — could
+therefore never see the value the user had just entered. Authored cascades were
+dead on this surface, in the safe direction: an unresolvable predicate offers the
+option rather than hiding it, so nobody was shown a wrongly-narrowed list.
+
+Per the maintainer's 2026-08-11 ruling (Option B on objectui#3765) the dialog is
+a small form, and its in-progress values are that record. The dialog now passes
+them as `dependentValues` to the option widgets (`select`, `multiselect`,
+`radio`, `checkboxes` — the same allow-list the object form threads the live
+record to). The evaluator is unchanged; this is the supply half that was missing.
+
+Ruled consequence, stated because it is a behavior change and not only a fix: a
+supplied record wins that chain outright, so an option predicate naming a field
+of the underlying ROW that the dialog has no param for no longer resolves inside
+a dialog. It becomes unresolvable, which fails open — the option stays offered,
+never wrongly hidden. Merging the two records was the alternative reading and was
+deliberately not taken: it would introduce a third scope dialect that has to be
+written into the contract before anything can rely on it.

--- a/packages/app-shell/src/utils/resolveActionParams.optionVisibleWhen.test.tsx
+++ b/packages/app-shell/src/utils/resolveActionParams.optionVisibleWhen.test.tsx
@@ -25,20 +25,21 @@
  * under a saturated transform pipeline can eat most of RTL's 1s budget, and the
  * assertions below are synchronous effects.
  *
- * Deliberately NOT passed: `dependentValues`. The dialog does not pass it either —
- * it keeps the in-progress param values in local state — so the predicate `record`
- * a dialog option sees is whatever `SchemaRendererContext` supplies (the page's
- * `formValues` / `data`), never the dialog's own values. The predicates exercised
- * here are therefore the ones that work in a dialog today: scope-relative
- * (`current_user`), the role-gating case ADR-0058 opens. RECORD-relative
- * predicates in a dialog are measured, not asserted, in the last test — see the
- * note there.
+ * Most cases below pass no `dependentValues`, which is now the NON-dialog wiring:
+ * since objectui#3765 the dialog supplies its own in-progress values on that prop,
+ * so a widget reached without one is a widget outside a dialog (the object form
+ * before it threads the record, hand-written SDUI, the inline editor). Those cases
+ * therefore exercise the predicates that need no record at all — scope-relative
+ * (`current_user`), the role-gating case ADR-0058 opens — plus, in the last two
+ * tests, what a record-relative predicate does on each side of that prop:
+ * supplied (the dialog's values narrow the list) and absent (the evaluator's
+ * documented fallback chain still reaches `SchemaRendererContext`).
  */
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { PredicateScopeProvider } from '@object-ui/react';
+import { PredicateScopeProvider, SchemaRendererContext } from '@object-ui/react';
 import { SelectField } from '@object-ui/fields';
 import type { ActionParamOption } from '@object-ui/core';
 import { resolveActionParams, type ResolveActionParamsContext } from './resolveActionParams';
@@ -76,6 +77,14 @@ function renderInheritedSelect(
   options: Array<ActionParamOption | string>,
   positions: string[],
   value?: string,
+  /**
+   * The two record channels `useCascadingOptions` reads, in its own precedence
+   * order. `dependentValues` is what a HOST supplies (the dialog now supplies
+   * its in-progress param values on it — objectui#3765); `ctxFormValues` is the
+   * `SchemaRendererContext` fallback the hook drops to when no host supplied
+   * one. Both default to absent, which is the "no record at all" case.
+   */
+  records?: { dependentValues?: Record<string, unknown>; ctxFormValues?: Record<string, unknown> },
 ) {
   const onChange = vi.fn();
   const param = resolveActionParams([{ field: 'tier' }], accountCtx(options))[0];
@@ -83,12 +92,27 @@ function renderInheritedSelect(
   // Same props the dialog passes a non-boolean param's widget. The cast is the
   // dialog's own seam: `paramToField()` returns `Record< string, unknown >`-shaped
   // field metadata and the widget is reached through a lazy `any` component there.
-  const props = { id: param.name, value: value ?? null, onChange, field } as unknown as
-    React.ComponentProps<typeof SelectField>;
-  render(
+  const props = {
+    id: param.name,
+    value: value ?? null,
+    onChange,
+    field,
+    ...(records?.dependentValues ? { dependentValues: records.dependentValues } : {}),
+  } as unknown as React.ComponentProps<typeof SelectField>;
+  const tree = (
     <PredicateScopeProvider scope={{ current_user: { positions } }}>
       <SelectField {...props} />
-    </PredicateScopeProvider>,
+    </PredicateScopeProvider>
+  );
+  render(
+    records?.ctxFormValues
+      // The context type declares `dataSource` only; `formValues` is the key
+      // `useCascadingOptions` / `LookupField` read off it through an `any` cast,
+      // so a host supplying one is expressed the same way here.
+      ? <SchemaRendererContext.Provider value={{ dataSource: null, formValues: records.ctxFormValues } as never}>
+          {tree}
+        </SchemaRendererContext.Provider>
+      : tree,
   );
   return { onChange, field };
 }
@@ -142,31 +166,54 @@ describe('field-inherited option predicates reach the dialog control (objectui#3
     expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
-  it('MEASURES a record-relative predicate with no record in context: fails OPEN', () => {
-    // Not a claim about correct behaviour — a recorded measurement, because the
-    // fix delivers the keys and the widget honours them, but WHICH record a
-    // dialog evaluates them against is a separate question this PR does not
-    // settle.
-    //
-    // Measured, not assumed (the prediction going in was the opposite): with no
-    // `dependentValues` — the dialog passes none, it keeps param values in local
-    // state — and no `SchemaRendererContext` above, `record` is `{}`, and
-    // `record.country == 'cn'` is UNRESOLVABLE rather than false. Per
-    // `resolveVisibleOptions()`'s documented fail-open default the option is
-    // therefore KEPT, not hidden. Same list against a populated record filters
-    // as expected (`{ country: 'us' }` → `[]`), which is what the object form
-    // gets and what a dialog mounted under a page picks up from that page's
-    // `formValues`/`data`.
-    //
-    // So the residual gap is narrow and safe-by-default: a dialog cannot narrow
-    // an inherited list against its OWN in-progress params, and unresolvable
-    // predicates offer everything rather than hiding everything. Reported
-    // separately; nothing here should be read as endorsing it.
-    renderInheritedSelect(
-      [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" }],
-      ['admin'],
-    );
-    expect(screen.queryByTestId('select-empty-tier')).not.toBeInTheDocument();
+  /**
+   * The record half, which objectui#3765 settled. The predicate is the same
+   * `record.country == 'cn'` in all three cases; only WHERE the record comes
+   * from changes.
+   *
+   * This file's last case used to be a MEASUREMENT rather than an assertion —
+   * "no record reaches a dialog option, so this fails open" — recorded that way
+   * on purpose, because which record a dialog evaluates against was undecided
+   * and the number could legitimately move. The maintainer ruled it on
+   * 2026-08-11 (Option B: the dialog's own in-progress values ARE the record),
+   * so the measurement becomes the three assertions below.
+   */
+  const PROVINCE = [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" }];
+
+  it('narrows a record-relative list against the record its HOST supplies', () => {
+    // The channel the dialog now feeds. A satisfied predicate keeps the option…
+    renderInheritedSelect(PROVINCE, ['admin'], undefined, { dependentValues: { country: 'cn' } });
     expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.queryByTestId('select-empty-tier')).not.toBeInTheDocument();
+  });
+
+  it('drops it when the supplied record fails the predicate', () => {
+    // …and a failed one drops it — the whole (single-option) list here, so the
+    // widget renders its empty state instead of a dropdown. This is the pair
+    // that makes the dialog's own values load-bearing: `{ country: 'us' }` is a
+    // value the user could have just picked in a sibling param.
+    renderInheritedSelect(PROVINCE, ['admin'], undefined, { dependentValues: { country: 'us' } });
+    expect(screen.getByTestId('select-empty-tier')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the context record when the host supplies none, and fails OPEN when neither exists', () => {
+    // The evaluator was NOT touched by objectui#3765 — the ruling was "supply
+    // the record, do not change the reader" — so its documented chain
+    // (`dependentValues ?? ctx.formValues ?? ctx.data ?? {}`) must still work
+    // from the second link down for every widget rendered outside a dialog.
+    // Pinned here because the dialog is now the loudest producer of the FIRST
+    // link, and a wiring change that quietly bypassed the rest of the chain
+    // would look identical from the dialog's side.
+    renderInheritedSelect(PROVINCE, ['admin'], undefined, { ctxFormValues: { country: 'us' } });
+    expect(screen.getByTestId('select-empty-tier')).toBeInTheDocument();
+
+    // Neither link supplied → `record` is `{}`, and `record.country` is
+    // UNRESOLVABLE rather than false, which `resolveVisibleOptions()` fails
+    // OPEN by documented default: the option is offered, never wrongly hidden.
+    // That is what an empty dialog now looks like, and it is the direction that
+    // makes this whole surface safe to get wrong.
+    renderInheritedSelect(PROVINCE, ['admin']);
+    expect(screen.getAllByRole('combobox')).toHaveLength(1);
   });
 });

--- a/packages/app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3765 — WHICH record an action dialog's per-option `visibleWhen`
+ * predicates are evaluated against.
+ *
+ * objectui#3559 delivered the keys (a field's per-option `visibleWhen` survives
+ * inheritance and reaches the control) and `resolveActionParams.optionVisibleWhen`
+ * pins that half at the widget level. What was missing was the SUPPLY: the dialog
+ * passed no `dependentValues`, so `useCascadingOptions` fell through its chain
+ * (`dependentValues ?? ctx.formValues ?? ctx.data ?? {}`) to the host page's
+ * record — and the values the user was typing INTO THIS DIALOG could never
+ * narrow a sibling param's list, however the author wrote the predicate.
+ *
+ * **Maintainer ruling, 2026-08-11 — Option B**: the dialog is a small form, so
+ * its own in-progress values are that record; the shared evaluator is not
+ * modified. This file drives the real `ActionParamDialog` (not a widget wired to
+ * look like it) because the wiring IS the change: only a real render can show
+ * that a keystroke in one param re-resolves another param's offered options.
+ *
+ * The ruling's accepted cost is pinned too, in `does not merge the page record`
+ * below — a supplied record wins the chain outright, so a predicate naming a row
+ * field the dialog has no param for stops resolving here and falls open. That
+ * test is what discriminates the ruled B from the unruled C (`{ ...row,
+ * ...values }`): under C its first assertion would be a filtered list, not an
+ * open one.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SchemaRendererContext } from '@object-ui/react';
+import type { ActionParamDef } from '@object-ui/core';
+// Module scope, per AGENTS.md §测试纪律: the dialog reaches its widgets through
+// `React.lazy(() => import('./widgets/RadioField'))` inside `@object-ui/fields`,
+// and a first dynamic import() under a saturated transform pipeline can eat most
+// of RTL's 1s `findBy` budget. This barrel STATICALLY re-exports those widget
+// modules, so importing it puts them in the ESM cache and the lazy factories
+// resolve in a microtask instead of racing the assertions below.
+import '@object-ui/fields';
+import { ActionParamDialog } from './ActionParamDialog';
+
+const COUNTRY: ActionParamDef = { name: 'country', label: 'Country', type: 'text' };
+
+/** Province options gated on a SIBLING PARAM's value (`country`), not on scope. */
+const PROVINCE: ActionParamDef = {
+  name: 'province',
+  label: 'Province',
+  type: 'radio',
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'Texas', value: 'tx', visibleWhen: "record.country == 'us'" },
+  ],
+};
+
+function openDialog(params: ActionParamDef[], hostFormValues?: Record<string, unknown>) {
+  const resolve = vi.fn();
+  const dialog = (
+    <ActionParamDialog state={{ open: true, params, resolve }} onOpenChange={() => {}} />
+  );
+  render(
+    hostFormValues
+      // The host page's record, expressed the way the evaluator reads it: the
+      // context type declares `dataSource` only, and `formValues` is the key
+      // `useCascadingOptions` picks off it through an `any` cast.
+      ? <SchemaRendererContext.Provider value={{ dataSource: null, formValues: hostFormValues } as never}>
+          {dialog}
+        </SchemaRendererContext.Provider>
+      : dialog,
+  );
+  return resolve;
+}
+
+const typeCountry = (value: string) =>
+  fireEvent.change(screen.getByLabelText('Country'), { target: { value } });
+
+describe('ActionParamDialog — the dialog IS the record for its option predicates (objectui#3765)', () => {
+  it("narrows a param's options against a value typed into a SIBLING param", async () => {
+    openDialog([COUNTRY, PROVINCE]);
+    // Nothing typed yet: `record.country` is unresolvable, which fails OPEN, so
+    // both provinces are offered. (The pre-#3765 dialog was stuck here forever —
+    // typing had no way to reach the predicate.)
+    expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-option-tx')).toBeInTheDocument();
+
+    typeCountry('cn');
+
+    // The keystroke re-resolved a DIFFERENT param's offered set: `zj` survives
+    // its predicate, `tx` does not. This assertion is the whole issue.
+    await waitFor(() => expect(screen.queryByTestId('radio-option-tx')).not.toBeInTheDocument());
+    expect(screen.getByTestId('radio-option-zj')).toBeInTheDocument();
+
+    // …and it tracks the value, rather than latching on the first one seen.
+    typeCountry('us');
+    await waitFor(() => expect(screen.queryByTestId('radio-option-zj')).not.toBeInTheDocument());
+    expect(screen.getByTestId('radio-option-tx')).toBeInTheDocument();
+  });
+
+  it('empties a select whose every option the in-progress values exclude', async () => {
+    // The `select` widget's counterpart: when the dialog's own values exclude
+    // the whole list there is no dropdown to offer, so the widget renders its
+    // legible empty state (objectui#3231) keyed on the param name.
+    openDialog([
+      COUNTRY,
+      {
+        name: 'region',
+        label: 'Region',
+        type: 'select',
+        options: [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" }],
+      },
+    ]);
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
+
+    typeCountry('us');
+
+    await waitFor(() => expect(screen.getByTestId('select-empty-region')).toBeInTheDocument());
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('keeps an option whose predicate names a key NO param carries: fails OPEN', async () => {
+    // The safety direction, unchanged by the wiring and pinned separately from
+    // the cases above because it is the one that decides how bad a mistake here
+    // can be. An unresolvable predicate offers the option (the user can still
+    // complete the action, and a wrong value earns a server rejection that
+    // carries a message) instead of hiding it (an empty control with nothing
+    // pointing at the predicate). Same direction the param-level `visible` gate
+    // rules on this surface — objectui#4640.
+    openDialog([
+      COUNTRY,
+      {
+        name: 'province',
+        label: 'Province',
+        type: 'radio',
+        options: [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.owner_id == 'u1'" }],
+      },
+    ]);
+    expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+    typeCountry('cn');
+    // Still unresolvable after a keystroke — `owner_id` is not a param — so the
+    // option stays offered rather than vanishing as the user types.
+    await waitFor(() => expect(screen.getByLabelText('Country')).toHaveValue('cn'));
+    expect(screen.getByTestId('radio-option-zj')).toBeInTheDocument();
+  });
+
+  it('does not merge the page record: the dialog record WINS, and an empty one falls open', async () => {
+    // Option B's ruled cost, asserted rather than left for a reader to discover.
+    // The host page says `country: 'us'`; the dialog says nothing yet. Because a
+    // supplied `dependentValues` wins `useCascadingOptions`' chain outright, the
+    // page's value does NOT reach the predicate — the list falls open instead of
+    // narrowing to Texas.
+    //
+    // Under the unruled option C (`{ ...pageRecord, ...dialogValues }`) this
+    // first assertion would read the other way: `tx` only. So this case is the
+    // executable difference between the two readings, and re-deciding the scope
+    // ruling has to come through here.
+    openDialog([COUNTRY, PROVINCE], { country: 'us' });
+    expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-option-tx')).toBeInTheDocument();
+
+    // And once the dialog HAS a value it is the only one that counts: `cn` wins
+    // over the page's `us`, in the same direction a form field's own value wins
+    // over anything ambient.
+    typeCountry('cn');
+    await waitFor(() => expect(screen.queryByTestId('radio-option-tx')).not.toBeInTheDocument());
+    expect(screen.getByTestId('radio-option-zj')).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -14,6 +14,11 @@
  * uploads) and `SchemaRendererContext` (dataSource for lookup/user pickers)
  * come from the host view, exactly as the previous `LookupField` reuse did.
  *
+ * One thing is threaded rather than ambient, and deliberately so: the record an
+ * option widget resolves its per-option `visibleWhen` against. The dialog is a
+ * small form, so its own in-progress `values` are that record — see
+ * `CASCADE_OPTION_WIDGET_TYPES` below (objectui#3765).
+ *
  * Returns collected param values or null on cancel.
  */
 
@@ -199,6 +204,28 @@ function WidgetFallback() {
   return <div className="h-9 w-full animate-pulse rounded-md bg-muted" aria-hidden="true" />;
 }
 
+/**
+ * Widget keys whose OFFERED option set is re-resolved against a live record by
+ * the shared cascading-options evaluator (`useCascadingOptions` →
+ * `resolveCascadingOptions`): each option may carry a `visibleWhen` predicate
+ * read against `record.*` (ADR-0058 / objectui#2284).
+ *
+ * Deliberately the same four keys the object form threads `dependentValues` to
+ * (`CASCADE_OPTION_FIELD_TYPES` in `components/renderers/form/form.tsx`) — the
+ * dialog and the form must feed one evaluator the same way or the two surfaces
+ * drift on what "the record" means. It is an ALLOW-LIST, not a blanket
+ * pass-through, because `dependentValues` is also the channel two widget-hint
+ * pickers read a specific SIBLING KEY from (`filter-condition` reads
+ * `object_name`, `recipient-picker` reads `recipient_type`) and the lookup
+ * family filters its query by it; feeding those from dialog params is a
+ * different wiring question than the one ruled here.
+ *
+ * `select` + `multiple: true` is not listed separately: `SelectField` delegates
+ * to `MultiSelectField` with the whole prop object, so the key it resolves
+ * under (`select`) is the one that must carry the record.
+ */
+const CASCADE_OPTION_WIDGET_TYPES = new Set(['select', 'multiselect', 'radio', 'checkboxes']);
+
 export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProps) {
   const { t, language } = useObjectTranslation();
   const [values, setValues] = useState<Record<string, any>>({});
@@ -305,6 +332,29 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
             const uploadProps = isUploadWidget
               ? { onUploadingChange: (u: boolean) => setUploading((prev) => ({ ...prev, [param.name]: u })) }
               : {};
+            // The dialog's own in-progress values ARE the record its option
+            // predicates are resolved against (objectui#3765, maintainer ruling
+            // 2026-08-11, Option B: "the dialog is a small form"). Until this
+            // prop existed the dialog passed nothing, so `useCascadingOptions`
+            // fell through to `SchemaRendererContext`'s `formValues` / `data` —
+            // the OUTER page's record — and a `visibleWhen` written against a
+            // sibling PARAM could never see the value the user had just picked
+            // in this same dialog. The evaluator is untouched: it already reads
+            // `dependentValues ?? formValues ?? data`; this is the supply half
+            // that was missing.
+            //
+            // Ruled cost, recorded rather than worked around: because a
+            // supplied record wins that chain outright, a predicate naming a
+            // ROW field the dialog has no param for (`record.owner_id`) no
+            // longer resolves against the host page here. It becomes
+            // unresolvable, which `resolveVisibleOptions` fails OPEN — the
+            // option is offered, never wrongly hidden. Merging the two records
+            // (`{ ...row, ...values }`) was option C on the card and was NOT
+            // ruled: it invents a third scope dialect that would have to be
+            // written into the contract first.
+            const cascadeProps = CASCADE_OPTION_WIDGET_TYPES.has(field.type)
+              ? { dependentValues: values }
+              : {};
             // A lookup-typed param that fell back to text (no referenceTo)
             // keeps the "paste an ID" placeholder/help hints.
             const isLookupParam = param.type === 'lookup' || param.type === 'reference';
@@ -393,6 +443,7 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
                   // whitelist, so this reaches the real control.
                   aria-required={param.required || undefined}
                   {...uploadProps}
+                  {...cascadeProps}
                 />
               </Suspense>
 


### PR DESCRIPTION
Fixes #3765

**per maintainer Option B ruling**(2026-08-11,评论 5248476948,四镜头评审):对话框把 `dependentValues` 传给共享 evaluator,**evaluator 本身不改,范围仅此一个接线缺口**。issue 里的 A(按页面记录)/ C(两者合并)均未被采纳,本 PR 不实现;`select` 类型 param 继承 `dependsOn` 的扩围(issue 第 4 点)按同一裁定**不在本单**,代码未动。

## 缺口

`ActionParamDialog` 渲染 param 控件时不传 `dependentValues`,而 param 的在途取值只存在对话框自己的 local state。于是共享的 `useCascadingOptions` 沿 `dependentValues ?? formValues ?? data` 一路回退到外层页面的记录(实测多数情况下干脆是 `{}`),作者写在选项上的 `record.某个兄弟_param` 谓词**永远看不到用户刚在同一个对话框里填的值** —— #3559 把键送到了控件,消费侧却没有一份可算的 record。方向是安全的(不可解谓词 fail-open,是全给不是全藏),所以今天没人被错藏选项,但级联在这个 surface 上是死的。

## 改动

- `packages/app-shell/src/views/ActionParamDialog.tsx`:渲染非 boolean 分支的控件时,把对话框自己的在途 `values` 作为 `dependentValues` 传下去。投放面用**允许表**(`select` / `multiselect` / `radio` / `checkboxes`),与对象表单 `form.tsx` 的 `CASCADE_OPTION_FIELD_TYPES` 一致 —— 不做无差别透传,因为 `filter-condition` / `recipient-picker` / lookup 家族把同一个 prop 读成**另一种含义**(某个具体兄弟键 / 查询过滤),那是另一个接线问题。
- `packages/fields/src/widgets/useCascadingOptions.ts`:**零改动**(裁定要求)。它的取值口径本来就在等这份供给。

裁定已知的代价,在代码注释与测试里都写明而不是留给下一个读者踩:供给的 record **直接赢下**整条回退链,所以只提到行记录字段(`record.owner_id` 之类)的谓词在对话框里不再可解 —— 它 fail-open,选项照给,不会被错藏。

## 测试

新增 `packages/app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx`(驱动真实对话框,4 例):

1. 在兄弟 param 里输入 `country=cn` → 另一个 param 的选项集当场收窄(`tx` 消失、`zj` 留下),再改 `us` 时反向跟随 —— 这一条就是本单;
2. 对话框在途值排除掉某 `select` 的全部选项 → 渲染空态而非空下拉;
3. 谓词命名了任何 param 都没有的键 → 维持 fail-open,输入过程中选项不会突然消失;
4. **不合并页面记录**:外层页面给 `country: 'us'` 时列表落到 fail-open(而不是被过滤成 Texas),对话框自己填了 `cn` 之后 `cn` 说了算。这一例是 B 与未被采纳的 C 的**可执行差别** —— 若哪天改判 C,它必须先红。

改写 `resolveActionParams.optionVisibleWhen.test.tsx` 末例:该例原本是「对话框拿不到 record,故 fail-open」的**测量**,注释里写明裁定后应随之改写。现拆成三条断言 —— 宿主供给的 record 能收窄 / 能过滤掉、以及 evaluator 的回退链(`ctx.formValues` 那一段与全空 fail-open)未被破坏。

跑法(仓根,不加 `--`):

- `pnpm exec vitest run packages/app-shell` → **Test Files 403 passed,Tests 3829 passed | 1 skipped**
- `pnpm exec turbo run type-check`、changeset / control-bytes / phantom-deps / i18n 各 gate 见 PR 检查

## 反向验证(先预判,后实测)

预判:撤掉接线后,①②④ 红、③(fail-open)绿、widget 级 6 例全绿。实测一致,且 ④ 是以**另一种失败**红的 —— `radio-option-zj` 直接找不到,因为撤掉接线后页面记录 `country: 'us'` 重新参与并把它过滤掉了。这正好反证了「页面记录此前在参与、现在不再参与」这件事,而不只是「新钉子会红」。

结果:`Tests 3 failed | 9 passed`,随后 `git checkout` 复原。

## 范围外(不动代码,仅记录)

`select` 类型 param 仍然继承不到 `dependsOn`:`resolveActionParams.ts:489` 的 `isLookupResolvedType` 只放行 `lookup` / `reference`,`depends_on` 只在 `:502` 那一支复制,`paramToField.ts:94` 同样只对 lookup / user / owner 家族映射。所以 #2284 / #2215 的「先选父字段」**门**在对话框 select 上依旧不可达 —— 但这不影响本 PR:逐选项 `visibleWhen` 的级联不需要 `dependsOn`,上面第 1 例就是在没有任何 `dependsOn` 声明的情况下跑通的。门的那一半是另一张卡的裁决。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_