### PR TITLE
docs(layout): app-shell.mdx 的 AppShellProps 声明块补齐到 7 个 props,并钉到 interface (#4808)

### DIFF
--- a/.changeset/app-shell-props-block-4808.md
+++ b/.changeset/app-shell-props-block-4808.md
@@ -1,0 +1,8 @@
+---
+---
+
+Docs-only alignment plus its pin: `content/docs/layout/app-shell.mdx` now reprints all
+seven props `AppShellProps` declares (adding `branding` and `rightRail`), and the existing
+app-shell docs pin test compares that block against `packages/layout/src/AppShell.tsx` on
+every run. No published behaviour changes — the MDX page is not part of any released
+package, and the only source file touched is a test (objectui#4808).

--- a/content/docs/layout/app-shell.mdx
+++ b/content/docs/layout/app-shell.mdx
@@ -39,6 +39,9 @@ interface AppShellProps {
   children: React.ReactNode;     // Main content area
   className?: string;            // Additional CSS classes for content area
   defaultOpen?: boolean;         // Sidebar default state (default: true)
+  branding?: AppShellBranding;   // App branding — see AppShellBranding
+  rightRail?: React.ReactNode;   // Optional right rail beside the content, not
+                                 // over it (ADR-0057 P3a)
 }
 ```
 

--- a/packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts
+++ b/packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts
@@ -49,6 +49,20 @@
  *    prop scan reads its expected key list OUT OF `SidebarNav.tsx`, so it can
  *    never rot into "update the test".
  *
+ * ## The page's `AppShellProps` block (objectui#4808)
+ *
+ * Same page, same failure mode, opposite direction: the `## Component Props`
+ * block reprints `AppShellProps` by hand and had gone stale by OMISSION — it
+ * listed 5 props while `AppShell.tsx` declared 7, so `branding` (the whole
+ * theme-customization entry point, `AppSchema.branding` landing in the
+ * renderer) and `rightRail` (ADR-0057 P3a) were shipped, exported, commented
+ * capabilities that a reader could only find by opening the source. Nothing
+ * asserted false, so no scan built for wrong keys could see it; only a
+ * both-directions comparison against the interface can. The block is therefore
+ * parsed and compared to `AppShellProps` — props, order, optionality and type
+ * text — with the expectation read OUT OF `AppShell.tsx` on every run, the same
+ * never-"update the test" construction the `SidebarNavProps` scan above uses.
+ *
  * Scope: this file scans `content/docs/layout/app-shell.mdx` and nothing else.
  * The `icon:`-as-string rejection in particular must NOT be widened to the docs
  * tree — `page-header` really does declare `icon` as a string (an icon NAME),
@@ -68,6 +82,16 @@ const MDX_PATH = join(REPO_ROOT, 'content', 'docs', 'layout', 'app-shell.mdx');
 const MDX = readFileSync(MDX_PATH, 'utf8');
 const SIDEBAR_NAV_SRC = readFileSync(
   join(REPO_ROOT, 'packages', 'layout', 'src', 'SidebarNav.tsx'),
+  'utf8',
+);
+/**
+ * The page documents `@object-ui/layout`'s AppShell — every example on it
+ * imports from `@object-ui/layout` — so this is the source of truth for its
+ * props. `packages/app-shell` exports a same-named `AppShellProps` for a
+ * different component; that one is not what this page teaches.
+ */
+const APP_SHELL_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'layout', 'src', 'AppShell.tsx'),
   'utf8',
 );
 const THIS_FILE = readFileSync(join(__dirname, 'app-shell-docs-nav-example.test.ts'), 'utf8');
@@ -183,13 +207,44 @@ function sidebarNavTagProps(body: string): string[] {
   return props;
 }
 
