### PR TITLE
docs(adr): ADR-0036 服务端 fault 策略收窄,未绑定根一类是 fail-CLOSED (#3888)

### DIFF
--- a/.changeset/adr36-server-fault-policy-narrowing-3888.md
+++ b/.changeset/adr36-server-fault-policy-narrowing-3888.md
@@ -1,0 +1,45 @@
+---
+---
+
+Docs-only correction, no behaviour and no authoring-surface change (objectui#3888).
+
+ADR-0036's `## Server enforcement (framework)` section stated the server's fault
+policy unconditionally: "A predicate that fails to evaluate is **fail-open** and
+logged". That covered both server-enforced predicates in one line, and it has been
+false for one whole fault class since objectstack#4889: a `readonlyWhen` predicate
+that faults because it names a scope ROOT the write never bound (`parent.status ==
+'paid'` with no master-detail header in hand) is fail-CLOSED —
+`isReadonlyWhenLocked` warns `… treating the field as LOCKED` and resolves the
+field to locked, and `stripReadonlyWhenFields` / `stripReadonlyWhenFieldsMulti`
+then delete that key from the UPDATE payload, surfacing as a `droppedFields` entry
+with `reason: 'readonly_when'`.
+
+This was the last uncorrected copy of that stale assertion. The code-comment copy,
+in `packages/core/src/evaluator/fieldRules.ts`, was narrowed by objectui#3828; the
+ADR is where a reader looks FIRST when asking what the server does, so leaving it
+preserved the wrong mental model in the more authoritative place.
+
+The summary bullet now carries the exception and points at a new subsection that
+states it in full: why the unbound-root case is not a broken predicate, what the
+server does with it, and — since the client deliberately does NOT mirror it — the
+silent symptom that divergence produces (field renders editable, save reports
+success, value never lands) plus which end to debug. The `## Client enforcement
+(objectui)` section's "the same posture as the server" clause is narrowed the same
+way, since it asserted the same parity.
+
+Two things verified as still accurate and left alone: the `requiredWhen` half
+(objectstack#4977 bound the same `parent` scope but deliberately kept fail-open
+semantics, so an unevaluable requirement is skipped on both ends) and the
+`visibleWhen` bullet (the server never evaluates it). Both are now stated as
+explicit non-exceptions rather than implied by an over-broad summary.
+
+The ADR-0057 D10 citation is marked as the **framework's** numbering: this repo
+carries an unrelated `docs/adr/0057-console-ai-chat-one-conversation-docked.md`,
+so an unqualified "ADR-0057" resolves to the wrong document for a reader in this
+tree. It is also written as an attribution — the shorthand the framework's
+rule-validator, lint diagnostics and QA runner all use — rather than as a claim
+that the D-anchor resolves, because verification could not confirm that it does
+(filed against the framework, not fixed here).
+
+No package is declared because nothing published changed: the diff is one
+markdown file under `docs/adr/`.

--- a/docs/adr/0036-field-conditional-rules.md
+++ b/docs/adr/0036-field-conditional-rules.md
@@ -65,10 +65,49 @@ import dragged into the bundle.
   the prior record only when an object actually declares conditional fields
   (`needsPriorRecord`).
 - A predicate that fails to evaluate is **fail-open** and logged (a broken rule
-  must never block a legitimate write).
+  must never block a legitimate write) — **except** a `readonlyWhen` whose fault
+  is an unbound scope root, which has been fail-CLOSED since objectstack#4889.
+  See the next subsection; this bullet used to state the policy unconditionally
+  and that is no longer true.
 - `visibleWhen` is **not** a server concept — visibility is purely a client UX
   affordance. The server's `requiredWhen` / `readonlyWhen` are the real guards,
   so hiding a field client-side never weakens enforcement.
+
+### The one fail-CLOSED fault (objectstack#4889)
+
+The exception is narrow, and worth stating in full because its symptom is
+silent. A `readonlyWhen` predicate can fault because it names a scope ROOT this
+write never bound — `parent.status == 'paid'` evaluated where no master-detail
+header was resolved. That is not a broken predicate; it is a supported construct
+the evaluation site could not answer, and answering "not locked" writes a field
+the author declared frozen. So the server takes the conservative branch:
+`isReadonlyWhenLocked` logs `… treating the field as LOCKED`, resolves the field
+to locked, and `stripReadonlyWhenFields` — with its bulk twin
+`stripReadonlyWhenFieldsMulti` — deletes the key from the UPDATE payload. The
+incoming change is dropped exactly as a TRUE predicate's would be, and reported
+on the write response as a `droppedFields` entry with `reason: 'readonly_when'`.
+Enforcement belongs on the server — *server enforces, client is courtesy*, the
+rule the framework cites throughout its rule-validator, its lint diagnostics and
+its QA runner as **ADR-0057 D10** (that is the **framework's** ADR numbering;
+this repo's own ADR-0057, `0057-console-ai-chat-one-conversation-docked.md`, is
+an unrelated document) — and a declared lock that failed open would leave
+enforcement in the courtesy layer instead.
+
+Everything else keeps the fail-open policy, deliberately:
+
+- **Every other `readonlyWhen` fault** — undeclared key, null overload, parse
+  error — logs `… failed to evaluate — change allowed through` and lets the
+  change land. The two faults are told apart by the engine's own error text (it
+  reports an unknown variable, naming the root, for the unbound case, versus a
+  missing key / an overload / a parse fault for the rest), not by guessing.
+- **`requiredWhen` carries no such carve-out.** objectstack#4977 bound the same
+  `parent` scope for it — so the requirement is now enforced where this ADR says
+  it is, on insert, single-id update and bulk — but deliberately kept the
+  fail-open *semantics*: an unevaluable requirement, an unresolvable header
+  included, is logged and skipped, and the write proceeds. Rejecting a write
+  because a header was momentarily unreadable is a louder failure than refusing
+  one field.
+- **`visibleWhen`** is never evaluated server-side at all, per the bullet above.
 
 ## Client enforcement (objectui)
 
