### PR TITLE
chore(data-objectstack): files 不再列 src —— 43 个源码文件(38 个测试)退出发布物 (#4847)

### DIFF
--- a/.changeset/data-objectstack-files-drops-src-4847.md
+++ b/.changeset/data-objectstack-files-drops-src-4847.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+`@object-ui/data-objectstack` stops publishing its `src/` tree
+
+The manifest's `files` array listed `src` alongside `dist`, so every published tarball carried all 43 source files — 38 of them `*.test.ts`. It had been that way since the package's first commit (`780a1b993`), never added for a consumer, and objectui#4006 recorded the same shape without acting on it: its scope was the `*.test.d.ts` half that the build program emitted into `dist`, and its own triage note graded this half as tarball weight rather than a break.
+
+Nothing in the published surface reached those files, which is why no consumer changes in either direction. Measured on a cleanly rebuilt `dist`, all four ways in are closed: the `exports` map has one entry (`.`) and every condition under it targets `dist`; `main` / `module` / `types` are `./dist/index.js`, `./dist/index.js`, `./dist/index.d.ts`; the repo and the docs teach only the root specifier, and no `@object-ui/data-objectstack/src/...` deep import exists anywhere (the `src` paths in sibling `vite.config.ts` / `vitest.config.mts` files are workspace aliases resolved through `path.resolve()` against the source tree, which no `files` array shapes); and the tarball holds no sourcemap that could point back at `src`, since `tsup.config.ts` sets `sourcemap: false` and its bundled `dts` writes no `.d.ts.map` — the built `dist` contains four files, zero `.map` among them, and zero occurrences of `sourceMappingURL` or `../src/`.
+
+`npm pack --dry-run` across the change, on the same `dist`:
+
+| | before | after |
+| --- | --- | --- |
+| entries | 51 | 8 |
+| unpacked | 1356830 B | 719876 B |
+| tarball | 393379 B | 222157 B |
+
+43 files leave, none arrives, and every surviving entry is byte-identical apart from the edited `package.json`: `dist/index.{js,cjs,d.ts,d.cts}`, `README.md`, `CHANGELOG.md`, `LICENSE`, `package.json`. The 43 are the 38 tests plus the five modules they cover (`index.ts`, `errors.ts`, `metadata-client.ts`, `userState.ts`, `cache/MetadataCache.ts`), whose published form remains the bundled `dist/index.js`.

--- a/packages/data-objectstack/package.json
+++ b/packages/data-objectstack/package.json
@@ -16,7 +16,6 @@
   },
   "files": [
     "dist",
-    "src",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/scripts/check-phantom-dependencies.mjs
+++ b/scripts/check-phantom-dependencies.mjs
@@ -74,8 +74,14 @@
  *     than "not present in the tarball" — which would be false. objectui#4006
  *     measured 73 `*.test.d.ts` files landing in the published `dist/` of
  *     `@object-ui/fields` and `@object-ui/plugin-editor`, and three packages
- *     (`fields`, `types`, `data-objectstack`) list `src` in `files`, so their
- *     tarballs carry the test SOURCES too. That is a real defect and it is
+ *     (`fields`, `types`, `data-objectstack`) listed `src` in `files`, so their
+ *     tarballs carried the test SOURCES too. `data-objectstack` no longer does
+ *     (objectui#4847 dropped `src` from its `files` — 43 source files, 38 of
+ *     them tests, left that tarball); `fields` and `types` still do, and for
+ *     `types` the entry is load-bearing rather than leftover, because it builds
+ *     with a bare `tsc` under the root's `declarationMap` / `sourceMap` and no
+ *     `inlineSources`, so its shipped `dist/*.d.ts.map` name `../src/*.ts` with
+ *     no embedded content. That is a real defect where it is one, and it is
  *     already filed; it is not this gate's, because nothing resolves those files
  *     and so no install of them can fail. Stated here rather than glossed,
  *     because "the build excludes tests" is the plausible-sounding version of


### PR DESCRIPTION
Fixes #4847

## 缺陷形态(一句话)

`packages/data-objectstack/package.json` 的 `files` 列了 `src`,于是每个发布 tarball 都带上 43 个源码文件(其中 38 个 `*.test.ts`)。这一条从包的**第一个 commit**(`780a1b993`)就在,不是为哪个消费者加的。与 #4836 / PR #4845 是同一个问题的两个入口(emit 进 dist / 直接列进 files),那条路在本包上已实测为 0(tsup 只从 entry 出料)。

## 前置核查:四项全部否定(实施前先做,任一命中即停手)

派发要求实施前核实 `src` 在发布物里有没有真实消费者。四条路全部关着,证据是干净重建后的实测,不是推断:

| 核查项 | 结果 | 证据 |
| --- | --- | --- |
| ① `exports` map 是否有条目解析进 `src` | 否 | 只有一个条目 `"."`,其下 `types`/`import`/`require` 三个条件全指 `./dist/*` |
| ② `main` / `module` / `types` 是否指 `src` | 否 | `./dist/index.js` / `./dist/index.js` / `./dist/index.d.ts` |
| ③ 全仓与文档是否教过 `src` deep-import | 否 | 引号精确路径 grep 全仓 + `content/docs/**` + 包内 README:`@object-ui/data-objectstack/` 带子路径的 specifier **零命中**,只教根 specifier |
| ④ sourcemap 是否落在 `src` 上 | 否 | `tsup.config.ts` 里 `sourcemap: false`,bundled dts 不产 `.d.ts.map`;干净重建后 `dist` 共 4 个文件,`.map` 0 个,`sourceMappingURL` 与 `../src` 各 0 处 |

③ 有一个**看起来像命中、实际不是**的形态,写清楚以免下一个读者按 grep 结果误判:`packages/plugin-form/vite.config.ts`、`packages/runner/vite.config.ts`、根 `vitest.config.mts` 等 7 处确实出现 `data-objectstack/src`,但它们是 `path.resolve(__dirname, '../data-objectstack/src')` 形式的**工作区别名**,解析的是仓内源码树,走不到 tarball —— `files` 只塑造 npm 包内容,对 workspace 的 symlink 解析没有任何作用。

干净重建后的 `dist` 全貌(precheck ④ 的原始材料):

```
dist/index.cjs   dist/index.d.cts   dist/index.d.ts   dist/index.js
```

## 打包验证:pack 清单前后对照

同一份 `dist`,只改 `files`,`npm pack --dry-run --json` 两侧:

| | 修复前 | 修复后 |
| --- | --- | --- |
| 条目数 | 51 | 8 |
| unpacked | 1356830 B | 719876 B |
| tarball | 393379 B | 222157 B |

**消失 43,新增 0**,幸存条目逐个大小不变(唯一变的是被编辑的 `package.json` 自身)。消失的 43 = 38 个 `*.test.ts` + 5 个实现源码(`index.ts`、`errors.ts`、`metadata-client.ts`、`userState.ts`、`cache/MetadataCache.ts`),后者的发布形态仍是打包好的 `dist/index.js`。

修复后 tarball 的完整清单(入口/README/许可证全在):

```
CHANGELOG.md  LICENSE  README.md  package.json
dist/index.cjs  dist/index.d.cts  dist/index.d.ts  dist/index.js
```

## 反向验证(方向先判后跑;方向与「钉子变红」模板**不同**,如实记录)

**预判**(跑之前写下的):本改动删的是一个 `files` 条目,而**仓内没有任何门在看这个数组的内容** —— `scripts/__tests__/package-files-exist.test.ts` 只断言「声明了的条目在磁盘上存在」,且用的是 `toBeGreaterThanOrEqual` 下限,删一条不会触底,加回来 `src` 也确实存在。所以正确预判**不是**「新钉子变红」,而是 PR #4845 记过的同一形态:(a) 把 `src` 加回 `files`、同一份 `dist` 重跑 pack,43 个文件原样重现;(b) **所有门在缺陷态保持全绿**,因为今天没有任何门看得见这一类缺陷 —— 这正是 #4847 判 observation-class 的依据本身。

**实跑,两半都与预判一致**(先 commit 修复再变异,变异不提交,已用 `git checkout` 对着分支名还原):

(a) 条目数 8 -> 51,重现 43 个(38 个 `*.test.ts` + 5 个实现源码),与修复前清单**逐字节相同**(`JSON.stringify` 全等),`src/` 以外**零条目**移动。

(b) 在同一个缺陷态下跑全部相关门,全部退 0:

```
node scripts/check-phantom-dependencies.mjs                       rc=0
node scripts/check-control-bytes.mjs                              rc=0
node scripts/check-package-self-import.mjs                        rc=0
pnpm exec vitest run scripts/__tests__/package-files-exist.test.ts  1 file / 18 tests passed
```

「什么都没变红」**就是结论本身**:缺陷在 CI 里完全不可见,与 PR #4845 对同族问题的测量一致。

## 验证(全部实跑)

```
干净重建(rm -rf dist tsconfig.tsbuildinfo 后 build)      tsup 出 4 个文件,tooling 产物 0

pnpm exec vitest run packages/data-objectstack/ \
  scripts/__tests__/package-files-exist.test.ts          39 files / 557 tests passed
pnpm exec vitest run packages/react/ \
  packages/plugin-designer/ packages/app-shell/          460 files / 4518 passed | 1 skipped
    (三个运行期 dependents;其余 6 个 dependent 只在 devDependencies 里用它)

pnpm exec turbo run type-check --concurrency=2           81 successful, 81 total

node scripts/check-control-bytes.mjs             OK 4339 文件
node scripts/check-phantom-dependencies.mjs      OK
node scripts/check-changeset-presence.mjs        OK
node scripts/check-changeset-no-major.mjs        OK
node scripts/check-changeset-fixed.mjs           OK
node scripts/check-package-self-import.mjs       OK
eslint(改动路径)                                  rc=0
grep -naP 控制字符自查(三个改动文件)                 零命中
```

## 顺带更新的一处仓内记载

`scripts/check-phantom-dependencies.mjs` 的表头写着「三个包(`fields`、`types`、`data-objectstack`)list `src` in `files`,所以它们的 tarball 也带测试**源码**」。这是本改动**直接证伪**的一句事实陈述,所以同 PR 更新,而不是留一句将来会误导人的话。更新后它记的是:`data-objectstack` 已退出(本卡),`fields` 与 `types` 仍在,**且 `types` 那处是承重的**(见下)。门的判决一个字节没变(改的是块注释)。

## 为什么本 PR 只修一个包(#4847 修法 3 的裁决,依据是测量)

#4847 的修法 3 提议「先量全仓还有哪些包的 `files` 含 `src`,同缺陷同 PR 处理」。量了:发布包里共 3 个 —— `data-objectstack`(本卡)、`fields`、`types`(`app-shell` 只列 `src/styles.css`,是精确文件不是整棵树,不同形态)。**但它们不是同一个判定**,所以没有并进本 PR:

- `@object-ui/types` 的 `build` 是裸 `tsc`,自己的 tsconfig 显式 `declarationMap: true`,根 `tsconfig.base.json` 还给了 `sourceMap: true` 且**没有** `inlineSources`。实测它已构建的 `dist/ai.d.ts.map`:`sources` 为 `["../src/ai.ts"]`,`sourcesContent` 为 `false`。也就是说**它的 `src` 是承重的** —— 去掉后随包发布的 declaration map 指向一个不存在的文件,消费者编辑器的 go-to-source 会断。这恰好是派发要求的 precheck ④ 在**另一个包上命中**的样子,按「任一命中即停手」的纪律,它不该被顺手删掉。
- `@object-ui/fields` 的 emitter 是 `vite-plugin-dts`,与上面两者都不同,要单独测。

三个包共享一个症状、不共享一个判定,合成一个 PR 会把一次机械删除和一次真实取舍混在一起。已另开 finding #4851 记录余下两个,不在本 PR 处理。

## 范围外

- 未建任何门(全仓判据的成本测量在 #4846,与 PR #4845 的结论一致:真正正确的判据是产物级的,而今天 CI 没有全仓 build)。
- 未碰 `content/docs/releases/**`、未碰任何 `src/` 源码、未碰任何 tsconfig 与 build 配置。
- `fields` / `types` 的同形态已另记 finding #4851,理由见上。

## Changeset

按 PR #4845 / #4006 的先例写了**真 patch changeset**(`.changeset/data-objectstack-files-drops-src-4847.md`):`check-changeset-presence.mjs` 不索要(没动发版包的 `src/`),但**发布物内容变了**,得让它出现在 CHANGELOG 里。未声明 `major`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_