### PR TITLE
docs(fields): grid.mdx / location.mdx teach the registered plugin types (#4796)

### DIFF
--- a/content/docs/fields/grid.mdx
+++ b/content/docs/fields/grid.mdx
@@ -177,17 +177,18 @@ For advanced grid features, use the grid plugin (`@object-ui/plugin-grid`):
 // Advanced grid with full features (requires plugin)
 // Keys sit on the node — a `props` envelope is never read by the renderer
 {
-  type: 'plugin:grid',
-  bind: 'items',
-  columns: [...],
-  editable: true,      // Plugin feature: inline editing
-  sortable: true,      // Plugin feature: column sorting
-  filterable: true,    // Plugin feature: filtering
+  type: 'object-grid',   // the registered type name — there is no `plugin:grid`
+  bind: 'items',         // resolves the array from the surrounding data scope
+  columns: [             // spec `ListColumn[]` — each entry is keyed by `field`
+    { field: 'product', label: 'Product' },
+    { field: 'quantity', label: 'Quantity', sortable: false }
+  ],
+  editable: true,               // Plugin feature: inline cell editing
   pagination: { pageSize: 20 }  // Plugin feature: pagination
 }
 ```
 
-**Note**: Features like `editable`, `sortable`, `filterable`, and advanced `pagination` are provided by the `@object-ui/plugin-grid` package, not the basic grid field.
+**Note**: `editable` and `pagination` are read off the node by `@object-ui/plugin-grid`, not by the basic grid field. Sorting and search are **not** node keys: column sorting is on by default and is turned off per column (`{ field, sortable: false }`), and there is no node-level `filterable` — a grid that fetches its own rows declares its query with `objectName` plus `filter` / `sort`.
 
 ## Use Cases
 

--- a/content/docs/fields/location.mdx
+++ b/content/docs/fields/location.mdx
@@ -87,13 +87,18 @@ import { LocationField } from '@object-ui/fields';
 // With map visualization (using map plugin)
 // Keys sit on the node — a `props` envelope is never read by the renderer
 {
-  type: 'plugin:map',
-  bind: 'location',
-  center: location,
-  zoom: 12,
-  markers: [location]
+  type: 'object-map',           // the registered type name — there is no `plugin:map`
+  objectName: 'store',          // the records to plot
+  map: {                        // the declared config input; markers are derived from the data
+    locationField: 'location',  // this page's field, read as { latitude, longitude }
+    titleField: 'name',         // field used as the marker label
+    zoom: 12,                     // initial zoom level
+    center: [37.7749, -122.4194]  // [latitude, longitude]; used when no records match
+  }                               // (with records the view fits to their bounds)
 }
 ```
+
+**Note**: the map plots the records it fetches, so it takes an `objectName` (or an explicit `data` array) rather than a `bind` path, and it derives its markers from those records — a `markers` key on the node is not read. Every marker setting lives under the declared `map` input.
 
 ## Validation
 

--- a/content/docs/fields/location.mdx
+++ b/content/docs/fields/location.mdx
@@ -92,9 +92,11 @@ import { LocationField } from '@object-ui/fields';
   map: {                        // the declared config input; markers are derived from the data
     locationField: 'location',  // this page's field, read as { latitude, longitude }
     titleField: 'name',         // field used as the marker label
-    zoom: 12,                     // initial zoom level
-    center: [37.7749, -122.4194]  // [latitude, longitude]; used when no records match
-  }                               // (with records the view fits to their bounds)
+    zoom: 12,                   // initial zoom level
+    // Initial centre as [latitude, longitude]. Used only when no record
+    // matches — with records the view fits to their bounds instead.
+    center: [37.7749, -122.4194]
+  }
 }
 ```
 


### PR DESCRIPTION
Fixes #4796

## 问题

`content/docs/fields/grid.mdx`（"Full Grid Functionality" 段）教 `type: 'plugin:grid'`，`content/docs/fields/location.mdx`（"With map visualization" 段）教 `type: 'plugin:map'`。这两个字符串全仓没有任何 `ComponentRegistry.register` 命中，照抄示例渲染出的是 OBJUI-001 "Unknown component type" 红框。真实注册名是 `object-grid`（`packages/plugin-grid/src/index.tsx:129`）与 `object-map`（`packages/plugin-map/src/index.tsx:62`）。

只换 type 名会留下一堆渲染器根本不读的死键，所以两段里的**每一个键**都对着对应渲染器的真实读点核过一遍。

## 键核对表

### grid.mdx — `object-grid`

| 键 | 判定 | 真实读点 / 依据 |
|---|---|---|
| `type` | 改名 `plugin:grid` 到 `object-grid` | `plugin-grid/src/index.tsx:129` |
| `bind` | 保留 | `ObjectGrid.tsx:670` `useDataScope(schema.bind)`，命中后走 `provider: 'value'` |
| `columns` | 保留，并把占位 `[...]` 写实 | `ObjectGrid.tsx:813-814` 到 `normalizeColumns`；spec `ListColumn` 的键是 `field` 不是 `name` |
| `editable` | 保留 | `ObjectGrid.tsx:2662 / 2665 / 2672` |
| `pagination.pageSize` | 保留 | `ObjectGrid.tsx:585 / 841 / 851 / 2544` |
| `sortable`（节点级） | **删除** | `schema.sortable` 全仓零读点；内层 data-table 拿到的是硬编码 `sortable: true`（`ObjectGrid.tsx:2652`）。它作为**列级** `ListColumn` 键是真的（`col.sortable`，`1572 / 2176 / 2178`），示例里改写到列上 |
| `filterable`（节点级） | **删除** | `filterable` 在 plugin-grid 整包出现 0 次（`grep -c` = 0）。`filterableFields` 只属于另一个 block `list-view`（`plugin-list/src/ListView.tsx:2111`） |

### location.mdx — `object-map`

| 键 | 判定 | 真实读点 / 依据 |
|---|---|---|
| `type` | 改名 `plugin:map` 到 `object-map` | `plugin-map/src/index.tsx:62` |
| `objectName` | **新增** | 注册表 required input（`index.tsx:67`）；`ObjectMap.tsx:100-103` `getDataConfig` |
| `map` | **新增**（声明过的配置 input） | 注册表 input（`index.tsx:68`）；`ObjectMap.tsx:194 / 228-238` `getMapConfig` 分支 2 |
| `bind` | **删除** | ObjectMap 里没有任何 `useDataScope` 调用 —— 全文件搜 `bind` 只命中两处注释 |
| `markers` | **删除** | `schema.markers` 全仓零读点；markers 是从抓到的记录**派生**的（`ObjectMap.tsx:521-551`） |
| `zoom` | 移到 `map` 下 | 顶层 `schema.zoom` 只在 `getMapConfig` 分支 1 被读（`ObjectMap.tsx:221`），而分支 1 要求节点上同时有 `latitudeField`/`locationField`；`map.zoom` 走分支 2，落到 `initialViewState.zoom`（`558 / 595 / 611`） |
| `center` | 移到 `map` 下，并注明语义 | 同上（`ObjectMap.tsx:222` 对 `593-594`）。`center` 只在**没有记录命中**时作初始中心；有记录时视野按 marker 的 bounds 自适应（`ObjectMap.tsx:590-612`） |

## Probe 读数（真实 SchemaRenderer + 真实注册表）

临时 probe：模块作用域直接 `import '@object-ui/plugin-grid'` / `'@object-ui/plugin-map'` 触发真实注册，经真实 SchemaRenderer 渲染。跑完已删除，本 PR 不含 probe 文件。

注册表解析：

```
@@REG plugin:grid  -> NOT REGISTERED
@@REG plugin:map   -> NOT REGISTERED
@@REG object-grid  -> RESOLVED
@@REG object-map   -> RESOLVED
```

**修前**（两段的原样 schema）：

```
@@PROBE BEFORE grid.mdx type=plugin:grid
  OBJUI-001=true
  head="Unknown component type: plugin:grid ... (OBJUI-001)"
