### PR TITLE
fix(components,plugin-detail): element:text.content / element:button.label 声明真实联合,第 6、7 个标本停止对合法写入告警 (#4970)

### DIFF
--- a/.changeset/element-text-button-i18n-arms-4970.md
+++ b/.changeset/element-text-button-i18n-arms-4970.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/components': minor
+'@object-ui/plugin-detail': minor
+---
+
+`element:text.content` and `element:button.label` declare the inline translation
+map they already accept
+
+Two more instances of the contradiction objectui#3832 fixed the mechanism for,
+measured after that ruling had fixed its scope at five specimens and filed
+separately as objectui#4970. Both inputs' own `description` tells the author to
+write an inline translation map (`{ en, "zh-CN", … }`), both renderers resolve one
+through `pickLocalized`, and both spec props schemas accept one — while the
+declaration said `type: 'string'`, so the manifest gate reported
+`type-mismatch` on the exact shape the block had recommended. Both blocks are in
+`PUBLIC_BLOCKS`, so this reached authors through `sdui.manifest.json` and
+`sdui-intrinsics.d.ts` as well as the save gate.
+
+Each declaration is now `type: ['string', 'object']`, the union form
+objectui#3832 introduced, and the arms are the ones the contract accepts —
+re-measured on the `@objectstack/spec` 17.0.0 GA pin rather than carried over
+from the issue, which was written at the 17.0.0-rc.6 pin:
+`ComponentPropsMap['element:text'].content` and
+`ComponentPropsMap['element:button'].label` are both
+`string | Record< string, string >`, and both refuse a number, a boolean and an
+array. Those three refusals are the controls in the acceptance test, which is
+what keeps a widening distinguishable from a silenced check.
+
+Nothing else about the two blocks moves. A plain-string `content` / `label`
+validates exactly as before, values matching neither arm are still reported, and
+no other manifest entry changes shape — the public manifest now carries seven
+array-valued input types, the five from objectui#3832 plus these two, with the
+remaining 57 public blocks serializing byte for byte as they did.
+
+`record:alert`'s renderer-local prop type is corrected in the same pass
+(`plugin-detail`): its `title` / `body` were still typed `string` while the same
+file resolves both through `pickLocalized` and the block's published `inputs`
+have declared `['string', 'object']` since objectui#3832. The type is not
+exported, so no consumer was misled and no published surface changes — it was
+simply the last place in the package still claiming the map form was not accepted
+there.

--- a/.changeset/element-text-button-i18n-arms-4970.md
+++ b/.changeset/element-text-button-i18n-arms-4970.md
@@ -35,7 +35,9 @@ remaining 57 public blocks serializing byte for byte as they did.
 `record:alert`'s renderer-local prop type is corrected in the same pass
 (`plugin-detail`): its `title` / `body` were still typed `string` while the same
 file resolves both through `pickLocalized` and the block's published `inputs`
-have declared `['string', 'object']` since objectui#3832. The type is not
-exported, so no consumer was misled and no published surface changes — it was
-simply the last place in the package still claiming the map form was not accepted
-there.
+have declared `['string', 'object']` since objectui#3832, so the two slots were
+narrower than both the renderer and the block's own published surface. The type
+is not exported, so no consumer was misled and no published surface changes. The
+CTA's `action.label` one level down is left alone on purpose (objectui#4998):
+`action` is published as a bare `object` whose member shape lives in prose, so
+there are no declared arms for it to be aligned against yet.

--- a/apps/console/src/__tests__/component-input-union-specimens.test.ts
+++ b/apps/console/src/__tests__/component-input-union-specimens.test.ts
@@ -40,11 +40,24 @@
  * Module-scope imports, not `beforeAll` (AGENTS.md §测试纪律): the specimens
  * resolve through registration side-effects, and paying that at import time
  * keeps it out of every test/hook timeout budget.
+ *
+ * ## Specimens 6 and 7 — objectui#4970
+ *
+ * `element:text.content` and `element:button.label` are the same shape and were
+ * measured during #3832's implementation, after the ruling had already fixed its
+ * scope at "the five measured specimens" — so they were filed separately rather
+ * than folded in, and land here in their own `describe` below. Their arms are
+ * derived from the spec's own verdicts rather than restated, which is the
+ * discipline `text-input-inputs-spec-parity.test.ts` adopted for the fifth
+ * specimen: the gap #3832 closed is EXPRESSIVENESS, and whether a declared arm
+ * matches the contract is nobody's gate (objectui#4971), so per-key derivation
+ * is what stands in for one.
  */
 import { describe, it, expect } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
 import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
 import type { Diagnostic, SchemaElement } from '@object-ui/sdui-parser';
+import { ElementButtonPropsSchema, ElementTextPropsSchema } from '@objectstack/spec/ui';
 import '@object-ui/components';
 import '../register-plugins';
 
@@ -71,6 +84,40 @@ const declaredArms = (type: string, input: string): string[] => {
   const declared = manifest.components[type]?.inputs.find((i) => i.name === input)?.type;
   return Array.isArray(declared) ? declared : [declared as string];
 };
+
+/**
+ * One representative value per coarse arm, in the vocabulary `checkType`'s
+ * `armAccepts` uses (`packages/sdui-parser/src/validate.ts`).
+ *
+ * `['Account']` earns its place: the `'object'` arm accepts a non-null non-array
+ * object and nothing else, so an array is the value that tells "declares the
+ * object arm" apart from "stopped checking non-primitives".
+ */
+const COARSE_ARM_PROBES: ReadonlyArray<readonly [string, unknown]> = [
+  ['string', 'Account'],
+  ['object', I18N_MAP],
+  ['number', 42],
+  ['boolean', true],
+  ['array', ['Account']],
+];
+
+type SpecPropsSchema = { safeParse: (value: unknown) => { success: boolean } };
+
+/**
+ * The coarse arms a spec props schema ACCEPTS for one key — derived from the
+ * schema's own verdicts, not read off its Zod internals and not restated here
+ * (objectui#4970).
+ *
+ * Restating them would pin the declaration and leave the fact the declaration
+ * exists FOR — that the arms are the ones the contract accepts — unmeasured,
+ * which is the disposition `text-input-inputs-spec-parity.test.ts` took for the
+ * fifth specimen. Derived, either side moving turns the comparison red: a spec
+ * release that drops an arm, or a declaration that grows one the spec rejects.
+ */
+const specAcceptedArms = (schema: SpecPropsSchema, key: string): string[] =>
+  COARSE_ARM_PROBES.filter(([, value]) => schema.safeParse({ [key]: value }).success).map(
+    ([arm]) => arm,
+  );
 
 describe('objectui#3832 — the five measured specimens declare their real unions', () => {
   it('every specimen block is registered (reachability before absence)', () => {
@@ -182,5 +229,89 @@ describe('objectui#3832 — the five measured specimens declare their real union
     expect(codesFor({ type: 'element:record_picker', emptyText: I18N_MAP })).toContain(
       'type-mismatch',
     );
+  });
+});
+
+/**
+ * objectui#4970 — specimens 6 and 7, the two the #3832 table missed.
+ *
+ * Same contradiction, same evidence: both keys are `required: true`, both blocks
+ * are in `PUBLIC_BLOCKS` (`packages/core/src/registry/public-blocks.ts:89` /
+ * `:91`) so they reach `sdui.manifest.json` and `sdui-intrinsics.d.ts`, both
+ * descriptions tell the author to write an inline translation map, and both
+ * renderers resolve one (`elements.tsx`, `pickLocalized` at the `content` and
+ * `label` read sites). Only the declared arm disagreed.
+ *
+ * Controls are paired per specimen for the reason the #3832 block states above,
+ * and they are not decoration: reverting `checkType`'s any-arm logic leaves the
+ * positives vacuously green — the array-valued `type` falls into the old
+ * `switch`'s `default: return null` and the prop produces nothing at all — so the
+ * controls are the only half that moves.
+ */
+describe('objectui#4970 — element:text.content / element:button.label declare their real unions', () => {
+  it('both specimen blocks are registered (reachability before absence)', () => {
+    // Without this, an unregistered or renamed block satisfies every
+    // "no type-mismatch" assertion below by never being validated at all —
+    // an absent block reports `unknown-component`, a different code, and the
+    // filters here are per-code by design.
+    for (const type of ['element:text', 'element:button']) {
+      expect(manifest.components[type], `${type} is not registered`).toBeDefined();
+    }
+  });
+
+  it('the installed spec accepts the string and inline-map arms on both keys, and no others', () => {
+    // Guards the derivation before anything is compared against it: a schema
+    // that rejected every probe (a renamed key, a new sibling required key)
+    // would return `[]` and make the two comparisons below agree vacuously.
+    //
+    // Measured on the `@objectstack/spec` 17.0.0 GA pin, which is what makes
+    // these arms honest rather than copied from the issue — #4970's own table
+    // was measured at the 17.0.0-rc.6 pin, and the answer had to be re-taken
+    // before the declarations moved.
+    expect(specAcceptedArms(ElementTextPropsSchema, 'content')).toEqual(['string', 'object']);
+    expect(specAcceptedArms(ElementButtonPropsSchema, 'label')).toEqual(['string', 'object']);
+  });
+
+  it('`element:text.content` accepts the inline translation map', () => {
+    expect([...declaredArms('element:text', 'content')].sort()).toEqual(
+      [...specAcceptedArms(ElementTextPropsSchema, 'content')].sort(),
+    );
+
+    expect(
+      diagnose({ type: 'element:text', content: I18N_MAP }).filter(
+        (d) => d.code === 'type-mismatch',
+      ),
+    ).toEqual([]);
+
+    // …and the plain-string arm keeps validating clean (that half must not move).
+    expect(
+      diagnose({ type: 'element:text', content: 'Account' }).filter(
+        (d) => d.code === 'type-mismatch',
+      ),
+    ).toEqual([]);
+
+    // CONTROL — values matching NEITHER arm are still reported. The spec refuses
+    // both (measured above), so the gate must too.
+    expect(codesFor({ type: 'element:text', content: 42 })).toContain('type-mismatch');
+    expect(codesFor({ type: 'element:text', content: ['Account'] })).toContain('type-mismatch');
+  });
+
+  it('`element:button.label` accepts the inline translation map', () => {
+    expect([...declaredArms('element:button', 'label')].sort()).toEqual(
+      [...specAcceptedArms(ElementButtonPropsSchema, 'label')].sort(),
+    );
+
+    expect(
+      diagnose({ type: 'element:button', label: I18N_MAP }).filter(
+        (d) => d.code === 'type-mismatch',
+      ),
+    ).toEqual([]);
+    expect(
+      diagnose({ type: 'element:button', label: 'Save' }).filter((d) => d.code === 'type-mismatch'),
+    ).toEqual([]);
+
+    // CONTROL
+    expect(codesFor({ type: 'element:button', label: true })).toContain('type-mismatch');
+    expect(codesFor({ type: 'element:button', label: ['Save'] })).toContain('type-mismatch');
   });
 });

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -106,7 +106,15 @@ ComponentRegistry.register('text', ElementTextRenderer, {
   label: 'Text',
   category: 'content',
   inputs: [
-    { name: 'content', type: 'string', label: 'Content', required: true, description: 'Accepts an inline translation map ({ en, "zh-CN", … })' },
+    // Two arms, because the contract has two (objectui#3832 mechanism,
+    // objectui#4970 specimen). The spec accepts a plain string OR an inline
+    // translation map here — measured against `ComponentPropsMap['element:text']`
+    // on the 17.0.0 GA pin, where `content` is `string | Record< string, string >`
+    // — and the renderer resolves the map form through `pickLocalized` at the read
+    // site above. While this said `type: 'string'` the manifest gate reported
+    // `type-mismatch` on the map form, which is the shape this input's own
+    // description teaches the author to write.
+    { name: 'content', type: ['string', 'object'], label: 'Content', required: true, description: 'Accepts an inline translation map ({ en, "zh-CN", … })' },
     { name: 'variant', type: 'enum', label: 'Variant', enum: ['heading', 'subheading', 'body', 'caption'], defaultValue: 'body' },
     { name: 'align', type: 'enum', label: 'Align', enum: ['left', 'center', 'right'], defaultValue: 'left' },
   ],
@@ -316,7 +324,11 @@ ComponentRegistry.register('button', ElementButtonRenderer, {
   // and gates on visible/enabled predicates. This one carries an inline
   // ActionDef — the standalone-page button.
   inputs: [
-    { name: 'label', type: 'string', label: 'Label', required: true, description: 'Accepts an inline translation map ({ en, "zh-CN", … })' },
+    // Two arms, on the same evidence as `element:text.content` above
+    // (objectui#4970): `ComponentPropsMap['element:button'].label` is
+    // `string | Record< string, string >` on the 17.0.0 GA pin, and the rendered
+    // label goes through `pickLocalized`.
+    { name: 'label', type: ['string', 'object'], label: 'Label', required: true, description: 'Accepts an inline translation map ({ en, "zh-CN", … })' },
     { name: 'action', type: 'object', label: 'Action', description: 'Inline ActionDef executed on click (url / navigation / api / script / modal / flow); omitted → renders inert' },
     { name: 'variant', type: 'enum', label: 'Variant', enum: ['primary', 'secondary', 'danger', 'ghost', 'link'], defaultValue: 'primary' },
     { name: 'size', type: 'enum', label: 'Size', enum: ['small', 'medium', 'large'], defaultValue: 'medium' },

--- a/packages/plugin-detail/src/renderers/record-alert.tsx
+++ b/packages/plugin-detail/src/renderers/record-alert.tsx
@@ -73,9 +73,14 @@ type Severity = 'info' | 'warning' | 'error' | 'success';
  * (objectui#4970): both are read through `pickLocalized` further down, and the
  * block's published authoring surface declares the two arms
  * (`plugin-detail/src/index.tsx`, `type: ['string', 'object']` since
- * objectui#3832). While these said `string`, this file was the last place in the
- * package still claiming the map form was not accepted here — the
+ * objectui#3832), so while these two said `string` they were narrower than both
+ * the renderer and this block's own published surface — the
  * declaration-narrower-than-the-renderer family of objectui#4581.
+ *
+ * The CTA's `action.label` below is the same slot one level down and is
+ * deliberately NOT widened here (objectui#4998): its published surface declares
+ * `action` as a bare `object` with the member shape in prose only, so the arms it
+ * would be aligned against do not exist yet.
  */
 interface RecordAlertProps {
   schema?: {

--- a/packages/plugin-detail/src/renderers/record-alert.tsx
+++ b/packages/plugin-detail/src/renderers/record-alert.tsx
@@ -56,15 +56,33 @@ import {
 import { Alert, AlertTitle, AlertDescription, Button, cn, LazyIcon } from '@object-ui/components';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionDef } from '@object-ui/core';
+// The spec's INLINE locale-map form (`string | Record< string, string >`), bound
+// by reference rather than re-spelled — same import and same spelling as
+// `BaseSchema.label` / `.description` in `packages/types/src/base.ts`, which
+// carry this identical fact. NOT the KEYED `{ key, defaultValue }` vocabulary:
+// the read sites below resolve through `pickLocalized`, whose input is the
+// inline map.
+import type { I18nLabel } from '@objectstack/spec/ui';
 
 type Severity = 'info' | 'warning' | 'error' | 'success';
 
+/**
+ * Local (unexported) prop shape for the renderer below.
+ *
+ * `title` / `body` accept the inline locale map as well as a plain string
+ * (objectui#4970): both are read through `pickLocalized` further down, and the
+ * block's published authoring surface declares the two arms
+ * (`plugin-detail/src/index.tsx`, `type: ['string', 'object']` since
+ * objectui#3832). While these said `string`, this file was the last place in the
+ * package still claiming the map form was not accepted here — the
+ * declaration-narrower-than-the-renderer family of objectui#4581.
+ */
 interface RecordAlertProps {
   schema?: {
     properties?: {
       severity?: Severity;
-      title?: string;
-      body?: string;
+      title?: string | I18nLabel;
+      body?: string | I18nLabel;
       visible?: any;
       icon?: string;
       action?: { actionName: string; label?: string; variant?: string };
@@ -73,8 +91,8 @@ interface RecordAlertProps {
     };
     // Legacy: support flat properties too (mirrors element:text convention).
     severity?: Severity;
-    title?: string;
-    body?: string;
+    title?: string | I18nLabel;
+    body?: string | I18nLabel;
     visible?: any;
     icon?: string;
     action?: { actionName: string; label?: string; variant?: string };


### PR DESCRIPTION
Fixes #4970

#3832 的机制已随 PR #4975 落 main(`279fb139d`),本卡是那张表漏掉的第 6、7 个同形标本,各一行;PM 在认领评论 5316410458 里把相邻观察(`record-alert.tsx` 两处局部 props 类型)并入本卡一次收拾。

> 本正文里的诊断消息把尖括号写成 `< tag >`(带空格):GitHub 的正文净化器会把「`<` 紧跟字母」当 HTML 标签吃掉,原始消息里没有这个空格。

## 前提验证(先做,后写码)—— 卡面实测是 rc.6 时代的,已在现 pin 上重取

卡正文的 spec 实测标注的是 `@objectstack/spec 17.0.0-rc.6`,当前 pin 已是 GA `17.0.0`(`package.json` / `packages/components` / `packages/sdui-parser` 三处都是 `^17.0.0`)。臂要对齐契约而不是抄卡面,所以按 #4975 同款探针在**现 pin** 上重测了两个键的四向(外加 `array`,因为 `'object'` 臂刻意不收数组):

| 键 | string | i18n-map | number | boolean | array |
|---|---|---|---|---|---|
| `element:text.content`(`ElementTextPropsSchema`) | **OK** | **OK** | no(`invalid_union`) | no(`invalid_union`) | no(`invalid_union`) |
| `element:button.label`(`ElementButtonPropsSchema`) | **OK** | **OK** | no(`invalid_union`) | no(`invalid_union`) | no(`invalid_union`) |

两个键在 GA 上都是 `z.ZodUnion< [ZodString, ZodRecord< ZodString, ZodString >] >`,与卡面 rc.6 的答案一致 —— `string=OK  i18n-map=OK  number=no  boolean=no` 仍然成立,**前提未变**(`premise_still_valid: true`)。

门侧同一次探针(`manifestFromConfigs` + `validateTree`,与 `page.tsx` 的 `kind:'jsx'` 编译同一条路),改前:

```
declared element:text.content = "string"
declared element:button.label = "string"
element:text.content   (i18n map) -> warning/type-mismatch: < element:text >   prop "content" expected a string
element:button.label   (i18n map) -> warning/type-mismatch: < element:button > prop "label"   expected a string
```

两个键的告警逐字复现。行号漂移:卡面写 `elements.tsx:109` / `:319`,`:109` 命中(`content`),`label` 实际在 `:319`(卡面准确);改后因注释各占几行落到 `:117` / `:328`。

`record:alert` 在 GA 上仍**没有** `ComponentPropsMap` 条目(实测 `'record:alert' in ComponentPropsMap === false`),所以并入那两处的依据仍然是渲染器 + 已落地的发布面声明,不是 spec —— 与 #4975 的记述一致,没有因为换 pin 而改变。

## 改动(三处)

**1. 两个标本各一行**(`packages/components/src/renderers/basic/elements.tsx`)

```
{ name: 'content', type: ['string', 'object'], … }   // element:text
{ name: 'label',   type: ['string', 'object'], … }   // element:button
```

各带一段注释写明两条臂的**依据**(GA pin 上的 spec 联合 + 渲染器的 `pickLocalized` 读点),而不是只写「有两条臂」。机制不动。

**2. 挂进标本验收面**(`apps/console/src/__tests__/component-input-union-specimens.test.ts`)

新增一个 `describe`(#3832 那个原样不动,它是那次裁定的验收面,五标本的范围应当保持可读),里面三条测试:可达性、spec 裁决派生的臂集合、以及两个标本各一条**正向 + 对照**。

对照按 #3832 的实证成对配齐:变异③(见下)实测到只撤机制时正向断言会**空绿**,红的只有对照。另外每个标本的臂集合不是重述 `['string','object']`,而是**从 spec 自己的裁决派生**(`COARSE_ARM_PROBES` 逐值 `safeParse`,取通过的那些粗类型)—— 这是 `text-input-inputs-spec-parity.test.ts` 为第五标本采用的处置:#3832 关掉的是**表达力**那一半,「臂是否与契约相符」今天没有门禁(finding #4971),per-key 派生是替代品。派生本身也带一条守卫测试(全拒 → `[]` 会让两条比对空洞地相等)。

**3. PM 并入**(`packages/plugin-detail/src/renderers/record-alert.tsx`)

未导出的局部 `RecordAlertProps` 两处(`properties.*` + flat 兼容)的 `title` / `body` 从 `string` 放宽。**不新增导出**,仍是局部。

选 `string | I18nLabel`(`import type { I18nLabel } from '@objectstack/spec/ui'`)而不是手写 `string | Record< string, string >`,两个理由:

1. **同一事实,仓内已有拼法。** `packages/types/src/base.ts` 的 `BaseSchema.label` / `.description` 承载的就是这个事实,拼法逐字是 `string | I18nLabel`,import 自 `@objectstack/spec/ui`。新起一种拼法只会让同一件事在仓里有两种写法。
2. **按引用绑定 spec,而不是复制它的形状。** `I18nLabel` = `z.input< typeof I18nLabelSchema >`,spec 若改动内联形态,这里跟着动;手写 `Record< string, string >` 是一份会漂的副本 —— 正是 `scripts/check-spec-symbol-derivation.mjs` 那条规则的形状(它按名字匹配,`RecordAlertProps` 不在其射程内,所以这里靠纪律而不是门禁)。注释里同时写明**不是** KEYED 那套词表(`{ key, defaultValue }`,`resolveKeyedI18nLabel`),因为本文件的读点是 `pickLocalized`,收的是内联映射 —— #4167 那对结构可混淆形状的老坑。

`plugin-detail` 已经依赖 `@objectstack/spec`(`^17.0.0`),import 不新增依赖。

## 序列化面复核(实测,不是引述折叠约束)

把 `manifestFromConfigs(getPublicConfigs())` 在改前/改后各 dump 一份逐字比对(与 `dev/manifest-dump.tsx` 同一对函数):

```
public blocks 改前/改后:  57 / 57
逐字不变的条目:            55
变化的条目:                ["element:text", "element:button"]
JSON diff:                 2 个 hunk,各一处 "type": "string" -> ["string","object"]
数组形态的 input 合计:      7  (record:alert.title/.body, page:card.title,
                               page:header.title/.subtitle  +  本卡两个)
```

即单臂折叠约束在实测上成立:其余 55 个公开块一个字节没动,数组只出现在真正声明了联合的 7 个键上。

## 测试

```
pnpm exec vitest run apps/console/.../component-input-union-specimens.test.ts
    → Test Files 1 passed,   Tests 10 passed      (改前该文件 6 tests;本卡两标本此前缺席)
pnpm exec vitest run packages/sdui-parser/ packages/plugin-detail/ examples/schema-catalog/ \
                     packages/plugin-charts/src/index.test.ts packages/layout/
    → Test Files 116 passed, Tests 2630 passed
pnpm exec vitest run packages/components/
    → Test Files 147 passed, Tests 1320 passed
pnpm exec vitest run apps/console/
    → Test Files 51 passed,  Tests 574 passed
pnpm exec vitest run packages/app-shell/.../previews/ packages/app-shell/.../inspectors/
    → Test Files 91 passed,  Tests 1043 passed | 1 skipped
pnpm exec turbo run type-check --concurrency=2
    → Tasks 81 successful, 81 total
node scripts/check-control-bytes.mjs        → OK (4459 tracked text files)
node scripts/check-changeset-no-major.mjs   → OK
node scripts/check-changeset-presence.mjs   → OK (3 source files / 1 changeset)
node scripts/check-doc-component-types.mjs  → OK
node scripts/check-spec-symbol-derivation.mjs / check-package-self-import.mjs → OK
pnpm exec eslint <三个改动文件>              → 0 errors(33 个既有 no-explicit-any warning,非本卡新增行)
```

消费半径按「谁读 `ComponentInput.type` / `ManifestInput.type`」扫,不按包猜:`manifestFromConfigs` / `validateTree` / `generateDts` 的调用点共 24 个文件(`packages/sdui-parser`、`packages/components`、`packages/layout`、`packages/plugin-charts`、`apps/console`、`examples/schema-catalog`、`scripts/`),全部覆盖在上面的批次里。另外扫了两个块在设计器面的 fixture(`app-shell` 的 `previews/block-config.ts:234` / `:315` 与其测试):那里是 `kind: 'text'` 的**另一套**词表,与注册的 `inputs` 无连接 —— 与 #4975 第 13 行的实测结论一致,无需跟改。

## 三条变异记录(先书面预判,后跑;变异前已 commit,还原用 `git checkout --`,⛔ stash)

**① 撤回 `element:text.content` 的 `'object'` 臂(留机制)。**
*预判 —— 与卡面派发模板预设的方向不同,如实先写下*:派发卡预判的是「该标本**对照**面红」,但那是 #3832 变异①的方向(撤的是**任一臂逻辑**,数组 `type` 掉进旧 `switch` 的 `default: return null`,什么都不产出 → 正向空绿、对照红)。本变异撤的是**声明的一条臂**、机制完好,单臂 `'string'` 照旧产出诊断,所以动的应该是**正向**那一半:臂集合比对红(`['string']` vs spec 派生的 `['string','object']`),i18n-map 正向断言红;**对照仍然绿**(42 / `['Account']` 照旧被报告),`element:button` 与派生守卫也绿。
*实测*:`Tests 1 failed | 9 passed`,唯一红的是 `element:text.content` 这条,失败点 `AssertionError: expected [ 'string' ] to deeply equal [ 'object', 'string' ]` —— 即臂集合比对(它是该 test 的第一条 expect,vitest 在此停下,所以 i18n-map 正向那条没跑到)。**方向与我的预判一致,与卡面模板的预设相反**,照直记录。

**② 给 `element:button.label` 加一条 spec 不接受的假臂(`'number'`)。**
*预判*:#3832 变异③把这件事分成两半 —— 「联合不是放行一切」那半成立,「臂是否对齐契约」那半有 per-block spec 断言的键会红、没有的会全绿(③b 在 `page:card` 上是 93 files / 856 tests **全绿**)。本卡两标本的臂集合是从 spec 裁决派生的,所以这一半应当**红**:`['number','object','string']` vs `['object','string']`;正向与对照都绿(`true` / `['Save']` 仍被三条臂一致拒绝)。
*实测*:`Tests 1 failed | 9 passed`,`AssertionError: expected [ 'number', 'object', 'string' ] to deeply equal [ 'object', 'string' ]`。**预判命中**,并且这正是 #3832 ③b 留在绿里的那半 —— 本卡两个标本在本地把它闭上了(全局那半仍是 finding #4971)。

**③ 把机制撤回 #3832 之前的形状(`checkType` 对数组 `type` 走 `default: return null`),验证对照断言承重。**
*预判*:全部七个标本的正向断言**空绿**、臂集合比对绿(它读的是 manifest 声明而不是门的行为),红的只有**对照**,报 `expected [] to include 'type-mismatch'` —— 空数组,即什么都没产出。
*实测*:`Tests 6 failed | 4 passed`,六条标本测试全红,失败点逐个落在对照行:`:151`(page:header)、`:169`(page:card)、`:189`(record:alert)、`:211`(text_input)、**`:295`(element:text.content)**、**`:314`(element:button.label)**,报的都是 `AssertionError: expected [] to include 'type-mismatch'`。**预判命中**,本卡两标本的对照与 #3832 五标本的对照承重方式相同。

## changeset

`.changeset/element-text-button-i18n-arms-4970.md`,`@object-ui/components` + `@object-ui/plugin-detail` 均 **minor**,理由与 #3832 先例同档:这是发布面**扩展**而非破坏 —— 单字符串写法保持合法、其余 55 个公开块序列化字节不变、诊断行为只在两个键的合法写入上从「报」变成「不报」。按 AGENTS.md「objectui 不声明 `major`、fixed 组联动」的规则,扩展记 minor(⛔ major)。`plugin-detail` 那一处虽是未导出局部类型、没有发布面移动,但它是 `packages/plugin-detail/src/**` 的真实源码改动,按 `check-changeset-presence.mjs` 的前提一并列出并在正文里说明其性质(#4975 把只改注释的 `packages/layout` 排除在外,这一处比那个重一档)。

## 顺手发现的相邻缺陷(立卡,不并入本 PR)

- **#4998** `[finding]` — 同一个 `RecordAlertProps` 里第三处同形槽位:CTA 的 `action.label` 两处仍写 `label?: string`,而 `:128` 是 `pickLocalized(props.action?.label, language)`。刻意**没有**顺手改:`title` / `body` 的第二条臂有已落地的发布面声明可以对齐,而 `action` 的发布面是 `type: 'object'`、成员形状只在 description 的散文里,窄声明的唯一对照物是渲染器本身 —— 判据不同,且要在发布面表达它得先有成员形状(PR #3795 的 open question)。observation-class(interface 未导出、`pickLocalized` 收 `unknown`,今天没有消费者被误导)。

草稿状态,等 PM 验收后再 undraft。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_