### PR TITLE
docs(layout): guide/layout.md 教真实的 SidebarNav,并按实现改写 Responsive Behavior (#4840, #4842)

### DIFF
--- a/.changeset/guide-layout-sidebar-nav-4840.md
+++ b/.changeset/guide-layout-sidebar-nav-4840.md
@@ -1,0 +1,32 @@
+---
+---
+
+Docs + test-only (objectui#4840, objectui#4842). `content/docs/guide/layout.md` taught a
+`{ "type": "sidebar-nav" }` JSON node across three blocks. That key is registered nowhere
+in this repo — `registerLayout()` registers `page-header`, `page:card`, `app-shell`,
+`responsive-grid`, `navigation-renderer` and `app-schema-renderer` — so the node does not
+resolve at all and the renderer replaces the whole sidebar with its red
+`Unknown component type: sidebar-nav` panel (OBJUI-001), measured on this tree. The page's
+`Schema API` block was wrong about the component's own shape in seven ways as well:
+`label` for `title`, `icon` as an icon name rather than a component, a nested `items` for
+`children`, invented `active` / `disabled` / `defaultOpen`, `collapsible` typed as a
+boolean when it is the union of `offcanvas` / `icon` / `none`, and the real `title` prop
+missing entirely.
+
+The SidebarNav material now teaches the React component it is, with props tables read
+against `SidebarNavProps` / `NavItem` / `NavGroup`, and points at `navigation-renderer`
+as the navigation path that genuinely is authorable in JSON.
+
+The same page's Responsive Behavior section promised a sidebar toggle button in the
+header. The AppShell header renders `navbar` and nothing else, so on a phone the sidebar
+had no way to open at all — the fact `content/docs/layout/app-shell.mdx` already stated
+correctly. Auditing the rest of that section found its three-tier structure fictional:
+the layout has exactly one breakpoint, at 768px, and never reads `lg`; the header is
+`h-14` at every breakpoint rather than a compact variant. The section now describes the
+one real boundary and tells readers to render a `SidebarTrigger` themselves.
+
+Pinned by `packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts`, whose
+expected key lists are read out of `packages/layout/src/SidebarNav.tsx` on every run.
+
+No published behaviour changes: no package's runtime source was touched, only the
+documentation and the test that compiles and scans it.

--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -279,63 +279,104 @@ renders nothing here.
 
 The `SidebarNav` provides a collapsible navigation sidebar with menu items.
 
+**`SidebarNav` is a React component, and `sidebar-nav` is not a component key at all.**
+`registerLayout()` (`packages/layout/src/index.ts`) registers six keys — `page-header`,
+`page:card`, `app-shell`, `responsive-grid`, `navigation-renderer` and
+`app-schema-renderer` — and nothing in this repo registers `sidebar-nav`. What a
+`{ "type": "sidebar-nav" }` node actually does is measured under
+[There is no `sidebar-nav` node](#there-is-no-sidebar-nav-node) below. Compose the nav in
+React, or use `navigation-renderer` when the tree has to come from metadata.
+
 ### Basic Usage
 
-```json
-{
-  "type": "sidebar-nav",
-  "items": [
-    {
-      "label": "Dashboard",
-      "href": "/dashboard",
-      "icon": "layout-dashboard"
-    },
-    {
-      "label": "Users",
-      "href": "/users", 
-      "icon": "users",
-      "badge": "12"
-    },
-    {
-      "label": "Reports",
-      "icon": "bar-chart",
-      "items": [
-        { "label": "Sales", "href": "/reports/sales" },
-        { "label": "Analytics", "href": "/reports/analytics" }
-      ]
-    }
-  ]
-}
+`SidebarNav` renders a Shadcn `Sidebar`, so it must be inside a `SidebarProvider` —
+`AppShell` supplies one. Its rows are `NavLink`s, so it also needs a router above it.
+
+```tsx
+import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
+import { SchemaRenderer } from '@object-ui/react';
+import { BarChart3, LayoutDashboard, Users } from 'lucide-react';
+
+const navItems: NavItem[] = [
+  { title: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+  { title: 'Users', href: '/users', icon: Users, badge: '12' },
+  {
+    title: 'Reports',
+    href: '/reports',
+    icon: BarChart3,
+    children: [
+      { title: 'Sales', href: '/reports/sales' },
+      { title: 'Analytics', href: '/reports/analytics' },
+    ],
+  },
+];
+
+<AppShell sidebar={<SidebarNav items={navItems} />}>
+  <SchemaRenderer schema={pageSchema} />
+</AppShell>;
 ```
 
-### Schema API
+Three things that block a copy-paste: `icon` is a **component**, not an icon name —
+`SidebarNav` renders it as `<item.icon />`. Nested rows go in `children`; `items` is a key
+on `NavGroup`, never on a `NavItem`. And `href` is **required** on every item, including
+one that only expands children — it is the row's React key as well as its link target.
 
-```typescript
-{
-  type: 'sidebar-nav',
-  
-  items: Array<{
-    label: string,
-    href?: string,
-    icon?: string,
-    badge?: string | number,
-    badgeVariant?: 'default' | 'destructive' | 'outline',
-    items?: Array<...>,  // Nested menu items (collapsible children)
-    active?: boolean,
-    disabled?: boolean
-  }>,
-  
-  // Items can also be grouped using NavGroup:
-  // items: Array<{ label: string, items: NavItem[] }>
+### Props
 
-  collapsible?: boolean,
-  defaultOpen?: boolean,
-  searchEnabled?: boolean,        // Show search input to filter navigation
-  searchPlaceholder?: string,     // Placeholder for search input
-  
-  className?: string
-}
+`SidebarNavProps` (`packages/layout/src/SidebarNav.tsx`) declares exactly these six.
+
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `items` | `NavItem[] \| NavGroup[]` | yes | The rows. A flat `NavItem[]`, or `NavGroup[]` for labelled sections — the array's first element decides which. |
+| `title` | `string` | no | Group label shown above a flat, ungrouped `items` list. Defaults to `"Application"`. |
+| `className` | `string` | no | Tailwind overrides for the `Sidebar` root. |
+| `collapsible` | `"offcanvas" \| "icon" \| "none"` | no | How the sidebar collapses at or above 768px. Defaults to `"icon"`. Not a boolean. |
+| `searchEnabled` | `boolean` | no | Show a search input that filters rows by title, children included. Defaults to `false`. |
+| `searchPlaceholder` | `string` | no | Placeholder for that input. Defaults to `"Search…"`. |
+
+#### `NavItem`
+
+| Key | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | yes | The row's label. |
+| `href` | `string` | yes | Link target, and the row's React key. |
+| `icon` | `React.ComponentType<{ className?: string }>` | no | Rendered as `<item.icon />` — pass the Lucide component, not its name. |
+| `badge` | `string \| number` | no | Trailing badge content. Rendered whenever it is not `null`/`undefined`, so `0` shows. |
+| `badgeVariant` | `'default' \| 'destructive' \| 'outline'` | no | Badge styling. Defaults to `'default'`. |
+| `children` | `NavItem[]` | no | One level of nested rows; the parent becomes a collapsible trigger. |
+
+#### `NavGroup`
+
+| Key | Type | Required | Description |
+| --- | --- | --- | --- |
+| `label` | `string` | yes | Section heading, shown in place of `title`. |
+| `items` | `NavItem[]` | yes | The section's rows. |
+
+There is no `active` key — the active row is derived from the router
+(`pathname === item.href`), never declared. There is no `disabled` key either, and no
+`defaultOpen`: that one is `AppShell`'s prop, not this component's.
+
+### There is no `sidebar-nav` node
+
+`sidebar-nav` was never registered, so the node does not resolve to anything. Rendering
+`{ "type": "sidebar-nav", "items": [...] }` produces the renderer's red error box instead
+of a sidebar:
+
 ```
+Unknown component type: sidebar-nav
+💡 Ensure the component is registered via registry.register() before rendering.
+   Check for typos in the component type name. (OBJUI-001)
+```
+
+This is louder than the `app-shell` case above — nothing is silently dropped, because
+nothing is parsed as props at all. The whole sidebar is replaced by the error panel.
+
+When the navigation tree genuinely has to come from JSON, that path exists and is a
+different component: `navigation-renderer` (`NavigationRenderer`) renders a
+`NavigationItem[]` tree from AppSchema JSON, and it declares its `inputs`, so an unknown
+key there is diagnosed rather than ignored. Its items are JSON-shaped — `icon` really is
+a string name there, resolved by `resolveIcon`. `app-schema-renderer` wraps that up with
+branding for a whole-shell-from-metadata setup.
 
 ### Features
 
@@ -462,22 +503,34 @@ Omit `sidebar` and the content fills the width under the top bar.
 
 ## Responsive Behavior
 
-Layout components automatically adapt to different screen sizes:
+The shell has exactly **one** layout breakpoint, at **768px** — Tailwind's `md`, and
+`MOBILE_BREAKPOINT` in `packages/components/src/hooks/use-mobile.tsx`. There is no
+separate tablet tier: nothing in `AppShell`, `SidebarNav` or the Shadcn sidebar underneath
+them reads `lg` (1024px), so 800px and 1400px get the same layout.
 
-### Desktop (≥1024px)
-- Full sidebar visible
-- Header spans full width
-- Content area uses remaining space
+### Sidebar, at or above 768px
 
-### Tablet (768px - 1023px)  
-- Collapsible sidebar (overlay mode)
-- Full header
-- Content uses most of screen
+- Rendered inline, as a flex sibling of the content — not an overlay.
+- How it collapses is the sidebar node's own `collapsible` prop: `"icon"` (the `SidebarNav`
+  default) leaves an icon rail, `"offcanvas"` slides it fully out, `"none"` pins it open.
+- `AppShell`'s `defaultOpen` picks the initial state, and defaults to `true`.
 
-### Mobile (<768px)
-- Hidden sidebar (toggle button in header)
-- Compact header
-- Full-width content
+### Sidebar, below 768px
+
+- It leaves the layout entirely and becomes a `Sheet` overlay (18rem) above the content,
+  which is why the content is full-width there.
+- **Nothing opens it for you.** `AppShell`'s header renders `{navbar}` and nothing else —
+  it adds no controls of its own, in particular **no sidebar toggle**. Render a
+  `SidebarTrigger` inside `navbar` yourself; otherwise the only way in is the
+  `SidebarProvider` keyboard shortcut, `Cmd/Ctrl + B`, which no touch device has.
+
+### Header and content
+
+- The header is `h-14` (3.5rem / 56px) at **every** breakpoint — there is no compact
+  variant — and spans the full viewport width at every size. The only thing about it that
+  responds is horizontal padding, and it turns at `sm` (640px), not 768: `px-2 sm:px-4`.
+- Content padding steps three ways — `p-3`, `sm:p-4` (640px), `md:p-6` (768px) — with a
+  taller `pb-20` below `sm` only.
 
 ## Styling and Customization
 
@@ -579,21 +632,40 @@ Use constrained width for forms and reading content:
 
 ### 5. Sidebar Organization
 
-Group related items in the sidebar:
+Group related items with `NavGroup`. Pass groups instead of a flat list and `SidebarNav`
+labels each section and draws the separator between them itself — there is no `divider`
+item, and a row is either a link or a group, never both:
 
-```json
-{
-  "items": [
-    { "label": "Dashboard", "icon": "home", "href": "/" },
-    { "label": "divider" },  // Visual separator
-    { "label": "Sales", "icon": "dollar-sign", "items": [
-      { "label": "Orders", "href": "/orders" },
-      { "label": "Invoices", "href": "/invoices" }
-    ]},
-    { "label": "divider" },
-    { "label": "Settings", "icon": "settings", "href": "/settings" }
-  ]
-}
+```tsx
+import { SidebarNav, type NavGroup } from '@object-ui/layout';
+import { DollarSign, Home, Settings } from 'lucide-react';
+
+const navGroups: NavGroup[] = [
+  {
+    label: 'Overview',
+    items: [{ title: 'Dashboard', href: '/', icon: Home }],
+  },
+  {
+    label: 'Sales',
+    items: [
+      {
+        title: 'Sales',
+        href: '/sales',
+        icon: DollarSign,
+        children: [
+          { title: 'Orders', href: '/orders' },
+          { title: 'Invoices', href: '/invoices' },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'System',
+    items: [{ title: 'Settings', href: '/settings', icon: Settings }],
+  },
+];
+
+<SidebarNav items={navGroups} />;
 ```
 
 ## Related Documentation

--- a/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
+++ b/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
@@ -1,0 +1,609 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `content/docs/guide/layout.md`'s SidebarNav material teaches the real
+ * component (objectui#4840), and its Responsive Behavior section describes the
+ * real breakpoints (objectui#4842).
+ *
+ * ## objectui#4840 — a node type that was never registered
+ *
+ * This is the same phantom-shape family as objectui#3999 (`packages/layout/README.md`,
+ * pinned by `readme-sidebar-nav-example.test.ts`) and objectui#4793
+ * (`content/docs/layout/app-shell.mdx`, pinned by `app-shell-docs-nav-example.test.ts`),
+ * on a THIRD surface — and this one went one level further than either. Those
+ * two misspelled the keys of a real React component. This page taught a JSON
+ * NODE TYPE that does not exist: `registerLayout()` registers `page-header`,
+ * `page:card`, `app-shell`, `responsive-grid`, `navigation-renderer` and
+ * `app-schema-renderer`, and nothing in the repo registers `sidebar-nav`.
+ *
+ * Measured on this tree, a `{ "type": "sidebar-nav", "items": [...] }` node
+ * renders the renderer's red panel and no sidebar at all:
+ *
+ *     Unknown component type: sidebar-nav
+ *     (OBJUI-001)
+ *
+ * So this defect is LOUDER than objectui#4827's `app-shell` one, which at least
+ * resolved to a component and dropped keys quietly. Here nothing is parsed as
+ * props, because nothing resolves.
+ *
+ * The page's `### Schema API` block also got the component's own shape wrong in
+ * seven ways at once — `label` for `title`, `icon` as a string rather than a
+ * component, `items` for `children`, invented `active` / `disabled` /
+ * `defaultOpen`, `collapsible` as a boolean rather than the three-value union —
+ * and omitted the real `title`. Those are what the table-parity halves below
+ * hold to source.
+ *
+ * ## objectui#4842 — a behaviour promise, not a key
+ *
+ * The Responsive Behavior section promised `Hidden sidebar (toggle button in
+ * header)` below 768px. `AppShell`'s header renders `{navbar}` and nothing else,
+ * so a reader who believed it never put a `SidebarTrigger` in `navbar` and the
+ * mobile sidebar had no way to open — silently, with nothing logged.
+ * `content/docs/layout/app-shell.mdx` already stated this correctly ("no sidebar
+ * toggle"); the two pages disagreed and this was the wrong one.
+ *
+ * Auditing the rest of that section found the tier structure itself was
+ * fictional: it described three tiers split at 1024px and 768px, while the
+ * implementation has exactly ONE breakpoint, 768px, and never reads `lg`. Its
+ * "Compact header" claim was wrong too — the header is `h-14` at every
+ * breakpoint. The last describe block pins the numbers the rewritten section
+ * now quotes.
+ *
+ * ## Scan surface — deliberately narrow
+ *
+ * This file judges `content/docs/guide/layout.md`'s SIDEBARNAV material and its
+ * Responsive Behavior section only. The `### Props` / `#### NavItem` /
+ * `#### NavGroup` tables are read from inside the `## SidebarNav Component`
+ * section, NOT page-wide — the same page has a second `### Props` table, for
+ * `AppShellProps`, which belongs to `guide-layout-app-shell-doc.test.ts`
+ * (objectui#4827) and must not be picked up here.
+ *
+ * The fence scans are page-wide but filtered to fences that mention
+ * `SidebarNav`, because the component is legitimately taught outside its own
+ * section: the app-shell examples compose it, and `### 5. Sidebar Organization`
+ * under Best Practices was a THIRD block of the same defect, rewritten with this
+ * change. The quoted-`icon` ban in particular must stay scoped that way —
+ * `page-header` declares `icon` as a string (an icon NAME), and so does
+ * `navigation-renderer`, whose `resolveIcon` looks names up on purpose. A
+ * page-wide ban on `icon: '…'` would be wrong.
+ *
+ * `packages/layout/README.md` belongs to `readme-sidebar-nav-example.test.ts`
+ * and `content/docs/layout/app-shell.mdx` to `app-shell-docs-nav-example.test.ts`;
+ * pinning the whole docs tree to source is objectui#3786's problem, not this one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { BarChart3, DollarSign, Home, LayoutDashboard, Settings, Users } from 'lucide-react';
+import type { NavGroup, NavItem, SidebarNavProps } from '../SidebarNav';
+
+/** Repo root — five levels up from `packages/layout/src/__tests__`. */
+const REPO_ROOT = resolve(__dirname, '../../../..');
+const GUIDE = readFileSync(join(REPO_ROOT, 'content', 'docs', 'guide', 'layout.md'), 'utf8');
+const SIDEBAR_NAV_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'layout', 'src', 'SidebarNav.tsx'),
+  'utf8',
+);
+const LAYOUT_INDEX_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'layout', 'src', 'index.ts'),
+  'utf8',
+);
+const APP_SHELL_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'layout', 'src', 'AppShell.tsx'),
+  'utf8',
+);
+/** The 768px the rewritten Responsive Behavior section is written around. */
+const USE_MOBILE_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'components', 'src', 'hooks', 'use-mobile.tsx'),
+  'utf8',
+);
+
+const GUIDE_LINES = GUIDE.split('\n').map((line) => line.trim());
+
+// ---------------------------------------------------------------------------
+// Half 1 — the page's SidebarNav examples, as typed values.
+//
+// `label:`, `icon: 'layout-dashboard'`, nested `items:` and the invented
+// `active` / `disabled` are all rejected by `tsc` here, at the keyboard.
+// ---------------------------------------------------------------------------
+
+/** `## SidebarNav Component` → `### Basic Usage`. */
+const basicNavItems: NavItem[] = [
+  { title: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+  { title: 'Users', href: '/users', icon: Users, badge: '12' },
+  {
+    title: 'Reports',
+    href: '/reports',
+    icon: BarChart3,
+    children: [
+      { title: 'Sales', href: '/reports/sales' },
+      { title: 'Analytics', href: '/reports/analytics' },
+    ],
+  },
+];
+
+/** `### 5. Sidebar Organization`, the third block of the same defect. */
+const organizationNavGroups: NavGroup[] = [
+  {
+    label: 'Overview',
+    items: [{ title: 'Dashboard', href: '/', icon: Home }],
+  },
+  {
+    label: 'Sales',
+    items: [
+      {
+        title: 'Sales',
+        href: '/sales',
+        icon: DollarSign,
+        children: [
+          { title: 'Orders', href: '/orders' },
+          { title: 'Invoices', href: '/invoices' },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'System',
+    items: [{ title: 'Settings', href: '/settings', icon: Settings }],
+  },
+];
+
+/**
+ * Both shapes have to be legal values of the SAME prop — that is the union the
+ * `items` row documents. If `SidebarNavProps['items']` ever narrows to one of
+ * them, these stop type-checking and the table has to move with the type.
+ */
+const flatItemsProp: SidebarNavProps['items'] = basicNavItems;
+const groupedItemsProp: SidebarNavProps['items'] = organizationNavGroups;
+
+// ---------------------------------------------------------------------------
+// Readers.
+// ---------------------------------------------------------------------------
+
+/** One prop of an interface: its name, whether it is optional, and its type. */
+interface DeclaredProp {
+  key: string;
+  optional: boolean;
+  type: string;
+}
+
+/** `title?: string` — how one prop reads in a failure message. */
+const format = (prop: DeclaredProp): string =>
+  `${prop.key}${prop.optional ? '?' : ''}: ${prop.type}`;
+
+/** Drop block and line comments, so a trailing `// …` never lands in a type. */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+/**
+ * The props `interface <name>` declares in `src`, in declaration order.
+ *
+ * Each prop is matched anchored at line start and terminated by the line's last
+ * `;`, so a key nested inside a type annotation — the `className?` in
+ * `icon?: React.ComponentType<{ className?: string }>` — is never collected as a
+ * prop of its own. Same construction as `guide-layout-app-shell-doc.test.ts`.
+ */
+function interfaceProps(src: string, name: string): DeclaredProp[] {
+  const body = new RegExp(`(?:export )?interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(src);
+  if (!body) throw new Error(`\`interface ${name}\` is gone from the source this test reads`);
+  return [...stripComments(body[1]).matchAll(/^[ \t]*(\w+)(\??)\s*:\s*(.+?);[ \t]*$/gm)].map(
+    (match) => ({ key: match[1], optional: match[2] === '?', type: match[3].trim() }),
+  );
+}
+
+/**
+ * The lines of the `## SidebarNav Component` section, up to the next `## `.
+ *
+ * Load-bearing: the page carries a SECOND `### Props` table, `AppShellProps`',
+ * higher up. Reading tables page-wide would compare this component's rows with
+ * that one's and belongs to a different test (objectui#4827).
+ */
+function sidebarNavSectionLines(): string[] {
+  const start = GUIDE_LINES.indexOf('## SidebarNav Component');
+  if (start === -1) {
+    throw new Error('content/docs/guide/layout.md no longer has a `## SidebarNav Component` section');
+  }
+  let end = GUIDE_LINES.length;
+  for (let i = start + 1; i < GUIDE_LINES.length; i += 1) {
+    if (GUIDE_LINES[i].startsWith('## ')) {
+      end = i;
+      break;
+    }
+  }
+  return GUIDE_LINES.slice(start, end);
+}
+
+/**
+ * Rows of the markdown table that follows `heading`, read as `DeclaredProp`s.
+ *
+ * Columns are `| Prop | Type | Required | Description |`; the first three are
+ * what a props table can be wrong about in the way these issues are about.
+ * `Required` is spelled `yes`/`no` rather than the interface's `?`, and anything
+ * else is a malformed row rather than a silently-skipped one. Table cells escape
+ * the union pipe as `\|`, so it is unescaped before comparison.
+ */
+function documentedProps(lines: string[], heading: string): DeclaredProp[] {
+  const start = lines.indexOf(heading);
+  if (start === -1) {
+    throw new Error(
+      `The SidebarNav section of content/docs/guide/layout.md no longer has a \`${heading}\` heading`,
+    );
+  }
+  const props: DeclaredProp[] = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.length === 0) continue;
+    if (!line.startsWith('|')) {
+      if (props.length > 0) break;
+      continue;
+    }
+    const cells = line.split(/(?<!\\)\|/).map((cell) => cell.trim());
+    const key = /^`(\w+)`$/.exec(cells[1] ?? '')?.[1];
+    if (!key) continue; // header row and the `| --- |` separator
+    const type = (cells[2] ?? '').replace(/`/g, '').replace(/\\\|/g, '|').trim();
+    const required = (cells[3] ?? '').toLowerCase();
+    if (required !== 'yes' && required !== 'no') {
+      throw new Error(
+        `The \`${heading}\` row for \`${key}\` spells Required as "${cells[3]}"; it must be "yes" or "no".`,
+      );
+    }
+    props.push({ key, optional: required === 'no', type });
+  }
+  return props;
+}
+
+/**
+ * Every fenced code block on the page, with its info string and the 1-based line
+ * its opening fence sits on — a JSON fence's first line is `{`, which identifies
+ * nothing, so failures quote the line number instead.
+ */
+function fences(): { lang: string; body: string; line: number }[] {
+  return [...GUIDE.matchAll(/```([a-z]*)\n([\s\S]*?)```/g)].map((match) => ({
+    lang: match[1],
+    body: match[2],
+    line: GUIDE.slice(0, match.index).split('\n').length,
+  }));
+}
+
+/** Fences anywhere on the page that are about this component. */
+function sidebarNavFences(): { lang: string; body: string; line: number }[] {
+  return fences().filter((fence) => fence.body.includes('SidebarNav'));
+}
+
+/**
+ * Prop names on every `<SidebarNav …>` opening tag in `body`.
+ *
+ * Walks the tag rather than regexing the fence, tracking `{}` depth and string
+ * quoting so a nested expression's identifiers and the words inside a quoted
+ * attribute value are never collected as SidebarNav's own. Bare boolean
+ * attributes (no `=`) are collected too. Same walker as
+ * `guide-layout-app-shell-doc.test.ts`.
+ */
+function sidebarNavTagProps(body: string): string[] {
+  const props: string[] = [];
+  const TAG = '<SidebarNav';
+  for (let start = body.indexOf(TAG); start !== -1; start = body.indexOf(TAG, start + 1)) {
+    // Guard against matching a longer identifier, e.g. `<SidebarNavFoo`.
+    if (/[\w-]/.test(body[start + TAG.length] ?? '')) continue;
+    let depth = 0;
+    let quote: string | null = null;
+    let tag = '';
+    for (let i = start + TAG.length; i < body.length; i += 1) {
+      const ch = body[i];
+      if (quote) {
+        if (ch === quote) quote = null;
+        tag += ' ';
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        tag += ' ';
+        continue;
+      }
+      if (ch === '{') depth += 1;
+      else if (ch === '}') depth -= 1;
+      else if ((ch === '>' || ch === '/') && depth === 0) break;
+      tag += depth === 0 ? ch : ' ';
+    }
+    props.push(...[...tag.matchAll(/[A-Za-z_$][\w$]*/g)].map((match) => match[0]));
+  }
+  return props;
+}
+
+/** Component keys `registerLayout()` registers, read out of the source. */
+function registeredKeys(): string[] {
+  return [...LAYOUT_INDEX_SRC.matchAll(/ComponentRegistry\.register\(\s*'([^']+)'/g)].map(
+    (match) => match[1],
+  );
+}
+
+describe("the guide's SidebarNav tables name exactly the real keys (objectui#4840)", () => {
+  it.each([
+    ['### Props', 'SidebarNavProps'],
+    ['#### `NavItem`', 'NavItem'],
+    ['#### `NavGroup`', 'NavGroup'],
+  ])('%s matches `%s` — same order, optionality and type', (heading, name) => {
+    const declared = interfaceProps(SIDEBAR_NAV_SRC, name);
+    expect(declared.length, `no props parsed out of \`${name}\``).toBeGreaterThan(1);
+
+    expect(
+      documentedProps(sidebarNavSectionLines(), heading).map(format),
+      [
+        `The \`${heading}\` table in content/docs/guide/layout.md and \`${name}\` in`,
+        'packages/layout/src/SidebarNav.tsx disagree about which keys exist. Those tables',
+        'replaced a `Schema API` block that was wrong in seven ways at once (objectui#4840):',
+        '`label` for `title`, `icon` as a string rather than a component, `items` for',
+        '`children`, invented `active` / `disabled` / `defaultOpen`, and `collapsible` typed',
+        'as a boolean when it is the union "offcanvas" | "icon" | "none".',
+        '',
+        'The expected list is READ OUT OF packages/layout/src/SidebarNav.tsx on every run, so',
+        'this is never "update the test": add the new key to the table, or drop the row for the',
+        'key that is gone. Only Prop / Type / Required are compared — Description is free prose.',
+        '',
+        `Declared by the component: ${declared.map(format).join('; ')}`,
+      ].join('\n'),
+    ).toEqual(declared.map(format));
+  });
+
+  it('and the example items really are `NavItem[]` / `NavGroup[]` (the compile-time half, made visible)', () => {
+    // These reads are the point: a `const` nobody looks at is easy to delete,
+    // and deleting it would silently retire the type-check that rejects
+    // `label:` and `icon: 'layout-dashboard'` at the keyboard.
+    expect(basicNavItems.map((item) => item.title)).toEqual(['Dashboard', 'Users', 'Reports']);
+    expect(basicNavItems.map((item) => item.href)).toEqual(['/dashboard', '/users', '/reports']);
+    // `icon` is a component, never a string — the defect objectui#3999 found on
+    // the README, repeated here in JSON where no compiler could see it.
+    expect(basicNavItems.some((item) => typeof item.icon === 'string')).toBe(false);
+    // Nested rows live in `children`; the page used to spell this `items`.
+    expect(basicNavItems[2].children?.map((child) => child.href)).toEqual([
+      '/reports/sales',
+      '/reports/analytics',
+    ]);
+    expect(organizationNavGroups.map((group) => group.label)).toEqual([
+      'Overview',
+      'Sales',
+      'System',
+    ]);
+    expect(flatItemsProp).toBe(basicNavItems);
+    expect(groupedItemsProp).toBe(organizationNavGroups);
+
+    // The keys the page used to teach, and the reason this pin exists.
+    const declared = interfaceProps(SIDEBAR_NAV_SRC, 'NavItem').map((prop) => prop.key);
+    expect(declared).toContain('title');
+    expect(declared).toContain('children');
+    expect(declared).not.toContain('label');
+    expect(declared).not.toContain('active');
+    expect(declared).not.toContain('disabled');
+    const props = interfaceProps(SIDEBAR_NAV_SRC, 'SidebarNavProps').map((prop) => prop.key);
+    expect(props).toContain('title');
+    expect(props).not.toContain('defaultOpen');
+  });
+});
+
+describe("the guide's SidebarNav examples pass only real props (objectui#4840)", () => {
+  it('every `<SidebarNav …>` prop on the page is a real one', () => {
+    const declared = interfaceProps(SIDEBAR_NAV_SRC, 'SidebarNavProps').map((prop) => prop.key);
+    expect(declared.length, 'no props parsed out of `SidebarNavProps`').toBeGreaterThan(1);
+
+    const navFences = sidebarNavFences();
+    expect(
+      navFences.length,
+      'no SidebarNav code fence found in content/docs/guide/layout.md at all',
+    ).toBeGreaterThan(0);
+
+    const used = [...new Set(navFences.flatMap((fence) => sidebarNavTagProps(fence.body)))];
+    expect(used.length, 'no `<SidebarNav …>` tag found on the page at all').toBeGreaterThan(0);
+
+    expect(
+      used.filter((prop) => !declared.includes(prop)),
+      [
+        'A `<SidebarNav>` example in content/docs/guide/layout.md passes a prop the component',
+        'does not declare (objectui#4840). The expected list is READ OUT OF',
+        'packages/layout/src/SidebarNav.tsx on every run, so this is never "update the test":',
+        'add the prop to `SidebarNavProps`, or stop teaching it.',
+        `Declared: ${declared.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and actually teaches `items`, `title` and `children`, so the scans are not passing on an empty set', () => {
+    // "No undeclared props" is trivially true of no props, and "no `label:`" is
+    // trivially true of a page with no examples. These are the spellings the
+    // phantom ones displaced, so they are asserted positively.
+    const navFences = sidebarNavFences();
+    const used = new Set(navFences.flatMap((fence) => sidebarNavTagProps(fence.body)));
+    expect(used.has('items'), '`items` is the only required prop and no example passes it').toBe(
+      true,
+    );
+
+    const bodies = navFences.map((fence) => fence.body).join('\n');
+    for (const spelling of ['title:', 'children:']) {
+      expect(
+        bodies.includes(spelling),
+        [
+          `No SidebarNav example in content/docs/guide/layout.md spells \`${spelling}\` any more.`,
+          'The page used to teach `label:` for the row label and a nested `items:` for child',
+          'rows; `title` and `children` are the real keys that replaced them (objectui#4840).',
+          'A page that stops showing them sends readers back to the shape that renders a row',
+          'with no label at all.',
+        ].join('\n'),
+      ).toBe(true);
+    }
+  });
+
+  it('never spells `icon` as a string in a SidebarNav example', () => {
+    for (const fence of sidebarNavFences()) {
+      expect(
+        /\bicon\s*:\s*['"`]/.test(fence.body),
+        [
+          `The SidebarNav example at content/docs/guide/layout.md:${fence.line} writes \`icon\` as a`,
+          'quoted string. `NavItem.icon` is a `React.ComponentType`, rendered as `<item.icon />`',
+          '(SidebarNav.tsx:60 and :109) — a string reaches React as an unknown lowercase tag and',
+          'renders nothing (objectui#4840, objectui#3999). Import the Lucide component and pass it.',
+          '',
+          'Scope note: `page-header` and `navigation-renderer` DO take an icon NAME as a string,',
+          "so this assertion is deliberately confined to fences that mention SidebarNav.",
+        ].join('\n'),
+      ).toBe(false);
+    }
+  });
+});
+
+describe('the guide authors no `sidebar-nav` JSON node (objectui#4840)', () => {
+  it('`sidebar-nav` is still not a registered component key', () => {
+    const keys = registeredKeys();
+    expect(keys.length, 'no `ComponentRegistry.register` calls parsed out of index.ts').toBeGreaterThan(1);
+
+    expect(
+      keys,
+      [
+        '`sidebar-nav` is now registered. content/docs/guide/layout.md states as measured fact',
+        'that the key does not resolve and that a node renders "Unknown component type"',
+        '(objectui#4840). That paragraph is now false, and the PAGE — not this assertion — is',
+        'what has to change: document the node, its `inputs`, and which of `SidebarNavProps`',
+        'a JSON document can actually fill (`items` is plain data, but `icon` is a',
+        '`React.ComponentType`, so the node needs an icon-name path of its own).',
+      ].join('\n'),
+    ).not.toContain('sidebar-nav');
+  });
+
+  it('and the page names exactly the keys that ARE registered', () => {
+    const keys = registeredKeys();
+    // The sentence reads: "registers six keys — `a`, `b` … and `f` — and nothing …".
+    const sentence = /registers six keys — ([\s\S]*?) — and nothing/.exec(GUIDE);
+    if (!sentence) {
+      throw new Error(
+        'The `## SidebarNav Component` intro no longer carries its "registers six keys — … — and nothing" list',
+      );
+    }
+    const named = [...sentence[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+
+    expect(
+      named.slice().sort(),
+      [
+        'The key list in content/docs/guide/layout.md and the `ComponentRegistry.register` calls',
+        'in packages/layout/src/index.ts disagree. The page names that list to make the point',
+        'that `sidebar-nav` is absent from it (objectui#4840), so a stale list undermines the',
+        'only claim it is there to support.',
+        `Registered: ${keys.join(', ')}`,
+      ].join('\n'),
+    ).toEqual(keys.slice().sort());
+    expect(named.length, 'the page says "six keys" but names a different number').toBe(6);
+    expect(keys.length, 'the page says "six keys" but the source registers a different number').toBe(6);
+  });
+
+  it('no fence on the page contains a `{ "type": "sidebar-nav" }` node', () => {
+    const offenders = fences().filter((fence) =>
+      /["']type["']\s*:\s*["']sidebar-nav["']/.test(fence.body),
+    );
+
+    expect(
+      offenders.map((fence) => `content/docs/guide/layout.md:${fence.line}`),
+      [
+        'A fence in content/docs/guide/layout.md authors a `sidebar-nav` node again',
+        '(objectui#4840). The key is not registered anywhere in this repo, so the node does not',
+        'resolve at all: the renderer replaces it with the red "Unknown component type:',
+        'sidebar-nav" panel (OBJUI-001) and no sidebar renders. Teach the React composition',
+        'instead, or `navigation-renderer` when the tree must come from metadata.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});
+
+describe("the source facts the guide's Responsive Behavior section rests on (objectui#4842)", () => {
+  it("`AppShell`'s header renders `navbar` and adds no toggle of its own", () => {
+    const header = /<header[\s\S]*?<\/header>/.exec(APP_SHELL_SRC);
+    if (!header) throw new Error('`AppShell` no longer renders a `header` element');
+
+    expect(
+      header[0],
+      [
+        'The `header` element in packages/layout/src/AppShell.tsx now renders something besides',
+        '`{navbar}`. content/docs/guide/layout.md tells readers the header adds no controls of',
+        'its own — in particular no sidebar toggle — and that they must render a',
+        '`SidebarTrigger` inside `navbar` themselves, or the mobile sidebar can only be opened',
+        'with Cmd/Ctrl+B (objectui#4842). content/docs/layout/app-shell.mdx says the same.',
+        'If the shell now supplies a toggle, BOTH pages are wrong and have to change.',
+      ].join('\n'),
+    ).not.toMatch(/SidebarTrigger|toggleSidebar/);
+    expect(header[0]).toContain('{navbar}');
+  });
+
+  it('the header is `h-14` at every breakpoint, with only its horizontal padding responsive', () => {
+    const header = /<header[\s\S]*?>/.exec(APP_SHELL_SRC);
+    if (!header) throw new Error('`AppShell` no longer renders a `header` element');
+
+    // The page says "h-14 at EVERY breakpoint — there is no compact variant",
+    // replacing a "Compact header" bullet that was never true (objectui#4842).
+    expect(header[0], 'the header is no longer `h-14`').toContain('h-14');
+    expect(
+      /(sm|md|lg):h-/.test(header[0]),
+      [
+        'The header now has a responsive height variant. content/docs/guide/layout.md states it',
+        'is `h-14` at every breakpoint and that there is no compact variant (objectui#4842) —',
+        'the page, not this assertion, is what has to change.',
+      ].join('\n'),
+    ).toBe(false);
+    expect(header[0], 'the header padding steps are no longer `px-2 sm:px-4`').toContain(
+      'px-2 sm:px-4',
+    );
+  });
+
+  it('the mobile breakpoint is still 768px, and nothing in the shell reads `lg`', () => {
+    const breakpoint = /const MOBILE_BREAKPOINT = (\d+)/.exec(USE_MOBILE_SRC);
+    if (!breakpoint) {
+      throw new Error('`MOBILE_BREAKPOINT` is gone from packages/components/src/hooks/use-mobile.tsx');
+    }
+
+    expect(
+      Number(breakpoint[1]),
+      [
+        'The sidebar breakpoint moved. content/docs/guide/layout.md is written around a single',
+        '768px boundary — Tailwind `md`, and this constant — after its three fictional tiers',
+        'split at 1024px were removed (objectui#4842). Update the page with the new number.',
+      ].join('\n'),
+    ).toBe(768);
+
+    // A Tailwind breakpoint prefix is `lg:` immediately followed by a utility;
+    // `lg: "h-12 …"` (with a space) is a cva SIZE-VARIANT key, not a breakpoint,
+    // which is why this matches `lg:` + non-space rather than the bare string.
+    for (const [name, src] of [
+      ['AppShell.tsx', APP_SHELL_SRC],
+      ['SidebarNav.tsx', SIDEBAR_NAV_SRC],
+    ] as const) {
+      expect(
+        /\blg:\S/.test(src),
+        [
+          `packages/layout/src/${name} now uses an \`lg:\` (1024px) utility.`,
+          'content/docs/guide/layout.md states there is no separate tablet/desktop tier and that',
+          '800px and 1400px get the same layout (objectui#4842). A real `lg` rule makes that',
+          'false — re-audit the section against the new classes.',
+        ].join('\n'),
+      ).toBe(false);
+    }
+  });
+
+  it('the content padding still steps the three ways the page quotes', () => {
+    const main = /<main[\s\S]*?>/.exec(APP_SHELL_SRC);
+    if (!main) throw new Error('`AppShell` no longer renders a `main` element');
+
+    for (const cls of ['p-3', 'sm:p-4', 'md:p-6', 'pb-20']) {
+      expect(
+        main[0],
+        [
+          `The \`main\` element in packages/layout/src/AppShell.tsx no longer has \`${cls}\`.`,
+          'content/docs/guide/layout.md quotes these padding steps literally (objectui#4842);',
+          'update the page to match the new classes.',
+        ].join('\n'),
+      ).toContain(cls);
+    }
+  });
+});

--- a/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
+++ b/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
@@ -501,8 +501,12 @@ describe('the guide authors no `sidebar-nav` JSON node (objectui#4840)', () => {
   });
 
   it('no fence on the page contains a `{ "type": "sidebar-nav" }` node', () => {
+    // The key is matched with OPTIONAL quotes on purpose. The block this issue
+    // removed was fenced as `typescript` and spelled the node `type:
+    // 'sidebar-nav'` with a bare key, so a JSON-only pattern would have walked
+    // straight past the very block that declared the phantom shape.
     const offenders = fences().filter((fence) =>
-      /["']type["']\s*:\s*["']sidebar-nav["']/.test(fence.body),
+      /["']?\btype["']?\s*:\s*["']sidebar-nav["']/.test(fence.body),
     );
 
     expect(


### PR DESCRIPTION
Fixes #4840
Fixes #4842

同一页 `content/docs/guide/layout.md` 的两处缺陷,一 PR 两单,方法论照 PR #4843(#4827):先实测量,再改写,钉子期望值一律运行时现读 interface。

> 正文凡提到 JSX 开标签与 HTML 元素,一律写成 `AppShell` 开标签 / `header` 元素,不带尖括号 —— GitHub 正文净化器在**存储时**把 `<` 紧跟字母当 HTML 标签吃掉,PR #4843 初版正文就这样丢过三处元素名。

## #4840 —— 教了一个从未注册的节点类型

这是 #3999(`packages/layout/README.md`)、#4793(`content/docs/layout/app-shell.mdx`)之后 SidebarNav 幻影形状的**第三个面**,而且比前两个深一层:那两个是把一个真实 React 组件的**键**拼错了,本页教的是一个**不存在的节点类型**。

`registerLayout()` 只注册六个键 —— `page-header` / `page:card` / `app-shell` / `responsive-grid` / `navigation-renderer` / `app-schema-renderer`;全仓 `packages/*/src`、`apps/*/src` 对 `sidebar-nav` 的注册命中数为 **0**。

先量后写。用一个探针渲染真实的节点核对结局:

```
{ "type": "sidebar-nav", "items": [...] }
→ Unknown component type: sidebar-nav
  💡 Ensure the component is registered via registry.register() before rendering. (OBJUI-001)
```

所以本单比 #4827 **更响**而不是更静:#4827 的 `app-shell` 至少解析得到组件、再把键悄悄丢掉;这里压根没有东西被当作 props 解析,因为节点根本不解析。整个侧边栏被红框取代。

### 键表逐项处置(现读 `SidebarNav.tsx:23-44`)

| 文档教的 | 真实情况 | 处置 |
| --- | --- | --- |
| `items[].label` | 不存在,真实键是 `title`(`:24`) | **改**,与 #3999 / #4793 同一个键 |
| `items[].icon?: string` | 真实是 `React.ComponentType< { className?: string } >`(`:26`),渲染为 `item.icon` 元素 | **改**,示例改传 Lucide 组件 |
| `items[].items`(嵌套) | 不存在,嵌套真实键是 `children`(`:29`);`items` 只在 `NavGroup`(`:32-35`)上 | **改** |
| `items[].active` | `NavItem` 没有 | **删**,并写明 active 由路由派生(`pathname === item.href`),从不声明 |
| `items[].disabled` | `NavItem` 没有 | **删** |
| `collapsible?: boolean` | 真实是 `"offcanvas" \| "icon" \| "none"`(`:41`),默认 `"icon"`(`:122`) | **改**,三值枚举 |
| `defaultOpen?: boolean` | `SidebarNavProps` 没有;那是 `AppShell` 的键 | **删**,并写明归属 |
| `href?: string` | 真实是**必填** `href: string`(`:25`) | **改**,写明它同时是 React key |
| (缺)`title?: string` | 真实存在(`:39`,默认 `"Application"`) | **补** |

`badge` / `badgeVariant` / `className` / `searchEnabled` / `searchPlaceholder` 原本就对,未动。

### 范围:两块 → 三块

卡里点名两块(`### Basic Usage` `:284-309`、`### Schema API` `:311-338`)。实读后 `### 5. Sidebar Organization`(Best Practices)是**同缺陷的第三块** —— 同样 `label` / 字符串 `icon` / 嵌套 `items`,外加一个 `NavItem` 从来没有的 `{ "label": "divider" }` 分隔符。三块一起改,理由与 PR #4843 的「两块 → 六块」相同:派单要求的钉子扫描面是「本文件的 SidebarNav 块」,留下第三块会让钉子当场变红,或退化成没有价值的窄扫描。

分隔符那条改教真相:`SidebarNav` 在 `NavGroup` 之间**自己画**分隔线(`:165-167`),不存在 divider 项。

页面现在教 React 组合,并写明 `SidebarNav` 必须在 `SidebarProvider` 内(`useSidebar` 否则抛错)、行是 `NavLink` 故需路由;末尾指向真正可用 JSON 表达的导航入口 `navigation-renderer`(已声明 `inputs`,其 `icon` 确实是字符串名,由 `resolveIcon` 解析)。

同页 `page` 块、#4843 刚落地的 app-shell 六块:**零触碰**。#4841(app-shell 注册面处置)在决策箱,本 PR 不预决。

## #4842 —— Responsive Behavior 逐条核对

卡内只主张 `:478` 那半句;派单要求同段 Tablet/Desktop 逐条核并披露。核完的结论是**整个三档结构是虚构的**:实现只有**一个**断点 768px(Tailwind `md`,与 `use-mobile.tsx` 的 `MOBILE_BREAKPOINT`),`AppShell.tsx` / `SidebarNav.tsx` 里 `lg:`(1024px)命中数为 0,所以 800px 与 1400px 拿到完全相同的布局。

| 原文条目 | 核对结果 | 处置 |
| --- | --- | --- |
| **Mobile** 「Hidden sidebar (toggle button in header)」 | **错**(本单主张)。header 只渲染 `{navbar}`(`AppShell.tsx:248-250`),组件不渲染任何开关;`SidebarProvider` 只给 `Cmd/Ctrl + B` 与 `useSidebar().toggleSidebar()` | **改**,照 `app-shell.mdx` 的 Header Bar 口径:header 不加自己的控件,尤其没有侧栏开关;要开关自己放 `SidebarTrigger` 进 `navbar` |
| **Mobile** 「Compact header」 | **错**。header 是 `h-14`,**每个断点都一样**,无任何 `sm:h-` / `md:h-` 变体;`app-shell.mdx:67` 已把同一事实写对 | **改**,写明无 compact 变体;唯一响应的是水平 padding,且转折在 `sm`(640px)而非 768:`px-2 sm:px-4` |
| **Mobile** 「Full-width content」 | **对**。小于 768px 侧栏变 Sheet 浮层(18rem)脱离布局,内容确实占满宽 | 保留,并补上「为什么」 |
| **Tablet (768-1023px)** 「Collapsible sidebar (overlay mode)」 | **错两次**。768px 及以上侧栏是**行内** flex 兄弟(`hidden … md:block` / `md:flex`),不是浮层;overlay/Sheet 是 768 **以下**。且 1023/1024 这条边界在实现里不存在 | **改**,整档删除,合并进「768px 及以上」 |
| **Tablet** 「Full header」 | **对但无意义**。header 在所有尺寸都是 `w-full`,不是 tablet 特有 | 归入「每个断点都一样」一句 |
| **Tablet** 「Content uses most of screen」 | **核不动**:没有对应的源码事实,是无法证伪的模糊话 | **删**,不另作主张 |
| **Desktop (≥1024px)** 「Full sidebar visible」 | **阈值错**。行内侧栏从 **768px** 起,不是 1024;且是否「full」取决于 `collapsible` 与 `defaultOpen`,不是尺寸单独决定 | **改**,写明真实阈值与两个决定因素 |
| **Desktop** 「Header spans full width」 | **对**(`w-full`),但非 desktop 特有 | 同上归并 |
| **Desktop** 「Content area uses remaining space」 | **对**(`SidebarInset` + `main` 的 `flex-1 min-w-0`) | 保留 |

改写后的段落只讲一条真实边界:768px 及以上侧栏行内、折叠行为由侧栏节点的 `collapsible` 决定、初始态由 `AppShell` 的 `defaultOpen` 决定;768px 以下变 Sheet 浮层,且**没有任何东西会替你打开它**。

## 防回潮钉

新增 `packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts`(14 tests),与 `readme-sidebar-nav-example.test.ts`(#3999)、`app-shell-docs-nav-example.test.ts`(#4793)、`guide-layout-app-shell-doc.test.ts`(#4827)同族同构:

1. 编译期:示例是真实 `NavItem[]` / `NavGroup[]` 值,由本包 `type-check` 编译。
2. 三张键表 parity:`### Props` / `#### NavItem` / `#### NavGroup` 对 `SidebarNav.tsx` 逐项比对(键、顺序、可选性、类型文本)。
3. 全页 SidebarNav 开标签 props 扫描 + `items` / `title:` / `children:` 正向锚点。
4. 全页禁 `sidebar-nav` 节点(键的引号**可选** —— 被删的 `Schema API` 块是 `typescript` fence、裸键 `type: 'sidebar-nav'`,只认 JSON 拼法会从声明幻影形状的那一块正上方走过去)。
5. `sidebar-nav` 仍未注册 + 页面点名的六个键与 `index.ts` 实际注册的一致。
6. #4842 的四条源码事实:header 只渲染 `navbar` 无开关、`h-14` 无响应式高度变体、`MOBILE_BREAKPOINT` 仍是 768 且 shell 不读 `lg`、`main` 的三档 padding。

**扫描面**:键表只在 `## SidebarNav Component` 段内读 —— 同页还有 #4843 的第二张 `### Props` 表(`AppShellProps`),页面级读法会把两者比对到一起。fence 扫描是全页但只筛提到 `SidebarNav` 的 fence,因为组件在自己段落之外也被合法教到(app-shell 示例组合它,Best Practices 那块也是)。引号 `icon` 禁令**必须**保持这个范围:`page-header` 与 `navigation-renderer` 的 `icon` 确实是字符串名,页面级禁令会是错的。钉子头注释写明了这条边界。

## 反向验证(先预判,后实跑)

**变异 A** —— 还原旧页面、保留钉子。逐测预判 14 条,实跑 **6 failed | 8 passed**,逐条命中:

```
× ### Props matches `SidebarNavProps`  → 段内已无 `### Props` 标题(抛错)
× #### `NavItem`                       → 同(抛错)
× #### `NavGroup`                      → 同(抛错)
✓ 编译期那一半                          → 按构造绿:它只读本文件的类型化常量与 interface
✓ 每个 SidebarNav 开标签的 prop 都是真的 → 按构造绿:页面上的 JSX 标签属于 #4843 的 app-shell fence,
                                          旧缺陷在 JSON 载体上,本扫描按设计不读
× 教 items / title: / children:         → 在 `children:` 上红
✓ 从不把 icon 写成字符串                 → 按构造绿:旧 JSON 块不含 "SidebarNav" 字样,不在本扫描的
                                          fence 集合里,它们由第 10 条捕获
✓ sidebar-nav 仍未注册                   → 按构造绿(只读 index.ts)
× 页面点名的键与实际注册一致              → 句子不存在(抛错)
× 全页无 sidebar-nav 节点                → 红
✓✓✓✓ #4842 四条源码事实                 → 按构造绿
```

后四条(及第 4、5、7、8 条)**按构造就是绿的**,如实记绿、不假造红:它们钉的是**源码相对页面漂移**,还原页面是它们的反方向。两个补充变异专门验它们真的会咬:

**变异 B** —— 把 `label:` 与字符串 `icon` 加回示例常量,跑 `tsc -p packages/layout/tsconfig.test.json`:

```
guide-layout-sidebar-nav-doc.test.ts(119,5): error TS2353: Object literal may only specify
  known properties, and 'label' does not exist in type 'NavItem'.
guide-layout-sidebar-nav-doc.test.ts(120,37): error TS2322: Type 'string' is not assignable
  to type 'ComponentType< { className?: string | undefined; } > | undefined'.
```

两种错各代表一类缺陷:TS2353 是**错键**,TS2322 是**合法键下的错值类型** —— 后者任何键名检查都看不见,正是 #3999 当年的 `icon: 'home'`。

**变异 C** —— 让源码漂移(header 里加 `SidebarTrigger`、`h-14` 改 `h-12 sm:h-14`、`main` 去掉 `md:p-6`、`MOBILE_BREAKPOINT` 改 1024),预判 #4842 那四条全红:实跑 **4 failed | 10 passed**,正是那四条。

三次变异都先 commit 再变异,还原一律 `git checkout 本分支 -- 路径`(⛔ 不用 stash);变异 C 触碰的两个生产文件已还原,最终 diff 只含三个文件,`packages/**` 生产代码零改动。

## 验证

- `pnpm exec vitest run packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts` → **14 passed**
- `pnpm exec vitest run packages/layout/` → **15 files / 175 tests passed**
- `pnpm exec vitest run scripts/` → **46 files / 1065 tests passed**
- `pnpm exec turbo run type-check --concurrency=2` → **81 successful, 81 total**
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → OK(另对三个改动文件做了 `grep -naP` 自扫,零命中)
- `node scripts/check-changeset-presence.mjs` → 1 个 src 文件(测试)变更 + 1 个**空 frontmatter** changeset,显式声明不发版;`check-changeset-no-major.mjs` 亦绿
- 改动路径 `eslint` 干净

## 顺带发现(本 PR 不修)

无新增。同页 `page` 块仍未审计,按 #4843 的声明留给分诊。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_