@@PROBE BEFORE location.mdx type=plugin:map
  OBJUI-001=true
  head="Unknown component type: plugin:map ... (OBJUI-001)"
```

**修后**（本 PR 落地的示例逐字节同形）：

```
@@PROBE AFTER grid.mdx type=object-grid
  OBJUI-001=false
  testids=["row-expand-button","primary-field-link","row-expand-button","primary-field-link"]
  head="#ProductQuantity1OpenWidget22OpenGadget5"

@@PROBE AFTER location.mdx type=object-map
  OBJUI-001=false
  testids=["maplibre-canvas","map-geolocate","probe-marker","probe-marker"]
  markers=["-122.4194,37.7749","-74.006,40.7128"]
  viewstate={"longitude":-98.2127,"latitude":39.24385,"zoom":12}
```

两段都超过了"无 OBJUI-001 + 解析到正确 renderer"的下限，跑到了真实产物：grid 渲染出 `Product` / `Quantity` 表头与 `Widget 2` / `Gadget 5` 两行（证明 `bind` 与 `columns[].field` 真的被读）；map 挂出两个 marker，坐标正是记录 `location` 字段里的经纬度（证明 `map.locationField` 真的被读），`viewstate.zoom=12` 证明 `map.zoom` 落到了地图上。

**死键反证**（同一个 probe，同一个可用 dataSource，只是把旧键原样挂到**真实** type 上）：

```
@@PROBE AUDIT object-map with only bind/center/zoom/markers
  OBJUI-001=false
  markers=[]
  viewstate={"longitude":0,"latitude":0,"zoom":10}
