### PR TITLE
feat(core,components,fields): labelling 扩为三值闭枚举,display 四 + grid 可编辑态不再丢 host id (#4857)

### DIFF
--- a/.changeset/labelling-display-declaration-4857.md
+++ b/.changeset/labelling-display-declaration-4857.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/core': minor
+'@object-ui/components': minor
+'@object-ui/fields': minor
+---
+
+`ComponentMeta.labelling` grows a third value: `'control' | 'group' | 'display'`
+(objectui#4857, ruled jointly with objectui#4871 as the single repo-wide vocabulary for
+"how does a host learn what a widget will render"). `'display'` declares a widget whose
+whole surface is a pure display in EVERY state — no focusable control, nothing a
+`<label for>` could ever reach.
+
+The form renderer answers the declaration with the objectui#4788 host container (field
+id + `aria-labelledby` + `aria-describedby` + `role="group"`) in the editable state too;
+the `readonly === true` arm keeps its exact #4788 semantics for undeclared widgets. The
+display-only four (`formula` / `summary` / `auto_number` / `vector`) declare `'display'`
+— on the real object-form path they arrive `disabled`, never `readonly` (a deliberate
+distinction this change does not touch), so their visible labels pointed `for` at an id
+no element carried and their help text had zero consumers in every editable form.
+
+`grid` was re-measured before being classified: its only bare-config focusable is the
+auxiliary "Add line" button (routing `for` there would have label clicks insert rows),
+and every realistic config is a table of per-cell inputs — a composite. It declares
+`labelling: 'group'` and its root container now consumes the host id, name and
+description, exactly like `address` / `checkboxes`.
+
+Companion registry gate: `FIELD_WIDGET_LABELLING` (exported) is a `Record` keyed by the
+field-widget map's own literal key union, so registering a widget without deciding its
+labelling is a compile error rather than a silent fall-through to the dangling-`for`
+path, and the declaration test asserts the registered meta agrees with it key by key.

