### PR TITLE
fix(studio): the Interfaces rail opens `action` nav entries instead of disabling them (#4019)

### DIFF
--- a/.changeset/studio-interfaces-action-nav-surface.md
+++ b/.changeset/studio-interfaces-action-nav-surface.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The Studio Interfaces rail opens `action` nav entries instead of greying them out.
+
+The Interfaces pillar's rail is the current package's App `navigation` tree, and
+each leaf opens the design surface of whatever it binds to. `resolveSurface`
+bound five shapes — `page`, `object`, `dashboard`, `report`, `view` — and not
+`action`, so an action entry rendered `disabled`: visible in the designer, 40%
+opacity, inert on click. The same entry works in the shipped product, where
+`NavigationRenderer` renders it and `useNavActionDispatch` resolves and executes
+it (framework#4509), and `action` has carried both a registered preview
+(`ActionPreview`) and a registered default inspector (`ActionDefaultInspector`)
+the whole time. Only the binding was missing, so the one nav variant naming an
+authorable metadata item was the one variant the designer could not author.
+
+Clicking such an entry now opens the action on the standard surface — the
+`ActionPreview` canvas plus the action's inspector — and draft-saves through the
+same generic path as the pillar's other leaves.
+
+Scope, stated because the neighbours are deliberately untouched: `url`,
+`separator` and `component` leaves stay unresolvable, and are not a gap — an
+external link, a divider, and a first-party UI shipped in code have no metadata
+item to design. Object-scoped actions keep their existing home, the object's
+Actions tab: `ActionNavItemSchema` is strict `{ actionName, params? }` with no
+`objectName`, so a nav action is a global action by construction and this path
+cannot reach an object-scoped one.
+
+`actionDef.actionName` is read as the only spelling. The spec answers `action` /
+`name` / `args` / `input` there with a named rejection rather than accepting
+them (objectstack#4001, measured on spec 17.0.0-rc.6), and a tolerant read here
+would re-open exactly what that closed: an entry that dispatches an action its
+author did not declare.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.interfacesAction.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.interfacesAction.test.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Acceptance for objectui#4019's `action` half, at the pillar level: the
+ * Studio Interfaces rail must LIST an action nav entry and OPEN it on the
+ * standard design surface.
+ *
+ * Before this, the entry rendered — the rail walks every nav leaf — but with
+ * `disabled` set, because `resolveSurface` had no `action` case. So the one
+ * nav variant that names an authorable metadata item was the one the designer
+ * could not open, while the shipped sidebar rendered and dispatched it
+ * (framework#4509). The two assertions below are exactly those two verbs.
+ */
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const NAV = [
+  { id: 'nav_home', type: 'page', label: 'Home', pageName: 'home' },
+  { id: 'nav_run_sync', type: 'action', label: 'Run Sync', actionDef: { actionName: 'sync_now' } },
+];
+
+/** Spec-valid (`ActionSchema`, 17.0.0-rc.6) — the item the rail must open. */
+const ACTION = {
+  name: 'sync_now',
+  label: 'Sync Now',
+  type: 'script',
+  target: 'sync',
+  locations: ['list_toolbar'],
+};
+
+const mockClient = {
+  list: vi.fn(async (type: string) =>
+    type === 'app' ? [{ name: 'acme_app', label: 'Acme' }] : [],
+  ),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async (type: string, name: string) => {
+    if (type === 'app') return { effective: { name: 'acme_app', label: 'Acme', navigation: NAV } };
+    if (type === 'action' && name === 'sync_now') return { effective: ACTION };
+    return { effective: { name, kind: 'blocks', blocks: [] } };
+  }),
+  getDraft: vi.fn(async () => null),
+  save: vi.fn(async () => ({})),
+  get: vi.fn(async () => undefined),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({ entries: [] }),
+  };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+import { InterfacesPillar } from './StudioDesignSurface';
+import { registerMetadataPreview } from '../metadata-admin/preview-registry';
+import { ActionPreview } from '../metadata-admin/previews/ActionPreview';
+
+// Registered directly rather than via `registerBuiltinPreviews()` — the barrel
+// pulls every preview module (flow canvas, dashboard, report…) into this file's
+// graph for one canvas. Same trade-off, and same precedent, as
+// `EmbeddedItemEditor.preview.test.tsx`. That the barrel itself still carries
+// the `action` line is the pre-existing registration this card builds on
+// (`previews/index.ts`), not something this test can drift from.
+//
+// The right-hand inspector is deliberately not asserted here: `action`'s
+// default inspector was already registered and already has its own coverage
+// (`inspectors/ActionDefaultInspector.celGate.test.tsx`); mounting it would
+// drag the CEL condition-builder tree into a rail test.
+registerMetadataPreview('action', ActionPreview);
+
+afterEach(cleanup);
+
+function renderPillar() {
+  return render(
+    <MemoryRouter initialEntries={['/studio/com.acme.app/interfaces']}>
+      <InterfacesPillar packageId="com.acme.app" />
+    </MemoryRouter>,
+  );
+}
+
+describe('Interfaces pillar — action nav entries (objectui#4019)', () => {
+  it('lists the action entry as an ENABLED rail item', async () => {
+    renderPillar();
+
+    const entry = await screen.findByTitle('action · sync_now');
+    expect(entry).toBeInTheDocument();
+    // The verb that was broken: the rail renders every leaf, but an
+    // unresolvable one is `disabled` and cannot be opened.
+    expect(entry).toBeEnabled();
+  });
+
+  it('opens it on the standard design surface when clicked', async () => {
+    renderPillar();
+
+    // The first resolvable leaf (`Home`) auto-opens, so this also proves the
+    // rail SWITCHES to the action rather than merely defaulting to it.
+    const entry = await screen.findByTitle('action · sync_now');
+    fireEvent.click(entry);
+
+    // Canvas breadcrumb — the surface the pillar is now editing. Matched on
+    // the element's whole text: the breadcrumb is `{type} · {name}` in JSX, so
+    // it reaches the DOM as three sibling text nodes and a plain string query
+    // would never match it.
+    await waitFor(() =>
+      expect(
+        screen.getAllByText((_content, el) => el?.tagName === 'SPAN' && el.textContent === 'action · sync_now'),
+      ).not.toHaveLength(0),
+    );
+    // ...rendered by the registered `ActionPreview`, which draws the action's
+    // own label as the faux button an author is designing.
+    await waitFor(() => expect(screen.getAllByText('Sync Now').length).toBeGreaterThan(0));
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -87,6 +87,7 @@ import {
 import { SourcePageEditor } from '../metadata-admin/previews/SourcePageEditor';
 import { formatMetadataError, formatPublishFailures, type PublishFailure } from './metadataError';
 import { loadPackageSurfaces } from './packageSurfaces';
+import { resolveSurface, findSurfaceInTree, type NavNode, type Surface } from './navSurface';
 import { useSurfaceDeepLink, resolveSurfaceDeepLink } from './useSurfaceDeepLink';
 import { buildObjectSkeleton, buildFlowSkeleton, buildAppSkeleton, buildPermissionSkeleton } from './skeletons';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n';
@@ -129,33 +130,6 @@ const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> =
   { key: 'access', label: 'Access', Icon: Shield },
 ];
 
-interface Surface {
-  type: string;
-  name: string;
-  label: string;
-  /** Lucide icon name from the object's metadata (`icon` field); falls back per getIcon. */
-  icon?: string;
-}
-
-interface NavNode {
-  id?: string;
-  label?: string;
-  type?: string;
-  icon?: string;
-  children?: NavNode[];
-  pageName?: string;
-  page?: string;
-  objectName?: string;
-  object?: string;
-  dashboardName?: string;
-  dashboard?: string;
-  reportName?: string;
-  report?: string;
-  viewName?: string;
-  view?: string;
-  [k: string]: unknown;
-}
-
 const KIND_ICON: Record<string, LucideIcon> = {
   group: Folder,
   page: FileText,
@@ -163,52 +137,9 @@ const KIND_ICON: Record<string, LucideIcon> = {
   dashboard: LayoutDashboard,
   report: BarChart3,
   view: Table2,
+  action: MousePointer2,
 };
 const navIcon = (type?: string): LucideIcon => KIND_ICON[type ?? ''] ?? Compass;
-
-/** Resolve a leaf nav node → the surface {type,name} it binds to. */
-function resolveSurface(node: NavNode): Surface | null {
-  const label = String(node.label ?? '');
-  switch (node.type) {
-    case 'page':
-      return node.pageName || node.page ? { type: 'page', name: String(node.pageName || node.page), label } : null;
-    case 'object':
-      return node.objectName || node.object
-        ? { type: 'object', name: String(node.objectName || node.object), label }
-        : null;
-    case 'dashboard':
-      return node.dashboardName || node.dashboard
-        ? { type: 'dashboard', name: String(node.dashboardName || node.dashboard), label }
-        : null;
-    case 'report':
-      return node.reportName || node.report
-        ? { type: 'report', name: String(node.reportName || node.report), label }
-        : null;
-    case 'view':
-      return node.viewName || node.view ? { type: 'view', name: String(node.viewName || node.view), label } : null;
-    default:
-      return null;
-  }
-}
-
-/**
- * Walk the nav tree for the leaf that binds to `{type,name}`, returning its
- * resolved Surface (carrying the node's label so the canvas title / highlight
- * match). Backs the `?surface=` deep-link restore — a shared URL only names
- * the target, so we re-derive the label from the live tree.
- */
-function findSurfaceInTree(nodes: NavNode[], target: { type: string; name: string }): Surface | null {
-  for (const node of nodes) {
-    if (node.type === 'group' || node.children?.length) {
-      const hit = findSurfaceInTree(node.children ?? [], target);
-      if (hit) return hit;
-    } else {
-      const s = resolveSurface(node);
-      if (s && s.type === target.type && s.name === target.name) return s;
-    }
-  }
-  return null;
-}
 
 /** Normalize the framework draft envelope `{ type, name, item }` → body | null. */
 function extractDraftBody(resp: unknown): Record<string, unknown> | null {
@@ -1027,7 +958,7 @@ function StudioNavItemInspector({
   );
 }
 
-function InterfacesPillar({
+export function InterfacesPillar({
   packageId,
   publishNonce = 0,
   draftNonce = 0,

--- a/packages/app-shell/src/views/studio-design/navSurface.test.ts
+++ b/packages/app-shell/src/views/studio-design/navSurface.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Interfaces-pillar nav-leaf binding (objectui#4019).
+ *
+ * The gap this pins: an `action` nav item is a LIVE runtime surface — the
+ * shipped sidebar renders it and `useNavActionDispatch` executes it
+ * (framework#4509) — but the Studio Interfaces rail could not resolve it to a
+ * design surface, so the very same entry rendered permanently DISABLED in the
+ * designer while it worked in the running app. `action` has had both a
+ * registered preview (`ActionPreview`) and a registered default inspector
+ * (`ActionDefaultInspector`) all along; only this binding was missing.
+ *
+ * The fixtures are parsed against the spec's own `NavigationItemSchema` rather
+ * than asserted by eye, so this file cannot drift into pinning a shape the
+ * schema rejects (the phantom-rule trap): the positive fixture must be
+ * spec-VALID for the designer to be required to open it, and the rejected
+ * alias spelling must stay unresolvable here because the schema refuses it by
+ * name — Commandment #0.1, no second dialect in the consumer.
+ */
+import { describe, expect, it } from 'vitest';
+import { NavigationItemSchema } from '@objectstack/spec/ui';
+import { resolveSurface, findSurfaceInTree, type NavNode } from './navSurface';
+
+/** A spec-valid global-action nav item. */
+const ACTION_NODE: NavNode = {
+  id: 'nav_run_sync',
+  type: 'action',
+  label: 'Run Sync',
+  actionDef: { actionName: 'sync_now' },
+};
+
+describe('resolveSurface — action nav items (objectui#4019)', () => {
+  it('the fixture is a real authoring surface: the spec accepts it whole', () => {
+    const parsed = NavigationItemSchema.safeParse(ACTION_NODE);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('binds an action nav leaf to the `action` design surface', () => {
+    expect(resolveSurface(ACTION_NODE)).toEqual({
+      type: 'action',
+      name: 'sync_now',
+      label: 'Run Sync',
+    });
+  });
+
+  it('leaves an action item with no actionName unresolved (stays disabled)', () => {
+    expect(resolveSurface({ id: 'nav_x', type: 'action', label: 'Nothing' })).toBeNull();
+    expect(resolveSurface({ id: 'nav_x', type: 'action', label: 'Nothing', actionDef: {} })).toBeNull();
+  });
+
+  it('reads the canonical key ONLY — a spelling the schema rejects stays unresolved', () => {
+    // `action` / `name` inside `actionDef` are REJECTED aliases carrying a
+    // redirect (objectstack#4001), not second spellings. Measured on
+    // spec 17.0.0-rc.6: `unrecognized_keys` on `actionDef` plus a missing
+    // `actionName`. A tolerant `??` limb here would resurrect exactly the bug
+    // #4001 closed — an entry that dispatches an action the author did not
+    // declare — so the designer must refuse what the schema refuses.
+    const aliasNode = {
+      id: 'nav_run_sync',
+      type: 'action',
+      label: 'Run Sync',
+      actionDef: { action: 'sync_now' },
+    };
+    const parsed = NavigationItemSchema.safeParse(aliasNode);
+    expect(parsed.success).toBe(false);
+    expect(resolveSurface(aliasNode as NavNode)).toBeNull();
+  });
+
+  it('reaches an action leaf nested in a group (the `?surface=` deep-link path)', () => {
+    const tree: NavNode[] = [
+      { id: 'g1', type: 'group', label: 'Ops', children: [ACTION_NODE] },
+    ];
+    expect(findSurfaceInTree(tree, { type: 'action', name: 'sync_now' })).toEqual({
+      type: 'action',
+      name: 'sync_now',
+      label: 'Run Sync',
+    });
+  });
+});
+
+describe('resolveSurface — the variants around the new one are unchanged', () => {
+  it('still binds the surface-bearing leaves', () => {
+    expect(resolveSurface({ type: 'page', pageName: 'home', label: 'Home' })?.type).toBe('page');
+    expect(resolveSurface({ type: 'object', objectName: 'crm_lead', label: 'Leads' })?.name).toBe('crm_lead');
+    expect(resolveSurface({ type: 'dashboard', dashboardName: 'sales', label: 'Sales' })?.name).toBe('sales');
+    expect(resolveSurface({ type: 'report', reportName: 'pipeline', label: 'Pipeline' })?.name).toBe('pipeline');
+  });
+
+  it('leaves the variants with no authorable target unresolved', () => {
+    // Deliberately NOT openable — `url` points out of the product, `separator`
+    // is a divider, and `component` names a first-party UI shipped in code, so
+    // none of the three has a metadata item to design. Only `action` was a
+    // metadata type sitting in this bucket by omission.
+    expect(resolveSurface({ id: 'nav_docs', type: 'url', label: 'Docs', url: 'https://example.com' })).toBeNull();
+    expect(resolveSurface({ id: 'nav_sep', type: 'separator' })).toBeNull();
+    expect(
+      resolveSurface({ id: 'nav_dir', type: 'component', label: 'Directory', componentRef: 'metadata:directory' }),
+    ).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/studio-design/navSurface.ts
+++ b/packages/app-shell/src/views/studio-design/navSurface.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Nav-leaf → design-surface resolution for the Studio Interfaces pillar.
+ *
+ * The Interfaces pillar's rail is NOT a per-type list (the Data / Automations /
+ * Access rails are — `object` / `flow` / `permission`). It is the current
+ * package's App `navigation` tree: every leaf is rendered, and the one that
+ * `resolveSurface` can bind to a `{type,name}` opens that item's design surface
+ * (`getMetadataPreview` canvas + `getMetadataInspector` / default inspector).
+ * A leaf that resolves to `null` renders DISABLED — correct for the nav
+ * variants whose target is not an authorable metadata item (`url` points out of
+ * the product, `separator` is a divider, `component` names a first-party UI
+ * shipped in code), and a dead entry for any variant that does have one.
+ *
+ * Extracted from `StudioDesignSurface.tsx` so the binding is unit-testable
+ * without mounting the pillar — the same reason `packageSurfaces.ts` and
+ * `centerTab.ts` live beside it.
+ */
+
+/** One rail entry / canvas target. */
+export interface Surface {
+  type: string;
+  name: string;
+  label: string;
+  /** Lucide icon name from the object's metadata (`icon` field); falls back per getIcon. */
+  icon?: string;
+}
+
+export interface NavNode {
+  id?: string;
+  label?: string;
+  type?: string;
+  icon?: string;
+  children?: NavNode[];
+  pageName?: string;
+  page?: string;
+  objectName?: string;
+  object?: string;
+  dashboardName?: string;
+  dashboard?: string;
+  reportName?: string;
+  report?: string;
+  viewName?: string;
+  view?: string;
+  /**
+   * `ActionNavItemSchema.actionDef` — a `.strict()` object of exactly
+   * `{ actionName, params? }`. The spec answers `action` / `name` / `args` /
+   * `input` here as REJECTED spellings with a redirect (objectstack#4001), so
+   * they are authoring errors, never second spellings to read (Commandment
+   * #0.1): this type declares the canonical key alone.
+   */
+  actionDef?: { actionName?: string; params?: Record<string, unknown> };
+  [k: string]: unknown;
+}
+
+/** Resolve a leaf nav node → the surface {type,name} it binds to. */
+export function resolveSurface(node: NavNode): Surface | null {
+  const label = String(node.label ?? '');
+  switch (node.type) {
+    case 'page':
+      return node.pageName || node.page ? { type: 'page', name: String(node.pageName || node.page), label } : null;
+    case 'object':
+      return node.objectName || node.object
+        ? { type: 'object', name: String(node.objectName || node.object), label }
+        : null;
+    case 'dashboard':
+      return node.dashboardName || node.dashboard
+        ? { type: 'dashboard', name: String(node.dashboardName || node.dashboard), label }
+        : null;
+    case 'report':
+      return node.reportName || node.report
+        ? { type: 'report', name: String(node.reportName || node.report), label }
+        : null;
+    case 'view':
+      return node.viewName || node.view ? { type: 'view', name: String(node.viewName || node.view), label } : null;
+    // A nav action is a GLOBAL action by construction: `ActionNavItemSchema` is
+    // `.strict()` with exactly `{ actionName, params? }` and carries no
+    // `objectName`, so an object-scoped action is not addressable from the nav
+    // (see `useNavActionDispatch`, which resolves the name against `action`
+    // metadata at click time). That makes this leaf the design-time half of a
+    // surface the running app already dispatches (framework#4509) — before
+    // this case it rendered permanently disabled in the rail while the same
+    // entry worked in the shipped sidebar.
+    //
+    // Object-scoped actions keep their own home, the object's Actions tab
+    // (`ObjectActionsPanel`, objectui#2330) — this case cannot reach them and
+    // must not try to.
+    case 'action':
+      return node.actionDef?.actionName
+        ? { type: 'action', name: String(node.actionDef.actionName), label }
+        : null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Walk the nav tree for the leaf that binds to `{type,name}`, returning its
+ * resolved Surface (carrying the node's label so the canvas title / highlight
+ * match). Backs the `?surface=` deep-link restore — a shared URL only names
+ * the target, so we re-derive the label from the live tree.
+ */
+export function findSurfaceInTree(nodes: NavNode[], target: { type: string; name: string }): Surface | null {
+  for (const node of nodes) {
+    if (node.type === 'group' || node.children?.length) {
+      const hit = findSurfaceInTree(node.children ?? [], target);
+      if (hit) return hit;
+    } else {
+      const s = resolveSurface(node);
+      if (s && s.type === target.type && s.name === target.name) return s;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes #4019

> ⚠️ **本 PR 只落了卡片的 `action` 一半。`dataset` 一半没有实现,也不应该在本 PR 里猜着实现** —— 理由见下面「前提复核」。合并前建议 PM 先把 `dataset` 拆成独立卡(否则 `Fixes` 会把一个尚有未决半边的卡片自动关掉)。

## 前提复核(stale-premise,卡片自己要求先做)

卡片的前提是「两类 preview 已注册,**只差 Interfaces pillar rail 接线**,与 view/page/dashboard/app/report 并列」。按 `origin/main` 逐条实测:

| 前提 | 实测 | 依据 |
|---|---|---|
| 两类 preview 已注册 | ✅ 属实,而且不止 preview —— 两类**还都注册了 default inspector** | `previews/index.ts` 的 `action` / `dataset` 两行;`inspectors/index.ts` 的 `ActionDefaultInspector` / `DatasetDefaultInspector` |
| Interfaces rail 是一个「类型列表」,把两类加进去即可 | ❌ **不成立**。该 pillar 的 rail 是当前包 App 的 `navigation` 树:`client.list('app')` → `appDraft.navigation` → `NavTree` → `resolveSurface`。view/page/dashboard/report 不是「并列列在 rail 上」,而是被 app 导航引用到才出现 | `StudioDesignSurface.tsx` 的 `InterfacesPillar`;#2657 的 2026-08-07 审计 §2(a) 早已记录「rails load exactly four types: object / flow / app / permission」 |
| 两类「无处可去」 | ❌ 两类今天都能在 Metadata Directory 列出/新建/编辑(注册表驱动) | 同一份审计 §2(b) |

也就是说卡片描述的那个「rail」在 main 上不存在。两个半边因此分道扬镳:

- **`action` 能落,而且是个真缺陷**:`NavigationItemSchema` 里**有** `action` 成员(`ActionNavItemSchema`),运行时也**真的**渲染并派发它(`NavigationRenderer` + `useNavActionDispatch`,framework#4509)。但 `resolveSurface` 没有 `action` 分支,于是同一个条目在设计器里是 `disabled` 的死条目 —— 产品里能用,设计器里点不开。这就是本 PR。
- **`dataset` 落不了**:`NavigationItemSchema` 是 `object | dashboard | page | url | report | action | component | separator | group` 九选一的判别联合,**没有 `dataset` 成员**。dataset 根本无法出现在 app 导航树里,除非改 spec(卡片明令「no framework/spec change required」),或者给 Interfaces pillar 新造一个「非导航的类型列表区」—— 后者是架构决策,不是 quick win。已按硬规停手回报,未写任何投机代码。

## 本 PR 做了什么

`resolveSurface` 增加 `action` 分支;导航里的 action 条目变为可点,打开标准设计面(`ActionPreview` 画布 + 已注册的 action inspector),草稿保存走 pillar 其余叶子完全相同的通用路径。

- **`navSurface.ts`(新)**:把 `resolveSurface` / `findSurfaceInTree` / `NavNode` / `Surface` 从 3729 行的 `StudioDesignSurface.tsx` 里抽出来,让这段绑定不用挂载整个 pillar 就能单测 —— 与同目录的 `packageSurfaces.ts`、`centerTab.ts` 是同一个既有做法。**新增的 `action` 分支是唯一的行为改动**,其余逐行照搬。
- **只读 `actionDef.actionName` 这一种拼写**。spec 对 `action` / `name` / `args` / `input` 是**具名拒绝**(objectstack#4001),不是第二拼写;实测 17.0.0-rc.6:`unrecognized_keys` on `actionDef` + `actionName` 缺失。这里加 `??` 兜底等于把 #4001 关掉的 bug(条目派发了作者没声明的 action)重新打开 —— 契约优先(Commandment #0.1)。
- **`url` / `separator` / `component` 仍然不可解析,这是对的**:站外链接、分隔线、代码内置 UI,都没有可设计的元数据条目。唯独 `action` 是「有元数据类型却被漏在这一桶里」。
- **对象级 action 不受影响**:`ActionNavItemSchema` 是严格的 `{ actionName, params? }`,**没有 `objectName`**,所以导航 action 天然只能是全局 action,这条路径够不着对象级的,也不该够着 —— 它们的家是对象的 Actions 页签(objectui#2330)。
- `InterfacesPillar` 导出(`DataPillar` / `AccessPillar` 早就是导出的),供 rail 级验收测试挂载。

## 验收实测

| 卡片验收 | 实测 |
|---|---|
| Interfaces pillar **列出** action 条目 | 改动前后都渲染,但改动前 `disabled`(40% 透明、点击无效);现在 `toBeEnabled()` 通过 |
| Interfaces pillar **打开** action 条目的标准编辑面 | 点击后画布面包屑变为 `action · sync_now`,`ActionPreview` 渲染出该 action 的标签 |
| dataset 同上 | **未实现** —— 见上,需要决策 |

## 测试

仓根跑,路径过滤:

```
pnpm exec vitest run packages/app-shell/src/views/studio-design/ --maxWorkers=2
  Test Files  28 passed (28)
       Tests  155 passed (155)
```

新增 9 个钉子(`navSurface.test.ts` 7 + `StudioDesignSurface.interfacesAction.test.tsx` 2)。fixture 不是靠眼睛判定的:正例直接过 spec 自己的 `NavigationItemSchema.safeParse` 断言为真,别名反例断言 spec 拒绝**且**设计器同样不解析 —— 免得钉子钉在一个 schema 根本不认的形状上。

`turbo run type-check --concurrency=2` → **81 successful, 81 total**。`node scripts/check-control-bytes.mjs` → OK;改动文件另做了一次 `grep -naP` 自查(0 命中)。新增文件 eslint 零告警。

## 反向验证(先预判方向,再跑)

摘掉 `case 'action'` 一条腿。**预判**:红 4 条 —— `navSurface.test.ts` 的「binds an action nav leaf」「reaches an action leaf nested in a group」,以及两条 pillar 测试(且**红在查询而非断言**上:叶子解析不出来时 rail 的 `title` 回落成 `node.label`,`findByTitle('action · sync_now')` 直接找不到)。

**实测:4 failed | 5 passed,恰好是点名的那 4 条**;两条 pillar 用例各耗时约 1050ms,正是 `findBy` 的 1000ms 超时,确认红在查询上。`git checkout` 还原(未用 `git stash`),复跑 9/9 绿。

**诚实标注**:5 条绿里有 **2 条是「因为什么都没产出而绿」**,不是覆盖 —— 「no actionName 时不解析」和「只认规范拼写」这两条都断言 `null`,腿被删掉后一切 action 形状都是 `null`,照样通过。它们防的是「产出一个无名 surface」和「接受 schema 拒绝的拼写」,不防这条腿本身;真正防这条腿的是上面点名的 4 条。

## 与源单裁定的核对(objectstack#6411 / #2657)

- #2657 的 2026-07-07 增量裁定:对象级 action 归对象页签,Interfaces 只放**全局** action。本 PR 与之一致,且是 spec 强制的(导航 action 结构上就没有 `objectName`)。
- 同一句里的另一半理由「`global_nav`」**已经作废**:`global_nav` 已随 objectstack#6888(protocol 17,维护者 2026-08-09 裁定)移出 `ACTION_LOCATIONS`,objectui#4169 于 2026-08-11 删掉了它的设计器面 —— 都发生在本卡建卡(2026-08-07/08-10)**之后**。这不影响本 PR:本 PR 接的是「全局 action 的编辑入口」,而全局 action 在运行时的家就是 app 导航本身,与 `locations` 无关。
- Part B 全线 `pm:on-hold`,本 PR 不触碰;framework/spec 零改动。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_