### PR TITLE
fix(components): FilterBuilder 值落在选项集外时清到空形或显示出来，不再隐形 (#4874)

### DIFF
--- a/.changeset/filter-builder-value-option-domain.md
+++ b/.changeset/filter-builder-value-option-domain.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/components": patch
+---
+
+fix(components): FilterBuilder 的值不再落在列的选项集之外还看不见 (objectui#4874)
+
+带 `options` 的 select/lookup 列，其值控件是一个受控的 Radix Select，而
+`SelectValue` 只认已挂载的 `SelectItem`。于是文本列的 `equals "acme"` 指到
+picklist 列（选项 `won` / `lost`）之后，值控件显示空，行里仍是
+`value: "acme"` —— `foldFilterGroupToSpecRules` 照样持久化、实时网格照样拿
+`stage equals "acme"` 去查。这是 #4768（operator）、#4781（值的类型）之后
+「看不见的值」的第三张脸，成因是**值域**而不是类型：`select` / `lookup` 属于
+文本族，`"acme"` 在类型上装得下，只是不在该列的选项集里。
+
+按 2026-08-17 维护者裁定（A + C 组合）：
+
+- **静态选项列**（`options` 是非空数组，选项集就是该列的全部值域）：切换 field
+  时做成员判定，不在选项集里的值清到 #4781 的那套空形 —— 标量 `''`、列表逐项
+  过滤后 `[]`。列表是**逐项**判定，用户写对的那几项不会被一颗坏项连坐。
+- **远程/异步列**（lookup 远程搜索、`options` 缺席，或 `options: []` 尚未到位）：
+  值**保留**并**可见** —— 绝不因一份从未声称完整的本地选项集去删一个合法的
+  lookup id。Select 把该值挂成一个临时项（标签用值本身，与
+  `LookupValuePicker` 对没有 label 的 id 的做法一致），多值列表把它渲染成一行
+  已勾选、可取消的条目。
+- 可见性是**无条件**的：无论值是切列带来的、从已存视图读回来的，还是选项集晚到
+  才对不上，控件都显示行里真正带着的东西。「行带值、控件空白」这个形态不再存在，
+  也不会为了显示去悄悄改写传入的 `value`。

--- a/packages/components/src/__tests__/filter-builder-value-option-domain.test.tsx
+++ b/packages/components/src/__tests__/filter-builder-value-option-domain.test.tsx
@@ -462,6 +462,11 @@ describe('narrowFilterValueToOptions — the A/C split, stated on the helper', (
   });
 
   it('is inert on a malformed or absent field entry', () => {
+    // Inert because `hasStaticOptionDomain` gates on `Array.isArray` BEFORE any
+    // option is read — not because the reading is lenient. Measured: with that
+    // gate removed, this case does not merely answer wrongly, it throws inside
+    // `optionKeysOf` (`.map` on a string). The criterion is what keeps the
+    // narrowing total, so it is pinned here as well as on the A/C split.
     expect(narrowFilterValueToOptions('acme', undefined, 'equals')).toBe('acme');
     expect(
       narrowFilterValueToOptions('acme', { type: 'select', options: 'won' as any }, 'equals'),

--- a/packages/components/src/__tests__/filter-builder-value-option-domain.test.tsx
+++ b/packages/components/src/__tests__/filter-builder-value-option-domain.test.tsx
@@ -1,0 +1,470 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A row's value must stay inside the option DOMAIN of the column it filters —
+ * and where it cannot be, it must at least be VISIBLE (objectui#4874).
+ *
+ * objectui#4781 settled the TYPE half of the field switch and deliberately
+ * stopped there: `select`/`lookup` are text-family, so `"acme"` is a string a
+ * picklist column can perfectly well HOLD. What it cannot be is one of that
+ * column's options — and the control drawn for those columns is a Radix Select,
+ * whose trigger renders only what one of its MOUNTED `SelectItem`s carries. So a
+ * text row filtered `equals "acme"`, pointed at a picklist of `won`/`lost`,
+ * showed a BLANK trigger while the row kept carrying `"acme"`: persisted by
+ * `foldFilterGroupToSpecRules`, queried by the live grid as
+ * `stage equals "acme"`. Third face of the same invisible value —
+ * objectui#4768 on the operator, objectui#4781 on the value's type, this one on
+ * its domain.
+ *
+ * Ruled 2026-08-17 as **A + C combined**:
+ *
+ *   - **A** — a column whose `options` are STATIC and present owns its whole
+ *     value domain, so a field switch clears a non-member to objectui#4781's
+ *     empty shape (scalar `''`, list `[]`);
+ *   - **C** — a remote/async column (lookup with remote search, `options`
+ *     absent or not yet loaded) keeps its value and the control MAKES IT
+ *     VISIBLE, because a valid lookup id is not the local page's to delete;
+ *   - **⛔ B** — keep the value and tolerate it being invisible — stays
+ *     rejected, as objectui#4781's ruling already rejected it.
+ *
+ * DIRECTIONS, predicted before running:
+ *
+ *   - everything under "a static option domain clears what it cannot hold" is
+ *     RED on `origin/main` (`e71c854`), where the switch carries `"acme"` onto
+ *     the picklist verbatim and the trigger goes blank — measured, that is the
+ *     card's own repro;
+ *   - everything under "a remote/async domain keeps the value AND shows it" is
+ *     RED on main too, but for the opposite reason: main KEEPS the value
+ *     correctly (it clears nothing) and renders an EMPTY Select for a column
+ *     whose options have not loaded, so the value assertions are green and the
+ *     *visibility* assertions are red. The two halves of the ruling fail main in
+ *     two different places, which is why both are pinned;
+ *   - "a value the new column DOES offer survives" is GREEN in both directions
+ *     by design. It is the blast-radius guard: a fix that cleared on every
+ *     switch to an option-bearing column turns all of it red, and so does one
+ *     that compares membership more strictly than the controls compare it
+ *     (`0` vs `'0'`);
+ *   - the `narrowFilterValueToOptions` matrix does not COMPILE on main (the
+ *     helper does not exist there) — the same status `retypeFilterValue`'s
+ *     matrix had in PR #4876.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FilterBuilder, narrowFilterValueToOptions } from '../custom/filter-builder';
+
+/**
+ * The four columns this card distinguishes, plus the text/number columns a value
+ * arrives FROM:
+ *
+ *   - `stage` / `stage_alt` / `priority` — STATIC picklists. Two of them share
+ *     the option id `won`, which is what makes "keep the members, drop the rest"
+ *     expressible on one list;
+ *   - `level` — a static picklist whose option id is `'0'`, the falsy id
+ *     objectui#4873 was about. Membership must not confuse it with "unset";
+ *   - `account` — a lookup with `referenceTo` and NO `options`: the remote
+ *     search column, `renderValueInput`'s own `!field?.options` branch;
+ *   - `account_pending` — a lookup whose `options` are PRESENT BUT EMPTY, the
+ *     shape `deriveFilterFields` produces before the picklist values arrive.
+ *     `[]` is truthy, so this does NOT reach the remote picker: it renders an
+ *     empty Select, and a membership test against it would clear everything.
+ */
+const FIELDS = [
+  { value: 'title', label: 'Title', type: 'text' },
+  { value: 'amount', label: 'Amount', type: 'number' },
+  {
+    value: 'stage',
+    label: 'Stage',
+    type: 'select',
+    options: [
+      { value: 'won', label: 'Won' },
+      { value: 'lost', label: 'Lost' },
+    ],
+  },
+  {
+    value: 'stage_alt',
+    label: 'Stage (alt)',
+    type: 'select',
+    options: [
+      { value: 'won', label: 'Won (alt)' },
+      { value: 'pending', label: 'Pending' },
+    ],
+  },
+  {
+    value: 'priority',
+    label: 'Priority',
+    type: 'status',
+    options: [
+      { value: 'high', label: 'High' },
+      { value: 'low', label: 'Low' },
+    ],
+  },
+  {
+    value: 'level',
+    label: 'Level',
+    type: 'select',
+    options: [
+      { value: '0', label: 'Zero' },
+      { value: '1', label: 'One' },
+    ],
+  },
+  { value: 'account', label: 'Account', type: 'lookup', referenceTo: 'accounts' },
+  {
+    value: 'account_pending',
+    label: 'Account (pending)',
+    type: 'lookup',
+    referenceTo: 'accounts',
+    options: [],
+  },
+];
+
+function renderRow(condition: Record<string, unknown>) {
+  const onChange = vi.fn();
+  // Hoisted OUT of the JSX, as in PR #4762 / #4779 / #4876's suites: the sync
+  // effect re-seeds internal state whenever the `value` PROP's identity changes,
+  // which would undo the interaction under test on the next render.
+  const value = { id: 'root', logic: 'and', conditions: [{ id: 'c1', ...condition }] };
+  const utils = render(
+    <FilterBuilder fields={FIELDS as any} value={value as any} onChange={onChange} />,
+  );
+  return { ...utils, onChange };
+}
+
+/** The row the component handed back on its most recent `onChange`. */
+function lastRow(onChange: ReturnType<typeof vi.fn>) {
+  const calls = onChange.mock.calls;
+  expect(calls.length, 'the builder never called onChange').toBeGreaterThan(0);
+  return calls[calls.length - 1][0].conditions[0];
+}
+
+/** Drive the REAL field dropdown — index 0 of the row's comboboxes. */
+async function pickField(label: string) {
+  const triggers = screen.getAllByRole('combobox');
+  fireEvent.keyDown(triggers[0], { key: 'ArrowDown' });
+  const option = await waitFor(() => {
+    const found = screen.getAllByRole('option').find((o) => o.textContent === label);
+    expect(found, `no "${label}" option in the field dropdown`).toBeTruthy();
+    return found!;
+  });
+  fireEvent.click(option);
+}
+
+/** Drive the REAL operator dropdown — index 1 of the row's comboboxes. */
+async function pickOperator(label: string) {
+  const triggers = screen.getAllByRole('combobox');
+  fireEvent.keyDown(triggers[1], { key: 'ArrowDown' });
+  const option = await waitFor(() => {
+    const found = screen.getAllByRole('option').find((o) => o.textContent === label);
+    expect(found, `no "${label}" option in the operator dropdown`).toBeTruthy();
+    return found!;
+  });
+  fireEvent.click(option);
+}
+
+/**
+ * What the VALUE control displays — the symptom this card is about, read off the
+ * rendered DOM rather than inferred.
+ *
+ * The value Select is the row's third combobox (field, operator, value). Radix
+ * puts the matched item's children in the trigger, so this is literally the text
+ * a user sees: `''` is the blank trigger of the bug report, and the placeholder
+ * `'Select value'` is the honest "nothing picked" state.
+ */
+function valueTriggerText(): string {
+  const triggers = screen.getAllByRole('combobox');
+  expect(triggers.length, 'the row drew no value Select').toBeGreaterThan(2);
+  return triggers[2].textContent ?? '';
+}
+
+/** Every checkbox row of a list-operator value control, label + checked state. */
+function checkboxRows(): Array<{ label: string; checked: boolean }> {
+  return screen.getAllByRole('checkbox').map((box) => ({
+    label: box.parentElement?.textContent ?? '',
+    checked: box.getAttribute('data-state') === 'checked',
+  }));
+}
+
+describe('the reported repro: a text value pointed at a static picklist column', () => {
+  it('clears the value the picklist cannot hold, instead of hiding it in the row', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'acme' });
+    await pickField('Stage');
+
+    const row = lastRow(onChange);
+    expect(row.field).toBe('stage');
+    // The row used to keep `"acme"` here — persisted by the fold, queried by the
+    // grid as `stage equals "acme"`, and invisible in the panel. `''` is
+    // objectui#4781's scalar empty shape, unchanged.
+    expect(row.value).toBe('');
+  });
+
+  it('leaves the value Select on its placeholder — nothing shown, nothing stored', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'acme' });
+    await pickField('Stage');
+
+    // Before the fix these two disagreed: a blank trigger over a row carrying
+    // `"acme"`. Now the placeholder and the empty row say the same thing.
+    expect(valueTriggerText()).toBe('Select value');
+    expect(lastRow(onChange).value).toBe('');
+  });
+});
+
+describe('a static option domain clears what it cannot hold', () => {
+  it('drops a scalar the new picklist does not offer', async () => {
+    const { onChange } = renderRow({ field: 'stage', operator: 'equals', value: 'lost' });
+    await pickField('Priority');
+
+    expect(lastRow(onChange)).toMatchObject({ field: 'priority', value: '' });
+    expect(valueTriggerText()).toBe('Select value');
+  });
+
+  it('keeps the list entries the new picklist offers and drops the rest', async () => {
+    const { onChange } = renderRow({
+      field: 'stage',
+      operator: 'in',
+      value: ['won', 'acme', 'lost'],
+    });
+    await pickField('Stage (alt)');
+
+    const row = lastRow(onChange);
+    expect(row.operator).toBe('in');
+    // Entry by entry, not all-or-nothing: `won` is an option of the new column,
+    // so the user's good term survives; `acme` never was one and `lost` is the
+    // OLD column's option, and neither can be shown or edited here.
+    expect(row.value).toEqual(['won']);
+    expect(checkboxRows()).toEqual([
+      { label: 'Won (alt)', checked: true },
+      { label: 'Pending', checked: false },
+    ]);
+  });
+
+  it('falls to the list empty shape `[]` when no entry survives', async () => {
+    const { onChange } = renderRow({
+      field: 'stage',
+      operator: 'in',
+      value: ['won', 'lost'],
+    });
+    await pickField('Priority');
+
+    // `[]`, objectui#4781's list empty shape — the "nothing filled in yet" shape
+    // the write path drops, not a one-element array with an empty string in it.
+    expect(lastRow(onChange).value).toEqual([]);
+    expect(checkboxRows()).toEqual([
+      { label: 'High', checked: false },
+      { label: 'Low', checked: false },
+    ]);
+  });
+
+  it('does not mistake the falsy option id `0` for an unfilled row', async () => {
+    // The objectui#4873 interplay: `'0'` is a real option of `level`, and
+    // membership is decided the way the controls decide visibility (`String()`
+    // on both sides), so it must survive a switch between two columns that both
+    // offer it. A membership test written with `!value` or `Number()` would
+    // clear it and hand the user a placeholder where they had picked "Zero".
+    const { onChange } = renderRow({ field: 'level', operator: 'equals', value: 0 });
+    await pickField('Level');
+    // Radix fires nothing when the field already selected is re-picked, so the
+    // switch is asserted from the render instead: the row is untouched and the
+    // trigger reads the option's label.
+    expect(onChange).not.toHaveBeenCalled();
+    expect(valueTriggerText()).toBe('Zero');
+  });
+});
+
+describe('a remote/async option domain keeps the value AND shows it', () => {
+  it('carries a value onto a remote lookup column instead of guessing it is invalid', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'acc_007' });
+    await pickField('Account');
+
+    // `options` absent ⇒ the domain lives on the server. Clearing here would
+    // delete a perfectly valid lookup id on the strength of a local option set
+    // that never existed — the risk that made this card a separate ruling.
+    expect(lastRow(onChange)).toMatchObject({ field: 'account', value: 'acc_007' });
+  });
+
+  it('shows the id on the remote column rather than an empty control', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'acc_007' });
+    await pickField('Account');
+
+    // No DataSource in this render, so `LookupValuePicker` draws its by-hand id
+    // input; with one it draws the popover trigger, which falls back to the raw
+    // id the same way. Either way the value is on screen — never invisible.
+    const input = document.querySelector<HTMLInputElement>('input[placeholder="Enter Account id"]');
+    expect(input, 'the remote lookup drew no id input').toBeTruthy();
+    expect(input!.value).toBe('acc_007');
+    expect(lastRow(onChange).value).toBe('acc_007');
+  });
+
+  it('keeps a value on a column whose options have not loaded yet', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'acc_007' });
+    await pickField('Account (pending)');
+
+    // `options: []` is "not in place", not "the domain is empty". Membership
+    // against it would clear every value on earth.
+    expect(lastRow(onChange)).toMatchObject({ field: 'account_pending', value: 'acc_007' });
+  });
+
+  it('mounts the kept value as its own option so the trigger is not blank', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'acc_007' });
+    await pickField('Account (pending)');
+
+    // The C half. On `origin/main` this trigger rendered `''` — Radix matches
+    // `SelectValue` against mounted `SelectItem`s and there were none — which is
+    // shape B (row carries it, control blank) and is what the ruling refuses.
+    expect(valueTriggerText()).toBe('acc_007');
+    expect(valueTriggerText()).not.toBe('');
+    expect(lastRow(onChange).value).toBe('acc_007');
+  });
+
+  it('shows a value that arrived from a persisted view, without rewriting it', () => {
+    // No switch happened, so nothing is cleared: silently mutating an incoming
+    // `value` prop would rewrite a saved view behind the user's back. The
+    // invariant the control owes is only that what the row holds is VISIBLE, and
+    // it holds however the value got here.
+    const { onChange } = renderRow({
+      field: 'account_pending',
+      operator: 'equals',
+      value: 'acc_042',
+    });
+
+    expect(valueTriggerText()).toBe('acc_042');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('shows a non-member list entry as its own checked row', () => {
+    // The list face of the same mechanism: a selected entry matching no option
+    // is checked nowhere, so the row filtered by a term the panel never drew.
+    renderRow({ field: 'stage', operator: 'in', value: ['acme', 'won'] });
+
+    expect(checkboxRows()).toEqual([
+      { label: 'acme', checked: true },
+      { label: 'Won', checked: true },
+      { label: 'Lost', checked: false },
+    ]);
+  });
+
+  it('lets the user remove a non-member list entry it just made visible', () => {
+    const { onChange } = renderRow({ field: 'stage', operator: 'in', value: ['acme', 'won'] });
+
+    const outside = screen.getAllByRole('checkbox')[0];
+    fireEvent.click(outside);
+
+    // Visible AND actionable — the point of showing it rather than clearing it.
+    expect(lastRow(onChange).value).toEqual(['won']);
+  });
+});
+
+describe('a value the new column DOES offer survives the switch', () => {
+  it('keeps a shared option id across two picklists', async () => {
+    const { onChange } = renderRow({ field: 'stage', operator: 'equals', value: 'won' });
+    await pickField('Stage (alt)');
+
+    expect(lastRow(onChange)).toMatchObject({ field: 'stage_alt', value: 'won' });
+    // Same id, the new column's label — the value moved, the display followed.
+    expect(valueTriggerText()).toBe('Won (alt)');
+  });
+
+  it('keeps a text value that happens to be an option of the new column', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'won' });
+    await pickField('Stage');
+
+    expect(lastRow(onChange).value).toBe('won');
+    expect(valueTriggerText()).toBe('Won');
+  });
+
+  it('leaves a `between` range alone — two plain inputs, no option domain', async () => {
+    // `between` draws range inputs and never consults `options`, so nothing is
+    // out of domain there. Answered structurally in
+    // `isOptionDrivenValueControl` rather than resting on the coincidence that
+    // the select bucket does not offer `between` today.
+    expect(
+      narrowFilterValueToOptions(['acme', 'zeta'], FIELDS[2] as any, 'between'),
+    ).toEqual(['acme', 'zeta']);
+  });
+
+  it('leaves the value alone on a switch between two non-option columns', async () => {
+    const { onChange } = renderRow({ field: 'title', operator: 'equals', value: 'acme' });
+    await pickOperator('Contains');
+    await pickField('Title');
+
+    // Blast-radius guard: the narrowing must be inert everywhere it has no
+    // option domain to narrow to.
+    expect(lastRow(onChange).value).toBe('acme');
+  });
+});
+
+describe('narrowFilterValueToOptions — the A/C split, stated on the helper', () => {
+  const STATIC_SELECT = {
+    type: 'select',
+    options: [
+      { value: 'won', label: 'Won' },
+      { value: 'lost', label: 'Lost' },
+    ],
+  };
+
+  it('clears a scalar outside a static domain, keeps one inside it', () => {
+    expect(narrowFilterValueToOptions('acme', STATIC_SELECT, 'equals')).toBe('');
+    expect(narrowFilterValueToOptions('won', STATIC_SELECT, 'equals')).toBe('won');
+  });
+
+  it('compares membership as the controls do — `String()` on both sides', () => {
+    const numericIds = { type: 'select', options: [{ value: '0', label: 'Zero' }] };
+    expect(narrowFilterValueToOptions(0, numericIds, 'equals')).toBe(0);
+    expect(narrowFilterValueToOptions('0', numericIds, 'equals')).toBe('0');
+    expect(narrowFilterValueToOptions(1, numericIds, 'equals')).toBe('');
+  });
+
+  it('filters a list entry by entry', () => {
+    expect(narrowFilterValueToOptions(['won', 'acme'], STATIC_SELECT, 'in')).toEqual(['won']);
+    expect(narrowFilterValueToOptions(['acme'], STATIC_SELECT, 'in')).toEqual([]);
+    expect(narrowFilterValueToOptions([], STATIC_SELECT, 'in')).toEqual([]);
+  });
+
+  it('reads the operator through the spec fold, so a stored alias narrows too', () => {
+    // `not_in` is the spec spelling of the dropdown's `notIn`; both are list
+    // arity, and a row read back in canonical form must be narrowed as a list
+    // rather than folded to a scalar.
+    expect(narrowFilterValueToOptions(['won', 'acme'], STATIC_SELECT, 'not_in')).toEqual(['won']);
+  });
+
+  it('treats an unfilled row as unfilled, never as a non-member to clear', () => {
+    expect(narrowFilterValueToOptions('', STATIC_SELECT, 'equals')).toBe('');
+    expect(narrowFilterValueToOptions([], STATIC_SELECT, 'equals')).toBe('');
+  });
+
+  it('is inert where the local option set cannot vouch for the value', () => {
+    // The three remote/async shapes, each returned untouched.
+    expect(narrowFilterValueToOptions('acc_007', { type: 'lookup' }, 'equals')).toBe('acc_007');
+    expect(
+      narrowFilterValueToOptions('acc_007', { type: 'lookup', options: [] }, 'equals'),
+    ).toBe('acc_007');
+    expect(
+      narrowFilterValueToOptions('acc_007', { type: 'lookup', options: undefined }, 'equals'),
+    ).toBe('acc_007');
+    expect(narrowFilterValueToOptions(['a', 'b'], { type: 'lookup', options: [] }, 'in')).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('is inert on a column whose control shows anything anyway', () => {
+    // A `text` column carrying `options` keeps its plain input — the value is
+    // visible, so there is nothing to decide. Clearing it would be the fix
+    // over-reaching into a control that never had the defect.
+    const textWithOptions = { type: 'text', options: [{ value: 'won', label: 'Won' }] };
+    expect(narrowFilterValueToOptions('acme', textWithOptions, 'equals')).toBe('acme');
+  });
+
+  it('is inert on a malformed or absent field entry', () => {
+    expect(narrowFilterValueToOptions('acme', undefined, 'equals')).toBe('acme');
+    expect(
+      narrowFilterValueToOptions('acme', { type: 'select', options: 'won' as any }, 'equals'),
+    ).toBe('acme');
+  });
+});

--- a/packages/components/src/custom/filter-builder.tsx
+++ b/packages/components/src/custom/filter-builder.tsx
@@ -1221,9 +1221,13 @@ function FilterBuilder({
       // checked, so it is both visible and removable; they lead the list because
       // they are the ones the user cannot otherwise find.
       const allowed = optionKeysOf(field)
-      const outsideOptions = selectedValues
-        .map(String)
-        .filter((entry) => !allowed.includes(entry))
+      // De-duplicated: an externally supplied `["acme", "acme"]` would otherwise
+      // draw two rows under one React key, and unchecking either removes both
+      // (the handler filters by value, not by position) — so one row is also the
+      // honest count of what unchecking does.
+      const outsideOptions = [
+        ...new Set(selectedValues.map(String).filter((entry) => !allowed.includes(entry))),
+      ]
       return (
         <div className="max-h-40 overflow-y-auto space-y-0.5 border rounded-md p-2">
           {outsideOptions.map((entry) => (

--- a/packages/components/src/custom/filter-builder.tsx
+++ b/packages/components/src/custom/filter-builder.tsx
@@ -634,6 +634,153 @@ export function retypeFilterValue(
   }
 }
 
+/** The shape of a `fields` entry that the option-domain helpers below read. */
+type OptionBearingField = {
+  type?: string
+  options?: ReadonlyArray<{ value: string; label: string }>
+}
+
+/**
+ * How a value control compares a row's value against an option — `String()` on
+ * both sides, which is what the rendered controls themselves do (the checkbox
+ * list's `selectedValues.map(String).includes(String(opt.value))`, and Radix's
+ * match of `SelectValue` against each mounted `SelectItem value`).
+ *
+ * Membership has to be decided the same way the control decides VISIBILITY, or
+ * the two answers drift and we are back to a value the row keeps and the
+ * control cannot show — the defect itself (objectui#4874).
+ */
+function optionKeysOf(field: OptionBearingField | undefined): string[] {
+  return (field?.options ?? []).map((opt) => String(opt.value))
+}
+
+/**
+ * Does this column carry a static option set that is actually IN PLACE — the
+ * ONE mechanical criterion that splits the two halves of objectui#4874's ruling
+ * (2026-08-17, A + C combined).
+ *
+ * `true` (a **static** column): the option set is the column's whole value
+ * domain — nothing else can ever be picked in it and nothing else will arrive
+ * later — so a value outside it is locally decidable as unholdable, and a field
+ * switch clears it exactly as objectui#4781 clears a value the new column's
+ * TYPE cannot hold.
+ *
+ * `false` (a **remote/async** column): the domain lives on the server. Three
+ * ways to land here, all meaning "the local option set cannot vouch for this
+ * value":
+ *
+ *   - `options` **absent** — the shape a lookup with `referenceTo` arrives in,
+ *     which `renderValueInput` sends to {@link LookupValuePicker}'s remote
+ *     search (`!field?.options` is that branch's own condition);
+ *   - `options: []` — **present but not yet loaded**. `[]` is truthy, so this
+ *     does NOT reach the remote picker: it renders an EMPTY Select, and a
+ *     membership test against it would clear every value on earth. This is not
+ *     hypothetical — `deriveFilterFields` in `@object-ui/fields` maps
+ *     `Array.isArray(f.options)` through as-is, so an object whose picklist
+ *     values have not arrived yields exactly this;
+ *   - not an array at all — a malformed `fields` entry decides nothing.
+ *
+ * For those, the ruling is the other half: never clear on a local non-membership
+ * guess (a valid lookup id is not the local page's to delete), and never leave
+ * the value invisible — which the render path answers unconditionally by
+ * mounting the value as a temporary option.
+ */
+function hasStaticOptionDomain(field: OptionBearingField | undefined): boolean {
+  const options = field?.options
+  return Array.isArray(options) && options.length > 0
+}
+
+/**
+ * Is this row's value control DRIVEN by the column's option set — i.e. can it
+ * only ever display a value that is one of the options?
+ *
+ * Mirrors `renderValueInput`'s branch order, because "which control is drawn"
+ * and "which values that control can show" are one question:
+ *
+ *   - `list` — the checkbox list over `field.options`; an entry matching no
+ *     option is checked nowhere.
+ *   - `pair` — `between` draws two plain range inputs and never consults the
+ *     options, so any value is visible and none is out of domain. (`between`
+ *     is not in the select/lookup buckets today; answered structurally rather
+ *     than by that coincidence.)
+ *   - `scalar` — the Radix Select, drawn only for the select/lookup-like types.
+ *     A `text` column that happens to carry `options` keeps its plain input,
+ *     which shows anything, so it is NOT option-driven.
+ */
+function isOptionDrivenValueControl(
+  field: OptionBearingField | undefined,
+  operator: string,
+): boolean {
+  if (!field?.options) return false
+  const type = field.type || ""
+  switch (filterValueArity(operator)) {
+    case "list":
+      return true
+    case "pair":
+      return false
+    default:
+      return selectLikeTypes.includes(type) || lookupLikeTypes.includes(type)
+  }
+}
+
+/**
+ * Narrow a row's `value` to the option DOMAIN of the field it is being changed
+ * TO — the value-domain question, standing beside {@link retypeFilterValue}'s
+ * type question and {@link reshapeFilterValue}'s shape question
+ * (objectui#4874).
+ *
+ * objectui#4781 settled the TYPE half and deliberately stopped there: `select`
+ * and `lookup` are text-family, so `"acme"` is a value those columns can
+ * perfectly well HOLD. What it cannot be is one of the column's options — and
+ * the control drawn for those columns is a Radix Select, whose trigger renders
+ * only what one of its mounted `SelectItem`s carries. So a text row filtered
+ * `equals "acme"`, pointed at a picklist column of `won`/`lost`, showed a BLANK
+ * trigger while the row went on carrying `"acme"`:
+ * `foldFilterGroupToSpecRules` persisted it and the live grid queried
+ * `stage equals "acme"`. The third face of the same invisible value —
+ * objectui#4768 on the operator, objectui#4781 on the value's type, this one on
+ * its domain.
+ *
+ * Ruled 2026-08-17 as **A + C combined**, and the A half is this function:
+ * clear on non-membership, but ONLY where the option set is the column's whole
+ * domain ({@link hasStaticOptionDomain}). A remote/async column's value is
+ * returned untouched — clearing it would delete a perfectly valid lookup id on
+ * the strength of a local page that never claimed to be complete, and the C
+ * half (the render path's temporary option) is what keeps it visible instead.
+ * Option B — keep the value and tolerate it being invisible — stays rejected,
+ * as it was on objectui#4781.
+ *
+ * The empty shape a cleared value falls to is objectui#4781's, unchanged and
+ * read from the same `filterValueArity` fold:
+ *
+ *   - `scalar` — `""`.
+ *   - `list` — filtered ENTRY BY ENTRY, keeping the members: `["acme", "won"]`
+ *     → `["won"]`, and `[]` when none survive. Per-entry rather than
+ *     all-or-nothing because each entry is its own filter term, and one bad
+ *     term is no reason to throw away the user's good ones.
+ *   - `pair` — untouched; `between` is not option-driven.
+ *
+ * @internal exported for tests
+ */
+export function narrowFilterValueToOptions(
+  value: FilterBuilderCondition["value"],
+  field: OptionBearingField | undefined,
+  operator: string,
+): FilterBuilderCondition["value"] {
+  if (!hasStaticOptionDomain(field)) return value
+  if (!isOptionDrivenValueControl(field, operator)) return value
+
+  const allowed = new Set(optionKeysOf(field))
+
+  if (filterValueArity(operator) === "list") {
+    return normalizeToArray(value).filter((entry) => allowed.has(String(entry)))
+  }
+
+  const scalar = Array.isArray(value) ? (value[0] ?? "") : value
+  if (isValueUnset(scalar)) return ""
+  return allowed.has(String(scalar)) ? scalar : ""
+}
+
 /**
  * Is this row's value FINISHED for the operator it carries — the arity-aware
  * reading of "the user has filled this in" (objectstack#8815).
@@ -987,8 +1134,8 @@ function FilterBuilder({
    * throw away a choice that is still valid (switching `contains` from one text
    * column to another must not silently become `equals`).
    *
-   * The value is settled in the same edit, in two steps that answer two
-   * different questions and are both needed (objectui#4781):
+   * The value is settled in the same edit, in three steps that answer three
+   * different questions and are all needed (objectui#4781, objectui#4874):
    *
    *   1. `reshapeFilterValue` — the SHAPE the new OPERATOR takes, and only when
    *      the operator actually changed;
@@ -997,10 +1144,17 @@ function FilterBuilder({
    *      that type cannot hold is a value the user can no longer see or edit
    *      while the row keeps filtering by it. Convertible values are carried
    *      (`"42"` → `42`); the rest clear.
+   *   3. `narrowFilterValueToOptions` — the DOMAIN the new field offers, for the
+   *      columns whose whole domain is local. Step 2 stops at the type, and
+   *      `select`/`lookup` are text-family: `"acme"` is a string a picklist
+   *      column can HOLD but not one of its options, and its Select shows only
+   *      what an option carries. Remote/async columns are left alone here on
+   *      purpose — see `hasStaticOptionDomain`.
    */
   const changeField = (conditionId: string, nextField: string) => {
     const offered = getOperatorsForField(nextField)
-    const nextType = fields.find((f) => f.value === nextField)?.type
+    const nextFieldDef = fields.find((f) => f.value === nextField)
+    const nextType = nextFieldDef?.type
     handleChange({
       ...filterGroup,
       conditions: filterGroup.conditions.map((c) => {
@@ -1008,11 +1162,12 @@ function FilterBuilder({
         const nextOperator = reconcileOperatorForField(c.operator, offered)
         const reshaped =
           nextOperator === c.operator ? c.value : reshapeFilterValue(c.value, nextOperator)
+        const retyped = retypeFilterValue(reshaped, nextType, nextOperator)
         return {
           ...c,
           field: nextField,
           operator: nextOperator,
-          value: retypeFilterValue(reshaped, nextType, nextOperator),
+          value: narrowFilterValueToOptions(retyped, nextFieldDef, nextOperator),
         }
       }),
     })
@@ -1059,8 +1214,35 @@ function FilterBuilder({
     // For select/lookup fields with options and multi-select operator (in/notIn)
     if (field?.options && isMultiOperator) {
       const selectedValues = normalizeToArray(condition.value)
+      // The list face of the same invisible value (objectui#4874). A selected
+      // entry matching no option is checked NOWHERE — the checkbox list can only
+      // ever show the options it draws — so the row went on filtering by a term
+      // the panel never displayed. Each such entry gets its own row, already
+      // checked, so it is both visible and removable; they lead the list because
+      // they are the ones the user cannot otherwise find.
+      const allowed = optionKeysOf(field)
+      const outsideOptions = selectedValues
+        .map(String)
+        .filter((entry) => !allowed.includes(entry))
       return (
         <div className="max-h-40 overflow-y-auto space-y-0.5 border rounded-md p-2">
+          {outsideOptions.map((entry) => (
+            <label
+              key={`outside-${entry}`}
+              className="flex items-center gap-2 text-sm py-1 px-1.5 rounded cursor-pointer bg-primary/5 text-primary"
+              data-testid={`filter-value-outside-options-${condition.field}`}
+            >
+              <Checkbox
+                checked
+                onCheckedChange={() =>
+                  updateCondition(condition.id, {
+                    value: selectedValues.filter((v) => String(v) !== entry),
+                  })
+                }
+              />
+              <span className="truncate">{entry}</span>
+            </label>
+          ))}
           {field.options.map((opt) => {
             const isChecked = selectedValues.map(String).includes(String(opt.value))
             return (
@@ -1155,14 +1337,25 @@ function FilterBuilder({
 
     // For select/lookup fields with options (single select)
     if (field?.options && (selectLikeTypes.includes(field.type || "") || lookupLikeTypes.includes(field.type || ""))) {
+      // `displayScalarValue`, never `value || ""` (objectui#4873): an option
+      // whose id is `0` — a status code, a level — is a real selection, and
+      // `0 || ""` handed the trigger the same `""` an unfilled row gives it, so
+      // the row filtered by an option the placeholder said was not picked.
+      const shown = displayScalarValue(condition.value)
+      // The C half of objectui#4874's ruling. Radix matches `SelectValue`
+      // against the `SelectItem`s actually MOUNTED, so a value no option
+      // carries leaves the trigger blank while the row keeps filtering by it —
+      // the same mechanism objectui#4768 hit on the operator trigger. Mounting
+      // the value as its own option is what makes it visible, and it is done
+      // UNCONDITIONALLY rather than only for remote columns: the invariant this
+      // control owes is "the trigger shows whatever the row holds", and that
+      // holds no matter HOW the value got here (a switch, a persisted view, an
+      // option set that loaded late). Which values may be CLEARED is the other
+      // half and lives in one place, `narrowFilterValueToOptions`.
+      const isOutsideOptions = shown !== "" && !optionKeysOf(field).includes(shown)
       return (
         <Select
-          // `displayScalarValue`, never `value || ""` (objectui#4873): an
-          // option whose id is `0` — a status code, a level — is a real
-          // selection, and `0 || ""` handed the trigger the same `""` an
-          // unfilled row gives it, so the row filtered by an option the
-          // placeholder said was not picked.
-          value={displayScalarValue(condition.value)}
+          value={shown}
           onValueChange={(value) =>
             updateCondition(condition.id, { value })
           }
@@ -1171,6 +1364,14 @@ function FilterBuilder({
             <SelectValue placeholder={t('filterBuilder.selectValue')} />
           </SelectTrigger>
           <SelectContent>
+            {isOutsideOptions && (
+              // Labelled with the value itself — the same answer
+              // `LookupValuePicker`'s trigger gives an id it has no label for
+              // (`resolved[id] || id`), because that IS what is known about it.
+              <SelectItem value={shown} data-testid={`filter-value-outside-options-${condition.field}`}>
+                {shown}
+              </SelectItem>
+            )}
             {field.options.map((opt) => (
               <SelectItem key={opt.value} value={opt.value}>
                 {opt.label}


### PR DESCRIPTION
Fixes #4874

实施依据 = 2026-08-17 05:03Z 维护者裁定（**A + C 组合**，B 维持否决），不是卡面的开放三选。

## 前提验证（jsdom，`origin/main` e71c854）

卡面症状原样复现，而且是三张脸而非一张：

| 场景 | 行里的值 | 控件显示 |
|---|---|---|
| 文本 `acme` → 切到 picklist 列（`won`/`lost`） | `value: "acme"`（照样持久化、照样下发查询） | 值 trigger 文本 `""` |
| `options: []` 的 lookup 列带 `acc_007` | `acc_007` | 值 trigger 文本 `""`（空 Select） |
| picklist 列 `in ["acme","won"]` | 带着 `acme` | 只画出 `Won`/`Lost` 两个勾选框，`acme` 哪儿都没勾 |

第二、三张脸此前没被单独记过：前者是「`options` present-but-empty」——`[]` 是真值，所以它**进不到**远程 picker 分支，落进一个空 Select；后者是同一机制的多值面。

## A/C 分流的机械判据

`hasStaticOptionDomain(field)` = **`options` 是非空数组**。这是全 PR 唯一的分流点：

- **非空数组 ⇒ 静态列**：选项集就是该列的全部值域，值不在其中是本地可判定的「装不下」，切列时清到空形；
- **`options` 缺席 / `options: []`（未到位）/ 非数组 ⇒ 远程异步列**：本地选项集为该值背书不了，一律原样保留。`options` 缺席正是 `renderValueInput` 自己那条远程 picker 分支的条件（`!field?.options`）；`options: []` 不是「值域为空」而是「还没到」——`@object-ui/fields` 的 `deriveFilterFields` 把 `Array.isArray(f.options)` 原样映射过来，picklist 值没到位时产出的就是它，对它做成员判定会清掉世上任何值。

第二个判据 `isOptionDrivenValueControl(field, operator)` 照 `renderValueInput` 的分支顺序回答「该控件是否只能显示选项内的值」：`list` → 勾选框列表（是）；`pair` → `between` 画两个普通区间框、从不读 options（否，结构性回答，不靠「select 桶今天不给 between」这个巧合）；`scalar` → 只对 select/lookup 族画 Select（`text` 列即使带 options 也仍是普通输入框，什么都显示得出来，因此不判）。

## 改动

- **A 半边** `narrowFilterValueToOptions`：切 field 时对静态选项列做成员判定，不匹配清到 **#4781 那套空形**（标量 `''`、列表逐项过滤后 `[]`、`pair` 不动）。列表**逐项**而非连坐——每项都是独立筛选项，一颗坏项不该丢掉用户写对的那几项（`["won","acme","lost"]` → `["won"]`）。成员判定用 `String()` 两端比，与控件判定**可见性**的方式逐字一致（勾选框的 `selectedValues.map(String).includes(String(opt.value))`、Radix 拿 `SelectValue` 匹配已挂载的 `SelectItem value`）——两个答案一旦分叉，就又回到「行带值、控件显示不出来」。顺带钉住 #4873 的交界：选项 id `'0'` 不会被当成「未填」清掉。
- **C 半边**（渲染路径，**无条件**）：Select 把选项外的值挂成一个临时 `SelectItem`，标签用值本身——与 `LookupValuePicker` 对没有 label 的 id 的做法（`resolved[id] || id`）同一个答案；多值勾选框列表把它渲染成一行已勾选、可取消的条目。无条件是有意的：控件欠的不变量是「trigger 显示行里真正带着的东西」，而它带着什么与**怎么带来的**无关（切列、已存视图读回、选项集晚到）。也因此不必为了显示去改写传入的 `value`——静默改写一份已存视图比隐形更糟。
- ⛔ **B 维持否决**：仓内已不存在「行带值、控件空白」的形态。

`LookupValuePicker`（`options` 缺席的真远程列）本来就把 id 兜底显示出来，未改动，只是补了钉子。

## 验证

- 新增 `packages/components/src/__tests__/filter-builder-value-option-domain.test.tsx`（25 项）：静态列清空 + 空形断言、远程列保值 + 临时项可见（断言 trigger 文本 = 值且非空串）、值在选项集内不清（blast-radius 对照）、`narrowFilterValueToOptions` 判据矩阵。
- `pnpm exec vitest run packages/components/src/__tests__/` → **89 files / 834 tests passed**（含 #4768 / #4781 / #4873 / #3958 既有钉全量）。
- 消费半径（规则改在 components，钉子可能在别处）：`packages/fields/`（FilterConditionField）、`packages/plugin-list/`（ListView）、`packages/plugin-view/`、`packages/data-objectstack/` → **196 files / 2995 tests passed**；`packages/app-shell/src/views/`（viewFilterFold / ObjectDataPage / metadata-admin widgets）→ **261 files / 2464 passed, 1 skipped**。
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **81/81 successful**；`node scripts/check-control-bytes.mjs` OK；改动文件 eslint **0 errors**（新增导出带的 `react-refresh/only-export-components` warning 与本文件既有 8 个导出助手同类）。

## 反向验证（先书面预判，commit 后变异，`git checkout --` 还原）

| 变异 | 预判 | 实测 |
|---|---|---|
| ① 撤 `changeField` 里的成员判定调用 | 静态列用例红 | 红 5 项。其中一条读作 `expected 'acme' to be 'Select value'` —— C 独在时值**可见但被错留**，正是 B 的形态 |
| ② 撤 Select 临时项 | 远程列可见性用例红（trigger 空串） | 红 2 项，`expected '' to be 'acc_007'` / `'acc_042'`；picker 的 id-input 那条按预判仍绿（另一个控件） |
| ②b 撤勾选框临时行 | 多值可见性用例红 | 红 2 项（少一行 + 取消勾选后剩 `['acme']` 而非 `['won']`） |
| ③ 撤 `hasStaticOptionDomain` 守卫，把远程列也接成员清空 | 「合法 lookup id 被清」用例红 —— 裁定专门要防的那条 | 红 4 项，`expected 'Select value' to be 'acc_007'`。**比预判多一条且性质不同**：非数组 `options` 那条不是答错而是在 `optionKeysOf` 里**抛异常**（对字符串 `.map`）—— 判据函数同时是该路径的全性保证。已把这个实测方向写在用例旁边，免得下一个人以为靠的是读取端的宽容 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_