### PR TITLE
fix(app-shell): metadata-admin 的 artifact 锁改问 provenance，可写包里的对象不再误挂只读 banner (#4308)

### DIFF
--- a/.changeset/metadata-admin-writable-package-banner-4308.md
+++ b/.changeset/metadata-admin-writable-package-banner-4308.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin stops declaring an object "provided by an installed package" when it lives in a writable package
+
+For an object published into a **writable** package, three surfaces disagreed about whether it could be edited: the metadata-admin designer showed the artifact lock banner — _"This object is provided by an installed package, so it is read-only at runtime. To change it, edit it in its source package and republish"_ — while Studio presented the same object as editable and the server accepted the PUT. The banner asserted a lock nothing enforced, so an operator who believed it went off to republish a source package for a change they could have made in front of them.
+
+The cause was the tier test this page uses to pick between the two-tier authorization gates: overlaying a code-shipped artifact needs `allowOrgOverride`, authoring org content needs only `allowRuntimeCreate`. It asked whether a `code` layer exists and is not tagged with the `sys_metadata` sentinel — and an org-authored item satisfies both, because boot-time rehydration of `sys_metadata` re-registers each row under its **real** package id. `object` is precisely the type where the two gates diverge (`allowOrgOverride: false`, `allowRuntimeCreate: true`), so the mis-tiering surfaced as a hard lock.
+
+The page now also asks ADR-0010 `provenance`, which the server already ships on the layered envelope and which is the axis that actually separates tenant-authored content from code-shipped artifacts. This is not a new opinion about writability: the framework was bitten by the identical read and fixed it the same way (`isTenantAuthored`, cloud#970 — an app the user had just built went un-editable at the first kernel rebuild); this page still carried the pre-cloud#970 spelling. The two in-place copies of the test, which is how they drifted apart in the first place, are now one derivation.
+
+Nothing was loosened. A genuine code package still reports `provenance: 'package'` and stays read-only here, per the objectui#4036 ruling — "a code-defined package is read-only; customize in a writable package" is one rule, and this only stops it firing on packages that are not code-defined. An item with no provenance stamped (older server) keeps the conservative artifact reading rather than unlocking on a missing field, matching the `lock` flags beside it. The suite pins both directions: the banner is gone for a writable package and the form is genuinely editable, and it is still rendered for a code package, for the legacy `sys_metadata` sentinel, and for an unstamped item.
+
+The banner wording is unchanged — it is now shown only where it was always accurate.

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -113,8 +113,9 @@ interface ObjectSummary {
  * Is this item backed by a **code-package artifact**? (objectui#4518)
  *
  * The client-side mirror of the server's `isArtifactBacked`
- * (metadata-protocol `protocol.ts`), and byte-for-byte the same predicate
- * `ResourceEditPage:1332` already computes inline for its own two-tier gate.
+ * (metadata-protocol `protocol.ts`). It began as byte-for-byte the predicate
+ * `ResourceEditPage` computes for its own two-tier gate; the two are NO LONGER
+ * identical — see the divergence note at the end.
  *
  * A non-null `code` layer alone is NOT proof of a code package: a published
  * ORG item also surfaces its active version in `code`, tagged with the
@@ -129,6 +130,21 @@ interface ObjectSummary {
  * `layered?.code != null` does, it is the pre-#4518 behaviour, and a transient
  * read failure must not invent a lock. The cost is bounded and honest — the
  * save still round-trips to the server's own gate.
+ *
+ * ── Divergence from `ResourceEditPage` (objectui#4308) ────────────────────
+ * The sibling now ALSO excludes ADR-0010 `provenance === 'org'`. The sentinel
+ * this function tests holds only on the save path: boot-time rehydration of
+ * `sys_metadata` re-registers each row under its REAL package id, so a
+ * tenant's own item reads back with a code-looking `_packageId` and this
+ * predicate calls it an artifact. The framework hit the same thing and fixed
+ * it by asking provenance (`isTenantAuthored`, cloud#970).
+ *
+ * That gap is NOT reachable here today: the artifact tier is gated on
+ * `!packageId` (see `artifactTierApplies`), so under a package door — the
+ * writable-package case #4308 reports, and the one #4446 fixed for this
+ * editor — this function is never consulted. The env-door residue is filed on
+ * objectui#4526 together with that card's own over-lock. Adopt provenance here
+ * when #4526 is picked up, rather than re-copying the sibling's expression.
  */
 function isArtifactBackedLayer(layered: { code?: unknown } | null | undefined): boolean {
   const code = layered?.code;

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.artifactTier.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.artifactTier.test.tsx
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The metadata-admin designer must claim "provided by an installed package"
+ * only for items that really come from one — objectui#4308.
+ *
+ * ## The defect
+ *
+ * Three surfaces disagreed about one object. For an object published into a
+ * WRITABLE package, this page showed the artifact lock banner while Studio
+ * presented the same object as editable and the server accepted the PUT. The
+ * banner therefore asserted a lock nothing enforced, sending an operator off
+ * to "edit it in its source package and republish" for a change they could
+ * have made in front of them.
+ *
+ * The cause was the tier test this page used to decide which of the two-tier
+ * gates applies. It asked only "is there a `code` layer, and is it not the
+ * `sys_metadata` sentinel" — and an org-authored item satisfies both, because
+ * boot-time rehydration of `sys_metadata` re-registers each row under its REAL
+ * package id. The framework had already been bitten by the identical read
+ * (cloud#970: an app the user had just built went un-editable at the first
+ * kernel rebuild) and fixed it by asking ADR-0010 provenance instead. This
+ * page still carried the pre-cloud#970 spelling.
+ *
+ * ## What this suite pins — both directions, deliberately
+ *
+ * The fix must not degenerate into "drop the lock". Half of these cases assert
+ * the banner is GONE where the package is writable, and half assert it is
+ * STILL THERE for a genuine code package — which is the objectui#4036 ruling
+ * ("a code-defined package is read-only; customize in a writable package") and
+ * must survive this change untouched. The unstamped-provenance case pins the
+ * fail direction for an older server: no opinion keeps the conservative
+ * artifact reading rather than unlocking on a guess.
+ *
+ * `object` is the type under test because it is the type the card reports and
+ * the one where the two tiers actually diverge: `allowOrgOverride: false` (the
+ * server refuses overlays of packaged objects with `NOT_OVERRIDABLE`) with
+ * `allowRuntimeCreate: true` (orgs author their own). A type with both flags
+ * true would be writable under either tier and could not detect the bug.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+/** The object body as the code layer surfaces it, minus provenance tags. */
+const objectDef = {
+  name: 'showcase_account',
+  label: 'Account',
+  fields: [{ name: 'title', label: 'Title', type: 'text' }],
+};
+
+const layeredImpl = { current: vi.fn() };
+
+const mockClient = {
+  list: vi.fn(async () => []),
+  listDrafts: vi.fn(async () => []),
+  get: vi.fn(async () => null),
+  getDraft: vi.fn(async () => null),
+  references: vi.fn(async () => []),
+  layered: vi.fn(async (...args: unknown[]) => layeredImpl.current(...args)),
+};
+
+// The registry entry for `object`: overlaying a PACKAGED object is refused by
+// the server (`allowOrgOverride: false`), authoring your own is not
+// (`allowRuntimeCreate: true`). Which of those two gates this page applies is
+// exactly what the tier test decides.
+vi.mock('./useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({
+      loading: false,
+      error: null,
+      entries: [
+        {
+          type: 'object',
+          name: 'object',
+          label: 'Object',
+          allowOrgOverride: false,
+          allowRuntimeCreate: true,
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' }, label: { type: 'string' } },
+          },
+        },
+      ],
+    }),
+  };
+});
+
+import { MetadataResourceEditPage } from './ResourceEditPage';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/**
+ * Mount the editor over one layered envelope. `code` carries the tags the
+ * server stamps; `provenance` is the top-level ADR-0010 flag the server
+ * resolves from the code layer and ships on the envelope.
+ */
+async function renderEditor(layered: Record<string, unknown>) {
+  layeredImpl.current = vi.fn(async () => layered);
+  render(
+    <MemoryRouter initialEntries={['/metadata/object/showcase_account']}>
+      <MetadataResourceEditPage type="object" name="showcase_account" />
+    </MemoryRouter>,
+  );
+  // The load effect has resolved once the layered read has been consumed;
+  // each assertion below then waits on the chrome it actually cares about.
+  await waitFor(() => expect(mockClient.layered).toHaveBeenCalled());
+}
+
+/** The read-only notice, addressed by testid — its two texts are asserted separately. */
+function banner(): HTMLElement | null {
+  return screen.queryByTestId('readonly-banner');
+}
+
+const INSTALLED_PACKAGE_CLAIM = 'provided by an installed package';
+
+describe('ResourceEditPage — the artifact lock follows provenance, not the package tag (#4308)', () => {
+  it('writable package: an org-authored object carries NO installed-package lock', async () => {
+    // The card's case. The row lives in a writable base, so rehydration gave
+    // it a real-looking `_packageId` — and `_provenance: 'org'` is what says
+    // it is the org's own content.
+    await renderEditor({
+      code: {
+        ...objectDef,
+        _packageId: 'com.example.base',
+        _provenance: 'org',
+      },
+      overlay: null,
+      overlayScope: null,
+      effective: objectDef,
+      provenance: 'org',
+      packageId: 'com.example.base',
+      editable: true,
+    });
+
+    await waitFor(() => {
+      expect(banner()).toBeNull();
+    });
+    expect(screen.queryByText(new RegExp(INSTALLED_PACKAGE_CLAIM))).toBeNull();
+  });
+
+  it('writable package: the editor is actually editable, not merely un-bannered', async () => {
+    // Suppressing the banner while leaving the form read-only would satisfy
+    // the assertion above and still ship the defect — the operator would just
+    // lose the explanation for a lock that is still there.
+    await renderEditor({
+      code: { ...objectDef, _packageId: 'com.example.base', _provenance: 'org' },
+      overlay: null,
+      overlayScope: null,
+      effective: objectDef,
+      provenance: 'org',
+      packageId: 'com.example.base',
+      editable: true,
+    });
+
+    await waitFor(() => expect(banner()).toBeNull());
+    // `canWrite` drives the Save affordance; a read-only page offers none.
+    const saveish = await screen.findAllByRole('button');
+    const labels = saveish.map((b) => (b.textContent ?? '').trim().toLowerCase());
+    expect(labels.some((l) => l.includes('save') || l.includes('edit'))).toBe(true);
+  });
+
+  it('code package: a genuine packaged object KEEPS the installed-package lock', async () => {
+    // The objectui#4036 ruling, pinned from this side: a code-defined package
+    // stays read-only here. If the fix ever widens into "drop the lock", this
+    // is the test that goes red.
+    await renderEditor({
+      code: {
+        ...objectDef,
+        _packageId: 'com.example.showcase',
+        _provenance: 'package',
+      },
+      overlay: null,
+      overlayScope: null,
+      effective: objectDef,
+      provenance: 'package',
+      packageId: 'com.example.showcase',
+      editable: true,
+    });
+
+    const el = await waitFor(() => {
+      const b = banner();
+      expect(b).not.toBeNull();
+      return b as HTMLElement;
+    });
+    // The banner text interpolates `{type}` as a <code> node, so read the
+    // whole subtree rather than matching one text node.
+    expect(el.textContent).toContain(INSTALLED_PACKAGE_CLAIM);
+  });
+
+  it('legacy sentinel: a `sys_metadata`-tagged code layer stays unlocked', async () => {
+    // The save-path sentinel carve-out that predates this change. It still
+    // holds — the provenance test is an ADDITIONAL exclusion, not a swap.
+    await renderEditor({
+      code: { ...objectDef, _packageId: 'sys_metadata' },
+      overlay: null,
+      overlayScope: null,
+      effective: objectDef,
+      packageId: 'sys_metadata',
+      editable: true,
+    });
+
+    await waitFor(() => {
+      expect(banner()).toBeNull();
+    });
+  });
+
+  it('no provenance opinion: an unstamped code layer keeps the conservative lock', async () => {
+    // Older server / unstamped item. `undefined` is not `'org'`, so the item
+    // stays in the artifact tier — the same fail direction the `lock*` flags
+    // beside it already take. Unlocking on a missing field would be a guess.
+    await renderEditor({
+      code: { ...objectDef, _packageId: 'com.example.showcase' },
+      overlay: null,
+      overlayScope: null,
+      effective: objectDef,
+      packageId: 'com.example.showcase',
+      editable: true,
+    });
+
+    const el = await waitFor(() => {
+      const b = banner();
+      expect(b).not.toBeNull();
+      return b as HTMLElement;
+    });
+    expect(el.textContent).toContain(INSTALLED_PACKAGE_CLAIM);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -949,6 +949,53 @@ function MetadataResourceEditPageImpl({
     return () => window.removeEventListener('keydown', onKey);
   }, [isFullscreen]);
 
+  // ── Is this item a packaged ARTIFACT, or org-authored content? ────────
+  // The two-tier authorization model (PR-10d.7) applies a different gate to
+  // each: overlaying a code-shipped artifact needs `allowOrgOverride`, while
+  // authoring org content needs only `allowRuntimeCreate`. Several call sites
+  // below key off the answer, so it is derived ONCE here — the previous two
+  // in-place copies are how the two drifted from the server (objectui#4308).
+  //
+  // A non-null `code` layer is NOT by itself proof of a packaged artifact: it
+  // only proves that SOME package tagged the item, and org-authored items
+  // carry a package tag too. Two exclusions cover that, and they mirror the
+  // server rather than guessing alongside it:
+  //
+  //   1. `_packageId === 'sys_metadata'` — the save-path sentinel for a
+  //      published org item, excluded by the protocol's own
+  //      `isArtifactBacked` / `lookupArtifactItem`.
+  //   2. `provenance === 'org'` (ADR-0010) — the axis that actually separates
+  //      tenant-authored content from code-shipped artifacts. The sentinel in
+  //      (1) holds only on the save path: boot-time rehydration of
+  //      `sys_metadata` re-registers each row under its REAL package id, so a
+  //      tenant's own item reads back with a code-looking `_packageId`. The
+  //      framework hit exactly this and fixed it by asking provenance instead
+  //      (`isTenantAuthored`, cloud#970) — an app the user had just built went
+  //      un-editable at the first kernel rebuild. This page still carried the
+  //      pre-cloud#970 spelling, which is objectui#4308: an object published
+  //      into a WRITABLE package was mis-tiered as a packaged artifact, so
+  //      this pillar alone showed the "provided by an installed package"
+  //      lock while Studio treated it as editable and the server accepted the
+  //      PUT.
+  //
+  // The server ships the answer on the layered envelope, so we read it rather
+  // than re-deriving package writability from a third source. `provenance`
+  // describes `code` here (the server resolves it from `code ?? overlay`, and
+  // this branch already requires `code != null`); `undefined` means "no
+  // opinion" (older server / unstamped item) and keeps the conservative
+  // artifact reading, matching the `lock*` flags below.
+  //
+  // Deliberately NOT loosened: a genuine code package still reports
+  // `provenance: 'package'` and stays read-only here, per the objectui#4036
+  // ruling — "a code-defined package is read-only; customize in a writable
+  // package" is one rule, and this change only stops it firing on packages
+  // that are not code-defined.
+  const isArtifactItem =
+    !createMode
+    && layered?.code != null
+    && (layered.code as { _packageId?: string } | null)?._packageId !== 'sys_metadata'
+    && layered?.provenance !== 'org';
+
   // Auto-enable design mode for designer-capable types. We do this once
   // per (type,name) navigation so the user lands in the productive
   // state instead of having to click "Edit". Truly read-only types
@@ -965,18 +1012,16 @@ function MetadataResourceEditPageImpl({
     if (designerAutoOnRef.current === key) return;
     const PC = getMetadataPreview(type);
     if (!PC) return;
-    // See `isArtifactItem` below — a `sys_metadata`-tagged code layer is a
-    // published org object, NOT a packaged artifact, so it stays editable.
-    const isArtifact =
-      layered?.code != null
-      && (layered.code as { _packageId?: string } | null)?._packageId !== 'sys_metadata';
-    const cw = isArtifact
+    // Same tier question as the Save gate below, from the same derivation —
+    // this used to be an in-place copy of the artifact heuristic, so the two
+    // could (and did) answer differently for one item (objectui#4308).
+    const cw = isArtifactItem
       ? !!entry?.allowOrgOverride
       : !!(entry?.allowOrgOverride || entry?.allowRuntimeCreate);
     if (!cw) return;
     designerAutoOnRef.current = key;
     setEditing(true);
-  }, [type, name, createMode, embedded, loading, entry, layered]);
+  }, [type, name, createMode, embedded, loading, entry, isArtifactItem]);
 
   // Keyboard shortcut: Cmd/Ctrl+\ toggles the inspector. This is the
   // designer convention shared by Figma, VS Code (Cmd+B), Sketch — `\`
@@ -1325,19 +1370,12 @@ function MetadataResourceEditPageImpl({
   // Two-tier authorization (PR-10d.7) — hoisted above the early `loading`
   // return so the auto-save / keyboard / blocker effects below can read
   // them. Recomputed cheaply on every render.
-  //   - artifact-backed items (layered.code != null) need allowOrgOverride
-  //   - DB-only items (no artifact) need allowOrgOverride OR allowRuntimeCreate
+  //   - artifact-backed items need allowOrgOverride
+  //   - org-authored items need allowOrgOverride OR allowRuntimeCreate
   //   - createMode is always writable (the server will gate on intent)
-  // A non-null `code` layer alone is NOT proof of a code (artifact) package:
-  // a published org object also surfaces its active version in `code`, but
-  // tagged with the `sys_metadata` provenance sentinel. Mirror the server's
-  // `isArtifactBacked` (which excludes `_packageId === 'sys_metadata'`) so an
-  // org-authored object stays editable after publish instead of being mis-read
-  // as a read-only packaged item.
-  const isArtifactItem =
-    !createMode
-    && layered?.code != null
-    && (layered.code as { _packageId?: string } | null)?._packageId !== 'sys_metadata';
+  // Which tier this item is in is decided once, next to the designer
+  // auto-on effect above — see `isArtifactItem` for why a non-null `code`
+  // layer alone cannot answer it.
   // ADR-0010 — server-computed lock flags. undefined means "no opinion"
   // (older server / non-lockable item) → preserve legacy behaviour.
   const lockEditable = layered?.editable !== false;


### PR DESCRIPTION
Fixes #4308

## 症状与病灶

发布到**可写**包里的对象，三个面各说各话：metadata-admin 设计器挂出 “provided by an installed package, so it is read-only at runtime” 的 artifact 锁 banner，Studio 却把同一个对象当作可编辑，服务端也接受 PUT。banner 断言了一把没人执行的锁 —— 运维照着它去「回源包改了再发布」，而这个改动本来在眼前就能做。

病灶在本页选择两级授权闸门的判定。覆盖代码包发来的 artifact 需要 `allowOrgOverride`；编写组织自有内容只需要 `allowRuntimeCreate`。旧判定只问两件事 —— 有没有 `code` 层、是不是 `sys_metadata` 哨兵 —— 而**组织自有条目两条都满足**：`sys_metadata` 哨兵只在保存路径上成立，启动期回灌会按**真实包 id** 重新注册每一行。`object` 恰好是两级闸门分叉的类型（`allowOrgOverride: false`、`allowRuntimeCreate: true`），所以误判直接表现为一把硬锁。

## 裁定源与判定源（未发明第四份口径）

本卡正文点名与 #4036 的 question A 同裁。#4036 已于 08-15 裁定 A1：**「代码定义的包在 Studio 里只读，去可写包里定制」是一条包级规则**（B 半 PR #4341 已把误导性 affordance 收敛到这条规则，A2 已在服务端落地）。该裁定覆盖本卡且极性一致：真正该被锁的是**代码定义的包**，而不是「带包标签」。本次只是让这条规则不再落到并非代码定义的包上。

判定源直接取**服务端已经算好并挂在 layered 信封上**的 ADR-0010 `provenance`，而不是在客户端第三次推导包可写性：

- 框架被同一个读法咬过并以同样方式修复过 —— `isTenantAuthored`（cloud#970：用户刚在 Studio 里建好的应用，第一次内核重建后就再也改不动），其注释明写「`_packageId !== 'sys_metadata'` 单独回答不了这个问题……provenance 才是真正区分的那根轴」。
- 本页留的正是 cloud#970 **之前**的那份拼写。所以这不是新增一份口径，而是把客户端对齐到服务端现行的那一份。

原先散在两处的同一判定（:951-955 与 :1311-1323 —— 它们正是这样漂开的）合并为**一处推导**，两个站点同修。

## 未放松任何闸门

- 真正的代码包 `provenance` 为 `package`，在此仍然只读 —— #4036 裁定原样保留。
- 遗留 `sys_metadata` 哨兵的豁免**保留**：provenance 是**新增**的排除项，不是替换。
- 未打 provenance 的条目（旧服务端）保持保守的 artifact 读法，不因缺字段而擅自解锁 —— 与旁边的 `lock` 系列标志同向。

banner 文案（`i18n.ts`）未改：语义没变，它现在只出现在本来就说得对的地方。

## 反向验证（先预判方向，再跑）

预判：删掉 `provenance` 那条肢，**可写包的两条钉红**，其余三条「未放松」控制项**保持绿**（控制项若变红，说明修复过界了）。实测与预判一致：

```
× writable package: an org-authored object carries NO installed-package lock
× writable package: the editor is actually editable, not merely un-bannered
  Tests  2 failed | 3 passed (5)
```

第二条钉子专门防「只拆 banner、表单仍然锁着」的假修 —— 它同样变红，证明断言非空转。还原后 5/5 全绿。

## 提交构成

1. **修复 + 测试 + changeset**（`ResourceEditPage.tsx`）。
2. **仅注释**（`PermissionMatrixEditor.tsx`）：该文件的 doc 原本自陈与本页判定「byte-for-byte 相同」并引用了行号 `ResourceEditPage:1332` —— 第 1 个提交让这句话变成假的、行号也失效。改为写明分叉内容、以及它今天为何不可达（本编辑器的 artifact 档由 `!packageId` 把关，包门下根本不查该谓词），并指向 #4526 统一处理。无行为改动。

## 测试

- 新增 `ResourceEditPage.artifactTier.test.tsx`：5 例，双向都钉（可写包无 banner 且可编辑；代码包、遗留哨兵、未打 provenance 三形态 banner 仍在）。
- `metadata-admin` + `studio-design` 全量回归：200 文件 / 1869 通过。
- 仓根 `turbo run type-check`：81/81。ESLint 改动文件 0 error。

## 相邻发现（未在本 PR 扩围）

- `PermissionMatrixEditor.isArtifactBackedLayer` 的同款陈旧拼写：env 门下的残留已评注到既有 open 卡 **#4526**（未开孪生单）；本 PR 只更正其失效注释。
- **#4886**（新立）：`doReset` 用的是第三份更松的读法（`layered?.code != null`），与按钮图标/提示所用的判定不一致 —— 图标写「删除」、确认框却问「重置」，且条目不会被删除。今日即可达（已发布的组织自有条目），本 PR 会扩大暴露面但既未引入也未修复；涉及破坏性动作与产品语义判定，故立单不顺手改。