### PR TITLE
docs(plugin-view): README 按真实导出面重写虚构的 viewComponents 手动注册,ObjectViewSchema 改从 @object-ui/types 导入

### DIFF
--- a/.changeset/plugin-view-readme-truth-5014.md
+++ b/.changeset/plugin-view-readme-truth-5014.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/plugin-view': patch
+---
+
+docs: README 按真实导出面重写虚构的 `viewComponents` 手动注册,并把 `ObjectViewSchema` 的导入路径改到 `@object-ui/types`
+
+`### Manual Registration` 教的 `viewComponents` 在本包(以至全仓)零命中,照抄第一行就是
+`Object.entries(undefined)` 抛 TypeError;替换为三节真话:七个 `ComponentRegistry.register`
+调用认领的 schema 类型键表、本包 39 个真实导出名、以及把导出组件挂到自定义键的写法。
+
+`ObjectViewSchema` 是真类型,但声明在 `@object-ui/types`,本包只 import 不 re-export,按
+README 原路径导入是 TS2305;改导入路径(未新增任何导出或 re-export),示例键面随之对齐真身
+(`objectName` 必填、`defaultViewType`、`table.columns`)。
+
+无代码/类型/运行时改动。声明 patch 是因为 `README.md` 在包的 `files` 里,随下次发布到 npm。

--- a/packages/plugin-view/README.md
+++ b/packages/plugin-view/README.md
@@ -35,15 +35,94 @@ const schema = {
 };
 ```
 
-### Manual Registration
+### What the side-effect import registers
+
+Registration is *only* a side effect of importing the package — the single
+`import '@object-ui/plugin-view'` above is the whole of it. There is no
+components map to iterate over: importing the entry point runs the
+`ComponentRegistry.register(...)` calls in `src/index.tsx`, which claim these
+schema types:
+
+| Schema `type` | Namespaced key | Renderer |
+| --- | --- | --- |
+| `object-view` | `plugin-view:object-view` | `ObjectViewRenderer` |
+| `view` | `plugin-view:view` | `ObjectViewRenderer` (alias of `object-view`) |
+| `view-switcher` | `view:view-switcher` | `ViewSwitcher` |
+| `filter-ui` | `view:filter-ui` | `FilterUI` |
+| `sort-ui` | `view:sort-ui` | `SortUI` |
+| `shared-view-link` | `view:shared-view-link` | `SharedViewLink` |
+| `view:simple` | `plugin-view:view:simple` | `SimpleViewRenderer` (container) |
+
+Both spellings resolve — `register` stores the namespaced key *and* a bare-`type`
+fallback (`packages/core/src/registry/Registry.ts:195,240`). Note the namespaces
+are not uniform: `object-view` / `view` / `view:simple` register under
+`plugin-view`, the four control components under `view`.
+
+`ObjectViewRenderer` is a thin internal wrapper — it pulls `dataSource` off the
+renderer context and hands the schema to `ObjectView`. It is not exported,
+because `ObjectView` itself takes `dataSource` as a **required prop**, not as a
+schema key.
+
+### Public exports
+
+The package exports components, helpers and their types — not a registry map:
 
 ```typescript
-import { viewComponents } from '@object-ui/plugin-view';
-import { ComponentRegistry } from '@object-ui/core';
+import {
+  ObjectView, // ObjectQL-integrated view: list + integrated create/edit
+  ViewSwitcher, // registered renderer for `view-switcher`
+  FilterUI, // registered renderer for `filter-ui`
+  SortUI, // registered renderer for `sort-ui`
+  SharedViewLink, // registered renderer for `shared-view-link`
+  ViewTabBar, // horizontal strip of saved-view tabs
+  ManageViewsDialog, // sortable dialog over every saved view
+  deriveRecordSurface, // record schema -> drawer / modal / page surface
+  deriveRecordFlowSurface,
+  deriveOverlaySize,
+  overlayWidthFor,
+  RECORD_SURFACE_PAGE_THRESHOLD,
+  deriveFieldOptions, // object fields -> picker options
+  toFilterGroup, // filter rules -> FilterGroup
+  toSortItems, // sort config -> SortItem[]
+  VIEW_TYPE_LABELS,
+  VIEW_TYPE_OPTIONS,
+  isImageLikeField,
+  isGeoLikeField,
+  pickPreferredField,
+  KANBAN_GROUP_PREFERRED,
+  PRIMARY_DATE_PREFERRED,
+  END_DATE_PREFERRED,
+  TITLE_PREFERRED,
+} from '@object-ui/plugin-view';
 
