### PR TITLE
docs(gantt): make QuickFilterBar JSDoc English and point at the bundle keys (#4021)

### DIFF
--- a/.changeset/quickfilterbar-jsdoc-english.md
+++ b/.changeset/quickfilterbar-jsdoc-english.md
@@ -1,0 +1,9 @@
+---
+---
+
+Comment-only: `QuickFilterBar`'s JSDoc in `@object-ui/plugin-gantt` is now English
+throughout (Commandment #-1 covers code comments, not just user-facing text), and each
+`QuickFilterLabels` member points at the `gantt.quickFilter.*` bundle key the host
+`ObjectGantt` resolves it from. The Chinese examples predated objectstack#5427 moving
+those four strings into the bundle, so they no longer matched any call site's literal.
+No behaviour change — no shipped code, type, or string was touched (objectui#4021).

--- a/packages/plugin-gantt/src/QuickFilterBar.tsx
+++ b/packages/plugin-gantt/src/QuickFilterBar.tsx
@@ -7,7 +7,7 @@
  */
 
 /**
- * QuickFilterBar (快速筛选栏) — a presentational, fully-controlled row of
+ * QuickFilterBar — a presentational, fully-controlled row of quick-filter
  * multi-select dropdowns rendered above the Gantt grid. Each dropdown narrows
  * the visible task bars by one dimension (project / product / status / …); the
  * owning ObjectGantt resolves the option lists (from select options, lookups,
@@ -37,14 +37,26 @@ export interface QuickFilterField {
   options: QuickFilterOption[];
 }
 
+/**
+ * Display strings for the bar. Every member is optional: `all`, `clear` and
+ * `empty` fall back to English defaults and an omitted `resultSummary` simply
+ * hides the summary, so a label is only ever *supplied* by the owner.
+ * The owning `ObjectGantt` passes translated values resolved from the
+ * `gantt.quickFilter.*` bundle namespace (objectstack#5427); the `Host:` key
+ * noted on each member is where that value comes from.
+ */
 export interface QuickFilterLabels {
-  /** "全部" / "All" — the select-all toggle and empty-selection trigger text. */
+  /** Select-all toggle and empty-selection trigger text. Host: `gantt.quickFilter.all`. */
   all?: string;
-  /** "清除筛选" / "Clear" — clears every dimension. */
+  /** Clears every dimension. Host: `gantt.quickFilter.clear`. */
   clear?: string;
-  /** Builds the "showing N / M" summary; omit to hide the summary. */
+  /**
+   * Builds the "showing N / M" summary; omit to hide the summary.
+   * Host: `gantt.quickFilter.resultSummary` (single-brace `{shown}` / `{total}`
+   * placeholders, resolved at the call site by a literal `.replace`).
+   */
   resultSummary?: (shown: number, total: number) => string;
-  /** Placeholder shown when a dimension resolved zero options. */
+  /** Placeholder shown when a dimension resolved zero options. Host: `gantt.quickFilter.empty`. */
   empty?: string;
 }
 


### PR DESCRIPTION
Fixes #4021

## 改了什么

`packages/plugin-gantt/src/QuickFilterBar.tsx` 三处中文注释改成纯英文 —— 诫条 #-1 的措辞覆盖 code comments,不止用户可见文案。

- 模块头 JSDoc(第 10 行)的括注 "快速筛选栏";
- `QuickFilterLabels` 的 `all`(第 41 行)与 `clear`(第 43 行)成员注释。

顺带把该 interface 四个成员的注释都指向宿主词条键(卡内建议形态),并给 interface 本身加了一句说明回退行为。

## 为什么不只是换语言

那两条成员注释里的中文**同时也是过期信息**:它们引的是宿主曾经硬编码的字面量,而 objectstack#5427 已把四条文案挪进 `gantt.quickFilter.*` 词条,注释里的引文不再对应任何调用点。所以不是原样翻译,而是改写成"这个 label 由宿主从哪个键取值":

- `all` -- `gantt.quickFilter.all`
- `clear` -- `gantt.quickFilter.clear`
- `empty` -- `gantt.quickFilter.empty`
- `resultSummary` -- `gantt.quickFilter.resultSummary`(并注明它是**单花括号**占位符、由调用点 `.replace` 解析,不是 i18next 插值 —— 这条约定在 `useGanttTranslation.ts` 与 `gantt-quickfilter-locale-parity.test.ts` 里都被钉住,objectui#4157 是把它写反的前情)

四个键均**先核实存在**再落笔:`packages/i18n/src/locales/en.ts:871` 的 `quickFilter` 块、`packages/plugin-gantt/src/useGanttTranslation.ts:90-102` 的独立回退表、调用点 `packages/plugin-gantt/src/ObjectGantt.tsx:1417-1423`。

interface 头新增的那句(`all`/`clear`/`empty` 回退英文默认值,`resultSummary` 省略即隐藏 summary)也按实现核过:`QuickFilterBar.tsx:288-290` 与 `:314`。

## 范围

- ⛔ 未动任何行为代码:diff 纯注释,无代码/类型/字符串变更。
- ⛔ 未动 `QuickFilterBar.test.tsx:40` 一带的中文夹具 —— issue 正文已裁明那是被验证的测试数据,是否统一改写由维护者定,不属本单。
- 本包其余源码文件仍有中文注释(见下"相邻发现"),按"不扩围"另单记录,本 PR 不碰。

## 验证

注释-only 改动**没有任何门可以为它变红**,如实记录:仓内没有任何 lint 规则或脚本机械强制诫条 #-1 的英文注释条款(`eslint.config.js` 与 `scripts/` 均无对应规则,这也正是这类残留能长期存在的原因)。因此判据是下面两条正向核验,而不是"改前红、改后绿":

1. **中文字符归零**(ripgrep `\p{Han}`,该文件):改前 3 行(10 / 41 / 43),改后 `No matches found`。
2. **词条键实存**:上面四个键的三处落点均已核实,并跑绿了钉住它们的测试。

跑过的命令:

```
pnpm exec vitest run packages/plugin-gantt/src/QuickFilterBar.test.tsx --maxWorkers=2
  -- Test Files 1 passed (1) / Tests 10 passed (10)

pnpm exec vitest run packages/i18n/src/__tests__/gantt-quickfilter-locale-parity.test.ts \
  packages/plugin-gantt/src/ObjectGantt.quickfilter.i18n.test.tsx \
  packages/plugin-gantt/src/ObjectGantt.quickfilter.i18n.fallback.test.tsx --maxWorkers=2
  -- Test Files 3 passed (3) / Tests 26 passed (26)

pnpm exec turbo run type-check --concurrency=2
  -- Tasks: 81 successful, 81 total

node scripts/check-control-bytes.mjs
  -- OK (scanned 4369 tracked text file(s); skipped 85 binary)

node scripts/check-changeset-presence.mjs
  -- OK,1 changeset,EMPTY frontmatter(该门明文的免除形态)
```

## changeset

按 `check-changeset-presence` 自身读数处理:`packages/plugin-gantt/src/**` 在受守面内,故必须声明;而这是零行为变更,用该门明文承认的**空 frontmatter** 形态声明(`.changeset/quickfilterbar-jsdoc-english.md`),不发版本。

## 相邻发现(不扩围)

`plugin-gantt` 其余源码文件仍有同形中文注释 —— `GanttView.tsx`(93 行)、`ObjectGantt.tsx`(51)、`shifts.ts`(9)、`scheduling.ts`(8)、`ResourceWorkload.tsx`(1)、`workload.ts`(1)。已逐一确认**全部位于注释内**(JSDoc 括注、行尾注释、JSX 注释块),非测试源码里没有中文运行期字符串,故与本单同属 observation-class。按"别的文件不扩围"另开单记录,不在本 PR 处理。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_