### PR TITLE
chore(build): 四个包的 dist 不再发布 tooling 产物 —— 排除判据从文件名对齐到目录约定 (#4836)

### DIFF
--- a/.changeset/core-plugins-tooling-artifacts-out-of-dist-4836.md
+++ b/.changeset/core-plugins-tooling-artifacts-out-of-dist-4836.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/core': patch
+'@object-ui/plugin-designer': patch
+'@object-ui/plugin-grid': patch
+'@object-ui/plugin-view': patch
+---
+
+Four packages stop publishing tooling material in their `dist/`
+
+Each of these packages spelled its build exclusions as `*.test.*`, while this repo's tooling convention is a directory one — `__tests__` / `__mocks__` / `__benchmarks__`, exactly as `TOOLING_FILE` in `scripts/check-phantom-dependencies.mjs` spells it. Any tooling file whose *name* is not `*.test.*` therefore stayed in the emit program and shipped in the tarball. This is the same shape and the same cause as objectui#4006, which fixed `@object-ui/fields` and `@object-ui/plugin-editor` by the filename criterion and so did not reach these four.
+
+Measured by building each package from a cleared `dist/` on both sides of the change. Nine files disappear, none appears, and every surviving file is untouched — the totals move by exactly the count removed:
+
+| package | `dist/` files | removed |
+| --- | --- | --- |
+| `@object-ui/core` | 176 to 174 | `dist/__benchmarks__/core.bench.js`, `core.bench.d.ts` |
+| `@object-ui/plugin-designer` | 70 to 66 | `dist/__tests__/__mocks__/plugin-form.d.ts`, `plugin-grid.d.ts`, and both `.d.ts.map` |
+| `@object-ui/plugin-grid` | 62 to 60 | `dist/__tests__/explainDouble.d.ts` and its `.d.ts.map` |
+| `@object-ui/plugin-view` | 13 to 12 | `dist/__tests__/explainDouble.d.ts` |
+
+Only `@object-ui/core`'s had runtime weight. The other eight are declarations nothing resolves, but `core.bench.js` is a real emitted module whose first import is `import { bench, describe } from 'vitest'` — a runtime import of a package a consumer never installs, since `vitest` is a devDependency of `@object-ui/core` and devDependencies are not installed transitively. Nothing resolves it today either (it is not in the `exports` map), so no consumer breaks in either direction; this is the tarball shedding files nothing reached.
+
+No type coverage leaves with the emit. The three plugins' helper and mock files are already program inputs of the `tsconfig.test.json` that each package's `type-check` chains, reached through the imports in the suites beside them — `tsc --listFiles` names all four files on both sides of the change. `core.bench.ts` had no such edge, since nothing imports a benchmark, so it is now named explicitly in `packages/core/tsconfig.test.json`. That move was deliberate rather than forced: `scripts/check-type-check-coverage.mjs` enumerates `*.test.ts(x)` only, so a benchmark that no program reads is invisible to it, and dropping the coverage silently would have been the "coverage that was right by accident" objectui#4006 recorded. Verified by appending a provably-false annotation to the benchmark, which turns `tsc -p packages/core/tsconfig.test.json` red at exit 2.

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,7 +8,40 @@
     "composite": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts"],
+  // This is the BUILD program — `build` is a bare `tsc` and the options above
+  // make it EMIT (`noEmit: false`, `declaration`, `outDir: dist`), so whatever
+  // this program reads is written into `dist`, and `files: ["dist"]` publishes
+  // all of it. The exclusions therefore have to cover every TOOLING directory,
+  // not just the `*.test.ts` name (objectui#4836).
+  //
+  // The old list named only `src/**/*.test.ts`, so `src/__benchmarks__/` was in
+  // the emit program and `dist/__benchmarks__/core.bench.{js,d.ts}` shipped in
+  // the tarball. `core.bench.js` is a REAL emitted module, not just a
+  // declaration: its first import is `import { bench, describe } from 'vitest'`
+  // — a runtime import of a package a consumer never installs, since `vitest`
+  // is a devDependency here and devDependencies are not installed
+  // transitively. That is the same shape objectui#4006 fixed for
+  // `@object-ui/fields` / `@object-ui/plugin-editor`, whose exclusion table was
+  // likewise written as `*.test.*` and so did not cover `__benchmarks__/`.
+  //
+  // The directory names are the repo's tooling convention, and they are
+  // deliberately spelled the same way `TOOLING_FILE` in
+  // scripts/check-phantom-dependencies.mjs spells it — that gate classifies
+  // these three directories as tooling and lets them resolve against the root
+  // devDependencies, so a build program that emits them publishes exactly the
+  // material the gate assumes never ships. `__tests__` and `__mocks__` are
+  // no-ops for this package today (every file under `src/**/__tests__/` here is
+  // a `*.test.ts`, already covered by the glob below); they are named so the
+  // criterion is the convention rather than one file's name.
+  //
+  // `core.bench.ts` did not lose its type coverage with the emit: it moved to
+  // the chained `tsconfig.test.json`, which `type-check` runs.
+  "exclude": [
+    "src/**/__tests__/**",
+    "src/**/__mocks__/**",
+    "src/**/__benchmarks__/**",
+    "src/**/*.test.ts"
+  ],
   "references": [
     { "path": "../types" }
   ]

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -37,5 +37,14 @@
     // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
     "paths": {}
   },
