### PR TITLE
fix(cli): resolve the project root the same way in dev, serve and build (#4923)

### DIFF
--- a/.changeset/cli-project-root-parity-4923.md
+++ b/.changeset/cli-project-root-parity-4923.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/cli': patch
+---
+
+`objectui serve` and `objectui build` now locate the project the way `dev` does, instead of looking only in the current directory.
+
+For a project with an app config and a `pages/` directory beside it, the three
+commands answered one invocation two different ways. `dev` anchored on the
+schema argument — `dirname(<schema>)` is the project root, `pages/` beside it
+means file-system routing, the named file is the app config. `serve` and `build`
+looked for a `pages/` directory in the current working directory and nowhere
+else, so from any directory above the project they fell through to single-schema
+mode and handed the app config to the renderer as if it were a page.
+
+Measured on the reported fixture (`<root>/app.json` + `<root>/pages/index.json`,
+invoked from the directory above): `dev` reported the project and one route,
+`serve` reported `Loading schema: <root>/app.json`, and `build` did the same and
+**exited 0** — the emitted bundle embedded the app config as the page schema and
+contained no page from `pages/` at all. A wrong artifact, produced silently.
+
+The detection now lives in one helper the three commands share
+(`utils/project-source.ts`), resolving in a fixed order: a `pages/` directory
+beside the schema argument, else one under the current directory, else
+single-schema mode. `serve` and `build` also pass the resolved app config to the
+routed app generator, which they never did, so a routed project keeps its layout
+under all three commands.
+
+A lone schema file with no `pages/` beside it is unchanged — that is the
+fallback, and it is still a supported way to run.

--- a/content/docs/utilities/cli.mdx
+++ b/content/docs/utilities/cli.mdx
@@ -228,18 +228,30 @@ body:
 
 ### File-system routing
 
-If the project contains a `pages/` directory, `dev` and `build` automatically
-switch to file-system routing — every `.json`/`.yaml` file under `pages/` becomes
-a route based on its path.
+If the project contains a `pages/` directory, `dev`, `serve` and `build`
+automatically switch to file-system routing — every `.json`/`.yaml` file under
+`pages/` becomes a route based on its path.
 
 ```
 my-app/
+├── app.json                → app config (title, layout)
 ├── pages/
 │   ├── index.json          → /
 │   ├── about.json          → /about
 │   └── users/
 │       └── [id].json       → /users/:id
 ```
+
+**Which directory is "the project"** is decided by the schema argument, so the
+three commands answer one invocation the same way from anywhere:
+
+1. The directory the schema argument points into — `objectui build my-app/app.json`
+   run from above `my-app/` routes from `my-app/pages/`, with `my-app/app.json`
+   as the app config.
+2. Otherwise the current working directory — `cd my-app && objectui dev` routes
+   from `./pages/`, with `./app.json` as the app config when present.
+3. Otherwise the named file is rendered on its own (single-schema mode), which
+   is what a lone `.json`/`.yaml` schema with no `pages/` beside it does.
 
 ## Programmatic API
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,6 +49,12 @@ objectui dev --no-open
 - `-h, --host <host>` — default `localhost`
 - `--no-open` — do not open browser
 
+`dev`, `serve` and `build` locate the project the same way: a `pages/` directory
+beside the schema argument means file-system routing (with that file as the app
+config), otherwise a `pages/` directory in the current directory, otherwise the
+named file is rendered on its own. So `objectui build my-app/app.json` from above
+`my-app/` builds the same routes `objectui dev my-app/app.json` serves.
+
 ### `objectui build [schema]`
 
 Build the application for production.

--- a/packages/cli/src/__tests__/project-source.test.ts
+++ b/packages/cli/src/__tests__/project-source.test.ts
@@ -1,0 +1,411 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pins the project-root / routing detection surface `dev`, `serve` and `build`
+ * share (objectui#4923).
+ *
+ * Measured before the fix, fixture `<root>/app.json` + `<root>/pages/index.json`
+ * invoked from the directory above:
+ *
+ * - `dev`   → `Detected project structure at <root>` … `✓ Found 1 route(s)`
+ * - `serve` → `📋 Loading schema: <root>/app.json` (single-schema mode)
+ * - `build` → same, **exit 0**, with the app config embedded in the bundle as
+ *   the page schema and no page from `pages/` in the output at all.
+ *
+ * Two commands out of three read the argument's directory, one read `cwd` only,
+ * and the losing reading failed silently. So the tests below judge one shared
+ * resolver, plus the property that all three reach it.
+ *
+ * ## Why there are no module mocks here
+ *
+ * A command-layer test that let a command run to completion would need `vite`
+ * stubbed, and the `unit` project runs with `isolate: false` — a mocked shared
+ * util would be visible to every other file in the worker. Instead the
+ * command-layer group uses inputs whose verdict is decided *inside* the
+ * detection step, so each command throws before it reaches Vite, `mkdirSync` or
+ * `npm install`: an empty `pages/` directory (the error names the directory that
+ * was scanned, which is exactly the fact that used to differ between the three)
+ * and the two single-schema failures. The positive routed case is pinned on the
+ * resolver, which is the same call all three now make.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { buildApp } from '../commands/build.js';
+import { dev } from '../commands/dev.js';
+import { serve } from '../commands/serve.js';
+import { reportProjectSource, resolveProjectSource } from '../utils/project-source.js';
+
+/**
+ * Strip ANSI colors so an assertion holds whether or not chalk is enabled.
+ *
+ * The escape character is BUILT, never written: an editing tool materializes a
+ * backslash-u escape into a real control byte precisely when the subject is
+ * control bytes (objectui#4890), and one raw byte makes grep read the whole file
+ * as binary — zero matches, no signal.
+ */
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+const stripAnsi = (text: string): string => text.replace(ANSI_PATTERN, '');
+
+/** packages/cli/src/__tests__ -> packages/cli/src/commands */
+const COMMAND_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../commands');
+
+const APP_CONFIG = { name: 'fixture_app', title: 'Issue 4923 Fixture App' };
+const PAGE = { type: 'text', content: 'fixture home page' };
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+function writeRaw(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+/**
+ * Run `body` against a fresh temp directory that stands in for the directory
+ * ABOVE the project — the invocation shape the card measured.
+ *
+ * `realpathSync` because the resolver derives its answers from the path it is
+ * given, and on platforms where `tmpdir()` is a symlink an un-normalized base
+ * would compare unequal to a directory name the resolver returned.
+ */
+async function withParentDir(body: (parent: string) => void | Promise<void>): Promise<void> {
+  const parent = realpathSync(mkdtempSync(join(tmpdir(), 'objectui-4923-')));
+  try {
+    await body(parent);
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+}
+
+/** The card's fixture: an app config with a `pages/` directory beside it. */
+function writeProject(parent: string, name = 'app'): string {
+  const root = join(parent, name);
+  writeJson(join(root, 'app.json'), APP_CONFIG);
+  writeJson(join(root, 'pages/index.json'), PAGE);
+  return root;
+}
+
+describe('resolveProjectSource — anchoring on the argument (objectui#4923)', () => {
+  it('finds the project from a directory above it', async () => {
+    await withParentDir((parent) => {
+      const root = writeProject(parent);
+      const source = resolveProjectSource(parent, 'app/app.json');
+
+      expect(source.mode).toBe('routes');
+      if (source.mode !== 'routes') return;
+      expect(source.projectRoot).toBe(root);
+      expect(source.pagesDir).toBe(join(root, 'pages'));
+      expect(source.pagesDirOrigin).toBe('schema-dir');
+      expect(source.routes.map((route) => route.path)).toEqual(['/']);
+      expect(source.appConfig).toEqual(APP_CONFIG);
+      expect(source.appConfigPath).toBe(join(root, 'app.json'));
+      expect(source.warnings).toEqual([]);
+    });
+  });
+
+  it('answers the same for one project however the invocation is spelled', async () => {
+    // The regression guard for the path that already worked: invoking from
+    // inside the project must keep resolving to the same project.
+    await withParentDir((parent) => {
+      const root = writeProject(parent);
+      const fromAbove = resolveProjectSource(parent, 'app/app.json');
+      const fromInside = resolveProjectSource(root, 'app.json');
+      const fromAbsolute = resolveProjectSource(parent, join(root, 'app.json'));
+
+      for (const source of [fromAbove, fromInside, fromAbsolute]) {
+        expect(source.mode).toBe('routes');
+        if (source.mode !== 'routes') continue;
+        expect(source.projectRoot).toBe(root);
+        expect(source.pagesDir).toBe(join(root, 'pages'));
+        expect(source.routes.map((route) => route.filePath)).toEqual([join(root, 'pages/index.json')]);
+        expect(source.appConfig).toEqual(APP_CONFIG);
+      }
+    });
+  });
+
+  it('reads the whole route set, dynamic routes last', async () => {
+    await withParentDir((parent) => {
+      const root = writeProject(parent);
+      writeJson(join(root, 'pages/about.json'), PAGE);
+      writeJson(join(root, 'pages/users/[id].json'), PAGE);
+
+      const source = resolveProjectSource(parent, 'app/app.json');
+      expect(source.mode).toBe('routes');
+      if (source.mode !== 'routes') return;
+      expect(source.routes.map((route) => route.path)).toEqual(['/', '/about', '/users/:id']);
+    });
+  });
+
+  it("prefers the argument's project over the working directory's", async () => {
+    await withParentDir((parent) => {
+      // The parent is itself a project — the reading `serve`/`build` used to
+      // have. The argument names a different one, and the argument wins.
+      writeJson(join(parent, 'app.json'), { name: 'outer_app' });
+      writeJson(join(parent, 'pages/index.json'), PAGE);
+      const root = writeProject(parent, 'inner');
+
+      const source = resolveProjectSource(parent, 'inner/app.json');
+      expect(source.mode).toBe('routes');
+      if (source.mode !== 'routes') return;
+      expect(source.pagesDir).toBe(join(root, 'pages'));
+      expect(source.pagesDirOrigin).toBe('schema-dir');
+      expect(source.appConfig).toEqual(APP_CONFIG);
+    });
+  });
+
+  it('falls back to the working directory when the argument names no project', async () => {
+    // `objectui dev` with the default `app.json` argument, in a project that has
+    // no app config — and `objectui dev pages/`, the documented directory form.
+    await withParentDir((parent) => {
+      writeJson(join(parent, 'pages/index.json'), PAGE);
+
+      const noAppConfig = resolveProjectSource(parent, 'app.json');
+      expect(noAppConfig.mode).toBe('routes');
+      if (noAppConfig.mode !== 'routes') return;
+      expect(noAppConfig.projectRoot).toBe(parent);
+      expect(noAppConfig.pagesDirOrigin).toBe('cwd');
+      expect(noAppConfig.appConfig).toBeNull();
+      expect(noAppConfig.appConfigPath).toBeNull();
+
+      writeJson(join(parent, 'app.json'), APP_CONFIG);
+      const viaPagesDir = resolveProjectSource(parent, 'pages');
+      expect(viaPagesDir.mode).toBe('routes');
+      if (viaPagesDir.mode !== 'routes') return;
+      expect(viaPagesDir.pagesDirOrigin).toBe('cwd');
+      expect(viaPagesDir.appConfig).toEqual(APP_CONFIG);
+    });
+  });
+
+  it('keeps a lone schema file rendering on its own', async () => {
+    // Single-schema mode is legitimate input, not a casualty of the fix.
+    await withParentDir((parent) => {
+      writeJson(join(parent, 'solo/page.json'), PAGE);
+
+      const source = resolveProjectSource(parent, 'solo/page.json');
+      expect(source.mode).toBe('schema');
+      if (source.mode !== 'schema') return;
+      expect(source.schemaFile).toBe(join(parent, 'solo/page.json'));
+      expect(source.schema).toEqual(PAGE);
+      expect(source.warnings).toEqual([]);
+    });
+  });
+
+  it('warns instead of failing when the app config is malformed', async () => {
+    await withParentDir((parent) => {
+      const root = join(parent, 'app');
+      writeRaw(join(root, 'app.json'), '{ "name": ');
+      writeJson(join(root, 'pages/index.json'), PAGE);
+
+      const source = resolveProjectSource(parent, 'app/app.json');
+      expect(source.mode).toBe('routes');
+      if (source.mode !== 'routes') return;
+      expect(source.routes).toHaveLength(1);
+      expect(source.appConfig).toBeNull();
+      expect(source.warnings).toHaveLength(1);
+      expect(source.warnings[0]).toContain('Failed to parse app config');
+    });
+  });
+
+  it('refuses an empty pages directory, naming the directory it scanned', async () => {
+    await withParentDir((parent) => {
+      const root = join(parent, 'app');
+      writeJson(join(root, 'app.json'), APP_CONFIG);
+      mkdirSync(join(root, 'pages'), { recursive: true });
+
+      expect(() => resolveProjectSource(parent, 'app/app.json')).toThrow(
+        `No schema files found in ${join(root, 'pages')}`
+      );
+    });
+  });
+
+  it('reports a missing schema file with the init hint', async () => {
+    await withParentDir((parent) => {
+      expect(() => resolveProjectSource(parent, 'nope.json')).toThrow('Schema file not found: nope.json');
+      expect(() => resolveProjectSource(parent, 'nope.json')).toThrow("Run 'objectui init'");
+    });
+  });
+
+  it('reports an unparsable lone schema', async () => {
+    await withParentDir((parent) => {
+      writeRaw(join(parent, 'broken.json'), '{ "type": ');
+      expect(() => resolveProjectSource(parent, 'broken.json')).toThrow('Invalid schema file:');
+    });
+  });
+});
+
+describe('reportProjectSource — the lines the three commands print', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function capture(body: () => void): { log: string[]; warn: string[] } {
+    const log: string[] = [];
+    const warn: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      log.push(stripAnsi(args.map(String).join(' ')));
+    });
+    vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      warn.push(stripAnsi(args.map(String).join(' ')));
+    });
+    body();
+    return { log, warn };
+  }
+
+  it('names the detected project, its config, its pages directory and its routes', async () => {
+    await withParentDir((parent) => {
+      const root = writeProject(parent);
+      const { log, warn } = capture(() => {
+        reportProjectSource(resolveProjectSource(parent, 'app/app.json'), parent);
+      });
+
+      expect(log).toEqual([
+        `📂 Detected project structure at ${root}`,
+        '⚙️  Loaded App Config from app/app.json',
+        `📁 Using file-system routing from ${join(root, 'pages')}`,
+        '✓ Found 1 route(s)',
+        '  / → app/pages/index.json'
+      ]);
+      expect(warn).toEqual([]);
+    });
+  });
+
+  it('names the file in single-schema mode', async () => {
+    await withParentDir((parent) => {
+      writeJson(join(parent, 'solo/page.json'), PAGE);
+      const { log } = capture(() => {
+        reportProjectSource(resolveProjectSource(parent, 'solo/page.json'), parent);
+      });
+
+      expect(log).toEqual(['📋 Loading schema: solo/page.json']);
+    });
+  });
+
+  it('surfaces a malformed app config as a warning, not silence', async () => {
+    await withParentDir((parent) => {
+      const root = join(parent, 'app');
+      writeRaw(join(root, 'app.json'), '{ "name": ');
+      writeJson(join(root, 'pages/index.json'), PAGE);
+
+      const { log, warn } = capture(() => {
+        reportProjectSource(resolveProjectSource(parent, 'app/app.json'), parent);
+      });
+
+      expect(warn).toHaveLength(1);
+      expect(warn[0]).toContain('Failed to parse app config');
+      // The routes still report — a broken layout config is not a dead project.
+      expect(log).toContain('✓ Found 1 route(s)');
+      expect(log.some((line) => line.startsWith('⚙️  Loaded App Config'))).toBe(false);
+    });
+  });
+});
+
+describe('dev / serve / build detection parity (objectui#4923)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * The three commands, each reduced to "resolve, then render".
+   *
+   * Every input below is decided inside the detection step, so none of these
+   * calls reaches Vite: they are the command layer's own answer to "what is this
+   * project", read off the thrown error.
+   */
+  const commands: ReadonlyArray<readonly [string, (schema: string) => Promise<unknown>]> = [
+    ['dev', (schema) => dev(schema, { port: '0', host: 'localhost', open: false })],
+    ['serve', (schema) => serve(schema, { port: '0', host: 'localhost' })],
+    ['build', (schema) => buildApp(schema, { outDir: 'dist' })]
+  ];
+
+  it.each(commands)('%s anchors the project on the argument, not on cwd', async (_name, run) => {
+    await withParentDir(async (parent) => {
+      const root = join(parent, 'app');
+      writeJson(join(root, 'app.json'), APP_CONFIG);
+      mkdirSync(join(root, 'pages'), { recursive: true });
+      vi.spyOn(process, 'cwd').mockReturnValue(parent);
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // Before the fix `serve`/`build` never looked here: they parsed the app
+      // config as a page and started Vite. Naming this directory in the error is
+      // the proof that the argument's project is what got scanned.
+      await expect(run('app/app.json')).rejects.toThrow(
+        `No schema files found in ${join(root, 'pages')}`
+      );
+    });
+  });
+
+  it.each(commands)('%s keeps single-schema mode for a lone file', async (_name, run) => {
+    await withParentDir(async (parent) => {
+      writeRaw(join(parent, 'solo.json'), '{ "type": ');
+      vi.spyOn(process, 'cwd').mockReturnValue(parent);
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // Reaching the parse at all means the fallback still runs for all three.
+      await expect(run('solo.json')).rejects.toThrow('Invalid schema file:');
+    });
+  });
+
+  it.each(commands)('%s reports a missing schema the same way', async (_name, run) => {
+    await withParentDir(async (parent) => {
+      vi.spyOn(process, 'cwd').mockReturnValue(parent);
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await expect(run('nope.json')).rejects.toThrow('Schema file not found: nope.json');
+    });
+  });
+});
+
+describe('the three commands reach detection through one helper (objectui#4923)', () => {
+  // Same shape as the objectui#3890 group in `workspace-vite.test.ts`, for the
+  // same reason: the routed happy path ends in a Vite server or a Vite build, so
+  // what the commands HAND ON cannot be read off a mock-free behavioral test —
+  // and dropping the app config is precisely how `serve` and `build` used to
+  // render a routed project without its layout.
+  const sources = new Map(
+    ['dev.ts', 'serve.ts', 'build.ts'].map(
+      (file) => [file, readFileSync(join(COMMAND_DIR, file), 'utf-8')] as const
+    )
+  );
+
+  it('resolves and reports through the shared functions', () => {
+    for (const [file, source] of sources) {
+      expect(source, `${file} must resolve through the shared helper`).toContain('resolveProjectSource');
+      expect(source, `${file} must report the shared detection lines`).toContain('reportProjectSource');
+    }
+  });
+
+  it('hands the resolved app config to the routed generator', () => {
+    // `createTempAppWithRouting(tmpDir, routes)` — two arguments — is how the
+    // app layout got dropped in `serve` and `build`.
+    for (const [file, source] of sources) {
+      expect(source, `${file} must pass the resolved app config`).toContain(
+        'createTempAppWithRouting(tmpDir, source.routes, source.appConfig)'
+      );
+    }
+  });
+
+  it('leaves no hand-rolled pages/ lookup behind in any of them', () => {
+    // The exact expression the card names, which `serve.ts` and `build.ts` each
+    // used to decide the whole question with. Matched as text, so it must not
+    // appear in a comment either — the history it belongs to is written up once,
+    // in `utils/project-source.ts`, which is not one of these files.
+    const handRolled = /join\(\s*cwd\s*,\s*['"]pages['"]\s*\)/;
+    for (const [file, source] of sources) {
+      expect(handRolled.test(source), `${file} still resolves pages/ by hand`).toBe(false);
+    }
+  });
+});

--- a/packages/cli/src/__tests__/project-source.test.ts
+++ b/packages/cli/src/__tests__/project-source.test.ts
@@ -382,9 +382,15 @@ describe('the three commands reach detection through one helper (objectui#4923)'
   );
 
   it('resolves and reports through the shared functions', () => {
+    // The CALL, not the identifier: reverting one command's detection while
+    // leaving its now-unused import behind kept a bare-name assertion green.
     for (const [file, source] of sources) {
-      expect(source, `${file} must resolve through the shared helper`).toContain('resolveProjectSource');
-      expect(source, `${file} must report the shared detection lines`).toContain('reportProjectSource');
+      expect(source, `${file} must resolve through the shared helper`).toContain(
+        'resolveProjectSource(cwd, schemaPath)'
+      );
+      expect(source, `${file} must report the shared detection lines`).toContain(
+        'reportProjectSource(source, cwd)'
+      );
     }
   });
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -12,7 +12,8 @@ import { existsSync, mkdirSync, cpSync, rmSync } from 'fs';
 import { join, resolve } from 'path';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
-import { scanPagesDirectory, createTempAppWithRouting, createTempApp, parseSchemaFile, type RouteInfo } from '../utils/app-generator.js';
+import { createTempAppWithRouting, createTempApp } from '../utils/app-generator.js';
+import { reportProjectSource, resolveProjectSource } from '../utils/project-source.js';
 import { isWorkspaceRoot, prepareWorkspaceTempApp } from '../utils/workspace-vite.js';
 
 interface BuildOptions {
@@ -28,57 +29,23 @@ export async function buildApp(schemaPath: string, options: BuildOptions) {
   console.log(chalk.blue('🔨 Building application for production...'));
   console.log();
   
-  // Check if pages directory exists for file-system routing
-  const pagesDir = join(cwd, 'pages');
-  const hasPagesDir = existsSync(pagesDir);
-  
-  let routes: RouteInfo[] = [];
-  let schema: unknown = null;
-  let useFileSystemRouting = false;
-
-  if (hasPagesDir) {
-    // File-system based routing
-    console.log(chalk.blue('📁 Using file-system routing'));
-    routes = scanPagesDirectory(pagesDir);
-    useFileSystemRouting = true;
-    
-    if (routes.length === 0) {
-      throw new Error('No schema files found in pages/ directory');
-    }
-    
-    console.log(chalk.green(`✓ Found ${routes.length} route(s)`));
-  } else {
-    // Single schema file mode
-    const fullSchemaPath = resolve(cwd, schemaPath);
-
-    // Check if schema file exists
-    if (!existsSync(fullSchemaPath)) {
-      throw new Error(`Schema file not found: ${schemaPath}\nRun 'objectui init' to create a sample schema.`);
-    }
-
-    console.log(chalk.blue('📋 Loading schema:'), chalk.cyan(schemaPath));
-
-    // Read and validate schema
-    try {
-      schema = parseSchemaFile(fullSchemaPath);
-    } catch (error) {
-      // The caught error's message is inlined below. We can't pass it as the
-      // `Error` `cause` option because this package targets ES2020, whose lib
-      // types the 1-arg `Error` constructor only; hence the scoped disable.
-      // eslint-disable-next-line preserve-caught-error
-      throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
-    }
-  }
+  // What this invocation names — the project root, the routes, the app config —
+  // resolved by the helper all three commands share. This command used to look
+  // for a pages/ directory under cwd and nowhere else, so from any directory
+  // above the project it emitted a bundle with the app config rendered as the
+  // page schema, exit 0 (objectui#4923).
+  const source = resolveProjectSource(cwd, schemaPath);
+  reportProjectSource(source, cwd);
 
   // Create temporary app directory
   const tmpDir = join(cwd, '.objectui-tmp');
   mkdirSync(tmpDir, { recursive: true });
 
   // Create temporary app files
-  if (useFileSystemRouting) {
-    createTempAppWithRouting(tmpDir, routes);
+  if (source.mode === 'routes') {
+    createTempAppWithRouting(tmpDir, source.routes, source.appConfig);
   } else {
-    createTempApp(tmpDir, schema);
+    createTempApp(tmpDir, source.schema);
   }
 
   // Install dependencies

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -8,11 +8,12 @@
 
 import { createServer } from 'vite';
 import react from '@vitejs/plugin-react';
-import { existsSync, mkdirSync, statSync } from 'fs';
-import { join, resolve, dirname } from 'path';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
-import { scanPagesDirectory, createTempAppWithRouting, createTempApp, parseSchemaFile, type RouteInfo } from '../utils/app-generator.js';
+import { createTempAppWithRouting, createTempApp } from '../utils/app-generator.js';
+import { reportProjectSource, resolveProjectSource } from '../utils/project-source.js';
 import { isWorkspaceRoot, prepareWorkspaceTempApp } from '../utils/workspace-vite.js';
 
 interface DevOptions {
@@ -23,103 +24,22 @@ interface DevOptions {
 
 export async function dev(schemaPath: string, options: DevOptions) {
   const cwd = process.cwd();
-  
-  // Resolve the actual project root and schema file
-  let _projectRoot = cwd;
-  const targetSchemaPath = schemaPath;
-  let hasPagesDir = false;
-  let pagesDir = '';
-  let appConfig: unknown = null;
 
-  // 1. Determine Project Root & Mode
-  const absoluteSchemaPath = resolve(cwd, schemaPath);
-  
-  if (existsSync(absoluteSchemaPath) && statSync(absoluteSchemaPath).isFile()) {
-    // If input is a file (e.g. examples/showcase/app.json)
-    const fileDir = dirname(absoluteSchemaPath);
-    const potentialPagesDir = join(fileDir, 'pages');
-
-    if (existsSync(potentialPagesDir)) {
-      console.log(chalk.blue(`📂 Detected project structure at ${fileDir}`));
-      _projectRoot = fileDir;
-      hasPagesDir = true;
-      pagesDir = potentialPagesDir;
-      
-      // Try to load app.json as config
-      try {
-        appConfig = parseSchemaFile(absoluteSchemaPath);
-        console.log(chalk.blue('⚙️  Loaded App Config from app.json'));
-      } catch (_e) {
-        console.warn('Failed to parse app config');
-      }
-    }
-  } 
-  
-  // Fallback: Check detect pages dir in current cwd if not found above
-  if (!hasPagesDir) {
-     const localPagesDir = join(cwd, 'pages');
-     if (existsSync(localPagesDir)) {
-        hasPagesDir = true;
-        pagesDir = localPagesDir;
-        // Try to find and load app.json in cwd
-        const appJsonPath = join(cwd, 'app.json');
-        if (existsSync(appJsonPath)) {
-          try {
-            appConfig = parseSchemaFile(appJsonPath);
-            console.log(chalk.blue('⚙️  Loaded App Config from app.json'));
-          } catch (_e) {
-            console.warn('Failed to parse app.json config');
-          }
-        }
-     }
-  }
-
-  let routes: RouteInfo[] = [];
-  let schema: unknown = null;
-  let useFileSystemRouting = false;
-
-  if (hasPagesDir) {
-    // File-system based routing
-    console.log(chalk.blue(`📁 Using file-system routing from ${pagesDir}`));
-    routes = scanPagesDirectory(pagesDir);
-    useFileSystemRouting = true;
-    
-    if (routes.length === 0) {
-      throw new Error(`No schema files found in ${pagesDir}`);
-    }
-    
-    console.log(chalk.green(`✓ Found ${routes.length} route(s)`));
-    routes.forEach(route => {
-      console.log(chalk.dim(`  ${route.path} → ${route.filePath.replace(cwd, '.')}`));
-    });
-  } else {
-    // Single schema file mode
-    const fullSchemaPath = resolve(cwd, schemaPath);
-    // ... (rest of the logic)
-    if (!existsSync(fullSchemaPath)) {
-      throw new Error(`Schema file not found: ${schemaPath}\nRun 'objectui init' to create a sample schema.`);
-    }
-    console.log(chalk.blue('📋 Loading schema:'), chalk.cyan(schemaPath));
-    try {
-      schema = parseSchemaFile(fullSchemaPath);
-    } catch (error) {
-      // The caught error's message is inlined below. We can't pass it as the
-      // `Error` `cause` option because this package targets ES2020, whose lib
-      // types the 1-arg `Error` constructor only; hence the scoped disable.
-      // eslint-disable-next-line preserve-caught-error
-      throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
-    }
-  }
+  // What this invocation names — the project root, the routes, the app config —
+  // resolved by the helper all three commands share, so `dev`, `serve` and
+  // `build` cannot answer the same invocation differently (objectui#4923).
+  const source = resolveProjectSource(cwd, schemaPath);
+  reportProjectSource(source, cwd);
 
   // Create temporary app directory (always in cwd to keep node_modules access)
   const tmpDir = join(cwd, '.objectui-tmp');
   mkdirSync(tmpDir, { recursive: true });
 
   // Create temporary app files
-  if (useFileSystemRouting) {
-    createTempAppWithRouting(tmpDir, routes, appConfig);
+  if (source.mode === 'routes') {
+    createTempAppWithRouting(tmpDir, source.routes, source.appConfig);
   } else {
-    createTempApp(tmpDir, schema);
+    createTempApp(tmpDir, source.schema);
   }
 
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -8,11 +8,12 @@
 
 import { createServer } from 'vite';
 import react from '@vitejs/plugin-react';
-import { existsSync, mkdirSync } from 'fs';
-import { join, resolve, relative } from 'path';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
-import { scanPagesDirectory, createTempAppWithRouting, createTempApp, parseSchemaFile, type RouteInfo } from '../utils/app-generator.js';
+import { createTempAppWithRouting, createTempApp } from '../utils/app-generator.js';
+import { reportProjectSource, resolveProjectSource } from '../utils/project-source.js';
 import { isWorkspaceRoot, prepareWorkspaceTempApp } from '../utils/workspace-vite.js';
 
 interface ServeOptions {
@@ -22,61 +23,24 @@ interface ServeOptions {
 
 export async function serve(schemaPath: string, options: ServeOptions) {
   const cwd = process.cwd();
-  
-  // Check if pages directory exists for file-system routing
-  const pagesDir = join(cwd, 'pages');
-  const hasPagesDir = existsSync(pagesDir);
-  
-  let routes: RouteInfo[] = [];
-  let schema: unknown = null;
-  let useFileSystemRouting = false;
 
-  if (hasPagesDir) {
-    // File-system based routing
-    console.log(chalk.blue('📁 Detected pages/ directory - using file-system routing'));
-    routes = scanPagesDirectory(pagesDir);
-    useFileSystemRouting = true;
-    
-    if (routes.length === 0) {
-      throw new Error('No schema files found in pages/ directory');
-    }
-    
-    console.log(chalk.green(`✓ Found ${routes.length} route(s)`));
-    routes.forEach(route => {
-      console.log(chalk.dim(`  ${route.path} → ${relative(cwd, route.filePath)}`));
-    });
-  } else {
-    // Single schema file mode
-    const fullSchemaPath = resolve(cwd, schemaPath);
-
-    // Check if schema file exists
-    if (!existsSync(fullSchemaPath)) {
-      throw new Error(`Schema file not found: ${schemaPath}\nRun 'objectui init' to create a sample schema.`);
-    }
-
-    console.log(chalk.blue('📋 Loading schema:'), chalk.cyan(schemaPath));
-
-    // Read and validate schema
-    try {
-      schema = parseSchemaFile(fullSchemaPath);
-    } catch (error) {
-      // The caught error's message is inlined below. We can't pass it as the
-      // `Error` `cause` option because this package targets ES2020, whose lib
-      // types the 1-arg `Error` constructor only; hence the scoped disable.
-      // eslint-disable-next-line preserve-caught-error
-      throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
-    }
-  }
+  // What this invocation names — the project root, the routes, the app config —
+  // resolved by the helper all three commands share. This command used to look
+  // for a pages/ directory under cwd and nowhere else, so the same invocation
+  // `dev` served as a routed project fell through to single-schema mode here
+  // (objectui#4923; the history is in `utils/project-source.ts`).
+  const source = resolveProjectSource(cwd, schemaPath);
+  reportProjectSource(source, cwd);
 
   // Create temporary app directory
   const tmpDir = join(cwd, '.objectui-tmp');
   mkdirSync(tmpDir, { recursive: true });
 
   // Create temporary app files
-  if (useFileSystemRouting) {
-    createTempAppWithRouting(tmpDir, routes);
+  if (source.mode === 'routes') {
+    createTempAppWithRouting(tmpDir, source.routes, source.appConfig);
   } else {
-    createTempApp(tmpDir, schema);
+    createTempApp(tmpDir, source.schema);
   }
 
   // Install dependencies

--- a/packages/cli/src/utils/project-source.ts
+++ b/packages/cli/src/utils/project-source.ts
@@ -1,0 +1,232 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * What `dev`, `serve` and `build` are asked to render — resolved once, for all
+ * three (objectui#4923).
+ *
+ * ## The divergence this replaces
+ *
+ * Every one of the three commands answered "what is this project?" on its own.
+ * `dev` anchored the answer on the SCHEMA ARGUMENT: `dirname(<schema>)` is the
+ * project root, `pages/` beside the schema means file-system routing, and the
+ * named file is the app config. `serve` and `build` looked only at
+ * `join(cwd, 'pages')` and never at where the argument pointed, so from any
+ * directory above the project the same invocation fell through to single-schema
+ * mode — with the app config itself handed to the renderer as if it were a page.
+ *
+ * Measured on the commit that filed the card, fixture `<root>/app.json` +
+ * `<root>/pages/index.json`, invoked from the directory above:
+ *
+ * - `objectui dev  <root>/app.json` → project structure, 1 route.
+ * - `objectui serve <root>/app.json` → `Loading schema: <root>/app.json`.
+ * - `objectui build <root>/app.json` → same, and it EXITS 0: the emitted bundle
+ *   embeds the app config as the page schema and contains no page from
+ *   `pages/` at all. A wrong artifact, produced silently.
+ *
+ * So the defect is not that one of the two readings is wrong — it is that one
+ * invocation has two answers, and the losing one fails without saying so. There
+ * is no documented intent for `serve`/`build` to be single-schema commands; the
+ * documentation states the opposite twice (`cli.ts` calls `dev` an "alias for
+ * serve", `README.md` and `content/docs/utilities/cli.mdx` call `serve` a
+ * "legacy alias of `dev`", and the docs' routing section says `dev` and `build`
+ * switch to file-system routing when "the project contains a `pages/`
+ * directory"). Hence the richer, argument-anchored reading wins and lives here,
+ * where the three share it — the same anti-drift shape objectui#3890 gave the
+ * module-resolution face in `workspace-vite.ts`.
+ *
+ * ## Single-schema mode is still a mode
+ *
+ * A lone schema file with no `pages/` next to it is legitimate input and keeps
+ * behaving exactly as before: the file is parsed and rendered on its own. It is
+ * the fallback, not the casualty.
+ */
+
+import { existsSync, statSync } from 'fs';
+import { dirname, join, relative, resolve } from 'path';
+
+import chalk from 'chalk';
+
+import { parseSchemaFile, scanPagesDirectory, type RouteInfo } from './app-generator.js';
+
+/** Where the `pages/` directory that won was found. */
+export type PagesDirOrigin = 'schema-dir' | 'cwd';
+
+/** File-system routing: a `pages/` directory decides the routes. */
+export interface RoutedProjectSource {
+  mode: 'routes';
+  /** The directory treated as the project root. */
+  projectRoot: string;
+  /** Absolute path of the `pages/` directory being scanned. */
+  pagesDir: string;
+  /** Which of the two candidate locations `pagesDir` came from. */
+  pagesDirOrigin: PagesDirOrigin;
+  routes: RouteInfo[];
+  /** Parsed app config, when one was found and readable. */
+  appConfig: unknown;
+  /** Absolute path the app config was read from, if any. */
+  appConfigPath: string | null;
+  /** Non-fatal problems for the caller to report. */
+  warnings: string[];
+}
+
+/** Single schema file mode: no `pages/` anywhere, render the named file. */
+export interface SingleSchemaSource {
+  mode: 'schema';
+  /** The directory treated as the project root. */
+  projectRoot: string;
+  /** Absolute path of the schema file that was parsed. */
+  schemaFile: string;
+  schema: unknown;
+  warnings: string[];
+}
+
+export type ProjectSource = RoutedProjectSource | SingleSchemaSource;
+
+/**
+ * Parse a file as an app config, degrading to a warning.
+ *
+ * A malformed app config is not fatal — the routes are still renderable without
+ * a layout — so it warns and continues, which is what `dev` has always done.
+ */
+function readAppConfig(path: string, warnings: string[]): unknown {
+  try {
+    return parseSchemaFile(path);
+  } catch (error) {
+    warnings.push(
+      `Failed to parse app config ${path}: ${error instanceof Error ? error.message : error}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Resolve what to render from an invocation, identically for all three commands.
+ *
+ * Pure apart from reading the filesystem: nothing is logged and nothing is
+ * written, so the three commands' reporting stays in `reportProjectSource` and
+ * this can be exercised directly.
+ *
+ * Resolution order — first match wins:
+ *
+ * 1. `<schemaArg>` is an existing file and `pages/` sits beside it → routing
+ *    from there, with the named file as the app config. This is the limb
+ *    `serve`/`build` never had.
+ * 2. `<cwd>/pages` exists → routing from there, with `<cwd>/app.json` as the app
+ *    config when it exists. Invoking inside the project keeps working, including
+ *    with the default `app.json` argument and with a `pages/` argument.
+ * 3. Otherwise → single schema file mode.
+ *
+ * Throws when the resolved input cannot be rendered at all: a missing schema
+ * file, an unparsable one, or a `pages/` directory holding no schema.
+ */
+export function resolveProjectSource(cwd: string, schemaArg: string): ProjectSource {
+  const warnings: string[] = [];
+  const absoluteSchemaPath = resolve(cwd, schemaArg);
+
+  // 1. Anchored on the argument: a project is the directory the schema lives in.
+  if (existsSync(absoluteSchemaPath) && statSync(absoluteSchemaPath).isFile()) {
+    const projectRoot = dirname(absoluteSchemaPath);
+    const pagesDir = join(projectRoot, 'pages');
+
+    if (existsSync(pagesDir)) {
+      return {
+        mode: 'routes',
+        projectRoot,
+        pagesDir,
+        pagesDirOrigin: 'schema-dir',
+        routes: scanRoutes(pagesDir),
+        appConfig: readAppConfig(absoluteSchemaPath, warnings),
+        appConfigPath: absoluteSchemaPath,
+        warnings
+      };
+    }
+  }
+
+  // 2. Anchored on the working directory.
+  const localPagesDir = join(cwd, 'pages');
+  if (existsSync(localPagesDir)) {
+    const localAppConfigPath = join(cwd, 'app.json');
+    const hasLocalAppConfig = existsSync(localAppConfigPath);
+
+    return {
+      mode: 'routes',
+      projectRoot: cwd,
+      pagesDir: localPagesDir,
+      pagesDirOrigin: 'cwd',
+      routes: scanRoutes(localPagesDir),
+      appConfig: hasLocalAppConfig ? readAppConfig(localAppConfigPath, warnings) : null,
+      appConfigPath: hasLocalAppConfig ? localAppConfigPath : null,
+      warnings
+    };
+  }
+
+  // 3. Single schema file mode.
+  if (!existsSync(absoluteSchemaPath)) {
+    throw new Error(
+      `Schema file not found: ${schemaArg}\nRun 'objectui init' to create a sample schema.`
+    );
+  }
+
+  let schema: unknown;
+  try {
+    schema = parseSchemaFile(absoluteSchemaPath);
+  } catch (error) {
+    // The caught error's message is inlined below. We can't pass it as the
+    // `Error` `cause` option because this package targets ES2020, whose lib
+    // types the 1-arg `Error` constructor only; hence the scoped disable.
+    // eslint-disable-next-line preserve-caught-error
+    throw new Error(`Invalid schema file: ${error instanceof Error ? error.message : error}`);
+  }
+
+  return {
+    mode: 'schema',
+    projectRoot: dirname(absoluteSchemaPath),
+    schemaFile: absoluteSchemaPath,
+    schema,
+    warnings
+  };
+}
+
+/** Scan a `pages/` directory, refusing an empty one. */
+function scanRoutes(pagesDir: string): RouteInfo[] {
+  const routes = scanPagesDirectory(pagesDir);
+  if (routes.length === 0) {
+    throw new Error(`No schema files found in ${pagesDir}`);
+  }
+  return routes;
+}
+
+/**
+ * Print the detection result.
+ *
+ * Split from the resolution so the three commands report identically by
+ * construction: the divergence the card describes was visible in exactly these
+ * lines, and a reader comparing two commands' output is comparing this function
+ * with itself.
+ */
+export function reportProjectSource(source: ProjectSource, cwd: string): void {
+  for (const warning of source.warnings) {
+    console.warn(chalk.yellow(`⚠ ${warning}`));
+  }
+
+  if (source.mode === 'schema') {
+    console.log(chalk.blue('📋 Loading schema:'), chalk.cyan(relative(cwd, source.schemaFile) || source.schemaFile));
+    return;
+  }
+
+  console.log(chalk.blue(`📂 Detected project structure at ${source.projectRoot}`));
+  if (source.appConfigPath && source.appConfig) {
+    console.log(chalk.blue(`⚙️  Loaded App Config from ${relative(cwd, source.appConfigPath) || source.appConfigPath}`));
+  }
+  console.log(chalk.blue(`📁 Using file-system routing from ${source.pagesDir}`));
+  console.log(chalk.green(`✓ Found ${source.routes.length} route(s)`));
+  for (const route of source.routes) {
+    console.log(chalk.dim(`  ${route.path} → ${relative(cwd, route.filePath)}`));
+  }
+}


### PR DESCRIPTION
Fixes #4923

## 修前实测(三命令,同一 fixture,从上层目录调用)

fixture 是卡面形态:`4923-fixture/app.json` + `4923-fixture/pages/index.json`,在仓根跑。

`objectui dev 4923-fixture/app.json`:

```
📂 Detected project structure at /home/user/objectui-cli-root-parity/4923-fixture
⚙️  Loaded App Config from app.json
📁 Using file-system routing from /home/user/objectui-cli-root-parity/4923-fixture/pages
✓ Found 1 route(s)
  / → ./4923-fixture/pages/index.json
```

`objectui serve 4923-fixture/app.json`:

```
📋 Loading schema: 4923-fixture/app.json
📦 Detected monorepo - using root node_modules
```

`objectui build 4923-fixture/app.json --out-dir 4923-fixture-dist`:同上退化成单 schema 模式,并且 **exit 0** 跑完了整个 Vite 构建。产物验尸:

```
$ grep -rl "fixture_app"      4923-fixture-dist/   # app 配置被当页面 schema 打进去了
4923-fixture-dist/assets/index-Cyt1JDho.js
$ grep -rl "fixture home page" 4923-fixture-dist/  # pages/ 里的真页面:一个都没有
(无输出)
```

即:错产物,静默产出,退出码 0。三命令对同一 invocation 给两种答案,输的那一种不报错。

## 修法

检测面抽成三命令共用的一步(`packages/cli/src/utils/project-source.ts`),解析顺序固定:

1. schema 参数指向的文件旁边有 `pages/` → 文件系统路由,该文件即 app 配置(这条是 serve/build 从来没有的支路);
2. 否则 cwd 下的 `pages/` → 文件系统路由,`app.json` 存在则作 app 配置;
3. 否则单 schema 文件模式。

报告(那几行检测输出)拆在同一文件里 `reportProjectSource`,所以两个命令的输出对比,对比的是同一个函数和它自己。serve/build 同时补上了**把解析出的 app 配置传给路由版生成器** —— 它们此前只传两个参数,路由认出来了、布局丢了。

`isWorkspaceRoot` / `prepareWorkspaceTempApp`(#3890 / PR #4922 的别名面)一行未动。

## 分叉出口:先查了「刻意单 schema 语义」是否文档化

结论是**没有**,而且文档三处说反:`cli.ts:62` 把 dev 描述为 “alias for serve”;`packages/cli/README.md` 与 `content/docs/utilities/cli.mdx` 都把 serve 写成 “Legacy alias of `dev`”;文档的 File-system routing 一节承诺 “dev 和 build 在项目含 `pages/` 时自动切文件系统路由”。所以不是二选一的语义之争,是实现没兑现文档 —— 按分诊的机制假设实施,并把文档补上「哪个目录算项目」。

## 修后实测

三命令输出逐字一致(仅 build 多一行自己的构建抬头):

```
📂 Detected project structure at /home/user/objectui-cli-root-parity/4923-fixture
⚙️  Loaded App Config from 4923-fixture/app.json
📁 Using file-system routing from /home/user/objectui-cli-root-parity/4923-fixture/pages
✓ Found 1 route(s)
  / → 4923-fixture/pages/index.json
```

产物同样验尸:`fixture home page`(真页面)、react-router 都进了 bundle。

## 测试

`packages/cli` 全量 144 passed(新增 25)。新测试有意**不用 module mock**:`unit` project 跑在 `isolate: false` 下,mock 掉共享 util 会被同一 worker 里别的文件看见。命令层改用「判决发生在检测步之内」的输入(空 `pages/` 目录、坏的孤立 schema、缺文件),三命令都在碰到 Vite 之前抛错,错误信息里带着**它扫的是哪个目录** —— 那正是三者此前不一致的那个事实。

## 反向验证(先书面预判,再变异)

- **① serve 退回 cwd-only 读法**:预判 1 条行为红 + 3 条源码钉红。实测先只红了 3 条 —— 行为红的形状与预判一致(`expected ... 'No schema files found in /tmp/objectu…' but got 'Failed to install dependencies…'`,11.7s,正是退化后一路走到 `npm install`),但**共享函数钉没红**:变异留下了没人用的 import,而钉子按裸标识符匹配。这条是变异查出来的真漏洞,已把钉子改成匹配调用形(`resolveProjectSource(cwd, schemaPath)`),重跑变异 → 4 条全红,与预判一致。
- **②a 撤掉 cwd 兜底支路**:预判**只**红 `falls back to the working directory…` 一条,孤立 schema 用例**不**红(它们根本不进这条支路)。实测 1 红 24 绿,与预判一致 —— 派发模板里预判的「孤立 schema 用例红」对应的是另一条支路,照直记在这里。
- **②b 撤掉单 schema 支路**:预判 10 红(解析器 3 + 报告 1 + 命令层 6)。实测 10 红,逐条对上。

全部变异后 `git checkout --` 还原(未用 stash)。

## 其他

- changeset:`@object-ui/cli` patch。
- 越界发现另开 #5037(文档化的 `pages/` 目录形参数只在 cwd 下可用,带路径调用报 EISDIR),未在本 PR 修。
- 仓根 `turbo run type-check` 81/81 绿;`node scripts/check-control-bytes.mjs` 绿;改动文件 eslint 0 error(dev.ts 一条既有的 `any` warning,非本次引入)。