### PR TITLE
fix(types): drop declarationMap and src from published files

### DIFF
--- a/.changeset/types-files-drops-src-4851.md
+++ b/.changeset/types-files-drops-src-4851.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/types': patch
+---
+
+`@object-ui/types` stops publishing its `src/` tree
+
+Its manifest's `files` array listed `src` alongside `dist`, so every published tarball carried all 91 source files. Unlike the two sibling packages already fixed (`@object-ui/data-objectstack` #4847, `@object-ui/fields` #4856), this one was not a mechanical delete: `packages/types/tsconfig.json` built with a bare `tsc` and `declarationMap: true`, and its shipped `dist/*.d.ts.map` named `sources: ["../src/*.ts"]` with `sourcesContent: false` — a real, if small, consumer (editor go-to-source). Deleting `src` from `files` while that map still pointed at it would have shipped a tarball with a broken-link map.
+
+Maintainer ruling (2026-08-17, objectui#4851): turn `declarationMap` off at the source rather than keep a permanent per-package exception in the phantom-dependencies gate's header, or add `inlineSources` (which saves nothing and adds a third emitter shape). `types` is a pure-types package built by bare `tsc`, so its `.d.ts` is near-isomorphic to its source — go-to-source degrading to the `.d.ts` is a near-zero-pull, deliberate trade.
+
+Order followed: flipped `declarationMap: false` in `packages/types/tsconfig.json` first, clean-rebuilt, and confirmed the published `dist` has zero `.map` files, zero `sourceMappingURL` occurrences, and zero `../src` references (a positive control against the pre-flip build showed 54 of each, so the greps are exercised, not vacuous) — only then trimmed `files` to `["dist", "README.md", "CHANGELOG.md", "LICENSE"]`.
+
+`npm pack --dry-run` across the change, on the freshly rebuilt `dist`:
+
+| | before | after |
+| --- | --- | --- |
+| entries | 203 | 112 |
+| unpacked | 3974143 B | 2828454 B |
+| tarball | 656307 B | 414644 B |
+
+91 `src/*.ts` files leave, none arrives; the `dist/` entry count (108) is unchanged, and its `.d.ts` payload is now map-free.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -56,10 +56,9 @@
   },
   "files": [
     "dist",
-    "src",
     "README.md",
-    "LICENSE",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "composite": true,
     "noEmit": false,
     "lib": ["ES2020", "DOM"],

--- a/scripts/check-phantom-dependencies.mjs
+++ b/scripts/check-phantom-dependencies.mjs
@@ -75,23 +75,27 @@
  *     measured 73 `*.test.d.ts` files landing in the published `dist/` of
  *     `@object-ui/fields` and `@object-ui/plugin-editor`, and three packages
  *     (`fields`, `types`, `data-objectstack`) listed `src` in `files`, so their
- *     tarballs carried the test SOURCES too. Two of the three no longer do:
+ *     tarballs carried the test SOURCES too. None of the three do anymore.
  *     objectui#4847 dropped `src` from `data-objectstack`'s `files` (43 source
- *     files, 38 of them tests, left that tarball) and objectui#4856 dropped it
- *     from `fields`' (173 source files, 97 of them tests). Only `types` still
- *     lists it, and there the entry is load-bearing rather than leftover,
- *     because it builds with a bare `tsc` under the root's `declarationMap` /
- *     `sourceMap` and no `inlineSources`, so its shipped `dist/*.d.ts.map` name
- *     `../src/*.ts` with no embedded content — dropping `src` there would leave
- *     published maps pointing at files the tarball no longer carries. `fields`
- *     was measurably NOT that shape, which is why the two were split rather than
- *     fixed together: its declarations come from `vite-plugin-dts`, and a clean
- *     rebuild emits zero `.map` files and zero `sourceMappingURL` comments, so
- *     nothing in its `dist` referred back to `src` at all. That is a real defect
- *     where it is one, and it is already filed; it is not this gate's, because
- *     nothing resolves those files and so no install of them can fail. Stated
- *     here rather than glossed, because "the build excludes tests" is the
- *     plausible-sounding version of this paragraph and it is not what the
+ *     files, 38 of them tests, left that tarball); objectui#4856 dropped it
+ *     from `fields`' (173 source files, 97 of them tests) after a clean rebuild
+ *     measured zero `.map` files and zero `sourceMappingURL` comments in its
+ *     `vite-plugin-dts` output, so nothing in its `dist` referred back to `src`
+ *     at all. `types` was the holdout: it builds with a bare `tsc`, and until
+ *     objectui#4851 its `tsconfig.json` set `declarationMap: true` with no
+ *     `inlineSources`, so its shipped `dist/*.d.ts.map` named `../src/*.ts`
+ *     with no embedded content — dropping `src` from `files` while that was
+ *     still true would have left published maps pointing at files the tarball
+ *     no longer carried. objectui#4851 closed the gap at the source instead of
+ *     leaving the exception standing: `declarationMap` is now `false`, a clean
+ *     rebuild confirmed zero `.map` files, zero `sourceMappingURL` comments,
+ *     and zero `../src` references in `dist`, and only then did `src` come out
+ *     of `files`. Go-to-source for `@object-ui/types` consumers now resolves
+ *     to the `.d.ts`, not the original `.ts` — a deliberate, near-zero-pull
+ *     trade for a pure-types package whose declarations are near-isomorphic to
+ *     their source, made explicitly rather than left as a silent regression.
+ *     Stated here rather than glossed, because "the build excludes tests" is
+ *     the plausible-sounding version of this paragraph and it is not what the
  *     repository measures.
  *
  * The root allowance is a decision, not an oversight, and it is worth stating