-  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  // `*.bench.ts` is here for the same reason the tests are, and it arrived the
+  // same way: `tsconfig.json` now excludes `src/__benchmarks__/` from the BUILD
+  // program so it stops being emitted into the published `dist`
+  // (objectui#4836). Until that exclusion, `src/__benchmarks__/core.bench.ts`
+  // was type-checked only as a side effect of being in the emit program — the
+  // exact "coverage that is right by accident" objectui#4006 recorded. Nothing
+  // would have reported its loss either: scripts/check-type-check-coverage.mjs
+  // enumerates `*.test.ts(x)` only, so a bench that no program reads is
+  // invisible to it. It is named here by choice, not because a gate forced it.
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.bench.ts"]
 }

--- a/packages/plugin-designer/tsconfig.json
+++ b/packages/plugin-designer/tsconfig.json
@@ -14,5 +14,30 @@
     "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  // The exclusions cover TOOLING DIRECTORIES, not just the `*.test.*` name
+  // (objectui#4836). `vite-plugin-dts` builds its declaration program from this
+  // config, so a tooling file left in it is emitted into `dist` and published:
+  // measured, `src/__tests__/__mocks__/plugin-form.tsx` and `plugin-grid.tsx`
+  // are not `*.test.tsx` by name, so the old list let
+  // `dist/__tests__/__mocks__/plugin-{form,grid}.d.ts` (+ `.d.ts.map`) ship in
+  // the tarball. Same shape as objectui#4006, same cause — an exclusion table
+  // written against a filename pattern while the repo's convention is a
+  // directory one (`__tests__` / `__mocks__` / `__benchmarks__`, exactly as
+  // `TOOLING_FILE` in scripts/check-phantom-dependencies.mjs spells it).
+  //
+  // No type coverage moves with them. Both mocks are reached from the suites
+  // here through a `vi.mock()` factory that returns a dynamic
+  // `import('./__mocks__/plugin-grid')`, and a dynamic import with a literal
+  // specifier is a module edge `tsc` follows — so the `tsconfig.test.json`
+  // chained off `type-check` already reads both as program inputs (measured
+  // with `tsc --listFiles`), both before and after this change.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__benchmarks__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }

--- a/packages/plugin-grid/tsconfig.json
+++ b/packages/plugin-grid/tsconfig.json
@@ -14,5 +14,27 @@
     "skipLibCheck": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  // The exclusions cover TOOLING DIRECTORIES, not just the `*.test.*` name
