### PR TITLE
fix(ga-pin): quick-reference 两行跟到 GA;$like/$ilike 按「未裁」引用式豁免(#4977)

### DIFF
--- a/.changeset/cli-app-generator-lucide-range-4968.md
+++ b/.changeset/cli-app-generator-lucide-range-4968.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/cli': patch
+---
+
+The routed temp app's generated manifest now asks for the same `lucide-react` range this repo installs.
+
+`utils/app-generator.ts` writes the routed variant's `dependencies` with two
+quoted third-party ranges, and `lucide-react` had fossilised a minor behind the
+22 sibling manifests that declare it: the generated manifest said `^1.29.0`
+while the repo had moved to `^1.31.0`. A generated app therefore asked npm for
+an icon library older than the one every `@object-ui/*` package it installs
+alongside was built against.
+
+The drift was not silent — `app-generator.test.ts` derives its expectation from
+the in-repo range precisely so a bump on one side and not the other fails a
+test, and both of its pins were red. What went wrong is that they went red too
+late to stop anything: the dependency PR that moved the repo range merged while
+those shards were still running, so the failure surfaced on `main` and then on
+the merge ref of every unrelated open PR. The range is now caught up; the
+reporting hole and the merge-ordering hole are filed separately (objectui#4968).
+
+The remaining eleven anchored ranges were swept against the same dependabot
+batch and are all in sync, so this is the batch's only consumer-side follow-up.
+Deriving the value from the workspace instead of quoting it was considered and
+rejected: nine of the thirteen anchored ranges quote the repo root manifest,
+which is not published with this CLI, so no single derivation can serve the
+table and a bespoke one for this one name would leave the class untouched.

--- a/.changeset/create-plugin-jest-dom-range-4968.md
+++ b/.changeset/create-plugin-jest-dom-range-4968.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/create-plugin': patch
+---
+
+A scaffolded plugin's generated manifest now asks for the same `@testing-library/jest-dom` range this repo installs.
+
+`src/templates.ts`'s `DEV_DEPENDENCIES` had fossilised one patch behind the repo
+root: the template said `^7.0.0` while the root manifest had moved to `^7.0.1`.
+`templates.test.ts`'s anchor rule caught it and was red on `main`.
+
+Same defect class, same day and same dependabot wave as the `lucide-react` drift
+in `@object-ui/cli`'s app generator, so both templates move together here — which
+is how the previous occurrence of this incident was handled too (objectui#4098 /
+PR objectui#4099 moved these same two templates in one PR). This one came from
+the dev-dependencies group bump rather than the single-package bump, and it was
+found only because the two ratchets live in different packages: the anchor rule
+throws on its first mismatch, so nothing reports the second template until the
+first is green.
+
+The remaining seven anchored ranges in this template were swept against the same
+wave and are all in sync.

--- a/.changeset/ga-pin-residue-quickref-and-like-exemption-4977.md
+++ b/.changeset/ga-pin-residue-quickref-and-like-exemption-4977.md
@@ -1,0 +1,21 @@
+---
+---
+
+Clears the two GA-pin residues that were red on `main` itself, so every open PR stopped
+inheriting a red `Test (shard 3/4)` (objectui#4977). No published behaviour changes: the
+only files touched are a root doc and a test file.
+
+`QUICK_REFERENCE.md`'s "Current Release" block still quoted `@objectstack/spec` and
+`@objectstack/client` as `^17.0.0-rc.6` after the manifests moved to the `^17.0.0` GA
+range. Both rows now state the range their named anchor declares — the doc followed the
+manifest, the pin that derives the expectation was not loosened.
+
+The `@objectstack/spec` GA `FieldOperatorsSchema` added `$like` and `$ilike`, which no
+builder operator authors, so the #2942 reachability sweep in
+`packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts` reported
+them by design. They are excluded through that gate's own citation mechanism as
+**undecided — see objectui#4911** (the open decision box on whether the visual filter
+builder should offer raw pattern matching), with the harvest condition written on the
+entry: a ruling on #4911 must either delete the members and add the operators, or restate
+the paragraph as a decision carrying its reopen condition. No operator was implemented and
+no other gate logic moved — the product ruling stays with the maintainer.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -113,9 +113,9 @@ that test tells you to edit this block. The one exception is called out on its r
 
 - **Version:** 17.5.0 (the version every `@object-ui/*` manifest carries — they are one
   `fixed` group in `.changeset/config.json`, so a release moves all of them together)
-- **Spec:** `@objectstack/spec` ^17.0.0-rc.6 (declared by the root `package.json` and by
+- **Spec:** `@objectstack/spec` ^17.0.0 (declared by the root `package.json` and by
   `apps/console/package.json`)
-- **Client:** `@objectstack/client` ^17.0.0-rc.6 (declared by `apps/console/package.json`
+- **Client:** `@objectstack/client` ^17.0.0 (declared by `apps/console/package.json`
   and `packages/data-objectstack/package.json`)
 - **Node.js:** ≥ 22 (see root `engines.node`)
 - **pnpm:** ≥ 9 (the workspace pins `pnpm@10.31.0` via `packageManager`)

--- a/packages/cli/src/utils/app-generator.ts
+++ b/packages/cli/src/utils/app-generator.ts
@@ -177,6 +177,23 @@ function buildAppDependencies(): Record<string, string> {
  * with an unsatisfiable import. Declaring it at the producer is the fix — the
  * alias becomes a workspace convenience rather than the only thing holding the
  * import up.
+ *
+ * Both ranges here are QUOTED from this repo, per the objectui#3742 /
+ * objectui#3754 anchoring discipline: `react-router-dom` from the root
+ * manifest, `lucide-react` from the sibling manifests that declare it (the root
+ * does not). `app-generator.test.ts`'s `DEPENDENCY_ANCHORS` names the anchor for
+ * each and fails when a bump on either side leaves this file behind — which is
+ * the whole reason the values are allowed to be literals at all.
+ *
+ * That gate is not decoration; it has fired. objectui#4968: a dependabot bump
+ * moved `lucide-react` across all 22 sibling manifests and this literal stayed
+ * a minor behind, so the pin went red on every open PR's merge ref until the
+ * literal caught up. Deriving the value instead was considered and rejected in
+ * that PR — 9 of the 13 anchored ranges quote the repo ROOT manifest, which is
+ * not published with this CLI, so there is no one derivation the whole table
+ * could share and a bespoke one for this single name would buy nothing. The
+ * durable cure is upstream of this file: the shards carrying the gate have to
+ * finish before a dependency PR can merge.
  */
 function buildRoutedAppDependencies(): Record<string, string> {
   const range = platformPackageRange();
@@ -184,7 +201,7 @@ function buildRoutedAppDependencies(): Record<string, string> {
     react: REACT_RANGE,
     'react-dom': REACT_RANGE,
     'react-router-dom': '^7.18.2',
-    'lucide-react': '^1.29.0',
+    'lucide-react': '^1.31.0',
     ...Object.fromEntries(PLATFORM_RUNTIME_PACKAGES.map((name) => [name, range]))
   };
 }

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -59,7 +59,7 @@ export const VITEST_SETUP_FILE = 'vitest.setup.ts';
  *
  * | dependency                  | range     | anchor                                     |
  * | --------------------------- | --------- | ------------------------------------------ |
- * | `@testing-library/jest-dom` | `^7.0.0`  | repo root package.json (also apps/console) |
+ * | `@testing-library/jest-dom` | `^7.0.1`  | repo root package.json (also apps/console) |
  * | `@testing-library/react`    | `^16.3.2` | repo root package.json (also apps/console) |
  * | `@vitejs/plugin-react`      | `^6.0.5`  | every `packages/plugin-*` (not in root)    |
  * | `jsdom`                     | `^30.0.1` | repo root package.json                     |
@@ -84,7 +84,7 @@ export const VITEST_SETUP_FILE = 'vitest.setup.ts';
  * monorepo, not a failing install.
  */
 const DEV_DEPENDENCIES: Record<string, string> = {
-  '@testing-library/jest-dom': '^7.0.0',
+  '@testing-library/jest-dom': '^7.0.1',
   '@testing-library/react': '^16.3.2',
   '@vitejs/plugin-react': '^6.0.5',
   jsdom: '^30.0.1',

--- a/packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts
+++ b/packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts
@@ -58,8 +58,33 @@ const noTypes = () => undefined;
  * it between @objectstack/spec 17.0.0-rc.2 and rc.5, and no builder operator
  * could author it. `containsCaseInsensitive` now does, so the entry is gone and
  * the parity assertion below is what holds that honest.
+ *
+ * `$like` and `$ilike` arrived with the `@objectstack/spec` 17.0.0 GA pin
+ * (objectui#4636). Their entry here is **undecided — see #4911**, and it claims
+ * nothing else: whether this builder should offer raw pattern matching at all is
+ * an authoring-surface question that has NOT been ruled on, so this is a CITED
+ * OPEN QUESTION, not a finding that the tokens should stay unauthorable. It was
+ * taken because the sweep below is red on `main` itself under the GA pin, which
+ * every open PR inherits (objectui#4977); the question keeps waiting on the
+ * maintainer either way.
+ *
+ * Harvest condition — a ruling on #4911 must change these two members or this
+ * paragraph. Neither survives the ruling untouched:
+ *
+ *   - ruled A (build the operators): delete both members and add the builder
+ *     operators that author them; the parity assertion below then holds that
+ *     honest, exactly as it did when objectui#4023 retired `$icontains`.
+ *   - ruled B (the builder will not offer raw pattern matching): rewrite this
+ *     paragraph as the refusal the ruling makes it — stated as a decision, with
+ *     the ruling's own reopen condition on the entry — and reopen #4911 if that
+ *     condition is ever met.
+ *
+ * Leaving it reading "undecided" after a ruling lands is the stale-exclusion rot
+ * this comment block already warns about, one level up: the ratchet below can
+ * only check that a member is still a spec operator, never that its reason is
+ * still the true one.
  */
-const KNOWN_UNREACHABLE = new Set(['$eq', '$between']);
+const KNOWN_UNREACHABLE = new Set(['$eq', '$between', '$like', '$ilike']);
 
 /** Pull the operator keys out of a `{ field: { $op: v } }` fragment. */
 function operatorsOf(frag: Record<string, any> | null): string[] {


### PR DESCRIPTION
Fixes #4977

基线:`origin/main` @ `590dd63560cdbc58439c0ffa5a58ac1bdd1100c7`(worktree 取的是 fetch 后的实 sha,不是 FETCH_HEAD)。

GA 批次(#4953-#4960)落 main 后 shard 3 的两处常红,任何 PR 的 merge-ref 都继承。两处**先在本基线复现红、再修绿**:

```
❯ scripts/__tests__/quick-reference-current-release-4143.test.ts (8 tests | 1 failed)
  AssertionError: QUICK_REFERENCE.md's "Current Release" block states ["^17.0.0-rc.6","^17.0.0-rc.6"],
  which no manifest in this tree produced. … Derived values are: ["17.5.0","^17.0.0", …]
❯ packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts (45 tests | 1 failed)
  AssertionError: FieldOperatorsSchema accepts these but no builder operator can author them:
  expected [ '$like', '$ilike' ] to deeply equal []
Test Files  2 failed (2) | Tests  2 failed | 51 passed (53)
```

## 1. quick-reference 的 Spec / Client 两行跟到 GA

`QUICK_REFERENCE.md` 的 `## Current Release` 块里,`@objectstack/spec` 与 `@objectstack/client` 仍写 `^17.0.0-rc.6`,而它自己在行内点名的锚(根 `package.json`、`apps/console/package.json`、`packages/data-objectstack/package.json`)已经是 `^17.0.0`。**改文档跟锚,钉一行没放宽** —— 期望值本来就是从 manifest 派生的,`scripts/__tests__/quick-reference-current-release-4143.test.ts` 一字未动。

这里有个值得写下来的细节:该钉的**正向**两条(Spec / Client 行必须 `toContain` manifest 声明的 range)在 rc.6 下**是绿的** —— 因为 `^17.0.0-rc.6` 作为字符串确实包含子串 `^17.0.0`。所以这处腐烂只有**反向**那条(「no un-derived literal」)抓得住,基线里 8 条只红 1 条正是这个原因。谁将来改这个块,别指望正向断言会兜住。

## 2. `$like` / `$ilike`:#2942 门的引用式豁免,措辞为「未裁」

GA 的 `FieldOperatorsSchema` 新增两个 token,builder 无对应算子,所以 #2942 可达性 sweep **按设计**报了它们。用该门自己设计的引用机制豁免,写进 `KNOWN_UNREACHABLE` 及其注释,**措辞按 #4911 评论区的纪律**:

- 写「**undecided — see #4911**」「a CITED OPEN QUESTION, not a finding that the tokens should stay unauthorable」;
- ⛔ **不写**「deliberately unsupported」之类 —— 那会预判尚未做出的 A/B 裁定;
- 注释里写死**收割条件**:裁 A 则删这两个成员并补算子(如 #4023 退役 `$icontains` 那样);裁 B 则把这段改写成「决定」并带上裁定给出的 reopen 条件。并点明为什么必须收割:下面那条 ratchet 只能检查成员**仍是 spec 算子**,永远检查不了它的**理由是否还成立**。

⛔ 未实现任何算子、未改门的其余逻辑。**A / B 的产品裁定完整留在 #4911 等维护者**;豁免一行可删。

## 反向验证(先书面预判,commit 后变异,`git checkout` 还原,⛔ 未用 stash)

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| 抠掉 `$like`/`$ilike` 两个成员 | **只**红 sweep 那条,报 `[ '$like', '$ilike' ]`;豁免喂的是**谓词**(`!KNOWN_UNREACHABLE.has(op)`)不是计数,少一个成员就回到被报数组里。ratchet 那条**必须仍绿**(成员少了仍都是 spec 算子)—— 若它也红,说明我加的 token 根本不是 spec key,豁免就是错的 | `× some builder operator emits every spec $-token` / `expected [ '$like', '$ilike' ] to deeply equal []` / `Tests 1 failed, 44 passed (45)` —— 与预判逐项一致,ratchet 绿 |
| 文档两行改回 `^17.0.0-rc.6` | **只**红反向那条(un-derived literal);正向两条因 `toContain` 子串关系**保持绿** | `× contains only version literals this test derives from a manifest` / `states ["^17.0.0-rc.6","^17.0.0-rc.6"]` / `Tests 1 failed, 7 passed (8)` —— 正向确实没红,如预判 |

即两处豁免/改动都**真在被读**,且两条钉红的方向都是事先说定的那一条。

## 验证

```
pnpm exec vitest run scripts/__tests__/quick-reference-current-release-4143.test.ts \
  packages/fields/src/widgets/__tests__/FilterConditionField.operators.test.ts --maxWorkers=2
  → Test Files 2 passed (2) | Tests 53 passed (53)      (改前:2 failed)

pnpm exec vitest run packages/fields/ scripts/__tests__/ --maxWorkers=2
  → Test Files 154 passed (154) | Tests 2887 passed (2887)   无连带

pnpm exec turbo run type-check --concurrency=2   → 81 successful, 81 total
node scripts/check-control-bytes.mjs             → OK (scanned 4435 tracked text file(s))
node scripts/check-changeset-presence.mjs        → OK(空 frontmatter changeset,按 #4808 先例)
```

另外自查了控制字节的门盲区:`grep -naP` 扫本 PR 三个文件,零命中。

## ⚠️ 未携带 #4968 / PR #4969 的 diff —— merge 被权限层拒绝,请 PM 定序

PM 加急指令要求本分支 `git merge origin/claude/issue-4968-lucide-range-hotfix`,让一单 PR 独立全绿。**我执行不了**:`git merge`(两种写法,含 `--no-ff -F msgfile`)都被权限分类器拒绝,而我的派发硬规同样是「⛔ 不 merge 任何东西」。⛔ 我没有绕开它 —— 也**没有**把 #4969 的两行 literal 手抄进本 PR:那会复制一张**已被认领的在途 PR** 的 diff,正是 AGENTS.md 禁止的「两个 agent 为同一问题落两个形状」。

死锁是真的,已实测(本分支 = main + 本 PR 两处修复):

```
pnpm exec vitest run packages/cli/src/__tests__/app-generator.test.ts packages/create-plugin/ --maxWorkers=2
  × sources every devDependency range from this repo instead of inventing them
  × sources every range from this repo instead of inventing one
  × writes a manifest whose @object-ui ranges name this CLI version
  AssertionError: routed manifest's lucide-react must match its in-repo range: expected '^1.29.0' to be '^1.31.0'
  AssertionError: @testing-library/jest-dom range must match the repo root: expected '^7.0.0' to be '^7.0.1'
  Tests  3 failed | 57 passed (60)
```

这 3 条红**不是本 PR 造成的**,它们活在纯 main 上,正是 PR #4969 修的面;而 PR #4969 红在本 PR 修的那两处。两张热修互卡。有 merge 权限的一方,一条命令即可把它们合成一单:

```
git checkout claude/issue-4977-ga-pin-residue
git merge --no-ff e7b77777b0c7f17557f344987d51865046d391db   # = origin/claude/issue-4968-lucide-range-hotfix
```

或者先落 PR #4969、再让本 PR rebase/合 main。**定序权在 PM**;本 PR 保持 draft 等加急验收。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_