### PR TITLE
test(cli,create-plugin): 两处生成器锚规则改累积报全部漂移,前置与漂移分开 (#4974)

### DIFF
--- a/.changeset/anchor-drift-cumulative-report-4974.md
+++ b/.changeset/anchor-drift-cumulative-report-4974.md
@@ -1,0 +1,12 @@
+---
+---
+
+Test-only: the two generator anchor rules — `packages/cli`'s app/init manifests and
+`packages/create-plugin`'s template devDependencies — now collect every drifted range and
+report them from a single assertion, instead of one `expect` per name that threw on the
+first mismatch. A dependabot batch that moves several in-repo ranges is one round of
+repair rather than one round per name, and which name got reported no longer depends on
+its position in the anchor table. The preconditions (the anchor must resolve; in-repo
+manifests must agree) still fail fast and are kept in a separate pass, so a repo-state
+failure is never reported as, or beside, template drift. No published behaviour changes
+(objectui#4974).

--- a/packages/cli/src/__tests__/app-generator.test.ts
+++ b/packages/cli/src/__tests__/app-generator.test.ts
@@ -332,6 +332,16 @@ function inRepoRangesOf(name: string): Record<string, string[]> {
  * objectui#3852 migrated that pipeline — so Tailwind anchors to this repo like
  * everything else. See `keeps the generated Tailwind pipeline v4 end to end`
  * below for what replaced the ledger.
+ *
+ * TWO RULES READ THIS MAP, and they are complements — stated together here
+ * because they live in separate `it`s below, where neither is visible from the
+ * other (objectui#4974): the range rule judges ONLY the names listed here, and
+ * the completeness rule requires the union of the three generated dependency
+ * maps to equal this key set exactly. So a dependency added to any generator
+ * without an entry here is not silently unjudged — it fails `keeps all three
+ * generated dependency maps under one anchor table`, and entering it here is
+ * what puts its range under the anchor gate at all. Add the dependency and its
+ * anchor in the same change.
  */
 const DEPENDENCY_ANCHORS: Record<string, 'root' | 'in-repo' | 'cli-version'> = {
   '@object-ui/components': 'cli-version',
@@ -536,44 +546,74 @@ describe('generated app manifests', () => {
     const plain = allRangesOf(buildAppPackageJson(STANDALONE));
     const init = allRangesOf(buildInitPackageJson('sample-app'));
     const cliVersion = readManifest(CLI_MANIFEST_PATH).version as string;
+    /**
+     * Every manifest that declares the name, so all of them are judged rather
+     * than just the first — one generator anchored and another fossilised is
+     * exactly the state objectui#3892 found, and reading `routed ?? plain ??
+     * init` would have reported it green.
+     */
+    const declaredBy = (name: string) => ({
+      routed: routed[name],
+      plain: plain[name],
+      init: init[name]
+    });
 
+    // Pass 1 — the PRECONDITIONS, which are facts about THIS REPO rather than
+    // drift in a generated range: a name no generator declares at all, a `root`
+    // anchor the root manifest no longer carries, an in-repo split with no
+    // single range to quote. They keep throwing on the first failure, and they
+    // all run before any range is compared, so a broken precondition can never
+    // be reported as drift nor read as crosstalk beside one (objectui#4974).
+    // There is nothing to accumulate here either: with the anchor unresolvable
+    // there is no expectation to compare a generated range against.
+    const expectedRanges: Record<string, { range: string; source: string }> = {};
     for (const [name, anchor] of Object.entries(DEPENDENCY_ANCHORS)) {
-      // Every manifest that declares the name is judged, not just the first —
-      // one generator anchored and another fossilised is exactly the state
-      // objectui#3892 found, and reading `routed ?? plain ?? init` would have
-      // reported it green.
-      const declaredBy = { routed: routed[name], plain: plain[name], init: init[name] };
       expect(
-        Object.values(declaredBy).some((range) => range !== undefined),
+        Object.values(declaredBy(name)).some((range) => range !== undefined),
         `${name} must be declared by at least one generator`
       ).toBe(true);
 
-      for (const [generator, generated] of Object.entries(declaredBy)) {
-        if (generated === undefined) continue;
-        const where = `${generator} manifest's ${name}`;
+      if (anchor === 'cli-version') {
+        expectedRanges[name] = { range: `^${cliVersion}`, source: "this CLI's own version" };
+        continue;
+      }
 
-        if (anchor === 'cli-version') {
-          expect(generated, `${where} must track this CLI's own version`).toBe(`^${cliVersion}`);
-          continue;
-        }
+      if (anchor === 'root') {
+        const rootRange = rootRangeOf(name);
+        expect(rootRange, `${name} must exist in the root manifest`).toBeTruthy();
+        expectedRanges[name] = { range: rootRange as string, source: 'the repo root' };
+        continue;
+      }
 
-        if (anchor === 'root') {
-          const rootRange = rootRangeOf(name);
-          expect(rootRange, `${name} must exist in the root manifest`).toBeTruthy();
-          expect(generated, `${where} must match the repo root`).toBe(rootRange);
-          continue;
-        }
+      const byRange = inRepoRangesOf(name);
+      const ranges = Object.keys(byRange);
+      expect(ranges.length, `${name} must be declared in-repo to anchor to`).toBeGreaterThan(0);
+      expect(
+        ranges.sort(),
+        `in-repo manifests disagree on ${name}: ${JSON.stringify(byRange)} — settle on one range first`
+      ).toHaveLength(1);
+      expectedRanges[name] = { range: ranges[0], source: 'its in-repo range' };
+    }
 
-        const byRange = inRepoRangesOf(name);
-        const ranges = Object.keys(byRange);
-        expect(ranges.length, `${name} must be declared in-repo to anchor to`).toBeGreaterThan(0);
-        expect(
-          ranges.sort(),
-          `in-repo manifests disagree on ${name}: ${JSON.stringify(byRange)} — settle on one range first`
-        ).toHaveLength(1);
-        expect(generated, `${where} must match its in-repo range`).toBe(ranges[0]);
+    // Pass 2 — the DRIFT, accumulated and reported by a single assertion, which
+    // is what objectui#4974 is about. The per-name `expect` this replaced threw
+    // on the first mismatch, and the table is walked in insertion order, so
+    // which drift you were told about depended on a name's POSITION in the
+    // table rather than on anything about the defect: objectui#4098 had five
+    // bumps hidden behind the first, and objectui#4968 had six hidden behind
+    // `lucide-react` — measuring the real size of that batch needed a throwaway
+    // script, because the gate would only ever name one. One dependabot round
+    // moving several ranges is now one round of repair, and every line carries
+    // the generator, the name, the generated range and the range it must be, so
+    // the whole batch is fixable from one failure report.
+    const drifted: string[] = [];
+    for (const [name, { range, source }] of Object.entries(expectedRanges)) {
+      for (const [generator, generated] of Object.entries(declaredBy(name))) {
+        if (generated === undefined || generated === range) continue;
+        drifted.push(`${generator} manifest's ${name}: ${generated} must match ${source}, ${range}`);
       }
     }
+    expect(drifted).toEqual([]);
   });
 
   it('names every range the pre-fix init manifest had drifted on', () => {

--- a/packages/create-plugin/src/__tests__/templates.test.ts
+++ b/packages/create-plugin/src/__tests__/templates.test.ts
@@ -129,6 +129,14 @@ function inRepoPluginManifests(): Record<string, Manifest> {
  * Every key of the generated `devDependencies` must appear here — the
  * completeness test below fails on an unanchored addition, so this map cannot
  * quietly go back to covering a subset (objectui#3742).
+ *
+ * That completeness rule and the range rule are complements, stated together
+ * here because they live in separate `it`s below where neither is visible from
+ * the other (objectui#4974): the range rule judges ONLY the names listed here,
+ * so entering the table is what puts a new template devDependency under the
+ * anchor gate at all, and `anchors every devDependency range, leaving none
+ * unpinned` is what makes skipping the entry impossible rather than silent. Add
+ * the devDependency and its anchor in the same change.
  */
 const DEV_DEPENDENCY_ANCHORS: Record<string, 'root' | 'in-repo-plugins'> = {
   '@testing-library/jest-dom': 'root',
@@ -349,11 +357,20 @@ describe('generated package.json', () => {
     // this test exists to catch — update `src/templates.ts` in the same PR.
     const generated = generatedDevDependencies(VARS);
 
+    // Pass 1 — the PRECONDITIONS, which are facts about THIS REPO rather than
+    // drift in a generated range: a `root` anchor the root manifest no longer
+    // carries, an in-repo split with no single range to quote. They keep
+    // throwing on the first failure, and they all run before any range is
+    // compared, so a broken precondition can never be reported as drift nor
+    // read as crosstalk beside one (objectui#4974). Nothing to accumulate here
+    // either: with the anchor unresolvable there is no expectation to compare a
+    // generated range against.
+    const expectedRanges: Record<string, { range: string; source: string }> = {};
     for (const [name, anchor] of Object.entries(DEV_DEPENDENCY_ANCHORS)) {
       if (anchor === 'root') {
         const rootRange = rootRangeOf(name);
         expect(rootRange, `${name} must exist in the root manifest`).toBeTruthy();
-        expect(generated[name], `${name} range must match the repo root`).toBe(rootRange);
+        expectedRanges[name] = { range: rootRange as string, source: 'the repo root' };
         continue;
       }
 
@@ -367,8 +384,24 @@ describe('generated package.json', () => {
         ranges.sort(),
         `in-repo plugins disagree on ${name}: ${JSON.stringify(byRange)} — settle on one range first`
       ).toHaveLength(1);
-      expect(generated[name], `${name} range must match packages/plugin-*`).toBe(ranges[0]);
+      expectedRanges[name] = { range: ranges[0], source: 'its in-repo plugin range' };
     }
+
+    // Pass 2 — the DRIFT, accumulated and reported by a single assertion
+    // (objectui#4974). Per-name `expect` threw on the first mismatch, so a
+    // dependabot round moving several of these ranges was one round of repair
+    // PER NAME, and which name you were told about depended on its POSITION in
+    // the table. It cost this file directly: the testing-library range sat
+    // drifted on `main` while the sibling generator's table in `packages/cli`
+    // was still red, so nothing reported it until that one was green
+    // (objectui#4968). Each line carries the name, the generated range and the
+    // range it must be, so the whole batch is fixable from one failure report.
+    const drifted: string[] = [];
+    for (const [name, { range, source }] of Object.entries(expectedRanges)) {
+      if (generated[name] === range) continue;
+      drifted.push(`${name}: ${generated[name]} must match ${source}, ${range}`);
+    }
+    expect(drifted).toEqual([]);
   });
 
   it('keeps the two anchors consistent wherever both declare a dependency', () => {


### PR DESCRIPTION
Fixes #4974

## 现象与根因

全仓两个「生成器模板区间 = 仓内区间」的 ratchet 规则,都在 `for` 循环里逐名 `expect`:

- `packages/cli/src/__tests__/app-generator.test.ts` — `sources every range from this repo instead of inventing one`(`DEPENDENCY_ANCHORS`,22 个名字 × 三份生成清单)
- `packages/create-plugin/src/__tests__/templates.test.ts` — `sources every devDependency range from this repo instead of inventing them`(`DEV_DEPENDENCY_ANCHORS`,8 个名字)

`expect` 失败即抛,表又是插入序遍历的,所以一轮只报第一个不匹配的名字,而**被报的是「谁排在前面」,不是「谁更严重」**。这条代价兑现过两次:#4098 有五个同窗 bump 藏在第一个后面;#4968 里 `lucide-react` 排在 `postcss` / `react` / `tailwindcss` / `typescript` / `vite` 之前,遮住后面六个名字的判定 —— 当时只能另写脚本把两张表全量算一遍,才敢说这批 dependabot 到底漂了几处。

## 改法:两趟,前置与漂移分开

两处都拆成两趟(卡面要点 1):

1. **前置断言** —— 「名字至少被一个生成器声明」「`root` 锚必须在根清单里」「仓内区间必须一致」都是关于**仓库状态**的前提,保持首败即抛;并且整趟跑在**任何区间比对之前**。锚不可解析时本来也没有可累积的期望值,更重要的是:前置败时**不产出任何漂移行**,不会让读者以为模板错了(见反向验证 ②)。
2. **漂移断言** —— 收齐全部不匹配后一次断言空集,逐条带生成器、名字、实得区间、应得区间与锚来源。

顺带把两张锚表的文档块补上那对互补关系(卡面末段):范围规则**只判本表内的名字**,完备性规则要求生成清单的键集**恰好等于**本表 —— 两条规则分居两个 `it`,读任一处都看不到另一处。

## 反向验证(方向先预判,后跑;commit 后变异,`git checkout` 还原)

**① 同时漂多处(核心验收,复刻 #4968 形状)** —— 把 cli 侧 `lucide-react` 改回 `^1.29.0`、`typescript` 改回 `^5.9.3`(排位在 lucide 之后,正是旧形态下被遮的那一类),create-plugin 侧 `@testing-library/jest-dom` 改回 `^7.0.0`。预判「一轮全报」,实测新形态一次运行给出:

```
FAIL packages/cli/.../app-generator.test.ts > sources every range from this repo instead of inventing one
AssertionError: expected [ …(4) ] to deeply equal []
+   "routed manifest's lucide-react: ^1.29.0 must match its in-repo range, ^1.31.0",
+   "routed manifest's typescript: ^5.9.3 must match the repo root, ^6.0.3",
+   "plain manifest's typescript: ^5.9.3 must match the repo root, ^6.0.3",
+   "init manifest's typescript: ^5.9.3 must match the repo root, ^6.0.3",

FAIL packages/create-plugin/.../templates.test.ts > sources every devDependency range …
+   "@testing-library/jest-dom: ^7.0.0 must match the repo root, ^7.0.1",
```

同一变异下把两个测试文件换回 base sha 的旧版本(源码变异不动),旧形态实测:

```
AssertionError: routed manifest's lucide-react must match its in-repo range: expected '^1.29.0' to be '^1.31.0'
AssertionError: @testing-library/jest-dom range must match the repo root: expected '^7.0.0' to be '^7.0.1'
```

—— `typescript` 的三份清单**一个字都没报**。这就是「一轮修一个」的直接测量。

**② 前置破坏 → 只红前置、不红漂移**,两半都跑了:

- **②a 锚表抠一条** —— 从 `DEPENDENCY_ANCHORS` 删掉 `typescript` 一行。预判「完备性红、漂移绿」,实测 `1 failed | 40 passed`:红的只有 `keeps all three generated dependency maps under one anchor table`(报文点名多出的 `typescript`),漂移那条绿 —— 该名字退出判定面,不产出任何漂移行,也不冒充漂移。
- **②b 前置与漂移同时存在,且前置名次在后** —— 把一份 plugin 清单的 `lucide-react` 改成 `^1.30.0`(制造仓内分裂,表内第 15 位),同时让 `@tailwindcss/postcss`(第 10 位)漂。预判「新形态只报前置」,实测新形态报文只有 `in-repo manifests disagree on lucide-react: {…} — settle on one range first`,**没有一条 postcss 漂移行**;旧形态同一变异只报 `routed manifest's @tailwindcss/postcss must match its in-repo range: expected '^4.1.18' to be '^4.3.3'`,仓内分裂完全不可见 —— 照旧形态报文去改模板,改完会再撞上「锚本身有歧义」,正是卡面担心的串扰误导。

**③ 单漂对照(报文可读性等价)** —— 只漂 `lucide-react`。新形态 `routed manifest's lucide-react: ^1.29.0 must match its in-repo range, ^1.31.0`;旧形态 `routed manifest's lucide-react must match its in-repo range: expected '^1.29.0' to be '^1.31.0'`。名字、锚来源、实得、期望四项齐全,信息量未减,只是从 vitest 的 `Object.is` 差异挪进报文的一行。

## 刻意没动的一处

同文件的 `writes a manifest whose @object-ui ranges name this CLI version` 也是逐名 `expect`(9 个平台包,末尾另有一条 lucide 断言)。没改,理由是它判的是**同一批事实**:那 9 个区间同出一源(CLI 自身版本),而 lucide 那条与本 PR 改过的累积规则重合 —— 任何一处漂移都会被上面那条断言完整列出,所以此处遮蔽不增加修复轮数。它的另一个问题(取仓内区间的任意一员而不断言一致性)已单独立卡 **#4991**,不并入本 PR。

## 测试

```
pnpm exec vitest run packages/cli packages/create-plugin --maxWorkers=2
  Test Files  6 passed (6)     Tests  138 passed (138)

turbo run type-check --concurrency=2
  Tasks: 81 successful, 81 total     Time: 5m45s

node scripts/check-control-bytes.mjs
  OK (scanned 4439 tracked text file(s))
```

另对改动的三个文件做了一次控制字符自扫(超出该门扫描面的那些码位),零命中。changeset 为测试-only 的空 frontmatter 声明,照 `.changeset/app-shell-props-block-4808.md` 先例。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_