### PR TITLE
docs(plugin-report): rewrite README export snippets against the real signatures

### DIFF
--- a/.changeset/plugin-report-export-signatures.md
+++ b/.changeset/plugin-report-export-signatures.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/plugin-report': patch
+---
+
+docs(plugin-report): rewrite the README export snippets against the real export signatures
+
+The `### Export` and `### Live Export` snippets called every export function with
+the wrong arity or argument order. Every name was real, so the name-set check
+could not see it — only the calls were wrong:
+
+- The six format exporters are `(report: ReportComponentSchema, data: any[], config?: ReportExportConfig): void`.
+  The README called them `(data, filename)`, so a filename string landed in the
+  `data` slot the engine iterates as rows, and there is no filename parameter at
+  all — the download name comes from `config.filename`, else `report.title`. All
+  five are synchronous `void`, so the snippet's `await` was inert.
+  `exportReport` takes the format **first**, which no snippet showed.
+- `exportWithLiveData(report, options)` requires `dataSource` and `resource` in
+  `LiveExportOptions`; the README passed only `{ format: 'pdf' }`.
+- `exportExcelWithFormulas(report, data, options)` takes three parameters; the
+  README passed two, and spelled the column key `field` where `ExcelColumnConfig`
+  has the required `name` and `header`. Formula templates use the `{ROW}`
+  placeholder, which the old `SUM(B2:B100)` never exercised.
+
+The rewritten blocks are the exporters' own (correct) JSDoc examples, and each
+one now compiles against the package's built `dist/index.d.ts`. Docs only — no
+API, export surface or runtime behaviour changed.

--- a/packages/plugin-report/README.md
+++ b/packages/plugin-report/README.md
@@ -222,7 +222,12 @@ callback above.
 
 ### Export
 
-Export reports in multiple formats:
+Every format exporter takes the **report schema first and the rows second** —
+`(report: ReportComponentSchema, data: any[], config?: ReportExportConfig)`. The
+schema is where the exporter reads the columns (`report.fields`) and the download
+name (`config.filename`, else `report.title`) from; there is **no filename
+parameter**. All five return `void` synchronously — they trigger a browser
+download — so there is nothing to `await`:
 
 ```tsx
 import {
@@ -233,24 +238,75 @@ import {
   exportAsPDF,
   exportAsExcel,
 } from '@object-ui/plugin-report';
+import type { ReportComponentSchema } from '@object-ui/types';
 
-await exportAsCSV(reportData, 'sales-report.csv');
-await exportAsPDF(reportData, 'sales-report.pdf');
-await exportAsExcel(reportData, 'sales-report.xlsx');
+const report: ReportComponentSchema = {
+  type: 'report',
+  title: 'Sales Report',
+  fields: [
+    { name: 'account', label: 'Account' },
+    { name: 'amount', label: 'Amount', type: 'currency', aggregation: 'sum' },
+  ],
+};
+const rows = [{ account: 'Acme', amount: 12000 }];
+
+exportAsCSV(report, rows); // downloads "Sales Report.csv"
+exportAsJSON(report, rows); // "Sales Report.json"
+exportAsHTML(report, rows); // "Sales Report.html"
+exportAsPDF(report, rows); // opens a print window; falls back to .html if blocked
+exportAsExcel(report, rows, { format: 'excel', filename: 'sales-2026-q1.tsv' });
+
+// `exportReport` is the router — the format comes FIRST, then the same triple.
+exportReport('csv', report, rows);
 ```
+
+`exportAsExcel` writes a BOM-prefixed **TSV** that Excel opens, so its default
+name is `report.title` + `.tsv`, not `.xlsx`. `config.includeHeaders: false` drops the
+header row; `orientation` / `pageSize` apply to the HTML and PDF paths only.
 
 ### Live Export
 