-// Register view components
-Object.entries(viewComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
+import type {
+  ObjectViewProps,
+  ViewSwitcherProps,
+  FilterUIProps,
+  SortUIProps,
+  SharedViewLinkProps,
+  ViewTabBarProps,
+  ViewTabItem,
+  AvailableViewType,
+  ManageViewsDialogProps,
+  RecordSurface,
+  RecordFlow,
+  RecordFlowContainer,
+  RecordFlowSurface,
+  OverlaySize,
+  FieldOption,
+} from '@object-ui/plugin-view';
+```
+
+To serve one of these components under a registry key of your own, register the
+exported component under that key:
+
+```typescript
+import { ComponentRegistry } from '@object-ui/core';
+import { ViewSwitcher } from '@object-ui/plugin-view';
+
+ComponentRegistry.register('my-switcher', ViewSwitcher, {
+  namespace: 'my-app',
 });
 ```
 
@@ -333,14 +412,28 @@ const schema = {
 
 ## TypeScript Support
 
+This package's type export surface is the seven `*Props` types plus the
+record-surface and field-option types listed under "Public exports" — it ships
+**no schema types**. The authored `type: 'object-view'` node is typed by
+`@object-ui/types`, which this package imports (`src/ObjectView.tsx`) without
+re-exporting, so import it from there:
+
+| Import from `@object-ui/types` | What it types |
+| --- | --- |
+| `ObjectViewSchema` | the whole `type: 'object-view'` node — `objectName` (required), `title`, `description`, `layout`, `defaultViewType`, `listViews`, `defaultListView`, `navigation`, `table`, `form`, `searchableFields`, `filterableFields`, `show*`, `operations`, `onNavigate`, `viewTabBar`, `viewActions` |
+| `NamedListView` | one entry of `listViews` |
+| `ViewNavigationConfig` | `navigation` — row/item click behaviour |
+| `ViewTabBarConfig` | `viewTabBar` — tab-bar UX (inline add, overflow, indicators) |
+
 ```typescript
-import type { ObjectViewSchema } from '@object-ui/plugin-view';
+import type { ObjectViewSchema } from '@object-ui/types';
 
 const userView: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'grid',
-  fields: ['name', 'email', 'role']
+  objectName: 'users',
+  defaultViewType: 'grid',
+  // Displayed columns are grid configuration, inherited from ObjectGridSchema.
+  table: { columns: ['name', 'email', 'role'] },
 };
 ```
 


### PR DESCRIPTION
Fixes #5014

基线 `origin/main` @ `e6cd3c26c9ee3c64d76b5e18ab8b41a4aaa09c97`(worktree 显式建在该 sha 上)。方法学照抄同族已落地的四单:#5010 → PR #5046、#5016 → PR #5053、#5012 → PR #5059、#5015 → PR #5069。

## 前提验证:卡面两条读数自己复测,都成立

卡面复核命令写的是裸 grep,按 #5012 的教训补词边界重测:

```
grep -rn "\bviewComponents\b" --include=*.ts --include=*.tsx --include=*.md packages apps
  -> 唯二命中就是 README 自己(:41、:45)。src 零命中,全仓零命中。
grep -rn "\bObjectViewSchema\b" packages/plugin-view/src
  -> 命中全在 __tests__ 与 src/ObjectView.tsx:27,且全部是 `from '@object-ui/types'` 的
     import 或用法;src/index.tsx 零命中(未 re-export)。
```

零命中用邻近词反查:同一套核对里 `ObjectView` 命中导出面(`src/index.tsx:18`),所以 `viewComponents` 的零命中不是工具没跑起来。

## 判定表

| README(改前) | 判定 | 依据 | 处理 |
| --- | --- | --- | --- |
| `:41` `import { viewComponents }` + `:45` `Object.entries(viewComponents).forEach(…)` | **纯虚构** | 全仓词边界零命中;39 个导出名里没有它 | **删虚构节**,改教真实机制 |
| `:337` `import type { ObjectViewSchema }` from 本包 | **真名,路径错** | 真身 `packages/types/src/objectql.ts`,从 `@object-ui/types` 导出;本包只 import(`src/ObjectView.tsx:27`)不 re-export | **改导入路径** —— ⛔ 未加 re-export |
| `:339-344` 该 typed 示例的键面(`object` / `viewMode` / `fields`) | **真类型,键面漂移** | `object` 不是声明成员(真名 `objectName`,必填);`viewMode` / `fields` 亦非声明成员 | **随导入路径一并对齐**(见下「为什么这一处必须一起改」) |

⛔ **未新增任何导出、re-export 或类型**来把 README 变真。

### 删掉的每一节,删因一行

- **`### Manual Registration` 整节(改前 `:38-48`)** —— 它教的 `viewComponents` 不存在,读者复制的第一行就是 `Object.entries(undefined)` 抛 TypeError;而它想表达的「注册」根本不需要手动做,是 import 入口的副作用。替换为三节真话:七个 `register` 调用认领的 schema 类型键表、本包 39 个真实导出名、以及原片段真正想做的事(把导出组件挂到自定义键)。

