### PR TITLE
docs(gantt): make the remaining plugin-gantt source comments English (#4884)

### DIFF
--- a/.changeset/gantt-source-comments-english.md
+++ b/.changeset/gantt-source-comments-english.md
@@ -1,0 +1,16 @@
+---
+---
+
+Comment-only: the remaining six non-test source files in `@object-ui/plugin-gantt`
+(`GanttView.tsx`, `ObjectGantt.tsx`, `shifts.ts`, `scheduling.ts`, `ResourceWorkload.tsx`,
+`workload.ts`) now carry English comments throughout — Commandment #-1 covers code
+comments, not just user-facing text. This is the sequel to objectui#4021 / PR #4883,
+which did the same for `QuickFilterBar.tsx` in the same package.
+
+Comments that named a UI label now point at the `gantt.*` bundle key that actually
+resolves it (`gantt.toolbar.saveLayout`, `gantt.menu.removeDependency`,
+`gantt.conflict.confirm`, …) instead of quoting a Chinese literal that no call site
+holds any more, and one comment block that had drifted above the wrong dialog was moved
+back over the JSX it describes. No behaviour change — every one of the six files is
+byte-identical after comment stripping, so no shipped code, type, or string was touched
+(objectui#4884).

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -48,7 +48,8 @@ const COLUMN_WIDTH = 100; // Time column width
 // Width, in px, of the resize "grab zone" at each end of a task bar. The visible
 // grip is only a few px, but pointer synthesis in headless browsers quantizes the
 // click coordinate, so a click aimed at the edge routinely lands a pixel or two
-// inside the bar body — starting a MOVE instead of a resize (命中不稳). Treating a
+// inside the bar body — starting a MOVE instead of a resize (unstable hit
+// detection). Treating a
 // full-height band at each end as a resize edge makes the hit deterministic.
 const RESIZE_EDGE_PX = 8;
 
@@ -143,9 +144,9 @@ export interface GanttTask {
   progress: number
   color?: string
   /**
-   * Per-task alert stroke (逐任务预警描边). When set, the bar/milestone/summary
+   * Per-task alert stroke. When set, the bar/milestone/summary
    * is outlined in this color (border + 2px halo) without touching its fill —
-   * e.g. red for 超期, amber for 临期, unset for normal. Maps from the view's
+   * e.g. red for overdue, amber for due-soon, unset for normal. Maps from the view's
    * `borderColorField` in ObjectGantt. The critical-path overlay, when active,
    * takes precedence on the rows it marks.
    */
@@ -157,16 +158,17 @@ export interface GanttTask {
   /**
    * Node kind. Defaults to a leaf `task` (or `summary` automatically when it has
    * children). Set `'group'` to render a pure tree header — expandable/collapsible
-   * like a summary but with NO timeline bar (用于 项目/产品 这类纯分组层级，左侧成树、右侧无条).
+   * like a summary but with NO timeline bar (for project / product style pure
+   * grouping levels: a tree on the left, no bar on the right).
    * Its children still render their own bars normally.
    */
   type?: GanttTaskType
   /**
-   * Per-node lock (仅查看/跳转). When true this row is view-only: its bar can't be
+   * Per-node lock (view-only / click-through). When true this row is view-only: its bar can't be
    * dragged/resized, progress can't be dragged, no dependency can be drawn from
    * it, and inline-edit / context-menu edit+delete are hidden. Clicking the bar
    * (onTaskClick — open drawer / jump) still works. Independent of the global
-   * `readOnly`; use to lock individual levels (e.g. 派工单) while others stay
+   * `readOnly`; use to lock individual levels (e.g. work orders) while others stay
    * editable. Maps from the view's `lockField` in ObjectGantt.
    */
   locked?: boolean
@@ -177,7 +179,7 @@ export interface GanttTask {
   baselineStart?: Date
   baselineEnd?: Date
   /**
-   * Extra label/value rows for the hover tooltip (悬浮详情), in display order.
+   * Extra label/value rows for the hover tooltip, in display order.
    * Populated from the view's `tooltipFields` config (resolved + formatted by
    * ObjectGantt). When present they replace the default date·duration·progress
    * line in the tooltip.
@@ -226,7 +228,7 @@ function tzOffsetMs(timeZone: string, at: Date): number {
 }
 
 /**
- * "Shifted clock" for business-time-zone rendering (业务时区渲染): translate
+ * "Shifted clock" for business-time-zone rendering: translate
  * real instants into a display space where the browser's local clock reads
  * the CONFIGURED zone's wall time. All existing local-clock logic — shift
  * bands, day columns, snapping, the today line, date labels — then renders
@@ -314,7 +316,7 @@ export interface GanttMarker {
 }
 
 /**
- * Per-interaction switches (交互开关) — the DHTMLX `drag_move` / `drag_resize` /
+ * Per-interaction switches — the DHTMLX `drag_move` / `drag_resize` /
  * `drag_progress` / `drag_links` model. Each defaults to true; flipping one off
  * hides that affordance everywhere while the others keep working. They only
  * NARROW what the write callbacks / `readOnly` / row locks already allow —
@@ -358,7 +360,8 @@ export interface GanttViewProps {
   onBeforeDependencyCreate?: (source: GanttTask, target: GanttTask, type: GanttLinkType) => boolean
   /**
    * Enables dependency removal: right-clicking a dependency link opens a menu
-   * with "移除依赖" and a type switch. Called with the source/target tasks of the
+   * with a "Remove dependency" entry (`gantt.menu.removeDependency`) and a type
+   * switch. Called with the source/target tasks of the
    * removed link (target no longer depends on source).
    */
   onDependencyDelete?: (source: GanttTask, target: GanttTask) => void
@@ -373,17 +376,18 @@ export interface GanttViewProps {
   inlineEdit?: boolean
   /**
    * Show the "auto-schedule" toolbar button. Clicking it runs a one-shot
-   * dependency-driven reschedule of the whole project (顺延): every successor is
+   * dependency-driven reschedule of the whole project (forward-only): every successor is
    * pushed later until its link constraints hold, preserving durations, and the
    * resulting date changes are emitted via `onTaskUpdate`. Requires onTaskUpdate.
    */
   autoSchedule?: boolean
   /**
    * After a bar drag/resize, validate the move against dependency constraints
-   * (拖拽冲突校验). If the new position would violate a link — the task moved
+   * If the new position would violate a link — the task moved
    * earlier than a predecessor allows, or its move pushes successors past their
-   * constraints — a confirmation prompts to 自动顺延 (cascade-reschedule the
-   * affected tasks, preserving durations) or keep the overlap. Requires
+   * constraints — a confirmation prompts to "Auto-reschedule"
+   * (`gantt.conflict.confirm` — cascade-reschedule the affected tasks,
+   * preserving durations) or keep the overlap. Requires
    * onTaskUpdate and only fires when links exist. Ignored in readOnly.
    */
   rescheduleOnConflict?: boolean
@@ -396,9 +400,9 @@ export interface GanttViewProps {
    */
   workingCalendar?: WorkingCalendar
   /**
-   * Shift segmentation (班次/排班分段). When set AND the active granularity is
-   * `day`, each day column is replaced by one column per band (白班 | 夜班…), and
-   * the upper header tier shows the 排班日 (shift-day starting at `dayStart`, e.g.
+   * Shift segmentation. When set AND the active granularity is
+   * `day`, each day column is replaced by one column per band (day | night | …),
+   * and the upper header tier shows the shift-day (starting at `dayStart`, e.g.
    * 08:00). Drag/resize then snaps to band boundaries instead of whole days.
    * Off by default → existing gantts are unaffected (parity with `folding`).
    * Mutually exclusive with weekend/holiday folding (segmenting wins).
@@ -417,7 +421,7 @@ export interface GanttViewProps {
    */
   readOnly?: boolean
   /**
-   * Mobile read-only (移动端只读缩略). When true, the chart auto-enters read-only
+   * Mobile read-only. When true, the chart auto-enters read-only
    * mode on narrow viewports (< 640px) so touch users get a clean, scrollable
    * thumbnail of the schedule instead of error-prone drag editing — equivalent
    * to `readOnly` but scoped to small screens. Wider viewports are unaffected.
@@ -425,7 +429,7 @@ export interface GanttViewProps {
    */
   mobileReadOnly?: boolean
   /**
-   * Dynamic grouping accessor (动态 Group by). When provided, leaf tasks are
+   * Dynamic grouping accessor. When provided, leaf tasks are
    * bucketed by the returned `key` and rendered beneath one synthesized summary
    * row per group — the original `parent` hierarchy is replaced by the grouping.
    * Return `null` to drop a task into the "ungrouped" bucket. Grouping is purely
@@ -436,18 +440,19 @@ export interface GanttViewProps {
   /** Label for the bucket collecting tasks whose `groupBy` returns null. */
   ungroupedLabel?: string
   /**
-   * Auto-collapse tree nodes at or below this depth on first render (默认折叠).
+   * Auto-collapse tree nodes at or below this depth on first render.
    * Depth is 0-indexed: roots are 0, their children 1, etc. Every node whose
    * depth is `>= defaultCollapsedDepth` AND which has children is seeded into the
    * collapsed set once, so its subtree starts hidden. The user can still expand
-   * any of them — this only sets the initial state. Example: a 项目→产品→排产计划→派工单
-   * tree where 排产计划 sits at depth 2 uses `defaultCollapsedDepth={2}` to start
-   * with every 排产计划 (and its 派工单 children) folded. Omit (or pass a depth past
+   * any of them — this only sets the initial state. Example: a
+   * project→product→production-plan→work-order tree where the production plan
+   * sits at depth 2 uses `defaultCollapsedDepth={2}` to start
+   * with every production plan (and its work-order children) folded. Omit (or pass a depth past
    * the deepest node) to start fully expanded.
    */
   defaultCollapsedDepth?: number
   /**
-   * How a summary bar's span is computed (汇总条区间). `'children'` (default)
+   * How a summary bar's span is computed. `'children'` (default)
    * rolls up from the children — min start / max end / duration-weighted
    * progress — ignoring the summary task's own dates. `'self'` draws the bar
    * from the task's OWN start/end/progress; tasks flagged `hasOwnDates: false`
@@ -459,18 +464,19 @@ export interface GanttViewProps {
   /**
    * Persist the user's layout tweaks (granularity + column/task-list widths)
    * to `localStorage` under this key. On mount the saved layout is restored;
-   * the "保存布局" toolbar button writes the current layout. Omit to disable
+   * the "Save layout" toolbar button (`gantt.toolbar.saveLayout`) writes the
+   * current layout. Omit to disable
    * persistence. The button still appears when `onLayoutChange` is set.
    */
   persistLayoutKey?: string
   /**
-   * Notified when the user saves the current layout (保存布局). Receives the
+   * Notified when the user saves the current layout. Receives the
    * snapshot `{ viewMode, columnWidth, taskListCollapsed }`. Use this to persist
    * layout in your own store instead of (or alongside) `persistLayoutKey`.
    */
   onLayoutChange?: (layout: GanttLayout) => void
   /**
-   * Show a manual refresh button in the toolbar (手动刷新). The host re-reads
+   * Show a manual refresh button in the toolbar (`gantt.toolbar.refresh`). The host re-reads
    * its data source so server-computed fields (rollups, alert colors) and
    * other users' edits reach the chart without a full page reload. Omit to
    * hide the button (e.g. inline `value` data has nothing to re-read).
@@ -481,30 +487,30 @@ export interface GanttViewProps {
   /**
    * Whether the data source can persist dependency LINK TYPES (fs/ss/ff/sf).
    * Default true. Set false when dependencies are stored as bare predecessor
-   * ids (仅存紧前 id,无类型位) — the link context menu then hides the type
+   * ids (predecessor ids only, no type slot) — the link context menu then hides the type
    * switcher (a switch would be silently reverted on refetch) and drag-created
    * links are always FS regardless of which endpoints were connected.
    */
   dependencyTypes?: boolean
   /**
-   * Business time zone for rendering (业务时区), an IANA name like
+   * Business time zone for rendering, an IANA name like
    * 'Asia/Shanghai'. The chart's calendar math — shift bands, day columns,
    * drag snapping, the today line, start/end labels — renders this zone's
    * wall time for EVERY viewer instead of the browser's; without it, a
-   * viewer in another zone sees bands and dates shifted (班次错位). Writes
+   * viewer in another zone sees bands and dates misaligned. Writes
    * still persist real instants. Note: dates handed to `onBeforeTaskUpdate`
    * are in this display space (durations/deltas are unaffected).
    */
   timeZone?: string
   /**
-   * Base name for exported files (导出文件名), e.g. the view or object label —
-   * "排班计划甘特图" exports as `排班计划甘特图-20260719-1530.png`. Falls back
+   * Base name for exported files, e.g. the view or object label —
+   * "Shift Plan Gantt" exports as `Shift Plan Gantt-20260719-1530.png`. Falls back
    * to "gantt". The timestamp suffix keeps repeated exports from silently
    * overwriting each other in the Downloads folder.
    */
   exportFileName?: string
   /**
-   * Per-interaction switches (交互开关). Omit for all-on. See
+   * Per-interaction switches. Omit for all-on. See
    * {@link GanttInteractions}: e.g. `{ resize: false }` keeps bars movable and
    * links drawable but pins every duration; `{ link: false }` removes the
    * dependency drag-dots and the create/delete menu entries. Subject to
@@ -526,7 +532,7 @@ export interface GanttViewProps {
   ) => boolean | Promise<boolean>
 }
 
-/** Persisted layout snapshot written by the "保存布局" toolbar button. */
+/** Persisted layout snapshot written by the "Save layout" toolbar button. */
 export interface GanttLayout {
   viewMode: GanttViewMode
   /** Effective day-column width in px, or null when auto-fit. */
@@ -535,14 +541,14 @@ export interface GanttLayout {
   /** User-dragged task-list (name column) width in px, or null when auto-sized. */
   taskListWidth?: number | null
   /**
-   * Ids of rows the user had collapsed when saving (展开状态). Present (even
+   * Ids of rows the user had collapsed when saving. Present (even
    * empty) means the saved expand/collapse state wins over
    * `defaultCollapsedDepth`; absent (older snapshots) leaves the default.
    */
   collapsedIds?: string[]
 }
 
-// --- Export helpers (导出 PNG / PDF) — module-level, no React deps. ---
+// --- Export helpers (PNG / PDF) — module-level, no React deps. ---
 
 /** Rasterize a standalone SVG string to a 2×-scaled canvas (white-backed). */
 function rasterizeSvg(svg: string, W: number, H: number, scale = 2): Promise<HTMLCanvasElement | null> {
@@ -699,7 +705,7 @@ export function GanttView({
   interactions,
   onBeforeTaskUpdate,
 }: GanttViewProps) {
-  // Business-time-zone shim (业务时区): translate every incoming date into
+  // Business-time-zone shim: translate every incoming date into
   // the display space where the browser clock reads the configured zone's
   // wall time; translate emitted date changes back to real instants. All
   // calendar logic below runs unchanged and becomes zone-correct.
@@ -741,7 +747,7 @@ export function GanttView({
   // drag/resize/progress, inline edit, delete, link-drag, reorder,
   // auto-schedule, and the Undo/Redo toolbar (which keys off onTaskUpdate) —
   // inherits it. `mobileReadOnly` folds in on narrow viewports so touch users
-  // get a read-only thumbnail (移动端只读缩略). `onTaskClick` / `onViewChange`
+  // get a read-only thumbnail. `onTaskClick` / `onViewChange`
   // stay live: they don't mutate.
   const effectiveReadOnly = readOnly || (mobileReadOnly && isNarrow);
   // Interaction switches (default all on). `link` folds into the dependency
@@ -883,7 +889,7 @@ export function GanttView({
   // Hovered bar id — used to highlight its dependency links.
   const [hoveredTaskId, setHoveredTaskId] = React.useState<string | number | null>(null);
 
-  // Dynamic Group by (动态 Group by). When `groupBy` is set we synthesize one
+  // Dynamic Group by. When `groupBy` is set we synthesize one
   // summary row per bucket and reparent each leaf task onto it, replacing the
   // original hierarchy. The existing rollup/collapse/summary machinery then
   // renders the groups for free. This is a PRESENTATIONAL transform: the
@@ -990,7 +996,7 @@ export function GanttView({
   const suppressNextClickRef = React.useRef(false);
 
   const computeDragChanges = React.useCallback((s: NonNullable<typeof dragState>) => {
-    // In shift mode a bar can be as short as the smallest band (e.g. a 12h 白班);
+    // In shift mode a bar can be as short as the smallest band (e.g. a 12h day shift);
     // otherwise never collapse below one whole day.
     const segActive = viewMode === 'day' && !!shiftSegments && shiftSegments.bands.length > 0;
     const minDurationMs =
@@ -1042,7 +1048,7 @@ export function GanttView({
   const commitTaskUpdates = React.useCallback(
     (updates: Array<{ task: GanttTask; changes: Partial<Pick<GanttTask, 'title' | 'start' | 'end' | 'progress'>> }>) => {
       if (!onTaskUpdate) return;
-      // Central belt: a locked row (仅查看) is never committed, whatever the
+      // Central belt: a locked (view-only) row is never committed, whatever the
       // path — group shift, conflict reschedule, or a future caller.
       const candidates = updates.filter((u) => !u.task.locked);
       // The host veto (onBeforeTaskUpdate) may be async, so the whole commit
@@ -1093,7 +1099,7 @@ export function GanttView({
     [onTaskUpdate, onBeforeTaskUpdate],
   );
 
-  // --- 拖拽冲突校验 + 顺延确认 (Group 2) ---
+  // --- Drag conflict validation + auto-reschedule confirmation (Group 2) ---
   // After a bar drag/resize commits, replay the dependency forward-pass over the
   // moved task(s). If the new position would violate a link (a predecessor ends
   // after the dragged task starts, or a successor now overlaps the dragged
@@ -1101,7 +1107,7 @@ export function GanttView({
   // from what the drag itself applied — that delta is the conflict we surface.
   const [pendingConflict, setPendingConflict] = React.useState<RescheduleChange[] | null>(null);
 
-  // Snap a rescheduled start onto the next shift-band boundary (班次边界) so
+  // Snap a rescheduled start onto the next shift-band boundary so
   // a pushed task never starts mid-band — the reschedule twin of the drag
   // snapping. Only meaningful when shift segments are configured.
   const snapToBandStart = React.useCallback(
@@ -1240,7 +1246,7 @@ export function GanttView({
           if (cur.group) {
             // Move the summary and every descendant by the same ms offset so
             // the subtree keeps its internal spacing and durations — recorded as
-            // a single undoable batch. Locked descendants (仅查看) stay put:
+            // a single undoable batch. Locked (view-only) descendants stay put:
             // they must never be mutated, by drag or by group shift.
             const deltaMs = start.getTime() - cur.originStart.getTime();
             const shifted = [task, ...collectDescendants(task.id).filter((t) => !t.locked)].map((t) => ({
@@ -1281,7 +1287,7 @@ export function GanttView({
     opts?: { group?: boolean; originStart?: Date; originEnd?: Date }
   ) => {
     // Synthetic Group-by rows have no real backing task to mutate; locked
-    // rows (仅查看) can't be dragged from any handle, summary bars included.
+    // view-only (locked) rows can't be dragged from any handle, summary bars included.
     if (!onTaskUpdate || task.data?.__group || task.locked) return;
     e.stopPropagation();
     e.preventDefault();
@@ -1364,7 +1370,7 @@ export function GanttView({
 
   // Built-in drop-target policy, applied both when a bar registers itself as
   // the hover target (no candidate highlight) and again on release (pointer
-  // ordering isn't trusted): locked rows (仅查看) and group headers can't
+  // ordering isn't trusted): locked (view-only) rows and group headers can't
   // receive a dependency, and a link that would close a cycle is rejected.
   // ONE classifier, two consumers. The hover affordance and the drop toast
   // both read this verdict, so the reason a user is shown cannot drift from
@@ -1475,7 +1481,7 @@ export function GanttView({
     };
   }, [ctxMenu]);
 
-  // --- Dependency link context menu (依赖增删 + 类型选择) ---------------------
+  // --- Dependency link context menu (add/remove + link type) ----------------
   // Right-clicking a dependency link opens a small menu to switch its type
   // (FS/SS/FF/SF) or remove it. Closing mirrors the task context menu.
   const [linkCtxMenu, setLinkCtxMenu] = React.useState<{
@@ -1501,7 +1507,8 @@ export function GanttView({
     };
   }, [linkCtxMenu]);
 
-  // --- "添加紧前/紧后" dependency picker --------------------------------------
+  // --- "Add predecessor / successor" dependency picker -----------------------
+  // (`gantt.menu.addPredecessor` / `gantt.menu.addSuccessor`)
   // A secondary panel that lists candidate tasks; choosing one creates a
   // dependency. `relation: 'pred'` makes the picked task a predecessor of the
   // anchor (anchor depends on picked); `'succ'` makes it a successor.
@@ -1587,7 +1594,7 @@ export function GanttView({
       return next;
     });
   }, []);
-  // Seed the collapsed set once from `defaultCollapsedDepth` (默认折叠). We walk
+  // Seed the collapsed set once from `defaultCollapsedDepth`. We walk
   // the parent chain to derive each node's 0-indexed depth and fold every node
   // at/below the threshold that actually has children. Runs a single time so the
   // user's later expand/collapse is never clobbered by a data refresh.
@@ -1791,8 +1798,8 @@ export function GanttView({
     
     // Snap the start to a column boundary of the active granularity so
     // bars (linear ms→px from range start) line up with the grid. In shift mode
-    // the boundary is the 排班日 start (e.g. 08:00), not calendar midnight, so a
-    // cross-midnight 夜班 sits wholly inside one shift-day's band columns.
+    // the boundary is the shift-day start (e.g. 08:00), not calendar midnight,
+    // so a cross-midnight night shift sits wholly inside one shift-day's band columns.
     if (viewMode === 'day' && shiftSegments && shiftSegments.bands.length > 0) {
       start = shiftDayStart(start, shiftSegments.dayStartMin);
     } else {
@@ -1809,14 +1816,14 @@ export function GanttView({
     return { start, end };
   }, [startDate, endDate, tasks, viewMode, shiftSegments, tzShift]);
 
-  // Non-linear working-time axis (非线性工作时间轴). In day mode, when a working
+  // Non-linear working-time axis. In day mode, when a working
   // calendar marks weekends/holidays as non-working, those columns are DROPPED
   // from the grid entirely — Friday sits directly against Monday — so the
   // timeline shows only working time. This makes the date→px mapping non-linear
   // (a weekend spans zero pixels), which is why all positioning is routed
   // through `dateToX`/`xToDate` below rather than a flat ms→px factor.
-  // Shift segmentation (班次分段). In day mode, when a normalized shift config is
-  // supplied, each day column is subdivided into its bands (白班 | 夜班…). Like
+  // Shift segmentation. In day mode, when a normalized shift config is
+  // supplied, each day column is subdivided into its bands (day | night | …). Like
   // `folding` this makes the axis non-linear in px (bands have different widths),
   // so all positioning routes through `dateToX`/`xToDate`. Off → zero regression.
   const segmenting =
@@ -1862,7 +1869,7 @@ export function GanttView({
 
     // Shift mode: emit one column per band, walking shift-day by shift-day.
     // Bands sum to 24h, so advancing the cursor by each band's duration lands
-    // exactly on the next 排班日 start — columns stay time-contiguous.
+    // exactly on the next shift-day start — columns stay time-contiguous.
     if (segmenting && shiftSegments) {
       let cursor = new Date(timelineRange.start);
       while (cursor <= timelineRange.end) {
@@ -2006,7 +2013,7 @@ export function GanttView({
   // keeps a raw pixel scrollLeft across a re-render, but a Day→Month switch
   // shrinks the timeline ~5×, so that same pixel offset lands on a wildly
   // different (usually clamped-to-edge) date — which is what users read as
-  // "乱". Instead we record the date sitting at the *left edge* of the viewport
+  // "jumbled". Instead we record the date sitting at the *left edge* of the viewport
   // now (via the current xToDate) and pin that same date back to the left edge
   // once the new layout is measured — so the leftmost visible date never moves.
   const changeViewMode = React.useCallback(
@@ -2097,9 +2104,9 @@ export function GanttView({
   // month/quarter, decade groups under year.
   const headerGroups = React.useMemo(() => {
     const groups: { key: string; label: string; width: number; offset: number }[] = [];
-    // Shift mode: the upper tier is the 排班日 (shift-day). All bands of one
+    // Shift mode: the upper tier is the shift-day. All bands of one
     // shift-day share its `shiftDayStart`, so grouping by it yields one cell per
-    // day spanning its 白班|夜班 columns, labelled by the day's date.
+    // day spanning its day|night band columns, labelled by the day's date.
     if (segmenting && shiftSegments) {
       let acc = 0;
       for (const col of timeColumns) {
@@ -2206,7 +2213,7 @@ export function GanttView({
     };
   }, []);
 
-  // 定位闪烁: id of the bar currently pulsing after a "locate" click, plus the
+  // Locate flash: id of the bar currently pulsing after a "locate" click, plus the
   // pending timers that toggle it on/off (cleared on re-trigger and unmount).
   const [flashTaskId, setFlashTaskId] = React.useState<string | number | null>(null);
   const flashTimerRef = React.useRef<number[]>([]);
@@ -2336,7 +2343,7 @@ export function GanttView({
     return () => window.cancelAnimationFrame(raf);
   }, [tasks, todayLeftPx, dateToX]);
 
-  // 导航: scroll the timeline so a given date sits near the left edge. Returns
+  // Navigation: scroll the timeline so a given date sits near the left edge. Returns
   // false (no-op) when the date is outside the rendered range.
   const scrollToDate = React.useCallback(
     (date: Date, align: 'left' | 'center' = 'left') => {
@@ -2349,7 +2356,7 @@ export function GanttView({
     },
     [timelineRange, dateToX],
   );
-  // 定位到记录: scroll the timeline so a row's bar is centered horizontally,
+  // Locate a record: scroll the timeline so a row's bar is centered horizontally,
   // triggered by the locate icon in the task list's End column. Centers on the
   // bar's midpoint and clamps so an out-of-range edge still lands on-screen.
   const scrollToTask = React.useCallback(
@@ -2380,7 +2387,7 @@ export function GanttView({
       flashCleanupRef.current = null;
       setFlashTaskId(null);
 
-      // 闪烁高亮: pulse the bar *after* the scroll lands so the eye catches it
+      // Flash highlight: pulse the bar *after* the scroll lands so the eye catches it
       // where it settles, not mid-flight. rAF restarts the CSS animation cleanly
       // even when the same row is located twice; auto-clears when it finishes.
       const startFlash = () => {
@@ -2439,7 +2446,7 @@ export function GanttView({
     [scrollToDate, tzShift],
   );
 
-  // --- Always-visible horizontal scrollbar (自绘水平滚动条) ----------------
+  // --- Always-visible horizontal scrollbar (self-drawn) -------------------
   // The native bar can't be relied on here: overlay-scrollbar engines (macOS
   // "show while scrolling", embedded Chromium) silently ignore the
   // ::-webkit-scrollbar styling injected above, and in tall host layouts the
@@ -2866,7 +2873,7 @@ export function GanttView({
   const CRIT_COLOR = '#dc2626';
 
   // --- Auto-schedule (Phase 6) ------------------------------------------
-  // One-shot dependency-driven reschedule (顺延): push successors later until
+  // One-shot dependency-driven reschedule (forward-only): push successors later until
   // their link constraints hold, preserving durations, then persist each
   // changed task through onTaskUpdate (as one undoable batch).
   // Toolbar auto-schedule is a bulk server write, so it CONFIRMS first (the
@@ -2978,8 +2985,8 @@ export function GanttView({
     // Timeline: bars / milestones / links / today line.
     parts.push(`<g transform="translate(${nameW},${headerH})" font-family="sans-serif" font-size="9">`);
     rows.forEach((row, i) => {
-      // 分组层级 (项目/产品): a pure tree header — the live chart draws NO
-      // bar for these rows, so the export must not invent a rollup one.
+      // Grouping level (project / product): a pure tree header — the live chart
+      // draws NO bar for these rows, so the export must not invent a rollup one.
       if (row.task.type === 'group') return;
       const y = i * rowHeight;
       const { left, width } = styleFor(row.start, row.end);
@@ -3001,7 +3008,7 @@ export function GanttView({
         parts.push(`<rect x="${left.toFixed(1)}" y="${(y + summaryBarTop).toFixed(1)}" width="${width.toFixed(1)}" height="${summaryBarHeight}" rx="3" fill="${fill}"${stroke}/>`);
         const pw = (width * Math.min(100, Math.max(0, row.progress))) / 100;
         parts.push(`<rect x="${left.toFixed(1)}" y="${(y + summaryBarTop).toFixed(1)}" width="${pw.toFixed(1)}" height="${summaryBarHeight}" rx="3" fill="rgba(0,0,0,0.2)"/>`);
-        // In-bar title (条上标题), matching the live summary bar.
+        // In-bar title, matching the live summary bar.
         const label = fitText(row.task.title, width);
         if (label) {
           parts.push(`<text x="${(left + 6).toFixed(1)}" y="${(y + rowHeight / 2 + 3).toFixed(1)}" fill="#ffffff" font-weight="500">${esc(label)}</text>`);
@@ -3050,7 +3057,7 @@ export function GanttView({
     return { svg, W, H };
   }, [tasks, rows, links, linkPath, styleFor, isCriticalTask, critical, timeColumns, colOffsets, totalWidth, taskListWidth, rowHeight, barTop, barHeight, summaryBarTop, summaryBarHeight, milestoneSize, todayLeftPx, viewMode, showBaselines, baselineTop, baselineHeight, BASELINE_FILL, BASELINE_BORDER, resolvedMarkers, headerGroups]);
 
-  // 导出文件名: `<view/object label>-<yyyyMMdd-HHmm>.<ext>` — carries the
+  // Export file name: `<view/object label>-<yyyyMMdd-HHmm>.<ext>` — carries the
   // business context instead of an opaque `gantt-week`, and the timestamp
   // keeps repeated exports from overwriting each other. Filesystem-hostile
   // characters are stripped from the label.
@@ -3122,7 +3129,7 @@ export function GanttView({
            button's own :hover/:focus-visible full-opacity rule can win. */
         :where(.group\\/task-row:hover) .gantt-row-open-btn { opacity: 0.6; }
         .gantt-row-open-btn:hover, .gantt-row-open-btn:focus-visible { opacity: 1; }
-        /* 定位闪烁: blink the located bar 3× with a thick ring + colored glow so
+        /* Locate flash: blink the located bar 3× with a thick ring + colored glow so
            it's hard to miss. The ring is an outline (not box-shadow) and the glow
            is a drop-shadow *filter* — both stay clear of the critical-path bar's
            inline box-shadow, which they'd otherwise clobber. */
@@ -3148,11 +3155,13 @@ export function GanttView({
           .gantt-sm-hidden { display: none; }
         }
         /* The timeline's NATIVE scrollbars are fully hidden — both axes are
-           replaced by the self-drawn bars (水平底部 / 垂直右侧). Styling the
+           replaced by the self-drawn bars (horizontal at the bottom, vertical
+           on the right). Styling the
            native bar is a dead end: overlay-scrollbar engines (macOS "show
            while scrolling", embedded Chromium) ignore ::-webkit-scrollbar
            theming yet still flash their own auto-hiding bar on scroll, which
-           doubled up with the self-drawn one (双滚动条). scrollbar-width:none
+           doubled up with the self-drawn one (two visible scrollbars).
+           scrollbar-width:none
            is honored by overlay engines too; the ::-webkit rule covers older
            WebKit. Wheel/trackpad/programmatic scrolling is unaffected. */
         [data-testid="gantt-timeline"] { scrollbar-width: none; }
@@ -3465,9 +3474,10 @@ export function GanttView({
                 <div className="w-16 gantt-sm-w20 text-right">{t('gantt.column.end')}</div>
               </>
             )}
-            {/* Mirror of the data rows' 「→」 open-details slot (w-6 + 4px gap).
+            {/* Mirror of the data rows' `→` open-details slot (w-6 + 4px gap).
                 Every row reserves it whenever onTaskClick is live, so the
-                header must too — otherwise the 开始/结束 labels sit 28px to the
+                header must too — otherwise the Start/End labels
+                (`gantt.column.start` / `gantt.column.end`) sit 28px to the
                 right of the values they caption. */}
             {onTaskClick && (
               <div
@@ -3579,10 +3589,11 @@ export function GanttView({
                 } : undefined}
                 onContextMenu={(e) => openContextMenu(task, e)}
                 onClick={() => {
-                  // Focus 查看: a single row click selects + locates the bar on
+                  // Focus/locate: a single row click selects + locates the bar on
                   // the timeline (scroll + pulse) WITHOUT opening the detail
-                  // drawer. Detail is on double-click, the row's 「→」 button,
-                  // the context menu 查看 and keyboard Enter.
+                  // drawer. Detail is on double-click, the row's `→` button,
+                  // the context menu's "View details" (`gantt.menu.view`) and
+                  // keyboard Enter.
                   setSelectedTaskId(task.id);
                   if (!isEditing) scrollToTask(row.start, row.end, task.id);
                 }}
@@ -3685,7 +3696,7 @@ export function GanttView({
                     row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })
                   )}
                 </div>
-                {/* 跳转详情「→」: opens the detail drawer / page — the row click
+                {/* Open details `→`: opens the detail drawer / page — the row click
                     itself is reserved for Focus-locate, so detail needs its own
                     always-reachable affordance besides double-click. A dedicated
                     flex slot (not an absolute overlay) so it never covers the
@@ -3711,7 +3722,7 @@ export function GanttView({
                   </div>
                 )}
                 {/* Row View/Edit/Delete stay reachable from the detail drawer
-                    (double-click / 「→」 / context menu / Enter); inline edit is
+                    (double-click / `→` / context menu / Enter); inline edit is
                     still triggerable via row double-click when enabled. */}
               </div>
               );
@@ -3793,10 +3804,11 @@ export function GanttView({
                   })}
                 </div>
 
-                {/* Calendar-midnight markers (日历午夜). A subtle dashed vertical
-                    line where the calendar date flips INSIDE a band — e.g. the
-                    夜班 (20:00→次日08:00) straddles 0:00. The 排班日 cell stays
-                    unbroken; the line is just a cue that the day rolled over. */}
+                {/* Calendar-midnight markers. A subtle dashed vertical
+                    line where the calendar date flips INSIDE a band — e.g. a
+                    night shift (20:00→08:00 next day) straddles 0:00. The
+                    shift-day cell stays unbroken; the line is just a cue that
+                    the day rolled over. */}
                 {segmenting && shiftSegments && shiftSegments.showMidnight && (
                   <div className="absolute inset-0 pointer-events-none" style={{ zIndex: 0 }}>
                     {timeColumns.slice(colWindow.start, colWindow.end).map((col, i) => {
@@ -3856,7 +3868,7 @@ export function GanttView({
                    const inDragGroup = dragGroupIds?.has(String(task.id)) ?? false;
                    const inDragStretch = dragStretchAncestorIds?.has(String(task.id)) ?? false;
                    const liveStyle = isDragging || inDragGroup || inDragStretch ? getLiveRowStyle(row) : baseStyle;
-                   // Per-node lock (仅查看): treat like read-only for this row —
+                   // Per-node lock (view-only): treat like read-only for this row —
                    // no move/resize/progress/link, but onTaskClick still fires.
                    const isLocked = !!task.locked;
                    // Per-interaction gates: the row must be editable at all
@@ -3868,7 +3880,7 @@ export function GanttView({
                    const canProgress = editableRow && ixProgress;
                    const canDrag = canMove || canResize;
                    // A bar that is explicitly non-editable — the whole view is
-                   // read-only, or this row is locked (仅查看) — gets a not-allowed
+                   // read-only, or this row is locked (view-only) — gets a not-allowed
                    // cursor so hovering signals "can't drag/resize here". A plain
                    // display gantt (no edit handlers, not flagged read-only) keeps a
                    // normal pointer instead.
@@ -3928,7 +3940,8 @@ export function GanttView({
                    const durationDays = Math.max(1, Math.round(
                      (row.end.getTime() - row.start.getTime()) / MS_PER_DAY
                    ));
-                   // Tooltip flip (bottom rows, 最后一行悬浮狂闪): a downward
+                   // Tooltip flip (bottom rows, where a hover on the last row
+                   // otherwise flickers): a downward
                    // tooltip on one of the last rows overflows the rows box,
                    // growing the scroller's scrollHeight while shown. With the
                    // user scrolled to the bottom, the browser's scroll
@@ -3987,7 +4000,7 @@ export function GanttView({
                    ) : null;
 
                    if (task.type === 'group') {
-                     // 分组层级 (项目/产品): a pure tree header — the left list still
+                     // Grouping level (project / product): a pure tree header — the left list still
                      // shows the caret + label, but the timeline row carries NO bar.
                      return (
                        <div
@@ -4017,7 +4030,7 @@ export function GanttView({
                        summaryExtent === 'self' && task.hasOwnDates !== false;
                      // Locked summaries were already unmovable (beginDrag rejects
                      // them) — folding the lock in here also fixes the cursor:
-                     // 仅查看 rows now show not-allowed (🚫) instead of grab.
+                     // view-only rows now show not-allowed (🚫) instead of grab.
                      const summaryMovable = !!onTaskUpdate && ixMove && !isLocked;
                      const summaryResizable = !!onTaskUpdate && ixResize && summaryOwnsDates && !isLocked;
                      return (
@@ -4084,7 +4097,7 @@ export function GanttView({
                             // Clicking the bar only selects it — opening the detail
                             // drawer is reserved for the task-name column, the
                             // context menu, and keyboard Enter, so a mis-tap while
-                            // aiming to drag never pops the side panel (易误触).
+                            // aiming to drag never pops the side panel.
                             setSelectedTaskId(task.id);
                           }}
                           onContextMenu={(e) => openContextMenu(task, e)}
@@ -4240,7 +4253,7 @@ export function GanttView({
                             // Clicking the bar only selects it — opening the detail
                             // drawer is reserved for the task-name column, the
                             // context menu, and keyboard Enter, so a mis-tap while
-                            // aiming to drag never pops the side panel (易误触).
+                            // aiming to drag never pops the side panel.
                             setSelectedTaskId(task.id);
                           }}
                           onContextMenu={(e) => openContextMenu(task, e)}
@@ -4318,7 +4331,7 @@ export function GanttView({
                           // Clicking the bar only selects it — opening the detail
                           // drawer is reserved for the task-name column, the
                           // context menu, and keyboard Enter, so a mis-tap while
-                          // aiming to drag never pops the side panel (易误触).
+                          // aiming to drag never pops the side panel.
                           setSelectedTaskId(task.id);
                         }}
                         onContextMenu={(e) => openContextMenu(task, e)}
@@ -4667,7 +4680,7 @@ export function GanttView({
             </div>
           </div>
 
-          {/* Self-drawn vertical scrollbar (自绘垂直滚动条) — the native bars
+          {/* Self-drawn vertical scrollbar — the native bars
               are fully hidden (see the style block), so this is the one
               vertical affordance; synced with the timeline's scrollTop. */}
           <div
@@ -4702,7 +4715,7 @@ export function GanttView({
           </div>
         </div>
 
-        {/* Always-visible horizontal scrollbar (自绘水平滚动条): sticky to the
+        {/* Always-visible horizontal scrollbar (self-drawn): sticky to the
             visible bottom so it stays reachable even when the pane's bottom
             edge extends past the viewport. Hidden by syncHScrollbar when the
             timeline fits. */}
@@ -4831,7 +4844,7 @@ export function GanttView({
         );
       })()}
 
-      {/* Dependency link context menu (类型选择 + 移除) — fixed-position. */}
+      {/* Dependency link context menu (link type + remove) — fixed-position. */}
       {linkCtxMenu && (() => {
         const source = tasks.find((tk) => String(tk.id) === String(linkCtxMenu.sourceId));
         const target = tasks.find((tk) => String(tk.id) === String(linkCtxMenu.targetId));
@@ -4900,7 +4913,7 @@ export function GanttView({
         );
       })()}
 
-      {/* "添加紧前/紧后" task picker — lists candidate tasks; choosing one
+      {/* "Add predecessor / successor" task picker — lists candidate tasks; choosing one
           creates a dependency. Excludes self and tasks already linked in that
           direction (avoids no-op duplicates). */}
       {depPicker && onDependencyCreate && (() => {
@@ -4912,10 +4925,10 @@ export function GanttView({
           links.map((l) => `${String(l.sourceId)}->${String(l.targetId)}`),
         );
         // Candidates = rows that can actually participate in a dependency:
-        // 'group' tree headers have no bar to schedule, and locked (仅查看)
+        // 'group' tree headers have no bar to schedule, and locked (view-only)
         // rows must not enter new links. Summary rows stay IN — they are
         // draggable (group move) and in parent-child models (plan → locked
-        // dispatch) the summary row is exactly the linkable record.
+        // work order) the summary row is exactly the linkable record.
         const candidates = tasks.filter((c) => {
           if (String(c.id) === String(anchor.id)) return false;
           if (c.type === 'group' || c.locked) return false;
@@ -4973,11 +4986,9 @@ export function GanttView({
         );
       })()}
 
-      {/* 拖拽冲突 → 顺延确认 (Group 2). A centered modal lists how many tasks
-          would shift and offers to auto-reschedule (自动顺延) or keep the manual
-          placement (取消保留). */}
-      {/* 自动排程确认 — the toolbar wand computes first, then asks before the
-          bulk write; mirrors the conflict dialog's interaction contract. */}
+      {/* Auto-schedule confirmation — the toolbar wand computes first, then
+          asks before the bulk write; mirrors the conflict dialog's interaction
+          contract. */}
       {pendingAutoSchedule && (
         <div
           className="fixed inset-0 z-[60] flex items-center justify-center bg-black/30"
@@ -5027,7 +5038,8 @@ export function GanttView({
         </div>
       )}
 
-      {/* 无需排程 transient notice — every link already holds. */}
+      {/* "Nothing to reschedule" transient notice (`gantt.autoScheduleDlg.none`)
+          — every link already holds. */}
       {autoScheduleClean && (
         <div
           className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] rounded-md border bg-popover text-popover-foreground px-3 py-1.5 text-sm shadow-md"
@@ -5038,6 +5050,10 @@ export function GanttView({
         </div>
       )}
 
+      {/* Drag conflict → auto-reschedule confirmation (Group 2). A centered
+          modal lists how many tasks would shift and offers to auto-reschedule
+          (`gantt.conflict.confirm`) or keep the manual placement
+          (`gantt.conflict.cancel`). */}
       {pendingConflict && (
         <div
           className="fixed inset-0 z-[60] flex items-center justify-center bg-black/30"

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -49,8 +49,8 @@ const COLUMN_WIDTH = 100; // Time column width
 // grip is only a few px, but pointer synthesis in headless browsers quantizes the
 // click coordinate, so a click aimed at the edge routinely lands a pixel or two
 // inside the bar body — starting a MOVE instead of a resize (unstable hit
-// detection). Treating a
-// full-height band at each end as a resize edge makes the hit deterministic.
+// detection). Treating a full-height band at each end as a resize edge makes
+// the hit deterministic.
 const RESIZE_EDGE_PX = 8;
 
 /**
@@ -382,7 +382,7 @@ export interface GanttViewProps {
    */
   autoSchedule?: boolean
   /**
-   * After a bar drag/resize, validate the move against dependency constraints
+   * After a bar drag/resize, validate the move against dependency constraints.
    * If the new position would violate a link — the task moved
    * earlier than a predecessor allows, or its move pushes successors past their
    * constraints — a confirmation prompts to "Auto-reschedule"
@@ -3156,14 +3156,13 @@ export function GanttView({
         }
         /* The timeline's NATIVE scrollbars are fully hidden — both axes are
            replaced by the self-drawn bars (horizontal at the bottom, vertical
-           on the right). Styling the
-           native bar is a dead end: overlay-scrollbar engines (macOS "show
-           while scrolling", embedded Chromium) ignore ::-webkit-scrollbar
-           theming yet still flash their own auto-hiding bar on scroll, which
-           doubled up with the self-drawn one (two visible scrollbars).
-           scrollbar-width:none
-           is honored by overlay engines too; the ::-webkit rule covers older
-           WebKit. Wheel/trackpad/programmatic scrolling is unaffected. */
+           on the right). Styling the native bar is a dead end: overlay-scrollbar
+           engines (macOS "show while scrolling", embedded Chromium) ignore
+           ::-webkit-scrollbar theming yet still flash their own auto-hiding bar
+           on scroll, which doubled up with the self-drawn one (two visible
+           scrollbars). scrollbar-width:none is honored by overlay engines too;
+           the ::-webkit rule covers older WebKit. Wheel/trackpad/programmatic
+           scrolling is unaffected. */
         [data-testid="gantt-timeline"] { scrollbar-width: none; }
         [data-testid="gantt-timeline"]::-webkit-scrollbar { display: none; width: 0; height: 0; }
         /* The task-list pane scrolls in lockstep with the timeline, so its own

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -65,7 +65,7 @@ import { normalizeShiftSegments, type ShiftSegmentsConfig } from './shifts';
 import { useGanttTranslation } from './useGanttTranslation';
 
 /**
- * One quick-filter dimension (快速筛选维度). Generic by design: the page configures
+ * One quick-filter dimension. Generic by design: the page configures
  * which record fields become filter dropdowns; the plugin resolves each one's
  * options from the object schema (select options / lookup reference records) so
  * no business field names are baked into the (MIT) plugin.
@@ -77,7 +77,7 @@ export interface QuickFilterDef {
   label?: string;
   /**
    * Explicit option override. Highest priority — use for fixed enums that are
-   * not modeled as select options (e.g. 派工类别). Plain strings become
+   * not modeled as select options (e.g. a work-order category). Plain strings become
    * value === label; objects allow a distinct display label.
    */
   options?: Array<string | { value: string | number; label?: string }>;
@@ -92,66 +92,68 @@ type GanttConfigEx = GanttConfig & {
   /**
    * Record field whose value maps onto a node kind (see {@link normalizeTaskType}):
    * `task` / `summary` (project/phase) / `milestone` / `group`. `group` (or
-   * `folder`) renders a pure tree header with NO bar — for 项目/产品 style levels
-   * that only group, never schedule.
+   * `folder`) renders a pure tree header with NO bar — for project / product
+   * style levels that only group, never schedule.
    */
   typeField?: string;
   /**
-   * Record field marking a node as view-only / 仅查看 (truthy → locked). A locked
+   * Record field marking a node as view-only (truthy → locked). A locked
    * row's bar can't be dragged/resized, its progress can't be dragged, no
    * dependency can be drawn from it, and its inline-edit / context-menu
    * edit+delete are hidden — but clicking it (open drawer / jump) still works.
    * Independent of the global `readOnly`; use to freeze individual levels (e.g.
-   * 派工单) while siblings stay editable. Maps to {@link GanttTask.locked}.
+   * work orders) while siblings stay editable. Maps to {@link GanttTask.locked}.
    */
   lockField?: string;
   /**
-   * Record field carrying the row's OBJECT API NAME (行级对象名). Mixed-object
+   * Record field carrying the row's OBJECT API NAME. Mixed-object
    * trees (an `api` provider composing parent-object rows with child-object rows)
    * need the detail drawer and its full-page link to follow each row's REAL
-   * object — otherwise a child row's 「→」 builds a URL under the view's bound
+   * object — otherwise a child row's `→` link builds a URL under the view's bound
    * object and 404s. Empty/missing value → falls back to the bound object.
    */
   objectField?: string;
   /**
-   * How a summary bar's span is computed (汇总条区间). `'children'` (default)
+   * How a summary bar's span is computed. `'children'` (default)
    * rolls the bar up from its children — min start / max end / duration-weighted
    * progress — and IGNORES the record's own dates. `'self'` renders the bar from
-   * the record's OWN start/end/progress (自身日期为准), falling back to rollup
+   * the record's OWN start/end/progress, falling back to rollup
    * only for records without dates (e.g. pure grouping levels). Use `'self'`
-   * when the parent's schedule is authoritative — e.g. 排班计划 whose 派工单
-   * children are locked history: under rollup, dragging the plan persists its
+   * when the parent's schedule is authoritative — e.g. a shift plan whose
+   * work-order children are locked history: under rollup, dragging the plan persists its
    * own dates but the bar snaps back to the children's extent on refetch.
    */
   summaryExtent?: 'children' | 'self';
   /**
-   * Auto-collapse tree nodes at/below this 0-indexed depth on first render
-   * (默认折叠). Roots are depth 0. Every node at depth `>= defaultCollapsedDepth`
+   * Auto-collapse tree nodes at/below this 0-indexed depth on first render.
+   * Roots are depth 0. Every node at depth `>= defaultCollapsedDepth`
    * with children starts folded; the user can still expand them. Example: a
-   * 项目→产品→排产计划→派工单 tree uses `defaultCollapsedDepth: 2` so every 排产计划
-   * (and its 派工单) starts collapsed. Forwarded to {@link GanttView}.
+   * project→product→production-plan→work-order tree uses
+   * `defaultCollapsedDepth: 2` so every production plan (and its work orders)
+   * starts collapsed. Forwarded to {@link GanttView}.
    */
   defaultCollapsedDepth?: number;
   /** Baseline (planned) start/end fields → planned-vs-actual reference bars. */
   baselineStartField?: string;
   baselineEndField?: string;
   /**
-   * Record field carrying a per-task alert stroke color (逐任务预警描边):any CSS
+   * Record field carrying a per-task alert stroke color: any CSS
    * color or semantic palette name (red/orange/…). When present the bar keeps
-   * its fill but gets an outline + halo in that color — e.g. 超期红、临期橙,
+   * its fill but gets an outline + halo in that color — e.g. red for overdue,
+   * orange for due-soon —
    * typically a server-computed alert field. Empty/null → no stroke. Maps to
    * {@link GanttTask.borderColor}.
    */
   borderColorField?: string;
   /**
-   * Dynamic Group by (动态 Group by). When set, leaf tasks are bucketed by this
+   * Dynamic Group by. When set, leaf tasks are bucketed by this
    * field and rendered under one synthesized summary row per distinct value
    * (replacing the parent hierarchy). Select options / lookups resolve to their
    * display label, matching list/kanban grouping.
    */
   groupByField?: string;
   /**
-   * Resource / Workload view (资源/工作负载视图). When true, the chart renders a
+   * Resource / Workload view. When true, the chart renders a
    * per-resource load histogram instead of the timeline grid: each task loads
    * its `assigneeField` resource by `effortField` units (default 1) over its
    * span, and any column whose summed load exceeds `capacity` is flagged as
@@ -163,7 +165,7 @@ type GanttConfigEx = GanttConfig & {
   /** Per-resource capacity ceiling (default 1). Loads above this flag overload. */
   capacity?: number;
   /**
-   * Quick filters (快速筛选). A row of multi-select dropdowns rendered above the
+   * Quick filters. A row of multi-select dropdowns rendered above the
    * chart; each narrows the visible task bars by one dimension. Options resolve
    * from the object schema (select options or lookup reference records) so the
    * lists are the full domain, not just values present in the current data.
@@ -178,28 +180,28 @@ type GanttConfigEx = GanttConfig & {
   /**
    * Whether the backing store persists dependency link TYPES (fs/ss/ff/sf).
    * Default true. Set false when dependencies are bare predecessor ids
-   * (仅存紧前 id) — the link menu hides the type switcher (a switch would be
+   * (predecessor ids only) — the link menu hides the type switcher (a switch would be
    * silently reverted on refetch) and drag-created links are always FS.
    * Forwarded to {@link GanttView}.
    */
   dependencyTypes?: boolean;
   /**
-   * Business time zone (业务时区), IANA name like 'Asia/Shanghai'. Renders the
+   * Business time zone, IANA name like 'Asia/Shanghai'. Renders the
    * chart's calendar — shift bands, day columns, snapping, today line, date
    * labels — in this zone's wall time for every viewer, instead of the
-   * browser's zone (which misplaces 班次 for viewers elsewhere). Persisted
+   * browser's zone (which misplaces shift bands for viewers elsewhere). Persisted
    * data stays real instants. Forwarded to {@link GanttView}.
    */
   timeZone?: string;
   /**
-   * Base name for exported PNG/PDF files (导出文件名), e.g. the view's display
+   * Base name for exported PNG/PDF files, e.g. the view's display
    * label — the host's view schema often reaches this component stripped of
    * `label`, so views declare it here. Falls back to the object schema label,
    * then the object API name. A timestamp suffix is always appended.
    */
   exportFileName?: string;
   /**
-   * Per-interaction switches (交互开关): `move` / `resize` / `progress` / `link`,
+   * Per-interaction switches: `move` / `resize` / `progress` / `link`,
    * each defaulting to true. Metadata-drivable so a view can e.g. allow bar
    * moves but pin durations (`{ resize: false }`) or keep the dependency UI
    * read-only (`{ link: false }`). They only narrow what `readOnly` / row locks
@@ -207,14 +209,15 @@ type GanttConfigEx = GanttConfig & {
    */
   interactions?: GanttInteractions;
   /**
-   * Shift segmentation (班次/排班分段). When set, the day-mode timeline splits each
-   * 排班日 (shift-day, starting at `dayStart`) into the configured bands (白班 |
-   * 夜班…): a two-tier header (date over band), per-band column tints, and
+   * Shift segmentation. When set, the day-mode timeline splits each shift-day
+   * (starting at `dayStart`) into the configured bands (day | night | …):
+   * a two-tier header (date over band), per-band column tints, and
    * drag/resize snapping to band boundaries. Pure config data — no shift concept
-   * is hardcoded. Off by default → existing gantts are unchanged. Example:
+   * is hardcoded. `label` is display text the caller has already localized.
+   * Off by default → existing gantts are unchanged. Example:
    * `{ dayStart: '08:00', bands: [
-   *     { key: 'day', label: '白班', start: '08:00', end: '20:00' },
-   *     { key: 'night', label: '夜班', start: '20:00', end: '08:00' } ] }`.
+   *     { key: 'day', label: 'Day shift', start: '08:00', end: '20:00' },
+   *     { key: 'night', label: 'Night shift', start: '20:00', end: '08:00' } ] }`.
    */
   timeSegments?: ShiftSegmentsConfig;
 };
@@ -224,8 +227,8 @@ export function normalizeTaskType(raw: unknown): GanttTaskType | undefined {
   if (raw == null) return undefined;
   const key = String(raw).toLowerCase().trim();
   if (key === 'milestone') return 'milestone';
-  // Pure grouping header (无条): a tree node with no timeline bar. Use for
-  // 项目/产品 style levels that只分组、不排期.
+  // Pure grouping header: a tree node with no timeline bar. Use for
+  // project / product style levels that only group, never schedule.
   if (key === 'group' || key === 'folder') return 'group';
   if (key === 'summary' || key === 'project' || key === 'phase') return 'summary';
   if (key === 'task') return 'task';
@@ -414,9 +417,10 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   const displayLocale = useDisplayLocale();
   const { t } = useGanttTranslation();
 
-  // Surface write-back failures (拖拽/连线/删除/行内编辑) as an error toast —
-  // silent revert alone leaves the user wondering why nothing stuck (#2473).
-  // The server's own message (e.g. 403「仅管理责任人可修改该排班计划」) leads;
+  // Surface write-back failures (drag / link / delete / inline edit) as an error
+  // toast — silent revert alone leaves the user wondering why nothing stuck (#2473).
+  // The server's own message (e.g. a 403 "only the managing owner may modify
+  // this shift plan") leads;
   // the generic i18n text is the fallback.
   const notifyWriteError = useCallback((err: unknown) => {
     toast.error(t('gantt.writeFailed'), {
@@ -459,7 +463,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // Load (and re-load) data through the resolved adapter. `silent: true`
   // re-reads the source WITHOUT flipping `loading`, so GanttView stays mounted
   // and keeps its scroll/collapse state — used by the write-readback below and
-  // the toolbar refresh button (写后回读 / 手动刷新, #2436 第 6/7 项). Concurrent
+  // the toolbar refresh button (write-readback / manual refresh, #2436 items 6
+  // and 7). Concurrent
   // reloads are sequenced: only the newest request may commit its result,
   // so a slow earlier response can't clobber a fresher one.
   const [refreshing, setRefreshing] = useState(false);
@@ -544,7 +549,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     // Fallback value→label maps from the view's quickFilters config. When the
     // data comes from an `api` provider there is no object schema, so select
     // fields have no option defs — but the same view often declares the exact
-    // label pairs as quick-filter options (e.g. status: completed→已完成).
+    // label pairs as quick-filter options (e.g. status: completed → "Completed").
     // Reuse them so the tooltip shows display labels, not raw machine values.
     const quickFilterLabels = new Map<string, Map<string, string>>();
     for (const qf of quickFilters ?? []) {
@@ -674,8 +679,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           // Multi-value lookup / multiselect: a populated relation array is
           // [{name},{name}] — also `typeof 'object'`, but with no
           // name/label/title/id of its own. Map each element to its display
-          // value (scalars pass through) and join, so e.g. 执行责任人 renders
-          // the assignees instead of collapsing to '—'.
+          // value (scalars pass through) and join, so e.g. an "assigned owners"
+          // lookup renders the assignees instead of collapsing to '—'.
           if (Array.isArray(value)) {
             const parts = value
               .map((el) => {
@@ -705,7 +710,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         if (!fieldName) continue;
         const explicitLabel = typeof entry === 'object' ? entry.label : undefined;
         const raw = resolvePath(record, fieldName);
-        // Per-level tooltips (悬浮分层字段): mixed trees list the UNION of every
+        // Per-level tooltips: mixed trees list the UNION of every
         // level's fields here; a row omits the ones that don't apply to it, so
         // an absent value must drop the line, not render a placeholder dash.
         if (raw == null || raw === '' || (Array.isArray(raw) && raw.length === 0)) continue;
@@ -741,7 +746,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           if (name) color = getSemanticHex(name);
         }
       }
-      // Alert stroke (预警描边): semantic palette names map to their hex;
+      // Alert stroke: semantic palette names map to their hex;
       // anything else (hex, css color) passes through untouched.
       const borderColorRaw = borderColorField ? record[borderColorField] : undefined;
       const borderColor =
@@ -784,7 +789,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     // untouched, and the tooltip would keep its pre-resolution rendering.
   }, [data, ganttConfig, objectSchema, displayLocale, tenantCurrency]);
 
-  // Dynamic Group by accessor (动态 Group by). Resolves each task's grouping
+  // Dynamic Group by accessor. Resolves each task's grouping
   // value off its backing record, mapping select options / lookups to their
   // display label — the same value story as list/kanban grouping. Returns null
   // for empty values so those tasks fall into GanttView's "ungrouped" bucket.
@@ -827,7 +832,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     };
   }, [ganttConfig?.groupByField, objectSchema]);
 
-  // Resource / Workload view (资源/工作负载视图). `assigneeAccessor` buckets each
+  // Resource / Workload view. `assigneeAccessor` buckets each
   // task by its resource field (select option / lookup → display label, same as
   // grouping); `effortAccessor` reads the per-task load (default 1). Both read
   // off the backing record so the histogram reflects the real assignment data.
@@ -891,7 +896,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     };
   }, [schema]);
 
-  // Shift segmentation (班次分段). Normalize the declarative `timeSegments` config
+  // Shift segmentation. Normalize the declarative `timeSegments` config
   // once into the model GanttView lays band columns / snaps drags against. null
   // (no/invalid config) leaves the timeline an ordinary day axis.
   const shiftSegments = useMemo(
@@ -899,7 +904,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     [ganttConfig?.timeSegments],
   );
 
-  // ── Quick filters (快速筛选) ─────────────────────────────────────────────
+  // ── Quick filters ────────────────────────────────────────────────────────
   // Resolve each task's value for a filter dimension into a stable key. Lookups
   // resolve to the embedded record's id (matching the lookup option values);
   // scalars / select values use their string form. Mirrors the grouping key
@@ -961,7 +966,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   }, [JSON.stringify(quickFilterDefs), dataSource, objectSchema]);
 
   // Resolve the final option list per dimension, by priority:
-  //   1. explicit `options` on the def (fixed enums like 派工类别)
+  //   1. explicit `options` on the def (fixed enums like a work-order category)
   //   2. select/enum field options from the object schema (full domain)
   //   3. fetched lookup reference records (full domain, async above)
   //   4. distinct values present in the loaded data (fallback)
@@ -1010,7 +1015,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     });
   }, [quickFilterDefs, objectSchema, lookupOptions, data, resolveFilterKey]);
 
-  // 保存布局 covers the quick-filter chips too: GanttView persists its own
+  // `saveLayout` covers the quick-filter chips too: GanttView persists its own
   // snapshot under persistLayoutKey and fires onLayoutChange; the chips live up
   // here, so they get a sibling localStorage key and restore on mount.
   const persistLayoutKey =
@@ -1050,7 +1055,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // row opened under the bound object's route otherwise builds a 404 URL.
   // deriveRecordPageHref needs the routed object's segment in the current path
   // (a foreign row object never appears there), so derive from the routed
-  // object and swap the segment. Used by the drawer's 整页 link.
+  // object and swap the segment. Used by the drawer's full-page link.
   // With objectField configured, a row without a value is a synthetic group
   // header composed by the endpoint (its id isn't a real record id) — no
   // detail page or drawer exists for it.
@@ -1206,7 +1211,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         await effectiveDataSource.update(resource, String(recordId), patch);
         // Read back so server-computed fields (parent rollups, alert
         // colors, recalculated durations) refresh — the optimistic patch
-        // only knows what the client wrote (#2436 第 6 项).
+        // only knows what the client wrote (#2436 item 6).
         void reload({ silent: true });
       } catch (err) {
         console.error('[ObjectGantt] Failed to persist task update:', err);
@@ -1251,7 +1256,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       );
       try {
         await effectiveDataSource.update(resource, String(targetId), { [depField]: nextValue });
-        void reload({ silent: true }); // 写后回读 — see handleTaskUpdateDefault
+        void reload({ silent: true }); // write-readback — see handleTaskUpdateDefault
       } catch (err) {
         console.error('[ObjectGantt] Failed to persist dependency:', err);
         setData(prevSnapshot); // revert
@@ -1261,7 +1266,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     [ganttConfig, effectiveDataSource, resource, data, reload, notifyWriteError],
   );
 
-  // Persist a created/updated dependency (依赖增 + 类型选择): upsert the source
+  // Persist a created/updated dependency (create + link type): upsert the source
   // (predecessor) id onto the target record's dependencies field with the given
   // link type. Re-invoking with a different type updates that link's type.
   const handleDependencyCreate = useCallback(
@@ -1289,7 +1294,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
     [ganttConfig, data, persistDependencies],
   );
 
-  // Persist a removed dependency (依赖删): drop the source id from the target
+  // Persist a removed dependency (delete): drop the source id from the target
   // record's dependencies field. Optimistic with revert, same as create.
   const handleDependencyDelete = useCallback(
     async (source: GanttTask, target: GanttTask) => {
@@ -1352,7 +1357,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       const ok = await effectiveDataSource.delete(resource, String(recordId));
       if (ok === false) throw new Error(t('gantt.writeFailed'));
       setPendingDelete(null);
-      void reload({ silent: true }); // 写后回读 — parent rollups shrink after a child delete
+      void reload({ silent: true }); // write-readback — parent rollups shrink after a child delete
     } catch (err) {
       console.error('[ObjectGantt] Failed to delete:', err);
       setData(prevSnapshot); // revert
@@ -1427,8 +1432,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       {/* Fill the host's flex cell instead of guessing with a viewport calc:
           `100vh - 200px` overshoots whenever the chrome above (tabs, toolbar,
           quick filters) exceeds 200px, and the overflow-hidden host then CLIPS
-          the pane's bottom edge — swallowing the horizontal scrollbar
-          (水平滚动条被裁掉). flex-1/min-h-0 tracks the real available height;
+          the pane's bottom edge — swallowing the horizontal scrollbar.
+          flex-1/min-h-0 tracks the real available height;
           the min-h keeps standalone embeds (no sized parent) usable. */}
       <div className="flex-1 min-h-[420px]">
         {ganttConfig?.resourceView && assigneeAccessor ? (
@@ -1475,7 +1480,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           timeZone={ganttConfig?.timeZone}
           onBeforeTaskUpdate={onBeforeTaskUpdate}
           exportFileName={
-            // Explicit view config first (排班计划甘特图) — the host strips
+            // Explicit view config first (e.g. "Shift Plan Gantt") — the host strips
             // `label` off the schema it hands us — then the bound object's
             // label, then its API name.
             String(
@@ -1556,7 +1561,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
                   ? { ...r, [field]: value }
                   : r,
               ));
-              void reload({ silent: true }); // 写后回读 — see handleTaskUpdateDefault
+              void reload({ silent: true }); // write-readback — see handleTaskUpdateDefault
             }}
             onDelete={recLocked ? undefined : async () => {
               if (!effectiveDataSource?.delete) return;

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -120,8 +120,9 @@ type GanttConfigEx = GanttConfig & {
    * the record's OWN start/end/progress, falling back to rollup
    * only for records without dates (e.g. pure grouping levels). Use `'self'`
    * when the parent's schedule is authoritative — e.g. a shift plan whose
-   * work-order children are locked history: under rollup, dragging the plan persists its
-   * own dates but the bar snaps back to the children's extent on refetch.
+   * work-order children are locked history: under rollup, dragging the plan
+   * persists its own dates but the bar snaps back to the children's extent on
+   * refetch.
    */
   summaryExtent?: 'children' | 'self';
   /**
@@ -137,12 +138,11 @@ type GanttConfigEx = GanttConfig & {
   baselineStartField?: string;
   baselineEndField?: string;
   /**
-   * Record field carrying a per-task alert stroke color: any CSS
-   * color or semantic palette name (red/orange/…). When present the bar keeps
-   * its fill but gets an outline + halo in that color — e.g. red for overdue,
-   * orange for due-soon —
-   * typically a server-computed alert field. Empty/null → no stroke. Maps to
-   * {@link GanttTask.borderColor}.
+   * Record field carrying a per-task alert stroke color: any CSS color or
+   * semantic palette name (red/orange/…). When present the bar keeps its fill
+   * but gets an outline + halo in that color — e.g. red for overdue, orange for
+   * due-soon — typically a server-computed alert field. Empty/null → no stroke.
+   * Maps to {@link GanttTask.borderColor}.
    */
   borderColorField?: string;
   /**

--- a/packages/plugin-gantt/src/ResourceWorkload.tsx
+++ b/packages/plugin-gantt/src/ResourceWorkload.tsx
@@ -7,7 +7,7 @@
  */
 
 /**
- * Resource / Workload view (资源/工作负载视图).
+ * Resource / Workload view.
  *
  * A per-resource load histogram aligned to the same time columns the Gantt grid
  * uses. Each resource gets a row; each column draws a bar whose height ∝ the

--- a/packages/plugin-gantt/src/scheduling.ts
+++ b/packages/plugin-gantt/src/scheduling.ts
@@ -6,7 +6,7 @@
  *     passes) to find the zero-slack chain that drives the project end.
  *   - `computeProjectReschedule` — dependency-driven forward shifting: push
  *     successors later until every link constraint holds, preserving each
- *     task's duration. Tasks are only ever moved *later* (顺延), never pulled
+ *     task's duration. Tasks are only ever moved *later* (forward-only), never pulled
  *     earlier, so the result is a minimal repair, not an ASAP recompute.
  *
  * Both treat the dependency on a task as a *predecessor* edge: if task B lists
@@ -114,7 +114,7 @@ export interface SchedulableTask {
   parent?: string | number | null;
   type?: string;
   /**
-   * Row-level lock (仅查看). A locked task is never moved by the reschedule;
+   * Row-level lock (view-only row). A locked task is never moved by the reschedule;
    * when it VIOLATES a link it is reported in `skippedLocked` instead.
    */
   locked?: boolean;
@@ -323,9 +323,9 @@ export interface RescheduleOptions {
    */
   summaryExtent?: 'children' | 'self';
   /**
-   * Snap a computed start instant onto a grid — e.g. shift-band boundaries
-   * (班次边界), so a pushed task never starts mid-band. Must return an
-   * instant `>=` the input (this is 顺延; snapping may only push later).
+   * Snap a computed start instant onto a grid — e.g. shift-band boundaries, so
+   * a pushed task never starts mid-band. Must return an instant `>=` the input
+   * (this is forward-only; snapping may only push later).
    * Applied only to tasks that actually move, and only in non-calendar mode
    * (a WorkingCalendar already owns the day-granularity snapping).
    */
@@ -336,7 +336,7 @@ export interface RescheduleResult {
   changes: RescheduleChange[];
   /**
    * Tasks that VIOLATE a link but stayed put because they are locked
-   * (仅查看). Lets the UI report "N skipped" honestly instead of implying
+   * (view-only rows). Lets the UI report "N skipped" honestly instead of implying
    * the schedule is fully repaired.
    */
   skippedLocked: string[];
@@ -350,7 +350,7 @@ export interface RescheduleResult {
  * Summary handling follows {@link RescheduleOptions.summaryExtent}: rollup
  * summaries are fixed predecessor nodes; self-dated summaries move and carry
  * their unlocked subtree (a descendant already pushed further by its own
- * links keeps the later position — 顺延 only, so max wins). The cascade is a
+ * links keeps the later position — forward-only, so max wins). The cascade is a
  * single forward pass: carried positions don't re-propagate through links,
  * matching the function's minimal-repair pragmatism (no constraint solver).
  *
@@ -409,7 +409,7 @@ export function computeProjectRescheduleDetailed(
       ? workingDaysSpan(startMs.get(id)!, endMs.get(id)!, cal)
       : endMs.get(id)! - startMs.get(id)!;
     const origStart = t.start.getTime();
-    // Never pull earlier than the current start — this is 顺延, not ASAP.
+    // Never pull earlier than the current start — this is forward-only, not ASAP.
     let reqStart = origStart;
     for (const e of preds.get(id) ?? []) {
       const pStart = startMs.get(e.pred)!;
@@ -459,7 +459,7 @@ export function computeProjectRescheduleDetailed(
   // Cascade: a shifted self-dated summary carries its subtree along — the
   // same semantics as dragging its bar — skipping locked descendants. A
   // descendant already pushed further by its OWN links keeps the later
-  // position (max wins; this stays 顺延-only).
+  // position (max wins; this stays forward-only).
   if (selfExtent) {
     for (const t of tasks) {
       const id = key(t.id);

--- a/packages/plugin-gantt/src/shifts.ts
+++ b/packages/plugin-gantt/src/shifts.ts
@@ -1,21 +1,24 @@
 /**
- * Shift segmentation (班次/排班) for the Gantt — pure, side-effect-free helpers.
+ * Shift segmentation (shift bands / rostering) for the Gantt — pure,
+ * side-effect-free helpers.
  *
- * A factory's day is split into named time bands (白班 08:00–20:00, 夜班
- * 20:00–次日08:00). The Gantt is positioned in continuous milliseconds, so a
- * band is just a recurring time window; this module turns a declarative config
- * into a normalized model the renderer can lay columns and snap drags against.
+ * A factory's day is split into named time bands (day shift 08:00–20:00, night
+ * shift 20:00–08:00 the next day). The Gantt is positioned in continuous
+ * milliseconds, so a band is just a recurring time window; this module turns a
+ * declarative config into a normalized model the renderer can lay columns and
+ * snap drags against.
  *
  * Two ideas make cross-midnight shifts a non-problem:
  *
- *   - **Shift-day (排班日):** the "day" column does NOT start at calendar
+ *   - **Shift-day:** the "day" column does NOT start at calendar
  *     midnight but at the configured `dayStart` (e.g. 08:00) and runs a full 24h
  *     to the next `dayStart`. A night shift that crosses 00:00 therefore sits
  *     wholly inside one shift-day column instead of straddling two date cells.
  *
  *   - **Attribution by start:** a record belongs to the shift-day that contains
- *     its START instant. The 夜班 starting 6/4 20:00 belongs to 6/4 even though
- *     it ends 6/5 08:00. {@link shiftDayStart} / {@link bandAt} encode this.
+ *     its START instant. A night shift starting 6/4 20:00 belongs to 6/4 even
+ *     though it ends 6/5 08:00. {@link shiftDayStart} / {@link bandAt} encode
+ *     this.
  *
  * Bands are laid out by *cumulative duration* from `dayStart`, never by absolute
  * clock math, so a band whose `end` < `start` (crosses midnight) needs no
@@ -30,7 +33,7 @@ const MINS_PER_DAY = 24 * 60;
 export interface ShiftBandConfig {
   /** Stable identifier (e.g. 'day' / 'night'); defaults to `band{index}`. */
   key?: string;
-  /** Display label (白班 / 夜班) — already localized by the caller. */
+  /** Display label ('Day shift' / 'Night shift') — already localized by the caller. */
   label: string;
   /** Band start, 'HH:mm' (24h). */
   start: string;
@@ -44,13 +47,13 @@ export interface ShiftBandConfig {
 export interface ShiftSegmentsConfig {
   /**
    * Clock time the shift-day begins, 'HH:mm'. The day column starts here and
-   * runs 24h. Defaults to '00:00' (calendar day). For 8点交接 set '08:00'.
+   * runs 24h. Defaults to '00:00' (calendar day). For an 08:00 handover set '08:00'.
    */
   dayStart?: string;
   /** Ordered bands covering the 24h shift-day, beginning at `dayStart`. */
   bands: ShiftBandConfig[];
   /**
-   * Draw the dashed calendar-midnight (日历午夜 0:00) cue inside cross-midnight
+   * Draw the dashed calendar-midnight (00:00) cue inside cross-midnight
    * bands. Defaults to `true`; set `false` to hide it.
    */
   showMidnight?: boolean;
@@ -131,8 +134,8 @@ export function shiftDayStart(date: Date, dayStartMin: number): Date {
 /**
  * The band a START instant falls into, by cumulative duration from its
  * shift-day start. Used both to tint/label columns and to derive the band of a
- * record (the 夜班/白班 of `startDateField`). Returns null only for an empty
- * model.
+ * record (the night/day band of `startDateField`). Returns null only for an
+ * empty model.
  */
 export function bandAt(date: Date, seg: NormShiftSegments): NormShiftBand | null {
   if (seg.bands.length === 0) return null;

--- a/packages/plugin-gantt/src/workload.ts
+++ b/packages/plugin-gantt/src/workload.ts
@@ -7,7 +7,7 @@
  */
 
 /**
- * Resource / workload model (资源/工作负载视图).
+ * Resource / workload model.
  *
  * Pure, framework-free aggregation that turns a flat task list into a
  * per-resource, per-time-column load histogram. The renderer (ResourceWorkload)


### PR DESCRIPTION
Fixes #4884

诫条 #-1 覆盖的是代码注释,不只是面向用户的文案。本 PR 是 #4021 / PR #4883 的同形续集 —— 那一单清掉了同包 `QuickFilterBar.tsx`,本单清掉 `packages/plugin-gantt/src` 下**其余六个非测试源码文件**共 163 行中文注释(JSDoc、行尾 `//`、JSX 注释块)。

## 前提复核(stale-premise)

立卡时 origin/main 是 `718ca9d45`,本 PR 基线是 `372d9f9b4`(即 PR #4883 的合并提交)。逐文件重扫,**六文件行数与卡内清单逐一吻合,合计 163**,前提成立。`QuickFilterBar.tsx` 已不在非测试命中列表内(#4883 已清)。

## 逐文件 Han 计数 before / after

| 文件 | before | after |
|---|---|---|
| `GanttView.tsx` | 93 | 0 |
| `ObjectGantt.tsx` | 51 | 0 |
| `shifts.ts` | 9 | 0 |
| `scheduling.ts` | 8 | 0 |
| `ResourceWorkload.tsx` | 1 | 0 |
| `workload.ts` | 1 | 0 |
| **合计** | **163** | **0** |

复现:`rg -c '\p{Han}' packages/plugin-gantt/src --glob '!*.test.*'` —— 改后零命中,**无声明例外**。

包内其余非测试源码(`index.tsx`、`useGanttTranslation.ts`、`QuickFilterBar.tsx`)顺扫零残留,所以六文件即全集。

## 额外:`\p{Han}` 扫不到的一处

`GanttView.tsx:3725` 的 `「→」` 用的是 CJK 括号(Unicode 类别 Po,不是 Han),卡内那条 `rg '\p{Han}'` **扫不到它**,163 这个数因此是偏低的。已一并改成 `` `→` ``,并补扫 CJK 标点/全角区(`U+3000-303F`、`U+FF00-FFEF`、`U+FE10-FE1F`)确认归零。记一笔:若后续真要建门,判据不能只有 `\p{Han}`。

## 按现状改写处(注释与代码现状矛盾)

### 1. 引用 UI 字面量的注释 → 改指真实 bundle 键

这些注释引用的中文按钮/菜单文案,现已由 `useGanttTranslation.ts` 的 `gantt.*` 键解析(英文默认值),注释里的中文literal 早已不对应任何调用点 —— 与 #4883 修 quick-filter labels 的同一类过期。改写后直接指键:

| 原注释引用 | 改后指向 |
|---|---|
| `"保存布局"`(2 处:`persistLayoutKey` JSDoc、`GanttLayout` JSDoc) | `gantt.toolbar.saveLayout` |
| `"移除依赖"` | `gantt.menu.removeDependency` |
| `手动刷新` | `gantt.toolbar.refresh` |
| `"添加紧前/紧后"`(2 处) | `gantt.menu.addPredecessor` / `gantt.menu.addSuccessor` |
| `查看`(context menu / focus 注释) | `gantt.menu.view` |
| `开始/结束 labels` | `gantt.column.start` / `gantt.column.end` |
| `自动顺延` / `取消保留` | `gantt.conflict.confirm` / `gantt.conflict.cancel` |
| `无需排程` | `gantt.autoScheduleDlg.none` |

### 2. 注释块贴错了 JSX(位置漂移)

`GanttView.tsx` 里 `拖拽冲突 → 顺延确认 (Group 2)` 这段注释,**贴在 `pendingAutoSchedule`(自动排程对话框)上方**,而它描述的冲突对话框在约 60 行之后的 `pendingConflict` 处 —— 两段注释叠在同一个 JSX 上,下面那段才是对的。已把冲突对话框的注释移回 `pendingConflict` 上方,自动排程那段留在原位。纯注释挪位,零行为。

### 3. `ObjectGantt.tsx` JSDoc 代码示例的取舍(216-217)

卡内点名的 `label: '白班'` / `label: '夜班'` 是 **JSDoc 代码示例**,不是运行期取值。二选一里我选了**改成英文示例**(`'Day shift'` / `'Night shift'`),理由三条:

1. **与同一字段的另一处文档一致** —— 这两行示例填的是 `ShiftBandConfig.label`,而 `shifts.ts` 里该字段自己的 JSDoc 我也改成了 `'Day shift' / 'Night shift'`;同一个字段在两个文件里给出不同语言的示例是新的不一致。
2. **示例演示的是形状,不是语言** —— 该字段文档明写 `label` 是「caller 已本地化的显示文本」,所以英文标签与中文标签作为示例**同样真实**,不存在失真;示例要传达的信息是 `key`/`label`/`start`/`end` 这四个键的结构。
3. **先例** —— #4883 处理 `QuickFilterLabels` 时,对同类中文示例字面量的处置就是移除/英文化,而非保留。

顺带在该 JSDoc 里补了一句 `label` 是 caller 已本地化文本,让示例的英文标签不被误读成硬编码默认值。

其余中文按语义译,不逐字直译;仓内统一术语:`顺延` 一律作 `forward-only`(与该模块既有英文 "moved *later*, never pulled earlier" 一致),`仅查看` 作 `view-only`,`写后回读` 作 `write-readback`,`排班日/白班/夜班` 作 `shift-day / day shift / night shift`。

## 验证

**注释-only 的机械证明**(比测试更强的判据):用 TypeScript 编译器对六个文件做 `removeComments` 转译,改前(`HEAD`)与改后逐文件比对 —— **六个文件全部 byte-identical**,即代码/类型/字符串一个字节没动:

```
IDENTICAL after comment-strip: GanttView.tsx
IDENTICAL after comment-strip: ObjectGantt.tsx
IDENTICAL after comment-strip: ResourceWorkload.tsx
IDENTICAL after comment-strip: scheduling.ts
IDENTICAL after comment-strip: shifts.ts
IDENTICAL after comment-strip: workload.ts
```

**测试**(`pnpm --filter @object-ui/plugin-gantt test`,先 `--filter '@object-ui/plugin-gantt^...' build` 备好依赖):

```
 Test Files  44 passed (44)
      Tests  386 passed (386)
   Duration  84.08s
```

**type-check**(`turbo run type-check --filter @object-ui/plugin-gantt`):`Tasks: 14 successful, 14 total`。

**lint**:`0 errors`(259 warnings 全部落在未改动的 `index.tsx` / `vitest.config.ts`,与 main 同)。

**门**:`check-control-bytes` OK(4370 文件);`check-changeset-presence` / `no-major` / `fixed` 均 OK。另按字节纪律对六文件自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` —— 零命中。

### 反向验证:如实记录方向

**无门可红**。仓内没有任何门机械强制诫条 #-1 的英文注释条款(#4884 正文已 grep 证实 `eslint.config.js` 与 `scripts/` 下都没有对应规则),#4021 也已证同一点。所以「把中文改回去看测试变红」在本单**不可能成立** —— 没有任何断言读注释。判据只能是:

- **Han grep 读数**:163 → 0(逐文件表如上),外加 CJK 标点补扫 1 → 0;
- **行为不变**:comment-strip 后六文件 byte-identical(充分条件),测试 386 全绿、计数与基线一致。

## changeset

`.changeset/gantt-source-comments-english.md`,**空 frontmatter** —— 声明「不发布任何东西」,这是该门的显式豁免而非绕行,与 PR #4883 同形。

## 范围

⛔ 未动测试文件(其中文夹具字面量是被验证的数据,#4021 正文已裁明,归维护者定,不属本单);⛔ 未动行为代码;⛔ 未动运行期字符串(复核确认非测试源码里没有中文运行期字符串);⛔ 未动 `content/docs/releases/`。

「仓内无门强制该条款」的**机制化半边不在本单**(属门禁强度,归维护者),按派发要求留在卡内记录。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_