### PR TITLE
fix(app-shell): modal target 拒绝诊断三处统一到一个构造器 (#4767)

### DIFF
--- a/.changeset/unify-modal-target-refusal-diagnostic.md
+++ b/.changeset/unify-modal-target-refusal-diagnostic.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The "modal target names no page" diagnostic is one message again, on all three surfaces
+
+A `type: 'modal'` action whose string `target` names no page is refused on three
+surfaces — `useActionModal.modalHandler` (the ActionProvider `onModal` path),
+`useConsoleActionRuntime.modalActionHandler` (list pages, SDUI pages, the
+declared-actions bar) and `RecordDetailView.modalActionHandler` (the record
+page). Each spelled the refusal itself, and they drifted.
+
+PR #4764 retired the object fallback (a modal target names a PAGE, only —
+maintainer ruling on objectstack#6739) and rewrote the wording in
+`useActionModal`, so it names the refused target and points at `type: 'form'`,
+the validated way to open an object's form. The other two — the ones a console
+user actually reaches — kept the pre-retirement text: the target "names no page
+or object to open", with `type: 'script'` as the only way out. The "or object"
+half described a limb that no longer exists, and the replacement capability was
+never mentioned, so the surfaces most likely to be read were the ones giving the
+worst advice.
+
+All three now build the message from one constructor
+(`utils/modalTargetDiagnostics`). Every variant names the refused target and
+points at `type: 'form'`; the console runtimes additionally keep the
+`type: 'script'` + `params` hint, which answers a different authoring intent
+(collect input, then run a handler) and rides alongside the form pointer rather
+than replacing it. `modalHandler`'s message is byte-identical to what PR #4764
+settled on — this is a de-duplication, not a rewording — and that byte-equality
+is pinned by a test, as is each call site's use of the shared source.
+
+These are hard-coded English authoring diagnostics on all three surfaces, before
+and after: they name a metadata key and a spec type and are read by whoever
+wrote the action. Translating them is a separate decision; this change only
+stops the English from disagreeing with itself.

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -81,6 +81,7 @@ vi.mock('sonner', () => {
 
 import { toast } from 'sonner';
 import { useConsoleActionRuntime, ConsoleActionRuntimeProvider } from '../useConsoleActionRuntime';
+import { modalTargetRefusalMessage } from '../../utils/modalTargetDiagnostics';
 import { useAction, usePageVariables, PageVariablesProvider, PageVariableActionBridge } from '@object-ui/react';
 
 beforeEach(() => {
@@ -509,8 +510,10 @@ describe('useConsoleActionRuntime — authenticated handlers', () => {
  * framework#3530 — `type: 'modal'` used to be wired straight to
  * `serverActionHandler` here, while RecordDetailView opened modals client-side.
  * The same button therefore did two different things depending on which surface
- * mounted it. Both now run this rule: render `target` when it names a page (or
- * object), else complete the action server-side.
+ * mounted it. Both now run this rule: render `target` when it names a page —
+ * only a page, since PR #4764 retired the object fallback — else report the
+ * authoring error (objectstack#3959 removed the server-side fallthrough this
+ * comment used to describe; the wording is shared as of objectui#4767).
  */
 describe('modalActionHandler — a modal action is CLIENT-SIDE ONLY (objectstack#3959)', () => {
   it('opens the resolved target client-side and never POSTs to /actions', async () => {
@@ -552,7 +555,18 @@ describe('modalActionHandler — a modal action is CLIENT-SIDE ONLY (objectstack
     expect(r.success).toBe(false);
     // The message must name the action, the dud target, and the way out.
     expect(String(r.error)).toContain('log_call');
-    expect(String(r.error)).toMatch(/type:'script' with params/);
+    expect(String(r.error)).toMatch(/`type: 'script'` with `params`/);
+    // objectui#4767 — and it must say the SAME thing the other two surfaces
+    // say. This copy was hand-written and went stale when PR #4764 retired the
+    // object fallback: it kept offering "no page or object" and never named
+    // `type: 'form'`, the capability the retirement handed authors instead.
+    expect(String(r.error)).toContain("type: 'form'");
+    expect(String(r.error)).not.toMatch(/or object/);
+    // Byte-equality with the shared constructor, so re-inlining the string
+    // here (the exact mistake #4767 records) fails rather than drifts.
+    expect(String(r.error)).toBe(
+      modalTargetRefusalMessage({ actionName: 'log_call', target: 'log_call', serverHandlerHint: true }),
+    );
   });
 
   it('prefers an inline `modal` descriptor over `target`', async () => {

--- a/packages/app-shell/src/hooks/useActionModal.tsx
+++ b/packages/app-shell/src/hooks/useActionModal.tsx
@@ -51,6 +51,7 @@ import {
 import { SchemaRenderer, useMetadata } from '@object-ui/react';
 import { ModalForm } from '@object-ui/plugin-form';
 import { resolveFormViewLayout } from '../utils/recordFormNavigation';
+import { modalTargetRefusalMessage } from '../utils/modalTargetDiagnostics';
 
 type Placement = 'center' | 'side' | 'bottom' | 'fullscreen';
 type ModalSize = 'sm' | 'default' | 'lg' | 'xl' | 'full';
@@ -217,13 +218,13 @@ export function useActionModal(dataSource?: any) {
       const d = await resolveModalTarget(schema);
       if (!d) {
         const name = normalizeModalSchema(schema).targetName;
-        return {
-          success: false,
-          error: name
-            ? `Modal target "${name}" names no page — a modal action's \`target\` names a PAGE, only. ` +
-              `To open an object's form, use \`type: 'form'\` with an \`<object>.<view>\` target.`
-            : 'Modal action has no target to open.',
-        };
+        // Wording lives in `utils/modalTargetDiagnostics` — the SAME source the
+        // console runtimes' `modalActionHandler` reads. This message was
+        // rewritten by PR #4764 while the two copies a console user actually
+        // reaches kept the pre-retirement text; objectui#4767 collapsed all
+        // three onto one constructor so the next contract change lands
+        // everywhere at once. Byte-identical to what #4764 settled on.
+        return { success: false, error: modalTargetRefusalMessage({ target: name }) };
       }
       return new Promise<ActionResult>((resolve) => {
         setState({ d, resolve });

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -51,6 +51,7 @@ import { entitlementDialogFromError, type EntitlementDialogSpec } from '../envir
 import { resolvePageVarTokens } from '../utils/resolvePageVarTokens';
 import { interpretFlowResponse } from '../utils/flowResponse';
 import { createConsoleServerActionHandler } from '../utils/consoleServerAction';
+import { modalTargetRefusalMessage } from '../utils/modalTargetDiagnostics';
 
 const FALLBACK_USER = { id: 'current-user', name: 'Demo User', isPlatformAdmin: false };
 
@@ -588,6 +589,15 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
    * An unresolvable target is now reported as what it is. To collect input and
    * then run server-side, declare `type: 'script'` with `params`: the runner
    * collects the same dialog and the handler runs with those values.
+   *
+   * The refusal WORDING is built by `utils/modalTargetDiagnostics`, shared with
+   * `RecordDetailView.modalActionHandler` and `useActionModal.modalHandler`.
+   * All three used to spell it here, and drifted: PR #4764 retired the object
+   * fallback and rewrote only `useActionModal`'s copy, leaving this one — the
+   * one console users actually read — saying the target names "no page or
+   * object" and never mentioning `type: 'form'`, the replacement the
+   * retirement handed authors (objectui#4767). Change the contract there, not
+   * here.
    */
   const modalActionHandler = useCallback(async (action: ActionDef, _context?: ActionContext): Promise<ActionResult> => {
     const schema = (action as any).modal ?? action.target ?? (action as any).params?.schema;
@@ -595,10 +605,11 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     if (descriptor) return modalHandler(descriptor);
     return {
       success: false,
-      error:
-        `Action "${action.name}" is type:'modal' but its target ` +
-        `${schema != null ? `"${String(schema)}" ` : ''}names no page or object to open. ` +
-        `Point it at a page, or use type:'script' with params to collect input and run a handler.`,
+      error: modalTargetRefusalMessage({
+        actionName: action.name,
+        target: schema,
+        serverHandlerHint: true,
+      }),
     };
   }, [resolveModalTarget, modalHandler]);
 

--- a/packages/app-shell/src/utils/__tests__/modalTargetDiagnostics.test.ts
+++ b/packages/app-shell/src/utils/__tests__/modalTargetDiagnostics.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4767 — the modal-target refusal is ONE message, built once.
+ *
+ * PR #4764 retired the object fallback (`type: 'modal'` targets a page, only)
+ * and rewrote `useActionModal.modalHandler`'s diagnostic to name the refused
+ * target and point at `type: 'form'`. The two copies a console user actually
+ * reaches — `useConsoleActionRuntime.modalActionHandler` and
+ * `RecordDetailView.modalActionHandler` — were hand-written duplicates and kept
+ * the pre-retirement text: "names no page or object to open", pointing only at
+ * `type: 'script'`. The "or object" half described a limb that no longer
+ * existed, and the replacement capability was never mentioned.
+ *
+ * These pin the CONTENT contract of the shared constructor; the two runtime
+ * call sites are pinned in `useConsoleActionRuntime.test.tsx` and
+ * `RecordDetailView.modalDispatch.test.tsx`, and `modalHandler`'s in
+ * `useActionModal.resolve.test.tsx`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { modalTargetRefusalMessage } from '../modalTargetDiagnostics';
+
+describe('modalTargetRefusalMessage — every variant carries the same contract', () => {
+  // The bare-target form is what `useActionModal.modalHandler` emits. Asserted
+  // as an EXACT string because PR #4764 settled this wording and objectui#4767
+  // is a de-duplication, not a rewording: if extracting the constructor changed
+  // even a byte of what #4764 shipped, that is a regression, not a cleanup.
+  it('reproduces PR #4764\'s modalHandler message byte for byte', () => {
+    expect(modalTargetRefusalMessage({ target: 'contact' })).toBe(
+      'Modal target "contact" names no page — a modal action\'s `target` names a PAGE, only. ' +
+        "To open an object's form, use `type: 'form'` with an `<object>.<view>` target.",
+    );
+  });
+
+  it('names the ACTION as well as the target when the caller knows it', () => {
+    const msg = modalTargetRefusalMessage({ actionName: 'log_call', target: 'schedule_followup' });
+    expect(msg).toContain('Action "log_call"');
+    expect(msg).toContain('"schedule_followup"');
+    expect(msg).toContain('names no page');
+  });
+
+  // The three facts objectui#4767 found missing from the console copies. Every
+  // variant that has a target to talk about must carry all three.
+  it.each([
+    ['bare target', { target: 'schedule_followup' }],
+    ['with action name', { actionName: 'log_call', target: 'schedule_followup' }],
+    ['console variant', { actionName: 'log_call', target: 'schedule_followup', serverHandlerHint: true }],
+  ])('%s: names the target, points at type: form, and never says "or object"', (_label, options) => {
+    const msg = modalTargetRefusalMessage(options);
+    expect(msg).toContain('schedule_followup');
+    expect(msg).toContain("type: 'form'");
+    expect(msg).not.toMatch(/or object/);
+    // The retired limb, in every spelling the old copies used.
+    expect(msg).not.toMatch(/no page or object/);
+  });
+
+  // The console runtimes keep the second way out — collect input, then run a
+  // handler — because a target that names nothing at all is just as likely an
+  // author who wanted a scripted dialog as one who wanted a form. It rides
+  // ALONGSIDE the form pointer now instead of replacing it.
+  it('appends the server-handler hint only when asked', () => {
+    const withHint = modalTargetRefusalMessage({ target: 'x', serverHandlerHint: true });
+    const without = modalTargetRefusalMessage({ target: 'x' });
+
+    expect(withHint).toContain("type: 'script'");
+    expect(withHint).toContain("type: 'form'");
+    expect(without).not.toContain("type: 'script'");
+    // The hint is additive: everything the plain form says, the console form
+    // says too. This is what keeps "unified" true as the contract changes.
+    expect(withHint.startsWith(without)).toBe(true);
+  });
+
+  // A missing target is a DIFFERENT authoring mistake ("declare one") from a
+  // target that resolves to nothing ("declare a different one"), so it gets no
+  // contract sentence to hang a name on. PR #4764 pinned this exact string.
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+  ])('reports a missing target (%s) distinctly, with no contract tail', (_label, target) => {
+    expect(modalTargetRefusalMessage({ target })).toBe('Modal action has no target to open.');
+    expect(modalTargetRefusalMessage({ target, actionName: 'log_call' })).toBe(
+      'Action "log_call" is type:\'modal\' but has no target to open.',
+    );
+    expect(modalTargetRefusalMessage({ target, serverHandlerHint: true })).not.toContain('script');
+  });
+
+  it('defaults to the missing-target message when called with nothing', () => {
+    expect(modalTargetRefusalMessage()).toBe('Modal action has no target to open.');
+  });
+
+  // The console call sites pass `action.modal ?? action.target ?? …` straight
+  // through, which can be an inline descriptor OBJECT. The pre-extraction code
+  // stringified it the same way; preserved so a non-string target still names
+  // something rather than crashing or silently becoming the missing-target case.
+  it('stringifies a non-string target rather than treating it as absent', () => {
+    const msg = modalTargetRefusalMessage({ target: { objectName: 'contact' }, actionName: 'a' });
+    expect(msg).toContain('[object Object]');
+    expect(msg).toContain('names no page');
+  });
+});

--- a/packages/app-shell/src/utils/modalTargetDiagnostics.ts
+++ b/packages/app-shell/src/utils/modalTargetDiagnostics.ts
@@ -1,0 +1,105 @@
+/**
+ * The ONE source of the "this modal target does not resolve" diagnostic.
+ *
+ * Three surfaces refuse a `type: 'modal'` action whose string `target` names no
+ * page, and each used to spell the refusal itself:
+ *
+ * - `hooks/useActionModal.tsx` — `modalHandler`, the ActionProvider `onModal`
+ *   path;
+ * - `hooks/useConsoleActionRuntime.tsx` — `modalActionHandler`, what a list
+ *   page / SDUI page / declared-actions bar dispatches through;
+ * - `views/RecordDetailView.tsx` — `modalActionHandler`, the record page's own
+ *   copy of the same rule.
+ *
+ * They drifted (objectui#4767). PR #4764 retired the object fallback and
+ * rewrote only the FIRST one, so the two a console user actually reaches kept
+ * saying the target "names no page or object to open" and pointed at
+ * `type: 'script'` — the "or object" half describing a limb that no longer
+ * exists, and no mention of `type: 'form'`, which is the replacement the
+ * retirement handed authors. Three hand-written copies of one fact is a fact
+ * that goes stale two-thirds of the time; this module makes it one.
+ *
+ * The refusal itself is decided by the callers (each already knows whether
+ * `resolveModalTarget` returned `null`) — this module only says it. Keeping the
+ * wording here and the judgement there is deliberate: a message helper that
+ * also decided would be a fourth place to disagree about the contract.
+ *
+ * Not i18n'd, on purpose and unchanged by this module: all three sites emit
+ * hard-coded English today. These are AUTHORING diagnostics — they name a
+ * metadata key and a spec type and are read by whoever wrote the action, not by
+ * an end user in their own language. Translating them is a separate decision
+ * with its own card; this module only stops the English from disagreeing with
+ * itself.
+ */
+
+/**
+ * What a modal `target` IS, plus the validated way to do the thing the retired
+ * object fallback used to do.
+ *
+ * Verbatim from PR #4764's `modalHandler` message (maintainer ruling on
+ * objectstack#6739): a `type: 'modal'` action's string `target` names a PAGE,
+ * only. The spec TSDoc (`packages/spec/src/ui/action.zod.ts`), the published
+ * docs (`content/docs/ui/actions.mdx`) and `defineStack`'s cross-reference walk
+ * (`packages/spec/src/stack.zod.ts`) all agree, and the walk REJECTS a
+ * registered modal action whose target is not a declared page.
+ *
+ * Opening an object's form from an action is `type: 'form'` with an
+ * `object.view` FORM-view target — the same capability, validated end-to-end.
+ */
+const MODAL_TARGET_CONTRACT =
+  "a modal action's `target` names a PAGE, only. " +
+  "To open an object's form, use `type: 'form'` with an `<object>.<view>` target.";
+
+/**
+ * The other way out, for the author who wanted to collect input and then run
+ * something server-side rather than to open a form.
+ *
+ * Only the console runtimes offer it, because only they sit on the dispatch
+ * path a `type: 'script'` action would take instead (objectstack#3959 removed
+ * the server fallthrough that used to swallow this case silently).
+ */
+const SERVER_HANDLER_HINT =
+  "Or use `type: 'script'` with `params` to collect input and run a handler.";
+
+export interface ModalTargetRefusalOptions {
+  /**
+   * The refused target, exactly as authored. `undefined`/`null`/`''` means the
+   * action carried no target at all — a distinct authoring mistake, reported
+   * distinctly.
+   */
+  target?: unknown;
+  /**
+   * The action's `name`, when the caller has one. The console runtimes dispatch
+   * a whole `ActionDef` and can say WHICH button misbehaved; `modalHandler` is
+   * handed the bare target and cannot.
+   */
+  actionName?: string;
+  /** Append {@link SERVER_HANDLER_HINT}. The console runtimes pass `true`. */
+  serverHandlerHint?: boolean;
+}
+
+/**
+ * Build the refusal message for a modal target that resolved to no page.
+ *
+ * Every variant carries the same two facts — the refused target by name, and
+ * `type: 'form'` as the way to open an object's form — because those are what
+ * objectui#4767 found missing from the copies users actually read.
+ */
+export function modalTargetRefusalMessage(options: ModalTargetRefusalOptions = {}): string {
+  const { target, actionName, serverHandlerHint } = options;
+  const name = target == null ? '' : String(target);
+
+  if (!name) {
+    // No target to name, so no contract sentence to attach it to: the fix is
+    // "declare one", not "declare a different one".
+    return actionName
+      ? `Action "${actionName}" is type:'modal' but has no target to open.`
+      : 'Modal action has no target to open.';
+  }
+
+  const lead = actionName
+    ? `Action "${actionName}" is type:'modal' but its target "${name}" names no page`
+    : `Modal target "${name}" names no page`;
+
+  return `${lead} — ${MODAL_TARGET_CONTRACT}${serverHandlerHint ? ` ${SERVER_HANDLER_HINT}` : ''}`;
+}

--- a/packages/app-shell/src/views/RecordDetailView.modalDispatch.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.modalDispatch.test.tsx
@@ -119,6 +119,7 @@ vi.mock('@object-ui/react', async (importOriginal) => {
 
 import { MetadataCtx } from '@object-ui/react';
 import { RecordDetailView } from './RecordDetailView';
+import { modalTargetRefusalMessage } from '../utils/modalTargetDiagnostics';
 
 const OBJECT_NAME = 'crm_call';
 const RECORD_ID = 'rec-call-1';
@@ -260,6 +261,16 @@ describe("RecordDetailView modal dispatch — CLIENT-SIDE ONLY (objectstack#3959
     // the same copy the shared runtime reports, so the two surfaces cannot
     // drift apart silently again.
     expect(String(r.error)).toContain('log_call');
-    expect(String(r.error)).toMatch(/type:'script' with params/);
+    expect(String(r.error)).toMatch(/`type: 'script'` with `params`/);
+    // objectui#4767 — "cannot drift apart silently again" was aspirational
+    // until now: the two copies were hand-written, and PR #4764's object-
+    // fallback retirement reached only `useActionModal`'s. This one kept
+    // "names no page or object" and never named `type: 'form'`, the validated
+    // way to open an object's form. Same constructor, byte for byte.
+    expect(String(r.error)).toContain("type: 'form'");
+    expect(String(r.error)).not.toMatch(/or object/);
+    expect(String(r.error)).toBe(
+      modalTargetRefusalMessage({ actionName: 'log_call', target: 'log_call', serverHandlerHint: true }),
+    );
   });
 });

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -34,6 +34,7 @@ import { withPageTabsUrlSync } from '../utils/pageTabsUrlSync';
 import { RECORD_DETAIL_TAB_PARAM, RECORD_TRAIL_PARAM, decodeRecordTrail, buildRecordTrailHref } from '../urlParams';
 import { resolveActionParams } from '../utils/resolveActionParams';
 import { createConsoleServerActionHandler } from '../utils/consoleServerAction';
+import { modalTargetRefusalMessage } from '../utils/modalTargetDiagnostics';
 import { interpretFlowResponse } from '../utils/flowResponse';
 import { useRecordBreadcrumbTitle } from '../context/NavigationContext';
 // Audit provenance renders as the one-line <RecordMetaFooter>; the other
@@ -856,8 +857,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   /**
    * `type: 'modal'` dispatch — same rule as the shared console runtime (see
    * `useConsoleActionRuntime.modalActionHandler`): CLIENT-SIDE ONLY. The
-   * action's `target` names the page (or object form) to open; rendering it is
-   * the whole of what a modal action does.
+   * action's `target` names the PAGE to open — only a page, since the object
+   * fallback retired (maintainer ruling on objectstack#6739, PR #4764);
+   * rendering it is the whole of what a modal action does.
    *
    * [objectstack#3959 / objectui#3320] This used to fall through to
    * `serverActionHandler` when the target resolved to neither a page nor an
@@ -871,6 +873,12 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
    * reported as what it is. To collect input and then run server-side, declare
    * `type: 'script'` with `params`: the runner collects the same dialog and
    * the handler runs with those values.
+   *
+   * The refusal WORDING is built by `utils/modalTargetDiagnostics`, shared with
+   * `useConsoleActionRuntime.modalActionHandler` and
+   * `useActionModal.modalHandler` — see that module for why three hand-written
+   * copies of one contract did not survive contact with PR #4764
+   * (objectui#4767). Change the contract there, not here.
    */
   const modalActionHandler = useCallback(async (action: ActionDef) => {
     const schema = (action as any).modal ?? action.target ?? (action as any).params?.schema;
@@ -878,10 +886,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     if (descriptor) return modalHandler(descriptor);
     return {
       success: false,
-      error:
-        `Action "${action.name}" is type:'modal' but its target ` +
-        `${schema != null ? `"${String(schema)}" ` : ''}names no page or object to open. ` +
-        `Point it at a page, or use type:'script' with params to collect input and run a handler.`,
+      error: modalTargetRefusalMessage({
+        actionName: action.name,
+        target: schema,
+        serverHandlerHint: true,
+      }),
     };
   }, [resolveModalTarget, modalHandler]);
 


### PR DESCRIPTION
Fixes #4767

## 事实

`type: 'modal'` 动作的字符串 `target` 指不到页面时,三处会拒绝并报错:

- `packages/app-shell/src/hooks/useActionModal.tsx` — `modalHandler`,ActionProvider `onModal` 路径
- `packages/app-shell/src/hooks/useConsoleActionRuntime.tsx` — `modalActionHandler`,列表页 / SDUI 页 / 声明式动作栏
- `packages/app-shell/src/views/RecordDetailView.tsx` — `modalActionHandler`,记录页自己那份

三处各自手写文案,于是漂移了。PR #4764 退役了 object fallback(modal target 只指页面 —— objectstack#6739 的维护者裁定),并只改写了第一处:点名被拒的 target,指向 `type: 'form'` 这个经校验的「打开对象表单」写法。另外两处 —— 恰恰是 console 用户真正会看到的两处 —— 仍是退役前的旧文案:target 「names no page or object to open」,唯一出路只给 `type: 'script'`。「or object」半句描述的是已经不存在的分支,替代能力则完全没提。最常被读到的两处,给的是最差的建议。

## 改动

新增 `packages/app-shell/src/utils/modalTargetDiagnostics.ts`,导出 `modalTargetRefusalMessage({ target, actionName?, serverHandlerHint? })`;三处调用点都改成从它取文案。

- 每个有 target 可谈的变体都**点名被拒 target**、**指向 `type: 'form'`**、**不再出现「or object」**。
- console 两处额外传 `serverHandlerHint: true`,保留 `type: 'script'` + `params` 提示 —— 它回答的是另一种作者意图(先收集输入再跑 handler),现在**与** form 指引并列而不是取而代之(该提示原本就被两处既有测试钉着)。附加式设计有测试钉住:console 变体必须以纯变体为前缀。
- `modalHandler` 的消息与 PR #4764 定下的**逐字节一致** —— 这是去重,不是改写 —— 该字节等价性由单测钉住。
- 「没有 target」与「target 指不到东西」是两种不同的编写错误(前者「声明一个」,后者「换一个」),仍分开报,`'Modal action has no target to open.'` 这一句照 PR #4764 原样保留。
- 判定逻辑一行未动;顺带订正了两处 TSDoc / 测试块注释里同一个「(or object)」错话。

## i18n

三处改动前后都是**硬编码英文**,不走 `t()`。它们是**编写期**诊断:点的是元数据键与 spec 类型,读者是写这个 action 的人。按派发边界只改内容、不顺手 i18n 化。`check:i18n-keys` / `check:i18n-drift` 均通过且报告 0 处 en 值变化,佐证本次没有触及任何翻译包。

## 边界

⛔ 未动 `DashboardView`(#4766 在飞;实测该文件本就不含此文案)。⛔ 未动 `useActionModal` 的判定逻辑。

## 验证

- `pnpm exec vitest run packages/app-shell --maxWorkers=2` — **406 文件 / 3860 通过,1 跳过**
- `turbo run type-check --filter @object-ui/app-shell` — 30/30 通过(`tsc --noEmit` + `tsconfig.test.json`)
- `turbo run lint --filter @object-ui/app-shell` — 0 errors
- `check:control-bytes`(4295 文件)、`check:i18n-keys`、`check:i18n-drift`、`changeset:check` 全绿;改动文件另做了越过门禁盲区的自扫,无控制字节

### 反向验证(先预判后跑,未提交)

预判 **红**:把 `RecordDetailView` 调用点还原成 #4767 之前那段内联字符串,该文件新增的四条断言应当转红,而共享构造器的单测应当**保持绿**(它不经过调用点)。实测一致:

```
× reports an unresolvable target instead of POSTing to /actions
AssertionError: expected 'Action "log_call" is type:\'modal\' b…' to match /`type: 'script'` with `params`/
 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 12 passed (13)
```

还原后四个相关测试文件 69/69 全绿。

## 测试

- 新增 `packages/app-shell/src/utils/__tests__/modalTargetDiagnostics.test.ts` —— 钉住内容契约:与 #4764 的字节等价、三条必备事实在每个变体上、hint 的附加性、缺 target 的独立文案、非字符串 target 的字符串化。
- `useConsoleActionRuntime.test.tsx` / `RecordDetailView.modalDispatch.test.tsx` 各自的「reports an unresolvable target」用例加上了 target 名 + `type: 'form'` + 无「or object」+ 与共享构造器**字节等价**的断言 —— 于是「把字符串再内联回去」(也就是 #4767 记录的那个错误本身)会红,而不是无声漂移。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_