### PR TITLE
fix(components): span 废弃提示改为每模块加载一条,且只对 JSON 作者面开火 (#4917)

### DIFF
--- a/.changeset/span-deprecation-parity-with-div-4917.md
+++ b/.changeset/span-deprecation-parity-with-div-4917.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/components': patch
+---
+
+The `span` deprecation notice is now reported once per page load, and only to the authoring surface it applies to.
+
+`SpanRenderer` was two rulings behind `div`. It still `console.warn`ed on **every
+render**, and it still fired at nodes the `kind:'html'` tier's own parser had
+emitted — the two defects that were ruled on for `div` in objectui#3965 (PR
+#3998, which explicitly named `span` as the follow-up) and objectui#4000 (PR
+#4916, which built the provenance mechanism). This is that follow-up
+(objectui#4917); it copies the shape now in `basic/div.tsx` rather than inventing
+a second one.
+
+- **Once per module load.** The notice is a property of the deprecated TYPE, not
+  of each node, so repeating it per render only buries the page's real console
+  errors. The deprecation still fires in dev builds, exactly once.
+- **JSON-authored nodes only.** An author writing the plain inline tag in a
+  `kind:'html'` page gets a node this deprecated renderer serves — and was told
+  to migrate to `badge` / `text`, neither of which exists in that tier's
+  vocabulary, with nothing they could write to make it stop. Provenance is
+  established by the producer (the parser stamps what it emits, via
+  `isHtmlTierNode`), not guessed from the node's shape here.
+- **The notice now names its surface**, so whoever reads the console can tell
+  which of their pages it is about. The migration guidance itself is unchanged:
+  this narrows WHO is told, it does not water down WHAT they are told.
+
+Order is load-bearing and pinned by tests: the html-tier exemption is checked
+BEFORE the warn-once set is marked, so an html-tier node rendering first cannot
+swallow the notice a JSON-authored node earns later on the same page.

--- a/content/docs/components/basic/span.mdx
+++ b/content/docs/components/basic/span.mdx
@@ -18,6 +18,13 @@ import { DemoGrid } from '@/app/components/ComponentDemo';
 
 The Span component is an inline container. **It is now deprecated in favor of semantic Shadcn-based components** that provide better accessibility and design system integration.
 
+**Scope of this deprecation: JSON-authored pages.** A `kind:'html'` page is written as
+constrained JSX/Tailwind text that the engine compiles (parses, never executes) into
+nodes, tag name straight through — there, the plain inline tag is part of that tier's own
+vocabulary and stays fully supported, because no other spelling of it exists for an
+author to migrate to. The dev-build deprecation notice is therefore reported for
+JSON-authored nodes only, and never for what the html tier compiled from its own source.
+
 ## Migration Guide
 
 Instead of using `span`, use these Shadcn alternatives:

--- a/packages/components/src/__tests__/span-deprecation-provenance.test.tsx
+++ b/packages/components/src/__tests__/span-deprecation-provenance.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `span` deprecation notice is scoped BY PROVENANCE (objectui#4917,
+ * applying the ruling made for `div` in objectui#4000).
+ *
+ * A `kind:'html'` page is authored as constrained JSX/Tailwind text that our own
+ * parser compiles (never executes) into SDUI nodes, tag name straight through.
+ * So an author writing the plain inline tag in that tier gets a node the
+ * DEPRECATED renderer serves — and the notice fired at them, recommending
+ * `badge` / `text`, neither of which is an html-tier tag. Nothing the author
+ * could write made it stop: in that tier the tag IS the tier's own vocabulary,
+ * and `basic/html-elements.tsx` deliberately leaves it out of its own TAGS list
+ * precisely because this module registers it. A notice nobody can act on is not
+ * a deprecation, it is noise, and it also meant the type could never be retired
+ * — the engine's own compiler keeps emitting it.
+ *
+ * Maintainer ruling (2026-08-10, on objectui#4000): split the notice by
+ * provenance. Nodes the html tier's parser emitted are exempt; JSON-authored
+ * nodes keep being reported, unchanged.
+ *
+ * NOTE ON ORDER — the warn-once guard from objectui#3965 is a module-level Set
+ * that latches for the lifetime of this module instance, so the cases below are
+ * ordered deliberately and each depends on the one before:
+ *
+ *   1. the html-tier case runs FIRST, against a virgin Set. "No notice" here
+ *      therefore cannot be explained away by an earlier render having latched
+ *      the guard — there was no earlier render.
+ *   2. the authored case then observes exactly one notice, which is only
+ *      possible if case 1 left the Set virgin. The two cases pin each other:
+ *      an exemption that silently marked the guard would show up as a ZERO in
+ *      case 2, not as a pass.
+ *
+ * NOTE ON THE RENDER CONTROL — this deliberately does NOT copy the sibling
+ * `div` test's control assertion. That test proves the html page really
+ * rendered by reading the box tag's own text back out; the inline tag's text
+ * never arrives, because this renderer reads `schema.body` while the parser
+ * emits `children` (objectui#5027, filed separately — a rendering-path defect,
+ * not a notice-scoping one, and one that needs its own ruling on which key is
+ * canonical). The control here therefore uses a sibling paragraph's text plus
+ * the presence of the inline element itself: together they prove the page
+ * compiled AND that the node reached this deprecated renderer, so silence is an
+ * exemption rather than a missing node. Both assertions still hold once #5027
+ * is fixed.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+const DEPRECATION_RE = /The "span" component is deprecated/;
+
+function deprecationCalls(spy: ReturnType<typeof vi.spyOn>): unknown[][] {
+  return spy.mock.calls.filter((args: unknown[]) => DEPRECATION_RE.test(String(args[0])));
+}
+
+/** Renders a `kind:'html'` page — source compiled by the parser, then rendered. */
+function renderHtmlPage(source: string) {
+  return render(<SchemaRenderer schema={{ type: 'home', kind: 'html', name: 'test_page', source } as never} />);
+}
+
+describe('span deprecation notice — scoped by provenance (#4917)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  // MUST run first: see the ordering note above.
+  it('stays silent for nodes the html tier compiled from its own source', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { container } = renderHtmlPage(
+      '<div className="outer"><span className="inner">hello html tier</span><p>page rendered</p></div>',
+    );
+
+    // Control FIRST: silence proves nothing if the page never rendered. A
+    // compile error replaces the whole page with an error panel, which would
+    // produce zero notices for entirely the wrong reason. See the note above on
+    // why the inline tag's own text is not what is read back here.
+    expect(container.textContent).not.toContain('failed to compile');
+    expect(container.textContent).toContain('page rendered');
+    // …and the inline node really did reach THIS renderer: the element exists,
+    // carrying the class the html source authored.
+    expect(container.querySelector('span.inner')).toBeTruthy();
+
+    expect(deprecationCalls(warn)).toHaveLength(0);
+  });
+
+  it('still reports a JSON-authored node, exactly once, and says which surface it means', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { container } = render(
+      <SchemaRenderer
+        schema={{
+          type: 'span',
+          className: 'authored',
+          body: [{ type: 'span', className: 'authored-inner' }],
+        } as never}
+      />,
+    );
+
+    // Same control on this side: the nodes have to have actually rendered.
+    expect(container.querySelector('.authored')).toBeTruthy();
+    expect(container.querySelector('.authored-inner')).toBeTruthy();
+
+    const calls = deprecationCalls(warn);
+    expect(calls).toHaveLength(1);
+    const notice = String(calls[0][0]);
+    // The migration guidance is untouched — this issue narrows WHO is told, it
+    // does not water down WHAT they are told.
+    expect(notice).toContain('use "badge" component');
+    expect(notice).toContain('use "text" component with appropriate className');
+    // …and the notice now names the surface it applies to. A notice that says
+    // the type is deprecated FULL STOP is false the moment another tier keeps
+    // it as permanent vocabulary; whoever reads the console has to be able to
+    // tell which of their pages it is about.
+    expect(notice).toMatch(/JSON-authored/);
+    expect(notice).toMatch(/html/);
+  });
+
+  it('does not re-report an authored node on a later render', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(<SchemaRenderer schema={{ type: 'span', className: 'later' } as never} />);
+
+    expect(deprecationCalls(warn)).toHaveLength(0);
+  });
+
+  it('keeps provenance off the DOM and out of the serialized node', () => {
+    // The marker rides on the node object, so it must not reach the element or
+    // survive serialization. A string-keyed marker would have been spread onto
+    // the host element as an unknown attribute, and would have been copied into
+    // any persisted form of the tree — where an authored page could replay it
+    // and silence the notice for itself.
+    const { container } = renderHtmlPage('<span className="probe">x</span>');
+    const el = container.querySelector('span.probe') as HTMLElement | null;
+    expect(el).toBeTruthy();
+    const attrs = Array.from(el!.attributes).map((a) => a.name);
+    expect(attrs.filter((n) => n.includes('provenance') || n.includes('tier'))).toHaveLength(0);
+  });
+});

