### PR TITLE
docs(layout): SidebarNav README 示例改回 NavItem 真实形状,补 props 表并钉住 (#3999)

### DIFF
--- a/.changeset/sidebar-nav-readme-real-navitem-shape.md
+++ b/.changeset/sidebar-nav-readme-real-navitem-shape.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/layout': patch
+---
+
+`SidebarNav`'s README example teaches the shape the component actually reads.
+
+`packages/layout/README.md` — the package's npm landing page, shipped in `files` —
+spelled every nav item `{ label, path, icon: 'home' }`. `NavItem` declares none of
+those three keys: the label is `title`, the target is `href`, and `icon` is a
+`React.ComponentType` rendered as `<item.icon />`, not an icon name. Copied
+verbatim the example produced a sidebar whose every row was unlabelled
+(`<span>{item.title}</span>` reading `undefined`), a `NavLink` with
+`to={undefined}`, and the string `'home'` handed to React as an unknown lowercase
+tag. Both README examples now use `title` / `href` / imported Lucide components,
+and annotate the array as `NavItem[]` so the same class of typo becomes a compile
+error where it is written instead of a blank sidebar at runtime.
+
+Adds the props tables the README never carried — `SidebarNavProps`, `NavItem`
+(`badge`, `badgeVariant` and `children` included) and `NavGroup`, plus a grouped
+and nested example — and pins all of it rather than leaving a second surface free
+to rot the same way: the examples are real, type-checked code in
+`readme-sidebar-nav-example.test.ts` asserted to appear verbatim in the README, and
+the tables are compared against the interface keys read out of `SidebarNav.tsx` on
+every run. Also corrects a comment in `side-effects-manifest.test.ts` that named
+`SidebarNav` as the component behind the `navigation-renderer` registration; that
+key belongs to a different component, and `SidebarNav` is registered under no key
+at all.
+
+No runtime change — `SidebarNav.tsx` is untouched. This is `patch` rather than a
+no-release declaration because the corrected landing page only reaches npm through
+a publish.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -84,16 +84,90 @@ ADR-0087 D2 conversion `page-header-subtitle-alias`.
 Navigation sidebar component with React Router integration.
 
 ```typescript
-import { SidebarNav } from '@object-ui/layout';
+import { SidebarNav, type NavItem } from '@object-ui/layout';
+import { Home, Settings, Users } from 'lucide-react';
 
-const navItems = [
-  { label: 'Dashboard', path: '/dashboard', icon: 'home' },
-  { label: 'Users', path: '/users', icon: 'users' },
-  { label: 'Settings', path: '/settings', icon: 'settings' }
+const navItems: NavItem[] = [
+  { title: 'Dashboard', href: '/dashboard', icon: Home },
+  { title: 'Users', href: '/users', icon: Users },
+  { title: 'Settings', href: '/settings', icon: Settings },
 ];
 
 <SidebarNav items={navItems} />
 ```
+
+An item's label is `title` and its target is `href` — and `icon` is a **component**,
+not an icon name: it is rendered as `<item.icon />` (`src/SidebarNav.tsx:60`, `:109`),
+so pass the imported Lucide component itself. This example used to be written with
+`label` / `path` / `icon: 'home'`, none of which `NavItem` declares (objectui#3999);
+copied as-is it produced rows with no label at all, a `NavLink` whose `to` was
+`undefined`, and the string `'home'` handed to React as an unknown lowercase tag.
+Annotating the array as `NavItem[]` is what turns that whole class of typo back into
+a compile error where it is written, instead of a blank sidebar at runtime.
+
+#### `SidebarNavProps`
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `items` | `NavItem[] \| NavGroup[]` | — (required) | Flat item list, or grouped sections. The array must be homogeneous: only the **first** element is probed to decide which of the two it is. |
+| `title` | `string` | `'Application'` | Section label shown above a flat `NavItem[]`. Ignored when `items` is a `NavGroup[]` — each group prints its own `label`. |
+| `className` | `string` | — | Tailwind overrides, forwarded to the root `Sidebar`. |
+| `collapsible` | `'offcanvas' \| 'icon' \| 'none'` | `'icon'` | Collapse behaviour of the underlying Shadcn `Sidebar`. |
+| `searchEnabled` | `boolean` | `false` | Renders a search box that filters items by `title` (an item also survives when one of its `children` matches). |
+| `searchPlaceholder` | `string` | `'Search…'` | Placeholder for that search box. |
+
+#### `NavItem`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | — (required) | The visible label, and what search matches against. |
+| `href` | `string` | — (required) | `NavLink` target; also the React key, so keep it unique within its list. Active state is `pathname === href`. |
+| `icon` | `React.ComponentType<{ className?: string }>` | — | The icon **component** (e.g. `Home` from `lucide-react`), not its name. |
+| `badge` | `string \| number` | — | Trailing badge content. Rendered whenever it is not `null`/`undefined`, so `0` shows. |
+| `badgeVariant` | `'default' \| 'destructive' \| 'outline'` | `'default'` | Badge styling. |
+| `children` | `NavItem[]` | — | Nested sub-items. A non-empty list turns the row into a collapsible group: the parent's own `href` is then no longer a link, only the children are. |
+
+#### `NavGroup`
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `label` | `string` | Section heading printed above the group. |
+| `items` | `NavItem[]` | The group's items — same `NavItem` shape as above, nesting included. |
+
+```typescript
+import { SidebarNav, type NavGroup } from '@object-ui/layout';
+import { FolderOpen, Home, Settings } from 'lucide-react';
+
+const navGroups: NavGroup[] = [
+  {
+    label: 'Workspace',
+    items: [
+      { title: 'Dashboard', href: '/dashboard', icon: Home },
+      {
+        title: 'Projects',
+        href: '/projects',
+        icon: FolderOpen,
+        badge: 3,
+        children: [
+          { title: 'Active', href: '/projects/active' },
+          { title: 'Archived', href: '/projects/archived', badge: 'WIP', badgeVariant: 'outline' },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'System',
+    items: [{ title: 'Settings', href: '/settings', icon: Settings }],
+  },
+];
+
+<SidebarNav items={navGroups} searchEnabled />
+```
+
+Note that `SidebarNav` is a plain React component: unlike the keys listed under
+[Registration](#registration) it is **not** on the `ComponentRegistry`, so it is
+composed in JSX rather than authored as a JSON node. Full guide:
+[SidebarNav docs](https://www.objectui.org/docs/layout/sidebar-nav).
 
 ## Usage with React Router
 
@@ -102,6 +176,7 @@ The layout components are designed to work seamlessly with React Router:
 ```typescript
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { AppShell, SidebarNav } from '@object-ui/layout';
+import { Home, Users } from 'lucide-react';
 
 function App() {
   return (
@@ -111,8 +186,8 @@ function App() {
         sidebar={
           <SidebarNav
             items={[
-              { label: 'Dashboard', path: '/', icon: 'home' },
-              { label: 'Users', path: '/users', icon: 'users' }
+              { title: 'Dashboard', href: '/', icon: Home },
+              { title: 'Users', href: '/users', icon: Users },
             ]}
           />
         }

--- a/packages/layout/src/__tests__/readme-sidebar-nav-example.test.ts
+++ b/packages/layout/src/__tests__/readme-sidebar-nav-example.test.ts
@@ -1,0 +1,279 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The README's `SidebarNav` examples are THIS file's code (objectui#3999).
+ *
+ * `packages/layout/README.md` used to hand every reader of the npm landing page
+ * a nav item spelled `{ label, path, icon: 'home' }`. All three keys are wrong,
+ * and not by a typo — `NavItem` declares `title` / `href` / `icon`, where `icon`
+ * is a COMPONENT (`<item.icon />`, `SidebarNav.tsx:60` and `:109`), never an
+ * icon name. Copied verbatim the example produced rows with no label at all
+ * (`<span>{item.title}</span>` on `undefined`), a `NavLink` with
+ * `to={undefined}`, and the string `'home'` handed to React as an unknown
+ * lowercase tag. TypeScript consumers got a compile error; JS consumers — and
+ * anyone (AI authors above all) who copies the snippet and then "fixes it until
+ * it compiles" — got a blank sidebar, which is the audience a README has.
+ *
+ * ## The three halves, and why each is a different kind of fact
+ *
+ * 1. **Compile-time.** The example arrays below are real TypeScript annotated
+ *    with the real `NavItem` / `NavGroup`, imported from `../SidebarNav`, with
+ *    real `lucide-react` components in `icon`. `packages/layout`'s
+ *    `type-check` script compiles this file (`tsconfig.test.json`), so a
+ *    README shape that `NavItem` cannot express stops the build here. This is
+ *    the half that catches `icon: 'home'`: a wrong VALUE type under a legal
+ *    key, which no key-name check can see.
+ *
+ * 2. **Doc parity.** Each example is fenced by markers and asserted to appear
+ *    in `README.md` as a contiguous run of lines (compared trimmed, so the
+ *    router snippet's JSX indentation is not part of the contract). One source,
+ *    two readers: editing the README's shape without editing the code — or the
+ *    reverse — goes red. Without this, half 1 degenerates into type-checking a
+ *    snippet nobody publishes.
+ *
+ * 3. **Props-table parity.** The table this issue added to the README is a
+ *    SECOND surface that can rot exactly the way the example did, so it is not
+ *    hand-listed here either: the expected keys are read out of
+ *    `SidebarNav.tsx`'s interface bodies. Adding a key to `NavItem` without
+ *    documenting it, or documenting a key that no longer exists, is red.
+ *    This half asserts KEYS only — that each documented row names a real
+ *    authoring key — which is all a table can be wrong about; the values those
+ *    keys accept are half 1's job.
+ *
+ * The scan in half 3's last test is deliberately narrow: it re-reads the fenced
+ * blocks that mention `SidebarNav` and rejects a quoted `icon:`. `page-header`
+ * really does take an icon NAME as a string (`src/index.ts`, `type: 'string'`),
+ * so this must never become a README-wide ban on `icon: '…'` — it is a fact
+ * about THIS component's prop, scoped to THIS component's examples.
+ *
+ * Not covered, on purpose: `content/docs/layout/sidebar-nav.mdx` already spelled
+ * these examples correctly, and pinning the whole docs tree to source is
+ * objectui#3786's problem, not this one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { FolderOpen, Home, Settings, Users } from 'lucide-react';
+import type { NavGroup, NavItem, SidebarNavProps } from '../SidebarNav';
+
+/** `packages/layout` — two levels up from `src/__tests__`. */
+const PKG_DIR = resolve(__dirname, '../..');
+const README = readFileSync(join(PKG_DIR, 'README.md'), 'utf8');
+const SIDEBAR_NAV_SRC = readFileSync(join(PKG_DIR, 'src', 'SidebarNav.tsx'), 'utf8');
+const THIS_FILE = readFileSync(join(__dirname, 'readme-sidebar-nav-example.test.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Half 1 — the examples, as code. Everything between a BEGIN/END marker pair is
+// asserted below to appear verbatim (trimmed) in README.md.
+// ---------------------------------------------------------------------------
+
+// >>> README EXAMPLE basic BEGIN
+const navItems: NavItem[] = [
+  { title: 'Dashboard', href: '/dashboard', icon: Home },
+  { title: 'Users', href: '/users', icon: Users },
+  { title: 'Settings', href: '/settings', icon: Settings },
+];
+// >>> README EXAMPLE basic END
+
+// >>> README EXAMPLE grouped BEGIN
+const navGroups: NavGroup[] = [
+  {
+    label: 'Workspace',
+    items: [
+      { title: 'Dashboard', href: '/dashboard', icon: Home },
+      {
+        title: 'Projects',
+        href: '/projects',
+        icon: FolderOpen,
+        badge: 3,
+        children: [
+          { title: 'Active', href: '/projects/active' },
+          { title: 'Archived', href: '/projects/archived', badge: 'WIP', badgeVariant: 'outline' },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'System',
+    items: [{ title: 'Settings', href: '/settings', icon: Settings }],
+  },
+];
+// >>> README EXAMPLE grouped END
+
+/** The "Usage with React Router" snippet passes its items inline to the JSX. */
+const routerItems: NavItem[] = [
+  // >>> README EXAMPLE router BEGIN
+  { title: 'Dashboard', href: '/', icon: Home },
+  { title: 'Users', href: '/users', icon: Users },
+  // >>> README EXAMPLE router END
+];
+
+/**
+ * Both example shapes have to be legal values of the SAME prop — that is the
+ * union the README's `items` row documents. If `SidebarNavProps['items']` ever
+ * narrows to one of them, these two stop type-checking and the row has to move
+ * with the type.
+ */
+const flatItemsProp: SidebarNavProps['items'] = navItems;
+const groupedItemsProp: SidebarNavProps['items'] = navGroups;
+
+// ---------------------------------------------------------------------------
+// Marker extraction. Markers are matched by WHOLE-LINE equality against the
+// strings these two helpers build, so the helpers' own source lines can never
+// match themselves — this file reads itself, and a substring match would.
+// ---------------------------------------------------------------------------
+
+const beginMarker = (name: string): string => `// >>> README EXAMPLE ${name} BEGIN`;
+const endMarker = (name: string): string => `// >>> README EXAMPLE ${name} END`;
+
+/** The trimmed, non-empty lines of one marked example block. */
+function exampleLines(name: string): string[] {
+  const lines = THIS_FILE.split('\n').map((line) => line.trim());
+  const begin = lines.indexOf(beginMarker(name));
+  const end = lines.indexOf(endMarker(name));
+  if (begin === -1 || end === -1 || end <= begin) {
+    throw new Error(
+      `No \`${name}\` example block in this file. The markers are load-bearing: ` +
+        'the README parity assertions below have nothing to compare without them.',
+    );
+  }
+  return lines.slice(begin + 1, end).filter((line) => line.length > 0);
+}
+
+/** Index of `needle` as a contiguous run inside `haystack`, or -1. */
+function indexOfSequence(haystack: string[], needle: string[]): number {
+  for (let i = 0; i + needle.length <= haystack.length; i += 1) {
+    if (needle.every((line, offset) => haystack[i + offset] === line)) return i;
+  }
+  return -1;
+}
+
+const README_LINES = README.split('\n').map((line) => line.trim());
+
+/** Fenced code blocks in the README that are about this component. */
+function sidebarNavFences(): string[] {
+  const fences = [...README.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((match) => match[1]);
+  return fences.filter((body) => body.includes('SidebarNav'));
+}
+
+// ---------------------------------------------------------------------------
+// Interface keys, read out of SidebarNav.tsx rather than listed here.
+// ---------------------------------------------------------------------------
+
+function interfaceKeys(name: string): string[] {
+  const body = new RegExp(`export interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(SIDEBAR_NAV_SRC);
+  if (!body) throw new Error(`\`export interface ${name}\` is gone from SidebarNav.tsx`);
+  // Anchored at line start, so nested keys inside a type (the `className?` in
+  // `icon?: React.ComponentType<{ className?: string }>`) are not collected.
+  return [...body[1].matchAll(/^\s*(\w+)\??\s*:/gm)].map((match) => match[1]);
+}
+
+/** First-column keys of the markdown table that follows a `#### \`Name\`` heading. */
+function documentedKeys(heading: string): string[] {
+  const start = README_LINES.indexOf(`#### \`${heading}\``);
+  if (start === -1) throw new Error(`README no longer has a \`#### \`${heading}\`\` section`);
+  const keys: string[] = [];
+  for (let i = start + 1; i < README_LINES.length; i += 1) {
+    const line = README_LINES[i];
+    if (line.length === 0) continue;
+    if (!line.startsWith('|')) {
+      if (keys.length > 0) break;
+      continue;
+    }
+    const cell = line.split('|')[1]?.trim() ?? '';
+    const key = /^`(\w+)`$/.exec(cell)?.[1];
+    if (key) keys.push(key);
+  }
+  return keys;
+}
+
+describe("the README's SidebarNav examples are this file's type-checked code (objectui#3999)", () => {
+  it.each(['basic', 'grouped', 'router'])(
+    'README.md carries the `%s` example verbatim',
+    (name) => {
+      const block = exampleLines(name);
+      expect(block.length, `the \`${name}\` block is empty`).toBeGreaterThan(0);
+      expect(
+        indexOfSequence(README_LINES, block),
+        [
+          `The \`${name}\` example in packages/layout/README.md no longer matches the code in this`,
+          'file. One of the two moved on its own, which is exactly how the README came to teach',
+          '`{ label, path, icon: \'home\' }` (objectui#3999) — a shape `NavItem` has never had.',
+          'Fix whichever is wrong, then make the other match; the code here is what `tsc` reads.',
+          '',
+          'Expected this run of lines (trimmed) in README.md:',
+          ...block.map((line) => `  ${line}`),
+        ].join('\n'),
+      ).toBeGreaterThanOrEqual(0);
+    },
+  );
+
+  it('and that code really is a `NavItem[]` / `NavGroup[]` (the compile-time half, made visible)', () => {
+    // These reads are the point: a `const` nobody looks at is easy to delete,
+    // and deleting it would silently retire the type-check above.
+    expect(navItems.map((item) => item.title)).toEqual(['Dashboard', 'Users', 'Settings']);
+    expect(navItems.map((item) => item.href)).toEqual(['/dashboard', '/users', '/settings']);
+    // `icon` is a component, never a string — the third defect this issue found.
+    expect(navItems.every((item) => typeof item.icon === 'function' || typeof item.icon === 'object')).toBe(true);
+    expect(navItems.some((item) => typeof item.icon === 'string')).toBe(false);
+
+    expect(navGroups.map((group) => group.label)).toEqual(['Workspace', 'System']);
+    expect(navGroups[0].items[1].children?.map((child) => child.href)).toEqual([
+      '/projects/active',
+      '/projects/archived',
+    ]);
+
+    expect(routerItems.map((item) => item.href)).toEqual(['/', '/users']);
+    expect(flatItemsProp).toBe(navItems);
+    expect(groupedItemsProp).toBe(navGroups);
+  });
+});
+
+describe("the README's SidebarNav props tables name exactly the real keys (objectui#3999)", () => {
+  it.each([
+    ['SidebarNavProps'],
+    ['NavItem'],
+    ['NavGroup'],
+  ])('`%s` is documented key-for-key', (name) => {
+    const declared = interfaceKeys(name);
+    expect(declared.length, `no keys parsed out of \`${name}\``).toBeGreaterThan(1);
+
+    expect(
+      documentedKeys(name).slice().sort(),
+      [
+        `The \`${name}\` table in packages/layout/README.md and the interface in`,
+        'src/SidebarNav.tsx disagree about which keys exist. The expected list is READ OUT OF',
+        'the source on every run, so this is never "update the test": add the new key to the',
+        'table, or drop the row for the key that is gone. A README is this package\'s npm',
+        'landing page; a key it invents is a shape the component cannot consume (objectui#3999).',
+      ].join('\n'),
+    ).toEqual(declared.slice().sort());
+  });
+
+  it('never spells `icon` as a string in a SidebarNav example', () => {
+    const fences = sidebarNavFences();
+    expect(fences.length, 'no SidebarNav code fence found in the README at all').toBeGreaterThan(0);
+
+    for (const body of fences) {
+      expect(
+        /\bicon\s*:\s*['"`]/.test(body),
+        [
+          'A SidebarNav example writes `icon` as a quoted string. `NavItem.icon` is a',
+          '`React.ComponentType`, rendered as `<item.icon />` — a string reaches React as an',
+          'unknown lowercase tag and renders nothing (objectui#3999). Import the Lucide',
+          'component and pass it.',
+          '',
+          'Scope note: `page-header` DOES declare `icon` as a string (an icon name), so this',
+          'assertion is deliberately confined to fences that mention SidebarNav.',
+        ].join('\n'),
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/layout/src/__tests__/side-effects-manifest.test.ts
+++ b/packages/layout/src/__tests__/side-effects-manifest.test.ts
@@ -285,9 +285,18 @@ describe('@object-ui/layout declares its load-time registration (objectui#3899)'
     // Every key the barrel registers, so losing all but one cannot pass on the
     // strength of that one. Read out of the source rather than listed here:
     // objectui#3899's own prose named a `sidebar-nav` key that this package has
-    // never registered (the SidebarNav component reaches the registry under
-    // `navigation-renderer`), and a hardcoded list is how that kind of mistake
-    // becomes a test asserting a component that does not exist.
+    // never registered, and a hardcoded list is how that kind of mistake becomes
+    // a test asserting a component that does not exist.
+    //
+    // The parenthetical that used to sit in that sentence — "the SidebarNav
+    // component reaches the registry under `navigation-renderer`" — was the same
+    // mistake one step further on, and is corrected here (objectui#3999):
+    // `SidebarNav` reaches the registry under NO key at all. `navigation-renderer`
+    // is a DIFFERENT component in a different file (`NavigationRenderer.tsx`,
+    // which never mentions `SidebarNav`); `src/index.ts` imports `SidebarNav`
+    // only to re-export it. It is consumed as a plain React component in JSX,
+    // which is why nothing below asserts a key for it and why the README
+    // documents it as JSX rather than as a JSON node type.
     const registeredKeys = [...readFileSync(join(SRC_DIR, 'index.ts'), 'utf8').matchAll(
       /ComponentRegistry\.register\(\s*'([^']+)'/g,
     )].map((match) => match[1]);


### PR DESCRIPTION
Fixes #3999

## 问题

`packages/layout/README.md` 是本包在 npm 上的门面页(`package.json` 的 `files` 里明确列了 `README.md`),而它的 `SidebarNav` 示例把每个导航项写成 `{ label, path, icon: 'home' }` —— 三个键 `NavItem` 一个都没有。行号按当下 main(基线 `c25222758`)自核过:

| README 旧写法 | `NavItem` 真实键(`SidebarNav.tsx:23-30`) |
| --- | --- |
| `label` | `title`(`:24`) |
| `path` | `href`(`:25`) |
| `icon: 'home'` | `icon?: React.ComponentType`(参数 `{ className?: string }`,`:26`)—— **组件**,不是图标名 |

照抄的后果不是「样式不对」。`isNavGroup`(`:47`,判据 `'items' in item && !('href' in item)`)对这些对象返回 false,于是走 `NavItem` 分支:

- `< span >{item.title}< /span >`(`:61`、`:110`)拿到 `undefined` —— 每行**没有标签**;
- `< NavLink to={item.href} >`(`:79`、`:108`)拿到 `undefined`;
- 字符串 `'home'` 经 `item.icon && < item.icon / >`(`:60`、`:109`)被 React 当作未知小写标签渲染。

TS 消费者当场类型报错;真正的受害者是 JS 消费者、以及照抄后自己「改到能编译」的作者(含 AI 作者)—— 后者正是 README 的读者。

## 改动

**① 两处示例改真实形状。** `### SidebarNav` 与「Usage with React Router」都改成 `title` / `href` + 从 `lucide-react` 导入的真实组件,并把数组标注成 `NavItem[]`。标注是这一改的关键一半:它把这类笔误从「运行时空白侧边栏」变回「书写处的编译错误」,也就是本仓 contract-first 的方向 —— 不在消费端容错,而在写下的地方拒绝。

**② 补 props 表(分诊裁定)。** README 从来没有形状表,只改示例等于让下一个作者再猜一次。新增 `SidebarNavProps`、`NavItem`(含 `badge` / `badgeVariant` / `children`)、`NavGroup` 三张表,外加一段分组 + 嵌套的示例。表里写进了几条只有读源码才知道的事实:`items` 必须同质(`:128` 只探 `items[0]` 决定整个数组走哪支)、`title` 在分组模式下被忽略、`href` 兼作 React key、`children` 非空时父行本身不再是链接、`badge` 判据是 `!= null` 所以 `0` 会显示。

**③ 旁证判定:确属失真,同 PR 改注释。** `side-effects-manifest.test.ts:289` 邻域注释写着「the SidebarNav component reaches the registry under `navigation-renderer`」。实读为**假**:`navigation-renderer` 注册的是另一个文件里的另一个组件 `NavigationRenderer`(`NavigationRenderer.tsx` 全文 grep 不到 `SidebarNav`),`src/index.ts` 导入 `SidebarNav` 只为 `export *` 再导出 —— 它**没有任何注册键**。注释改为陈述这一事实,并说明这正是 README 把它记成 JSX 而非 JSON 节点类型的原因。

**④ 钉子。** 新增 `packages/layout/src/__tests__/readme-sidebar-nav-example.test.ts`,三半各钉一类事实:

- **编译期** —— README 的示例数组就是这个文件里的**真代码**,用真的 `NavItem` / `NavGroup` 标注、`icon` 放真的 lucide 组件,由本包 `tsconfig.test.json` 编译。这是唯一抓得住 `icon: 'home'` 的一半:合法键上的错误**值**类型,任何键名检查都看不见(key-vs-value:表只可能在「键存不存在」上出错,所以表那半只断言键;值归编译期)。
- **文档同源** —— 同一段代码用 BEGIN/END 标记取出,断言它作为**连续行**出现在 README 里(按 trim 比较,所以 JSX 缩进不进契约)。没有这一半,上一半就退化成给「没人发布的片段」做类型检查。
- **表同源** —— 表的期望键**每次运行从 `SidebarNav.tsx` 的接口体里读**,不硬编码。给 `NavItem` 加键却不写进表、或表里留着已删的键,都会红。外加一条窄扫描:提到 `SidebarNav` 的代码围栏里 `icon:` 不得是引号字符串;这条刻意只限本组件的围栏 —— `page-header` 的 `icon` 确实是字符串图标名(`index.ts` 里 `type: 'string'`),扩成 README 全局禁令就是这条钉子越权。

## 反向验证(先预判,后实测)

**变异 A —— 把 README 恢复成旧形状(`git checkout c25222758 -- packages/layout/README.md`)。**
预判:8 条里 7 红 —— 三条示例同源(basic/grouped/router 的行对不上)、三条表同源(`####` 小节整个消失,`documentedKeys` 抛错)、一条 icon 引号扫描;**唯一该绿的是** `and that code really is a NavItem[] / NavGroup[]`,因为它只断言本文件自己的常量,README 怎么改都碰不到它。
实测:`Tests 7 failed | 1 passed (8)`,绿的正是预判的那一条。7 条全部以**断言/抛错**转红,没有一条靠超时。

**变异 B —— 把整个旧形状(`{ label, path, icon: 'home' }`)放回被类型检查的示例代码里。**
预判:`type-check` 红,并报**三类**错 —— `icon` 的值类型、`label`/`path` 的多余属性、缺 `title`/`href`。
实测:红(exit 2),但**只报了一类**:

```
src/__tests__/readme-sidebar-nav-example.test.ts(79,45): error TS2322: Type 'string' is
  not assignable to type 'ComponentType< { className?: string | undefined; } > | undefined'.
```

预判在这里不准,如实记下:同一个对象字面量既有「共有属性类型不符」又有「多余属性/缺必需属性」时,TS 只报更具体的前者,后两类被它盖住。**红的方向对,红的数量不对** —— 于是「三个键都会变成编译错误」这句话,在变异 B 里只证到了 `icon` 一个。

**变异 C —— 因此单独测另一半:只把键写错(`label`/`path`),`icon` 留正确的组件。**
预判:仍红,报多余属性(TS2353)或缺必需属性(TS2739)。
实测:红(exit 2):

```
src/__tests__/readme-sidebar-nav-example.test.ts(79,5): error TS2353: Object literal may
  only specify known properties, and 'label' does not exist in type 'NavItem'.
```

B 与 C 合起来才支撑 README 里那句「标注成 `NavItem[]` 把这一类笔误变成书写处的编译错误」:键错 → TS2353,值错 → TS2322。只跑 B 会让这句话有一半没被测过。

三次变异都在 commit 之后做,还原用 `git checkout claude/issue-3999-sidebarnav-readme -- 路径`(AGENTS.md §9:反向验证前先 commit;⛔ 未用共享 stash 栈),工作区无残留。

## 验证

- 仓根 `turbo run type-check --concurrency=2` → `Tasks: 81 successful, 81 total`。
- `pnpm exec vitest run packages/layout --maxWorkers=2` → `Test Files 11 passed (11)` / `Tests 139 passed (139)`,exit 0。
- `check-control-bytes`(4307 个文件)、`check-doc-links`(13 个 scan root)、`check-changeset-presence` / `-fixed` / `-no-major` 全绿;改动的两个测试文件 eslint 0 error。

## 范围

- ⛔ 未动 `SidebarNav.tsx` 本体 —— 这单是文档面缺陷,组件行为不变。
- ⛔ 未动 README 的 PageHeader 段(PR #4759 刚改过)。
- ⛔ 未碰 `content/docs/releases/`。
- 「给 README 代码块上门禁」是 #3786 家族的大题,按分诊裁定不入本单;本 PR 的钉子只覆盖 `packages/layout/README.md` 这一张页面。
- changeset:`patch`(`@object-ui/layout`)。触发门禁的其实是 `packages/layout/src/` 下的新测试文件(实测 `check-changeset-presence.mjs` 只点名了这两个测试文件,只改 README 不会触发);声明成 `patch` 而不是空 frontmatter 的理由是 —— `README.md` 在 `files` 里,改正后的门面页**只能靠一次发布**才到得了 npm。

## 消费半径扫查

`SidebarNav` 的示例载体全仓枚举过一遍(`grep -rn SidebarNav`,排除 node_modules/dist):`content/docs/layout/sidebar-nav.mdx` 早就写对;`packages/react/src/hooks/useFocusManagement.ts:110` 是某 hook 的 JSDoc 里同名但无关的局部示例组件(`items: string[]`);`ROADMAP.md` / `CHANGELOG.md` 只是提及。**唯一另一处同族缺陷在 `content/docs/layout/app-shell.mdx`**(两处示例用 `label:` 与字符串 `icon:`,并写了 `SidebarNavProps` 没有的 `header` prop)—— 那是 `content/docs/**`、超出本单 file surface,已按调度约定回传给 PM,未在此 PR 修改。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_