### PR TITLE
feat(components,plugin-detail): 五个 GA 键发布为 inputs,page:tabs 补上被发布的那个拼写的读点 (#4668)

### DIFF
--- a/.changeset/ga-five-honoured-inputs-4668.md
+++ b/.changeset/ga-five-honoured-inputs-4668.md
@@ -1,0 +1,54 @@
+---
+'@object-ui/components': minor
+'@object-ui/plugin-detail': minor
+---
+
+Publish the five `@objectstack/spec` 17.0.0 keys the renderers already honoured, so
+authors can discover them
+
+`page:header.maxVisible`, `page:header.mobileMaxVisible`, `page:tabs.alwaysShowStrip`,
+`record:details.inlineEdit` and `record:details.showHeader` are declared by the spec and
+read by the renderers today, and none of them was in its block's published `inputs`. That
+is the direction nothing reports: `gen-manifest.ts` left all five out of
+`sdui.manifest.json` and `sdui-intrinsics.d.ts`, so they were in no designer panel and no
+generated type; `sdui-parser`'s prop walk reported `unknown-prop` on an author who wrote
+one anyway; and the renderer honoured it regardless. Measured on the console's own
+manifest before this change, all five drew
+
+```
+unknown-prop: page:header has no prop "maxVisible"
+unknown-prop: page:header has no prop "mobileMaxVisible"
+unknown-prop: page:tabs has no prop "alwaysShowStrip"
+unknown-prop: record:details has no prop "inlineEdit"
+unknown-prop: record:details has no prop "showHeader"
+```
+
+and now draw nothing. Same defect as `record:details.hideFields` in objectui#3808 and
+`readonly` in objectui#3407; it could not land until the GA pin moved (objectui#4636),
+because the pre-GA pin declared none of the five and publishing them would have failed the
+repo-wide parity gate's forward direction.
+
+Each entry carries a description, because for these keys the discoverability IS the fix.
+Two are worth reading before use:
+
+- `maxVisible` / `mobileMaxVisible` are positive integers — the contract rejects `0` and
+  fractional values — and they do not govern every action: an action declaring
+  `record_more` without `record_header`, and any action with `component: 'action:menu'`,
+  is routed to the overflow menu regardless of the budget.
+- `inlineEdit` is an opt-OUT only. The value is combined with the object's own resolved
+  editability (ADR-0103) and with the server's effective API operation set, so `false`
+  always wins while `true` cannot open editing the platform refuses.
+
+**`page:tabs` also gains a read.** `alwaysShowStrip` was honoured only as
+`schema.properties.alwaysShowStrip`, while `inputs` publishes TOP-LEVEL keys — the shape
+the manifest whitelists, the generated types declare and the JSX-page compiler validates.
+Measured on a one-tab schema: the wrapped form showed the strip, the flat form did not, so
+publishing the key alone would have advertised a write the renderer throws away. The
+canonical top-level arm is read first now, with the `properties` arm kept for paths that
+reach the renderer without `SchemaRenderer`'s hoist — the same dual read `maxVisible` has
+always had. This can only ever ADD a strip to a one-tab page; multi-tab pages are
+unaffected, and `false` and non-boolean values both read as "not set".
+
+The five GA-pending entries that held this card's place in
+`registry-inputs-spec-parity.test.ts` are deleted, which is what the gate's own
+`carries no stale unpublished-key exemption` check demands once the keys are published.

--- a/apps/console/src/__tests__/ga-honoured-inputs-author-reach.test.ts
+++ b/apps/console/src/__tests__/ga-honoured-inputs-author-reach.test.ts
@@ -1,0 +1,141 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#4668 — the five @objectstack/spec 17.0.0 GA keys the renderers
+ * already honoured, seen from where an AUTHOR stands.
+ *
+ * `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` pins the
+ * declarations. This file pins what the declarations were FOR: before them, the
+ * manifest that gates authoring reported `unknown-prop` on all five —
+ *
+ *   page:header      maxVisible          "<page:header> has no prop "maxVisible""
+ *   page:header      mobileMaxVisible    "<page:header> has no prop "mobileMaxVisible""
+ *   page:tabs        alwaysShowStrip     "<page:tabs> has no prop "alwaysShowStrip""
+ *   record:details   inlineEdit          "<record:details> has no prop "inlineEdit""
+ *   record:details   showHeader          "<record:details> has no prop "showHeader""
+ *
+ * — measured on this exact `manifestFromConfigs` + `validateTree` pair, while
+ * the renderers honoured every one of them. An author was warned off five keys
+ * that work, and an author who never tried them could not learn they exist:
+ * `gen-manifest.ts` serializes these same `inputs` into `sdui.manifest.json`
+ * (the save gate and parser whitelist) and into `sdui-intrinsics.d.ts` (the JSX
+ * authoring types), and `page.tsx:462` builds the JSX-page compiler's prop
+ * whitelist from `getKnownTypes()` plus the same `inputs`. objectui#3407's
+ * complaint verbatim, on five more keys.
+ *
+ * WHY EVERY POSITIVE COMES WITH A CONTROL. "No diagnostic" is also what a
+ * SILENCED check looks like: if `validateTree` stopped reporting `unknown-prop`
+ * at all — or if the manifest came up empty and every node resolved to
+ * `unknown-component` instead — the five assertions below would pass while the
+ * gap sat wide open. So each block is probed with a key nothing declares, which
+ * must still be reported, and the manifest's own reachability is asserted
+ * first. The same pairing `component-input-union-specimens.test.ts` uses next
+ * door for objectui#3832, and for the same reason: this change is a WIDENING.
+ *
+ * Module-scope registration imports, not a hook (AGENTS.md §测试纪律,
+ * objectui#3010): the registrations are the fixture, and paying their cold
+ * transform at import time keeps it out of every test and hook timeout budget.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+import type { Diagnostic, SchemaElement } from '@object-ui/sdui-parser';
+import '@object-ui/components';
+import '../register-plugins';
+
+/**
+ * The manifest built from the WHOLE registry — the same construction
+ * `dev/manifest-dump.tsx` and the JSX-page compiler use, rather than a
+ * hand-assembled list that could agree with itself and prove nothing.
+ */
+const manifest = manifestFromConfigs(
+  ComponentRegistry.getAllConfigs() as unknown as Parameters<typeof manifestFromConfigs>[0],
+);
+
+const diagnose = (node: unknown): Diagnostic[] =>
+  validateTree(node as SchemaElement, manifest).diagnostics;
+
+/** Diagnostics naming a specific prop, by code. */
+const codesMentioning = (node: unknown, prop: string): string[] =>
+  diagnose(node)
+    .filter((d) => d.message.includes(`"${prop}"`))
+    .map((d) => d.code);
+
+/** A minimally valid node per block, so `missing-required-prop` never rides along. */
+const BASE: Record<string, Record<string, unknown>> = {
+  'page:header': { type: 'page:header' },
+  'page:tabs': { type: 'page:tabs', items: [{ label: 'Details', children: [] }] },
+  'record:details': { type: 'record:details' },
+};
+
+const node = (type: string, props: Record<string, unknown>) => ({ ...BASE[type], ...props });
+
+/** The five keys, by the block that publishes them. */
+const PUBLISHED: Array<[string, string, unknown]> = [
+  ['page:header', 'maxVisible', 4],
+  ['page:header', 'mobileMaxVisible', 2],
+  ['page:tabs', 'alwaysShowStrip', true],
+  ['record:details', 'inlineEdit', false],
+  ['record:details', 'showHeader', true],
+];
+
+describe('objectui#4668 — the five GA keys are reachable from the authoring manifest', () => {
+  it('the manifest resolves all three blocks (reachability before absence)', () => {
+    // Without this, every "no unknown-prop" assertion below passes vacuously on
+    // a manifest that never knew the block: an unresolved type produces
+    // `unknown-component`, a DIFFERENT code, and the per-prop filters here would
+    // find nothing to report.
+    for (const type of Object.keys(BASE)) {
+      expect(manifest.components[type], `${type} missing from the manifest`).toBeTruthy();
+      expect(diagnose(BASE[type]).map((d) => d.code)).not.toContain('unknown-component');
+    }
+  });
+
+  it('each block still reports an undeclared key — the check is live, not silenced', () => {
+    // The control half. `unknown-prop` has to be reachable on each of the three
+    // blocks for the five positives to mean anything.
+    for (const type of Object.keys(BASE)) {
+      const probe = node(type, { objectui4668NotAProp: 'x' });
+      expect(
+        codesMentioning(probe, 'objectui4668NotAProp'),
+        `${type} no longer reports undeclared props`,
+      ).toContain('unknown-prop');
+    }
+  });
+
+  it('none of the five draws a diagnostic any more', () => {
+    // The acceptance face of this card: the write an author makes, judged by the
+    // manifest the platform gates on. Filtered to diagnostics that NAME the key,
+    // so an unrelated report elsewhere in the node cannot mask a regression here
+    // — nor a regression here hide behind an unrelated pass.
+    for (const [type, prop, value] of PUBLISHED) {
+      expect(codesMentioning(node(type, { [prop]: value }), prop), `${type}.${prop}`).toEqual([]);
+    }
+  });
+
+  it('the declared type is the one the value has, so no type-mismatch either', () => {
+    // `unknown-prop` was the loud half; `checkType` is the quiet one. A key
+    // declared with the wrong coarse arm goes from "undiscoverable" to
+    // "discoverable and warned about on every legal write", which is the trap
+    // objectui#3832 was filed over. Probing the OFF-arm value proves the arm is
+    // narrow enough to be worth having.
+    for (const [type, prop, value] of PUBLISHED) {
+      expect(codesMentioning(node(type, { [prop]: value }), prop)).not.toContain('type-mismatch');
+    }
+    // Booleans given a number, and the numeric budget given a boolean.
+    expect(codesMentioning(node('page:tabs', { alwaysShowStrip: 1 }), 'alwaysShowStrip')).toContain(
+      'type-mismatch',
+    );
+    expect(codesMentioning(node('record:details', { inlineEdit: 'no' }), 'inlineEdit')).toContain(
+      'type-mismatch',
+    );
+    expect(codesMentioning(node('page:header', { maxVisible: true }), 'maxVisible')).toContain(
+      'type-mismatch',
+    );
+  });
+});

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -558,36 +558,38 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
   'element:record_picker.targetVariable':
     "Spec's own declarative hint with zero read points repo-wide; the live binding is the reverse lookup by component id, as on element:text_input. Whether to publish an intent-only key is an open judgement: objectui#3834.",
 
-  // ── GA-added keys the renderers already honour — held by the PIN (5 keys) ──
-  // A different class from every entry above, and the difference is the whole
-  // reason they are here rather than declared: publishing them is the RIGHT
-  // answer and this file's own bar says so ("a spec key the renderer HONOURS
-  // and `inputs` omits is a plain defect and gets declared"). What blocks it is
-  // the installed contract, not a judgement.
+  // FIVE GA-PENDING ENTRIES DELETED HERE — objectui#4668, and they too were
+  // designed to die exactly this way.
   //
-  // @objectstack/spec 17.0.0 GA declares all five; the pinned 17.0.0-rc.6
-  // declares none of them. Declaring the inputs today would therefore fail the
-  // FORWARD direction of this very file on the pinned spec — and a forward
-  // exemption to cover THAT would go stale, and red, the moment the pin moves.
-  // The two clauses collide and "must stay green on current main" wins, the
-  // same resolution PR objectui#4660 recorded for `SECRET_MASK`.
+  // `page:header.maxVisible` / `page:header.mobileMaxVisible` /
+  // `page:tabs.alwaysShowStrip` / `record:details.inlineEdit` /
+  // `record:details.showHeader` were a class of their own: publishing them was
+  // the RIGHT answer and this file's own bar said so ("a spec key the renderer
+  // HONOURS and `inputs` omits is a plain defect and gets declared"). What held
+  // them was the installed contract, not a judgement — @objectstack/spec 17.0.0
+  // GA declares all five and the then-pinned 17.0.0-rc.6 declared none, so
+  // declaring the inputs would have failed the FORWARD direction of this very
+  // file, and a forward exemption to cover THAT would have gone stale the moment
+  // the pin moved (the collision PR objectui#4660 recorded for `SECRET_MASK`).
   //
-  // So these five are dormant on this pin and fully judged on a GA tree (see
-  // `GA_PENDING_UNPUBLISHED_KEYS`), and objectui#4668 owns declaring them once
-  // objectui#4636 / PR objectui#4639 lands the GA pin. Each dies the moment its
-  // input exists — `carries no stale unpublished-key exemption` is what kills
-  // it, exactly as it killed `element:record_picker.filter` when #3830 declared
-  // that one.
-  'page:header.maxVisible':
-    'GA declares it and PageHeaderRenderer HONOURS it already — containers.tsx:1360, `readMax(schema?.maxVisible ?? schema?.properties?.maxVisible) ?? 3`, the desktop inline/overflow action budget. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it, so the input would fail this file\'s forward direction today. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
-  'page:header.mobileMaxVisible':
-    'GA declares it and PageHeaderRenderer HONOURS it already — containers.tsx:1359, the mobile half of the same overflow budget (`?? 1`). Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
-  'page:tabs.alwaysShowStrip':
-    'GA declares it and PageTabsRenderer HONOURS it already — containers.tsx:637, `itemsWithValue.length > 1 || schema?.properties?.alwaysShowStrip === true` keeps the strip visible for a single tab. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
-  'record:details.inlineEdit':
-    'GA declares it and RecordDetailsRenderer HONOURS it already — renderers/record-details.tsx:234, `(schema.inlineEdit ?? true) && objectInlineEditable` gates the inline-edit affordance. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
-  'record:details.showHeader':
-    'GA declares it and RecordDetailsRenderer HONOURS it already — renderers/record-details.tsx:257, `showHeader: schema.showHeader ?? false` reaches DetailView, which reads it at DetailView.tsx:909/:1183. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
+  // The GA pin landed (objectui#4636 / PR objectui#4639) and objectui#4668
+  // declared all five at their registration sites, which is what made `carries
+  // no stale unpublished-key exemption` name every one of them at once —
+  // exactly as it killed `element:record_picker.filter` when #3830 declared that
+  // one. They are pinned as DECLARED, by name, in `the five GA keys
+  // objectui#4668 declared are discoverable` at the bottom of this file: the
+  // derived reverse loop goes green just as readily if a declaration is swapped
+  // back for an entry here, which is the cheap move and the one thing the pin
+  // forbids.
+  //
+  // One of the five needed more than a declaration, and it is recorded here
+  // because this list is where the next reader looks: `page:tabs.alwaysShowStrip`
+  // was read ONLY as `schema.properties.alwaysShowStrip`, while `inputs`
+  // publishes top-level keys. Measured on a one-tab schema, the flat form every
+  // layer of the manifest accepts was dropped by the renderer — so #4668 added
+  // the canonical top-level arm in the same change. Publishing a key whose only
+  // read is under a different carrier is not a declaration, it is this gate's own
+  // failure mode moved one layer in.
 
   // ── object-grid's own @deprecated legacy spellings — the RULED carve-out ───
   //                                                          (10 keys)
@@ -661,8 +663,8 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
  * Every other entry in `UNPUBLISHED_EXEMPTIONS` describes a key the installed
  * spec declares right now — that is what `every unpublished-key exemption names
  * a key the spec really declares` asserts, and it is why a typo cannot hide in
- * the list. These five describe keys only @objectstack/spec 17.0.0 GA has, so
- * on the pinned 17.0.0-rc.6 they describe nothing yet.
+ * the list. These ten describe keys of a block only @objectstack/spec 17.0.0 GA
+ * carries, so on a pin predating the GA element set they describe nothing yet.
  *
  * Pinning them as a SET rather than skipping "any entry the spec does not
  * declare" is the whole safety of the mechanism: only these entries may be
@@ -671,22 +673,27 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
  * directions — so a GA release that dropped one of them fails here instead of
  * leaving an entry that quietly covers nothing.
  *
- * TWO GROUPS, and they are dormant for the same reason but retire differently:
+ * ONE GROUP NOW, and knowing which one LEFT matters more than the one that
+ * stayed:
  *
- *   - the first five are keys on blocks this pin already carries, awaiting
- *     declaration by objectui#4668 once the pin moves. Each dies when its input
- *     lands;
  *   - the ten `object-grid` entries are objectui#4648's RULED carve-out. They
- *     are dormant here only because rc.6 does not carry `object-grid` at all, so
+ *     are dormant only on a pin that does not carry `object-grid` at all, so
  *     none of its keys resolves; on a GA tree they are fully judged. They are
- *     not awaiting declaration — see their reasons above.
+ *     not awaiting declaration — see their reasons above;
+ *   - the FIVE that were listed first here (`page:header.maxVisible`,
+ *     `page:header.mobileMaxVisible`, `page:tabs.alwaysShowStrip`,
+ *     `record:details.inlineEdit`, `record:details.showHeader`) were the other
+ *     kind: keys on blocks the pin already carried, awaiting declaration. They
+ *     retired the way this mechanism intends — the pin moved to GA, objectui#4668
+ *     declared all five, and their exemption entries went stale in the same run.
+ *     A "pending" entry that never lands is the rot this set exists to make
+ *     visible; these five are the worked example of it not happening.
+ *
+ * So the two arms of `isDormantOnThisPin` are no longer symmetric in practice:
+ * a future entry here is either a ruled carve-out on a block the pin may not
+ * carry, or a declaration someone owes. Say which in the reason.
  */
 const GA_PENDING_UNPUBLISHED_KEYS = [
-  'page:header.maxVisible',
-  'page:header.mobileMaxVisible',
-  'page:tabs.alwaysShowStrip',
-  'record:details.inlineEdit',
-  'record:details.showHeader',
   'object-grid.fields',
   'object-grid.staticData',
   'object-grid.selectable',
@@ -942,7 +949,7 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
     expect(dangling).toEqual([]);
   });
 
-  it('every GA-pending exemption arms exactly with the installed spec, all fifteen together', () => {
+  it('every GA-pending exemption arms exactly with the installed spec, all ten together', () => {
     // The non-vacuity and self-arming half of `GA_PENDING_UNPUBLISHED_KEYS`.
     // Without it the pinned set could name keys no entry covers (licensing
     // nothing while reading as cover) or stay dormant forever on a GA tree that
@@ -1204,6 +1211,53 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
         `element:record_picker does not publish ${key}`,
       ).toContain(key);
       expect(Object.keys(UNPUBLISHED_EXEMPTIONS)).not.toContain(`element:record_picker.${key}`);
+    }
+  });
+
+  it('the five GA keys objectui#4668 declared are discoverable, block by block', () => {
+    // Named, not merely covered by the derived reverse loop above, for exactly
+    // the reason the #3808 five and the rc.6 record_picker trio next door are:
+    // that loop goes green just as readily if a declaration is REPLACED by an
+    // `UNPUBLISHED_EXEMPTIONS` entry, which is the cheap move under time
+    // pressure and the one thing these five may not resolve to a second time.
+    // Their entries existed for a stated, expiring reason — the pre-GA pin — and
+    // that reason cannot be re-borrowed now that the pin carries the keys.
+    //
+    // Three assertions per key, and the first is the non-vacuity half: if a
+    // later pin dropped one of these from its props schema,
+    // `undiscoverableSpecKeys` would stop naming it and every derived assertion
+    // would pass while the input sat there publishing a key the contract no
+    // longer has — the forward direction would then be the one to red, which is
+    // the correct place for that failure, not here.
+    const declared: Array<[string, string]> = [
+      ['page:header', 'maxVisible'],
+      ['page:header', 'mobileMaxVisible'],
+      ['page:tabs', 'alwaysShowStrip'],
+      ['record:details', 'inlineEdit'],
+      ['record:details', 'showHeader'],
+    ];
+    for (const [type, key] of declared) {
+      expect(specTopLevelKeys(type), `${type} spec no longer declares ${key}`).toContain(key);
+      expect(declaredInputs(type) ?? [], `${type} does not publish ${key}`).toContain(key);
+      expect(Object.keys(UNPUBLISHED_EXEMPTIONS)).not.toContain(`${type}.${key}`);
+      // And they are no longer nameable as dormant: the set that licensed the
+      // dormancy dropped them, so `isDormantOnThisPin` answers false for a
+      // second, independent reason. Without this, re-adding the key to
+      // `GA_PENDING_UNPUBLISHED_KEYS` *and* to the exemption map would restore
+      // the pre-GA state and only `every GA-pending exemption arms exactly with
+      // the installed spec` would notice — and only while the pin carries the
+      // key.
+      expect(GA_PENDING_UNPUBLISHED_KEYS).not.toContain(`${type}.${key}`);
+    }
+
+    // Each carries a description, because for these five the discoverability
+    // IS the fix: an input with an empty description publishes the key to
+    // `sdui.manifest.json` and the `.d.ts` while still telling a designer panel
+    // nothing about what to write in it.
+    for (const [type, key] of declared) {
+      const input = (ComponentRegistry.getConfig(type)?.inputs ?? []).find((i) => i.name === key);
+      expect(input, `${type}.${key} input vanished`).toBeTruthy();
+      expect((input?.description ?? '').length, `${type}.${key} has no description`).toBeGreaterThan(0);
     }
   });
 

--- a/packages/components/src/__tests__/page-tabs-always-show-strip.test.tsx
+++ b/packages/components/src/__tests__/page-tabs-always-show-strip.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `page:tabs.alwaysShowStrip` — the published key, on the spelling it is
+ * published as (objectui#4668).
+ *
+ * The key opts a one-tab strip back into visibility: `PageTabsRenderer` hides
+ * the strip entirely at length 1, because a lone pill labelled "Details" is
+ * clutter rather than an affordance. @objectstack/spec 17.0.0 GA declares the
+ * key on `PageTabsProps`, the renderer has honoured it since the suppression
+ * landed, and `inputs` omitted it — so `gen-manifest.ts` left it out of
+ * `sdui.manifest.json` and `sdui-intrinsics.d.ts`, `sdui-parser`'s prop walk
+ * reported `unknown-prop` on an author who wrote it, and the renderer honoured
+ * it anyway. objectui#4668 declares it.
+ *
+ * WHY THIS FILE EXISTS RATHER THAN A DECLARATION ASSERTION ALONE. Declaring the
+ * input was not sufficient, and the measurement is what said so. `inputs`
+ * publishes TOP-LEVEL keys — that is the shape `validate.ts` walks, the shape
+ * `sdui-intrinsics.d.ts` types, and the shape the JSX-page compiler whitelists —
+ * while this renderer's only read was `schema.properties.alwaysShowStrip`.
+ * Measured on a one-tab schema before the change: the wrapped form showed the
+ * strip, the flat form did not. Publishing the key on a spelling the renderer
+ * drops would have reproduced the parity gate's own failure mode one layer in —
+ * a manifest telling an author to write a key the platform throws away — so the
+ * canonical arm was added with the declaration, and both spellings are pinned
+ * here.
+ *
+ * `SchemaRenderer` hoists `properties.*` onto the schema, so the canonical arm
+ * covers the wrapped form as well; the `properties` arm survives for paths that
+ * reach this renderer without that hoist. Deleting either arm turns exactly one
+ * test below red, which is what keeps the pair honest.
+ *
+ * Module-scope registration import, not a hook: the cold transform belongs to
+ * the import phase, which carries no test/hook timeout (AGENTS.md §测试纪律,
+ * objectui#3010).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { SchemaRenderer } from '@object-ui/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PageTabsProps } from '@objectstack/spec/ui';
+import '../renderers';
+
+const ONE_TAB = [{ label: 'Details', value: 'details', children: [] }];
+const TWO_TABS = [
+  { label: 'Details', value: 'details', children: [] },
+  { label: 'Related', value: 'related', children: [] },
+];
+
+/** Is the tab strip in the DOM? Radix renders it as `role="tablist"`. */
+const stripVisible = (schema: unknown): boolean => {
+  const { container } = render(<SchemaRenderer schema={schema as never} />);
+  return container.querySelector('[role="tablist"]') !== null;
+};
+
+describe('page:tabs alwaysShowStrip — the read (objectui#4668)', () => {
+  it('hides a one-tab strip when the key is absent', () => {
+    // The control, FIRST. Every positive assertion below is "the strip is
+    // there", and a renderer that always drew the strip would satisfy all of
+    // them; this is the only test that fails in that case.
+    expect(stripVisible({ type: 'page:tabs', id: 't-default', items: ONE_TAB })).toBe(false);
+  });
+
+  it('shows a one-tab strip for the PUBLISHED top-level spelling', () => {
+    // The spelling `inputs`, the manifest and the generated `.d.ts` all
+    // advertise. Red before objectui#4668 added the canonical arm — measured,
+    // not assumed.
+    expect(
+      stripVisible({ type: 'page:tabs', id: 't-flat', items: ONE_TAB, alwaysShowStrip: true }),
+    ).toBe(true);
+  });
+
+  it('shows a one-tab strip for the wrapped `properties` spelling', () => {
+    // The spec-bridge form, which `SchemaRenderer` hoists. Green before the
+    // change and green after: the point of asserting it is that the widening
+    // did not cost the form that already worked.
+    expect(
+      stripVisible({
+        type: 'page:tabs',
+        id: 't-wrapped',
+        properties: { items: ONE_TAB, alwaysShowStrip: true },
+      }),
+    ).toBe(true);
+  });
+
+  it('treats `false` and a non-boolean as "not set" — only `true` opts in', () => {
+    // The read is `=== true`, deliberately: the contract types the key boolean,
+    // so a truthy string is off-contract input rather than a second way to say
+    // yes, and the renderer must not invent one (AGENTS.md #0.1).
+    expect(
+      stripVisible({ type: 'page:tabs', id: 't-false', items: ONE_TAB, alwaysShowStrip: false }),
+    ).toBe(false);
+    expect(
+      stripVisible({ type: 'page:tabs', id: 't-str', items: ONE_TAB, alwaysShowStrip: 'true' }),
+    ).toBe(false);
+  });
+
+  it('leaves multi-tab pages alone in every spelling', () => {
+    // Scope guard: the key can only ever ADD a strip at length 1. A regression
+    // that made it a general gate would show up here.
+    expect(stripVisible({ type: 'page:tabs', id: 't-multi', items: TWO_TABS })).toBe(true);
+    expect(
+      stripVisible({ type: 'page:tabs', id: 't-multi-off', items: TWO_TABS, alwaysShowStrip: false }),
+    ).toBe(true);
+  });
+});
+
+describe('page:tabs alwaysShowStrip — the declaration (objectui#4668)', () => {
+  const inputs = () => ComponentRegistry.getConfig('page:tabs')?.inputs ?? [];
+  const input = (name: string) => inputs().find((i) => i.name === name);
+
+  it('publishes the key as a boolean, with a description', () => {
+    // Non-empty FIRST: an emptied `inputs` list would satisfy a bare
+    // `toBeDefined()` for the wrong reason, the vacuous-green trap
+    // objectui#3808's reverse run documented.
+    expect(inputs().length).toBeGreaterThan(0);
+    expect(inputs().map((i) => i.name)).toContain('alwaysShowStrip');
+    expect(input('alwaysShowStrip')?.type).toBe('boolean');
+    expect((input('alwaysShowStrip')?.description ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('declares the single arm the contract really has', () => {
+    // A VALUE verdict, so the criterion is a full parse either way — the
+    // declared `boolean` has to be the shape the spec accepts, and the arms it
+    // does NOT have have to be refused rather than merely stripped. `items` is
+    // required on this props schema, so it rides along on every probe.
+    const withItems = (value: unknown) =>
+      PageTabsProps.safeParse({ items: ONE_TAB, alwaysShowStrip: value });
+
+    expect(withItems(true).success).toBe(true);
+    expect(withItems(true).data?.alwaysShowStrip).toBe(true);
+    expect(withItems(false).success).toBe(true);
+    expect(withItems(false).data?.alwaysShowStrip).toBe(false);
+
+    for (const rejected of [1, 0, 'true', null]) {
+      const parsed = withItems(rejected);
+      expect(parsed.success, `spec accepted ${JSON.stringify(rejected)}`).toBe(false);
+      expect(parsed.error?.issues.map((i) => i.path.join('.'))).toContain('alwaysShowStrip');
+    }
+  });
+});

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -632,9 +632,30 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     >
       {/* Hide the tab strip entirely when there's only one tab — a single
           pill labelled "Details" is visual clutter rather than an
-          affordance. Authors who want the strip even at length 1 can pass
-          `properties.alwaysShowStrip: true`. */}
-      {(itemsWithValue.length > 1 || schema?.properties?.alwaysShowStrip === true) && (
+          affordance. Authors who want the strip even at length 1 pass
+          `alwaysShowStrip: true`.
+
+          BOTH spellings are read, canonical FIRST, and the top-level arm is
+          why: `alwaysShowStrip` is a PUBLISHED input since objectui#4668, and
+          `inputs` publishes top-level keys — `gen-manifest.ts`,
+          `sdui-intrinsics.d.ts` and `sdui-parser`'s prop walk all judge the
+          flat `{ type: 'page:tabs', alwaysShowStrip: true }`. This read was
+          `properties.*`-only, so that flat form passed every one of those
+          layers and was then dropped here. Measured on a one-tab schema before
+          the arm was added: the wrapped form showed the strip, the flat form
+          did not — publishing the key without this arm would have advertised a
+          write the renderer throws away, which is the exact defect the parity
+          gate exists to prevent, one layer further in.
+
+          `SchemaRenderer` hoists `properties.*` onto the schema (it keeps the
+          bag intact for the collision-prone `type` / `id`), so the canonical
+          arm already covers the wrapped form; the `properties` arm stays for
+          any path that reaches this renderer without that hoist. The same dual
+          read `maxVisible` / `mobileMaxVisible` carry below, for the same
+          reason. */}
+      {(itemsWithValue.length > 1 ||
+        schema?.alwaysShowStrip === true ||
+        schema?.properties?.alwaysShowStrip === true) && (
         <TabsList className={listClass}>
           {itemsWithValue.map((item) => (
             <TabsTrigger key={item.value} value={item.value} className={triggerClass()}>
@@ -689,10 +710,18 @@ ComponentRegistry.register('tabs', PageTabsRenderer, {
   label: 'Page Tabs',
   category: 'layout',
   isContainer: true,
+  // `alwaysShowStrip` is DECLARED, not merely honoured (objectui#4668).
+  // @objectstack/spec 17.0.0 GA declares it on `PageTabsProps` and this
+  // renderer has read it since the one-tab strip was first suppressed, while
+  // `inputs` omitted it — so the manifest, the generated `.d.ts` and the
+  // designer panel all said the key did not exist, `sdui-parser` reported
+  // `unknown-prop` on an author who wrote it anyway, and the renderer honoured
+  // it regardless. Same defect as `record:details.hideFields` in objectui#3808.
   inputs: [
     { name: 'items', type: 'array', label: 'Tabs', required: true, description: 'Tab definitions [{ label, value?, icon?, count?, visibleWhen?, children }] — value is the stable ?tab= URL token, count auto-derives from record:related_list descendants when omitted' },
     { name: 'tabStyle', type: 'enum', label: 'Style', enum: ['line', 'card', 'pill'], defaultValue: 'line' },
     { name: 'position', type: 'enum', label: 'Position', enum: ['top', 'left'], defaultValue: 'top' },
+    { name: 'alwaysShowStrip', type: 'boolean', label: 'Always Show Tab Strip', defaultValue: false, description: 'Keep the tab strip visible when only one tab survives. Default false: a lone pill is clutter rather than an affordance, so a one-tab strip is hidden and its panel renders bare. Count the tabs AFTER each item visibleWhen predicate has been evaluated — a page authored with four tabs of which three are conditional reaches this rule whenever the other three are false.' },
   ],
 });
 
@@ -1707,6 +1736,24 @@ ComponentRegistry.register('header', PageHeaderRenderer, {
     { name: 'recordChrome', type: 'boolean', label: 'Record Chrome', defaultValue: true, description: 'Set false for the bare h1 header on non-record pages' },
     { name: 'showStar', type: 'boolean', label: 'Show Follow Star', defaultValue: true },
     { name: 'showCopyId', type: 'boolean', label: 'Show Copy-ID', defaultValue: true },
+    // The inline/overflow budget, DECLARED rather than merely honoured
+    // (objectui#4668). Both are @objectstack/spec 17.0.0 GA keys this renderer
+    // has read since objectui#2361 (`readMax(...)` at the split above, in both
+    // spellings — `page-header-actions.test.tsx` pins the schema-level and the
+    // `properties.*` variant), while `inputs` omitted them: the manifest and
+    // `sdui-intrinsics.d.ts` left them out and `sdui-parser` warned
+    // `unknown-prop` on the very key that then took effect.
+    //
+    // ONE arm each, not a union: measured against
+    // `ComponentPropsMap['page:header']` on the installed GA pin, both are
+    // `z.number()` constrained to a POSITIVE SAFE INTEGER — `0`, `-1` and `2.5`
+    // are all rejected by value, which is why the descriptions say so instead
+    // of leaving an author to discover it from a parse error. (`readMax` here is
+    // laxer than that — it accepts `0` and floors fractions — but a renderer
+    // tolerance is not an authoring surface, and the contract is what `inputs`
+    // publishes.)
+    { name: 'maxVisible', type: 'number', label: 'Max Inline Actions', defaultValue: 3, description: 'How many header actions render as inline buttons on desktop before the rest fold into the overflow menu. A positive integer — the contract rejects 0 and fractional values. Two kinds of action are routed to the overflow menu regardless of this budget and never occupy an inline slot: an action whose locations declare record_more without record_header, and any action with component action:menu.' },
+    { name: 'mobileMaxVisible', type: 'number', label: 'Max Inline Actions (Mobile)', defaultValue: 1, description: 'The same inline-button budget on mobile viewports, where horizontal room is scarce. A positive integer, defaulting to 1; the desktop half is Max Inline Actions, and the overflow routing rules stated there apply unchanged.' },
   ],
 });
 

--- a/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
@@ -316,6 +316,61 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     expect(description).not.toContain('{');
   });
 
+  it('publishes the two GA keys the renderer has read all along (#4668)', () => {
+    // The same reverse direction as `hideFields` above, on the two keys
+    // @objectstack/spec 17.0.0 GA added to this block. Both were read by
+    // `RecordDetailsRenderer` — `(schema.inlineEdit ?? true) &&
+    // objectInlineEditable`, and `showHeader: schema.showHeader ?? false` on the
+    // synthesized `detail-view` — while `inputs` omitted them, so the manifest
+    // and the generated `.d.ts` said the keys did not exist and `sdui-parser`
+    // reported `unknown-prop` on an author who wrote one, which the renderer then
+    // honoured.
+    //
+    // A VALUE verdict, not merely a key-reachability one: the published
+    // `type: 'boolean'` is a claim about which values the contract takes, so the
+    // criterion is a full parse both ways. Both keys read straight off the
+    // top-level schema, so unlike `page:tabs.alwaysShowStrip` (see
+    // `packages/components/src/__tests__/page-tabs-always-show-strip.test.tsx`)
+    // the published spelling was already the one the renderer reads — no arm had
+    // to be added here.
+    for (const key of ['inlineEdit', 'showHeader']) {
+      expect(specTopLevelKeys()).toContain(key);
+      expect(isTombstoned(key), `${key} is a tombstone, not a live key`).toBe(false);
+
+      expect(inputs().map((i) => i.name)).toContain(key);
+      expect(input(key)?.type).toBe('boolean');
+      expect((input(key)?.description ?? '').length).toBeGreaterThan(0);
+
+      for (const value of [true, false]) {
+        const parsed = RecordDetailsProps.safeParse({ [key]: value });
+        expect(parsed.success).toBe(true);
+        expect((parsed.data as Record<string, unknown> | undefined)?.[key]).toBe(value);
+      }
+      for (const rejected of [1, 'true', null]) {
+        const parsed = RecordDetailsProps.safeParse({ [key]: rejected });
+        expect(parsed.success, `spec accepted ${key}=${JSON.stringify(rejected)}`).toBe(false);
+        expect(parsed.error?.issues.map((i) => i.path.join('.'))).toContain(key);
+      }
+    }
+  });
+
+  it('`inlineEdit` is documented as the opt-OUT it actually is (#4668)', () => {
+    // The description is the only place this asymmetry can be stated, and it is
+    // the part a wrong reading makes expensive rather than merely vague: the
+    // value is AND-ed with the object's resolved editability (ADR-0103) and with
+    // the server's effective API operation set (objectui#3546), so `false` is
+    // unconditional while `true` cannot open editing the platform refuses. An
+    // author told "true enables inline editing" files a bug against the renderer
+    // when a system object stays read-only.
+    const description = input('inlineEdit')?.description ?? '';
+    expect(description).not.toBe('');
+    expect(description).toMatch(/false/);
+    // Asserted through the renderer's own default, so the text cannot drift from
+    // the read: `schema.inlineEdit ?? true`.
+    expect(input('inlineEdit')?.defaultValue).toBe(true);
+    expect(input('showHeader')?.defaultValue).toBe(false);
+  });
+
   it('`fields` documents no entry shape, because the spec accepts bare names only', () => {
     // objectui#3807's fence check on the sibling input at the same call site.
     // Top-level `fields` is `z.array(z.string())`: there is no member shape to

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -302,6 +302,31 @@ ComponentRegistry.register('details', RecordDetailsRenderer, {
     // `DetailSection.tsx:439` (`visibleFields.length === 0 &&
     // emptyCount === section.fields.length` returns null), not assumed.
     { name: 'hideFields', type: 'array', label: 'Hide Fields', description: 'Field names to omit from the body — applied to the top-level `fields` list AND to every section\'s `fields`. Bare field names only. Authors rarely need it: the synth pipeline fills it with the fields already shown in `record:highlights`, and hand-authored pages get the same dedup live from HighlightFieldsContext, so its purpose is suppressing a field you do not want repeated (the page H1 title field is dropped for you too). Hiding every field of a section leaves that section out entirely.' },
+    // `inlineEdit` and `showHeader` are DECLARED, not merely honoured
+    // (objectui#4668) — the same reverse-direction defect `hideFields` above
+    // records, on the two keys @objectstack/spec 17.0.0 GA added to this block.
+    // `RecordDetailsRenderer` has read both all along (`renderers/
+    // record-details.tsx`: `(schema.inlineEdit ?? true) && objectInlineEditable`,
+    // and `showHeader: schema.showHeader ?? false` on the synthesized
+    // `detail-view`), while `inputs` omitted them — so `sdui.manifest.json` and
+    // `sdui-intrinsics.d.ts` never mentioned them, `sdui-parser`'s prop walk
+    // raised `unknown-prop` on an author who wrote one, and the renderer
+    // honoured it regardless.
+    //
+    // Both are plain booleans on the installed pin — measured against
+    // `ComponentPropsMap['record:details']`, `z.boolean().optional()` each, so a
+    // single arm and no union (objectui#3832): `1` / `'true'` / `null` are
+    // rejected by value.
+    //
+    // `inlineEdit` is documented as an opt-OUT because that is the only
+    // direction it can decide. The value is AND-ed with the object's own
+    // resolved editability (`isObjectInlineEditable`, ADR-0103) and with the
+    // server's effective API operation set (objectui#3546), so `true` cannot
+    // open editing the platform refuses; only `false` is unconditional. Saying
+    // "enables inline editing" would advertise an authority this key does not
+    // have.
+    { name: 'inlineEdit', type: 'boolean', label: 'Inline Edit', defaultValue: true, description: 'Offer the per-field double-click / pencil inline-edit affordances in the detail body. On by default, and an OPT-OUT only: the value is combined with the object\'s own editability (system, engine-owned, append-only and better-auth objects are not user-editable unless they opened userActions.edit) and with the server\'s effective API operation set for the object, so `false` always wins while `true` cannot open editing the platform refuses. The edit session and the atomic Save bar are hosted by the page, so one draft spans the highlights strip and this body.' },
+    { name: 'showHeader', type: 'boolean', label: 'Show Body Header', defaultValue: false, description: 'Render the detail body\'s own title / follow-star / copy-id chip above the fields. Off by default because this block is normally composed under a `page:header` that already draws that chrome, and turning it on there shows the record title twice. Set it true only when this block is the whole page.' },
   ],
 });
 


### PR DESCRIPTION
Fixes #4668

`@objectstack/spec@17.0.0` GA 声明、渲染器一直兑现、`inputs` 从未发布的五个键,现在在各自注册位声明为 `inputs`,每条带 description;parity 门里占位的五条 GA-pending 豁免随之删除。

## 前提验证:五个读点在现 main 重定位

卡面行号来自 `6d4f5bd59`,PR #4975 之后 `containers.tsx` 已动过。基线 `origin/main` @ `ec1f4d728`,逐个重定位并确认仍兑现:

| block | key | 现读点 | 兑现 |
|---|---|---|---|
| `page:header` | `maxVisible` | `containers.tsx:1382` | ✅ 双读(顶层 `??` `properties.*`) |
| `page:header` | `mobileMaxVisible` | `containers.tsx:1381` | ✅ 双读,默认 1 |
| `page:tabs` | `alwaysShowStrip` | `containers.tsx:637` | ⚠️ **仅** `properties.*`,见下 |
| `record:details` | `inlineEdit` | `record-details.tsx:234` | ✅ 顶层 |
| `record:details` | `showHeader` | `record-details.tsx:257` | ✅ 顶层 |

## 类型按实测定,不按措辞猜

实测 `ComponentPropsMap` 的成员与判定:

- `maxVisible` / `mobileMaxVisible` —— `optional -> number`,checks 为 `safeint` + `greater_than 0 (exclusive)`。实测 `1/2/3/100` 通过,`0` / `-1` / `1.5` 全部按值拒。单臂 `'number'`,无联合(#3832 的数组臂用不上)。
- `alwaysShowStrip` / `inlineEdit` / `showHeader` —— `optional -> boolean`。实测 `true` / `false` 通过,`1` / `0` / `'true'` / `null` 全部 `invalid_type`。单臂 `'boolean'`。

## 用户可见验收面:改前全 unknown-prop,改后全 CLEAN

在 console 自己的 manifest 上(`manifestFromConfigs` + `validateTree`,与 JSX-page 编译器和保存门同一对)实测对照。改前:

```
page:header.maxVisible        -> unknown-prop: page:header has no prop "maxVisible"
page:header.mobileMaxVisible  -> unknown-prop: page:header has no prop "mobileMaxVisible"
page:tabs.alwaysShowStrip     -> unknown-prop: page:tabs has no prop "alwaysShowStrip"
record:details.inlineEdit     -> unknown-prop: record:details has no prop "inlineEdit"
record:details.showHeader     -> unknown-prop: record:details has no prop "showHeader"
```

改后五条全部空。`apps/console/src/__tests__/ga-honoured-inputs-author-reach.test.ts` 把这个面钉住,并且**每个正向都配对照**:三个 block 各探一个谁都没声明的键,`unknown-prop` 必须照报(否则「无诊断」和「检查被静默」长得一样);另有 off-arm 探针(`alwaysShowStrip: 1` / `inlineEdit: 'no'` / `maxVisible: true`)确认声明的臂窄得有意义,而不是把 `type-mismatch` 一并关掉。

## page:tabs 另补一个读点(本 PR 唯一超出「加声明」的改动)

`alwaysShowStrip` 原先只按 `schema.properties.alwaysShowStrip` 读,而 `inputs` 发布的是**顶层**键 —— manifest 白名单、生成的 `.d.ts`、`sdui-parser` 的 prop walk、JSX-page 编译器判的都是顶层那个拼写。单标签页实测(改前):

```
WRAPPED  (properties.alwaysShowStrip: true)  strip present: true
FLAT     (alwaysShowStrip: true)             strip present: false
BASELINE (未写该键)                           strip present: false
```

只声明不补读点,等于发布一个渲染器会丢掉的写法 —— 正是 parity 门文件头写的那个失效模式(「manifest 告诉作者写一个平台会扔掉的键」)往里挪一层。所以规范拼写先读,`properties` 臂保留给不经 `SchemaRenderer` hoist 的路径,与 `maxVisible` 一贯的双读一致。`page-tabs-always-show-strip.test.tsx` 两个拼写都钉住,并含对照(不写该键必须不出条)与范围守卫(多标签页不受影响;`false` 与非布尔都读作「未设」)。

## 反向验证(三个变异,预判先写后跑)

**① 删豁免但不发布 inputs** —— 预判 #3808 那向红点名五键。实测一致,6 红:

```
page:header    publishes every top-level key … : expected [ 'maxVisible', 'mobileMaxVisible' ] to deeply equal []
page:tabs      publishes every top-level key … : expected [ 'alwaysShowStrip' ] to deeply equal []
record:details publishes every top-level key … : expected [ 'inlineEdit', 'showHeader' ] to deeply equal []
the five GA keys objectui#4668 declared are discoverable: page:header does not publish maxVisible
+ author-reach 两条(unknown-prop 回来)
```

**② 发布 inputs 但留豁免**(五条同时加回 `UNPUBLISHED_EXEMPTIONS` 与 `GA_PENDING_UNPUBLISHED_KEYS`)—— 预判 stale-exemption 检查红点名五条。实测一致,2 红:

```
carries no stale unpublished-key exemption: expected [ 'page:header.maxVisible', …(4) ] to deeply equal []
the five GA keys objectui#4668 declared are discoverable: expected […(17)] to not include 'page:header.maxVisible'
```

预判里明确写了「arming 检查应当**保持绿**」,实测确认:`every GA-pending exemption arms exactly with the installed spec` 在 GA pin 上要求 `isDormantOnThisPin === false`,而键被 spec 列出所以确实非 dormant —— 该检查管的是休眠是否跟着 spec 走,不是豁免是否过期。两个变异合起来钉住「删豁免与发布必须同 PR」。

**③ 回退 `alwaysShowStrip` 的顶层臂** —— 预判恰好一条红(被发布的那个拼写),wrapped、对照、声明块保持绿。实测一致,1 红:

```
shows a one-tab strip for the PUBLISHED top-level spelling: expected false to be true
```

**这一条最值得看的是什么保持了绿**:parity 门 65 条全绿、author-reach 4 条全绿。两者一个比顶层键名、一个读 manifest 诊断,都看不出渲染器读的是哪个载体 —— 只有行为测试能抓到。这也正是那个读点缺口能一路活到今天的原因。

三次变异后一律 `git checkout --` 还原(未用 stash),树回到本 commit。

## parity 门的收尾

五条豁免条目删除,`GA_PENDING_UNPUBLISHED_KEYS` 只剩 `object-grid` 那十条(测试名 `all fifteen together` 随之改为 `all ten together`,doc comment 从「TWO GROUPS」改为「ONE GROUP NOW」并记下离开的是哪一组、为什么 —— 一条永不落地的 pending 条目正是那个集合要暴露的腐坏)。删除处留下墓碑注释,含 `alwaysShowStrip` 读点缺口那笔,给下一个读者。

五个键另按名钉成 DECLARED(`the five GA keys objectui#4668 declared are discoverable`),理由与隔壁 #3808 五条、rc.6 record_picker 三条一致:派生的 reverse 循环在「声明被换回豁免」时一样绿,而那是时间压力下更省事的一步。

## 验证

全部经 `flock /tmp/os-heavy-verify.lock` + `--max-old-space-size=4096` + `--maxWorkers=2`:

| 面 | 结果 |
|---|---|
| `apps/console` 全项目 | 52 文件 / 575 测试 绿 |
| `packages/components/` | 148 文件 / 1327 测试 绿 |
| `packages/sdui-parser/` + `packages/plugin-detail/` | 89 文件 / 846 测试 绿 |
| `packages/layout/` + `packages/react/` + `packages/types/` | 99 文件 / 1216 测试 绿 |
| `packages/app-shell/.../metadata-admin/` + `examples/` | 183 文件 / 3314 绿(1 skipped) |
| 仓根 `turbo run type-check --concurrency=2` | 81/81 successful |
| `node scripts/check-control-bytes.mjs` | OK(4459 文件);另做门盲区自扫 `grep -naP` 六个改动文件,干净 |
| 改动文件 eslint | 0 error(112 warning 全是既有 `react-refresh/only-export-components`) |
| changeset 门 | `check-changeset-fixed` / `check-changeset-no-major` 均绿 |

消费半径按「规则被谁读」而非「改了哪个包」扫过:`BLOCK_CONFIG`(metadata-admin 设计器面板)是另一套人工策展面、无 parity 门,其 `page:header` 字段集被 `toEqual(['title','subtitle','breadcrumb'])` 精确钉住,本 PR 不动它;`page-container-authorable-keys.test.tsx` 的精确集断言只覆盖 `page:card`。两者都未受影响。

## 顺手记录,未在本 PR 处理

- #5006 —— `ComponentInput.type` 只有粗粒度 `number` 臂,无法表达整数/正数约束:作者写 `maxVisible: 0` 时 objectui 侧零诊断、渲染器照渲、上游 `os validate` 按值拒。附带一半是 `readMax` 比契约更宽(接受 `0`、小数下取整)。是发布契约的形状决定,列了四个方向待裁。
- #5007 —— parity 门 `GLOBALLY_UNPUBLISHED_SPEC_KEYS` 的理由串引用 `plugin-detail/src/index.tsx:335-337`,实际差约 70 行(本 PR 之前就已错,本 PR 让它更远)。`finding`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_