### PR TITLE
fix(lint): honour the `_` prefix convention in no-unused-vars (#4835)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,41 @@ export default tseslint.config({
       { allowConstantExport: true },
     ],
     '@typescript-eslint/no-explicit-any': 'warn',
-    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    // objectui#4835 — this repo already writes a leading `_` to mean "declared
+    // on purpose, deliberately unused", but only `argsIgnorePattern` was set,
+    // so the rule honoured that convention for FUNCTION PARAMETERS and for
+    // nothing else. Measured on origin/main @ 378dc920b (#4806, re-measured in
+    // this PR): 822 no-unused-vars warnings, 613 of them (74.6%) on names the
+    // author had already marked `_`. The two dominant populations are
+    // legitimate constructs rather than dead code — 442 type-level assertions
+    // in tests (`type _NotAny = Assert< ... >`, erased before anything runs, so
+    // "unused" is what a passing pin looks like) and the deliberate-omit
+    // destructuring idiom. `caughtErrors` defaults to `'all'` in
+    // typescript-eslint v8, so `catch (_e)` was reported too. The two patterns
+    // added below close that gap; they do not weaken the rule, and severity
+    // stays `warn` — `.github/workflows/lint.yml` sets no `--max-warnings`, so
+    // this rule could not fail CI before and cannot now (errors 0 -> 0,
+    // no-unused-vars 822 -> 209).
+    //
+    // `ignoreRestSiblings` is deliberately LEFT at its `false` default, so
+    // `const { a, ...rest }` still reports `a`. It is a different mechanism
+    // from the `_` convention, not an extension of it: it exempts every
+    // rest-sibling by SYNTAX whatever it is named, so a property someone simply
+    // forgot to use is silenced with nothing declared at the site. Measured:
+    // 194 findings sit next to a rest element and 155 of them (80%) are ALREADY
+    // spelled `_` — that idiom is what this codebase actually uses (see
+    // packages/plugin-view/src/ObjectView.tsx and
+    // packages/components/src/renderers/action/action-bar.tsx), and the
+    // patterns below already cover all 155. The 39 left over carry no `_`, and
+    // 20 of those are function PARAMETERS — exempting them by syntax would open
+    // a second, undeclared path around the `argsIgnorePattern` convention this
+    // very config states. Turning it on is a separate decision with its own
+    // trade-off; see objectui#4835.
+    '@typescript-eslint/no-unused-vars': ['warn', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+      caughtErrorsIgnorePattern: '^_',
+    }],
     // objectui#4029 — importing a package must not write noise to the
     // consumer's console. House convention (measured, not invented): the
     // one known leak used `console.log`, while every deliberate diagnostic


### PR DESCRIPTION
Fixes #4835
Refs #4806

## 做了什么

`eslint.config.js` 的 `@typescript-eslint/no-unused-vars` 只设了 `argsIgnorePattern: '^_'` —— 全仓「`_` 前缀 = 故意声明、故意不用」的约定,只对**函数参数**生效,对变量、类型、catch 变量一概不认。本 PR 补上 `varsIgnorePattern: '^_'` 与 `caughtErrorsIgnorePattern: '^_'`,把配置对齐到作者早就在用的写法。

**只改了 `eslint.config.js` 一个文件**,不动任何规则 severity,不删任何代码。

配置语义是**实读**安装版本 `@typescript-eslint/eslint-plugin@8.66.0` 的 `dist/rules/no-unused-vars.js` 确认的,不是照记忆:

- `defaultOptions: [{}]`,传入的 options 对象是**并到默认值上**的,所以原来只写 `argsIgnorePattern` 并没有重置别的开关;
- `caughtErrors` 默认 `'all'`(:263),所以 `catch (_e)` 之前**确实**被报;
- 派发口径的 `ignoreRestSiblings` 默认 `false`(:269),rest-sibling 惯用法之前**确实**被报 —— #4806 这条实测成立;
- `reportUsedIgnorePattern` 默认 `false`(:271),所以新增 pattern **不可能**反向制造出新的 no-unused-vars warning;
- 生效分支是 `if (CatchClause) ... else if (Parameter) ... else if (varsIgnorePattern)`(:707-747),即 catch 只认 `caughtErrorsIgnorePattern`、参数只认 `argsIgnorePattern`、**其余全部**(变量、type alias、import、class/function 名)认 `varsIgnorePattern`。

## 前后计数(仓根照 `lint.yml` 的实际命令跑,`turbo run lint`,47/47 tasks,`--force` 关缓存)

