### PR TITLE
docs(layout): README 的 AppShell 示例传 `navbar` 而非幻影 `header`,并加键表钉 (#4817)

### DIFF
--- a/.changeset/readme-app-shell-navbar-example.md
+++ b/.changeset/readme-app-shell-navbar-example.md
@@ -1,0 +1,14 @@
+---
+---
+
+Docs + test-only (objectui#4817). `packages/layout/README.md`'s `AppShell` examples now
+pass `navbar` — the component's only top-bar slot — instead of a `header` prop that
+`AppShellProps` has never declared. `AppShell` destructures a fixed key list with no rest
+element, so the node was built and dropped: every reader who copied the npm landing page's
+snippet got a permanently empty top bar. The "Usage with React Router" fence had the same
+defect, and "Customization" taught `headerClassName` / `sidebarClassName`, neither of which
+exists either. The README also gains an `AppShellProps` key table, and all of it is pinned
+to the real interface by `packages/layout/src/__tests__/readme-app-shell-example.test.ts`.
+
+No published behaviour changes: no package's runtime source was touched, only the
+documentation and the test that now compiles and scans it.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -73,7 +73,7 @@ floor: copied verbatim, the snippet rendered an empty top bar and said nothing.
 | `rightRail` | `React.ReactNode` | — | Optional right-side rail. It reflows the content beside it rather than overlaying it (ADR-0057 P3a); absent → unchanged single-pane layout. |
 | `className` | `string` | — | Tailwind overrides for the `<main>` content element — **not** for the outer container. |
 | `defaultOpen` | `boolean` | `true` | Initial open state of the underlying Shadcn `SidebarProvider`. |
-| `branding` | `AppShellBranding` | — | Brand colors, favicon, logo and document title, applied as CSS custom properties on the document root. |
+| `branding` | `AppShellBranding` | — | App branding, applied by `useAppShellBranding`: `primaryColor` / `accentColor` become CSS custom properties on the document root (re-derived for dark mode), `favicon` sets the icon link's `href`, and `title` sets `document.title`. |
 
 ### PageHeader
 

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -43,18 +43,37 @@ prefer to register explicitly.
 
 ### AppShell
 
-Complete application shell with header, sidebar, and main content area.
+Complete application shell with a top navbar, a sidebar, and a main content area.
 
 ```typescript
 import { AppShell } from '@object-ui/layout';
 
 <AppShell
-  header={<div>Header Content</div>}
+  navbar={<div>Navbar Content</div>}
   sidebar={<div>Sidebar Content</div>}
 >
   <div>Main Content</div>
 </AppShell>
 ```
+
+The top bar's content goes in `navbar`. `AppShell` renders the `<header>`
+element itself (`src/AppShell.tsx:248`) and `{navbar}` is the only thing that
+fills it (`:249`) — there is no `header` prop. This example used to pass one
+(objectui#4817), and because the component destructures a fixed key list with
+**no rest element** (`:233-241`), the node was built and then dropped on the
+floor: copied verbatim, the snippet rendered an empty top bar and said nothing.
+
+#### `AppShellProps`
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `children` | `React.ReactNode` | — (required) | Main content, rendered inside the `<main>` element. |
+| `navbar` | `React.ReactNode` | — | Top bar content. `AppShell` supplies the sticky `<header>` around it, so pass only what goes inside. |
+| `sidebar` | `React.ReactNode` | — | Left sidebar node, rendered as a flex sibling of the content. Pass `SidebarNav`, or your own node. |
+| `rightRail` | `React.ReactNode` | — | Optional right-side rail. It reflows the content beside it rather than overlaying it (ADR-0057 P3a); absent → unchanged single-pane layout. |
+| `className` | `string` | — | Tailwind overrides for the `<main>` content element — **not** for the outer container. |
+| `defaultOpen` | `boolean` | `true` | Initial open state of the underlying Shadcn `SidebarProvider`. |
+| `branding` | `AppShellBranding` | — | Brand colors, favicon, logo and document title, applied as CSS custom properties on the document root. |
 
 ### PageHeader
 
@@ -182,7 +201,7 @@ function App() {
   return (
     <BrowserRouter>
       <AppShell
-        header={<div className="p-4">My App</div>}
+        navbar={<div className="p-4">My App</div>}
         sidebar={
           <SidebarNav
             items={[
@@ -204,15 +223,18 @@ function App() {
 
 ## Customization
 
-All components accept `className` prop for Tailwind customization:
+`AppShell` takes a single `className`, and it lands on the `<main>` content
+element (`src/AppShell.tsx:256`) rather than on the outer container. There is no
+per-slot `headerClassName` / `sidebarClassName` — the navbar and the sidebar are
+nodes **you** build, so style them where you build them:
 
 ```typescript
 <AppShell
   className="bg-gray-50"
-  headerClassName="border-b"
-  sidebarClassName="bg-white shadow-lg"
+  navbar={<div className="border-b px-4">My App</div>}
+  sidebar={<div className="bg-white shadow-lg">Sidebar Content</div>}
 >
-  {children}
+  <div>Main Content</div>
 </AppShell>
 ```
 

--- a/packages/layout/src/__tests__/readme-app-shell-example.test.ts
+++ b/packages/layout/src/__tests__/readme-app-shell-example.test.ts
@@ -1,0 +1,273 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `packages/layout/README.md`'s AppShell examples spell only real props
+ * (objectui#4817).
+ *
+ * The npm landing page for this package taught `<AppShell header={…}>`.
+ * `AppShellProps` has never declared `header` — the top bar's entry point is
+ * `navbar` — and `AppShell` destructures a FIXED key list with no rest element
+ * (`AppShell.tsx:233-241`), so the node was built and dropped on the floor with
+ * no warning of any kind. `AppShell` renders the `<header>` element itself
+ * (`:248`) and fills it from `{navbar}` (`:249`), so a reader who copied the
+ * example verbatim got a shell whose top bar was permanently empty. Two further
+ * fences on the same page had the same defect in two more spellings: the
+ * "Usage with React Router" example passed `header={…}` too, and "Customization"
+ * passed `headerClassName` / `sidebarClassName`, neither of which exists either
+ * (there is no per-slot className at all — `className` goes to `<main>`).
+ *
+ * This is objectui#3999's defect (SidebarNav, same README, pinned by
+ * `readme-sidebar-nav-example.test.ts`) and objectui#4793's (SidebarNav on
+ * `content/docs/layout/app-shell.mdx`, pinned by
+ * `app-shell-docs-nav-example.test.ts`) reproduced on a third teaching surface,
+ * which is why this pin is built the same way.
+ *
+ * ## The halves, and why each is a different kind of fact
+ *
+ * 1. **Compile-time.** The prop objects below are real `AppShellProps` values
+ *    imported from `../AppShell`. `packages/layout`'s `type-check` script
+ *    compiles this file (`tsconfig.test.json`), so re-adding `header` — or
+ *    `headerClassName` — makes them stop compiling (TS2353 "Object literal may
+ *    only specify known properties") instead of silently rendering nothing.
+ *    This half catches an undeclared key at the keyboard.
+ *
+ * 2. **Props-table parity.** The `#### \`AppShellProps\`` table this issue added
+ *    to the README is a SECOND surface that can rot exactly the way the example
+ *    did, so its keys are not hand-listed here either: the expected list is read
+ *    out of `AppShell.tsx`'s interface body on every run. Documenting a key that
+ *    does not exist, or adding one to the interface and not the table, is red.
+ *    This half asserts KEYS only — that each documented row names a real
+ *    authoring prop — which is all a key table can be wrong about.
+ *
+ * 3. **Whole-section scan.** Parity guards the table; the compile-time half
+ *    guards the two objects it declares. A NEW `<AppShell>` example pasted into
+ *    the README later would be guarded by neither. So the last two tests re-read
+ *    every fence on the page that mentions `AppShell`, collect the props of each
+ *    `<AppShell …>` opening tag, and reject any the interface does not declare —
+ *    with the expected key list read OUT OF the source, so this can never rot
+ *    into "update the test".
+ *
+ * ## Scan surface — deliberately narrow
+ *
+ * This file reads `packages/layout/README.md` and `packages/layout/src/AppShell.tsx`,
+ * and nothing else. Within that README it judges only the `<AppShell …>` opening
+ * tags: the `SidebarNav` section, its props tables and the `<SidebarNav …>` tag
+ * nested inside the router example's `sidebar={…}` belong to
+ * `readme-sidebar-nav-example.test.ts` (objectui#3999) and are not touched here
+ * — which is why `appShellTagProps` walks the tag with brace-depth tracking
+ * rather than regexing the fence, so a nested element's props are never
+ * collected as AppShell's own. `content/docs/layout/app-shell.mdx` is
+ * `app-shell-docs-nav-example.test.ts`'s surface (objectui#4793), and pinning
+ * the whole docs tree to source is objectui#3786's problem, not this one.
+ *
+ * Note also that `@object-ui/app-shell` exports a DIFFERENT `AppShellProps`
+ * (`packages/app-shell/src/types.ts`) which really does declare `header` — that
+ * is a separate component, and reading this one's key list off this one's source
+ * is what keeps the two from being conflated again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { AppShellProps } from '../AppShell';
+
+/** `packages/layout` — two levels up from `src/__tests__`. */
+const PKG_DIR = resolve(__dirname, '../..');
+const README = readFileSync(join(PKG_DIR, 'README.md'), 'utf8');
+const APP_SHELL_SRC = readFileSync(join(PKG_DIR, 'src', 'AppShell.tsx'), 'utf8');
+
+const README_LINES = README.split('\n').map((line) => line.trim());
+
+// ---------------------------------------------------------------------------
+// Half 1 — the README's two `<AppShell>` examples, as typed values.
+//
+// These are not decoration: `header` (the defect) and `headerClassName` /
+// `sidebarClassName` (the same defect in the Customization fence) are rejected
+// by `tsc` here, at the keyboard, which is the only half that can catch a bad
+// prop before it is published. `null` is a legal `React.ReactNode`, so the
+// slots can be typed without dragging JSX into a `.ts` file.
+// ---------------------------------------------------------------------------
+
+/** The `### AppShell` fence's props. Re-adding `header:` here is TS2353. */
+const basicExampleProps: AppShellProps = {
+  navbar: null,
+  sidebar: null,
+  children: null,
+};
+
+/**
+ * The `## Customization` fence's props. That example used to pass
+ * `headerClassName` / `sidebarClassName`; `AppShellProps` declares neither, and
+ * restoring either one stops this object from compiling.
+ */
+const customizationExampleProps: AppShellProps = {
+  className: 'bg-gray-50',
+  navbar: null,
+  sidebar: null,
+  children: null,
+};
+
+// ---------------------------------------------------------------------------
+// Readers: interface keys, table keys, and the props each example tag passes.
+// ---------------------------------------------------------------------------
+
+/** Keys declared by an interface in `AppShell.tsx`, read off the source. */
+function interfaceKeys(name: string): string[] {
+  const body = new RegExp(`export interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(APP_SHELL_SRC);
+  if (!body) throw new Error(`\`export interface ${name}\` is gone from AppShell.tsx`);
+  // Anchored at line start, so neither JSDoc lines (which start with `*` or
+  // `/`) nor keys nested inside a type annotation are collected.
+  return [...body[1].matchAll(/^\s*(\w+)\??\s*:/gm)].map((match) => match[1]);
+}
+
+/** First-column keys of the markdown table that follows a `#### \`Name\`` heading. */
+function documentedKeys(heading: string): string[] {
+  const start = README_LINES.indexOf(`#### \`${heading}\``);
+  if (start === -1) throw new Error(`README no longer has a \`#### \`${heading}\`\` section`);
+  const keys: string[] = [];
+  for (let i = start + 1; i < README_LINES.length; i += 1) {
+    const line = README_LINES[i];
+    if (line.length === 0) continue;
+    if (!line.startsWith('|')) {
+      if (keys.length > 0) break;
+      continue;
+    }
+    const cell = line.split('|')[1]?.trim() ?? '';
+    const key = /^`(\w+)`$/.exec(cell)?.[1];
+    if (key) keys.push(key);
+  }
+  return keys;
+}
+
+/** Fenced code blocks in the README that are about this component. */
+function appShellFences(): string[] {
+  const fences = [...README.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((match) => match[1]);
+  return fences.filter((body) => body.includes('AppShell'));
+}
+
+/**
+ * Prop names on every `<AppShell …>` opening tag in `body`.
+ *
+ * Walks the tag rather than regexing the fence, tracking `{}` depth so props of
+ * nested elements — the `className` on the `<div>` inside `navbar={…}`, or the
+ * whole `<SidebarNav items={…} />` inside the router example's `sidebar={…}` —
+ * are never collected as AppShell's own.
+ */
+function appShellTagProps(body: string): string[] {
+  const props: string[] = [];
+  const TAG = '<AppShell';
+  for (let start = body.indexOf(TAG); start !== -1; start = body.indexOf(TAG, start + 1)) {
+    // Guard against matching a longer identifier, e.g. `<AppShellFoo`.
+    if (/[\w-]/.test(body[start + TAG.length] ?? '')) continue;
+    let depth = 0;
+    let tag = '';
+    for (let i = start + TAG.length; i < body.length; i += 1) {
+      const ch = body[i];
+      if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+      else if (ch === '>' && depth === 0) break;
+      tag += depth === 0 ? ch : ' ';
+    }
+    props.push(...[...tag.matchAll(/([A-Za-z_$][\w$]*)\s*=/g)].map((match) => match[1]));
+  }
+  return props;
+}
+
+describe("the README's AppShellProps table names exactly the real keys (objectui#4817)", () => {
+  it('`AppShellProps` is documented key-for-key', () => {
+    const declared = interfaceKeys('AppShellProps');
+    expect(declared.length, 'no keys parsed out of `AppShellProps`').toBeGreaterThan(1);
+
+    expect(
+      documentedKeys('AppShellProps').slice().sort(),
+      [
+        'The `AppShellProps` table in packages/layout/README.md and the interface in',
+        'src/AppShell.tsx disagree about which props exist. The expected list is READ OUT OF',
+        'the source on every run, so this is never "update the test": add the new prop to the',
+        'table, or drop the row for the prop that is gone. A README is this package\'s npm',
+        'landing page; a prop it invents is a node AppShell silently discards (objectui#4817).',
+      ].join('\n'),
+    ).toEqual(declared.slice().sort());
+  });
+
+  it('and the example prop objects really are `AppShellProps` (the compile-time half, made visible)', () => {
+    // These reads are the point: a `const` nobody looks at is easy to delete,
+    // and deleting it would silently retire the type-check that rejects
+    // `header` / `headerClassName` at the keyboard.
+    const declared = interfaceKeys('AppShellProps');
+    for (const key of [...Object.keys(basicExampleProps), ...Object.keys(customizationExampleProps)]) {
+      expect(declared, `\`${key}\` is not declared by AppShellProps`).toContain(key);
+    }
+    expect(Object.keys(basicExampleProps).sort()).toEqual(['children', 'navbar', 'sidebar']);
+    expect(customizationExampleProps.className).toBe('bg-gray-50');
+    // The prop the README used to spell `header`, and the reason this pin exists.
+    expect(declared).toContain('navbar');
+    expect(declared).not.toContain('header');
+  });
+});
+
+describe("the README's AppShell examples pass only props AppShellProps declares (objectui#4817)", () => {
+  it('every `<AppShell …>` prop on the page is a real one', () => {
+    const declared = interfaceKeys('AppShellProps');
+    expect(declared.length, 'no keys parsed out of `AppShellProps`').toBeGreaterThan(1);
+
+    const fences = appShellFences();
+    expect(fences.length, 'no AppShell code fence found in the README at all').toBeGreaterThan(0);
+
+    const used = [...new Set(fences.flatMap(appShellTagProps))];
+    expect(used.length, 'no `<AppShell …>` tag found in the README at all').toBeGreaterThan(0);
+
+    expect(
+      used.filter((prop) => !declared.includes(prop)),
+      [
+        'An `<AppShell>` example in packages/layout/README.md passes a prop the component does',
+        'not declare. `AppShell` destructures a fixed key list with NO rest element',
+        '(AppShell.tsx:233-241), so an undeclared prop is not "ignored with a warning" — the',
+        'node is built and dropped, and the README promises UI that can never appear. That is',
+        'exactly what `header={…}` did: the top bar stayed empty for everyone who copied the',
+        'snippet, and `headerClassName` / `sidebarClassName` did the same for styling',
+        '(objectui#4817).',
+        '',
+        'The expected list is READ OUT OF src/AppShell.tsx on every run, so this is never',
+        '"update the test": add the prop to `AppShellProps`, or stop teaching it.',
+        `Declared: ${declared.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and actually teaches `navbar`, so the scan above is not passing on an empty set', () => {
+    // Without this the test above would stay green if every `<AppShell>` example
+    // lost its props, or the top-bar slot quietly stopped being documented at
+    // all: "no undeclared props" is trivially true of no props. `navbar` is the
+    // fact objectui#4817 is about, so it is asserted positively.
+    const used = new Set(appShellFences().flatMap(appShellTagProps));
+
+    expect(
+      used.has('navbar'),
+      [
+        'No `<AppShell>` example in packages/layout/README.md passes `navbar` any more.',
+        '`navbar` is the ONLY entry point for top-bar content (AppShell.tsx:249); a page that',
+        'stops showing it sends readers looking for the `header` prop that objectui#4817 was',
+        'filed about, which has never existed.',
+        `Props currently passed: ${[...used].join(', ') || '(none)'}`,
+      ].join('\n'),
+    ).toBe(true);
+
+    expect(
+      used.has('header'),
+      [
+        'An `<AppShell>` example in packages/layout/README.md is passing `header` again.',
+        'That prop does not exist on this component (objectui#4817). Note that',
+        '`@object-ui/app-shell` exports a different `AppShellProps` which DOES declare',
+        '`header` — this README documents `@object-ui/layout`\'s, whose top-bar slot is',
+        '`navbar`.',
+      ].join('\n'),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #4817

## 事实

`packages/layout/README.md` 的 AppShell 示例传 `header=`,而 `AppShellProps`(`packages/layout/src/AppShell.tsx:25-40`)从未声明该键 —— 顶栏内容的唯一入口是 `navbar`:AppShell 自己渲染那个 header 元素(`:248`),`{navbar}` 是唯一填充它的东西(`:249`)。组件解构(`:233-241`)是固定键表、**无 rest**,所以传进去的节点被整个构造出来再丢掉:照抄这个 npm 落地页的读者得到一个永远空的顶栏,而且零诊断。

## 改了什么

1. **`### AppShell` 示例**:`header=` 改 `navbar=`,并补一段散文写清 header 元素由 AppShell 自渲染、`navbar` 才是入口。
2. **`#### AppShellProps` 键表**(新增):7 个真实 props 逐条列出(含此前文档面看不到的 `branding` / `rightRail`)。
3. **`## Usage with React Router` 示例**:同一个 `header=` 幻影键,同样改 `navbar=`。
4. **`## Customization` 示例**:原来教 `headerClassName` / `sidebarClassName`,这两个键 `AppShellProps` 同样没有 —— 根本不存在按槽位的 className。改成演示真实的 `className`(它落在 main 元素上,`:256`,不是外层容器)+ 在你自己构建的 navbar / sidebar 节点上加类。
5. **钉子**(新增 `packages/layout/src/__tests__/readme-app-shell-example.test.ts`)。

### 为什么 3、4 也在本 PR 里

3 和 4 与 1 是**同一个文件、同一个组件、同一条事实**(AppShellProps 没有这些键)的另外两处实例。更关键的是钉子的诚实性:新钉子的扫描面是「该 README 里所有 AppShell 开标签」,留着 3、4 不改就等于在覆盖面里手工挖一个正好套住已知 bug 的洞 —— 那种「因为什么都没产出所以断言通过」的空绿是明确的反面教材。范围硬边按派单严格执行:SidebarNav 段与 `readme-sidebar-nav-example.test.ts` **零触碰**、`AppShell.tsx` 生产代码**零触碰**(「要不要加 header 插槽」是产品增强,不在本单)、`content/docs/layout/app-shell.mdx` **零触碰**。`## Features` 的两条 bullet 也**未动**:它们描述的是版面区域而不是 prop 名,而 AppShell 确实渲染一个 header 元素,那句话本身不假。

## 钉子的三半(照 PR #4819 的写法)

- **编译期**:两个示例的 props 写成真实 `AppShellProps` 值。重新加回 `header` 或 `headerClassName` 会在 `pnpm type-check` 报 TS2353,而不是静默渲染空白。
- **键表对齐**:`AppShellProps` 表的首列键**现读自** `AppShell.tsx` 的 interface 体,不硬编码 —— 表与接口任一侧单独漂移即红,永远不会退化成「改一下测试」。
- **整段扫描**:重读该 README 里所有提到 AppShell 的 fence,用花括号深度游走每个 AppShell 开标签来收键(所以嵌套在 `sidebar=` 表达式里的 SidebarNav 的 props 绝不会被误收成 AppShell 自己的),拒绝接口未声明的任何键;外加一条**正向**断言「README 确实还在教 `navbar`」,防止扫描退化成对空集合成立。

扫描面在文件头注释里写死:只有 `packages/layout/README.md` + `packages/layout/src/AppShell.tsx`。SidebarNav 面归 #3999 的钉子,app-shell.mdx 面归 #4793 的钉子。注释里另记了一条容易踩的坑:`@object-ui/app-shell` 导出的是**另一个** `AppShellProps`,那个确实声明 `header` —— 键表现读自本组件的源码,正是防止两者再被混为一谈。

## 反向验证(先预判,后实跑)

先 commit,再把 `### AppShell` 那一处改回 `header=`(⛔ 未用 stash;还原走 `git checkout 分支名 -- 路径`)。

**预判**:4 个测试 2 红 2 绿。「every AppShell prop 是真的」红在 `['header']` 不等于 `[]`;「actually teaches navbar」**只红在它的第二条断言**(`used.has('header')`),第一条(`used.has('navbar')`)仍绿 —— 因为 router 与 Customization 两处 fence 还在传 `navbar`;键表与编译期两条绿(表没动,且类型化的常量在测试文件里,单改 README 够不到它),`type-check` 不受影响。

**实跑:完全命中**,`Tests 2 failed | 2 passed (4)`,且第二条红的失败行正是 `:271`(`header` 那条),不是更靠前的 `navbar` 那条:

```
AssertionError: An `AppShell` example in packages/layout/README.md passes a prop the component does
not declare. ... Declared: sidebar, navbar, children, className, defaultOpen, branding, rightRail
  : expected [ 'header' ] to deeply equal []
 ❯ packages/layout/src/__tests__/readme-app-shell-example.test.ts:241:7

AssertionError: An `AppShell` example in packages/layout/README.md is passing `header` again.
  : expected true to be false
 ❯ packages/layout/src/__tests__/readme-app-shell-example.test.ts:271:7
```

还原后整包复跑仍是 `13 passed / 152 passed`。

## 测试与门禁(均为实跑输出)

```
pnpm exec vitest run packages/layout/src/__tests__/readme-app-shell-example.test.ts --maxWorkers=2
  Test Files  1 passed (1)        Tests  4 passed (4)

pnpm exec vitest run packages/layout/ --maxWorkers=2
  Test Files  13 passed (13)      Tests  152 passed (152)

pnpm exec turbo run type-check --concurrency=2
  Tasks: 81 successful, 81 total

node scripts/check-control-bytes.mjs      OK (scanned 4324 tracked text file(s))
node scripts/check-changeset-presence.mjs OK   node scripts/check-changeset-no-major.mjs OK
node scripts/check-changeset-fixed.mjs    OK   node scripts/check-doc-links.mjs          OK
pnpm exec eslint <改动路径>                0 errors
```

控制字节除门禁外另做了一次自查(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,零命中)。

## changeset

`.changeset/readme-app-shell-navbar-example.md`,**空 frontmatter**。依据:本 PR 没有任何发版包的运行时源码改动,但新增的测试文件位于 `packages/layout/src/__tests__/`,而 `check-changeset-presence.mjs` 对 `src/**` **没有**测试文件豁免(脚本注释 `:91-92` 明写「No carve-out for test files under `src/`」),所以必须声明一次 —— 空 frontmatter 正是 AGENTS.md 认可的一等写法:显式声明「不发版」。

## 顺带发现(未在本 PR 修)

- **#4827**:`content/docs/guide/layout.md` 的 app-shell「Schema API」块(`:73-88`)与「Custom Classes」示例(`:478-486`)教了 7 个 `AppShellProps` 从未声明的键(`header` / `body` / `sidebarCollapsible` / `sidebarDefaultOpen` / `headerClassName` / `sidebarClassName` / `contentClassName`)。同族事实的**第三个载体**,而且是 JSON 载体 —— 比 React 载体更糟,因为 `app-shell` 注册时 `inputs` 为空,连 unknown-prop 校验都说不出话。已按未认领立单交 PM 分诊。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_