### PR TITLE
docs(plugin-gantt): README 按真实导出面重写虚构的手动注册与 GanttSchema 类型

### DIFF
--- a/.changeset/plugin-gantt-readme-truth-5012.md
+++ b/.changeset/plugin-gantt-readme-truth-5012.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/plugin-gantt': patch
+---
+
+Docs only: `packages/plugin-gantt/README.md` no longer teaches two identifiers the
+package does not export, nor a task shape it does not produce (objectui#5012).
+Each README import was judged against the entry module's real export surface
+(35 names, read from the build product's `dist/index.d.ts`), and every corrected
+snippet was type-checked against that same build product:
+
+- **`ganttComponents`** — taught as a components map to iterate over for "manual
+  registration" (`Object.entries(ganttComponents).forEach(...)`). It does not
+  exist anywhere in the package, so the snippet was `Object.entries(undefined)`:
+  a `TypeError` on the first line a reader copied. Registration is *only* the
+  side effect of importing the entry point, which runs the two
+  `ComponentRegistry.register(...)` calls in `src/index.tsx`. The section is
+  replaced by what actually happens: the schema types those calls claim
+  (`object-gantt` → `plugin-gantt:object-gantt`, `gantt` → `view:gantt`, both
+  with a bare-`type` fallback), the package's real export surface, and — for the
+  use case the old snippet was reaching for — registering the exported
+  `ObjectGanttRenderer` under a key of your own.
+
+- **`GanttSchema`** — taught as the component schema type in the TypeScript
+  section. Pure fiction: zero hits in this package and in `@object-ui/types`
+  (a plain grep appears to find it only as a substring of `ObjectGanttSchema`;
+  under a word boundary it has no hits at all). The authored type does exist
+  under its real name, so the example is rewritten around it rather than
+  dropped: `ObjectGanttSchema` from `@object-ui/types`, which is
+  **record-driven** — `type: 'object-gantt'` plus an object name and the fields
+  to read. It never carried the `tasks` array the old snippet assigned to it.
+  No export was added to make the old name true.
+
+- **`GanttTask`** — the one real name of the three, and the reason the section
+  still failed to compile. The documented shape had drifted from the exported
+  type on three counts: the label field is `title`, not `name`; `start`/`end`
+  are `Date` objects, not ISO strings; and `color` is a CSS color, not a
+  Tailwind class. Both the "Task Structure" reference block and the typed
+  example now match the exported declaration, and the reference block is pinned
+  against it in both assignment directions so a future drift fails a check
+  instead of compiling as an unrelated local interface.
+
+No code, types or runtime behaviour change — the diff is one README and this
+changeset. The correction reaches npm with the package's next publish, which is
+why it declares a patch: `README.md` is in the package's published `files`.

--- a/packages/plugin-gantt/README.md
+++ b/packages/plugin-gantt/README.md
@@ -102,15 +102,82 @@ const schema = {
 };
 ```
 
-### Manual Registration
+### What the side-effect import registers
+
+Registration is *only* a side effect of importing the package — the single
+`import '@object-ui/plugin-gantt'` above is the whole of it. There is no
+components map to iterate over: importing the entry point runs the
+`ComponentRegistry.register(...)` calls at the bottom of `src/index.tsx`, which
+claim these schema types:
+
+| Schema `type` | Namespaced key | Renderer |
+| --- | --- | --- |
+| `object-gantt` | `plugin-gantt:object-gantt` | `ObjectGanttRenderer` |
+| `gantt` | `view:gantt` | `ObjectGanttRenderer` |
+
+Both spellings resolve — `register` stores the namespaced key *and* a bare-`type`
+fallback. Both keys declare the same two inputs: `objectName` (required) and the
+`gantt` configuration object.
+
+`ObjectGanttRenderer` is a thin wrapper: it pulls `dataSource` off the renderer
+context and hands the schema to `ObjectGantt`.
+
+### Public exports
+
+The package exports components, helpers and their types — not a registry map:
 
 ```typescript
-import { ganttComponents } from '@object-ui/plugin-gantt';
-import { ComponentRegistry } from '@object-ui/core';
+import {
+  ObjectGantt, // ObjectQL-integrated gantt: loads records, writes back edits
+  ObjectGanttRenderer, // the registered renderer for `object-gantt` / `gantt`
+  GanttView, // the standalone timeline component
+  QuickFilterBar, // the toolbar's quick-filter dropdowns
+  ResourceWorkload, // resource × period workload grid
+  normalizeDependencies, // raw dependency-field value -> GanttDependency[]
+  normalizeTaskType, // raw type-field value -> GanttTaskType
+  normalizeShiftSegments, // raw timeSegments config -> NormShiftSegments
+  parseHHMM,
+  shiftDayStart,
+  bandAt,
+  computeWorkload,
+} from '@object-ui/plugin-gantt';
 
-// Register gantt components
-Object.entries(ganttComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
+import type {
+  ObjectGanttProps,
+  GanttViewProps,
+  GanttTask,
+  GanttTaskType,
+  GanttViewMode,
+  GanttDependency,
+  GanttDependencyObject,
+  GanttLinkType,
+  GanttMarker,
+  QuickFilterDef,
+  QuickFilterBarProps,
+  QuickFilterField,
+  QuickFilterOption,
+  QuickFilterLabels,
+  ShiftSegmentsConfig,
+  ShiftBandConfig,
+  NormShiftSegments,
+  NormShiftBand,
+  ResourceWorkloadProps,
+  WorkloadColumn,
+  WorkloadOptions,
+  ResourceCell,
+  ResourceLoad,
+} from '@object-ui/plugin-gantt';
+```
+
+To serve the gantt under a registry key of your own, register the exported
+renderer under that key:
+
+```typescript
+import { ComponentRegistry } from '@object-ui/core';
+import { ObjectGanttRenderer } from '@object-ui/plugin-gantt';
+
+ComponentRegistry.register('my-gantt', ObjectGanttRenderer, {
+  namespace: 'my-app',
 });
 ```
 
@@ -134,18 +201,32 @@ Display project timeline with tasks:
 
 ### Task Structure
 
+`GanttTask` is the **component's runtime** task — what `<GanttView>` renders and
+what `ObjectGantt` produces from each record. Dates are real `Date` objects and
+the label field is `title` (`src/GanttView.tsx`):
+
 ```typescript
 interface GanttTask {
-  id: string;
-  name: string;
-  start: string;                  // ISO date string
-  end: string;                    // ISO date string
-  progress: number;               // 0-100
-  dependencies?: string[];         // Task IDs
-  assignee?: string;
-  color?: string;                 // Tailwind color class
+  id: string | number;
+  title: string;
+  start: Date;
+  end: Date;
+  progress: number;                  // 0-100
+  dependencies?: GanttDependency[];  // predecessor id, optionally with a link type
+  parent?: string | number | null;   // builds the hierarchy; unknown ids render as roots
+  type?: GanttTaskType;              // 'task' | 'summary' | 'milestone' | 'group'
+  color?: string;                    // bar fill — any CSS color, e.g. '#3b82f6'
+  borderColor?: string;              // alert outline, fill untouched
+  locked?: boolean;                  // view-only row (still clickable)
+  baselineStart?: Date;              // planned-vs-actual reference bar
+  baselineEnd?: Date;
+  data?: any;                        // the source record behind the row
 }
 ```
+
+A few more optional fields (`fields` for tooltip rows, `hasOwnDates`) are
+populated by `ObjectGantt` itself — see `GanttTask` in `src/GanttView.tsx` for
+the full declaration.
 
 ## Examples
 
@@ -403,24 +484,52 @@ const schema = {
 
 ## TypeScript Support
 
+Two different vocabularies, two different packages — don't mix them up.
+
+**The component's runtime types** come from this package. Use them when you
+render `<GanttView>` (or `ObjectGantt`) yourself in React:
+
 ```typescript
-import type { GanttSchema, GanttTask } from '@object-ui/plugin-gantt';
+import type { GanttTask, GanttViewProps } from '@object-ui/plugin-gantt';
 
 const task: GanttTask = {
   id: '1',
-  name: 'My Task',
-  start: '2024-01-01',
-  end: '2024-01-10',
+  title: 'My Task',
+  start: new Date('2024-01-01'),
+  end: new Date('2024-01-10'),
   progress: 50,
-  dependencies: []
+  dependencies: [],
 };
 
-const gantt: GanttSchema = {
-  type: 'gantt',
+const props: GanttViewProps = {
+  tasks: [task],
   viewMode: 'week',
-  tasks: [task]
 };
 ```
+
+**The authored (JSON metadata) types** live in `@object-ui/types` — this package
+imports them and does not re-export them. There is no `GanttSchema`; the
+component schema is `ObjectGanttSchema`, and it is **record-driven**: it names an
+object and the fields to read, it does not carry a task array.
+
+```typescript
+import type { ObjectGanttSchema } from '@object-ui/types';
+
+const gantt: ObjectGanttSchema = {
+  type: 'object-gantt',
+  objectName: 'project_tasks',
+  titleField: 'name',
+  startDateField: 'start_date',
+  endDateField: 'end_date',
+  progressField: 'completion_percentage',
+  dependencyField: 'dependent_task_ids',
+};
+```
+
+For a list view served under the `gantt` view type, the same configuration is a
+`gantt` block on `ListViewSchema` (typed by `GanttConfig`, also from
+`@object-ui/types`) rather than top-level keys — `ObjectGantt` reads either
+spelling.
 
 ## Links
 


### PR DESCRIPTION
Fixes #5012

基线 `origin/main` @ `f331f5a8bdb728039519ace070f6433f597e0dd4`(worktree 显式建在该 sha 上)。方法学照抄同族 #5002 → PR #5021 的减法形,以及今日已落地的 #5010 → PR #5046、#5016 → PR #5053。

## 判定表(虚构 vs 改名 vs 真名)

卡面列了两处,名集合核对与示例编译又在同一段里揪出第三处 —— 同为「README 对本包某个标识符的断言不成立」,一并修,单列如下。

| README(改前) | 判定 | 依据 | 处理 |
| --- | --- | --- | --- |
| `:108` `import { ganttComponents }` + `:112` `Object.entries(ganttComponents).forEach(…)` | **纯虚构** | 全包零命中;导出面 35 个名字里没有它 | **删虚构节**,改教真实机制 |
| `:407` `import type { GanttSchema }`、`:418` `const gantt: GanttSchema` | **虚构名,但真身存在** | 加词边界后本包与 `@object-ui/types` 皆零命中;裸 grep 的 6 处命中全是 `ObjectGanttSchema` 的**子串**(卡面复核命令写的是裸 grep,故复测时特意补了词边界) | **按真身重写**:`ObjectGanttSchema` from `@object-ui/types` |
| `:138-147` `interface GanttTask { name; start: string; … }` | **真名,形状漂移** | 真身 `src/GanttView.tsx:139`:`title` 非 `name`、`Date` 非 ISO 字符串、`color` 是 CSS 颜色(`GanttView.tsx:4319` 直接塞内联 `backgroundColor`)非 Tailwind 类名 | **参考块 + 示例双双对齐**,并双向钉住 |
| `:407` `GanttTask`(导入本身) | **真名** | 导出面命中 | 保留 |

第三处不是夹带:`:407` 的示例 `const task: GanttTask = { name: …, start: '2024-01-01' }` 用的正是这个真类型,不改它示例就编译不过;而只改示例、留着 14 行外的参考块继续教假形状,同一个 README 会自相矛盾。

⛔ **未新增任何导出或类型**来把 README 变真(契约扩张需另立卡)。

### 删掉的每一节,删因一行

- **`### Manual Registration` 整节(改前 `:105-115`)** —— 它教的 `ganttComponents` 不存在,`Object.entries(undefined)` 在读者复制的第一行就抛 TypeError;而它想表达的「注册」根本不需要手动做,是 import 入口的副作用。替换为三节真话:两个 `register` 调用认领的 schema 类型表(`object-gantt` → `plugin-gantt:object-gantt`、`gantt` → `view:gantt`,各带裸 `type` 回落 —— 见 `packages/core/src/registry/Registry.ts:195,226`)、包的真实导出面、以及原片段真正想做的事(把导出的 `ObjectGanttRenderer` 注册到自定义键)。
- **`const gantt: GanttSchema = { type: 'gantt', viewMode, tasks }`(改前 `:418-422`)** —— 类型名虚构,且形状也不成立:真身 `ObjectGanttSchema` 是**记录驱动**的(`type: 'object-gantt'` + `objectName` + `*Field`),从不携带 tasks 数组。
- **`GanttTask` 参考块的 `assignee?: string`(改前 `:145`)** —— 真身上没有这个字段。

## 名集合核对读数

导出名集合取自**构建产物** `packages/plugin-gantt/dist/index.d.ts`,走 TS compiler API 的 `checker.getExportsOfModule`(不是对 src 做正则)。README 侧不用正则抓 import:先抽 fenced 代码块,每块 `ts.createSourceFile`,再走 `ImportDeclaration` 的 AST。

这样 #5043 记的两个坑在结构上不可能发生 —— 多行块本就是**一个** `ImportDeclaration` 节点(fence/散文吃不进 import clause);行尾 `//` 注释对 parser 是 trivia(不可能贡献名字);`A as B` 的 AST 直接给出 `propertyName = A`(导出名)与 `name = B`(别名),**判 A**。

第一版确实照卡面规格写了跨行正则,**在本包上直接报 5 个假名**(`weeks`/`title`/`selection`/`target`/`dataSource`)而真正的两个虚构名一个没报:副作用导入 `import '@object-ui/plugin-gantt';` 无 `from`,懒惰量词从它一路吃到 20 行之后的下一个 `from '@object-ui/plugin-gantt'`,把中间整段 markdown 当成了 import clause。已把这条读数与 AST 版规格写在 #5043 上(不另立卡)。

```
改前:  export surface: 35 names / README 4 bindings / MISSING COUNT: 2
          - ganttComponents @ README:108
          - GanttSchema     @ README:407
改后:  export surface: 35 names / README 39 bindings / MISSING COUNT: 0
```

改后 39 个绑定逐个 OK,覆盖新增的两个多行 import 块全部 35 个导出名。

## 编译探针读数

README 的 ts/tsx 块抄进 scratch,对同一构建产物 `dist/index.d.ts` 编译(`strict: true`,**没有为让块通过而放松任何选项**)。每块独立成文件并补一行 `export {};` —— 多个块各自声明 `const schema` 都是全局 script,会撞重复标识符;补这一行只改作用域,不影响块内检查。

```
### 卡面半径(本 PR 改写的 5 个块:公共导出面 ×2、自定义键注册、GanttTask 参考块+pin、两个 TypeScript 示例)
tsc -> rc=0   (no diagnostics)

### 全 README(15 个可编译块;2 块按设计跳过并在输出里列明理由)
tsc -> rc=2
  5012-block07.tsx(4,17): error TS7006: Parameter 'task' implicitly has an 'any' type.
  5012-block07.tsx(8,18): error TS7006: Parameter 'updatedTask' implicitly has an 'any' type.
```

余下这两条**不是本 PR 的漏修**:block07 是 "Interactive Gantt" 示例里 `onTaskClick: (task) => …` 写在无类型标注的 `const schema = { … }` 里,属那一族虚构 schema 键的一部分,已立 #5057。按纪律不在本卡里顺手改。

跳过的两块(输出里列明,不静默丢):`:191-199` 裸 `{ type, tasks: …, … }` 形状速写、`:449-454` 裸 `dependencies: [ … ]` 片段 —— 都是**故意不合法**的 TS。

`GanttTask` 参考块额外**双向钉**在真身上,否则它绿得没有意义(独立的 `interface GanttTask { … }` 只是个与真类型无关的本地声明,内容再假也编译通过):

```ts
declare const real: RealGanttTask;
export const docFromReal: GanttTask = real;   // real -> documented
declare const doc: GanttTask;
export const realFromDoc: RealGanttTask = doc; // documented -> real
```

散文里唯一一条探针覆盖不到的断言(「`gantt` 块挂在 `ListViewSchema` 上、类型是 `GanttConfig`」)另写了一个小探针单独验:`rc=0`。

## 反向验证(两条,预判先写)

**(a) 名集合核对自证。** 预判:往**多行** import 块里 planted 四处,`MISSING COUNT` 0 → 2,恰为 `{ganttThings, GanttSchema}`;还原后回 0。四条全符 ——

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| 行尾注释改成含非导出词(`// ganttComponents was never real`) | **不得**报(假阳性测试) | 未报 |
| 多行值导入里加 `ganttThings as Things` | 报,且按**导出名** `ganttThings` 而非别名 | 报 `ganttThings` @ `:143` |
| 多行类型导入里 `GanttTask` → `GanttTask as Task` | 仍 OK(别名判导出名) | OK |
| 多行类型导入**中段**插 `GanttSchema` | 报 | 报 @ `:156` |

`MISSING COUNT: 2`,还原读数 `0`。变异全做在 README 的 **scratch 副本**上(检查器加了一个 `--readme` 参数指向该副本),**工作树一次都没被改过** —— 不存在「临时改动误入 commit」的窗口。

**(b) 示例编译自证。** 预判:把改前 README 回填,tsc 必须转红,且错误一一对应所改各处。同一套探针机器直接跑改前 README(harness/skip 按**内容签名**分类而非块序号,所以两个版本共用一套机器)。转红,`rc=2`,对应关系:

| 所改之处 | 预判 | 实测诊断 |
| --- | --- | --- |
| `ganttComponents` | TS2305 | `block02(1,10): TS2305 … has no exported member 'ganttComponents'` |
| `GanttSchema` | TS2305 | `block14(1,15): TS2305 … has no exported member 'GanttSchema'` |
| `GanttTask` 形状(real → doc) | 转红 | `block04(13,14): TS2741 Property 'name' is missing in type '…GanttTask' but required in type 'GanttTask'` |
| `GanttTask` 形状(doc → real) | 转红 | `block04(15,14): TS2741 Property 'title' is missing in type 'GanttTask' but required in type '…GanttTask'` |
| 示例里的字符串日期 | 转红 | `block14(6,3)` / `block14(7,3): TS2322 Type 'string' is not assignable to type 'Date'` |
| 既有的两条 TS7006 | 原样携带 | `block06(4,17)` / `block06(8,18)`(改后为 block07) |

**预判不符的一处,如实记**:我同时预判改前的 `const task: GanttTask = { name: …, start: '…' }` 会在 `name`/`title` 上报错,实测那一块**只**报了两条日期 `TS2322` —— present 属性的类型不符会抢在 missing-property 详述之前短路。也就是说 `name`/`title` 这个事实**只由 (b) 表里的 pin 块承载**,typed-example 那一侧靠不住。这正是双向 pin 值得写下来的理由;若只抽 typed example 不做 pin,键名重命名这一整类会整体漏掉。此点已一并记在 #5043。

另有一处**探针 harness 的诚实修正**:`:66-73` 的 `< GanttView onTaskUpdate >` 块,harness 初版把 `save` 声明成要求必填 `Date`,块就红了两条。但真实签名第二参是 `Partial` 包 `Pick`,`start`/`end` 本就是 `Date | undefined` —— 那两条红测的是我的假设,不是这个块。harness 已改为中性(`Partial`),块随之转绿;README 那条「start/end are JS Date objects」的注释确实与签名和运行时都不符(`GanttView.tsx:1335` 的进度拖拽提交纯 `{ progress }`,照抄会把日期写空),但那是散文断言的缺陷,应当由它自己的证据立卡,不该借探针红来主张 —— 已立 #5058。

## 验证

- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **81 successful, 81 total**(重活经 `flock` 串行 + `--max-old-space-size=4096`)。
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4505 tracked text file(s))`;改动两文件另做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中。
- `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-gantt...' build` → rc=0(探针所依赖的构建产物)。

**docs-only 的 CI 形状**:`ci.yml` / `lint.yml` 把 `**/*.md` 与 `.changeset/**` 列进 `paths-ignore`,所以 Test / Type Check 各 job 的实质步骤会被 path-filter 短路成 skipped 而 job 报 success。按纪律计绿,但**类型证据是上面的本地仓根读数**,不是 CI 的(#5046 / #5053 先例)。

## 顺手立的卡(均未认领,不夹带进本 PR)

同文件、不同性质,各自需要独立定级:

- **#5057** — README 整片 schema 键面渲染器一个都不读(`tasks` / `viewMode` / `object` / `nameField` / `startField` / `endField` / `fields` 全零命中;`getDataConfig` 只读 `data` / `staticData` / `objectName`)。照抄任一示例得空图。名集合核对看不见(这些块里没有 import),抽块编译也看不见(无类型标注的字面量)。
- **#5058** — `:66-73` 的 `onTaskUpdate` 示例在进度拖拽时写入 `undefined` 日期;注释断言 `start`/`end` 必为 `Date`,而签名是 `Partial`、`GanttView.tsx:1335` 提交纯 `{ progress }`。名字与键全真,错的是可选性。
- **#5043 追评**(不另立卡,命中在途卡即写在卡上)—— AST 版名集合核对的规格、正则版在本包上报 5 个假名的实测读数、双向 pin 的必要性、以及给这道门定入场价时该预期到的既有红。

## changeset

`.changeset/plugin-gantt-readme-truth-5012.md`,`@object-ui/plugin-gantt: patch`,口径同 #5046 / #5053:无代码/类型/运行时改动,声明 patch 是因为 `README.md` 在包的 `files` 里,随下次发布到 npm。
