### PR TITLE
docs(components): stop restating the shadcn classification in README_SHADCN_SYNC.md, pin what survives

### DIFF
--- a/.changeset/shadcn-sync-readme-manifest-pin.md
+++ b/.changeset/shadcn-sync-readme-manifest-pin.md
@@ -1,0 +1,19 @@
+---
+---
+
+Docs and pin only — no published behaviour changes.
+
+`packages/components/README_SHADCN_SYNC.md` no longer restates the component
+classification that `shadcn-components.json` owns (objectui#3881). The page's two
+prose censuses contradicted the manifest three ways — `resizable` was listed as
+registry-updatable although the manifest records that re-syncing it breaks the
+build, `chart` was missing entirely, and the custom heading said 14 against the
+manifest's 15 — while the `(46)` total still matched, because the two membership
+errors cancelled out.
+
+The censuses are deleted rather than corrected: the page now states what the two
+categories mean and points at `pnpm shadcn:list`, which prints both from the
+manifest, offline. The one enumeration that survives is the diverged set, whose
+misreading is what breaks the build, and it is held to the manifest by
+`packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts` as
+member sets — deliberately not as counts.

--- a/packages/components/README_SHADCN_SYNC.md
+++ b/packages/components/README_SHADCN_SYNC.md
@@ -1,61 +1,75 @@
 # Shadcn Components Synchronization
 
-This directory contains tools for keeping ObjectUI components in sync with Shadcn UI.
+How ObjectUI keeps its Shadcn UI primitives in sync with the upstream registry.
 
 ## Files
 
-- `shadcn-components.json` - Component manifest tracking Shadcn components and custom ObjectUI components
-- `shadcn-sync.js` - Automated sync script (requires network access to ui.shadcn.com)
+Paths are repo-relative — the tooling does **not** live in this directory:
+
+- `packages/components/shadcn-components.json` - the component manifest: what is
+  tracked, what may be re-fetched from the registry, and what must not be
+- `scripts/shadcn-sync.js` - the sync script (repo root); every `pnpm shadcn:*`
+  script below is a thin wrapper over it
+- `scripts/shadcn-local-patches.mjs` - local edits declared as data and
+  re-applied after every update, so they survive a sync instead of depending on
+  someone remembering them at review time
 
 ## Component Categories
 
-### Shadcn Components (46)
+`shadcn-components.json` sorts every tracked component into one of two objects,
+and `shadcn-sync.js` reads that split to decide what an update may overwrite:
 
-These components come from Shadcn UI and can be updated from the registry:
+- **`components`** - fetched from the registry. `pnpm shadcn:update <name>` pulls
+  upstream and rewrites the local file.
+- **`customComponents`** - never fetched. `pnpm shadcn:update` and
+  `pnpm shadcn:update-all` skip these. Entries carrying `movedToPlugin` now live
+  in their own `@object-ui/plugin-*` package.
 
-**Form Controls:**
-- input, textarea, select, checkbox, radio-group, switch, form, label, input-otp
+**Membership is data, not prose.** This page deliberately does not reproduce
+either list. The manifest is the only source of truth, and
 
-**Layout:**
-- card, tabs, accordion, separator, scroll-area, resizable
+```bash
+pnpm shadcn:list
+```
 
-**Overlays:**
-- dialog, popover, tooltip, hover-card, sheet, drawer, alert-dialog
+prints both categories - with each custom entry's stated reason - straight out of
+the manifest. It reads no network, so it works offline and cannot be stale.
 
-**Navigation:**
-- button, breadcrumb, navigation-menu, dropdown-menu, context-menu, menubar, pagination
+Restating the names here is precisely what let this page contradict the manifest
+about three of them (objectui#3881), including one where following the page
+performed a build-breaking action. The one list that survives below survives
+because getting it wrong breaks the build, and it is held to the manifest by
+`src/__tests__/readme-shadcn-sync-categories.test.ts`.
 
-**Data Display:**
-- table, avatar, badge, skeleton, progress, slider
+### Diverged components - re-syncing breaks the build
 
-**Feedback:**
-- alert, toast, sonner
+Some `customComponents` entries are not "custom by origin" at all. They began as
+Shadcn components and were hand-migrated past a breaking upstream change, so the
+version upstream still ships **cannot compile here**. The manifest marks each one
+with a `divergedFrom` URL and states the reason; the local file's own header
+repeats it.
 
-**Advanced:**
-- command, carousel, sidebar, collapsible, calendar, aspect-ratio, toggle, toggle-group
+Currently diverged:
 
-### Custom ObjectUI Components (14)
+- `resizable`
 
-These are custom to ObjectUI and should NOT be auto-updated:
-
-- `button-group` - Button group wrapper
-- `calendar-view` - Full calendar implementation
-- `chatbot` - Chatbot UI interface
-- `combobox` - Combined select/input component
-- `date-picker` - Date picker with calendar
-- `empty` - Empty state component
-- `field` - Form field wrapper with validation
-- `filter-builder` - Advanced query builder
-- `input-group` - Input with prefix/suffix
-- `item` - Generic item display
-- `kbd` - Keyboard shortcut display
-- `spinner` - Loading spinner
-- `timeline` - Timeline/activity feed
-- `toaster` - Toast notification manager
+Do not move one of these back into `components` because it looks like it belongs
+there - that is the mistake this page used to invite. Move it back only after
+upstream regenerates for the major version this repo actually installs, and prove
+it with a real build first.
 
 ## Usage
 
+### Offline (reads the manifest only)
+
+```bash
+# List both categories, with each custom entry's reason
+pnpm shadcn:list
+```
+
 ### Automated Sync (Requires Internet)
+
+These reach `ui.shadcn.com`:
 
 ```bash
 # Check component status
@@ -69,9 +83,6 @@ pnpm shadcn:update-all
 
 # Show diff for a component
 pnpm shadcn:diff button
-
-# List all components
-pnpm shadcn:list
 ```
 
 ### Manual Sync Process

--- a/packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts
+++ b/packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts
@@ -1,0 +1,395 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `packages/components/README_SHADCN_SYNC.md` may not contradict
+ * `shadcn-components.json` about which components are re-syncable (objectui#3881).
+ *
+ * ## Why this file exists
+ *
+ * The README used to publish the whole classification as prose — a
+ * `### Shadcn Components` census of 46 names ("can be updated from the registry")
+ * and a `### Custom ObjectUI Components` census of 14 ("should NOT be
+ * auto-updated"). The manifest is the real source: `shadcn-sync.js` reads its
+ * `components` / `customComponents` split to decide what an update may
+ * overwrite. Nothing held the two together, so by objectui#3881 they disagreed
+ * three ways:
+ *
+ *   - `resizable` was listed as registry-updatable while the manifest had it
+ *     under `customComponents` — whose own entry says re-syncing it BREAKS THE
+ *     BUILD (upstream still ships the react-resizable-panels v3 file, which
+ *     imports two names v4 does not export). Following the README performed the
+ *     breaking action;
+ *   - `chart` was in the manifest's `components` and absent from the README
+ *     entirely, so a synced component was documented nowhere;
+ *   - the custom heading said 14 while the manifest held 15.
+ *
+ * ## Why this pin holds SETS, and deliberately not counts
+ *
+ * The filer's sharpest observation on objectui#3881 is the reason this file
+ * asserts no totals anywhere: the README's `(46)` still matched the manifest's 46
+ * on the day the card was written — because the two membership errors cancelled
+ * out (`resizable` counted in, `chart` left out). A count check would have been
+ * green across the whole defect. Counts are not a weaker guard here, they are a
+ * fake one, and adding one later would re-introduce exactly that blind spot.
+ *
+ * ## The fix this pin defends is subtraction, not correction
+ *
+ * Re-spelling the two censuses correctly would have left the drift generator
+ * loaded — a hand-maintained second copy of a machine-readable fact drifts again
+ * on the next manifest edit, which is how objectui#3767 and objectui#3724 went
+ * the same way. So the censuses are gone: the README now states the two
+ * categories' MEANING and points at `pnpm shadcn:list`, which prints both from
+ * the manifest, offline (it calls `loadManifest()` and no network at all).
+ *
+ * Exactly one enumeration survives, and it is here on purpose. The diverged set —
+ * `customComponents` entries carrying a `divergedFrom` URL — is the subset whose
+ * misreading is what objectui#3881 actually cost: not a stale list, a broken
+ * build. A reader skimming the page must see that hazard by name without running
+ * a command, so the names stay and this file holds them to the manifest.
+ *
+ * ## Direction — deliberately BOTH, plus a guard that the censuses stay gone
+ *
+ *   - README names a diverged component the manifest does not mark → the page
+ *     warns about a component that is fine, and the next reader learns to
+ *     distrust the warning;
+ *   - the manifest marks one the README does not name → the build-breaking
+ *     hazard is invisible on the page whose job is to warn about it (the
+ *     objectui#3881 shape, verbatim);
+ *   - the Component Categories section names any `components` key at all → the
+ *     census is growing back. This is the one that keeps the subtraction from
+ *     being quietly undone, and it is why the section's prose names no
+ *     registry-synced component even as an example.
+ *
+ * Order is not compared, and neither are totals.
+ *
+ * ## The expected sets are READ OUT OF the manifest, never listed here
+ *
+ * Hardcoding "resizable" below would rebuild the defect one level up — a second
+ * hand-maintained copy, this time in a test that would then have to be edited
+ * whenever the manifest changed, which is the edit everybody makes without
+ * reading. Both sides are parsed on every run, so a red here is always "fix the
+ * README (or the manifest)", never "update the test".
+ *
+ * `resizable` returning to `components` once upstream regenerates for v4 is a
+ * REAL expected future, not a defect, so it is handled explicitly rather than
+ * left to a floor that would redden on it: when the manifest marks nothing
+ * diverged, the README's subsection must be gone too (see the third test).
+ *
+ * ## Scan surface — deliberately narrow
+ *
+ * This file reads `packages/components/README_SHADCN_SYNC.md` and
+ * `packages/components/shadcn-components.json`, plus `existsSync` for the paths
+ * the README backticks. Nothing else. In particular it does not police the
+ * Usage / Manual Sync / Rollback sections, whose fenced command examples name
+ * components (`pnpm shadcn:update button`) legitimately — fenced blocks are
+ * stripped before the section is judged for that reason.
+ *
+ * The path check is here because no link gate can see this file:
+ * `check-doc-links.mjs`'s per-package `SCAN_ROOTS` row globs one directory level
+ * and then matches the exact filename `README.md`, so `README_SHADCN_SYNC.md` has
+ * never been scanned by anything — which is also how its `## Files` section came
+ * to claim `shadcn-sync.js` sits in this directory when it has always been at the
+ * repo root. Widening that scan root is a separate change with its own entry
+ * price (the objectui#3603 / objectui#3622 shape: one row plus whatever it turns
+ * red) and is deliberately not taken here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/** `packages/components` — two levels up from `src/__tests__`. */
+const PKG_DIR = resolve(__dirname, '../..');
+/** Repo root — `packages/components` is two levels below it. */
+const REPO_ROOT = resolve(PKG_DIR, '../..');
+
+const README = readFileSync(join(PKG_DIR, 'README_SHADCN_SYNC.md'), 'utf8');
+
+interface ManifestEntry {
+  readonly divergedFrom?: string;
+  readonly movedToPlugin?: string;
+  readonly description?: string;
+}
+
+interface Manifest {
+  readonly components: Record<string, unknown>;
+  readonly customComponents: Record<string, ManifestEntry>;
+}
+
+const MANIFEST = JSON.parse(
+  readFileSync(join(PKG_DIR, 'shadcn-components.json'), 'utf8'),
+) as Manifest;
+
+/** The line that introduces the one surviving enumeration. */
+const DIVERGED_ANCHOR = 'Currently diverged:';
+
+/**
+ * Body of a top-level `## ` section, up to the next top-level heading.
+ *
+ * `### ` subsections are deliberately included: the diverged list lives in one,
+ * and it is part of what the Component Categories section claims.
+ */
+function topLevelSection(heading: string): string {
+  const lines = README.split('\n');
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start === -1) {
+    throw new Error(
+      [
+        `packages/components/README_SHADCN_SYNC.md no longer has a "${heading}" heading, so this`,
+        'pin has nothing to compare (objectui#3881). If the page was restructured, re-point this',
+        'reader at the new heading — do not delete the pin, or the classification goes back to',
+        'being prose that nothing holds to shadcn-components.json.',
+      ].join('\n'),
+    );
+  }
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start + 1, end).join('\n');
+}
+
+/** Fenced code blocks removed — they carry command examples, not claims. */
+function withoutFences(text: string): string {
+  return text.replace(/```[\s\S]*?```/g, '');
+}
+
+/** Inline `backticked` tokens, one entry per occurrence. */
+function inlineTokens(text: string): string[] {
+  return [...text.matchAll(/`([^`\n]+)`/g)].map((match) => match[1]);
+}
+
+function componentCategoriesProse(): string {
+  return withoutFences(topLevelSection('## Component Categories'));
+}
+
+/** Whether the README still carries its diverged subsection at all. */
+function divergedSectionPresent(): boolean {
+  return componentCategoriesProse()
+    .split('\n')
+    .some((line) => line.trim() === DIVERGED_ANCHOR);
+}
+
+/** Component names the README lists as diverged. */
+function documentedDiverged(): string[] {
+  const lines = componentCategoriesProse().split('\n');
+  const at = lines.findIndex((line) => line.trim() === DIVERGED_ANCHOR);
+  if (at === -1) return [];
+
+  const names: string[] = [];
+  for (let i = at + 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line === '') {
+      // Blank lines between the anchor and the list are layout; a blank AFTER
+      // the first entry ends the list.
+      if (names.length === 0) continue;
+      break;
+    }
+    const bullet = /^- `([^`]+)`/.exec(line);
+    if (!bullet) break;
+    names.push(bullet[1]);
+  }
+  return names;
+}
+
+/** `customComponents` entries the manifest marks as diverged-from-upstream. */
+function manifestDiverged(): string[] {
+  return Object.entries(MANIFEST.customComponents)
+    .filter(([, info]) => typeof info.divergedFrom === 'string')
+    .map(([name]) => name);
+}
+
+describe("README_SHADCN_SYNC.md's categories match shadcn-components.json (objectui#3881)", () => {
+  it('lists no diverged component the manifest does not mark diverged', () => {
+    const marked = manifestDiverged();
+    const documented = documentedDiverged();
+
+    expect(
+      documented.filter((name) => !marked.includes(name)),
+      [
+        'README_SHADCN_SYNC.md lists a component under "Diverged components - re-syncing breaks',
+        'the build" that shadcn-components.json does not mark with `divergedFrom`.',
+        '',
+        'Either the manifest moved it back into `components` (upstream regenerated for the major',
+        'this repo installs) and the README kept warning about it — drop the bullet, and drop the',
+        'whole subsection if it was the last one — or the name is simply wrong.',
+        '',
+        'The expected set is READ OUT OF shadcn-components.json on every run, so this is never',
+        '"update the test".',
+        `Marked diverged in the manifest: ${marked.join(', ') || '(none)'}`,
+        `Listed in the README: ${documented.join(', ') || '(none)'}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and lists every component the manifest marks diverged', () => {
+    const marked = manifestDiverged();
+    const documented = documentedDiverged();
+
+    expect(
+      marked.filter((name) => !documented.includes(name)),
+      [
+        'shadcn-components.json marks a component with `divergedFrom` — meaning upstream still',
+        'ships a version that cannot compile here, so re-syncing it BREAKS THE BUILD — and',
+        'README_SHADCN_SYNC.md does not name it.',
+        '',
+        'This is the objectui#3881 defect verbatim: the page a reader consults before running',
+        '`pnpm shadcn:update` stays silent about the one component where that command is',
+        'destructive. Add it to the "Currently diverged:" list, or stop marking it in the',
+        'manifest.',
+        `Marked diverged in the manifest: ${marked.join(', ') || '(none)'}`,
+        `Listed in the README: ${documented.join(', ') || '(none)'}`,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and both sides really parsed — the manifest split is read, and the hazard section exists exactly while the hazard does', () => {
+    // Two set-difference assertions are BOTH trivially green on two empty lists,
+    // which is how a pin dies without ever going red: if the README were
+    // reworded so the anchor stopped matching, the tests above would silently
+    // become no-ops. The floors are asserted here as their own visible fact
+    // rather than only inside `expect` messages.
+    const components = Object.keys(MANIFEST.components);
+    const custom = Object.keys(MANIFEST.customComponents);
+
+    expect(
+      components.length,
+      'no `components` entries parsed out of shadcn-components.json — every assertion in this file would prove nothing',
+    ).toBeGreaterThan(1);
+    expect(
+      custom.length,
+      'no `customComponents` entries parsed out of shadcn-components.json — every assertion in this file would prove nothing',
+    ).toBeGreaterThan(1);
+
+    // A component may not be in both objects: the two are a partition, and
+    // `shadcn-sync.js` would have to pick one. This is the manifest-side drift
+    // the README comparison above cannot see.
+    expect(
+      components.filter((name) => custom.includes(name)),
+      'shadcn-components.json lists a component in BOTH `components` and `customComponents`; the two are meant to partition the tracked set, and the sync script reads the split to decide whether an update may overwrite the local file',
+    ).toEqual([]);
+
+    // The honest treatment of the empty case. `resizable` going back to
+    // `components` is an expected future (upstream regenerating for
+    // react-resizable-panels v4), not a defect — so rather than a floor that
+    // would redden on it, the requirement is an "exactly while": the README
+    // carries its diverged subsection if and only if the manifest marks
+    // something diverged.
+    const marked = manifestDiverged();
+    expect(
+      divergedSectionPresent(),
+      marked.length > 0
+        ? [
+            `shadcn-components.json marks ${marked.length} component(s) with \`divergedFrom\` (${marked.join(', ')}),`,
+            'but README_SHADCN_SYNC.md no longer has its "Currently diverged:" list. That list is the',
+            'only place a reader is warned before running a build-breaking `pnpm shadcn:update`.',
+            'Restore it (and re-point DIVERGED_ANCHOR if the wording changed) — removing it is how',
+            'objectui#3881 happened.',
+          ].join('\n')
+        : [
+            'No component in shadcn-components.json carries `divergedFrom` any more, but',
+            'README_SHADCN_SYNC.md still has a "Currently diverged:" list. If upstream regenerated',
+            'and the component moved back into `components`, delete that whole subsection together',
+            'with the two set tests above — a hazard section for a hazard that no longer exists is',
+            'the next stale claim.',
+          ].join('\n'),
+    ).toBe(marked.length > 0);
+
+    if (marked.length > 0) {
+      const documented = documentedDiverged();
+      expect(
+        documented.length,
+        'the "Currently diverged:" anchor was found but no `backticked` bullet parsed under it — the two set assertions above are comparing against an empty list and proving nothing',
+      ).toBeGreaterThan(0);
+
+      // A repeated entry keeps both set differences empty while the two lists
+      // are not the same list, so it is the one drift the pair above cannot see.
+      expect(
+        documented.length,
+        `The README lists a diverged component twice: ${documented.join(', ')}`,
+      ).toBe(new Set(documented).size);
+      expect(
+        marked.length,
+        `shadcn-components.json marks a component diverged twice: ${marked.join(', ')}`,
+      ).toBe(new Set(marked).size);
+    }
+  });
+
+  it('and the Component Categories prose names no registry-synced component — the census stays gone', () => {
+    const components = Object.keys(MANIFEST.components);
+    expect(
+      components.length,
+      'no `components` entries parsed out of shadcn-components.json — the assertion below would prove nothing',
+    ).toBeGreaterThan(1);
+
+    const prose = componentCategoriesProse();
+    expect(
+      prose.length,
+      'the Component Categories section is empty after stripping fenced blocks — the assertion below would prove nothing',
+    ).toBeGreaterThan(0);
+
+    expect(
+      [...new Set(inlineTokens(prose))].filter((token) => components.includes(token)),
+      [
+        'The `## Component Categories` section names a component that shadcn-components.json',
+        'lists under `components` (registry-synced). That section is deliberately census-free:',
+        'objectui#3881 was caused by a hand-maintained copy of this exact classification, and it',
+        'was fixed by deleting the copy, not by correcting it — the page now states what the two',
+        'categories MEAN and points at `pnpm shadcn:list`, which prints both from the manifest.',
+        '',
+        'If a per-component list is growing back here, it will drift again. If instead the',
+        'manifest just moved a name from `customComponents` into `components` while the README',
+        'still discusses it by name, update the README to match the manifest.',
+        '',
+        'Command examples inside fenced code blocks are exempt (they are stripped before this',
+        'check), so a `pnpm shadcn:update <a component>` example is fine — inline prose is not.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('and every in-repo path the README backticks exists on disk', () => {
+    // objectui#3881 also recorded a path drift: `## Files` claimed the sync
+    // script sits in this directory while it has always been at the repo root.
+    // No link gate can see this file (see the header), so the check lives here.
+    // Fences are stripped: their examples include a deliberate glob
+    // (`.backup/button.tsx.*`) that is not a real path.
+    const prose = withoutFences(README);
+    const tokens = [...new Set(inlineTokens(prose))].filter((token) => !token.includes('*'));
+
+    const repoRelative = tokens.filter((token) =>
+      /^(packages|scripts|apps|content|docs|examples|e2e|public|patches|skills)\//.test(token),
+    );
+    const packageRelative = tokens.filter((token) => /^src\//.test(token));
+
+    expect(
+      repoRelative.length,
+      'no repo-relative backticked path parsed out of README_SHADCN_SYNC.md — the assertion below would prove nothing, and the `## Files` section is meant to name at least the manifest and the sync script',
+    ).toBeGreaterThan(1);
+
+    expect(
+      repoRelative.filter((token) => !existsSync(join(REPO_ROOT, token))),
+      [
+        'README_SHADCN_SYNC.md backticks a repo-relative path that does not exist. This is the',
+        'objectui#3881 path drift: the page told readers the sync script was in',
+        'packages/components/ when it is at scripts/shadcn-sync.js.',
+      ].join('\n'),
+    ).toEqual([]);
+
+    expect(
+      packageRelative.filter((token) => !existsSync(join(PKG_DIR, token))),
+      [
+        'README_SHADCN_SYNC.md backticks a path under `src/` (read as relative to',
+        'packages/components/) that does not exist.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #3881

## 前提复核(`origin/main` @ `25c8007d4`,逐条实测)

三处矛盾**全部现存**,premise 成立:

| 项 | README(改前) | shadcn-components.json |
|---|---|---|
| `resizable` | Shadcn Components → Layout,即「可从 registry 更新」 | `customComponents`,条目自述「重同步会构建失败」 |
| `chart` | 全文零命中 | `components`(registry 同步) |
| custom 计数 | 标题 `(14)`,正文 14 条 | `customComponents` 实为 **15** 条 |

机械比对(README 枚举 ↔ manifest 键集)输出:

```
manifest components: 46          doc shadcn enumerated: 46
manifest customComponents: 15    doc custom enumerated: 14
SHADCN doc-only:      [ 'resizable' ]
SHADCN manifest-only: [ 'chart' ]
CUSTOM manifest-only: [ 'resizable' ]
```

卡面最关键那句实测成立:**两侧计数都是 46,`(46)` 在整个缺陷期间都对得上**,因为两处成员错误刚好互相抵消(多算 `resizable`、漏掉 `chart`)。

manifest 与磁盘**一致**,没有第二处缺陷需要另立卡:`packages/components/src/ui/resizable.tsx` 的文件头自己写明它不再是 upstream 同步文件、重同步会挂(v4 已把 `PanelGroup`/`PanelResizeHandle` 改名),与 manifest 的分类同向。**manifest 是真源**,漂的是 README。

外加卡面记的路径漂移一处:`## Files` 称 `shadcn-sync.js` 在本目录,实际一直在仓根 `scripts/shadcn-sync.js`。

## 实施(按分诊非绑定方向 2+3)

**散文停止枚举成员。** 两份点名清单(46 + 14)整段删除,**不是**逐条校正 —— 校正只会把同一个漂移生成器重新上膛(#3767 / #3724 同族)。改为讲两类的**含义**(`components` 会被 `pnpm shadcn:update` 拉取覆写;`customComponents` 一律跳过),成员归属指向 manifest 与 `pnpm shadcn:list`。

这个指向已实测兑现:`listComponents()` 只调 `loadManifest()`,**不碰网络**,两类都打印,并把每条 custom 的原因一并打出来(含 resizable 那句 "re-syncing would break the build")—— 严格强于原散文。顺带把 `shadcn:list` 从「Requires Internet」小节下挪出并新增一个 Offline 小节,否则新指向自相矛盾。

**幸存的唯一枚举 = diverged 集合,且入钉。** `customComponents` 里带 `divergedFrom` 的那一类不是「天生 custom」,而是曾是 Shadcn、被手工迁过破坏性升级,upstream 仍在发的版本在本仓**编译不过**。这一条的误读代价不是「清单陈旧」而是**构建挂掉**,读者必须不跑命令就看得见 —— 所以名字保留,并由钉子按**成员集合**双向对住 manifest。

**⛔ 不钉计数。** 如上,`(46)` 在整个缺陷期间都是绿的;计数钉在这里不是弱守卫,是**假守卫**。钉子里没有任何总数断言。

## 钉子:`packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts`

照 #4860 / PR #4893 的 README 键表钉形态(双向 + 非空下限 + 无重复;期望集**一律从源头解析**,绝不硬编码 —— 硬编码 `resizable` 等于把同一个缺陷搬高一层),共 5 条:

1. README 列的 diverged 名字,manifest 必须都标了 `divergedFrom`
2. manifest 标了 `divergedFrom` 的,README 必须都列(**#3881 缺陷本体方向**)
3. 两侧确实读到了 + 无重复 + `components`/`customComponents` 必须是划分(无交集)+ 空集情形显式处理
4. `## Component Categories` 散文不得点名任何 `components` 键 —— 让这次「删除」不被悄悄撤销
5. README 反引号里的仓内路径必须存在(本仓**没有任何链接门禁看得见这个文件**)

第 3 条的空集处理值得单说:`resizable` 在 upstream 为 v4 重新生成后回到 `components` 是**预期未来,不是缺陷**,所以没有用「会在那天变红」的下限,而是写成 **iff** —— manifest 不标任何 diverged 时,README 的该小节必须一并消失。围栏代码块在判定前被剥掉,所以 Usage 小节里 `pnpm shadcn:update button` 这类合法命令示例不受第 4 条约束。

钉子落在 `packages/components` 包内测试邻域(README 与 manifest 都是该包的文件),进 `unit` project(纯 fs 读、node 环境,无需 build 依赖)。

## 反向验证(先书面预判,后跑;变异前已 commit,还原一律 `git checkout`,⛔ stash)

五次变异,预判与实测**逐条相符**:

| 变异 | 预判 | 实测 |
|---|---|---|
| A. README diverged 列表加一个 manifest 没标的名字(`chart`) | 钉 1 + 钉 4 红 | `2 failed \| 3 passed` ✔ |
| B. manifest 侧把 `resizable` 从 `customComponents` 挪进 `components` | 钉 1 + 钉 3 + 钉 4 红 | `3 failed \| 2 passed` ✔,钉 3 命中空集分支的正确文案 |
| C. 改写锚点 `Currently diverged:`(reader 停止匹配) | 钉 2 + 钉 3 红,**不得静默绿** | `2 failed \| 3 passed` ✔ |
| D. 改掉 `## Component Categories` 标题 | 钉 1-4 硬抛,钉 5 绿 | `4 failed \| 1 passed` ✔ |
| E. 复原卡面那处路径漂移 | **仅**钉 5 红 | `1 failed \| 4 passed` ✔ |

A 与 B 各证一面(README 侧 / manifest 侧);A 落在**两条**钉上而非一条,是因为 `chart` 同时是 `components` 的键,钉 4 也会命中 —— 这一点预判时已写明。C 是零命中断言的**防空绿正查**:锚点一旦失配,两条 `toEqual([])` 会双双退化成 no-op,C 证明它们反而变红(钉 2 与钉 3 各报一句可执行的修法)。

## 验证

```
pnpm exec vitest run packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts --maxWorkers=2
  Test Files  1 passed (1)        Tests  5 passed (5)

# 消费半径清扫(manifest 的既有读者 + 链接门禁自测)
pnpm exec vitest run scripts/__tests__/shadcn-check-report.test.ts \
  scripts/__tests__/shadcn-local-patches.test.ts \
  scripts/__tests__/shadcn-sync-fetch-cache.test.ts \
  scripts/__tests__/check-doc-links.test.ts --maxWorkers=2
  Test Files  4 passed (4)        Tests  157 passed (157)

pnpm exec turbo run type-check --concurrency=2
  Tasks: 81 successful, 81 total

node scripts/check-control-bytes.mjs      → OK (4417 tracked text files)
node scripts/check-doc-links.mjs          → Links are valid across 13 scan roots.
node scripts/check-changeset-presence.mjs → 空 frontmatter,显式豁免,通过
node scripts/check-changeset-no-major.mjs → 无 major
pnpm exec eslint  (新钉文件)              → exit 0
```

全部重验证走共享锁 `/tmp/os-heavy-verify.lock`。changeset 用**空 frontmatter**(纯文档 + 钉,无发布语义;`packages/components/src/**` 触发门禁,空 frontmatter 是该门禁写明的完整答案)。

## 相邻发现(未扩围)

已另立 finding 卡 **#4938**:`check-doc-links` 的包级扫描面是精确文件名匹配,包内非 README markdown(15 个文件)从未被任何门禁解析过,实测 1 条死链(`TIMELINE.md` 指向不存在的 prototype app)。#3881 可选修法 3 提过「顺带把包内 README* 纳入扫描面」,本 PR **刻意未取** —— 那是独立的门禁扩面,有自己的入场价,按 #3536 → #3572 → #3603/#3622 → #4148 的先例链每次都是独立一张卡;本 PR 只在包内测试里把**这一个文件**的反引号路径局部钉住(钉 5)。

## 未改动

`shadcn-components.json`(真源,无需改)、`content/docs/releases/**`、`scripts/shadcn-sync.js`、任何 `src/ui/**` 组件文件。无 force-push。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_