### 为什么 typed 示例的键面必须跟着一起改(而不是夹带)

改前那个示例被 `ObjectViewSchema` 标注,但因为导入失败、标注是 error type,键面从不被判。**把导入路径修对的同时,这三个键就第一次落到了编译面上**:`object` 不是声明成员且真名 `objectName` 必填 —— 不改示例就编译不过。这与 #5059 里 `GanttTask` 那一处同形。

## 名集合核对读数

导出名集合取自**构建产物** `dist/index.d.ts`,走 TS compiler API 的 `checker.getExportsOfModule`;README 侧不用正则抓 import —— 先抽 fenced 块,每块 `ts.createSourceFile`,再走 `ImportDeclaration` 的 AST,`A as B` 判 `propertyName`(导出名)而非本地别名。#5043 记的两个坑因此在结构上不可能发生。

```
export surfaces: @object-ui/plugin-view 39 / @object-ui/types 675 /
                 @object-ui/core 416 / @object-ui/data-objectstack 72

改前:  18 个 fenced 块 / 4 bindings / MISSING COUNT: 2
          - viewComponents   from @object-ui/plugin-view  @ README.md:41
          - ObjectViewSchema from @object-ui/plugin-view   @ README.md:337
改后:  19 个 fenced 块 / 43 bindings / MISSING COUNT: 0
```

改后 43 个绑定逐个 OK,其中新增的两个多行 import 块覆盖本包**全部 39 个导出名**(24 值 + 15 类型),核对因此不再只是抽样。

## 编译探针读数

README 的 ts/tsx 块抄进 scratch,对同一批构建产物编译(`strict: true`,**没有为让块通过而放松任何选项**);块按**内容签名**分类而非块序号,所以改前改后共用一套机器。

```
改前:  14 个可编译块(4 块按设计跳过并列明理由)   tsc -> rc=2
  block02(1,10): error TS2305: Module '"@object-ui/plugin-view"' has no exported member 'viewComponents'.      [README:41]
  block18(1,15): error TS2305: Module '"@object-ui/plugin-view"' has no exported member 'ObjectViewSchema'.    [README:337]
  block08(7,14) / block10(8,20) / block12(9,20) / block12(9,24) / block13(8,20): TS7006 (既有)

改后:  15 个可编译块(4 块按设计跳过)             tsc -> rc=2
  block09(7,14) / block11(8,20) / block13(9,20) / block13(9,24) / block14(8,20): TS7006 (原样携带)
```

跳过的四块(输出里列明,不静默丢):`:135` / `:153` / `:172` / `:193` 的 Schema API 形状速写 —— `object: string` / `views: [...]` 这类**类型语法落在值位置**或裸字面量,故意不合法的 TS。

剩下的 5 条 TS7006 **不是本 PR 的漏修**:是 CRUD 四段里 `onCreate: async (data) => …` 写在无类型标注的 `const schema = { … }` 里,属那一族虚构 schema 键的一部分。改前改后**逐条一一对应、坐标与文本完全相同**(README 行号各 +79,即本 PR 的插入量):

| 改前 | 改后 | README(前 → 后) |
| --- | --- | --- |
| `block08.ts(7,14)` | `block09.ts(7,14)` | `:148` → `:227`(Form View) |
| `block10.ts(8,20)` | `block11.ts(8,20)` | `:179` → `:258`(Create) |
| `block12.ts(9,20)` | `block13.ts(9,20)` | `:209` → `:288`(Update) |
| `block12.ts(9,24)` | `block13.ts(9,24)` | `:209` → `:288`(Update) |
| `block13.ts(8,20)` | `block14.ts(8,20)` | `:225` → `:304`(Delete) |

### 逐键 pin(改后示例的键面不靠外推)

