### PR TITLE
fix(app-shell): a 400 FLOW_FAILED or 404 on the flow route is terminal, not retryable

### DIFF
--- a/.changeset/flow-resume-flow-failed-terminal.md
+++ b/.changeset/flow-resume-flow-failed-terminal.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/app-shell': patch
+---
+
+A flow-run failure that arrives as `400 FLOW_FAILED` — and any `404` on the flow route — is now classified as terminal rather than retryable.
+
+`interpretFlowResponse` tested `!res.ok` first and returned `retryable: true` for
+everything it caught, so every non-2xx was treated as a transport failure. That
+flag is what `FlowRunner` reads to decide whether to keep the wizard dialog open:
+a transport failure did not consume the suspension, so retrying the same run is
+meaningful, while a flow failure is terminal because the engine consumes the
+suspension before running downstream nodes (resume-once) and a retry can only
+reach "No suspended run".
+
+Two classes were landing on the wrong side of that line:
+
+- **`400` + `FLOW_FAILED`** — the flow ran and failed. objectstack#8684 moves this
+  exact event off `200 {data:{success:false}}` onto a real status code, inheriting
+  the objectstack#3962 ruling that business failures must not ride HTTP 200 inside
+  a double envelope. Landing this read **first** is the maintainer's explicit
+  sequencing (ruling of 2026-08-15, sub-decision 3): had the backend flipped
+  first, a terminal node failure would have kept the wizard open offering a retry
+  guaranteed to fail. Forward-compatible — nothing sends that body yet, so the arm
+  is dormant until it does. Only this code qualifies; the route's other 400s
+  (`INVALID_SIGNAL`, `INVALID_SCREEN_INPUT`) are refused before the signal reaches
+  the engine's variable map, so the suspension survives and a corrected resubmit
+  stays meaningful.
+- **`404`** — no such suspended run, or no such flow. This half is **not** dormant:
+  the route already answers `404 No such suspended run` today, and each one had
+  been keeping the wizard open for a retry that could only 404 again. Keyed on the
+  status alone, since a proxy or unmounted-route 404 carries no envelope to read a
+  code from.
+
+The flow's authorable `errorMessage` is preferred again on the failing path. The
+error envelope carries no `data`, so it is read from `error.details` — the
+envelope's own declared carrier for structured extras, and the only slot that
+survives to the wire once `splitSemanticCode` promotes `details.code`. Absent, the
+message degrades to the envelope's own `error.message`, never to silence.

--- a/packages/app-shell/src/utils/__tests__/flowResponse.test.ts
+++ b/packages/app-shell/src/utils/__tests__/flowResponse.test.ts
@@ -75,6 +75,134 @@ describe('interpretFlowResponse — transport failures stay retryable', () => {
     });
 });
 
