### PR TITLE
fix(fields): close the FieldEditWidget delegation road for retired field types

### DIFF
--- a/.changeset/retired-field-types-close-the-inline-edit-delegation-road.md
+++ b/.changeset/retired-field-types-close-the-inline-edit-delegation-road.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/fields': patch
+---
+
+Retired field-type spellings can no longer reach an inline editor by delegation — the grid's inline cell editor stops offering a working person picker for `owner`.
+
+objectui#4814 retired the `owner` field type with a loud tombstone, and the
+record form has answered `type: 'owner'` with a visible refusal ever since.
+`FieldEditWidget` did not participate, and the reason it was missed is that no
+routing table had to list the spelling for it to stay alive:
+`hasFieldEditWidget` answers `resolveInlineEditType(type) in EDIT_WIDGETS`, and
+`resolveInlineEditType` returns a type **unchanged** when it is already a key of
+`EDIT_WIDGETS`. So while `owner: UserField` sat in that map, the alias table —
+where the retirement lives — was never consulted, and the retirement never
+applied. Measured: `hasFieldEditWidget('owner') === true`, and a direct
+`FieldEditWidget` call rendered a working person picker. Every host built on
+this seam, the data grid's inline cell editor being the user-facing one, still
+let a person be picked and saved for a field the record form refuses.
+
+The gate now consults the retirement table itself, so this closes the **class**
+rather than the spelling — the next retirement covers this seam the day it lands
+in `RETIRED_FIELD_TYPES`, with no edit here:
+
+- `hasFieldEditWidget()` answers `false` for any retired spelling, ahead of
+  every table lookup (so it holds even if a retired spelling is still a key of
+  the widget map);
+- `isInlineExcludedFieldType()` answers `true` for any retired spelling, which
+  is what routes a host to its read-only path;
+- `FieldEditWidget` itself renders no control for a retired spelling and writes
+  the once-per-spelling console prescription naming the migration;
+- `owner` is dropped from `EDIT_WIDGETS` and from the cosmetic
+  `COMPACT_EDIT_TYPES` sizing set.
+
+The second bullet is load-bearing and not cosmetic. `ObjectGrid` marks a column
+`editable: false` exactly when `isFieldInlineEditable` is false, and that
+predicate consults `isInlineExcludedFieldType`. Without it, closing the first
+gate alone would have left the column editable, handed the cell editor a `null`
+widget, and let DataTable fall back to its built-in **plain text input** — which
+for a stored person reference displays a coerced value and writes a bare string
+straight back over it. Measured before/after on the grid consumer: a stored
+`owner` field went from an editable cell rendering the person picker to a
+read-only cell (`isFieldInlineEditable('owner')` `true` → `false`), which is the
+same disposition `password`, `formula` and `composite` already get, for the same
+reason. The read path is unchanged from #4814: the text cell plus the console
+prescription.
+
+`user` is untouched — it keeps the person picker, its compact sizing and its
+expanded-object value resolution. The record-owner idiom survives verbatim as
+`{ type: 'user', name: 'owner' }`: the field NAME carries the ownership meaning,
+the type carries the widget.

