### PR TITLE
fix(plugin-form): 致谢面板按组件自己的 redirect 裁定渲染,拒绝时不再假承诺跳转 (#5073)

### DIFF
--- a/.changeset/embeddable-form-thankyou-countdown-verdict-5073.md
+++ b/.changeset/embeddable-form-thankyou-countdown-verdict-5073.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+A public form's thank-you panel no longer promises a redirect its own guard just
+refused, and the `texts.redirectBlocked` string can finally reach a screen.
+
+`EmbeddableForm` decided whether to redirect from `isRedirectUrlSafe` /
+`allowedRedirectHosts`, but the panel's copy was keyed on something else: whether
+a `thankYouPage.redirectUrl` had been *authored* (objectui#5073). An author who
+declared a cross-origin destination without allowlisting its host therefore got a
+submitter who was told `Redirecting in 3 seconds…` and was then never redirected.
+The guard did its job; the screen contradicted it. That screen is the terminal
+state of a public form, so nothing came after to correct the impression.
+
+On the same path, the `texts.redirectBlocked` string the refusal set was
+unreachable in every locale. It was recorded with `setError(...)`, whose banner
+lives in the form branch — and `setSubmitted(true)` has already run one statement
+earlier, so the component is showing the thank-you branch, which renders no error
+at all. That was the only assignment of the key anywhere; pressing
+`Submit Another Response` cleared it rather than showing it.
+
+Both now follow the verdict:
+
+- The countdown renders on `pendingRedirect` — the destination that was actually
+  accepted — and reads its seconds from the delay captured with it, so the
+  displayed wait is the wait being served. A refused destination, and the
+  honeypot's silent fake-success (which accepts no destination either), simply
+  omit the line.
+- A refused destination renders `texts.redirectBlocked` in the thank-you panel
+  when the author declared it — the case the key exists for, in the author's own
+  words to the public. Undeclared means silence; the author keeps the existing
+  `console.warn`, which is the channel for the person who can fix the
+  declaration.
+
+Which destinations are refused is unchanged: `isRedirectUrlSafe` and
+`allowedRedirectHosts` are untouched, as is the timer ownership introduced for
+objectui#5049. Nothing was ever at risk in the data — the write succeeds before
+any of this — the harm was a false statement on the confirmation screen and a
+shipped, translated string no user could see.

--- a/content/docs/guide/public-forms.md
+++ b/content/docs/guide/public-forms.md
@@ -123,6 +123,15 @@ bypasses this whitelist.
 match subdomains; the apex itself must be listed explicitly. Dangerous
 schemes (`javascript:`, `data:`) are always rejected.
 
+The thank-you panel follows that verdict rather than the declaration: the
+`Redirecting in N seconds…` line appears only for a destination that was
+**accepted**, and reads its countdown from the delay that destination was
+accepted with. When the destination is refused the line is omitted, and
+`texts.redirectBlocked` — if you declared it — is shown in the panel instead;
+leave it undeclared and the panel stays silent. Either way the refusal is
+logged with `console.warn`, which is where to look if a redirect you expected
+never happens.
+
 ### GDPR consent
 
 ```tsx

--- a/packages/plugin-form/src/EmbeddableForm.redirectVerdictCopy.test.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.redirectVerdictCopy.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5073 — the thank-you panel's copy must follow the component's own
+ * redirect VERDICT, not the mere fact that a `redirectUrl` was authored.
+ *
+ * Two facts were measured on `6098ecd08` before the fix, and both are pinned
+ * here:
+ *
+ * 1. The countdown paragraph rendered on `thankYou?.redirectUrl` — i.e. on
+ *    whether the author declared a destination. When `isRedirectUrlSafe`
+ *    refused that destination the submitter was still told
+ *    `Redirecting in 3 seconds…` and was then never redirected. The panel is
+ *    the terminal state of a public form, so nothing came after to correct it.
+ * 2. `texts.redirectBlocked` was unreachable. The refusal arm set it through
+ *    `setError(...)`, whose banner lives in the FORM branch — which the
+ *    component has already left by then, `setSubmitted(true)` having run one
+ *    statement earlier. The only assignment of that key could therefore never
+ *    reach a screen, in any locale.
+ *
+ * The countdown is now keyed on `pendingRedirect` — the destination that was
+ * actually ACCEPTED (the state PR #5070 introduced) — and the refusal is held
+ * separately from `error`, so the author's `redirectBlocked` copy renders in
+ * the panel the submitter is actually looking at.
+ *
+ * ## Why the cases are paired
+ *
+ * A negative case alone passes for the wrong reason: deleting the countdown
+ * outright also makes it absent on a refused destination. The accepted cases
+ * below therefore require the countdown to be PRESENT and, for the allowlisted
+ * one, require the navigation itself to still happen — so "absent" can only be
+ * earned by the verdict, never by subtraction.
+ *
+ * ## What this file deliberately does not touch
+ *
+ * `isRedirectUrlSafe` / `allowedRedirectHosts` — WHICH destinations are refused
+ * — is unchanged, and so is the relative-path-only question of objectui#4989.
+ * Every fixture below is judged by the guard exactly as it was before. Timer
+ * ownership (objectui#5049 / PR #5070) is pinned by its own file,
+ * `EmbeddableForm.redirectTimerLifetime.test.tsx`, and is untouched here.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+
+import { EmbeddableForm, type EmbeddableFormConfig } from './EmbeddableForm';
+
+// ObjectForm resolves field widgets through the global registry.
+registerAllFields();
+
+/** Cross-origin and NOT in `allowedRedirectHosts` — the guard refuses it. */
+const REFUSED_DESTINATION = 'https://evil.example.com/phish';
+/** Cross-origin but explicitly allowlisted below — the guard accepts it. */
+const ALLOWED_HOST = 'trusted.example.com';
+const ALLOWED_DESTINATION = `https://${ALLOWED_HOST}/ok`;
+/** Same-origin relative — accepted without any allowlist entry. */
+const SAME_ORIGIN_DESTINATION = '/thanks-5073';
+
+/** Short enough to outlive inside a test, long enough to observe before it fires. */
+const SHORT_DELAY_MS = 120;
+/** Distinctive seconds reading, so the countdown copy can be matched exactly. */
+const LONG_DELAY_MS = 5000;
+
+const THANK_YOU_TITLE = 'Thanks for your answer';
+/** The author's own words, addressed to the public — see the PM ruling on #5073. */
+const BLOCKED_COPY = 'We could not send you on. You can close this window.';
+
+const realSetTimeout = globalThis.setTimeout;
+/** Real-clock sleep — this file never fakes the clock (see the sibling file). */
+const sleep = (ms: number) => new Promise((resolve) => { realSetTimeout(resolve, ms); });
+
+function buildDataSource() {
+  return {
+    create: vi.fn(async (_obj: string, data: Record<string, unknown>) => ({ id: '1', ...data })),
+    update: vi.fn(),
+    delete: vi.fn(),
+    findOne: vi.fn(),
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+  };
+}
+
+function baseConfig(overrides: Partial<EmbeddableFormConfig> = {}): EmbeddableFormConfig {
+  return {
+    formId: 'f5073',
+    objectName: 'lead',
+    customFields: [{ name: 'email', label: 'Email', type: 'email', required: true } as any],
+    // The anti-bot minimum fill time is a different gate; disable it so submit
+    // reaches the redirect arm without fighting a 1.5s timer.
+    minFillTime: 0,
+    texts: { thankYouTitle: THANK_YOU_TITLE },
+    ...overrides,
+  };
+}
+
+let hrefSetter: ReturnType<typeof vi.fn<(url: string) => void>>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  hrefSetter = vi.fn<(url: string) => void>();
+
+  // `window.location.href = url` is the component's navigation call. Shadow just
+  // that accessor on the real Location instance so `origin` — which
+  // `isRedirectUrlSafe` reads — stays genuinely real and the guard genuinely
+  // runs on every fixture below.
+  const realHref = window.location.href;
+  Object.defineProperty(window.location, 'href', {
+    configurable: true,
+    get: () => realHref,
+    set: (value: string) => { hrefSetter(value); },
+  });
+
+  // The refusal's author-facing signal; kept out of the test output but
+  // asserted on where it is the point.
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  delete (window.location as any).href;
+});
+
+/** Renders the form and drives one successful submit through to `create`. */
+async function submitOnce(config: EmbeddableFormConfig, ds: ReturnType<typeof buildDataSource>) {
+  const view = render(
+    <EmbeddableForm
+      config={config}
+      // Prefilled programmatically so react-hook-form's required-field
+      // validation passes without racing a typed value into its state — the
+      // same reason the sibling EmbeddableForm suites prefill.
+      prefillParams={{ email: 'a@b.com' }}
+      dataSource={ds as any}
+    />,
+  );
+  await screen.findByLabelText(/email/i);
+  fireEvent.click(await screen.findByRole('button', { name: /^submit$/i }));
+  await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+  await screen.findByText(THANK_YOU_TITLE);
+  return view;
+}
+
+describe('objectui#5073 — the thank-you panel follows the redirect verdict', () => {
+  it('refused destination: omits the countdown and renders the author\'s redirectBlocked copy', async () => {
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({
+        thankYouPage: { redirectUrl: REFUSED_DESTINATION, redirectDelay: SHORT_DELAY_MS },
+        texts: { thankYouTitle: THANK_YOU_TITLE, redirectBlocked: BLOCKED_COPY },
+      }),
+      ds,
+    );
+
+    // No promise of a navigation the component has already refused.
+    expect(screen.queryByText(/Redirecting in/i)).toBeNull();
+    // The author declared copy for exactly this case; it belongs on the screen
+    // the submitter is looking at, which is the panel — not the form branch's
+    // error banner, which is no longer rendered by the time refusal happens.
+    expect(screen.getByText(BLOCKED_COPY)).toBeInTheDocument();
+
+    // And the refusal itself still holds, well past the declared delay.
+    await sleep(SHORT_DELAY_MS * 5);
+    expect(hrefSetter).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[EmbeddableForm] Blocked unsafe redirect target:',
+      REFUSED_DESTINATION,
+    );
+    // The write itself succeeded — refusing the redirect does not undo it.
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('refused destination without redirectBlocked: the panel says nothing about redirecting', async () => {
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({
+        thankYouPage: { redirectUrl: REFUSED_DESTINATION, redirectDelay: SHORT_DELAY_MS },
+      }),
+      ds,
+    );
+
+    // Silence is the ruling when the author declared no copy: no countdown, and
+    // no component-invented notice standing in for one. `/redirect/i` catches
+    // both the default countdown template and any hard-coded fallback.
+    expect(screen.queryByText(/redirect/i)).toBeNull();
+    // The author still gets told, on the channel that was always theirs.
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[EmbeddableForm] Blocked unsafe redirect target:',
+      REFUSED_DESTINATION,
+    );
+
+    await sleep(SHORT_DELAY_MS * 5);
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+
+  it('allowlisted cross-origin destination: keeps the countdown and still navigates', async () => {
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({
+        thankYouPage: { redirectUrl: ALLOWED_DESTINATION, redirectDelay: SHORT_DELAY_MS },
+        allowedRedirectHosts: [ALLOWED_HOST],
+        texts: { thankYouTitle: THANK_YOU_TITLE, redirectBlocked: BLOCKED_COPY },
+      }),
+      ds,
+    );
+
+    // Accepted: the promise is made, because it will be kept.
+    expect(screen.getByText(/Redirecting in/i)).toBeInTheDocument();
+    // …and the refusal copy is not shown for a destination that was accepted.
+    expect(screen.queryByText(BLOCKED_COPY)).toBeNull();
+
+    await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith(ALLOWED_DESTINATION));
+    expect(hrefSetter).toHaveBeenCalledTimes(1);
+  });
+
+  it('same-origin destination: the countdown reads the delay of the accepted destination', async () => {
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({
+        thankYouPage: { redirectUrl: SAME_ORIGIN_DESTINATION, redirectDelay: LONG_DELAY_MS },
+      }),
+      ds,
+    );
+
+    // 5000 ms accepted → "5 seconds". The reading comes from the destination
+    // that was accepted, so it cannot describe a wait nobody is serving.
+    expect(screen.getByText(/Redirecting in 5 seconds/i)).toBeInTheDocument();
+    expect(hrefSetter).not.toHaveBeenCalled(); // still counting down
+  });
+
+  it('honeypot fake-success: no countdown, since no destination was ever accepted', async () => {
+    const ds = buildDataSource();
+    const { container } = render(
+      <EmbeddableForm
+        config={baseConfig({
+          thankYouPage: { redirectUrl: SAME_ORIGIN_DESTINATION, redirectDelay: SHORT_DELAY_MS },
+        })}
+        prefillParams={{ email: 'a@b.com' }}
+        dataSource={ds as any}
+      />,
+    );
+
+    await screen.findByLabelText(/email/i);
+    // A bot blindly fills every input, including the off-screen honeypot.
+    const honeypot = container.querySelector(
+      'input[name="_company_website_2"]',
+    ) as HTMLInputElement | null;
+    expect(honeypot).not.toBeNull();
+    fireEvent.change(honeypot!, { target: { value: 'http://spam' } });
+    fireEvent.click(await screen.findByRole('button', { name: /^submit$/i }));
+
+    await screen.findByText(THANK_YOU_TITLE);
+    // The submit was never accepted, so no destination was either — the panel
+    // must not narrate a navigation that this path never arms.
+    expect(screen.queryByText(/Redirecting in/i)).toBeNull();
+    expect(ds.create).not.toHaveBeenCalled();
+
+    await sleep(SHORT_DELAY_MS * 5);
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-form/src/EmbeddableForm.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.tsx
@@ -227,6 +227,21 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
     { url: string; delayMs: number } | null
   >(null);
 
+  // Whether the guard below refused the authored destination (objectui#5073).
+  //
+  // Held apart from `error` on purpose. The refusal used to be recorded as
+  // `setError(texts.redirectBlocked ?? null)`, but the error banner lives in the
+  // form branch and `setSubmitted(true)` has already run one statement earlier —
+  // so that assignment, the only one of that key anywhere, could never reach a
+  // screen in any locale. This flag is read by the thank-you panel, which is the
+  // screen the submitter is actually looking at when a redirect is refused.
+  //
+  // A fact, not a copy of the string: the panel's other copy is read from
+  // `config.texts` at render time, and the author's `redirectBlocked` wording is
+  // read the same way. Only `pendingRedirect` captures its value at accept time,
+  // and for a reason that does not apply here — it feeds a running timer.
+  const [redirectRefused, setRedirectRefused] = useState(false);
+
   const honeypotRef = useRef<HTMLInputElement | null>(null);
   // Seeded lazily by the mount effect below — Date.now() is impure and must not
   // run during render. The effect always overwrites this before any submit.
@@ -349,7 +364,12 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
             setPendingRedirect({ url: rawRedirect, delayMs: delay });
           } else {
             console.warn('[EmbeddableForm] Blocked unsafe redirect target:', rawRedirect);
-            setError(config.texts?.redirectBlocked ?? null);
+            // The author keeps their console channel; the submitter gets the
+            // panel to match the verdict (objectui#5073). Nothing here re-judges
+            // the URL — `isRedirectUrlSafe` and `allowedRedirectHosts` are
+            // untouched; only the record of what they decided is now readable
+            // where the copy is rendered.
+            setRedirectRefused(true);
           }
         }
       } catch (err) {
@@ -371,6 +391,10 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
     // destination re-runs the effect above, whose cleanup clears the timer —
     // the cancellation is done by that `clearTimeout`, not by this line alone.
     setPendingRedirect(null);
+    // This is the only route back to the form, so it is also the only place the
+    // refusal has to be forgotten: a later submit that IS accepted must not
+    // inherit the previous attempt's refusal notice next to its countdown.
+    setRedirectRefused(false);
   }, []);
 
   // Branding styles
