### PR TITLE
fix(fields): group-labelled widget 的只读/零选项面也消费 host 的 description IDREF (#4005)

### DIFF
--- a/.changeset/great-hounds-sing.md
+++ b/.changeset/great-hounds-sing.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/fields': patch
+---
+
+A readonly group-labelled field is now DESCRIBED by its own help text, not just named by its label.
+
+The seven `labelling: 'group'` widgets (`address`, `geolocation`, `checkboxes`, `radio`, `rating`, `file`, `multiselect`) render a `<FormDescription>` in their readonly and zero-option states, and the form renderer publishes its `id` — but nothing in the document referenced that id, so the visible help text had no programmatic association with the field it describes. Measured before the change, one field per row: `consumers=0` on every readonly surface of all seven, against `consumers=1` on the same widget's editable one.
+
+`toHostGroupProps` now carries `aria-describedby` alongside the host `id` and `aria-labelledby`, onto the `role="group"` surface those states already render (a group is a description carrier under ARIA 1.2 — no focusable control required, which is why this became possible only once objectui#3990 gave those surfaces a role).
+
+Control-channel state deliberately does NOT come along: `aria-invalid` and `aria-required` report what a user's editing may do wrong, and a readonly display cannot be edited. The boundary is pinned from both sides, including with a live failed validation on a readonly required field. Editable surfaces are unchanged — a composite's editable container still leaves the description on the sub-input the user focuses, so the help text is never announced twice.

--- a/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
+++ b/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
@@ -7,8 +7,9 @@
  */
 
 /**
- * End-to-end: a group-labelled field's visible label names the widget's surface
- * in EVERY state it renders — not only the editable one (objectui#3990).
+ * End-to-end: a group-labelled field's visible label names — and its visible
+ * help text describes — the widget's surface in EVERY state it renders, not
+ * only the editable one (objectui#3990, objectui#4005).
  *
  * The residual of objectui#3961 / #3975. Those two moved the association from an
  * inert `<label for>` to the WAI-ARIA group pattern (the label publishes its own
@@ -50,13 +51,58 @@
  * editable e2e for exactly those two, and the last describe block pins that the
  * editable answers are untouched.
  *
+ * ## The description was the other half of the same defect (objectui#4005)
+ *
+ * #3990 landed the NAME and deliberately stopped there, because at the time the
+ * readonly surfaces had no role and an `aria-describedby` on a role-less
+ * `div` / `span` is as inert as the `aria-labelledby` was. Giving them
+ * `role="group"` retired that reason — a group is a description carrier under
+ * ARIA 1.2 with no focusable control required — but the help text stayed
+ * unconsumed. Measured on `origin/main` at `c25222758`, a real form, one field
+ * per row, counting the elements whose `aria-describedby` names the rendered
+ * `<FormDescription>`:
+ *
+ * ```
+ *                                    descEl  consumers  consumerTags
+ * address      editable   desc=YES   SET         1      [input]
+ * address      readonly   desc=YES   SET         0      []
+ * geolocation  editable   desc=YES   SET         1      [input]
+ * geolocation  readonly   desc=YES   SET         0      []
+ * checkboxes   editable   desc=YES   SET         1      [div[group]]
+ * checkboxes   readonly   desc=YES   SET         0      []
+ * radio        editable   desc=YES   SET         1      [div[radiogroup]]
+ * radio        readonly   desc=YES   SET         0      []
+ * rating       editable   desc=YES   SET         1      [div[group]]
+ * rating       readonly   desc=YES   SET         0      []
+ * file         editable   desc=YES   SET         1      [div[button]]
+ * file         readonly   desc=YES   SET         0      []
+ * multiselect  editable   desc=YES   SET         1      [div[group]]
+ * multiselect  readonly   desc=YES   SET         0      []
+ * ```
+ *
+ * All seven render the `<FormDescription>` in the readonly state — none is
+ * exempt for want of one — and all seven left it referenced by nothing. The
+ * `describes` block below is that table's 0 turning into 1; the boundary block
+ * after it pins the OTHER direction, that gaining the description gained
+ * nothing else (`aria-invalid` / `aria-required` are control-channel state and
+ * a readonly display is not a control — objectui#3291 / objectui#3318).
+ *
+ * The built-in branch is measured, not assumed, and it has no defect of this
+ * kind: `input` / `textarea` / `checkbox` / `switch` / `select` render a real
+ * control inside `<FormControl>` in the readonly state too, so the Slot's
+ * `aria-describedby` lands on it and the reading is `consumers=1` either way.
+ * (The comparison row in #4005's issue body reads `consumers=0` for a builtin;
+ * it was measured on `type: 'text'`, which is neither a `BUILTIN_FIELD_TYPES`
+ * member nor registered in a bare-registration setup, so that field rendered no
+ * control at all. The issue flagged the row as noise; this is the re-measure.)
+ *
  * The widgets are registered raw rather than through `registerAllFields()`, whose
  * `React.lazy` loaders put an unbounded module load inside a bounded `findBy`
  * window — this repo's known flake generator (AGENTS.md 测试纪律, objectui#3010).
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ComponentRegistry } from '@object-ui/core';
 // Module scope: pulls in the form renderer's registration side effect.
@@ -175,7 +221,7 @@ function labelTargets(): Array<{ forId: string; resolves: boolean; labelable: bo
 
 function fieldConfig(
   type: string,
-  opts: { readonly?: boolean; zeroOptions?: boolean } = {},
+  opts: { readonly?: boolean; zeroOptions?: boolean; description?: string; required?: boolean } = {},
 ): Record<string, unknown> {
   const config: any = { name: `f_${type}`, label: `Group Label ${type}`, type };
   if ((OPTION_TYPES as readonly string[]).includes(type)) {
@@ -185,23 +231,51 @@ function fieldConfig(
   // `mode: 'view'`, which renders a different (detail) path and was already
   // naming its group correctly.
   if (opts.readonly) config.readonly = true;
+  if (opts.description) config.description = opts.description;
+  if (opts.required) config.required = true;
   return config;
 }
 
 /** The real form renderer hosting one field — the #3990 reproduction. */
-function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+function renderForm(
+  fields: any[],
+  defaultValues: Record<string, unknown> = {},
+  opts: { showSubmit?: boolean } = {},
+) {
   const Form = ComponentRegistry.get('form')!;
   return render(
     <Form
       schema={{
         type: 'form',
         mode: 'create',
-        showSubmit: false,
+        showSubmit: !!opts.showSubmit,
+        submitLabel: 'Create',
         showCancel: false,
         defaultValues,
         fields,
       }}
     />,
+  );
+}
+
+/** The `<FormDescription>` the host renders for `description`, or null. */
+const descriptionEl = (): HTMLElement | null =>
+  document.querySelector('[id$="-form-item-description"]');
+
+/**
+ * Every element whose `aria-describedby` NAMES `id` — the measurement #4005 is
+ * about, read from the DOM rather than through a query helper.
+ *
+ * Deliberately not `getAllByLabelText` / `toHaveAccessibleDescription` alone:
+ * this has to count CONSUMERS, and the failure being pinned is a count of zero
+ * against a description element that renders perfectly well. An accessible-name
+ * query would answer "no match" for both "nobody references it" and "the
+ * reference resolves to nothing", and the token list matters too — after a
+ * failed validation the same attribute carries the message id as well.
+ */
+function describedbyConsumers(id: string): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('[aria-describedby]')).filter((el) =>
+    (el.getAttribute('aria-describedby') ?? '').split(/\s+/).includes(id),
   );
 }
 
