### PR TITLE
docs(layout): app-shell.mdx 停止承诺 AppShell 并不渲染的 sidebar toggle (#3946);删 AppShell 的 dead Sidebar import (#3947)

### DIFF
--- a/.changeset/appshell-drop-dead-sidebar-import.md
+++ b/.changeset/appshell-drop-dead-sidebar-import.md
@@ -1,0 +1,8 @@
+---
+'@object-ui/layout': patch
+---
+
+AppShell: drop the unused `Sidebar` import. `AppShell` renders the node the caller passes
+in the `sidebar` prop and never constructs a `Sidebar` itself, so the import was dead
+(tree-shaken out of every bundle) and only suggested otherwise to readers. No runtime
+behaviour changes.

--- a/content/docs/layout/app-shell.mdx
+++ b/content/docs/layout/app-shell.mdx
@@ -48,16 +48,20 @@ interface AppShellProps {
 
 ### Responsive Sidebar
 
-The AppShell includes a responsive sidebar that:
+The AppShell does not build a sidebar of its own: it renders the node you pass in
+`sidebar`, wrapped in a `SidebarProvider`. Pass a `Sidebar`-based node (`SidebarNav`, or
+your own) and you get a sidebar that:
 - Collapses on mobile devices
-- Can be toggled via hamburger menu
+- Can be toggled with the `Cmd/Ctrl + B` keyboard shortcut, or by a toggle button you
+  render yourself — see Collapsible Sidebar below
 - Persists state across page navigations
 - Supports smooth animations
 
 ### Header Bar
 
-The header bar provides:
-- Sidebar toggle button
+The header renders your `navbar` content and nothing else — the AppShell adds no controls
+of its own to it, in particular **no sidebar toggle**. If you want one, render it inside
+`navbar` (see Collapsible Sidebar below). The header itself provides:
 - Custom navbar content area
 - Fixed height: `h-14` (3.5rem / 56px) at every breakpoint — there is no responsive height variant
 - Border bottom separator
@@ -76,7 +80,7 @@ The main content area features:
 
 ```
 ┌─────────────────────────────────────┐
-│     Header (Sidebar Toggle + Nav)  │
+│     Header (your navbar content)    │
 ├──────────┬──────────────────────────┤
 │          │                          │
 │ Sidebar  │   Main Content Area      │
@@ -100,10 +104,22 @@ Control whether sidebar is open by default:
 
 ### Collapsible Sidebar
 
-The sidebar can be toggled via:
-- Hamburger menu button (always visible)
-- Keyboard shortcuts (when implemented)
-- Programmatic control
+The AppShell renders no toggle button of its own. What it does give you is the
+`SidebarProvider` wrapped around both slots, so the sidebar you supply can be toggled via:
+- The `Cmd/Ctrl + B` keyboard shortcut, provided by `SidebarProvider`
+- Programmatic control — `useSidebar().toggleSidebar()` from any component inside the shell
+- A toggle button you render yourself; it belongs in the `navbar` slot:
+
+```plaintext
+import { SidebarTrigger } from '@object-ui/components';
+
+<AppShell
+  navbar={<SidebarTrigger />}
+  sidebar={<SidebarNav items={navItems} />}
+>
+  {/* Your page content */}
+</AppShell>
+```
 
 ## Navbar Content
 
@@ -247,13 +263,12 @@ Combine AppShell with the Page component for complete layouts:
 The AppShell uses Tailwind CSS and Shadcn UI components:
 
 - `SidebarProvider`: Manages sidebar state
-- `SidebarTrigger`: Hamburger menu button
 - `SidebarInset`: Content area wrapper
 
 ## Accessibility
 
 The AppShell includes:
-- Proper ARIA labels for sidebar toggle
+- A keyboard shortcut for toggling the sidebar (`Cmd/Ctrl + B`), from `SidebarProvider`
 - Keyboard navigation support
 - Focus management
 - Screen reader announcements

--- a/packages/layout/src/AppShell.tsx
+++ b/packages/layout/src/AppShell.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import {
   SidebarProvider,
-  SidebarInset,
-  Sidebar
+  SidebarInset
 } from '@object-ui/components';
 import { cn } from '@object-ui/components';
 


### PR DESCRIPTION
Fixes #3946
Fixes #3947

## 为什么一个 PR 装两单

两单是同一个事实的两面:`AppShell` 从不渲染 `SidebarTrigger`,也从不自己构造 `Sidebar` —— 文档那三条声称和源码那行 dead import 是同一个误解的两个载体。#3947 的分诊评论本身也是这么裁的(「the deletion rides the PR that lands that ruling」,#3946 的裁定 PR)。两处改动零耦合、零冲突面(一个 `content/docs`,一个 `packages/layout/src`),分成两个 PR 只会让 reviewer 来回跳两次,所以合成一个,分支沿用 `claude/issue-3946-appshell-docs-toggle`。

## #3946 — 文档对齐实现

按维护者 2026-08-10 的裁定(docs follow implementation)执行,**零产品行为变更**:没有给 `AppShell` 加任何 toggle,`packages/layout/src/AppShell.tsx` 除了删那行 import 一个字符没动。

实况(基线 `8a9deceea` 实测):`AppShell` 的 header 元素唯一子节点是 `{navbar}`,下半区渲染调用方传进来的 `{sidebar}`;`git grep -c SidebarTrigger -- packages/layout/src` 为 0。

### 范围说明:声称载体实测是 6 处,不是 3 处(请复核这一点)

派单和 issue 都写「三处」,那是对 `Sidebar toggle` / `Hamburger` / `SidebarTrigger` 做**大小写敏感**检索的结果。同一页做大小写不敏感的复查,同一条声称还有 3 个载体:

| 位置(基线行号) | 原文 | 是否派单点名 |
|---|---|---|
| `:53` Responsive Sidebar | `- Can be toggled via hamburger menu` | 否(小写 hamburger,漏检) |
| `:60` Header Bar | `- Sidebar toggle button` | **是** |
| `:79` Layout Structure 图 | `Header (Sidebar Toggle + Nav)` | 否(ASCII 图) |
| `:104` Collapsible Sidebar | `- Hamburger menu button (always visible)` | **是** |
| `:250` Styling | `` - `SidebarTrigger`: Hamburger menu button `` | **是** |
| `:256` Accessibility | `- Proper ARIA labels for sidebar toggle` | 否 |

只改点名的 3 处,会让同一页在 `:53` 继续原样承诺 hamburger、`:79` 继续把 toggle 画进 header,并且和我刚改完的 `:104` 正面打架 —— 那不是「窄范围」,是发一个自相矛盾的文档页。所以 6 处一起改,**在此显式披露供 PM 判**;若认为超界,把后 3 处回退成独立卡我没有意见,只是不建议中间态落地。

### 改成了什么(只写代码能验证的事)

- sidebar 内容与 toggle **均由使用者提供**:`AppShell` 只把两个插槽包进 `SidebarProvider`;
- toggle 塞进 `navbar` 插槽,给了一行示例(`navbar` 传 `SidebarTrigger`);
- 替换句只断言实测存在的东西:`SidebarProvider` 自带的 `Cmd/Ctrl + B` 快捷键(`packages/components/src/ui/sidebar.tsx` 的 keydown handler,`SIDEBAR_KEYBOARD_SHORTCUT = "b"` + metaKey/ctrlKey)、`useSidebar().toggleSidebar()` 程控;`SidebarTrigger` 与 `useSidebar` 都确认从 `@object-ui/components` 导出;
- Styling 段删掉 `SidebarTrigger` 一项;
- Accessibility 段把「ARIA labels for sidebar toggle」换成实际存在的键盘快捷键(没有 trigger 就没有那个 label)。

顺带修正:`:79` 那行 ASCII 框比其它行短 1 格,重写该行时一并对齐(38 → 39)。

### 明确没碰的东西

- **#4793 范围**:两处示例的 `label:` / 字符串 `icon:` / 不存在的 `header` prop —— 一个字符没动(改动集里没有任何示例代码块的 diff);
- **#3914 / PR #3945 钉过的数值**:`h-14` 那行与 padding 那两行逐字节未变,可在 diff 里核。

### 文档侧没有钉子可更新(实测,不是推断)

全仓检索:没有任何测试引用 `app-shell.mdx`(唯二命中是 gitignore 的 `apps/site/.source/` 生成物)。把 6 处旧句**原样恢复**后重跑 `doc-version-claims` / `check-doc-links` / `extract-mdx-demos` / `check-control-bytes` 四个测试文件 + `node scripts/check-doc-links.mjs`:**全绿**(4 files / 155 tests passed;Links are valid across 13 scan roots)。所以本 PR 没有钉子要改,`content/docs` 的散文面今天确实无门禁(#3786 家族的已知缺口,#4793 也记了同一点)。这一条如实写在这里,免得下一个人以为改文档有钉子兜底。

按 `doc-version-claims` 的棘轮要求,本次改动**没有**向扫描面新增任何版本字面量。

## #3947 — dead import + lint 为何放行

删掉 `packages/layout/src/AppShell.tsx:5` 的 `Sidebar` 具名导入。它只出现在 import 行,组件渲染的是调用方传进来的 `{sidebar}`;barrel 无副作用,打包本来就 tree-shake 掉,**零运行时变化**。

### 「为什么现有 lint 没拦」的结论(查证,未改任何配置)

两道门都不会红,而且都是**有意为之**的配置,不是漏配:

1. **eslint 规则在跑,但严重度是 `warn`。** `eslint.config.js:45` 是 `'@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]`。实测把 import 加回去再跑:

   ```
   5:3  warning  'Sidebar' is defined but never used  @typescript-eslint/no-unused-vars
   ✖ 2 problems (0 errors, 2 warnings)      exit 0
   ```

   规则**报了**,只是报成 warning。而 `.github/workflows/lint.yml` 明确写了不设 `--max-warnings`(注释里说明理由:仓内 warning 数以千计,主体是 `no-explicit-any` 与被有意降级的 React Compiler 规则,「This gate is about errors」)。于是任何 dead import 在本仓**结构上不可能让 CI 变红**。

2. **type-check 也不会红。** `packages/layout/tsconfig.json` extends 仓根 `tsconfig.json`,而根配置 `tsconfig.json:18` 是 `"noUnusedLocals": false`。实测把 import 加回去跑 `pnpm --filter @object-ui/layout run type-check`:exit 0。

   附带查到一处值得单记的事实:`tsconfig.base.json:14` 反过来设了 `"noUnusedLocals": true`,但 `packages/` 与 `apps/` 下 **38 个** tsconfig 全部 extends 仓根 `tsconfig.json`,**0 个** extends `tsconfig.base.json`(base 只被 `tsconfig.node.json` / `tsconfig.scripts.json` / `tsconfig.react.json` 和一个 example 用到)。也就是说 base 里那条 `true` 对包源码是休眠的。

结论:这类 dead import 会重复发生,是配置的既定后果而非疏忽。**按派单要求本 PR 不改 lint 配置**,该结论另立 observation-class finding 记录,由维护者决定要不要动。

## 反向验证(先预判后跑,两个方向都不是「红」,如实记)

派单模板预设的是「还原修复 → 钉子变红」。本 PR 两半都**不是**这个方向,预判在跑之前就已写下,结果与预判逐条吻合:

- **#3947 还原 dead import**:预判 eslint 多出 1 条 **warning**、errors 仍为 0、exit 仍为 0;type-check 仍绿。实测完全一致(见上)。**这正是本单要查的结论本身** —— 若这里能变红,#3947 一开始就不会存在。
- **#3946 还原 6 处旧句**:预判文档门禁**全绿**(没有钉子覆盖 `content/docs` 散文)。实测全绿。所以本 PR 没有钉子可更新,这一点是被证实的,不是被假设的。

两次还原都是对着已提交的 commit 做 `git checkout 分支名 -- 路径`,未用 `git stash`。

## 验证记录

```
pnpm --workspace-concurrency=2 --filter '@object-ui/layout^...' build        -> Done
pnpm exec vitest run packages/layout/ --maxWorkers=2                          -> 11 files / 139 tests passed
pnpm exec vitest run scripts/ --maxWorkers=2                                  -> 44 files / 983 tests passed
pnpm exec vitest run scripts/ packages/layout/ --maxWorkers=2 (末次)          -> 55 files / 1122 tests passed
pnpm exec turbo run type-check --concurrency=2                                -> 81 successful, 81 total
node scripts/check-doc-links.mjs                                              -> Links are valid across 13 scan roots
node scripts/check-control-bytes.mjs                                          -> OK (4311 tracked text files)
node scripts/check-changeset-{presence,fixed,no-major}.mjs                     -> 三门全绿
pnpm exec eslint packages/layout/src/AppShell.tsx                             -> 0 errors, 1 warning(既有 react-refresh,与本改动无关)
```

changeset:`@object-ui/layout: patch`。presence 门实测口径 —— 它只数发版包的 `src/`:改动 2 个文件时它报「1 of them under the src/ of a package the release covers」,`content/docs` 的 mdx **不计入**;即纯文档那一半自己不会触发 presence 门,本 PR 的 changeset 是为 `AppShell.tsx` 那行删除声明的。

重活全程走 `flock /tmp/os-heavy-verify.lock` + `NODE_OPTIONS=--max-old-space-size=4096`,未起任何 dev 服务。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_