### PR TITLE
fix(data-objectstack): layered 读迁到声明路径 GET /meta/:type/:name/layers (#4016)

### DIFF
--- a/.changeset/layered-read-declared-path-4016.md
+++ b/.changeset/layered-read-declared-path-4016.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+`MetadataClient.layered()` now reads the three-layer view from its declared path,
+`GET /meta/:type/:name/layers`, instead of flagging the ordinary item read.
+
+The consumer half of objectstack#5882 (ruled B by the maintainer; the server half
+landed in objectstack#6596 and shipped in `@objectstack/spec@17.0.0`). The layered
+projection — packaged baseline vs tenant overlay vs merged effective, which is
+what the Studio metadata editor's comparison tabs render — used to be reached by
+hanging a query flag on `GET /meta/:type/:name`. One route therefore answered two
+unrelated representations chosen by a query parameter, while `packages/spec`
+declared only the unflagged one: anything generating a client from the route
+table produced a parser that was simply wrong for the flagged call. The
+projection now has a path of its own and a response schema of its own
+(`GetMetaItemLayeredResponseSchema`).
+
+Same body, same envelope, so nothing in the editor changes shape: `code`,
+`overlay`, `overlayScope`, `effective`, the load-time `_diagnostics` and the full
+ADR-0010 protection envelope all still arrive on one round trip, and `?package=`
+(ADR-0048) is still threaded — the two entry points are served by ONE handler
+upstream precisely so the deprecation window's promise holds. The retired
+spelling still answers during that window, marked with RFC 9745 `Deprecation` and
+an RFC 8288 `Link: rel="successor-version"` pointing here, so this migration is
+safe against a lagging backend for as long as the window stays open, and it is
+what lets the maintainer close it.
+
+One behaviour delta rides along, and it is the server's design rather than a
+choice made here: the retired flag FELL THROUGH to the plain item read when the
+backend's protocol implementation had no layered support, answering the
+`{ type, name, item }` envelope. A dedicated path refuses to answer a different
+resource under this one's declared shape and returns 501 `NOT_IMPLEMENTED`, which
+surfaces as a failed read instead of a comparison view whose `code` and `overlay`
+are silently blank.
+
+The request is built in this package rather than delegated to
+`@objectstack/client` because the SDK expresses no layered read in either
+spelling — the framework's REST route ledger records the route as `server-only`,
+"consumed by objectui over plain HTTP", and whether the SDK should express it is
+an open upstream product call. The new path expectation is derived from the
+installed `@objectstack/spec` route table, and a ratchet keeps any shipped source
+file or skills guide from reaching the projection by query flag again.

--- a/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
+++ b/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
@@ -12,7 +12,7 @@
  *   • Overlay   — pretty-printed JSON of just the deltas they've saved.
  *   • Effective — the merged value the runtime serves.
  *
- * Backed by `client.layered(type, name)` (Phase 3a `?layers=true`).
+ * Backed by `client.layered(type, name)`, i.e. `GET /meta/:type/:name/layers`.
  *
  * Diff scope: top-level keys only. Nested objects/arrays are compared by
  * JSON-stringify equality. Drilling into nested diffs is a future

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.fieldEnvelope.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.fieldEnvelope.test.tsx
@@ -79,7 +79,17 @@ function realClient(): MetadataClient {
     baseUrl: 'http://localhost:3000',
     fetch: (async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('/meta/permission/sales_perms?layers=true')) {
+      // The layered read's declared path (objectstack#5882 ruling B, migrated
+      // in objectui#4016). Kept exact so this double stays truthful about what
+      // the real client puts on the wire — the next reader copies from here.
+      //
+      // Measured, not assumed: it carries no assertion pressure. Reverting the
+      // client to the retired query flag leaves all three cases below GREEN,
+      // because the layered body only feeds the artifact-backed verdict and the
+      // permission draft, and the field sub-table these cases assert is fed by
+      // the `get()` read further down. The URL itself is pinned where it belongs,
+      // in `packages/data-objectstack/src/metadata-client.layeredRoute.test.ts`.
+      if (url.endsWith('/meta/permission/sales_perms/layers')) {
         return json({
           code: null,
           overlay: null,

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -4,8 +4,8 @@
  * MetadataResourceEditPage — generic AutoForm-driven editor (Phase 3c).
  *
  * What it does:
- *   1. Fetches the layered view (`?layers=true`) so the user sees code
- *      vs overlay vs effective.
+ *   1. Fetches the layered view (`GET /meta/:type/:name/layers`) so the user
+ *      sees code vs overlay vs effective.
  *   2. Renders a SchemaForm against the JSONSchema in the type's
  *      `/meta/types` registry row.
  *   3. Save → PUT, with automatic destructive-change handling: a 409

--- a/packages/data-objectstack/src/metadata-client.layeredRoute.test.ts
+++ b/packages/data-objectstack/src/metadata-client.layeredRoute.test.ts
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4016 — `MetadataClient.layered()` reads the three-layer projection
+ * from the path the framework DECLARES for it, `GET /meta/:type/:name/layers`,
+ * instead of flagging the ordinary item read.
+ *
+ * Why the move (objectstack#5882, ruled B by the maintainer; server half landed
+ * in objectstack#6596): one route was answering two unrelated representations
+ * chosen by a query flag, while `packages/spec` declared only the unflagged one.
+ * Anything generating a client from the route table — SDK annotations, codegen,
+ * an AI-written integration — produced a parser that was simply wrong for the
+ * flagged call. The projection now has a path of its own AND a response schema
+ * of its own (`GetMetaItemLayeredResponseSchema`); the flag still answers the
+ * same body during a deprecation window, marked with RFC 9745 `Deprecation` and
+ * an RFC 8288 `Link: rel="successor-version"`, and is scheduled for removal.
+ *
+ * `@objectstack/client` is not in the picture on purpose: the SDK expresses no
+ * layered read in either spelling (the framework's REST route ledger records
+ * this route as `server-only`, "consumed by objectui over plain HTTP"), so this
+ * package builds the request and these cases are what hold it to the contract.
+ *
+ * The path expectation is DERIVED from the installed `@objectstack/spec` route
+ * table rather than retyped here — a hand-copied string would keep passing
+ * after the producer moved the route, which is the failure mode this whole card
+ * exists to remove.
+ *
+ * The repo-wide half — that no shipped source file or skills guide reaches the
+ * projection by query flag any more — is a ratchet over a scan surface wider
+ * than this package, so it lives in
+ * `scripts/__tests__/layered-read-declared-path-4016.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_METADATA_ROUTES,
+  GetMetaItemLayeredResponseSchema,
+} from '@objectstack/spec/api';
+import { MetadataClient } from './metadata-client';
+
+const BASE_URL = 'http://localhost:3000';
+
+/** The layered endpoint as the installed spec declares it. */
+function specLayeredEndpoint() {
+  const endpoints = (DEFAULT_METADATA_ROUTES as { endpoints: Array<Record<string, unknown>> }).endpoints;
+  const matches = endpoints.filter((e) => e.handler === 'getMetaItemLayered');
+  // If the producer ever declares this handler twice (or drops it), the
+  // expectation below is meaningless — say so instead of silently picking one.
+  expect(matches).toHaveLength(1);
+  return matches[0] as { method: string; path: string; responseSchema?: string };
+}
+
+/** `http://host/api/v1/meta/object/showcase_project/layers`, spec-derived. */
+function specLayeredUrl(type: string, name: string): string {
+  const prefix = (DEFAULT_METADATA_ROUTES as { prefix: string }).prefix;
+  const suffix = specLayeredEndpoint().path
+    .replace(':type', type)
+    .replace(':name', name);
+  return `${BASE_URL}${prefix}${suffix}`;
+}
+
+/** A client over a fetch that records the URL and answers `body`. */
+function clientAnswering(body: unknown, status = 200) {
+  const urls: string[] = [];
+  const client = new MetadataClient({
+    baseUrl: BASE_URL,
+    fetch: (async (input: RequestInfo | URL) => {
+      urls.push(String(input));
+      return new Response(status === 204 ? null : JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch,
+  });
+  return { client, urls };
+}
+
+/**
+ * Exactly what the declared body carries — every layer, the load-time
+ * diagnostics and the full ADR-0010 protection envelope. Validated against the
+ * producer's own schema below, so the equivalence case cannot be green against
+ * a shape no server sends.
+ */
+const LAYERED_BODY = {
+  type: 'object',
+  name: 'showcase_project',
+  code: { name: 'showcase_project', label: 'Project', fields: { code: { type: 'text' } } },
+  overlay: { label: 'Projects (ours)' },
+  overlayScope: 'org',
+  effective: { name: 'showcase_project', label: 'Projects (ours)', fields: { code: { type: 'text' } } },
+  _diagnostics: { valid: false, errors: [{ path: 'label', message: 'too long', code: 'too_big' }] },
+  lock: 'no-delete',
+  lockReason: 'shipped by the crm package',
+  lockSource: 'package',
+  lockDocsUrl: 'https://docs.objectstack.ai/metadata/locks',
+  provenance: 'package',
+  packageId: 'crm',
+  packageVersion: '1.2.3',
+  editable: true,
+  deletable: false,
+  resettable: true,
+} as const;
+
+describe('objectui#4016 · the layered read goes to its declared path', () => {
+  it('is declared by the installed spec as a GET on its own path with its own schema', () => {
+    const endpoint = specLayeredEndpoint();
+    expect(endpoint.method).toBe('GET');
+    expect(endpoint.path).toBe('/:type/:name/layers');
+    // The point of ruling B: a representation of its own, not a second shape
+    // hiding behind the item read's schema.
+    expect(endpoint.responseSchema).toBe('GetMetaItemLayeredResponseSchema');
+  });
+
+  it('requests the spec-declared path and carries no `layers` query flag', async () => {
+    const { client, urls } = clientAnswering(LAYERED_BODY);
+
+    await client.layered('object', 'showcase_project');
+
+    expect(urls).toEqual([specLayeredUrl('object', 'showcase_project')]);
+    // Belt and braces on the retired spelling: the flag is gone as a QUERY
+    // parameter, not merely relocated inside the string.
+    expect(urls[0]).not.toMatch(/[?&]layers=/);
+    expect(urls[0]).not.toContain('?');
+  });
+
+  it('leads the query string with `?package=` instead of trailing it (ADR-0048)', async () => {
+    const { client, urls } = clientAnswering(LAYERED_BODY);
+
+    await client.layered('object', 'showcase_project', { packageId: 'crm/base' });
+
+    // The migration's live trap: the package id used to be appended with `&`
+    // behind the flag. Left as `&` it would have fused onto the last PATH
+    // segment (`…/layers&package=crm%2Fbase`), which matches no route — a 404
+    // that `layered()` reports as an empty-but-successful layered view.
+    expect(urls).toEqual([`${specLayeredUrl('object', 'showcase_project')}?package=crm%2Fbase`]);
+    expect(urls[0]).not.toContain('layers&');
+  });
+
+  it('percent-encodes the type and name into the path', async () => {
+    const { client, urls } = clientAnswering(LAYERED_BODY);
+
+    await client.layered('object', 'a/b c');
+
+    expect(urls).toEqual([`${BASE_URL}/api/v1/meta/object/a%2Fb%20c/layers`]);
+  });
+
+  it('hands back every layer and protection carrier the declared body sends', async () => {
+    // Guard the fixture first: a value verdict is being asserted, so the body
+    // must parse fully green against the producer's schema, not merely avoid
+    // unknown keys.
+    const parsed = GetMetaItemLayeredResponseSchema.safeParse(LAYERED_BODY);
+    expect(parsed.success).toBe(true);
+
+    const { client } = clientAnswering(LAYERED_BODY);
+
+    const layered = await client.layered<Record<string, unknown>>('object', 'showcase_project');
+
+    // Behaviour equivalence with the retired spelling: same envelope, same
+    // keys, `type` / `name` still dropped (the caller passed them in).
+    expect(layered).toEqual({
+      code: LAYERED_BODY.code,
+      overlay: LAYERED_BODY.overlay,
+      overlayScope: 'org',
+      effective: LAYERED_BODY.effective,
+      _diagnostics: LAYERED_BODY._diagnostics,
+      lock: 'no-delete',
+      lockReason: 'shipped by the crm package',
+      lockSource: 'package',
+      lockDocsUrl: 'https://docs.objectstack.ai/metadata/locks',
+      provenance: 'package',
+      packageId: 'crm',
+      packageVersion: '1.2.3',
+      editable: true,
+      deletable: false,
+      resettable: true,
+    });
+  });
+
+  it('reports an unknown item as an empty layered view (404)', async () => {
+    const { client } = clientAnswering({ error: 'not found' }, 404);
+
+    await expect(client.layered('object', 'nope')).resolves.toEqual({
+      code: null,
+      overlay: null,
+      overlayScope: null,
+      effective: null,
+    });
+  });
+
+  it('throws when the backend cannot serve the projection (501)', async () => {
+    // The one intentional behaviour delta of the move, and it is the server's
+    // call, not this client's: the retired flag FELL THROUGH to the plain item
+    // read on a backend whose protocol implementation had no layered support,
+    // answering `{ type, name, item }`. A dedicated path refuses to answer a
+    // different resource under this one's declared shape and returns 501
+    // `NOT_IMPLEMENTED` — which must surface, not degrade into a view whose
+    // `code` and `overlay` are blank for a reason the operator cannot see.
+    const { client } = clientAnswering(
+      { error: 'Layered metadata view not supported by protocol implementation', code: 'NOT_IMPLEMENTED' },
+      501,
+    );
+
+    await expect(client.layered('object', 'showcase_project')).rejects.toThrow();
+  });
+});

--- a/packages/data-objectstack/src/metadata-client.ts
+++ b/packages/data-objectstack/src/metadata-client.ts
@@ -239,7 +239,14 @@ export interface MetadataDeleteOptions extends MetadataClientSaveOptions {
   state?: 'active' | 'draft';
 }
 
-/** Layered view of a metadata item — Phase 3a `?layers=true`. */
+/**
+ * Layered view of a metadata item — the body of
+ * `GET /meta/:type/:name/layers` (`GetMetaItemLayeredResponseSchema`).
+ *
+ * A subset by design: the response also carries `type` / `name`, which the
+ * caller already knows because it passed them in, so
+ * {@link MetadataClient.layered} does not hand them back.
+ */
 export interface MetadataLayered<T = unknown> {
   /** Code-level (artifact) item; null if the item only exists as an overlay. */
   code: T | null;
@@ -803,17 +810,49 @@ export class MetadataClient {
   }
 
   /**
-   * Get the 3-state layered view of a metadata item (Phase 3a). Returns
-   * `code` (the artifact / fallback default), `overlay` (the saved
-   * customisation, if any), and `effective` (what the runtime sees).
+   * Get the 3-state layered view of a metadata item: `code` (the packaged
+   * artifact baseline), `overlay` (the tenant customisation row alone) and
+   * `effective` (the merged value the runtime sees).
+   *
+   * Reads **`GET /meta/:type/:name/layers`** — the path the framework declares
+   * for this projection, with a response schema of its own
+   * (`GetMetaItemLayeredResponseSchema`, objectstack#5882 ruling B). It used to
+   * be reached by hanging a `layers` flag on the ordinary item read, which made
+   * one route answer two unrelated representations while `packages/spec`
+   * declared only one of them. That spelling still answers this same body
+   * inside its deprecation window (the response carries RFC 9745
+   * `Deprecation: true` and an RFC 8288 `Link: rel="successor-version"` back to
+   * this path) and is scheduled for removal upstream, so nothing here may
+   * depend on it — the repo-wide ratchet is
+   * `scripts/__tests__/layered-read-declared-path-4016.test.ts`.
+   *
+   * The request is built here rather than delegated to `@objectstack/client`
+   * because the SDK expresses no layered read in EITHER spelling: the
+   * framework's REST route ledger records this route as `server-only`,
+   * "consumed by objectui over plain HTTP", and whether the SDK should express
+   * it is an open upstream product call.
+   *
+   * One behaviour delta rides along with the path, and it is the server's
+   * choice rather than ours: the retired flag FELL THROUGH to the plain item
+   * read on a backend whose protocol implementation had no layered support,
+   * answering the `{ type, name, item }` envelope. A dedicated path refuses to
+   * answer a different resource under this one's declared shape, so it returns
+   * 501 `NOT_IMPLEMENTED` instead — which surfaces here as a thrown error
+   * rather than a view with `code` and `overlay` silently blank.
    */
   async layered<T = unknown>(
     type: string,
     name: string,
     options: { packageId?: string } = {},
   ): Promise<MetadataLayered<T>> {
-    const pkg = options.packageId ? `&package=${encodeURIComponent(options.packageId)}` : '';
-    const url = `${this.base}/${encodeURIComponent(type)}/${encodeURIComponent(name)}?layers=true${pkg}`;
+    // ADR-0048 — `?package=` scopes resolution to one installed package (the
+    // editor passes the edited item's owning package, not the Studio app's).
+    // It leads the query string now that the flag it used to trail is gone:
+    // keeping the `&` would have appended it to the last PATH segment
+    // (`…/layers&package=crm`), which matches no route — a 404 that this
+    // method turns into an empty-but-successful layered view.
+    const qs = options.packageId ? `?package=${encodeURIComponent(options.packageId)}` : '';
+    const url = `${this.base}/${encodeURIComponent(type)}/${encodeURIComponent(name)}/layers${qs}`;
     const res = await this.fetchImpl(url, { method: 'GET', headers: this.headers, cache: 'no-store' });
     if (res.status === 404) {
       return { code: null, overlay: null, overlayScope: null, effective: null };
@@ -822,6 +861,13 @@ export class MetadataClient {
     const body = (await res.json()) as MetadataLayered<T> & Record<string, unknown>;
     const hasEnvelope =
       body && (('code' in body) || ('overlay' in body) || ('effective' in body));
+    // Left standing, but no longer reachable from a conforming server: the only
+    // producer of a 200 body WITHOUT these keys was the retired flag's
+    // fall-through to the plain item read, and the declared path answers 501
+    // there. Kept out of this migration's scope on purpose — deleting it is a
+    // behaviour change for a non-conforming backend, not part of moving the
+    // request — and filed as objectui#4983 for removal once the upstream
+    // deprecation window closes.
     if (!hasEnvelope) {
       return {
         code: null,

--- a/scripts/__tests__/layered-read-declared-path-4016.test.ts
+++ b/scripts/__tests__/layered-read-declared-path-4016.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#4016 ratchet — nothing in this repo reaches the metadata LAYERED
+ * projection by hanging a query flag on the ordinary item read.
+ *
+ * The projection (packaged baseline / tenant overlay / merged effective, which
+ * is what Studio's metadata-editor comparison tabs render) has a path and a
+ * response schema of its own: `GET /meta/:type/:name/layers`, declared by
+ * `@objectstack/spec` with `GetMetaItemLayeredResponseSchema`
+ * (objectstack#5882, ruled B by the maintainer; server half objectstack#6596).
+ * Before that ruling, one route answered two unrelated representations chosen
+ * by a query parameter while the spec declared only the unflagged one, so any
+ * client generated from the route table was simply wrong for the flagged call.
+ *
+ * The retired spelling still answers the same body during a deprecation window,
+ * advertised with RFC 9745 `Deprecation: true` and an RFC 8288
+ * `Link: rel="successor-version"` pointing at the new path — which means a
+ * regression here CANNOT be caught by anything failing. It would keep working,
+ * quietly, until the maintainer closes the window; and closing the window is
+ * exactly what this repo moving off the flag is supposed to unblock. Hence a
+ * ratchet rather than trust.
+ *
+ * Why it lives in `scripts/__tests__` rather than beside the client: its scan
+ * surface is the whole repo (the packages that build metadata requests, the apps
+ * that could hand-roll one, and the skills guides that teach AI agents how). The
+ * transport-level cases — that `MetadataClient.layered()` requests the
+ * spec-declared path, leads the query string with `?package=`, and reports the
+ * declared body unchanged — live in
+ * `packages/data-objectstack/src/metadata-client.layeredRoute.test.ts`.
+ *
+ * Reverse verification (direction predicted before running, then measured):
+ * restoring the retired spelling in `MetadataClient.layered()` turns this RED by
+ * naming that file in `offenders` — the assertion fails because it PRODUCED a
+ * finding, not because it produced nothing. The two floors below exist for the
+ * other direction: a walk that silently scanned zero files would otherwise pass
+ * with an empty `offenders` and report the repo clean.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** Source files that could construct a metadata request, tests excluded. */
+function walkSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === '__tests__') continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walkSources(full, out);
+    else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** Skills guides — what an AI agent reads before writing console code. */
+function walkMarkdown(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules') continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walkMarkdown(full, out);
+    else if (entry.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The retired spelling as a QUERY parameter. Deliberately broader than the one
+ * value this repo used: the first version of this projection was reached with a
+ * layer LIST rather than a boolean, and either form is the same mistake now.
+ *
+ * Matching on `[?&]` is what keeps it off the many legitimate uses of the word —
+ * the editor's `'layers'` sheet id, `engine.edit.layers` i18n keys, and prose
+ * about "three layers" are all untouched. CHANGELOG files are out of the scan
+ * surface by construction: they are history, and history did use the flag.
+ */
+const RETIRED_FLAG = /[?&]layers=/;
+
+describe('objectui#4016 ratchet · nothing reaches the layered projection by query flag', () => {
+  it('no shipped source file and no skills guide names the retired flag', () => {
+    // Both halves of the consumption radius: the packages that build the
+    // request and the apps that could hand-roll one beside them.
+    const sources = ['packages', 'apps']
+      .flatMap((group) => {
+        const groupDir = path.join(repoRoot, group);
+        return readdirSync(groupDir).map((pkg: string) => path.join(groupDir, pkg, 'src'));
+      })
+      .filter((src) => {
+        try {
+          return statSync(src).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .flatMap((src) => walkSources(src));
+    const guides = walkMarkdown(path.join(repoRoot, 'skills'));
+
+    // A scan that scanned nothing passes for the wrong reason. Both floors sit
+    // far below the real counts (1327 sources / 18 guides when this was
+    // written) — they fail a broken walk, not a growing repo.
+    expect(sources.length).toBeGreaterThan(800);
+    expect(guides.length).toBeGreaterThan(5);
+
+    const offenders = [...sources, ...guides]
+      .filter((file) => RETIRED_FLAG.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(repoRoot, file));
+
+    // If this fails: call `client.layered(type, name)` from
+    // `@object-ui/data-objectstack`, which reads the declared
+    // `GET /meta/:type/:name/layers`. The flag it replaced answers the same body
+    // only until the maintainer closes the deprecation window, and the response
+    // already says so in its `Deprecation` / `Link` headers.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/skills/objectui/guides/console-development.md
+++ b/skills/objectui/guides/console-development.md
@@ -211,8 +211,11 @@ generic-engine defaults can be registered independently.
    `type: 'permission'`.
 2. Otherwise it picks a schema: `createSchema` in create mode, else the `/meta/types`
    row's `schema`, else the registry's `defaultSchema`.
-3. Fetches the layered view (`?layers=true`) so code / overlay / effective are all
-   visible, and renders `SchemaForm` against that schema.
+3. Fetches the layered view (`GET /meta/:type/:name/layers`, via `client.layered()`) so
+   code / overlay / effective are all visible, and renders `SchemaForm` against that
+   schema. That projection has a path and a response schema of its own
+   (`GetMetaItemLayeredResponseSchema`); the older spelling that flagged the ordinary
+   item read is deprecated upstream — don't reintroduce it.
 4. Save → PUT. A `409 destructive_change` opens a confirmation dialog and retries with
    `?force=true`. Reset overlay → DELETE. The References tab calls `client.references()`
    so an admin sees the back-pointers before deleting.


### PR DESCRIPTION
Fixes #4016

os#5882 B 案的**消费半边**:Studio 元数据编辑页的三层对比读,从「给普通条目读挂一个查询标记」迁到声明路径 `GET /meta/:type/:name/layers`。服务端半边是 os#6596,已随 `@objectstack/spec@17.0.0` GA 落到本仓 pin(dependabot `7484f7f0a` / PR #4953)。

## 一、前提测量(动工前先量,三项)

**1. GA 契约在位。** 本仓解析到的 `@objectstack/spec@17.0.0` 里,`DEFAULT_METADATA_ROUTES` 声明了 `GET /:type/:name/layers`(prefix `/api/v1/meta`,handler `getMetaItemLayered`,responseSchema `GetMetaItemLayeredResponseSchema`),且该 schema 确实从 `@objectstack/spec/api` 导出(运行时 `typeof` 为 function)。spec 自己的 route 描述也写明老拼法「still works during its deprecation window but is answered with `Deprecation` / `Link` headers pointing here」。

**2. GA 客户端没有 layered 方法 —— 但这不是「缺口」。** `@objectstack/client@17.0.0` 整包 grep `layered` 零命中,两种拼法都没有。framework `origin/main`(e4e5c6e3c)的 `packages/rest/src/rest-route-ledger.ts` 把该路由记作 `disposition: 'server-only'`,note 原文:「consumed by objectui over plain HTTP, and the SDK expressed no layered read under the `?layers=` spelling either」,并明确把「SDK 是否应当表达它」留作独立的产品决定。**所以本仓继续手工构造该请求,是台账声明的消费方式,不是绕过 SDK**;本 PR 只搬路径,不新增任何手拼 URL(那一处手拼在改动前就已经存在)。

**3. 调用点清单。** 构造该查询串的地方全仓**只有一处**:`packages/data-objectstack/src/metadata-client.ts` 的 `MetadataClient.layered()`。app-shell 共 **15** 个 `client.layered()` 调用点全部经由它,零个自己拼 URL —— `studio-design/` 6 处(`PackageOwdOverviewPanel` 2、`StudioDesignSurface` 4),`metadata-admin/` 9 处(`ResourceEditPage` 5、`PermissionMatrixEditor` 3、`EmbeddedItemEditor` 1)。除此之外还有:1 个按老 URL 匹配的 fetch 测试替身、3 处注释、1 处技能指南正文提到老拼法。

前提成立,`premise_still_valid: true`。

## 二、改了什么

- `MetadataClient.layered()` 改读 `…/:type/:name/layers`。
- **迁移里唯一的活陷阱是 package 参数的连接符**:它此前以 `&` 挂在标记后面。留着 `&` 会把它焊到最后一个 **PATH 段**上(`…/layers&package=crm`),不匹配任何路由 —— 404,而 `layered()` 把 404 报成「空但成功」的层视图,**静默**。已改成 `?package=` 并单独钉了一条。
- 老拼法归零:注释、技能指南、测试替身一并改到新路径,并加了一条 ratchet 扫描 `packages/*/src`、`apps/*/src` 与 `skills/**/*.md`,阻止任何出货源文件或技能指南再用查询标记去取该投影。

**信封不变(行为等价)**:`code` / `overlay` / `overlayScope` / `effective`、载入期 `_diagnostics`、ADR-0010 完整保护信封仍在同一次往返里回来,`?package=`(ADR-0048)照旧透传 —— 上游两个入口由**同一个** handler 服务,正是为了让弃用窗口的承诺成立。

**一条行为差异,是服务端的设计而不是本仓的选择**:被弃用的标记在后端 protocol 实现缺 `getMetaItemLayered` 时会**下坠**到普通条目读、答 `{ type, name, item }` 信封;专用路径拒绝用本路径声明的形状去答另一个资源,改答 **501 `NOT_IMPLEMENTED`**(rest-server.ts 该挂载点注释原话:「A dedicated path cannot fall through to the plain read the way the flag did」)。于是这里表现为**抛错**,而不是 `code` / `overlay` 无故空白的对比视图。这条已单独钉住。

新测试的路径期望**派生**自装到本地的 `@objectstack/spec` 路由表,而不是抄一份字符串 —— 抄的那份在生产者搬路由之后仍然会绿,而那正是这张卡要消除的失效模式。信封等价那条先用生产者自己的 `GetMetaItemLayeredResponseSchema` 校验 fixture(断的是**值**的判定,所以要求 full parse 绿,不是只看没有 `unrecognized_keys`),再断言解析结果逐键相等。

## 三、反向验证(先预判,后跑;`git checkout` 还原,未用 stash)

**预判(跑之前写下)**:把 `layered()` 的 URL 改回老拼法(含 `&package=`)后 ——

1. ratchet 红,且是**多出一条发现**而红(offenders 从 `[]` 变成 1 个文件),不是「什么都没产出」的空绿;
2. `metadata-client.layeredRoute.test.ts` 7 条里 **3 红 4 绿**:红的是 3 条 URL 钉,绿的 4 条(spec 声明、信封等价、404、501)**必须**保持绿 —— 它们量的是「回来的东西没变」,而本 PR 改的是「去哪里取」;它们若也红,说明我顺手改了行为;
3. app-shell `PermissionMatrixEditor.fieldEnvelope.test.tsx` 红(替身按新路径精确匹配,老拼法会掉到 catch-all)。

**实测**:1 与 2 与预判逐条一致 ——

```
× scripts/__tests__/layered-read-declared-path-4016.test.ts > ... names the retired flag
  → expected [ Array(1) ] to deeply equal []
  +   "packages/data-objectstack/src/metadata-client.ts",
✓ ... > is declared by the installed spec as a GET on its own path with its own schema
× ... > requests the spec-declared path and carries no `layers` query flag
× ... > leads the query string with `?package=` instead of trailing it (ADR-0048)
× ... > percent-encodes the type and name into the path
✓ ... > hands back every layer and protection carrier the declared body sends
✓ ... > reports an unknown item as an empty layered view (404)
✓ ... > throws when the backend cannot serve the projection (501)
Test Files  2 failed | 1 passed (3)      Tests  4 failed | 7 passed (11)
```

**第 3 条预判错了,如实报告**:`PermissionMatrixEditor.fieldEnvelope.test.tsx` 三条全绿。原因是那个替身的 layered 分支**对该文件的断言没有任何压力**:layered body 只喂「是否 artifact-backed」的判定与 permission 草稿,而这三条断言的字段子表是由下面那条 `get()` 读喂的;掉到 catch-all 的 `{ items: [] }` 也不影响它们(`client.layered(...).catch(() => null)` 是 `PermissionMatrixEditor.tsx:433` 有意的 fail-open,注释已论证过「a transient read failure must not invent a lock」)。

我原本在那处替身上写了一句「老拼法会掉到 catch-all 并把断言一起带红」的注释 —— 实测证明那是假的,已把注释改成实测结论,并注明 URL 的钉在 data-objectstack 那份测试里。替身仍改到新路径:留着老拼法会让这个「用真 client 答真服务端形状」的替身对着线上撒谎,下一个读者会从这里抄走已弃用的拼法。

## 四、测试

仓根跑法(AGENTS.md §9 唯一正确写法),全部在共享验证锁内串行:

- `pnpm exec vitest run packages/data-objectstack/ scripts/__tests__/layered-read-declared-path-4016.test.ts packages/app-shell/src/views/metadata-admin/` → `Test Files 213 passed (213)` / `Tests 2267 passed | 1 skipped (2268)`
- `turbo run type-check --filter=@object-ui/data-objectstack --filter=@object-ui/app-shell` → `Tasks: 31 successful, 31 total`(首轮曾红:ratchet 用 node 内建但 data-objectstack 的 tsconfig 不带 node types —— 这也是把 ratchet 放进 `scripts/__tests__/` 的原因,那里 `types: ["node"]` 且由 `pnpm type-check:scripts` 与 ci.yml 覆盖)
- `pnpm type-check:scripts` → exit 0
- `check:control-bytes` / `check:changeset-presence` / `check:changeset-no-major` / `check:spec-symbols` / `check:phantom-deps` / `check:self-import` / `check:skills-paths` / `check:type-check-coverage` / `check:lint-coverage` → 全绿
- 改动文件 `eslint` → 0 error(只剩本文件既有的 `no-explicit-any` warning,均在未改动行)

## 五、相邻发现(未在本 PR 修)

- **#4982**(未打 finding,具体缺陷):`MetadataLayered.overlayScope` 类型是 `string`、注释声称 `organization | environment | package | null`,而 GA spec 与 framework 生产者都只有 `org` / `env` / null;`LayeredDiff.tsx` 把该原值直接当徽标渲染,同行另外三个层标签都过 `translateConsoleValue` —— zh-CN 下「有 overlay」的条目显示裸英文 `org` / `env`,「没有 overlay」的回退支才是翻译过的。
- **#4983**(`finding`,观察类):`layered()` 里那段「非 layered 信封」兜底在迁到新路径后已不可达(唯一生产者是老拼法的下坠,新路径答 501)。故意留在本 PR 之外 —— 删它是对「不合规后端」的行为变更,不属于搬路径这件事;等上游关掉弃用窗口后一并删。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_