### PR TITLE
chore(fields): files 不再列 src —— 173 个源码文件(97 个测试)退出发布物 (#4856)

### DIFF
--- a/.changeset/fields-files-drops-src-4856.md
+++ b/.changeset/fields-files-drops-src-4856.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/fields': patch
+---
+
+`@object-ui/fields` stops publishing its `src/` tree
+
+The manifest's `files` array listed `src` alongside `dist`, so every published tarball carried all 173 source files — 97 of them `*.test.tsx` / `*.test.ts`. It has been that way since the file's first commit (`780a1b993`), where `files` was already `["dist", "src", "README.md"]` while `exports` named only `dist`, so the entry was never added for a consumer. objectui#4006 recorded this exact shape and did not act on it: its scope was the `*.test.d.ts` half the build program emitted into `dist`, and it noted in passing that the test sources were already in the tarball by this other route.
+
+Nothing in the published surface reached those files, which is why no consumer changes in either direction. Measured on a cleanly rebuilt `dist`, all four ways in are closed: the `exports` map has two entries and both target `dist` (`.` resolves `types` / `import` / `require` to `./dist/index.d.ts` / `./dist/index.js` / `./dist/index.cjs`, and `./style.css` to `./dist/index.css`); `main` / `module` / `types` are `./dist/index.cjs`, `./dist/index.js`, `./dist/index.d.ts`; no deep import into this package exists anywhere in the repo or the docs — the one that used to, `@object-ui/fields/widgets/MarkdownContent`, was ruled out by objectui#4325 precisely because a package's surface is its index, and the `../fields/src` paths in sibling `vite.config.ts` files are workspace aliases resolved through `resolve()` against the source tree, which no `files` array shapes; and the tarball holds no sourcemap that could point back at `src`. That last one is the check that had to be measured rather than assumed, because this package emits its declarations through `vite-plugin-dts` rather than the `tsup` of objectui#4847 or the bare `tsc` of `@object-ui/types`: a clean rebuild writes 78 files into `dist`, of which zero are `.d.ts.map`, zero are `.js.map`, zero contain a `sourceMappingURL` comment and zero mention `../src`. `src/index.css` is an input to `scripts/build-css.mjs`, not an output anyone resolves; the sheet the `./style.css` export names is the built `dist/index.css`, which still ships.
+
+`npm pack --dry-run` across the change, on the same `dist`:
+
+| | before | after |
+| --- | --- | --- |
+| entries | 255 | 82 |
+| unpacked | 2265557 B | 841772 B |
+| tarball | 629843 B | 252364 B |
+
+173 files leave, none arrives, nothing outside `src/` moves, and every surviving entry is byte-identical apart from the edited `package.json` itself. The 173 are the 97 tests plus 76 implementation modules, whose published form remains the bundled `dist/index.js` / `dist/index.cjs` and the 75 declaration files beside them.
+
+`@object-ui/types` keeps its `src` entry for now, and that is a different judgement rather than an omission: it builds with a bare `tsc` under a `declarationMap` / `sourceMap` config with no `inlineSources`, so its shipped `dist/*.d.ts.map` name `../src/*.ts` with no embedded content and dropping `src` there would leave published maps pointing at files the tarball no longer carries. That trade-off is filed as objectui#4851.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -18,7 +18,6 @@
   },
   "files": [
     "dist",
-    "src",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/scripts/check-phantom-dependencies.mjs
+++ b/scripts/check-phantom-dependencies.mjs
@@ -75,17 +75,24 @@
  *     measured 73 `*.test.d.ts` files landing in the published `dist/` of
  *     `@object-ui/fields` and `@object-ui/plugin-editor`, and three packages
  *     (`fields`, `types`, `data-objectstack`) listed `src` in `files`, so their
- *     tarballs carried the test SOURCES too. `data-objectstack` no longer does
- *     (objectui#4847 dropped `src` from its `files` — 43 source files, 38 of
- *     them tests, left that tarball); `fields` and `types` still do, and for
- *     `types` the entry is load-bearing rather than leftover, because it builds
- *     with a bare `tsc` under the root's `declarationMap` / `sourceMap` and no
- *     `inlineSources`, so its shipped `dist/*.d.ts.map` name `../src/*.ts` with
- *     no embedded content. That is a real defect where it is one, and it is
- *     already filed; it is not this gate's, because nothing resolves those files
- *     and so no install of them can fail. Stated here rather than glossed,
- *     because "the build excludes tests" is the plausible-sounding version of
- *     this paragraph and it is not what the repository measures.
+ *     tarballs carried the test SOURCES too. Two of the three no longer do:
+ *     objectui#4847 dropped `src` from `data-objectstack`'s `files` (43 source
+ *     files, 38 of them tests, left that tarball) and objectui#4856 dropped it
+ *     from `fields`' (173 source files, 97 of them tests). Only `types` still
+ *     lists it, and there the entry is load-bearing rather than leftover,
+ *     because it builds with a bare `tsc` under the root's `declarationMap` /
+ *     `sourceMap` and no `inlineSources`, so its shipped `dist/*.d.ts.map` name
+ *     `../src/*.ts` with no embedded content — dropping `src` there would leave
+ *     published maps pointing at files the tarball no longer carries. `fields`
+ *     was measurably NOT that shape, which is why the two were split rather than
+ *     fixed together: its declarations come from `vite-plugin-dts`, and a clean
+ *     rebuild emits zero `.map` files and zero `sourceMappingURL` comments, so
+ *     nothing in its `dist` referred back to `src` at all. That is a real defect
+ *     where it is one, and it is already filed; it is not this gate's, because
+ *     nothing resolves those files and so no install of them can fail. Stated
+ *     here rather than glossed, because "the build excludes tests" is the
+ *     plausible-sounding version of this paragraph and it is not what the
+ *     repository measures.
  *
  * The root allowance is a decision, not an oversight, and it is worth stating
  * why it is honest rather than convenient. This repository installs its test


