### PR TITLE
fix(app-shell): metadata-admin SchemaForm 按 widget 声明发命名通道,颜色 widget 拆双注册 (#4871)

### DIFF
--- a/.changeset/schemaform-widget-labelling-4871.md
+++ b/.changeset/schemaform-widget-labelling-4871.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin: SchemaForm emits the naming channel each widget DECLARES, and the colour widget splits into two registrations
+
+`MetadataField` wrote `<Label htmlFor={id}>` for every field and handed the same
+`id` down on the convention "the wrapped control carries it". Probed across the
+whole `WIDGETS` registry, both the editable and the read-only state: eight keys
+pointed that `for` at an id **no element in the document carried** — a dangling
+IDREF, which reads as a closed association to tooling and to assistive tech
+while naming nothing. Two more (`field-multi`, `action-multi`) resolved in the
+editable state and dangled in the read-only one, because the element that
+carried the id was an auxiliary "add" picker gated behind `!readOnly`.
+
+The registry now carries `WIDGET_LABELLING`, a table keyed by the widget map's
+own literal key union — registering a widget without deciding how the host's
+label reaches it is a compile error, not a silent fall-through to the dangling
+path. Its vocabulary is derived from `ComponentMeta['labelling']` in
+`@object-ui/core` rather than restated locally (the 2026-08-17 ruling on
+objectui#4857 + objectui#4871). `'control'` keeps the plain `<label for>`;
+`'group'` publishes the label's own `id`, hands it down as `aria-labelledby`,
+and **drops** the `for`.
+
+`color-picker` was one entry that chose between a swatch `radiogroup` and a
+labelable `input[type="color"]` at runtime — after the host had already written
+the label, which is why the host could not know which channel to emit. It is two
+registrations now (`color-picker` / `color-input`) and the **host** picks between
+them from the schema, before the label. Both read the palette through one shared
+function, so host and widget cannot disagree about which surface renders.
+
+Also fixed on the way, both measured by the same probe: `secret` and the free
+colour picker carried self-owned `aria-label` constants that **won** the
+accessible-name computation, so fields labelled "API Key" or "Brand Color"
+announced as "Secret value" and "Color"; those now defer to the host label and
+keep the constant only for a caller that renders them with no label at all. The
+hex box beside the colour picker, and the boolean switches inside
+`dynamic-config`, had no accessible name at all.

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.colorPicker.labelling.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.colorPicker.labelling.test.tsx
@@ -11,7 +11,7 @@
  *    can name;
  *  - a free colour → `<input type="color">`, a labelable element —
  *
- * while `MetadataField` had already written `<Label htmlFor={id}>` above it. The
+ * while `FieldRow` had already written `<Label htmlFor={id}>` above it. The
  * host could not publish an IDREF for the group to answer, because it did not
  * yet know which surface it was labelling. #4010 fixed the half it could reach
  * (the group carried its OWN name) and pinned the other half as a KNOWN
@@ -94,7 +94,7 @@ describe('color-picker (palette ⇒ radiogroup) — named by the host, by IDREF'
     // Through `SchemaForm` there is ALWAYS a visible label to reference, so the
     // host-IDREF arm is what this path takes — the widget's `ariaLabel` fallback
     // is for a caller that renders it standalone (pinned in
-    // SchemaForm.widgetLabelling.test.tsx). With no `title`, `MetadataField`
+    // SchemaForm.widgetLabelling.test.tsx). With no `title`, `FieldRow`
     // prettifies the field name, and that prettified text is what names the
     // group: one fact, one author.
     renderColorField({ type: 'string', enum: ['default', 'blue'] });
@@ -104,7 +104,7 @@ describe('color-picker (palette ⇒ radiogroup) — named by the host, by IDREF'
 
 describe('color-input (free colour ⇒ native picker) — a labelable control', () => {
   it('takes the host id on the native picker, so the plain `for` resolves', () => {
-    // `prettify('colorVariant') === 'Color Variant'`, so `MetadataField` shows no
+    // `prettify('colorVariant') === 'Color Variant'`, so `FieldRow` shows no
     // machine-name `<code>` and the label's whole text is the field title.
     renderColorField({ type: 'string', title: 'Color Variant' }, '#112233');
 

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.colorPicker.labelling.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.colorPicker.labelling.test.tsx
@@ -1,33 +1,29 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * objectui#4010, the third call site — the generic `color-picker` widget.
+ * objectui#4010, the third call site — the generic colour widget — CLOSED OUT by
+ * objectui#4871.
  *
- * `ColorPickerWidget` renders TWO different surfaces from one registry entry,
- * and only one of them can be named the way its host assumes:
+ * The shape this file used to pin: ONE registry entry, `color-picker`, rendering
+ * two different surfaces chosen at runtime from `schema`/`fieldSpec` —
  *
  *  - an enum palette → `div[role="radiogroup"]`, a container no `<label for>`
  *    can name;
- *  - a free colour → `<input type="color">`, a labelable element.
+ *  - a free colour → `<input type="color">`, a labelable element —
  *
- * `MetadataField` writes `<Label htmlFor={id}>` and hands the widget the same
- * `id` BEFORE either branch is chosen — the choice is made inside the widget,
- * from `schema`/`fieldSpec`. So the host cannot publish an IDREF for the group
- * to answer, the way the two curated inspectors' labels now do; teaching it to
- * needs a per-widget `labelling` declaration (the shape `packages/components`'
- * form renderer already has for field widgets, objectui#3961) and is filed as
- * objectui#4871 rather than guessed at here.
+ * while `MetadataField` had already written `<Label htmlFor={id}>` above it. The
+ * host could not publish an IDREF for the group to answer, because it did not
+ * yet know which surface it was labelling. #4010 fixed the half it could reach
+ * (the group carried its OWN name) and pinned the other half as a KNOWN
+ * RESIDUAL: `for="mdf-colorVariant"` resolving to nothing at all.
  *
- * Until then the group carries its OWN name, like this file's other
- * unassociated groups. Measured on `origin/main` before the change, the enum
- * branch's radiogroup had `aria-label: null`, `aria-labelledby: null` and an
- * accessible name of `''` — anonymous, while the free-colour branch beside it
- * had been self-naming all along.
- *
- * The host's `for` still resolves to nothing at THIS site; that is the residual
- * objectui#4871 carries. This file deliberately does not paper over it by moving
- * the id onto the group, which would make a link-checker happy while naming
- * nobody (pinned below).
+ * objectui#4871 removed the runtime choice instead of tolerating it. The two
+ * surfaces are two registrations — `color-picker` (palette ⇒ radiogroup,
+ * declared `labelling: 'group'`) and `color-input` (free colour ⇒ native
+ * picker, declared `'control'`) — and the HOST picks between them from the
+ * schema, BEFORE it writes the label. So each surface now gets the one naming
+ * channel that works on it, and the three assertions below that used to pin the
+ * residual pin its absence.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -38,7 +34,11 @@ afterEach(cleanup);
 
 const form = { type: 'simple' as const, sections: [{ label: 'Basics', fields: [{ field: 'colorVariant' }] }] };
 
-/** `detectColorWidget` resolves `colorVariant` to the `color-picker` widget. */
+/**
+ * `detectColorWidget` resolves `colorVariant` to the colour widget; which of the
+ * two registrations renders is then decided by `resolveRegisteredWidget` from
+ * the schema — the split this file's residual was waiting on.
+ */
 function renderColorField(schema: Record<string, unknown>, value: unknown = 'blue') {
   return render(
     <SchemaForm
@@ -50,12 +50,12 @@ function renderColorField(schema: Record<string, unknown>, value: unknown = 'blu
   );
 }
 
-describe('color-picker (enum branch) — the swatch group is named (objectui#4010)', () => {
+describe('color-picker (palette ⇒ radiogroup) — named by the host, by IDREF', () => {
   it('announces the field label rather than nothing', () => {
     renderColorField({ type: 'string', title: 'Color Variant', enum: ['default', 'blue', 'teal'] });
 
     const group = screen.getByRole('radiogroup');
-    // Pre-fix: `''`. The swatches inside were named ("Blue"); the group was not.
+    // Pre-#4010: `''`. The swatches inside were named ("Blue"); the group was not.
     expect(group).toHaveAccessibleName('Color Variant');
     // Equal to the visible label — a generic stand-in ("Color") over a field
     // labelled "Color Variant" would fail WCAG 2.5.3 (Label in Name).
@@ -63,42 +63,71 @@ describe('color-picker (enum branch) — the swatch group is named (objectui#401
     expect(screen.getByRole('radiogroup', { name: 'Color Variant' })).toBeInTheDocument();
   });
 
-  it('does NOT take the host id to make the dangling `for` resolve', () => {
-    // The refused half-fix. `role="radiogroup"` is not labelable, so an id here
-    // would satisfy "the IDREF resolves" while the group stayed unnamed — the
-    // shape objectui#4010 was filed to remove, not to relocate.
+  it('is named by the host label’s IDREF, and the dangling `for` is GONE', () => {
+    // The residual objectui#4010 pinned and objectui#4871 removed. Three facts,
+    // and the third is the one that used to fail:
     renderColorField({ type: 'string', title: 'Color Variant', enum: ['default', 'blue'] });
 
     const group = screen.getByRole('radiogroup');
-    expect(group).not.toHaveAttribute('id');
-    expect(group).not.toHaveAttribute('aria-labelledby');
-    // The host's own `for` is untouched by this change and still resolves to
-    // nothing HERE — a host-side `labelling` declaration is what fixes that
-    // (objectui#4871). Documented, not endorsed: this assertion is the tripwire
-    // that makes whoever lands #4871 update this file.
     const label = screen.getByText('Color Variant');
-    expect(label).toHaveAttribute('for', 'mdf-colorVariant');
+
+    // 1. The label publishes an id and emits NO `for`. Not merely redundant on a
+    //    container — a `for` there activates nothing and names nothing, and
+    //    beside a working `aria-labelledby` it is one label with two channels,
+    //    one of them broken (objectui#3978).
+    expect(label).not.toHaveAttribute('for');
+    expect(label).toHaveAttribute('id', 'mdf-colorVariant-label');
+
+    // 2. The group answers that id. This is the association channel that works
+    //    on a non-labelable element.
+    expect(group).toHaveAttribute('aria-labelledby', 'mdf-colorVariant-label');
+
+    // 3. The host id is on NO element — and that is now correct rather than
+    //    broken, because nothing points at it any more. The refused half-fix
+    //    was to put it on the group instead: the IDREF would have resolved
+    //    while the group stayed unnamed.
+    expect(group).not.toHaveAttribute('id');
     expect(document.getElementById('mdf-colorVariant')).toBeNull();
   });
 
-  it('falls back to the constant only when the host offers no label source', () => {
-    // No `title`, so `MetadataField` prettifies the field name. The widget can
-    // read neither that computation nor the locale, so it degrades to the same
-    // constant its free-colour sibling has always used.
+  it('keeps its self-owned name only when rendered without a host label', () => {
+    // Through `SchemaForm` there is ALWAYS a visible label to reference, so the
+    // host-IDREF arm is what this path takes — the widget's `ariaLabel` fallback
+    // is for a caller that renders it standalone (pinned in
+    // SchemaForm.widgetLabelling.test.tsx). With no `title`, `MetadataField`
+    // prettifies the field name, and that prettified text is what names the
+    // group: one fact, one author.
     renderColorField({ type: 'string', enum: ['default', 'blue'] });
-    expect(screen.getByRole('radiogroup')).toHaveAccessibleName('Color');
+    expect(screen.getByRole('radiogroup')).toHaveAccessibleName('Color Variant');
   });
 });
 
-describe('color-picker (free-colour branch) — unchanged', () => {
-  it('still renders the native picker, named as before', () => {
-    // The branch split is where this change lives, so the other side is pinned
-    // too: no enum ⇒ no radiogroup, and the labelable input keeps its own name.
-    renderColorField({ type: 'string', title: 'Brand Color' }, '#112233');
+describe('color-input (free colour ⇒ native picker) — a labelable control', () => {
+  it('takes the host id on the native picker, so the plain `for` resolves', () => {
+    // `prettify('colorVariant') === 'Color Variant'`, so `MetadataField` shows no
+    // machine-name `<code>` and the label's whole text is the field title.
+    renderColorField({ type: 'string', title: 'Color Variant' }, '#112233');
 
     expect(screen.queryByRole('radiogroup')).toBeNull();
     const native = document.querySelector('input[type="color"]');
     expect(native).not.toBeNull();
-    expect(native).toHaveAttribute('aria-label', 'Color');
+
+    // `<label for>` → a real labelable element, the plain channel.
+    const label = screen.getByText('Color Variant');
+    expect(label).toHaveAttribute('for', 'mdf-colorVariant');
+    expect(native).toHaveAttribute('id', 'mdf-colorVariant');
+    expect(native).toHaveAccessibleName('Color Variant');
+
+    // The old self-owned `aria-label="Color"` is GONE on this path: an
+    // `aria-label` wins the accessible-name computation, so keeping it would
+    // have overridden the visible field label with a generic constant.
+    expect(native).not.toHaveAttribute('aria-label');
+  });
+
+  it('names the hex mirror beside it', () => {
+    // Two inputs edit one value. The picker is named by the field's label; the
+    // hex box had NO accessible name at all before objectui#4871.
+    renderColorField({ type: 'string', title: 'Color Variant' }, '#112233');
+    expect(screen.getByRole('textbox', { name: 'Hex value' })).toBeInTheDocument();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -348,19 +348,13 @@ function detectColorWidget(name: string, schema: JsonSchema | undefined): string
   return undefined;
 }
 
-const CONDITION_FIELD_NAMES = new Set(['visible', 'hidden', 'disabled', 'visibleOn', 'condition', 'predicate']);
-/**
- * Detect a CEL predicate field by NAME CONVENTION (`visible` / `hidden` /
- * `disabled` / `visibleOn` / `condition` / `*When`) so it renders the no-code
- * condition builder instead of a raw expression text box. String-only, no enum.
- */
 /**
  * Resolve a CONDITIONAL widget name to the concrete registration that will
  * render (objectui#4871, maintainer ruling point 4).
  *
  * `color-picker` used to be one registry entry that chose between a swatch
  * `radiogroup` and a labelable `input[type="color"]` at RUNTIME, from
- * `schema`/`fieldSpec` — i.e. AFTER `MetadataField` had already written
+ * `schema`/`fieldSpec` — i.e. AFTER `FieldRow` had already written
  * `<Label htmlFor>`, which is exactly why the host could not know which naming
  * channel to emit. The two surfaces are two registrations now, and this
  * function is where the host picks between them: from the schema, BEFORE the
@@ -383,6 +377,12 @@ function resolveRegisteredWidget(
   return widget;
 }
 
+const CONDITION_FIELD_NAMES = new Set(['visible', 'hidden', 'disabled', 'visibleOn', 'condition', 'predicate']);
+/**
+ * Detect a CEL predicate field by NAME CONVENTION (`visible` / `hidden` /
+ * `disabled` / `visibleOn` / `condition` / `*When`) so it renders the no-code
+ * condition builder instead of a raw expression text box. String-only, no enum.
+ */
 function detectConditionWidget(name: string, schema: JsonSchema | undefined): string | undefined {
   if (Array.isArray(schema?.enum)) return undefined;
   const isString =
@@ -1178,7 +1178,7 @@ function FieldControl({
       return (
         <Renderer
           // Exactly one of these is defined, decided by the widget's own
-          // `labelling` declaration in `MetadataField` (objectui#4871).
+          // `labelling` declaration in `FieldRow` (objectui#4871).
           id={id}
           ariaLabelledBy={ariaLabelledBy}
           schema={schema}

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -56,7 +56,14 @@ import {
   CollapsibleContent,
 } from '@object-ui/components';
 import { evaluatePredicate } from './predicate';
-import { WIDGETS, type WidgetContext } from './widgets';
+import {
+  WIDGETS,
+  widgetLabelling,
+  resolveColorWidgetKey,
+  type RegisteredWidgetKey,
+  type WidgetContext,
+  type WidgetRenderer,
+} from './widgets';
 import { useMetadataLocale, t, tFormat, translateValidationMessage, translateEnumOption, translateSchemaFieldLabel, translateSchemaFieldHelp } from './i18n';
 
 type JsonSchema = Record<string, any>;
@@ -347,6 +354,35 @@ const CONDITION_FIELD_NAMES = new Set(['visible', 'hidden', 'disabled', 'visible
  * `disabled` / `visibleOn` / `condition` / `*When`) so it renders the no-code
  * condition builder instead of a raw expression text box. String-only, no enum.
  */
+/**
+ * Resolve a CONDITIONAL widget name to the concrete registration that will
+ * render (objectui#4871, maintainer ruling point 4).
+ *
+ * `color-picker` used to be one registry entry that chose between a swatch
+ * `radiogroup` and a labelable `input[type="color"]` at RUNTIME, from
+ * `schema`/`fieldSpec` — i.e. AFTER `MetadataField` had already written
+ * `<Label htmlFor>`, which is exactly why the host could not know which naming
+ * channel to emit. The two surfaces are two registrations now, and this
+ * function is where the host picks between them: from the schema, BEFORE the
+ * label. `resolveColorWidgetKey` lives beside the widgets and is what both of
+ * them read their palette through, so host and widget cannot disagree.
+ *
+ * Runs on the AUTHORED name too, not only the inferred one: a spec that pins
+ * `widget: 'color-picker'` on a free-colour field must still land on the
+ * registration that actually renders, or the declaration would describe a
+ * different surface than the one on screen.
+ */
+function resolveRegisteredWidget(
+  widget: string | undefined,
+  schema: JsonSchema | undefined,
+  fieldSpec: FormFieldSpec | undefined,
+): string | undefined {
+  if (widget === 'color-picker' || widget === 'color-input') {
+    return resolveColorWidgetKey(schema, fieldSpec);
+  }
+  return widget;
+}
+
 function detectConditionWidget(name: string, schema: JsonSchema | undefined): string | undefined {
   if (Array.isArray(schema?.enum)) return undefined;
   const isString =
@@ -913,6 +949,35 @@ function FieldRow({
     }
   }
 
+  // Which registration will actually render, decided BEFORE the label so the
+  // declaration below describes the surface the user gets (objectui#4871).
+  widget = resolveRegisteredWidget(widget, schema, fieldSpec);
+
+  // How this field's visible label must reach what the widget renders — the
+  // widget's own DECLARATION, never an inference from the DOM it happens to
+  // produce (objectui#4871, the vocabulary of `ComponentMeta.labelling`).
+  //
+  //  - `'control'` — the widget puts this `id` on a labelable element, so the
+  //    label associates the plain way, `<label for>` → id. Unchanged path;
+  //    every non-registered widget name resolves here too.
+  //  - `'group'` — no `<label for>` can reach the surface. The label publishes
+  //    its OWN id, the widget answers `aria-labelledby`, and the `for` is
+  //    DROPPED: aimed at a container it activates nothing and names nothing,
+  //    and leaving it beside the working channel is one label with two
+  //    associations, one of them broken (the `form.tsx` `labelling: 'group'`
+  //    branch, objectui#3961/#3978, and objectui#4010's refusal to relocate
+  //    the id onto the radiogroup instead).
+  const labelling = widgetLabelling(widget);
+  const groupLabelled = labelling === 'group';
+  // Whitespace-free by construction (`mdf-` + a field name), and consumed as an
+  // `aria-labelledby` IDREF — a space in it would silently resolve to two ids.
+  const labelId = groupLabelled ? `${id}-label` : undefined;
+  // Exactly one of these two reaches the widget, ever.
+  const channel = groupLabelled
+    ? { id: undefined, ariaLabelledBy: labelId }
+    : { id, ariaLabelledBy: undefined };
+  const labelAssociation = groupLabelled ? { id: labelId } : { htmlFor: id };
+
   // Booleans with a schema default are never *missing* — don't show the
   // required asterisk (which would otherwise lie about user obligation).
   const isBoolean = schema?.type === 'boolean' || widget === 'switch';
@@ -930,7 +995,7 @@ function FieldRow({
     return (
       <div className="flex items-start justify-between gap-3 py-1.5">
         <div className="min-w-0 flex-1">
-          <Label htmlFor={id} className="text-sm font-medium cursor-pointer">
+          <Label {...labelAssociation} className="text-sm font-medium cursor-pointer">
             {label}
             {showRequiredStar && <span className="text-destructive ml-0.5">*</span>}
           </Label>
@@ -942,7 +1007,8 @@ function FieldRow({
           ))}
         </div>
         <FieldControl
-          id={id}
+          id={channel.id}
+          ariaLabelledBy={channel.ariaLabelledBy}
           fieldName={name}
           schema={schema}
           value={value}
@@ -960,7 +1026,7 @@ function FieldRow({
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between gap-2">
-        <Label htmlFor={id} className="text-sm font-medium">
+        <Label {...labelAssociation} className="text-sm font-medium">
           {label}
           {showRequiredStar && <span className="text-destructive ml-0.5">*</span>}
           {!labelMatchesName && (
@@ -974,7 +1040,8 @@ function FieldRow({
         </Label>
       </div>
       <FieldControl
-        id={id}
+        id={channel.id}
+        ariaLabelledBy={channel.ariaLabelledBy}
         fieldName={name}
         schema={schema}
         value={value}
@@ -999,6 +1066,7 @@ function FieldRow({
 
 function FieldControl({
   id,
+  ariaLabelledBy,
   fieldName,
   schema,
   value,
@@ -1009,7 +1077,16 @@ function FieldControl({
   widgetContext,
   formData,
 }: {
-  id: string;
+  /**
+   * The host field id — present only on the `labelling: 'control'` channel,
+   * `undefined` on the `'group'` one (objectui#4871). Every builtin branch below
+   * renders a labelable element, so they all spread it unconditionally; a group
+   * declaration can only come from a REGISTERED widget, and that branch returns
+   * before them.
+   */
+  id?: string;
+  /** The host label's id, on the `'group'` channel only. */
+  ariaLabelledBy?: string;
   /** Machine field name — keys enum-option localization (e.g. flow `type`). */
   fieldName?: string;
   schema: JsonSchema;
@@ -1096,11 +1173,14 @@ function FieldControl({
   // Widget hint takes precedence: try the registry first, then the
   // passthrough hint list, then fall back to JSON with an inline hint.
   if (widget) {
-    const Renderer = WIDGETS[widget];
+    const Renderer = WIDGETS[widget as RegisteredWidgetKey] as WidgetRenderer | undefined;
     if (Renderer) {
       return (
         <Renderer
+          // Exactly one of these is defined, decided by the widget's own
+          // `labelling` declaration in `MetadataField` (objectui#4871).
           id={id}
+          ariaLabelledBy={ariaLabelledBy}
           schema={schema}
           value={value}
           onChange={onChange}
@@ -1742,9 +1822,13 @@ function RecordField({
   // Delegate to a registered widget if the form spec asked for one
   // explicitly (e.g. `widget: 'airtable'`). The widget owns the entire UI.
   if (widget) {
-    const Renderer = WIDGETS[widget];
+    const Renderer = WIDGETS[widget as RegisteredWidgetKey] as WidgetRenderer | undefined;
     if (Renderer) {
       return (
+        // Neither naming channel is handed down here: this delegation is nested
+        // INSIDE a `record` field that already rendered its own label above, and
+        // the widget replaces the record editor rather than being that field's
+        // control. Unchanged by objectui#4871 — measured and left alone.
         <Renderer
           schema={schema}
           value={value}

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.widgetLabelling.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.widgetLabelling.test.tsx
@@ -1,0 +1,339 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4871 — metadata-admin's `WIDGETS` registry gains a labelling
+ * declaration, and `SchemaForm` emits the channel it dictates.
+ *
+ * ## What was measured
+ *
+ * `MetadataField` wrote `<Label htmlFor={id}>` for EVERY field and handed the
+ * same `id` down, on the convention "the wrapped control carries it". Probed on
+ * real `SchemaForm` renders at `167ec42e7` — every registry key, both the
+ * editable and the read-only state, three columns each (does the host `for`
+ * resolve, and to a LABELABLE element / is the rendered face labelable at all /
+ * does the group have an accessible name):
+ *
+ * ```
+ *                     editable                              read-only
+ * ref:object          for=RESOLVES-LABELABLE  button        for=RESOLVES-LABELABLE  button
+ * filter-mode         for=DANGLING  hostIdEl=NONE           for=DANGLING  hostIdEl=NONE
+ * field-multi         for=RESOLVES-LABELABLE  button        for=DANGLING  hostIdEl=NONE   <-
+ * action-multi        for=RESOLVES-LABELABLE  button        for=DANGLING  hostIdEl=NONE   <-
+ * filter-builder      for=DANGLING  hostIdEl=NONE           for=DANGLING  hostIdEl=NONE
+ * color-picker/enum   for=DANGLING  group name="Probe"      for=DANGLING  group name="Probe"
+ * color-picker/free   for=DANGLING  hostIdEl=NONE           for=DANGLING  hostIdEl=NONE
+ * condition           for=DANGLING  hostIdEl=NONE           for=DANGLING  hostIdEl=NONE
+ * master-detail       for=DANGLING  hostIdEl=NONE           for=DANGLING  hostIdEl=NONE
+ * multiselect         for=DANGLING  group name=""           for=DANGLING  group name=""
+ * code                for=DANGLING  hostIdEl=NONE           for=DANGLING  hostIdEl=NONE
+ * dynamic-config      for=DANGLING  hostIdEl=NONE           for=DANGLING  hostIdEl=NONE
+ * …(the remaining keys resolved to a labelable element in both states)
+ * ```
+ *
+ * Two readings decided the shape of the fix:
+ *
+ *  - `hostIdEl=NONE` on eight keys — the `for` pointed at an id NO element in
+ *    the document carried. A dangling IDREF is worse than a missing one: tooling
+ *    reports an association that resolves to nothing, so it reads as closed;
+ *  - the rows marked `<-`: `field-multi` / `action-multi` were labelable in ONE
+ *    state. The element that carried the id — an auxiliary "add" picker — is
+ *    gated behind `!readOnly`. A declaration that is conditionally true is
+ *    exactly the runtime inference the #4871 ruling removed from `color-picker`,
+ *    so those two are `'group'`, not `'control'`.
+ *
+ * ## What this file pins
+ *
+ * The ledger's three columns, re-measured through the same real renders and
+ * asserted against each widget's DECLARATION rather than against a hand-listed
+ * expectation — so the table in `widgets.tsx` and the DOM cannot drift apart.
+ * A `'group'` case asserts the named surface EXISTS and answers the IDREF, not
+ * merely that the `for` is gone: "no dangling `for`" is also true of a widget
+ * that renders nothing, and that green would mean nothing.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { SchemaForm, type FormFieldSpec } from './SchemaForm';
+import {
+  WIDGETS,
+  WIDGET_LABELLING,
+  widgetLabelling,
+  colorPaletteOptions,
+  resolveColorWidgetKey,
+  type RegisteredWidgetKey,
+  type WidgetContext,
+} from './widgets';
+
+afterEach(cleanup);
+
+/** The HTML elements a `<label for>` can actually address. */
+const LABELABLE = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'METER', 'OUTPUT', 'PROGRESS']);
+
+// `prettify('probe') === 'Probe'`, so `MetadataField` renders no machine-name
+// `<code>` inside the label and the accessible name is the visible text alone.
+const NAME = 'probe';
+const HOST_ID = `mdf-${NAME}`;
+const LABEL_ID = `${HOST_ID}-label`;
+const TITLE = 'Probe';
+
+type Case = {
+  key: RegisteredWidgetKey;
+  variant?: string;
+  schema: Record<string, unknown>;
+  /**
+   * Extra `FormFieldSpec` keys. Loosely typed because two of these widgets read
+   * `fieldSpec.dependsOn`, which `FormFieldSpec` does not declare — a real
+   * producer/consumer gap, filed separately rather than papered over here.
+   */
+  spec?: Record<string, unknown>;
+  ctx?: WidgetContext;
+  value?: unknown;
+  formData?: Record<string, unknown>;
+};
+
+function renderCase(c: Case, readOnly: boolean) {
+  const spec = { field: NAME, widget: c.key, ...c.spec } as FormFieldSpec;
+  const properties: Record<string, unknown> = { [NAME]: c.schema };
+  for (const k of Object.keys(c.formData ?? {})) properties[k] = { type: 'string' };
+  return render(
+    <SchemaForm
+      schema={{ type: 'object', properties } as never}
+      form={{ type: 'simple', sections: [{ label: 'S', fields: [spec] }] } as never}
+      value={{ [NAME]: c.value, ...(c.formData ?? {}) }}
+      onChange={() => {}}
+      readOnly={readOnly}
+      widgetContext={c.ctx}
+    />,
+  );
+}
+
+/**
+ * One probe case per registry key (plus the branch variants that made the old
+ * single `color-picker` entry conditional, and `multiselect`'s option-less
+ * degradation). Every key of `WIDGETS` must appear — asserted below, so a widget
+ * added without a probe fails here as well as at the declaration.
+ */
+const CASES: Case[] = [
+  { key: 'ref:object', schema: { type: 'string', title: TITLE }, ctx: { objectNames: ['account'] }, value: 'account' },
+  { key: 'ref:object', variant: 'no-objects', schema: { type: 'string', title: TITLE }, ctx: {}, value: 'x' },
+  { key: 'ref:component', schema: { type: 'string', title: TITLE }, ctx: { componentIds: [{ id: 'c1' }] }, value: 'c1' },
+  { key: 'ref:component', variant: 'no-components', schema: { type: 'string', title: TITLE }, ctx: {}, value: 'c1' },
+  { key: 'filter-mode', schema: { type: 'object', title: TITLE }, ctx: { objectFields: [{ name: 'status' }] }, value: { element: 'dropdown' } },
+  { key: 'object-selector', schema: { type: 'string', title: TITLE }, ctx: { objectNames: ['account'] }, value: 'account' },
+  { key: 'object-selector', variant: 'multiple', schema: { type: 'array', title: TITLE }, spec: { multiple: true }, ctx: { objectNames: ['account', 'contact'] }, value: ['account'] },
+  { key: 'field-selector', schema: { type: 'string', title: TITLE }, spec: { dependsOn: 'objectName' }, formData: { objectName: '' }, value: '' },
+  { key: 'field-ref', schema: { type: 'string', title: TITLE }, ctx: { objectFields: [{ name: 'status' }] }, value: 'status' },
+  { key: 'field-multi', schema: { type: 'array', title: TITLE }, ctx: { objectFields: [{ name: 'status' }, { name: 'owner' }] }, value: ['status'] },
+  { key: 'action-multi', schema: { type: 'array', title: TITLE }, ctx: { objectActions: [{ name: 'approve' }, { name: 'reject' }] }, value: ['approve'] },
+  { key: 'filter-builder', schema: { type: 'array', title: TITLE }, ctx: { objectFields: [{ name: 'status' }] }, value: [] },
+  { key: 'view-ref', schema: { type: 'string', title: TITLE }, ctx: { objectViews: [{ name: 'all' }] }, value: 'all' },
+  { key: 'icon', schema: { type: 'string', title: TITLE }, value: 'check' },
+  { key: 'color-picker', schema: { type: 'string', title: TITLE, enum: ['default', 'blue'] }, value: 'blue' },
+  { key: 'color-input', schema: { type: 'string', title: TITLE }, value: '#112233' },
+  { key: 'condition', schema: { type: 'string', title: TITLE }, value: 'a == 1' },
+  { key: 'master-detail', schema: { type: 'array', title: TITLE, items: { type: 'object', properties: { name: { type: 'string' } } } }, value: [{ name: 'a' }] },
+  { key: 'master-detail', variant: 'untyped-items', schema: { type: 'array', title: TITLE, items: {} }, value: [] },
+  { key: 'string-tags', schema: { type: 'array', title: TITLE, items: { type: 'string' } }, value: ['a'] },
+  { key: 'multiselect', schema: { type: 'array', title: TITLE, items: { type: 'string', enum: ['grid', 'kanban'] } }, value: ['grid'] },
+  { key: 'multiselect', variant: 'no-options', schema: { type: 'array', title: TITLE, items: { type: 'string' } }, value: ['a'] },
+  { key: 'code', schema: { type: 'string', title: TITLE }, spec: { language: 'javascript' }, value: 'x = 1' },
+  { key: 'secret', schema: { type: 'string', title: TITLE }, value: 's3cr3t' },
+  { key: 'dynamic-config', schema: { type: 'object', title: TITLE }, spec: { dependsOn: 'driver' }, formData: { driver: 'pg' }, ctx: { dynamicSchemas: { pg: { properties: { host: { type: 'string' } } } } }, value: {} },
+  { key: 'dynamic-config', variant: 'unconfigured', schema: { type: 'object', title: TITLE }, spec: { dependsOn: 'driver' }, formData: { driver: '' }, value: {} },
+];
+
+describe('registered ⇒ declared (objectui#4871 / #4857 registry gate)', () => {
+  // The compile-time half is `WIDGET_LABELLING`'s `Record<RegisteredWidgetKey, …>`
+  // type: registering a widget without a labelling decision does not compile.
+  // These runtime assertions guard the SHAPE that makes it work — re-annotating
+  // `WIDGETS` as `Record<string, WidgetRenderer>` would silently dissolve the
+  // literal key union and with it the compile error, while leaving both objects
+  // looking correct.
+  it('declares exactly the registered keys, no more and no fewer', () => {
+    expect(Object.keys(WIDGET_LABELLING).sort()).toEqual(Object.keys(WIDGETS).sort());
+  });
+
+  it('declares only the repo-wide vocabulary', () => {
+    for (const [key, value] of Object.entries(WIDGET_LABELLING)) {
+      expect(['control', 'group'], `${key} declares an unknown labelling`).toContain(value);
+    }
+  });
+
+  it('resolves an UNREGISTERED widget name to the control path', () => {
+    // Passthrough hints (`text`, `json`) and third-party names keep exactly the
+    // pre-declaration behaviour: a plain `<label for>`.
+    expect(widgetLabelling('json')).toBe('control');
+    expect(widgetLabelling('not-a-widget')).toBe('control');
+    expect(widgetLabelling(undefined)).toBe('control');
+  });
+
+  it('probes every registered key', () => {
+    expect([...new Set(CASES.map((c) => c.key))].sort()).toEqual(Object.keys(WIDGETS).sort());
+  });
+});
+
+describe('the ledger, re-measured: every widget gets the channel it declares', () => {
+  for (const c of CASES) {
+    const tag = `${c.key}${c.variant ? ` (${c.variant})` : ''}`;
+    const declared = WIDGET_LABELLING[c.key];
+
+    for (const readOnly of [false, true]) {
+      const state = readOnly ? 'read-only' : 'editable';
+
+      it(`${tag} — ${declared}, ${state}`, () => {
+        renderCase(c, readOnly);
+        const label = screen.getByText(TITLE);
+        expect(label.tagName).toBe('LABEL');
+
+        if (declared === 'control') {
+          // Column 1: the `for` resolves, AND to a LABELABLE element. Splitting
+          // those apart is the point — "the id is on SOME element" is the
+          // deceptive green that a half-fix (id parked on a container) produces.
+          expect(label).toHaveAttribute('for', HOST_ID);
+          expect(label).not.toHaveAttribute('id');
+          const target = document.getElementById(HOST_ID);
+          expect(target, `${tag}: host id is on no element in the ${state} state`).not.toBeNull();
+          expect(
+            LABELABLE.has(target!.tagName),
+            `${tag}: host id landed on <${target!.tagName.toLowerCase()}>, which no <label for> can address`,
+          ).toBe(true);
+          // Column 3: the named surface IS that control, and it is named by the
+          // visible label rather than by some self-owned string.
+          expect(target).toHaveAccessibleName(TITLE);
+          return;
+        }
+
+        // `'group'`. Column 1: no `for` at all — not a `for` pointing somewhere
+        // harmless. On a container it activates nothing and names nothing, and
+        // beside the working IDREF it is a second, broken channel (#3978/#4010).
+        expect(label).not.toHaveAttribute('for');
+        expect(label).toHaveAttribute('id', LABEL_ID);
+        expect(document.getElementById(HOST_ID)).toBeNull();
+
+        // Columns 2 + 3: the face EXISTS, answers the IDREF, and is a group.
+        // Asserted positively on purpose — a widget that rendered nothing would
+        // satisfy every "is absent" assertion above.
+        const named = document.querySelector(`[aria-labelledby="${LABEL_ID}"]`);
+        expect(named, `${tag}: nothing answers the host label's IDREF in the ${state} state`).not.toBeNull();
+        expect(['group', 'radiogroup']).toContain(named!.getAttribute('role'));
+        expect(named).toHaveAccessibleName(TITLE);
+      });
+    }
+  }
+});
+
+describe('the two colour registrations (ruling point 4 — the host picks, not the widget)', () => {
+  it('routes a declared palette to the radiogroup registration', () => {
+    expect(resolveColorWidgetKey({ type: 'string', enum: ['default', 'blue'] }, undefined)).toBe('color-picker');
+    // `fieldSpec.options` takes precedence over `schema.enum`, as the widget's
+    // own palette lookup always did.
+    expect(
+      resolveColorWidgetKey({ type: 'string' }, { field: 'c', options: [{ label: 'Blue', value: 'blue' }] }),
+    ).toBe('color-picker');
+  });
+
+  it('routes a free colour to the input registration — including the near-misses', () => {
+    expect(resolveColorWidgetKey({ type: 'string' }, undefined)).toBe('color-input');
+    // An `enum` present but empty, and an `enum` of non-strings, both left the
+    // OLD single widget on its free-colour branch. Host and widget read the same
+    // palette function, so they cannot disagree about which surface renders.
+    expect(resolveColorWidgetKey({ type: 'string', enum: [] }, undefined)).toBe('color-input');
+    expect(resolveColorWidgetKey({ type: 'string', enum: [1, 2] }, undefined)).toBe('color-input');
+    expect(colorPaletteOptions({ type: 'string', enum: [1, 2] }, undefined)).toEqual([]);
+  });
+
+  it('re-routes an AUTHORED `widget: color-picker` on a free-colour field', () => {
+    // A spec that pins the palette registration on a field with no palette must
+    // still land on the surface that actually renders — otherwise the
+    // declaration would describe a different DOM than the one on screen, which
+    // is the whole failure this split removes.
+    render(
+      <SchemaForm
+        schema={{ type: 'object', properties: { [NAME]: { type: 'string', title: TITLE } } } as never}
+        form={{ type: 'simple', sections: [{ label: 'S', fields: [{ field: NAME, widget: 'color-picker' }] }] } as never}
+        value={{ [NAME]: '#112233' }}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByRole('radiogroup')).toBeNull();
+    const native = document.querySelector('input[type="color"]');
+    expect(native).toHaveAttribute('id', HOST_ID);
+    expect(screen.getByText(TITLE)).toHaveAttribute('for', HOST_ID);
+  });
+
+  it('keeps the swatch group self-named when rendered with no host label', () => {
+    // The `ariaLabel` arm of `ColorVariantPickerNaming` (objectui#4010). Reached
+    // by any caller that renders a registry widget directly — the shape
+    // `IconPickerWidget.test.tsx` / `SecretWidget.test.tsx` already use — where
+    // there is no visible label in a position to publish an id.
+    const Swatches = WIDGETS['color-picker'];
+    render(
+      <Swatches
+        schema={{ type: 'string', title: 'Badge Tone', enum: ['default', 'blue'] }}
+        value="blue"
+        onChange={() => {}}
+      />,
+    );
+    const group = screen.getByRole('radiogroup');
+    expect(group).toHaveAccessibleName('Badge Tone');
+    expect(group).not.toHaveAttribute('aria-labelledby');
+  });
+});
+
+describe('the two channels name a field identically', () => {
+  // The accessible name comes from the SAME visible label either way — via `for`
+  // on the control path, via `aria-labelledby` on the group path. Pinned on a
+  // field whose machine name IS shown (`prettify('colorVariant')` is "Color
+  // Variant", so a title of "Tone" makes `MetadataField` append a `<code>`
+  // inside the label), because that is the case where the two computations could
+  // plausibly diverge: both must read the label's whole subtree, not its first
+  // text node. The two names are compared to EACH OTHER rather than to a
+  // hand-spelled string — the claim is parity, and a literal would only pin
+  // whichever channel the author looked at first.
+  const field = 'colorVariant';
+  const renderWith = (schema: Record<string, unknown>) =>
+    render(
+      <SchemaForm
+        schema={{ type: 'object', properties: { [field]: schema } } as never}
+        form={{ type: 'simple', sections: [{ label: 'S', fields: [{ field }] }] } as never}
+        value={{ [field]: schema.enum ? 'blue' : '#112233' }}
+        onChange={() => {}}
+      />,
+    );
+
+  it('both channels resolve to the same visible label element', () => {
+    // Group path — the enum branch. The IDREF names the label.
+    const { container: groupTree } = renderWith({ type: 'string', title: 'Tone', enum: ['default', 'blue'] });
+    const group = screen.getByRole('radiogroup');
+    const groupLabel = document.getElementById(group.getAttribute('aria-labelledby')!)!;
+    expect(groupLabel).toBe(within(groupTree).getByText('Tone').closest('label'));
+    cleanup();
+
+    // Control path — the same field with no palette. The `for` names the label.
+    const { container: controlTree } = renderWith({ type: 'string', title: 'Tone' });
+    const native = document.querySelector('input[type="color"]') as HTMLInputElement;
+    const controlLabel = document.querySelector(`label[for="${native.id}"]`)!;
+    expect(controlLabel).toBe(within(controlTree).getByText('Tone').closest('label'));
+
+    // Same rendered text on both paths, machine-name `<code>` and all — so the
+    // channel a field takes cannot change what it is called.
+    expect(groupLabel.textContent).toBe(controlLabel.textContent);
+    expect(groupLabel.textContent).toContain('Tone');
+    expect(groupLabel.textContent).toContain(field);
+  });
+
+  it('and the accessibility tree agrees — each surface is findable BY that name', () => {
+    // The check above says the two channels point at ONE label; this says the
+    // computed accessible name follows, which is what a user actually gets.
+    renderWith({ type: 'string', title: 'Tone', enum: ['default', 'blue'] });
+    expect(screen.getByRole('radiogroup', { name: /Tone/ })).toBeInTheDocument();
+    cleanup();
+
+    renderWith({ type: 'string', title: 'Tone' });
+    expect(document.querySelector('input[type="color"]')).toHaveAccessibleName(
+      // The visible label verbatim: title + the machine name `MetadataField`
+      // appends when the two differ.
+      `Tone ${field}`,
+    );
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.widgetLabelling.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.widgetLabelling.test.tsx
@@ -6,7 +6,7 @@
  *
  * ## What was measured
  *
- * `MetadataField` wrote `<Label htmlFor={id}>` for EVERY field and handed the
+ * `FieldRow` wrote `<Label htmlFor={id}>` for EVERY field and handed the
  * same `id` down, on the convention "the wrapped control carries it". Probed on
  * real `SchemaForm` renders at `167ec42e7` — every registry key, both the
  * editable and the read-only state, three columns each (does the host `for`
@@ -69,7 +69,7 @@ afterEach(cleanup);
 /** The HTML elements a `<label for>` can actually address. */
 const LABELABLE = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'METER', 'OUTPUT', 'PROGRESS']);
 
-// `prettify('probe') === 'Probe'`, so `MetadataField` renders no machine-name
+// `prettify('probe') === 'Probe'`, so `FieldRow` renders no machine-name
 // `<code>` inside the label and the accessible name is the visible text alone.
 const NAME = 'probe';
 const HOST_ID = `mdf-${NAME}`;
@@ -284,7 +284,7 @@ describe('the two channels name a field identically', () => {
   // The accessible name comes from the SAME visible label either way — via `for`
   // on the control path, via `aria-labelledby` on the group path. Pinned on a
   // field whose machine name IS shown (`prettify('colorVariant')` is "Color
-  // Variant", so a title of "Tone" makes `MetadataField` append a `<code>`
+  // Variant", so a title of "Tone" makes `FieldRow` append a `<code>`
   // inside the label), because that is the case where the two computations could
   // plausibly diverge: both must read the label's whole subtree, not its first
   // text node. The two names are compared to EACH OTHER rather than to a
@@ -331,7 +331,7 @@ describe('the two channels name a field identically', () => {
 
     renderWith({ type: 'string', title: 'Tone' });
     expect(document.querySelector('input[type="color"]')).toHaveAccessibleName(
-      // The visible label verbatim: title + the machine name `MetadataField`
+      // The visible label verbatim: title + the machine name `FieldRow`
       // appends when the two differ.
       `Tone ${field}`,
     );

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -938,6 +938,10 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.form.removeRow': 'Remove row',
   'engine.form.dragToReorder': 'Drag to reorder',
   'engine.form.arrayPlaceholder': 'comma, separated, values',
+  // Accessible name for the hex mirror beside the native colour picker. The
+  // picker itself is named by the field's visible label (objectui#4871); this
+  // second input edits the same value and needs a name of its own.
+  'engine.form.colorHex': 'Hex value',
   'engine.form.loadingObjects': 'Loading objects…',
   'engine.form.noObjects': 'object_name (no objects detected)',
   'engine.form.selectObject': 'Select object…',
@@ -2728,6 +2732,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.form.removeRow': '删除行',
   'engine.form.dragToReorder': '拖动排序',
   'engine.form.arrayPlaceholder': '用逗号分隔多个值',
+  'engine.form.colorHex': '十六进制值',
   'engine.form.loadingObjects': '正在加载对象…',
   'engine.form.noObjects': 'object_name（未检测到对象）',
   'engine.form.selectObject': '选择对象…',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
@@ -30,7 +30,7 @@ import {
   SelectValue,
 } from '@object-ui/components';
 import type { DashboardWidgetSchema } from '@object-ui/types';
-import { resolveDashboardFilterDefs, type DashboardFilterDef } from '@object-ui/core';
+import { resolveDashboardFilterDefs, type DashboardFilterDef, type ComponentMeta } from '@object-ui/core';
 import type { MetadataInspectorProps } from '../inspector-registry';
 import { t, tFormat } from '../i18n';
 // The spec's `I18nLabel` resolver (new in @objectstack/spec 17.0.0-rc.6),
@@ -528,8 +528,17 @@ function Field({
    *    carries) it is a DANGLING IDREF — tooling reports an association that
    *    resolves to nothing, which is worse than an unnamed control because it
    *    reads as closed. That was objectui#4010's defect on `widget-color`.
+   *
+   * DERIVED from the repo-wide vocabulary, not a restatement of it: the 2026-08-17
+   * ruling (objectui#4857 + objectui#4871) made `ComponentMeta['labelling']` the
+   * single answer to "how does a host learn what a widget will render" and
+   * forbade host-local variants. `'display'` is excluded because this panel has
+   * no such field — every one of its children is an editable control or a
+   * container of them — and because it has no display CHANNEL to route one to;
+   * introducing one is a compile error here rather than a silent degradation.
+   * Re-spell a member in `packages/core` and this type stops compiling.
    */
-  labelling?: 'control' | 'group';
+  labelling?: Exclude<NonNullable<ComponentMeta['labelling']>, 'display'>;
   children: React.ReactNode;
 }) {
   const group = labelling === 'group';

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -41,6 +41,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@object-ui/components';
+import type { ComponentMeta } from '@object-ui/core';
 import { ChevronDown, ChevronsUpDown, ChevronUp, Eye, EyeOff, Plus, Search, Trash2 } from 'lucide-react';
 import { iconNames } from 'lucide-react/dynamic.mjs';
 import { toast } from 'sonner';
@@ -99,7 +100,26 @@ export interface WidgetContext {
 }
 
 export interface WidgetProps {
+  /**
+   * The host field id, handed down ONLY to a widget declared
+   * `labelling: 'control'` in {@link WIDGET_LABELLING} — the host's
+   * `<Label htmlFor>` points at it, so the widget must put it on the LABELABLE
+   * element that is the field's primary control (objectui#4871).
+   *
+   * A `'group'` widget receives `undefined` here on purpose: `<label for>` is
+   * inert on a container, and taking the id anyway would make the IDREF resolve
+   * while still naming nobody — the cosmetic half-fix objectui#4010 refused.
+   */
   id?: string;
+  /**
+   * The host label's own `id`, handed down ONLY to a widget declared
+   * `labelling: 'group'`. The widget answers it with `aria-labelledby` on the
+   * surface that IS the field (a `role="group"` / `role="radiogroup"`
+   * container), which is the one naming channel that works on a non-labelable
+   * element. `undefined` for `'control'` widgets — one label, one channel
+   * (objectui#3978).
+   */
+  ariaLabelledBy?: string;
   schema: Record<string, any>;
   value: unknown;
   onChange: (v: unknown) => void;
@@ -552,6 +572,7 @@ function MasterDetailWidget({
   onChange,
   readOnly,
   context,
+  ariaLabelledBy,
 }: WidgetProps) {
   const locale = useMetadataLocale();
   // Unwrap anyOf/oneOf: pick the first array-of-object branch.
@@ -574,7 +595,11 @@ function MasterDetailWidget({
   if (cols.length === 0) {
     // Falls back to JSON if the array items aren't a typed object.
     return (
-      <div className="rounded border border-dashed border-amber-500/40 bg-amber-500/5 p-2 text-xs text-amber-700 dark:text-amber-300">
+      <div
+        role="group"
+        aria-labelledby={ariaLabelledBy}
+        className="rounded border border-dashed border-amber-500/40 bg-amber-500/5 p-2 text-xs text-amber-700 dark:text-amber-300"
+      >
         {t('engine.form.masterDetailSchemaError', locale)}
       </div>
     );
@@ -595,7 +620,11 @@ function MasterDetailWidget({
   }
 
   return (
-    <div className="space-y-2">
+    // A table of per-cell inputs plus row actions — a composite, so the host's
+    // visible label names this container by IDREF (objectui#4871). Same shape
+    // and same reason as `grid`'s `labelling: 'group'` in packages/fields
+    // (objectui#4857): no `<label for>` can reach a table.
+    <div className="space-y-2" role="group" aria-labelledby={ariaLabelledBy}>
       <div className="overflow-x-auto rounded border border-border/40">
         <table className="w-full text-sm">
           <thead className="bg-muted/40">
@@ -860,7 +889,7 @@ function humanizeOption(v: string): string {
  * free-text tag input the generic array renderer fell back to — the author
  * picks from the real allowed values instead of typing (and mistyping) them.
  */
-function MultiSelectWidget({ value, onChange, readOnly, schema, fieldSpec }: WidgetProps) {
+function MultiSelectWidget({ value, onChange, readOnly, schema, fieldSpec, ariaLabelledBy }: WidgetProps) {
   // Prefer explicit form options; else the JSON Schema enum on the items.
   const options: Array<{ label: string; value: string }> = React.useMemo(() => {
     if (Array.isArray(fieldSpec?.options) && fieldSpec!.options!.length) {
@@ -892,11 +921,22 @@ function MultiSelectWidget({ value, onChange, readOnly, schema, fieldSpec }: Wid
   if (options.length === 0) {
     // No known option set — degrade to the comma-tag editor so the field
     // is still editable rather than rendering an empty box.
-    return <StringTagsWidget value={value} onChange={onChange} readOnly={readOnly} schema={schema} fieldSpec={fieldSpec} />;
+    //
+    // The degradation stays INSIDE this widget's named group rather than
+    // handing the tag editor the host id: the declaration
+    // (`multiselect: 'group'`) is read by the host BEFORE the option list is
+    // known, so a fallback that changed naming channel would be exactly the
+    // runtime self-selection objectui#4871 removed from `color-picker`. The
+    // group is named; the tag input inside it is a sub-control.
+    return (
+      <div role="group" aria-labelledby={ariaLabelledBy}>
+        <StringTagsWidget value={value} onChange={onChange} readOnly={readOnly} schema={schema} fieldSpec={fieldSpec} />
+      </div>
+    );
   }
 
   return (
-    <div className="flex flex-wrap gap-1.5" role="group">
+    <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby={ariaLabelledBy}>
       {options.map((o) => {
         const on = selected.includes(o.value);
         return (
@@ -1061,7 +1101,7 @@ function ViewRefWidget({ id, value, onChange, readOnly, context }: WidgetProps) 
  * `yAxisFields`, `searchableFields`, …). Preserves order; supports reorder
  * and removal; values outside the catalog are retained.
  */
-function FieldRefMultiWidget({ id, value, onChange, readOnly, context }: WidgetProps) {
+function FieldRefMultiWidget({ value, onChange, readOnly, context, ariaLabelledBy }: WidgetProps) {
   const locale = useMetadataLocale();
   const fields = context?.objectFields ?? [];
   const selected: string[] = Array.isArray(value)
@@ -1089,7 +1129,13 @@ function FieldRefMultiWidget({ id, value, onChange, readOnly, context }: WidgetP
   };
 
   return (
-    <div className="space-y-2">
+    // An ORDERED SET, not a single control: reorder/remove buttons per chip plus
+    // an auxiliary "add" picker. Measured for objectui#4871's ledger — the add
+    // picker (the only element that ever carried the host id) is gated behind
+    // `!readOnly`, so a `control` declaration was true in the editable state and
+    // DANGLING in the read-only one. A declaration that is conditionally true is
+    // the shape the #4871 ruling removed, so the whole set is the named surface.
+    <div className="space-y-2" role="group" aria-labelledby={ariaLabelledBy}>
       {selected.length > 0 && (
         <div className="space-y-1">
           {selected.map((name, i) => (
@@ -1137,7 +1183,11 @@ function FieldRefMultiWidget({ id, value, onChange, readOnly, context }: WidgetP
       )}
       {!readOnly && (
         <Select value="" onValueChange={add} disabled={remaining.length === 0}>
-          <SelectTrigger id={id}>
+          {/* No host id here: the group above is the named surface, and an id
+              on this auxiliary trigger would make the host's `for` resolve to
+              "add a field" — a label click would open the picker rather than
+              name the set (objectui#4871, the #4857 `grid` reading). */}
+          <SelectTrigger aria-label={t('engine.form.addField', locale)}>
             <SelectValue
               placeholder={
                 fields.length
@@ -1368,7 +1418,7 @@ const FILTER_MODES: Array<{ key: 'none' | UFMode; label: string }> = [
 const slugifyTabName = (s: string): string =>
   (s || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'tab';
 
-function FilterModeWidget({ value, onChange, readOnly, context }: WidgetProps) {
+function FilterModeWidget({ value, onChange, readOnly, context, ariaLabelledBy }: WidgetProps) {
   const uf = (value && typeof value === 'object' ? value : undefined) as UFValue | undefined;
   const mode: 'none' | UFElement = uf?.element ?? (uf ? 'dropdown' : 'none');
   const objectFields = context?.objectFields ?? [];
@@ -1445,7 +1495,11 @@ function FilterModeWidget({ value, onChange, readOnly, context }: WidgetProps) {
   const setShowAllRecords = (c: boolean) => onChange({ ...(uf ?? {}), element: 'tabs', showAllRecords: c });
 
   return (
-    <div className="space-y-3">
+    // The host's visible label names this whole editor (mode choice + the field
+    // / tab pickers that follow), by IDREF — objectui#4871. The inner
+    // radiogroup keeps its OWN name: it is a sub-choice ("which element"), not
+    // the field, and the two names are about different things.
+    <div className="space-y-3" role="group" aria-labelledby={ariaLabelledBy}>
       {/* Segmented mode selector */}
       <div className="inline-flex rounded-md border border-input bg-background p-0.5" role="radiogroup" aria-label="Filter element">
         {FILTER_MODES.map((m) => {
@@ -1608,7 +1662,7 @@ function FilterModeWidget({ value, onChange, readOnly, context }: WidgetProps) {
 /* This makes "buttons = object actions" correct-by-construction (the picker  */
 /* only offers actions the object actually defines).                          */
 /* -------------------------------------------------------------------------- */
-function ActionMultiWidget({ id, value, onChange, readOnly, context }: WidgetProps) {
+function ActionMultiWidget({ value, onChange, readOnly, context, ariaLabelledBy }: WidgetProps) {
   const actions = context?.objectActions ?? [];
   const selected: string[] = Array.isArray(value)
     ? value.map(String)
@@ -1629,7 +1683,10 @@ function ActionMultiWidget({ id, value, onChange, readOnly, context }: WidgetPro
   };
 
   return (
-    <div className="space-y-2" data-testid="action-multi">
+    // Same ordered-set shape as {@link FieldRefMultiWidget}, and the same
+    // measured reason for `labelling: 'group'` (objectui#4871): the add trigger
+    // that used to carry the host id disappears in the read-only state.
+    <div className="space-y-2" data-testid="action-multi" role="group" aria-labelledby={ariaLabelledBy}>
       {selected.length > 0 && (
         <div className="space-y-1">
           {selected.map((name, i) => (
@@ -1651,7 +1708,8 @@ function ActionMultiWidget({ id, value, onChange, readOnly, context }: WidgetPro
       )}
       {!readOnly && (
         <Select value="" onValueChange={add} disabled={remaining.length === 0}>
-          <SelectTrigger id={id} data-testid="action-multi-add">
+          {/* No host id — see {@link FieldRefMultiWidget}'s add trigger. */}
+          <SelectTrigger data-testid="action-multi-add" aria-label="Add action button">
             <SelectValue placeholder={actions.length ? (remaining.length ? '+ Add action button…' : 'All actions added') : 'Bind a source object to pick actions'} />
           </SelectTrigger>
           <SelectContent>
@@ -1703,11 +1761,19 @@ const SPEC_TO_FB: Record<string, string> = {
 
 interface FilterRuleLite { field: string; operator: string; value?: unknown }
 
-function FilterBuilderField({ value, onChange, fields, readOnly }: {
+function FilterBuilderField({ value, onChange, fields, readOnly, id }: {
   value?: FilterRuleLite[];
   onChange: (rules: FilterRuleLite[]) => void;
   fields: Array<{ name: string; label?: string; type?: string }>;
   readOnly?: boolean;
+  /**
+   * Host field id, forwarded onto the trigger BUTTON — a labelable element, so
+   * the host's `<label for>` reaches it (objectui#4871). Only the standalone
+   * `filter-builder` widget passes one; the in-widget call site inside
+   * {@link FilterModeWidget}'s tab editor is a sub-control of a group and
+   * carries its own name instead.
+   */
+  id?: string;
 }) {
   // The metadata-admin `t` above is a static engine-string table; refusal
   // copy lives in the shared console locale packs, so it resolves through the
@@ -1745,7 +1811,7 @@ function FilterBuilderField({ value, onChange, fields, readOnly }: {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" disabled={readOnly}
+        <Button id={id} variant="outline" size="sm" disabled={readOnly}
           className="h-8 w-full justify-between text-xs font-normal" data-testid="filter-builder-trigger">
           <span className="truncate text-left">{summary || <span className="text-muted-foreground">+ Add filter…</span>}</span>
           <ChevronDown className="h-3.5 w-3.5 opacity-60 shrink-0" />
@@ -1762,9 +1828,13 @@ function FilterBuilderField({ value, onChange, fields, readOnly }: {
   );
 }
 
-function FilterBuilderWidget({ value, onChange, readOnly, context }: WidgetProps) {
+function FilterBuilderWidget({ id, value, onChange, readOnly, context }: WidgetProps) {
   return (
+    // The whole face is ONE labelable element — a popover trigger `<button>` —
+    // so this stays on the plain `<label for>` channel and simply stops dropping
+    // the id the host hands down (objectui#4871: measured DANGLING before).
     <FilterBuilderField
+      id={id}
       value={value as FilterRuleLite[] | undefined}
       onChange={(rules) => onChange(rules.length ? rules : undefined)}
       fields={context?.objectFields ?? []}
@@ -1774,64 +1844,114 @@ function FilterBuilderWidget({ value, onChange, readOnly, context }: WidgetProps
 }
 
 /* -------------------------------------------------------------------------- */
-/* color-picker — semantic swatch row (enum) or native hex input (free color) */
+/* color-picker / color-input — TWO registrations, picked by the HOST         */
 /* -------------------------------------------------------------------------- */
 
-function ColorPickerWidget({ value, onChange, readOnly, schema, fieldSpec }: WidgetProps) {
-  const enumOpts: Array<{ value: string; label?: string }> | null =
-    Array.isArray(fieldSpec?.options) && fieldSpec!.options!.length
-      ? fieldSpec!.options!.map((o) => ({ value: o.value, label: o.label }))
-      : Array.isArray(schema?.enum)
-        ? (schema!.enum as unknown[]).filter((v): v is string => typeof v === 'string').map((v) => ({ value: v }))
-        : null;
-
-  if (enumOpts && enumOpts.length) {
-    return (
-      <ColorVariantPicker
-        // Self-owned name, not the host label's IDREF (objectui#4010).
-        //
-        // `MetadataField` renders `<Label htmlFor={id}>` above this widget and
-        // hands it the same `id`. That works for a labelable control — the free
-        // colour branch below is one — but this branch renders a
-        // `div[role="radiogroup"]`, which no `<label for>` can name. The host
-        // cannot publish an `id` for us to reference instead, because WHICH of
-        // these two branches renders is decided HERE, from `schema`/`fieldSpec`,
-        // after that label is already written; teaching the host to decide it
-        // needs a `labelling` declaration per widget (the shape
-        // `packages/components`' form renderer already has, objectui#3961) and
-        // is filed as objectui#4871 rather than guessed at here.
-        //
-        // So the group carries its own name, exactly as this file's other
-        // unassociated groups do (`FilterModeWidget`'s segmented radiogroup,
-        // and the free-colour `<input type="color">` below). The text is the
-        // host's own first-precedence label source so the two agree wherever set —
-        // WCAG 2.5.3 (Label in Name) is about the visible text, not a generic
-        // stand-in — falling back to this file's existing constant.
-        ariaLabel={fieldSpec?.label ?? (typeof schema?.title === 'string' ? schema.title : undefined) ?? 'Color'}
-        value={value == null ? undefined : String(value)}
-        onChange={(v) => onChange(v)}
-        disabled={readOnly}
-        options={enumOpts}
-      />
-    );
+/**
+ * The semantic palette a colour field declares, or an EMPTY array when it
+ * declares none (objectui#4871).
+ *
+ * This is the split point of what used to be one `color-picker` widget with a
+ * runtime `if`. Both the host — which must know, BEFORE it writes the label,
+ * whether this field renders a `radiogroup` or a labelable input — and the
+ * widgets themselves read the palette through this one function, so producer
+ * and consumer cannot disagree about which surface will render. (Same discipline
+ * `packages/components`' `resolveFieldLabelling` follows against
+ * `renderFieldComponent`.)
+ */
+export function colorPaletteOptions(
+  schema: Record<string, unknown> | undefined,
+  fieldSpec: WidgetProps['fieldSpec'],
+): Array<{ value: string; label?: string }> {
+  if (Array.isArray(fieldSpec?.options) && fieldSpec!.options!.length) {
+    return fieldSpec!.options!.map((o) => ({ value: o.value, label: o.label }));
   }
+  if (Array.isArray(schema?.enum)) {
+    return (schema!.enum as unknown[])
+      .filter((v): v is string => typeof v === 'string')
+      .map((v) => ({ value: v }));
+  }
+  return [];
+}
 
-  // Free color → native picker + hex text.
+/**
+ * Which of the two colour registrations a field resolves to — `'color-picker'`
+ * (a declared palette ⇒ swatch `radiogroup`) or `'color-input'` (free colour ⇒
+ * native picker).
+ *
+ * The maintainer ruling of 2026-08-17 (objectui#4871, point 4) split the single
+ * conditional registration precisely so this choice happens in the HOST, from
+ * the schema, ahead of the label — passing both naming channels down for the
+ * widget to pick at runtime would have re-introduced the inference the ruling
+ * removes.
+ */
+export function resolveColorWidgetKey(
+  schema: Record<string, unknown> | undefined,
+  fieldSpec: WidgetProps['fieldSpec'],
+): 'color-picker' | 'color-input' {
+  return colorPaletteOptions(schema, fieldSpec).length > 0 ? 'color-picker' : 'color-input';
+}
+
+/**
+ * `color-picker` — a declared palette, rendered as a swatch `radiogroup`.
+ * `labelling: 'group'`: `role="radiogroup"` is a container, so the host's label
+ * publishes an id and this surface answers it by IDREF (objectui#4010 named the
+ * group; objectui#4871 is what finally removed the host's dangling `for`).
+ */
+function ColorSwatchGroupWidget({ value, onChange, readOnly, schema, fieldSpec, ariaLabelledBy }: WidgetProps) {
+  // Exactly one naming channel, chosen by which one the caller can supply
+  // (`ColorVariantPickerNaming` makes that a type-level XOR, objectui#4010):
+  // `SchemaForm` publishes a label id and takes the IDREF arm; a caller that
+  // renders this widget standalone — with no visible label in a position to
+  // publish an id — falls to the self-owned name, kept equal to the visible
+  // text wherever there is one (WCAG 2.5.3).
+  const naming = ariaLabelledBy
+    ? ({ ariaLabelledBy } as const)
+    : ({
+        ariaLabel:
+          fieldSpec?.label ?? (typeof schema?.title === 'string' ? schema.title : undefined) ?? 'Color',
+      } as const);
+  return (
+    <ColorVariantPicker
+      {...naming}
+      value={value == null ? undefined : String(value)}
+      onChange={(v) => onChange(v)}
+      disabled={readOnly}
+      options={colorPaletteOptions(schema, fieldSpec)}
+    />
+  );
+}
+
+/**
+ * `color-input` — free colour, rendered as the native picker plus a hex mirror.
+ * `labelling: 'control'`: `input[type="color"]` IS a labelable element and is
+ * the field's primary control, so it takes the host id and the plain
+ * `<label for>` names it. The hex box beside it edits the same value and carries
+ * its own name — before objectui#4871 it had none at all.
+ */
+function ColorInputWidget({ id, value, onChange, readOnly }: WidgetProps) {
+  const locale = useMetadataLocale();
   const v = value == null ? '' : String(value);
   return (
     <div className="flex items-center gap-2">
       <input
+        id={id}
         type="color"
         value={/^#([0-9a-f]{6})$/i.test(v) ? v : '#000000'}
         disabled={readOnly}
         onChange={(e) => onChange(e.target.value)}
         className="h-8 w-10 shrink-0 rounded border border-input bg-background p-0.5 disabled:opacity-60"
-        aria-label="Color"
+        // No `aria-label` beside the host's `<label for>`: an `aria-label` WINS
+        // the accessible-name computation, so keeping the old constant here
+        // would have overridden the field's visible label with "Color" — one
+        // label, two channels, the broken one louder (objectui#3978).
+        aria-label={id ? undefined : 'Color'}
       />
       <Input
         value={v}
         placeholder="#RRGGBB"
         disabled={readOnly}
+        aria-label={t('engine.form.colorHex', locale)}
         onChange={(e) => onChange(e.target.value || undefined)}
         className="h-8 text-sm font-mono"
       />
@@ -1853,14 +1973,20 @@ function ColorPickerWidget({ value, onChange, readOnly, schema, fieldSpec }: Wid
  * pair is shape-preserving, so the plain-`string` predicate fields this widget
  * also serves keep round-tripping as strings.
  */
-function ConditionWidget({ value, onChange, readOnly, context }: WidgetProps) {
+function ConditionWidget({ value, onChange, readOnly, context, ariaLabelledBy }: WidgetProps) {
   return (
-    <ConditionBuilder
-      value={expressionSource(value)}
-      onCommit={(cel) => onChange(writeExpressionSource(value, cel))}
-      fields={context?.objectFields}
-      disabled={readOnly}
-    />
+    // `ConditionBuilder` is a multi-control composite (field / operator / value
+    // rows plus add-condition buttons) shared with the curated inspectors, so
+    // the naming wrapper lives HERE — the widget owns the host contract, the
+    // shared builder stays host-agnostic (objectui#4871).
+    <div role="group" aria-labelledby={ariaLabelledBy}>
+      <ConditionBuilder
+        value={expressionSource(value)}
+        onCommit={(cel) => onChange(writeExpressionSource(value, cel))}
+        fields={context?.objectFields}
+        disabled={readOnly}
+      />
+    </div>
   );
 }
 
@@ -1923,7 +2049,14 @@ function SecretWidget({ value, onChange, readOnly, schema, id }: WidgetProps) {
         placeholder={stored ? (schema?.description ? '•••••••• set — type to replace' : '•••••••• set — leave blank to keep') : (typeof schema?.description === 'string' ? '' : 'Enter a value')}
         onChange={(e) => update(e.target.value)}
         className="h-8 text-sm font-mono"
-        aria-label="Secret value"
+        // Same single-channel rule as `color-input`'s picker (objectui#4871):
+        // this widget declares `labelling: 'control'`, so when the host hands
+        // down an `id` its `<label for>` is the naming channel — and an
+        // `aria-label` here WINS the accessible-name computation, which had the
+        // visible field label ("API Key", "Client Secret") replaced by the
+        // constant "Secret value" on every SchemaForm render. Kept only for a
+        // caller that renders this widget with no host label at all.
+        aria-label={id ? undefined : 'Secret value'}
       />
       <Button type="button" variant="ghost" size="icon" className="h-8 w-8 shrink-0" disabled={readOnly} aria-label={reveal ? 'Hide value' : 'Reveal value'} onClick={() => setReveal((r) => !r)}>
         {reveal ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -1949,7 +2082,7 @@ function SecretWidget({ value, onChange, readOnly, schema, id }: WidgetProps) {
  * that changes fields per driver, but it is generic: any "pick X → these
  * settings" pattern can reuse it by populating `dynamicSchemas`.
  */
-function DynamicConfigWidget({ value, onChange, readOnly, fieldSpec, formData, context }: WidgetProps) {
+function DynamicConfigWidget({ value, onChange, readOnly, fieldSpec, formData, context, ariaLabelledBy }: WidgetProps) {
   const dep = Array.isArray(fieldSpec?.dependsOn) ? fieldSpec!.dependsOn![0] : fieldSpec?.dependsOn;
   const depVal = dep ? (formData?.[dep] as string | undefined) : undefined;
   const sub = depVal != null ? context?.dynamicSchemas?.[String(depVal)] : undefined;
@@ -1963,14 +2096,26 @@ function DynamicConfigWidget({ value, onChange, readOnly, fieldSpec, formData, c
   };
 
   if (!depVal) {
-    return <p className="text-xs text-muted-foreground">Select {dep ?? 'an option'} to configure.</p>;
+    // Every branch answers the host's IDREF, so the field's visible label owns
+    // this surface in each of its three states (objectui#4871) — a group named
+    // in one state and anonymous in another is the conditional shape the #4871
+    // ruling removed.
+    return (
+      <div role="group" aria-labelledby={ariaLabelledBy} className="text-xs text-muted-foreground">
+        Select {dep ?? 'an option'} to configure.
+      </div>
+    );
   }
   if (!sub || Object.keys(props).length === 0) {
-    return <p className="text-xs text-muted-foreground">No configuration needed for "{String(depVal)}".</p>;
+    return (
+      <div role="group" aria-labelledby={ariaLabelledBy} className="text-xs text-muted-foreground">
+        No configuration needed for "{String(depVal)}".
+      </div>
+    );
   }
 
   return (
-    <div className="space-y-2 rounded-md border border-border/60 p-3">
+    <div className="space-y-2 rounded-md border border-border/60 p-3" role="group" aria-labelledby={ariaLabelledBy}>
       {Object.entries(props).map(([key, p]) => {
         const label = (p as any)?.title || key;
         const cur = cfg[key];
@@ -1979,7 +2124,10 @@ function DynamicConfigWidget({ value, onChange, readOnly, fieldSpec, formData, c
           return (
             <div key={key} className="flex items-center justify-between gap-2">
               <Label className="text-xs">{label}</Label>
-              <Switch checked={Boolean(cur)} disabled={readOnly} onCheckedChange={(c) => setKey(key, c)} />
+              {/* Sub-controls of a `labelling: 'group'` widget carry their OWN
+                  names (objectui#4857's composite rule) — this one was the last
+                  anonymous control inside the group. */}
+              <Switch aria-label={label} checked={Boolean(cur)} disabled={readOnly} onCheckedChange={(c) => setKey(key, c)} />
             </div>
           );
         }
@@ -2023,7 +2171,12 @@ function DynamicConfigWidget({ value, onChange, readOnly, fieldSpec, formData, c
   );
 }
 
-export const WIDGETS: Record<string, WidgetRenderer> = {
+// `satisfies` (not a `Record<string, …>` annotation) so the KEY SET survives as
+// a literal union — that union is what makes `WIDGET_LABELLING` below exhaustive
+// BY CONSTRUCTION: adding a widget here without deciding how the host's label
+// reaches it is a compile error, not a silent fall-through to the dangling-`for`
+// path (objectui#4871, the registry gate ruled jointly with objectui#4857).
+export const WIDGETS = {
   'ref:object': RefObjectWidget,
   'ref:component': RefComponentWidget,
   'filter-mode': FilterModeWidget,
@@ -2035,7 +2188,8 @@ export const WIDGETS: Record<string, WidgetRenderer> = {
   'filter-builder': FilterBuilderWidget,
   'view-ref': ViewRefWidget,
   'icon': IconPickerWidget,
-  'color-picker': ColorPickerWidget,
+  'color-picker': ColorSwatchGroupWidget,
+  'color-input': ColorInputWidget,
   'condition': ConditionWidget,
   'master-detail': MasterDetailWidget,
   'string-tags': StringTagsWidget,
@@ -2043,7 +2197,102 @@ export const WIDGETS: Record<string, WidgetRenderer> = {
   'code': CodeWidget,
   'secret': SecretWidget,
   'dynamic-config': DynamicConfigWidget,
+} satisfies Record<string, WidgetRenderer>;
+
+/** Every key of {@link WIDGETS}, as a literal union. */
+export type RegisteredWidgetKey = keyof typeof WIDGETS;
+
+/**
+ * The labelling vocabulary this host implements, DERIVED from the repo-wide
+ * declaration type rather than restated (`ComponentMeta['labelling']`,
+ * objectui#3961 → #4857 → #4871's joint ruling: no host may keep a local
+ * variant of it).
+ *
+ * `'display'` is excluded on a MEASURED basis, not an editorial one: every one
+ * of this registry's widgets is an editable control or an editable composite —
+ * none is the "pure display in every state" case `'display'` names, so this host
+ * has no display CHANNEL to route one to. Excluding it here means adding such a
+ * widget is a compile error at the declaration, pointing at the host that must
+ * grow the `#4788` wrapper first — instead of a `'display'` declaration silently
+ * degrading to the group channel and naming nothing (a widget declared
+ * `'display'` spreads no props, so an `aria-labelledby` handed to it lands
+ * nowhere). Deriving by `Exclude` keeps the vocabulary single-sourced: rename or
+ * re-spell a member in `packages/core` and this stops compiling.
+ */
+export type WidgetLabelling = Exclude<NonNullable<ComponentMeta['labelling']>, 'display'>;
+
+/**
+ * How the HOST's visible label reaches each registered widget — the reviewed
+ * table that replaced seventeen scattered per-widget judgements (objectui#4871,
+ * maintainer ruling of 2026-08-17, point 1: ledger first, then declare).
+ *
+ * Measured on real `SchemaForm` renders at `167ec42e7`, both states, three
+ * columns per widget: does the host `for` RESOLVE and to a LABELABLE element /
+ * is the rendered face labelable at all / does the group have an accessible
+ * name. The ledger is in the PR body; the three readings that decided a
+ * classification are called out on the widgets themselves.
+ *
+ * ## `'control'` — the host's `<label for>` reaches a real labelable element
+ *
+ * The widget puts `id` on the ONE labelable element that is the field's primary
+ * control, in EVERY branch it can render (loading, empty-catalog, read-only).
+ * Auxiliary affordances beside it — a chip's remove button, a reveal toggle —
+ * keep their own names; they are not what the field's label names. "In every
+ * branch" is the load-bearing half: `field-multi` and `action-multi` look like
+ * this in the editable state and were measured DANGLING in the read-only one,
+ * which is why they are NOT here.
+ *
+ * ## `'group'` — no `<label for>` can reach it; the WIDGET answers by IDREF
+ *
+ * Two shapes, one declaration, exactly as `packages/fields`' own table splits
+ * them (objectui#4857):
+ *
+ *  - real composites — `filter-mode` (mode radiogroup + field/tab pickers),
+ *    `master-detail` (a table of per-cell inputs), `condition` (predicate rows),
+ *    `dynamic-config` (a driver-shaped sub-form), `field-multi` / `action-multi`
+ *    (an ordered set with reorder/remove buttons plus an auxiliary add picker);
+ *  - single non-labelable surfaces — `color-picker`'s `div[role="radiogroup"]`,
+ *    `multiselect`'s `div[role="group"]` of checkbox buttons, and `code`, whose
+ *    only focusable is Monaco's internal textarea that this widget never renders.
+ *
+ * The host publishes its label's `id`, drops the `for` (inert on a container,
+ * and a second broken channel beside a working one — objectui#3978/#4010), and
+ * hands the id down as `ariaLabelledBy`; the widget puts it on the surface that
+ * IS the field.
+ */
+export const WIDGET_LABELLING: Record<RegisteredWidgetKey, WidgetLabelling> = {
+  'ref:object': 'control',
+  'ref:component': 'control',
+  'filter-mode': 'group',
+  'object-selector': 'control',
+  'field-selector': 'control',
+  'field-ref': 'control',
+  'field-multi': 'group',
+  'action-multi': 'group',
+  'filter-builder': 'control',
+  'view-ref': 'control',
+  'icon': 'control',
+  'color-picker': 'group',
+  'color-input': 'control',
+  'condition': 'group',
+  'master-detail': 'group',
+  'string-tags': 'control',
+  'multiselect': 'group',
+  'code': 'group',
+  'secret': 'control',
+  'dynamic-config': 'group',
 };
+
+/**
+ * The declared labelling of a widget key, for the host's channel decision.
+ * An UNREGISTERED key (a passthrough hint, a third-party name) resolves to
+ * `'control'` — byte for byte what `MetadataField` emitted before the
+ * declaration existed.
+ */
+export function widgetLabelling(widget: string | undefined): WidgetLabelling {
+  if (!widget) return 'control';
+  return WIDGET_LABELLING[widget as RegisteredWidgetKey] ?? 'control';
+}
 
 /* -------------------------------------------------------------------------- */
 /* CodeWidget — Monaco editor for `type: 'code'` fields                       */
@@ -2076,11 +2325,15 @@ export function CodeWidget({
   onChange,
   readOnly,
   fieldSpec,
+  ariaLabelledBy,
 }: WidgetProps) {
   const language = inferCodeLanguage(fieldSpec, schema);
   const stringValue = typeof value === 'string' ? value : (value == null ? '' : String(value));
   return (
-    <div className="rounded-md border border-border/50 overflow-hidden">
+    // The editor's own focusable is Monaco's internal textarea — this widget
+    // never renders it and cannot put the host id on it, so a `<label for>` can
+    // never reach the editing surface. Named by IDREF instead (objectui#4871).
+    <div className="rounded-md border border-border/50 overflow-hidden" role="group" aria-labelledby={ariaLabelledBy}>
       <div className="flex items-center justify-between px-2 py-1 bg-muted/40 border-b border-border/30 text-[10px] font-mono text-muted-foreground">
         <span>{language}</span>
         {readOnly && <span>read-only</span>}

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -2286,7 +2286,7 @@ export const WIDGET_LABELLING: Record<RegisteredWidgetKey, WidgetLabelling> = {
 /**
  * The declared labelling of a widget key, for the host's channel decision.
  * An UNREGISTERED key (a passthrough hint, a third-party name) resolves to
- * `'control'` — byte for byte what `MetadataField` emitted before the
+ * `'control'` — byte for byte what `FieldRow` emitted before the
  * declaration existed.
  */
 export function widgetLabelling(widget: string | undefined): WidgetLabelling {

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -2223,8 +2223,10 @@ export type WidgetLabelling = Exclude<NonNullable<ComponentMeta['labelling']>, '
 
 /**
  * How the HOST's visible label reaches each registered widget — the reviewed
- * table that replaced seventeen scattered per-widget judgements (objectui#4871,
+ * table that replaced twenty scattered per-widget judgements (objectui#4871,
  * maintainer ruling of 2026-08-17, point 1: ledger first, then declare).
+ * (Nineteen before the `color-picker` split; objectui#4871's own body says
+ * "17", which the ledger corrected — see the PR.)
  *
  * Measured on real `SchemaForm` renders at `167ec42e7`, both states, three
  * columns per widget: does the host `for` RESOLVE and to a LABELABLE element /


### PR DESCRIPTION
Fixes #4871

依据 2026-08-17 05:03Z 维护者合裁五点(与 #4857 一体裁定,其实施件 PR #5036 已落 main `167ec42e7`)。本 PR 基线即 `167ec42e7`,复用其落地的 `ComponentMeta['labelling']` 三值词表与穷尽 Record 门形态。

## 一、账本先行(合裁点 1)

真 `SchemaForm` 渲染 probe,**19 个注册项**、可编辑 + 只读两态、三列读数:host 的 `for` 是否 RESOLVES-**LABELABLE** / 渲染面是否可 label / 组有无可访问名。

**先更正立卡时的两个数**:注册表今天是 **19** 项不是 17,签名里解构 `id` 的是 **11** 个不是 5 个(立卡时的计数是单行签名 grep 的产物,多行解构的 `RefObjectWidget` / `ObjectSelectorWidget` / `FieldSelectorWidget` / `StringTagsWidget` 与单行的 `IconPickerWidget` / `SecretWidget` 都被漏掉了)。**机制本身完全成立**:立卡点名的两处样本(`color-picker` enum 分支的 radiogroup、`MultiSelectWidget` 的匿名 `div[role=group]`)实测与描述逐字一致。只是「解构了 id」不等于「for 解析得到」,这正是三列口径要拆开测的原因。

| 注册键 | 修前 `for`(编辑 / 只读) | 修前渲染面 | 修前组名 | 声明 | 修后 |
| --- | --- | --- | --- | --- | --- |
| `ref:object` | RESOLVES-LABELABLE / 同 | button[combobox](空目录时 input) | 无组 | `control` | 不变,绿 |
| `ref:component` | RESOLVES-LABELABLE / 同 | button[combobox] / input | 无组 | `control` | 不变,绿 |
| `filter-mode` | **DANGLING / DANGLING** | div(模式 radiogroup + 字段/tab 选择器) | 外层无名;内层 radiogroup 自名 "Filter element" | `group` | 外层应答 IDREF;内层保留自名(它命名的是子选择,不是字段) |
| `object-selector` | RESOLVES-LABELABLE / 同 | div 内 SelectTrigger(button) | 无组 | `control` | 不变,绿 |
| `field-selector` | RESOLVES-LABELABLE / 同 | input / button | 无组 | `control` | 不变,绿 |
| `field-ref` | RESOLVES-LABELABLE / 同 | button[combobox] | 无组 | `control` | 不变,绿 |
| `field-multi` | RESOLVES-LABELABLE / **DANGLING** | div(有序集:chips + 增删排序 + add 选择器) | 无组 | `group` | 根 div 应答 IDREF;add 触发器改自名 |
| `action-multi` | RESOLVES-LABELABLE / **DANGLING** | 同上 | 无组 | `group` | 同上 |
| `filter-builder` | **DANGLING / DANGLING** | button(popover 触发器,可 label) | 无组 | `control` | 补上 `id` 转发,for 解析到 button |
| `view-ref` | RESOLVES-LABELABLE / 同 | button[combobox] | 无组 | `control` | 不变,绿 |
| `icon` | RESOLVES-LABELABLE / 同 | button[combobox] | 无组 | `control` | 不变,绿 |
| `color-picker`(enum) | **DANGLING / DANGLING** | div[role=radiogroup] | 自名(#4010 补的) | `group` | 拆为独立注册项;应答宿主 IDREF |
| `color-picker`(无 enum) | **DANGLING / DANGLING** | div 内 input[type=color] + 十六进制输入 | 无组;input[color] 自名 "Color" | — | 拆出 `color-input`,`control` |
| `condition` | **DANGLING / DANGLING** | div(谓词行 + 增删按钮,6 个可聚焦) | 无组 | `group` | 包裹层应答 IDREF |
| `master-detail` | **DANGLING / DANGLING** | div 内 table(逐格输入 + 行操作) | 无组 | `group` | 根 div 应答 IDREF |
| `string-tags` | RESOLVES-LABELABLE / 同 | div 内 input[text](chips 为辅助件) | 无组 | `control` | 不变,绿 |
| `multiselect` | **DANGLING / DANGLING** | div[role=group] 复选按钮组 | **匿名** | `group` | 应答 IDREF |
| `multiselect`(无选项) | **DANGLING / DANGLING** | 降级到 StringTags,且 `id` 未转发 | 无组 | — | 降级留在同一个具名 group 内 |
| `code` | **DANGLING / DANGLING** | div(Monaco;唯一可聚焦是它内部的 textarea) | 无组 | `group` | 根 div 应答 IDREF |
| `secret` | RESOLVES-LABELABLE / 同 | div 内 input[password] + 显隐按钮 | 无组 | `control` | 见下「顺带修掉的两处」 |
| `dynamic-config` | **DANGLING / DANGLING** | div(按驱动值渲染的子表单) | 无组 | `group` | 三个分支全部应答 IDREF |

**8 个注册键在两态都悬空**,另 **2 个**(`field-multi` / `action-multi`)只在只读态悬空 —— 后者是本次账本最有信息量的读数:持有 `id` 的元素是那个 add 选择器,它被 `!readOnly` 门住了。一个**只在某些状态成立的 `control` 声明**,正是本次合裁从 `color-picker` 身上移除的那种运行期推断,所以这两个定 `group` 而非 `control`。

对照组:内建标量分支(string / number / enum-select / boolean switch / array-of-primitive)两态全部 RESOLVES-LABELABLE,未动。非注册表的 6 条结构化路径两态全部 DANGLING —— 不在本卡合裁范围(注册表之外无声明面),已另立 #5039。

## 二、meta 层复用 core 的声明类型(合裁点 2)

`WIDGETS` 从裸 `Record` 改为 `satisfies` 对象,键集保留为字面量联合;`WIDGET_LABELLING` 是 `Record< RegisteredWidgetKey, WidgetLabelling >` —— 注册一个 widget 而不决定它的命名通道是**编译期错误**,不是静默落回悬空路径。

词表**派生自** `packages/core` 的 `ComponentMeta['labelling']`,不是本地重述:

```ts
export type WidgetLabelling = Exclude< NonNullable< ComponentMeta['labelling'] >, 'display' >;
```

`'display'` 的排除是**实测依据**而非编辑口味:本注册表 19 项全部是可编辑控件或可编辑组合件,没有一项符合 `'display'` 的定义(「每种状态下都是纯展示面」),因此本宿主也没有对应的 #4788 包裹**通道**可以路由过去。用 `Exclude` 排除,意味着将来引入这类 widget 会在**声明处编译报错**、指向必须先长出通道的宿主;若保留三值而不实现 display 分支,得到的是一个没有任何 fixture 到达的死枝(#4984 家族的失效形状);若保留三值并实现,得到的是一段无人执行的宿主代码。`Exclude` 同时保证词表单源:`packages/core` 里改名或改拼写,这里立刻编译不过。

11 项 `control`,9 项 `group`。分类判据在 `WIDGET_LABELLING` 的文档注释里逐条写明,决定分类的那几个读数写在 widget 自己身上。

## 三、SchemaForm 按声明发通道(合裁点 3)

`FieldRow` 里两条通道互斥,**恰好一条**到达 widget:

- `control` → `Label htmlFor={id}`,`id` 下发,`ariaLabelledBy` 为 undefined;
- `group` → label 发布自己的 `id`,`ariaLabelledBy` 下发,**`for` 摘除**,`id` **不**下发。

`id` 在 group 通道上刻意不下发:`packages/components` form.tsx 的 `labelling: 'group'` 分支与 #4010 都把「把 id 挪到组容器上」定性为**被拒绝的半修**(IDREF 解析得到、组仍然没名字)。不下发,这个半修就没有材料。

(顺带:本区域的注释此前一律称这个函数为 `MetadataField` —— 它并不存在,真名是 `FieldRow`。该漂移早于本分支,#4871 单体正文也这么写;已在本分支已触及的四个文件内更名,见第二个 commit。)

## 四、color-picker 拆双注册(合裁点 4)

原来一个注册项在**运行期**按 `schema`/`fieldSpec` 二选一渲染 radiogroup 或可 label 的 `input[type=color]` —— 而那时 label 已经写完了。现在是两个注册项:

- `color-picker` ⇒ `ColorSwatchGroupWidget`(声明色板 ⇒ 色块 radiogroup),`group`;
- `color-input` ⇒ `ColorInputWidget`(无色板 ⇒ 原生选择器 + 十六进制镜像),`control`。

**宿主按 schema 挑**:`resolveRegisteredWidget()` 在 `FieldRow` 里、写 label **之前**跑;它和两个 widget 都通过同一个 `colorPaletteOptions()` 读色板,所以 producer 与 consumer 不可能对「到底渲染哪个面」产生分歧。作用于**授权名**也作用于推断名 —— spec 里显式钉 `widget: 'color-picker'` 的自由颜色字段同样会被改路由到真正渲染的那一项,否则声明描述的就不是屏幕上那个 DOM。

## 五、registered ⇒ 声明 门(合裁点 5)

编译期:上面那个穷尽 `Record`。运行期奇偶:声明表的键集与 `WIDGETS` 键集互为子集、每个值都在闭合词表内、每个注册键都有 probe 用例。运行期这几条守的是**让编译期生效的形状** —— 把 `WIDGETS` 重新标注回 `Record< string, WidgetRenderer >` 会悄悄溶解字面量联合,两个对象看上去都还对。

## 顺带修掉的两处(同一次 probe 测出,同一失效)

账本的第三列把两个 widget 自带的 `aria-label` 常量抓了出来 —— 它们**压过**了可见 label 的可访问名计算:

- `secret` 的 `aria-label="Secret value"`:标着 "API Key" / "Client Secret" 的字段,朗读出来是 "Secret value";
- 自由颜色的 `aria-label="Color"`:标着 "Brand Color" 的字段,朗读出来是 "Color"。

两处都改成「宿主给了 `id` 就让位、没给才保留常量」;后一半正是这两个 widget 现有单测走的独立渲染路径(`SecretWidget.test.tsx` 不传 `id`),所以不是死枝。另外十六进制镜像输入与 `dynamic-config` 的布尔开关此前**完全没有可访问名**,一并补上。

## DashboardWidgetInspector 的处置

它的私有 `Field` 组件有一个本地二值 `labelling?: 'control' | 'group'` prop。合裁点 2 禁止 host 本地变体,统一成本很低(纯类型改动,零行为变化),所以**一并收进**:改为 `Exclude< NonNullable< ComponentMeta['labelling'] >, 'display' >`,与注册表声明层同源同理由。`Field` 的两条分支实现不动 —— 它面对的是本面板自己的子组件,不是注册表。

## 反向验证(预判先写,commit 后变异,`git checkout --` 还原)

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| ① `WIDGET_LABELLING` 摘掉 `'multiselect'` | tsc 红并**点名** multiselect | 一致。`widgets.tsx(2263,14): error TS2741: Property 'multiselect' is missing in type ... but required in type 'Record< "ref:object" \| ... , WidgetLabelling >'` |
| ② group 通道退回 `htmlFor`(`groupLabelled` 恒 false) | group 类用例红,首个断言是 `label` 重新长出 `for="mdf-probe"` | 一致,形状逐字命中:`Expected the element not to have attribute: for / Received: for="mdf-probe"`。**数目更正**:预判写「约 22 例」,实测 **27** 例 —— 12 个 group 用例 × 2 态 = 24,加 colorPicker 文件 2 例、通道等价性 1 例。预判漏算了后 3 例,方向与形状无误 |
| ③ `resolveRegisteredWidget` 退回透传(宿主不再挑) | 自由颜色字段落到色板 widget 上,`input[type=color]` 消失、出现本不该有的 radiogroup | 一致,5 例红,全部落在两个注册项的形态钉上 |

## 测试

- 新增 `SchemaForm.widgetLabelling.test.tsx`:账本三列以断言复现(19 个注册键 × 两态 × 分支变体 = 52 例),按**声明**而非手写期望值断言,声明表与 DOM 不会各自漂移;加注册表门 4 例、两注册项形态 4 例、通道等价性 2 例。group 类用例**正向**断言具名面存在并应答 IDREF —— 「没有悬空 for」对一个什么都不渲染的 widget 同样成立,那种绿没有意义。
- `SchemaForm.colorPicker.labelling.test.tsx`:#4010 钉住的「已知残留」按其注释指引**转正** —— 三条原本钉住缺陷的断言现在钉住它的消失。
- app-shell 全量绿:419 文件 / 4015 例。仓根 `turbo run type-check`:81/81。`check-control-bytes`:OK,改动文件另做 `grep -naP` 自扫无命中。eslint 改动文件 0 error(新增 4 条 `react-refresh/only-export-components` 与既有导出同类:声明表必须与它作键的注册表同文件,这正是编译期穷尽性的前提)。
- CI(head `9c552fcb0`):20 个 check 全部 completed,零 failure。

## 一处判断点(可低成本翻转)

`color-input` 定 `control`(宿主 id 落在 `input[type=color]` 上,十六进制镜像自带名)。理由:合裁原话即「无 enum ⇒ color-input 注册项」;立卡正文也把自由分支归在「可 label 控件」那一档;且与本文件既有两处先例一致(`secret` = 密码框 + 显隐按钮、`string-tags` = 输入框 + chips,都是「主控件收 id,辅助件自带名」)。

替代读法是 `group`:严格套 #4857 的「several inputs under one container」判据,色板 + 十六进制是两个平级输入。若维护者取这一读法,改动面是 `ColorInputWidget` 一处(根 div 加 `role=group` + `aria-labelledby`,两个输入各自留名)加声明表一行加对应用例。如实列出,不代为裁决。

## 派生 findings(未认领,已按 Prime Directive #10 另立)

- #5039 —— 同宿主里 6 条**非注册表**渲染路径(composite / repeater / record / 两条结构化兜底 / raw-JSON)两态全部悬空 `for`。有实测账本;不夹带进本 PR 的原因写在单里(其中 3 条的分支判定发生在 label 写完之后,解法面比本次合裁范围大)。
- #5040 —— `FormFieldSpec` 未声明 `dependsOn`,而 `field-selector` / `dynamic-config` 都读它;同一个契约的两份不一致描述。观察类,已挂 `finding`,未挂 `pm:queue`。
