### PR TITLE
fix(fields): grid columns 收敛到声明拼写 `name`,spec 合规元数据不再渲染空单元格 (#3951)

### DIFF
--- a/.changeset/grid-column-declared-name-spelling.md
+++ b/.changeset/grid-column-declared-name-spelling.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/fields": patch
+"@object-ui/plugin-form": patch
+---
+
+fix(fields): grid columns are keyed by the declared `name`, so spec-compliant grid metadata renders populated cells
+
+`GridField` declared its own column interface keyed by `field` and read
+`c.field` at every site (`key=`, `row[…]`, the blank row, cell writes, the
+column chooser, the running-total lookup), while the published
+`GridColumnDefinition` in `@object-ui/types` — and the grid documentation, and
+the `fields-grid` catalog examples — declare the key as `name`. Metadata
+authored against the published type therefore rendered a grid with the correct
+row count and every cell empty, plus a React "unique key" warning per column.
+
+The renderer now reads the declared `name`, and the master-detail derivation
+(`deriveColumns` / `hydrateColumns` / `pickAmountField`) produces and consumes
+the same key. There is deliberately **no** `col.field ?? col.name` alias: one
+spelling at the producer (AGENTS.md #0.1).
+
+**Breaking for `field`-keyed columns.** Grid / line-item / master-detail
+subform columns spelled `{ field: 'amount' }` must be re-spelled
+`{ name: 'amount' }`. This affects author-supplied `columns` on the `grid`
+field, `record:line_items`, `object-master-detail-form` details and a
+relationship field's `inlineColumns`. Auto-derived columns (no explicit
+`columns` block) need no change. List-view and `object-grid` columns are a
+different contract (`ListColumn`) and keep their own `field` key.

--- a/apps/console/src/dev/DevLookup.tsx
+++ b/apps/console/src/dev/DevLookup.tsx
@@ -10,9 +10,9 @@ export const DevLookup: React.FC = () => {
   const [rows, setRows] = React.useState<Record<string, any>[]>([{}, {}]);
   const field = {
     columns: [
-      { field: 'account', label: 'Account', type: 'lookup', reference: 'showcase_account', displayField: 'name' },
-      { field: 'note', label: 'Note', type: 'text' },
-      { field: 'amount', label: 'Amount', type: 'currency' },
+      { name: 'account', label: 'Account', type: 'lookup', reference: 'showcase_account', displayField: 'name' },
+      { name: 'note', label: 'Note', type: 'text' },
+      { name: 'amount', label: 'Amount', type: 'currency' },
     ],
     total_field: 'amount',
   } as any;

--- a/apps/console/src/dev/DevMasterDetail.tsx
+++ b/apps/console/src/dev/DevMasterDetail.tsx
@@ -23,9 +23,9 @@ const schema = {
       amountField: 'amount',
       totalField: 'total_amount',
       columns: [
-        { field: 'expense_date', label: 'Date', type: 'date' },
+        { name: 'expense_date', label: 'Date', type: 'date' },
         {
-          field: 'category',
+          name: 'category',
           label: 'Category',
           type: 'select',
           options: [
@@ -39,9 +39,9 @@ const schema = {
             { label: 'Other', value: 'other' },
           ],
         },
-        { field: 'description', label: 'Description', type: 'text' },
-        { field: 'merchant_vendor', label: 'Merchant', type: 'text' },
-        { field: 'amount', label: 'Amount', type: 'currency' },
+        { name: 'description', label: 'Description', type: 'text' },
+        { name: 'merchant_vendor', label: 'Merchant', type: 'text' },
+        { name: 'amount', label: 'Amount', type: 'currency' },
       ],
     },
   ],

--- a/docs/adr/0001-master-detail-subform.md
+++ b/docs/adr/0001-master-detail-subform.md
@@ -135,11 +135,13 @@ the dormant `GridFieldMetadata` type promised.
 - Read-only mode renders the same table without inputs (replaces the
   `"N rows"` stub) — this is the **view** half of the requirement.
 
-Column config (reuses the existing `GridColumnDefinition` shape):
+Column config (reuses the existing `GridColumnDefinition` shape — keyed by
+`name`, as that type declares; the examples here said `field` until
+objectui#3951 aligned the renderer to the declared spelling):
 
 ```ts
 {
-  field: 'amount',
+  name: 'amount',
   label: 'Amount',
   type: 'currency',        // text | number | currency | select | date | lookup
   options?: [...],         // for select
@@ -187,10 +189,10 @@ slot) can drop in the children grid bound to the current record:
     "relationshipField": "expense_claim",
     "totalField": "total_amount",
     "columns": [
-      { "field": "expense_date", "type": "date" },
-      { "field": "category", "type": "lookup", "reference": "expense_category" },
-      { "field": "description", "type": "text" },
-      { "field": "amount", "type": "currency" }
+      { "name": "expense_date", "type": "date" },
+      { "name": "category", "type": "lookup", "reference": "expense_category" },
+      { "name": "description", "type": "text" },
+      { "name": "amount", "type": "currency" }
     ]
   }
 }

--- a/packages/app-shell/src/providers/MetadataProvider.merge.test.ts
+++ b/packages/app-shell/src/providers/MetadataProvider.merge.test.ts
@@ -192,7 +192,7 @@ describe('attachInlineSubforms — relationship-level inlineEdit', () => {
   it('lets an explicit form.subforms entry override the derived one', () => {
     const withExplicit = objects.map((o) =>
       o.name === 'invoice'
-        ? { ...o, form: { type: 'simple', subforms: [{ childObject: 'invoice_line', columns: [{ field: 'amount' }] }] } }
+        ? { ...o, form: { type: 'simple', subforms: [{ childObject: 'invoice_line', columns: [{ name: 'amount' }] }] } }
         : o,
     );
     const out = attachInlineSubforms(withExplicit);

--- a/packages/fields/src/__tests__/date-locale-channel.test.tsx
+++ b/packages/fields/src/__tests__/date-locale-channel.test.tsx
@@ -187,8 +187,8 @@ describe('zh session — every date branch renders Chinese (objectui#4468)', () 
   it('the sub-grid read-only table', () => {
     const temporalField = {
       columns: [
-        { field: 'merchant', label: 'Merchant', type: 'text' as const },
-        { field: 'incurred_on', label: 'Incurred On', type: 'date' as const },
+        { name: 'merchant', label: 'Merchant', type: 'text' as const },
+        { name: 'incurred_on', label: 'Incurred On', type: 'date' as const },
       ],
     } as any;
     renderSession(

--- a/packages/fields/src/complex-widgets.test.tsx
+++ b/packages/fields/src/complex-widgets.test.tsx
@@ -827,8 +827,8 @@ describe('Complex & Relationship Widgets', () => {
 
     describe('GridField', () => {
         const columns = [
-            { field: 'name', label: 'Name' },
-            { field: 'age', label: 'Age', type: 'number' }
+            { name: 'name', label: 'Name' },
+            { name: 'age', label: 'Age', type: 'number' }
         ];
         const data = [
             { name: 'Alice', age: 30 },

--- a/packages/fields/src/widgets/GridField.declaredSpelling.test.tsx
+++ b/packages/fields/src/widgets/GridField.declaredSpelling.test.tsx
@@ -25,15 +25,16 @@
  * one spelling at the producer — there is deliberately no `c.field ?? c.name`
  * alias to make the retired spelling keep working.
  *
- * Reverse verification (predicted before running): restore the reader to
- * `c.field` and BOTH assertions below go red — cell inputs read back `''`
- * because `row[undefined]` is `undefined`, and React logs the missing-key
- * warning because every `key` is `undefined`. That is the "Red" direction: the
- * rule reads a key the fixtures do not spell, so removing the fix removes the
- * values, not merely the diagnostics.
+ * Reverse verification: restore the reader to `c.field` and every case here
+ * goes red — cell inputs read back `''` because `row[undefined]` is
+ * `undefined`. The other half of the bug, the React missing-key warning, is
+ * pinned in `GridField.keyWarning.test.tsx` rather than here: React emits that
+ * warning only ONCE per owner component, so a second render inside this file
+ * observes nothing and the assertion would pass for an empty reason. It needs
+ * to own the first render of the file, hence its own file.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import type { GridColumnDefinition, GridFieldMetadata } from '@object-ui/types';
@@ -54,26 +55,9 @@ const rows = [
 
 const field = { type: 'grid', name: 'order_items', columns } as GridFieldMetadata;
 
-/** Collect React's console warnings for the duration of one render. */
-function captureConsole() {
-  const messages: string[] = [];
-  const record = (...args: unknown[]) => { messages.push(args.map(String).join(' ')); };
-  const errorSpy = vi.spyOn(console, 'error').mockImplementation(record);
-  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(record);
-  return {
-    messages,
-    keyWarnings: () => messages.filter((m) => /unique "?key"?/i.test(m)),
-    restore: () => { errorSpy.mockRestore(); warnSpy.mockRestore(); },
-  };
-}
-
-afterEach(() => { vi.restoreAllMocks(); });
-
 describe('GridField reads the DECLARED column spelling (objectui#3951)', () => {
   it('renders every cell populated from metadata authored as GridColumnDefinition', () => {
-    const capture = captureConsole();
     render(<GridField value={rows} onChange={() => {}} field={field} />);
-    capture.restore();
 
     // One cell input per column per row, each echoing the row's stored value —
     // this is the assertion the `field`-keyed reader could not satisfy.
@@ -93,13 +77,6 @@ describe('GridField reads the DECLARED column spelling (objectui#3951)', () => {
     for (const cell of [...products.slice(0, 2), ...quantities.slice(0, 2), ...prices.slice(0, 2)]) {
       expect(cell.value).not.toBe('');
     }
-  });
-
-  it('renders with no React "unique key" warning', () => {
-    const capture = captureConsole();
-    render(<GridField value={rows} onChange={() => {}} field={field} />);
-    capture.restore();
-    expect(capture.keyWarnings()).toEqual([]);
   });
 
   it('the read-only surface shows the stored values, not blanks', () => {

--- a/packages/fields/src/widgets/GridField.declaredSpelling.test.tsx
+++ b/packages/fields/src/widgets/GridField.declaredSpelling.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3951 — grid columns have ONE key spelling, and it is the declared
+ * one: `GridColumnDefinition.name` (`@object-ui/types`), the same key the grid
+ * docs page and the three `fields-grid` catalog examples author.
+ *
+ * `GridField` used to declare its own local column interface keyed by `field`
+ * and read `c.field` everywhere — `key={c.field}`, `row[c.field]`,
+ * `blank[c.field]`, `applyCell(rowIdx, col.field, …)`. Metadata authored
+ * against the published type therefore rendered a grid with the right row
+ * COUNT and every cell EMPTY, plus a React "unique key" warning for every
+ * column (the key was `undefined`). The three demos on `/docs/fields/grid`
+ * shipped in exactly that state.
+ *
+ * The fixtures below are typed as `GridColumnDefinition[]` on purpose: the pin
+ * is anchored to the DECLARED contract, not to the widget's own idea of it, so
+ * the two can never silently drift apart again. Per AGENTS.md #0.1 the fix is
+ * one spelling at the producer — there is deliberately no `c.field ?? c.name`
+ * alias to make the retired spelling keep working.
+ *
+ * Reverse verification (predicted before running): restore the reader to
+ * `c.field` and BOTH assertions below go red — cell inputs read back `''`
+ * because `row[undefined]` is `undefined`, and React logs the missing-key
+ * warning because every `key` is `undefined`. That is the "Red" direction: the
+ * rule reads a key the fixtures do not spell, so removing the fix removes the
+ * values, not merely the diagnostics.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import type { GridColumnDefinition, GridFieldMetadata } from '@object-ui/types';
+import { GridField } from './GridField';
+
+/** Authored exactly as `GridColumnDefinition` declares — keyed by `name`. */
+const columns: GridColumnDefinition[] = [
+  { name: 'product', label: 'Product', type: 'text' },
+  { name: 'quantity', label: 'Qty', type: 'number' },
+  { name: 'price', label: 'Price', type: 'currency' },
+];
+
+/** The `fields-grid/grid-with-data` catalog example's rows, verbatim. */
+const rows = [
+  { product: 'Widget A', quantity: 2, price: 29.99 },
+  { product: 'Widget B', quantity: 1, price: 49.99 },
+];
+
+const field = { type: 'grid', name: 'order_items', columns } as GridFieldMetadata;
+
+/** Collect React's console warnings for the duration of one render. */
+function captureConsole() {
+  const messages: string[] = [];
+  const record = (...args: unknown[]) => { messages.push(args.map(String).join(' ')); };
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(record);
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(record);
+  return {
+    messages,
+    keyWarnings: () => messages.filter((m) => /unique "?key"?/i.test(m)),
+    restore: () => { errorSpy.mockRestore(); warnSpy.mockRestore(); },
+  };
+}
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('GridField reads the DECLARED column spelling (objectui#3951)', () => {
+  it('renders every cell populated from metadata authored as GridColumnDefinition', () => {
+    const capture = captureConsole();
+    render(<GridField value={rows} onChange={() => {}} field={field} />);
+    capture.restore();
+
+    // One cell input per column per row, each echoing the row's stored value —
+    // this is the assertion the `field`-keyed reader could not satisfy.
+    const products = screen.getAllByLabelText('Product') as HTMLInputElement[];
+    const quantities = screen.getAllByLabelText('Qty') as HTMLInputElement[];
+    const prices = screen.getAllByLabelText('Price') as HTMLInputElement[];
+
+    expect(products[0].value).toBe('Widget A');
+    expect(quantities[0].value).toBe('2');
+    expect(prices[0].value).toBe('29.99');
+    expect(products[1].value).toBe('Widget B');
+    expect(quantities[1].value).toBe('1');
+    expect(prices[1].value).toBe('49.99');
+
+    // Not one empty cell across the authored rows (the ghost/new row is last
+    // and is legitimately blank, so only the authored rows are checked).
+    for (const cell of [...products.slice(0, 2), ...quantities.slice(0, 2), ...prices.slice(0, 2)]) {
+      expect(cell.value).not.toBe('');
+    }
+  });
+
+  it('renders with no React "unique key" warning', () => {
+    const capture = captureConsole();
+    render(<GridField value={rows} onChange={() => {}} field={field} />);
+    capture.restore();
+    expect(capture.keyWarnings()).toEqual([]);
+  });
+
+  it('the read-only surface shows the stored values, not blanks', () => {
+    render(<GridField value={rows} onChange={() => {}} field={field} readonly />);
+    expect(screen.getByText('Widget A')).toBeTruthy();
+    expect(screen.getByText('Widget B')).toBeTruthy();
+  });
+
+  it('a blank row is keyed by the declared column names', () => {
+    const onChange = vi.fn();
+    render(<GridField value={[]} onChange={onChange} field={field} />);
+    fireEvent.click(screen.getByRole('button', { name: /Add line/i }));
+    expect(onChange).toHaveBeenCalledWith([{ product: null, quantity: null, price: null }]);
+  });
+
+  it('an edited cell writes back under the declared column name', () => {
+    const onChange = vi.fn();
+    render(<GridField value={[{ product: 'Widget A' }]} onChange={onChange} field={field} />);
+    fireEvent.change((screen.getAllByLabelText('Qty') as HTMLInputElement[])[0], { target: { value: '7' } });
+    expect(onChange).toHaveBeenCalledWith([{ product: 'Widget A', quantity: 7 }]);
+  });
+});

--- a/packages/fields/src/widgets/GridField.keyWarning.test.tsx
+++ b/packages/fields/src/widgets/GridField.keyWarning.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3951, diagnostics half — a grid authored in the declared spelling
+ * (`GridColumnDefinition.name`) must render without React's missing-key
+ * warning. While `GridField` read a divergent `field` key, every header, chip
+ * and cell was emitted with `key={undefined}`, so a spec-compliant grid logged
+ * the warning on top of rendering blank cells.
+ *
+ * WHY THIS LIVES IN ITS OWN FILE: React emits the missing-key warning only
+ * ONCE per owner component. A second `GridField` render in the same module
+ * instance observes nothing at all, so the same assertion sitting after
+ * another render would pass whether or not the bug is present — green for an
+ * empty reason. Vitest isolates per FILE (`isolate: true` on the `dom`
+ * project), so giving the check its own file guarantees it owns the first
+ * render and the observation is real. Keep it that way: do not add another
+ * GridField render above it.
+ *
+ * The positive control below renders a deliberately key-less list first and
+ * asserts the spy DOES see a warning, so a green result downstream proves the
+ * detector is live rather than proving the console spy is broken.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import type { GridColumnDefinition, GridFieldMetadata } from '@object-ui/types';
+import { GridField } from './GridField';
+
+const columns: GridColumnDefinition[] = [
+  { name: 'product', label: 'Product', type: 'text' },
+  { name: 'quantity', label: 'Qty', type: 'number' },
+  { name: 'price', label: 'Price', type: 'currency' },
+];
+
+const field = { type: 'grid', name: 'order_items', columns } as GridFieldMetadata;
+
+const rows = [
+  { product: 'Widget A', quantity: 2, price: 29.99 },
+  { product: 'Widget B', quantity: 1, price: 49.99 },
+];
+
+/** Collects everything React writes to console for the duration of a render. */
+function captureConsole() {
+  const messages: string[] = [];
+  const record = (...args: unknown[]) => { messages.push(args.map(String).join(' ')); };
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(record);
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(record);
+  return {
+    keyWarnings: () => messages.filter((m) => /unique "?key"?/i.test(m)),
+    restore: () => { errorSpy.mockRestore(); warnSpy.mockRestore(); },
+  };
+}
+
+/** Deliberately key-less — the positive control for the detector above. */
+function KeylessControl(): React.ReactElement {
+  return <ul>{['a', 'b'].map((v) => <li>{v}</li>)}</ul>;
+}
+
+describe('GridField emits no missing-key warning for declared-spelling columns (objectui#3951)', () => {
+  it('renders spec-compliant grid metadata with no React "unique key" warning', () => {
+    const capture = captureConsole();
+
+    // Control first: prove a missing key IS observable through this spy in
+    // this environment, so the assertion that follows means something.
+    render(<KeylessControl />);
+    expect(capture.keyWarnings().length).toBeGreaterThan(0);
+
+    const before = capture.keyWarnings().length;
+    render(<GridField value={rows} onChange={() => {}} field={field} />);
+    capture.restore();
+
+    // No NEW key warning attributable to the grid's own render.
+    expect(capture.keyWarnings().length).toBe(before);
+  });
+});

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -5,8 +5,8 @@ import { UploadProvider } from '@object-ui/providers';
 import { GridField, LineItemsField, sumColumn, lookupAutofillPatch } from './GridField';
 
 const columns = [
-  { field: 'description', label: 'Description', type: 'text' as const },
-  { field: 'amount', label: 'Amount', type: 'currency' as const },
+  { name: 'description', label: 'Description', type: 'text' as const },
+  { name: 'amount', label: 'Amount', type: 'currency' as const },
 ];
 
 const field = { columns, total_field: 'amount' } as any;
@@ -33,9 +33,9 @@ describe('GridField / LineItemsField — editable line items', () => {
   describe('column chooser (defaultHidden columns)', () => {
     const withHidden = {
       columns: [
-        { field: 'title', label: 'Title', type: 'text' as const, required: true },
-        { field: 'amount', label: 'Amount', type: 'currency' as const },
-        { field: 'notes', label: 'Notes', type: 'text' as const, defaultHidden: true },
+        { name: 'title', label: 'Title', type: 'text' as const, required: true },
+        { name: 'amount', label: 'Amount', type: 'currency' as const },
+        { name: 'notes', label: 'Notes', type: 'text' as const, defaultHidden: true },
       ],
     } as any;
 
@@ -63,8 +63,8 @@ describe('GridField / LineItemsField — editable line items', () => {
   describe('list mode (displayMode="list" — form-factor for fat children)', () => {
     const listField = {
       columns: [
-        { field: 'title', label: 'Title', type: 'text' as const, required: true },
-        { field: 'status', label: 'Status', type: 'select' as const, options: [{ label: 'To Do', value: 'todo' }] },
+        { name: 'title', label: 'Title', type: 'text' as const, required: true },
+        { name: 'status', label: 'Status', type: 'select' as const, options: [{ label: 'To Do', value: 'todo' }] },
       ],
     } as any;
 
@@ -126,8 +126,8 @@ describe('GridField / LineItemsField — editable line items', () => {
   describe('date columns echo the stored value (#3566)', () => {
     const dateField = {
       columns: [
-        { field: 'description', label: 'Description', type: 'text' as const },
-        { field: 'incurred_on', label: 'Incurred On', type: 'date' as const },
+        { name: 'description', label: 'Description', type: 'text' as const },
+        { name: 'incurred_on', label: 'Incurred On', type: 'date' as const },
       ],
     } as any;
 
@@ -195,10 +195,10 @@ describe('GridField / LineItemsField — editable line items', () => {
 
     const temporalField = {
       columns: [
-        { field: 'merchant', label: 'Merchant', type: 'text' as const },
-        { field: 'incurred_on', label: 'Incurred On', type: 'date' as const },
-        { field: 'incurred_at', label: 'Incurred At', type: 'datetime' as const },
-        { field: 'started_at', label: 'Started At', type: 'time' as const },
+        { name: 'merchant', label: 'Merchant', type: 'text' as const },
+        { name: 'incurred_on', label: 'Incurred On', type: 'date' as const },
+        { name: 'incurred_at', label: 'Incurred At', type: 'datetime' as const },
+        { name: 'started_at', label: 'Started At', type: 'time' as const },
       ],
     } as any;
 
@@ -363,10 +363,10 @@ describe('GridField / LineItemsField — editable line items', () => {
   describe('computed columns (amount = qty × unit_price)', () => {
     const computedField = {
       columns: [
-        { field: 'product', label: 'Product', type: 'text' as const },
-        { field: 'quantity', label: 'Qty', type: 'number' as const },
-        { field: 'unit_price', label: 'Unit Price', type: 'currency' as const },
-        { field: 'amount', label: 'Amount', type: 'currency' as const, computed: true, expr: 'record.quantity * record.unit_price', scale: 2 },
+        { name: 'product', label: 'Product', type: 'text' as const },
+        { name: 'quantity', label: 'Qty', type: 'number' as const },
+        { name: 'unit_price', label: 'Unit Price', type: 'currency' as const },
+        { name: 'amount', label: 'Amount', type: 'currency' as const, computed: true, expr: 'record.quantity * record.unit_price', scale: 2 },
       ],
       total_field: 'amount',
     } as any;
@@ -442,11 +442,11 @@ describe('GridField / LineItemsField — editable line items', () => {
 
   describe('lookupAutofillPatch (item typeahead auto-fill)', () => {
     const cols = [
-      { field: 'product', type: 'lookup' as const, reference: 'product' },
-      { field: 'description', type: 'text' as const },
-      { field: 'quantity', type: 'number' as const },
-      { field: 'unit_price', type: 'currency' as const },
-      { field: 'amount', type: 'currency' as const, computed: true, expr: 'record.quantity * record.unit_price' },
+      { name: 'product', type: 'lookup' as const, reference: 'product' },
+      { name: 'description', type: 'text' as const },
+      { name: 'quantity', type: 'number' as const },
+      { name: 'unit_price', type: 'currency' as const },
+      { name: 'amount', type: 'currency' as const, computed: true, expr: 'record.quantity * record.unit_price' },
     ];
     const product = { value: 'p1', label: 'Widget A', name: 'Widget A', description: 'Standard widget', unit_price: 29.99, sku: 'WIDGET-A' };
 
@@ -476,7 +476,7 @@ describe('GridField / LineItemsField — editable line items', () => {
     });
 
     it('flags a required, empty cell on a real row (not the ghost row)', () => {
-      const reqField = { columns: [{ field: 'description', label: 'Description', type: 'text' as const, required: true }] } as any;
+      const reqField = { columns: [{ name: 'description', label: 'Description', type: 'text' as const, required: true }] } as any;
       render(<GridField value={[{ description: '' }]} onChange={() => {}} field={reqField} />);
       // The data row's required-empty cell is flagged...
       expect(screen.getByTestId('line-items-invalid-0-description')).toBeTruthy();
@@ -488,8 +488,8 @@ describe('GridField / LineItemsField — editable line items', () => {
   describe('file columns (upload in a grid cell — #2360)', () => {
     const fileField = {
       columns: [
-        { field: 'description', label: 'Description', type: 'text' as const },
-        { field: 'receipt', label: 'Receipt', type: 'file' as const },
+        { name: 'description', label: 'Description', type: 'text' as const },
+        { name: 'receipt', label: 'Receipt', type: 'file' as const },
       ],
     } as any;
 
@@ -546,7 +546,7 @@ describe('GridField / LineItemsField — editable line items', () => {
 
     it('passes the column accept list to the native picker', () => {
       const withAccept = {
-        columns: [{ field: 'receipt', label: 'Receipt', type: 'file' as const, accept: ['image/*', '.pdf'] }],
+        columns: [{ name: 'receipt', label: 'Receipt', type: 'file' as const, accept: ['image/*', '.pdf'] }],
       } as any;
       render(<GridField value={[]} onChange={() => {}} field={withAccept} />);
       const input = document.querySelector('input[type="file"]') as HTMLInputElement;
@@ -574,9 +574,9 @@ describe('GridField / LineItemsField — editable line items', () => {
   describe('parent-scoped conditional rules (B2 follow-up — "paid invoice → lock lines")', () => {
     const lockField = {
       columns: [
-        { field: 'product', label: 'Product', type: 'text' as const },
-        { field: 'qty', label: 'Qty', type: 'number' as const, readonlyWhen: "parent.status == 'paid'" },
-        { field: 'unit_price', label: 'Unit Price', type: 'currency' as const, readonlyWhen: "parent.status == 'paid'" },
+        { name: 'product', label: 'Product', type: 'text' as const },
+        { name: 'qty', label: 'Qty', type: 'number' as const, readonlyWhen: "parent.status == 'paid'" },
+        { name: 'unit_price', label: 'Unit Price', type: 'currency' as const, readonlyWhen: "parent.status == 'paid'" },
       ],
     } as any;
 
@@ -611,9 +611,9 @@ describe('GridField / LineItemsField — editable line items', () => {
     it('re-evaluates per row, mixing the parent header with row data', () => {
       const rowRule = {
         columns: [
-          { field: 'qty', label: 'Qty', type: 'number' as const },
+          { name: 'qty', label: 'Qty', type: 'number' as const },
           // Locks only when the header is paid AND this row is already invoiced.
-          { field: 'note', label: 'Note', type: 'text' as const, readonlyWhen: "parent.status == 'paid' && record.invoiced == true" },
+          { name: 'note', label: 'Note', type: 'text' as const, readonlyWhen: "parent.status == 'paid' && record.invoiced == true" },
         ],
       } as any;
       render(

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -32,7 +32,7 @@ import { toDateInputValue, toDateTimeInputValue, fromDateTimeInputValue } from '
  * engine behind the master-detail subform (see ADR-0001).
  *
  * Column config (a subset of `GridColumnDefinition`):
- *   { field, label?, type?, options?, width?, required?, prefix?, step? }
+ *   { name, label?, type?, options?, width?, required?, prefix?, step? }
  *   type ∈ 'text' | 'number' | 'currency' | 'date' | 'datetime' | 'time'
  *        | 'select' | 'lookup' | 'file'
  *
@@ -41,7 +41,17 @@ import { toDateInputValue, toDateTimeInputValue, fromDateTimeInputValue } from '
  */
 
 export interface GridColumn {
-  field: string;
+  /**
+   * The column's field name — the key it reads and writes on each row object.
+   *
+   * Spelled `name`, exactly as the declared `GridColumnDefinition`
+   * (`@object-ui/types`) and the grid docs page say (objectui#3951). This
+   * widget used to read a divergent `field` key, so metadata authored against
+   * the published type rendered every cell empty plus a React key warning.
+   * There is deliberately NO `col.field ?? col.name` alias: one spelling, at
+   * the producer — AGENTS.md #0.1.
+   */
+  name: string;
   label?: string;
   /**
    * Cell control + read/write adapter for the column.
@@ -246,12 +256,12 @@ export function evalArith(expr: string, row: Row): number | null {
  * it is unit-testable independent of the picker UI.
  */
 export function lookupAutofillPatch(columns: GridColumn[], col: GridColumn, record: any): Row {
-  const patch: Row = { [col.field]: record?.value ?? record?.id ?? record?._id };
+  const patch: Row = { [col.name]: record?.value ?? record?.id ?? record?._id };
   if (col.autofill !== false && record && typeof record === 'object') {
     for (const other of columns) {
-      if (other.field === col.field || other.computed || other.type === 'lookup') continue;
-      const v = record[other.field];
-      if (v !== undefined && v !== null && v !== '') patch[other.field] = v;
+      if (other.name === col.name || other.computed || other.type === 'lookup') continue;
+      const v = record[other.name];
+      if (v !== undefined && v !== null && v !== '') patch[other.name] = v;
     }
   }
   return patch;
@@ -263,9 +273,9 @@ export function computeRow(columns: GridColumn[], row: Row): Row {
   const next = { ...row };
   for (const c of computedCols) {
     const v = evalArith(c.expr!, next);
-    if (v === null) { next[c.field] = null; continue; }
+    if (v === null) { next[c.name] = null; continue; }
     const scale = c.scale ?? (c.type === 'currency' ? 2 : undefined);
-    next[c.field] = scale != null ? Number(v.toFixed(scale)) : v;
+    next[c.name] = scale != null ? Number(v.toFixed(scale)) : v;
   }
   return next;
 }
@@ -427,7 +437,7 @@ export function GridField({
   const [extraShown, setExtraShown] = React.useState<Set<string>>(() => new Set());
   const optionalColumns = allColumns.filter((c) => c.defaultHidden && !c.required);
   const columns: GridColumn[] = allColumns.filter(
-    (c) => !c.defaultHidden || c.required || extraShown.has(c.field),
+    (c) => !c.defaultHidden || c.required || extraShown.has(c.name),
   );
   const toggleColumn = useCallback((fieldName: string) => {
     setExtraShown((prev) => {
@@ -465,7 +475,7 @@ export function GridField({
 
   const blankRow = useCallback((): Row => {
     const blank: Row = {};
-    for (const c of columns) blank[c.field] = null;
+    for (const c of columns) blank[c.name] = null;
     return blank;
   }, [columns]);
 
@@ -489,7 +499,7 @@ export function GridField({
   );
 
   const applyCell = useCallback(
-    (rowIdx: number, field: string, value: any) => applyPatch(rowIdx, { [field]: value }),
+    (rowIdx: number, columnName: string, value: any) => applyPatch(rowIdx, { [columnName]: value }),
     [applyPatch],
   );
 
@@ -509,13 +519,13 @@ export function GridField({
 
   /** Set a cell to an already-typed value (lookup ids, etc.) without coercion. */
   const setCellValue = useCallback(
-    (rowIdx: number, field: string, value: any) => applyCell(rowIdx, field, value),
+    (rowIdx: number, columnName: string, value: any) => applyCell(rowIdx, columnName, value),
     [applyCell],
   );
 
   const setCell = useCallback(
     (rowIdx: number, col: GridColumn, raw: string) => {
-      applyCell(rowIdx, col.field, coerce(col.type, raw));
+      applyCell(rowIdx, col.name, coerce(col.type, raw));
     },
     [applyCell],
   );
@@ -594,7 +604,7 @@ export function GridField({
   const total = showTotal ? sumColumn(rows, totalField!) : 0;
   // Align the running total under the column it sums (not blindly under the
   // last column). The label sits right-aligned immediately to its left.
-  const totalColIndex = showTotal ? Math.max(0, columns.findIndex((c) => c.field === totalField)) : -1;
+  const totalColIndex = showTotal ? Math.max(0, columns.findIndex((c) => c.name === totalField)) : -1;
 
   // Column chooser — reveal/hide the optional (default-hidden) columns. Only
   // rendered when there are optional columns to manage.
@@ -621,19 +631,19 @@ export function GridField({
         <div className="px-1 pb-1.5 text-xs font-medium text-muted-foreground">Optional columns</div>
         <div className="max-h-64 space-y-0.5 overflow-y-auto">
           {optionalColumns.map((c) => {
-            const id = `col-toggle-${c.field}`;
+            const id = `col-toggle-${c.name}`;
             return (
               <Label
-                key={c.field}
+                key={c.name}
                 htmlFor={id}
                 className="flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1.5 text-sm font-normal hover:bg-muted"
               >
                 <Checkbox
                   id={id}
-                  checked={extraShown.has(c.field)}
-                  onCheckedChange={() => toggleColumn(c.field)}
+                  checked={extraShown.has(c.name)}
+                  onCheckedChange={() => toggleColumn(c.name)}
                 />
-                <span className="truncate">{c.label || c.field}</span>
+                <span className="truncate">{c.label || c.name}</span>
               </Label>
             );
           })}
@@ -656,14 +666,14 @@ export function GridField({
               )}
               {columns.map((c) => (
                 <th
-                  key={c.field}
+                  key={c.name}
                   style={{ minWidth: minWidthFor(c) }}
                   className={cn(
                     'px-3 py-2 text-xs font-medium text-muted-foreground whitespace-nowrap',
                     isNumeric(c.type) ? 'text-right' : 'text-left',
                   )}
                 >
-                  {c.label || c.field}
+                  {c.label || c.name}
                 </th>
               ))}
             </tr>
@@ -686,12 +696,12 @@ export function GridField({
                   )}
                   {columns.map((c) => (
                     <td
-                      key={c.field}
+                      key={c.name}
                       className={cn('px-3 py-2 text-foreground', isNumeric(c.type) && 'text-right tabular-nums')}
                     >
-                      {c.type === 'lookup' && row[c.field] != null && row[c.field] !== '' ? (
+                      {c.type === 'lookup' && row[c.name] != null && row[c.name] !== '' ? (
                         <LookupField
-                          value={row[c.field]}
+                          value={row[c.name]}
                           onChange={() => {}}
                           readonly
                           field={{ reference: c.reference, display_field: c.displayField, id_field: c.idField } as any}
@@ -702,9 +712,9 @@ export function GridField({
                         // for a date, and for a datetime it would ALSO have been
                         // wrong to render as a bare day (objectui#3569). Now that
                         // the three types are distinct, each formats as itself.
-                        displayText(c, row[c.field], displayLocale)
-                      ) : row[c.field] != null && row[c.field] !== '' ? (
-                        String(row[c.field])
+                        displayText(c, row[c.name], displayLocale)
+                      ) : row[c.name] != null && row[c.name] !== '' ? (
+                        String(row[c.name])
                       ) : (
                         '—'
                       )}
@@ -749,7 +759,7 @@ export function GridField({
   /** Cell content: read-only display (list mode / computed columns) or an
    *  editable borderless control (spreadsheet feel). */
   const renderCellInput = (c: GridColumn, colIdx: number, rowIdx: number, row: Row) => {
-    const val = row?.[c.field];
+    const val = row?.[c.name];
     // A readonlyWhen-TRUE cell is locked: treat like the form-wide `disabled`.
     const locked = disabled || cellRules(c, row).readonly;
     // List (form-factor) mode → read-only at-a-glance display.
@@ -772,7 +782,7 @@ export function GridField({
         <span
           className={cn('block px-2 text-sm tabular-nums', isNumeric(c.type) ? 'text-right' : 'text-left', (val == null || val === '') ? 'text-muted-foreground' : 'text-foreground')}
           title="Computed"
-          data-computed={c.field}
+          data-computed={c.name}
         >
           {displayText(c, val, displayLocale)}
         </span>
@@ -782,7 +792,7 @@ export function GridField({
       return (
         <LookupField
           value={val}
-          onChange={(v: any) => setCellValue(rowIdx, c.field, v)}
+          onChange={(v: any) => setCellValue(rowIdx, c.name, v)}
           onSelectRecord={(rec: any) => applyLookupSelection(rowIdx, c, rec)}
           compact
           field={{ reference: c.reference, display_field: c.displayField, id_field: c.idField, multiple: c.multiple, options: c.options, placeholder: '—' } as any}
@@ -796,11 +806,11 @@ export function GridField({
       return (
         <FileCell
           value={val}
-          onChange={(v: any) => setCellValue(rowIdx, c.field, v)}
+          onChange={(v: any) => setCellValue(rowIdx, c.name, v)}
           multiple={c.multiple}
           accept={Array.isArray(c.accept) && c.accept.length > 0 ? c.accept.join(',') : undefined}
           disabled={locked}
-          aria-label={c.label || c.field}
+          aria-label={c.label || c.name}
           data-cell={`${rowIdx}-${colIdx}`}
         />
       );
@@ -808,7 +818,7 @@ export function GridField({
     if (c.type === 'select') {
       return (
         <Select value={val != null ? String(val) : ''} onValueChange={(v) => setCell(rowIdx, c, v)} disabled={locked}>
-          <SelectTrigger className="h-8 rounded-none border-0 bg-transparent px-2 shadow-none focus:ring-1 focus:ring-ring/60" aria-label={c.label || c.field}>
+          <SelectTrigger className="h-8 rounded-none border-0 bg-transparent px-2 shadow-none focus:ring-1 focus:ring-ring/60" aria-label={c.label || c.name}>
             <SelectValue placeholder="—" />
           </SelectTrigger>
           <SelectContent>
@@ -844,7 +854,7 @@ export function GridField({
                     : 'text'
           }
           step={isNumeric(c.type) ? c.step ?? 'any' : undefined}
-          aria-label={c.label || c.field}
+          aria-label={c.label || c.name}
           // A temporal cell holding the API's ISO shape (`2026-06-17T14:30:00.000Z`)
           // is SILENTLY rejected by the native control — the attribute lands in
           // the DOM but `input.value` reads back `''` and the cell paints empty
@@ -884,14 +894,14 @@ export function GridField({
               )}
               {columns.map((c) => (
                 <th
-                  key={c.field}
+                  key={c.name}
                   className={cn(
                     'px-2 py-2 text-xs font-medium text-muted-foreground whitespace-nowrap',
                     isNumeric(c.type) ? 'text-right' : 'text-left',
                   )}
                   style={widthStyle(c)}
                 >
-                  {c.label || c.field}
+                  {c.label || c.name}
                   {c.required && !c.computed && <span className="text-destructive"> *</span>}
                 </th>
               ))}
@@ -952,13 +962,13 @@ export function GridField({
                       // "required" verdict honors a column's `requiredWhen` CEL
                       // rule (B2), evaluated against the row + parent header.
                       const required = cellRules(c, row).required;
-                      const invalid = !isGhost && !isList && required && !c.computed && (row[c.field] == null || row[c.field] === '');
+                      const invalid = !isGhost && !isList && required && !c.computed && (row[c.name] == null || row[c.name] === '');
                       return (
                         <td
-                          key={c.field}
+                          key={c.name}
                           aria-invalid={invalid || undefined}
-                          title={invalid ? `${c.label || c.field} is required` : undefined}
-                          data-testid={invalid ? `line-items-invalid-${rowIdx}-${c.field}` : undefined}
+                          title={invalid ? `${c.label || c.name} is required` : undefined}
+                          data-testid={invalid ? `line-items-invalid-${rowIdx}-${c.name}` : undefined}
                           className={cn(
                             'border-r border-border/40 px-1 py-0.5 align-middle last:border-r-0',
                             isList && 'px-2 py-1.5',

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -48,8 +48,13 @@ export interface GridColumn {
    * (`@object-ui/types`) and the grid docs page say (objectui#3951). This
    * widget used to read a divergent `field` key, so metadata authored against
    * the published type rendered every cell empty plus a React key warning.
-   * There is deliberately NO `col.field ?? col.name` alias: one spelling, at
-   * the producer — AGENTS.md #0.1.
+   * There is deliberately no tolerant alias bridging the retired spelling to
+   * this one: a single spelling, enforced at the producer — AGENTS.md #0.1.
+   *
+   * (Wording note: do not restate that rule as an alternation expression over
+   * the two key names. `column-identity.ratchet.test.ts` (objectui#3104) scans
+   * these files line by line and cannot tell prose from code, so spelling the
+   * shape out here registers as a new dual read and fails the gate.)
    */
   name: string;
   label?: string;

--- a/packages/plugin-form/src/LineItemsPanel.elementDataSource.test.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.elementDataSource.test.tsx
@@ -43,7 +43,7 @@ const HOT_VIEW = {
   pagination: { pageSize: 7 },
 };
 
-const COLUMNS = [{ field: 'qty', label: 'Qty', type: 'number' as const }];
+const COLUMNS = [{ name: 'qty', label: 'Qty', type: 'number' as const }];
 
 function makeAdapter(listViews: Record<string, unknown> = { hot: HOT_VIEW }) {
   return {
@@ -173,7 +173,7 @@ describe('record:line_items — parent scope AND the authored criteria (objectst
     expect(params.$top).toBe(3);
 
     // And the editable grid still keeps the authored GridColumn list — a view's
-    // bare field names would arrive with no `field`/`type` and render
+    // bare field names would arrive with no `name`/`type` and render
     // header-less, type-less cells. Wrong SHAPE, not merely a wider answer.
     await waitFor(() => expect(headerTexts(container)).toContain('Qty'));
     expect(headerTexts(container).join('|')).not.toContain('price');

--- a/packages/plugin-form/src/LineItemsPanel.test.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.test.tsx
@@ -28,7 +28,7 @@ const schema = {
   parentId: 'p1',
   amountField: 'amount',
   totalField: 'total_amount',
-  columns: [{ field: 'amount', label: 'Amount', type: 'number' }],
+  columns: [{ name: 'amount', label: 'Amount', type: 'number' }],
 } as any;
 
 function renderPanel(ds: any) {

--- a/packages/plugin-form/src/MasterDetailForm.elementDataSource.test.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.elementDataSource.test.tsx
@@ -47,7 +47,7 @@ const DETAILS = [
     childObject: 'invoice_line',
     relationshipField: 'invoice',
     title: 'Invoice lines',
-    columns: [{ field: 'qty', type: 'number' as const }],
+    columns: [{ name: 'qty', type: 'number' as const }],
   },
 ];
 

--- a/packages/plugin-form/src/MasterDetailForm.test.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.test.tsx
@@ -159,7 +159,7 @@ describe('MasterDetailForm — non-atomic fallback (emulation via runBatchTransa
     mode: 'create',
     fields: ['ref'],
     details: [
-      { childObject: 'po_line', relationshipField: 'po', columns: [{ field: 'qty', label: 'Qty', type: 'number' }] },
+      { childObject: 'po_line', relationshipField: 'po', columns: [{ name: 'qty', label: 'Qty', type: 'number' }] },
     ],
   } as any;
 
@@ -241,8 +241,8 @@ describe('MasterDetailForm — parent-scoped line rules ("paid invoice → lock 
         childObject: 'inv_line',
         relationshipField: 'inv',
         columns: [
-          { field: 'product', label: 'Product', type: 'text' },
-          { field: 'qty', label: 'Qty', type: 'number', readonlyWhen: "parent.status == 'paid'" },
+          { name: 'product', label: 'Product', type: 'text' },
+          { name: 'qty', label: 'Qty', type: 'number', readonlyWhen: "parent.status == 'paid'" },
         ],
       },
     ],

--- a/packages/plugin-form/src/MasterDetailForm.tsx
+++ b/packages/plugin-form/src/MasterDetailForm.tsx
@@ -317,7 +317,7 @@ export const MasterDetailForm: React.FC<MasterDetailFormProps> = ({
   // A detail can be configured with just `{ childObject }` — the relationship
   // FK and grid columns are then derived from the child object's metadata
   // (DataSource.getObjectSchema). We also resolve when columns are hand-authored
-  // as bare `{ field, label }` (no `type`): those need their widget type
+  // as bare `{ name, label }` (no `type`): those need their widget type
   // hydrated from the child schema, else every cell falls back to a text input.
   const needsDerive = rawDetails.some(
     (d) => !d.relationshipField || !d.columns?.length || d.columns.some((c) => !c.type),

--- a/packages/plugin-form/src/ObjectForm.test.tsx
+++ b/packages/plugin-form/src/ObjectForm.test.tsx
@@ -318,7 +318,7 @@ describe('ObjectForm Integration', () => {
                     mode: 'create',
                     subforms: [
                         { childObject: 'test_line', relationshipField: 'parent', title: 'Lines',
-                          columns: [{ field: 'qty', type: 'number' }] },
+                          columns: [{ name: 'qty', type: 'number' }] },
                     ],
                 } as any}
                 dataSource={ds}

--- a/packages/plugin-form/src/deriveMasterDetail.declaredSpelling.test.tsx
+++ b/packages/plugin-form/src/deriveMasterDetail.declaredSpelling.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3951, master-detail half — the derivation is a PRODUCER of the very
+ * columns `GridField` consumes, so it must emit the declared spelling
+ * (`GridColumnDefinition.name`) and read author-supplied columns by the same
+ * key. Before the fix `deriveColumns` emitted `{ field: name, … }` and
+ * `hydrateColumns` looked the child field up as `fields[col.field]`: that pair
+ * agreed with the widget's old `c.field` reader, which is precisely why the
+ * master-detail path worked while spec-compliant hand-authored metadata did
+ * not.
+ *
+ * The end-to-end case below is the one that would have caught #3951 from
+ * either side: derived columns are fed straight into the real widget, so
+ * producer and reader can never again drift onto two different keys while both
+ * halves' own unit tests stay green.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { GridField } from '@object-ui/fields';
+import { deriveColumns, hydrateColumns, deriveDetail } from './deriveMasterDetail';
+
+const lineSchema = {
+  name: 'expense_line',
+  fields: {
+    id: { type: 'text', system: true },
+    description: { type: 'text', label: 'Description', required: true },
+    quantity: { type: 'number', label: 'Qty' },
+    amount: { type: 'currency', label: 'Amount' },
+    expense_claim: { type: 'master_detail', label: 'Claim', reference: 'expense_claim' },
+  },
+};
+
+describe('deriveMasterDetail speaks the declared column spelling (objectui#3951)', () => {
+  it('deriveColumns emits `name`, and no column carries the retired `field` key', () => {
+    const cols = deriveColumns(lineSchema, { relationshipField: 'expense_claim' });
+    expect(cols.map((c) => c.name)).toEqual(['description', 'quantity', 'amount']);
+    for (const c of cols) expect(c).not.toHaveProperty('field');
+  });
+
+  it('hydrateColumns resolves a bare `name`-keyed author column against the child schema', () => {
+    const [col] = hydrateColumns([{ name: 'amount' }] as any, lineSchema);
+    expect(col).toMatchObject({ name: 'amount', type: 'currency', label: 'Amount' });
+  });
+
+  it('a `field`-keyed column is NOT silently rehabilitated (no tolerant dual-read)', () => {
+    // AGENTS.md #0.1: the retired spelling stops being understood — it is not
+    // aliased onto `name`. The column passes through untouched (no `type`
+    // resolved, no label filled), which is the visible, debuggable outcome.
+    const [col] = hydrateColumns([{ field: 'amount' }] as any, lineSchema);
+    expect(col).toEqual({ field: 'amount' });
+    expect(col).not.toHaveProperty('name');
+  });
+
+  it('deriveDetail picks the running-total column by its declared name', () => {
+    const d = deriveDetail('expense_line', lineSchema, 'expense_claim');
+    expect(d.amountField).toBe('amount');
+    expect(d.columns.map((c) => c.name)).toContain('amount');
+  });
+
+  it('end to end: derived columns render POPULATED cells in the real GridField', () => {
+    const { columns } = deriveDetail('expense_line', lineSchema, 'expense_claim');
+    render(
+      <GridField
+        value={[{ description: 'Taxi to airport', quantity: 1, amount: 42.5 }]}
+        onChange={() => {}}
+        field={{ columns } as any}
+      />,
+    );
+    expect((screen.getAllByLabelText('Description')[0] as HTMLInputElement).value).toBe('Taxi to airport');
+    expect((screen.getAllByLabelText('Qty')[0] as HTMLInputElement).value).toBe('1');
+    expect((screen.getAllByLabelText('Amount')[0] as HTMLInputElement).value).toBe('42.5');
+  });
+});

--- a/packages/plugin-form/src/deriveMasterDetail.test.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.test.ts
@@ -70,7 +70,7 @@ describe('findRelationshipField', () => {
 describe('deriveColumns', () => {
   it('derives editable columns, skipping system/audit/FK/non-editable fields', () => {
     const cols = deriveColumns(taskSchema, { relationshipField: 'project' });
-    const names = cols.map((c) => c.field);
+    const names = cols.map((c) => c.name);
     expect(names).toEqual(['title', 'status', 'estimate_hours', 'budget', 'due_date', 'assignee']);
     // id (system), created_at (audit), project (FK), health (formula) excluded
     expect(names).not.toContain('id');
@@ -81,7 +81,7 @@ describe('deriveColumns', () => {
 
   it('carries type, options, required and lookup reference through', () => {
     const cols = deriveColumns(taskSchema, { relationshipField: 'project' });
-    const byName = Object.fromEntries(cols.map((c) => [c.field, c]));
+    const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
     expect(byName.title).toMatchObject({ type: 'text', label: 'Title', required: true });
     expect(byName.status).toMatchObject({ type: 'select', options: [{ label: 'To Do', value: 'todo' }, { label: 'Done', value: 'done' }] });
     expect(byName.estimate_hours.type).toBe('number');
@@ -102,7 +102,7 @@ describe('deriveColumns', () => {
         memo: { type: 'text', label: 'Memo', conditionalRequired: 'record.qty >= 1' },
       },
     };
-    const byName = Object.fromEntries(deriveColumns(schema, { relationshipField: 'parent' }).map((c) => [c.field, c]));
+    const byName = Object.fromEntries(deriveColumns(schema, { relationshipField: 'parent' }).map((c) => [c.name, c]));
     expect(byName.qty.readonlyWhen).toBe("parent.status == 'paid'");
     expect(byName.note.requiredWhen).toBe('record.qty >= 100');
     expect(byName.memo.requiredWhen).toBeUndefined();
@@ -118,7 +118,7 @@ describe('deriveColumns', () => {
         photo: { type: 'image', label: 'Photo' },
       },
     };
-    const byName = Object.fromEntries(deriveColumns(schema, { relationshipField: 'expense' }).map((c) => [c.field, c]));
+    const byName = Object.fromEntries(deriveColumns(schema, { relationshipField: 'expense' }).map((c) => [c.name, c]));
     expect(byName.receipt).toMatchObject({ type: 'file', multiple: true, accept: ['image/*', '.pdf'] });
     // Image fields restrict the picker to images when no accept list is declared.
     expect(byName.photo).toMatchObject({ type: 'file', accept: ['image/*'] });
@@ -145,7 +145,7 @@ describe('deriveColumns curation (column budget)', () => {
     },
   };
 
-  const visible = (cols: any[]) => cols.filter((c) => !c.defaultHidden).map((c) => c.field);
+  const visible = (cols: any[]) => cols.filter((c) => !c.defaultHidden).map((c) => c.name);
 
   it('returns ALL columns — none dropped — and defaults a focused 6 visible', () => {
     const cols = deriveColumns(wideSchema, { relationshipField: 'parent' });
@@ -162,14 +162,14 @@ describe('deriveColumns curation (column budget)', () => {
 
   it('collapses low-signal text columns into the chooser (hidden, not dropped)', () => {
     const cols = deriveColumns(wideSchema, { relationshipField: 'parent' });
-    const byName = Object.fromEntries(cols.map((c) => [c.field, c]));
+    const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
     expect(byName.notes).toBeDefined();
     expect(byName.notes.defaultHidden).toBe(true);
     expect(byName.labels.defaultHidden).toBe(true);
   });
 
   it('preserves schema order (including hidden columns)', () => {
-    const names = deriveColumns(wideSchema, { relationshipField: 'parent' }).map((c) => c.field);
+    const names = deriveColumns(wideSchema, { relationshipField: 'parent' }).map((c) => c.name);
     const sorted = [...names].sort(
       (a, b) => Object.keys(wideSchema.fields).indexOf(a) - Object.keys(wideSchema.fields).indexOf(b),
     );
@@ -198,7 +198,7 @@ describe('deriveColumns curation (column budget)', () => {
     };
     const cols = deriveColumns(reqHeavy, { relationshipField: 'parent' });
     expect(visible(cols)).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']); // 7 required visible
-    expect(cols.find((c) => c.field === 'h')?.defaultHidden).toBe(true); // non-required collapsed
+    expect(cols.find((c) => c.name === 'h')?.defaultHidden).toBe(true); // non-required collapsed
     expect(cols.length).toBe(8); // nothing dropped
   });
 });
@@ -241,19 +241,19 @@ describe('deriveFormFields (per-row expand form)', () => {
 });
 
 describe('hydrateColumns (fill types on bare author columns)', () => {
-  it('infers each bare {field,label} column\'s widget type from the child schema', () => {
+  it('infers each bare {name,label} column\'s widget type from the child schema', () => {
     const cols = hydrateColumns(
       [
-        { field: 'title', label: 'Title' },
-        { field: 'status', label: 'Status' },
-        { field: 'estimate_hours', label: 'Est' },
-        { field: 'budget', label: 'Budget' },
-        { field: 'due_date', label: 'Due' },
-        { field: 'assignee', label: 'Owner' },
+        { name: 'title', label: 'Title' },
+        { name: 'status', label: 'Status' },
+        { name: 'estimate_hours', label: 'Est' },
+        { name: 'budget', label: 'Budget' },
+        { name: 'due_date', label: 'Due' },
+        { name: 'assignee', label: 'Owner' },
       ] as any,
       taskSchema,
     );
-    const byName = Object.fromEntries(cols.map((c) => [c.field, c]));
+    const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
     expect(byName.title.type).toBe('text');
     expect(byName.status).toMatchObject({ type: 'select', options: [{ label: 'To Do', value: 'todo' }, { label: 'Done', value: 'done' }] });
     expect(byName.estimate_hours.type).toBe('number');
@@ -264,10 +264,10 @@ describe('hydrateColumns (fill types on bare author columns)', () => {
 
   it('preserves the author\'s column set, order and labels', () => {
     const cols = hydrateColumns(
-      [{ field: 'due_date', label: '合同时间' }, { field: 'status', label: 'Status' }] as any,
+      [{ name: 'due_date', label: '合同时间' }, { name: 'status', label: 'Status' }] as any,
       taskSchema,
     );
-    expect(cols.map((c) => c.field)).toEqual(['due_date', 'status']); // order kept, no extra columns
+    expect(cols.map((c) => c.name)).toEqual(['due_date', 'status']); // order kept, no extra columns
     expect(cols[0].label).toBe('合同时间'); // author label kept, not schema's "Due Date"
   });
 
@@ -279,14 +279,14 @@ describe('hydrateColumns (fill types on bare author columns)', () => {
         photo: { type: 'image', label: 'Photo' },
       },
     };
-    const cols = hydrateColumns([{ field: 'receipt' }, { field: 'photo' }] as any, schema);
+    const cols = hydrateColumns([{ name: 'receipt' }, { name: 'photo' }] as any, schema);
     expect(cols[0]).toMatchObject({ type: 'file', multiple: true, accept: ['.pdf'] });
     expect(cols[1]).toMatchObject({ type: 'file', accept: ['image/*'] });
   });
 
   it('never overrides an explicit type the author already set', () => {
     const cols = hydrateColumns(
-      [{ field: 'status', label: 'Status', type: 'text' }] as any,
+      [{ name: 'status', label: 'Status', type: 'text' }] as any,
       taskSchema,
     );
     expect(cols[0].type).toBe('text'); // author wins — not upgraded to select
@@ -294,12 +294,12 @@ describe('hydrateColumns (fill types on bare author columns)', () => {
   });
 
   it('leaves a column untouched when its field is absent from the schema', () => {
-    const cols = hydrateColumns([{ field: 'ghost', label: 'Ghost' }] as any, taskSchema);
+    const cols = hydrateColumns([{ name: 'ghost', label: 'Ghost' }] as any, taskSchema);
     expect(cols[0].type).toBeUndefined(); // unknown field → grid falls back to text
   });
 
   it('is a no-op without a schema or columns', () => {
-    expect(hydrateColumns([{ field: 'x' }] as any, undefined)).toEqual([{ field: 'x' }]);
+    expect(hydrateColumns([{ name: 'x' }] as any, undefined)).toEqual([{ name: 'x' }]);
     expect(hydrateColumns(undefined, taskSchema)).toEqual([]);
   });
 });
@@ -308,12 +308,12 @@ describe('deriveDetail hydrates explicit-but-untyped override columns', () => {
   it('fills widget types on bare author columns instead of passing them through raw', () => {
     const d = deriveDetail('showcase_task', taskSchema, 'showcase_project', {
       relationshipField: 'project',
-      columns: [{ field: 'status', label: 'Status' }, { field: 'due_date', label: 'Due' }] as any,
+      columns: [{ name: 'status', label: 'Status' }, { name: 'due_date', label: 'Due' }] as any,
     });
-    const byName = Object.fromEntries(d.columns.map((c) => [c.field, c]));
+    const byName = Object.fromEntries(d.columns.map((c) => [c.name, c]));
     expect(byName.status.type).toBe('select');
     expect(byName.due_date.type).toBe('date');
-    expect(d.columns.map((c) => c.field)).toEqual(['status', 'due_date']); // author set kept
+    expect(d.columns.map((c) => c.name)).toEqual(['status', 'due_date']); // author set kept
   });
 });
 
@@ -377,7 +377,7 @@ describe('deriveDetail', () => {
   it('resolves relationshipField + columns + amountField from the child schema', () => {
     const d = deriveDetail('showcase_task', taskSchema, 'showcase_project');
     expect(d.relationshipField).toBe('project');
-    expect(d.columns.map((c) => c.field)).toContain('estimate_hours');
+    expect(d.columns.map((c) => c.name)).toContain('estimate_hours');
     // The running total prefers the (last) currency column over a raw number
     // like hours — a line-grid footer is almost always a money total.
     expect(d.amountField).toBe('budget');
@@ -395,7 +395,7 @@ describe('deriveDetail', () => {
       },
     };
     const d = deriveDetail('inv_line', lineSchema, 'inv');
-    const amountCol = d.columns.find((c) => c.field === 'amount')!;
+    const amountCol = d.columns.find((c) => c.name === 'amount')!;
     expect(amountCol.computed).toBe(true);
     expect(amountCol.expr).toBe('record.quantity * record.unit_price');
     expect(amountCol.required).toBe(false); // computed → never user-required
@@ -413,15 +413,15 @@ describe('deriveDetail', () => {
     };
     const d = deriveDetail('inv_line', lineSchema, 'inv');
     expect(d.sortField).toBe('position');
-    expect(d.columns.map((c) => c.field)).not.toContain('position'); // not user-edited
+    expect(d.columns.map((c) => c.name)).not.toContain('position'); // not user-edited
     expect(d.formFields).not.toContain('position');
-    expect(d.columns.map((c) => c.field)).toEqual(['product', 'quantity']);
+    expect(d.columns.map((c) => c.name)).toEqual(['product', 'quantity']);
   });
 
   it('honors explicit overrides over derived values', () => {
     const d = deriveDetail('showcase_task', taskSchema, 'showcase_project', {
       relationshipField: 'project',
-      columns: [{ field: 'title', type: 'text' }],
+      columns: [{ name: 'title', type: 'text' }],
       amountField: 'budget',
     });
     expect(d.columns).toHaveLength(1);

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -182,19 +182,19 @@ function fillPriority(col: GridColumn): number {
 function curateColumns(cols: GridColumn[], max: number): GridColumn[] {
   if (max <= 0 || cols.length <= max) return cols;
   const visible = new Set<string>();
-  const primary = cols.find((c) => NAME_LIKE_FIELDS.includes(c.field)) ?? cols[0];
-  if (primary) visible.add(primary.field);
-  for (const c of cols) if (c.required) visible.add(c.field); // required is always visible
+  const primary = cols.find((c) => NAME_LIKE_FIELDS.includes(c.name)) ?? cols[0];
+  if (primary) visible.add(primary.name);
+  for (const c of cols) if (c.required) visible.add(c.name); // required is always visible
   const remaining = cols
     .map((c, i) => ({ c, i }))
-    .filter(({ c }) => !visible.has(c.field))
+    .filter(({ c }) => !visible.has(c.name))
     .sort((a, b) => fillPriority(a.c) - fillPriority(b.c) || a.i - b.i);
   for (const { c } of remaining) {
     if (visible.size >= max) break;
-    visible.add(c.field);
+    visible.add(c.name);
   }
   // Keep every column; collapse the overflow into the chooser.
-  return cols.map((c) => (visible.has(c.field) ? c : { ...c, defaultHidden: true }));
+  return cols.map((c) => (visible.has(c.name) ? c : { ...c, defaultHidden: true }));
 }
 
 /**
@@ -218,7 +218,7 @@ export function deriveColumns(
     if (d?.system || d?.readonly || d?.hidden) continue;
     if (NON_EDITABLE_TYPES.has(d?.type)) continue;
     const col: GridColumn = {
-      field: name,
+      name,
       label: d?.label || name,
       type: fieldTypeToColumnType(d?.type),
       required: !!d?.required,
@@ -254,7 +254,7 @@ export function deriveColumns(
 /**
  * Fill in missing widget metadata on author-supplied grid columns from the
  * child object's field definitions. A view often lists columns as bare
- * `{ field, label }` (the common, ergonomic authoring form) — without a `type`
+ * `{ name, label }` (the common, ergonomic authoring form) — without a `type`
  * those cells fall back to a plain text `<Input>`, so a lookup, date, number or
  * picklist field silently renders as free text. This resolves each such
  * column's `type` (plus `options` / `reference` / computed `expr`) from the
@@ -271,11 +271,11 @@ export function hydrateColumns(
   if (!cols.length || !fields || typeof fields !== 'object') return cols;
   return cols.map((col) => {
     if (col.type) return col; // explicit type — respect the author's choice
-    const d = (fields as any)[col.field];
+    const d = (fields as any)[col.name];
     if (!d) return col; // unknown field — leave as-is (grid falls back to text)
     const type = fieldTypeToColumnType(d?.type);
     const next: GridColumn = { ...col, type };
-    if (next.label == null) next.label = d?.label || col.field;
+    if (next.label == null) next.label = d?.label || col.name;
     if (next.required == null) next.required = !!d?.required;
     const options = optionsFor(d);
     if (type === 'select' && options && !next.options) next.options = options;
@@ -395,12 +395,12 @@ function pickAmountField(columns: GridColumn[]): string | undefined {
   const numeric = columns.filter((c) => c.type === 'number' || c.type === 'currency');
   if (numeric.length === 0) return undefined;
   const computed = numeric.find((c) => c.computed);
-  if (computed) return computed.field;
-  const named = numeric.find((c) => AMOUNT_LIKE_FIELDS.includes(c.field));
-  if (named) return named.field;
+  if (computed) return computed.name;
+  const named = numeric.find((c) => AMOUNT_LIKE_FIELDS.includes(c.name));
+  if (named) return named.name;
   const lastCurrency = [...numeric].reverse().find((c) => c.type === 'currency');
-  if (lastCurrency) return lastCurrency.field;
-  return numeric[numeric.length - 1].field;
+  if (lastCurrency) return lastCurrency.name;
+  return numeric[numeric.length - 1].name;
 }
 
 export interface DerivedDetail {

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -287,9 +287,9 @@ import { LineItemsPanel } from './LineItemsPanel';
  *    must name a field ON the bound child object. Rebinding `object` without
  *    updating it is an authoring error the panel cannot paper over.
  *  - `columns` is NOT a field-name projection here. It is `GridColumn[]`
- *    (`{ field, type, options, computed, expr, … }`) driving an EDITABLE grid; a
+ *    (`{ name, type, options, computed, expr, … }`) driving an EDITABLE grid; a
  *    saved view's column list would arrive as bare names and render a grid of
- *    column definitions with no `field`. Wrong shape, not merely a wider answer.
+ *    column definitions with no `name`. Wrong shape, not merely a wider answer.
  *
  * So a `view` named on this block now contributes its filter, sort and page size
  * to the child query (and an unresolvable name still reports instead of silently

--- a/packages/plugin-form/src/subformHosts.test.tsx
+++ b/packages/plugin-form/src/subformHosts.test.tsx
@@ -22,7 +22,7 @@ const ds: any = {
   batchTransaction: vi.fn(),
 };
 
-const subforms = [{ childObject: 'expense_line', relationshipField: 'claim', title: 'Lines', columns: [{ field: 'amount', type: 'number' }] }];
+const subforms = [{ childObject: 'expense_line', relationshipField: 'claim', title: 'Lines', columns: [{ name: 'amount', type: 'number' }] }];
 
 beforeEach(() => vi.clearAllMocks());
 


### PR DESCRIPTION
Fixes #3951

按 2026-08-10 维护者裁定实施:**已发布的声明拼写胜出,修 reader**。`GridField` 对齐 `GridColumnDefinition`(`@object-ui/types`)读 `name`,master-detail 派生侧(`deriveColumns` / `hydrateColumns` / `pickAmountField`)随迁。**没有** `col.field ?? col.name` 别名 —— 一套拼写落在生产者侧,AGENTS.md #0.1。

## 前提复核(改前先验)

卡面写于 2026-08-09,行号已随文件增长漂移(正文的 `:558/:590/:620` 现为 `:659/:689/…`),但**前提完全成立**:

- `packages/types/src/field-types.ts:677` `GridColumnDefinition.name` 是 `GridFieldMetadata.columns` 的声明类型 —— 现状未变。
- `packages/fields/src/widgets/GridField.tsx` 本地 `GridColumn` 声明 `field: string`,31 处 `c.field` 读点,无任何 normalize —— 现状未变。
- `content/docs/fields/grid.mdx`:散文、`ColumnDefinition` interface、三组 pattern 示例**全部**是 `name` 侧;页内唯一 `field` 键的代码块是 `object-grid`(plugin-grid 的 `ListColumn`,另一份契约,已在原文注明)。**核实无误,未反向改动。**
- `examples/schema-catalog/src/schemas/fields-grid/` 三例 9 个列条目**全部** `name` 侧。**核实无误,未反向改动。**

## 存量 `field` 拼写普查(仅 grid-field 列,即 `GridColumnDefinition` / `GridColumn`)

甄别口径:list view / `object-grid` 的 `ListColumn`、record picker 的 `LookupColumnDef`、`sort` / `filter` 子句、form section 的 `field` 都是**另外的契约**,合法保留 `field`,不计入、不改动。

| 面 | `field` 拼写 | 说明 |
|---|---|---|
| stored / example metadata(`objectstack` 仓 `examples/app-crm`、`app-showcase`、`app-todo` 的 `inlineColumns`) | **0** | 例应用的 inline grid 全部走自动派生,无显式 columns;`relatedListColumns` 是裸字符串数组,`lookupColumns` 是 record picker 契约 |
| `examples/schema-catalog` fields-grid 三例(9 条) | **0** | 本就 `name` 侧 |
| `content/docs/fields/grid.mdx` | **0** | 本就 `name` 侧 |
| `apps/**` | **7 处 / 2 文件** | 均为 dev harness(`DevLookup` / `DevMasterDetail`),已逐处改拼写 |
| 仓内源码 + fixture + ADR 示例 | **143 处 / 16 文件** | 见下迁移清单 |

**结论:授权侧(stored/example metadata)存量为 0,无需数据迁移;转换面全部落在仓内代码、dev harness 与 ADR 示例,已逐处显式改写,无兼容层。**

## 迁移清单

**Reader / producer(行为改动)**

- `packages/fields/src/widgets/GridField.tsx` —— `GridColumn.field` 改为 `name`(带注释锚定 #3951 与「不设别名」),31 处读点全迁:`key=`、`row[…]`、`blank[…]`、`applyCell`、`columns.findIndex`、`extraShown.has`、`data-computed`、`aria-label` 兜底等;两个局部形参 `field: string` 更名 `columnName`,免得退役拼写在读路径上留影子。
- `packages/plugin-form/src/deriveMasterDetail.ts` —— `deriveColumns` 产出 `{ name, … }`;`hydrateColumns` 改查 `fields[col.name]`;`curateColumns` / `pickAmountField` 全部按 `name` 判定。

**Fixture / harness / 文档示例(拼写对齐)**

`GridField.test.tsx`、`date-locale-channel.test.tsx`、`complex-widgets.test.tsx`、`deriveMasterDetail.test.ts`、`LineItemsPanel.test.tsx`、`LineItemsPanel.elementDataSource.test.tsx`、`MasterDetailForm.test.tsx`、`MasterDetailForm.elementDataSource.test.tsx`、`ObjectForm.test.tsx`、`subformHosts.test.tsx`、`MetadataProvider.merge.test.ts`(subform columns 那一条;同文件的 list view columns **保持** `field` 不动)、`apps/console/src/dev/DevLookup.tsx`、`DevMasterDetail.tsx`、`docs/adr/0001-master-detail-subform.md`(两处授权示例,ADR 原文自称「reuses the existing `GridColumnDefinition` shape」却写着 `field`,正是本卡记录的分歧本身)。

消费半径按**规则被谁读**扫,不按被改包扫:`GridColumn` 的 TS 消费者只有 plugin-form(LineItemsPanel / MasterDetailForm / deriveMasterDetail);plugin-grid 的 `VirtualGridColumn` / `ObjectGridColumnState` 是另一套类型,未涉及。

## 新增钉(pin,纪律同 #4041)

- `packages/fields/src/widgets/GridField.declaredSpelling.test.tsx` —— fixture **以 `GridColumnDefinition[]` 显式标注类型**(钉在声明契约上,而不是 widget 自己的理解上),断言单元格逐格非空、只读面有值、空行按声明列名开、编辑按声明列名回写。
- `packages/fields/src/widgets/GridField.keyWarning.test.tsx` —— React missing-key 警告那一半,**单独成文件**。原因见下。
- `packages/plugin-form/src/deriveMasterDetail.declaredSpelling.test.tsx` —— master-detail 路径的钉:产出/消费均为 `name`、`field` 键列**不被容忍性复活**、以及一条端到端(派生列直接喂进真 `GridField`,渲染出非空单元格)—— 生产者与消费者再也不能各说各话而两边单测都绿。

### 一处必须讲清的测试设计

key 警告最初和「单元格非空」放在同一文件的第二个用例里,**反向验证时它没有变红**。查因:React 的 missing-key 警告对同一 owner 组件**只发一次**,第一个用例的渲染已经把它消费掉,第二个用例观察到的是「什么都没有」—— 断言绿是因为没东西可看,不是因为逻辑对。这正是「空绿」陷阱,故拆成独立文件(`dom` project 是 `isolate: true`,按文件隔离,能保证它拥有首次渲染),并加了一个**阳性对照**:先渲染一个故意不带 key 的列表,断言 spy 确实抓得到警告,再断言 grid 自己的渲染没有**新增**警告。这样绿是被证明过的绿。

## 反向验证(先预判、后执行;变异前已 commit,还原用 `git checkout HEAD --`,未用 stash)

**预判方向:Red(常规向)** —— reader 读的键是 fixture 不拼写的那个,还原退役读法会同时抽掉「值」和「诊断」,不是只动诊断。

**变异一:reader 还原成读 `c.field`**(`git checkout 97da1b0d6 -- GridField.tsx`),fixture 保持 `name`:

```
FAIL  keyWarning       · 无 unique key 警告      → expected 2 to be 1  (对照 1 条 + grid 新增 1 条)
FAIL  declaredSpelling · 单元格逐格非空          → expected '' to be 'Widget A'
FAIL  declaredSpelling · 只读面有值              → Unable to find an element with the text: Widget A
FAIL  declaredSpelling · 空行按声明列名开        → expected [ { product: null, …(2) } ]
FAIL  declaredSpelling · 编辑按声明列名回写      → expected [ { product: 'Widget A', … } ]
FAIL  deriveMasterDetail · 端到端渲染非空        → expected '' to be 'Taxi to airport'
PASS  deriveMasterDetail · 纯派生 4 例保持绿(变异未触及生产者)
   Tests  6 failed | 4 passed (10)
```

与预判一致:值与诊断同时变红,派生侧不受影响的 4 例如期保持绿。

**变异二:生产者还原成产出 `field: name` 且 `hydrateColumns` 查 `col.field`**(reader 保持已修):

```
FAIL  deriveColumns 产出 name  → expected [ undefined, undefined, undefined ] to deeply equal [ 'description', 'quantity', 'amount' ]
FAIL  hydrateColumns 认 name   → expected { name: 'amount' } to match object { name: 'amount', …(2) }
FAIL  field 键不被容忍性复活   → expected { field: 'amount', …(3) } to deeply equal { field: 'amount' }
FAIL  amountField 按 name 选   → expected undefined to be 'amount'
FAIL  端到端渲染非空           → expected '' to be 'Taxi to airport'
   Tests  5 failed (5)
```

第三条按预期**反向**变红:旧生产者读 `col.field`,`{ field: 'amount' }` 反而被补全了 type/label —— 恰好把「容忍性双读会长回来」这件事钉住。

两次变异后均 `git checkout HEAD -- ` 还原,复跑全绿。

## 验证

```
pnpm exec vitest run packages/fields/src/widgets/ packages/plugin-form/ --maxWorkers=2
   Test Files  101 passed (101)
        Tests  1001 passed (1001)
     Duration  238.88s

pnpm exec turbo run type-check --concurrency=2
   Tasks:    81 successful, 81 total

node scripts/check-control-bytes.mjs
   check-control-bytes: OK (scanned 4389 tracked text file(s); skipped 85 binary)
```

(全部重验证经 `flock /tmp/os-heavy-verify.lock` 串行,`NODE_OPTIONS=--max-old-space-size=4096`,`--maxWorkers=2`。)

## Breaking change 与 changeset

`.changeset/grid-column-declared-name-spelling.md`(patch,`@object-ui/fields` + `@object-ui/plugin-form`)已写明:作者显式提供的 grid / line-items / master-detail subform 列必须由 `{ field: 'amount' }` 改写为 `{ name: 'amount' }`;自动派生列(未写 `columns`)无需改动;list view 与 `object-grid` 的 `ListColumn` 是另一份契约,保留自己的 `field` 键。

## 顺带发现(未在本 PR 修)

- objectstack#9227 —— `Field.inlineColumns` 在 spec 里是 `z.array(z.any())`,任何拼错的列键都能发布通过、只在浏览器里表现为空单元格。本 PR 修好了 renderer,但授权面仍然没有守卫;例应用中该键用量为 0,故对本仓无影响,已另立卡(未指派)。
