### PR TITLE
fix(console): PublicFormsPage 的 redirect 授权门改问契约,越契约值在保存时刻被拒 (#4990)

### DIFF
--- a/.changeset/public-forms-redirect-authoring-door-4990.md
+++ b/.changeset/public-forms-redirect-authoring-door-4990.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/console": patch
+---
+
+The Public Forms dialog now refuses an out-of-contract `submitBehavior.url` at the moment it is authored, with the contract's own prescription shown next to the field (objectui#4990).
+
+The redirect branch validated one thing — that the field was not empty — and wrote whatever else was typed into the view metadata. objectstack#7496 rules this key **relative-only** and refuses seven families of value; this door enforced the first. An admin could type `https://example.com/thanks`, or `javascript:alert(1)`, and be told nothing by the surface that had just taught them the value was acceptable — the field was `type="url"`, whose own notion of valid is an absolute URL, under a `https://example.com/thanks` placeholder.
+
+What changed:
+
+- **The save is refused, with the spec's sentence.** The verdict comes from `checkSubmitRedirectUrl`, the same `@objectstack/spec` `FormViewSchema` parse the renderer already asks at submit time — now exported from `submitRedirect` and called by the door. An absolute URL, a script or data scheme, a protocol-relative `//host`, a backslash, whitespace or a control character, a malformed `{{record.field_name}}` token, a document-relative path and an empty value each get their own author-facing prescription, naming the rule and what to write instead. The rule is not restated here: a second copy in the dialog would pass every value comparison right up to the release that moved the original, so a later widening of the ruling is followed by the pin rather than by an edit.
+- **`Redirect URL is required` is gone.** Empty is one of the seven families, so it routes through the contract too and the author reads a sentence that says what a destination looks like.
+- **The field no longer teaches the wrong value.** It is a plain text input with a `/thanks` placeholder, and a hint stating the rule — an in-app path, `{{record.field_name}}` interpolation, and the app navigation item that is declared for a deliberately external destination.
+
+The saved value is the one the schema accepted, read back off the parse, so the door and the renderer cannot hold different opinions about a destination. `thank-you`'s `title` and `message` stay unvalidated deliberately: the spec declares both as free-form strings, so there is no contract for a door to state about them.
+
+The server's own metadata gate already refused these bodies (`422 invalid_metadata` on `submitBehavior.url`, from the same schema), so this closes an error path rather than a silent-save hole: the correction now arrives in the field the admin can fix instead of as a failed round-trip.

--- a/apps/console/src/components/submitRedirect.test.ts
+++ b/apps/console/src/components/submitRedirect.test.ts
@@ -58,7 +58,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { FormViewSchema } from '@objectstack/spec/ui';
-import { resolveSubmitRedirect } from './submitRedirect';
+import { checkSubmitRedirectUrl, resolveSubmitRedirect } from './submitRedirect';
 
 /**
  * The contract's verdict on one authored value — the same minimal parse the
@@ -67,6 +67,21 @@ import { resolveSubmitRedirect } from './submitRedirect';
  */
 function specAccepts(url: string): boolean {
   return FormViewSchema.safeParse({ submitBehavior: { kind: 'redirect', url } }).success;
+}
+
+/**
+ * The contract's own prescription for a value it refuses, read off the same
+ * parse. Used to pin message PROVENANCE rather than message wording: a reworded
+ * spec keeps these tests green, a hand-written copy in either caller does not.
+ */
+function specRefusalMessage(url: string): string {
+  const parsed = FormViewSchema.safeParse({ submitBehavior: { kind: 'redirect', url } });
+  if (parsed.success) throw new Error(`fixture is IN contract, not out of it: ${url}`);
+  const onUrl = parsed.error.issues.find(
+    (issue) => issue.path[0] === 'submitBehavior' && issue.path[1] === 'url',
+  );
+  if (!onUrl) throw new Error(`the schema refused ${url} on some other path`);
+  return onUrl.message;
 }
 
 /** Values the ruling allows: rooted, relative, optionally interpolated. */
@@ -224,6 +239,43 @@ describe('interpolation — the consumer’s half of the ruling', () => {
       if (!verdict.ok) continue;
       expect(verdict.path).not.toContain('{');
       expect(verdict.path).not.toContain('}');
+    }
+  });
+});
+
+/**
+ * `checkSubmitRedirectUrl` — the shape half of the ruling, exported for the
+ * authoring door (objectui#4990).
+ *
+ * The console's Public Forms dialog validated one of the seven families and
+ * saved the rest into view metadata unexamined. It now calls this, so the
+ * property under test is not "the door has a rule" but "the door and the
+ * renderer cannot hold different opinions about a value, because there is one
+ * parse". That is what a second hand-written copy in the dialog would take away
+ * while passing every value comparison until the spec moved.
+ */
+describe('the authoring door asks the same question (#4990)', () => {
+  it.each(IN_CONTRACT)('accepts %j, handing back the value the schema accepted', (url) => {
+    expect(checkSubmitRedirectUrl(url)).toEqual({ ok: true, url });
+  });
+
+  it.each(OUT_OF_CONTRACT)('refuses %s with the spec’s own prescription', (_label, url) => {
+    // Direction first: the contract itself rejects this value, so the refusal
+    // below is the contract's and not this module's private opinion.
+    expect(specAccepts(url)).toBe(false);
+
+    const verdict = checkSubmitRedirectUrl(url);
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) return;
+    expect(verdict.refusal).toBe(specRefusalMessage(url));
+  });
+
+  it('never disagrees with the renderer about a value', () => {
+    for (const url of [...IN_CONTRACT, ...OUT_OF_CONTRACT.map(([, u]) => u)]) {
+      const door = checkSubmitRedirectUrl(url);
+      const renderer = resolveSubmitRedirect(url, { id: 'x', slug: 's', status: 'open' });
+      expect(door.ok).toBe(renderer.ok);
+      if (!door.ok && !renderer.ok) expect(door.refusal).toBe(renderer.refusal);
     }
   });
 });

