### PR TITLE
fix(plugin-grid): 批量动作对话框把自己的在途 param 值作为选项谓词的 record (#4757)

### DIFF
--- a/.changeset/bulk-action-dialog-param-values-as-option-record.md
+++ b/.changeset/bulk-action-dialog-param-values-as-option-record.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+A bulk action dialog's per-option `visibleWhen` predicates now read the dialog's own in-progress param values.
+
+The second landing site of the same gap objectui#3765 closed for the
+single-record action dialog. A field's per-option `visibleWhen` reaches a bulk
+param's control, but the dialog supplied no record to evaluate it against: it
+passed no `dependentValues`, so the shared cascading-options evaluator fell
+through its chain (`dependentValues ?? formValues ?? data`) to whatever record
+the host grid page happened to publish, or to nothing at all. A predicate
+written against a SIBLING PARAM — `record.country == 'cn'` on a province option,
+next to a `country` param in the same dialog — could therefore never see the
+value the user had just entered. Authored cascades were dead on this surface, in
+the safe direction: an unresolvable predicate offers the option rather than
+hiding it, so nobody was shown a wrongly-narrowed list.
+
+Per the maintainer's 2026-08-11 ruling (Option B on objectui#3765) the dialog is
+a small form, and its in-progress values are that record. The bulk dialog now
+passes them as `dependentValues` to the option widgets (`select`, `multiselect`,
+`radio`, `checkboxes` — the same allow-list the object form and the single-record
+action dialog thread the live record to). The evaluator is unchanged; this is the
+supply half that was missing.
+
+Bulk is the cheap case for that ruling, which is why it needed no separate one:
+an action over N selected rows has no single row record for the dialog's values
+to displace — the selection was never offered to these predicates, so the
+dialog's values are the only record there has ever been. What the supplied record
+does displace is the host page's, since it wins the chain outright: a predicate
+naming a column the dialog has no param for stays unresolvable, which fails open
+— the option is offered, never wrongly hidden.

--- a/packages/plugin-grid/src/__tests__/bulkActionDialogRecord.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionDialogRecord.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4757 — WHICH record a BULK action dialog's per-option `visibleWhen`
+ * predicates are evaluated against.
+ *
+ * The same gap objectui#3765 closed for the single-record action dialog, at its
+ * second landing site. objectui#3559 delivered the keys (a per-option
+ * `visibleWhen` survives inheritance and reaches the control) and the shared
+ * evaluator has always read `dependentValues ?? ctx.formValues ?? ctx.data ??
+ * {}`. What was missing here was the SUPPLY: `BulkActionDialog`'s `ParamField`
+ * passed only `dataSource`, never `dependentValues`, so the values the user was
+ * typing INTO THIS DIALOG could not narrow a sibling param's list however the
+ * author wrote the predicate.
+ *
+ * Maintainer ruling of 2026-08-11 (Option B on objectui#3765): the dialog is a
+ * small form, so its own in-progress values are that record, and the shared
+ * evaluator is not modified. Bulk needed no separate ruling and gets none —
+ * see `the SELECTION is never the record` below for why it is the cheap case:
+ * an action over N selected rows has no single row record that the dialog's
+ * values could be displacing.
+ *
+ * These four cases mirror `app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx`
+ * one-for-one, deliberately: the two dialogs feed one evaluator, and a shared
+ * pin shape is how a future change to it shows up on both surfaces at once.
+ * They drive the real `BulkActionDialog` rather than a widget wired to look
+ * like one, because the wiring IS the change — only a real render can show a
+ * keystroke in one param re-resolving another param's offered options.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SchemaRendererContext } from '@object-ui/react';
+// Module scope, per AGENTS.md §测试纪律: the dialog reaches its widgets through
+// `getLazyFieldWidget` → `React.lazy(() => import('./widgets/RadioField'))`
+// inside `@object-ui/fields`, and a first dynamic import() under a saturated
+// transform pipeline can eat most of RTL's 1s `findBy` budget. This barrel
+// STATICALLY re-exports those widget modules, so importing it puts them in the
+// ESM cache and the lazy factories resolve in a microtask instead of racing the
+// assertions below.
+import '@object-ui/fields';
+
+import { BulkActionDialog } from '../components/BulkActionDialog';
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+  // Radix Select probes pointer-capture APIs happy-dom lacks.
+  if (!(Element.prototype as any).hasPointerCapture) {
+    (Element.prototype as any).hasPointerCapture = () => false;
+  }
+  if (!(Element.prototype as any).setPointerCapture) {
+    (Element.prototype as any).setPointerCapture = () => {};
+  }
+});
+
+beforeEach(() => {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as any;
+});
+
+const COUNTRY = { name: 'country', label: 'Country', type: 'text' };
+
+/** Province options gated on a SIBLING PARAM's value (`country`), not on scope. */
+const PROVINCE = {
+  name: 'province',
+  label: 'Province',
+  type: 'radio',
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'Texas', value: 'tx', visibleWhen: "record.country == 'us'" },
+  ],
+};
+
+function makeDataSource() {
+  return { update: vi.fn(async () => ({})), delete: vi.fn(async () => ({})) } as any;
+}
+
+function openDialog(
+  params: Array<Record<string, unknown>>,
+  opts: {
+    /** The SELECTED rows. Never a predicate record — asserted, not assumed. */
+    rows?: Array<Record<string, unknown>>;
+    /** The host grid page's record, as the evaluator's fallback chain reads it. */
+    hostFormValues?: Record<string, unknown>;
+  } = {},
+) {
+  const def: any = { name: 'bulk_edit', label: 'Bulk edit', operation: 'update', params };
+  const dialog = (
+    <BulkActionDialog
+      def={def}
+      rows={opts.rows ?? [{ id: 'r1' }, { id: 'r2' }]}
+      resource="account"
+      dataSource={makeDataSource()}
+      open
+      onClose={() => {}}
+    />
+  );
+  render(
+    opts.hostFormValues
+      // The host page's record, expressed the way the evaluator reads it: the
+      // context type declares `dataSource` only, and `formValues` is the key
+      // `useCascadingOptions` picks off it through an `any` cast.
+      ? <SchemaRendererContext.Provider value={{ dataSource: null, formValues: opts.hostFormValues } as never}>
+          {dialog}
+        </SchemaRendererContext.Provider>
+      : dialog,
+  );
+}
+
+/** The dialog labels its controls `bulk-param-<name>`; type into one by id. */
+const typeCountry = (value: string) => {
+  const el = document.getElementById('bulk-param-country');
+  expect(el).not.toBeNull();
+  fireEvent.change(el as HTMLElement, { target: { value } });
+};
+
+describe('BulkActionDialog — the dialog IS the record for its option predicates (objectui#4757)', () => {
+  it("narrows a param's options against a value typed into a SIBLING param", async () => {
+    openDialog([COUNTRY, PROVINCE]);
+    // Nothing typed yet: `record.country` is unresolvable, which fails OPEN, so
+    // both provinces are offered. (Before this wiring the bulk dialog was stuck
+    // here forever — typing had no way to reach the predicate.)
+    expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-option-tx')).toBeInTheDocument();
+
+    typeCountry('cn');
+
+    // The keystroke re-resolved a DIFFERENT param's offered set: `zj` survives
+    // its predicate, `tx` does not. This assertion is the whole issue.
+    await waitFor(() => expect(screen.queryByTestId('radio-option-tx')).not.toBeInTheDocument());
+    expect(screen.getByTestId('radio-option-zj')).toBeInTheDocument();
+
+    // …and it tracks the value rather than latching on the first one seen.
+    typeCountry('us');
+    await waitFor(() => expect(screen.queryByTestId('radio-option-zj')).not.toBeInTheDocument());
+    expect(screen.getByTestId('radio-option-tx')).toBeInTheDocument();
+  });
+
+  it('the SELECTION is never the record: the dialog values are the whole basis', async () => {
+    // Why bulk needed no ruling of its own. Both other candidate records say
+    // `country: 'us'` here — the N selected ROWS, and the host grid page's
+    // `SchemaRendererContext` — and neither reaches the predicate: the list
+    // falls open (Texas AND Zhejiang) instead of narrowing to Texas.
+    //
+    // The rows never could: a bulk action has no single row, `rows` is a
+    // selection, and no per-row scope was ever offered to these predicates.
+    // That is what makes Option B free on this surface — the dialog's values
+    // are not displacing a row record, they are the only record there has ever
+    // been. The page record IS displaced, which is Option B's ruled cost
+    // (a supplied `dependentValues` wins `useCascadingOptions`' chain outright),
+    // and it is asserted here rather than left for a reader to discover: under
+    // the unruled option C (`{ ...pageRecord, ...dialogValues }`) the first two
+    // assertions would read `tx` only, so this case is the executable
+    // difference between the two readings.
+    openDialog([COUNTRY, PROVINCE], {
+      rows: [{ id: 'r1', country: 'us' }, { id: 'r2', country: 'us' }],
+      hostFormValues: { country: 'us' },
+    });
+    expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-option-tx')).toBeInTheDocument();
+
+    // And once the dialog HAS a value it is the only one that counts: `cn` wins
+    // over the ambient `us`, the same direction a form field's own value wins
+    // over anything ambient.
+    typeCountry('cn');
+    await waitFor(() => expect(screen.queryByTestId('radio-option-tx')).not.toBeInTheDocument());
+    expect(screen.getByTestId('radio-option-zj')).toBeInTheDocument();
+  });
+
+  it('keeps an option whose predicate names a key NO param carries: fails OPEN', async () => {
+    // The safety direction, unchanged by the wiring and pinned separately from
+    // the cases above because it decides how bad a mistake here can be. An
+    // unresolvable predicate OFFERS the option — the user can still complete
+    // the action, and a wrong value earns a server rejection that carries a
+    // message — instead of hiding it, which would leave an empty control with
+    // nothing pointing at the predicate. Same direction the param-level
+    // `visible` gate rules on this surface (objectui#4640).
+    openDialog([
+      COUNTRY,
+      {
+        name: 'province',
+        label: 'Province',
+        type: 'radio',
+        options: [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.owner_id == 'u1'" }],
+      },
+    ]);
+    expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+
+    typeCountry('cn');
+
+    // Still unresolvable after a keystroke — `owner_id` is not a param, and the
+    // selected rows do not supply one either — so the option stays offered
+    // rather than vanishing as the user types.
+    await waitFor(() =>
+      expect(document.getElementById('bulk-param-country')).toHaveValue('cn'),
+    );
+    expect(screen.getByTestId('radio-option-zj')).toBeInTheDocument();
+  });
+
+  it('empties a select whose every option the in-progress values exclude', async () => {
+    // The `select` widget's counterpart to the radio cases: when the dialog's
+    // own values exclude the whole list there is no dropdown to offer, so the
+    // widget renders its legible empty state (objectui#3231) keyed on the param
+    // name — not a silently-empty Radix trigger.
+    openDialog([
+      COUNTRY,
+      {
+        name: 'region',
+        label: 'Region',
+        type: 'select',
+        options: [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" }],
+      },
+    ]);
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
+
+    typeCountry('us');
+
+    await waitFor(() => expect(screen.getByTestId('select-empty-region')).toBeInTheDocument());
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+});

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -360,6 +360,11 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
                 param={p}
                 multiple={isParamMultiple(p)}
                 value={values[p.name]}
+                // The WHOLE in-progress record, not only this row's value: an
+                // option widget's per-option `visibleWhen` is resolved against
+                // it, so a sibling param's value can narrow this param's
+                // offered list (objectui#4757).
+                values={values}
                 dataSource={dataSource}
                 onChange={(v) => setValues(prev => ({ ...prev, [p.name]: v }))}
               />
@@ -552,6 +557,44 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   );
 };
 
+/**
+ * Widget keys whose OFFERED option set is re-resolved against a live record by
+ * the shared cascading-options evaluator (`useCascadingOptions` →
+ * `resolveCascadingOptions`): each option may carry a `visibleWhen` CEL
+ * predicate read against `record.*` (ADR-0058 / objectui#2284).
+ *
+ * SAME FOUR KEYS as the two other surfaces that feed that one evaluator, and
+ * they must stay the same set or the three drift on what "the record" means:
+ *
+ * - `CASCADE_OPTION_WIDGET_TYPES` in `app-shell/src/views/ActionParamDialog.tsx`
+ *   (the single-record action dialog, objectui#3765 / PR objectui#4756)
+ * - `CASCADE_OPTION_FIELD_TYPES` in `components/src/renderers/form/form.tsx`
+ *   (the object form, the original)
+ *
+ * Duplicated rather than imported ON PURPOSE, and this is a debt worth naming:
+ * neither of those definitions is exported from its package, and plugin-grid
+ * depends on neither app-shell (which depends the other way) nor form-internal
+ * modules. Lifting the set to a shared home — `@object-ui/fields`, next to
+ * `resolveFormWidgetType`, which every one of the three already imports — is
+ * the right end state; it is out of scope here because objectui#4757 is scoped
+ * to this file and both other packages have work in flight. If you move one
+ * copy, move all three.
+ *
+ * It is an ALLOW-LIST, not a blanket pass-through, because `dependentValues` is
+ * also the channel two widget-hint pickers read a specific SIBLING KEY from
+ * (`filter-condition` reads `object_name`, `recipient-picker` reads
+ * `recipient_type`) and the lookup family filters its query by it; feeding
+ * those from bulk params is a different wiring question than the one ruled on
+ * objectui#3765.
+ *
+ * `select` + `multiple: true` is not listed separately: `SelectField` delegates
+ * to `MultiSelectField` with the whole prop object, so the key it resolves
+ * under (`select`) is the one that must carry the record. The keys are the
+ * post-`bulkParamToField` WIDGET keys (`resolveFormWidgetType` output), not the
+ * authored `param.type` spellings.
+ */
+const CASCADE_OPTION_WIDGET_TYPES = new Set(['select', 'multiselect', 'radio', 'checkboxes']);
+
 interface ParamFieldProps {
   param: BulkActionParam;
   /** Effective multi-value semantics — explicit `param.multiple` or the target field's schema (#2204). */
@@ -560,6 +603,13 @@ interface ParamFieldProps {
   onChange: (v: unknown) => void;
   /** Threaded into picker widgets (lookup/user) for candidate search. */
   dataSource: BulkActionDialogProps['dataSource'];
+  /**
+   * ALL of the dialog's in-progress param values — not just this row's. They
+   * are the record an option widget resolves its per-option `visibleWhen`
+   * against (objectui#4757, the bulk landing site of objectui#3765's Option B
+   * ruling); see {@link CASCADE_OPTION_WIDGET_TYPES}.
+   */
+  values: Record<string, unknown>;
 }
 
 /**
@@ -571,7 +621,7 @@ interface ParamFieldProps {
  * PeoplePicker. Widgets stay lazy behind `<Suspense>` so opening a dialog only
  * loads the widgets its params actually use.
  */
-const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChange, dataSource }) => {
+const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChange, dataSource, values }) => {
   const id = `bulk-param-${param.name}`;
   const field = useMemo(() => bulkParamToField(param, multiple), [param, multiple]);
   // getLazyFieldWidget caches per type, and the useMemo keeps the reference
@@ -580,6 +630,28 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChang
   // Only picker widgets receive the dataSource — the simple widgets spread
   // unknown props toward the DOM.
   const dataSourceProps = fieldNeedsDataSource(field) ? { dataSource } : {};
+  // The dialog's own in-progress values ARE the record its option predicates
+  // are resolved against (objectui#4757 — the bulk landing site of the ruling
+  // taken on objectui#3765, "the dialog is a small form", implemented for the
+  // single-record dialog in PR objectui#4756). Until this prop existed the bulk
+  // dialog passed nothing, so `useCascadingOptions` fell through its chain
+  // (`dependentValues ?? ctx.formValues ?? ctx.data ?? {}`) to whatever record
+  // the HOST GRID PAGE happened to publish — and a `visibleWhen` written
+  // against a sibling PARAM could never see the value the user had just picked
+  // in this same dialog. The shared evaluator is untouched: it already reads
+  // that chain; this is the supply half that was missing.
+  //
+  // Bulk is where the ruling costs least, which is why it needed no separate
+  // decision. An action dialog over N selected rows has NO single row record to
+  // compete with — `rows` is a selection, and no per-row scope was ever offered
+  // to these predicates — so "the dialog's values are the record" is not a
+  // choice between two records here; it is the only record there has ever been.
+  // A predicate naming a column the dialog has no param for (`record.owner_id`)
+  // stays unresolvable, which `resolveVisibleOptions` fails OPEN: the option is
+  // offered, never wrongly hidden.
+  const cascadeProps = CASCADE_OPTION_WIDGET_TYPES.has(field.type)
+    ? { dependentValues: values }
+    : {};
 
   return (
     <div className="space-y-1.5">
@@ -615,6 +687,7 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChang
           // matching `ActionParamDialog`.
           aria-required={param.required || undefined}
           {...dataSourceProps}
+          {...cascadeProps}
         />
       </Suspense>
       {param.help && <p className="text-[11px] text-muted-foreground">{param.help}</p>}


### PR DESCRIPTION
Fixes #4757

This is the **second landing site of the objectui#3765 Option B ruling, mechanism per PR #4756** —— 同一个缺口在批量动作表面上的另一处落点,形态照抄 #4756,无新裁决。

## 事实(已对 origin/main 复核,前提成立)

`packages/plugin-grid/src/components/BulkActionDialog.tsx` 的 `ParamField` 经 `getLazyFieldWidget` 渲染共享 option widget,却只按 `fieldNeedsDataSource` 投放 `dataSource`,**从不传 `dependentValues`**。共享 evaluator `useCascadingOptions` 于是沿它那条链(`dependentValues ?? ctx.formValues ?? ctx.data ?? {}`)落到宿主表格页的 record,或落空。写在**兄弟 param** 上的 `visibleWhen` —— province 选项上的 `record.country == 'cn'`,紧邻同一对话框里的 `country` param —— 因此永远看不到用户刚填的值。该表面上的级联是死的,方向安全:谓词不可解则 fail-open,选项照给不藏,没人被展示过错误收窄的列表。

## 修法

照维护者 2026-08-11 的裁定(objectui#3765 Option B,单记录对话框由 PR #4756 实施):对话框即小表单,其在途 `values` 就是那个 record。现按与对象表单、单记录动作对话框**同一张允许表**(`select` / `multiselect` / `radio` / `checkboxes`)把 `values` 作为 `dependentValues` 传给 option widget。**共享 evaluator 零改动** —— 缺的一直是供给端。

bulk 是该裁定最便宜的落点,故无需另行裁决:N 行选区上的动作本就**没有单行 record** 可被 values 顶掉(`rows` 是选区,从未有 per-row scope 进过这些谓词),所以「对话框的值即 record」在这里不是二选一,而是从来就只有这一个 record。被顶掉的只是宿主页 record(供给的 record 直接赢下整条链),对话框没有对应 param 的列名谓词保持不可解即 fail-open。

### 允许表的取舍(请复核)

`CASCADE_OPTION_WIDGET_TYPES` 在 plugin-grid 内**自建同集**,而非复用。两处同源定义**都未导出**:app-shell 的 `ActionParamDialog.tsx:227`(PR #4756 留在模块内)、components 的 `form.tsx:253`;且 plugin-grid 既不依赖 app-shell(依赖方向相反)也不依赖 form 内部模块。注释单向指向那两处并写明:抬升到共享位置(`@object-ui/fields`,紧邻三者都已 import 的 `resolveFormWidgetType`)才是终局,「动一处就三处一起动」。反向注释未加 —— 本 issue 范围仅限本文件,且 app-shell / components 均有在飞工作。

## 钉子

新增 `packages/plugin-grid/src/__tests__/bulkActionDialogRecord.test.tsx`,四例与 `app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx` 一一对应(两个对话框喂同一个 evaluator,同形钉子才能让将来对它的改动同时在两面显形)。驱动真实 `BulkActionDialog`,因为接线本身就是改动。

1. 兄弟 param 的击键收窄另一个 param 的可选集,并跟随取值而非latch首见值;
2. **选区从来不是 record**:选中行与宿主页 `SchemaRendererContext` 都说 `country: 'us'`,列表仍 fail-open —— 这一例是已裁 B 与未裁 C(`{ ...pageRecord, ...dialogValues }`)之间可执行的差别;
3. 谓词点名任何 param 都不携带的 key → fail-open;
4. `select` 全排除 → 可读空态 `select-empty-region`,而非静默空 trigger。

## 反向验证(先预判后跑)

预判:撤掉 `{...cascadeProps}` 后 ① ② ④ 红、③ 绿(fail-open 不依赖供给)。实测完全吻合 —— ②**是以另一个方向红的**:失去接线后宿主页的 `us` 反而抵达谓词并藏掉 Zhejiang(`Unable to find [data-testid="radio-option-zj"]`),证明该断言不是空过。已还原,未提交。



---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_