### PR TITLE
docs(plugin-calendar): 对齐 README 的导入面与包的真实导出面

### DIFF
--- a/.changeset/plugin-calendar-readme-export-surface-5010.md
+++ b/.changeset/plugin-calendar-readme-export-surface-5010.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/plugin-calendar': patch
+---
+
+`plugin-calendar`'s README no longer documents imports the package does not export.
+
+Three defects in `packages/plugin-calendar/README.md`, all of which made a
+copy-pasted snippet fail to compile. Checked by taking the package's real export
+name set off `src/index.tsx` through the TypeScript compiler API and cross-checking
+every import statement in the README against it — including multi-line import
+blocks, which a single-line grep cannot see.
+
+1. **Fabricated (deleted).** A "Manual Registration" section taught
+   `import { calendarComponents } from '@object-ui/plugin-calendar'` followed by
+   `Object.entries(calendarComponents).forEach(register)`. There is no
+   `calendarComponents` export and never was — the identifier does not occur
+   anywhere in `src/`. Copying it gave `undefined`, and `Object.entries(undefined)`
+   throws a `TypeError`, so the section could not run at all. Registration in this
+   package is purely a side effect of importing the entry point, so there is no
+   components map to iterate. The fabricated section is replaced by what the
+   side-effect import actually claims (the three registered schema types and their
+   namespaced keys) and by the package's real export surface — `ObjectCalendar`,
+   `CalendarView`, `ObjectCalendarRenderer` plus the component prop types. Hosts
+   that want their own registry key are shown the honest way to get one:
+   registering the exported `ObjectCalendarRenderer` under it.
+
+2. **Wrong import path (path corrected).** `CalendarViewSchema` was imported from
+   `@object-ui/plugin-calendar`. The type is real but belongs to `@object-ui/types`;
+   this package imports it and does not re-export it, so the documented import was
+   a "no exported member" error. The path now points at `@object-ui/types`.
+
+3. **Name collision (import re-pointed).** Correcting (2) alone still left the
+   snippet uncompilable: the same example imported `CalendarEvent` from
+   `@object-ui/plugin-calendar`, which is a real export but a *different* type —
+   the `CalendarView` component's runtime shape (`id: string | number`,
+   `start: Date`), not the authored JSON shape (`id: string`, `start: string | Date`)
+   that `CalendarViewSchema.events` requires and that the README's own "Calendar
+   Event Structure" section documents. The example's ISO-string values therefore did
+   not typecheck, and the plugin's event type was not assignable to the schema's.
+   Both authored types now come from `@object-ui/types`, and the two same-named
+   types are documented side by side so the next reader does not re-pick the wrong one.
+
+No exports were added to make the README true — the docs were moved to the code,
+not the reverse.

--- a/packages/plugin-calendar/README.md
+++ b/packages/plugin-calendar/README.md
@@ -100,16 +100,48 @@ const schema = {
 };
 ```
 
-### Manual Registration
+### What the side-effect import registers
+
+Registration is *only* a side effect of importing the package — the single
+`import '@object-ui/plugin-calendar'` above is the whole of it. There is no
+components map to iterate over: importing the entry point runs the
+`ComponentRegistry.register(...)` calls in `src/index.tsx` and
+`src/calendar-view-renderer.tsx`, which claim these schema types:
+
+| Schema `type` | Namespaced key | Renderer |
+| --- | --- | --- |
+| `object-calendar` | `plugin-calendar:object-calendar` | `ObjectCalendarRenderer` |
+| `calendar` | `view:calendar` | `ObjectCalendarRenderer` |
+| `calendar-view` | `plugin-calendar:calendar-view` | internal wrapper around `CalendarView` (not exported) |
+
+Both spellings work — the namespaced key and the bare `type` fallback.
+
+### Public exports
+
+The package exports components and their types, not a registry map:
 
 ```typescript
-import { calendarComponents } from '@object-ui/plugin-calendar';
-import { ComponentRegistry } from '@object-ui/core';
+import {
+  ObjectCalendar, // ObjectQL-integrated calendar component
+  CalendarView, // standalone calendar component
+  ObjectCalendarRenderer, // the registered renderer for `object-calendar` / `calendar`
+} from '@object-ui/plugin-calendar';
 
