### PR TITLE
fix(plugin-form): a no-sections drawer form honours field-level conditional rules (#4755)

### DIFF
--- a/.changeset/drawer-flat-field-rules-4755.md
+++ b/.changeset/drawer-flat-field-rules-4755.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+Fix: a `drawer` form with no `sections` now honours the object's field-level
+conditional rules (`visibleWhen` / `readonlyWhen` / `requiredWhen`) and field
+`group`.
+
+`ModalForm` and `DrawerForm` each carried their own copy of the "object-schema
+field to runtime FormField" loop for the no-sections case, and the drawer's
+copy had fallen behind: it stopped at `multiple`, so the ADR-0036 predicates
+never reached the runtime field and `resolveFieldRuleState` had nothing to
+resolve. A hidden field rendered anyway, a frozen field stayed editable (with
+the server then dropping the write), and a conditionally-required field never
+blocked the submit.
+
+Both containers now build that list through one shared `buildFlatFields`, which
+resolves each field through the same `fromObjectSchema` the sectioned path uses
+— so the next field-mapping fix lands once and reaches every container.

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -37,16 +37,11 @@ import { Loader2 } from 'lucide-react';
 import { SchemaRenderer, useSafeFieldLabel, usePreviewMode } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { MasterDetailForm } from './MasterDetailForm';
-import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
+import { buildFlatFields } from './flatFields';
 import { applyAutoLayout } from './autoLayout';
 import { sanitizeFormData } from './sanitize';
-import {
-  seedCreateValues,
-  isCreateFormMode,
-  isRequiredInForm,
-  omitServerResolvedDefaults,
-} from './schemaDefaults';
+import { seedCreateValues, omitServerResolvedDefaults } from './schemaDefaults';
 import { useOccSave } from './occSave';
 
 /**
@@ -328,35 +323,21 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
 
     if (!objectSchema) return;
 
-    const fieldsToShow = schema.fields || Object.keys(objectSchema.fields || {});
-    const generated: FormField[] = [];
-
-    for (const fieldName of fieldsToShow) {
-      const name = typeof fieldName === 'string' ? fieldName : (fieldName as any).name;
-      if (!name) continue;
-      const field = objectSchema.fields?.[name];
-      if (!field) continue;
-
-      generated.push({
-        name,
-        label: fieldLabel(schema.objectName, name, field.label || name),
-        // (type, multiple) decides the widget (objectui#3986) — see `sectionFields`.
-        type: mapFieldTypeToFormType(field.type, { multiple: field.multiple }),
-        // Mode-aware, same rule as the sectioned path (#4069) — a runtime
-        // `defaultValue` is the server's to resolve, so a CREATE form does not
-        // refuse the submit over the empty control it deliberately left.
-        required: isRequiredInForm(field, isCreateFormMode(schema)),
-        disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
-        placeholder: field.placeholder,
-        description: field.help || field.description,
-        validation: buildValidationRules(field),
-        field: field,
-        options: field.options,
-        multiple: field.multiple,
-      });
-    }
-
-    setFormFields(generated);
+    // ONE builder, shared with ModalForm (objectui#4755). The two containers
+    // each carried their own copy of this loop; the drawer's copy had fallen
+    // behind on the ADR-0036 field-level rules and `group`, so a no-sections
+    // drawer silently ignored every conditional-rule declaration.
+    setFormFields(
+      buildFlatFields({
+        fields: schema.fields as any,
+        objectSchema,
+        objectName: schema.objectName,
+        readOnly: schema.readOnly,
+        mode: schema.mode,
+        recordId: schema.recordId,
+        fieldLabel,
+      }),
+    );
     setLoading(false);
   }, [objectSchema, schema.fields, schema.customFields, schema.sections, schema.readOnly, schema.mode, dataSource]);
 

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -37,8 +37,8 @@ import { Loader2 } from 'lucide-react';
 import { MasterDetailForm } from './MasterDetailForm';
 import { SchemaRenderer, useSafeFieldLabel, usePreviewMode } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
-import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
+import { buildFlatFields } from './flatFields';
 import {
   applyAutoColSpan,
   applyAutoLayout,
@@ -50,12 +50,7 @@ import {
 } from './autoLayout';
 import { deriveFieldGroupSections } from './fieldGroups';
 import { sanitizeFormData } from './sanitize';
-import {
-  seedCreateValues,
-  isCreateFormMode,
-  isRequiredInForm,
-  omitServerResolvedDefaults,
-} from './schemaDefaults';
+import { seedCreateValues, omitServerResolvedDefaults } from './schemaDefaults';
 import { usePermissions } from '@object-ui/permissions';
 import { useOccSave } from './occSave';
 
@@ -403,43 +398,20 @@ export const ModalForm: React.FC<ModalFormProps> = ({
 
     if (!objectSchema) return;
 
-    const fieldsToShow = schema.fields || Object.keys(objectSchema.fields || {});
-    const generated: FormField[] = [];
-
-    for (const fieldName of fieldsToShow) {
-      const name = typeof fieldName === 'string' ? fieldName : (fieldName as any).name;
-      if (!name) continue;
-      const field = objectSchema.fields?.[name];
-      if (!field) continue;
-
-      generated.push({
-        name,
-        label: fieldLabel(schema.objectName, name, field.label || name),
-        // (type, multiple) decides the widget (objectui#3986) — see `sectionFields`.
-        type: mapFieldTypeToFormType(field.type, { multiple: field.multiple }),
-        // Mode-aware, same rule as the sectioned path (#4069) — a runtime
-        // `defaultValue` is the server's to resolve, so a CREATE form does not
-        // refuse the submit over the empty control it deliberately left.
-        required: isRequiredInForm(field, isCreateFormMode(schema)),
-        disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
-        placeholder: field.placeholder,
-        description: field.help || field.description,
-        validation: buildValidationRules(field),
-        field: field,
-        options: field.options,
-        multiple: field.multiple,
-        // Field-level conditional rules (ADR-0036) — resolved reactively by
-        // the form renderer via the canonical engine (#2212).
-        visibleWhen: (field as any).visibleWhen,
-        readonlyWhen: (field as any).readonlyWhen,
-        requiredWhen: (field as any).requiredWhen,
-        // Field-group membership (Field.group → object.fieldGroups[].key) —
-        // read by deriveFieldGroupSections for the fieldGroups fallback.
-        group: (field as any).group,
-      });
-    }
-
-    setFormFields(generated);
+    // ONE builder, shared with DrawerForm (objectui#4755) — the ADR-0036 rules
+    // and `group` this path carries now reach both containers from a single
+    // mapping instead of a hand-copied second loop.
+    setFormFields(
+      buildFlatFields({
+        fields: schema.fields as any,
+        objectSchema,
+        objectName: schema.objectName,
+        readOnly: schema.readOnly,
+        mode: schema.mode,
+        recordId: schema.recordId,
+        fieldLabel,
+      }),
+    );
     setLoading(false);
   }, [objectSchema, schema.fields, schema.customFields, schema.sections, schema.readOnly, schema.mode, dataSource]);
 

--- a/packages/plugin-form/src/flatFieldRules.test.tsx
+++ b/packages/plugin-form/src/flatFieldRules.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A no-sections overlay form honours the object's ADR-0036 field-level rules —
+ * objectui#4755.
+ *
+ * `DrawerForm` and `ModalForm` each accept `objectName` with no `sections`, and
+ * each used to build the runtime field list with its own hand-copied loop. The
+ * drawer's copy stopped at `multiple`: `visibleWhen`, `readonlyWhen` and
+ * `requiredWhen` never reached the runtime `FormField`, so
+ * `resolveFieldRuleState` had nothing to resolve and every declaration was
+ * silently ignored — a `visibleWhen`-FALSE field rendered anyway, a
+ * `readonlyWhen`-TRUE field stayed editable (and the server then dropped the
+ * write and reported `droppedFields`), and `requiredWhen` never fired.
+ *
+ * Both containers are driven here as ONE table, deliberately: the modal rows
+ * are the non-regression half (it already behaved this way and must keep
+ * doing so after both builders converged onto `buildFlatFields`), the drawer
+ * rows are the fix. Any future re-fork of either builder shows up as one
+ * container's rows going red while the other's stay green — which is exactly
+ * the signal that was missing when this drift shipped.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ModalForm } from './ModalForm';
+import { DrawerForm } from './DrawerForm';
+
+registerAllFields();
+
+/**
+ * An invoice whose three conditional rules all key off the same live field, so
+ * one `status` value decides all three verdicts at once.
+ */
+const OBJECT_SCHEMA = {
+  name: 'invoice',
+  fields: {
+    status: { type: 'text', label: 'Status' },
+    // Shown only once the invoice has been sent.
+    sent_at: { type: 'text', label: 'Sent at', visibleWhen: "record.status == 'sent'" },
+    // Frozen once the invoice has been sent (the server strips the write too).
+    amount: { type: 'text', label: 'Amount', readonlyWhen: "record.status == 'sent'" },
+    // Mandatory only once the invoice has been sent.
+    reference: { type: 'text', label: 'Reference', requiredWhen: "record.status == 'sent'" },
+  },
+};
+
+const makeDS = () =>
+  ({
+    getObjectSchema: vi.fn().mockResolvedValue(OBJECT_SCHEMA),
+    create: vi.fn().mockResolvedValue({ id: 'r1' }),
+    update: vi.fn().mockResolvedValue({ id: 'r1' }),
+    findOne: vi.fn().mockResolvedValue({ id: 'r1' }),
+  }) as any;
+
+const submit = () => fireEvent.submit(document.body.querySelector('form') as HTMLFormElement);
+
+/**
+ * The editable control of a rendered field, if the renderer gave it one.
+ *
+ * A locked field is not a disabled `<input>` in this design system — the
+ * renderer swaps the control for a read-only VALUE DISPLAY (`data-slot`
+ * `empty-value` when there is nothing to show). So "is it locked" is asked as
+ * "did it keep an editable control", which is also the fact the user
+ * experiences; a `readonly` attribute check would silently pass on a field
+ * that renders no control at all.
+ */
+const controlOf = (field: string) =>
+  document.body.querySelector(`[data-field="${field}"] input, [data-field="${field}"] textarea`);
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => cleanup());
+
+const CONTAINERS: Array<[string, React.ComponentType<any>, string]> = [
+  ['ModalForm', ModalForm as any, 'modal'],
+  ['DrawerForm', DrawerForm as any, 'drawer'],
+];
+
+describe.each(CONTAINERS)('%s — no-sections form honours field-level rules (#4755)', (_name, Container, formType) => {
+  /** No `sections`, no `customFields` — the flat builder is the only producer. */
+  const renderFlat = (ds: any, status: string) =>
+    render(
+      <Container
+        schema={{
+          type: 'object-form',
+          formType,
+          objectName: 'invoice',
+          mode: 'create',
+          open: true,
+          initialData: { status },
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+  it('hides a `visibleWhen`-FALSE field and shows it when the predicate holds', async () => {
+    renderFlat(makeDS(), 'draft');
+    await screen.findByLabelText(/^Status$/);
+    expect(screen.queryByLabelText(/^Sent at$/)).toBeNull();
+
+    cleanup();
+
+    renderFlat(makeDS(), 'sent');
+    expect(await screen.findByLabelText(/^Sent at$/)).toBeTruthy();
+  });
+
+  it('locks a `readonlyWhen`-TRUE field', async () => {
+    renderFlat(makeDS(), 'sent');
+    await waitFor(() => expect(document.body.querySelector('[data-field="amount"]')).toBeTruthy());
+    expect(controlOf('amount')).toBeNull();
+  });
+
+  it('leaves the same field editable when the predicate is FALSE', async () => {
+    renderFlat(makeDS(), 'draft');
+    await waitFor(() => expect(document.body.querySelector('[data-field="amount"]')).toBeTruthy());
+    expect(controlOf('amount')).not.toBeNull();
+  });
+
+  it('refuses the submit while a `requiredWhen` field is empty', async () => {
+    const ds = makeDS();
+    renderFlat(ds, 'sent');
+    // The predicate reached BOTH layers: the marker (display) and the
+    // validator (submit). Asserting only the refusal would pass on a form that
+    // is merely broken.
+    const reference = await screen.findByLabelText(/^Reference/);
+    expect(reference).toHaveAttribute('aria-required', 'true');
+
+    submit();
+
+    await waitFor(() => expect(document.body.textContent).toMatch(/required/i));
+    expect(ds.create).not.toHaveBeenCalled();
+  });
+
+  it('lets the submit through once the `requiredWhen` field is filled', async () => {
+    const ds = makeDS();
+    renderFlat(ds, 'sent');
+    fireEvent.change(await screen.findByLabelText(/^Reference/), { target: { value: 'INV-1' } });
+
+    submit();
+
+    await waitFor(() => expect(ds.create).toHaveBeenCalled());
+    expect(ds.create.mock.calls[0][1]).toMatchObject({ reference: 'INV-1' });
+  });
+
+  it('does not require the field while the predicate is FALSE', async () => {
+    const ds = makeDS();
+    renderFlat(ds, 'draft');
+    expect(await screen.findByLabelText(/^Reference/)).not.toHaveAttribute('aria-required', 'true');
+
+    submit();
+
+    await waitFor(() => expect(ds.create).toHaveBeenCalled());
+  });
+});

--- a/packages/plugin-form/src/flatFields.test.ts
+++ b/packages/plugin-form/src/flatFields.test.ts
@@ -1,0 +1,107 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The FLAT (no-sections) field builder — objectui#4755.
+ *
+ * `ModalForm` and `DrawerForm` used to carry one hand-copied copy of this
+ * mapping each, and they drifted: the drawer's copy stopped at `multiple`,
+ * dropping `visibleWhen` / `readonlyWhen` / `requiredWhen` / `group`. These
+ * tests pin the two facts that keep them from drifting again:
+ *
+ *   1. the flat builder carries every ADR-0036 field-level rule, and
+ *   2. it agrees KEY BY KEY with the sectioned producer
+ *      (`normalizeSectionField`) over the same object field — which is what a
+ *      shared mapping buys, and what a re-forked copy would break first.
+ *
+ * The container-level behavioural half (a rule actually firing inside a
+ * no-sections drawer) lives in `flatFieldRules.test.tsx`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildFlatFields } from './flatFields';
+import { normalizeSectionField } from './sectionFields';
+
+const fieldLabel = (_o: string, _f: string, fallback: string) => fallback;
+
+const OBJECT_SCHEMA = {
+  name: 'invoice',
+  fields: {
+    status: { type: 'select', label: 'Status', options: [{ label: 'Draft', value: 'draft' }] },
+    sent_at: {
+      type: 'datetime',
+      label: 'Sent at',
+      group: 'delivery',
+      visibleWhen: "record.status == 'sent'",
+      readonlyWhen: "record.status == 'paid'",
+      requiredWhen: "record.status == 'sent'",
+    },
+    note: { type: 'textarea', label: 'Note' },
+  },
+} as any;
+
+const ctx = {
+  objectSchema: OBJECT_SCHEMA,
+  objectName: 'invoice',
+  mode: 'create' as const,
+  fieldLabel,
+};
+
+describe('buildFlatFields — ADR-0036 rules reach the runtime FormField (#4755)', () => {
+  it('carries visibleWhen / readonlyWhen / requiredWhen off the object field', () => {
+    const built = buildFlatFields(ctx);
+    const sentAt = built.find((f) => f.name === 'sent_at')!;
+
+    expect(sentAt.visibleWhen).toBe("record.status == 'sent'");
+    expect(sentAt.readonlyWhen).toBe("record.status == 'paid'");
+    expect(sentAt.requiredWhen).toBe("record.status == 'sent'");
+  });
+
+  it('carries `group` (the fieldGroups fallback has nothing to group on without it)', () => {
+    const built = buildFlatFields(ctx);
+    expect((built.find((f) => f.name === 'sent_at') as any).group).toBe('delivery');
+  });
+
+  it('honours an explicit `fields` whitelist, in the order given', () => {
+    const built = buildFlatFields({ ...ctx, fields: ['note', 'status'] });
+    expect(built.map((f) => f.name)).toEqual(['note', 'status']);
+  });
+
+  it('defaults to every declared field, in object-schema order', () => {
+    expect(buildFlatFields(ctx).map((f) => f.name)).toEqual(['status', 'sent_at', 'note']);
+  });
+
+  it('skips a whitelisted field the object schema does not declare', () => {
+    const built = buildFlatFields({ ...ctx, fields: ['status', 'not_a_field'] });
+    expect(built.map((f) => f.name)).toEqual(['status']);
+  });
+});
+
+/**
+ * PARITY PIN. The flat and sectioned producers now resolve every field through
+ * the same `fromObjectSchema`, so their output must agree on every key the
+ * sectioned one produces. `group` is the one deliberate flat-only addition (its
+ * only reader, `deriveFieldGroupSections`, runs on the flat path alone) — so it
+ * is asserted as an addition rather than treated as drift.
+ *
+ * A future edit that re-forks either builder fails HERE, before it can ship a
+ * container that quietly ignores half the object's declarations.
+ */
+describe('buildFlatFields ↔ normalizeSectionField parity (#4755)', () => {
+  it('agrees key-by-key with the sectioned producer, adding only `group`', () => {
+    for (const name of Object.keys(OBJECT_SCHEMA.fields)) {
+      const flat = buildFlatFields({ ...ctx, fields: [name] })[0] as Record<string, unknown>;
+      const sectioned = normalizeSectionField(name, ctx) as Record<string, unknown>;
+
+      expect(new Set(Object.keys(flat))).toEqual(new Set([...Object.keys(sectioned), 'group']));
+      for (const key of Object.keys(sectioned)) {
+        expect({ key, value: flat[key] }).toEqual({ key, value: sectioned[key] });
+      }
+    }
+  });
+});

--- a/packages/plugin-form/src/flatFields.ts
+++ b/packages/plugin-form/src/flatFields.ts
@@ -1,0 +1,80 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Shared FLAT field builder for the overlay form containers (Modal / Drawer).
+ *
+ * `ModalForm` and `DrawerForm` each accept `objectName` (plus an optional
+ * `fields` whitelist) with NO `sections` and no `customFields`. In that shape
+ * there is no section to normalize, so both used to build the runtime
+ * `FormField` list inline — two hand-copied loops over the same "object-schema
+ * field to runtime FormField" mapping that `sectionFields`' `fromObjectSchema`
+ * already owns for the sectioned path.
+ *
+ * They drifted, exactly as duplicated mappings do (objectui#4755): the modal's
+ * copy carried the ADR-0036 field-level rules (`visibleWhen` / `readonlyWhen` /
+ * `requiredWhen`) and the field-group membership (`group`), the drawer's copy
+ * stopped at `multiple`. A drawer form opened over an object declaring
+ * conditional rules therefore ignored every one of them — a `visibleWhen`-FALSE
+ * field rendered anyway, a `readonlyWhen`-TRUE field stayed editable (and the
+ * server then dropped the write), and `requiredWhen` never fired. Nothing was
+ * broken in the renderer: `resolveFieldRuleState` simply never received the
+ * predicates, because the builder did not copy them onto the FormField.
+ *
+ * So there is now ONE mapping in this package, shared by all three producers —
+ * this module for the flat path, `buildSectionFields` for the sectioned path,
+ * both resolving each field through `fromObjectSchema`. The next widget-arity
+ * fix (#3986), create-mode `required` rule (#4069) or ADR-0036 key lands once
+ * and reaches every container.
+ */
+
+import type { FormField } from '@object-ui/types';
+import { fromObjectSchema, type SectionFieldsContext } from './sectionFields';
+
+export interface FlatFieldsContext extends SectionFieldsContext {
+  /**
+   * The caller's explicit field whitelist, in render order. Entries are field
+   * names or objects carrying one (`{ name }`). Omitted → every field the
+   * object schema declares, in schema order.
+   */
+  fields?: Array<string | Record<string, any>>;
+}
+
+/**
+ * Build the runtime `FormField` list for a container rendering an object's
+ * fields flat (no sections).
+ *
+ * Fields the object schema does not declare are SKIPPED — the flat containers
+ * have always dropped them rather than rendering `fromObjectSchema`'s bare
+ * `input` stub, and a whitelist naming a field the object does not have is an
+ * authoring error the form should not paper over with an untyped control.
+ */
+export function buildFlatFields(ctx: FlatFieldsContext): FormField[] {
+  const fieldsToShow = ctx.fields || Object.keys(ctx.objectSchema?.fields || {});
+  const generated: FormField[] = [];
+
+  for (const entry of fieldsToShow) {
+    const name = typeof entry === 'string' ? entry : (entry as any)?.name;
+    if (!name) continue;
+    const field = ctx.objectSchema?.fields?.[name];
+    if (!field) continue;
+
+    generated.push({
+      ...fromObjectSchema(name, ctx),
+      // Field-group membership (Field.group → object.fieldGroups[].key), read
+      // by `deriveFieldGroupSections` for the fieldGroups fallback. Carried
+      // HERE and not in `fromObjectSchema` because that fallback only ever runs
+      // over a flat field list — both call sites (ObjectForm, ModalForm) skip
+      // it the moment explicit sections exist, so stamping `group` onto
+      // section-built fields would add a key with no reader.
+      group: (field as any).group,
+    });
+  }
+
+  return generated;
+}

--- a/packages/plugin-form/src/sectionFields.ts
+++ b/packages/plugin-form/src/sectionFields.ts
@@ -99,8 +99,15 @@ function warnOnMixedVocabulary(fd: Record<string, any>, objectName: string): voi
   );
 }
 
-/** Build a runtime FormField from object-schema metadata for `fieldName`. */
-function fromObjectSchema(fieldName: string, ctx: SectionFieldsContext): FormField {
+/**
+ * Build a runtime FormField from object-schema metadata for `fieldName`.
+ *
+ * The ONE object-field-to-FormField mapping in this package. Exported because
+ * the flat (no-sections) containers need the identical mapping — see
+ * `flatFields.ts`, and objectui#4755 for what a second hand-copied version
+ * costs.
+ */
+export function fromObjectSchema(fieldName: string, ctx: SectionFieldsContext): FormField {
   const field = ctx.objectSchema?.fields?.[fieldName];
   if (!field) {
     return { name: fieldName, label: fieldName, type: 'input' } as FormField;


### PR DESCRIPTION
Fixes #4755

Base: `d971e51c0`(含刚落 main 的 PR #4760)。

## 前提核验(自证,未采信 issue 正文)

两个 flat builder 逐行取出对比,确认 issue 报的「line-for-line identical except keys」属实:

```
$ diff -u <(sed -n '313,361p' packages/plugin-form/src/DrawerForm.tsx) \
          <(sed -n '389,443p' packages/plugin-form/src/ModalForm.tsx)
```

差异只有三处:两行注释措辞,以及 ModalForm 多出的四个键 —— `visibleWhen` / `readonlyWhen` / `requiredWhen` / `group`。依赖数组、`isRequiredInForm(field, isCreateFormMode(schema))`、`mapFieldTypeToFormType(field.type, { multiple })`、跳过未声明字段的 `continue`,两边完全一致。

`SplitForm` / `TabbedForm` 复核:两者都没有 flat builder,恒经 `buildSectionFieldsShared` 走 `sectionFields.ts`(SplitForm.tsx:201-203、TabbedForm.tsx:276-278),而 `fromObjectSchema` 本就带三条规则 —— 确认不受影响,与 #4085 dev 的结论一致。

## 取舍:走了收敛,不是补齐

分诊给的第一选择是收敛,实测后确认成本没有超出:两份循环的**唯一**实质差异就是那四个键,且 `sectionFields.ts` 的 `fromObjectSchema` 已经是同一个「对象字段 → 运行时 FormField」映射的第三份实现(它带三条 ADR-0036 规则,不带 `group`)。所以没有做「DrawerForm 补齐四键 + parity 钉」,而是:

- `sectionFields.ts` 导出 `fromObjectSchema`(纯导出,零行为改动);
- 新增 `packages/plugin-form/src/flatFields.ts`,`buildFlatFields` 在其上加一个 `group` 组成扁平路径的映射;
- `ModalForm` / `DrawerForm` 的 useEffect 各自换成一次 `buildFlatFields(...)` 调用,**依赖数组一字未动** —— 两个容器读的还是原来那几个值(`schema.recordId` / `schema.objectName` / `fieldLabel` 改动前后都被读、都不在依赖里),所以重跑时机与旧行为逐字相同。

包内因此只剩**一份**映射,由分区路径与扁平路径共用。下一次 widget arity(#3986)、create 模式 `required`(#4069)或 ADR-0036 的改动落一次即可覆盖所有容器 —— 这正是 issue 里「stop maintaining two hand-copied builders」的诉求。

`group` 为什么只加在 `buildFlatFields` 而不是 `fromObjectSchema`:它唯一的读者 `deriveFieldGroupSections` 只在扁平字段列表上跑,两个调用点(ObjectForm.tsx:909、ModalForm.tsx:258)在存在显式 sections 时都会跳过,放进 `fromObjectSchema` 只会给分区字段加一个没有读者的键。代码里写了这条理由。

## 钉子

`packages/plugin-form/src/flatFields.test.ts`(单元,6 例)
- 四个键各自被带上;
- **双向 parity 钉**:对每个字段,`buildFlatFields` 与 `normalizeSectionField` 的输出**逐键相等**,键集合只允许多出 `group`。任何一侧被重新分叉都先在这里红。

`packages/plugin-form/src/flatFieldRules.test.tsx`(容器级,Modal/Drawer 同一张 `describe.each`,12 例)
- `visibleWhen` 为假的字段不渲染、为真时渲染;
- `readonlyWhen` 为真时字段失去可编辑控件(该设计系统下锁定字段渲染为只读值展示,不是 disabled 输入框 —— 测试里注明了为何不断言 `readonly` 属性);
- `requiredWhen` 为真时 `aria-required` 与提交校验**两层**一致:空值拦提交(`create` 未被调用),填值后放行且 payload 带上该字段;为假时不拦。

modal 行是防回归(收敛后行为必须不变),drawer 行是本次修复;将来任一侧再分叉,表现为一个容器整片红、另一个全绿。

`requiredWhen` 与 PR #4760 的 serverOwnedValue 让位语义:构建器层不做任何判断,`requiredWhen` 原样带下去,create 模式的让位由下游 `resolveFieldRuleState` 统一裁决 —— 与分诊要求一致。

## 反向验证(先预判,后跑)

预判:把 DrawerForm 还原成修复前那份不带四键的内联循环(ModalForm 保持共享构建器),应当 **drawer 6 行里红 3 行**,即三条断言「规则确实生效」的用例;另外三条 FALSE 方向的用例**应当保持绿**,因为「谓词判假」与「谓词根本没送达」在 DOM 上完全同形,这三行本就区分不了该 bug。modal 6 行全绿,`flatFields.test.ts` 6 例全绿(它直接测共享构建器,不受容器层变异影响)。

实测与预判逐条吻合:

```
 Test Files  1 failed | 1 passed (2)
      Tests  3 failed | 15 passed (18)
 FAIL  ... DrawerForm — no-sections form honours field-level rules (#4755) > hides a `visibleWhen`-FALSE field and shows it when the predicate holds
 FAIL  ... DrawerForm — no-sections form honours field-level rules (#4755) > locks a `readonlyWhen`-TRUE field
 FAIL  ... DrawerForm — no-sections form honours field-level rules (#4755) > refuses the submit while a `requiredWhen` field is empty
```

变异已还原(`git checkout` 回本分支的提交),未提交。

## 消费半径扫描

改动只在 plugin-form 内部(`flatFields.ts` 不从 index 导出)。跨包只可能经 DrawerForm 的新增键影响到:枚举了仓内所有跑 drawer 表单的测试,与 `visibleWhen|readonlyWhen|requiredWhen` 取交集为空,无 fixture 需要改。

## 验证

- `pnpm exec vitest run packages/plugin-form/` → **45 files / 462 tests passed**
- `pnpm exec turbo run type-check --concurrency=2` → **81/81 successful**
- `check-control-bytes` / `check-changeset-presence` / `check-changeset-no-major` / `check-changeset-fixed` / `check-phantom-dependencies` / `check-lint-coverage` / `check-type-check-coverage` 全绿
- `eslint` 改动文件:0 error(仅既有的 `no-explicit-any` warning,与周边同型)
- changeset:`.changeset/drawer-flat-field-rules-4755.md`(patch,`@object-ui/plugin-form`)

## 超范围发现(已另立,未在本 PR 修)

issue 正文里 `group` 那段的因果写反了:`DrawerForm` 并不是「fallback 没东西可分组」,而是**根本没有 fallback** —— 全仓 `deriveFieldGroupSections` 只有 ObjectForm 与 ModalForm 两个调用点。本 PR 让 drawer 的运行时字段带上了 `group`(fallback 需要的输入已就位),缺的是调用点本身。已作为 #4774 单独立单(unassigned),不在本卡范围内修。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_