@@ -101,7 +140,21 @@ merged record.
 
 `evalFieldPredicate`'s fallbacks are chosen so a fault is *safe*: `true` for
 visibility (don't hide content on error), `false` for required/readonly (don't
-block submit or lock a field on error) — the same posture as the server.
+block submit or lock a field on error) — the same posture as the server for
+every fault but one.
+
+**The one place the two ends point in opposite directions.** For the
+unbound-root `readonlyWhen` fault above the server locks the field and the
+client keeps it editable, deliberately: by the same *server enforces, client is
+courtesy* reasoning that makes the server the authority, the courtesy layer does
+not get to guess "locked" and grey out a field the server might have accepted. The consequence is worth knowing
+before debugging it, because nothing about it looks like a failure: the form
+renders the field editable, the user edits it, the save reports SUCCESS, and the
+new value never lands. That trail leads to the SERVER-side lock — its `… treating
+the field as LOCKED` warning and the write response's `droppedFields` — not to
+the client predicate, which returned exactly what it was asked for. The
+narrowing is recorded on the client helper's own module head too
+(`packages/core/src/evaluator/fieldRules.ts`, objectui#3828).
 
 **Amendment (objectstack#5149, appeal 2).** Fail-open is now **loud**: a
 predicate that cannot be evaluated (parse error, unbound identifier, engine


### PR DESCRIPTION
Fixes #3888

ADR-0036 的 `## Server enforcement (framework)` 段把服务端 fault 策略写成**无条件**成立:

> - A predicate that fails to evaluate is **fail-open** and logged (a broken rule must never block a legitimate write).

这一句一行覆盖了该段上面两个服务端谓词(`requiredWhen` 与 `readonlyWhen`),而自 objectstack#4889 起它对 `readonlyWhen` 的一个 fault 类不成立。这是同一个陈旧断言的**最后一份未改副本** —— 代码注释那一份(`packages/core/src/evaluator/fieldRules.ts` 模块头)已由 #3828 / PR #3887 收窄,ADR 是读者问「服务端到底怎么办」时的第一站,留着它等于把刚拆掉的错误心智模型原样保存在更权威的位置。文档改动,无行为、无授权面变化。

## 前提验证(先行)

卡片正文与晋级评论给的 framework 行号已经漂了两次(正文按 `fec784863` 写 `:599-603`/`:604`/`:606-607`,晋级评论按 `86e6f6c` 写 `:601` vs `:606`),按硬规重新定位。以下全部读自 objectstack `origin/main` @ `23abe2782` 的 `packages/objectql/src/validation/rule-validator.ts`(读法:`git -C /home/user/objectstack fetch origin main` 后 `git show origin/main:PATH`,未碰共享工作树):

| 事实 | 重定位后的位置 |
|---|---|
| 设计小节「`readonlyWhen`: the UNBOUND-ROOT case is fail-CLOSED (#4889)」 | `:99`(正文 `:99-113`) |
| 「Every OTHER `readonlyWhen` fault … keeps the fail-open policy」 | `:106-108` |
| `isReadonlyWhenLocked` | `:588` |
| 未绑定根 → 记日志 `treating the field as LOCKED` | `:607-611` |
| 同一分支 `return true`(= LOCKED) | `:612` |
| **其他** fault → `failed to evaluate — change allowed through` | `:614` |
| 同一分支 `return false`(= fail-open) | `:615` |
| `stripReadonlyWhenFields` 及其 `delete` | `:530` / `:545` |
| 批量孪生 `stripReadonlyWhenFieldsMulti` 及其 `delete` | `:749` / `:780` |
| `requiredWhen` fault(含未绑定根)记日志后 `continue` —— 仍是 fail-OPEN | `:1695-1712` |
| 「Do NOT copy the fail-CLOSED carve-out」(#4977 裁定) | `:136` |

另两条新声称的出处:`droppedFields` 的 `reason: 'readonly_when'` 见 objectstack `packages/objectql/src/engine-dropped-fields-primary-key.test.ts:205`(契约来自 objectstack#3794);客户端 readonly fallback 为 `false` 见本仓 `packages/core/src/evaluator/fieldRules.ts:253`。

premise **成立**:那一句仍在,仍是无条件写法,且对 `readonlyWhen` 的未绑定根一类确实反了方向。

## 改了什么

1. **概括那条 bullet 带上例外**并指向新增小节 —— 它的职责就是给出正确的一眼概括,所以收窄而非删除。
2. **新增 `### The one fail-CLOSED fault (objectstack#4889)`**:为什么未绑定根不是「谓词坏了」(是 spec 支持的构造,只是求值点答不上来)、服务端拿它怎么办(判锁死 + 从 payload 删 key + 记 `droppedFields`)、以及两条**非例外**:其他 `readonlyWhen` fault 仍 fail-open(并说明两类 fault 靠引擎错误文本区分,不靠猜),`requiredWhen` 没有这个 carve-out(#4977 绑了 scope 但刻意保留 fail-open 语义)。
3. **`## Client enforcement (objectui)` 段**:原文「the same posture as the server」断言的是同一件事,同样收窄,并点明两端在这一格方向相反是刻意的,附上那个静默症状(表单可编辑、保存报成功、值不落库)与该往哪一端排障(服务端 `treating the field as LOCKED` 警告 + 写响应的 `droppedFields`,不是客户端谓词)。措辞与 PR #3887 的 docblock 对齐。

## ADR-0057 编号:两层,一层修了一层立案

**本仓撞号(已按卡片处理)**:引用写明是 **framework** 编号 —— 本仓另有一份无关的 `docs/adr/0057-console-ai-chat-one-conversation-docked.md`,裸编号会把本仓读者送到错误的文档。

**framework 侧 D 锚点不可解(未修,已立案)**:核验时顺手查了这个引用能不能落地,结论是不能 —— framework 的两份 ADR-0057 里都没有内容对得上的 D10(`0057-erp-authorization-core-business-units-and-scope-depth.md:422` 的 D10 是 "Setup-nav surfacing follows the capability";`0057-system-data-lifecycle-and-retention.md` 没有任何 D 编号决策,它用 P0–P4)。规则本身是真的、代码自证,不成立的只是锚点。

所以本 PR 把它写成**归属式**表述(「the rule the framework cites throughout its rule-validator, its lint diagnostics and its QA runner as **ADR-0057 D10**」)而不是断言该锚点可解 —— 本卡的全部要点就是不要在权威记录里保存一个查不实的断言,那么在同一次改动里新种一个会很讽刺。framework 侧共 20 个文件 + 一条 `adr-anchors/` invariant 骑在这个锚点上,已单独立案 **objectstack#9255**(观察类,`finding`,未定级),本 PR 不修。

## 验证(文档类:正向判据)

- `node scripts/check-control-bytes.mjs` → `OK (scanned 4432 tracked text file(s); skipped 85 binary)`
- 门外自扫 `grep -naP` + 控制字符类(U+0000–U+0008、U+000B、U+000C、U+000E–U+001F)两个改动文件 → 零命中(本 PR 的散文完全不提及控制字符,仍按规矩自扫)
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`(`docs/**` 是它的扫描面之一;本 PR 未新增任何链接,ADR-0057 的文件名以反引号给出而非链接)
- `node scripts/check-doc-component-types.mjs` → `Every documented component type is registered.`
- `node scripts/check-changeset-fixed.mjs` / `check-changeset-no-major.mjs` → 均绿
- 仓根 `flock … 'NODE_OPTIONS=--max-old-space-size=4096 pnpm exec turbo run type-check --concurrency=2'` → **81 successful, 81 total**(6m11s)。跑在正文定稿前;此后三处编辑全部落在 `docs/adr/**` 与 `.changeset/**`,这两处不进任何 tsconfig program(按 `--include=tsconfig*.json` 搜 `docs/` 前缀零命中),故未复跑。
- **无新增/更新测试,这是诚实的**:改动是一份 markdown ADR,零代码。「新增测试」这一栏对本改动没有可测对象 —— 断言的正确性由上表每条声称配一个 framework `file:line` 指针来承担,这是文档类改动的正向判据。

改前/改后的逐字对照见 issue 与下方 diff:改前一句 = `A predicate that fails to evaluate is **fail-open** and logged (a broken rule must never block a legitimate write).`;改后同一 bullet 追加 `— **except** a readonlyWhen whose fault is an unbound scope root, which has been fail-CLOSED since objectstack#4889.`,细节移入新小节。

分支基于 `1b21b1aaa`;此后 `main` 已前移,但 `docs/adr/0036-field-conditional-rules.md` 与 `.changeset/` 在这段区间内无改动(按路径比对为空),无冲突。

草稿 PR,不 undraft。
