### PR TITLE
fix(plugin-form): redirect 的 delayMs 等待改由组件持有,unmount 即取消 (#5033)

### DIFF
--- a/.changeset/form-redirect-delay-timer-lifetime-5033.md
+++ b/.changeset/form-redirect-delay-timer-lifetime-5033.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+A form's declared redirect delay no longer outlives the form that armed it.
+
+`ObjectForm` and `WizardForm` consumed `submitBehavior: { kind: 'redirect' }` by
+arming the `delayMs` wait with a bare `setTimeout` inside the submit handler. The
+handle was not stored, nothing cleared it on unmount, and no part of the component
+owned it — so for the whole of the declared delay there was a pending full-page
+navigation that survived the form being taken off screen (objectui#5033). A
+submitter who dismissed the modal or drawer variant after the confirmation, who
+clicked an in-app link, or whose host re-keyed the subtree for its own reasons was
+pulled away from wherever they had gone by a timer belonging to a form that no
+longer existed. The longer the authored delay, the wider that window — and a
+non-trivial delay is the intended authoring, since `delayMs` exists so the
+confirmation is readable before the redirect.
+
+The wait now lives in an effect keyed on the accepted destination, with a
+`clearTimeout` cleanup, so unmounting cancels it. This is the same move
+`apps/console`'s `FormPage` already made for its own copy of this defect.
+
+`delayMs` semantics are unchanged: the pause is still a pause, an unset value is
+still "go now" (a zero timer, exactly as the in-handler version scheduled it), and
+which destinations are followed or refused is untouched — the contract verdict
+that decides WHETHER to navigate is the same one, only WHEN it happens is now
+owned by the component. The delay is captured together with the destination at the
+moment the write is accepted, so a host re-rendering with a different `delayMs`
+mid-wait cannot restart the pause under the submitter. Nothing was ever at risk of
+being lost: the write has already succeeded before the wait begins, so the harm
+was a surprising navigation, not a corrupted record.

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -430,6 +430,42 @@ const SimpleObjectForm: React.FC<ObjectFormComponentProps> = ({
     { title?: string; message?: string; refusal?: string } | null
   >(null);
 
+  // The accepted destination of a `submitBehavior: { kind: 'redirect' }` submit,
+  // together with the delay declared for it, held from the moment the write
+  // succeeds until the wait below elapses (objectui#5033).
+  //
+  // The wait used to be a bare `setTimeout` armed inside the submit handler:
+  // nothing stored the handle and nothing cleared it, so for the whole of
+  // `delayMs` a full-page navigation was pending that OUTLIVED this component. A
+  // submitter who dismissed the modal/drawer variant, followed an in-app link, or
+  // whose host re-keyed the subtree was pulled away from wherever they had gone.
+  // Recording the destination here hands the wait to the effect below, which owns
+  // it for exactly as long as this component is mounted.
+  //
+  // The delay travels WITH the destination rather than being re-read from
+  // `schema.submitBehavior` at wait time: the value honoured is the one declared
+  // when the write was accepted, so a host re-rendering with a different
+  // `delayMs` mid-wait cannot restart the pause under the submitter.
+  const [pendingRedirect, setPendingRedirect] = useState<
+    { url: string; delayMs: number } | null
+  >(null);
+
+  // The delayed leg of a `redirect` submit behaviour.
+  //
+  // `delayMs` semantics are unchanged: the pause is what makes the confirmation
+  // readable, and an unset value still means "go now" (a zero timer, exactly as
+  // the in-handler version scheduled it). The one thing that changed is who owns
+  // the wait — unmounting cancels it instead of leaving it to fire into a page
+  // the submitter has left.
+  useEffect(() => {
+    if (!pendingRedirect) return;
+    const timer = setTimeout(
+      () => window.location.assign(pendingRedirect.url),
+      pendingRedirect.delayMs,
+    );
+    return () => clearTimeout(timer);
+  }, [pendingRedirect]);
+
   // OCC-guarded edit save + its conflict dialog (see occSave.tsx).
   const { saveWithOcc, conflictDialog } = useOccSave();
 
@@ -843,7 +879,11 @@ const SimpleObjectForm: React.FC<ObjectFormComponentProps> = ({
               });
               break;
             }
-            setTimeout(() => window.location.assign(verdict.url), behavior.delayMs ?? 0);
+            // Record the destination; the effect that owns the wait takes it
+            // from here (objectui#5033). Nothing about the verdict flow above
+            // changes — this arm still decides WHETHER to navigate, only no
+            // longer WHEN, because a timer armed here answered to nobody.
+            setPendingRedirect({ url: verdict.url, delayMs: behavior.delayMs ?? 0 });
             break;
           }
           case 'continue':

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -247,6 +247,29 @@ export const WizardForm: React.FC<WizardFormProps> = ({
   const [submitted, setSubmitted] = useState<
     { title?: string; message?: string; refusal?: string } | null
   >(null);
+  // The accepted destination of a `submitBehavior: { kind: 'redirect' }` submit
+  // plus the delay declared for it (objectui#5033). Same reasoning as
+  // ObjectForm's copy of this state, and the same reason it is a state and not a
+  // timer armed in the handler: a bare `setTimeout` there was owned by nobody, so
+  // the pending full-page navigation outlived this wizard and yanked back a
+  // submitter who had closed the modal/drawer variant or navigated on. The delay
+  // is captured with the destination so the pause cannot be restarted mid-wait by
+  // a host re-render carrying a different `delayMs`.
+  const [pendingRedirect, setPendingRedirect] = useState<
+    { url: string; delayMs: number } | null
+  >(null);
+
+  // The delayed leg of a `redirect` submit behaviour, owned by this component:
+  // unmounting cancels the wait. `delayMs` semantics are untouched — the pause is
+  // still a pause, an unset value is still a zero timer, i.e. "go now".
+  React.useEffect(() => {
+    if (!pendingRedirect) return;
+    const timer = setTimeout(
+      () => window.location.assign(pendingRedirect.url),
+      pendingRedirect.delayMs,
+    );
+    return () => clearTimeout(timer);
+  }, [pendingRedirect]);
 
   // Stable id for the *inner* step form's <form> element. The wizard's
   // Next/Create buttons live in the footer, OUTSIDE that form, and submit it
@@ -525,7 +548,10 @@ export const WizardForm: React.FC<WizardFormProps> = ({
                 });
                 break;
               }
-              setTimeout(() => window.location.assign(verdict.url), behavior.delayMs ?? 0);
+              // Hand the accepted destination to the effect that owns the wait
+              // (objectui#5033). The verdict flow above is unchanged: this arm
+              // still decides WHETHER to navigate, no longer when.
+              setPendingRedirect({ url: verdict.url, delayMs: behavior.delayMs ?? 0 });
               break;
             }
             case 'continue':

--- a/packages/plugin-form/src/submitRedirect.timerLifetime.test.tsx
+++ b/packages/plugin-form/src/submitRedirect.timerLifetime.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5033 — the declared `submitBehavior: { kind: 'redirect' }` delay must
+ * not outlive the component that armed it.
+ *
+ * Both rendered forms used to arm the wait with a bare `setTimeout` inside the
+ * submit handler: the timer was not stored, not cleared, and owned by nobody. So
+ * for the whole of `delayMs` there was a pending full-page navigation that
+ * survived the form being taken off screen — a submitter who dismissed a
+ * modal/drawer variant, clicked an in-app link, or whose host re-keyed the
+ * subtree was pulled away from wherever they went. The wait now lives in an
+ * effect keyed on the pending destination, so unmount cancels it.
+ *
+ * ## What each half measures, and why both are needed
+ *
+ * The unmount pin alone can pass for the WRONG reason: a form that never arms
+ * the wait at all also assigns nothing after unmount. Two things stop that empty
+ * pass from reading as a fix. Each unmount case first REQUIRES the wait to have
+ * been armed (see below), so a form that arms nothing fails there rather than
+ * sailing through to a satisfied `not.toHaveBeenCalled()`. And each is paired
+ * with a same-schema case that does NOT unmount and asserts the destination IS
+ * reached once the delay ends, so deleting the redirect outright is red too.
+ *
+ * ## Why a real clock, and how the arming is observed without racing it
+ *
+ * The submit path is a chain of awaited promises, so faking the clock around it
+ * makes the observation race the resolution rather than the delay — the reason
+ * the two component redirect files measure `delayMs` with real timers too. This
+ * file keeps the real clock and instead makes ARMING observable: `setTimeout` is
+ * wrapped by a pass-through spy that records calls carrying this file's
+ * distinctive delay value. The unmount therefore provably happens AFTER the wait
+ * was armed, which is the only ordering that can falsify anything.
+ *
+ * `delayMs` semantics are unchanged by this file's subject: an unset value still
+ * means "go now" (a zero timer) and is covered by the `navigates to a ruled
+ * relative path` cases in `ObjectForm.submitRedirect.test.tsx` /
+ * `WizardForm.submitRedirect.test.tsx`. It is deliberately not raced against an
+ * unmount here — there is no window to unmount inside of, and a test that tried
+ * would measure scheduler luck.
+ *
+ * ## Counterfactuals (measured, see the PR for the run)
+ *
+ * 1. **Restore the bare in-handler `setTimeout`** (i.e. revert the fix): the two
+ *    `assigns nothing after the form is unmounted` cases go red on
+ *    `expect(assign).not.toHaveBeenCalled()`, having been handed the url by a
+ *    timer that outlived the component.
+ * 2. **Drop the `clearTimeout` from the effect cleanup**: same two cases, same
+ *    assertion — the cleanup is the whole mechanism.
+ * 3. **Key the effect on a constant (`[]`)**: the wait is then never armed at all.
+ *    Note the direction, because it is not the one a reader expects from a file
+ *    about unmount safety: ALL FOUR cases go red, and all four on the same
+ *    `armed.length` assertion rather than on an `assign` one — the unmount pair
+ *    included, because arming is a precondition here and not an assumption. That
+ *    is the whole point of observing it: a mutation that quietly removes the
+ *    redirect cannot buy a green unmount case with an empty one. (The navigation
+ *    cases in both component redirect files go red under this mutation too.)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import { ObjectForm } from './ObjectForm';
+import { WizardForm } from './WizardForm';
+import { registerAllFields } from '@object-ui/fields';
+
+registerAllFields();
+
+/**
+ * A declared delay long enough to unmount inside, distinctive enough that the
+ * pass-through spy below can recognise the form's own timer among the ones React
+ * and the testing library schedule.
+ */
+const DELAY_MS = 137;
+
+const objectSchema = {
+  name: 'o',
+  fields: { name: { type: 'text', label: 'Name' } },
+};
+
+const makeDS = () => ({
+  getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+  create: vi.fn(async (_o: string, d: any) => ({ id: 'r1', ...d })),
+  update: vi.fn(),
+  findOne: vi.fn(),
+});
+
+const waitInput = (c: HTMLElement, name: string) =>
+  waitFor(() => {
+    const el = c.querySelector(`input[name="${name}"]`) as HTMLInputElement | null;
+    if (!el) throw new Error(`${name} not ready`);
+    return el;
+  });
+
+const realSetTimeout = globalThis.setTimeout;
+/** Real-clock sleep, taken before the spy is installed so it is never recorded. */
+const sleep = (ms: number) => new Promise((resolve) => { realSetTimeout(resolve, ms); });
+
+let assign: ReturnType<typeof vi.spyOn>;
+let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+/** One entry per `setTimeout(_, DELAY_MS)` — i.e. per armed redirect wait. */
+let armed: number[];
+
+beforeEach(() => {
+  armed = [];
+  assign = vi.spyOn(window.location, 'assign').mockImplementation(() => {});
+  setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+    cb: any,
+    ms?: number,
+    ...rest: any[]
+  ) => {
+    if (ms === DELAY_MS) armed.push(ms);
+    return (realSetTimeout as any)(cb, ms, ...rest);
+  }) as any);
+});
+
+afterEach(() => {
+  setTimeoutSpy.mockRestore();
+  assign.mockRestore();
+});
+
+/** Renders a flat form whose redirect declares this file's delay, and submits it. */
+async function submitObjectForm(ds: ReturnType<typeof makeDS>) {
+  const view = render(
+    <ObjectForm
+      schema={{
+        type: 'object-form', objectName: 'o', mode: 'create',
+        submitBehavior: { kind: 'redirect', url: '/apps/x/done', delayMs: DELAY_MS },
+      } as any}
+      dataSource={ds as any}
+    />,
+  );
+  fireEvent.change(await waitInput(view.container, 'name'), { target: { value: 'Alpha' } });
+  fireEvent.submit(view.container.querySelector('form') as HTMLFormElement);
+  await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+  return view;
+}
+
+/** Same declaration, driven through the wizard's last step. */
+async function submitWizardForm(ds: ReturnType<typeof makeDS>) {
+  const view = render(
+    <WizardForm
+      schema={{
+        type: 'object-form', formType: 'wizard', objectName: 'o', mode: 'create',
+        sections: [{ label: 'A', fields: ['name'] }],
+        submitBehavior: { kind: 'redirect', url: '/apps/x/done', delayMs: DELAY_MS },
+      } as any}
+      dataSource={ds as any}
+    />,
+  );
+  fireEvent.change(await waitInput(view.container, 'name'), { target: { value: 'Alpha' } });
+  fireEvent.submit(view.container.querySelector('form') as HTMLFormElement);
+  await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+  return view;
+}
+
+/** Waits until the form has armed its wait, and checks it has not fired yet. */
+async function waitUntilArmed() {
+  await waitFor(() => expect(armed.length).toBe(1));
+  expect(assign).not.toHaveBeenCalled();
+}
+
+describe('objectui#5033 — ObjectForm redirect delay is owned by the component', () => {
+  it('assigns nothing after the form is unmounted mid-delay', async () => {
+    const ds = makeDS();
+    const view = await submitObjectForm(ds);
+    await waitUntilArmed();
+
+    // The submitter closes the modal/drawer, or the host re-keys the subtree.
+    view.unmount();
+
+    // Well past the declared delay on the real clock.
+    await sleep(DELAY_MS * 5);
+    expect(assign).not.toHaveBeenCalled();
+    // The write itself already succeeded — cancelling the wait does not undo it.
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('reaches the destination when the delay ends on a mounted form', async () => {
+    const ds = makeDS();
+    await submitObjectForm(ds);
+    await waitUntilArmed();
+
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/apps/x/done'));
+    expect(assign).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('objectui#5033 — WizardForm redirect delay is owned by the component', () => {
+  it('assigns nothing after the wizard is unmounted mid-delay', async () => {
+    const ds = makeDS();
+    const view = await submitWizardForm(ds);
+    await waitUntilArmed();
+
+    view.unmount();
+
+    await sleep(DELAY_MS * 5);
+    expect(assign).not.toHaveBeenCalled();
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('reaches the destination when the delay ends on a mounted wizard', async () => {
+    const ds = makeDS();
+    await submitWizardForm(ds);
+    await waitUntilArmed();
+
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/apps/x/done'));
+    expect(assign).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #5033

基线 `dc9d651a2c55c10a9e4d30434e429e5fdc5ae968`(即 PR #5041 的 tip)。

## 改了什么

`ObjectForm` 与 `WizardForm` 消费 `submitBehavior: { kind: 'redirect' }` 时,在提交处理器里裸 `setTimeout(() => window.location.assign(verdict.url), behavior.delayMs ?? 0)`:句柄不存、unmount 不清、无人拥有。整个声明延迟窗口内都挂着一次全页导航,而它活得比组件长 —— 用户在确认后关掉 modal/drawer 变体、点了站内链接,或宿主自行重挂子树,都会被一个已不存在的表单的定时器拽走。

等待现在住在以「已裁定目的地」为键的 effect 里,cleanup `clearTimeout`。形状照 `apps/console` 的 `FormPage` 对同一缺陷已落地的 PR #4992:提交臂只记「待定目的地」状态,effect 武装定时器,cleanup 取消。

延迟与目的地在**写入被接受的那一刻**一起被捕获(`{ url, delayMs }` 一个状态),而不是等待时再从 `schema.submitBehavior` 读一遍 —— 被兑现的是写入被接受时声明的那个值,宿主中途以不同 `delayMs` 重渲染无法在用户脚下重启停顿。

## 语义账本(逐条:动了什么、没动什么)

| 项 | 之前 | 之后 |
| --- | --- | --- |
| `delayMs` 设了值 | 停顿后导航 | 停顿后导航(不变) |
| `delayMs` 未设 | `setTimeout(fn, 0)`,即宏任务后走 | 仍是零延迟定时器(状态提交 + effect 后排的同一个 0 定时器);**没有**为了「立即走」改成同步 assign,那才会改时序 |
| 哪些目的地被跟随 / 被拒绝 | `checkSubmitRedirectUrl` / `resolveSubmitRedirect` 裁定 | 分毫未动 —— #4989 / PR #5032 落地的契约裁定流(verdict 的产生与消费点)一行未改;本 PR 只换「何时导航」的所有权 |
| 拒绝路径(`!verdict.ok`) | toast + `setSubmitted({ refusal })`,不导航 | 不变(不进 pending 状态,也就没有等待可武装) |
| unmount 落在延迟窗口内 | 定时器照 fire,全页导航 | cleanup 取消,什么都不发生 |
| 延迟窗口内二次提交(表单在延迟期间仍挂着) | 两个定时器都排着,两次待定导航 | effect 重跑:先 `clearTimeout` 旧的,再武装新目的地 —— 最后被接受的目的地胜出。附带收益,不是 `delayMs` 语义变更 |
| 数据 | 等待开始前写入已成功 | 同上;取消等待不会回滚写入(钉子测试顺带断言 `create` 仍是 1 次) |

## 前提复现读数(改动前,基线 dc9d651a2)

新钉子文件先在**未改动**的基线上跑,复现「unmount 后计时器仍 fire」:

```
❯ src/submitRedirect.timerLifetime.test.tsx (4 tests | 2 failed)
   × assigns nothing after the form is unmounted mid-delay 771ms
   × assigns nothing after the wizard is unmounted mid-delay 737ms

AssertionError: expected "assign" to not be called at all, but actually been called 1 times
Received: 1st assign call: Array [ "/apps/x/done" ]

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

两条 unmount 用例红、配对的「不 unmount」两条绿 —— 与预判一致:缺陷只在生命周期上,功能本身是通的。

## 钉子测试

`packages/plugin-form/src/submitRedirect.timerLifetime.test.tsx`,两组件各一对:

- **unmount 对**:武装延迟 → `unmount()` → 走完真实时钟(声明延迟的 5 倍)→ 断言未发生任何 `assign`,且 `create` 仍是 1 次。
- **挂载对**(同一 schema,不 unmount):延迟到点后目的地照旧到达,`assign` 恰好 1 次。防止「把功能修没」也拿到绿。

武装本身被**显式观测**:`setTimeout` 套一层 pass-through spy,只记本文件那个独特延迟值(137ms)的调用,`waitFor` 等到武装完成才 unmount。这一条是关键 —— 它保证 unmount 发生在武装**之后**(唯一能falsify任何东西的次序),并且让「什么都没武装」的变异无法用空绿冒充修好。真实时钟而非 fake timers:提交路径是一串 await 的 promise,假时钟会让观测去和 resolution 抢时间而不是和延迟抢 —— 两个既有 redirect 测试文件测 `delayMs` 也是同样理由用真时钟。

`delayMs` 未设的「立即走」不在本文件里和 unmount 对赌:没有可以插进去的窗口,那样的测试量的是调度运气;它由两个组件既有 redirect 文件里的 `navigates to a ruled relative path` 覆盖。

## 反向验证(先书面预判,commit 后变异,`git checkout --` 还原)

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| ① 删掉两处 cleanup 的 `clearTimeout` | 恰好两条 unmount 用例红,红在 `expect(assign).not.toHaveBeenCalled()`(收到 `["/apps/x/done"]`);挂载对与既有 redirect 文件全绿 | **完全一致**:`Tests 2 failed \| 18 passed (20)`,两条 `AssertionError: expected "assign" to not be called at all, but actually been called 1 times`,行号 176 / 200 |
| ② effect 依赖键改成恒空数组 `[]` | 方向**不是**读者预期的那个:等待压根不武装,于是**四条全红**,且全红在 `armed.length` 而非任何 `assign` 断言上 —— unmount 对也红,因为「已武装」在本文件是前置条件不是假设;既有两个 redirect 文件的导航用例一并红 | **完全一致**:`Tests 13 failed \| 7 passed (20)`。我的四条全部 `AssertionError: expected +0 to be 1`,同一行 `timerLifetime.test.tsx:161`(即 `waitUntilArmed`);另外 9 条是两个既有文件的 `expected "assign" to be called with arguments: [ … ]` |
| 还原后 | 全绿 | `Test Files 3 passed (3) / Tests 20 passed (20)` |

②的方向已写进测试文件头注:一个悄悄把 redirect 删掉的变异**买不到**绿的 unmount 用例,这正是显式观测武装的目的。

## 验证

- 依赖构建:`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-form^...' build` → Done
- 包全量(仓根,路径过滤):`pnpm exec vitest run packages/plugin-form --maxWorkers=2` → `Test Files 52 passed (52) / Tests 539 passed (539)`
- 仓根类型检查:`pnpm exec turbo run type-check --concurrency=2` → `Tasks: 81 successful, 81 total`,exit 0
- `pnpm --filter @object-ui/plugin-form lint` → `0 errors`(576 个既有 `any` warning,与本改动无关)
- `node scripts/check-control-bytes.mjs` → OK(4505 个文件);改动文件另做 `grep -naP` 自扫,零命中

一切测试读数取自**仓库根目录**的规范跑法(AGENTS.md §怎么跑测试)。派发单里「若 setupFiles 是 cwd 相对路径就 cd 进包跑」这条没有用到:仓根跑法下本文件由根 `dom` project 收集(用根 setup),不需要绕过 `vitest-invocation-guard`。

## 顺手发现(未在本 PR 修)

filed as #5049:`EmbeddableForm.tsx` 的 thank-you redirect 是**同一缺陷类的第三个调用点**(`thankYouPage.redirectUrl` / `redirectDelay`,默认延迟 3000ms),而且它连 unmount 都不需要 —— `allowMultiple` 的 `Submit Another Response` 按钮只把 `submitted` 翻回 false,待定导航照旧走完,用户正在重填第二份时整页被丢掉。#5033 的卡片只点名 `ObjectForm.tsx` / `WizardForm.tsx`,该处配置键与 host 白名单契约(`isRedirectUrlSafe` / `allowedRedirectHosts`)都是另一套,故按范围纪律另立卡片,本 PR 原样未动。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_