### PR TITLE
chore(lint): 清掉 ESLint 自己报的 49 条失效 eslint-disable 指令 (#4833)

### DIFF
--- a/.changeset/drop-stale-eslint-disable-directives.md
+++ b/.changeset/drop-stale-eslint-disable-directives.md
@@ -1,0 +1,23 @@
+---
+---
+
+Comment-only cleanup (objectui#4833). Removed all 49 `eslint-disable` directives that ESLint
+itself reports as `Unused eslint-disable directive (no problems were reported from 'X')` —
+suppressions whose underlying finding no longer exists, spread over 35 files in 17 packages.
+
+No published behaviour changes: the diff removes comment lines and nothing else. The single
+line that is modified rather than deleted is `apps/console/src/pages/developer/PublicFormsPage.tsx:151`,
+where the directive sat inline inside a statement, so only the comment was stripped and the
+`useEffect` call itself is byte-identical.
+
+The judgement was never ours: every site was taken from ESLint's own `ruleId: null` report,
+and the whole-repo counts reconcile exactly — warnings 9828 to 9779 (−49, one per directive),
+errors 0 to 0, unused directives 49 to 0, and **no other rule's count moved in either
+direction**. That last figure is what proves the deletions were inert: had any directive still
+been load-bearing, removing it would have surfaced the rule it was suppressing.
+
+Twenty of the 49 sat on `no-console`, which this repo's config sets to `error` (the objectui#4029
+ratchet) — they were dead because that rule is configured `{ allow: ['warn', 'error'] }` and the
+calls beneath them are `console.warn` / `console.error`, or because the file is one the config
+turns `no-console` off for. A stale suppression on an error-level ratchet is the kind of comment
+a later reader copies as precedent, which is why they are worth removing rather than tolerating.

--- a/apps/console/src/pages/developer/PublicFormsPage.tsx
+++ b/apps/console/src/pages/developer/PublicFormsPage.tsx
@@ -148,7 +148,7 @@ export function PublicFormsPage() {
     }
   };
 
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+  useEffect(() => { load(); }, []);
 
   const origin = typeof window !== 'undefined' ? window.location.origin : '';
 

