### PR TITLE
docs(console): name the app-list route the console actually calls, and where per-session filtering really happens

### DIFF
--- a/.changeset/console-app-list-route-comment-truth.md
+++ b/.changeset/console-app-list-route-comment-truth.md
@@ -1,0 +1,17 @@
+---
+---
+
+Comments-only truth correction: six comments in the console app surface named the app
+LIST endpoint with a plural-collection spelling that no request in this repo constructs
+and that no framework route ledger declares as a row of its own. All six now name what
+the console actually calls — the generic metadata list route `GET /api/v1/meta/:type`,
+requested with the singular type segment `app` (`MetadataProvider` →
+`client.meta.getItems('app')`) — and keep the per-session filtering claim, which
+verification confirmed: `filterAppForUser` in `packages/rest/src/rest-server.ts` gates the
+list inside that `:type` handler once the type segment resolves to `app`. Three of the six
+are test-file rationale headers; every assertion is untouched, and one of them
+(`appAccessProbe.test.ts`) already pinned the singular address in its own expectation,
+which is what made the header's spelling demonstrably wrong.
+
+No behaviour changes: each touched file transpiles byte-identically with comments stripped
+(objectui#4887).

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -243,9 +243,12 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
   }, [requestedAppMissing, metadataLoading, previewDrafts, missingRecheck, refreshMetadata]);
 
   // objectui#4252 — WHY the app is missing, once the re-check above has settled
-  // and it still is. `GET /meta/apps` is filtered per session server-side
-  // (`filterAppForUser`), so a withheld app and a nonexistent one are
-  // byte-identical in the list: both absent. Everything this component can read
+  // and it still is. The list this reads is the generic metadata list route
+  // `GET /api/v1/meta/:type`, requested with the SINGULAR type segment `app`
+  // (`MetadataProvider` → `client.meta.getItems('app')`), and the server filters
+  // it per session (`filterAppForUser`, `packages/rest/src/rest-server.ts`), so
+  // a withheld app and a nonexistent one are byte-identical in the list: both
+  // absent. Everything this component can read
   // from the list has therefore already been read, and the remaining question
   // has to be asked of the BY-NAME route, which answers it explicitly since
   // objectstack#8013 (403 `PERMISSION_DENIED` for exists-but-unauthorized; 404
@@ -673,9 +676,11 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
   }
 
   // objectui#4473 — a viewer with NO app to enter here must not be left on a
-  // chrome-less screen. `GET /meta/apps` is filtered PER SESSION server-side
-  // (`filterAppForUser`), so an empty list on a `member` means "nothing here is
-  // yours to open", not "this workspace has no apps" — and switching
+  // chrome-less screen. The app list arrives from `GET /api/v1/meta/:type` with
+  // the SINGULAR type segment `app`, and the server filters that list PER
+  // SESSION (`filterAppForUser`, `packages/rest/src/rest-server.ts`), so an
+  // empty list on a `member` means "nothing here is yours to open", not "this
+  // workspace has no apps" — and switching
   // organization lands exactly there: `WorkspaceSwitcher` reloads onto the
   // console root, `RootLandingRedirect` resolves the landing from the app
   // metadata `MetadataProvider` seeded out of sessionStorage (the PREVIOUS

--- a/packages/app-shell/src/console/__tests__/AppContent.deniedVsUnpublished.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.deniedVsUnpublished.test.tsx
@@ -6,9 +6,12 @@
  *
  * ## The measured defect
  *
- * `GET /api/v1/meta/apps` is filtered per session server-side
- * (`filterAppForUser`), so an app withheld by `requiredPermissions` and an app
- * that does not exist were byte-identical to the console: both simply absent
+ * The console reads its app list from the generic metadata list route
+ * `GET /api/v1/meta/:type` with the singular type segment `app`, and the server
+ * filters that list per session in `filterAppForUser`
+ * (`packages/rest/src/rest-server.ts`), so an app withheld by
+ * `requiredPermissions` and an app that does not exist were byte-identical to
+ * the console: both simply absent
  * from the list. `AppContent`'s `requestedAppMissing` branch therefore rendered
  * its only copy for an absent app — "This app is not available yet — it may
  * still be publishing. Try again in a moment." — over a PERMANENT authorization

