### PR TITLE
fix(types): DashboardWidgetSchema 不再把已退休的 responsive 重新声明为 any

### DIFF
--- a/.changeset/khaki-cars-attack.md
+++ b/.changeset/khaki-cars-attack.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/types': patch
+---
+
+`DashboardWidgetSchema`: stop re-typing the retired `responsive` key as `any`
+
+`dashboard.widgets[].responsive` was retired in `@objectstack/spec` 17.0.0-rc.6
+(objectstack#4876, ADR-0049 D2), and objectui's Zod twin — which derives every
+spec key by reference — has refused it ever since. The TypeScript interface did
+not follow: `responsive` was held out of the inherited key set by an `Omit` and
+re-declared as `any`, so one key was accepted by tsc and rejected by validation.
+
+Authoring `responsive` on a widget is now a tsc error, matching the Zod tombstone
+that already refuses it. The key inherits as `?: never`, the same way the four
+keys objectstack#5010 retired do.
+
+The `any` was deliberate and carried a written reason — that objectui's renderer
+reads a per-breakpoint record the spec's single object could not express.
+objectui#3173 measured that claim and it was false: there are no
+`widget.responsive` read points in the repo and no authored occurrences in either
+corpus, so nothing migrates. Breakpoint behaviour is unaffected — the shared
+`ResponsiveConfig` shape stays live on `page.components[].responsive`, which
+`useResponsiveConfig` really does read.

--- a/packages/types/src/__tests__/report-chart-query-spec-parity.test.ts
+++ b/packages/types/src/__tests__/report-chart-query-spec-parity.test.ts
@@ -41,6 +41,7 @@ import {
 import type { JoinedReportBlock as SpecJoinedReportBlock } from '@objectstack/spec/ui';
 import { AppContextSelectorSchema } from '../zod/app.zod.js';
 import { DashboardWidgetSchema, GlobalFilterSchema } from '../zod/complex.zod.js';
+import type { DashboardWidgetSchema as DashboardWidgetInterface } from '../complex.js';
 import {
   liftLegacyGlobalFilterDefault,
   liftLegacyDashboardFilterDefaults,
@@ -427,6 +428,68 @@ describe('DashboardWidgetSchema derives from the spec', () => {
         expect(result.error.issues.some((i) => i.path[0] === key)).toBe(true);
       }
     }
+  });
+
+  it('REFUSES `responsive`, retired separately by objectstack#4876', () => {
+    // Same inheritance mechanism as the four above, DIFFERENT retirement:
+    // `responsive` fell in @objectstack/spec 17.0.0-rc.6 under objectstack#4876
+    // (ADR-0049 D2), not rc.3's #5010 — so it carries its own tombstone text and
+    // gets its own case rather than a fifth entry in the loop above.
+    //
+    // objectui kept `responsive?: any` in `complex.ts` past that retirement, on
+    // the stated grounds that the renderer reads a per-breakpoint record.
+    // objectui#3173 measured it: zero `widget.responsive` read points, zero
+    // authored occurrences. The override was removed, so TS and Zod now agree.
+    const result = DashboardWidgetSchema.safeParse({
+      id: 'w1',
+      type: 'bar',
+      dataset: 'pipeline',
+      dimensions: ['stage'],
+      values: ['amount'],
+      responsive: { sm: { columns: 1 } },
+    });
+    expect(result.success, '`responsive` must be refused, not accepted').toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'responsive');
+      expect(issue, '`responsive` must be reported by name').toBeDefined();
+      // The tombstone names its own retirement, not #5010's — if this ever reads
+      // `#5010` the key was folded into the wrong retirement upstream.
+      expect(issue?.message).toContain('#4876, ADR-0049 D2');
+      // And it must point at the surviving home for breakpoint behaviour rather
+      // than just saying "removed".
+      expect(issue?.message).toContain('page.components[].responsive');
+    }
+  });
+
+  it('refuses `responsive` on the TypeScript interface too', () => {
+    // The Zod case above does NOT guard this change, and saying so is the point
+    // of splitting it out. Restoring `responsive?: any` to `complex.ts` leaves
+    // that case green: the Zod twin derives every key by reference, so it
+    // refused `responsive` from the moment rc.6 landed the tombstone and its
+    // verdict never depended on the interface. What objectui#3173 actually
+    // fixed is the TS half — the `Omit` that held `responsive` out of the
+    // inherited key set so tsc kept accepting a value validation rejects.
+    //
+    // So the guard for it is this directive, not an `expect`. Per this
+    // package's `type-check` (`tsc -p tsconfig.test.json` compiles every test
+    // file), putting `responsive` back makes the directive unused and fails
+    // the build — the same enforcement `accordion-item-authorable-keys.test.ts`
+    // relies on. Measured both ways on objectui#3173's branch: with the fix,
+    // `error TS2322: Type '{ sm: { columns: number; }; }' is not assignable to
+    // type 'undefined'`; with `responsive?: any` restored, tsc is silent.
+    const widget: DashboardWidgetInterface = {
+      id: 'w1',
+      type: 'bar',
+      // @ts-expect-error `responsive` is retired (objectstack#4876, ADR-0049
+      // D2) and inherits as `?: never`. Excess-property checking on this
+      // literal is what carries the retirement to authors writing TypeScript,
+      // who would otherwise meet it only at validation time.
+      responsive: { sm: { columns: 1 } },
+    };
+
+    // The runtime assertion is incidental — the contract lives in the directive
+    // above, which only compiles while the key is absent from the interface.
+    expect(widget.id).toBe('w1');
   });
 });
 

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -674,7 +674,7 @@ export interface DashboardWidgetLayout {
  * Drift guard: `__tests__/report-chart-query-spec-parity.test.ts`.
  */
 export interface DashboardWidgetSchema
-  extends Omit<Partial<SpecDashboardWidget>, 'type' | 'options' | 'chartConfig' | 'filter' | 'responsive'> {
+  extends Omit<Partial<SpecDashboardWidget>, 'type' | 'options' | 'chartConfig' | 'filter'> {
   // `id`, `title`, `description`, `colorVariant`, `dataset`, `dimensions`,
   // `values`, `filterBindings`, `requiresObject`, `requiresService`,
   // `compareTo`, … all flow in from the spec through the `extends` above — do
@@ -689,6 +689,17 @@ export interface DashboardWidgetSchema
   // panel kept producing `actionUrl` until objectstack#7129. A dashboard
   // widget's click-through affordance lives in `header.actions[]`, whose own
   // `actionUrl` is unrelated and still live.
+  //
+  // `responsive` inherits the same way, from a SEPARATE retirement:
+  // @objectstack/spec 17.0.0-rc.6 (objectstack#4876, ADR-0049 D2) — so its
+  // tombstone message differs from the four above. It was re-typed `any` here
+  // on the stated grounds that "the renderer reads a per-breakpoint record";
+  // objectui#3173's measurement found zero `widget.responsive` read points in
+  // the whole repo and zero authored occurrences in either corpus, so that
+  // premise was false and the override only made TS accept a key the Zod twin
+  // already refused. The shared `ResponsiveConfig` shape is NOT gone — it
+  // stays live on `page.components[].responsive`, which `useResponsiveConfig`
+  // really does read.
   // Pinned by `__tests__/report-chart-query-spec-parity.test.ts`.
   /** Component schema (legacy format) — objectui-only, no spec counterpart. */
   component?: SchemaNode;
@@ -709,12 +720,6 @@ export interface DashboardWidgetSchema
    * FilterNode array here, not the spec's `FilterCondition` envelope.
    */
   filter?: any;
-  /**
-   * Responsive configuration per breakpoint. Kept `any` — the renderer reads a
-   * per-breakpoint record, which the spec's single `responsive` object does not
-   * model; converging the two is deferred.
-   */
-  responsive?: any;
   /**
    * Enable search input for table-type widgets. objectui-only — no spec counterpart.
    * @default false


### PR DESCRIPTION
Fixes #3173

按本卡 2026-08-16 的 **「PM 裁定·测量回贴」** 评论执行（objectstack-ai/objectui#3173 (comment) — https://github.com/objectstack-ai/objectui/issues/3173#issuecomment-5305770098 ）：卡上原本的三条出路（spec 改按断点建模 / objectui 收敛到单对象 / 确认为两层词汇）**全部作废**，因为它们共同的前提被测量证伪；实际要做的是**选项 4：退休跟进**。

## 前提为什么作废

卡正文说「objectui 渲染器读按断点的 record，spec 建模单个对象，两者结构不同」。测量结果：

1. 全仓**零个** `widget.responsive` 读点。dashboard 链上的 `.responsive` 命中全是 CSS 布局注释；唯二的真实命中是 `WidgetCapabilities.responsive`（一个 boolean 能力开关）和 `page.components[].responsive`（另一个键，仍然活着）。前提疑似把 `page.components[].responsive` 的形状误载到了 widget 名下。
2. 两仓语料**两种形态均零书写**，存量迁移量为 0。
3. spec 侧今天既不是「单对象」也不是别的形状，而是**墓碑**：objectstack#4876（ADR-0049 D2）把 `dashboard.widgets[].responsive` 整键退休，已随本仓现锁的 `@objectstack/spec@17.0.0-rc.6` 生效。

所以卡正文「`objectui validate` 对 responsive 里的任何内容都放行」今天也已不成立 —— 本仓 Zod 孪生按引用派生，rc.6 落地那一刻起就在拒收该键。

## 剩下的唯一缺陷

`packages/types/src/complex.ts` 的 TS 接口没有跟上：`responsive` 被 `Omit` 列表挡在继承之外、并重新声明为 `any`。同一个键因此 **tsc 放行、Zod 拒收**。

本 PR 把 `'responsive'` 移出 `Omit` 列表、删除 `any` 声明及其理由注释（该注释陈述的「渲染器读按断点 record」正是被证伪的那句），让它像 objectstack#5010 退休的四个键一样自然继承为 `?: never`。**无需 pin-bump，无需 spec 改动。**

## 反向验证：非标准方向，照裁定执行

裁定评论已声明方向，这里**不套**「改前绿、改后红」模板 —— 那个模板在本改动上是错的。

变异 = 把 `'responsive'` 加回 `Omit` 列表 + 恢复 `responsive?: any`。预判与实测一致：

| 观测面 | 改前（= 变异后） | 改后（本 PR） |
|:--|:--|:--|
| Zod / `safeParse` | **红** | **红**（不变） |
| tsc 对 `widget.responsive = {...}` 的赋值 | **放行** | **报错** |

Zod 侧改前改后都红，因为孪生按引用派生，它的判决从来不依赖 TS 接口。**可观测差异全部在 TS 侧。**

实测（临时探针文件，验证后已删除，不入仓）：

- 修复后 —— `error TS2322: Type '{ sm: { columns: number; }; }' is not assignable to type 'undefined'`
- 恢复 `responsive?: any` 后 —— tsc 静默无输出

## 因此 pin 分两半，守的不是同一件事

这一点值得写下来，否则下一个读者会以为那条 Zod 断言守住了本次改动 —— 它没有。

- **Zod 半边**（`report-chart-query-spec-parity.test.ts` 的 REFUSES 区）：单独一个 case，不是并进 #5010 那个四键循环，因为**墓碑消息不同** —— 本键的消息含 `#4876, ADR-0049 D2`，断言按实测消息原文写。它守的是**上游不要把该键并进错误的退休批次**、以及消息继续指向幸存的 `page.components[].responsive`。把 `any` 恢复回去，这条**仍然绿**。
- **TS 半边**：一条 `@ts-expect-error`。本包 `type-check` 跑 `tsc -p tsconfig.test.json`（编译每个测试文件），所以这条指令是**真实执行**而非装饰 —— 与 `accordion-item-authorable-keys.test.ts` 依赖的是同一个机制。实测变异后：`error TS2578: Unused '@ts-expect-error' directive.` 守住本次改动的是它。

## 验证

- `pnpm exec vitest run packages/types --maxWorkers=2` —— 36 files / **428 passed**
- 仓根 `turbo run type-check --concurrency=2` —— **81/81 successful**。types 是全仓依赖根，这一遍同时证明了**没有任何下游包在写 `widget.responsive`**（若有会在这里现形），与测量结论一致。
- `node scripts/check-control-bytes.mjs` OK；`check:spec-symbol-derivation`、`changeset:check` OK；`--filter @object-ui/types lint` 0 errors。

changeset：`@object-ui/types` **patch** —— TS 表面由 `any` 变 `never` 是 user-visible。

## 顺带说明

断点能力**没有丢**：共享的 `ResponsiveConfig` 形状仍活在 `page.components[].responsive` 上，`useResponsiveConfig` 读的就是那个；墓碑消息本身也把作者指向那里。

两条超范围 finding（`useResponsiveConfig` 生产零调用者、`MobileComponentConfig` 零消费者）已按测量回贴另行归档，本 PR 不碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_