### PR TITLE
docs(plugin-dashboard): README 的 TypeScript 一节按真实导出面重写虚构的 DashboardSchema / MetricCardSchema

### DIFF
--- a/.changeset/plugin-dashboard-readme-truth-5015.md
+++ b/.changeset/plugin-dashboard-readme-truth-5015.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+Docs only: `packages/plugin-dashboard/README.md`'s TypeScript section no longer
+imports two type names that exist nowhere (objectui#5015). Every README import was
+judged against the entry module's real export surface — 20 names, read from the
+build product's `dist/index.d.ts` through the TypeScript compiler API — and every
+corrected snippet was type-checked against that same build product under `strict`.
+
+- **`DashboardSchema`** — taught as the dashboard's schema type, imported from this
+  package. Not on its export surface, and not on `@object-ui/types`' either. It
+  *looks* present because it occurs in three comments here
+  (`src/DashboardRenderer.tsx:884`, `src/DashboardGridLayout.tsx:76` and `:88`) and
+  as the name of the metadata-level Zod schema in `@objectstack/spec/ui` — an
+  identifier grep hits both, an export-surface check hits neither. The authored
+  type does exist under its real name, so the example is rewritten around it rather
+  than dropped: `DashboardComponentSchema` from `@object-ui/types`.
+- **`MetricCardSchema`** — pure fiction: zero hits repo-wide under a word boundary,
+  outside this README. There is no per-widget-family schema type at all — one
+  `DashboardWidgetSchema` covers every `type`, and family-specific settings live
+  under `options` — so the name could not be corrected to a sibling. The example now
+  types its widgets as `DashboardWidgetSchema` and shows the three authored forms
+  the type really carries: a dataset-bound KPI, a static single-value widget with
+  its number under `options`, and a registered component node in the widget's
+  `component` slot.
+
+The section also states what the type set does *not* cover, because the old snippet
+implied otherwise: `value`, `trend` and `trendValue` are `MetricCard`'s **component**
+props, and `DashboardWidgetSchema` declares none of the three (each measured on its
+own, since the first excess property short-circuits the rest of the diagnostic).
+`MetricCard`'s props interface is not on this package's export surface either.
+
+No export was added, re-exported or renamed to make the old names true, and the
+package's real `dashboardComponents` export is untouched. No code, types or runtime
+behaviour change — the diff is one README and this changeset. The correction reaches
+npm with the package's next publish, which is why it declares a patch: `README.md`
+is in the package's published `files`.

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -317,23 +317,70 @@ here.
 
 ## TypeScript Support
 
-```typescript
-import type { DashboardSchema, MetricCardSchema } from '@object-ui/plugin-dashboard';
+This package ships **components, not schema types** — its whole type export
+surface is `WidgetConfigPanelProps`, `ConfigPanelTranslate` and the three
+`WidgetDataset*` catalog types, none of which describe an authored dashboard.
+The authored shape is typed by `@object-ui/types`:
 
-const metricCard: MetricCardSchema = {
-  type: 'metric-card',
+| Import from `@object-ui/types` | What it types |
+| --- | --- |
+| `DashboardComponentSchema` | the whole `type: 'dashboard'` node — `columns`, `gap`, `widgets`, `header`, `globalFilters`, `dateRange`, `refreshInterval`, … |
+| `DashboardWidgetSchema` | one entry of `widgets[]` — the spec's `DashboardWidget` keys, plus objectui's own (`component`, `layout`, `options`, …) |
+| `DashboardWidgetLayout` | a widget's `{ x, y, w, h }` grid box |
+
+```typescript
+import type {
+  DashboardComponentSchema,
+  DashboardWidgetSchema,
+} from '@object-ui/types';
+
+// Dataset-bound KPI — the widget vocabulary (see "Dashboard-level filters").
+const revenue: DashboardWidgetSchema = {
+  id: 'kpi_revenue',
+  type: 'metric',
   title: 'Revenue',
-  value: '$123,456',
-  trend: 'up',
-  trendValue: '+12%'
+  dataset: 'invoices',
+  values: ['count'],
+  colorVariant: 'success',
 };
 
-const dashboard: DashboardSchema = {
+// Single-value widget with no query: the number lives under `options`.
+const users: DashboardWidgetSchema = {
+  id: 'kpi_users',
+  type: 'metric',
+  title: 'Total Users',
+  options: { value: '1,234' },
+};
+
+// Component format: a registered component node in the widget's `component`
+// slot. Its keys are that COMPONENT's props, not widget keys.
+const custom: DashboardWidgetSchema = {
+  id: 'kpi_custom',
+  component: {
+    type: 'metric-card',
+    title: 'Revenue',
+    value: '$123,456',
+    trend: 'up',
+    trendValue: '+12%',
+  },
+  layout: { x: 0, y: 0, w: 3, h: 2 },
+};
+
+const dashboard: DashboardComponentSchema = {
   type: 'dashboard',
   columns: 3,
-  widgets: [metricCard]
+  gap: 4,
+  widgets: [revenue, users, custom],
 };
 ```
+
+There is **no per-widget-family schema type**: one `DashboardWidgetSchema`
+covers every `type` (`metric`, `bar`, `table`, …) and the family-specific
+settings live under `options`. `MetricCard`'s own props — `value`, `trend`,
+`trendValue` — are the component's, not the widget's: `DashboardWidgetSchema`
+declares none of them, and the component's props interface is not on this
+package's export surface either. So a `metric-card` node is typed only where it
+appears as a component (the `component` slot above), not as a widget family.
 
 ## Customization
 


### PR DESCRIPTION
Fixes #5015

基线 `origin/main` @ `bb3fab62c7729092174a1e8ae6032cbb29ce28a3`(worktree 显式建在该 sha 上)。方法学照抄同族已落地的三单:#5010 → PR #5046、#5016 → PR #5053、#5012 → PR #5059。

## 前提验证:卡面读数自己复测,两条都成立

卡面的复核命令写的是裸 grep,所以按 #5012 的教训先补词边界重测:

```
# 词边界,全仓
grep -rn "\bDashboardSchema\b"  --include=*.ts --include=*.tsx --include=*.md packages apps
grep -rn "\bMetricCardSchema\b" --include=*.ts --include=*.tsx --include=*.md packages apps
```

- **`DashboardSchema`** —— 19 处命中,**没有一处是本包或 `@object-ui/types` 的导出**:3 处是本包的注释(`src/DashboardRenderer.tsx:884`、`src/DashboardGridLayout.tsx:76`、`:88`),其余是 `@objectstack/spec/ui` 那个**元数据级 zod schema** 的名字被引用(`packages/types/src/zod/complex.zod.ts:21` 以 `DashboardSchema as SpecDashboardSchema` 导入、`packages/app-shell/src/views/metadata-admin/dashboard-schema.ts:25`、`clientValidation.ts:587`),加上 `SKILL.md` 与本 README 自己。卡面说的「标识符 grep 的假信号」成立,而且假信号有**两个**来源:注释,以及一个同名但属于另一个包、另一个层次(zod 而非 TS 类型)的真实物件。
- **`MetricCardSchema`** —— 除本 README 的 `:321` / `:323` 外**全仓零命中**。纯虚构。
- 卡面「`MetricCardProps` 是真的但未从 index re-export」也成立,见下。

## 真身查证(#5012 的路数:先查真身再定修法)

声明式 grep(`^\s*(export )?(declare )?(type|interface|const|class) …`)在 `@object-ui/types` 找 dashboard 侧的授权类型:

| 真身 | 声明处 | 从 `@object-ui/types` 导出 |
| --- | --- | --- |
| `DashboardComponentSchema` | `packages/types/src/complex.ts:738`(`type: 'dashboard'` + `widgets` + `columns` / `gap` / `header` / `globalFilters` / `dateRange`) | `src/index.ts:278` |
| `DashboardWidgetSchema` | `complex.ts:676`(`extends Omit< Partial< SpecDashboardWidget >, 'type' \| 'options' \| 'chartConfig' \| 'filter' >`) | `src/index.ts:277` |
| `DashboardWidgetLayout` | `complex.ts:652` | `src/index.ts:276` |

**容器侧真身存在** ⇒ 示例按真身从 `@object-ui/types` 重写。

**metric card 侧不是「同名换路径」,分两层量:**

1. **widget 层没有「按族」的类型可换。** 一个 `DashboardWidgetSchema` 覆盖全部 `type`,族内设置在 `options` 下 —— 不存在 `MetricCardSchema` 的兄弟名。而且 `metric-card` 也不是 spec widget 家族成员:`@objectstack/spec@17.0.0` 的 `DashboardWidgetSchema.type` 枚举里是 `metric` / `kpi`,没有 `metric-card`(objectui 把 `type` 放宽成 `string`,所以 tsc 收但 spec 不收)。
2. **组件层的真身在,但不在公开面上。** `MetricCardProps`(`src/MetricCard.tsx:35`)是真的,没从 `src/index.tsx` re-export:

```
import type { MetricCardProps } from '@object-ui/plugin-dashboard';
   -> TS2724: '"@object-ui/plugin-dashboard"' has no exported member named
      'MetricCardProps'. Did you mean 'MetricCard'?
```

按认领裁定 ⛔ 不代裁命名、⛔ 不加新导出、⛔ 不 re-export `MetricCardProps`。这半个裁定**已经是在途卡 #4600 的余留范围**(该卡 2026-08-14 状态注记:「which schema an SDUI dashboard COMPONENT node validates against; classes A/B + **metric-card**」,等 objectstack#8593),所以按「附着不散落」的纪律**写成 #4600 的追评**而不另立孪生卡 —— 见下文「顺手立的卡」。

## 判定表

| README(改前) | 判定 | 依据 | 处理 |
| --- | --- | --- | --- |
| `:321` `import type { DashboardSchema … }` from 本包 | **虚构名,但真身存在** | 导出面 20 名零命中;假信号来自 3 处注释 + `@objectstack/spec/ui` 的同名 zod schema | **按真身重写**:`DashboardComponentSchema` from `@object-ui/types` |
| `:321` `… MetricCardSchema }`、`:323` `const metricCard: MetricCardSchema` | **纯虚构,且无同族真名可换** | 全仓词边界零命中;widget 侧无按族类型;组件侧真身 `MetricCardProps` 不在导出面(TS2724) | **示例改按 `DashboardWidgetSchema` 写**,并如实陈述这三个键是组件 props |
| `:42-52` `dashboardComponents` 手动注册 | **真名** | 导出面命中(`src/index.tsx:338`) | **未动**(键词汇表另有问题,见 #5064) |
| `:416-422` `onSchemaChange` 示例 | **真名真键,可选性不符** | 改前改后同样红,与本卡两处无关 | **未动**,单立 #5066 |

## 名集合核对读数

导出名集合取自**构建产物** `dist/index.d.ts`,走 TS compiler API 的 `checker.getExportsOfModule`;README 侧不用正则抓 import —— 先抽 fenced 块,每块 `ts.createSourceFile`,再走 `ImportDeclaration` 的 AST,`A as B` 判 `propertyName`(导出名)而非本地别名。#5043 记的两个坑因此在结构上不可能发生。

```
export surfaces: @object-ui/plugin-dashboard 20 / @object-ui/types 675 /
                 @object-ui/core 416 / @object-ui/data-objectstack 72 /
                 @object-ui/components 420

改前:  README 5 bindings / MISSING COUNT: 2
          - DashboardSchema   from @object-ui/plugin-dashboard  @ README.md:321
          - MetricCardSchema  from @object-ui/plugin-dashboard  @ README.md:321
改后:  README 5 bindings / MISSING COUNT: 0
```

绑定数不变是对的:换掉的两个名从本包挪到了 `@object-ui/types`,另三个(`dashboardComponents`、`ComponentRegistry`、`createObjectStackAdapter`)本来就成立。

## 编译探针读数

README 的 ts/tsx 块抄进 scratch,对同一批构建产物编译(`strict: true`,**没有为让块通过而放松任何选项**);块按**内容签名**分类而非块序号,所以改前改后共用一套机器。

```
改前:  10 个可编译块(2 块按设计跳过并列明理由)  tsc -> rc=2
  block10(1,15): error TS2305: Module '"@object-ui/plugin-dashboard"' has no exported member 'DashboardSchema'.
  block10(1,32): error TS2305: Module '"@object-ui/plugin-dashboard"' has no exported member 'MetricCardSchema'.
  block12(8,63): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.

改后:  10 个可编译块  tsc -> rc=2
  block12(8,63): error TS2345: (原样携带 —— 非本卡漏修,已立 #5066)
```

跳过的两块(输出里列明,不静默丢):`:61-67` 与 `:75-84` 的 Schema API 形状速写 —— `widgets: Widget[]` / `title: string` 是**类型语法落在值位置**,故意不合法的 TS。

harness 两处,都只补作用域、不放松检查:`:293` 的 `colorVariant` 裸 widget 字面量被**钉在真 `DashboardWidgetSchema` 上**(改前改后皆绿,该节确认为真话);`:417` 的裸 JSX 补 `dashboard` / `client` 声明。

**逐键 pin(散文新增的断言不靠外推)。** 新增那段说 `value` / `trend` / `trendValue` 三个键 `DashboardWidgetSchema` 都不声明,而合并写在一个字面量里**只报一条** —— 第一个多余属性会把其余诊断短路(PR #5059 记过同一现象)。所以一文件一键单独探:

| 键 | 对 `DashboardWidgetSchema` 的诊断 |
| --- | --- |
| `value` | `TS2561 … 'value' does not exist … Did you mean to write 'values'?` |
| `trend` | `TS2353 … 'trend' does not exist in type 'DashboardWidgetSchema'` |
| `trendValue` | `TS2353 … 'trendValue' does not exist in type 'DashboardWidgetSchema'` |

## 反向验证(两条,预判先写)

**(a) 名集合核对自证。** 预判:往**多行**类型 import 块里 planted,`MISSING COUNT` 0 → 2,恰为 `{DashboardSchema, DashboardThings}`;别名判导出名;行尾注释里的非导出词不得报。四条全符 ——

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| 多行块**中段**插 `DashboardSchema` | 报 | 报 `DashboardSchema` @ `:332` |
| 多行块里加 `DashboardThings as Things` | 报,且按**导出名** `DashboardThings` 而非别名 `Things` | 报 `DashboardThings` @ `:332` |
| `DashboardWidgetSchema` → `DashboardWidgetSchema as WidgetSchema` | 仍 OK(别名判导出名) | OK |
| 行尾 `// MetricCardSchema was never real` | **不得**报(假阳性测试) | 未报 |

`MISSING COUNT: 2`,还原读数 `0`。变异全做在 README 的 **scratch 副本**上(检查器的 `--readme` 指向副本),`git status --porcelain` 全程只有本卡那一个 `M` —— 不存在「临时改动误入 commit」的窗口。

**(b) 改前 README 回填探针。** 预判:回填后必须转红,且错误与所改两处一一对应,`:417` 那条既有红原样携带。同一套机器直接跑 `git show $BASE:packages/plugin-dashboard/README.md` 的副本,转红 `rc=2`:

| 所改之处 | 预判 | 实测诊断 |
| --- | --- | --- |
| `DashboardSchema` | TS2305 | `block10(1,15): TS2305 … has no exported member 'DashboardSchema'` |
| `MetricCardSchema` | TS2305 | `block10(1,32): TS2305 … has no exported member 'MetricCardSchema'` |
| 既有的 `onSchemaChange` 红 | 原样携带 | `block12(8,63): TS2345`(改前改后同一坐标) |

预判与实测无出入,方向即通常的「改前红 / 改后绿」—— 本卡的 `??` 链、计数门那类反转情形不适用(这是导入名不存在,不是取值判决)。

## 验证

- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **`81 successful, 81 total`**(4m34s;重活经 `flock -w 3600 /tmp/os-heavy-verify.lock` 串行 + `--max-old-space-size=4096`)。
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4512 tracked text file(s); skipped 85 binary)`;改动两文件另做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中。
- `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-dashboard...' build` → rc=0(探针与名集合核对所依赖的构建产物)。

**docs-only 的 CI 形状**:`**/*.md` 与 `.changeset/**` 在 `paths-ignore` 里,Test / Type Check 各 job 的实质步骤会被 path-filter 短路成 skipped 而 job 报 success。按纪律计绿,但**类型证据是上面的本地仓根读数**,不是 CI 的(#5046 / #5053 / #5059 先例)。

## 顺手立的卡(均未认领,不夹带进本 PR)

- **#5064** — `dashboardComponents` 用**组件类名**作键(`'DashboardRenderer'` …),是全仓 5 个 `*Components` map 里唯一一个;其余 4 个(charts / editor / kanban / markdown)全按 schema type 键。于是 README 教的那个 `Object.entries(...).forEach(register)` 循环注册 11 个没人写的 type,本包真正认领的 8 个一个没注册,并触发 11 条 namespace 弃用告警。名字是真的、键的词汇表是错的 —— 与本卡**不同性质**,且认领裁定明写该节勿动。
- **#5066** — `:416-422` 的 `onSchemaChange` 示例把 `DashboardComponentSchema['name']`(`string | undefined`,`packages/types/src/base.ts:86`)传给 `saveItem(type: string, name: string, item: any)`(`@objectstack/client@17.0.0` `dist:714`)的必填 `name`。名字与键全真,错的是可选性。就是改后探针剩下的那一条。
- **#5067**(`finding`,不打 `pm:queue`) — `DashboardRenderer.tsx:528` 读 `widget.dataset` 的 `as any` 及其理由注释已过期:spec 17.0.0 的 `DashboardWidgetSchema` 已声明 `dataset` / `values`,`dataset` 不在 objectui 的 `Omit` 名单里,直接读即可通过 strict。观察级 —— 行为与收窄后一致,今天没有用户会撞上。
- **#4600 追评**(不另立卡,命中在途卡即写在卡上)—— 本包导出面上没有任何 schema 类型、容器真身是 `DashboardComponentSchema`、widget 侧无按族类型、`MetricCardProps` 的 TS2724 与三个键的逐键读数。都落在该卡等 objectstack#8593 的余留范围内。

## changeset

`.changeset/plugin-dashboard-readme-truth-5015.md`,`@object-ui/plugin-dashboard: patch`,口径同 #5046 / #5053 / #5059:无代码/类型/运行时改动,声明 patch 是因为 `README.md` 在包的 `files` 里,随下次发布到 npm。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_