### PR TITLE
fix(app-shell)!: DashboardView 交出 modal target 解析,退役前缀约定的第二副本 (#4766)

### DIFF
--- a/.changeset/retire-dashboard-modal-prefix-convention.md
+++ b/.changeset/retire-dashboard-modal-prefix-convention.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/app-shell': minor
+---
+
+A dashboard header `modal` action's `target` names a PAGE, only — DashboardView's second copy of the prefix convention retires
+
+`DashboardView` installed its own `onModal` handler on the dashboard's
+ActionRunner, independent of `useActionModal`, carrying a second live copy of
+the `create_`/`new_`/`add_`/`edit_`/`update_` prefix convention:
+`{ actionType: 'modal', actionUrl: 'create_opportunity' }` was split into the
+object `opportunity` in `create` mode, and any other string became
+`{ objectName: <the target> }` — an object create form, unconditionally. There
+was no page resolution at all on this path.
+
+Both limbs retire under the same maintainer ruling that retired them in
+`useActionModal` (objectstack#6739, 2026-08-09; the `useActionModal` side
+shipped in #4764). The view no longer implements the contract — it installs the
+SHARED `useActionModal` handler, the same one `RecordDetailView` and the console
+runtimes install, so a dashboard header button, a record-header action and a
+console list action now resolve, refuse and REPORT identically.
+
+The convention's self-declared producer — the handler's comment claimed it
+served "server-driven dashboard schemas" emitting `verb_object` names — was
+enumerated before deletion and does not exist. No dashboard in either repo's
+corpus authors a `header.actions[]` entry at all, let alone a prefixed one.
+
+**Breaking surface.** A dashboard header action with `actionType: 'modal'` whose
+`actionUrl` names an OBJECT (bare, or under a verb prefix) no longer opens that
+object's create/edit form. It is refused, with a diagnostic naming the refused
+target and pointing at the replacement. Opening an object's form from a
+dashboard header is `actionType: 'form'` with an `object.view` FORM-view target
+— `actionType` accepts the full action-type enum, so that shape reaches this
+surface too, and it is validated end-to-end.
+
+A header action whose target names a real page now resolves and opens that page
+in the dialog — which this view could not do before at all.

--- a/packages/app-shell/src/views/DashboardView.modalTarget.test.tsx
+++ b/packages/app-shell/src/views/DashboardView.modalTarget.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * DashboardView — a header `modal` action's `target` names a PAGE, only
+ * (objectui#4766; maintainer ruling on objectstack#6739, 2026-08-09).
+ *
+ * This view used to install its OWN `onModal` handler on the dashboard's
+ * ActionRunner, carrying a second live copy of the retired convention:
+ *
+ *   create_/new_/add_/edit_/update_ + object  ->  { objectName, mode }
+ *   anything else                             ->  { objectName: <target> }
+ *
+ * PR #4764 retired both limbs in `useActionModal`, but this copy was not on
+ * that path, so the ruling could not reach it. It is gone: the view now
+ * installs the SHARED `useActionModal` handler — the same one RecordDetailView
+ * and the console runtimes install — so one contract has one implementation.
+ *
+ * What these pin, in the shape PR #4764 established:
+ *
+ *   1. a prefixed target and a bare target get the IDENTICAL verdict (the
+ *      ruling explicitly declined the middle shape "keep the prefix, reject
+ *      bare object names");
+ *   2. the refusal is a NAMED diagnostic — it quotes the target and points at
+ *      `type: 'form'`;
+ *   3. a target naming a page still resolves and opens;
+ *   4. the non-modal dashboard action paths (`script` handlers) are untouched.
+ *
+ * Non-vacuity: every refusal case puts the object the old code would have
+ * parsed into REALLY in the metadata. A refusal measured against an empty
+ * object list would pass by proving nothing was found, rather than proving
+ * nothing was looked for — so each case also asserts the object metadata is
+ * never consulted at all.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { MetadataCtx } from '@object-ui/react';
+
+// Captured props of the (stubbed) DashboardRenderer — `modalHandler` is the
+// handler the view really installs on the dashboard's ActionRunner, which is
+// the thing under test. Stubbing the renderer also keeps this file out of the
+// ComponentRegistry-heavy setup.
+const cap = vi.hoisted(() => ({ props: null as any }));
+vi.mock('@object-ui/plugin-dashboard', () => ({
+  DashboardRenderer: (props: any) => {
+    cap.props = props;
+    return null;
+  },
+}));
+
+// The metadata the view itself reads (dashboards). `useActionModal` reads the
+// SAME value through the real `MetadataCtx` below, so `getItem` sees every
+// lookup either side makes.
+const meta = vi.hoisted(() => ({ value: null as any }));
+vi.mock('../providers/MetadataProvider', () => ({ useMetadata: () => meta.value }));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ dashboardName: 'sales_overview' }),
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/dashboards/sales_overview', search: '' }),
+}));
+
+vi.mock('./useOpenRecordList', () => ({ useOpenRecordList: () => vi.fn() }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false }),
+}));
+vi.mock('../providers/AdapterProvider', () => ({ useAdapter: () => ({}) }));
+vi.mock('../providers/ExpressionProvider', () => ({ useExpressionContext: () => ({ app: undefined }) }));
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({ t: (k: string) => k }),
+  useObjectLabel: () => ({
+    dashboardLabel: ({ label, name }: any) => label ?? name,
+    dashboardDescription: ({ description }: any) => description,
+  }),
+  // <ModalForm> builds its discard-guard strings with this at import time.
+  createSafeTranslation: (defaults: Record<string, string>) => () => ({
+    t: (k: string) => defaults?.[k] ?? k,
+  }),
+}));
+
+import { DashboardView } from './DashboardView';
+
+const SALES_DASHBOARD = { name: 'sales_overview', label: 'Sales Overview', widgets: [] };
+/** A REAL object — the one `create_opportunity` used to be parsed into. */
+const OPPORTUNITY_OBJECT = { name: 'opportunity', label: 'Opportunity', fields: {} };
+const QUICK_LOG_PAGE = { name: 'quick_log_call', type: 'utility', label: 'Log a Call' };
+
+/**
+ * A refusal settles immediately; an OPENED modal returns a promise that settles
+ * only when the dialog closes. So `await modalHandler(...)` on a case that is
+ * supposed to be refused would HANG to the suite timeout if the retired branch
+ * ever came back — failing late, opaquely, and cascading into the next test in
+ * the file (PR #4764 measured exactly that cascade and hardened its own
+ * diagnostic pin for it). This turns that hang into a fast, named assertion.
+ */
+const HUNG = Symbol('handler did not settle — it opened a modal instead of refusing');
+function settle<T>(p: Promise<T>): Promise<T | typeof HUNG> {
+  return Promise.race([p, new Promise<typeof HUNG>((r) => setTimeout(() => r(HUNG), 250))]);
+}
+
+/**
+ * Mount the view and hand back the `modalHandler` it installed, plus the
+ * `getItem` spy every metadata lookup goes through.
+ */
+async function mountDashboard(items: Record<string, any[]>) {
+  const getItem = vi.fn(async (type: string, name: string) =>
+    (items[type] ?? []).find((i) => i.name === name) ?? null);
+  meta.value = {
+    apps: [],
+    objects: items.object ?? [],
+    dashboards: items.dashboard ?? [SALES_DASHBOARD],
+    reports: [],
+    pages: [],
+    loading: false,
+    error: null,
+    refresh: async () => {},
+    invalidate: () => {},
+    ensureType: async () => [],
+    getItem,
+    getItemsByType: () => [],
+    getTypeStatus: () => 'ready',
+  };
+
+  render(
+    <MetadataCtx.Provider value={meta.value as any}>
+      <DashboardView />
+    </MetadataCtx.Provider>,
+  );
+
+  await waitFor(() => expect(cap.props).not.toBeNull());
+  return { modalHandler: cap.props.modalHandler as (s: any) => Promise<any>, getItem };
+}
+
+beforeEach(() => {
+  cap.props = null;
+  vi.clearAllMocks();
+});
+
+describe('DashboardView — a header modal target names a page, only (objectui#4766)', () => {
+  it('REFUSES a create_ prefixed target, naming it and pointing at type: form', async () => {
+    const { modalHandler, getItem } = await mountDashboard({
+      object: [OPPORTUNITY_OBJECT],
+      page: [],
+    });
+
+    let r: any;
+    await act(async () => { r = await settle(modalHandler('create_opportunity')); });
+
+    expect(r).not.toBe(HUNG);
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('create_opportunity');
+    expect(r.error).toContain("type: 'form'");
+    // The prefix is not special: `opportunity` exists, and is never asked for.
+    expect(getItem).toHaveBeenCalledWith('page', 'create_opportunity');
+    expect(getItem).not.toHaveBeenCalledWith('object', 'opportunity');
+    expect(getItem).not.toHaveBeenCalledWith('object', 'create_opportunity');
+  });
+
+  it('judges a prefixed target and a bare object name IDENTICALLY', async () => {
+    // The ruling declined the middle shape (keep the prefix, reject bare object
+    // names), so the two spellings must be indistinguishable here — same
+    // refusal, same diagnostic modulo the quoted name. Both objects really
+    // exist in the metadata for this comparison.
+    const { modalHandler, getItem } = await mountDashboard({
+      object: [OPPORTUNITY_OBJECT],
+      page: [],
+    });
+
+    let prefixed: any;
+    let bare: any;
+    await act(async () => { prefixed = await settle(modalHandler('create_opportunity')); });
+    await act(async () => { bare = await settle(modalHandler('opportunity')); });
+
+    expect(prefixed).not.toBe(HUNG);
+    expect(bare).not.toBe(HUNG);
+    expect(prefixed.success).toBe(false);
+    expect(bare.success).toBe(false);
+    expect(prefixed.error.replace('create_opportunity', 'opportunity')).toBe(bare.error);
+    expect(getItem).not.toHaveBeenCalledWith('object', 'opportunity');
+  });
+
+  it('opens a target that names a PAGE, without probing the object metadata', async () => {
+    const { modalHandler, getItem } = await mountDashboard({
+      object: [OPPORTUNITY_OBJECT],
+      page: [QUICK_LOG_PAGE],
+    });
+
+    // NOT awaited: a resolved target opens the dialog and returns a promise
+    // that settles only when the dialog CLOSES, so awaiting it here would hang
+    // to the suite timeout. `settled` is the assertion that it stayed open.
+    let settled = false;
+    await act(async () => {
+      void modalHandler('quick_log_call').then(() => { settled = true; });
+    });
+
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
+    expect(settled).toBe(false);
+    expect(getItem).toHaveBeenCalledWith('page', 'quick_log_call');
+    expect(getItem).not.toHaveBeenCalledWith('object', 'quick_log_call');
+  });
+
+  it('reports a missing target distinctly from a refused one', async () => {
+    const { modalHandler } = await mountDashboard({ object: [], page: [] });
+
+    let r: any;
+    await act(async () => { r = await settle(modalHandler('')); });
+
+    expect(r).not.toBe(HUNG);
+    expect(r.success).toBe(false);
+    expect(r.error).toBe('Modal action has no target to open.');
+  });
+
+  it('leaves the non-modal dashboard action paths alone', async () => {
+    // The `script` handlers this view owns are the other half of what it
+    // installs on the runner; the modal retirement must not disturb them.
+    await mountDashboard({ object: [], page: [] });
+
+    expect(Object.keys(cap.props.scriptHandlers)).toEqual(
+      expect.arrayContaining(['export_dashboard_pdf', 'forecast_dashboard']),
+    );
+    expect(typeof cap.props.modalHandler).toBe('function');
+  });
+});

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -9,28 +9,21 @@
  * so there is a single, consistent authoring surface.
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { DashboardRenderer } from '@object-ui/plugin-dashboard';
 import { DrillNavigationProvider } from '@object-ui/react';
 import { useOpenRecordList } from './useOpenRecordList';
