### PR TITLE
feat(app-shell)!: modal target 只命名 page,退役 object fallback 与前缀约定 (#3925)

### DIFF
--- a/.changeset/retire-modal-target-object-fallback.md
+++ b/.changeset/retire-modal-target-object-fallback.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/app-shell': minor
+---
+
+A `type: 'modal'` action's string `target` names a PAGE, only — the object fallback retires
+
+`useActionModal.resolveModalTarget` resolved a string target page-first and then
+fell back to the OBJECT metadata, opening a create/edit form for an object of
+that name. Riding the same branch was a `create_`/`new_`/`add_`/`edit_`/`update_`
+prefix convention: `create_opportunity` was parsed into the object `opportunity`
+in `create` mode whenever no page owned the literal name.
+
+Both retire (maintainer ruling on objectstack#6739, 2026-08-09). The contract was
+never ambiguous — the spec TSDoc (`packages/spec/src/ui/action.zod.ts`), the
+published docs (`content/docs/ui/actions.mdx`) and `defineStack`'s cross-reference
+walk (`packages/spec/src/stack.zod.ts`) all say a modal target names a page, and
+the walk REJECTS a registered modal action whose target is not a declared page.
+The fallback was consumer leniency on top of that: it made the runtime serve
+exactly what the build gate refuses, so an authoring mistake opened something
+plausible instead of failing, and the corpus learned the wrong shape from it
+(objectstack#6737's showcase line built only because it leaned on this branch and
+on a validation hole in inline-action checking, both at once).
+
+The ruling explicitly declined the middle shape — keep the prefix, reject bare
+object names — because a name-shaped guess is the authoring hazard the contract
+exists to remove. `create_opportunity` now names the page `create_opportunity`,
+or it names nothing.
+
+**Breaking surface.** A `type: 'modal'` action whose `target` names an OBJECT
+(bare, or under a verb prefix) no longer opens that object's form. It is refused,
+with a diagnostic naming the refused target and pointing at the replacement.
+Opening an object's form from an action is `type: 'form'` with an
+`object.view` FORM-view target — the same capability, validated end-to-end
+(a form target pointing at a LIST view is itself a build error, objectstack#2554).
+
+Not affected, because neither is a modal action's `target`:
+
+- the lookup field's inline "create the referenced record" path, which hands the
+  runner a fully-formed `{ objectName, mode }` DESCRIPTOR whose object identity
+  comes from the field's `referenceTo`. `ModalDescriptor.objectName` was
+  re-judged with this change and KEPT — its "Back-compat" label was simply
+  wrong, and it is documented now as the descriptor-only key it has always been;
+- a modal action targeting a real page, which resolves exactly as before.

--- a/packages/app-shell/src/hooks/__tests__/useActionModal.resolve.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useActionModal.resolve.test.tsx
@@ -7,17 +7,25 @@
  */
 
 /**
- * Regression (framework#3530 — "Console: modal-typed actions resolve `target` as
- * an object"): a `type: 'modal'` action's `target` names the PAGE to open, but
- * the console read it as an OBJECT name and opened a create form for it. That
- * issued `GET /meta/object/<page>`, which 400s, so the modal body was replaced
- * with ModalForm's "Error loading form — Bad Request" and the action never
- * completed.
+ * A `type: 'modal'` action's `target` names a PAGE, and only a page
+ * (maintainer ruling on objectstack#6739, 2026-08-09).
  *
- * These pin the resolution CONTRACT: page first (what the spec says the name
- * means), object second (back-compat), `null` last so the console runtimes can
- * fall through to the action's server-side handler. The pure normalization
- * step is covered separately in `useActionModal.test.ts`.
+ * Origin (framework#3530 — "Console: modal-typed actions resolve `target` as an
+ * object"): the console read the target as an OBJECT name and opened a create
+ * form for it. That issued `GET /meta/object/<page>`, which 400s, so the modal
+ * body was replaced with ModalForm's "Error loading form — Bad Request" and the
+ * action never completed. The first fix made resolution page-FIRST, keeping an
+ * object fallback behind it.
+ *
+ * That fallback is now RETIRED. The spec TSDoc, the published docs and
+ * `defineStack`'s cross-reference walk all say a modal target is a page, and the
+ * walk rejects a registered modal action targeting a non-page — so resolving one
+ * anyway made the runtime serve what the build gate refuses. Opening an object's
+ * form from an action is `type: 'form'`, validated end-to-end.
+ *
+ * These pin the resolution CONTRACT: a page resolves, anything else is REFUSED
+ * with a diagnostic naming the target and pointing at `type: 'form'`. The pure
+ * normalization step is covered separately in `useActionModal.test.ts`.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -53,7 +61,7 @@ function makeWrapper(items: Record<string, any[]>) {
 
 beforeEach(() => vi.clearAllMocks());
 
-describe('useActionModal — modal target resolution (framework#3530)', () => {
+describe('useActionModal — a modal target names a page, only (objectstack#6739)', () => {
   it('resolves a string target to the PAGE of that name, never GET /meta/object', async () => {
     const { wrapper, getItem } = makeWrapper({ page: [LOG_CALL_PAGE] });
     const { result } = renderHook(() => useActionModal(), { wrapper });
@@ -72,19 +80,28 @@ describe('useActionModal — modal target resolution (framework#3530)', () => {
     expect(getItem).not.toHaveBeenCalledWith('object', 'log_call');
   });
 
-  it('falls back to an object create form when no page owns the name', async () => {
-    const { wrapper } = makeWrapper({ page: [], object: [CONTACT_OBJECT] });
+  it('REFUSES a target that names an existing object but no page', async () => {
+    // Replaces the old "falls back to an object create form" case, which pinned
+    // exactly the limb being deleted. The object is deliberately PRESENT in the
+    // metadata: a refusal against an empty object list would pass vacuously,
+    // proving only that nothing was found rather than that nothing was looked
+    // for. `contact` is a real object here and is still refused.
+    const { wrapper, getItem } = makeWrapper({ page: [], object: [CONTACT_OBJECT] });
     const { result } = renderHook(() => useActionModal(), { wrapper });
 
     let d: any;
     await act(async () => { d = await result.current.resolveModalTarget('contact'); });
 
-    expect(d).toMatchObject({ objectName: 'contact', mode: 'create' });
-    expect(d.content).toBeUndefined();
+    expect(d).toBeNull();
+    expect(getItem).toHaveBeenCalledWith('page', 'contact');
+    expect(getItem).not.toHaveBeenCalledWith('object', 'contact');
   });
 
-  it('prefers a page over the object a create_ prefix would parse into', async () => {
-    const { wrapper } = makeWrapper({
+  it('resolves a page whose name happens to carry a create_ prefix', async () => {
+    // A prefixed name is an ordinary page name. Asserting the object is never
+    // consulted is what keeps this non-vacuous now that the fallback is gone:
+    // without it, "the page won" would be true by default.
+    const { wrapper, getItem } = makeWrapper({
       page: [{ name: 'create_opportunity', type: 'utility', label: 'New Opportunity' }],
       object: [{ name: 'opportunity' }],
     });
@@ -95,21 +112,27 @@ describe('useActionModal — modal target resolution (framework#3530)', () => {
 
     expect(d.content).toMatchObject({ name: 'create_opportunity' });
     expect(d.objectName).toBeUndefined();
+    expect(getItem).not.toHaveBeenCalledWith('object', 'opportunity');
+    expect(getItem).not.toHaveBeenCalledWith('object', 'create_opportunity');
   });
 
-  it('still honors the create_ prefix when no page owns the name', async () => {
-    const { wrapper } = makeWrapper({ page: [], object: [{ name: 'opportunity' }] });
+  it('REFUSES a create_ prefixed target with no page — the prefix is not special', async () => {
+    // Replaces "still honors the create_ prefix when no page owns the name".
+    // The ruling declined the middle shape (keep the prefix, reject bare object
+    // names), so this must be judged EXACTLY like the bare-object-name case
+    // above: same refusal, and the `opportunity` object it would have been
+    // parsed into is never asked for even though it exists.
+    const { wrapper, getItem } = makeWrapper({ page: [], object: [{ name: 'opportunity' }] });
     const { result } = renderHook(() => useActionModal(), { wrapper });
 
     let d: any;
     await act(async () => { d = await result.current.resolveModalTarget('create_opportunity'); });
 
-    expect(d).toMatchObject({ objectName: 'opportunity', mode: 'create' });
+    expect(d).toBeNull();
+    expect(getItem).not.toHaveBeenCalledWith('object', 'opportunity');
   });
 
-  it('returns null when the target names neither a page nor an object', async () => {
-    // Not an error on its own — the console runtimes read null as "not a
-    // client-rendered modal" and run the action server-side instead.
+  it('returns null when the target names no page at all', async () => {
     const { wrapper } = makeWrapper({ page: [], object: [] });
     const { result } = renderHook(() => useActionModal(), { wrapper });
 
@@ -119,7 +142,10 @@ describe('useActionModal — modal target resolution (framework#3530)', () => {
   });
 
   it('passes an explicit { objectName, mode } descriptor through without lookups', async () => {
-    // The lookup field's inline "create the referenced record" path.
+    // The lookup field's inline "create the referenced record" path
+    // (`@object-ui/fields`' LookupField). UNAFFECTED by the retirement: the
+    // object identity comes from the field's `referenceTo` in a fully-formed
+    // descriptor, not from parsing an action's string target.
     const { wrapper, getItem } = makeWrapper({ page: [], object: [] });
     const { result } = renderHook(() => useActionModal(), { wrapper });
 
@@ -132,14 +158,39 @@ describe('useActionModal — modal target resolution (framework#3530)', () => {
     expect(getItem).not.toHaveBeenCalled();
   });
 
-  it('modalHandler reports an unresolvable target instead of opening a broken form', async () => {
+  it('modalHandler names the refused target and points at type: form', async () => {
+    const { wrapper } = makeWrapper({ page: [], object: [CONTACT_OBJECT] });
+    const { result } = renderHook(() => useActionModal(), { wrapper });
+
+    // Assert the REFUSAL before invoking `modalHandler`. If the object fallback
+    // ever comes back, `contact` resolves, `modalHandler` opens the dialog and
+    // returns a promise that settles only when the dialog CLOSES — so this test
+    // would hang to the suite timeout instead of failing, and the hung state
+    // leaks into the next test in this file. Verified against the restored
+    // fallback: the timeout cascaded a spurious failure onto the neighbour.
+    // This line makes the regression fail fast, loudly, and locally.
+    let d: any;
+    await act(async () => { d = await result.current.resolveModalTarget('contact'); });
+    expect(d).toBeNull();
+
+    let r: any;
+    await act(async () => { r = await result.current.modalHandler('contact'); });
+
+    expect(r.success).toBe(false);
+    // The diagnostic has to be actionable on its own: which target was refused,
+    // and what to author instead.
+    expect(r.error).toContain('contact');
+    expect(r.error).toContain("type: 'form'");
+  });
+
+  it('modalHandler reports a missing target distinctly from a refused one', async () => {
     const { wrapper } = makeWrapper({ page: [], object: [] });
     const { result } = renderHook(() => useActionModal(), { wrapper });
 
     let r: any;
-    await act(async () => { r = await result.current.modalHandler('schedule_followup'); });
+    await act(async () => { r = await result.current.modalHandler(''); });
 
     expect(r.success).toBe(false);
-    expect(r.error).toContain('schedule_followup');
+    expect(r.error).toBe('Modal action has no target to open.');
   });
 });

--- a/packages/app-shell/src/hooks/__tests__/useActionModal.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/useActionModal.test.ts
@@ -11,25 +11,28 @@ describe('normalizeModalSchema', () => {
     expect(normalizeModalSchema('contact')).toEqual({ targetName: 'contact' });
   });
 
-  it('carries a create_/new_/add_ prefix guess ALONGSIDE the raw target', () => {
-    expect(normalizeModalSchema('create_opportunity')).toEqual({
-      targetName: 'create_opportunity', objectName: 'opportunity', mode: 'create',
-    });
-    expect(normalizeModalSchema('new_task')).toEqual({
-      targetName: 'new_task', objectName: 'task', mode: 'create',
-    });
-    expect(normalizeModalSchema('add_note')).toEqual({
-      targetName: 'add_note', objectName: 'note', mode: 'create',
-    });
+  // objectstack#6739 — the `create_`/`new_`/`add_`/`edit_`/`update_` prefix
+  // convention RETIRED with the object fallback. These used to assert the
+  // opposite (a verb+object guess riding alongside `targetName`); they are
+  // rewritten rather than deleted so the retirement is pinned, not merely
+  // un-covered. A prefixed name is now an ordinary page name — nothing about
+  // its spelling is special.
+  it('does NOT parse a create_/new_/add_ prefix into an object guess', () => {
+    expect(normalizeModalSchema('create_opportunity')).toEqual({ targetName: 'create_opportunity' });
+    expect(normalizeModalSchema('new_task')).toEqual({ targetName: 'new_task' });
+    expect(normalizeModalSchema('add_note')).toEqual({ targetName: 'add_note' });
   });
 
-  it('carries an edit_/update_ prefix guess as an edit form', () => {
-    expect(normalizeModalSchema('edit_account')).toEqual({
-      targetName: 'edit_account', objectName: 'account', mode: 'edit',
-    });
-    expect(normalizeModalSchema('update_lead')).toEqual({
-      targetName: 'update_lead', objectName: 'lead', mode: 'edit',
-    });
+  it('does NOT parse an edit_/update_ prefix into an edit-mode object guess', () => {
+    expect(normalizeModalSchema('edit_account')).toEqual({ targetName: 'edit_account' });
+    expect(normalizeModalSchema('update_lead')).toEqual({ targetName: 'update_lead' });
+  });
+
+  it('treats a prefixed name and a bare name identically — no shape depends on spelling', () => {
+    // The ruling declined the middle shape (keep the prefix, reject bare object
+    // names), so the two spellings must be indistinguishable at this step.
+    expect(normalizeModalSchema('create_opportunity')).toEqual({ targetName: 'create_opportunity' });
+    expect(normalizeModalSchema('opportunity')).toEqual({ targetName: 'opportunity' });
   });
 
   it('treats a bare SchemaNode (has type, no descriptor keys) as content', () => {

--- a/packages/app-shell/src/hooks/useActionModal.tsx
+++ b/packages/app-shell/src/hooks/useActionModal.tsx
@@ -18,9 +18,10 @@
  * <ModalForm> (what a lookup field's inline "create the referenced record"
  * passes).
  *
- * A STRING target — what `type: 'modal'` actions carry — is resolved through
- * {@link resolveModalTarget}: page first, then object. See that function for
- * why the order matters.
+ * A STRING target — what `type: 'modal'` actions carry — names a PAGE, and only
+ * a page; {@link resolveModalTarget} resolves it against the page metadata and
+ * REFUSES anything else (maintainer ruling, objectstack#6739). Opening an
+ * object's form from an action is what `type: 'form'` is for.
  *
  * Returns `{ modalHandler, modalElement, resolveModalTarget }`: pass
  * `modalHandler` as the ActionProvider `onModal`, render `modalElement` once in
@@ -62,17 +63,33 @@ export interface ModalDescriptor {
   description?: string;
   /** Arbitrary SchemaNode rendered inside the chosen container. */
   content?: any;
-  /** Back-compat: open an object form. */
+  /**
+   * Open an object form directly — a DESCRIPTOR-only key, never derived from a
+   * string target.
+   *
+   * Re-judged with the object-fallback retirement (objectstack#6739): the
+   * "Back-compat" label this carried was wrong, and keeping the key is not
+   * leniency. Its live and only producer is the lookup field's inline "create
+   * the referenced record" path, which hands the runner a fully-formed
+   * descriptor — `execute({ type: 'modal', modal: { objectName, mode } })` in
+   * `@object-ui/fields`' `LookupField` — where the object identity is known by
+   * the FIELD's `referenceTo`, not guessed from a name. Nothing about that is a
+   * modal action's `target`, so nothing about it is what the ruling retires.
+   *
+   * What DID retire is the inference: a string `target` can no longer become an
+   * `objectName`. An authored action that wants an object's form declares
+   * `type: 'form'`.
+   */
   objectName?: string;
   mode?: string;
   recordId?: string;
   fields?: any;
   /**
    * An UNRESOLVED string target, straight off a `type: 'modal'` action. It
-   * names a page or an object; which one is only knowable by asking the
+   * names a PAGE; whether that page exists is only knowable by asking the
    * metadata service, so `normalizeModalSchema` (pure) records the name here
    * and {@link resolveModalTarget} (async) turns it into a renderable
-   * descriptor. Never rendered directly.
+   * descriptor — or refuses. Never rendered directly.
    */
   targetName?: string;
 }
@@ -100,26 +117,19 @@ const SIDE_SIZE_CLASS: Partial<Record<ModalSize, string>> = {
  * modal/page name to open" — so reading it as an object name sent every
  * page-targeting modal action to `GET /meta/object/<page>`, which 400s, and the
  * dialog rendered <ModalForm>'s "Error loading form — Bad Request" instead of
- * the page (framework#3530). `resolveModalTarget` decides page-vs-object by
- * asking the metadata service.
+ * the page (framework#3530). `resolveModalTarget` then asks the metadata
+ * service whether a page of that name exists.
  *
- * The `create_`/`new_`/`add_`/`edit_`/`update_` prefix convention still yields
- * an object-form guess, but it is now only a FALLBACK: it rides alongside
- * `targetName` so a page actually named `create_opportunity` wins over the
- * object `opportunity` it would otherwise be parsed into.
+ * The `create_`/`new_`/`add_`/`edit_`/`update_` prefix convention RETIRED with
+ * the object fallback (maintainer ruling, objectstack#6739): a string target is
+ * a page name, whole, and is never parsed into a verb plus an object. The
+ * ruling explicitly declined the middle shape — keep the prefix, reject bare
+ * object names — because a name-shaped guess is exactly the authoring hazard
+ * the contract exists to remove: `create_opportunity` names the page
+ * `create_opportunity`, or it names nothing.
  */
 export function normalizeModalSchema(schema: any): ModalDescriptor {
-  if (typeof schema === 'string') {
-    const m = schema.match(/^(create|new|add|edit|update)_(.+)$/);
-    if (m) {
-      return {
-        targetName: schema,
-        objectName: m[2],
-        mode: m[1] === 'edit' || m[1] === 'update' ? 'edit' : 'create',
-      };
-    }
-    return { targetName: schema };
-  }
+  if (typeof schema === 'string') return { targetName: schema };
   if (schema && typeof schema === 'object') {
     // A bare SchemaNode (has `type` but isn't a modal descriptor) → render as content.
     if (schema.type && !schema.content && !schema.objectName && !schema.placement) {
@@ -151,16 +161,28 @@ export function useActionModal(dataSource?: any) {
    * Turn whatever the ActionRunner handed us into a descriptor this hook can
    * actually render, or `null` when the target names nothing renderable.
    *
-   * Resolution order for a string target is PAGE FIRST, then object, because
-   * that is what the spec says the name means — `type: 'modal'` documents
-   * `target` as "the modal/page name to open". Probing the object first would
-   * re-introduce framework#3530 in reverse for any app whose page and object
-   * share a name.
+   * A string target names a PAGE, and ONLY a page. That is what the spec says
+   * the name means — `type: 'modal'` documents `target` as "the modal/page name
+   * to open" — and the spec TSDoc (`packages/spec/src/ui/action.zod.ts`), the
+   * published docs (`content/docs/ui/actions.mdx`) and `defineStack`'s
+   * cross-reference walk (`packages/spec/src/stack.zod.ts`) all agree: the walk
+   * REJECTS a registered modal action whose target is not a declared page.
    *
-   * A `null` return is not an error by itself: the console runtimes read it as
-   * "this isn't a client-rendered modal" and fall through to the action's
-   * server-side handler, which is how a modal action whose target names a
-   * registered `engine.registerAction` handler still completes.
+   * This hook used to probe the object metadata after the page missed, so a
+   * target the build gate rejects still opened something at runtime. That
+   * divergence retires (maintainer ruling, objectstack#6739): a consumer that
+   * quietly serves what the contract refuses teaches the wrong shape and hides
+   * the authoring error until the gate catches it somewhere else. A non-page
+   * target is a REFUSAL now, and `modalHandler` names it and points at
+   * `type: 'form'`, which is the validated way to open an object's form.
+   *
+   * A `null` return means "no page of that name" — which every caller reports
+   * as an authoring error. It is NOT a server-dispatch fallthrough: a modal
+   * action has no server dispatch at all (the framework's
+   * `headlessActionTypeError` rejects `type: 'modal'` over REST with a 400), so
+   * objectstack#3959 removed that fallthrough from the console runtimes and
+   * objectui#3320 removed the copy in `RecordDetailView`. This TSDoc still
+   * described the pre-#3959 behaviour; corrected here.
    */
   const resolveModalTarget = useCallback(
     async (schema: any): Promise<ModalDescriptor | null> => {
@@ -172,27 +194,20 @@ export function useActionModal(dataSource?: any) {
       }
 
       const page = await getItem('page', targetName);
-      if (page) {
-        // Rendered exactly like PageView does it: the page item IS the schema
-        // node, with `type` naming the page kind ('record' | 'utility' | …).
-        return {
-          placement: d.placement ?? 'center',
-          size: d.size ?? 'xl',
-          title: d.title ?? (page as any).label ?? undefined,
-          description: d.description,
-          content: { ...(page as any), type: (page as any).type || 'page' },
-        };
+      if (!page) {
+        // No object probe: a modal target that is not a page is refused, not
+        // re-read as an object name (objectstack#6739).
+        return null;
       }
-
-      // Object fallback: the `create_x`/`edit_x` prefix guess first (it names a
-      // different object than the raw target), then the raw target itself.
-      for (const objectName of [d.objectName, targetName]) {
-        if (!objectName) continue;
-        if (await getItem('object', objectName)) {
-          return { ...d, targetName: undefined, objectName, mode: d.mode ?? 'create' };
-        }
-      }
-      return null;
+      // Rendered exactly like PageView does it: the page item IS the schema
+      // node, with `type` naming the page kind ('record' | 'utility' | …).
+      return {
+        placement: d.placement ?? 'center',
+        size: d.size ?? 'xl',
+        title: d.title ?? (page as any).label ?? undefined,
+        description: d.description,
+        content: { ...(page as any), type: (page as any).type || 'page' },
+      };
     },
     [getItem],
   );
@@ -205,7 +220,8 @@ export function useActionModal(dataSource?: any) {
         return {
           success: false,
           error: name
-            ? `Modal target "${name}" matches no page or object — a modal action's \`target\` names the page to open.`
+            ? `Modal target "${name}" names no page — a modal action's \`target\` names a PAGE, only. ` +
+              `To open an object's form, use \`type: 'form'\` with an \`<object>.<view>\` target.`
             : 'Modal action has no target to open.',
         };
       }


### PR DESCRIPTION
Fixes #3925

按维护者裁定 **objectstack#6739-A**(2026-08-09,decision-inbox 轮次「全部接受」):`type: 'modal'` 动作的字符串 `target` 只命名 **PAGE**。本仓的 page-then-object 解析属于消费端宽容,退役。

Base: `2646ccb728e36af1e7b38d79de49c09f041e4ed6`

## 改了什么

`packages/app-shell/src/hooks/useActionModal.tsx`:

1. **`resolveModalTarget`** —— 删掉 page 未命中后的 object 元数据回落。非 page 名是**拒绝**,不再静默解析为 object。
2. **`create_`/`new_`/`add_`/`edit_`/`update_` 前缀约定** —— 随同退役。`normalizeModalSchema` 对字符串一律返回 `{ targetName }`,不再拆成动词 + object。裁定明确拒绝了第三形态(保前缀、弃裸名)。
3. **诊断** —— `modalHandler` 点名被拒 target 并给出替代:``Modal target "contact" names no page — a modal action's `target` names a PAGE, only. To open an object's form, use `type: 'form'` with an `object.view` target.``
4. **`ModalDescriptor.objectName` 的 "Back-compat" 注记(交付清单第 3 项)—— 重判为「保留,但注记是错的」**。理由见下。
5. 顺带纠正 `resolveModalTarget` 一段**过期 TSDoc**:它仍写着 `null` 会回落到服务端处理器,而该回落早已由 objectstack#3959 / objectui#3320 移除。这段在 `main` 上就已与同文件消费者的实际行为矛盾。

### 为什么 `objectName` 保留而不是一并删

它**不是** back-compat,也不是宽容 —— 它的唯一在产者是 lookup 字段的行内「创建被引用记录」:`@object-ui/fields` 的 `LookupField` 调用 `execute({ type: 'modal', modal: { objectName, mode } })`,传入的是**完整 descriptor**,object 身份来自字段的 `referenceTo`,而不是从名字猜出来的。这条路径与动作的 `target` 无关,因而不在裁定退役范围内。真正退役的是**推断**:字符串 target 不再能变成 `objectName`。注记已按此改写。

## 风险门(卡内明示:发现真实依赖 → 停手报测量)—— 已枚举,**未发现依赖,放行**

| 位置 | 形态 | 是否依赖被删分支 |
|---|---|---|
| objectstack `examples/app-showcase` `QuickViewAction` | `type: 'modal'` + `target: 'showcase_component_gallery'` | **否** —— 目标是已声明 page,走 page 分支 |
| objectstack showcase 「Create Task」行内按钮 | 已迁至 `type: 'form'` + `showcase_task.edit` | **否** —— os#6737 已落地,实测确认 |
| objectstack `examples/app-showcase/test/actions.test.ts` | 语料钉:每个 modal target 必须是已声明 page | **否** —— 与本变更同向 |
| objectui `apps/` `examples/` | 全仓无 `type: 'modal'` 动作携带字符串 target(命中项均为 FormView 的 `type: 'modal'`,另一个概念) | **否** |
| objectui `packages/fields` `LookupField.tsx:823` | `{ objectName, mode }` **descriptor**,非字符串 target | **否** —— 见上,保留且有测试钉 |
| objectui `packages/app-shell/.../metadata-admin/package-schema.ts:81` | `FormViewSpec` 的 `type: 'modal'`(表单呈现模式) | **否** —— 不同概念 |
| 全仓前缀约定 target 元数据 | 无 | **否** |

## 测试

`packages/app-shell` 全量:**403 文件 / 3831 通过 | 1 skipped**。

按三类处置逐条重判 fixture,而非批量改写:

- **整体替换**(原用例正好钉住被删的那条肢体):「falls back to an object create form」→ 改为拒绝钉;「still honors the create_ prefix」→ 改为拒绝钉(与裸名同判,即钉 ③)。两个拒绝钉的 fixture 都**故意让 object 真实存在**于元数据里 —— 对空 object 列表断言 null 会**空洞通过**,只证明没找到,而非证明没去找。同时断言 `getItem` 从未以 `('object', …)` 被调用。
- **改写**(原用例断言的是被删语义):`useActionModal.test.ts` 的两条前缀用例改为断言前缀**不**被解析;新增一条「前缀名与裸名判定完全一致」,直接钉裁定拒绝的第三形态。
- **保留为对照**:page 解析、`{ objectName, mode }` descriptor 直通(LookupField 路径)、缺失 target 的独立诊断。

## 反向验证 —— 先预判,后跑变异

预判(恢复两条被删肢体后):3 条 normalize 钉转红、2 条拒绝钉转红、诊断钉**以超时而非断言转红**(因为 target 一旦可解析,`modalHandler` 会打开对话框并返回一个只在关闭时 settle 的 promise),5 条对照保持绿。

实测:**7 红 8 绿**,比预判多一条。多出来的是诊断钉的**邻居**「reports a missing target distinctly」—— 单独隔离跑(`-t`)在变异下**通过**,证明它是被上一条超时用例污染的级联失败,不是独立信号。

这条不写进报告了事:我据此**加固了诊断钉** —— 在调用 `modalHandler` 前先断言 `resolveModalTarget` 返回 `null`。这样一旦回落复活,用例会立刻以干净断言失败,而不是挂到超时再把状态泄漏给邻居。

`type: 'form'` 对照(交付清单第 4 项)诚实说明:该路径由 `packages/core` 的 `ActionRunner.executeForm` 承接(导航至 `/forms/` + 表单名),与 `useActionModal` **无任何共享代码**,结构上不可能被本变更影响 —— 所以我没有新造一条形式上好看的"form 钉",而是把既有 `ActionRunner.formObjectIdentity.test.ts` + `ActionRunner.test.ts` 作为对照跑通(6 文件 / 159 通过)。

## 门禁

- `turbo run type-check --concurrency=2` → **81/81 successful**
- `node scripts/check-control-bytes.mjs` → OK(4277 文件);另按纪律自扫改动文件的控制字节,干净
- `check:action-forward-parity` / `check:spec-symbols` / `check:phantom-deps` → 通过
- `eslint`(改动文件)→ **0 error**(25 条既有 `any` warning)

## 超范围发现(未立单,按派发词回传 PM)

1. **两处诊断文案已随本变更过期**:`useConsoleActionRuntime.tsx:600` 与 `RecordDetailView.tsx:883` 都写 `names no page or object to open`,且只指向 `type:'script'`,不提 `type: 'form'`。**控制台动作的实际用户可见文案出自这两处**,而非 `useActionModal.modalHandler`。按边界(views/ 属 #3765 面)未改。建议单独一张卡统一三处文案。
2. **`DashboardView.tsx:70-93` 自带一份独立的前缀约定实现**,不经过 `useActionModal`,因此本次退役影响不到它 —— 但这意味着同一个已被裁定退役的约定在仓内仍有第二份活体,注释还自称支持「server-driven dashboard schemas」发出的 `verb_object`。属 views/ 面,未改。
