### PR TITLE
fix(layout): mobileNavMode 声明收窄为实现值枚举,退休零读点的第三个模式 (#3985)

### DIFF
--- a/.changeset/mobile-nav-mode-enum-3985.md
+++ b/.changeset/mobile-nav-mode-enum-3985.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/layout': minor
+---
+
+**Breaking (shipped as `minor`, following the `app-shell` component-key deregistration):**
+`app-schema-renderer`'s `mobileNavMode` is now declared as the vocabulary the renderer
+implements — `enum: ['drawer', 'bottom_nav']` — instead of free-text `string`, and the
+third member of `MobileNavMode` is retired (objectui#3985, ADR-0049 enforce-or-remove,
+maintainer ruling 2026-08-10).
+
+**What used to happen.** The registration declared `{ name: 'mobileNavMode', type:
+'string' }`, so `sdui-parser`'s `checkType` asked only whether the value was a string.
+`mobileNavMode="bottom-nav"` — the hyphenated spelling of the underscored value, and the
+likeliest typo on this key — passed the manifest gate, passed the parser, reached the
+renderer, missed its one equality test, and rendered the drawer. Nothing reported
+anything, at any layer. The declaration was WIDER than the implementation, which is why
+the `invalid-enum` that should have fired never could.
+
+**What happens now.** A value outside the vocabulary is an **error**-level `invalid-enum`
+from `validateTree` / `compile`, so a schema-driven author — very often an AI author — is
+stopped at the typo instead of debugging a mode that silently did nothing. The generated
+`sdui-intrinsics.d.ts` narrows from `mobileNavMode?: string` to the two-value union for
+the same reason.
+
+**Retirement.** `MobileNavMode` had a third member documented as "collapsed sidebar" with
+**zero read points** in `AppSchemaRenderer`: the only two reads are the `drawer` default
+and the `=== 'bottom_nav'` comparison that gates the bottom bar, so the value was
+behaviourally identical to the default while the union, the JSDoc and `ROADMAP.md`
+presented it as a capability. It is gone from the union and from the published
+vocabulary. Making it real behaviour is an implementation card first — the value comes
+back together with a renderer read point, never as a declaration on its own.
+
+**Migration.** Both implemented modes are unchanged; no runtime behaviour moves. A
+TypeScript caller passing the retired literal now fails to compile (it previously
+compiled and rendered the drawer), and a JSON/JSX author writing it — or any other
+out-of-vocabulary value — now gets a validation error where they previously got silence.
+In both cases the value that reproduces the old behaviour exactly is `drawer`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,7 +136,8 @@ ObjectUI is a universal Server-Driven UI (SDUI) engine built on React + Tailwind
 - [x] Implement `AppSchema` renderer consuming spec JSON (name, label, icon, branding)
 - [x] Build navigation tree renderer (7 nav item types: object, dashboard, page, url, report, action, group)
 - [x] Implement `NavigationAreaSchema` support (business domain partitioning)
-- [x] Implement mobile navigation modes (drawer/bottom_nav/hamburger)
+- [x] Implement mobile navigation modes (drawer/bottom_nav — the third mode this line
+      used to claim was declared but never had a read point, retired in objectui#3985)
 - [x] Add permission guards (`requiredPermissions`, `visible`) on navigation items
 
 ---

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -43,6 +43,7 @@
     "react-router-dom": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
+    "@object-ui/sdui-parser": "workspace:*",
     "@vitejs/plugin-react": "^6.0.5",
     "react-router-dom": "^7.18.2",
     "vite": "^8.2.1",

--- a/packages/layout/src/AppSchemaRenderer.tsx
+++ b/packages/layout/src/AppSchemaRenderer.tsx
@@ -57,8 +57,26 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-/** Mobile navigation display mode */
-export type MobileNavMode = 'drawer' | 'bottom_nav' | 'hamburger';
+/**
+ * Mobile navigation display mode — the two modes this renderer implements.
+ *
+ * `drawer` is the default (the sidebar rides in the AppShell's mobile sheet
+ * overlay); `bottom_nav` additionally renders the fixed bottom bar. Those are
+ * the renderer's only two read points for the prop — the default below and the
+ * `=== 'bottom_nav'` comparison that gates the bottom bar — so every value that
+ * is not `bottom_nav` produces drawer behaviour.
+ *
+ * A third member (spelled after the collapsed-sidebar menu button) rode in this
+ * union with a JSDoc line promising "collapsed sidebar" and NO read point
+ * anywhere, which made it behaviourally identical to `drawer` while reading as
+ * a capability. Retired in objectui#3985 under ADR-0049 enforce-or-remove
+ * (maintainer ruling 2026-08-10): it never was behaviour, so it is gone from
+ * this union and from the published vocabulary rather than being documented as
+ * a synonym for the default. Wanting a collapsed-sidebar mode is an
+ * implementation card first, and the value comes back with a read point — never
+ * as a declaration on its own.
+ */
+export type MobileNavMode = 'drawer' | 'bottom_nav';
 
 export interface AppSchemaRendererProps {
   /** The AppSchema JSON to render */
@@ -461,8 +479,8 @@ function InternalSidebar({
  * - Area switcher when multiple areas are VISIBLE — area visibility is
  *   derived from the items inside, not authored (objectui#3311): an area
  *   whose items are all gated away is hidden and never auto-activated
- * - Mobile modes: `drawer` (sheet overlay, default), `bottom_nav` (fixed
- *   bottom bar), `hamburger` (collapsed sidebar)
+ * - Mobile modes: `drawer` (sheet overlay, default) and `bottom_nav` (fixed
+ *   bottom bar) — see `MobileNavMode` for why that list is two long
  * - Evaluates `visible` expressions and `requiredPermissions` on every item
  *
  * @example

--- a/packages/layout/src/__tests__/AppSchemaRenderer.test.tsx
+++ b/packages/layout/src/__tests__/AppSchemaRenderer.test.tsx
@@ -521,6 +521,22 @@ describe('AppSchemaRenderer', () => {
     expect(bottomNav).toBeNull();
   });
 
+  // Narrowing `mobileNavMode` to a two-value enum (objectui#3985) must not move
+  // either surviving mode. The default is covered above; this is the same value
+  // passed EXPLICITLY, which is the path an author takes and the one a
+  // vocabulary change would break first — a default that still works says
+  // nothing about whether the value is still accepted.
+  it('does not render bottom nav when drawer is passed explicitly', () => {
+    const { container } = renderApp(schemaWithNav, { mobileNavMode: 'drawer' });
+    expect(
+      container.querySelector('[role="navigation"][aria-label="Mobile navigation"]'),
+    ).toBeNull();
+    // Non-vacuity: the shell and its sidebar navigation rendered, so "no bottom
+    // nav" is a verdict about the mode rather than about an empty container.
+    expect(screen.getByTestId('page-content')).toBeTruthy();
+    expect(screen.getAllByText('Accounts').length).toBeGreaterThan(0);
+  });
+
   // --- Sidebar footer slot ---
 
   it('renders sidebarFooter slot', () => {

--- a/packages/layout/src/__tests__/appSchemaRendererMobileNavMode.test.tsx
+++ b/packages/layout/src/__tests__/appSchemaRendererMobileNavMode.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `app-schema-renderer.mobileNavMode` is a published VOCABULARY, not free text
+ * (objectui#3985, maintainer ruling 2026-08-10).
+ *
+ * ## What was wrong
+ *
+ * The registration declared `{ name: 'mobileNavMode', type: 'string' }` while
+ * the renderer implemented a small closed set. `checkType`'s string arm asks
+ * only `typeof value === 'string'`, so `mobileNavMode="bottom-nav"` — the
+ * hyphenated spelling of the underscored value, the single most likely typo on
+ * this key — passed the manifest gate, passed the parser, reached the renderer,
+ * missed its one equality test, and rendered the default. No diagnostic at any
+ * layer. The designer drew a free-text box rather than a picker for the same
+ * reason. That is objectui#3972's family with the polarity flipped: the
+ * declaration was WIDER than the implementation, so the `invalid-enum` that
+ * should have fired never could.
+ *
+ * The union also carried a third member with a JSDoc line promising "collapsed
+ * sidebar" behaviour and zero read points, i.e. a value whose entire effect was
+ * to be indistinguishable from the default. It is retired here under ADR-0049
+ * enforce-or-remove; the ruling is explicit that making it behaviour is an
+ * implementation card first.
+ *
+ * ## What this file pins, and where each pin actually fires
+ *
+ *   1. THE DECLARATION — an `enum` over exactly the implemented values. Fails
+ *      in this run if the declaration is widened back to `string`, or if a
+ *      value with no read point is added to the published vocabulary.
+ *   2. THE VERDICT, through the real validator — `manifestFromConfigs` over the
+ *      LIVE registration plus `compile`, never a hand-written manifest that
+ *      could agree with itself. A misspelling and the retired value both come
+ *      back `invalid-enum` at severity `error`; both legal values come back
+ *      clean, which is the control that stops "no diagnostics" from passing for
+ *      an empty reason.
+ *   3. THE TYPE — a `@ts-expect-error` on the retired literal. This one does
+ *      NOT fire in the Vitest run: Vitest transpiles without type-checking, so
+ *      re-widening `MobileNavMode` leaves this file green here and fails
+ *      `pnpm --filter @object-ui/layout type-check` instead ("Unused
+ *      '@ts-expect-error' directive"). Said out loud because a pin whose gate
+ *      you cannot name is a pin nobody will re-run.
+ *
+ * Behaviour of the two surviving values is pinned where behaviour belongs, on
+ * the rendered DOM, in `AppSchemaRenderer.test.tsx` — a declaration test that
+ * also claimed to prove rendering would be proving it from the wrong face.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { compile, manifestFromConfigs } from '@object-ui/sdui-parser';
+
+import { registerLayout, type MobileNavMode } from '../index';
+
+const TYPE = 'app-schema-renderer';
+
+beforeAll(() => {
+  // The barrel registers on evaluation; say so explicitly, so an import-order
+  // accident is not what makes these claims true.
+  registerLayout();
+});
+
+const inputs = () => ComponentRegistry.getConfig(TYPE)?.inputs ?? [];
+const navModeInput = () => inputs().find((input) => input.name === 'mobileNavMode');
+
+/**
+ * A manifest built the way `renderers/layout/page.tsx` builds the JSX-page
+ * compiler's whitelist — from the live registry — so these verdicts are the
+ * ones a real author gets, not the ones a fixture was written to produce.
+ */
+const liveManifest = () =>
+  manifestFromConfigs(
+    ComponentRegistry.getKnownTypes().map((type) => {
+      const meta = ComponentRegistry.getMeta(type);
+      return { type, namespace: meta?.namespace, isContainer: meta?.isContainer, inputs: meta?.inputs };
+    }) as unknown as Parameters<typeof manifestFromConfigs>[0],
+  );
+
+const diagnose = (value: string) =>
+  compile(`<${TYPE} mobileNavMode="${value}" />`, liveManifest()).diagnostics;
+
+describe('the `mobileNavMode` declaration is the implemented vocabulary (objectui#3985)', () => {
+  it('declares an `enum`, not free text', () => {
+    expect(
+      navModeInput(),
+      [
+        '`app-schema-renderer` no longer declares `mobileNavMode` at all. The key is still read',
+        'by the renderer, so dropping the declaration does not retire it — it only hides it:',
+        '`sdui-parser` would report `unknown-prop` on a key that works, and no designer panel',
+        'would offer it.',
+      ].join('\n'),
+    ).toBeDefined();
+
+    expect(
+      navModeInput()?.type,
+      [
+        '`mobileNavMode` is declared as something other than `enum`. Back at `string` it is the',
+        'objectui#3985 defect verbatim: `checkType` would judge only `typeof value ===',
+        '"string"`, every misspelling would pass, and the renderer would silently fall back to',
+        'the drawer. The declaration has to name the vocabulary for the error-level',
+        '`invalid-enum` to exist at all.',
+      ].join('\n'),
+    ).toBe('enum');
+  });
+
+  it('publishes exactly the two values the renderer implements', () => {
+    expect(
+      navModeInput()?.enum,
+      [
+        'The published vocabulary changed. The renderer has exactly two read points for this',
+        'prop — the `drawer` default and the `=== "bottom_nav"` comparison that gates the bottom',
+        'bar — so these two values are the whole of what it implements.',
+        '',
+        'ADDING a value here republishes the objectui#3985 defect in its other form: a value with',
+        'no read point behaves exactly like the default while the manifest, the generated',
+        '`.d.ts` and the designer all present it as a mode. That is why the third member was',
+        'retired rather than documented. A new mode lands as a renderer read point FIRST, in the',
+        'same change that adds it here.',
+      ].join('\n'),
+    ).toEqual(['drawer', 'bottom_nav']);
+  });
+
+  it('carries the renderer default and a description that names both modes', () => {
+    // `defaultValue` is what the designer pre-fills; it must be the value the
+    // renderer already falls back to, or the panel and the runtime disagree
+    // about what "leave it alone" means.
+    expect(navModeInput()?.defaultValue).toBe('drawer');
+
+    const description = navModeInput()?.description ?? '';
+    expect(description).toMatch(/drawer/);
+    expect(description).toMatch(/bottom_nav/);
+  });
+});
+
+describe('the validator refuses an out-of-vocabulary value (objectui#3985)', () => {
+  it('accepts both legal values with no diagnostics', () => {
+    // Non-vacuity for everything below: if the tag or the manifest were broken,
+    // the "rejected" assertions would pass for the wrong reason.
+    expect(diagnose('drawer')).toEqual([]);
+    expect(diagnose('bottom_nav')).toEqual([]);
+  });
+
+  it('reports an error-level `invalid-enum` for the hyphenated misspelling', () => {
+    const diagnostics = diagnose('bottom-nav');
+
+    expect(
+      diagnostics.map((d) => d.code),
+      [
+        'The hyphenated spelling of `bottom_nav` is accepted again. This is the exact input',
+        'objectui#3985 was filed about: it used to pass validation and then miss the renderer’s',
+        'equality check, so the author saw drawer behaviour and no error anywhere.',
+      ].join('\n'),
+    ).toContain('invalid-enum');
+
+    expect(
+      diagnostics.find((d) => d.code === 'invalid-enum')?.severity,
+      'the `invalid-enum` dropped below `error` — a warning is dismissible, which is how the silent fallback comes back',
+    ).toBe('error');
+  });
+
+  it('refuses the retired value by name, rather than treating it as a synonym for the default', () => {
+    expect(
+      diagnose('hamburger').map((d) => d.code),
+      [
+        'The retired value validates again. It was removed in objectui#3985 (ADR-0049',
+        'enforce-or-remove) because the renderer never read it: it was published as a mode and',
+        'behaved as the default. Re-accepting it in the DECLARATION alone restores exactly that',
+        'state. If it has since been implemented, this assertion is replaced by one about what',
+        'the renderer DOES with it — never merely deleted.',
+      ].join('\n'),
+    ).toContain('invalid-enum');
+  });
+
+  it('the retired literal is not assignable to `MobileNavMode`', () => {
+    // Type-level half of the retirement. See this file's header: it fails under
+    // `type-check`, not here, and it fails as an UNUSED directive the moment
+    // the union is widened back.
+    // @ts-expect-error — the retired mode is no longer a member of this union.
+    const retired: MobileNavMode = 'hamburger';
+
+    // Referenced so the binding is not merely unused-variable noise; the
+    // assertion that matters is the directive above.
+    expect(typeof retired).toBe('string');
+  });
+});

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -264,7 +264,22 @@ export function registerLayout() {
     inputs: [
       { name: 'schema', type: 'object' },
       { name: 'basePath', type: 'string' },
-      { name: 'mobileNavMode', type: 'string' },
+      // Declared as the vocabulary the renderer implements, not as free text
+      // (objectui#3985). `type: 'string'` judged only `typeof value ===
+      // 'string'`, so a hyphenated misspelling of `bottom_nav` passed every
+      // gate and then failed the renderer's one equality check in silence —
+      // the author got drawer behaviour and no diagnostic. As an `enum`,
+      // `sdui-parser`'s `checkType` raises an error-level `invalid-enum`
+      // instead, which is where an AI author finds the typo.
+      {
+        name: 'mobileNavMode',
+        type: 'enum',
+        enum: ['drawer', 'bottom_nav'],
+        defaultValue: 'drawer',
+        label: 'Mobile Nav Mode',
+        description:
+          'Mobile navigation mode. "drawer" (default) puts the sidebar in the mobile sheet overlay; "bottom_nav" additionally renders a fixed bottom bar. These are the only two modes the renderer implements.',
+      },
     ],
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1391,6 +1391,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@object-ui/sdui-parser':
+        specifier: workspace:*
+        version: link:../sdui-parser
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.10)(yaml@2.9.0))


### PR DESCRIPTION
Fixes #3985

按 2026-08-10 维护者裁定实施:①声明收窄为枚举;②误拼值在校验层**拒绝**(error 级 `invalid-enum`),不再静默回落;③零读点的第三个模式按 ADR-0049 enforce-or-remove **退休**。

## 裁定散文的措辞歧义,以及本 PR 取的操作语义

裁定里「the real three-value union」与「`hamburger` is retired ... zero read points ... never was behavior」并置。两句不能同时字面成立 —— 退休一个成员之后联合就是两值。本 PR 按**两条操作句**执行:发布的枚举 = 渲染器**实现了的**值 = `['drawer', 'bottom_nav']`;「the real ... union」理解为「声明面要对齐实现,而不是自由文本」,紧接着的那句退休决定了对齐的终点是两值。这不构成真矛盾,故未按前提证伪停手;若维护者的本意是保留三值(即 issue 里的方案 a),这一处一行可改,但那需要先有 collapsed-sidebar 的实现卡,本 PR 不替它做决定。

## 前提验证(先行,`origin/main` @ `5ffcc1432`)

issue 与分诊评论给的行号已漂移,机制**全部成立**:

| 事实 | issue/评论所记 | 实测(`5ffcc1432`) |
|---|---|---|
| 声明 `{ name: 'mobileNavMode', type: 'string' }` | `packages/layout/src/index.ts:181` | 同文件 **`:267`** ✅ |
| 三值联合 | `AppSchemaRenderer.tsx:57` | 同文件 **`:61`** ✅ |
| 默认值读点 | `:430` | **`:484`**(`mobileNavMode = 'drawer'`)✅ |
| `=== 'bottom_nav'` 读点 | `:538` | **`:592`**(`const showBottomNav = ...`)✅ |
| 把第三个值写成 collapsed sidebar 的 JSDoc | `:411` | **`:465`** ✅ |

另外两处需要纠正的定位:分诊认领评论写的是「`packages/app-shell` 的 AppSchemaRenderer」,实际这个渲染器仍在 **`packages/layout`**,`packages/app-shell` 与本卡无关;`mobileNavMode` 在 `@objectstack/spec` 里**不存在**(全量 grep 无命中),所以这是渲染器自有的 prop,不需要 spec 侧协同。

**读点清单(全仓,精确名 `mobileNavMode`):**

- `packages/layout/src/AppSchemaRenderer.tsx:484` —— 解构默认值 `= 'drawer'`(读点 1/2)
- `packages/layout/src/AppSchemaRenderer.tsx:592` —— `=== 'bottom_nav'`(读点 2/2)
- `packages/layout/src/AppSchemaRenderer.tsx:71` —— props 类型标注(不是读)
- `packages/layout/src/index.ts:267` —— 注册声明(不是读)
- `packages/layout/src/__tests__/AppSchemaRenderer.test.tsx:513` —— 仓内唯一传值处,传 `'bottom_nav'`

即:**读点恰好两个,没有新读点出现**,第三个值零读点的判据在本次实测下仍然成立。

## 改了什么

1. **声明收窄**(`packages/layout/src/index.ts`):`type: 'string'` → `type: 'enum'` + `enum: ['drawer', 'bottom_nav']`,并补上 `defaultValue: 'drawer'`(与渲染器的回落值一致,否则设计器面板与运行时对「不填」的理解会分叉)、`label` 与一条点名两个模式的 `description`。
2. **联合收窄**(`AppSchemaRenderer.tsx:61`):`MobileNavMode` 去掉第三个成员,并把「为什么是两值 / 退休依据 / 怎样才能回来」写进类型的 JSDoc。
3. **JSDoc 纠正**(`AppSchemaRenderer.tsx:465`):不再把第三个模式写成 collapsed sidebar。
4. **`ROADMAP.md:139`**:那一行 `- [x] Implement mobile navigation modes (drawer/bottom_nav/hamburger)` 是**已勾选**的实装声明,而第三个模式从来没有读点 —— 按 #3818/#3829 家族的退休惯例改成两值并注明退休来源,而不是留着一条勾了的假声明。
5. **测试**:新增 `packages/layout/src/__tests__/appSchemaRendererMobileNavMode.test.tsx`(7 条),并给 `AppSchemaRenderer.test.tsx` 补一条「显式传 `drawer`」的行为钉。
6. **changeset**:`.changeset/mobile-nav-mode-enum-3985.md`。

## 退休提及普查(带引号精确名,全仓 case-insensitive)

共 5 处,逐处判定,**没有批量替换**:

| 位置 | 判定 |
|---|---|
| `packages/layout/src/AppSchemaRenderer.tsx:61` | 联合成员 → **删除** |
| `packages/layout/src/AppSchemaRenderer.tsx:465` | JSDoc 把它写成 collapsed sidebar → **删除该措辞** |
| `ROADMAP.md:139` | 已勾选的实装声明 → **改为两值 + 注明退休** |
| `content/docs/layout/sidebar-nav.mdx:294` | **保留**。这句讲的是 `SidebarNav`/AppShell 的移动端**触发按钮**(shadcn `Sidebar` 的 `SidebarTrigger` + Sheet,`packages/components/src/ui/sidebar.tsx:281`),是真实存在的交互件,与 `mobileNavMode` 的**取值词表**是两回事。改它会把一句真话改成假话。 |
| `packages/types/src/mobile.ts:85` | **不在本 PR 范围**。是另一个包、另一个类型(`MobileOverrides`)、另一个键(`navigation`)的三值词表,且整棵类型全仓零读点。同族但独立,已另立 finding 卡 **#4919**。 |

`mobileNavMode` 本身在 `content/docs/**`、`packages/layout/README.md`、catalog、示例里**零提及**(全量 grep 只命中上面读点清单里的 5 行),所以没有文档/catalog 要跟改。

## 反向验证(先书面预判,再跑;变异前已 commit,还原一律 `git checkout`)

三个变异,方向各不相同 —— 第二个的方向与「变异 → 测试红」的默认模板**不一致**,如实记录:

**A. 撤掉校验拒绝**(声明改回 `type: 'string'`,联合保持两值)
- 预判:枚举/校验类 5 条钉红;`AppSchemaRenderer.test.tsx` 的 DOM 行为钉**全绿**(声明缺陷对渲染不可见 —— 这正是本卡能存在这么久的原因)。
- 实测:`Tests 5 failed | 50 passed`,红的恰好是 `declares an enum, not free text` / `publishes exactly the two values` / `carries the renderer default and a description` / `reports an error-level invalid-enum for the hyphenated misspelling` / `refuses the retired value by name`;`AppSchemaRenderer.test.tsx` 整文件 `1 passed`。✅ 与预判一致。

**B. 把退休值塞回联合**(只改 `MobileNavMode`,声明不动)
- 预判:**vitest 全绿**,`type-check` 红。Vitest 只转译不做类型检查,所以类型钉在测试运行里是惰性的;声明没动,运行时判定不变。这一条的钉落在 `type-check` 门上。
- 实测:`Test Files 1 passed / Tests 7 passed`;`tsc -p packages/layout/tsconfig.test.json` 报 `src/__tests__/appSchemaRendererMobileNavMode.test.tsx(184,5): error TS2578: Unused '@ts-expect-error' directive.` ✅ 与预判一致 —— 钉是**换了门**,不是缺失。测试文件头把这一点写死了,以免后来者以为它该在 vitest 里红。

**C. 把退休值塞回发布的枚举**(只改 `enum` 数组,联合不动)
- 预判:`publishes exactly the two values` 与 `refuses the retired value by name` 两条红,其余绿。
- 实测:`Tests 2 failed | 5 passed`,红的正是这两条。✅

三次变异后 `git checkout` 还原,`git status` 干净,复跑全绿。

## 钉在哪一面(key vs value)

本卡判的是**取值**,不是键 —— `mobileNavMode` 这个键本来就合法。所以校验钉要求的是**判定**:走真 `manifestFromConfigs`(从 LIVE 注册表构建,不是手写 fixture)+ `compile`,断言误拼值与退休值都拿到 `severity: 'error'` 的 `invalid-enum`,同时断言两个合法值**零诊断**作为非空对照 —— 否则「没有诊断」这种形状会因为管线坏掉而假绿。行为面(两个存活模式渲染不变)钉在 DOM 上,留在 `AppSchemaRenderer.test.tsx`,不与声明钉混在一个文件里。

## 测试与门(实测输出)

```
pnpm exec vitest run packages/layout/ packages/sdui-parser/ --maxWorkers=2
  Test Files  21 passed (21)
       Tests  199 passed (199)

pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts \
    apps/console/src/__tests__/public-contract.test.ts \
    apps/console/src/__tests__/public-block-binding-reach.test.tsx --maxWorkers=2
  Test Files  3 passed (3)
       Tests  81 passed (81)

pnpm exec turbo run type-check --concurrency=2
  Tasks:  81 successful, 81 total

node scripts/check-control-bytes.mjs      ✅ OK (4397 tracked text files)
node scripts/check-phantom-dependencies.mjs ✅ 每个 in-scope import 都被发布它的包声明
node scripts/check-changeset-no-major.mjs   ✅
node scripts/check-changeset-fixed.mjs      ✅
eslint(仅改动文件)                          0 errors(余下 warning 均为改动前既有)
```

消费半径扫过:`sdui-parser` 的 `validate`/`manifestFromConfigs`/`codegen`(枚举 → `.d.ts` 联合)、`apps/console` 的三个 registry 门、`packages/components` 里同样吃 `manifestFromConfigs` 的 parity 测试 —— 没有别的包的 fixture 写过这个键。

## 两处诚实标注

- **设计器那一半没有兑现。** issue 说声明成自由文本会让设计器画输入框而不是三选一。实测本仓**没有任何**消费者在 `ComponentInput.type` 上分派控件(`grep` 全仓无 `case 'enum'` 之类的属性面板分派),所以本 PR 能证明改善的是校验、manifest 与生成的 `.d.ts` 三面,设计器控件是另一处消费者的事,不在这里冒领。
- **`packages/layout` 新增了一个 devDependency** `@object-ui/sdui-parser`(workspace),只给新测试文件用 —— 它要走**真校验器**得判,`check-phantom-dependencies.mjs` 要求 tooling import 也被声明。`packages/components` 已有同样的依赖方向先例。

## 版本号

标 **`minor` 而非 `patch`**:这是收紧公开契约(导出的 `MobileNavMode` 少了一个成员,TS 调用方写退休值不再编译;仓外 schema 驱动的作者从「静默回落」变成「校验报错」),按 AGENTS.md §版本号策略「objectui 自身的破坏性变更也标 `minor`」,并与同包同类退休的先例 `.changeset/deregister-app-shell-component-key.md` 一致(它也是 `minor` + 正文写明 breaking 语义)。**没有**声明 `major`。

## 相邻缺陷(未扩围)

- **#4919** —— `MobileOverrides.navigation` 发布了三值导航词表,整棵类型全仓零读点。普查退休提及时撞见,另一个包/类型/键,已按 observation-class 打 `finding`、不挂 `pm:queue`,未认领。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_