### PR TITLE
docs(skills): skill 入口与 project-setup evals 停教/停评「加 @source 扫 ObjectUI 包」

### DIFF
--- a/skills/objectui/SKILL.md
+++ b/skills/objectui/SKILL.md
@@ -136,8 +136,8 @@ See `rules/no-touch-zones.md` for the full list and rationale.
 - Registering components without a namespace in plugin-heavy projects.
 - Skipping docs updates for newly introduced schema patterns.
 - Putting expression values in top-level `value` / `label` fields instead of `props.*`.
-- Missing Shadcn CSS variables — components render but look completely unstyled.
-- Forgetting `@source` directives in Tailwind config — utility classes not generated for ObjectUI packages.
+- Missing the published stylesheet imports — `@object-ui/components/style.css` then `@object-ui/fields/style.css`, in that order — components render but look completely unstyled. The components sheet carries the theme tokens and the `:root` / `.dark` defaults; the fields sheet is a subtracted supplement that resolves against them.
+- Pointing Tailwind at the installed ObjectUI packages instead of importing those two sheets: the published tarballs carry `dist` only, so the theme block the themed utilities are built on is not there to scan. Inside the ObjectUI workspace the reverse holds — packages are linked to their sources, an app scans them and declares the theme itself. See [`rules/styling.md`](./rules/styling.md) for both cases; do not keep a second copy of the answer here.
 
 ## Fast Triage Playbook for Ambiguous Requests
 

--- a/skills/objectui/evals/project-setup.json
+++ b/skills/objectui/evals/project-setup.json
@@ -4,49 +4,55 @@
     {
       "id": 1,
       "prompt": "I want to start a new project using Object UI with Vite and React. What do I need to install and configure? Give me the full setup.",
-      "expected_output": "Provides complete setup: package.json dependencies, vite.config.ts, index.css with Shadcn theme and @source directives, tsconfig.json, and a minimal App.tsx with SchemaRenderer.",
+      "expected_output": "Provides complete setup: package.json dependencies, vite.config.ts, an index.css that imports tailwindcss and then '@object-ui/components/style.css' before '@object-ui/fields/style.css', tsconfig.json, and a minimal App.tsx with SchemaRenderer. No tailwind.config.js step and no theme block of the consumer's own — the components sheet already ships those tokens.",
       "files": [],
       "assertions": {
         "must_contain": [
           "package.json",
           "vite.config",
-          "@source",
-          "@theme",
+          "@object-ui/components/style.css",
+          "@object-ui/fields/style.css",
           "SchemaRenderer"
         ],
         "must_not_contain": [
-          "create-react-app"
+          "create-react-app",
+          "node_modules/@object-ui"
         ]
       }
     },
     {
       "id": 2,
       "prompt": "My Object UI components render but they have no styling at all — just plain text and bare inputs. What's wrong?",
-      "expected_output": "Diagnoses missing CSS setup: explains need for @source directives, @theme color token mapping, and :root CSS variables. Provides the complete index.css template.",
+      "expected_output": "Diagnoses the missing stylesheet imports and gives the complete index.css: '@import \"tailwindcss\"', then '@object-ui/components/style.css', then '@object-ui/fields/style.css'. Explains that the order is load-bearing — the components sheet carries the utilities, the theme tokens they are built on and the :root/.dark defaults, while the fields sheet is a supplement with every rule the first sheet already ships subtracted from it, so imported first or alone its rules resolve against tokens that are not there yet.",
       "files": [],
       "assertions": {
         "must_contain": [
-          "@source",
-          "@theme",
-          "--color-",
-          ":root"
+          "@import",
+          "@object-ui/components/style.css",
+          "@object-ui/fields/style.css",
+          "order"
         ],
-        "must_not_contain": []
+        "must_not_contain": [
+          "node_modules/@object-ui"
+        ]
       }
     },
     {
       "id": 3,
       "prompt": "How do I add the grid and kanban plugins to my existing Object UI project and make sure they're available in my schemas?",
-      "expected_output": "Shows how to install plugin packages, import them to trigger ComponentRegistry registration, and update @source paths in CSS for plugin styling.",
+      "expected_output": "Shows installing @object-ui/plugin-grid and @object-ui/plugin-kanban, the side-effect import at the app entry that registers each plugin's renderers in ComponentRegistry (without it SchemaRenderer resolves the node to 'Unknown component type'), and the schema type to use afterwards. On styling: the plugin packages publish no stylesheet of their own — only @object-ui/components and @object-ui/fields export a ./style.css — so there is no third sheet to import and nothing to point Tailwind at inside node_modules. Inside the ObjectUI workspace the app owns the Tailwind entry and adds one @source line per plugin package's src, the way apps/console/src/index.css does.",
       "files": [],
       "assertions": {
         "must_contain": [
-          "plugin",
+          "@object-ui/plugin-grid",
+          "@object-ui/plugin-kanban",
           "import",
-          "ComponentRegistry",
-          "@source"
+          "ComponentRegistry"
         ],
-        "must_not_contain": []
+        "must_not_contain": [
+          "node_modules/@object-ui",
+          "@object-ui/plugin-grid/style.css"
+        ]
       }
     }
   ]