@@ -386,11 +410,23 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
   if (submitted) {
     const thankYou = config.thankYouPage;
     const texts = config.texts ?? {};
-    const redirectSeconds = Math.ceil((thankYou?.redirectDelay ?? 3000) / 1000);
-    const redirectingText = (texts.redirecting ?? 'Redirecting in {{seconds}} seconds…').replace(
-      '{{seconds}}',
-      String(redirectSeconds),
-    );
+    // The countdown describes the destination that was ACCEPTED, not the one
+    // that was authored (objectui#5073). Keyed on `thankYou?.redirectUrl`, this
+    // line told a submitter `Redirecting in 3 seconds…` even when the guard in
+    // the submit handler had just refused that destination — on the terminal
+    // screen of a public form, where nothing comes after to correct it.
+    //
+    // Reading the delay off `pendingRedirect` rather than re-deriving it from
+    // `config.thankYouPage` also leaves exactly one default for it (the `?? 3000`
+    // in the submit handler): the seconds displayed are the seconds being
+    // served, and a host that re-renders with a different `redirectDelay`
+    // mid-wait cannot make the two disagree.
+    const redirectingText = pendingRedirect
+      ? (texts.redirecting ?? 'Redirecting in {{seconds}} seconds…').replace(
+          '{{seconds}}',
+          String(Math.ceil(pendingRedirect.delayMs / 1000)),
+        )
+      : null;
     return (
       <div
         className={`min-h-screen flex items-center justify-center p-4 bg-gradient-to-b from-muted/40 via-background to-background ${className || ''}`}
@@ -411,8 +447,16 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
               {texts.submitAnother ?? 'Submit Another Response'}
             </Button>
           )}
