### PR TITLE
fix(components): 级联清值 effect 归一化字段类型,对象表单的带前缀 id 不再落空 (#4014)

### DIFF
--- a/.changeset/cascade-clear-normalize-prefixed-field-type.md
+++ b/.changeset/cascade-clear-normalize-prefixed-field-type.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/components': patch
+---
+
+The form's cascade clear now recognises object-form fields, so a narrowed option list no longer submits a stale value.
+
+`field:select` and `select` name the SAME field kind: the object-form path
+(`mapFieldTypeToFormType`) emits the prefixed widget id, hand-written SDUI
+schemas the bare one. The form host's cascade-clear effect (objectui#2284)
+compared the RAW type string against the bare-name set, so every option field
+coming from an OBJECT schema fell out of the effect entirely. Its controlling
+field could change, its option list narrow, and the no-longer-offered value was
+never dropped — the form submitted exactly the stale "china + california" pair
+the effect exists to prevent. Only genuinely cascading fields were affected
+(those carrying a `dependsOn` or a per-option `visibleWhen`); a plain picklist
+has nothing to recompute either way.
+
+The comparison now normalizes the type before the lookup, which is what the
+render path a few hundred lines below has done for `isOptionField` since
+objectui#3231 — the two readers of "is this an option field?" no longer
+disagree about what a `select` is. This half was the one missed then.
+
+Stated because it is a behavior change and not an equivalent refactor: the
+object-form path gains cascade clearing for the FIRST time. A form whose stored
+value is genuinely excluded by its chosen parent will now clear that value where
+it previously kept it. The narrowing is bounded by the rules already in place
+for the bare-name path, both of which the object path now inherits unchanged: a
+GATED list (a declared `dependsOn` parent still empty) is treated as unknown
+rather than invalid and never deletes anything (objectui#4247), and a field with
+no `dependsOn` and no per-option predicate is never recomputed at all.

--- a/packages/components/src/renderers/form/__tests__/form-cascade-clear-prefixed-type.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-cascade-clear-prefixed-type.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The form host's cascade clear recognises the PREFIXED widget id (objectui#4014).
+ *
+ * `field:select` and `select` name the same field kind: the object-form path
+ * (`mapFieldTypeToFormType`) emits the prefixed id, hand-written SDUI schemas
+ * the bare one. The cascade-clear effect (#2284) compared the RAW type string
+ * against the bare-name set, so every option field coming from an OBJECT schema
+ * fell out of the effect entirely — its parent could narrow the offered set and
+ * the now-unoffered value was never dropped, so the form submitted exactly the
+ * stale "china + california" pair the effect exists to prevent.
+ *
+ * This is a BEHAVIOUR CHANGE, not an equivalent refactor: the object-form path
+ * gains cascade clearing for the first time. The pins below are therefore
+ * written as POSITIVE assertions on the prefixed path (the parent narrows the
+ * set → the stale value is gone from the payload), with the bare-name path kept
+ * alongside as the unchanged control and a non-option field as the
+ * fail-open control.
+ *
+ * Same normalization the render path applies for `isOptionField` (objectui#3231,
+ * the first half of this family) — the two readers of "is this an option field?"
+ * must agree.
+ *
+ * These components tests never load `@object-ui/fields`, so `field:select` does
+ * not resolve to a registered widget here and renders through the fallback
+ * branch. That is deliberate and sufficient: the effect under test reads the
+ * FIELD CONFIG, not whatever component ends up rendering, and the submitted
+ * payload is the fact the issue is about. Nothing but `form.tsx`'s own effect
+ * can move a value in this environment.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module-scope import (not `beforeAll`) — objectui#3010.
+import '../../../renderers';
+
+function renderForm(schema: Record<string, unknown>) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(<Form schema={{ type: 'form', submitLabel: 'Save', ...schema }} />);
+}
+
+const PROVINCE_OPTIONS = [
+  { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+  { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+];
+
+/** What `mapFieldTypeToFormType` emits for an object schema's picklist fields. */
+const PREFIXED_FIELDS = [
+  { name: 'country', label: 'Country', type: 'input' },
+  {
+    name: 'province',
+    label: 'Province',
+    type: 'field:select',
+    dependsOn: 'country',
+    options: PROVINCE_OPTIONS,
+  },
+  {
+    name: 'provinces',
+    label: 'Provinces',
+    type: 'field:multiselect',
+    dependsOn: 'country',
+    options: PROVINCE_OPTIONS,
+  },
+  {
+    name: 'homeProvince',
+    label: 'Home province',
+    type: 'field:radio',
+    dependsOn: 'country',
+    options: PROVINCE_OPTIONS,
+  },
+  {
+    name: 'visited',
+    label: 'Visited',
+    type: 'field:checkboxes',
+    dependsOn: 'country',
+    options: PROVINCE_OPTIONS,
+  },
+];
+
+/** The hand-written-SDUI spelling of the same form — the unchanged control. */
+const BARE_FIELDS = PREFIXED_FIELDS.map((f) =>
+  typeof f.type === 'string' && f.type.startsWith('field:')
+    ? { ...f, type: f.type.slice('field:'.length) }
+    : f,
+);
+
+async function submitAndRead(onSubmit: ReturnType<typeof vi.fn>) {
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  return onSubmit.mock.calls[0][0] as Record<string, unknown>;
+}
+
+describe('form host cascade clear — prefixed widget ids are option fields too (#4014)', () => {
+  it('drops the values the CHOSEN parent no longer offers', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: PREFIXED_FIELDS,
+      // Parent IS chosen (so the list is resolved, not gated — #4247) and `ca`
+      // is a US province, genuinely excluded by `country == 'cn'`.
+      defaultValues: {
+        country: 'cn',
+        province: 'ca',
+        provinces: ['ca'],
+        homeProvince: 'ca',
+        visited: ['ca'],
+      },
+      onSubmit,
+    });
+
+    const payload = await submitAndRead(onSubmit);
+    expect(payload.province).toBeUndefined();
+    expect(payload.homeProvince).toBeUndefined();
+    expect(payload.provinces).toEqual([]);
+    expect(payload.visited).toEqual([]);
+  });
+
+  it('drops the stale value when the user NARROWS the set by changing the parent', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: PREFIXED_FIELDS,
+      // Starts consistent: `zj` is offered while country is `cn`.
+      defaultValues: {
+        country: 'cn',
+        province: 'zj',
+        provinces: ['zj'],
+        homeProvince: 'zj',
+        visited: ['zj'],
+      },
+      onSubmit,
+    });
+
+    // The user switches the parent to one whose list excludes the stored value.
+    fireEvent.change(screen.getByLabelText(/country/i), { target: { value: 'us' } });
+    await waitFor(() =>
+      expect((screen.getByLabelText(/country/i) as HTMLInputElement).value).toBe('us'),
+    );
+
+    const payload = await submitAndRead(onSubmit);
+    expect(payload.province).toBeUndefined();
+    expect(payload.homeProvince).toBeUndefined();
+    expect(payload.provinces).toEqual([]);
+    expect(payload.visited).toEqual([]);
+  });
+
+  it('keeps the values the chosen parent still offers', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: PREFIXED_FIELDS,
+      defaultValues: {
+        country: 'cn',
+        province: 'zj',
+        provinces: ['zj'],
+        homeProvince: 'zj',
+        visited: ['zj'],
+      },
+      onSubmit,
+    });
+
+    const payload = await submitAndRead(onSubmit);
+    expect(payload.province).toBe('zj');
+    expect(payload.homeProvince).toBe('zj');
+    expect(payload.provinces).toEqual(['zj']);
+    expect(payload.visited).toEqual(['zj']);
+  });
+
+  it('leaves a GATED prefixed list alone — gated is unknown, not invalid (#4247)', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: PREFIXED_FIELDS,
+      // Controlling field arrives empty: the whole list is withheld, which says
+      // nothing about the stored value. Reaching this effect at all is new for
+      // the prefixed path, so the #4247 ruling is pinned here too.
+      defaultValues: {
+        country: '',
+        province: 'zj',
+        provinces: ['zj'],
+        homeProvince: 'zj',
+        visited: ['zj'],
+      },
+      onSubmit,
+    });
+
+    const payload = await submitAndRead(onSubmit);
+    expect(payload.province).toBe('zj');
+    expect(payload.homeProvince).toBe('zj');
+    expect(payload.provinces).toEqual(['zj']);
+    expect(payload.visited).toEqual(['zj']);
+  });
+});
+
+describe('control — the bare-name (hand-written SDUI) path is unchanged', () => {
+  it('still drops the values the chosen parent no longer offers', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: BARE_FIELDS,
+      defaultValues: {
+        country: 'cn',
+        province: 'ca',
+        provinces: ['ca'],
+        homeProvince: 'ca',
+        visited: ['ca'],
+      },
+      onSubmit,
+    });
+
+    const payload = await submitAndRead(onSubmit);
+    expect(payload.province).toBeUndefined();
+    expect(payload.homeProvince).toBeUndefined();
+    expect(payload.provinces).toEqual([]);
+    expect(payload.visited).toEqual([]);
+  });
+
+  it('still keeps the values the chosen parent offers', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: BARE_FIELDS,
+      defaultValues: {
+        country: 'cn',
+        province: 'zj',
+        provinces: ['zj'],
+        homeProvince: 'zj',
+        visited: ['zj'],
+      },
+      onSubmit,
+    });
+
+    const payload = await submitAndRead(onSubmit);
+    expect(payload.province).toBe('zj');
+    expect(payload.provinces).toEqual(['zj']);
+  });
+});
+
+describe('control — normalization does not widen the effect to non-option fields', () => {
+  it('never touches a prefixed NON-option field that declares dependsOn', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: [
+        { name: 'country', label: 'Country', type: 'input' },
+        {
+          // A `field:`-prefixed type whose bare name is NOT in the cascade set.
+          // Normalizing the comparison must not sweep it in: its value carries
+          // no relation to the option list beside it.
+          name: 'note',
+          label: 'Note',
+          type: 'field:text',
+          dependsOn: 'country',
+          options: PROVINCE_OPTIONS,
+        },
+      ],
+      defaultValues: { country: 'cn', note: 'ca' },
+      onSubmit,
+    });
+
+    const payload = await submitAndRead(onSubmit);
+    expect(payload.note).toBe('ca');
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -921,13 +921,19 @@ ComponentRegistry.register('form',
         const name = f?.name;
         if (!name) continue;
         const resolvedType = (f as any).widget || f.type;
-        if (
-          resolvedType !== 'select' &&
-          resolvedType !== 'radio' &&
-          resolvedType !== 'multiselect' &&
-          resolvedType !== 'checkboxes'
-        )
-          continue;
+        // `field:select` and `select` name the SAME field kind, so this clear
+        // must recognise both spellings — the object-form path
+        // (`mapFieldTypeToFormType`) emits the prefixed id, hand-written SDUI
+        // schemas the bare one. Comparing the RAW string recognised only the
+        // bare form, so every option field coming from an object schema fell
+        // out of this effect entirely: its parent could narrow the offered set
+        // and the stale value was never dropped, submitting the "china +
+        // california" pair this effect exists to prevent (objectui#4014).
+        // `normalizeFieldType` + the shared set is exactly what the render path
+        // below already does for `isOptionField` (objectui#3231) — the two
+        // readers of "is this an option field?" must not disagree.
+        if (typeof resolvedType !== 'string') continue;
+        if (!CASCADE_OPTION_FIELD_TYPES.has(normalizeFieldType(resolvedType))) continue;
         const opts = (f as any).options as SelectOption[] | undefined;
         if (!opts || opts.length === 0) continue;
         const dependsOn = f.dependsOn;


### PR DESCRIPTION
Fixes #4014

## 前提核验(立卡后 form.tsx 被多次改过,行号已漂移)

机制**仍在**,原样存活。旧锚 `:944` 现漂到 `packages/components/src/renderers/form/form.tsx:923`:

```
const resolvedType = (f as any).widget || f.type;
if (
  resolvedType !== 'select' &&
  resolvedType !== 'radio' &&
  resolvedType !== 'multiselect' &&
  resolvedType !== 'checkboxes'
)
  continue;
```

RAW 字符串与裸名逐一比对,未过 `normalizeFieldType`。同文件渲染路径的
`isOptionField` 已在 #3231 里修成 `CASCADE_OPTION_FIELD_TYPES.has(normalizeFieldType(resolvedType))`(现 `:1568`)—— 正如 issue 所述,这是漏掉的第二处。

生产可达性也已坐实,不只是理论落空:`packages/plugin-form/src/sectionFields.ts:206`
把 `base.type` 赋成 `mapFieldTypeToFormType(rawType, …)`(即 `field:select`),
而 `:226` 把 `base.dependsOn` 挂在**同一个** field 对象上 —— 一个真实的级联对象表单
正好落进这条死分支。

## 修法

比对先过 `normalizeFieldType` 再查共享集合 `CASCADE_OPTION_FIELD_TYPES`(只消费,
未动 `:253` 的定义)。另加一条 `typeof resolvedType !== 'string'` 守卫:原先四次
`!==` 比较对 `undefined` 是安全的,`normalizeFieldType` 的 `startsWith` 不是。

## 行为变化(非等价重构)

对象表单路径**首次**获得级联清值。收敛边界沿用裸名路径既有的两条规则,对象路径原样继承:

- 被 gate 的列表(已声明的 `dependsOn` 父字段仍为空)视为「未知」而非「非法」,绝不删值(#4247);
- 既无 `dependsOn` 也无 per-option `visibleWhen` 的字段完全不参与重算 —— 普通 picklist 两边都无事发生。

## 钉子

新增 `packages/components/src/renderers/form/__tests__/form-cascade-clear-prefixed-type.test.tsx`(7 例),四种前缀类型 `field:select` / `field:multiselect` / `field:radio` / `field:checkboxes` 全覆盖:

- **正向**(2 例):父值已选且旧值被排除 → 清;用户改父值致选项集**收窄** → 清。
- **前缀路径守卫**(2 例):仍被提供的值保留;被 gate 的列表不删值(#4247)。
- **裸名路径对照**(2 例,手写 SDUI):既有行为逐字不变。
- **非选项字段对照**(1 例):带前缀但裸名不在集合内的 `field:text`,即便声明了 `dependsOn` 也绝不被扫进来 —— 归一化不得放宽 effect 的适用面。

## 反向验证(先预判后跑)

预判:撤掉 normalize → 两条**正向**断言转红;两条前缀守卫因两边都不清值而保持绿(它们是过度清值的护栏,只有修复后才真正带电);裸名与非选项对照保持绿。

实跑与预判逐字吻合 —— `2 failed | 5 passed`:

```
× drops the values the CHOSEN parent no longer offers
× drops the stale value when the user NARROWS the set by changing the parent
AssertionError: expected 'ca' to be undefined
AssertionError: expected 'zj' to be undefined
```

`expected 'ca' to be undefined` 即 issue 正文「可脏值提交」的逐字复现。已还原,未提交该状态。

诚实标注:两条前缀守卫例在反向验证下**不动**,按设计如此 —— 修复前该路径根本进不了
effect,断言是「因为什么都没发生」而绿;修复后它才真正读到 gate 分支。它们是新增的
带电护栏,不是本次方向性证据。

## 验证

| 项 | 结果 |
| --- | --- |
| `vitest run packages/components` | `137 passed (137)` / `1184 passed (1184)` |
| `vitest run packages/fields packages/plugin-form`(消费半径扫尾) | `140 passed (140)` / `1927 passed (1927)` |
| `turbo run type-check --filter=@object-ui/components` | `9 successful, 9 total`,exit 0 |
| `node scripts/check-control-bytes.mjs` | OK(4295 文件) |

消费半径按「规则被谁跑」而非「改了哪个包」枚举:跨包 grep 出同时含前缀选项类型与
`dependsOn` / `visibleWhen` 的 fixture,落在 `fields` 与 `plugin-form`,已一并跑绿。

## 边界

未动 `:253` 的 `CASCADE_OPTION_FIELD_TYPES` 定义(#4770 收敛单另管,此处只消费)、
未动 `custom/filter-builder.tsx`(#4768)、未动 `plugin-form`(#4774)。

已加 changeset(`@object-ui/components` patch);未动 `content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_