| 指标 | 修前(`origin/main` @ `378dc920b`) | 修后 | 差 |
|---|---|---|---|
| `@typescript-eslint/no-unused-vars` | **822** | **209** | −613 |
| 总 warning | **10437** | **9828** | −609 |
| **error** | **0** | **0** | **0** |
| 失效 `eslint-disable` 指令 | 45 | 49 | +4 |

计数用两条互相独立的口径交叉核对过:stylish 自己的 `problems (N errors, M warnings)` 汇总行求和,与逐行正则计数,两者都得 10437 / 9828;`grep -c` 再核一遍规则名命中数。

**822 与 209 都与卡上预期完全一致,偏差 0%**(卡预期 822 量级 → ~209 量级)。613 = 822 的 74.6%,与 #4806 测得的「613 条已是 `_` 开头」逐条对上。修后剩下的 209 条里,**`_` 开头的是 0 条** —— 被消掉的恰好就是全部已标注项,一条没多、一条没少。

### 为什么总量只降了 609 而不是 613

差的 4 条是**新增**的,全部是同一类:`Unused eslint-disable directive`。它们出现在仓里仅有的 4 处手写 `eslint-disable @typescript-eslint/no-unused-vars` —— 也就是作者为了绕开本 PR 修的这个缺口而自己加的豁免。缺口补上后这些豁免就多余了:

| 站点 | 原本在挡什么 |
|---|---|
| `packages/components/src/renderers/action/action-bar.tsx:126` | 一串 `actions: _schemaActions` 之类的 omit 解构 |
| `packages/plugin-view/src/ObjectView.tsx:712` | `const { columns: _kanbanColumns, ..., ...restKanban }` |
| `packages/react/src/__tests__/SchemaRenderer.propsResolution.test.ts:55` | 整文件的 `_` 类型级断言 |
| `packages/mobile/src/__tests__/responsive-config-spec-parity.test.ts:56` | 整文件的 `_` 类型级断言 |

最后那处的豁免理由注释本身就是本卡前提的**仓内佐证**,它写的是:「The repo's `no-unused-vars` ignores `^_` for ARGUMENTS only, which is why `packages/types`' equivalent file carries the same warnings; scoping the exemption to this file keeps it from becoming a repo-wide hole.」

按 PM 在 #4806 的排程(「R1 可能新增少量失效指令,后做避免二次清」),这 4 条**不在本单清理**,留给 #4833 一次扫完(45 → 49)。

## 门禁强度零变化

修前修后 **error 都是 0**,`turbo` 两次都 `TURBO_EXIT=0`。规则 severity 仍是 `warn`,而 `.github/workflows/lint.yml:20-28` 有意不设 `--max-warnings`,所以这条规则修前修后都不可能让 CI 变红。新增的 4 条失效指令也是 warning,同样不影响门禁。

## 反向验证(先写预判,再跑,不提交)

已先 commit 再变异(AGENTS.md §9 要求的还原点),变异内容:**只**删掉 `varsIgnorePattern: '^_'`,保留另外两条。

预判方向是**计数回升**,不是反转 —— `varsIgnorePattern` 是纯抑制项,没有任何下游谓词读它的计数,所以删掉只可能让 finding 回来,不可能在别处凭空多出 finding。

| 指标 | 已提交版 | **预判** | **实测** | 修前基线 |
|---|---|---|---|---|
| no-unused-vars | 209 | **820** | **820** ✅ | 822 |
| 总 warning | 9828 | **10435** | **10435** ✅ | 10437 |
| error | 0 | **0** | **0** ✅ | 0 |
| 失效 `eslint-disable` | 49 | **45** | **45** ✅ | 45 |

四项全中。预判 820 而非 822,是因为变异版仍留着 `caughtErrorsIgnorePattern`,那 2 条 `_` 开头的 catch 变量仍被抑制;总量同理差 2。`_` 开头的 finding 数也回到 611(= 613 − 2),与模型一致。验证完已 `git checkout` 还原,工作树与 commit 逐字节一致(`git diff HEAD` 为空)。

## 抽查:5 条被消掉的 warning,逐条确认是故意声明