-import { ModalForm } from '@object-ui/plugin-form';
 import { toast } from 'sonner';
-import type { ModalHandler, ActionDef, ActionContext, ActionResult } from '@object-ui/core';
+import type { ActionDef, ActionContext, ActionResult } from '@object-ui/core';
 import {
   Empty,
   EmptyTitle,
   EmptyDescription,
-  Button,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
 } from '@object-ui/components';
 import { LayoutDashboard } from 'lucide-react';
 import { MetadataPanel, useMetadataInspector } from './MetadataInspector';
+import { useActionModal } from '../hooks/useActionModal';
 import { SkeletonDashboard } from '../skeletons';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useExpressionContext } from '../providers/ExpressionProvider';
@@ -52,46 +45,35 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
   const { dashboardLabel, dashboardDescription } = useObjectLabel();
   const [isLoading, setIsLoading] = useState(true);
 
-  // Modal state for header action buttons that request a modal (e.g. New Opportunity)
-  const [modalState, setModalState] = useState<{
-    schema: any;
-    resolve: (r: ActionResult) => void;
-  } | null>(null);
-
-  const closeModal = useCallback((result: ActionResult) => {
-    setModalState((curr) => {
-      if (curr) curr.resolve(result);
-      return null;
-    });
-  }, []);
-
-  const modalHandler = useCallback<ModalHandler>(
-    (schema) =>
-      new Promise<ActionResult>((resolve) => {
-        // Normalize string schema (e.g. action.target = 'opportunity' or
-        // 'create_opportunity') to a ModalForm-compatible descriptor so header
-        // `modal` actions like { actionType: 'modal', actionUrl: 'create_opportunity' }
-        // open the create form for that object. Supports the conventional
-        // `<verb>_<object>` form (create_/new_/add_/edit_/update_) emitted by
-        // server-driven dashboard schemas.
-        let normalized: any;
-        if (typeof schema === 'string') {
-          const m = schema.match(/^(create|new|add|edit|update)_(.+)$/);
-          if (m) {
-            const verb = m[1];
-            const objectName = m[2];
-            const mode = verb === 'edit' || verb === 'update' ? 'edit' : 'create';
-            normalized = { objectName, mode };
-          } else {
-            normalized = { objectName: schema, mode: 'create' };
-          }
-        } else {
-          normalized = schema;
-        }
-        setModalState({ schema: normalized, resolve });
-      }),
-    [],
-  );
+  /**
+   * Client-side modal transport for header `modal` actions — the SHARED
+   * `useActionModal`, the same handler `RecordDetailView` and the console
+   * runtimes install (objectui#4766).
+   *
+   * This view used to carry its own private handler, and with it a second
+   * live copy of the `create_`/`new_`/`add_`/`edit_`/`update_` prefix
+   * convention: `create_opportunity` was split into the object `opportunity`
+   * in `create` mode, and any other string became `{ objectName: <target> }`.
+   * Both limbs retire under the maintainer ruling on objectstack#6739
+   * (2026-08-09) — a `type: 'modal'` action's string `target` names a PAGE,
+   * and only a page. PR #4764 retired them in `useActionModal`; this copy was
+   * off that path, so the ruling could not reach it.
+   *
+   * The convention's stated producer — "server-driven dashboard schemas" —
+   * was enumerated before deleting it and does not exist: no dashboard in
+   * either repo's corpus (objectstack `examples/app-{crm,showcase,todo}`,
+   * `packages/apps/*`, objectui `apps/*` + `examples/*` including the 11
+   * dashboards in `examples/schema-catalog`) authors a `header.actions[]`
+   * entry at all, let alone a `<verb>_<object>` one.
+   *
+   * Delegating rather than re-implementing is the point: the contract now has
+   * one implementation, so a dashboard header button, a record-header action
+   * and a console list action resolve, refuse, and REPORT identically. The
+   * refusal names the target and points at `type: 'form'` — which reaches a
+   * dashboard header too (`actionType` is the full `ActionType` enum), and is
+   * the validated way to open an object's form.
+   */
+  const { modalHandler, modalElement } = useActionModal(adapter);
 
   const scriptHandlers = useMemo<Record<string, (a: ActionDef, c: ActionContext) => Promise<ActionResult> | ActionResult>>(
     () => ({
@@ -235,43 +217,8 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
          />
       </div>
 
-      {/* Modal triggered by header actions (e.g. "New Opportunity") */}
-      {modalState && modalState.schema?.objectName ? (
-        <ModalForm
-          schema={{
-            type: 'object-form',
-            formType: 'modal',
-            objectName: modalState.schema.objectName,
-            mode: modalState.schema.mode || 'create',
-            recordId: modalState.schema.recordId,
-            title: modalState.schema.title,
-            description: modalState.schema.description,
-            fields: modalState.schema.fields,
-            open: true,
-            onOpenChange: (open: boolean) => { if (!open) closeModal({ success: false }); },
-            onSuccess: (data: any) => { closeModal({ success: true, reload: true, data }); },
-            onCancel: () => { closeModal({ success: false }); },
-            showSubmit: true,
-            showCancel: true,
-          }}
-          dataSource={adapter as any}
-        />
-      ) : modalState ? (
-        <Dialog open onOpenChange={(open) => { if (!open) closeModal({ success: false }); }}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>{modalState.schema?.title || t('actionDialog.defaultActionTitle')}</DialogTitle>
-              {modalState.schema?.description && (
-                <DialogDescription>{modalState.schema.description}</DialogDescription>
-              )}
-            </DialogHeader>
-            <DialogFooter>
-              <Button variant="outline" onClick={() => closeModal({ success: false })}>{t('actionDialog.cancel')}</Button>
-              <Button onClick={() => closeModal({ success: true })}>{t('actionDialog.ok')}</Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      ) : null}
+      {/* Modal opened by a header action whose `target` names a page. */}
+      {modalElement}
     </div>
   );
 }


### PR DESCRIPTION
Fixes #4766

Base: `469b60493b066b8718ed124043028e320ea85483`

按维护者裁定 **objectstack#6739-A**(2026-08-09):`type: 'modal'` 动作的字符串 `target` 只命名 **PAGE**。PR #4764 在 `useActionModal` 里退役了 object 兜底与 `create_`/`new_`/`add_`/`edit_`/`update_` 前缀约定;`DashboardView` 自带的第二份实现不在那条路径上,裁定够不到,本 PR 处置它。

## 先枚举:注释自称的生产者不存在

被删代码的注释写着该约定服务「server-driven dashboard schemas 发出的 verb_object 名」。删之前先实证:

| 语料 | dashboard 数 | 有 `header.actions[]` 吗 | verb_object modal target |
|---|---|---|---|
| objectstack `examples/app-crm` / `app-showcase` / `app-todo` | 5 | 无 | 无 |
| objectstack `packages/apps/{account,setup,studio}` | — | 无 | 无 |
| objectui `apps/console` / `apps/site` | — | 无 | 无 |
| objectui `examples/schema-catalog`(catalog) | 11 | 无(全仓 `actionType` 零命中) | 无 |
| objectui `examples/*` 其余 | — | 无 | 无 |

**两仓语料里没有任何 dashboard 声明过 `header.actions[]`**,更没有前缀形态的。该形态在两仓仅存于三处非生产者:objectstack `packages/lint/src/validate-dashboard-action-refs.ts` 的 `MODAL_VERB_RE`、它的三条钉子测试、以及 `content/docs/deployment/validating-metadata.mdx:83` 的一行示例。这三处是**校验器与它的文档**,不是 schema 生产者 —— 详见下面的「超范围回传」。

## 改了什么

这份副本比 `useActionModal` 那份更宽:**它根本没有 page 解析**。任何字符串 target 一律变成 `{ objectName }` 打开对象表单,前缀命中时再先劈成动词 + 对象。一个真正命名 page 的 target 在这里从来就打不开。

处置不是就地改写,而是**交出去**:`DashboardView` 不再自己实现契约,改为安装共享的 `useActionModal` —— `RecordDetailView` 与控制台运行时安装的同一个。

- 契约只剩一份实现,dashboard 头部按钮 / 记录头动作 / 控制台列表动作三处的**解析、拒绝、报错完全一致**;
- 被拒 target 的诊断就是 PR #4764 那一条(点名 target + 指向 `type: 'form'`),因为现在它就是同一段代码;
- 顺带补上这个视面从未有过的能力:**命名 page 的 target 现在能开出该 page**。

替代写法在这个面上是通的:`DashboardHeaderAction.actionType` 用的是完整的 `ActionType` 枚举(含 `form`),`ActionRunner.executeForm` 导航到 `/forms/`,所以 `{ actionType: 'form', actionUrl: 'opportunity.edit' }` 是 dashboard 头部打开对象表单的受校验写法。

## 钉子(`DashboardView.modalTarget.test.tsx`,5 条)

1. 前缀名被拒,诊断点名 target 并指向 `type: 'form'`;
2. **前缀名与裸名同判** —— 裁定明确拒绝了第三形态(保前缀、弃裸名),两种拼法在这里必须不可区分;
3. page 名正常解析并开出对话框,且从不问询 object 元数据;
4. 空 target 走独立诊断;
5. `script` 动作路径(`export_dashboard_pdf` / `forecast_dashboard`)不回归。

两条拒绝钉都让被解析的对象(`opportunity`)**真实存在**于元数据里,并断言 `getItem` 从未以 `('object', …)` 被调用 —— 对空对象列表断言拒绝会空洞通过,只证明没找到,而非证明没去找。

## 反向验证 —— 先预判,后跑变异

预判(把被删肢体原样恢复并重新装回 runner):**4 红 1 绿,且全部以断言而非超时转红**。

为了做到「而非超时」,拒绝类用例加了 `HUNG` 哨兵:一旦对象兜底复活,handler 会打开对话框并返回一个只在关闭时 settle 的 promise —— PR #4764 实测过这会挂到 suite 超时,并把失败级联给邻居用例。哨兵把它变成快速具名失败。

实测:**4 红 1 绿**,最慢 320ms,无超时。

一处**如实说明**:page 用例转红的是 `getItem('page', …)` 从未被调用那一条断言;它的「对话框出现了」那半在变异下**仍然绿** —— 旧代码也开对话框,只是开的是对象表单。这条写进了用例注释,免得下一个读者以为「有对话框」就是这条钉子的信号。

## 测试与门禁

- `pnpm exec vitest run packages/app-shell --maxWorkers=2` → **406 文件 / 3854 通过 | 1 skipped**
- 仓根 `turbo run type-check --concurrency=2` → **81/81 successful**
- `node scripts/check-control-bytes.mjs` → OK(4297 文件);另按纪律自扫改动文件的控制字节,干净
- `check:action-forward-parity` / `check:spec-symbols` / `check:phantom-deps` / `check:i18n-keys` → 通过
- `eslint`(改动文件)→ **0 error**(23 条既有 warning,均在未改动的行上)

## 超范围回传(未立单,按派发词交 PM)

**objectstack 侧仍在祝福被本 PR 退役的形态,方向已反转。** `packages/lint/src/validate-dashboard-action-refs.ts` 的 `resolveActionTarget` 对 `actionType: 'modal'` 接受「裸对象名」与「verb_object」,其 docblock 明写理由是「mirrors the objectui runtime dispatch(`DashboardRenderer` + `DashboardView`)so the lint flags exactly what would fail to resolve at runtime」—— 依据正是本 PR 删掉的这段代码。三条钉子测试与 `content/docs/deployment/validating-metadata.mdx:83`(把 `{ label: 'New Deal', actionType: 'modal', actionUrl: 'create_opportunity' }` 标成 ✓ 合法)同源。

本 PR 合并后,`os validate` 会放行一个运行时点下去只会 `console.warn` 的按钮 —— 正是该规则自己写着要消灭的 false affordance,只是方向反了。**建议单独一张 objectstack 卡**:按裁定 A 收窄 `resolveActionTarget`(modal target 只认已声明 page)、改三条钉子、改那行文档。检索过 objectstack open issues,无重复卡。

第二条,更小:`actionDialog.ok` 与 `actionDialog.defaultActionTitle` 两个 i18n key 随本次删除失去唯一调用点。`check:i18n-dead-keys` 按设计是 report-only、未接 CI,且十个语言包的清理落在 `packages/i18n`(超出本卡文件面),故未动。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_