### PR TITLE
test(layout): pin the README Registration key list to registerLayout() (#4860)

### DIFF
--- a/.changeset/layout-readme-registration-keys-pin.md
+++ b/.changeset/layout-readme-registration-keys-pin.md
@@ -1,0 +1,23 @@
+---
+---
+
+Test-only (objectui#4860): pin `packages/layout/README.md`'s `## Registration`
+key list to `registerLayout()`'s actual `ComponentRegistry.register` calls, in
+both directions. No published source changed and no behaviour changed, so this
+declares no package.
+
+The same component-key list is published in three places. Two were already held
+to source — the guide's sentence by `guide-layout-sidebar-nav-doc.test.ts`
+(objectui#4840) and the keys' existence by `app-shell-not-a-component-key.test.tsx`
+(objectui#4841) — and this README's list was the one copy nothing checked. The
+asymmetry was measured rather than assumed: objectui#4841 deregistered
+`app-shell`, the guide's list went red and forced the page to be edited, and the
+README's list named the same retired key with no test noticing. It was corrected
+by hand in PR #4859, which is the failure mode itself: a README is this package's
+npm landing page, and a key listed there that nothing registers is a reader
+authoring that node and getting the renderer's `Unknown component type` panel
+(OBJUI-001).
+
+Both lists are parsed on every run rather than restated in the test — hardcoding
+them would reproduce objectui#3899's own defect, whose prose listed a
+`sidebar-nav` key this package has never registered.

--- a/packages/layout/src/__tests__/readme-registration-keys.test.ts
+++ b/packages/layout/src/__tests__/readme-registration-keys.test.ts
@@ -1,0 +1,231 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `packages/layout/README.md`'s `## Registration` section names exactly the keys
+ * `registerLayout()` registers (objectui#4860).
+ *
+ * ## Why this file exists
+ *
+ * The same key list is published in THREE places, and until this pin two of them
+ * were held to source and this one was not:
+ *
+ *   - `content/docs/guide/layout.md`'s "registers five keys — …" sentence, held
+ *     by `guide-layout-sidebar-nav-doc.test.ts` (objectui#4840);
+ *   - `src/index.ts` itself — the keys' existence — held by
+ *     `app-shell-not-a-component-key.test.tsx` (objectui#4841, one key) and
+ *     `side-effects-manifest.test.ts` (a count FLOOR, not a census);
+ *   - this README's `## Registration` paragraph — nothing.
+ *
+ * The asymmetry was measured, not theorised. objectui#4841 deregistered
+ * `app-shell`, and the guide's key list went red and forced the page to be
+ * edited; the README's list named the same retired key and no test noticed. It
+ * was corrected by hand in PR #4859 — which is exactly the failure mode, because
+ * "someone read it" is not a mechanism. This README is the npm landing page for
+ * `@object-ui/layout`; a key listed here that nothing registers is a reader
+ * authoring `{ "type": "<that key>" }` and getting the renderer's red
+ * `Unknown component type` panel (OBJUI-001) instead of a component.
+ *
+ * ## Direction — deliberately BOTH
+ *
+ * Two separate defects, so two separate tests with two separate messages:
+ *
+ *   - README names a key the barrel does not register → it teaches a node type
+ *     that does not resolve (the objectui#4841 shape, and objectui#3899's
+ *     phantom `sidebar-nav` before it);
+ *   - the barrel registers a key the README does not name → the landing page
+ *     hides a live authoring surface, which is how a key ends up documented
+ *     nowhere and then "cleaned up" as dead.
+ *
+ * Order is NOT compared. The list happening to run in registration order is a
+ * nicety, not a contract, and a pin that reddens on a reordered sentence would
+ * be a pin readers learn to edit around.
+ *
+ * ## The expected list is READ OUT OF the source, never listed here
+ *
+ * Hardcoding the five keys in this file would reproduce the very defect the pin
+ * is against: objectui#3899's own prose confidently listed a `sidebar-nav` key
+ * this package has never registered. So both sides are parsed on every run, and
+ * a red test here is always "fix the README (or the barrel)", never "update the
+ * test".
+ *
+ * That parse has a dependency worth naming, because it is easy to break from the
+ * other side: the source reader is a regex for `ComponentRegistry` + `.register(`,
+ * so a register call QUOTED VERBATIM inside a comment in `src/index.ts` would be
+ * collected as a live registration. `src/index.ts` describes the removed
+ * `app-shell` call in prose for precisely this reason (objectui#4841 wrote that
+ * note); this pin is a third beneficiary of that discipline, and anyone tempted
+ * to paste a real call into a comment there breaks this file too.
+ *
+ * ## Scan surface — deliberately narrow
+ *
+ * This file reads `packages/layout/README.md`'s `## Registration` sentence and
+ * `packages/layout/src/index.ts`'s register calls, and nothing else.
+ *
+ * A NEW file rather than an extension of `readme-app-shell-example.test.ts`
+ * (objectui#4817), which reads the same README: that file states its scan
+ * surface as the `<AppShell …>` opening tags and the `AppShellProps` table, and
+ * reads only the README and `AppShell.tsx`. The Registration list is a fact
+ * about `src/index.ts`, a source this package's README pins otherwise never
+ * open, so it gets its own file the way `readme-sidebar-nav-example.test.ts`
+ * (objectui#3999) has one — one pin per documented concern is this package's
+ * existing shape.
+ *
+ * Not judged here, though both are adjacent and both are already covered:
+ *
+ *   - the `### AppShell` section's paragraph stating that `app-shell` was
+ *     retired and now reports `Unknown component type`. Re-registering the key
+ *     turns `app-shell-not-a-component-key.test.tsx` red by name, and turns the
+ *     second test below red as well (a live key the README does not list), so the
+ *     paragraph cannot go stale unnoticed.
+ *   - the `### SidebarNav` note that `SidebarNav` is not on the registry. Its
+ *     surface is `readme-sidebar-nav-example.test.ts`.
+ *
+ * The reader below is this repo's fourth copy of the same three-line
+ * `ComponentRegistry.register` regex (the others are in
+ * `guide-layout-sidebar-nav-doc.test.ts`, `app-shell-not-a-component-key.test.tsx`
+ * and `side-effects-manifest.test.ts`). Extracting a shared helper is raised as a
+ * side option on objectui#4860 and is deliberately NOT taken here: it would edit
+ * three pin files to serve one, and each of those files is self-contained on
+ * purpose — a pin that imports its own reader from a shared module can be
+ * silently neutered from outside the file it defends.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/** `packages/layout` — two levels up from `src/__tests__`. */
+const PKG_DIR = resolve(__dirname, '../..');
+const README = readFileSync(join(PKG_DIR, 'README.md'), 'utf8');
+const LAYOUT_INDEX_SRC = readFileSync(join(PKG_DIR, 'src', 'index.ts'), 'utf8');
+
+/**
+ * The sentence that publishes the key list, and the parenthesised list itself.
+ *
+ * Whitespace between the anchor words is `\s+` rather than a literal space: the
+ * list is markdown prose that gets re-wrapped whenever its length changes, and
+ * it already wraps mid-list on this tree. Where the line breaks fall is not a
+ * fact this file should have an opinion about — `guide-layout-sidebar-nav-doc.test.ts`
+ * learned the same lesson when a rewrap reddened it for no drift at all.
+ *
+ * `[^)]*` for the list body, so the wrap costs nothing and the match stops at
+ * the closing paren.
+ */
+const REGISTRATION_SENTENCE = /registers\s+its\s+component\s+keys\s*\(([^)]*)\)/g;
+
+/** Component keys `registerLayout()` registers, read out of the source. */
+function registeredKeys(): string[] {
+  return [...LAYOUT_INDEX_SRC.matchAll(/ComponentRegistry\.register\(\s*'([^']+)'/g)].map(
+    (match) => match[1],
+  );
+}
+
+/** Component keys the README's `## Registration` sentence names. */
+function documentedKeys(): string[] {
+  const matches = [...README.matchAll(REGISTRATION_SENTENCE)];
+  if (matches.length === 0) {
+    throw new Error(
+      [
+        'packages/layout/README.md no longer carries its "registers its component keys (…)"',
+        'sentence, so this pin has nothing to compare (objectui#4860). If the Registration',
+        'section was reworded, re-point REGISTRATION_SENTENCE at the new wording — do not',
+        'delete the pin, or the npm landing page goes back to being the one copy of this key',
+        'list that nothing checks.',
+      ].join('\n'),
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `packages/layout/README.md now has ${matches.length} "registers its component keys (…)" sentences; this pin would judge only the first. Merge them, or teach this reader about both.`,
+    );
+  }
+  return [...matches[0][1].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+describe("the README's Registration list names exactly the registered keys (objectui#4860)", () => {
+  it('names no key `registerLayout()` does not register', () => {
+    const registered = registeredKeys();
+    expect(
+      registered.length,
+      'no `ComponentRegistry.register` call parsed out of src/index.ts — the assertion below would prove nothing',
+    ).toBeGreaterThan(1);
+
+    const documented = documentedKeys();
+    expect(
+      documented.filter((key) => !registered.includes(key)),
+      [
+        'The `## Registration` list in packages/layout/README.md names a component key that',
+        '`registerLayout()` does not register. This README is the npm landing page for',
+        '@object-ui/layout: a reader who authors `{ "type": "<the listed key>" }` gets the',
+        "renderer's red `Unknown component type` panel (OBJUI-001) and no component at all.",
+        '',
+        'This is exactly how the list rotted before — objectui#4841 deregistered `app-shell`',
+        'while the README went on listing it, and only the guide (objectui#4840) went red.',
+        '',
+        'The expected list is READ OUT OF packages/layout/src/index.ts on every run, so this is',
+        'never "update the test": drop the key from the README, or register it.',
+        `Registered: ${registered.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and names every key `registerLayout()` does register', () => {
+    const registered = registeredKeys();
+    const documented = documentedKeys();
+    expect(
+      documented.length,
+      'no backticked key parsed out of the README `## Registration` sentence — the assertion below would prove nothing',
+    ).toBeGreaterThan(1);
+
+    expect(
+      registered.filter((key) => !documented.includes(key)),
+      [
+        'packages/layout/src/index.ts registers a component key the `## Registration` list in',
+        'packages/layout/README.md does not name. The landing page is where a consumer looks',
+        'for the authorable node types of this package, so an unlisted key is a live authoring',
+        'surface nobody can discover — and the first thing that happens to an undocumented key',
+        'is that someone retires it as dead.',
+        '',
+        'The list is READ OUT OF the source on every run: add the key to the README sentence,',
+        'or stop registering it.',
+        `Registered: ${registered.join(', ')}`,
+        `Documented: ${documented.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and both sides really parsed — neither list is empty, and neither repeats itself', () => {
+    // Two set-difference assertions are BOTH trivially green on two empty lists,
+    // which is the shape a pin fails in without ever going red: a regex that
+    // stops matching (the README reworded, a register call written with double
+    // quotes) would silently turn the tests above into no-ops. The floors are
+    // asserted here as their own visible fact rather than only as `expect`
+    // messages, so "the readers still read something" cannot be deleted by
+    // accident along with a message nobody looks at.
+    const registered = registeredKeys();
+    const documented = documentedKeys();
+
+    expect(registered.length, 'no register call parsed out of src/index.ts').toBeGreaterThan(1);
+    expect(
+      documented.length,
+      'no backticked key parsed out of the README Registration sentence',
+    ).toBeGreaterThan(1);
+
+    // A repeated entry keeps both set differences empty while the two lists are
+    // not the same list, so it is the one drift the pair above cannot see.
+    expect(
+      documented.length,
+      `The README Registration list names a key twice: ${documented.join(', ')}`,
+    ).toBe(new Set(documented).size);
+    expect(
+      registered.length,
+      `src/index.ts registers a key twice: ${registered.join(', ')}`,
+    ).toBe(new Set(registered).size);
+  });
+});


### PR DESCRIPTION
Fixes #4860

## 背景:三处同源键表,只有这一处没有钉子

`@object-ui/layout` 的组件键表在仓内发布在三个地方,其中两处早已机械钉到源码:

| 位置 | 钉子 |
|---|---|
| `content/docs/guide/layout.md` 的 "registers five keys …" 句 | `guide-layout-sidebar-nav-doc.test.ts`(#4840) |
| `packages/layout/src/index.ts` 键的存废 | `app-shell-not-a-component-key.test.tsx`(#4841)+ `side-effects-manifest.test.ts`(只有数量下限) |
| `packages/layout/README.md` 的 `## Registration` 段 | **无** |

这个不对称是**实测**出来的,不是推断:#4841 撤销 `app-shell` 注册时,guide 的键表被钉子打红、逼出了文档修改;README 的键表列着同一个已撤销的键,**没有任何测试发现**,最后是 PR #4859 里人工改对的。「有人读到了」不是机制。README 是本包的 npm 首屏 —— 列一个没人注册的键,等于读者照着写那个节点、拿到渲染器的红框 `Unknown component type`(OBJUI-001)。

## 改动

只加两个文件,**README.md 本体零修改**(自 PR #4859 起它就是对的):

- `packages/layout/src/__tests__/readme-registration-keys.test.ts` — 新钉子
- `.changeset/layout-readme-registration-keys-pin.md` — 空 frontmatter(纯测试,不发布任何包)

### 钉子形态:双向

照 #4840 钉 guide 的形态,但拆成**两个方向、两条独立诊断**,因为它们是两种不同的缺陷:

1. **README 多列** → 教了一个不解析的节点类型(#4841 的形状;更早是 #3899 的幽灵 `sidebar-nav`)。
2. **README 少列** → npm 首屏藏起一个活的可编写面;而一个哪里都没写的键,接下来就是被当成死代码撤掉。

第三条测试把**下限**断言成显式事实:两个集合差在两个空列表上都是平凡绿,所以正则一旦不再匹配(README 改写、注册调用改用双引号),上面两条会静默变成空操作。这条同时挡住重复项 —— 重复项能让两个集合差都为空,而两份列表其实并不相同。

**顺序不比较**:列表恰好按注册顺序排列是好习惯、不是契约;一个因重排就变红的钉子,读者会学会绕开它。

### 期望值一律从源码读出,绝不写死

在测试里硬编码这五个键,正是这个钉子要防的缺陷本身:#3899 自己的散文就自信地列了一个本包从未注册过的 `sidebar-nav`。所以两侧每次运行都重新解析 —— 红了永远是「改 README(或改 barrel)」,绝不是「更新测试」。

这个解析有一个值得写下来的依赖:源码侧读的是 `ComponentRegistry` + `.register(` 的正则,因此 `src/index.ts` 注释里**逐字引用**一个 register 调用会被当成活注册。`index.ts` 用散文描述那个已撤销的 `app-shell` 调用正是为此(#4841 留下的注释),本钉子是第三个受益者,文件头注释里也记了这条。

### 为什么是新文件,而不是扩 `readme-app-shell-example.test.ts`

那个文件(#4817)自述的扫描面是 AppShell 开标签与 `AppShellProps` 表格,且只读 README 与 `AppShell.tsx`。Registration 键表是关于 `src/index.ts` 的事实 —— 本包已有的 README 钉子从不打开这个源。按包内既有惯例(`readme-sidebar-nav-example.test.ts` / `readme-app-shell-example.test.ts`),一个被记录的关注点配一个钉子文件。

### 两处与派单预判不同的形态,记录在案

1. **README 侧不是 markdown 表格。** 派单预判需要解析表格行;实际上 Registration 键表是一句散文里括号内的反引号列表(README.md:26-27),而且**跨行折行**。所以解析照 #4840 的 guide 句子做(锚点词之间用 `\s+`,列表体用 `[^)]*`),而不是照表格行做 —— guide 那条钉子正是被一次纯重排打红过,才留下这个教训。
2. **共用 helper 没有提取。** #4860 把它列为选项 A 的附带项。这条正则在仓内已有三份副本(`guide-layout-sidebar-nav-doc.test.ts`、`app-shell-not-a-component-key.test.tsx`、`side-effects-manifest.test.ts`),本 PR 是第四份。刻意不提取:为服务一个钉子去改三个钉子文件,而这些文件是**故意自包含**的 —— 一个从共享模块导入自己读取器的钉子,可以在它所守护的文件之外被静默架空。理由写在新文件的头注释里。

## 反向验证(两个方向,先预判后跑)

预判写在跑之前:方向 A 只让第 1 条红、方向 B 只让第 2 条红,且**两次 `packages/layout` 其余 16 个测试文件全绿** —— 后者才是本单前提的实测证据。

**方向 A —— README 键表加一个假键 `fake-key`:**

```
× names no key `registerLayout()` does not register
AssertionError: The `## Registration` list in packages/layout/README.md names a component key that
`registerLayout()` does not register. This README is the npm landing page for @object-ui/layout …
Registered: page-header, page:card, responsive-grid, navigation-renderer, app-schema-renderer
: expected [ 'fake-key' ] to deeply equal []

 Test Files  1 failed | 16 passed (17)
      Tests  1 failed | 183 passed (184)
```

**方向 B —— README 键表删掉活键 `app-schema-renderer`:**

```
× and names every key `registerLayout()` does register
AssertionError: packages/layout/src/index.ts registers a component key the `## Registration` list in
packages/layout/README.md does not name …
Registered: page-header, page:card, responsive-grid, navigation-renderer, app-schema-renderer
Documented: page-header, page:card, responsive-grid, navigation-renderer
: expected [ 'app-schema-renderer' ] to deeply equal []

 Test Files  1 failed | 16 passed (17)
      Tests  1 failed | 183 passed (184)
```

两次都与预判逐字相符,而且两次**其余 16 个文件全绿** —— 即在本 PR 之前,README 键表向任一方向漂移,仓内没有任何东西会发现。这正是 #4860 立单所依据的事实,现在被测量下来了。

还原用 `git checkout -- packages/layout/README.md`,**未用 `git stash`**(stash 栈跨 worktree 共享,AGENTS.md 明令禁止)。

## 验证

还原后全绿:

```
$ pnpm exec vitest run packages/layout --maxWorkers=2
 Test Files  17 passed (17)
      Tests  184 passed (184)
```

```
$ pnpm --filter @object-ui/layout type-check     # tsc --noEmit && tsc -p tsconfig.test.json
(无输出,exit 0)

$ pnpm --filter @object-ui/layout lint
✖ 41 problems (0 errors, 41 warnings)            # 全部是既有告警,新文件零告警

$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 4371 tracked text file(s); skipped 85 binary).

$ node scripts/check-changeset-presence.mjs --base origin/main
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
    Every one of them has an EMPTY frontmatter — declared as releasing nothing …

$ node scripts/check-changeset-no-major.mjs
✅  No changeset declares a `major` bump.
```

type-check 用的是包级脚本而非仓根 `turbo run type-check` 全量:改动是 `packages/layout` 内一个新增测试文件,不被任何包导入,能编译它的正是该包的 `tsconfig.test.json`(已跑,干净);容器内多 agent 并行,全量 type-check 属于无谓的重扫。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_