### PR TITLE
chore(tsconfig): 删根 tsconfig.json 六条死 paths,并把守卫扩到这张表 (#4804)

### DIFF
--- a/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
+++ b/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
@@ -39,10 +39,35 @@ import { fileURLToPath } from 'node:url';
  * naming that entry, while the two coverage cases stay green (a well-formed
  * entry is still parsed).
  *
- * Deliberately NOT in scope: `tsconfig.json`'s `paths` carries dead entries of
- * the same shape for three of the four names. That file is outside this issue's
- * surface and belongs to whoever triages it; this guard reads the alias table
- * only, and says so rather than half-covering a second file.
+ * ---------------------------------------------------------------------------
+ * objectui#4804 — this guard now reads TWO tables.
+ *
+ * The paragraph that used to sit here said `tsconfig.json`'s `paths` carried
+ * dead entries of the same shape for three of the four names, and left them to
+ * whoever triaged it. #4804 is that triage: it deleted the six lines
+ * (`@object-ui/engine`, `@object-ui/ui`, `@object-ui/renderer`, each in bare
+ * and `/*`-suffixed form) and folded the table in here instead of starting a
+ * second guard file — one guard watching both tables, as PR #4802 suggested.
+ * The file name keeps its `3944` provenance; each `describe` names its table.
+ *
+ * Note the two dead sets are NOT the same: `@object-ui/plugin-aggrid` was in
+ * the alias table and never in `paths`, so the pins below differ on purpose.
+ *
+ * Why `tsconfig.json` is read as TEXT too, when it looks like plain JSON: it is
+ * JSONC. Two block comments sit in `compilerOptions` (at :9 and :16 on the
+ * post-#4804 file), and `JSON.parse` throws on them — measured: `Expected
+ * double-quoted property name in JSON at position 187`. The alternative is to
+ * strip comments first, i.e. hand-roll a second parser that has to respect
+ * string literals to avoid mangling a target that contains comment-like
+ * characters. One brace-balanced text read, shared by both tables, is less
+ * surface than that, and keeps the two halves of this file the same shape.
+ *
+ * Reverse verification for the `paths` half (direction predicted before
+ * running — plain RED again, and for the same reason: the table is the sole
+ * input, so an added bad entry can only add a finding): add
+ * `"@object-ui/ghost-4804": ["packages/ghost-4804/src"]` and the
+ * "maps to a path that exists" case fails naming that entry, while the two
+ * coverage cases and both pins stay green.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -57,31 +82,46 @@ interface AliasEntry {
 }
 
 /**
- * The text of the `resolve.alias` object literal, brace-balanced from its
- * opening `{` so a nested object in a future entry cannot truncate it.
+ * The text of an object literal, brace-balanced from its opening `{` so a
+ * nested object in a future entry cannot truncate it. Shared by both tables.
  */
-function aliasBlock(): string {
-  const header = /alias:\s*\{/.exec(configSource);
-  if (!header) throw new Error('vitest.config.mts has no resolve.alias object');
+function balancedObjectLiteral(source: string, header: RegExp, what: string): string {
+  const match = header.exec(source);
+  if (!match) throw new Error(`${what}: object literal not found`);
 
-  const open = header.index + header[0].length - 1;
+  const open = match.index + match[0].length - 1;
   let depth = 0;
-  for (let i = open; i < configSource.length; i += 1) {
-    const ch = configSource[i];
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
     if (ch === '{') depth += 1;
     else if (ch === '}') {
       depth -= 1;
-      if (depth === 0) return configSource.slice(open + 1, i);
+      if (depth === 0) return source.slice(open + 1, i);
     }
   }
-  throw new Error('vitest.config.mts: resolve.alias object is never closed');
+  throw new Error(`${what}: object literal is never closed`);
 }
 
-/** `//` line comments stripped, so they cannot be miscounted as entries. */
-const block = aliasBlock()
-  .split('\n')
-  .filter((line) => !/^\s*\/\//.test(line))
-  .join('\n');
+/**
+ * Comment LINES stripped, so they cannot be miscounted as entries — both the
+ * `//` form and a block comment occupying a whole line.
+ *
+ * Only whole lines: an entry hidden inside a multi-line block comment is still
+ * read as live and then fails the existence check. That is the safe direction
+ * for a guard (fail loud, never silently drop a key), and the fix is the one
+ * this file argues for anyway — delete a dead entry rather than commenting it
+ * out.
+ */
+function withoutCommentLines(source: string): string {
+  return source
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line) && !/^\s*\/\*.*\*\/\s*$/.test(line))
+    .join('\n');
+}
+
+const block = withoutCommentLines(
+  balancedObjectLiteral(configSource, /alias:\s*\{/, 'vitest.config.mts: resolve.alias')
+);
 
 const ENTRY = /(['"])([^'"]+)\1\s*:\s*path\.resolve\(\s*__dirname\s*,\s*(['"])([^'"]+)\3\s*\)/g;
 
@@ -149,5 +189,172 @@ describe('objectui#3944 — root vitest.config.mts alias table', () => {
     expect(specifiers).not.toContain('@object-ui/renderer');
     expect(specifiers).not.toContain('@object-ui/plugin-aggrid');
     expect(specifiers).not.toContain('@object-ui/ui');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// objectui#4804 — the second table: root `tsconfig.json`'s `compilerOptions.paths`.
+// ---------------------------------------------------------------------------
+
+const TSCONFIG_PATH = path.join(repoRoot, 'tsconfig.json');
+const tsconfigSource = fs.readFileSync(TSCONFIG_PATH, 'utf8');
+
+const pathsBlock = withoutCommentLines(
+  balancedObjectLiteral(tsconfigSource, /"paths"\s*:\s*\{/, 'tsconfig.json: compilerOptions.paths')
+);
+
+/** `"<specifier>": ["<target>", ...]` — a `paths` value is always an array. */
+const PATHS_ENTRY = /(['"])([^'"]+)\1\s*:\s*\[([^\]]*)\]/g;
+const QUOTED = /(['"])([^'"]+)\1/g;
+
+/**
+ * Flattened to one row per target: `paths` allows several fallback targets per
+ * specifier, and every one of them is a claim that has to hold. Reuses
+ * `AliasEntry` — a `paths` mapping is the same (specifier, target) pair.
+ */
+const pathEntries: AliasEntry[] = [...pathsBlock.matchAll(PATHS_ENTRY)].flatMap((entry) =>
+  [...entry[3].matchAll(QUOTED)].map((target) => ({
+    specifier: entry[2],
+    target: target[2],
+  }))
+);
+
+/**
+ * A `paths` target may carry TypeScript's `*` substitution token
+ * (`packages/core/src/*`), which is a pattern, not a path — `existsSync` on it
+ * is always false. What has to exist is the prefix it substitutes into, and
+ * that prefix has to be a directory for the substitution to mean anything.
+ */
+function resolveTarget(target: string): { abs: string; isPattern: boolean } {
+  const star = target.indexOf('*');
+  if (star === -1) return { abs: path.resolve(repoRoot, target), isPattern: false };
+
+  return {
+    abs: path.resolve(repoRoot, target.slice(0, star).replace(/\/$/, '')),
+    isPattern: true,
+  };
+}
+
+/**
+ * objectui#4820 — two entries whose targets do not exist and which #4804
+ * deliberately did NOT delete. They are dead for a different reason: they point
+ * into `node_modules` for packages that are not dependencies of this workspace
+ * at all (`node_modules/@objectstack/` holds only `spec`; neither name appears
+ * in any package.json), so no install can ever produce them. Whether the fix is
+ * to drop the lines or to add the dependencies AGENTS.md section 7 prescribes
+ * is a maintainer call, not a rider on #4804's six-line deletion.
+ *
+ * A shrink-only ratchet, not an exemption. The list may not grow — a NEW dead
+ * target is still red — and the pin below asserts each listed entry is still
+ * declared AND still missing, so resolving #4820 either way turns this file red
+ * until the list is emptied with it.
+ */
+const KNOWN_MISSING_TARGETS: readonly string[] = [
+  '@objectstack/plugin-msw',
+  '@objectstack/objectql',
+];
+
+/** The six lines #4804 removed, in both spellings. */
+const REMOVED_BY_4804 = [
+  '@object-ui/engine',
+  '@object-ui/engine/*',
+  '@object-ui/ui',
+  '@object-ui/ui/*',
+  '@object-ui/renderer',
+  '@object-ui/renderer/*',
+];
+
+describe('objectui#4804 — root tsconfig.json compilerOptions.paths table', () => {
+  it('parses a plausible table (a zero-hit parse would make every case below vacuous)', () => {
+    // Same empty-fixture trap as the alias half: if the file is reformatted and
+    // the regex stops matching, `pathEntries` becomes [] and every case below
+    // passes while checking nothing.
+    expect(pathEntries.length).toBeGreaterThanOrEqual(10);
+    expect(pathEntries.map((e) => e.specifier)).toContain('@object-ui/core');
+  });
+
+  it('parses EVERY key in the block, so no entry can dodge the existence check', () => {
+    // Coverage, not style. A key whose value is written in some other form — a
+    // bare string instead of an array, or an empty array — would be skipped by
+    // PATHS_ENTRY and silently escape.
+    const keys = [...pathsBlock.matchAll(/^\s*(['"])([^'"]+)\1\s*:/gm)].map((m) => m[2]);
+
+    expect(
+      keys.filter((key) => !pathEntries.some((e) => e.specifier === key)),
+      'These `paths` keys are not written as an array of at least one quoted repo-relative ' +
+        'target, so the target-exists check below never sees them. Use that form, or teach this ' +
+        'test the new one.'
+    ).toEqual([]);
+    expect(new Set(pathEntries.map((e) => e.specifier)).size).toBe(keys.length);
+  });
+
+  it.each(pathEntries.filter((e) => !KNOWN_MISSING_TARGETS.includes(e.specifier)))(
+    '$specifier maps to a path that exists ($target)',
+    ({ specifier, target }) => {
+      const { abs, isPattern } = resolveTarget(target);
+
+      expect(
+        fs.existsSync(abs),
+        `paths['${specifier}'] maps to ${target}, which does not exist in the workspace. A dead ` +
+          'mapping never fails a build — nothing resolves through it — it just reads as if the ' +
+          'package were wired up (objectui#4804). Drop the entry, or add the package.'
+      ).toBe(true);
+
+      if (isPattern) {
+        expect(
+          fs.statSync(abs).isDirectory(),
+          `paths['${specifier}'] substitutes '*' into ${target.replace(/\*$/, '')}, which exists ` +
+            'but is not a directory, so no deep import can resolve through it.'
+        ).toBe(true);
+      }
+    }
+  );
+
+  it('maps an extension-less target to a directory, not a stray file', () => {
+    // `@object-ui/console` legitimately targets a single `.ts` file; every
+    // other non-pattern entry is a package `src/` root. Existence alone would
+    // accept a file where a directory is meant.
+    const wrongKind = pathEntries.filter(({ specifier, target }) => {
+      if (KNOWN_MISSING_TARGETS.includes(specifier)) return false;
+      const { abs, isPattern } = resolveTarget(target);
+      if (isPattern || path.extname(target) !== '') return false;
+      return fs.existsSync(abs) && !fs.statSync(abs).isDirectory();
+    });
+
+    expect(wrongKind.map((e) => e.specifier)).toEqual([]);
+  });
+
+  it('no longer carries the six dead engine/ui/renderer entries', () => {
+    // Named explicitly, for the same reason as the alias half: the generic
+    // check above would also go green if someone "fixed" these by creating
+    // empty `packages/<name>/src` directories. Note `@object-ui/plugin-aggrid`
+    // is absent here on purpose — it was in the alias table, never in `paths`.
+    const specifiers = pathEntries.map((e) => e.specifier);
+
+    for (const dead of REMOVED_BY_4804) {
+      expect(
+        specifiers,
+        `objectui#4804 removed paths['${dead}'] because its target never existed. Re-adding it ` +
+          'needs the package to exist first.'
+      ).not.toContain(dead);
+    }
+  });
+
+  it('the objectui#4820 carve-out still describes exactly the entries it was written for', () => {
+    const declared = pathEntries.filter((e) => KNOWN_MISSING_TARGETS.includes(e.specifier));
+
+    expect(
+      [...new Set(declared.map((e) => e.specifier))].sort(),
+      'KNOWN_MISSING_TARGETS names an entry that is no longer in tsconfig.json. If objectui#4820 ' +
+        'was resolved by deleting the line, delete it from the carve-out too.'
+    ).toEqual([...KNOWN_MISSING_TARGETS].sort());
+
+    const nowResolving = declared.filter((e) => fs.existsSync(resolveTarget(e.target).abs));
+
+    expect(
+      nowResolving.map((e) => e.specifier),
+      'A carved-out target now exists, so the objectui#4820 carve-out is obsolete for it — drop ' +
+        'it from KNOWN_MISSING_TARGETS so the entry is guarded like every other one.'
+    ).toEqual([]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,12 +31,6 @@
       "@object-ui/sdui-parser/*": ["packages/sdui-parser/src/*"],
       "@object-ui/protocol": ["packages/core/src"],
       "@object-ui/protocol/*": ["packages/core/src/*"],
-      "@object-ui/engine": ["packages/engine/src"],
-      "@object-ui/engine/*": ["packages/engine/src/*"],
-      "@object-ui/ui": ["packages/ui/src"],
-      "@object-ui/ui/*": ["packages/ui/src/*"],
-      "@object-ui/renderer": ["packages/renderer/src"],
-      "@object-ui/renderer/*": ["packages/renderer/src/*"],
       "@objectstack/plugin-msw": ["node_modules/@objectstack/plugin-msw/src/index.ts"],
       "@objectstack/objectql": ["node_modules/@objectstack/objectql/src/index.ts"],
       "@object-ui/console": ["apps/console/plugin.ts"]


### PR DESCRIPTION
Fixes #4804

## 做了什么

1. 删掉根 `tsconfig.json` `compilerOptions.paths` 里的六行(实读为 :34-:39):`@object-ui/engine`、`@object-ui/engine/[star]`、`@object-ui/ui`、`@object-ui/ui/[star]`、`@object-ui/renderer`、`@object-ui/renderer/[star]`(`[star]` 即通配符 `*`,下同)。目标 `packages/{engine,ui,renderer}/src` 三个目录在 workspace 里都不存在。
2. 扩展 `scripts/__tests__/vitest-config-alias-targets-3944.test.ts`,让它顺带读 tsconfig 的 paths 表,复用它已有的「每个声明目标必须存在」断言 —— 这是 PR #4802 的 dev 自己给出的完成态建议,一个守卫盯两张表。

`@object-ui/plugin-aggrid` **不在**本次删除之列:它只在 vitest alias 表里出现过,从来没进过 `paths`。两张表的死条目集刻意不同,两侧的钉子也就不同,测试注释里写明了。

## 删前的消费面核实

**三个目标目录确不存在**:

```
$ ls -d packages/engine packages/ui packages/renderer
ls: cannot access 'packages/engine': No such file or directory
ls: cannot access 'packages/ui': No such file or directory
ls: cannot access 'packages/renderer': No such file or directory
```

**六个 specifier 全仓零消费**(带引号精确名,裸名与 `/` 子路径两种形态都扫):

```
$ grep -rn --exclude-dir=node_modules --exclude=pnpm-lock.yaml -F -e "'@object-ui/engine'" -e '"@object-ui/engine"' .
(除 tsconfig.json 本身与守卫测试的反向断言外,零命中;ui / renderer 同)
```

扫描器反查证伪 —— 同一把 grep 对 `@object-ui/core`:**559 个文件 / 637 行命中**。所以零命中是事实,不是 grep 写错了。

**tsconfig 特有的消费面(与 vitest 表不同,额外查了 extends 链)**:全仓 91 个 `tsconfig*.json`,其中 74 个 `extends` 到根 `../../tsconfig.json`,因此这张 paths 表**确实**被广泛继承 —— 但继承者里没有任何一个引用这六条:

```
$ grep -rn --exclude-dir=node_modules -E 'packages/(engine|ui|renderer)(/|"|'"'"'|$)' .
./tsconfig.json:34-39            (即本次删掉的六行)
./scripts/__tests__/vitest-config-alias-targets-3944.test.ts:11-13   (#3944 的历史说明注释)
```

即整仓对这三个目录路径的引用,只有这六行自己。

## 爆炸半径:类型解析未伤

删的是共享基建,所以按硬要求跑了仓根全量 type-check:

```
$ pnpm exec turbo run type-check --concurrency=2
 Tasks:    81 successful, 81 total
  Time:    5m54.514s
```

`scripts/` 自己的程序(本次改的测试文件归它管)另跑:

```
$ pnpm type-check:scripts        →  exit=0
```

## 守卫怎么写的

- **解析策略:文本解析,不 `JSON.parse`。** 根 `tsconfig.json` 实际是 **JSONC** —— `compilerOptions` 里有两处块注释,`JSON.parse` 直接抛:`Expected double-quoted property name in JSON at position 187`。备选是「先剥注释再 parse」,那等于手搓第二个 parser 且必须正确处理字符串字面量。改成沿用本文件既有的花括号配平文本读法:一套读法喂两张表,面更小,两半形状也对称。原因写进了文件头注释。
- **通配符不是路径。** `packages/core/src/[star]` 里的 `[star]` 是替换符,`existsSync` 对它恒为 false。存在性检查对模式项改判**替换前缀**,并额外要求前缀是目录(否则深层 import 无从解析)。
- **断言结构照抄既有**:逐条存在性 + 「块内每个 key 都被解析覆盖」(否则写成别的形式的条目会静默逃逸) + 非空防陷阱(`>= 10` 条且必含 `@object-ui/core`,防重排后正则失配变成「零条目全绿」的空 fixture 陷阱)。

## 范围外发现:同表另有 2 条死条目,已单开卡,未在本 PR 删

`@objectstack/plugin-msw` 与 `@objectstack/objectql` 指向 `node_modules/@objectstack/[包名]/src/index.ts`,两个目标也不存在 —— 而且不是「装了但布局不同」:这两个包整个不在依赖图里(`node_modules/@objectstack/` 只有 `spec`,pnpm store 零命中,38 个 package.json 都没声明)。**成因与本卡的六行不同**(指向 node_modules 而非 workspace 目录),且牵扯「这两个包是不是本该成为依赖」的产品取舍,故按范围纪律未在本 PR 一并删,单开 **#4820** 交维护者定。

它们会让新断言变红,因此进了一条**只准缩短的棘轮豁免名单** `KNOWN_MISSING_TARGETS`,而不是一个口子:

- 名单**不能变长** —— 任何新的死目标照常红;
- 名单里的条目若已从 tsconfig 删掉、或其目标开始存在,守卫也红,强制同步清掉豁免项。

所以 #4820 无论怎么收口,都必须顺手把名单清空,豁免不会烂在那里。

## 反向验证(先预判方向,再实跑)

两次都预判为**纯红**(无反转):paths 表是该断言的唯一输入,加一条坏条目只能**新增**一个 finding,不可能减少 —— 与 alias 那半的既有结论同理。

**A. 注入假条目** `"@object-ui/ghost-4804": ["packages/ghost-4804/src"]`。预判:恰好 1 条红且指名该条,两条覆盖用例与两条钉子全绿。实跑:

```
 × '@object-ui/ghost-4804' maps to a path that exists ('packages/ghost-4804/src')
   → paths['@object-ui/ghost-4804'] maps to packages/ghost-4804/src, which does not exist ...
 Tests  1 failed | 58 passed (59)
```

**B. 把删掉的六行装回去。** 预判:7 条红 —— 6 条存在性 + 「no longer carries the six」那条钉子。实跑:

```
 × '@object-ui/engine' / '@object-ui/engine/[star]' / '@object-ui/ui' / '@object-ui/ui/[star]'
 × '@object-ui/renderer' / '@object-ui/renderer/[star]'  maps to a path that exists
 × no longer carries the six dead engine/ui/renderer entries
 Tests  7 failed | 57 passed (64)
```

两次预判与实跑逐条吻合。变异均在 commit 之后进行、`git checkout [分支] -- tsconfig.json` 还原,未提交;还原后复跑 58 passed (58),工作树 diff 为空。

## 测试与门禁

```
$ pnpm exec vitest run scripts/__tests__/vitest-config-alias-targets-3944.test.ts --reporter=verbose
  Test Files  1 passed (1)
       Tests  58 passed (58)

$ pnpm exec vitest run scripts/__tests__/        # 消费半径整扫
  Test Files  45 passed (45)
       Tests  1041 passed (1041)

$ node scripts/check-control-bytes.mjs
  ✅ check-control-bytes: OK (scanned 4320 tracked text file(s); skipped 85 binary)

$ pnpm exec eslint scripts/__tests__/vitest-config-alias-targets-3944.test.ts   → exit=0
```

**changeset 三门:不欠**,按 presence 门实测判(与 PR #4802 先例一致):

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with ac600e5d2 (merge-base with origin/main): 2 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

改的两个文件是仓根配置与 `scripts/` 下的测试,都不在发版包的 `src/` 里,门禁自己判定无需声明。

Related: #3944 / PR #4802、#3904 / PR #3942、#4820(本 PR 新开的范围外卡)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_