+  // (objectui#4836). `vite-plugin-dts` builds its declaration program from this
+  // config, so a tooling file left in it is emitted into `dist` and published:
+  // measured, `src/__tests__/explainDouble.ts` is not a `*.test.ts` by name, so
+  // the old list let `dist/__tests__/explainDouble.d.ts` (+ `.d.ts.map`) ship in
+  // the tarball. Same shape as objectui#4006, same cause — an exclusion table
+  // written against a filename pattern while the repo's convention is a
+  // directory one (`__tests__` / `__mocks__` / `__benchmarks__`, exactly as
+  // `TOOLING_FILE` in scripts/check-phantom-dependencies.mjs spells it).
+  //
+  // No type coverage moves with them: `explainDouble.ts` is imported by the
+  // suites in this directory, so the `tsconfig.test.json` chained off
+  // `type-check` already reads it as a program input (measured with
+  // `tsc --listFiles`), both before and after this change.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__benchmarks__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }

--- a/packages/plugin-view/tsconfig.json
+++ b/packages/plugin-view/tsconfig.json
@@ -16,5 +16,27 @@
   // Tests are type-checked by `tsconfig.test.json`, which the `type-check`
   // script chains: they need `@testing-library/jest-dom`'s global matcher
   // augmentation, and this project is the build, so they must not reach `dist`.
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  //
+  // The exclusions cover TOOLING DIRECTORIES, not just the `*.test.*` name
+  // (objectui#4836). `vite-plugin-dts` builds its declaration program from this
+  // config, so a tooling file left in it is emitted into `dist` and published:
+  // measured, `src/__tests__/explainDouble.ts` is not a `*.test.ts` by name, so
+  // the old list let `dist/__tests__/explainDouble.d.ts` ship in the tarball.
+  // Same shape as objectui#4006, same cause — an exclusion table written
+  // against a filename pattern while the repo's convention is a directory one
+  // (`__tests__` / `__mocks__` / `__benchmarks__`, exactly as `TOOLING_FILE` in
+  // scripts/check-phantom-dependencies.mjs spells it).
+  //
+  // No type coverage moves with them: `explainDouble.ts` is imported by the
+  // suites in this directory, so the chained `tsconfig.test.json` already reads
+  // it as a program input (measured with `tsc --listFiles`).
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__benchmarks__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
Fixes #4836

## 缺陷形态(一句话)

build 程序的排除表按**文件名** `*.test.*` 写,而本仓 tooling 约定是**目录**约定(`__tests__` / `__mocks__` / `__benchmarks__` —— 与 `scripts/check-phantom-dependencies.mjs` 的 `TOOLING_FILE` 逐字一致)。凡是名字不叫 `*.test.*` 的 tooling 文件都留在 emit 程序里,随 `files: ["dist"]` 进 tarball。这正是 objectui#4006 的形态与成因:#4006 按 `*.test.*` 修,所以够不着这四处。

## 全仓面测量(逐包判定)

⛔ 不是 grep 配置。用 TypeScript API 把**每个** workspace 包的 build tsconfig 解析成真实程序文件表(走 `extends`),按 `TOOLING_FILE` 判,再对候选包**干净重建实测 dist**。46 个包里 9 个包的 tsconfig 程序含 tooling 文件,其中 **4 个真的 emit 进 dist**:

| 包 | emitter | tsconfig 程序含 tooling | 干净重建后 dist 里的 tooling 产物 | 判定 |
|---|---|---|---|---|
| `@object-ui/core` | 裸 `tsc`(`noEmit:false`) | 1 | `__benchmarks__/core.bench.js` + `.d.ts` | **命中,本 PR 修** |
| `@object-ui/plugin-designer` | `vite-plugin-dts` | 2 | `__tests__/__mocks__/plugin-{form,grid}.d.ts` + 两个 `.d.ts.map` | **命中,本 PR 修** |
| `@object-ui/plugin-grid` | `vite-plugin-dts` | 1 | `__tests__/explainDouble.d.ts` + `.d.ts.map` | **命中,本 PR 修** |
| `@object-ui/plugin-view` | `vite-plugin-dts` | 1 | `__tests__/explainDouble.d.ts` | **命中,本 PR 修** |
| `@object-ui/plugin-charts` | `vite-plugin-dts` | 31 | 无 | 干净:31 个全是 `*.test.*`,dts 的 exclude 已覆盖 |
| `@object-ui/cli` | `tsup`(entry 卷 dts) | 4 | 无 | 干净:tsup 只从 `entry` 出料,程序含测试是 `tsc --noEmit` 的**类型覆盖**,不是 emit |
| `@object-ui/data-objectstack` | `tsup`(entry 卷 dts) | 38 | 无 | 同上。注:其 `files` 本就含 `src`,与本缺陷无关 |
| `@object-ui/console` | `tsc --noEmit` + vite 应用打包 | 51 | 无 | 干净:tsconfig `noEmit:true`,tsc 不写盘;bundle 只收 entry 可达图 |
| `@object-ui/test-support` | 无 build | 1 | 无 | 干净:`private:true`,不发布 |

