### PR TITLE
refactor(core,fields): one exported cascade option allow-table, not three private copies (#4770)

### DIFF
--- a/.changeset/cascade-option-allow-table-single-source.md
+++ b/.changeset/cascade-option-allow-table-single-source.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/core': patch
+'@object-ui/fields': patch
+'@object-ui/components': patch
+'@object-ui/app-shell': patch
+'@object-ui/plugin-grid': patch
+---
+
+The allow-list of option widgets that are fed the live record is now one exported constant, `CASCADE_OPTION_WIDGET_TYPES`, instead of three private copies.
+
+`select` / `multiselect` / `radio` / `checkboxes` are the widgets whose OFFERED
+option set is re-resolved against a record (per-option `visibleWhen`, plus the
+`dependsOn` gate), so they are the widgets a surface must thread its live record
+to. Three surfaces feed that one evaluator — the object form, the single-record
+action dialog and the bulk action dialog — and until now each carried its own
+private `new Set([...])` of the same four keys, with a comment in each asking the
+next person to change all three together. Nothing could have reported them
+drifting: every copy passed its own behavioural tests, and a divergence would
+have shown up only as one surface silently disagreeing with another about what
+"the record" is.
+
+The set now lives in `@object-ui/core`, next to `resolveCascadingOptions` — the
+evaluator that reads that record — because core is the one package all three
+surfaces already depend on, and it is re-exported from `@object-ui/fields` next
+to `resolveFormWidgetType`, whose output is the vocabulary the keys are written
+in. Both are the same object, pinned by test; each consumer keeps its own
+normalization (`normalizeFieldType` in the form, `resolveFormWidgetType` in the
+dialogs), which agree on these four members.
+
+No behaviour changes: the members are identical on all three surfaces, and the
+existing pins for each surface still assert the same records reaching the same
+widgets. The rationale that was repeated in the three copies — including the
+note that the widget-hint picker family (`filter-condition`, `recipient-picker`,
+the lookup family) reads a different sibling key off the same channel and is
+deliberately NOT in this set — is now stated once, in the constant's own
+documentation. Whether the action and bulk dialogs should ever feed those
+pickers stays an open question (objectui#4771), unchanged by this convergence.

--- a/packages/app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx
@@ -36,6 +36,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SchemaRendererContext } from '@object-ui/react';
 import type { ActionParamDef } from '@object-ui/core';
+import { CASCADE_OPTION_WIDGET_TYPES } from '@object-ui/core';
 // Module scope, per AGENTS.md §测试纪律: the dialog reaches its widgets through
 // `React.lazy(() => import('./widgets/RadioField'))` inside `@object-ui/fields`,
 // and a first dynamic import() under a saturated transform pipeline can eat most
@@ -168,5 +169,27 @@ describe('ActionParamDialog — the dialog IS the record for its option predicat
     typeCountry('cn');
     await waitFor(() => expect(screen.queryByTestId('radio-option-tx')).not.toBeInTheDocument());
     expect(screen.getByTestId('radio-option-zj')).toBeInTheDocument();
+  });
+});
+
+describe('ActionParamDialog — the allow-table is the SHARED object (objectui#4770)', () => {
+  it('asks @object-ui/core CASCADE_OPTION_WIDGET_TYPES which params get the record', async () => {
+    // Identity, not membership. Three surfaces feed one cascading-options
+    // evaluator and each used to hold a private copy of the same four keys; the
+    // failure mode #4770 closes is those copies drifting, which no test could
+    // see because every copy passed its OWN behavioural pins. So this asserts
+    // the object: the spy is installed on the very Set exported by
+    // `@object-ui/core`, and it only records a call if the dialog consulted
+    // THAT object while rendering. Re-inline a private copy here and the four
+    // behavioural cases above stay green (the members are unchanged) while this
+    // one turns red — which is exactly the drift they cannot report.
+    const spy = vi.spyOn(CASCADE_OPTION_WIDGET_TYPES, 'has');
+    try {
+      openDialog([COUNTRY, PROVINCE]);
+      expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+      expect(spy.mock.calls.map(([k]) => k)).toContain('radio');
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -16,8 +16,9 @@
  *
  * One thing is threaded rather than ambient, and deliberately so: the record an
  * option widget resolves its per-option `visibleWhen` against. The dialog is a
- * small form, so its own in-progress `values` are that record — see
- * `CASCADE_OPTION_WIDGET_TYPES` below (objectui#3765).
+ * small form, so its own in-progress `values` are that record — for WHICH
+ * widgets receive it, see `CASCADE_OPTION_WIDGET_TYPES` in `@object-ui/core`
+ * (objectui#3765; shared with the form and the bulk dialog per objectui#4770).
  *
  * Returns collected param values or null on cancel.
  */
@@ -35,7 +36,15 @@ import {
 } from '@object-ui/components';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionParamDef } from '@object-ui/core';
-import { evalRowPredicate, hasDeclaredPredicate } from '@object-ui/core';
+import {
+  evalRowPredicate,
+  hasDeclaredPredicate,
+  // The shared allow-table of widgets that are fed the dialog's own values as
+  // their record — one definition for this dialog, the object form and the bulk
+  // dialog (objectui#4770). Its TSDoc carries the rationale that used to be
+  // repeated in each of the three copies.
+  CASCADE_OPTION_WIDGET_TYPES,
+} from '@object-ui/core';
 import { usePredicateScope } from '@object-ui/react';
 import { getLazyFieldWidget, fileIdOf } from '@object-ui/fields';
 import { paramToField } from '../utils/paramToField';
@@ -203,28 +212,6 @@ export function serializeParamValues(
 function WidgetFallback() {
   return <div className="h-9 w-full animate-pulse rounded-md bg-muted" aria-hidden="true" />;
 }
-
-/**
- * Widget keys whose OFFERED option set is re-resolved against a live record by
- * the shared cascading-options evaluator (`useCascadingOptions` →
- * `resolveCascadingOptions`): each option may carry a `visibleWhen` predicate
- * read against `record.*` (ADR-0058 / objectui#2284).
- *
- * Deliberately the same four keys the object form threads `dependentValues` to
- * (`CASCADE_OPTION_FIELD_TYPES` in `components/renderers/form/form.tsx`) — the
- * dialog and the form must feed one evaluator the same way or the two surfaces
- * drift on what "the record" means. It is an ALLOW-LIST, not a blanket
- * pass-through, because `dependentValues` is also the channel two widget-hint
- * pickers read a specific SIBLING KEY from (`filter-condition` reads
- * `object_name`, `recipient-picker` reads `recipient_type`) and the lookup
- * family filters its query by it; feeding those from dialog params is a
- * different wiring question than the one ruled here.
- *
- * `select` + `multiple: true` is not listed separately: `SelectField` delegates
- * to `MultiSelectField` with the whole prop object, so the key it resolves
- * under (`select`) is the one that must carry the record.
- */
-const CASCADE_OPTION_WIDGET_TYPES = new Set(['select', 'multiselect', 'radio', 'checkboxes']);
 
 export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProps) {
   const { t, language } = useObjectTranslation();

--- a/packages/components/src/renderers/form/__tests__/form-dependent-values.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-dependent-values.test.tsx
@@ -17,9 +17,9 @@
  * matter what the user picked in the parent field.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { ComponentRegistry } from '@object-ui/core';
+import { ComponentRegistry, CASCADE_OPTION_WIDGET_TYPES } from '@object-ui/core';
 import '../../../renderers';
 
 // Probe widget standing in for a lookup field: surfaces the received
@@ -109,4 +109,37 @@ describe('form renderer — dependentValues injection for data-source fields (#2
     });
   });
 
+});
+
+describe('form renderer — the allow-table is the SHARED object (objectui#4770)', () => {
+  it('asks @object-ui/core CASCADE_OPTION_WIDGET_TYPES which fields get the record', () => {
+    // Identity, not membership — the same pin the two dialog surfaces carry
+    // (`app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx`,
+    // `plugin-grid/src/__tests__/bulkActionDialogRecord.test.tsx`). The
+    // injection cases above pass against ANY set holding these four members,
+    // including the private `CASCADE_OPTION_FIELD_TYPES` copy this form carried
+    // until objectui#4770 — so they cannot report the failure mode #4770
+    // closed, which was the three copies drifting apart. The spy is installed
+    // on the Set object exported by `@object-ui/core`; it records a call only
+    // if this renderer consulted THAT object.
+    const spy = vi.spyOn(CASCADE_OPTION_WIDGET_TYPES, 'has');
+    try {
+      renderForm([
+        { name: 'country', label: 'Country', type: 'input', defaultValue: '' },
+        {
+          name: 'province',
+          label: 'Province',
+          type: 'select',
+          widget: 'field:select',
+          dependsOn: 'country',
+          options: [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" }],
+        },
+      ]);
+      // The form normalizes `field:select` to `select` BEFORE the lookup, so
+      // the key reaching the shared set is the widget key it is defined on.
+      expect(spy.mock.calls.map(([k]) => k)).toContain('select');
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveCascadingOptions, isValueStillOffered, isMissingForRequired, isServerOwnedValue } from '@object-ui/core';
+import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveCascadingOptions, CASCADE_OPTION_WIDGET_TYPES, isValueStillOffered, isMissingForRequired, isServerOwnedValue } from '@object-ui/core';
 import type { FormSchema, FormField as FormFieldConfig, FormFieldTab, FormFieldPane, FieldValidationRules, FieldCondition, SelectOption } from '@object-ui/types';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from '../../ui/form';
@@ -249,8 +249,10 @@ const DATA_SOURCE_FIELD_TYPES = new Set([
 // its OFFERED set against the live form record (`record.country == 'cn'` …). They
 // take no `dataSource`, but they DO need the live `dependentValues` record —
 // without it a cascading select never sees its controlling field and stays
-// permanently gated on the "select the parent first" hint.
-const CASCADE_OPTION_FIELD_TYPES = new Set(['select', 'radio', 'multiselect', 'checkboxes']);
+// permanently gated on the "select the parent first" hint. The set itself is
+// `CASCADE_OPTION_WIDGET_TYPES`, imported from `@object-ui/core` above: this
+// form, the action dialog and the bulk dialog feed one evaluator and must read
+// one allow-table (objectui#4770 — until then each held a private copy).
 
 function stripRendererOnlyProps<T extends Record<string, any>>(props: T): T {
   const {
@@ -399,7 +401,7 @@ function stripRegisteredFieldProps(type: string, props: RenderFieldProps): Rende
     // stripped by default because every OTHER registered widget spreads its
     // leftover props onto a DOM node, where an unknown `emptyHint` attribute is
     // a React warning — hence an allow-list, not an unconditional pass-through.
-    ...(CASCADE_OPTION_FIELD_TYPES.has(normalizedType) ? { dependentValues, emptyHint } : {}),
+    ...(CASCADE_OPTION_WIDGET_TYPES.has(normalizedType) ? { dependentValues, emptyHint } : {}),
   };
 }
 
@@ -933,7 +935,7 @@ ComponentRegistry.register('form',
         // below already does for `isOptionField` (objectui#3231) — the two
         // readers of "is this an option field?" must not disagree.
         if (typeof resolvedType !== 'string') continue;
-        if (!CASCADE_OPTION_FIELD_TYPES.has(normalizeFieldType(resolvedType))) continue;
+        if (!CASCADE_OPTION_WIDGET_TYPES.has(normalizeFieldType(resolvedType))) continue;
         const opts = (f as any).options as SelectOption[] | undefined;
         if (!opts || opts.length === 0) continue;
         const dependsOn = f.dependsOn;
@@ -1565,7 +1567,7 @@ ComponentRegistry.register('form',
       // (objectui#3231). `normalizeFieldType` is the same normalization
       // `stripRegisteredFieldProps` already applies a few lines down; the two
       // must agree on what a `select` is.
-      const isOptionField = CASCADE_OPTION_FIELD_TYPES.has(normalizeFieldType(resolvedType));
+      const isOptionField = CASCADE_OPTION_WIDGET_TYPES.has(normalizeFieldType(resolvedType));
       const rawOptions = (fieldProps as any).options as SelectOption[] | undefined;
       // Resolve gating + `visibleWhen` filtering through the shared
       // core helper so this pre-filter can't drift from the widgets'

--- a/packages/core/src/evaluator/optionRules.ts
+++ b/packages/core/src/evaluator/optionRules.ts
@@ -156,3 +156,64 @@ export function resolveCascadingOptions<T extends OptionLike>(
   const options = gated ? [] : resolveVisibleOptions(rawOptions, record, scope);
   return { options, gated, dependsOnFields };
 }
+
+/**
+ * Widget keys whose OFFERED option set is re-resolved against a live record by
+ * {@link resolveCascadingOptions} — i.e. the allow-list of widgets a surface
+ * must thread its live record to (`dependentValues`). Each of their options may
+ * carry a `visibleWhen` predicate read against `record.*`, and the field may
+ * declare a `dependsOn` gate (ADR-0058 / objectui#2284 / objectui#1583).
+ * Without the record a cascading select never sees its controlling field and
+ * stays permanently gated on the "select the parent first" hint.
+ *
+ * ## One definition, three surfaces (objectui#4770)
+ *
+ * Three surfaces feed this one evaluator, and each carried its own private copy
+ * of these four keys until this constant existed — with no gate able to notice
+ * them drifting apart on what "the record" means:
+ *
+ * - the object form — `CASCADE_OPTION_FIELD_TYPES` in
+ *   `components/src/renderers/form/form.tsx` (the original);
+ * - the single-record action dialog — `CASCADE_OPTION_WIDGET_TYPES` in
+ *   `app-shell/src/views/ActionParamDialog.tsx` (objectui#3765 / PR #4756);
+ * - the bulk action dialog — the same name in
+ *   `plugin-grid/src/components/BulkActionDialog.tsx` (objectui#4757 / PR #4763).
+ *
+ * The set lives in `@object-ui/core`, next to the evaluator it describes,
+ * because core is the one package all three already depend on — the form layer
+ * cannot reach `@object-ui/fields` (that dependency runs the other way). Same
+ * shape and same reason as `EXPANDABLE_FIELD_TYPES` in
+ * `core/src/utils/expand-fields.ts`, the in-repo precedent for a form-layer
+ * allow-table more than one surface reads. `@object-ui/fields` re-exports it
+ * next to `resolveFormWidgetType` for discoverability — a re-export, never a
+ * second definition.
+ *
+ * ## An ALLOW-LIST, not a blanket pass-through
+ *
+ * `dependentValues` is also the channel two widget-hint pickers read a specific
+ * SIBLING KEY from (`filter-condition` reads `object_name`, `recipient-picker`
+ * reads `recipient_type`), and the lookup family filters its query by it. All
+ * three surfaces above agree today in NOT feeding those from action / bulk
+ * dialog params, but that is a different wiring question from the one ruled
+ * here and it has never been decided either way. Stated here so the three
+ * copies of the statement become one — the boundary itself stays open:
+ * objectui#4771.
+ *
+ * ## Normalization stays with the consumer
+ *
+ * The members are WIDGET keys — `resolveFormWidgetType` output in the two
+ * dialogs, `normalizeFieldType` output (the `field:` prefix stripped) in the
+ * form — not authored `type` spellings. Each consumer keeps its own
+ * normalization; the two normalizations agree on these four members, which is
+ * what makes one shared set safe to read from both.
+ *
+ * `select` + `multiple: true` is not listed separately: `SelectField` delegates
+ * to `MultiSelectField` with the whole prop object, so the key it resolves
+ * under (`select`) is the one that must carry the record.
+ */
+export const CASCADE_OPTION_WIDGET_TYPES: ReadonlySet<string> = new Set([
+  'select',
+  'multiselect',
+  'radio',
+  'checkboxes',
+]);

--- a/packages/fields/src/cascadeOptionWidgetTypes.reexport.test.tsx
+++ b/packages/fields/src/cascadeOptionWidgetTypes.reexport.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4770 — `@object-ui/fields` re-exports the cascade allow-table, it
+ * does not redefine it.
+ *
+ * The set of widget keys that must be fed the live record (`dependentValues`)
+ * is defined once, in `@object-ui/core` next to `resolveCascadingOptions` — the
+ * evaluator that reads that record — because core is the only package all three
+ * consuming surfaces can depend on (the object form in `@object-ui/components`
+ * cannot reach `@object-ui/fields`: that dependency runs the other way). It is
+ * surfaced HERE as well because this package's `resolveFormWidgetType` produces
+ * the keys the set is keyed on, so a consumer resolving widget keys finds the
+ * allow-table where it resolves them.
+ *
+ * Two doorways, one definition. If someone ever "restores discoverability" by
+ * writing a second `new Set([...])` in this package instead of re-exporting,
+ * the first assertion fails — while a membership-only check would happily pass
+ * on a copy and let the two definitions drift apart later, which is the exact
+ * failure objectui#4770 removed.
+ */
+import { describe, it, expect } from 'vitest';
+import { CASCADE_OPTION_WIDGET_TYPES as fromCore } from '@object-ui/core';
+import { CASCADE_OPTION_WIDGET_TYPES as fromFields, resolveFormWidgetType } from '@object-ui/fields';
+
+describe('CASCADE_OPTION_WIDGET_TYPES re-export (objectui#4770)', () => {
+  it('is the SAME object as the core definition, not a copy', () => {
+    expect(fromFields).toBe(fromCore);
+  });
+
+  it('holds exactly the four option widgets that take the live record', () => {
+    // Membership is pinned so changing WHICH widgets receive `dependentValues`
+    // stays a deliberate, reviewable edit on all surfaces at once. Adding a key
+    // here is not a formality: the picker family (`filter-condition`,
+    // `recipient-picker`, the lookup family) reads a specific SIBLING KEY off
+    // the same channel, and whether the action / bulk dialogs should feed those
+    // is an open question recorded on objectui#4771, not settled by this set.
+    expect([...fromFields].sort()).toEqual(['checkboxes', 'multiselect', 'radio', 'select']);
+  });
+
+  it('is keyed on this package widget keys: every member resolves to itself', () => {
+    // What makes the shared set safe to read from surfaces that normalize
+    // differently: these are `resolveFormWidgetType` OUTPUT (what the two
+    // dialogs look up), which for these four coincides with the form's
+    // `normalizeFieldType` output (the `field:` prefix stripped). A member that
+    // is not a real widget key would resolve to `text` here.
+    for (const key of fromFields) {
+      expect(resolveFormWidgetType(key)).toBe(key);
+    }
+  });
+});

--- a/packages/fields/src/cascadeOptionWidgetTypes.reexport.test.tsx
+++ b/packages/fields/src/cascadeOptionWidgetTypes.reexport.test.tsx
@@ -27,7 +27,15 @@
  */
 import { describe, it, expect } from 'vitest';
 import { CASCADE_OPTION_WIDGET_TYPES as fromCore } from '@object-ui/core';
-import { CASCADE_OPTION_WIDGET_TYPES as fromFields, resolveFormWidgetType } from '@object-ui/fields';
+// This package's own entry is imported RELATIVELY, not as `@object-ui/fields`.
+// A package self-import resolves through the published `exports` map to
+// `dist/*.d.ts`, and `fields:type-check` has no dependency edge on this
+// package's own build — so on a cold CI cache the declarations do not exist yet
+// and the self-import fails with TS2307 (it passes locally only because a
+// previous build left `dist/` behind). The relative specifier reads the SOURCE
+// entry, which is also what the vitest alias resolves `@object-ui/fields` to,
+// so the identity assertion below is over the same module either way.
+import { CASCADE_OPTION_WIDGET_TYPES as fromFields, resolveFormWidgetType } from './index';
 
 describe('CASCADE_OPTION_WIDGET_TYPES re-export (objectui#4770)', () => {
   it('is the SAME object as the core definition, not a copy', () => {

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -2486,6 +2486,19 @@ export function resolveFormWidgetType(fieldType: string): string {
   return fieldWidgetMap[mapped] ? mapped : 'text';
 }
 
+/**
+ * The widget keys that must be fed the live record (`dependentValues`) so their
+ * offered option set can be re-resolved per option `visibleWhen` / `dependsOn`.
+ *
+ * Defined in `@object-ui/core`, next to `resolveCascadingOptions` — the
+ * evaluator that reads the record — and re-exported here because this is the
+ * package whose {@link resolveFormWidgetType} produces the keys the set is
+ * keyed on: a consumer resolving a widget key finds the allow-table in the
+ * same place. One definition, two doorways; never a second copy (objectui#4770,
+ * which converged the three private copies that preceded it).
+ */
+export { CASCADE_OPTION_WIDGET_TYPES } from '@object-ui/core';
+
 /** Cache so each widget type creates one lazy component (and one chunk request). */
 const lazyFieldWidgets = new Map<string, React.ComponentType<any>>();
 

--- a/packages/plugin-grid/src/__tests__/bulkActionDialogRecord.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionDialogRecord.test.tsx
@@ -38,6 +38,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SchemaRendererContext } from '@object-ui/react';
+import { CASCADE_OPTION_WIDGET_TYPES } from '@object-ui/core';
 // Module scope, per AGENTS.md §测试纪律: the dialog reaches its widgets through
 // `getLazyFieldWidget` → `React.lazy(() => import('./widgets/RadioField'))`
 // inside `@object-ui/fields`, and a first dynamic import() under a saturated
@@ -234,5 +235,26 @@ describe('BulkActionDialog — the dialog IS the record for its option predicate
 
     await waitFor(() => expect(screen.getByTestId('select-empty-region')).toBeInTheDocument());
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+});
+
+describe('BulkActionDialog — the allow-table is the SHARED object (objectui#4770)', () => {
+  it('asks @object-ui/core CASCADE_OPTION_WIDGET_TYPES which params get the record', async () => {
+    // Identity, not membership — the same pin the other two surfaces carry
+    // (`app-shell/src/views/ActionParamDialog.dialogRecord.test.tsx`,
+    // `components/src/renderers/form/__tests__/form-dependent-values.test.tsx`).
+    // This file's four behavioural cases above pass against ANY set with these
+    // four members, including a re-inlined private copy — which is precisely
+    // the drift objectui#4770 removed and nothing could report. The spy is
+    // installed on the Set object exported by `@object-ui/core`, so it records
+    // a call only if this dialog consulted THAT object while rendering.
+    const spy = vi.spyOn(CASCADE_OPTION_WIDGET_TYPES, 'has');
+    try {
+      openDialog([COUNTRY, PROVINCE]);
+      expect(await screen.findByTestId('radio-option-zj')).toBeInTheDocument();
+      expect(spy.mock.calls.map(([k]) => k)).toContain('radio');
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -22,6 +22,12 @@ import {
 import { AlertTriangle, CheckCircle2, Loader2, XCircle } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import { getLazyFieldWidget } from '@object-ui/fields';
+// The shared allow-table of widgets that are fed the dialog's own in-progress
+// values as their record — one definition for this dialog, the single-record
+// action dialog and the object form (objectui#4770). Its TSDoc carries the
+// rationale (including the unruled picker-family boundary, objectui#4771) that
+// used to be repeated in each of the three copies.
+import { CASCADE_OPTION_WIDGET_TYPES } from '@object-ui/core';
 import type { BulkActionDef, BulkActionParam } from '@object-ui/types';
 import { useBulkExecutor, type BulkExecutorOptions, type BulkResult } from '../hooks/useBulkExecutor';
 import { hasMultiValueShape, type MultiValueFieldDef } from '../hooks/multiValueFields';
@@ -556,44 +562,6 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
     </Dialog>
   );
 };
-
-/**
- * Widget keys whose OFFERED option set is re-resolved against a live record by
- * the shared cascading-options evaluator (`useCascadingOptions` →
- * `resolveCascadingOptions`): each option may carry a `visibleWhen` CEL
- * predicate read against `record.*` (ADR-0058 / objectui#2284).
- *
- * SAME FOUR KEYS as the two other surfaces that feed that one evaluator, and
- * they must stay the same set or the three drift on what "the record" means:
- *
- * - `CASCADE_OPTION_WIDGET_TYPES` in `app-shell/src/views/ActionParamDialog.tsx`
- *   (the single-record action dialog, objectui#3765 / PR objectui#4756)
- * - `CASCADE_OPTION_FIELD_TYPES` in `components/src/renderers/form/form.tsx`
- *   (the object form, the original)
- *
- * Duplicated rather than imported ON PURPOSE, and this is a debt worth naming:
- * neither of those definitions is exported from its package, and plugin-grid
- * depends on neither app-shell (which depends the other way) nor form-internal
- * modules. Lifting the set to a shared home — `@object-ui/fields`, next to
- * `resolveFormWidgetType`, which every one of the three already imports — is
- * the right end state; it is out of scope here because objectui#4757 is scoped
- * to this file and both other packages have work in flight. If you move one
- * copy, move all three.
- *
- * It is an ALLOW-LIST, not a blanket pass-through, because `dependentValues` is
- * also the channel two widget-hint pickers read a specific SIBLING KEY from
- * (`filter-condition` reads `object_name`, `recipient-picker` reads
- * `recipient_type`) and the lookup family filters its query by it; feeding
- * those from bulk params is a different wiring question than the one ruled on
- * objectui#3765.
- *
- * `select` + `multiple: true` is not listed separately: `SelectField` delegates
- * to `MultiSelectField` with the whole prop object, so the key it resolves
- * under (`select`) is the one that must carry the record. The keys are the
- * post-`bulkParamToField` WIDGET keys (`resolveFormWidgetType` output), not the
- * authored `param.type` spellings.
- */
-const CASCADE_OPTION_WIDGET_TYPES = new Set(['select', 'multiselect', 'radio', 'checkboxes']);
 
 interface ParamFieldProps {
   param: BulkActionParam;


### PR DESCRIPTION
Fixes #4770

## 前提修正:本卡原文的落点不成立,按 A 案落地

本卡原文的修法是「抬升到 `@object-ui/fields` 导出,三处改 import(三处都已 import 该包的
`resolveFormWidgetType`,依赖方向成立)」。实施阶段核验证伪了这个前提:该条只对 app-shell /
plugin-grid 成立,`@object-ui/components` **不能**依赖 `@object-ui/fields` —— 依赖方向是
fields → components,AGENTS.md §3 的分层亦然。按原文执行只能收敛 2/3,第三份继续漂移,parity
钉也写不出来。

据 #4770 上 2026-08-16 的「PM 裁定·前提修正」评论,本 PR 按 **A 案** 实施:

- 共享常量落 `@object-ui/core` 的 `evaluator/optionRules.ts`,紧邻它所描述的求值器
  `resolveCascadingOptions`(evaluator barrel 已经 `export *`,barrel 无需改动);四个包都已依赖 core。
- `@object-ui/fields` 加**一行 re-export**,紧邻 `resolveFormWidgetType` —— 保留本卡原本要的可发现性:
  常量的成员正是这个函数的输出。
- 仓内直接先例:`EXPANDABLE_FIELD_TYPES`(`packages/core/src/utils/expand-fields.ts`)。同样是「form 层
  的允许表被不止一个面读」的问题,同样裁进 core,TSDoc 同样写明 single-source-of-truth 的理由。

## 改动

- `packages/core/src/evaluator/optionRules.ts` —— 新增导出常量 `CASCADE_OPTION_WIDGET_TYPES`
  (ReadonlySet,四成员 select / multiselect / radio / checkboxes)。TSDoc 归拢了原先在三份拷贝里各写
  一遍的三件事:哪些 widget 吃 `dependentValues`、它是允许表而非无差别透传(picker 家族的边界,见下)、
  以及成员是 widget key 而非作者书写的 type 拼写。
- `packages/fields/src/index.tsx` —— 一行 re-export,紧邻 `resolveFormWidgetType`。
- 三处删掉各自的内联副本,改 import 同一常量:`app-shell/src/views/ActionParamDialog.tsx`、
  `components/src/renderers/form/form.tsx`(局部名 `CASCADE_OPTION_FIELD_TYPES` 一并统一)、
  `plugin-grid/src/components/BulkActionDialog.tsx`。
- ⛔ 未触碰 `packages/fields/src/widgets/**`(#4005 同批在飞)。

行为零变化:三处成员逐字节相同,各消费方保留自己的归一化(form 的 `normalizeFieldType`、两个对话框的
`resolveFormWidgetType`),两者对这四个成员重合 —— 这正是共享一个集合安全的前提,已写进 TSDoc。

## parity 钉:钉的是「同一个对象」,不是「同样的成员」

三处既有的行为钉断言的是「哪些 widget 拿到了 record」,它们对**任何**含这四个成员的集合都是绿的,包括
各自内联的私有副本 —— 这正是三份拷贝能悄悄漂移、而没有任何 gate 能发现的原因。所以新钉断言的是**对象
身份**:spy 装在 core 导出的那个 Set 上,只有消费方渲染时确实问了**那个对象**才会记录到调用。

落点取舍(报告一并写明):没有任何一个包能同时 import 这三个消费方(components 不能反向依赖 app-shell /
plugin-grid),而三处的常量都是模块私有、也不应为测试而导出。因此取 PM 给的第二个选项 —— **各包各钉一条
identity 断言**,与该面既有的行为钉同文件(复用现成的 render harness);另加
`packages/fields/src/cascadeOptionWidgetTypes.reexport.test.tsx` 钉住 core 与 fields 两个出口是同一个
对象、成员恰为四个、且每个成员都是 `resolveFormWidgetType` 的不动点(即它们确实是本包词汇里的真 widget key)。

## 反向验证(先预判、后执行,已还原)

预判:把 plugin-grid 一处改回**成员逐字节相同**的内联 Set —— 该文件 4 条行为钉**全绿**(成员没变),
新增的身份钉**红**。实跑与预判一致:

```
 PASS  BulkActionDialog — the dialog IS the record ... > narrows a param's options against a value typed into a SIBLING param
 PASS  BulkActionDialog — the dialog IS the record ... > the SELECTION is never the record: the dialog values are the whole basis
 PASS  BulkActionDialog — the dialog IS the record ... > keeps an option whose predicate names a key NO param carries: fails OPEN
 PASS  BulkActionDialog — the dialog IS the record ... > empties a select whose every option the in-progress values exclude
 FAIL  BulkActionDialog — the allow-table is the SHARED object (objectui#4770) > asks @object-ui/core CASCADE_OPTION_WIDGET_TYPES which params get the record
       AssertionError: expected [] to include 'radio'
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

不属于「诊断变多」或「方向反转」那两族:身份钉是对某个具名对象上一次调用的存在性断言,去掉这次读取就去掉了
这次调用,方向就是直接的红。

## 未裁边界

#4771(picker 家族 —— `filter-condition` 读 `object_name`、`recipient-picker` 读 `recipient_type`、
lookup 家族用它过滤查询 —— 在动作/批量对话框是否该供给 `dependentValues`)本 PR **只归拢陈述,不裁**:
三面一致「不喂」的现状原先写在三份注释里,现在写在共享常量的 TSDoc 里一处,边界本身仍然敞着。

## 验证

- `pnpm exec vitest run packages/core packages/fields packages/components packages/app-shell/src/views packages/plugin-grid --maxWorkers=2`
  → `Test Files 646 passed (646)` / `Tests 7595 passed | 1 skipped (7596)`,exit 0。
- 四个钉文件 verbose:16 passed(含三条 identity 钉与三条 re-export 钉)。
- 仓根 `turbo run type-check --concurrency=2` → `Tasks: 81 successful, 81 total`;`check-control-bytes`、
  `check-changeset-presence`、`check-changeset-no-major`、`check-phantom-dependencies` 全绿;
  改动路径 eslint 0 error。
- changeset:`.changeset/cascade-option-allow-table-single-source.md`,patch × 5(core / fields /
  components / app-shell / plugin-grid,按实际触及)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_