### PR TITLE
test(config): 删掉 vitest alias 表的 4 条死条目,并钉住「每个 alias 目标必须存在」

### DIFF
--- a/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
+++ b/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3944 — every `resolve.alias` target in the root `vitest.config.mts`
+ * must exist on disk.
+ *
+ * Four entries pointed at directories that are not in the workspace:
+ * `@object-ui/engine` -> `packages/engine/src`, `@object-ui/renderer` ->
+ * `packages/renderer/src`, `@object-ui/plugin-aggrid` ->
+ * `packages/plugin-aggrid/src`, `@object-ui/ui` -> `packages/ui/src`.
+ * `packages/plugin-aggrid` was published once (the CHANGELOGs still record
+ * `@object-ui/plugin-aggrid@0.4.1`) and then removed; the other three never had
+ * a package at all. Nothing imported any of the four, so nothing ever resolved
+ * through them and no test went red — the entries were inert.
+ *
+ * Why that still earns a mechanical guard rather than a one-off deletion: this
+ * is the same defect class as objectui#3904 — configuration that *declares* a
+ * capability the dependency graph does not have. There, `@object-ui/layout` sat
+ * in `apps/site`'s `transpilePackages` while being neither a dependency nor an
+ * import, read to every reader as "already wired up", and the Playground kept
+ * painting the red OBJUI-001 panel until someone drove it in a browser (#3787).
+ * A dead entry is worse than a missing one, because it reads as connected. The
+ * guard PR #3942 added there is this file's shape sibling; this is the same
+ * check for the alias table, so entry #44 cannot arrive the same way.
+ *
+ * Read from the SOURCE TEXT, not by importing the config: `vitest.config.mts`
+ * runs `assertCanonicalVitestInvocation()` at module scope and pulls in the
+ * whole Vitest config surface. A unit test that only needs a list of strings
+ * should not boot that (the same reason #3904's guard parses
+ * `apps/site/next.config.mjs` as text).
+ *
+ * Reverse verification (direction predicted before running — plain RED, no
+ * inversion: the alias table is the sole input, and an added bad entry can only
+ * add a finding): add `'@object-ui/ghost-3944'` pointing at
+ * `packages/ghost-3944/src` and the "target directory that exists" case fails
+ * naming that entry, while the two coverage cases stay green (a well-formed
+ * entry is still parsed).
+ *
+ * Deliberately NOT in scope: `tsconfig.json`'s `paths` carries dead entries of
+ * the same shape for three of the four names. That file is outside this issue's
+ * surface and belongs to whoever triages it; this guard reads the alias table
+ * only, and says so rather than half-covering a second file.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const CONFIG_PATH = path.join(repoRoot, 'vitest.config.mts');
+const configSource = fs.readFileSync(CONFIG_PATH, 'utf8');
+
+interface AliasEntry {
+  /** The bare specifier being aliased, e.g. `@object-ui/core`. */
+  specifier: string;
+  /** The repo-relative target as written in the config. */
+  target: string;
+}
+
+/**
+ * The text of the `resolve.alias` object literal, brace-balanced from its
+ * opening `{` so a nested object in a future entry cannot truncate it.
+ */
+function aliasBlock(): string {
+  const header = /alias:\s*\{/.exec(configSource);
+  if (!header) throw new Error('vitest.config.mts has no resolve.alias object');
+
+  const open = header.index + header[0].length - 1;
+  let depth = 0;
+  for (let i = open; i < configSource.length; i += 1) {
+    const ch = configSource[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return configSource.slice(open + 1, i);
+    }
+  }
+  throw new Error('vitest.config.mts: resolve.alias object is never closed');
+}
+
+/** `//` line comments stripped, so they cannot be miscounted as entries. */
+const block = aliasBlock()
+  .split('\n')
+  .filter((line) => !/^\s*\/\//.test(line))
+  .join('\n');
+
+const ENTRY = /(['"])([^'"]+)\1\s*:\s*path\.resolve\(\s*__dirname\s*,\s*(['"])([^'"]+)\3\s*\)/g;
+
+const entries: AliasEntry[] = [...block.matchAll(ENTRY)].map((m) => ({
+  specifier: m[2],
+  target: m[4],
+}));
+
+describe('objectui#3944 — root vitest.config.mts alias table', () => {
+  it('parses a plausible table (a zero-hit parse would make every case below vacuous)', () => {
+    // The failure mode this guards: the config is reformatted, the regex stops
+    // matching, `entries` becomes [] and the existence check passes while
+    // checking nothing — the empty-fixture trap.
+    expect(entries.length).toBeGreaterThanOrEqual(30);
+    expect(entries.map((e) => e.specifier)).toContain('@object-ui/core');
+  });
+
+  it('parses EVERY key in the block, so no entry can dodge the existence check', () => {
+    // Coverage, not style: an entry whose value is written in some other form
+    // (a bare string, a template literal, a helper call) would be skipped by
+    // ENTRY and silently escape. Compare the parsed count against the number of
+    // keys actually present.
+    const keys = [...block.matchAll(/^\s*(['"])([^'"]+)\1\s*:/gm)].map((m) => m[2]);
+
+    expect(
+      keys.filter((key) => !entries.some((e) => e.specifier === key)),
+      'These alias keys are not written as `path.resolve(__dirname, "<relative path>")`, so the ' +
+        'target-exists check below never sees them. Use that form, or teach this test the new one.'
+    ).toEqual([]);
+    expect(entries).toHaveLength(keys.length);
+  });
+
+  it.each(entries)('$specifier resolves to a path that exists ($target)', ({ specifier, target }) => {
+    const abs = path.resolve(repoRoot, target);
+
+    expect(
+      fs.existsSync(abs),
+      `Alias '${specifier}' points at ${target}, which does not exist in the workspace. A dead ` +
+        'alias never fails a test — nothing resolves through it — it just reads as if the package ' +
+        'were wired up (objectui#3944). Drop the entry, or add the package.'
+    ).toBe(true);
+  });
+
+  it('aliases an extension-less target to a directory, not a stray file', () => {
+    // `@object-ui/types/zod` legitimately targets a single .ts file; every other
+    // entry is a package `src/` root. Existence alone would accept a file where
+    // a directory is meant, which resolves for the bare specifier and breaks
+    // every deep import through it.
+    const wrongKind = entries.filter(
+      ({ target }) =>
+        path.extname(target) === '' &&
+        fs.existsSync(path.resolve(repoRoot, target)) &&
+        !fs.statSync(path.resolve(repoRoot, target)).isDirectory()
+    );
+
+    expect(wrongKind.map((e) => e.specifier)).toEqual([]);
+  });
+
+  it('no longer carries the four dead entries', () => {
+    // Named explicitly: the generic check above would also go green if someone
+    // "fixed" it by re-creating empty `packages/<name>/src` directories.
+    const specifiers = entries.map((e) => e.specifier);
+
+    expect(specifiers).not.toContain('@object-ui/engine');
+    expect(specifiers).not.toContain('@object-ui/renderer');
+    expect(specifiers).not.toContain('@object-ui/plugin-aggrid');
+    expect(specifiers).not.toContain('@object-ui/ui');
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -251,8 +251,6 @@ export default defineConfig({
       '@object-ui/types': path.resolve(__dirname, './packages/types/src'),
       '@object-ui/react': path.resolve(__dirname, './packages/react/src'),
       '@object-ui/protocol': path.resolve(__dirname, './packages/core/src'),
-      '@object-ui/engine': path.resolve(__dirname, './packages/engine/src'),
-      '@object-ui/renderer': path.resolve(__dirname, './packages/renderer/src'),
       '@object-ui/components': path.resolve(__dirname, './packages/components/src'),
       '@object-ui/providers': path.resolve(__dirname, './packages/providers/src'),
       '@object-ui/fields': path.resolve(__dirname, './packages/fields/src'),
@@ -263,7 +261,6 @@ export default defineConfig({
       '@object-ui/plugin-list': path.resolve(__dirname, './packages/plugin-list/src'),
       '@object-ui/data-objectstack': path.resolve(__dirname, './packages/data-objectstack/src'),
       '@object-ui/layout': path.resolve(__dirname, './packages/layout/src'),
-      '@object-ui/plugin-aggrid': path.resolve(__dirname, './packages/plugin-aggrid/src'),
       '@object-ui/plugin-calendar': path.resolve(__dirname, './packages/plugin-calendar/src'),
       '@object-ui/plugin-chatbot': path.resolve(__dirname, './packages/plugin-chatbot/src'),
       '@object-ui/plugin-detail': path.resolve(__dirname, './packages/plugin-detail/src'),
@@ -289,7 +286,6 @@ export default defineConfig({
       // rather than depending on how Vite treats a symlinked dependency.
       '@object-ui/test-support': path.resolve(__dirname, './packages/test-support/src'),
       '@': path.resolve(__dirname, './packages/components/src'),
-      '@object-ui/ui': path.resolve(__dirname, './packages/ui/src'),
     },
   },
 });


### PR DESCRIPTION
Fixes #3944

## 背景

根 `vitest.config.mts` 的 `resolve.alias` 表里有 4 条指向不存在目录的死条目。它们从来不会让测试变红 —— 没有任何东西经它们解析 —— 但读起来像是「这些包存在、而且已经接好了」。这正是 #3904 那一类「配置声明了、依赖图里没有」的漂移:`@object-ui/layout` 当初以完全相同的形状让人误判能力已就位,最后靠浏览器实测才发现渲染的是红面板(#3787)。

## 实测核验(不是照抄 issue)

在 `origin/main` `8a9deceea` 上逐条复核:

| 条目 | 行号 | 目标目录 | 精确 specifier 命中数 |
|---|---|---|---|
| `@object-ui/engine` | :254 | `packages/engine/src` 不存在 | 0 |
| `@object-ui/renderer` | :255 | `packages/renderer/src` 不存在 | 0 |
| `@object-ui/plugin-aggrid` | :266 | `packages/plugin-aggrid/src` 不存在 | 0 |
| `@object-ui/ui` | :292 | `packages/ui/src` 不存在 | 0 |

四个目录 `git ls-tree HEAD packages/` 零输出;命中数用带引号的精确名在 `packages/ apps/ examples/` 扫(裸名会被家族名子串命中)。**零命中做了证伪**:同一个扫描器对 `@object-ui/core` 报 551 条、`@object-ui/layout` 报 27 条 —— 所以 0 是真的 0,不是扫描器坏了。

alias 表总数 43 → 39,只删这 4 条。

## 断言落点与理由

新增 `scripts/__tests__/vitest-config-alias-targets-3944.test.ts`。

- **放 `scripts/__tests__/`**:仓内已有一整个 config-truth 测试家族在这里(`turbo-*-inputs.test.ts`、`check-type-check-coverage.test.ts`、`site-playground-layout-registration-3904.test.ts`),按 §9 的 `unit` project(`scripts/**/*.test.ts`,node env)跑,零额外接线。文件名沿用家族的 `主题-issue号` 命名。
- **读源码文本、不 import 配置**:`vitest.config.mts` 在模块作用域跑 `assertCanonicalVitestInvocation()` 并拉起整个 Vitest 配置面,一个只需要一串字符串的 unit 测试不该把它启起来 —— PR #3942 给 `apps/site/next.config.mjs` 的守卫出于同样理由也是文本解析。这一条是那条守卫的 alias 表姊妹版。
- 三层断言:①每个 alias 目标必须在磁盘上存在;②**block 里每个 key 都必须被解析到**(否则将来有人换一种写法就能绕开 ①);③四个死名按名字钉死(只有 ① 的话,重建四个空目录也能变绿)。另加一条:无扩展名的目标必须是目录而不是散文件。①之前先有一条「解析到的条目数不少于 30 且含 `@object-ui/core`」—— 防的是配置重排后正则失配、`entries` 变空表、断言在空集合上假绿(empty-fixture 陷阱)。

## 反向验证(先预判后跑)

预判:往 alias 表临时加一条 `@object-ui/ghost-3944` 指向 `packages/ghost-3944/src`,存在性用例**直接变红并报出该条目名**;两条覆盖率用例保持绿(格式良好的条目照样被解析到);用例总数 43 → 44。**无反转**:alias 表是唯一输入,加一条坏条目只可能多出一个 finding。

实跑一致:

```
x '@object-ui/ghost-3944' resolves to a path that exists ('./packages/ghost-3944/src')
  Alias '@object-ui/ghost-3944' points at ./packages/ghost-3944/src, which does not
  exist in the workspace. ...
Tests  1 failed | 43 passed (44)
```

已还原(`git checkout` 回本分支的 commit,`grep ghost-3944` 零命中),假条目未提交。

## 测试与门禁

| 项 | 结果 |
|---|---|
| 新断言 | `Test Files 1 passed (1)` / `Tests 43 passed (43)` |
| `scripts/` + `packages/layout/` | `Test Files 56 passed (56)` / `Tests 1165 passed (1165)` |
| `packages/fields/`(真实经 alias 解析的消费方) | `Test Files 95 passed (95)` / `Tests 1527 passed (1527)` |
| `turbo run type-check --concurrency=2`(仓根全量) | `81 successful, 81 total` |
| `check-control-bytes.mjs` | OK(4311 个文件);改动路径另跑了一遍控制字符自扫,零命中 |
| changeset 三门(presence / no-major / fixed) | 全绿 |
| eslint(改动路径) | 0 error |

改的是共享测试基建,所以特意跑了 `packages/fields` 整包 —— 它有 127 处经 `@object-ui/*` 解析的 import,全绿即证明删条目没伤到任何真实消费(本来也不可能:死 alias 只会解析失败,不会解析成别的东西)。

## 关于 changeset

**本 PR 不带 changeset**,依据是仓例而非省事:`check-changeset-presence.mjs` 判定「没有任何发版包的 `src/` 变动,不欠 changeset」(退出 0)。近期同形状的 merged 提交同样没有 changeset —— `34a3badc9`(改根 `vitest.config.mts` + 新增 `scripts/__tests__` 守卫,#3437)与 `4f66d835c`(#3198);相对地 `031bde732`(#4499)带了 changeset,因为它动了 `packages/*/src` 与发版包的 `package.json`。本 PR 属于前者。

## 范围外(未在本 PR 处理)

`tsconfig.json` 的 `paths` 里有同一形状的死条目 —— `@object-ui/engine`、`@object-ui/ui`、`@object-ui/renderer` 各带 `/*` 通配共 6 行,目标是同样不存在的三个目录(`plugin-aggrid` 不在其中)。超出本 issue 的面,已随实施报告回传给 PM 分诊,本 PR 一字未动该文件。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_