### PR TITLE
fix(plugin-form): EmbeddableForm 的 thank-you redirect 等待改由组件持有,unmount 与「再填一份」均取消 (#5049)

### DIFF
--- a/.changeset/embeddable-form-thankyou-redirect-timer-lifetime-5049.md
+++ b/.changeset/embeddable-form-thankyou-redirect-timer-lifetime-5049.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+A public form's thank-you redirect no longer outlives the form that armed it, and
+"Submit Another Response" now cancels it.
+
+`EmbeddableForm` armed the `thankYouPage.redirectUrl` wait with a bare
+`setTimeout` inside the submit handler: the handle was not stored, nothing cleared
+it, and no part of the component owned it (objectui#5049). Two consequences, and
+the second needs no unmount at all:
+
+- For the whole of the delay a full-page navigation was pending that survived the
+  form being taken off screen — an embed removed by the host page, a route change,
+  a re-keyed subtree. With `redirectDelay` unset that window is the 3000 ms
+  default, so this was the normal state of every submit on this surface rather
+  than an edge authoring; the thank-you panel says as much out loud with
+  `Redirecting in {{seconds}} seconds…`.
+- Under `allowMultiple`, `Submit Another Response` only flipped `submitted` back
+  to false while the pending navigation kept ticking. The component invited the
+  submitter into a fresh form and then, about three seconds later, threw the whole
+  page away while they were typing the next response.
+
+The wait now lives in an effect keyed on the accepted destination, with a
+`clearTimeout` cleanup, so unmounting cancels it; and `handleReset` drops the
+destination, so pressing `Submit Another Response` cancels it too. The button
+offers the submitter a fresh form, and that offer cannot be honoured alongside
+discarding the page a moment later. This is the same move `ObjectForm` /
+`WizardForm` (objectui#5033) and `apps/console`'s `FormPage` already made for
+their own copies of this defect.
+
+Nothing else changed. Which destinations are followed and which are refused is
+still decided by the same `isRedirectUrlSafe` / `allowedRedirectHosts` guard, on
+the same line as before — only who owns the wait changed. The delay is captured
+together with the destination at the moment the write is accepted, so a host
+re-rendering with a different `redirectDelay` mid-wait cannot restart the pause
+under the submitter. The countdown copy is untouched. No data was ever at risk:
+the write has already succeeded before the wait begins, so the harm was a
+surprising navigation — and, on the `allowMultiple` path, the loss of what the
+submitter had just re-typed.

--- a/packages/plugin-form/src/EmbeddableForm.redirectTimerLifetime.test.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.redirectTimerLifetime.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5049 — `EmbeddableForm`'s thank-you redirect must not outlive either
+ * the component that armed it or the destination it was armed for.
+ *
+ * The wait used to be a bare `setTimeout` inside the submit handler: the handle
+ * was not stored, not cleared, and owned by nobody. Two consequences, and the
+ * second one needs no unmount at all:
+ *
+ * 1. The pending full-page navigation survived the form being taken off screen
+ *    (an embed removed by the host page, a route change, a re-keyed subtree).
+ *    With `redirectDelay` unset that window is the 3000 ms default — the NORMAL
+ *    state of this surface, which is why the thank-you panel says
+ *    `Redirecting in {{seconds}} seconds…` out loud.
+ * 2. Under `allowMultiple`, `Submit Another Response` only flipped `submitted`
+ *    back to false. The timer kept ticking, so the component invited the
+ *    submitter into a fresh form and then threw the whole page away while they
+ *    were typing the next response.
+ *
+ * The wait now lives in an effect keyed on the pending destination, so both
+ * unmounting and dropping the destination cancel it.
+ *
+ * ## What each case measures, and why the positive one is required
+ *
+ * A negative case alone can pass for the WRONG reason: a form that never arms a
+ * redirect also navigates nowhere. Two things stop that empty pass from reading
+ * as a fix. Each negative case first REQUIRES the wait to have been armed (see
+ * `waitUntilArmed`), so a form that arms nothing fails there rather than sailing
+ * through to a satisfied `not.toHaveBeenCalled()`. And they are paired with a
+ * mounted case asserting the destination IS reached when the delay ends, so
+ * deleting the redirect outright is red too.
+ *
+ * ## Why a real clock, and how the arming is observed without racing it
+ *
+ * The submit path is a chain of awaited promises, so faking the clock around it
+ * makes the observation race the resolution rather than the delay. This file
+ * keeps the real clock and instead makes ARMING observable: `setTimeout` is
+ * wrapped by a pass-through spy recording the delays this file declares. The
+ * unmount (or the reset click) therefore provably happens AFTER the wait was
+ * armed, which is the only ordering that can falsify anything.
+ *
+ * ## What this file deliberately does not touch
+ *
+ * Which destinations are followed and which are refused is `isRedirectUrlSafe` /
+ * `allowedRedirectHosts` — a different contract from the relative-path-only
+ * ruling that objectui#4989 covers, and unchanged here (its cases live in
+ * `__tests__/EmbeddableForm.test.tsx`). Every destination below is same-origin
+ * relative, i.e. already accepted before this file's subject begins. The
+ * countdown copy is not touched either.
+ *
+ * ## Counterfactuals (measured, see the PR for the runs)
+ *
+ * 1. **Drop the `clearTimeout` from the effect cleanup**: BOTH negative cases go
+ *    red on `expect(hrefSetter).not.toHaveBeenCalled()`. Note that this includes
+ *    the reset case: dropping the destination only re-runs the effect, and it is
+ *    that re-run's cleanup which does the cancelling — clearing the state is not
+ *    itself a cancellation.
+ * 2. **`handleReset` no longer clears the pending destination**: the reset case
+ *    goes red and the unmount case stays green — unmount safety alone never
+ *    covered the `Submit Another Response` path, which is the point of this
+ *    issue over objectui#5033.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+
+import { EmbeddableForm, type EmbeddableFormConfig } from './EmbeddableForm';
+
+// ObjectForm resolves field widgets through the global registry.
+registerAllFields();
+
+/**
+ * A declared delay long enough to act inside of, distinctive enough that the
+ * pass-through spy below can recognise the form's own timer among the ones React
+ * and the testing library schedule.
+ */
+const DELAY_MS = 149;
+/** The delay the component applies when `redirectDelay` is left unset. */
+const DEFAULT_DELAY_MS = 3000;
+const DESTINATION = '/thanks-5049';
+
+const buildDataSource = () => ({
+  create: vi.fn(async (_obj: string, data: Record<string, unknown>) => ({ id: '1', ...data })),
+  update: vi.fn(),
+  delete: vi.fn(),
+  findOne: vi.fn(),
+  find: vi.fn(async () => ({ data: [], total: 0 })),
+  getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+});
+
+function baseConfig(overrides: Partial<EmbeddableFormConfig> = {}): EmbeddableFormConfig {
+  return {
+    formId: 'f5049',
+    objectName: 'lead',
+    customFields: [{ name: 'email', label: 'Email', type: 'email', required: true } as any],
+    // The anti-bot minimum fill time is a different gate; disable it so the
+    // submit reaches the redirect arm without fighting a 1.5s timer.
+    minFillTime: 0,
+    thankYouPage: { redirectUrl: DESTINATION, redirectDelay: DELAY_MS },
+    ...overrides,
+  };
+}
+
+const realSetTimeout = globalThis.setTimeout;
+const realClearTimeout = globalThis.clearTimeout;
+/** Real-clock sleep, taken before the spy is installed so it is never recorded. */
+const sleep = (ms: number) => new Promise((resolve) => { realSetTimeout(resolve, ms); });
+
+let hrefSetter: ReturnType<typeof vi.fn<(url: string) => void>>;
+let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+let clearTimeoutSpy: ReturnType<typeof vi.spyOn>;
+/** One entry per redirect wait armed by the component, in arming order. */
+let armed: { ms: number; handle: unknown }[];
+/** Every handle passed to `clearTimeout`, by anyone. */
+let cleared: unknown[];
+
+beforeEach(() => {
+  armed = [];
+  cleared = [];
+  hrefSetter = vi.fn<(url: string) => void>();
+
+  // `window.location.href = url` is the component's navigation call. Shadow just
+  // that accessor on the real Location instance (the prototype's is
+  // configurable) so `origin` / `search` — which `isRedirectUrlSafe` reads —
+  // stay genuinely real, and the guard therefore genuinely runs. `delete`
+  // restores the prototype accessor in the teardown below.
+  const realHref = window.location.href;
+  Object.defineProperty(window.location, 'href', {
+    configurable: true,
+    get: () => realHref,
+    set: (value: string) => { hrefSetter(value); },
+  });
+
+  setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+    cb: any,
+    ms?: number,
+    ...rest: any[]
+  ) => {
+    const handle = (realSetTimeout as any)(cb, ms, ...rest);
+    if (ms === DELAY_MS || ms === DEFAULT_DELAY_MS) armed.push({ ms, handle });
+    return handle;
+  }) as any);
+
+  // Pass-through, like the setTimeout spy: the cancellation this file is about
+  // has to really happen, so the negative cases below measure the component and
+  // not the spy.
+  clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout').mockImplementation(((handle: any) => {
+    cleared.push(handle);
+    return (realClearTimeout as any)(handle);
+  }) as any);
+});
+
+afterEach(() => {
+  clearTimeoutSpy.mockRestore();
+  setTimeoutSpy.mockRestore();
+  delete (window.location as any).href;
+});
+
+/** Renders the form and drives one successful submit through to `create`. */
+async function submitOnce(config: EmbeddableFormConfig, ds: ReturnType<typeof buildDataSource>) {
+  const view = render(
+    <EmbeddableForm
+      config={config}
+      // Prefilled programmatically so react-hook-form's required-field
+      // validation passes without racing a typed value into its state — the
+      // same reason the sibling EmbeddableForm suite prefills.
+      prefillParams={{ email: 'a@b.com' }}
+      dataSource={ds as any}
+    />,
+  );
+  await screen.findByLabelText(/email/i);
+  fireEvent.click(await screen.findByRole('button', { name: /^submit$/i }));
+  await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+  return view;
+}
+
+/** Waits until the form has armed its wait, and checks it has not fired yet. */
+async function waitUntilArmed(ms: number) {
+  await waitFor(() => expect(armed.length).toBe(1));
+  expect(armed[0].ms).toBe(ms);
+  expect(hrefSetter).not.toHaveBeenCalled();
+}
+
+describe('objectui#5049 — EmbeddableForm thank-you redirect is owned by the component', () => {
+  it('navigates nowhere after the form is unmounted mid-delay', async () => {
+    const ds = buildDataSource();
+    const view = await submitOnce(baseConfig(), ds);
+    await waitUntilArmed(DELAY_MS);
+
+    // The host page removes the embed, or the route changes under it.
+    view.unmount();
+
+    // Well past the declared delay on the real clock.
+    await sleep(DELAY_MS * 5);
+    expect(hrefSetter).not.toHaveBeenCalled();
+    // The write itself already succeeded — cancelling the wait does not undo it.
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates nowhere after "Submit Another Response" is pressed mid-delay', async () => {
+    const ds = buildDataSource();
+    await submitOnce(baseConfig({ allowMultiple: true }), ds);
+    await waitUntilArmed(DELAY_MS);
+
+    fireEvent.click(await screen.findByRole('button', { name: /submit another response/i }));
+
+    // The button's offer: a fresh form, which the submitter is now filling.
+    await screen.findByLabelText(/email/i);
+
+    await sleep(DELAY_MS * 5);
+    expect(hrefSetter).not.toHaveBeenCalled();
+    // Still on the fresh form, not on a page the redirect replaced.
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+
+  it('reaches the destination when the delay ends on a mounted form', async () => {
+    const ds = buildDataSource();
+    await submitOnce(baseConfig(), ds);
+    await waitUntilArmed(DELAY_MS);
+
+    await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith(DESTINATION));
+    expect(hrefSetter).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures the 3000 ms default when redirectDelay is unset, and cancels it on unmount', async () => {
+    const ds = buildDataSource();
+    const view = await submitOnce(
+      baseConfig({ thankYouPage: { redirectUrl: DESTINATION } }),
+      ds,
+    );
+    // The default is the delay actually armed — it is captured at the moment the
+    // write is accepted, not re-read at wait time.
+    await waitUntilArmed(DEFAULT_DELAY_MS);
+
+    view.unmount();
+
+    // Cancellation is asserted on the handle rather than by outliving the delay:
+    // waiting out 3 s of real time would buy no extra evidence about the
+    // cleanup, which the two cases above already pin on the real clock. This
+    // case exists to keep the default value itself from drifting.
+    expect(cleared).toContain(armed[0].handle);
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-form/src/EmbeddableForm.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.tsx
@@ -207,6 +207,26 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
   );
   const [consentError, setConsentError] = useState<string | null>(null);
 
+  // The accepted thank-you destination, together with the delay declared for
+  // it, held from the moment the write succeeds until the wait below elapses
+  // (objectui#5049).
+  //
+  // The wait used to be a bare `setTimeout` armed inside the submit handler:
+  // nothing stored the handle and nothing cleared it, so a full-page navigation
+  // stayed pending for the whole delay and OUTLIVED this component. With the
+  // default delay that window is 3 seconds on every submit, not an edge
+  // authoring. Recording the destination here hands the wait to the effect
+  // below, which owns it for exactly as long as this component is mounted and
+  // for exactly as long as the destination stands.
+  //
+  // The delay travels WITH the destination rather than being re-read from
+  // `config.thankYouPage` at wait time: the value honoured is the one declared
+  // when the write was accepted, so a host re-rendering with a different
+  // `redirectDelay` mid-wait cannot restart the pause under the submitter.
+  const [pendingRedirect, setPendingRedirect] = useState<
+    { url: string; delayMs: number } | null
+  >(null);
+
   const honeypotRef = useRef<HTMLInputElement | null>(null);
   // Seeded lazily by the mount effect below — Date.now() is impure and must not
   // run during render. The effect always overwrites this before any submit.
@@ -216,6 +236,21 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
     // screen so anti-bot timing measures the next interaction, not the first.
     if (!submitted) mountedAtRef.current = Date.now();
   }, [submitted]);
+
+  // The delayed leg of a thank-you redirect.
+  //
+  // Which destinations are followed and which are refused is decided before a
+  // destination ever reaches this state (`isRedirectUrlSafe` in the submit
+  // handler); nothing here re-judges a URL. What changed is who owns the wait:
+  // unmounting, or dropping the destination, cancels it instead of leaving it to
+  // fire into a page the submitter has moved on from.
+  useEffect(() => {
+    if (!pendingRedirect) return;
+    const timer = setTimeout(() => {
+      window.location.href = pendingRedirect.url;
+    }, pendingRedirect.delayMs);
+    return () => clearTimeout(timer);
+  }, [pendingRedirect]);
 
   const honeypotName = config.honeypot === false ? null : config.honeypot || DEFAULT_HONEYPOT_NAME;
   const minFillTime = config.minFillTime ?? DEFAULT_MIN_FILL_MS;
@@ -307,9 +342,11 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
         if (rawRedirect) {
           if (isRedirectUrlSafe(rawRedirect, config.allowedRedirectHosts)) {
             const delay = config.thankYouPage?.redirectDelay ?? 3000;
-            setTimeout(() => {
-              window.location.href = rawRedirect;
-            }, delay);
+            // Record the destination; the effect that owns the wait takes it
+            // from here (objectui#5049). This arm still decides WHETHER to
+            // navigate — the guard above is untouched — only no longer WHEN,
+            // because a timer armed here answered to nobody.
+            setPendingRedirect({ url: rawRedirect, delayMs: delay });
           } else {
             console.warn('[EmbeddableForm] Blocked unsafe redirect target:', rawRedirect);
             setError(config.texts?.redirectBlocked ?? null);
@@ -327,6 +364,13 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
   const handleReset = useCallback(() => {
     setSubmitted(false);
     setError(null);
+    // "Submit Another Response" cancels a pending thank-you redirect
+    // (objectui#5049). The button offers the submitter a fresh form; that offer
+    // and throwing the whole page away a moment later cannot both be honoured,
+    // and the one the submitter just chose is the form. Dropping the
+    // destination re-runs the effect above, whose cleanup clears the timer —
+    // the cancellation is done by that `clearTimeout`, not by this line alone.
+    setPendingRedirect(null);
   }, []);
 
   // Branding styles


### PR DESCRIPTION
Fixes #5049

基线 `f68018d565b7c875e652f237b5413b97be5b9012` —— 即 PR #5055(#5033 的 ObjectForm/WizardForm 两处)的 squash 提交本身,所以同类形状在本 PR 的基线里已经在树上,可直接对照。本文件与它不相交。

## 改了什么

`EmbeddableForm` 在提交处理器里用裸 `setTimeout` 武装 `thankYouPage.redirectUrl` 的等待:句柄不存、无人清除、无人拥有。比 #5033 更糟的两点,第二点连 unmount 都不需要:

1. **默认 3000ms 是常态而非边缘**。整个延迟窗口内都挂着一次全页导航,且它活得比组件长 —— 宿主页面撤掉这段 embed、路由切走、子树被重新 key,都会被一个已不存在的表单的定时器拽走。`redirectDelay` 未设时该窗口就是 3000ms,即本界面**每次**提交的常态;致谢面板本就把它写在脸上(`Redirecting in {{seconds}} seconds…`)。
2. **`allowMultiple` 下按钮自己就能踩中**。`Submit Another Response` 的 `handleReset` 只把 `submitted`/`error` 翻回去,待定导航照旧走完。组件先请提交者再填一份,约三秒后又在他打字时把整页丢掉。

等待现在住在以「已接受目的地」为键的 effect 里,cleanup `clearTimeout`:unmount 即取消;`handleReset` 一并丢掉该目的地,于是按钮也取消它。延迟与目的地在**写入被接受的那一刻**一起被捕获(`{ url, delayMs }` 一个状态),而不是等待时再从 `config.thankYouPage` 读一遍 —— 被兑现的是写入被接受时声明的那个值,宿主中途以不同 `redirectDelay` 重渲染无法在用户脚下重启停顿。

## PM 代裁(认领评论 5320362764 已公示,留否决窗)

`handleReset` **取消**待定 redirect。依据即卡面论证:按钮承诺的是「再填一份」,与三秒后丢弃整页不可共存;取消是按钮语义的机械执行,不是新口味。维护者可否决 —— 若改判为「作者声明的 redirect 优先」,`handleReset` 里那一行 `setPendingRedirect(null)` 与对应的那条负向用例即为全部改动面。

## 语义账本(逐条:动了什么、没动什么)

| 项 | 之前 | 之后 |
| --- | --- | --- |
| `redirectDelay` 设了值 | 停顿后导航 | 停顿后导航(不变) |
| `redirectDelay` 未设 | `setTimeout(fn, 3000)` | 仍是 3000ms 定时器,默认值在接受时刻被捕获(钉子测试第 4 条钉住这个数) |
| 哪些目的地被跟随 / 被拒绝 | `isRedirectUrlSafe(raw, config.allowedRedirectHosts)` | **同一行,分毫未动** |
| 拒绝路径 | `console.warn` + `setError(texts.redirectBlocked)`,不导航 | 不变(不进 pending 状态,也就没有等待可武装) |
| host-allow-list 契约本身 | `isRedirectUrlSafe` / `allowedRedirectHosts` | **未并入** #4989 / PR #5032 的 relative-only 裁定 —— 两契约是否统一是独立问题,本 PR 一行不碰 |
| 倒计时文案 | 由 `thankYou?.redirectUrl` 存在与否决定是否渲染 | 不变(未改为读 pending 状态;它与裁定脱钩另立 #5073) |
| unmount 落在延迟窗口内 | 定时器照 fire,全页导航 | cleanup 取消,什么都不发生 |
| 按 `Submit Another Response` | 表单回来了,导航仍在三秒后 fire | 目的地被丢掉,effect 重跑的 cleanup 取消定时器 |
| 数据 | 等待开始前写入已成功 | 同上;取消等待不会回滚写入(钉子测试顺带断言 `create` 仍是 1 次) |

## 前提复现读数(改动前,基线 f68018d56)

新钉子文件先在**未改动**的 `EmbeddableForm.tsx` 上跑(`git checkout f68018d56 -- packages/plugin-form/src/EmbeddableForm.tsx`),卡面两条断言逐条复现:

```
FAIL > navigates nowhere after the form is unmounted mid-delay
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received: 1st vi.fn() call: Array [ "/thanks-5049" ]
  at EmbeddableForm.redirectTimerLifetime.test.tsx:199

FAIL > navigates nowhere after "Submit Another Response" is pressed mid-delay
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received: 1st vi.fn() call: Array [ "/thanks-5049" ]
  at EmbeddableForm.redirectTimerLifetime.test.tsx:215

FAIL > captures the 3000 ms default when redirectDelay is unset, and cancels it on unmount
AssertionError: expected [ …(4) ] to include Timeout { _idleTimeout: 3000, … }
  at EmbeddableForm.redirectTimerLifetime.test.tsx:245

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

**① unmount 后仍导航**:红,收到 `/thanks-5049`。**② 按重置钮后仍导航**:红,同样收到 `/thanks-5049` —— 表单已经回来了(用例先断言 email 输入框在场),然后被丢掉。配对的正向用例(mounted 到点导航)在基线上就是**绿**的:缺陷只在生命周期上,功能本身是通的。第 4 条在基线上红在「句柄从未被 clear」,而 `armed[0].ms === 3000` 这半在基线上就通过 —— 3000 默认值今天就存在,红的是没人取消它。

## 钉子测试

`packages/plugin-form/src/EmbeddableForm.redirectTimerLifetime.test.tsx`,四条:

- **unmount 负向**:武装 → `unmount()` → 走完真实时钟(声明延迟的 5 倍)→ 断言未发生任何导航,且 `create` 仍是 1 次。
- **重置负向**:`allowMultiple` → 武装 → 点 `Submit Another Response` → 断言新表单在场 → 走完真实时钟 → 断言未发生任何导航,且仍停在那张新表单上。
- **mounted 正向**:同一 schema 不 unmount,延迟到点后目的地照旧到达,恰好 1 次。防「把功能删了换绿」。
- **默认值一条**:`redirectDelay` 未设 → 武装的延迟就是 3000(在接受时刻被捕获),unmount 后断言**该句柄**被 clear。这一条刻意不去等满 3 秒真实时钟:cleanup 的红绿已由上面两条在真实时钟上钉住,等 3 秒买不到新证据;它存在的意义是别让 3000 这个默认值悄悄漂走。

两处观测手法:武装本身由 pass-through 的 `setTimeout` spy 显式观测(只记本文件声明的两个延迟值 149/3000),`waitFor` 等到武装完成才 unmount/点按钮 —— 保证动作发生在武装**之后**(唯一能 falsify 任何东西的次序),也让「什么都没武装」的变异无法用空绿冒充修好。导航的观测则是在**真实 Location 实例**上只影子化 `href` 这一个访问器(原型上的是 configurable,`delete` 即还原),`origin` / `search` 保持真值 —— 于是 `isRedirectUrlSafe` 是真的在跑,而不是对着一个假 location 空转。真实时钟而非 fake timers:提交路径是一串 await 的 promise,假时钟会让观测去和 resolution 抢时间而不是和延迟抢(与 `submitRedirect.timerLifetime.test.tsx` 同一理由)。

## 反向验证

先书面预判,commit 之后再变异,还原用 `git checkout 本分支名 -- 该路径`(对着已提交的 commit 取回,不碰共享 stash)。

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| ① 删掉 effect cleanup 的 `clearTimeout` | **两条负向都红**(不只 unmount 那条)。重置走的**不是**「state 清除本身取消」这条路:`setPendingRedirect(null)` 只是让 effect 重跑,真正取消的是重跑前那次 cleanup 里的 `clearTimeout` —— 所以删掉它,重置负向一并红。正向绿,第 4 条红在句柄未被 clear | **完全一致**:`Tests 3 failed \| 1 passed (4)`,两条负向红在 `expected "vi.fn()" to not be called at all`(行 199 / 215),第 4 条红在 `toContain(Timeout { _idleTimeout: 3000 })`(行 245),正向绿 |
| ② `handleReset` 不清待定目的地 | **重置负向红、unmount 负向绿** —— unmount 安全从来不覆盖 `Submit Another Response` 这条路,这正是本单区别于 #5033 之处。正向与第 4 条绿 | **完全一致**:`Tests 1 failed \| 3 passed (4)`,唯一的红是重置负向(行 215) |
| ③ 整个武装删掉(`setPendingRedirect({…})` 不再调用) | 方向**不是**读者从「unmount 安全」预期的那个:**四条全红**,且全红在 `armed.length` 而非任何导航断言上 —— 负向两条也红,因为「已武装」在本文件是前置条件不是假设 | **完全一致**:`Tests 4 failed (4)`,四条全部 `AssertionError: expected +0 to be 1`,同一行 `:183`(即 `waitUntilArmed`) |
| 还原后 | 全绿 | `Test Files 1 passed (1) / Tests 4 passed (4)` |

③ 的方向已写进测试文件头注。

## 验证

- 依赖构建:`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-form^...' build` → Done
- 包全量(仓根路径过滤):`pnpm exec vitest run packages/plugin-form --maxWorkers=2` → `Test Files 53 passed (53) / Tests 543 passed (543)`
- 新文件 + 两个相邻 redirect 套件:`pnpm exec vitest run …EmbeddableForm.redirectTimerLifetime.test.tsx …__tests__/EmbeddableForm.test.tsx …submitRedirect.timerLifetime.test.tsx` → `Test Files 3 passed (3) / Tests 27 passed (27)`
- 仓根类型检查:`pnpm exec turbo run type-check --concurrency=2` → `Tasks: 81 successful, 81 total`。**中途真红过一次,值得记一笔**:`plugin-form` 的 `type-check` 是 `tsc --noEmit && tsc -p tsconfig.test.json`,测试文件也进类型门禁。`hrefSetter` 原先声明为 `ReturnType` 套 `typeof vi.fn`,被判成不可调用的 `Mock` 联合类型(TS2348);给 `vi.fn` 补上显式调用签名(取一个 `url: string`、返回 `void`)后通过
- `pnpm --filter @object-ui/plugin-form lint` → `0 errors`(586 warnings,其中新文件 10 条是 spy pass-through 的 `any`,与 `submitRedirect.timerLifetime.test.tsx` 同形)
- `node scripts/check-changeset-presence.mjs` → 1 changeset 已声明
- `node scripts/check-control-bytes.mjs` → OK(4511 个文件);改动三个文件另做 `grep -naP` 自扫,零命中

一切测试读数取自**仓库根目录**的规范跑法(AGENTS.md §怎么跑测试),重活全程经 `/tmp/os-heavy-verify.lock` 串行。

## 顺手发现(未在本 PR 修)

**filed as #5073**:致谢面板的倒计时文案与组件自己的 redirect 裁定脱钩 —— 它只看「作者是否声明了 `redirectUrl`」,不看 `isRedirectUrlSafe` 是否放行。于是安全门拦下一个跨源目的地之后,提交者仍被告知「Redirecting in 3 seconds…」然后永远不会被跳转;同一路径上 `texts.redirectBlocked` 被 `setError` 写入的那一刻组件已切到致谢分支,而该分支根本不渲染 error,所以这个已翻译的字符串永远显示不出来。按 #5049 卡面与认领评论的范围划定(倒计时文案行为不动),本 PR 一行未碰,已另立独立卡片(未指派;非 #5049 子卡,亦不 `Blocked-by:` 本 PR)。

另:`thankYouPage.redirectUrl` 的 host-allow-list 该不该并入 #4989 / PR #5032 的 relative-only 裁定,是独立开放问题,已记录在 #5049 正文,本 PR 未碰、亦未另立卡片。
