### PR TITLE
fix(metadata-admin): 审计面板锁状态列补齐中文，词表键绑 lockState union (#5004)

### DIFF
--- a/.changeset/audit-lock-state-zh-vocabulary-5004.md
+++ b/.changeset/audit-lock-state-zh-vocabulary-5004.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The metadata Audit panel's lock column now shows Chinese for every lock state it can print.
+
+`AuditPanel` renders `MetadataAuditEntry.lockState` through
+`translateConsoleValue('lock', …)`, but `CONSOLE_VALUE_ZH.lock` held
+`draft` / `locked` / `published` / `none` — a draft-status vocabulary, not the
+ADR-0010 §3.6 four-state lock. The misalignment was total rather than partial
+(objectui#5004): `draft` / `locked` / `published` matched no value `lockState`
+can hold; `none`, the only entry that did match, is excluded by the call site's
+own guard (an unlocked row renders an em dash) and so was unreachable; and the
+three values that actually reach the helper — `no-overlay` / `no-delete` /
+`full` — had no entry at all. Hit rate 0/3. A zh-CN admin opening any locked
+item's Audit panel read bare English tokens in a column headed 锁状态.
+
+The table is now the lock vocabulary it claims to be — `禁止编辑` / `禁止删除` /
+`完全锁定`, wording tracked to the lock-banner sentences a reader meets on the
+same screen — and the three draft-status entries are gone. They were dead in the
+measured sense: `translateConsoleValue('lock', …)` has exactly one call site
+repo-wide and `CONSOLE_VALUE_ZH` is module-private, so nothing else could read
+them.
+
+Following objectui#4982's `LAYER_SCOPE_ZH`, the keys are bound to their
+producer's union — `Record< NonNullable< MetadataAuditEntry['lockState'] >,
+string >`. A fifth lock state therefore fails `type-check` naming the label that
+is missing, instead of the column silently shipping a raw English value. The
+union is this repo's own hand-written one in `@object-ui/data-objectstack`, not a
+`@objectstack/spec` enum; whether the spec should own the lock vocabulary is a
+separate question and is deliberately not answered here.
+
+`none` is kept in the record even though the call site never asks for it, so the
+key set stays complete over the producer's type rather than tracking a `!==`
+guard in another file. Unchanged on purpose: `translateConsoleValue` is still
+zh-only, and the em-dash branch for `none` / `null` still renders exactly as
+before.

--- a/packages/app-shell/src/views/metadata-admin/AuditPanel.lockState.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/AuditPanel.lockState.test.tsx
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Audit tab's lock column speaks the UI language (objectui#5004).
+ *
+ * `AuditPanel` renders `MetadataAuditEntry.lockState` through
+ * `translateConsoleValue('lock', …)`, and `CONSOLE_VALUE_ZH.lock` used to hold
+ * `draft` / `locked` / `published` / `none` — a draft-status vocabulary, not the
+ * ADR-0010 §3.6 four-state lock. Alignment was total, not partial:
+ *
+ *   - `draft` / `locked` / `published` matched NO value `lockState` can hold;
+ *   - `none`, the one entry that did match, is excluded by the call site's own
+ *     guard (an unlocked row renders an em dash), so it was unreachable;
+ *   - the three values that DO reach the helper — `no-overlay` / `no-delete` /
+ *     `full` — had no entry, so zh-CN fell through to the raw token.
+ *
+ * Hit rate 0/3: a zh-CN admin opening any locked item's Audit panel read bare
+ * English in a column headed 锁状态.
+ *
+ * The state list below is bound to `MetadataAuditEntry['lockState']` itself
+ * rather than spelled freely, so a fifth lock state is covered by these cases
+ * the moment the union gains it. Unlike objectui#4982's overlay scopes there is
+ * no `@objectstack/spec` enum to read at runtime — this union is hand-written in
+ * `packages/data-objectstack` — hence the `satisfies`-checked key trick instead
+ * of a `.options` array. (The compile-time half of the coverage is
+ * `LOCK_STATE_ZH` in `./i18n`, whose key type is that union: a new state with no
+ * zh-CN label fails `type-check` before it can reach the column.)
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type {
+  MetadataAuditEntry,
+  MetadataClient,
+} from '@object-ui/data-objectstack';
+import { AuditPanel } from './AuditPanel';
+import { translateConsoleValue } from './i18n';
+
+afterEach(cleanup);
+
+type LockState = NonNullable<MetadataAuditEntry['lockState']>;
+
+/**
+ * Every lock state the producer type can send. `satisfies` makes the record
+ * exhaustive in both directions — a state added to the union leaves a key
+ * missing, a state renamed leaves an extra one — so this list cannot drift from
+ * `lockState` without failing `type-check`.
+ */
+const ALL_LOCK_STATES = Object.keys({
+  none: 0,
+  'no-overlay': 0,
+  'no-delete': 0,
+  full: 0,
+} satisfies Record<LockState, 0>) as LockState[];
+
+/** The states the column actually prints — `none` takes the em-dash branch. */
+const RENDERED_LOCK_STATES = ALL_LOCK_STATES.filter((s) => s !== 'none');
+
+/** The draft-status entries the table used to hold, none of them a lock state. */
+const RETIRED_ENTRIES = ['draft', 'locked', 'published'];
+
+const EM_DASH = '—';
+
+function auditRow(over: Partial<MetadataAuditEntry> = {}): MetadataAuditEntry {
+  return {
+    id: 'a_1',
+    occurredAt: '2026-08-17T10:00:00.000Z',
+    actor: 'admin@objectos.ai',
+    source: 'protocol.saveMetaItem',
+    operation: 'save',
+    outcome: 'denied',
+    code: 'item_locked',
+    lockState: 'full',
+    lockOverridden: false,
+    requestId: null,
+    note: null,
+    ...over,
+  };
+}
+
+/** Minimal stand-in — the panel only calls `audit()` on its client. */
+function clientWith(events: MetadataAuditEntry[]): MetadataClient {
+  const stub: Pick<MetadataClient, 'audit'> = {
+    audit: async () => ({ events }),
+  };
+  return stub as MetadataClient;
+}
+
+async function renderPanel(over: Partial<MetadataAuditEntry>, locale: string) {
+  render(
+    <AuditPanel
+      type="object"
+      name="a_account"
+      client={clientWith([auditRow(over)])}
+      locale={locale}
+    />,
+  );
+  // The panel loads in an effect; wait for the row's actor cell to land.
+  await screen.findByText('admin@objectos.ai');
+}
+
+describe('AuditPanel lock-state column (objectui#5004)', () => {
+  it('every lock state the union can hold has a zh-CN label', () => {
+    for (const state of ALL_LOCK_STATES) {
+      expect(
+        translateConsoleValue('lock', state, 'zh-CN'),
+        `CONSOLE_VALUE_ZH.lock has no entry for lock state '${state}'`,
+      ).not.toBe(state);
+    }
+  });
+
+  it.each(RENDERED_LOCK_STATES)('renders the zh-CN label for lockState=%s', async (state) => {
+    await renderPanel({ lockState: state }, 'zh-CN');
+    const zh = translateConsoleValue('lock', state, 'zh-CN');
+    expect(screen.getByText(zh)).toBeInTheDocument();
+    // The raw producer token must not be on screen anywhere.
+    expect(screen.queryByText(state)).toBeNull();
+  });
+
+  it('keeps the em-dash branch for an unlocked row', async () => {
+    await renderPanel({ lockState: 'none' }, 'zh-CN');
+    expect(screen.getByText(EM_DASH)).toBeInTheDocument();
+    // `none` has a label, but the guard at the call site means the column never
+    // asks for it — the em dash is the unlocked presentation, not a fallback.
+    expect(screen.queryByText(translateConsoleValue('lock', 'none', 'zh-CN'))).toBeNull();
+  });
+
+  it('keeps the em-dash branch for a null lockState', async () => {
+    await renderPanel({ lockState: null }, 'zh-CN');
+    expect(screen.getByText(EM_DASH)).toBeInTheDocument();
+  });
+
+  it('keeps the override star next to the localized label', async () => {
+    // `lockOverridden` appends ' *' as a sibling text node; pinned so the label
+    // change did not disturb the forced-write marker.
+    await renderPanel({ lockState: 'no-delete', lockOverridden: true }, 'zh-CN');
+    const zh = translateConsoleValue('lock', 'no-delete', 'zh-CN');
+    expect(screen.getByText(`${zh} *`)).toBeInTheDocument();
+  });
+
+  it('leaves the raw value alone outside zh — the helper has always done that', async () => {
+    // `translateConsoleValue` returns the input verbatim for every non-zh
+    // locale. Whether the other nine locale packs should gain these values is a
+    // separate decision, deliberately not made here; this case pins that this
+    // fix did not quietly make it.
+    await renderPanel({ lockState: 'no-overlay' }, 'en-US');
+    expect(screen.getByText('no-overlay')).toBeInTheDocument();
+  });
+
+  it('does not resurrect the draft-status entries as lock labels', async () => {
+    // The three retired keys are values `lockState` cannot hold. Falling through
+    // to the raw token is the correct answer for them now — an entry here would
+    // be another 0-hit-rate row, which is the defect this file guards.
+    for (const stale of RETIRED_ENTRIES) {
+      expect(translateConsoleValue('lock', stale, 'zh-CN')).toBe(stale);
+    }
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -54,9 +54,13 @@
  */
 
 import { useObjectTranslation } from '@object-ui/i18n';
-// Type-only (erased at build): the overlay-scope label table below is keyed by
-// the spec's enum rather than by hand — see `LAYER_SCOPE_ZH`.
-import type { MetadataOverlayScope } from '@object-ui/data-objectstack';
+// Type-only (erased at build): the overlay-scope and lock-state label tables
+// below are keyed by their producer's own union rather than by hand — see
+// `LAYER_SCOPE_ZH` and `LOCK_STATE_ZH`.
+import type {
+  MetadataAuditEntry,
+  MetadataOverlayScope,
+} from '@object-ui/data-objectstack';
 
 export type SupportedLocale = 'en-US' | 'zh-CN';
 
@@ -4125,6 +4129,44 @@ const LAYER_SCOPE_ZH: Record<NonNullable<MetadataOverlayScope>, string> = {
 };
 
 /**
+ * zh-CN labels for the ADR-0010 §3.6 four-state metadata lock, keyed by the
+ * producer field the only consumer actually renders.
+ *
+ * The key type is `MetadataAuditEntry['lockState']` — the hand-written union in
+ * `packages/data-objectstack/src/metadata-client.ts`, not a `@objectstack/spec`
+ * enum, because this repo owns that union today. (Whether the spec should own
+ * the lock vocabulary is a separate question; it is deliberately not answered
+ * here.) Binding the keys means a fifth lock state added to the union stops this
+ * record from compiling and names the label that is missing, instead of the
+ * column silently shipping a raw English token.
+ *
+ * That silent path is objectui#5004, and it was total rather than partial: the
+ * table used to hold `draft` / `locked` / `published` / `none` — a draft-status
+ * vocabulary — so of the three values the audit column can actually show, zero
+ * had an entry. A zh-CN admin read bare `no-overlay` / `no-delete` / `full`.
+ *
+ * Wording tracks the lock banner sentences a reader meets on the same screen
+ * (`engine.edit.lockNoOverlay` 不可编辑 / `lockNoDelete` 不可删除 / `lockFull`
+ * 不可编辑或删除), compressed to state names for a narrow badge column.
+ *
+ * `none` is currently unreachable through the sole call site — `AuditPanel`
+ * renders an em dash for an unlocked/`null` row rather than a word — and is kept
+ * anyway: the key set follows the producer's type, so the record stays complete
+ * over the domain and does not need editing the day that presentation choice
+ * changes.
+ *
+ * Deliberately zh-only, like every other group here — `translateConsoleValue`
+ * returns the raw value for the other nine locale packs by existing design, and
+ * whether to extend it is a separate decision, not a rider on this fix.
+ */
+const LOCK_STATE_ZH: Record<NonNullable<MetadataAuditEntry['lockState']>, string> = {
+  none: '无',
+  'no-overlay': '禁止编辑',
+  'no-delete': '禁止删除',
+  full: '完全锁定',
+};
+
+/**
  * zh-CN labels for the metadata-editor side panels' raw enum-ish values —
  * History operation badges, Audit operation/outcome/lock-state, and the Layered
  * diff tab badges. Shared by every metadata type (not flow-specific). English
@@ -4143,7 +4185,7 @@ const CONSOLE_VALUE_ZH: Record<string, Record<string, string>> = {
     rollback: '回滚',
   },
   outcome: { allowed: '允许', denied: '拒绝', forced: '强制' },
-  lock: { draft: '草稿', locked: '已锁定', published: '已发布', none: '无' },
+  lock: LOCK_STATE_ZH,
   layer: {
     artifact: '工件',
     none: '无',


### PR DESCRIPTION
Fixes #5004

## 症状

zh-CN 管理员打开元数据编辑页的「审计」面板，凡是带锁的审计行，标题为「锁状态」的那一列显示裸英文 `no-overlay` / `no-delete` / `full`。

## 根因：不是漏译，是整张词表串了行

`CONSOLE_VALUE_ZH.lock` 里装的是一套**草稿状态**词表（`draft` / `locked` / `published` / `none`），而它服务的字段是 ADR-0010 §3.6 的**四态锁** `MetadataAuditEntry.lockState`。三者对齐后是完全错位，不是部分缺失：

| 词表条目 | 能否被命中 |
|---|---|
| `draft` / `locked` / `published` | 对不上 `lockState` 的**任何**可能值 |
| `none` | 唯一对得上的，却被调用点自己的守卫排除 —— `AuditPanel.tsx:191` 的 `ev.lockState && ev.lockState !== 'none'` 为假时走 `—` 支路，永远不会问它 |
| `no-overlay` / `no-delete` / `full` | 实际能到 `translateConsoleValue` 的三个值，**一条条目都没有** |

命中率 0/3。`translateConsoleValue` 把 `value` 声明为 `string`，所以类型检查对此毫无意见 —— 与 #4982 里 `overlayScope` 被声明成 `string` 的同一个原因。

## 改动

1. **补三条中文**：`no-overlay` → 禁止编辑、`no-delete` → 禁止删除、`full` → 完全锁定。用词跟随读者在同一屏上会读到的锁定横幅句子（`engine.edit.lockNoOverlay` 不可编辑 / `lockNoDelete` 不可删除 / `lockFull` 不可编辑或删除），压缩成适合窄列的状态名。

2. **键绑生产者的 union**（仿 #4982 / PR #5005 落地的 `LAYER_SCOPE_ZH`）：新表 `LOCK_STATE_ZH` 的键类型是 `Record< NonNullable< MetadataAuditEntry['lockState'] >, string >`。今后 union 加第五态时，这条记录**编译不过并点名缺失的那个标签**，而不是让界面静默漏出裸英文。

   键集选的是**完整的 `NonNullable`（含 `none`）**，不是按调用点现实剔除 `none` 后的 `Exclude< …, 'none' >`。理由两条：一是与 PR #5005 已落地的形状一致；二是词表的完备性应当对着**生产者的类型**，而不是对着另一个文件里 JSX 三元表达式中的一个 `!==` —— 那个守卫是「未锁定显示破折号而非文字」的展示选择，它哪天改了，词表不该需要跟着改。`none` 因此保留一条，并在 docblock 里写明它目前经唯一调用点不可达。

3. **删掉三条死条目**（先量后删，这正是本卡记录的陷阱）：
   - 全仓扫 `translateConsoleValue('lock'` → **仅 1 个调用点**（`AuditPanel.tsx:193`）；
   - `CONSOLE_VALUE_ZH` 是模块私有 `const`，全仓只有两处引用：定义处与 `translateConsoleValue` 内那一次查表；
   - 6 个 `translateConsoleValue` 调用点的 group 实参**全是字面量**（`'op'` / `'outcome'` / `'lock'` / `'layer'`），没有变量 group 能间接读到；
   - `MetadataLayered['lock']`（同一套四态锁的另一个字段）由 `ResourceEditPage.tsx:1935-1937` 渲染，走的是 `t('engine.edit.lockFull'…)` 整句字符串，**不读这张词表**。

   结论：确无第二调用点，三条删除。键绑定本身也强制了这一点 —— 多余键会触发 excess property check。

## 刻意未改

- `translateConsoleValue` 仍是 zh-only（其余九个 locale pack 返回原值是既有设计）；是否扩出去是独立决定，不搭车。
- `none` / `null` 的 `—` 支路渲染与改前逐字一致。
- 是否该由 `@objectstack/spec` 拥有这套锁词表：本仓今天手写这个 union，按分诊围栏**不伸手 spec**，问题留给维护者（见下）。

## 测试

新增 `AuditPanel.lockState.test.tsx`（9 例）。状态清单不是自由手写的，而是用 `satisfies Record< LockState, 0 >` 校验过的键集反推 —— 双向穷尽（少一个键报缺失，改名报多余），所以清单无法与 union 漂移。这里没有 `@objectstack/spec` 的 `z.enum` 可在运行时读 `.options`（union 是本仓手写的），故用 `satisfies` 技巧代替 #4982 的 `.options` 数组。

```
pnpm exec vitest run packages/app-shell/src/views/metadata-admin/
  Test Files  175 passed (175)
  Tests  1735 passed | 1 skipped (1736)

pnpm exec turbo run type-check --concurrency=2
  Tasks: 81 successful, 81 total

node scripts/check-control-bytes.mjs
  OK (scanned 4479 tracked text file(s))
```

### 反向验证（先书面预判，再变异）

**变异①：从 `LOCK_STATE_ZH` 删掉 `'no-delete'` 一条。** 预判 **tsc 红 + vitest 红**（2 例）。这里**刻意不同于** PR #5005 变异① 的「tsc 红、vitest 绿」先例：本 PR 的测试里写了那个编译期钉的运行时孪生（穷尽循环 + 逐状态渲染例），所以两侧都该动。实测与预判一致：

```
i18n.ts(4162,7): error TS2741: Property '"no-delete"' is missing in type
  '{ none: string; 'no-overlay': string; full: string; }' but required in type
  'Record< NonNullable< "none" | "no-overlay" | "no-delete" | "full" | null >, string >'.
AssertionError: CONSOLE_VALUE_ZH.lock has no entry for lock state 'no-delete'
AssertionError: expected span to be null   // 屏幕上出现裸 no-delete
  Tests  2 failed | 7 passed (9)
```

**变异②：把 `i18n.ts` 整体退回 `origin/main`（保留测试）。** 预判 **vitest 红 5 例、tsc 绿**。tsc 绿是这里最有信息量的一半：改前那个状态**编译得干干净净**，这正是缺陷能出厂的原因。实测与预判一致，红的是穷尽例 + 三个渲染例 + 死条目例，绿的 4 例恰好是三条不回归钉（`none` 破折号、`null` 破折号、override 星号）与 en-US 原值钉：

```
TSC_EXIT=0
AssertionError: CONSOLE_VALUE_ZH.lock has no entry for lock state 'no-overlay'
AssertionError: expected span to be null   // no-overlay / no-delete / full 三例
AssertionError: expected '草稿' to be 'draft'   // 死条目复活即红
  Tests  5 failed | 4 passed (9)
```

## 留给维护者的开放问题（未自行决定）

这套四态锁词表是否应归 `@objectstack/spec` 拥有？现状是 `MetadataLayered['lock']` 与 `MetadataAuditEntry['lockState']` 在本仓 `packages/data-objectstack/src/metadata-client.ts` 手写两遍同一个 union（第 298 行与第 340 行，字面重复）。若 spec 出 `z.enum`，两处可派生、词表键可像 `LAYER_SCOPE_ZH` 一样绑到 spec，跨仓漂移也一并关闭。本 PR 按围栏不伸手 spec，绑到本仓 union；如维护者认可归属 spec，这里的键类型换一行即可。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_