### PR TITLE
fix(fields): 可编辑 rich-text 把 host 的 id 与 aria-describedby 铺到真正的编辑控件 (#4810)

### DIFF
--- a/.changeset/richtext-editable-host-plumbing.md
+++ b/.changeset/richtext-editable-host-plumbing.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/fields': patch
+---
+
+Editable `markdown` / `html` / `richtext` fields now carry the host's `id` and `aria-describedby` on the editor.
+
+`RichTextField` — the one widget all three registry keys resolve to — read only
+`className` and `disabled` off its props and had no `toDomProps` anywhere in the
+file, so everything `<FormControl>`'s Radix `Slot` hands a field widget landed on
+no element at all. Measured on a real form with a field carrying a description:
+
+```
+markdown  editable  descEl=SET  consumers=0  hostIdEl=NONE  for=DANGLING
+text      editable  descEl=SET  consumers=1  hostIdEl=input     for=RESOLVES
+textarea  editable  descEl=SET  consumers=1  hostIdEl=textarea  for=RESOLVES
+```
+
+Two user-visible consequences: the form's visible label pointed at an id nothing
+carried, so clicking it did not reach the editor and the control had no
+accessible name; and the `<FormDescription>` the form rendered below the field
+had zero consumers, so a screen reader never announced the help text or — on a
+failed submit — the error message id that rides in the same `aria-describedby`.
+
+The fix is objectui#3318's standing recipe: `toDomProps(props)` spread onto the
+REAL focusable control, which here is the `<Textarea>` inside the shared
+`RichTextEditorSurface`. The pass-through is given to the inline surface only —
+the fullscreen dialog's copy of the same surface must not carry a duplicate of
+the host id, and the description ids it names sit outside the modal Radix
+`aria-hidden`s. `aria-invalid` still comes from the widget's own `error` read,
+kept after the spread so objectui#3318's PASS entry for this widget is unchanged.
+
+The readonly branch is untouched: the same reading there belongs to
+objectui#4788, whose mechanism is still open.

--- a/packages/fields/src/__tests__/richtext-host-plumbing-e2e.test.tsx
+++ b/packages/fields/src/__tests__/richtext-host-plumbing-e2e.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * End-to-end: the EDITABLE rich-text widget forwards the host's `id` and
+ * `aria-describedby` to the control the user actually types into
+ * (objectui#4810).
+ *
+ * The defect, measured on a real form renderer with a field carrying a
+ * `description` — count the elements whose `aria-describedby` names the
+ * `…-form-item-description` id, and resolve the visible label's `for`:
+ *
+ * ```
+ * markdown  editable  descEl=SET  consumers=0  hostIdEl=NONE  for=DANGLING
+ * text      editable  descEl=SET  consumers=1  hostIdEl=input     for=RESOLVES
+ * textarea  editable  descEl=SET  consumers=1  hostIdEl=textarea  for=RESOLVES
+ * ```
+ *
+ * `RichTextField` had no `toDomProps` anywhere in the file: `<FormControl>`'s
+ * Radix `Slot` handed it the field's `id` / `aria-describedby`, the widget read
+ * only `className` / `disabled` off `props`, and both landed nowhere. So the
+ * form's visible label pointed at an id NO element carried (clicking it focused
+ * nothing) and the `<FormDescription>` the form rendered had zero consumers —
+ * a screen reader never announced the help text for a markdown / html /
+ * richtext field.
+ *
+ * `markdown`, `html` and `richtext` are three registry keys on ONE widget
+ * (`fieldWidgetMap`), so every case below runs for all three: a fix landed on
+ * one key and not the others is not possible here, but a REGISTRATION that
+ * stops pointing at this widget is, and that is what the parameterisation
+ * pins.
+ *
+ * ## What this file deliberately does NOT cover
+ *
+ * - The **readonly** branch. `markdown readonly` measures `consumers=0` too,
+ *   but that half is objectui#4788 (the read-only replacement display family),
+ *   whose mechanism is still undecided. Pinning today's readonly reading here
+ *   would freeze a defect that has an open design question.
+ * - Other widgets missing the same pass-through (`slider` / `grid` /
+ *   `signature`): they are in objectui#3318's ledger and are fixed by its
+ *   recipe, not here.
+ *
+ * The widget is registered raw rather than through `registerAllFields()`, which
+ * wraps every loader in `React.lazy`: an unbounded module load inside a bounded
+ * `findBy`/`waitFor` window is the repo's known flake generator (AGENTS.md
+ * 测试纪律, objectui#3010). Same component, no Suspense boundary.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { RichTextField } from '../widgets/RichTextField';
+
+/** The three `fieldWidgetMap` keys that resolve to this one widget. */
+const RICH_TEXT_TYPES = ['markdown', 'html', 'richtext'] as const;
+
+const DESCRIPTION = 'Some help';
+
+beforeAll(() => {
+  for (const type of RICH_TEXT_TYPES) {
+    ComponentRegistry.register(type, RichTextField as any, {
+      namespace: 'field',
+      skipFallback: true,
+    });
+  }
+}, 30000);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The real form renderer hosting one rich-text field — the #4810 probe. */
+function renderForm(type: string, extra: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues: { body: '' },
+        fields: [
+          {
+            name: 'body',
+            label: 'Body',
+            type: `field:${type}`,
+            description: DESCRIPTION,
+            ...extra,
+          },
+        ],
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+/** The editing surface the widget renders — what focus and ARIA must land on. */
+function editorSurface(): HTMLTextAreaElement {
+  const el = document.querySelector('[data-field="body"] textarea');
+  if (!el) throw new Error('the rich-text widget rendered no textarea');
+  return el as HTMLTextAreaElement;
+}
+
+/**
+ * The probe from the issue, verbatim: which element carries the host id, does
+ * the visible label's `for` resolve, and how many elements consume the
+ * description id.
+ */
+function probe() {
+  const descEl = document.querySelector('[id$="-form-item-description"]');
+  const descId = descEl?.getAttribute('id') ?? '';
+  const consumers = Array.from(document.querySelectorAll('[aria-describedby]')).filter((el) =>
+    (el.getAttribute('aria-describedby') ?? '').split(/\s+/).includes(descId),
+  );
+  const label = document.querySelector('label[for]');
+  const forId = label?.getAttribute('for') ?? '';
+  const hostIdEl = forId ? document.getElementById(forId) : null;
+  return {
+    descEl,
+    descId,
+    consumers,
+    forId,
+    hostIdEl,
+    for: hostIdEl ? 'RESOLVES' : 'DANGLING',
+  };
+}
+
+describe('editable rich-text carries the host id (objectui#4810)', () => {
+  it.each(RICH_TEXT_TYPES)('%s: the visible label resolves to the editor', (type) => {
+    renderForm(type);
+
+    const reading = probe();
+    // The measured defect: `for=DANGLING`, `hostIdEl=NONE`.
+    expect(reading.for).toBe('RESOLVES');
+    expect(reading.forId).toMatch(/-form-item$/);
+    expect(reading.hostIdEl).toBe(editorSurface());
+  });
+
+  it.each(RICH_TEXT_TYPES)('%s: getByLabelText reaches the editor', (type) => {
+    renderForm(type);
+
+    // Resolves label→control through `for`/id, so it fails outright — "found a
+    // label … however no form control was found associated to that label" —
+    // while the id lands nowhere.
+    expect(screen.getByLabelText('Body')).toBe(editorSurface());
+  });
+
+  it.each(RICH_TEXT_TYPES)('%s: clicking the label reaches the editor', (type) => {
+    renderForm(type);
+
+    // The user-facing symptom: clicking a field's label is the normal way to
+    // start typing, and it reaches the control only through `for`/id — the
+    // label's ACTIVATION BEHAVIOUR, which forwards the click to the labelled
+    // control. Asserted as the forwarded click rather than as focus because
+    // jsdom implements the forwarding and not the focus that follows it in a
+    // browser; a dangling `for` forwards nothing, which is the reading this
+    // pins.
+    const editor = editorSurface();
+    const clicked = vi.fn();
+    editor.addEventListener('click', clicked);
+
+    fireEvent.click(screen.getByText('Body'));
+
+    expect(clicked).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('editable rich-text consumes the form description (objectui#4810)', () => {
+  it.each(RICH_TEXT_TYPES)('%s: the description has exactly one consumer', (type) => {
+    renderForm(type);
+
+    const reading = probe();
+    // `descEl=SET` was never the problem — the form rendered the help text all
+    // along. `consumers=0` is: nothing pointed at it.
+    expect(reading.descEl).not.toBeNull();
+    expect(reading.descEl).toHaveTextContent(DESCRIPTION);
+    expect(reading.consumers).toHaveLength(1);
+    expect(reading.consumers[0]).toBe(editorSurface());
+  });
+
+  it.each(RICH_TEXT_TYPES)('%s: the editor names the description id', (type) => {
+    renderForm(type);
+
+    const { descId } = probe();
+    expect(descId).not.toBe('');
+    expect((editorSurface().getAttribute('aria-describedby') ?? '').split(/\s+/)).toContain(descId);
+  });
+});
+
+describe('rich-text keeps announcing invalidity (objectui#3318 stays PASS)', () => {
+  // `RichTextEditorSurface` reads `error` and sets `aria-invalid` itself — one
+  // of #3318's 17 PASS entries, and the reason this widget was never on that
+  // issue's fix list. The pass-through spread must not disturb it: the host's
+  // own `aria-invalid` arrives through `toDomProps`' `aria-*` family, so the
+  // widget's read has to stay AFTER the spread to remain the authority.
+
+  it.each(RICH_TEXT_TYPES)('%s: a valid field is not marked invalid', (type) => {
+    renderForm(type);
+
+    expect(editorSurface()).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it.each(RICH_TEXT_TYPES)('%s: a failed required check marks the editor invalid', async (type) => {
+    renderForm(type, { required: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    await waitFor(() => {
+      expect(editorSurface()).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    // And the error message joins the description in `aria-describedby` — the
+    // second half of what `<FormControl>` hands down, delivered by the same
+    // spread.
+    const messageId = document
+      .querySelector('[data-field="body"] [id$="-form-item-message"]')
+      ?.getAttribute('id');
+    expect(messageId).toBeTruthy();
+    expect((editorSurface().getAttribute('aria-describedby') ?? '').split(/\s+/)).toContain(
+      messageId,
+    );
+  });
+});

--- a/packages/fields/src/widgets/RichTextField.tsx
+++ b/packages/fields/src/widgets/RichTextField.tsx
@@ -3,6 +3,7 @@ import { cn, Textarea, EmptyValue } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/react';
 import { FullscreenFieldEditor } from './FullscreenFieldEditor';
 import { FieldWidgetComponentProps } from './types';
+import { toDomProps, type DomProps } from './toDomProps';
 
 /**
  * The rich-text editing surface, rendered by `RichTextField` in BOTH positions:
@@ -17,6 +18,9 @@ import { FieldWidgetComponentProps } from './types';
  *
  * `fullHeight` is the only difference between the two renderings: inline the
  * textarea is `rows`-sized, in the dialog it fills the available height.
+ *
+ * The `<Textarea>` below is this widget's ONE focusable control, so it is where
+ * the host's DOM pass-through has to land (objectui#4810) — see `domProps`.
  */
 function RichTextEditorSurface({
   value,
@@ -32,6 +36,7 @@ function RichTextEditorSurface({
   autoFocus,
   textareaTestId,
   overlay,
+  domProps,
 }: {
   value: string;
   onChange: (next: string) => void;
@@ -47,6 +52,21 @@ function RichTextEditorSurface({
   textareaTestId?: string;
   /** Absolutely-positioned children over the textarea (the expand affordance). */
   overlay?: React.ReactNode;
+  /**
+   * The host's DOM pass-through (objectui#4810), already filtered through the
+   * `toDomProps` whitelist by the caller — the field's `id`, the
+   * `aria-describedby` `<FormControl>`'s Slot minted, `name`, `tabIndex`, the
+   * focus handlers.
+   *
+   * Given to the INLINE surface only, and that is a statement about the dialog
+   * rather than an omission: the host id is unique per form item, so handing it
+   * to a second `<Textarea>` mounted at the same time would put two elements
+   * under one id and make the visible label's `for` ambiguous, and the ids the
+   * host's `aria-describedby` names sit OUTSIDE the dialog, which Radix
+   * `aria-hidden`s while the modal is open. Exactly the split `TextAreaField`
+   * makes for the same pair of surfaces.
+   */
+  domProps?: DomProps<FieldWidgetComponentProps<string>>;
 }) {
   return (
     <div className={cn('space-y-2', fullHeight && 'flex flex-col h-full')}>
@@ -56,22 +76,38 @@ function RichTextEditorSurface({
       </div>
       <div className={cn('relative', fullHeight && 'flex-1 min-h-0')}>
         <Textarea
+          // BEFORE the spread, both of them, so a host that supplies either key
+          // wins and one that supplies neither still gets this surface's own
+          // value. After the spread they would be re-assigned `undefined` on
+          // the inline surface — which is how a pass-through silently drops a
+          // key it was handed.
+          autoFocus={autoFocus}
+          data-testid={textareaTestId}
+          {...domProps}
           value={value || ''}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
           disabled={disabled}
-          autoFocus={autoFocus}
           rows={fullHeight ? undefined : rows}
           // `text-base` in the dialog for the same reason `TextAreaField` uses
           // it there: sub-16px inputs make iOS Safari zoom on focus, which is
           // exactly wrong for a surface the user opened to get more room.
+          //
+          // After the spread because it COMPOSES the host's `className` (which
+          // reaches this component as the `className` prop) with the surface's
+          // own classes, rather than letting the raw host value replace them.
           className={cn(
             'font-mono',
             fullHeight ? 'text-base h-full min-h-full resize-none' : 'text-sm',
             className,
           )}
+          // After the spread, deliberately: `toDomProps` forwards the whole
+          // `aria-` family, so `<FormControl>`'s own `aria-invalid` arrives in
+          // `domProps` too. This widget reading `error` itself is one of
+          // objectui#3318's 17 PASS entries — keeping the read last is what
+          // keeps that entry passing instead of handing the state back to a
+          // host that may not have one.
           aria-invalid={!!error}
-          data-testid={textareaTestId}
         />
         {overlay}
       </div>
@@ -101,6 +137,23 @@ function RichTextEditorSurface({
  * tolerant fallback in one of them. The affordance and dialog themselves come
  * from the shared `FullscreenFieldEditor`, so one form-level setting keeps
  * producing one behaviour across both widgets.
+ *
+ * ## Host plumbing (objectui#4810)
+ *
+ * The editable branch had no `toDomProps` at all, so everything
+ * `<FormControl>`'s Radix `Slot` hands down — the field's `id`, the
+ * `aria-describedby` naming its `<FormDescription>` and `<FormMessage>` —
+ * arrived as props and landed on no element. Measured on a real form: the
+ * visible label's `for` pointed at an id nothing carried (`for=DANGLING`) and
+ * the rendered description had zero consumers, for all three registry keys
+ * (`markdown` / `html` / `richtext`) since they are this one widget.
+ *
+ * The fix is objectui#3318's standing recipe — `toDomProps(props)` spread onto
+ * the REAL focusable control, which here is the `<Textarea>` inside
+ * `RichTextEditorSurface`, never the wrapper `<div>`s (a non-focusable wrapper
+ * carrying the id would satisfy `document.getElementById` and still leave the
+ * label inert). Only the inline surface receives it; see `domProps` there for
+ * why the dialog's copy must not.
  */
 export function RichTextField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   const { t } = useObjectTranslation();
@@ -120,12 +173,19 @@ export function RichTextField({ value, onChange, field, readonly, error, ...prop
   // Same single read as `TextAreaField`: the field metadata is the only
   // carrier, and this widget is the second consumer the flag always had.
   const showFullscreenButton = Boolean(richField?.mobile_fullscreen);
+
+  // The host plumbing, filtered by the declared whitelist (objectui#3291) so
+  // renderer-only props and authored field-config keys cannot become DOM
+  // attributes. Read the semantic props below off it rather than off `props`
+  // for the same reason `TextAreaField` does: one source, no chance of the
+  // spread and the read disagreeing.
+  const domProps = toDomProps(props);
   // Resolved once and given to BOTH renderings of the editor (objectui#3402) —
   // exactly like `formatLabel` / `hint` / `placeholder` below, and for the same
   // reason. Landing it on the inline surface alone left a disabled rich-text
   // field greyed out next to a live expand button whose dialog committed any
   // edit through `onCommit`. `disabled` also carries the form's `isSubmitting`.
-  const disabled = Boolean(props.disabled);
+  const disabled = Boolean(domProps.disabled);
 
   // Resolved once and handed to BOTH renderings of the editor, so the dialog
   // cannot drift into showing different copy than the inline surface.
@@ -145,7 +205,8 @@ export function RichTextField({ value, onChange, field, readonly, error, ...prop
       rows={rows}
       disabled={readonly || disabled}
       error={error}
-      className={props.className}
+      className={domProps.className}
+      domProps={domProps}
       overlay={
         showFullscreenButton && (
           <FullscreenFieldEditor


### PR DESCRIPTION
Fixes #4810

## 问题

`RichTextField` 是 `markdown` / `html` / `richtext` 三个注册键共用的同一个 widget,而全文没有 `toDomProps`(grep 计数 0)。可编辑分支只从 `props` 取 `className` / `disabled`,`FormControl`(Radix Slot)下发的 `id` 与 `aria-describedby` 到达组件后就没有任何元素承载:

- 可见 label 的 `for` 指向一个不存在的 id —— 点击 label 到不了编辑框,控件没有 accessible name;
- 表单渲染出的 FormDescription 零消费者 —— 屏幕阅读器从不朗读帮助文本;提交失败时同一条 `aria-describedby` 里的 error message id 也一并丢失。

## probe 读数(卡内读数,已入仓复现)

新增的钉子文件就是卡里那套 probe:真 form renderer + 裸注册,字段带 `description`,数「引用 `…-form-item-description` 的元素个数」,并单独看 label 的 `for` 解析到什么。

| | 修前 | 修后 |
|---|---|---|
| `markdown` editable | `descEl=SET consumers=0 hostIdEl=NONE for=DANGLING` | `descEl=SET consumers=1 hostIdEl=textarea for=RESOLVES` |
| `html` editable | 同上 | 同上 |
| `richtext` editable | 同上 | 同上 |
| 对照组 `text` / `textarea` | `consumers=1 for=RESOLVES`(一直正常) | 不变 |

跑测数字:修前 `18 failed | 3 passed (21)`,修后 `21 passed (21)`。

## 修法

照 #3318 的既定配方:`toDomProps(props)` 铺到**真正可聚焦的控件**上 —— 这里是 `RichTextEditorSurface` 内部的那个 Textarea,而不是外层任何 div(非可聚焦 wrapper 承载 id 能骗过 `getElementById`,label 照样是死的)。

几处落点判断写在代码注释里:

- **只给 inline 那一份 surface**。fullscreen 对话框里渲染的是同一个 surface 组件,给它同一份 domProps 会让两个同时挂载的 Textarea 共用一个 host id;而且 host 的 `aria-describedby` 指的节点在对话框外,modal 打开时被 Radix `aria-hidden` 掉。`TextAreaField` 对同一对 surface 做的是同一个切分。
- **`aria-invalid={!!error}` 留在 spread 之后**。`toDomProps` 是按前缀转发整个 `aria-` 家族的,`FormControl` 自己的 `aria-invalid` 也在 domProps 里;widget 自读 `error` 是 #3318 的 17 个 PASS 项之一,读在最后才保得住这条既有行为。
- **`autoFocus` / `data-testid` 放在 spread 之前**。放在之后会在 inline 那一份上被重新赋成 `undefined` —— 那正是「pass-through 悄悄丢掉自己拿到的键」的写法。
- **`className` 放在 spread 之后**,因为它是 `cn()` **组合**(host 的 className 经 `className` prop 进来),不是让 host 原值顶掉 surface 自己的类。

## 范围

- ⛔ **只读分支一个字符没动** —— 只读那一半的同类读数属于 #4788,机制方向尚未裁决,在这里钉住今天的读数等于把一个还有开放设计问题的缺陷冻结掉。测试文件头部写明了这一点。
- ⛔ 其它 widget 没碰(`slider` / `grid` / `signature` 归 #3318 账本,按它的配方一并修)。
- 改动全部落在 `packages/fields`,无跨包改动。

## 反向验证(先预判后跑)

预判:去掉编辑框元素上的 `{...domProps}` 一行 → 18 条 plumbing 钉子转红,3 条 `aria-invalid='false'` 钉子**保持绿**(它们在修前也是绿的,#3318 的 PASS 项与本次 spread 无关);另外 3 条 required-failure 用例应当只在最后一句 `aria-describedby` 含 message id 上失败,`aria-invalid='true'` 的 `waitFor` 仍应通过。

实跑(先 commit 再变异,变异未提交,`git checkout` 还原):

```
Tests  18 failed | 3 passed (21)
AssertionError: expected 'DANGLING' to be 'RESOLVES'
TestingLibraryElementError: Found a label with the text of: Body, however no form control was found associated to that label.
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
AssertionError: expected [] to have a length of 1 but got +0
AssertionError: expected [ '' ] to include '_r_p_-form-item-description'
AssertionError: expected [ '' ] to include '_r_15_-form-item-message'
```

与预判逐条一致,包括 required-failure 三条只在 message-id 那句红 —— 即 `aria-invalid` 在「修前 / 修后 / 变异后」三态完全相同,#3318 的 PASS 项确认无回归。

(第一次变异写成了 JSX 属性列表里的注释,是 parse error 的假红,已重跑为整行删除。)

## 验证

- `pnpm exec vitest run packages/fields/src/__tests__/richtext-host-plumbing-e2e.test.tsx` → `21 passed (21)`
- `pnpm exec vitest run packages/fields/` → `Test Files 97 passed (97) / Tests 1551 passed (1551)`
- 消费半径扫描(规则跑到哪就扫到哪,不按改动包划线):`plugin-form/ObjectForm.mobileFullscreen`、`plugin-form/EmbeddableForm`、`plugin-detail/inlineEditTypeCoverage`、`plugin-detail/RelatedList.longFormColumns`、`app-shell/richtextSurfaceParity` → `104 passed (104)`
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → `81 successful, 81 total`
- `node scripts/check-control-bytes.mjs` → OK(4316 文件);改动文件另做了越过门禁盲区的自扫(`grep -naP` 控制字符,零命中)
- changeset 三门:`check-changeset-presence` / `check-changeset-fixed` / `check-changeset-no-major` 全绿
- 改动路径 eslint:0 error(2 warning 均为既有 `as any` 写法,与对照测试文件一致)
