### PR TITLE
docs(skills): auth-permissions 的 PermissionProvider 配置示例改成导出类型的真实形状,并补齐 roles 缺失时的防炸

### DIFF
--- a/.changeset/spotty-pugs-refuse.md
+++ b/.changeset/spotty-pugs-refuse.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/permissions': patch
+---
+
+Permission reads no longer throw on a config that omits the required `roles`
+member. `ObjectPermissionConfig.roles` is declared required, but a config
+arriving from plain JS or from metadata loaded at runtime can omit it, and
+`objectConfig.roles[roleName]` then threw a `TypeError` out of `check()` and
+took the whole render down — the failure mode the evaluator's own note already
+forbids (`a permission check must never be able to crash a render`).
+
+`evaluatePermission` now treats a missing `roles` as granting nothing: no role
+resolves, and the call returns the ordinary `allowed: false` denial. The
+`publicAccess` channel is evaluated before this and is unchanged. The three
+matching reads in `PermissionProvider` (`checkField`, `getFieldPermissions`,
+`getRowFilter`) are guarded the same way and keep their own documented
+defaults — the guard removes the crash, not the semantics.

--- a/packages/permissions/src/PermissionProvider.tsx
+++ b/packages/permissions/src/PermissionProvider.tsx
@@ -57,8 +57,12 @@ export function PermissionProvider({
       const objectConfig = permissions.find((p) => p.object === object);
       if (!objectConfig) return true; // No config means no restrictions
 
+      // Same guard as `evaluator.ts` (objectui#4812): a config that omits the
+      // required `roles` must deny or fall through, never throw. Here the
+      // fall-through lands on this function's own documented default (allow),
+      // which is unchanged — the guard removes the crash, not the semantics.
       for (const role of userRoles) {
-        const roleConfig = objectConfig.roles[role];
+        const roleConfig = objectConfig.roles?.[role];
         if (roleConfig?.fieldPermissions) {
           const fieldPerm = roleConfig.fieldPermissions.find((fp) => fp.field === field);
           if (fieldPerm) {
@@ -87,7 +91,9 @@ export function PermissionProvider({
 
       const fieldPerms: FieldLevelPermission[] = [];
       for (const role of userRoles) {
-        const roleConfig = objectConfig.roles[role];
+        // Missing `roles` reports no restrictions rather than throwing
+        // (objectui#4812).
+        const roleConfig = objectConfig.roles?.[role];
         if (roleConfig?.fieldPermissions) {
           fieldPerms.push(...roleConfig.fieldPermissions);
         }
@@ -103,7 +109,9 @@ export function PermissionProvider({
       if (!objectConfig) return undefined;
 
       for (const role of userRoles) {
-        const roleConfig = objectConfig.roles[role];
+        // Missing `roles` reports no row filter rather than throwing
+        // (objectui#4812).
+        const roleConfig = objectConfig.roles?.[role];
         if (roleConfig?.rowPermissions?.length) {
           return roleConfig.rowPermissions[0].filter;
         }

--- a/packages/permissions/src/__tests__/skill-guide-permission-config.test.tsx
+++ b/packages/permissions/src/__tests__/skill-guide-permission-config.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4812 — the `PermissionProvider` setup example in
+ * `skills/objectui/guides/auth-permissions.md` had four shapes that no
+ * exported type in `@object-ui/types` accepts, and copying it made `check()`
+ * throw rather than deny:
+ *
+ *   1. `roles[].permissions` — retired with `RoleDefinition` in objectui#4288.
+ *   2. `fieldPermissions` / `rowPermissions` at the top level of a permission
+ *      entry instead of nested under `roles.<roleName>`, with the required
+ *      `roles` member absent entirely. This is the one that threw: the
+ *      evaluator read `objectConfig.roles[roleName]` off `undefined`.
+ *   3. `RowLevelPermission.filter` given as an object; it is a `string`.
+ *   4. `FieldLevelPermission.roles` — that type has no `roles` member.
+ *
+ * The suite has three halves, after PR #4792:
+ *
+ *   - COMPILE-TIME. The example below is real code, annotated with the real
+ *     exported types and compiled by this package's `tsconfig.test.json`.
+ *     This is the only half that can catch a wrong *value* on a legal key
+ *     (defect 3, the object-valued `filter`) — no key-name check can see it.
+ *   - DOC-SAMENESS. The same lines are lifted out of this file by marker and
+ *     asserted to appear, contiguously, in the guide. Without this half the
+ *     compile-time half only type-checks a snippet nobody ships.
+ *   - BEHAVIOUR. The example is fed to the real evaluator and the real
+ *     provider, pinning that the documented config denies rather than throws,
+ *     and that `filter` comes back verbatim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ObjectPermissionConfig, RoleDefinition } from '@object-ui/types';
+import { evaluatePermission } from '../evaluator';
+import { PermissionProvider } from '../PermissionProvider';
+import { usePermissions } from '../usePermissions';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+const GUIDE = path.join(repoRoot, 'skills/objectui/guides/auth-permissions.md');
+
+// --- 8< --- guide example begin --- 8< ---
+// A role definition carries identity and inheritance only. Its grants live in
+// `ObjectPermissionConfig.roles` below, keyed by object — that is the single
+// wired home for "what may this role do".
+const roles: RoleDefinition[] = [
+  { name: 'admin', label: 'Administrator' },
+  { name: 'viewer', label: 'Viewer', inherits: ['base'] },  // Role inheritance
+];
+
+const permissions: ObjectPermissionConfig[] = [
+  {
+    object: 'contacts',
+    publicAccess: ['read'],  // Public actions (no auth needed)
+    // `roles` is required, and it is the level that decides *who* a rule
+    // applies to. Field and row rules nest under the role name; they carry
+    // no `roles` member of their own.
+    roles: {
+      admin: {
+        actions: ['create', 'read', 'update', 'delete', 'export'],
+      },
+      viewer: {
+        actions: ['read'],
+        // Only admin sees salary: the restriction is declared on the role
+        // it restricts, and admin simply has no entry for the field.
+        fieldPermissions: [{ field: 'salary', read: false, mask: '****' }],
+      },
+      owner: {
+        actions: ['read', 'update', 'delete'],
+        // `filter` is a string, and it is handed back to you verbatim.
+        rowPermissions: [
+          { filter: 'ownerId = ${user.id}', actions: ['update', 'delete'] },
+        ],
+      },
+    },
+  },
+  {
+    object: 'orders',
+    roles: {
+      admin: { actions: ['create', 'read', 'update', 'delete'] },
+      viewer: { actions: ['read'] },
+    },
+  },
+];
+// --- 8< --- guide example end --- 8< ---
+
+const BEGIN = '// --- 8< --- guide example begin --- 8< ---';
+const END = '// --- 8< --- guide example end --- 8< ---';
+
+/** The example above, lifted from this file's own source. */
+function exampleLines(): string[] {
+  const self = fs.readFileSync(fileURLToPath(import.meta.url), 'utf8').split('\n');
+  const from = self.findIndex((l) => l.trim() === BEGIN);
+  const to = self.findIndex((l) => l.trim() === END);
+  expect(from).toBeGreaterThan(-1);
+  expect(to).toBeGreaterThan(from);
+  return self.slice(from + 1, to);
+}
+
+describe('objectui#4812 — the guide example is the shape the types declare', () => {
+  it('is published verbatim in the guide (contiguous lines)', () => {
+    const guide = fs.readFileSync(GUIDE, 'utf8').split('\n').map((l) => l.trimEnd());
+    const want = exampleLines().map((l) => l.trimEnd());
+
+    const start = guide.findIndex((l) => l === want[0]);
+    expect(
+      start,
+      `first line of the pinned example not found in ${path.relative(repoRoot, GUIDE)}`,
+    ).toBeGreaterThan(-1);
+    expect(guide.slice(start, start + want.length)).toEqual(want);
+  });
+
+  it('leaves none of the four retired/mis-levelled shapes in the guide example', () => {
+    const want = exampleLines().join('\n');
+    // 1: no role-direct grants. 4: no `roles` member on a field rule.
+    expect(want).not.toMatch(/permissions:\s*\{/);
+    expect(want).not.toMatch(/field:.*roles:/);
+    // 2: the required `roles` member is present on every entry.
+    expect(permissions.every((p) => p.roles !== undefined)).toBe(true);
+    // 3: every `filter` is a string, never an object.
+    const filters = permissions.flatMap((p) =>
+      Object.values(p.roles).flatMap((r) => r.rowPermissions ?? []),
+    );
+    expect(filters.length).toBeGreaterThan(0);
+    for (const rp of filters) expect(typeof rp.filter).toBe('string');
+  });
+
+  it('denies instead of throwing on the action the guide itself goes on to check', () => {
+    // The guide derives `canDeleteContacts` from `check('contacts', 'delete')`.
+    // `publicAccess` covers only `read`, so this is the call that used to hit
+    // the unguarded `objectConfig.roles[roleName]`.
+    const asViewer = () =>
+      evaluatePermission({
+        roles,
+        permissions,
+        userRoles: ['viewer'],
+        user: { id: 'v', roles: ['viewer'] },
+        object: 'contacts',
+        action: 'delete',
+      });
+    expect(asViewer).not.toThrow();
+    expect(asViewer().allowed).toBe(false);
+
+    expect(
+      evaluatePermission({
+        roles,
+        permissions,
+        userRoles: ['admin'],
+        user: { id: 'a', roles: ['admin'] },
+        object: 'contacts',
+        action: 'delete',
+      }).allowed,
+    ).toBe(true);
+  });
+
+  it('returns the row filter verbatim — the package interpolates nothing', () => {
+    const result = evaluatePermission({
+      roles,
+      permissions,
+      userRoles: ['owner'],
+      user: { id: 'u-1', roles: ['owner'] },
+      object: 'contacts',
+      action: 'update',
+      record: { ownerId: 'u-1' },
+    });
+    expect(result.allowed).toBe(true);
+    // Not `ownerId = u-1`: the placeholder reaches the caller unresolved.
+    expect(result.rowFilter).toBe('ownerId = ${user.id}');
+  });
+});
+
+function Probe() {
+  const { check, checkField, getFieldPermissions, getRowFilter } = usePermissions();
+  return (
+    <div>
+      <span data-testid="delete">{String(check('contacts', 'delete').allowed)}</span>
+      <span data-testid="read">{String(check('contacts', 'read').allowed)}</span>
+      <span data-testid="salary">{String(checkField('contacts', 'salary', 'read'))}</span>
+      <span data-testid="fieldPerms">{String(getFieldPermissions('contacts').length)}</span>
+      <span data-testid="rowFilter">{String(getRowFilter('contacts'))}</span>
+    </div>
+  );
+}
+
+/**
+ * objectui#4812 task B — a config missing the required `roles` must deny, not
+ * crash. `ObjectPermissionConfig` declares `roles` required, so this fixture
+ * has to be cast: the point is precisely the config the compiler never saw
+ * (plain JS, or metadata loaded at runtime). Both polarities are pinned, since
+ * a guard that denied everything would also pass the first half alone.
+ */
+const ROLELESS = [
+  { object: 'contacts', publicAccess: ['read'] } as unknown as ObjectPermissionConfig,
+];
+
+describe('objectui#4812 — a malformed config denies rather than crashing the render', () => {
+  it('evaluator: non-public action on a roles-less config is a denial, not a TypeError', () => {
+    const call = () =>
+      evaluatePermission({
+        roles,
+        permissions: ROLELESS,
+        userRoles: ['viewer'],
+        user: { id: 'v', roles: ['viewer'] },
+        object: 'contacts',
+        action: 'delete',
+      });
+    expect(call).not.toThrow();
+    expect(call().allowed).toBe(false);
+    expect(call().reason).toContain('delete');
+  });
+
+  it('evaluator: the publicAccess channel still answers first', () => {
+    expect(
+      evaluatePermission({
+        roles,
+        permissions: ROLELESS,
+        userRoles: ['viewer'],
+        user: { id: 'v', roles: ['viewer'] },
+        object: 'contacts',
+        action: 'read',
+      }).allowed,
+    ).toBe(true);
+  });
+
+  it('provider: every read survives a roles-less config', () => {
+    render(
+      <PermissionProvider roles={roles} permissions={ROLELESS} userRoles={['viewer']}>
+        <Probe />
+      </PermissionProvider>,
+    );
+    expect(screen.getByTestId('delete').textContent).toBe('false');
+    expect(screen.getByTestId('read').textContent).toBe('true');
+    // `checkField` / `getFieldPermissions` / `getRowFilter` keep their own
+    // documented defaults (allow / none / none); the guard removed the crash,
+    // it did not change what they mean.
+    expect(screen.getByTestId('salary').textContent).toBe('true');
+    expect(screen.getByTestId('fieldPerms').textContent).toBe('0');
+    expect(screen.getByTestId('rowFilter').textContent).toBe('undefined');
+  });
+
+  it('provider: a well-formed config is unaffected by the guard', () => {
+    render(
+      <PermissionProvider roles={roles} permissions={permissions} userRoles={['viewer']}>
+        <Probe />
+      </PermissionProvider>,
+    );
+    expect(screen.getByTestId('delete').textContent).toBe('false');
+    expect(screen.getByTestId('read').textContent).toBe('true');
+    expect(screen.getByTestId('salary').textContent).toBe('false');
+    expect(screen.getByTestId('fieldPerms').textContent).toBe('1');
+  });
+});

--- a/packages/permissions/src/evaluator.ts
+++ b/packages/permissions/src/evaluator.ts
@@ -54,7 +54,16 @@ export function evaluatePermission({
 
   // Check role-based permissions
   for (const roleName of effectiveRoles) {
-    const roleConfig = objectConfig.roles[roleName];
+    // `roles` is declared required on `ObjectPermissionConfig`, but a config
+    // reaching here from JS — or from metadata the type checker never saw —
+    // can omit it, and `undefined[roleName]` is a TypeError, not a denial.
+    // Reading it unguarded therefore let a malformed config crash the render
+    // through every `check()` for a non-public action, which is precisely
+    // what the note below forbids. Guarded, a missing `roles` grants nothing:
+    // no role resolves, the loop falls through, and the function returns the
+    // ordinary `allowed: false` denial. Fail-closed, and the `publicAccess`
+    // early return above still answers first (objectui#4812).
+    const roleConfig = objectConfig.roles?.[roleName];
     if (!roleConfig) continue;
 
     // `actions` is optional in practice: a role config may carry only

--- a/skills/objectui/guides/auth-permissions.md
+++ b/skills/objectui/guides/auth-permissions.md
@@ -125,37 +125,48 @@ const dataSource = new ObjectStackAdapter({
 
 ```typescript
 import { PermissionProvider } from '@object-ui/permissions';
+import type { ObjectPermissionConfig, RoleDefinition } from '@object-ui/types';
 
-const roles = [
-  {
-    name: 'admin',
-    label: 'Administrator',
-    permissions: {
-      contacts: { actions: ['create', 'read', 'update', 'delete', 'export'] },
-      orders: { actions: ['create', 'read', 'update', 'delete'] },
-    },
-  },
-  {
-    name: 'viewer',
-    label: 'Viewer',
-    inherits: ['base'],  // Role inheritance
-    permissions: {
-      contacts: { actions: ['read'] },
-      orders: { actions: ['read'] },
-    },
-  },
+// A role definition carries identity and inheritance only. Its grants live in
+// `ObjectPermissionConfig.roles` below, keyed by object — that is the single
+// wired home for "what may this role do".
+const roles: RoleDefinition[] = [
+  { name: 'admin', label: 'Administrator' },
+  { name: 'viewer', label: 'Viewer', inherits: ['base'] },  // Role inheritance
 ];
 
-const permissions = [
+const permissions: ObjectPermissionConfig[] = [
   {
     object: 'contacts',
     publicAccess: ['read'],  // Public actions (no auth needed)
-    fieldPermissions: [
-      { field: 'salary', roles: ['admin'] },  // Only admin sees salary
-    ],
-    rowPermissions: [
-      { roles: ['owner'], filter: { ownerId: '${user.id}' }, actions: ['update', 'delete'] },
-    ],
+    // `roles` is required, and it is the level that decides *who* a rule
+    // applies to. Field and row rules nest under the role name; they carry
+    // no `roles` member of their own.
+    roles: {
+      admin: {
+        actions: ['create', 'read', 'update', 'delete', 'export'],
+      },
+      viewer: {
+        actions: ['read'],
+        // Only admin sees salary: the restriction is declared on the role
+        // it restricts, and admin simply has no entry for the field.
+        fieldPermissions: [{ field: 'salary', read: false, mask: '****' }],
+      },
+      owner: {
+        actions: ['read', 'update', 'delete'],
+        // `filter` is a string, and it is handed back to you verbatim.
+        rowPermissions: [
+          { filter: 'ownerId = ${user.id}', actions: ['update', 'delete'] },
+        ],
+      },
+    },
+  },
+  {
+    object: 'orders',
+    roles: {
+      admin: { actions: ['create', 'read', 'update', 'delete'] },
+      viewer: { actions: ['read'] },
+    },
   },
 ];
 
@@ -173,6 +184,25 @@ function App() {
   );
 }
 ```
+
+The keys under `roles` are matched against the `userRoles` you pass to the
+provider (after inheritance is expanded through the `roles` array), so a grant
+key such as `owner` above works whether or not it also has a `RoleDefinition`
+entry — the definitions array is read only to expand `inherits`.
+
+### Row filters are returned verbatim — nothing interpolates them
+
+`RowLevelPermission.filter` is a **string**, not a filter object, and
+`@object-ui/permissions` performs no interpolation on it anywhere. `check()`
+returns it as `rowFilter` and `getRowFilter()` returns it unchanged; the
+package has no substitution step at all.
+
+So a placeholder like `${user.id}` is **not** resolved for you. It arrives at
+your code exactly as written, and it is the caller's job either to substitute
+it — using whatever user scope that caller has — or to forward the string to a
+backend that understands the placeholder itself. This is also not a
+`SchemaRenderer` expression, so the expression scope described later in this
+guide does not govern it; the two look alike and are unrelated.
 
 ### usePermissions hook
 


### PR DESCRIPTION
Fixes #4812

## 问题

`skills/objectui/guides/auth-permissions.md` 的「PermissionProvider setup」示例有四处与 `packages/types/src/permissions.ts` 的导出类型不符。基线 `64553a851`(即 PR #4813 落 main 后)逐条实读核过。

| # | 旧写法 | 导出类型的事实 | 后果 |
|---|---|---|---|
| 1 | `roles[].permissions: { contacts: { actions: [...] } }` | `RoleDefinition` 只有 `name` / `label` / `description` / `inherits` / `system`(#4288 退役了 `permissions`) | 写上去不报错也不生效 |
| 2 | `fieldPermissions` / `rowPermissions` 挂在 permissions 条目**顶层**,且整个没写 `roles` | `ObjectPermissionConfig.roles` 是**必填**,两者嵌在它下面 | **照抄即 TypeError** |
| 3 | `filter: { ownerId: '...' }` | `RowLevelPermission.filter` 是 `string`;该类型也没有 `roles` 成员 | 类型不符 |
| 4 | `fieldPermissions: [{ field: 'salary', roles: ['admin'] }]` | `FieldLevelPermission` 只有 `field` / `read` / `write` / `effect` / `mask` | 类型不符 |

第 2 条是会炸的那条:`evaluator.ts:57` 的 `objectConfig.roles[roleName]` 无可选链,`roles` 是 `undefined` 时直接抛。触发路径就是本文档下一段自己教的 `check('contacts', 'delete')` —— `publicAccess: ['read']` 在 L48 提前返回,所以 `read` 侥幸不炸,`delete` / `update` 必炸。

## 改动

### 任务 A · 文档形状(四条逐条)

1. 角色数组删掉 `permissions`,只留身份与继承,并写明授权唯一的生效位置是 `ObjectPermissionConfig.roles`。
2. 补上必填的 `roles`,把 `fieldPermissions` / `rowPermissions` 移进它下面的角色键。
3. `filter` 改成 string(`'ownerId = ${user.id}'`),并新增一节「Row filters are returned verbatim」写清事实(实读核过):`getRowFilter()` 返回 `roleConfig.rowPermissions[0].filter`(`PermissionProvider.tsx:108`)、`check()` 返回 `rowFilter`(`evaluator.ts:78`),两处都**原样**;`@object-ui/permissions` 全包 grep 不到任何插值/替换步骤。所以 `${user.id}` 由调用方按其自身作用域处理,且它**不是** SchemaRenderer 表达式,不归 #4813 那节作用域管辖 —— 这一点与 #4813 正文表格里对该行的判定一致。
4. 删掉 `FieldLevelPermission` 上的 `roles` 键;「只有 admin 看得到 salary」改成把限制声明在被限制的角色(viewer)上,admin 无该字段条目。

另补一句事实:`roles` 下的角色键是拿 `userRoles`(经 `inherits` 展开后)去匹配的,所以示例里的 `owner` 这种授权键有没有对应的 `RoleDefinition` 条目都能生效 —— 角色定义数组只被读来展开 `inherits`。这是把第 3、4 条的 `roles: [...]` 值搬成角色键之后必须交代的一句。

### 任务 B · 防炸(PM 预授权,已做)

条件逐条核过后做了:

- **fail-closed**:`roles` 缺失 → 没有角色解析得到 → 循环走完 → 返回原本的 `allowed: false` 否决,不抛。
- **publicAccess 通道不受影响**:它的提前返回在循环**之上**,顺序未动。
- **下游无 fallback 语义依赖**:全仓 grep,`check(` 周围无 try/catch,无任何 `toThrow` 钉住这个抛错,现有 fixture 全部带 `roles`。

**范围较预授权扩了三处,请 PM 复核**:同一个缺陷在 `PermissionProvider.tsx` 的 `checkField:61` / `getFieldPermissions:90` / `getRowFilter:106` 各有一份完全相同的无可选链读法。只修 evaluator 会让本 PR 号称修好的「check 不该炸掉 render」在本文档同一段教的 `checkField('contacts', 'salary', 'read')` 上照样炸。四处一起补。

**语义上的区别已如实分开写**,没有一律称作 fail-closed:只有 evaluator 那处在做准入判定,才谈得上 fail-closed;`PermissionProvider` 那三处各自的既有默认(allow / 空数组 / undefined)**原样不动** —— 补的是不抛,不是改语义。

## 钉子

新增 `packages/permissions/src/__tests__/skill-guide-permission-config.test.tsx`,照 PR #4792 的三半结构:

- **编译期** —— 示例就是这个文件里的**真代码**,用真的 `RoleDefinition[]` / `ObjectPermissionConfig[]` 标注,由本包 `tsconfig.test.json` 编译(`type-check` 脚本第二条就是它)。这是唯一抓得住第 3 条的一半:合法键上的错误**值**,任何键名检查都看不见。
- **文档同源** —— 同一段代码按 BEGIN/END 标记从本文件源码取出,断言它作为**连续行**出现在 guide 里。没有这一半,上一半就退化成给没人发布的片段做类型检查。
- **行为** —— 把示例喂给真的 evaluator 与真的 provider:`check('contacts','delete')` 对 viewer 否决且不抛、对 admin 放行;`rowFilter` 断言等于 `'ownerId = ${user.id}'` 原文(不是 `ownerId = u-1`),把「不插值」钉成可执行事实。

任务 B 的两极性也在同一文件:配置无 `roles` 时 check 非 public 动作返回 false 不抛 + provider 四个读全部存活;配置有 `roles` 时行为逐项不变。

## 反向验证(四次变异,均先声明预期方向再跑)

反向验证全部在 commit 之后做,还原用 `git checkout claude/issue-4812-auth-doc-config-shape -- 路径`(AGENTS.md §9;⛔ 未用共享 stash 栈),每次还原后 `git status` 空。

**变异 C —— 去掉四处防护(`git checkout 64553a851 -- evaluator.ts PermissionProvider.tsx`)。**
预判:**恰好 2 条红**,且都以 TypeError 形态红 —— evaluator 那条 roleless 否决、provider 那条 roleless 四读;两条对照必须**保持绿** —— publicAccess 提前返回(在循环之上,构造上碰不到)与良构配置那条。
实测 `Tests 2 failed | 6 passed (8)`,红的正是预判那两条:

```
AssertionError: expected [Function call] to not throw an error but
  'TypeError: Cannot read properties of undefined (reading 'viewer')' was thrown
```

两条对照如预判保持绿 —— 这正是「防护没有顺手改掉 publicAccess 语义」的证据。

**变异 B —— 把四条旧形状原样放回被类型检查的示例代码。**
预判:`tsc` 红;错误条数可能少于 4,因为同一对象字面量上 TS 只报最具体的那类(PR #4792 已记过这个坑)。
实测:红(exit 2),**只报 2 条**:

```
error TS2353: ... 'permissions' does not exist in type 'RoleDefinition'.
error TS2353: ... 'fieldPermissions' does not exist in type 'ObjectPermissionConfig'.
```

条目级的多余属性错误把第 3、4 条**盖住了**。所以变异 B 单独跑**证不到**第 3、4 条,如实记下。

**变异 D —— 因此单独测另一半:层级改对(嵌进 `roles` 下的角色键),只保留错的值与错的键。**
预判:仍红,应分别报值类型错与多余属性错。
实测:红(exit 2),两条都出来了:

```
error TS2353: ... 'roles' does not exist in type 'FieldLevelPermission'.
error TS2322: Type '{ ownerId: string; }' is not assignable to type 'string'.
```

B 与 D 合起来,四条形状才**各自**被证明是编译错误。

**变异 A —— 只把 guide 还原成旧文(`git checkout 64553a851 -- 该 md`)。**
预判:**只有 1 条红** —— 文档同源那条;「四条形状都不在示例里」那条读的是本测试文件自己的标记区,guide 怎么改都碰不到它,必须**保持绿**。这个不对称与 #4792 记的是同一个。
实测 `Tests 1 failed | 7 passed (8)`,红的正是文档同源那条:

```
AssertionError: first line of the pinned example not found in
  skills/objectui/guides/auth-permissions.md: expected -1 to be greater than -1
```

## 门禁(实测输出)

| 门 | 结果 |
|---|---|
| `pnpm exec vitest run packages/permissions/` | `Test Files 6 passed (6)` / `Tests 69 passed (69)` |
| 消费面 `plugin-list` + `plugin-detail` + `plugin-form` + `plugin-grid` | `Test Files 241 passed (241)` / `Tests 2516 passed (2516)` |
| app-shell 权限相邻 6 个测试 | `Test Files 6 passed (6)` / `Tests 48 passed (48)` |
| 仓根 `turbo run type-check --concurrency=2` | `Tasks: 81 successful, 81 total` |
| `node scripts/check-doc-links.mjs` | `Links are valid across 13 scan roots.` |
| `node scripts/check-skills-paths.mjs` | `OK (88/89 stated path(s) resolve across 18 guide file(s); 1 baselined).` |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 4320 tracked text file(s); skipped 85 binary).` |
| doc-truth 家族 4 个测试 | `Test Files 4 passed (4)` / `Tests 168 passed (168)` |
| `check-changeset-presence` / `-fixed` / `-no-major` | 全绿 |
| 改动路径 eslint | 0 error |

**changeset:欠,已补** —— 门自己点名了 `@object-ui/permissions` 的两个源文件,故 `.changeset/spotty-pugs-refuse.md` 声明 `patch`(非 `major`,按 §版本号策略)。补前门是红的(exit 1),补后 `✅ ... declares 1 changeset(s)`。

**doc-version-claims 棘轮**:本 PR 未新增任何版本字面量。控制字节除跑门外另做一次自扫(`grep -naP` 扫 `[\x00-\x08\x0b\x0c\x0e-\x1f]`),改动的全部文件零命中。

**消费半径**:`evaluatePermission` 的入口只有 `PermissionProvider` 与 `createPermissionStore` 两个。`app-shell` / `apps/console` 只挂 `MePermissionsProvider`(另一个文件,本 PR 未动)并消费 `usePermissions` 上下文,到不了本次改的代码路径 —— 仍跑了那 6 个权限相邻测试作旁证。

## 范围

- ⛔ 未动 #4813 刚改的表达式段(「Expression scope: which roots resolve」整节与 `${data.canDeleteContacts}` 示例)。
- ⛔ 未动 #4786 的信封段。
- ⛔ 未碰 `content/docs/releases/`。
- ⛔ 未 force-push;draft,未挂 auto-merge。
- 示例里 `inherits: ['base']` 指向一个未定义的角色 —— 原文如此,类型合法(`resolveRoles` 找不到就跳过),不属四条形状之一,未动。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_