+/** One prop of an interface: its name, whether it is optional, and its type. */
+interface DeclaredProp {
+  key: string;
+  optional: boolean;
+  type: string;
+}
+
+/** Drop block and line comments, so a trailing `// …` never lands in a type. */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+/**
+ * The props `interface <name>` declares in `src`, in declaration order.
+ *
+ * `export` is optional so the same parser reads both a `.tsx` source and the
+ * hand-written copy inside an MDX fence. Each prop is matched anchored at line
+ * start and terminated by the line's last `;`, so nested keys inside a type
+ * (the `className?` in `icon?: React.ComponentType<{ className?: string }>`)
+ * are never collected as props of their own.
+ */
+function interfaceProps(src: string, name: string): DeclaredProp[] {
+  const body = new RegExp(`(?:export )?interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(src);
+  if (!body) throw new Error(`\`interface ${name}\` is gone from the source this test reads`);
+  return [...stripComments(body[1]).matchAll(/^[ \t]*(\w+)(\??)\s*:\s*(.+?);[ \t]*$/gm)].map(
+    (match) => ({ key: match[1], optional: match[2] === '?', type: match[3].trim() }),
+  );
+}
+
 /** Keys declared by an interface in `SidebarNav.tsx`, read off the source. */
 function interfaceKeys(name: string): string[] {
-  const body = new RegExp(`export interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(SIDEBAR_NAV_SRC);
-  if (!body) throw new Error(`\`export interface ${name}\` is gone from SidebarNav.tsx`);
-  // Anchored at line start, so nested keys inside a type (the `className?` in
-  // `icon?: React.ComponentType<{ className?: string }>`) are not collected.
-  return [...body[1].matchAll(/^\s*(\w+)\??\s*:/gm)].map((match) => match[1]);
+  return interfaceProps(SIDEBAR_NAV_SRC, name).map((prop) => prop.key);
+}
+
+/** Fenced code blocks on the page that reprint `AppShellProps`. */
+function appShellPropsFences(): string[] {
+  const fences = [...MDX.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((match) => match[1]);
+  return fences.filter((body) => body.includes('interface AppShellProps'));
 }
 
 describe("app-shell.mdx's SidebarNav examples are this file's type-checked code (objectui#4793)", () => {
@@ -315,5 +370,48 @@ describe("app-shell.mdx's SidebarNav examples spell only real keys (objectui#479
         `Declared: ${declared.join(', ')}`,
       ].join('\n'),
     ).toEqual([]);
+  });
+});
+
+describe("app-shell.mdx's `AppShellProps` block reprints the real interface (objectui#4808)", () => {
+  /** `sidebar?: React.ReactNode` — how one prop reads in a failure message. */
+  const format = (prop: DeclaredProp): string =>
+    `${prop.key}${prop.optional ? '?' : ''}: ${prop.type}`;
+
+  it('is the one block on the page, inside a fence', () => {
+    expect(
+      appShellPropsFences().length,
+      [
+        'content/docs/layout/app-shell.mdx should reprint `AppShellProps` in exactly one',
+        'fenced block (the `## Component Props` section). Zero means the block was renamed',
+        'or unfenced and the parity assertion below is comparing against nothing; more than',
+        'one means two copies that can now disagree with each other as well as with source.',
+      ].join('\n'),
+    ).toBe(1);
+  });
+
+  it('lists every prop the component declares — same order, optionality and types', () => {
+    const declared = interfaceProps(APP_SHELL_SRC, 'AppShellProps');
+    expect(declared.length, 'no props parsed out of `AppShellProps`').toBeGreaterThan(1);
+
+    const documented = interfaceProps(appShellPropsFences()[0], 'AppShellProps');
+
+    expect(
+      documented.map(format),
+      [
+        "The `AppShellProps` block on content/docs/layout/app-shell.mdx no longer matches the",
+        'component. That block is a hand-written copy of the interface, and the way it rots is',
+        'by OMISSION: it listed 5 of 7 props, so `branding` (the theming entry point) and',
+        '`rightRail` (ADR-0057 P3a) were shipped, exported and documented in source while the',
+        'page said they did not exist (objectui#4808). Nothing on the page was false, which is',
+        'why only a both-directions comparison catches it.',
+        '',
+        'The expected list is READ OUT OF packages/layout/src/AppShell.tsx on every run, so',
+        'this is never "update the test": add the prop to the page, or take it off the',
+        'component. Prose about a prop is free — only the declaration lines are compared.',
+        '',
+        `Declared by the component: ${declared.map(format).join('; ')}`,
+      ].join('\n'),
+    ).toEqual(declared.map(format));
   });
 });


### PR DESCRIPTION
Fixes #4808

## 问题

`content/docs/layout/app-shell.mdx` 的 `## Component Props` 段手抄了一份 `AppShellProps`,只列了 5 个键;`packages/layout/src/AppShell.tsx:25-40` 实际声明 **7** 个。漏掉的两个:

- `branding?: AppShellBranding` —— 有实现(`useAppShellBranding`)、有导出类型、有注释;
- `rightRail?: React.ReactNode` —— ADR-0057 P3a,`AppShell.tsx:253-262` 里作为主内容的 flex 兄弟渲染。