--- a/packages/components/src/renderers/form/__tests__/form-readonly-host-group.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-readonly-host-group.test.tsx
@@ -125,6 +125,12 @@ beforeAll(() => {
   ComponentRegistry.register('anchorprobe', AnchorProbe, { namespace: 'field' });
   ComponentRegistry.register('textprobe', TextProbe, { namespace: 'field' });
   ComponentRegistry.register('displayonlyprobe', DisplayOnlyProbe, { namespace: 'field' });
+  // The same face WITH the objectui#4857 declaration — the production shape of
+  // the display-only four (`formula` / `summary` / `auto_number` / `vector`).
+  ComponentRegistry.register('displaydeclaredprobe', DisplayOnlyProbe, {
+    namespace: 'field',
+    labelling: 'display',
+  });
   ComponentRegistry.register('groupprobe', GroupProbe, { namespace: 'field', labelling: 'group' });
   // NOT in the `field` namespace — the bare-name fallback, whose contract is
   // `schema`, not `FieldWidgetComponentProps`.
@@ -350,5 +356,71 @@ describe('nothing else changed shape (the paths this issue does not touch)', () 
     // scoped the wrapper to registered FIELD widgets.
     expect(group('f_barenameprobe')).toBeNull();
     expect(screen.getByTestId('bare-name')).toBeInTheDocument();
+  });
+});
+
+describe('a `labelling: "display"` declaration extends the wrapper to the EDITABLE state (objectui#4857)', () => {
+  it('EDITABLE display-declared widget: wrapped, named, described — the #4788 shape without `readonly`', () => {
+    renderForm([FIELD('displaydeclaredprobe')], { f_displaydeclaredprobe: 'computed' });
+
+    const g = group('f_displaydeclaredprobe');
+    expect(g).not.toBeNull();
+    expect(g).toHaveAttribute('role', 'group');
+    expect(byId(g!.getAttribute('id'))).toBe(g);
+
+    const label = hostLabel('f_displaydeclaredprobe');
+    expect(label).not.toHaveAttribute('for');
+    const labelled = idrefs(g!, 'aria-labelledby');
+    expect(byId(labelled[0])).toBe(label);
+    expect(byId(labelled[1])).toBe(g);
+    expect(byId(idrefs(g!, 'aria-describedby')[0])).toHaveTextContent('Some help');
+    expect(g).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('EDITABLE + `disabled`: the wrapper still applies — the real object-form path for computed fields', () => {
+    // ObjectForm maps `formula` / `summary` / `auto_number` to `disabled: true`,
+    // never `readonly: true` (a deliberate distinction the #4857 ruling kept —
+    // option 1, re-mapping it, was rejected). The gate reads the DECLARATION,
+    // so the disabled path is covered without touching that mapping.
+    renderForm([FIELD('displaydeclaredprobe', { disabled: true })], {
+      f_displaydeclaredprobe: 'computed',
+    });
+
+    const g = group('f_displaydeclaredprobe');
+    expect(g).not.toBeNull();
+    expect(g).toHaveAccessibleName('Label displaydeclaredprobe computed');
+  });
+
+  it('READONLY display-declared widget: both arms true, still exactly ONE wrapper', () => {
+    renderForm([FIELD('displaydeclaredprobe', { readonly: true })], {
+      f_displaydeclaredprobe: 'computed',
+    });
+
+    expect(
+      item('f_displaydeclaredprobe').querySelectorAll('[data-slot="readonly-field-group"]'),
+    ).toHaveLength(1);
+    expect(item('f_displaydeclaredprobe').querySelectorAll('[role="group"]')).toHaveLength(1);
+  });
+
+  it('an UNDECLARED display-only widget stays on the single-control path while editable', () => {
+    // The fallback the declaration exists to replace: without `labelling:
+    // "display"` the host cannot know the widget renders no control, so the
+    // editable state keeps the (dangling) `for`. Pinned so the registry-level
+    // "registered ⇒ declared" gate in `@object-ui/fields` is what carries the
+    // guarantee, not a host-side guess.
+    renderForm([FIELD('displayonlyprobe')], { f_displayonlyprobe: 'computed' });
+
+    expect(group('f_displayonlyprobe')).toBeNull();
+    expect(hostLabel('f_displayonlyprobe')).toHaveAttribute('for');
+  });
+
+  it('a display declaration does NOT wrap a label-less field (nothing would name it)', () => {
+    renderForm(
+      [{ name: 'f_nolabel_display', type: 'displaydeclaredprobe', description: 'Some help' }],
+      { f_nolabel_display: 'computed' },
+    );
+
+    expect(group('f_nolabel_display')).toBeNull();
+    expect(document.querySelector('[role="group"]')).toBeNull();
   });
 });

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -395,11 +395,10 @@ function normalizeFieldType(type: string): string {
  * unregistered type — resolves to `'control'`: the single-control path, byte for
  * byte what this renderer emitted before the declaration existed.
  */
-function resolveFieldLabelling(type: string): 'control' | 'group' {
+function resolveFieldLabelling(type: string): 'control' | 'group' | 'display' {
   if (BUILTIN_FIELD_TYPES.has(type)) return 'control';
-  return ComponentRegistry.getMeta(normalizeFieldType(type), 'field')?.labelling === 'group'
-    ? 'group'
-    : 'control';
+  const declared = ComponentRegistry.getMeta(normalizeFieldType(type), 'field')?.labelling;
+  return declared === 'group' || declared === 'display' ? declared : 'control';
 }
 
 /**
@@ -426,10 +425,16 @@ function resolvesToRegisteredFieldWidget(type: string): boolean {
 }
 
 /**
- * The container a READONLY registered field widget's output is wrapped in, so
- * the field's visible label NAMES and its visible help text DESCRIBES the
- * surface that replaced the control (objectui#4788, maintainer ruling of
- * 2026-08-16 — option E of the measured option set).
+ * The container a registered field widget's replacement-display output is
+ * wrapped in, so the field's visible label NAMES and its visible help text
+ * DESCRIBES the surface that replaced the control (objectui#4788, maintainer
+ * ruling of 2026-08-16 — option E of the measured option set). Reached two
+ * ways: a READONLY registered widget (#4788's original gate, unchanged), and —
+ * since objectui#4857 — a widget declared `labelling: 'display'`, whose whole
+ * surface is such a display in every state (`formula` / `summary` /
+ * `auto_number` / `vector`), so the wrapper applies in the editable state too.
+ * The `data-slot` keeps its original name: what this container wraps is a
+ * read-only display either way, whatever the form's own mode.
  *
  * ## What was broken
  *
@@ -1890,28 +1895,48 @@ ComponentRegistry.register('form',
       // the form schema has no owning object.
       const fieldTestId = `field:${schema.objectName ? `${schema.objectName}.` : ''}${name}`;
 
-      const groupLabelled = resolveFieldLabelling(resolvedType) === 'group';
+      const fieldLabelling = resolveFieldLabelling(resolvedType);
+      const groupLabelled = fieldLabelling === 'group';
 
-      // A READONLY registered field widget renders a replacement display in
-      // place of its control, and drops every prop the host handed down with it
-      // (objectui#4788). The host therefore wraps that output in a named group
-      // of its own — see {@link ReadonlyFieldGroup} for the measurement and the
-      // shape. Three gates, each carrying its own reason:
+      // A registered field widget whose output is a replacement display drops
+      // every prop the host handed down, so the host wraps that output in a
+      // named group of its own — see {@link ReadonlyFieldGroup} for the
+      // measurement and the shape. Two ways a field gets here, one wrapper:
+      //
+      //  - `readonly === true` (objectui#4788): the widget's readonly branch
+      //    renders the display in place of its control. Unchanged semantics —
+      //    this arm still keys off the field STATE, not the declaration, so an
+      //    undeclared third-party widget keeps exactly the #4788 behaviour;
+      //  - `labelling: 'display'` (objectui#4857): the widget declares that its
+      //    surface is a pure display in EVERY state — `formula` / `summary` /
+      //    `auto_number` / `vector` have no editable branch at all — so the
+      //    wrapper applies in the editable state too. Without this arm those
+      //    four lost the host id whenever the form was editable: on the real
+      //    object-form path they arrive as `disabled`, not `readonly`
+      //    (ObjectForm keeps that distinction deliberately — option 1 of the
+      //    #4857 option set was rejected), so the #4788 gate never fired and
+      //    the label's `for` dangled.
+      //
+      // Two further gates, each carrying its own reason:
       //
       //  - `label`: with no visible label there is no naming channel to repair,
       //    and a `role="group"` that nothing names is the inert pair this issue
       //    exists to avoid. Standalone / label-less rendering therefore stays
       //    byte-identical, exactly as `toHostGroupProps` keeps it;
-      //  - `!groupLabelled`: the seven group-labelled widgets already consume
-      //    the host's id / name / description themselves (objectui#3961 →
-      //    #3990 → #4005). Wrapping them too would nest a second group with the
-      //    same name and take the id off the surface those PRs put it on;
+      //  - `!groupLabelled`: the group-labelled widgets already consume the
+      //    host's id / name / description themselves (objectui#3961 → #3990 →
+      //    #4005). Wrapping them too would nest a second group with the same
+      //    name and take the id off the surface those PRs put it on;
       //  - a registered FIELD widget: the builtin branch renders a real control
       //    inside `<FormControl>` in the readonly state too, so its label keeps
       //    a `for` that resolves to a labelable element — measured, and left
-      //    alone.
-      const readonlyHostGroup =
-        readonly === true && !!label && !groupLabelled && resolvesToRegisteredFieldWidget(resolvedType);
+      //    alone. (A `'display'` declaration can only come from a registered
+      //    widget's meta, so for that arm this gate is belt-and-braces.)
+      const hostWrappedDisplay =
+        (readonly === true || fieldLabelling === 'display') &&
+        !!label &&
+        !groupLabelled &&
+        resolvesToRegisteredFieldWidget(resolvedType);
 
       // The visible label is associated by IDREF instead of `for` — it gets an
       // `id`, and the surface that answers to it gets `aria-labelledby`. Two
@@ -1928,14 +1953,15 @@ ComponentRegistry.register('form',
       // list: an id containing a space would silently resolve to two ids,
       // neither of which exists.
       const hostLabelId =
-        label && (groupLabelled || readonlyHostGroup)
+        label && (groupLabelled || hostWrappedDisplay)
           ? `${labelIdPrefix}${String(name).replace(/\s+/g, '_')}-group-label`
           : undefined;
 
       // The widget-facing half. Only the group-labelled path hands the IDREF
-      // DOWN to the widget: on the readonly path the wrapper is the named
-      // surface, and passing the same id to the widget as well would give one
-      // label two consumers — the double channel #3978 removed.
+      // DOWN to the widget: on the host-wrapped path (readonly, or a declared
+      // `'display'` widget) the wrapper is the named surface, and passing the
+      // same id to the widget as well would give one label two consumers — the
+      // double channel #3978 removed.
       const groupLabelId = groupLabelled ? hostLabelId : undefined;
 
       return (
@@ -1962,10 +1988,12 @@ ComponentRegistry.register('form',
                   // beside the `aria-labelledby` would give one label two
                   // association channels, one of which is broken.
                   //
-                  // A readonly registered widget (objectui#4788) reaches the
-                  // same shape through the host's own wrapper, and needs the
-                  // `for` gone for the same reason — it was measurably DANGLING
-                  // there, pointing at an id no element in the document carried.
+                  // A readonly registered widget (objectui#4788) — and a
+                  // widget declared `labelling: 'display'`, in every state
+                  // (objectui#4857) — reaches the same shape through the
+                  // host's own wrapper, and needs the `for` gone for the same
+                  // reason: it was measurably DANGLING there, pointing at an
+                  // id no element in the document carried.
                   {...(hostLabelId ? { id: hostLabelId, htmlFor: undefined } : null)}
                 >
                   {label}
@@ -1999,7 +2027,7 @@ ComponentRegistry.register('form',
                     A readonly registered widget's output goes inside the host's
                     own named group (objectui#4788) — every other field is handed
                     to `<FormControl>`'s Slot exactly as before. */}
-                {withReadonlyHostGroup(readonlyHostGroup ? hostLabelId : undefined, renderFieldComponent(resolvedType, {
+                {withReadonlyHostGroup(hostWrappedDisplay ? hostLabelId : undefined, renderFieldComponent(resolvedType, {
                   ...fieldProps,
                   // Specialized fields need the raw metadata object. `.field`
                   // is the declared metadata slot (#3090 — never the spec

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -64,7 +64,11 @@ export type ComponentMeta = {
   skipFallback?: boolean;
   /**
    * How a HOST must associate its own visible label with what this component
-   * renders (objectui#3961). Read by the form renderer; absent ⇒ `'control'`.
+   * renders (objectui#3961, extended by objectui#4857). Read by the form
+   * renderer; absent ⇒ `'control'`. This closed three-value vocabulary is the
+   * single repo-wide answer to "how does a host learn what a widget will
+   * render" (maintainer ruling of 2026-08-17, joint with objectui#4871) — no
+   * host may keep a local variant of it.
    *
    * - `'control'` — the component's outermost rendered element is a LABELABLE
    *   HTML element (`input` / `textarea` / `select` / `button` / …), so the host
@@ -77,7 +81,18 @@ export type ComponentMeta = {
    *   nothing and contributes no accessible name (`HTMLLabelElement.control` is
    *   `null`) — so the host must instead give its label an `id` and hand the
    *   component `aria-labelledby`, which associates by IDREF and works on any
-   *   element.
+   *   element. The COMPONENT consumes those keys on its own surface.
+   * - `'display'` — the rendered surface is a pure display in EVERY state:
+   *   there is no focusable control and the component itself spreads nothing
+   *   (computed / system-generated values such as `formula` / `summary` /
+   *   `auto_number` / `vector`). The host must not emit a `<label for>` at all
+   *   — no labelable element will ever exist for it to reach, in the editable
+   *   state as much as the readonly one — and instead wraps the component's
+   *   output in the host's own container carrying the field id,
+   *   `aria-labelledby`, `aria-describedby` and `role="group"` (the
+   *   objectui#4788 channel, driven by this declaration rather than by
+   *   `readonly` alone). Unlike `'group'`, the WIDGET is not expected to
+   *   consume anything: the host's wrapper is the named surface.
    *
    * This is a DECLARATION, not a guess: the host cannot infer it from the DOM a
    * widget happens to render, and a widget that fails to declare it falls back
@@ -85,7 +100,7 @@ export type ComponentMeta = {
    * label-association tests (objectui#3952) instead of silently producing an
    * unlabelled group.
    */
-  labelling?: 'control' | 'group';
+  labelling?: 'control' | 'group' | 'display';
   inputs?: ComponentInput[];
   defaultProps?: Record<string, any>; // Default props when dropped
   defaultChildren?: SchemaNode[]; // Default children when dropped

--- a/packages/fields/src/__tests__/composite-group-label-e2e.test.tsx
+++ b/packages/fields/src/__tests__/composite-group-label-e2e.test.tsx
@@ -124,7 +124,7 @@ beforeAll(() => {
     ComponentRegistry.register(type, Component as any, {
       namespace: 'field',
       skipFallback: true,
-      // The declaration under test, mirroring `FIELD_TYPES_GROUP_LABELLED`.
+      // The declaration under test, mirroring `FIELD_WIDGET_LABELLING`.
       labelling: 'group',
     });
   }
@@ -302,7 +302,7 @@ describe('the group name does not swallow the sub-controls\' own names (objectui
 describe('an undeclared single-control field keeps the plain `for` association (objectui#3961)', () => {
   it('text: the label still points at the input, with no second naming channel', () => {
     // The positive control for the DECLARATION. `text` is not in
-    // `FIELD_TYPES_GROUP_LABELLED`, so it must travel the unchanged path: a
+    // `FIELD_WIDGET_LABELLING`, so it must travel the unchanged path: a
     // working `for`, and NO `aria-labelledby` — two channels naming one control
     // is what #3290 / #3222 / #3952 each refused.
     renderForm([{ name: 'f_text', label: 'Plain Text', type: 'text' }]);

--- a/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
+++ b/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
@@ -185,7 +185,7 @@ beforeAll(() => {
     ComponentRegistry.register(type, Component as any, {
       namespace: 'field',
       skipFallback: true,
-      // The declaration under test, mirroring `FIELD_TYPES_GROUP_LABELLED`.
+      // The declaration under test, mirroring `FIELD_WIDGET_LABELLING`.
       labelling: 'group',
     });
   }
@@ -674,7 +674,7 @@ describe('STANDALONE readonly widgets are unchanged (objectui#3990)', () => {
 
   it('the shared options-empty box emits nothing for a widget that is not group-labelled', () => {
     // The positive control for `OptionsEmptyState`'s new prop. The single
-    // `SelectField` is NOT in `FIELD_TYPES_GROUP_LABELLED` — its label keeps a
+    // `SelectField` is NOT in `FIELD_WIDGET_LABELLING` — its label keeps a
     // plain, working `for` — so the shared box must stay attribute-for-attribute
     // what it was: no `role`, no IDREF, no host id.
     render(

--- a/packages/fields/src/__tests__/display-grid-host-channels-e2e.test.tsx
+++ b/packages/fields/src/__tests__/display-grid-host-channels-e2e.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * GATE: the five widgets objectui#4857 left holding a dangling host id in the
+ * EDITABLE state are named and described there too — the display-only four
+ * through the host's declaration-driven wrapper, `grid` through its own
+ * container.
+ *
+ * ## What was broken
+ *
+ * objectui#4788 wrapped a READONLY registered widget's replacement display in a
+ * host-owned named group, keyed on `readonly === true`. Five widgets never
+ * reached that gate while editable. Measured on `origin/main` at `e71c854ce`
+ * (this file's probe, a real form + this file's registration, `description`
+ * set, editable column):
+ *
+ * ```
+ * formula      editable  for=DANGLING hostIdEl=NONE consumers=0
+ * summary      editable  for=DANGLING hostIdEl=NONE consumers=0
+ * auto_number  editable  for=DANGLING hostIdEl=NONE consumers=0
+ * vector       editable  for=DANGLING hostIdEl=NONE consumers=0
+ * grid         editable  for=DANGLING hostIdEl=NONE consumers=0
+ * ```
+ *
+ * The display four have NO editable branch — the whole widget is a replacement
+ * display — and on the real object-form path they arrive `disabled`, never
+ * `readonly` (ObjectForm keeps `disabled`/`readonly` distinct deliberately; the
+ * #4857 ruling rejected re-mapping them), so the #4788 gate could never fire.
+ * They now declare `labelling: 'display'` and the host wraps them in EVERY
+ * state.
+ *
+ * `grid` was re-measured before being classified (the 06:36Z correction on the
+ * card warned against extrapolating from `slider`/`signature`): its bare config
+ * offers exactly ONE focusable, the auxiliary "Add line" button — labelable,
+ * but handing it the host id would make the field label NAME the add-row action
+ * and a label click INSERT A ROW — and its realistic config offers 8 focusables
+ * across cell inputs and row actions. A composite, so it declares
+ * `labelling: 'group'` and its own container consumes the host's keys, exactly
+ * like `address` / `checkboxes`.
+ *
+ * The widgets are registered raw with their PRODUCTION declarations rather than
+ * through `registerAllFields()`, whose `React.lazy` loaders put an unbounded
+ * module load inside a bounded `findBy` window — this repo's known flake
+ * generator (AGENTS.md 测试纪律, objectui#3010).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { withFieldCarrier } from '../withFieldCarrier';
+import { FormulaField } from '../widgets/FormulaField';
+import { SummaryField } from '../widgets/SummaryField';
+import { AutoNumberField } from '../widgets/AutoNumberField';
+import { VectorField } from '../widgets/VectorField';
+import { GridField } from '../widgets/GridField';
+import { TextField } from '../widgets/TextField';
+
+const DISPLAY_TYPES = ['formula', 'summary', 'auto_number', 'vector'] as const;
+
+const VALUES: Record<string, unknown> = {
+  formula: 'computed',
+  summary: 7,
+  auto_number: 'A-0001',
+  vector: [0.1, 0.2, 0.3, 0.4],
+};
+
+const GRID_FIELD_META = {
+  columns: [
+    { name: 'item', label: 'Item', type: 'text' },
+    { name: 'qty', label: 'Qty', type: 'number' },
+  ],
+};
+
+beforeAll(() => {
+  // The PRODUCTION declarations, exactly as `registerField` writes them from
+  // `FIELD_WIDGET_LABELLING` — the declaration is half of what is under test.
+  ComponentRegistry.register('formula', withFieldCarrier(FormulaField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'display',
+  });
+  ComponentRegistry.register('summary', withFieldCarrier(SummaryField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'display',
+  });
+  ComponentRegistry.register('auto_number', withFieldCarrier(AutoNumberField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'display',
+  });
+  ComponentRegistry.register('vector', withFieldCarrier(VectorField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'display',
+  });
+  ComponentRegistry.register('grid', withFieldCarrier(GridField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'group',
+  });
+  // Positive control: an ordinary single-control widget, undeclared, whose
+  // label must KEEP reaching a labelable element the plain way — the 27-row
+  // green control group of the measurement.
+  ComponentRegistry.register('text', withFieldCarrier(TextField) as any, {
+    namespace: 'field',
+    skipFallback: true,
+  });
+}, 60000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const fieldName = (type: string) => `f_${type}`;
+const fieldLabel = (type: string) => `Label ${type}`;
+
+function fieldConfig(
+  type: string,
+  opts: { readonly?: boolean; disabled?: boolean; field?: unknown } = {},
+): Record<string, unknown> {
+  const config: any = {
+    name: fieldName(type),
+    label: fieldLabel(type),
+    type,
+    description: 'Some help',
+  };
+  if (opts.field) config.field = opts.field;
+  if (opts.readonly) config.readonly = true;
+  if (opts.disabled) config.disabled = true;
+  return config;
+}
+
+/** The real form renderer hosting one field — the reproduction. */
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        defaultValues,
+        fields,
+      }}
+    />,
+  );
+}
+
+const item = (name: string): HTMLElement => {
+  const el = document.querySelector<HTMLElement>(`[data-field="${name}"]`);
+  if (!el) throw new Error(`no form item rendered for field "${name}"`);
+  return el;
+};
+
+const hostLabel = (name: string): HTMLLabelElement => {
+  const el = item(name).querySelector('label');
+  if (!el) throw new Error(`no host label rendered for field "${name}"`);
+  return el as HTMLLabelElement;
+};
+
+const byId = (id: string | null | undefined): HTMLElement | null =>
+  id ? document.getElementById(id) : null;
+
+const idrefs = (el: Element, attr: string): string[] =>
+  (el.getAttribute(attr) ?? '').split(/\s+/).filter(Boolean);
+
+/** Every element whose `aria-describedby` NAMES `id` — the `consumers=` column. */
+function describedbyConsumers(id: string): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('[aria-describedby]')).filter((el) =>
+    (el.getAttribute('aria-describedby') ?? '').split(/\s+/).includes(id),
+  );
+}
+
+/** The host id, derived exactly as the #4788 probe derived it. */
+function hostIdOf(name: string): string {
+  const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]');
+  expect(descEl).not.toBeNull();
+  return descEl!.id.replace(/-description$/, '');
+}
+
+describe('a display-declared widget is named and described while the form is EDITABLE (objectui#4857)', () => {
+  it.each(DISPLAY_TYPES)('%s: the host id is on a named group, and the label `for` is gone', (type) => {
+    const name = fieldName(type);
+    renderForm([fieldConfig(type)], { [name]: VALUES[type] });
+
+    // `hostIdEl=NONE` → the host's wrapper group, in the EDITABLE state.
+    const hostId = hostIdOf(name);
+    const host = byId(hostId);
+    expect(host).not.toBeNull();
+    expect(host).toHaveAttribute('role', 'group');
+    expect(host).toHaveAttribute('data-slot', 'readonly-field-group');
+    expect(item(name).contains(host!)).toBe(true);
+
+    // `for=DANGLING` → no `for` at all, and a published id instead
+    // (single naming channel, objectui#3978).
+    const label = hostLabel(name);
+    expect(label).not.toHaveAttribute('for');
+    expect(label.id).not.toBe('');
+
+    // The name IDREFs resolve: label first, then the group itself so the VALUE
+    // stays in the accessible name (`group` is not a name-from-content role).
+    const labelled = idrefs(host!, 'aria-labelledby');
+    expect(labelled).toEqual([label.id, hostId]);
+    expect(byId(labelled[0])).toBe(label);
+
+    // `consumers=0` → 1, on the same element that carries the name.
+    const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]')!;
+    expect(describedbyConsumers(descEl.id)).toEqual([host]);
+
+    // The widget's own display output sits INSIDE the named group.
+    expect(host!.firstElementChild).not.toBeNull();
+    expect(host).toHaveAccessibleName(new RegExp(`^${fieldLabel(type)} .+`));
+    expect(item(name).querySelectorAll('[role="group"]')).toHaveLength(1);
+
+    // No control-channel state rides along (objectui#4005 boundary): a pure
+    // display cannot be edited, so it cannot be invalid or required.
+    expect(host).not.toHaveAttribute('aria-invalid');
+    expect(host).not.toHaveAttribute('aria-required');
+  });
+
+  it('formula: the wrapper applies on the DISABLED path — the real object-form shape', () => {
+    // `ObjectForm` maps computed fields to `disabled: true`, NOT
+    // `readonly: true` (deliberately — option 1 of the #4857 option set was
+    // rejected). The gate keys off the DECLARATION, so `disabled` neither
+    // enables nor defeats it.
+    const name = fieldName('formula');
+    renderForm([fieldConfig('formula', { disabled: true })], { [name]: 'computed' });
+
+    const host = byId(hostIdOf(name));
+    expect(host).toHaveAttribute('role', 'group');
+    expect(host).toHaveAccessibleName('Label formula computed');
+    expect(host).toHaveAccessibleDescription('Some help');
+    expect(hostLabel(name)).not.toHaveAttribute('for');
+  });
+
+  it.each(DISPLAY_TYPES)('%s: the readonly state keeps the same shape (both arms of the gate)', (type) => {
+    const name = fieldName(type);
+    renderForm([fieldConfig(type, { readonly: true })], { [name]: VALUES[type] });
+
+    const host = byId(hostIdOf(name));
+    expect(host).toHaveAttribute('role', 'group');
+    expect(hostLabel(name)).not.toHaveAttribute('for');
+    const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]')!;
+    expect(describedbyConsumers(descEl.id)).toEqual([host]);
+  });
+});
+
+describe('grid consumes the host channels on its own container (objectui#4857)', () => {
+  it('editable: the container is the named, described group; cells keep their own names', () => {
+    const name = fieldName('grid');
+    renderForm(
+      [fieldConfig('grid', { field: GRID_FIELD_META })],
+      { [name]: [{ item: 'Widget', qty: 2 }] },
+    );
+
+    // The host id lands on the widget's OWN root container — no host wrapper
+    // (the `'group'` path hands the widget the IDREF instead, objectui#3961).
+    const hostId = hostIdOf(name);
+    const host = byId(hostId);
+    expect(host).not.toBeNull();
+    expect(host).toHaveAttribute('data-testid', 'line-items');
+    expect(host).toHaveAttribute('role', 'group');
+    expect(host).not.toHaveAttribute('data-slot', 'readonly-field-group');
+
+    // `for=DANGLING` → no `for`, a published label id, and the container names
+    // itself by that single IDREF.
+    const label = hostLabel(name);
+    expect(label).not.toHaveAttribute('for');
+    expect(label.id).not.toBe('');
+    expect(idrefs(host!, 'aria-labelledby')).toEqual([label.id]);
+    expect(host).toHaveAccessibleName(fieldLabel('grid'));
+
+    // `consumers=0` → 1, the container (no cell input takes the FIELD's
+    // description; each cell keeps its own `aria-label`).
+    const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]')!;
+    expect(describedbyConsumers(descEl.id)).toEqual([host]);
+
+    // The composite's sub-controls keep their own names — the group name must
+    // not swallow them (objectui#3961's second half).
+    expect(screen.getAllByRole('textbox', { name: 'Item' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('spinbutton', { name: 'Qty' }).length).toBeGreaterThan(0);
+
+    // Withheld keys: `name` is DOM-legal on form controls only (objectui#3291),
+    // and `aria-invalid` is control-channel state this grid reports per CELL.
+    expect(host).not.toHaveAttribute('name');
+    expect(host).not.toHaveAttribute('aria-invalid');
+    expect(host).not.toHaveAttribute('aria-required');
+  });
+
+  it('readonly: the replacement table takes the name AND the description itself', () => {
+    const name = fieldName('grid');
+    renderForm(
+      [fieldConfig('grid', { readonly: true, field: GRID_FIELD_META })],
+      { [name]: [{ item: 'Widget', qty: 2 }] },
+    );
+
+    const host = byId(hostIdOf(name));
+    expect(host).not.toBeNull();
+    // The widget's own container, not the host's readonly wrapper — a
+    // group-labelled widget is excluded from the #4788 wrap so the id stays on
+    // the surface the widget owns.
+    expect(host).toHaveAttribute('role', 'group');
+    expect(host).not.toHaveAttribute('data-slot', 'readonly-field-group');
+    expect(item(name).querySelectorAll('[role="group"]')).toHaveLength(1);
+
+    const label = hostLabel(name);
+    expect(label).not.toHaveAttribute('for');
+    expect(idrefs(host!, 'aria-labelledby')).toEqual([label.id]);
+
+    const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]')!;
+    expect(describedbyConsumers(descEl.id)).toEqual([host]);
+  });
+
+  it('standalone (no host label): no role claim, markup keeps its shape', () => {
+    // A grid rendered without a visible label is handed no `aria-labelledby`,
+    // so the container must NOT answer `role="group"` — a group nothing names
+    // is the inert pair the declaration family exists to avoid.
+    const name = fieldName('grid');
+    renderForm(
+      [{ name, type: 'grid', field: GRID_FIELD_META }],
+      { [name]: [{ item: 'Widget', qty: 2 }] },
+    );
+
+    const container = document.querySelector('[data-testid="line-items"]')!;
+    expect(container).not.toBeNull();
+    expect(container).not.toHaveAttribute('role');
+    expect(container).not.toHaveAttribute('aria-labelledby');
+  });
+});
+
+describe('the control group is untouched — a single-control label still addresses its control', () => {
+  it('text: no group, `for` resolves to a labelable element, description consumed by it', () => {
+    const name = fieldName('text');
+    renderForm([fieldConfig('text')], { [name]: 'Hello' });
+
+    expect(screen.queryByRole('group')).toBeNull();
+    const label = hostLabel(name);
+    expect(label).not.toHaveAttribute('id');
+    const target = byId(label.getAttribute('for'));
+    expect(target).not.toBeNull();
+    expect(['input', 'textarea', 'select', 'button']).toContain(target!.tagName.toLowerCase());
+    const descEl = item(name).querySelector<HTMLElement>('[id$="-form-item-description"]')!;
+    expect(describedbyConsumers(descEl.id)).toEqual([target]);
+  });
+});

--- a/packages/fields/src/__tests__/group-labelling-declaration.test.ts
+++ b/packages/fields/src/__tests__/group-labelling-declaration.test.ts
@@ -31,11 +31,16 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
-import { registerAllFields, mapFieldTypeToFormType } from '../index';
+import {
+  registerAllFields,
+  mapFieldTypeToFormType,
+  FIELD_WIDGET_LABELLING,
+  FORM_FIELD_TYPES,
+} from '../index';
 
 /**
  * Every field type whose host label must be associated by IDREF. Two shapes, one
- * declaration — see `FIELD_TYPES_GROUP_LABELLED` in `../index`:
+ * declaration — see `FIELD_WIDGET_LABELLING` in `../index`:
  * real composites, plus `file`, whose single control is a `div[role="button"]`.
  *
  * `multiselect` (objectui#3975) is the seventh, added after #3961 shipped: its
@@ -47,6 +52,13 @@ import { registerAllFields, mapFieldTypeToFormType } from '../index';
  * are `file`'s shape rather than a composite: ONE surface, which happens not to
  * be labelable. A slider's control is Radix's `span[role="slider"]` thumb; a
  * signature's is a `<canvas>`. `<label for>` reaches neither.
+ *
+ * `grid` (objectui#4857) is the tenth, and it is the COMPOSITE shape, measured
+ * before being classified: its bare config offers exactly one focusable — the
+ * auxiliary "Add line" button, which a `for` could reach but must not (the
+ * label would name the add-row action, and clicking the label would insert a
+ * row) — and every realistic config is a table of per-cell inputs and row
+ * actions under one container, `address`'s shape at larger scale.
  */
 const GROUP_LABELLED = [
   'address',
@@ -58,7 +70,18 @@ const GROUP_LABELLED = [
   'multiselect',
   'slider',
   'signature',
+  'grid',
 ] as const;
+
+/**
+ * Widgets whose whole surface is a pure display in EVERY state — no editable
+ * branch, no focusable control, nothing a `<label for>` could ever reach
+ * (objectui#4857). Declared `'display'` so the form renderer wraps their output
+ * in its own named container (the objectui#4788 channel) in the editable state
+ * too — on the real object-form path these arrive `disabled`, never `readonly`,
+ * so the readonly-keyed gate alone could not cover them.
+ */
+const DISPLAY_LABELLED = ['formula', 'summary', 'auto_number', 'vector'] as const;
 
 /**
  * Single-control widgets: the host's `<label for>` reaches a real labelable
@@ -96,9 +119,17 @@ describe('field widgets declare how their label must be associated (objectui#396
     expect(ComponentRegistry.getMeta(type, 'field')?.labelling).toBe('group');
   });
 
+  it.each(DISPLAY_LABELLED)('%s declares labelling: "display" (objectui#4857)', (type) => {
+    expect(ComponentRegistry.getMeta(type, 'field')?.labelling).toBe('display');
+  });
+
   it.each(CONTROL_LABELLED)('%s leaves labelling undeclared (⇒ "control")', (type) => {
     // Absent, not `'control'`: one spelling of the default, and the form
-    // renderer reads any non-`'group'` value as the single-control path.
+    // renderer reads any non-`'group'`/-`'display'` value as the single-control
+    // path. The DECISION is still mandatory — `FIELD_WIDGET_LABELLING` spells
+    // `'control'` for every one of these, and its exhaustive `Record` key makes
+    // omission a compile error; absence here is that record's runtime spelling
+    // of the default, not a widget that skipped the question.
     expect(ComponentRegistry.getMeta(type, 'field')?.labelling).toBeUndefined();
   });
 
@@ -116,6 +147,54 @@ describe('field widgets declare how their label must be associated (objectui#396
       .sort();
 
     expect(declared).toEqual([...GROUP_LABELLED].sort());
+  });
+
+  it('declares display labelling for exactly the audited set — no more (objectui#4857)', () => {
+    // Same both-directions discipline as the group set: a widget declared
+    // `'display'` without actually BEING a pure display would have the host
+    // wrap a live control inside a group and drop its `for` — so growth of this
+    // set must be a deliberate, audited act.
+    const declared = ComponentRegistry.getKnownTypes()
+      .filter((key) => key.startsWith('field:'))
+      .filter((key) => ComponentRegistry.getMeta(key.slice('field:'.length), 'field')?.labelling === 'display')
+      .map((key) => key.slice('field:'.length))
+      .sort();
+
+    expect(declared).toEqual([...DISPLAY_LABELLED].sort());
+  });
+});
+
+describe('registered ⇒ declared (objectui#4857 registry gate)', () => {
+  it('every registered field widget carries a labelling decision', () => {
+    // The load-bearing half of this gate is COMPILE-time: `FIELD_WIDGET_LABELLING`
+    // is a `Record` keyed by the widget map's own literal key union, so an entry
+    // missing for a registered widget (or left over for an unregistered one) is
+    // a type-check failure, not a runtime discovery. This runtime restatement
+    // exists so the parity is also visible to a mutation that bypasses tsc, and
+    // so the failure NAMES the widget.
+    expect(Object.keys(FIELD_WIDGET_LABELLING).sort()).toEqual([...FORM_FIELD_TYPES].sort());
+
+    for (const [type, labelling] of Object.entries(FIELD_WIDGET_LABELLING)) {
+      expect(
+        ['control', 'group', 'display'],
+        `widget "${type}" must declare a labelling value from the closed vocabulary`,
+      ).toContain(labelling);
+    }
+  });
+
+  it('the runtime meta agrees with the declaration record, key by key', () => {
+    // `'control'` is spelled as ABSENCE in the registry meta (one spelling of
+    // the default, objectui#3961); `'group'` / `'display'` must be present and
+    // exact. This is the join that catches a `registerField` regression which
+    // reads the record but writes the wrong meta.
+    for (const [type, labelling] of Object.entries(FIELD_WIDGET_LABELLING)) {
+      const meta = ComponentRegistry.getMeta(type, 'field')?.labelling;
+      if (labelling === 'control') {
+        expect(meta, `widget "${type}" (control) must leave the meta key absent`).toBeUndefined();
+      } else {
+        expect(meta, `widget "${type}" must register labelling: "${labelling}"`).toBe(labelling);
+      }
+    }
   });
 });
 

--- a/packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx
+++ b/packages/fields/src/__tests__/readonly-host-plumbing-e2e.test.tsx
@@ -410,9 +410,15 @@ describe('the editable branch is untouched — its label still addresses a real 
     if (type === 'formula') {
       // The D group has no editable branch to keep: it renders the same
       // display-only span, which is why its editable row measured
-      // `for=DANGLING hostIdEl=NONE consumers=0` too. That residual is NOT this
-      // issue's readonly defect and is deliberately left as measured — pinned
-      // here so a later change to it is a deliberate one.
+      // `for=DANGLING hostIdEl=NONE consumers=0` too. objectui#4857 closed that
+      // residual — deliberately, as this pin demanded — through a
+      // `labelling: 'display'` DECLARATION, whose covered behaviour is pinned
+      // in `display-grid-host-channels-e2e.test.tsx`. THIS file registers every
+      // widget bare, declaration-less, so what this branch now pins is the
+      // UNDECLARED fallback: a widget that skips the declaration falls to the
+      // single-control path and its editable `for` dangles again — the silent
+      // degradation the exhaustive `FIELD_WIDGET_LABELLING` record exists to
+      // make impossible for this package's own registrations.
       expect(screen.queryByRole('group')).toBeNull();
       expect(hostLabel(name)).toHaveAttribute('for');
       expect(byId(hostLabel(name).getAttribute('for'))).toBeNull();

--- a/packages/fields/src/__tests__/slider-signature-host-channels-e2e.test.tsx
+++ b/packages/fields/src/__tests__/slider-signature-host-channels-e2e.test.tsx
@@ -69,7 +69,7 @@ const HELP = 'How firmly do you agree';
 
 beforeAll(() => {
   // Registered exactly as `registerField` does for a member of
-  // FIELD_TYPES_GROUP_LABELLED — the declaration is half of what is under test.
+  // FIELD_WIDGET_LABELLING — the declaration is half of what is under test.
   // Registered one by one rather than over a tuple: the two widgets implement
   // `FieldWidgetComponentProps` at different value types, and a shared loop
   // variable would only unify them through `any`.

--- a/packages/fields/src/__tests__/widget-aria-invalid-registry-e2e.test.tsx
+++ b/packages/fields/src/__tests__/widget-aria-invalid-registry-e2e.test.tsx
@@ -253,7 +253,7 @@ const NOT_APPLICABLE: ReadonlyMap<string, string> = new Map([
   ],
   [
     'signature',
-    'Drawing surface is a <canvas> with no keyboard path; the one other element, Clear, is disabled while empty. Its LABEL is a separate half and IS delivered — see FIELD_TYPES_GROUP_LABELLED.',
+    'Drawing surface is a <canvas> with no keyboard path; the one other element, Clear, is disabled while empty. Its LABEL is a separate half and IS delivered — see FIELD_WIDGET_LABELLING.',
   ],
   [
     'filter-condition',

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import type { FieldMetadata, SelectOptionMetadata } from '@object-ui/types';
-import { ComponentRegistry, percentDisplayValue, getRecordDisplayName } from '@object-ui/core';
+import { ComponentRegistry, percentDisplayValue, getRecordDisplayName, type ComponentMeta } from '@object-ui/core';
 import { useLocalization, useDisplayLocale, formatDisplayNumber } from '@object-ui/i18n';
 import { Badge, Avatar, AvatarImage, AvatarFallback, Button, Checkbox, EmptyValue, cn } from '@object-ui/components';
 import { Check, X, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
@@ -2393,7 +2393,13 @@ export function evaluateCondition(condition: any, formData: any): boolean {
  * Field widget map for lazy loading
  * Maps field type to widget component
  */
-const fieldWidgetMap: Record<string, () => Promise<{ default: React.ComponentType<any> }>> = {
+type FieldWidgetLoader = () => Promise<{ default: React.ComponentType<any> }>;
+
+// `satisfies` (not a `Record<string, …>` annotation) so the KEY SET survives as
+// a literal union — that union is what makes `FIELD_WIDGET_LABELLING` below
+// exhaustive BY CONSTRUCTION: adding a widget here without deciding its
+// labelling is a compile error, not a silent fallback (objectui#4857).
+const fieldWidgetMap = {
   // Basic fields
   'text': () => import('./widgets/TextField').then(m => ({ default: m.TextField })),
   'textarea': () => import('./widgets/TextAreaField').then(m => ({ default: m.TextAreaField })),
@@ -2472,7 +2478,16 @@ const fieldWidgetMap: Record<string, () => Promise<{ default: React.ComponentTyp
   'object-ref': () => import('./widgets/ObjectRefField').then(m => ({ default: m.ObjectRefField })),
   'filter-condition': () => import('./widgets/FilterConditionField').then(m => ({ default: m.FilterConditionField })),
   'recipient-picker': () => import('./widgets/RecipientPickerField').then(m => ({ default: m.RecipientPickerField })),
-};
+} satisfies Record<string, FieldWidgetLoader>;
+
+/** The registered field widget keys, as a literal union (objectui#4857). */
+export type RegisteredFieldWidgetType = keyof typeof fieldWidgetMap;
+
+// String-indexed view of the same object, for the resolver call sites below
+// that look up ARBITRARY spellings (aliases, retired keys, author typos). The
+// literal-keyed `fieldWidgetMap` cannot be indexed by a plain `string`; this
+// alias widens the key without copying anything.
+const fieldWidgetLoaderByKey: Record<string, FieldWidgetLoader | undefined> = fieldWidgetMap;
 
 /**
  * Every field type the form can render (the canonical list of supported types).
@@ -2494,14 +2509,14 @@ export const FORM_FIELD_TYPES: readonly string[] = Object.freeze(Object.keys(fie
  * support can never drift behind the form surface (ADR-0059).
  */
 export function resolveFormWidgetType(fieldType: string): string {
-  if (fieldWidgetMap[fieldType]) return fieldType;
+  if (fieldWidgetLoaderByKey[fieldType]) return fieldType;
   // A retired spelling resolves to ITSELF, not to `text`: the registry holds a
   // tombstone widget under that key which refuses visibly, so every host built
   // on this seam (the app-shell `ActionParamDialog`, the bulk dialog) reports
   // the retirement instead of silently rendering an input (objectui#4814).
   if (RETIRED_FIELD_TYPES[fieldType]) return fieldType;
   const mapped = mapFieldTypeToFormType(fieldType).replace(/^field:/, '');
-  return fieldWidgetMap[mapped] ? mapped : 'text';
+  return fieldWidgetLoaderByKey[mapped] ? mapped : 'text';
 }
 
 /**
@@ -2536,7 +2551,8 @@ export function getLazyFieldWidget(fieldType: string): React.ComponentType<any> 
   if (RETIRED_FIELD_TYPES[key]) return RetiredFieldTombstone;
   let Widget = lazyFieldWidgets.get(key);
   if (!Widget) {
-    Widget = React.lazy(fieldWidgetMap[key]);
+    // `resolveFormWidgetType` only returns keys the map holds, hence the `!`.
+    Widget = React.lazy(fieldWidgetLoaderByKey[key]!);
     lazyFieldWidgets.set(key, Widget);
   }
   return Widget;
@@ -2589,58 +2605,110 @@ const FIELD_TYPES_SKIP_FALLBACK = new Set([
 ]);
 
 /**
- * Widgets whose labelled surface is NOT a labelable HTML element, so a host's
- * `<label for>` cannot reach it and the association has to go by IDREF instead
- * (`ComponentMeta.labelling`, objectui#3961). Two shapes, one declaration:
+ * The labelling declaration of EVERY registered field widget
+ * (`ComponentMeta.labelling` — the closed `'control' | 'group' | 'display'`
+ * vocabulary, objectui#3961 extended by objectui#4857). This `Record` is keyed
+ * by the widget map's own literal key union, so it is exhaustive BY
+ * CONSTRUCTION: registering a widget without deciding how a host's label
+ * reaches it is a COMPILE error here, not a silent fall-through to the
+ * `'control'` path — the omitted-declaration degradation is exactly the trap
+ * the #4857 ruling named, and it is what turned the display-only four into
+ * fields with no accessible name.
+ *
+ * ## `'group'` — a surface no `<label for>` can reach; the WIDGET consumes the IDREF
+ *
+ * Two shapes, one declaration:
  *
  *  - real composites — `address` / `geolocation` render several inputs under one
- *    container, and `checkboxes` / `radio` / `rating` / `multiselect` a set of
- *    choice controls; the host's label names the GROUP, each sub-control keeps
- *    its own name (a sub-label, or the chip's own text content).
- *  - `file` is not composite at all: it has exactly ONE control, the dropzone,
- *    which is a `div[role="button"]` (it is the keyboard path to the hidden file
- *    input). It is here because a `div` cannot be `for`-labelled, not because it
- *    is a group, and it renders NO `role="group"` — the dropzone itself takes the
- *    `aria-labelledby`.
+ *    container, `checkboxes` / `radio` / `rating` / `multiselect` a set of
+ *    choice controls, and `grid` a whole table of cell inputs plus row actions;
+ *    the host's label names the GROUP, each sub-control keeps its own name (a
+ *    sub-label, the chip's text content, or a cell's own `aria-label`).
+ *  - single non-labelable controls — `file`'s one control is a
+ *    `div[role="button"]` dropzone, `slider`'s is Radix's `span[role="slider"]`
+ *    thumb (objectui#3318), `signature`'s drawing surface is a `<canvas>`
+ *    (objectui#3318). A `div`/`span`/`canvas` cannot be `for`-labelled, so the
+ *    name goes by IDREF to the control (or, for `signature`, its container).
  *
- * Measured, not assumed: every entry was verified in a real form to be a widget
- * whose host label either resolved to nothing (`address` / `geolocation`, whose
- * sub-input ids overwrote the host id — objectui#3343) or resolved to an element
- * that cannot carry it (`checkboxes` / `radio` / `rating` / `file` /
- * `multiselect`). In both shapes the visible group label was, before this
- * declaration, the accessible name of NOTHING.
+ * Measured, not assumed: every `'group'` entry was verified in a real form —
+ * the #3961/#3975 probes for the first seven, the #3318 delivery for
+ * `slider`/`signature`, and the #4857 re-measurement for `grid` (bare config:
+ * one focusable, the auxiliary "Add line" BUTTON — routing `for` there would
+ * have label clicks INSERT A ROW; realistic config: 8 focusables across cell
+ * inputs and row actions — a composite, not a single control).
  *
- * `multiselect` arrived one issue later (objectui#3975) for a coverage reason,
- * not a mechanism one: #3961's probe covered the six above, and re-running it
- * over the full widget map afterwards found `multiselect` on the byte-identical
- * failure shape as `checkboxes` — the host id kept, on the chip row's wrapper
- * `div`, where a `for` is inert. Same declaration, same container answer.
+ * ## `'display'` — a pure display in EVERY state; the HOST wraps (objectui#4857)
  *
- * A widget NOT listed here takes the single-control path unchanged. That is the
- * safe default: the host keeps emitting `for`, and a composite that forgot to
- * declare itself is caught by the label-association tests (objectui#3952) rather
- * than silently emitting an `aria-labelledby` onto a container with no role.
+ * `formula` / `summary` / `auto_number` / `vector` have no editable branch at
+ * all: the whole widget is a replacement display with no focusable control, in
+ * the editable state as much as the readonly one (on the real object-form path
+ * they arrive `disabled`, never `readonly`, so the #4788 readonly gate could
+ * not cover them). The form renderer answers the declaration with its own
+ * wrapper — id + `aria-labelledby` + `aria-describedby` + `role="group"`, the
+ * #4788 container — and the label emits no `for`. The widgets spread nothing,
+ * by design; the host is the named surface.
+ *
+ * ## `'control'` — everything else
+ *
+ * The host's `<label for>` reaches a real labelable element. At registration
+ * this is deliberately spelled as ABSENCE of the meta key (one spelling of the
+ * default, objectui#3961), so hosts keep one rule for these and for
+ * out-of-registry widgets alike; the entry here is still mandatory, because
+ * "defaulted by omission" and "decided to be the default" are different facts.
  */
-const FIELD_TYPES_GROUP_LABELLED = new Set([
-  'address',
-  'geolocation',
-  'checkboxes',
-  'radio',
-  'rating',
-  'file',
-  // objectui#3975 — the residual after #3961's six, same shape as `checkboxes`.
-  'multiselect',
-  // objectui#3318 — two more of `file`'s shape, not composites:
-  //  - `slider`'s one control is Radix's `span[role="slider"]` thumb;
-  //  - `signature`'s drawing surface is a `<canvas>`.
-  // Neither is one of HTML's labelable elements, so a host `for` can only
-  // dangle at it; both must be named by IDREF instead.
-  'slider',
-  'signature',
-]);
+export const FIELD_WIDGET_LABELLING: Record<
+  RegisteredFieldWidgetType,
+  NonNullable<ComponentMeta['labelling']>
+> = {
+  text: 'control',
+  textarea: 'control',
+  number: 'control',
+  boolean: 'control',
+  select: 'control',
+  date: 'control',
+  datetime: 'control',
+  time: 'control',
+  email: 'control',
+  phone: 'control',
+  url: 'control',
+  multiselect: 'group',
+  radio: 'group',
+  checkboxes: 'group',
+  tags: 'control',
+  currency: 'control',
+  percent: 'control',
+  password: 'control',
+  markdown: 'control',
+  html: 'control',
+  richtext: 'control',
+  lookup: 'control',
+  master_detail: 'control',
+  file: 'group',
+  image: 'control',
+  location: 'control',
+  formula: 'display',
+  summary: 'display',
+  auto_number: 'display',
+  user: 'control',
+  object: 'control',
+  vector: 'display',
+  grid: 'group',
+  color: 'control',
+  slider: 'group',
+  rating: 'group',
+  code: 'control',
+  avatar: 'control',
+  address: 'group',
+  geolocation: 'group',
+  signature: 'group',
+  qrcode: 'control',
+  'object-ref': 'control',
+  'filter-condition': 'control',
+  'recipient-picker': 'control',
+};
 
 export function registerField(fieldType: string): void {
-  const loader = fieldWidgetMap[fieldType];
+  const loader = fieldWidgetLoaderByKey[fieldType];
   if (!loader) {
     console.warn(`Unknown field type: ${fieldType}`);
     return;
@@ -2653,13 +2721,17 @@ export function registerField(fieldType: string): void {
   // label/description/spacing. The only thing wrapped is the metadata carrier:
   // `withFieldCarrier` maps `SchemaRenderer`'s `schema` node onto `field`
   // (objectui#3233) and renders nothing of its own.
+  // The loader check above proves `fieldType` is a map key, which is what the
+  // labelling record is keyed by — hence the cast, not a second lookup table.
+  const labelling = FIELD_WIDGET_LABELLING[fieldType as RegisteredFieldWidgetType];
   ComponentRegistry.register(fieldType, withFieldCarrier(LazyFieldWidget), {
     namespace: 'field',
     skipFallback: FIELD_TYPES_SKIP_FALLBACK.has(fieldType),
-    // Only the group-labelled widgets carry the key; everything else leaves it
-    // absent, which the form renderer reads as `'control'` (objectui#3961). One
-    // spelling of the default, in one place.
-    ...(FIELD_TYPES_GROUP_LABELLED.has(fieldType) ? { labelling: 'group' as const } : null),
+    // Only the group- and display-labelled widgets carry the meta key;
+    // `'control'` stays ABSENT, which every host reads as `'control'`
+    // (objectui#3961). One spelling of the default, in one place — while the
+    // exhaustive record above still forces every widget to declare.
+    ...(labelling !== 'control' ? { labelling } : null),
   });
 }
 

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -21,9 +21,42 @@ import { useDisplayLocale } from '@object-ui/i18n';
 import { LookupField } from './LookupField';
 import { FileCell } from './FileField';
 import { toDateInputValue, toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue';
+import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 
 /**
  * GridField / LineItemsField — editable child-grid ("line items") widget.
+ *
+ * ## Where the host's label and help text land, and why (objectui#4857)
+ *
+ * This widget forwarded nothing a host handed it, so the field's visible label
+ * pointed `for` at an id no element carried and the help text had zero
+ * consumers. Measured on `origin/main` at `e71c854ce`, a real form, editable
+ * state, `description` set:
+ *
+ * ```
+ * bare (no columns)   for=DANGLING hostIdEl=NONE consumers=0  focusables=[button]
+ * columns + one row   for=DANGLING hostIdEl=NONE consumers=0  focusables=[drag,
+ *                       input(Item), input(Qty), button(Duplicate row),
+ *                       button(Remove row), input(Item), input(Qty), button(Add)]
+ * ```
+ *
+ * The bare row's single focusable is the auxiliary "Add line" BUTTON — labelable,
+ * but routing the host id (and so the label's `for`) onto it would make the
+ * field's label NAME the add-row action and make a click on the label insert a
+ * row. Every realistic config is a composite: many cell inputs, each with its
+ * own `aria-label`, under one container. So this widget declares
+ * `labelling: 'group'` (see `FIELD_WIDGET_LABELLING` in `../index`) — the
+ * objectui#3961 composite shape, like `address` — and the CONTAINER consumes the
+ * host's keys:
+ *
+ *  - editable / list mode: the root div takes the DOM pass-through minus `name`
+ *    (DOM-legal on form controls only — the objectui#3291 leak) and minus
+ *    `aria-invalid` (control-channel state; this grid reports validity per CELL,
+ *    with its own inline marks), answering `role="group"` only when a host
+ *    actually named it — `CheckboxesField`'s split, key for key.
+ *  - readonly: the table replaces the inputs entirely, so that surface takes the
+ *    name AND the description via `toHostGroupProps` — `'instead-of-the-inputs'`.
  *
  * A controlled component: `value` is an array of row objects, `onChange`
  * receives the next array. It renders one editable cell per configured
@@ -660,7 +693,14 @@ export function GridField({
   // ── Read-only / view rendering ────────────────────────────────────────────
   if (readonly) {
     return (
-      <div className={cn('space-y-2', className)}>
+      <div
+        // No input of the field's own renders here, so this surface is the only
+        // candidate for the host's name AND description (objectui#4857; the
+        // objectui#3990/#4005 route). Standalone rendering hands down none of
+        // the keys, so nothing is emitted and the markup is unchanged.
+        {...toHostGroupProps(props, 'instead-of-the-inputs')}
+        className={cn('space-y-2', className)}
+      >
         {columnChooser && <div className="flex justify-end">{columnChooser}</div>}
         <div className="border border-border rounded-lg overflow-x-auto" data-testid="line-items-readonly">
         <table className="w-full text-sm">
@@ -887,8 +927,28 @@ export function GridField({
     );
   };
 
+  // DOM pass-through (objectui#4857): the container carries the form renderer's
+  // id / aria-labelledby / aria-describedby, but NOT its `name` (DOM-legal on
+  // form controls only — the objectui#3291 leak) and NOT its `aria-invalid`
+  // (control-channel state; this grid reports validity per CELL with its own
+  // inline marks). `CheckboxesField`'s split, key for key.
+  const {
+    'aria-invalid': _hostAriaInvalid,
+    name: _domName,
+    ...groupDomProps
+  } = toDomProps(props);
+  // The container answers `role="group"` only when a host actually NAMED it by
+  // IDREF (objectui#3961) — standalone rendering (a bare SDUI node) hands down
+  // no `aria-labelledby`, emits no role, and keeps its markup unchanged.
+  const isLabelledGroup = groupDomProps['aria-labelledby'] != null;
+
   return (
-    <div className={cn('space-y-2', className)} data-testid="line-items">
+    <div
+      {...groupDomProps}
+      role={isLabelledGroup ? 'group' : undefined}
+      className={cn('space-y-2', className)}
+      data-testid="line-items"
+    >
       {columnChooser && <div className="flex justify-end">{columnChooser}</div>}
       <div className="border border-border rounded-lg overflow-x-auto">
         <table ref={gridRef} className="w-full text-sm">

--- a/packages/fields/src/widgets/SignatureField.tsx
+++ b/packages/fields/src/widgets/SignatureField.tsx
@@ -22,7 +22,7 @@ import { toHostGroupProps } from './toHostGroupProps';
  * The name and the description arrive here, on the container, through
  * {@link toHostGroupProps} — the objectui#3961 route for a widget whose surface
  * no `<label for>` can reach (`<canvas>` is not a labelable element), and which
- * therefore declares `labelling: 'group'` in `FIELD_TYPES_GROUP_LABELLED`.
+ * therefore declares `labelling: 'group'` in `FIELD_WIDGET_LABELLING`.
  * `'instead-of-the-inputs'` because this field renders no input of its own for
  * the description to land on: the Clear button is auxiliary — it acts on the
  * value, it is not the value's control — the same reading that put

--- a/packages/fields/src/widgets/SliderField.tsx
+++ b/packages/fields/src/widgets/SliderField.tsx
@@ -39,7 +39,7 @@ import { toHostGroupProps } from './toHostGroupProps';
  * The visible label reaches the thumb by IDREF, not by `for`: a
  * `span[role="slider"]` is not one of HTML's labelable elements, so this widget
  * is declared `labelling: 'group'` for the same reason `file` is — see
- * `FIELD_TYPES_GROUP_LABELLED` in `../index` and objectui#3961. No extra
+ * `FIELD_WIDGET_LABELLING` in `../index` and objectui#3961. No extra
  * `role="group"` wrapper: there is one control here, and `slider` is a role
  * that carries a name perfectly well on its own.
  */


### PR DESCRIPTION
Fixes #4857

## 实施依据

2026-08-17 05:03Z 维护者裁定(评论 5312059193,与 #4871 合裁)+ 06:36Z 实测更正(评论 5312685254)。卡面三选不再开放:方案 1(disabled→readonly 重映射)被裁否,`ObjectForm.tsx:687` 一字未动;slider / signature 已由 PR #4933 交付,本 PR 不触碰;剩余五行 = display 四 + grid。

## 变更

### 1. 声明扩展(公开契约键,`packages/core`)

`ComponentMeta.labelling` 从二值扩为三值闭枚举 `'control' | 'group' | 'display'` —— 全仓唯一词表,即合裁给「host 如何得知 widget 将渲染什么」的统一答案,⛔ host 本地变体。`'display'` 语义写入注释:渲染面在**任何状态**下都是纯展示、无可聚焦控件;host 不发 label 的 `for`(任何状态下都不存在 labelable 元素可指),改走 #4788 已裁的容器通道(id + `aria-labelledby` + `aria-describedby` + `role="group"`),且与 `'group'` 不同,widget 侧不消费任何键 —— host 容器即命名面。

zod 侧核查:全仓不存在 `ComponentMeta` 的 zod schema(`packages/core` 与 `@objectstack/spec` 均无 `labelling` 相关 schema),无可同步项。

### 2. display 四接 host 容器(`packages/components` + `packages/fields`)

`formula` / `summary` / `auto_number` / `vector` 声明 `'display'`。form renderer 的 host 门从「`readonly === true`」扩为「`readonly === true` **或** 声明 `'display'`」:

- readonly 臂语义一字未动 —— 未声明的第三方 widget 保持 #4788 原行为;
- display 臂读**声明**而非状态,所以真实对象表单路径(计算字段映射为 `disabled: true`,从不 `readonly`)也被覆盖 —— 这正是 #4788 门管不到这四个的原因;
- 四个 widget 本体零改动(#4788 的结构性主张:机制落 host 一次,不留「记得 spread」的入口)。

### 3. grid:先重测,实测推翻卡面预设后按复合体落地

06:36Z 更正明言勿按 slider/signature 外推、grid 需重测。同套 probe(真 form renderer + 裸注册,`description` 设置,编辑态,RESOLVES-LABELABLE 口径)实测 `origin/main` `e71c854ce`:

```
bare(无 columns) for=DANGLING hostIdEl=NONE consumers=0 focusables=[button]
realistic(列+行)for=DANGLING hostIdEl=NONE consumers=0 focusables=[drag, input(Item),
                  input(Qty), button(Duplicate row), button(Remove row),
                  input(Item), input(Qty), button(Add)]
```

读数裁决:bare 配置唯一 focusable 是**辅助动作** "Add line" button —— 它确实 labelable,但把 host id 落上去意味着字段 label 命名「加行」动作、**点 label 会插行**(label 激活转发);realistic 配置是 8 个 focusable 的单元格输入矩阵。即 grid 是复合体(`address` 形态),「其控件是单个 labelable button」的前提被实测推翻,方案 3 单用不成立。落地:声明 `labelling: 'group'`,root 容器按 `CheckboxesField` 的键位逐键消费 host 通道 —— 编辑/list 态容器收 id、label IDREF、describedby,`name` 与 `aria-invalid` 按 #3291/#3318 界线扣下(grid 的 invalid 本就按单元格上报;`aria-invalid` 轴归 #3318 账本,本 PR 前后都不落任何 host `aria-invalid`,该轴零变化);readonly 分支(替换性表格,无字段输入)走 `toHostGroupProps('instead-of-the-inputs')`,名字与描述同落容器。

### 4. 配套门:registered ⇒ declared

`FIELD_TYPES_GROUP_LABELLED`(Set)升级为 **`FIELD_WIDGET_LABELLING`** —— 以 `fieldWidgetMap` 字面键联合为键的**穷尽 Record**(#3935 的 Record 形态,并照 `group-labelling-declaration.test` 既有集合断言扩展,未另起炉灶):往 map 加 widget 而不定 labelling 是**编译期红**(tsc 报缺键),而非静默退回 control 路径 —— 裁定点名的漏声明陷阱。运行时 meta 侧保留 #3961 已钉的「`'control'` 以缺省拼写」约定(第三方 widget 本就以缺省进入 control 路径,host 读法不因此双轨;Record 里的 `'control'` 条目仍是强制决定 ——「被缺省」与「决定用缺省」是两个事实)。声明测试新增:display 逐项 + 精确集合断言、record↔`FORM_FIELD_TYPES` 键位奇偶断言、record↔注册 meta 逐键一致断言。Record 已导出,供姊妹单 #4871 的 metadata-admin 宿主复用同一词表。

## 测试

- 新增 `packages/fields/src/__tests__/display-grid-host-channels-e2e.test.tsx`:display 四**可编辑态**(含 `disabled: true` 的真实 ObjectForm 形态)+ readonly 态、grid 编辑/readonly/无 label 三态、control 绿对照;
- `packages/components` `form-readonly-host-group.test.tsx` 增补 display 声明 describe(编辑态包裹、disabled 路径、双臂同真仅一层、未声明回退钉、无 label 不包);
- `readonly-host-plumbing-e2e.test.tsx` 中 formula 编辑态残留钉按其自述「后改需是 deliberate 的」升级为**未声明回退**钉(该文件裸注册无声明,断言不变,语义改为钉住门要防的静默退化形状);
- 全量:fields+components 3121 通过、plugin-form/plugin-detail/plugin-grid 1940 通过、app-shell 3952 通过(1 例既有 skip),仓根 `turbo run type-check` 通过,`check-control-bytes` 通过,改动文件 eslint 0 error。

## 反向验证(先书面预判,commit 后变异,checkout 还原)

1. **撤 display 分支(保留声明)**:预判 fields e2e 可编辑态 5 例红于 `expect(host).not.toBeNull()`、components 新 describe 2 例红,readonly 与 grid 全绿 —— 实测 7 红 24 绿,与预判一致。
2. **从 Record 摘 `vector` 声明**:预判 tsc 红(缺键)+ 声明测试红且点名 vector;实测 tsc `TS2741: Property 'vector' is missing`、vitest 3 红(逐项 + 精确集合 + registered⇒declared 奇偶)—— 比 PR #5023 变异①先例的「tsc 红 vitest 绿」更强一档:本门在 Record 之外另有读 Record 的运行时奇偶断言,vitest 同红。
3. **把 `formula` 错标 `'control'`**:预判 tsc 绿、声明测试的 display 逐项与精确集合断言红(record↔meta 奇偶断言绿 —— 两者一致地错),e2e 绿(裸注册硬编码 'display',不读 Record)。实测 tsc exit 0、恰好 2 红,与预判一致。声明↔渲染面一致性由两文件**合取**持有:声明文件钉注册边界(本变异被它抓住),e2e 文件钉「声明 ⇒ 渲染」—— #3961 起两文件自述的既有分工,无新缺口,故不另立 finding。

## 边界

- ⛔ `ObjectForm.tsx:687` disabled 映射未动(方案 1 裁否);
- ⛔ slider / signature(PR #4933 已交付)未触碰 —— 其 widget 文件仅注释里的旧标识符引用更名跟随;
- ⛔ `app-shell` metadata-admin 宿主(#4871 姊妹单持有)未伸手;其 `DashboardWidgetInspector` 内部 `Field` 组件的本地二值 `labelling` prop 属 #4871 已裁范围,类型上与 `ComponentMeta` 无耦合,本 PR 不动;
- ⛔ `aria-invalid` 轴归 #3318 账本,前后零变化。

changeset:core / components / fields 三包 `minor`(公开契约键**扩展**,向后兼容 —— 对照 #3985/#3832 先例;仓规 fixed group ⛔ major)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_