| # | 位置 | 写法 | 判定 |
|---|---|---|---|
| 1 | `packages/plugin-charts/src/__tests__/spec-symbol-batch7.test.ts:56` | `type _SpecIsReal = Assert< Equal< IsAny< SpecChartConfig >, false > >;` | **故意**。编译期断言,`tsc` 是它唯一消费者、运行前即被擦除 —— 「没被用」正是一条**通过**的断言该有的样子。删了等于删掉断言本身 |
| 2 | `packages/cli/src/commands/dev.ts:97`(及 `:115`) | `} catch (_e) {` | **故意**。handler 只打一句固定文案,不检查 error 对象。`caughtErrors` 默认 `'all'` 才使它被报 |
| 3 | `examples/schema-catalog/vitest.config.ts:9` | `const { projects: _omit, ...rootTest } = rootConfig.test ?? {};` | **故意**。上方有 6 行注释说明为什么必须丢掉 `projects`;这个绑定的存在目的就是被丢弃 |
| 4 | `packages/plugin-chatbot/src/useHitlInChat.ts:182` | `const { [toolCallId]: _omit, ...rest } = prev;` | **故意**。不可变地从 state 对象里摘掉一个键,同样是「存在即为了被丢弃」 |
| 5 | `packages/cli/src/commands/dev.ts:73` / `:89` | `let _projectRoot = cwd;`,`:89` 再赋值一次,全文再无读取 | **`_` 标注属实,但如实说:这条更接近休眠代码而非构造性写法** —— 赋值了从不读取。本 PR 兑现的是作者的显式声明,不是在掩盖缺陷(它不是任何用户碰得到的问题),但它确实不像前四条那样「不得不这么写」 |

第 5 条不粉饰:它引出一个对后续排程有用的事实,已单独回帖到 #4806。

## `ignoreRestSiblings`:实读 + 实测后**决定不动**,依据如下

派发允许我实读后自行判断,并要求「若它有独立争议就不动并回传」。结论是**不动**(保持默认 `false`),理由不是回避,是实测数据指向这一侧:

单独跑了一次 `ignoreRestSiblings: true` 的探针,把 rest-sibling 全量摸清了:

- 全仓紧邻 rest 元素的 finding 共 **194** 条;
- 其中 **155 条(80%)本来就是 `_` 开头的** —— 也就是说,这个仓对 omit 惯用法**实际采用的写法就是 `_`**(`packages/plugin-view/src/ObjectView.tsx:712`、`packages/components/src/renderers/action/action-bar.tsx:126` 都是现成例子),而本 PR 的 `varsIgnorePattern` 已经把这 155 条全部覆盖;
- 剩下 **39 条**都不带 `_`,分布在 16 个文件,**其中 20 条是函数参数**(名字如 `asChild` / `variant` / `size` / `align` / `sideOffset` / `field`)。

所以:

1. 它**不是** `_` 约定的延伸,而是另一套机制 —— 按**语法**豁免,不看名字。`const { a, ...rest }` 里那个纯粹忘了用的 `a`,会在作者**没有作出任何声明**的情况下被静音;`_` 则要求作者在现场把「我故意不用」打出来,是可见、可 grep 的声明。
2. 它会越过变量伸进**参数**(39 条里占 20 条)。参数这一类,本配置**已经**用 `argsIgnorePattern` 明文立了约定;再开一条按语法豁免的暗路绕过它,等于同一个概念有两套互不知情的豁免机制。
3. 本卡要兑现的那条 rest-sibling 冲突,**80% 已经被本 PR 通过声明式的路径解决掉了**,剩下 39 条属于「作者没声明」,恰恰是该留着报的那部分。

因此这属于**独立决策**、有自己的取舍(会不会因此逼着人写 `const { className: _className, ...rest }` 这种略啰嗦的拼法),不适合搭在这张零决策的机械卡里。已按派发要求回传 PM 定夺。理由同时写进了配置注释,免得下一个读到这行的人以为是漏配。

## 其他

- **changeset:实测判定不欠**,不是照惯例推断。`node scripts/check-changeset-presence.mjs` 输出:「1 file(s) changed, 0 of them under the src/ of a package the release covers ... ✅ No source of a released package changed in this range, so no changeset is owed.」根配置文件不属发版包 `src/`,与 PR #4802 / #4825 的先例一致。
- `node scripts/check-control-bytes.mjs` 通过(4329 个文件);另按纪律做了超出门禁扫描面的自查 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,`eslint.config.js` 干净。
- 仓根 type-check 免跑:本改动无任何 TS 语义变化(只改 lint 配置,不碰源码)。硬要求的 `pnpm lint` 全绿已达成(0 error)。
- 入队前复核过共享基建纪律:`git log 378dc920b..origin/main -- eslint.config.js` 为空,在飞期间无人改过这个文件。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_