### PR TITLE
fix(app-shell): word every dropped-fields reason on its own instead of calling the rest "Read-only" (#3935)

### DIFF
--- a/.changeset/write-warning-reason-table-3935.md
+++ b/.changeset/write-warning-reason-table-3935.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/i18n': patch
+---
+
+A write-warning toast now words each strip reason on its own instead of calling everything that is not `readonly_when` "read-only".
+
+`emitWriteWarning` picked its sentence with a two-way conditional on
+`reason === 'readonly_when'`. The other arm was never "readonly" — it was
+"everything that is not `readonly_when`", so any reason the server-side write
+path gained afterwards was announced to the user as a read-only lock, pointing
+them at a permission problem that does not exist. That is the same defect
+objectui#3484 / framework#3794 fixed for `readonly_when` itself, one reason
+later.
+
+The reason is now resolved through a table declared
+`Record<DroppedFieldsEvent['reason'], …>`, mirroring the framework side of the
+same seam (`service-automation`'s `DROPPED_REASON_LABEL`) and the shape the
+spec's own `DroppedFieldsEventSchema` comment asks consumers for. The next reason
+added upstream is a `type-check` failure here, unworded, where the conditional
+compiled forever — which is what re-exporting THE spec type rather than a
+hand-widened `string` was for all along.
+
+Not a latent fix: the pinned spec (`@objectstack/spec` 17.0.0-rc.6) already
+carries `primary_key` (objectstack#6437), the strip that keeps a payload `id` the
+update dispatch ruled is not an identifier out of the targeted rows' primary key.
+Until now a user who triggered it was told the field was read-only. It gets its
+own wording in all ten locale packs: "The record's identifier cannot be changed
+by a save, so it did not take effect".
+
+One more line was added for a reason ahead of this bundle's pin — the adapter
+reads `reason` structurally off the wire without checking it against the enum, so
+a server newer than the bundle can deliver a value no table can have an arm for.
+It names the fields and claims nothing about the cause, rather than throwing
+inside a listener invoked as `void emitWriteWarning(...)` (which would cost the
+user the whole toast, including the reasons that did resolve) or reusing a
+wording that would state a cause we do not know.

--- a/packages/app-shell/src/providers/writeWarningToast.test.ts
+++ b/packages/app-shell/src/providers/writeWarningToast.test.ts
@@ -21,6 +21,12 @@
  * It now resolves labels off the object schema (the adapter caches it) and says
  * one coherent thing: saved, and here is what did not take effect.
  *
+ * A third thing was wrong, one reason later (objectui#3935): the wording was
+ * picked by a two-way conditional on `readonly_when`, so every reason the write
+ * path gained afterwards was announced as read-only. The reason table is now
+ * exhaustive over the spec union, and the suite pins each reason's own sentence
+ * plus the skew case a `Record` cannot cover.
+ *
  * The sink is a PARAMETER, so this suite mocks no module. That is not a style
  * preference: `vitest.config.mts` runs the `unit` project with `isolate: false`
  * (one module graph per worker), where a `vi.mock('sonner')` holds only if no
@@ -29,8 +35,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DroppedFieldsEventSchema } from '@objectstack/spec/data';
 import { emitWriteWarning, type WriteWarningSink } from './writeWarningToast';
-import type { WriteWarningEvent } from '@object-ui/data-objectstack';
+import type { DroppedFieldsEvent, WriteWarningEvent } from '@object-ui/data-objectstack';
 
 /** Stand-in for i18next: returns the caller's English default, interpolated. */
 const t = (_key: string, opts?: Record<string, unknown>) => {
@@ -143,6 +150,130 @@ describe('emitWriteWarning (#3484)', () => {
     );
 
     expect(calls[0].description).toMatch(/^Read-only/);
+  });
+
+  it('uses the state wording for reason `readonly_when`, which is NOT read-only', async () => {
+    const { sink, calls } = makeSink();
+
+    await emitWriteWarning(EVENT, t, adapter as never, identityLabel, sink);
+
+    expect(calls[0].description).toMatch(/^Not editable in this record's current state/);
+    expect(calls[0].description).not.toMatch(/Read-only/);
+  });
+
+  it('uses the identifier wording for reason `primary_key` (objectstack#6437)', async () => {
+    const { sink, calls } = makeSink();
+
+    await emitWriteWarning(
+      { ...EVENT, droppedFields: [{ object: 'andon', fields: ['type'], reason: 'primary_key' }] },
+      t,
+      adapter as never,
+      identityLabel,
+      sink,
+    );
+
+    expect(calls[0].description).toMatch(/^The record's identifier cannot be changed by a save/);
+    // The whole point of objectui#3935: the strip is not a read-only lock, and
+    // saying so pointed the user at a permission problem that does not exist.
+    expect(calls[0].description).not.toMatch(/Read-only/);
+  });
+
+  it('keeps one line per reason when a save was stripped for several', async () => {
+    const { sink, calls } = makeSink();
+
+    await emitWriteWarning(
+      {
+        ...EVENT,
+        droppedFields: [
+          { object: 'andon', fields: ['type'], reason: 'readonly' },
+          { object: 'andon', fields: ['source_method'], reason: 'primary_key' },
+        ],
+      },
+      t,
+      adapter as never,
+      identityLabel,
+      sink,
+    );
+
+    const lines = (calls[0].description ?? '').split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe('Read-only, so it did not take effect: Andon type');
+    expect(lines[1]).toBe(
+      "The record's identifier cannot be changed by a save, so it did not take effect: Source method",
+    );
+  });
+
+  /**
+   * The exhaustiveness pin (objectui#3935), read off the SPEC rather than a hand
+   * list that would drift: `STRIPPED_LINE` is declared
+   * `Record<DroppedFieldsEvent['reason'], …>`, so an extra key is a type error
+   * and a missing one is too — but `type-check` and `vitest` are different gates,
+   * and the reason the ternary this replaced survived so long is that nothing in
+   * the test suite could see the gap at all.
+   *
+   * So assert it behaviourally: drive the toast once per reason the INSTALLED
+   * spec declares and require each to produce its own sentence rather than the
+   * skew wording. A pin bump that widens the enum makes this red next to the
+   * compile error, in the gate a wording change is normally noticed in.
+   */
+  it('gives every reason the pinned spec declares its own wording (#3935)', async () => {
+    const reasons = DroppedFieldsEventSchema.shape.reason.options;
+    expect(reasons).toContain('primary_key');
+
+    const wordings = new Map<string, string>();
+    for (const reason of reasons) {
+      const { sink, calls } = makeSink();
+
+      await emitWriteWarning(
+        { ...EVENT, droppedFields: [{ object: 'andon', fields: ['type'], reason }] },
+        t,
+        adapter as never,
+        identityLabel,
+        sink,
+      );
+
+      const line = calls[0]?.description ?? '';
+      expect(line, `reason \`${reason}\` has no wording of its own`).not.toMatch(
+        /^Not applied by the server/,
+      );
+      wordings.set(reason, line);
+    }
+
+    expect(new Set(wordings.values()).size).toBe(reasons.length);
+  });
+
+  /**
+   * A server ahead of this bundle's spec pin. `notifyDroppedFields` asserts the
+   * wire entry into `DroppedFieldsEvent` without checking `reason` against the
+   * enum, so the value really can arrive from outside the union — and the toast
+   * must neither throw (the adapter calls this as `void emitWriteWarning(...)`,
+   * so a rejection is unhandled and the user loses the whole toast) nor reuse a
+   * wording that would state a cause it does not know.
+   */
+  it('names the fields and claims no cause for a reason ahead of the spec pin (#3935)', async () => {
+    const aheadOfPin: string = 'some_future_reason';
+    const { sink, calls } = makeSink();
+
+    await emitWriteWarning(
+      {
+        ...EVENT,
+        droppedFields: [
+          {
+            object: 'andon',
+            fields: ['type'],
+            reason: aheadOfPin as DroppedFieldsEvent['reason'],
+          },
+        ],
+      },
+      t,
+      adapter as never,
+      identityLabel,
+      sink,
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].description).toBe('Not applied by the server: Andon type');
+    expect(calls[0].description).not.toMatch(/Read-only/);
   });
 
   it('says nothing for an empty event', async () => {

--- a/packages/app-shell/src/providers/writeWarningToast.ts
+++ b/packages/app-shell/src/providers/writeWarningToast.ts
@@ -15,7 +15,11 @@
  * @module providers/writeWarningToast
  */
 
-import type { ObjectStackAdapter, WriteWarningEvent } from '@object-ui/data-objectstack';
+import type {
+  DroppedFieldsEvent,
+  ObjectStackAdapter,
+  WriteWarningEvent,
+} from '@object-ui/data-objectstack';
 
 /** i18next's `t`, narrowed to what this module uses. */
 export type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
@@ -68,15 +72,94 @@ async function resolveFieldLabels(
     fieldLabel(objectName, fieldName, fields?.[fieldName]?.label || fieldName);
 }
 
+/** One description line, given the translator and the already-labelled field list. */
+type StrippedLine = (t: TranslateFn, fields: string) => string;
+
+/**
+ * The sentence each strip reason gets — EXHAUSTIVE over
+ * `DroppedFieldsEvent['reason']` by construction (objectui#3935).
+ *
+ * This was a two-way conditional on `readonly_when` whose other arm said
+ * "Read-only". That arm never meant "readonly"; it meant "everything that is not
+ * `readonly_when`", so every reason the write path gained afterwards was
+ * announced to the user as a read-only lock — sending them after a permission
+ * problem that does not exist. `primary_key` (objectstack#6437) is not a
+ * hypothetical: the spec pin this package builds against already carries it.
+ *
+ * A `Record` keyed by the union is what finally delivers the guarantee that
+ * re-exporting THE spec type was for (see `DroppedFieldsEvent`'s own comment in
+ * `data-objectstack`): the next reason added upstream fails `type-check` HERE,
+ * unworded, whereas the conditional would have compiled forever. It is the same
+ * shape the framework side of this seam uses (`service-automation`'s
+ * `DROPPED_REASON_LABEL`), and the shape the spec's own schema comment asks every
+ * consumer that branches on `reason` to use.
+ */
+const STRIPPED_LINE: Record<DroppedFieldsEvent['reason'], StrippedLine> = {
+  readonly: (t, fields) =>
+    t('detail.writeStrippedReadonly', {
+      fields,
+      defaultValue: 'Read-only, so it did not take effect: {{fields}}',
+    }),
+  readonly_when: (t, fields) =>
+    t('detail.writeStrippedByState', {
+      fields,
+      defaultValue:
+        "Not editable in this record's current state, so it did not take effect: {{fields}}",
+    }),
+  primary_key: (t, fields) =>
+    t('detail.writeStrippedPrimaryKey', {
+      fields,
+      defaultValue:
+        "The record's identifier cannot be changed by a save, so it did not take effect: {{fields}}",
+    }),
+};
+
+/**
+ * What to say for a reason THIS bundle's spec pin has never heard of.
+ *
+ * A real runtime state rather than a limb the types already ruled out: the
+ * adapter's `notifyDroppedFields` reads `reason` structurally off the wire and
+ * asserts the entry into `DroppedFieldsEvent` without ever checking the value
+ * against the spec enum, so a server running ahead of the bundle's pin delivers
+ * one the table above cannot possibly have an arm for. Both of the other
+ * dispositions are worse: indexing blindly would throw inside an `async`
+ * function the adapter invokes as `void emitWriteWarning(...)`, so the rejection
+ * goes unhandled and the user loses the whole toast INCLUDING the reasons that
+ * did resolve; borrowing a known arm would make exactly the false claim this
+ * card exists to delete. So name the fields and claim nothing about the cause —
+ * version skew is the one case where "we cannot say why" is the true answer.
+ */
+const strippedLineUnknownReason: StrippedLine = (t, fields) =>
+  t('detail.writeStrippedUnknownReason', {
+    fields,
+    defaultValue: 'Not applied by the server: {{fields}}',
+  });
+
+/**
+ * Resolve one reason to its sentence.
+ *
+ * The PARAMETER carries the spec union — that is what makes {@link STRIPPED_LINE}
+ * exhaustive-checked at its declaration above. The LOOKUP is done through a
+ * widened view of the same table, because the runtime value may sit outside that
+ * union (see {@link strippedLineUnknownReason}); the `undefined` this branch
+ * handles is therefore reachable, not dead.
+ */
+function lineFor(reason: DroppedFieldsEvent['reason']): StrippedLine {
+  const known: Partial<Record<string, StrippedLine>> = STRIPPED_LINE;
+  return known[reason] ?? strippedLineUnknownReason;
+}
+
 /**
  * Announce a write-warning. The write SUCCEEDED — some caller-supplied fields
  * were legally stripped, so we tell the user rather than let it pass silently.
  *
- * The REASON decides the wording (#3794). `readonly_when` is not "this field is
- * read-only" — the field is editable in other states and the form rendered it
- * as an ordinary input; what happened is that THIS record's current state locks
- * it. Saying "read-only" there sends the user looking for a permission problem
- * that doesn't exist.
+ * The REASON decides the wording (#3794), via the exhaustive {@link STRIPPED_LINE}
+ * table. `readonly_when` is not "this field is read-only" — the field is editable
+ * in other states and the form rendered it as an ordinary input; what happened is
+ * that THIS record's current state locks it. Saying "read-only" there sends the
+ * user looking for a permission problem that doesn't exist, and the same is true
+ * of every later reason the old two-way conditional swept into that wording
+ * (objectui#3935).
  *
  * The wording ACKNOWLEDGES the save (objectui#3484 point B). This message lands
  * next to the save surface's own "Updated" toast, and the pair used to read as
@@ -94,7 +177,7 @@ export async function emitWriteWarning(
   fieldLabel: FieldLabelFn,
   sink: WriteWarningSink,
 ): Promise<void> {
-  const byReason = new Map<string, string[]>();
+  const byReason = new Map<DroppedFieldsEvent['reason'], string[]>();
   for (const d of ev.droppedFields) {
     const seen = byReason.get(d.reason) ?? [];
     for (const f of d.fields) if (!seen.includes(f)) seen.push(f);
@@ -110,18 +193,7 @@ export async function emitWriteWarning(
   for (const [reason, fields] of byReason) {
     if (fields.length === 0) continue;
     const list = fields.map(labelOf).join(', ');
-    lines.push(
-      reason === 'readonly_when'
-        ? t('detail.writeStrippedByState', {
-            fields: list,
-            defaultValue:
-              "Not editable in this record's current state, so it did not take effect: {{fields}}",
-          })
-        : t('detail.writeStrippedReadonly', {
-            fields: list,
-            defaultValue: 'Read-only, so it did not take effect: {{fields}}',
-          }),
-    );
+    lines.push(lineFor(reason)(t, list));
   }
   if (lines.length === 0) return;
   sink.warning(

--- a/packages/app-shell/src/providers/writeWarningToast.ts
+++ b/packages/app-shell/src/providers/writeWarningToast.ts
@@ -72,7 +72,17 @@ async function resolveFieldLabels(
     fieldLabel(objectName, fieldName, fields?.[fieldName]?.label || fieldName);
 }
 
-/** One description line, given the translator and the already-labelled field list. */
+/**
+ * One description line, given the translator and the already-labelled field list.
+ *
+ * Every implementation below re-annotates `t: TranslateFn` even though this type
+ * already infers it. That is not noise: `scripts/check-i18n-call-site-keys.mjs`
+ * decides whether a `t(...)` call is a real translator from the ANNOTATION on the
+ * binding (`TRANSLATOR_TYPE`), and an inferred parameter reads as "not a
+ * translator" — which silently drops these keys out of the en-pack resolution,
+ * the inline-`defaultValue` comparison and the interpolation-parity check. The
+ * wording table is exactly the code that gate needs to be watching.
+ */
 type StrippedLine = (t: TranslateFn, fields: string) => string;
 
 /**
@@ -95,18 +105,18 @@ type StrippedLine = (t: TranslateFn, fields: string) => string;
  * consumer that branches on `reason` to use.
  */
 const STRIPPED_LINE: Record<DroppedFieldsEvent['reason'], StrippedLine> = {
-  readonly: (t, fields) =>
+  readonly: (t: TranslateFn, fields: string) =>
     t('detail.writeStrippedReadonly', {
       fields,
       defaultValue: 'Read-only, so it did not take effect: {{fields}}',
     }),
-  readonly_when: (t, fields) =>
+  readonly_when: (t: TranslateFn, fields: string) =>
     t('detail.writeStrippedByState', {
       fields,
       defaultValue:
         "Not editable in this record's current state, so it did not take effect: {{fields}}",
     }),
-  primary_key: (t, fields) =>
+  primary_key: (t: TranslateFn, fields: string) =>
     t('detail.writeStrippedPrimaryKey', {
       fields,
       defaultValue:
@@ -129,7 +139,7 @@ const STRIPPED_LINE: Record<DroppedFieldsEvent['reason'], StrippedLine> = {
  * card exists to delete. So name the fields and claim nothing about the cause —
  * version skew is the one case where "we cannot say why" is the true answer.
  */
-const strippedLineUnknownReason: StrippedLine = (t, fields) =>
+const strippedLineUnknownReason: StrippedLine = (t: TranslateFn, fields: string) =>
   t('detail.writeStrippedUnknownReason', {
     fields,
     defaultValue: 'Not applied by the server: {{fields}}',

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -964,6 +964,8 @@ const ar = {
     writeStrippedTitle: "تم الحفظ، لكن بعض الحقول لم تُطبَّق",
     writeStrippedReadonly: "للقراءة فقط، لذلك لم تُطبَّق: {{fields}}",
     writeStrippedByState: "غير قابلة للتعديل في الحالة الحالية لهذا السجل، لذلك لم تُطبَّق: {{fields}}",
+    writeStrippedPrimaryKey: "معرّف السجل لا يمكن تغييره عند الحفظ، لذلك لم تُطبَّق: {{fields}}",
+    writeStrippedUnknownReason: "لم تُطبَّق من قِبل الخادم: {{fields}}",
     approvalPendingEditable: "قيد الموافقة · قابل للتعديل",
     approvalPendingTooltip: "يحتوي هذا السجل على طلب موافقة معلق، لكن هذه الخطوة لا تزال تسمح بالتعديل",
     approvalProgress: "الموافقات — {{got}} من {{need}}",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -958,6 +958,8 @@ const de = {
     writeStrippedTitle: "Gespeichert — einige Felder wurden jedoch nicht übernommen",
     writeStrippedReadonly: "Schreibgeschützt und daher nicht übernommen: {{fields}}",
     writeStrippedByState: "Im aktuellen Status dieses Datensatzes nicht bearbeitbar und daher nicht übernommen: {{fields}}",
+    writeStrippedPrimaryKey: "Die Kennung des Datensatzes kann beim Speichern nicht geändert werden und wurde daher nicht übernommen: {{fields}}",
+    writeStrippedUnknownReason: "Vom Server nicht übernommen: {{fields}}",
     approvalPendingEditable: "In Genehmigung · bearbeitbar",
     approvalPendingTooltip: "Dieser Datensatz hat eine ausstehende Genehmigungsanfrage; dieser Schritt erlaubt weiterhin die Bearbeitung",
     approvalProgress: "Genehmigungen — {{got}} von {{need}}",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -929,6 +929,8 @@ const en = {
     writeStrippedTitle: 'Saved — but some fields did not take effect',
     writeStrippedReadonly: 'Read-only, so it did not take effect: {{fields}}',
     writeStrippedByState: "Not editable in this record's current state, so it did not take effect: {{fields}}",
+    writeStrippedPrimaryKey: "The record's identifier cannot be changed by a save, so it did not take effect: {{fields}}",
+    writeStrippedUnknownReason: 'Not applied by the server: {{fields}}',
     approvalPendingEditable: 'In approval · editable',
     approvalPendingTooltip: 'This record has a pending approval request; this step still allows editing',
     approvalProgress: 'Approvals — {{got}} of {{need}}',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -962,6 +962,8 @@ const es = {
     writeStrippedTitle: "Guardado, pero algunos campos no se aplicaron",
     writeStrippedReadonly: "De solo lectura, por lo que no se aplicó: {{fields}}",
     writeStrippedByState: "No editable en el estado actual de este registro, por lo que no se aplicó: {{fields}}",
+    writeStrippedPrimaryKey: "El identificador del registro no se puede cambiar al guardar, por lo que no se aplicó: {{fields}}",
+    writeStrippedUnknownReason: "No aplicado por el servidor: {{fields}}",
     approvalPendingEditable: "En aprobación · editable",
     approvalPendingTooltip: "Este registro tiene una solicitud de aprobación pendiente; este paso todavía permite la edición",
     approvalProgress: "Aprobaciones — {{got}} de {{need}}",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -960,6 +960,8 @@ const fr = {
     writeStrippedTitle: "Enregistré — mais certains champs n'ont pas été appliqués",
     writeStrippedReadonly: "En lecture seule, donc non appliqué : {{fields}}",
     writeStrippedByState: "Non modifiable dans l'état actuel de cet enregistrement, donc non appliqué : {{fields}}",
+    writeStrippedPrimaryKey: "L'identifiant de l'enregistrement ne peut pas être modifié lors d'un enregistrement, donc non appliqué : {{fields}}",
+    writeStrippedUnknownReason: "Non appliqué par le serveur : {{fields}}",
     approvalPendingEditable: "En approbation · modifiable",
     approvalPendingTooltip: "Cet enregistrement a une demande d'approbation en attente ; cette étape autorise encore la modification",
     approvalProgress: "Approbations — {{got}} sur {{need}}",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -969,6 +969,8 @@ const ja = {
     writeStrippedTitle: "保存しました（一部の項目は反映されていません）",
     writeStrippedReadonly: "次の項目は読み取り専用のため反映されませんでした: {{fields}}",
     writeStrippedByState: "次の項目はこのレコードの現在の状態では編集できないため反映されませんでした: {{fields}}",
+    writeStrippedPrimaryKey: "次の項目はレコードの識別子で、保存では変更できないため反映されませんでした: {{fields}}",
+    writeStrippedUnknownReason: "次の項目はサーバーで反映されませんでした: {{fields}}",
     approvalPendingEditable: "承認中 · 編集可能",
     approvalPendingTooltip: "このレコードには承認待ちのリクエストがありますが、このステップでは編集できます",
     approvalProgress: "承認 — {{need}} 件中 {{got}} 件",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -958,6 +958,8 @@ const ko = {
     writeStrippedTitle: "저장되었지만 일부 필드는 적용되지 않았습니다",
     writeStrippedReadonly: "다음 필드는 읽기 전용이므로 적용되지 않았습니다: {{fields}}",
     writeStrippedByState: "다음 필드는 이 레코드의 현재 상태에서 편집할 수 없으므로 적용되지 않았습니다: {{fields}}",
+    writeStrippedPrimaryKey: "다음 필드는 레코드의 식별자이며 저장으로 변경할 수 없으므로 적용되지 않았습니다: {{fields}}",
+    writeStrippedUnknownReason: "다음 필드는 서버에서 적용되지 않았습니다: {{fields}}",
     approvalPendingEditable: "승인 진행 중 · 편집 가능",
     approvalPendingTooltip: "이 레코드에 대기 중인 승인 요청이 있지만 이 단계에서는 편집할 수 있습니다",
     approvalProgress: "승인 — {{need}}건 중 {{got}}건",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -959,6 +959,8 @@ const pt = {
     writeStrippedTitle: "Salvo, mas alguns campos não foram aplicados",
     writeStrippedReadonly: "Somente leitura, portanto não foi aplicado: {{fields}}",
     writeStrippedByState: "Não editável no estado atual deste registro, portanto não foi aplicado: {{fields}}",
+    writeStrippedPrimaryKey: "O identificador do registro não pode ser alterado ao salvar, portanto não foi aplicado: {{fields}}",
+    writeStrippedUnknownReason: "Não aplicado pelo servidor: {{fields}}",
     approvalPendingEditable: "Em aprovação · editável",
     approvalPendingTooltip: "Este registro tem uma solicitação de aprovação pendente; esta etapa ainda permite a edição",
     approvalProgress: "Aprovações — {{got}} de {{need}}",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -977,6 +977,8 @@ const ru = {
     writeStrippedTitle: "Сохранено, но часть полей не применена",
     writeStrippedReadonly: "Поля только для чтения, поэтому не применены: {{fields}}",
     writeStrippedByState: "Поля недоступны для редактирования в текущем состоянии записи, поэтому не применены: {{fields}}",
+    writeStrippedPrimaryKey: "Идентификатор записи нельзя изменить при сохранении, поэтому поля не применены: {{fields}}",
+    writeStrippedUnknownReason: "Не применены сервером: {{fields}}",
     approvalPendingEditable: "На согласовании · редактирование доступно",
     approvalPendingTooltip: "У этой записи есть ожидающий запрос на согласование, но этот шаг всё ещё разрешает редактирование",
     approvalProgress: "Согласования — {{got}} из {{need}}",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -865,6 +865,8 @@ const zh = {
     writeStrippedTitle: '已保存，但部分字段未生效',
     writeStrippedReadonly: '以下字段为只读，未生效：{{fields}}',
     writeStrippedByState: '以下字段在记录当前状态下不可编辑，未生效：{{fields}}',
+    writeStrippedPrimaryKey: '以下字段是记录的标识符，保存时无法修改，未生效：{{fields}}',
+    writeStrippedUnknownReason: '以下字段未被服务端写入：{{fields}}',
     approvalPendingEditable: '审批中 · 可编辑',
     approvalPendingTooltip: '该记录有待审批的请求，但当前审批节点仍允许编辑',
     approvalProgress: '审批 — 已通过 {{got}} / 共需 {{need}}',


### PR DESCRIPTION
Fixes #3935

## 前提复核(先行) —— 成立,而且**已经激活**

- 三元式确实在 `packages/app-shell/src/providers/writeWarningToast.ts:114`(基线 `origin/main` @ `25c8007d4`),`else` 臂给出 `detail.writeStrippedReadonly`。
- **`DroppedFieldsEvent['reason']` 现在是三个成员,不是两个。** 本仓 lockfile 已把 `@objectstack/spec` 解析到 `17.0.0-rc.6`;运行时 `DroppedFieldsEventSchema.shape.reason.options` 返回 `["readonly","readonly_when","primary_key"]`。
- 更硬的现场证据来自本仓自己:`packages/data-objectstack/src/spec-symbol-batch6.test.ts:221` 早已把三成员并集钉死,其注释原文写着 rc.6「是 #3935 预言的那一刻,#3935 stops being a prediction」,并明确把消费者侧的修法留给本卡(「needs replacing with an exhaustive map plus a third wording」)。
- 所以这不是「等上游到 pin 才会错」的预防性重构:**今天**触发 primary-key strip 的用户已经被告知字段只读,并被指向一个不存在的权限问题。派发卡「现两 reason 即可动手」的口径已过期 —— 形态不变,但第三条文案必须当场给出,这是本 PR 与卡面唯一的偏差。

## 改法

`STRIPPED_LINE` 声明为 `Record< DroppedFieldsEvent['reason'], StrippedLine >`,镜像 framework `service-automation` 的 `DROPPED_REASON_LABEL`,也正是 spec `DroppedFieldsEventSchema` 注释向「凡按 reason 分支的消费者」点名要求的形状。`byReason` 的键从 `string` 收窄到该并集,穷尽性交给类型系统:上游再加 reason,这里是 `type-check` 红(缺臂),而三元式会永远编译通过 —— 那正是 #3160 坚持复用 spec 类型(而非手工放宽成 `string`)想换来的编译期信号。

文案走现行通道,未发明新通道:`t('detail.…', { defaultValue })` + 十个 locale pack(全量 key parity 是强制的)。新增两个 key:

- `detail.writeStrippedPrimaryKey` —— `primary_key` 专属句子:「记录的标识符在保存时无法修改,未生效」。
- `detail.writeStrippedUnknownReason` —— 超出本包 pin 的 reason:只点字段,不声称原因。

第二个 key 需要交代,因为它形似被禁的宽容兜底。adapter 的 `notifyDroppedFields` 只按**形状**过滤(`fields` 是非空数组),从不拿 `reason` 校验 enum,却把整条断言成 `DroppedFieldsEvent` —— 所以并集外的值真的会到达,而类型说不会。表不可能为它备臂,另两种处置都更差:盲取会在 adapter 以 `void emitWriteWarning(...)` 调用的 async 函数里抛,rejection 无人接管,用户连**已正确解析的那些 reason** 的整条 toast 都丢掉(正是 #3484 要消除的沉默);借用已知臂就是本卡要删的那句假话。未校验的边界本身不在本 PR 范围,已记为 #4934(observation-class,未排队)。

## 钉证

- 三个现有 reason 各一条,各自断言自己的句子;`readonly_when` 与 `primary_key` 另断言 **不含** `Read-only`。
- 多 reason 同一事件:两行,逐行全等比对。
- **穷尽性运行时钉**:从 `DroppedFieldsEventSchema.shape.reason.options` 逐个驱动 toast,要求每个 reason 都不落到 skew 文案、且彼此互异。钉的是「表键 ⊇ 类型成员」,来源是装好的 spec 本身,不会与类型漂移(「⊆」由 `Record` 对多余键报错承担)。pin 升级加了 reason,vitest 会与编译错误一起红。
- 超前 pin 的 skew reason:不抛、不沉默、不编原因。

## 反向验证(先书面预判,后跑)

**变异 A —— 从 `STRIPPED_LINE` 抠掉 `primary_key` 臂。**
预判:红落在 **type-check 门**;并且 —— 与派发卡「换门(而非 vitest)」的模板相反 —— vitest **也**会红,因为上面那条运行时穷尽钉是照卡面选项特意加的。实跑证实,两门皆红:

```
src/providers/writeWarningToast.ts(107,7): error TS2741: Property 'primary_key' is missing in type
  '{ readonly: …; readonly_when: …; }' but required in type
  'Record< "readonly" | "readonly_when" | "primary_key", StrippedLine >'.
```
```
× uses the identifier wording for reason `primary_key` (objectstack#6437)
× keeps one line per reason when a save was stripped for several
× gives every reason the pinned spec declares its own wording (#3935)
  AssertionError: reason `primary_key` has no wording of its own
Tests  3 failed | 10 passed (13)
```

如实记下与模板的差异:「换门」对**类型**机制成立(旧三元式在任何门都不会红),但运行时钉让 vitest 一并报警,实测失败数是 3 而非预判的 2 —— 多 reason 那条也用了 `primary_key`。

**变异 B —— 互换 `readonly` / `readonly_when` 的 defaultValue。**
预判:vitest 红、type-check 绿、`check-i18n-call-site-keys.mjs` 红。三项全部落实:

```
TSC_EXIT=0
× uses the static read-only wording for reason `readonly`
× uses the state wording for reason `readonly_when`, which is NOT read-only
× keeps one line per reason when a save was stripped for several
Tests  3 failed | 10 passed (13)
```
```
2 inline defaultValues contradict the en value of a key that EXISTS (2 distinct keys)
  writeWarningToast.ts:109:5  [default-value-drift]  detail.writeStrippedReadonly
  writeWarningToast.ts:114:5  [default-value-drift]  detail.writeStrippedByState
GATE_EXIT=1
```

## 第二个 commit:一处被我自己弄丢又补回的门覆盖

把四个 `t('detail.writeStripped…')` 搬进箭头函数,**静默地**把它们踢出了 `check-i18n-call-site-keys.mjs` 的视野:该门是按绑定上的**类型标注**(`TRANSLATOR_TYPE`)判断 `t` 是否真译器的,而箭头参数的 `t` 由 `StrippedLine` 推断、没有标注,于是四处都被判为「not a translator」(计数 36 -> 40),不再参与 en pack 解析、inline `defaultValue` 一致性与插值 parity 检查 —— 恰恰是这门最该盯的代码。逐个补回 `t: TranslateFn` 标注后恢复:pack-backed 2556 -> 2558、literal keys 2504/2504 全解析、literal inline defaults 909 -> 911、not-a-translator 回到 36(各 +2 即本 PR 两个新 key)。理由写在 `StrippedLine` 的注释里。变异 B 里那门能红,靠的就是这次补回。

## 验证命令与实际输出

```
pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build      # exit 0
pnpm exec turbo run type-check --concurrency=2                                # Tasks: 81 successful, 81 total
pnpm exec vitest run packages/app-shell/src/providers/ --maxWorkers=2         # 6 files, 44 tests passed
pnpm exec vitest run packages/i18n --maxWorkers=2                             # 46 files, 822 tests passed
node scripts/check-i18n-call-site-keys.mjs                                    # exit 0
node scripts/check-i18n-en-drift.mjs                                          # 0 en value(s) changed (2 key(s) added)
node scripts/check-control-bytes.mjs                                          # OK (4418 files)
```

`check-i18n-en-drift` 明确报「0 en value changed, 2 keys added」—— 本 PR 没有改动任何既有 en 文案,只新增 key,十个 pack 同步。

changeset:`.changeset/write-warning-reason-table-3935.md`(`patch`,`@object-ui/app-shell` + `@object-ui/i18n`)。未触及 `content/docs/releases/`,未 force-push。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_