--- a/apps/console/src/pages/settings/SettingsView.tsx
+++ b/apps/console/src/pages/settings/SettingsView.tsx
@@ -36,7 +36,6 @@ function evalVisibility(expr: string | undefined, data: Record<string, unknown>)
   const m = trimmed.match(/^\$\{(.+)\}$/);
   if (!m) return true;
   try {
-    // eslint-disable-next-line no-new-func
     const fn = new Function('data', `with (data) { return (${m[1]}); }`);
     return Boolean(fn(data));
   } catch {

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -351,7 +351,6 @@ export function useAppContextSelectors(
       const key = contextSelectorQueryKey(sel.id);
       const owner = owners.get(key);
       if (owner) {
-        // eslint-disable-next-line no-console
         console.warn(
           `[ObjectUI] contextSelectors "${owner}" and "${sel.id}" both map to the URL `
           + `scope key "?${key}=" — their values will mirror each other. Rename one id.`,

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1965,7 +1965,6 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         },
       }),
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   // `approvals.requests` / `approvals.pendingRequest` are in the deps for the
   // Approvals tab payload (#3461) — the tab's node carries the live rows, and
   // the panel's headline is the pending one. (The decision actions no longer

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -891,7 +891,6 @@ function MetadataResourceEditPageImpl({
     if (Number.isFinite(v) && v >= 22 && v <= 80) {
       lastInspectorSizeRef.current = v;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const inspectorPanelRef = React.useRef<any>(null);

--- a/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
@@ -83,11 +83,8 @@ const authorable = listMetadataResources().filter(
 describe('create-roundtrip conformance: default create output passes spec validation', () => {
   it('surfaces excluded canvas-create types + types without a client schema (no silent cap)', () => {
     const noSchema = authorable.filter((c) => !hasClientValidator(c.type)).map((c) => c.type);
-    // eslint-disable-next-line no-console
     console.log(`[conformance] canvas-create (interactive, excluded): ${[...CANVAS_CREATE_TYPES].join(', ')}`);
-    // eslint-disable-next-line no-console
     console.log(`[conformance] name-first types covered: ${authorable.map((c) => c.type).join(', ')}`);
-    // eslint-disable-next-line no-console
     if (noSchema.length) console.log(`[conformance] shape-only (no client schema): ${noSchema.join(', ')}`);
     expect(authorable.length).toBeGreaterThan(4);
   });

--- a/packages/app-shell/src/views/metadata-admin/previews/PreviewShell.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PreviewShell.tsx
@@ -115,7 +115,6 @@ export class PreviewErrorBoundary extends React.Component<
     return { error };
   }
   componentDidCatch(error: Error) {
-    // eslint-disable-next-line no-console
     console.error('[MetadataPreview] render failed', error);
   }
   render() {

--- a/packages/components/src/__tests__/action-bar.test.tsx
+++ b/packages/components/src/__tests__/action-bar.test.tsx
@@ -406,7 +406,6 @@ describe('ActionBar (action:bar)', () => {
   describe('requiredPermissions capability gate', () => {
     const Bar = ({ actions, systemActions }: { actions?: any[]; systemActions?: any[] }) => {
       const Component = ComponentRegistry.get('action:bar')!;
-      // eslint-disable-next-line react-hooks/static-components -- registry component is stable
       return <Component schema={{ type: 'action:bar', location: 'list_toolbar', actions, systemActions }} />;
     };
     const withUser = (user: unknown, props: { actions?: any[]; systemActions?: any[] }) =>

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -123,7 +123,6 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
       // must NOT be spread onto the underlying DOM element (avoids React
       // "unknown DOM attribute" warnings — especially for camelCase keys
       // like `systemActions`, `mobileMaxVisible`).
-      /* eslint-disable @typescript-eslint/no-unused-vars */
       actions: _schemaActions,
       systemActions: _schemaSystemActions,
       location: _schemaLocation,
@@ -134,7 +133,6 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
       variant: _schemaVariant,
       size: _schemaSize,
       visible: _schemaVisible,
-      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...rest
     } = props;
 

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -708,7 +708,6 @@ ComponentRegistry.register('form',
         if (previousValues[k] !== undefined) out[k] = previousValues[k];
       }
       return out;
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fields, previousValues]);
 
     // Is this an INSERT? Same signal the memo above documents and the read-only

--- a/packages/core/src/actions/ActionEngine.ts
+++ b/packages/core/src/actions/ActionEngine.ts
@@ -72,7 +72,6 @@ function warnHiddenPredicate(name: unknown, raw: unknown, err: unknown): void {
   if (_warnedPredicates.has(key)) return;
   _warnedPredicates.add(key);
   const msg = err instanceof Error ? err.message : String(err);
-  // eslint-disable-next-line no-console
   console.warn(
     `[ActionEngine] action "${String(name)}" hidden: its \`visible\` predicate threw — ${msg}. ` +
     `Predicate: ${src}. Action predicates evaluate against { record, recordId, objectName, user, os.user, … }; ` +

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -1152,11 +1152,9 @@ export class ActionRunner {
         } catch (err) {
           // Acknowledgement failure is non-fatal; the underlying action already
           // succeeded. Log so consumers can wire it through their error reporter.
-          // eslint-disable-next-line no-console
           console.warn('[ActionRunner] resultDialog handler rejected; treating as acknowledged', err);
         }
       } else {
-        // eslint-disable-next-line no-console
         console.warn(
           '[ActionRunner] action.resultDialog set but no resultDialogHandler registered — the response value will not be shown to the user.',
           { action: action.name, data: result.data }

--- a/packages/core/src/evaluator/SafeExpressionParser.ts
+++ b/packages/core/src/evaluator/SafeExpressionParser.ts
@@ -311,7 +311,6 @@ export class SafeExpressionParser {
     let left = this.parseAddition();
     this.skipWhitespace();
 
-    // eslint-disable-next-line no-constant-condition
     while (true) {
       // Every branch below either assigns `op` or `break`s out of the loop, so
       // `op` is always set by the time the switch reads it (no null initializer
@@ -344,9 +343,7 @@ export class SafeExpressionParser {
       switch (op) {
         case '===': left = left === right; break;
         case '!==': left = left !== right; break;
-        // eslint-disable-next-line eqeqeq
         case '==': left = (left as any) == (right as any); break;
-        // eslint-disable-next-line eqeqeq
         case '!=': left = (left as any) != (right as any); break;
         case '>': left = (left as any) > (right as any); break;
         case '<': left = (left as any) < (right as any); break;
@@ -441,7 +438,6 @@ export class SafeExpressionParser {
   private parseMember(): unknown {
     let obj = this.parsePrimary();
 
-    // eslint-disable-next-line no-constant-condition
     while (true) {
       this.skipWhitespace();
 

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -1032,7 +1032,6 @@ export async function resolveDimensionFieldMeta(
     for (let i = 0; i < segments.length - 1; i += 1) {
       const target = resolveRelationshipTarget(fieldDefsOf(schema)?.[segments[i]]);
       if (!target) { walked = false; break; }
-      // eslint-disable-next-line no-await-in-loop
       schema = await load(target);
       if (!schema) { walked = false; break; }
       // Prefer the loaded doc's own `name` over the reference's spelling, so a

--- a/packages/core/src/utils/column-identity.ts
+++ b/packages/core/src/utils/column-identity.ts
@@ -134,7 +134,6 @@ function warnOnConflictingIdentity(
     const memo = `${identity}:${key}:${String(entry[key])}`;
     if (warnedConflicts.has(memo)) continue;
     warnedConflicts.add(memo);
-    // eslint-disable-next-line no-console
     console.warn(
       `[ObjectUI] Column carries two identities: \`${CANONICAL_COLUMN_IDENTITY_KEY}: ` +
         `'${identity}'\` and \`${key}: '${String(entry[key])}'\`. ` +

--- a/packages/core/src/utils/filter-tokens.ts
+++ b/packages/core/src/utils/filter-tokens.ts
@@ -141,7 +141,6 @@ export function resolveContextTokens<T = any>(filter: T, scope: FilterTokenScope
       ? () => {}
       : scope.onUnresolved ??
         ((message: string) => {
-          // eslint-disable-next-line no-console
           console.warn(`[object-ui] ${message}`);
         });
 

--- a/packages/core/src/validation/validators/object-validation-engine.ts
+++ b/packages/core/src/validation/validators/object-validation-engine.ts
@@ -279,13 +279,11 @@ class SimpleExpressionEvaluator implements ValidationExpressionEvaluator {
           return leftVal === rightVal;
         case '==':
           // Use loose equality for backward compatibility with existing expressions
-          // eslint-disable-next-line eqeqeq
           return leftVal == rightVal;
         case '!==':
           return leftVal !== rightVal;
         case '!=':
           // Use loose inequality for backward compatibility with existing expressions
-          // eslint-disable-next-line eqeqeq
           return leftVal != rightVal;
         case '>': return leftVal > rightVal;
         case '<': return leftVal < rightVal;

--- a/packages/fields/src/widgets/ObjectField.tsx
+++ b/packages/fields/src/widgets/ObjectField.tsx
@@ -34,12 +34,10 @@ export function ObjectField({ value, onChange, field, readonly, error, ...props 
       // This prevents cursor jumping/reformatting while typing valid JSON
       const currentParsed = jsonString ? JSON.parse(jsonString) : null;
       if (JSON.stringify(currentParsed) !== JSON.stringify(value)) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- Required for controlled component sync
         setJsonString(JSON.stringify(value, null, 2));
       }
     } catch {
       // Fallback if internal state was invalid JSON
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Required for controlled component sync
       setJsonString(JSON.stringify(value, null, 2));
     }
   }, [value, jsonString]);

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -75,7 +75,6 @@ function createMissingKeyHandler(): (
     if (seen.has(dedupeKey)) return;
     seen.add(dedupeKey);
     const fb = fallbackValue ? `"${fallbackValue}"` : 'the key itself';
-    // eslint-disable-next-line no-console
     console.warn(
       `[object-ui i18n] Missing translation for "${key}" (language "${lng}") — falling back to ${fb}.`,
     );

--- a/packages/mobile/src/__tests__/responsive-config-spec-parity.test.ts
+++ b/packages/mobile/src/__tests__/responsive-config-spec-parity.test.ts
@@ -53,14 +53,6 @@ import { describe, it, expect } from 'vitest';
 import { ResponsiveConfigSchema, type ResponsiveConfig } from '@objectstack/spec/ui';
 import type { SpecResponsiveConfig } from '../index';
 
-/* eslint-disable @typescript-eslint/no-unused-vars --
- * The pins below are compile-time assertions: `tsc` is their only consumer and
- * they are erased before anything runs, so "unused" is what a passing one looks
- * like. The repo's `no-unused-vars` ignores `^_` for ARGUMENTS only, which is
- * why `packages/types`' equivalent file carries the same warnings; scoping the
- * exemption to this file keeps it from becoming a repo-wide hole.
- */
-
 /* ── Type-level helpers ──────────────────────────────────────────────────── */
 
 /**
@@ -108,8 +100,6 @@ type _BreakpointVocabularyIsTheSchemaSix = Expect<
     'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
   >
 >;
-
-/* eslint-enable @typescript-eslint/no-unused-vars */
 
 /* ── Runtime half ────────────────────────────────────────────────────────── */
 

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -450,7 +450,6 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
     } catch (err) {
       // Roll back optimistic state
       setData(prevData);
-      // eslint-disable-next-line no-console
       console.error('[ObjectCalendar] Failed to persist drag-and-drop reschedule:', err);
       // Surface the failure — never silently snap the event back. A row-level
       // security denial (403) is the common case: the user lacks permission to
@@ -545,7 +544,6 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
     } catch (err: any) {
       const msg = err?.message || String(err);
       setQuickCreate(qc => qc ? { ...qc, submitting: false, error: msg } : qc);
-      // eslint-disable-next-line no-console
       console.error('[ObjectCalendar] Quick-create failed:', err);
     }
   }, [quickCreate, calendarConfig, schema.objectName, dataSource, objectSchema]);

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -703,7 +703,6 @@ function AdvancedChartImplInner({
       }
     }
     return out;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, series, hasDualAxis]);
 
   /** Recharts props derived from one spec y-axis (domain / scale / ticks / label). */

--- a/packages/plugin-charts/src/__tests__/chart-type-spec-parity.test.tsx
+++ b/packages/plugin-charts/src/__tests__/chart-type-spec-parity.test.tsx
@@ -78,7 +78,6 @@ describe('plugin-charts covers the spec chart-type vocabulary', () => {
     // instead of quietly accumulating stale exceptions.
     const adopted = [...TRACKED_DIALECT].filter((name) => specNames.includes(name));
     if (adopted.length > 0) {
-      // eslint-disable-next-line no-console
       console.info(
         `[chart-type parity] the spec now defines ${adopted.join(', ')} — remove them from TRACKED_DIALECT.`,
       );

--- a/packages/plugin-chatbot/src/elements/prompt-input.tsx
+++ b/packages/plugin-chatbot/src/elements/prompt-input.tsx
@@ -690,7 +690,6 @@ export const PromptInput = ({
         }
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup only on unmount; filesRef always current
     [usingProvider]
   );
 

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -435,7 +435,6 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     setVisibleCount(vsBatchSize);
     const timer = setTimeout(() => setVisibleCount(undefined), VS_REVEAL_DELAY);
     return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [vsEnabled, layoutFields.length, vsBatchSize]);
 
   // Hide entire section when all fields are empty AND the user has not asked to

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -458,7 +458,6 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   // Add affordance is unconfigured and the list body is perfectly fine.
   React.useEffect(() => {
     if (!add || pickerObject) return;
-    // eslint-disable-next-line no-console
     console.warn(
       `[RelatedList] "${api || objectName || 'related list'}" declares add without add.picker.object — the Add affordance is not rendered. add.picker is required by the spec (RecordRelatedListProps.add): set add.picker.object to the object the picker should list.`,
     );
@@ -481,7 +480,6 @@ export const RelatedList: React.FC<RelatedListProps> = ({
       if (!canScope) {
         if (api && (parentId === undefined || parentId === null || parentId === '') && !referenceField) {
           // Developer hint: only surface in console once per mount.
-          // eslint-disable-next-line no-console
           console.warn(
             `[RelatedList] "${api}" has no referenceField/parentId — refusing to fetch all rows. Pass relationshipField + parentId to scope the query.`,
           );
@@ -554,7 +552,6 @@ export const RelatedList: React.FC<RelatedListProps> = ({
         // wiring exists to remove (objectstack#7118), so it refuses and says so
         // instead. Empty-and-loud beats wider-and-quiet; the guard above refuses
         // an unscoped fetch on the same reasoning.
-        // eslint-disable-next-line no-console
         console.warn(
           `[RelatedList] "${api}" declares a filter but has no dataSource adapter — the raw-URL fallback cannot express it, so no rows are fetched. Pass a dataSource (RecordContext) to use a filtered related list.`,
         );
@@ -602,7 +599,6 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   // page 3 of the filtered ones.
   React.useEffect(() => {
     setCurrentPage(0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [api, referenceField, parentId, filterKey]);
 
   // Refetch when a mutation elsewhere signals this related object changed —

--- a/packages/plugin-form/src/EmbeddableForm.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.tsx
@@ -311,7 +311,6 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
               window.location.href = rawRedirect;
             }, delay);
           } else {
-            // eslint-disable-next-line no-console
             console.warn('[EmbeddableForm] Blocked unsafe redirect target:', rawRedirect);
             setError(config.texts?.redirectBlocked ?? null);
           }

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -216,7 +216,6 @@ const MasterDetailLines: React.FC<MasterDetailLinesProps> = ({
       host.removeEventListener('change', onEvt);
       timers.forEach(clearTimeout);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formHostRef, formKey, details.length]);
 
   // Document totals: Subtotal (Σ line amounts) → Tax (header rate %) → Total.

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -1479,7 +1479,6 @@ const ImportHistoryPanel: React.FC<{
   // "reverted" and its Undo button disappears.
   const handleUndo = useCallback(async (jobId: string) => {
     if (typeof ds?.undoImportJob !== 'function') return;
-    // eslint-disable-next-line no-alert
     if (typeof window !== 'undefined' && !window.confirm(t('grid.import.undoConfirm'))) return;
     setUndoingId(jobId); setError(null);
     try {

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1122,7 +1122,6 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // become 2, and "page 5" of that is nothing at all.
   React.useEffect(() => {
     setServerPage(1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [objectName, schemaFilter, schemaSort, headerSort, searchTerm]);
 
   // --- NavigationConfig support ---

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -709,7 +709,6 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           (Array.isArray(kanbanCfg.columns) && kanbanCfg.columns.length > 0
             ? kanbanCfg.columns
             : baseProps.fields) || [];
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { columns: _kanbanColumns, groupByField: _gbf, groupField: _gf, titleField: _tf, conditionalFormatting: _kanbanCf, ...restKanban } = kanbanCfg;
         // Forward conditional formatting to kanban (issue #1584): nested
         // `options.kanban.conditionalFormatting` wins, then the view-level, then

--- a/packages/providers/src/UploadProvider.tsx
+++ b/packages/providers/src/UploadProvider.tsx
@@ -331,7 +331,6 @@ async function uploadWithProgress(
   const maxRetries = options.maxRetries ?? 3;
   const baseDelay = options.retryDelayMs ?? 500;
   let attempt = 0;
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     if (options.signal?.aborted) throw new DOMException('aborted', 'AbortError');
     try {

--- a/packages/react-runtime/src/index.tsx
+++ b/packages/react-runtime/src/index.tsx
@@ -33,7 +33,6 @@ const evalCode = (code: string, scope: Scope): unknown => {
   const { default: _d, import: imports, ...rest } = scope as Scope & { import?: Scope };
   const finalScope: Scope = { React, require: createRequire(imports), ...rest };
   const keys = Object.keys(finalScope);
-  // eslint-disable-next-line no-new-func
   return new Function(...keys, code)(...keys.map((k) => finalScope[k]));
 };
 

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -77,7 +77,6 @@ function validateSchemaOnce(schema: any): _ValidationCacheEntry {
       entry = { valid: false, messages: msgs };
       if (!_warnedSchemas.has(schema)) {
         _warnedSchemas.add(schema);
-        // eslint-disable-next-line no-console
         console.warn(
           '[ObjectUI] Invalid schema detected:\n' + msgs.join('\n'),
           schema
@@ -88,7 +87,6 @@ function validateSchemaOnce(schema: any): _ValidationCacheEntry {
     // Validator itself failed — surface but don't crash render.
     if (!_warnedSchemas.has(schema)) {
       _warnedSchemas.add(schema);
-      // eslint-disable-next-line no-console
       console.warn('[ObjectUI] Schema validator threw:', err);
     }
   }
@@ -235,8 +233,6 @@ export interface SchemaRendererProps {
  * and `packages/react/README.md` documents callers relying on it. The `any` is
  * the point: this is a pass-through channel, not a typed prop.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above: the
-// forwarded value is opaque to this component by construction.
 type ForwardedProps = Record<string, any>;
 
 /**

--- a/packages/react/src/__tests__/SchemaRenderer.propsResolution.test.ts
+++ b/packages/react/src/__tests__/SchemaRenderer.propsResolution.test.ts
@@ -52,7 +52,6 @@
  * deliberately never referenced, and a violation is a COMPILE error rather than
  * a use site. `no-unused-vars` has nothing to say about that here.
  */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { describe, it, expect } from 'vitest';
 import type { ComponentProps } from 'react';


### PR DESCRIPTION
Fixes #4833
Refs #4844, #4806, #4029

## 做了什么

删掉全仓 **49 条已失效的 `eslint-disable` 指令**,分布在 17 个包的 35 个文件里。

判据全程只用 ESLint 自己的报文,零主观判断:取仓根 `pnpm exec eslint . -f json` 里
`ruleId` 为 `null` 的那些 message —— 它们不是任何一条规则的报告,而是 ESLint 自己的
`Unused eslint-disable directive (no problems were reported from 'X')`。哪一条该动、动哪一行,
全部由这份报文点名,我没有自己判断过任何一条指令"看起来多余"。

**改动只有注释行。** 35 个文件合计 60 删 1 增,唯一那 1 行"增"是把一条写在语句内部的行内指令
剥掉注释、保留代码本身(见下面的 B 类),`useEffect` 调用逐字节未变。

## 前后对账(两条互相独立的口径,数字一致)

| 指标 | 修前(`origin/main` @ `815cad03d`) | 修后 | 差 |
|---|---|---|---|
| 失效指令(`ruleId: null`) | **49** | **0** | −49 |
| 总 warning | **9828** | **9779** | −49 |
| **error** | **0** | **0** | **0** |

口径一是仓根 `eslint . -f json`(3177 个文件);口径二是 `lint.yml` 实际跑的
`turbo run lint`(47/47 tasks,`TURBO_EXIT=0`),两者都得 9779 / 0 error / 0 条失效指令。

减少数与删除数**逐条吻合**:49 条指令、warning 恰好减 49。

### 最强的一项证据:除了失效指令这一类,**没有任何一条规则的计数发生变化**

逐 rule 对账修前修后的完整计数表,结果是**只有 `(unused-directive)` 这一行动了(49 → 0),
其余每一条规则前后完全相同**,既没有新增、也没有减少:

```
              before   after   delta
errors             0       0       0
warnings        9828    9779     -49
stale directs     49       0     -49

--- per-rule deltas (any rule that CHANGED) ---
  (unused-directive)                            49 ->      0   (-49)

rules other than the directive class that moved: 0 (NONE)
```

这正是"这些指令确实是死的"的判据:只要有任何一条指令其实还在压着东西,删掉它就会让被压的规则冒出来。
一条都没冒出来。

## 逐条处置表

修法三选一,实际只用到两类,如实说明另一类为 0:

| 处置 | 条数 | 说明 |
|---|---|---|
| **A. 删整条** | 48 | 指令独占注释行,整行删除 |
| **B. 剥离行内注释(保留代码)** | 1 | 指令写在语句内部,只摘注释 |
| **C. 摘多余规则名** | **0** | 全仓没有任何一条 disable 列了多个规则,详见下 |
| **D. 例外:不动并回传** | **0** | 没有一条触发,详见下 |

### C 类为 0 是实测结论,不是漏做

逐条解析了 49 条指令的规则名列表,**没有一条列了一个以上的规则**(49 条全部是单规则指令),
所以"一条 disable 列多规则、只摘掉多余那个"这种修法在本仓根本没有适用对象。

### D 类为 0 的验证方式

每条删除后都重跑并逐 rule 对账,若某条指令其实不是失效、而是 ESLint 的误报,删掉它必然让原规则冒出来。
上面那张"其余规则一条没动"的表就是这项检查的结果:**0 条需要按 D 类回退**。
其中 20 条压的是 error 级棘轮 `no-console`,若有一条判错,`error` 会立刻从 0 变正数 —— 实测仍是 0。

## 为什么这 49 条是死的(机制,不是"eslint 说的")

不是逐条猜,而是每一类都有配置层面的成因:

- **`no-console` 20 条** —— `eslint.config.js` 把它配成 `['error', { allow: ['warn', 'error'] }]`。
  这 20 条底下的调用全是 `console.warn` / `console.error`(规则本来就放行),或者所在文件命中
  `'no-console': 'off'` 的 override(`**/*.test.*`、`**/__tests__/**` 等)。规则从一开始就没打算报它们。
- **`@typescript-eslint/no-unused-vars` 4 条** —— 正是 PR #4844 补上 `varsIgnorePattern: '^_'` 之后
  转为多余的那 4 处手写豁免,站点与 #4844 回报的清单逐条对上(45 → 49 的那 4 条)。
- **`eqeqeq` 4 条 / `no-alert` 1 条 / `no-await-in-loop` 1 条** —— 这几条规则本仓压根没有启用
  (不在 `js.configs.recommended` 里,配置也没开),压一条没开的规则自然永远是多余的。
- 其余(`react-hooks/exhaustive-deps` 10、`no-constant-condition` 3、`no-new-func` 2、
  `react-hooks/set-state-in-effect` 2、`react-hooks/static-components` 1、`no-explicit-any` 1)
  属于代码本身变了、被压的问题已不存在。

## 两条"错位指令":删对了,但值得单独说

有 2 条的失效原因不是"问题没了",而是**指令写错了位置,从来就没生效过** —— `eslint-disable-next-line`
的"下一行"落在了另一条注释或空行上:

| 站点 | 情况 |
|---|---|
| `apps/console/src/pages/developer/PublicFormsPage.tsx:151` | 指令写在语句内部行尾,它的"下一行"是空行;`react-hooks/exhaustive-deps` 目前在 **151 行本行**照常报着 |
| `packages/react/src/SchemaRenderer.tsx:238` | 指令的理由换行续写到 239 行,于是"下一行"是注释;`no-explicit-any` 目前在 **240 行**照常报着 |

对这两条我**只做删除,没有"顺手挪到正确位置"**。挪位置会让两条现存 warning 被新压制下去 —— 那是抑制
语义的变更,不属于本卡"清理失效指令"的范围,该不该压制是另一个判断。删除后这两条 warning 原样保留
(它们本来就在 9779 里,不是本 PR 新增的)。已按纪律另行留档,交 PM 分诊。

另有 `packages/app-shell/src/views/RecordDetailView.tsx:1968` 同样是错位(下一行是 5 行说明性注释),
但它的依赖数组本来就是全的、没有 warning 可压,所以删掉它没有任何遗留。

## 反向验证(先写预判,再跑;已先 commit 再变异,不提交)

**方向说明:本卡不是"还原修复 → 钉子变红",硬套那个模板会是假证据。** 理由先写在前面:
本 PR 删除的东西**本身就是那条诊断**,没有任何测试断言"这些指令不存在";裁判是 ESLint 自己的
`Unused eslint-disable directive` 报文。所以把删掉的指令加回去,是**重新造出一条 warning**,不是让什么变红。
又因为 `lint.yml` 有意不设 `--max-warnings`、门禁只看 error,所以两个状态下 **error 都必须是 0** ——
error 一旦不为 0,说明我删错了,而不是说明验证成功。

变异内容:挑 2 条已删的加回去,分别代表两个最值得钉的子类。

| 加回的站点 | 规则 | 为什么它是死的(机制) |
|---|---|---|
| `packages/core/src/actions/ActionEngine.ts:75` | `no-console` | 配置是 `['error', { allow: ['warn', 'error'] }]`,底下是 `console.warn` —— 规则本来就放行。钉的是"20 条压 error 级棘轮"那一类 |
| `packages/plugin-view/src/ObjectView.tsx:712` | `@typescript-eslint/no-unused-vars` | PR #4844 补的 `varsIgnorePattern: '^_'` 已覆盖 `_kanbanColumns` 等名字。钉的是 #4844 转出来的那 4 条 |

| 指标 | 已提交版 | **预判** | **实测** |
|---|---|---|---|
| 失效指令 | 0 | **2** | **2** ✅ |
| 总 warning | 9779 | **9781** | **9781** ✅ |
| error | 0 | **0** | **0** ✅ |

三项全中,且重新出现的两条正是加回去的那两个站点(报文逐字对上)。

其中 `error` 仍为 0 这一项**是实打实的断言,不是走形式**:如果那条 `no-console` 指令其实还在压着东西,
把它加回去、再删掉时 `no-console` 就会以 **error** 身份冒出来 —— 那正是"D 类例外"的判据。实测 error 恒为 0,
说明这 20 条压在 error 级棘轮上的指令,删除是安全的。

验证完已 `git checkout` 还原,工作树与 commit 逐字节一致(`git diff HEAD` 为空)。

## 测试与门禁

注释删除理论上零行为变化,整包测试是防"手滑删错行"的兜底。

- **受影响 17 个包整包测试**(仓根路径过滤跑法,按 AGENTS.md §9):
  `pnpm exec vitest run --maxWorkers=2 apps/console/ packages/app-shell/ … packages/react/`

  ```
  Test Files  1152 passed (1152)
       Tests  13165 passed | 1 skipped (13166)
    Duration  1337.64s
  ```

  退出码 0,零失败。(输出里几条 `ECONNREFUSED 127.0.0.1:3000` 是某个测试去够后端的既有噪音,
  与本改动无关,不影响结果。)

- **type-check**:仓根 `pnpm exec turbo run type-check --concurrency=2` → `81 successful, 81 total`,退出码 0。
- **lint**:仓根 `pnpm lint`(即 `turbo run lint`)→ `47 successful, 47 total`,`TURBO_EXIT=0`,0 error。
- **control bytes**:`node scripts/check-control-bytes.mjs` → OK(扫描 4335 个文件);另按纪律做了超出门禁扫描面的自查
  `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,改动文件全部干净。
- **changeset:实测判定,不是照惯例推断。** `node scripts/check-changeset-presence.mjs` 修前退出 1
  (35 个文件全部落在 17 个发版包的 `src/` 下),因此**必须**补一个;本改动纯注释、零用户可见变化,
  按 AGENTS.md §9 写**空 frontmatter** 显式声明"不发版",门现输出:
  `✅ … declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing`。
  `check-changeset-no-major.mjs` 亦通过。

## 边界自查

- **只删/改注释行,零逻辑改动**:全 diff 里非注释的增删只有 PublicFormsPage 那一行(剥离行内注释,代码不变)。
- **未动 `eslint.config.js`**。issue 正文提到的"顺手把 `reportUnusedDisableDirectives` 设成 error 关门"
  **不在本 PR**,那是独立决策(会改变门禁强度),留给 PM 分诊。本 PR 只做清理,清理后该项恰好为 0,
  正是关门的前置条件已具备。
- **未动 `content/docs/releases/`**;未 force-push。
- **在飞 PR 文件面复核**:收工前 fetch 并逐一核对了 4 个 open PR(#4848 / #4655 / #4639 / #4093)的文件清单,
  与本 PR 的 35 个文件**零交叠**(#4848 只动 `content/docs` 与 `packages/layout`;#4639 / #4093 只动
  `package.json` 与 lockfile;#4655 是发版 PR)。无需跳过任何文件。

## 附:49 条逐条清单(按被压制的规则分组)

未特别标注的即 A 类「删整条」。

**`no-console`** — 20 条

| 位置 | 处置 |
|---|---|
| `packages/app-shell/src/layout/ContextSelectors.tsx:354` | 删整条 |
| `packages/app-shell/src/views/metadata-admin/createConformance.test.ts:86` | 删整条 |
| `packages/app-shell/src/views/metadata-admin/createConformance.test.ts:88` | 删整条 |
| `packages/app-shell/src/views/metadata-admin/createConformance.test.ts:90` | 删整条 |
| `packages/app-shell/src/views/metadata-admin/previews/PreviewShell.tsx:118` | 删整条 |
| `packages/core/src/actions/ActionEngine.ts:75` | 删整条 |
| `packages/core/src/actions/ActionRunner.ts:1155` | 删整条 |
| `packages/core/src/actions/ActionRunner.ts:1159` | 删整条 |
| `packages/core/src/utils/column-identity.ts:137` | 删整条 |
| `packages/core/src/utils/filter-tokens.ts:144` | 删整条 |
| `packages/i18n/src/i18n.ts:78` | 删整条 |
| `packages/plugin-calendar/src/ObjectCalendar.tsx:453` | 删整条 |
| `packages/plugin-calendar/src/ObjectCalendar.tsx:548` | 删整条 |
| `packages/plugin-charts/src/__tests__/chart-type-spec-parity.test.tsx:81` | 删整条 |
| `packages/plugin-detail/src/RelatedList.tsx:461` | 删整条 |
| `packages/plugin-detail/src/RelatedList.tsx:484` | 删整条 |
| `packages/plugin-detail/src/RelatedList.tsx:557` | 删整条 |
| `packages/plugin-form/src/EmbeddableForm.tsx:314` | 删整条 |
| `packages/react/src/SchemaRenderer.tsx:80` | 删整条 |
| `packages/react/src/SchemaRenderer.tsx:91` | 删整条 |

**`react-hooks/exhaustive-deps`** — 10 条

| 位置 | 处置 |
|---|---|
| `apps/console/src/pages/developer/PublicFormsPage.tsx:151` | 剥离行内注释(保留代码) |
| `packages/app-shell/src/views/RecordDetailView.tsx:1968` | 删整条 |
| `packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx:894` | 删整条 |
| `packages/components/src/renderers/form/form.tsx:711` | 删整条 |
| `packages/plugin-charts/src/AdvancedChartImpl.tsx:706` | 删整条 |
| `packages/plugin-chatbot/src/elements/prompt-input.tsx:693` | 删整条 |
| `packages/plugin-detail/src/DetailSection.tsx:438` | 删整条 |
| `packages/plugin-detail/src/RelatedList.tsx:605` | 删整条 |
| `packages/plugin-form/src/MasterDetailForm.tsx:219` | 删整条 |
| `packages/plugin-grid/src/ObjectGrid.tsx:1125` | 删整条 |

**`@typescript-eslint/no-unused-vars`** — 4 条

| 位置 | 处置 |
|---|---|
| `packages/components/src/renderers/action/action-bar.tsx:126` | 删整条(连同配对的 eslint-enable:137) |
| `packages/mobile/src/__tests__/responsive-config-spec-parity.test.ts:56` | 删整条(7 行块注释 56-62 + 配对 eslint-enable:112) |
| `packages/plugin-view/src/ObjectView.tsx:712` | 删整条 |
| `packages/react/src/__tests__/SchemaRenderer.propsResolution.test.ts:55` | 删整条 |

**`eqeqeq`** — 4 条

| 位置 | 处置 |
|---|---|
| `packages/core/src/evaluator/SafeExpressionParser.ts:347` | 删整条 |
| `packages/core/src/evaluator/SafeExpressionParser.ts:349` | 删整条 |
| `packages/core/src/validation/validators/object-validation-engine.ts:282` | 删整条 |
| `packages/core/src/validation/validators/object-validation-engine.ts:288` | 删整条 |

**`no-constant-condition`** — 3 条

| 位置 | 处置 |
|---|---|
| `packages/core/src/evaluator/SafeExpressionParser.ts:314` | 删整条 |
| `packages/core/src/evaluator/SafeExpressionParser.ts:444` | 删整条 |
| `packages/providers/src/UploadProvider.tsx:334` | 删整条 |

**`no-new-func`** — 2 条

| 位置 | 处置 |
|---|---|
| `apps/console/src/pages/settings/SettingsView.tsx:39` | 删整条 |
| `packages/react-runtime/src/index.tsx:36` | 删整条 |

**`react-hooks/set-state-in-effect`** — 2 条

| 位置 | 处置 |
|---|---|
| `packages/fields/src/widgets/ObjectField.tsx:37` | 删整条 |
| `packages/fields/src/widgets/ObjectField.tsx:42` | 删整条 |

**`react-hooks/static-components`** — 1 条

| 位置 | 处置 |
|---|---|
| `packages/components/src/__tests__/action-bar.test.tsx:409` | 删整条 |

**`no-await-in-loop`** — 1 条

| 位置 | 处置 |
|---|---|
| `packages/core/src/utils/chart-series.ts:1035` | 删整条 |

**`no-alert`** — 1 条

| 位置 | 处置 |
|---|---|
| `packages/plugin-grid/src/ImportWizard.tsx:1482` | 删整条 |

**`@typescript-eslint/no-explicit-any`** — 1 条

| 位置 | 处置 |
|---|---|
| `packages/react/src/SchemaRenderer.tsx:238` | 删整条(连同换行续写的理由:239) |


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_