--- a/apps/console/src/components/submitRedirect.ts
+++ b/apps/console/src/components/submitRedirect.ts
@@ -25,12 +25,27 @@
  * reference-integrity family owns that. Point 2's "when the redirect is built"
  * and point 3's consumption are runtime, and this module is where they happen.
  *
+ * ## Both layers ask the same question here (objectui#4990)
+ *
+ * "The spec enforces point 1 at the authoring door" is only true of a door that
+ * ASKS it. This repo ships one — the console's Public Forms dialog — and it
+ * enforced exactly one of the seven refusal families (empty), writing the other
+ * six into view metadata unexamined. So the parse below is exported as
+ * {@link checkSubmitRedirectUrl} and called there at save time: one parse, two
+ * callers, one spelling of a security rule. The author now reads the spec's
+ * prescription at the moment they can still fix the value, and the submitter
+ * never meets a destination the door let past.
+ *
+ * The door needs the verdict on the string alone — there is no record at
+ * authoring time — which is why the shape check and the substitution are
+ * separate exports rather than one function with an optional scope.
+ *
  * ## The shape verdict is the spec's, not a copy of it
  *
  * `@objectstack/spec` does not export its URL check as a function, but it does
  * export the schema the check lives in, so the verdict here is produced by
  * PARSING the smallest form view that carries this behavior. That costs one
- * parse per submit and buys the property that matters: there is no second
+ * parse per submit or save and buys the property that matters: there is no second
  * spelling of a security rule in this repo to drift from the first. When the
  * ruling widens — it says an allowlist of absolute origins "waits for measured
  * demand" — the console follows the pin with no edit here, which is the same
@@ -42,12 +57,8 @@
  * objectui#4074/#4588/#4592): a hand copy passes every value comparison right
  * up to the release that moves the original.
  *
- * Parsing a MINIMAL view is load-bearing, not laziness. A whole stored
- * `FormView` refuses on any unrelated key the strict schema does not know, and
- * a redirect must not be refused because some other part of the metadata
- * drifted. The question asked here is narrow — "is this url a value the
- * contract allows?" — so only that value is submitted for judgement, and only
- * issues on that value's path are read back.
+ * That the parsed view is a MINIMAL one is load-bearing, not laziness — see
+ * {@link checkSubmitRedirectUrl}, which is where the parse lives.
  *
  * Neither the import nor the parse is new ground in this repo, which is worth
  * knowing before weighing the cost:
