### PR TITLE
docs(skills): 脚手架指南的四处版本字面量改回仓内实测值 (#4981)

### DIFF
--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -326,7 +326,7 @@ double-displays it.
     "@object-ui/core": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^0.400.0"
+    "lucide-react": "^1.31.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/skills/objectui/guides/project-setup.md
+++ b/skills/objectui/guides/project-setup.md
@@ -48,9 +48,9 @@ Then configure the required files (see "Essential configuration files" below).
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.0.0",
-    "vite": "^6.0.0",
-    "@vitejs/plugin-react": "^4.0.0"
+    "typescript": "^6.0.3",
+    "vite": "^8.2.1",
+    "@vitejs/plugin-react": "^6.0.5"
   }
 }
 ```


### PR DESCRIPTION
Part of #4981 —— 内容半。门禁半(把 `skills/` 纳入 `doc-version-claims` 的扫描面,防复发)是单独一个 PR,分支 `claude/issue-4981-version-gate`,那一个挂 `Fixes #4981`。

⚠️ **skills/** 人合车道**:diff 全部落在 `skills/**`,按 #4865 的处置 —— PM 验收后转 ready,**不挂 auto-merge**,留维护者亲合。

## 改了什么

四处版本字面量,改前逐个在 `origin/main` @ `6098ecd08` 上复测(数字是「声明该依赖的清单数 / 全部一致」):

| 位置 | 原值 | 实测值 | 证据 |
| --- | --- | --- | --- |
| `skills/objectui/guides/project-setup.md:51` | `typescript ^5.0.0` | `^6.0.3` | 40 个清单声明,全部 `^6.0.3`(含仓根、`apps/console`、`examples/console-starter`) |
| `skills/objectui/guides/project-setup.md:52` | `vite ^6.0.0` | `^8.2.1` | 29 个清单,全部 `^8.2.1`(含 19/19 `packages/plugin-*`) |
| `skills/objectui/guides/project-setup.md:53` | `@vitejs/plugin-react ^4.0.0` | `^6.0.5` | 27 个清单,全部 `^6.0.5`;其中 `packages/plugin-*` **19/19** 一致(与 #4961 复核值相同) |
| `skills/objectui/guides/plugin-development.md:329` | `lucide-react ^0.400.0` | `^1.31.0` | 23 个清单,全部 `^1.31.0`;其中 `packages/plugin-*` **16** 个一致 |

**卡面「9 个包一致」这一读数已过时**:`lucide-react ^1.31.0` 现在是 16 个 plugin 包 / 23 个仓内清单一致,不是 9 个。这个差别不是无关紧要的 —— 它决定了门禁半能不能把这一行入锚(`skeletonDep` 的既有下限是「至少 10 个 plugin 包声明」),详见门禁 PR。

## 没动什么(判据同 #3827 / #3855)

同一个代码块里的 `react ^19.0.0` / `react-dom ^19.0.0`、`peerDependencies` 的 `^18.0.0 || ^19.0.0`、`tailwindcss ^4.0.0` 与 `@tailwindcss/vite ^4.0.0` 一律未动:peer 说的是「能接受什么」,由抄走这段的人自己拥有;tailwind 与仓内 `^4.3.3` 同 major,`^4.0.0` 本来就覆盖它,不是化石。

## changeset

**不需要**,两条独立证据:

1. 机械判定 —— 本分支工作树上跑 `node scripts/check-changeset-presence.mjs`:
   `Compared the working tree with 6098ecd08 (merge-base with origin/main): 2 file(s) changed, 0 of them under the src/ of a package the release covers … ✅ No source of a released package changed in this range, so no changeset is owed.`
2. 同类先例 —— 近期 `docs(skills):` 提交 #4866 / #4813 / #4786 / #4011 均无 changeset;唯一带 changeset 的那一个(#4826)是因为它同时改了 `packages/permissions` 的源码。

## 验证

- `pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts` → `Test Files 1 passed / Tests 18 passed`(本 PR 不改门禁,这里证明的是不回归)
- `pnpm exec turbo run type-check --concurrency=2` → `Tasks: 81 successful, 81 total`
- `node scripts/check-control-bytes.mjs` → OK(4520 个文件);`node scripts/check-skills-paths.mjs` → OK(93/94 路径解析)
- 改动文件 `grep -naP` 控制字节自扫:无命中

## 留给维护者的一个岔路(不在本 PR 内做判断)

`plugin-development.md` 的 `lucide-react` 这一行,除了「改成实测值」还有第二种处置 —— **整行删掉**:

- 该页的示例插件源码**从头到尾没有 import 过 lucide-react**(整个 `skills/` 里唯一的 lucide import 在 `rules/composition.md`,是另一份文件);
- `content/docs/guide/plugins.md` 里对应的同形骨架**根本没有这一行**;
- #3755 已经在生成器侧对同一个声明做过裁定:`create-plugin` 的 `DEPENDENCIES` 里原有 `lucide-react ^0.563.0`,被删而不是重新入锚,理由写在 `packages/create-plugin/src/templates.ts:106-121` —— 「这个仓库在 import 图标库的地方才声明它……想要图标的作者跑 `pnpm add lucide-react` 就会拿到当时的版本」。而 `^0.400.0` 恰好又是那条注释点名的形状:`0.x` 的 caret 跨不过 minor。

按卡面与分诊的交付形,本 PR 走的是「改成实测值」;删行属于卡面列的方向 2,会改变交付范围,故只在这里提出、不擅自执行。若维护者取删行,本 PR 的这一行改动作废,门禁 PR 里对应的那条 `KNOWN_CLAIMS` 条目一并删除即可(其余三行不受影响)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_