### PR TITLE
docs(skills): 三份指南改教发布态 style.css 导入,停教扫 node_modules 源码

### DIFF
--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -237,67 +237,57 @@ For the full expression syntax reference (operators, formula functions, security
 
 ## CSS theming template for third-party apps
 
-Third-party projects must set up Tailwind + Shadcn CSS variables correctly. Without this, Object UI components render unstyled.
+Object UI components render unstyled unless the app's Tailwind entry brings in the
+packages' styles. How it does that depends on where the packages come from — installed
+from npm, or linked inside the ObjectUI workspace. The two cases are not interchangeable.
+
+### Installed from npm (the third-party case)
+
+Import the published stylesheets. There is no `tailwind.config.js` step, and no scanning
+of `node_modules`.
 
 **Required `src/index.css`:**
 ```css
 @import "tailwindcss";
+@import "@object-ui/components/style.css";
+@import "@object-ui/fields/style.css";
+```
 
-/* Scan ObjectUI packages so Tailwind generates their utility classes */
+Each `style.css` is a real package export, mapped to that package's `dist/index.css` and
+compiled at build time from the package's own sources. The components sheet carries every
+utility its components use **and** the `@theme` block those utilities are built on, so the
+whole Shadcn palette and the `:root` / `.dark` token defaults arrive with that one import
+— you do not restate those tokens in a `@theme` block of your own. The order is
+load-bearing: the fields sheet is a supplement compiled against the components theme with
+every rule that sheet already ships subtracted from it, so imported first or alone its
+rules resolve against tokens that are not there yet. `@object-ui/fields` is a separate
+dependency, not a transitive one — install it, or leave that second line out.
+
+Do **not** point Tailwind at the ObjectUI packages inside `node_modules`, with neither a
+v4 `@source` line nor a v3 `content` entry: the published tarballs carry `dist` only, and
+the `@theme` block the themed utilities come from lives in package source, which is not
+published. To recolour, override the token values (Shadcn HSL channel triples) rather than
+the utilities — see `content/docs/guide/theming.md`.
+
+### Inside the ObjectUI workspace
+
+Here the packages are linked to their sources, so Tailwind scans them directly and the app
+owns the theme declaration:
+
+```css
+@import "tailwindcss";
+
+/* Workspace packages are linked to their sources — scan them */
 @source "../../packages/components/src/**/*.tsx";
 @source "../../packages/fields/src/**/*.tsx";
 @source "../../packages/layout/src/**/*.tsx";
 @source "../../packages/react/src/**/*.tsx";
-@source "../../node_modules/@object-ui/components/src/**/*.tsx";
-@source "../../node_modules/@object-ui/fields/src/**/*.tsx";
-
-/* Map Shadcn CSS variables to Tailwind 4 color tokens */
-@theme {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-}
-
-/* Light mode CSS variables (Shadcn defaults) */
-:root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --radius: 0.625rem;
-}
 ```
 
-Adjust `@source` paths based on your project's location relative to `node_modules` or the monorepo root.
+Adjust those paths to your app's location relative to the monorepo root, and add a
+`@source` line per plugin package the app renders. Because the app owns the Tailwind entry
+in this case, it also declares the `@theme` mapping and the `:root` token values;
+`apps/console/src/index.css` is the maintained reference for both.
 
 ## Plugin integration in page schemas
 
@@ -484,7 +474,7 @@ It exposes `ObjectRenderer`, `PageRenderer`, `DashboardRenderer` and matching pr
 - Skipping docs updates for newly introduced schema patterns.
 - Putting expression values in top-level `value`/`label` fields instead of `props.*`.
 - Missing Shadcn CSS variables — components render but look completely unstyled.
-- Forgetting `@source` directives in Tailwind config — utility classes not generated for ObjectUI packages.
+- Forgetting the `@object-ui/components/style.css` and `@object-ui/fields/style.css` imports, or importing them in the wrong order — ObjectUI's utilities never reach the page.
 
 ## Fast triage playbook for ambiguous requests
 

--- a/skills/objectui/guides/project-setup.md
+++ b/skills/objectui/guides/project-setup.md
@@ -25,7 +25,7 @@ The `init` command scaffolds a project with templates: `simple`, `form`, `dashbo
 ```bash
 pnpm create vite my-app --template react-ts
 cd my-app
-pnpm add @object-ui/components @object-ui/core @object-ui/react
+pnpm add @object-ui/components @object-ui/core @object-ui/react @object-ui/fields
 pnpm add -D tailwindcss @tailwindcss/vite postcss
 ```
 
@@ -41,6 +41,7 @@ Then configure the required files (see "Essential configuration files" below).
     "@object-ui/components": "latest",
     "@object-ui/core": "latest",
     "@object-ui/react": "latest",
+    "@object-ui/fields": "latest",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -120,65 +121,47 @@ export default {
 };
 ```
 
-### src/index.css (Shadcn theme)
+### src/index.css (ObjectUI stylesheets)
 
-This file is critical — without it, Object UI components render unstyled.
+This file is critical — without it, Object UI components render unstyled. There is no
+`tailwind.config.js` step: ObjectUI is Tailwind 4, configured in CSS.
 
 ```css
 @import "tailwindcss";
+@import "@object-ui/components/style.css";
+@import "@object-ui/fields/style.css";
+```
 
-/* Scan ObjectUI packages for utility class generation */
-@source "../node_modules/@object-ui/components/src/**/*.tsx";
-@source "../node_modules/@object-ui/fields/src/**/*.tsx";
-@source "../node_modules/@object-ui/layout/src/**/*.tsx";
-@source "../node_modules/@object-ui/react/src/**/*.tsx";
+That is the whole of the styling setup. Each `style.css` is a real package export, mapped
+to that package's `dist/index.css` and compiled at build time from the package's own
+sources: the components sheet carries every utility its components use **and** the
+`@theme` block those utilities are built on, so the whole Shadcn palette
+(`bg-background`, `bg-primary`, `border-input`, `ring-ring`) and the `:root` / `.dark`
+token defaults arrive with it. You do not restate those tokens in a `@theme` block of your
+own.
 
-/* Map Shadcn CSS variables to Tailwind 4 color tokens */
-@theme {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-}
+The order matters: `@object-ui/fields/style.css` is a supplement compiled against the
+components theme, with every rule that sheet already ships subtracted from it. Imported
+first, or alone, its rules resolve against tokens that are not there yet.
 
+Do **not** point Tailwind at the ObjectUI packages inside `node_modules`, with neither a
+v4 `@source` line nor a v3 `content` entry. The published tarballs carry `dist` only, and
+the `@theme` block the themed utilities come from lives in package source, which is not
+published — so scanning them regenerates shape-only utilities the two sheets already carry
+and cannot produce the themed ones at all. Your own `@source` lines (or Tailwind's
+defaults) go on covering *your* source, exactly as before.
+
+To recolour, override the token values rather than the utilities — they are Shadcn HSL
+channel triples, not finished colours:
+
+```css
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --radius: 0.625rem;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
 }
 ```
 
-Adjust `@source` paths to match your project structure relative to `node_modules`.
+See `content/docs/guide/theming.md` for the full token list and the `ThemeProvider` route.
 
 ### tsconfig.json
 
@@ -465,8 +448,9 @@ Access in code: `import.meta.env.VITE_API_BASE_URL`
 ## Troubleshooting
 
 ### Components render unstyled
-- Missing `@source` directives in CSS — Tailwind can't find ObjectUI utility classes
-- Missing `:root` CSS variables — Shadcn components need color tokens
+- Missing the `@object-ui/components/style.css` / `@object-ui/fields/style.css` imports — ObjectUI's own utilities never reach the page
+- The two sheets imported in the wrong order, or the components one left out — the fields sheet carries no tokens of its own
+- Overridden `:root` tokens written as finished colours instead of Shadcn HSL channel triples (`0 0% 100%`), so `hsl(var(--token))` resolves to nothing
 - CSS file not imported in `main.tsx`
 
 ### Module not found errors

--- a/skills/objectui/rules/styling.md
+++ b/skills/objectui/rules/styling.md
@@ -178,61 +178,58 @@ className="overflow-hidden text-ellipsis whitespace-nowrap"
 
 ## Rule: Tailwind 4 CSS Variables Setup
 
-For ObjectUI components to render correctly, third-party projects must include this CSS setup:
+For ObjectUI components to render correctly, a third-party project imports the
+stylesheets the packages **publish**. There is no `tailwind.config.js` step: ObjectUI is
+Tailwind 4, configured in CSS.
+
+**✅ CORRECT:**
+```css
+/* src/index.css */
+@import "tailwindcss";
+@import "@object-ui/components/style.css";
+@import "@object-ui/fields/style.css";
+```
+
+Each `style.css` is a real package export, mapped to that package's `dist/index.css` and
+compiled at build time from the package's own sources.
+
+`@object-ui/components/style.css` is the base of the pair. It carries every utility its
+components use **and** the `@theme` block those utilities are built on, so the whole
+Shadcn palette (`bg-background`, `bg-primary`, `border-input`, `ring-ring`) plus the
+`:root` / `.dark` token defaults arrive with that one import. You do **not** restate
+those tokens in a `@theme` block of your own.
+
+The order is load-bearing. `@object-ui/fields/style.css` is a supplement: it is compiled
+against the components theme and then has every rule that sheet already ships subtracted
+from it, so it holds only what the field widgets add — the tag colour map, the signature
+canvas cursor, and 17 themed utilities such as `hover:bg-accent/30` that no consumer-side
+configuration can generate. Import it first, or alone, and those rules resolve against
+tokens that are not there yet. `@object-ui/fields` is a separate dependency, not a
+transitive one — install it, or leave that second line out.
+
+**❌ FORBIDDEN — pointing Tailwind at the installed packages:**
+
+Do not scan the ObjectUI packages inside `node_modules`, with neither a v4 `@source` line
+nor a v3 `content` entry. It regenerates the shape-only utilities (`inline-flex`,
+`rounded-md`, `h-9`) the two sheets already contain, and it cannot produce the themed ones
+at all: the `@theme` block they come from lives in package source, which is not published
+(the tarballs carry `dist` only). Your own Tailwind entry goes on generating the classes
+*your* source uses, exactly as before.
+
+Inside the ObjectUI workspace the picture is different, and `@source` is right there: the
+packages are linked to their sources, so an app scans `packages/*/src` and declares the
+theme itself. `apps/console/src/index.css` is the maintained reference for that case.
+
+To recolour, override the token **values** rather than the utilities. They are Shadcn HSL
+channel triples, not finished colours:
 
 ```css
-@import "tailwindcss";
-
-/* Scan ObjectUI packages so Tailwind generates their utility classes */
-@source "../../node_modules/@object-ui/components/src/**/*.tsx";
-@source "../../node_modules/@object-ui/fields/src/**/*.tsx";
-@source "../../node_modules/@object-ui/layout/src/**/*.tsx";
-@source "../../node_modules/@object-ui/react/src/**/*.tsx";
-
-/* Map Shadcn CSS variables to Tailwind 4 color tokens */
-@theme {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-ring: var(--ring);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-}
-
-/* Light mode CSS variables (Shadcn defaults) */
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --radius: 0.625rem;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
 }
 ```
 
-**Without this setup, ObjectUI components will render but look completely unstyled.**
+See `content/docs/guide/theming.md` for the full token list and the `ThemeProvider` route.
+
+**Without these imports, ObjectUI components will render but look completely unstyled.**


### PR DESCRIPTION
Fixes #4858

## 改了什么

三份 skill 指南给消费者的 Tailwind 样板是 `@source` 扫 `node_modules/@object-ui/*/src`。
按 #4858 的实测:`components` / `layout` / `react` 三个包的 `files` 只含 `dist`,那三条 glob
今天匹配 **0 个文件**;`fields` 是同族最后一个还把 `src` 装进 tarball 的包(PR #4861 之后也归零)。
三份文件同时 **零提及** `style.css` —— 而 objectui#4059 之后那才是正路。

按 #4858 正文修法 1 改为发布态导入,逐处判别场景:

| 文件 | 行(原) | 场景 | 动作 |
| --- | --- | --- | --- |
| `skills/objectui/rules/styling.md` | 187-190 | published-consumer | 整段样板换成两张 `style.css` 导入 |
| `skills/objectui/guides/page-builder.md` | 251-252 | published-consumer | 同上;同段 247-250 的 `packages/*/src` 是 **monorepo** 路径,**保留** |
| `skills/objectui/guides/project-setup.md` | 131-134 | published-consumer | 整段样板换成两张 `style.css` 导入 |

`page-builder.md` 那段原本把两种路径混在同一个模板里(既 `packages/*/src` 又 `node_modules/*/src`),
已拆成「Installed from npm」与「Inside the ObjectUI workspace」两个场景;工作区的四条 `@source`
原样保留(那是工作区路径,与 tarball 无关,今天有效)。

## 与仓内三处维护中答案的对齐读数

1. **`content/docs/guide/theming.md:66-82`** —— 导入顺序与包清单以它为准:
   `@import "tailwindcss"` → `@import "@object-ui/components/style.css"` → `@import "@object-ui/fields/style.css"`。
   顺序不是装饰:fields 表是**减法补充**(compiled against components theme,再减去 components 已发的每条规则),
   先导或单独导,其规则解析的 token 还不存在。它并写明「Do **not** point Tailwind at the packages inside
   `node_modules`」与「You do not restate those tokens in a config of your own」。
2. **`packages/components/README.md:55-68`** —— 「importing it is the whole of the styling setup」,
   以及 64 行「You do **not** add a `@source` line for `node_modules/@object-ui/components`」,
   理由与上同(shape-only utility 重复生成,主题化的仍生成不出)。
3. **`packages/cli/src/utils/app-generator.ts:329-337`** —— scaffold 的两个分支:非 monorepo 扫
   **dist**(`@source '../node_modules/@object-ui/*/dist/**/*.js';`),monorepo 扫 `packages/components/src`
   与 `packages/plugin-*/src`。**从不扫已发布的 `src`** —— 与本 PR 删掉的正是同一条判据。

第四处旁证(非派发指定,实读时撞上):`packages/fields/src/index.css:1-24` 的文件头把消费者该写的
两行原样写着,并说明「the import ORDER above is not cosmetic」。

## 一处超出「只换 @source」的改动,以及为什么必须一起改

三份样板在 `@source` 之后还重述了一份 `@theme` + `:root` token 表,用的是 **oklch 字面色** 配
`--color-x: var(--x)`;而发布的 `style.css`(源自 `packages/components/src/index.css`)走
**Shadcn HSL 通道值** 配 `--color-x: hsl(var(--x))`,并且自带 `:root` / `.dark` 默认值。

两者并存会让 components 已编译好的 utility 拿到 `hsl(oklch(1 0 0))` —— 无效值。也就是说:**只把
`@source` 换成 `style.css` 导入、却留下那份 token 表,会把「不生成 utility」换成「颜色全废」**,
比改之前更糟。theming.md 与 components README 都明说这些 token 不该由消费者重述,故一并删除;
需要改色的场景改成按 theming.md 的 HSL 通道值覆盖 token,并指向该文档。

`project-setup.md` 的依赖清单同步加了 `@object-ui/fields`(实测 `@object-ui/components` 的
`dependencies` 不含 fields,不是传递依赖),否则新模板里第二行导入解析不到。

## 验证

- `pnpm exec vitest run scripts/__tests__/ --maxWorkers=2`(套 flock):**46 files / 1065 tests passed**。
  `check-skills-paths` 的钉子里没有引用这三份文件的行号或内容(只有 `console-development.md` 有 per-file 钉),
  无需更新。
- `node scripts/check-skills-paths.mjs`:OK,93/94 stated path 解析(新增的 `apps/console/src/index.css`
  与 `content/docs/guide/theming.md` 两处散文坐标都落在实文件上)。
- `node scripts/check-control-bytes.mjs`:OK(4345 tracked text files);另做超出门的自扫
  `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 三份文件,零命中。
- 仓根 `turbo run type-check --concurrency=2`:**81 successful, 81 total**(本 PR 纯 markdown,预期无影响,
  按流程跑满)。
- `node scripts/check-changeset-presence.mjs`:「0 of them under the src/ of a package the release covers …
  **No source of a released package changed in this range, so no changeset is owed**」—— 故本 PR 不带 changeset。

### 反向验证(方向先判后跑)

预判:**没有任何门会红**。判据是两条 —— `check-skills-paths` 明确只读散文里的行内 code span、
**从不读 fenced block**,且其 `PATH_PREFIXES` 只有 `apps|packages|examples|scripts|content`
(`node_modules/...` 不在内,且含 `**` 会被 pattern 规则排除)。实跑:把 `styling.md` 整份还原成旧样板后,
`check-skills-paths` 仍 OK(91/92)、`check-control-bytes` 仍 OK、`check-skills-paths.test.ts` 31 tests 全绿。
与 #4858 正文的判断一致 —— **今天唯一看得见这类样板的判据是 grep 自查读数**:
三份文件里 `node_modules/@object-ui` 与 `/src` 的组合由 4 处归零(全 `skills/` 树为 0),
`style.css` 在每份文件的样板里都出现。还原用 `git checkout`,未用 stash。

机制化的门(#4858 方向 2)按派发不在本单做 —— 与 #4846 记的产物级判据同族成本。

## 顺序

本 PR 落 main 后,跟着旧样板走的项目不会经历「fields 的 shape utility 也没了」这一步,
再放 PR #4861(#4856,fields `files` 去 `src`)。

## 相邻缺陷(未在本 PR 修,已立新单)

- #4865 —— `skills/objectui/SKILL.md:140` 的「Common Mistakes」仍教「加 `@source`」,
  `skills/objectui/evals/project-setup.json` 三条 eval 的 `must_contain` 仍把 `@source` / `@theme` /
  `:root` 当正确答案(仓内无 harness 读它,今天不影响任何门)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_