### PR TITLE
fix(components): FilterBuilder 为 in/not_in/between 渲染匹配形状的值输入,家族判定改读 spec 词表 (#3958)

### DIFF
--- a/.changeset/filter-builder-set-operator-value-shapes.md
+++ b/.changeset/filter-builder-set-operator-value-shapes.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/components': patch
+'@object-ui/i18n': patch
+---
+
+`FilterBuilder` gives the set and range operators an input that matches the value shape the spec accepts, and stops minting the shape it refuses.
+
+Three independent paths let one filter row end up with `operator: 'in'` and a
+SCALAR `value` — the shape `ViewFilterRuleSchema` refuses at save time since
+objectstack#6227, and the shape the query path answered `400 INVALID_FILTER` on
+before that (objectstack#5869):
+
+- Changing the operator dropdown wrote `{ operator }` alone, so the seed `''`
+  (or whatever the previous family had produced) survived the switch into
+  `in` / `not_in` / `between`. The operator and the shape of its value are one
+  edit, so they are now made together: switching families re-shapes the value —
+  a typed scalar becomes a one-element list, an empty one becomes `[]`, a range
+  keeps its first bound and leaves the second open, and a list collapsing to a
+  scalar keeps its first entry.
+- A plain text or number column has no static `options`, so `in` fell through to
+  the single-value input and the user could only ever type a scalar into it.
+  Those columns now get a token input (type, Enter or comma commits, `×` or
+  Backspace removes) that always emits an array; `between` gets its two bounds
+  instead of one box. The lookup picker's no-DataSource fallback, which also
+  handed back a scalar while `multiple`, emits a list too.
+- The multi-value families were decided from a local `["in", "notIn"]` literal,
+  already one spelling adrift: `notIn` is an alias and the canonical member is
+  `not_in`, so a stored view read back in canonical form got the single-value
+  input for a set operator. The families are now read from `@objectstack/spec`'s
+  exported `VIEW_FILTER_LIST_VALUE_OPERATORS` / `VIEW_FILTER_PAIR_VALUE_OPERATORS`
+  and folded through `normalizeFilterOperator`, so both spellings of one operator
+  get one answer and a family the spec widens is picked up without an edit here.
+
+`foldFilterGroupToSpecRules` is unchanged and needed no change: it normalizes the
+operator and carries `value` through verbatim, so the shape that reaches storage
+is the producer's to get right. An untouched `in` row arrives as `[]`, which the
+fold's existing incomplete-row rule already drops.
+
+Four locale keys are added to all ten packs for the new inputs
+(`filterBuilder.addValue` / `.removeValue` / `.rangeStart` / `.rangeEnd`).

--- a/packages/app-shell/src/views/viewFilterFold.builderSetOperators.test.tsx
+++ b/packages/app-shell/src/views/viewFilterFold.builderSetOperators.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The whole chain, with nothing stubbed: the real `FilterBuilder` produces a
+ * row, the real `foldFilterGroupToSpecRules` folds it, and the real
+ * `ViewFilterRuleSchema` parses the result (objectui#3958, objectstack#6227).
+ *
+ * Why it lives HERE and not beside the component: this is the only package that
+ * can see all three. `@object-ui/components` cannot import the fold (`app-shell`
+ * depends on it, not the reverse), so its own tests can only mirror what the
+ * fold does — which is exactly the kind of restatement that drifts. This file
+ * is the one place the mirror is checked against the original.
+ *
+ * It also carries the READ-ONLY finding about the fold itself: the fold needed
+ * NO change for this card. It normalizes the operator and carries `value`
+ * through verbatim, so the value shape it persists is decided entirely by the
+ * builder — which is why the fix belongs at the producer (AGENTS.md
+ * contract-first) and not as a coercion here. The `in`-with-a-scalar case below
+ * is the proof: fold it and the spec still refuses it, because the fold never
+ * had the information to repair it.
+ *
+ * DIRECTION, predicted before running: the two "builder output parses" cases
+ * are RED on `origin/main` (the builder emits a scalar there) and green after.
+ * The "a scalar under `in` is refused after folding" case is green in BOTH
+ * directions on purpose — it is what makes the other two mean something.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ViewFilterRuleSchema } from '@objectstack/spec/ui';
+import { FilterBuilder } from '@object-ui/components';
+import { foldFilterGroupToSpecRules } from './viewFilterFold';
+
+// `stage` is a `select` column with no static `options` — the bucket whose
+// dropdown offers `in` / `notIn`, and the one whose value input fell through to
+// the single-value box because there were no options to draw checkboxes from.
+const FIELDS = [
+  { value: 'stage', label: 'Stage', type: 'select' },
+  { value: 'closed_at', label: 'Closed at', type: 'date' },
+];
+
+function renderBuilder(condition: Record<string, unknown>) {
+  const onChange = vi.fn();
+  const value = { id: 'root', logic: 'and', conditions: [{ id: 'c1', ...condition }] };
+  const utils = render(
+    <FilterBuilder fields={FIELDS as any} value={value as any} onChange={onChange} />,
+  );
+  return { ...utils, onChange };
+}
+
+/** Fold the group the builder last emitted, exactly as the toolbar's save does. */
+function foldLast(onChange: ReturnType<typeof vi.fn>) {
+  const calls = onChange.mock.calls;
+  expect(calls.length, 'the builder never called onChange').toBeGreaterThan(0);
+  const result = foldFilterGroupToSpecRules(calls[calls.length - 1][0]);
+  expect(result.ok, `the fold refused the group: ${JSON.stringify(result)}`).toBe(true);
+  return (result as { ok: true; rules: unknown[] }).rules;
+}
+
+async function pickOperator(label: string) {
+  const triggers = screen.getAllByRole('combobox');
+  fireEvent.keyDown(triggers[1], { key: 'ArrowDown' });
+  const option = await waitFor(() => {
+    const found = screen.getAllByRole('option').find((o) => o.textContent === label);
+    expect(found, `no "${label}" option in the operator dropdown`).toBeTruthy();
+    return found!;
+  });
+  fireEvent.click(option);
+}
+
+describe('FilterBuilder -> foldFilterGroupToSpecRules -> ViewFilterRuleSchema', () => {
+  it('the row a user builds with `in` on a plain column is one the spec accepts', () => {
+    const { onChange, getByTestId } = renderBuilder({
+      field: 'stage',
+      operator: 'in',
+      value: [],
+    });
+    const input = getByTestId('filter-multi-value-stage').querySelector('input')!;
+    fireEvent.change(input, { target: { value: 'won' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    const rules = foldLast(onChange);
+    expect(rules).toEqual([{ field: 'stage', operator: 'in', value: ['won'] }]);
+    for (const rule of rules) {
+      const parsed = ViewFilterRuleSchema.safeParse(rule);
+      expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+    }
+  });
+
+  it('switching a filled scalar row into `in` still persists something the spec accepts', async () => {
+    const { onChange } = renderBuilder({ field: 'stage', operator: 'equals', value: 'won' });
+    await pickOperator('In');
+
+    const rules = foldLast(onChange);
+    expect(rules).toEqual([{ field: 'stage', operator: 'in', value: ['won'] }]);
+    expect(ViewFilterRuleSchema.safeParse(rules[0]).success).toBe(true);
+  });
+
+  it('an untouched `in` row is DROPPED, not persisted as an empty predicate', async () => {
+    // `[]` is a legal `in` value the spec accepts, but a row the user never
+    // filled in is not a filter — the fold's existing incomplete-row rule
+    // (objectui#4155) already reads `[]` as missing, and the re-shaping makes
+    // an untouched row arrive in exactly that shape instead of as `''`.
+    const { onChange } = renderBuilder({ field: 'stage', operator: 'equals', value: '' });
+    await pickOperator('In');
+    expect(foldLast(onChange)).toEqual([]);
+  });
+
+  it('a `between` row folds to a two-bound range the spec accepts', () => {
+    const { onChange, getByTestId } = renderBuilder({
+      field: 'closed_at',
+      operator: 'between',
+      value: ['2024-01-01', ''],
+    });
+    const inputs = getByTestId('filter-range-closed_at').querySelectorAll('input');
+    fireEvent.change(inputs[1], { target: { value: '2024-12-31' } });
+
+    const rules = foldLast(onChange);
+    expect(rules).toEqual([
+      { field: 'closed_at', operator: 'between', value: ['2024-01-01', '2024-12-31'] },
+    ]);
+    expect(ViewFilterRuleSchema.safeParse(rules[0]).success).toBe(true);
+  });
+
+  it('the fold cannot repair a scalar under `in` — which is why the producer had to', () => {
+    // The shape the builder used to emit, handed to the fold directly. It
+    // survives the fold verbatim (the fold normalizes the OPERATOR, never the
+    // value) and the spec refuses it. Green before and after this change: it
+    // states why the fix is at the producer, and it is what makes the cases
+    // above discriminating rather than tautological.
+    const folded = foldFilterGroupToSpecRules({
+      id: 'root',
+      logic: 'and',
+      conditions: [{ id: 'c1', field: 'stage', operator: 'in', value: 'won' }],
+    });
+    expect(folded).toEqual({ ok: true, rules: [{ field: 'stage', operator: 'in', value: 'won' }] });
+    const parsed = ViewFilterRuleSchema.safeParse((folded as any).rules[0]);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error!.issues[0].message).toMatch(/requires an ARRAY/);
+  });
+});

--- a/packages/components/src/__tests__/filter-builder-operator-value-arity.test.tsx
+++ b/packages/components/src/__tests__/filter-builder-operator-value-arity.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The FilterBuilder must not mint a value shape `ViewFilterRuleSchema` refuses
+ * (objectui#3958, objectstack#6227).
+ *
+ * Three facts are pinned here, and they are three because the builder had three
+ * independent ways to produce the same broken row:
+ *
+ *   1. **The families come from the spec.** `VIEW_FILTER_LIST_VALUE_OPERATORS`
+ *      and `VIEW_FILTER_PAIR_VALUE_OPERATORS` are imported here and asserted
+ *      against `filterValueArity`, so the component cannot answer this question
+ *      from a local list again. The local list it used to keep — `["in",
+ *      "notIn"]` — was already one spelling adrift: `notIn` is an ALIAS and the
+ *      canonical member is `not_in`, so a stored view read back in canonical
+ *      form got the SINGLE-value input for a set operator.
+ *   2. **Changing the operator re-shapes the value.** The dropdown used to
+ *      write `{ operator }` alone, so the seed `""` (or whatever the previous
+ *      family had produced) survived the switch into `in`.
+ *   3. **Every family has an input that can express it.** A select or lookup
+ *      column OFFERS `in` in its dropdown but carries no static `options` until
+ *      something loads them, so the row fell through to the single-value input
+ *      and the user could only ever type a scalar into it; `between` had one
+ *      input for two bounds.
+ *
+ * DIRECTION, predicted before running: every pin below is RED on `origin/main`
+ * and green after — none of them is a "must not change" guard. The reverse
+ * mutation is recorded in the PR: restoring the `["in", "notIn"]` literal turns
+ * the canonical-`not_in` pin red (and ONLY that one — the alias spelling keeps
+ * matching, which is exactly why the defect survived so long); restoring
+ * `updateCondition(id, { operator })` turns the three switching pins red.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  VIEW_FILTER_LIST_VALUE_OPERATORS,
+  VIEW_FILTER_PAIR_VALUE_OPERATORS,
+  ViewFilterRuleSchema,
+  normalizeFilterOperator,
+} from '@objectstack/spec/ui';
+import {
+  FilterBuilder,
+  filterValueArity,
+  reshapeFilterValue,
+} from '../custom/filter-builder';
+
+/**
+ * `stage` is the column this card is about: a `select` — so its bucket OFFERS
+ * `in` / `notIn` — carrying no static `options`, which is what made
+ * `renderValueInput` fall past every multi-value branch to the single-value
+ * input. (Only the select and lookup buckets offer the set operators at all; a
+ * `text` column can still ARRIVE at one by being read back from stored
+ * metadata, which the spelling cases below cover.)
+ */
+const FIELDS = [
+  { value: 'stage', label: 'Stage', type: 'select' },
+  { value: 'title', label: 'Title', type: 'text' },
+  { value: 'amount', label: 'Amount', type: 'number' },
+  { value: 'closed_at', label: 'Closed at', type: 'date' },
+];
+
+function group(condition: Record<string, unknown>) {
+  return { id: 'root', logic: 'and', conditions: [{ id: 'c1', ...condition }] };
+}
+
+function renderRow(condition: Record<string, unknown>) {
+  const onChange = vi.fn();
+  // Hoisted OUT of the JSX: `FilterBuilder`'s sync effect re-seeds its internal
+  // state whenever the `value` PROP's identity changes, so an inline literal
+  // would undo the interaction under test on the next render.
+  const value = group(condition);
+  const utils = render(
+    <FilterBuilder fields={FIELDS as any} value={value as any} onChange={onChange} />,
+  );
+  return { ...utils, onChange };
+}
+
+/** The row the component handed back on its most recent `onChange`. */
+function lastRow(onChange: ReturnType<typeof vi.fn>) {
+  const calls = onChange.mock.calls;
+  expect(calls.length, 'the builder never called onChange').toBeGreaterThan(0);
+  return calls[calls.length - 1][0].conditions[0];
+}
+
+/**
+ * Drive the REAL operator dropdown. The row's three controls are Radix
+ * comboboxes in field / operator / value order, so index 1 is the operator.
+ */
+async function pickOperator(label: string) {
+  const triggers = screen.getAllByRole('combobox');
+  fireEvent.keyDown(triggers[1], { key: 'ArrowDown' });
+  const option = await waitFor(() => {
+    const found = screen.getAllByRole('option').find((o) => o.textContent === label);
+    expect(found, `no "${label}" option in the operator dropdown`).toBeTruthy();
+    return found!;
+  });
+  fireEvent.click(option);
+}
+
+describe('operator families are the SPEC vocabulary, not a local literal', () => {
+  it.each([...VIEW_FILTER_LIST_VALUE_OPERATORS])('reads %s as a list operator', (operator) => {
+    expect(filterValueArity(operator)).toBe('list');
+  });
+
+  it.each([...VIEW_FILTER_PAIR_VALUE_OPERATORS])('reads %s as a pair operator', (operator) => {
+    expect(filterValueArity(operator)).toBe('pair');
+  });
+
+  it('reads BOTH spellings of the same operator the same way', () => {
+    // The whole point of folding through `normalizeFilterOperator`: the
+    // builder's camelCase dropdown id and the canonical spelling a stored rule
+    // carries are one operator, so they get one answer.
+    expect(normalizeFilterOperator('notIn')).toBe('not_in');
+    expect(filterValueArity('notIn')).toBe('list');
+    expect(filterValueArity('not_in')).toBe('list');
+  });
+
+  it('leaves every other operator scalar', () => {
+    for (const operator of ['equals', 'notEquals', 'contains', 'greaterThan', 'isEmpty']) {
+      expect(filterValueArity(operator), operator).toBe('scalar');
+    }
+  });
+});
+
+describe('changing the operator re-shapes the value across families', () => {
+  it('scalar to list: what the user typed becomes a one-element list', () => {
+    expect(reshapeFilterValue('acme', 'in')).toEqual(['acme']);
+    // The seed an untouched row carries becomes the EMPTY list, which the spec
+    // accepts as a real predicate — not the `""` it refuses.
+    expect(reshapeFilterValue('', 'notIn')).toEqual([]);
+  });
+
+  it('list to scalar: the first entry survives, the rest cannot', () => {
+    expect(reshapeFilterValue(['a', 'b'], 'equals')).toBe('a');
+    expect(reshapeFilterValue([], 'equals')).toBe('');
+  });
+
+  it('scalar to pair: one bound is filled, the other left open', () => {
+    expect(reshapeFilterValue('2024-01-01', 'between')).toEqual(['2024-01-01', '']);
+    // Nothing to carry → the "not filled in yet" shape, which the write path
+    // drops rather than persisting an empty range.
+    expect(reshapeFilterValue('', 'between')).toEqual([]);
+  });
+
+  it('pair to scalar, and list to pair', () => {
+    expect(reshapeFilterValue(['1', '9'], 'greaterThan')).toBe('1');
+    expect(reshapeFilterValue(['a', 'b', 'c'], 'between')).toEqual(['a', 'b']);
+  });
+
+  it('within one family the value is untouched', () => {
+    const values = ['a', 'b'];
+    expect(reshapeFilterValue(values, 'notIn')).toBe(values);
+    expect(reshapeFilterValue('acme', 'contains')).toBe('acme');
+  });
+
+  it('drives it through the real operator dropdown', async () => {
+    const { onChange } = renderRow({ field: 'stage', operator: 'equals', value: 'acme' });
+    await pickOperator('In');
+    expect(lastRow(onChange)).toMatchObject({ operator: 'in', value: ['acme'] });
+  });
+
+  it('drives the reverse switch too', async () => {
+    const { onChange } = renderRow({ field: 'stage', operator: 'in', value: ['acme', 'globex'] });
+    await pickOperator('Equals');
+    expect(lastRow(onChange)).toMatchObject({ operator: 'equals', value: 'acme' });
+  });
+
+  it('drives a switch into the pair family', async () => {
+    const { onChange } = renderRow({ field: 'closed_at', operator: 'after', value: '2024-01-01' });
+    await pickOperator('Between');
+    expect(lastRow(onChange)).toMatchObject({ operator: 'between', value: ['2024-01-01', ''] });
+  });
+});
+
+describe('a list operator on an optionless field has a list input', () => {
+  it('renders the token input and emits an ARRAY', () => {
+    const { onChange, getByTestId } = renderRow({ field: 'stage', operator: 'in', value: [] });
+    const input = getByTestId('filter-multi-value-stage').querySelector('input')!;
+    fireEvent.change(input, { target: { value: 'acme' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(lastRow(onChange).value).toEqual(['acme']);
+  });
+
+  it('converts tokens on a numeric column', () => {
+    const { onChange, getByTestId } = renderRow({ field: 'amount', operator: 'in', value: [] });
+    const input = getByTestId('filter-multi-value-amount').querySelector('input')!;
+    fireEvent.change(input, { target: { value: '42' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    // A number, not "42": `ViewFilterRuleSchema` accepts both, but the live
+    // grid compares against a numeric column.
+    expect(lastRow(onChange).value).toEqual([42]);
+  });
+
+  it('removes a token', () => {
+    const { onChange, getByTestId } = renderRow({
+      field: 'stage',
+      operator: 'in',
+      value: ['acme', 'globex'],
+    });
+    const remove = getByTestId('filter-multi-value-stage').querySelectorAll('button')[0];
+    fireEvent.click(remove);
+    expect(lastRow(onChange).value).toEqual(['globex']);
+  });
+
+  // The two-directional pin. `notIn` is the spelling the dropdown writes;
+  // `not_in` is the spelling a stored rule carries. Both are the same operator
+  // and both must reach the same input — the canonical one is the half that was
+  // broken, and it was invisible because the alias half worked.
+  it.each(['in', 'notIn', 'not_in'])('renders it for the %s spelling', (operator) => {
+    const { getByTestId } = renderRow({ field: 'title', operator, value: [] });
+    expect(getByTestId('filter-multi-value-title')).toBeInTheDocument();
+  });
+});
+
+describe('the pair operator has two bounds', () => {
+  it('renders two inputs and emits a two-element array', () => {
+    const { onChange, getByTestId } = renderRow({
+      field: 'closed_at',
+      operator: 'between',
+      value: [],
+    });
+    const inputs = getByTestId('filter-range-closed_at').querySelectorAll('input');
+    expect(inputs.length).toBe(2);
+    fireEvent.change(inputs[0], { target: { value: '2024-01-01' } });
+    expect(lastRow(onChange).value).toEqual(['2024-01-01', '']);
+  });
+
+  it('collapses back to the unfilled shape when both bounds are cleared', () => {
+    const { onChange, getByTestId } = renderRow({
+      field: 'closed_at',
+      operator: 'between',
+      value: ['2024-01-01', ''],
+    });
+    const inputs = getByTestId('filter-range-closed_at').querySelectorAll('input');
+    fireEvent.change(inputs[0], { target: { value: '' } });
+    expect(lastRow(onChange).value).toEqual([]);
+  });
+});
+
+describe('the scalar operators are untouched', () => {
+  it('still renders ONE plain input and still emits a scalar', () => {
+    const { onChange, container } = renderRow({ field: 'title', operator: 'equals', value: '' });
+    const inputs = container.querySelectorAll('input');
+    expect(inputs.length).toBe(1);
+    fireEvent.change(inputs[0], { target: { value: 'acme' } });
+    expect(lastRow(onChange).value).toBe('acme');
+  });
+
+  it('draws no token or range input for a scalar operator', () => {
+    const { queryByTestId } = renderRow({ field: 'title', operator: 'contains', value: 'ac' });
+    expect(queryByTestId('filter-multi-value-title')).toBeNull();
+    expect(queryByTestId('filter-range-title')).toBeNull();
+  });
+});
+
+/**
+ * The end this whole card is about: what the builder produces must PARSE.
+ *
+ * The real spec schema, not a restatement of it — and the `id` strip plus
+ * operator normalization mirror what `app-shell`'s `foldFilterGroupToSpecRules`
+ * does on the way to storage (pinned against the actual fold in
+ * `viewFilterFold.builderSetOperators.test.tsx`, which this package cannot
+ * import: `app-shell` depends on this one).
+ */
+function parseAsSpecRule(row: Record<string, unknown>) {
+  const { id: _id, ...rest } = row;
+  return ViewFilterRuleSchema.safeParse({
+    ...rest,
+    operator: normalizeFilterOperator(rest.operator),
+  });
+}
+
+describe('what the builder emits is what the spec accepts', () => {
+  it('refuses the shape this card is about — proving the parse is discriminating', () => {
+    const refused = parseAsSpecRule({ id: 'c1', field: 'stage', operator: 'in', value: 'acme' });
+    expect(refused.success).toBe(false);
+    expect(refused.error!.issues[0].message).toMatch(/requires an ARRAY/);
+  });
+
+  it('accepts the row the token input builds', () => {
+    const { onChange, getByTestId } = renderRow({ field: 'stage', operator: 'notIn', value: [] });
+    const input = getByTestId('filter-multi-value-stage').querySelector('input')!;
+    fireEvent.change(input, { target: { value: 'acme' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    const parsed = parseAsSpecRule(lastRow(onChange));
+    expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+    expect(parsed.data).toEqual({ field: 'stage', operator: 'not_in', value: ['acme'] });
+  });
+
+  it('accepts the row the operator switch re-shapes', async () => {
+    const { onChange } = renderRow({ field: 'stage', operator: 'equals', value: 'acme' });
+    await pickOperator('In');
+    const parsed = parseAsSpecRule(lastRow(onChange));
+    expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+    expect(parsed.data).toEqual({ field: 'stage', operator: 'in', value: ['acme'] });
+  });
+
+  it('accepts the range the pair input builds', () => {
+    const { onChange, getByTestId } = renderRow({
+      field: 'closed_at',
+      operator: 'between',
+      value: ['2024-01-01', ''],
+    });
+    const inputs = getByTestId('filter-range-closed_at').querySelectorAll('input');
+    fireEvent.change(inputs[1], { target: { value: '2024-12-31' } });
+    const parsed = parseAsSpecRule(lastRow(onChange));
+    expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+    expect(parsed.data).toEqual({
+      field: 'closed_at',
+      operator: 'between',
+      value: ['2024-01-01', '2024-12-31'],
+    });
+  });
+});

--- a/packages/components/src/custom/filter-builder.tsx
+++ b/packages/components/src/custom/filter-builder.tsx
@@ -10,10 +10,16 @@
 
 import * as React from "react"
 import { X, Plus, Trash2, Search, Loader2, ChevronDown } from "lucide-react"
+import {
+  VIEW_FILTER_LIST_VALUE_OPERATORS,
+  VIEW_FILTER_PAIR_VALUE_OPERATORS,
+  normalizeFilterOperator,
+} from "@objectstack/spec/ui"
 import { SchemaRendererContext } from "@object-ui/react"
 import { createSafeTranslation } from "@object-ui/i18n"
 
 import { cn } from "../lib/utils"
+import { Badge } from "../ui/badge"
 import { Button } from "../ui/button"
 import { Checkbox } from "../ui/checkbox"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select"
@@ -253,6 +259,96 @@ export const VALUELESS_FILTER_BUILDER_OPERATORS: ReadonlySet<string> = new Set([
   "notExists",
 ])
 
+/**
+ * The SHAPE an operator's `value` must have — the question
+ * `ViewFilterRuleSchema` asks, asked here in the one place that decides what
+ * input the user is given (objectui#3958).
+ *
+ *   - `list` — membership over any arity, `[]` included (`in` / `not_in`).
+ *   - `pair` — exactly two bounds, in order (`between`).
+ *   - `scalar` — everything else, including the value-less operators above
+ *     (they draw no input at all, so their shape never reaches storage).
+ */
+export type FilterValueArity = "scalar" | "list" | "pair"
+
+/**
+ * The two families are IMPORTED from `@objectstack/spec`, never restated
+ * (objectstack#6227 exports them for exactly this).
+ *
+ * This component used to decide the same fact from a local
+ * `["in", "notIn"]` literal, and that literal was already one spelling adrift:
+ * `notIn` is an ALIAS, the canonical member is `not_in`. Any path that hands
+ * this builder a canonical operator — a stored view read back through a reader
+ * that does not camelCase it — matched neither entry, so a SET operator got
+ * the single-value input and the user typed a scalar into it.
+ * `ViewFilterRuleSchema` then refused the row at save time, on a shape this
+ * builder's own UI led them into building.
+ */
+const LIST_VALUE_OPERATORS: ReadonlySet<string> = new Set(VIEW_FILTER_LIST_VALUE_OPERATORS)
+const PAIR_VALUE_OPERATORS: ReadonlySet<string> = new Set(VIEW_FILTER_PAIR_VALUE_OPERATORS)
+
+/**
+ * Which value shape `operator` takes, in EITHER dialect.
+ *
+ * The argument is folded through the spec's own `normalizeFilterOperator`
+ * first, so the builder's camelCase dropdown ids (`notIn`) and the canonical
+ * spellings a stored rule carries (`not_in`) land on the same answer. That
+ * fold is the whole point: one vocabulary, declared upstream, consulted here —
+ * not a second local dialect that has to be kept in sync by hand.
+ *
+ * @internal exported for tests
+ */
+export function filterValueArity(operator: string): FilterValueArity {
+  const canonical = normalizeFilterOperator(operator)
+  if (LIST_VALUE_OPERATORS.has(canonical)) return "list"
+  if (PAIR_VALUE_OPERATORS.has(canonical)) return "pair"
+  return "scalar"
+}
+
+/**
+ * Re-shape a row's `value` for the operator it is being changed TO.
+ *
+ * Switching the operator dropdown used to update `operator` alone, so the
+ * value the previous family had produced simply survived the switch — a scalar
+ * `"acme"` (or the seed `""`) still sitting there under `in`, which is
+ * precisely the shape `ViewFilterRuleSchema` refuses. Re-shaping rather than
+ * blanking keeps what the user typed wherever it still means something:
+ *
+ *   - to `list`: a scalar becomes a one-element list (`"acme"` → `["acme"]`),
+ *     an empty scalar becomes `[]` — a real, spec-valid predicate;
+ *   - to `pair`: the first two entries become `[min, max]`, padded with `""`;
+ *     with nothing to carry it collapses to `[]`, which the write path reads
+ *     as "row not filled in yet" and drops, exactly as it drops an empty
+ *     scalar today;
+ *   - to `scalar`: the first entry of a list survives; the rest cannot, and
+ *     dropping them is the honest answer — `equals` compares against one value.
+ *
+ * @internal exported for tests
+ */
+export function reshapeFilterValue(
+  value: FilterBuilderCondition["value"],
+  nextOperator: string,
+): FilterBuilderCondition["value"] {
+  switch (filterValueArity(nextOperator)) {
+    case "list":
+      return Array.isArray(value) ? value : normalizeToArray(value)
+    case "pair": {
+      const [min = "", max = ""] = normalizeToArray(value)
+      return min === "" && max === "" ? [] : [min, max]
+    }
+    default:
+      return Array.isArray(value) ? (value[0] ?? "") : value
+  }
+}
+
+/** The two bounds a `pair` row edits, with the gaps filled in for rendering. */
+function toPairBounds(
+  value: FilterBuilderCondition["value"],
+): [string | number | boolean, string | number | boolean] {
+  const [min = "", max = ""] = normalizeToArray(value)
+  return [min, max]
+}
+
 const useSafeFilterTranslation = createSafeTranslation(
   {
     'filterBuilder.where': 'Where',
@@ -270,6 +366,10 @@ const useSafeFilterTranslation = createSafeTranslation(
     'filterBuilder.noResults': 'No results',
     'filterBuilder.searchField': 'Search {{label}}…',
     'filterBuilder.enterId': 'Enter {{label}} id',
+    'filterBuilder.addValue': 'Type a value, press Enter',
+    'filterBuilder.removeValue': 'Remove {{value}}',
+    'filterBuilder.rangeStart': 'From',
+    'filterBuilder.rangeEnd': 'To',
     'filterBuilder.operators.equals': 'Equals',
     'filterBuilder.operators.notEquals': 'Does not equal',
     'filterBuilder.operators.contains': 'Contains',
@@ -433,6 +533,27 @@ function FilterBuilder({
     })
   }
 
+  /**
+   * Change a row's operator AND bring its value into the shape the new
+   * operator's family takes (objectui#3958).
+   *
+   * Deliberately not `updateCondition(id, { operator })`: that update carried
+   * the previous family's value through untouched, which is how a scalar ended
+   * up under `in`. The two edits are one edit — a row's operator and the shape
+   * of its value are not independently settable — so they are made together
+   * here rather than left for each caller to remember.
+   */
+  const changeOperator = (conditionId: string, nextOperator: string) => {
+    handleChange({
+      ...filterGroup,
+      conditions: filterGroup.conditions.map((c) =>
+        c.id === conditionId
+          ? { ...c, operator: nextOperator, value: reshapeFilterValue(c.value, nextOperator) }
+          : c,
+      ),
+    })
+  }
+
   const toggleLogic = () => {
     handleChange({
       ...filterGroup,
@@ -465,7 +586,11 @@ function FilterBuilder({
 
   const renderValueInput = (condition: FilterBuilderCondition) => {
     const field = fields.find((f) => f.value === condition.field)
-    const isMultiOperator = ["in", "notIn"].includes(condition.operator)
+    // The spec's vocabulary, not a local literal — and folded through
+    // `normalizeFilterOperator`, so a stored `not_in` read back in canonical
+    // form gets the multi-value input its alias `notIn` already got.
+    const arity = filterValueArity(condition.operator)
+    const isMultiOperator = arity === "list"
     const isLookupLike = lookupLikeTypes.includes(field?.type || "")
 
     // Lookup-like fields without static options → use remote search picker
@@ -508,6 +633,64 @@ function FilterBuilder({
               </label>
             )
           })}
+        </div>
+      )
+    }
+
+    // A LIST operator on a field with no static options and no remote picker —
+    // a plain text or number column (objectui#3958). This used to fall all the
+    // way through to the single-value input below, so `in` on such a field
+    // could only ever produce a scalar: refused by `ViewFilterRuleSchema` at
+    // save time, and read as an unfiltered query by the live grid before that.
+    // A token input is the input that matches the shape, so the row the user
+    // builds is a row the spec accepts.
+    if (isMultiOperator) {
+      return (
+        <MultiValueInput
+          values={normalizeToArray(condition.value)}
+          inputType={getInputType(condition.field)}
+          numeric={numberLikeTypes.includes(field?.type || "")}
+          testId={`filter-multi-value-${condition.field}`}
+          onChange={(next) => updateCondition(condition.id, { value: next })}
+        />
+      )
+    }
+
+    // A PAIR operator (`between`) — two bounds, in order. One input could only
+    // ever produce one of them, and the spec refuses an incomplete range as
+    // firmly as it refuses a scalar for `in`.
+    if (arity === "pair") {
+      const bounds = toPairBounds(condition.value)
+      const inputType = getInputType(condition.field)
+      const numeric = numberLikeTypes.includes(field?.type || "")
+      const setBound = (index: 0 | 1, raw: string) => {
+        const next: [string | number | boolean, string | number | boolean] = [bounds[0], bounds[1]]
+        next[index] = numeric && raw !== "" ? parseFloat(raw) || 0 : raw
+        // Both bounds cleared → back to the "nothing filled in yet" shape the
+        // write path drops, rather than persisting an empty range.
+        updateCondition(condition.id, {
+          value: next[0] === "" && next[1] === "" ? [] : next,
+        })
+      }
+      return (
+        <div className="flex items-center gap-1.5" data-testid={`filter-range-${condition.field}`}>
+          <Input
+            type={inputType}
+            className="h-9 text-sm"
+            placeholder={t('filterBuilder.rangeStart')}
+            aria-label={t('filterBuilder.rangeStart')}
+            value={bounds[0] === "" ? "" : String(bounds[0])}
+            onChange={(e) => setBound(0, e.target.value)}
+          />
+          <span className="text-xs text-muted-foreground shrink-0">-</span>
+          <Input
+            type={inputType}
+            className="h-9 text-sm"
+            placeholder={t('filterBuilder.rangeEnd')}
+            aria-label={t('filterBuilder.rangeEnd')}
+            value={bounds[1] === "" ? "" : String(bounds[1])}
+            onChange={(e) => setBound(1, e.target.value)}
+          />
         </div>
       )
     }
@@ -650,9 +833,7 @@ function FilterBuilder({
               <div className="col-span-4">
                 <Select
                   value={condition.operator}
-                  onValueChange={(value) =>
-                    updateCondition(condition.id, { operator: value })
-                  }
+                  onValueChange={(value) => changeOperator(condition.id, value)}
                 >
                   <SelectTrigger className="h-9 text-sm">
                     <SelectValue placeholder={t('filterBuilder.operator')} />
@@ -709,6 +890,99 @@ function FilterBuilder({
 }
 
 FilterBuilder.displayName = "FilterBuilder"
+
+// ============================================================================
+// MultiValueInput — token input for the LIST operators on an optionless field
+// ============================================================================
+
+interface MultiValueInputProps {
+  values: (string | number | boolean)[]
+  /** The `<input type>` the field's own type asks for (`text` / `number` / …). */
+  inputType: string
+  /** Numeric field → committed tokens are numbers, so the wire carries numbers. */
+  numeric: boolean
+  testId: string
+  onChange: (next: (string | number | boolean)[]) => void
+}
+
+/**
+ * A list of committed tokens plus a draft input — the same interaction
+ * `@object-ui/fields`' `TagsField` uses (type, Enter or comma commits, `×` or
+ * Backspace removes), rebuilt here because `fields` depends on this package and
+ * not the other way round.
+ *
+ * It exists so that `in` / `not_in` have a value input AT ALL on a field with
+ * no static options. Its only contract with the outside is the shape it emits:
+ * always an array, `[]` when empty — never the scalar
+ * {@link https://github.com/objectstack-ai/objectstack/issues/6227 |
+ * ViewFilterRuleSchema} refuses for a membership operator.
+ */
+function MultiValueInput({ values, inputType, numeric, testId, onChange }: MultiValueInputProps) {
+  const { t } = useSafeFilterTranslation()
+  const [draft, setDraft] = React.useState("")
+
+  const commit = (raw: string) => {
+    const trimmed = raw.trim()
+    if (trimmed === "") return
+    const next = numeric ? (parseFloat(trimmed) || 0) : trimmed
+    setDraft("")
+    if (values.some((v) => String(v) === String(next))) return
+    onChange([...values, next])
+  }
+
+  const removeAt = (index: number) => {
+    onChange(values.filter((_, i) => i !== index))
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      // Enter inside a <form> would submit it (objectstack#3821, the same
+      // hazard every control here is `type="button"` for).
+      e.preventDefault()
+      commit(draft)
+    } else if (e.key === "Backspace" && draft === "" && values.length > 0) {
+      removeAt(values.length - 1)
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5 rounded-md border border-input bg-background p-1.5"
+      data-testid={testId}
+    >
+      {values.map((v, index) => (
+        <Badge key={`${String(v)}-${index}`} variant="secondary" className="gap-1">
+          <span className="truncate max-w-[12ch]">{String(v)}</span>
+          <button
+            type="button"
+            onClick={() => removeAt(index)}
+            className="ml-0.5 rounded-full text-muted-foreground hover:text-foreground"
+            aria-label={t('filterBuilder.removeValue', { value: String(v) })}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ))}
+      <Input
+        type={inputType}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={() => commit(draft)}
+        placeholder={values.length === 0 ? t('filterBuilder.addValue') : ""}
+        aria-label={t('filterBuilder.addValue')}
+        // `min-w-[6ch]`, not the `8ch` its `TagsField` twin uses: that utility
+        // is produced ONLY by `@object-ui/fields`, and its CSS build subtracts
+        // the components sheet from its own — emitting it here would delete it
+        // from the fields bundle, which `build-css.mjs` refuses as
+        // over-subtraction (objectui#4059).
+        className="h-7 flex-1 border-0 bg-transparent p-0 px-1 shadow-none focus-visible:ring-0 min-w-[6ch] text-sm"
+      />
+    </div>
+  )
+}
+
+MultiValueInput.displayName = "MultiValueInput"
 
 // ============================================================================
 // LookupValuePicker — remote-search picker for lookup/master_detail/user/owner
@@ -895,7 +1169,22 @@ function LookupValuePicker({ field, value, multiple, onChange }: LookupValuePick
   }
 
   if (!hasDataSource) {
-    // Fallback to a plain text input when no DataSource is available
+    // Fallback when no DataSource is available: ids are typed in by hand.
+    // A MULTIPLE picker still has to emit a LIST here (objectui#3958) — this
+    // branch used to hand back `e.target.value`, a scalar, which is the shape
+    // `ViewFilterRuleSchema` refuses for `in` / `not_in`. The single case keeps
+    // the plain input it always had.
+    if (multiple) {
+      return (
+        <MultiValueInput
+          values={normalizeToArray(value)}
+          inputType="text"
+          numeric={false}
+          testId={`lookup-ids-${field.value}`}
+          onChange={onChange}
+        />
+      )
+    }
     return (
       <Input
         className="h-9 text-sm"

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -3352,6 +3352,10 @@ const ar = {
     noResults: "لا توجد نتائج",
     searchField: "بحث {{label}}…",
     enterId: "أدخل معرّف {{label}}",
+    addValue: "أدخل قيمة ثم اضغط Enter",
+    removeValue: "إزالة {{value}}",
+    rangeStart: "من",
+    rangeEnd: "إلى",
     operators: {
       equals: "يساوي",
       notEquals: "لا يساوي",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -3345,6 +3345,10 @@ const de = {
     noResults: "Keine Ergebnisse",
     searchField: "{{label}} suchen…",
     enterId: "{{label}}-ID eingeben",
+    addValue: "Wert eingeben, Enter drücken",
+    removeValue: "{{value}} entfernen",
+    rangeStart: "Von",
+    rangeEnd: "Bis",
     operators: {
       equals: "Gleich",
       notEquals: "Ungleich",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -3592,6 +3592,10 @@ const en = {
     noResults: 'No results',
     searchField: 'Search {{label}}…',
     enterId: 'Enter {{label}} id',
+    addValue: 'Type a value, press Enter',
+    removeValue: 'Remove {{value}}',
+    rangeStart: 'From',
+    rangeEnd: 'To',
     operators: {
       equals: 'Equals',
       notEquals: 'Does not equal',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -3349,6 +3349,10 @@ const es = {
     noResults: "Sin resultados",
     searchField: "Buscar {{label}}…",
     enterId: "Ingresar ID de {{label}}",
+    addValue: "Escriba un valor y pulse Intro",
+    removeValue: "Quitar {{value}}",
+    rangeStart: "Desde",
+    rangeEnd: "Hasta",
     operators: {
       equals: "Igual a",
       notEquals: "Distinto de",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -3347,6 +3347,10 @@ const fr = {
     noResults: "Aucun résultat",
     searchField: "Rechercher {{label}}…",
     enterId: "Saisir l'ID {{label}}",
+    addValue: "Saisir une valeur, puis Entrée",
+    removeValue: "Supprimer {{value}}",
+    rangeStart: "De",
+    rangeEnd: "À",
     operators: {
       equals: "Égal à",
       notEquals: "Différent de",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -3345,6 +3345,10 @@ const ja = {
     noResults: "結果なし",
     searchField: "{{label}}を検索…",
     enterId: "{{label}} IDを入力",
+    addValue: "値を入力して Enter キーを押す",
+    removeValue: "{{value}} を削除",
+    rangeStart: "開始",
+    rangeEnd: "終了",
     operators: {
       equals: "等しい",
       notEquals: "等しくない",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -3344,6 +3344,10 @@ const ko = {
     noResults: "결과 없음",
     searchField: "{{label}} 검색…",
     enterId: "{{label}} ID 입력",
+    addValue: "값을 입력하고 Enter 키를 누르세요",
+    removeValue: "{{value}} 제거",
+    rangeStart: "시작",
+    rangeEnd: "끝",
     operators: {
       equals: "같음",
       notEquals: "같지 않음",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -3344,6 +3344,10 @@ const pt = {
     noResults: "Sem resultados",
     searchField: "Pesquisar {{label}}…",
     enterId: "Inserir ID de {{label}}",
+    addValue: "Digite um valor e pressione Enter",
+    removeValue: "Remover {{value}}",
+    rangeStart: "De",
+    rangeEnd: "Até",
     operators: {
       equals: "Igual a",
       notEquals: "Diferente de",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -3356,6 +3356,10 @@ const ru = {
     noResults: "Нет результатов",
     searchField: "Поиск {{label}}…",
     enterId: "Введите ID {{label}}",
+    addValue: "Введите значение и нажмите Enter",
+    removeValue: "Удалить {{value}}",
+    rangeStart: "От",
+    rangeEnd: "До",
     operators: {
       equals: "Равно",
       notEquals: "Не равно",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -3403,6 +3403,10 @@ const zh = {
     noResults: '无结果',
     searchField: '搜索 {{label}}…',
     enterId: '输入 {{label}} ID',
+    addValue: '输入值后按回车',
+    removeValue: '移除 {{value}}',
+    rangeStart: '起始值',
+    rangeEnd: '结束值',
     operators: {
       equals: '等于',
       notEquals: '不等于',


### PR DESCRIPTION
Fixes #3958

## 问题

console 的 FilterBuilder 有三条互相独立的路径,都能产出 `operator: "in"` 搭配**标量** `value` 的行 —— 正是 objectstack#6227 之后 `ViewFilterRuleSchema` 在保存期拒绝的形状(在此之前该形状保存得下去,渲染时回 `400 INVALID_FILTER`,objectstack#5869)。用户从 builder 自己提供的下拉里选了合法算子、往 builder 自己渲染的输入框里打了字,然后被拒绝。

BASE `2e82ab2ae` 上逐条复核(issue 正文行号已随 PR #4737 漂移,下表为实测):

| issue 锚点 | BASE 行号 | 状态 |
| --- | --- | --- |
| `:226` addCondition 种子 | `:400` | 仍是 `{ operator: "equals", value: "" }` |
| `:306` renderValueInput | `:466` | 未变 |
| `:308` isMultiOperator 本地字面量 | `:468` | `["in", "notIn"]` 仍在 |
| `:324` options + multi 分支 | `:484` | 未变 |
| `:493` 算子切换 | `:654` | 仍是 `{ operator: value }`,不重整 value |

PR #4737(`extraOperators` / `OPT_IN_OPERATORS`)动的是「下拉**提供**哪些算子」,与「算子的 value 是什么**形状**」正交,三条方向一条都没有被顺带修掉。本 PR 不回退该机制,`operatorsForFieldType` 与 `OPT_IN_OPERATORS` 原样保留。

一处对 issue 正文的修正:正文说「纯文本/数字列」是落空分支的入口,但纯文本列的算子桶根本不提供 `in`。真正的生产入口是**没有静态 options 的 select / lookup 列**(它们的桶提供 `in` / `notIn`,而 options 常常是异步加载或干脆没有),以及**以 canonical 拼写读回的存量视图**。测试夹具按此更正。

## 改动

1. **算子切换时重整 value**。算子和它的 value 形状不是两件可以分别设定的事,所以现在一起改:标量转列表(`"acme"` 变成 `["acme"]`,空串变成 `[]`);标量转区间保留第一个边界、第二个留空;两个边界都空则收敛回 `[]`,交给写入侧既有的「未填完」规则丢弃;列表转标量保留首项。
2. **列表/区间输入始终可达**。没有静态 options 的列以前一路落到单值输入,`in` 只可能打出标量;现在给 token 输入(回车或逗号提交,`×` 或退格删除),`between` 给两个边界框。LookupValuePicker 在无 DataSource 时的回退分支同样有这个洞 —— `multiple` 为真也回传标量 —— 一并改为回传列表。
3. **家族判定读 spec 导出词表**。删掉本地 `["in", "notIn"]` 字面量,改读 `@objectstack/spec` 的 `VIEW_FILTER_LIST_VALUE_OPERATORS` / `VIEW_FILTER_PAIR_VALUE_OPERATORS`,并先过一遍 `normalizeFilterOperator`。`notIn` 是别名、canonical 是 `not_in`,旧字面量只认得别名那一半。

`foldFilterGroupToSpecRules` **未改动,也不需要改动**:它归一算子、value 原样透传,形状是生产端的责任。这不是乐观判断而是被钉住的事实 —— 新增的 app-shell 测试里有一条把旧形状(`in` 配标量)直接喂给 fold,fold 原样透传、spec 照旧拒绝,证明 fold 手里没有修复它所需的信息,修复只能在生产端(AGENTS.md contract-first)。

## 钉

`packages/components/src/__tests__/filter-builder-operator-value-arity.test.tsx`(27 钉)+ `packages/app-shell/src/views/viewFilterFold.builderSetOperators.test.tsx`(5 钉),32 全绿。家族词表用 `it.each` 直接遍历 spec 的两个导出,spec 日后加成员这边自动跟随;算子切换走真实的 Radix 下拉而非直接调内部函数;端到端一条链没有 mock:真 FilterBuilder 出行 → 真 `foldFilterGroupToSpecRules` 折叠 → 真 `ViewFilterRuleSchema` 解析。

## 反向验证(先预判后跑,变异未提交)

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| `isMultiOperator` 改回本地字面量 | 只有 canonical `not_in` 那一钉红,`in` / `notIn` 保持绿 —— 别名那一半本来就工作,这正是缺陷藏了这么久的原因 | 1 红,正是 `renders it for the not_in spelling` |
| 算子切换改回只写 `{ operator }` | 5 红(components 4 + app-shell 1);「未填完的 in 行被丢弃」那一钉**保持绿**,因为未重整的 `''` 与 `[]` 一样会被 fold 判为未填完 | 5 红,清单与预判逐条一致,该钉确实绿 |

## 一处 gate 教学

`min-w-[8ch]`(照抄 fields 的 TagsField)会让 `@object-ui/fields` 的 CSS 构建报 over-subtraction:该 utility 原先只有 fields 能产出,components 一旦也产出,fields 的「减去 components 表」就把它删掉了(objectui#4059 的守卫)。改用 `min-w-[6ch]` 并在代码里记下原因。

## 门禁

`turbo run type-check` 81/81 绿(含 fields 的 build + CSS 守卫);三个改动包 eslint 0 error;`check-control-bytes` / `check-i18n-call-site-keys` / `check-i18n-en-drift` / `check-changeset-presence` / `check-spec-symbol-derivation` / `check-phantom-dependencies` 全绿。消费半径扫描:`packages/fields` + `packages/plugin-list` + `packages/plugin-view` 共 149 文件 2215 钉全绿。

四个新 locale 键(`filterBuilder.addValue` / `.removeValue` / `.rangeStart` / `.rangeEnd`)已补齐十个 pack。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_