### PR TITLE
fix(app-shell): CloudConnectionPanel 绑定失败先读 error.message，与同文件 getJson 的优先级一致

### DIFF
--- a/.changeset/cloud-connection-bind-error-message-5028.md
+++ b/.changeset/cloud-connection-bind-error-message-5028.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`CloudConnectionPanel` prefers `error.message` over `error.code` on a bind-poll failure, matching the precedence the same file already applies everywhere else.
+
+`poll()`'s terminal branch read `body?.error?.code ?? t('cloudConnection.errors.bindFailed')`,
+so a failure body that carried a human-readable sentence beside its machine code
+was still rendered as the code. Fifty lines above, this file's own `getJson`
+helper already reads `body?.error?.message ?? body?.error?.code ?? body?.error`;
+this brings the one call site that diverged into line with it (objectui#5028).
+The `code` arm is kept as the fallback — a producer still short of
+`ApiErrorSchema`'s required `message` shows its code rather than nothing — and
+the chain still ends at the translated string.
+
+Narrower than the filed card, because verification moved the boundary. The card
+expected this line to be what displays a device-authorization failure
+(`expired_token`, `access_denied`) after objectstack#9267 / PR #9369 added
+`error.message` to that envelope. It is not: `/bind/poll` serves the terminal
+device-code failure with HTTP **400** (before and after that PR), and `getJson`
+throws on any non-2xx whose body is not `success: true`, so the string a user
+reads there was always picked by `getJson`'s already-correct precedence. The
+upstream message reached the UI the moment it merged, with nothing owed here.
+
+What the changed line genuinely governs is the 2xx path: `/bind/poll` forwards
+the control plane's own `/bind` answer verbatim, with the control plane's status.
+A 200 that says `success: false` — an envelope violation of the kind
+objectstack#9364 is still counting — is handed back by `getJson` and lands in
+this branch, and that is where a code was being shown instead of the sentence
+next to it. Four cases pin the surface end to end, including a control that
+records where the device-authorization text actually comes from, so the next
+reader is not sent looking for it in `poll()`.

--- a/packages/app-shell/src/console/cloud-connection/CloudConnectionPanel.tsx
+++ b/packages/app-shell/src/console/cloud-connection/CloudConnectionPanel.tsx
@@ -125,7 +125,25 @@ export function CloudConnectionPanel() {
           await refreshStatus();
           return;
         }
-        setPhase({ kind: 'error', message: body?.error?.code ?? t('cloudConnection.errors.bindFailed') });
+        // `message` first, `code` only as a fallback — the same precedence
+        // `getJson` above already applies to every OTHER failure on this
+        // surface. Reading `code` alone showed a machine identifier to a human
+        // whenever the readable half was on the wire.
+        //
+        // Which bodies land here: a 2xx that says `success: false` with neither
+        // `pending` nor `bound` — i.e. the control plane's `/bind` answer,
+        // passed through verbatim with its own status. A non-2xx failure never
+        // reaches this line at all: `getJson` throws it, and the catch below
+        // renders that error's message.
+        //
+        // The chain stops at `code` deliberately. `getJson` has a third arm
+        // (`?? body?.error`) but guards it with a non-string check before use;
+        // here the last arm is the translated string, which is always safe to
+        // render, and an unguarded object would reach JSX as a child.
+        setPhase({
+          kind: 'error',
+          message: body?.error?.message ?? body?.error?.code ?? t('cloudConnection.errors.bindFailed'),
+        });
       } catch (err: any) {
         setPhase({ kind: 'error', message: err?.message ?? String(err) });
       }

