### PR TITLE
feat(layout)!: 撤销 app-shell 组件键注册 (#4841)

### DIFF
--- a/.changeset/deregister-app-shell-component-key.md
+++ b/.changeset/deregister-app-shell-component-key.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/layout': minor
+---
+
+**Breaking (shipped as `minor`, following the `page-header` `description` retirement):**
+`app-shell` is no longer a component key. `registerLayout()` registered `AppShell` under
+that key with no `inputs`; the registration is gone (objectui#4841, ADR-0049
+enforce-or-remove, remove side, maintainer ruling 2026-08-16).
+
+**What it could never do.** Four of `AppShellProps`' seven keys are `React.ReactNode`
+slots — `sidebar`, `navbar`, `children`, `rightRail` — and a JSON document can fill none
+of them, so `{ "type": "app-shell" }` resolved to a component that had exactly two
+outcomes, neither of them a shell. `children` was dropped in silence: `SchemaRenderer`
+strips `children` (and `body`) before spreading a node's keys as props, and `AppShell`
+reads its `children` prop, never `schema.children`, so the `<main>` element rendered
+empty with nothing logged. A schema written into `sidebar` / `navbar` / `rightRail`
+arrived as a plain object React refuses to render, replacing the node with an error box.
+Only `className`, `defaultOpen` and `branding` ever survived the JSON path, i.e. the best
+result JSON could reach was a shell with no navigation, no top bar and an empty content
+area. With no `inputs` declared, `sdui-parser` had no declaration face to compare a node
+against either, so neither outcome was diagnosed.
+
+**What changes for an author.** The middle state — parses, resolves, renders nothing — is
+replaced by a named refusal. `SchemaRenderer` now shows its `Unknown component type:
+app-shell` panel (`OBJUI-001`) and `sdui-parser` reports an `error`-severity
+`unknown-component` diagnostic before render.
+
+**FROM → TO.** There is no in-place rewrite, because the node never produced a shell.
+Schema authors who want the whole shell from metadata use `app-schema-renderer`
+(`AppSchemaRenderer`), which declares its `inputs` and builds branding and sidebar
+navigation from an `AppSchema` document: `{ "type": "app-shell", … }` →
+`{ "type": "app-schema-renderer", "schema": { … } }`. Everyone else composes in React —
+`AppShell` is **unchanged and still exported** from `@object-ui/layout`, and remains the
+way to build a shell and render JSON pages inside it.
+
+Repo-wide scan before removal found no `"type": "app-shell"` node anywhere in
+`objectstack-ai/objectui` or `objectstack-ai/objectstack` at `origin/main` — no example,
+catalog schema, fixture or template authored one. `content/docs/guide/layout.md` is
+updated to state the new fact, and
+`packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx` pins it on both
+faces (source and live registry) plus the rendered diagnostic.

--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -91,7 +91,7 @@ does not register it, and nothing else in this repo does either, so a
 - `SchemaRenderer` replaces the node with its error panel —
   `Unknown component type: app-shell`, error code `OBJUI-001`.
 - `sdui-parser` reports it before render, as an `error`-severity diagnostic with code
-  `unknown-component`: `` `<app-shell> is not a known component` ``.
+  `unknown-component` and the message `<app-shell> is not a known component`.
 
 It **was** registered until objectui#4841, and the registration could never produce a
 shell. Four of the seven props are `React.ReactNode` slots that a JSON document cannot

--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -34,8 +34,9 @@ a main content area.
 **`AppShell` is a React component, not an authorable JSON node.** Four of its seven props
 are `React.ReactNode` slots — `sidebar`, `navbar`, `children` and `rightRail` — and a JSON
 document has no way to put a node into any of them. Compose the shell in React, and render
-your JSON pages *inside* it. What a `{ "type": "app-shell" }` node does with each key is
-spelled out under [In a JSON node](#in-a-json-node) below.
+your JSON pages *inside* it. `app-shell` is not a component key either — what a
+`{ "type": "app-shell" }` node does now is measured under
+[There is no `app-shell` node](#there-is-no-app-shell-node) below.
 
 ### Basic Usage
 
@@ -68,39 +69,50 @@ the component's `children`; there is no `body` prop either.
 component destructures that fixed key list with **no rest element**, so anything else you
 pass is built and then dropped on the floor.
 
-| Prop | Type | Required | In a JSON node | Description |
-| --- | --- | --- | --- | --- |
-| `sidebar` | `React.ReactNode` | no | no | Left sidebar node, a flex sibling of the content. Pass `SidebarNav`, or your own node. |
-| `navbar` | `React.ReactNode` | no | no | Top-bar content. `AppShell` supplies the sticky `<header>` around it, so pass only what goes inside. |
-| `children` | `React.ReactNode` | yes | no | Main content, rendered inside the `<main>` element. |
-| `className` | `string` | no | yes | Tailwind overrides for the `<main>` content element — **not** for the outer container. |
-| `defaultOpen` | `boolean` | no | yes | Initial open state of the underlying Shadcn `SidebarProvider`. Defaults to `true`. |
-| `branding` | `AppShellBranding` | no | yes | App branding, applied by `useAppShellBranding`: `primaryColor` / `accentColor` become CSS custom properties on the document root, `favicon` sets the icon link's `href`, and `title` sets `document.title`. |
-| `rightRail` | `React.ReactNode` | no | no | Optional right-side rail. It reflows the content beside it rather than overlaying it; absent → unchanged single-pane layout. |
+These are React props, passed in JSX. None of them is authorable in JSON — there is no
+`app-shell` node to write them on.
 
-### In a JSON node
+| Prop | Type | Required | Description |
+| --- | --- | --- | --- |
+| `sidebar` | `React.ReactNode` | no | Left sidebar node, a flex sibling of the content. Pass `SidebarNav`, or your own node. |
+| `navbar` | `React.ReactNode` | no | Top-bar content. `AppShell` supplies the sticky `<header>` around it, so pass only what goes inside. |
+| `children` | `React.ReactNode` | yes | Main content, rendered inside the `<main>` element. |
+| `className` | `string` | no | Tailwind overrides for the `<main>` content element — **not** for the outer container. |
+| `defaultOpen` | `boolean` | no | Initial open state of the underlying Shadcn `SidebarProvider`. Defaults to `true`. |
+| `branding` | `AppShellBranding` | no | App branding, applied by `useAppShellBranding`: `primaryColor` / `accentColor` become CSS custom properties on the document root, `favicon` sets the icon link's `href`, and `title` sets `document.title`. |
+| `rightRail` | `React.ReactNode` | no | Optional right-side rail. It reflows the content beside it rather than overlaying it; absent → unchanged single-pane layout. |
 
-`app-shell` is registered on the `ComponentRegistry` (`packages/layout/src/index.ts`), so
-`{ "type": "app-shell" }` does resolve to this component. The registration declares no
-`inputs`, which is why `sdui-parser`'s unknown-prop check has nothing to compare a node
-against and stays silent whatever you write. Measured, key by key:
+### There is no `app-shell` node
 
-- **The three plain-data props work.** `className`, `defaultOpen` and `branding` are
-  spread onto the component unchanged. `className` lands on the `<main>` element, and
-  `branding`'s fields are applied by `useAppShellBranding` exactly as in React.
-- **`children` is dropped, silently.** `SchemaRenderer` strips `children` (and `body`) out
-  of a node before spreading the remaining keys as props, and `AppShell` reads its
-  `children` **prop**, not `schema.children`. The `<main>` element renders empty and
-  nothing is logged.
-- **`sidebar` / `navbar` / `rightRail` cannot hold a schema.** They are `React.ReactNode`;
-  a JSON value reaches the component as a plain object, and React refuses to render one.
-  The node is replaced by the renderer's error box: `Component "app-shell" failed to
-  render — Objects are not valid as a React child`.
+`app-shell` is not a component key. `registerLayout()` (`packages/layout/src/index.ts`)
+does not register it, and nothing else in this repo does either, so a
+`{ "type": "app-shell" }` node resolves to nothing and says so. Measured on this tree:
 
-So do not author an `app-shell` node in JSON. Build the shell in React as above — or, when
-the whole shell should come from metadata, use `AppSchemaRenderer` (registered as
-`app-schema-renderer`), which builds branding and sidebar navigation from an `AppSchema`
-JSON document and takes the page content as its `children`.
+- `SchemaRenderer` replaces the node with its error panel —
+  `Unknown component type: app-shell`, error code `OBJUI-001`.
+- `sdui-parser` reports it before render, as an `error`-severity diagnostic with code
+  `unknown-component`: `` `<app-shell> is not a known component` ``.
+
+It **was** registered until objectui#4841, and the registration could never produce a
+shell. Four of the seven props are `React.ReactNode` slots that a JSON document cannot
+fill, so a node had exactly two outcomes: `children` was stripped by `SchemaRenderer`
+before a node's keys were spread as props — `AppShell` reads its `children` prop, never
+`schema.children` — so the `<main>` element rendered **empty with nothing logged**; and a
+schema written into `sidebar` / `navbar` / `rightRail` arrived as a plain object, which
+React refuses to render, replacing the node with an error box. Only `className`,
+`defaultOpen` and `branding` ever survived the JSON path, i.e. the best result JSON could
+reach was a shell with no navigation, no top bar and an empty content area. The key was
+retired under ADR-0049 (enforce-or-remove) so that this comes out as a named refusal
+rather than a page that renders nothing.
+
+Two doors remain, one per capability:
+
+- **Compose in React** — `<AppShell>` as shown above, with your JSON pages rendered
+  *inside* it through `SchemaRenderer`.
+- **The whole shell from metadata** — `AppSchemaRenderer`, registered as
+  `app-schema-renderer` and declaring its `inputs`, which builds branding and sidebar
+  navigation from an `AppSchema` JSON document and takes the page content as its
+  `children`.
 
 ### Features
 
@@ -280,9 +292,9 @@ renders nothing here.
 The `SidebarNav` provides a collapsible navigation sidebar with menu items.
 
 **`SidebarNav` is a React component, and `sidebar-nav` is not a component key at all.**
-`registerLayout()` (`packages/layout/src/index.ts`) registers six keys — `page-header`,
-`page:card`, `app-shell`, `responsive-grid`, `navigation-renderer` and
-`app-schema-renderer` — and nothing in this repo registers `sidebar-nav`. What a
+`registerLayout()` (`packages/layout/src/index.ts`) registers five keys — `page-header`,
+`page:card`, `responsive-grid`, `navigation-renderer` and `app-schema-renderer` — and
+nothing in this repo registers `sidebar-nav`. What a
 `{ "type": "sidebar-nav" }` node actually does is measured under
 [There is no `sidebar-nav` node](#there-is-no-sidebar-nav-node) below. Compose the nav in
 React, or use `navigation-renderer` when the tree has to come from metadata.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -24,9 +24,9 @@ pnpm add @object-ui/layout
 ## Registration
 
 Importing this package registers its component keys (`page-header`, `page:card`,
-`app-shell`, `responsive-grid`, `navigation-renderer`, `app-schema-renderer`) on
-the `ComponentRegistry` as a module load side effect, so the side-effect-only
-import is enough:
+`responsive-grid`, `navigation-renderer`, `app-schema-renderer`) on the
+`ComponentRegistry` as a module load side effect, so the side-effect-only import
+is enough:
 
 ```typescript
 import '@object-ui/layout';
@@ -62,6 +62,12 @@ fills it (`:249`) — there is no `header` prop. This example used to pass one
 (objectui#4817), and because the component destructures a fixed key list with
 **no rest element** (`:233-241`), the node was built and then dropped on the
 floor: copied verbatim, the snippet rendered an empty top bar and said nothing.
+
+Like `SidebarNav` below, `AppShell` is composed in JSX and is **not** on the
+`ComponentRegistry`: four of its seven props are `React.ReactNode` slots that no
+JSON document can fill, so the `app-shell` key was retired in objectui#4841 and
+`{ "type": "app-shell" }` now reports `Unknown component type`. When the whole
+shell has to come from metadata, the key for that is `app-schema-renderer`.
 
 #### `AppShellProps`
 

--- a/packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx
+++ b/packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx
@@ -142,8 +142,10 @@ describe('a JSON `app-shell` node is refused by name (objectui#4841)', () => {
         'unregistered, this panel is what an author must see.',
       ].join('\n'),
     ).not.toBeNull();
-    expect(panel?.textContent).toContain('Unknown component type');
-    expect(panel?.textContent).toContain('app-shell');
+    // Asserted as the composed line rather than two loose substrings, so this
+    // is the diagnostic an author actually reads — and so the PR/changeset can
+    // quote it as measured rather than reconstructed from the JSX.
+    expect(panel?.textContent).toContain('Unknown component type: app-shell');
     // The suggestion line carries the error code; it is dev-only, and the test
     // environment is not production.
     expect(panel?.textContent).toContain('OBJUI-001');

--- a/packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx
+++ b/packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `app-shell` is NOT a component key (objectui#4841, ADR-0049 enforce-or-remove,
+ * remove side, maintainer ruling 2026-08-16).
+ *
+ * ## What was removed and why
+ *
+ * `registerLayout()` used to register `AppShell` under `app-shell`, with no
+ * `inputs`. The key resolved, so `{ "type": "app-shell" }` parsed and built a
+ * component — and that component could never be an app shell. Four of
+ * `AppShellProps`' seven keys are `React.ReactNode` slots (`sidebar`, `navbar`,
+ * `children`, `rightRail`) and a JSON document can fill none of them, which left
+ * a node exactly two outcomes:
+ *
+ *   - `children` was dropped in SILENCE — `SchemaRenderer` strips `children`
+ *     (and `body`) before spreading a node's keys as props, and `AppShell` reads
+ *     its `children` PROP, never `schema.children`. The `<main>` element
+ *     rendered empty, console.error count 0.
+ *   - a schema in `sidebar` / `navbar` / `rightRail` reached the component as a
+ *     plain object, which React refuses to render, so the node became the
+ *     renderer's error box.
+ *
+ * Only `className` / `defaultOpen` / `branding` survived the JSON path, i.e. the
+ * best result JSON could reach was a shell with no navigation, no top bar and an
+ * empty content area — and with no `inputs` declared, `sdui-parser` had no
+ * declaration face to compare a node against, so neither outcome was diagnosed
+ * (objectui#3972's family).
+ *
+ * ## What this file pins
+ *
+ * Removing a registration is trivially reversible and reads like a cleanup, so
+ * the state is pinned on the two faces that can disagree — the SOURCE (no
+ * register call) and the LIVE registry (nothing else claims the key either,
+ * bare or namespaced) — plus the fact the removal exists to produce: the node is
+ * refused BY NAME.
+ *
+ * The refusal is measured, not asserted from the error-code table: the test
+ * renders the node and reads the panel. `responsive-grid` is rendered the same
+ * way as the control, because "no unknown-component panel appeared" is exactly
+ * the shape that passes for an empty reason — a probe that cannot tell a
+ * registered key from an unregistered one would be green on both.
+ *
+ * The other half of the ruling is pinned too: `AppShell` stays EXPORTED as a
+ * React composition primitive, and `app-schema-renderer` stays registered WITH
+ * `inputs` as the one JSON door to a metadata-driven shell. Deleting either is
+ * a different decision from deregistering the key, and this file fails if one
+ * is taken for the other.
+ *
+ * Not pinned here: `content/docs/guide/layout.md`'s prose, which belongs to
+ * `guide-layout-app-shell-doc.test.ts` (objectui#4827) and — for the registered
+ * key list the page publishes — `guide-layout-sidebar-nav-doc.test.ts`
+ * (objectui#4840).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+
+import { registerLayout, AppShell } from '../index';
+
+/** Repo root — four levels up from `packages/layout/src/__tests__`. */
+const REPO_ROOT = resolve(__dirname, '../../../..');
+const LAYOUT_INDEX_SRC = readFileSync(
+  join(REPO_ROOT, 'packages', 'layout', 'src', 'index.ts'),
+  'utf8',
+);
+
+/** Component keys `registerLayout()` registers, read out of the source. */
+const registeredKeys = (): string[] =>
+  [...LAYOUT_INDEX_SRC.matchAll(/ComponentRegistry\.register\(\s*'([^']+)'/g)].map(
+    (match) => match[1],
+  );
+
+beforeAll(() => {
+  // The barrel registers on evaluation, but say so explicitly: this file's
+  // claims are about what `registerLayout()` puts in the registry, and an
+  // import-order accident must not be what makes them true.
+  registerLayout();
+});
+
+describe('`app-shell` is not registered (objectui#4841)', () => {
+  it('src/index.ts has no `app-shell` register call', () => {
+    const keys = registeredKeys();
+    expect(
+      keys.length,
+      'no `ComponentRegistry.register` call parsed out of src/index.ts — the assertion below would prove nothing',
+    ).toBeGreaterThan(1);
+
+    expect(
+      keys,
+      [
+        '`app-shell` is registered again. It was removed in objectui#4841 (ADR-0049',
+        'enforce-or-remove) because the key resolved to a component a JSON document can never',
+        'fill: four of the seven props are `React.ReactNode` slots, `children` is stripped by',
+        'SchemaRenderer before a node is spread as props, and the registration declared no',
+        '`inputs`, so nothing diagnosed either outcome.',
+        '',
+        'Putting the key back is option B on that issue, and it is not a one-line revert: it',
+        'needs `inputs` AND a rendering adapter that turns the schema values in',
+        '`sidebar`/`navbar`/`rightRail` into nodes and wires `schema.children` to `children`,',
+        'plus an answer to how it then differs from `app-schema-renderer`. If that work has',
+        'landed, this file records it — but the diagnostic assertions below must be replaced by',
+        'assertions about what the node RENDERS, never merely deleted.',
+        `Registered: ${keys.join(', ')}`,
+      ].join('\n'),
+    ).not.toContain('app-shell');
+  });
+
+  it('and nothing else in the loaded registry claims the key, bare or namespaced', () => {
+    // The source read above cannot see a registration made by another package.
+    // `register(type, …, { namespace })` writes BOTH `layout:app-shell` and the
+    // bare `app-shell` fallback, so both spellings are asked for by name.
+    expect(ComponentRegistry.getConfig('app-shell')).toBeUndefined();
+    expect(ComponentRegistry.getConfig('app-shell', 'layout')).toBeUndefined();
+    expect(ComponentRegistry.has('app-shell')).toBe(false);
+  });
+});
+
+describe('a JSON `app-shell` node is refused by name (objectui#4841)', () => {
+  it('renders the OBJUI-001 unknown-component panel, not an empty shell', () => {
+    const { container } = render(<SchemaRenderer schema={{ type: 'app-shell' }} />);
+
+    const panel = container.querySelector('[role="alert"]');
+    expect(
+      panel,
+      [
+        'A `{ "type": "app-shell" }` node no longer produces the unknown-component panel.',
+        'objectui#4841 removed the registration precisely so this node fails LOUDLY: what it',
+        'used to do was parse, resolve, and then render a shell with no navigation, no top bar',
+        'and an empty content area — with nothing logged. If the key is authorable again, that',
+        'is a change to the component (see the sibling test above); if it is merely',
+        'unregistered, this panel is what an author must see.',
+      ].join('\n'),
+    ).not.toBeNull();
+    expect(panel?.textContent).toContain('Unknown component type');
+    expect(panel?.textContent).toContain('app-shell');
+    // The suggestion line carries the error code; it is dev-only, and the test
+    // environment is not production.
+    expect(panel?.textContent).toContain('OBJUI-001');
+  });
+
+  it('and the probe can tell a registered key apart — `responsive-grid` renders', () => {
+    // The control. Without it, "an unknown-component panel appeared" would pass
+    // just as happily on a renderer that panels EVERY node, and this file would
+    // be green for a reason that has nothing to do with `app-shell`.
+    const { container } = render(
+      <SchemaRenderer schema={{ type: 'responsive-grid', children: [] }} />,
+    );
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.textContent).not.toContain('Unknown component type');
+  });
+});
+
+describe('the two surviving doors, one per capability (objectui#4841)', () => {
+  it('`AppShell` is still exported as a React composition primitive', () => {
+    // The remove side of ADR-0049 retired the KEY, not the component. Compose
+    // the shell in React and render JSON pages inside it — that path is the
+    // reason the deregistration costs no capability.
+    expect(
+      typeof AppShell,
+      [
+        '`AppShell` is no longer exported from @object-ui/layout. objectui#4841 deregistered the',
+        '`app-shell` COMPONENT KEY and explicitly kept the component: it is the React',
+        'composition primitive every consumer of this package uses, and the guide teaches it as',
+        'the way to build a shell.',
+      ].join('\n'),
+    ).toBe('function');
+  });
+
+  it('`app-schema-renderer` is still the JSON door, and still declares its `inputs`', () => {
+    const config = ComponentRegistry.getConfig('app-schema-renderer');
+    expect(
+      config,
+      [
+        '`app-schema-renderer` is gone from the registry. It is the ONE key that renders a whole',
+        'shell from a JSON document (objectui#4841 kept it for exactly that reason), so removing',
+        'it leaves metadata-driven shells with no entry point at all.',
+      ].join('\n'),
+    ).toBeTruthy();
+
+    expect(
+      (config?.inputs ?? []).map((input) => input.name),
+      [
+        '`app-schema-renderer` no longer declares `inputs`. That declaration is what separates it',
+        'from the `app-shell` registration objectui#4841 removed: an authorable key with no',
+        'declared surface gives `sdui-parser` nothing to compare a node against, so every',
+        'misspelling passes in silence.',
+      ].join('\n'),
+    ).toContain('schema');
+  });
+});

--- a/packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts
+++ b/packages/layout/src/__tests__/guide-layout-app-shell-doc.test.ts
@@ -22,17 +22,24 @@
  * `headerClassName`, `sidebarClassName` and `contentClassName` do not exist,
  * and four of them were demonstrated a second time in the `### Custom Classes`
  * example. On the React surfaces a copied phantom prop at least reaches a
- * TypeScript consumer as an error; in a JSON document nothing checks it —
- * `app-shell` is registered with no `inputs` (`packages/layout/src/index.ts`),
- * so `sdui-parser`'s unknown-prop check has nothing to compare a node against
- * and reports nothing at all.
+ * TypeScript consumer as an error; in a JSON document nothing checked it —
+ * `app-shell` was registered with no `inputs` (`packages/layout/src/index.ts`),
+ * so `sdui-parser`'s unknown-prop check had nothing to compare a node against
+ * and reported nothing at all.
+ *
+ * That registration is GONE (objectui#4841, ADR-0049 enforce-or-remove, remove
+ * side). The key resolves to nothing now, so the node is refused by name instead
+ * of silently under-rendering — `app-shell-not-a-component-key.test.tsx` owns
+ * that fact and measures the diagnostic. This file is unchanged in what it
+ * judges: the page's React material, and that no fence on it authors the node.
  *
  * ## What the page says now, and what the halves below hold to it
  *
  * The page was rewritten to teach `AppShell` as what it is — a React component
  * whose four node slots (`sidebar` / `navbar` / `children` / `rightRail`) a JSON
  * document cannot fill. Those claims were measured against this tree, not
- * inferred:
+ * inferred, and they are what objectui#4841 then acted on — the three bullets
+ * below describe the registration as it behaved BEFORE it was removed:
  *
  *   - `className`, `defaultOpen` and `branding` DO survive the JSON path. They
  *     are plain data, `SchemaRenderer` spreads them onto the component, and a
@@ -402,16 +409,19 @@ describe('the guide authors no `app-shell` JSON node (objectui#4827)', () => {
       offenders.map((fence) => `content/docs/guide/layout.md:${fence.line}`),
       [
         'A fence in content/docs/guide/layout.md authors an `app-shell` node again',
-        '(objectui#4827). Four of the seven props are `React.ReactNode` slots and a JSON',
-        'document can fill none of them: `children` is stripped by SchemaRenderer before a',
-        "node's keys are spread as props, so `<main>` renders EMPTY with nothing logged, and a",
-        'schema in `sidebar` / `navbar` / `rightRail` reaches the component as a plain object,',
-        'which React refuses to render. The registration declares no `inputs`, so nothing',
-        'diagnoses either case. Teach the React composition instead.',
+        '(objectui#4827). The key is not registered at all any more (objectui#4841), so the',
+        'node resolves to nothing: the renderer replaces it with the red "Unknown component',
+        'type: app-shell" panel (OBJUI-001) and sdui-parser reports `unknown-component`. It was',
+        'deregistered because four of the seven props are `React.ReactNode` slots a JSON',
+        'document can fill none of — `children` was stripped by SchemaRenderer before a node\'s',
+        'keys were spread as props, so `<main>` rendered EMPTY with nothing logged, and a schema',
+        'in `sidebar` / `navbar` / `rightRail` reached the component as a plain object, which',
+        'React refuses to render. Teach the React composition instead, or `app-schema-renderer`',
+        'when the whole shell has to come from metadata.',
         '',
-        'If `app-shell` is ever made authorable — inputs declared AND the slots fed from the',
-        'schema — this assertion is the right place to record that, but it must be a change to',
-        'the component, not to the page.',
+        'If `app-shell` is ever made authorable — registered again WITH inputs AND the slots fed',
+        'from the schema — this assertion is the right place to record that, but it must be a',
+        'change to the component, not to the page.',
       ].join('\n'),
     ).toEqual([]);
   });

--- a/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
+++ b/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
@@ -19,8 +19,12 @@
  * on a THIRD surface — and this one went one level further than either. Those
  * two misspelled the keys of a real React component. This page taught a JSON
  * NODE TYPE that does not exist: `registerLayout()` registers `page-header`,
- * `page:card`, `app-shell`, `responsive-grid`, `navigation-renderer` and
+ * `page:card`, `responsive-grid`, `navigation-renderer` and
  * `app-schema-renderer`, and nothing in the repo registers `sidebar-nav`.
+ * (`app-shell` was a sixth key until objectui#4841 deregistered it — for the
+ * same reason, one step less far along: it resolved to a component that a JSON
+ * document could never fill. `sidebar-nav` never resolved at all, which is why
+ * this page's defect was the LOUDER of the two.)
  *
  * Measured on this tree, a `{ "type": "sidebar-nav", "items": [...] }` node
  * renders the renderer's red panel and no sidebar at all:
@@ -28,9 +32,11 @@
  *     Unknown component type: sidebar-nav
  *     (OBJUI-001)
  *
- * So this defect is LOUDER than objectui#4827's `app-shell` one, which at least
+ * So this defect was LOUDER than objectui#4827's `app-shell` one, which at least
  * resolved to a component and dropped keys quietly. Here nothing is parsed as
- * props, because nothing resolves.
+ * props, because nothing resolves. objectui#4841 has since given `app-shell` the
+ * same treatment — deregistered, so it too now renders `Unknown component type`
+ * rather than an empty shell.
  *
  * The page's `### Schema API` block also got the component's own shape wrong in
  * seven ways at once — `label` for `title`, `icon` as a string rather than a
@@ -325,6 +331,27 @@ function registeredKeys(): string[] {
   );
 }
 
+/**
+ * The count words the intro sentence can spell its key list with.
+ *
+ * The number used to be hardcoded as `6` in the assertions below, which made a
+ * pin that reads its key list out of source carry one fact that did not:
+ * objectui#4841 deregistered `app-shell` and the count went to five, so the
+ * literal was the only thing standing between an accurate page and a red test
+ * for the wrong reason. The page's own word is read instead — the sentence and
+ * the source still have to agree, but agreeing at any number is allowed.
+ */
+const NUMBER_WORDS: Record<string, number> = {
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+};
+
 describe("the guide's SidebarNav tables name exactly the real keys (objectui#4840)", () => {
   it.each([
     ['### Props', 'SidebarNavProps'],
@@ -477,14 +504,26 @@ describe('the guide authors no `sidebar-nav` JSON node (objectui#4840)', () => {
 
   it('and the page names exactly the keys that ARE registered', () => {
     const keys = registeredKeys();
-    // The sentence reads: "registers six keys — `a`, `b` … and `f` — and nothing …".
-    const sentence = /registers six keys — ([\s\S]*?) — and nothing/.exec(GUIDE);
+    // The sentence reads: "registers five keys — `a`, `b` … and `e` — and nothing …".
+    //
+    // Whitespace is matched as `\s+` rather than a literal space throughout: the
+    // sentence is markdown prose that gets re-wrapped whenever the key list
+    // changes length, and with literal spaces this pin failed on a line break
+    // landing between "and" and "nothing" — a rewrap, not a drift. Where the
+    // lines break is not a fact this file should have an opinion about.
+    const sentence = /registers (\w+) keys\s+—\s+([\s\S]*?)\s+—\s+and\s+nothing/.exec(GUIDE);
     if (!sentence) {
       throw new Error(
-        'The `## SidebarNav Component` intro no longer carries its "registers six keys — … — and nothing" list',
+        'The `## SidebarNav Component` intro no longer carries its "registers <count> keys — … — and nothing" list',
       );
     }
-    const named = [...sentence[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+    const spelled = NUMBER_WORDS[sentence[1].toLowerCase()];
+    if (spelled === undefined) {
+      throw new Error(
+        `The \`## SidebarNav Component\` intro spells its key count "${sentence[1]}", which is not a number word this test can read. Spell it in words (e.g. "five"), or add the word to NUMBER_WORDS.`,
+      );
+    }
+    const named = [...sentence[2].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
 
     expect(
       named.slice().sort(),
@@ -496,8 +535,14 @@ describe('the guide authors no `sidebar-nav` JSON node (objectui#4840)', () => {
         `Registered: ${keys.join(', ')}`,
       ].join('\n'),
     ).toEqual(keys.slice().sort());
-    expect(named.length, 'the page says "six keys" but names a different number').toBe(6);
-    expect(keys.length, 'the page says "six keys" but the source registers a different number').toBe(6);
+    expect(
+      named.length,
+      `the page says "${sentence[1]} keys" but names a different number`,
+    ).toBe(spelled);
+    expect(
+      keys.length,
+      `the page says "${sentence[1]} keys" but the source registers a different number`,
+    ).toBe(spelled);
   });
 
   it('no fence on the page contains a `{ "type": "sidebar-nav" }` node', () => {

--- a/packages/layout/src/__tests__/side-effects-manifest.test.ts
+++ b/packages/layout/src/__tests__/side-effects-manifest.test.ts
@@ -11,9 +11,10 @@
  * manifest has to say so (objectui#3899).
  *
  * `src/index.ts` ends with a bare `try { registerLayout(); } catch {}`, which is
- * the only thing that puts `page-header`, `page:card`, `app-shell`,
- * `responsive-grid`, `navigation-renderer` and `app-schema-renderer` into the
- * `ComponentRegistry`. The manifest used to declare `"sideEffects": false` —
+ * the only thing that puts `page-header`, `page:card`, `responsive-grid`,
+ * `navigation-renderer` and `app-schema-renderer` into the `ComponentRegistry`.
+ * (There was a sixth, `app-shell`, until objectui#4841 deregistered it.) The
+ * manifest used to declare `"sideEffects": false` —
  * a promise to bundlers that no module here does anything on evaluation, so any
  * module whose exports go unused may be dropped whole.
  *
@@ -22,7 +23,7 @@
  * documented "import it to register" pattern) with the repo's own bundler:
  *
  *   sideEffects: false  ->  bundle is 0 bytes, zero registrations
- *   this array          ->  bundle keeps all six `ComponentRegistry.register` calls
+ *   this array          ->  bundle keeps every `ComponentRegistry.register` call
  *
  * Zero bytes, exit code 0, no warning. The failure surfaces far away as a red
  * `Unknown component type` panel (OBJUI-001) on a green build. Nobody was bitten
@@ -301,10 +302,17 @@ describe('@object-ui/layout declares its load-time registration (objectui#3899)'
       /ComponentRegistry\.register\(\s*'([^']+)'/g,
     )].map((match) => match[1]);
 
+    // A floor, not a census: it exists so a regex that stops matching cannot
+    // turn the loop below into a no-op. It read `6` until objectui#4841
+    // deregistered `app-shell` (ADR-0049 remove side), which is the one way this
+    // number is allowed to move — DOWN, with a register call deleted in the same
+    // commit. It is not a licence to delete registrations: the keys themselves
+    // are pinned by name in `guide-layout-sidebar-nav-doc.test.ts`, against the
+    // list the guide publishes.
     expect(
       registeredKeys.length,
       'No `ComponentRegistry.register` call found in src/index.ts — the loop below would assert nothing.',
-    ).toBeGreaterThanOrEqual(6);
+    ).toBeGreaterThanOrEqual(5);
 
     for (const key of registeredKeys) {
       expect(code, `the \`${key}\` registration must survive a side-effect-only import`).toContain(key);

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -161,6 +161,7 @@ export function registerLayout() {
   // `ComponentRegistry` + `.register(`, and a verbatim copy in a comment reads
   // to them as a live registration. Same reason the file's other notes name
   // keys in prose.)
+  //
   // Four of `AppShellProps`' seven keys are `React.ReactNode` slots (`sidebar`,
   // `navbar`, `children`, `rightRail`) and a JSON document can fill none of
   // them. Measured on `378dc920b`, a node had exactly two outcomes, neither of

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -5,7 +5,6 @@
 
 import { ComponentRegistry } from '@object-ui/core';
 import { PageHeader } from './PageHeader';
-import { AppShell } from './AppShell';
 import { PageCard } from './PageCard';
 import { SidebarNav } from './SidebarNav';
 import { ResponsiveGrid } from './ResponsiveGrid';
@@ -150,11 +149,59 @@ export function registerLayout() {
     isContainer: true
   });
 
-  ComponentRegistry.register('app-shell', AppShell, {
-    namespace: 'layout',
-    label: 'App Shell',
-    category: 'Layout',
-  });
+  // NOTE: `app-shell` is deliberately NOT a component key (objectui#4841,
+  // ADR-0049 enforce-or-remove, remove side; maintainer ruling 2026-08-16).
+  //
+  // It used to be registered here — key `app-shell`, component `AppShell`,
+  // `namespace: 'layout'`, `label: 'App Shell'`, `category: 'Layout'`, and no
+  // `inputs` — and that registration could never produce an app shell.
+  //
+  // (The call is described rather than quoted on purpose: the pins that read
+  // this file ask it for the registered key list with a regex over
+  // `ComponentRegistry` + `.register(`, and a verbatim copy in a comment reads
+  // to them as a live registration. Same reason the file's other notes name
+  // keys in prose.)
+  // Four of `AppShellProps`' seven keys are `React.ReactNode` slots (`sidebar`,
+  // `navbar`, `children`, `rightRail`) and a JSON document can fill none of
+  // them. Measured on `378dc920b`, a node had exactly two outcomes, neither of
+  // them a shell:
+  //
+  //   - `children` is dropped in SILENCE. `SchemaRenderer` strips `children`
+  //     (and `body`) out of a node before spreading the remaining keys as
+  //     props, and `AppShell` reads its `children` PROP, never
+  //     `schema.children`. The `<main>` element rendered empty, console.error
+  //     count 0.
+  //   - a schema in `sidebar` / `navbar` / `rightRail` reaches the component as
+  //     a plain object and React refuses to render it, so the node became the
+  //     renderer's error box ("Objects are not valid as a React child").
+  //
+  // Only `className` / `defaultOpen` / `branding` — the three plain-data keys —
+  // ever survived the JSON path, i.e. the best result JSON could reach was a
+  // shell with no navigation, no top bar and an empty content area. With no
+  // `inputs` declared, `sdui-parser`'s unknown-prop check had nothing to compare
+  // a node against either, so neither outcome was diagnosed (same family as
+  // objectui#3972).
+  //
+  // Removing the key does not remove a capability — it replaces a
+  // parse-succeeds-renders-nothing middle state with a NAMED refusal:
+  // `{ "type": "app-shell" }` now resolves to nothing, so `SchemaRenderer`
+  // renders its OBJUI-001 panel ("Unknown component type: app-shell") and
+  // `sdui-parser` reports `unknown-component`. Loud beats silent.
+  //
+  // The two survivors carry the two real capabilities, and this is the whole
+  // point of the split:
+  //   - `AppShell` stays EXPORTED (above) as a React composition primitive —
+  //     compose the shell in React and render JSON pages inside it.
+  //   - `app-schema-renderer` (below) stays the ONE JSON door for "render a
+  //     whole shell from a schema": it declares `inputs` and builds branding and
+  //     sidebar navigation out of an `AppSchema` document.
+  //
+  // Re-registering `app-shell` is not a one-line revert: it needs `inputs` AND a
+  // rendering adapter that turns the schema values in `sidebar`/`navbar`/
+  // `rightRail` into nodes and wires `schema.children` to `children` (option B
+  // on objectui#4841), plus an answer to how it then differs from
+  // `app-schema-renderer`. `__tests__/app-shell-not-a-component-key.test.tsx`
+  // pins the current state and says the same thing where it fails.
 
   ComponentRegistry.register('responsive-grid', ResponsiveGrid, {
     namespace: 'layout',


### PR DESCRIPTION
Fixes #4841

按 2026-08-16 维护者裁定（#4841 评论 5307574602）执行**方案 A —— 撤销 `app-shell` 组件键注册**（ADR-0049 enforce-or-remove 的 remove 侧）。`AppShell` 组件本体与导出保留；`app-schema-renderer` 不动。

## 为什么撤

`registerLayout()` 把 `AppShell` 注册成 `app-shell`，且不声明 `inputs`。键能解析，但这个组件 JSON 永远填不满：`AppShellProps` 七个键里四个是 `React.ReactNode` 插槽（`sidebar` / `navbar` / `children` / `rightRail`），JSON 一个都填不了。于是节点只有两种结局，没有一种是壳：

- **`children` 被静默剥掉。** `SchemaRenderer` 在 spread 节点其余键之前把 `children`（和 `body`）摘出去，而 `AppShell` 读的是 `children` **prop**、从不读 `schema.children`。main 元素渲染为空，`console.error` 计数 0。
- **三个节点插槽直接崩。** `sidebar` / `navbar` / `rightRail` 里的 schema 以纯对象抵达组件，React 拒绝渲染，节点被换成渲染器的错误框。

只有 `className` / `defaultOpen` / `branding` 三个纯数据键真的走通 JSON 路径 —— JSON 侧能拿到的最好结果，是一个没有导航、没有顶栏、内容区空着的壳。`inputs` 为空是第二层：`sdui-parser` 没有可比对的声明面，上述任一种写法都不会被校验器说一句话。

## 撤除后的诊断读数

**渲染面（实测，由新钉子逐字断言）**：`{ "type": "app-shell" }` 经 `SchemaRenderer` 得到 `role="alert"` 的红框，正文首行逐字为

```
Unknown component type: app-shell
```

开发态另有一行建议文案，携带错误码 `OBJUI-001`（`ERROR_CODES` 表，`packages/core/src/errors/index.ts:23-30`）。这两条都是 `app-shell-not-a-component-key.test.tsx` 里的断言，不是从 JSX 反推的。

**校验面（源码面，未在本 PR 中渲染实测）**：`sdui-parser` 的 manifest 由注册表投影而来（`manifestFromConfigs`，`packages/sdui-parser/src/index.ts:125-155`），键消失后 `validateTree` 走 `!comp` 分支，产出 `severity: 'error'` / `code: 'unknown-component'` 的诊断，message 模板见 `packages/sdui-parser/src/validate.ts:44-50`（形如 `... is not a known component`，尖括号包裹节点 type —— 此处不逐字贴，避免被 GitHub 正文的 HTML 清洗吞掉）。

也就是说：从「解析成功、渲染不出东西」的中间态，换成了一条指名道姓的拒绝。

## 前置扫描面记录（撤已发布键的标准动作）

在两个本地可达仓的 `origin/main` 上扫 `"type": "app-shell"`（含 `"type":"app-shell"` 紧凑写法、`type: 'app-shell'` JS 写法、`type: app-shell` YAML 写法）：

| 仓 | commit | 命中 |
|---|---|---|
| `objectstack-ai/objectui` | `1ef236e18` | 只有 `content/docs/guide/layout.md` 的说明性散文与 `guide-layout-app-shell-doc.test.ts` 的钉子文案；**无任何真实节点** |
| `objectstack-ai/objectstack` | `d491625c1` | 0 |

`examples/`、`apps/`、`e2e/`、`skills/`、`public/` 全域再扫一遍 `app-shell` 裸词，命中全部是 `@object-ui/app-shell` **包名**（另一个包）或 `namespace: 'app-shell'`，与本组件键无关。

**扫描器反查（负控制）**：同一套命令扫邻近键 `"type": "page"`，在 `examples/schema-catalog` 命中 5 个文件、`content/docs` 6 个、`packages/runner` 1 个 —— 证明扫描面确实覆盖 examples/catalog 目录，`app-shell` 的 0 命中是真 0，不是扫不到。

## 改动面

- `packages/layout/src/index.ts` —— 删注册块与随之无用的 `AppShell` 具名 import（`export * from './AppShell'` 保留，组件照常导出）。原地留了一段注释，写明撤除理由、两个幸存入口、以及「要恢复注册需要什么」。注释里**不逐字抄那行 register 调用** —— 读这个文件取注册键表的钉子用的是 `ComponentRegistry` + `.register(` 正则，抄一份进注释会被它当成活注册（第一轮实测就红在这里）。
- **文档（非可选，说明如下）**：
  - `content/docs/guide/layout.md` —— AppShell 小节原有一整块「In a JSON node」，逐条陈述「`app-shell` 已注册、节点确实解析到本组件、三个纯数据键生效」。这些陈述被本次改动**直接证伪**，改写为「There is no `app-shell` node」并给出新诊断；props 表删掉「In a JSON node」列（不再有节点可写）。
  - 同页 SidebarNav 小节的「registers six keys — …」句列举了注册键表，其中含 `app-shell`。这句由 `guide-layout-sidebar-nav-doc.test.ts` **机械比对** `index.ts` 的 register 调用 —— 不改文档，这条钉子必红。已改为 five keys 并去掉 `app-shell`。
  - `packages/layout/README.md` —— 「Registration」小节同样列举注册键表（已发布包的 README），去掉 `app-shell`，并补一句与既有 `SidebarNav` 说明同构的短注。
- 钉子：
  - 新增 `packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx` —— 从**两个面**断言键不在（源码正则 + 活注册表的裸键/命名空间键两种拼写），断言渲染出的诊断，并断言两个幸存入口（`AppShell` 仍导出、`app-schema-renderer` 仍注册且仍声明 `inputs`）。带一个负控制：`responsive-grid` 走同一条渲染路径**不**出错误框 —— 否则「没出现未注册红框」这种断言在一个对所有节点都报错的渲染器上同样会绿。
  - `guide-layout-sidebar-nav-doc.test.ts` —— 键数从硬编码 `6` 改成从页面的数词读（`NUMBER_WORDS`），并把句子匹配的空白改成 `\s+`：这句是会随键表长度重新折行的散文，原来的字面空格让一次**折行**（`and` 与 `nothing` 被换行分开）也判红，那不是漂移。
  - `side-effects-manifest.test.ts` —— 注册数下限 `>= 6` 改 `>= 5`（它是「正则没失效」的底线，不是键表普查；键表本身由上一条按名钉住）。
  - `guide-layout-app-shell-doc.test.ts` —— 只改被证伪的失败文案与文件头叙述，判定面一行未动。

## 验证

```
pnpm exec vitest run packages/layout/ --maxWorkers=2
  Test Files  16 passed (16)        Tests  181 passed (181)

pnpm exec vitest run examples/schema-catalog/ packages/sdui-parser/ --maxWorkers=2
  Test Files  12 passed (12)        Tests  1591 passed (1591)

pnpm exec vitest run apps/console/src/__tests__/ --maxWorkers=2
  Test Files  12 passed (12)        Tests  176 passed (176)

pnpm exec turbo run type-check --concurrency=2
  Tasks:    81 successful, 81 total

node scripts/check-control-bytes.mjs
  OK (scanned 4342 tracked text file(s); skipped 85 binary)

node scripts/check-doc-links.mjs
  Links are valid across 13 scan roots.
```

消费半径不止 `packages/layout`：`examples/schema-catalog` 与 `apps/site` 各自显式调 `registerLayout()`，catalog 的 gallery 测试会把每份 catalog schema 都渲染一遍 —— 这是本改动最可能把别人的 fixture 打红的地方，所以单独跑了。`apps/console` 一组是注册表全量枚举类测试（`public-contract` / `public-block-binding-reach` 等）所在处。

## 反向验证

把注册加回（import + register 块），**方向先写死、再跑**。预判与实测逐条对上：

| 预判 | 实测 |
|---|---|
| 🔴 `app-shell-not-a-component-key` › 源码正则重新看见键 | 🔴 `expected [...] to not include 'app-shell'` |
| 🔴 同文件 › 活注册表两种拼写都能取到 | 🔴 `expected { type: 'layout:app-shell', …(4) } to be undefined` |
| 🔴 同文件 › 不再出未注册红框，且失败形态应是**「panel 为 null」**而非换成另一种文案 | 🔴 `expected null not to be null` —— 形态也对上：无 props 的 `AppShell` 不抛异常，安静地渲染出一个空壳，所以根本没有 `role="alert"` 节点 |
| 🔴 `guide-layout-sidebar-nav-doc` › 键表比对（页面 five vs 源码 six） | 🔴 `expected [ 'app-schema-renderer', …(4) ] to deeply equal [ …(5) ]` |
| 🟢 `guide-layout-app-shell-doc.test.ts` 全绿（判的是页面的 React 素材与 fence，从没钉过注册面） | 🟢 |
| 🟢 `side-effects-manifest.test.ts` 全绿（`>= 5` 是下限，6 照样过） | 🟢 |

合计 `Test Files 2 failed / 14 passed (16)`、`Tests 4 failed / 177 passed (181)` —— 红的正好是预判的那 4 条，没有多、没有少。还原用 `git checkout --`，未用 `git stash`（本仓 stash 栈跨 worktree 共享，见 CLAUDE.md）。

还原后的复跑正在排队等本容器的共享验证锁（多 agent 并行，锁上此刻还有 6 个等待者），结果落地后补一条评论；上面「验证」一节的 16/16、181/181 是**撤除态**下已经跑出的数字，复跑只是确认还原动作本身没带进别的东西。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_