### PR TITLE
docs(i18n): 把 engine.* 的 en/zh 立场写进 i18n 惯例文档 (#4662)

### DIFF
--- a/.changeset/engine-i18n-carveout-recorded.md
+++ b/.changeset/engine-i18n-carveout-recorded.md
@@ -1,0 +1,13 @@
+---
+---
+
+Docs only (objectui#4662): records the `engine.*` carve-out where the i18n
+conventions live — `packages/i18n/README.md` gains a "Scope" section stating
+that the metadata-admin (Studio) namespace resolves through a module-local
+`en`/`zh` table rather than the ten locale packs, why that is Phase 3f design
+rather than drift (the server's `/meta/types` `label` is the primary path; the
+table is the fallback), the two consequences (eight locales render English
+there; the i18n gates cannot see the namespace by construction), and the
+condition for revisiting it. `packages/app-shell/src/views/metadata-admin/i18n.ts`
+gains a header note pointing at that section — a comment-only edit. No key was
+migrated, no locale pack was touched, and no published behaviour changes.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -37,6 +37,20 @@
  * more machinery than the defect is worth). Follow it when adding a value; the
  * designer renders inside the console shell, so a `...` here lands on the same
  * screen as a `…` from the packs.
+ *
+ * ## The same posture, recorded on the i18n conventions side (objectui#4662)
+ *
+ * Everything above is this file's own account of why it exists.
+ * `packages/i18n/README.md`, section "Scope — the `engine.*` carve-out", states
+ * it from the pack system's end, where a reader looking for the translation
+ * conventions finds it, and adds the two facts this header does not spell out:
+ * only `en` and `zh` are covered, so the other eight shipped locales render
+ * English on these screens; and the i18n gates cannot see it by construction
+ * (key parity compares pack against pack, and `scripts/check-i18n-call-site-keys.mjs`
+ * skips this module by declaration). It also carries the condition for
+ * reopening the question, which is deliberately narrow: a stated demand for an
+ * admin console in a language other than `en` or `zh` — not a general wish for
+ * broader locale coverage. Keep the two records in step when either moves.
  */
 
 import { useObjectTranslation } from '@object-ui/i18n';

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -135,6 +135,48 @@ isRTL('ar'); // true
 isRTL('en'); // false
 ```
 
+## Scope — the `engine.*` carve-out (metadata-admin / Studio)
+
+Not every user-facing string in this repository resolves through these packs.
+The metadata-admin (Studio) surface — the metadata directory, the inspectors,
+package management, the flow designer and their refusal messages — resolves its
+`engine.*` keys through a module-local **two-locale** table in
+[`packages/app-shell/src/views/metadata-admin/i18n.ts`](../app-shell/src/views/metadata-admin/i18n.ts):
+a plain `Record` lookup over `en-US` and `zh-CN`, not an i18next namespace.
+Roughly 1,300 keys per locale live there, and **no `engine.*` key exists in any
+of the ten packs.**
+
+That is design, not drift — the file's header records it as "Phase 3f". The
+server holds the primary path: the engine consumes `label` from the
+`/meta/types` response, sourced from the platform's metadata-type registry. The
+module-local table is a **fallback** for deployments with no translation bundles
+configured, and the interim source of truth for Chinese until the platform's
+`setup.translation.ts` ships zh-CN coverage. Copying the namespace into the
+packs would duplicate strings whose primary source is a server response.
+
+Two consequences follow, and both are accepted rather than outstanding work:
+
+- **Only `en` and `zh` are covered.** On an `ar` / `de` / `es` / `fr` / `ja` /
+  `ko` / `pt` / `ru` console, `engine.*` strings render English. That is the
+  price of the carve-out, not a backfill someone forgot.
+- **The i18n gates cannot see this namespace, by construction.** Key parity
+  ([`src/__tests__/all-locales-key-parity.test.ts`](./src/__tests__/all-locales-key-parity.test.ts))
+  compares pack against pack, and `engine.*` is in no pack — so it is not an
+  *exception* to that test, it is outside its subject. The call-site gate
+  ([`scripts/check-i18n-call-site-keys.mjs`](../../scripts/check-i18n-call-site-keys.mjs))
+  skips these call sites **by declaration**: the module is registered in its
+  `EXCLUDED_TRANSLATORS` list with a reason, and an imported `t` from any
+  unregistered module is a hard error there — so a second local table cannot
+  appear silently, and this carve-out cannot quietly widen.
+
+**When to revisit.** Migrating the namespace into the packs is mechanical but
+wide (~1,300 keys × 8 further locales) and argues against the server-driven
+design above, so it is not worth doing speculatively. The condition to reopen it
+is concrete: a stated demand for an admin console in a language other than `en`
+or `zh` — not a general wish for broader locale coverage, which the packs
+already serve on every other surface. See objectui#4662 for the measurement and
+the ruling.
+
 ## Links
 
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/i18n)


### PR DESCRIPTION
Fixes #4662

按 2026-08-16 维护者裁定(评论 5306093125,方案 A)执行:**记录立场,不迁移 key**。docs-only。

## 前提复核(origin/main @ 65e88e6c2)

issue 的事实基础全部复现,无一失效:

- `packages/app-shell/src/views/metadata-admin/i18n.ts` 4299 行;`ENGINE_STRINGS_EN` 1305 个 `engine.*` key、`ENGINE_STRINGS_ZH` 1349 个。
- 十个语言包里 `engine.*` key 数为 **0**(`grep -c engine packages/i18n/src/locales/*.ts` 全 0)。
- 文件头确实把这套两语言表记为 Phase 3f 的**设计**:服务端 `/meta/types` 的 `label` 为主路径,本地表是无翻译包环境的兜底 + zh-CN 的过渡真源。

命名空间分布(en 侧):`studio` 414、`inspector` 377、`packages` 95、`edit` 82,其余为 flow 设计器 / 诊断 / 目录等 —— 即整个 Studio 管理台面。

## 落点选择

**`packages/i18n/README.md`**,新增一节 `Scope — the engine.* carve-out (metadata-admin / Studio)`。

选它的理由:仓内**没有**独立的 i18n 惯例文档 —— `content/docs/**` 无任何 i18n 页;`skills/objectui/guides/i18n.md` 是面向应用作者的对外技能指南,内部管理台的 carve-out 放进去不合适;三道 i18n 门的惯例各自记在自己的脚本头里。十语言包体系对外的权威落点就是这个包 README,因此按「⛔ 自创新文档除非确无既有落点」的要求,补进既有文档而非新建。

## 补的是什么(避免复述)

已有三处记录彼此一致,均未被改动:

| 已有记录 | 说了什么 |
|---|---|
| `i18n.ts` 文件头 | 为什么存在(Phase 3f、服务端 label 为主) |
| `scripts/check-i18n-call-site-keys.mjs` | 门为什么跳过它(1074 个调用点、移除排除项实测 89 个永久假红) |
| `EXCLUDED_TRANSLATORS` | 按声明跳过,且未注册模块的 `t` 导入是硬错误 |

**新增的三点是这三处都没有的**:

1. **语言后果** —— 只覆盖 en/zh,ar/de/es/fr/ja/ko/pt/ru 八个语言在这些页面渲染英文;这是 carve-out 的代价,不是漏做的 backfill。
2. **门为什么看不见** —— key parity 是包与包相比,`engine.*` 不在任何包里,所以它**不是该测试的例外,而是在其主题之外**(刻意与该测试头部「唯一允许的例外是 outbound 消息集」区分,没去动那个测试)。
3. **重启条件** —— 收窄到具体信号:出现**非 en/zh 管理台**的明确需求时重看;泛泛的「多语言覆盖」诉求不算,那部分包体系在其他所有面上已经服务到位。

另在 `i18n.ts` 文件头补一段指回该节,两处互指,并写明「任一处变动时保持同步」。

## 验证

docs-only 改动,**没有任何门会因为这段文字的措辞变红**,如实说明判据:

- **有门看得见的部分**:`packages/i18n/README.md` 在 `check-doc-links.mjs` 的 `SCAN_ROOTS` 里(`packages/*/README.md`,`disk` 规则),新增的三个相对链接受该门覆盖。**反向验证**(方向预判为红,结果一致):把 `../app-shell/src/views/metadata-admin/i18n.ts` 改成不存在的 `i18n-NOPE.ts`,门立刻报 `Found 1 broken link (1 distinct target) ... [example-relative]` 并 exit 1;改回后 `Links are valid across 13 scan roots.`
- **无门看得见的部分**:正文与既有记录是否一致,靠人读对齐 —— 已逐条比对 `i18n.ts` 文件头、call-site 门头部、`EXCLUDED_TRANSLATORS` 的 reason,无矛盾表述。

跑过的门(全绿):

```
node scripts/check-doc-links.mjs        -> Links are valid across 13 scan roots.
node scripts/check-control-bytes.mjs    -> OK (scanned 4354 tracked text file(s); skipped 85 binary)
node scripts/check-i18n-call-site-keys.mjs -> Every in-scope call-site key resolves against the en pack (2890 keys)...
node scripts/check-i18n-en-drift.mjs    -> No en value changed in this range.
node scripts/check-skills-paths.mjs     -> OK (93/94 stated path(s) resolve; 1 baselined)
node scripts/check-changeset-fixed.mjs / check-changeset-no-major.mjs -> OK
```

type-check(改到了 `.ts` 文件头注释,仓根 turbo,scoped):

```
pnpm exec turbo run type-check --filter=@object-ui/app-shell --filter=@object-ui/i18n --concurrency=2
Tasks:    31 successful, 31 total
```

测试:

```
pnpm exec vitest run packages/i18n/src/__tests__/all-locales-key-parity.test.ts \
                     packages/app-shell/src/views/metadata-admin/studio-locale.i18n.test.tsx --maxWorkers=2
Test Files  2 passed (2)
     Tests  37 passed (37)
```

## changeset

`.changeset/engine-i18n-carveout-recorded.md`,**空 frontmatter**。这是门自己的读数,不是我的判断:因为动了 `packages/app-shell/src/**`(纯注释),`check-changeset-presence.mjs` 先判红要求声明;空 frontmatter 是它文档化的一等通过方式("declared as releasing nothing, which is the explicit exemption and a complete answer to this gate"),补上后:

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
```

## 边界

⛔ 未迁移任何 key;⛔ 未动十语言包;⛔ 未碰 `content/docs/releases/**`;⛔ 未改 `all-locales-key-parity.test.ts`(`engine.*` 不是它的例外,加进去反而会误导)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_