--- a/packages/app-shell/src/console/__tests__/AppContent.inaccessibleAppStrand.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.inaccessibleAppStrand.test.tsx
@@ -14,8 +14,10 @@
  * workspace's single visible app (`setup`) still decides the landing after the
  * switch. The user therefore arrives at `/apps/setup`.
  *
- * `GET /api/v1/meta/apps` is already filtered PER SESSION server-side
- * (`filterAppForUser`, `packages/rest/src/rest-server.ts` — see
+ * That list is the generic metadata list route `GET /api/v1/meta/:type`
+ * requested with the singular type segment `app` — the same one the
+ * `sessionStorage` key above mirrors — and the server already filters it PER
+ * SESSION (`filterAppForUser`, `packages/rest/src/rest-server.ts` — see
  * objectstack#8013), so for a `member` with no app access the settled list is
  * EMPTY. In `AppContent` that means: `isSetupRoute` ⇒ `requestedAppMissing` is
  * false ⇒ the pseudo-route fallback finds no `launcherApps[0]` ⇒ `activeApp` is

--- a/packages/data-objectstack/src/appAccessProbe.test.ts
+++ b/packages/data-objectstack/src/appAccessProbe.test.ts
@@ -10,9 +10,11 @@
  * objectui#4252 — an app the session may not open must be distinguishable from
  * an app that is not there.
  *
- * `GET /api/v1/meta/apps` is filtered per session server-side
- * (`filterAppForUser`), so those two conditions are byte-identical in the list:
- * both are simply absent. The maintainer ruling (2026-08-12) put the
+ * The app LIST is the generic metadata list route `GET /api/v1/meta/:type`
+ * requested with the singular type segment `app`, and the server filters it per
+ * session in `filterAppForUser` (`packages/rest/src/rest-server.ts`), so those
+ * two conditions are byte-identical in the list: both are simply absent. The
+ * maintainer ruling (2026-08-12) put the
  * distinction on the BY-NAME route instead of flagging the list — the
  * enumeration surface is not widened past what a by-name probe already implies
  * — and objectstack#8013 (PR #8135) shipped it:

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -3797,8 +3797,13 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * Ask the by-name meta app route WHY an app is not in this session's app list
    * (objectui#4252).
    *
-   * `GET /api/v1/meta/apps` is filtered per session server-side
-   * (`filterAppForUser`), so an app withheld by `requiredPermissions` and an app
+   * The app LIST is the generic metadata list route `GET /api/v1/meta/:type`,
+   * requested with the singular type segment `app` — the same address this
+   * method appends a name to below, and the one `MetadataProvider` reads its
+   * items from. The server filters that list per session in `filterAppForUser`
+   * (`packages/rest/src/rest-server.ts`, applied inside the `:type` list handler
+   * once the type segment resolves to `app`), so an app withheld by
+   * `requiredPermissions` and an app
    * that does not exist are byte-identical there: both are simply absent. A
    * console reading only that list has one fact and two conditions, and it
    * renders its copy for the wrong one — "it may still be publishing" over a


### PR DESCRIPTION
Fixes #4887

## 溯源结论(先做这一步,再动注释)

卡面要求「先确认 console 到底用哪个端点列 apps、per-session 过滤真正发生在哪」。两个问题分开答:

**1. 端点:通用元数据列表路由 `GET /api/v1/meta/:type`,type 段用单数 `app`。**

| 环节 | 证据指针 |
|---|---|
| console 的取数点 | `packages/app-shell/src/providers/MetadataProvider.tsx:466-468` — `preview ? preview.list(type) : adapterRef.current.getClient().meta.getItems(type)` |
| `type` 的值是单数 `app` | 同文件 `:72` `TYPE_BY_STATE_KEY = { apps: 'app', … }`;`:50` `EAGER_TYPES = ['app', 'view']`(挂载即取) |
| SDK 拼出的 URL | `@objectstack/client` `meta.getItems`:`` `${baseUrl}${route}/${type}` ``,`route = getRoute('metadata')`,默认表 `metadata: '/api/v1/meta'` → 线上路径 `/api/v1/meta/app` |
| ADR-0037 draft 预览路径拼的是同一个地址 | `packages/data-objectstack/src/metadata-client.ts:586` `` const url = `${this.base}/${encodeURIComponent(type)}${qs}` ``,base 由 `:405-406` 的 `API_PREFIX='/api/v1'` + `META_PREFIX='/meta'` 组成 |
| by-name 探针用的是同一族地址 | `packages/data-objectstack/src/index.ts` `probeAppAccess` → `this.client.meta.getItem('app', appName)`;`appAccessProbe.test.ts:94` 断言 `toContain('/api/v1/meta/app/finance')` |
| framework 路由台账 | `packages/rest/src/rest-route-ledger.ts:150` — `GET /api/v1/meta/:type` → `meta.getItems`;`packages/runtime/src/route-ledger.ts:343` 同一行 |

台账里**没有**以集合复数拼写单独立行的 app 列表路由 —— 这正是卡面测量到的「零命中」。

补一条诚实的限定,免得下个读者按「404」去理解:那个被退役的拼写并不会 404。列表路由本身是参数化的 `:type`,而 `RestServer.metaTypeSingular`(`rest-server.ts:1500-1503`)用 `@objectstack/spec/shared` 的 `PLURAL_TO_SINGULAR` 把复数折叠成单数(spec 侧钉死:`packages/spec/src/shared/metadata-collection.test.ts:283` `expect(PLURAL_TO_SINGULAR['apps']).toBe('app')`)。所以问题不是「那个 URL 不存在」,而是:**本仓没有任何一处 fetch 构造那个拼写,台账也没有它自己的行** —— 六处注释按名字指了一个不是调用地址的东西。

**2. per-session 过滤:真实存在,且确实在服务端 —— 这半句注释原本就是对的。**

`@objectstack/rest` 的 `RestServer`:

- `filterAppForUser`(`packages/rest/src/rest-server.ts:1814`)/ `filterAppForUserWithReason`(`:1867`)。
- 列表侧:路由挂载在 `:3700-3704`(`path: ${metaPath}/:type`);app 分支入口 `:3818`(`metaTypeSingular(req.params.type) === 'app'`);过滤调用 `:3838`;整段包在 `if (ctx?.userId)`(`:3827`)里 —— **这就是「per session」的机械依据**,没有解析出会话用户就不过滤。
- by-name 侧:`:4682` 用 `filterAppForUserWithReason` 得出 objectstack#8013 的 `403 PERMISSION_DENIED` 判决。

所以本卡的两个候选原因里,命中的是**前者**:路由名错,过滤位置不错。六处注释因此保留「服务端 per-session 过滤」这句声称,并把它从一个泛泛的函数名升级成带文件路径的定位(`filterAppForUser`, `packages/rest/src/rest-server.ts`)。

⛔ 卡面边界照办:没做全仓幽灵路由 sweep,没有声称也没有修任何访问控制缺陷。

## 六处前后对照

每处的新声称都配了上表里的一条可核证据指针。

| # | 位置 | 改前(节选) | 改后(节选) |
|---|---|---|---|
| 1 | `packages/app-shell/src/console/AppContent.tsx:246` | 「(退役拼写)is filtered per session server-side (`filterAppForUser`)」 | 「The list this reads is the generic metadata list route `GET /api/v1/meta/:type`, requested with the SINGULAR type segment `app` (`MetadataProvider` → `client.meta.getItems('app')`), and the server filters it per session (`filterAppForUser`, `packages/rest/src/rest-server.ts`)」 |
| 2 | `packages/app-shell/src/console/AppContent.tsx:676` | 「(退役拼写)is filtered PER SESSION server-side (`filterAppForUser`)」 | 「The app list arrives from `GET /api/v1/meta/:type` with the SINGULAR type segment `app`, and the server filters that list PER SESSION (`filterAppForUser`, `packages/rest/src/rest-server.ts`)」 |
| 3 | `packages/data-objectstack/src/index.ts:3800`(`probeAppAccess` docblock) | 「(退役拼写)is filtered per session server-side (`filterAppForUser`)」 | 「The app LIST is the generic metadata list route `GET /api/v1/meta/:type`, requested with the singular type segment `app` — the same address this method appends a name to below … applied inside the `:type` list handler once the type segment resolves to `app`」 |
| 4 | `packages/data-objectstack/src/appAccessProbe.test.ts:13` | 同上句式,作为「两种条件在列表里不可区分」的 rationale | 同一 rationale,路由名与过滤位置改成真实的;**断言未动** |
| 5 | `…/console/__tests__/AppContent.deniedVsUnpublished.test.tsx:9` | 同上句式,作为 measured defect 的前提 | 「The console reads its app list from the generic metadata list route `GET /api/v1/meta/:type` with the singular type segment `app`, and the server filters that list per session in `filterAppForUser` (`packages/rest/src/rest-server.ts`)」;**断言未动** |
| 6 | `…/console/__tests__/AppContent.inaccessibleAppStrand.test.tsx:17` | 「(退役拼写)is already filtered PER SESSION server-side (`filterAppForUser`, `packages/rest/src/rest-server.ts`)」 | 「That list is the generic metadata list route `GET /api/v1/meta/:type` requested with the singular type segment `app` — the same one the `sessionStorage` key above mirrors — and the server already filters it PER SESSION (…)」;**断言未动** |

第 6 处原本已经写对了过滤位置(它是六处里唯一带 `rest-server.ts` 路径的),所以那处只订正了路由名。

**三个测试文件的断言本体一行未改**,rationale 修正后也不需要跟着改语义 —— 因为修正的方向是「注释向断言靠拢」,不是反过来:`appAccessProbe.test.ts:94` 的 `expect(String(fetchImpl.mock.calls[0][0])).toContain('/api/v1/meta/app/finance')` **本来就钉着单数地址**。文件自己的断言与自己的文件头互相矛盾,这是本卡结论最硬的一条内证。

CHANGELOG.md 里还有三处同样的拼写(app-shell / data-objectstack / i18n),**故意未动**:那是已发布的 release 记录,改它等于重写历史发布说明。

## 验证

注释-only 改动没有行为门可反向验证,所以用**机械等价证明** + **正向判据**,不编造一个「改前红/改后绿」的形状。

**A. 机械等价(照 PR #4888 六文件 `removeComments` 先例)** —— 五个被改文件在 `removeComments: true` 下转译,改前(`git show HEAD:`)与改后逐字节比对:

```
IDENTICAL  emit 33067B/33067B  packages/app-shell/src/console/AppContent.tsx
IDENTICAL  emit 10560B/10560B  .../__tests__/AppContent.deniedVsUnpublished.test.tsx
IDENTICAL  emit  6217B/ 6217B  .../__tests__/AppContent.inaccessibleAppStrand.test.tsx
IDENTICAL  emit  3992B/ 3992B  packages/data-objectstack/src/appAccessProbe.test.ts
IDENTICAL  emit 81706B/81706B  packages/data-objectstack/src/index.ts

5 files; comment-stripped emit identical for all: true
```

`git diff -U0` 过滤掉注释行后剩零行,与上面互为独立佐证。

**B. 受影响测试(flock 串行)**

```
pnpm exec vitest run packages/app-shell/src/console/__tests__/ packages/data-objectstack/ --maxWorkers=2
 Test Files  48 passed (48)
      Tests  630 passed (630)
```

单独跑三个被改的测试文件:`Test Files 3 passed (3)` / `Tests 25 passed (25)`。

**C. 仓根 type-check + 控制字节门**

```
pnpm exec turbo run type-check --concurrency=2
 Tasks:    81 successful, 81 total   [exited with code 0]
node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 4417 tracked text file(s); skipped 85 binary).
```

排版微调发生在那次全仓 type-check 之后,所以又对两个受影响包重跑了一遍最终树:`Tasks: 31 successful, 31 total`。另按控制字节纪律做了门外自查(`grep -naP` 扫 `\x00-\x08\x0b\x0c\x0e-\x1f`,六个文件 + changeset):零命中。

**D. 「六处全改、零处遗漏」的正向判据**

- 退役拼写在 `packages/**` / `apps/**` 的 `.ts`/`.tsx` 里命中数:**0**。
- 扫描器活着(邻近词正查,同一条 grep 管道):`meta/:type` 在两个受影响包里 **37** 命中;`filterAppForUser` 全仓 **8** 命中 —— 其中 6 处是本 PR 改过的句子,另 2 处(`deniedVsUnpublished.test.tsx:187`、`inaccessibleAppStrand.test.tsx:127`)只提函数名、不带路由名,本来就没有错误声称,不在六处之内。

changeset:`.changeset/console-app-list-route-comment-truth.md`(注释-only,照 `combo-drill-doc-truth.md` / `app-shell-props-block-4808.md` 先例用空 frontmatter,不推任何包版本)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_