-Export with real-time data and Excel formulas:
+`exportWithLiveData` fetches the rows itself, so `dataSource` and `resource` are
+**required** in `LiveExportOptions` — an options object carrying only `format`
+does not compile. It is the one `async` export function, resolving to a
+`LiveExportResult`:
 
 ```tsx
-import { exportWithLiveData, exportExcelWithFormulas } from '@object-ui/plugin-report';
+import { exportWithLiveData } from '@object-ui/plugin-report';
 
-await exportWithLiveData(reportConfig, { format: 'pdf' });
-await exportExcelWithFormulas(reportConfig, {
-  columns: [{ field: 'total', formula: 'SUM(B2:B100)' }],
+// `myAdapter` is a host-provided DataSource (see @object-ui/data-*).
+const result = await exportWithLiveData(report, {
+  dataSource: myAdapter,
+  resource: 'orders',
+  format: 'pdf',
+});
+// -> { success: true, recordCount: 42, format: 'pdf' }
+```
+
+The format falls back to `report.defaultExportFormat`, then `'pdf'`. Failures are
+returned, not thrown: `{ success: false, recordCount: 0, format, error }`.
+
+`exportExcelWithFormulas` is a separate, synchronous three-parameter function —
+`(report, data, options)` — with the column list inside the third argument. A
+column is `{ name, header, width?, numberFormat?, formula? }`: `name` is the key
+read off each row (there is no `field` key), `header` is required, and a `formula`
+is a template in which the `{ROW}` placeholder is replaced by that row's
+spreadsheet line number:
+
+```tsx
+import { exportExcelWithFormulas } from '@object-ui/plugin-report';
+
+exportExcelWithFormulas(report, rows, {
+  columns: [
+    { name: 'amount', header: 'Amount', numberFormat: '#,##0.00' },
+    { name: 'total', header: 'Total', formula: '=B{ROW}*C{ROW}' },
+  ],
+  includeAggregationRow: true,
 });
 ```
+
+Omitting `columns` derives them from `report.fields`. `includeAggregationRow`
+appends a totals row built from each field's `aggregation`.
 
 ### Scheduled export
 


### PR DESCRIPTION
Fixes #5048

`packages/plugin-report/README.md` 的 `### Export` / `### Live Export` 两节里,导出函数的**名字全部真实**,但**调用的参数个数与顺序全错**。这正是 #5016 用的名集合核对看不见的缺陷类:每个 import 读起来都是真的,错的是调用形。本 PR 只重写这三个示例块 + 一个 changeset,**不改任何 API、不加导出、不动 `src/`**。