+/**
+ * The ADR-0112 error envelope, reproduced from the producer rather than
+ * imagined: `apiErrorResponse` (objectstack `packages/runtime/src/error-envelope.ts`)
+ * emits `{success:false, error:{code, message, httpStatus, details?}}`, and
+ * `splitSemanticCode` promotes a `details.code` into `error.code` while keeping
+ * the remaining `details` keys on the wire.
+ */
+function errorEnvelope(
+    status: number,
+    code: string,
+    message: string,
+    details?: Record<string, unknown>,
+) {
+    return {
+        success: false,
+        error: { code, message, httpStatus: status, ...(details ? { details } : {}) },
+    };
+}
+
+const RESUME_FAILED = "Node 'create_opportunity' failed: Amount must be greater than zero";
+
+describe('interpretFlowResponse — a 400 FLOW_FAILED on resume is TERMINAL (objectui#4784)', () => {
+    // objectstack#8684 moves this exact event off `200 {data:{success:false}}`
+    // onto a real status code. It must land in the same class as the inner
+    // envelope failure, NOT in the transport class: the engine consumed the
+    // suspension (resume-once), so the wizard must close rather than offer a
+    // retry that can only reach "No suspended run".
+    it('classifies it NON-retryable — keyed on the code, not on the status alone', () => {
+        const out = interpretFlowResponse(
+            { ok: false, status: 400 },
+            errorEnvelope(400, 'FLOW_FAILED', RESUME_FAILED),
+            'Resume',
+        );
+        expect(out).toMatchObject({ kind: 'failed', retryable: false, error: RESUME_FAILED });
+    });
+
+    it('prefers the flow-declared errorMessage from `error.details` over the raw error', () => {
+        // The 200 path prefers `data.errorMessage`; the error envelope has no
+        // `data`, so `error.details` is the declared carrier that survives to
+        // the wire. Losing this half was the second regression #4784 names.
+        const out = interpretFlowResponse(
+            { ok: false, status: 400 },
+            errorEnvelope(400, 'FLOW_FAILED', RESUME_FAILED, {
+                errorMessage: 'This lead has already been converted.',
+            }),
+            'Resume',
+        );
+        expect(out).toMatchObject({
+            kind: 'failed',
+            retryable: false,
+            error: 'This lead has already been converted.',
+        });
+    });
+
+    it('falls back to the envelope message when no errorMessage was carried', () => {
+        const out = interpretFlowResponse(
+            { ok: false, status: 400 },
+            errorEnvelope(400, 'FLOW_FAILED', RESUME_FAILED, { durationMs: 45 }),
+            'Resume',
+        );
+        expect(out).toMatchObject({ kind: 'failed', error: RESUME_FAILED, retryable: false });
+    });
+
+    it('matches the pre-ADR-0112 lowercase spelling too — the console outlives one vocabulary', () => {
+        const out = interpretFlowResponse(
+            { ok: false, status: 400 },
+            errorEnvelope(400, 'flow_failed', RESUME_FAILED),
+            'Resume',
+        );
+        expect(out).toMatchObject({ kind: 'failed', retryable: false });
+    });
+
+    it('needs BOTH the 400 and the code — FLOW_FAILED on another status stays retryable', () => {
+        // A 500 is the server saying it broke, whatever code rode along; that
+        // did not consume the suspension.
+        const out = interpretFlowResponse(
+            { ok: false, status: 500 },
+            errorEnvelope(500, 'FLOW_FAILED', 'Internal server error'),
+            'Resume',
+        );
+        expect(out).toMatchObject({ kind: 'failed', retryable: true });
+    });
+
+    it('leaves the OTHER 400s on this route retryable — the engine refused before consuming', () => {
+        // `INVALID_SCREEN_INPUT` / `INVALID_SIGNAL` are refused at the one place
+        // a signal reaches the variable map, i.e. before the suspension is
+        // consumed. The user fixes the input and resubmits the same run — the
+        // exact case the flag exists to keep open.
+        for (const code of ['INVALID_SCREEN_INPUT', 'INVALID_SIGNAL', 'VALIDATION_ERROR']) {
+            const out = interpretFlowResponse(
+                { ok: false, status: 400 },
+                errorEnvelope(400, code, 'Field "amount" is required'),
+                'Resume',
+            );
+            expect(out, code).toMatchObject({ kind: 'failed', retryable: true });
+        }
+    });
+});
+
+describe('interpretFlowResponse — a 404 is terminal for a different reason (objectui#4784)', () => {
+    // NOT dormant: the route answers this today (`RUN_NOT_FOUND` → 404), and
+    // every one of them had been keeping the wizard open for a retry that can
+    // only 404 again.
+    it('marks "no such suspended run" non-retryable, keeping the endpoint’s own message', () => {
+        const out = interpretFlowResponse(
+            { ok: false, status: 404 },
+            errorEnvelope(404, 'RESOURCE_NOT_FOUND', 'No such suspended run'),
+            'Resume',
+        );
+        expect(out).toMatchObject({
+            kind: 'failed',
+            retryable: false,
+            error: 'No such suspended run',
+        });
+    });
+
+    it('holds for a BARE 404 with no envelope at all — status alone decides', () => {
+        // A proxy or an unmounted route answers 404 with HTML; `json` is null
+        // because parsing threw. The disposition must not depend on that.
+        const out = interpretFlowResponse({ ok: false, status: 404 }, null, 'Resume');
+        expect(out).toMatchObject({
+            kind: 'failed',
+            retryable: false,
+            error: 'Resume failed (HTTP 404)',
+        });
+    });
+});
+
 describe('interpretFlowResponse — error is ALWAYS a string (React #31)', () => {
     it('resolves the nested {code, message} object to a string', () => {
         // Handing this object to `toast.error()` puts an object where React

--- a/packages/app-shell/src/utils/flowResponse.ts
+++ b/packages/app-shell/src/utils/flowResponse.ts
@@ -42,9 +42,62 @@
  * STRING. Handing a `{code, message}` object to `toast.error()` puts an object
  * where React expects a child and crashes the page (React #31) — the same trap
  * `actionErrorDetail` exists for.
+ *
+ * ## A failed run does NOT always arrive as HTTP 200 (objectui#4784)
+ *
+ * The three shapes above describe the route as it answers today. objectstack#8684
+ * unifies the resume route onto real status codes — inheriting the #3962 ruling
+ * that business failures must not ride HTTP 200 inside a double envelope — so the
+ * SAME terminal node failure that answers `200 {data:{success:false}}` today will
+ * answer `400` + `FLOW_FAILED` once that lands, in the ADR-0112 error envelope:
+ *
+ * ```
+ * { success: false, error: { code, message, httpStatus, details? } }
+ * ```
+ *
+ * That moves a terminal failure into the `!res.ok` branch, which is the
+ * TRANSPORT branch — and the two are not interchangeable, because `retryable`
+ * is what `FlowRunner` uses to decide whether to keep the wizard open. A
+ * terminal failure classified as transport leaves the dialog open offering a
+ * retry that is *guaranteed* to fail: the engine consumes the suspension before
+ * running downstream nodes (resume-once), so the retry can only reach "No
+ * suspended run". Hence the two non-retryable arms below, both keyed on what is
+ * already on the wire rather than on which caller invoked us:
+ *
+ * - **400 + `FLOW_FAILED`** — the flow RAN and failed. Terminal. Only this code
+ *   qualifies: the other 400s on this route (`INVALID_SIGNAL`,
+ *   `INVALID_SCREEN_INPUT`) are refused by the engine *before* the signal
+ *   reaches the variable map, so the suspension survives and a corrected
+ *   resubmit is meaningful — they stay retryable, and that distinction is the
+ *   whole point of the flag.
+ * - **404** — there is no such run (or no such flow). Terminal for a different
+ *   reason: not "your submission was rejected" but "there is nothing to submit
+ *   to". Unlike the branch above this one is NOT dormant — the route already
+ *   answers `404 No such suspended run` today (`RUN_NOT_FOUND`), and every one
+ *   of those has been keeping the wizard open for a retry that can only 404
+ *   again. Keyed on the STATUS alone, deliberately: a 404 from a proxy or an
+ *   unmounted route carries no envelope to read a code out of, and the user's
+ *   disposition must not depend on whether a body parsed.
+ *
+ * Landing this BEFORE the backend flip is the ruling's explicit sequencing
+ * (objectstack#8684, maintainer ruling of 2026-08-15, sub-decision 3). It is
+ * forward-compatible: nothing sends `400 FLOW_FAILED` on this route yet, so that
+ * arm is simply dormant until it does.
+ *
+ * ⚠️ **The authorable `errorMessage` needs a slot on the wire.** A flow declares
+ * `errorMessage` so the user sees its words instead of an engine string, and the
+ * 200-path failure prefers it (`flowFailureMessage`). The error envelope has no
+ * `data`, so the producer must carry it in `error.details` — the envelope's own
+ * declared carrier for structured extras, and the only one that survives to the
+ * wire (`splitSemanticCode` promotes `details.code` to `error.code` and keeps
+ * the rest). That is the single location read below; there is deliberately no
+ * alias chain hunting for it elsewhere (commandment #0.1 — one strict contract
+ * beats N dialects). If it is absent the message degrades to the envelope's own
+ * `error.message`, never to silence.
  */
 
 import { actionErrorDetail } from '@object-ui/core';
+import { errorCodeIs } from '@object-ui/types';
 
 /**
  * The `AutomationResult` fields the console reads. Deliberately loose: this is
@@ -93,6 +146,18 @@ function flowFailureMessage(data: FlowRunResult, fallback: string): string {
 }
 
 /**
+ * `error.details` out of an ADR-0112 error envelope, as the loose result shape
+ * the failure-message rule reads. `{}` when there is none — this route's `error`
+ * has always been able to arrive as a bare string, and a non-2xx may carry no
+ * parseable body at all, so nothing here may assume an object.
+ */
+function errorEnvelopeDetails(json: any): FlowRunResult {
+    const details = (json?.error as { details?: unknown } | null | undefined)?.details;
+    if (!details || typeof details !== 'object' || Array.isArray(details)) return {};
+    return details as FlowRunResult;
+}
+
+/**
  * Classify a `POST /api/v1/automation/{flow}/trigger` or
  * `.../runs/{runId}/resume` response.
  *
@@ -104,7 +169,44 @@ export function interpretFlowResponse<S = unknown>(
     json: any,
     label: string,
 ): FlowResponseOutcome<S> {
-    if (!res.ok || (json && json.success === false)) {
+    if (!res.ok) {
+        // The flow RAN and failed — same event as the inner-envelope failure
+        // below, just carried on a real status code. Terminal, and the
+        // authorable `errorMessage` stays preferred for it; the envelope's own
+        // `message` is the fallback. See the header note.
+        if (res.status === 400 && errorCodeIs(json?.error, 'FLOW_FAILED')) {
+            return {
+                kind: 'failed',
+                error: flowFailureMessage(
+                    errorEnvelopeDetails(json),
+                    actionErrorDetail(json, `${label} failed`),
+                ),
+                retryable: false,
+            };
+        }
+
+        // Nothing to resume (or no such flow). A retry cannot conjure the run
+        // back; status alone decides, since a proxy 404 carries no envelope.
+        if (res.status === 404) {
+            return {
+                kind: 'failed',
+                error: actionErrorDetail(json, `${label} failed (HTTP ${res.status})`),
+                retryable: false,
+            };
+        }
+
+        // Every other non-2xx is a genuine transport failure: it did not consume
+        // the suspension, so retrying the same run is meaningful.
+        return {
+            kind: 'failed',
+            error: actionErrorDetail(json, `${label} failed (HTTP ${res.status})`),
+            retryable: true,
+        };
+    }
+
+    if (json && json.success === false) {
+        // Outer envelope failure under a 2xx — the request was refused before
+        // the run started, so nothing was consumed.
         return {
             kind: 'failed',
             error: actionErrorDetail(json, `${label} failed (HTTP ${res.status})`),

--- a/packages/app-shell/src/utils/flowResponse.ts
+++ b/packages/app-shell/src/utils/flowResponse.ts
@@ -151,8 +151,9 @@ function flowFailureMessage(data: FlowRunResult, fallback: string): string {
  * has always been able to arrive as a bare string, and a non-2xx may carry no
  * parseable body at all, so nothing here may assume an object.
  */
-function errorEnvelopeDetails(json: any): FlowRunResult {
-    const details = (json?.error as { details?: unknown } | null | undefined)?.details;
+function errorEnvelopeDetails(json: unknown): FlowRunResult {
+    const envelope = (json as { error?: { details?: unknown } } | null | undefined)?.error;
+    const details = envelope?.details;
     if (!details || typeof details !== 'object' || Array.isArray(details)) return {};
     return details as FlowRunResult;
 }


### PR DESCRIPTION
Fixes #4784

Teaches `interpretFlowResponse` that two non-2xx classes on the flow trigger/resume
route are **terminal**, not transport failures. Lands ahead of the backend flip in
objectstack#8684, which is the maintainer's explicit sequencing (ruling of
2026-08-15, sub-decision 3).

## The bug this prevents

`retryable` is what `FlowRunner` reads to decide whether to keep the wizard dialog
open. A transport failure did not consume the suspension, so retrying the same run
is meaningful; a flow failure is terminal, because the engine consumes the
suspension before running downstream nodes (resume-once) and a retry can only reach
"No suspended run".

`interpretFlowResponse` tested `!res.ok || json.success === false` **first** and
returned `retryable: true` for everything it caught, so every non-2xx was
classified as transport. Two classes were on the wrong side of that line:

**1. `400` + `FLOW_FAILED` — dormant today, the regression objectstack#8684 would
otherwise ship.** That card moves a terminal node failure off
`200 {data:{success:false}}` onto a real status code, inheriting the
objectstack#3962 ruling that business failures must not ride HTTP 200 inside a
double envelope. Had the backend flipped first, that failure would have landed in
the retryable branch and the wizard would have stayed open offering a retry
guaranteed to fail. Nothing sends that body yet, so this arm is dormant until it
does — which is exactly why it can land now, and why waiting is what creates the
regression window.

Only that code qualifies. The route's other 400s (`INVALID_SIGNAL`,
`INVALID_SCREEN_INPUT`) are refused by the engine *before* the signal reaches the
variable map, so the suspension survives and a corrected resubmit is meaningful.
That distinction is the whole point of the flag and it is pinned by a test.

**2. `404` — NOT dormant; this half is a live fix.** The route already answers
`404 No such suspended run` (`RUN_NOT_FOUND`) today, and every one of those has
been keeping the wizard open for a retry that could only 404 again. This is the
question the card asked me to answer with the code in front of me, and the code
answered it: implement now. It is keyed on the **status alone**, deliberately — a
proxy or unmounted-route 404 carries no envelope to read a code out of, and the
user's disposition must not depend on whether a body parsed. Same reasoning the
sibling `commitHistory.ts` records for its own classification.

## The authorable `errorMessage` half

A flow declares `errorMessage` so the user sees its words instead of an engine
string. The `!res.ok` branch never reached `flowFailureMessage()`, so that
preference was lost for anything arriving on a status code.

The error envelope carries no `data`, so it is read from **`error.details`** — the
envelope's own declared carrier for structured extras, and the only slot that
survives to the wire (objectstack `error-envelope.ts`: `splitSemanticCode` promotes
`details.code` into `error.code` and keeps the remaining keys). One location, no
alias chain hunting for it elsewhere (commandment #0.1). Absent, the message
degrades to the envelope's own `error.message`, never to silence.

Note for the backend half: **objectstack#8684 must carry the authorable
`errorMessage` in `error.details` for this to resolve.** That is the contract this
PR reads, stated here because landing the consumer first means the consumer is
where the shape gets written down.

## Verification

Reverse-verified from the committed fix: reverting `flowResponse.ts` to
`origin/main` turns **exactly the 6 discriminating new tests red** (17 pass). The
other 2 new tests stay green under the old code, correctly — they pin behavior this
change does **not** alter (a 500 carrying `FLOW_FAILED` stays retryable; the other
400 codes stay retryable). Restored byte-identically from the commit.

Gate union re-run at `3c7107c` (the final commit):

- `pnpm exec vitest run packages/app-shell/src/utils/ .../FlowRunner*.test.tsx .../flow-envelope.ratchet.test.ts` — 25 files, 375 tests passed
- `turbo run type-check --filter=@object-ui/app-shell` — 30 tasks successful
- `pnpm check:control-bytes` — OK; plus a direct `grep -naP` control-byte scan of the changed files
- `node scripts/check-changeset-presence.mjs` — 1 changeset declared for 2 changed source files
- `eslint` on both changed files — 0 errors (the single remaining `any` warning is the pre-existing one on the public signature)

## Scope

`packages/app-shell/src/utils/flowResponse.ts` and its tests, plus the changeset.
`FlowRunner.tsx` is untouched: the flag's semantics are unchanged, so its existing
`if (!outcome.retryable) onClose()` and the comment stating that contract are both
still accurate — no plumbing was required. In-flight sibling #4308's
`metadata-admin/` surface is not touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbRmJD3iPhXjKr6vhd4Qkv)_