### PR TITLE
fix(fields): 接通 slider 的三条 a11y 通道、命名 signature、把 aria-invalid 账本拆成两个语义位 (#3318)

### DIFF
--- a/.changeset/slider-signature-host-aria-channels.md
+++ b/.changeset/slider-signature-host-aria-channels.md
@@ -1,0 +1,36 @@
+---
+"@object-ui/components": patch
+"@object-ui/fields": patch
+---
+
+fix(fields): deliver the host's a11y channels to `slider` and name `signature`
+
+`SliderField` and `SignatureField` forwarded nothing a form host handed them —
+neither spread `toDomProps(props)` at all — so `<FormControl>`'s whole payload
+landed on nothing. Measured on a real form, one required field per row, freshly
+failed validation:
+
+```
+slider     ariaInvalidTrue=[]  labelFor=…-form-item -> DANGLING  descConsumers=0  ids=[]
+signature  ariaInvalidTrue=[]  labelFor=…-form-item -> DANGLING  descConsumers=0  ids=[]
+text       ariaInvalidTrue=[input]  labelFor -> input            descConsumers=1
+```
+
+`ids=[]` is the tell: no element in either row carried an id at all, so the
+visible label pointed `for` at nothing, the rendered help text had zero
+consumers, and a failed slider announced no error state.
+
+**`slider`** now delivers all three. Its focusable control is Radix's
+`span[role="slider"]` thumb, which the synced `ui/slider.tsx` renders internally
+and does not export, so the primitive grew a declared `thumbProps` — routed
+through a new `lib/slider-thumb` and applied to the no-touch file as a declared
+sync patch, so it survives regeneration. The split of which keys stay on Root
+(`name`, `disabled`) is the one the `select` fix already settled.
+
+**`signature`** gets the name and the description on a `role="group"` container.
+Its control state deliberately does not follow: the drawing surface is a
+`<canvas>` with no keyboard path, and its only other element is disabled while
+the pad is empty, so there is no element a control state could be read from.
+
+Both are now declared `labelling: 'group'` — a `<span>` and a `<canvas>` are not
+labelable elements, so a host `for` could only dangle at them.

--- a/packages/components/src/lib/slider-thumb.ts
+++ b/packages/components/src/lib/slider-thumb.ts
@@ -1,0 +1,98 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type * as React from 'react';
+
+/**
+ * The payload of the `slider-thumb-pass-through` local patch
+ * (`scripts/shadcn-local-patches.mjs`, objectui#3318).
+ *
+ * ## The defect this exists for
+ *
+ * A Radix slider's focusable control is the THUMB — `span[role="slider"]`,
+ * `tabindex="0"`, the element that carries `aria-valuenow` and the one a
+ * keyboard user and their screen reader actually land on. `Slider.Root` renders
+ * a role-less wrapper `span` and forwards every unrecognised prop to it, so a
+ * host's control-channel facts (`id`, `aria-invalid`, `aria-describedby`,
+ * `aria-labelledby`, `aria-required`) landed on a wrapper assistive technology
+ * never visits. Measured on `origin/main`, a real form + a required slider that
+ * had just failed validation:
+ *
+ * ```
+ * slider  ariaInvalidTrue=[]  labelFor=…-form-item -> DANGLING
+ *         descConsumers=0     focusable=[span[slider],input]
+ *         ids=[]              <- no element of the row carried an id at all
+ * ```
+ *
+ * This is the same shape objectui#3306 fixed for `select`, one step harder:
+ * there the focusable control is `SelectTrigger`, a component the primitive
+ * EXPORTS, so the widget could address it directly. `ui/slider.tsx` renders its
+ * thumb internally and exports only `Slider`, so the widget has no handle on
+ * the one element that must carry the state — hence a pass-through.
+ *
+ * ## Why a declared prop and not an implicit bridge
+ *
+ * The primitive could instead have COPIED a fixed list of `aria-*` keys from
+ * its own props down to the thumb. Rejected: the copy would leave the same keys
+ * on Root as well, and for `id` that is not a duplicate attribute but a
+ * duplicate DOM ID — `document.getElementById` answers with the wrapper, so a
+ * host `<label for>` would resolve to the non-focusable span and the bug would
+ * survive its own fix wearing a green test. Splitting is therefore mandatory,
+ * and once the caller must say which keys go where, saying it explicitly is
+ * strictly better than a list the caller cannot see (AGENTS.md #0.1: one strict
+ * contract, no consumer-side guessing).
+ *
+ * ## Where the split is decided
+ *
+ * Not here — this only routes. The widget decides, and `SliderField` mirrors
+ * `SelectField`'s #3306 split exactly: `name` and `disabled` stay on Root (Root
+ * owns the hidden form input and is the single disabled authority), everything
+ * else in the DOM pass-through whitelist goes to the thumb.
+ */
+
+/** Props the `Slider` wrapper hands to its internal `SliderPrimitive.Thumb`. */
+export interface SliderThumbPassThrough {
+  /**
+   * Forwarded verbatim onto the focusable `span[role="slider"]`.
+   *
+   * Deliberately typed as the DOM attribute surface rather than
+   * `ComponentPropsWithoutRef<typeof SliderPrimitive.Thumb>`: this module must
+   * not import the primitive (it is consumed BY the no-touch file, and a cycle
+   * through it would be a fragile thing to hang a sync patch on), and the thumb
+   * is a plain `span` as far as every key a host delivers is concerned.
+   */
+  thumbProps?: React.HTMLAttributes<HTMLSpanElement> & {
+    id?: string;
+    tabIndex?: number;
+    'aria-label'?: string;
+  };
+}
+
+/**
+ * Route a `Slider`'s props to the two elements that need them.
+ *
+ * `thumbProps` is REMOVED from the root half — leaving it there would put
+ * `thumbprops="[object Object]"` on the wrapper span, which is exactly the leak
+ * objectui#3291's sweep exists to catch.
+ *
+ * The pre-existing `aria-label` bridge is preserved and applied FIRST, so a
+ * caller that passes both keeps the explicit `thumbProps` value; nothing about
+ * the attribute's previous behaviour changes for callers that pass neither.
+ */
+export function splitSliderThumbProps<P extends Record<string, unknown>>(
+  props: P,
+): { root: Omit<P, 'thumbProps'>; thumb: Record<string, unknown> } {
+  const { thumbProps, ...root } = props as P & SliderThumbPassThrough;
+  return {
+    root: root as Omit<P, 'thumbProps'>,
+    thumb: {
+      'aria-label': props['aria-label'] as string | undefined,
+      ...(thumbProps ?? {}),
+    },
+  };
+}

--- a/packages/components/src/ui/slider.tsx
+++ b/packages/components/src/ui/slider.tsx
@@ -12,10 +12,11 @@ import * as React from "react"
 import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "../lib/utils"
+import { splitSliderThumbProps, type SliderThumbPassThrough } from "../lib/slider-thumb"
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & SliderThumbPassThrough
 >(({ className, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
@@ -23,14 +24,14 @@ const Slider = React.forwardRef<
       "relative flex w-full touch-none select-none items-center",
       className
     )}
-    {...props}
+    {...splitSliderThumbProps(props).root}
   >
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
     <SliderPrimitive.Thumb
       className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-      aria-label={props["aria-label"]}
+      {...splitSliderThumbProps(props).thumb}
     />
   </SliderPrimitive.Root>
 ))

--- a/packages/fields/src/__tests__/group-labelling-declaration.test.ts
+++ b/packages/fields/src/__tests__/group-labelling-declaration.test.ts
@@ -42,6 +42,11 @@ import { registerAllFields, mapFieldTypeToFormType } from '../index';
  * chip row is the same wrapper `div` holding the host id that `checkboxes` had.
  * It is listed here rather than left to the e2e file alone because the omission
  * of a declaration is exactly the failure that degrades silently.
