### PR TITLE
fix(plugin-map): 首帧相机取景到查询记录集,经度取短弧 (#4941)

### DIFF
--- a/.changeset/map-camera-fits-queried-records.md
+++ b/.changeset/map-camera-fits-queried-records.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/plugin-map': patch
+---
+
+A map view now fits its camera to the records it queried, so a view with data never first-paints an empty viewport.
+
+The initial camera was never derived from the data. The zoom came from
+`getMapConfig`'s default branch — the branch reached precisely when the author
+declared nothing — which synthesized `zoom: 10` at the origin, and the fabricated
+value was indistinguishable from a declared one at the read site. An unconfigured
+object list view of continent-wide records therefore opened on a ~30km-wide
+viewport centred on the set's midpoint: no markers anywhere on screen, the
+records reachable only by zooming out and panning by hand (objectui#4941, seen on
+the showcase `task` map view, whose ten seeded US-city locations span ~4000km).
+
+The camera is now the marker set's bounding box, handed to MapLibre as
+`initialViewState.bounds` so the fit happens against the real container size,
+with padding and a city-scale zoom ceiling (a single record, or several at one
+address, fits a zero-width box — unbounded, that answers with a rooftop view of a
+style whose tiles stop far short of it).
+
+The box is measured along the **shortest arc** containing every marker, not
+between the naive longitude extremes. Read as a line rather than a circle, two
+records two degrees apart across the antimeridian (179 and -179) describe a
+358-degree box whose centre is their antipode; MapLibre then places the markers in
+whichever copy of the world is nearest their previous screen position, which is
+how a fitted-looking camera ends up showing empty ocean with the records sitting
+on a neighbouring copy.
+
+Unchanged on purpose: record coordinates are not rescued. The platform's
+`location` value bounds longitude to [-180, 180], so an out-of-range coordinate is
+a producer-side defect — such records keep being rejected and counted in the
+view's "invalid coordinates" notice, and the normalization above is camera
+arithmetic over already-valid values. No new configuration key was added either:
+the documented `zoom` / `center` pair of the `map` block is still the only camera
+declaration, it still wins outright, and declaring one half keeps the other
+derived (`zoom` alone applies at the records' centre; `center` alone at a
+continental zoom). An empty result set is not fitted — it opens on the whole
+world rather than a zoom-10 patch of sea.

--- a/content/docs/plugins/plugin-map.mdx
+++ b/content/docs/plugins/plugin-map.mdx
@@ -119,8 +119,8 @@ const schema = {
   locationField?: string,      // Field with combined location (alternative)
   titleField?: string,         // Field to use as marker title
   descriptionField?: string,   // Field for marker description
-  zoom?: number,               // Default zoom level (1-20)
-  center?: [number, number]    // Center coordinates [lat, lng]
+  zoom?: number,               // Zoom level (1-20) — opts out of the auto-fit
+  center?: [number, number]    // Center coordinates [lat, lng] — opts out of the auto-fit
 }
 ```
 
@@ -159,9 +159,24 @@ When your data has a combined location field:
 }
 ```
 
+### Initial Camera
+
+By default the map has no fixed camera: on load it **fits the records it queried**.
+The marker set's bounding box is measured along the shortest arc that contains
+every marker — so a set straddling the antimeridian is framed across the line
+rather than around the far side of the planet — and the map fits that box with
+padding, up to a city-scale zoom ceiling (a single record does not become a
+rooftop view). A view with data therefore never opens on an empty viewport.
+
+Two cases sit outside the fit:
+
+- **No records** (empty result, or every record missing coordinates): nothing to
+  fit, so the map opens on the whole world.
+- **A declared camera** (below): the declaration wins and the fit is skipped.
+
 ### Zoom and Center
 
-Control the initial map view:
+Declare either one to take the camera over and opt this view out of the auto-fit:
 
 ```tsx
 {
@@ -176,6 +191,9 @@ Control the initial map view:
   }
 }
 ```
+
+Declaring only one half keeps the other derived: `zoom` on its own is applied at
+the centre of the records, `center` on its own at a continental zoom.
 
 ## Data Providers
 

--- a/packages/plugin-map/src/ObjectMap.camera.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.camera.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression (objectui#4941): a map list view with records first-painted a
+ * viewport that did not contain them. The camera never fitted the data — the
+ * zoom came from a synthesized default (10, a city-block scale) and the centre
+ * from the naive longitude extremes — so the showcase `task` map opened on empty
+ * sea and the records had to be found by hand.
+ *
+ * These pin what `MapGL` is actually mounted with. The derivation itself is
+ * pinned in `camera.test.ts`.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ObjectMap } from './ObjectMap';
+import { FIT_MAX_ZOOM, FIT_PADDING_PX, EMPTY_VIEW_ZOOM, UNFITTED_CENTER_ZOOM } from './camera';
+
+let capturedProps: any = null;
+
+vi.mock('react-map-gl/maplibre', () => ({
+  default: (props: any) => {
+    capturedProps = props;
+    return <div aria-label="Map">{props.children}</div>;
+  },
+  Map: ({ children }: any) => <div aria-label="Map">{children}</div>,
+  NavigationControl: () => <div data-testid="nav-control" />,
+  Marker: ({ children, longitude, latitude }: any) => (
+    <div data-testid="map-marker" data-lng={longitude} data-lat={latitude}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
+}));
+
+/**
+ * Showcase-shaped records: the platform's `location` value is `{ lat, lng }`,
+ * and the showcase map view declares no map config at all — the exact pair of
+ * facts that produced the reported empty first paint.
+ */
+const usCities = [
+  { id: '1', name: 'Seattle', location: { lat: 47.6062, lng: -122.3321 } },
+  { id: '2', name: 'San Francisco', location: { lat: 37.7749, lng: -122.4194 } },
+  { id: '3', name: 'New York', location: { lat: 40.7128, lng: -74.006 } },
+  { id: '4', name: 'Austin', location: { lat: 30.2672, lng: -97.7431 } },
+];
+
+const valueView = (items: any[], map?: Record<string, unknown>): any => ({
+  type: 'map',
+  ...(map ? { map } : {}),
+  data: { provider: 'value', items },
+});
+
+const renderMap = async (schema: any) => {
+  render(<ObjectMap schema={schema} />);
+  await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+  await waitFor(() => expect(capturedProps).not.toBeNull());
+};
+
+describe('ObjectMap — initial camera', () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it('fits the queried records when no camera is declared', async () => {
+    await renderMap(valueView(usCities));
+
+    const { bounds, fitBoundsOptions, zoom, longitude, latitude } = capturedProps.initialViewState;
+
+    expect(bounds).toEqual([
+      [-122.4194, 30.2672],
+      [-74.006, 47.6062],
+    ]);
+    expect(fitBoundsOptions).toEqual({ padding: FIT_PADDING_PX, maxZoom: FIT_MAX_ZOOM });
+    // The fit owns the camera: no synthesized centre/zoom rides along. A zoom of
+    // 10 here is the bug — a viewport ~30km wide, on a set spanning ~4000km.
+    expect(zoom).toBeUndefined();
+    expect(longitude).toBeUndefined();
+    expect(latitude).toBeUndefined();
+
+    expect(screen.getAllByTestId('map-marker')).toHaveLength(4);
+  });
+
+  it('fits across the antimeridian along the short arc', async () => {
+    await renderMap(
+      valueView([
+        { id: '1', name: 'west of the line', location: { lat: -16, lng: 179 } },
+        { id: '2', name: 'east of the line', location: { lat: -18, lng: -179 } },
+      ]),
+    );
+
+    // 179 -> 181 keeps the box on one world copy. The naive extremes would give
+    // [-179, 179]: a box centred on 0, half a planet from both records.
+    expect(capturedProps.initialViewState.bounds).toEqual([
+      [179, -18],
+      [181, -16],
+    ]);
+  });
+
+  it('fits a single record without zooming to rooftop scale', async () => {
+    await renderMap(valueView([usCities[1]]));
+
+    const { bounds, fitBoundsOptions } = capturedProps.initialViewState;
+    expect(bounds).toEqual([
+      [-122.4194, 37.7749],
+      [-122.4194, 37.7749],
+    ]);
+    expect(fitBoundsOptions.maxZoom).toBe(FIT_MAX_ZOOM);
+  });
+
+  it('does not fit an empty record set — the world, not a random sea', async () => {
+    await renderMap(valueView([]));
+
+    expect(capturedProps.initialViewState).toEqual({
+      longitude: 0,
+      latitude: 0,
+      zoom: EMPTY_VIEW_ZOOM,
+    });
+    expect(capturedProps.initialViewState.bounds).toBeUndefined();
+  });
+
+  it('lets a declared camera win over the fit', async () => {
+    await renderMap(
+      valueView(usCities, {
+        latitudeField: 'latitude',
+        longitudeField: 'longitude',
+        locationField: 'location',
+        titleField: 'name',
+        // Declared as [lat, lng], the documented order for this block.
+        center: [51.5074, -0.1278],
+        zoom: 12,
+      }),
+    );
+
+    expect(capturedProps.initialViewState.bounds).toBeUndefined();
+    expect(capturedProps.initialViewState).toEqual({
+      longitude: -0.1278,
+      latitude: 51.5074,
+      zoom: 12,
+    });
+  });
+
+  it('keeps a declared zoom and takes the centre from the records', async () => {
+    await renderMap(
+      valueView(usCities, { locationField: 'location', titleField: 'name', zoom: 6 }),
+    );
+
+    const { bounds, longitude, latitude, zoom } = capturedProps.initialViewState;
+    expect(bounds).toBeUndefined();
+    expect(zoom).toBe(6);
+    // Centre of the fitted box, not the origin.
+    expect(longitude).toBeCloseTo((-122.4194 + -74.006) / 2, 6);
+    expect(latitude).toBeCloseTo((30.2672 + 47.6062) / 2, 6);
+  });
+
+  it('keeps a declared centre and falls back to a continental zoom', async () => {
+    await renderMap(
+      valueView(usCities, {
+        locationField: 'location',
+        titleField: 'name',
+        center: [51.5074, -0.1278],
+      }),
+    );
+
+    expect(capturedProps.initialViewState).toEqual({
+      longitude: -0.1278,
+      latitude: 51.5074,
+      zoom: UNFITTED_CENTER_ZOOM,
+    });
+  });
+
+  it('still fits when the declared camera cannot be read', async () => {
+    // The shape a reader of the package README would write. It is diagnosed by
+    // `MapConfigSchema`, not adapted — and it must not cost the view its fit.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await renderMap(
+        valueView(usCities, {
+          locationField: 'location',
+          titleField: 'name',
+          center: { lat: 51.5074, lng: -0.1278 } as unknown as [number, number],
+        }),
+      );
+
+      expect(capturedProps.initialViewState.bounds).toEqual([
+        [-122.4194, 30.2672],
+        [-74.006, 47.6062],
+      ]);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -29,6 +29,14 @@ import { z } from 'zod';
 import MapGL, { NavigationControl, Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import {
+  computeMarkerBounds,
+  boundsCenter,
+  EMPTY_VIEW_ZOOM,
+  FIT_MAX_ZOOM,
+  FIT_PADDING_PX,
+  UNFITTED_CENTER_ZOOM,
+} from './camera';
 
 const MapConfigSchema = z.object({
   latitudeField: z.string().optional(),
@@ -74,9 +82,16 @@ interface MapConfig {
   titleField?: string;
   /** Field to use for marker description */
   descriptionField?: string;
-  /** Default zoom level (1-20) */
+  /**
+   * Zoom level (1-20). Declaring it opts the view OUT of fitting the camera to
+   * its records — the declaration wins (objectui#4941).
+   */
   zoom?: number;
-  /** Center coordinates [lat, lng] */
+  /**
+   * Center coordinates [lat, lng] — latitude first, as documented and as the
+   * `map` block's shape has always been read. Declaring it opts the view OUT of
+   * fitting the camera to its records.
+   */
   center?: [number, number];
   /** MapLibre style URL/spec (overrides the public demo default) */
   style?: string;
@@ -211,15 +226,20 @@ function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
      return { ...config, style: config.style || style };
   }
 
-  // Default configuration
+  // Default configuration — field names only. No camera is synthesized here
+  // (objectui#4941): this branch is reached precisely when the author declared
+  // nothing, and a fabricated `zoom` / `center` is indistinguishable from a
+  // declared one at the read site. The old defaults (zoom 10 at the origin)
+  // therefore SUPPRESSED the fit for exactly the views that need it most — an
+  // unconfigured object list view of continent-wide records first-painted a
+  // city-block viewport centred on the set's midpoint, showing no markers at
+  // all. With no camera declared, the camera comes from the data.
   return {
     latitudeField: 'latitude',
     longitudeField: 'longitude',
     locationField: 'location',
     titleField: 'name',
     descriptionField: 'description',
-    zoom: 10,
-    center: [0, 0],
     style,
   };
 }
@@ -559,31 +579,55 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
     return clusterMarkers(filteredMarkers, currentZoom, clusterRadius);
   }, [filteredMarkers, currentZoom, enableClustering, clusterRadius, schema]);
 
-  // Calculate map bounds
+  /**
+   * The box the records occupy, along the shortest arc containing them
+   * (see `./camera`). `null` when there is nothing to fit.
+   */
+  const markerBounds = useMemo(
+    () => computeMarkerBounds(filteredMarkers.map(m => m.coordinates)),
+    [filteredMarkers],
+  );
+
+  /**
+   * A camera the author declared, read from the documented `map` block. Only a
+   * READABLE declaration counts: `MapConfigSchema` already warns about a
+   * malformed one, and a shape whose numbers cannot be read is not a camera —
+   * letting it suppress the fit would first-paint an empty viewport, which is
+   * the defect this whole path exists to prevent (objectui#4941). Nothing is
+   * coerced: an unreadable declaration is diagnosed and ignored, never adapted.
+   */
+  const declaredLatitude = typeof mapConfig.center?.[0] === 'number' ? mapConfig.center[0] : undefined;
+  const declaredLongitude = typeof mapConfig.center?.[1] === 'number' ? mapConfig.center[1] : undefined;
+  const declaredZoom = typeof mapConfig.zoom === 'number' ? mapConfig.zoom : undefined;
+  const hasDeclaredCamera =
+    declaredLatitude !== undefined || declaredLongitude !== undefined || declaredZoom !== undefined;
+
+  /**
+   * Initial camera. Read once, when `MapGL` mounts — which is also every time
+   * the record set changes, because the `loading` gate below unmounts the map
+   * for the duration of each fetch. So the one-shot camera always reflects the
+   * records currently in hand, and nothing here ever yanks a camera the user
+   * has since panned.
+   */
   const initialViewState = useMemo(() => {
-    if (!filteredMarkers.length) {
+    // Records, no declared camera: hand MapLibre the box and let it fit at the
+    // real container size. `bounds` overrides center/zoom on the constructor.
+    if (markerBounds && !hasDeclaredCamera) {
       return {
-        longitude: mapConfig.center?.[1] || 0,
-        latitude: mapConfig.center?.[0] || 0,
-        zoom: mapConfig.zoom || 2
+        bounds: markerBounds,
+        fitBoundsOptions: { padding: FIT_PADDING_PX, maxZoom: FIT_MAX_ZOOM },
       };
     }
 
-    // Simple bounds calculation
-    const lngs = filteredMarkers.map(m => m.coordinates[0]);
-    const lats = filteredMarkers.map(m => m.coordinates[1]);
-    
-    const minLng = Math.min(...lngs);
-    const maxLng = Math.max(...lngs);
-    const minLat = Math.min(...lats);
-    const maxLat = Math.max(...lats);
-
+    // Otherwise the declared halves win and the rest falls back: to the box's
+    // centre when there are records, to the world when there are none.
+    const fallback = markerBounds ? boundsCenter(markerBounds) : { longitude: 0, latitude: 0 };
     return {
-      longitude: (minLng + maxLng) / 2,
-      latitude: (minLat + maxLat) / 2,
-      zoom: mapConfig.zoom || 3, // Auto-zoom logic could be improved here
+      longitude: declaredLongitude ?? fallback.longitude,
+      latitude: declaredLatitude ?? fallback.latitude,
+      zoom: declaredZoom ?? (markerBounds ? UNFITTED_CENTER_ZOOM : EMPTY_VIEW_ZOOM),
     };
-  }, [filteredMarkers, mapConfig]);
+  }, [markerBounds, hasDeclaredCamera, declaredLongitude, declaredLatitude, declaredZoom]);
 
   if (loading) {
     return (

--- a/packages/plugin-map/src/camera.test.ts
+++ b/packages/plugin-map/src/camera.test.ts
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Regression (objectui#4941): the initial camera of a map view with records was
+ * never derived from those records — the zoom came from a synthesized default
+ * and the centre from the naive longitude extremes, so a view with data could
+ * first-paint an empty viewport. These pin the derivation itself; the component
+ * wiring is pinned in `ObjectMap.camera.test.tsx`.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeMarkerBounds,
+  boundsCenter,
+  normalizeLongitude,
+  MAX_FIT_LATITUDE,
+} from './camera';
+
+describe('normalizeLongitude', () => {
+  it('leaves in-range longitudes untouched', () => {
+    expect(normalizeLongitude(0)).toBe(0);
+    expect(normalizeLongitude(-122.3321)).toBeCloseTo(-122.3321, 10);
+    expect(normalizeLongitude(179.5)).toBeCloseTo(179.5, 10);
+  });
+
+  it('folds wrapped longitudes back onto the circle', () => {
+    expect(normalizeLongitude(190)).toBeCloseTo(-170, 10);
+    expect(normalizeLongitude(-190)).toBeCloseTo(170, 10);
+    expect(normalizeLongitude(540)).toBeCloseTo(180 - 360, 10);
+    expect(normalizeLongitude(180)).toBe(-180);
+  });
+});
+
+describe('computeMarkerBounds', () => {
+  it('returns null for an empty record set — nothing to fit', () => {
+    expect(computeMarkerBounds([])).toBeNull();
+  });
+
+  it('fits a continent-wide set to its own extent', () => {
+    // The showcase `task` seed: US cities, [lng, lat] as markers carry them.
+    const bounds = computeMarkerBounds([
+      [-122.3321, 47.6062], // Seattle
+      [-122.4194, 37.7749], // San Francisco
+      [-74.006, 40.7128], // New York
+      [-97.7431, 30.2672], // Austin
+      [-71.0589, 42.3601], // Boston
+    ]);
+
+    expect(bounds).not.toBeNull();
+    const [[west, south], [east, north]] = bounds!;
+    expect(west).toBeCloseTo(-122.4194, 6);
+    expect(east).toBeCloseTo(-71.0589, 6);
+    expect(south).toBeCloseTo(30.2672, 6);
+    expect(north).toBeCloseTo(47.6062, 6);
+
+    // The box is the data's own extent, so its centre is inside it — not the
+    // fabricated zoom-10 origin the component used to open on.
+    const { longitude, latitude } = boundsCenter(bounds!);
+    expect(longitude).toBeGreaterThan(west);
+    expect(longitude).toBeLessThan(east);
+    expect(latitude).toBeGreaterThan(south);
+    expect(latitude).toBeLessThan(north);
+  });
+
+  it('takes the SHORT arc across the antimeridian, not the naive extremes', () => {
+    // Two markers two degrees apart, straddling 180. Naive min/max longitude
+    // would describe a 358-degree box centred on 0 — the antipode of the data,
+    // which is how markers end up on a neighbouring world copy.
+    const bounds = computeMarkerBounds([
+      [179, -16], // Fiji side
+      [-179, -18], // just east of the line
+    ]);
+
+    const [[west, south], [east, north]] = bounds!;
+    expect(west).toBeCloseTo(179, 6);
+    expect(east).toBeCloseTo(181, 6); // past 180 on purpose: MapLibre's own spelling
+    expect(east - west).toBeCloseTo(2, 6);
+    expect(south).toBeCloseTo(-18, 6);
+    expect(north).toBeCloseTo(-16, 6);
+
+    // ...and the centre lands ON the data, folded back onto the circle.
+    expect(boundsCenter(bounds!).longitude).toBeCloseTo(-180, 6);
+  });
+
+  it('keeps a genuinely global set on the long span', () => {
+    // Nothing to shorten here: the widest empty gap is the 120 degrees between
+    // 120 and -120, so the box spans the other 240.
+    const bounds = computeMarkerBounds([
+      [-120, 0],
+      [0, 10],
+      [120, -10],
+    ]);
+
+    const [[west], [east]] = bounds!;
+    expect(west).toBeCloseTo(-120, 6);
+    expect(east).toBeCloseTo(120, 6);
+  });
+
+  it('yields a degenerate box for a single record', () => {
+    // Zero-width: the fit's maxZoom is what stops this becoming a rooftop view.
+    const bounds = computeMarkerBounds([[-122.4194, 37.7749]]);
+    expect(bounds).toEqual([
+      [-122.4194, 37.7749],
+      [-122.4194, 37.7749],
+    ]);
+    expect(boundsCenter(bounds!)).toEqual({ longitude: -122.4194, latitude: 37.7749 });
+  });
+
+  it('yields a degenerate box when several records share one address', () => {
+    const bounds = computeMarkerBounds([
+      [8.5417, 47.3769],
+      [8.5417, 47.3769],
+      [8.5417, 47.3769],
+    ]);
+    expect(bounds).toEqual([
+      [8.5417, 47.3769],
+      [8.5417, 47.3769],
+    ]);
+  });
+
+  it('folds an out-of-range longitude onto the circle for the camera only', () => {
+    // `ObjectMap` rejects such a record before it can become a marker (the
+    // platform bounds longitude to [-180, 180]); this pins the arithmetic, not
+    // an intake path.
+    const bounds = computeMarkerBounds([
+      [190, 10],
+      [-170, 12],
+    ]);
+    const [[west], [east]] = bounds!;
+    expect(west).toBeCloseTo(-170, 6);
+    expect(east).toBeCloseTo(-170, 6);
+  });
+
+  it('clamps the box to the Mercator-safe latitude band', () => {
+    const bounds = computeMarkerBounds([
+      [10, 89.9],
+      [12, -89.9],
+    ]);
+    const [[, south], [, north]] = bounds!;
+    expect(south).toBe(-MAX_FIT_LATITUDE);
+    expect(north).toBe(MAX_FIT_LATITUDE);
+  });
+});

--- a/packages/plugin-map/src/camera.ts
+++ b/packages/plugin-map/src/camera.ts
@@ -1,0 +1,152 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Initial-camera derivation for ObjectMap (objectui#4941).
+ *
+ * A map view whose query returned records must never first-paint an empty
+ * viewport. The camera is therefore derived from the records themselves: the
+ * marker set's bounding box, handed to MapLibre so it fits the box with the
+ * real container size (`initialViewState.bounds` -> the `bounds` /
+ * `fitBoundsOptions` pair on the MapLibre `Map` constructor, which overrides
+ * `center` / `zoom`).
+ *
+ * Two things this module deliberately does NOT do:
+ *
+ * 1. It does not rescue out-of-range record coordinates. The platform's
+ *    `location` value is `{ lat, lng }` with longitude bounded to [-180, 180]
+ *    by `@objectstack/spec` (`data/field-value.zod.ts`), so a longitude outside
+ *    that range is a producer-side defect, not a dialect this renderer should
+ *    learn to read. `ObjectMap` keeps rejecting such records and counting them
+ *    in its "invalid coordinates" notice. The normalization here is projection
+ *    arithmetic over already-valid values, applied to the CAMERA only.
+ * 2. It does not introduce any authoring surface. The only camera declaration
+ *    read anywhere is the documented `zoom` / `center` pair of the map config
+ *    block (`content/docs/plugins/plugin-map.mdx`), and an author who declares
+ *    it keeps winning over everything computed here.
+ */
+
+/**
+ * `[[west, south], [east, north]]` — the two-corner form MapLibre accepts as
+ * `LngLatBoundsLike`. `east` may exceed 180: that is how MapLibre expects a box
+ * crossing the antimeridian to be spelled (its own `adjustAntiMeridian` produces
+ * exactly this shape), and it is what keeps the fitted camera on the same world
+ * copy as the markers.
+ */
+export type MarkerBounds = [[number, number], [number, number]];
+
+/** Breathing room around the fitted box, in pixels. */
+export const FIT_PADDING_PX = 48;
+
+/**
+ * Ceiling for the fitted zoom. A single record — or several records at one
+ * address — fits a zero-width box, and an unbounded fit answers that with the
+ * map's maximum zoom (22): a building-level view of a style whose tiles usually
+ * stop far short of it. City scale is the useful answer instead.
+ */
+export const FIT_MAX_ZOOM = 12;
+
+/** Zoom used when there is nothing to fit: the whole world, not a random sea. */
+export const EMPTY_VIEW_ZOOM = 2;
+
+/**
+ * Zoom used when a partially declared camera pins the position but not the
+ * scale, so the box cannot drive the fit. Same value the component used before
+ * the fit existed.
+ */
+export const UNFITTED_CENTER_ZOOM = 3;
+
+/**
+ * Latitude ceiling for the fitted box. Web Mercator is unbounded at the poles,
+ * so a record sitting exactly at +/-90 projects to infinity and takes the whole
+ * camera with it. Markers themselves stay at their real latitude.
+ */
+export const MAX_FIT_LATITUDE = 85;
+
+/**
+ * Fold any longitude onto the [-180, 180) circle.
+ *
+ * In-range values return unchanged rather than through the modulo, which would
+ * round-trip them into a neighbouring float (-74.006 came back as
+ * -74.00599999999997) and put that drift into every fitted box.
+ */
+export function normalizeLongitude(lng: number): number {
+  if (lng >= -180 && lng < 180) return lng;
+  return ((((lng + 180) % 360) + 360) % 360) - 180;
+}
+
+const clampLatitude = (lat: number): number =>
+  Math.min(MAX_FIT_LATITUDE, Math.max(-MAX_FIT_LATITUDE, lat));
+
+/**
+ * Bounding box of a marker set, along the SHORTEST arc that contains every
+ * marker.
+ *
+ * Why the shortest arc and not `[min(lng), max(lng)]`: the naive extremes read
+ * the circle as a line, so a set straddling the antimeridian (say 179 and -179,
+ * two degrees apart) yields a 358-degree-wide box whose midpoint is 0 — the
+ * antipode of the data, half a planet away. MapLibre then places the markers in
+ * whichever world copy is nearest their previous screen position (`smartWrap`),
+ * which is how a fitted-looking camera ends up showing an empty ocean with the
+ * records sitting on a neighbouring copy of the world.
+ *
+ * The widest EMPTY gap between adjacent longitudes is the seam to cut; what
+ * remains is the shortest containing arc. `west` is the first marker east of
+ * that seam, and the span is measured eastward from it, so the box may extend
+ * past 180.
+ *
+ * @param coordinates marker coordinates in MapLibre order, `[lng, lat]`
+ * @returns the box, or `null` when there is nothing to fit
+ */
+export function computeMarkerBounds(
+  coordinates: ReadonlyArray<readonly [number, number]>,
+): MarkerBounds | null {
+  if (coordinates.length === 0) return null;
+
+  const lngs = coordinates.map(([lng]) => normalizeLongitude(lng)).sort((a, b) => a - b);
+  const lats = coordinates.map(([, lat]) => clampLatitude(lat));
+
+  const count = lngs.length;
+  // Start from the seam that closes the circle (last -> first), then look for a
+  // wider gap between neighbours.
+  let widestGap = lngs[0] + 360 - lngs[count - 1];
+  let firstAfterGap = 0;
+  for (let i = 1; i < count; i++) {
+    const gap = lngs[i] - lngs[i - 1];
+    if (gap > widestGap) {
+      widestGap = gap;
+      firstAfterGap = i;
+    }
+  }
+
+  // Both edges are marker longitudes, so the box carries the data's own values
+  // instead of a sum of spans. The eastern edge is shifted a full turn only when
+  // the arc runs over the antimeridian.
+  const west = lngs[firstAfterGap];
+  const easternmost = lngs[(firstAfterGap + count - 1) % count];
+  const east = firstAfterGap === 0 ? easternmost : easternmost + 360;
+
+  return [
+    [west, Math.min(...lats)],
+    [east, Math.max(...lats)],
+  ];
+}
+
+/**
+ * Centre of a box from {@link computeMarkerBounds}, for the paths that cannot
+ * hand the box to a fit (a declared zoom with no declared centre). The
+ * longitude is folded back onto the circle so a box crossing the antimeridian
+ * still yields a real centre rather than a value past 180.
+ */
+export function boundsCenter(bounds: MarkerBounds): { longitude: number; latitude: number } {
+  const [[west, south], [east, north]] = bounds;
+  return {
+    longitude: normalizeLongitude((west + east) / 2),
+    latitude: (south + north) / 2,
+  };
+}

--- a/packages/plugin-map/src/index.registration.test.tsx
+++ b/packages/plugin-map/src/index.registration.test.tsx
@@ -19,6 +19,20 @@ vi.mock('react-map-gl/maplibre', () => ({
   Popup: () => null,
 }));
 
+// AGENTS.md §9 测试纪律 — the assertion below re-imports this module after
+// `vi.resetModules()`, and that import drags in the whole component graph
+// (`@object-ui/components`, `@object-ui/react`, the map bindings). Loading it
+// for the FIRST time inside the test put an unbounded transform inside the 5s
+// test budget: this file timed out when run on its own and stayed green only
+// while a sibling file happened to warm the transform cache first — an order
+// dependency that broke as soon as the package gained another test file
+// (objectui#4941). Importing the same specifiers at module scope moves the cost
+// into the import phase, which no test/hook timeout bounds, and leaves the
+// in-test import to re-EXECUTE an already-transformed graph. The specifiers
+// must match the in-test ones exactly for the cache to serve them.
+import './index';
+import '@object-ui/core';
+
 /**
  * Regression pin for objectstack#7139: a leftover
  * `console.log('Registering object-map...')` sat at this module's top level, so


### PR DESCRIPTION
Fixes #4941

## 前提复核(先证伪,再动手)

卡面两半,一半实测证实、一半重新归因。基线 `origin/main` 实 sha `279fb139d`(派发时刻的 `1f4504bfa` 之后又进了两个 PR)。

**「有数据的视图首开空视口」——证实,并量到了具体相机。** 在 baseline worktree 上用探针跑真组件(showcase 形状的记录:`location: { lat, lng }`,视图不声明任何 map 配置),`MapGL` 拿到的首帧相机是:

```
{"longitude":-98.2127,"latitude":38.9367,"zoom":10}
```

即堪萨斯州中部、zoom 10(该纬度上视口约 30km 宽),而最近的一条记录(Austin,-97.74/30.27)在约 950km 之外,其余在 1500–2500km 外 —— 首帧一个 marker 都不在视口里。机械成因是两处叠加:

1. `ObjectMap.tsx` 的 `initialViewState` 里 zoom 从来不由数据推导,只写 `mapConfig.zoom || 3`;
2. `getMapConfig` 的默认分支 —— 恰恰是「作者什么都没声明」时走到的那一支 —— 凭空造出 `zoom: 10` 与 `center: [0, 0]`。伪造值在读取处与真声明无法区分,于是最需要取景的视图反而被这个默认值挡住了。

showcase `task` 的 map 视图正是这条路径:`examples/app-showcase/src/ui/views/task.view.ts` 的 map 视图只写了 `type` / `data` / `columns`,没有 map 配置块。

**「markers 落在相邻世界副本」——按 showcase 数据这一半没能复现,重新归因。** 平台 `location` 值是 `{ lat, lng }` 且经度被 spec 约束在 [-180, 180](`packages/spec/src/data/field-value.zod.ts`),showcase 的十个种子坐标全在 -122..-71;旧代码算出的中心 -98.2 与它们的经度差最大约 25 度。MapLibre 的 marker 换副本逻辑(`smartWrap`)只在 marker 与相机中心相差超过 180 度、且该 marker 投影落在画面外时才移动一个整圈 —— 这个条件在 showcase 数据上不成立。所以在这份数据上,「相邻副本」不是本卡代码算出来的。

但这条症状本身有真实的机械通路,而且就在同一段被删掉的算术里:旧的中心取 `(min(lng) + max(lng)) / 2`,把圆当成直线。跨反经线相距两度的两条记录(179 与 -179)会得到一个 358 度宽、中心恰在其对极点的包围盒 —— 相机与 marker 相差 180 度,`smartWrap` 的条件成立,marker 就真的会被放到相邻的世界副本里,并因为它按「离上一次屏幕位置最近」取副本而黏在那儿。报告者在 zoom 10 空视口上缩小观察时(demo 样式默认 `renderWorldCopies`,低 zoom 下世界横向重复,而 marker 只画一次)读成「记录待在另一个世界」也说得通。

结论:卡面要求的修法(经度归一 + fitBounds)两半都需要,并且都做了;只是「相邻副本」在 showcase 数据上是缩小观察时的读解,而不是这份数据触发的路径。

## 契约排查:相机声明位

- `@objectstack/spec` 的 `ListViewSchema` 是 `strictObject`,按可视化类型声明了 `kanban` / `calendar` / `gantt` / `gallery` / `timeline` / `chart` / `tree` 七个配置块,**没有 `map`**,也没有任何 `center` / `zoom` / camera 位。showcase 自己的注释已经记着这件事(「map needs a spec MapConfigSchema the ListViewSchema doesn't yet have」)。也就是说:对象列表视图的 map 目前**无法**声明相机(也无法声明字段映射)—— 这是本卡之外的契约缺口,已另立 finding #5001。
- objectui 侧:`content/docs/plugins/plugin-map.mdx` 明确文档化了 `map` 块里的 `zoom` 与 `center: [lat, lng]`,注册表也把 `{ name: 'map', type: 'object' }` 声明为输入,本包内的 `MapConfigSchema` 校验它。所以插件层**有**一个已发布的相机声明位。

据此:已声明的相机继续完全胜出,fitBounds 只在没有相机声明时执行,**不新增任何配置键**。

## 改动

- 新增 `packages/plugin-map/src/camera.ts`:纯推导。`computeMarkerBounds` 沿**包含全部 marker 的最短弧**给出包围盒 —— 取相邻经度之间最宽的**空隙**作为切缝,剩下的就是最短弧;跨反经线时东边界写成超过 180 的值,这正是 MapLibre 期望的写法(它自己的 `adjustAntiMeridian` 产出同一形状)。纬度按 Mercator 可用带钳到 85 度,免得极点记录把相机算成无穷。
- `ObjectMap.tsx`:有记录且无相机声明时,`initialViewState` 交出 `bounds` + `fitBoundsOptions`(padding 48、maxZoom 12),由 MapLibre 在**真实容器尺寸**下完成 fit(`bounds` 覆盖构造期的 center/zoom;构造里 `resize()` 就在 `fitBounds` 之前)。没有再加命令式的 fit 调用:`loading` 门在每次取数期间把 `MapGL` 卸掉,数据一变它必然重挂,一次性的 `initialViewState` 因此总是对应手里的记录集,也就不会去拽用户已经平移过的相机。
- `getMapConfig` 的默认分支不再合成相机,只留字段名默认值。空视口回退因此落回原本就写在那儿的 `|| 2`(整个世界),而不是原点附近的一块海。
- 只有**可读**的声明才算声明:`center` 写成 README 里那种 `{ lat, lng }` 对象时,`MapConfigSchema` 已经会告警,此处不做任何迁就地把它当作未声明,视图照常取景 —— 不为坏形状发明第二套读法,也不让它换来一个空视口。
- 记录坐标一律不挽救:越界经度是生产端缺陷,继续被拒绝并计入视图的 invalid coordinates 提示;上面的归一只是对已合法值做的相机算术。

## 验证

`packages/plugin-map`:7 个测试文件 43 个用例全绿;包内 `tsc --noEmit` 与 `tsc -p tsconfig.test.json` 通过;仓根 `turbo run type-check --concurrency=2` 81/81;`check-control-bytes` OK;改动文件 eslint 0 error。远端 20 个 check 全部 completed:18 success + 2 skipped(`Test (coverage)`、`dependabot`,path/config 过滤),0 failure。

单测钉住:多点集、跨反经线集(179/-179 得到 179..181,而不是 -179..179)、单点与同址多点(零宽盒 + maxZoom)、空集(不 fit)、显式声明相机时不 fit、只声明一半时另一半继续推导、以及不可读声明仍取景。

**反向验证**(先书面预判,后跑;commit 后变异,`git checkout --` 还原):

1. 撤掉经度归一与最短弧(保留 fit)—— 预判 4 红且只红在绕圈用例上:实测正是那 4 个(`fits across the antimeridian` 收到 `[[-179,-18],[179,-16]]`),其余 14 绿。美国点集、单点、全球点集在这个变异下**不会**红 —— 不跨反经线时朴素极值与最短弧一致,所以绕圈用例是归一那一半唯一的守卫,这点如实写在测试注释里。
2. 撤掉 fit 分支 —— 预判组件用例 4 红、`camera.test.ts` 全绿:实测一致(`bounds` 变 undefined)。纯推导测不到有没有人调用它,这正是另起组件级文件的原因:只有推导测试的话,把接线删掉仍然 100% 绿。
3. 恢复被删掉的伪造默认值(`zoom: 10, center: [0, 0]`)—— 这一条直接复现卡面症状。预判 5 红,**实测 4 红**,与预判不符的一条如实记录:`still fits when the declared camera cannot be read` 保持绿,因为那条 fixture 声明了 `map` 块,`getMapConfig` 在第二分支就返回了,根本走不到被变异的默认分支。变异的作用面恰好就是「无配置」这条路径 —— 也就是 showcase 与本卡所在的那条。

**活体复现:没有做。** 容器内没有起 objectstack showcase dev server 与浏览器(与并行 agent 共享一台机器,maplibre 还需要 WebGL)。上面 `{"longitude":-98.2127,...}` 是在 baseline worktree 里用真组件 + showcase 形状记录量到的,不是浏览器截图;「相邻世界副本」这一半没有活体验证,只有上面的代码级归因。

## 顺带一处必须改的测试

`index.registration.test.tsx` 把待测模块图的导入提到了模块作用域(AGENTS.md §9)。该文件单跑一直超时(baseline 上也是:`tests 6.19s`,预算 5s),只在同批别的测试文件先热了 transform 缓存时才绿 —— 本包新增测试文件后这个顺序依赖立刻断了。按 §9 的办法把成本挪进不受任何 test/hook 超时约束的 import 阶段,不调超时;现在它单跑也绿(`import 6.14s / tests 55ms`)。

## 相关 finding(本 PR 不修)

- #5001 — `ListViewSchema` 没有 map 配置块,map 列表视图整个配置面不可声明(showcase 里 marker 标题因此为空)。
- #5002 — `packages/plugin-map/README.md` 教的是不存在的 API。
- #5003 — `finding`:`props.data` 不在取数 effect 的依赖里;聚类用的 zoom 种子看不到首帧相机。