### PR TITLE
fix(app-shell): SchemaForm 的六条非注册表渲染路径按解析出的面发命名通道 (#5039)

### DIFF
--- a/.changeset/schemaform-nonregistry-labelling-5039.md
+++ b/.changeset/schemaform-nonregistry-labelling-5039.md
@@ -1,0 +1,16 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin 表单里六条不经注册表的渲染路径不再发悬空 `for`：结构化面按 IDREF 命名，JSON 兜底面把 id 落到自己的 textarea 上。
+
+objectui#4871（PR #5041）给 `WIDGETS` 注册表的二十个条目加了 `labelling` 声明，`FieldRow` 据此发命名通道。但有六条路径根本不经过注册表，因而没有声明可依，一律走默认的 `control` 通道，而它们都不消费 `id`：`composite` / `repeater` / `record` 由 `fieldSpec.type` 决定并在注册表查找之前短路；另外三条结构化兜底（递归 `SchemaForm` / `RepeaterField` / `RawJsonEditor`）是在 `FieldControl` 内部、按 union 解析后的 `effective` schema 才选的 —— 也就是标签已经写完之后。真 `SchemaForm` 渲染实测（基线 `e7c5a80a8`，可编辑与只读两态）：六条路径十二个读数全是 `for=DANGLING hostIdEl=NONE` —— 可见标签指向文档中不存在的 id。这与 #4871 / #4857 / #4788 同一失效类，且比干脆没有关联更糟：解析到无的关联被工具链读作已闭合。
+
+修法与 #4871 同形：把那段晚判定整体上提成纯函数 `resolveFieldFace()`，只吃 `FieldControl` 渲染所依据的那几个输入（`fieldSpec` / `widget` / `schema` / `value`），返回究竟渲染哪一个面。`FieldRow` 在写标签之前调它决定通道，`FieldControl` 调同一个函数而不再自行判定 —— 判据只有一份，声明与 DOM 无从走岔。
+
+六条路径的处置按实测逐条判定，并不齐整：
+
+- `composite`、递归 `nested-form` 里确有可 label 元素，但它属于**子字段自己的**标签（`mdf-sub` / `mdf-inner`）；`repeater` / `array-of-object` / `record` 自己只拥有折叠、新增、删除这些辅助按钮。这五条都是容器面，走 #4788 的容器形：标签发布自身 id，容器以 `role="group"` 应答 `aria-labelledby`，`for` 摘掉。`record` 委派给注册 widget 的那一形态也把 IDREF 转发下去，声明才在两种形态下都成立。
+- `raw-json` 是卡面点名要**确认而非假定**的一条，实测结果与预期相反：`RawJsonEditor` 的面恰好是一个可 label 元素 —— 一个没有任何别的标签指向的 `<textarea>`，在每个分支、两种状态下都在。它读到 `hostIdEl=NONE` 是因为 id 从未被接进去，不是因为这个面接不住。所以它是真正的 `control` 面，id 直接落到 textarea 上；反过来把一个孤零零的 textarea 包进具名 group，只会命名容器而让用户真正输入的控件无名 —— 那正是 objectui#4010 裁定的反面。
+
+注册表的二十个条目、`WIDGET_LABELLING` 声明表及其断言一字未动：注册 widget 仍由注册表说话，上提的解析函数不替它改判。

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.nonRegistryLabelling.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.nonRegistryLabelling.test.tsx
@@ -1,0 +1,483 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5039 — the SIX `SchemaForm` render paths that never reach the
+ * `WIDGETS` registry, and therefore had no `labelling` declaration to route
+ * their label by.
+ *
+ * ## What was measured
+ *
+ * objectui#4871 (PR #5041) put a `labelling` declaration on all twenty registry
+ * entries and made `FieldRow` emit the channel it dictates. Six paths bypass the
+ * registry entirely: `composite` / `repeater` / `record` come from
+ * `fieldSpec.type` and short-circuit ahead of the registry lookup, and the three
+ * structural fallbacks were chosen INSIDE `FieldControl` from the union-resolved
+ * `effective` schema — i.e. after `FieldRow` had already written its label. All
+ * six took the default `control` channel and none of them consumed the `id`.
+ * Probed on real `SchemaForm` renders at `e7c5a80a8`, both states, same columns
+ * as the #4871 ledger plus what the face actually owns:
+ *
+ * ```
+ *                                editable / read-only (identical)
+ * (spec) composite               for=DANGLING hostIdEl=NONE  group=NONE  labelable=1[input]
+ * (spec) repeater                for=DANGLING hostIdEl=NONE  group=NONE  labelable=[button]
+ * (spec) record                  for=DANGLING hostIdEl=NONE  group=NONE  labelable=[button,input]
+ * (fallback) nested-object       for=DANGLING hostIdEl=NONE  group=NONE  labelable=1[input]
+ * (fallback) array-of-obj        for=DANGLING hostIdEl=NONE  group=NONE  labelable=[button]
+ * (fallback) raw-json            for=DANGLING hostIdEl=NONE  group=NONE  labelable=1[textarea]
+ * ```
+ *
+ * `hostIdEl=NONE` twelve times over: the `for` pointed at an id no element in the
+ * document carried, the same failure class as #4871 / #4857 / #4788 — an
+ * association that resolves to nothing reads to tooling as closed, which is worse
+ * than none at all.
+ *
+ * The `labelable=` column is what decided each disposition, and it does NOT come
+ * out uniform:
+ *
+ *  - `composite` and `nested-object` do contain one labelable `<input>`, but it
+ *    belongs to a SUB-field's own `<label for>` (`mdf-sub` / `mdf-inner`). The
+ *    outer field owns nothing of its own to address → container, `'group'`;
+ *  - `repeater` / `array-of-obj` / `record` own only auxiliary buttons — collapse,
+ *    add, remove — and just the collapse toggles when read-only → `'group'`;
+ *  - `raw-json` is the exception the card asked to CONFIRM rather than assume.
+ *    Its face is exactly one labelable element, a `<textarea>` no other label
+ *    addresses, in every branch and both states. It read `hostIdEl=NONE` because
+ *    the id was never PLUMBED to it, not because the face cannot hold one → it is
+ *    a real `'control'` face, and wrapping a lone textarea in a named group
+ *    instead would name the container and leave the control the user types in
+ *    anonymous (objectui#4010's ruling, in reverse).
+ *
+ * ## What this file pins
+ *
+ * Two independent halves, so neither can carry the other:
+ *
+ *  1. the LEDGER — each path's face kind and channel spelled out here and
+ *     asserted against `resolveFieldFace` / `faceLabelling`, so flipping a
+ *     classification in the source fails a test rather than silently re-routing;
+ *  2. host/DOM AGREEMENT — the channel the assertions demand is read from
+ *     `faceLabelling()` (not from a second hand-written list), while the DOM half
+ *     comes from a real render. A resolver that misclassifies a path therefore
+ *     fails here too: it hands the id to a face that never spreads it.
+ *
+ * Group cases assert the named surface EXISTS and answers the IDREF — not merely
+ * that the `for` is gone, which is equally true of a path that renders nothing.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import {
+  SchemaForm,
+  resolveFieldFace,
+  faceLabelling,
+  type FieldFace,
+  type FormFieldSpec,
+} from './SchemaForm';
+import { WIDGET_LABELLING } from './widgets';
+
+afterEach(cleanup);
+
+/** The HTML elements a `<label for>` can actually address. */
+const LABELABLE = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'METER', 'OUTPUT', 'PROGRESS']);
+
+// `prettify('probe') === 'Probe'`, so `FieldRow` renders no machine-name `<code>`
+// inside the label and the accessible name is the visible text alone.
+const NAME = 'probe';
+const HOST_ID = `mdf-${NAME}`;
+const LABEL_ID = `${HOST_ID}-label`;
+const TITLE = 'Probe';
+
+type Case = {
+  /** The ledger row this case is. */
+  tag: string;
+  /** The face this path must resolve to — the ledger, spelled out. */
+  face: FieldFace['kind'];
+  schema: Record<string, unknown>;
+  spec?: Record<string, unknown>;
+  value?: unknown;
+};
+
+/**
+ * The six non-registry paths, plus the second shape of three of them: a
+ * `nested-object` reached through a union instead of an inferred
+ * `object-fields` widget, a `raw-json` announced by an unregistered widget name,
+ * a `composite` in its popover disclosure, and a `record` that delegates to a
+ * registered widget. Each shape is a distinct route to the same face and each
+ * one was `for=DANGLING` before.
+ */
+const CASES: Case[] = [
+  {
+    tag: '(spec) composite',
+    face: 'composite',
+    spec: { type: 'composite', fields: [{ field: 'sub', type: 'text' }] },
+    schema: { type: 'object', title: TITLE, properties: { sub: { type: 'string' } } },
+    value: { sub: 'a' },
+  },
+  {
+    tag: '(spec) composite / popover disclosure',
+    face: 'composite',
+    spec: { type: 'composite', disclosure: 'popover', fields: [{ field: 'sub', type: 'text' }] },
+    schema: { type: 'object', title: TITLE, properties: { sub: { type: 'string' } } },
+    value: { sub: 'a' },
+  },
+  {
+    tag: '(spec) repeater',
+    face: 'repeater',
+    spec: { type: 'repeater', fields: [{ field: 'sub', type: 'text' }] },
+    schema: {
+      type: 'array',
+      title: TITLE,
+      items: { type: 'object', properties: { sub: { type: 'string' } } },
+    },
+    value: [{ sub: 'a' }],
+  },
+  {
+    tag: '(spec) repeater / grid layout',
+    face: 'repeater',
+    spec: { type: 'repeater', widget: 'grid', fields: [{ field: 'sub', type: 'text' }] },
+    schema: {
+      type: 'array',
+      title: TITLE,
+      items: { type: 'object', properties: { sub: { type: 'string' } } },
+    },
+    value: [{ sub: 'a' }],
+  },
+  {
+    tag: '(spec) record',
+    face: 'record',
+    spec: { type: 'record' },
+    schema: {
+      type: 'object',
+      title: TITLE,
+      additionalProperties: {
+        type: 'object',
+        properties: { name: { type: 'string' }, label: { type: 'string' } },
+      },
+    },
+    value: { alpha: { name: 'alpha' } },
+  },
+  {
+    // The record face's other shape: the whole editor delegated to a registered
+    // widget. `fieldSpec.type` still decides the face — the registry lookup is
+    // short-circuited — so the channel is the record's, and the IDREF has to
+    // reach the delegate for the declaration to hold.
+    tag: '(spec) record / delegated to a registered widget',
+    face: 'record',
+    spec: { type: 'record', widget: 'code' },
+    schema: { type: 'object', title: TITLE, additionalProperties: { type: 'object' } },
+    value: { alpha: {} },
+  },
+  {
+    // `inferWidget` returns `object-fields` for every `type: 'object'` schema;
+    // it is not a registry key, so this lands in the widget branch's structural
+    // fallback.
+    tag: '(fallback) nested-object',
+    face: 'nested-form',
+    schema: { type: 'object', title: TITLE, properties: { inner: { type: 'string' } } },
+    value: { inner: 'a' },
+  },
+  {
+    // The same face with NO widget hint at all: the outer schema has no `type`,
+    // so the union has to be resolved before the object branch is visible — the
+    // View `data`-provider shape.
+    tag: '(fallback) nested-object / union-resolved',
+    face: 'nested-form',
+    schema: {
+      title: TITLE,
+      anyOf: [{ type: 'string' }, { type: 'object', properties: { provider: { type: 'string' } } }],
+    },
+    value: { provider: 'rest' },
+  },
+  {
+    // The View `sort` shape (objectui#3379): `anyOf: [string, {field,order}[]]`.
+    tag: '(fallback) array-of-obj',
+    face: 'object-rows',
+    schema: {
+      title: TITLE,
+      anyOf: [
+        { type: 'string' },
+        { type: 'array', items: { type: 'object', properties: { field: { type: 'string' } } } },
+      ],
+    },
+    value: [{ field: 'name' }],
+  },
+  {
+    tag: '(fallback) raw-json',
+    face: 'raw-json',
+    schema: { title: TITLE },
+    value: { anything: 1 },
+  },
+  {
+    // An unregistered, non-passthrough widget name: the JSON editor plus the
+    // "no renderer for <widget>" hint. Reached before the scalar chain, so even
+    // this `type: 'string'` field renders the editor.
+    tag: '(fallback) raw-json / unregistered widget hint',
+    face: 'raw-json',
+    spec: { widget: 'gizmo' },
+    schema: { type: 'string', title: TITLE },
+    value: 'x',
+  },
+];
+
+function renderCase(c: Case, readOnly: boolean) {
+  const spec = { field: NAME, ...c.spec } as FormFieldSpec;
+  return render(
+    <SchemaForm
+      schema={{ type: 'object', properties: { [NAME]: c.schema } } as never}
+      form={{ type: 'simple', sections: [{ label: 'S', fields: [spec] }] } as never}
+      value={{ [NAME]: c.value }}
+      onChange={() => {}}
+      readOnly={readOnly}
+    />,
+  );
+}
+
+const faceOf = (c: Case) =>
+  resolveFieldFace({
+    fieldSpec: { field: NAME, ...c.spec } as FormFieldSpec,
+    // `FieldRow` resolves the widget name before calling; for these paths that is
+    // either the authored one or nothing (an inferred `object-fields` /
+    // `master-detail` would be the registry's business, not this file's).
+    widget: (c.spec as { widget?: string } | undefined)?.widget,
+    schema: c.schema,
+    value: c.value,
+  });
+
+describe('resolveFieldFace — the lifted decision, as a pure function', () => {
+  for (const c of CASES) {
+    it(`${c.tag} → ${c.face}`, () => {
+      expect(faceOf(c).kind).toBe(c.face);
+    });
+  }
+
+  it('keeps the registry as the authority for a REGISTERED widget', () => {
+    // The lifted resolver must not second-guess objectui#4871's reviewed table:
+    // a registry key resolves to `registered` and its channel comes from
+    // `WIDGET_LABELLING`, group and control alike.
+    const cond = resolveFieldFace({ widget: 'condition', schema: { type: 'string' } });
+    expect(cond).toEqual({ kind: 'registered', widget: 'condition' });
+    expect(faceLabelling(cond)).toBe(WIDGET_LABELLING['condition']);
+    expect(faceLabelling(cond)).toBe('group');
+
+    const icon = resolveFieldFace({ widget: 'icon', schema: { type: 'string' } });
+    expect(faceLabelling(icon)).toBe(WIDGET_LABELLING['icon']);
+    expect(faceLabelling(icon)).toBe('control');
+  });
+
+  it('routes every builtin scalar branch to the one `scalar` face', () => {
+    // Each of these renders a labelable control that spreads the host id, so they
+    // are one face for naming purposes — unchanged from before the lift.
+    const scalars: Array<Parameters<typeof resolveFieldFace>[0]> = [
+      { schema: { type: 'string' } },
+      { schema: { type: 'number' } },
+      { schema: { type: 'integer' } },
+      { schema: { type: 'boolean' } },
+      { schema: { type: 'string', enum: ['a', 'b'] } },
+      { schema: { type: 'array', items: { type: 'string' } } },
+      { schema: {}, fieldSpec: { field: 'f', options: [{ label: 'A', value: 'a' }] } },
+      // A composite sub-field's schema fragment is often `{}` while the spec
+      // marks it boolean — the `switch` case that predates this change.
+      { schema: {}, fieldSpec: { field: 'f', type: 'boolean' } },
+      { schema: {}, widget: 'switch' },
+      // A union of primitives resolves against the value before the type check.
+      { schema: { anyOf: [{ type: 'string' }, { type: 'number' }] }, value: 7 },
+    ];
+    for (const input of scalars) {
+      const face = resolveFieldFace(input);
+      expect(face.kind, JSON.stringify(input)).toBe('scalar');
+      expect(faceLabelling(face)).toBe('control');
+    }
+  });
+
+  it('keeps a PASSTHROUGH widget hint on the scalar path, but not over structure', () => {
+    // `json` / `text` / `textarea` … are hints that overlay the default control:
+    // they must not divert a string to the JSON editor…
+    expect(resolveFieldFace({ widget: 'json', schema: { type: 'string' } }).kind).toBe('scalar');
+    // …while an unregistered, non-passthrough name does exactly that.
+    expect(resolveFieldFace({ widget: 'gizmo', schema: { type: 'string' } })).toEqual({
+      kind: 'raw-json',
+      hint: 'gizmo',
+    });
+    // A structured schema still wins over the passthrough hint, as it always did.
+    expect(
+      resolveFieldFace({
+        widget: 'json',
+        schema: { type: 'object', properties: { a: { type: 'string' } } },
+      }).kind,
+    ).toBe('nested-form');
+  });
+
+  it('resolves the repeater row schema through a union (objectui#3379)', () => {
+    // The face carries the resolved `items`, so the sub-field list and the
+    // per-row controls both see real sub-schemas rather than a blank row.
+    const face = resolveFieldFace({
+      fieldSpec: { field: 'sort', type: 'repeater' },
+      schema: {
+        anyOf: [
+          { type: 'string' },
+          { type: 'array', items: { type: 'object', properties: { field: { type: 'string' } } } },
+        ],
+      },
+      value: [{ field: 'name' }],
+    });
+    expect(face.kind).toBe('repeater');
+    expect((face as { itemSchema: Record<string, unknown> }).itemSchema.properties).toEqual({
+      field: { type: 'string' },
+    });
+  });
+
+  it('declares a channel for every face kind, and the six non-registry ones by measurement', () => {
+    // `faceLabelling` is a total function over the union — a new face kind added
+    // without a channel is a compile error there, and this is its runtime half.
+    const kinds: FieldFace['kind'][] = [
+      'composite',
+      'repeater',
+      'record',
+      'registered',
+      'nested-form',
+      'object-rows',
+      'raw-json',
+      'scalar',
+    ];
+    const channels = Object.fromEntries(
+      kinds
+        .filter((k) => k !== 'registered')
+        .map((k) => [k, faceLabelling({ kind: k } as FieldFace)]),
+    );
+    expect(channels).toEqual({
+      composite: 'group',
+      repeater: 'group',
+      record: 'group',
+      'nested-form': 'group',
+      'object-rows': 'group',
+      // MEASURED, not assumed: one labelable `<textarea>`, both states.
+      'raw-json': 'control',
+      scalar: 'control',
+    });
+    // Every case in the ledger below covers one of the eight kinds, and between
+    // them the six non-registry faces are all exercised through a real render.
+    expect([...new Set(CASES.map((c) => c.face))].sort()).toEqual(
+      ['composite', 'nested-form', 'object-rows', 'raw-json', 'record', 'repeater'].sort(),
+    );
+  });
+});
+
+describe('the ledger, re-measured: every non-registry path gets the channel its face declares', () => {
+  for (const c of CASES) {
+    for (const readOnly of [false, true]) {
+      const state = readOnly ? 'read-only' : 'editable';
+      const declared = faceLabelling({ kind: c.face } as FieldFace);
+
+      it(`${c.tag} — ${declared}, ${state}`, () => {
+        renderCase(c, readOnly);
+        const label = screen.getByText(TITLE).closest('label')!;
+        expect(label.tagName).toBe('LABEL');
+
+        if (declared === 'control') {
+          // Column 1: the `for` resolves, AND to a LABELABLE element. "The id is
+          // on SOME element" is the deceptive green a half-fix produces.
+          expect(label).toHaveAttribute('for', HOST_ID);
+          expect(label).not.toHaveAttribute('id');
+          const target = document.getElementById(HOST_ID);
+          expect(target, `${c.tag}: host id is on no element in the ${state} state`).not.toBeNull();
+          expect(
+            LABELABLE.has(target!.tagName),
+            `${c.tag}: host id landed on <${target!.tagName.toLowerCase()}>, which no <label for> can address`,
+          ).toBe(true);
+          // Column 3: the named surface IS that control, named by the visible
+          // label rather than by some self-owned string.
+          expect(target).toHaveAccessibleName(TITLE);
+          return;
+        }
+
+        // `'group'`. Column 1: no `for` at all — not a `for` pointing somewhere
+        // harmless. On a container it activates nothing and names nothing, and
+        // beside the working IDREF it is a second, broken channel (#3978/#4010).
+        expect(label).not.toHaveAttribute('for');
+        expect(label).toHaveAttribute('id', LABEL_ID);
+        expect(document.getElementById(HOST_ID)).toBeNull();
+
+        // Columns 2 + 3: the face EXISTS, answers the IDREF, and is a group.
+        // Asserted positively on purpose — a path that rendered nothing would
+        // satisfy every "is absent" assertion above.
+        const named = document.querySelector(`[aria-labelledby="${LABEL_ID}"]`);
+        expect(named, `${c.tag}: nothing answers the host label's IDREF in the ${state} state`).not.toBeNull();
+        expect(['group', 'radiogroup']).toContain(named!.getAttribute('role'));
+        expect(named).toHaveAccessibleName(TITLE);
+      });
+    }
+  }
+});
+
+describe('a group name does not swallow the sub-fields it contains', () => {
+  // `nested-object` recurses into a whole nested `SchemaForm`, and `composite`
+  // into recursive `FieldRow`s. Naming the outer container must leave every inner
+  // field's own channel intact — the inner rows are the reason the outer face is
+  // a group in the first place.
+  it('nested-object — the inner field keeps its own `for`, and the outer name is only the outer label', () => {
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: {
+              [NAME]: {
+                type: 'object',
+                title: TITLE,
+                properties: { inner: { type: 'string', title: 'Inner' } },
+              },
+            },
+          } as never
+        }
+        form={{ type: 'simple', sections: [{ label: 'S', fields: [{ field: NAME }] }] } as never}
+        value={{ [NAME]: { inner: 'a' } }}
+        onChange={() => {}}
+      />,
+    );
+
+    const group = document.querySelector(`[aria-labelledby="${LABEL_ID}"]`)!;
+    // The outer group is named by the outer label ALONE, though it contains the
+    // inner label's text too: `aria-labelledby` wins over subtree content.
+    expect(group).toHaveAccessibleName(TITLE);
+
+    // The inner field is a plain control on its own `control` channel, reached by
+    // its own label — not by the outer one, and not by `aria-labelledby`.
+    const innerLabel = within(group as HTMLElement).getByText('Inner').closest('label')!;
+    expect(innerLabel).toHaveAttribute('for', 'mdf-inner');
+    const innerInput = document.getElementById('mdf-inner')!;
+    expect(innerInput.tagName).toBe('INPUT');
+    expect(innerInput).not.toHaveAttribute('aria-labelledby');
+    expect(innerInput).toHaveAccessibleName('Inner');
+    // And the inner control is inside the outer group rather than replacing it —
+    // the outer field never claimed it as its own control.
+    expect(group.contains(innerInput)).toBe(true);
+    expect(group).not.toBe(innerInput);
+  });
+
+  it('composite — each sub-row keeps its own `for` under the named box', () => {
+    render(
+      <SchemaForm
+        schema={
+          { type: 'object', properties: { [NAME]: { type: 'object', title: TITLE, properties: { sub: { type: 'string' } } } } } as never
+        }
+        form={
+          {
+            type: 'simple',
+            sections: [
+              { label: 'S', fields: [{ field: NAME, type: 'composite', fields: [{ field: 'sub', type: 'text', label: 'Sub' }] }] },
+            ],
+          } as never
+        }
+        value={{ [NAME]: { sub: 'a' } }}
+        onChange={() => {}}
+      />,
+    );
+
+    const group = document.querySelector(`[aria-labelledby="${LABEL_ID}"]`)!;
+    expect(group).toHaveAccessibleName(TITLE);
+    const subInput = document.getElementById('mdf-sub')!;
+    expect(subInput.tagName).toBe('INPUT');
+    expect(subInput).toHaveAccessibleName('Sub');
+    expect(within(group as HTMLElement).getByText('Sub').closest('label')).toHaveAttribute('for', 'mdf-sub');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -62,6 +62,7 @@ import {
   resolveColorWidgetKey,
   type RegisteredWidgetKey,
   type WidgetContext,
+  type WidgetLabelling,
   type WidgetRenderer,
 } from './widgets';
 import { useMetadataLocale, t, tFormat, translateValidationMessage, translateEnumOption, translateSchemaFieldLabel, translateSchemaFieldHelp } from './i18n';
@@ -375,6 +376,192 @@ function resolveRegisteredWidget(
     return resolveColorWidgetKey(schema, fieldSpec);
   }
   return widget;
+}
+
+/* ----- which face renders, resolved BEFORE the label (objectui#5039) ------- */
+
+/**
+ * The face {@link FieldControl} will render for a field — a closed set, so the
+ * host can name it without rendering it first.
+ */
+export type FieldFace =
+  /** `fieldSpec.type: 'composite'` → {@link CompositeField}. */
+  | { kind: 'composite' }
+  /** `fieldSpec.type: 'repeater'` → {@link RepeaterField}. */
+  | { kind: 'repeater'; itemSchema: JsonSchema }
+  /** `fieldSpec.type: 'record'` → {@link RecordField}. */
+  | { kind: 'record'; itemSchema: JsonSchema }
+  /** A key of {@link WIDGETS} — the face objectui#4871's declaration covers. */
+  | { kind: 'registered'; widget: RegisteredWidgetKey }
+  /** Object-with-properties → a recursive {@link SchemaForm} in a bordered box. */
+  | { kind: 'nested-form'; effective: JsonSchema }
+  /** Array-of-object → {@link RepeaterField} with per-row inputs. */
+  | { kind: 'object-rows'; effective: JsonSchema; itemSchema: JsonSchema }
+  /**
+   * {@link RawJsonEditor}. `hint` is the unregistered widget name whose
+   * fallback we are announcing; absent for the last-resort (`small`) editor.
+   */
+  | { kind: 'raw-json'; hint?: string }
+  /** Every builtin branch: select / switch / number / input / tag input. */
+  | { kind: 'scalar'; effective: JsonSchema };
+
+/**
+ * Resolve which face a field renders, from exactly the inputs `FieldControl`
+ * renders from — no DOM, no render (objectui#5039).
+ *
+ * `FieldRow` must decide how its visible label reaches the control BEFORE it
+ * writes that label. For the twenty REGISTERED widgets objectui#4871 answered
+ * that from the registry's `labelling` declaration. Six paths never reach the
+ * registry, so they had no declaration and took the default `control` channel:
+ * `composite` / `repeater` / `record` come from `fieldSpec.type`, and the three
+ * structural fallbacks (recursive `SchemaForm` / `RepeaterField` /
+ * `RawJsonEditor`) were picked INSIDE `FieldControl` from the union-resolved
+ * `effective` schema — i.e. after the label had already been written. None of the
+ * six consumed the id, so all six emitted a `<label for>` aimed at an id no
+ * element in the document carried (`for=DANGLING hostIdEl=NONE`, both states).
+ *
+ * This function is that late decision lifted out whole. `FieldRow` calls it
+ * before the label; `FieldControl` calls it instead of deciding again — one
+ * resolution, so the naming channel and the rendered DOM cannot drift apart.
+ * Same shape as `resolveRegisteredWidget()`, applied to the paths that have no
+ * registry entry to declare anything.
+ *
+ * Branch order mirrors `FieldControl` exactly, asymmetry included: with a widget
+ * hint present the structural checks run BEFORE the scalar chain, and an
+ * unregistered non-passthrough hint short-circuits to the JSON editor; with no
+ * hint (or a passthrough one that matched no structure) the scalar chain runs
+ * first.
+ */
+export function resolveFieldFace({
+  fieldSpec,
+  widget,
+  schema,
+  value,
+}: {
+  fieldSpec?: FormFieldSpec;
+  widget?: string;
+  schema?: JsonSchema;
+  value?: unknown;
+}): FieldFace {
+  // 1. Spec-declared structured types — known from `fieldSpec.type` alone, and
+  // short-circuited in `FieldControl` ahead of the registry lookup.
+  if (fieldSpec?.type === 'composite') return { kind: 'composite' };
+  if (fieldSpec?.type === 'repeater') {
+    return { kind: 'repeater', itemSchema: repeaterItemSchema(schema, value) };
+  }
+  if (fieldSpec?.type === 'record') {
+    return {
+      kind: 'record',
+      itemSchema: (schema?.additionalProperties as JsonSchema | undefined) ?? {},
+    };
+  }
+
+  const effective = resolveUnionBranch(schema, value) ?? schema ?? {};
+  const isObjectForm = (s: JsonSchema | undefined) =>
+    s?.type === 'object' && !!s.properties && typeof s.properties === 'object';
+  /** The row schema of an array-of-object face, or undefined if it isn't one. */
+  const objectRowSchema = (s: JsonSchema | undefined): JsonSchema | undefined => {
+    if (s?.type !== 'array' || !s.items || typeof s.items !== 'object') return undefined;
+    const itemSchema = resolveUnionBranch(
+      s.items as JsonSchema,
+      Array.isArray(value) && value.length ? value[0] : undefined,
+    );
+    return isObjectForm(itemSchema) ? itemSchema : undefined;
+  };
+
+  // 2. A widget hint: the registry first, then the structural fallbacks, then
+  // the announced JSON editor — the order of `FieldControl`'s `if (widget)` block.
+  if (widget) {
+    if (WIDGETS[widget as RegisteredWidgetKey]) {
+      return { kind: 'registered', widget: widget as RegisteredWidgetKey };
+    }
+    if (isObjectForm(effective)) return { kind: 'nested-form', effective };
+    const rows = objectRowSchema(effective);
+    if (rows) return { kind: 'object-rows', effective, itemSchema: rows };
+    if (!KNOWN_PASSTHROUGH_WIDGETS.has(widget)) return { kind: 'raw-json', hint: widget };
+  }
+
+  // 3. The builtin scalar chain. Each of these branches spreads the host id onto
+  // its own labelable control, so they are all one face as far as naming goes.
+  const effectiveType = effective?.type as string | undefined;
+  const hasOptions = Array.isArray(fieldSpec?.options) && fieldSpec.options.length > 0;
+  const hasEnum = Array.isArray(effective?.enum) && (effective.enum as unknown[]).length > 0;
+  if (
+    hasOptions ||
+    hasEnum ||
+    effectiveType === 'boolean' ||
+    widget === 'switch' ||
+    fieldSpec?.type === 'boolean' ||
+    fieldSpec?.type === 'toggle' ||
+    effectiveType === 'number' ||
+    effectiveType === 'integer' ||
+    effectiveType === 'string'
+  ) {
+    return { kind: 'scalar', effective };
+  }
+  if (effectiveType === 'array') {
+    const itemsSchema = (effective?.items as JsonSchema | undefined) ?? {};
+    if (
+      itemsSchema.type === 'string' ||
+      itemsSchema.type === 'number' ||
+      itemsSchema.type === 'integer'
+    ) {
+      return { kind: 'scalar', effective };
+    }
+  }
+
+  // 4. Structured fallback, then the last-resort JSON editor.
+  if (isObjectForm(effective)) return { kind: 'nested-form', effective };
+  const rows = objectRowSchema(effective);
+  if (rows) return { kind: 'object-rows', effective, itemSchema: rows };
+  return { kind: 'raw-json' };
+}
+
+/**
+ * The naming channel each face needs — what `WIDGET_LABELLING` does for the
+ * registry, for the paths that have no registry entry. Decided on the same
+ * MEASURED basis (objectui#5039's ledger: real `SchemaForm` renders, both
+ * states, does the `for` resolve and to a labelable element / what does the face
+ * actually own).
+ *
+ * `'group'` — five of the six. `composite` and the recursive `nested-form` are
+ * containers of independently labelled sub-rows: every labelable element inside
+ * them is addressed by a SUB-field's own label, so the outer `for` had nothing of
+ * its own to point at. `repeater` / `object-rows` / `record` own nothing but
+ * auxiliary buttons — collapse, add, remove — in the editable state, and just the
+ * collapse toggles when read-only. All five take the objectui#4788 container
+ * shape: the label publishes its id, the container answers `aria-labelledby` on
+ * a `role="group"`, and the `for` is dropped rather than left pointing at a
+ * container it can neither activate nor name (objectui#3978/#4010).
+ *
+ * `'control'` — `raw-json`, MEASURED rather than assumed (objectui#5039 named
+ * this the reading to confirm). `RawJsonEditor`'s face is exactly ONE labelable
+ * element, a `<textarea>` no other label addresses, in every branch and both
+ * states — `readOnly` only sets the attribute. Its `hostIdEl=NONE` reading was
+ * the id never being PLUMBED to it, not a face that cannot hold one. Naming a
+ * wrapper `role="group"` around a lone textarea instead would name the container
+ * and leave the control the user actually types in anonymous, which is
+ * objectui#4010's ruling in reverse. So the id reaches the textarea and the plain
+ * `<label for>` channel is what this face gets.
+ *
+ * `'registered'` defers to the widget's own declaration — this function must not
+ * second-guess objectui#4871's reviewed table. `'scalar'` is every builtin
+ * branch, each of which already spreads the host id onto its own control.
+ */
+export function faceLabelling(face: FieldFace): WidgetLabelling {
+  switch (face.kind) {
+    case 'registered':
+      return widgetLabelling(face.widget);
+    case 'composite':
+    case 'repeater':
+    case 'record':
+    case 'nested-form':
+    case 'object-rows':
+      return 'group';
+    case 'raw-json':
+    case 'scalar':
+      return 'control';
+  }
 }
 
 const CONDITION_FIELD_NAMES = new Set(['visible', 'hidden', 'disabled', 'visibleOn', 'condition', 'predicate']);
@@ -953,21 +1140,29 @@ function FieldRow({
   // declaration below describes the surface the user gets (objectui#4871).
   widget = resolveRegisteredWidget(widget, schema, fieldSpec);
 
-  // How this field's visible label must reach what the widget renders — the
-  // widget's own DECLARATION, never an inference from the DOM it happens to
-  // produce (objectui#4871, the vocabulary of `ComponentMeta.labelling`).
+  // Which face `FieldControl` will render — resolved HERE, before the label, from
+  // the same inputs it renders from (objectui#5039). The six paths that never
+  // reach the `WIDGETS` registry (`composite` / `repeater` / `record` and the
+  // three structural fallbacks) used to be decided inside `FieldControl`, i.e.
+  // after this label was written, which is why they all emitted a dangling `for`.
+  const face = resolveFieldFace({ fieldSpec, widget, schema, value });
+
+  // How this field's visible label must reach what that face renders — a
+  // DECLARATION either way, never an inference from the DOM it happens to
+  // produce (objectui#4871, the vocabulary of `ComponentMeta.labelling`): the
+  // registry's `labelling` for a registered widget, `faceLabelling` for the
+  // structural faces that have no registry entry (objectui#5039).
   //
-  //  - `'control'` — the widget puts this `id` on a labelable element, so the
-  //    label associates the plain way, `<label for>` → id. Unchanged path;
-  //    every non-registered widget name resolves here too.
+  //  - `'control'` — the face puts this `id` on a labelable element, so the
+  //    label associates the plain way, `<label for>` → id.
   //  - `'group'` — no `<label for>` can reach the surface. The label publishes
-  //    its OWN id, the widget answers `aria-labelledby`, and the `for` is
+  //    its OWN id, the face answers `aria-labelledby`, and the `for` is
   //    DROPPED: aimed at a container it activates nothing and names nothing,
   //    and leaving it beside the working channel is one label with two
   //    associations, one of them broken (the `form.tsx` `labelling: 'group'`
   //    branch, objectui#3961/#3978, and objectui#4010's refusal to relocate
   //    the id onto the radiogroup instead).
-  const labelling = widgetLabelling(widget);
+  const labelling = faceLabelling(face);
   const groupLabelled = labelling === 'group';
   // Whitespace-free by construction (`mdf-` + a field name), and consumed as an
   // `aria-labelledby` IDREF — a space in it would silently resolve to two ids.
@@ -1080,9 +1275,9 @@ function FieldControl({
   /**
    * The host field id — present only on the `labelling: 'control'` channel,
    * `undefined` on the `'group'` one (objectui#4871). Every builtin branch below
-   * renders a labelable element, so they all spread it unconditionally; a group
-   * declaration can only come from a REGISTERED widget, and that branch returns
-   * before them.
+   * renders a labelable element and spreads it unconditionally; so does the JSON
+   * editor, whose `<textarea>` is exactly such an element (objectui#5039). The
+   * `'group'` faces never read it — `FieldRow` doesn't hand it to them.
    */
   id?: string;
   /** The host label's id, on the `'group'` channel only. */
@@ -1099,15 +1294,23 @@ function FieldControl({
   formData?: Record<string, unknown>;
 }) {
   const locale = useMetadataLocale();
+  // WHICH face renders is not decided here — `resolveFieldFace` decides it, and
+  // `FieldRow` already called it with these very inputs to pick the naming
+  // channel (objectui#5039). Calling the same pure function again here, rather
+  // than re-testing `fieldSpec.type` / the union-resolved schema inline, is what
+  // makes the declaration and the DOM impossible to drift apart: there is one
+  // set of branch predicates, not two that must be kept in step.
+  const face = resolveFieldFace({ fieldSpec, widget, schema, value });
+
   // Composite/repeater are first-class structured types — render natively
   // with recursive FieldRow calls so all UI features (widgets, options,
   // visibility, readonly) work uniformly at every nesting level.
   // When `fields` is omitted, fall back to schema-derived sub-fields
   // (all schema.properties / items.properties) so authors don't have to
   // enumerate every sub-property by hand.
-  if (fieldSpec?.type === 'composite') {
+  if (face.kind === 'composite') {
     const fields =
-      fieldSpec.fields?.length
+      fieldSpec?.fields?.length
         ? fieldSpec.fields
         : derivePropertyNames(schema);
     return (
@@ -1118,21 +1321,22 @@ function FieldControl({
         readOnly={readOnly}
         widgetContext={widgetContext}
         fieldSpec={fieldSpec}
+        ariaLabelledBy={ariaLabelledBy}
         onChange={onChange}
       />
     );
   }
-  if (fieldSpec?.type === 'repeater') {
+  if (face.kind === 'repeater') {
     // The row schema may be nested inside a union (`anyOf` / `oneOf`) — e.g.
     // a View `sort` authored as `anyOf: [ string, {field,order}[] ]`. Reading
     // `schema.items` at the top level misses the array branch and renders a
-    // blank row with no sub-fields (objectui#3379). Resolve to the array
-    // branch's items and hand RepeaterField a schema whose `items` is that
-    // object schema, so both the derived field list and `pickSubSchema`
+    // blank row with no sub-fields (objectui#3379). `resolveFieldFace` resolved
+    // to the array branch's items; hand RepeaterField a schema whose `items` is
+    // that object schema, so both the derived field list and `pickSubSchema`
     // (per-row controls) see real sub-schemas.
-    const itemSchema = repeaterItemSchema(schema, value);
+    const itemSchema = face.itemSchema;
     const fields =
-      fieldSpec.fields?.length
+      fieldSpec?.fields?.length
         ? fieldSpec.fields
         : derivePropertyNames(itemSchema);
     return (
@@ -1142,17 +1346,18 @@ function FieldControl({
         schema={{ ...schema, items: itemSchema }}
         readOnly={readOnly}
         widgetContext={widgetContext}
-        widget={fieldSpec.widget}
+        widget={fieldSpec?.widget}
+        ariaLabelledBy={ariaLabelledBy}
         onChange={onChange}
       />
     );
   }
-  if (fieldSpec?.type === 'record') {
+  if (face.kind === 'record') {
     // Record<string, item> — name-keyed map. Insertion order is display
     // order. JSON Schema shape: { type:'object', additionalProperties: itemSchema }.
-    const itemSchema = (schema?.additionalProperties as JsonSchema | undefined) ?? {};
+    const itemSchema = face.itemSchema;
     const fields =
-      fieldSpec.fields?.length
+      fieldSpec?.fields?.length
         ? fieldSpec.fields
         : derivePropertyNames(itemSchema);
     return (
@@ -1162,116 +1367,106 @@ function FieldControl({
         schema={schema}
         readOnly={readOnly}
         widgetContext={widgetContext}
-        widget={fieldSpec.widget}
-        keyField={(fieldSpec as any).keyField}
+        widget={fieldSpec?.widget}
+        keyField={(fieldSpec as any)?.keyField}
         formData={formData}
+        ariaLabelledBy={ariaLabelledBy}
         onChange={onChange}
       />
     );
   }
 
-  // Widget hint takes precedence: try the registry first, then the
-  // passthrough hint list, then fall back to JSON with an inline hint.
-  if (widget) {
-    const Renderer = WIDGETS[widget as RegisteredWidgetKey] as WidgetRenderer | undefined;
-    if (Renderer) {
-      return (
-        <Renderer
-          // Exactly one of these is defined, decided by the widget's own
-          // `labelling` declaration in `FieldRow` (objectui#4871).
-          id={id}
-          ariaLabelledBy={ariaLabelledBy}
-          schema={schema}
-          value={value}
-          onChange={onChange}
-          readOnly={readOnly}
-          context={widgetContext}
-          fieldSpec={fieldSpec}
-          formData={formData}
-        />
-      );
-    }
-    // Resolve discriminated unions (oneOf / anyOf) against the current
-    // value so the recursive renderer below works on a concrete branch.
-    // Without this, every union field (View `data`, `columns`, `sort`,
-    // ...) falls through to a raw JSON editor.
-    const effective = resolveUnionBranch(schema, value);
+  // Widget hint takes precedence: the registry first, then the structural
+  // fallbacks, then JSON with an inline hint — all four already resolved.
+  if (face.kind === 'registered') {
+    const Renderer = WIDGETS[face.widget] as WidgetRenderer;
+    return (
+      <Renderer
+        // Exactly one of these is defined, decided by the widget's own
+        // `labelling` declaration in `FieldRow` (objectui#4871).
+        id={id}
+        ariaLabelledBy={ariaLabelledBy}
+        schema={schema}
+        value={value}
+        onChange={onChange}
+        readOnly={readOnly}
+        context={widgetContext}
+        fieldSpec={fieldSpec}
+        formData={formData}
+      />
+    );
+  }
 
-    // Nested object schema with a `properties` map: recurse into a
-    // nested SchemaForm so the user gets real labelled inputs instead
-    // of raw JSON. Covers the auto-inferred `object-fields` widget that
-    // SchemaForm picks for every `type: 'object'` schema, and any custom
-    // widget name that wasn't registered but still describes structured
-    // data.
-    if (
-      effective?.type === 'object' &&
-      effective.properties &&
-      typeof effective.properties === 'object'
-    ) {
-      return (
-        <div className="rounded-md border border-border/40 bg-card/30 p-3">
-          <SchemaForm
-            schema={effective}
-            value={(value as Record<string, unknown>) ?? {}}
-            onChange={(v) => onChange(v)}
-            readOnly={readOnly}
-            widgetContext={widgetContext}
-          />
-        </div>
-      );
-    }
-    // Array-of-object schemas: route through RepeaterField so the user
-    // gets per-row inputs rather than a JSON blob. Derive sub-field
-    // names from items.properties (after union resolution).
-    if (
-      effective?.type === 'array' &&
-      effective.items &&
-      typeof effective.items === 'object'
-    ) {
-      const itemSchema = resolveUnionBranch(
-        effective.items as JsonSchema,
-        Array.isArray(value) && value.length ? value[0] : undefined,
-      );
-      if (
-        itemSchema?.type === 'object' &&
-        itemSchema.properties &&
-        typeof itemSchema.properties === 'object'
-      ) {
-        return (
-          <RepeaterField
-            value={value}
-            fields={derivePropertyNames(itemSchema)}
-            schema={{ ...effective, items: itemSchema }}
-            readOnly={readOnly}
-            widgetContext={widgetContext}
-            widget={fieldSpec?.widget}
-            onChange={onChange}
-          />
-        );
-      }
-    }
-    if (!KNOWN_PASSTHROUGH_WIDGETS.has(widget)) {
+  // Nested object schema with a `properties` map: recurse into a nested
+  // SchemaForm so the user gets real labelled inputs instead of raw JSON.
+  // Covers the auto-inferred `object-fields` widget that SchemaForm picks for
+  // every `type: 'object'` schema, any custom widget name that wasn't
+  // registered but still describes structured data, and the same shape reached
+  // with no widget hint at all (a union whose object branch won).
+  if (face.kind === 'nested-form') {
+    return (
+      // A container of independently labelled sub-rows: the host label names it
+      // by IDREF and dropped its `for`, because every labelable element in here
+      // belongs to a SUB-field's own label (objectui#5039, #4788's shape). The
+      // inner `SchemaForm` publishes its own per-field channels, untouched — this
+      // name is the outer field's, not theirs.
+      <div className="rounded-md border border-border/40 bg-card/30 p-3" role="group" aria-labelledby={ariaLabelledBy}>
+        <SchemaForm
+          schema={face.effective}
+          value={(value as Record<string, unknown>) ?? {}}
+          onChange={(v) => onChange(v)}
+          readOnly={readOnly}
+          widgetContext={widgetContext}
+        />
+      </div>
+    );
+  }
+  // Array-of-object schemas: route through RepeaterField so the user gets
+  // per-row inputs rather than a JSON blob. Sub-field names come from the
+  // union-resolved `items.properties`.
+  if (face.kind === 'object-rows') {
+    return (
+      <RepeaterField
+        value={value}
+        fields={derivePropertyNames(face.itemSchema)}
+        schema={{ ...face.effective, items: face.itemSchema }}
+        readOnly={readOnly}
+        widgetContext={widgetContext}
+        widget={fieldSpec?.widget}
+        ariaLabelledBy={ariaLabelledBy}
+        onChange={onChange}
+      />
+    );
+  }
+  // Raw JSON — the announced fallback for an unregistered widget name (`hint`),
+  // or the last resort for a shape no branch could type. Its `<textarea>` IS a
+  // labelable element and takes the host id: this face is `labelling: 'control'`
+  // (objectui#5039), so `id` is defined here whenever the host has a label.
+  if (face.kind === 'raw-json') {
+    if (face.hint) {
       return (
         <div className="space-y-1">
           <RawJsonEditor
+            id={id}
             value={value as any}
             onChange={(v) => onChange(v)}
             readOnly={readOnly}
           />
           <div className="text-[10px] text-muted-foreground">
-            {tFormat('engine.form.fallbackJson', locale, { widget })}
+            {tFormat('engine.form.fallbackJson', locale, { widget: face.hint })}
           </div>
         </div>
       );
     }
+    return <RawJsonEditor id={id} value={value} onChange={onChange} readOnly={readOnly} small />;
   }
-  // For schemas authored as `anyOf` / `oneOf` (e.g. `width: anyOf[string,
-  // number]`, `sort: anyOf[string, array<obj>]`), the outer schema's
-  // `type` / `enum` are undefined and every primitive branch below would
-  // miss, dropping us straight to RawJsonEditor. Resolve the union against
-  // the current value once and use the resolved branch for type/enum
-  // checks so primitive unions render as real inputs.
-  const effective = resolveUnionBranch(schema, value) ?? schema;
+
+  // The builtin scalar chain. For schemas authored as `anyOf` / `oneOf` (e.g.
+  // `width: anyOf[string, number]`, `sort: anyOf[string, array<obj>]`), the
+  // outer schema's `type` / `enum` are undefined and every primitive branch
+  // below would miss; `resolveFieldFace` already resolved the union against the
+  // current value, so these checks run on the concrete branch.
+  const effective = face.effective;
   const effectiveType = effective?.type as string | undefined;
   // Enum / Select — fieldSpec.options takes precedence over schema.enum.
   const options = fieldSpec?.options;
@@ -1433,62 +1628,20 @@ function FieldControl({
     }
   }
 
-  // Structured fallback — try to recurse into a real nested form before
-  // dropping to a raw JSON editor. Order matters:
-  //   1. Resolve oneOf / anyOf against the value (discriminated unions
-  //      like View `data.provider` or anyOf [array<string>, array<obj>]).
-  //   2. type:'object' with properties → nested SchemaForm.
-  //   3. type:'array' of objects → RepeaterField with per-row inputs.
-  //   4. Last resort → JSON editor.
-  {
-    if (
-      effective?.type === 'object' &&
-      effective.properties &&
-      typeof effective.properties === 'object'
-    ) {
-      return (
-        <div className="rounded-md border border-border/40 bg-card/30 p-3">
-          <SchemaForm
-            schema={effective}
-            value={(value as Record<string, unknown>) ?? {}}
-            onChange={(v) => onChange(v)}
-            readOnly={readOnly}
-            widgetContext={widgetContext}
-          />
-        </div>
-      );
-    }
-    if (
-      effective?.type === 'array' &&
-      effective.items &&
-      typeof effective.items === 'object'
-    ) {
-      const itemSchema = resolveUnionBranch(
-        effective.items as JsonSchema,
-        Array.isArray(value) && value.length ? value[0] : undefined,
-      );
-      if (
-        itemSchema?.type === 'object' &&
-        itemSchema.properties &&
-        typeof itemSchema.properties === 'object'
-      ) {
-        return (
-          <RepeaterField
-            value={value}
-            fields={derivePropertyNames(itemSchema)}
-            schema={{ ...effective, items: itemSchema }}
-            readOnly={readOnly}
-            widgetContext={widgetContext}
-            widget={fieldSpec?.widget}
-            onChange={onChange}
-          />
-        );
-      }
-    }
-  }
-
-  // Object / complex → JSON fallback so admins can still edit.
-  return <RawJsonEditor value={value} onChange={onChange} readOnly={readOnly} small />;
+  // The structured fallbacks that used to be re-tested here — object-with-
+  // properties → nested SchemaForm, array-of-object → RepeaterField, and the
+  // last-resort JSON editor — are the `nested-form` / `object-rows` / `raw-json`
+  // faces, returned above. `resolveFieldFace` keeps their precedence relative to
+  // this scalar chain (structural checks come after it when there is no widget
+  // hint, before it when there is), so the rendering order is unchanged; what is
+  // gone is the second copy of the predicates.
+  //
+  // Unreachable by construction: a `'scalar'` face is returned only when one of
+  // the branches above matches, and every one of them returns. The compiler can't
+  // prove that correspondence, so this terminal stays — spelled as the same
+  // `'control'`-channel JSON editor the `raw-json` face renders, so that if a
+  // future edit did make it reachable the label channel would still be right.
+  return <RawJsonEditor id={id} value={value} onChange={onChange} readOnly={readOnly} small />;
 }
 
 /* ----- composite / repeater (embedded structured values) ----------------- */
@@ -1536,6 +1689,7 @@ function CompositeField({
   readOnly,
   widgetContext,
   fieldSpec,
+  ariaLabelledBy,
   onChange,
 }: {
   value: unknown;
@@ -1544,6 +1698,12 @@ function CompositeField({
   readOnly?: boolean;
   widgetContext?: WidgetContext;
   fieldSpec?: FormFieldSpec;
+  /**
+   * The host label's id — this face is `labelling: 'group'` (objectui#5039).
+   * Answered on the box, not on any inner control: every labelable element in
+   * here is addressed by a SUB-field's own label.
+   */
+  ariaLabelledBy?: string;
   onChange: (v: unknown) => void;
 }) {
   const obj = (value && typeof value === 'object' && !Array.isArray(value))
@@ -1573,7 +1733,11 @@ function CompositeField({
   if (fieldSpec?.disclosure === 'popover') {
     const summary = summariseComposite(obj, specs);
     return (
-      <div className="flex items-center justify-between gap-2 rounded-md border border-border/50 bg-muted/20 px-3 py-1.5">
+      <div
+        className="flex items-center justify-between gap-2 rounded-md border border-border/50 bg-muted/20 px-3 py-1.5"
+        role="group"
+        aria-labelledby={ariaLabelledBy}
+      >
         <span className="text-sm text-muted-foreground truncate" title={summary}>
           {summary || <span className="italic opacity-70">Not configured</span>}
         </span>
@@ -1592,7 +1756,7 @@ function CompositeField({
   }
 
   return (
-    <div className="rounded-md border border-border/50 bg-muted/20 p-3 space-y-3">
+    <div className="rounded-md border border-border/50 bg-muted/20 p-3 space-y-3" role="group" aria-labelledby={ariaLabelledBy}>
       {rows}
     </div>
   );
@@ -1605,6 +1769,7 @@ function RepeaterField({
   readOnly,
   widgetContext,
   widget,
+  ariaLabelledBy,
   onChange,
 }: {
   value: unknown;
@@ -1613,6 +1778,12 @@ function RepeaterField({
   readOnly?: boolean;
   widgetContext?: WidgetContext;
   widget?: string;
+  /**
+   * The host label's id — this face is `labelling: 'group'` (objectui#5039).
+   * Both layouts own only auxiliary buttons (collapse, add, remove) plus rows
+   * that label themselves, so the name belongs on the list, not on a control.
+   */
+  ariaLabelledBy?: string;
   onChange: (v: unknown) => void;
 }) {
   const locale = useMetadataLocale();
@@ -1638,7 +1809,7 @@ function RepeaterField({
 
   if (useGrid) {
     return (
-      <div className="space-y-2">
+      <div className="space-y-2" role="group" aria-labelledby={ariaLabelledBy}>
         <div className="overflow-x-auto rounded-md border border-border/50">
           <table className="w-full text-sm">
             <thead className="bg-muted/40">
@@ -1703,7 +1874,7 @@ function RepeaterField({
 
   // Card layout — one collapsible fieldset per row.
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" role="group" aria-labelledby={ariaLabelledBy}>
       {rows.length === 0 && (
         <div className="rounded-md border border-dashed border-border/50 px-3 py-4 text-center text-xs text-muted-foreground">
           {t('engine.list.empty', locale)}
@@ -1792,6 +1963,7 @@ function RecordField({
   widget,
   keyField,
   formData,
+  ariaLabelledBy,
   onChange,
 }: {
   value: unknown;
@@ -1800,6 +1972,12 @@ function RecordField({
   readOnly?: boolean;
   widgetContext?: WidgetContext;
   widget?: string;
+  /**
+   * The host label's id — this face is `labelling: 'group'` (objectui#5039).
+   * Answered on the card list, and forwarded to a delegated widget so the
+   * declaration holds in BOTH of this face's shapes.
+   */
+  ariaLabelledBy?: string;
   keyField?: {
     field?: string;
     label?: string;
@@ -1825,11 +2003,14 @@ function RecordField({
     const Renderer = WIDGETS[widget as RegisteredWidgetKey] as WidgetRenderer | undefined;
     if (Renderer) {
       return (
-        // Neither naming channel is handed down here: this delegation is nested
-        // INSIDE a `record` field that already rendered its own label above, and
-        // the widget replaces the record editor rather than being that field's
-        // control. Unchanged by objectui#4871 — measured and left alone.
+        // The `id` channel is deliberately NOT handed down: a `record` field is
+        // declared `labelling: 'group'`, so the host published its label's id and
+        // dropped the `for` (objectui#5039). The IDREF is forwarded, because this
+        // delegated widget IS what the record field renders — leaving it out is
+        // what left this shape unnamed while objectui#4871 measured it and left
+        // it alone.
         <Renderer
+          ariaLabelledBy={ariaLabelledBy}
           schema={schema}
           value={value}
           onChange={onChange}
@@ -1930,7 +2111,7 @@ function RecordField({
   };
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" role="group" aria-labelledby={ariaLabelledBy}>
       {entries.length === 0 && (
         <div className="rounded-md border border-dashed border-border/50 px-3 py-4 text-center text-xs text-muted-foreground">
           {t('engine.list.empty', locale)}
@@ -2055,11 +2236,21 @@ function RecordField({
 /* ----- raw JSON fallback -------------------------------------------------- */
 
 function RawJsonEditor({
+  id,
   value,
   onChange,
   readOnly,
   small,
 }: {
+  /**
+   * The host field id, when this editor is a field's control. It goes on the
+   * `<textarea>` — the one labelable element this face renders, in every branch
+   * and both states — which is why the face is declared `labelling: 'control'`
+   * rather than wrapped in a named group (objectui#5039). Absent when
+   * `SchemaForm` renders this as the whole-form fallback, where there is no host
+   * label to associate.
+   */
+  id?: string;
   value: unknown;
   onChange: (v: any) => void;
   readOnly?: boolean;
@@ -2080,6 +2271,7 @@ function RawJsonEditor({
   return (
     <div className="space-y-1">
       <Textarea
+        id={id}
         rows={small ? 4 : 12}
         className="font-mono text-xs"
         value={text}


### PR DESCRIPTION
Fixes #5039

基线 `e7c5a80a8`(含 PR #5041,即 #4871 的注册表半)。分支 `claude/issue-5039-nonregistry-labelling`。

## 机制

#4871 / PR #5041 给 `WIDGETS` 注册表二十个条目加了 `labelling` 声明,`FieldRow` 据此发命名通道。但 `FieldControl` 里有六条路径**不经过注册表**,没有声明可依,一律走默认 `control` 通道 —— 而它们都不消费 `id`:

- `composite` / `repeater` / `record` 由 `fieldSpec.type` 决定,在注册表查找之前短路;
- 三条结构化兜底(递归 `SchemaForm` / `RepeaterField` / `RawJsonEditor`)是在 `FieldControl` **内部**、按 union 解析后的 `effective` schema 才选的 —— 也就是标签已经写完之后。

## 账本(6×2,真 `SchemaForm` 渲染,可编辑 + 只读两态)

列口径同 #4871 账本(`for` 是否解析且解析到可 label 元素 / 宿主 id 落在哪 / 组名),另加一列**这个面自己拥有什么可 label 元素** —— 正是这一列决定了逐条处置。

修复前(基线 `e7c5a80a8`,两态读数完全相同):

```
                                for                hostIdEl   group      面自己拥有的可 label 元素
(spec) composite                DANGLING           NONE       NONE       1 input(属子字段 mdf-sub 的标签)
(spec) repeater                 DANGLING           NONE       NONE       仅 button(折叠/新增/删除)
(spec) record                   DANGLING           NONE       NONE       仅 button + 键名 input
(fallback) nested-object        DANGLING           NONE       NONE       1 input(属内层字段 mdf-inner 的标签)
(fallback) array-of-obj        DANGLING           NONE       NONE       仅 button
(fallback) raw-json             DANGLING           NONE       NONE       1 textarea(无任何标签指向它)
```

修复后:

```
                                for                        hostIdEl   group
(spec) composite                ABSENT                     NONE       role=group name="Probe"
(spec) repeater                 ABSENT                     NONE       role=group name="Probe"
(spec) record                   ABSENT                     NONE       role=group name="Probe"
(fallback) nested-object        ABSENT                     NONE       role=group name="Probe"
(fallback) array-of-obj        ABSENT                     NONE       role=group name="Probe"
(fallback) raw-json             RESOLVES-LABELABLE textarea textarea   (control 通道,不发 IDREF)
```

另外四个形态同样是原先 `for=DANGLING`、现已闭合:`composite` 的 popover 披露、`repeater` 的 grid 布局、`nested-object` 经 union 解析(View `data` 判别式形)、`raw-json` 由未注册 widget 名触发(带 fallback 提示)。以及 `record` 委派给注册 widget 的形态 —— 该形态 #4871 当时「测过且刻意未动」,本 PR 把 IDREF 转发下去,声明才在 record 面的两种形态下都成立。

## 实施(采 PM 代裁的方案 1:上提解析)

PM 代裁见认领评论 [#5039 (comment)](https://github.com/objectstack-ai/objectui/issues/5039#issuecomment-5320062847):采卡面方案 1,弃方案 2(全包 group 宿主容器,保留晚判定且带未验证前提)。**否决窗仍开** —— 维护者若不同意此代裁,可在本 PR 或原单否决,两形态成本都已在卡面列出;本 PR 为 draft,未自行 undraft。

与 #4871 的 `resolveRegisteredWidget()` 同形:

1. 新增纯函数 `resolveFieldFace()` —— 只吃 `FieldControl` 渲染所依据的输入(`fieldSpec` / `widget` / `schema` / `value`),返回究竟渲染哪一个面(`composite` / `repeater` / `record` / `registered` / `nested-form` / `object-rows` / `raw-json` / `scalar`)。分支次序逐条照搬 `FieldControl`,包括那处不对称:有 widget 提示时结构判定先于标量链,无提示时反之。
2. `FieldRow` 在写标签**之前**调它决定通道;`FieldControl` 调同一个函数而不再自行判定,末尾那份重复的结构化兜底判定随之删除。判据只有一份,声明与 DOM 无从走岔 —— 这也是 M2 反向验证要证的点。
3. 新增 `faceLabelling()`:面到通道的**总函数**(新增面没有通道则编译不过)。注册面转交 `WIDGET_LABELLING`,不替 #4871 的评审表改判。

**通道判据在函数里,不在硬编码清单里**,所以逐条按实测判定,结果并不齐整 —— 五条 group,一条 control:

- 五条容器面走 group 通道(#4788 容器形:标签发布自身 id、容器以 `role="group"` 应答 `aria-labelledby`、`for` 摘掉)。`composite` 与 `nested-form` 里那个可 label 元素属于**子字段自己的**标签;`repeater` / `object-rows` / `record` 自己只有辅助按钮。
- `raw-json` 是卡面点名要**确认而非假定**的一条,实测与派发预期相反:`RawJsonEditor` 的面恰好是**一个**可 label 元素 —— 一个没有任何别的标签指向的 `textarea`,在每个分支、两种状态下都在(`readOnly` 只加属性)。它读到 `hostIdEl=NONE` 是因为 id 从未被**接进去**,不是因为这个面接不住。故它是真 `control` 面,id 直接落到 `textarea` 上;反过来把孤零零一个 `textarea` 包进具名 group,只会命名容器、让用户真正输入的控件无名 —— 那正是 objectui#4010 裁定的反面。

## 测试

新增 `SchemaForm.nonRegistryLabelling.test.tsx`(40 例),照 `SchemaForm.widgetLabelling.test.tsx` 的**正向断言**形:group 例断言具名面**存在**并应答 IDREF(不是只断「没有悬空 for」—— 那对一个什么都不渲染的路径同样成立)。两层互不承载:

1. **账本层** —— 每条路径的面在测试里写明,断言 `resolveFieldFace` / `faceLabelling`:改了分类就红,不会被静默改道;
2. **宿主/DOM 一致层** —— 断言要求的通道从 `faceLabelling()` 读出(不是第二份手写清单),DOM 一半来自真渲染。解析函数误判则此层也红。

另含解析纯函数自身单测(注册面转交注册表、十条标量形态、passthrough 提示、union 行 schema 解析 objectui#3379),以及递归断言:外层组名不吞内层字段关联(内层 `mdf-inner` 保有自己的 `for`,且 `aria-labelledby` 为空)。

```
pnpm exec vitest run .../SchemaForm.nonRegistryLabelling.test.tsx   → 40 passed
pnpm exec vitest run .../SchemaForm.widgetLabelling.test.tsx        → 62 passed(PR5041 回归红线)
pnpm exec vitest run packages/app-shell/src/views/metadata-admin    → 178 files, 1855 passed | 1 skipped
pnpm exec vitest run packages/app-shell                             → 421 files, 4072 passed | 1 skipped
pnpm exec turbo run type-check --concurrency=2                       → 81 successful, 81 total
node scripts/check-control-bytes.mjs                                 → OK(4506 files)
eslint 改动文件                                                       → 0 errors
```

## 反向验证(先书面预判,commit 后变异,`git checkout --` 还原)

| # | 变异 | 预判 | 实测 |
|---|---|---|---|
| M1 | `faceLabelling` 把 `repeater` 面误报成 `control` | 4 个账本例红(repeater 两形态 × 两态),断言形状为「host id is on no element」;加 1 个通道表例红 = 5;#4871 那 62 例不受影响 | **完全符合**:5 红,断言文本与预判一致,`SchemaForm.widgetLabelling.test.tsx` 62 全绿 |
| M2 | `resolveFieldFace` 删掉 `fieldSpec.type === 'repeater'` 分支 | **DOM 一半仍绿** —— 卡片形 schema 会重新解析成 `object-rows`,那也是 group、也渲染同一个 `RepeaterField`;只有账本层抓得住,3 红且全在纯函数块 | **完全符合**:3 红,全在纯函数块(`expected 'object-rows' to be 'repeater'`),DOM 账本 0 红 —— 这正是两层设计的理由:一个 DOM 层看不见的判定改动 |
| M3 | group 通道退回同时发 `for`(等价 PR5041 变异 ②,作用在非注册表路径) | 本 PR 文件 18 红(9 个 group 例 × 两态)+ #4871 文件 24 红(12 个 group 例 × 两态)≈ 42 | **完全符合**:42 红(18 + 24),两文件均停在同一断言(`:396` / `:209`,`expect(label).not.toHaveAttribute('for')`);raw-json 4 例与两个递归例如预判保持绿 |
| M4 | 把上提的解析调用挪回去,`FieldRow` 改用 `widgetLabelling(widget)`(恢复晚判定) | **与派发预判不符,先行书面记录**:派发预判「兜底三条红」,我预判**五条**红(spec 三条也红 —— #5039 之前的宿主只问注册表,`fieldSpec.type` 它同样不看),raw-json 保持绿(其实测通道 `control` 与默认值重合,此变异对它不可见),纯函数单测全绿;计 20 红 | **方向符合、数目差 2**:18 红(8 个 group 形态 × 两态 + 2 个递归例),raw-json 4 例绿、纯函数单测全绿、#4871 文件全绿 —— 均如预判。差的 2 例是 `(spec) record / 委派给注册 widget`:它 `widget: 'code'`,`widgetLabelling('code')` 恰好也返回 `group`,晚判定在这一形态上**碰巧**发对了通道(且本 PR 转发的 IDREF 让它仍被命名),故此变异对它不可见。派发预判的「三条」确实偏少 —— 落在五条 |

## 边界

⛔ 未动 PR #5041 落地的 `WIDGET_LABELLING` 声明表、`WIDGETS` 注册表及其断言;⛔ 未动 `packages/components` / `packages/fields`;⛔ 未触碰 `content/docs/releases/**`;无 force-push,无 `git stash`。changeset 一文件(`@object-ui/app-shell` patch)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_