### PR TITLE
retire(studio): drop the canonical page:header icon field, restate the alias's on its renderer read (#3829)

### DIFF
--- a/.changeset/tidy-buttons-repeat.md
+++ b/.changeset/tidy-buttons-repeat.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/layout': patch
+---
+
+Studio 页面设计器不再为 canonical `page:header` 提供 `icon` 编辑框(objectui#3829)
+
+`PageHeaderProps.icon` 已在 `@objectstack/spec` 17.0.0 随 ADR-0087 D2 退役
+(objectstack#6946 / PR objectstack#7115):canonical `page:header` 渲染器从未读过它,
+表头的身份由 record chrome(`recordChrome`)与每个 action 自带的 `icon` 承担。退役前
+作者填入的值被静默丢弃,退役后平台按名拒绝整个节点 —— 而设计器仍在提供那个输入框,
+等于教作者写出解析失败的元数据。本次移除该字段与它此时已成孤儿的两条 i18n 键
+(en / zh 同一次改动,两张表的键集保持一致),并把「不得回潮」钉在
+`previews/__tests__/block-config.test.ts`。
+
+`@object-ui/layout` 的 `page-header` / `layout:page-header` 别名**保留** `icon` 输入,
+行为不变:那是另一个渲染器,它真读真画(`PageHeader.tsx`),文档与本仓唯一的活 demo
+都写它。变的只是这条声明的**依据** —— 从 spec parity 改述为 renderer-read 事实,并让
+`page-header-authorable-keys` 守卫在派生 spec 键集时跳过墓碑成员,不再因为
+`Object.keys(shape)` 仍列着已退役的 `icon` 而假绿。

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -398,24 +398,53 @@ const OFF_SPEC_EXEMPTIONS: Record<string, string> = {};
  *     and its own issue owns it.
  *
  * Every reason cites an issue, which `references a tracking issue` asserts.
- * Verified against renderer read sites at objectui `origin/main` @ `c85268256`
- * with `@objectstack/spec@17.0.0-rc.5` — not assumed from the spec's wording.
+ * Verified against renderer read sites at objectui `origin/main` @ `c25222758`
+ * with `@objectstack/spec@17.0.0-rc.6` — not assumed from the spec's wording.
+ * (The four `…-rc.5` mentions left in the entries below are the stale-pin
+ * entries' own prose and belong to their issues, not to this header.)
  */
 const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
-  // ── B class — spec declares it, NO renderer read point at all (2 keys) ─────
-  // The instinct here is to add an input, and it is wrong: that publishes a key
-  // the platform drops on the floor, which is exactly the defect objectui#3797
-  // spent a repo-wide gate closing. The other instinct — wire it — is a visual
-  // decision (where an icon sits next to RecordTitleChip; whether a card grows
-  // an actions area, which reaches into `renderers/action/**`). The third option
-  // is the `record:activity.showSubscriptionToggle` precedent: declare it and
-  // say NOT IMPLEMENTED in the description, so both directions are in parity and
-  // the author is told. Three viable shapes, one public contract — filed as
-  // objectui#3829 rather than guessed at here.
+  // ── page:header.icon / page:card.actions — retired upstream (2 keys) ───────
+  // These two used to be a MENU: objectui#3829 filed them as a three-way fork
+  // (wire them; declare them with a KNOWN GAP per the
+  // `record:activity.showSubscriptionToggle` precedent; retire them upstream)
+  // and this entry listed all three so no implementing agent would guess. The
+  // fork is closed. The maintainer ruled route (c) on 2026-08-09 —
+  // zero producers, zero consumers, zero demand — and objectstack#6946 /
+  // PR objectstack#7115 executed it: both keys are ADR-0087 D2 tombstones in
+  // `@objectstack/spec` 17.0.0, live on the rc.6 this repo installs. So the
+  // class here is no longer B (undecided) but the same one as
+  // `record:details.layout` below: the spec rejects the key BY NAME, and the
+  // reverse direction demands it anyway because the tombstone is still a member
+  // of the shape.
+  //
+  // Read the upstream prescriptions before touching either key — they say what
+  // replaces it, which is why neither is coming back. A header's identity is
+  // drawn by the record chrome (`recordChrome`, on by default) plus each
+  // action's own `icon`; a card's buttons are authored as components in
+  // `children` or `footer` (`element:button`, `record:quick_actions`).
+  //
+  // DO NOT DELETE THESE TWO ENTRIES YET, and the reason is the one this file
+  // already writes out twice above: D2 retirement REPLACES the member with
+  // `z.never()` rather than deleting it, so `Object.keys(shape)` still reports
+  // both keys as declared and `carries no stale unpublished-key exemption`
+  // still needs the cover. They resolve when objectui#3809's tombstone
+  // recognition narrows `specTopLevelKeys` — not on a pin bump, and not by
+  // declaring the inputs.
+  //
+  // The objectui half of route (c) is otherwise complete (objectui#3829).
+  // `page:card.actions` had no producer at all; `page:header.icon` had exactly
+  // one — the metadata-admin designer's BLOCK_CONFIG field for the CANONICAL
+  // `page:header`, which kept offering authors an icon box whose value rc.6
+  // rejects by name — and it was removed with its two i18n keys in the same
+  // change that rewrote these entries. The `layout:page-header` ALIAS keeps its
+  // `icon` input deliberately: that is a different renderer with a real read
+  // point (`packages/layout/src/PageHeader.tsx`), so the two are opposite facts,
+  // not an inconsistency.
   'page:header.icon':
-    'Spec declares it; PageHeaderRenderer has NO read point — `icon` in containers.tsx:822-1570 is only ever per-action (`action.icon`, :1321/:1365) or a nav item (:604). Wire it, or declare it with a KNOWN GAP per the showSubscriptionToggle precedent: objectui#3829.',
+    'Retired upstream by objectstack#6946 / PR objectstack#7115 (ADR-0087 D2 tombstone) — PageHeaderRenderer never had a read point: `icon` inside containers.tsx:973-1677 is only ever per-action (`action.icon`, :1428/:1472) or a nav item (:641/:816), and the spec now rejects the key by name, prescribing the record chrome plus per-action icons instead. Unlike the stale-pin entries below this one is LIVE at @objectstack/spec@17.0.0-rc.6: the tombstone stays in `Object.keys(shape)`, so the reverse direction demands a key the contract refuses. Resolves via objectui#3809 tombstone recognition, not by declaring the input — objectui#3829.',
   'page:card.actions':
-    'Spec declares it; PageCardRenderer (containers.tsx:666-695) renders title/body/footer only and never reads `actions`. Wire it, or declare it with a KNOWN GAP per the showSubscriptionToggle precedent: objectui#3829.',
+    'Retired upstream by objectstack#6946 / PR objectstack#7115 (ADR-0087 D2 tombstone) — PageCardRenderer (containers.tsx:703-745) builds its card from title/body/children/footer and never had an actions area, and the spec now rejects the key by name, prescribing buttons authored as components in `children` or `footer` (`element:button`, `record:quick_actions`). Unlike the stale-pin entries below this one is LIVE at @objectstack/spec@17.0.0-rc.6: the tombstone stays in `Object.keys(shape)`, so the reverse direction demands a key the contract refuses. Resolves via objectui#3809 tombstone recognition, not by declaring the input — objectui#3829.',
 
   // ── page:tabs.type — the carrier collision, from the other side ────────────
   // The mirror image of the `page:tabs.tabStyle` exemption in

--- a/content/docs/layout/page-header.mdx
+++ b/content/docs/layout/page-header.mdx
@@ -43,7 +43,7 @@ recordChrome / showStar / showCopyId / aria` and has no `description`. Both `tit
 
 `icon` is deliberately **not** in that list, and the distinction matters because this page
 documents a React component while the spec governs an authored node. `PageHeaderProps.icon`
-was retired in `@objectstack/spec` 17.0.0 (objectstack#6946, ADR-0087 D2): the canonical
+was retired from `@objectstack/spec` (objectstack#6946, ADR-0087 D2): the canonical
 `page:header` renderer never read it, so an authored value used to be accepted and dropped,
 and the contract now rejects the key by name. On a canonical `page:header` node the
 header's identity comes from the record chrome (`recordChrome`, on by default) plus each

--- a/content/docs/layout/page-header.mdx
+++ b/content/docs/layout/page-header.mdx
@@ -37,9 +37,24 @@ interface PageHeaderComponentProps extends React.HTMLAttributes<HTMLDivElement> 
 ```
 
 `subtitle` is the canonical key: `@objectstack/spec/ui`'s `PageHeaderProps` — the contract
-for the authored `page:header` node — declares `title / subtitle / icon / breadcrumb /
-actions / aria` and has no `description`. Both `title` and `subtitle` interpolate
-`{field.path}` tokens against the surrounding record context.
+for the authored `page:header` node — declares `title / subtitle / breadcrumb / actions /
+recordChrome / showStar / showCopyId / aria` and has no `description`. Both `title` and
+`subtitle` interpolate `{field.path}` tokens against the surrounding record context.
+
+`icon` is deliberately **not** in that list, and the distinction matters because this page
+documents a React component while the spec governs an authored node. `PageHeaderProps.icon`
+was retired in `@objectstack/spec` 17.0.0 (objectstack#6946, ADR-0087 D2): the canonical
+`page:header` renderer never read it, so an authored value used to be accepted and dropped,
+and the contract now rejects the key by name. On a canonical `page:header` node the
+header's identity comes from the record chrome (`recordChrome`, on by default) plus each
+action's own `icon`; `os migrate meta --from 16` rewrites stored sources.
+
+The `icon` prop listed above is this component's **own** capability, not that spec key.
+`PageHeader` from `@object-ui/layout` — registered as `page-header` and
+`layout:page-header` — really does draw it (a string resolves through `LazyIcon`, a React
+node renders as-is), which is why it stays on that registration's `inputs` and why the demo
+on this page writes `"icon": "users"` (objectui#3829). Do not carry the key over to a
+canonical `page:header` node: the same JSON renders here and fails to parse there.
 
 `description` used to be a **legacy alias** of `subtitle` that this component read as
 well. It is **retired** (objectui#3789): the prop is gone and the renderer draws a

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -626,8 +626,11 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.element:button.action': 'Action',
   'engine.inspector.pageBlock.field.page:header.title': 'Title',
   'engine.inspector.pageBlock.field.page:header.subtitle': 'Subtitle',
-  'engine.inspector.pageBlock.field.page:header.icon': 'Icon',
-  'engine.inspector.pageBlock.placeholder.page:header.icon': 'lucide icon name',
+  // `…field.page:header.icon` and its placeholder retired with the spec key
+  // itself (objectstack#6946 / PR objectstack#7115, @objectstack/spec
+  // 17.0.0-rc.6). Their only reader was the canonical `page:header` icon field
+  // removed from `previews/block-config.ts`; a key kept past its field is dead
+  // vocabulary that the next author reads as a live surface. objectui#3829.
   'engine.inspector.pageBlock.field.page:header.breadcrumb': 'Show breadcrumb',
   'engine.inspector.pageBlock.field.page:card.title': 'Title',
   'engine.inspector.pageBlock.field.page:card.bordered': 'Bordered',
@@ -2380,8 +2383,9 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.element:button.action': '动作',
   'engine.inspector.pageBlock.field.page:header.title': '标题',
   'engine.inspector.pageBlock.field.page:header.subtitle': '副标题',
-  'engine.inspector.pageBlock.field.page:header.icon': '图标',
-  'engine.inspector.pageBlock.placeholder.page:header.icon': 'lucide 图标名',
+  // `…field.page:header.icon` and its placeholder retired with the spec key —
+  // see the matching note in the `en` table above. Removed from BOTH tables in
+  // the same edit so the two key sets stay identical.
   'engine.inspector.pageBlock.field.page:header.breadcrumb': '显示面包屑',
   'engine.inspector.pageBlock.field.page:card.title': '标题',
   'engine.inspector.pageBlock.field.page:card.bordered': '显示边框',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
@@ -319,7 +319,7 @@ describe("PageBlockInspector's own chrome follows the locale (#3963)", () => {
  * straight to the input.
  *
  * What makes this column different from the two before it is that translating
- * ALL of it would be wrong. Ten of the eighteen placeholders are example VALUES,
+ * ALL of it would be wrong. Ten of the seventeen placeholders are example VALUES,
  * and the assertions come in matching pairs: the prose ones must change with the
  * locale, the value ones must NOT. Both halves are pinned here because both are
  * regressions a reader could introduce while believing they were finishing the
@@ -329,7 +329,17 @@ describe("PageBlockInspector's own chrome follows the locale (#3963)", () => {
 describe('PageBlockInspector placeholders follow the locale — but only the prose ones (#3979)', () => {
   it('translates the text-field hint under an already-Chinese label', () => {
     // The issue's headline symptom: 「图标」 over a box hinting `lucide icon name`.
-    renderInspector(pageDraft('page:header'), 'zh-CN');
+    //
+    // Rendered from `record:alert`, not `page:header`. This pair used to use the
+    // header's own icon box until objectui#3829 removed it: @objectstack/spec
+    // 17.0.0 retired `PageHeaderProps.icon` (objectstack#6946 / PR
+    // objectstack#7115) because the canonical renderer never read it, so the
+    // field was offering authors a key the platform now rejects by name. Same
+    // move, same reason, as objectui#4649's re-point a few tests above —
+    // `record:alert.icon` reproduces the symptom exactly (a `text` field with a
+    // prose placeholder under a translated label) on a key the renderer really
+    // reads, so the case cannot be satisfied by a surface that should not exist.
+    renderInspector(pageDraft('record:alert'), 'zh-CN');
 
     expect(screen.getByText('图标')).toBeTruthy(); // #3913's half, still working
     expect(screen.getByPlaceholderText('lucide 图标名')).toBeTruthy();
@@ -341,7 +351,7 @@ describe('PageBlockInspector placeholders follow the locale — but only the pro
   it('renders the same panel in English under en-US, unchanged', () => {
     // en-US is the baseline: the new keys carry the exact literals the table
     // used to hold, so nothing an English admin sees may have moved.
-    renderInspector(pageDraft('page:header'), 'en-US');
+    renderInspector(pageDraft('record:alert'), 'en-US');
 
     expect(screen.getByPlaceholderText('lucide icon name')).toBeTruthy();
     expectNoRawKeyPlaceholders();

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
@@ -50,7 +50,7 @@
  *
  * #3913 stopped at labels, so the hints under them stayed English: 「图标」 over
  * a box reading `lucide icon name`. The column joins the walk above as a fifth
- * family, with the SAME positional derivation — but only for the 8 placeholders
+ * family, with the SAME positional derivation — but only for the 7 placeholders
  * that are prose. The other 10 are example VALUES (`20`, `https://…`, a JSON
  * sample) and are `{ literal: … }` in `block-config.ts`, never keys: translating
  * them would corrupt the thing the author is being told to type.
@@ -178,12 +178,13 @@ describe('block-config labels are translation keys (#3913)', () => {
     expect(families.field).toBeGreaterThan(80);
     expect(families.add).toBe(5);
     expect(families.option).toBeGreaterThan(50);
-    // Exact, like `add`: the keyed half of the placeholder column is 8 of 18
-    // (#3979). A 9th prose placeholder should fail here and be translated; a
-    // 9th VALUE placeholder does not reach this family at all and is caught by
-    // the literal inventory instead. Either way the new one gets classified
-    // rather than defaulting to English-on-screen.
-    expect(families.placeholder).toBe(8);
+    // Exact, like `add`: the keyed half of the placeholder column is 7 of 17
+    // (#3979; 8 of 18 until objectui#3829 retired the canonical
+    // `page:header.icon` field). An 8th prose placeholder should fail here and
+    // be translated; an 8th VALUE placeholder does not reach this family at all
+    // and is caught by the literal inventory instead. Either way the new one
+    // gets classified rather than defaulting to English-on-screen.
+    expect(families.placeholder).toBe(7);
   });
 
   it('stores exactly the key its position implies', () => {
@@ -297,16 +298,24 @@ describe('en-US labels are unchanged by the key migration (#3913)', () => {
     'engine.inspector.pageBlock.option.location.record_more': 'Record more menu',
     'engine.inspector.pageBlock.option.severity.warning': 'Warning',
     // ── the placeholder family (#3979) ───────────────────────────────────────
-    // ALL EIGHT, not a sample: this column was migrated by hand rather than
+    // ALL SEVEN, not a sample: this column was migrated by hand rather than
     // mechanically, and the en side is the only thing standing between "the key
     // resolves" and "the key resolves to what the box used to say". Each value
     // below is byte-identical to the literal `block-config.ts` held at
     // `origin/main` 6bd6a4d76 — including the U+2026 ellipsis in `Text…`, which
     // a re-typed `...` would silently replace.
+    //
+    // It was EIGHT until objectui#3829: `…placeholder.page:header.icon` went
+    // with the canonical `page:header` icon field, retired upstream by
+    // objectstack#6946 / PR objectstack#7115. Dropping the sample row is the
+    // right move rather than keeping it as a "still translated" check — the key
+    // is gone from both locale tables, so `t()` now returns it unchanged and an
+    // assertion here would be pinning the passthrough against itself. The
+    // deliberate absence is pinned in `block-config.test.ts` instead, where the
+    // field's absence is pinned beside it.
     'engine.inspector.pageBlock.placeholder.object-metric.icon': 'lucide icon name',
     'engine.inspector.pageBlock.placeholder.element:text.content': 'Text…',
     'engine.inspector.pageBlock.placeholder.element:button.icon': 'lucide icon name',
-    'engine.inspector.pageBlock.placeholder.page:header.icon': 'lucide icon name',
     'engine.inspector.pageBlock.placeholder.record:details.sections.name': 'snake_case, e.g. contact_info',
     'engine.inspector.pageBlock.placeholder.record:alert.icon': 'lucide icon name',
     'engine.inspector.pageBlock.placeholder.record:quick_actions.actionNames': 'action name',
@@ -363,11 +372,16 @@ describe('placeholders that must NOT be translated (#3979)', () => {
     'record:details.sections.columns': { literal: '2', because: 'a column count' },
   };
 
-  it('collects all 18 placeholders — 8 keyed, 10 literal', () => {
+  it('collects all 17 placeholders — 7 keyed, 10 literal', () => {
     // Guards the walk: if placeholder collection silently found nothing, every
     // assertion here would pass over an empty list.
-    expect(PLACEHOLDERS.length).toBe(18);
-    expect(PLACEHOLDERS.filter((p) => p.spec.key !== undefined).length).toBe(8);
+    //
+    // 18 / 8 / 10 until objectui#3829: the canonical `page:header` icon box was
+    // a KEYED placeholder, and it went with the field when objectstack#6946 /
+    // PR objectstack#7115 retired `PageHeaderProps.icon`. The literal half is
+    // untouched, which is what this split says.
+    expect(PLACEHOLDERS.length).toBe(17);
+    expect(PLACEHOLDERS.filter((p) => p.spec.key !== undefined).length).toBe(7);
     expect(PLACEHOLDERS.filter((p) => p.spec.literal !== undefined).length).toBe(10);
   });
 

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { ACTION_LOCATIONS, PageComponentType, RecordDetailsProps } from '@objectstack/spec/ui';
+import {
+  ACTION_LOCATIONS,
+  PageComponentType,
+  PageHeaderProps,
+  RecordDetailsProps,
+} from '@objectstack/spec/ui';
 import { BLOCK_CONFIG, blockHasConfig, type PlaceholderSpec } from '../block-config';
 import { BLOCK_TYPE_META, PALETTE_EXCLUSIONS } from '../block-types';
 import { t } from '../../i18n';
@@ -281,5 +286,83 @@ describe('page palette ↔ spec PageComponentType coverage', () => {
       expect(t(key, 'en-US')).toBe(key);
       expect(t(key, 'zh-CN')).toBe(key);
     });
+  });
+});
+
+/**
+ * `page:header.icon` — the designer field that outlived the spec key (#3829).
+ *
+ * The same shape as the `global_nav` removal above, and it is here because
+ * BLOCK_CONFIG is a PUBLISH FACE with no parity gate of its own: nothing in
+ * this repo diffs the designer's field set against `ComponentPropsMap`, so a
+ * field can go on offering a key the contract has retired and every derived
+ * check stays green. This file is the substitute, per key.
+ *
+ * What was wrong: `PageHeaderProps.icon` was retired in @objectstack/spec
+ * 17.0.0 (objectstack#6946 / PR objectstack#7115, ADR-0087 D2, maintainer
+ * ruling 2026-08-09 route (c)) because no renderer ever read it — the canonical
+ * `page:header` draws its identity from the record chrome (`recordChrome`) and
+ * per-action `icon`s. The retirement's own prescription said "zero producers",
+ * and for `page:card.actions` that was true; for this key it was not. The
+ * designer kept offering an icon box for the canonical `page:header`, so an
+ * author (an AI author especially) filled it in and the platform — which used
+ * to drop the value silently — now rejects the whole node BY NAME. A retirement
+ * that leaves its producer standing makes the failure worse, not better.
+ *
+ * The `layout:page-header` ALIAS keeps its own `icon` input, deliberately: that
+ * is a different renderer with a real read point, and it is guarded separately
+ * in `packages/layout/src/__tests__/page-header-authorable-keys.test.tsx`. The
+ * two are opposite read facts about two renderers, not an inconsistency.
+ */
+describe('page:header `icon` — the designer field retired with the spec key (#3829)', () => {
+  const fieldNames = () => BLOCK_CONFIG['page:header'].map((f) => f.name);
+
+  // POSITIVE half, for the reason the location dropdown states: without it the
+  // negative pin below passes just as happily on a deleted panel.
+  it('still offers the canonical header fields the renderer does implement', () => {
+    expect(fieldNames()).toEqual(['title', 'subtitle', 'breadcrumb']);
+  });
+
+  it('does NOT offer the retired `icon` field', () => {
+    expect(fieldNames().length, 'field list is empty — the pin would be vacuous').toBeGreaterThan(0);
+    expect(fieldNames()).not.toContain('icon');
+  });
+
+  // Why `Object.keys(shape)` cannot be the test, and why this pin exists at all.
+  // ADR-0087 D2 retirement REPLACES the member with `z.never()` rather than
+  // deleting it, so `icon` is STILL a key of the shape: every "is it declared?"
+  // check reads green while the parser rejects every value by name. The
+  // criterion is therefore the unwrapped member's type — the same one
+  // objectui#3809 converges on repo-wide.
+  it('the spec tombstones `icon` rather than deleting it', () => {
+    const shape = (PageHeaderProps as unknown as { shape: Record<string, unknown> }).shape;
+    const memberType = (key: string): string | undefined => {
+      const member = shape[key] as { unwrap?: () => unknown } | undefined;
+      const inner = (typeof member?.unwrap === 'function' ? member.unwrap() : member) as
+        | { _def?: { type?: string }; def?: { type?: string } }
+        | undefined;
+      return inner?._def?.type ?? inner?.def?.type;
+    };
+    expect(Object.keys(shape)).toContain('icon');
+    expect(memberType('icon')).toBe('never');
+    // Non-vacuity for the probe itself: a Zod-internals change that made every
+    // member read `'never'` would make the line above meaningless, and a live
+    // key is the only thing that can tell the difference.
+    expect(memberType('title')).not.toBe('never');
+    expect(memberType('title')).toBeTruthy();
+  });
+
+  // The i18n side, exactly as the retired option above: a key kept past its
+  // field is dead vocabulary the next author reads as a live surface, so BOTH
+  // locale tables lost the label and its placeholder. `t()` returns the key
+  // unchanged on a miss, which is precisely "this locale has no translation".
+  it('has no leftover translation for the retired field in either locale', () => {
+    for (const key of [
+      'engine.inspector.pageBlock.field.page:header.icon',
+      'engine.inspector.pageBlock.placeholder.page:header.icon',
+    ]) {
+      expect(t(key, 'en-US')).toBe(key);
+      expect(t(key, 'zh-CN')).toBe(key);
+    }
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -357,7 +357,16 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
   'page:header': [
     { name: 'title', label: 'engine.inspector.pageBlock.field.page:header.title', kind: 'text' },
     { name: 'subtitle', label: 'engine.inspector.pageBlock.field.page:header.subtitle', kind: 'text' },
-    { name: 'icon', label: 'engine.inspector.pageBlock.field.page:header.icon', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.page:header.icon' } },
+    // No `icon` field: `PageHeaderProps.icon` was retired from the spec in
+    // @objectstack/spec 17.0.0-rc.6 (objectstack#6946 / PR objectstack#7115,
+    // ADR-0087 D2, maintainer ruling 2026-08-09 route (c)). The canonical
+    // `page:header` renderer never read it — the header's identity is drawn by
+    // the record chrome (`recordChrome`) and each action carries its own `icon`
+    // — so before the retirement an authored value was silently dropped, and
+    // after it the platform rejects the key BY NAME. Offering the box here
+    // would let the designer author metadata that fails to parse, which is
+    // strictly worse than the silent drop it replaced. Pinned negatively in
+    // `__tests__/block-config.test.ts`. objectui#3829.
     { name: 'breadcrumb', label: 'engine.inspector.pageBlock.field.page:header.breadcrumb', kind: 'boolean' },
   ],
   'page:card': [

--- a/packages/layout/src/__tests__/page-header-authorable-keys.test.tsx
+++ b/packages/layout/src/__tests__/page-header-authorable-keys.test.tsx
@@ -45,6 +45,20 @@
  * the same change. The measurement itself did not go away with them: it is a
  * standing pin in `page-header-subtitle-conversion-coverage.test.ts`, which goes
  * red if that reach ever narrows again.
+ *
+ * TOMBSTONES — objectui#3829. "Derived from the spec's own shape" was doing less
+ * work than it read as. `Object.keys(shape)` reports a key whether the spec
+ * ACCEPTS it or REJECTS it by name: an ADR-0087 D2 retirement replaces the
+ * member with `z.never()` and leaves the entry in place. So when
+ * @objectstack/spec 17.0.0 retired `PageHeaderProps.icon` (objectstack#6946 /
+ * PR objectstack#7115), every assertion here that consulted the derived key set
+ * went on passing for `icon` — describing a spec key that no longer exists. The
+ * derivation now skips tombstones, and the two facts the old reading conflated
+ * are stated separately: `actions` is declared because the spec owns it, `icon`
+ * is declared because THIS renderer draws it (the canonical `page:header` never
+ * did, which is why upstream retired the key at all). The carve-out is a named,
+ * issue-backed, self-clearing list rather than a silent pass — see
+ * `RENDERER_OWN_DECLARED`.
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
@@ -54,8 +68,67 @@ import { PageHeaderProps as SpecPageHeaderProps } from '@objectstack/spec/ui';
 
 import { registerLayout, PageHeader } from '../index';
 
-/** Authorable keys of the spec node this renderer serves. */
-const specKeys = new Set(Object.keys(SpecPageHeaderProps.shape));
+/** Every key `PageHeaderProps` still LISTS — ADR-0087 tombstones included. */
+const specDeclaredKeys = new Set(Object.keys(SpecPageHeaderProps.shape));
+
+/**
+ * One `.shape` member's type, unwrapped past `.optional()`.
+ *
+ * Walking Zod internals is the only way to ask this question, so the probe is
+ * guarded by its own non-vacuity test below rather than trusted.
+ */
+const shapeMemberType = (key: string): string | undefined => {
+  const shape = SpecPageHeaderProps.shape as unknown as Record<string, unknown>;
+  const member = shape[key] as { unwrap?: () => unknown } | undefined;
+  const inner = (typeof member?.unwrap === 'function' ? member.unwrap() : member) as
+    | { _def?: { type?: string }; def?: { type?: string } }
+    | undefined;
+  return inner?._def?.type ?? inner?.def?.type;
+};
+
+/**
+ * Is this key an ADR-0087 D2 tombstone — still listed, but typed `never` so the
+ * contract rejects every value by name with a migration message?
+ *
+ * The distinction is the whole reason this file changed in objectui#3829. A D2
+ * retirement does NOT delete the key from the shape; it REPLACES the member with
+ * `z.never()`. So `Object.keys(shape)` keeps answering "yes, declared" for a key
+ * the spec refuses — and every assertion below that derived its truth from raw
+ * `Object.keys` was therefore FALSE GREEN for `icon` from the moment
+ * @objectstack/spec 17.0.0 retired `PageHeaderProps.icon` (objectstack#6946 /
+ * PR objectstack#7115). The criterion here is deliberately the same one
+ * objectui#3809 converges on repo-wide; when that lands, this local helper is
+ * what it replaces.
+ */
+const isTombstoned = (key: string): boolean => shapeMemberType(key) === 'never';
+
+/** Authorable keys of the spec node this renderer serves — tombstones excluded. */
+const specKeys = new Set([...specDeclaredKeys].filter((key) => !isTombstoned(key)));
+
+/**
+ * Keys this ALIAS declares on a renderer-read fact the spec no longer carries.
+ *
+ * Exactly one entry, and it is a ruling rather than a shortcut: objectui#3829
+ * measured `page:header.icon` after upstream retired it and found the two
+ * renderers disagree. The CANONICAL `page:header` never read the key — which is
+ * why the spec retired it, and why the metadata-admin designer's icon field for
+ * that block was removed in the same change. This alias renderer DOES read it
+ * (`PageHeader.tsx:123`, drawn at `:231-233`), `content/docs/layout/
+ * page-header.mdx` publishes the prop, and the docs page's only live demo writes
+ * `"icon": "users"`. Withdrawing the input would delete a working capability and
+ * break that demo, so route A was taken: keep the input, and stop pretending the
+ * spec is what licenses it.
+ *
+ * The residual risk is named rather than hidden: `icon` now renders under
+ * `page-header` and is rejected by name under `page:header`, which is one key
+ * with two outcomes — the failure mode a single contract exists to prevent. It
+ * is accepted only because this alias is the legacy registration and the
+ * capability is real; if the canonical renderer ever grows the same drawing, the
+ * right move is to un-retire the key upstream, not to widen this list.
+ */
+const RENDERER_OWN_DECLARED: Record<string, string> = {
+  icon: 'Retired upstream as an ADR-0087 D2 tombstone by objectstack#6946 / PR objectstack#7115 because the CANONICAL page:header renderer never read it. This alias renderer reads and draws it (PageHeader.tsx:123, :231-233), the docs page publishes it and its live demo writes it, so objectui#3829 ruled the input stays — declared on the renderer read, not on spec parity.',
+};
 
 const declaredInputs = (type: string, namespace?: string) => {
   const config = ComponentRegistry.getConfig(type, namespace);
@@ -93,9 +166,47 @@ describe('the `page-header` registration declares the spec key, not a dialect', 
     expect(specKeys.has('description')).toBe(false);
   });
 
-  it('declares nothing `@objectstack/spec` does not', () => {
-    const offSpec = declaredInputNames('page-header').filter((name) => !specKeys.has(name));
+  it('the tombstone probe really reads the spec — not `undefined` for everything', () => {
+    // Guards `isTombstoned`, not the subject. A Zod-internals change that made
+    // `shapeMemberType` return `undefined` everywhere would silently restore the
+    // raw `Object.keys` behaviour this file exists to stop, and every assertion
+    // below would go green describing nothing. Both directions are pinned: a
+    // known tombstone reads `never`, a known live key does not.
+    expect(specDeclaredKeys.size).toBeGreaterThan(0);
+    expect(shapeMemberType('title')).toBeTruthy();
+    expect(isTombstoned('title')).toBe(false);
+    expect(isTombstoned('icon')).toBe(true);
+    // …and the narrowing is not a no-op, which is the third way this could rot.
+    expect(specKeys.size).toBeLessThan(specDeclaredKeys.size);
+  });
+
+  it('declares nothing `@objectstack/spec` accepts, beyond the declared renderer-own keys', () => {
+    // objectui#3226's original assertion, on the narrowed key set. `specKeys`
+    // used to be raw `Object.keys(shape)`, which counted a retired `icon` as a
+    // spec key and let this test pass for the wrong reason.
+    const offSpec = declaredInputNames('page-header')
+      .filter((name) => !specKeys.has(name))
+      .filter((name) => !(name in RENDERER_OWN_DECLARED));
     expect(offSpec).toEqual([]);
+  });
+
+  it('every renderer-own declaration is licensed by a tombstone and says why', () => {
+    // What keeps `RENDERER_OWN_DECLARED` from becoming the dialect door
+    // objectui#3226 closed. An entry is legal only for a key the spec ONCE
+    // declared and has since retired — a key the spec never had is `showBack`,
+    // and that one is pinned as NOT declared further down. Each clause is
+    // self-clearing: un-retire the key upstream and the tombstone assertion
+    // reds, drop the input and the first one does.
+    for (const [name, reason] of Object.entries(RENDERER_OWN_DECLARED)) {
+      expect(declaredInputNames('page-header'), `${name} is allowed but not declared`).toContain(
+        name,
+      );
+      expect(specDeclaredKeys.has(name), `${name} was never a spec key — that is a dialect`).toBe(
+        true,
+      );
+      expect(isTombstoned(name), `${name} is live spec; it needs no carve-out`).toBe(true);
+      expect(/#\d+/.test(reason), `${name} needs a tracking issue`).toBe(true);
+    }
   });
 });
 
@@ -130,29 +241,55 @@ describe('the `page-header` registration declares the child slot it renders (obj
 });
 
 describe('the `page-header` registration declares the keys the renderer reads (objectui#3972)', () => {
-  // The `declares nothing @objectstack/spec does not` test above is ONE-WAY: it
+  // The `declares nothing @objectstack/spec accepts` test above is ONE-WAY: it
   // catches a declared key the spec rejects, and can never catch a spec key the
   // renderer honours while `inputs` omits it. That omission is not a documentation
   // gap — `sdui-parser/src/validate.ts:70-77` reports `unknown-prop` for any
   // top-level key not in `inputs`, so the manifest gate warned authors off keys
   // this component renders. `icon` was live on the repo's own documented demo.
   //
-  // Both keys pass the same three-face test (renderer read point × spec key ×
-  // a `ManifestInputType` that can spell the value); the omissions below pin the
-  // audit's negative results, which is what keeps this from becoming "copy the
-  // spec's shape into `inputs`".
-  it.each([
-    ['icon', 'string'],
-    ['actions', 'array'],
-  ])('declares `%s` with type `%s`, on both registration keys', (name, type) => {
+  // Both keys pass the renderer-read × `ManifestInputType` halves of the audit;
+  // the omissions below pin the audit's negative results, which is what keeps
+  // this from becoming "copy the spec's shape into `inputs`".
+  //
+  // They no longer share a THIRD face, which is why the two are split rather
+  // than kept in one `it.each`. `actions` is a live spec key and is declared on
+  // spec parity; `icon` is an ADR-0087 tombstone and is declared on the renderer
+  // read alone (objectui#3829). One assertion cannot state both facts, and the
+  // version that tried — `expect(specKeys.has(name)).toBe(true)` for both — was
+  // green only because the retired member was still listed in the raw shape.
+  const declaresWithType = (name: string, type: string) => {
     for (const namespace of [undefined, 'layout']) {
       const input = declaredInputs('page-header', namespace).find((i) => i.name === name);
       expect(input, `page-header (namespace: ${namespace}) does not declare \`${name}\``).toBeTruthy();
       expect(input?.type).toBe(type);
     }
-    // …and it is legal to declare only because the spec owns the key. If the spec
+  };
+
+  it('declares `actions` with type `array`, on both registration keys', () => {
+    declaresWithType('actions', 'array');
+    // …and it is legal to declare because the spec owns the key. If the spec
     // ever drops it, this line fails here rather than as a mystery parity red.
-    expect(specKeys.has(name)).toBe(true);
+    expect(specKeys.has('actions')).toBe(true);
+  });
+
+  it('declares `icon` with type `string` on both keys — on the renderer read, not spec parity', () => {
+    // The assertion this issue moved. What is pinned is the ALIAS INPUT ITSELF:
+    // the input exists, on both registration keys, spelled `string` because the
+    // authorable form is an icon name. That is the fact the docs page and its
+    // live demo depend on, and it is unaffected by the spec key's retirement.
+    declaresWithType('icon', 'string');
+    // What DID change is the licence. `icon` is no longer a key the spec
+    // accepts, so the old `expect(specKeys.has('icon')).toBe(true)` is now
+    // asserted in reverse — and the two lines under it are why that is a
+    // retirement rather than a deletion, which is exactly what the raw
+    // `Object.keys` reading could not tell apart.
+    expect(specKeys.has('icon')).toBe(false);
+    expect(specDeclaredKeys.has('icon')).toBe(true);
+    expect(isTombstoned('icon')).toBe(true);
+    // The carve-out is stated, not implied: `RENDERER_OWN_DECLARED` is what the
+    // dialect guard above consults, and its own discipline test licenses this.
+    expect(Object.keys(RENDERER_OWN_DECLARED)).toContain('icon');
   });
 
   it('does not declare `breadcrumb` — a spec key this renderer never reads', () => {

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -72,32 +72,46 @@ export function registerLayout() {
   //
   // `icon` and `actions` are the same lie on two more keys, found by auditing
   // this list against the renderer's actual read points (objectui#3972). Each
-  // declared key below is aligned on the three faces that have to agree, and the
+  // declared key below is aligned on the faces that have to agree, and the
   // audit's negative results are as load-bearing as its positive ones:
   //
-  //   RENDERER READS IT × SPEC DECLARES IT × `ManifestInputType` CAN SPELL IT
-  //   - `title` / `subtitle`  — read at `PageHeader.tsx:113/115`, spec keys.
-  //   - `icon`      — read at `:117`, rendered at `:224-226` (a string goes
-  //     through `LazyIcon`, a node renders as-is); `PageHeaderProps.icon` is the
-  //     spec's icon NAME, hence `type: 'string'`. `content/docs/layout/
-  //     page-header.mdx` documents it AND its only live demo
-  //     (`layout-page-header/pageheader-with-actions`) writes `"icon": "users"`
-  //     — so omitting it made the manifest gate report `unknown-prop` on the
-  //     repo's own documented example.
-  //   - `actions`   — read at `:119`, resolved at `:192-196` and delegated to
-  //     `record:quick_actions`; `PageHeaderProps.actions` is an array of action
-  //     ids, and the canonical `page:header` already publishes it as
-  //     `type: 'array'` (`components/.../containers.tsx:1585`). Spelled
+  //   RENDERER READS IT × A `ManifestInputType` CAN SPELL IT
+  //   - `title` / `subtitle`  — read at `PageHeader.tsx:121/122`; both are live
+  //     spec keys of `PageHeaderProps`, which is the objectui#3226 narrowing
+  //     above.
+  //   - `icon`      — read at `PageHeader.tsx:123`, rendered at `:231-233` (a
+  //     string goes through `LazyIcon`, a node renders as-is). This one stands
+  //     on the RENDERER-READ fact ALONE, and the change of footing is
+  //     deliberate rather than an oversight: `PageHeaderProps.icon` was retired
+  //     upstream as an ADR-0087 D2 tombstone in @objectstack/spec 17.0.0
+  //     (objectstack#6946 / PR objectstack#7115) because the CANONICAL
+  //     `page:header` renderer never read it. THIS renderer does — it draws the
+  //     icon beside the title — `content/docs/layout/page-header.mdx` publishes
+  //     the prop, and the docs page's only live demo
+  //     (`layout-page-header/pageheader-with-actions`) writes `"icon": "users"`,
+  //     so withdrawing the input would delete a working capability and make the
+  //     manifest gate report `unknown-prop` on the repo's own documented
+  //     example. `type: 'string'` because the AUTHORABLE spelling is an icon
+  //     name; the `React.ReactNode` form is a programmatic prop, not JSON.
+  //     objectui#3829 ruled it stays on exactly this footing. What keeps the
+  //     claim honest — and stops the retired spec key from reading as parity —
+  //     is `__tests__/page-header-authorable-keys.test.tsx`, which skips
+  //     tombstones when it derives the spec's key set.
+  //   - `actions`   — read at `:125`, resolved at `:199-203` and delegated to
+  //     `record:quick_actions`; `PageHeaderProps.actions` is a LIVE spec key (an
+  //     array of action ids), and the canonical `page:header` already publishes
+  //     it as `type: 'array'` (`components/.../containers.tsx:1692`). Spelled
   //     identically here on purpose — one concept, one key, one type.
   //
   // NOT declared, deliberately, and each for its own reason:
   //   - `breadcrumb` — spec declares it, this renderer has NO read point (the
   //     word appears only in a comment and an `aria-label`). Declaring it would
   //     be objectui#3829's defect in reverse: an authoring surface the platform
-  //     silently drops. (`page:header.icon` is that same case on the CANONICAL
-  //     renderer, which is why it sits in `UNPUBLISHED_EXEMPTIONS` in
-  //     `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` while
-  //     `icon` gets declared HERE — different renderers, opposite read facts.)
+  //     silently drops. (`page:header.icon` WAS that same case on the CANONICAL
+  //     renderer — which is why it sits in `UNPUBLISHED_EXEMPTIONS` in
+  //     `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`, and
+  //     why the spec retired the key there while `icon` stays declared HERE:
+  //     different renderers, opposite read facts.)
   //   - `showBack` / `action` — this renderer reads them, the spec has no such
   //     keys. Declaring one would publish a second dialect, which is the whole
   //     point of the objectui#3226 narrowing above. (`description` used to sit


### PR DESCRIPTION
Fixes #3829

落地本卡 2026-08-16 的「PM 裁定 · 测量回贴」:route (c) 的 objectui follow-through,
alias 半边按代裁的 **A 案**。维护者 2026-08-09 已裁 route (c),上游 objectstack#6946 /
PR objectstack#7115 已执行,并随本仓现锁的 `@objectstack/spec@17.0.0-rc.6` 生效 ——
`PageHeaderProps.icon` 与 `PageCardProps.actions` 均已是 ADR-0087 D2 墓碑(成员被替换为
`z.never()`,带具名迁移文案)。

## 为什么 objectui 这半边比原裁定预想的大

退役 prescription 写的是「零生产者」。这对 `page:card.actions` 成立 —— 它是干净完整的
退役;对 `page:header.icon` **不成立**:metadata-admin 设计器的 BLOCK_CONFIG 仍在为
canonical `page:header` 发布 `icon` 编辑框。退役前作者填进去的值被静默丢弃,退役后平台
**按名拒绝整个节点** —— 留着生产面比退役前更糟,因为它在教作者(尤其是 AI 作者)写出
解析失败的元数据。

原裁定描述的完成机制也需要修正:D2 退役是把成员**替换**成 `z.never()`,不是删除,两键
因此仍留在 `Object.keys(shape)` 里 —— pin bump 并不会让那两条 exemption 变 stale
(gate 源码自己写明了这一点)。所以正确的 sequencing 是**重写**而不是删除,删除权归
objectui#3809。

## 四件事

**1. 两条 exemption 重写**(`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`)

从「wire it or declare it」菜单改写为 retired-upstream 类,模板逐字取自同文件的
`record:details.layout` 条目:引用 objectstack#6946 / PR objectstack#7115、写明墓碑留在
`Object.keys(shape)`、删除权交 objectui#3809。顺带修陈旧行号(822-1570 改为 973-1677、
666-695 改为 703-745,均按当前 `containers.tsx` 自核)与块头的 rc.5 注。
两条 exemption **不删** —— 删了 gate 会反向变红。

**2. 移除设计器 canonical `page:header` 的 icon 字段**

`previews/block-config.ts` 的字段,加上此时已成孤儿的两条 i18n 键(en / zh 同一次改动,
两张表键集保持一致)。先例逐字:commit 38ab5054f(PR #4169)对 global_nav 的同类清理
(「the palette option and its now-orphaned i18n key」)。防回潮钉在
`previews/__tests__/block-config.test.ts`:正面非空半 + 「不提供 icon」负钉 + spec 侧
墓碑断言(含探针自身的非空性)+ 两条 i18n 键在两个 locale 都已无译文。

**3. docs 修正**(`content/docs/layout/page-header.mdx`)

第 40 行仍把 `icon` 教成 `PageHeaderProps` 的成员。改按 rc.6 现实重写,并把**组件自有
prop** 与**已退役的 spec 键**如实区分 —— 这页文档写的是 `@object-ui/layout` 的
`PageHeader` 组件,它的 `icon` 是 renderer 自有能力;canonical 节点上同名键已被按名拒绝。
未碰 `content/docs/releases/`。

**4. alias 半边(A 案)**

`packages/layout` 的 `page-header` / `layout:page-header` 的 `icon` input **保留**:那是
另一个渲染器,它真读真画(`PageHeader.tsx:123` 读、`:231-233` 画),文档发布它,本仓唯一
的活 demo(`layout-page-header/pageheader-with-actions`)写 `"icon": "users"`。撤掉等于
删除一项工作能力并弄坏 demo —— B 案已拒。

变的是**依据**:注释从 spec parity 改述为 renderer-read 事实;
`page-header-authorable-keys.test.tsx` 的 specKeys 派生**跳过墓碑**(unwrap optional 后
inner 为 `never` 即墓碑,判据与 objectui#3809 一致,实现为局部 helper 并注释指向 #3809
收敛),让 `icon` 不再因为 `Object.keys(shape)` 仍列着它而假绿。豁免写成具名、引单、
自清的 `RENDERER_OWN_DECLARED`,并附一条纪律断言:条目必须对应一个 spec **曾经声明、
现已退役**的键(spec 从未有过的键就是方言,`showBack` 就在同文件被钉为「不声明」)。
未碰 alias renderer 的读点。

顺带:`PageBlockInspector.i18n.test.tsx` 的 #3979 placeholder 测试对从 `page:header`
改指 `record:alert` —— 同样的症状(译过的标签下一条 prose 提示),但钉在渲染器真读的键上。
同一处几行之上的 objectui#4649 就是同样的动作与同样的理由。

## 反向验证(先预判后跑,两次都未提交,跑完 `git checkout HEAD --` 还原,工作树 0 dirty)

预判写在跑之前。两个实验的结果与预判**逐条一致**。

**实验 A —— 把删掉的 BLOCK_CONFIG icon 字段装回去**(两条 i18n 键保持删除,隔离两半)

预判红 7 条,实测红 7 条,无一条计划外:

```
× still offers the canonical header fields the renderer does implement
    expected [ 'title', 'subtitle', 'icon', …(1) ] to deeply equal [ 'title', 'subtitle', 'breadcrumb' ]
× does NOT offer the retired `icon` field
    expected [ 'title', 'subtitle', 'icon', …(1) ] to not include 'icon'
× collects every label site — the walk itself is not empty      expected 8 to be 7
× collects all 17 placeholders — 7 keyed, 10 literal            expected 18 to be 17
× every key resolves in en-US                                   expected [ …(2) ] to deeply equal []
× every key resolves in zh-CN                                   expected [ …(2) ] to deeply equal []
× zh-CN is actually translated, not a copy of en-US             expected [ …(2) ] to deeply equal []
 Tests  7 failed | 31 passed (38)
```

预判绿且实测绿的两条也是有意义的:spec 侧墓碑断言与「两个 locale 都已无译文」都**不**受
设计器字段影响 —— 这正说明字段与 i18n 键必须同进同出,而不是任一可选。后三条红是派生的
双 locale walk 抓到的,它才是这个纪律的机械保证。

**实验 B —— 只撤回 specKeys 的墓碑窄化**(断言全部保留原样)

这一条的方向**不是**「全红」,预判时就写明了,实测确认:

```
× the tombstone probe really reads the spec — not `undefined` for everything
    expected 9 to be less than 9
× declares `icon` with type `string` on both keys — on the renderer read, not spec parity
    expected true to be false
 Tests  2 failed | 14 passed (16)
```

红的恰好是本次**新增**的两条断言。原有的方言守卫
(`declares nothing @objectstack/spec accepts, beyond the declared renderer-own keys`)
**仍然绿**,而且这是重点而非缺陷:撤回窄化只是把 `icon` 从「被 carve-out 放行」换回
「被 `specKeys.has` 放行」,守卫两个世界都分辨不出来 —— 那份分辨不出来,正是 #3829 在被
测量之前一直隐形的原因。若这里报「方言守卫转红」,那就是照模板编的。

## 测试

```
pnpm exec vitest run packages/app-shell/src/views/metadata-admin packages/layout \
  apps/console/src/__tests__/registry-inputs-spec-parity.test.ts --maxWorkers=2
  Test Files  179 passed (179)
       Tests  1874 passed | 1 skipped (1875)

# 消费半径复跑(alias demo 的 manifest 门、console 全部 parity 门、app-shell 全量)
pnpm exec vitest run examples/schema-catalog apps/console packages/app-shell --maxWorkers=2
  Test Files  465 passed (465)
       Tests  5998 passed | 1 skipped (5999)

pnpm type-check --concurrency=2
  Tasks:    81 successful, 81 total

check:control-bytes OK(4307 个文件)· check:i18n-keys OK · check:i18n-en-drift 0 changed ·
check:doc-links OK · changeset presence / fixed / no-major 均 OK · eslint 改动文件 0 error
```

Base:`c25222758598aec3d17c5aa22f1640659f1ecacc`(显式 sha,非 FETCH_HEAD)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_