+ *
+ * `slider` and `signature` (objectui#3318) are the eighth and ninth, and both
+ * are `file`'s shape rather than a composite: ONE surface, which happens not to
+ * be labelable. A slider's control is Radix's `span[role="slider"]` thumb; a
+ * signature's is a `<canvas>`. `<label for>` reaches neither.
  */
 const GROUP_LABELLED = [
   'address',
@@ -51,6 +56,8 @@ const GROUP_LABELLED = [
   'rating',
   'file',
   'multiselect',
+  'slider',
+  'signature',
 ] as const;
 
 /**

--- a/packages/fields/src/__tests__/slider-signature-host-channels-e2e.test.tsx
+++ b/packages/fields/src/__tests__/slider-signature-host-channels-e2e.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * GATE: the three things a form host hands a field widget all reach an element
+ * that can carry them — for the two widgets that forwarded NONE of them
+ * (objectui#3318's ledger remainder).
+ *
+ * ## Why one file for three channels
+ *
+ * The registry sweep next door measures ONE axis, `aria-invalid`, and that is
+ * what put `slider` and `signature` on its ledger. But the cause was never
+ * per-attribute: neither widget spread `toDomProps(props)` at all, so
+ * `<FormControl>`'s Slot delivered its whole payload into nothing. Measured on
+ * `origin/main`, a real form, the field required and freshly failed:
+ *
+ * ```
+ * slider     ariaInvalidTrue=[]  labelFor=…-form-item -> DANGLING  descConsumers=0  ids=[]
+ * signature  ariaInvalidTrue=[]  labelFor=…-form-item -> DANGLING  descConsumers=0  ids=[]
+ * text       ariaInvalidTrue=[input]  labelFor -> input            descConsumers=1  (control)
+ * ```
+ *
+ * `ids=[]` is the tell: not "the id was overwritten" (objectui#3952's shape on
+ * `boolean`) but "no element in the row carried an id at all". Removing one
+ * ledger row therefore closes three defects, and pinning only the one the
+ * ledger names would leave the other two free to regress with the sweep still
+ * green — which is exactly how they survived the first delivery batch.
+ *
+ * ## Why the label channel needed more than the spread
+ *
+ * A `for` that RESOLVES is not a label that WORKS. `<label for>` only addresses
+ * HTML's labelable elements (`button`, `input`, `meter`, `output`, `progress`,
+ * `select`, `textarea`); a slider's control is Radix's `span[role="slider"]`
+ * thumb and a signature's is a `<canvas>`, so handing either the host id would
+ * merely upgrade a dangling `for` to an inert one. Both are therefore declared
+ * `labelling: 'group'` (objectui#3961's route, `file`'s shape rather than a
+ * composite's) and named by IDREF. This file registers them WITH that
+ * declaration, because it is the production registration and the association
+ * cannot be observed without it.
+ *
+ * ## The asymmetry between the two, and why it is deliberate
+ *
+ * `slider` HAS a focusable control, so it takes the full DOM pass-through and
+ * carries its own validation state. `signature` has none — the canvas offers no
+ * keyboard path and Clear is disabled while the pad is empty — so it takes the
+ * name and the description on a `role="group"` container and NOT the control
+ * state, the boundary `toHostGroupProps` draws. Both directions are pinned
+ * below, so neither "spread it all" nor "take it all back" can pass quietly.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { withFieldCarrier } from '../withFieldCarrier';
+import { SliderField } from '../widgets/SliderField';
+import { SignatureField } from '../widgets/SignatureField';
+import { TextField } from '../widgets/TextField';
+
+const HELP = 'How firmly do you agree';
+
+beforeAll(() => {
+  // Registered exactly as `registerField` does for a member of
+  // FIELD_TYPES_GROUP_LABELLED — the declaration is half of what is under test.
+  // Registered one by one rather than over a tuple: the two widgets implement
+  // `FieldWidgetComponentProps` at different value types, and a shared loop
+  // variable would only unify them through `any`.
+  ComponentRegistry.register('slider', withFieldCarrier(SliderField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'group',
+  });
+  ComponentRegistry.register('signature', withFieldCarrier(SignatureField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'group',
+  });
+  // Positive control: an ordinary single-control widget, undeclared, whose
+  // label reaches a labelable element the plain way.
+  ComponentRegistry.register('text', withFieldCarrier(TextField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+  });
+}, 60000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(type: string, opts: { readonly?: boolean } = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues: { f: null },
+        fields: [
+          {
+            name: 'f',
+            label: 'Confidence',
+            type: `field:${type}`,
+            required: true,
+            description: HELP,
+            ...(opts.readonly ? { readonly: true } : {}),
+          },
+        ],
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+async function formRow(): Promise<Element> {
+  return waitFor(() => {
+    const row = document.querySelector('[data-field="f"]');
+    if (!row) throw new Error('field row never rendered');
+    return row;
+  });
+}
+
+/** Submit and prove the failure RENDERED before reading any aria off it. */
+async function failValidation(): Promise<Element> {
+  fireEvent.click(screen.getByRole('button', { name: /create/i }));
+  await waitFor(() => {
+    expect(document.querySelector('[data-field="f"]')?.textContent ?? '').toContain('is required');
+  });
+  return formRow();
+}
+
+/** The rendered `<FormDescription>` and everything that references it. */
+function describedByConsumers(row: Element): Element[] {
+  const desc = Array.from(row.querySelectorAll('p')).find((p) => p.textContent === HELP);
+  const id = desc?.getAttribute('id');
+  expect(desc, 'the field rendered no description to point at').toBeTruthy();
+  expect(id, 'the rendered description carries no id to be referenced by').toBeTruthy();
+  return Array.from(row.querySelectorAll('[aria-describedby]')).filter((el) =>
+    (el.getAttribute('aria-describedby') ?? '').split(/\s+/).includes(id!),
+  );
+}
+
+describe('slider delivers all three host channels to its thumb (objectui#3318)', () => {
+  it('marks the FOCUSABLE control invalid — not the wrapper Radix renders', async () => {
+    renderForm('slider');
+    const row = await formRow();
+
+    // No premature alarm, and the explicit "false": a valid field SAYS so.
+    expect(row.querySelector('[aria-invalid="true"]')).toBeNull();
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-invalid', 'false');
+
+    const after = await failValidation();
+    const marked = after.querySelectorAll('[aria-invalid="true"]');
+
+    expect(marked).toHaveLength(1);
+    // The whole point of the components-level change: the attribute is on the
+    // element with the widget role, not on Root's role-less span. Asserting the
+    // ROLE (rather than "some element in the row") is what makes this fail if a
+    // later refactor moves the delivery back up to the wrapper.
+    expect(marked[0]).toBe(screen.getByRole('slider'));
+  });
+
+  it('is NAMED by its visible label, by IDREF', async () => {
+    renderForm('slider');
+    const row = await formRow();
+
+    const label = row.querySelector('label')!;
+    // A `for` here could only dangle or resolve to a non-labelable span, so the
+    // group route drops it and publishes an id instead.
+    expect(label).not.toHaveAttribute('for');
+    expect(label.id).toBeTruthy();
+
+    const thumb = screen.getByRole('slider');
+    expect(thumb).toHaveAttribute('aria-labelledby', label.id);
+    // The IDREF resolves, and the name that comes out is the visible one.
+    expect(document.getElementById(label.id)).toBe(label);
+    expect(screen.getByRole('slider', { name: /Confidence/ })).toBe(thumb);
+  });
+
+  it('is DESCRIBED by its help text, on the same control', async () => {
+    renderForm('slider');
+    const row = await formRow();
+
+    const consumers = describedByConsumers(row);
+    expect(consumers).toHaveLength(1);
+    expect(consumers[0]).toBe(screen.getByRole('slider'));
+  });
+
+  it('carries the host id on the thumb, and only there', async () => {
+    renderForm('slider');
+    const row = await formRow();
+
+    const thumb = screen.getByRole('slider');
+    expect(thumb.id).toBeTruthy();
+    // Exactly one element may answer to a given id. The root-half of the
+    // primitive patch is what keeps this true; without it the id would sit on
+    // the wrapper as well and `getElementById` would answer with the wrapper.
+    expect(document.getElementById(thumb.id)).toBe(thumb);
+    expect(row.querySelectorAll(`[id="${thumb.id}"]`)).toHaveLength(1);
+  });
+
+  it('leaks no renderer plumbing onto the thumb (objectui#3291)', async () => {
+    renderForm('slider');
+    await formRow();
+
+    const thumb = screen.getByRole('slider');
+    // `name` is DOM-legal on form controls only; on this span it is the leak
+    // class the sweep exists for. It stays on Root, which owns the hidden input.
+    expect(thumb).not.toHaveAttribute('name');
+    expect(thumb).not.toHaveAttribute('thumbprops');
+    // The thumb keeps its own shape: a host className must not replace it.
+    expect(thumb.className).toContain('rounded-full');
+  });
+
+  it('readonly: the row that renders no control is still named and described', async () => {
+    renderForm('slider', { readonly: true });
+    const row = await formRow();
+
+    const label = row.querySelector('label')!;
+    const named = row.querySelector('[role="group"]')!;
+    expect(named).toHaveAttribute('aria-labelledby', label.id);
+    expect(describedByConsumers(row)).toEqual([named]);
+    // Control-channel state does not follow it there (objectui#4005's line).
+    expect(named).not.toHaveAttribute('aria-invalid');
+  });
+});
+
+describe('signature is named and described, and marks nothing (objectui#3318)', () => {
+  it('is NAMED by its visible label on a container that can carry a name', async () => {
+    renderForm('signature');
+    const row = await formRow();
+
+    const label = row.querySelector('label')!;
+    expect(label).not.toHaveAttribute('for');
+
+    const group = screen.getByRole('group');
+    expect(group).toHaveAttribute('aria-labelledby', label.id);
+    expect(screen.getByRole('group', { name: /Confidence/ })).toBe(group);
+    // The canvas is inside the named group; it is not itself the name carrier,
+    // because a role-less element cannot take an author name.
+    expect(group.querySelector('canvas')).toBeTruthy();
+  });
+
+  it('is DESCRIBED by its help text on that same container', async () => {
+    renderForm('signature');
+    const row = await formRow();
+
+    const consumers = describedByConsumers(row);
+    expect(consumers).toHaveLength(1);
+    expect(consumers[0]).toBe(screen.getByRole('group'));
+  });
+
+  it('does NOT take control-channel state, because it has no control', async () => {
+    renderForm('signature');
+    await formRow();
+    const after = await failValidation();
+
+    // The other half of objectui#3318's split verdict for this widget, pinned
+    // from the positive side so a later "just spread everything" is caught
+    // here as well as by the sweep's NOT_APPLICABLE guard.
+    expect(after.querySelector('[aria-invalid="true"]')).toBeNull();
+    expect(screen.getByRole('group')).not.toHaveAttribute('aria-required');
+  });
+});
+
+describe('the single-control path is untouched (control group)', () => {
+  it('text keeps a working `for` and takes no IDREF name', async () => {
+    renderForm('text');
+    const row = await formRow();
+
+    const label = row.querySelector('label')!;
+    const input = row.querySelector('input')!;
+    expect(label).toHaveAttribute('for', input.id);
+    // Two channels naming one control is the thing the declaration avoids.
+    expect(input).not.toHaveAttribute('aria-labelledby');
+    expect(describedByConsumers(row)).toEqual([input]);
+  });
+});

--- a/packages/fields/src/__tests__/widget-aria-invalid-registry-e2e.test.tsx
+++ b/packages/fields/src/__tests__/widget-aria-invalid-registry-e2e.test.tsx
@@ -23,15 +23,40 @@
  * with a swallowed or missing `aria-invalid` fails here by name instead of
  * shipping.
  *
- * ## The ratchet
+ * ## The ratchet, and its two ledgers
  *
  * Widgets listed in {@link NOT_YET_DELIVERED} are known not to deliver the
  * attribute today. They are asserted in the OPPOSITE direction — the sweep
  * proves they still do NOT deliver — so fixing one turns its entry red and
  * forces its removal from the ledger. The ledger can only shrink; a widget can
  * never silently regress INTO it, and a fix can never silently go unrecorded.
- * The remaining entries are tracked as follow-up work (see the ledger's doc
- * comment); this file is the source of truth for what is left.
+ *
+ * {@link NOT_APPLICABLE} is the OTHER answer, and it is a different claim, not
+ * a softer one (objectui#3318 triage). `aria-invalid` is control-channel state:
+ * it reports what a user's own editing may do wrong, to the element they would
+ * edit. A widget that renders no focusable control has no such element, and
+ * marking its text span instead would be precisely the non-focusable-wrapper
+ * move this sweep exists to forbid. Those types are not waiting for a delivery
+ * that should happen; they are recorded as types where the attribute does not
+ * apply, each with the reason in the ledger itself.
+ *
+ * That second ledger is only safe because a reclassification is FALSIFIABLE.
+ * Three structures make "move the row instead of doing the work" fail loudly:
+ *
+ *  1. `DELIVERING` is DERIVED (`ALL_TYPES` minus both ledgers), so the three
+ *     sets partition the registry by construction. Deleting a row from both
+ *     ledgers does not retire it — it lands in the positive sweep, which is the
+ *     strictest assertion of the three.
+ *  2. Every `NOT_APPLICABLE` row carries its own GUARD: the sweep measures that
+ *     the widget's row really does offer no focusable control. `grid` cannot be
+ *     moved there to tidy the ledger — it renders a button, so the guard goes
+ *     red. The same guard is what fails the day someone gives one of these
+ *     widgets a real control and leaves the row behind.
+ *  3. The two ledgers are asserted DISJOINT and to name only real types, so a
+ *     row cannot be double-booked or left pointing at a widget that is gone.
+ *
+ * What survives in `NOT_YET_DELIVERED` is tracked as follow-up work; this file
+ * is the source of truth for what is left.
  *
  * ## Discipline inherited from the #3291 sweep
  *
@@ -157,55 +182,105 @@ const WIDGETS: Record<string, ComponentType<any>> = {
 /**
  * THE RATCHET LEDGER — widget types MEASURED (by this very sweep, run with an
  * empty ledger) not to put `aria-invalid` on any element of their row after a
- * real validation failure. Every entry is a known accessibility gap tracked in
- * objectui#3318, not an accepted state: the field shows its red message while
- * assistive tech is told nothing.
+ * real validation failure, and which SHOULD. Every entry is a known
+ * accessibility gap tracked in objectui#3318, not an accepted state: the field
+ * shows its red message while assistive tech is told nothing.
  *
  * The objectui#3318 delivery batch cleared 20 of the original 29 entries with
- * the objectui#3222/#3306 pattern. What remains cannot take that pattern
- * as-is; each entry names why, so the follow-up starts from the blocker and
- * not from a re-audit:
+ * the objectui#3222/#3306 pattern, and the remainder pass cleared `slider` and
+ * reclassified seven (see {@link NOT_APPLICABLE}). One is left, and it is the
+ * one that needs a DESIGN rather than a spread:
  *
- * - `formula` / `summary` / `auto_number` / `vector` — read-only computed /
- *   display widgets: they render static text and NO focusable control, so
- *   there is no element assistive tech would read the state from (marking the
- *   text span would be exactly the non-focusable-wrapper move this ledger's
- *   rules forbid). A `required` failure on a non-editable field is a metadata
- *   authoring problem more than a widget one.
  * - `grid` — composite line-item editor with its own per-CELL `aria-invalid`
- *   for line validation; driving it from a FORM-level failure needs a design
- *   (which cell? the add-row button?) rather than a spread.
- * - `slider` — the focusable thumb (`role="slider"`, the ARIA-designated
- *   carrier) is rendered inside the synced shadcn `ui/slider.tsx` (a #7
- *   no-touch file), which forwards arbitrary props only to its non-focusable
- *   Root span; delivering needs a components-level change.
- * - `signature` — the drawing `<canvas>` is not focusable at all (no keyboard
- *   input path exists); the only focusable element is the auxiliary Clear
- *   button. Needs a real a11y design, not an attribute.
- * - `filter-condition` / `recipient-picker` — dependency-gated: with no
- *   sibling `object_name` / `recipient_type` chosen (the state a fresh form
- *   and THIS SWEEP render) they show a hint paragraph with no focusable
- *   control. Their editable states DO deliver `aria-invalid` since #3318's
- *   delivery batch.
+ *   for line validation; driving it from a FORM-level failure has no obvious
+ *   target (which cell? the add-row button?). It is emphatically NOT a
+ *   `NOT_APPLICABLE` candidate: its row DOES offer a focusable control, which
+ *   is exactly what that ledger's guard measures.
  *
  * Do NOT add to this list to make a new widget pass; fix the widget (the
  * objectui#3222/#3306 pattern: spread `toDomProps(props)` onto the real
- * focusable control — never a non-DOM Radix Root — then `aria-invalid=
- * {!!error}` after the spread). An entry is removed by fixing the widget: the
- * sweep asserts each entry still fails to deliver, so a fixed widget turns
- * its own ledger row red until it is removed here. The ledger only shrinks.
+ * focusable control — never a non-DOM Radix Root, never a wrapper — then
+ * `aria-invalid={!!error}` after the spread). An entry is removed by fixing the
+ * widget: the sweep asserts each entry still fails to deliver, so a fixed
+ * widget turns its own ledger row red until it is removed here. The ledger only
+ * shrinks.
  */
-const NOT_YET_DELIVERED: ReadonlySet<string> = new Set([
-  'formula',
-  'summary',
-  'auto_number',
-  'vector',
-  'grid',
-  'slider',
-  'signature',
-  'filter-condition',
-  'recipient-picker',
+const NOT_YET_DELIVERED: ReadonlySet<string> = new Set(['grid']);
+
+/**
+ * THE SECOND LEDGER — widget types for which `aria-invalid` is not a delivery
+ * that is owed, because there is no element that could carry it: the row
+ * renders NO focusable control at all (objectui#3318's triage).
+ *
+ * This is a semantic verdict, so every row states its ground, and the sweep
+ * then MEASURES that ground rather than trusting it — see the "no focusable
+ * control" case below. A row whose widget grows a real control goes red here
+ * and has to move to {@link NOT_YET_DELIVERED} or be delivered outright; a row
+ * moved here to escape the first ledger goes red on arrival.
+ *
+ * Reachability note, because the two ledgers are graded differently: the first
+ * ledger judges a VALUE (does the attribute arrive?) and its rows must reach a
+ * real rendered control. These rows judge the opposite fact — that no such
+ * control exists — so the assertion is about what the row does NOT contain, in
+ * the exact state this sweep renders (fresh, empty, required, just failed).
+ *
+ * That state is named deliberately rather than as a hedge, and it is the whole
+ * of what these rows claim. The four read-only types render their EMPTY-value
+ * branch here (an `EmptyValue` placeholder, not the formatted-value span), and
+ * `signature`'s Clear button becomes focusable only once something has been
+ * drawn. Both are the right state to judge: `required` is a PRESENCE check, so
+ * the moment the attribute would have to be announced is exactly the moment the
+ * value is missing. A row saying "no control, therefore nothing to mark" is
+ * saying it about that moment — verified there, and claiming nothing about a
+ * filled field, which is not the one failing.
+ */
+const NOT_APPLICABLE: ReadonlyMap<string, string> = new Map([
+  [
+    'formula',
+    'Read-only computed display: renders the backend-computed value as text, no control.',
+  ],
+  [
+    'summary',
+    'Read-only aggregation display: renders the rolled-up value as text, no control.',
+  ],
+  [
+    'auto_number',
+    'Read-only system-generated display: renders the assigned number as text, no control.',
+  ],
+  [
+    'vector',
+    'Read-only embedding preview: renders a truncated numeric preview as text, no control.',
+  ],
+  [
+    'signature',
+    'Drawing surface is a <canvas> with no keyboard path; the one other element, Clear, is disabled while empty. Its LABEL is a separate half and IS delivered — see FIELD_TYPES_GROUP_LABELLED.',
+  ],
+  [
+    'filter-condition',
+    'Dependency-gated: with no sibling object_name chosen — the state a fresh form renders — it shows a hint paragraph and no control. Its editable state delivers.',
+  ],
+  [
+    'recipient-picker',
+    'Dependency-gated: with no sibling recipient_type chosen — the state a fresh form renders — it shows a hint paragraph and no control. Its editable state delivers.',
+  ],
 ]);
+
+/**
+ * HTML's own focusability rules, as a selector: the elements a keyboard user
+ * can land on and therefore the only ones assistive technology would read a
+ * control state from. `:not([disabled])` matters — a disabled button is not in
+ * the tab order, which is why `signature`'s Clear button does not count while
+ * the pad is empty.
+ */
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',');
 
 /** Option widgets render an "unfillable" placeholder unless offered a list. */
 const OPTION_TYPES = new Set(['select', 'multiselect', 'radio', 'checkboxes', 'tags']);
@@ -288,18 +363,54 @@ afterEach(() => {
 });
 
 const ALL_TYPES = Object.keys(WIDGETS);
-const DELIVERING = ALL_TYPES.filter((type) => !NOT_YET_DELIVERED.has(type));
+// DERIVED, never listed: a type is swept positively unless a ledger claims it.
+// This is what makes "quietly retire a row" impossible — dropping a row from
+// both ledgers promotes the widget into the strictest assertion of the three,
+// it does not excuse it.
+const DELIVERING = ALL_TYPES.filter(
+  (type) => !NOT_YET_DELIVERED.has(type) && !NOT_APPLICABLE.has(type),
+);
 const LEDGERED = ALL_TYPES.filter((type) => NOT_YET_DELIVERED.has(type));
+const INAPPLICABLE = ALL_TYPES.filter((type) => NOT_APPLICABLE.has(type));
 
 describe('every registered field widget announces a failed validation (objectui#3306)', () => {
   it('covers every field type the form can render', () => {
     expect(Object.keys(WIDGETS).sort()).toEqual([...FORM_FIELD_TYPES].sort());
   });
 
-  it('the ledger only names types that exist', () => {
+  it('both ledgers only name types that exist', () => {
     // A renamed/removed widget must not leave a stale ledger entry that would
     // silently assert against nothing.
-    expect([...NOT_YET_DELIVERED].filter((type) => !(type in WIDGETS))).toEqual([]);
+    const stale = [...NOT_YET_DELIVERED, ...NOT_APPLICABLE.keys()].filter(
+      (type) => !(type in WIDGETS),
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it('the two ledgers are mutually exclusive', () => {
+    // A type in both would be claimed as owed AND as not owed at once, and
+    // whichever case ran second would look like it had been considered.
+    const both = [...NOT_YET_DELIVERED].filter((type) => NOT_APPLICABLE.has(type));
+    expect(both).toEqual([]);
+  });
+
+  it('the three cases partition the registry — no type is swept twice or not at all', () => {
+    // Mechanical given the derivation above, and asserted anyway because it is
+    // the property every other case in this file leans on. Note what it does
+    // NOT catch, so nobody reads more into a green here than is there: deleting
+    // a row from both ledgers keeps this partition valid (the type simply moves
+    // into DELIVERING) and is caught one case down, by the positive sweep.
+    expect([...DELIVERING, ...LEDGERED, ...INAPPLICABLE].sort()).toEqual([...ALL_TYPES].sort());
+  });
+
+  it('every NOT_APPLICABLE row states its ground', () => {
+    // The row is a claim about the widget's markup; an unexplained one cannot
+    // be reviewed, and "it was already in the list" is how a wrong verdict
+    // outlives the reasoning that produced it.
+    const unexplained = [...NOT_APPLICABLE.entries()]
+      .filter(([, reason]) => reason.trim().length < 20)
+      .map(([type]) => type);
+    expect(unexplained).toEqual([]);
   });
 
   it.each(DELIVERING)(
@@ -334,6 +445,37 @@ describe('every registered field widget announces a failed validation (objectui#
       expect(
         after.querySelector('[aria-invalid="true"]'),
         `field:${type} now delivers aria-invalid — remove it from NOT_YET_DELIVERED so the sweep guards it forward`,
+      ).toBeNull();
+    },
+  );
+
+  it.each(INAPPLICABLE)(
+    'field:%s — NOT APPLICABLE: renders no focusable control, so there is nothing to mark',
+    async (type) => {
+      renderForm(fieldConfig(type));
+      await formRow();
+
+      const after = await failValidation();
+
+      // The GROUND of the verdict, measured rather than asserted in prose. Two
+      // separate futures turn this red, and both should:
+      //  - the widget gains a real control (an editable formula, a keyboard
+      //    path on the signature canvas, a gated picker that renders its input
+      //    up front) — the row now owes a delivery and must leave this ledger;
+      //  - someone parks a row here to empty NOT_YET_DELIVERED. `grid` is the
+      //    live specimen: it renders a button, so it fails on arrival.
+      const focusable = Array.from(after.querySelectorAll(FOCUSABLE));
+      expect(
+        focusable.map((el) => el.tagName.toLowerCase()),
+        `field:${type} is on the NOT_APPLICABLE ledger ("${NOT_APPLICABLE.get(type)}") but its row now offers a focusable control — the verdict has expired, move the row`,
+      ).toEqual([]);
+
+      // And the line this whole sweep draws: no control means the state does
+      // not go on a wrapper instead. A widget must not buy a green DELIVERING
+      // row by marking a text span.
+      expect(
+        after.querySelector('[aria-invalid="true"]'),
+        `field:${type} carries aria-invalid on a row with no focusable control — that marks a wrapper, which is the move this sweep forbids`,
       ).toBeNull();
     },
   );

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -2630,6 +2630,13 @@ const FIELD_TYPES_GROUP_LABELLED = new Set([
   'file',
   // objectui#3975 — the residual after #3961's six, same shape as `checkboxes`.
   'multiselect',
+  // objectui#3318 — two more of `file`'s shape, not composites:
+  //  - `slider`'s one control is Radix's `span[role="slider"]` thumb;
+  //  - `signature`'s drawing surface is a `<canvas>`.
+  // Neither is one of HTML's labelable elements, so a host `for` can only
+  // dangle at it; both must be named by IDREF instead.
+  'slider',
+  'signature',
 ]);
 
 export function registerField(fieldType: string): void {

--- a/packages/fields/src/widgets/SignatureField.tsx
+++ b/packages/fields/src/widgets/SignatureField.tsx
@@ -2,12 +2,48 @@ import React, { useRef, useEffect } from 'react';
 import { Button } from '@object-ui/components';
 import { Eraser } from 'lucide-react';
 import { FieldWidgetComponentProps } from './types';
+import { toHostGroupProps } from './toHostGroupProps';
 
 /**
  * Signature field widget - provides a signature pad for capturing signatures
  * Outputs signature as a base64 PNG image
+ *
+ * ## Naming, and the half that is deliberately absent (objectui#3318)
+ *
+ * This widget forwarded nothing a host handed it — every branch below wrote its
+ * attributes by hand — so its visible label pointed `for` at an id no element
+ * in the row carried, and the rendered help text had zero consumers. Measured
+ * on `origin/main`, a real form, this field required and freshly failed:
+ *
+ * ```
+ * signature  labelFor=…-form-item -> DANGLING  descConsumers=0  ids=[]
+ * ```
+ *
+ * The name and the description arrive here, on the container, through
+ * {@link toHostGroupProps} — the objectui#3961 route for a widget whose surface
+ * no `<label for>` can reach (`<canvas>` is not a labelable element), and which
+ * therefore declares `labelling: 'group'` in `FIELD_TYPES_GROUP_LABELLED`.
+ * `'instead-of-the-inputs'` because this field renders no input of its own for
+ * the description to land on: the Clear button is auxiliary — it acts on the
+ * value, it is not the value's control — the same reading that put
+ * `geolocation`'s focusable "View on map" link on that side of the split.
+ *
+ * `aria-invalid` and `aria-required` are NOT here, and their absence is a
+ * verdict rather than an omission. The drawing surface has no keyboard path at
+ * all (measured: this row offers zero focusable elements while empty — the only
+ * candidate, Clear, is `disabled` until something has been drawn), so there is
+ * no element assistive technology would read a control state from. Marking the
+ * container instead would announce a state with no control behind it — the
+ * non-focusable-wrapper move objectui#3291 and #3318 both draw the line
+ * against. The type is recorded in that sweep's NOT_APPLICABLE ledger with a
+ * guard that turns red the day a real control appears here.
  */
-export function SignatureField({ value, onChange, readonly }: FieldWidgetComponentProps<string>) {
+export function SignatureField({
+  value,
+  onChange,
+  readonly,
+  ...props
+}: FieldWidgetComponentProps<string>) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isDrawing, setIsDrawing] = React.useState(false);
   const [isEmpty, setIsEmpty] = React.useState(!value);
@@ -91,20 +127,26 @@ export function SignatureField({ value, onChange, readonly }: FieldWidgetCompone
     onChange('');
   };
 
+  const hostGroupProps = toHostGroupProps(props, 'instead-of-the-inputs');
+
   if (readonly && value) {
     return (
-      <div className="border rounded p-2 bg-white">
+      <div {...hostGroupProps} className="border rounded p-2 bg-white">
         <img src={value} alt="Signature" loading="lazy" className="max-w-full h-auto" />
       </div>
     );
   }
 
   if (readonly && !value) {
-    return <span className="text-sm text-muted-foreground">No signature</span>;
+    return (
+      <span {...hostGroupProps} className="text-sm text-muted-foreground">
+        No signature
+      </span>
+    );
   }
 
   return (
-    <div className="space-y-2">
+    <div {...hostGroupProps} className="space-y-2">
       <div className="border rounded bg-white">
         <canvas
           ref={canvasRef}

--- a/packages/fields/src/widgets/SliderField.tsx
+++ b/packages/fields/src/widgets/SliderField.tsx
@@ -1,12 +1,56 @@
 import React from 'react';
 import { Slider } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
+import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 
 /**
  * Slider field widget - provides a range slider input
  * Supports numeric values with configurable min, max, and step
+ *
+ * ## Where the host's facts go, and why (objectui#3318)
+ *
+ * This widget used to read exactly two keys off its props (`disabled`,
+ * `className`) and forward nothing else, so everything `<FormControl>`'s Slot
+ * delivered was dropped on the floor. Measured on `origin/main`, a real form
+ * with a required slider that had just failed validation:
+ *
+ * ```
+ * ariaInvalidTrue=[]   labelFor=…-form-item -> DANGLING
+ * descConsumers=0      ids=[]   <- no element of the row carried an id at all
+ * ```
+ *
+ * Three channels, one cause. The DOM pass-through now goes to the THUMB — the
+ * `span[role="slider"]` a keyboard user lands on, which is where ARIA state
+ * belongs — through the `thumbProps` the primitive grew for this
+ * (`lib/slider-thumb.ts`; the shadcn `ui/slider.tsx` renders its thumb
+ * internally and exports only `Slider`, so it cannot be addressed from here
+ * the way objectui#3306 addressed `SelectTrigger`).
+ *
+ * The split of which keys stay on Root is `SelectField`'s, key for key:
+ *
+ * - `name`: Root owns the hidden input that takes part in form submission; on
+ *   a `span` it is not even DOM-legal, and is exactly the leak objectui#3291
+ *   sweeps for.
+ * - `disabled`: Root is the single authority (it disables the thumb and the
+ *   hidden input together); forwarding the raw prop to the thumb as well would
+ *   give the state a second, OR-merged author.
+ *
+ * The visible label reaches the thumb by IDREF, not by `for`: a
+ * `span[role="slider"]` is not one of HTML's labelable elements, so this widget
+ * is declared `labelling: 'group'` for the same reason `file` is — see
+ * `FIELD_TYPES_GROUP_LABELLED` in `../index` and objectui#3961. No extra
+ * `role="group"` wrapper: there is one control here, and `slider` is a role
+ * that carries a name perfectly well on its own.
  */
-export function SliderField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<number>) {
+export function SliderField({
+  value,
+  onChange,
+  field,
+  readonly,
+  error,
+  ...props
+}: FieldWidgetComponentProps<number>) {
   // Get slider-specific configuration from field metadata
   const sliderField = field as any;
   const min = sliderField?.min ?? 0;
@@ -14,17 +58,31 @@ export function SliderField({ value, onChange, field, readonly, ...props }: Fiel
   const step = sliderField?.step ?? 1;
 
   if (readonly) {
+    // No control to name or describe here, so this read-only row is the only
+    // surface the host's label and help text have (objectui#3990 / #4005).
     return (
-      <div className="flex items-center gap-2">
+      <div {...toHostGroupProps(props, 'instead-of-the-inputs')} className="flex items-center gap-2">
         <span className="text-sm font-medium">{value ?? min}</span>
         <span className="text-xs text-muted-foreground">/ {max}</span>
       </div>
     );
   }
 
+  // `className` is withheld alongside them for a third, purely mechanical
+  // reason: the primitive spreads `thumbProps` AFTER the thumb's own classes,
+  // so a host className passed through here would REPLACE the thumb's shape
+  // rather than compose with it. It goes to Root below, exactly as before.
+  const {
+    name: domName,
+    disabled: _domDisabled,
+    className: _domClassName,
+    ...thumbDomProps
+  } = toDomProps(props);
+
   return (
     <div className="flex items-center gap-4">
       <Slider
+        name={domName}
         value={[value ?? min]}
         onValueChange={(values) => onChange(values[0])}
         min={min}
@@ -32,6 +90,14 @@ export function SliderField({ value, onChange, field, readonly, ...props }: Fiel
         step={step}
         disabled={readonly || props.disabled}
         className={props.className}
+        thumbProps={{
+          ...thumbDomProps,
+          // AFTER the spread so this widget's own computation wins, the #3222
+          // discipline: `error` is the published validation slot
+          // (`FieldWidgetPropsSchema`), and `!!undefined` must yield an explicit
+          // `"false"` — a valid field SAYS it is valid rather than staying mute.
+          'aria-invalid': !!error,
+        }}
       />
       <span className="text-sm font-medium w-12 text-right">{value ?? min}</span>
     </div>

--- a/packages/fields/src/widgets/SliderField.tsx
+++ b/packages/fields/src/widgets/SliderField.tsx
@@ -68,10 +68,11 @@ export function SliderField({
     );
   }
 
-  // `className` is withheld alongside them for a third, purely mechanical
-  // reason: the primitive spreads `thumbProps` AFTER the thumb's own classes,
-  // so a host className passed through here would REPLACE the thumb's shape
-  // rather than compose with it. It goes to Root below, exactly as before.
+  // `name` and `disabled` stay on Root for the contract reasons in this
+  // widget's doc comment above. `className` is withheld for a third, purely
+  // mechanical one: the primitive spreads `thumbProps` AFTER the thumb's own
+  // classes, so a host className routed through here would REPLACE the thumb's
+  // shape rather than compose with it. It goes to Root below, exactly as before.
   const {
     name: domName,
     disabled: _domDisabled,

--- a/scripts/__tests__/shadcn-local-patches.test.ts
+++ b/scripts/__tests__/shadcn-local-patches.test.ts
@@ -94,6 +94,96 @@ describe('shadcn local patches — application to fresh upstream (objectstack#55
     expect(ids).toEqual(['sidebar-cookie-read-import', 'sidebar-cookie-read-initial-state']);
   });
 
+  /**
+   * The third family: the slider thumb pass-through (objectui#3318).
+   *
+   * The root half is listed here on purpose. It is easy to read
+   * `slider-thumb-root-split` as bookkeeping next to the delivery patch and
+   * drop it, and the result compiles and renders: the object is simply
+   * String()-ed onto the wrapper as `thumbprops="[object Object]"`, and the id
+   * it also leaves behind gives the row two elements answering to one id.
+   */
+  it('slider declares the thumb pass-through patches', () => {
+    const ids = LOCAL_PATCHES.slider.map((p: { id: string }) => p.id);
+    expect(ids).toEqual([
+      'slider-thumb-import',
+      'slider-thumb-props-type',
+      'slider-thumb-root-split',
+      'slider-thumb-aria-delivery',
+    ]);
+  });
+
+  it('applies the slider family to fresh upstream, and is idempotent', () => {
+    // The upstream shape the registry serves, after `rewriteRegistryImports`.
+    // `aria-label` on the thumb is upstream's OWN hand-written bridge — the
+    // anchor the delivery patch replaces, and the standing evidence that the
+    // thumb cannot be addressed from outside the primitive.
+    const upstream = `"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "../lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn("relative flex", className)}
+    {...props}
+  >
+    <SliderPrimitive.Track />
+    <SliderPrimitive.Thumb
+      className="block h-5 w-5"
+      aria-label={props["aria-label"]}
+    />
+  </SliderPrimitive.Root>
+))
+`;
+
+    const once = applyLocalPatches('slider', upstream);
+    expect(once.failed).toEqual([]);
+    expect(once.applied).toHaveLength(4);
+    expect(verifyLocalPatches('slider', once.content)).toEqual([]);
+    // The thumb takes the routed props and the wrapper does not take the raw
+    // `props` object any more — the two halves that must land together.
+    expect(once.content).toContain('{...splitSliderThumbProps(props).thumb}');
+    expect(once.content).toContain('{...splitSliderThumbProps(props).root}');
+    expect(once.content).not.toContain('aria-label={props["aria-label"]}');
+
+    const twice = applyLocalPatches('slider', once.content);
+    expect(twice.applied).toEqual([]);
+    expect(twice.content).toBe(once.content);
+  });
+
+  it('refuses when upstream restructures the thumb away', () => {
+    // A future registry drop of the hand-written `aria-label` bridge takes the
+    // delivery patch's anchor with it. That must be a hard failure the operator
+    // sees, not a sync that quietly ships an unreachable thumb again.
+    const withoutThumbAnchor = `import { cn } from "../lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    {...props}
+  >
+    <SliderPrimitive.Thumb className="block" />
+  </SliderPrimitive.Root>
+))
+`;
+
+    const result = applyLocalPatches('slider', withoutThumbAnchor);
+
+    expect(result.failed.map((p: { id: string }) => p.id)).toEqual([
+      'slider-thumb-aria-delivery',
+    ]);
+    expect(result.failed[0].found).toBe(0);
+  });
+
   it('turns an unpatched upstream file into the translated form', () => {
     const result = applyLocalPatches('dialog', UPSTREAM_DIALOG);
 

--- a/scripts/shadcn-local-patches.mjs
+++ b/scripts/shadcn-local-patches.mjs
@@ -160,6 +160,87 @@ const sidebarCookieReadPatches = [
 ];
 
 /**
+ * The slider thumb pass-through patch (objectui#3318).
+ *
+ * A Radix slider's focusable control is the THUMB (`span[role="slider"]`,
+ * `tabindex="0"`) — the element a keyboard user lands on and the one assistive
+ * technology reads state from. `Slider.Root` renders a role-less wrapper span
+ * and takes every unrecognised prop, so a host's `id` / `aria-invalid` /
+ * `aria-describedby` / `aria-labelledby` landed on a wrapper nobody visits:
+ * a required slider showed its red message with nothing announced, its visible
+ * label pointed `for` at an id no element carried, and its help text had zero
+ * consumers.
+ *
+ * The primitive exports only `Slider`, so unlike `SelectTrigger` (objectui#3306,
+ * the same defect one step easier) a widget has NO handle on the element that
+ * must carry those facts. Hence a declared `thumbProps`.
+ *
+ * Four one-liners, each anchored on a line upstream has carried across every
+ * sync in this file's history. As with the families above, the payload stays
+ * OUT of `src/ui/`: the routing and its reasoning live in
+ * `packages/components/src/lib/slider-thumb.ts`.
+ *
+ * The root half is patched too, and that is not optional: leaving `thumbProps`
+ * in Root's spread would stringify it onto the wrapper (`thumbprops="[object
+ * Object]"`), the exact leak objectui#3291 sweeps for.
+ *
+ * @type {LocalPatch[]}
+ */
+const sliderThumbPassThroughPatches = [
+  {
+    id: 'slider-thumb-import',
+    issue: 'objectui#3318',
+    reason:
+      'Imports the router that splits a Slider\'s props between its Root wrapper ' +
+      'and its focusable thumb. Anchored on the `cn` import, which every Shadcn ' +
+      'component carries.',
+    find: 'import { cn } from "../lib/utils"',
+    replace:
+      'import { cn } from "../lib/utils"\nimport { splitSliderThumbProps, type SliderThumbPassThrough } from "../lib/slider-thumb"',
+    marker: 'from "../lib/slider-thumb"',
+    occurrences: 1,
+  },
+  {
+    id: 'slider-thumb-props-type',
+    issue: 'objectui#3318',
+    reason:
+      'Declares `thumbProps` on the wrapper so addressing the focusable control ' +
+      'is type-checked rather than cast through `any` (AGENTS.md #6). Additive: ' +
+      'every existing call site keeps the exact prop surface it had.',
+    find: '  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>\n>',
+    replace:
+      '  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & SliderThumbPassThrough\n>',
+    marker: '& SliderThumbPassThrough',
+    occurrences: 1,
+  },
+  {
+    id: 'slider-thumb-root-split',
+    issue: 'objectui#3318',
+    reason:
+      'Withholds `thumbProps` from the Root spread. Without this the object is ' +
+      'String()-ed onto the wrapper span as `thumbprops="[object Object]"` — the ' +
+      'leak class objectui#3291 sweeps for.',
+    find: '    {...props}\n  >',
+    replace: '    {...splitSliderThumbProps(props).root}\n  >',
+    marker: 'splitSliderThumbProps(props).root',
+    occurrences: 1,
+  },
+  {
+    id: 'slider-thumb-aria-delivery',
+    issue: 'objectui#3318',
+    reason:
+      'Delivers the host\'s control-channel facts to the element that can carry ' +
+      'them. Replaces (and preserves) the narrower hand-written `aria-label` ' +
+      'bridge upstream already needed here for the very same reason — proof the ' +
+      'thumb is unreachable from outside, not a new claim.',
+    find: '      aria-label={props["aria-label"]}\n',
+    replace: '      {...splitSliderThumbProps(props).thumb}\n',
+    marker: 'splitSliderThumbProps(props).thumb',
+    occurrences: 1,
+  },
+];
+
+/**
  * Component name (as tracked in `shadcn-components.json`) → patches it needs.
  *
  * @type {Record<string, LocalPatch[]>}
@@ -168,6 +249,7 @@ export const LOCAL_PATCHES = {
   sheet: i18nCloseLabelPatches('Sheet'),
   dialog: i18nCloseLabelPatches('Dialog'),
   sidebar: sidebarCookieReadPatches,
+  slider: sliderThumbPassThroughPatches,
 };
 
 /** Components that carry at least one declared patch. */


### PR DESCRIPTION
Part of #3318

按 2026-08-17 的 PM 分流裁定处理账本残留 9 条。**账本未清零**（`grid` 仍留一条，见下），所以正文用 `Part of` 而非关闭关键字。

## 一、先量后改：`origin/main` 上 9 条的实测读数

真表单 + 真 react-hook-form，每行一个 `required` 字段、`null` 值（presence 语义），提交后先自证 "is required" 已渲染再读 aria。`text` 是对照组。

| type | `aria-invalid=true` | 可聚焦控件 | 可见 label 的 `for` | description 消费者 |
|---|---|---|---|---|
| formula | 无 | **0 个** | DANGLING | 0 |
| summary | 无 | **0 个** | DANGLING | 0 |
| auto_number | 无 | **0 个** | DANGLING | 0 |
| vector | 无 | **0 个** | DANGLING | 0 |
| signature | 无 | **0 个** | DANGLING | 0 |
| filter-condition | 无 | **0 个** | DANGLING | 0 |
| recipient-picker | 无 | **0 个** | DANGLING | 0 |
| grid | 无 | **1 个** `button` | DANGLING | 0 |
| slider | 无 | **2 个** `span[role=slider]` + 隐藏 `input` | DANGLING | 0 |
| _text（对照）_ | `input` | 1 个 `input` | 解析到 `input` | 1 |

这张表就是分流线本身：**「可聚焦控件 = 0」是「不适用」的事实依据，不是说法**。`grid` 与 `slider` 各有控件，所以它们不在那条线上。

另外，9 行**全部** `ids=[]` —— 不是 id 被覆写（#3952 在 `boolean` 上的形态），而是整行 DOM 里没有任何元素带 id。这正是 08-09 / 08-16 三通道实测的结论：一处缺失同时掉了三样东西。

## 二、逐条处置

| # | type | 处置 | 依据 |
|---|---|---|---|
| 1 | `slider` | **已交付**，账本行删除→转正向守卫 | 三通道全接通，见下 |
| 2 | `signature` | **拆两半**：`aria-invalid` 判不适用；**label 关联已交付** | canvas 无键盘路径成立（实测 0 可聚焦）；名字按 #3961 `file` 范式 |
| 3 | `formula` | 迁入 `NOT_APPLICABLE` | 只读计算展示，0 可聚焦控件 |
| 4 | `summary` | 迁入 `NOT_APPLICABLE` | 只读聚合展示，0 可聚焦控件 |
| 5 | `auto_number` | 迁入 `NOT_APPLICABLE` | 只读系统生成展示，0 可聚焦控件 |
| 6 | `vector` | 迁入 `NOT_APPLICABLE` | 只读 embedding 预览，0 可聚焦控件 |
| 7 | `filter-condition` | 迁入 `NOT_APPLICABLE` | 门控态（未选 `object_name`）只有提示段落；可编辑态已交付 |
| 8 | `recipient-picker` | 迁入 `NOT_APPLICABLE` | 门控态（未选 `recipient_type`）只有提示段落；可编辑态已交付 |
| 9 | `grid` | **留 `NOT_YET_DELIVERED`**，不修 | 表单级失败驱动 per-cell 需设计（哪个 cell？add-row 按钮？） |

`NOT_YET_DELIVERED` 现在只剩 `grid` 一条。按裁定这不卡 issue 关闭决策，交 PM 定。

## 三、`slider`：为什么需要一次 components 级改动

`aria-invalid` 必须落在 `role="slider"` 的 thumb 上 —— 那才是键盘用户落点、辅助技术读状态的元素。Radix 的 Root 渲染一个无 role 的包裹 `span` 并吞掉所有它不认识的 prop，所以 host 下发的一切都落在辅助技术永不访问的包裹层上。

这与 #3306 的 `select` 同形态但难一档：那里可聚焦控件是 `SelectTrigger`，primitive **导出**了它，widget 能直接寻址；`ui/slider.tsx` 的 thumb 是内部渲染、只导出 `Slider`，widget 对那个唯一必须承载状态的元素**没有任何把手**。

走仓库既有的**声明式 sync patch 机制**（`scripts/shadcn-local-patches.mjs`）—— 这正是它存在的用途：「必须在 regeneration 后存活的 `src/ui/**` 编辑，以数据形式声明，由 sync 自己重放」。payload 依该文件自身的指引留在 `src/ui/` 之外（`packages/components/src/lib/slider-thumb.ts`），`ui/slider.tsx` 只收四行有锚点的一行改。

四条 patch 里 **root 那条不是记账**：若只加 thumb 交付而不从 Root 的 spread 里摘掉 `thumbProps`，代码照样编译照样渲染 —— 对象会被 `String()` 成 `thumbprops="[object Object]"` 贴到包裹 span（#3291 扫的那类泄漏），并且 host id 会同时落在两个元素上，`getElementById` 答出包裹层，于是 label 的 `for` 依旧指向不可聚焦的 span，**bug 穿着自己的修复活下来**。这条已在 `scripts/__tests__/shadcn-local-patches.test.ts` 里单独钉住并写明原因。

`SliderField` 的分流与 `SelectField` 逐键相同：`name`（Root 拥有参与提交的隐藏 input）和 `disabled`（Root 是唯一权威）留在 Root，其余走 thumb，`aria-invalid={!!error}` 写在 spread 之后。`className` 也扣住 —— primitive 把 `thumbProps` spread 在 thumb 自身 class **之后**，透过去会把 thumb 的形状整个换掉。

## 四、三通道读数（修后）

`slider` 一处修改同时接通三通道，三面都钉在 `slider-signature-host-channels-e2e.test.tsx`：

| 通道 | 修后 | 断言 |
|---|---|---|
| `aria-invalid` | 落在 `span[role=slider]` 上，整行恰好 1 个 | 断言的是**角色**而非「行内某元素」，将来若被挪回包裹层会红 |
| 可见 label | label 丢掉 `for`、发 `aria-labelledby`；`getByRole('slider', {name:/Confidence/})` 命中 thumb | IDREF 解析且出来的名字就是可见的那个 |
| `aria-describedby` | FormDescription 的消费者 = 1，且就是 thumb | 从「0 消费者」到 1 |

外加两条：host id 在 thumb 上且**全行只有一个元素答应该 id**；thumb 上没有 `name` / `thumbprops` 泄漏、且保留自身 `rounded-full` 形状。

**label 通道为何单靠 spread 不够**：`for` 能 **resolve** 不等于 label 能 **工作**。`label for` 只能寻址 HTML 的 labelable 元素（button / input / meter / output / progress / select / textarea）。slider 的控件是 `span[role=slider]`、signature 的是 canvas，直接把 host id 给它们只是把「悬空的 `for`」升级成「无效的 `for`」。所以两者都声明 `labelling: 'group'`（#3961 的路子，**`file` 的形态：一个不可 label 的控件，而非复合体**），改由 IDREF 命名。这条连带更新了 `group-labelling-declaration.test.ts` 的精确集合断言。

`signature` 则拿到名字与描述（`role="group"` 容器，`instead-of-the-inputs`），**不拿控件态**：Clear 按钮是作用于值的辅助按钮，不是值的控件 —— 与 `geolocation` 只读行里那个可聚焦的「View on map」链接同一读法。

## 五、棘轮结构：为什么「借改判逃账」结构上不可能

`DELIVERING` 是**推导**出来的：`ALL_TYPES` 减去两个账本。三个集合按构造划分注册表。三重防线：

1. **删行不等于销账** —— 从两个账本里都删掉，该类型直接落入最严的正向 sweep。
2. **每条 `NOT_APPLICABLE` 自带守卫** —— sweep 实测该 widget 的行确实不提供可聚焦控件。`grid` 无法被挪进来凑数（它渲染一个 button）；将来谁给这些 widget 加了真控件而账本行没动，同一条守卫也红。
3. 两账本断言**互斥**、且只能命名真实存在的类型；每条不适用行必须写出理由（空理由会红）。

## 六、反向验证（先书面预判，后跑；变异前已 commit，还原用 `git checkout`，未用 stash）

四次变异，**预判与实测的一致/不一致都照实报**：

| 变异 | 预判 | 实测 | 一致 |
|---|---|---|---|
| M1 撤掉 slider 的 spread（整文件还原） | 6 红：sweep 的 `field:slider` 正向断言 + channels 的 5 条 | **恰好 6 红**，一字不差 | ✅ |
| M2 把 `formula` 从两个账本都删掉 | **划分断言仍绿**（该类型落入 DELIVERING，划分依然精确）；红的是 `field:formula` 正向 sweep | 正如预判：1 红，且红在正向 sweep | ✅ |
| M3 给 `formula` 塞一个可聚焦控件（假阳测试） | 不适用守卫红 | **绿 —— 预判错了** | ❌ |
| M3b 同上，改到 sweep 真正渲染的分支 | 不适用守卫红，报 `[ 'span' ]` | 如预判 | ✅ |
| M4 把 `grid` 从 `NOT_YET_DELIVERED` 挪进 `NOT_APPLICABLE` | 不适用守卫红报 `[ 'button' ]`；互斥/存在/划分三条仍绿 | 如预判 | ✅ |

**M1 的一个诚实例外**：`leaks no renderer plumbing onto the thumb` 那条在 M1 下**保持绿色**，而且这是预判里就写明的 —— 它整条都是「不存在」断言（`not.toHaveAttribute('name')` / `'thumbprops'`）加一个 className 检查，而改动前的 widget 什么都不转发，因此**空洞地**满足它。它守的是修复的回归，不是修复的缺席；在这里它两个方向都不构成证据，不当成证据用。

**M3 为什么预判错，以及它教了什么**：我把 `tabIndex` 加在 `FormulaField` 的**有值分支**上，而 sweep 渲染的是 `value == null` 的 `EmptyValue` 早返回 —— 变异落在一条这个 fixture 走不到的分支上，红不了是机械原因，不是守卫弱。M3b 改到真正渲染的分支即按预判变红。

这件事本身是条真事实，已写进账本的文档注释：不适用守卫读的是 sweep 渲染的那个状态（fresh / empty / required / 刚失败），而那**恰好是该判的状态** —— `required` 是 presence 检查，属性需要被播报的时刻正是值缺失的时刻。四个只读类型在这里渲染的是空值分支、`signature` 的 Clear 按钮要画过才可聚焦，两者都已在注释里点名，是**披露**而非藏起来。

## 七、验证

- `pnpm exec vitest run packages/fields/` → **103 files / 1709 tests passed**
- `pnpm exec vitest run packages/components/ scripts/` → **195 files / 2464 tests passed**
- 消费半径（被改的声明在别处也跑）：`plugin-form` + `plugin-detail` + `plugin-designer` + `plugin-grid` → **209 / 1964 passed**；`app-shell` → **414 / 3919 passed（1 skipped）**
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **81/81 successful**
- `node scripts/check-control-bytes.mjs` → OK（4413 files）；另对本 PR 触及文件做了越过该门的自查（`grep -naP` 控制字符类）→ clean

changeset：`@object-ui/components` + `@object-ui/fields` 各 patch（⛔ 无 major）。未触碰 `content/docs/releases/**`，未 force-push。

## 八、偏差一条

派发单钉的基线是 `40d3a3318`，实际从 `origin/main`（`69dbea20a`）开分支。原因：派发后 main 又进了两个 commit，其中 `e7747f19a`（#4814 retire `owner` alias，落地时间比分流评论晚 16 秒）**改的正是本单目标账本文件** —— 它把 `owner: UserField` 从 `WIDGETS` 里摘走换成一段注释。基于旧基线会让我在一个 main 已经走过的文件版本上重写账本。较新基线同样是钉死的 SHA。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_