### PR TITLE
fix(gantt,map,calendar): 三份私有 sort→$orderby 副本收敛到 core 共享 sink

### DIFF
--- a/.changeset/gantt-map-calendar-shared-sort-sink.md
+++ b/.changeset/gantt-map-calendar-shared-sort-sink.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/plugin-gantt': patch
+'@object-ui/plugin-map': patch
+'@object-ui/plugin-calendar': patch
+---
+
+`object-gantt` / `object-map` / `object-calendar` no longer drop a sort entry that omits `order`.
+
+The three blocks each inlined a byte-identical private copy of the `sort` →
+`$orderby` conversion. That copy required BOTH `field` and `order` on an array
+entry and silently skipped any entry missing one, so a stored view sorting by
+`[{ field: 'amount' }]` reached the wire with no ordering at all — the authored
+sort key was lost, not applied. The same copy already treated the STRING
+spelling `"amount"` as ascending, so this was an inconsistency between two
+spellings of one thing rather than deliberate strictness.
+
+All three now import the shared `convertSortToQueryParams` sink from
+`@object-ui/core` (introduced by objectstack#7137, already used by
+`object-timeline` and `record:line_items`), and the private copies are gone —
+the sink is the repo's only definition. Two behavior changes come with it, both
+of which make the blocks more faithful to what is already declared rather than
+more tolerant:
+
+- An array entry that omits `order` now orders ASCENDING instead of vanishing.
+  That is what `QueryParams.$orderby`'s own member shape
+  (`{ field: string; order?: 'asc' | 'desc' }`) says, and what
+  `@object-ui/data-objectstack`'s `serializeOrderBy` already did with a missing
+  direction.
+- When nothing orderable was authored, the query now carries no `$orderby` at
+  all instead of an empty object. `{}` is truthy and meant "no ordering" only by
+  accident of the adapter's serializer.
+
+Reachability, so the size of this is not overstated: `SortConfig.order` and
+`ElementDataSourceSort.order` are REQUIRED in objectui's own types, so a typed
+caller could never author the dropped shape. The affected surface is untyped
+stored view metadata (`ElementSavedView` is a loose record by design) — which is
+exactly where an order-less entry can arrive today.

--- a/packages/core/src/utils/sort-query.ts
+++ b/packages/core/src/utils/sort-query.ts
@@ -17,21 +17,23 @@
  * accepts four shapes; normalizing here means one shape reaches the wire and a
  * block does not have to know which spelling its author used.
  *
- * This is the same conversion three sibling blocks already inline privately
- * (`ObjectGantt` / `ObjectMap` / `ObjectCalendar`, byte-identical copies). It is
- * hoisted here because objectstack#7137 added two more read sites
- * (`object-timeline`, `record:line_items`), and a fifth and sixth private copy is
- * how the conversions start disagreeing. Collapsing the three existing copies
- * onto this one is deliberately NOT part of #7137 — it is tracked as
- * objectstack#7148.
+ * This is now the ONLY definition in the repo. It was hoisted here because
+ * objectstack#7137 added two more read sites (`object-timeline`,
+ * `record:line_items`) next to three sibling blocks that each inlined a
+ * byte-identical private copy (`ObjectGantt` / `ObjectMap` / `ObjectCalendar`),
+ * and a fifth and sixth copy is how the conversions start disagreeing. Those
+ * three copies were deliberately left alone by #7137 and collapsed onto this
+ * function by objectui#4022; every block now imports it from here.
  *
- * Two deliberate differences from those private copies, both of which make this
- * function more faithful to the declared contract rather than adding tolerance:
+ * Two deliberate differences from those retired private copies, both of which
+ * make this function more faithful to the declared contract rather than adding
+ * tolerance — and both are BEHAVIOUR CHANGES the migration delivered, not pure
+ * refactor:
  *
  *  - **`order` is optional in `SortConfig`**, so an entry that omits it means
  *    ascending (that is what `$orderby`'s own
  *    `Array<{ field: string; order?: 'asc' | 'desc' }>` shape says). The private
- *    copies require BOTH keys and silently drop such an entry, which loses an
+ *    copies required BOTH keys and silently dropped such an entry, which lost an
  *    authored sort key instead of ordering by it.
  *  - **Nothing usable yields `undefined`, never `{}`.** An empty object is a
  *    truthy value that means "no ordering" only by accident of the adapter's

--- a/packages/plugin-calendar/src/ObjectCalendar.elementDataSource.test.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.elementDataSource.test.tsx
@@ -33,6 +33,17 @@ const HOT_VIEW = {
   pagination: { pageSize: 7 },
 };
 
