### PR TITLE
fix(templates): move the generator dependency ranges with today's dependabot wave

### DIFF
--- a/.changeset/cli-app-generator-lucide-range-4968.md
+++ b/.changeset/cli-app-generator-lucide-range-4968.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/cli': patch
+---
+
+The routed temp app's generated manifest now asks for the same `lucide-react` range this repo installs.
+
+`utils/app-generator.ts` writes the routed variant's `dependencies` with two
+quoted third-party ranges, and `lucide-react` had fossilised a minor behind the
+22 sibling manifests that declare it: the generated manifest said `^1.29.0`
+while the repo had moved to `^1.31.0`. A generated app therefore asked npm for
+an icon library older than the one every `@object-ui/*` package it installs
+alongside was built against.
+
+The drift was not silent — `app-generator.test.ts` derives its expectation from
+the in-repo range precisely so a bump on one side and not the other fails a
+test, and both of its pins were red. What went wrong is that they went red too
+late to stop anything: the dependency PR that moved the repo range merged while
+those shards were still running, so the failure surfaced on `main` and then on
+the merge ref of every unrelated open PR. The range is now caught up; the
+reporting hole and the merge-ordering hole are filed separately (objectui#4968).
+
+The remaining eleven anchored ranges were swept against the same dependabot
+batch and are all in sync, so this is the batch's only consumer-side follow-up.
+Deriving the value from the workspace instead of quoting it was considered and
+rejected: nine of the thirteen anchored ranges quote the repo root manifest,
+which is not published with this CLI, so no single derivation can serve the
+table and a bespoke one for this one name would leave the class untouched.

--- a/.changeset/create-plugin-jest-dom-range-4968.md
+++ b/.changeset/create-plugin-jest-dom-range-4968.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/create-plugin': patch
+---
+
+A scaffolded plugin's generated manifest now asks for the same `@testing-library/jest-dom` range this repo installs.
+
+`src/templates.ts`'s `DEV_DEPENDENCIES` had fossilised one patch behind the repo
+root: the template said `^7.0.0` while the root manifest had moved to `^7.0.1`.
+`templates.test.ts`'s anchor rule caught it and was red on `main`.
+
+Same defect class, same day and same dependabot wave as the `lucide-react` drift
+in `@object-ui/cli`'s app generator, so both templates move together here — which
+is how the previous occurrence of this incident was handled too (objectui#4098 /
+PR objectui#4099 moved these same two templates in one PR). This one came from
+the dev-dependencies group bump rather than the single-package bump, and it was
+found only because the two ratchets live in different packages: the anchor rule
+throws on its first mismatch, so nothing reports the second template until the
+first is green.
+
+The remaining seven anchored ranges in this template were swept against the same
+wave and are all in sync.

--- a/packages/cli/src/utils/app-generator.ts
+++ b/packages/cli/src/utils/app-generator.ts
@@ -177,6 +177,23 @@ function buildAppDependencies(): Record<string, string> {
  * with an unsatisfiable import. Declaring it at the producer is the fix — the
  * alias becomes a workspace convenience rather than the only thing holding the
  * import up.
+ *
+ * Both ranges here are QUOTED from this repo, per the objectui#3742 /
+ * objectui#3754 anchoring discipline: `react-router-dom` from the root
+ * manifest, `lucide-react` from the sibling manifests that declare it (the root
+ * does not). `app-generator.test.ts`'s `DEPENDENCY_ANCHORS` names the anchor for
+ * each and fails when a bump on either side leaves this file behind — which is
+ * the whole reason the values are allowed to be literals at all.
+ *
+ * That gate is not decoration; it has fired. objectui#4968: a dependabot bump
+ * moved `lucide-react` across all 22 sibling manifests and this literal stayed
+ * a minor behind, so the pin went red on every open PR's merge ref until the
+ * literal caught up. Deriving the value instead was considered and rejected in
+ * that PR — 9 of the 13 anchored ranges quote the repo ROOT manifest, which is
+ * not published with this CLI, so there is no one derivation the whole table
+ * could share and a bespoke one for this single name would buy nothing. The
+ * durable cure is upstream of this file: the shards carrying the gate have to
+ * finish before a dependency PR can merge.
  */
 function buildRoutedAppDependencies(): Record<string, string> {
   const range = platformPackageRange();
@@ -184,7 +201,7 @@ function buildRoutedAppDependencies(): Record<string, string> {
     react: REACT_RANGE,
     'react-dom': REACT_RANGE,
     'react-router-dom': '^7.18.2',
-    'lucide-react': '^1.29.0',
+    'lucide-react': '^1.31.0',
     ...Object.fromEntries(PLATFORM_RUNTIME_PACKAGES.map((name) => [name, range]))
   };
 }

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -59,7 +59,7 @@ export const VITEST_SETUP_FILE = 'vitest.setup.ts';
  *
  * | dependency                  | range     | anchor                                     |
  * | --------------------------- | --------- | ------------------------------------------ |
- * | `@testing-library/jest-dom` | `^7.0.0`  | repo root package.json (also apps/console) |
+ * | `@testing-library/jest-dom` | `^7.0.1`  | repo root package.json (also apps/console) |
  * | `@testing-library/react`    | `^16.3.2` | repo root package.json (also apps/console) |
  * | `@vitejs/plugin-react`      | `^6.0.5`  | every `packages/plugin-*` (not in root)    |
  * | `jsdom`                     | `^30.0.1` | repo root package.json                     |
@@ -84,7 +84,7 @@ export const VITEST_SETUP_FILE = 'vitest.setup.ts';
  * monorepo, not a failing install.
  */
 const DEV_DEPENDENCIES: Record<string, string> = {
-  '@testing-library/jest-dom': '^7.0.0',
+  '@testing-library/jest-dom': '^7.0.1',
   '@testing-library/react': '^16.3.2',
   '@vitejs/plugin-react': '^6.0.5',
   jsdom: '^30.0.1',


### PR DESCRIPTION
Fixes #4968

## 改了什么

两个生成器模板的第三方区间跟到 workspace 现值,各一行 + 各一个 changeset:

| 包 | 文件 | 依赖 | 改动 | 来自哪个 bump |
|---|---|---|---|---|
| `@object-ui/cli` | `src/utils/app-generator.ts` | `lucide-react` | `^1.29.0` → `^1.31.0` | #4959 (`c1454a2d9`) |
| `@object-ui/create-plugin` | `src/templates.ts` | `@testing-library/jest-dom` | `^7.0.0` → `^7.0.1` | #4948 (`590dd6356`) |

⚠️ **第二条不在原卡范围内,但不修则本 PR 落地后全仓依然红。** 详见「扫出第二处同症」。

## 修法选择:字面量,不派生(逐条说明为何)

钉的注释自述「A literal here is the very fossil generator this file exists to stop」,所以我先认真评估了派生路线,结论是**不派生**。理由是实测的,不是偏好:

1. **拿不到 manifest。** 派生要读 `@object-ui/components` 的 manifest(lucide 是它的 `dependencies`,且 cli 确实依赖它)。实测两种 specifier 都不通:

   ```
   FAIL @object-ui/components/package.json -> ERR_PACKAGE_PATH_NOT_EXPORTED
   OK   @object-ui/components -> .../packages/components/dist/index.umd.cjs
   ```

   前者是 exports map 只有 `.` 和 `./style.css` 的必然结果 —— 要走通就得给**另一个已发布包**的公开 exports 面加 `./package.json`,已越出本卡包边界;后者只在 build 之后才 resolve,且落到 `dist/`,拿 manifest 仍要目录上溯。

2. **它只能治 13 个里的 1 个。** cli 侧锚表 `DEPENDENCY_ANCHORS` 有 13 个第三方区间,其中 **9 个锚到仓库根 manifest**,而根 manifest 不随 cli 发布(`files: ["dist","README.md","CHANGELOG.md","LICENSE"]`)—— react / react-dom / react-router-dom / @types/react / @types/react-dom / autoprefixer / tailwindcss / typescript / vite 在运行期**没有任何可派生来源**。派生给不出全表共享的机制,只能给 lucide 单开一条 bespoke 路径:同类问题还在,还多一份不对称。create-plugin 侧同理(8 个里 6 个锚到根)。

3. **锚定纪律本来就是「字面量 + 门」。** objectui#3742 / #3754 写得很直白:「quoted rather than invented, so bumping an in-repo manifest and leaving a generator behind **fails a test instead of shipping**」。`cli-version` 之所以派生,是因为 fixed 组每次发版都重编号、字面量**隔天就腐**;第三方区间不是这个节奏,门就是为它设计的机制 —— 这次门也确实响了。

**修法半衰期,如实声明:一次 bump。** 下次 dependabot 动这两个包中任一个,对应钉会以同样方式再红。这不是推测,我实测了(反向验证方向 2)。真正的持久解在本文件上游,见下。

## 为什么 #4959 自己的 CI 没拦住:门响了,只是响得太晚

**这不是检查面漏了,是时序。** #4959 自己的 head SHA `31745d8b` 上,Test shard 1/4 与 3/4 的 conclusion 都是 `failure`,报的就是本卡引用的那两条断言(job 95325241579 日志):

```
AssertionError: routed manifest's lucide-react must match its in-repo range:
  expected '^1.29.0' to be '^1.31.0'
  packages/cli/src/__tests__/app-generator.test.ts:574:68
AssertionError: expected '^1.29.0' to be '^1.31.0'
  packages/cli/src/__tests__/app-generator.test.ts:1139:55
```

时间线是决定性的:

| 时刻 | 事件 |
|---|---|
| 08:07:41Z | #4959 建立 |
| 08:13:07Z | test shard job 启动 |
| **08:13:36Z** | **PR 被 `github-actions[bot]` 合入 main** |
| 08:13:38Z | shard 里的 vitest 才真正开跑(合并后 2 秒) |
| 08:21:53Z | shard 1/4 报 failure(**合并后 8 分 17 秒**) |

`dependabot-auto-merge.yml` 对 semver-patch/minor 无条件执行 `gh pr merge --auto --squash`(1.29.0 到 1.31.0 是 minor,命中)。`--auto` 在 required check 集满足的那一刻就落,而承载这个门的 4 分片 test 矩阵是整个 workflow 里最慢的 job(本次 `import 986.93s`,单片约 9 分钟),因此系统性地最后报到、最容易被 auto-merge 跑过去。仓库 AGENTS.md 恰好禁止 agent 用 `--auto`,理由一字不差就是这个;而 `dependabot-auto-merge.yml` 仍在用。这是**任何**红都能落到 main 的通道,不限于区间漂移,所以我单独立卡而没在本 PR 改 CI。

## 这是一周内的第二次复发

#4098(8-10)是**同一条测试、同一个依赖**:`lucide-react` 1.28.0 → 1.29.0 打断同一个 ratchet,由 PR #4099 以同样的字面量跟进修掉。#4098 当时就写下了持久问题:

> the durable question is whether that can be made automatic — a dependabot bump touching a range that a template mirrors should either update the template in the same PR or fail its own CI rather than a later, unrelated one.

那个问题没有落地,七天后同一处以同样方式再红。#4098 也已经观察到「only the first mismatch in each file is reported」—— 同样没落地,而这正是下面第二处同症一周后仍能藏住的原因。

## 扫出第二处同症:`packages/create-plugin`(本 PR 一并修)

#4099 的处理方式是**一个 PR 修两个模板**(标题即 "move generator dependency ranges with the dependabot wave"),我按同一先例做:

`packages/create-plugin/src/__tests__/templates.test.ts:356` 在 `main` 上**当前就是红的**,与 lucide 无关:

```
AssertionError: @testing-library/jest-dom range must match the repo root:
  expected '^7.0.0' to be '^7.0.1'
```

来自 #4948 的 dev-dependencies 组 bump(`590dd6356`)。**只修 #4968 不能让全仓转绿**,受阻 PR 的 shard 仍会红,auto-merge 队列仍然堵着 —— 所以一并修。

顺带一条方法学教训:这处是**按缺陷类别扫**才发现的,不是按包扫。锚规则逐名 `expect`、首个不匹配即抛,所以第一个模板绿之前,第二个模板什么都不报。我用 grep 把这一类 ratchet 全量枚举了一遍,全仓只有这两个测试文件带它(`app-generator.test.ts` 与 `templates.test.ts`),两个都已在本 PR 内。

## 两个模板的全量区间核对:各只有一处漂

因为门只报第一处,下面两张表是我另写脚本全量算的,不是测试报的。

**`@object-ui/cli` — `DEPENDENCY_ANCHORS` 13 项:**

| name | anchor | generated | repo | 判定 |
|---|---|---|---|---|
| lucide-react | in-repo | ^1.29.0 | ^1.31.0 | **漂移,本 PR 修** |
| react | root | 19.2.8 | 19.2.8 | ok |
| react-dom | root | 19.2.8 | 19.2.8 | ok |
| react-router-dom | root | ^7.18.2 | ^7.18.2 | ok |
| @tailwindcss/postcss | in-repo | ^4.3.3 | ^4.3.3 | ok |
| @types/react | root | 19.2.18 | 19.2.18 | ok |
| @types/react-dom | root | 19.2.4 | 19.2.4 | ok |
| @vitejs/plugin-react | in-repo | ^6.0.5 | ^6.0.5 | ok |
| autoprefixer | root | ^10.5.4 | ^10.5.4 | ok |
| postcss | in-repo | ^8.5.26 | ^8.5.26 | ok |
| tailwindcss | root | ^4.3.3 | ^4.3.3 | ok |
| typescript | root | ^6.0.3 | ^6.0.3 | ok |
| vite | root | ^8.2.1 | ^8.2.1 | ok |

**`@object-ui/create-plugin` — `DEV_DEPENDENCY_ANCHORS` 8 项:**

| name | anchor | generated | repo | 判定 |
|---|---|---|---|---|
| @testing-library/jest-dom | root | ^7.0.0 | ^7.0.1 | **漂移,本 PR 修** |
| @testing-library/react | root | ^16.3.2 | ^16.3.2 | ok |
| @vitejs/plugin-react | in-repo-plugins | ^6.0.5 | ^6.0.5 | ok |
| jsdom | root | ^30.0.1 | ^30.0.1 | ok |
| typescript | root | ^6.0.3 | ^6.0.3 | ok |
| vite | root | ^8.2.1 | ^8.2.1 | ok |
| vite-plugin-dts | in-repo-plugins | ^5.0.3 | ^5.0.3 | ok |
| vitest | root | ^4.1.10 | ^4.1.10 | ok |

本批次点名的另外两个包与模板零交集:`@sentry/react` (#4957) 与 `maplibre-gl` (#4956) 在 `packages/cli/src` 与 `packages/create-plugin/src` 里**一次都没出现**(plugin-report / plugin-map 的依赖);`@objectstack/spec|client|formula|lint` 的 GA bump (#4953/#4954/#4955/#4960) 也都不在两张锚表里。`commands/init.ts` 不自己写任何区间,全部读 `scaffold-dependencies.ts`,第三个生成器无需另改。

`create-plugin` 里那张写在注释里的 anchor 表也同步移了一行 —— 它逐条列出每个锚定区间,不动就只是把化石搬进注释。

## 验证

- `pnpm --workspace-concurrency=2 --filter '@object-ui/cli^...' build` → exit 0
- `pnpm exec vitest run packages/create-plugin/ packages/cli/ --maxWorkers=2` → `Test Files 6 passed (6) / Tests 138 passed (138)`
- 本卡点名的两处钉转绿:
  ```
  ✓ generated app manifests > sources every range from this repo instead of inventing one 20ms
  ✓ generation onto disk > writes a manifest whose @object-ui ranges name this CLI version 3ms
  ```
- `pnpm exec turbo run type-check --concurrency=2` → `81 successful, 81 total`(cli 改动后全量);create-plugin 改动后另跑两包 scoped type-check,均 Done
- `node scripts/check-control-bytes.mjs` → OK(4436 files);另对本 PR 改动的文件做了越过门盲区的自扫(`grep -naP` 覆盖门不扫的 `0x01`-`0x1f`),无控制字节
- changeset 三个 guard 全绿(`no-major` / `fixed` / `presence`:2 源文件 / 2 changeset)

### 反向验证(每个方向都在跑之前先预判)

**方向 1 — 预判「红」:** 把 lucide 字面量退回 `^1.29.0`(workspace 停在 `^1.31.0`),两处钉必须红且与 issue 逐字一致。实测:

```
Tests  2 failed | 39 passed (41)
AssertionError: routed manifest's lucide-react must match its in-repo range: expected '^1.29.0' to be '^1.31.0'
  packages/cli/src/__tests__/app-generator.test.ts:574:68
AssertionError: expected '^1.29.0' to be '^1.31.0'
  packages/cli/src/__tests__/app-generator.test.ts:1139:55
```

证明这两处钉读的确实是我改的那个值。jest-dom 同样做了一次,`expected '^7.0.0' to be '^7.0.1'` at `templates.test.ts:356:75`,`1 failed | 18 passed`。

**方向 2 — 预判「反向红」,即半衰期的实测证明:** 字面量保持 `^1.31.0`,把 23 个仓内 manifest 全部改成假值 `^9.99.0`(**全部**改,因为 dependabot 就是一个 commit 动所有 manifest —— 这也正是 #4959 上仓内一致性依然成立、门能判出值不匹配而不是先撞「in-repo manifests disagree」的原因)。预判:钉以相反方向红。实测:

```
AssertionError: routed manifest's lucide-react must match its in-repo range: expected '^1.31.0' to be '^9.99.0'
  packages/cli/src/__tests__/app-generator.test.ts:574:68
AssertionError: expected '^1.31.0' to be '^9.99.0'
  packages/cli/src/__tests__/app-generator.test.ts:1139:55
```

这就是上面「半衰期 = 一次 bump」的证据,而不是一句修辞。三次临时改动全部已回退,工作树只剩本 PR 的四个文件。

## 不在本 PR 范围内(已另立卡)

见下方 findings 评论。两条都是 CI / 门自身的问题,都是 #4098 一周前就写下、至今未落地的那两条,不该搭在一个全仓阻断的热修上:auto-merge 时序(持久解),与锚规则只报首个不匹配(正是它让第二处模板藏了一周)。