--- a/packages/app-shell/src/console/cloud-connection/__tests__/CloudConnectionPanel.bindError.test.tsx
+++ b/packages/app-shell/src/console/cloud-connection/__tests__/CloudConnectionPanel.bindError.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5028 — what the bind-failure surface actually shows a human, and
+ * from which of the panel's TWO failure readers it comes.
+ *
+ * The card asked for one call site to stop preferring a machine code:
+ * `poll()`'s terminal branch read `body?.error?.code ?? t(...)`, while
+ * `getJson()` fifty lines above already reads `message ?? code ?? error`. That
+ * change is made and pinned below.
+ *
+ * ## The card's SYMPTOM claim does not survive verification
+ *
+ * The card predicted that after objectstack#9267 / PR #9369 a user would see
+ * `DEVICE_CODE_FAILED` where they previously saw `expired_token`, i.e. that the
+ * device-authorization failure is displayed by the `poll()` branch. It is not.
+ * That envelope is served with HTTP **400**
+ * (`packages/cloud-connection/src/cloud-connection-plugin.ts`, the `/bind/poll`
+ * terminal exit — 400 before PR #9369 and 400 after it), and `getJson` throws
+ * on any non-2xx whose body is not `success: true`. So the string a user reads
+ * for an expired or denied device code has always come from `getJson`'s
+ * precedence, which already preferred `message` — the upstream fix reached the
+ * UI the moment it merged, with no change needed here.
+ *
+ * The first case below is the CONTROL that pins exactly that, so the next
+ * reader is not sent looking for this text in `poll()`.
+ *
+ * ## What is genuinely reached by the changed line
+ *
+ * `poll()`'s terminal branch runs only for a body `getJson` hands BACK, i.e. a
+ * 2xx, that then says neither `data.pending` nor `data.bound` nor
+ * `success: true`. `/bind/poll` has exactly one such exit: it returns the
+ * control plane's own `/bind` answer verbatim, `c.json(bindJson,
+ * bindResp.status)`. A control plane answering 200 with `success: false` — an
+ * envelope violation on its side, and precisely the population objectstack#9364
+ * is still counting — lands here, and this is where a code used to be rendered
+ * instead of the sentence beside it.
+ *
+ * ## Reverse verification (direction predicted BEFORE running)
+ *
+ *   - Revert the line to `code ?? t(...)`: case 2 RED (reads
+ *     `ENVIRONMENT_BIND_FAILED` where the sentence was expected), cases 3 and 4
+ *     GREEN (no `message` to prefer), case 1 GREEN — it never used this line.
+ *   - Invert the chain to `code ?? message ?? t(...)`: case 2 RED for the same
+ *     reason, 1/3/4 GREEN. Only case 2 can tell the two orders apart, because
+ *     it is the only fixture that carries both halves.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+// Spread the real module: other exports (`createSafeTranslation`) are pulled
+// from it by packages this component's graph imports, and a bare factory would
+// blank them out.
+vi.mock('@object-ui/i18n', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@object-ui/i18n');
+  return {
+    ...actual,
+    // Identity `t`: an assertion on the KEY is the honest way to say "the
+    // translated string was chosen", without pinning today's English copy.
+    useObjectTranslation: () => ({ t: (key: string) => key, language: 'en' }),
+  };
+});
+
+import { CloudConnectionPanel } from '../CloudConnectionPanel';
+
+const BIND_FAILED_KEY = 'cloudConnection.errors.bindFailed';
+
+/** The `/bind/poll` answer the case under test wants. */
+let pollReply: { status: number; body: unknown } = { status: 200, body: {} };
+
+const reply = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('fetch', vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.endsWith('/status')) {
+      return reply(200, { success: true, data: { environmentId: null, bound: false, connection: null } });
+    }
+    if (url.endsWith('/bind/start')) {
+      // No verification_uri: the popup path is not this file's subject, and
+      // leaving it out keeps window.open out of the run entirely.
+      return reply(200, {
+        success: true,
+        data: { device_code: 'dc_1', user_code: 'ABCD-EFGH', interval: 2, expires_in: 600 },
+      });
+    }
+    if (url.endsWith('/bind/poll')) return reply(pollReply.status, pollReply.body);
+    throw new Error(`unexpected fetch: ${url}`);
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+/** Move the clock, flushing the promises each timer wakes. */
+const advance = (ms: number) => act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+
+/**
+ * Mount, connect, and let exactly one poll tick land. `interval: 2` is the
+ * floor `poll()` clamps to, so the first tick fires at 2000ms.
+ */
+async function connectAndPollOnce() {
+  render(<CloudConnectionPanel />);
+  await advance(0); // the mount-time /status read settles -> unbound
+  const connect = screen.getByRole('button', { name: /cloudConnection\.unbound\.connect/ });
+  await act(async () => { connect.click(); });
+  await advance(0); // /bind/start settles -> waiting, first tick scheduled
+  await advance(2000); // the tick, and the /bind/poll read it issues
+}
+
+describe('objectui#5028 — the bind-failure text a human reads', () => {
+  it('CONTROL: the upstream 400 device-authorization envelope is rendered by getJson, not by poll()', async () => {
+    // objectstack#9267's body, verbatim, at the status it is served with.
+    // `getJson` throws on it, so the message shown is the one IT picked; the
+    // changed line in poll() is not on this path in either direction.
+    pollReply = {
+      status: 400,
+      body: {
+        success: false,
+        data: { pending: false },
+        error: {
+          code: 'DEVICE_CODE_FAILED',
+          declaredCode: 'expired_token',
+          message: 'Device authorization failed: expired_token',
+        },
+      },
+    };
+
+    await connectAndPollOnce();
+
+    expect(screen.getByText('Device authorization failed: expired_token')).toBeInTheDocument();
+    expect(screen.queryByText('DEVICE_CODE_FAILED')).not.toBeInTheDocument();
+  });
+
+  it('prefers error.message over error.code on a 2xx failure body — the changed line', async () => {
+    // The `/bind` pass-through: the control plane's answer, forwarded with its
+    // own status. 2xx, so getJson returns it; no pending/bound/success, so
+    // poll()'s terminal branch is what renders it.
+    pollReply = {
+      status: 200,
+      body: {
+        success: false,
+        data: { pending: false },
+        error: { code: 'ENVIRONMENT_BIND_FAILED', message: 'This environment is already bound to another organization.' },
+      },
+    };
+
+    await connectAndPollOnce();
+
+    expect(screen.getByText('This environment is already bound to another organization.')).toBeInTheDocument();
+    expect(screen.queryByText('ENVIRONMENT_BIND_FAILED')).not.toBeInTheDocument();
+  });
+
+  it('falls back to error.code when the body carries no message', async () => {
+    // The pre-#9369 shape, and any producer still short of ApiErrorSchema's
+    // required `message`. Showing the code beats showing nothing, so the
+    // fallback arm stays.
+    pollReply = {
+      status: 200,
+      body: { success: false, data: { pending: false }, error: { code: 'ENVIRONMENT_BIND_FAILED' } },
+    };
+
+    await connectAndPollOnce();
+
+    expect(screen.getByText('ENVIRONMENT_BIND_FAILED')).toBeInTheDocument();
+    expect(screen.queryByText(BIND_FAILED_KEY)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the translated string when there is no error object at all', async () => {
+    pollReply = { status: 200, body: { success: false, data: { pending: false } } };
+
+    await connectAndPollOnce();
+
+    expect(screen.getByText(BIND_FAILED_KEY)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #5028

`poll()` 的终止分支原来读 `body?.error?.code ?? t('cloudConnection.errors.bindFailed')`，
所以即使失败信封里已经带着一句人能读的话，渲染出来的仍是机器码。同一文件上方的
`getJson`（`:76`）早就用 `message ?? code ?? error` 这条链；本 PR 只把唯一偏离的那个
调用点拉回本文件已有的房规，不是新约定。

## 上游解锁引用

objectstack-ai/objectstack#9267 已于 2026-08-17 17:59:18Z 经 PR #9369（`d2e6b1d67`）落 main：
`/bind/poll` 的失败信封现在带 `error.message`（`Device authorization failed: expired_token`）
与 `error.declaredCode`（RFC 8628 原拼写），`data.pending: false` 刻意保留，轮询状态机不受影响。

## 前提复验读数（基线 `dc9d651a2c55c10a9e4d30434e429e5fdc5ae968`）

卡面钉的两处内容级读数，逐字复核，行号与卡面一致：

| 位置 | 基线内容 |
|---|---|
| `CloudConnectionPanel.tsx:128` | `setPhase({ kind: 'error', message: body?.error?.code ?? t('cloudConnection.errors.bindFailed') });` |
| `CloudConnectionPanel.tsx:76` | `const msg = body?.error?.message ?? body?.error?.code ?? body?.error ?? ` 加上 `HTTP ${resp.status}` 模板串 |

**但卡面的「症状归因」不成立，这是本 PR 与卡面唯一的实质差异。** 卡面预测上游落地后用户会看到
`DEVICE_CODE_FAILED`，即认为设备授权失败是由 `:128` 显示的。实测不是：

- 该信封由 `/bind/poll` 以 **HTTP 400** 下发（`packages/cloud-connection/src/cloud-connection-plugin.ts`，
  PR #9369 之前是 `pending ? 200 : 400`，之后仍是 `400`）；
- `getJson` 对任何「非 2xx 且 body 不是 `success: true`」的响应**先抛**（`:75`），
  `poll()` 的 catch（`:130`）渲染的是 `err.message`；
- 所以过期/被拒的设备码那句文案，一直由 `getJson` 那条已经正确的链选出。上游 message 一合并就到了 UI，本仓这一侧其实不欠这个。

**那么改动的这一行真正管什么**：只有 `getJson` **交还**的 body（2xx）且既无 `data.pending`
又无 `data.bound` 也无 `success: true` 才会落到这里。`/bind/poll` 恰有一个这样的出口 —— 它把控制面
`/bind` 的应答连状态码一起原样转发（`c.json(bindJson, bindResp.status)`）。控制面若以 200 回
`success: false`（其侧的信封违规，正是 objectstack#9364 还在清点的那一类），就落在这一支，
而这里过去显示的是码、不是它旁边那句话。

## 反向验证（方向先书面预判，commit 后变异，`git checkout --` 还原）

四个用例，编号见测试文件。注意 PM 派单模板预判的是「新信封用例变红」，而实测新信封用例（① 控制组）
**不可能**因这一行变红 —— 它从不走这一行；能分辨优先级的只有同时带两半的 ② 号。如实记录：

| 变异 | 预判 | 实测 | 一致 |
|---|---|---|---|
| 退回只读 `code` | ② 红（渲染 `ENVIRONMENT_BIND_FAILED`）；①③④ 绿 | `Tests 1 failed \| 3 passed`，失败即 ②，dump 里正是 `ENVIRONMENT_BIND_FAILED` | ✅ |
| 优先级写反 `code ?? message` | ② 红（码胜出）；①③④ 绿 | `Tests 1 failed \| 3 passed`，同一条、同一断言 | ✅ |
| 还原后 | 全绿 | `Test Files 2 passed / Tests 8 passed` | ✅ |

① 号在两次变异下都保持绿，就是「设备授权那句话不由这一行产生」的实测证据 —— 它作为控制组留在
文件里，好让下一个读者不必再去 `poll()` 里找那段文案。

## 验证

构建先行：

```
pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build
→ 全部 Done
```

测试（仓根，经共享 verify 锁，`--maxWorkers=2`）：

```
pnpm exec vitest run packages/app-shell/src/console
→ Test Files 50 passed (50) / Tests 362 passed (362)