### PR DESCRIPTION
Fixes #4865

#4858(PR #4866)把三份指南改成教发布态 `style.css` 导入之后,同一段样板还留在两处没跟上。本 PR 只改这两个文件,两处都对齐 #4866 已经落地的教法。

## 前提验证(先做,再动手)

两处现状与卡面逐字一致,`origin/main` 未被别的 PR 抢先修:

- `skills/objectui/SKILL.md:139-140` 现文原样存在。
- `skills/objectui/evals/project-setup.json` 三条 eval 的 `must_contain` 仍是 `@source` / `@theme` / `--color-` / `:root`。
- `git log -- skills/objectui/rules/styling.md` 顶端就是 `5d7a655f6 docs(skills): 三份指南改教发布态 style.css 导入,停教扫 node_modules 源码 (#4866)`,三份指南确已改完,残留确实只剩这两处。

`premise_still_valid: true`。

## 一、`skills/objectui/SKILL.md` —— Common Mistakes

**改前**

```
- Missing Shadcn CSS variables — components render but look completely unstyled.
- Forgetting `@source` directives in Tailwind config — utility classes not generated for ObjectUI packages.
```

对已发布消费者两条都是反向指路。第二条卡面已说明;第一条同样过期 —— `:root` / `.dark` 的 token 默认值随 `@object-ui/components/style.css` 一起到货,消费者不需要自己补 Shadcn CSS 变量,`rules/styling.md:196` 原话就是「You do **not** restate those tokens in a `@theme` block of your own」。两条并列时,入口面给出的诊断是「缺变量 + 缺 @source」,恰好是 #4858 判定失效的那一组。

**改后**(与三份子指南同向,并把两种场景的完整答案指回 `rules/styling.md`,入口不留第二份说法)

```
- Missing the published stylesheet imports — `@object-ui/components/style.css` then
  `@object-ui/fields/style.css`, in that order — components render but look completely
  unstyled. The components sheet carries the theme tokens and the `:root` / `.dark`
  defaults; the fields sheet is a subtracted supplement that resolves against them.
- Pointing Tailwind at the installed ObjectUI packages instead of importing those two
  sheets: the published tarballs carry `dist` only, so the theme block the themed
  utilities are built on is not there to scan. Inside the ObjectUI workspace the reverse
  holds — packages are linked to their sources, an app scans them and declares the theme
  itself. See `rules/styling.md` for both cases; do not keep a second copy of the answer
  here.
```

与子指南的对照(逐字):

| 子指南 | 现文 |
| --- | --- |
| `guides/project-setup.md:451` | Missing the `@object-ui/components/style.css` / `@object-ui/fields/style.css` imports — ObjectUI's own utilities never reach the page |
| `guides/page-builder.md:477` | Forgetting the `@object-ui/components/style.css` and `@object-ui/fields/style.css` imports, or importing them in the wrong order — ObjectUI's utilities never reach the page. |
| `rules/styling.md:219` | Inside the ObjectUI workspace the picture is different, and `@source` is right there |

入口两条现在是这三句的摘要 + 指路,场景区分与 `page-builder.md` 一致。

## 二、`skills/objectui/evals/project-setup.json`

三条 eval 的 `expected_output` 与 `must_contain` 都把旧样板当正确答案,照修正后的指南作答会扣分。改为按 `style.css` 正路计分。

| eval | `must_contain` 改前 | 改后 |
| --- | --- | --- |
| 1 | `package.json`, `vite.config`, `@source`, `@theme`, `SchemaRenderer` | `package.json`, `vite.config`, `@object-ui/components/style.css`, `@object-ui/fields/style.css`, `SchemaRenderer` |
| 2 | `@source`, `@theme`, `--color-`, `:root` | `@import`, `@object-ui/components/style.css`, `@object-ui/fields/style.css`, `order` |
| 3 | `plugin`, `import`, `ComponentRegistry`, `@source` | `@object-ui/plugin-grid`, `@object-ui/plugin-kanban`, `import`, `ComponentRegistry` |

`must_not_contain` 加了旧样板的特征串 `node_modules/@object-ui`(三条都加)。选它而不是 `@source` / `@theme`,是因为后两者会出现在**正确答案的解释性散文**里(指南自己就写「the `@theme` block those utilities are built on」),拿去做负向断言会反过来罚掉最好的答案;而 `node_modules/@object-ui` 只出现在错误**指令**里 —— 三份指南的警告句都写成「the ObjectUI packages inside `node_modules`」,没有一处拼出这个串。

