### PR TITLE
docs(guide): plugin skeleton 声明 @vitejs/plugin-react,并把该行入版本声称锚 (#4961)

### DIFF
--- a/.changeset/plugin-guide-skeleton-react-plugin-dep-4961.md
+++ b/.changeset/plugin-guide-skeleton-react-plugin-dep-4961.md
@@ -1,0 +1,27 @@
+---
+---
+
+Docs + test-only (objectui#4961). The plugin skeleton in `content/docs/guide/plugins.md`
+contradicted itself across two adjacent steps: step 5 writes `vite.config.ts` with
+`import react from '@vitejs/plugin-react'` and calls `react()` in `plugins`, while step 6's
+`devDependencies` never declared that package — the import on step 5 was its only mention on
+the page. A reader following the numbered tutorial 1 through 6 therefore reached their first
+`pnpm build` with a config importing something they were never told to install, and the
+build failed while resolving the third line of the config. Fixed by declaring
+`"@vitejs/plugin-react": "^6.0.5"` in step 6, the range all 19 in-repo
+`packages/plugin-*` manifests declare unanimously.
+
+Same defect the closed objectui#3716 and #3742 fixed on the `create-plugin` generator side
+(a generated artifact declaring a usage without declaring its dependency); this
+hand-written page teaches the same thing and was never walked alongside them.
+
+The new literal is anchored rather than merely recorded: it joins
+`scripts/__tests__/doc-version-claims.test.ts` as a third `anchored` entry carrying
+`skeletonDep`, which objectui#3855's derived floor was built to absorb without a new
+mechanism, so the next toolchain bump turns the gate red naming that page. Two things on the
+same block were checked and deliberately left alone — the `peerDependencies` `react` range
+(what a copied plugin accepts from its host, which its author owns) and the absence of
+`vite-plugin-dts` (the skeleton emits declarations with `tsc --emitDeclarationOnly`, so it
+needs no dts plugin even though all 19 plugin manifests carry one). The assertion judges the
+range of a dependency the page already names; it never demands the page name every
+dependency the manifests do.

--- a/content/docs/guide/plugins.md
+++ b/content/docs/guide/plugins.md
@@ -398,6 +398,7 @@ export default defineConfig({
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
     "@object-ui/types": "workspace:*",
+    "@vitejs/plugin-react": "^6.0.5",
     "typescript": "^6.0.3",
     "vite": "^8.2.1"
   }

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -140,8 +140,8 @@ import { fileURLToPath } from 'node:url';
  * `packages/plugin-<name>` manifests declared `vite` `^8.2.1`, and the 16 that declare
  * `typescript` all said `^6.0.3`. An anchor that unanimous is not a judgement call.
  *
- * Hence `describe('the plugin-skeleton assertion')` below, and the `skeletonDep` field: the
- * two entries are now `anchored`, each naming the dependency whose range is READ off the
+ * Hence `describe('the plugin-skeleton assertion')` below, and the `skeletonDep` field: those
+ * entries are `anchored`, each naming the dependency whose range is READ off the
  * skeleton line and compared against the in-repo plugin manifests. The next toolchain bump
  * turns this file red naming that page, which is the half of #3855 that outlives the two
  * values it corrected — the values alone would re-fossilise on the next bump, and had
@@ -154,6 +154,40 @@ import { fileURLToPath } from 'node:url';
  * may legitimately widen or narrow it; a devDependency range says what gets INSTALLED to
  * build this thing here. objectui#3827's anchor table drew that line first and excluded
  * peer ranges from its anchor sources for the same reason.
+ *
+ * ## What objectui#4961 added: a third anchored line, and the limit of what this judges
+ *
+ * #4961 is the same page and the same block, arriving from the opposite direction: not a
+ * range that had drifted, but a dependency the block never declared AT ALL. Step 5 of the
+ * numbered tutorial writes `vite.config.ts` with `import react from '@vitejs/plugin-react'`
+ * and calls `react()` in `plugins`; step 6's `devDependencies` listed the three
+ * `workspace:*` deps, `typescript` and `vite`, and nothing else. That page-wide import was
+ * the only mention of the package on the page. A reader following 1 through 6 therefore hit
+ * their first `pnpm build` with a config importing something they were never told to
+ * install — the same defect the closed objectui#3716 and #3742 fixed on the
+ * `create-plugin` generator side, on a hand-written page nobody walked at the same time.
+ *
+ * It cost one doc line and one inventory entry, which is what #3855's second half was for:
+ * the derived floor in the unanimity test picks up a third `skeletonDep` without a new
+ * mechanism, and it is now three names rather than two. The entry itself is also the worked
+ * example of why `skeletonDep` is a written-out name and not something derived from the
+ * inventory key: the key the scan produces for that line is `react": "^6.0.5`, because
+ * `React` is a `TOOLCHAIN` word and the `-` in `@vitejs/plugin-react` is a word boundary,
+ * so the recorded literal is the TAIL of the package name and names a different package
+ * than the line declares. `parseManifestLine` reads the whole line, so the comparison is
+ * against `@vitejs/plugin-react` regardless.
+ *
+ * And the boundary, stated because this assertion invites exactly one wrong inference: it
+ * judges the RANGE of a dependency the page ALREADY NAMES. It does not, and must not, be
+ * read as "the skeleton should declare whatever the plugin manifests declare". All 19
+ * in-repo plugin manifests carry `vite-plugin-dts`; the skeleton has no such line and needs
+ * none, because its build script is `vite build && tsc --emitDeclarationOnly` and the
+ * declarations come from the compiler. Both spellings are internally consistent, so
+ * completing the skeleton from the manifest list would add a dependency nothing on the page
+ * uses. What made the plugin-react line belong was not its presence in the manifests but
+ * its use in step 5 — the page contradicted ITSELF, and the manifests only supplied the
+ * range once the line had to exist. The unanimity of an anchor decides which range to
+ * teach, never which dependencies a doc ought to have.
  *
  * ## The census that set the design (measured on d46b40324, the merge of PR #3698)
  *
@@ -563,6 +597,18 @@ const KNOWN_CLAIMS: KnownClaim[] = [
     claim: 'react": "^18.0.0',
     kind: 'sample',
     why: 'A peerDependencies range in the plugin skeleton: what the copied plugin ACCEPTS from its host, which its author owns and may legitimately widen or narrow. Stays a sample while the two devDependency ranges in the same block became anchored in objectui#3855 - installed-here versus accepted-from-the-host is the distinction, not which fence the line sits in.',
+  },
+  {
+    file: 'content/docs/guide/plugins.md',
+    // Reads as a `react` claim and is not one: the scan matches the TAIL of the scoped
+    // package name (`@vitejs/plugin-react`), because `React` is a TOOLCHAIN word and the
+    // `-` before it is a word boundary. The dep this entry is anchored on is the one
+    // `skeletonDep` names, which the assertion parses off the WHOLE line — this entry is
+    // the worked example of why that field is written out rather than derived from the key.
+    claim: 'react": "^6.0.5',
+    kind: 'anchored',
+    skeletonDep: '@vitejs/plugin-react',
+    why: 'The third devDependency of the same in-workspace skeleton, added in objectui#4961 - and added because it was MISSING, not because its range had drifted: step 5 of the same numbered tutorial imports @vitejs/plugin-react in vite.config.ts and calls react() in plugins, while step 6 never declared it, so a reader following 1-6 failed on their first pnpm build with an import of a package they were never told to install. Same shape as the closed objectui#3716 and #3742, which fixed it on the create-plugin generator side while this hand-written page was never walked. Anchored on the same unanimous evidence as its two neighbours: all 19 packages/plugin-<name> manifests declare ^6.0.5.',
   },
   {
     file: 'content/docs/guide/plugins.md',
@@ -1541,28 +1587,30 @@ describe('doc version claims - the plugin-skeleton assertion', () => {
 
     expect(
       skeletonChecks.length,
-      'no inventory entry carries skeletonDep - the two plugin-guide entries lost the field ' +
+      'no inventory entry carries skeletonDep - the three plugin-guide entries lost the field ' +
         'and are back to being recorded rather than checked',
-    ).toBeGreaterThanOrEqual(2);
+    ).toBeGreaterThanOrEqual(3);
 
     expect(
       skeletonChecks.reduce((n, check) => n + check.stated.length, 0),
       'the skeleton assertion compared implausibly few lines - the manifest-line parser or ' +
         'the claim resolution collapsed, and it is now green over nothing',
-    ).toBeGreaterThanOrEqual(2);
+    ).toBeGreaterThanOrEqual(3);
   });
 
   it('resolves the anchor unanimously, and would notice if it stopped being unanimous', () => {
     // The premise the assertion rests on, asserted rather than assumed: it is only fair to
     // pin a doc to "the" range if there is one. Measured at the #3855 cut - 19 plugin
-    // manifests declaring vite ^8.2.1, 16 of them typescript ^6.0.3.
+    // manifests declaring vite ^8.2.1, 16 of them typescript ^6.0.3; re-measured at the
+    // #4961 cut, which added the third name below - 19 of 19 on @vitejs/plugin-react ^6.0.5.
     //
     // Derived from the inventory rather than hardcoded, so a THIRD skeletonDep added later
-    // is covered by this premise too instead of resting on the assertion alone. The two
-    // names below are then a floor on that derivation: read from skeletonChecks and it
-    // could quietly become an empty loop, so the deps #3855 measured must still be in it.
+    // is covered by this premise too instead of resting on the assertion alone. #4961 was
+    // that third one and needed no change here beyond joining the list. The names below are
+    // then a floor on that derivation: read from skeletonChecks and it could quietly become
+    // an empty loop, so every dep measured so far must still be in it.
     const anchoredDeps = [...new Set(skeletonChecks.map((check) => check.dep))];
-    for (const measured of ['vite', 'typescript']) {
+    for (const measured of ['vite', 'typescript', '@vitejs/plugin-react']) {
       expect(
         anchoredDeps,
         `${measured} lost its skeletonDep entry - either the plugin guide stopped naming it ` +


### PR DESCRIPTION
Fixes #4961

同文件串行门:PR #4963 在派发前已落 main(merged 11:58:37Z,分诊认领评论 11:58:50Z),**无需等待循环**。本分支从其落地 sha `7d1017790` 切出,用的正是它落地的 `skeletonDep` 机制。

## 前提验证:成立,卡上三个测量值全部复核无漂移

三样都对着 `7d1017790` 重新读过,没有沿用卡上的数字:

| | 卡上写的 | 本次实测 |
| --- | --- | --- |
| step 5 的 import | `:340` `import react from '@vitejs/plugin-react'`,并在 `plugins: [react()]` 用掉 | ✅ 一字不差,行号仍是 340 |
| step 6 的 devDependencies | `:397-403`,五条,无 `@vitejs/plugin-react` | ✅ 成立;全页仅 `:340` 一次 import 提到该包 |
| 仓内锚 | `@vitejs/plugin-react ^6.0.5`,19/19 | **`^6.0.5`,19/19 全一致**(逐个 `packages/plugin-*/package.json` 读过) |

卡上写的「锚现成且一致,不需要任何判断」成立。与 #4963 的经历不同,这次九天里锚**没有**漂 —— 但仍是重测过才敢用。

## 改法(两个文件 + 一条 changeset)

1. `content/docs/guide/plugins.md:401` 的 devDependencies 增 `"@vitejs/plugin-react": "^6.0.5"`,按仓内 plugin 清单的字典序位置(`@object-ui/types` 之后、`typescript` 之前)。
2. `scripts/__tests__/doc-version-claims.test.ts`:第三条 `kind: 'anchored'` + `skeletonDep: '@vitejs/plugin-react'` 的 `KNOWN_CLAIMS` 条目;两条真空下限 2 提到 3;`resolves the anchor unanimously` 的派生下限名单加一个名字。**没有新机制** —— #4963 第 3 个 commit 留的派生下限正是为这种后续新增设计的,这一单是它的第一个用户。
3. 头部注释加一节 `## What objectui#4961 added`。

### 一处非显然的事实,值得点名而不是让下个读者踩

该行被扫出来的 claim key 是 **`react": "^6.0.5`**,不是 `@vitejs/plugin-react": "^6.0.5"`。原因:`React` 是 `TOOLCHAIN` 词,而 `@vitejs/plugin-react` 里 `react` 前面的 `-` 构成词边界,于是匹配从 `react` 起,记下的字面量是**包名的尾巴**,指向一个与该行实际声明**不同**的包。

这恰好是 `skeletonDep` 那段注释所说「dep 名写出来而不是从 claim 文本派生」的第一个真实用例 —— `parseManifestLine` 读**整行**,所以比对仍然打在 `@vitejs/plugin-react` 上(见下方变异 ②b/③ 的红法,报的是 `@vitejs/plugin-react` 而非 `react`,这就是机械证据)。条目上加了行内注释说明。

## 逆向验证:四个变异,方向都先预测后跑;两个的方向与任务卡的预设**不一致**,据实回报

任务卡给的两条是「①删掉新增行 → 骨架断言红;②版本改假值 → 锚红」。①如预期;②按字面做**到不了锚的比对支路**,原因是结构性的,与 #4963 变异 A 同一条:清单键内嵌版本字面量。下面把两半分开跑。

### 变异 ① —— 临时删掉新增的 doc 行

**预测:红 2 条,且骨架断言的红来自「真空下限」而非比对支路** —— 字面量离开树 → 条目变孤儿(上行棘轮红);`skeletonChecks` 该项 `absent: true` → 比对循环**故意跳过**,但 `stated` 为空 → 比对行数和从 3 掉到 2,撞下限。

```
× keeps the inventory honest - no entry may outlive the claim it excuses
  AssertionError: KNOWN_CLAIMS names version claims that are no longer in the tree
× pins the skeleton toolchain to the range the in-repo plugin packages declare
  AssertionError: the skeleton assertion compared implausibly few lines ...
  expected 2 to be greater than or equal to 3
  Tests  2 failed | 16 passed (18)
```

逐条对上。「骨架断言红」成立,但**红的是下限而不是比对** —— 据实写明,不套模板。

### 变异 ②a —— 只把 doc 里的值改成 `^9.9.9`(任务卡的字面读法)

**预测:红 3 条,锚的比对支路仍然跳过。** 键含版本字面量,所以改值同时造出一条未记账的新 claim(下行棘轮)并让旧条目变孤儿(上行棘轮),该项再次 `absent`。

```
× records every version literal on the scanned surfaces
  - content/docs/guide/plugins.md:401  "react": "^9.9.9"
× keeps the inventory honest ...
  - content/docs/guide/plugins.md :: react": "^6.0.5
× pins the skeleton toolchain ...   expected 2 to be greater than or equal to 3
  Tests  3 failed | 15 passed (18)
```

所以「版本改假值 → 锚红」按字面做不成立:值被两个方向的棘轮先钉住了,比对支路根本没轮到。要真的动到锚,得让**记下的字面量与 doc 行一致、而与仓内不一致** —— 即下面两个变异。

### 变异 ②b —— doc 值与清单键**同步**改成 `^9.9.9`(真实的误操作形状:页面和账本一起 bump 了,仓内没有)

**预测:恰好一条红,走比对支路,点名行号与两侧区间。**

```
× pins the skeleton toolchain ...
  - content/docs/guide/plugins.md:401  @vitejs/plugin-react: the page teaches "^9.9.9",
    every in-repo plugin package declares "^6.0.5"
  Tests  1 failed | 17 passed (18)
```

注意报的是 `@vitejs/plugin-react`,不是 claim key 里那个 `react` —— 上文那段的机械证据。

### 变异 ③ —— bump **全部 19 个** plugin 清单到 `^7.1.0`,文档留在原地

这才是这条门存在的那个场景(下次仓升级同一行再化石化)。**预测:恰好一条红走比对支路,且 `resolves the anchor unanimously` 保持绿** —— bump 做完了就是一致的,只有文档旧,两条断言判两件不同的事。

```
× pins the skeleton toolchain ...
  - content/docs/guide/plugins.md:401  @vitejs/plugin-react: the page teaches "^6.0.5",
    every in-repo plugin package declares "^7.1.0"
  Tests  1 failed | 17 passed (18)
```

### 变异 ④ —— 抽掉新条目的 `skeletonDep`(证我扩的那条派生下限真的咬)

**预测:红 2 条 —— 计数下限 + 派生名单点名新 dep。**

```
× pins the skeleton toolchain ...
  AssertionError: no inventory entry carries skeletonDep - the three plugin-guide entries
  lost the field ...: expected 2 to be greater than or equal to 3
× resolves the anchor unanimously ...
  AssertionError: @vitejs/plugin-react lost its skeletonDep entry - either the plugin guide
  stopped naming it or the inventory did ...
  expected [ 'typescript', 'vite' ] to include '@vitejs/plugin-react'
  Tests  2 failed | 16 passed (18)
```

四个变异全部还原后复跑 `18 passed`,`git status` 只剩本 PR 的三个文件。

## 测试

```
$ pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts
   Test Files  1 passed (1) ;  Tests  18 passed (18)      # 基线 18(#4963 后),条数不变
$ pnpm exec vitest run scripts/ --maxWorkers=2
   Test Files  50 passed (50) ;  Tests  1171 passed (1171)
$ pnpm run type-check:scripts                    exit=0
$ pnpm exec turbo run type-check --concurrency=2  Tasks: 81 successful, 81 total
$ pnpm exec eslint scripts/__tests__/doc-version-claims.test.ts   exit=0
$ node scripts/check-control-bytes.mjs   ✅ OK (scanned 4439 tracked text file(s); skipped 85 binary)
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' 本 PR 三个文件      0 命中
$ pnpm run changeset:check   ✅ fixed group OK;✅ 无 major
$ node scripts/check-doc-links.mjs   Links are valid across 13 scan roots.
```

新增字面量本身不新增测试条数 —— 它是被**现成断言**接住的,这正是 #4963 那半个交付物的目的;新增的覆盖体现在两条下限从 2 升到 3(变异 ①/④ 是它咬人的证据)。

## 消费半径扫过

按规则的调用者而非改动的包来扫:读 `guide/plugins.md` 的除本门禁外只有 `check-doc-links.mjs` 及其测试,后者用自建内存 fixture(`'guide/plugins.md': '[Charts](...)'`),不碰版本字面量。全仓 grep `plugin-myfeature` 只命中本 PR 这两个文件。另外 grep 了全仓 `@vitejs/plugin-react` 的其它拼写面(`packages/cli`、`packages/create-plugin` 的生成器测试、`content/docs/utilities/cli.mdx`),均未受本改动影响。

## 顺带核过、**明确没动**的两处(卡面预核,复核后同意)

- 骨架的 `peerDependencies` `react`/`react-dom` `^18.0.0 || ^19.0.0`:peer 说「拷走后向宿主接受什么」,由该插件作者拥有,与「在这里装什么来构建」是两件事。该条目照旧 `sample`。
- 骨架**没有** `vite-plugin-dts`,而 19 个 plugin 包都有 —— 不是缺项:骨架 build 脚本是 `vite build && tsc --emitDeclarationOnly`,声明文件由 tsc 自己出。两种写法都自洽。

这一点在头部注释里写成了显式边界,因为这条断言正好邀请一个错误推论:它判的是**页面已经命名的**依赖的区间,**不**是「骨架该声明仓内清单声明的一切」。让 plugin-react 该在的理由不是它出现在清单里,而是 step 5 用了它 —— **页面自我矛盾**,清单只在该行必须存在之后提供了区间。

## 另外两条纪律

- ⛔ 未触碰 `content/docs/releases/**`。
- ⛔ 未 force-push;单分支单 commit。

## 越界发现(只记录、不顺手修)

- **#4981** —— 做上面那轮消费半径扫描时扫到:`doc-version-claims` 的 `SCAN_ROOTS` 是 `['content/docs', 'packages/*/README.md']`,**不含 `skills/`**,而 `skills/objectui/guides/` 下两份带 `package.json` 代码块的脚手架指南共 4 处版本字面量从未被任何门禁读过 —— 实测 `typescript ^5.0.0`(差 1 个 major)、`vite ^6.0.0`(差 2 个)、`@vitejs/plugin-react ^4.0.0`(差 2 个)、`lucide-react ^0.400.0`(跨 major)。`check-skills-paths.mjs` 确实扫 skills 但只判路径。这条比 content/docs 面更值得看:`skills/` 是**给 agent 读的面**,化石会随每次脚手架复制进用户仓库。与 #4938(check-doc-links 的扫描面洞)完全同形但不同 gate、不同文件集合,故独立立卡、未标 label,交 PM 分诊。

另外**核过但判定不是缺陷**、故未立卡:`content/docs/guide/quick-start.md:45` 与 `building-crud-app.md:41` 同样 `import react from '@vitejs/plugin-react'` 却没有对应的 install 指令 —— 但这两页的第一步是 `pnpm create vite my-app --template react-ts`,该模板自带 `@vitejs/plugin-react`,所以 import 有着落,不是 #4961 那个形状。写在这里是因为「同一 import 出现在三页」很容易被机械判成三处同样的缺陷。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_