### PR TITLE
fix(app-shell): converge the console's index fallback schema to IndexSchema

### DIFF
--- a/.changeset/console-index-fallback-matches-index-schema.md
+++ b/.changeset/console-index-fallback-matches-index-schema.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The console's embedded index editor no longer offers controls for keys the spec removed.
+
+`index` is an embedded-only sub-type with no metadata type of its own, so `/meta` has no
+slot to publish a schema for it and `EmbeddedItemEditor` ships a hand-copied one in
+`FALLBACK_SCHEMAS.index`. That copy had drifted from `IndexSchema`
+(objectstack-ai/objectstack#5247), and `@objectstack/spec` 17.0.0 turned the drift from a
+silent bug into a hard failure:
+
+- **`type` ("Algorithm")** and **`partial`** were retired in spec 17.0.0
+  (objectstack-ai/objectstack#5248, ADR-0049 enforce-or-remove) and are `retiredKey`
+  tombstones today — `IndexSchema` rejects them at any value, so every option of the
+  Algorithm select produced a 422 on the parent object save. Its `brin` option was never
+  in the spec's enum to begin with.
+- **`where` ("Partial-index predicate")** was never a declared key — the spec's spelling
+  was `partial`, itself now retired — so an administrator's predicate was silently
+  stripped on every save.
+
+Both controls are removed. An index method is the driver/dialect's choice and a partial
+index is built at the database layer by a runtime migration, so neither is a
+declaration-surface concern.
+
+`unique` is converged onto the ADR-0120 scope union: the console can now author
+`'organization'` (one holder per organization, NULL-safe) and `'global'`, instead of only
+emitting the deprecated bare `true` that protocol 18 rejects. Indexes already carrying the
+boolean keep rendering their existing control and are saved unchanged.

--- a/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.indexFallback.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.indexFallback.test.tsx
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The console's hand-copied index schema mirrors `IndexSchema` (objectstack#5247).
+ *
+ * `index` is an embedded-only sub-type — it lives inside `object.indexes[]` and
+ * is not a registered metadata type, so `/meta` has no slot to publish a schema
+ * for it and `EmbeddedItemEditor` ships its own copy in `FALLBACK_SCHEMAS.index`.
+ * A hand copy is a drift source by construction, and it drifted: the console
+ * offered a **`where`** control ("Partial-index predicate") the spec never
+ * declared, and a **`brin`** option the spec never allowed.
+ *
+ * ## Why the pin is measured against the INSTALLED spec, not a literal
+ *
+ * A test that re-states the expected property names in its own source is a
+ * second hand copy — it drifts in lockstep with the first and certifies
+ * nothing. Every assertion below therefore runs the console's OWN properties
+ * through `@objectstack/spec`'s `IndexSchema`, so the pin re-derives itself on
+ * every `@objectstack/spec` bump: the day a key is added, retired, or has its
+ * value space narrowed, this file is what goes red.
+ *
+ * ## Why "the parse succeeded" is not the assertion
+ *
+ * `IndexSchema` is deliberately NOT `.strict()` (objectstack#4001 批 20 held
+ * this one site open precisely because of this console copy), so an undeclared
+ * key is **stripped**, not rejected — `safeParse` returns `success: true` and
+ * the admin's input is gone. `unrecognized_keys`, the usual reachability
+ * criterion for a key-level guard, does not exist on a stripping schema. The
+ * equivalent that actually holds here is ROUND-TRIP SURVIVAL: a control is a
+ * real authoring surface only if the value it writes is still there after the
+ * parse. That is what catches `where`, and it is what the first block asserts.
+ *
+ * Retired keys are the other half and fail differently — `type` and `partial`
+ * are `retiredKey` tombstones in spec 17.0.0 (objectstack#5248, ADR-0049), so
+ * they are REJECTED at any value. The old "Algorithm" select was thus a control
+ * every one of whose five options produced a 422 on the parent save, not merely
+ * a dropped one.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { IndexSchema } from '@objectstack/spec/data';
+
+vi.mock('./useMetadata', () => ({
+  useMetadataClient: () => ({
+    layered: async () => ({ effective: {}, code: null, overlay: null, overlayScope: null }),
+    save: async (_t: string, _n: string, payload: Record<string, unknown>) => payload,
+  }),
+  // `index` has no registry entry — that absence is what routes the editor to
+  // `FALLBACK_SCHEMAS.index`, so it is the state under test, not a shortcut.
+  useMetadataTypes: () => ({ loading: false, error: null, entries: [] }),
+}));
+
+import { EmbeddedItemEditor, FALLBACK_SCHEMAS } from './EmbeddedItemEditor';
+
+afterEach(cleanup);
+
+const INDEX_SCHEMA = FALLBACK_SCHEMAS.index.schema as {
+  required?: string[];
+  properties: Record<string, Record<string, unknown>>;
+};
+const CONSOLE_PROPS = INDEX_SCHEMA.properties;
+
+/**
+ * A value the console's control for `prop` can actually emit. Kept tiny and
+ * derived from the control's own declared shape so it stays honest if a
+ * property's type changes.
+ */
+function sampleFor(prop: string, schema: Record<string, unknown>): unknown {
+  const branches = schema.anyOf as Array<Record<string, unknown>> | undefined;
+  const effective = branches?.[0] ?? schema;
+  const enumValues = effective.enum as unknown[] | undefined;
+  if (Array.isArray(enumValues) && enumValues.length > 0) return enumValues[0];
+  switch (effective.type) {
+    case 'array':
+      return ['sample_column'];
+    case 'boolean':
+      return true;
+    case 'number':
+    case 'integer':
+      return 1;
+    default:
+      return prop === 'name' ? 'idx_sample' : 'sample';
+  }
+}
+
+describe('every control the console offers is a real authoring surface', () => {
+  it('non-vacuity: the fallback really is the index schema and really has controls', () => {
+    // Without this, a renamed export or an emptied `properties` would satisfy
+    // every per-property assertion below by iterating nothing.
+    expect(Object.keys(CONSOLE_PROPS).length).toBeGreaterThanOrEqual(3);
+    expect(CONSOLE_PROPS).toHaveProperty('fields');
+    expect(INDEX_SCHEMA.required).toEqual(['fields']);
+  });
+
+  it.each(Object.keys(CONSOLE_PROPS))(
+    '`%s` survives an IndexSchema parse — not dropped, not rejected',
+    (prop) => {
+      const value = sampleFor(prop, CONSOLE_PROPS[prop]);
+      const parsed = IndexSchema.safeParse({ fields: ['sample_column'], [prop]: value });
+
+      // Half 1 — not REJECTED. This is the half a retired key (`type`,
+      // `partial`) fails: the tombstone's message is the upgrade prescription,
+      // so surface it rather than a bare boolean.
+      expect(
+        parsed.success ? '' : parsed.error.issues.map((i) => i.message).join(' | '),
+      ).toBe('');
+
+      // Half 2 — not silently STRIPPED. This is the half `where` failed: the
+      // save succeeded and the admin's predicate was gone.
+      expect(parsed.success && (parsed.data as Record<string, unknown>)[prop]).toEqual(value);
+    },
+  );
+
+  it('the spec keys an author can still set are all offered (no missing control)', () => {
+    // Completeness, the other direction. A tombstone rejects every probe; a
+    // live key accepts at least one, so this needs no hand-listed key set and
+    // survives the next key the spec adds.
+    const probes: unknown[] = ['x', true, 1, ['x'], {}];
+    const authorable = Object.keys(IndexSchema.shape).filter((key) =>
+      probes.some((probe) => IndexSchema.safeParse({ fields: ['c'], [key]: probe }).success),
+    );
+
+    expect(authorable.length).toBeGreaterThan(0);
+    expect(Object.keys(CONSOLE_PROPS).sort()).toEqual(authorable.sort());
+  });
+});
+
+describe('the retired keys are gone and stay gone (objectstack#5248)', () => {
+  it('offers no `type` / "Algorithm" control and no `partial` / `where` control', () => {
+    expect(CONSOLE_PROPS).not.toHaveProperty('type');
+    expect(CONSOLE_PROPS).not.toHaveProperty('partial');
+    expect(CONSOLE_PROPS).not.toHaveProperty('where');
+  });
+
+  it('control: those keys are rejected by the spec, so re-adding them would 422', () => {
+    // Pins WHY they may not come back, and is the non-vacuity guard for the
+    // assertion above — if a spec bump ever made these parse again, this goes
+    // red and the retirement is re-litigated deliberately rather than by drift.
+    for (const [key, value] of [
+      ['type', 'btree'],
+      ['partial', "status = 'open'"],
+    ] as const) {
+      const parsed = IndexSchema.safeParse({ fields: ['c'], [key]: value });
+      expect(parsed.success, `\`${key}\` is a retired-key tombstone`).toBe(false);
+    }
+    // `brin` was never legal even before the retirement — the enum it sat in
+    // was `btree|hash|gin|gist|fulltext`. It is doubly gone.
+    expect(JSON.stringify(INDEX_SCHEMA)).not.toContain('brin');
+  });
+});
+
+describe('`unique` mirrors the ADR-0120 scope union', () => {
+  it('offers exactly the scope spellings protocol 18 keeps', () => {
+    const branch = (CONSOLE_PROPS.unique.anyOf as Array<Record<string, unknown>>)[0];
+    expect(branch.enum).toEqual(['global', 'organization']);
+    for (const scope of branch.enum as string[]) {
+      expect(IndexSchema.safeParse({ fields: ['c'], unique: scope }).success).toBe(true);
+    }
+  });
+
+  it('does not offer the deprecated bare `true` as a selectable option', () => {
+    // Bare `true` is the positional spelling of `'global'`: lint
+    // `unique/unscoped-declared-index` warns in 17.x and protocol 18 rejects it
+    // (objectstack#5082). It parses today — so this is a claim about what the
+    // console EMITS, which is why it is asserted on the control, not the parse.
+    const branch = (CONSOLE_PROPS.unique.anyOf as Array<Record<string, unknown>>)[0];
+    expect(branch.enum).not.toContain(true);
+    expect(branch.enum).not.toContain('true');
+    // Control: it is still ACCEPTED, so legacy indexes are readable/savable.
+    expect(IndexSchema.safeParse({ fields: ['c'], unique: true }).success).toBe(true);
+  });
+
+  it("rejects 'tenant' — the word is 'organization' (ADR-0120 §Terminology)", () => {
+    expect(IndexSchema.safeParse({ fields: ['c'], unique: 'tenant' }).success).toBe(false);
+  });
+});
+
+describe('the rendered form matches the converged schema', () => {
+  function openIndex(initialRaw: Record<string, unknown>) {
+    return render(
+      <EmbeddedItemEditor
+        parentType="object"
+        parentName="sales_order"
+        embeddedPath="indexes"
+        itemName="idx_email"
+        editAs="index"
+        initialRaw={initialRaw}
+      />,
+    );
+  }
+
+  it('draws the surviving controls', () => {
+    const { container } = openIndex({ name: 'idx_email', fields: ['email'] });
+    expect(screen.getByText('Fields')).toBeInTheDocument();
+    expect(screen.getByText('Unique')).toBeInTheDocument();
+    // The real form, not the raw-JSON fallback branch (which is a textarea).
+    expect(container.querySelector('textarea')).toBeNull();
+  });
+
+  it('draws NO "Algorithm" or "Partial-index predicate" control', () => {
+    // The user-visible half of the retirement. Asserted on the rendered labels
+    // rather than the schema object, because the label is what an admin clicks
+    // — and clicking the old one is what produced the 422.
+    openIndex({ name: 'idx_email', fields: ['email'] });
+    expect(screen.queryByText('Algorithm')).toBeNull();
+    expect(screen.queryByText(/partial-index predicate/i)).toBeNull();
+  });
+
+  it('a legacy `unique: true` index still renders its control (no data loss)', () => {
+    // The boolean branch of the union exists for exactly this: an index
+    // authored before ADR-0120 must stay editable, and its stored value must
+    // not be silently reinterpreted by the form.
+    openIndex({ name: 'idx_email', fields: ['email'], unique: true });
+    expect(screen.getByText('Unique')).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
@@ -63,10 +63,10 @@ export function EmbeddedItemEditor({
   const { entries } = useMetadataTypes(client);
   const subEntry = editAs ? entries.find((e) => e.type === editAs) : undefined;
   // Fallback inline schemas for sub-types the framework registers without
-  // a JSON-Schema (validation / index live in object.body but the
-  // registry only exposes their metadata, not their shape). The
-  // schemas below mirror the framework's Zod definitions and the
-  // shapes we see on disk under packages/data-objectstack fixtures.
+  // a JSON-Schema (index lives in object.body but the registry only
+  // exposes its metadata, not its shape). The schemas below mirror the
+  // framework's Zod definitions — a claim that is now ASSERTED rather
+  // than promised, by `EmbeddedItemEditor.indexFallback.test.tsx`.
   const fallback = !subEntry?.schema && editAs ? FALLBACK_SCHEMAS[editAs] : undefined;
   const schema = (subEntry?.schema as Record<string, unknown> | undefined) ?? fallback?.schema;
   const form = (subEntry?.form as any) ?? fallback?.form;
@@ -301,8 +301,31 @@ function spliceEmbedded(
  *
  * `validation` used to be here but is now published by the server via
  * `HAND_CRAFTED_SCHEMAS.validation` in `objectql/protocol.ts`.
+ *
+ * ## ⛔ This copy must MIRROR `IndexSchema`, and that is now pinned
+ *
+ * A hand-copied schema is a drift source by construction, and this one drifted
+ * (objectstack#5247): it grew a `where` control the spec never declared and a
+ * `brin` value the spec never allowed. `EmbeddedItemEditor.indexFallback.test.tsx`
+ * now parses a fixture built from these very properties through the INSTALLED
+ * `@objectstack/spec`, so a control that edits a key the spec drops or rejects
+ * fails the build instead of shipping.
+ *
+ * ### Do not re-add `type` ("Algorithm") or `partial` / `where`
+ *
+ * Both keys were RETIRED in `@objectstack/spec` 17.0.0 (objectstack#5248,
+ * ADR-0049 enforce-or-remove, maintainer ruling 2026-08-06) and are `retiredKey`
+ * tombstones in `IndexSchema` today — the spec REJECTS them at any value, so the
+ * old "Algorithm" select was a control every one of whose options now produces a
+ * 422 on the parent save. `where` was never declared at all (the spec's spelling
+ * was `partial`, itself now retired), so it was silently dropped on every save.
+ *
+ * The replacements are not console controls: an index METHOD is the
+ * driver/dialect's choice, and a PARTIAL index is built at the database layer by
+ * a runtime migration issuing `CREATE [UNIQUE] INDEX … WHERE`. Neither is a
+ * declaration-surface concern, so neither comes back here.
  */
-const FALLBACK_SCHEMAS: Record<
+export const FALLBACK_SCHEMAS: Record<
   string,
   { schema: Record<string, unknown>; form?: Record<string, unknown> }
 > = {
@@ -314,29 +337,39 @@ const FALLBACK_SCHEMAS: Record<
         name: {
           type: 'string',
           title: 'Name',
-          description: 'Synthesised from columns if omitted (e.g. idx_email).',
+          description: 'Index name (auto-generated from the columns if not provided).',
         },
         fields: {
           type: 'array',
           title: 'Fields',
-          description: 'Columns to index, in order.',
+          description: 'Fields included in the index, in order.',
           items: { type: 'string' },
         },
-        type: {
-          type: 'string',
-          title: 'Algorithm',
-          enum: ['btree', 'hash', 'gin', 'gist', 'brin'],
-          default: 'btree',
-        },
+        // ADR-0120: `unique` is a SCOPE, not a flag —
+        // `z.union([z.boolean(), z.literal('global'), z.literal('organization')])`.
+        // The union is mirrored verbatim, with the scope branch FIRST on
+        // purpose: `resolveUnionBranch` falls back to `branches[0]` when the
+        // value is absent, so a new index gets the scope select and can only
+        // author a spelling that survives protocol 18. An index already
+        // carrying the legacy boolean scores the boolean branch and keeps
+        // rendering as the switch it was authored with, unchanged.
+        //
+        // Bare `true` is the DEPRECATED positional spelling of `'global'`: lint
+        // `unique/unscoped-declared-index` warns on it in 17.x and protocol 18
+        // rejects it (objectstack#5082), which is why it is not offered as an
+        // option here. Leaving the control empty is the spec default (`false`).
         unique: {
-          type: 'boolean',
           title: 'Unique',
-          description: 'Enforce uniqueness across the indexed columns.',
-        },
-        where: {
-          type: 'string',
-          title: 'Partial-index predicate',
-          description: 'Optional WHERE clause for a partial index.',
+          description:
+            "Whether the index enforces uniqueness, and at which scope. 'global' " +
+            'materializes over exactly the listed fields — one holder across the whole ' +
+            "installation. 'organization' has the driver prepend the NULL-safe " +
+            'organization key part at registration — one holder per organization. Leave ' +
+            'empty for a non-unique index.',
+          anyOf: [
+            { type: 'string', enum: ['global', 'organization'] },
+            { type: 'boolean' },
+          ],
         },
       },
     },


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5247

The console ships a hand-copied JSON-Schema for `object.indexes[]` entries, in `FALLBACK_SCHEMAS.index` (`packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx`). The copy exists for a good reason — `index` is an embedded-only sub-type with no metadata type of its own, so `/meta` has no slot to publish a schema for it — but it had drifted from `IndexSchema`, and `@objectstack/spec` 17.0.0 turned one half of that drift from a silent bug into a hard failure.

## What was measured

Against the **installed** `@objectstack/spec@17.0.0-rc.6` in this repo:

```
IndexSchema shape keys:  name, fields, unique, type, partial

type:    'btree'        REJECT — "`indexes[].type` was removed in @objectstack/spec 17.0.0 …"
partial: "s = 'open'"   REJECT — "`indexes[].partial` was removed in @objectstack/spec 17.0.0 …"
where:   "s = 'open'"   OK -> {"fields":["a"],"unique":false}      ← key silently gone
unique:  true / false / 'global' / 'organization'   all OK
unique:  'tenant'       REJECT — the word is 'organization'
```

So the two drifted controls failed in two different ways, and neither was benign:

- **`type` ("Algorithm")** — retired in spec 17.0.0 (objectstack-ai/objectstack#5248, ADR-0049 enforce-or-remove, maintainer ruling 2026-08-06) and a `retiredKey` tombstone today. The spec rejects it at **any** value, so every one of the select's five options produced a **422 on the parent object save**. Its `brin` option was never in the spec's enum (`btree|hash|gin|gist|fulltext`) even before the retirement, so it was doubly wrong. This is the objectstack-ai/objectstack#5114 class — a 422 landing on a control the console itself renders — caught before an admin hit it.
- **`where` ("Partial-index predicate")** — never a declared key at all. The spec's spelling was `partial`, itself now retired. `IndexSchema` is deliberately not `.strict()`, so the predicate an admin typed was **stripped on save with no error at all**.

## What changed

Both controls are deleted. Per the ruling, the replacements are not console controls: an index **method** is the driver/dialect's choice, and a **partial** index is built at the database layer by a runtime migration issuing `CREATE [UNIQUE] INDEX … WHERE` (the way `metadata-protocol`'s `ensureOverlayIndex` already does for `sys_metadata`). Neither is a declaration-surface concern, so neither comes back.

`unique` is converged onto the ADR-0120 scope union it has become in the spec — `z.union([z.boolean(), z.literal('global'), z.literal('organization')])`. Before this PR the console rendered a plain boolean switch, so the only thing it could emit was the **deprecated positional spelling** `true`, which lint `unique/unscoped-declared-index` warns on in 17.x and protocol 18 rejects (objectstack-ai/objectstack#5082) — a producer already emitting a spelling the platform is retiring, i.e. the same defect class as the card. The union is mirrored verbatim with the scope branch first, which `SchemaForm.resolveUnionBranch` turns into exactly the right two behaviours:

- a **new** index (no value) resolves to `branches[0]` and gets a scope select offering `global` / `organization` — the console can no longer author the deprecated spelling;
- an index **already carrying** the boolean scores the boolean branch and keeps rendering the switch it was authored with, so legacy indexes stay editable and are saved unchanged. Leaving the control empty is the spec default (`false`, non-unique).

## The pin, and why it is not a second hand copy

`EmbeddedItemEditor.indexFallback.test.tsx` never re-states the expected property names in its own source — a test that did would drift in lockstep with the schema it guards and certify nothing. Instead it runs the console's **own** properties through the installed `IndexSchema`, so it re-derives on every `@objectstack/spec` bump.

Because `IndexSchema` strips rather than rejects, "the parse succeeded" is not the assertion. `unrecognized_keys` — the usual key-level reachability criterion — does not exist on a stripping schema, so the pin asserts **round-trip survival**: a control is a real authoring surface only if the value it writes is still present after the parse. That is the half that catches `where`; rejection is the half that catches `type` / `partial`. A completeness direction runs the other way (probe each spec key; a tombstone rejects every probe, a live key accepts one), so a spec key with **no** control also fails, with no hand-listed key set to maintain.

## Verification

Union re-run after the final commit, at `2be19d6`, clean working tree:

```
pnpm exec vitest run packages/app-shell/src/views/metadata-admin/
  Test Files  168 passed (168)
        Tests  1684 passed | 1 skipped (1685)

pnpm exec vitest run …/EmbeddedItemEditor.indexFallback.test.tsx …/EmbeddedItemEditor.preview.test.tsx
  Test Files  2 passed (2)        Tests  21 passed (21)

pnpm --filter @object-ui/app-shell run type-check      exit 0  (tsc --noEmit && tsc -p tsconfig.test.json)
pnpm exec eslint (the two changed files)               exit 0  (0 errors, 10 warnings)
check:phantom-deps / check:control-bytes / lint:coverage / check:i18n-keys /
  check:i18n-drift / check:i18n-dead-keys / check:spec-symbols / changeset-presence /
  changeset-no-major                                   all PASS
```

`tsc` needed `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` first — without the dependency closure it reports `Cannot find module '@object-ui/components'` and friends, which reads exactly like a broken import.

**Reverse verification** (fix committed first, then its substance ablated with the `export` kept so the failure is the drift and not a missing import): expected direction RED, observed RED — 8 failures, each naming the real defect rather than just going red.

```
× `type` survives an IndexSchema parse   → expected '`indexes[].type` was removed in @obje…' to be ''
× `where` survives an IndexSchema parse  → expected undefined to deeply equal 'sample'   ← the silent strip
× the spec keys an author can still set are all offered
     → expected [ 'fields', 'name', 'type', …(2) ] to deeply equal [ 'fields', 'name', 'unique' ]
× offers no `type` / "Algorithm" control and no `partial` / `where` control
× control: those keys are rejected by the spec  → expected '{"type":"object"…' not to contain 'brin'
× draws NO "Algorithm" or "Partial-index predicate" control  → expected < label …> to be null
× offers exactly the scope spellings protocol 18 keeps
× does not offer the deprecated bare `true` as a selectable option
```

## Notes for the reviewer

- **One new lint warning, deliberate.** `FALLBACK_SCHEMAS` is now exported so the pin can read the real object instead of regexing source text, which trips `react-refresh/only-export-components` (warning, not error — lint exits 0). The clean fix is to move the constant into its own module, but that would add a file outside this card's declared surface (`EmbeddedItemEditor.tsx` + its tests); happy to do it in a follow-up if you would rather have the fast-refresh boundary back.
- **Third suggestion in the issue body is still out of scope and still valid.** An embedded-sub-type registry that lets the framework publish `index`'s schema/form server-side — the way `HAND_CRAFTED_SCHEMAS.validation` already does — would delete this hand copy rather than re-align it. The card's 2026-08-06 premise comment explicitly kept it out; the pin added here is the cheap interim guard, not a substitute.
- **Out-of-scope finding filed, not fixed:** objectstack-ai/objectui#4765 — `UniquenessValidation`'s `@deprecated` JSDoc in `packages/types/src/data-protocol.ts` prescribes `partial` (retired) and `unique: true` (deprecated positional spelling). Same false-guidance class, different file, so it is filed unassigned per the declared file surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SgModTWkJPeXMgbg7enL5Z)_