### PR TITLE
fix(metadata-admin): overlayScope 收窄为 spec 派生词表,层徽标过 i18n

### DIFF
--- a/.changeset/overlay-scope-vocabulary-4982.md
+++ b/.changeset/overlay-scope-vocabulary-4982.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/data-objectstack': patch
+'@object-ui/app-shell': patch
+---
+
+The Studio's overlay-layer badge stops printing the producer's raw scope value
+
+objectui#4982. `MetadataLayered.overlayScope` was typed `string | null` under a comment naming its
+vocabulary as `organization | environment | package` — three spellings the producer has never
+emitted. The real vocabulary lives in `@objectstack/spec`'s `GetMetaItemLayeredResponseSchema`
+(`z.enum(['org', 'env']).nullable()`), and the framework's two assignment sites write `'org'` /
+`'env'`. Because the declared type was `string`, no compiler anywhere had an opinion, so the wrong
+comment was the only description of the field a reader had.
+
+`overlayScope` is now the spec union, derived by indexing the published response type rather than
+restated locally (a restatement is the fork `check:spec-symbol-derivation` rejects); the alias ships
+as `MetadataOverlayScope`.
+
+User-visible half: `LayeredDiff`'s overlay badge rendered that value straight to screen while the
+sibling artifact / none / merged badges all went through `translateConsoleValue`, and
+`CONSOLE_VALUE_ZH.layer` had no entry for either value the field can hold. One badge therefore had
+two languages depending on the data — a zh-CN admin opening any overlaid metadata item read `org` /
+`env`, while an un-overlaid one read 「已设」. The badge now translates like its three siblings, with
+「组织」/「环境」 added to the layer table. That table's overlay-scope half is keyed by the spec union,
+so a scope the spec adds later fails `type-check` until it has a label instead of quietly reaching a
+badge in English. `translateConsoleValue` remains zh-only for every group, as before — extending it
+to the other locale packs is a separate decision and not part of this change.