-// Register calendar components
-Object.entries(calendarComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
-});
+import type {
+  ObjectCalendarComponentProps,
+  CalendarViewProps,
+  CalendarEvent,
+} from '@object-ui/plugin-calendar';
+```
+
+To serve the calendar under a registry key of your own, register the exported
+renderer under that key:
+
+```typescript
+import { ComponentRegistry } from '@object-ui/core';
+import { ObjectCalendarRenderer } from '@object-ui/plugin-calendar';
+
+ComponentRegistry.register('my-calendar', ObjectCalendarRenderer);
 ```
 
 ## Schema API
@@ -130,6 +162,8 @@ Display a monthly calendar with events:
 ```
 
 ### Calendar Event Structure
+
+The authored event shape, declared by `@object-ui/types`:
 
 ```typescript
 interface CalendarEvent {
@@ -238,8 +272,11 @@ const schema = {
 
 ## TypeScript Support
 
+The **authored** (JSON metadata) types live in `@object-ui/types`, not in this
+package — this package imports them too, and does not re-export them:
+
 ```typescript
-import type { CalendarViewSchema, CalendarEvent } from '@object-ui/plugin-calendar';
+import type { CalendarViewSchema, CalendarEvent } from '@object-ui/types';
 
 const event: CalendarEvent = {
   id: '1',
@@ -253,6 +290,16 @@ const schema: CalendarViewSchema = {
   events: [event]
 };
 ```
+
+> **Two different `CalendarEvent` types, same name.** The one above, from
+> `@object-ui/types`, is the *authored* event: `id: string` and
+> `start` / `end` accept ISO strings — that is the shape documented under
+> [Calendar Event Structure](#calendar-event-structure) and the one a
+> `calendar-view` schema carries. This package also exports a `CalendarEvent`
+> (`CalendarViewProps['events']`), which is the `CalendarView` **component's
+> runtime** type: `id: string | number` and `start: Date` / `end?: Date`. Use
+> the `@object-ui/types` one for metadata and the plugin one when you render
+> `CalendarView` yourself in React; they are not interchangeable.
 
 ## Links
 


### PR DESCRIPTION
Fixes #5010

`packages/plugin-calendar/README.md` 的导入面与包的真实导出面对齐。卡面点了两处漂移,核对过程扫出**第三处**(同文件同性质,一并修,下面单列)。⛔ 没有为了让 README 变真而新增任何导出。

## 前提验证(先行,含证伪反查)

| 卡面断言 | 复测 | 结论 |
| --- | --- | --- |
| `calendarComponents` 在 `src` 零命中 | `grep -rnw calendarComponents packages/plugin-calendar/src` → exit 1,无输出 | ✅ 成立 |
| 零命中不是扫描器坏了 | 反查确定存在的邻近词:`grep -rlnw ObjectCalendar packages/plugin-calendar/src` → 5 个文件(`ObjectCalendar.tsx`、`CalendarView.tsx`、`index.tsx`、两个 test) | ✅ 扫描器正常,零命中是真零命中 |
| `CalendarViewSchema` 真身在 `@object-ui/types` | `packages/types/src/complex.ts:174` 声明,`packages/types/src/index.ts:268` 导出;本包 `src/calendar-view-renderer.tsx:10` 只 import,`src/index.tsx` 无 re-export | ✅ 成立 |

两处漂移都成立,`premise_still_valid: true`。

编译探针实测 README 在 `origin/main` 上的原样(tsc 直读源码,非 dist):

```
c-readme-asis.ts(4,10):  error TS2305: Module '"@object-ui/plugin-calendar"' has no exported member 'calendarComponents'.
c-readme-asis.ts(5,15):  error TS2724: '"@object-ui/plugin-calendar"' has no exported member named 'CalendarViewSchema'. Did you mean 'CalendarView'?
c-readme-asis.ts(15,3):  error TS2322: Type 'string' is not assignable to type 'Date'.
c-readme-asis.ts(16,3):  error TS2322: Type 'string' is not assignable to type 'Date'.
```

一处与卡面小有出入,如实记:`CalendarViewSchema` 报的是 **TS2724**(带拼写建议的「无此导出成员」)而非卡面写的 TS2305 —— 同族诊断,不影响判定与修法。后两条 TS2322 就是下面的第三处漂移。

## 三处漂移:判定与修法(刻意区分,勿混)

| # | 位置(原行号) | 症状 | 判定 | 修法 |
| --- | --- | --- | --- | --- |
| 1 | `:106-112` "Manual Registration" | `calendarComponents` 不存在 → 照抄拿 `undefined`,`Object.entries(undefined)` 抛 `TypeError`,整节跑不起来 | **虚构** | **删虚构节**,改教真实注册方式 |
| 2 | `:242` | `CalendarViewSchema` 类型是真的,但属于 `@object-ui/types`,本包只 import 不 re-export | **路径错** | **改导入路径** |
| 3 | `:242-249`(卡面未列) | 同一例子里的 `CalendarEvent` 是本包**真导出**,但是**运行时**类型;示例的 ISO 字符串与 `CalendarViewSchema.events` 要的**授权**类型对不上 | **同名撞车**(名字真、类型错) | **改导入来源** |

### 第三处漂移的来历(为什么只改路径不够)

把 #2 的路径改对之后,示例**仍然不编译**。探针 A(只改 #2 的路径、`CalendarEvent` 继续从本包导入)实测:

```
a-pathfix-only.ts(10,3):  error TS2322: Type 'string' is not assignable to type 'Date'.
a-pathfix-only.ts(11,3):  error TS2322: Type 'string' is not assignable to type 'Date'.
a-pathfix-only.ts(16,12): error TS2322: Type '…/plugin-calendar/src/CalendarView").CalendarEvent'
  is not assignable to type '…/types/src/complex").CalendarEvent'.
    Types of property 'id' are incompatible.
      Type 'string | number' is not assignable to type 'string'.
```

根因是两个同名类型:

| | `@object-ui/types`(授权 JSON) | `@object-ui/plugin-calendar`(组件运行时) |
| --- | --- | --- |
| `id` | `string` | `string \| number` |
| `start` | `string \| Date` | `Date` |
| `end` | `string \| Date`(必填) | `Date`(可选) |
| `description` | 有 | 无 |

`CalendarViewSchema.events` 要授权型,README 这个例子导的是运行时型。**名集合核对看不见这一类**(两个名字都是真导出),只有真编译看得见。

修法定向不是猜的:README **自己**的 "Calendar Event Structure" 一节记的就是授权型的形状(ISO 字符串 + `description`),整篇 schema 示例也全用 ISO 字符串。所以两个授权型统一从 `@object-ui/types` 取,并加一段把两个同名类型并列写清,免得下一个读者(或 IDE 自动导入)再挑错。探针 B(本 PR 的写法)实测 **0 error**。

同名本身没动 —— 那是契约变更,已另立 #5044 并给出三个方向与推荐。

## 名集合核对读数(全部自包导入,含多行块)

方法按 #5010 楼上立卡人的方法学备注:**不做文本近似**。用 TypeScript compiler API 从 `src/index.tsx` 取 `checker.getExportsOfModule` 的导出符号集(解析 alias 后再判 value/type —— `export { ObjectCalendar }` 是 Alias 符号、不带 Value flag,按 alias 判会把每个 re-export 误标成 type),再用跨行正则抓 README **全部** import 语句(单行 + 多行块),剥掉注释后逐名核对。

真实导出面(7 个):

```
type   CalendarEvent            value  CalendarView
type   CalendarViewProps        value  ObjectCalendar
type   ObjectCalendarComponentProps
type   ObjectCalendarProps      value  ObjectCalendarRenderer
```

**修复前**:

| README 行 | 形态 | 导入名 | 判定 |
| --- | --- | --- | --- |
| :106 | 单行 | `calendarComponents` | ❌ **虚构** |
| :242 | 单行 | `CalendarViewSchema` | ❌ **路径错** → 真身 `@object-ui/types` |
| :242 | 单行 | `CalendarEvent` | ✅ 真(但见第三处漂移:名真、类型错) |

**修复后**(0 处缺陷):

| README 行 | 形态 | 导入名 | 判定 |
| --- | --- | --- | --- |
| :124 | **多行块** | `ObjectCalendar` / `CalendarView` / `ObjectCalendarRenderer` | ✅ 真(value ×3) |
| :130 | **多行块** | `ObjectCalendarComponentProps` / `CalendarViewProps` / `CalendarEvent` | ✅ 真(type ×3) |
| :142 | 单行 | `ObjectCalendarRenderer` | ✅ 真(value) |
| :279 | 单行 | `CalendarViewSchema` / `CalendarEvent` | ✅ 真,来自 `@object-ui/types` |

跨包导入顺带核过:`ComponentRegistry` → `@object-ui/core`(`src/registry/Registry.ts`)✅;`createObjectStackAdapter` → `@object-ui/data-objectstack`(`src/index.ts`)✅。

## 删因(逐节一行)

- **删 `### Manual Registration`(原 `:103-113`)** —— 删因:所教的 `calendarComponents` 导出不存在且从未存在(`src` 零命中),整节照抄即 `TypeError`;本包注册纯粹是 import 入口的副作用,**没有可遍历的组件表**,所以这一节不是「写错了」而是「描述了一个不存在的机制」,无法就地改对,只能删。
  - 补位内容(不是恢复该节,是改教真实机制):新增 `### What the side-effect import registers`,列副作用 import 真正 claim 的三个 schema type 及其命名空间键(`plugin-calendar:object-calendar`、`view:calendar`、`plugin-calendar:calendar-view`,均取自 `ComponentRegistry.register(...)` 实际调用);新增 `### Public exports` 列真实导出面;想要自定义注册键的宿主,改教注册**已导出的** `ObjectCalendarRenderer`(`ComponentRegistry` 是 `Registry` 实例,`register(type, component, meta?)` 的 meta 可省,两参调用合法)。

除此之外没有删任何一节。

## 反向验证(docs 形)

预判方向:往名集合核对里塞假名,**应当被抓出**;并且要专门验证立卡人指出的下限 —— **多行 import 块**。

往两个多行块各塞一个假名(`calendarComponents`、`CalendarBogusSchema`)后实测:

```
FABRICATED    README:124  calendarComponents      → no such export anywhere
FABRICATED    README:131  CalendarBogusSchema     → no such export anywhere
  (2 defective self-package imported name(s))
```

两个都在多行块里、两个都被抓出 —— 正是单行 grep 看不到的那一类。截读数后已还原,临时改动未进 commit(`grep -n "PLANTED|CalendarBogusSchema|calendarComponents" README.md` → exit 1;还原后核对读数回到 0 缺陷)。

顺带一记核对器自身的假阳性并已修:第一版没剥行尾 `//` 注释,多行块里的注释被粘到前一个标识符上,把三个真名报成虚构。这条已写进 #5043。

## 验证

- 仓根 `pnpm exec turbo run type-check --concurrency=2` —— **Tasks: 81 successful, 81 total**,exit 0(4m4s)。
- `node scripts/check-control-bytes.mjs` —— OK,扫 4504 个已跟踪文本文件(含本 PR 两个新增/改动文件)。
- `grep -naP` 控制字节自扫改动文件 —— exit 1,无控制字节;`file README.md` 报 UTF-8 text(未被当成 binary)。
- `node scripts/check-doc-links.mjs` —— Links are valid across 13 scan roots.
- `node scripts/check-changeset-fixed.mjs` + `check-changeset-no-major.mjs` —— 均 ✅(patch,未声明 major)。
- README 内每个 TypeScript 示例的自包导入均对导出面核验;新增的两段示例(公共导出多行块、自定义注册键)编译探针实测 **0 error**,保持可照抄运行。

## changeset

一文件:`.changeset/plugin-calendar-readme-export-surface-5010.md`,`@object-ui/plugin-calendar: patch`。README 在本包 `package.json` 的 `files` 里,随 npm 发布,属用户可见。

## 顺手记录的 finding(未在本 PR 修)

- #5043 —— 没有门禁核对包内 README 自包导入名 vs 真实导出面(#5002 家族 7 个包的根因);附本单验证过的检查器原型与两个已踩的坑。
- #5044 —— 两个结构不兼容的 `CalendarEvent` 同名并存(本 PR 第三处漂移的根因);给了三个方向与推荐。
- #5045 —— 同文件 "Schema API" 块把必填的 `events` 标成选填,且只列了 13 个键里的 6 个(**不同性质**,故未夹带)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_