--- a/packages/components/src/__tests__/span-deprecation-warn-once.test.tsx
+++ b/packages/components/src/__tests__/span-deprecation-warn-once.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pins the once-semantics of the `span` deprecation notice (objectui#4917).
+ *
+ * `SpanRenderer` used to `console.warn` on EVERY render. That is harmless on a
+ * page with one inline node, and destructive on a page with many: the notice
+ * buries the page's real console errors underneath, which is what cost two
+ * browser-verification runs the signal they were looking for when `div` had the
+ * same defect (objectui#3965, fixed by PR #3998 — that PR named `span` as the
+ * follow-up and left the shape here untouched).
+ *
+ * What is pinned here is the DEDUPLICATION, not the removal of the warning:
+ * the deprecation still fires in dev builds, exactly once per module load.
+ *
+ * NOTE ON ORDER — the guard is a module-level Set, so it latches for the
+ * lifetime of this module instance. The production-silence case must therefore
+ * run BEFORE the dev case, and it doubles as a pin on the guard's ordering:
+ * the production early-return happens before the Set is marked, so a
+ * production render must not swallow a later dev notice.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+const DEPRECATION_RE = /The "span" component is deprecated/;
+
+function renderSpan(schema: Record<string, unknown>) {
+  const Component = ComponentRegistry.get('span');
+  if (!Component) throw new Error('Component "span" is not registered');
+  return render(<Component schema={schema} />);
+}
+
+function deprecationCalls(spy: ReturnType<typeof vi.spyOn>): unknown[][] {
+  // `ReturnType<typeof vi.spyOn>` erases the spied signature, so `mock.calls`
+  // arrives as `any` and this parameter had no type to infer. `unknown[]` is
+  // the row type this function already DECLARES it returns (objectui#4353).
+  return spy.mock.calls.filter((args: unknown[]) => DEPRECATION_RE.test(String(args[0])));
+}
+
+describe('span deprecation notice — once per module load (#4917)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  // MUST run first: see the note above. A production render may not mark the
+  // warn-once Set, otherwise it would suppress the dev notice that follows.
+  it('stays silent in production builds', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('NODE_ENV', 'production');
+
+    renderSpan({ type: 'span', className: 'px-1', body: [{ type: 'text', content: 'a' }] });
+
+    expect(deprecationCalls(warn)).toHaveLength(0);
+  });
+
+  it('warns exactly once however many span nodes render', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Three separate renders, and one of them nests three more `span` nodes:
+    // seven SpanRenderer invocations in total, one notice expected.
+    renderSpan({ type: 'span', className: 'a' });
+    renderSpan({ type: 'span', className: 'b' });
+    renderSpan({
+      type: 'span',
+      className: 'outer',
+      body: [
+        {
+          type: 'span',
+          className: 'middle',
+          body: [
+            { type: 'span', className: 'inner-1' },
+            { type: 'span', className: 'inner-2' },
+          ],
+        },
+      ],
+    });
+
+    const calls = deprecationCalls(warn);
+    expect(calls).toHaveLength(1);
+    // The notice itself is unchanged — the deprecation is still being reported,
+    // with its migration guidance intact.
+    expect(String(calls[0][0])).toContain('use "badge" component');
+    expect(String(calls[0][0])).toContain('use "text" component with appropriate className');
+  });
+
+  it('does not warn again on a later render', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderSpan({ type: 'span', className: 'later' });
+
+    expect(deprecationCalls(warn)).toHaveLength(0);
+  });
+});

