### PR TITLE
fix(auth,app-shell): 邀请状态与插件信任层级收窄为封闭枚举,消费端不再比契约宽松 (#3879, #3846)

### DIFF
--- a/.changeset/auth-invitation-status-closed-union-3879.md
+++ b/.changeset/auth-invitation-status-closed-union-3879.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/auth': minor
+'@object-ui/app-shell': minor
+---
+
+`AuthInvitation.status` is the closed four-member union it always documented, enforced at the auth client's wire boundary.
+
+The field was declared `status: string` while its own doc comment enumerated
+`'pending' | 'accepted' | 'rejected' | 'canceled'`, and `createAuthClient` cast
+better-auth's `any` responses straight to `AuthInvitation[]` with no check. The
+enumeration was therefore advisory: any value a backend stored reached the
+console untouched, where the invitations screen coloured it through a
+`default: 'secondary'` badge arm and printed it with
+`defaultValue: inv.status` — the raw wire string rendered as interface copy, in
+all ten packs (objectui#3879). Nobody could trigger it today, because the four
+are what better-auth writes; it was the contract that was loose, and a loose
+consumer is where an unexpected value would have hidden.
+
+`AuthInvitationStatus` now carries the union and **binds better-auth's own
+`InvitationStatus`** rather than restating it, the way `org-roles.ts` binds the
+spec's `BUILTIN_MEMBERSHIP_ROLES` — a member-for-member copy is the state one
+upstream release away from drifting silently. The runtime list
+(`AUTH_INVITATION_STATUSES`) is derived from a total map keyed by that union, so
+a fifth status upstream is a build failure here rather than a gap in the guard.
+`isAuthInvitationStatus` is exported alongside, and all four invitation-returning
+client methods (`listInvitations`, `listUserInvitations`, `getInvitation`,
+`inviteMember`) narrow their wire rows through it.
+
+Behaviour change, stated because it is one: an invitation whose `status` is
+outside the set now **fails loudly** — the call rejects with a message naming the
+value it refused and the four it expected — instead of resolving into a badge.
+Both call paths already render a rejection with a retry, so the throw lands on a
+designed surface. Degrading quietly was the alternative and was deliberately not
+taken: a neutral label is how the raw value shipped in the first place, and
+dropping the row would delete an invitation from an administrative ledger without
+saying so. The console's badge switch is exhaustive over the union now and has no
+`default:` arm, so if better-auth ever adds a member the type-check gate stops the
+build at the one place a human has to choose a colour.
+
+Consumers assigning an arbitrary string to `AuthInvitation.status` (a hand-built
+fixture, a mock) will need one of the four members.

--- a/.changeset/marketplace-runtime-tier-spec-enum-3846.md
+++ b/.changeset/marketplace-runtime-tier-spec-enum-3846.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The marketplace plugin trust tier is typed by the spec's own enum, so the install panel can no longer render a raw wire value as a trust label.
+
+`MarketplacePackageVersion.runtime` was declared `string` while the producer
+validates it against `@objectstack/spec`'s `PluginRuntimeSchema` —
+`z.enum(['node', 'sandbox', 'worker'])`, ADR-0025 §3.6. Consumer looser than the
+contract, and the looseness propagated into `PluginDisclosure`: the label map was
+a `Record<string, string>` (so a missing tier could not be a compile error), the
+badge fell back to `?? version.runtime`, and the translation key carried an
+`as any`. That fallback rendered the raw wire string as interface copy on the
+panel where a user grants a package the right to execute code — the one badge on
+that panel that must never be guessed at (objectui#3846).
+
+The field now binds the spec's `PluginRuntime`, which is what this same interface
+already does one field over for `PluginPermissions`, for the same stated reason:
+a local copy of a spec enumeration rots the day the spec adds a member. No new
+dependency was needed — `@object-ui/app-shell` already depends on
+`@objectstack/spec`, and this file already imports from
+`@objectstack/spec/kernel`. The label map is keyed by that union, so it is total
+by construction and the `?? version.runtime` arm it needed is gone along with the
+`as any`.
+
+No change to what a user sees for the three legal tiers — the labels are
+byte-identical. What changed is that a fourth tier, or a `string`, stops
+compiling: a new pin compares the map's keys against `PluginRuntimeSchema.options`
+directly, and objectui#3546 slice five's pack-parity assertions now point at it
+for that comparison instead of reading the map's `string` annotation.

--- a/packages/app-shell/src/console/marketplace/PluginDisclosure.tsx
+++ b/packages/app-shell/src/console/marketplace/PluginDisclosure.tsx
@@ -12,9 +12,21 @@
 import { Badge } from '@object-ui/components';
 import { Boxes, CheckCircle2, Code2, FolderTree, Network, ShieldAlert, ShieldCheck, Webhook } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
-import type { MarketplacePackageVersion } from './marketplaceApi';
+import type { MarketplacePackageVersion, PluginRuntime } from './marketplaceApi';
 
-const RUNTIME_FALLBACK: Record<string, string> = {
+/**
+ * English label per trust tier — the map i18next's `defaultValue` reads.
+ *
+ * Keyed by the spec's `PluginRuntime` rather than `string` (objectui#3846): a
+ * tier the spec adds is now a compile error here instead of a silent hole that
+ * used to fall through to `?? version.runtime` and render the raw wire value on
+ * the panel granting code execution. Total map, so the lookup below needs no
+ * fallback of its own.
+ *
+ * Exported for the parity pin next door, which compares these keys against
+ * `PluginRuntimeSchema` itself.
+ */
+export const RUNTIME_FALLBACK: Record<PluginRuntime, string> = {
   node: 'In-process · full trust',
   sandbox: 'Sandboxed',
   worker: 'Out-of-process',
@@ -67,8 +79,8 @@ export function PluginDisclosure({ version }: { version?: MarketplacePackageVers
       <div className="flex flex-wrap items-center gap-1.5">
         {version.runtime && (
           <Badge variant="outline">
-            {t(`marketplace.disclosure.runtime.${version.runtime}` as any, {
-              defaultValue: RUNTIME_FALLBACK[version.runtime] ?? version.runtime,
+            {t(`marketplace.disclosure.runtime.${version.runtime}`, {
+              defaultValue: RUNTIME_FALLBACK[version.runtime],
             })}
           </Badge>
         )}

--- a/packages/app-shell/src/console/marketplace/__tests__/plugin-runtime-tier-3846.test.tsx
+++ b/packages/app-shell/src/console/marketplace/__tests__/plugin-runtime-tier-3846.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3846 — the plugin trust tier is the SPEC's closed enum, here too.
+ *
+ * ## What was loose
+ *
+ * `MarketplacePackageVersion.runtime` was declared `string` while the producer
+ * validates it against `PluginRuntimeSchema` — `z.enum(['node','sandbox',
+ * 'worker'])`, ADR-0025 §3.6. Consumer looser than the contract, and the
+ * looseness propagated: `RUNTIME_FALLBACK` was a `Record< string, string >` (a
+ * missing tier could not be a compile error), the badge fell back to
+ * `?? version.runtime` (raw wire value rendered as UI copy — on the panel where
+ * a user grants a package the right to execute code), and the `t()` key carried
+ * an `as any`.
+ *
+ * ## Why the spec and not a repo-local union
+ *
+ * The card left the route open: bind the spec's type (B) or restate the three
+ * members locally (A). The dependency turned out to need nothing — `app-shell`
+ * already depends on `@objectstack/spec`, and this very interface already binds
+ * the spec's `PluginPermissions` one field over, with a header explaining that a
+ * member-for-member local copy is what rots the day the spec adds a member
+ * (objectstack#4115). So B costs zero dependencies and follows the file's own
+ * precedent.
+ *
+ * ## Which gate each half fails at
+ *
+ * Both pins here are compile-time-or-value, and neither is a rendering change:
+ * the labels a user sees for the three legal tiers are byte-identical before and
+ * after. A render test would therefore be green both ways and prove nothing —
+ * what actually changed is that a fourth tier, or a `string`, stops compiling.
+ * The `Assert` block is erased before vitest runs and is checked by app-shell's
+ * `tsc -p tsconfig.test.json`; the key-set case below is the one runtime
+ * assertion, and it reads the producer's enum directly so a spec release that
+ * adds `worker`'s successor turns it red here rather than in production.
+ *
+ * #3546 slice five pins the same three members from the i18n side (pack keys ===
+ * the label map's keys). That suite cannot import the spec — `@object-ui/i18n`
+ * does not depend on it — so it reads the component's source; this file is the
+ * half that compares against `PluginRuntimeSchema` itself, and slice five now
+ * points here for that comparison.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PluginRuntimeSchema, type PluginRuntime as SpecPluginRuntime } from '@objectstack/spec/kernel';
+import { RUNTIME_FALLBACK } from '../PluginDisclosure';
+import type { MarketplacePackageVersion, PluginRuntime } from '../marketplaceApi';
+
+describe('objectui#3846 — the trust-tier label map answers to the spec enum', () => {
+  it('covers exactly the tiers PluginRuntimeSchema declares', () => {
+    // The producer's own list, read from the schema rather than retyped.
+    const declared = [...PluginRuntimeSchema.options].sort();
+    expect(declared).toEqual(['node', 'sandbox', 'worker']);
+    expect(Object.keys(RUNTIME_FALLBACK).sort()).toEqual(declared);
+  });
+
+  it('labels every tier with human copy — no tier falls through to a raw value', () => {
+    // The `?? version.runtime` arm existed because this map could be partial.
+    // Totality is now a compile-time property; this is the runtime half of it,
+    // and it also catches an entry blanked to '' (which would render an empty
+    // badge on the trust panel).
+    for (const tier of PluginRuntimeSchema.options) {
+      const label = RUNTIME_FALLBACK[tier];
+      expect(typeof label, tier).toBe('string');
+      expect(label.trim().length, tier).toBeGreaterThan(0);
+      // A label must not be the wire value dressed up as copy — that is the
+      // exact thing the removed fallback did.
+      expect(label, tier).not.toBe(tier);
+    }
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins. A violation is a `tsc` error, not a runtime failure.     */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+describe('objectui#3846 — the narrowing itself (checked by tsc, erased before vitest)', () => {
+  it('is pinned at compile time', () => {
+    // Guard against the probe lying: an `any` on either side makes every
+    // assertion below vacuous (objectstack#4171).
+    type _SpecTierNotAny = Assert<Equal<IsAny<SpecPluginRuntime>, false>>;
+    type _OursNotAny = Assert<Equal<IsAny<PluginRuntime>, false>>;
+
+    // The binding: what this module re-exports IS the spec's type, not a
+    // same-shaped local union that would drift on the next spec release.
+    type _TierIsSpecs = Assert<Equal<PluginRuntime, SpecPluginRuntime>>;
+
+    // The field carries it, optional as it is on the wire — and is NOT `string`,
+    // which is the assertion that goes red if the looseness is restored.
+    type _FieldIsTier = Assert<Equal<MarketplacePackageVersion['runtime'], PluginRuntime | undefined>>;
+    type _FieldIsNotString = Assert<
+      Equal<Equal<MarketplacePackageVersion['runtime'], string | undefined>, false>
+    >;
+
+    // The label map is keyed by the union, so it is total by construction: a
+    // partial map (the state that needed `?? version.runtime`) cannot type-check.
+    type _MapIsTotal = Assert<Equal<keyof typeof RUNTIME_FALLBACK, PluginRuntime>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('refuses a tier the spec does not declare', () => {
+    // The `@ts-expect-error` IS the assertion: widen `runtime` back to `string`
+    // and this line stops erroring, which makes the directive unused — a tsc
+    // error in its own right.
+    // @ts-expect-error — 'quickjs' is not one of the spec's three tiers
+    const version: Pick<MarketplacePackageVersion, 'runtime'> = { runtime: 'quickjs' };
+    expect(version.runtime).toBe('quickjs');
+  });
+});

--- a/packages/app-shell/src/console/marketplace/marketplaceApi.ts
+++ b/packages/app-shell/src/console/marketplace/marketplaceApi.ts
@@ -132,7 +132,19 @@ export interface MarketplacePackageDetail extends MarketplacePackageSummary {
  */
 export type { PluginPermissions } from '@objectstack/spec/kernel';
 
-import type { PluginPermissions } from '@objectstack/spec/kernel';
+/**
+ * Trust / isolation tier a plugin runs under (ADR-0025 §3.6).
+ *
+ * Owned by `@objectstack/spec/kernel`'s `PluginRuntimeSchema`
+ * (`z.enum(['node', 'sandbox', 'worker'])`) — the same reasoning as
+ * `PluginPermissions` above, and the same defect one field over: this was
+ * declared `string` here, i.e. looser than the contract the producer validates
+ * against, and the looseness leaked a raw wire value onto the trust-tier badge
+ * of the panel that grants code execution (objectui#3846).
+ */
+export type { PluginRuntime } from '@objectstack/spec/kernel';
+
+import type { PluginPermissions, PluginRuntime } from '@objectstack/spec/kernel';
 
 export interface MarketplacePackageVersion {
   id: string;
@@ -153,8 +165,8 @@ export interface MarketplacePackageVersion {
   artifact_kind?: string;
   /** True when this version carries executable code (a `plugin` artifact). */
   contains_code?: boolean;
-  /** Trust tier the plugin runs under: 'node' | 'sandbox' | 'worker'. */
-  runtime?: string;
+  /** Trust tier the plugin runs under — the spec's closed three-member enum. */
+  runtime?: PluginRuntime;
   /** Dependency packaging: 'bundled' | 'manifest-deps'. */
   packaging?: string;
   /** Structured permission set the plugin asks the installer to grant. */

--- a/packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx
+++ b/packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx
@@ -21,7 +21,7 @@ import {
   Separator,
 } from '@object-ui/components';
 import { useAuth } from '@object-ui/auth';
-import type { AuthInvitation } from '@object-ui/auth';
+import type { AuthInvitation, AuthInvitationStatus } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Loader2, Copy, Check, X, Mail } from 'lucide-react';
 import { toast } from 'sonner';
@@ -33,7 +33,18 @@ import { resolveOrgErrorMessage } from '../orgErrorMessage';
 
 type StatusFilter = 'all' | 'pending' | 'accepted' | 'rejected' | 'canceled';
 
-function statusBadgeVariant(status: string): 'outline' | 'default' | 'destructive' | 'secondary' {
+/**
+ * Badge variant per status. Exhaustive over `AuthInvitationStatus` on purpose —
+ * there is no `default:` arm any more (objectui#3879).
+ *
+ * The arm used to return `'secondary'` for anything unrecognized, which is how an
+ * unexpected status reached the badge looking deliberate. The union is closed and
+ * enforced at the auth client's wire boundary now, so a fifth member cannot
+ * arrive at runtime — and if better-auth ever adds one, this switch stops
+ * covering the parameter type and fails the type-check gate, which is exactly the
+ * moment a human should decide what colour it is.
+ */
+function statusBadgeVariant(status: AuthInvitationStatus): 'outline' | 'default' | 'destructive' {
   switch (status) {
     case 'pending':
       return 'outline';
@@ -42,8 +53,6 @@ function statusBadgeVariant(status: string): 'outline' | 'default' | 'destructiv
     case 'rejected':
     case 'canceled':
       return 'destructive';
-    default:
-      return 'secondary';
   }
 }
 

--- a/packages/auth/src/__tests__/invitation-status-3879.test.ts
+++ b/packages/auth/src/__tests__/invitation-status-3879.test.ts
@@ -1,0 +1,236 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3879 — `AuthInvitation.status` is a CLOSED union, enforced at the wire
+ * boundary.
+ *
+ * ## What was loose
+ *
+ * The field was declared `string` while its own doc comment enumerated four
+ * members, and `createAuthClient` cast better-auth's `any` straight to
+ * `AuthInvitation[]`. So the enumeration was advisory: a fifth wire value passed
+ * through untouched and landed in `InvitationsPage`'s badge, where a
+ * `default: 'secondary'` arm coloured it and `defaultValue: inv.status` printed
+ * the raw wire string as UI copy — in all ten packs. #3546 slice seven pins the
+ * detection half (its key-set assertion goes red when a fifth status appears);
+ * this file pins the HANDLING half.
+ *
+ * ## What each half of the fix is pinned by, and where it fails
+ *
+ * The two halves fail at different gates, and saying so is the point:
+ *
+ *  - the **boundary** is runtime behaviour — these vitest cases go red if
+ *    `asAuthInvitation` stops rejecting, or stops naming the offending value;
+ *  - the **narrowing** is compile-time only — the `Assert` block and the
+ *    `@ts-expect-error` below are erased before vitest ever runs, and are checked
+ *    by this package's `tsc -p tsconfig.test.json` project (see that file's
+ *    header). Widening `status` back to `string` leaves every runtime case green
+ *    and turns the TYPE-CHECK gate red.
+ *
+ * ## Why the union is better-auth's and not four literals of ours
+ *
+ * better-auth's organization plugin is the producer (`sys_invitation.status`
+ * holds what it writes) and it exports the union itself. Restating it here would
+ * be a member-for-member copy — the state one upstream release away from
+ * drifting — so `AuthInvitationStatus` BINDS `InvitationStatus`, and the
+ * `Equal` pin below is what makes an upstream change land as a red build instead
+ * of a silent gap in the guard.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { InvitationStatus } from 'better-auth/client/plugins';
+import { createAuthClient } from '../createAuthClient';
+import {
+  AUTH_INVITATION_STATUSES,
+  isAuthInvitationStatus,
+  type AuthInvitationStatus,
+} from '../invitation-status';
+import type { AuthInvitation } from '../types';
+
+/**
+ * Route better-auth's organization calls onto canned bodies. Same shape as
+ * `createAuthClient.test.ts`'s helper next door, kept local so this file's
+ * fixtures cannot be perturbed by an edit made for another card.
+ */
+function mockFetchFor(handlers: Record<string, unknown>) {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    for (const [pattern, body] of Object.entries(handlers)) {
+      if (url.includes(pattern)) {
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+    return new Response(JSON.stringify({ message: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+}
+
+const clientWith = (handlers: Record<string, unknown>) =>
+  createAuthClient({ baseURL: 'http://localhost/api/auth', fetchFn: mockFetchFor(handlers) });
+
+/** A row that is spec-shaped in every respect except the status under test. */
+const rowWith = (status: string) => ({
+  id: 'inv_1',
+  organizationId: 'org_1',
+  email: 'invitee@example.com',
+  role: 'member',
+  status,
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  inviterId: 'usr_1',
+});
+
+describe('objectui#3879 — the invitation status vocabulary', () => {
+  it('is the four members better-auth stores, and nothing else', () => {
+    expect([...AUTH_INVITATION_STATUSES].sort()).toEqual([
+      'accepted',
+      'canceled',
+      'pending',
+      'rejected',
+    ]);
+  });
+
+  it('the runtime list is derived from the compile-time map, so it cannot half-drift', () => {
+    // Every member of the list narrows, and the list is exactly the guard's
+    // domain — a member added to one and not the other fails one of these.
+    for (const status of AUTH_INVITATION_STATUSES) {
+      expect(isAuthInvitationStatus(status), status).toBe(true);
+    }
+    expect(AUTH_INVITATION_STATUSES).toHaveLength(4);
+  });
+
+  it('the guard refuses everything outside the set — including the near-misses', () => {
+    // `cancelled` (two Ls) is the one a hand-written copy of this vocabulary
+    // gets wrong; `Pending` is what a control plane that title-cases its enums
+    // would send. Both must fail, or the guard is decorative.
+    for (const value of ['cancelled', 'Pending', 'expired', '', 'PENDING']) {
+      expect(isAuthInvitationStatus(value), value).toBe(false);
+    }
+    for (const value of [undefined, null, 0, {}, ['pending']]) {
+      expect(isAuthInvitationStatus(value), String(value)).toBe(false);
+    }
+  });
+});
+
+describe('objectui#3879 — the wire boundary in createAuthClient', () => {
+  it('listInvitations passes the four known statuses through unchanged', async () => {
+    const rows = AUTH_INVITATION_STATUSES.map((s, i) => ({ ...rowWith(s), id: `inv_${i}` }));
+    const client = clientWith({ '/organization/list-invitations': rows });
+
+    const out = await client.listInvitations('org_1');
+
+    expect(out.map((inv) => inv.status)).toEqual([...AUTH_INVITATION_STATUSES]);
+    expect(out).toHaveLength(4);
+  });
+
+  it('listInvitations rejects an unknown status LOUDLY, naming the value it refused', async () => {
+    const client = clientWith({
+      '/organization/list-invitations': [rowWith('pending'), rowWith('expired')],
+    });
+
+    // The behaviour this card is about: before the fix this resolved, and
+    // `expired` reached the badge as English UI copy in ten locales.
+    await expect(client.listInvitations('org_1')).rejects.toThrow(/unexpected invitation status/);
+    // The value has to be IN the message — a generic "invalid response" would
+    // leave the next reader to diff the payload by hand.
+    await expect(client.listInvitations('org_1')).rejects.toThrow(/"expired"/);
+    // And the message says what WAS acceptable, so the fix is obvious from the
+    // error alone.
+    await expect(client.listInvitations('org_1')).rejects.toThrow(/pending \| accepted/);
+  });
+
+  it('a missing status is refused too — the shape better-auth would send if it dropped the column', async () => {
+    const { status: _dropped, ...withoutStatus } = rowWith('pending');
+    const client = clientWith({ '/organization/list-invitations': [withoutStatus] });
+
+    await expect(client.listInvitations('org_1')).rejects.toThrow(/unexpected invitation status/);
+  });
+
+  it('guards every invitation-returning route, not just the one the card named', async () => {
+    // `listInvitations` is the card's site, but the declared type is the same on
+    // all four producers — a boundary on one of four would leave the union
+    // unenforced exactly where the next screen reads it.
+    const bad = rowWith('expired');
+    await expect(
+      clientWith({ '/organization/get-invitation': bad }).getInvitation('inv_1'),
+    ).rejects.toThrow(/getInvitation: unexpected invitation status/);
+    await expect(
+      clientWith({ '/organization/list-user-invitations': [bad] }).listUserInvitations(),
+    ).rejects.toThrow(/listUserInvitations: unexpected invitation status/);
+    await expect(
+      clientWith({ '/organization/invite-member': bad }).inviteMember({
+        organizationId: 'org_1',
+        email: 'invitee@example.com',
+        role: 'member',
+      }),
+    ).rejects.toThrow(/inviteMember: unexpected invitation status/);
+  });
+
+  it('the same four routes accept a well-formed row', async () => {
+    const good = rowWith('pending');
+    await expect(
+      clientWith({ '/organization/get-invitation': good }).getInvitation('inv_1'),
+    ).resolves.toMatchObject({ status: 'pending' });
+    await expect(
+      clientWith({ '/organization/list-user-invitations': [good] }).listUserInvitations(),
+    ).resolves.toHaveLength(1);
+    await expect(
+      clientWith({ '/organization/invite-member': good }).inviteMember({
+        organizationId: 'org_1',
+        email: 'invitee@example.com',
+        role: 'member',
+      }),
+    ).resolves.toMatchObject({ status: 'pending' });
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins. A violation is a `tsc` error, not a runtime failure.     */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+describe('objectui#3879 — the narrowing itself (checked by tsc, erased before vitest)', () => {
+  it('is pinned at compile time', () => {
+    // Guard against the probe lying: an `any` on either side makes every
+    // assertion below vacuous (objectstack#4171, same reasoning as
+    // auth-spec-parity.test.ts).
+    type _BetterAuthUnionNotAny = Assert<Equal<IsAny<InvitationStatus>, false>>;
+    type _OursNotAny = Assert<Equal<IsAny<AuthInvitationStatus>, false>>;
+
+    // The binding: ours IS better-auth's, both directions. A fifth member
+    // upstream — or a hand-written copy here — fails right here.
+    type _IsBetterAuths = Assert<Equal<AuthInvitationStatus, InvitationStatus>>;
+
+    // The field carries the union, not `string`. This is the assertion that goes
+    // red if `AuthInvitation.status` is ever widened back.
+    type _FieldIsUnion = Assert<Equal<AuthInvitation['status'], AuthInvitationStatus>>;
+    type _FieldIsNotString = Assert<Equal<Equal<AuthInvitation['status'], string>, false>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('refuses a foreign literal where the field is assigned', () => {
+    // The `@ts-expect-error` IS the assertion: widen `status` back to `string`
+    // and this line stops erroring, which makes the directive unused — a tsc
+    // error in its own right. It cannot go quietly green.
+    // @ts-expect-error — 'expired' is outside the closed set
+    const status: AuthInvitationStatus = 'expired';
+    expect(status).toBe('expired');
+  });
+});

--- a/packages/auth/src/createAuthClient.ts
+++ b/packages/auth/src/createAuthClient.ts
@@ -12,6 +12,7 @@ import type {
   AuthClient, AuthClientConfig, AuthUser, AuthClientSession, SignInCredentials, SignUpData,
   AuthOrganization, AuthOrganizationMember, AuthInvitation, AuthPublicConfig, SignInWithProviderOptions,
 } from './types';
+import { AUTH_INVITATION_STATUSES, isAuthInvitationStatus } from './invitation-status';
 
 const TOKEN_STORAGE_KEY = 'auth-session-token';
 
@@ -130,6 +131,41 @@ function toAuthError(
   ) as Error & { code?: string };
   if (error.code) err.code = error.code;
   return err;
+}
+
+/**
+ * The wire boundary for invitations (objectui#3879).
+ *
+ * better-auth's client hands these routes back as `any`, so `as AuthInvitation`
+ * was a claim nothing checked — and with `status` narrowed to a closed union,
+ * an unchecked cast would make that union a comment again the day a backend
+ * stored a fifth value. This is the ONE place the claim is verified.
+ *
+ * It fails LOUDLY, naming the offending value, rather than degrading: a status
+ * outside better-auth's own `InvitationStatus` is a producer defect, and the
+ * alternatives all hide it — a neutral badge label renders it as UI copy in ten
+ * packs (the objectui#3879 symptom), and dropping the row deletes an invitation
+ * from an administrative ledger without saying so. Both call paths already
+ * render a rejection with a retry (`InvitationsPage`, `AcceptInvitationPage`),
+ * so the throw lands on a designed surface; `resolveOrgErrorMessage` shows the
+ * sentence verbatim, which is that module's own stated preference over
+ * swallowing an error.
+ */
+function asAuthInvitation(raw: unknown, method: string): AuthInvitation {
+  const status = (raw as { status?: unknown } | null | undefined)?.status;
+  if (!isAuthInvitationStatus(status)) {
+    throw new Error(
+      `${method}: unexpected invitation status ${JSON.stringify(status)} — ` +
+        `expected one of ${AUTH_INVITATION_STATUSES.join(' | ')}`,
+    );
+  }
+  return raw as AuthInvitation;
+}
+
+/** Same boundary, per row, for the list-returning invitation routes. */
+function asAuthInvitations(raw: unknown, method: string): AuthInvitation[] {
+  const rows = Array.isArray(raw) ? (raw as unknown[]) : [];
+  return rows.map((row) => asAuthInvitation(row, method));
 }
 
 /**
@@ -848,7 +884,7 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
         ...(inviteData.positions?.length ? { positions: inviteData.positions } : {}),
       });
       if (error) throw toAuthError(error, 'Failed to invite member');
-      return data as unknown as AuthInvitation;
+      return asAuthInvitation(data, 'inviteMember');
     },
 
     async removeMember(removeData: { organizationId: string; memberIdOrUserId: string }): Promise<void> {
@@ -898,7 +934,7 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
         query: { organizationId: orgId },
       });
       if (error) throw toAuthError(error, 'Failed to list invitations');
-      return (data ?? []) as AuthInvitation[];
+      return asAuthInvitations(data, 'listInvitations');
     },
 
     async cancelInvitation(invitationId: string): Promise<void> {
@@ -911,7 +947,7 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
         query: { id: invitationId },
       });
       if (error) throw toAuthError(error, 'Failed to load invitation');
-      return data as unknown as AuthInvitation;
+      return asAuthInvitation(data, 'getInvitation');
     },
 
     async acceptInvitation(invitationId: string): Promise<void> {
@@ -927,7 +963,7 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
     async listUserInvitations(): Promise<AuthInvitation[]> {
       const { data, error } = await (betterAuth as any).organization.listUserInvitations();
       if (error) throw toAuthError(error, 'Failed to list invitations');
-      return (data ?? []) as AuthInvitation[];
+      return asAuthInvitations(data, 'listUserInvitations');
     },
   };
 }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -55,6 +55,16 @@ export {
   type OrgRole,
 } from './org-roles';
 
+// Invitation lifecycle vocabulary — a CLOSED set of four, bound to better-auth's
+// own `InvitationStatus` so it cannot drift, plus the narrowing guard the wire
+// boundary uses. Exported because a screen switching on `AuthInvitation.status`
+// needs the union by name (objectui#3879).
+export {
+  AUTH_INVITATION_STATUSES,
+  isAuthInvitationStatus,
+  type AuthInvitationStatus,
+} from './invitation-status';
+
 // Shared auth form primitives — exposed so consumers can build custom forms
 // that match the look of LoginForm / RegisterForm / ForgotPasswordForm.
 export {

--- a/packages/auth/src/invitation-status.ts
+++ b/packages/auth/src/invitation-status.ts
@@ -1,0 +1,81 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Invitation status vocabulary — the console's ONE entry point for it.
+ *
+ * ## Why this is a module and not a doc comment
+ *
+ * `AuthInvitation.status` was declared as an open `string` while its own doc
+ * comment enumerated exactly four members (objectui#3879). A comment cannot be
+ * enforced, so every consumer had to be liberal in turn: `InvitationsPage`
+ * carried a `default: 'secondary'` arm in its badge-variant switch and a
+ * `defaultValue: inv.status` that would render the raw wire string as UI copy —
+ * in all ten packs — for any value the enumeration did not cover. Declared =
+ * enforced (AGENTS.md #0.1): the union now lives in the type, and the wire
+ * boundary in `createAuthClient` is the one place an unvalidated string may
+ * become one.
+ *
+ * ## The vocabulary is CLOSED — and derived, not mirrored
+ *
+ * The producer is better-auth's organization plugin, whose own
+ * `InvitationStatus` is `'pending' | 'accepted' | 'rejected' | 'canceled'`
+ * (`better-auth/client/plugins`; the framework stores it in
+ * `sys_invitation.status`). This module BINDS that type instead of restating it,
+ * for the same reason `org-roles.ts` binds the spec's
+ * `BUILTIN_MEMBERSHIP_ROLES`: a member-for-member copy is precisely the state
+ * one upstream release away from drifting silently.
+ *
+ * The runtime list is derived from a total `Record` keyed by that union, so the
+ * compile-time half and the runtime half cannot disagree — a fifth status
+ * upstream fails to compile HERE (the map is missing a key) rather than slipping
+ * past the boundary check and out onto a badge.
+ *
+ * What stays LOCAL, deliberately: everything about *display*. The filter tabs'
+ * `StatusFilter` (which adds an `all` pseudo-member) and the badge variants are
+ * screen concerns and live with the screen — the same boundary `org-roles.ts`
+ * draws for its labels and grade ladder.
+ */
+
+import type { InvitationStatus } from 'better-auth/client/plugins';
+
+/**
+ * Status an organization invitation can carry — better-auth's own union, bound
+ * rather than copied.
+ */
+export type AuthInvitationStatus = InvitationStatus;
+
+/**
+ * Total map over the union — the compile-time half of the pin. Values are the
+ * members themselves so the runtime list below is DERIVED rather than restated
+ * (one literal list, not two).
+ */
+const STATUS_MEMBERS: Record<AuthInvitationStatus, AuthInvitationStatus> = {
+  pending: 'pending',
+  accepted: 'accepted',
+  rejected: 'rejected',
+  canceled: 'canceled',
+};
+
+/** Every status an invitation can carry, in the order the screens list them. */
+export const AUTH_INVITATION_STATUSES: readonly AuthInvitationStatus[] =
+  Object.values(STATUS_MEMBERS);
+
+/** Membership test backing the guard. `Set` so the check stays O(1) per row. */
+const STATUS_LOOKUP: ReadonlySet<string> = new Set<string>(AUTH_INVITATION_STATUSES);
+
+/**
+ * Narrow an unvalidated wire value onto the closed status set.
+ *
+ * The ONE place a `string` may become an `AuthInvitationStatus`. Everything
+ * downstream reads the narrowed type and therefore needs no fallback arm — which
+ * is the whole point: a tolerant consumer is where an unexpected value hides.
+ */
+export function isAuthInvitationStatus(value: unknown): value is AuthInvitationStatus {
+  return typeof value === 'string' && STATUS_LOOKUP.has(value);
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -13,6 +13,7 @@ import type {
   DelegableAdminScope,
 } from '@objectstack/spec/contracts';
 import type { TenancyPosture } from '@objectstack/spec/security';
+import type { AuthInvitationStatus } from './invitation-status';
 
 /**
  * Authentication types for @object-ui/auth
@@ -451,8 +452,16 @@ export interface AuthInvitation {
   email: string;
   /** Role to be granted upon acceptance */
   role: string;
-  /** Status: 'pending' | 'accepted' | 'rejected' | 'canceled' */
-  status: string;
+  /**
+   * Lifecycle status, as the CLOSED set better-auth stores.
+   *
+   * Was an open `string` with the four members living in this comment, which
+   * left every consumer to be liberal about the fifth value that comment could
+   * not forbid (objectui#3879). The union is `AuthInvitationStatus` now, and
+   * `createAuthClient` narrows the wire value onto it at the boundary — so a
+   * screen reading this field can switch on it exhaustively.
+   */
+  status: AuthInvitationStatus;
   /** Expiration timestamp */
   expiresAt?: string;
   /** ID of the inviting user */

--- a/packages/i18n/src/__tests__/marketplace-preview-namespace-3546.test.tsx
+++ b/packages/i18n/src/__tests__/marketplace-preview-namespace-3546.test.tsx
@@ -32,18 +32,30 @@
  * `PluginDisclosure.tsx:70`:
  *
  *     t(`marketplace.disclosure.runtime.${version.runtime}`, {
- *       defaultValue: RUNTIME_FALLBACK[version.runtime] ?? version.runtime,
+ *       defaultValue: RUNTIME_FALLBACK[version.runtime],
  *     })
  *
  * Its value surface is a CLOSED enumeration — `PluginRuntimeSchema` in
  * objectstack `packages/spec/src/kernel/manifest.zod.ts` is
  * `z.enum(['node', 'sandbox', 'worker'])` (ADR-0025 §3.6) — so the repair is an
  * enumeration of three members, not a wildcard, and the family leaves
- * `missingPrefixes` (3 → 2). The spec lives in a sibling repo and cannot be read
- * from here, so the in-repo authority this test reads is the component's own
- * `RUNTIME_FALLBACK` map, which is what `defaultValue` reads; a fourth tier
- * added to either side fails the test, which is the job the prefix entry used to
- * do.
+ * `missingPrefixes` (3 → 2). The in-repo authority this test reads is the
+ * component's own `RUNTIME_FALLBACK` map, which is what `defaultValue` reads; a
+ * fourth tier added to either side fails the test, which is the job the prefix
+ * entry used to do.
+ *
+ * **Repointed by objectui#3846.** When this file was written the map was a
+ * `Record< string, string >` and the spec — living in a sibling repo — was
+ * unreadable from here, so "the component's own map" was the only authority
+ * available. The map is keyed by the spec's `PluginRuntime` now, and the
+ * value-level comparison against `PluginRuntimeSchema.options` itself lives in
+ * `packages/app-shell/src/console/marketplace/__tests__/plugin-runtime-tier-3846.test.tsx`
+ * — app-shell depends on `@objectstack/spec`, `@object-ui/i18n` deliberately does
+ * not (its dependencies are `@object-ui/core` + i18next, and a test-only spec
+ * dependency would be the first). So this file keeps doing what it can prove
+ * from here — that the PACKS and the label map agree, member for member — and
+ * additionally pins that the map is keyed by the spec's type rather than by
+ * `string`, which is what makes the two files one chain instead of two truths.
  *
  * ## Why a provider is mounted
  *
@@ -322,12 +334,20 @@ describe('objectui#3546 slice five — the marketplace and preview namespaces', 
     it('is enumerated from the trust-tier enum, not guessed', () => {
       // The family left `missingPrefixes` because all three members now exist.
       // The canonical enum is objectstack spec `PluginRuntimeSchema`
-      // (z.enum(['node','sandbox','worker']), ADR-0025 §3.6) which is in another
-      // repo; the in-repo authority is the component's own fallback map, and a
+      // (z.enum(['node','sandbox','worker']), ADR-0025 §3.6); since objectui#3846
+      // the component's map is KEYED by that enum's type, so this file's job is
+      // pack-vs-map parity plus proving the map still answers to the spec, and a
       // fourth tier on either side fails here — the job the prefix entry did.
       const src = sourceOf(DISCLOSURE);
-      const block = src.match(/const RUNTIME_FALLBACK: Record<string, string> = \{([^}]+)\}/);
+      const block = src.match(/const RUNTIME_FALLBACK: Record<PluginRuntime, string> = \{([^}]+)\}/);
       expect(block, 'RUNTIME_FALLBACK not found — did the map move?').not.toBeNull();
+      // The authority, asserted rather than assumed: keyed by the spec's type,
+      // imported from the spec (via marketplaceApi's re-export). A local
+      // `Record<string, …>` or a hand-written union here would be the drift this
+      // family exists to catch.
+      expect(src, 'the tier map stopped answering to the spec type').toMatch(
+        /import type \{[^}]*\bPluginRuntime\b[^}]*\} from '\.\/marketplaceApi'/,
+      );
       const members = [...block![1].matchAll(/(\w+):\s*'([^']*)'/g)].map((m) => m[1]);
       expect(members.sort()).toEqual(['node', 'sandbox', 'worker']);
       const packMembers = Object.keys(at(builtInLocales.en, 'marketplace.disclosure.runtime') as object);
@@ -341,7 +361,7 @@ describe('objectui#3546 slice five — the marketplace and preview namespaces', 
       // paths must not diverge: with the pack present i18next answers, without it
       // the map does, and a user must not be able to tell which one ran.
       const block = sourceOf(DISCLOSURE).match(
-        /const RUNTIME_FALLBACK: Record<string, string> = \{([^}]+)\}/,
+        /const RUNTIME_FALLBACK: Record<PluginRuntime, string> = \{([^}]+)\}/,
       );
       const labels = Object.fromEntries(
         [...block![1].matchAll(/(\w+):\s*'([^']*)'/g)].map((m) => [m[1], m[2]]),


### PR DESCRIPTION
Fixes #3879
Fixes #3846

合单执行:两卡分诊互相点名同类 —— **消费端比契约宽松**。一分支一 PR、两个 `Fixes`,changeset 与验收证据**分卡**;两卡各一次(#3879 两次)反向验证,先书面预判再跑。

---

## 前提验证(先行 · `origin/main` @ `25c8007d4`)

两卡锚点都还在,行号漂移已重定位:

| 卡 | 卡面锚点 | 实际位置 | 结论 |
|---|---|---|---|
| #3879 | `packages/auth/src/types.ts:404` / 分诊记的 `:414` | `types.ts:455` `status: string`,doc 注释仍枚举四成员;`createAuthClient.ts:901` `return (data ?? []) as AuthInvitation[]`,零运行期校验 | 前提成立 |
| #3879 | `InvitationsPage.tsx` 裸渲染 | `:206`(徽章文案 `defaultValue: inv.status`)与 `:36` `statusBadgeVariant` 的 `default: return 'secondary'` | 前提成立 |
| #3846 | `marketplaceApi.ts:157` `runtime?: string` | `:157`,原样 | 前提成立 |
| #3846 | `PluginDisclosure.tsx:70-71` 的 `as any` 与 `?? version.runtime` | `:70-71`,原样 | 前提成立(第三个症状的**性质**有更正,见文末) |

`@objectstack/spec` 里检索 `Invitation*`:**零命中** —— #3879 的生产方不是 spec,而是 better-auth 的 organization 插件,这决定了两卡收窄的"真相源"不同(见各卡)。

---

## #3879 — `AuthInvitation.status` 收窄 + wire 边界响亮拒绝

### 改法

注释里的枚举提到类型里,并且**绑定生产方自己的联合**而不是抄四个字面量:better-auth 的 `better-auth/client/plugins` 导出 `type InvitationStatus = "pending" | "accepted" | "rejected" | "canceled"`(`dist/plugins/organization/schema.d.mts:319`,框架落在 `sys_invitation.status`)。抄写正是"离上游一次发布就静默漂移"的状态 —— 同 `org-roles.ts` 绑定 spec 的 `BUILTIN_MEMBERSHIP_ROLES` 一个道理,这个先例就在同一个包里。

新模块 `packages/auth/src/invitation-status.ts`:

- `AuthInvitationStatus` = better-auth 的 `InvitationStatus`(绑定,非副本);
- 运行期列表 `AUTH_INVITATION_STATUSES` 从一张**以该联合为键的全量 `Record`** 派生 —— 一份字面量清单而非两份;上游多出第五个成员是**这里编译失败**(map 缺键),而不是守卫留一个洞;
- `isAuthInvitationStatus` 是唯一允许 `string` 变成该联合的地方。

`createAuthClient.ts` 加显式边界 `asAuthInvitation` / `asAuthInvitations`,并落在**四条**返回邀请的方法上,不只卡面点名的 `listInvitations`:`listInvitations`、`listUserInvitations`、`getInvitation`、`inviteMember` 四处都是同一个 `as` 断言,单点边界会让"声明"在下一个屏幕读它的地方仍然无人强制。

未知值**响亮失败**(报错文本点名被拒的值 + 四个合法值),而不是降级。刻意不做静默降级的理由写进了函数注释:中性文案正是裸 wire 值当初的伪装(#3879 的症状本体),丢掉该行则是从管理台账里删掉一条邀请而不说。两条调用路径本来就渲染带重试的错误态(`InvitationsPage` 的 `organization.invitations.loadFailed`、`AcceptInvitationPage` 的 `organization.errors.invitationNotFound`),所以抛错落在设计好的表面上;`resolveOrgErrorMessage` 会把这句英文原样呈现 —— 那正是该模块自己写明的取向("English is worse than Chinese and far better than a blank box… Never swallow an error"),而且契约违例是**要去生产方修的缺陷**,不是一个值得回填十包翻译的用户态。

消费侧 `statusBadgeVariant` 改为**对联合穷尽**、删掉 `default:` 分支(返回类型同时收掉 `'secondary'`)。

### 反向验证(两次,方向不同 —— 先预判后跑)

**变异一(类型半):** 把 `status` 撤回 `string`,边界与钉都留着。
预判:vitest **绿**(边界与字段声明类型无关),type-check **红**(两条 `Assert` 钉 + 穷尽 switch 收到 `string`)。**照此发生**:

```
packages/auth  tsc -p tsconfig.test.json
  src/__tests__/invitation-status-3879.test.ts(222,33): error TS2344: Type 'false' does not satisfy the constraint 'true'.
  src/__tests__/invitation-status-3879.test.ts(223,37): error TS2344: Type 'false' does not satisfy the constraint 'true'.
packages/app-shell  tsc --noEmit  (重建 auth dist 之后)
  src/console/organizations/manage/InvitationsPage.tsx(246,50): error TS2345:
    Argument of type 'string' is not assignable to parameter of type 'InvitationStatus'.
vitest packages/auth/src/__tests__/invitation-status-3879.test.ts → 10 passed (10)
```

这里有一条**如实记录的过程细节**:第一次跑 app-shell 的 `tsc` 时它是**绿**的 —— 因为 app-shell 通过 `node_modules` 软链读 `@object-ui/auth` 的**已构建 dist**(根 tsconfig 的 `paths` 不含 auth),源码变异尚未传导。`pnpm --filter @object-ui/auth build` 之后才红。AGENTS.md §9 的 stale-artefact 陷阱,镜像形态,写在这里免得下一位把"绿"当结论。

**变异二(行为半):** 只撤 `listInvitations` 的边界(恢复 `(data ?? []) as AuthInvitation[]`),喂第五状态。
预判:vitest **红**(经典方向)。**照此发生**:

```
× listInvitations rejects an unknown status LOUDLY, naming the value it refused
  AssertionError: promise resolved "[ { id: 'inv_1', …(6) }, …(1) ]" instead of rejecting
× a missing status is refused too — the shape better-auth would send if it dropped the column
  AssertionError: promise resolved "[ { id: 'inv_1', …(5) } ]" instead of rejecting
Test Files 1 failed (1) · Tests 2 failed | 8 passed (10)
```

"promise resolved instead of rejecting" 就是修复前的线上行为本身。

### 与 #3546 切片七的关系

切片七是**探测半**(第五状态出现时它的 key 集合断言变红),本卡是**处理半**。它零组件改动,但它**读 `InvitationsPage.tsx` 源码**做断言 —— 其中一条逐字钉住徽章调用形状:

```
expect(src, 'the badge template call moved').toContain(
  "t(`organization.invitations.status.${inv.status}`, { defaultValue: inv.status })",
);
```

所以 `defaultValue: inv.status` **保留未动**,这是一处需要解释的取舍:卡面把它列为症状之一,但那个症状的实体是"**未知**值被当界面文案渲染"。联合封闭且在边界强制之后,`inv.status` 只能是四成员之一,而四者在十包里都有 key(切片七回填的),于是 `defaultValue` 从"裸 wire 值通道"变成了一条同语言的冗余兜底。删掉它反而会:(1) 无谓地弄红另一张卡的钉;(2) 让"某包缺 key"从渲染英文成员退化成渲染点分 key 路径 —— 而切片七的等价模型(`en` === `capitalize(member)`)正建立在前者上。因此症状按**成因**消除(类型 + 边界),而不是按**形状**删除。

### 证据

```
vitest packages/auth/ packages/app-shell/src/console/ packages/i18n/src/__tests__/
  Test Files  110 passed (110)
  Tests  1352 passed (1352)
```

---

## #3846 — 信任层级 `runtime` 绑定 spec 的 `PluginRuntime`

### 路线测量(B 的依赖可接受性:测量,不是裁定)

分诊记的方向是"B 优先,测出真约束则回落 A"。量出来的结论比预期更强 —— **B 的依赖成本是零**:

1. `packages/app-shell/package.json` 已列 `"@objectstack/spec": "^17.0.0-rc.6"`(不是"可以加",是**已经在**);
2. app-shell 源码里 134 个文件提到 spec,含 `@objectstack/spec/ui`、`/kernel`、`/data`、`/shared` 真实 subpath 导入;
3. **`marketplaceApi.ts` 自己**隔一个字段就已经绑定了 spec:`export type { PluginPermissions } from '@objectstack/spec/kernel';`,注释写明"本地副本 member-for-member 一致,而这正是 spec 加一种 grant 那天静默腐烂的副本(objectstack#4115)" —— 与本卡同一条理由,同一个 interface;
4. `PluginRuntimeSchema` / `type PluginRuntime` 从 `@objectstack/spec/kernel` 双面可达,运行期实测 `options = ["node","sandbox","worker"]`、`safeParse('quickjs').success === false`。

所以走 B,**不新增任何依赖**;`check:phantom-deps` 与 `check:spec-symbols` 都绿。A(仓内字面联合)不需要了,C(开放兜底表)按卡面反推荐弃。

### 改法

- `marketplaceApi.ts`:`runtime?: PluginRuntime`,并按 `PluginPermissions` 的先例 `export type { PluginRuntime } from '@objectstack/spec/kernel';`(消费方拿类型不必各自去认 spec 的 subpath);
- `PluginDisclosure.tsx`:兜底表改为 `Record< PluginRuntime, string >` —— 全量由构造保证,于是 `?? version.runtime` 的存在理由消失,`as any` 一并删掉。两个症状都不在了。

不可能路径的**方向是刻意的**:若真有一个层级名越过 spec 校验到达前端,现在渲染的是点分 key 路径而不是一个看起来像人话的裸值。前者一眼是坏的,后者会被当成一个真实的信任层级读 —— 这块面板正是授予代码执行权的地方,所以"明显坏掉"优于"貌似正常"。

### 反向验证(先预判后跑)

**变异三:** 把 `runtime?: string` 塞回去。
预判:vitest **绿**(类型被 esbuild 擦除),type-check **红**(索引类型 + 两条 `Assert` 钉 + `@ts-expect-error` 变成未使用)。**照此发生** —— 这是 #3985 先例的"换门"情形,如实写明:

```
tsc --noEmit
  src/console/marketplace/PluginDisclosure.tsx(83,29): error TS7053: Element implicitly has an 'any'
    type because expression of type 'string' can't be used to index type
    'Record<"node" | "sandbox" | "worker", string>'.
tsc -p tsconfig.test.json
  …/__tests__/plugin-runtime-tier-3846.test.tsx(103,32): error TS2344: Type 'false' does not satisfy the constraint 'true'.
  …/__tests__/plugin-runtime-tier-3846.test.tsx(105,7):  error TS2344: Type 'false' does not satisfy the constraint 'true'.
  …/__tests__/plugin-runtime-tier-3846.test.tsx(119,5):  error TS2578: Unused '@ts-expect-error' directive.
vitest …/plugin-runtime-tier-3846.test.tsx → 4 passed (4)
```

**变异四(`as any` 塞回):预判"什么都不会红",并且这个预判是对的。** 不是模板套话,是先测出来的:本仓**没有** i18next 的 `CustomTypeOptions` 增强(全仓 grep 零命中),`useObjectTranslation().t` 的 key 参数就是 `string` —— 探针里一个**编造的 key** `marketplace.disclosure.runtime.definitely_not_a_key` 干净通过 app-shell 的 `tsc`。所以那个 `as any` 抑制不了任何**今天存在**的检查。实跑:

```
tsc --noEmit && tsc -p tsconfig.test.json   → exit 0
vitest …/marketplace/ + slice-5             → 3 files, 58 passed
eslint PluginDisclosure.tsx                 → 2 warnings, 0 errors
                                              (82:71 @typescript-eslint/no-explicit-any ← 唯一信号)
```

**结论如实写:** 卡面把这个 `as any` 描述成"把 `TranslationKeys` 的类型保护整个关掉了" —— 今天**没有这层保护可关**。删它仍然正确(warn 级债务,且它会替将来真接上 key 类型的那天预先失明),但它的性质是**债务清理**,不是保护恢复。这处归因更正连同收口方向已单独立卡:**#4943**(observation 级,`finding` 标签,不排队)。

**顺带一次否证:** 我猜过 `?? version.runtime` 的删除可能被 `check-i18n-call-site-keys.mjs` 的 "Sibling fallbacks" 普查看到。实测把 `??` 塞回后该计数**不变**(2 → 2):那条普查数的是 `t()` **调用本身**坐在 `||`/`??` 左边的形状,不是 options 对象里面的 `??`。所以该症状的消除只由类型层的全量钉(`_MapIsTotal`)担保 —— 本仓没开 `no-unnecessary-condition`,一条对全量 map 的 `??` 是"合法但已死"的 TS,没有门会红。记下来,免得这条被当成有门守着。

### 消费半径:改动在 app-shell,被弄红的 fixture 在 i18n

切片五的断言用**源码正则**读兜底表 —— 正则里逐字写着旧注解 `Record< string, string >`(源码与正则中无空格,此处加空格只为绕开 GitHub 正文的 HTML 标签清洗)。改注解会让它 `toBeNull()` 失败(第一条)并在 `block[1]` 抛错(第二条)—— 一个只扫 app-shell 的清扫看不见它。两条正则已按新注解更新,并按卡面自带的注记**把权威重指到导出类型**:

- 值层对账(兜底表键集合 === `PluginRuntimeSchema.options`)落在新钉 `packages/app-shell/src/console/marketplace/__tests__/plugin-runtime-tier-3846.test.tsx` —— app-shell 依赖 spec,读得到;
- `packages/i18n` **故意不**依赖 spec(它的依赖只有 `@object-ui/core` + i18next,加一条测试专用 spec 依赖会是第一条),所以切片五继续做它在那儿能证明的事(包 vs 兜底表逐成员一致),**外加**一条新断言:兜底表必须以 spec 的类型为键(断言源码 `import type { … PluginRuntime … } from './marketplaceApi'`)。两个文件由此是**一条链**,不是两处各自漂移的真相 —— 切片五的 docblock 里写明了这次重指与理由。

清扫过的调用者面:`MarketplacePackageVersion` 全仓只有 `PluginDisclosure` 消费(`contains_code` 全仓 3 处命中,全在 app-shell src);无 `runtime: '…'` 字面 fixture(仅十包里的 `runtime: 'Runtime'` 标签,不同东西)。

### 证据

```
vitest packages/app-shell/src/console/marketplace/__tests__/plugin-runtime-tier-3846.test.tsx
       packages/auth/src/__tests__/invitation-status-3879.test.ts
  Test Files  2 passed (2) · Tests  14 passed (14)
```

---

## changeset 分卡两份

| 文件 | 卡 | 级别 | 判据 |
|---|---|---|---|
| `.changeset/auth-invitation-status-closed-union-3879.md` | #3879 | **minor** | 公开契约**收紧** + 新增公开导出(`AuthInvitationStatus` / `AUTH_INVITATION_STATUSES` / `isAuthInvitationStatus`)+ 运行期行为变更(未知 status 现在抛错)。三条里任一条都够 minor;按 AGENTS.md「版本号策略」,objectui 自身的破坏性语义也标 minor,正文里写清 breaking 语义,**绝不** `major`(fixed 组 39 包联动) |
| `.changeset/marketplace-runtime-tier-spec-enum-3846.md` | #3846 | **patch** | 收窄的类型**不在**发布面上:app-shell 的 barrel 只导出 `MarketplacePage` / `MarketplacePackagePage` / `MarketplaceInstalledPage`,`MarketplacePackageVersion` 与 `RUNTIME_FALLBACK` 都不在 `index.ts` 里;三个合法层级的用户可见文案逐字不变 |

`check:changeset-no-major` / `check:changeset-fixed` 皆绿。

---

## 门禁

```
pnpm exec turbo run type-check --concurrency=2      → 81 successful, 81 total
vitest packages/auth/ packages/app-shell/src/console/ packages/i18n/src/__tests__/
                                                    → 110 files, 1352 tests passed
node scripts/check-control-bytes.mjs                → OK (4422 tracked text files)
node scripts/check-phantom-dependencies.mjs         → 每个 in-scope import 都由发布它的包声明
node scripts/check-spec-symbol-derivation.mjs        → OK(未新增 collision;spec 无 Invitation* 导出)
node scripts/check-i18n-call-site-keys.mjs           → 每个调用点 key 都在 en 包里解析
node scripts/check-changeset-no-major.mjs            → 无 major
eslint(改动文件)                                    → 0 errors
```

控制字符另做了门以外的自扫(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,含 changeset 与测试),零命中。

**一条新增 warning,如实报**:`RUNTIME_FALLBACK` 为了给新钉做值层对账而 `export`,触发 `react-refresh/only-export-components`(warn 级,`lint.yml` 无 `--max-warnings`,不 gate)。同目录同类先例三处(`ConsoleShell.tsx` 1、`ai/AiChatPage.tsx` 12、`ai/ConversationsSidebar.tsx` 2)。把这张表迁到独立模块能消掉它,但那会把切片五 `sourceOf(DISCLOSURE)` 读的文件也换掉 —— 为一条不 gate 的 warning 去动另一张卡钉住的读取面,风险换比不划算,故不做。

---

## 相邻发现(已立卡,未在本 PR 修)

- **#4943**(`finding`,不排队):`TranslationKeys` 从未绑定到 i18next 的 `CustomTypeOptions`,`t()` 接受任意 key 字符串,整个 key 面由 `scripts/check-i18n-call-site-keys.mjs` 而非编译器守着。它是变异四的测量产物,也更正了 #3846 卡面对 `as any` 的归因。收口(接上 `CustomTypeOptions`)是仓级契约决定,牵动 170+ 调用点与十包,需独立定范围,故不搭车。

草稿 PR,不 undraft —— 等 PM 验收。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_