### PR TITLE
fix(react): 删除 form-view bridge 对 spec 已退休 defaultSort/aria 的休眠读 (#3901, #3974)

### DIFF
--- a/.changeset/form-view-retired-key-reads.md
+++ b/.changeset/form-view-retired-key-reads.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/react': patch
+---
+
+SpecBridge's form-view bridge stops reading `defaultSort` and `aria`, two keys spec 17
+retired on the FormView carrier (`retiredKey()` tombstones — authoring either is a parse
+error). Both guards were unreachable for any FormView that passed validation, and both
+ends were measured dead before removal: no form renderer reads either off the node
+(`plugin-form` reads neither, and `SchemaRenderer`'s ARIA injection resolves flat
+`ariaLabel`/`ariaDescribedBy`/`role`, never a nested `aria` object). Behaviour for
+spec-valid metadata is unchanged; a host that fed the exported bridge a raw pre-17
+document no longer gets these two keys copied onto a node slot nothing consumed. The
+LIST view's `aria` pass-through is untouched — that carrier stayed live and is applied by
+`ListView`.

--- a/packages/react/src/spec-bridge/__tests__/FormViewRetiredKeys.test.ts
+++ b/packages/react/src/spec-bridge/__tests__/FormViewRetiredKeys.test.ts
@@ -1,0 +1,119 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Form-view bridge — retired keys stay unread (objectui#3901 / #3974).
+ *
+ * The bridge used to end with two copies that could never fire:
+ *
+ *   if (spec.defaultSort) node.defaultSort = spec.defaultSort;   // :188
+ *   if (spec.aria) node.aria = spec.aria;                        // :193
+ *
+ * Spec 17 retired both keys on the FORM carrier (`retiredKey()` tombstones in
+ * `packages/spec/src/ui/view.zod.ts`), so a FormView that passed validation can
+ * never carry either. Under the maintainer's 2026-08-11 enforce-or-remove
+ * ruling the reads were removed rather than documented.
+ *
+ * This file pins the removal from both directions, because a dormant read is
+ * only safely deletable when BOTH ends are dead:
+ *
+ *  1. **Producer** — the contract still rejects the keys. This is what makes
+ *     the deletion "not a capability removal": the capability was already gone
+ *     at the spec. If a future spec un-retires either key, this half turns red
+ *     and tells the next agent the ruling needs revisiting BEFORE they re-add a
+ *     read to make something work.
+ *  2. **Bridge output** — even fed a RAW, never-validated object carrying both
+ *     keys (the only class of input that could still present them: a host
+ *     calling the exported `SpecBridge` with a stored pre-17 document), the
+ *     node gains neither key. Feeding raw input on purpose is the point — a
+ *     fixture that could not carry the key would pass for the wrong reason.
+ *
+ * Key-presence assertions (`'aria' in node`), not value assertions: what is
+ * guarded is that the bridge does not PRODUCE these node slots at all.
+ */
+import { describe, it, expect } from 'vitest';
+import { FormViewSchema } from '@objectstack/spec/ui';
+import { SpecBridge } from '../SpecBridge';
+import { bridgeFormView } from '../bridges/form-view';
+
+/** A FormView that is spec-valid except for the deliberately-planted key. */
+const VALID_BASE = {
+  type: 'simple',
+  sections: [{ label: 'Basic', fields: [{ field: 'name' }] }],
+};
+
+describe('form-view bridge — retired spec keys (#3901 / #3974)', () => {
+  describe('producer: the contract still refuses both keys', () => {
+    it('parses the base form view (the control — the fixture is otherwise valid)', () => {
+      expect(FormViewSchema.safeParse(VALID_BASE).success).toBe(true);
+    });
+
+    it('rejects `aria` on a form view by name', () => {
+      const parsed = FormViewSchema.safeParse({
+        ...VALID_BASE,
+        aria: { ariaLabel: 'Create Account Form', role: 'form' },
+      });
+
+      expect(parsed.success).toBe(false);
+      // `retiredKey()` is `z.never().optional()`, so the key is REJECTED at the
+      // parse rather than stripped — the issue lands on the key's own path.
+      expect(parsed.error?.issues.some((i) => i.path[0] === 'aria')).toBe(true);
+    });
+
+    it('rejects `defaultSort` on a form view by name', () => {
+      const parsed = FormViewSchema.safeParse({
+        ...VALID_BASE,
+        defaultSort: [{ field: 'name', order: 'asc' }],
+      });
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error?.issues.some((i) => i.path[0] === 'defaultSort')).toBe(true);
+    });
+  });
+
+  describe('bridge: raw input carrying the retired keys produces neither slot', () => {
+    const RAW_WITH_RETIRED_KEYS = {
+      ...VALID_BASE,
+      aria: { ariaLabel: 'Create Account Form', role: 'form' },
+      defaultSort: [{ field: 'name', order: 'asc' }],
+    };
+
+    it('does not carry `aria` or `defaultSort` onto the node', () => {
+      const node = new SpecBridge().transformFormView(RAW_WITH_RETIRED_KEYS);
+
+      expect('aria' in node).toBe(false);
+      expect('defaultSort' in node).toBe(false);
+      expect(Object.keys(node)).not.toContain('aria');
+      expect(Object.keys(node)).not.toContain('defaultSort');
+    });
+
+    it('still carries the live keys beside them (the read removal was surgical)', () => {
+      const node = new SpecBridge().transformFormView({
+        ...RAW_WITH_RETIRED_KEYS,
+        title: 'Edit Opportunity',
+        sharing: { visibility: 'team' },
+        submitBehavior: { kind: 'redirect', url: '/done' },
+      });
+
+      // `sharing` and `submitBehavior` sat on the same trailing block as the
+      // two deleted copies — if a future edit takes the block out wholesale,
+      // this is what reports it.
+      expect(node.title).toBe('Edit Opportunity');
+      expect(node.sharing).toEqual({ visibility: 'team' });
+      expect(node.submitBehavior).toEqual({ kind: 'redirect', url: '/done' });
+      expect((node.sections as unknown[]).length).toBe(1);
+    });
+
+    it('holds when the bridge function is called directly, not just via SpecBridge', () => {
+      const node = bridgeFormView(RAW_WITH_RETIRED_KEYS, {});
+
+      expect('aria' in node).toBe(false);
+      expect('defaultSort' in node).toBe(false);
+    });
+  });
+});

--- a/packages/react/src/spec-bridge/__tests__/FormViewSpecConformance.test.ts
+++ b/packages/react/src/spec-bridge/__tests__/FormViewSpecConformance.test.ts
@@ -12,9 +12,17 @@
  * The bridge must never silently drop `@objectstack/spec` FormViewSchema
  * configuration: every serializable spec key is either mapped onto the
  * `object-form` node or explicitly listed in IGNORED_SPEC_KEYS with a reason.
- * The fixture below carries every top-level FormViewSchema key (spec 14.6.0 /
- * 15.0.0 — identical key sets), so a newly-added spec key that the bridge
- * ignores will fail the completeness assertion when the fixture is updated.
+ * The fixture below carries top-level FormViewSchema keys, so a newly-added
+ * spec key that the bridge ignores will fail the completeness assertion when
+ * the fixture is updated.
+ *
+ * `defaultSort` and `aria` were dropped from this fixture (#3974 / #3901): spec
+ * 17 retired both on the FORM carrier, so they are no longer keys this fixture
+ * can claim — `FormViewSchema.safeParse` now rejects them by name. Keeping them
+ * here would have asserted the bridge carries configuration the contract
+ * refuses. They are NOT in IGNORED_SPEC_KEYS either: that list means "a real
+ * spec key we deliberately do not copy", and these are not spec keys any more.
+ * Their removal is pinned by `FormViewRetiredKeys.test.ts`.
  */
 import { describe, it, expect } from 'vitest';
 import { SpecBridge } from '../SpecBridge';
@@ -25,7 +33,7 @@ const IGNORED_SPEC_KEYS: Record<string, string> = {
   groups: 'legacy alias of sections — normalized into node.sections',
 };
 
-/** Every top-level serializable key of spec FormViewSchema (14.6.0 / 15.0.0). */
+/** Top-level serializable keys of spec FormViewSchema the bridge must carry. */
 const FULL_SPEC_FORM_VIEW = {
   type: 'wizard',
   layout: 'grid',
@@ -77,10 +85,8 @@ const FULL_SPEC_FORM_VIEW = {
     },
   ],
   subforms: [{ childObject: 'opportunity_line_item', amountField: 'amount' }],
-  defaultSort: [{ field: 'name', order: 'asc' }],
   sharing: { visibility: 'team' },
   submitBehavior: { kind: 'redirect', url: '/done' },
-  aria: { ariaLabel: 'Opportunity form', role: 'form' },
 };
 
 describe('FormView spec conformance (#2545)', () => {

--- a/packages/react/src/spec-bridge/__tests__/P1SpecBridge.test.ts
+++ b/packages/react/src/spec-bridge/__tests__/P1SpecBridge.test.ts
@@ -341,15 +341,21 @@ describe('P1 SpecBridge Protocol Alignment', () => {
       expect(field.colSpan).toBe(2);
     });
 
-    it('should pass through aria properties', () => {
+    // The `should pass through aria properties` case that stood here pinned a
+    // read the bridge no longer has: spec 17 retired `aria` on the FORM carrier
+    // (#3901), so no FormView that parsed can carry it. Replacing rather than
+    // re-spelling — a fixture whose key the bridge stopped reading keeps passing
+    // only because nothing is produced. The surviving behaviour is pinned in
+    // `FormViewRetiredKeys.test.ts`; the LIST carrier's aria pass-through is
+    // still live and still covered above (P1.1).
+    it('does not carry the retired form `aria` onto the node', () => {
       const bridge = new SpecBridge();
       const node = bridge.transformFormView({
         type: 'simple',
         aria: { ariaLabel: 'Create Account Form' },
       });
 
-      expect(node.aria).toBeDefined();
-      expect(node.aria.ariaLabel).toBe('Create Account Form');
+      expect('aria' in node).toBe(false);
     });
   });
 

--- a/packages/react/src/spec-bridge/bridges/form-view.ts
+++ b/packages/react/src/spec-bridge/bridges/form-view.ts
@@ -78,9 +78,11 @@ interface FormViewSpec {
   groups?: FormSection[];
   /** Inline master-detail child collections. */
   subforms?: any[];
-  defaultSort?: any;
+  // `defaultSort` and `aria` are NOT declared here on purpose — see the
+  // retirement note above `bridgeFormView`'s trailing key copies (#3901/#3974).
+  // Re-adding either to this mirror is the first half of re-adding a read that
+  // can never fire.
   sharing?: any;
-  aria?: { ariaLabel?: string; ariaDescribedBy?: string; role?: string };
   submitBehavior?: any;
 }
 
@@ -185,12 +187,27 @@ export const bridgeFormView: BridgeFn<FormViewSpec> = (
     if (spec[key] != null) node[key] = spec[key];
   }
 
-  if (spec.defaultSort) node.defaultSort = spec.defaultSort;
   if (spec.submitBehavior) node.submitBehavior = spec.submitBehavior;
 
-  // P1.6 — i18n & ARIA
+  // P1.6 — sharing
   if (spec.sharing) node.sharing = spec.sharing;
-  if (spec.aria) node.aria = spec.aria;
+
+  // `defaultSort` (#3974) and `aria` (#3901) USED to be copied here. Both are
+  // `retiredKey()` tombstones on spec 17's FormViewSchema, so a FormView that
+  // parsed can never carry either — the guards were unreachable, and their
+  // shape invited the next reader to copy a dead pattern. Removed under the
+  // maintainer's 2026-08-11 enforce-or-remove ruling; measured dormant at BOTH
+  // ends before removal:
+  //   - producer: `FormViewSchema.safeParse` rejects both keys by name
+  //     (`form.defaultSort` / `form.aria` removed in the #3896 close-out).
+  //   - consumer: no form renderer reads either off the node — plugin-form
+  //     reads neither, and `SchemaRenderer`'s generic ARIA injection resolves
+  //     FLAT `ariaLabel`/`ariaDescribedBy`/`role` (SchemaRenderer.tsx:109-119),
+  //     never a nested `aria` object.
+  // The nested `aria` copy is still correct on the LIST bridge
+  // (`list-view.ts:214`), whose carrier stayed live and IS consumed at
+  // `plugin-list/src/ListView.tsx:2389-2392` — do not "align" the two.
+  // Pinned by `__tests__/FormViewRetiredKeys.test.ts`.
 
   return node;
 };


### PR DESCRIPTION
Fixes #3901
Fixes #3974

维护者 2026-08-11 裁定 **enforce-or-remove**,一 PR 双关两卡:删掉 `form-view.ts` 里两条永不可能命中的休眠读 —— `spec.defaultSort`(旧 `:188`)与 `spec.aria`(旧 `:193`),以及本地 `FormViewSpec` mirror 中对应的声明。

## 前置门:非验证输入路径测量(裁定要求的产物)

两卡都把「是否存在把**未经 schema 验证**的对象喂进这个 bridge 的路径」列为删除前必须回答的问题。测量结论:**零 load-bearing 路径**,可以安全删除。

| 候选路径 | 测量方法 | 结果 |
|---|---|---|
| 仓内生产调用点 | `git grep -n "bridgeFormView\|transformFormView\|transform('form'"` 全仓 | **零**。只有 `SpecBridge.ts:49` 自身与 5 个测试文件。与 PR #4603 独立测得的结论一致(记在 `packages/types/src/__tests__/base-schema-label-vocabulary.test.ts:71`:「`SpecBridge` has zero in-repo production consumers」) |
| `apps/` `examples/` 演示数据 | `git grep -rn "SpecBridge\|transformFormView\|bridgeFormView" -- apps examples` | **零命中**。仓内无 `.stories.tsx` |
| 持久化直读 / 存储文档 | 同上;bridge 无任何仓内生产调用者,故无「读库直喂」路径 | **零** |
| 外部 host(bridge 经 `@object-ui/react` 公开导出) | `packages/react/src/index.ts:14` 确实公开导出,`transformFormView(spec: any)` 是真实的非验证边界(`list-view.ts:81` 记过同一边界,#4442 曾在此踩实) | 边界**存在**,但对这两个键**非 load-bearing** —— 见下面「下游同样是空的」 |
| fixture / 测试替身 | `git grep -rn "defaultSort"`、`aria` 全仓 | 命中 **2 处,全部是测试**,无生产:`FormViewSpecConformance.test.ts:80,83` 与 `P1SpecBridge.test.ts:344`。本 PR 按 fixture 分诊逐个处置(见下) |

**下游同样是空的**(这是外部 host 边界不构成 load-bearing 的决定性一环):

- `plugin-form` 对 `schema.aria` 与 `schema.defaultSort` 的读取数为 **0**。
- `SchemaRenderer` 的通用 ARIA 注入读的是**扁平**的 `ariaLabel` / `ariaDescribedBy` / `role`(`SchemaRenderer.tsx:109-119`),**不是**嵌套的 `aria` 对象 —— 所以 bridge 写出的 `node.aria` 连通用渲染路径也接不上。
- `object-form` 的 registry inputs 两个键都未声明。

即:即使某个 host 拿一份 pre-17 存储文档直喂 bridge,这两条读也只是把键抄到一个**无人消费**的 node 槽位上,删前删后行为一致。这正是与 `rowHeight`(#4442)先例的分野 —— 那个键抄过去是**真被下游读的**。

**反查(证明扫描器没坏)** —— 零命中必须用确定存在的邻近词反证:

- `submitBehavior`(同一尾块 `:189`):同样的 grep 找到真实下游 `ObjectForm.tsx:799-800`、`:1197`。
- `sharing`(同一尾块 `:192`):找到 `ListView.tsx:2924`。
- `aria` 的 **live 对照**:list view 载体仍是活的,同一套 grep 在 `plugin-list/src/ListView.tsx:2389-2392` 找到嵌套 `schema.aria?.ariaLabel` / `ariaDescribedBy` / `live` / `role` 的消费。**同样的嵌套形状、同样的方法,在 plugin-form 是零** —— 仪器可用,零就是真零。

## 生产者侧核验(ledger 的 dead 判定)

objectstack `origin/main` @ `35ceabb09`,`packages/spec/src/ui/view.zod.ts`:`defaultSort`(`:2432`)与 `aria`(`:2565`)在 FormViewSchema 上都是 `retiredKey()` 墓碑。`aria` 墓碑的理由本身就独立复述了我上面测到的下游结论:「no form renderer applied it (plugin-form/SchemaForm never read schema.aria)」。

**正向证据 —— 删读不是删功能**:对本仓实际依赖的 `@objectstack/spec@17.0.0-rc.6` 实跑 `FormViewSchema.safeParse`:

```
--- baseline (no retired keys): success=true
--- with aria: success=false
    path=["aria"] code=invalid_type
      msg=`form.aria` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) — no form
          renderer ever applied it, so declared ARIA attributes silently did not reach the DOM...
--- with defaultSort: success=false
    path=["defaultSort"] code=invalid_type
      msg=`form.defaultSort` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) —
          nothing read it: a related list inside a form sorts by its own list view's `sort`...
```

能力早已在**契约**处被移除,且是带指引的具名拒绝;renderer 这两条读只是墓碑立起来之后留下的残肢。契约优先(AGENTS.md #0.1):留着它等于在消费端替一个契约明确拒绝的键做容错。

## 改动

- `packages/react/src/spec-bridge/bridges/form-view.ts`:删两条读 + mirror 里 `defaultSort` 与 `aria` 的声明;原 `// P1.6 — i18n & ARIA` 注释已随之改成 `// P1.6 — sharing`(它现在只覆盖 `sharing`);原地留下退休说明,并**显式写明 list bridge 的同名拷贝是对的、不要去「对齐」二者** —— 裁定里点名的「模仿陷阱」就是这个。
- **fixture 分诊**(逐条判,不是批量重拼):
  - `FormViewSpecConformance.test.ts` —— fixture 自称「every top-level key of spec FormViewSchema」,而这两个键在 spec 17 已不再是 FormViewSchema 的键,**从 fixture 移除**;同时说明为什么**不**放进 `IGNORED_SPEC_KEYS`(那份清单的语义是「确实是 spec 键、但我们故意不抄」)。
  - `P1SpecBridge.test.ts` 的 `should pass through aria properties` —— 它钉的正是被删的那条肢。**整条替换**而非改写:一个断言「键被抄过去」的用例,在读被删后会因为「什么都没产出」而继续绿,那是假绿。
- 新增 `packages/react/src/spec-bridge/__tests__/FormViewRetiredKeys.test.ts`(仿仓内 `spec-symbol-parity.test.ts` 的退休键先例):两端一起钉 —— 生产者侧 `safeParse` 仍具名拒绝两个键(墓碑若被解除,这半边先红,提醒下一个 agent 先回到裁定而不是直接加读);bridge 侧**故意喂原始未验证对象**(唯一还可能带这两个键的输入类别),断言 node 两个槽位都不产生。用**键存在性**断言(`'aria' in node`)而不是值断言 —— 被守的事实是「bridge 不产出这两个 node 槽位」。

## 反向验证(先预判、后实跑)

**预判(跑之前写死)**:只把 `aria` 那条读加回去 → 2 个文件、3 个测试变红,即 `FormViewRetiredKeys` 的两条 bridge 用例 + `P1SpecBridge` 那条;生产者半边**必须仍绿**(消费端加一条读不可能改变 schema);`FormViewSpecConformance` **也必须仍绿**,因为它的 fixture 已不再带这个键 —— 换句话说那套 conformance 用例**不是**这个回归的探测器,这正是新增独立钉子文件的理由。

**实跑结果:与预判逐条吻合。**

```
× does not carry the retired form `aria` onto the node
× does not carry `aria` or `defaultSort` onto the node
× holds when the bridge function is called directly, not just via SpecBridge
AssertionError: expected true to be false
 Test Files  2 failed | 4 passed (6)
      Tests  3 failed | 108 passed (111)
```

还原后 6 files / 111 tests 全绿。反向验证在**已 commit** 的修复上做,还原走 `git checkout` 分支加路径的形式(AGENTS.md §9),不用 `git stash`。

## 验证

```
pnpm exec vitest run packages/react/                  → 45 files / 599 tests passed
pnpm exec vitest run packages/plugin-form/ \
    packages/plugin-list/ packages/plugin-grid/       → 160 files / 1727 tests passed
pnpm exec turbo run type-check --concurrency=2        → 81 successful, 81 total
node scripts/check-control-bytes.mjs                  → OK (4312 files)
node scripts/check-changeset-presence.mjs             → OK (1 changeset)
node scripts/check-changeset-no-major.mjs             → OK
node scripts/check-changeset-fixed.mjs                → OK
eslint(改动路径)                                      → 0 errors(15 warnings 均为既有 `any`)
```

消费面按「规则的调用半径」扫过,不只是被改的包:bridge 的输出被 `plugin-form` 消费、`plugin-grid` 有一个 `SpecBridge` 测试(走的是 list 路径)、`plugin-list` 是 live `aria` 载体 —— 三个包整包跑过,全绿。

Changeset:`@object-ui/react: patch`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_