### PR TITLE
test(components): re-express the two element:* spec-parity contrast probes pin-aware for GA's strict flip (#4910)

### DIFF
--- a/.changeset/strict-mode-parity-probes-4910.md
+++ b/.changeset/strict-mode-parity-probes-4910.md
@@ -1,0 +1,27 @@
+---
+---
+
+Test-only (objectui#4910). The two `element:*` spec-parity tests in
+`packages/components/src/__tests__/` — `text-input-inputs-spec-parity.test.ts` and
+`record-picker-inputs-spec-parity.test.ts` — re-express their undeclared-key contrast probe
+so it holds on both `@objectstack/spec` pins.
+
+`@objectstack/spec@17.0.0` GA flipped the `element:*` props schemas from strip mode to
+strict (objectstack#4001 batch A): an undeclared prop used to parse green and vanish from
+`data`, and now fails with `unrecognized_keys` naming the key. Each probe existed to keep
+the surrounding key-reachability claim non-vacuous — it shows what an *unpublished* key
+looks like, so "the declared key survives the parse" means something — and it asserted the
+strip-mode half as its control, which GA falsifies.
+
+Both probes now read the installed spec's refusal mode **behaviourally** (parse a payload
+carrying a key no spec declares) and assert the same verdict under either mode: a named
+`unrecognized_keys` refusal under GA, a silent drop under the pinned `17.0.0-rc.6`. Neither
+arm is vacuous, and the probe never reads a version string, so it cannot go stale against a
+pin it does not observe. The undeclared key is now carried alongside the declared one, which
+is what makes either arm attributable to the undeclared key rather than to the declared key
+having gone bad. This is the disposition already taken by
+`packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts`
+(objectui#4648 / PR #4671).
+
+No published behaviour changes: no runtime source, no registration, and no gate was touched
+— only the two test files.

--- a/packages/components/src/__tests__/record-picker-inputs-spec-parity.test.ts
+++ b/packages/components/src/__tests__/record-picker-inputs-spec-parity.test.ts
@@ -69,6 +69,31 @@ const filterDescription = () => input('filter')?.description ?? '';
  */
 const withFilter = (filter: unknown) => ({ object: 'account', filter });
 
+/**
+ * Does the installed spec REFUSE an undeclared top-level key, or drop it in
+ * silence? (objectui#4910, measured on both pins.)
+ *
+ * `@objectstack/spec` 17.0.0 GA flipped the `element:*` props schemas from
+ * strip mode to strict under objectstack#4001 batch A, so an undeclared prop
+ * now raises `unrecognized_keys` with a named message; the pinned
+ * `17.0.0-rc.6` still drops it in silence. The VERDICT under test is identical
+ * either way — an undeclared key is not an authoring surface, which is the
+ * whole reason "the declared key survives the parse" says anything — but the
+ * EVIDENCE differs, and asserting the wrong one turns this file red for a
+ * reason that has nothing to do with what it guards.
+ *
+ * Probed behaviourally rather than off a version string: the strictness IS the
+ * fact this file cares about, a probe cannot go stale against a pin it never
+ * reads, and the probe key is a name no spec would ever declare. `object` is
+ * carried because it is required, so a refusal here can only be the probe key.
+ * Same shape as `recordHighlightsInputs.spec-parity.test.ts`, which took this
+ * disposition first (objectui#4648 / PR #4671).
+ */
+const specRefusesUnknownTopLevelKeys = !ElementRecordPickerPropsSchema.safeParse({
+  object: 'account',
+  __objectui_4910_probe__: true,
+} as never).success;
+
 describe('element:record_picker — registry inputs vs @objectstack/spec', () => {
   it('is registered with a non-empty `inputs` surface', () => {
     expect(config()).toBeDefined();
@@ -83,23 +108,50 @@ describe('element:record_picker — registry inputs vs @objectstack/spec', () =>
 
   it('publishes `filter`, which the renderer has read all along', () => {
     // A KEY-reachability claim, so the criterion is that the key SURVIVES the
-    // parse — not that the parse succeeds. This props schema is a strip-mode
-    // `z.object`, so an UNDECLARED key parses green too and is simply absent
-    // from `data` afterwards; asserting `success` alone would prove nothing.
+    // parse — not that the parse succeeds. Neither refusal mode makes
+    // `success === true` proof on its own: under rc.6's strip mode an
+    // UNDECLARED key parses green as well, and under GA's strict mode a green
+    // parse only reports that no undeclared key was present. Survival is the
+    // claim on both pins.
     expect(specTopLevelKeys()).toContain('filter');
     const parsed = ElementRecordPickerPropsSchema.safeParse(withFilter({ status: 'open' }));
     expect(parsed.success).toBe(true);
     expect(parsed.data?.filter).toEqual({ status: 'open' });
 
-    // The contrast that makes the criterion meaningful: same green parse, key
-    // gone, no diagnostic. That is what `filter` looked like to every manifest
-    // consumer before it was declared here.
+    // The contrast that makes the criterion meaningful: the SAME payload plus a
+    // key the spec does not declare. Two contract spellings, one verdict — the
+    // undeclared key never becomes authoring surface (see
+    // `specRefusesUnknownTopLevelKeys`). Carrying `filter` alongside is
+    // load-bearing rather than tidy: it is what makes either arm attributable
+    // to `notASpecKey` instead of to the declared key having gone bad, and the
+    // green parse asserted just above is what proves the base is valid.
     const undeclared = ElementRecordPickerPropsSchema.safeParse({
-      object: 'account',
+      ...withFilter({ status: 'open' }),
       notASpecKey: 1,
     } as never);
-    expect(undeclared.success).toBe(true);
-    expect(Object.keys(undeclared.data ?? {})).not.toContain('notASpecKey');
+
+    if (specRefusesUnknownTopLevelKeys) {
+      // 17.0.0 GA: a loud refusal, and the STRONGER guarantee — the author now
+      // gets told. Asserted as an envelope (the code AND the key it names)
+      // because a bare "it failed" would be satisfied just as well by a
+      // rejection of `filter` or `object`, the halves that have to stay valid.
+      expect(undeclared.success).toBe(false);
+      expect(undeclared.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+      const refused = undeclared.error?.issues.flatMap(
+        (i) => (i as unknown as { keys?: string[] }).keys ?? [],
+      );
+      expect(refused).toContain('notASpecKey');
+      expect(refused).not.toContain('filter');
+      expect(refused).not.toContain('object');
+    } else {
+      // The pinned rc.6: same green parse, key gone, no diagnostic. That is
+      // what `filter` looked like to every manifest consumer before it was
+      // declared here — and the silent-drop harm objectstack#4001 batch A
+      // retired.
+      expect(undeclared.success).toBe(true);
+      expect(Object.keys(undeclared.data ?? {})).not.toContain('notASpecKey');
+      expect(undeclared.data?.filter).toEqual({ status: 'open' });
+    }
 
     expect(inputNames()).toContain('filter');
     expect(filterDescription()).not.toBe('');

--- a/packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts
+++ b/packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts
@@ -49,6 +49,29 @@ const inputNames = () => inputs().map((i) => i.name);
 const input = (name: string) => inputs().find((i) => i.name === name);
 const defaultValueDescription = () => input('defaultValue')?.description ?? '';
 
+/**
+ * Does the installed spec REFUSE an undeclared top-level key, or drop it in
+ * silence? (objectui#4910, measured on both pins.)
+ *
+ * `@objectstack/spec` 17.0.0 GA flipped the `element:*` props schemas from
+ * strip mode to strict under objectstack#4001 batch A, so an undeclared prop
+ * now raises `unrecognized_keys` with a named message; the pinned
+ * `17.0.0-rc.6` still drops it in silence. The VERDICT under test is identical
+ * either way — an undeclared key is not an authoring surface, which is the
+ * whole reason "the declared key survives the parse" says anything — but the
+ * EVIDENCE differs, and asserting the wrong one turns this file red for a
+ * reason that has nothing to do with what it guards.
+ *
+ * Probed behaviourally rather than off a version string: the strictness IS the
+ * fact this file cares about, a probe cannot go stale against a pin it never
+ * reads, and the probe key is a name no spec would ever declare. Same shape as
+ * `recordHighlightsInputs.spec-parity.test.ts`, which took this disposition
+ * first (objectui#4648 / PR #4671).
+ */
+const specRefusesUnknownTopLevelKeys = !ElementTextInputPropsSchema.safeParse({
+  __objectui_4910_probe__: true,
+} as never).success;
+
 describe('element:text_input — registry inputs vs @objectstack/spec', () => {
   it('is registered with a non-empty `inputs` surface', () => {
     expect(config()).toBeDefined();
@@ -68,20 +91,49 @@ describe('element:text_input — registry inputs vs @objectstack/spec', () => {
 
   it('publishes `defaultValue`, which the renderer has read all along', () => {
     // A KEY-reachability claim, so the criterion is that the key SURVIVES the
-    // parse — not that the parse succeeds. This props schema is a strip-mode
-    // `z.object`, so an UNDECLARED key parses green too and is simply absent from
-    // `data` afterwards; asserting `success` alone would prove nothing at all.
+    // parse — not that the parse succeeds. Neither refusal mode makes
+    // `success === true` proof on its own: under rc.6's strip mode an
+    // UNDECLARED key parses green as well, and under GA's strict mode a green
+    // parse only reports that no undeclared key was present. Survival is the
+    // claim on both pins.
     expect(specTopLevelKeys()).toContain('defaultValue');
     const parsed = ElementTextInputPropsSchema.safeParse({ defaultValue: 'acme' });
     expect(parsed.success).toBe(true);
     expect(parsed.data?.defaultValue).toBe('acme');
 
-    // The contrast that makes the criterion meaningful: same green parse, key
-    // gone, no diagnostic. That is what `defaultValue` looked like to every
-    // manifest consumer before it was declared here.
-    const undeclared = ElementTextInputPropsSchema.safeParse({ notASpecKey: 1 } as never);
-    expect(undeclared.success).toBe(true);
-    expect(Object.keys(undeclared.data ?? {})).not.toContain('notASpecKey');
+    // The contrast that makes the criterion meaningful: the SAME payload plus a
+    // key the spec does not declare. Two contract spellings, one verdict — the
+    // undeclared key never becomes authoring surface (see
+    // `specRefusesUnknownTopLevelKeys`). Carrying `defaultValue` alongside is
+    // load-bearing rather than tidy: it is what makes either arm attributable
+    // to `notASpecKey` instead of to the declared key having gone bad, and the
+    // green parse asserted just above is what proves the base is valid.
+    const undeclared = ElementTextInputPropsSchema.safeParse({
+      defaultValue: 'acme',
+      notASpecKey: 1,
+    } as never);
+
+    if (specRefusesUnknownTopLevelKeys) {
+      // 17.0.0 GA: a loud refusal, and the STRONGER guarantee — the author now
+      // gets told. Asserted as an envelope (the code AND the key it names)
+      // because a bare "it failed" would be satisfied just as well by a
+      // rejection of `defaultValue`, the half that has to stay valid.
+      expect(undeclared.success).toBe(false);
+      expect(undeclared.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+      const refused = undeclared.error?.issues.flatMap(
+        (i) => (i as unknown as { keys?: string[] }).keys ?? [],
+      );
+      expect(refused).toContain('notASpecKey');
+      expect(refused).not.toContain('defaultValue');
+    } else {
+      // The pinned rc.6: same green parse, key gone, no diagnostic. That is
+      // what `defaultValue` looked like to every manifest consumer before it
+      // was declared here — and the silent-drop harm objectstack#4001 batch A
+      // retired.
+      expect(undeclared.success).toBe(true);
+      expect(Object.keys(undeclared.data ?? {})).not.toContain('notASpecKey');
+      expect(undeclared.data?.defaultValue).toBe('acme');
+    }
 
     expect(inputNames()).toContain('defaultValue');
     expect(defaultValueDescription()).not.toBe('');


### PR DESCRIPTION
Fixes #4910

Implements the adjudicated **option A — assert the rejection, expressed PIN-AWARE**. Both
probes now read the installed spec's refusal mode *behaviourally* and assert the same
verdict under either mode, never branching off a version string. Option B (dropping the
probe) is not taken. This inherits the disposition the maintainer accepted on #4648's open
question 2, landed as PR #4671's adapted plugin-detail gates.

## The premise, re-verified on this branch

Both halves of the card reproduce exactly.

```
rc.6 (native pin, 17.0.0-rc.6)
  text_input     success = true   keys = ["inputType","required","disabled"]
  record_picker  success = true   keys = ["object"]

GA overlay (17.0.0)
  text_input     success = false  code = unrecognized_keys  keys = ["notASpecKey"]
  record_picker  success = false  code = unrecognized_keys  keys = ["notASpecKey"]
```

And the two named assertions are the only things that were red, at exactly the two lines
the card names — `record-picker…:101` and `text-input…:83`:

```
FAIL packages/components/src/__tests__/record-picker-inputs-spec-parity.test.ts:101:32
FAIL packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts:83:32
     expect(undeclared.success).toBe(true);   AssertionError: expected false to be true
Test Files  2 failed (2)   Tests  2 failed | 13 passed (15)
```

## What each probe became

The contrast probe parses a payload carrying a key no spec declares, then branches on a
module-level behavioural reading:

```
const specRefusesUnknownTopLevelKeys = !ElementTextInputPropsSchema.safeParse({
  __objectui_4910_probe__: true,
} as never).success;
```

- **strict arm (GA)** — asserts the refusal as an **envelope**: `unrecognized_keys` among
  the issue codes, and the refused `keys` naming `notASpecKey`. A bare "it failed" is
  deliberately not enough — it would be satisfied just as well by a rejection of the
  *declared* key, which is the half that has to stay valid, so the arm also asserts
  `defaultValue` / `filter` / `object` are **not** among the refused keys.
- **strip arm (rc.6)** — asserts the key is absent from `data` on a green parse: the
  silent drop the comments currently pin, kept verbatim as behaviour.

Two changes beyond a straight port, both load-bearing:

1. **The undeclared key is now carried alongside the declared one** (`{ defaultValue:
   'acme', notASpecKey: 1 }`, `{ ...withFilter({status:'open'}), notASpecKey: 1 }`) rather
   than alone. That is what makes either arm attributable to `notASpecKey` instead of to
   the declared key having gone bad — and the green parse asserted immediately above is
   what proves the base fixture is valid.
2. **The load-bearing comments in both files now state the two-mode contract** instead of
   the falsified strip-mode premise, as the card requires. The header comment on each
   probe records why it is behavioural rather than version-sniffed, and cites the sibling
   `recordHighlightsInputs.spec-parity.test.ts` that took this shape first.

Neither arm is vacuous, and neither reads a pin it does not observe.

## Ruled widening scan

The strict flip is schema-wide, so the scan was run in two halves — static across
spellings, then **empirically** under the GA overlay, which is the half that cannot miss a
spelling nobody thought of.

**Static.** Four spellings over `packages apps examples scripts`:

```
grep -rniE "strip-mode|strip mode|\.strip\(\)|stripped it|strips it|silently strip" --include=*.ts --include=*.tsx --include=*.md
grep -rniE "notASpecKey|not_a_spec_key|undeclaredKey|unknownKey|bogusKey|extraKey|notAKey|nonSpecKey|fakeKey" --include=*.ts --include=*.tsx
grep -rn "unrecognized_keys" --include=*.ts --include=*.tsx
grep -rnE --include=*.ts --include=*.tsx "safeParse\(.*\bas (never|any|unknown)"   # plus a multiline -Pz variant
```

The last one is the high-signal spelling: a payload carrying a key the props type does not
declare needs a type escape to be written at all. Its **only** hits repo-wide are the two
files this PR changes — which doubles as the positive control that the scan reaches them.
The one other identifier hit, `clientValidation.optOuts.test.ts`'s
`notAKeyAnySchemaDeclares`, is already an assert-the-refusal probe (`bogus.ok` is asserted
`false`) on a metadata schema, not a strip-mode premise.

**Empirical.** Every test file importing `@objectstack/spec` — **220 files** — run under
the GA overlay. Before this branch:

```
Test Files  3 failed | 217 passed (220)      Tests  3 failed | 3396 passed | 1 skipped (3400)
  packages/components/src/__tests__/record-picker-inputs-spec-parity.test.ts   <- this card
  packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts      <- this card
  packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts <- NOT this card
```

At this branch's HEAD:

```
Test Files  1 failed | 219 passed (220)
  packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts
```

**Hit list for this card: exactly the two named files. No third file needed adapting.**

The remaining failure is a different GA change — GA's `FieldOperatorsSchema` adds `$like` /
`$ilike`, which the builder cannot author (`expected [ '$like', '$ilike' ] to deeply equal
[]`). Not the strip flip, no undeclared-key parse involved. It is **already filed** as
#4911, which is not addressed here and remains open.

## Verification — both pins, at `846ec5dd8` (working tree clean)

GA readings use PR #4660's npm-pack overlay, re-derived: `npm pack
@objectstack/spec@17.0.0` unpacked over the pnpm **store** directory every one of the 34
`@objectstack/spec` symlinks already resolves to, so all 34 arm at once and none is
repointed or restored wrongly. That placement is also the peer-link repair PR #4901's
report records: `ai` and `zod` live one level up inside the same store entry, so they are
mirrored by construction rather than by hand. rc.6 restored afterwards, and the installed
version plus the raw refusal mode were printed before every run.

| reading | rc.6 | GA overlay |
|---|---|---|
| the two files | **15 passed (2 files)** | **15 passed (2 files)** |
| `@object-ui/components` full suite | **145 files / 1311 tests passed** | — |
| every `@objectstack/spec`-importing test (220 files) | — | **219 passed / 1 failed** (#4911) |
| `type-check` — `@object-ui/components` | PASS | PASS |
| `eslint --quiet`, 2 changed files | PASS (0 errors) | — |
| `check:control-bytes` | PASS (4398 files) | — |
| `check-changeset-presence` / `-fixed` / `-no-major` | PASS | — |
| `check:self-import` | PASS | — |

The dependency closure was built first (`pnpm --workspace-concurrency=2 --filter
'@object-ui/components^...' build`) before either type-check.

### Reverse verification — direction predicted first, one ablation per arm

Predicted before running, and the point of using two: each ablation must redden on
**exactly one** pin, which is what proves each arm actually judges under its own pin and is
genuinely dormant under the other. Run from the committed state.

**Ablation A** — break only the *strict* arm (`refused` must contain a key that is not
there), in `text-input`. Predicted GA red, rc.6 green.

**Ablation B** — break only the *strip* arm (the surviving `filter` value), in
`record-picker`. Predicted rc.6 red, GA green.

Observed, exactly and symmetrically:

```
GA:    × text-input … publishes `defaultValue`, which the renderer has read all along
       AssertionError: expected [ 'notASpecKey' ] to include '__ablation_A_no_such_key__'
       Test Files  1 failed | 1 passed (2)      <- record-picker green: strip arm dormant

rc.6:  × record-picker … publishes `filter`, which the renderer has read all along
       AssertionError: expected { status: 'open' } to deeply equal { status: '__ablation_B__' }
       Test Files  1 failed | 1 passed (2)      <- text-input green: strict arm dormant
```

So: **the strict arm judges under GA and the strip arm judges under rc.6, each dormant on
the other pin.** Ablation A's message is also the direct positive control that the strict
arm truly receives the named key — the refused set really is `[ 'notASpecKey' ]`.

Both restored with `git checkout` from the branch; `git status` clean, i.e.
byte-identical, and re-run green on both pins.

## Changeset

An **empty-frontmatter** changeset — the repo's tests-only exemption, per precedent PRs
#4641 / #4666 / #4671. No runtime source, no registration and no gate was touched; only the
two test files. The gate confirms it rather than my reading of it:

```
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

No `skip-changeset` label is applied or created — that label does not exist in this repo
(#4912).

## Scope

Three files: the two parity tests and the changeset. No production code, no gate weakening,
no `content/docs/releases/`. In-flight siblings untouched.

One finding filed unassigned rather than fixed here: **#4918** — two `plugin-detail`
parity tests still narrate rc.6 strip mode as present-tense fact in *prose only*. No
assertion depends on it, so both files are green under the GA overlay and no gate can catch
it; it falls outside this card's claimed surface, which is bounded to tests that *assert* a
green `safeParse` with an undeclared key.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbRmJD3iPhXjKr6vhd4Qkv)_