```

零 marker，且视野是**默认**配置（`zoom: 10`、`center: [0, 0]`），而节点上明明写着 `zoom: 12` / `center: [37.7749, -122.4194]`。这是"这些键确实不被读"的直接读数，不是只靠 grep。

### 证据边界（不谎报）

- `react-map-gl/maplibre` 在 probe 里是 stub（本仓既有测试同款做法，happy-dom 没有 WebGL）。所以"地图真的画出瓦片"没有被断言；被断言的是 ObjectMap 组件挂载成功、数据抓取跑通、marker 数量与坐标正确、initialViewState 正确。
- grid 的 `bind: 'items'` 需要外层数据作用域提供 `items`（文档语境里就是记录表单的数据）。probe 用 `SchemaRendererProvider` 的 `dataSource` 供了这个作用域；裸渲染（无作用域、无 `objectName`）时 ObjectGrid 自己报 "Object name required for data fetching"，那是它自己的诊断，不是 OBJUI-001。

## 门禁

- `node scripts/check-doc-links.mjs` 到 `Links are valid across 13 scan roots.`
- `pnpm exec vitest run scripts/ --maxWorkers=2` 到 `Test Files 45 passed (45)` / `Tests 1026 passed (1026)`（含 `doc-version-claims.test.ts`、`check-doc-links.test.ts`）
- `node scripts/check-control-bytes.mjs` 到 OK（4316 个文件）；改动文件另做了越过门禁盲区的自扫，无控制字节
- `node scripts/check-changeset-presence.mjs` 到 `No source of a released package changed in this range, so no changeset is owed.` —— **本 PR 不欠 changeset，是实测判的**（纯 `content/docs/**`，没碰任何发版包的 `src/`）
- 改动路径 eslint：`content/docs/**/*.mdx` 不在 eslint 配置覆盖内（`File ignored because no matching configuration was supplied`，exit 0）

## 范围

- 只改这两个文件的这两段。#4786 / PR #4800 刚拆的 `props` 信封那两行注释零触碰。
- 教学面 prose 没有 catalog 侧 #4616 那样的 "不许出现 OBJUI-001" 棘轮 —— 这是结构性缺口，不在本单范围内处理。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_