### PR TITLE
fix(components,fields): 全屏长文本对话框播报校验状态、控件拿到可访问名 (#4824, #4832)

### DIFF
--- a/.changeset/fullscreen-dialog-validation-and-name-4824.md
+++ b/.changeset/fullscreen-dialog-validation-and-name-4824.md
@@ -1,0 +1,97 @@
+---
+'@object-ui/components': minor
+'@object-ui/fields': patch
+---
+
+The fullscreen long-text dialog announces the field's validation state and carries the field's name
+
+objectui#4824, objectui#4832.
+
+`mobile.fullscreenLongText` is a shipped opt-in, and with it on the phone user
+edits long text in this dialog and nowhere else. Measured on all three surfaces
+that render the dialog — `TextAreaField`, `RichTextField`, and the form
+renderer's built-in `textarea` branch — with the field genuinely invalid at that
+moment:
+
+```
+INLINE  richtext  aria-invalid= true
+DIALOG  richtext  aria-invalid= false   aria-describedby= null
+INLINE  textarea  aria-invalid= true
+DIALOG  textarea  aria-invalid= null    aria-describedby= null
+```
+
+and the accessible name of every dialog control empty, against `F` on every
+inline one. The rich-text row is the sharp half: the dialog was not silent about
+the failure, it was announcing the OPPOSITE of the inline control for the same
+field at the same moment, because `RichTextEditorSurface` computed
+`aria-invalid={!!error}` from an `error` prop the dialog rendering never
+received. 3 surfaces, 3 broken, one cause: the dialog's control is built from
+scratch by the host, so none of the wiring the inline control gets from the form
+renderer reaches it.
+
+**Answered once, in the primitive.** `FullscreenEditor` now takes the field's
+`error` and owns what the dialog does with it: it renders the message in a
+dialog-local node, and hands `children` a required fourth argument — a
+spreadable set of DOM attributes — carrying `aria-labelledby` (the dialog
+title's text, i.e. the field label #3393 already put there), `aria-invalid`, and
+`aria-errormessage` naming that node. The host spreads it; the host never learns
+an id, so it cannot name the wrong node, cannot compose the attributes subtly
+wrong, and cannot compute its own `aria-invalid` from a prop it forgot to plumb.
+Three hosts hand-answering this is the shape that produced three identical
+holes.
+
+**On objectui#3222's "the text belongs to `FormMessage`".** The maintainer's
+ruling of 2026-08-16 restates that rule as what it was always protecting —
+only one copy of the error text is in the accessibility tree at any moment —
+which the dialog-local node satisfies: it exists only while the dialog is open,
+and for exactly that window Radix `aria-hidden`s everything outside the modal,
+`FormMessage` included. The shortcut of pointing the dialog control's
+`aria-describedby` / `aria-errormessage` at the host's `FormMessage` id is
+forbidden rather than merely unused: it resolves to a node that is `aria-hidden`
+for the whole time the reference is live (an ARIA MUST violation), and neither
+happy-dom nor jsdom can see the difference — which is why every new pin asserts
+that the named node is inside THIS dialog, not merely that it exists.
+
+`aria-errormessage` carries a single IDREF and is emitted only alongside
+`aria-invalid="true"`. It is deliberately not folded into the host's
+`aria-describedby` chain, which on the textarea surface already carries the
+fullscreen character counter's sentence.
+
+**The name reuses the visible title rather than minting a second author for it**
+(#3978): `aria-labelledby` points at a span inside `DialogTitle`, not at
+`DialogTitle` itself — Radix renders the title as `h2` with the id its own
+`DialogContent` `aria-labelledby` names, so putting an id on it would buy the
+control a name at the cost of the dialog's.
+
+**Breaking (shipped as `minor`, see below), `@object-ui/components` only.**
+`FullscreenEditorProps.error` is REQUIRED, not optional, and
+`FullscreenEditorProps['children']` takes a fourth argument.
+
+FROM → TO for an out-of-repo host:
+
+```
+<FullscreenEditor value={v} onCommit={c} label={l} testIdPrefix="x">
+  {(draft, setDraft, disabled) => <textarea … />}
+</FullscreenEditor>
+
+<FullscreenEditor value={v} onCommit={c} label={l} testIdPrefix="x" error={err}>
+  {(draft, setDraft, disabled, aria) => <textarea {...aria} … />}
+</FullscreenEditor>
+```
+
+A render prop may still declare fewer parameters, so only `error` fails to
+compile — which is the point of making it required. Every consumer already has
+the value at hand (registered widgets take `error` off the widget props
+contract, objectui#3222; the built-in branch reads `fieldState.error?.message`),
+and an omitted `error` reproduces this defect exactly: a dialog announcing
+`aria-invalid="false"` for a field its own form has already failed. An optional
+key was forgotten by three surfaces in a row; a required one cannot be.
+
+`@object-ui/fields` is `patch`: `FullscreenFieldEditor` is internal to that
+package (not re-exported from its entry), so nothing in its public surface
+changes — only the behaviour of the two long-text widgets' dialogs.
+
+`minor` rather than `major` follows the repo's standing retirement precedent
+(AGENTS.md §版本号策略, enforced by `scripts/check-changeset-no-major.mjs`): all
+publishable packages sit in one `fixed` group, so a `major` here would carry the
+whole family up against an `@objectstack` that has not moved.

--- a/packages/components/src/__tests__/fullscreen-editor-dialog-aria.test.tsx
+++ b/packages/components/src/__tests__/fullscreen-editor-dialog-aria.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FullscreenEditor` (components/custom) — the dialog's editor gets a NAME and
+ * a truthful VALIDATION state, both minted here (objectui#4824 / #4832).
+ *
+ * The control inside the dialog is built from scratch by the host, and for all
+ * three surfaces that render this primitive it was built without either. What
+ * #4824 measured, with a field that was genuinely invalid at the time:
+ *
+ *     INLINE  richtext  aria-invalid= true
+ *     DIALOG  richtext  aria-invalid= false   aria-describedby= null
+ *     INLINE  textarea  aria-invalid= true
+ *     DIALOG  textarea  aria-invalid= null    aria-describedby= null
+ *
+ * and #4832 measured the accessible name of the same four controls as `F`,
+ * empty, `F`, empty. The dialog was not merely silent about the failure — the
+ * rich-text half was announcing the OPPOSITE of the inline control.
+ *
+ * The fix is one answer, here, handed to `children` as a required fourth
+ * argument. So this file pins the primitive's half of the contract; the three
+ * hosts' half (that they actually spread it onto the control they render) is
+ * pinned per surface, in `FullscreenFieldEditor.dialogAria.test.tsx` and
+ * `renderers/form/__tests__/form-fullscreen-textarea-dialog-aria.test.tsx`.
+ *
+ * ## Why every assertion about an IDREF also asserts CONTAINMENT
+ *
+ * The forbidden shape passes a naive test. Pointing the dialog control at the
+ * host's `<FormMessage>` id resolves to a real node with the right text — and
+ * is an ARIA MUST violation, because Radix `aria-hidden`s everything outside
+ * the modal for exactly as long as the reference is live. happy-dom and jsdom
+ * both compute accessible names and descriptions straight off the id, so
+ * neither can see the difference. `expect(dialog).toContainElement(target)` is
+ * what tells the two apart, so no IDREF is asserted here without it.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { FullscreenEditor } from '../custom/fullscreen-editor';
+
+afterEach(cleanup);
+
+/**
+ * Renders the primitive with a minimal host editor that does the one thing
+ * every real host does: spread the fourth argument onto its control.
+ */
+function renderEditor(over: { label?: string; error?: string; disabled?: boolean } = {}) {
+  const { error = undefined, disabled = false } = over;
+  // `in`, not a destructuring default: the label-less case passes `undefined`
+  // deliberately, and a default would silently substitute "Notes" for it.
+  const label = 'label' in over ? over.label : 'Notes';
+  const result = render(
+    <FullscreenEditor
+      value="hello"
+      onCommit={vi.fn()}
+      label={label}
+      testIdPrefix="probe"
+      disabled={disabled}
+      error={error}
+    >
+      {(draft, setDraft, editorDisabled, editorAria) => (
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          disabled={editorDisabled}
+          data-testid="probe-fullscreen-input"
+          {...editorAria}
+        />
+      )}
+    </FullscreenEditor>,
+  );
+  fireEvent.click(screen.getByTestId('probe-fullscreen-toggle'));
+  return result;
+}
+
+const dialog = () => screen.getByTestId('probe-fullscreen-dialog');
+const input = () => screen.getByTestId('probe-fullscreen-input');
+
+/** The node an IDREF attribute names, asserted to exist AND to live in the dialog. */
+function target(attr: string) {
+  const id = input().getAttribute(attr);
+  expect(id, `${attr} is set`).toBeTruthy();
+  // Single id, never a list: `aria-errormessage` takes one IDREF in this
+  // toolchain, and a space-separated value would silently resolve to nothing.
+  expect(id).not.toContain(' ');
+  const el = document.getElementById(id!);
+  expect(el, `${attr} names an existing element`).not.toBeNull();
+  expect(dialog()).toContainElement(el);
+  return el as HTMLElement;
+}
+
+describe('FullscreenEditor — the dialog control is NAMED (objectui#4832)', () => {
+  it('names it from the dialog title text, not from a second copy of the label', () => {
+    renderEditor({ label: 'Notes' });
+
+    // The reading the issue took: empty before, the field label after.
+    expect(input()).toHaveAccessibleName('Notes');
+    // …and the name comes from the visible title, so there is still exactly one
+    // author for it (#3978). A widget minting `aria-label="Notes"` would pass
+    // the line above and fail this one.
+    expect(input()).not.toHaveAttribute('aria-label');
+    expect(target('aria-labelledby')).toHaveTextContent('Notes');
+  });
+
+  it('leaves the DIALOG its own accessible name while doing so', () => {
+    // The regression this shape exists to avoid. Radix renders
+    // `<h2 id={context.titleId} {...titleProps}>`, so putting our id on
+    // `<DialogTitle>` would replace the id `DialogContent`'s `aria-labelledby`
+    // names — buying the control a name at the cost of the dialog's (#3393).
+    renderEditor({ label: 'Notes' });
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('Notes');
+  });
+
+  it('falls back to the generic title when the field has no label', () => {
+    renderEditor({ label: undefined });
+
+    expect(input()).toHaveAccessibleName('Edit text');
+  });
+});
+
+describe('FullscreenEditor — the dialog control tells the TRUTH about validation (objectui#4824)', () => {
+  it('announces aria-invalid=true and names a dialog-local message node', () => {
+    renderEditor({ error: 'Notes is required' });
+
+    expect(input()).toHaveAttribute('aria-invalid', 'true');
+    // Container-ownership, not just resolution: see the file header.
+    expect(target('aria-errormessage')).toHaveTextContent('Notes is required');
+    expect(screen.getByTestId('probe-fullscreen-error')).toHaveTextContent(
+      'Notes is required',
+    );
+  });
+
+  it('renders the host message verbatim rather than re-wording it', () => {
+    renderEditor({ error: 'Give the note a body' });
+
+    expect(screen.getByTestId('probe-fullscreen-error')).toHaveTextContent(
+      'Give the note a body',
+    );
+  });
+
+  it('emits neither the attribute nor the node when the field is valid', () => {
+    renderEditor({ error: undefined });
+
+    expect(input()).toHaveAttribute('aria-invalid', 'false');
+    // Absent, not `aria-errormessage=""`: the attribute is only exposed
+    // alongside `aria-invalid="true"`, and there is no node for it to name.
+    expect(input()).not.toHaveAttribute('aria-errormessage');
+    expect(screen.queryByTestId('probe-fullscreen-error')).not.toBeInTheDocument();
+  });
+
+  it('keeps the message out of the accessibility tree while the dialog is closed', () => {
+    // The 2026-08-16 restatement of objectui#3222 — "only one copy of the error
+    // text is in the accessibility tree at any moment" — has a closed-dialog
+    // half: this node may not exist alongside the host's own `<FormMessage>`.
+    // Radix unmounts the content, so it does not; a primitive that hoisted the
+    // node out of `<DialogContent>` to "keep it stable" would break this.
+    render(
+      <FullscreenEditor
+        value="hello"
+        onCommit={vi.fn()}
+        label="Notes"
+        testIdPrefix="closed"
+        error="Notes is required"
+      >
+        {(draft, _setDraft, _disabled, editorAria) => (
+          <textarea readOnly value={draft} {...editorAria} />
+        )}
+      </FullscreenEditor>,
+    );
+
+    expect(screen.queryByTestId('closed-fullscreen-error')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notes is required')).not.toBeInTheDocument();
+  });
+
+  it('does not fold the message id into the control aria-describedby', () => {
+    // `aria-errormessage` and `aria-describedby` are separate channels here.
+    // The host owns `aria-describedby` (a character counter rides it), and the
+    // primitive contributing to it would either overwrite that or double the
+    // announcement of the same sentence.
+    renderEditor({ error: 'Notes is required' });
+
+    expect(input()).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('keeps name and validation state through a `disabled` that flips mid-edit', () => {
+    // `disabled` carries the form's `isSubmitting`, which goes true while the
+    // dialog may ALREADY be open — the window the primitive's own doc calls
+    // out. A field does not stop being invalid, or stop having a name, because
+    // a submit is in flight. (It cannot be opened while disabled: the toggle is
+    // inert and `openFullscreen` refuses, which is why this starts enabled.)
+    const editor = (disabled: boolean) => (
+      <FullscreenEditor
+        value="hello"
+        onCommit={vi.fn()}
+        label="Notes"
+        testIdPrefix="probe"
+        disabled={disabled}
+        error="Notes is required"
+      >
+        {(draft, setDraft, editorDisabled, editorAria) => (
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={editorDisabled}
+            data-testid="probe-fullscreen-input"
+            {...editorAria}
+          />
+        )}
+      </FullscreenEditor>
+    );
+
+    const { rerender } = render(editor(false));
+    fireEvent.click(screen.getByTestId('probe-fullscreen-toggle'));
+    rerender(editor(true));
+
+    expect(input()).toBeDisabled();
+    expect(input()).toHaveAccessibleName('Notes');
+    expect(input()).toHaveAttribute('aria-invalid', 'true');
+    expect(target('aria-errormessage')).toHaveTextContent('Notes is required');
+  });
+});
+
+describe('FullscreenEditor — two editors on one page do not share ids (objectui#4824)', () => {
+  it('mints per-instance ids so one dialog cannot name the other message node', () => {
+    render(
+      <>
+        <FullscreenEditor
+          value="a"
+          onCommit={vi.fn()}
+          label="Notes"
+          testIdPrefix="first"
+          error="Notes is required"
+        >
+          {(draft, _s, _d, aria) => (
+            <textarea readOnly value={draft} data-testid="first-input" {...aria} />
+          )}
+        </FullscreenEditor>
+        <FullscreenEditor
+          value="b"
+          onCommit={vi.fn()}
+          label="Summary"
+          testIdPrefix="second"
+          error="Summary is required"
+        >
+          {(draft, _s, _d, aria) => (
+            <textarea readOnly value={draft} data-testid="second-input" {...aria} />
+          )}
+        </FullscreenEditor>
+      </>,
+    );
+
+    fireEvent.click(screen.getByTestId('second-fullscreen-toggle'));
+
+    const secondInput = screen.getByTestId('second-input');
+    const secondDialog = screen.getByTestId('second-fullscreen-dialog');
+    const errorEl = document.getElementById(
+      secondInput.getAttribute('aria-errormessage')!,
+    );
+    expect(secondDialog).toContainElement(errorEl);
+    expect(errorEl).toHaveTextContent('Summary is required');
+    expect(secondInput).toHaveAccessibleName('Summary');
+  });
+});

--- a/packages/components/src/custom/fullscreen-editor.tsx
+++ b/packages/components/src/custom/fullscreen-editor.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import { cn } from '../lib/utils';
 import { Button } from '../ui/button';
 import {
@@ -101,6 +101,57 @@ import { createSafeTranslation } from '@object-ui/i18n';
  * the safe direction — nothing is written — and it follows from `readOnly`
  * meaning there is no editing surface at all.
  *
+ * ## Validation state and the accessible name are answered HERE (objectui#4824 / #4832)
+ *
+ * The editor injected through `children` is built from scratch by the host, and
+ * for three surfaces in a row that meant it was built without any of the
+ * accessibility wiring the INLINE control gets for free from the form renderer.
+ * Measured on all three (`TextAreaField`, `RichTextField`, the form renderer's
+ * built-in `textarea` branch): the dialog control had no accessible name at all,
+ * and its validation state was either missing or — worse — actively wrong
+ * (`RichTextEditorSurface` computed `aria-invalid={!!error}` from an `error`
+ * prop the dialog rendering never received, so the dialog announced
+ * `aria-invalid="false"` for a field whose inline control was announcing
+ * `true` at the same moment).
+ *
+ * Neither is something a host can be trusted to re-answer once per surface —
+ * that is the shape that produced three identical holes. So this primitive owns
+ * both, and hands the result to `children` as a required fourth argument the
+ * host spreads onto whatever control it renders (the #3417 required-parameter
+ * shape). The host never learns an id, so it cannot name the wrong node.
+ *
+ *  - **Name** — `aria-labelledby` points at the dialog title's own text node.
+ *    The visible title is already the field label (#3393), so this reuses the
+ *    one naming channel rather than minting a second author for the name
+ *    (#3978). The id sits on a `<span>` INSIDE `<DialogTitle>` rather than on
+ *    the title element: Radix renders `<h2 id={context.titleId} {...props}>`, so
+ *    an `id` passed to `DialogTitle` would replace the id `DialogContent`'s own
+ *    `aria-labelledby` names and cost the DIALOG its accessible name.
+ *  - **Validation** — `aria-invalid` from `error`, plus `aria-errormessage`
+ *    naming a dialog-LOCAL node that renders the message text.
+ *
+ * ## Why the message text is rendered here at all
+ *
+ * objectui#3222 ruled that a widget drives `aria-invalid` and leaves the TEXT to
+ * `<FormMessage/>`, to keep one copy of it in the accessibility tree. The
+ * maintainer's ruling of 2026-08-16 restates that rule as what it was always
+ * protecting — "only one copy of the error text is in the accessibility tree at
+ * any moment" — which this node satisfies: it exists only while the dialog is
+ * open, and for exactly that window Radix `aria-hidden`s everything outside the
+ * modal, `<FormMessage/>` included. There is no window in which both are
+ * readable.
+ *
+ * ⛔ The shortcut this replaces is forbidden: pointing the dialog control's
+ * `aria-describedby` / `aria-errormessage` at the host's `<FormMessage>` id.
+ * That target is outside the modal and `aria-hidden` for the whole time the
+ * reference is live — an ARIA MUST violation that no jsdom/happy-dom test can
+ * see, because the id resolves and the node has text.
+ *
+ * `aria-errormessage` carries a SINGLE id (this repo's toolchain rejects a list
+ * there) and is emitted only alongside `aria-invalid="true"`, which is the
+ * condition under which it is exposed at all. It is deliberately not folded
+ * into the host's `aria-describedby` chain.
+ *
  * ## Copy
  *
  * Every string goes through `createSafeTranslation` on the SAME
@@ -137,6 +188,32 @@ const useSafeFullscreenTranslation = createSafeTranslation(
   // the English defaults above.
   'common.cancel',
 );
+
+/**
+ * The accessibility attributes the dialog's injected editor MUST carry, handed
+ * to `children` as its required fourth argument (objectui#4824 / #4832).
+ *
+ * Shaped as a spreadable set of real DOM attributes rather than the ids behind
+ * them, on purpose: `{...aria}` is the whole integration, so a host cannot get
+ * the composition subtly wrong, cannot name a node outside the dialog, and
+ * cannot compute its own `aria-invalid` from a prop it forgot to plumb — the
+ * three ways every one of the three surfaces got this wrong before.
+ */
+export interface FullscreenEditorAria {
+  /**
+   * The dialog title's text node — the field label (#3393) reused as the
+   * control's accessible name rather than a second, string-valued author for it.
+   */
+  'aria-labelledby': string;
+  /** Mirrors `error`, so the dialog cannot disagree with the inline control. */
+  'aria-invalid': boolean;
+  /**
+   * The dialog-local message node. A SINGLE id, present only when `error` is —
+   * `aria-errormessage` is exposed only alongside `aria-invalid="true"`, and
+   * this repo's toolchain does not accept an id list here.
+   */
+  'aria-errormessage'?: string;
+}
 
 export interface FullscreenEditorProps {
   /**
@@ -179,6 +256,22 @@ export interface FullscreenEditorProps {
    */
   disabled?: boolean;
   /**
+   * The field's validation message, or `undefined` when the field is valid.
+   *
+   * **Required, not optional** (objectui#4824). Every consumer already has it —
+   * the registered widgets take `error` off the widget props contract
+   * (objectui#3222), the built-in branch reads `fieldState.error?.message` — and
+   * an omitted `error` reproduces this issue exactly: a dialog that announces
+   * `aria-invalid="false"` while the same field's inline control announces
+   * `true`. A key the type system makes every call site answer cannot be
+   * forgotten by the next surface; an optional one was, three times.
+   *
+   * **Producers**: `TextAreaField`, `RichTextField`, and the form renderer's
+   * built-in `textarea` branch (which reads it off the PRE-strip props, exactly
+   * like `label` — `stripRendererOnlyProps` discards `error` for the DOM).
+   */
+  error: string | undefined;
+  /**
    * The editor itself, rendered inside the dialog body against the draft. The
    * host passes the SAME editor it renders inline.
    *
@@ -187,11 +280,17 @@ export interface FullscreenEditorProps {
    * editor's disabled state belongs on. Ignoring it is not a write-back hole —
    * `onCommit` is gated here regardless — but it does leave a control that looks
    * editable while the field is not, so every in-repo host applies it.
+   *
+   * The fourth argument is the accessibility set this component owns — name and
+   * validation state — and it is spread onto the control the host renders. See
+   * `FullscreenEditorAria` and the section above for why it is computed here
+   * rather than by each host.
    */
   children: (
     draft: string,
     setDraft: (next: string) => void,
     disabled: boolean,
+    aria: FullscreenEditorAria,
   ) => React.ReactNode;
   /** Optional footer status for the draft (e.g. a character counter). */
   footer?: (draft: string) => React.ReactNode;
@@ -204,12 +303,30 @@ export function FullscreenEditor({
   testIdPrefix,
   readOnly = false,
   disabled = false,
+  error,
   children,
   footer,
 }: FullscreenEditorProps) {
   const { t } = useSafeFullscreenTranslation();
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(value ?? '');
+
+  // Two ids off one `useId()`, both naming nodes this component renders INSIDE
+  // the dialog. The host never sees them — it receives the finished attributes —
+  // which is what makes "the reference names a node in this dialog" a property
+  // of the primitive rather than a rule each host has to remember.
+  const instanceId = useId();
+  const titleTextId = `${instanceId}-fullscreen-title`;
+  const errorId = `${instanceId}-fullscreen-error`;
+
+  const editorAria: FullscreenEditorAria = {
+    'aria-labelledby': titleTextId,
+    'aria-invalid': Boolean(error),
+    // Spread conditionally: absent, not `undefined`. `aria-errormessage` is only
+    // exposed alongside `aria-invalid="true"`, and a valid field renders no node
+    // for it to name.
+    ...(error ? { 'aria-errormessage': errorId } : null),
+  };
 
   const openFullscreen = () => {
     if (disabled || readOnly) return;
@@ -255,7 +372,15 @@ export function FullscreenEditor({
         >
           <DialogHeader className="p-4 border-b">
             <DialogTitle className="text-base">
-              {label ?? t('form.fullscreen.title')}
+              {/*
+                The id sits on this span, not on `<DialogTitle>`: Radix renders
+                `<h2 id={context.titleId} {...titleProps}>`, so an `id` prop
+                would REPLACE the id `DialogContent`'s `aria-labelledby` names
+                and leave the dialog itself unnamed. The span carries the same
+                visible text, so the control's name and the dialog's name are
+                one string with one author.
+              */}
+              <span id={titleTextId}>{label ?? t('form.fullscreen.title')}</span>
             </DialogTitle>
             {/*
               Without this line Radix reports no `descriptionPresent` and omits
@@ -267,8 +392,31 @@ export function FullscreenEditor({
             <DialogDescription className="sr-only">
               {t('form.fullscreen.description')}
             </DialogDescription>
+            {error ? (
+              /*
+                The dialog-local error node. Rendered only while the dialog is
+                open (Radix unmounts the content when it closes), which is
+                exactly the window in which the host's own `<FormMessage>` is
+                `aria-hidden` behind the modal — so the accessibility tree holds
+                one copy of this text, never two (the 2026-08-16 restatement of
+                objectui#3222).
+
+                Same classes as `<FormMessage>` so the two readings of the same
+                failure look alike; the text itself is the host's, never
+                re-worded here.
+              */
+              <p
+                id={errorId}
+                className="text-sm font-medium text-destructive"
+                data-testid={`${testIdPrefix}-fullscreen-error`}
+              >
+                {error}
+              </p>
+            ) : null}
           </DialogHeader>
-          <div className="flex-1 min-h-0 p-4">{children(draft, setDraft, disabled)}</div>
+          <div className="flex-1 min-h-0 p-4">
+            {children(draft, setDraft, disabled, editorAria)}
+          </div>
           <DialogFooter className="p-3 border-t flex-row justify-between sm:justify-end gap-2">
             {footer?.(draft)}
             <div className="flex gap-2 ml-auto">

--- a/packages/components/src/renderers/form/__tests__/form-fullscreen-textarea-dialog-aria.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-fullscreen-textarea-dialog-aria.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The form renderer's built-in `textarea` branch — third of the three surfaces
+ * whose fullscreen dialog announced nothing about validation and named nothing
+ * at all (objectui#4824 / #4832).
+ *
+ * This one is the reason the fix could not be scoped to `@object-ui/fields`.
+ * `mobile.fullscreenLongText` is ONE form-level promise honoured on two render
+ * paths, and a `fields`-scoped sweep cannot see this path at all — it lives
+ * here, it is unregistered, and #4824's measurement found it broken in exactly
+ * the same way as the two registered widgets (#4250's half-fix lesson, stated
+ * as a scope fence).
+ *
+ * It is also the only one of the three that can be measured against a REAL
+ * `<FormMessage>`: this branch renders inside `<FormControl>` with the form's
+ * own message node as a sibling, so the forbidden shape has a real target here
+ * and the pin can assert it was not taken.
+ *
+ * ## The forbidden shape, and why it needs its own assertions
+ *
+ * ⛔ Pointing the dialog control's `aria-describedby` / `aria-errormessage` at
+ * the host's `<FormMessage>` id. It is the cheapest-looking fix — the id exists,
+ * the node has the right text, every assertion about names and descriptions
+ * goes green — and it is an ARIA MUST violation: Radix `aria-hidden`s
+ * everything outside the modal for exactly as long as the reference is live.
+ * happy-dom and jsdom compute accessible names/descriptions straight off the
+ * IDREF, so no amount of `toHaveAccessibleDescription` can tell the two apart.
+ *
+ * The assertions that can: the named node is INSIDE the dialog, and the id is
+ * not the form item's message id. Both are below, on every IDREF this branch
+ * emits.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues,
+        fields,
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+const longText = (over: Record<string, unknown> = {}) => ({
+  name: 'notes',
+  label: 'F',
+  type: 'textarea',
+  mobile_fullscreen: true,
+  ...over,
+});
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+/**
+ * Fails the form, then opens the dialog — the exact sequence a user hits: the
+ * field is already invalid when the fullscreen editor is opened to fix it.
+ */
+async function failThenOpen(fields: any[] = [longText({ required: true })]) {
+  const { container } = renderForm(fields, { notes: '' });
+  submit();
+  await waitFor(() => {
+    expect(screen.getByText('F is required')).toBeInTheDocument();
+  });
+
+  const formMessage = screen.getByText('F is required');
+  fireEvent.click(screen.getByTestId('form-textarea-fullscreen-toggle'));
+
+  return {
+    formMessage,
+    // The INLINE control. Located through `container` rather than by label:
+    // once the fix lands, the dialog's textarea answers to the field name too
+    // (that is #4832), so `getByLabelText('F')` would match both. The dialog is
+    // portalled to `document.body`, outside this tree.
+    inline: container.querySelector('textarea') as HTMLTextAreaElement,
+    dialog: screen.getByTestId('form-textarea-fullscreen-dialog'),
+    input: screen.getByTestId('form-textarea-fullscreen-input'),
+  };
+}
+
+describe('form renderer built-in textarea — the dialog tells the truth about validation (objectui#4824)', () => {
+  it('announces aria-invalid="true" on the dialog control', async () => {
+    const { input } = await failThenOpen();
+
+    // Measured `null` before: the attribute was absent entirely, on the surface
+    // the phone user is actually typing into.
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('names a message node that lives INSIDE the dialog, not the form FormMessage', async () => {
+    const { formMessage, dialog, input } = await failThenOpen();
+
+    const id = input.getAttribute('aria-errormessage');
+    expect(id).toBeTruthy();
+    // Single IDREF — a list resolves to nothing in this toolchain.
+    expect(id).not.toContain(' ');
+
+    const named = document.getElementById(id!);
+    expect(named).toHaveTextContent('F is required');
+    // ⛔ THE assertion. `formMessage` has the same text and a resolvable id, so
+    // every text-based check passes for the forbidden shape; only ownership
+    // separates them.
+    expect(dialog).toContainElement(named);
+    expect(dialog).not.toContainElement(formMessage);
+    expect(id).not.toBe(formMessage.id);
+  });
+
+  it('does not point the dialog control describedby at anything outside the dialog', async () => {
+    const { dialog, input } = await failThenOpen();
+
+    // The built-in branch's dialog textarea composes no description of its own,
+    // so the only way this attribute could appear is a host id leaking in —
+    // and every host id names a node the modal has hidden.
+    const describedBy = input.getAttribute('aria-describedby');
+    if (describedBy) {
+      for (const id of describedBy.split(/\s+/)) {
+        expect(dialog).toContainElement(document.getElementById(id));
+      }
+    }
+  });
+
+  it('leaves the inline control pointing at the form message as before', async () => {
+    // The other direction: the dialog getting its own node must not have moved
+    // the INLINE control off `<FormControl>`'s wiring.
+    const { formMessage, inline } = await failThenOpen();
+
+    expect(inline).toHaveAttribute('aria-invalid', 'true');
+    expect(inline.getAttribute('aria-describedby')).toContain(formMessage.id);
+  });
+
+  it('renders no message node while the field is valid', async () => {
+    renderForm([longText({ required: true })], { notes: 'already filled in' });
+
+    fireEvent.click(screen.getByTestId('form-textarea-fullscreen-toggle'));
+
+    const input = screen.getByTestId('form-textarea-fullscreen-input');
+    expect(input).toHaveAttribute('aria-invalid', 'false');
+    expect(input).not.toHaveAttribute('aria-errormessage');
+    expect(
+      screen.queryByTestId('form-textarea-fullscreen-error'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps ONE readable copy of the message text in the dialog', async () => {
+    // The 2026-08-16 restatement of objectui#3222. Both copies exist in the
+    // document while the dialog is open — that is unavoidable, `<FormMessage>`
+    // stays mounted behind the overlay — but only one is inside the modal, and
+    // the modal is the only part of the tree assistive technology can reach.
+    const { dialog } = await failThenOpen();
+
+    const copies = screen.getAllByText('F is required');
+    expect(copies).toHaveLength(2);
+    expect(copies.filter((el) => dialog.contains(el))).toHaveLength(1);
+  });
+});
+
+describe('form renderer built-in textarea — the dialog control is NAMED (objectui#4832)', () => {
+  it('takes its name from the dialog title, which is the field label', async () => {
+    const { dialog, input } = await failThenOpen();
+
+    // Measured empty before, against `F` on the inline control.
+    expect(input).toHaveAccessibleName('F');
+    // From the visible title, not a second string author (#3978).
+    expect(input).not.toHaveAttribute('aria-label');
+    const labelledBy = document.getElementById(input.getAttribute('aria-labelledby')!);
+    expect(labelledBy).toHaveTextContent('F');
+    expect(dialog).toContainElement(labelledBy);
+  });
+
+  it('leaves the dialog itself named (objectui#3393)', async () => {
+    await failThenOpen();
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('F');
+  });
+
+  it('names the control on a valid field too', async () => {
+    renderForm([longText()], { notes: 'hello' });
+    fireEvent.click(screen.getByTestId('form-textarea-fullscreen-toggle'));
+
+    expect(screen.getByTestId('form-textarea-fullscreen-input')).toHaveAccessibleName('F');
+  });
+
+  it('gives two long-text fields on one form two DISTINCT dialog control names', async () => {
+    renderForm([longText(), longText({ name: 'summary', label: 'Summary' })], {
+      notes: 'a',
+      summary: 'b',
+    });
+
+    fireEvent.click(screen.getAllByTestId('form-textarea-fullscreen-toggle')[1]);
+
+    expect(screen.getByTestId('form-textarea-fullscreen-input')).toHaveAccessibleName(
+      'Summary',
+    );
+  });
+});
+
+describe('form renderer built-in textarea — `error` stays off the DOM (objectui#3222)', () => {
+  it('puts no `error` attribute on the inline or the dialog control', async () => {
+    // `error` is forwarded to this branch by name, off the PRE-strip props,
+    // exactly like `label` — `stripRendererOnlyProps` still discards it, so it
+    // must not reappear as a stray attribute on either textarea.
+    const { inline, input } = await failThenOpen();
+
+    expect(input).not.toHaveAttribute('error');
+    expect(inline).not.toHaveAttribute('error');
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -623,6 +623,7 @@ function FullscreenTextarea({
   label,
   readOnly,
   disabled,
+  error,
   ...rest
 }: {
   value?: string;
@@ -632,6 +633,18 @@ function FullscreenTextarea({
   label?: string;
   readOnly?: boolean;
   disabled?: boolean;
+  /**
+   * The field's validation message (objectui#4824). DECLARED, so it is not a
+   * passenger on `rest` — it must not reach the inline `<Textarea>` as a stray
+   * `error="…"` attribute, and the primitive needs it by name.
+   *
+   * Like `label` and `mobile_fullscreen`, it is read off the PRE-strip props at
+   * the call site: `stripRendererOnlyProps` discards `error` for the DOM,
+   * correctly, because the INLINE control gets its `aria-invalid` from
+   * `<FormControl>`'s Slot. The DIALOG's control is built from scratch and gets
+   * nothing from that Slot, which is the whole of objectui#4824.
+   */
+  error?: string;
   [key: string]: any;
 }) {
   // The inline control's own gate. `readOnly`/`disabled` are real attributes on
@@ -667,8 +680,9 @@ function FullscreenTextarea({
         testIdPrefix="form-textarea"
         readOnly={readOnly}
         disabled={disabled}
+        error={error}
       >
-        {(draft, setDraft, editorDisabled) => (
+        {(draft, setDraft, editorDisabled, editorAria) => (
           <Textarea
             autoFocus
             value={draft}
@@ -677,6 +691,16 @@ function FullscreenTextarea({
             className="h-full min-h-full resize-none text-base"
             disabled={editorDisabled}
             data-testid="form-textarea-fullscreen-input"
+            /*
+              Name + validation state, computed by the primitive and spread whole
+              (objectui#4824 / #4832). This control used to carry neither: no
+              `aria-invalid` at all, and an empty accessible name, while the
+              inline `<Textarea>` above announced both off `<FormControl>`'s
+              Slot. Spread rather than unpacked — this branch is not told which
+              ids it names, so it cannot point at the host's `<FormMessage>`,
+              which Radix `aria-hidden`s for as long as the dialog is open.
+            */
+            {...editorAria}
           />
         )}
       </FullscreenEditor>
@@ -2687,13 +2711,23 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       // the call site never forwarded a `label`, so the guard was defending
       // against something that never arrived, while every OTHER built-in
       // branch had no guard at all. Now the strip owns it for all branches.
-      const { mobile_fullscreen, label } = fieldProps as any;
+      //
+      // `error` rides the same way, and for the same reason (objectui#4824):
+      // `stripRendererOnlyProps` discards it because the INLINE control takes
+      // its `aria-invalid` from `<FormControl>`'s Slot and would only gain a
+      // stray `error="…"` attribute. The fullscreen DIALOG's control is built
+      // from scratch inside this branch, reaches no Slot, and so had no way to
+      // say the field had failed — measured announcing nothing at all while the
+      // inline control announced `aria-invalid="true"` for the same field. The
+      // primitive, not this branch, decides what to do with it.
+      const { mobile_fullscreen, label, error } = fieldProps as any;
       const rest = stripRendererOnlyProps(fieldProps);
       if (mobile_fullscreen) {
         return (
           <FullscreenTextarea
             placeholder={placeholder}
             label={label}
+            error={error}
             // `readonly` is destructured off `props` at the top of this
             // function, so — exactly like `label` and `mobile_fullscreen` — it
             // is NOT in `rest` and has to be forwarded by name (objectui#3400).

--- a/packages/fields/src/widgets/FullscreenFieldEditor.tsx
+++ b/packages/fields/src/widgets/FullscreenFieldEditor.tsx
@@ -45,8 +45,15 @@ import { FullscreenEditor, type FullscreenEditorProps } from '@object-ui/compone
  * primitive already answers it (no affordance at all).
  *
  * Everything else — `value` / `onCommit` / `label` / `testIdPrefix` /
- * `disabled` / `children` / `footer` — passes straight through, so the hosts and
- * their pins are unchanged. `testIdPrefix` still namespaces this package's ids
+ * `disabled` / `error` / `children` / `footer` — passes straight through, so the
+ * hosts and their pins are unchanged. `error` is REQUIRED by the primitive
+ * (objectui#4824) and stays required here: both hosts already destructure it off
+ * the widget props contract (objectui#3222), and it is what the primitive turns
+ * into the dialog control's `aria-invalid` / `aria-errormessage` and into the
+ * dialog-local message node. A host that omits it gets a dialog announcing
+ * `aria-invalid="false"` for an invalid field, which is the defect #4824
+ * measured — so the type system asks for it rather than trusting the next
+ * author to remember. `testIdPrefix` still namespaces this package's ids
  * (`textarea-`, `richtext-`), distinct from the built-in branch's
  * `form-textarea-`, so a test can still say which render path it found.
  */

--- a/packages/fields/src/widgets/RichTextField.tsx
+++ b/packages/fields/src/widgets/RichTextField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cn, Textarea, EmptyValue } from '@object-ui/components';
+import { cn, Textarea, EmptyValue, type FullscreenEditorAria } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/react';
 import { FullscreenFieldEditor } from './FullscreenFieldEditor';
 import { FieldWidgetComponentProps } from './types';
@@ -37,6 +37,7 @@ function RichTextEditorSurface({
   textareaTestId,
   overlay,
   domProps,
+  editorAria,
 }: {
   value: string;
   onChange: (next: string) => void;
@@ -67,6 +68,23 @@ function RichTextEditorSurface({
    * makes for the same pair of surfaces.
    */
   domProps?: DomProps<FieldWidgetComponentProps<string>>;
+  /**
+   * The accessibility set `FullscreenFieldEditor` computes for the control it
+   * hosts — accessible name and validation state (objectui#4824 / #4832).
+   *
+   * The mirror image of `domProps`: given to the DIALOG rendering only, because
+   * only the dialog rendering has a name and a message node to be pointed at
+   * from inside the modal. The inline surface takes both from the host, through
+   * `domProps` and its own `error`.
+   *
+   * It is the dialog copy's SINGLE author of `aria-invalid`, which is why the
+   * dialog rendering below passes no `error`: this surface used to compute
+   * `aria-invalid={!!error}` from an `error` prop the dialog rendering never
+   * received, so it announced a literal `aria-invalid="false"` for a field the
+   * inline surface was announcing `true` for at the same moment — the sharper
+   * half of objectui#4824.
+   */
+  editorAria?: FullscreenEditorAria;
 }) {
   return (
     <div className={cn('space-y-2', fullHeight && 'flex flex-col h-full')}>
@@ -108,6 +126,12 @@ function RichTextEditorSurface({
           // keeps that entry passing instead of handing the state back to a
           // host that may not have one.
           aria-invalid={!!error}
+          // LAST, and only ever non-empty on the dialog rendering: inside the
+          // modal the primitive is the authority on both the name and the
+          // validation state, and its `aria-invalid` must win over the `!!error`
+          // above (which is the INLINE channel and is `false` there by
+          // construction). On the inline surface this spreads nothing.
+          {...editorAria}
         />
         {overlay}
       </div>
@@ -215,8 +239,17 @@ export function RichTextField({ value, onChange, field, readonly, error, ...prop
             label={richField?.label}
             testIdPrefix="richtext"
             disabled={disabled}
+            /*
+              The validation channel the dialog rendering never had
+              (objectui#4824). It is handed to the PRIMITIVE, not down to the
+              second `RichTextEditorSurface`, because the primitive is what
+              renders the message node the control points at — a node that must
+              live inside the modal, since the host's `<FormMessage>` is
+              `aria-hidden` for as long as this dialog is open.
+            */
+            error={error}
           >
-            {(draft, setDraft, editorDisabled) => (
+            {(draft, setDraft, editorDisabled, editorAria) => (
               <RichTextEditorSurface
                 value={draft}
                 onChange={setDraft}
@@ -227,6 +260,7 @@ export function RichTextField({ value, onChange, field, readonly, error, ...prop
                 autoFocus
                 fullHeight
                 textareaTestId="richtext-fullscreen-input"
+                editorAria={editorAria}
               />
             )}
           </FullscreenFieldEditor>

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -153,6 +153,17 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
           testIdPrefix="textarea"
           disabled={disabled}
           /*
+            The same `error` the inline control turns into `aria-invalid`
+            (objectui#3222), handed to the dialog so its control can say the
+            same thing (objectui#4824). Before this the dialog's textarea
+            carried no `aria-invalid` at all: the field was invalid, the inline
+            control said so, and the surface the user was actually typing into
+            said nothing. The primitive — not this widget — decides what the
+            dialog does with it, so both long-text widgets and the built-in
+            branch cannot answer it three different ways again.
+          */
+          error={error}
+          /*
             The FULLSCREEN surface's counter (objectui#3417). This slot used to
             render a bare `{n}/{max}` span: no accessible name, no association
             with the dialog's textarea, nothing `aria-live`. A screen reader
@@ -181,7 +192,7 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
             ) : null
           }
         >
-          {(draft, setDraft, editorDisabled) => (
+          {(draft, setDraft, editorDisabled, editorAria) => (
             <Textarea
               autoFocus
               value={draft}
@@ -189,6 +200,19 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
               disabled={editorDisabled}
               maxLength={maxLength}
               placeholder={textareaField?.placeholder}
+              /*
+                Name + validation state, computed by `FullscreenFieldEditor` and
+                spread whole (objectui#4824 / #4832). Spread rather than
+                unpacked: this widget is not told which ids it names, so it
+                cannot name a node outside the dialog — the ⛔ shortcut of
+                pointing at the host's `<FormMessage>`, which Radix
+                `aria-hidden`s for the entire time the dialog is open.
+
+                It carries no `aria-describedby`, so it composes with — rather
+                than overwrites — the character-count description assigned
+                below.
+              */
+              {...editorAria}
               /*
                 Assigned, not appended — and that is a statement about THIS
                 element, not a relaxation of the rule above. The inline control

--- a/packages/fields/src/widgets/__tests__/FullscreenFieldEditor.dialogAria.test.tsx
+++ b/packages/fields/src/widgets/__tests__/FullscreenFieldEditor.dialogAria.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The fullscreen dialog's editor announces the field's NAME and its VALIDATION
+ * state — on BOTH registered long-text widgets (objectui#4824 / #4832).
+ *
+ * `mobile.fullscreenLongText` is a shipped opt-in: with it on, the phone user
+ * writes long text in this dialog and nowhere else. What #4824 measured there,
+ * with the field genuinely invalid at that moment:
+ *
+ *     INLINE  richtext  aria-invalid= true
+ *     DIALOG  richtext  aria-invalid= false   aria-describedby= null
+ *     INLINE  textarea  aria-invalid= true
+ *     DIALOG  textarea  aria-invalid= null    aria-describedby= null
+ *
+ * The rich-text row is the sharp one: the dialog was not silent, it was
+ * announcing the OPPOSITE of the inline control for the same field at the same
+ * moment, because `RichTextEditorSurface` computed `aria-invalid={!!error}`
+ * from an `error` prop the dialog rendering never received. #4832 measured the
+ * accessible name of the same dialog controls as empty while the inline ones
+ * read `F`.
+ *
+ * Both widgets are pinned in ONE file on purpose. The pair is what keeps a
+ * single form-level setting producing a single behaviour; #4250's lesson is
+ * that half a fix on a two-surface feature is worse than a symmetric gap,
+ * because nothing reports the asymmetry. The third surface — the form
+ * renderer's built-in `textarea` branch — lives in `@object-ui/components`
+ * and is pinned there (`form-fullscreen-textarea-dialog-aria.test.tsx`),
+ * because a `fields`-scoped sweep cannot see it.
+ *
+ * ## Every IDREF assertion carries a containment assertion
+ *
+ * The shortcut this fix must not become is pointing the dialog control at the
+ * host's `<FormMessage>` id. It resolves, it has the right text, and it is an
+ * ARIA MUST violation — Radix `aria-hidden`s everything outside the modal for
+ * exactly as long as the reference is live. happy-dom computes names and
+ * descriptions straight off the id and cannot tell the two apart, so the pin
+ * has to be "the named node is inside THIS dialog", never "the named node
+ * exists".
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { TextAreaField } from '../TextAreaField';
+import { RichTextField } from '../RichTextField';
+import type { FieldMetadata } from '@object-ui/types';
+
+afterEach(cleanup);
+
+const fieldMeta = (extra: Record<string, unknown> = {}) =>
+  ({
+    name: 'notes',
+    label: 'F',
+    type: 'textarea',
+    mobile_fullscreen: true,
+    ...extra,
+  }) as unknown as FieldMetadata;
+
+/**
+ * The two widgets under one description, so every case below runs on both and
+ * neither can be fixed alone. `inlineTestId` is how each widget's INLINE
+ * control is found — the reading the dialog has to match.
+ */
+const SURFACES = [
+  {
+    name: 'textarea',
+    prefix: 'textarea',
+    dialogInputTestId: 'textarea-fullscreen-input',
+    render: (props: { error?: string; extra?: Record<string, unknown> }) =>
+      render(
+        <TextAreaField
+          value="hello"
+          onChange={() => {}}
+          field={fieldMeta({ type: 'textarea', ...(props.extra ?? {}) })}
+          error={props.error}
+        />,
+      ),
+  },
+  {
+    name: 'richtext',
+    prefix: 'richtext',
+    dialogInputTestId: 'richtext-fullscreen-input',
+    render: (props: { error?: string; extra?: Record<string, unknown> }) =>
+      render(
+        <RichTextField
+          value="hello"
+          onChange={() => {}}
+          field={fieldMeta({ type: 'markdown', ...(props.extra ?? {}) })}
+          error={props.error}
+        />,
+      ),
+  },
+] as const;
+
+describe.each(SURFACES)(
+  '$name fullscreen dialog — validation state and name (objectui#4824 / #4832)',
+  ({ prefix, dialogInputTestId, render: renderSurface }) => {
+    const open = (props: { error?: string; extra?: Record<string, unknown> } = {}) => {
+      renderSurface(props);
+      fireEvent.click(screen.getByTestId(`${prefix}-fullscreen-toggle`));
+      return {
+        dialog: screen.getByTestId(`${prefix}-fullscreen-dialog`),
+        input: screen.getByTestId(dialogInputTestId),
+      };
+    };
+
+    /** The node an IDREF names — asserted to exist AND to be owned by the dialog. */
+    const target = (el: HTMLElement, dialog: HTMLElement, attr: string) => {
+      const id = el.getAttribute(attr);
+      expect(id, `${attr} is set`).toBeTruthy();
+      // `aria-errormessage` takes a SINGLE IDREF in this toolchain; a list
+      // silently resolves to nothing.
+      expect(id).not.toContain(' ');
+      const node = document.getElementById(id!);
+      expect(node, `${attr} names an existing element`).not.toBeNull();
+      expect(dialog).toContainElement(node);
+      return node as HTMLElement;
+    };
+
+    it('announces aria-invalid="true" when the field is invalid', () => {
+      const { input } = open({ error: 'F is required' });
+
+      // richtext read `false` here (its own `!!error` over an undefined prop);
+      // textarea had no attribute at all.
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('announces aria-invalid="false" when the field is valid', () => {
+      const { input } = open({});
+
+      expect(input).toHaveAttribute('aria-invalid', 'false');
+      expect(input).not.toHaveAttribute('aria-errormessage');
+      expect(screen.queryByTestId(`${prefix}-fullscreen-error`)).not.toBeInTheDocument();
+    });
+
+    it('points aria-errormessage at a message node INSIDE the dialog', () => {
+      const { dialog, input } = open({ error: 'F is required' });
+
+      expect(target(input, dialog, 'aria-errormessage')).toHaveTextContent('F is required');
+    });
+
+    it('agrees with the inline control instead of contradicting it', () => {
+      // The defect stated as a relation rather than an attribute value: the two
+      // surfaces are the same field, so they may not disagree about whether it
+      // has failed. Read the inline control BEFORE opening — it stays mounted
+      // behind the overlay either way.
+      const { container } = renderSurface({ error: 'F is required' });
+      const inline = container.querySelector('textarea') as HTMLTextAreaElement;
+      expect(inline).toHaveAttribute('aria-invalid', 'true');
+
+      fireEvent.click(screen.getByTestId(`${prefix}-fullscreen-toggle`));
+
+      expect(screen.getByTestId(dialogInputTestId)).toHaveAttribute(
+        'aria-invalid',
+        inline.getAttribute('aria-invalid')!,
+      );
+    });
+
+    it('gives the dialog control the field name (objectui#4832)', () => {
+      const { dialog, input } = open({ error: 'F is required' });
+
+      expect(input).toHaveAccessibleName('F');
+      // From the visible dialog title, so the label keeps a single author
+      // (#3978) — an `aria-label` string minted by the widget would pass the
+      // line above and fail these two.
+      expect(input).not.toHaveAttribute('aria-label');
+      expect(target(input, dialog, 'aria-labelledby')).toHaveTextContent('F');
+    });
+
+    it('leaves the dialog itself named too', () => {
+      // #3393 put the field label in `DialogTitle` and Radix turns that into the
+      // dialog's own `aria-labelledby`. Naming the control must not be paid for
+      // out of that.
+      open({ error: 'F is required' });
+
+      expect(screen.getByRole('dialog')).toHaveAccessibleName('F');
+    });
+
+    it('renders exactly one copy of the message inside the dialog', () => {
+      // The 2026-08-16 restatement of objectui#3222: one copy of the error text
+      // in the accessibility tree at any moment. The host's `<FormMessage>` is
+      // `aria-hidden` behind the modal for this whole window; a widget that
+      // ALSO printed the text next to its control would put two readable copies
+      // in the dialog.
+      const { dialog } = open({ error: 'F is required' });
+
+      expect(screen.getAllByText('F is required')).toHaveLength(1);
+      expect(dialog).toContainElement(screen.getByText('F is required'));
+    });
+
+    it('drops the message node again when the dialog closes', () => {
+      open({ error: 'F is required' });
+      expect(screen.getByTestId(`${prefix}-fullscreen-error`)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.queryByTestId(`${prefix}-fullscreen-error`)).not.toBeInTheDocument();
+    });
+  },
+);
+
+describe('textarea fullscreen dialog — the counter description still composes (objectui#3417)', () => {
+  it('keeps aria-describedby on the character count and out of the error channel', () => {
+    // `aria-errormessage` is a separate channel from `aria-describedby` on
+    // purpose: this surface's `aria-describedby` already carries the fullscreen
+    // counter's sentence, so folding the message id in would either overwrite
+    // that (trading "no cap announced" for nothing gained) or announce the same
+    // failure twice.
+    render(
+      <TextAreaField
+        value="hello"
+        onChange={() => {}}
+        field={fieldMeta({ maxLength: 500 })}
+        error="F is required"
+      />,
+    );
+    fireEvent.click(screen.getByTestId('textarea-fullscreen-toggle'));
+
+    const input = screen.getByTestId('textarea-fullscreen-input');
+    const describedBy = input.getAttribute('aria-describedby');
+    const errorMessage = input.getAttribute('aria-errormessage')!;
+
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).not.toContain(errorMessage);
+    expect(document.getElementById(describedBy!)).toHaveTextContent(/500/);
+    // Still the counter's description, still owned by the dialog.
+    expect(screen.getByTestId('textarea-fullscreen-dialog')).toContainElement(
+      document.getElementById(describedBy!),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #4824
Fixes #4832

按 2026-08-16 维护者裁定(#4824 评论 5307575529)实施,两单同批同 PR —— 同一批对话框控件、同一段 JSX。**三个面全部落地。**

> **前置门已通过(记录在案)。** 第三面(form.tsx 内置 FullscreenTextarea)与在飞的 #4788 同文件。按门规 60 秒一轮循环等它落 main,**等满 40 轮超时**,当时它连分支都还没 push,遂先按超时分支交付了两个面。随后 #4788 以 PR #4862 落地(`7458a418b`),本分支 `git merge origin/main`(无冲突)后补上第三面。⛔ 全程未抢改同文件;两边的改动落在 form.tsx 的不同区域(它改 `renderFormField` 的只读路径,本 PR 改 `FullscreenTextarea` 与 `case 'textarea'`)。

## 这条修的是什么

`mobile.fullscreenLongText` 是已发布的 opt-in:开了它,手机用户就是在这个全屏对话框里写长文本。#4824 的测量在**字段真的处于校验失败态**时读到:

```
INLINE  richtext  aria-invalid= true
DIALOG  richtext  aria-invalid= false   aria-describedby= null
INLINE  textarea  aria-invalid= true
DIALOG  textarea  aria-invalid= null    aria-describedby= null
```

richtext 那一行是更尖锐的一半:对话框不是「没说」,而是在同一时刻**主动播报了与 inline 面相反的结论** —— 因为 RichTextEditorSurface 用 `aria-invalid={!!error}` 计算,而对话框那次渲染从来没拿到 `error`。#4832 在同一批控件上读可访问名:inline 面 `F`,对话框面全空。

三个渲染面、3/3 全坏,根因是同一个:对话框里那份编辑控件是**宿主从零构造**的,inline 控件从表单渲染器白拿的那套 plumbing 一件都到不了它身上。

### 三面读数(改前 → 改后)

| 面 | aria-invalid | aria-errormessage | 可访问名 |
|---|---|---|---|
| richtext 对话框 | `false`(字段实为 invalid) → `true` | 无 → 对话框内节点 | 空 → `F` |
| textarea 对话框 | 属性缺席 → `true` | 无 → 对话框内节点 | 空 → `F` |
| 内置 textarea 对话框 | 属性缺席 → `true` | 无 → 对话框内节点 | 空 → `F` |

## 落点:E1,一处回答,必填参数交出

`FullscreenEditor`(components 包 primitive)现在接收字段的 `error`,并独占这两件事的答案:

- 在**对话框内部**渲染错误文案节点;
- 把结果作为 children render prop 的**必填第 4 个参数**交给宿主 —— 一个可直接展开的 DOM 属性集,含 `aria-labelledby`(对话框标题的文本节点,即 #3393 已经放在那里的字段 label)、`aria-invalid`、以及单 IDREF 的 `aria-errormessage`。

宿主只管展开,**永远不知道任何 id**。所以它无法指向对话框外的节点、无法把属性组合错、也无法用一个忘了接线的 prop 自己算 `aria-invalid` —— 这三样正是三个面各自出错的方式。让三个宿主各自回答,就是造出三个同样的洞的那个形状。

## 关于 #3222「文案归 FormMessage」

维护者裁定把该规则重述为它一直在保护的东西 —— **同一时刻只有一份错误文案在无障碍树内** —— 而对话框本地的这个节点满足它:它只在对话框打开期间存在(Radix 关闭即卸载),而恰恰在这个窗口里 Radix 把模态外的一切、包括 FormMessage,`aria-hidden` 掉了。两份可读文案的窗口不存在。

⛔ **硬禁,已写进 primitive 的注释与钉子**:把对话框内控件的 `aria-describedby` / `aria-errormessage` 指回模态外那个被 `aria-hidden` 的 FormMessage。它是最省事的写法 —— id 解析得到、节点文字正确、所有关于名与描述的断言都会绿 —— 而它是 ARIA MUST 违规:引用存活的整个期间,目标都是 `aria-hidden` 的。happy-dom 与 jsdom 都直接按 IDREF 算可访问名/描述,**对这条同盲**。

所以本 PR 的每一条 IDREF 断言都**同时**断言容器归属:被指向的节点在**这个**对话框内,而不只是「存在」。第三面那份钉子里还多一条 —— 它是三个面里唯一能对着**真实的 FormMessage** 测的(该分支渲染在 FormControl 里,表单自己的 message 节点就在旁边),所以直接断言 `aria-errormessage` 的 id 不等于表单项的 message id、且该节点不在对话框内。

`aria-errormessage` 只带单 ID(本仓工具链不认列表),且只在 `aria-invalid="true"` 时发出;**刻意不**并进宿主的 `aria-describedby` 链 —— textarea 面那条链上已经有全屏字数计数的句子,钉子断言两者互不污染。

## 可访问名:复用可见文本,不新造名字来源

`aria-labelledby` 指向 DialogTitle **内部的一个 span**,而不是 DialogTitle 本身:Radix 渲染的是 h2 元素并把 `id={context.titleId}` 放在属性展开之前,给 DialogTitle 传 `id` 会**替换掉** DialogContent 自己 `aria-labelledby` 所指的那个 id —— 等于用对话框的名字换控件的名字(#3393 的回退)。钉子两边都钉了:控件有名 **且** 对话框仍有名。

⛔ 不新造 `aria-label` 文案来源(#3978 单一命名通道)—— 钉子里有「控件不带 `aria-label`」这一条,一个自己 mint 字符串的实现会在那里红。

## Breaking(按仓约定发 `minor`),仅 `@object-ui/components`

`FullscreenEditorProps.error` 是**必填**而非可选,`children` 多一个第 4 参数。

render prop 少声明参数在 TS 里合法,所以**真正编译报错的只有 `error`** —— 这正是把它设成必填的理由,也是裁定里「3 个消费者编译强制迁移」的落点。它确实起了作用:第三面未迁移时,type-check 精确地指着那一个调用点(`form.tsx(519,8) error TS2741: Property 'error' is missing ... but required in type 'FullscreenEditorProps'`),迁完即转绿。

每个消费者手上本来就有这个值(注册 widget 从 #3222 的 widget props 契约取 `error`;built-in 分支取 `fieldState.error?.message`),而漏掉 `error` 复现的正是本单的缺陷:表单已经判失败,对话框却播报 `aria-invalid="false"`。可选键被三个面连续忘了三次;必填键忘不掉。

`@object-ui/fields` 记 `patch`:`FullscreenFieldEditor` 是该包内部件(未从入口再导出),公开面无变化。

`minor` 而非 `major` 依仓内既有先例(AGENTS.md 版本号策略,由 `scripts/check-changeset-no-major.mjs` 机械强制):全部可发布包在一个 `fixed` 组里,`major` 会把整组顶上去、脱离 `@objectstack` 的节奏。

## 验证

- 新钉子 3 个文件、合计 **38 条执行用例**,全绿:
  - `packages/components/src/__tests__/fullscreen-editor-dialog-aria.test.tsx` —— primitive 契约,**10 条**;
  - `packages/fields/src/widgets/__tests__/FullscreenFieldEditor.dialogAria.test.tsx` —— 9 个 `it` 块,其中 8 个在 `describe.each` 里对**两个 widget 面**各跑一遍,合计 **17 条**(#4250 的半修教训:同一组断言两个面一起跑,修一个漏一个必红);
  - `packages/components/src/renderers/form/__tests__/form-fullscreen-textarea-dialog-aria.test.tsx` —— 内置面,对着真实 FormMessage 测,**11 条**。这一份是**先写后修**的:实现落地前 `7 failed | 4 passed`,落地后 `11 passed`。
- 合并 main 后的回归扫:`vitest run packages/fields packages/components packages/plugin-form` —— **Test Files 287 passed (287),Tests 3400 passed (3400)**(含 #4788 随 main 带进来的两份新测试)。
- `turbo run type-check --filter=@object-ui/components --filter=@object-ui/fields` —— **Tasks: 12 successful, 12 total**。
- `check-control-bytes`、`check-changeset-fixed`、`check-changeset-no-major`、`check-phantom-dependencies` 全绿;改动文件另做了控制字符自查,无命中。

### 反向验证(先预判,后跑)

变异:把 richtext 对话框面的第 4 参数展开断开(只动 RichTextEditorSurface 那一处),已 commit 后做,复原用 `git checkout --`(⛔ 未用 stash)。

**预判**:红 4 条,且**全部**落在 richtext 面 —— aria-invalid 真值、errormessage 归属、与 inline 面一致、可访问名。

预判里同样写清了**不会**红的部分,因为这才是这条变异的关键:richtext 的「字段有效时播报 `aria-invalid="false"`」**保持绿**,因为断开后该面退回自己的 `aria-invalid={!!error}`、而对话框那次渲染不传 `error`,于是照样渲染出字面的 `false` —— 那正是修复前的缺陷本身,只是在「有效」这一格上碰巧看起来是对的。这也是为什么钉住它的必须是「无效」那一格。同理,错误节点由 primitive 渲染,所以「对话框内只有一份文案」「关闭后节点消失」「对话框自身有名」三条也保持绿。

**实测**:`Tests 4 failed | 23 passed (27)`,四条逐字就是预判的那四条,零条红出现在 richtext 之外。
