### PR TITLE
test(plugin-detail): record:alert 的 `visible` 判定改由真实谓词管道裁决 (#3941)

### DIFF
--- a/.changeset/record-alert-predicate-pipeline-pins.md
+++ b/.changeset/record-alert-predicate-pipeline-pins.md
@@ -1,0 +1,20 @@
+---
+---
+
+Test-only: `record:alert`'s own suite stubbed BOTH ends of the predicate pipeline —
+an identity `toPredicateInput` that only recorded its argument, plus a `useCondition`
+pinned to a constant — so the banner's `visible` verdict was unobservable from the one
+file that covers this renderer (objectui#3941). The only assertable fact left was "the
+renderer handed `props.visible` to something"; any normalization or evaluation defect
+stayed green, which is where objectui#3871's defect (a `${…}`-spelled predicate
+double-wrapped, unparseable, and — on this fail-soft surface — resolved to a constant
+`true`, i.e. a conditionally-authored banner permanently visible) sat unseen.
+
+The data-layer doubles (record context, the metadata fetch behind the CTA, the action
+dispatch) stay; the predicate entry is now the shipped one (real `toPredicateInput` +
+`useCondition`, with the real `PredicateScopeProvider` for the ambient-scope case), and
+the verdict is pinned for every authorable shape in both polarities: `false` hides,
+`true` shows, `''` is not a declared gate, and a bare expression / a `${…}` template /
+a `{ dialect: 'cel' }` envelope each keep their own verdict when the record makes them
+hold and when it makes them fail. Restores the regression detector for this surface;
+no published behaviour changes.

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
@@ -311,9 +311,9 @@ describe('RecordAlertRenderer', () => {
  *   1. "Is a gate declared" is asked of the NORMALIZED value, not of the
  *      authored one, so `visible: false` is a declared gate (a boolean survives
  *      normalization) while `visible: ''` is not (it normalizes to `undefined`).
- *      This is the objectui#3492 / #3850 / #3862 口径, and asking it of the
- *      normalized value is what keeps `false` from being read as "no gate" the
- *      way a truthiness test would.
+ *      This is the reading the objectui#3492 / #3850 / #3862 family settled on,
+ *      and asking it of the normalized value is what keeps `false` from being
+ *      read as "no gate" the way a truthiness test would.
  *   2. This surface is fail-SOFT — no `throwOnError` — so a predicate that
  *      cannot be evaluated resolves to SHOWN, not hidden. That sets the
  *      direction of the objectui#3871 case below, and it is the opposite of
@@ -326,9 +326,9 @@ describe('RecordAlertRenderer', () => {
  * "should be hidden" assertion on its own, and "always shown" satisfies every
  * "should be shown" one. Where a hidden verdict is asserted, the SAME record
  * and the SAME schema are also mounted in the shown direction — the renderer
- * has three other `return null` paths (dismissed, empty record, and the
- * predicate gate itself), so "nothing rendered" needs the paired mount to mean
- * "the gate said no".
+ * has two other `return null` paths besides this gate (dismissed, and an empty
+ * record), so "nothing rendered" needs the paired mount to mean "the gate said
+ * no".
  */
 const UNVERIFIED = { id: 'rec_1', name: 'Acme', email_verified: false };
 const VERIFIED = { id: 'rec_1', name: 'Acme', email_verified: true };

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
@@ -12,9 +12,12 @@
  *
  * The renderer relies on several `@object-ui/react` hooks that normally
  * require a live provider tree (RecordContext, ActionProvider,
- * MetadataProvider). We stub them surgically so the tests stay focused
- * on renderer behaviour, not on provider wiring — the same approach
+ * MetadataProvider). We stub the DATA layer surgically so the tests stay
+ * focused on renderer behaviour, not on provider wiring — the same approach
  * the live render in `RecordDetailView` relies on at runtime.
+ *
+ * The PREDICATE entry is deliberately NOT stubbed (objectui#3941) — see the
+ * mock factory below.
  */
 
 import * as React from 'react';
@@ -26,25 +29,44 @@ const mockExecuteAction = vi.fn(async () => ({ success: true }));
 const stub = {
   recordCtx: undefined as any,
   metadataItem: undefined as any,
-  predicate: { input: undefined as any, passes: true },
 };
 
-vi.mock('@object-ui/react', () => ({
-  useRecordContext: () => stub.recordCtx,
-  useMetadataItem: (_type: string, _name: string | null) => ({ item: stub.metadataItem }),
-  useCondition: (_input: unknown, _scope: unknown) => stub.predicate.passes,
-  toPredicateInput: (visible: unknown) => {
-    stub.predicate.input = visible;
-    return visible;
-  },
-  useActionEngine: (_opts: unknown) => ({
-    executeAction: mockExecuteAction,
-    getActionsForLocation: () => [],
-    getBulkActions: () => [],
-    handleShortcut: async () => null,
-    engine: {} as any,
-  }),
-}));
+// Only the DATA layer is doubled here — record context, the metadata fetch
+// behind the CTA, and the action dispatch. The predicate entry
+// (`toPredicateInput` / `useCondition`) and the ambient
+// `PredicateScopeProvider` are the REAL ones (objectui#3941).
+//
+// They used to be doubled too: an IDENTITY `toPredicateInput` that only
+// recorded its argument, plus a `useCondition` pinned to a constant. Between
+// them the banner's whole `visible` verdict was unobservable from its own
+// suite — the only assertable fact left was "the renderer handed `props.visible`
+// to something", so any normalization or evaluation defect stayed green here.
+// That is the objectstack#4984 family (a fixture keeping a broken pipeline
+// green), and this file is where objectui#3871's defect actually lived: the
+// documented `${…}` spelling was double-wrapped, the reparse failed, this
+// renderer's fail-SOFT `useCondition` handed back the original non-empty
+// string, and `Boolean(…)` made a conditionally-authored banner permanently
+// visible. `DeclaredActionsBar.test.tsx:22-34` wrote the same lesson down after
+// objectui#3835; a re-spelled stub cannot fix it, because a stub is a second
+// copy of exactly the semantics under test. `@object-ui/react`'s barrel is
+// cheap for the light `dom` project (the sibling
+// `record-quick-actions.template-predicate.test.tsx` imports it unmocked), so
+// the verdicts below are judged by the shipped pipeline instead.
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useRecordContext: () => stub.recordCtx,
+    useMetadataItem: (_type: string, _name: string | null) => ({ item: stub.metadataItem }),
+    useActionEngine: (_opts: unknown) => ({
+      executeAction: mockExecuteAction,
+      getActionsForLocation: () => [],
+      getBulkActions: () => [],
+      handleShortcut: async () => null,
+      engine: {} as any,
+    }),
+  };
+});
 
 vi.mock('@object-ui/components', () => ({
   Alert: ({ children, className, role, ...rest }: any) => (
@@ -66,6 +88,10 @@ vi.mock('@object-ui/components', () => ({
 }));
 
 import { RecordAlertRenderer } from '../record-alert';
+// The real provider — the `@object-ui/react` double above spreads `actual`, so
+// the ambient predicate scope pinned at the bottom of this file is the shipped
+// one, not a stand-in for it.
+import { PredicateScopeProvider } from '@object-ui/react';
 
 const RECORD_DEFAULTS = {
   recordCtx: {
@@ -90,7 +116,6 @@ beforeEach(() => {
   mockExecuteAction.mockClear();
   stub.recordCtx = RECORD_DEFAULTS.recordCtx;
   stub.metadataItem = RECORD_DEFAULTS.metadataItem;
-  stub.predicate = { input: undefined, passes: true };
   // happy-dom doesn't always ship a working localStorage; install a
   // minimal Storage shim so the renderer's persistence path is
   // exercised the same way as in the browser.
@@ -198,17 +223,8 @@ describe('RecordAlertRenderer', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('hides when the visibility predicate evaluates to false', () => {
-    stub.predicate = { input: 'record.email_verified == false', passes: false };
-    const { container } = render(
-      <RecordAlertRenderer
-        schema={{ properties: { title: 'X', visible: 'record.email_verified == false' } }}
-      />,
-    );
-    expect(container.firstChild).toBeNull();
-    expect(stub.predicate.input).toBe('record.email_verified == false');
-  });
-
+  // The `visible` VERDICT — every shape, both polarities — is pinned in its own
+  // describe at the bottom of this file, against the real predicate pipeline.
   it('renders unconditionally when no `visible` predicate is supplied', () => {
     render(<RecordAlertRenderer schema={{ properties: { title: 'Always visible' } }} />);
     expect(screen.getByTestId('alert')).toBeTruthy();
@@ -277,5 +293,153 @@ describe('RecordAlertRenderer', () => {
     render(<RecordAlertRenderer schema={{ severity: 'success', title: 'Saved' } as any} />);
     expect(screen.getByTestId('alert-title').textContent).toBe('Saved');
     expect(screen.getByTestId('alert-icon').getAttribute('data-name')).toBe('CheckCircle2');
+  });
+});
+
+/**
+ * objectui#3941 — the `visible` VERDICT on `record:alert`, judged by the
+ * shipped pipeline (`toPredicateInput` -> `useCondition`, both real).
+ *
+ * What the renderer actually asks (`record-alert.tsx:140-141` / `:193`):
+ *
+ *   const predicateInput = toPredicateInput(props.visible);
+ *   const passesPredicate = useCondition(predicateInput, { record });
+ *   if (predicateInput !== undefined && !passesPredicate) return null;
+ *
+ * Two facts about that shape drive every case below:
+ *
+ *   1. "Is a gate declared" is asked of the NORMALIZED value, not of the
+ *      authored one, so `visible: false` is a declared gate (a boolean survives
+ *      normalization) while `visible: ''` is not (it normalizes to `undefined`).
+ *      This is the objectui#3492 / #3850 / #3862 口径, and asking it of the
+ *      normalized value is what keeps `false` from being read as "no gate" the
+ *      way a truthiness test would.
+ *   2. This surface is fail-SOFT — no `throwOnError` — so a predicate that
+ *      cannot be evaluated resolves to SHOWN, not hidden. That sets the
+ *      direction of the objectui#3871 case below, and it is the opposite of
+ *      the fail-CLOSED direction pinned for the same spelling on
+ *      `record-quick-actions` (`record-quick-actions.template-predicate.test.tsx`,
+ *      where the engine hid the action instead).
+ *
+ * Both polarities are pinned for every expression shape. A single-polarity pin
+ * cannot tell a verdict from a constant: "always hidden" satisfies every
+ * "should be hidden" assertion on its own, and "always shown" satisfies every
+ * "should be shown" one. Where a hidden verdict is asserted, the SAME record
+ * and the SAME schema are also mounted in the shown direction — the renderer
+ * has three other `return null` paths (dismissed, empty record, and the
+ * predicate gate itself), so "nothing rendered" needs the paired mount to mean
+ * "the gate said no".
+ */
+const UNVERIFIED = { id: 'rec_1', name: 'Acme', email_verified: false };
+const VERIFIED = { id: 'rec_1', name: 'Acme', email_verified: true };
+const BANNER_TITLE = 'Verify your email';
+
+function mountAlert(visible: unknown, record: Record<string, unknown> = UNVERIFIED) {
+  stub.recordCtx = { data: record, objectName: 'sys_user', recordId: 'rec_1' };
+  return render(
+    <RecordAlertRenderer schema={{ properties: { title: BANNER_TITLE, visible } }} />,
+  );
+}
+
+/** Mount inside a real ambient predicate scope (what a host shell feeds). */
+function mountAlertInScope(visible: unknown, scope: Record<string, unknown>) {
+  stub.recordCtx = { data: UNVERIFIED, objectName: 'sys_user', recordId: 'rec_1' };
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <RecordAlertRenderer schema={{ properties: { title: BANNER_TITLE, visible } }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+const bannerShown = () => screen.queryByTestId('alert') !== null;
+
+describe('record:alert — the `visible` verdict, real predicate pipeline (objectui#3941)', () => {
+  it('visible:false hides the banner', () => {
+    // The most explicit "never show this" an author can write. Asked of the
+    // AUTHORED value by a truthiness test, `false` reads as "no gate declared"
+    // and the banner renders for everyone — the objectui#3492 family defect.
+    expect(mountAlert(false).container.firstChild).toBeNull();
+    cleanup();
+    // Same record, same schema, predicate REMOVED → the banner renders. Without
+    // this half, "hidden" above could equally mean the render never happened.
+    mountAlert(undefined);
+    expect(bannerShown()).toBe(true);
+  });
+
+  it('visible:true renders the banner', () => {
+    mountAlert(true);
+    expect(bannerShown()).toBe(true);
+  });
+
+  it('an empty-string `visible` is not a declared gate — the banner renders', () => {
+    // Semantics documentation, not a mutation detector: `toPredicateInput('')`
+    // is `undefined`, so the gate is skipped; and even if the gate were widened
+    // to ask the AUTHORED value, `evaluateCondition('')` is "no condition →
+    // true". `''` is shown on both sides of that change, so a reader should not
+    // read this passing as proof the `!== undefined` limb is exercised — the
+    // `false` case above is what exercises it.
+    mountAlert('');
+    expect(bannerShown()).toBe(true);
+  });
+
+  it('a bare-expression `visible` keeps its verdict — holds shows, fails hides', () => {
+    const PRED = 'record.email_verified == false';
+    mountAlert(PRED, UNVERIFIED);
+    expect(bannerShown()).toBe(true);
+    cleanup();
+    mountAlert(PRED, VERIFIED);
+    expect(bannerShown()).toBe(false);
+  });
+
+  it('a `${…}`-spelled `visible` keeps its verdict — holds shows, fails hides (objectui#3871)', () => {
+    // `${…}` is a spelling this repo documents (AGENTS.md §4) and one of the
+    // shapes `EvaluatorPredicateInput` lists as a normalized OUTPUT, so the
+    // normalizer must leave it alone. While it did not (objectui#3871), the
+    // double wrap `'${${…}}'` missed the single-template fast path, the global
+    // replace could not parse `'${x'`, and this fail-SOFT caller got the
+    // original non-empty string back — `Boolean(…)` a constant `true`.
+    //
+    // Direction, predicted before running: the FAILING half below is the
+    // detector (it was shown when it should have been hidden — a banner the
+    // author gated stayed on screen for everyone); the HOLDING half is green
+    // either way, because a constant `true` and a correct `true` look the same.
+    // Both are kept: without the holding half, "hide unconditionally" would
+    // satisfy the detector.
+    const PRED = '${record.email_verified == false}';
+    mountAlert(PRED, UNVERIFIED);
+    expect(bannerShown()).toBe(true);
+    cleanup();
+    mountAlert(PRED, VERIFIED);
+    expect(bannerShown()).toBe(false);
+  });
+
+  it('a `{ dialect: cel }` envelope keeps its verdict — holds shows, fails hides', () => {
+    // The envelope must survive normalization: only while it is still
+    // `{ dialect: 'cel' }` does `evaluateCondition` route to the canonical
+    // `@objectstack/formula` engine — the one the SERVER enforces with.
+    // Collapsed to `${source}` it falls to the legacy JS path, whose verdicts
+    // differ (#2661 / #3314), and this banner would then disagree with the
+    // action buttons it is authored next to.
+    const PRED = { dialect: 'cel', source: 'record.email_verified == false' };
+    mountAlert(PRED, UNVERIFIED);
+    expect(bannerShown()).toBe(true);
+    cleanup();
+    mountAlert(PRED, VERIFIED);
+    expect(bannerShown()).toBe(false);
+  });
+
+  it('the ambient predicate scope reaches the banner — a `features.*` gate resolves both ways', () => {
+    // The renderer passes only `{ record }`; everything else the header
+    // docblock promises (`features`, `user`, `app`, …) arrives through the
+    // ambient `PredicateScopeProvider` that host shells mount, merged UNDER the
+    // local context by `useCondition`. Stubbing the predicate entry hid this
+    // path entirely — a deployment-level gate could stop resolving with the
+    // suite still green.
+    const PRED = 'features.email_verification_banner == true';
+    mountAlertInScope(PRED, { features: { email_verification_banner: true } });
+    expect(bannerShown()).toBe(true);
+    cleanup();
+    mountAlertInScope(PRED, { features: { email_verification_banner: false } });
+    expect(bannerShown()).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #3941

## 问题

`packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx` 把 `@object-ui/react` 整体替成替身,谓词管道的**两端一起**被替掉:

- `toPredicateInput` 是恒等函数(只把入参记进 `stub.predicate.input`),归一根本不发生;
- `useCondition` 是常量 `stub.predicate.passes`,求值也不发生。

于是这一面唯一可断言的事实只剩「渲染器有没有把 `props.visible` 传下去」,而「这个 `visible` 会得到什么 verdict」完全不可观测 —— 任意归一器缺陷、任意求值缺陷,在本文件里都是绿的。objectui#3871 的缺陷正是藏在这里:`${…}` 拼法被二次包裹、重解析失败,而本渲染器是 fail-soft(不传 `throwOnError`),原样退回的非空串经 `Boolean(…)` 恒为 `true` —— 作者写了 `visible` 想按条件收起的横幅**永远显示**。生产端已由 #3871 的 PR 修好,**本 PR 不动任何生产文件**。

## 改法:stub -> 真管道 对照

| 面 | 改前 | 改后 |
|---|---|---|
| `toPredicateInput` | 恒等替身 | 真实现(`@object-ui/core` 的唯一归一器) |
| `useCondition` | 常量 | 真实现(fail-soft,与生产调用一致) |
| `PredicateScopeProvider` | 不存在 | 真 provider,喂 ambient scope |
| `useRecordContext` / `useMetadataItem` / `useActionEngine` | 替身 | **保持替身**(数据层) |
| `@object-ui/components` | 替身 | **保持替身** |

`vi.mock` 由「整体工厂」改为 `importOriginal` 局部替换,与同仓先例 `DeclaredActionsBar.test.tsx:22-34`(objectui#3835 的教训)一致。同包的 `record-quick-actions.template-predicate.test.tsx` 干脆不 mock 直接 import barrel,印证 `@object-ui/react` 对轻量 `dom` project 是便宜的:本文件实测 import 阶段 2.1s,整包 81 files / 788 tests 全绿、耗时无异常。

## 新增 verdict 钉子(每种可授权形态,两个极性)

判定读的是 `record-alert.tsx:140-141` / `:193` 的原样语义 —— 「是否声明了门」问的是**归一后**的值,所以 `false` 是已声明的门、`''` 不是。

| `visible` | 记录 | 期望 |
|---|---|---|
| `false` | — | 隐藏(配一个「同记录同 schema、去掉谓词」的对照,证明不是别的 `return null` 路径) |
| `true` | — | 显示 |
| `''` | — | 显示(未声明门;注释里写明它在本面**不是**变异探测器,是语义文档) |
| `record.email_verified == false` | 未验证 / 已验证 | 显示 / 隐藏 |
| `${record.email_verified == false}` | 未验证 / 已验证 | 显示 / 隐藏(objectui#3871 的探测器) |
| `{ dialect: 'cel', source: … }` | 未验证 / 已验证 | 显示 / 隐藏(信封必须活过归一,否则落回 legacy JS 引擎,#2661 / #3314) |
| `features.email_verification_banner == true`(ambient scope) | 开 / 关 | 显示 / 隐藏 |

两个极性都钉是必需的:单极性分不清「verdict」与「常量」——「永远隐藏」自己就能满足所有「应隐藏」断言,反之亦然。

## 反向验证(先预判、后实测;两处变异均已还原,未提交)

**变异 A(派发指定):** `record-alert.tsx` 的 `predicateInput` 恒为 `undefined`(渲染器不再读 `props.visible`)。
预判:门永不触发 -> 恒显示 -> `visible:false` 与四个表达式用例的「应隐藏」那一半红,`true` / `''`(都期望显示)保持绿 == **5 红**。
实测:`Tests  5 failed | 15 passed (20)` —— 红的正是 `visible:false` / bare 表达式 / `${…}` / cel 信封 / ambient scope 五条,失败行全部落在 `toBe(false)` 那一半。**与预判逐条一致。**

**变异 B(还原 objectui#3871 本身):** `packages/core/src/evaluator/predicateInput.ts` 的 `wrapIfBare` 改回无条件包裹。
预判:只有已带模板语法的字符串被二次包裹;布尔短路、`''`、bare 表达式(包一次,与现状同)、cel 信封(在包裹之前就 return)全都不受影响 -> **恰好 1 红**,且只红 `${…}` 用例的「应隐藏」那一半(fail-soft 退回原串 -> 恒 `true` -> 该藏没藏);它的「应显示」那一半恒真恒绿,所以两半都保留。
实测:`Tests  1 failed | 19 passed (20)`,失败点 `record-alert.test.tsx:413`,正是 `${…}` 用例的 `toBe(false)`。**与预判一致 —— 新钉子确实抓得住当初藏在本文件里的那个真缺陷。**

还原后复跑:`Tests  20 passed (20)`,`git status` 干净。

## 验证

- 改前基线(现行 suite):`Tests  14 passed (14)`
- 改后单文件:`Tests  20 passed (20)`
- 整包 `packages/plugin-detail/`:`Test Files  81 passed (81)` / `Tests  788 passed (788)`
- 仓根 `turbo run type-check --concurrency=2`:`81 successful, 81 total`
- `node scripts/check-control-bytes.mjs` OK;改动路径 eslint 0 error;changeset presence / fixed / no-major 三门通过

## 关于 changeset 的一处说明(请复核)

派发单写的是 `@object-ui/plugin-detail: patch`,本 PR 实际写的是**空 frontmatter**(显式声明「不发版」)。理由:本改动纯测试面、无任何已发布行为变化,而 AGENTS.md「改完代码提交时」那条把空 frontmatter 定为「只动测试」的一等合法写法,仓内已有 14 个同类先例(如 `.changeset/metadata-admin-inspector-client-doubles.md`、`.changeset/paginated-result-vacuous-block-4712.md`);写 `patch` 会让 fixed 组 39 个包为一次测试改动整体起版。若维护者/PM 仍要 `patch`,改一行即可。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_