### PR TITLE
docs(layout): guide/layout.md 的 app-shell 只教真实 props,并钉住 JSON 载体的可表达性 (#4827)

### DIFF
--- a/.changeset/guide-layout-app-shell-4827.md
+++ b/.changeset/guide-layout-app-shell-4827.md
@@ -1,0 +1,21 @@
+---
+---
+
+Docs + test-only (objectui#4827). `content/docs/guide/layout.md`'s `app-shell` material
+taught seven keys `AppShellProps` has never declared — `header`, `body`,
+`sidebarCollapsible`, `sidebarDefaultOpen`, `headerClassName`, `sidebarClassName`,
+`contentClassName` — across six blocks, and its carrier was JSON: `app-shell` is
+registered with no `inputs`, so `sdui-parser`'s unknown-prop check had nothing to compare
+a node against and copied metadata was dropped with no diagnostic at all.
+
+The page now teaches `AppShell` as the React component it is, with a props table read
+against the interface, and states measured facts about what a JSON `app-shell` node does
+with each key: `className` / `defaultOpen` / `branding` survive, `children` is stripped by
+`SchemaRenderer` so `<main>` renders empty in silence, and a schema in `sidebar` / `navbar`
+/ `rightRail` reaches the component as a plain object React refuses to render.
+
+Pinned by `packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts`, whose
+expected key list is read out of `packages/layout/src/AppShell.tsx` on every run.
+
+No published behaviour changes: no package's runtime source was touched, only the
+documentation and the test that compiles and scans it.

--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -11,7 +11,7 @@ ObjectUI provides a comprehensive layout system through the `@object-ui/layout` 
 
 The layout system provides:
 
-- **AppShell** - Full application container with header, sidebar, and content areas
+- **AppShell** - Full application container with a top navbar, sidebar, and content areas
 - **Page** - Individual page wrapper with header and body
 - **PageHeader** - Consistent page headers with title, breadcrumbs, and actions
 - **SidebarNav** - Navigation sidebar with menu items
@@ -28,60 +28,79 @@ Layout components are automatically registered when you import ObjectUI.
 
 ## AppShell Component
 
-The `AppShell` provides a complete application structure with header, sidebar, and main content area.
+The `AppShell` provides a complete application structure with a top navbar, a sidebar, and
+a main content area.
+
+**`AppShell` is a React component, not an authorable JSON node.** Four of its seven props
+are `React.ReactNode` slots — `sidebar`, `navbar`, `children` and `rightRail` — and a JSON
+document has no way to put a node into any of them. Compose the shell in React, and render
+your JSON pages *inside* it. What a `{ "type": "app-shell" }` node does with each key is
+spelled out under [In a JSON node](#in-a-json-node) below.
 
 ### Basic Usage
 
-```json
-{
-  "type": "app-shell",
-  "header": {
-    "type": "header-bar",
-    "title": "My Application"
-  },
-  "sidebar": {
-    "type": "sidebar-nav",
-    "items": [
-      { "label": "Dashboard", "href": "/dashboard", "icon": "layout-dashboard" },
-      { "label": "Users", "href": "/users", "icon": "users" },
-      { "label": "Settings", "href": "/settings", "icon": "settings" }
-    ]
-  },
-  "body": {
-    "type": "page",
-    "title": "Dashboard",
-    "body": {
-      "type": "text",
-      "value": "Welcome to the dashboard!"
-    }
-  }
-}
+```tsx
+import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
+import { SchemaRenderer } from '@object-ui/react';
+import { LayoutDashboard, Settings, Users } from 'lucide-react';
+
+const navItems: NavItem[] = [
+  { title: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+  { title: 'Users', href: '/users', icon: Users },
+  { title: 'Settings', href: '/settings', icon: Settings },
+];
+
+<AppShell
+  navbar={<span className="font-semibold">My Application</span>}
+  sidebar={<SidebarNav items={navItems} />}
+>
+  <SchemaRenderer schema={pageSchema} />
+</AppShell>
 ```
 
-### Schema API
+Top-bar content goes in `navbar`. `AppShell` renders the sticky `<header>` element itself
+and `{navbar}` is the only thing that fills it — there is no `header` prop. Main content is
+the component's `children`; there is no `body` prop either.
 
-```typescript
-{
-  type: 'app-shell',
-  
-  // Header configuration
-  header?: ComponentSchema,
-  
-  // Sidebar configuration  
-  sidebar?: ComponentSchema,
-  sidebarCollapsible?: boolean,  // Allow sidebar collapse
-  sidebarDefaultOpen?: boolean,  // Initial sidebar state
-  
-  // Main content
-  body: ComponentSchema,
-  
-  // Styling
-  className?: string,
-  headerClassName?: string,
-  sidebarClassName?: string,
-  contentClassName?: string
-}
-```
+### Props
+
+`AppShellProps` (`packages/layout/src/AppShell.tsx`) declares exactly these seven. The
+component destructures that fixed key list with **no rest element**, so anything else you
+pass is built and then dropped on the floor.
+
+| Prop | Type | Required | In a JSON node | Description |
+| --- | --- | --- | --- | --- |
+| `sidebar` | `React.ReactNode` | no | no | Left sidebar node, a flex sibling of the content. Pass `SidebarNav`, or your own node. |
+| `navbar` | `React.ReactNode` | no | no | Top-bar content. `AppShell` supplies the sticky `<header>` around it, so pass only what goes inside. |
+| `children` | `React.ReactNode` | yes | no | Main content, rendered inside the `<main>` element. |
+| `className` | `string` | no | yes | Tailwind overrides for the `<main>` content element — **not** for the outer container. |
+| `defaultOpen` | `boolean` | no | yes | Initial open state of the underlying Shadcn `SidebarProvider`. Defaults to `true`. |
+| `branding` | `AppShellBranding` | no | yes | App branding, applied by `useAppShellBranding`: `primaryColor` / `accentColor` become CSS custom properties on the document root, `favicon` sets the icon link's `href`, and `title` sets `document.title`. |
+| `rightRail` | `React.ReactNode` | no | no | Optional right-side rail. It reflows the content beside it rather than overlaying it; absent → unchanged single-pane layout. |
+
+### In a JSON node
+
+`app-shell` is registered on the `ComponentRegistry` (`packages/layout/src/index.ts`), so
+`{ "type": "app-shell" }` does resolve to this component. The registration declares no
+`inputs`, which is why `sdui-parser`'s unknown-prop check has nothing to compare a node
+against and stays silent whatever you write. Measured, key by key:
+
+- **The three plain-data props work.** `className`, `defaultOpen` and `branding` are
+  spread onto the component unchanged. `className` lands on the `<main>` element, and
+  `branding`'s fields are applied by `useAppShellBranding` exactly as in React.
+- **`children` is dropped, silently.** `SchemaRenderer` strips `children` (and `body`) out
+  of a node before spreading the remaining keys as props, and `AppShell` reads its
+  `children` **prop**, not `schema.children`. The `<main>` element renders empty and
+  nothing is logged.
+- **`sidebar` / `navbar` / `rightRail` cannot hold a schema.** They are `React.ReactNode`;
+  a JSON value reaches the component as a plain object, and React refuses to render one.
+  The node is replaced by the renderer's error box: `Component "app-shell" failed to
+  render — Objects are not valid as a React child`.
+
+So do not author an `app-shell` node in JSON. Build the shell in React as above — or, when
+the whole shell should come from metadata, use `AppSchemaRenderer` (registered as
+`app-schema-renderer`), which builds branding and sidebar navigation from an `AppSchema`
+JSON document and takes the page content as its `children`.
 
 ### Features
 
@@ -332,55 +351,47 @@ The `SidebarNav` provides a collapsible navigation sidebar with menu items.
 
 ### Full Application Layout
 
-```json
-{
-  "type": "app-shell",
-  "header": {
-    "type": "header-bar",
-    "title": "My App",
-    "logo": "/logo.png",
-    "actions": [
-      { "type": "button", "text": "Profile", "variant": "ghost" }
-    ]
-  },
-  "sidebar": {
-    "type": "sidebar-nav",
-    "items": [
-      { "label": "Home", "href": "/", "icon": "home" },
-      { "label": "Products", "href": "/products", "icon": "package" },
-      { "label": "Orders", "href": "/orders", "icon": "shopping-cart" }
-    ]
-  },
-  "sidebarCollapsible": true,
-  "sidebarDefaultOpen": true,
-  "body": {
-    "type": "page",
-    "title": "Dashboard",
-    "body": {
-      "type": "object-grid",
-      "object": "orders"
-    }
+The shell is React; the page inside it is your JSON.
+
+```tsx
+import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
+import { SchemaRenderer } from '@object-ui/react';
+import { SidebarTrigger } from '@object-ui/components';
+import { Home, Package, ShoppingCart } from 'lucide-react';
+
+const navItems: NavItem[] = [
+  { title: 'Home', href: '/', icon: Home },
+  { title: 'Products', href: '/products', icon: Package },
+  { title: 'Orders', href: '/orders', icon: ShoppingCart },
+];
+
+<AppShell
+  navbar={
+    <div className="flex w-full items-center gap-2">
+      <SidebarTrigger />
+      <span className="font-semibold">My App</span>
+    </div>
   }
-}
+  sidebar={<SidebarNav items={navItems} />}
+  defaultOpen
+>
+  <SchemaRenderer schema={pageSchema} />
+</AppShell>
 ```
+
+`AppShell` adds no controls of its own to the top bar — the sidebar toggle above is one
+you render yourself, in `navbar`. There is no `sidebarCollapsible` prop: the sidebar's
+collapse behaviour belongs to the sidebar node you pass (`SidebarNav`'s `collapsible`),
+and `defaultOpen` is the shell's own initial-state prop.
 
 ### Landing Page (No Sidebar)
 
-```json
-{
-  "type": "app-shell",
-  "header": {
-    "type": "header-bar",
-    "title": "Welcome"
-  },
-  "body": {
-    "type": "container",
-    "className": "mx-auto py-12",
-    "children": [
-      { "type": "text", "value": "Landing page content" }
-    ]
-  }
-}
+Omit `sidebar` and the content fills the width under the top bar.
+
+```tsx
+<AppShell navbar={<span className="font-semibold">Welcome</span>}>
+  <SchemaRenderer schema={landingSchema} />
+</AppShell>
 ```
 
 ### Settings Page with Tabs
@@ -474,16 +485,24 @@ Layout components automatically adapt to different screen sizes:
 
 Add Tailwind classes to layout components:
 
-```json
-{
-  "type": "app-shell",
-  "className": "custom-app",
-  "headerClassName": "bg-primary text-primary-foreground",
-  "sidebarClassName": "bg-muted",
-  "contentClassName": "bg-background",
-  "body": {...}
-}
+```tsx
+<AppShell
+  className="bg-background"
+  navbar={
+    <div className="flex w-full items-center bg-primary text-primary-foreground">
+      My App
+    </div>
+  }
+  sidebar={<SidebarNav className="bg-muted" items={navItems} />}
+>
+  <SchemaRenderer schema={pageSchema} />
+</AppShell>
 ```
+
+`className` is the only class hook `AppShell` itself takes, and it lands on the `<main>`
+content element — not on the outer container. There is **no** per-slot className:
+`headerClassName`, `sidebarClassName` and `contentClassName` do not exist. The top bar and
+the sidebar are nodes you build, so style them where you build them, as above.
 
 ### Page Padding
 
@@ -505,20 +524,13 @@ Control page content padding:
 
 ### 1. Consistent Structure
 
-Use the same layout structure across your app:
+Compose the shell once and let the page JSON change per route:
 
-```json
-// Every page should follow this pattern
-{
-  "type": "app-shell",
-  "header": { ... },
-  "sidebar": { ... },
-  "body": {
-    "type": "page",
-    "title": "...",
-    "body": { ... }
-  }
-}
+```tsx
+// One shell for the whole app; `pageSchema` is whatever the route resolves to.
+<AppShell navbar={navbar} sidebar={<SidebarNav items={navItems} />}>
+  <SchemaRenderer schema={pageSchema} />
+</AppShell>
 ```
 
 ### 2. Breadcrumbs for Deep Navigation

--- a/packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts
+++ b/packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts
@@ -1,0 +1,456 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `content/docs/guide/layout.md`'s AppShell material teaches only real props
+ * (objectui#4827).
+ *
+ * This is the same phantom-key fact as objectui#4817 (`packages/layout/README.md`,
+ * pinned by `readme-app-shell-example.test.ts`) and objectui#4808
+ * (`content/docs/layout/app-shell.mdx`, pinned by `app-shell-docs-nav-example.test.ts`),
+ * on a THIRD teaching surface — and this one was the worst of the three, because
+ * its carrier was JSON.
+ *
+ * The page's `### Schema API` block declared ten keys for a
+ * `{ "type": "app-shell" }` node, of which `AppShellProps` has ever declared
+ * two: `header`, `body`, `sidebarCollapsible`, `sidebarDefaultOpen`,
+ * `headerClassName`, `sidebarClassName` and `contentClassName` do not exist,
+ * and four of them were demonstrated a second time in the `### Custom Classes`
+ * example. On the React surfaces a copied phantom prop at least reaches a
+ * TypeScript consumer as an error; in a JSON document nothing checks it —
+ * `app-shell` is registered with no `inputs` (`packages/layout/src/index.ts`),
+ * so `sdui-parser`'s unknown-prop check has nothing to compare a node against
+ * and reports nothing at all.
+ *
+ * ## What the page says now, and what the halves below hold to it
+ *
+ * The page was rewritten to teach `AppShell` as what it is — a React component
+ * whose four node slots (`sidebar` / `navbar` / `children` / `rightRail`) a JSON
+ * document cannot fill. Those claims were measured against this tree, not
+ * inferred:
+ *
+ *   - `className`, `defaultOpen` and `branding` DO survive the JSON path. They
+ *     are plain data, `SchemaRenderer` spreads them onto the component, and a
+ *     rendered `{ "type": "app-shell", "branding": {…} }` node really did set
+ *     `document.title` and `--primary`.
+ *   - `children` does NOT. `SchemaRenderer` strips `children` (and `body`) out
+ *     of a node before spreading the rest as props, and `AppShell` reads its
+ *     `children` PROP, never `schema.children`. The `<main>` element rendered
+ *     empty with zero console output — the silent half of this issue.
+ *   - `sidebar` / `navbar` / `rightRail` do NOT. A JSON value arrives as a plain
+ *     object, and `AppShell` renders it directly, so React throws and the node
+ *     is replaced by the renderer's error box (`Objects are not valid as a React
+ *     child`). Loud, but still not the UI the page promised.
+ *
+ * 1. **Compile-time.** The prop objects below are real `AppShellProps` values
+ *    imported from `../AppShell`, mirroring the four `<AppShell …>` examples the
+ *    page now shows. `packages/layout`'s `type-check` script compiles this file
+ *    (`tsconfig.test.json`), so re-adding `header` — or `headerClassName` —
+ *    makes them stop compiling (TS2353) instead of silently rendering nothing.
+ *
+ * 2. **Props-table parity.** The `### Props` table is a hand-written copy of the
+ *    interface and rots the same way the `Schema API` block did, so its rows are
+ *    not hand-listed here either: props, order, optionality and type text are
+ *    read OUT OF `AppShell.tsx` on every run. Inventing a key, dropping one, or
+ *    adding one to the interface and not the table is red.
+ *
+ * 3. **Whole-page tag scan.** Parity guards the table and the compile-time half
+ *    guards the objects it declares; a NEW `<AppShell>` example pasted in later
+ *    would be guarded by neither. So every fence on the page is re-read, the
+ *    props of each `<AppShell …>` opening tag collected, and any the interface
+ *    does not declare rejected — again with the expected key list read out of
+ *    source, so this can never rot into "update the test".
+ *
+ * 4. **No JSON `app-shell` node.** The four `React.ReactNode` slots are the
+ *    whole point of an app shell, and none of them can be written in JSON, so a
+ *    `{ "type": "app-shell" }` node on this page is the defect itself and not
+ *    merely a stale spelling of it. The fences are checked for that node shape.
+ *
+ * 5. **The two source facts the page's prose rests on**, so the prose cannot go
+ *    stale silently: `AppShell` still destructures a fixed key list with no rest
+ *    element (which is why an undeclared prop vanishes without a warning), and
+ *    `SchemaRenderer` still strips `children`/`body` before spreading a node's
+ *    keys as props (which is why the `<main>` element comes out empty).
+ *
+ * ## Scan surface — deliberately narrow
+ *
+ * This file judges `content/docs/guide/layout.md`'s APP-SHELL material only: the
+ * `### Props` table, the `<AppShell …>` opening tags in its fences, and whether
+ * any fence authors an `app-shell` JSON node. The same page's `page`,
+ * `page-header` and `sidebar-nav` sections are NOT audited here and must not be
+ * swept in — `page` in particular declares `headerClassName` / `bodyClassName`
+ * for a different component (`PageRenderer` in `@object-ui/components`), so a
+ * file-wide ban on those spellings would be wrong. `packages/layout/README.md`
+ * belongs to `readme-app-shell-example.test.ts` (objectui#4817) and
+ * `content/docs/layout/app-shell.mdx` to `app-shell-docs-nav-example.test.ts`
+ * (objectui#4793 / #4808); pinning the whole docs tree to source is
+ * objectui#3786's problem, not this one.
+ *
+ * Note also that `@object-ui/app-shell` exports a DIFFERENT `AppShellProps`
+ * (`packages/app-shell/src/types.ts`) which really does declare `header` — that
+ * is a separate component, and reading this one's key list off this one's source
+ * is what keeps the two from being conflated again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { AppShellProps } from '../AppShell';
+
+/** Repo root — five levels up from `packages/layout/src/__tests__`. */
+const REPO_ROOT = resolve(__dirname, '../../../..');
+const GUIDE = readFileSync(join(REPO_ROOT, 'content', 'docs', 'guide', 'layout.md'), 'utf8');
+const APP_SHELL_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'layout', 'src', 'AppShell.tsx'),
+  'utf8',
+);
+/**
+ * The renderer the page's "In a JSON node" section describes. Read for the one
+ * fact that section rests on — that `children` is stripped before a node's keys
+ * are spread as props — so the claim cannot quietly become false.
+ */
+const SCHEMA_RENDERER_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'react', 'src', 'SchemaRenderer.tsx'),
+  'utf8',
+);
+
+const GUIDE_LINES = GUIDE.split('\n').map((line) => line.trim());
+
+// ---------------------------------------------------------------------------
+// Half 1 — the page's four `<AppShell>` examples, as typed values.
+//
+// `header` / `body` (the Schema API block) and `headerClassName` /
+// `sidebarClassName` / `contentClassName` (the Custom Classes block) are
+// rejected by `tsc` here, at the keyboard. `null` is a legal `React.ReactNode`,
+// so the slots can be typed without dragging JSX into a `.ts` file.
+// ---------------------------------------------------------------------------
+
+/** `### Basic Usage`. Re-adding `header:` here is TS2353. */
+const basicExampleProps: AppShellProps = {
+  navbar: null,
+  sidebar: null,
+  children: null,
+};
+
+/**
+ * `### Full Application Layout`. This one used to pass `sidebarCollapsible` and
+ * `sidebarDefaultOpen`; the shell declares neither — `defaultOpen` is its own
+ * initial-state prop, and collapse behaviour belongs to the sidebar node.
+ */
+const fullLayoutExampleProps: AppShellProps = {
+  navbar: null,
+  sidebar: null,
+  defaultOpen: true,
+  children: null,
+};
+
+/** `### Landing Page (No Sidebar)`. Used to pass `header` and `body`. */
+const landingExampleProps: AppShellProps = {
+  navbar: null,
+  children: null,
+};
+
+/**
+ * `### Custom Classes`. That example used to teach `headerClassName` /
+ * `sidebarClassName` / `contentClassName`; there is no per-slot className at
+ * all, and restoring any of them stops this object from compiling.
+ */
+const customClassesExampleProps: AppShellProps = {
+  className: 'bg-background',
+  navbar: null,
+  sidebar: null,
+  children: null,
+};
+
+// ---------------------------------------------------------------------------
+// Readers: interface props, table rows, and the props each example tag passes.
+// ---------------------------------------------------------------------------
+
+/** One prop of an interface: its name, whether it is optional, and its type. */
+interface DeclaredProp {
+  key: string;
+  optional: boolean;
+  type: string;
+}
+
+/** `sidebar?: React.ReactNode` — how one prop reads in a failure message. */
+const format = (prop: DeclaredProp): string =>
+  `${prop.key}${prop.optional ? '?' : ''}: ${prop.type}`;
+
+/** Drop block and line comments, so a trailing `// …` never lands in a type. */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+/**
+ * The props `interface <name>` declares in `src`, in declaration order.
+ *
+ * Each prop is matched anchored at line start and terminated by the line's last
+ * `;`, so keys nested inside a type annotation are never collected as props of
+ * their own. Same construction as `app-shell-docs-nav-example.test.ts`.
+ */
+function interfaceProps(src: string, name: string): DeclaredProp[] {
+  const body = new RegExp(`(?:export )?interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(src);
+  if (!body) throw new Error(`\`interface ${name}\` is gone from the source this test reads`);
+  return [...stripComments(body[1]).matchAll(/^[ \t]*(\w+)(\??)\s*:\s*(.+?);[ \t]*$/gm)].map(
+    (match) => ({ key: match[1], optional: match[2] === '?', type: match[3].trim() }),
+  );
+}
+
+/**
+ * Rows of the markdown table that follows the page's `### Props` heading, read
+ * as `DeclaredProp`s so they can be compared with the interface directly.
+ *
+ * Columns are `| Prop | Type | Required | In a JSON node | Description |`; the
+ * first three are the ones a props table can be wrong about in the way this
+ * issue is about. `Required` is spelled `yes`/`no` rather than the interface's
+ * `?`, and anything else is a malformed row rather than a silently-skipped one.
+ */
+function documentedProps(): DeclaredProp[] {
+  const start = GUIDE_LINES.indexOf('### Props');
+  if (start === -1) {
+    throw new Error('content/docs/guide/layout.md no longer has a `### Props` heading');
+  }
+  const props: DeclaredProp[] = [];
+  for (let i = start + 1; i < GUIDE_LINES.length; i += 1) {
+    const line = GUIDE_LINES[i];
+    if (line.length === 0) continue;
+    if (!line.startsWith('|')) {
+      if (props.length > 0) break;
+      continue;
+    }
+    const cells = line.split('|').map((cell) => cell.trim());
+    const key = /^`(\w+)`$/.exec(cells[1] ?? '')?.[1];
+    if (!key) continue; // header row and the `| --- |` separator
+    const type = (cells[2] ?? '').replace(/`/g, '').trim();
+    const required = (cells[3] ?? '').toLowerCase();
+    if (required !== 'yes' && required !== 'no') {
+      throw new Error(
+        `The \`### Props\` row for \`${key}\` spells Required as "${cells[3]}"; it must be "yes" or "no".`,
+      );
+    }
+    props.push({ key, optional: required === 'no', type });
+  }
+  return props;
+}
+
+/** Every fenced code block on the page, with its info string. */
+function fences(): { lang: string; body: string }[] {
+  return [...GUIDE.matchAll(/```([a-z]*)\n([\s\S]*?)```/g)].map((match) => ({
+    lang: match[1],
+    body: match[2],
+  }));
+}
+
+/**
+ * Prop names on every `<AppShell …>` opening tag in `body`.
+ *
+ * Walks the tag rather than regexing the fence, tracking `{}` depth and string
+ * quoting so a nested element's props — the `className` on the `<span>` inside
+ * `navbar={…}`, or the whole `<SidebarNav …/>` inside `sidebar={…}` — and the
+ * words inside a quoted attribute value are never collected as AppShell's own.
+ * Bare boolean attributes (`defaultOpen` with no `=`) are collected too, which
+ * is the one thing objectui#4817's README walker could not see.
+ */
+function appShellTagProps(body: string): string[] {
+  const props: string[] = [];
+  const TAG = '<AppShell';
+  for (let start = body.indexOf(TAG); start !== -1; start = body.indexOf(TAG, start + 1)) {
+    // Guard against matching a longer identifier, e.g. `<AppShellFoo`.
+    if (/[\w-]/.test(body[start + TAG.length] ?? '')) continue;
+    let depth = 0;
+    let quote: string | null = null;
+    let tag = '';
+    for (let i = start + TAG.length; i < body.length; i += 1) {
+      const ch = body[i];
+      if (quote) {
+        if (ch === quote) quote = null;
+        tag += ' ';
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        tag += ' ';
+        continue;
+      }
+      if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+      else if (ch === '>' && depth === 0) break;
+      tag += depth === 0 ? ch : ' ';
+    }
+    props.push(...[...tag.matchAll(/[A-Za-z_$][\w$]*/g)].map((match) => match[0]));
+  }
+  return props;
+}
+
+describe("the guide's AppShellProps table names exactly the real props (objectui#4827)", () => {
+  it('lists every prop the component declares — same order, optionality and type', () => {
+    const declared = interfaceProps(APP_SHELL_SRC, 'AppShellProps');
+    expect(declared.length, 'no props parsed out of `AppShellProps`').toBeGreaterThan(1);
+
+    expect(
+      documentedProps().map(format),
+      [
+        'The `### Props` table in content/docs/guide/layout.md and the interface in',
+        'packages/layout/src/AppShell.tsx disagree about which props exist. That table replaced',
+        'a `Schema API` block which declared ten keys for a JSON `app-shell` node, seven of',
+        'which the component has never had (objectui#4827) — and a JSON carrier has no',
+        'TypeScript consumer to catch them, so every one was dropped in silence.',
+        '',
+        'The expected list is READ OUT OF packages/layout/src/AppShell.tsx on every run, so this',
+        'is never "update the test": add the new prop to the table, or drop the row for the prop',
+        'that is gone. Only Prop / Type / Required are compared — the Description and',
+        '"In a JSON node" columns are free prose.',
+        '',
+        `Declared by the component: ${declared.map(format).join('; ')}`,
+      ].join('\n'),
+    ).toEqual(declared.map(format));
+  });
+
+  it('and the example prop objects really are `AppShellProps` (the compile-time half, made visible)', () => {
+    // These reads are the point: a `const` nobody looks at is easy to delete,
+    // and deleting it would silently retire the type-check that rejects
+    // `header` / `body` / `headerClassName` at the keyboard.
+    const declared = interfaceProps(APP_SHELL_SRC, 'AppShellProps').map((prop) => prop.key);
+    const examples = [
+      basicExampleProps,
+      fullLayoutExampleProps,
+      landingExampleProps,
+      customClassesExampleProps,
+    ];
+    for (const key of examples.flatMap((example) => Object.keys(example))) {
+      expect(declared, `\`${key}\` is not declared by AppShellProps`).toContain(key);
+    }
+    expect(Object.keys(basicExampleProps).sort()).toEqual(['children', 'navbar', 'sidebar']);
+    expect(fullLayoutExampleProps.defaultOpen).toBe(true);
+    expect(Object.keys(landingExampleProps).sort()).toEqual(['children', 'navbar']);
+    expect(customClassesExampleProps.className).toBe('bg-background');
+    // The keys the page used to teach, and the reason this pin exists.
+    expect(declared).toContain('navbar');
+    expect(declared).not.toContain('header');
+    expect(declared).not.toContain('body');
+    expect(declared).not.toContain('headerClassName');
+  });
+});
+
+describe("the guide's AppShell examples pass only props AppShellProps declares (objectui#4827)", () => {
+  it('every `<AppShell …>` prop on the page is a real one', () => {
+    const declared = interfaceProps(APP_SHELL_SRC, 'AppShellProps').map((prop) => prop.key);
+    expect(declared.length, 'no props parsed out of `AppShellProps`').toBeGreaterThan(1);
+
+    const appShellFences = fences().filter((fence) => fence.body.includes('AppShell'));
+    expect(
+      appShellFences.length,
+      'no AppShell code fence found in content/docs/guide/layout.md at all',
+    ).toBeGreaterThan(0);
+
+    const used = [...new Set(appShellFences.flatMap((fence) => appShellTagProps(fence.body)))];
+    expect(used.length, 'no `<AppShell …>` tag found on the page at all').toBeGreaterThan(0);
+
+    expect(
+      used.filter((prop) => !declared.includes(prop)),
+      [
+        'An `<AppShell>` example in content/docs/guide/layout.md passes a prop the component',
+        'does not declare. `AppShell` destructures a fixed key list with NO rest element, so an',
+        'undeclared prop is not "ignored with a warning" — the node is built and dropped, and',
+        'the page promises UI that can never appear (objectui#4827).',
+        '',
+        'The expected list is READ OUT OF packages/layout/src/AppShell.tsx on every run, so this',
+        'is never "update the test": add the prop to `AppShellProps`, or stop teaching it.',
+        `Declared: ${declared.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and actually teaches `navbar`, so the scan above is not passing on an empty set', () => {
+    // "No undeclared props" is trivially true of no props. `navbar` is the slot
+    // the phantom `header` displaced, so it is asserted positively.
+    const used = new Set(
+      fences()
+        .filter((fence) => fence.body.includes('AppShell'))
+        .flatMap((fence) => appShellTagProps(fence.body)),
+    );
+
+    expect(
+      used.has('navbar'),
+      [
+        'No `<AppShell>` example in content/docs/guide/layout.md passes `navbar` any more.',
+        '`navbar` is the ONLY entry point for top-bar content; a page that stops showing it',
+        'sends readers looking for the `header` key objectui#4827 was filed about, which has',
+        'never existed on this component.',
+        `Props currently passed: ${[...used].join(', ') || '(none)'}`,
+      ].join('\n'),
+    ).toBe(true);
+  });
+});
+
+describe('the guide authors no `app-shell` JSON node (objectui#4827)', () => {
+  it('no fence on the page contains a `{ "type": "app-shell" }` node', () => {
+    const offenders = fences().filter((fence) => /["']type["']\s*:\s*["']app-shell["']/.test(fence.body));
+
+    expect(
+      offenders.map((fence) => fence.body.split('\n')[0]),
+      [
+        'A fence in content/docs/guide/layout.md authors an `app-shell` node again',
+        '(objectui#4827). Four of the seven props are `React.ReactNode` slots and a JSON',
+        'document can fill none of them: `children` is stripped by SchemaRenderer before a',
+        "node's keys are spread as props, so `<main>` renders EMPTY with nothing logged, and a",
+        'schema in `sidebar` / `navbar` / `rightRail` reaches the component as a plain object,',
+        'which React refuses to render. The registration declares no `inputs`, so nothing',
+        'diagnoses either case. Teach the React composition instead.',
+        '',
+        'If `app-shell` is ever made authorable — inputs declared AND the slots fed from the',
+        'schema — this assertion is the right place to record that, but it must be a change to',
+        'the component, not to the page.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});
+
+describe("the source facts the guide's JSON section rests on (objectui#4827)", () => {
+  it('`AppShell` still destructures a fixed key list with no rest element', () => {
+    const params = /export function AppShell\(\{([\s\S]*?)\}: AppShellProps\)/.exec(APP_SHELL_SRC);
+    if (!params) throw new Error('`export function AppShell({ … }: AppShellProps)` is gone');
+
+    expect(
+      params[1].includes('...'),
+      [
+        'AppShell now takes a rest element. The guide tells readers that anything not on the',
+        'prop list is "built and then dropped on the floor" — the exact mechanism that made',
+        "objectui#4827's phantom keys silent. With a rest element that is no longer true, and",
+        'the page needs rewriting rather than this assertion relaxing.',
+      ].join('\n'),
+    ).toBe(false);
+  });
+
+  it('`SchemaRenderer` still strips `children` and `body` before spreading a node as props', () => {
+    const strip = /const \{([\s\S]*?)\.\.\.componentProps\s*\n\s*\} = evaluatedSchema;/.exec(
+      SCHEMA_RENDERER_SRC,
+    );
+    if (!strip) {
+      throw new Error(
+        "SchemaRenderer's metadata-strip destructuring is gone from packages/react/src/SchemaRenderer.tsx",
+      );
+    }
+    const stripped = [...stripComments(strip[1]).matchAll(/^[ \t]*(\w+)\s*:/gm)].map((m) => m[1]);
+
+    for (const key of ['children', 'body']) {
+      expect(
+        stripped,
+        [
+          `SchemaRenderer no longer strips \`${key}\` out of a node before spreading its keys as`,
+          'props. content/docs/guide/layout.md states that a JSON `app-shell` node renders an',
+          'EMPTY `<main>` for exactly that reason (objectui#4827); if the key now reaches the',
+          'component, that paragraph is false and the page — not this assertion — is what has to',
+          'change.',
+          `Currently stripped: ${stripped.join(', ')}`,
+        ].join('\n'),
+      ).toContain(key);
+    }
+  });
+});

--- a/packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts
+++ b/packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts
@@ -239,11 +239,16 @@ function documentedProps(): DeclaredProp[] {
   return props;
 }
 
-/** Every fenced code block on the page, with its info string. */
-function fences(): { lang: string; body: string }[] {
+/**
+ * Every fenced code block on the page, with its info string and the 1-based
+ * line its opening fence sits on — a JSON fence's first line is `{`, which
+ * identifies nothing, so failures quote the line number instead.
+ */
+function fences(): { lang: string; body: string; line: number }[] {
   return [...GUIDE.matchAll(/```([a-z]*)\n([\s\S]*?)```/g)].map((match) => ({
     lang: match[1],
     body: match[2],
+    line: GUIDE.slice(0, match.index).split('\n').length,
   }));
 }
 
@@ -394,7 +399,7 @@ describe('the guide authors no `app-shell` JSON node (objectui#4827)', () => {
     const offenders = fences().filter((fence) => /["']type["']\s*:\s*["']app-shell["']/.test(fence.body));
 
     expect(
-      offenders.map((fence) => fence.body.split('\n')[0]),
+      offenders.map((fence) => `content/docs/guide/layout.md:${fence.line}`),
       [
         'A fence in content/docs/guide/layout.md authors an `app-shell` node again',
         '(objectui#4827). Four of the seven props are `React.ReactNode` slots and a JSON',


### PR DESCRIPTION
Fixes #4827

`content/docs/guide/layout.md` 教了 7 个 `AppShellProps` 从未声明的键。这是 #4817(`packages/layout/README.md`,React props 载体)与 #4808(`content/docs/layout/app-shell.mdx`)之后的**第三个教学面**,也是三者里最糟的一个 —— 载体是 JSON:`app-shell` 注册时不声明 `inputs`(`packages/layout/src/index.ts`),`sdui-parser` 的 unknown-prop 检查没有可比对的声明面,照抄的键**全程零诊断**。

> 正文里凡提到 HTML 元素与 JSX 开标签,一律写成 `header` 元素 / `main` 元素 / `AppShell` 开标签,不带尖括号 —— GitHub 的正文净化器会把 `<` 紧跟字母当 HTML 标签在**存储时**吃掉(本 PR 初版正文就这样丢了三处元素名,回读发现后重写)。

## 范围:两块 → 六块

卡里点名的是两块(`Schema API` `:73-88`、`Custom Classes` `:478-486`)。实读后同页还有四块 app-shell 节点在重复同一批拼写 —— `Basic Usage` `:37`、`Full Application Layout` `:337`、`Landing Page` `:371`、`Consistent Structure` `:513` —— 六块一起改,理由与 PR #4828 相同(卡里点名一处 fence,实际同页三处同缺陷,一并修掉);而且派单要求的钉子扫描面是"本文件的 app-shell 块",留下四块会让钉子当场变红或退化成没有价值的窄扫描。

同文件的 `page` 块(现 `:160`)按派单**零触碰**。

## 七键逐个处置

先量后写。用一个探针组件量了 `SchemaRenderer` 实际递给组件的 props(schema 里八个键全给),再分别渲染真实的 `app-shell` 节点核对结局:

| 键 | 处置 | 为何 |
| --- | --- | --- |
| `header` | **删**,改教 `navbar` | `AppShellProps` 从无此键;`AppShell` 自己渲染 `header` 元素,`{navbar}` 是唯一填充物(`AppShell.tsx:248-250`) |
| `body` | **删**,改教 `children` | 同上无此键;而且 `SchemaRenderer` 把 `body` 与 `children` 一起从节点里剥掉再 spread(`SchemaRenderer.tsx:550-579`) |
| `sidebarCollapsible` | **删**,改写为"折叠行为属于你传入的侧栏节点(`SidebarNav` 的 `collapsible`)" | `AppShellProps` 无此键;`SidebarNavProps.collapsible` 是 `"offcanvas" / "icon" / "none"` |
| `sidebarDefaultOpen` | **删**,改教真实的 `defaultOpen` | `AppShellProps` 只有 `defaultOpen` |
| `headerClassName` | **删**,写明没有 per-slot className | 顶栏是调用方自建的节点,在自建处加类 |
| `sidebarClassName` | **删**,同上(示例改为 `SidebarNav className=…`) | 同上 |
| `contentClassName` | **删**,改教真实的 `className` | `className` 落在 `main` 元素上(`AppShell.tsx:256`) |

真实的七个键,以及各自在 JSON 路径上的实测结局:

| 真实 prop | 类型 | JSON 里可表达? | 实测 |
| --- | --- | --- | --- |
| `sidebar` | `React.ReactNode` | **否** | schema 值以纯对象抵达组件,`AppShell` 直接渲染 → `Component "app-shell" failed to render — Objects are not valid as a React child` |
| `navbar` | `React.ReactNode` | **否** | 同上 |
| `children` | `React.ReactNode` | **否** | `SchemaRenderer` 剥掉 `children`,组件读的是 `children` **prop** 而非 `schema.children`;`main` 元素渲染为空,`console.error` 计数 **0** —— 本单"静默"的那一半 |
| `className` | `string` | **是** | 落到 `main` 元素的 class 上(实测 `class="… custom-app"`) |
| `defaultOpen` | `boolean` | **是** | 纯数据,原样 spread 到组件 |
| `branding` | `AppShellBranding` | **是** | 经 JSON 实测设到了 `document.title` 与 `--primary` |
| `rightRail` | `React.ReactNode` | **否** | 同 `sidebar` |

所以页面没有硬造 JSON 形态:改成教 React 组合,并单列一节把上面三档结局逐条写清,末尾指向 `AppSchemaRenderer`(`app-schema-renderer`,已声明 `inputs`)作为"整壳来自元数据"的真实入口。

`branding` 行遵守 #4818 边界,照 PR #4828 第二个 commit 的写法:只列 `useAppShellBranding` 真正读的四个字段(`primaryColor` / `accentColor` / `favicon` / `title`),对无读取方的 `logo` 不作任何承诺。

## 防回潮钉

新增 `packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts`,与 `readme-app-shell-example.test.ts`(#4817)、`app-shell-docs-nav-example.test.ts`(#4793/#4808)同族同构,期望值一律**运行时现读 interface**:

1. 编译期:四个示例的 props 声明为真实 `AppShellProps` 值,由本包 `type-check` 编译 —— 重新加回 `header` 就是 TS2353。
2. 键表 parity:`### Props` 表的 prop / 顺序 / 可选性 / 类型文本对 `AppShell.tsx` 逐项比对。
3. 全页 tag 扫描:每个 `AppShell` 开标签的 props 必须都被 interface 声明(走括号深度 + 引号状态的标签行走器,顺带补上 #4817 那版看不见的裸布尔属性);外加 `navbar` 正向锚点。
4. 全页 JSON 节点扫描:任何 fence 里不得再出现 `app-shell` 节点。
5. 页面 prose 所依赖的两个源码事实:`AppShell` 仍是无 rest 的固定键表解构;`SchemaRenderer` 仍剥离 `children` / `body`。

扫描面**只**覆盖本页的 app-shell 材料 —— 同页 `page` 块为另一个组件(`@object-ui/components` 的 `PageRenderer`)声明了 `headerClassName` / `bodyClassName`,所以文件级禁词是错的,钉子头注释里写明了这条边界。

## 反向验证(先预判,后实跑)

**变异 A** —— 还原旧页面、保留钉子。预判:T1 表 parity 红(且是**抛错**而非 diff —— 旧页没有 `### Props` 标题);T2 编译期半边**绿**(它只读源码与类型化常量,`tsc` 才是它的执行者,还原文档动不了它 —— 这一项如实记为绿,不假造红);T3 tag 扫描红,但落在 `no AppShell code fence found` 这道守卫上而非"未声明 prop"清单(旧页的幻影键是 **JSON** 键,本扫描按设计不读);T4 `navbar` 锚点红;T5 JSON 节点红(5 处);T6/T7 源码事实绿。

实跑 **4 failed | 3 passed**,逐条命中预判:

```
× lists every prop the component declares …
  → content/docs/guide/layout.md no longer has a `### Props` heading
✓ and the example prop objects really are `AppShellProps` …
× every AppShell-tag prop on the page is a real one
  → no AppShell code fence found in content/docs/guide/layout.md at all: expected 0 to be greater than 0
× and actually teaches `navbar`, …
  → Props currently passed: (none): expected false to be true
× no fence on the page contains a `{ "type": "app-shell" }` node
  → expected [ '{', '{', '{', '{', …(1) ] to deeply equal []
✓ `AppShell` still destructures a fixed key list with no rest element
✓ `SchemaRenderer` still strips `children` and `body` …
```

还原用 `git checkout 本分支 -- 路径`(先 commit 后变异,不用 stash)。

**变异 B** —— 因为 T2 在变异 A 下按构造就是绿的,单独把 `header: null` / `headerClassName: 'x'` 加回 `basicExampleProps` 跑 `tsc -p packages/layout/tsconfig.test.json`,验证编译期那一半真的会咬:

```
guide-layout-app-shell-doc.test.ts(135,3): error TS2353: Object literal may only specify
known properties, and 'header' does not exist in type 'AppShellProps'.
```

变异 A 里那份 `[ '{', '{', '{', '{', … ]` 的失败清单定位不到任何东西(JSON fence 的首行就是 `{`),第二个 commit 把它改成报 `content/docs/guide/layout.md` 加行号。

## 验证

- `pnpm exec vitest run packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts` → **7 passed**
- `pnpm exec vitest run packages/layout/` → **14 files / 161 tests passed**
- `pnpm exec vitest run scripts/` → **45 files / 1041 tests passed**
- `pnpm exec turbo run type-check --concurrency=2` → **81 successful, 81 total**
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → OK(另对改动文件做了 `grep -naP` 自扫,零命中)
- `node scripts/check-changeset-presence.mjs` → 1 个 src 文件(测试)变更 + 1 个**空 frontmatter** changeset,显式声明不发版
- 改动路径 `eslint` 干净

## 顺带发现(本 PR 不修,已另立)

- #4840 —— 同页 SidebarNav 两块教一个**从未注册**的 `sidebar-nav` JSON 节点,键表与 `SidebarNavProps` / `NavItem` 全面不符(`label` 应为 `title` 等)
- #4841 —— `[finding]` `app-shell` 注册面本身:四个 ReactNode 插槽 JSON 一个都填不了、`inputs` 又为空,节点解析得到却永远渲染不出壳
- #4842 —— 同页「Responsive Behavior」承诺 header 自带侧栏开关按钮,而 `AppShell` 的 header 只渲染 `{navbar}`

同页 `page` 块仍未审计,按卡内声明留给分诊。
