### PR TITLE
docs(layout): app-shell.mdx 导航示例改真实 NavItem 键,删两个被丢弃的 prop (#4793)

### DIFF
--- a/.changeset/app-shell-docs-nav-examples.md
+++ b/.changeset/app-shell-docs-nav-examples.md
@@ -1,0 +1,11 @@
+---
+---
+
+Docs + test-only (objectui#4793). `content/docs/layout/app-shell.mdx`'s two `SidebarNav`
+examples now spell the real `NavItem` keys — `title` instead of `label`, and the imported
+Lucide **component** instead of a quoted icon name — and stop teaching a `header` /
+`footer` prop that `SidebarNavProps` never declared. The examples are pinned to the real
+types by `packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts`.
+
+No published behaviour changes: nothing in any package's runtime source was touched, only
+the documentation page and the test that now compiles it.

--- a/content/docs/layout/app-shell.mdx
+++ b/content/docs/layout/app-shell.mdx
@@ -8,19 +8,17 @@ The AppShell component provides the main application layout structure with an in
 ## Basic Usage
 
 ```plaintext
-import { AppShell } from '@object-ui/layout';
-import { SidebarNav } from '@object-ui/layout';
+import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
+import { Home, Settings, Users } from 'lucide-react';
+
+const navItems: NavItem[] = [
+  { title: 'Dashboard', href: '/', icon: Home },
+  { title: 'Users', href: '/users', icon: Users },
+  { title: 'Settings', href: '/settings', icon: Settings },
+];
 
 <AppShell
-  sidebar={
-    <SidebarNav
-      items={[
-        { label: 'Dashboard', href: '/', icon: 'home' },
-        { label: 'Users', href: '/users', icon: 'users' },
-        { label: 'Settings', href: '/settings', icon: 'settings' }
-      ]}
-    />
-  }
+  sidebar={<SidebarNav items={navItems} />}
   navbar={
     <div className="flex items-center gap-4">
       <span className="font-semibold">My App</span>
@@ -160,55 +158,30 @@ navbar={
 ## Complete Example
 
 ```plaintext
-import { AppShell, SidebarNav } from '@object-ui/layout';
-import { Avatar, Button, Input } from '@object-ui/components';
+import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
+import { Avatar, AvatarFallback, Button, Input } from '@object-ui/components';
+import { Bell, Folder, LayoutDashboard, Settings, Users } from 'lucide-react';
+
+const navItems: NavItem[] = [
+  { title: 'Dashboard', href: '/', icon: LayoutDashboard, badge: '12' },
+  {
+    title: 'Projects',
+    href: '/projects',
+    icon: Folder,
+    children: [
+      { title: 'Active', href: '/projects/active' },
+      { title: 'Archived', href: '/projects/archived' },
+    ],
+  },
+  { title: 'Team', href: '/team', icon: Users },
+  { title: 'Settings', href: '/settings', icon: Settings },
+];
 
 function App() {
   return (
     <AppShell
       defaultOpen={true}
-      sidebar={
-        <SidebarNav
-          header={{
-            logo: '/logo.svg',
-            title: 'ObjectUI'
-          }}
-          items={[
-            {
-              label: 'Dashboard',
-              href: '/',
-              icon: 'layout-dashboard',
-              badge: '12'
-            },
-            {
-              label: 'Projects',
-              href: '/projects',
-              icon: 'folder',
-              children: [
-                { label: 'Active', href: '/projects/active' },
-                { label: 'Archived', href: '/projects/archived' }
-              ]
-            },
-            {
-              label: 'Team',
-              href: '/team',
-              icon: 'users'
-            },
-            {
-              label: 'Settings',
-              href: '/settings',
-              icon: 'settings'
-            }
-          ]}
-          footer={
-            <div className="p-4 border-t">
-              <Button variant="outline" className="w-full">
-                Upgrade Plan
-              </Button>
-            </div>
-          }
-        />
-      }
+      sidebar={<SidebarNav title="ObjectUI" items={navItems} />}
       navbar={
         <div className="flex items-center justify-between w-full">
           {/* Search */}
@@ -241,6 +214,11 @@ function App() {
   );
 }
 ```
+
+`SidebarNav` has no logo slot and no footer slot — `title` is its only branding prop, the
+section label printed above a flat `NavItem[]` (it is ignored when `items` is a
+`NavGroup[]`, since each group prints its own `label`). Put a logo in the `navbar` slot
+instead, as the Logo and Title example under Navbar Content above does.
 
 ## With Page Component
 

--- a/packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts
+++ b/packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts
@@ -1,0 +1,319 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `content/docs/layout/app-shell.mdx`'s SidebarNav examples are THIS file's code
+ * (objectui#4793).
+ *
+ * The published AppShell page (objectui.org/docs/layout/app-shell) taught two
+ * nav examples spelled `{ label, href, icon: 'home' }`. Two of those three keys
+ * are wrong: `NavItem` declares `title` / `href` / `icon`, and `icon` is a
+ * COMPONENT (rendered `<item.icon />`, `SidebarNav.tsx:60` and `:109`), never an
+ * icon name. `href` was the only correct one — so navigation worked while the
+ * row rendered no label (`<span>{item.title}</span>` on `undefined`), no icon,
+ * and a collapsed-sidebar tooltip of `undefined`. The same page also passed
+ * `header={{ logo, title }}` and `footer={…}` to `SidebarNav`, neither of which
+ * `SidebarNavProps` declares — the component destructures a fixed key list with
+ * no rest element, so both objects were built and dropped on the floor.
+ *
+ * This is objectui#3999's defect (fixed for `packages/layout/README.md` in
+ * PR #4792) reproduced on a second teaching surface, which is why the pin is
+ * built the same way.
+ *
+ * ## The halves, and why each is a different kind of fact
+ *
+ * 1. **Compile-time.** The item arrays below are real TypeScript annotated with
+ *    the real `NavItem`, imported from `../SidebarNav`, with real `lucide-react`
+ *    components in `icon`. `packages/layout`'s `type-check` script compiles this
+ *    file (`tsconfig.test.json`), so a shape `NavItem` cannot express stops the
+ *    build here. This half is what catches `icon: 'home'` — a wrong VALUE type
+ *    under a legal key, which no key-name check can see — and, via
+ *    `completeExampleProps`, a `header`/`footer` prop that does not exist.
+ *
+ * 2. **Doc parity.** Each array is fenced by markers and asserted to appear in
+ *    the MDX as a contiguous run of lines (compared trimmed). One source, two
+ *    readers: editing the page's shape without editing this code — or the
+ *    reverse — goes red. Without this, half 1 degenerates into type-checking a
+ *    snippet nobody publishes.
+ *
+ * 3. **Whole-page scans.** Parity only guards the two blocks it marks; a NEW
+ *    example added to the page later would be unguarded. So three narrow scans
+ *    re-read every fence on the page that mentions `SidebarNav` and reject the
+ *    exact defects this issue found: a quoted `icon:`, an item-level `label:`,
+ *    and a `<SidebarNav>` prop that `SidebarNavProps` does not declare. The
+ *    prop scan reads its expected key list OUT OF `SidebarNav.tsx`, so it can
+ *    never rot into "update the test".
+ *
+ * Scope: this file scans `content/docs/layout/app-shell.mdx` and nothing else.
+ * The `icon:`-as-string rejection in particular must NOT be widened to the docs
+ * tree — `page-header` really does declare `icon` as a string (an icon NAME),
+ * so this is a fact about THIS component's prop on THIS page. Pinning the whole
+ * docs tree to source is objectui#3786's problem, not this one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { Folder, Home, LayoutDashboard, Settings, Users } from 'lucide-react';
+import type { NavItem, SidebarNavProps } from '../SidebarNav';
+
+/** Repo root — four levels up from `packages/layout/src/__tests__`. */
+const REPO_ROOT = resolve(__dirname, '../../../..');
+const MDX_PATH = join(REPO_ROOT, 'content', 'docs', 'layout', 'app-shell.mdx');
+const MDX = readFileSync(MDX_PATH, 'utf8');
+const SIDEBAR_NAV_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'layout', 'src', 'SidebarNav.tsx'),
+  'utf8',
+);
+const THIS_FILE = readFileSync(join(__dirname, 'app-shell-docs-nav-example.test.ts'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Half 1 — the examples, as code. Everything between a BEGIN/END marker pair is
+// asserted below to appear verbatim (trimmed) in app-shell.mdx.
+// ---------------------------------------------------------------------------
+
+/** The "Basic Usage" example's items. */
+const basicItems: NavItem[] = [
+  // >>> APP-SHELL MDX EXAMPLE basic BEGIN
+  { title: 'Dashboard', href: '/', icon: Home },
+  { title: 'Users', href: '/users', icon: Users },
+  { title: 'Settings', href: '/settings', icon: Settings },
+  // >>> APP-SHELL MDX EXAMPLE basic END
+];
+
+/** The "Complete Example" items — badge, and a nested `children` group. */
+const completeItems: NavItem[] = [
+  // >>> APP-SHELL MDX EXAMPLE complete BEGIN
+  { title: 'Dashboard', href: '/', icon: LayoutDashboard, badge: '12' },
+  {
+    title: 'Projects',
+    href: '/projects',
+    icon: Folder,
+    children: [
+      { title: 'Active', href: '/projects/active' },
+      { title: 'Archived', href: '/projects/archived' },
+    ],
+  },
+  { title: 'Team', href: '/team', icon: Users },
+  { title: 'Settings', href: '/settings', icon: Settings },
+  // >>> APP-SHELL MDX EXAMPLE complete END
+];
+
+/**
+ * The Complete Example's `SidebarNav` props, as a typed value. The page used to
+ * pass `header={{ logo, title }}` and `footer={…}` here; both are absent from
+ * `SidebarNavProps`, so restoring either makes this object stop compiling
+ * (TS2353) instead of silently rendering nothing. `title` is the one real
+ * branding prop, which is what the example was rewritten onto.
+ */
+const completeExampleProps: SidebarNavProps = {
+  title: 'ObjectUI',
+  items: completeItems,
+};
+
+// ---------------------------------------------------------------------------
+// Marker extraction. Markers are matched by WHOLE-LINE equality against the
+// strings these two helpers build, so the helpers' own source lines can never
+// match themselves — this file reads itself, and a substring match would.
+// ---------------------------------------------------------------------------
+
+const beginMarker = (name: string): string => `// >>> APP-SHELL MDX EXAMPLE ${name} BEGIN`;
+const endMarker = (name: string): string => `// >>> APP-SHELL MDX EXAMPLE ${name} END`;
+
+/** The trimmed, non-empty lines of one marked example block. */
+function exampleLines(name: string): string[] {
+  const lines = THIS_FILE.split('\n').map((line) => line.trim());
+  const begin = lines.indexOf(beginMarker(name));
+  const end = lines.indexOf(endMarker(name));
+  if (begin === -1 || end === -1 || end <= begin) {
+    throw new Error(
+      `No \`${name}\` example block in this file. The markers are load-bearing: ` +
+        'the MDX parity assertions below have nothing to compare without them.',
+    );
+  }
+  return lines.slice(begin + 1, end).filter((line) => line.length > 0);
+}
+
+/** Index of `needle` as a contiguous run inside `haystack`, or -1. */
+function indexOfSequence(haystack: string[], needle: string[]): number {
+  for (let i = 0; i + needle.length <= haystack.length; i += 1) {
+    if (needle.every((line, offset) => haystack[i + offset] === line)) return i;
+  }
+  return -1;
+}
+
+const MDX_LINES = MDX.split('\n').map((line) => line.trim());
+
+/** Fenced code blocks on the page that are about this component. */
+function sidebarNavFences(): string[] {
+  const fences = [...MDX.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((match) => match[1]);
+  return fences.filter((body) => body.includes('SidebarNav'));
+}
+
+/**
+ * Prop names on every `<SidebarNav …>` opening tag in `body`.
+ *
+ * Walks the tag rather than regexing the whole fence, tracking `{}` depth so
+ * props of nested elements (`<Input placeholder=… />` inside a `navbar={…}`
+ * expression, say) are never collected as SidebarNav's own.
+ */
+function sidebarNavTagProps(body: string): string[] {
+  const props: string[] = [];
+  const TAG = '<SidebarNav';
+  for (let start = body.indexOf(TAG); start !== -1; start = body.indexOf(TAG, start + 1)) {
+    // Guard against matching a longer identifier, e.g. `<SidebarNavFoo`.
+    if (/[\w-]/.test(body[start + TAG.length] ?? '')) continue;
+    let depth = 0;
+    let i = start + TAG.length;
+    let tag = '';
+    for (; i < body.length; i += 1) {
+      const ch = body[i];
+      if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+      else if (ch === '>' && depth === 0) break;
+      tag += depth === 0 ? ch : ' ';
+    }
+    props.push(...[...tag.matchAll(/([A-Za-z_$][\w$]*)\s*=/g)].map((match) => match[1]));
+  }
+  return props;
+}
+
+/** Keys declared by an interface in `SidebarNav.tsx`, read off the source. */
+function interfaceKeys(name: string): string[] {
+  const body = new RegExp(`export interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(SIDEBAR_NAV_SRC);
+  if (!body) throw new Error(`\`export interface ${name}\` is gone from SidebarNav.tsx`);
+  // Anchored at line start, so nested keys inside a type (the `className?` in
+  // `icon?: React.ComponentType<{ className?: string }>`) are not collected.
+  return [...body[1].matchAll(/^\s*(\w+)\??\s*:/gm)].map((match) => match[1]);
+}
+
+describe("app-shell.mdx's SidebarNav examples are this file's type-checked code (objectui#4793)", () => {
+  it.each(['basic', 'complete'])('app-shell.mdx carries the `%s` items verbatim', (name) => {
+    const block = exampleLines(name);
+    expect(block.length, `the \`${name}\` block is empty`).toBeGreaterThan(0);
+    expect(
+      indexOfSequence(MDX_LINES, block),
+      [
+        `The \`${name}\` example in content/docs/layout/app-shell.mdx no longer matches the code`,
+        'in this file. One of the two moved on its own, which is exactly how the page came to',
+        "teach `{ label, href, icon: 'home' }` (objectui#4793) — a shape `NavItem` has never",
+        'had. Fix whichever is wrong, then make the other match; the code here is what `tsc`',
+        'reads.',
+        '',
+        'Expected this run of lines (trimmed) in app-shell.mdx:',
+        ...block.map((line) => `  ${line}`),
+      ].join('\n'),
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  it('and that code really is a `NavItem[]` (the compile-time half, made visible)', () => {
+    // These reads are the point: a `const` nobody looks at is easy to delete,
+    // and deleting it would silently retire the type-check above.
+    expect(basicItems.map((item) => item.title)).toEqual(['Dashboard', 'Users', 'Settings']);
+    expect(basicItems.map((item) => item.href)).toEqual(['/', '/users', '/settings']);
+    expect(completeItems.map((item) => item.title)).toEqual([
+      'Dashboard',
+      'Projects',
+      'Team',
+      'Settings',
+    ]);
+    expect(completeItems[1].children?.map((child) => child.title)).toEqual(['Active', 'Archived']);
+
+    // `icon` is a component, never a string — the defect this issue found.
+    for (const item of [...basicItems, ...completeItems]) {
+      expect(typeof item.icon).not.toBe('string');
+      expect(item.icon).toBeTruthy();
+    }
+
+    // The one real branding prop the `header={{ logo, title }}` example became.
+    expect(completeExampleProps.title).toBe('ObjectUI');
+    expect(completeExampleProps.items).toBe(completeItems);
+  });
+});
+
+describe("app-shell.mdx's SidebarNav examples spell only real keys (objectui#4793)", () => {
+  it('declares its nav arrays as `NavItem[]`, which is what makes a typo a compile error', () => {
+    const declaring = sidebarNavFences().filter((body) => body.includes('const navItems'));
+    expect(declaring.length, 'no fence on the page declares `navItems` at all').toBeGreaterThan(0);
+
+    for (const body of declaring) {
+      expect(
+        body.includes('const navItems: NavItem[] = ['),
+        [
+          'A SidebarNav example builds `navItems` without annotating it `NavItem[]`. The',
+          'annotation is the entire reason a copied typo fails at the keyboard instead of',
+          'rendering a blank sidebar (objectui#3999 / #4793); an unannotated array literal',
+          'is inferred structurally and accepts any shape.',
+        ].join('\n'),
+      ).toBe(true);
+    }
+  });
+
+  it('never spells `icon` as a string in a SidebarNav example', () => {
+    const fences = sidebarNavFences();
+    expect(fences.length, 'no SidebarNav code fence found on the page at all').toBeGreaterThan(0);
+
+    for (const body of fences) {
+      expect(
+        /\bicon\s*:\s*['"`]/.test(body),
+        [
+          'A SidebarNav example writes `icon` as a quoted string. `NavItem.icon` is a',
+          '`React.ComponentType`, rendered as `<item.icon />` — a string reaches React as an',
+          'unknown lowercase tag and renders nothing (objectui#4793). Import the Lucide',
+          'component and pass it.',
+          '',
+          'Scope note: `page-header` DOES declare `icon` as a string (an icon name), so this',
+          'assertion is deliberately confined to SidebarNav fences on this one page.',
+        ].join('\n'),
+      ).toBe(false);
+    }
+  });
+
+  it('never spells an item label as `label` (that key belongs to NavGroup)', () => {
+    // `NavGroup.label` is a real key, so a fence that actually builds a
+    // `NavGroup[]` is exempt — the defect is `label` on an ITEM, where the key
+    // is `title`. Today no fence on this page builds groups; the exemption is
+    // here so adding a grouped example later is not spuriously blocked.
+    const fences = sidebarNavFences().filter((body) => !body.includes('NavGroup'));
+    expect(fences.length, 'no non-grouped SidebarNav fence found on the page').toBeGreaterThan(0);
+
+    for (const body of fences) {
+      expect(
+        /\blabel\s*:/.test(body),
+        [
+          'A SidebarNav example spells an item label as `label:`. `NavItem` declares `title`;',
+          '`label` is `NavGroup`\'s key. Copied as-is the row renders no text at all, and its',
+          'collapsed tooltip is `undefined` (objectui#4793).',
+        ].join('\n'),
+      ).toBe(false);
+    }
+  });
+
+  it('passes only props that `SidebarNavProps` declares', () => {
+    const declared = interfaceKeys('SidebarNavProps');
+    expect(declared.length, 'no keys parsed out of `SidebarNavProps`').toBeGreaterThan(1);
+
+    const used = [...new Set(sidebarNavFences().flatMap(sidebarNavTagProps))];
+    expect(used.length, 'no `<SidebarNav …>` tag found on the page at all').toBeGreaterThan(0);
+
+    expect(
+      used.filter((prop) => !declared.includes(prop)),
+      [
+        'A `<SidebarNav>` example on content/docs/layout/app-shell.mdx passes a prop the',
+        'component does not declare. `SidebarNav` destructures a fixed key list with NO rest',
+        'element, so an undeclared prop is not "ignored with a warning" — the value is built',
+        'and dropped, and the page promises UI that can never appear. That is exactly what',
+        '`header={{ logo, title }}` and `footer={…}` did (objectui#4793).',
+        '',
+        'The expected list is READ OUT OF src/SidebarNav.tsx on every run, so this is never',
+        '"update the test": add the prop to `SidebarNavProps`, or stop teaching it.',
+        `Declared: ${declared.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #4793

## 前置门(已过)

本单与 PR #4805(#3946+#3947)同文件。等其落 main 后才开工:`d44279598` 即 #4805 的合并提交,worktree 以该显式 sha 建立。#4805 刚改写的 toggle / SidebarTrigger 散文、#3914 钉过的 `h-14` 与 padding 数值、Accessibility 段 —— 三处零触碰,可在 diff 里核。

## 三组计数的前后对照

| 组 | 前 | 后 | 处置 |
|---|---|---|---|
| 项级 `label:` | 9 | 0 | 全改真实键 `title` |
| 字符串 `icon:` | 7 | 0 | 全改 lucide 组件引用 |
| 不存在的 `header` prop | 1 | 0 | 改写成 `title="ObjectUI"` |
| 不存在的 `footer` prop | 1 | 0 | 删除(**超出派单枚举,见下方披露**) |

9 处 `label` 逐一核对过**不是** NavGroup 的合法组级键:本页 9 处全部落在 `items:` 数组内、与 `href` 同级,即 NavItem;`NavGroup.label` 在本页零出现(同目录 sidebar-nav.mdx 那 5 处才是合法用法,本 PR 不碰)。

7 处图标映射:`home`→`Home`、`users`→`Users`、`settings`→`Settings`(Basic Usage 3 处);`layout-dashboard`→`LayoutDashboard`、`folder`→`Folder`、`users`→`Users`、`settings`→`Settings`(Complete Example 4 处)。`href` 本来就是对的,一个字符没动。

形态照 #3999 / PR #4792 在 packages/layout/README.md 的定型抄,**含 `NavItem[]` 类型标注** —— README 里那句话说得最准:标注才是把这一整类笔误变回「在键盘上就编译报错」而不是「运行时空侧栏」的东西。

### `header` 为什么改成 `title` 而不是删掉

`SidebarNavProps` 里唯一能表达它的真实 prop 是 `title`(扁平 `NavItem[]` 上方的分区标签,默认 `'Application'`)。所以 `header={{ logo, title }}` 的 title 那一半有真实去处,直接删会连带删掉一个真 prop 的演示;logo 那一半侧栏没有任何插槽,本页 Navbar Content 段早就演示了 logo 放 `navbar` 的写法,正文补了一句指过去,避免读者找不到 logo 去哪了。

**「要不要给 SidebarNav 加 header / footer 插槽」是产品增强,不在本单范围,留维护者定。** 本 PR 只做「文档停止承诺组件没有的东西」。

## ⚠️ 超出派单枚举的两处,显式披露供 PM 判

派单枚举的是 9/7/1。实测同一个示例里还有两处同类事实,一并改了,理由与 PR #4805 那次 6-vs-3 披露相同 —— 中间态会发出一个自相矛盾的页面:

1. **`footer={…}` 与 `header` 是同一个事实**:`SidebarNavProps` 同样没有它,组件解构同样无 rest,那个 "Upgrade Plan" 按钮同样永不出现。只修 header 会让同一段示例继续教另一个被丢弃的 prop,而且本 PR 新加的 props 钉子会当场判它红。
2. **该 fence 的 import 行**:原文用了 `AvatarFallback` 与 `Bell` 却从未导入。我本来就要重写这一行的 import(要加 lucide),留两个未定义标识符在刚改过的 import 旁边说不过去,所以补齐(`AvatarFallback` 进 components,`Bell` 进 lucide)。

两处都零耦合,认为超界的话单独回退这两点即可,但不建议中间态落地。

## 钉子(新增,扫描面只覆盖本页)

新增 `packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts`,照 PR #4792 的 `readme-sidebar-nav-example.test.ts` 同构建。#4793 正文说「PR #4792 的钉子只覆盖 packages/layout/README.md,够不到 content/docs —— 防回潮缺口如实存在」:本 PR 把这一页补上了,但**只补这一页**,整棵 docs 树对源码的钉子仍是 #3786 的题。

三半各管一类事实:

1. **编译时** —— 示例数组是真 TypeScript,标注真 `NavItem`,`icon` 放真 lucide 组件,由本包 `tsconfig.test.json` 编译。这一半才抓得住 `icon: 'home'`:合法键下的**值**类型错,任何键名检查都看不见。另有一个 `SidebarNavProps` 类型的 props 对象,专管 `header` / `footer` 这类**键**错。
2. **文档一致** —— 两个数组用标记围起来,断言在 mdx 里逐行(trim 后)连续出现。没有这一半,第 1 半退化成给没人发布的片段做类型检查。
3. **整页扫描** —— 第 2 半只管它标记的两块,后来新加的示例不设防。所以三条窄扫描重读本页每个提到 SidebarNav 的 fence,分别拒绝:带引号的 `icon:`、项级 `label:`、以及 SidebarNavProps 未声明的 prop。最后一条的期望键表是**每次运行从 `SidebarNav.tsx` 现读**的,所以它不会烂成「顺手改测试」。

扫描面的边界写在文件头注释里:`icon:` 不许是字符串这条**绝不能**推广到 docs 树 —— `page-header` 的 `icon` 本来就声明成字符串(图标**名**),这是关于这个组件这个 prop 在这一页的事实。项级 `label:` 那条也留了 NavGroup 豁免(fence 里出现 `NavGroup` 就跳过),免得以后有人加合法的分组示例被误伤。

## 反向验证(先预判后跑;有一处预判偏差,如实记)

方向预判:**全部是普通的「红」**,没有 inversion —— 钉子的示例块是标注过的 `NavItem[]`,旧形状是「表达不出来」而不是「读不到」,所以恢复旧形状必然编译红。照 PR #4792 的 B+C 教训把**键**错与**值**错分开证:

| 探针 | 预判 | 实测 |
|---|---|---|
| P1 `title` 改成 `label`(键没了) | 缺必填属性 **TS2741** | **TS2353** `'label' does not exist in type 'NavItem'` —— 预判的错误码不对,方向(红)对 |
| P2 `icon: Home` 改成 `icon: 'home'`(只错值) | **TS2322** | **TS2322** `Type 'string' is not assignable to type 'ComponentType'` ✅ |
| P3 `label` 与 `title` **并存**(纯多余键) | **TS2353** | **TS2353** ✅ |
| P4 `header` 加回 `SidebarNavProps` | **TS2353** | **TS2353** `'header' does not exist in type 'SidebarNavProps'` ✅ |
| P5 mdx 还原成 main 版、钉子保留 | 7 个测试红 6 个,**「编译半可见」那个仍绿** | **6 failed / 1 passed**,绿的正是那一个 ✅ |

**P1 的预判偏差值得写下来**:`label` 顶掉 `title` 时 TypeScript 报的是多余属性 TS2353,不是我预判的缺属性 TS2741 —— 对象字面量的 excess-property 检查先于必填缺失报出来。结论方向没变(照抄旧示例编译就是红),但 P1 和 P3 因此撞成同一个错误码,真正把「值错」单独证出来的只有 P2。这一点如实记,免得下一个人以为 P1/P3 是两个独立信号。

**P5 里 `NavItem[]` 标注那条测试是经它自己的空集守卫变红的**(`no fence on the page declares navItems at all`),不是逐 fence 判红 —— 旧 mdx 把数组内联进 JSX,压根没有 `const navItems` 声明。这正是那个守卫存在的理由:没有它,该断言会因为「什么都没扫到」而空绿。

反向验证全程按 AGENTS.md:先 commit 再还原,`git checkout 分支名 -- 路径`,**未用 `git stash`**;跑完工作树已还原干净(`git status --porcelain` 空)。

## 验证记录(实测输出)

```
pnpm --workspace-concurrency=2 --filter '@object-ui/layout^...' build   -> Done
pnpm exec vitest run packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts
                                                                        -> 1 file / 7 tests passed
pnpm exec vitest run packages/layout/ --maxWorkers=2                    -> 12 files / 148 tests passed
pnpm exec vitest run scripts/ --maxWorkers=2                            -> 45 files / 1026 tests passed
node scripts/check-doc-links.mjs                                        -> Links are valid across 13 scan roots
pnpm --filter @object-ui/layout run type-check                          -> exit 0(tsc --noEmit && tsc -p tsconfig.test.json)
pnpm exec turbo run type-check --concurrency=2                          -> 81 successful, 81 total
pnpm exec eslint packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts
                                                                        -> exit 0,0 problems
node scripts/check-control-bytes.mjs                                    -> OK (4318 tracked text files)
node scripts/check-changeset-{presence,fixed,no-major}.mjs               -> 三门全绿
```

重活全程走 `flock -w 3600 /tmp/os-heavy-verify.lock` + `NODE_OPTIONS=--max-old-space-size=4096`,未起任何 dev 服务。

**changeset 按门实测判,不靠猜**:presence 门只数发版包的 `src/`,`content/docs` 的 mdx 不计入 —— 未加 changeset 时它明确点名 `packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts` 一个文件而报红。本改动没碰任何包的运行时源码,只有文档页和钉住它的测试,所以按 AGENTS.md 的一等写法用**空 frontmatter** 显式声明「不发版」,门随即转绿并确认 `Every one of them has an EMPTY frontmatter — declared as releasing nothing`。

按 `doc-version-claims` 棘轮要求,本次**没有**向 mdx 新增任何版本字面量。

## 明确没碰的东西

- PR #4805 刚改的 toggle / hamburger / SidebarTrigger 相关行(含 Collapsible Sidebar 段那个 fence);
- #3914 钉过的 `h-14`、padding 数值;
- Accessibility 段那三条;
- `href`(本来就对);
- Complete Example 里 `size="icon"` 是 Button 的 prop,不是 NavItem 的 `icon`,未误伤。

## 顺带发现(未在本 PR 修,已按 #4949 纪律先查重后立单)

1. **已存在,未开新单** —— `AppShellProps` 的文档块少了 `branding` / `rightRail` 两个真实 prop:检索命中**已立的 #4808**,不开孪生单。该块在本页 Component Props 段,与导航示例无关,本 PR 未动。
2. **#4817**(新立,未认领,未打标交 PM 分诊)—— packages/layout/README.md 的 AppShell 示例传了一个 `header` prop,而 `AppShellProps` 没有它、解构无 rest:与本页 SidebarNav 的 `header` 是同一类幻影 prop,但载体是另一个文件的另一个示例。PR #4792 给该 README 加的钉子只断言 SidebarNav 的 fence 与 props 表,够不到上方这个 AppShell 示例;本 PR 的钉子扫描面只覆盖 app-shell.mdx 一页,同样够不到。
3. **#4818**(新立,`finding` 标,不挂 `pm:queue`)—— `AppShellBranding.logo` 全无读取方(`useAppShellBranding` 只消费 primaryColor / accentColor / favicon / title,依赖数组里也没有它),而注释写着「passed to sidebar/navbar via context」,AppShell 根本没有那个 context;`apps/console/src/hooks/useBranding.ts:27` 还在喂值。判 observation-class 的理由:侧栏 logo 今天照常显示,因为它走 `AppSidebar.tsx:194` 直接读 app schema 的另一条路,坏的只是这个声明面。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_