### PR DESCRIPTION
Fixes #4856
Part of #4851

## 缺陷形态(一句话)

`packages/fields/package.json` 的 `files` 列了 `src`,于是每个发布 tarball 都带上 173 个源码文件(其中 97 个 `*.test.tsx` / `*.test.ts`)。这条从该文件的**第一个 commit**(`780a1b993`)就在,而那时 `files` 已是 `["dist", "src", "README.md"]`、`exports` 已只指 `dist` —— 从来不是为哪个消费者加的。#4006 记过同一形态并明确没有处理它:那卡的范围是 build 程序 emit 进 `dist` 的 `*.test.d.ts` 那一半。

## 第一步:前置测量(本卡的走向由它决定,不由先例决定)

#4856 要求先量再选分支,因为这个包的 dts emitter 是第三种:#4847 是 `tsup`,`@object-ui/types` 是裸 `tsc`,`@object-ui/fields` 是 `vite-plugin-dts`。

干净重建(删 `dist` 与 `tsconfig.tsbuildinfo`,先 `pnpm --workspace-concurrency=2 --filter '@object-ui/fields^...' build` 建依赖,再建本体;`build` 是 `tsc && vite build && node scripts/build-css.mjs`)后实测 `dist/`:

| 读数 | 值 |
| --- | --- |
| `dist/` 文件总数 | 78(75 个 `.d.ts` + `index.js` + `index.cjs` + `index.css`) |
| `.d.ts.map` | **0** |
| `.js.map` | **0** |
| 任何 `.map` | **0** |
| 含 `sourceMappingURL` 的文件 | **0** |
| 提到 `../src` 的文件 | **0** |

**没有 map,所以没有 `sources` 指向、也没有 `sourcesContent` 可读** —— 与 `@object-ui/types` 的承重形态(`dist/ai.d.ts.map` 的 `sources` 为 `["../src/ai.ts"]`、`sourcesContent` 为 `false`)**相反**。原因可查而不只是巧合:`packages/fields/tsconfig.json` 继承的是根 `tsconfig.json`(`noEmit: true`,且**不**设 `declarationMap` / `sourceMap` —— 设这两项的 `tsconfig.base.json` 不在 fields 的继承链上),`vite.config.ts` 也没开 `build.sourcemap`。所以 `tsc` 在这里只做检查,`dist` 全部由 vite + vite-plugin-dts 写出,两者都不产 map。

判据成立:走**同形(机械删)分支**。

## 前置核查四项:③ 命中,已单独立卡 #4858;其余三项否定

