### PR TITLE
docs(skills,docs,site): 教学面停止教 `props` 信封,键提回节点 (#4786)

### DIFF
--- a/apps/site/app/components/ReactVsObjectUI.tsx
+++ b/apps/site/app/components/ReactVsObjectUI.tsx
@@ -5,6 +5,24 @@
  * The whole point of this section is the line-count delta — keep both
  * snippets honest (no cheating by omitting imports, no padding the
  * React side with formatting).
+ *
+ * The JSON side must stay COPY-RUNNABLE, because "an AI agent can author this"
+ * is the claim the panel makes (objectui#4786). Two ways it stopped being true
+ * before, both measured through a real SchemaRenderer:
+ *
+ *  - `"type": "stats-card"` is registered by nothing in the repo, so every one
+ *    of the four children painted the registry's OBJUI-001 "Unknown component
+ *    type" panel. It is now `statistic`, which `@object-ui/components`
+ *    registers and which reads `label` / `value` / `description` / `icon`.
+ *  - the keys were wrapped in a `props` envelope. `SchemaRenderer` spreads
+ *    `schema.props` as React props instead of merging it into the node, and the
+ *    renderers read `schema.*` — so the envelope rendered an empty card and
+ *    leaked into the DOM as `props="[object Object]"` (same defect class as the
+ *    `cols` fix in objectui#4011 / PR #4785).
+ *
+ * `OBJECTUI_LINES` feeds `REDUCTION_PCT`, shown on the page as "N lines" and
+ * "X% less code" — keep this snippet at 18 lines so a correctness fix never
+ * silently moves the marketing number (the constraint PR #4785 established).
  */
 
 const REACT_CODE = `import {
@@ -55,18 +73,18 @@ const OBJECTUI_CODE = `{
   "type": "grid",
   "columns": { "xs": 1, "md": 2, "lg": 4 }, "gap": 4,
   "children": [
-    { "type": "stats-card", "props": { "title": "Total Revenue",
-      "value": "$45,231.89", "change": "+20.1% from last month",
-      "icon": "dollar-sign" } },
-    { "type": "stats-card", "props": { "title": "Subscriptions",
-      "value": "+2,350", "change": "+180.1% from last month",
-      "icon": "users" } },
-    { "type": "stats-card", "props": { "title": "Sales",
-      "value": "+12,234", "change": "+19% from last month",
-      "icon": "credit-card" } },
-    { "type": "stats-card", "props": { "title": "Active Now",
-      "value": "+573", "change": "+201 since last hour",
-      "icon": "activity" } }
+    { "type": "statistic", "label": "Total Revenue",
+      "value": "$45,231.89", "description": "+20.1% from last month",
+      "icon": "dollar-sign" },
+    { "type": "statistic", "label": "Subscriptions",
+      "value": "+2,350", "description": "+180.1% from last month",
+      "icon": "users" },
+    { "type": "statistic", "label": "Sales",
+      "value": "+12,234", "description": "+19% from last month",
+      "icon": "credit-card" },
+    { "type": "statistic", "label": "Active Now",
+      "value": "+573", "description": "+201 since last hour",
+      "icon": "activity" }
   ]
 }`;
 

--- a/content/docs/fields/grid.mdx
+++ b/content/docs/fields/grid.mdx
@@ -175,16 +175,15 @@ For advanced grid features, use the grid plugin (`@object-ui/plugin-grid`):
 { type: 'grid', name: 'items', columns: [...] }
 
 // Advanced grid with full features (requires plugin)
+// Keys sit on the node — a `props` envelope is never read by the renderer
 {
   type: 'plugin:grid',
   bind: 'items',
-  props: {
-    columns: [...],
-    editable: true,      // Plugin feature: inline editing
-    sortable: true,      // Plugin feature: column sorting
-    filterable: true,    // Plugin feature: filtering
-    pagination: { pageSize: 20 }  // Plugin feature: pagination
-  }
+  columns: [...],
+  editable: true,      // Plugin feature: inline editing
+  sortable: true,      // Plugin feature: column sorting
+  filterable: true,    // Plugin feature: filtering
+  pagination: { pageSize: 20 }  // Plugin feature: pagination
 }
 ```
 

--- a/content/docs/fields/location.mdx
+++ b/content/docs/fields/location.mdx
@@ -85,14 +85,13 @@ import { LocationField } from '@object-ui/fields';
 <LocationField {...props} />
 
 // With map visualization (using map plugin)
+// Keys sit on the node — a `props` envelope is never read by the renderer
 {
   type: 'plugin:map',
   bind: 'location',
-  props: {
-    center: location,
-    zoom: 12,
-    markers: [location]
-  }
+  center: location,
+  zoom: 12,
+  markers: [location]
 }
 ```
 

--- a/content/docs/plugins/index.md
+++ b/content/docs/plugins/index.md
@@ -351,12 +351,15 @@ All ObjectUI plugins follow the same usage pattern:
 ```json
 {
   "type": "plugin-component-name",
-  "className": "tailwind-classes",
-  "props": {
-    // Plugin-specific properties
-  }
+  "className": "tailwind-classes"
+  // Plugin-specific properties go here, on the node itself
 }
 ```
+
+Plugin renderers read their configuration off the node (`schema.objectName`,
+`schema.columns`, …), exactly like the built-in ones. Do not wrap those keys in
+a `props` envelope: `SchemaRenderer` spreads `schema.props` as React props
+rather than merging it into the node, so anything parked there is never read.
 
 ### Example: Code Editor
 

--- a/content/docs/utilities/runner.mdx
+++ b/content/docs/utilities/runner.mdx
@@ -243,10 +243,9 @@ import '@object-ui/plugin-yourplugin'
 
 ```json
 {
-  "type": "your-component",
-  "props": {
-    // Your component props
-  }
+  "type": "your-component"
+  // Your component's keys go here, on the node itself — renderers read
+  // `schema.<key>`, not a `props` envelope
 }
 ```
 

--- a/skills/objectui/guides/auth-permissions.md
+++ b/skills/objectui/guides/auth-permissions.md
@@ -227,7 +227,7 @@ Combine permissions with expression-based visibility:
 ```json
 {
   "type": "button",
-  "props": { "label": "Delete Selected" },
+  "label": "Delete Selected",
   "hidden": "${data.userRole !== 'admin'}"
 }
 ```
@@ -251,7 +251,7 @@ Then in schema:
 ```json
 {
   "type": "button",
-  "props": { "label": "Delete" },
+  "label": "Delete",
   "hidden": "${!canDeleteContacts}"
 }
 ```

--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -184,30 +184,47 @@ Data-driven components (grids, tables, kanbans, charts) use the `bind` field:
 {
   "type": "data-table",
   "bind": "customers",
-  "props": {
-    "columns": [
-      { "name": "name", "label": "Name" },
-      { "name": "email", "label": "Email" }
-    ]
-  }
+  "columns": [
+    { "name": "name", "label": "Name" },
+    { "name": "email", "label": "Email" }
+  ]
 }
 ```
 
 Inside the component: `const data = useDataScope("customers")` resolves to the `customers` array from the dataSource.
 
-### Via expressions in `props`
+### Via expressions on the node
 
-Static data or computed values through the expression system:
+Computed values go through the expression system. `content` is the text key that
+is both expression-evaluated and read back by the renderer, and the provider's
+`dataSource` is reachable under the `data` root:
+
+```json
+{
+  "type": "card",
+  "title": "Total Customers",
+  "children": [
+    { "type": "text", "content": "${data.metrics.total} customers" }
+  ]
+}
+```
+
+A `statistic`'s `label` / `value` / `description` are read off the node but are
+**not** expression-evaluated, so give them values the host already resolved:
 
 ```json
 {
   "type": "statistic",
-  "props": {
-    "label": "Total Customers",
-    "value": "${metrics.total}"
-  }
+  "label": "Total Customers",
+  "value": "128",
+  "description": "+12 this week",
+  "trend": "up"
 }
 ```
+
+Do not reach for a `props` envelope to get an expression evaluated — values
+inside it are evaluated and then handed over as React props, which these
+renderers never read, so the component paints an empty frame.
 
 ### Via DataSource methods (in plugin code)
 

--- a/skills/objectui/guides/i18n.md
+++ b/skills/objectui/guides/i18n.md
@@ -121,13 +121,13 @@ const { t } = useObjectTranslation();
 
 const localizedSchema = {
   type: 'card',
-  props: {
-    title: t('customers.title'),
-    description: t('customers.description'),
-  },
+  // Keys sit on the node — the renderers read `schema.title` / `schema.label`,
+  // not a `props` envelope.
+  title: t('customers.title'),
+  description: t('customers.description'),
   children: [
-    { type: 'button', props: { label: t('common.save') } },
-    { type: 'button', props: { label: t('common.cancel') } },
+    { type: 'button', label: t('common.save') },
+    { type: 'button', label: t('common.cancel') },
   ],
 };
 ```

--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -73,22 +73,28 @@ Use a strict component schema shape similar to:
   "type": "card",
   "id": "customer_summary",
   "className": "col-span-12 lg:col-span-4",
-  "props": {
-    "title": "Customer Summary"
-  },
+  "title": "Customer Summary",
   "hidden": "${data.userRole !== 'admin'}",
   "children": [
     {
       "type": "text",
-      "props": {
-        "content": "Active users: ${data.metrics.activeUsers}"
-      }
+      "content": "Active users: ${data.metrics.activeUsers}"
     }
   ]
 }
 ```
 
-Prefer expression-based behavior (`hidden`, `disabled`, computed props) over imperative branching in component code.
+**Every key belongs on the node itself — never in a `props` envelope.** The
+renderers read `schema.title` / `schema.content` / `schema.columns` directly;
+`SchemaRenderer` spreads `schema.props` as React props instead of merging it
+into the node, so a key parked under `props` is never read and the component
+paints an empty frame (the envelope itself also lands in the DOM as
+`props="[object Object]"`). Namespaced `element:*` components are the one
+deliberate exception — they read their config out of `properties` / `props`
+by design (`readProps` in `packages/components/src/renderers/basic/elements.tsx`).
+
+Prefer expression-based behavior (`hidden`, `disabled`) over imperative
+branching in component code.
 
 ### 4. Wire renderer and registry cleanly
 
@@ -161,39 +167,64 @@ When users ask for a "console-like" experience, prefer:
 
 Understanding what gets evaluated and what does not is critical for correct schemas.
 
+A key must clear **two independent gates** to reach the screen: the renderer
+has to *read* it, and `SchemaRenderer` has to *evaluate* it. Keys on the node
+clear the first gate; only the short list below clears the second.
+
 **Evaluated by SchemaRenderer automatically:**
 
 | Field | What happens |
 |-------|-------------|
-| `props.*` | All values in the `props` object are expression-evaluated. Use `props.label`, `props.value`, etc. |
-| `content` | Evaluated for text components. `"content": "Hello ${user.name}"` works. |
+| `content` | Template-evaluated **and** read by the text renderers. `"content": "Hello ${user.name}"` works end to end. |
 | `hidden` / `hiddenOn` | Boolean expression. Component removed from DOM when true. |
 | `visible` / `visibleOn` | Boolean expression. `visible` takes priority over `hidden`. |
 | `disabled` / `disabledOn` | Boolean expression. Passed as prop to component. |
+| `props.*` | Template-evaluated, but handed to the component as React props — a `ui:*` / `page:*` renderer never reads the result back, so the evaluated value is discarded. Only `element:*` components consume it. Do not use it as an expression carrier. |
 
 **NOT evaluated (raw strings passed through):**
 
-| Field | Workaround |
+| Field | What to do instead |
 |-------|-----------|
-| `value` (top-level) | Move to `props.value` |
-| `label` (top-level) | Move to `props.label` |
-| `description` (top-level) | Move to `props.description` |
+| `title` / `label` / `value` / `description` | Read by the renderer, but never template-evaluated — an inline `${...}` reaches the screen as literal text. Moving it under `props` does not help: it gets evaluated there and then dropped. Resolve the value in the host **before** handing the schema to `SchemaRenderer` (the same pattern the i18n guide uses for `t(...)`), or carry it on a `text` node's `content`. |
 | `className` | Not expression-evaluated. Use static Tailwind classes only. |
 | `id` | Static string. No expressions. |
 
-**Correct pattern:**
+**Correct pattern** — a `statistic`'s text keys sit on the node and carry
+values the host already resolved:
+```json
+{
+  "type": "statistic",
+  "label": "Active Users",
+  "value": "42",
+  "description": "+5% from last month",
+  "trend": "up"
+}
+```
+
+**Correct pattern for a live-bound number** — `content` is the one text key
+that is both evaluated and read:
+```json
+{
+  "type": "card",
+  "title": "Active Users",
+  "children": [
+    { "type": "text", "content": "${data.metrics.activeUsers} active, +${data.metrics.growth}% this month" }
+  ]
+}
+```
+
+**Wrong pattern (renders an empty card — the envelope is never read):**
 ```json
 {
   "type": "statistic",
   "props": {
     "label": "Active Users",
-    "value": "${data.metrics.activeUsers}",
-    "description": "+${data.metrics.growth}% from last month"
+    "value": "${data.metrics.activeUsers}"
   }
 }
 ```
 
-**Wrong pattern (value will show as raw `${...}` text):**
+**Also wrong (value shows as raw `${...}` text — read, but not evaluated):**
 ```json
 {
   "type": "statistic",
@@ -270,20 +301,21 @@ Adjust `@source` paths based on your project's location relative to `node_module
 
 ## Plugin integration in page schemas
 
-When pages need heavy widgets (grids, forms, kanbans, charts), import the plugin package and ensure its components are registered before rendering.
+When pages need heavy widgets (grids, forms, kanbans, charts), import the plugin package and ensure its components are registered before rendering. Plugin
+widgets read their configuration off the node exactly like the built-in
+renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
+`schema.gantt`) — the `props` envelope is not read here either.
 
 **Grid plugin example:**
 ```json
 {
   "type": "object-grid",
-  "props": {
-    "objectName": "products",
-    "columns": [
-      { "name": "name", "label": "Name", "type": "text" },
-      { "name": "price", "label": "Price", "type": "currency" },
-      { "name": "status", "label": "Status", "type": "select" }
-    ]
-  },
+  "objectName": "products",
+  "columns": [
+    { "name": "name", "label": "Name", "type": "text" },
+    { "name": "price", "label": "Price", "type": "currency" },
+    { "name": "status", "label": "Status", "type": "select" }
+  ],
   "bind": "products"
 }
 ```
@@ -292,14 +324,12 @@ When pages need heavy widgets (grids, forms, kanbans, charts), import the plugin
 ```json
 {
   "type": "object-form",
-  "props": {
-    "objectName": "customer",
-    "mode": "edit",
-    "fields": [
-      { "name": "name", "label": "Name", "type": "text", "required": true },
-      { "name": "email", "label": "Email", "type": "text" }
-    ]
-  }
+  "objectName": "customer",
+  "mode": "edit",
+  "fields": [
+    { "name": "name", "label": "Name", "type": "text", "required": true },
+    { "name": "email", "label": "Email", "type": "text" }
+  ]
 }
 ```
 
@@ -307,10 +337,8 @@ When pages need heavy widgets (grids, forms, kanbans, charts), import the plugin
 ```json
 {
   "type": "kanban",
-  "props": {
-    "objectName": "tasks",
-    "groupBy": "status"
-  },
+  "objectName": "tasks",
+  "groupBy": "status",
   "bind": "tasks"
 }
 ```
@@ -319,37 +347,35 @@ When pages need heavy widgets (grids, forms, kanbans, charts), import the plugin
 ```json
 {
   "type": "gantt",
-  "props": {
-    "objectName": "project_task",
-    "gantt": {
-      "titleField": "name",
-      "startDateField": "start_date",
-      "endDateField": "end_date",
-      "progressField": "progress",
-      "parentField": "parent_id",
-      "dependenciesField": "depends_on",
-      "typeField": "item_type",
-      "lockField": "is_locked",
-      "defaultCollapsedDepth": 2,
-      "colorField": "status",
-      "baselineStartField": "planned_start",
-      "baselineEndField": "planned_end",
-      "tooltipFields": [{ "field": "owner", "label": "Owner" }, "status", "effort"],
-      "groupByField": "owner",
-      "assigneeField": "owner",
-      "effortField": "effort"
-    },
-    "criticalPath": true,
-    "skipWeekends": true,
-    "holidays": ["2026-01-01", "2026-12-25"],
-    "quickFilters": [
-      { "field": "status", "label": "状态" },
-      { "field": "project", "label": "项目" },
-      { "field": "priority", "label": "优先级", "options": ["high", "medium", "low"] }
-    ],
-    "autoZoomToFilter": true,
-    "readOnly": false
+  "objectName": "project_task",
+  "gantt": {
+    "titleField": "name",
+    "startDateField": "start_date",
+    "endDateField": "end_date",
+    "progressField": "progress",
+    "parentField": "parent_id",
+    "dependenciesField": "depends_on",
+    "typeField": "item_type",
+    "lockField": "is_locked",
+    "defaultCollapsedDepth": 2,
+    "colorField": "status",
+    "baselineStartField": "planned_start",
+    "baselineEndField": "planned_end",
+    "tooltipFields": [{ "field": "owner", "label": "Owner" }, "status", "effort"],
+    "groupByField": "owner",
+    "assigneeField": "owner",
+    "effortField": "effort"
   },
+  "criticalPath": true,
+  "skipWeekends": true,
+  "holidays": ["2026-01-01", "2026-12-25"],
+  "quickFilters": [
+    { "field": "status", "label": "状态" },
+    { "field": "project", "label": "项目" },
+    { "field": "priority", "label": "优先级", "options": ["high", "medium", "low"] }
+  ],
+  "autoZoomToFilter": true,
+  "readOnly": false,
   "bind": "project_task"
 }
 ```

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -30,9 +30,12 @@ SchemaRenderer evaluates these fields before passing props to the resolved compo
 
 ### Automatically evaluated fields
 
+Evaluation and *readback* are two different gates. A value is only visible if
+`SchemaRenderer` evaluates it **and** the renderer reads the key it sits on —
+see "The `props` envelope is evaluated but not read" below.
+
 | Schema field | Evaluation type | Return type | Example |
 |---|---|---|---|
-| `props.*` | Template (`${}`) | Preserves original type | `"props": { "count": "${items.length}" }` → number |
 | `content` | Template (`${}`) | string | `"content": "Total: ${data.total}"` |
 | `hidden` | Condition | boolean | `"hidden": "${data.role !== 'admin'}"` |
 | `hiddenOn` | Condition | boolean | `"hiddenOn": "data.status === 'draft'"` |
@@ -47,14 +50,41 @@ SchemaRenderer evaluates these fields before passing props to the resolved compo
 
 These top-level schema fields are **not** processed by ExpressionEvaluator:
 
-- `value` — use `props.value` instead
-- `label` — use `props.label` instead
-- `description` — use `props.description` instead
-- `title` — use `props.title` instead
+- `value`, `label`, `description`, `title` — read by the renderers, but never
+  template-evaluated. Resolve them in the host before rendering, or carry the
+  bound text on a `text` node's `content`.
 - `className` — always a static Tailwind class string
 - `id` — always a static string
 - `type` — component type identifier
 - `bind` — data scope path (resolved by `useDataScope`, not by expressions)
+
+### The `props` envelope is evaluated but not read
+
+`SchemaRenderer` **does** run every value inside `props` through the evaluator —
+and then spreads the object as React props rather than merging it into the node.
+Every `ui:*` / `page:*` renderer reads `schema.title` / `schema.content` /
+`schema.columns` off the node itself, so the evaluated value is discarded: the
+component paints an empty frame and the envelope lands in the DOM as the invalid
+attribute `props="[object Object]"`.
+
+So `props` is not an escape hatch for the unevaluated keys above — it trades a
+literal `${...}` on screen for nothing on screen. Put keys on the node.
+
+```json
+// ❌ Evaluated, then dropped — renders an empty card
+{ "type": "card", "props": { "title": "${data.customer.name}" } }
+
+// ❌ Read, but never evaluated — renders the literal "${data.customer.name}"
+{ "type": "card", "title": "${data.customer.name}" }
+
+// ✅ `content` is the one text key that is both evaluated and read
+{ "type": "card", "title": "Customer", "children": [
+  { "type": "text", "content": "${data.customer.name}" }
+] }
+```
+
+The `element:*` namespace is the deliberate exception: those components read
+their config out of `properties` / `props`, so the envelope is required there.
 
 ## Template expression syntax (`${}`)
 
@@ -342,12 +372,10 @@ The `bind` field is NOT expression-evaluated. It's a path string resolved by `us
 {
   "type": "data-table",
   "bind": "customers",
-  "props": {
-    "columns": [
-      { "name": "name", "label": "Name" },
-      { "name": "email", "label": "Email" }
-    ]
-  }
+  "columns": [
+    { "name": "name", "label": "Name" },
+    { "name": "email", "label": "Email" }
+  ]
 }
 ```
 
@@ -394,21 +422,22 @@ Expressions are compiled once per unique `(expression, variableNames)` pair and 
 **Avoid:**
 - Heavy array operations (`filter`, `map`, `reduce`) on large datasets inside expressions — move to derived state or the data layer
 - Deeply nested optional chaining in hot paths
-- Multiple complex expressions in a single `props` object in frequently re-rendered components
+- Multiple complex expressions on a single node in frequently re-rendered components
 
 ## Common mistakes and how to fix them
 
 ### Expression shows as literal text (`${data.x}` visible in UI)
 
-**Cause:** The field isn't expression-evaluated. Move to `props`.
+**Cause:** The field isn't expression-evaluated. Use `content`.
 
 ```json
-// ❌ Won't evaluate
+// ❌ Won't evaluate — `value` is read but never templated
 { "type": "text", "value": "${data.total}" }
 
-// ✅ Evaluated
+// ❌ Worse — evaluated inside the envelope, then discarded: renders nothing
 { "type": "text", "props": { "value": "${data.total}" } }
-// or
+
+// ✅ Evaluated and read
 { "type": "text", "content": "Total: ${data.total}" }
 ```
 
@@ -431,20 +460,20 @@ Expressions are compiled once per unique `(expression, variableNames)` pair and 
 
 ```json
 // ❌ Blocked
-{ "props": { "date": "${new Date(data.timestamp)}" } }
+{ "type": "text", "content": "${new Date(data.timestamp)}" }
 
 // ✅ Use formula functions
-{ "props": { "date": "${DATEFORMAT(data.timestamp, 'YYYY-MM-DD')}" } }
+{ "type": "text", "content": "${DATEFORMAT(data.timestamp, 'YYYY-MM-DD')}" }
 ```
 
 ### Object literal in expression
 
 ```json
 // ❌ Object literals not supported
-{ "props": { "style": "${{ color: 'red' }}" } }
+{ "type": "text", "style": "${{ color: 'red' }}" }
 
-// ✅ Use individual props or className
-{ "className": "text-red-500" }
+// ✅ Use className
+{ "type": "text", "className": "text-red-500" }
 ```
 
 ### Missing variable returns undefined silently
@@ -452,14 +481,14 @@ Expressions are compiled once per unique `(expression, variableNames)` pair and 
 Expressions don't throw on missing variables — they return `undefined`. Use fallback patterns:
 
 ```json
-{ "props": { "name": "${data.user?.name || 'Unknown'}" } }
+{ "type": "text", "content": "${data.user?.name || 'Unknown'}" }
 ```
 
 ## Debugging checklist
 
 When an expression isn't working:
 
-1. Is the field in `props.*` or `content`? If not, it won't be evaluated.
+1. Is it `content` (or a predicate key)? Those are the fields that are both evaluated and read. A `${...}` on `title` / `label` / `value` / `description` is never evaluated, and one inside a `props` envelope is evaluated and then discarded.
 2. Is the `${}` syntax correct? Check for unmatched braces.
 3. Is the data actually available in scope? Check `SchemaRendererProvider dataSource`.
 4. For conditions: are you using `On` suffix correctly? (`hiddenOn` takes raw expression, `hidden` needs `${}` if it's a string).

--- a/skills/objectui/guides/testing.md
+++ b/skills/objectui/guides/testing.md
@@ -122,7 +122,7 @@ describe('schema validation', () => {
       type: 'card',
       children: [
         { type: 'text', content: 'Hello' },
-        { type: 'button', props: { label: 'Click' } },
+        { type: 'button', label: 'Click' },
       ],
     };
     expect(isValidSchema(schema)).toBe(true);

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -6,11 +6,12 @@
 
 ### Fields That ARE Evaluated
 
-SchemaRenderer evaluates these fields automatically:
+SchemaRenderer evaluates these fields automatically. **Evaluated is not the
+same as read** — see "Rule: Keys Live on the Node" below for the second gate a
+value must clear before it reaches the screen.
 
 | Field | Evaluation Type | Return Type | Example |
 |---|---|---|---|
-| `props.*` | Template (`${}`) | Preserves original type | `"props": { "count": "${items.length}" }` → number |
 | `content` | Template (`${}`) | string | `"content": "Total: ${data.total}"` |
 | `hidden` | Condition | boolean | `"hidden": "${data.role !== 'admin'}"` |
 | `hiddenOn` | Condition | boolean | `"hiddenOn": "data.status === 'draft'"` |
@@ -18,6 +19,7 @@ SchemaRenderer evaluates these fields automatically:
 | `visibleOn` | Condition | boolean | `"visibleOn": "data.permissions.canView"` |
 | `disabled` | Condition | boolean | `"disabled": "${form.isSubmitting}"` |
 | `disabledOn` | Condition | boolean | `"disabledOn": "!data.hasPermission"` |
+| `props.*` | Template (`${}`) | Preserves original type | Evaluated, then spread as **React props** — a `ui:*` / `page:*` renderer reads `schema.*` and never sees the result. Consumed only by `element:*` components. |
 
 **Precedence rule:** `visible` takes priority over `hidden`.
 
@@ -25,10 +27,12 @@ SchemaRenderer evaluates these fields automatically:
 
 These top-level schema fields are passed as raw strings:
 
-- `value` — use `props.value` instead
-- `label` — use `props.label` instead
-- `description` — use `props.description` instead
-- `title` — use `props.title` instead
+- `value`, `label`, `description`, `title` — read by the renderers, but never
+  template-evaluated. **Do not "move them to `props`"** to make an expression
+  work: under `props` they are evaluated and then discarded, so the component
+  paints an empty frame instead. Resolve the value in the host before handing
+  the schema to `SchemaRenderer`, or carry it on a `text` node's `content`,
+  which is the one text key that is both evaluated and read.
 - `className` — always a static Tailwind class string
 - `id` — always a static string
 - `type` — component type identifier
@@ -52,6 +56,39 @@ interface UIComponent {
 }
 ```
 
+## Rule: Keys Live on the Node, Not in a `props` Envelope
+
+Every `ui:*` / `page:*` renderer reads its configuration off the node —
+`schema.title`, `schema.content`, `schema.value`, `schema.columns`.
+`SchemaRenderer` does **not** merge `schema.props` into the node; it spreads it
+as React props (`packages/react/src/SchemaRenderer.tsx`), which those renderers
+ignore. A key parked under `props` is therefore silently dropped: the component
+renders an empty frame, and the envelope itself lands in the DOM as the invalid
+attribute `props="[object Object]"`.
+
+**❌ WRONG — renders an empty card:**
+```json
+{
+  "type": "card",
+  "props": { "title": "Customer Summary" }
+}
+```
+
+**✅ CORRECT:**
+```json
+{
+  "type": "card",
+  "title": "Customer Summary"
+}
+```
+
+**The one exception is the `element:*` namespace.** Those components read their
+config out of `properties` / `props` by design (`readProps` in
+`packages/components/src/renderers/basic/elements.tsx`), so
+`{ "type": "element:text", "properties": { "content": "Hi" } }` is correct and
+the same keys on the node would be ignored. Match the envelope to the
+namespace; do not apply either shape everywhere.
+
 ## Rule: No Schema Property Invention
 
 **❌ FORBIDDEN:** Adding custom properties not defined in `@objectstack/spec`.
@@ -59,7 +96,7 @@ interface UIComponent {
 **Example violation:**
 ```json
 {
-  "type": "grid",
+  "type": "data-table",
   "fields": [...],  // ❌ spec uses "columns"
   "customProp": "value"  // ❌ not in spec
 }
@@ -68,10 +105,8 @@ interface UIComponent {
 **✅ CORRECT:**
 ```json
 {
-  "type": "grid",
-  "props": {
-    "columns": [...]  // ✅ follows spec
-  }
+  "type": "data-table",
+  "columns": [...]  // ✅ declared by DataTableSchema, read off the node
 }
 ```
 
@@ -93,9 +128,7 @@ The `bind` field is NOT expression-evaluated. It's a path string resolved by `us
 {
   "type": "data-table",
   "bind": "customers",  // Resolved as dataSource.customers
-  "props": {
-    "columns": [...]
-  }
+  "columns": [...]
 }
 ```
 

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -46,7 +46,8 @@ Every UI component node MUST follow this shape:
 interface UIComponent {
   type: string;              // Required: component type identifier
   id?: string;               // Optional: unique identifier
-  props?: Record<string, any>; // Optional: component properties
+  props?: Record<string, any>; // Optional: element:* config envelope — NOT a
+                               // general bag. See "Rule: Keys Live on the Node".
   bind?: string;             // Optional: data binding path
   className?: string;        // Optional: Tailwind CSS classes
   hidden?: string;           // Optional: visibility expression

--- a/skills/objectui/rules/styling.md
+++ b/skills/objectui/rules/styling.md
@@ -85,17 +85,15 @@ const buttonVariants = cva(
 );
 ```
 
-## Rule: Expose `className` in Schema Props
+## Rule: Expose `className` on the Schema Node
 
-**Every component must accept `className` in its schema props** to allow JSON-level style overrides:
+**Every component must accept `className` on its schema node** to allow JSON-level style overrides. Like every other key, it is read off the node itself — not out of a `props` envelope, which the renderers never read:
 
 ```json
 {
   "type": "card",
   "className": "bg-red-500",  // ✅ User can override styles
-  "props": {
-    "title": "Alert"
-  }
+  "title": "Alert"
 }
 ```
 


### PR DESCRIPTION
Fixes #4786

基线 `db8184cd9`(PR #4785 已落 main)。

渲染器从节点本身读键,`SchemaRenderer` 把 `schema.props` **spread 成 React props**、不并进节点。照 `page-builder.md` 写出的页面因此是一片空白框,信封本身还以 `props="[object Object]"` 落进 DOM。#4011 / PR #4785 修的是一个键教错;本单是一个**信封形态**教错,覆盖任意组件类型。

---

## 1. 甄别表(全仓重数:18 个文件,不是 10 个)

以「`props` 作为键出现」为口径(`"props":` 或 `props:`)全仓枚举 markdown / mdx:**18 个文件、41 处**。issue 正文说 10 个,数少了。逐处判定:

### A 类 —— schema 节点信封(改写,12 个文件)

| 文件 | 处数 | 判定 | 处置 |
|---|---|---|---|
| `skills/objectui/guides/page-builder.md` | 7 | card/text 节点形态、statistic「Correct pattern」、四个插件示例 | 全部拆信封提顶层;求值边界整节重写 |
| `skills/objectui/guides/schema-expressions.md` | 8 | 求值表、data-table、text ✅/❌、四处表达式语法示例 | 7 处改写;1 处**刻意保留**(见下) |
| `skills/objectui/rules/protocol.md` | 3 | 求值表 `props.*` 行、「No Schema Property Invention」的 ✅ 例、`bind` 例 | 改写 + 新增「Rule: Keys Live on the Node」 |
| `skills/objectui/guides/i18n.md` | 3 | card + 两个 button 的 `t()` 示例 | 拆信封 |
| `skills/objectui/guides/data-integration.md` | 2 | data-table、statistic | 拆信封;「Via expressions in `props`」整节重写 |
| `skills/objectui/guides/auth-permissions.md` | 2 | 两个 button | 拆信封 |
| `skills/objectui/rules/styling.md` | 1 | card(规则标题也写着 "Schema Props") | 拆信封 + 改标题 |
| `skills/objectui/guides/testing.md` | 1 | `isValidSchema` 用例里的 button | 拆信封(实测两态 `isValidSchema` 均为 `true`,未丢覆盖) |
| `content/docs/plugins/index.md` | 1 | 插件通用模板 | 拆信封 + 补一句为什么 |
| `content/docs/utilities/runner.mdx` | 1 | 自建组件通用模板 | 拆信封 |
| `content/docs/fields/grid.mdx` | 1 | `plugin:grid` | 拆信封(`type` 名另有缺陷 → #4796) |
| `content/docs/fields/location.mdx` | 1 | `plugin:map` | 同上 → #4796 |

外加 `apps/site/app/components/ReactVsObjectUI.tsx`(4 处信封,见第 3 节)。

### B 类 —— React 组件 props 教学(保留,5 个文件)

| 文件 | 处数 | 为什么保留 |
|---|---|---|
| `content/docs/guide/component-registry.md` | 5 | 全是 `function MyComponent(props: ComponentProps...)` 这类 TSX 形参,与 schema 节点无关 |
| `content/docs/guide/plugin-development.md` | 1 | 正文讨论 widget 的 React props(`required` 不在 props 里) |
| `content/docs/guide/architecture.md` | 1 | 「renders with evaluated props」+ JSX 示例 |
| `CONTRIBUTING.md` | 1 | `function MyComponent(props: { schema: ... })` |
| `.github/prompts/engine.prompt.md` | 1 | `(props: { config: PageComponent })` HOC 形参 |

### C 类 —— 其它合法用法(保留,1 个文件)

| 文件 | 处数 | 为什么保留 |
|---|---|---|
| `skills/objectui/guides/mobile.md` | 1 | 正是 PR #4785 新写的 ❌ DO NOT 反例文本(`"props": { "cols": … }`)。派单已划为禁区,内容也正确 |

### 刻意保留的那 1 处 A 类

`schema-expressions.md` 的「Iteration scopes (loops)」示例(`list` + `children` + `${item.name}`)**保持原样**。原则是:**改写不得引入新的错**。这一处的信封不是它的病根 —— 实测 `list` 从不渲染 `children`(2 条数据渲染出 2 个空 `li`),且全仓不存在 `item` / `index` 求值作用域。把 `title` 提到节点上会得到一个"看着修好了、照样空白、还多了一个不求值的 `${...}`"的示例,比原样更难被发现。已立 #4797,由那一单决定是补能力还是收缩文档。

对照:`grid.mdx` / `location.mdx` 的信封**改了** —— 那里拆信封不引入任何新错(键位置本来就该在节点上),残留的 `type` 名缺陷原封不动且已单独立单。同一条原则,两种结论。

---

## 2. 每处改写的探针实测

全部经真实 `SchemaRenderer` + 真实注册表渲染,探针文件跑完即删、不入仓。派单里「猜形态不可靠」这一条在本单反复兑现 —— 下面三条结论都不是从代码推出来的,是量出来的。

### 2.1 机制:`ui:*` / `page:*` 读节点,`element:*` 读信封

```
@@PROBE text/ENVELOPE       text=""        html=(空)
@@PROBE text/TOPLEVEL       text="HELLO"
@@PROBE card/ENVELOPE       text=""        html=... props="[object Object]" title="KPI 1" ...
@@PROBE card/TOPLEVEL       text="KPI 1"
@@PROBE statistic/ENVELOPE  text=""
@@PROBE statistic/TOPLEVEL  text="Active Users42+5% mom"
@@PROBE button/ENVELOPE     text=""        html=... props="[object Object]" label="Delete Selected" ...
@@PROBE button/TOPLEVEL     text="Delete Selected"
@@PROBE data-table/ENVELOPE text="No results found..."          ← 表头没了
@@PROBE data-table/TOPLEVEL text="NameEmailNo results found..."
@@PROBE grid/ENVELOPE       class="grid grid-cols-2 gap-4"      ← 每断点平两列(复现 #4785)
@@PROBE grid/TOPLEVEL       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4"

@@PROBE element:text/props        text="HELLO"
@@PROBE element:text/properties   text="HELLO"
@@PROBE element:text/TOPLEVEL     text=""      ← element:* 恰好相反
@@PROBE page:card/TOPLEVEL        text="KPI 1"
@@PROBE page:card/props           text=""
```

所以规则写成**按命名空间匹配信封**,而不是一刀切「永远别用 `props`」。后者会变成一条新的教错:`element:*` 的 `readProps`(`packages/components/src/renderers/basic/elements.tsx`)按设计只读 `properties` / `props`,节点上的同名键根本不看。protocol.md 的新规则里明写了这条例外。

### 2.2 求值与读回是两道独立闸门 —— 原 workaround 是反向的

| 写法 | 求值 | 读回 | 实测 |
|---|---|---|---|
| `{"type":"card","props":{"title":"${data.total}"}}` | ✅ | ❌ | `text=""`,DOM 里 `title="99"` —— **值求出来了,然后被扔了** |
| `{"type":"card","title":"${data.total}"}` | ❌ | ✅ | `text="${data.total}"` 字面量 |
| `{"type":"text","content":"Total: ${data.total}"}` | ✅ | ✅ | `text="Total: 99"` |

三处教学面(protocol.md、page-builder.md、schema-expressions.md)成体系地写着「`value` → 用 `props.value`」这类 workaround。它把"屏上字面量"换成了"屏上空白" —— 更难诊断,方向还是反的。本 PR 把三处都改成如实陈述 + 给出可跑写法(`content`,或宿主预解析);引擎侧的洞另开 **#4795**,本单零改 `packages/**`。

### 2.3 改写后每一处的实测(24 条,全绿)

```
@@PROBE pb/node-shape              text="Customer SummaryActive users: 42"     propsAttr=false
@@PROBE pb/statistic-host-resolved text="Active Users42+5% from last month"
@@PROBE pb/live-bound-card         text="Active Users42 active, +5% this month"
@@PROBE protocol/card-wrong        text=""                          propsAttr=true    ← ❌ 例,如实为空
@@PROBE protocol/card-right        text="Customer Summary"
@@PROBE protocol/element-text      text="Hi"                        ← 例外条款也实测
@@PROBE protocol/data-table-correct text="NameEmail..."
@@PROBE sx/dropped                 text=""            propsAttr=true
@@PROBE sx/literal                 text="${data.customer.name}"
@@PROBE sx/correct                 text="CustomerAcme Corp"
@@PROBE sx/text-content            text="Total: 99"
@@PROBE sx/dateformat              text="2026-08-16"
@@PROBE sx/fallback                text="Unknown"
@@PROBE sx/className               text="red"
@@PROBE di/card-content            text="Total Customers128 customers"
@@PROBE di/statistic               text="Total Customers128+12 this week"
@@PROBE auth/shown                 text="Delete Selected"           (userRole=admin)
@@PROBE auth/hidden                text=""                          (userRole=viewer)
@@PROBE styling/card               text="Alert"
@@PROBE i18n/card                  text="CustomersAll customersSaveCancel"
@@PROBE testing/button             text="HelloClick"
@@PROBE site/shipped               text="Total Revenue$45,231.89+20.1% from last monthSubscriptions..."
```

`unknownPanel=false`、`propsAttr=false` 对每一条改写后示例都成立(两处 ❌ 反例除外,它们**应当**为空/带属性,方向是预期内的)。

**反向验证方向说明:** 本单是纯文档 PR,仓内没有新增钉子可以"删掉修复看它变红"。这里的等价物是上面每一组的**前后成对实测** —— 旧形态 `text=""`、新形态有内容,同一探针同一次运行里量出来。没有把一个不适用的模板套上去。

### 2.4 插件四例(page-builder.md)的证据等级,如实标注

`object-grid` / `kanban` / `gantt` 在探针环境里需要完整 provider + dataSource 才能画出可区分的产物(裸渲染报 `useSchemaContext must be used within a SchemaRendererProvider`),`object-form` 两态输出相同。**所以这四处的改写依据是读码,不是端到端渲染实测** —— 三者都直接读节点:

- `packages/plugin-grid/src/index.tsx:155-157` —— `objectName={schema.objectName}` / `fields={schema.fields ?? []}`
- `packages/plugin-kanban/src/ObjectKanban.tsx:183,203-213` —— `schema.objectName`
- `packages/plugin-form/src/index.tsx` / `packages/plugin-gantt/src/index.tsx` 同形

再叠加 2.1 里已在六个 `ui:*` 类型上端到端量到的通用机制。这一条**不谎报**成渲染实测。

---

## 3. `ReactVsObjectUI.tsx` —— 取舍说明

派单给了两条路:换成已注册组件让示例真跑,或如实弱化「可复制」暗示。**选了第一条**,因为面板自己打的招牌就是「plain JSON an AI agent can author」——弱化措辞是把 bug 写进文案,换组件是把 bug 修掉。

实测原状:四个子节点**全部**画 OBJUI-001 红框。

```
@@PROBE site/CURRENT  text="Unknown component type: stats-card ... (OBJUI-001) ..."
@@PROBE site/FIXED    text="Total Revenue$45,231.89+20.1% from last month"
```

`stats-card` 全仓零注册(只作为文件名 / `id` 出现);换成 `statistic`(`packages/components` 注册,读 `label` / `value` / `description` / `icon`),键同时提回节点。取值参照 catalog 里真实可跑的 `examples/schema-catalog/src/schemas/dashboard/stats-cards-grid.json`(未改动该文件)。

按 PR #4785 立下的约束**保持 18 行不变**:`OBJECTUI_LINES=18`、`REACT_LINES=43`、`REDUCTION_PCT=58`,与改动前逐字相同 —— 一次正确性修复不该悄悄挪动页面上的营销数字。已在文件头注释里把这条约束和两个失效原因写下来,免得下次再被改回去。

---

## 4. SchemaRenderer 诊断半边 —— 只评估,零代码

按派单要求,对「`schema.props` 静默展开该不该给诊断」按 #3972 / #3987 家族先例单列评估。**本 PR 未改 `packages/**` 一行。**

### 现状(实测)

`SchemaRenderer.tsx` 的 `React.createElement` 调用里,`props` 既没被 strip 也没被并进节点:它落在 `componentProps`(metadata 解构的剩余项)里被 spread 一次,内容再被 `...(evaluatedSchema.props || {})` spread 一次。两个后果都量到了:

- 内容被读不到 —— 上面 2.1 的整张表;
- 信封原样落进 DOM —— `props="[object Object]"`。同一路径上还有 `columns="[object Object]"`、`gap="4"`、`bind="users"`、`label="Delete Selected"`,即**任何**未被 metadata 解构 strip 的节点键都会变成非法 DOM 属性。所以这不是 `props` 一个键的问题,是「未知节点键 → DOM 属性」这条通路的问题。

另一条实测:`isValidSchema` 对带信封和不带信封的同一棵树**都返回 `true`**。现有校验面完全看不见这个形态。

### 三个方向与代价

1. **发布期(authoring / publish)拒绝** —— 在 spec / Zod 层把 `props` 判成非法(`element:*` 命名空间除外)。
   - 长期最优,和 AGENTS.md #0.1「在生产者侧修、让它在发布期被拒」完全同向;也最能让 AI 写出的元数据"写错就当场报错"而不是"上线后一片空白"。
   - 代价:`props` 今天**声明在** `UIComponent` 里(AGENTS.md §4、protocol.md 的 interface 块都写着 `props?: Record< string, any >`),`element:*` 还真的读它。所以这不是加一条校验,是**先把契约裁清楚**:`props` 到底是"全局合法但多数渲染器不读",还是"仅 `element:*` 合法"。属契约收紧,应走 ADR / 维护者裁决。
2. **运行期 DEV 诊断** —— `__DEV__` 下,若节点带 `props` 且解析到的 renderer 不在 `element:*`,`console.warn` 指名道姓;可复用已有的 `data-obj-schema-invalid` 标记通路。
   - 成本最低、不改契约、对既有元数据零破坏,能立刻把"空白框"变成一条可搜索的信息。
   - 代价:只在开发期可见,产线照旧静默;且属"渲染器替生产者报错",治标。
3. **停止把未知节点键 spread 进 DOM** —— 收窄 `componentProps`,只转发白名单/已声明键。
   - 能一并消掉 `props="[object Object]"` / `columns="[object Object]"` 这类非法属性。
   - 代价**最高且有真实回归风险**:该转发面是**被声明的功能**(`packages/react/README.md` 记录了 `SchemaRenderer schema={...} onSubmit={...}` 这种用法,form renderer 就消费它;#4548 的注释把"不要关闭这个面"写得很明确)。收窄它等于改一条公开契约,先例是 `dataSource` 那次(objectstack#5576:strip 一个键就把组件搞坏了)。

### 门禁联动

- `check:skills-paths` 只校验反引号里的**仓内路径**是否存在,不看 schema 键;
- `check:doc-links` 判的是 markdown 链接;
- catalog 侧的 `catalog-gallery-render.test.tsx`(#4616)会对 OBJUI-001 变红,但它只看 catalog,看不到教学面 prose;
- 现有 `isValidSchema` 如上所述对两态都放行。

即:**今天没有任何门会因为一个 `props` 信封变红**,无论它在 catalog、在 prose、还是在产线元数据里。方向 1 会顺带把这条补上(发布期拒绝天然是门);方向 2 不会。

**倾向:2 立刻做(廉价、零契约风险、把静默变成信号),1 作为目标态走裁决,3 不建议单独做。** 拿不准的部分已按派单要求回传,不在本 PR 里实施。

---

## 5. 防回潮:评估结论是**现在不建门**

派单要求评估「skills 面有没有低成本机械断言位置(如 `check-skills-paths` 同族的键拼写扫描)」,并明令不擅自建门。结论:**低成本且够精确的门在这里不存在**,理由是量出来的:

1. **朴素形态(禁止 md 里出现 `props` 键)当场就是错的。** `element:*` 按设计必须用信封 —— 一刀切的门会变成一条新的教错,正是 #5009 / #4984 家族反复警告的"规则替 schema 越权"。
2. **正确形态要求类型感知**(只在同级 `type` 不属 `element:` 命名空间时报警),这需要把 ```json fence 当 JSON 解析。实测本仓的教学 fence 大量**解析不了**:`"columns": [...]` 这种占位符、`// ❌ ...` 行内注释(protocol.md、grid.mdx、schema-expressions.md 都有)。
3. **本 PR 新写的正确文案里,`props` 是故意出现的** —— protocol.md 的 ❌ WRONG 块、schema-expressions.md 的三路对照块。任何键存在性扫描都会对着"教这条规则的那段文字"变红,只能靠 ❌ 上下文启发式豁免 —— 这类脆弱启发式恰恰是本仓门禁一贯回避的。

**真正该建的是另一样东西:让教学面的 fence 可执行。** 本仓已有抽取机制的先例(`scripts/extract-mdx-demos.mjs` 把 MDX 里的 schema 抽成 catalog JSON),catalog 侧也已有"渲染不出来就红"的棘轮(#4616)。缺的是把 `skills/` + `content/docs/` 的 fence 接进同一条通路 —— 那是结构性缺口的正解(#4001 → #4011 → #4786 是同一个缺口的第三次复发:catalog 上了棘轮,产出 catalog 的教学源没有)。工作量不小,不该顺手塞进本 PR,已在报告里回传给 PM 定夺。

---

## 6. 验证

- `pnpm turbo run type-check --concurrency=2` —— **81/81 通过**(35 cached / 46 cache miss 真跑),`Time: 3m32.627s`。
- `pnpm --workspace-concurrency=2 --filter @object-ui/site type-check` —— **通过**(`fumadocs-mdx && next typegen && tsc --noEmit`,`Types generated successfully`)。**单独跑的原因**:`@object-ui/site` 的 type-check 任务并未出现在上面那次 turbo 运行的日志里(grep `site:type-check` 零命中),所以没有把它算进那 81 个,而是显式跑了一遍。
- `node scripts/check-control-bytes.mjs` —— OK(4307 文件);另按纪律对 13 个改动文件自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,**零命中**(本 PR 正文与文档都提到了控制字符/转义,按纪律多扫一道)。
- `node scripts/check-skills-paths.mjs` —— OK(88/89 路径解析,1 baselined),覆盖 protocol.md / page-builder.md 新增的 `packages/react/src/SchemaRenderer.tsx`、`packages/components/src/renderers/basic/elements.tsx` 引用。
- `node scripts/check-doc-links.mjs` —— OK(13 个 scan root)。
- `node scripts/check-i18n-call-site-keys.mjs` —— OK(动了 `i18n.md`,顺带跑)。
- `node scripts/check-changeset-presence.mjs` —— **实测判定不欠 changeset**:`13 file(s) changed, 0 of them under the src/ of a package the release covers` → `No source of a released package changed in this range, so no changeset is owed`。(`apps/site` 在 `.changeset/config.json` 的 `ignore` 列表里。)
- **未跑 `pnpm test`**:本 PR 零改 `packages/**`,`apps/site` 既无 `test` 脚本也无测试文件(与 PR #4785 的实测一致),没有受影响的测试文件可跑 —— 不伪造该项。探针 5 批共 40 余条断言全部跑通(`Test Files 1 passed` × 5),但探针按派单要求已删除、不入仓。

---

## 7. 超范围发现(均已立单,本 PR 未修)

| 单号 | 一句话 |
|---|---|
| #4795 | 除 `content` 外没有任何文本键既被求值又被读回 —— `statistic.value` / `card.title` / `button.label` 无法绑定表达式(引擎侧的洞,本单教学面改写的根因) |
| #4796 | `content/docs/fields/{grid,location}.mdx` 教的 `plugin:grid` / `plugin:map` 全仓未注册,照抄即 OBJUI-001 红框(与本 PR 已修的 `stats-card` 同类,落在不同文件) |
| #4797 | `list` 从不渲染 `children`,且全仓不存在 `item` / `index` 迭代作用域 —— schema-expressions.md「Iteration scopes」整节是空头支票(本 PR 刻意保留那一处信封的原因) |
| #4798 | auth-permissions.md 的 `"hidden": "${!canDeleteContacts}"` 裸根不解析,按钮无条件消失、与权限位取值无关(实测 true/false 两态都空) |
| #4799 | `element:*` 的规范拼写 `properties` 不参与表达式求值,而被注释称作 legacy alias 的 `props` 参与 —— 写规范形态反而丢表达式 |

边界遵守情况:未碰 `examples/schema-catalog`、未碰 PR #4785 刚改的 protocol.md「Rule: Layout Responsiveness」与 mobile.md 段落、未碰 `packages/**`、未碰 `content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_