Base: `ee4f796d26635c39ff1f9a814bf9fc04529a9e7a`(含前置 PR #5053 的 `f331f5a8b`)。

## 前提验证:卡面三处签名断言逐条对 src 复核

卡面的行号在本 base 上**全部命中**,三条断言全部为真 —— 前提成立。

| 断言 | 卡面行号 | 复核读数 | 结论 |
| --- | --- | --- | --- |
| 六个格式导出器 `(report, data, config?): void` | `ReportExportEngine.ts:19,43,57,96,151` | `:19` CSV / `:43` JSON / `:57` HTML / `:96` PDF / `:151` Excel,五个签名逐字一致,全部 `: void`、无 `async` | ✅ |
| `exportReport` format-first | `:175` | `exportReport(format: ReportExportFormat, report, data, config?): void` | ✅ |
| 无 filename 形参 | — | 名字取自 `config?.filename \|\| report.title \|\| 'report'`(`:37,:50,:90,:169`) | ✅ |
| `LiveExportOptions` 的 `dataSource`/`resource` 必填 | `LiveReportExporter.ts:34-45` | `:34-45`,`dataSource: DataSource` / `resource: string` 均无 `?` | ✅ |
| `exportWithLiveData` 真签名 | `:97` | `async (report, options: LiveExportOptions): Promise< LiveExportResult >` | ✅ |
| 其 JSDoc 示例正确 | `:88-95` | `:86-94`(内容定位;偏移 2 行),形状正确,已直接复用 | ✅ |
| `exportExcelWithFormulas` 三参 | `:161` | `:161` `(report, data, options = {}): void` | ✅ |
| `ExcelColumnConfig` 列键是 `name` 而非 `field` | `:50-61` | `:50-61`,`{ name: string; header: string; width?; numberFormat?; formula? }` | ✅ |
| formula 用 `{ROW}` 占位 | 正例 `:139-146` | `:149-156`(偏移 10 行);实现在 `:177` `col.formula.replace(/\{ROW\}/g, String(rowIndex + 2))` | ✅ |

**卡面未列、复核时补测到的一条**:`ExcelColumnConfig.header` 也是**必填**(`header: string`,无 `?`)。所以把 `field` 改成 `name` 并不足以让示例编译 —— 见下面探针 P6。重写后的列都带 `header`。

## 逐块签名对照

**块 1 — `### Export`(旧 `README.md:237-239`)**

| | 旧 | 真 |
| --- | --- | --- |
| 调用形 | `await exportAsCSV(reportData, 'sales-report.csv')` | `exportAsCSV(report, rows, config?)` |
| 第 1 参 | `reportData`(读作数据) | `report: ReportComponentSchema` —— 列与标题的来源 |
| 第 2 参 | 文件名字符串 | `data: any[]` —— 引擎按行迭代 |
| 文件名 | 幻想出的第 2 形参 | `config.filename`,否则 `report.title` |
| 返回 | `await`(视作 async) | `void` 同步,`await` 空转 |
| `exportReport` | 无示例 | format 在**最前**:`exportReport('csv', report, rows)` |

`exportAsJSON` / `exportAsHTML` 原先只在 import 列表里出现、从无调用,现在六个全部各给一行。顺带订正两处旧文字的事实错误:`exportAsPDF` 才是开打印窗口的那个(`:100` `window.open`,被拦则退回 `.html`),`exportAsHTML` 是下载 `.html`(`:90`);`exportAsExcel` 落盘的是带 BOM 的 **TSV**,默认名后缀 `.tsv` 而非旧示例写的 `.xlsx`(`:169`)。

**块 2 — `exportWithLiveData`(旧 `:249`)**:旧写法 `{ format: 'pdf' }` 缺两个必填键。改后直接复用函数自己的 JSDoc 示例(`dataSource` + `resource` + `format`),并补上返回值 `LiveExportResult` 的形状与失败语义(返回而非抛出)。

**块 3 — `exportExcelWithFormulas`(旧 `:250-252`)**:旧写法传 2 参、列键写 `field`、formula 写死 `SUM(B2:B100)`。改后三参齐全,列键 `name` + 必填 `header`,formula 用 `'=B{ROW}*C{ROW}'`(即 `:149-156` 的正例)。

## 编译探针读数

探针把 README 的三个 ``` tsx ``` 块**用脚本从 `README.md` 里提取**(不是手抄),对构建产物编译。解析确认打到的是产物而非源码:

```
Module name '@object-ui/plugin-report' was successfully resolved to
  '.../packages/plugin-report/dist/index.d.ts' with Package ID '@object-ui/plugin-report/dist/index.d.ts@17.5.0'
```

前置构建:`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-report...' build` → Done。

| 探针 | 结果 |
| --- | --- |
| 改后三块(脚本提取,`tsc --noEmit --strict`) | **rc=0**,零诊断 |
| 接线自证:把 `exportReport('csv', report, rows)` 故意换成 `exportReport(report, 'csv', rows)` | 转红 `TS2345: Argument of type 'ReportComponentSchema' is not assignable to parameter of type 'ReportExportFormat'.` —— 证明探针不是静默 `any` |

## 反向验证 —— 预判先写,含两条「抓不到」

预判在跑之前写进探针文件头,方向为**旧写法回填必须转红**:

| 预判 | 结果 | 实测 |
| --- | --- | --- |
| **P1** 块 1 转红:文件名字符串落进 `data: any[]`,三次 | ✅ | `35,33 / 36,33 / 37,35: error TS2345: Argument of type 'string' is not assignable to parameter of type 'any[]'.` |
| **P2** 块 2 转红:缺两个必填键 | ✅ | `42,42: error TS2345: ... '{ format: "pdf"; }' is missing the following properties from type 'LiveExportOptions': dataSource, resource` |
| **P3** 块 3 转红,且红在**参数位**而非键名;arity 本身合法(options 有默认值),故无 TS2554 | ✅ 方向对,**诊断码预判错** | 实际是 `48,5: error TS2353: Object literal may only specify known properties, and 'columns' does not exist in type 'any[]'.` —— 我预判 TS2345,实为 TS2353。同一缺陷,码不同,如实记录 |
| **P4 抓不到**:对 `void` 同步函数 `await`。TS 允许 await 非 thenable,只有 eslint `await-thenable` 看得见 | ✅ 确认抓不到 | 单独隔离 `await exportAsCSV(report, rows)` + `await exportExcelWithFormulas(report, rows, {})` → **零诊断**。故「`await` 空转」这一条**没有编译期证据**,证据改用源码读数:`ReportExportEngine.ts:19,43,57,96,151` 五个签名均为 `: void`、无 `async`、不返回 Promise;`exportExcelWithFormulas`(`:161`)同样 `: void`。README 里改为不写 `await`,并在正文点明「同步 `void`,没有可 await 的东西」 |
| **P5 抓不到(被遮蔽)**:块 3 的 `field` 键名。它只有在对象落到 `options` 位后才被判定,躺在 P3 后面永远轮不到 | ✅ 确认被遮蔽,隔离后可见 | 把同一列字面量放进真正的第 3 参 → `56,17: error TS2353: Object literal may only specify known properties, and 'field' does not exist in type 'ExcelColumnConfig'.` |
| **P6**(卡面外补测)`field` 改成 `name` 后,缺 `header` 是否仍红 | ✅ 仍红 | `error TS2741: Property 'header' is missing in type '{ name: string; formula: string; }' but required in type 'ExcelColumnConfig'.` |

### 一处对 issue「影响」段的订正

Issue 的 Impact 写「块 1 和块 3 **能过检**(type-check as written against `any[]`/loose params),在运行期才炸」。实测**不成立**:在 `strict` 程序里两块都是**硬编译错误**(P1 / P3),读者会被编译器直接拦住,而不是拿到一份用文件名字符逐字拼出来的表格。签名断言本身全部为真,所以前提成立;错的只是**严重性刻画**。方向上这让缺陷更硬而非更软 —— 每个照抄的读者都会被拦,而不是只有一部分被误导。唯一真正「静默」的一条是 `await` 空转(P4),而它落在 tsc 的盲区里。

## 同文件同性质漂移扫描

README 其余带真实 API 调用的块(`isDatasetReport` + `DatasetReportRenderer`、`ReportViewer` 的 `schema` 形、`createScheduleTrigger(report, dataSource, resource, onComplete)` 四参 + `trigger()`、`formatValue(value, field?)`)逐块抄进同一探针 → **rc=0**,无未列的同性质签名漂移可修。#5047 的 schema 形(retired query form)是**不同性质**,按钉子未碰。

名集合核对(多行 import 块 + 剥注释,对 `dist/index.d.ts` 与 `types/dist/index.d.ts` 的真实导出面):**14 块,fake=0** —— 本次改动没有引入任何假名。(过程中修了核对脚本自身一个贪婪正则:它会跨过相邻两条 import 语句把 `ReportInput } from '@objectstack/spec/ui'; import { ReportRenderer` 整段当成一个名字误报;改成 `[^{}]*?` 后归零。脚本是探针,不入库。)

## 验证

- `pnpm exec turbo run type-check --concurrency=2`(仓根,全量)→ `Tasks: 81 successful, 81 total`
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4507 tracked text file(s); skipped 85 binary)`;两个改动文件另做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中
- docs-only:Test / Type Check 的实质步骤会被 path-filter 短路,类型证据以上述本地读数为准(#5046 / #5053 先例)
- 无测试文件读取本 README(`packages/plugin-report/src/__tests__/` 无 README 引用;`scripts/__tests__/doc-version-claims.test.ts` 只核该文件的 peer 版本声明,本次未触及)

`.changeset/plugin-report-export-signatures.md`:`@object-ui/plugin-report` patch,docs 级说明。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_