--- a/packages/components/src/renderers/basic/span.tsx
+++ b/packages/components/src/renderers/basic/span.tsx
@@ -7,25 +7,84 @@
  */
 
 import { ComponentRegistry } from '@object-ui/core';
+import { isHtmlTierNode } from '@object-ui/sdui-parser';
 import type { TextSpanSchema } from '@object-ui/types';
 import { renderChildren } from '../../lib/utils';
 import { forwardRef } from 'react';
+
+/**
+ * Deprecated types already reported in this module instance — the notice is a
+ * property of the TYPE, not of the node, so one report per page load is the
+ * whole signal. Mirrors the warn-once machinery in `basic/div.tsx`.
+ */
+const _warnedDeprecations = new Set<string>();
+
+/**
+ * Report the deprecation ONCE per type per module load.
+ *
+ * The renderer used to warn on every single render, so a page with many inline
+ * nodes turned the console into a flood that buries the page's real errors
+ * (objectui#3965 measured ~190 identical `div` notices on the docs
+ * schema-catalog index). PR #3998 fixed `div` and named `span` as the
+ * follow-up; this is that follow-up (objectui#4917).
+ *
+ * The deprecation itself is unchanged and still fires in dev builds; only the
+ * repetition is dropped. Order matters: the production check returns BEFORE the
+ * seen-set is marked, so a production render never suppresses the dev notice.
+ */
+function warnDeprecatedOnce(type: string, message: string): void {
+  if (process.env.NODE_ENV === 'production') return;
+  if (_warnedDeprecations.has(type)) return;
+  _warnedDeprecations.add(type);
+  console.warn(message);
+}
+
+/**
+ * The notice, including WHICH AUTHORING SURFACE it is about.
+ *
+ * Scope is part of the message, not decoration. This type is deprecated on the
+ * JSON surface and simultaneously a permanent, first-class tag of the
+ * `kind:'html'` tier — an author there writes the plain inline tag and our own
+ * parser maps it straight through, and no other spelling exists for them to
+ * migrate to. A notice that says the type is deprecated FULL STOP is therefore
+ * false for one of its two readers, and it was the reader who could do nothing
+ * about it who kept receiving it (objectui#4000, ruled for `div`; the same
+ * ruling applies here because `basic/html-elements.tsx` deliberately leaves
+ * this tag out of its own TAGS list — it is registered by this module).
+ *
+ * The migration guidance below is byte-for-byte what it was: this issue narrows
+ * WHO is told, it does not water down WHAT they are told.
+ */
+const SPAN_DEPRECATION_NOTICE =
+  '[ObjectUI] The "span" component is deprecated for JSON-authored pages. Please use Shadcn components instead:\n' +
+  '  - For badges/labels: use "badge" component\n' +
+  '  - For inline text emphasis: use "text" component with appropriate className\n' +
+  '  This applies to JSON-authored nodes. In a kind:\'html\' page the tag is part of that tier\'s own\n' +
+  '  vocabulary, is compiled straight through, and is not reported here.\n' +
+  'See documentation at https://www.objectui.org/docs/components for alternatives.';
 
 // Index signature on the parameter annotation, not on the `forwardRef` type
 // argument — mechanism note on `action:bar` (objectui#4422), pinned by
 // `__tests__/forwardref-props-annotation.guard.test.ts`.
 const SpanRenderer = forwardRef<HTMLSpanElement, { schema: TextSpanSchema; className?: string }>(
   ({ schema, className, ...props }: { schema: TextSpanSchema; className?: string; [key: string]: any }, ref) => {
-    // Deprecation warning
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        '[ObjectUI] The "span" component is deprecated. Please use Shadcn components instead:\n' +
-        '  - For badges/labels: use "badge" component\n' +
-        '  - For inline text emphasis: use "text" component with appropriate className\n' +
-        'See documentation at https://www.objectui.org/docs/components for alternatives.'
-      );
+    // Deprecation notice — JSON-authored nodes only (objectui#4000), once per
+    // module load (objectui#3965, see warnDeprecatedOnce). Both rulings landed
+    // for `div` first; objectui#4917 brings this renderer level with it.
+    //
+    // ORDER, same discipline as the production early-return inside
+    // warnDeprecatedOnce: the exemption is checked BEFORE the seen-set is
+    // marked. An html-tier node rendering first must not latch the guard, or it
+    // would swallow the notice a JSON-authored node earns later on the same
+    // page — silencing exactly the reader this notice is for.
+    //
+    // The test is provenance, established by the producer (the parser stamps
+    // what it emits), not a guess about the node's shape here.
+    if (!isHtmlTierNode(schema)) {
+      warnDeprecatedOnce('span', SPAN_DEPRECATION_NOTICE);
     }
-    
+
+
     // Extract designer-related props
     const { 
         'data-obj-id': dataObjId, 


### PR DESCRIPTION
Fixes #4917

## 背景:同一个渲染器落后 `div` 两步

`span` 的废弃提示身上压着两条**已经裁定过**的纪律,而 `div` 两条都补上了,`span` 一条没补:

- **#3965 / PR #3998** 把 `div` 从「每次渲染 warn 一条」改成「每模块加载一条」。该 PR 的「边界」一节写明 `span` 「该照抄本 PR 的守卫形状,留作后续」—— 至今没有后续。
- **#4000 / PR #4916** 裁定 `kind:'html'` tier 自己的解析器产出的节点豁免废弃提示,并把机制落在生产者侧、从 `@object-ui/sdui-parser` 包入口导出 `isHtmlTierNode`(`Symbol.for` 注册键,对 JSON / DOM 都不可见)。`span` 的判断面一字未动。

两条叠加的后果与 `div` 当初一致:提示对**引擎自己解析器的输出**开火,而且不去重。`basic/html-elements.tsx` 的 TAGS 列表**故意**把这个标签排除在外(注释写明「已在别处注册」),正是因为它由 `basic/span.tsx` 注册 —— 所以 html tier 页面里写这个内联标签,编译出的节点必然落到这个废弃渲染器上,作者收到一条建议换 `badge` / `text` 的提示,而那两个都不是 html tier 里的等价标签,作者写什么都消不掉。

本 PR 就是那个「后续」:**照抄 `div.tsx` 现在的形状**,不另发明一套。

## 改动

`packages/components/src/renderers/basic/span.tsx`:

- 模块级 `_warnedDeprecations` Set + `warnDeprecatedOnce()` —— 提示是**类型**的属性而不是节点的属性,每次渲染重复一遍只会把页面真正的报错埋掉。dev 构建照旧报,恰好一条。
- 豁免判断 `isHtmlTierNode(schema)`,provenance 由**生产者**建立(parser 给自己产出的节点打标),不是在这里猜节点形状。
- **顺序是承重的**:豁免判断放在 Set 标记**之前**。html-tier 节点先渲染不得 latch 守卫,否则会吞掉同一页上之后 JSON 作者节点应得的那一条 —— 正好把这条提示唯一的目标读者静音。与 `warnDeprecatedOnce` 内部「production 提前 return 在标记之前」是同一条纪律。
- 文案加一句写明它针对哪个作者面。迁移建议**逐字未动** —— 这一单收窄的是「告诉谁」,不是「告诉什么」。

`content/docs/components/basic/span.mdx` 补一段作用域说明,与 `div.mdx` 同形。

## 测试

两个新钉子,照抄 `div-deprecation-*.test.tsx` 的形状:

- `span-deprecation-warn-once.test.tsx` —— production 静默用例**必须跑在最前**(Set 会 latch 整个模块实例的生命周期),它同时钉住守卫的顺序:production 渲染不得吞掉之后的 dev 提示。七次 SpanRenderer 调用(含三层嵌套)只收一条。
- `span-deprecation-provenance.test.tsx` —— html-tier 用例跑在最前、对着一个**未被污染**的 Set,所以「零提示」不能用「之前某次渲染已经 latch 了守卫」解释;紧接着的 JSON 作者面用例观察到恰好一条,只有在前一个用例没标记 Set 时才可能。两个用例互相钉住。

### 一处刻意的偏离,连带发现 #5027

provenance 测试**没有**照抄 `div` 那条 `textContent` 对照断言。原因是这个内联标签在 html tier 里的文字压根不会渲染:该渲染器读 `schema.body`,而 parser 产出的是 `children`(`div.tsx` 读的是 `schema.children || schema.body`,所以 `div` 没事)。实测:

```
源码   < div className="outer" >< span className="inner" >hello html tier< /span >< p >page rendered< /p >< /div >
渲染   < div class="outer" >< span class="inner" >< /span >< p >page rendered< /p >< /div >
```

这是**渲染路径**的独立缺陷,不是提示作用域的缺陷,而且它需要单独裁定「规范的子节点键是 `children` 还是 `body`」—— 按 Commandment #0.1 contract-first,这该在类型/规范侧定,不该由渲染器顺手加一个宽容的 `||` 糊掉。已单独立 **#5027**,本 PR 不碰。

对照断言因此改用「同页 p 标签的文字」+「内联元素本身存在(带 html 源码里写的 class)」:两者合起来证明**页面确实编译并渲染了**、且**节点确实落到了这个废弃渲染器上**,所以观察到的静默是豁免生效,而不是节点根本没出现。两条断言在 #5027 修好之后依然成立。

## 反向验证(先书面预判,再变异)

| 变异 | 预判 | 实测 |
|---|---|---|
| ① 撤掉 `isHtmlTierNode` 豁免判断 | provenance 用例 1 红(html-tier 节点收到 1 条,期望 0);用例 2 连带红(Set 被用例 1 latch,变成 0 条) | 完全一致:`expected [ Array(1) ] to have a length of +0 but got 1` / `expected [] to have a length of 1 but got +0` |
| ② 只撤去重(`has`/`add`),保留 production 提前 return | warn-once 用例 2、3 红(条数 > 1);**用例 1「production 静默」应保持绿** —— 这是区分两道守卫彼此独立的判别项 | 完全一致:4 红(4 / 2 / 9 / 1 条),3 绿 = production 静默 + html-tier 静默 + provenance 不上 DOM |
| ③ 把 html fixture 改成编译不过的源码(塞一个未注册标签) | ③a 同时去掉三条对照断言 → **绿**(演示空绿危险:`toHaveLength(0)` 在页面根本没渲染时免费通过);③b 保留对照断言 → 红在 `not.toContain('failed to compile')` | 完全一致:③a `Tests 4 passed`(绿,且是错误的绿);③b `expected 'HTML page failed to compile (2)…' not to contain 'failed to compile'` |

变异 ① 的第二处失败是顺序钉子在响:没有豁免时,html-tier 节点会把 JSON 作者应得的那一条吞掉 —— 这恰好是把豁免放在 Set 标记之前所要防的事。

变异 ② 的判别项(用例 1 保持绿)证明 production 提前 return 与去重是两道独立的守卫,不是一道。

变异 ③ 是对**对照断言本身**的验证,回答「这条 `toHaveLength(0)` 会不会因为整页编译失败而免费通过」:③a 证明危险真实存在,③b 证明本 PR 的对照断言确实拦得住。

还原一律 `git checkout --` 指定路径,未使用 `git stash`(共享栈)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_