### PR DESCRIPTION
Fixes #4851

## What

The `@object-ui/types` half of the `src`-in-`files` finding, ruled option (b) in the
[maintainer ruling](https://github.com/objectstack-ai/objectui/issues/4851#issuecomment-5310924919):
turn `declarationMap` off at the source, then trim `files` to dist-only, matching the
shape #4847 (`@object-ui/data-objectstack`) and #4856 (`@object-ui/fields`) already used.

Unlike those two, this one was not a mechanical delete: `packages/types` builds with a
bare `tsc` and had `declarationMap: true`, and its shipped `dist/*.d.ts.map` named
`sources: ["../src/*.ts"]` with `sourcesContent: false` — a real (if small) consumer:
editor go-to-source. Deleting `src` from `files` while that map still pointed at it
would have shipped a tarball with broken-link maps, the one state the ruling excludes.

## Order followed (per the ruling)

1. Flipped `declarationMap: false` in `packages/types/tsconfig.json`. Checked the
   inheritance chain: `packages/types/tsconfig.json` extends the **repo-root**
   `tsconfig.json` (not `tsconfig.base.json` — nothing under `packages/types` is on
   that chain), and neither the root nor the package config ever set `sourceMap: true`
   for this package (confirmed via `tsc --showConfig`), so the bare-`tsc` build only
   ever emitted `.d.ts` + `.d.ts.map`, never `.js.map`.
2. Clean rebuild (`rm -rf dist tsconfig.tsbuildinfo && tsc`) — no workspace dependency
   build was needed (`@object-ui/types` has none in this package's own build graph
   beyond `@objectstack/spec`, already installed).
3. Verified `dist` with a positive control:

   | | pre-flip (baseline) | post-flip |
   | --- | --- | --- |
   | `.map` files | 54 | **0** |
   | `sourceMappingURL` occurrences | 54 | **0** |
   | `../src` references | 54 | **0** |

   The pre-flip run is the positive control proving the greps actually hit something
   (not a vacuously-passing pattern) before trusting the post-flip zeros.
4. Trimmed `files` to `["dist", "README.md", "CHANGELOG.md", "LICENSE"]`, after
   confirming all four points of #4847's pre-deletion checklist for this package:
   - `exports` map: 11 subpath entries, every condition targets `dist`.
   - `main` / `module` / `types`: all `./dist/...`.
   - Repo-wide grep for `@object-ui/types/src` (docs, code) — zero hits; no guide
     teaches a `src` deep-import for this package (unlike `fields`, which had this in
     3 skill guides per #4851's own investigation — filed separately as #4858, not
     applicable here since `types` has no such guide text at all).
   - Sourcemaps: covered by step 3 above.

   `npm pack --dry-run` before/after, on the freshly rebuilt `dist`:

   | | before | after |
   | --- | --- | --- |
   | entries | 203 | 112 |
   | unpacked | 3974143 B | 2828454 B |
   | tarball | 656307 B | 414644 B |

   91 `src/*.ts` files leave, none arrives; the `dist/` entry count (108) is unchanged
   byte-for-byte apart from the edited `package.json`.
5. Updated the `scripts/check-phantom-dependencies.mjs` header paragraph: it previously
   read "`fields`/`types` still list `src`, and `types`'s entry is load-bearing" (already
   updated once by #4856/PR #4861 to retire the `data-objectstack` example). This PR
   retires the last of the three — the paragraph now states all three originally-recorded
   packages have dropped `src` from `files`, and explains why `types` needed the
   `declarationMap` flip first rather than a bare delete.

## Consumer impact

Go-to-source for `@object-ui/types` consumers now resolves to the shipped `.d.ts`
instead of the original `.ts` — a deliberate, near-zero-pull trade per the ruling
(`types` is a pure-types package built by bare `tsc`, so its declarations are
near-isomorphic to their source). No public type surface changed; `exports` targets are
unchanged.

## Tests (HEAD `903f47f`)

- `pnpm exec vitest run --root . scripts/__tests__/package-files-exist.test.ts` — 18/18 passed
- `pnpm exec vitest run packages/types/ --maxWorkers=2` — 36 files / 428 tests passed
- `node scripts/check-phantom-dependencies.mjs` — passing (re-run at HEAD)
- `cd packages/types && npm run type-check` (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`) — clean
- `node scripts/check-control-bytes.mjs` — passing
- `node scripts/check-package-self-import.mjs` — passing
- `node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs` — passing (re-run at HEAD)
- `node scripts/check-published-dist-tooling.mjs` — **not run locally**: this gate costs
  a full monorepo build (objectui#4846) and is not implicated by this diff (no change to
  what any package's build program emits); left to CI per "本地验证范围".

## Out-of-scope finding (not fixed here)

While auditing `packages/types/package.json`'s `exports` map against the built `dist`,
found `exports["."].require` points at `./dist/index.cjs`, which the package's bare
`tsc` build (`"build": "tsc"`) never emits — confirmed pre-existing on `origin/main`,
unrelated to this change. Filed as #4896, out of this PR's file surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbRmJD3iPhXjKr6vhd4Qkv)_