+/**
+ * A sort entry that omits `order` — reachable only through UNTYPED saved-view
+ * metadata (`ElementSavedView` is `Record< string, unknown >`; `SortConfig.order`
+ * is required in objectui's own types). See objectui#4022.
+ */
+const PARTIAL_SORT_VIEW = {
+  name: 'partial',
+  label: 'Partially ordered',
+  sort: [{ field: 'starts_at' }, { field: 'name', order: 'desc' }],
+};
+
 const CALENDAR = { startDateField: 'starts_at', endDateField: 'ends_at', titleField: 'name' };
 
 function makeAdapter(listViews: Record<string, unknown> = { hot: HOT_VIEW }) {
@@ -74,7 +85,10 @@ describe('object-calendar — dataSource: { object, view } (objectstack#6953)', 
     const [object, params] = adapter.find.mock.calls[0] as [string, any];
     expect(object).toBe('account');
     expect(params.$filter).toEqual([['rating', '=', 'hot']]);
-    expect(params.$orderby).toBeTruthy();
+    // Was `toBeTruthy()`, which an EMPTY object also satisfies — the one value the
+    // old private copy produced when it had dropped every entry. Pinned to the
+    // actual map so this case can still fail for the right reason (objectui#4022).
+    expect(params.$orderby).toEqual({ name: 'desc' });
   });
 
   it('reports an unresolvable `view` instead of fetching the whole object', async () => {
@@ -106,5 +120,20 @@ describe('object-calendar — dataSource: { object, view } (objectstack#6953)', 
     const [object, params] = adapter.find.mock.calls[0] as [string, any];
     expect(object).toBe('account');
     expect(params.$filter).toEqual([['owner', '=', 'me']]);
+  });
+
+  it('orders by a sort entry that omits `order` instead of dropping it', async () => {
+    const adapter = makeAdapter({ partial: PARTIAL_SORT_VIEW });
+    renderBlock(
+      { type: 'object-calendar', calendar: CALENDAR, dataSource: { object: 'account', view: 'partial' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    const [, params] = adapter.find.mock.calls[0] as [string, any];
+    // The private copy required BOTH keys and silently dropped `starts_at`,
+    // sending `{ name: 'desc' }`. The shared sink reads a missing `order` as
+    // ascending — what `QueryParams.$orderby`'s member shape declares.
+    expect(params.$orderby).toEqual({ starts_at: 'asc', name: 'desc' });
   });
 });

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -46,7 +46,12 @@ import {
   Label,
   toast,
 } from '@object-ui/components';
-import { extractRecords, buildExpandFields, getRecordDisplayName } from '@object-ui/core';
+import {
+  extractRecords,
+  buildExpandFields,
+  convertSortToQueryParams,
+  getRecordDisplayName,
+} from '@object-ui/core';
 
 export interface CalendarSchema {
   type: 'calendar';
@@ -119,33 +124,6 @@ function getDataConfig(schema: ObjectGridSchema | CalendarSchema): ViewData | nu
   }
   
   return null;
-}
-
-/**
- * Helper to convert sort config to QueryParams format
- */
-function convertSortToQueryParams(sort: string | any[] | undefined): Record<string, 'asc' | 'desc'> | undefined {
-  if (!sort) return undefined;
-  
-  // If it's a string like "name desc"
-  if (typeof sort === 'string') {
-    const parts = sort.split(' ');
-    const field = parts[0];
-    const order = (parts[1]?.toLowerCase() === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc';
-    return { [field]: order };
-  }
-  
-  // If it's an array of SortConfig objects
-  if (Array.isArray(sort)) {
-    return sort.reduce((acc, item) => {
-      if (item.field && item.order) {
-        acc[item.field] = item.order;
-      }
-      return acc;
-    }, {} as Record<string, 'asc' | 'desc'>);
-  }
-  
-  return undefined;
 }
 
 /**

--- a/packages/plugin-gantt/src/ObjectGantt.elementDataSource.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.elementDataSource.test.tsx
@@ -49,6 +49,19 @@ const HOT_VIEW = {
   pagination: { pageSize: 7 },
 };
 
+/**
+ * A sort entry that omits `order` is only reachable through UNTYPED saved-view
+ * metadata: `SortConfig.order` / `ElementDataSourceSort.order` are REQUIRED in
+ * objectui's own types, so a typed caller cannot spell this, while
+ * `ElementSavedView` is `Record< string, unknown >` by design. That is the
+ * authoring surface this fixture stands in for (objectui#4022).
+ */
+const PARTIAL_SORT_VIEW = {
+  name: 'partial',
+  label: 'Partially ordered',
+  sort: [{ field: 'end_date' }, { field: 'name', order: 'desc' }],
+};
+
 const GANTT = { startDateField: 'start_date', endDateField: 'end_date', titleField: 'name' };
 
 function makeAdapter(listViews: Record<string, unknown> = { hot: HOT_VIEW }) {
@@ -162,5 +175,38 @@ describe('object-gantt — dataSource: { object, view } (objectstack#7121)', () 
     expect(object).toBe('task');
     expect(params.$filter).toEqual([['owner', '=', 'me']]);
     expect(params.$orderby).toEqual({ end_date: 'asc' });
+  });
+
+  it('orders by a sort entry that omits `order` instead of dropping it', async () => {
+    const adapter = makeAdapter({ partial: PARTIAL_SORT_VIEW });
+    renderBlock(
+      { type: 'object-gantt', gantt: GANTT, dataSource: { object: 'task', view: 'partial' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    const [, params] = adapter.find.mock.calls[0] as [string, any];
+    // The private copy this block used to inline required BOTH keys and silently
+    // dropped `end_date`, sending `{ name: 'desc' }` — an authored sort key lost
+    // on the way to the wire. The shared sink reads a missing `order` as
+    // ascending, which is what `QueryParams.$orderby`'s own member shape
+    // (`{ field: string; order?: 'asc' | 'desc' }`) declares, and what the string
+    // spelling (`"end_date"`) already meant in the very same copy.
+    expect(params.$orderby).toEqual({ end_date: 'asc', name: 'desc' });
+  });
+
+  it('sends NO $orderby when nothing orderable was authored', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      { type: 'object-gantt', objectName: 'task', gantt: GANTT, sort: [] },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    const [, params] = adapter.find.mock.calls[0] as [string, any];
+    // The private copy reduced an empty array to `{}` — a TRUTHY value that only
+    // means "no ordering" by accident of the adapter serializer. `undefined` says
+    // it outright, so the query simply carries no `$orderby`.
+    expect(params.$orderby).toBeUndefined();
   });
 });

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -40,7 +40,13 @@ import {
   AlertDialogTitle,
   cn,
 } from '@object-ui/components';
-import { extractRecords, buildExpandFields, getRecordDisplayName, resolveDataSource } from '@object-ui/core';
+import {
+  extractRecords,
+  buildExpandFields,
+  convertSortToQueryParams,
+  getRecordDisplayName,
+  resolveDataSource,
+} from '@object-ui/core';
 import {
   getSemanticColorName,
   getSemanticHex,
@@ -307,33 +313,6 @@ function getDataConfig(schema: ObjectGridSchema): ViewData | null {
   }
   
   return null;
-}
-
-/**
- * Helper to convert sort config to QueryParams format
- */
-function convertSortToQueryParams(sort: string | any[] | undefined): Record<string, 'asc' | 'desc'> | undefined {
-  if (!sort) return undefined;
-  
-  // If it's a string like "name desc"
-  if (typeof sort === 'string') {
-    const parts = sort.split(' ');
-    const field = parts[0];
-    const order = (parts[1]?.toLowerCase() === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc';
-    return { [field]: order };
-  }
-  
-  // If it's an array of SortConfig objects
-  if (Array.isArray(sort)) {
-    return sort.reduce((acc, item) => {
-      if (item.field && item.order) {
-        acc[item.field] = item.order;
-      }
-      return acc;
-    }, {} as Record<string, 'asc' | 'desc'>);
-  }
-  
-  return undefined;
 }
 
 /**

--- a/packages/plugin-map/src/ObjectMap.elementDataSource.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.elementDataSource.test.tsx
@@ -44,6 +44,17 @@ const HOT_VIEW = {
   pagination: { pageSize: 7 },
 };
 
+/**
+ * A sort entry that omits `order` — reachable only through UNTYPED saved-view
+ * metadata (`ElementSavedView` is `Record< string, unknown >`; `SortConfig.order`
+ * is required in objectui's own types). See objectui#4022.
+ */
+const PARTIAL_SORT_VIEW = {
+  name: 'partial',
+  label: 'Partially ordered',
+  sort: [{ field: 'rating' }, { field: 'name', order: 'desc' }],
+};
+
 const MAP = { latitudeField: 'lat', longitudeField: 'lng', titleField: 'name' };
 
 function makeAdapter(listViews: Record<string, unknown> = { hot: HOT_VIEW }) {
@@ -148,5 +159,20 @@ describe('object-map — dataSource: { object, view } (objectstack#7121)', () =>
     expect(object).toBe('store');
     expect(params.$filter).toEqual([['owner', '=', 'me']]);
     expect(params.$orderby).toEqual({ name: 'asc' });
+  });
+
+  it('orders by a sort entry that omits `order` instead of dropping it', async () => {
+    const adapter = makeAdapter({ partial: PARTIAL_SORT_VIEW });
+    renderBlock(
+      { type: 'object-map', map: MAP, dataSource: { object: 'store', view: 'partial' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    const [, params] = adapter.find.mock.calls[0] as [string, any];
+    // The private copy required BOTH keys and silently dropped `rating`, sending
+    // `{ name: 'desc' }`. The shared sink reads a missing `order` as ascending —
+    // what `QueryParams.$orderby`'s member shape declares.
+    expect(params.$orderby).toEqual({ rating: 'asc', name: 'desc' });
   });
 });

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -24,7 +24,7 @@ import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react'
 import type { ObjectGridSchema, DataSource, ViewData } from '@object-ui/types';
 import { useNavigationOverlay } from '@object-ui/react';
 import { NavigationOverlay, cn, useIsMobile } from '@object-ui/components';
-import { extractRecords, buildExpandFields } from '@object-ui/core';
+import { extractRecords, buildExpandFields, convertSortToQueryParams } from '@object-ui/core';
 import { z } from 'zod';
 import MapGL, { NavigationControl, Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef } from 'react-map-gl/maplibre';
@@ -105,33 +105,6 @@ function getDataConfig(schema: ObjectGridSchema): ViewData | null {
   }
   
   return null;
-}
-
-/**
- * Helper to convert sort config to QueryParams format
- */
-function convertSortToQueryParams(sort: string | any[] | undefined): Record<string, 'asc' | 'desc'> | undefined {
-  if (!sort) return undefined;
-  
-  // If it's a string like "name desc"
-  if (typeof sort === 'string') {
-    const parts = sort.split(' ');
-    const field = parts[0];
-    const order = (parts[1]?.toLowerCase() === 'desc' ? 'desc' : 'asc') as 'asc' | 'desc';
-    return { [field]: order };
-  }
-  
-  // If it's an array of SortConfig objects
-  if (Array.isArray(sort)) {
-    return sort.reduce((acc, item) => {
-      if (item.field && item.order) {
-        acc[item.field] = item.order;
-      }
-      return acc;
-    }, {} as Record<string, 'asc' | 'desc'>);
-  }
-  
-  return undefined;
 }
 
 const isDev = (): boolean =>


### PR DESCRIPTION
Fixes #4022

## 前提复核(按 origin/main `65e88e6c2`)

卡的前提成立,一处行号漂移:三份逐字副本仍在,但 calendar 那份已从 `ObjectCalendar.tsx:111` 漂到 `:127`(gantt `:315`、map `:113` 与卡内读数一致)。三份互为逐字副本这一点复核无误。

伴随卡 #4038 **未并入**:认领时点它已 `closed`(completed,PR #4267 于 08-11 合入),晋级评论给的前提「仍 open 且无人认领」不满足,故 `ListViewBlock` 一字未碰。

## 改了什么

三处删除本地 `convertSortToQueryParams`,改为从 `@object-ui/core` 导入共享 sink(三个包本就已依赖 `@object-ui/core`,且都已从它导入 `extractRecords` / `buildExpandFields`,故无新增依赖)。

**退役核验(声明式 grep)**:`grep -rn "function convertSortToQueryParams" packages/` 全仓仅剩 `packages/core/src/utils/sort-query.ts:60` 一条 —— sink 是唯一定义。

## 副本 vs sink 的语义差(这是 behavior fix,不是纯重构)

两处差异都是**更贴合已声明的契约**,不是新增容忍:

1. **数组项缺 `order` → 升序,不再丢弃。** 副本要求 `item.field && item.order` 两者皆真,否则 `continue`,于是 `sort: [{ field: 'amount' }]` 静默丢掉整条排序。同一份副本对**字符串**写法(`"amount"`)却早已按升序处理 —— 这是两种写法之间的不一致,不是刻意的严格。`QueryParams.$orderby` 自己声明的成员形状即 `{ field: string; order?: 'asc' | 'desc' }`(order 可选),`@object-ui/data-objectstack` 的 `serializeOrderBy` 对缺方向同样按升序。
2. **无可排序内容 → `undefined`,不再是 `{}`。** 空对象是 truthy 值,只是恰好被 adapter 序列化器当成「无排序」。

另有两处副本的边角行为一并被 sink 收掉,均在已声明契约之外、无消费者依赖,记录以免读者以为是遗漏:字符串路径副本用 `split(' ')` 且不 trim,`"name  desc"`(双空格)会被读成升序、`"   "` 会产出 `{ '': 'asc' }` 这种空字段名条目;sink 用 `trim().split(/\s+/)` 并在字段名为空时返回 `undefined`。数组路径副本把 `item.order` 原样写出(`order: 'DESC'` 会照抄),sink 归一到 `'desc'` / `'asc'` 两值。

## 钉子(每个消费点一条,可达面是存视图元数据)

可达性说明,免得把严重度判高:`SortConfig.order` / `ElementDataSourceSort.order` 在 objectui 自己的类型里都是**必填**,类型化调用方写不出缺 order 的项;能走到这里的只有未类型化的已存视图元数据(`ElementSavedView` 按设计是松记录)。三条钉子因此都走 saved-view 路径,而不是直接喂 `schema.sort` —— 钉在真正可达的authoring surface 上。

- `ObjectGantt.elementDataSource.test.tsx` — 新增 2 条:缺 order 项不丢(`{ end_date: 'asc', name: 'desc' }`);无可排序内容时不下发 `$orderby`。
- `ObjectMap.elementDataSource.test.tsx` — 新增 1 条:缺 order 项不丢(`{ rating: 'asc', name: 'desc' }`)。
- `ObjectCalendar.elementDataSource.test.tsx` — 新增 1 条同上(`{ starts_at: 'asc', name: 'desc' }`);并把原有的 `expect(params.$orderby).toBeTruthy()` 收紧为 `toEqual({ name: 'desc' })` —— **空对象同样 truthy**,而 `{}` 正是旧副本把所有项丢光时的产物,该断言原本无法为正确的理由失败(fixture 三分法里的「整例替换」同因)。

## 反向验证(方向为**先预判后执行**)

预判:把 gantt 一处 import 换回本地副本后,**该消费点的两条新钉子转红并指名缺陷,而原有 5 条保持绿** —— 原有 5 条喂的都是 `{ field, order }` 齐全的项,两份实现对它们逐字节同解,**它们不具备判别力**,这点如实记录而不是假装它们也守住了。

实测与预判逐条吻合:

```
 ✓ queries the bound object with the saved view's filter and sort
 ✓ narrows, never widens: the binding's own filter ANDs with the view's
 ✓ reports an unresolvable `view` instead of fetching the whole object
 ✓ writes NO row cap: the gantt reload issues no $top for one to land on
 ✓ leaves a gantt with NO dataSource exactly as it was
 × orders by a sort entry that omits `order` instead of dropping it
   → expected { name: 'desc' } to deeply equal { end_date: 'asc', name: 'desc' }
 × sends NO $orderby when nothing orderable was authored
   → expected {} to be undefined
 Test Files  1 failed (1)
      Tests  2 failed | 5 passed (7)
```

两条红都精确复现了卡里描述的缺陷本体:`end_date` 被丢掉、空对象取代 `undefined`。随后 `git checkout --` 还原(未用 stash)。

## core 里被本 PR 证伪的注释

`packages/core/src/utils/sort-query.ts` 的头注释原文写着「三份副本仍在,收敛它们不属于 #7137 的范围」—— 本 PR 一落地这句话就成了假话。仅更正该注释(并把描述副本行为的时态改为过去时),**sink 的逻辑一行未动**。

## 测试

```
pnpm exec vitest run packages/plugin-gantt packages/plugin-map packages/plugin-calendar --maxWorkers=2
 Test Files  59 passed (59)
      Tests  490 passed (490)
```

```
turbo run type-check --concurrency=2
 Tasks:    81 successful, 81 total
```

`node scripts/check-control-bytes.mjs` → OK(4354 个跟踪文本文件)。

## 范围外(已另立单,不在本 PR 修)

卡的「建议范围」第三条提到 `packages/plugin-view/src/ObjectView.tsx` 那条 `$orderby: sort` 直接透传要不要也走这个 sink。**本 PR 不动它**:它属于另一个包与另一条容器路径,且今天没有用户可见缺陷(`serializeOrderBy` 对缺方向本就按升序)。因为 #4022 一合就会关闭、这条观察会随之丢失,已另立 finding 单承接。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_