### PR TITLE
fix(core,components,plugin-form): create 表单的 `requiredWhen` 让位于 producer-owned runtime default (#4085)

### DIFF
--- a/.changeset/required-when-yields-to-runtime-default.md
+++ b/.changeset/required-when-yields-to-runtime-default.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/core': patch
+'@object-ui/components': patch
+'@object-ui/plugin-form': patch
+---
+
+A create form no longer deadlocks on a `requiredWhen` field that also declares a runtime `defaultValue`.
+
+`#4069` ruled that in **create** mode a field whose `defaultValue` is a runtime
+instruction the server resolves per insert (`NOW()` / `current_user`, or a CEL
+Expression envelope) is producer-owned: the control is deliberately left empty
+and the key is omitted from the payload, because `ObjectQL.applyFieldDefaults`
+resolves the declaration only for a field that arrives absent or null. That was
+implemented on the STATIC `required` flag.
+
+The conditional spelling was not covered. `requiredWhen` is resolved one layer
+downstream, in the form renderer, against the live record — so a predicate
+resolving TRUE on a create form put the requirement straight back: the control
+was still empty by design, the submit was refused, and the user had nothing
+sensible to type.
+
+Both spellings now behave identically on a producer-owned field. A
+`requiredWhen` predicate is a claim about the value at rest in a given state,
+and `NOW()` / `current_user` resolve at insert regardless of state, so the
+producer's guarantee covers the conditional claim by the same argument that
+covers the unconditional one. An author who really means "the user must supply
+this in this state" has a natural spelling for it: do not declare the default.
+
+The suppression lands in the single evaluator both layers read,
+`resolveFieldRuleState` — the same verdict that draws the required marker and
+the one the submit-time check consults — so a field can never lose its asterisk
+while still refusing the write. The classifier that answers "is this value the
+producer's to supply" moved down to `@object-ui/core`
+(`isRuntimeDefault` / `isServerOwnedValue`, re-exported from
+`@object-ui/plugin-form`) so the renderer, the wizard's cross-step gate and the
+create-form field builders all read one implementation rather than three.
+
+**Edit mode is unchanged.** Defaults do not re-apply to an existing record, so
+on a persisted row the token was already resolved at insert and blanking the
+column is a real removal: `requiredWhen` enforces there exactly as authored.
+Fields with no declared default, and fields whose default is a static literal
+(which IS seeded into the control), are also unaffected in both modes.

--- a/packages/components/src/renderers/form/__tests__/form-required-when-server-owned.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-required-when-server-owned.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A CREATE form must not re-require a control it deliberately leaves empty
+ * (objectui#4085 — the conditional half of #4069).
+ *
+ * #4069 ruled that a field whose `defaultValue` is a runtime instruction the
+ * server resolves per insert (`NOW()` / `current_user`, or a CEL Expression
+ * envelope) is SERVER-OWNED on a create form: the control opens empty and the
+ * key is omitted from the payload, because `ObjectQL.applyFieldDefaults`
+ * resolves the declaration only for a field that arrives absent or null. PR
+ * #4084 implemented that on the STATIC `required` flag, in
+ * `@object-ui/plugin-form`.
+ *
+ * `requiredWhen` is resolved HERE instead — reactively, against the live
+ * record — so it survived that fix untouched and simply put the requirement
+ * back: predicate TRUE on a create form re-required the empty control, and the
+ * submit was refused with nothing sensible for the user to type. Ruled
+ * 2026-08-11 (#4085): in create mode the two spellings behave identically on a
+ * producer-owned field.
+ *
+ * The suppression lives in the ONE evaluator both layers read
+ * (`resolveFieldRuleState`, objectui#4201), so these tests assert the star and
+ * the submit together — a fix applied a layer up would drop the asterisk and
+ * still refuse the write.
+ *
+ * The create/edit signal is `FormSchema.previousValues`: set by an edit-mode
+ * host only, its ABSENCE is the declared "this is an insert" (objectui#3484).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** Resolves TRUE for every record below — the deadlock state. */
+const WHEN_SCHEDULED = "record.status == 'scheduled'";
+
+/**
+ * A field as the object-bound builders hand it to this renderer: the resolved
+ * object-field metadata rides in `field`, which is the only spelling of a
+ * declared `defaultValue` that reaches here.
+ */
+const remindAt = (defaultValue: unknown) => ({
+  name: 'remind_at',
+  label: 'Remind at',
+  type: 'input',
+  requiredWhen: WHEN_SCHEDULED,
+  field: { defaultValue },
+});
+
+/** Conditionally required with no declared default — the user's to fill. */
+const PLAN = { name: 'plan', label: 'Plan', type: 'input', requiredWhen: WHEN_SCHEDULED };
+
+function renderForm(
+  fields: any[],
+  defaultValues: Record<string, unknown>,
+  onSubmit: (data: any) => Promise<unknown> | unknown,
+  extra: Record<string, unknown> = {},
+) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues,
+        fields,
+        onSubmit,
+        ...extra,
+      }}
+    />,
+  );
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+describe('form renderer — `requiredWhen` yields to a producer-owned default on create (#4085)', () => {
+  it.each([
+    ['a NOW() token', 'NOW()'],
+    ['a current_user token', 'current_user'],
+    ['a CEL Expression envelope', { dialect: 'cel', source: 'today()' }],
+  ])('%s: submit goes through with the control left empty', async (_what, defaultValue) => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderForm([PLAN, remindAt(defaultValue)], { status: 'scheduled', plan: 'ring', remind_at: '' }, onSubmit);
+
+    // Predicate TRUE, control empty — and no asterisk, because the field is
+    // not the user's to supply on this submit.
+    expect(screen.getByLabelText(/remind at/i)).not.toHaveAttribute('aria-required', 'true');
+    submit();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+
+  it('keeps enforcing a conditionally-required field that declares NO default', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderForm([PLAN, remindAt('NOW()')], { status: 'scheduled', plan: '', remind_at: '' }, onSubmit);
+
+    // The contrast: same predicate, same empty control, but nothing declared
+    // that the server will supply. The suppression reads the default, not the
+    // mode alone.
+    expect(screen.getByLabelText(/plan/i)).toHaveAttribute('aria-required', 'true');
+    submit();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('keeps enforcing when the declared default is a STATIC literal', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    // A static default IS seeded into the control (#4068), so an empty one
+    // means the user emptied it — a removed value, not one the producer will
+    // supply.
+    renderForm([remindAt('2026-01-01')], { status: 'scheduled', remind_at: '' }, onSubmit);
+
+    expect(screen.getByLabelText(/remind at/i)).toHaveAttribute('aria-required', 'true');
+    submit();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('EDIT mode is untouched — `previousValues` present means the token was resolved at insert', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderForm(
+      [remindAt('NOW()')],
+      { status: 'scheduled', remind_at: '' },
+      onSubmit,
+      // The declared edit-mode signal (objectui#3484). Blanking a column on a
+      // persisted row is a real removal, so the predicate means what it says.
+      { previousValues: { status: 'scheduled', remind_at: '2026-01-01T00:00:00Z' } },
+    );
+
+    expect(screen.getByLabelText(/remind at/i)).toHaveAttribute('aria-required', 'true');
+    submit();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not touch a field the predicate leaves FALSE either way', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderForm([remindAt('NOW()')], { status: 'draft', remind_at: '' }, onSubmit);
+
+    expect(screen.getByLabelText(/remind at/i)).not.toHaveAttribute('aria-required', 'true');
+    submit();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+
+  it('a value the user DOES type is still submitted — the RULE yields, not the field', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderForm([remindAt('NOW()')], { status: 'scheduled', remind_at: '' }, onSubmit);
+
+    fireEvent.change(screen.getByLabelText(/remind at/i), { target: { value: 'typed by hand' } });
+    submit();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ remind_at: 'typed by hand' });
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveCascadingOptions, isValueStillOffered, isMissingForRequired } from '@object-ui/core';
+import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveCascadingOptions, isValueStillOffered, isMissingForRequired, isServerOwnedValue } from '@object-ui/core';
 import type { FormSchema, FormField as FormFieldConfig, FormFieldTab, FormFieldPane, FieldValidationRules, FieldCondition, SelectOption } from '@object-ui/types';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from '../../ui/form';
@@ -664,6 +664,13 @@ ComponentRegistry.register('form',
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fields, previousValues]);
 
+    // Is this an INSERT? Same signal the memo above documents and the read-only
+    // strip already gates on: `FormSchema.previousValues` is set by an
+    // edit-mode host only, and its ABSENCE is the declared "this is an insert"
+    // (objectui#3484). Read once here so the three rule-state call sites below
+    // cannot each answer the mode differently.
+    const isCreateForm = previousRecord === undefined;
+
     const ruleRecord = React.useMemo(() => {
       // Seed every declared field to `null` so a predicate referencing a field
       // that's absent / not-yet-registered evaluates against a present-null
@@ -716,7 +723,11 @@ ComponentRegistry.register('form',
             requiredWhen: (f as any).requiredWhen,
           },
           ruleRecord,
-          { required: !!f.required, readonly: (f as any).readonly === true },
+          {
+            required: !!f.required,
+            readonly: (f as any).readonly === true,
+            serverOwnedValue: isServerOwnedValue(f, isCreateForm),
+          },
           previousRecord,
           undefined,
           // Same locator as the render path (#5149). A failure here reports the
@@ -728,7 +739,7 @@ ComponentRegistry.register('form',
         if (st.readonly) locked.add(name);
       }
       return locked;
-    }, [fields, ruleRecord, previousRecord]);
+    }, [fields, ruleRecord, previousRecord, isCreateForm]);
 
     // When a field's CEL rule relaxes — it becomes hidden (visibleWhen FALSE) or
     // no longer required (requiredWhen FALSE) — clear any stale validation error
@@ -748,7 +759,11 @@ ComponentRegistry.register('form',
             requiredWhen: (f as any).requiredWhen,
           },
           ruleRecord,
-          { required: !!f.required, readonly: (f as any).readonly === true },
+          {
+            required: !!f.required,
+            readonly: (f as any).readonly === true,
+            serverOwnedValue: isServerOwnedValue(f, isCreateForm),
+          },
           previousRecord,
           undefined,
           `field '${name}'`,
@@ -1360,7 +1375,18 @@ ComponentRegistry.register('form',
       const ruleState = resolveFieldRuleState(
         { visibleWhen, readonlyWhen, requiredWhen },
         ruleRecord,
-        { required: staticRequired, readonly: staticReadonly === true },
+        {
+          required: staticRequired,
+          readonly: staticReadonly === true,
+          // A CREATE form leaves a producer-owned control empty on purpose and
+          // omits the key so the server resolves the declared runtime default
+          // (#4069). Nothing may then declare the field required — neither the
+          // static flag (which `@object-ui/plugin-form` already lowers at the
+          // producer) nor a `requiredWhen` predicate resolving TRUE against the
+          // live record, which used to re-require it here with nothing the user
+          // could type to unblock the submit (#4085).
+          serverOwnedValue: isServerOwnedValue(field, isCreateForm),
+        },
         previousRecord,
         undefined,
         `field '${name}'`,

--- a/packages/core/src/evaluator/__tests__/fieldRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/fieldRules.test.ts
@@ -154,6 +154,69 @@ describe('resolveFieldRuleState', () => {
   });
 });
 
+/**
+ * `statics.serverOwnedValue` — the create-mode suppression (#4069 / #4085).
+ *
+ * A CREATE form leaves a producer-owned control empty on purpose and omits the
+ * key so `ObjectQL.applyFieldDefaults` resolves the declared runtime default.
+ * Required-ness is then not the client's question, and THIS is the single place
+ * that answers it: the static flag and the `requiredWhen` predicate both yield.
+ * Pinned here, at the evaluator, because since objectui#4201 the submit-time
+ * check and the required marker read one verdict — a suppression applied a
+ * layer up would show a field without an asterisk and still refuse the submit.
+ */
+describe('resolveFieldRuleState — a server-owned value outranks every required rule (#4085)', () => {
+  const REQUIRED_WHEN = "record.status == 'scheduled'";
+  const TRUE_RECORD = { status: 'scheduled' };
+
+  it('suppresses a requiredWhen that resolves TRUE', () => {
+    const s = resolveFieldRuleState({ requiredWhen: REQUIRED_WHEN }, TRUE_RECORD, {
+      serverOwnedValue: true,
+    });
+    expect(s.required).toBe(false);
+  });
+
+  it('suppresses the static flag too — the two spellings behave identically', () => {
+    const s = resolveFieldRuleState({}, TRUE_RECORD, { required: true, serverOwnedValue: true });
+    expect(s.required).toBe(false);
+  });
+
+  it('suppresses both at once', () => {
+    const s = resolveFieldRuleState({ requiredWhen: REQUIRED_WHEN }, TRUE_RECORD, {
+      required: true,
+      serverOwnedValue: true,
+    });
+    expect(s.required).toBe(false);
+  });
+
+  it('leaves visibility and readonly alone — it is the required rule that yields', () => {
+    const s = resolveFieldRuleState(
+      { visibleWhen: REQUIRED_WHEN, readonlyWhen: REQUIRED_WHEN, requiredWhen: REQUIRED_WHEN },
+      TRUE_RECORD,
+      { serverOwnedValue: true },
+    );
+    expect(s.visible).toBe(true);
+    expect(s.readonly).toBe(true);
+    expect(s.required).toBe(false);
+  });
+
+  it('does nothing when the field is not server-owned — the EDIT-mode boundary', () => {
+    // `isServerOwnedValue` returns false for every edit form, so this is the
+    // shape an edit-mode caller passes: the predicate decides, as authored.
+    for (const statics of [{ serverOwnedValue: false }, {}]) {
+      const s = resolveFieldRuleState({ requiredWhen: REQUIRED_WHEN }, TRUE_RECORD, statics);
+      expect(s.required).toBe(true);
+    }
+  });
+
+  it('omitting the member preserves the prior behaviour — callers that never state the fact are unaffected', () => {
+    expect(resolveFieldRuleState({}, {}, { required: true }).required).toBe(true);
+    expect(
+      resolveFieldRuleState({ requiredWhen: REQUIRED_WHEN }, { status: 'draft' }, {}).required,
+    ).toBe(false);
+  });
+});
+
 describe('failure diagnostics — loud fail-open (objectstack#5149, appeal 2)', () => {
   // Every test uses a UNIQUE predicate text: the once-per-predicate dedupe is
   // module-level on purpose (it must survive re-renders), so a text reused

--- a/packages/core/src/evaluator/fieldRules.ts
+++ b/packages/core/src/evaluator/fieldRules.ts
@@ -203,6 +203,24 @@ export function evalFieldPredicate(
  * `false` predicate result for required/readonly — but `visibleWhen` is
  * authoritative when present (so a field can be conditionally shown/hidden).
  *
+ * ## `statics.serverOwnedValue` — the one thing that outranks BOTH
+ *
+ * A CREATE form leaves a producer-owned control empty on purpose and omits the
+ * key, so the server resolves the declared runtime default (#4069). Required-
+ * ness is then not the client's question at all, and this is the single place
+ * that answers it: `required` resolves to `false` whatever `statics.required`
+ * says and whatever `requiredWhen` evaluates to.
+ *
+ * Both spellings had to land HERE, not in a gate a layer up. Since
+ * objectui#4201 the submit-time check and the required marker read one live
+ * verdict — this function's — so a suppression applied anywhere else would
+ * show a field without an asterisk and still refuse the submit, which is the
+ * exact two-layer disagreement #4201 removed. #4085 is the conditional half:
+ * `requiredWhen` resolving TRUE on a create form re-required a control the
+ * renderer deliberately left empty, with nothing the user could type to
+ * unblock it. See `isServerOwnedValue` in `../validation/server-owned-value.js`
+ * for who computes the fact and why the mode is the caller's to state.
+ *
  * @param fieldContext  Optional locator for failure warnings — e.g.
  *                      `"field 'amount'"`. The warning then reads
  *                      `visibleWhen of field 'amount' …`; without it, the rule
@@ -215,7 +233,7 @@ export function resolveFieldRuleState(
     requiredWhen?: FieldRulePredicate;
   },
   record: Record<string, unknown>,
-  statics: { required?: boolean; readonly?: boolean },
+  statics: { required?: boolean; readonly?: boolean; serverOwnedValue?: boolean },
   previous?: Record<string, unknown>,
   scope?: Record<string, unknown>,
   fieldContext?: string,
@@ -235,11 +253,18 @@ export function resolveFieldRuleState(
       ? evalFieldPredicate(rules.readonlyWhen, record, false, previous, scope, diag('readonlyWhen'))
       : false);
 
+  // Short-circuited, not evaluated-and-discarded: the verdict cannot depend on
+  // the predicate, so running it would only spend an engine call per field per
+  // render. A broken `requiredWhen` still warns wherever it decides something
+  // — the same object's EDIT form, and any create form where the field is not
+  // server-owned.
   const required =
-    statics.required === true ||
-    (rules.requiredWhen != null
-      ? evalFieldPredicate(rules.requiredWhen, record, false, previous, scope, diag('requiredWhen'))
-      : false);
+    statics.serverOwnedValue === true
+      ? false
+      : statics.required === true ||
+        (rules.requiredWhen != null
+          ? evalFieldPredicate(rules.requiredWhen, record, false, previous, scope, diag('requiredWhen'))
+          : false);
 
   return { visible, readonly, required };
 }

--- a/packages/core/src/validation/__tests__/server-owned-value.test.ts
+++ b/packages/core/src/validation/__tests__/server-owned-value.test.ts
@@ -1,0 +1,88 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * "Is this field's value the producer's to supply?" — the classifier every
+ * required-ness decision reads (#4069 / #4085).
+ *
+ * The runtime shapes come from `@objectstack/spec`'s own `DEFAULT_VALUE_TOKENS`
+ * rather than a hand-copied list, so a token added to the family tomorrow is
+ * pinned here without an edit — and so this suite cannot drift from the
+ * classifier the way a literal list would. `@object-ui/plugin-form`'s
+ * `createDefaults.test.tsx` pins the same predicate from the seeding side; both
+ * import ONE implementation, which is the point.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_VALUE_TOKENS } from '@objectstack/spec/data';
+import { isRuntimeDefault, isServerOwnedValue } from '../server-owned-value.js';
+
+/** A CEL Expression envelope — the non-token half of "the server resolves it". */
+const CEL_DEFAULT = { dialect: 'cel', source: 'today()' };
+
+const RUNTIME_SHAPES: Array<readonly [string, unknown]> = [
+  ...DEFAULT_VALUE_TOKENS.map((t) => [String(t), t as unknown] as const),
+  ['CEL envelope', CEL_DEFAULT as unknown] as const,
+];
+
+describe('isRuntimeDefault', () => {
+  it.each(RUNTIME_SHAPES)('%s is an instruction the server resolves', (_what, value) => {
+    expect(isRuntimeDefault(value)).toBe(true);
+  });
+
+  it.each([
+    ['a static literal', 'draft'],
+    ['a number', 0],
+    ['a boolean', false],
+    ['an empty string', ''],
+    ['no default', undefined],
+    ['null', null],
+    ['a plain object', { foo: 'bar' }],
+    // Structural, not dialect-specific: the point is "the server evaluates
+    // this", which is true for every dialect — but BOTH halves must be there.
+    ['a half-formed envelope', { dialect: 'cel' }],
+  ])('%s is a literal value, not an instruction', (_what, value) => {
+    expect(isRuntimeDefault(value)).toBe(false);
+  });
+});
+
+describe('isServerOwnedValue (#4085)', () => {
+  /** A runtime FormField as the object-bound builders produce it. */
+  const withDefault = (defaultValue: unknown) => ({ name: 'remind_at', field: { defaultValue } });
+
+  it.each(RUNTIME_SHAPES)('%s makes a CREATE form field server-owned', (_what, value) => {
+    expect(isServerOwnedValue(withDefault(value), true)).toBe(true);
+  });
+
+  it.each(RUNTIME_SHAPES)('%s is NOT server-owned on an EDIT form', (_what, value) => {
+    // The token was resolved at insert; the control shows a persisted value, so
+    // blanking it is a real removal and every required rule enforces normally.
+    expect(isServerOwnedValue(withDefault(value), false)).toBe(false);
+  });
+
+  it('a STATIC literal default is never server-owned — that control was seeded', () => {
+    expect(isServerOwnedValue(withDefault('draft'), true)).toBe(false);
+  });
+
+  it('a field declaring no default is never server-owned', () => {
+    expect(isServerOwnedValue(withDefault(undefined), true)).toBe(false);
+    expect(isServerOwnedValue({ name: 'title' }, true)).toBe(false);
+  });
+
+  it('a hand-authored FormField carries no object metadata, so it is untouched', () => {
+    // Only the object-bound builders stash `field`; a form schema written by
+    // hand has no declared default the server knows about, so its rules stand.
+    expect(isServerOwnedValue({ name: 'title', defaultValue: 'NOW()' } as any, true)).toBe(false);
+  });
+
+  it('tolerates a missing field descriptor', () => {
+    expect(isServerOwnedValue(undefined, true)).toBe(false);
+    expect(isServerOwnedValue(null, true)).toBe(false);
+    expect(isServerOwnedValue({ field: null }, true)).toBe(false);
+  });
+});

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -14,6 +14,7 @@
  */
 
 export * from './required-presence.js';
+export * from './server-owned-value.js';
 export * from './validation-engine.js';
 export * from './schema-validator.js';
 export * from './validators/index.js';

--- a/packages/core/src/validation/server-owned-value.ts
+++ b/packages/core/src/validation/server-owned-value.ts
@@ -1,0 +1,122 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The ONE client-side answer to "is this field's value the PRODUCER's to
+ * supply?" — the other half of {@link isMissingForRequired}.
+ *
+ * A `required` verdict is a question about two facts: is the value absent
+ * (`required-presence.ts`), and was the client ever supposed to provide it.
+ * This module owns the second one. Both live here in `@object-ui/core` because
+ * every layer that decides required-ness reads them: the form renderer
+ * (`resolveFieldRuleState`), the wizard's cross-step gate, and the
+ * create-form field builders in `@object-ui/plugin-form`.
+ *
+ * ## What makes a value server-owned
+ *
+ * A `defaultValue` may be a literal, or an *instruction* the server resolves
+ * per insert:
+ *
+ *   - a runtime token — `'NOW()'` / `'current_user'`, the whole
+ *     `DEFAULT_VALUE_TOKENS` family from `@objectstack/spec/data`
+ *   - a CEL Expression envelope — `{ dialect: 'cel', source: 'today()' }`
+ *
+ * A CREATE form deliberately leaves such a control EMPTY and omits the key
+ * from the payload, because `ObjectQL.applyFieldDefaults` resolves a declared
+ * default only for a field that arrives absent or null (#4047 / #4068). The
+ * field is therefore not "missing" on that submit — it is server-owned, and
+ * nothing the client evaluates may declare it required (#4069 / #4085).
+ *
+ * ## Create only
+ *
+ * On an EDIT form the token was already resolved at insert. The control shows
+ * a persisted value, so blanking it is a real removal and `required` (static
+ * or conditional) enforces normally.
+ */
+
+import { isRuntimeDefaultToken } from '@objectstack/spec/data';
+
+/**
+ * Is `v` a CEL/template Expression envelope rather than a literal value?
+ *
+ * Same shape test the engine applies before handing a default to
+ * `ExpressionEngine` (`{ dialect, source }`), kept structural on purpose: the
+ * point is "the server evaluates this", which is true for every dialect.
+ */
+function isExpressionEnvelope(v: unknown): boolean {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as { dialect?: unknown }).dialect === 'string' &&
+    typeof (v as { source?: unknown }).source === 'string'
+  );
+}
+
+/**
+ * Is this declared `defaultValue` a RUNTIME INSTRUCTION the server resolves per
+ * insert, rather than a literal value?
+ *
+ * True for the `DEFAULT_VALUE_TOKENS` family (`'NOW()'` / `'current_user'`) and
+ * for CEL/template Expression envelopes. This is THE classifier for "the
+ * producer owns this field's create value", and every consumer reads THIS one
+ * — a second copy would be free to disagree about, say, a CEL envelope, and
+ * then a form would seed a field it also refuses to submit. Today's consumers:
+ *
+ *   1. seeding (#4047 / #4068) — such a default is not seeded, because putting
+ *      the literal text `NOW()` into a datetime input and submitting it
+ *      suppresses the very resolution the declaration asked for;
+ *   2. the create-mode static `required` rule (#4069) —
+ *      `isRequiredInForm` in `@object-ui/plugin-form`;
+ *   3. the create-mode `requiredWhen` rule (#4085) —
+ *      {@link isServerOwnedValue}, read by `resolveFieldRuleState`.
+ */
+export function isRuntimeDefault(v: unknown): boolean {
+  return isRuntimeDefaultToken(v) || isExpressionEnvelope(v);
+}
+
+/**
+ * A runtime `FormField` as far as this module is concerned: the resolved
+ * object-field metadata stash, and whatever else the field carries.
+ *
+ * Stated structurally rather than as `@object-ui/types`' `FormField` so the
+ * one key this module reads is visible in the signature — and with an index
+ * signature so a caller (or a test) may hand over an object literal carrying
+ * the rest of the field without tripping TypeScript's excess-property check.
+ */
+export interface FieldWithDeclaredDefault {
+  field?: { defaultValue?: unknown } | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Does the PRODUCER supply this field's value for the submit this form is
+ * about to make? (#4085)
+ *
+ * The single derivation of that fact, so the three call sites that feed
+ * `resolveFieldRuleState` cannot each answer "where does the declared default
+ * live" differently. It reads the runtime FormField's `field` slot — the
+ * resolved object-field metadata the object-bound builders stash there
+ * (`ObjectForm`, `sectionFields`, and the containers' no-sections paths), and
+ * the only spelling of a declared `defaultValue` that reaches the renderer.
+ * A hand-authored FormField carries no object metadata, so it is never
+ * server-owned and its rules are untouched.
+ *
+ * `isCreateForm` is the CALLER's fact, never inferred here: the form renderer
+ * reads it off `FormSchema.previousValues` (whose absence *is* the declared
+ * "this is an insert" signal, objectui#3484), while the wizard's step gate
+ * reads its own `mode`. An evaluator guessing from a `previous` argument would
+ * call an edit-mode caller that simply passes no `previous` a create form, and
+ * silently drop a `requiredWhen` the author meant to enforce.
+ */
+export function isServerOwnedValue(
+  field: FieldWithDeclaredDefault | null | undefined,
+  isCreateForm: boolean,
+): boolean {
+  if (!isCreateForm) return false;
+  return isRuntimeDefault(field?.field?.defaultValue);
+}

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -115,7 +115,7 @@ it; folding a default in over a column the record leaves unset would arm a
 silent write of a value the user never chose, on the next save of any other
 field.
 
-#### `required` + a runtime default
+#### `required` (or `requiredWhen`) + a runtime default
 
 A field may declare both, and it is coherent authoring — storage-level required,
 with the value guaranteed by the producer:
@@ -131,22 +131,36 @@ rule, and the field is **omitted from the payload** — omitted, not sent empty,
 because `applyFieldDefaults` resolves the declaration only for a field that
 arrives absent or null, and a blank string is neither.
 
+The **conditional** spelling reaches the same verdict. A `requiredWhen`
+predicate says "required in this state", but `NOW()` / `current_user` resolve
+at insert regardless of state, so the producer's guarantee covers the
+conditional claim exactly as it covers the unconditional one:
+
+```ts
+remind_at: Field.datetime({ requiredWhen: 'status == "scheduled"', defaultValue: 'NOW()' }),
+```
+
 | Mode | Declared | Left empty | Effect |
 |---|---|---|---|
-| create | `required` + a runtime default | yes | submits; the key is absent, and the server resolves it |
-| create | `required` + a runtime default | no (user typed) | submits the typed value — it outranks the default |
-| create | `required` + a static literal | user cleared the seeded control | refused: they removed a value that was really there |
-| edit | `required`, anything | user blanked it | refused: the token was resolved at insert, so this is a real removal |
+| create | `required` / `requiredWhen` TRUE + a runtime default | yes | submits; the key is absent, and the server resolves it |
+| create | `required` / `requiredWhen` TRUE + a runtime default | no (user typed) | submits the typed value — it outranks the default |
+| create | `required` / `requiredWhen` TRUE + a static literal | user cleared the seeded control | refused: they removed a value that was really there |
+| create | `requiredWhen` TRUE, no default | yes | refused: nobody else supplies this value |
+| edit | `required` / `requiredWhen` TRUE, anything | user blanked it | refused: the token was resolved at insert, so this is a real removal |
 
 The required marker and `aria-required` go with the rule in the create case,
-since one boolean drives all three — in that mode the user genuinely is not
+since one verdict drives all three — in that mode the user genuinely is not
 required to provide the value. Showing what the server *will* supply, as a
 non-authoritative preview, is a separate follow-up.
 
-Both halves read one predicate (`isRuntimeDefault` in `schemaDefaults`), which
-is what keeps a form from seeding a field it also refuses to submit. Not
-extended to `requiredWhen`, the conditional-required CEL rule, which the form
-renderer resolves against the live record.
+Every consumer reads one predicate, `isRuntimeDefault` in `@object-ui/core`
+(re-exported here) — which is what keeps a form from seeding a field it also
+refuses to submit. The static half is decided at the producer, in
+`isRequiredInForm`; the conditional half cannot be, because `requiredWhen` is
+resolved downstream against the live record, so it is suppressed inside the one
+evaluator that resolves it — `resolveFieldRuleState`, reading
+`isServerOwnedValue`. Display and validation share that single verdict, so a
+field can never lose its asterisk while still refusing the submit.
 
 ### Column width of a sectioned form
 

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -17,12 +17,12 @@ import React, { useState, useCallback, useMemo } from 'react';
 import type { FormField, DataSource } from '@object-ui/types';
 import { Button, cn, toast } from '@object-ui/components';
 import { AlertCircle, Check, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
-import { resolveFieldRuleState, evalFieldPredicate, isMissingForRequired } from '@object-ui/core';
+import { resolveFieldRuleState, evalFieldPredicate, isMissingForRequired, isServerOwnedValue } from '@object-ui/core';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { FormSectionContainer } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
-import { seedCreateValues, omitServerResolvedDefaults } from './schemaDefaults';
+import { seedCreateValues, omitServerResolvedDefaults, isCreateFormMode } from './schemaDefaults';
 import { applyAutoColSpan, containerGridColsFor } from './autoLayout';
 import { resolveSuccessNavigate, isSameOriginUrl, type SubmitBehavior } from './successBehavior';
 import { useOccSave } from './occSave';
@@ -329,6 +329,11 @@ export const WizardForm: React.FC<WizardFormProps> = ({
     [objectSchema, schema.readOnly, schema.mode, schema.recordId, schema.objectName, fieldLabel],
   );
 
+  // The same "no persisted record" test the seeding and the create-mode
+  // `required` suppression use, so this wizard cannot be seeded as a create
+  // form and gated as an edit one.
+  const isCreateWizard = isCreateFormMode(schema);
+
   // Current section fields
   const currentSectionFields = useMemo(() => {
     if (currentStep >= 0 && currentStep < totalSteps) {
@@ -368,7 +373,19 @@ export const WizardForm: React.FC<WizardFormProps> = ({
               requiredWhen: (field as any).requiredWhen,
             },
             record,
-            { required: !!field.required, readonly: (field as any).readonly === true },
+            {
+              required: !!field.required,
+              readonly: (field as any).readonly === true,
+              // Same suppression the form renderer applies (#4069 / #4085): on
+              // a CREATE wizard a producer-owned control is left empty and its
+              // key omitted, so neither the static flag nor a `requiredWhen`
+              // resolving TRUE may hold the final submit. The mode is read from
+              // the schema rather than from the absent `previous` argument
+              // above — this gate passes no `previous` in EITHER mode, so
+              // inferring create-ness from it would drop a `requiredWhen` an
+              // EDIT wizard is supposed to enforce.
+              serverOwnedValue: isServerOwnedValue(field, isCreateWizard),
+            },
             undefined,
             undefined,
             `field '${name}'`,
@@ -391,7 +408,7 @@ export const WizardForm: React.FC<WizardFormProps> = ({
       });
       return out;
     },
-    [schema.sections, buildSectionFields],
+    [schema.sections, buildSectionFields, isCreateWizard],
   );
 
   // Handle step data collection (merge partial data into formData)

--- a/packages/plugin-form/src/createDefaults.test.tsx
+++ b/packages/plugin-form/src/createDefaults.test.tsx
@@ -622,3 +622,234 @@ describe('one classifier, two consumers (#4069)', () => {
     expect(isRequiredInForm(undefined, true)).toBe(false);
   });
 });
+
+/**
+ * The CONDITIONAL half: `requiredWhen` + a runtime `defaultValue` (#4085).
+ *
+ * #4069 ruled the STATIC spelling — a create form does not enforce `required`
+ * on a field whose value the producer resolves at insert. `requiredWhen` is
+ * resolved one layer downstream, in the form renderer, against the LIVE record
+ * (`resolveFieldRuleState`), so it survived that fix untouched: a predicate
+ * resolving TRUE on a create form re-required a control the renderer
+ * deliberately leaves empty, and the submit was refused with nothing sensible
+ * for the user to type. Ruled 2026-08-11 (#4085): in CREATE mode the two
+ * spellings behave identically on a producer-owned field, because `NOW()` /
+ * `current_user` resolve at insert regardless of the state the predicate names.
+ *
+ * This is the issue's own "Reproduce" recipe: the #4069 fixture with one
+ * field's `required: true` swapped for a `requiredWhen` that resolves TRUE.
+ *
+ * Four directions, the same three boundaries #4069 pinned plus the one this
+ * card adds:
+ *
+ *   1. create + predicate TRUE + runtime default  → submit SUCCEEDS, key ABSENT
+ *   2. create + predicate TRUE + NO default       → still refused (the contrast
+ *      that proves the suppression is targeted, not "create forms don't
+ *      validate")
+ *   3. EDIT + predicate TRUE + runtime default    → still enforced. The token
+ *      was resolved at insert; blanking the column now is a real removal
+ *   4. the required MARKER tracks the same verdict — display and validation
+ *      read ONE `resolveFieldRuleState` result (#4201), so a suppressed field
+ *      may never show an asterisk it will not enforce
+ */
+
+/** Resolves TRUE on the fixture below, in both create and edit mode. */
+const WHEN_SCHEDULED = "record.status == 'scheduled'";
+
+/** The #4069 runtime shapes again, conditionally required instead of statically. */
+const CONDITIONAL_RUNTIME_FIELDS = RUNTIME_FIELDS.map((f) => ({ ...f, name: `cw_${f.name}` }));
+
+/**
+ * `status` carries a STATIC literal default so a create form opens with the
+ * predicate already TRUE — the deadlock state, reached without the user
+ * touching anything.
+ *
+ * `plan` is conditionally required with NO default: the control the user
+ * genuinely must fill, and the contrast that proves the suppression reads the
+ * declared default rather than the mode alone.
+ */
+const CONDITIONAL_OBJECT_SCHEMA = {
+  name: 'reminder',
+  fields: {
+    status: { type: 'text', label: 'Status', defaultValue: 'scheduled' },
+    plan: { type: 'text', label: 'Plan', requiredWhen: WHEN_SCHEDULED },
+    ...Object.fromEntries(
+      CONDITIONAL_RUNTIME_FIELDS.map((f) => [
+        f.name,
+        { type: 'text', label: f.what, requiredWhen: WHEN_SCHEDULED, defaultValue: f.defaultValue },
+      ]),
+    ),
+  },
+};
+
+const CONDITIONAL_SECTIONS = [
+  {
+    name: 'basics',
+    label: 'Basics',
+    fields: ['status', 'plan', ...CONDITIONAL_RUNTIME_FIELDS.map((f) => f.name)],
+  },
+];
+
+describe.each(CONTAINERS)('%s — `requiredWhen` + runtime `defaultValue` on create (#4085)', (_name, Container, formType) => {
+  const renderConditional = (ds: any, extra: Record<string, unknown> = {}) =>
+    render(
+      <Container
+        schema={{
+          type: 'object-form',
+          formType,
+          objectName: 'reminder',
+          mode: 'create',
+          open: true,
+          sections: CONDITIONAL_SECTIONS,
+          ...extra,
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+  it('submits with the conditionally-required runtime-default fields left empty, and OMITS them', async () => {
+    const ds = makeDS(CONDITIONAL_OBJECT_SCHEMA);
+    renderConditional(ds);
+
+    const plan = await awaitField('plan');
+    fireEvent.change(plan, { target: { value: 'ring the bell' } });
+    // The predicate is TRUE the whole time — `status` opened seeded.
+    expect(fieldInput('status')?.value).toBe('scheduled');
+    submit();
+
+    // Before this change the submit was refused here: `resolveFieldRuleState`
+    // re-required every `cw_*` control from the live record, over the top of
+    // the static suppression #4084 had already applied.
+    await waitFor(() => expect(ds.create).toHaveBeenCalled());
+    const payload = ds.create.mock.calls[0][1];
+    expect(payload).toMatchObject({ plan: 'ring the bell' });
+    for (const f of CONDITIONAL_RUNTIME_FIELDS) expect(payload).not.toHaveProperty(f.name);
+  });
+
+  it('drops the required marker on them, so the star and the submit agree', async () => {
+    const ds = makeDS(CONDITIONAL_OBJECT_SCHEMA);
+    renderConditional(ds);
+
+    await awaitField('plan');
+    // The predicate holds for every field alike; only the producer-owned ones
+    // lose the rule — and they lose the marker with it, because both read one
+    // verdict (#4201).
+    await waitFor(() => expect(marksRequired('plan')).toBe(true));
+    for (const f of CONDITIONAL_RUNTIME_FIELDS) expect(marksRequired(f.name)).toBe(false);
+  });
+
+  it('still refuses a conditionally-required field that declares NO default', async () => {
+    const ds = makeDS(CONDITIONAL_OBJECT_SCHEMA);
+    renderConditional(ds);
+
+    await awaitField('plan'); // left empty on purpose
+    submit();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ds.create).not.toHaveBeenCalled();
+  });
+
+  it('submits a value the user DOES type into a conditionally-required runtime-default field', async () => {
+    const ds = makeDS(CONDITIONAL_OBJECT_SCHEMA);
+    renderConditional(ds);
+
+    const plan = await awaitField('plan');
+    fireEvent.change(plan, { target: { value: 'ring the bell' } });
+    const target = CONDITIONAL_RUNTIME_FIELDS[0].name;
+    const typed = await awaitField(target);
+    fireEvent.change(typed, { target: { value: 'typed by hand' } });
+    submit();
+
+    await waitFor(() => expect(ds.create).toHaveBeenCalled());
+    // What is suppressed is the "must not be empty" rule, never the field.
+    expect(ds.create.mock.calls[0][1]).toMatchObject({
+      plan: 'ring the bell',
+      [target]: 'typed by hand',
+    });
+  });
+
+  it('leaves EDIT mode alone — `requiredWhen` still enforces on a persisted row', async () => {
+    const stored: Record<string, unknown> = { id: 'r1', status: 'scheduled', plan: 'ring the bell' };
+    for (const f of CONDITIONAL_RUNTIME_FIELDS) stored[f.name] = 'resolved at insert';
+    const ds = makeDS(CONDITIONAL_OBJECT_SCHEMA, stored);
+    render(
+      <Container
+        schema={{
+          type: 'object-form',
+          formType,
+          objectName: 'reminder',
+          mode: 'edit',
+          recordId: 'r1',
+          open: true,
+          sections: CONDITIONAL_SECTIONS,
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const target = CONDITIONAL_RUNTIME_FIELDS[0].name;
+    const el = await waitFor(() => {
+      const input = fieldInput(target);
+      if (input?.value !== 'resolved at insert') throw new Error('record not loaded yet');
+      return input;
+    });
+    // Defaults do not re-apply to an existing record, so the predicate means
+    // exactly what it says here: the marker stays and the blank is refused.
+    expect(marksRequired(target)).toBe(true);
+
+    fireEvent.change(el, { target: { value: '' } });
+    submit();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ds.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('ObjectForm — `requiredWhen` + runtime `defaultValue` on create (#4085)', () => {
+  // The flat container builds its fields on its own path (no sections), so the
+  // conditional rule is pinned here too rather than assumed from the table.
+  it('submits with the conditionally-required runtime-default fields left empty, and OMITS them', async () => {
+    const ds = makeDS(CONDITIONAL_OBJECT_SCHEMA);
+    render(
+      <ObjectForm
+        schema={{ type: 'object-form', objectName: 'reminder', mode: 'create' } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const plan = await awaitField('plan');
+    fireEvent.change(plan, { target: { value: 'ring the bell' } });
+    submit();
+
+    await waitFor(() => expect(ds.create).toHaveBeenCalled());
+    const payload = ds.create.mock.calls[0][1];
+    expect(payload).toMatchObject({ plan: 'ring the bell' });
+    for (const f of CONDITIONAL_RUNTIME_FIELDS) expect(payload).not.toHaveProperty(f.name);
+  });
+
+  it('leaves EDIT mode alone', async () => {
+    const stored: Record<string, unknown> = { id: 'r1', status: 'scheduled', plan: 'ring the bell' };
+    for (const f of CONDITIONAL_RUNTIME_FIELDS) stored[f.name] = 'resolved at insert';
+    const ds = makeDS(CONDITIONAL_OBJECT_SCHEMA, stored);
+    render(
+      <ObjectForm
+        schema={{ type: 'object-form', objectName: 'reminder', mode: 'edit', recordId: 'r1' } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const target = CONDITIONAL_RUNTIME_FIELDS[0].name;
+    const el = await waitFor(() => {
+      const input = fieldInput(target);
+      if (input?.value !== 'resolved at insert') throw new Error('record not loaded yet');
+      return input;
+    });
+    expect(marksRequired(target)).toBe(true);
+
+    fireEvent.change(el, { target: { value: '' } });
+    submit();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ds.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-form/src/schemaDefaults.ts
+++ b/packages/plugin-form/src/schemaDefaults.ts
@@ -15,7 +15,10 @@
  * server resolves per insert is neither seedable nor missing. Keeping the two
  * consumers on one predicate is the point of this module — a second copy would
  * be free to disagree about, say, a CEL envelope, and then a form would seed a
- * field it also refuses to submit.
+ * field it also refuses to submit. Since #4085 that classifier LIVES in
+ * `@object-ui/core` (this module re-exports it) so a third consumer — the
+ * `requiredWhen` suppression inside `resolveFieldRuleState` — reads the very
+ * same one from a package `@object-ui/components` is allowed to depend on.
  *
  * ## What this is for
  *
@@ -65,49 +68,18 @@
  * Callers gate on create; this module never sees the mode.
  */
 
-import { isRuntimeDefaultToken } from '@objectstack/spec/data';
-import { isMissingForRequired } from '@object-ui/core';
+import { isMissingForRequired, isRuntimeDefault } from '@object-ui/core';
+
+// Re-exported (not re-implemented) so this package's long-standing import site
+// keeps working while there is exactly ONE classifier in the workspace. It
+// moved down to `@object-ui/core` for #4085: the form renderer and the
+// wizard's step gate need the same fact to suppress `requiredWhen`, and
+// `@object-ui/components` cannot depend on a `plugin-*` package.
+export { isRuntimeDefault };
 
 /** An object schema as the data source serves it (`{ fields: { [name]: def } }`). */
 interface ObjectSchemaLike {
   fields?: Record<string, { defaultValue?: unknown } | undefined>;
-}
-
-/**
- * Is `v` a CEL/template Expression envelope rather than a literal value?
- *
- * Same shape test the engine applies before handing a default to
- * `ExpressionEngine` (`{ dialect, source }`), kept structural on purpose: the
- * point is "the server evaluates this", which is true for every dialect.
- */
-function isExpressionEnvelope(v: unknown): boolean {
-  return (
-    typeof v === 'object' &&
-    v !== null &&
-    typeof (v as { dialect?: unknown }).dialect === 'string' &&
-    typeof (v as { source?: unknown }).source === 'string'
-  );
-}
-
-/**
- * Is this declared `defaultValue` a RUNTIME INSTRUCTION the server resolves per
- * insert, rather than a literal value?
- *
- * True for the `DEFAULT_VALUE_TOKENS` family (`'NOW()'` / `'current_user'`) and
- * for CEL/template Expression envelopes. This is THE classifier for "the
- * producer owns this field's create value" — both consumers in this package
- * read it, and neither may grow a second copy:
- *
- *   1. seeding (#4047 / #4068) — such a default is not seeded, because putting
- *      the literal text `NOW()` into a datetime input and submitting it
- *      suppresses the very resolution the declaration asked for;
- *   2. the create-mode `required` rule (#4069) — see {@link isRequiredInForm}.
- *
- * The two are the same fact seen twice: a field whose value the server supplies
- * is neither seedable nor missing.
- */
-export function isRuntimeDefault(v: unknown): boolean {
-  return isRuntimeDefaultToken(v) || isExpressionEnvelope(v);
 }
 
 /**
@@ -172,9 +144,16 @@ export function isCreateFormMode(
  * user really is not required to provide the value. Surfacing what the server
  * WILL supply is issue #4069's option B, a separate follow-up card.
  *
- * Deliberately NOT extended to `requiredWhen` (the conditional-required CEL
- * rule): that is resolved downstream in the form renderer against the live
- * record, outside this package.
+ * The CONDITIONAL spelling (`requiredWhen`) reaches the same verdict, ruled
+ * identically in #4085 — but it cannot be decided here, because it is resolved
+ * downstream against the live record. It is suppressed in the one evaluator
+ * that resolves it, `resolveFieldRuleState`, which reads the same fact off
+ * `@object-ui/core`'s `isServerOwnedValue` (and therefore the same
+ * {@link isRuntimeDefault} classifier this function reads). That evaluator
+ * subsumes this function on every path that threads the fact; this static
+ * answer stays because it is also the one the containers publish as the
+ * FormField's `required` flag, and because it is what re-runs when a form VIEW
+ * restates `required` over the object field (see `normalizeSectionField`).
  */
 export function isRequiredInForm(
   field: { required?: unknown; defaultValue?: unknown } | null | undefined,


### PR DESCRIPTION
Fixes #4085

## 问题

#4069 裁定:CREATE 模式下,字段的 `defaultValue` 若是服务端按 insert 解析的运行时指令(`DEFAULT_VALUE_TOKENS` 成员 `NOW()` / `current_user`,或 CEL Expression 信封 `{ dialect, source }`),该字段是 **producer-owned** —— 控件按设计留空,提交时整个键被省略,因为 `ObjectQL.applyFieldDefaults` 只对「缺席或 null」的字段解析声明。PR #4084 把这条实现在了**静态** `required` 标志上,落在 `@object-ui/plugin-form`。

**条件写法没被覆盖。** `requiredWhen` 是在下游一层、由表单渲染器针对**实时记录**解析的(`resolveFieldRuleState`),所以它原封不动地把要求又加了回来:谓词在 create 表单上为 TRUE 时,控件仍然按设计是空的、提交被拒、而用户没有任何可以填进去的东西 —— 正是 #4069 描述的死锁,只是换了一种拼写。

## 裁定与实现

按 2026-08-11 的委任裁定(issue 评论 5249384519):**CREATE 模式下两种拼写在 producer-owned 字段上行为完全一致。** `requiredWhen` 主张的是「在该状态下、值在存储时必须存在」,而 `NOW()` / `current_user` 无论处于哪个状态都会在 insert 时解析,所以 producer 的保证覆盖条件主张的方式,和它覆盖无条件主张的方式是同一个论证。反向读法(「本状态下必须由**用户**提供,压过我自己声明的默认值」)是一种奇异意图 —— 作者真要那样表达有更自然的拼写:不声明默认值。

抑制落在**两层共读的那一个求值器**里,即 `resolveFieldRuleState`:自 #4201 起,提交期的 required 检查与画星号的显示层读的是同一份 live verdict,所以任何加在其上的第二道门都会造成「星号消失、提交照拒」的两层分歧 —— 那正是 #4201 消除掉的形态。具体地,`resolveFieldRuleState` 的 statics 参数新增 `serverOwnedValue`;为 true 时,静态标志与 `requiredWhen` 谓词都不能让该字段 required。

「这个值是不是 producer 的」这个分类器**下沉到了 `@object-ui/core`**(`isRuntimeDefault` / `isServerOwnedValue`,由 `@object-ui/plugin-form` 重新导出),因为 `@object-ui/components` 不能依赖 `plugin-` 前缀的包 —— 只能移下去,不能抄一份。现在表单渲染器、向导的跨步 gate、以及 create 表单的字段构建器读的是**同一份实现**。

**create/edit 这个事实由调用方陈述,绝不在求值器内部推断。** 表单渲染器从 `FormSchema.previousValues` 读它(它的缺席就是仓内已声明的「这是一次 insert」,#3484);向导的步骤 gate 读自己的 `mode` —— 那个 gate 在**两种模式下都**不传 `previous`,若从该参数推断 create,就会把一个 edit 向导本该 enforce 的 `requiredWhen` 悄悄丢掉。

## 边界(都已钉住)

- **EDIT 模式不动。** 默认值不会重新施加到已有记录上,token 在 insert 时已解析完毕,此刻清空该列是一次真实的删除,`requiredWhen` 照常 enforce。
- **只针对运行时默认值。** 静态字面量默认值**会**被播种进控件(#4068),用户清空它就是移除了一个确实存在过的值 —— 规则照旧。
- **没有声明默认值的字段完全不受影响** —— 这是证明抑制是定向的、而不是「create 表单不做校验」的对照。
- **抑制的是规则,不是字段。** 用户真填了值就照常提交,压过声明的默认值。
- 显示与校验同源:被抑制的字段同时失去必填星号与 `aria-required`,不会出现「无星号却拒交」。

## 测试

全绿(仓根跑,`packages/components packages/plugin-form packages/core`):`Test Files 266 passed (266)` / `Tests 3472 passed (3472)`。仓根 `turbo run type-check`:`Tasks: 81 successful, 81 total`。

新增/扩展的钉:

- `packages/core/src/validation/__tests__/server-owned-value.test.ts`(新增):分类器与 `isServerOwnedValue`,运行时形状取自 spec 自己的 `DEFAULT_VALUE_TOKENS`,不手抄清单 —— 家族里明天新增一个 token 也自动被钉住。
- `packages/core/src/evaluator/__tests__/fieldRules.test.ts`:求值器层的抑制 + 边界(不影响 visible/readonly;非 producer-owned 时谓词照常裁决;不传该成员时行为与改动前逐字相同)。
- `packages/components/src/renderers/form/__tests__/form-required-when-server-owned.test.tsx`(新增):渲染器消费处,create / edit / 静态字面量默认值 / 无默认值 / 谓词 FALSE / 用户已填 六个方向。
- `packages/plugin-form/src/createDefaults.test.tsx`:issue「Reproduce」段点名的现成 fixture —— 把 #4069 fixture 里字段的 `required: true` 换成解析为 TRUE 的 `requiredWhen`,覆盖四个 sectioned 容器 + `ObjectForm`,含 edit 模式边界钉。

## 反向验证(先书面预判方向,再跑变异)

做了两次变异,都只跑上述三个钉文件(118 tests),结果与预判一致。

**变异 A —— 删掉求值器里的 `serverOwnedValue` limb**(threading 保留)。预判:#4085 的钉转红;边界钉**按构造不可能转红**(它们断言的是 enforce,而变异恰好把 enforce 恢复到各处);#4069 的**静态集成钉仍然绿**,因为 plugin-form 的 `isRequiredInForm` 依然在 producer 侧先把静态标志压掉了。实测 `Tests 20 failed | 98 passed`,20 条失败**全部**带 `#4085` 标题,无一条 `#4069`;edit 模式钉、无默认值钉、静态字面量钉全绿。

预判里有**一处偏差,如实记录**:我预判 plugin-form 那条「用户 DOES type 一个值」会保持绿(填了值即满足 required),实测转红。原因是该 fixture 把整个运行时形状家族渲染在同一个表单里 —— 用户只填了其中一个,**其余** `cw_*` 字段在变异下仍然条件必填,于是提交被别的字段拦下,而不是被填了值的那个。同一断言在 components 层(单字段)确实**保持了绿**,正好印证这个解释。

**变异 B —— 保留求值器 limb,只回退 `form.tsx` 里的三处 threading**。预判:components + plugin-form 转红,core 单测**保持全绿**(它们直接调求值器)。实测 `Test Files 2 failed | 1 passed`、`Tests 16 failed | 102 passed`,绿的那个文件正是 `fieldRules.test.ts`。这一次证明 threading 是**承重的**,而不是被 core 单测掩盖的死代码 —— 只有 A 一次变异是证不到这点的。

两次变异都先 commit 了修复再做,还原用 `git checkout` 指定本分支加路径的形式从该 commit 取回(不用 stash —— 共享栈),工作树事后已核对干净。

## 顺带发现(未在本 PR 修)

已另立 #4755:`DrawerForm` 的 no-sections 字段构建器漏掉了 `visibleWhen` / `readonlyWhen` / `requiredWhen` / `group`,而 `ModalForm` 逐行相同的构建器带上了它们(`SplitForm` / `TabbedForm` 无此路径,始终走 `sectionFields.ts`,不受影响)。与本卡无关,未扩围。
