### PR TITLE
docs(plugin-report): README 按真实导出面重写三处虚构导出与陈旧幸存清单

### DIFF
--- a/.changeset/plugin-report-readme-truth-5016.md
+++ b/.changeset/plugin-report-readme-truth-5016.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/plugin-report': patch
+---
+
+Docs only: `packages/plugin-report/README.md` no longer teaches three exports the
+package does not have (objectui#5016). Each was judged individually against the
+entry module's export surface, and all three turned out to be **survivors of the
+9.0 cutover** rather than renames — `CHANGELOG.md` records `ReportBuilder`,
+`ScheduleConfig` and the drill helpers as removed with the pre-9.0 query-form
+renderers, and the README kept teaching them afterwards:
+
+- **`ReportBuilder`** — taught as the main editor component. Removed; there is no
+  authoring component in this package. The Quick Start now teaches the real ones,
+  with their real signatures: `ReportRenderer` (the dispatcher, which takes the
+  report as `schema`), `DatasetReportRenderer` (which takes it as `report`), and
+  `ReportViewer` — whose props are `{ schema, onRefresh }`, so the old
+  `< ReportViewer report={…} showToolbar />` would not have compiled either.
+  `report` / `showToolbar` are keys inside a `ReportViewerSchema`.
+- **`registerDrillHandler(actionRunner, …)`** — taught as the drill registration
+  call. Removed, and its mechanism no longer exists: drill-down is now a host
+  callback, `onDrill?: (args: DatasetDrillArgs) => void`, and the host owns
+  navigation because the renderer only knows dimension names (ADR-0021 D2). The
+  section is rewritten around what a click actually emits, including why
+  `objectFilter` (raw stored values) is what filters select/lookup dimensions
+  correctly where a display-label `groupKey` would not.
+- **`ScheduleConfig`** — taught as a configuration component. Removed. A schedule
+  is *data* on the report schema: `ReportComponentSchema.schedule`, typed
+  `ReportScheduleConfig`. Both types live in `@object-ui/types` and are not
+  re-exported here, so the corrected snippet imports them from there —
+  `createScheduleTrigger` is the real export, and its real signature takes
+  `(report, dataSource, resource, onComplete)` and returns
+  `() => Promise< LiveExportResult[] >`, not the single callback the old snippet
+  passed.
+
+Two further leftovers of the same removal are corrected: the stale survivor
+sentence that listed `ReportBuilder` as still available, and the schema-driven
+example's `"type": "report-builder"`, which no component registers — the
+registered types are `report`, `spec-report` and `report-viewer`, now listed
+explicitly. The two feature bullets asserting the removed mechanisms (a
+`useReportData()` query pipeline, an `ActionRunner`-dispatched `drill` action)
+state the dataset-bound path instead.
+
+No code, types or runtime behaviour change — the diff is one README and this
+changeset. The correction reaches npm with the package's next publish, which is
+why it declares a patch: `README.md` is in the package's published `files`.

--- a/packages/plugin-report/README.md
+++ b/packages/plugin-report/README.md
@@ -1,14 +1,14 @@
 # @object-ui/plugin-report
 
-Report components for Object UI — build, view, render, and export reports with scheduling support.
+Report components for Object UI — render, view and export reports, with scheduling support. Report *authoring* is not part of this package.
 
 ## Features
 
 - 🧩 **Four spec report variants** — `tabular` / `summary` / `matrix` / `joined`, dispatched by a single `<ReportRenderer schema={...}>`
-- 🧮 **Server-side aggregation** — `useReportData()` posts spec `QueryAST` to `POST /api/v1/data/:object/query`; transparent in-memory fallback
+- 🧮 **Server-side aggregation** — a dataset-bound report selects measures by name through `dataSource.queryDataset`; totals come back pre-aggregated (ADR-0021)
 - 📅 **Date bucketing** — `dateGranularity: day|week|month|quarter|year` on `groupingsAcross` / `groupingsDown`
 - 🪜 **Multi-level grouping + totals** — row totals, column totals, grand totals for matrix; tabular/summary delegate to `ObjectGrid`
-- 🎯 **Cell drill-down** — every aggregated cell dispatches a `drill` action via `ActionRunner`; targets List view or a nested Report (M3)
+- 🎯 **Cell drill-down** — aggregated rows and matrix cells emit `DatasetDrillArgs` to the host's `onDrill` callback; the host owns navigation (ADR-0021 D2)
 - 🧱 **Joined reports** — vertically stacked sub-reports; each block owns its own `objectName`, filter and data fetch
 - 🎨 **Type-aware cells** — `select` → Badge, `lookup` → link, `boolean` → ✓/✗, `email`/`url`/`phone` → links, `image` → thumbnail (auto-hydrated from object metadata)
 - 🖨️ **Multi-format export** — CSV, JSON, HTML, PDF, Excel; live-data and Excel-formula variants
@@ -26,23 +26,55 @@ npm install @object-ui/plugin-report
 
 ## Quick Start
 
+`ReportRenderer` is the one entry point — a dispatcher that routes any report
+shape to the right renderer. It takes the report as `schema`; there is no
+report-authoring component in this package (see
+[Legacy presentation layer](#legacy-presentation-layer)).
+
 ```tsx
-import { ReportBuilder, ReportViewer, ReportRenderer } from '@object-ui/plugin-report';
+import { ReportRenderer } from '@object-ui/plugin-report';
 
-function ReportEditorPage() {
-  return <ReportBuilder report={initialReport} />;
-}
-
-function ReportViewPage() {
-  return <ReportViewer report={reportDefinition} showToolbar />;
-}
-
-function EmbeddedReport() {
+// `dataSource` and `router` are host-provided.
+function ReportPage() {
   return (
     <ReportRenderer
-      title="Monthly Sales"
-      description="Sales performance overview"
-      chart={chartConfig}
+      schema={{
+        name: 'opp_by_stage',
+        type: 'summary',
+        dataset: 'opportunity_pipeline',
+        rows: ['stage'],
+        values: ['amount_sum', 'deal_count'],
+      }}
+      dataSource={dataSource}
+      onDrill={({ object }) => router.push(`/records/${object}`)}
+    />
+  );
+}
+```
+
+The dataset-bound renderer can also be addressed directly when the host has
+already decided the shape — it takes the report as `report`, not `schema`:
+
+```tsx
+import { DatasetReportRenderer, isDatasetReport } from '@object-ui/plugin-report';
+
+if (isDatasetReport(stored)) {
+  return <DatasetReportRenderer report={stored} dataSource={dataSource} />;
+}
+```
+
+`ReportViewer` renders a presentation-layer report, and takes a whole
+`ReportViewerSchema` as `schema` — `report` / `showToolbar` are keys *inside*
+that schema, not props of the component:
+
+```tsx
+import { ReportViewer } from '@object-ui/plugin-report';
+
+function LegacyReportPage() {
+  return (
+    <ReportViewer
+      schema={{ type: 'report-viewer', report: reportDefinition, data: rows, showToolbar: true }}
+      onRefresh={refetch}
     />
   );
 }
@@ -115,22 +147,47 @@ with the container's; each block runs an isolated `useReportData()` call;
 
 ## Server-side aggregation + drill-down
 
-`useReportData()` translates a `Report` into spec `QueryAST` and posts it
-to `POST /api/v1/data/:object/query`. If the endpoint is unavailable it
-falls back transparently to `dataSource.find()` + client-side aggregation.
+A dataset-bound report selects its dimensions (`rows`, and for `matrix` also
+`columns`) and measures (`values`) **by name** and runs them through
+`dataSource.queryDataset` — the same governed semantic-layer path that
+dataset-bound dashboard widgets and the dataset preview use, so the numbers and
+the server-resolved dimension labels match everywhere. Totals (row subtotals,
+column subtotals, grand total) are **server-computed**: the renderer places the
+pre-aggregated rows it is handed and never re-aggregates bucketed values
+client-side, since measures like `avg` cannot be recombined without drifting
+from the semantic layer.
 
-Every aggregated cell dispatches a `drill` action through `ActionRunner`:
+Drill-down is a **host callback, not a registered handler**: pass `onDrill` and
+every aggregated row / matrix cell becomes clickable. The report emits *what was
+clicked*; the host decides where that goes, because the renderer only knows
+dimension names (ADR-0021 D2).
 
 ```tsx
-import { registerDrillHandler } from '@object-ui/plugin-report';
-registerDrillHandler(actionRunner, { navigate: router.push });
+import { ReportRenderer, type DatasetDrillArgs } from '@object-ui/plugin-report';
+
+<ReportRenderer
+  schema={report}
+  dataSource={dataSource}
+  onDrill={(args: DatasetDrillArgs) => {
+    // The host resolves dataset → object and dimension → field, then navigates.
+    const filter = { ...args.objectFilter, ...args.runtimeFilter };
+    router.push(`/records/${args.object}?filter=${encodeURIComponent(JSON.stringify(filter))}`);
+  }}
+/>
 ```
 
-Drill targets:
-1. **List view** — default; navigates to the filtered records.
-2. **Report drawer** — if the host widget declares `drillDown.report`,
-   the click opens a side drawer that renders that report scoped to the
-   cell's group key (composes dashboard → report → record).
+What a drill click carries:
+
+| `DatasetDrillArgs` | Meaning |
+| ------------------ | ------- |
+| `dataset`      | Dataset the clicked aggregate was computed over. |
+| `groupKey`     | Dimension **name** → clicked bucket value (row dims, plus across dims for a matrix cell). |
+| `runtimeFilter`| The effective render-time scope filter, if any. |
+| `object`       | The dataset's base object, when the server supplied it. |
+| `objectFilter` | Exact record-list filter (object **field** name → raw stored value) for the clicked bucket. Present only when the server returned the dimension→field mapping plus raw grouped values — that is what lets select/lookup dimensions filter precisely instead of by display label. |
+
+Supply no `onDrill` and nothing is clickable; a report can also opt out with
+`drilldown: false`.
 
 ## Filter-time date helpers — current limitation
 
@@ -150,13 +207,20 @@ filter: { close_date: { $gte: daysAgo(30) } }
 See the bundled CRM `customer_churn_signals` demo for the full pattern.
 Native filter-time CEL evaluation is tracked for a future major version.
 
-## Legacy components
+## Legacy presentation layer
 
-`ReportBuilder`, `ReportViewer` and the export functions below remain
-available for legacy presentation-layer reports and are not affected by
-the spec-driven pipeline above.
+`ReportViewer`, `LegacyReportRenderer` and the export functions below remain
+available for pre-spec presentation reports (`{ report, data, columns, chart }`)
+and are not affected by the dataset-bound pipeline above.
 
+The authoring components that used to sit alongside them — `ReportBuilder`,
+`ScheduleConfig`, `ChartConfig`, the columns/groupings editors — and the
+`registerDrillHandler`-style drill helpers were **removed** in the 9.0 cutover
+(see `CHANGELOG.md`). They have no replacement export in this package: report
+authoring lives in the console designer, and drill-down is the `onDrill`
+callback above.
 
+### Export
 
 Export reports in multiple formats:
 
@@ -188,31 +252,80 @@ await exportExcelWithFormulas(reportConfig, {
 });
 ```
 
-### ScheduleConfig
+### Scheduled export
 
-Configure recurring report generation:
+A schedule is **data on the report schema**, not a component: it is
+`ReportComponentSchema.schedule`, typed `ReportScheduleConfig`. Both types live
+in `@object-ui/types` and are *not* re-exported here — importing them from this
+package is a TS2305.
 
-```tsx
-import { ScheduleConfig, createScheduleTrigger } from '@object-ui/plugin-report';
+`createScheduleTrigger` turns that declared schedule into a callable a workflow
+engine can invoke. It takes the report, the data source, the resource to query
+and a completion callback:
 
-<ScheduleConfig
-  reportId="monthly-sales"
-  onSave={(schedule) => saveSchedule(schedule)}
-/>
+```ts
+import { createScheduleTrigger } from '@object-ui/plugin-report';
+import type { ReportComponentSchema, ReportScheduleConfig } from '@object-ui/types';
 
-const trigger = createScheduleTrigger((reportId) => generateReport(reportId));
+// `dataSource` and `notify` are host-provided.
+
+const report: ReportComponentSchema = {
+  type: 'report',
+  title: 'Monthly Sales',
+  schedule: {
+    enabled: true,
+    frequency: 'monthly',
+    dayOfMonth: 1,
+    time: '07:00',
+    formats: ['pdf', 'excel'],
+    recipients: ['sales@example.com'],
+  },
+};
+
+const trigger = createScheduleTrigger(
+  report,
+  dataSource,
+  'orders',
+  (exported: ReportComponentSchema, schedule: ReportScheduleConfig) => {
+    notify(schedule.recipients ?? [], schedule.subject ?? exported.title);
+  },
+);
+
+const results = await trigger(); // LiveExportResult[] — one entry per scheduled format
 ```
+
+`trigger()` reads `report.schedule` itself: a schedule that is missing or
+`enabled: false` exports nothing and resolves to `[]`. Otherwise it exports once
+per entry in `schedule.formats` (falling back to `report.defaultExportFormat`,
+then `'pdf'`) and calls the completion callback with the report and the schedule
+it ran.
 
 ### Schema-Driven Usage
 
-Components auto-register with `ComponentRegistry`:
+Importing the package registers three component types with `ComponentRegistry`:
+
+| `type`          | Component        | Notes                                              |
+| --------------- | ---------------- | -------------------------------------------------- |
+| `report`        | `ReportRenderer` | The dispatcher.                                    |
+| `spec-report`   | `ReportRenderer` | Spec-native alias; the report goes under `report`.  |
+| `report-viewer` | `ReportViewer`   | Presentation-layer viewer.                         |
 
 ```json
 {
-  "type": "report-builder",
-  "report": { "sections": [] }
+  "type": "spec-report",
+  "report": {
+    "name": "opp_by_stage",
+    "type": "summary",
+    "dataset": "opportunity_pipeline",
+    "rows": ["stage"],
+    "values": ["amount_sum"]
+  }
 }
 ```
+
+There is no `report-builder` component type — the authoring component that name
+addressed was removed in the 9.0 cutover, so a node declaring it resolves to
+nothing.
 
 ### Type-aware cell rendering
 


### PR DESCRIPTION
Fixes #5016

`packages/plugin-report/README.md` 教三个本包没有的导出。逐条判定后按 #5002 → PR #5021 的减法形重写:删虚构名、按真身重教,**不加任何新导出**。基线 `origin/main` = `dc9d651a2c55c10a9e4d30434e429e5fdc5ae968`,改动 1 个 README + 1 个 changeset。

> 正文里的 JSX 一律在 `<` 后留一个空格(`< ReportViewer …`)—— GitHub 会把 `<` + 字母当 HTML 标签吞掉。本 PR 正文第一版就在「删因」表里被吞了两处,读回后修正。

## 一、逐条判定:未实现 vs 改名

三条都不是「改名」,也不是「从未实现」—— 是 **ADR-0021 9.0 切换时已删除**的旧件,README 是那次删除的幸存者。判据不是 grep,而是 `packages/plugin-report/CHANGELOG.md:1284` 的原文:

> plugin-report: the pre-9.0 query-form renderers (SpecReportGrid, MatrixRenderer, JoinedReportRenderer), **the drill helpers**, and the legacy authoring components (**ReportBuilder**, ReportConfigPanel, ColumnsEditor, GroupingsBuilder, JoinedBlocksEditor, FieldPickerDialog, ChartConfig, **ScheduleConfig**) are removed.

| # | README 原文 | 判定 | 依据 | 修法 |
| --- | --- | --- | --- | --- |
| 1 | `:30/:33` `ReportBuilder` 当主编辑器组件 | **已删除**(非改名):没有任何名字承接「报表编辑器」这个角色,本包不再有编辑组件 | CHANGELOG:1284 列名;导出面 25 名无此名 | 删。Quick Start 改教真组件:`ReportRenderer`(dispatcher,取 `schema`)、`DatasetReportRenderer`(取 `report`)、`ReportViewer` |
| 2 | `:125-126` `registerDrillHandler(actionRunner, …)` | **已删除且机制更换**:不是换名,是换形 —— 从「注册 handler」变成「宿主回调」 | CHANGELOG:1284 "the drill helpers";真身是 `ReportRendererProps.onDrill?: (args: DatasetDrillArgs) => void`(`src/ReportRenderer.tsx:47-52`)、`DatasetReportRenderer.tsx:52-58` 的 ADR-0021 D2 注释 | 整节按真实下钻面重写:`onDrill` + `DatasetDrillArgs` 五个字段表,写明导航归宿主(renderer 只认 dimension 名) |
| 3 | `:191-198` `ScheduleConfig` 当组件 | **已删除**;近名 `ReportScheduleConfig` 是**类型**,且**不在本包** | CHANGELOG:1284 列名;`ReportScheduleConfig` 定义在 `packages/types/src/reports.ts:254`,由 `packages/types/src/index.ts:730` 导出,本包只 import(`src/LiveReportExporter.ts:27`)不 re-export | 按真身重教:排程是 `ReportComponentSchema.schedule` 上的**数据**,类型从 `@object-ui/types` 导入;`createScheduleTrigger` 按真签名 `(report, dataSource, resource, onComplete)` → `() => Promise< LiveExportResult[] >`(`src/LiveReportExporter.ts:245-251`) |
| 4 | `:155` "`ReportBuilder`, `ReportViewer` and the export functions below remain" | 陈旧幸存清单 | 同上 | 改为 `ReportViewer` / `LegacyReportRenderer` + 显式记下哪些是被删的,免得再被当成存活项加回来 |

⚠️ **卡面前提的一处修正**:卡面写 `ScheduleConfig` 的真身是「类型 `ReportScheduleConfig`(`src/LiveReportExporter.ts:27/:82`)」。类型确实存在,但那两行是 **import 与使用**,不是定义 —— 它在 `@object-ui/types`,本包不 re-export,所以写成 `import type { ReportScheduleConfig } from '@object-ui/plugin-report'` 会是 **TS2305**。这正是 #5010 那条 `CalendarViewSchema` 同形陷阱,修法(改导入路径)与 #1、#2(删)不同。README 里把这一点明写了出来。

## 二、名集合核对读数(导出面,非「src 里出现过」)

方法学按 #5010 评论:名集合取自 **TypeScript program 对包入口 `src/index.tsx` 的 exported symbols**(`checker.getExportsOfModule`),不是 grep src —— 注释里的名字和「只 import 不 re-export 的邻居包名字」都会骗过后者。README 侧按 **import 语句**解析,含多行 import 块与内联 `type` 修饰符。

导出面 25 名:`DatasetDrillArgs, DatasetReportRenderer, DatasetReportRendererProps, ExcelColumnConfig, LegacyReportRenderer, LegacyReportRendererProps, LiveExportOptions, LiveExportResult, ReportRenderer, ReportRendererProps, ReportRendererSchema, ReportViewer, ScheduleTriggerCallback, createScheduleTrigger, exportAsCSV, exportAsExcel, exportAsHTML, exportAsJSON, exportAsPDF, exportExcelWithFormulas, exportReport, exportWithLiveData, formatValue, isDatasetReport, mergeFilters`

**改前**(14 个自包命名导入 / 3 假):

```
README: 30  ReportBuilder            FAKE  <-- not on export surface
README: 30  ReportViewer             REAL
README: 30  ReportRenderer           REAL
README:125  registerDrillHandler     FAKE  <-- not on export surface
README:165  exportReport             REAL
README:166  exportAsCSV              REAL
README:167  exportAsJSON             REAL
README:168  exportAsHTML             REAL
README:169  exportAsPDF              REAL
README:170  exportAsExcel            REAL
README:183  exportWithLiveData       REAL
README:183  exportExcelWithFormulas  REAL
README:196  ScheduleConfig           FAKE  <-- not on export surface
README:196  createScheduleTrigger    REAL
result: 11 real / 3 fake
```

**改后**(仍是 14 个自包命名导入 / 0 假 —— 数量没掉,所以这个绿不是「把 import 全删光」换来的):

```
README: 35  ReportRenderer           REAL
README: 59  DatasetReportRenderer    REAL
README: 59  isDatasetReport          REAL
README: 71  ReportViewer             REAL
README:166  DatasetDrillArgs         REAL      (多行 import 块 + 内联 `type` 修饰符)
README:229  exportReport             REAL
README:230  exportAsCSV              REAL
README:231  exportAsJSON             REAL
README:232  exportAsHTML             REAL
README:233  exportAsPDF              REAL
README:234  exportAsExcel            REAL
README:247  exportWithLiveData       REAL
README:247  exportExcelWithFormulas  REAL
README:267  createScheduleTrigger    REAL
result: 14 real / 0 fake
```

跨包导入另行核对:`ReportComponentSchema`(`packages/types/src/index.ts:721`)、`ReportScheduleConfig`(`:730`)均在 `@object-ui/types` 导出面上;示例里的字面量也对过 union —— `frequency: 'monthly'` ∈ `ReportScheduleFrequency`(`reports.ts:47`),`formats: ['pdf','excel']` ⊂ `ReportExportFormat`(`:42`)。

## 三、每一节的「删因」

| 删/改 | 删因 |
| --- | --- |
| Quick Start 的 `ReportBuilder` 示例 | 组件不存在;顺带该块里 `< ReportViewer report={…} showToolbar />` 与 `< ReportRenderer title=… description=… chart={…} />` 也都不是真 props(见下方反向验证 (b)),照抄不编译 |
| `registerDrillHandler` 整节(含 "Drill targets" 两条) | 函数与机制都不存在;`drillDown.report` 侧抽屉那条也无对应读点,留着等于教一个不存在的 API 面 |
| `### ScheduleConfig` 组件块 | 组件不存在,且把「schema 上的数据」教成了「组件」,方向本身是错的 |
| `"type": "report-builder"` JSON 示例 | 同一次删除的第二个面:仓里没有任何 `ComponentRegistry.register('report-builder', …)`(`ReportBuilderSchema` 只剩 `packages/types` 里的 zod/TS 声明),照抄得到一个解析不到组件的节点。改为列出真实注册的三个 type |
| feature 条目 `:8` / `:11` | 分别断言 `useReportData()` 查询管线与 `ActionRunner` 派发的 `drill` action —— 正是 #1/#2 删掉的两个机制(`src/index.tsx:33-37` 记了 `useReportData` 随 ADR-0021 一并移除)。不改会与重写后的正文自相矛盾 |
| 标题行 `:3` "build, view, render" | 「build」指的就是被删的编辑器 |
| `### Export` 小标题 | 不是新增内容:原文 `:158-161` 是一段无标题的悬空引导句(同一次删除留下的空洞),补回标题让该节可读 |

## 四、验证

`README` 不进编译,所以另外三条都是为「照抄可跑」做的实证:

1. **名集合核对**:上表,3 假 → 0 假。
2. **示例真编译**:把 README 四个 tsx/ts 块原样抄进一个 scratch 文件,`@object-ui/plugin-report` 指向**构建产物** `packages/plugin-report/dist/index.d.ts`(即消费者看到的公开类型面),`@object-ui/types` 走仓根 paths → `tsc --noEmit` **0 error**。
3. **仓根 `pnpm exec turbo run type-check --concurrency=2`**:确认工位干净(结果见下方评论)。
4. **文档门禁**:`node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`(`packages/*/README.md` 在其 `SCAN_ROOTS` 内);`node scripts/check-control-bytes.mjs` → OK;改动文件 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 无命中;`check-changeset-no-major` 通过。

### 反向验证(两次,方向都是事先定好的)

**(a) 核对流程自证** —— 预期方向:注入的假名被抓出,且**能区分「src 里出现过」**。往改后 README 的 import 里临时塞两个名字,一个纯虚构(`ReportBuilder`)、一个**在 `src/` 里出现两次但不在导出面上**(`ReportScheduleConfig`,`LiveReportExporter.ts:27/:82`):

```
README:267  createScheduleTrigger    REAL
README:267  ReportBuilder            FAKE  <-- not on export surface
README:267  ReportScheduleConfig     FAKE  <-- not on export surface
result: 14 real / 2 fake
```

两个都被抓出。`ReportScheduleConfig` 这一个是判别性的:若核对用的是「src 里出现过」的近似,它会被判 REAL —— 被判 FAKE 才证明读的是导出面。临时改动已还原,`sha256` 与还原前逐字节相同(`c13ebf21bbed…`),未进 commit。
（读数口径说明:我脚本的退出码经了管道,所以以上以**读数**为证,不以 exit code 为证。）

**(b) 示例编译自证** —— 预期方向:把**旧** README 的三处写法放回 scratch 文件,`tsc` 必须转红,且报的错要正好对上我改的三处。实测转红(rc=2),三条一一对应:

```
error TS2322: Type '{ report: ReportComponentSchema; showToolbar: true; }' is not assignable to type 'IntrinsicAttributes & ReportViewerProps'.
  Property 'report' does not exist on type 'IntrinsicAttributes & ReportViewerProps'.
error TS2322: Type '{ title: string; description: string; chart: {}; }' is not assignable to type 'IntrinsicAttributes & ReportRendererProps'.
  Property 'title' does not exist on type 'IntrinsicAttributes & ReportRendererProps'.
error TS2554: Expected 4 arguments, but got 1.        // createScheduleTrigger 旧写法
```

即:旧 README 的 `ReportViewer` / `ReportRenderer` 用法**本来也编译不过**,不只是三个假名的问题 —— 这是本次顺带修正的部分。（`ReportBuilder` / `registerDrillHandler` 两个假名无法参与本项,它们连符号都不存在,由 (a) 覆盖。）

## 五、changeset 口径(请复核一处取舍)

按派发口径写成 `'@object-ui/plugin-report': patch`(README 在本包 published `files` 里,修正随下次 publish 到 npm)。**同族先例 PR #5021 选的是空 frontmatter**(「无代码/行为变更,不声明发版」),`scripts/check-changeset-presence.mjs` 也认为本次不欠 changeset(`0 of them under the src/`)。两种都过门禁;若维护者更认 #5021 的口径,把 frontmatter 清空即可,一行改动。

## 六、本单未修、已另立的发现(scope = 本 issue)

- **#5047** —— 同文件其余部分与 `content/docs/plugins/plugin-report.mdx` 仍把**前 9.0 查询形**(`objectName` + `columns` + `groupingsDown/Across`)当作现行写法教,并点名三个已退休的 renderer(`SpecReportGrid` / `MatrixRenderer` / `JoinedReportRenderer`)。是 schema 形态问题,不是导出名问题,且牵涉 ADR-0021 迁移口径的取舍,不该由实施者代决。
- **#5048** —— README 三个导出示例的**签名/参数序**全错(名字都是真的,所以名集合核对看不见):`exportAsCSV(reportData, 'sales-report.csv')` 把文件名传进了 `data` 位;`exportWithLiveData` 缺必填 `dataSource`/`resource`;`exportExcelWithFormulas` 少一个参数且列键应为 `name` 而非 `field`。

两条都先搜过在开 issue(关键词 + 文件路径),无重复;均未打 `finding` 标签,交 PM 分诊。