### PR TITLE
test(i18n): 占位符拼写门 —— 无 provider 回退只会遇到它认得的 {{name}} 拼形 (#3512)

### DIFF
--- a/.changeset/i18n-fallback-placeholder-spelling-gate.md
+++ b/.changeset/i18n-fallback-placeholder-spelling-gate.md
@@ -1,0 +1,26 @@
+---
+---
+
+Test-only (objectui#3512). Every copy source the provider-less translation fallback can be
+asked to render is now held to the one placeholder spelling that fallback resolves, pinned by
+`packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`.
+
+`createSafeTranslation`'s `fallbackT` interpolates with an exact literal needle, so it
+recognises `{{name}}` and nothing else, while i18next — serving the same strings whenever an
+`I18nProvider` is mounted — also recognises `{{ name }}`, `{{count, number}}`, `{{- name}}`
+and `$t(nested)`. Copy written in any of those four renders correctly through a provider and
+leaks literal braces without one, silently, on exactly the standalone and embedded hosts we
+never look at. Per the maintainer's objectui#4135 ruling the answer is the spelling contract,
+not a second interpolator chasing i18next's dialects: `{{x}}` is i18next-bound copy, `{x}` is
+a hole filled downstream of `t()`.
+
+The gate reads only string VALUES reached through a copy table's own data structure — the ten
+locale packs, the 31 `createSafeTranslation` defaults tables (discovered from the factory's
+first argument, so a new table is covered the day it is written) and the three hand-rolled
+sibling tables that re-implement the same needle. Single-brace holes and JSX object literals
+(`style={{ … }}`, `context={{ org }}`) are therefore out of range by construction rather than
+by an allow-list that could rot. Zero violations on this tree, which is why the gate lands
+green: it makes a dormant divergence unreachable by construction instead of by luck.
+
+No published behaviour changes — no package's runtime source was touched, `useSafeTranslation.ts`
+least of all.

--- a/packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts
+++ b/packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts
@@ -1,0 +1,647 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Every placeholder a provider-less fallback will ever meet is spelled the one
+ * way that fallback can resolve — objectui#3512.
+ *
+ * ## The fork this closes, and the direction it is closed in
+ *
+ * `createSafeTranslation`'s `fallbackT` interpolates with an EXACT literal
+ * needle (`useSafeTranslation.ts`: ``value.split(`{{${k}}}`).join(String(v))``),
+ * so it recognises `{{name}}` and nothing else. i18next — which serves the
+ * SAME strings whenever an `I18nProvider` is mounted — additionally recognises
+ * `{{ name }}` (whitespace inside the braces), `{{count, number}}` (a format
+ * spec), `{{- name}}` (the unescape prefix) and `$t(otherKey)` (nesting).
+ * Measured on a real i18next 26.3.6 instance configured the way `createI18n`
+ * configures it (`interpolation: { escapeValue: false }`), those four render
+ * correctly through the provider and leak literal braces without one.
+ *
+ * The card left two directions open. The maintainer's objectui#4135 ruling
+ * settled it: `{{x}}` is EXCLUSIVELY i18next-bound copy, `{x}` is a hole filled
+ * downstream of `t()`. So the answer is not to teach the fallback three more
+ * dialects (a second interpolator to keep in step with i18next forever), it is
+ * to hold the copy to the one spelling both paths agree on. Declared =
+ * enforced: the divergence stays unreachable by construction instead of by
+ * luck. The fallback's behaviour is deliberately NOT changed by this file.
+ *
+ * ## The false positives this must not produce
+ *
+ * Two classes, both named on the card and by three triage rounds:
+ *
+ *   - **Single braces.** `{shown}` / `{total}` in `gantt.quickFilter.resultSummary`
+ *     is a downstream hole by design — its call site does a literal
+ *     `.replace('{shown}', …)`. Under #4135 that is the CORRECT spelling for a
+ *     non-i18next hole, so flagging it would invert the ruling. The rule below
+ *     only ever inspects the inside of a `{{…}}` pair, so single braces are
+ *     structurally out of range, and the liveness cases pin real single-brace
+ *     rows staying green.
+ *   - **JSX object literals.** `style={{ opacity: 0 }}`, `context={{ org }}` —
+ *     `{{` in TSX that is syntax, not copy. Every earlier sweep of this card hit
+ *     them, because a bare source grep cannot tell them from a spaced
+ *     placeholder. This gate never greps source text for `{{`: it reads only
+ *     STRING VALUES reached through a copy table's own data structure, and a JSX
+ *     brace is not inside a string literal. The class is excluded by where the
+ *     scanner looks, not by an allow-list that could rot.
+ *
+ * ## The copy sources under the gate, and why exactly these
+ *
+ * The subject is "text a literal-needle interpolator can be asked to render".
+ * Three surfaces, measured on this tree:
+ *
+ *   1. **The ten locale packs** (`builtInLocales`, 28k+ string leaves). Imported
+ *      as data. They are upstream of surface 2 — `defaults-maps-mirror-en-pack.test.ts`
+ *      (objectui#4401) and objectui#3440 pin defaults rows byte-identical to
+ *      their `en` row — so a spaced placeholder authored in a pack lands in a
+ *      defaults table by way of a gate that is doing its job. Note the existing
+ *      `all-locales-key-parity.test.ts` "placeholders match en" case cannot see
+ *      this: its `\{\{\w+\}\}` shape regex simply does not match `{{ name }}`,
+ *      so a spelling introduced in `en` AND its nine translations at once is
+ *      shape-equal, hence green. That case compares packs to each other; this
+ *      one judges a pack against the fallback's grammar in absolute terms.
+ *   2. **The `createSafeTranslation` defaults tables** — 31 of them, 762 string
+ *      rows, DISCOVERED rather than listed (below), so a new table is gated the
+ *      day it is written.
+ *   3. **The three hand-rolled sibling tables** whose packages re-implemented
+ *      the same literal needle instead of taking the factory
+ *      (`GANTT_DEFAULT_TRANSLATIONS`, `IMPORT_DEFAULT_TRANSLATIONS`,
+ *      `TIMELINE_DEFAULT_TRANSLATIONS`; each file states its own reason for not
+ *      using the factory). They are a registry, and a completeness case pins the
+ *      set of files carrying that needle, so a fourth copy of the interpolator
+ *      cannot quietly land outside the gate.
+ *
+ * Two neighbours were measured and deliberately left out:
+ *
+ *   - **Inline `t(key, { defaultValue })`.** `fallbackT` does read it (the
+ *     objectui#3865 chain step), and 1195 such literals carry 0 violations
+ *     today. Left out because it is a call-site option rather than a copy TABLE
+ *     — the two surfaces this card was scoped to — and because
+ *     `check:i18n-keys`' `default-value-drift` class already pins each one
+ *     byte-identical to its `en` row, which surface 1 gates. Recorded as a
+ *     coverage boundary rather than silently assumed.
+ *   - **`ConcurrentUpdateDialog.tsx`'s `.split('{{field}}')`.** A hard-coded
+ *     needle CONSUMING a pack value, not a table of its own — surface 1 covers
+ *     the value it splits.
+ *
+ * ## Why this file lives in `@object-ui/i18n` when two of its surfaces do not
+ *
+ * `defaults-maps-mirror-en-pack.test.ts` had to move to `app-shell` because it
+ * IMPORTS three plugin maps, and every one of those packages depends on this
+ * one — importing them back inverts the dependency. This file imports nothing
+ * outside its own package: it READS the source files as text and parses them,
+ * which is not a module dependency in either direction (same mechanism as
+ * `forwardref-props-annotation.guard.test.ts`). So the rule can live beside the
+ * fallback whose grammar it is enforcing, which is where the next person to
+ * touch `useSafeTranslation.ts` will look.
+ *
+ * ## Direction of the reverse verification, predicted before running (#4118)
+ *
+ * Straight red, not the inverted or count-shaped variants: the rule is an
+ * absolute predicate over values, with no `??` chain and no verdict count for a
+ * mutation to empty out. Injecting `{{ name }}` (spaced), `{{count, number}}`
+ * (format spec) or `$t(other)` (nesting) into ONE real row of ONE real table
+ * must turn exactly the case that owns that surface red, naming the file and the
+ * key — and leave the liveness and single-brace cases green, because the
+ * injected row is one row. Verified all three ways on this tree, plus the two
+ * false-positive controls staying green; recorded on the PR.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { builtInLocales } from '../locales';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/i18n/src/__tests__  ->  repo root
+const REPO_ROOT = path.resolve(here, '../../../..');
+
+/* ------------------------------------------------------------------ */
+/* The rule                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A `{{…}}` pair and its contents. `[^{}]*` deliberately: a placeholder never
+ * nests braces, and refusing to cross one keeps an unterminated `{{` from
+ * swallowing the rest of the sentence into a bogus "placeholder".
+ */
+const DOUBLE_BRACE = /\{\{([^{}]*)\}\}/g;
+
+/** Every `{{` occurrence, matched or not — the balance check's other half. */
+const DOUBLE_BRACE_OPEN = /\{\{/g;
+
+/**
+ * The one spelling `fallbackT` resolves. `k` comes from `Object.entries(options)`
+ * and is spliced into the needle raw, so the accepted name is exactly a bare
+ * identifier: no whitespace, no format spec, no `-` prefix, no dotted path.
+ */
+const CANONICAL_NAME = /^[A-Za-z0-9_]+$/;
+
+/** i18next's nesting syntax. The fallback has no notion of it at all. */
+const NESTING = '$t(';
+
+/** Why one placeholder is not something `fallbackT` can resolve. */
+function reasonFor(inner: string): string {
+  if (inner !== inner.trim()) return 'whitespace inside the braces';
+  if (inner.startsWith('-')) return 'the {{- x}} unescape prefix';
+  if (inner.includes(',')) return 'an i18next format spec';
+  if (inner.includes('.')) return 'a dotted/keyed placeholder path';
+  return 'a non-identifier placeholder name';
+}
+
+/**
+ * THE rule. Returns one human-readable violation per offending placeholder, and
+ * `[]` for copy the provider-less fallback renders identically to i18next.
+ *
+ * Only the inside of a `{{…}}` pair is judged, so single-brace `{x}` holes
+ * (objectui#4135's downstream-fill convention) can never reach a verdict here.
+ */
+export function placeholderViolations(value: string): string[] {
+  const out: string[] = [];
+  const regions = [...value.matchAll(DOUBLE_BRACE)];
+  for (const region of regions) {
+    const inner = region[1];
+    if (CANONICAL_NAME.test(inner)) continue;
+    out.push(
+      `${JSON.stringify(region[0])} — ${reasonFor(inner)}; the fallback resolves only {{name}}`,
+    );
+  }
+  // An unterminated `{{` renders as literal braces on BOTH paths, so it is not
+  // an i18next divergence — but it is never intentional copy, and the regions
+  // above cannot report what they did not match.
+  const opens = (value.match(DOUBLE_BRACE_OPEN) ?? []).length;
+  if (opens > regions.length) out.push('an unterminated `{{` with no closing `}}`');
+  if (value.includes(NESTING)) {
+    out.push('`$t(` — i18next nesting, which the fallback emits verbatim');
+  }
+  return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* Copy source 1 — the ten locale packs                                */
+/* ------------------------------------------------------------------ */
+
+interface Leaf {
+  readonly key: string;
+  readonly value: string;
+}
+
+function leaves(node: unknown, prefix = ''): Leaf[] {
+  if (typeof node === 'string') return [{ key: prefix, value: node }];
+  if (node === null || typeof node !== 'object') return [];
+  return Object.entries(node as Record<string, unknown>).flatMap(([k, v]) =>
+    leaves(v, prefix ? `${prefix}.${k}` : k),
+  );
+}
+
+const LOCALE_CODES = Object.keys(builtInLocales) as (keyof typeof builtInLocales)[];
+const PACK_LEAVES = new Map(LOCALE_CODES.map((code) => [code, leaves(builtInLocales[code])]));
+
+/* ------------------------------------------------------------------ */
+/* Copy source 2/3 — the defaults tables, read from source             */
+/* ------------------------------------------------------------------ */
+
+/** The factory, and plugin-detail's re-export alias for it. */
+const FACTORY_NAMES = new Set(['createSafeTranslation', 'createSafeTranslationHook']);
+
+/**
+ * The literal needle, as it is spelled in source: ``.split(`{{${``. The
+ * completeness case below pins which files carry it, so a fourth hand-rolled
+ * copy of `fallbackT` forces an edit here instead of escaping the gate.
+ */
+const NEEDLE_IN_SOURCE = '.split(`{{${';
+
+/** Every runtime `.ts`/`.tsx` under the workspace — tests and tooling excluded. */
+function collectSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const name = entry.name;
+      if (
+        name === 'node_modules' ||
+        name === 'dist' ||
+        name === '__tests__' ||
+        name === '__mocks__' ||
+        name.startsWith('.')
+      ) {
+        continue;
+      }
+      const full = path.join(dir, name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.tsx?$/.test(name) && !/\.(test|spec|bench|stories)\.tsx?$/.test(name)) {
+        out.push(full);
+      }
+    }
+  };
+  for (const root of ['packages', 'apps', 'examples']) {
+    const full = path.join(REPO_ROOT, root);
+    if (existsSync(full) && statSync(full).isDirectory()) walk(full);
+  }
+  return out.sort();
+}
+
+const SOURCE_FILES = collectSourceFiles();
+const rel = (abs: string) => path.relative(REPO_ROOT, abs);
+
+const parsed = new Map<string, ts.SourceFile | null>();
+function sourceFileFor(abs: string): ts.SourceFile | null {
+  if (parsed.has(abs)) return parsed.get(abs) ?? null;
+  const sf = existsSync(abs)
+    ? ts.createSourceFile(
+        abs,
+        readFileSync(abs, 'utf8'),
+        ts.ScriptTarget.Latest,
+        true,
+        abs.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+      )
+    : null;
+  parsed.set(abs, sf);
+  return sf;
+}
+
+/** Peel the wrappers a table declaration may carry before its object literal. */
+function unwrap(node: ts.Expression): ts.Expression {
+  let e = node;
+  for (;;) {
+    if (ts.isAsExpression(e) || ts.isSatisfiesExpression(e) || ts.isParenthesizedExpression(e)) {
+      e = e.expression;
+      continue;
+    }
+    return e;
+  }
+}
+
+/** The initializer of a top-level `const <name> = …` in this file. */
+function constInitializer(sf: ts.SourceFile, name: string): ts.Expression | null {
+  let found: ts.Expression | null = null;
+  const visit = (node: ts.Node) => {
+    if (found) return;
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return found;
+}
+
+/** Follow `import { <name> } from './relative'` to the file that declares it. */
+function importedFrom(sf: ts.SourceFile, name: string): string | null {
+  let spec: string | null = null;
+  ts.forEachChild(sf, (node) => {
+    if (spec !== null) return;
+    if (
+      ts.isImportDeclaration(node) &&
+      node.importClause?.namedBindings &&
+      ts.isNamedImports(node.importClause.namedBindings) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      for (const element of node.importClause.namedBindings.elements) {
+        if (element.name.text === name) spec = node.moduleSpecifier.text;
+      }
+    }
+  });
+  if (spec === null || !(spec as string).startsWith('.')) return null;
+  const base = path.resolve(path.dirname(sf.fileName), spec);
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, `${base}/index.ts`, `${base}/index.tsx`]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * A string a table row is declared with. Handles the `'a' + 'b'` concatenation
+ * one row uses (`plugin-form/src/occSave.tsx`); anything else returns
+ * `undefined` and is REPORTED rather than skipped — a row the gate cannot read
+ * is a hole in it, not an exemption.
+ */
+function staticString(node: ts.Expression): string | undefined {
+  const e = unwrap(node);
+  if (ts.isStringLiteral(e) || ts.isNoSubstitutionTemplateLiteral(e)) return e.text;
+  if (ts.isBinaryExpression(e) && e.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = staticString(e.left);
+    const right = staticString(e.right);
+    if (left !== undefined && right !== undefined) return left + right;
+  }
+  return undefined;
+}
+
+/** One row of one gated table, located precisely enough to fix. */
+interface Row {
+  readonly table: string;
+  readonly where: string;
+  readonly key: string;
+  readonly value: string;
+}
+
+interface TableScan {
+  readonly rows: Row[];
+  /** Rows whose value is not a static string, and tables that never resolved. */
+  readonly unreadable: string[];
+}
+
+function scanObjectLiteral(
+  literal: ts.ObjectLiteralExpression,
+  table: string,
+  into: TableScan,
+  keyPrefix = '',
+): void {
+  const owner = literal.getSourceFile();
+  const at = (node: ts.Node) =>
+    `${rel(owner.fileName)}:${owner.getLineAndCharacterOfPosition(node.getStart()).line + 1}`;
+  for (const property of literal.properties) {
+    if (ts.isPropertyAssignment(property)) {
+      const name =
+        ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)
+          ? property.name.text
+          : null;
+      if (name === null) {
+        into.unreadable.push(`${at(property)} — computed key in ${table}`);
+        continue;
+      }
+      const key = keyPrefix ? `${keyPrefix}.${name}` : name;
+      const initializer = unwrap(property.initializer);
+      if (ts.isObjectLiteralExpression(initializer)) {
+        scanObjectLiteral(initializer, table, into, key);
+        continue;
+      }
+      const value = staticString(initializer);
+      if (value === undefined) {
+        into.unreadable.push(`${at(property)} — ${table}.${key} is not a static string`);
+        continue;
+      }
+      into.rows.push({ table, where: at(property), key, value });
+    } else {
+      into.unreadable.push(`${at(property)} — non-assignment member in ${table}`);
+    }
+  }
+}
+
+/**
+ * Resolve a `createSafeTranslation` first argument to its object literal: an
+ * inline table, a `const` in the same file, or a `const` imported from a
+ * relative module.
+ */
+function resolveTableArgument(
+  sf: ts.SourceFile,
+  argument: ts.Expression,
+): { literal: ts.ObjectLiteralExpression | null; name: string } {
+  const unwrapped = unwrap(argument);
+  if (ts.isObjectLiteralExpression(unwrapped)) {
+    return { literal: unwrapped, name: '(inline table)' };
+  }
+  if (ts.isIdentifier(unwrapped)) {
+    const name = unwrapped.text;
+    let initializer = constInitializer(sf, name);
+    if (initializer === null) {
+      const from = importedFrom(sf, name);
+      const imported = from === null ? null : sourceFileFor(from);
+      if (imported) initializer = constInitializer(imported, name);
+    }
+    if (initializer !== null) {
+      const literal = unwrap(initializer);
+      if (ts.isObjectLiteralExpression(literal)) return { literal, name };
+    }
+    return { literal: null, name };
+  }
+  return { literal: null, name: ts.SyntaxKind[unwrapped.kind] };
+}
+
+/**
+ * The three tables whose packages re-implemented `fallbackT`'s literal needle
+ * rather than taking the factory. Each file states its own reason for that;
+ * none of them changes the grammar the needle accepts, so the rule is the same.
+ * `TIMELINE_DEFAULT_TRANSLATIONS` also reaches the factory — listed anyway, so
+ * the registry mirrors the needle-file set the completeness case pins.
+ */
+const HAND_ROLLED_TABLES: readonly { readonly file: string; readonly name: string }[] = [
+  { file: 'packages/plugin-gantt/src/useGanttTranslation.ts', name: 'GANTT_DEFAULT_TRANSLATIONS' },
+  { file: 'packages/plugin-grid/src/ImportWizard.tsx', name: 'IMPORT_DEFAULT_TRANSLATIONS' },
+  {
+    file: 'packages/plugin-timeline/src/useTimelineTranslation.ts',
+    name: 'TIMELINE_DEFAULT_TRANSLATIONS',
+  },
+];
+
+/** Files that carry the literal needle today — the completeness case's subject. */
+const NEEDLE_FILES = [
+  'packages/i18n/src/useSafeTranslation.ts',
+  'packages/plugin-gantt/src/useGanttTranslation.ts',
+  'packages/plugin-grid/src/ImportWizard.tsx',
+  'packages/plugin-timeline/src/useTimelineTranslation.ts',
+];
+
+function scanDefaultsTables(): TableScan & { readonly tables: string[]; readonly needle: string[] } {
+  const scan: TableScan = { rows: [], unreadable: [] };
+  const tables: string[] = [];
+  const needle: string[] = [];
+
+  for (const abs of SOURCE_FILES) {
+    const text = readFileSync(abs, 'utf8');
+    if (text.includes(NEEDLE_IN_SOURCE)) needle.push(rel(abs));
+    if (!text.includes('createSafeTranslation')) continue;
+    const sf = sourceFileFor(abs);
+    if (!sf) continue;
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node)) {
+        const callee = node.expression;
+        const name = ts.isIdentifier(callee)
+          ? callee.text
+          : ts.isPropertyAccessExpression(callee)
+            ? callee.name.text
+            : null;
+        if (name !== null && FACTORY_NAMES.has(name) && node.arguments.length > 0) {
+          const line = sf.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+          const { literal, name: tableName } = resolveTableArgument(sf, node.arguments[0]);
+          const label = `${tableName} (${rel(abs)}:${line})`;
+          if (literal === null) {
+            // Not an exemption: a table the gate cannot reach is a table the
+            // gate does not cover, and that has to be visible.
+            scan.unreadable.push(`${rel(abs)}:${line} — cannot resolve ${tableName} to a table`);
+          } else {
+            tables.push(label);
+            scanObjectLiteral(literal, label, scan);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(sf, visit);
+  }
+
+  for (const { file, name } of HAND_ROLLED_TABLES) {
+    const abs = path.join(REPO_ROOT, file);
+    const sf = sourceFileFor(abs);
+    const initializer = sf === null ? null : constInitializer(sf, name);
+    const literal = initializer === null ? null : unwrap(initializer);
+    if (literal === null || !ts.isObjectLiteralExpression(literal)) {
+      scan.unreadable.push(`${file} — hand-rolled table ${name} no longer resolves`);
+      continue;
+    }
+    const label = `${name} (${file})`;
+    tables.push(label);
+    scanObjectLiteral(literal, label, scan);
+  }
+
+  return { ...scan, tables, needle: needle.sort() };
+}
+
+const TABLE_SCAN = scanDefaultsTables();
+
+/* ------------------------------------------------------------------ */
+/* The cases                                                           */
+/* ------------------------------------------------------------------ */
+
+describe('the fallback only ever meets placeholders it can resolve (objectui#3512)', () => {
+  describe('the locale packs', () => {
+    it('the walk reaches real copy — not an empty assertion', () => {
+      // Non-vacuity, #4118 family standard. Every assertion below is "no value
+      // violates", which a broken walk satisfies trivially. Floors, not pins.
+      expect(LOCALE_CODES).toHaveLength(10);
+      const total = [...PACK_LEAVES.values()].reduce((n, list) => n + list.length, 0);
+      expect(total).toBeGreaterThan(20_000);
+      for (const code of LOCALE_CODES) {
+        expect(PACK_LEAVES.get(code)!.length, `${code} contributed no strings`).toBeGreaterThan(
+          1_000,
+        );
+      }
+    });
+
+    it('the scanner sees placeholders at all — the positive control', () => {
+      // The zero-violation assertions below are only meaningful if the scanner
+      // finds the placeholders that DO exist. Same reasoning as the parity
+      // suite's `EN.size > 2000` guard: a regex that matched nothing would make
+      // this file green while asserting nothing whatsoever.
+      const spellings = new Set<string>();
+      for (const { value } of PACK_LEAVES.get('en')!) {
+        for (const region of value.matchAll(DOUBLE_BRACE)) spellings.add(region[0]);
+      }
+      expect(spellings.size).toBeGreaterThan(50);
+      expect(spellings).toContain('{{count}}');
+      expect(spellings).toContain('{{name}}');
+      // …and every one of them is canonical, which is the rule restated over
+      // the set the control just proved is non-empty.
+      expect([...spellings].filter((s) => placeholderViolations(s).length > 0)).toEqual([]);
+    });
+
+    it.each(LOCALE_CODES)('%s uses only placeholders the fallback resolves', (code) => {
+      const violations = PACK_LEAVES.get(code)!.flatMap(({ key, value }) =>
+        placeholderViolations(value).map(
+          (why) => `${code} pack, ${key} = ${JSON.stringify(value)}\n    ${why}`,
+        ),
+      );
+      expect(violations, `${code}: ${violations.length} placeholder spelling violation(s)`).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe('the defaults tables', () => {
+    it('discovers every table — not an empty assertion', () => {
+      // The discovery is structural (first argument of the factory + the
+      // hand-rolled registry), so these are floors that a new table raises for
+      // free; only a table DISAPPEARING has to be explained.
+      expect(TABLE_SCAN.tables.length).toBeGreaterThanOrEqual(34);
+      expect(TABLE_SCAN.rows.length).toBeGreaterThanOrEqual(700);
+      expect(SOURCE_FILES.length).toBeGreaterThan(1_000);
+      // Every discovered table resolved to a literal and every row to a string.
+      // A table the scanner cannot read is a hole in the gate, reported here
+      // rather than skipped in silence.
+      expect(TABLE_SCAN.unreadable).toEqual([]);
+    });
+
+    it('covers the three hand-rolled interpolators, and no fourth exists', () => {
+      // The registry above is a list, and lists rot. This pins the fact that
+      // makes it complete: exactly these files re-implement the literal needle.
+      // A new copy of `fallbackT` fails here, naming itself, instead of serving
+      // an ungated table.
+      expect(TABLE_SCAN.needle).toEqual(NEEDLE_FILES);
+      for (const { name, file } of HAND_ROLLED_TABLES) {
+        const rows = TABLE_SCAN.rows.filter((row) => row.table === `${name} (${file})`);
+        expect(rows.length, `${name} contributed no rows`).toBeGreaterThan(0);
+      }
+    });
+
+    it('every table row uses only placeholders the fallback resolves', () => {
+      // THE gate for surfaces 2 and 3. This is the path that actually renders
+      // without a provider, so a violation here is the user-visible one.
+      const violations = TABLE_SCAN.rows.flatMap(({ table, where, key, value }) =>
+        placeholderViolations(value).map(
+          (why) => `${where}  ${key} = ${JSON.stringify(value)}\n    in ${table}\n    ${why}`,
+        ),
+      );
+      expect(
+        violations,
+        `${violations.length} placeholder spelling violation(s) in the defaults tables`,
+      ).toEqual([]);
+    });
+  });
+
+  describe('the rule does not over-reach (objectui#4135)', () => {
+    it('leaves single-brace holes alone', () => {
+      // #4135: `{x}` is a hole filled downstream of `t()`. Flagging it would
+      // invert the ruling this gate exists to enforce. Both a synthetic case and
+      // the real row that motivated the exception.
+      expect(placeholderViolations('Showing {shown} / {total} tasks')).toEqual([]);
+      expect(placeholderViolations('{count}')).toEqual([]);
+      expect(placeholderViolations('Rendered {2} of {n}')).toEqual([]);
+
+      const real = PACK_LEAVES.get('en')!.find(
+        ({ key }) => key === 'gantt.quickFilter.resultSummary',
+      );
+      // Positive control: the exempt row is genuinely IN the scanned set and
+      // genuinely single-braced, so its green verdict is the rule declining to
+      // fire — not the row having quietly left the corpus.
+      expect(real?.value, 'the single-brace control row left the en pack').toContain('{shown}');
+      expect(real?.value).not.toContain('{{');
+      expect(placeholderViolations(real!.value)).toEqual([]);
+    });
+
+    it('leaves JSX object-literal braces out of range by construction', () => {
+      // The known false-positive class from three triage rounds: `style={{ … }}`
+      // and `context={{ org }}` are TSX syntax, never copy. They are excluded by
+      // WHERE the scanner looks — inside string values of a copy table — so the
+      // proof is that no scanned row is a JSX brace, not an allow-list.
+      const jsxLike = TABLE_SCAN.rows.filter(
+        ({ value }) => value.includes('style={{') || value.includes('={{'),
+      );
+      expect(jsxLike.map((row) => `${row.where} ${row.key}`)).toEqual([]);
+      // And the packs never carry a JSX-shaped string either.
+      const packJsx = [...PACK_LEAVES.values()]
+        .flat()
+        .filter(({ value }) => value.includes('={{'));
+      expect(packJsx.map(({ key }) => key)).toEqual([]);
+    });
+
+    it('does fire on each of the four i18next-only spellings', () => {
+      // The rule's own unit coverage, so the corpus cases above cannot be the
+      // only evidence it works. One case per divergence the card measured.
+      expect(placeholderViolations('Hello {{ name }}')).toHaveLength(1);
+      expect(placeholderViolations('Hello {{ name }}')[0]).toContain('whitespace');
+      expect(placeholderViolations('Total {{count, number}}')).toHaveLength(1);
+      expect(placeholderViolations('Total {{count, number}}')[0]).toContain('format spec');
+      expect(placeholderViolations('Hi {{- name}}')).toHaveLength(1);
+      expect(placeholderViolations('Hi {{- name}}')[0]).toContain('unescape prefix');
+      expect(placeholderViolations('A $t(otherKey)')).toHaveLength(1);
+      expect(placeholderViolations('A $t(otherKey)')[0]).toContain('nesting');
+      // …and the canonical spelling, which every one of them is a deviation from.
+      expect(placeholderViolations('Hello {{name}}, {{name}}')).toEqual([]);
+      expect(placeholderViolations('Deleted {{count}} of {{total}}')).toEqual([]);
+      // Structural leftovers the regions cannot report on their own.
+      expect(placeholderViolations('Hello {{name')).toHaveLength(1);
+      expect(placeholderViolations('Hello {{name')[0]).toContain('unterminated');
+    });
+  });
+});

--- a/packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts
+++ b/packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts
@@ -78,15 +78,37 @@
  * Two neighbours were measured and deliberately left out:
  *
  *   - **Inline `t(key, { defaultValue })`.** `fallbackT` does read it (the
- *     objectui#3865 chain step), and 1195 such literals carry 0 violations
- *     today. Left out because it is a call-site option rather than a copy TABLE
- *     — the two surfaces this card was scoped to — and because
- *     `check:i18n-keys`' `default-value-drift` class already pins each one
- *     byte-identical to its `en` row, which surface 1 gates. Recorded as a
- *     coverage boundary rather than silently assumed.
+ *     objectui#3865 chain step), and 0 of them violate the rule today. Left out
+ *     because it is a call-site OPTION rather than a copy table — the two
+ *     surfaces this card was scoped to — and because `check:i18n-keys`'
+ *     `default-value-drift` class already pins 906 of its 909 literal inline
+ *     defaults byte-identical to their `en` row, which surface 1 gates. The
+ *     residual is those 3 "not comparable" plus 62 computed ones: recorded as a
+ *     coverage boundary, and filed, rather than silently assumed covered.
  *   - **`ConcurrentUpdateDialog.tsx`'s `.split('{{field}}')`.** A hard-coded
  *     needle CONSUMING a pack value, not a table of its own — surface 1 covers
  *     the value it splits.
+ *
+ * ## Division of labour with the three existing i18n gates
+ *
+ * All four read the same packs, and each is blind to what this one owns:
+ *
+ *   - `scripts/check-i18n-call-site-keys.mjs` — its `holesOf()` deliberately
+ *     reads THROUGH all four dialects when extracting a hole's NAME (`{{n, number}}`
+ *     yields `n`, `{{- html}}` yields `html`, `{{user.name}}` yields `user`), so
+ *     that an argument-parity verdict survives one appearing. It tolerates; it
+ *     never rejects — and its own comment records the measurement this file turns
+ *     into a rule: "all 84 distinct holes in `en` are bare names". This gate is
+ *     the enforcement half of that sentence.
+ *   - `all-locales-key-parity.test.ts` — pack vs pack, and RELATIVE: its shape
+ *     regex is `\{\{\w+\}\}`, which does not match `{{ name }}` at all. A
+ *     spelling introduced in `en` and its nine translations together is
+ *     shape-equal in that comparison, hence green. This file judges a pack
+ *     against the fallback's grammar in ABSOLUTE terms, which is the only way
+ *     that case is reachable.
+ *   - `scripts/check-i18n-en-drift.mjs` — fires on an `en` value CHANGING. A
+ *     value authored with a spaced placeholder on day one never changes, so it
+ *     is invisible there by construction.
  *
  * ## Why this file lives in `@object-ui/i18n` when two of its surfaces do not
  *


### PR DESCRIPTION
Fixes #3512

按 2026-08-17 晋级评论重切后的范围实施:**不拓宽 fallback**,建占位符拼写门。行为本体 `packages/i18n/src/useSafeTranslation.ts` 一个字节都没改。

## 分叉与裁定

`createSafeTranslation` 的 `fallbackT` 用精确字面 needle 插值(``value.split(`{{${k}}}`).join(String(v))``),所以它只认 `{{name}}` 一种拼形;而挂了 `I18nProvider` 时服务同一批文案的 i18next 还认 `{{ name }}`(花括号内空格)、`{{count, number}}`(格式化参数)、`{{- name}}`(反转义前缀)和 `$t(nested)`(嵌套)。四种里任何一种写进文案,挂 provider 渲染正确、无 provider 就把花括号原样吐给用户 —— 不抛错、不打日志,而且专挑独立/嵌入式宿主,正是我们最看不到的运行环境。

维护者 #4135 裁定(2026-08-11)已经把方向定死:

> `{{x}}`(双花括号)专属 i18next 洞 —— 调用点写了 `{{x}}` 就**必须**传参。`t()` 下游填充的洞(组件侧替换)**一律**写 `{x}`(单花括号),它落在 i18next 语法之外,因此天然安全。

所以剩下的活不是教 fallback 再学三种方言(那等于长期维护第二个插值器去追 i18next),而是把文案约束到两条路径都认的那一种拼形上。declared = enforced:分叉从「靠运气不发生」变成「按构造不可达」。

这一条**不是**在重开 #3418 的裁定。#3418 是真实现 bug(`replace` 只替第一次,与 i18next 不一致),在生产端修掉了;这一条是声明一个受支持子集,#3512 卡面本身就把两者的性质区分开了,晋级评论按 #4135 裁定拍板。

## 会被字面 needle 消费的文案源清单(在 97da1b0d6 上实测)

| # | 面 | 规模 | 发现方式 |
|---|---|---|---|
| 1 | 十个语言包 `builtInLocales` | 10 包 / 28,867 条字符串叶子 | 直接 import 数据结构 |
| 2 | `createSafeTranslation` / `createSafeTranslationHook` 默认表 | **31 张** / 762 条字符串行 | AST:工厂第一实参(内联字面量 / 同文件 const / 相对 import 的 const) |
| 3 | 手写同款 needle 的兄弟表 | 3 张 | 注册表 + needle 文件集完备性钉 |

第 2 面按包展开:`components` 10 张(filter-builder 41 行、form 23、data-table 20、sort-builder 7、fullscreen-editor 6、navigation-overlay 6、config-panel-renderer 2、containers 2、close-label 1、action-param-dialog 1)、`plugin-designer` 1(164 行)、`plugin-detail` 1(148)、`fields` 1(75)、`plugin-dashboard` 2(75+6)、`plugin-list` 2(62+9)、`collaboration` 1(36)、`plugin-grid` 2(18+11)、`plugin-timeline` 1(16)、`plugin-form` 4、`plugin-kanban` 3、`plugin-calendar` 1、`plugin-view` 1、`plugin-tree` 1。

第 3 面是 `GANTT_DEFAULT_TRANSLATIONS`、`IMPORT_DEFAULT_TRANSLATIONS`、`TIMELINE_DEFAULT_TRANSLATIONS` —— 这三个包各自写了「不走工厂」的理由,但都手抄了同一个字面 needle,所以适用同一条规则。

**实测量清楚地留在门外的两个邻面**(写进正文而不是默默假设):

- **内联 `t(key, { defaultValue })`**:`fallbackT` 确实读它(#3865 那一段链)。`check:i18n-keys` 报 909 条字面内联默认值,其中 906 条被 `default-value-drift` 钉成与 `en` 行逐字节相同(3 条 not comparable,另有 62 条 computed 只报告不判)—— 所以绝大多数经由第 1 面被传递性覆盖。它是调用点选项而不是文案**表**,不在本卡重切的两个面里;残余缺口(那 3+62 条)已另立 finding 卡记账,今日违例数 0。
- **`ConcurrentUpdateDialog.tsx` 的 `.split('{{field}}')`**:硬编码 needle,消费的是一条包值而不是自带一张表 —— 第 1 面已经覆盖它 split 的那个值。

## 门不误伤什么,以及为什么是「按构造」

卡面和历届三轮分诊都点名了两类已知假阳:

- **单花括号 `{x}`**。`gantt.quickFilter.resultSummary` 的 `{shown}` / `{total}` 是设计上的下游洞(调用点做字面 `.replace('{shown}', …)`)。按 #4135 这恰恰是非 i18next 洞的**正确**拼形,报它等于把裁定反着执行。规则只检查 `{{…}}` 配对**内部**,单花括号在结构上就够不到判决。
- **JSX 对象字面量**(`style={{ opacity: 0 }}`、`context={{ org }}`)。这是 TSX 语法不是文案 —— 历届每次裸 grep 扫描都撞上它。本门**从不**对源码文本 grep `{{`:它只读「经由文案表自身数据结构到达的字符串值」,而 JSX 的花括号不在字符串字面量里面。这一类是被**扫描器看的位置**排除的,不是被一张会腐烂的白名单排除的。

顺带交代与既有 i18n 门的分工:`scripts/check-i18n-call-site-keys.mjs` 的 `holesOf()` 在**抽取洞名时**刻意读得通四种方言(注释写着「今天 `en` 的 84 个洞全是裸名字」),它容忍但从不拒绝;本门是同一条观察的执行半边 —— 把「今天全是裸名字」从一句实测变成一条规则。`all-locales-key-parity.test.ts` 的 `placeholders match en` 用的形状正则压根匹配不上 `{{ name }}`,所以「en 和九个翻译一起改成带空格拼形」在它眼里形状相等、全绿 —— 那正是本门补上的绝对判据(包 vs fallback 语法),而不是相对判据(包 vs 包)。`check-i18n-en-drift.mjs` 只在 `en` 值**发生变化**时开火,第一天就写成带空格的值它永远看不到。

## 三面反向验证 + 两项误伤对照(每面先书面预判再跑)

变异前先 commit(29fbf9ca9),每次只改一处真实文案行,还原一律 `git checkout`(⛔ stash,按 CLAUDE.md 共享 stash 栈规则)。

预判方向是**直红**,不是倒挂也不是计数型:规则是对值的绝对谓词,没有 `??` 链、没有可以被变异掏空的判决计数。

| # | 变异 | 预判 | 实测 |
|---|---|---|---|
| ① | `ListView.tsx:497` `'{{count}} records'` → `'{{ count }} records'` | 恰好 1 条红:`every table row uses only placeholders the fallback resolves`,报出精确 file:line + 键 + 原因;其余 17 绿 | **1 failed / 17 passed** — `packages/plugin-list/src/ListView.tsx:497  list.recordCount = "{{ count }} records"` / `in LIST_DEFAULT_TRANSLATIONS (packages/plugin-list/src/ListView.tsx:629)` / `"{{ count }}" — whitespace inside the braces; the fallback resolves only {{name}}` |
| ② | `en.ts:54` `'{{count}} objects'` → `'{{count, number}} objects'` | **2 条**红:`en uses only placeholders…` 之外,`the scanner sees placeholders at all` 这条正控的末尾断言也会红(它把规则重跑在 en 的全部拼形集合上);其余 16 绿 | **2 failed / 16 passed** — `en pack, perm.facet.objects = "{{count, number}} objects"` / `an i18next format spec`,正控收到 `["{{count, number}}"]` |
| ③ | `useGanttTranslation.ts:61` 注入 `$t(gantt.readOnly)` | 恰好 1 条红:同 ① 那条用例,报第 3 面手写表的 file:line | **1 failed / 17 passed** — `packages/plugin-gantt/src/useGanttTranslation.ts:61  gantt.delete.body = …` / `in GANTT_DEFAULT_TRANSLATIONS` / `` `$t(` — i18next nesting, which the fallback emits verbatim `` |
| 对照 A | `ListView.tsx:497` → `'{{count}} records {shown} {total}'`(单花括号) | 全绿 18/18 | **18 passed** |
| 对照 B | `ListView.tsx:2399` → `style={{ opacity: 1, height: pullDistance }} data-ctx={{ org: 1 }} data-t={{ transform: 2 }}` | 全绿 18/18 —— 注意这是**变异 ① 证明扫描器确实读过的同一个文件**,所以「绿」只能是规则拒绝开火,不可能是文件没被扫到 | **18 passed** |

② 的两条红是提前写下来的:在 `en` 上注入必然同时触发那条正控,报一条反而说明我预判错了。

**防空集假绿**(零命中断言配「确定存在的邻近词」正查):`the scanner sees placeholders at all` 要求 en 包里 distinct 双花括号拼形 > 50(实测 90 种)且必须包含 `{{count}}` 和 `{{name}}`;`discovers every table` 要求发现的表 ≥ 34、行 ≥ 700、扫描文件 ≥ 1000,并且 `unreadable` 必须为空 —— 一张扫描器读不出的表是门上的洞,要报出来而不是静默跳过(唯一一条非字面量值 `plugin-form/src/occSave.tsx` 的 `'a' + 'b'` 拼接因此被显式支持)。对照 A 里那条单花括号断言也配了正查:先确认 `gantt.quickFilter.resultSummary` 确实还在扫描集合里且确实是单花括号,再断言它绿。

## 完备性(防注册表腐烂)

第 3 面是列表,列表会腐烂。所以有一条用例钉住让它完备的那个事实:携带该字面 needle 的**运行时**文件集恰好是这四个 —— `packages/i18n/src/useSafeTranslation.ts`、`plugin-gantt/src/useGanttTranslation.ts`、`plugin-grid/src/ImportWizard.tsx`、`plugin-timeline/src/useTimelineTranslation.ts`。第四份 `fallbackT` 手抄件落地时,这条用例会指名自己红掉,而不是让一张没上门的表溜过去。第 2 面则完全靠发现(工厂第一实参),新表写出来当天就自动进门。

## 门放在 `packages/i18n` 而两个面不在这个包里,为什么不算依赖倒置

`defaults-maps-mirror-en-pack.test.ts` 必须搬去 `app-shell`,是因为它 **import** 三张插件表,而那些包都依赖 `@object-ui/i18n` —— import 回来就把依赖倒过来了。本文件不 import 本包之外的任何东西:它把源文件当**文本读进来再 parse**,这在两个方向上都不构成模块依赖(与 `forwardref-props-annotation.guard.test.ts` 同一机制)。所以规则可以就近放在它所约束的那个 fallback 旁边 —— 下一个改 `useSafeTranslation.ts` 的人会往那儿看。`typescript` 已在 `packages/i18n` 的 devDependencies 里(`^6.0.3`),不引入幻影依赖。

## 验证

- `pnpm --workspace-concurrency=2 --filter '@object-ui/i18n^...' build` —— clean(types / core)。
- `pnpm exec vitest run packages/i18n/ --maxWorkers=2` —— **46 files / 822 tests passed**,新门 18/18。
- `pnpm exec turbo run type-check --concurrency=2` —— **81 successful, 81 total**,EXIT=0。
- `node scripts/check-control-bytes.mjs` —— OK(4386 tracked text files);另做超出该门扫描面的自查 `grep -naP` 于新增两文件,无命中。
- `node scripts/check-i18n-call-site-keys.mjs` / `check-i18n-en-drift.mjs` / `check-changeset-presence.mjs` / `check-changeset-no-major.mjs` / `check-changeset-fixed.mjs` —— 全绿。

## changeset

空 frontmatter,照 `.changeset/app-shell-docs-nav-examples.md` 的同类先例(测试-only、不发布任何包)。`check-changeset-presence` 明确认可这条豁免:「declared as releasing nothing, which is the explicit exemption and a complete answer to this gate」。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_