### PR TITLE
fix(components): span 渲染器读规范子节点键 `children`,html tier 的文字不再被静默丢弃

### DIFF
--- a/.changeset/span-renders-canonical-children-5027.md
+++ b/.changeset/span-renders-canonical-children-5027.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/components': patch
+---
+
+The `span` renderer renders its content again — it reads `children`, the key its own type declares and its producers emit.
+
+The renderer read `schema.body` and nothing else, and no producer on either of
+its authoring surfaces emits that key. In a `kind:'html'` page the parser
+assigns compiled child nodes to `children`
+(`@object-ui/sdui-parser`'s `parse.ts`), so an author writing the plain inline
+tag with text inside it got an EMPTY element back — the text was dropped with no
+warning and no diagnostic, because the parser's tree validation does not inspect
+child keys. A sibling paragraph on the same page rendered normally, which is what
+made this read as anything but a compile failure. On the JSON surface the same
+thing happened to anyone following the declaration: `TextSpanSchema` declares
+`value` and `children`, so `children` is what an author writes, and `children` is
+what rendered nothing.
+
+The canonical child key is `children` — what the type declares, what the parser
+emits, and what the sibling `div` renderer already reads. `body` is deliberately
+NOT accepted as a second spelling: a tolerant read would fossilize a second
+de-facto contract for the one type whose declaration never named it
+(Commandment #0.1), and a repo sweep found no page, example, catalog entry or
+metadata document authoring it on this tag. A pin test states both halves — the
+content renders, and a `body` alias renders nothing — so re-adding the lenient
+read turns a test red rather than passing review.
+
+Reachability, stated plainly: the `span` type is deprecated for JSON-authored
+pages, but it is permanent first-class vocabulary of the `kind:'html'` tier,
+where the tag is compiled straight through and no other spelling exists. So the
+authors who could do nothing about the deprecation were exactly the ones losing
+their text.
+
+Not changed here, and named because the declaration still promises it: `value`
+on this tag is declared by `TextSpanSchema` and read by nobody, as it was before
+this fix. Making it render needs a ruling on precedence against `children`,
+which belongs with the wider child-key drift (objectui#4631) rather than in a
+rendering-path fix.

--- a/content/docs/components/basic/span.mdx
+++ b/content/docs/components/basic/span.mdx
@@ -57,8 +57,7 @@ interface SpanSchema {
   
   // Content
   value?: string;                        // Text content
-  children?: SchemaNode | SchemaNode[];  // Child components
-  body?: SchemaNode | SchemaNode[];      // Alternative content prop
+  children?: SchemaNode | SchemaNode[];  // Child components (the child key this component reads)
   
   // Styling
   className?: string;                    // Tailwind CSS classes

--- a/packages/components/src/__tests__/basic-renderers.test.tsx
+++ b/packages/components/src/__tests__/basic-renderers.test.tsx
@@ -125,7 +125,10 @@ describe('Basic Renderers - Display Issue Detection', () => {
     it('should render inline content', () => {
       const { container } = renderComponent({
         type: 'span',
-        body: [{ type: 'text', content: 'Inline text' }],
+        // Canonical child key — what `TextSpanSchema` declares and what the
+        // renderer reads (objectui#5027). This case used to spell `body`, the
+        // one key nothing produced, which is what kept the defect invisible.
+        children: [{ type: 'text', content: 'Inline text' }],
       });
 
       const span = container.querySelector('span');

--- a/packages/components/src/__tests__/span-children-rendering.test.tsx
+++ b/packages/components/src/__tests__/span-children-rendering.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `span` renderer reads the child key its own type declares (objectui#5027).
+ *
+ * It used to read `schema.body` and nothing else, while every producer on both
+ * of its authoring surfaces emits `children`:
+ *
+ *   - the `kind:'html'` tier — `sdui-parser`'s `parse.ts` assigns compiled child
+ *     nodes to `node.children`, so an author writing the plain inline tag with
+ *     text in it got an EMPTY element back. No diagnostic: the parser's
+ *     `validateTree` does not inspect child keys, so the text was dropped in
+ *     silence. The sibling paragraph on the same page rendered normally, which
+ *     is what made this look like anything but a compile failure.
+ *   - the JSON surface — `TextSpanSchema` declares `value` and `children`. An
+ *     author following the declaration got the same empty element.
+ *
+ * The canonical key is `children`: that is what the type declares, what the
+ * parser emits, and what the sibling `div` renderer already reads. `body` is
+ * deliberately NOT accepted as a second spelling — a tolerant `||` here would
+ * fossilize a second de-facto contract for the one type whose declaration never
+ * named it (Commandment #0.1). The third case below pins that.
+ *
+ * Note on what the type surface can and cannot say: `body` was never a type
+ * ERROR on a span, because `BaseSchema` declares both child keys and carries an
+ * index signature. So the read side is the only place this can be stated, which
+ * is exactly why it is stated here rather than left to review.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+import type { TextSpanSchema } from '@object-ui/types';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+/** Renders a `kind:'html'` page — source compiled by the parser, then rendered. */
+function renderHtmlPage(source: string) {
+  return render(<SchemaRenderer schema={{ type: 'home', kind: 'html', name: 'test_page', source } as never} />);
+}
+
+describe('span renders its canonical child key (#5027)', () => {
+  it('renders the text an html-tier author wrote inside the inline tag', () => {
+    // The reproduction from the card, byte for byte: the inline tag's text used
+    // to vanish while the paragraph next to it rendered.
+    const { container } = renderHtmlPage(
+      '<div className="outer"><span className="inner">hello html tier</span><p>page rendered</p></div>',
+    );
+
+    // Control first: a compile error replaces the whole page with an error
+    // panel, which would fail the assertions below for the wrong reason.
+    expect(container.textContent).not.toContain('failed to compile');
+    expect(container.textContent).toContain('page rendered');
+
+    const span = container.querySelector('span.inner');
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toBe('hello html tier');
+  });
+
+  it('renders `children` authored on the JSON surface, as TextSpanSchema declares it', () => {
+    const schema: TextSpanSchema = {
+      type: 'span',
+      className: 'json-authored',
+      children: [{ type: 'text', value: 'inline from children' }],
+    };
+
+    const { container } = render(<SchemaRenderer schema={schema} />);
+
+    const span = container.querySelector('span.json-authored');
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toContain('inline from children');
+  });
+
+  it('accepts a single child node, not only an array — the declaration allows both', () => {
+    const schema: TextSpanSchema = {
+      type: 'span',
+      className: 'single-child',
+      children: { type: 'text', value: 'lone child' },
+    };
+
+    const { container } = render(<SchemaRenderer schema={schema} />);
+
+    expect(container.querySelector('span.single-child')?.textContent).toContain('lone child');
+  });
+
+  it('does not accept a `body` alias — one contract, not two spellings', () => {
+    // Guarding the removal, not the defect: re-adding a lenient read here would
+    // make this red. `body` never entered this type's declaration, and a repo
+    // sweep at the time of the fix found no page, example, catalog entry or
+    // metadata document authoring it on a span.
+    const { container } = render(
+      <SchemaRenderer
+        schema={{
+          type: 'span',
+          className: 'alias-probe',
+          body: [{ type: 'text', value: 'must not render' }],
+        } as never}
+      />,
+    );
+
+    const span = container.querySelector('span.alias-probe');
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toBe('');
+    expect(container.textContent).not.toContain('must not render');
+  });
+});

--- a/packages/components/src/__tests__/span-deprecation-provenance.test.tsx
+++ b/packages/components/src/__tests__/span-deprecation-provenance.test.tsx
@@ -39,15 +39,21 @@
  *
  * NOTE ON THE RENDER CONTROL — this deliberately does NOT copy the sibling
  * `div` test's control assertion. That test proves the html page really
- * rendered by reading the box tag's own text back out; the inline tag's text
- * never arrives, because this renderer reads `schema.body` while the parser
- * emits `children` (objectui#5027, filed separately — a rendering-path defect,
- * not a notice-scoping one, and one that needs its own ruling on which key is
- * canonical). The control here therefore uses a sibling paragraph's text plus
- * the presence of the inline element itself: together they prove the page
- * compiled AND that the node reached this deprecated renderer, so silence is an
- * exemption rather than a missing node. Both assertions still hold once #5027
- * is fixed.
+ * rendered by reading the box tag's own text back out. When this file was
+ * written the inline tag's text never arrived, because the renderer read
+ * `schema.body` while the parser emits `children` — filed separately as
+ * objectui#5027, since it was a rendering-path defect rather than a
+ * notice-scoping one and needed its own ruling on which key is canonical. The
+ * control here therefore uses a sibling paragraph's text plus the presence of
+ * the inline element itself: together they prove the page compiled AND that the
+ * node reached this deprecated renderer, so silence is an exemption rather than
+ * a missing node.
+ *
+ * objectui#5027 has since been fixed (the renderer reads `children`), and both
+ * assertions hold unchanged, as predicted here. They are deliberately left as
+ * they are: what this file is about is WHO gets told, and the inline tag's own
+ * text is now pinned where it belongs, in
+ * `__tests__/span-children-rendering.test.tsx`.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -104,7 +110,11 @@ describe('span deprecation notice — scoped by provenance (#4917)', () => {
         schema={{
           type: 'span',
           className: 'authored',
-          body: [{ type: 'span', className: 'authored-inner' }],
+          // Canonical child key (objectui#5027) — this used to spell `body`.
+          // The inner node has to really render for the assertions below to
+          // mean anything: it is the second `span` whose absence would let the
+          // "exactly once" count pass without the guard doing any work.
+          children: [{ type: 'span', className: 'authored-inner' }],
         } as never}
       />,
     );

--- a/packages/components/src/__tests__/span-deprecation-warn-once.test.tsx
+++ b/packages/components/src/__tests__/span-deprecation-warn-once.test.tsx
@@ -61,7 +61,7 @@ describe('span deprecation notice — once per module load (#4917)', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubEnv('NODE_ENV', 'production');
 
-    renderSpan({ type: 'span', className: 'px-1', body: [{ type: 'text', content: 'a' }] });
+    renderSpan({ type: 'span', className: 'px-1', children: [{ type: 'text', content: 'a' }] });
 
     expect(deprecationCalls(warn)).toHaveLength(0);
   });
@@ -71,22 +71,31 @@ describe('span deprecation notice — once per module load (#4917)', () => {
 
     // Three separate renders, and one of them nests three more `span` nodes:
     // seven SpanRenderer invocations in total, one notice expected.
+    //
+    // The nesting spells the canonical child key (objectui#5027). It used to
+    // spell `body`, the one key nothing produces and, since that fix, the one
+    // key this renderer does not read — so the nested nodes would never have
+    // mounted and the count below would have been three invocations dressed up
+    // as seven, passing for the wrong reason.
     renderSpan({ type: 'span', className: 'a' });
     renderSpan({ type: 'span', className: 'b' });
-    renderSpan({
+    const nested = renderSpan({
       type: 'span',
       className: 'outer',
-      body: [
+      children: [
         {
           type: 'span',
           className: 'middle',
-          body: [
+          children: [
             { type: 'span', className: 'inner-1' },
             { type: 'span', className: 'inner-2' },
           ],
         },
       ],
     });
+    // The seven invocations are a claim about what mounted, so read it back
+    // instead of trusting the schema's shape.
+    expect(nested.container.querySelectorAll('span')).toHaveLength(4);
 
     const calls = deprecationCalls(warn);
     expect(calls).toHaveLength(1);

--- a/packages/components/src/renderers/basic/span.tsx
+++ b/packages/components/src/renderers/basic/span.tsx
@@ -101,7 +101,24 @@ const SpanRenderer = forwardRef<HTMLSpanElement, { schema: TextSpanSchema; class
         // Apply designer props
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
     >
-      {renderChildren(schema.body)}
+      {/*
+        The canonical child key is `children` (objectui#5027).
+
+        This read used to be `schema.body`, which no producer on either
+        authoring surface emits: `TextSpanSchema` declares `value` and
+        `children`, the html tier's parser assigns compiled child nodes to
+        `children` (`sdui-parser/src/parse.ts`), and the sibling `div` renderer
+        reads `children` too. So the tag rendered EMPTY and dropped its content
+        without a diagnostic — the parser's tree validation does not inspect
+        child keys.
+
+        `body` is deliberately not accepted as a second spelling. Adding a
+        tolerant read here would fossilize a second de-facto contract for the
+        one type whose declaration never named it (Commandment #0.1), and the
+        sweep for this issue found nothing in the repo authoring it on this tag.
+        `__tests__/span-children-rendering.test.tsx` pins both halves.
+      */}
+      {renderChildren(schema.children)}
     </span>
   );
   }


### PR DESCRIPTION
Fixes #5027

基线 `origin/main` @ `dc9d651a2c55c10a9e4d30434e429e5fdc5ae968`。

> 正文里的标签一律写成 `< span >` 这种**尖括号后带空格**的形式 —— GitHub 的正文消毒器会把「尖括号紧跟字母」当 HTML 标签在存储时吞掉。本 PR 第一版正文就被吞掉了三处载荷片段(DOM dump 与两个 html tier 标签),此版已改写并读回确认。

## PM 代裁与否决窗

采卡面建议 1:**规范子节点键 = `children`**。PM 在 #5027 的认领评论(comment 5319770596)里公示了这条代裁并留了否决窗 —— 依据是这不属于在两个候选契约里挑一个,而是执行**已经写下的**契约:`TextSpanSchema` 声明的是 `children`(`packages/types/src/layout.ts:36-46`),parser 产出的是 `children`(`packages/sdui-parser/src/parse.ts:95`),兄弟 `div.tsx` 读得到 `children`,`span.tsx` 是三面之外唯一的离群者。维护者对这条裁定有异议可直接在本 PR 或 #5027 上否决,实施可回退。

按裁定的边界,本 PR **没有**做的事:不新增 `body` 兼容读法(Commandment #0.1:宽容读法会给这个唯一从未在声明面出现过该键的类型固化出第二套事实契约);不动 `div.tsx`(那是 #4631 的系统性面,`pm:on-hold`);不动 `TextSpanSchema` 本身(它已是规范源)。

## 改动

`packages/components/src/renderers/basic/span.tsx` 的 `renderChildren(schema.body)` 改为 `renderChildren(schema.children)`,并把上面这段理由写在读取点旁边。

## 前提复现(基线读数,改之前)

新钉子测试先在**未改动的** `span.tsx` 上跑,四条全红,复刻卡面现象:

```
FAIL span-children-rendering.test.tsx > renders the text an html-tier author wrote inside the inline tag
AssertionError: expected '' to be 'hello html tier'
FAIL ... > renders `children` authored on the JSON surface, as TextSpanSchema declares it
AssertionError: expected '' to contain 'inline from children'
FAIL ... > accepts a single child node, not only an array
AssertionError: expected '' to contain 'lone child'
FAIL ... > does not accept a `body` alias — one contract, not two spellings
AssertionError: expected 'must not render' to be ''
Test Files  1 failed (1)   Tests  4 failed (4)
```

第一条的控制断言(同页 p 标签的 `page rendered` 在、无 `failed to compile`)在基线上是绿的 —— 所以空元素不是整页编译失败,正是卡面说的那一种静默丢弃。

## 消费面普查(`body` 在 span 上有没有真实消费面)

| 扫描面 | `span` 上写 `body` 的命中 |
|---|---|
| 仓内 JSON / mdx / yaml 元数据(键 `type` 值 `span`) | **0** |
| `examples/schema-catalog`(4 个 `components-basic-span/*` 条目) | **0** —— 那 4 条示范的是替代品(`badge` / `flex` / `text`),没有一条是 `span` 节点 |
| ts/tsx 里的 `type: 'span'` | 只有 `packages/types` 的声明 + `packages/components` 的 3 个测试文件 |
| `kind:'html'` tier 的 source(含 `apps/console/src/sdui-tiers-preview.tsx` 的预览页) | 该预览页无 span;仓内 html tier source 里的 span 只出现在 span 自己的两个测试 |
| 已发布文档 | `content/docs/components/basic/span.mdx` 的 Schema 块列了 `body?`(**是声明面,不是消费面**) |

零命中做了证伪反查(同一扫描器、同一文件集、邻近词):值 `div` 98 命中、`text` 775、`card` 141、`grid` 43 —— 扫描器是活的,`span` 的 0 是真 0。

所以没有兼容义务。唯一需要跟着走的是那条**文档声明**:`span.mdx` 里 `body?: SchemaNode | SchemaNode[]; // Alternative content prop` 一行删掉(留着就等于在文档里继续教一个会静默丢内容的键),`children?` 那行标注为渲染器读的键。

## fixture 逐条判定(不是批量改字)

三个既有测试文件在 span 节点上写 `body`,按「重新拼写 / 补声明 / 整条替换」逐条判定,结论都是**重新拼写**,但其中两条如果只改字就会变成「因为什么都没产生而绿」:

| 文件 | 处置 | 若只改字会怎样 |
|---|---|---|
| `basic-renderers.test.tsx:127` | 改 `children` | 直接失效→改后真读 |
| `span-deprecation-provenance.test.tsx:107` | 改 `children` | 那条 `.authored-inner` 断言是「内层节点确实 mount 了」的控制;`body` 不再被读时它会红,而 `exactly once` 的计数会**照样绿** —— 因为第二个 span 压根没 mount |
| `span-deprecation-warn-once.test.tsx`(3 处) | 改 `children`,并补一条 DOM 读回 | 同上:`querySelectorAll('span')` 从 4 掉到 1,而「七次调用一条通知」的计数仍绿。补的 `expect(nested.container.querySelectorAll('span')).toHaveLength(4)` 就是把这个空绿关掉 |

#4917 / PR #5029 的 provenance 测试断言**全部保持成立、未改动**(它当时刻意绕开了本缺陷,用同页 p 的文字 + span 元素存在做控制,并预言「修好后两条断言依然成立」 —— 实测确实成立)。该文件里那段解释缺陷的注释改成了过去时,并指明 span 自己的文字现在钉在新文件里。

## 反向验证

两条变异都在 commit 之后做、`git checkout --` 还原,**预判先写后跑**:

| 变异 | 预判 | 实测 | 相符 |
|---|---|---|---|
| ① `span.tsx` 改回只读 `body` | 4 个文件共 7 条红:新钉子 4 条 + provenance 的 `.authored-inner` + warn-once 新增的 DOM 读回 + basic-renderers 的 inline content | 7 条红,逐条对上:`expected '' to be 'hello html tier'`、`expected 'must not render' to be ''`、`expected null to be truthy`、`expected < span >< /span > to have a length of 4 but got 1`、`expected '' to contain 'Inline text'` | ✅ |
| ② parser 侧把产出键改名(`node.children` → `body`) | 只有 1 条红(新钉子的 html tier 那条);`div` 的 provenance 保持绿(它读 `children \|\| body`,宽容那一支会吸收改名) | span 那条如预判红、div 如预判绿 —— **但共 3 条红**,多出 `html-page-lazy-blocks.test.tsx` 两条 | ❌ 部分不符,如实记录 |

变异 ② 的预判**低估了产出键的消费半径**,机制如实写下:`flex` 与 span 改后一样是严格读 `children`,所以产出键改名让 `< flex >< object-kanban object="showcase_project" / >< /flex >` 渲染成空元素(失败现场的 DOM dump 就是一个空的 `< div data-obj-type="flex" / >`),嵌套块永不 mount。其中「recovers a page」那条在整文件跑时首个断言变成 `expected '' to contain 'failed to compile'`,而**单独跑该条时首个断言恢复通过**、失败点后移到 `expected null to be truthy` —— 说明整文件跑里那一下是变异改了 case 1 的结局与时序、`object-kanban` 在 case 2 运行时仍被注册的跨用例状态,不是产出键改名本身让编译诊断消失。

变异 ② 是一个**不存在的生产者状态**,记录它的价值在那条对照读数:改名之下只有严格读 `children` 的渲染器会红,`div.tsx`(`children || body`)与 `html-elements.tsx`(`children ?? body`)的宽容支照样绿 —— 也就是说这条 PR 把 span 挪到了严格那一侧,没有新增方言,而宽容支仍是 #4631 的存量债。

## 验证

- 构建先行:`pnpm --workspace-concurrency=2 --filter '@object-ui/components^...' build` 成功。
- `packages/components` 全量:`Test Files 154 passed (154)` / `Tests 1416 passed (1416)`。
- 仓根 `pnpm exec turbo run type-check --concurrency=2`:`Tasks: 81 successful, 81 total`。
- 还原变异后复跑 6 个相关文件:`Test Files 6 passed (6)` / `Tests 40 passed (40)`。
- `node scripts/check-control-bytes.mjs`:`OK (scanned 4503 tracked text file(s))`;改动文件另做 `grep -naP` 自扫,零命中。

## changeset

`@object-ui/components: patch`(一文件)。parser 未改,所以没给 `@object-ui/sdui-parser` 发 changeset。

## 顺手记录、本 PR 未修

- #5050 —— `span` 的 `value` 声明面(类型 + 已发布文档都列为作者面)**无人读取**,写 `value` 同样渲染空元素。修它要裁 `value` 与 `children` 的优先级,是一条没有裁定的新行为,按纪律没有顺手带过。
- #5051(`finding`)—— registry meta 的 `defaultChildren` 有 4 处声明、11 处生产、1 处已发布插件文档,**0 处消费**(拖放只读 `defaultProps`)。
- #4631 补了一条评论:`span` 是那张类问题的第三个实测样本(且是第一个「跟着声明面写的任何键都会空」的样本),外加一条机制读数 —— `BaseSchema` 同时声明 `body?` 与 `children?` 且带 `[key: string]: any` 索引签名,所以写错子节点键在任何类型上都不是 TS 错误,类型面今天无法拒绝。