## 三、eval 3 的前置查证:plugin 包到底有没有 `style.css`

按卡面要求,改写 eval 3 前先从树上把这个问题答了(基线 `40d3a3318`)。

**结论:插件包不发布 `style.css`,也根本不产出任何 CSS。**

1. 遍历全部 40 个 `packages/*/package.json` 的 `exports`,声明 `"./style.css": "./dist/index.css"` 的只有 `@object-ui/components` 与 `@object-ui/fields`。没有任何 `@object-ui/plugin-*` 有这个导出。
2. `scripts.build`:components 是 `vite build && node scripts/build-css.mjs`,fields 是 `tsc && vite build && node scripts/build-css.mjs`,而 `plugin-grid` / `plugin-kanban` 是裸 `vite build`。`scripts/build-css.mjs` 正是把 `src/index.css` 编成 `dist/index.css` 的那一步,插件包没有。
3. `packages/plugin-grid/src` 与 `packages/plugin-kanban/src` 下一个 `.css` 文件都没有。
4. 两个插件包的 `files` 同样是 `["dist","README.md","CHANGELOG.md","LICENSE"]`,源码不发布 —— 与 components / fields 一致。

**因此 eval 3 的正确答案形状**是:注册那半靠 `pnpm add` + 入口处的 side-effect `import`(填 `ComponentRegistry`,漏了就是 `Unknown component type`);样式那半**没有第三张表可导**,工作区里靠 app 自己的 Tailwind 入口为每个插件包加一行 `@source` 扫其 `src`(`apps/console/src/index.css` 是维护中的参照)。`expected_output` 按这个形状重写,`must_not_contain` 里的 `@object-ui/plugin-grid/style.css` 就是把「插件有样式表」这个不存在的导出钉成负向断言。

## 四、方向对偶(文档/评分类改动,无行为门可红,用正向判据)

| 作答方式 | 改前 | 改后 |
| --- | --- | --- |
| 旧样板(`@source '../node_modules/@object-ui/plugin-grid/src/**'` + 自建 `@theme` / `:root`) | eval 1/2/3 **全过**(`@source`、`@theme`、`--color-`、`:root` 全部命中) | eval 1/2/3 **全不过**(`must_not_contain` 命中 `node_modules/@object-ui`;`must_contain` 的两个 `style.css` 缺失) |
| 修正后指南的答法(导两张 `style.css`;插件只讲注册 + 工作区 `@source`) | eval 1/2 **不过**(不含 `@theme` / `--color-` / `:root`) | eval 1/2/3 **全过** |

即卡面要的「照修正后指南做得分、照旧做不得分」两个方向都成立,且改前的反向计分是可复现的:改前 eval 2 要求答案同时含 `@theme`、`--color-`、`:root`,而 `guides/project-setup.md` 现在给的 `index.css` 模板三样都没有。

## 五、验证

| 命令 | 结果 |
| --- | --- |
| `node scripts/check-control-bytes.mjs` | OK,scanned 4407 tracked text file(s) |
| `node scripts/check-skills-paths.mjs` | OK,93/94 stated path(s) resolve across 18 guide file(s);1 baselined |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 两个改动文件 | 零命中(自查,超出 gate 扫描面) |
| `node -e "require('./skills/objectui/evals/project-setup.json')"` | 解析通过,evals: 3,ids 1,2,3 |
| `pnpm exec turbo run type-check --concurrency=2` | **81 successful, 81 total** |
| `node scripts/check-changeset-presence.mjs` | 「No source of a released package changed in this range, so no changeset is owed.」 |

**changeset**:不需要。gate 只管「changesets 覆盖的包的 `src/`」,`skills/**` 不在其内;前序 PR #4866 同样是纯 `skills/**` 改动、同样零 changeset。

## 六、相邻缺陷(已立卡,未在本 PR 修)

**#4929** —— 上面第三节的查证还量出一件 eval 不该替仓库现场发明答案的事:`packages/components/src/index.css:14` 是 `@source '../src/**'`、`packages/fields/src/index.css:43` 是 `@source './**'`,两张已发布表按构造只扫各自的包,于是插件独有的类一个都不在里面。逐字面 grep 量到 **21 个主题化 utility**(`bg-card/60`、`ring-primary/60`、`bg-muted/15`、`shadow-primary/25` …)被 plugin-grid / plugin-kanban 源码使用而两张表零覆盖 —— 发布态消费者渲染 grid / kanban 时它们没有任何来源。怎么补(插件各发一张减法表 / 并进 components / 只补文档)是公开契约取舍,已按三个选项写进 #4929 交维护者,本 PR 不碰。

因此 eval 3 的 `expected_output` 只写到「工作区靠 `@source`,发布态没有插件样式表可导」为止 —— 把尚未定案的发布态插件样式路径写进评分面,等于在评分面上现造契约。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_