-          {thankYou?.redirectUrl && (
+          {redirectingText && (
             <p className="text-xs text-muted-foreground">{redirectingText}</p>
+          )}
+          {/* Refused destination: the author's own words to the public, shown
+              only because the author declared them for this case. Undeclared
+              means silence here — an operational message the author did not
+              write is not the submitter's to read, and `console.warn` above
+              already told the one person who can fix the declaration. */}
+          {redirectRefused && texts.redirectBlocked && (
+            <p className="text-xs text-muted-foreground">{texts.redirectBlocked}</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
Fixes #5073

## 问题

`EmbeddableForm` 由 `isRedirectUrlSafe` / `allowedRedirectHosts` 裁定是否跳转,致谢面板的文案却按另一件事渲染 —— 作者是否**声明**了 `thankYouPage.redirectUrl`。于是作者声明了跨源目的地却没把其 host 放进 allow-list 时,提交者被告知「Redirecting in 3 seconds…」而后永远不会被跳转:守卫尽了职,屏幕却否认它。那是公开表单的终态屏,后面没有任何东西来纠正这一印象。

同一路径上第二个事实:拒绝分支设置的 `texts.redirectBlocked` 在任何语言下都不可达。它经 `setError(...)` 记录,而 error 横幅住在表单分支 —— `setSubmitted(true)` 已在上一条语句执行,组件已切到不渲染任何 error 的致谢分支。那是该键在全仓唯一的赋值处;按下「Submit Another Response」是清掉它而不是显示它。

## 前提验证:基线复现读数(实测,非推断)

在基线 `6098ecd08`(含 PR #5070 的 `e354dd064`)上先写了一份**正向断言 bug** 的临时探针(`EmbeddableForm.tmp5073BaselineProbe.test.tsx`,读数取完即删,未进本 PR),避免两个事实在同一个测试里互相遮蔽:

```
Test Files  1 passed (1)
      Tests  2 passed (2)
```

- **FACT 1 绿**:非白名单跨源 `redirectUrl` 提交后,面板逐字渲染 `Redirecting in 3 seconds…`;等过 5 倍延迟后 `window.location.href` 的 setter **零次**被调用,`console.warn('[EmbeddableForm] Blocked unsafe redirect target:', …)` 已发出 —— 承诺与裁定确实相反。
- **FACT 2 绿**:同一次提交里 `texts.redirectBlocked` 的文案在致谢面板查不到;按下「Submit Another Response」回到表单分支后仍查不到,且 `[role="alert"]` 在文档中不存在 —— 该字符串确实无处可达。

同时,新钉子测试在基线上跑出的是 3 红 2 绿,失败三条正是三处「倒计时应缺席」的断言(其中一条的报文即 `Received: Redirecting in 1 seconds…`),两条「已接受目的地」的正向断言基线本就绿 —— 与修复后的方向一致。

## 改动

PM 代裁(认领评论 5321007178,**留否决窗**;若维护者不认可可直接推翻本 PR 的取舍):倒计时按**实际被接受的目的地**渲染;拒绝时略去倒计时,若作者声明了 `texts.redirectBlocked` 则在致谢面板渲染该文案(作者写给公众的话,受众由作者的声明选择),未声明则静默略去。

- 倒计时改按 `pendingRedirect`(#5049 / PR #5070 引入的「已接受目的地」state)渲染,秒数取与目的地一同捕获的 `delayMs` —— 显示的等待就是正在服务的等待,并把 `?? 3000` 默认值收敛回提交处理器这一处(面板不再二次推导)。被拒绝的目的地、以及蜜罐的静默假成功(它同样没有接受任何目的地),都只是略去该行。
- 拒绝的记录从 `setError(...)` 换成独立的 `redirectRefused` 布尔 state,由致谢面板读取;文案本身仍在渲染期从 `config.texts` 读,与面板其余文案一致。`handleReset` 是回到表单分支的唯一路径,因此也是唯一需要清除它的地方。
- `console.warn` 原样保留 —— 能改声明的人在那一端。
- 文档:`content/docs/guide/public-forms.md` 的 open-redirect 一节补了三句,说明面板跟随裁定、以及 `redirectBlocked` 声明与否的两种表现。

⛔ **未动**:`isRedirectUrlSafe` / `allowedRedirectHosts` 的判定本身(哪些目的地被拒绝一字未改);#5049 / PR #5070 的定时器所有权机制;#4989 的 relative-only 并轨问题(卡面已划出)。README 未碰(同包另一席在改)。

## 钉子测试(成对,防「删倒计时换绿」)

新增 `packages/plugin-form/src/EmbeddableForm.redirectVerdictCopy.test.tsx`,5 条:

1. 非白名单跨源 + 声明 `redirectBlocked` → 倒计时**缺席**、该文案**在场**、过 5 倍延迟仍零导航、warn 已发。
2. 非白名单跨源 + 未声明 → 面板对 redirect **只字不提**(`/redirect/i` 零命中,连组件自造的兜底文案也一并挡住)、零导航、warn 仍发。
3. 白名单跨源 → 倒计时**在场**、`redirectBlocked` 文案**不在场**、且**照常跳到目的地**。
4. 同源目的地(5000ms)→ 倒计时读作 `Redirecting in 5 seconds`,秒数来自被接受目的地的 delay。
5. 蜜罐假成功 + 已声明 redirectUrl → 倒计时缺席、`create` 未被调用、零导航。

## 反向验证(先书面预判,commit 后变异,`git checkout --` 还原)

| 变异 | 预判 | 实测 | 一致 |
| --- | --- | --- | --- |
| A:倒计时条件退回按 `thankYou?.redirectUrl`,秒数退回从 `config.thankYouPage` 二次推导 | 用例 1 / 2 / 5 红(三处「倒计时缺席」断言),用例 3 / 4 绿(已接受目的地两种写法下都渲染,不该动) | 3 红 2 绿,红在 `:157` `:186` `:256` —— 正是那三处断言 | 是 |
| B:剪掉 `redirectBlocked` 的渲染分支 | **仅**用例 1 红(`getByText(BLOCKED_COPY)`);2 未声明该文案、3 断言的正是该文案**不在场**、4 / 5 不涉及,故都应绿 | 1 红 4 绿,红在 `:161`,报文 `Unable to find an element with the text: We could not send you on…` | 是 |

两次变异的 vitest 原文读数(表格单元格容不下竖线,原样附此):

```
变异 A:  Tests  3 failed | 2 passed (5)
变异 B:  Tests  1 failed | 4 passed (5)
还原后:  Tests  9 passed (9)   (钉子文件 + PR #5070 红线文件同跑)
```

两条变异分别击中两个事实,且各自的绿组说明另一半断言不是靠同一处逻辑撑着。

## 验证

- 构建先行:`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-form^...' build` ✅
- `pnpm exec vitest run packages/plugin-form/` → `Test Files 54 passed (54) / Tests 548 passed (548)` ✅(含 PR #5070 的红线文件 `EmbeddableForm.redirectTimerLifetime.test.tsx` 4 条全绿)
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → `Tasks: 81 successful, 81 total` ✅
- `pnpm exec eslint` 改动两文件 → 0 error(仅既有 `no-explicit-any` / `react-refresh` warning)
- `node scripts/check-control-bytes.mjs` ✅;改动文件另行自扫控制字符零命中
- `node scripts/check-changeset-presence.mjs` ✅(`@object-ui/plugin-form: patch`)

基线 BASE = `6098ecd08a8c884b22a4130571d17af1ffafebdb`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_