### PR TITLE
fix(plugin-report): report chart 的度量显示名按三级回落解析，不再印原始 name (#4020)

### DIFF
--- a/.changeset/report-chart-measure-label-4020.md
+++ b/.changeset/report-chart-measure-label-4020.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/plugin-report': patch
+---
+
+报表内嵌图表的度量显示名按三级回落解析，不再直接印原始 `name`
+
+数据集绑定的 report chart 此前把度量原样交给图表组件（`series: [{ dataKey }]`，无 label），
+于是图例、标记 tooltip 与单值卡片的说明文字都落回 dataKey——在全中文控制台上打出
+`potential_upside_tons`，而同一张报表下方的汇总表、以及绑定同一数据集的 dashboard 图表
+都能正确解析出授权 `label`。`ReportChartSchema` 自 rc.1 起声明的 `series[].label` 也从未
+被读取，作者因此没有任何可授权的手段控制这个字符串。
+
+现按三级回落解析，与汇总表和 dashboard 的既有口径对齐：
+
+1. `chart.series[]` 中 `name` 命中该度量的条目的 `label`（spec 的 `I18nLabel`，按控制台
+   语言解析；同名重复以第一条为准）；
+2. 绑定数据集的度量 `label`（结果字段的 `label`，即汇总表表头一直在读的同一个值）；
+3. 度量 `name` 兜底。
+
+图例与 tooltip 同源同修：`ChartRenderer` 把 series 的 `label` 写进 `config[dataKey].label`，
+三处读的是同一个输入。单值族（`metric`/`kpi`/`gauge`）的说明文字与系列图共用这一次解析。

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -71,7 +71,7 @@ import {
   type DatasetResultField,
   type DatasetDrillRange,
 } from '@object-ui/core';
-import { useSafeFieldLabel, useSafeTranslate, useDisplayLocale } from '@object-ui/i18n';
+import { useSafeFieldLabel, useSafeTranslate, useDisplayLocale, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { mergeFilters } from './mergeFilters';
 import { useDatasetDimensionLabels } from './useDatasetDimensionLabels';
 
@@ -643,6 +643,37 @@ function useRegistryComponent(
 }
 
 /**
+ * The author's per-chart override for ONE measure's display name — the entry of
+ * `chart.series[]` whose `name` IS that measure (objectui#4020, level ①).
+ *
+ * `ReportChartSchema.series[]` has declared `{ name, label? }` since rc.1, but
+ * the renderer never read it: the chart was handed `series: [{ dataKey }]` with
+ * no label at all, so an authored `label` was inert metadata and the measure
+ * printed as its raw `name`. Declared is now enforced.
+ *
+ * The FIRST entry naming the measure wins, the same ruling the dashboard's
+ * `mergeAuthoredPresentation` makes for its own `chartConfig.series` — a later
+ * duplicate cannot silently re-label a series the author already described.
+ *
+ * `label` is the spec's `I18nLabel` (`string | { en, 'zh-CN', … }`), so it goes
+ * through `pickLocalized`, the repo's one resolver for that shape — a
+ * first-string-wins pick would put the English limb of a translated label on a
+ * zh-CN console, which is the very defect class this card closes. An entry that
+ * names the measure but carries no usable `label` returns `undefined` and falls
+ * through to the dataset's own measure label, exactly as an absent entry does.
+ */
+function authoredSeriesLabel(series: unknown, measure: string, language: string | undefined): string | undefined {
+  if (!Array.isArray(series) || !measure) return undefined;
+  for (const entry of series as unknown[]) {
+    if (!entry || typeof entry !== 'object') continue;
+    const { name, label } = entry as { name?: unknown; label?: unknown };
+    if (name !== measure) continue;
+    return pickLocalized(label, language) || undefined;
+  }
+  return undefined;
+}
+
+/**
  * Render a report's embedded `chart` (ADR-0021) by running its OWN dataset
  * query — the `xAxis` dimension grouped, the `yAxis` measure aggregated — and
  * feeding the rows to the registered generic chart component (plugin-charts).
@@ -696,6 +727,12 @@ function DatasetReportChart({
   // and follows the display locale. (The series charts render their own labels
   // through the chart component, not through `formatMeasure`.)
   const displayLocale = useDisplayLocale();
+  // objectui#4020 — the UI LANGUAGE an authored `series[].label` is picked in.
+  // Deliberately not `displayLocale`: that one prefers the tenant's REGIONAL
+  // locale (ADR-0053) because it feeds `Intl` number formatting, and a workspace
+  // formatting numbers as `de-DE` while its console runs zh must still read the
+  // zh limb of a translated label.
+  const { language } = useObjectTranslation();
   // objectui#4330 — the embedded chart plots the SAME dimension the table
   // beneath it groups by, so it takes the same label map. Leaving it out would
   // put the two spellings of one value on one screen, which is the defect this
@@ -738,8 +775,25 @@ function DatasetReportChart({
   // On error or empty, fall back silently to the table beneath.
   if (state.status === 'error' || state.rows.length === 0) return null;
 
+  const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
+  // The measure's display name, resolved ONCE for every branch below
+  // (objectui#4020). Three levels, highest first:
+  //
+  //  1. `chart.series[]`'s entry naming this measure — the spec's own per-chart
+  //     override (see `authoredSeriesLabel`);
+  //  2. the bound dataset's `measures[].label`, which reaches the client as the
+  //     result field's `label` — `headerLabel` reads exactly that (then the i18n
+  //     field-label convention), so the chart and the summary table BENEATH IT
+  //     print one string for one measure instead of two;
+  //  3. the measure NAME, `headerLabel`'s own last resort.
+  //
+  // Level ② is what the dashboard's `buildChartSeries` already did for its own
+  // chart series (`fields[].label`), and what the table here has always done;
+  // the report chart was the one surface that consulted neither and shipped the
+  // raw `name` to a fully-translated console.
+  const measureLabel = authoredSeriesLabel(chart.series, yAxis, language) ?? headerLabel(yAxis);
+
   if (plan.kind === 'single_value') {
-    const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
     const mf = measureField(yAxis);
     return (
       <div className="rounded-md border bg-card p-3" data-testid="dataset-report-metric">
@@ -748,7 +802,7 @@ function DatasetReportChart({
           <span className="text-2xl font-semibold tabular-nums">
             {formatMeasure(state.rows[0]?.[yAxis], mf?.format, mf?.currency, mf?.percentScale, displayLocale)}
           </span>
-          <span className="text-xs text-muted-foreground">{headerLabel(yAxis)}</span>
+          <span className="text-xs text-muted-foreground">{measureLabel}</span>
         </div>
       </div>
     );
@@ -767,7 +821,12 @@ function DatasetReportChart({
           chartType: plan.chartType,
           data: relabelDimensions(state.rows, dimensionLabels),
           xAxisKey: xAxis,
-          series: [{ dataKey: yAxis }],
+          // One series, carrying its display name. `ChartRenderer` turns a
+          // series `label` into `config[dataKey].label`, which is the single
+          // input the legend, the mark's tooltip name and the single-value
+          // caption all read — so legend and tooltip follow this by
+          // construction rather than by a second resolution.
+          series: [{ dataKey: yAxis, label: measureLabel }],
           height: typeof chart.height === 'number' ? chart.height : 280,
           // Render deterministically (no rAF entrance animation): reports are
           // often viewed in a background tab or exported, where an animated

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartMeasureLabel.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartMeasureLabel.test.tsx
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4020 — a report chart printed the raw dataset measure `name` where
+ * the summary table beneath it, and a dashboard chart over the same dataset,
+ * both printed the authored `label`.
+ *
+ * The renderer handed the chart component `series: [{ dataKey: yAxis }]`: no
+ * label at all. `ChartRenderer` then fills `config[dataKey].label` with the
+ * dataKey itself, so the legend, the mark's tooltip name and (on a single-value
+ * family) the caption all read `potential_upside_tons` under a fully-translated
+ * console. The authored `chart.series[].label` — declared by
+ * `ReportChartSchema` since rc.1 — never reached the chart either, which is why
+ * the card's reporter measured it as inert metadata.
+ *
+ * The resolution these cases pin, highest first:
+ *   ① `chart.series[]`'s entry naming the measure,
+ *   ② the bound dataset's measure label (the result field's `label`),
+ *   ③ the measure `name`.
+ *
+ * DIRECTIONS, written before the reverse verification was run — the resolution
+ * is NOT canonical-first, so this is the ordinary direction throughout:
+ *  - ① and ② are RED before the change (they resolve to the raw `name`, which
+ *    is precisely what the card reports) and green after;
+ *  - ③ is GREEN on both sides: with nothing to resolve, the name IS the answer.
+ *    It is here to pin that the fallback did not become `undefined`/`[object
+ *    Object]`, a failure the other two cases cannot see;
+ *  - the table/chart parity case is red before for the same reason as ②, and is
+ *    the one that states the card's actual invariant: ONE measure, ONE string,
+ *    on ONE screen.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { DatasetReportRenderer } from '../DatasetReportRenderer';
+
+/** The card's own dataset: a measure whose authored label is Chinese. */
+const RESULT = {
+  rows: [
+    { account_name: 'Acme', potential_upside_tons: 120 },
+    { account_name: 'Globex', potential_upside_tons: 80 },
+  ],
+  fields: [
+    { name: 'account_name', type: 'string', label: '客户名称' },
+    { name: 'potential_upside_tons', type: 'number', label: '可抢吨位(吨)' },
+  ],
+};
+
+/** The same result with NO field labels — the level ③ shape. */
+const UNLABELLED = {
+  rows: RESULT.rows,
+  fields: [
+    { name: 'account_name', type: 'string' },
+    { name: 'potential_upside_tons', type: 'number' },
+  ],
+};
+
+const sourceOf = (result: unknown) => ({ queryDataset: vi.fn(async () => result) });
+
+/** Props the registered chart component was handed, or `null` if never called. */
+let captured: { schema: Record<string, any> } | null = null;
+
+beforeEach(() => {
+  captured = null;
+  ComponentRegistry.register('chart', (props: any) => {
+    captured = props;
+    return null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The label the chart component is asked to paint for the plotted measure. */
+async function chartSeriesLabel(report: Record<string, unknown>, result: unknown = RESULT) {
+  render(<DatasetReportRenderer report={report as never} dataSource={sourceOf(result) as never} />);
+  await waitFor(() => expect(captured?.schema?.series?.[0]?.dataKey).toBe('potential_upside_tons'));
+  return captured!.schema.series[0].label;
+}
+
+const BASE = {
+  name: 'heimao_key_account_attack_list',
+  type: 'tabular',
+  dataset: 'heimao_account_metrics',
+  rows: ['account_name'],
+  values: ['potential_upside_tons'],
+};
+
+describe('report chart measure label — three levels (objectui#4020)', () => {
+  it('① an authored chart.series[].label naming the measure wins', async () => {
+    // The card measured this exact metadata as inert: authored, rebuilt,
+    // restarted, still `potential_upside_tons` on the axis.
+    const label = await chartSeriesLabel({
+      ...BASE,
+      chart: {
+        type: 'horizontal-bar',
+        xAxis: 'account_name',
+        yAxis: 'potential_upside_tons',
+        series: [{ name: 'potential_upside_tons', label: '本季可抢吨位' }],
+      },
+    });
+    // Beats the dataset's own label, which is a DIFFERENT string here on
+    // purpose: a per-chart override that merely agreed with the dataset would
+    // pass whether or not it was read.
+    expect(label).toBe('本季可抢吨位');
+  });
+
+  it('② with no series authored, the dataset measure label is the default', async () => {
+    const label = await chartSeriesLabel({
+      ...BASE,
+      chart: { type: 'horizontal-bar', xAxis: 'account_name', yAxis: 'potential_upside_tons' },
+    });
+    expect(label).toBe('可抢吨位(吨)');
+  });
+
+  it('③ with neither, the measure name is the last resort', async () => {
+    const label = await chartSeriesLabel(
+      { ...BASE, chart: { type: 'horizontal-bar', xAxis: 'account_name', yAxis: 'potential_upside_tons' } },
+      UNLABELLED,
+    );
+    expect(label).toBe('potential_upside_tons');
+  });
+
+  it('a series entry naming ANOTHER measure does not relabel this one', async () => {
+    // Membership belongs to the report's `values`/`yAxis`; an authored entry
+    // that names something else is presentation for a series this chart does
+    // not plot, and must not leak onto the one it does.
+    const label = await chartSeriesLabel({
+      ...BASE,
+      chart: {
+        type: 'horizontal-bar',
+        xAxis: 'account_name',
+        yAxis: 'potential_upside_tons',
+        series: [{ name: 'shipped_volume_tons', label: '发货量(吨)' }],
+      },
+    });
+    expect(label).toBe('可抢吨位(吨)');
+  });
+
+  it('an entry naming the measure with no usable label falls through to ②', async () => {
+    const label = await chartSeriesLabel({
+      ...BASE,
+      chart: {
+        type: 'horizontal-bar',
+        xAxis: 'account_name',
+        yAxis: 'potential_upside_tons',
+        series: [{ name: 'potential_upside_tons' }],
+      },
+    });
+    expect(label).toBe('可抢吨位(吨)');
+  });
+
+  it('the FIRST entry naming the measure wins over a later duplicate', async () => {
+    const label = await chartSeriesLabel({
+      ...BASE,
+      chart: {
+        type: 'horizontal-bar',
+        xAxis: 'account_name',
+        yAxis: 'potential_upside_tons',
+        series: [
+          { name: 'potential_upside_tons', label: '第一次' },
+          { name: 'potential_upside_tons', label: '第二次' },
+        ],
+      },
+    });
+    expect(label).toBe('第一次');
+  });
+});
+
+describe('report chart measure label — one measure, one string, one screen', () => {
+  it('the chart series and the summary-table header read the SAME label', async () => {
+    // The card's diagnosis in one assertion: the two elements sit on one
+    // screen, over one measure, and disagreed.
+    render(
+      <DatasetReportRenderer
+        report={
+          {
+            ...BASE,
+            chart: { type: 'horizontal-bar', xAxis: 'account_name', yAxis: 'potential_upside_tons' },
+          } as never
+        }
+        dataSource={sourceOf(RESULT) as never}
+      />,
+    );
+    await waitFor(() => expect(captured?.schema?.series?.[0]?.label).toBeTruthy());
+    const headers = (await screen.findAllByRole('columnheader')).map((th) => th.textContent);
+    expect(headers).toContain('可抢吨位(吨)');
+    expect(captured!.schema.series[0].label).toBe('可抢吨位(吨)');
+    // And the raw name is nowhere on the screen the chart component paints.
+    expect(headers).not.toContain('potential_upside_tons');
+  });
+});
+
+describe('report chart measure label — an i18n label record picks the console language', () => {
+  it('resolves the zh limb of an authored { en, zh-CN } series label', async () => {
+    // `ReportChartSchema.series[].label` is the spec's I18nLabel, so the record
+    // form is as authorable as the string one. Resolving it "first string wins"
+    // would paint the English limb on a zh console — the defect class this card
+    // closes, reintroduced by the fix.
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false, resources: { zh: {} } }}>
+        <DatasetReportRenderer
+          report={
+            {
+              ...BASE,
+              chart: {
+                type: 'horizontal-bar',
+                xAxis: 'account_name',
+                yAxis: 'potential_upside_tons',
+                series: [
+                  { name: 'potential_upside_tons', label: { en: 'Upside (t)', 'zh-CN': '可抢吨位' } },
+                ],
+              },
+            } as never
+          }
+          dataSource={sourceOf(RESULT) as never}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(captured?.schema?.series?.[0]?.label).toBeTruthy());
+    expect(captured!.schema.series[0].label).toBe('可抢吨位');
+  });
+});
+
+describe('report chart measure label — the single-value families take the same resolution', () => {
+  it('a kpi caption honours the authored series label over the dataset one', async () => {
+    // `metric`/`kpi`/`gauge` render the measure as a number with its display
+    // name beneath; that caption resolved ② and ③ already and skipped ①. One
+    // resolution now serves both branches, so the two cannot drift.
+    render(
+      <DatasetReportRenderer
+        report={
+          {
+            ...BASE,
+            chart: {
+              type: 'kpi',
+              yAxis: 'potential_upside_tons',
+              series: [{ name: 'potential_upside_tons', label: '本季可抢吨位' }],
+            },
+          } as never
+        }
+        dataSource={sourceOf(RESULT) as never}
+      />,
+    );
+    const metric = await screen.findByTestId('dataset-report-metric');
+    expect(metric.textContent).toContain('本季可抢吨位');
+    expect(metric.textContent).not.toContain('potential_upside_tons');
+  });
+
+  it('a kpi caption still falls back to the dataset measure label', async () => {
+    render(
+      <DatasetReportRenderer
+        report={{ ...BASE, chart: { type: 'kpi', yAxis: 'potential_upside_tons' } } as never}
+        dataSource={sourceOf(RESULT) as never}
+      />,
+    );
+    const metric = await screen.findByTestId('dataset-report-metric');
+    expect(metric.textContent).toContain('可抢吨位(吨)');
+  });
+});

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartMeasureLabel.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartMeasureLabel.test.tsx
@@ -18,16 +18,27 @@
  *   ② the bound dataset's measure label (the result field's `label`),
  *   ③ the measure `name`.
  *
- * DIRECTIONS, written before the reverse verification was run — the resolution
- * is NOT canonical-first, so this is the ordinary direction throughout:
- *  - ① and ② are RED before the change (they resolve to the raw `name`, which
- *    is precisely what the card reports) and green after;
- *  - ③ is GREEN on both sides: with nothing to resolve, the name IS the answer.
- *    It is here to pin that the fallback did not become `undefined`/`[object
- *    Object]`, a failure the other two cases cannot see;
- *  - the table/chart parity case is red before for the same reason as ②, and is
- *    the one that states the card's actual invariant: ONE measure, ONE string,
- *    on ONE screen.
+ * DIRECTIONS, written before the reverse verification was run. "Revert it and
+ * watch them go red" is ambiguous here, because there are two different ways to
+ * take the resolution away and they do NOT move the same case — so both were
+ * predicted, then run, and both matched:
+ *
+ *  - **name直读** (`measureLabel = yAxis`): 9 red, 1 green. The survivor is ③,
+ *    and necessarily so — reading the name directly COINCIDES with level ③, so
+ *    that case cannot distinguish the two. Every failure printed
+ *    `potential_upside_tons`, i.e. the card's reported symptom verbatim.
+ *  - **the exact pre-change lines** (`series: [{ dataKey }]`, caption
+ *    `headerLabel(yAxis)`): 9 red, 1 green — a DIFFERENT survivor. ③ goes red
+ *    here (the forwarded series carried no `label` key at all, so it is
+ *    `undefined`, not the name), and the green one is "a kpi caption still
+ *    falls back to the dataset measure label" — measured `'120可抢吨位(吨)'`.
+ *    That is not a weak case; it is the record that the single-value branch
+ *    already resolved ② and ③ before this change, and that ① was the only level
+ *    missing there. The series branch resolved none of the three.
+ *
+ * So ③'s job is not "red before": it is the guard that the last resort still
+ * lands on the NAME and did not become `undefined` or `[object Object]` — a
+ * failure ① and ② cannot see, and the one the pre-change code actually had.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';


### PR DESCRIPTION
Fixes #4020

## 病灶

数据集绑定的 report chart 把度量原样交给图表组件，实测转发出去的 schema 键只有六个：

```
chartType, data, height, isAnimationActive, series, xAxisKey
```

其中 `series` 是 `[{ dataKey: yAxis }]` —— 没有 label。`ChartRenderer` 随后用 `s.label || s.dataKey` 填 `config[dataKey].label`，于是图例、标记 tooltip 的 name、以及单值族卡片的说明文字**同时**落回 dataKey，在全中文控制台上打出 `potential_upside_tons`。同一张报表下方的汇总表读 `headerLabel()`（结果字段 `label`）一直是对的，绑定同一数据集的 dashboard 图表走 `buildChartSeries`（`fields[].label`）也一直是对的 —— 报表图是唯一两边都不查的那一面，立卡人的定位准确。

`ReportChartSchema.series[].label` 自 rc.1 起就已声明，但这条路径从未读过它。立卡人把它实测为惰性元数据，属实：作者因此**没有任何**可授权的手段控制这个字符串。

## 修法

在 `DatasetReportChart` 里把度量显示名解析一次，系列图分支与单值族分支共用（原先两条分支各写各的，正是漂移的温床）：

1. `chart.series[]` 中 `name` 命中该度量的条目的 `label` —— spec 的 `I18nLabel`，经 `pickLocalized` 按控制台语言解析；同名重复以第一条为准，与 dashboard 的 `mergeAuthoredPresentation` 同一裁定；
2. 绑定数据集的度量 `label` —— 即结果字段的 `label`，`headerLabel()` 读的正是这一个值，所以图和它下方的汇总表在一屏上只有一种拼写；
3. 度量 `name` 兜底，`headerLabel()` 自己的最后一档。

**复用而非新造口径**：② 和 ③ 直接落在既有共享 helper `buildDatasetFieldHelpers().headerLabel`（`@object-ui/core`，汇总表、矩阵表头、dashboard 表格、DatasetPreview 都在用）；① 的 i18n 记录形用 `@object-ui/i18n` 的 `pickLocalized` —— 全仓解析 `I18nLabel` 的那一个 helper。没有引入第三份拼写。

语言取 `useObjectTranslation().language` 而非本组件已有的 `useDisplayLocale()`：后者优先租户区域 locale（ADR-0053）因为它喂 `Intl` 数字格式；数字按 de-DE 格式化的工作区若控制台跑 zh，标签仍应读 zh 那一支。

**tooltip / legend 同源同修**：三者读的是同一个 `config[dataKey].label`，所以一处 label 落位，图例、tooltip、单值说明文字一起对 —— 不是第二次解析，是同一个输入。

## 反向验证：两种探针，方向分别预判后再跑，都对上了

"把修改撤掉看钉子红"在这张卡上是歧义的 —— 有两种撤法，动的不是同一批用例。两种都先写预判再跑：

**探针 B（`measureLabel = yAxis`，name 直读）**：预判 9 红 1 绿，绿的必须是 ③。实测一致：

```
× ① an authored chart.series[].label naming the measure wins
× ② with no series authored, the dataset measure label is the default
× the chart series and the summary-table header read the SAME label
AssertionError: expected 'potential_upside_tons' to be '本季可抢吨位'
AssertionError: expected 'potential_upside_tons' to be '可抢吨位(吨)'
 Tests  9 failed | 1 passed (10)
```

③ 活下来是**必然**而非侥幸：name 直读与三级回落的第 ③ 档重合，这条用例在原理上就分辨不了两者。每条失败打印的都是 `potential_upside_tons` —— 立卡正文报的症状原样复现。

**探针 A（还原改动前的真实两行）**：预判同样 9 红 1 绿，但**绿的是另一条**。实测一致：

```
× ③ with neither, the measure name is the last resort
AssertionError: expected undefined to be 'potential_upside_tons'
× a kpi caption honours the authored series label over the dataset one
AssertionError: expected '120可抢吨位(吨)' to contain '本季可抢吨位'
 Tests  9 failed | 1 passed (10)
```

③ 在这里转红：改动前转发的 series 根本没有 `label` 键，值是 `undefined` 而不是 name。唯一的绿是 "a kpi caption still falls back to the dataset measure label" —— 它记录了一个真实事实：单值族分支改动前就已解析 ② 和 ③，缺的只有 ①；系列图分支三档一档都没有。

所以 ③ 的职责不是"改前红"，而是守住兜底仍落在 **name** 上、没变成 `undefined` 或 `[object Object]` —— 这正是改动前代码真实具备的缺陷，而 ① ② 两条看不见它。两种探针的方向差异已如实写进用例文件头，不按"改前绿改后红"的模板硬套。

## 测试

新增 `DatasetReportRenderer.chartMeasureLabel.test.tsx`（10 条）：三级各一、命名了**别的**度量的条目不得越权改名、命中但无可用 label 落回 ②、同名重复第一条胜、i18n 记录形按控制台语言取 zh 支、table 与 chart 同度量同名（本卡病灶的反面）、单值族 ① 与 ②。

```
pnpm exec vitest run packages/plugin-report --maxWorkers=2
 Test Files  10 passed (10)
      Tests  111 passed (111)

pnpm exec vitest run .../ReportPreview.dataset.test.tsx --maxWorkers=2   # 消费半径
 Test Files  1 passed (1)   Tests  7 passed (7)

pnpm exec turbo run type-check --concurrency=2
 Tasks:    81 successful, 81 total

pnpm --filter '@object-ui/plugin-report' lint   →  0 errors（74 条既有 warning）
node scripts/check-control-bytes.mjs            →  OK (4363 tracked text files)
```

消费半径按规矩点过：`DatasetReportRenderer` 的调用方是 app-shell 的 `ReportView` 与 metadata-admin 的 `ReportPreview`，两者的 dataset 用例均绿；没有任何别处 fixture 断言这条转发出去的 series 形状。

## 顺手发现，不扩围（已另立单）

- #4877 —— 同一行转发丢掉了**全部**授权 chrome：实测 `showLegend: false` / `colors` / `showDataLabels` 都没进 schema，而 `AdvancedChartImpl` 的 `showLegend !== false` 让缺省等于**开**，作者的显式 `false` 不是被忽略而是被反转。立卡人自己的报表正authored 了 `showLegend: false`。
- #4878 —— 同一行从不给 NULL 分类分桶：实测 `data = [{"owner":null,...}]` 原样送达渲染器，正是 #4466 测得"完全不画标记"的输入。#4466/#4497/#4673/#4500/#4508 整族修的都是 `buildChartSeries`，而报表图这条路径不调它。

两条都是实测到接缝、非代码阅读推断；均未认领，留给 PM 分诊。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_