@@ -265,18 +339,27 @@ describe('a READONLY group-labelled field is named by its host label (objectui#3
     expect(labelTargets().filter((l) => !l.resolves || !l.labelable)).toEqual([]);
   });
 
-  it.each(TYPES)('%s: the readonly surface takes the two whole-field keys ONLY', (type) => {
-    // The narrow pair is deliberate (`toHostGroupProps`): a readonly display has
-    // no focusable control, so control-only plumbing must not ride along. `name`
-    // is the one that would be a DOM leak of the objectui#3291 class — it is
-    // legal on form controls only, and these surfaces are `div` / `span`.
-    renderForm([{ ...fieldConfig(type, { readonly: true }), description: 'Some help' }], {
+  it.each(TYPES)('%s: the readonly surface takes the three whole-field keys ONLY', (type) => {
+    // The narrow set is deliberate (`toHostGroupProps`): the field's NAME, its
+    // DESCRIPTION, and the `role` that lets a non-control surface carry either.
+    // Nothing else. `name` is the one that would be a DOM leak of the
+    // objectui#3291 class — it is legal on form controls only, and these
+    // surfaces are `div` / `span`.
+    //
+    // Both halves are asserted here so neither can pass vacuously: an
+    // implementation that emits nothing at all would satisfy the three
+    // `not.toHaveAttribute`s on their own.
+    renderForm([fieldConfig(type, { readonly: true, description: 'Some help' })], {
       [`f_${type}`]: VALUES[type],
     });
 
     const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    expect(named).toHaveAttribute('id');
+    expect(named).toHaveAttribute('aria-labelledby');
+    expect(named).toHaveAttribute('aria-describedby');
     expect(named).not.toHaveAttribute('name');
     expect(named).not.toHaveAttribute('aria-invalid');
+    expect(named).not.toHaveAttribute('aria-required');
   });
 
   it('all seven readonly in ONE form: each is named exactly once', () => {
@@ -291,6 +374,147 @@ describe('a READONLY group-labelled field is named by its host label (objectui#3
   });
 });
 
+describe('a READONLY group-labelled field is DESCRIBED by its host help text (objectui#4005)', () => {
+  it.each(TYPES)('%s: the description has exactly one consumer, and it is the named group', (type) => {
+    renderForm([fieldConfig(type, { readonly: true, description: 'Some help' })], {
+      [`f_${type}`]: VALUES[type],
+    });
+
+    // The `<FormDescription>` renders in the readonly state for all seven —
+    // that was never the defect, and a widget whose readonly shape omitted it
+    // would have to be exempted here rather than silently pass.
+    const desc = descriptionEl();
+    expect(desc).not.toBeNull();
+    expect(desc).toHaveTextContent('Some help');
+
+    // 0 before this fix, 1 after — the whole issue, in one number.
+    const consumers = describedbyConsumers(desc!.id);
+    expect(consumers).toHaveLength(1);
+    expect(consumers[0]).toBe(screen.getByRole('group', { name: `Group Label ${type}` }));
+    // The same association read the way assistive tech resolves it.
+    expect(consumers[0]).toHaveAccessibleDescription('Some help');
+  });
+
+  it.each(TYPES)('%s: the description lands on the SAME element as the name', (type) => {
+    // Name and description must not drift onto two different elements: the one
+    // the host handed its id to is the field's surface, and both belong to it.
+    renderForm([fieldConfig(type, { readonly: true, description: 'Some help' })], {
+      [`f_${type}`]: VALUES[type],
+    });
+
+    const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    expect(named.getAttribute('id')).toMatch(/-form-item$/);
+    expect(named.getAttribute('aria-describedby')).toBe(descriptionEl()!.id);
+  });
+
+  it.each(TYPES)('%s: readonly with NO value describes the placeholder surface too', (type) => {
+    // `EmptyValue` is the same surface with nothing in it. Its own
+    // `aria-label` ("No value") is the NAME channel and is outranked by
+    // `aria-labelledby`; the description is a separate channel and must arrive
+    // on it just the same.
+    renderForm([fieldConfig(type, { readonly: true, description: 'Some help' })]);
+
+    const consumers = describedbyConsumers(descriptionEl()!.id);
+    expect(consumers).toHaveLength(1);
+    expect(consumers[0]).toBe(screen.getByRole('group', { name: `Group Label ${type}` }));
+  });
+
+  it('all seven readonly in ONE form: each description has exactly one consumer', () => {
+    const fields = TYPES.map((type) => fieldConfig(type, { readonly: true, description: 'Some help' }));
+    const values = Object.fromEntries(TYPES.map((type) => [`f_${type}`, VALUES[type]]));
+    renderForm(fields, values);
+
+    const descriptions = Array.from(
+      document.querySelectorAll<HTMLElement>('[id$="-form-item-description"]'),
+    );
+    expect(descriptions).toHaveLength(TYPES.length);
+    // Per description, not in aggregate: one field consuming another's id would
+    // keep a total count right while both associations are wrong.
+    for (const desc of descriptions) {
+      expect(describedbyConsumers(desc.id)).toHaveLength(1);
+    }
+  });
+});
+
+describe('the readonly surface gains the description and NOTHING else (objectui#3291 / #3318)', () => {
+  // The boundary, pinned from both sides. `aria-invalid` / `aria-required` are
+  // CONTROL-channel state: they report what a user's editing may do wrong, to
+  // the element they would edit. A readonly display cannot be edited, so
+  // neither may appear on it — in any circumstance, including the two that
+  // would produce them on an editable control.
+
+  it.each(TYPES)('%s: a REQUIRED readonly field is described, never aria-required', (type) => {
+    renderForm([fieldConfig(type, { readonly: true, required: true, description: 'Some help' })], {
+      [`f_${type}`]: VALUES[type],
+    });
+
+    const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    expect(named).toHaveAttribute('aria-describedby', descriptionEl()!.id);
+    expect(named).not.toHaveAttribute('aria-required');
+    expect(named).not.toHaveAttribute('aria-invalid');
+  });
+
+  it.each(TYPES)('%s: a FAILED validation still puts no aria-invalid on it', async (type) => {
+    // Measured as reachable, not presumed: a readonly `required` field with no
+    // value really is validated on submit and really does render its
+    // `<FormMessage>`, so this is the live invalid state rather than a
+    // hypothetical one.
+    renderForm([fieldConfig(type, { readonly: true, required: true, description: 'Some help' })], {}, {
+      showSubmit: true,
+    });
+
+    expect(screen.getByRole('group', { name: `Group Label ${type}` })).not.toHaveAttribute(
+      'aria-invalid',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    const message = await waitFor(() => {
+      const el = document.querySelector<HTMLElement>('[id$="-form-item-message"]');
+      if (!el) throw new Error('no validation message rendered');
+      return el;
+    });
+
+    // Re-queried after the re-render rather than reusing the pre-submit
+    // reference, so the assertion cannot read a detached node's stale attributes.
+    const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    // `<FormControl>`'s Slot widens `aria-describedby` to "description message"
+    // once there is an error, and the readonly surface forwards that verbatim —
+    // the same value the editable control would carry. What it must NOT gain is
+    // the state channel.
+    expect(named.getAttribute('aria-describedby')?.split(/\s+/)).toEqual([
+      descriptionEl()!.id,
+      message.id,
+    ]);
+    expect(named).not.toHaveAttribute('aria-invalid');
+    expect(named).not.toHaveAttribute('aria-required');
+  });
+
+  it.each(TYPES)('%s: a readonly field with NO description answers as the editable one does', (type) => {
+    // Honest pin, not an aspiration: `<FormControl>`'s Slot emits the
+    // description IDREF unconditionally, so a field without a `description`
+    // hands EVERY control — builtin, single-control widget, and now this
+    // readonly surface — a reference to an element that never rendered.
+    // Measured on `origin/main` at `c25222758`, `desc=NO`: all seven
+    // group-labelled widgets plus builtin `input` and `email` already carried
+    // exactly one such reference on their editable control. The readonly
+    // surface answering the same way is parity; it is NOT this issue's defect
+    // (an unresolvable IDREF is inert for assistive tech, while an unconsumed
+    // description is simply lost), and pinning it here is what would make a
+    // later change to that unconditional emission visible.
+    renderForm([fieldConfig(type, { readonly: true })], { [`f_${type}`]: VALUES[type] });
+
+    expect(descriptionEl()).toBeNull();
+    const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    const describedby = named.getAttribute('aria-describedby');
+    expect(describedby).toMatch(/-form-item-description$/);
+    expect(document.getElementById(describedby!)).toBeNull();
+    // Which is the point: an IDREF resolving to nothing contributes no
+    // accessible description, so the surface announces exactly what it did
+    // before this change.
+    expect(named).not.toHaveAccessibleDescription();
+  });
+});
+
 describe('a ZERO-OPTION group-labelled field is named by its host label (objectui#3990)', () => {
   it.each(OPTION_TYPES)('%s: the unfillable-options box is the named group', (type) => {
     renderForm([fieldConfig(type, { zeroOptions: true })]);
@@ -302,6 +526,23 @@ describe('a ZERO-OPTION group-labelled field is named by its host label (objectu
     expect(named[0]).toBe(screen.getByTestId(`${type}-empty-f_${type}`));
     expect(named[0].getAttribute('id')).toMatch(/-form-item$/);
     expect(screen.getAllByLabelText(`Group Label ${type}`)).toEqual(named);
+  });
+
+  it.each(OPTION_TYPES)('%s: the unfillable-options box is also DESCRIBED (objectui#4005)', (type) => {
+    // Same surface, same reasoning: this box is everything the field renders in
+    // this state, so there is no option control anywhere for the help text to
+    // be announced on. It asks `toHostGroupProps` for the same
+    // `'instead-of-the-inputs'` answer the readonly branches do.
+    renderForm([fieldConfig(type, { zeroOptions: true, description: 'Some help' })]);
+
+    const box = screen.getByTestId(`${type}-empty-f_${type}`);
+    const consumers = describedbyConsumers(descriptionEl()!.id);
+    expect(consumers).toEqual([box]);
+    expect(box).toHaveAccessibleDescription('Some help');
+    // The boundary holds here too.
+    expect(box).not.toHaveAttribute('aria-invalid');
+    expect(box).not.toHaveAttribute('aria-required');
+    expect(box).not.toHaveAttribute('name');
   });
 
   it.each(OPTION_TYPES)('%s: readonly wins over zero options, and is still named', (type) => {
@@ -330,6 +571,33 @@ describe('the editable answers are untouched (objectui#3961 / #3975 regression)'
     renderForm([fieldConfig(type, { readonly: true })], { [`f_${type}`]: VALUES[type] });
     expect(screen.getAllByRole('group', { name: `Group Label ${type}` })).toHaveLength(1);
   });
+
+  it.each(TYPES)('%s: editable still has exactly ONE description consumer', (type) => {
+    // The regression #4005 could most easily have caused. `address` and
+    // `geolocation` spread the SAME helper's result on their editable
+    // container, so a `toHostGroupProps` that always emitted
+    // `aria-describedby` would have described the container as well as the
+    // sub-input inside it — the help text announced twice, which is the double
+    // channel objectui#3290 removed from the required marker and objectui#3318
+    // refused for this one. The `'above-the-inputs'` argument at those two call
+    // sites is the only thing preventing it.
+    renderForm([fieldConfig(type, { description: 'Some help' })], { [`f_${type}`]: VALUES[type] });
+
+    expect(describedbyConsumers(descriptionEl()!.id)).toHaveLength(1);
+  });
+
+  it.each(['address', 'geolocation'])(
+    '%s: the editable CONTAINER stays undescribed, the sub-input keeps it',
+    (type) => {
+      renderForm([fieldConfig(type, { description: 'Some help' })], { [`f_${type}`]: VALUES[type] });
+
+      const container = screen.getByRole('group', { name: `Group Label ${type}` });
+      expect(container).not.toHaveAttribute('aria-describedby');
+      const [consumer] = describedbyConsumers(descriptionEl()!.id);
+      expect(consumer.tagName.toLowerCase()).toBe('input');
+      expect(container.contains(consumer)).toBe(true);
+    },
+  );
 });
 
 describe('STANDALONE readonly widgets are unchanged (objectui#3990)', () => {
@@ -357,6 +625,28 @@ describe('STANDALONE readonly widgets are unchanged (objectui#3990)', () => {
     expect(screen.queryAllByRole('group')).toHaveLength(0);
     expect(document.querySelector('[aria-labelledby]')).toBeNull();
     expect(document.querySelector('[id]')).toBeNull();
+  });
+
+  it.each(TYPES)('%s: no description channel either (objectui#4005)', (type) => {
+    const Widget = WIDGETS[type];
+    render(
+      <Widget
+        value={VALUES[type]}
+        onChange={() => {}}
+        readonly
+        field={{
+          name: type,
+          label: `Group Label ${type}`,
+          type,
+          ...((OPTION_TYPES as readonly string[]).includes(type) ? { options: OPTIONS } : null),
+        }}
+      />,
+    );
+
+    // No host, so no IDREF was handed down and none may be invented: the third
+    // key is `undefined` exactly like the first two, React emits no attribute,
+    // and this markup stays byte-identical to what it was.
+    expect(document.querySelector('[aria-describedby]')).toBeNull();
   });
 
   it.each(TYPES)('%s: no value, still nothing emitted', (type) => {

--- a/packages/fields/src/widgets/AddressField.tsx
+++ b/packages/fields/src/widgets/AddressField.tsx
@@ -56,11 +56,20 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
     'aria-labelledby': _hostLabelledBy,
     ...domProps
   } = toDomProps(props);
-  // The pair held back above, in the one spelling every group-labelled widget
-  // uses for it — and computed HERE, before the readonly early return below,
-  // because that return used to drop both keys on the floor: a published label
-  // id with no consumer in the document (objectui#3990). See `toHostGroupProps`.
-  const hostGroupProps = toHostGroupProps(props);
+  // The keys held back above, in the one spelling every group-labelled widget
+  // uses for them — and computed HERE, before the readonly early return below,
+  // because that return used to drop them on the floor: a published label id
+  // with no consumer in the document (objectui#3990). See `toHostGroupProps`.
+  //
+  // TWO surfaces, so two answers, and the difference is only the description
+  // (objectui#4005). Readonly this widget collapses to ONE formatted line with
+  // no sub-input in it, so that line is the only thing that can carry the help
+  // text. The editable container below is a different case: its five sub-inputs
+  // each take `aria-describedby` in the `domProps` spread, and the container
+  // must NOT take it a second time — objectui#3318's split, pinned in
+  // `composite-group-label-e2e.test.tsx`.
+  const readonlyHostGroupProps = toHostGroupProps(props, 'instead-of-the-inputs');
+  const hostGroupProps = toHostGroupProps(props, 'above-the-inputs');
   // Sub-input ids (objectui#3343): `useId()` prefix + sub-field name — the
   // `groupId` paradigm of RadioField / CheckboxesField. Hardcoded literals
   // ("street", "city", …) collide as soon as a form renders two address
@@ -98,7 +107,9 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
 
   if (readonly) {
     // Readonly the composite collapses to ONE formatted line — no sub-inputs and
-    // no sub-labels — so that line is the surface the host label names, and
+    // no sub-labels — so that line is the surface the host label names, the
+    // surface its help text describes (objectui#4005: with the sub-inputs gone,
+    // the description's IDREF had no consumer left in the document), and
     // `EmptyValue` is the same surface with nothing in it (objectui#3990). The
     // placeholder's own `aria-label` ("No value") is outranked by
     // `aria-labelledby` per accname, and on its `generic` role an author name was
@@ -110,9 +121,9 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
     // (the very thing objectui#4037 unified them for).
     const formatted = formatAddress(address, displayLocale);
     return formatted ? (
-      <span {...hostGroupProps} className="text-sm">{formatted}</span>
+      <span {...readonlyHostGroupProps} className="text-sm">{formatted}</span>
     ) : (
-      <EmptyValue {...hostGroupProps} />
+      <EmptyValue {...readonlyHostGroupProps} />
     );
   }
 
@@ -122,7 +133,10 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
     // standalone rendering — the inline grid editor, a bare SDUI node — must stay
     // byte-identical to what it was before. That condition now lives in
     // `toHostGroupProps` so this container and the readonly line above cannot
-    // answer differently (objectui#3990).
+    // answer differently about the NAME (objectui#3990). They answer differently
+    // about exactly one key, by declaration rather than by drift: this container
+    // asks for `'above-the-inputs'` and gets no `aria-describedby`, because the
+    // sub-inputs below already carry it (objectui#3318 / objectui#4005).
     // The five sub-inputs carry NO placeholder any more (objectui#4028). They
     // used to hold `123 Main St` / `San Francisco` / `CA` / `94102` / `United
     // States` — untranslated AND US-specific, so a zh/ja/ar user was shown an

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -66,12 +66,15 @@ export function CheckboxesField({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, gated]);
 
-  // The host's group label has to be consumed on EVERY surface this widget can
-  // render, not only the editable one (objectui#3990): both branches below
-  // return before the editable container's `groupDomProps` spread, which is how
-  // a field-level `readonly: true` and a zero-option list ended up with a
-  // published label id and no consumer at all. See `toHostGroupProps`.
-  const hostGroupProps = toHostGroupProps(props);
+  // The host's group label — and its help text (objectui#4005) — have to be
+  // consumed on EVERY surface this widget can render, not only the editable one
+  // (objectui#3990): both branches below return before the editable container's
+  // `groupDomProps` spread, which is how a field-level `readonly: true` and a
+  // zero-option list ended up with a published label id and a published
+  // description id and no consumer at all. Neither surface renders a checkbox,
+  // so neither has anywhere else to put the description. See
+  // `toHostGroupProps`.
+  const hostGroupProps = toHostGroupProps(props, 'instead-of-the-inputs');
 
   if (readonly) {
     // The readonly display of a checkbox set is the set of CHECKED labels — a

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -186,12 +186,14 @@ export function FileField({ value, onChange, field, readonly, onUploadingChange,
   if (readonly) {
     // Readonly there is no dropzone: the field's whole rendered surface is the
     // list of file names, so THAT is what the host's group label names
-    // (objectui#3990). The role is therefore `group` here and `button` (the
-    // dropzone) while editable — the same widget, two different surfaces. See
-    // `toHostGroupProps`; `EmptyValue`'s own `aria-label` ("No value") is
+    // (objectui#3990) and what its help text describes (objectui#4005) — the
+    // dropzone that took the description while editable is exactly what this
+    // branch does not render. The role is therefore `group` here and `button`
+    // (the dropzone) while editable — the same widget, two different surfaces.
+    // See `toHostGroupProps`; `EmptyValue`'s own `aria-label` ("No value") is
     // outranked by `aria-labelledby` per accname, and on the `generic` role that
     // placeholder span carries it was never exposed as a name anyway.
-    const hostGroupProps = toHostGroupProps(props);
+    const hostGroupProps = toHostGroupProps(props, 'instead-of-the-inputs');
     if (!value) return <EmptyValue {...hostGroupProps} />;
 
     return (

--- a/packages/fields/src/widgets/GeolocationField.tsx
+++ b/packages/fields/src/widgets/GeolocationField.tsx
@@ -37,11 +37,21 @@ export function GeolocationField({ value, onChange, field, readonly, error, ...p
     'aria-labelledby': _hostLabelledBy,
     ...domProps
   } = toDomProps(props);
-  // The pair held back above, in the one spelling every group-labelled widget
-  // uses for it — and computed HERE, before the readonly early return below,
-  // because that return used to drop both keys on the floor: a published label
-  // id with no consumer in the document (objectui#3990). See `toHostGroupProps`.
-  const hostGroupProps = toHostGroupProps(props);
+  // The keys held back above, in the one spelling every group-labelled widget
+  // uses for them — and computed HERE, before the readonly early return below,
+  // because that return used to drop them on the floor: a published label id
+  // with no consumer in the document (objectui#3990). See `toHostGroupProps`.
+  //
+  // TWO surfaces, so two answers, and the difference is only the description
+  // (objectui#4005). Readonly this widget collapses to a coordinates row with no
+  // lat/lng input in it, so that row is the only thing that can carry the help
+  // text — the "View on map" link inside it is focusable but is not an input of
+  // the FIELD and never receives the field's `aria-describedby`. The editable
+  // container below is a different case: its sub-inputs each take
+  // `aria-describedby` in the `domProps` spread and the container must NOT take
+  // it a second time — objectui#3318's split.
+  const readonlyHostGroupProps = toHostGroupProps(props, 'instead-of-the-inputs');
+  const hostGroupProps = toHostGroupProps(props, 'above-the-inputs');
   // Sub-input ids (objectui#3343): `useId()` prefix + sub-field name — the
   // `groupId` paradigm of RadioField / CheckboxesField. Hardcoded literals
   // ("latitude" / "longitude") collide as soon as a form renders two
@@ -99,11 +109,12 @@ export function GeolocationField({ value, onChange, field, readonly, error, ...p
   if (readonly) {
     // Readonly the composite collapses to the formatted coordinates (plus the
     // "View on map" link), so THAT row is the surface the host label names
-    // (objectui#3990). The `EmptyValue` placeholder sits inside it, so it needs
-    // nothing of its own.
+    // (objectui#3990) and the surface its help text describes (objectui#4005).
+    // The `EmptyValue` placeholder sits inside it, so it needs nothing of its
+    // own.
     const formatted = formatLocation(location);
     return (
-      <div {...hostGroupProps} className="flex items-center gap-2">
+      <div {...readonlyHostGroupProps} className="flex items-center gap-2">
         <MapPin className="w-4 h-4 text-muted-foreground" />
         {formatted ? <span className="text-sm">{formatted}</span> : <EmptyValue />}
         {location.latitude && location.longitude && (
@@ -125,7 +136,11 @@ export function GeolocationField({ value, onChange, field, readonly, error, ...p
     // `role="group"` only when a host actually named this container
     // (objectui#3961); standalone rendering stays exactly as it was. That
     // condition now lives in `toHostGroupProps` so this container and the
-    // readonly row above cannot answer differently (objectui#3990).
+    // readonly row above cannot answer differently about the NAME
+    // (objectui#3990). They answer differently about exactly one key, by
+    // declaration rather than by drift: this container asks for
+    // `'above-the-inputs'` and gets no `aria-describedby`, because the
+    // sub-inputs below already carry it (objectui#3318 / objectui#4005).
     <div className="space-y-3" {...hostGroupProps}>
       <div className="flex items-center gap-2">
         <Button

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -86,12 +86,15 @@ export function MultiSelectField({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, gated]);
 
-  // The host's group label has to be consumed on EVERY surface this widget can
-  // render, not only the editable one (objectui#3990): both branches below
-  // return before the editable container's `groupDomProps` spread, which is how
-  // a field-level `readonly: true` and a zero-option list ended up with a
-  // published label id and no consumer at all. See `toHostGroupProps`.
-  const hostGroupProps = toHostGroupProps(props);
+  // The host's group label — and its help text (objectui#4005) — have to be
+  // consumed on EVERY surface this widget can render, not only the editable one
+  // (objectui#3990): both branches below return before the editable container's
+  // `groupDomProps` spread, which is how a field-level `readonly: true` and a
+  // zero-option list ended up with a published label id and a published
+  // description id and no consumer at all. Neither surface renders a chip
+  // picker, so neither has anywhere else to put the description. See
+  // `toHostGroupProps`.
+  const hostGroupProps = toHostGroupProps(props, 'instead-of-the-inputs');
 
   if (readonly) {
     // A readonly set of values is still a set, so it takes the same `group`

--- a/packages/fields/src/widgets/OptionsEmptyState.tsx
+++ b/packages/fields/src/widgets/OptionsEmptyState.tsx
@@ -57,13 +57,19 @@ export interface OptionsEmptyStateProps {
    * The host label's IDREF plumbing, when this box is the whole rendered surface
    * of a group-labelled field (objectui#3990) — a `checkboxes` / `radio` /
    * `multiselect` whose option list came back empty renders NOTHING but this
-   * box, so the visible label named zero elements until it landed here.
+   * box, so the visible label named zero elements until it landed here. Its
+   * help text described zero elements for the same reason, which is why the
+   * callers ask `toHostGroupProps` for the `'instead-of-the-inputs'` surface:
+   * there is no option control in this state to announce the description on
+   * (objectui#4005).
    *
-   * A closed three-key type rather than an open props tail: only `id`,
-   * `aria-labelledby` and the `role` that makes them meaningful may reach this
-   * element, and reopening a spread is what objectui#3291 exists to prevent.
-   * Absent for the single `SelectField` — it is not group-labelled, its label
-   * still uses a plain `for`, and it must keep emitting no such attributes.
+   * A closed type rather than an open props tail: only `id`, `aria-labelledby`,
+   * `aria-describedby` and the `role` that makes them meaningful may reach this
+   * element, and reopening a spread is what objectui#3291 exists to prevent —
+   * `aria-invalid` / `aria-required` are control-channel state and stay off this
+   * surface. Absent for the single `SelectField` — it is not group-labelled, its
+   * label still uses a plain `for`, and it must keep emitting no such
+   * attributes.
    */
   hostGroupProps?: HostGroupProps;
 }

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -63,14 +63,16 @@ export function RadioField({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, gated]);
 
-  // The host's group label has to be consumed on EVERY surface this widget can
-  // render, not only the `RadioGroup` (objectui#3990): both branches below return
-  // before that spread, which is how a field-level `readonly: true` and a
-  // zero-option list ended up with a published label id and no consumer at all.
+  // The host's group label — and its help text (objectui#4005) — have to be
+  // consumed on EVERY surface this widget can render, not only the `RadioGroup`
+  // (objectui#3990): both branches below return before that spread, which is how
+  // a field-level `readonly: true` and a zero-option list ended up with a
+  // published label id and a published description id and no consumer at all.
   // See `toHostGroupProps` — note the role it emits is `group`, not the
   // `radiogroup` the editable branch keeps: there is not one radio left in
-  // either of these surfaces.
-  const hostGroupProps = toHostGroupProps(props);
+  // either of these surfaces, which is also why the description has nowhere
+  // else to go here.
+  const hostGroupProps = toHostGroupProps(props, 'instead-of-the-inputs');
 
   if (readonly) {
     // `EmptyValue`'s own `aria-label` ("No value") is outranked by

--- a/packages/fields/src/widgets/RatingField.tsx
+++ b/packages/fields/src/widgets/RatingField.tsx
@@ -22,9 +22,14 @@ export function RatingField({ value, onChange, field, readonly, className, error
   if (readonly) {
     // The readonly star row is the field's whole rendered surface, so it — not
     // only the editable row below — consumes the host's group label
-    // (objectui#3990). See `toHostGroupProps`.
+    // (objectui#3990) and its help text (objectui#4005). There is no star
+    // BUTTON left in this row to announce the description on. See
+    // `toHostGroupProps`.
     return (
-      <div {...toHostGroupProps(props)} className={cn("flex items-center gap-1", className)}>
+      <div
+        {...toHostGroupProps(props, 'instead-of-the-inputs')}
+        className={cn("flex items-center gap-1", className)}
+      >
         {Array.from({ length: max }, (_, i) => (
           <Star
             key={i}

--- a/packages/fields/src/widgets/toHostGroupProps.ts
+++ b/packages/fields/src/widgets/toHostGroupProps.ts
@@ -10,19 +10,21 @@ import { toDomProps } from './toDomProps';
 
 /**
  * The props that make a group-labelled widget's rendered surface the thing its
- * host label actually NAMES, on the surfaces that are not controls
- * (objectui#3990).
+ * host label actually NAMES — and, where nothing else can carry it, DESCRIBES
+ * (objectui#3990, objectui#4005).
  *
  * ## What it is for
  *
  * A widget declared `labelling: 'group'` (objectui#3961) is told by the form
  * renderer: your label publishes an `id` and drops its `for`, so name yourself
- * by IDREF. The renderer hands down exactly two facts that address the field as
- * a WHOLE:
+ * by IDREF. The renderer hands down facts that address the field as a WHOLE:
  *
  *  - `id` — the host's control id (`…-form-item`), the id the label's `for`
  *    used to point at;
- *  - `aria-labelledby` — the IDREF of that visible label.
+ *  - `aria-labelledby` — the IDREF of that visible label;
+ *  - `aria-describedby` — the IDREF of `<FormDescription>`, the field's visible
+ *    help text. Which surface may consume it is the one thing that is NOT
+ *    uniform, so it is decided per call site — see {@link HostGroupSurface}.
  *
  * Every editable branch already consumes them inside its wider `toDomProps`
  * spread. The branches that returned EARLY did not — a field-level
@@ -42,19 +44,66 @@ import { toDomProps } from './toDomProps';
  * to nothing can at least be swept for, while "a label published an id and
  * nobody consumed it" looks like healthy markup.
  *
- * ## Why this narrow pair, and not the whole `toDomProps` result
+ * ## The description was the other half of the same defect (objectui#4005)
  *
- * Everything else in the DOM pass-through addresses a CONTROL, and a readonly
- * display has none: `aria-describedby` / `aria-required` are announced when
- * focus lands on something focusable, `disabled` / `tabIndex` / the focus
- * handlers only mean something on an interactive element, and `name` is
- * DOM-legal on form controls only — on a `div` it is exactly the leak
- * objectui#3291 sweeps for. Spreading the full result would also put the host's
- * `className` on top of the widget's own, because the widgets whose readonly
- * surface is a placeholder or a plain container (`EmptyValue`, `FileField`,
- * `AddressField`) keep `className` inside `props`.
+ * #3990 landed the `id` + `aria-labelledby` pair above and deliberately stopped
+ * there. The reasoning it recorded — a readonly display has no focusable
+ * control, and `aria-describedby` is announced when focus lands on something
+ * focusable — was the right call for the surface as it stood THEN: before this
+ * helper existed, a readonly branch had no role at all, and on a role-less
+ * `div` / `span` an `aria-describedby` is as inert as the `aria-labelledby`
+ * was. That premise expired the moment #3990 gave those surfaces
+ * `role="group"`. A group IS a description carrier under ARIA 1.2: assistive
+ * technology announces a group's name and description on entering it, with no
+ * focusable control required. So the help text stayed measurably unreachable
+ * for exactly as long as it took to have somewhere to put it. Measured on
+ * `origin/main` at `c25222758`, a real form, one field per row, counting the
+ * elements whose `aria-describedby` names the rendered `<FormDescription>`:
  *
- * ## Why `role` travels with the two keys
+ * ```
+ *                                    descEl  consumers  consumerTags
+ * address      editable   desc=YES   SET         1      [input]
+ * address      readonly   desc=YES   SET         0      []
+ * geolocation  editable   desc=YES   SET         1      [input]
+ * geolocation  readonly   desc=YES   SET         0      []
+ * checkboxes   editable   desc=YES   SET         1      [div[group]]
+ * checkboxes   readonly   desc=YES   SET         0      []
+ * radio        editable   desc=YES   SET         1      [div[radiogroup]]
+ * radio        readonly   desc=YES   SET         0      []
+ * rating       editable   desc=YES   SET         1      [div[group]]
+ * rating       readonly   desc=YES   SET         0      []
+ * file         editable   desc=YES   SET         1      [div[button]]
+ * file         readonly   desc=YES   SET         0      []
+ * multiselect  editable   desc=YES   SET         1      [div[group]]
+ * multiselect  readonly   desc=YES   SET         0      []
+ * ```
+ *
+ * All seven render the `<FormDescription>` in the readonly state — none is
+ * exempt for want of one — and all seven left it referenced by nothing.
+ *
+ * ## What still does NOT come along, and why that is a boundary and not an oversight
+ *
+ * `aria-invalid` and `aria-required` are CONTROL-channel state: they report
+ * what a user's own editing may do wrong, to the element they would edit. A
+ * readonly display cannot be edited and cannot be made invalid by the person
+ * reading it, so putting either on it announces a state that has no action
+ * behind it. Spreading the whole `toDomProps` result would drag both back —
+ * along with `disabled` / `tabIndex` / the focus handlers, which only mean
+ * something on an interactive element, and `name`, which is DOM-legal on form
+ * controls only and on a `div` is exactly the leak objectui#3291 sweeps for.
+ * That is what objectui#3291 and objectui#3318 drew the line against, and
+ * adding the description does not move it: the description is what the FIELD
+ * is, the other two are what the CONTROL is doing. The line is pinned from both
+ * sides in `composite-group-label-readonly-e2e.test.tsx` — the description must
+ * be there, `aria-invalid` / `aria-required` must not — so neither a later
+ * "spread it all" nor a later "take it all back out" can pass quietly.
+ *
+ * Spreading the full result would also put the host's `className` on top of the
+ * widget's own, because the widgets whose readonly surface is a placeholder or
+ * a plain container (`EmptyValue`, `FileField`, `AddressField`) keep
+ * `className` inside `props`.
+ *
+ * ## Why `role` travels with the keys
  *
  * `aria-labelledby` on a role-less `div` / `span` names NOTHING — `generic`
  * prohibits an author name — so the pair is inert without a role that supports
@@ -76,27 +125,85 @@ export interface HostGroupProps {
   id?: string;
   /** IDREF of the host's visible label. */
   'aria-labelledby'?: string;
+  /**
+   * IDREF of the host's visible help text — present only on a surface that
+   * renders no input of the field's own. See {@link HostGroupSurface}.
+   */
+  'aria-describedby'?: string;
   /** `'group'` when — and only when — a host named this surface. */
   role?: 'group';
 }
 
 /**
- * Read the two whole-field keys out of a widget's leftover props, plus the role
- * that makes them mean something. See {@link HostGroupProps}.
+ * WHERE the surface being named sits relative to the field's own inputs. The
+ * name is uniform; the DESCRIPTION is not, so every call site has to say which
+ * of the two shapes it is, and the compiler makes the next widget author say it
+ * too rather than inherit whichever default happened to be there.
+ *
+ *  - `'above-the-inputs'` — a composite's EDITABLE container (`address`,
+ *    `geolocation`): the field's real inputs are inside it and each already
+ *    receives `aria-describedby` in its own `toDomProps` spread, straight from
+ *    `<FormControl>`'s Slot. This surface therefore takes the NAME only.
+ *    objectui#3318 chose that split deliberately and
+ *    `composite-group-label-e2e.test.tsx` pins it: the help text is announced
+ *    when focus reaches the box the user types into, and announcing it a second
+ *    time on the container that merely wraps those boxes is a double channel of
+ *    exactly the kind objectui#3290 removed from the required marker.
+ *
+ *  - `'instead-of-the-inputs'` — every readonly branch, and the zero-option box
+ *    (`OptionsEmptyState`). The field renders no input at all here, so no
+ *    element inside can carry the description and this surface is the only
+ *    candidate there is. It takes the name AND the description.
+ *
+ * Note what the discriminator is NOT about: whether the surface contains
+ * anything focusable. `geolocation`'s readonly row holds a "View on map" link
+ * — focusable, and correctly announced as itself. It is not an input OF THE
+ * FIELD and never receives the field's `aria-describedby`, so that row is still
+ * `'instead-of-the-inputs'`.
+ */
+export type HostGroupSurface = 'above-the-inputs' | 'instead-of-the-inputs';
+
+/**
+ * Read the whole-field keys out of a widget's leftover props, plus the role
+ * that makes them mean something. See {@link HostGroupProps} and
+ * {@link HostGroupSurface}.
  *
  * Routed through {@link toDomProps} rather than reading `props` directly so the
- * pair keeps ONE gate: those keys reach an element only if the DOM pass-through
- * whitelist still forwards them, and its two compile-time assertions bind that
+ * keys keep ONE gate: they reach an element only if the DOM pass-through
+ * whitelist still forwards them, and its compile-time assertions bind that
  * whitelist to the props contract in both directions.
+ *
+ * `aria-describedby` is forwarded exactly as the host handed it down, with no
+ * check that it resolves — a widget cannot see whether `<FormDescription>`
+ * rendered, and a DOM probe for it would be a layout-effect hack around the
+ * renderer's own knowledge. That is not a new gap: `<FormControl>`'s Slot emits
+ * the IDREF unconditionally, so a field with NO description already hands every
+ * editable control an `aria-describedby` pointing at an element that does not
+ * exist. Measured on `origin/main` at `c25222758`, `desc=NO`: all seven
+ * group-labelled widgets plus the builtin `input` and the single-control
+ * `email` carry exactly one such reference, on the same element that would
+ * carry a resolving one. A readonly surface answering identically is parity
+ * with the editable branch, not a class of its own — and an IDREF that resolves
+ * to nothing is inert for assistive technology, where an unconsumed
+ * description is simply lost.
  */
-export function toHostGroupProps(props: {
-  id?: string;
-  'aria-labelledby'?: string;
-}): HostGroupProps {
-  const { id, 'aria-labelledby': labelledBy } = toDomProps(props);
+export function toHostGroupProps(
+  props: {
+    id?: string;
+    'aria-labelledby'?: string;
+    'aria-describedby'?: string;
+  },
+  surface: HostGroupSurface,
+): HostGroupProps {
+  const {
+    id,
+    'aria-labelledby': labelledBy,
+    'aria-describedby': describedBy,
+  } = toDomProps(props);
   return {
     id,
     'aria-labelledby': labelledBy,
+    ...(surface === 'instead-of-the-inputs' ? { 'aria-describedby': describedBy } : null),
     ...(labelledBy != null ? { role: 'group' as const } : null),
   };
 }


### PR DESCRIPTION
Fixes #4005

## 这条修的是什么

#3990 / PR #4002 让七个 group-labelled widget 的只读面消费了 host label 的 IDREF(**名**),并**刻意**停在那里。当时写在 `toHostGroupProps` 注释里的理由是:只读面没有可聚焦控件,而 `aria-describedby` 是「焦点落到可聚焦元素上时宣读」的通道。

**那个理由在 #4002 落地的同一刻就过期了** —— 它自己给这些面发了 `role="group"`,而 group 在 ARIA 1.2 里**是**合法的描述承载者:辅助技术进入一个 group 时会宣读它的名与描述,不要求里面有可聚焦控件。于是可见的帮助文本在只读态继续「发了 id 没人引用」,恰好持续到有地方可放它为止。本 PR 把 helper 从两键扩到三键。

## 逐 widget 实测(七类全量,含正文列为「未实测」的四类)

`origin/main` c25222758,真 form renderer + 裸注册 `labelling: 'group'`,字段带 `description: 'Some help'`,数「引用 `…-form-item-description` 这个 id 的元素个数」:

| widget | 态 | descEl | consumers(before) | consumerTags(before) | consumers(after) | consumerTags(after) |
|---|---|---|---|---|---|---|
| address | editable | SET | 1 | `[input]` | 1 | `[input]` |
| address | **readonly** | SET | **0** | `[]` | **1** | `[span[group]]` |
| geolocation | editable | SET | 1 | `[input]` | 1 | `[input]` |
| geolocation | **readonly** | SET | **0** | `[]` | **1** | `[div[group]]` |
| checkboxes | editable | SET | 1 | `[div[group]]` | 1 | `[div[group]]` |
| checkboxes | **readonly** | SET | **0** | `[]` | **1** | `[div[group]]` |
| radio | editable | SET | 1 | `[div[radiogroup]]` | 1 | `[div[radiogroup]]` |
| radio | **readonly** | SET | **0** | `[]` | **1** | `[span[group]]` |
| rating | editable | SET | 1 | `[div[group]]` | 1 | `[div[group]]` |
| rating | **readonly** | SET | **0** | `[]` | **1** | `[div[group]]` |
| file | editable | SET | 1 | `[div[button]]` | 1 | `[div[button]]` |
| file | **readonly** | SET | **0** | `[]` | **1** | `[div[group]]` |
| multiselect | editable | SET | 1 | `[div[group]]` | 1 | `[div[group]]` |
| multiselect | **readonly** | SET | **0** | `[]` | **1** | `[div[group]]` |

正文列为「未实测」的四类(`multiselect` / `rating` / `file` / `geolocation`)已逐个实测:**四类的只读面都照常渲染 FormDescription**,无一因形态特殊(如不渲染帮助文本)而需要豁免;`descEl=SET`、改前 `consumers=0`,与已量的三类同形。

## 改法:三键,且第三个键带一个必填的判别参数

`toHostGroupProps` 新增 `aria-describedby`,但**不是**无条件发。helper 加了一个必填的 `surface` 参数,让每个调用点(以及下一个 widget 作者)必须说明自己是哪种面 —— 由编译器强制,而不是继承一个恰好在那里的默认值:

- `'instead-of-the-inputs'` —— 七个只读分支 + 零选项框(`OptionsEmptyState`)。该面**根本不渲染字段自己的输入框**,没有别的元素能承载描述。
- `'above-the-inputs'` —— address / geolocation 的**可编辑**容器。它们的子输入各自已在 `domProps` 展开里拿到 `aria-describedby`,容器不得再拿一次。

第二类是本改动最容易造成的回归:这两个 widget 的可编辑容器与只读面**共用同一个 helper 结果**,一个无条件发 `aria-describedby` 的版本会让帮助文本被宣读两次 —— #3318 明确拒绝过的双通道(与 #3290 从 required 星号上移除的那种双通道同类),`composite-group-label-e2e.test.tsx` 早有钉子。判别参数是唯一挡住它的东西,这一点由下面的反向验证第二向量证明。

## 边界:`aria-invalid` / `aria-required` 不回铺(双向钉死)

它们是**控件通道状态** —— 报告使用者的编辑可能哪里出错,报给他要编辑的那个元素。只读面不可编辑,铺回去等于宣读一个背后没有动作的状态,正是 #3291 / #3318 划的线。描述不同:描述说的是**这个字段是什么**,那两个说的是**这个控件正在怎样**。

钉子从两侧同时钉:只读面**必须**带三键(正向断言,否则一个什么都不发的实现也能通过三条 `not.toHaveAttribute`),**且**必须不带 `aria-invalid` / `aria-required` / `name` —— 包括 `required: true` 的字段,以及**真实失败校验之后**(实测可达:只读 required 空值提交确实产出 FormMessage,此时 Slot 把 `aria-describedby` 扩成「描述 id + 消息 id」,只读面原样转发,但状态通道仍然一个都不加)。

## 无描述时的形态:如实钉住,不粉饰

FormControl 的 Slot **无条件**下发描述 IDREF,所以没有 `description` 的字段今天就已经让**每个**可编辑控件指向一个不存在的元素。实测 `desc=NO`:七类 group-labelled + 内建 `input` + 单控件 `email` 各有恰好一处这样的引用。只读面照抄这一点是与可编辑态**对齐**,不是新增一类缺陷 —— 解析不到的 IDREF 对辅助技术是惰性的,而没人消费的描述是直接丢失。测试按这个事实写(断言引用存在、目标不存在、可访问描述为空),而不是假装它不存在。

## 内建分支对照行重量(正文声明作废)

`BUILTIN_FIELD_TYPES` = `input` / `textarea` / `checkbox` / `switch` / `select`,只读态照样在 FormControl 里渲染真控件,Slot 的 `aria-describedby` 正常落地:

```
input     editable/readonly   descEl=SET  consumers=1  [input]
textarea  editable/readonly   descEl=SET  consumers=1  [textarea]
checkbox  editable/readonly   descEl=SET  consumers=1  [button[checkbox]]
switch    editable/readonly   descEl=SET  consumers=1  [button[switch]]
select    editable/readonly   descEl=SET  consumers=1  [div]
```

**内建分支没有本缺陷。** 正文那行 `consumers=0` 的读数量的是 `type: 'text'` —— 它既不在 `BUILTIN_FIELD_TYPES` 里、在裸注册的 setup 下也没有注册,那个字段**根本没渲染出控件**(整个 field 容器里只有 label 和帮助文本两个元素)。正文已自行把该行作废,这里是重量结论。

## 反向验证(先预判后跑,两个向量)

**向量一 —— 撤掉修复**(helper 永不发第三个键)。

预判:描述类钉子全红;可编辑态与 standalone 全绿;`composite-group-label-e2e.test.tsx` 全绿。

实测 `Tests 53 failed | 115 passed (168)`,`Test Files 1 failed | 1 passed (2)` —— 与预判逐条相符:

```
 7  {type}: the description has exactly one consumer, and it is the named group
 7  {type}: the description lands on the SAME element as the name
 7  {type}: readonly with NO value describes the placeholder surface too
 7  {type}: the readonly surface takes the three whole-field keys ONLY
 7  {type}: a REQUIRED readonly field is described, never aria-required
 7  {type}: a FAILED validation still puts no aria-invalid on it
 7  {type}: a readonly field with NO description answers as the editable one does
 3  {type}: the unfillable-options box is also DESCRIBED (objectui#4005)
 1  all seven readonly in ONE form: each description has exactly one consumer
```

**向量二 —— 撤掉判别参数**(无条件发第三个键)。

预判:描述类钉子**全绿**(它们不关心键是怎么来的);转红的只有 address / geolocation 的可编辑家族 —— 其余五个 widget 的可编辑分支根本不走这个 helper,所以**不会**转红;另加 #3318 在 `composite-group-label-e2e.test.tsx` 里那条既有钉子。合计 5 条。

实测 `Tests 5 failed | 163 passed (168)`,正是预判的那 5 条:

```
composite-group-label-e2e      > the description stays on the first focusable sub-input, not on the container
composite-group-label-readonly > address:     editable still has exactly ONE description consumer
composite-group-label-readonly > geolocation: editable still has exactly ONE description consumer
composite-group-label-readonly > address:     the editable CONTAINER stays undescribed, the sub-input keeps it
composite-group-label-readonly > geolocation: the editable CONTAINER stays undescribed, the sub-input keeps it
```

两个向量都是在**修复已 commit 之后**做的变异,还原用 `git checkout 本分支 -- 该文件`,均未提交。

## 范围外发现(已立单,不在本 PR 修)

- #4788:**非** group-labelled 的只读替换显示(`email` / `url` / `phone` 实测)丢掉 host 下发的整份 plumbing —— 不只是描述零消费者,连 `…-form-item` 这个 id 在只读态**整个文档里都没有元素带**,label 的 `for` 悬空。比本单更重一档,且修法形状需要单独裁决(这些字段不是 group-labelled,不能照搬 `toHostGroupProps`)。本 PR 不扩围。

## 测试

- `pnpm exec vitest run packages/fields` —— 95 files / 1527 tests 全绿。
- 仓根 `turbo type-check` 81/81 successful;`check:control-bytes`、changeset presence / no-major 门禁全绿。
- changeset:`.changeset/great-hounds-sing.md`(`@object-ui/fields` patch)。
- ⛔ 未动 `field-type-alias.ts` 邻域(#4770 同批在飞)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_