散文与示例新增的断言单独钉在真类型上,一文件一键(多余属性会短路其余诊断 —— #5059 / #5069 都记过):

| 钉的内容 | 诊断 |
| --- | --- |
| `{ type: 'object-view', object: 'users' }` | `TS2741: Property 'objectName' is missing … but required in type 'ObjectViewSchema'` |
| `{ …, viewMode: 'grid' }` | **rc=0,无诊断** |
| `{ …, fields: ['name'] }` | **rc=0,无诊断** |
| 改后示例(`objectName` / `defaultViewType` / `table.columns`) | rc=0,无诊断 |

**中间两行是本 PR 最该被读到的一条读数,如实记**:`viewMode` / `fields` 这两个虚构键 tsc **不报**。原因是结构性的 —— `ObjectViewSchema extends BaseSchema`,而 `BaseSchema` 带 `[key: string]: any`(`packages/types/src/base.ts:318`),excess property 检查整体失效。也就是说**编译探针在这个类型上唯一有牙的是「必填 `objectName` 缺失」**;虚构键这一整类,这道门天生看不见。若不写下来,下一个读者会误以为「改后探针绿」等于「键面已被验证」。这条同时是下面 #5077 立卡的核心依据。

## 反向验证(两条,预判先写)

**(a) 名集合核对自证。** 预判:`MISSING COUNT` 0 → 2;别名判导出名;行尾注释里的非导出词不得报。四条全符 ——

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| 多行**值**导入块**中段**插 `viewComponents,` | 报 | 报 `viewComponents` @ `:87` |
| 多行**类型**导入块中段插 `ViewThings as Things` | 报,且按**导出名** `ViewThings` 而非别名 `Things` | 报 `ViewThings` @ `:112` |
| `ViewSwitcher` → `ViewSwitcher as Switcher` | 仍 OK(别名判导出名) | OK @ `:73` |
| 行尾 `// viewComponents was never real` | **不得**报(假阳性测试) | 未报,该行 `ViewTabBar` 仍 OK @ `:77` |

`MISSING COUNT: 2`,还原读数 `0`。变异全做在 README 的 **scratch 副本**上(检查器的 `--readme` 指向副本),`git status --porcelain` 全程只有本卡那两个条目 —— 不存在「临时改动误入 commit」的窗口。

**(b) 改前 README 回填探针。** 预判(先写):必须转红;新增诊断**恰好两条**、与所改两处一一对应;5 条既有 TS7006 原样携带;并且 —— 改前 typed 示例的坏键(`object` / `viewMode` / `fields`)**不会**贡献诊断,因为导入失败会把标注变成 error type、把键面**遮蔽**掉。

实测**与预判完全一致**(读数见上表)。第四条预判尤其要记:它意味着「改前红 / 改后绿」这条线**只**由两个 TS2305 承载;键面那一层**从来没有被探针覆盖过**,是改对导入路径之后才第一次可判 —— 这也是为什么键面对齐必须与路径修改同一 commit,以及为什么剩下 13 个无标注块的键面只能另立卡(#5077)。

方向即通常的「改前红 / 改后绿」,不适用 `??` 链、计数门那类反转情形(这是导入名不存在,不是取值判决)。

## 验证

- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **`81 successful, 81 total`**(4m9s;重活经 `flock -w 3600 /tmp/os-heavy-verify.lock` 串行 + `--max-old-space-size=4096`)。
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4516 tracked text file(s); skipped 85 binary)`;改动两文件另做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中。
- `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-view...' build` → rc=0(探针与名集合核对所依赖的构建产物)。

**docs-only 的 CI 形状**:`**/*.md` 与 `.changeset/**` 在 `paths-ignore` 里,Test / Type Check 各 job 的实质步骤会被 path-filter 短路成 skipped 而 job 报 success。按纪律计绿,但**类型证据是上面的本地仓根读数**,不是 CI 的(#5046 / #5053 / #5059 / #5069 先例)。

## 顺手立的卡(未认领,不夹带进本 PR)

- **#5077** — README 其余 13 个**无类型标注**的 schema 字面量块,键面渲染器一个都不读:`object`(真名 `objectName`)/ `viewMode` / `fields` / `mode` / `recordId` / `fieldConfig` / `nestedFields` / `tabs` / `pagination` / `searchable` / `sortable` / `enableDelete` / `onCreate` / `onUpdate` / `onDelete` / `onSubmit`,以及写进 schema 的 `dataSource`(真身是 `ObjectViewProps` 的必填 prop)。与本卡**不同性质**、不可切半,且两道门都看不见(无 import ⇒ 名集合核对不覆盖;有索引签名 ⇒ 编译探针不覆盖)。同族 #5057 / #5064,元卡 #4631。

顺带记入本 PR(不另立卡,是 README 新增内容的一部分):本包的注册命名空间不统一 —— `object-view` / `view` / `view:simple` 用 `plugin-view`,四个控件用 `view`;`view:simple` 因带命名空间实际落成 `plugin-view:view:simple`。都已按实际读数写进新表,未做任何改动主张。

## changeset

`.changeset/plugin-view-readme-truth-5014.md`,`@object-ui/plugin-view: patch`,口径同 #5046 / #5053 / #5059 / #5069:无代码/类型/运行时改动,声明 patch 是因为 `README.md` 在包的 `files` 里,随下次发布到 npm。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_