| 核查项 | 结果 | 证据 |
| --- | --- | --- |
| ① `exports` 是否有条目解析进 `src` | 否 | 两个条目全指 dist:`.` 的 `types`/`import`/`require` 为 `./dist/index.d.ts` / `./dist/index.js` / `./dist/index.cjs`,`./style.css` 为 `./dist/index.css` |
| ② `main` / `module` / `types` 是否指 `src` | 否 | `./dist/index.cjs` / `./dist/index.js` / `./dist/index.d.ts` |
| ③ 全仓与文档是否教过 `src` deep-path | **是,但教的那处已被仓内两处维护中的答案否定** | 见下 |
| ④ sourcemap 是否落在 `src` 上 | 否 | 上表:0 个 map、0 处 `sourceMappingURL`、0 处 `../src` |

**③ 的详情(与 PR #4852 在 `data-objectstack` 上的干净结果不同,如实写出来):**

先说**看起来像命中、实际不是**的那类,以免下一个读者按 grep 结果误判:15 个 `packages/*/vite.config.ts` 里的 `'@object-ui/fields': resolve(__dirname, '../fields/src')` 是**工作区别名**,解析的是仓内源码树,`files` 对它没有任何作用;`@object-ui/fields/widgets/MarkdownContent` 这个 deep specifier 在散文里出现四次,但都是**记录它已被 #4325 否决**的注释,今天全仓没有任何一条 live import 走 fields 的子路径(引号精确 grep:`from`/`import`/`require(` + `@object-ui/fields/` 只剩 `style.css` 与散文)。

真正命中的是 Tailwind 的 `@source`。三份 skill 指南给消费者的样板里有:

```
@source "../node_modules/@object-ui/fields/src/**/*.tsx";
```

(`skills/objectui/rules/styling.md:188`、`guides/page-builder.md:252`、`guides/project-setup.md:132`)

这条今天确实能匹配到 tarball 里的 173 个文件。但它**不是**一个受支持的入口,依据是测量而不是判断:

- 同一段样板对 `components` / `layout` / `react` 写了同样的三行,而这三个包的 `files` 都是 `["dist","README.md","CHANGELOG.md","LICENSE"]` —— **四条 glob 里三条今天就已经匹配 0 个文件**。`fields` 只是同族三例里最后一个还把整棵 `src` 装进 tarball 的包。
- 那三份文件里 `style.css` **零命中**:它们从不教 #4059 之后的正路 `@import '@object-ui/fields/style.css'`。
- 仓内两处**维护中**的答案说的正相反:`packages/components/README.md:64` 明写「You do **not** add a `@source` line for `node_modules/@object-ui/components`」,并解释扫已发布文件既是重复生成 shape-only utility、又**生成不出**主题化的那些(`@theme` 块在未发布的源码里);`packages/cli/src/utils/app-generator.ts:335` 给非 monorepo 消费者 scaffold 的是 `@source '../node_modules/@object-ui/*/dist/**/*.js';` —— 扫 **dist**,并且有测试盯着。

所以把 `src` 留在 tarball 里迁就这段样板,正是「消费者侧容忍」那一类修法:它迁就的对象对 3/4 的包已经失效,而对第 4 个包也生成不出它承诺的那 17 个主题化 utility。指南本身是**今天就存在的缺陷**(照它搭的第三方项目基本无样式),已按范围外纪律另立 **#4858**,不在本 PR 修。

⚠️ **合并顺序**:#4858 先修掉那三份指南更安全 —— 否则跟着旧样板走的项目会多经历一步「fields 的 shape utility 也没了」。本 PR 是 draft,顺序请维护者裁。

## 打包验证:pack 清单前后对照

同一份 `dist`,只改 `files`,`npm pack --dry-run --json` 两侧:

| | 修复前 | 修复后 |
| --- | --- | --- |
| 条目数 | 255 | 82 |
| unpacked | 2265557 B | 841772 B |
| tarball | 629843 B | 252364 B |

**消失 173,新增 0,`src/` 以外零条目移动**,幸存条目逐个大小不变(唯一变的是被编辑的 `package.json` 自身,2291 -> 2280 B)。消失的 173 = 97 个测试 + 76 个实现源码,后者的发布形态仍是打包好的 `dist/index.js` / `dist/index.cjs` 与旁边 75 个 `.d.ts`。

修复后 tarball 的完整清单(入口 / 样式 / README / 许可证全在):

```
CHANGELOG.md  LICENSE  README.md  package.json
dist/index.js  dist/index.cjs  dist/index.css  dist/index.d.ts
dist/currency.d.ts  dist/field-type-alias.d.ts  dist/FieldEditWidget.d.ts
dist/withFieldCarrier.d.ts  dist/widgets/*.d.ts (70 个)
```

`src/index.css` 是 `scripts/build-css.mjs` 的**输入**而不是任何人 resolve 的产物;`./style.css` 导出指的 `dist/index.css` 照常随包发布(#4059 建的那条路没有被本 PR 碰到)。

## 反向验证(方向先判后跑;方向与「钉子变红」模板**不同**,如实记录)

**预判**(跑之前写下的):本改动删的是一个 `files` 条目,而**仓内没有任何门在看这个数组的内容**。`scripts/__tests__/package-files-exist.test.ts` 只断言「声明了的条目在磁盘上存在」,而 `src` 确实存在,所以把它加回去照样绿。#4851 已经把这一点实测过并作为它判 observation-class 的依据。所以正确的预判**不是**「新钉子变红」,而是:(a) 把 `src` 加回 `files`、同一份 `dist` 重跑 pack,173 个文件原样重现;(b) 所有门在缺陷态**保持全绿**。

**实跑,两半都与预判一致**(先 commit 修复再变异,变异不提交,已用 `git checkout` 对着文件路径还原,未用 `git stash`):

(a) 条目数 82 -> 255,`unpacked` 841772 -> 2265557 B,与修复前清单**逐条相同**(全部 255 条的 path+size 排序后 `JSON.stringify` 全等,差异集为空数组),`src/` 恢复 173 条。

(b) 在同一个缺陷态下跑相关门,全部退 0:

```
node scripts/check-phantom-dependencies.mjs                          rc=0
node scripts/check-control-bytes.mjs                                 rc=0
node scripts/check-package-self-import.mjs                           rc=0
pnpm exec vitest run scripts/__tests__/package-files-exist.test.ts   1 file / 18 tests passed
```

「什么都没变红」**就是结论本身**:这一类缺陷在 CI 里完全不可见,与 PR #4852 / PR #4845 对同族问题的测量一致,机制化的判据是产物级的(#4846)。

## 验证(全部实跑)

```
干净重建 @object-ui/fields                        dist 78 个文件,map 0 个

pnpm exec turbo run type-check --concurrency=2    81 successful, 81 total(exit 0)

pnpm exec vitest run \
  scripts/__tests__/package-files-exist.test.ts   1 file / 18 tests passed

node scripts/check-phantom-dependencies.mjs       OK  Every in-scope import is declared…
node scripts/check-control-bytes.mjs              OK  scanned 4340 tracked text file(s)
node scripts/check-package-self-import.mjs        OK  No package names itself inside its own src/
node scripts/check-changeset-presence.mjs         OK
node scripts/check-changeset-no-major.mjs         OK
node scripts/check-changeset-fixed.mjs            OK

npx eslint scripts/check-phantom-dependencies.mjs rc=0
grep -naP 控制字符自查(三个改动文件)                零命中
```

未跑 `packages/fields` 的 97 个测试文件:本改动不碰任何源码、任何 tsconfig、任何 build 配置,只改发布清单与一段块注释,`turbo run type-check` 已覆盖 fields 的两个 program(`tsc --noEmit && tsc -p tsconfig.test.json`)。

## 顺带更新的一处仓内记载

`scripts/check-phantom-dependencies.mjs` 的表头是 PR #4852 刚更新过的一句事实陈述:「`data-objectstack` 已退出,`fields` 与 `types` 仍在」。本改动**直接证伪**它的后半句,所以同 PR 更新为:三例中已退出两例,只剩 `types`;并写下 `fields` 与 `types` 形态不同(因而分开处理)的实测依据 —— fields 的 dts 出自 `vite-plugin-dts`,干净重建产 0 个 map、0 处 `sourceMappingURL`。门的判决一个字节没变(改的是块注释)。

## 范围外

- 未碰 `@object-ui/types`(承重半在 #4851 的决策箱)。
- 未碰 `packages/fields/src/**` 任何源码、未碰 tsconfig / vite 配置 / `scripts/build-css.mjs`。
- 未碰 `content/docs/releases/**`。
- 未建任何门(判据机制化的成本测量在 #4846)。
- 三份 skill 指南的 `@source` 样板另立 **#4858**,未在本 PR 修。

## Changeset

`.changeset/fields-files-drops-src-4856.md`,`@object-ui/fields: patch`。按 PR #4852 / #4845 / #4006 的先例写的**真 patch changeset**:`check-changeset-presence.mjs` 不索要(没动发版包的 `src/`),但**发布物内容变了**,得让它出现在 CHANGELOG 里。未声明 `major`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_