@@ -124,6 +135,56 @@ interface SubmitRedirectRefused {
 export type SubmitRedirectVerdict = SubmitRedirectAccepted | SubmitRedirectRefused;
 
 /**
+ * The contract's verdict on one authored `url`, before any substitution: `url`
+ * is the value the schema accepted, and the refused arm is the same
+ * author-facing prose the renderer quotes.
+ */
+export type SubmitRedirectUrlVerdict = { ok: true; url: string } | SubmitRedirectRefused;
+
+/**
+ * Ask the contract whether an authored `submitBehavior.url` is a value it
+ * accepts, and get its own prescription back when it is not.
+ *
+ * This is the shape half of the ruling — the half that needs only the string —
+ * so it is what an authoring door calls before writing the value, and what
+ * {@link resolveSubmitRedirect} calls before substituting into it.
+ *
+ * Parsing a MINIMAL view is load-bearing, not laziness. A whole stored
+ * `FormView` refuses on any unrelated key the strict schema does not know, and
+ * neither a redirect nor a save dialog must be refused because some other part
+ * of the metadata drifted. The question asked here is narrow — "is this url a
+ * value the contract allows?" — so only that value is submitted for judgement,
+ * and only issues on that value's path are read back.
+ */
+export function checkSubmitRedirectUrl(url: string): SubmitRedirectUrlVerdict {
+  const parsed = FormViewSchema.safeParse({ submitBehavior: { kind: 'redirect', url } });
+
+  if (!parsed.success) {
+    // Only this value was submitted for judgement, so an issue on its path is
+    // the answer; the two fallbacks exist so a refusal is never silent, not
+    // because either is expected to be reached.
+    const onUrl = parsed.error.issues.find(
+      (issue) => issue.path[0] === 'submitBehavior' && issue.path[1] === 'url',
+    );
+    return {
+      ok: false,
+      refusal:
+        onUrl?.message
+        ?? parsed.error.issues[0]?.message
+        ?? `\`submitBehavior.url\` is not a value this contract accepts: ${JSON.stringify(url)}.`,
+    };
+  }
+
+  // Read the value back off the parse rather than reusing the input: the schema
+  // is the authority on what it accepted, so if it ever normalises the string
+  // both callers follow without a second edit. Today the two are identical —
+  // the key is a plain string with a refinement, deliberately, so that what is
+  // saved and what reaches the renderer stay the string the author wrote.
+  const behavior = parsed.data.submitBehavior;
+  return { ok: true, url: behavior?.kind === 'redirect' ? behavior.url : url };
+}
+
+/**
  * The string form of a record value inside a URL.
  *
  * Scalars only, and that is not a shortcut: the ruling accepts a FLAT field
@@ -179,33 +240,10 @@ export function resolveSubmitRedirect(
   url: string,
   record: Record<string, unknown>,
 ): SubmitRedirectVerdict {
-  const parsed = FormViewSchema.safeParse({ submitBehavior: { kind: 'redirect', url } });
+  const verdict = checkSubmitRedirectUrl(url);
+  if (!verdict.ok) return verdict;
 
-  if (!parsed.success) {
-    // Only this value was submitted for judgement, so an issue on its path is
-    // the answer; the two fallbacks exist so a refusal is never silent, not
-    // because either is expected to be reached.
-    const onUrl = parsed.error.issues.find(
-      (issue) => issue.path[0] === 'submitBehavior' && issue.path[1] === 'url',
-    );
-    return {
-      ok: false,
-      refusal:
-        onUrl?.message
-        ?? parsed.error.issues[0]?.message
-        ?? `\`submitBehavior.url\` is not a value this contract accepts: ${JSON.stringify(url)}.`,
-    };
-  }
-
-  // Read the value back off the parse rather than reusing the input: the schema
-  // is the authority on what it accepted, so if it ever normalises the string
-  // this follows without a second edit. Today the two are identical — the key
-  // is a plain string with a refinement, deliberately, so that what reaches
-  // this renderer stays the string the author wrote.
-  const behavior = parsed.data.submitBehavior;
-  const accepted = behavior?.kind === 'redirect' ? behavior.url : url;
-
-  const path = accepted.replace(RECORD_TOKEN_RE, (_token, field: string) =>
+  const path = verdict.url.replace(RECORD_TOKEN_RE, (_token, field: string) =>
     encodeURIComponent(urlValue(record[field])),
   );
 

--- a/apps/console/src/pages/developer/PublicFormsPage.redirect.test.tsx
+++ b/apps/console/src/pages/developer/PublicFormsPage.redirect.test.tsx
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4990 — the Public Forms dialog is an authoring door for
+ * `submitBehavior.url`, so it must refuse what the contract refuses.
+ *
+ * The ruling is objectstack#7496 (2026-08-11), landed in `@objectstack/spec` by
+ * objectstack#7657 and live on this repo's 17.0.0 GA pin: the key is a RELATIVE
+ * in-app path, interpolated only as `{{record.field_name}}`. The spec refuses
+ * seven families of value, each with its own author-facing prescription. This
+ * dialog enforced ONE of them — non-empty — and wrote the other six into view
+ * metadata unexamined.
+ *
+ * ## What is pinned, and against what
+ *
+ * The oracle is the contract itself. `specRefusal()` below performs the same
+ * minimal parse an authoring door performs and reads the message off it, so
+ * every expectation here is "the dialog showed the SPEC's sentence", never "the
+ * dialog showed this string I typed into a test". That distinction is the whole
+ * point of the fix: a local copy of the seven prescriptions would pass a
+ * literal-text assertion right up to the spec release that reworded one, which
+ * is the drift `scripts/check-spec-symbol-derivation.mjs` exists to discourage.
+ * These tests follow the pin instead — reword the spec and they still pass;
+ * hand-write the message in the dialog and they fail.
+ *
+ * The second half of every refusal case is that `meta.saveItem` was NOT called.
+ * A dialog that showed the refusal and saved anyway would be the same corpus
+ * defect wearing an error's clothes.
+ *
+ * ## Reverse verification — predicted first, then measured
+ *
+ * 1. **Reverting the door to the non-empty check** (`if (!editBehaviorUrl)` +
+ *    `url: editBehaviorUrl`): all eight out-of-contract cases go RED, and each
+ *    fails on BOTH assertions — `saveItem` is called with the rejected value,
+ *    and no alert renders to read a message from. The empty case stays GREEN in
+ *    its save-blocking half (the old code refused empty too) and goes RED on the
+ *    message, because `Redirect URL is required` is not the spec's sentence.
+ *    The in-contract cases and the thank-you boundary case stay green.
+ * 2. **Keeping the parse but showing a local string** (`setEditUrlRefusal('That
+ *    URL is not allowed')`): every refusal case stays green on `saveItem` and
+ *    goes RED on the message comparison — the narrow change detector for message
+ *    PROVENANCE, which is the property a second copy of the rule would silently
+ *    take away.
+ *
+ * Control characters in the fixtures below are written as escape sequences on
+ * purpose — a raw one makes the whole file read as binary to grep, and this repo
+ * has paid for that four times (objectui#4890 among them).
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormViewSchema } from '@objectstack/spec/ui';
+
+/**
+ * One published public form: `isForm` needs a form-ish shape, and the page only
+ * lists a row when `sharing.allowAnonymous` and a parseable `publicLink` are
+ * both present.
+ */
+const { saveItem, ADAPTER } = vi.hoisted(() => {
+  const spec = {
+    name: 'showcase_task.public',
+    label: 'Log Time',
+    object: 'showcase_task',
+    type: 'simple',
+    sections: [{ label: 'Task', fields: ['title'] }],
+    sharing: { enabled: true, allowAnonymous: true, publicLink: '/forms/log-time' },
+  };
+  const saveItem = vi.fn(async () => ({ ok: true }));
+  // A STABLE singleton: a fresh object per render loops the page's load effect.
+  const ADAPTER = {
+    getClient: () => ({
+      meta: {
+        getItems: async (type: string) => (type === 'view' ? [{ spec }] : []),
+        saveItem,
+      },
+    }),
+  };
+  return { saveItem, ADAPTER };
+});
+
+vi.mock('@object-ui/app-shell', () => ({ useAdapter: () => ADAPTER }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// Imported AFTER the mocks so the page picks them up.
+import { PublicFormsPage } from './PublicFormsPage';
+
+/**
+ * The contract's own prescription for one authored value — the same minimal
+ * parse the door performs, spelled out here independently so the test states the
+ * question rather than borrowing the door's answer.
+ */
+function specRefusal(url: string): string {
+  const parsed = FormViewSchema.safeParse({ submitBehavior: { kind: 'redirect', url } });
+  if (parsed.success) throw new Error(`fixture is IN contract, not out of it: ${url}`);
+  const onUrl = parsed.error.issues.find(
+    (issue) => issue.path[0] === 'submitBehavior' && issue.path[1] === 'url',
+  );
+  if (!onUrl) throw new Error(`the schema refused ${url} on some other path`);
+  return onUrl.message;
+}
+
+/**
+ * Put a value in the field with `fireEvent.change` rather than `user.type`.
+ *
+ * Not a shortcut: userEvent's keyboard DSL reads `{` and `[` as key descriptors
+ * — `{{` types ONE literal brace and `{record.id}` reads as an unknown key —
+ * and half of these fixtures exist to be about braces. What the door reacts to
+ * is the change event, so dispatching it directly asks the same question of the
+ * same handler without fighting the DSL over the fixture's own content.
+ */
+function setUrl(field: HTMLElement, value: string) {
+  fireEvent.change(field, { target: { value } });
+}
+
+/** Open the row's editor and switch the post-submit behavior to `redirect`. */
+async function openRedirectEditor(user: ReturnType<typeof userEvent.setup>) {
+  render(<PublicFormsPage />);
+  await user.click(
+    await screen.findByRole('button', { name: /Edit sharing & post-submit behavior/i }),
+  );
+  await user.selectOptions(await screen.findByLabelText(/After submit/i), 'redirect');
+  return screen.getByLabelText(/Redirect URL/i);
+}
+
+beforeEach(() => saveItem.mockClear());
+afterEach(cleanup);
+
+/**
+ * One fixture per family the spec's check defends, named by what saving it would
+ * have put into the metadata corpus.
+ */
+const OUT_OF_CONTRACT: Array<[label: string, url: string]> = [
+  ['an absolute URL — the open redirect the ruling closed', 'https://example.com/thanks'],
+  ['a script scheme, the same refusal for a stronger reason', 'javascript:alert(1)'],
+  ['protocol-relative: another origin despite the leading slash', '//evil.example/thanks'],
+  ['a backslash, which browsers normalise to a slash while resolving', '/\\evil.example'],
+  ['whitespace, stripped before resolving and hiding the real start', '/ thanks'],
+  ['a tab, the same smuggle in a form that is easy to miss', '/\u0009thanks'],
+  ['a single-brace near-miss of the token spelling', '/thanks?x={record.id}'],
+  ['document-relative, so one form lands in different places', 'thanks'],
+];
+
+describe('the redirect door refuses what the contract refuses (#4990)', () => {
+  it.each(OUT_OF_CONTRACT)('refuses %s', async (_label, url) => {
+    const user = userEvent.setup();
+    const field = await openRedirectEditor(user);
+
+    setUrl(field, url);
+    await user.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    // The value never reaches the metadata corpus.
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(saveItem).not.toHaveBeenCalled();
+
+    // And the sentence the author reads is the SPEC's, not this dialog's. This
+    // is the assertion a hand-written mirror of the rule would fail.
+    expect(screen.getByRole('alert')).toHaveTextContent(specRefusal(url));
+  });
+
+  /**
+   * Empty is the one family the old door DID catch, with a local
+   * `Redirect URL is required`. It routes through the contract now for the same
+   * reason as the other seven: the spec's sentence says what to write instead.
+   */
+  it('refuses empty with the contract’s prescription, not a local “required”', async () => {
+    const user = userEvent.setup();
+    const field = await openRedirectEditor(user);
+
+    setUrl(field, '');
+    await user.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(saveItem).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(specRefusal(''));
+  });
+
+  it('marks the field invalid and describes it by the refusal', async () => {
+    const user = userEvent.setup();
+    const field = await openRedirectEditor(user);
+
+    setUrl(field, 'https://example.com/thanks');
+    await user.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => expect(field).toHaveAttribute('aria-invalid', 'true'));
+    expect(field).toHaveAttribute('aria-describedby', 'edit-url-refusal');
+  });
+
+  it('clears the refusal when the author starts fixing the value', async () => {
+    const user = userEvent.setup();
+    const field = await openRedirectEditor(user);
+
+    setUrl(field, 'https://example.com/thanks');
+    await user.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    setUrl(field, '/thanks');
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+});
+
+describe('in-contract values still save (#4990)', () => {
+  it.each([
+    ['a rooted in-app path', '/thanks'],
+    ['a path with a query', '/thanks?ref=42'],
+    ['an interpolated path, the one form the ruling allows', '/t/{{record.slug}}?r={{record.id}}'],
+  ])('saves %s unchanged', async (_label, url) => {
+    const user = userEvent.setup();
+    const field = await openRedirectEditor(user);
+
+    setUrl(field, url);
+    await user.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => expect(saveItem).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(saveItem).toHaveBeenCalledWith(
+      'view',
+      'showcase_task.public',
+      expect.objectContaining({ submitBehavior: { kind: 'redirect', url } }),
+    );
+  });
+
+  /**
+   * The scope boundary, pinned so a later reading of #4990 does not widen it by
+   * accident: `thank-you`'s `title` and `message` are free-form strings in the
+   * spec, so there is no contract for this door to state about them — even when
+   * the text happens to look like the address the redirect key refuses.
+   */
+  it('leaves thank-you title/message unvalidated — the spec declares them free text', async () => {
+    const user = userEvent.setup();
+    render(<PublicFormsPage />);
+    await user.click(
+      await screen.findByRole('button', { name: /Edit sharing & post-submit behavior/i }),
+    );
+
+    setUrl(await screen.findByLabelText(/^Title$/i), 'https://example.com/thanks');
+    setUrl(screen.getByLabelText(/^Message$/i), 'See javascript:alert(1) below');
+    await user.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => expect(saveItem).toHaveBeenCalledTimes(1));
+    expect(saveItem).toHaveBeenCalledWith(
+      'view',
+      'showcase_task.public',
+      expect.objectContaining({
+        submitBehavior: {
+          kind: 'thank-you',
+          title: 'https://example.com/thanks',
+          message: 'See javascript:alert(1) below',
+        },
+      }),
+    );
+  });
+});

--- a/apps/console/src/pages/developer/PublicFormsPage.tsx
+++ b/apps/console/src/pages/developer/PublicFormsPage.tsx
@@ -6,6 +6,29 @@
  * Console is not project-scoped, so there is no `useParams().package`, no
  * `<Link>` to the legacy metadata editor, and no `useMetadataHmr` polling —
  * refresh is driven by the explicit Refresh button.
+ *
+ * ## The redirect field is an authoring door, so it states the contract
+ *
+ * `submitBehavior.url` is ruled relative-only (objectstack#7496, landed by
+ * objectstack#7657 in the `@objectstack/spec` 17.0.0 GA pin this repo installs),
+ * and the spec refuses seven families of value with an author-facing
+ * prescription for each. This dialog used to enforce one of them — non-empty —
+ * and save the rest into view metadata unexamined (objectui#4990), so an admin
+ * could type `https://example.com/thanks`, or `javascript:alert(1)`, and be
+ * told nothing.
+ *
+ * `checkSubmitRedirectUrl` (from the renderer's own `submitRedirect`) is asked
+ * instead, at save time, and its refusal — the spec's prose, verbatim — is shown
+ * next to the field. That reuse is the point: a hand-written mirror of the seven
+ * families here is exactly the shape `scripts/check-spec-symbol-derivation.mjs`
+ * exists to discourage, and it would be a second spelling of a security rule
+ * that passes every value comparison right up to the release that moves the
+ * original. The door and the renderer now refuse identically because they are
+ * one parse.
+ *
+ * `thank-you`'s `title` / `message` stay unvalidated deliberately: the spec
+ * declares both as free-form strings, so there is no contract for a door to
+ * state.
  */
 
 import { useEffect, useState } from 'react';
@@ -35,6 +58,7 @@ import {
 } from '@object-ui/components';
 import { Copy, ExternalLink, FormInput, RefreshCw, Code2, Link2, Settings2, Plus } from 'lucide-react';
 import { toast } from 'sonner';
+import { checkSubmitRedirectUrl } from '../../components/submitRedirect';
 
 interface PublicFormRow {
   name: string;
@@ -84,6 +108,13 @@ export function PublicFormsPage() {
   const [editBehaviorTitle, setEditBehaviorTitle] = useState('');
   const [editBehaviorMessage, setEditBehaviorMessage] = useState('');
   const [editBehaviorUrl, setEditBehaviorUrl] = useState('');
+  /**
+   * The contract's refusal for the value currently in the Redirect URL field,
+   * or null while there is nothing to say. Set only by a save attempt — typing
+   * clears it, so the author is corrected once, at the moment they asked to
+   * commit, rather than nagged mid-keystroke.
+   */
+  const [editUrlRefusal, setEditUrlRefusal] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const load = async () => {
@@ -209,6 +240,7 @@ export function PublicFormsPage() {
     setEditBehaviorTitle(sb?.title ?? '');
     setEditBehaviorMessage(sb?.message ?? '');
     setEditBehaviorUrl(sb?.url ?? '');
+    setEditUrlRefusal(null);
     setEditOpen(true);
   };
 
@@ -219,6 +251,7 @@ export function PublicFormsPage() {
       toast.error('Invalid slug');
       return;
     }
+    setEditUrlRefusal(null);
     let submitBehavior: any;
     switch (editBehavior) {
       case 'thank-you':
@@ -226,13 +259,20 @@ export function PublicFormsPage() {
         if (editBehaviorTitle) submitBehavior.title = editBehaviorTitle;
         if (editBehaviorMessage) submitBehavior.message = editBehaviorMessage;
         break;
-      case 'redirect':
-        if (!editBehaviorUrl) {
-          toast.error('Redirect URL is required');
+      case 'redirect': {
+        // The contract's verdict, not this dialog's: empty is one of the seven
+        // families the spec refuses, so it comes back through here too rather
+        // than keeping a local `required` message that says less.
+        const verdict = checkSubmitRedirectUrl(editBehaviorUrl);
+        if (!verdict.ok) {
+          setEditUrlRefusal(verdict.refusal);
           return;
         }
-        submitBehavior = { kind: 'redirect', url: editBehaviorUrl };
+        // The value the schema accepted, so a future normalisation in the spec
+        // is what gets saved — the same read-back the renderer does.
+        submitBehavior = { kind: 'redirect', url: verdict.url };
         break;
+      }
       case 'continue':
       case 'next-record':
         submitBehavior = { kind: editBehavior };
@@ -480,7 +520,10 @@ export function PublicFormsPage() {
                 id="edit-behavior"
                 className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
                 value={editBehavior}
-                onChange={(e) => setEditBehavior(e.target.value as any)}
+                onChange={(e) => {
+                  setEditBehavior(e.target.value as any);
+                  setEditUrlRefusal(null);
+                }}
               >
                 <option value="thank-you">Show a thank-you panel</option>
                 <option value="redirect">Redirect to a URL</option>
@@ -513,13 +556,39 @@ export function PublicFormsPage() {
             {editBehavior === 'redirect' && (
               <div className="space-y-1.5">
                 <Label htmlFor="edit-url">Redirect URL</Label>
+                {/*
+                  Not `type="url"`: that type's own notion of valid is an
+                  ABSOLUTE URL, which is the one thing this key refuses, so it
+                  pulled the author the wrong way — as did the former
+                  `https://example.com/thanks` placeholder.
+                */}
                 <Input
                   id="edit-url"
-                  type="url"
-                  placeholder="https://example.com/thanks"
+                  type="text"
+                  placeholder="/thanks"
                   value={editBehaviorUrl}
-                  onChange={(e) => setEditBehaviorUrl(e.target.value)}
+                  onChange={(e) => {
+                    setEditBehaviorUrl(e.target.value);
+                    setEditUrlRefusal(null);
+                  }}
+                  aria-invalid={editUrlRefusal ? true : undefined}
+                  aria-describedby={editUrlRefusal ? 'edit-url-refusal' : 'edit-url-hint'}
                 />
+                {editUrlRefusal ? (
+                  <p
+                    id="edit-url-refusal"
+                    role="alert"
+                    className="text-xs text-destructive"
+                  >
+                    {editUrlRefusal}
+                  </p>
+                ) : (
+                  <p id="edit-url-hint" className="text-xs text-muted-foreground">
+                    An in-app path, starting with <code>/</code> — interpolate a field of
+                    the submitted record as <code>{'{{record.field_name}}'}</code>. To send
+                    the browser out of the app, use an app navigation item instead.
+                  </p>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
Fixes #4990

## 问题

`apps/console/src/pages/developer/PublicFormsPage.tsx` 的 `saveEdit` redirect 分支只验一件事 —— 字段非空,然后 `client.meta.saveItem('view', …)`。

objectstack#7496(2026-08-11 裁定,objectstack#7657 落 spec,本仓 `@objectstack/spec` 17.0.0 GA pin 已覆盖)把 `submitBehavior.url` 裁为**仅相对路径**,并对七族越契约值各给一句 author-facing 处方:空值、前导 scheme(`https:`,同样地 `javascript:` / `data:`)、前导 `//`、反斜杠、空白或 C0/DEL 控制字符、非良构 token 的花括号形状、不以 `/` 开头。

这道门只执行了其中第一族。管理员可以输入 `https://example.com/thanks` 或 `javascript:alert(1)`,得不到任何提示 —— 而这个界面自己刚教过他这个值可以用:字段是 `type="url"`(该 type 自己认的「合法」恰是本键拒绝的绝对 URL),占位符写着 `https://example.com/thanks`。「declared = enforced」在这里是反的:授权门比它所授权的 schema 更宽松。

## 修法:复用同一次解析,不写第二份规则

按卡面形状,判定复用 #4992(#4190 消费侧)落地的那条 spec-schema 解析路径:

- `apps/console/src/components/submitRedirect.ts` 把其中的 shape 判定抽出为新导出 `checkSubmitRedirectUrl(url)`,返回 schema 接受后的值或 spec 自己那句 refusal;`resolveSubmitRedirect`(消费侧)改为调用它再做插值替换 —— 行为不变,少一份代码。
- 授权门在**保存时刻**调用它。越契约就把 spec 的处方渲染在字段旁(`role="alert"` + `aria-invalid` + `aria-describedby`),并且**不保存**;输入即清除,作者在他想提交的那一刻被纠正一次,而不是逐键被追问。
- 保存的是 schema 回读的值,所以授权门与渲染侧不可能对同一个目的地有两种意见 —— 它们是同一次解析。

规则**没有**在对话框里重写一份:镜像拷贝在 spec 改动前的每次取值比较里都是绿的,正是 `scripts/check-spec-symbol-derivation.mjs` 要劝退的形状(objectstack#4115、objectui#4074/#4588/#4592 各付过一次)。裁定日后放宽,跟着 pin 走,这里不需要改。

附带两处:本地的 `Redirect URL is required` 去掉(空值本就是七族之一,一并走契约,作者读到的是「目的地长什么样」而不是「必填」);字段改回纯文本输入、占位符 `/thanks`、并给出规则提示 —— 它不该再教错值。

## 边界(照卡面办)

- `thank-you` 的 `title` / `message` **不加验证**:spec 里两者就是自由串,没有可供门陈述的契约。已用一个测试把这条边界钉住,免得后来人顺手扩大。
- 只动授权门,消费侧 #4992 已收口。

## 服务端到底拒不拒(卡面的开放点,已测)

**拒。** 只读判定,未起任何服务:`packages/rest` 的 `PUT /meta/:type/:name` 委托 `protocol.saveMetaItem`,其 spec-conformance gate 走 `resolveOverlaySchema` → `getMetadataTypeSchema('view')`(`@objectstack/spec/kernel`,与 console 打包的同一个 17.0.0 GA pin)。用 `PublicFormsPage.saveEdit` 实际构造的 body 直接跑这条 gate:

```
"/thanks"                    => ACCEPTS -> would persist
"/t/{{record.id}}"           => ACCEPTS -> would persist
"https://example.com/thanks" => 422 invalid_metadata on: ["submitBehavior.url"]
"javascript:alert(1)"        => 422 invalid_metadata on: ["submitBehavior.url"]
"//evil.example/x"           => 422 invalid_metadata on: ["submitBehavior.url"]
"thanks"                     => 422 invalid_metadata on: ["submitBehavior.url"]
""                           => 422 invalid_metadata on: ["submitBehavior.url"]
```

所以卡面「either way」里成立的是前一支:**元数据语料不会积累这些值,本卡收口的是错误路径而非静默入库**。这不削弱修法,反而是它的论据 —— 纠正现在出现在管理员能改的字段里,而不是一次失败的往返;而且门与服务端从构造上就同判,因为是同一个 schema。

未测的部分如实标注:这是在 gate 函数层面测的(服务端路由实际调用的那个函数与注册表),不是活的 HTTP 往返;某个部署的 spec 版本若与 GA pin 不同,结论随之不同。另有一处顺带观察但**未能证实**,故不据此立 issue:上面的 probe 必须补 `viewKind` 才能让 body 落到 `formOverlay` 分支,缺它时同一条 gate 会对本页**任何**保存都 422(与 url 无关)—— 但本页保存的是 `getItems` 读回的 `it.spec`,其真实形状要有真实存量数据才能判定,我没有。

## 验证

- `pnpm exec vitest run apps/console/` → **54 files / 647 tests 全绿**(含新增 15 + 扩充 20)。
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **81/81 successful**。
- `node scripts/check-control-bytes.mjs` → OK(4465 files);`check-spec-symbol-derivation.mjs` / 两个 changeset 门 → OK。改动文件 eslint:0 error,warning 数与基线逐一相同(14 → 14,均为既有 `any` / `useEffect`)。
- 测试用例里的控制字符一律写作转义序列(反斜杠 + `u0009` 那种写法),并在越门之外自扫 `[\x00-\x08\x0b\x0c\x0e-\x1f]`(#4890 形态)。**本 PR 正文自身也栽过一次**:初版这一行里我把制表符写成了真实字节,读回存档时发现并改掉 —— 正是「写规则时把字节物化」的那个形状。

### 反向验证(先书面预判,再变异实测)

预判写在两个测试文件的 docblock 里,commit 后变异、`git checkout --` 还原(未用 stash):

| 变异 | 预判 | 实测 |
|---|---|---|
| 门退回只验非空 | 页面 11 红(七族 8 + 空值 + aria-invalid + 清除),且**每例先死在「没有 alert 渲染」**;`submitRedirect.test.ts` 全绿(模块未动) | 完全一致:`Tests 11 failed \| 58 passed`,首个失败即 `Unable to find role="alert"` |
| 保留解析、改用本地文案 | 只有文案来源那一条断言红 9 例(七族 8 + 空值),`saveItem` 那半仍绿;aria / 清除 / 合法值 / thank-you 全绿 | 完全一致:`Tests 9 failed \| 60 passed`,失败点在 `:158 toHaveTextContent` |

第二个变异是本卡真正要防的那件事的窄探测器:一份镜像拷贝会让 `saveItem` 那半照旧通过,只在**文案来源**上失守 —— 所以断言比的是 schema 现场解析出来的那句话,而不是我抄进测试的字符串;spec 改词,测试照绿,拷贝规则,测试变红。
