### PR TITLE
refactor(schema-catalog): 103 个 div 节点的布局意图改写成 flex/stack/container/grid props (#4003)

### DIFF
--- a/.changeset/tidy-poems-shave.md
+++ b/.changeset/tidy-poems-shave.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/components': minor
+---
+
+layout: `flex` and `container` now honour a declared scale value of `0`
+
+`FlexSchema.gap` and `ContainerSchema.padding` are declared `number`, and both
+renderers already carried an explicit zero branch (`gap === 0 && 'gap-0'`,
+`padding === 0 && 'p-0'`). Neither branch was reachable: the value was read with
+`||`, so a declared `0` was folded into the default before the branch was tested.
+A `flex` asking for no gap rendered `gap-1.5 sm:gap-2`, and a `container` asking
+for no padding rendered `p-2 sm:p-3 md:p-4` — the JSON said one thing and the DOM
+did another, with nothing reported.
+
+Both now read the value with `??`, matching how the sibling `stack` and `grid`
+renderers already read theirs. Omitting the key still applies the same defaults
+(`gap: 2`, `padding: 4`); only an explicitly declared `0` changes, and no node in
+this repository declared either key as `0` before this change.

--- a/examples/schema-catalog/src/schemas/block-schema/block-marketplace-listing.json
+++ b/examples/schema-catalog/src/schemas/block-schema/block-marketplace-listing.json
@@ -3,8 +3,11 @@
   "className": "max-w-md mx-auto",
   "children": [
     {
-      "type": "div",
-      "className": "h-32 bg-gradient-to-br from-blue-500/20 to-purple-500/20 rounded-t-lg flex items-center justify-center",
+      "type": "flex",
+      "justify": "center",
+      "align": "center",
+      "gap": 0,
+      "className": "h-32 bg-gradient-to-br from-blue-500/20 to-purple-500/20 rounded-t-lg",
       "children": [
         {
           "type": "icon",

--- a/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-analytics-feature.json
+++ b/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-analytics-feature.json
@@ -8,8 +8,11 @@
       "className": "items-center text-center p-4",
       "children": [
         {
-          "type": "div",
-          "className": "w-12 h-12 rounded-lg bg-purple-500/10 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-12 h-12 rounded-lg bg-purple-500/10",
           "children": [
             {
               "type": "icon",

--- a/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-security-feature.json
+++ b/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-security-feature.json
@@ -8,8 +8,11 @@
       "className": "items-center text-center p-4",
       "children": [
         {
-          "type": "div",
-          "className": "w-12 h-12 rounded-lg bg-green-500/10 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-12 h-12 rounded-lg bg-green-500/10",
           "children": [
             {
               "type": "icon",

--- a/examples/schema-catalog/src/schemas/block-schema/feature-card-block.json
+++ b/examples/schema-catalog/src/schemas/block-schema/feature-card-block.json
@@ -8,8 +8,11 @@
       "className": "items-center text-center p-4",
       "children": [
         {
-          "type": "div",
-          "className": "w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-12 h-12 rounded-lg bg-primary/10",
           "children": [
             {
               "type": "icon",

--- a/examples/schema-catalog/src/schemas/components-complex-carousel/photo-gallery.json
+++ b/examples/schema-catalog/src/schemas/components-complex-carousel/photo-gallery.json
@@ -7,8 +7,11 @@
   "items": [
     [
       {
-        "type": "div",
-        "className": "aspect-video bg-gradient-to-br from-blue-400 to-blue-600 rounded-lg flex items-center justify-center text-white text-2xl font-bold",
+        "type": "flex",
+        "justify": "center",
+        "align": "center",
+        "gap": 0,
+        "className": "aspect-video bg-gradient-to-br from-blue-400 to-blue-600 rounded-lg text-white text-2xl font-bold",
         "children": [
           {
             "type": "text",
@@ -19,8 +22,11 @@
     ],
     [
       {
-        "type": "div",
-        "className": "aspect-video bg-gradient-to-br from-purple-400 to-purple-600 rounded-lg flex items-center justify-center text-white text-2xl font-bold",
+        "type": "flex",
+        "justify": "center",
+        "align": "center",
+        "gap": 0,
+        "className": "aspect-video bg-gradient-to-br from-purple-400 to-purple-600 rounded-lg text-white text-2xl font-bold",
         "children": [
           {
             "type": "text",
@@ -31,8 +37,11 @@
     ],
     [
       {
-        "type": "div",
-        "className": "aspect-video bg-gradient-to-br from-green-400 to-green-600 rounded-lg flex items-center justify-center text-white text-2xl font-bold",
+        "type": "flex",
+        "justify": "center",
+        "align": "center",
+        "gap": 0,
+        "className": "aspect-video bg-gradient-to-br from-green-400 to-green-600 rounded-lg text-white text-2xl font-bold",
         "children": [
           {
             "type": "text",
@@ -43,8 +52,11 @@
     ],
     [
       {
-        "type": "div",
-        "className": "aspect-video bg-gradient-to-br from-orange-400 to-orange-600 rounded-lg flex items-center justify-center text-white text-2xl font-bold",
+        "type": "flex",
+        "justify": "center",
+        "align": "center",
+        "gap": 0,
+        "className": "aspect-video bg-gradient-to-br from-orange-400 to-orange-600 rounded-lg text-white text-2xl font-bold",
         "children": [
           {
             "type": "text",

--- a/examples/schema-catalog/src/schemas/components-complex-filter-builder/search-interface.json
+++ b/examples/schema-catalog/src/schemas/components-complex-filter-builder/search-interface.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "space-y-4 p-6 border rounded-lg max-w-3xl",
+  "type": "stack",
+  "gap": 4,
+  "className": "p-6 border rounded-lg max-w-3xl",
   "children": [
     {
       "type": "text",

--- a/examples/schema-catalog/src/schemas/components-complex-resizable/horizontal-split.json
+++ b/examples/schema-catalog/src/schemas/components-complex-resizable/horizontal-split.json
@@ -8,8 +8,11 @@
       "defaultSize": 50,
       "content": [
         {
-          "type": "div",
-          "className": "p-4 h-full flex items-center justify-center bg-slate-50",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "p-4 h-full bg-slate-50",
           "children": [
             {
               "type": "text",
@@ -23,8 +26,11 @@
       "defaultSize": 50,
       "content": [
         {
-          "type": "div",
-          "className": "p-4 h-full flex items-center justify-center bg-slate-100",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "p-4 h-full bg-slate-100",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/components-complex-scroll-area/chat-messages.json
+++ b/examples/schema-catalog/src/schemas/components-complex-scroll-area/chat-messages.json
@@ -4,16 +4,22 @@
   "className": "rounded-md border",
   "content": [
     {
-      "type": "div",
-      "className": "p-4 space-y-3",
+      "type": "stack",
+      "gap": 3,
+      "className": "p-4",
       "children": [
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -40,12 +46,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -72,12 +83,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -104,12 +120,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -136,12 +157,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -168,12 +194,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -200,12 +231,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -232,12 +268,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -264,12 +305,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -296,12 +342,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -328,12 +379,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -360,12 +416,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -392,12 +453,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -424,12 +490,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",
@@ -456,12 +527,17 @@
           ]
         },
         {
-          "type": "div",
-          "className": "flex gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
+          "type": "flex",
+          "align": "stretch",
+          "gap": 3,
+          "className": "p-3 rounded-lg bg-slate-50 hover:bg-slate-100",
           "children": [
             {
-              "type": "div",
-              "className": "w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center text-white font-semibold flex-shrink-0",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "w-10 h-10 rounded-full bg-blue-500 text-white font-semibold flex-shrink-0",
               "children": [
                 {
                   "type": "text",

--- a/examples/schema-catalog/src/schemas/components-complex-scroll-area/document-browser.json
+++ b/examples/schema-catalog/src/schemas/components-complex-scroll-area/document-browser.json
@@ -8,8 +8,10 @@
       "className": "divide-y",
       "children": [
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -34,8 +36,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -60,8 +64,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -86,8 +92,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -112,8 +120,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -138,8 +148,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -164,8 +176,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -190,8 +204,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -216,8 +232,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -242,8 +260,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -268,8 +288,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -294,8 +316,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -320,8 +344,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -346,8 +372,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -372,8 +400,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -398,8 +428,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -424,8 +456,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -450,8 +484,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -476,8 +512,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",
@@ -502,8 +540,10 @@
           ]
         },
         {
-          "type": "div",
-          "className": "p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3",
+          "type": "flex",
+          "align": "center",
+          "gap": 3,
+          "className": "p-3 hover:bg-slate-50 cursor-pointer",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/components-complex-scroll-area/horizontal-scroll.json
+++ b/examples/schema-catalog/src/schemas/components-complex-scroll-area/horizontal-scroll.json
@@ -11,8 +11,11 @@
       "className": "p-4",
       "children": [
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -21,8 +24,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -31,8 +37,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -41,8 +50,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -51,8 +63,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -61,8 +76,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -71,8 +89,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -81,8 +102,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -91,8 +115,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",
@@ -101,8 +128,11 @@
           ]
         },
         {
-          "type": "div",
-          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0 flex items-center justify-center",
+          "type": "flex",
+          "justify": "center",
+          "align": "center",
+          "gap": 0,
+          "className": "w-40 h-32 bg-slate-200 rounded flex-shrink-0",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/components-complex-scroll-area/short-150px.json
+++ b/examples/schema-catalog/src/schemas/components-complex-scroll-area/short-150px.json
@@ -4,8 +4,8 @@
   "className": "rounded-md border p-4",
   "content": [
     {
-      "type": "div",
-      "className": "space-y-2",
+      "type": "stack",
+      "gap": 2,
       "children": [
         {
           "type": "text",

--- a/examples/schema-catalog/src/schemas/components-complex-scroll-area/tall-300px.json
+++ b/examples/schema-catalog/src/schemas/components-complex-scroll-area/tall-300px.json
@@ -4,8 +4,8 @@
   "className": "rounded-md border p-4",
   "content": [
     {
-      "type": "div",
-      "className": "space-y-2",
+      "type": "stack",
+      "gap": 2,
       "children": [
         {
           "type": "text",

--- a/examples/schema-catalog/src/schemas/components-data-display-statistic/sales-dashboard.json
+++ b/examples/schema-catalog/src/schemas/components-data-display-statistic/sales-dashboard.json
@@ -1,6 +1,8 @@
 {
-  "type": "div",
-  "className": "max-w-4xl",
+  "type": "container",
+  "maxWidth": "4xl",
+  "centered": false,
+  "padding": 0,
   "children": [
     {
       "type": "text",

--- a/examples/schema-catalog/src/schemas/components-feedback-toaster/with-toast-trigger.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toaster/with-toast-trigger.json
@@ -1,6 +1,6 @@
 {
-  "type": "div",
-  "className": "space-y-4",
+  "type": "stack",
+  "gap": 4,
   "children": [
     {
       "type": "button",

--- a/examples/schema-catalog/src/schemas/components-form-calendar/form-integration.json
+++ b/examples/schema-catalog/src/schemas/components-form-calendar/form-integration.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "max-w-sm space-y-4 p-4 border rounded-lg",
+  "type": "stack",
+  "gap": 4,
+  "className": "max-w-sm p-4 border rounded-lg",
   "children": [
     {
       "type": "label",

--- a/examples/schema-catalog/src/schemas/components-form-file-upload/form-example.json
+++ b/examples/schema-catalog/src/schemas/components-form-file-upload/form-example.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "max-w-md space-y-6 p-6 border rounded-lg",
+  "type": "stack",
+  "gap": 6,
+  "className": "max-w-md p-6 border rounded-lg",
   "children": [
     {
       "type": "text",

--- a/examples/schema-catalog/src/schemas/components-form-toggle/settings-example.json
+++ b/examples/schema-catalog/src/schemas/components-form-toggle/settings-example.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "max-w-md p-6 border rounded-lg space-y-4",
+  "type": "stack",
+  "gap": 4,
+  "className": "max-w-md p-6 border rounded-lg",
   "children": [
     {
       "type": "text",

--- a/examples/schema-catalog/src/schemas/components-layout-semantic/complete-layout.json
+++ b/examples/schema-catalog/src/schemas/components-layout-semantic/complete-layout.json
@@ -1,6 +1,9 @@
 {
-  "type": "div",
-  "className": "max-w-4xl border rounded-lg overflow-hidden",
+  "type": "container",
+  "maxWidth": "4xl",
+  "centered": false,
+  "padding": 0,
+  "className": "border rounded-lg overflow-hidden",
   "children": [
     {
       "type": "header",

--- a/examples/schema-catalog/src/schemas/ecommerce/order-summary.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/order-summary.json
@@ -8,8 +8,12 @@
       "className": "text-2xl font-bold"
     },
     {
-      "type": "div",
-      "className": "grid md:grid-cols-2 gap-6",
+      "type": "grid",
+      "columns": {
+        "xs": 1,
+        "md": 2
+      },
+      "gap": 6,
       "children": [
         {
           "type": "card",
@@ -77,8 +81,11 @@
                   "className": "items-center gap-3",
                   "children": [
                     {
-                      "type": "div",
-                      "className": "h-10 w-16 rounded bg-muted flex items-center justify-center",
+                      "type": "flex",
+                      "justify": "center",
+                      "align": "center",
+                      "gap": 0,
+                      "className": "h-10 w-16 rounded bg-muted",
                       "children": [
                         {
                           "type": "icon",

--- a/examples/schema-catalog/src/schemas/ecommerce/product-card.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/product-card.json
@@ -3,8 +3,11 @@
   "className": "w-full max-w-sm mx-auto overflow-hidden",
   "children": [
     {
-      "type": "div",
-      "className": "aspect-square bg-muted flex items-center justify-center",
+      "type": "flex",
+      "justify": "center",
+      "align": "center",
+      "gap": 0,
+      "className": "aspect-square bg-muted",
       "children": [
         {
           "type": "icon",

--- a/examples/schema-catalog/src/schemas/ecommerce/product-grid.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/product-grid.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "w-full max-w-6xl mx-auto",
+  "type": "container",
+  "maxWidth": "6xl",
+  "padding": 0,
   "children": [
     {
       "type": "flex",
@@ -19,16 +20,24 @@
       ]
     },
     {
-      "type": "div",
-      "className": "grid sm:grid-cols-2 lg:grid-cols-4 gap-6",
+      "type": "grid",
+      "columns": {
+        "xs": 1,
+        "sm": 2,
+        "lg": 4
+      },
+      "gap": 6,
       "children": [
         {
           "type": "card",
           "className": "overflow-hidden",
           "children": [
             {
-              "type": "div",
-              "className": "aspect-square bg-muted flex items-center justify-center",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "aspect-square bg-muted",
               "children": [
                 {
                   "type": "icon",
@@ -67,8 +76,11 @@
           "className": "overflow-hidden",
           "children": [
             {
-              "type": "div",
-              "className": "aspect-square bg-muted flex items-center justify-center",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "aspect-square bg-muted",
               "children": [
                 {
                   "type": "icon",
@@ -107,8 +119,11 @@
           "className": "overflow-hidden",
           "children": [
             {
-              "type": "div",
-              "className": "aspect-square bg-muted flex items-center justify-center",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "aspect-square bg-muted",
               "children": [
                 {
                   "type": "icon",
@@ -147,8 +162,11 @@
           "className": "overflow-hidden",
           "children": [
             {
-              "type": "div",
-              "className": "aspect-square bg-muted flex items-center justify-center",
+              "type": "flex",
+              "justify": "center",
+              "align": "center",
+              "gap": 0,
+              "className": "aspect-square bg-muted",
               "children": [
                 {
                   "type": "icon",

--- a/examples/schema-catalog/src/schemas/ecommerce/shopping-cart.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/shopping-cart.json
@@ -34,8 +34,11 @@
               "className": "gap-4",
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-24 w-24 rounded-lg bg-muted flex items-center justify-center flex-shrink-0",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-24 w-24 rounded-lg bg-muted flex-shrink-0",
                   "children": [
                     {
                       "type": "icon",
@@ -113,8 +116,11 @@
               "className": "gap-4",
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-24 w-24 rounded-lg bg-muted flex items-center justify-center flex-shrink-0",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-24 w-24 rounded-lg bg-muted flex-shrink-0",
                   "children": [
                     {
                       "type": "icon",

--- a/examples/schema-catalog/src/schemas/marketing/features-grid.json
+++ b/examples/schema-catalog/src/schemas/marketing/features-grid.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "w-full max-w-6xl mx-auto",
+  "type": "container",
+  "maxWidth": "6xl",
+  "padding": 0,
   "children": [
     {
       "type": "div",
@@ -19,8 +20,12 @@
       ]
     },
     {
-      "type": "div",
-      "className": "grid md:grid-cols-3 gap-8",
+      "type": "grid",
+      "columns": {
+        "xs": 1,
+        "md": 3
+      },
+      "gap": 8,
       "children": [
         {
           "type": "card",
@@ -30,8 +35,11 @@
               "spacing": 3,
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-12 w-12 rounded-lg bg-primary/10",
                   "children": [
                     {
                       "type": "icon",
@@ -62,8 +70,11 @@
               "spacing": 3,
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-12 w-12 rounded-lg bg-primary/10",
                   "children": [
                     {
                       "type": "icon",
@@ -94,8 +105,11 @@
               "spacing": 3,
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-12 w-12 rounded-lg bg-primary/10",
                   "children": [
                     {
                       "type": "icon",
@@ -126,8 +140,11 @@
               "spacing": 3,
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-12 w-12 rounded-lg bg-primary/10",
                   "children": [
                     {
                       "type": "icon",
@@ -158,8 +175,11 @@
               "spacing": 3,
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-12 w-12 rounded-lg bg-primary/10",
                   "children": [
                     {
                       "type": "icon",
@@ -190,8 +210,11 @@
               "spacing": 3,
               "children": [
                 {
-                  "type": "div",
-                  "className": "h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center",
+                  "type": "flex",
+                  "justify": "center",
+                  "align": "center",
+                  "gap": 0,
+                  "className": "h-12 w-12 rounded-lg bg-primary/10",
                   "children": [
                     {
                       "type": "icon",

--- a/examples/schema-catalog/src/schemas/marketing/pricing-table.json
+++ b/examples/schema-catalog/src/schemas/marketing/pricing-table.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "w-full max-w-6xl mx-auto",
+  "type": "container",
+  "maxWidth": "6xl",
+  "padding": 0,
   "children": [
     {
       "type": "div",
@@ -19,8 +20,12 @@
       ]
     },
     {
-      "type": "div",
-      "className": "grid md:grid-cols-3 gap-8",
+      "type": "grid",
+      "columns": {
+        "xs": 1,
+        "md": 3
+      },
+      "gap": 8,
       "children": [
         {
           "type": "card",

--- a/examples/schema-catalog/src/schemas/marketing/testimonials.json
+++ b/examples/schema-catalog/src/schemas/marketing/testimonials.json
@@ -1,6 +1,7 @@
 {
-  "type": "div",
-  "className": "w-full max-w-6xl mx-auto",
+  "type": "container",
+  "maxWidth": "6xl",
+  "padding": 0,
   "children": [
     {
       "type": "div",
@@ -19,8 +20,12 @@
       ]
     },
     {
-      "type": "div",
-      "className": "grid md:grid-cols-3 gap-6",
+      "type": "grid",
+      "columns": {
+        "xs": 1,
+        "md": 3
+      },
+      "gap": 6,
       "children": [
         {
           "type": "card",

--- a/examples/schema-catalog/test/layout-props-conversion.test.tsx
+++ b/examples/schema-catalog/test/layout-props-conversion.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Catalog-wide guardrail: a `div` whose className spells a first-class layout
+ * component's own capability is authored as that component, with props
+ * (objectui#4003, the vocabulary-independent half of objectui#3965).
+ *
+ * 189 `div` nodes shipped in this catalog; 106 of them hand-wrote in Tailwind
+ * exactly what `flex` / `stack` / `container` / `grid` already expose as declared
+ * props (`items-center` → `align`, `space-y-4` → `gap`, `max-w-6xl` → `maxWidth`,
+ * `md:grid-cols-3` → `columns`). Every example here is copy-paste reference
+ * material and an AI few-shot retrieval source, so a `div` carrying layout intent
+ * teaches authors to reimplement a component instead of configuring it — and
+ * teaches it at the scale of the whole docs site.
+ *
+ * Three different facts get pinned:
+ *
+ *  1. RATCHET — no `div` anywhere in the catalog carries layout-intent classes,
+ *     except three nodes that cannot be converted and say why (below). This is
+ *     the "keep the 107th out" guard, and the allowlist is what keeps it honest:
+ *     a future conversion that regresses to `div` fails here.
+ *  2. NO DEAD SLOT — no `flex` / `stack` / `grid` / `container` node carries a
+ *     `body` key. `div` renders `children || body`; all four layout renderers
+ *     render `children` ONLY, so a body-keyed node re-typed naively renders
+ *     EMPTY, silently. Four catalog `div` nodes use `body` today (the sidebars),
+ *     which is exactly how this trap gets hit by the next sweep.
+ *  3. EQUIVALENCE — for a sample of each category, the converted node and the
+ *     `div` it replaced are rendered through the real `SchemaRenderer` and their
+ *     subtrees compared byte-for-byte, with the converted node's own class string
+ *     pinned literally. The `div` fixtures below are the ACTUAL pre-conversion
+ *     className strings, so the comparison is against what shipped, not a guess.
+ *
+ * On the class deltas the pins encode. Three are deliberate and none is a
+ * regression:
+ *   - `flex-row` / `justify-start` / `items-stretch` / `gap-0` / `p-0` are the
+ *     CSS initial values the bare `div` already had — the renderer states them
+ *     explicitly where the utility class list left them implicit.
+ *   - `grid-cols-1` makes explicit the single-column base that a bare `grid` with
+ *     only responsive `md:grid-cols-*` classes already resolved to.
+ *   - `gap-N` becomes a mobile-first ladder (`gap-3` → `gap-2 sm:gap-3`). Below
+ *     640px that is NOT byte-identical, and it is the correct exemplar: the
+ *     ladder is what `FlexSchema.gap` means. It is deliberately NOT faked back to
+ *     byte-equality by declaring `gap: 0` and leaving `gap-3` in `className` —
+ *     that spelling contradicts itself and re-teaches the very anti-pattern this
+ *     card removes.
+ *
+ * Module-scope import of `@object-ui/components`, not `beforeAll` (AGENTS.md
+ * §测试纪律): registering the renderers is an unbounded module load and must not
+ * be billed to a bounded hook timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@object-ui/components';
+import { SchemaRenderer } from '@object-ui/react';
+import { allExamples } from '../src/index.js';
+
+type Node = Record<string, unknown>;
+
+const LAYOUT_TYPES = new Set(['flex', 'stack', 'grid', 'container']);
+
+/**
+ * The three `div` nodes that keep layout-intent classes, each for a reason that
+ * survives any terminal state of #3965.
+ *
+ *   `components-basic-div/custom-card` (2 nodes) — rendered by
+ *   `content/docs/components/basic/div.mdx` under "Legacy Examples (For Reference
+ *   Only)". They exist to SHOW the deprecated spelling; converting them deletes
+ *   the thing the page documents.
+ *
+ *   `components-layout-page/documentation-page` (1 node) — `prose prose-slate
+ *   max-w-none`. `max-w-none` REMOVES a max-width (it cancels the typography
+ *   plugin's own), the opposite of what `container.maxWidth` constrains, and no
+ *   `maxWidth` value renders it: `ContainerSchema` declares `false` for the
+ *   no-constraint case, but `container.tsx` reads it as `schema.maxWidth || 'xl'`,
+ *   so `false` renders `max-w-xl`. Converting it would change the rendering; it
+ *   is tracked separately rather than forced.
+ */
+const DIV_EXEMPTIONS: ReadonlyArray<readonly [string, string]> = [
+  ['components-basic-div/custom-card', 'max-w-sm rounded-lg border bg-card text-card-foreground shadow-sm'],
+  ['components-basic-div/custom-card', 'p-6 space-y-2'],
+  ['components-layout-page/documentation-page', 'prose prose-slate max-w-none'],
+];
+
+/** Does this className spell a capability one of the four layout types owns? */
+function layoutIntent(className: unknown): string | null {
+  if (typeof className !== 'string' || className.trim() === '') return null;
+  const t = className.split(/\s+/);
+  const hasFlex = t.some((x) => /^((sm|md|lg|xl|2xl):)?flex$/.test(x));
+  const hasFlexCol = t.some((x) => /(^|:)flex-col$/.test(x));
+  if (hasFlex && !hasFlexCol) return 'flex';
+  if (t.some((x) => /(^|:)space-y-/.test(x))) return 'stack';
+  if (t.some((x) => /(^|:)max-w-/.test(x))) return 'container';
+  if (t.some((x) => /(^|:)grid$/.test(x) || /(^|:)grid-cols-/.test(x))) return 'grid';
+  return null;
+}
+
+function collect(node: unknown, pred: (n: Node) => boolean, out: Node[] = []): Node[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collect(item, pred, out);
+    return out;
+  }
+  if (node && typeof node === 'object') {
+    const rec = node as Node;
+    if (pred(rec)) out.push(rec);
+    for (const value of Object.values(rec)) collect(value, pred, out);
+  }
+  return out;
+}
+
+describe('schema-catalog — layout intent is authored as props, not className (#4003)', () => {
+  it('no div carries layout-intent classes outside the documented exemptions', () => {
+    const offenders = allExamples().flatMap((example) =>
+      collect(example.schema, (n) => n.type === 'div')
+        .map((n) => [example.id, String(n.className ?? '')] as const)
+        .filter(([, cn]) => layoutIntent(cn) !== null)
+        .filter(([id, cn]) => !DIV_EXEMPTIONS.some(([eid, ecn]) => eid === id && ecn === cn))
+        .map(([id, cn]) => `${id} :: ${cn} (→ ${layoutIntent(cn)})`),
+    );
+    expect(
+      offenders,
+      'a `div` whose className already names a first-class layout component\'s own ' +
+        'props teaches authors to reimplement the component instead of configuring ' +
+        'it. Author it as flex/stack/container/grid with props (#4003).',
+    ).toEqual([]);
+  });
+
+  it('every documented exemption is still present (allowlist is not stale)', () => {
+    for (const [id, className] of DIV_EXEMPTIONS) {
+      const example = allExamples().find((e) => e.id === id);
+      expect(example, `${id} is missing from the catalog`).toBeTruthy();
+      const found = collect(example!.schema, (n) => n.type === 'div').some(
+        (n) => n.className === className,
+      );
+      expect(found, `exemption \`${id} :: ${className}\` no longer matches any div — ` +
+        'delete the entry rather than leaving the allowlist wider than the facts').toBe(true);
+    }
+  });
+
+  it('sees enough converted layout nodes for the ratchet to mean something', () => {
+    const nodes = allExamples().flatMap((e) =>
+      collect(e.schema, (n) => typeof n.type === 'string' && LAYOUT_TYPES.has(n.type as string)),
+    );
+    // 441 at the time of writing (flex 248, stack 153, grid 26, container 14),
+    // of which 103 were converted by #4003. A floor, so adding examples never
+    // fails this.
+    expect(nodes.length).toBeGreaterThanOrEqual(430);
+  });
+
+  it('no layout node carries a `body` key, which those renderers never render', () => {
+    const offenders = allExamples().flatMap((example) =>
+      collect(
+        example.schema,
+        (n) => typeof n.type === 'string' && LAYOUT_TYPES.has(n.type as string) && 'body' in n,
+      ).map((n) => `${example.id} (type: ${String(n.type)})`),
+    );
+    expect(
+      offenders,
+      'flex/stack/grid/container render `children` only — `div` was the one that ' +
+        'also rendered `body`. A `body` key on these types is content that never ' +
+        'reaches the DOM, and it fails silently (#4003).',
+    ).toEqual([]);
+  });
+});
+
+/**
+ * Render-level equivalence. Each case carries the EXACT className the converted
+ * node replaced; the `div` is rebuilt around the converted node's own children so
+ * the subtree comparison isolates this one conversion rather than re-measuring
+ * descendants that were converted too.
+ */
+describe('converted nodes render what their div rendered (#4003)', () => {
+  const cases: ReadonlyArray<readonly [string, string, string, string]> = [
+    // [example id, className of the div it replaced, converted type, pinned class]
+    [
+      'components-complex-scroll-area/document-browser',
+      'p-3 hover:bg-slate-50 cursor-pointer flex items-center gap-3',
+      'flex',
+      'flex flex-row justify-start items-center gap-2 sm:gap-3 p-3 hover:bg-slate-50 cursor-pointer',
+    ],
+    [
+      'marketing/features-grid',
+      'h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center',
+      'flex',
+      'flex flex-row justify-center items-center gap-0 h-12 w-12 rounded-lg bg-primary/10',
+    ],
+    [
+      'components-form-file-upload/form-example',
+      'max-w-md space-y-6 p-6 border rounded-lg',
+      'stack',
+      'flex flex-col justify-start items-stretch gap-3 sm:gap-4 md:gap-6 max-w-md p-6 border rounded-lg',
+    ],
+    [
+      'components-complex-scroll-area/short-150px',
+      'space-y-2',
+      'stack',
+      'flex flex-col justify-start items-stretch gap-1.5 sm:gap-2',
+    ],
+    [
+      'marketing/pricing-table',
+      'w-full max-w-6xl mx-auto',
+      'container',
+      'w-full max-w-6xl mx-auto p-0',
+    ],
+    [
+      'components-layout-semantic/complete-layout',
+      'max-w-4xl border rounded-lg overflow-hidden',
+      'container',
+      'w-full max-w-4xl p-0 border rounded-lg overflow-hidden',
+    ],
+    [
+      'ecommerce/product-grid',
+      'grid sm:grid-cols-2 lg:grid-cols-4 gap-6',
+      'grid',
+      'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6',
+    ],
+    [
+      'marketing/testimonials',
+      'grid md:grid-cols-3 gap-6',
+      'grid',
+      'grid grid-cols-1 md:grid-cols-3 gap-6',
+    ],
+  ];
+
+  function renderNode(schema: unknown) {
+    const { container } = render(<SchemaRenderer schema={schema as never} />);
+    const el = container.firstElementChild as HTMLElement;
+    return { className: el.className, innerHTML: el.innerHTML };
+  }
+
+  it('covers every category at least twice (sample is not lopsided)', () => {
+    for (const type of LAYOUT_TYPES) {
+      expect(cases.filter((c) => c[2] === type).length, `${type} needs 2+ cases`)
+        .toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it.each(cases)('%s (%s → %s)', (id, originalClassName, type, expectedClass) => {
+    const example = allExamples().find((e) => e.id === id);
+    expect(example, `${id} is missing from the catalog`).toBeTruthy();
+
+    const node = collect(example!.schema, (n) => n.type === type).find((n) => {
+      const { className } = renderNode(n);
+      return className === expectedClass;
+    });
+    expect(node, `${id} has no ${type} node rendering \`${expectedClass}\``).toBeTruthy();
+
+    // Rebuild the div this node replaced, around the SAME children.
+    const asDiv: Node = { type: 'div', className: originalClassName };
+    if (node!.children !== undefined) asDiv.children = node!.children;
+
+    const after = renderNode(node!);
+    const before = renderNode(asDiv);
+
+    // The whole content of the node still reaches the DOM. This is the assertion
+    // that a naive re-type of a body-keyed node would fail.
+    expect(after.innerHTML).toBe(before.innerHTML);
+    expect(after.className).toBe(expectedClass);
+  });
+});

--- a/packages/components/src/__tests__/layout-zero-scale-values.test.tsx
+++ b/packages/components/src/__tests__/layout-zero-scale-values.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `gap: 0` and `padding: 0` are declared, legal, and must reach the DOM
+ * (objectui#4003).
+ *
+ * `FlexSchema.gap` and `ContainerSchema.padding` are declared `number`, and both
+ * renderers carry an explicit branch for the zero case — `gap === 0 && 'gap-0'`
+ * in `layout/flex.tsx`, `padding === 0 && 'p-0'` in `layout/container.tsx`. Both
+ * branches were unreachable: the value was read with `||`, so a declared `0` was
+ * folded into the default (`2` / `4`) before the branch was ever tested. A node
+ * asking for no gap rendered `gap-1.5 sm:gap-2`; a container asking for no
+ * padding rendered `p-2 sm:p-3 md:p-4`.
+ *
+ * This is the #4001 failure mode one layer down: a declared key whose value the
+ * engine silently discards, so the JSON says one thing and the DOM does another.
+ * `stack.tsx` and `grid.tsx` already read their scales with `??`; the fix
+ * converged `flex` and `container` onto the same spelling rather than inventing
+ * one.
+ *
+ * Zero pre-existing node in the repository declared either key as `0` (measured
+ * across every JSON under `packages/`, `apps/`, `examples/` at the base commit),
+ * so nothing that renders today changes — the fix only makes the declared zero
+ * reachable for the catalog examples that now need it.
+ *
+ * Module-scope import of the renderers, not `beforeAll` (AGENTS.md §测试纪律):
+ * registering them is an unbounded module load and must not be billed to a
+ * bounded hook timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '../renderers';
+import { SchemaRenderer } from '@object-ui/react';
+
+function classOf(schema: unknown): string {
+  const { container } = render(<SchemaRenderer schema={schema as never} />);
+  return (container.firstElementChild as HTMLElement).className;
+}
+
+describe('flex honours a declared gap of 0 (#4003)', () => {
+  it('renders gap-0, not the default ladder', () => {
+    expect(classOf({ type: 'flex', gap: 0, children: [] })).toBe(
+      'flex flex-row justify-start items-start gap-0',
+    );
+  });
+
+  it('still defaults to 2 when gap is omitted', () => {
+    // The zero fix must not turn "unspecified" into "zero" — that would be the
+    // mirror-image bug, and it is the reason `??` is correct where `||` was not.
+    expect(classOf({ type: 'flex', children: [] })).toBe(
+      'flex flex-row justify-start items-start gap-1.5 sm:gap-2',
+    );
+  });
+
+  it('leaves every non-zero gap on the mobile-first ladder', () => {
+    expect(classOf({ type: 'flex', gap: 3, children: [] })).toBe(
+      'flex flex-row justify-start items-start gap-2 sm:gap-3',
+    );
+  });
+});
+
+describe('container honours a declared padding of 0 (#4003)', () => {
+  it('renders p-0, not the default ladder', () => {
+    expect(classOf({ type: 'container', maxWidth: '6xl', padding: 0, children: [] })).toBe(
+      'w-full max-w-6xl mx-auto p-0',
+    );
+  });
+
+  it('still defaults to 4 when padding is omitted', () => {
+    expect(classOf({ type: 'container', maxWidth: '6xl', children: [] })).toBe(
+      'w-full max-w-6xl mx-auto p-2 sm:p-3 md:p-4',
+    );
+  });
+
+  it('leaves every non-zero padding on the mobile-first ladder', () => {
+    expect(classOf({ type: 'container', maxWidth: '6xl', padding: 6, children: [] })).toBe(
+      'w-full max-w-6xl mx-auto p-3 sm:p-4 md:p-6',
+    );
+  });
+});

--- a/packages/components/src/renderers/layout/container.tsx
+++ b/packages/components/src/renderers/layout/container.tsx
@@ -18,7 +18,11 @@ import { forwardRef } from 'react';
 const ContainerRenderer = forwardRef<HTMLDivElement, { schema: ContainerSchema; className?: string }>(
   ({ schema, className, ...props }: { schema: ContainerSchema; className?: string; [key: string]: any }, ref) => {
     const maxWidth = (schema.maxWidth || 'xl') as any;
-    const padding = schema.padding || 4;
+    // `??`, not `||`: `padding` is a declared `number`, and `0` is a legal value
+    // that `||` folds into the default — which left the `padding === 0 && 'p-0'`
+    // branch below permanently unreachable, so a container asking for no padding
+    // silently rendered `p-2 sm:p-3 md:p-4` (objectui#4003).
+    const padding = schema.padding ?? 4;
     const centered = schema.centered !== false; // Default to true
     
     const containerClass = cn(

--- a/packages/components/src/renderers/layout/flex.tsx
+++ b/packages/components/src/renderers/layout/flex.tsx
@@ -16,7 +16,11 @@ ComponentRegistry.register('flex',
     const direction = schema.direction || 'row';
     const justify = schema.justify || 'start';
     const align = schema.align || 'start';
-    const gap = schema.gap || 2;
+    // `??`, not `||`: `gap` is a declared `number`, and `0` is a legal value that
+    // `||` folds into the default — which left the `gap === 0 && 'gap-0'` branch
+    // below permanently unreachable. Sibling `stack.tsx` / `grid.tsx` already read
+    // theirs with `??`; this converges the family (objectui#4003).
+    const gap = schema.gap ?? 2;
     const wrap = schema.wrap || false;
     
     const flexClass = cn(


### PR DESCRIPTION
Fixes #4003
Part of #3965

基 `origin/main` @ `372d9f9b4`。

## 前置核查(两项,均已确认)

**#4001 已落 main** —— `34a00bf29 fix(schema-catalog): grid 示例的列数键 cols → columns (#4001) (#4008)`。本单基于其结果动工,新增的 5 个 grid 节点一律写声明键 `columns`,#4001 留下的 `grid-columns-key.test.tsx` 全程绿。

**106 节点清单按 origin/main 重扫对账 —— 与 PR #3998 的判定表逐格一致**,catalog 一周内无增删影响:189 个 `div` 节点 / 47 个文件 / 全目录 423 个示例,四类计数 flex 84、stack 9、container 8、grid 5,合计 106。差异为零。

## 转换结果:106 判定 → 103 转换 + 3 豁免

| 类别 | 判定 | 转换 | 目标 props |
|---|---|---|---|
| `flex`(含 `flex` 不含 `flex-col`) | 84 | **84** | `align` / `justify` / `gap` / `wrap` |
| `stack`(`space-y-*`) | 9 | **8** | `gap` |
| `container`(`max-w-*`) | 8 | **6** | `maxWidth` / `centered` / `padding` |
| `grid`(`grid` / `grid-cols-*`) | 5 | **5** | `columns` 对象 + `gap` |
| 合计 | 106 | **103** | |

转换后 catalog 的 `div` 节点从 189 降到 86,含 `div` 的文件从 47 降到 28。

### 3 个豁免(逐个有据,并写进测试的 allowlist)

- **`components-basic-div/custom-card`(2 节点)** —— `content/docs/components/basic/div.mdx` 的 "Legacy Examples (For Reference Only)" 两个示例之一,存在的意义就是**展示废弃写法**,转换等于把该文档页要讲的东西删掉。任何 #3965 终态下永久豁免(PR #3998 评论在案)。卡内点名的另一个 `nested-divs` 全是纯装饰盒,本就不在 106 内。
- **`components-layout-page/documentation-page`(1 节点,`prose prose-slate max-w-none`)** —— `max-w-none` 是**取消**最大宽度(抵消 typography 插件自带的),与 `container.maxWidth` 施加约束语义相反;且没有任何 `maxWidth` 值渲染得出它:`ContainerSchema` 为「无约束」声明了 `false`,但 `container.tsx:20` 读的是 `schema.maxWidth || 'xl'`,`false` 被折成 `max-w-xl`。强转会改渲染,故不转,已另立 #4889。

## 卡内 4 个 `body` 节点:前提不成立,已改为前瞻性防护

卡内列的第一个坑是「4 个节点用 `body` 而非 `children`,先改 `body` 再换类型」。**按 origin/main 重扫,这 4 个节点不在本单范围内** —— 它们是 `components-basic-sidebar/*.json` 的四个 `{"type":"div","className":"p-4","body":[...]}`,className 只有 `p-4`,落在 PR3998 判定表的「纯装饰盒子 61」里,属于 83 个无对等物那批。本单 103 个转换节点里 `body` 键出现 **0 次**,`body`→`children` 改写数因此是 **0**,不是漏做。

坑本身是真的,只是命中面在别处。所以没有强行凑一个改写,而是把它钉成**面向整个类型族的前瞻守卫**:`flex`/`stack`/`grid`/`container` 一律不得携带 `body` 键。下一轮 sweep 处理那 83 个时,naive 换类型会当场撞红而不是静默丢内容(反向验证已实测,见下)。

## 两处渲染器读法修复(**本 PR 越出了卡内文件面,单独声明**)

卡内给 container 的等价办法是「默认 padding 4,需显式 `padding: 0` 保等价」。**实测该办法本身失效**:

```
packages/components/src/renderers/layout/flex.tsx:19       const gap = schema.gap || 2;
packages/components/src/renderers/layout/container.tsx:21  const padding = schema.padding || 4;
```

`FlexSchema.gap` / `ContainerSchema.padding` 都声明为 `number`,`0` 是合法值,但 `||` 把它折进默认值 —— 于是两个渲染器里各自那行**专门为零值写的分支是死代码**:

```
flex.tsx:47       gap === 0 && 'gap-0',
container.tsx:43  padding === 0 && 'p-0',
```

后果实测:声明 `padding: 0` 的 container 渲染出 `p-2 sm:p-3 md:p-4`(6 个 container 节点凭空长出内边距,其中 4 个是 ecommerce / marketing 文档页的顶层包装),声明 `gap: 0` 的 flex 渲染出 `gap-1.5 sm:gap-2`。这就是 #4001 的同型故障往下一层:**声明了的键,引擎默默丢弃,JSON 说一套 DOM 做一套**。

两行改为 `??`,与同族的 `stack.tsx:25` / `grid.tsx:88` 本来就用的读法一致 —— 不是新发明的约定,是把跑偏的两个收回来。**未声明该键时默认值一字不变**(`gap: 2` / `padding: 4`);只有显式声明的 `0` 会变,而基线 commit 上全仓 JSON 声明 `gap: 0` 或 `padding: 0` 的节点数是 **0**,所以今天渲染的任何东西都不改变。

为什么放进本 PR 而不是拆单:不修则卡内的 container 验收条款无法达成,而唯一的绕法是在 className 里塞 `p-0 sm:p-0 md:p-0` 去对冲自己声明的 `padding` —— 正是卡里 ⛔ 掉的「自相矛盾的授权」。若维护者认为该走独立单,回退这 2 行 + 对应 pin 测试即可,代价是本 PR 需撤下 6 个 container 节点、49 个 flex 节点改回不声明 `gap`。

## 等价验证:103/103 渲染子树逐字节一致

把每个转换后的节点、与它替换掉的那个 `div`(用**转换前的真实 className**、包住**同一批 children**)双双送进真的 `SchemaRenderer` 渲染后比对。逐节点隔离比较,不比整棵子树 —— 否则差异只会来自后代也被转换了。

**103 个节点的 `innerHTML` 全部逐字节相同。** 类名增减的全集(按 token 统计出现节点数)只有下面这些,没有一项是回归:

| 增加的 token | 节点数 | 性质 |
|---|---|---|
| `flex-row` | 84 | flex 的 CSS 初始方向,裸 `div` 加 `flex` 本来就是 row |
| `justify-start` | 43 | CSS 初始值 `flex-start`,原本没写 |
| `items-stretch` | 23 | CSS 初始值,原本没写 `items-*`(15 flex + 8 stack) |
| `gap-0` | 49 | 原本就没有任何 gap 类 |
| `p-0` | 6 | 原本就没有 padding 类 |
| `w-full` | 2 | block 元素常规流下 `width:auto` 已铺满,等效(另 4 个 container 原本就带 `w-full`) |
| `grid-cols-1` | 5 | 只有 `md:grid-cols-*` 之类响应式列类的裸 `grid`,基础断点本就解析成单列 |
| `flex` `flex-col` | 8 | stack:`space-y-*` 的块级间距换成 flex column |
| gap 阶梯(`gap-2` `sm:gap-3` 等) | 40 + 4 | 见下 |

| 减少的 token | 节点数 | 换成了 |
|---|---|---|
| `gap-3` | 35 | `gap-2 sm:gap-3`(mobile-first 阶梯) |
| `space-y-4` / `space-y-2` / `space-y-3` / `space-y-6` | 4 / 2 / 1 / 1 | stack 的 gap 阶梯 |

前 8 行全部是**无渲染差异**的显式化:要么是 CSS 初始值被写明,要么是原本就没有的属性被声明成零。真正改变渲染的只有最后一类 —— gap/space-y 换成阶梯。

**gap 阶梯在 640px 以下不是逐字节等价,这是正确语义** —— 阶梯就是 `FlexSchema.gap` 的含义。⛔ 没有用「`gap: 0` + className 留着 `gap-3`」去硬凑逐字节:那种写法自相矛盾,而且恰好再教一遍本单要消除的反模式。

grid 一类卡内写的是「逐字节等价」,实测**略有出入且出入是对的**:5 个节点原本都只有响应式列类(`md:grid-cols-3` 之类)、没有基础列类,渲染器必然产出一个基础列类,于是 5 个各多出一个 `grid-cols-1`;其余 token 逐字节同序。多出来的正是裸 `grid` 隐式解析出的单列基线。

## 反向验证(三组,均先写预判再执行)

**RV1 —— 渲染器读法。** 把 `flex.tsx` 的 `??` 改回 `||`。预判:`gap-0` 钉子翻红、features-grid 等价钉翻红,而「省略 gap 时仍默认 2」应当**保持绿**(`||` 与 `??` 在键缺席时一致)。实测与预判一致:

```
× renders gap-0, not the default ladder
  Expected: "flex flex-row justify-start items-start gap-0"
  Received: "flex flex-row justify-start items-start gap-1.5 sm:gap-2"
× marketing/features-grid (... 转 flex)
  AssertionError: marketing/features-grid has no flex node rendering
  `flex flex-row justify-center items-center gap-0 h-12 w-12 rounded-lg bg-primary/10`
 Tests  2 failed | 17 passed (19)
```

17 个通过的里就含「省略 gap 时仍默认 2」 —— 预判的不变方向也确认了(这条正是 `??` 正确、`||` 不正确的分界)。

**RV2 —— `body` 陷阱守卫。** 卡内预设的靶子(范围内的 body 转 children 转换)不存在,故改用真实标本反向验证守卫本身:取范围外的 `components-basic-sidebar/basic-sidebar.json` 的 body 节点,naive 换成 `flex`。预判:`body` 守卫翻红,且内容静默丢失。实测一致:

```
× no layout node carries a `body` key, which those renderers never render
  + "components-basic-sidebar/basic-sidebar (type: flex)"
```

内容丢失实测(同一节点两种 type 渲染):`div` 的 innerHTML 是 `"Main content area"`(17 字节),`flex` 的是 `""`(0 字节)—— 静默清零,没有任何报错。

**RV3 —— 反模式棘轮。** 把 `marketing/testimonials` 的 grid 节点改回 `div` 原写法。预判:棘轮翻红。实测一致:

```
× no div carries layout-intent classes outside the documented exemptions
  + "marketing/testimonials :: grid md:grid-cols-3 gap-6 (转 grid)"
```

三组变异均已 `git checkout` 还原(⛔ 未用 `git stash` —— stash 栈是跨 worktree 共享的)。

## 新增测试

**`examples/schema-catalog/test/layout-props-conversion.test.tsx`**(13 条),沿 `fields-form-hosted` 的 harness 形态,钉三件不同的事:

1. **棘轮** —— catalog 里没有任何 `div` 携带布局意图 className,除上述 3 个豁免;另有一条「豁免仍然命中」的反向条款,防止 allowlist 比事实更宽。
2. **无死插槽** —— 没有任何 `flex`/`stack`/`grid`/`container` 节点携带 `body` 键(即上文的前瞻守卫);外加非空性下限(当前 441 个布局节点)。
3. **等价** —— 每类至少 2 个抽样(共 8 个),内联**转换前的真实 className**,断言渲染子树逐字节一致 + 转换后类名逐字面钉死。

**`packages/components/src/__tests__/layout-zero-scale-values.test.tsx`**(6 条)钉住零值可达:`gap: 0` 得 `gap-0`、`padding: 0` 得 `p-0`;并各配一条「省略时仍取默认值」(防止把 `||` 的 bug 修成反向的 bug)与一条非零阶梯不受影响。

## 验证

```
pnpm --workspace-concurrency=2 --filter "@object-ui/example-schema-catalog^..." build
  BUILD EXIT: 0

pnpm exec vitest run examples/schema-catalog --maxWorkers=2
  Test Files  9 passed (9)
       Tests  1589 passed (1589)

pnpm exec vitest run packages/components --maxWorkers=2
  Test Files  144 passed (144)
       Tests  1293 passed (1293)

pnpm exec turbo run type-check --concurrency=2
  Tasks:    81 successful, 81 total
  Cached:    25 cached, 81 total
    Time:    6m33.999s

node scripts/check-control-bytes.mjs
  OK (scanned 4370 tracked text file(s); skipped 85 binary)
  改动文件另做了越过门禁盲区的自查(grep -naP 控制字符类),零命中
```

全部重活都在 `flock /tmp/os-heavy-verify.lock` 里串行执行,堆上限 4GB。

## changeset

catalog 侧**不欠** changeset:`@object-ui/example-schema-catalog` 命中 `.changeset/config.json` 的 `ignore` 项 `@object-ui/example-*`,changesets 从不给它发版。`node scripts/check-changeset-presence.mjs` 实测:

```
Compared the working tree with 372d9f9b4 (merge-base with origin/main): 25 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

但 `packages/components` 的两行读法修复动的是**已发版包**,故补了 `.changeset/tidy-poems-shave.md`,按 AGENTS.md 版本策略标 `minor`(⛔ 不标 `major`)。

## 边界

只动了 25 个 catalog JSON + 2 个渲染器读法 + 2 个测试 + 1 个 changeset。**没有**碰 83 个无对等物节点、`div.mdx` 的 2 个 legacy 示例、任何 MDX 文档页,**没有**碰 `content/docs/releases/`,**没有**给渲染器加任何宽容别名。

## 浏览器抽查

未做。容器内没有可用的 preview / 浏览器通道,如实记录:以上述 103/103 的真实 `SchemaRenderer` DOM 断言代替,该断言比缩略图目视更严(逐字节比对子树 + 类名逐字面钉死)。

## 相邻发现(已另立单,不在本 PR 扩围)

三条都打了 `finding`(今天都没有用户撞到),交分诊定级;三条都做过关键词 + 文件路径的重复检索,无既有单。

- **#4889** —— `ContainerSchema.maxWidth` 声明了 `false` 这一档,但 `container.tsx:20` 用 `|| 'xl'` 读它,`false` 渲染出 `max-w-xl`。本族里剩下的最后一处假值读法,**没有**跟着本 PR 一起改:它不像 `gap`/`padding` 那样有现成的目标分支,「不产出 max-width 类」与 `max-w-none` 是否等价是个需要拍板的设计问题。上面那个 `documentation-page` 豁免修好后可回收。
- **#4890** —— `stack.tsx:25` 读一个 `StackSchema` 从未声明的 `spacing` 键(`(schema as any).spacing`),catalog 里 135 个节点、39 个文件照着它写。#4001 的宽容变体:consumer 接住了所以渲染正确,错写法就一直传播;`flex` 不读这个键,哪天有人把 `stack` 换 `flex` 就是完整重演。
- **#4891** —— 140 个节点(33 文件)**已经**是 `flex`/`stack`/`container`,却仍把自己声明的 props 手写在 className 里(`{"type":"flex","className":"items-center justify-between …"}`)。与本单同一条立论、不同一批节点:本单管「类型都错」的,这条管「类型对了、props 没用」的。与 #4890 文件面高度重叠,建议合并成一次 sweep;本 PR 建的棘轮就是它的落点。

完整的 103 节点转换清单(文件 → 原 className → 新 props)见下方评论,避免正文过长。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_