### PR TITLE
docs(plugin-grid): README 按真实导出面重写虚构的手动注册与 GridSchema / GridColumn 类型

### DIFF
--- a/.changeset/plugin-grid-readme-truth-5013.md
+++ b/.changeset/plugin-grid-readme-truth-5013.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+plugin-grid README: replace the fictional `gridComponents` manual-registration
+snippet and the `GridSchema` / `GridColumn` type names with this package's real
+export surface and the real data-grid types.
+
+Three assertions the README made about identifiers were not true of this package
+(objectui#5013):
+
+- `gridComponents` had zero hits anywhere in the repo. The snippet's
+  `Object.entries(gridComponents).forEach(…)` threw `TypeError` on the first
+  copied line. Registration here is a side effect of importing the entry, so the
+  section is replaced by what actually happens: the keys the three real
+  `ComponentRegistry.register(…)` calls claim, the 49-name export surface, and —
+  for the case the snippet was reaching for — registering the exported
+  `ObjectGridRenderer` under a caller's own key.
+- `GridSchema` and `GridColumn` were imported from `@object-ui/plugin-grid` as
+  the data-grid schema and column types. Neither is on this package's export
+  surface, and both names denote something else where they do exist:
+  `GridSchema` in `@object-ui/types` is the **CSS Grid layout** container
+  (`columns` there is a column count, not a column list), and `GridColumn` in
+  `@object-ui/fields` is the **form line-items** widget's column (keyed `name`).
+  The example is rewritten on the real types, `ObjectGridSchema` and
+  `ListColumn` from `@object-ui/types`, with the component-props type
+  `ObjectGridComponentProps` named as the thing row callbacks belong to.
+- The in-prose `interface GridColumn { header; accessorKey; … }` reference block
+  made that absent name read like a real export, and contradicted this README's
+  own Column Summaries section, which already documented columns as `field` +
+  `summary`. It is replaced by the 14 keys of `ListColumn`, whose Zod
+  declaration is strict — `accessorKey` / `header` are rejected, not ignored.
+
+Documentation only: no code, type or runtime change. `patch` because `README.md`
+is in the package's published `files`.

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -19,34 +19,127 @@ pnpm add @object-ui/plugin-grid
 
 ## Usage
 
-### Automatic Registration (Side-Effect Import)
+### Registration is a side effect of the import
+
+There is no registration call to make. Importing the package entry once runs the
+three `ComponentRegistry.register(…)` calls in `src/index.tsx`, and from then on
+the schema types below resolve:
 
 ```typescript
 // In your app entry point (e.g., App.tsx or main.tsx)
 import '@object-ui/plugin-grid';
 
-// Now you can use grid types in your schemas
+// The data grid is `object-grid`, and it queries an object — see below for why
+// this is not `type: 'grid'`.
 const schema = {
-  type: 'grid',
-  columns: [
-    { header: 'Name', accessorKey: 'name' },
-    { header: 'Email', accessorKey: 'email' }
-  ],
-  data: []
+  type: 'object-grid',
+  objectName: 'users',
+  columns: ['name', 'email']
 };
 ```
 
-### Manual Registration
+### The schema types this package claims
+
+`register(type, component, { namespace })` publishes `namespace:type`, and — unless
+`skipFallback` is set — the bare `type` as a back-compat fallback
+(`packages/core/src/registry/Registry.ts:194`, fallback at `:226-240`). So the
+three calls in `src/index.tsx` claim exactly these keys:
+
+| `register(…)` call | Namespaced key | Bare fallback |
+| --- | --- | --- |
+| `('object-grid', ObjectGridRenderer, { namespace: 'plugin-grid' })` — `src/index.tsx:181` | `plugin-grid:object-grid` | `object-grid` |
+| `('grid', ObjectGridRenderer, { namespace: 'view', skipFallback: true })` — `src/index.tsx:193` | `view:grid` | **none** — `skipFallback: true` |
+| `('import-wizard', ImportWizardRenderer, { namespace: 'plugin-grid' })` — `src/index.tsx:216` | `plugin-grid:import-wizard` | `import-wizard` |
+
+**Bare `grid` is deliberately not ours.** `skipFallback: true` on the second call
+keeps this plugin from claiming it, because `grid` belongs to the CSS Grid *layout*
+container in `@object-ui/components`
+(`src/renderers/layout/grid.tsx:50`), whose schema type is `GridSchema` in
+`@object-ui/types` (`src/layout.ts:202` — `columns` there is a **column count**,
+not a column list). A schema written as `{ type: 'grid', columns: [...] }` therefore
+renders that layout container, not this data grid. Use `object-grid`, or `view:grid`
+when you want the namespaced spelling.
+
+### Registering the renderer under your own key
+
+If you need the data grid under an additional key, register the exported renderer
+directly — that is what a "manual registration" is here:
 
 ```typescript
-import { gridComponents } from '@object-ui/plugin-grid';
+import { ObjectGridRenderer } from '@object-ui/plugin-grid';
 import { ComponentRegistry } from '@object-ui/core';
 
-// Register grid components
-Object.entries(gridComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
+ComponentRegistry.register('my-grid', ObjectGridRenderer, {
+  namespace: 'my-app',
+  label: 'My Grid',
+  category: 'plugin',
 });
 ```
+
+### Exports
+
+The complete public surface — 20 values and 29 types:
+
+```typescript
+import {
+  ObjectGrid,
+  ObjectGridRenderer,
+  VirtualGrid,
+  SplitPaneGrid,
+  ImportWizard,
+  InlineEditing,
+  FormulaBar,
+  GroupRow,
+  RowActionMenu,
+  BulkActionBar,
+  formatActionLabel,
+  inferColumnType,
+  parseSpreadsheetFile,
+  parseClipboardTable,
+  useCellClipboard,
+  useColumnSummary,
+  useGradientColor,
+  useGroupReorder,
+  useGroupedData,
+  useRowColor,
+} from '@object-ui/plugin-grid';
+
+import type {
+  ObjectGridComponentProps,
+  ObjectGridColumnState,
+  ObjectGridExternalPaginationProps,
+  ObjectGridProps, // deprecated alias of ObjectGridComponentProps (objectui#4650)
+  VirtualGridProps,
+  VirtualGridColumn,
+  SplitPaneGridProps,
+  ImportWizardProps,
+  ImportResult,
+  InlineEditingProps,
+  FormulaBarProps,
+  GroupRowProps,
+  RowActionMenuProps,
+  BulkActionBarProps,
+  GroupEntry,
+  UseGroupedDataResult,
+  AggregationType,
+  AggregationConfig,
+  AggregationResult,
+  CellRange,
+  UseCellClipboardOptions,
+  UseCellClipboardResult,
+  GradientStop,
+  UseGradientColorOptions,
+  UseGroupReorderOptions,
+  UseGroupReorderResult,
+  ColumnSummarySetting,
+  ColumnSummaryType,
+  ColumnSummaryResult,
+} from '@object-ui/plugin-grid';
+```
+
+The *schema* types are not here — they live in `@object-ui/types`
+(`ObjectGridSchema`, `ListColumn`), because the schema is the shared authoring
+contract rather than this package's component API.
 
 ## Schema API
 
@@ -56,8 +149,9 @@ Data grid with advanced features:
 
 ```typescript
 {
-  type: 'grid',
-  columns: GridColumn[],
+  type: 'object-grid',
+  objectName: string,
+  columns?: string[] | ListColumn[],
   data?: any[],
   sortable?: boolean,
   filterable?: boolean,
@@ -70,16 +164,40 @@ Data grid with advanced features:
 
 ### Column Definition
 
+A column is either a **field name** (`'name'`) or a `ListColumn` object. `ListColumn`
+is declared by `@objectstack/spec/ui` (`ListColumnSchema`) and re-exported from
+`@object-ui/types`; it is the type of `ObjectGridSchema['columns']`, so it is the
+same column vocabulary the saved-view metadata uses.
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `field` | `string` (**required**) | The field this column reads. There is no `accessorKey`. |
+| `label` | `string \| Record<string, string>` | Header text, or an inline locale map. There is no `header`. |
+| `width` | `number` | Column width in pixels. |
+| `align` | `'left' \| 'center' \| 'right'` | Cell alignment. |
+| `hidden` | `boolean` | Hidden by default, revealable in the column chooser. |
+| `sortable` | `boolean` | Allow sorting on this column. |
+| `resizable` | `boolean` | Allow dragging this column's width. |
+| `wrap` | `boolean` | Wrap long cell text instead of eliding it. |
+| `type` | `string` | Override the rendered cell type instead of inferring it from the field. |
+| `pinned` | `'left' \| 'right'` | Freeze the column to one edge. |
+| `summary` | `ColumnSummary \| { type; field? }` | Footer aggregation — see [Column Summaries](#column-summaries). |
+| `prefix` | `{ field: string; type?: 'text' \| 'badge' }` | Render a second field inline before the value. |
+| `link` | `boolean` | Render the value as a link to the record. |
+| `action` | `string` | Run a named action when the cell is clicked. |
+
+`ListColumnSchema` is a **strict** Zod object, so an unknown key is rejected rather
+than ignored — a column is spelled this one way.
+
 ```typescript
-interface GridColumn {
-  header: string;
-  accessorKey: string;
-  sortable?: boolean;
-  filterable?: boolean;
-  width?: number | string;
-  align?: 'left' | 'center' | 'right';
-  cell?: (value, row) => ReactNode;
-}
+import type { ListColumn } from '@object-ui/types';
+
+const columns: ListColumn[] = [
+  { field: 'name', label: 'Full Name', width: 200, sortable: true, pinned: 'left', link: true },
+  { field: 'stage', type: 'select', prefix: { field: 'health', type: 'badge' }, wrap: true },
+  { field: 'amount', type: 'currency', align: 'right', summary: 'sum', resizable: true },
+  { field: 'owner_id', label: { en: 'Owner', 'zh-CN': '负责人' }, hidden: true, action: 'reassign' },
+];
 ```
 
 ### Column Summaries
@@ -388,23 +506,36 @@ const schema = {
 
 ## TypeScript Support
 
-```typescript
-import type { GridSchema, GridColumn } from '@object-ui/plugin-grid';
+The schema and column types come from `@object-ui/types`; this package exports the
+*component* types.
 
-const nameColumn: GridColumn = {
-  header: 'Name',
-  accessorKey: 'name',
+```typescript
+import type { ObjectGridSchema, ListColumn } from '@object-ui/types';
+import type { ObjectGridComponentProps } from '@object-ui/plugin-grid';
+
+const nameColumn: ListColumn = {
+  field: 'name',
+  label: 'Full Name',
   sortable: true
 };
 
-const grid: GridSchema = {
-  type: 'grid',
+const grid: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
   columns: [nameColumn],
-  data: [],
-  sortable: true,
-  pagination: true
+  pagination: { pageSize: 20 }
+};
+
+// Row callbacks are COMPONENT props, not schema keys.
+const gridProps: ObjectGridComponentProps = {
+  schema: grid,
+  onRowClick: (record) => console.log('Row clicked:', record)
 };
 ```
+
+`ObjectGridProps` is a deprecated alias of `ObjectGridComponentProps` and denotes the
+same type; `@objectstack/spec/ui` owns the name `ObjectGridProps` for the *authored*
+props document of the `object-grid` element (objectui#4650).
 
 ## Links
 


### PR DESCRIPTION
Fixes #5013

基线 `origin/main` @ `bb3fab62c7729092174a1e8ae6032cbb29ce28a3`(worktree 显式建在该 sha 上)。方法学照同族已落地的 #5010 → PR #5046、#5016 → PR #5053、#5012 → PR #5059。

## 判定表(虚构 / 错指涉 / 真名)

卡面列了三处。前提复测(词边界)确认了三处都成立,但**其中一处的成因比卡面记的更糟**:那个"不存在"的名字其实**存在于第三个包**,又是一次同名错指涉。

| README(改前) | 判定 | 依据 | 处理 |
| --- | --- | --- | --- |
| `:42` `import { gridComponents }` + `:46` `Object.entries(gridComponents).forEach(…)` | **纯虚构** | 全仓零命中(不只本包);49 个导出名里没有它 | **删虚构节**,改教真实机制 |
| `:392` `import type { GridSchema }`、`:400` `const grid: GridSchema` | **本包无此名;同名真身指涉 CSS Grid 布局** | `@object-ui/types` `src/layout.ts:202` 的 `GridSchema` 是布局容器,`columns` 在那里是**列数**(`number` 或 `Record`)不是列表 | **按真身重写**:`ObjectGridSchema` |
| `:392` `import type { GridColumn }`、`:394` `const nameColumn: GridColumn` | **本包无此名;同名真身指涉表单行项目列** | 卡面记「`GridColumn` 全仓不存在」——**不成立**:`@object-ui/fields` `src/widgets/GridField.tsx:76` 有 `GridColumn`,是 `field:grid` 控件(表单行项目/主从子表)的列,键为 `name`。它不在 `@object-ui/types` 里,这一半卡面是对的 | **按真身重写**:`ListColumn` |
| `:74-82` 文内 `interface GridColumn { header; accessorKey; … }` | **假名 + 假形状** | 真列类型 `ListColumn`(`ListColumnSchema`,`@objectstack/spec/ui`,经 `@object-ui/types` 转出)是 `field` / `label`,且是 **strict** Zod 对象 —— `header` / `accessorKey` 被拒绝而非忽略 | **改为 `ListColumn` 的 14 键表**,并按提取式双向钉住 |

⛔ **未新增任何导出或类型**来把 README 变真;⛔ 未 re-export 撞名的 `GridSchema` / `GridColumn`。

### 两处同名错指涉,是同一个事实的两半

`skipFallback: true`(`src/index.tsx:195`)让本插件**故意不认领**裸 `grid`,因为裸 `grid` 属于 `@object-ui/components` 的 CSS Grid 布局容器(`src/renderers/layout/grid.tsx:50`)—— 而 `@object-ui/types` 里那个撞名的 `GridSchema` **正是该布局容器的 schema 类型**。键面上的 `grid` 归属与类型名上的 `GridSchema` 归属是同一件事,所以改写时把它写进了 README:读者需要知道的不是"换个导入路径",而是"这个名字整族都属于另一个组件"。

### 删掉的每一节,删因一行

- **`### Manual Registration` 整节(改前 `:39-49`)** —— 它教的 `gridComponents` 不存在,`Object.entries(undefined)` 在第一行就抛 TypeError;而它想表达的"注册"根本不需要手动做。替换为四节真话:注册是 import 副作用、三个 `register` 调用认领的键表(`plugin-grid:object-grid` + 裸 `object-grid`、`view:grid` **无**裸回落、`plugin-grid:import-wizard` + 裸 `import-wizard`;机制见 `packages/core/src/registry/Registry.ts:194`,回落在 `:226-240`)、49 个名字的真实导出面、以及原片段真正想做的事(把导出的 `ObjectGridRenderer` 注册到自定义键)。
- **`interface GridColumn` 说明块(改前 `:74-82`)** —— 假名坐实成"真导出",且与本 README 自己的 `### Column Summaries` 节自相矛盾:那一节 `:92-96` 早就按 `field` + `summary` 记述,而这一块说 `accessorKey`。同一文件两种拼法,留一种。
- **`const grid: GridSchema = { type: 'grid', columns: [nameColumn], data: [], sortable: true, pagination: true }`(改前 `:400-406`)** —— 类型名错指涉,`type` 也错(裸 `grid` 不归本插件)。
- **`cell?: (value, row) => ReactNode`(改前 `:81`)** —— `ListColumn` 上没有这个键;单元格渲染由字段类型推断,不由列上的函数决定。(它也是探针里那条 `TS2304 Cannot find name 'ReactNode'` 的来源。)

## 卡面前提复测(词边界,先做再改)

`#5043` 追评记过:裸 grep 在这一族上会骗人。三处逐一复测,并用确定存在的邻近词 `ObjectGrid` 反查:

```
grep -rn  "gridComponents"  packages --include=*.ts --include=*.tsx   -> 0 命中
grep -rnP '\bGridColumn\b'  packages --include=*.ts --include=*.tsx   -> 命中!@object-ui/fields + plugin-form 共 20+ 处
grep -rn  "GridColumn"      packages ...(裸 grep)                     -> 另有 GridColumnDefinition 子串噪声
grep -rnP '\bGridSchema\b'  packages ...                              -> @object-ui/types layout.ts:202 等 12 处
```

**卡面「`GridColumn` 全仓不存在」不成立**,但结论方向不变、反而更强:它不是"没有这个名字",而是"这个名字属于表单行项目控件"。词边界这一步同时抓出裸 grep 的 `GridColumnDefinition` 子串噪声。

## 名集合核对读数(AST 版)

导出名集合取自**构建产物** `packages/plugin-grid/dist/index.d.ts`,走 TS compiler API 的 `checker.getExportsOfModule`(不对 src 做正则)。README 侧先抽 fenced 代码块、每块 `ts.createSourceFile`、走 `ImportDeclaration` 的 AST,`A as B` 判 **A**(导出名)。#5043 记的两个坑因此结构上不可能发生:多行块本就是**一个** `ImportDeclaration` 节点,行尾 `//` 注释对 parser 是 trivia。按卡面指示**未**照抄任何一条正则。

```
改前:  export surface: 49 names / README 3 bindings / MISSING COUNT: 3
          - gridComponents @ README:42
          - GridSchema     @ README:392
          - GridColumn     @ README:392
改后:  export surface: 49 names / README 51 bindings / MISSING COUNT: 0
```

改后 51 个绑定逐个 OK,覆盖新增导出面两个多行块的全部 49 个名字(20 值 + 29 类型;`ObjectGridRenderer` 与 `ObjectGridComponentProps` 各出现两次)。

## 编译探针读数

README 的 ts/tsx 块抄进 `packages/plugin-grid/node_modules/.5013-probe/`(git 忽略,且 node 解析能直接看到本包的真实依赖),对同一构建产物 `dist/index.d.ts` 编译(`strict: true`,**没有为让块通过而放松任何选项**)。每块补一行 `export {};`——多个块各自声明 `const schema` 都是全局 script,会撞重复标识符;这一行只改作用域。

```
### 全 README(16 块;1 块按设计跳过并在输出里列明理由)
改前: 26 diagnostics
改后: 20 diagnostics
仅存于改前(即本 PR 消掉的)= 6 条,新引入 = 0 条
```

跳过的一块(输出里列明,不静默丢):`Schema API` 下的裸属性列表 `{ type: …, columns: … }` 形状速写 —— 故意不合法的 TS。

余下 20 条**不是本 PR 的漏修**:全部来自无类型标注的 `const schema = { … }` 里的回调(TS7006 / TS7031)与一处未声明的 `dataSource`(TS2304),属那一族虚构 schema 键面,已立 **#5065**。改前改后逐条相同。

## 反向验证(两条预判先写,均已印证;另加第三条)

### (a) 名集合核对自证 —— 4 条预判,4 条符

变异全做在 README 的 **scratch 副本**上(检查器带 `--readme` 参数),**工作树一次都没被改过**,不存在"临时改动误入 commit"的窗口。

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| 行尾注释改成含非导出词(`// gridComponents was never real`) | **不得**报(假阳性测试) | 未报 |
| **多行**值导入块里加 `gridThings as Things` | 报,且按**导出名** `gridThings` 而非别名 | 报 `gridThings` @ `:105` |
| 多行类型块里 `VirtualGridColumn` → `VirtualGridColumn as Col` | 仍 OK(别名判导出名) | OK |
| 多行类型块**中段**插 `GridSchema` | 报 | 报 @ `:123` |

`MISSING COUNT` 0 → 2(恰为 `{gridThings, GridSchema}`),还原读数 `0`。

### (b) 改前 README 回填探针 —— 转红,且错误一一对应

同一套探针机器直接跑改前 README(skip 按**内容签名**分类而非块序号,所以两版共用一套机器);诊断按"去块号"归一后做集合差。

| 所改之处 | 预判 | 实测诊断(仅存于改前) |
| --- | --- | --- |
| `gridComponents` | TS2305 | `TS2305 … has no exported member 'gridComponents'` |
| `GridSchema` | TS2305 | `TS2305 … has no exported member 'GridSchema'` |
| `GridColumn` | TS2305 | `TS2305 … has no exported member 'GridColumn'` |
| 删掉的 `interface GridColumn` 块里的 `cell?: (value, row) => ReactNode` | 转红 | `TS7006 Parameter 'value'` / `TS7006 Parameter 'row'` / `TS2304 Cannot find name 'ReactNode'` |

**新引入 0 条** —— 这是这条验证里最该被读到的一格:改后集合是改前集合的真子集,所以"20 条既有红"不是被我搅动过的残留。

### (c) 表格钉子自证 —— 因为"表格"本身没有编译力

改前那种独立 `interface GridColumn { … }` 块**照原样喂 tsc 是永远绿的**(#5043 追评 §3)。这次的改写没有再放一个文内 interface,而是写成 `ListColumn` 的 14 键**表格** —— 表格更不可能被 tsc 看见。所以另写了一个提取式钉子:键名从 README 表格里**机械提取**(不手抄),再与 `keyof ListColumn` 双向断言 `never`。

预判:改 `field` 行为 `accessorKey` → **两向都红**(正是改前 README 的病);删 `action` 行 → **只有一向红**。两条都符:

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| 表格 `field` 行改成 `accessorKey` | 两向红 | `TS2344 Type '"accessorKey"' does not satisfy the constraint 'never'`(documented → real)+ `TS2344 Type '"field"' …`(real → documented) |
| 删掉表格 `action` 行 | 仅 real → documented 红 | 只报 `TS2344 Type '"action"' …` |

未变异时:`documented keys (14): field, label, width, align, hidden, sortable, resizable, wrap, type, pinned, summary, prefix, link, action`,`rc=0` —— 与 `keyof ListColumn` 恰好相等。单向只钉一半:只钉 real → documented 时,表格多写的假键不会被发现。

### 一处**与卡面预设相反**的实测,如实记

卡面写「改对路径也仍是错形状,**TS 会绿着通过一个错的类型**」。照那个场景实测(只把导入路径改到两个名字的真身,其余一字不动):**tsc 转红,不是绿**——

```
wrong-referent.ts(7,3):   error TS2353: Object literal may only specify known properties,
                          and 'header' does not exist in type 'GridColumn'.
wrong-referent.ts(14,13): error TS2322: Type 'GridColumn' is not assignable to type 'number'.
```

第二条把错指涉说得比任何散文都清楚:布局 `GridSchema` 的 `columns` 是**列数**,所以一个列对象赋不进去。

所以真实的危险方向与卡面预设**相反**:照抄 README 的读者会撞上编译错误(有信号);真正无声的是**反过来**的读者 —— 按撞名类型正确地写一个 `{ type: 'grid', columns: 3, gap: 4 }`,以为自己在写数据表格,拿到的是布局容器。那个无声失败的运行时症状已立 #4787。本 PR 因此不止改类型名,还把"这个名字整族属于谁"写进了 README。

## 有意留下的接缝(不是漏修)

`### Grid` 那个形状速写块里,`sortable` / `filterable` / `onRowClick` / `data` 以及下游 10 个示例块的 `type: 'grid'` **原样留着**,连同它们的 20 条既有红一起交给 **#5065**。理由是纪律:那些是 **schema 键面**漂移,与本卡的**标识符**漂移不同性质,按派发指示不夹带。本 PR 在该块里只改了让 `ListColumn` 这个名字在上下文中成立所必需的三行(`type: 'object-grid'`、新增必填 `objectName`、`columns?: string[] | ListColumn[]`)—— 即不新增任何我自己写的假话,也不去修既有的那些。同族先例:#5012 → PR #5059 同样把键面留给了 #5057。

## 验证

- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **81 successful, 81 total**(重活经 `flock` 串行 + `--max-old-space-size=4096`)。
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4512 tracked text file(s); skipped 85 binary)`;改动两文件另做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中。
- `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-grid...' build` → rc=0(探针所依赖的构建产物)。

**docs-only 的 CI 形状**:`ci.yml` / `lint.yml` 把 `**/*.md` 与 `.changeset/**` 列进 `paths-ignore`,所以各 job 的实质步骤会被 path-filter 短路成 skipped 而 job 报 success。按纪律计绿,但**类型证据是上面的本地仓根读数**,不是 CI 的(#5046 / #5053 / #5059 先例)。

## 顺手立的卡(均未认领,不夹带进本 PR)

- **#5065** — 同文件 10 个示例块整片 schema 键面不成立:`type: 'grid'` 落到布局容器(#4787 是其运行时症状),`sortable` / `filterable` / `onRowClick` / `onCellChange` / `onRowSave` / `onBatchSave` / `onSelectionChange` / `dataSource` / `object` 在 `ObjectGrid.tsx` 上 `schema.` 读点数全为 0。探针余下的 20 条红属于它。
- **#5068**(`finding`)— `ObjectGrid.tsx:1361-1379` 在 `ObjectGridSchema.columns` 上容忍未声明的 `accessorKey` / `header`,而声明类型 `ListColumn` 是 strict 的。**这正是本卡那处文档假形状"看起来可信"的原因**:照抄确实能渲染,所以没有信号。#3104 的列身份门禁要求同一行的 `||` / `??` 交替链,结构上看不见这条 `if ('accessorKey' in …)` 分支。

## changeset

`.changeset/plugin-grid-readme-truth-5013.md`,`@object-ui/plugin-grid: patch`,口径同 #5046 / #5053 / #5059:无代码/类型/运行时改动,声明 patch 是因为 `README.md` 在包的 `files` 里,随下次发布到 npm。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_