pnpm exec vitest run \
  packages/app-shell/src/console/cloud-connection/__tests__/CloudConnectionPanel.bindError.test.tsx \
  packages/i18n/src/__tests__/cloudConnection-locale-parity.test.ts \
  packages/app-shell/src/console/marketplace/__tests__/readApiError.test.ts
→ Test Files 3 passed (3) / Tests 16 passed (16)
```

类型与门禁：

```
pnpm exec turbo run type-check --concurrency=2
→ Tasks: 81 successful, 81 total（exit 0）

pnpm exec eslint 改动的两个文件
→ 0 errors（6 warnings 全为基线既有的 no-explicit-any / set-state-in-effect，行号均不在本次改动内）

node scripts/check-control-bytes.mjs
→ OK（scanned 4503 tracked text files）
```

测试范围说明：app-shell 全量过重，按 `packages/app-shell/src/console` 目录跑（含本次新增文件），
另按消费半径把 `packages/i18n` 的 cloudConnection 平价测试与 marketplace 的 `readApiError` 一并跑过 ——
grep 全仓后，这三处是 `cloud-connection` 相关的全部测试面。

## 范围

只这一个调用点 + 一个测试文件 + 一个 changeset。卡面自留的 UX 题（是否一律偏好译文而非任何机器码）
不在本 PR 裁 —— 复验把它变成了一个更具体的 **翻译** 问题（线上那句话是英文，而面板对同一失败已有译文键
`cloudConnection.errors.expired`），已另立 finding 单记录（见下方评论），不夹带进本 PR。