四处命中的**共同点**是排除表写成 `*.test.*`;命中的具体文件恰好都不叫 `*.test.*`(`core.bench.ts`、`explainDouble.ts`、`__mocks__/plugin-*.tsx`)。

## 修法

统一在**发射程序**那一层把排除判据从「文件名」改成「tooling 目录」。四个包都只动 build tsconfig 的 `exclude`:

- `packages/core/tsconfig.json`
- `packages/plugin-designer/tsconfig.json`
- `packages/plugin-grid/tsconfig.json`
- `packages/plugin-view/tsconfig.json`

**没有动任何 `vite.config.ts`。** 实测:三个 vite 包的 dts 产物由 `vite-plugin-dts` 出,但该插件会合并 tsconfig 的 `exclude`,单加 tsconfig exclude 就足以让产物消失(与 #4006 对 plugin-editor 的实测结论一致:「the exclude alone removes it, so no dts-plugin exclude is needed」)。

### 类型覆盖:三个插件零移动,core 显式搬家

- 三个插件的 helper/mock **本来就是**各自链式 `tsconfig.test.json` 的程序输入,靠同目录测试的 import 边进去(`explainDouble.ts` 被 suite 直接 import;两个 mock 经 `vi.mock()` 工厂里的 `import('./__mocks__/plugin-grid')` —— 字面 specifier 的动态 import 是 `tsc` 会跟的模块边)。改动前后 `tsc --listFiles` 都点名这四个文件,**覆盖零移动**。
- `core.bench.ts` 没有这种边(没人会 import 一个 benchmark),所以显式写进 `packages/core/tsconfig.test.json` 的 `include`。**这一步是主动做的,不是门逼的** —— `scripts/check-type-check-coverage.mjs` 只枚举 `*.test.ts(x)`,一个没人编译的 bench 对它完全隐形,静默丢覆盖正是 #4006 记下的「靠副作用对的覆盖」。已用**可证伪注解**验证覆盖是真的:给 bench 追加一行错误类型标注,`tsc -p packages/core/tsconfig.test.json` 退出 2 并报 `TS2322`,还原后退 0。

## 机制化判断:本 PR **不建门**,理由是测量出来的

面是 4 处(多处),按派发要求评估了在 gate 家族加一条断言的成本,结论是**当前不值得**,把依据写在这里交维护者复核:

1. **静态判据会误红,而且误导的方向是删覆盖。** 唯一便宜的静态写法是「build tsconfig 程序不得含 `TOOLING_FILE`」。实测它会红 5 个**零缺陷**的包(charts / cli / data-objectstack / console / test-support);其中 cli、data-objectstack、plugin-charts 的 tooling 文件留在程序里**正是它们测试拿到 `tsc --noEmit` 覆盖的方式**。按这条门去「修」它们 = 把 73 个测试挪出类型程序,恰好是 #4006 的镜像失败。
2. **真正正确的判据是产物级的**(「已发布包的 `dist/` 不得含 `TOOLING_FILE`」),但它要求先 build。**今天 CI 没有任何 job 全仓 build**:`Build & E2E` 只跑 `pnpm --filter @object-ui/console exec vite build`(注释里写明了原因),`Type Check` 只经 turbo `^build` 建出依赖闭包,叶子包不保证被建。挂在「dist 存在才检查」上就是那种**因为没东西可查所以绿**的空判决门,比没有更坏。
3. 因此这条断言的真实成本是「新增一个全仓 build 的 CI job」,不是「再写一个 `check:*` 脚本」—— 这个取舍超出本卡,建议单独立卡由维护者定夺。

## 反向验证(方向先判后跑;实际方向与模板预设**不同**,如实记录)

**预判**(跑之前写下的):这次修的是「排除」,产物是**一组 emit 文件**,而本 PR 没建门,所以正确预判**不是**「钉子变红」,而是——(a) 去掉新 exclude、干净重建,9 个 tooling 产物**原样重现**;(b) **所有门保持绿**,因为今天没有任何门看得见这一类缺陷。

**实跑,两半都与预判一致**(先 commit 修复再变异,变异不提交,已还原):

去掉新 exclude 干净重建,产物重现,总数差恰好等于被删数,没有任何其它文件变动:

| 包 | dist 文件数(有缺陷 -> 修复后) | 重现的 tooling 产物 |
|---|---|---|
| core | 176 -> 174 | `__benchmarks__/core.bench.{js,d.ts}` |
| plugin-designer | 70 -> 66 | `__tests__/__mocks__/plugin-{form,grid}.d.ts(+.map)` |
| plugin-grid | 62 -> 60 | `__tests__/explainDouble.d.ts(+.map)` |
| plugin-view | 13 -> 12 | `__tests__/explainDouble.d.ts` |

在**同一个有缺陷的状态**下跑全部相关门,全部退 0:

```
node scripts/check-type-check-coverage.mjs    OK 45/46 + 41/41   rc=0
node scripts/check-phantom-dependencies.mjs   OK                 rc=0
node scripts/check-control-bytes.mjs          OK                 rc=0
node scripts/check-package-self-import.mjs    OK                 rc=0
```

这个「什么都没变红」**就是结论本身**:它是上面第 2 条机制化判断的实测依据 —— 缺陷在 CI 里完全不可见。还原后重建,四个包 tooling 产物均为 0,文件数回到 174/66/60/12。

## 验证(全部实跑)

```
干净重建(rm -rf dist tsbuildinfo 后 build):
  core / plugin-designer / plugin-grid / plugin-view
  tooling 产物 0 / 0 / 0 / 0,入口 dist/index.d.ts 四个包均在

pnpm exec vitest bench packages/core/src/__benchmarks__/core.bench.ts --run   rc=0(bench 真跑起来了)
pnpm exec vitest run packages/core/ packages/plugin-grid/ packages/plugin-view/ packages/plugin-designer/ --maxWorkers=2
                                              180 files / 2688 tests passed

pnpm exec turbo run type-check --concurrency=2 --force      81 successful, 81 total
  (动了 tsconfig,必须 --force 防缓存假绿)
tsc -p packages/core/tsconfig.test.json                     rc=0;--listFiles 点名 core.bench.ts
tsc -p packages/core/tsconfig.test.json(bench 加错误标注)    rc=2,TS2322 —— 覆盖是真的

node scripts/check-type-check-coverage.mjs     OK 45/46 via type-check;41/41 编译测试,0 债
node scripts/check-phantom-dependencies.mjs    OK 40 包 / 14002 specifier
node scripts/check-control-bytes.mjs           OK 4332 文件
node scripts/check-changeset-presence.mjs      OK(门不索要:没动发版包 src/;仍按 #4006/PR #4539 先例写了真 patch changeset,因为发布物内容变了)
node scripts/check-changeset-no-major.mjs      OK
node scripts/check-changeset-fixed.mjs         OK
eslint(改动路径)                                0 errors
```

## 范围外

- 未新建任何门(理由见上「机制化判断」)。
- 未碰 `content/docs/releases/**`、未碰任何 `vite.config.ts`、未碰任何 `src/` 源码。
- `@object-ui/data-objectstack` 的 `files` 含 `src`(测试源码本就随包发布)与本缺陷不同源,未处理。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_