--- a/packages/app-shell/src/views/metadata-admin/LayeredDiff.overlayScope.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/LayeredDiff.overlayScope.test.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Layers tab's overlay badge speaks the UI language (objectui#4982).
+ *
+ * `LayeredDiff` renders four layer badges. Three of them — artifact / none /
+ * merged — went through `translateConsoleValue`; the overlay one printed
+ * `layered.overlayScope` raw, and `CONSOLE_VALUE_ZH.layer` had no entry for
+ * either value that field can hold. So the badge's LANGUAGE depended on whether
+ * the item had an overlay: a zh-CN admin opening an overlaid item read `org` /
+ * `env`, while an un-overlaid one hit the `set` fallback and read 「已设」. One
+ * badge, two languages, decided by data.
+ *
+ * The scope list is read from `GetMetaItemLayeredResponseSchema` rather than
+ * spelled here, so a scope the spec adds is covered by these cases the moment it
+ * exists — the same reason `MetadataOverlayScope` is derived rather than
+ * restated. (The compile-time half of that coverage is `LAYER_SCOPE_ZH` in
+ * `./i18n`, whose key type is the spec union: a new scope with no zh-CN label
+ * fails `type-check` before it can reach a badge.)
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { GetMetaItemLayeredResponseSchema } from '@objectstack/spec/api';
+import type { MetadataLayered } from '@object-ui/data-objectstack';
+import { LayeredDiff } from './LayeredDiff';
+import { translateConsoleValue } from './i18n';
+
+afterEach(cleanup);
+
+/** Every overlay scope the producer's schema can send. */
+const SPEC_SCOPES = GetMetaItemLayeredResponseSchema.shape.overlayScope.unwrap().options;
+
+type Layered = MetadataLayered<Record<string, unknown>>;
+
+function layeredWith(overlayScope: Layered['overlayScope']): Layered {
+  const overlaid = overlayScope !== null;
+  return {
+    code: { label: 'Account' },
+    overlay: overlaid ? { label: 'Client' } : null,
+    overlayScope,
+    effective: { label: overlaid ? 'Client' : 'Account' },
+  };
+}
+
+describe('LayeredDiff overlay-scope badge (objectui#4982)', () => {
+  it('every scope the spec can send has a zh-CN label', () => {
+    for (const scope of SPEC_SCOPES) {
+      expect(
+        translateConsoleValue('layer', scope, 'zh-CN'),
+        `CONSOLE_VALUE_ZH.layer has no entry for overlay scope '${scope}'`,
+      ).not.toBe(scope);
+    }
+  });
+
+  it.each(SPEC_SCOPES)('renders the zh-CN label for overlayScope=%s', (scope) => {
+    render(<LayeredDiff layered={layeredWith(scope)} locale="zh-CN" />);
+    const zh = translateConsoleValue('layer', scope, 'zh-CN');
+    expect(screen.getByText(zh)).toBeInTheDocument();
+    // The raw producer value must not be on screen anywhere.
+    expect(screen.queryByText(scope)).toBeNull();
+  });
+
+  it('leaves the raw value alone outside zh — the helper has always done that', () => {
+    // `translateConsoleValue` returns the input verbatim for every non-zh
+    // locale, for all four layer badges. Whether the other nine locale packs
+    // should gain these values is a separate decision, deliberately not made
+    // here; this case pins that this fix did not quietly make it.
+    render(<LayeredDiff layered={layeredWith('org')} locale="en-US" />);
+    expect(screen.getByText('org')).toBeInTheDocument();
+  });
+
+  it('keeps the no-overlay branch on the "none" badge', () => {
+    render(<LayeredDiff layered={layeredWith(null)} locale="zh-CN" />);
+    expect(
+      screen.getByText(translateConsoleValue('layer', 'none', 'zh-CN')),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(translateConsoleValue('layer', 'set', 'zh-CN')),
+    ).toBeNull();
+  });
+
+  it('still falls back to "set" for an overlay that reports no scope', () => {
+    // Off-contract per the spec (`overlayScope` is null exactly when `overlay`
+    // is null), but the fallback branch predates this fix and is untouched by
+    // it. Pinned so the rewrite of the badge expression is provably behaviour-
+    // preserving on the path it did not aim at.
+    render(
+      <LayeredDiff
+        layered={{ ...layeredWith(null), overlay: { label: 'Client' } }}
+        locale="zh-CN"
+      />,
+    );
+    expect(
+      screen.getByText(translateConsoleValue('layer', 'set', 'zh-CN')),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
+++ b/packages/app-shell/src/views/metadata-admin/LayeredDiff.tsx
@@ -193,7 +193,18 @@ export function LayeredDiff({ layered, loading, locale }: LayeredDiffProps) {
           {t('engine.layers.overlay', locale)}
           {hasOverlay ? (
             <Badge className="ml-1.5 text-[10px] bg-emerald-600 text-emerald-50">
-              {layered.overlayScope ?? translateConsoleValue('layer', 'set', locale)}
+              {/*
+                objectui#4982 — the scope goes through `translateConsoleValue`
+                like the other three layer labels in this list. It used to be
+                rendered raw, so this one badge's language depended on whether
+                the item HAD an overlay: with one, a zh-CN admin read `org` /
+                `env`; without one, the `set` fallback below rendered 「已设」.
+              */}
+              {translateConsoleValue(
+                'layer',
+                layered.overlayScope ?? 'set',
+                locale,
+              )}
             </Badge>
           ) : (
             <Badge variant="outline" className="ml-1.5 text-[10px] text-muted-foreground">

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -54,6 +54,9 @@
  */
 
 import { useObjectTranslation } from '@object-ui/i18n';
+// Type-only (erased at build): the overlay-scope label table below is keyed by
+// the spec's enum rather than by hand — see `LAYER_SCOPE_ZH`.
+import type { MetadataOverlayScope } from '@object-ui/data-objectstack';
 
 export type SupportedLocale = 'en-US' | 'zh-CN';
 
@@ -4103,6 +4106,25 @@ export function translateFlowMeta(
 }
 
 /**
+ * zh-CN labels for the overlay-scope vocabulary, keyed by the spec's own enum.
+ *
+ * The key type is `@objectstack/spec`'s `GetMetaItemLayeredResponseSchema`
+ * `overlayScope` union, reached through `MetadataOverlayScope` — so the day the
+ * spec adds a scope this record stops compiling and names the label that is
+ * missing, instead of the badge silently shipping a raw English value. That
+ * silent path is objectui#4982: `overlayScope` reached the badge untranslated
+ * while the only two values it can hold had no entry in the table below.
+ *
+ * Deliberately zh-only, like every other group here — `translateConsoleValue`
+ * returns the raw value for the other nine locale packs by existing design, and
+ * whether to extend it is a separate decision, not a rider on this fix.
+ */
+const LAYER_SCOPE_ZH: Record<NonNullable<MetadataOverlayScope>, string> = {
+  org: '组织',
+  env: '环境',
+};
+
+/**
  * zh-CN labels for the metadata-editor side panels' raw enum-ish values —
  * History operation badges, Audit operation/outcome/lock-state, and the Layered
  * diff tab badges. Shared by every metadata type (not flow-specific). English
@@ -4122,7 +4144,14 @@ const CONSOLE_VALUE_ZH: Record<string, Record<string, string>> = {
   },
   outcome: { allowed: '允许', denied: '拒绝', forced: '强制' },
   lock: { draft: '草稿', locked: '已锁定', published: '已发布', none: '无' },
-  layer: { artifact: '工件', none: '无', merged: '合并', set: '已设', overlay: '覆盖' },
+  layer: {
+    artifact: '工件',
+    none: '无',
+    merged: '合并',
+    set: '已设',
+    overlay: '覆盖',
+    ...LAYER_SCOPE_ZH,
+  },
 };
 
 /** Localized label for a metadata-editor side-panel value (English = raw). */

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -4576,6 +4576,7 @@ export type {
   MetadataError,
   MetadataValidationIssue,
   MetadataLayered,
+  MetadataOverlayScope,
   MetadataReference,
   MetadataDiagnostics,
   MetadataDiagnosticsOptions,

--- a/packages/data-objectstack/src/metadata-client.overlayScope.test.ts
+++ b/packages/data-objectstack/src/metadata-client.overlayScope.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `MetadataLayered.overlayScope` ↔ spec vocabulary pin (objectui#4982).
+ *
+ * The field was declared `string | null` under a doc comment naming the
+ * vocabulary as `organization | environment | package`. All three spellings are
+ * rejected by the producer's own schema, `package` was never a scope on this
+ * field at all, and `string` meant no compiler anywhere in the repo had an
+ * opinion — so the wrong comment was the only description of the vocabulary a
+ * reader (or an agent) had. It is now derived from
+ * `GetMetaItemLayeredResponseSchema`, and this file is what keeps it derived.
+ *
+ * ## Why the pin is split across two mechanisms
+ *
+ * There is no runtime witness to compare by reference here, so the strongest
+ * form used elsewhere in the repo — `expect(local).toBe(spec)` on a re-exported
+ * zod object (`packages/types/src/__tests__/spec-subschema-parity.test.ts`) —
+ * has nothing to assert: the binding is a TYPE alias, and the shipped module
+ * imports no spec VALUE. Manufacturing one (exporting a copy of the enum's
+ * options from this package purely so a test could pin it) would create exactly
+ * the fork the derivation guard rejects, so it is deliberately not done.
+ *
+ * What replaces it, at the same strength:
+ *
+ *   1. The `satisfies` block below, in BOTH directions. This package's
+ *      `tsconfig.json` includes the whole of `src` (tests included), so
+ *      `pnpm --filter @object-ui/data-objectstack type-check` compiles this
+ *      file — these are enforcement, not decoration (the objectui#3009
+ *      distinction).
+ *   2. The `@ts-expect-error` line. Reverting the field to `string | null` makes
+ *      `'organization'` assignable again, the directive stops suppressing
+ *      anything, and `tsc` fails it as TS2578. That is the one line that turns a
+ *      revert of this fix red.
+ *   3. `LAYER_SCOPE_ZH` in `@object-ui/app-shell`'s metadata-admin `i18n.ts`,
+ *      whose key type is `NonNullable<MetadataOverlayScope>` — a scope the spec
+ *      adds fails to compile there until it has a zh-CN label, which is the
+ *      user-visible half of this bug.
+ */
+import { describe, it, expect } from 'vitest';
+import { GetMetaItemLayeredResponseSchema } from '@objectstack/spec/api';
+import type { MetadataLayered, MetadataOverlayScope } from './metadata-client';
+
+// ── Compile-time: the alias IS the spec's vocabulary, both directions ────────
+
+// Every value the producer can send flows into the alias. A narrower
+// restatement (say, dropping `env`) fails here.
+const _specCovers = null as unknown as 'org' | 'env' | null satisfies MetadataOverlayScope;
+// …and the alias is no WIDER than that. This is the line that fails the day the
+// spec adds a scope — deliberately, because a new scope needs a zh-CN label
+// (see mechanism 3 above) rather than silently reaching the badge.
+const _noWider = null as unknown as MetadataOverlayScope satisfies 'org' | 'env' | null;
+// The interface field is the alias, not a widened `string`.
+const _fieldIsAlias = null as unknown as MetadataLayered['overlayScope'] satisfies MetadataOverlayScope;
+const _org: MetadataLayered['overlayScope'] = 'org';
+const _env: MetadataLayered['overlayScope'] = 'env';
+const _none: MetadataLayered['overlayScope'] = null;
+// @ts-expect-error — objectui#4982: the spelling the old comment claimed is not
+// a value this field can hold. Reverting the narrowing to `string | null` makes
+// this assignment legal and the directive unused, which `tsc` reports as TS2578.
+const _notASpecScope: MetadataLayered['overlayScope'] = 'organization';
+
+// ── Runtime: what the producer's schema actually declares ────────────────────
+
+const specOverlayScope = GetMetaItemLayeredResponseSchema.shape.overlayScope;
+
+describe('MetadataLayered.overlayScope tracks the spec enum (objectui#4982)', () => {
+  it('the producer vocabulary is exactly org | env, plus null', () => {
+    expect(specOverlayScope.unwrap().options).toEqual(['org', 'env']);
+    expect(specOverlayScope.safeParse(null).success).toBe(true);
+  });
+
+  it('rejects all three spellings the old doc comment claimed', () => {
+    // Not "these are wrong today" — they were never right. `package` in
+    // particular is a scope this field has never carried in any spec release.
+    for (const claimed of ['organization', 'environment', 'package']) {
+      expect(
+        specOverlayScope.safeParse(claimed).success,
+        `spec unexpectedly accepts '${claimed}' — re-read the derivation`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/data-objectstack/src/metadata-client.ts
+++ b/packages/data-objectstack/src/metadata-client.ts
@@ -32,7 +32,10 @@
  * type, mirroring the framework's "single Zod source per type" rule.
  */
 
-import type { RuntimeAuthoringIssue } from '@objectstack/spec/api';
+import type {
+  GetMetaItemLayeredResponse,
+  RuntimeAuthoringIssue,
+} from '@objectstack/spec/api';
 
 /**
  * One advisory finding the framework's runtime authoring gate produced for a
@@ -240,6 +243,29 @@ export interface MetadataDeleteOptions extends MetadataClientSaveOptions {
 }
 
 /**
+ * Which layer an overlay was saved at — `'org'` for a tenant overlay, `'env'`
+ * for an environment-level one, `null` exactly when `overlay` is null.
+ *
+ * DERIVED from `@objectstack/spec`, not restated: the vocabulary lives once, in
+ * `GetMetaItemLayeredResponseSchema`'s `overlayScope`
+ * (`z.enum(['org', 'env']).nullable()`), and this alias indexes the published
+ * response type so a scope the spec adds arrives here with no edit. Restating
+ * the union locally is the fork `scripts/check-spec-symbol-derivation.mjs`
+ * exists to reject, and the mirror-image mistake — a consumer re-spelling a
+ * producer's enum — is what this field carried until objectui#4982.
+ *
+ * What it carried: `string | null`, under a comment naming the vocabulary as
+ * `organization | environment | package`. Not one of those three spellings is a
+ * value the producer emits (`metadata-protocol`'s two assignment sites write
+ * `'org'` / `'env'`); the schema rejects all three by name, and `package` is
+ * not a scope this field has ever had. Because the declared type was `string`
+ * the compiler had no opinion, so the wrong comment was the only description of
+ * the vocabulary — a planted premise rather than stale prose, and the reason
+ * the Studio's layer badge shipped the raw value straight to screen.
+ */
+export type MetadataOverlayScope = GetMetaItemLayeredResponse['overlayScope'];
+
+/**
  * Layered view of a metadata item — the body of
  * `GET /meta/:type/:name/layers` (`GetMetaItemLayeredResponseSchema`).
  *
@@ -252,8 +278,11 @@ export interface MetadataLayered<T = unknown> {
   code: T | null;
   /** Org/environment overlay (just the saved delta or full overlay row). */
   overlay: T | null;
-  /** Overlay scope (`organization` | `environment` | `package` | null). */
-  overlayScope: string | null;
+  /**
+   * Which layer {@link MetadataLayered.overlay} came from, or null when there
+   * is no overlay. Spec-derived — see {@link MetadataOverlayScope}.
+   */
+  overlayScope: MetadataOverlayScope;
   /** Merged effective view — what the runtime actually sees. */
   effective: T | null;
   /**


### PR DESCRIPTION
Fixes #4982

## 前提复核(锚点在合并后 ref 上重定位)

基线 `origin/main` = `85fdb0612`,#4016 的 PR #4988(`cf4f8a6e4`)已在其中。分诊要求的硬串行门已满足,三处锚点复核如下:

| 卡面锚点 | 合并后 ref 坐标 | 说明 |
|---|---|---|
| `metadata-client.ts` 的 `MetadataLayered.overlayScope` | 255(错注释)/ 256(声明) | #4988 之前在 249,被该 PR 下推 7 行 |
| `LayeredDiff.tsx:196` | 196,未移动 | |
| `i18n.ts:4125`(`CONSOLE_VALUE_ZH.layer`) | 4125,未移动 | |

卡面三条事实逐条复核**为真**:

1. 声明是 `string | null`,紧邻注释把词表写成 `organization | environment | package`;
2. 装到本仓的 `@objectstack/spec@17.0.0` 里,`GetMetaItemLayeredResponseSchema` 的 `overlayScope` 是 `z.enum(['org', 'env']).nullable()` —— 实测该 schema 对上面三种拼法**逐个拒绝**,`package` 这个 scope 在此字段上从来没有过;
3. 全仓 `overlayScope` 的取值面只有 `null`(23 处)与 `'org'`(4 处),没有任何一处写那三种拼法 —— 所以收窄不会打断任何现存调用点。

## 改动

**契约侧(`@object-ui/data-objectstack`)** —— 词表从 spec **派生**,不在消费侧复述:

```ts
export type MetadataOverlayScope = GetMetaItemLayeredResponse['overlayScope'];
```

以索引 spec 已发布响应类型的方式绑定,spec 日后加一个 scope 本仓自动跟随。复述一份局部 union 正是 `check:spec-symbol-derivation` 要拒绝的 fork 的镜像类,所以没有走那条路;别名随包导出(`MetadataOverlayScope`),字段与那条错注释一并改正。

因为原声明是 `string`,编译器对这个字段从来没有意见,那条错注释就成了它**唯一**的说明 —— 不是过时文档,而是给下一位读者(或 agent)埋的前提。

**用户可见侧(`@object-ui/app-shell`)** —— `LayeredDiff` 的 overlay 徽标此前把原值直出,而同一列表另外三个层徽标(artifact / none / merged)全部过 `translateConsoleValue`,且 `CONSOLE_VALUE_ZH.layer` 对该字段能取的两个值都没有条目。结果是同一个徽标的语言取决于数据:zh-CN 管理员打开任一**有** overlay 的元数据项读到裸英文 `org` / `env`,没有 overlay 的走 `set` 支路才读到「已设」。现在它与三个同伴一致过翻译,层词表补入「组织」/「环境」。

补的那两条不是手写键,而是**以 spec union 为键**:

```ts
const LAYER_SCOPE_ZH: Record< NonNullable< MetadataOverlayScope >, string > = {
  org: '组织',
  env: '环境',
};
```

spec 日后新增 scope 会在 `type-check` 处失败并点名缺失的标签,而不是让英文原值悄悄漏到界面上 —— 也就是让这个 bug 的形状在**编写期**就无法再成立。

**禁区已守**:`translateConsoleValue` 仍然只对 zh 生效(所有分组一致,其余语言恒返回原值),这是它的现有设计;是否扩到十个语言包是独立决定,本 PR 不搭车,并且专门留了一条 en-US 用例把「没有顺手改」钉住。

## 测试

- `pnpm exec vitest run packages/data-objectstack/ packages/app-shell/src/views/metadata-admin/ --maxWorkers=2` → **214 files / 2274 passed, 1 skipped**
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **81 successful, 81 total**,零 TS 错误
- `node scripts/check-control-bytes.mjs`(4465 个文件)、`node scripts/check-spec-symbol-derivation.mjs`、`node scripts/check-changeset-no-major.mjs` 全绿
- 改动文件 eslint:**0 error**(仅既有 `no-explicit-any` / `react-refresh` warning,均不在本 diff 触及的行上)

新增两个文件,共 8 条用例。

### 关于「引用同一性 `toBe`」这一钉:此处不适用,如实记录

本仓最强的派生钉形态是 `expect(local).toBe(spec)`(见 `packages/types/src/__tests__/spec-subschema-parity.test.ts` —— 忠实的拷贝也会红,因为拷贝就是 fork)。**这里没有可比的运行期见证**:绑定是**类型**别名,产品代码只 `import type`,不引入任何 spec **值**。为了让一条 `toBe` 有东西可比而从本包导出一份 enum options 拷贝,恰好就是那个 guard 要拒绝的 fork,所以刻意不做。同等强度的替代是三条:

1. 双向 `satisfies`(spec 成员全部流入别名 / 别名不比 spec 更宽)。本包 `tsconfig.json` 的 `include` 覆盖整个 `src`(含测试),所以 `type-check` 真的编译它们 —— 是 enforcement,不是装饰(objectui#3009 的区分);
2. 一条 `@ts-expect-error`:把收窄退回 `string | null`,`'organization'` 重新可赋值,该指令失去抑制对象,`tsc` 以 TS2578 报红。**这是让本修复的回退变红的那一行**;
3. app-shell 的 `LAYER_SCOPE_ZH` 键类型 —— 编译期覆盖,见上。

app-shell 一侧的用例不写死 scope 清单,而是从 `GetMetaItemLayeredResponseSchema` 读 options 迭代,spec 新增的 scope 一存在就自动进入覆盖。

### 反向验证(先书面预判,commit 后变异,`git checkout --` 还原,⛔ stash)

三条变异全部**与预判一致**,无一条需要改写预判:

| 变异 | 预判 | 实测 |
|---|---|---|
| ① `overlayScope` 退回 `string \| null`(保留别名) | `type-check` 红:TS2578(`@ts-expect-error` 失效)+ `_fieldIsAlias` 的 `satisfies` 失败;**vitest 仍绿** | ✅ 一致。`tsc` 恰好两条错误:`metadata-client.overlayScope.test.ts(54,74): error TS1360: Type 'string \| null' does not satisfy the expected type '"org" \| "env" \| null'` 与 `(58,1): error TS2578: Unused '@ts-expect-error' directive`;同一文件 vitest **2 passed** |
| ② 去掉 `CONSOLE_VALUE_ZH.layer` 里的 `...LAYER_SCOPE_ZH` | app-shell 套件红:覆盖用例报 `no entry for overlay scope 'org'`,两条渲染用例读到裸英文徽标 | ✅ 一致。**3 failed / 3 passed**,首条错误逐字为 `AssertionError: CONSOLE_VALUE_ZH.layer has no entry for overlay scope 'org': expected 'org' not to be 'org'`;两条渲染用例栽在 `queryByText(scope)` 上 —— 裸值确实在屏幕上 |
| ③ 徽标退回 `layered.overlayScope ?? …` 原值直出 | 两条 zh 渲染用例红、覆盖用例仍绿 | ✅ 一致。**2 failed / 4 passed**,红的正是 `overlayScope=org` / `=env` 两条 |

① 的预判方向值得单独说明:它**不是**「钉子变红」的常规方向。派生钉是编译期的,所以退回收窄后 `vitest` 会一直绿 —— 只有 `type-check` 会红,实测也正是如此(2 passed)。把它写成「测试变红」会是一份符合模板、读起来却像已验证的伪造,所以这里照实分开写。

②③ 合起来把这个 bug 的两半分开钉住:③ 只动渲染(词表在,徽标不查表)→ 覆盖用例仍绿;② 只动词表(徽标查表,表里没有)→ 覆盖用例也红。两半各有各的红。

还原后三个文件回到 HEAD,`git status` 干净,重跑两文件 **8 passed**。

## 顺手发现(已另立卡,未在本 PR 修复)

同一张 `CONSOLE_VALUE_ZH` 表的邻组 `lock` 与 `MetadataAuditEntry.lockState` **完全错位**(命中率 0/3:表里 4 条有 3 条对不上任何可能值,唯一对得上的 `none` 被调用点显式排除,而实际能送到的 `no-overlay` / `no-delete` / `full` 一条都没有):已按 Prime Directive #10 立为 #5004,未认领,未在本 PR 修复。它的修法与本卡**不同**(那套 4 态锁在本仓是手写 union,spec 没有可派生的 enum),所以不是本卡的子任务。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_