页面上**没有一句是假的**,是漏写:两个已发布的能力在文档里不存在,只能读源码才知道。这也是它躲过既有钉子的原因 —— #4793 那组扫描是冲着「写错的键」去的,漏写它一个都看不见。

## 改法

1. 按 interface 逐键补齐声明块(全部键、可选性、类型拼写照抄 interface,顺序一致);
2. 扩展本页既有的钉子文件 `packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts`,把声明块解析出来与 `AppShell.tsx` 的 interface **双向**比对。

### 键表(补齐前 → 补齐后)

| 键 | 前 | 后 |
|---|---|---|
| `sidebar?: React.ReactNode` | 有 | 有 |
| `navbar?: React.ReactNode` | 有 | 有 |
| `children: React.ReactNode` | 有 | 有 |
| `className?: string` | 有 | 有 |
| `defaultOpen?: boolean` | 有 | 有 |
| `branding?: AppShellBranding` | **缺** | 新增 |
| `rightRail?: React.ReactNode` | **缺** | 新增 |

### 范围自限

- `branding` **只按 interface 列出**,注释仅写类型指向(`see AppShellBranding`),不展开任何行为承诺 —— `AppShellBranding.logo` 的零读取方是 #4818 的题,本 PR 不预决其处置,也没有把 `AppShellBranding` 的五个字段搬到页面上(那会再造一个会漂的教学面)。
- `rightRail` 一行说明,内容严格取自渲染点的事实(内容旁边、不覆盖)。
- #4819 刚改的导航示例段、#4805 的 toggle 段、#3914 钉过的数值,以及 Accessibility 段,零触碰。声明块紧邻没有与键表矛盾的散文,故无顺带修改。

## 为什么扩展既有钉子文件而不是新建

按该文件现行结构判,答案是扩展:

- **扫描面完全相同** —— 它的头注释已经写死「scans `content/docs/layout/app-shell.mdx` and nothing else」,新建文件等于把同一份 MDX 读第二遍、把 fence 提取逻辑抄一份;
- **机制已经在里面了** —— 它的 `passes only props that SidebarNavProps declares` 那条就是「期望键表从组件源码现读、永不退化成 update the test」的写法。本次把它的 interface 解析器提升成 `interfaceProps(src, name)`(返回 键 / 可选性 / 类型三元组,`export` 可选,行首锚定 + 行尾 `;` 终止,故类型里的嵌套键不会被当成 prop),`interfaceKeys` 改为在其上的一行封装,SidebarNav 那半的语义不变;
- 唯一的代价是文件名 `app-shell-docs-nav-example.test.ts` 现在窄于内容;已在头注释里写清它现在钉两件事,改名留给需要动它的下一单,本 PR 不做无关重命名。

新增两条断言:声明块在页面上是**唯一**且在 fence 内(0 个 = 比了个寂寞,2 个 = 两份副本可以互相打架);以及键 / 顺序 / 可选性 / 类型文本与 `AppShell.tsx` 逐项相等。注释是自由的 —— 只比较声明行。

## 验证

反向验证(**先预判后跑**):把声明块 checkout 回漏写态,预判「恰好 1 条红:`lists every prop the component declares`,documented 5 vs declared 7;fence 计数那条与 #4793 的 7 条全绿」。实跑一致 —— `Tests 1 failed | 8 passed (9)`,失败 diff 精确列出 `- "branding?: AppShellBranding"` / `- "rightRail?: React.ReactNode"`。还原后 9/9 绿。

- `pnpm exec vitest run packages/layout/src/__tests__/app-shell-docs-nav-example.test.ts` → 9 passed(verbose 逐条)
- `pnpm exec vitest run packages/layout/` → 12 files / 150 tests passed
- `pnpm exec vitest run scripts/` → 45 files / 1026 tests passed(doc 家族在内)
- `node scripts/check-doc-links.mjs` → exit 0;`node scripts/check-control-bytes.mjs` → exit 0(另补一次 `grep -naP` 自扫,无命中)
- `node scripts/check-changeset-presence.mjs` → exit 0;`check-changeset-no-major.mjs` → exit 0。改动含测试文件,故按 presence 实测需要 changeset;MDX 不属发版包,唯一的源文件是测试 —— 空 frontmatter 显式声明不发版
- 改动路径 `eslint` → exit 0;仓根 `turbo run type-check` → 81/81 successful


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_