### PR TITLE
fix(components): 只读注册字段的替换显示接上 host 的命名与描述通道 (#4788)

### DIFF
--- a/.changeset/readonly-registered-field-a11y-container.md
+++ b/.changeset/readonly-registered-field-a11y-container.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/components': patch
+---
+
+A readonly field's replacement display is now named by the field's label and described by its help text.
+
+A registered field widget's readonly branch renders a replacement display — a
+`mailto:` anchor, a formatted span, a chip row, a preview table — and returns
+before its DOM pass-through, so nothing the form renderer handed down reached an
+element. Measured on a real form, one field per row, with `description` set: the
+host control id (`…-form-item`) was on NO element in the document, so the visible
+label's `for` pointed at nothing and the readonly surface had NO accessible name
+at all, while the rendered help text had zero consumers. All 34 registered
+non-group-labelled widget types read identically, including the four display-only
+ones (`formula` / `summary` / `auto_number` / `vector`) whose whole widget is a
+replacement display.
+
+The form renderer now wraps a readonly registered field widget's output in a
+container carrying the host id, `role="group"`, `aria-labelledby` and
+`aria-describedby`, and the label publishes an `id` in place of its `for` — the
+same WAI-ARIA group pattern objectui#3961 / #3990 / #4005 established for the
+seven composite widgets, applied at the host instead of in each widget. Not one
+widget file changed: the mechanism lands once, so the current widgets and any
+future third-party one are correct by construction, with no "remember to spread
+the host props" step left to miss.
+
+The name is composite — the label's id AND the container's own — so the VALUE
+stays in the accessible name (`Email user@example.com`, not just `Email`);
+`group` is not a name-from-content role, and the value is usually the only thing
+on screen. `aria-invalid` is deliberately dropped at this boundary: it is
+control-channel state reporting what a user's own editing may do wrong, and a
+readonly display cannot be edited (objectui#3291 / #3318 / #4005).
+
+Two consequences worth stating. Readonly registered fields gain one DOM layer,
+which end-to-end selectors written against the widget root as a direct child of
+the form item will see; the layer carries `data-slot="readonly-field-group"` as a
+stable locator. And because that layer is a block box where several readonly
+faces were inline, those rows now take the form's standard label-to-value
+spacing, matching the editable state. Builtin types (`input` / `textarea` /
+`checkbox` / `switch` / `select`), editable fields, group-labelled widgets and
+fields rendered without a label are untouched, byte for byte.

--- a/packages/components/src/renderers/form/__tests__/form-readonly-host-group.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-readonly-host-group.test.tsx
@@ -1,0 +1,354 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A READONLY registered field widget's replacement display is named by the
+ * field's visible label and described by its visible help text — the HOST half,
+ * and under objectui#4788 the only half (maintainer ruling of 2026-08-16,
+ * option E of the measured option set).
+ *
+ * ## The defect
+ *
+ * A widget's readonly branch renders a replacement display — a `mailto:` anchor,
+ * a formatted span, a chip row — and returns BEFORE its `toDomProps` spread, so
+ * every prop the host handed down is dropped. Measured on `origin/main` at
+ * `1ef236e18` with a real form + bare registration, `description` set, one field
+ * per row:
+ *
+ * ```
+ *                readonly                                    editable
+ * text     for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * boolean  for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=switch consumers=1
+ * email    for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * formula  for=DANGLING hostIdEl=NONE consumers=0   for=DANGLING           hostIdEl=NONE   consumers=0
+ * …(33 registered non-group-labelled types, every readonly row identical)
+ * ```
+ *
+ * `hostIdEl=NONE` is the load-bearing reading, and it is a step worse than the
+ * objectui#3990 family: the `…-form-item` id was on NO element in the document,
+ * so the visible label's `for` DANGLED and the readonly surface had no
+ * accessible name at all.
+ *
+ * ## Why the host and not the widgets
+ *
+ * The measurement also disproved the obvious widget-side fix. An
+ * `aria-labelledby` on a role-less `span` / `div` names NOTHING (`generic`
+ * prohibits an author name) — yet `toHaveAccessibleName()` in jsdom answers PASS
+ * for that markup. A per-widget fix would therefore have shipped 26 inert
+ * surfaces with green tests certifying them. Landing it once in the host removes
+ * the "remember to spread" entry point entirely, for the current widgets and any
+ * future third-party one alike.
+ *
+ * That is exactly why the assertions below are written against DOM OWNERSHIP —
+ * every IDREF is resolved with `getElementById` and the resolved node is checked
+ * to be the right element inside the right form item — instead of resting on
+ * `toHaveAccessibleName`, which cannot tell a real association from an inert one.
+ *
+ * The probes here render replacement displays that spread NOTHING, mirroring the
+ * real widgets (`@object-ui/components` tests never load `@object-ui/fields`; the
+ * real-widget sweep lives in `packages/fields/src/__tests__/`). A probe that
+ * spread its leftover props would go green whether or not the host wrapped it.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/**
+ * The anchor face: `email` / `phone` / `url` return a link and spread nothing.
+ * Its own accessible name comes from its content, and must keep doing so.
+ */
+function AnchorProbe(props: any) {
+  const { value, readonly } = props;
+  if (readonly) {
+    return <a href={`mailto:${value}`}>{String(value ?? '')}</a>;
+  }
+  return <input data-testid="anchor-input" value={(value as string) ?? ''} onChange={() => {}} {...domOnly(props)} />;
+}
+
+/** The plain-text face: 26 of the 33 measured types return a `span` / `div`. */
+function TextProbe(props: any) {
+  const { value, readonly } = props;
+  if (readonly) {
+    return <span>{String(value ?? '')}</span>;
+  }
+  return <input data-testid="text-input" value={(value as string) ?? ''} onChange={() => {}} {...domOnly(props)} />;
+}
+
+/**
+ * The display-only face (D group: `formula` / `summary` / `auto_number` /
+ * `vector`) — no editable branch at all, so `readonly` is not even read.
+ */
+function DisplayOnlyProbe(props: any) {
+  return <span>{String(props.value ?? '')}</span>;
+}
+
+/** Group-labelled widget: consumes the host keys ITSELF (objectui#3990/#4005). */
+function GroupProbe(props: any) {
+  const { value, readonly } = props;
+  const hosted = {
+    id: props.id,
+    'aria-labelledby': props['aria-labelledby'],
+    'aria-describedby': props['aria-describedby'],
+    role: props['aria-labelledby'] ? ('group' as const) : undefined,
+  };
+  if (readonly) return <div {...hosted}>{String(value ?? '')}</div>;
+  return <div {...hosted}><input data-testid="group-input" value={(value as string) ?? ''} onChange={() => {}} /></div>;
+}
+
+/** A plain SDUI component reached through the bare-name fallback, not `field:`. */
+function BareNameProbe(props: any) {
+  return <span data-testid="bare-name">{String(props.value ?? props.schema?.name ?? '')}</span>;
+}
+
+/** Only the keys an `<input>` may legally carry, so the editable probes are honest. */
+function domOnly(props: any) {
+  return {
+    id: props.id,
+    'aria-describedby': props['aria-describedby'],
+    'aria-invalid': props['aria-invalid'],
+    'aria-required': props['aria-required'],
+    'aria-labelledby': props['aria-labelledby'],
+  };
+}
+
+beforeAll(() => {
+  ComponentRegistry.register('anchorprobe', AnchorProbe, { namespace: 'field' });
+  ComponentRegistry.register('textprobe', TextProbe, { namespace: 'field' });
+  ComponentRegistry.register('displayonlyprobe', DisplayOnlyProbe, { namespace: 'field' });
+  ComponentRegistry.register('groupprobe', GroupProbe, { namespace: 'field', labelling: 'group' });
+  // NOT in the `field` namespace — the bare-name fallback, whose contract is
+  // `schema`, not `FieldWidgetComponentProps`.
+  ComponentRegistry.register('barenameprobe', BareNameProbe);
+}, 30000);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}, showSubmit = false) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit,
+        submitLabel: 'Create',
+        showCancel: false,
+        defaultValues,
+        fields,
+      }}
+    />,
+  );
+}
+
+const item = (name: string): HTMLElement => {
+  const el = document.querySelector<HTMLElement>(`[data-field="${name}"]`);
+  if (!el) throw new Error(`no form item rendered for field "${name}"`);
+  return el;
+};
+
+const hostLabel = (name: string): HTMLLabelElement => {
+  const el = item(name).querySelector('label');
+  if (!el) throw new Error(`no label rendered for field "${name}"`);
+  return el as HTMLLabelElement;
+};
+
+/** The wrapper the host emits for a readonly registered widget, or null. */
+const group = (name: string): HTMLElement | null =>
+  item(name).querySelector<HTMLElement>('[data-slot="readonly-field-group"]');
+
+/** Resolve one IDREF against the document — the whole point of these tests. */
+const byId = (id: string | null | undefined): HTMLElement | null =>
+  id ? document.getElementById(id) : null;
+
+const idrefs = (el: Element, attr: string): string[] =>
+  (el.getAttribute(attr) ?? '').split(/\s+/).filter(Boolean);
+
+const FIELD = (type: string, extra: Record<string, unknown> = {}) => ({
+  name: `f_${type}`,
+  label: `Label ${type}`,
+  type,
+  description: 'Some help',
+  ...extra,
+});
+
+describe('readonly registered widget: the host names and describes the replacement display (objectui#4788)', () => {
+  it.each(['anchorprobe', 'textprobe', 'displayonlyprobe'])(
+    '%s: every IDREF the group carries resolves to the right node in the same form item',
+    (type) => {
+      const name = `f_${type}`;
+      renderForm([FIELD(type, { readonly: true })], { [name]: 'user@example.com' });
+
+      const g = group(name);
+      // 0 before this change: no element in the document carried the host id.
+      expect(g).not.toBeNull();
+      expect(g).toHaveAttribute('role', 'group');
+
+      // The group IS the element the host handed its control id to — the
+      // `hostIdEl=NONE` reading turning into `hostIdEl=div[group]`.
+      const hostId = g!.getAttribute('id');
+      expect(hostId).toMatch(/-form-item$/);
+      expect(byId(hostId)).toBe(g);
+
+      // Ownership, not just a passing name: the label IDREF resolves to THE
+      // visible label of THIS field, and the self-reference to the group itself.
+      const labelled = idrefs(g!, 'aria-labelledby');
+      expect(labelled).toHaveLength(2);
+      const labelNode = byId(labelled[0]);
+      expect(labelNode).toBe(hostLabel(name));
+      expect(item(name).contains(labelNode!)).toBe(true);
+      expect(byId(labelled[1])).toBe(g);
+
+      // The description IDREF resolves to THE `<FormDescription>` of this field
+      // — `consumers=0` turning into `consumers=1`.
+      const described = idrefs(g!, 'aria-describedby');
+      const descNode = byId(described[0]);
+      expect(descNode).not.toBeNull();
+      expect(descNode).toHaveTextContent('Some help');
+      expect(descNode!.id).toMatch(/-form-item-description$/);
+      expect(item(name).contains(descNode!)).toBe(true);
+
+      // The widget's own output sits INSIDE the group, so entering the group is
+      // what reads the value — the containment half of "the label names THIS".
+      expect(g!.textContent).toContain('user@example.com');
+    },
+  );
+
+  it('the host label publishes an id and drops its `for` (single naming channel, objectui#3978)', () => {
+    renderForm([FIELD('textprobe', { readonly: true })], { f_textprobe: 'Hello' });
+
+    const label = hostLabel('f_textprobe');
+    // Before: `for="…-form-item"` pointing at an id NOTHING carried.
+    expect(label).not.toHaveAttribute('for');
+    expect(label.id).not.toBe('');
+    // And exactly one channel: the id it published is the one the group reads.
+    expect(idrefs(group('f_textprobe')!, 'aria-labelledby')[0]).toBe(label.id);
+  });
+
+  it('the value stays in the accessible name (composite `labelId hostId`)', () => {
+    renderForm([FIELD('anchorprobe', { readonly: true })], { f_anchorprobe: 'user@example.com' });
+
+    // `group` is not a name-from-content role, so without the self-reference the
+    // address — the only thing on screen — would be absent from the name.
+    expect(group('f_anchorprobe')).toHaveAccessibleName('Label anchorprobe user@example.com');
+    // The anchor keeps its OWN name, from its own content: it is read as itself
+    // inside the group, and the field name is not duplicated onto it.
+    expect(screen.getByRole('link')).toHaveAccessibleName('user@example.com');
+  });
+
+  it('the widget is NOT handed the label IDREF as well (one fact, one author)', () => {
+    renderForm([FIELD('textprobe', { readonly: true })], { f_textprobe: 'Hello' });
+
+    // The wrapper is the named surface. A widget that spread a second
+    // `aria-labelledby` would give one label two consumers.
+    const inner = group('f_textprobe')!.querySelector('span');
+    expect(inner).not.toBeNull();
+    expect(inner).not.toHaveAttribute('aria-labelledby');
+    expect(inner).not.toHaveAttribute('id');
+  });
+});
+
+describe('the control-channel boundary is NOT crossed (objectui#3291 / #3318 / #4005)', () => {
+  it('a valid readonly field carries no `aria-invalid` and no `aria-required`', () => {
+    renderForm([FIELD('textprobe', { readonly: true, required: true })], { f_textprobe: 'Hello' });
+
+    const g = group('f_textprobe')!;
+    // `<FormControl>`'s Slot injects `aria-invalid` into whatever it wraps. A
+    // readonly display cannot be edited and so cannot be made invalid by the
+    // person reading it; the wrapper consumes the key and emits nothing.
+    expect(g).not.toHaveAttribute('aria-invalid');
+    expect(g).not.toHaveAttribute('aria-required');
+  });
+
+  it('an INVALID field still carries no `aria-invalid`, and keeps the message in `aria-describedby`', async () => {
+    renderForm(
+      [
+        FIELD('textprobe', { readonly: true, required: true }),
+        // A second, editable field to make the submit reach validation with a
+        // real error on the readonly one.
+        { name: 'f_edit', label: 'Editable', type: 'textprobe' },
+      ],
+      {},
+      true,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      const g = group('f_textprobe')!;
+      const described = idrefs(g, 'aria-describedby');
+      // The Slot appends the message id once the field is in error; the
+      // DESCRIPTION channel is legitimate for a group, the STATE channel is not.
+      expect(described.some((id) => id.endsWith('-form-item-message'))).toBe(true);
+      expect(g).not.toHaveAttribute('aria-invalid');
+    });
+  });
+});
+
+describe('nothing else changed shape (the paths this issue does not touch)', () => {
+  it('an EDITABLE registered widget keeps its `for`, its id, and no group', () => {
+    renderForm([FIELD('textprobe')], { f_textprobe: 'Hello' });
+
+    expect(group('f_textprobe')).toBeNull();
+    const label = hostLabel('f_textprobe');
+    expect(label).not.toHaveAttribute('id');
+    const target = byId(label.getAttribute('for'));
+    expect(target).toBe(screen.getByTestId('text-input'));
+    expect(idrefs(target!, 'aria-describedby')[0]).toMatch(/-form-item-description$/);
+  });
+
+  it('a READONLY builtin type is untouched — it renders a real control that takes the id', () => {
+    // `BUILTIN_FIELD_TYPES` never consults the registry, and its readonly
+    // rendering keeps a labelable element, so its `for` already resolved.
+    renderForm([FIELD('input', { readonly: true })], { f_input: 'Hello' });
+
+    expect(group('f_input')).toBeNull();
+    const label = hostLabel('f_input');
+    expect(label).toHaveAttribute('for');
+    expect(byId(label.getAttribute('for'))!.tagName.toLowerCase()).toBe('input');
+  });
+
+  it('a READONLY group-labelled widget keeps consuming the host keys itself (no second group)', () => {
+    renderForm([FIELD('groupprobe', { readonly: true })], { f_groupprobe: 'Hello' });
+
+    // objectui#3990 / #4005 put the id, the name and the description on the
+    // WIDGET's surface. Wrapping it here would nest a second identically-named
+    // group and strip the id off the surface those PRs put it on.
+    expect(group('f_groupprobe')).toBeNull();
+    const named = screen.getByRole('group', { name: 'Label groupprobe' });
+    expect(named.getAttribute('id')).toMatch(/-form-item$/);
+    expect(idrefs(named, 'aria-describedby')[0]).toMatch(/-form-item-description$/);
+  });
+
+  it('a READONLY field with NO label emits no group (nothing would name it)', () => {
+    renderForm([{ name: 'f_nolabel', type: 'textprobe', readonly: true, description: 'Some help' }], {
+      f_nolabel: 'Hello',
+    });
+
+    // A `role="group"` nothing names is the inert pair this issue exists to
+    // avoid, so the label-less path stays byte-identical.
+    expect(group('f_nolabel')).toBeNull();
+    expect(document.querySelector('[role="group"]')).toBeNull();
+  });
+
+  it('a bare-name SDUI component is not a field widget and is left alone', () => {
+    renderForm([FIELD('barenameprobe', { readonly: true })], { f_barenameprobe: 'Hello' });
+
+    // Its contract is `schema`, not `FieldWidgetComponentProps`; the ruling
+    // scoped the wrapper to registered FIELD widgets.
+    expect(group('f_barenameprobe')).toBeNull();
+    expect(screen.getByTestId('bare-name')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -402,6 +402,146 @@ function resolveFieldLabelling(type: string): 'control' | 'group' {
     : 'control';
 }
 
+/**
+ * Does this type render a REGISTERED FIELD WIDGET (objectui#4788)?
+ *
+ * Mirrors `renderFieldComponent`'s resolution the same way
+ * `resolveFieldLabelling` mirrors it, and for the same reason: the answer
+ * decides whether the host wraps the output, so producer and consumer must not
+ * be able to disagree about which component actually renders.
+ *
+ *  - a builtin name is decided on the RAW type and never consults the registry;
+ *  - a bare name resolves through the `field:` namespace;
+ *  - a colon-qualified type resolves directly, and is a FIELD widget only when
+ *    it names the `field` namespace — the bare-name fallback (`alert`, `badge`,
+ *    the display `text` widget) implements the universal `schema` contract, not
+ *    `FieldWidgetComponentProps`, and is deliberately left alone.
+ */
+function resolvesToRegisteredFieldWidget(type: string): boolean {
+  if (BUILTIN_FIELD_TYPES.has(type)) return false;
+  if (type.includes(':')) {
+    return type.startsWith('field:') && !!ComponentRegistry.get(type);
+  }
+  return !!ComponentRegistry.get(`field:${type}`);
+}
+
+/**
+ * The container a READONLY registered field widget's output is wrapped in, so
+ * the field's visible label NAMES and its visible help text DESCRIBES the
+ * surface that replaced the control (objectui#4788, maintainer ruling of
+ * 2026-08-16 — option E of the measured option set).
+ *
+ * ## What was broken
+ *
+ * A widget's readonly branch renders a REPLACEMENT DISPLAY — a `mailto:` anchor,
+ * a formatted span, a chip row, a preview table — and returns before its
+ * `toDomProps` spread, so not one prop the host handed down reaches an element.
+ * Measured on `origin/main` at `1ef236e18`, a real form + bare registration, one
+ * field per row, `description` set, counting the elements whose
+ * `aria-describedby` names the rendered `<FormDescription>`:
+ *
+ * ```
+ *                       readonly                                      editable
+ * text      for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * boolean   for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=switch consumers=1
+ * email     for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * formula   for=DANGLING hostIdEl=NONE consumers=0    for=DANGLING           hostIdEl=NONE   consumers=0
+ * …(33 registered non-group-labelled types, every readonly row identical)
+ * ```
+ *
+ * `hostIdEl=NONE` is the load-bearing reading: in the readonly state the
+ * `…-form-item` id is on NO element in the document, so the visible label's
+ * `for` pointed at nothing and the readonly surface had no accessible name at
+ * all. That is a whole step worse than objectui#3990's family, where the label
+ * at least published an id nobody consumed.
+ *
+ * ## Why the host, and not the 33 widgets
+ *
+ * Every widget-side variant needs each author to remember one more spread, and
+ * the measurement showed exactly how such a fix goes silently wrong: an
+ * `aria-labelledby` on a role-less `span` / `div` names NOTHING (`generic`
+ * prohibits an author name), while `toHaveAccessibleName()` in jsdom answers
+ * PASS for it — a ghost fix that ships green tests. Landing the mechanism once,
+ * here, makes the 33 current widgets and any future third-party one correct by
+ * construction: there is no "remember to spread" entry point left.
+ *
+ * ## The shape
+ *
+ * `<FormControl>` is a Radix `Slot`, so it injects the field's `id` /
+ * `aria-describedby` / `aria-invalid` into THIS element instead of the widget's
+ * root, and the widget below renders exactly the markup it rendered before.
+ *
+ *  - `role="group"` — the same semantic claim objectui#3990 established for the
+ *    seven composite surfaces. It is what makes the name and the description
+ *    land at all, and it does not promise the interactivity `textbox` would.
+ *  - `aria-labelledby="<labelId> <hostId>"` — the label's id AND this element's
+ *    own. `group` is not a name-from-content role, so the self-reference is what
+ *    keeps the VALUE in the accessible name: an `email` field reads
+ *    `"Email user@example.com"` rather than dropping the address that is the
+ *    only thing on screen. (accname §2F: a node reached through
+ *    `aria-labelledby` is named from its contents whatever its role.)
+ *  - `aria-describedby` — forwarded as the Slot handed it down. A group is a
+ *    description carrier under ARIA 1.2 with no focusable control required,
+ *    which is the objectui#4005 reasoning applied to a second surface.
+ *  - `aria-invalid` — DROPPED. It is control-channel state: it reports what a
+ *    user's own editing may do wrong, to the element they would edit. A
+ *    readonly display cannot be edited and cannot be made invalid by the person
+ *    reading it. Same boundary objectui#3291 / objectui#3318 / objectui#4005
+ *    drew, pinned from both sides in the tests.
+ *
+ * `aria-required` never reaches here at all — it rides the widget props, exactly
+ * as before, for the same reason.
+ */
+type ReadonlyFieldGroupProps = {
+  /** The id `<FormLabel>` published in place of its `for`. */
+  labelId: string;
+  children: React.ReactNode;
+  /** Injected by `<FormControl>`'s Slot: the host control id (`…-form-item`). */
+  id?: string;
+  /** Injected by `<FormControl>`'s Slot: `<FormDescription>` (+ `<FormMessage>`). */
+  'aria-describedby'?: string;
+  /** Injected by `<FormControl>`'s Slot, and deliberately consumed here — see above. */
+  'aria-invalid'?: boolean | 'true' | 'false';
+};
+
+const ReadonlyFieldGroup = React.forwardRef<HTMLDivElement, ReadonlyFieldGroupProps>(
+  function ReadonlyFieldGroup(
+    { labelId, children, id, 'aria-describedby': describedBy, 'aria-invalid': _ariaInvalid },
+    ref,
+  ) {
+    return (
+      <div
+        ref={ref}
+        id={id}
+        role="group"
+        // The host id is appended to the label IDREF, not substituted for it:
+        // the field's name comes first and the rendered value follows. Falls
+        // back to the label alone if the Slot ever stops handing down an id,
+        // because half a name beats a reference to `"<labelId> undefined"`.
+        aria-labelledby={id ? `${labelId} ${id}` : labelId}
+        aria-describedby={describedBy}
+        // Stable locator for this DOM layer (ADR-0054 C4) so end-to-end specs
+        // and CSS have something to select that is not an a11y attribute.
+        data-slot="readonly-field-group"
+      >
+        {children}
+      </div>
+    );
+  },
+);
+ReadonlyFieldGroup.displayName = 'ReadonlyFieldGroup';
+
+/**
+ * Wrap `node` in {@link ReadonlyFieldGroup} when the host resolved a label id
+ * for it, and hand it back untouched otherwise — so every field that is NOT a
+ * readonly registered widget keeps the exact element tree it had, with
+ * `<FormControl>`'s Slot injecting straight into the widget as before.
+ */
+function withReadonlyHostGroup(labelId: string | undefined, node: React.ReactNode): React.ReactNode {
+  if (!labelId) return node;
+  return <ReadonlyFieldGroup labelId={labelId}>{node}</ReadonlyFieldGroup>;
+}
+
 function stripRegisteredFieldProps(type: string, props: RenderFieldProps): RenderFieldProps {
   const {
     dataSource,
@@ -1726,21 +1866,53 @@ ComponentRegistry.register('form',
       // the form schema has no owning object.
       const fieldTestId = `field:${schema.objectName ? `${schema.objectName}.` : ''}${name}`;
 
-      // Group-labelled widget (objectui#3961)? Then the visible label is
-      // associated by IDREF instead of `for`: it gets an `id`, the widget gets
-      // `aria-labelledby`. `undefined` on the single-control path, and every use
-      // below is a conditional spread, so that path emits not one changed
-      // attribute — no second naming channel for the widgets that never needed
-      // one (the #3290 / #3222 / #3952 rule: one fact, one author).
+      const groupLabelled = resolveFieldLabelling(resolvedType) === 'group';
+
+      // A READONLY registered field widget renders a replacement display in
+      // place of its control, and drops every prop the host handed down with it
+      // (objectui#4788). The host therefore wraps that output in a named group
+      // of its own — see {@link ReadonlyFieldGroup} for the measurement and the
+      // shape. Three gates, each carrying its own reason:
+      //
+      //  - `label`: with no visible label there is no naming channel to repair,
+      //    and a `role="group"` that nothing names is the inert pair this issue
+      //    exists to avoid. Standalone / label-less rendering therefore stays
+      //    byte-identical, exactly as `toHostGroupProps` keeps it;
+      //  - `!groupLabelled`: the seven group-labelled widgets already consume
+      //    the host's id / name / description themselves (objectui#3961 →
+      //    #3990 → #4005). Wrapping them too would nest a second group with the
+      //    same name and take the id off the surface those PRs put it on;
+      //  - a registered FIELD widget: the builtin branch renders a real control
+      //    inside `<FormControl>` in the readonly state too, so its label keeps
+      //    a `for` that resolves to a labelable element — measured, and left
+      //    alone.
+      const readonlyHostGroup =
+        readonly === true && !!label && !groupLabelled && resolvesToRegisteredFieldWidget(resolvedType);
+
+      // The visible label is associated by IDREF instead of `for` — it gets an
+      // `id`, and the surface that answers to it gets `aria-labelledby`. Two
+      // paths reach this shape: a group-labelled widget (objectui#3961), where
+      // the WIDGET answers, and a readonly registered widget (objectui#4788),
+      // where the host's own wrapper does. `undefined` everywhere else, and
+      // every use below is a conditional spread, so the single-control path
+      // emits not one changed attribute — no second naming channel for the
+      // fields that never needed one (the #3290 / #3222 / #3952 rule: one fact,
+      // one author).
       //
       // Whitespace is squeezed out of the field name because this id is consumed
       // as an `aria-labelledby` IDREF, and that attribute is a SPACE-SEPARATED
       // list: an id containing a space would silently resolve to two ids,
       // neither of which exists.
-      const groupLabelId =
-        label && resolveFieldLabelling(resolvedType) === 'group'
+      const hostLabelId =
+        label && (groupLabelled || readonlyHostGroup)
           ? `${labelIdPrefix}${String(name).replace(/\s+/g, '_')}-group-label`
           : undefined;
+
+      // The widget-facing half. Only the group-labelled path hands the IDREF
+      // DOWN to the widget: on the readonly path the wrapper is the named
+      // surface, and passing the same id to the widget as well would give one
+      // label two consumers — the double channel #3978 removed.
+      const groupLabelId = groupLabelled ? hostLabelId : undefined;
 
       return (
         <FormField
@@ -1765,7 +1937,12 @@ ComponentRegistry.register('form',
                   // `div` (or nothing at all) is inert HTML, and leaving it
                   // beside the `aria-labelledby` would give one label two
                   // association channels, one of which is broken.
-                  {...(groupLabelId ? { id: groupLabelId, htmlFor: undefined } : null)}
+                  //
+                  // A readonly registered widget (objectui#4788) reaches the
+                  // same shape through the host's own wrapper, and needs the
+                  // `for` gone for the same reason — it was measurably DANGLING
+                  // there, pointing at an id no element in the document carried.
+                  {...(hostLabelId ? { id: hostLabelId, htmlFor: undefined } : null)}
                 >
                   {label}
                   {required && (
@@ -1794,8 +1971,11 @@ ComponentRegistry.register('form',
                 </FormLabel>
               )}
               <FormControl>
-                {/* Render the actual field component based on resolved type */}
-                {renderFieldComponent(resolvedType, {
+                {/* Render the actual field component based on resolved type.
+                    A readonly registered widget's output goes inside the host's
+                    own named group (objectui#4788) — every other field is handed
+                    to `<FormControl>`'s Slot exactly as before. */}
+                {withReadonlyHostGroup(readonlyHostGroup ? hostLabelId : undefined, renderFieldComponent(resolvedType, {
                   ...fieldProps,
                   // Specialized fields need the raw metadata object. `.field`
                   // is the declared metadata slot (#3090 — never the spec
@@ -1906,7 +2086,7 @@ ComponentRegistry.register('form',
                   // Spread conditionally so the single-control path receives no
                   // such key at all: absent, not `undefined`.
                   ...(groupLabelId ? { 'aria-labelledby': groupLabelId } : null),
-                })}
+                }))}
               </FormControl>
               {description && (
                 <FormDescription>{description}</FormDescription>

--- a/packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx
+++ b/packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx
@@ -1,0 +1,425 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * End-to-end over the REAL widgets: a readonly field's replacement display is
+ * named by its visible label and described by its visible help text, whatever
+ * shape that display takes (objectui#4788).
+ *
+ * The residual of the objectui#3961 → #3990 → #4005 family, on the other side of
+ * the `labelling` declaration. Those three fixed the seven group-labelled
+ * widgets, which consume the host's keys themselves. Every OTHER registered
+ * widget declares `labelling: 'control'` by omission — correct for its editable
+ * branch, which renders a labelable element and lands the host id on it — and
+ * then returns EARLY in the readonly state with a replacement display that
+ * spreads nothing at all.
+ *
+ * Measured on `origin/main` at `1ef236e18`, a real form + the same bare
+ * registration this file uses, `description: 'Some help'` on every field, one
+ * field per row. `for=` is the host label's target, `hostIdEl=` the element
+ * carrying `…-form-item`, `consumers=` the elements whose `aria-describedby`
+ * names the rendered `<FormDescription>`:
+ *
+ * ```
+ *                readonly                                    editable
+ * text     for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * number   for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * boolean  for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=switch consumers=1
+ * email    for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * phone    for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * url      for=DANGLING hostIdEl=NONE consumers=0   for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
+ * formula  for=DANGLING hostIdEl=NONE consumers=0   for=DANGLING           hostIdEl=NONE   consumers=0
+ * …(all 34 registered non-group-labelled types below, every readonly row identical)
+ * ```
+ *
+ * `hostIdEl=NONE` is the reading that makes this heavier than #3990's family: in
+ * the readonly state the `…-form-item` id was on NO element in the document, so
+ * the visible label's `for` DANGLED and the surface had no accessible name at
+ * all. The D group (`formula` / `summary` / `auto_number` / `vector`) has no
+ * editable branch to differ from — the whole widget is a replacement display —
+ * and reads the same in both columns.
+ *
+ * ## Why the assertions resolve IDREFs instead of trusting a name query
+ *
+ * The measurement that produced the table also ran a controlled experiment on
+ * the obvious widget-side fix, and disproved it: an `aria-labelledby` on a
+ * role-less `span` / `div` names NOTHING (`generic` prohibits an author name),
+ * while `toHaveAccessibleName()` in jsdom answers PASS for exactly that markup.
+ * A per-widget fix would have shipped 26 inert surfaces plus green tests
+ * certifying them. So the mechanism landed once in the host — the form renderer
+ * wraps a readonly registered widget's output in a `role="group"` container
+ * carrying the id, the composite name and the description — and this file
+ * checks OWNERSHIP: every IDREF is resolved against the document and the
+ * resolved node is asserted to be the right element inside the right form item.
+ *
+ * ⛔ Not one widget under `packages/fields/src/widgets/` changed for this. That
+ * is the structural claim of the fix (option E of the measured option set,
+ * ratified 2026-08-16): there is no "remember to spread the host props" entry
+ * point left for the next widget author, or for the next AI-written widget, to
+ * miss.
+ *
+ * The widgets are registered raw rather than through `registerAllFields()`, whose
+ * `React.lazy` loaders put an unbounded module load inside a bounded `findBy`
+ * window — this repo's known flake generator (AGENTS.md 测试纪律, objectui#3010).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { TextField } from '../widgets/TextField';
+import { TextAreaField } from '../widgets/TextAreaField';
+import { NumberField } from '../widgets/NumberField';
+import { BooleanField } from '../widgets/BooleanField';
+import { SelectField } from '../widgets/SelectField';
+import { DateField } from '../widgets/DateField';
+import { DateTimeField } from '../widgets/DateTimeField';
+import { TimeField } from '../widgets/TimeField';
+import { EmailField } from '../widgets/EmailField';
+import { PhoneField } from '../widgets/PhoneField';
+import { UrlField } from '../widgets/UrlField';
+import { TagsField } from '../widgets/TagsField';
+import { CurrencyField } from '../widgets/CurrencyField';
+import { PercentField } from '../widgets/PercentField';
+import { PasswordField } from '../widgets/PasswordField';
+import { RichTextField } from '../widgets/RichTextField';
+import { LookupField } from '../widgets/LookupField';
+import { ImageField } from '../widgets/ImageField';
+import { LocationField } from '../widgets/LocationField';
+import { FormulaField } from '../widgets/FormulaField';
+import { SummaryField } from '../widgets/SummaryField';
+import { AutoNumberField } from '../widgets/AutoNumberField';
+import { UserField } from '../widgets/UserField';
+import { ObjectField } from '../widgets/ObjectField';
+import { VectorField } from '../widgets/VectorField';
+import { GridField } from '../widgets/GridField';
+import { ColorField } from '../widgets/ColorField';
+import { SliderField } from '../widgets/SliderField';
+import { CodeField } from '../widgets/CodeField';
+import { AvatarField } from '../widgets/AvatarField';
+import { SignatureField } from '../widgets/SignatureField';
+import { QRCodeField } from '../widgets/QRCodeField';
+
+/**
+ * Every registered widget that is NOT group-labelled — i.e. everything the
+ * #3961 family left behind. `textarea` and `select` appear under their
+ * `field:`-qualified keys because the bare spellings are `BUILTIN_FIELD_TYPES`
+ * members: a bare `type: 'textarea'` never consults the registry and renders the
+ * host's own control, which had no defect (measured: `consumers=1` either way).
+ */
+const WIDGETS: Record<string, any> = {
+  text: TextField,
+  'field:textarea': TextAreaField,
+  number: NumberField,
+  boolean: BooleanField,
+  'field:select': SelectField,
+  date: DateField,
+  datetime: DateTimeField,
+  time: TimeField,
+  email: EmailField,
+  phone: PhoneField,
+  url: UrlField,
+  tags: TagsField,
+  currency: CurrencyField,
+  percent: PercentField,
+  password: PasswordField,
+  markdown: RichTextField,
+  html: RichTextField,
+  richtext: RichTextField,
+  lookup: LookupField,
+  master_detail: LookupField,
+  image: ImageField,
+  location: LocationField,
+  // The D group — no editable branch at all, the whole widget is the display.
+  formula: FormulaField,
+  summary: SummaryField,
+  auto_number: AutoNumberField,
+  vector: VectorField,
+  user: UserField,
+  owner: UserField,
+  object: ObjectField,
+  grid: GridField,
+  color: ColorField,
+  slider: SliderField,
+  code: CodeField,
+  avatar: AvatarField,
+  signature: SignatureField,
+  qrcode: QRCodeField,
+};
+
+/** A stored value per type, so the readonly branch renders its FILLED shape. */
+const VALUES: Record<string, unknown> = {
+  text: 'Hello',
+  'field:textarea': 'Hello there',
+  number: 42,
+  boolean: true,
+  'field:select': 'a',
+  date: '2026-01-02',
+  datetime: '2026-01-02T03:04:05Z',
+  time: '03:04',
+  email: 'user@example.com',
+  phone: '+15551234567',
+  url: 'https://example.com',
+  tags: ['red', 'blue'],
+  currency: 12.5,
+  percent: 0.25,
+  password: 'hunter2',
+  markdown: '# Hi',
+  html: '<p>Hi</p>',
+  richtext: '<p>Hi</p>',
+  lookup: 'rec_1',
+  master_detail: 'rec_1',
+  image: 'https://example.com/a.png',
+  location: { latitude: 1, longitude: 2 },
+  formula: 'computed',
+  summary: 7,
+  auto_number: 'A-0001',
+  vector: [0.1, 0.2, 0.3, 0.4],
+  user: 'u1',
+  owner: 'u1',
+  object: { a: 1 },
+  grid: [{ a: 1 }],
+  color: '#ff0000',
+  slider: 5,
+  code: 'const a = 1;',
+  avatar: 'https://example.com/a.png',
+  signature: 'data:image/png;base64,AAA',
+  qrcode: 'https://example.com',
+};
+
+const TYPES = Object.keys(WIDGETS);
+
+/** The four sampled shapes: anchor, plain text, toggle display, display-only. */
+const SAMPLES = ['email', 'text', 'boolean', 'formula'] as const;
+
+beforeAll(() => {
+  for (const [type, Component] of Object.entries(WIDGETS)) {
+    // No `labelling` key — these are the `'control'` widgets by omission, which
+    // is exactly the population this issue is about.
+    ComponentRegistry.register(type.replace(/^field:/, ''), Component as any, {
+      namespace: 'field',
+      skipFallback: true,
+    });
+  }
+}, 30000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const fieldName = (type: string) => `f_${type.replace(':', '_')}`;
+const fieldLabel = (type: string) => `Label ${type.replace(/^field:/, '')}`;
+
+function fieldConfig(type: string, opts: { readonly?: boolean } = {}): Record<string, unknown> {
+  const bare = type.replace(/^field:/, '');
+  const config: any = {
+    name: fieldName(type),
+    label: fieldLabel(type),
+    type,
+    description: 'Some help',
+  };
+  if (bare === 'select' || bare === 'tags') config.options = [{ label: 'Alpha', value: 'a' }];
+  // Field-level readonly — the state this issue is about.
+  if (opts.readonly) config.readonly = true;
+  return config;
+}
+
+/** The real form renderer hosting one field — the reproduction. */
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        defaultValues,
+        fields,
+      }}
+    />,
+  );
+}
+
+const item = (name: string): HTMLElement => {
+  const el = document.querySelector<HTMLElement>(`[data-field="${name}"]`);
+  if (!el) throw new Error(`no form item rendered for field "${name}"`);
+  return el;
+};
+
+const hostLabel = (name: string): HTMLLabelElement => {
+  const el = item(name).querySelector('label');
+  if (!el) throw new Error(`no host label rendered for field "${name}"`);
+  return el as HTMLLabelElement;
+};
+
+const byId = (id: string | null | undefined): HTMLElement | null =>
+  id ? document.getElementById(id) : null;
+
+const idrefs = (el: Element, attr: string): string[] =>
+  (el.getAttribute(attr) ?? '').split(/\s+/).filter(Boolean);
+
+/**
+ * Every element whose `aria-describedby` NAMES `id` — the `consumers=` column,
+ * read from the DOM rather than through a query helper. Deliberately not
+ * `toHaveAccessibleDescription`: the failure being pinned is a COUNT of zero
+ * against a description element that renders perfectly well, and a name query
+ * answers "no match" for both "nobody references it" and "the reference
+ * resolves to nothing".
+ */
+function describedbyConsumers(id: string): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('[aria-describedby]')).filter((el) =>
+    (el.getAttribute('aria-describedby') ?? '').split(/\s+/).includes(id),
+  );
+}
+
+describe('every readonly registered widget is named and described by its host (objectui#4788)', () => {
+  it.each(TYPES)('%s: the host id is on a named group, and the label `for` is gone', (type) => {
+    const name = fieldName(type);
+    renderForm([fieldConfig(type, { readonly: true })], { [name]: VALUES[type] });
+
+    // `hostIdEl=NONE` → the group. Read from the description id so the host id
+    // is derived exactly as the probe derived it, not guessed.
+    const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]');
+    expect(descEl).not.toBeNull();
+    const hostId = descEl!.id.replace(/-description$/, '');
+    const host = byId(hostId);
+    expect(host).not.toBeNull();
+    expect(host).toHaveAttribute('role', 'group');
+    expect(item(name).contains(host!)).toBe(true);
+
+    // `for=DANGLING` → no `for` at all, and a published id instead
+    // (single naming channel, objectui#3978).
+    const label = hostLabel(name);
+    expect(label).not.toHaveAttribute('for');
+    expect(label.id).not.toBe('');
+
+    // The name IDREFs resolve: label first, then the group itself so the VALUE
+    // stays in the accessible name (`group` is not a name-from-content role).
+    const labelled = idrefs(host!, 'aria-labelledby');
+    expect(labelled).toEqual([label.id, hostId]);
+    expect(byId(labelled[0])).toBe(label);
+
+    // `consumers=0` → 1, on the same element that carries the name.
+    expect(describedbyConsumers(descEl!.id)).toEqual([host]);
+  });
+
+  it.each(TYPES)('%s: the widget output the user reads sits INSIDE that group', (type) => {
+    const name = fieldName(type);
+    renderForm([fieldConfig(type, { readonly: true })], { [name]: VALUES[type] });
+
+    const host = screen.getByRole('group');
+    // The host wraps, it does not replace: whatever the widget rendered is still
+    // there, and it is there INSIDE the named group rather than beside it.
+    expect(host.firstElementChild).not.toBeNull();
+    expect(host.textContent).not.toBe('');
+    // And the group is the only one in the item — no nested second claim.
+    expect(item(name).querySelectorAll('[role="group"]')).toHaveLength(1);
+  });
+
+  it.each(TYPES)('%s: no control-channel state rides along (objectui#4005 boundary)', (type) => {
+    const name = fieldName(type);
+    renderForm([fieldConfig(type, { readonly: true })], { [name]: VALUES[type] });
+
+    const host = screen.getByRole('group');
+    // `<FormControl>`'s Slot injects `aria-invalid` into whatever it wraps. A
+    // readonly display cannot be edited and cannot be made invalid by the person
+    // reading it, so the wrapper consumes the key and emits nothing.
+    expect(host).not.toHaveAttribute('aria-invalid');
+    expect(host).not.toHaveAttribute('aria-required');
+  });
+});
+
+describe('the four sampled shapes read the way a user would hear them', () => {
+  it('email (anchor face): the group carries label + value, the link keeps its own name', () => {
+    const name = fieldName('email');
+    renderForm([fieldConfig('email', { readonly: true })], { [name]: 'user@example.com' });
+
+    // The composite name — this is the reading the ruling asked for: the value
+    // must not vanish from the accessible name when the label takes it over.
+    expect(screen.getByRole('group')).toHaveAccessibleName('Label email user@example.com');
+    // The anchor is read as itself inside the group, with the field name NOT
+    // duplicated onto it.
+    const link = screen.getByRole('link');
+    expect(link).toHaveAccessibleName('user@example.com');
+    expect(link).toHaveAttribute('href', 'mailto:user@example.com');
+    expect(link).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('text (plain-text face): the name is real, not the inert pair a role-less span gives', () => {
+    const name = fieldName('text');
+    renderForm([fieldConfig('text', { readonly: true })], { [name]: 'Hello' });
+
+    const host = screen.getByRole('group', { name: 'Label text Hello' });
+    // The role is what makes the name and the description land at all — the
+    // controlled experiment in the measurement showed `aria-labelledby` on a
+    // role-less span passing `toHaveAccessibleName` while naming nothing.
+    expect(host.tagName.toLowerCase()).toBe('div');
+    expect(host.querySelector('span')).not.toBeNull();
+    expect(host).toHaveAccessibleDescription('Some help');
+  });
+
+  it('boolean: the readonly display of a toggle is named as a value, not a control', () => {
+    const name = fieldName('boolean');
+    renderForm([fieldConfig('boolean', { readonly: true })], { [name]: true });
+
+    expect(screen.getByRole('group')).toHaveAccessibleName(/^Label boolean /);
+    // No switch is left in the readonly branch, so nothing must claim to be one.
+    expect(screen.queryByRole('switch')).toBeNull();
+  });
+
+  it('formula (D group): a widget with no editable branch is covered by the same wrapper', () => {
+    const name = fieldName('formula');
+    renderForm([fieldConfig('formula', { readonly: true })], { [name]: 'computed' });
+
+    // `FormulaField` never reads `readonly` — the whole widget is a replacement
+    // display. The host gate is `readonly` + a registered field widget, so the
+    // D group is covered by construction rather than by a per-widget exception.
+    expect(screen.getByRole('group')).toHaveAccessibleName('Label formula computed');
+    expect(screen.getByRole('group')).toHaveAccessibleDescription('Some help');
+  });
+});
+
+describe('the editable branch is untouched — its label still addresses a real control', () => {
+  it.each(SAMPLES)('%s: no group, `for` resolves, description consumed by the control', (type) => {
+    const name = fieldName(type);
+    renderForm([fieldConfig(type)], { [name]: VALUES[type] });
+
+    if (type === 'formula') {
+      // The D group has no editable branch to keep: it renders the same
+      // display-only span, which is why its editable row measured
+      // `for=DANGLING hostIdEl=NONE consumers=0` too. That residual is NOT this
+      // issue's readonly defect and is deliberately left as measured — pinned
+      // here so a later change to it is a deliberate one.
+      expect(screen.queryByRole('group')).toBeNull();
+      expect(hostLabel(name)).toHaveAttribute('for');
+      expect(byId(hostLabel(name).getAttribute('for'))).toBeNull();
+      return;
+    }
+
+    expect(screen.queryByRole('group')).toBeNull();
+    const label = hostLabel(name);
+    expect(label).not.toHaveAttribute('id');
+    const target = byId(label.getAttribute('for'));
+    expect(target).not.toBeNull();
+    // A labelable element, so the plain `for` is a real association.
+    expect(['input', 'textarea', 'select', 'button']).toContain(target!.tagName.toLowerCase());
+    const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]')!;
+    expect(describedbyConsumers(descEl.id)).toEqual([target]);
+  });
+});

--- a/packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx
+++ b/packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx
@@ -327,7 +327,14 @@ describe('every readonly registered widget is named and described by its host (o
     // The host wraps, it does not replace: whatever the widget rendered is still
     // there, and it is there INSIDE the named group rather than beside it.
     expect(host.firstElementChild).not.toBeNull();
-    expect(host.textContent).not.toBe('');
+    // And because the group names ITSELF as well as the label, that rendered
+    // content is part of the accessible name — which is the assertion that
+    // actually holds for every face. `textContent` does not: `image` and
+    // `signature` render an `img` whose value is its `alt`, so their text is
+    // empty while their name reads `Label image a.png` / `Label signature
+    // Signature`. Measured, then corrected — the first spelling of this
+    // assertion was red on exactly those two.
+    expect(host).toHaveAccessibleName(new RegExp(`^${fieldLabel(type)} .+`));
     // And the group is the only one in the item — no nested second claim.
     expect(item(name).querySelectorAll('[role="group"]')).toHaveLength(1);
   });


### PR DESCRIPTION
Fixes #4788

按 2026-08-16 维护者裁定(A / A / E,评论 5307576062)实施:只读态 host label 去 `for` 改发 id;只读值面接受 `role="group"`;机制落 `packages/components/src/renderers/form/form.tsx` 一处包容器。**`packages/fields/src/widgets/` 下零改动** —— 这是 E 方案的结构卖点。

## 缺陷(复跑的实测读数)

注册 field widget 的只读分支渲染的是「替换显示」(mailto 锚、格式化 span、chip 行、预览表),并且在自己的 DOM pass-through **之前**提前 return,所以 host 下发的东西一件都没落到元素上。在 `origin/main` `1ef236e18` 上复跑测量评论的 probe(真 form renderer + 裸注册,每字段带 `description: 'Some help'`,一行一个字段):

```
                readonly                                      editable
text      for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
number    for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
boolean   for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=switch consumers=1
email     for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
phone     for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
url       for=DANGLING hostIdEl=NONE consumers=0    for=RESOLVES-LABELABLE hostIdEl=input  consumers=1
formula   for=DANGLING hostIdEl=NONE consumers=0    for=DANGLING           hostIdEl=NONE   consumers=0
…(34 个注册的非 group-labelled 类型,只读行逐字相同)
```

`hostIdEl=NONE` 是关键读数:只读态下 `…-form-item` 这个 id **整个文档里没有任何元素带**,所以可见 label 的 `for` 悬空、只读面在无障碍树里**没有名字**,同时渲染出来的帮助文本零消费者。D 组四件(formula / summary / auto_number / vector)没有可编辑分支,整个 widget 就是替换显示,两列读数相同。

修复后同一 probe 的只读列(36 行,逐字相同):

```
for=NO-FOR  labelId=SET  hostIdEl=div[group]  consumers=1  ariaInvalid=(absent)  name="Label email user@example.com"
```

36 行 editable 读数改动前后 diff 为空。

## 修法

form renderer 在「readonly + 有 label + 非 group-labelled + 解析到注册 field widget」时,把 widget 的渲染结果包进一个容器,同时 label 发 id 去 `for`。`FormControl` 是 Radix Slot,于是它原本注给 widget 根元素的 `id` / `aria-describedby` / `aria-invalid` 改注到这一层,widget 自己渲染的标记一个字节都没变。

容器上:

- `role="group"` —— 与 #3990 为七个复合面确立的同一语义主张。没有它,`aria-labelledby` 落在无 role 的 span / div 上命名的是 NOTHING(`generic` 禁止作者名);
- `aria-labelledby` 是**复合**的 `"labelId hostId"` —— label 的 id 加容器自身的 id。`group` 不是 name-from-content 角色,自引用是把**值**留在可访问名里的唯一办法:email 面读作 `Email user@example.com` 而不是丢掉屏幕上唯一那行内容(accname §2F:经 `aria-labelledby` 到达的节点无论什么 role 都按内容取名);
- `aria-describedby` 原样转发。ARIA 1.2 下 group 是描述载体,不需要可聚焦控件 —— 即 #4005 的同一条理由用在第二个面上;
- `aria-invalid` **剥掉**。它是控件通道状态,报告使用者自己的编辑可能错在哪;只读显示不可编辑,也不可能被阅读它的人弄成非法。这正是 #3291 / #3318 / #4005 划的那条线,测试从两侧钉住。

`aria-required` 根本到不了这一层 —— 它照旧随 widget props 走,理由相同。

## 为什么落 host 而不是 33 个 widget

测量评论用受控实验否掉了 widget 侧的写法:`aria-labelledby` 落在无 role 的 span / div 上在 ARIA 上惰性,而 jsdom 里 `toHaveAccessibleName()` 对这份标记**答 PASS**。照那条路走会得到 26 个惰性面 + 一条把它们认证下来的钉子测试 —— 本仓视为一等失败的「declared but not delivered」。落在 host 一处之后,「下一个作者忘了 spread」这个入口不存在了,当下 34 个和将来任意第三方 widget 一律正确。

也因此本 PR 的断言全部写成 **DOM 归属**:每个 IDREF 都用 `getElementById` 解析,再断言解析到的节点是正确 form item 内的正确元素,而不是靠 `toHaveAccessibleName` —— 它分不出真关联和惰性关联。

## 未改变的路径(逐条钉住)

内建类型(input / textarea / checkbox / switch / select)、可编辑字段、group-labelled widget、无 label 渲染的字段:逐字节不变。

## 两个需要说清的后果

1. 只读注册字段多一层 DOM。按 widget 根元素是 form item 直接子元素来写的 e2e 选择器会看到它;该层带 `data-slot="readonly-field-group"` 作为稳定定位器(ADR-0054 C4)。
2. 那一层是块级盒,而好几个只读面原本是行内元素 —— 于是这些行现在拿到表单标准的 label 到值间距,与可编辑态一致。

## 一处如实记录的测试自我修正

`readonly-host-plumbing-e2e.test.tsx` 里「widget 输出在容器内」这条,第一版断言写的是 `textContent` 非空,对 `image` / `signature` **变红**:它们的只读面渲染的是 img,值在 `alt` 里,文本为空。断言换成了更强也更贴题的一条 —— 容器的**可访问名**必须超出 label 本身(`Label image a.png` / `Label signature Signature`),这正是复合命名要保证的事。读数在先,断言在后。

## 验证(全部实跑)

新增两个测试文件:

- `packages/components/src/renderers/form/__tests__/form-readonly-host-group.test.tsx` —— host 机制钉子(合成 widget:锚面 / 纯文本面 / display-only 面 / group-labelled 面 / 裸名 SDUI 组件),含容器归属、控件通道边界、五条「什么都没变」;
- `packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx` —— 34 个真 widget 全量扫(每个三条),加 email / text / boolean / formula 四类抽样,再加四条可编辑态回归。

```
vitest run packages/components packages/fields packages/plugin-form --maxWorkers=2
  Test Files  284 passed (284)
       Tests  3362 passed (3362)          SWEEP_EXIT=0

vitest run packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx
  Test Files  1 passed (1)
       Tests  116 passed (116)

turbo run type-check --concurrency=2 --filter=@object-ui/components --filter=@object-ui/fields
  Tasks:    12 successful, 12 total       TC_EXIT=0

node scripts/check-control-bytes.mjs      OK (scanned 4343 tracked text files)
node scripts/check-changeset-presence.mjs / -no-major / -fixed      OK
grep -naP 控制字符自查(四个改动文件)      零命中
```

### 反向验证(方向先判后跑,预判写在跑之前)

先 commit,再把包容器逻辑临时摘掉(`withReadonlyHostGroup` 恒等返回,label 发 id 那半故意留着,所以唯一被删的就是容器);`git checkout` 对着文件路径还原,**未用 stash**。

**预判**:方向是**红**,不是反转 —— 断言的是一个被实验删掉的容器的存在与归属;而「什么都没变」那组断言的是该容器在未受影响路径上的**不存在**,所以必须保持绿。逐条点名 8 条应红、5 条应绿,并预测 fields 侧 112 红 / 4 绿。

**实跑,与预判逐条一致**:

```
form-readonly-host-group.test.tsx        13 tests | 8 failed   (8 条名字与预判完全相同)
readonly-host-plumbing-e2e.test.tsx     116 tests | 112 failed
Test Files  2 failed (2)
     Tests  120 failed | 9 passed (129)  REV_EXIT=1
```

保持绿的 9 条正是「什么都没变」那 5 条 + fields 侧 4 条可编辑态回归。

## 范围外

- 相邻缺陷 **#4857**:七个 widget(formula / summary / auto_number / vector / grid / slider / signature)在**可编辑态**也丢 host id,`for` 同样悬空 —— readonly 门管不到,且真实 ObjectForm 把计算型字段映射成 `disabled` 而非 `readonly`。已另立单,未在本 PR 修。
- 未碰 `packages/fields/src/widgets/` 任何源码。
- 未碰 `content/docs/releases/**`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_