--- a/packages/fields/src/FieldEditWidget.test.ts
+++ b/packages/fields/src/FieldEditWidget.test.ts
@@ -71,7 +71,14 @@ describe('inline editor ↔ form widget parity', () => {
   });
 
   it('relational fields use the standard picker inline (regression: lookup was a text box)', () => {
-    for (const t of ['lookup', 'master_detail', 'user', 'owner']) {
+    // `owner` stood beside `user` here until objectui#4931. It is NOT merely
+    // dropped for convenience: this assertion pinned the exact branch that card
+    // removed — `EDIT_WIDGETS`' `owner` key, the road by which objectui#4814's
+    // retirement was bypassed — so keeping it in any form would be pinning the
+    // bug. Its replacement fact (the retirement gate answers `false`, and the
+    // grid degrades to a read-only cell rather than a text box) is asserted in
+    // one place, `__tests__/FieldEditWidget.retiredFieldType.test.tsx`.
+    for (const t of ['lookup', 'master_detail', 'user']) {
       expect(hasFieldEditWidget(t)).toBe(true);
     }
   });

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -46,7 +46,30 @@ import { CodeField } from './widgets/CodeField';
 import { QRCodeField } from './widgets/QRCodeField';
 // The FORM's spec-alias table (`json` → `field:code`, `tree` → `field:lookup`,
 // …) — inline resolution reuses it so spec spellings get the form's decision.
-import { mapFieldTypeToFormType } from './field-type-alias';
+// `RETIRED_FIELD_TYPES` / `reportRetiredFieldType` come from the same module on
+// purpose: it is the live retirement table (objectui#4814), and importing it
+// from here — rather than from the `./index` barrel, which re-exports this
+// file — keeps the module graph acyclic, exactly as the alias import already
+// does (see the note at index.tsx's `mapFieldTypeToFormType` re-export).
+import {
+  mapFieldTypeToFormType,
+  RETIRED_FIELD_TYPES,
+  reportRetiredFieldType,
+} from './field-type-alias';
+
+/**
+ * True when a spelling has been RETIRED by this renderer (objectui#4814's
+ * tombstone table, read live — never copied).
+ *
+ * Quantified over the whole table rather than written per spelling, which is
+ * the point: the next retirement closes every seam in this file the day it
+ * lands in `RETIRED_FIELD_TYPES`, instead of leaving a delegation road open
+ * until someone notices it (objectui#4931 — which is how `owner` survived
+ * #4814 here).
+ */
+function isRetiredFieldType(type: string): boolean {
+  return Object.prototype.hasOwnProperty.call(RETIRED_FIELD_TYPES, type);
+}
 
 /**
  * Field types that edit in place with a dedicated widget. Keyed by the raw
@@ -82,7 +105,17 @@ const EDIT_WIDGETS: Record<string, React.ComponentType<FieldWidgetComponentProps
   lookup: LookupField,
   master_detail: LookupField,
   user: UserField,
-  owner: UserField,
+  // `owner: UserField` sat here — pointing at the very same widget `user`
+  // resolves to — until objectui#4931 removed it, closing the last road by
+  // which objectui#4814's retirement could be bypassed. Membership in THIS
+  // table is what made `resolveInlineEditType` return the spelling unchanged
+  // (it short-circuits on `type in EDIT_WIDGETS`), so the alias table was never
+  // consulted and the retirement never applied: `hasFieldEditWidget('owner')`
+  // answered `true` and every host built on this seam still offered a working
+  // person picker while the record form answered the same field with a
+  // tombstone refusal. Do not re-add it — and note that re-adding it alone
+  // would no longer resurrect the picker, because the retirement gate below
+  // is keyed on the retirement table, not on this map's keys.
   // Structured-value editors — same widgets the form uses.
   color: ColorField,
   address: AddressField,
@@ -145,9 +178,25 @@ function resolveInlineEditType(type: string): string {
   return mapFieldTypeToFormType(type).replace(/^field:/, '');
 }
 
-/** True when a field type has a dedicated in-place edit widget. */
+/**
+ * True when a field type has a dedicated in-place edit widget.
+ *
+ * A RETIRED spelling answers `false` unconditionally, ahead of every table
+ * lookup (objectui#4931). This is the gate the retirement was missing: hosts
+ * ask this question to decide whether to hand a cell to {@link FieldEditWidget},
+ * and while it answered `true` for a retired spelling the whole tombstone was
+ * bypassable by delegation — the grid's inline cell editor rendered a working
+ * person picker for a field the record form refuses.
+ *
+ * Keyed on the retirement TABLE rather than on the raw `type`, and checked
+ * BEFORE `resolveInlineEditType`, so it holds even if a future retired spelling
+ * is still (or again) a key of {@link EDIT_WIDGETS} — closing the class, not
+ * one spelling.
+ */
 export function hasFieldEditWidget(type: string | undefined): boolean {
-  return !!type && resolveInlineEditType(type) in EDIT_WIDGETS;
+  if (!type) return false;
+  if (isRetiredFieldType(type)) return false;
+  return resolveInlineEditType(type) in EDIT_WIDGETS;
 }
 
 /**
@@ -157,17 +206,48 @@ export function hasFieldEditWidget(type: string | undefined): boolean {
  * text editor is exactly the corruption path the exclusion exists to close.
  */
 export function isInlineExcludedFieldType(type: string | undefined): boolean {
-  return !!type && INLINE_EXCLUDED_FIELD_TYPES.has(resolveInlineEditType(type));
+  if (!type) return false;
+  // A RETIRED spelling is excluded from inline editing (objectui#4931).
+  //
+  // This is the half that decides what the grid actually DOES once
+  // `hasFieldEditWidget` starts answering `false`, and without it the fix would
+  // trade one silent failure for another. `ObjectGrid` marks a column
+  // `editable: false` exactly when `isFieldInlineEditable` is false (which
+  // consults this predicate) — otherwise the column stays editable, the cell
+  // editor asks `hasFieldEditWidget`, gets `false`, returns `null`, and
+  // DataTable falls back to its built-in PLAIN TEXT input. For a stored
+  // person-reference that input displays the coerced value and writes a bare
+  // string straight back over it. So the retirement routes the cell to the
+  // grid's normal read-only path — the same disposition `password`, `formula`
+  // and `composite` get, and for the same reason: a text box here is a
+  // value-corruption path, not a graceful degradation.
+  //
+  // Deliberately a predicate-level answer and NOT a membership in
+  // `INLINE_EXCLUDED_FIELD_TYPES`: that set is documented as the types this
+  // renderer *chose* not to edit in place and is asserted to contain only
+  // renderable form types, which a retired spelling is precisely not. The
+  // predicate already diverges from raw set membership for the alias-resolved
+  // spellings (`composite` → `object`, `video` → `file`), so answering on
+  // behalf of the retirement table is the established shape here.
+  if (isRetiredFieldType(type)) return true;
+  return INLINE_EXCLUDED_FIELD_TYPES.has(resolveInlineEditType(type));
 }
 
 /**
- * Relational picker widgets (lookup / master_detail / user / owner) render best
- * in a grid cell as a single-line, borderless trigger — so the selected
- * record's NAME shows inside the trigger instead of a chip stacked above a
- * separate "Select…" button (which double-stacks and wastes the row height).
- * This mirrors how the line-item grid (`GridField`) renders its lookup cells.
+ * Relational picker widgets (lookup / master_detail / user) render best in a
+ * grid cell as a single-line, borderless trigger — so the selected record's
+ * NAME shows inside the trigger instead of a chip stacked above a separate
+ * "Select…" button (which double-stacks and wastes the row height). This
+ * mirrors how the line-item grid (`GridField`) renders its lookup cells.
+ *
+ * `owner` was listed here (objectui#4914 item 11) until objectui#4931 dropped
+ * it in the same stroke as the routing-table key above. Purely cosmetic on its
+ * own — it only ever added `compact` to a widget that is no longer reached —
+ * but it is removed rather than left to rot, because a retired spelling
+ * lingering in a sizing set is how the next reader concludes the type is still
+ * live here.
  */
-const COMPACT_EDIT_TYPES = new Set<string>(['lookup', 'master_detail', 'user', 'owner']);
+const COMPACT_EDIT_TYPES = new Set<string>(['lookup', 'master_detail', 'user']);
 
 /**
  * Render the dedicated edit widget for a field's type — the SAME control the
@@ -188,6 +268,29 @@ export function FieldEditWidget({
   readonly,
   autoFocus,
 }: FieldWidgetComponentProps<any>): React.ReactElement | null {
+  // A RETIRED spelling never reaches a widget here, whatever the tables say,
+  // and it says so out loud (objectui#4931). This branch is for the caller that
+  // ignores `hasFieldEditWidget` and calls this component directly: without it
+  // such a host would still be handed the person picker for a field the record
+  // form refuses, which is the exact contradiction #4814's tombstone exists to
+  // end.
+  //
+  // The loud half is the once-per-spelling console prescription, not a rendered
+  // alert, and that is deliberate: this component's hosts are CELL-sized (the
+  // grid's inline editor, the kanban required-fields dialog), and #4814 settled
+  // the same question the same way for the read path — "there is no visible
+  // alert a table CELL can carry without wrecking the row". The visible refusal
+  // is the record form's job, and `RetiredFieldTombstone` is what it renders.
+  //
+  // Returning `null` is this function's documented contract for "no dedicated
+  // widget", not a new fallback invented here — and every in-repo host is
+  // already routed away from that path by the two predicates above
+  // (`hasFieldEditWidget` → false, `isInlineExcludedFieldType` → true), so the
+  // grid marks the column read-only instead of opening a plain text box.
+  if (field?.type && isRetiredFieldType(field.type)) {
+    reportRetiredFieldType(field.type);
+    return null;
+  }
   const resolved = field?.type ? resolveInlineEditType(field.type) : undefined;
   const Widget = resolved ? EDIT_WIDGETS[resolved] : undefined;
   if (!Widget) return null;

--- a/packages/fields/src/__tests__/FieldEditWidget.retiredFieldType.test.tsx
+++ b/packages/fields/src/__tests__/FieldEditWidget.retiredFieldType.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — the inline-edit DELEGATION road (objectui#4931, the last
+ * measured active-contradiction face of objectui#4814's ruling A′).
+ *
+ * #4814 retired the `owner` field type with a loud tombstone, and #4914 carried
+ * the shrink onto the published contract twins and inline edit. This seam
+ * survived all of it. `hasFieldEditWidget` answers
+ * `resolveInlineEditType(type) in EDIT_WIDGETS`, and `resolveInlineEditType`
+ * returns a type UNCHANGED when it is already a key of `EDIT_WIDGETS` — so
+ * while `owner: UserField` sat in that table the alias table was never
+ * consulted and the retirement never applied. Measured on this branch before
+ * the fix: `hasFieldEditWidget('owner') === true`, and a direct
+ * `FieldEditWidget` call rendered a working person picker (one `role=button`
+ * reading `Select…`, no tombstone). Deleting a routing-table membership
+ * elsewhere does not disable a type; delegation reaches the same widget by
+ * another road.
+ *
+ * What is pinned here is therefore the CLASS, not the spelling. Every
+ * assertion below is quantified over `@object-ui/fields`' live
+ * `RETIRED_FIELD_TYPES` table rather than written against `owner`, so the next
+ * retirement closes this seam the day it lands in that table instead of
+ * leaving a fresh delegation road open until someone measures it again.
+ *
+ * Three roads, three pins, because closing only the first would trade one
+ * silent failure for another:
+ *
+ *  1. `hasFieldEditWidget` — the gate hosts ask before handing a cell to
+ *     `FieldEditWidget`. Answers `false`.
+ *  2. `isInlineExcludedFieldType` — what the host does NEXT. `ObjectGrid`
+ *     marks a column `editable: false` exactly when `isFieldInlineEditable`
+ *     (which consults this predicate) is false; otherwise the column stays
+ *     editable, the cell editor gets `null`, and DataTable falls back to its
+ *     built-in PLAIN TEXT input — which for a stored person reference writes a
+ *     bare string over the value. Answers `true`.
+ *  3. `FieldEditWidget` called directly, ignoring both gates. Renders no
+ *     control at all and writes the once-per-spelling prescription.
+ *
+ * Both wrong outcomes are pinned in both directions — a working picker (the
+ * pre-#4931 state) and a quiet text box (what closing road 1 alone would have
+ * produced) — because a test asserting merely "not a UserField" would pass
+ * just as happily against the text-box regression.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import {
+  FieldEditWidget,
+  hasFieldEditWidget,
+  isInlineExcludedFieldType,
+  INLINE_EXCLUDED_FIELD_TYPES,
+  RETIRED_FIELD_TYPES,
+  resetRetiredFieldTypeReports,
+} from '../index';
+
+/** The one retired spelling today, and the survivor it was a synonym for. */
+const RETIRED = 'owner';
+const SURVIVOR = 'user';
+
+const RETIRED_TYPES = () => Object.keys(RETIRED_FIELD_TYPES);
+
+let error: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetRetiredFieldTypeReports();
+  error = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const said = () =>
+  (error.mock.calls as unknown[][]).map((c) => String(c[0])).join('\n');
+
+describe('the retirement premise this file is quantified over', () => {
+  it('is a spelling this repo really has retired', () => {
+    // Guards every assertion below from going vacuous: if the table emptied,
+    // the quantified pins would all pass while testing nothing.
+    expect(RETIRED_TYPES()).toContain(RETIRED);
+    expect(RETIRED_TYPES().length).toBeGreaterThan(0);
+  });
+});
+
+describe('road 1 — the delegation gate refuses every retired spelling', () => {
+  it('`hasFieldEditWidget` answers false for every key of RETIRED_FIELD_TYPES', () => {
+    const stillOffered = RETIRED_TYPES().filter((t) => hasFieldEditWidget(t));
+    expect(stillOffered).toEqual([]);
+  });
+
+  it('is not a vacuous pass — the live relational types still answer true', () => {
+    // If this ever fails together with the pin above, the gate has stopped
+    // discriminating and is simply refusing everything.
+    for (const t of ['lookup', 'master_detail', SURVIVOR]) {
+      expect(hasFieldEditWidget(t), `${t} must keep its inline editor`).toBe(true);
+    }
+  });
+});
+
+describe('road 2 — the host is routed to its read-only path, not to a text box', () => {
+  it('`isInlineExcludedFieldType` answers true for every retired spelling', () => {
+    // This is the answer `ObjectGrid` turns into `editable: false` on the
+    // column (via `isFieldInlineEditable`), which is what stops DataTable from
+    // opening its built-in plain text input on a stored person reference.
+    const notExcluded = RETIRED_TYPES().filter((t) => !isInlineExcludedFieldType(t));
+    expect(notExcluded).toEqual([]);
+  });
+
+  it('answers so from the retirement table, without polluting the exclusion SET', () => {
+    // `INLINE_EXCLUDED_FIELD_TYPES` is documented as the types this renderer
+    // CHOSE not to edit in place, and a sibling guard asserts it holds only
+    // renderable form types — which a retired spelling is precisely not. The
+    // predicate diverging from raw membership is the established shape here
+    // (`composite` → `object`, `video` → `file` resolve in the same way).
+    for (const t of RETIRED_TYPES()) {
+      expect(INLINE_EXCLUDED_FIELD_TYPES.has(t)).toBe(false);
+    }
+  });
+
+  it('leaves the two answers consistent — never "no editor" AND "not excluded"', () => {
+    // The pairing the whole file exists to protect: a type that has no inline
+    // editor and is not excluded is exactly the state that falls through to
+    // the grid's plain text input.
+    for (const t of RETIRED_TYPES()) {
+      expect(hasFieldEditWidget(t) || isInlineExcludedFieldType(t)).toBe(true);
+    }
+  });
+});
+
+describe('road 3 — a direct call, ignoring both gates', () => {
+  it('renders no control at all for a retired spelling', () => {
+    const { container } = render(
+      <FieldEditWidget
+        field={{ name: 'record_owner', type: RETIRED }}
+        value="u-1"
+        onChange={vi.fn()}
+      />,
+    );
+
+    // Direction 1 — the pre-#4931 failure: a working person picker while the
+    // record form refused the same field. Measured before the fix as one
+    // `role=button` reading `Select…`.
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+    expect(container.querySelector('[role="combobox"]')).toBeNull();
+    // Direction 2 — the failure closing the gate ALONE would have introduced:
+    // a raw text box that saves a bare string over the stored reference.
+    expect(container.querySelector('input')).toBeNull();
+    expect(container.querySelector('textarea')).toBeNull();
+    // Nothing an author could mistake for a working field.
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('holds for an `$expand`-ed value too — the refusal is not value-shaped', () => {
+    // The expanded object is the case the picker branch existed for, so it is
+    // the one most likely to slip past a refusal keyed on anything but type.
+    const { container } = render(
+      <FieldEditWidget
+        field={{ name: 'record_owner', type: RETIRED }}
+        value={{ id: 'u-1', name: 'Ada Lovelace' }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('is LOUD — it writes the prescription naming the migration', () => {
+    render(
+      <FieldEditWidget
+        field={{ name: 'record_owner', type: RETIRED }}
+        value="u-1"
+        onChange={vi.fn()}
+      />,
+    );
+
+    // Rendering nothing is only half the disposition; silence would be the
+    // other silent failure. The message is the text an author or an AI author
+    // will act on, so its content is the contract — and asserting it also
+    // proves this path runs through the retirement machinery rather than
+    // merely missing a key in the widget map.
+    expect(said()).toContain('`owner`');
+    expect(said()).toContain('RETIRED');
+    expect(said()).toContain("{ type: 'user', name: 'owner' }");
+    expect(said()).toContain('objectui#4814');
+  });
+
+  it('reports ONCE per spelling, so a rendered grid cannot bury the message', () => {
+    for (let i = 0; i < 25; i++) {
+      render(
+        <FieldEditWidget
+          field={{ name: `owner_${i}`, type: RETIRED }}
+          value="u-1"
+          onChange={vi.fn()}
+        />,
+      );
+    }
+    const prescriptions = (error.mock.calls as unknown[][])
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('objectui#4814'));
+    expect(prescriptions).toHaveLength(1);
+  });
+});
+
+describe('the `user` path is untouched — this is a subtraction of exactly one', () => {
+  it('still routes to the real person picker and reaches no retirement machinery', () => {
+    expect(hasFieldEditWidget(SURVIVOR)).toBe(true);
+    expect(isInlineExcludedFieldType(SURVIVOR)).toBe(false);
+
+    const { container } = render(
+      <FieldEditWidget
+        field={{ name: 'assignee', type: SURVIVOR }}
+        value="u-1"
+        onChange={vi.fn()}
+      />,
+    );
+    // A real control, not the refusal — the widget `owner` used to borrow.
+    expect(container.innerHTML).not.toBe('');
+    expect(container.querySelectorAll('button').length).toBeGreaterThan(0);
+    expect(said()).not.toContain('objectui#4814');
+  });
+
+  it('leaves a genuinely unknown type on its pre-existing quiet fallback', () => {
+    // Measured, not assumed — and the measurement is the sharpest statement of
+    // what this card fixed. An unknown type resolves through the alias table's
+    // `|| 'field:text'` tail onto the `text` editor, so `hasFieldEditWidget`
+    // answers TRUE for it and the grid hands it a plain text box. That is the
+    // pre-existing quiet fallback, deliberately preserved: retirement is a
+    // NAMED disposition, never a new blanket noise source.
+    //
+    // The contrast with the retired spelling is the whole point. `owner` used
+    // to be answered by an even worse road (a working person picker); had it
+    // merely been dropped from the widget map it would have landed HERE, on
+    // this text-box fallback, and saved a bare string over a stored person
+    // reference. It is refused instead — the only type in this file that the
+    // text tail does not catch.
+    expect(hasFieldEditWidget('not-a-real-type')).toBe(true);
+    expect(isInlineExcludedFieldType('not-a-real-type')).toBe(false);
+    expect(said()).not.toContain('objectui#4814');
+
+    // …and that fallback is exactly what every retired spelling is kept OFF.
+    for (const t of RETIRED_TYPES()) {
+      expect(hasFieldEditWidget(t), `${t} must not reach the text fallback`).toBe(false);
+    }
+  });
+});

--- a/packages/fields/src/__tests__/FieldEditWidget.retiredFieldType.test.tsx
+++ b/packages/fields/src/__tests__/FieldEditWidget.retiredFieldType.test.tsx
@@ -67,6 +67,26 @@ const SURVIVOR = 'user';
 
 const RETIRED_TYPES = () => Object.keys(RETIRED_FIELD_TYPES);
 
+/**
+ * A field literal spelling a RETIRED type.
+ *
+ * The type escape is the POINT here, not a workaround, and it is confined to
+ * this one helper so the strictness holds everywhere else in the file. PR
+ * #4932 shrank `owner` out of the published field-type unions in
+ * `@object-ui/types`, so the compiler now REFUSES to let this payload be
+ * written at all — and a payload the type refuses needs an escape to be
+ * authored (the shape settled by objectui#4910 / PR #4920). That refusal is
+ * the published contract twin working exactly as designed; it is asserted
+ * head-on by `packages/types/src/__tests__/owner-retired-contract-twins.test.ts`,
+ * so nothing is lost by escaping it here.
+ *
+ * This suite still has to author the refused spelling, because what it pins is
+ * the RUNTIME disposition for a field that is ALREADY STORED that way — a
+ * record typed `owner` before the retirement, which no compile-time union can
+ * reach or fix. That stored-field case is the whole reason this seam mattered.
+ */
+const retiredFieldLiteral = (name: string) => ({ name, type: RETIRED as never });
+
 let error: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
@@ -140,7 +160,7 @@ describe('road 3 — a direct call, ignoring both gates', () => {
   it('renders no control at all for a retired spelling', () => {
     const { container } = render(
       <FieldEditWidget
-        field={{ name: 'record_owner', type: RETIRED }}
+        field={retiredFieldLiteral('record_owner')}
         value="u-1"
         onChange={vi.fn()}
       />,
@@ -164,7 +184,7 @@ describe('road 3 — a direct call, ignoring both gates', () => {
     // the one most likely to slip past a refusal keyed on anything but type.
     const { container } = render(
       <FieldEditWidget
-        field={{ name: 'record_owner', type: RETIRED }}
+        field={retiredFieldLiteral('record_owner')}
         value={{ id: 'u-1', name: 'Ada Lovelace' }}
         onChange={vi.fn()}
       />,
@@ -175,7 +195,7 @@ describe('road 3 — a direct call, ignoring both gates', () => {
   it('is LOUD — it writes the prescription naming the migration', () => {
     render(
       <FieldEditWidget
-        field={{ name: 'record_owner', type: RETIRED }}
+        field={retiredFieldLiteral('record_owner')}
         value="u-1"
         onChange={vi.fn()}
       />,
@@ -196,7 +216,7 @@ describe('road 3 — a direct call, ignoring both gates', () => {
     for (let i = 0; i < 25; i++) {
       render(
         <FieldEditWidget
-          field={{ name: `owner_${i}`, type: RETIRED }}
+          field={retiredFieldLiteral(`owner_${i}`)}
           value="u-1"
           onChange={vi.fn()}
         />,

--- a/packages/fields/src/complex-widgets.test.tsx
+++ b/packages/fields/src/complex-widgets.test.tsx
@@ -745,16 +745,16 @@ describe('Complex & Relationship Widgets', () => {
             expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
         });
 
-        it('owner field resolves an expanded-object value inline', () => {
-            render(
-                <FieldEditWidget
-                    field={{ name: 'owner', type: 'owner' } as any}
-                    value={{ id: 'u2', name: 'Grace Hopper' }}
-                    onChange={vi.fn()}
-                />
-            );
-            expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
-        });
+        // An `owner field resolves an expanded-object value inline` case stood
+        // here until objectui#4931. It is REPLACED rather than re-spelled: it
+        // asserted that `type: 'owner'` reaches the person picker through
+        // `FieldEditWidget`, which is precisely the delegation road that card
+        // closed (objectui#4814 retired the spelling; this seam kept answering
+        // for it). The value-shape contract it was covering is unchanged and
+        // still pinned by the `user` case directly above — same widget, same
+        // expanded-object resolution. The retired spelling's own disposition
+        // (no control, plus the once-per-spelling prescription) is pinned in
+        // `__tests__/FieldEditWidget.retiredFieldType.test.tsx`.
 
         it('resolves a JSON-encoded external-id reference string without a bogus fetch', () => {
             render(


### PR DESCRIPTION
Fixes #4931

Closes the last measured active-contradiction face of #4814's ruling A′: the
inline-edit **delegation road**. Its parent #4914 stays open — items 4 and 6–15
remain there as ordinary cleanup, and this PR does not reference that card with
a closing keyword.

## Why this seam survived two retirement PRs

`hasFieldEditWidget` answers `resolveInlineEditType(type) in EDIT_WIDGETS`, and
`resolveInlineEditType` returns a type **unchanged** when it is already a key of
`EDIT_WIDGETS`:

```ts
if (type in EDIT_WIDGETS || INLINE_EXCLUDED_FIELD_TYPES.has(type)) return type;
return mapFieldTypeToFormType(type).replace(/^field:/, '');
```

So while `owner: UserField` sat in that map, the alias table — where #4814's
retirement lives — was never consulted, and the retirement never applied. No
routing table had to *list* the spelling for it to stay alive, which is why
deleting memberships in #4932 did not reach it.

**Re-measured on this branch** (not inherited from the card, which measured on
`69dbea20a`), at `origin/main` `25c8007d4`:

| probe | before | after |
| --- | --- | --- |
| `hasFieldEditWidget('owner')` | `true` | `false` |
| `isInlineExcludedFieldType('owner')` | `false` | `true` |
| direct `FieldEditWidget` call, `type: 'owner'` | 1 `role=button` reading `Select…` | renders nothing, prescription logged |
| `hasFieldEditWidget('user')` | `true` | `true` |

## The user-facing consumer, measured before/after

The real direct consumers are the grid's inline cell editor
(`ObjectGrid.tsx:2674`), the kanban required-fields dialog
(`requiredWhenPrompt.ts:123`), and `InlineFieldInput`'s delegation tail. The
grid is the user-facing one:

| grid probe | before | after |
| --- | --- | --- |
| `isFieldInlineEditable({ type: 'owner' })` | `true` | `false` |
| column decoration at `ObjectGrid.tsx:1989` | stays editable | forced `editable: false` |
| what the user gets on a stored `owner` field | a working person picker | a read-only cell |
| `isFieldInlineEditable({ type: 'user' })` | `true` | `true` |

So the cell degrades to the grid's **normal read-only path** — the same
disposition `password`, `formula` and `composite` already get. It does not
crash, and it never saves a string. The read path is unchanged from #4814: the
text cell plus the once-per-spelling console prescription.

## What changed, and why the second gate is not optional

The gate consults the live `RETIRED_FIELD_TYPES` table (imported from
`./field-type-alias`, never copied, and not via the `./index` barrel — that
would cycle), so this closes the **class**: the next retirement covers this seam
the day it lands in that table, with no edit here.

1. `hasFieldEditWidget()` → `false` for any retired spelling, **ahead of every
   table lookup**, so it holds even if a retired spelling is still a key of the
   widget map.
2. `isInlineExcludedFieldType()` → `true` for any retired spelling.
3. `FieldEditWidget` renders no control for a retired spelling and writes the
   once-per-spelling prescription.
4. `owner` dropped from `EDIT_WIDGETS` and from the cosmetic
   `COMPACT_EDIT_TYPES` sizing set (#4914 item 11, same stroke).

Gate 2 is load-bearing, and the reverse verification below proves it. `ObjectGrid`
forces `editable: false` on a column exactly when `isFieldInlineEditable` is
false, and that predicate consults `isInlineExcludedFieldType`. Closing gate 1
**alone** would have left the column editable, handed the cell editor a `null`
widget, and let DataTable fall back to its built-in **plain text input** — which
for a stored person reference displays a coerced value and writes a bare string
straight back over it. That would have traded a visible wrong answer for a
silent one.

Gate 3 answers with the console prescription rather than a rendered
`RetiredFieldTombstone` deliberately. This component's hosts are cell-sized, and
#4814 settled the same question the same way for the read path — "there is no
visible alert a table CELL can carry without wrecking the row". The visible
refusal remains the record form's job. Returning `null` is this function's
documented contract for "no dedicated widget", not a new fallback, and every
in-repo host is routed away from it by gates 1–2.

## Reverse verification — direction predicted first, both legs from the committed state

**Leg A — restore `owner: UserField` to `EDIT_WIDGETS`, keep the gates.**
Predicted: **all pins stay green**, because the gates key on the retirement
table rather than on map absence. That is the class-closure property, so a red
here would have disproved it. Observed: `Test Files 2 passed (2) / Tests 21
passed (21)`. Note this is a *reversal* of the naive "restoring the key reddens
the pins" expectation — reported as observed.

**Leg B — strip all three gates, keep the `EDIT_WIDGETS` deletion** (i.e. the
weaker spelling-only fix). Predicted: road 1 and road 3 stay **green**
(`hasFieldEditWidget` is already `false` via map absence; the alias table still
fires the prescription as a side effect), and **exactly the two exclusion pins
redden**. Observed exactly that — `Tests 2 failed | 10 passed (12)`:

```
× `isInlineExcludedFieldType` answers true for every retired spelling
    AssertionError: expected [ 'owner' ] to deeply equal []
× leaves the two answers consistent — never "no editor" AND "not excluded"
    AssertionError: expected false to be true
```

This is the empirical argument for gate 2: a delegation-road-only fix passes
every other pin in the file while leaving the grid's text-box path open.

Both legs restored with `git checkout e255f9123 -- ` + the edited path; `git diff HEAD`
empty afterwards.

## Tests

New pin `packages/fields/src/__tests__/FieldEditWidget.retiredFieldType.test.tsx`
is quantified over `RETIRED_FIELD_TYPES` throughout (the structural shape
#4932 used), with a non-vacuity guard on the table and on the live relational
types. It pins both wrong outcomes in both directions — a working picker and a
quiet text box — plus the once-per-spelling dedupe, the `$expand`-ed value case,
and the `user` survivor.

Two existing fixtures were triaged rather than re-spelled, because each pinned
the exact branch this PR removes:

- `FieldEditWidget.test.ts` — `hasFieldEditWidget('owner') === true` in the
  relational-picker list; `owner` dropped, the three survivors kept.
- `complex-widgets.test.tsx` — "owner field resolves an expanded-object value
  inline" **removed**, not re-spelled: its value-shape contract is unchanged and
  still pinned by the identical `user` case directly above it.

One of my own assertions failed on first run and was corrected to measured
reality rather than forced: `hasFieldEditWidget('not-a-real-type')` is **`true`**,
not false — an unknown type resolves through the alias table's `|| 'field:text'`
tail onto the `text` editor. That sharpens the contrast the card is about, and
the test now says so: the retired spelling is the one type the text tail does
**not** catch, and had `owner` merely been dropped from the widget map it would
have landed on exactly that fallback.

`hasFieldEditWidget('owner')` is deliberately still not pinned by
#4932's `InlineFieldInput.retiredFieldType.test.tsx`, so this fix does not redden
it — confirmed green in the run below.

## Evidence

Union run at `e255f9123` (= final commit = pushed remote head), heavy runs under
`flock -E 99 -w 540 /tmp/os-heavy-verify.lock`, dependency closures built before
every type-check verdict.

- `packages/fields/` → `Test Files 103 passed (103) / Tests 1705 passed (1705)`
- `packages/plugin-grid/ packages/plugin-kanban/ packages/plugin-detail/` (the
  three real consumers) → `Test Files 167 passed (167) / Tests 1514 passed (1514)`
- `type-check` for `@object-ui/fields`, `plugin-grid`, `plugin-kanban`,
  `plugin-detail` → all `Done`, script echoed as
  `tsc --noEmit && tsc -p tsconfig.test.json` (no zero-match trap). First attempt
  failed on unbuilt `@object-ui/mobile` / `@object-ui/permissions` — the closure
  trap, not this change; green after building the closures.
- Gates derived from the changed paths: `check:control-bytes` OK (4419 files),
  `check:self-import` OK, `check:phantom-deps` OK, `check:published-dist` OK (39
  packages), `changeset:check` OK, `check:doc-types` OK. Plus a manual
  control-byte scan of the five changed files: clean.

No exported signature changed, so this is a behavior narrowing rather than a type
narrowing; a real patch changeset for `@object-ui/fields` records it. No
`skip-changeset` label was created or applied (phantom in this repo, #4912).

`user` is untouched throughout — it keeps the picker, its compact sizing and its
expanded-object resolution. The record-owner idiom survives verbatim as
`{ type: 'user', name: 'owner' }`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbRmJD3iPhXjKr6vhd4Qkv)_