### PR TITLE
refactor(core,components): 表单 data-source 规则派生自 core 的引用字段族,不再自留一份副本 (#4790)

### DIFF
--- a/.changeset/form-data-source-wiring-reads-core-reference-family.md
+++ b/.changeset/form-data-source-wiring-reads-core-reference-family.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/components': patch
+'@object-ui/core': patch
+---
+
+A `user` field in a form now receives `dataSource` / `dependentValues` / `dependsOnLabels`, like every other reference field.
+
+The form renderer decided which registered widget gets those three props from a
+module-private `DATA_SOURCE_FIELD_TYPES` set, while `@object-ui/core` kept
+`EXPANDABLE_FIELD_TYPES` for the same underlying fact — a field whose stored
+value is a foreign key into another object. The core side's TSDoc claimed to
+mirror the form's set, and it did for 15 days: the form's copy then gained
+`capability-multiselect` (objectui#2403) and the three widget-hint pickers
+`object-ref` / `filter-condition` / `recipient-picker` (objectui#2421) on the
+same day, after which the two sets were not in a subset relation in either
+direction — `user` only in core, the picker names only in the form — with
+nothing able to report it.
+
+The form now derives its rule instead of restating it: the reference half is
+core's set, the form-specific half is the three picker names, which are widget
+hints and can never be a declarable field `type`. Adding a member to
+`EXPANDABLE_FIELD_TYPES` therefore also grants it the form's data-source wiring;
+that coupling is intended and is now written down on both sides.
+
+The user-visible half is `user`. It previously received none of the three props.
+`dataSource` and `dependentValues` each have a `SchemaRendererContext` fallback
+inside the widget, so the person picker limped along wherever a provider
+happened to supply one; `dependsOnLabels` has no fallback, so a
+dependency-gated user picker interpolated the raw API name into its
+"select ... first" hint in every locale — the leak objectstack#5407 closed for
+lookups and left open here. The widget contract's own `dataSource` doc has
+always named `user` among the types the form renderer injects for.
+
+No change to what is expanded, projected or rendered anywhere else: the core
+set's members are untouched.

--- a/packages/components/src/renderers/form/__tests__/form-data-source-wiring.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-data-source-wiring.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Which widgets the form renderer threads `dataSource` / `dependentValues` /
+ * `dependsOnLabels` to — objectui#4790.
+ *
+ * The rule has two halves and only one of them belongs to this package:
+ *
+ *  - the reference-bearing field family, which is `EXPANDABLE_FIELD_TYPES` in
+ *    `@object-ui/core` — the same set the `$expand` builder and predicate-record
+ *    projection read;
+ *  - three widget-hint-only pickers (`object-ref` / `filter-condition` /
+ *    `recipient-picker`) that no object schema can ever declare as a field
+ *    `type`, so they cannot live in the core set.
+ *
+ * This renderer used to restate the first half as a private `Set`, with the core
+ * side's TSDoc claiming the two "mirror" each other. They stopped mirroring on
+ * 2026-07-13 and no gate could say so: `user` was in core only, the three picker
+ * names here only. The membership assertions below pass against ANY set holding
+ * the right members — including a re-inlined private copy — so they cannot
+ * report that failure mode on their own. The identity pin at the bottom is what
+ * does, exactly as in objectui#4770 / PR #4789.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ComponentRegistry, EXPANDABLE_FIELD_TYPES } from '@object-ui/core';
+import { SchemaRendererContext } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../../../renderers';
+
+/** Props each stub widget saw on its last render, keyed by registry type. */
+const seen: Record<string, any> = {};
+
+function makeStub(type: string) {
+  return function Stub(props: any) {
+    seen[type] = props;
+    return <div data-testid={`stub-${type}`} />;
+  };
+}
+
+/** Widget-hint-only pickers — the form-specific half of the rule. */
+const PICKER_WIDGET_TYPES = ['object-ref', 'filter-condition', 'recipient-picker'];
+
+/**
+ * Stubs for the whole rule, DERIVED from the core set rather than retyped: a
+ * member added to `EXPANDABLE_FIELD_TYPES` tomorrow is covered here without
+ * anyone remembering to add it, which is the point of the exercise.
+ */
+beforeAll(() => {
+  // These `field:*` ids are contributed by `@object-ui/fields`, which this
+  // package does not (and must not) depend on — so the stubs shadow nothing.
+  for (const type of [...EXPANDABLE_FIELD_TYPES, ...PICKER_WIDGET_TYPES]) {
+    ComponentRegistry.register(`field:${type}`, makeStub(type));
+  }
+  // A widget outside the family, to pin the strip half.
+  ComponentRegistry.register('field:tags', makeStub('tags'));
+});
+
+afterEach(() => cleanup());
+
+const dataSource = { find: async () => ({ data: [] }) };
+
+/**
+ * The renderer takes the `DataSource` from `SchemaRendererContext`, not from a
+ * prop on the form (`form.tsx`: `schemaCtx?.dataSource ?? null`) — so the
+ * provider is the realistic wiring, and rendering without it would assert
+ * `null === null` and pass for the wrong reason.
+ */
+function renderWith(fieldTypes: string[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <SchemaRendererContext.Provider value={{ dataSource } as any}>
+      <Form
+        schema={{
+          type: 'form',
+          showSubmit: false,
+          showCancel: false,
+          fields: [
+            { name: 'parent', label: 'Parent', type: 'input' },
+            ...fieldTypes.map((t) => ({
+              name: `f_${t}`,
+              label: `F ${t}`,
+              type: `field:${t}`,
+              field: { name: `f_${t}`, depends_on: ['parent'] },
+            })),
+          ],
+        }}
+      />
+    </SchemaRendererContext.Provider>,
+  );
+}
+
+describe('form renderer — data-source wiring covers the core reference family', () => {
+  it('threads all three props to every EXPANDABLE_FIELD_TYPES member', () => {
+    const members = [...EXPANDABLE_FIELD_TYPES];
+    renderWith(members);
+
+    for (const type of members) {
+      expect(seen[type], `${type} never rendered`).toBeDefined();
+      expect(seen[type].dataSource, `${type} lost dataSource`).toBe(dataSource);
+      expect(seen[type].dependentValues, `${type} lost dependentValues`).toBeDefined();
+      expect(seen[type].dependsOnLabels, `${type} lost dependsOnLabels`).toEqual(
+        expect.objectContaining({ parent: 'Parent' }),
+      );
+    }
+  });
+
+  it('threads them to `user` — the member the private copy never had', () => {
+    // Before objectui#4790 a `user` field received NONE of the three. Two of
+    // them have a `SchemaRendererContext` fallback inside the widget, so the
+    // person picker limped along; `dependsOnLabels` has no fallback at all, so
+    // a dependency-gated user picker interpolated the raw API name into its
+    // "select … first" hint — the leak objectstack#5407 closed for lookups and
+    // left open here. `user` is also named in the widget contract's own
+    // `dataSource` doc (`fields/src/widgets/types.ts`) as a type this renderer
+    // injects for, so the omission contradicted the published contract too.
+    expect(EXPANDABLE_FIELD_TYPES.has('user')).toBe(true);
+    renderWith(['user']);
+
+    expect(seen.user.dataSource).toBe(dataSource);
+    expect(seen.user.dependentValues).toBeDefined();
+    expect(seen.user.dependsOnLabels).toEqual(expect.objectContaining({ parent: 'Parent' }));
+  });
+
+  it('still threads them to the three widget-hint-only pickers', () => {
+    // The form-specific half. These are reached only through a `widget:` hint
+    // (`widgetHintOnly: true`, `app-shell/src/utils/paramValueShape.ts`), so
+    // they can never move into the core schema-type set.
+    renderWith(PICKER_WIDGET_TYPES);
+
+    for (const type of PICKER_WIDGET_TYPES) {
+      expect(seen[type], `${type} never rendered`).toBeDefined();
+      expect(seen[type].dataSource, `${type} lost dataSource`).toBe(dataSource);
+      expect(seen[type].dependentValues, `${type} lost dependentValues`).toBeDefined();
+    }
+  });
+
+  it('strips all three for a widget outside the family', () => {
+    // `tags` spreads its leftover props onto a DOM node, where an object-valued
+    // prop is a React warning — which is why this is an allow-list, not a
+    // blanket pass-through.
+    renderWith(['tags']);
+
+    expect(seen.tags).toBeDefined();
+    expect(seen.tags.dataSource).toBeUndefined();
+    expect(seen.tags.dependentValues).toBeUndefined();
+    expect(seen.tags.dependsOnLabels).toBeUndefined();
+  });
+});
+
+describe('form renderer — the reference half is the SHARED object (objectui#4790)', () => {
+  it('asks @object-ui/core EXPANDABLE_FIELD_TYPES which fields get a dataSource', () => {
+    // Identity, not membership — the same pin shape the cascade allow-table
+    // carries (`form-dependent-values.test.tsx`, objectui#4770). Every
+    // assertion above is satisfied by a private copy holding the same seven
+    // strings, which is precisely the state objectui#4790 closed. The spy is
+    // installed on the Set object exported by `@object-ui/core`; it records a
+    // call only if this renderer consulted THAT object.
+    const spy = vi.spyOn(EXPANDABLE_FIELD_TYPES, 'has');
+    try {
+      renderWith(['lookup']);
+      // The form normalizes `field:lookup` to `lookup` BEFORE the lookup, so
+      // the key reaching the shared set is the widget key, which coincides with
+      // the schema-type spelling the set is defined on.
+      expect(spy.mock.calls.map(([k]) => k)).toContain('lookup');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveCascadingOptions, CASCADE_OPTION_WIDGET_TYPES, isValueStillOffered, isMissingForRequired, isServerOwnedValue } from '@object-ui/core';
+import { ComponentRegistry, resolveFieldRuleState, evalFieldPredicate, resolveCascadingOptions, CASCADE_OPTION_WIDGET_TYPES, EXPANDABLE_FIELD_TYPES, isValueStillOffered, isMissingForRequired, isServerOwnedValue } from '@object-ui/core';
 import type { FormSchema, FormField as FormFieldConfig, FormFieldTab, FormFieldPane, FieldValidationRules, FieldCondition, SelectOption } from '@object-ui/types';
 import { useForm } from 'react-hook-form';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from '../../ui/form';
@@ -233,16 +233,61 @@ const BOOLEAN_WIDGET_TYPES = new Set([
 const resolveWidgetType = (f: any): string => f?.widget || f?.field?.widget || f?.type;
 
 const BUILTIN_FIELD_TYPES = new Set(['input', 'textarea', 'checkbox', 'switch', 'select']);
-const DATA_SOURCE_FIELD_TYPES = new Set([
-  // `capability-multiselect` was listed here until objectui#3308 retired the
-  // widget name (ADR-0049 enforce-or-remove): no producer stamped the hint and
-  // `field:capability-multiselect` was never registered on the live path, so the
-  // entry could never match a resolvable widget.
-  'lookup', 'master_detail', 'tree',
-  // Widget-hint pickers that resolve records / object catalogs and read sibling
-  // field values — they need both `dataSource` and `dependentValues` threaded.
+/**
+ * Widget-hint pickers that resolve records / object catalogs and read sibling
+ * field values — they need `dataSource` and `dependentValues` threaded exactly
+ * like a lookup does, but they are NOT declarable field types: they are reached
+ * only through a `widget:` hint (`widgetHintOnly: true` in
+ * `app-shell/src/utils/paramValueShape.ts`), so no object schema can produce a
+ * field whose `type` is one of them.
+ *
+ * This is the ONLY form-specific half of the data-source rule; the other half
+ * is the shared reference-bearing family — see {@link needsDataSourceWiring}.
+ *
+ * `capability-multiselect` was listed here until objectui#3308 retired the
+ * widget name (ADR-0049 enforce-or-remove): no producer stamped the hint and
+ * `field:capability-multiselect` was never registered on the live path, so the
+ * entry could never match a resolvable widget.
+ */
+const DATA_SOURCE_ONLY_WIDGET_TYPES = new Set([
   'object-ref', 'filter-condition', 'recipient-picker',
 ]);
+
+/**
+ * Whether this widget key receives `dataSource` / `dependentValues` /
+ * `dependsOnLabels` — i.e. whether the control it renders has to QUERY records
+ * to do its job.
+ *
+ * The reference-bearing half is not restated here: it is
+ * `EXPANDABLE_FIELD_TYPES`, the one relational-field family in
+ * `@object-ui/core` that the `$expand` builder and predicate-record projection
+ * already read. This renderer held a private copy of it
+ * (`DATA_SOURCE_FIELD_TYPES`) until objectui#4790, whose TSDoc on the core side
+ * claimed the two "mirror" each other; by then they had drifted apart in both
+ * directions — `user` only in core, the three picker names only here — and the
+ * gap was live, not theoretical: a `user` field got NONE of the three props.
+ * `dataSource` and `dependentValues` each have a `SchemaRendererContext`
+ * fallback inside the widget so the picker limped along, but `dependsOnLabels`
+ * has none, so a dependent user picker interpolated raw API names into its
+ * "select … first" hint — the very leak objectstack#5407 fixed for lookups.
+ * The widget contract has always named `user` among the types this renderer
+ * injects `dataSource` for (`fields/src/widgets/types.ts`).
+ *
+ * Members are WIDGET keys — `normalizeFieldType` output, the `field:` prefix
+ * stripped — and they coincide with the core set's schema-type spellings
+ * because `mapFieldTypeToFormType` maps each reference type onto a same-named
+ * widget id (`lookup` → `field:lookup`, `user` → `field:user`, …). The one
+ * exception is `tree`, which maps to `field:lookup` and so reaches this test as
+ * `lookup`; the `tree` member is therefore inert on the object-schema path and
+ * matches only a hand-authored `type: 'tree'`. It stays because the core set is
+ * defined over SCHEMA types, where `tree` is a real reference type.
+ */
+function needsDataSourceWiring(widgetType: string): boolean {
+  return (
+    EXPANDABLE_FIELD_TYPES.has(widgetType) ||
+    DATA_SOURCE_ONLY_WIDGET_TYPES.has(widgetType)
+  );
+}
 
 // Option fields (`select`/`radio`/`multiselect`/`checkboxes`) support per-option
 // `visibleWhen` cascading + `dependsOn` gating (#2284/#1583): the widget re-filters
@@ -395,7 +440,7 @@ function stripRegisteredFieldProps(type: string, props: RenderFieldProps): Rende
     // in the gate hint (objectstack#5407). Stripped for everything else for the
     // same reason `emptyHint` is — an unknown object prop reaching a DOM node
     // through a widget's `...props` spread is a React warning.
-    ...(DATA_SOURCE_FIELD_TYPES.has(normalizedType) ? { dataSource, dependentValues, dependsOnLabels } : {}),
+    ...(needsDataSourceWiring(normalizedType) ? { dataSource, dependentValues, dependsOnLabels } : {}),
     // The cascade option widgets own the gate hint's presentation, so they get
     // the computed `emptyHint` alongside the live record (objectui#3231). It is
     // stripped by default because every OTHER registered widget spreads its

--- a/packages/core/src/utils/expand-fields.ts
+++ b/packages/core/src/utils/expand-fields.ts
@@ -14,17 +14,50 @@ import { columnIdentity } from './column-identity.js';
  * list / grid / detail cell can render the related record's display name
  * instead of a bare id placeholder ("—").
  *
- * This mirrors the form layer's `DATA_SOURCE_FIELD_TYPES`
- * (`lookup` / `master_detail` / `tree`) and additionally covers `user` — a
- * lookup specialised to `sys_user`. The server resolves `user` through the
- * same expand path as `lookup` / `master_detail` (it carries the same
- * `reference` + id storage), so a `user` column that is NOT requested for
- * expansion comes back as a raw user id and renders as "—". Keeping the set
- * here as the single source of truth is what closes that gap.
+ * `user` is a lookup specialised to `sys_user`: it carries the same `reference`
+ * + id storage and the server resolves it through the same expand path as
+ * `lookup` / `master_detail`, so a `user` column that is NOT requested for
+ * expansion comes back as a raw user id and renders as "—" (objectui#2032).
  *
  * Note on `tree`: a self-referencing hierarchy field is a reference too, so it
  * belongs in this set; whether the backend materialises the expanded object
  * for it is a server concern — requesting it is harmless and forward-compatible.
+ *
+ * ## One family, three consumers
+ *
+ * This is the reference-bearing FAMILY, not the `$expand` builder's private
+ * list, and three concerns already read it under three different words:
+ *
+ *  - `$expand` construction — `buildExpandFields` below ("expandable");
+ *  - predicate-record projection — `predicate-record.ts` ("relational");
+ *  - the object form's data-source wiring — `needsDataSourceWiring` in
+ *    `packages/components/src/renderers/form/form.tsx`, which decides which
+ *    registered widget gets `dataSource` / `dependentValues` /
+ *    `dependsOnLabels` threaded to it.
+ *
+ * The third one used to be a second hand-maintained copy, and this comment used
+ * to claim the set "mirrors the form layer's `DATA_SOURCE_FIELD_TYPES`
+ * (`lookup` / `master_detail` / `tree`)". That was true for 15 days. The form's
+ * copy then gained `capability-multiselect` (objectui#2403) and, the same day,
+ * `object-ref` / `filter-condition` / `recipient-picker` (objectui#2421), after
+ * which the two sets were not in a subset relation in EITHER direction — `user`
+ * only here, three picker names only there — and no gate could say so
+ * (objectui#4790). The form now DERIVES from this set instead of restating it:
+ *
+ *     form's data-source rule  ==  EXPANDABLE_FIELD_TYPES
+ *                                  + three widget-hint-only picker names
+ *
+ * The extension is one-directional and cannot fold back into this set:
+ * `object-ref` / `filter-condition` / `recipient-picker` are widget HINTS, never
+ * declarable field types (`widgetHintOnly: true` in
+ * `app-shell/src/utils/paramValueShape.ts`), so no object schema can produce a
+ * field whose `type` is one of them.
+ *
+ * Stated so it reads as a decision rather than a surprise: **adding a member
+ * here also grants that type the form's data-source wiring.** That is the
+ * intended coupling — a type whose stored value is a foreign key needs a
+ * `DataSource` to resolve that key on the read path (expand) and on the edit
+ * path (the picker) alike.
  */
 export const EXPANDABLE_FIELD_TYPES: ReadonlySet<string> = new Set([
   'lookup',


### PR DESCRIPTION
Fixes #4790

⛔ 不预设「必须合一」,先测量。结论:**两表不是同一个域,但共享同一个概念**,且「mirrors」那句注释确实已经是假话 —— 按 (b)「一表 + 显式超集」定型,并顺带修掉超集关系成立所必需的那半个活缺口。

## 一、测量:两表各自在判什么

| | `EXPANDABLE_FIELD_TYPES`(core) | `DATA_SOURCE_FIELD_TYPES`(form,改前) |
|---|---|---|
| 键入的域 | 对象 schema 的 `fieldDef.type` | `normalizeFieldType` 输出的 **widget 键**(剥掉 `field:` 前缀) |
| 成员 | lookup / master_detail / tree / user | lookup / master_detail / tree + object-ref / filter-condition / recipient-picker |
| 判什么 | 哪些字段名进查询的 `$expand` | 哪些注册 widget 收到 `dataSource` / `dependentValues` / `dependsOnLabels` |

消费点逐个实读:

- core 侧 **三个**消费面,而且已经在用三个不同的词称呼它:`buildExpandFields`(`$expand`,"expandable")、`predicate-record.ts:75,80`("relational")、`plugin-list/ListView.tsx:2157`(变量名就叫 `relational`)。所以它早就是「引用字段族」这张表,不是 `$expand` 的私有清单。
- form 侧唯一消费点是 `stripRegisteredFieldProps`(form.tsx:398),决定三个 prop 的下发。

两表**在任一方向上都不是子集关系**:`user` 只在 core,三个 picker 名只在 form。issue 正文说的「不完全同集」是对的,但比正文更狠 —— 不存在可以直接写 `new Set([...DATA_SOURCE_FIELD_TYPES, 'user'])` 的超集形态。

## 二、`user` 的考古:有意语义差?不是,是漂移

- `196aa5330`(#2032,2026-06-28)一次性把 `tree` 和 `user` 加进 core 表,commit 正文写明理由:`user` 是特化到 `sys_user` 的 lookup,同一条 expand 路径,不请求展开就回裸 id、渲染成「—」。同一个 commit 写下「mirrors the form layer's `DATA_SOURCE_FIELD_TYPES` (`lookup` / `master_detail` / `tree`)」。
- 查 form 表当时的成员:`ed1c50247`(#1481,2026-06-04)出生即 `{lookup, master_detail, tree}` —— **那句注释写下时是真的**。
- 然后 2026-07-13 同一天两次加键:`e492b9d01`(#2403)加 `capability-multiselect`,`6a741605b`(#2421)加三个 picker。**「mirrors」真了 15 天,已经假了 34 天。**

漂移方向全在 form 一侧,且加的都是 widget-hint 名。所以 `user` 不在 form 表**不是有意语义差,是 form 表出生时就漏了**(它出生比 `user` 进 core 早 24 天,那时 core 表还不存在)。

## 三、probe 读数(真渲染,跑完即删)

在 form 渲染器上注册探针 widget,读三个 prop 的实际到达情况:

```
a_lookup {"hasDataSource":true, "hasDependentValues":true, "hasDependsOnLabels":true}
b_user   {"hasDataSource":false,"hasDependentValues":false,"hasDependsOnLabels":false}
c_owner  {"hasDataSource":false,"hasDependentValues":false,"hasDependsOnLabels":false}
d_md     {"hasDataSource":true, "hasDependentValues":true, "hasDependsOnLabels":true}
e_tree   {"hasDataSource":true, "hasDependentValues":true, "hasDependsOnLabels":true}
f_objref {"hasDataSource":true, "hasDependentValues":true, "hasDependsOnLabels":true}
g_grid   {"hasDataSource":false,"hasDependentValues":false,"hasDependsOnLabels":false}
```

`user` 三项全无 —— 是活缺口,不是纸面差异:

- `dataSource` / `dependentValues` 在 `LookupField` 里各有 `SchemaRendererContext` 兜底(`LookupField.tsx:321-330`),所以人员选择器在有 provider 时能瘸着跑;
- **`dependsOnLabels` 没有任何兜底**(`LookupField.tsx:307` 只读 prop),于是带 `depends_on` 的 user 选择器把裸 API 名插进「先选 … 」提示句 —— objectstack#5407 给 lookup 关掉、给 user 留着的同一个洞;
- 而 widget 契约自己的 TSDoc 一直把 `user` 列在「Injected by the form renderer」里(`fields/src/widgets/types.ts:166`)。声明与实现互相矛盾,矛盾的那一侧是 form。

## 四、选择的形态:(b) 一表 + 显式超集,超集方向是 form ⊃ core

补上 `user` 之后,超集关系才**真正成立**并可以写成代码:

```
form 的 data-source 规则  ==  EXPANDABLE_FIELD_TYPES + 三个 widget-hint-only picker 名
```

```ts
function needsDataSourceWiring(widgetType: string): boolean {
  return EXPANDABLE_FIELD_TYPES.has(widgetType) || DATA_SOURCE_ONLY_WIDGET_TYPES.has(widgetType);
}
```

为什么这个扩展**方向上不可能折回** core:`object-ref` / `filter-condition` / `recipient-picker` 是 widget 提示,不是可声明的字段类型(`app-shell/src/utils/paramValueShape.ts:174-176` 明写 `widgetHintOnly: true`),任何对象 schema 都产不出 `type` 等于它们的字段。所以它们只能留在 form 侧,这不是妥协,是域的性质。

写成函数而不是 `new Set([...EXPANDABLE_FIELD_TYPES, ...])`,是为了让 identity 钉钉得住:派生出的新 Set 与「成员相同的私有副本」在运行期无法区分,而**每次判定都去问共享对象**就可以。

两侧 TSDoc 都写清了随之而来的耦合:**往 core 表里加成员,同时也就给了那个类型表单侧的 data-source 接线** —— 这是有意为之(值是外键的类型,读路径要 expand、编辑路径要 picker,需要的是同一个 DataSource),写下来免得下次成为惊喜。「mirrors」那句已删。

未改动的:core 表成员一个没动,`$expand` / predicate-record / list / grid 行为逐字节不变。

## 五、测试与反向验证(先预判后跑)

新增 `packages/components/src/renderers/form/__tests__/form-data-source-wiring.test.tsx`(5 例):遍历 `EXPANDABLE_FIELD_TYPES` 全体成员断言三个 prop 到位(stub 由该集合**派生**注册,将来加成员自动覆盖)、`user` 专项、三个 picker 仍在、族外 widget 三项被 strip、以及 identity 钉。

**变异 A** —— 把派生换成成员逐字节相同的私有副本(7 个字符串全同)。预判:4 条成员/行为断言**全绿**(成员没变,prop 照样下发),**只有** identity 钉红在 `expected [] to include 'lookup'`。实跑:

```
× asks @object-ui/core EXPANDABLE_FIELD_TYPES which fields get a dataSource
AssertionError: expected [] to include 'lookup'
 Tests  1 failed | 4 passed (5)
```

与预判逐条相符 —— 这正是 issue 描述的失效模式:成员断言对私有副本一律放行,只有身份钉认得出来。

**变异 B** —— 从派生规则里减掉 `user`。预判:`user` 专项 + 遍历成员两条红,identity 钉保持绿。实跑:

```
× threads all three props to every EXPANDABLE_FIELD_TYPES member
× threads them to `user` — the member the private copy never had
AssertionError: user lost dataSource: expected undefined to be { find: [AsyncFunction find] }
 Tests  2 failed | 3 passed (5)
```

同样相符。两次变异均先 commit 后变异、`git checkout` 还原,变异不提交。

## 六、验证

- `pnpm exec vitest run packages/core/ packages/components/` → **227 files / 3087 tests passed**
- `pnpm exec vitest run packages/plugin-form/ packages/plugin-detail/ packages/plugin-grid/ packages/plugin-list/` → **241 files / 2510 tests passed**(规则的消费半径:core 表的四个下游包)
- `pnpm exec turbo run type-check --concurrency=2` → **81 successful, 81 total**
- `node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs` / `check-control-bytes.mjs` 全绿;改动路径 eslint **0 errors**

## 七、范围外发现(已另立,均未指派)

- **#4814** —— `owner` widget 拿不到表单下发的 dataSource,而 plugin-grid 认为它需要;且 `owner` 根本不在 spec 的 `FieldType` 枚举里(48 个成员实读,无它)。因此「顺手加一个 string」等于新造一条 declared-but-unexercised 条目,正是本族在关的失效模式 —— 故意没加,留给分诊判 enforce-or-remove。附带记录 `types.ts:166` 那句 TSDoc 里的 `grid` 是零消费者的声明。
- **#4815**(`finding`)—— plugin-grid `bulkParamToField.ts:40-46` 的 `DATA_SOURCE_WIDGET_TYPES` 是同一概念的第四份私有副本(lookup/master_detail/user/owner),与本 PR 定型后的规则仍不同集、零 gate;今天没有用户症状,但正是 #4770/#4790 两次描述的前夜状态。已标 `Blocked-by: #4814`。

metadata-admin 三处近似副本按派单要求未碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_