### PR TITLE
docs(plugins): 三个插件文档页按真实 register 键表重写虚构的 `*Components` 手动注册

### DIFF
--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -153,22 +153,60 @@ spec rejects `pane` on non-split form types at parse.)
 
 ## Usage
 
-### Auto-registration (Side-effect Import)
+### Registration is a side effect of the import
 
 ```plaintext
 import '@object-ui/plugin-form';
 ```
 
-### Manual Registration
+That single import is the whole of registration — there is no components map to
+iterate over. Importing the entry runs the six `ComponentRegistry.register(...)`
+calls in `packages/plugin-form/src/index.tsx`, which claim exactly these schema
+types:
+
+| Namespaced key | Bare-name fallback | Renderer behind it |
+| --- | --- | --- |
+| `plugin-form:object-form` | `object-form` | `ObjectForm` — metadata-driven form over one record |
+| `view:form` | none — `skipFallback: true` | the same renderer, under the view protocol |
+| `plugin-form:embeddable-form` | `embeddable-form` | `EmbeddableForm` — standalone public form |
+| `plugin-form:form-analytics` | `form-analytics` | `FormAnalytics` — submission dashboard |
+| `plugin-form:object-master-detail-form` | `object-master-detail-form` | `MasterDetailForm` — parent plus child line items in one submit |
+| `record:line_items` | none — `skipFallback: true` | `LineItemsPanel` — child grid bound to the record on the page |
+
+`ComponentRegistry.register` publishes `namespace:type`, and — unless the call
+passes `skipFallback: true` — the bare `type` as a back-compat fallback
+(`packages/core/src/registry/Registry.ts:194`, fallback at `:226`). The two
+`skipFallback` calls here are deliberate: bare `form` stays the basic
+`@object-ui/components` form, and bare `line_items` is left to whoever else
+claims it.
+
+### Registering a component under your own key
+
+To serve one of this package's components under a key of your own, register the
+exported component — that is what a manual registration is here:
 
 ```plaintext
-import { formComponents } from '@object-ui/plugin-form';
 import { ComponentRegistry } from '@object-ui/core';
+import { ObjectForm } from '@object-ui/plugin-form';
 
-Object.entries(formComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
-});
+ComponentRegistry.register('my-form', ObjectForm, { namespace: 'my-app' });
 ```
+
+The renderers this package registers for *itself* are internal wrappers rather
+than these exported components. `SchemaRenderer` hands a registered component
+its `schema`, but never a `dataSource` — that travels on
+`SchemaRendererContext` — so each wrapper resolves it from the context first.
+`ObjectForm` takes `dataSource` as a prop (optional, because inline
+`customFields` need no adapter), so a custom-key registration either supplies
+one or wraps the component the same way.
+
+The components are on the package's export surface — `ObjectForm`,
+`TabbedForm`, `WizardForm`, `SplitForm`, `DrawerForm`, `ModalForm`,
+`EmbeddableForm`, `MasterDetailForm`, `LineItemsPanel`, `FormAnalytics`,
+`FormSectionContainer` — alongside the layout helpers (`applyAutoLayout`,
+`inferColumns`, `filterCreateModeFields`, …) and the per-container schema types
+(`TabbedFormSchema`, `WizardFormSchema`, `ModalFormSchema`, …). There is no
+aggregate map among them.
 
 ## Examples
 

--- a/content/docs/plugins/plugin-grid.mdx
+++ b/content/docs/plugins/plugin-grid.mdx
@@ -109,22 +109,57 @@ view whose columns are all `none` (or carry no `summary`) has no footer.
 
 ## Usage
 
-### Auto-registration (Side-effect Import)
+### Registration is a side effect of the import
 
 ```plaintext
 import '@object-ui/plugin-grid';
 ```
 
-### Manual Registration
+That single import is the whole of registration — there is no components map to
+iterate over. Importing the entry runs the three `ComponentRegistry.register(...)`
+calls in `packages/plugin-grid/src/index.tsx`, which claim exactly these schema
+types:
+
+| Namespaced key | Bare-name fallback | Renderer behind it |
+| --- | --- | --- |
+| `plugin-grid:object-grid` | `object-grid` | `ObjectGridRenderer` — the data grid, queried from an object |
+| `view:grid` | none — `skipFallback: true` | the same renderer, under the view protocol |
+| `plugin-grid:import-wizard` | `import-wizard` | `ImportWizardRenderer` — spreadsheet / clipboard import |
+
+`ComponentRegistry.register` publishes `namespace:type`, and — unless the call
+passes `skipFallback: true` — the bare `type` as a back-compat fallback
+(`packages/core/src/registry/Registry.ts:194`, fallback at `:226`).
+
+**Bare `grid` is deliberately not this plugin's.** `skipFallback: true` on the
+`view:grid` call keeps the data grid from claiming it, because `grid` belongs to
+the CSS Grid *layout* container in `@object-ui/components`
+(`packages/components/src/renderers/layout/grid.tsx:50`). Reach the data grid as
+`object-grid`, or as `view:grid` when you want the namespaced spelling.
+
+### Registering the renderer under your own key
+
+To serve the data grid under a key of your own, register the exported renderer —
+that is what a manual registration is here:
 
 ```plaintext
-import { gridComponents } from '@object-ui/plugin-grid';
 import { ComponentRegistry } from '@object-ui/core';
+import { ObjectGridRenderer } from '@object-ui/plugin-grid';
 
-Object.entries(gridComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
+ComponentRegistry.register('my-grid', ObjectGridRenderer, {
+  namespace: 'my-app',
+  label: 'My Grid',
+  category: 'plugin',
 });
 ```
+
+`ObjectGrid`, `ObjectGridRenderer`, `VirtualGrid`, `SplitPaneGrid`,
+`ImportWizard`, `InlineEditing` and `FormulaBar` are on the package's export
+surface, alongside the hooks (`useGroupedData`, `useColumnSummary`,
+`useCellClipboard`, …) and the component prop types
+(`ObjectGridComponentProps`, `VirtualGridProps`, …). There is no aggregate map
+among them, and the *schema* types are not here either — they live in
+`@object-ui/types`, because the schema is the shared authoring contract rather
+than this package's component API.
 
 ## Examples
 

--- a/content/docs/plugins/plugin-view.mdx
+++ b/content/docs/plugins/plugin-view.mdx
@@ -58,22 +58,58 @@ npm install @object-ui/plugin-view
 
 ## Usage
 
-### Auto-registration (Side-effect Import)
+### Registration is a side effect of the import
 
 ```plaintext
 import '@object-ui/plugin-view';
 ```
 
-### Manual Registration
+That single import is the whole of registration — there is no components map to
+iterate over. Importing the entry runs the seven `ComponentRegistry.register(...)`
+calls in `packages/plugin-view/src/index.tsx`, which claim exactly these schema
+types:
+
+| Namespaced key | Bare-name fallback | Renderer behind it |
+| --- | --- | --- |
+| `plugin-view:object-view` | `object-view` | `ObjectViewRenderer` — list plus integrated create / edit |
+| `plugin-view:view` | `view` | the same renderer, registered as an alias |
+| `plugin-view:view:simple` | `view:simple` | `SimpleViewRenderer` — container-only view |
+| `view:view-switcher` | `view-switcher` | `ViewSwitcher` |
+| `view:filter-ui` | `filter-ui` | `FilterUI` |
+| `view:sort-ui` | `sort-ui` | `SortUI` |
+| `view:shared-view-link` | `shared-view-link` | `SharedViewLink` |
+
+Both spellings resolve here: `ComponentRegistry.register` publishes
+`namespace:type` and, unless the call passes `skipFallback: true`, the bare
+`type` as a back-compat fallback (`packages/core/src/registry/Registry.ts:194`,
+fallback at `:226`). No call in this package sets `skipFallback`. Note the
+namespaces are not uniform — `object-view`, `view` and `view:simple` register
+under `plugin-view`, the four control components under `view`.
+
+`ObjectViewRenderer` and `SimpleViewRenderer` are internal wrappers and are not
+exported: the wrapper resolves `dataSource` from the renderer context and hands
+the schema to `ObjectView`, which takes `dataSource` as a required prop rather
+than as a schema key.
+
+### Registering a component under your own key
+
+To serve one of this package's components under a key of your own, register the
+exported component — that is what a manual registration is here:
 
 ```plaintext
-import { viewComponents } from '@object-ui/plugin-view';
 import { ComponentRegistry } from '@object-ui/core';
+import { ViewSwitcher } from '@object-ui/plugin-view';
 
-Object.entries(viewComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
-});
+ComponentRegistry.register('my-switcher', ViewSwitcher, { namespace: 'my-app' });
 ```
+
+`ObjectView`, `ViewSwitcher`, `FilterUI`, `SortUI`, `SharedViewLink`,
+`ViewTabBar` and `ManageViewsDialog` are on the package's export surface,
+alongside the derivation helpers (`deriveRecordSurface`, `deriveFieldOptions`,
+`toFilterGroup`, `toSortItems`, …) and the component prop types
+(`ObjectViewProps`, `ViewSwitcherProps`, …). There is no aggregate map among
+them, and no schema types — the authored `object-view` node is typed by
+`@object-ui/types`.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #5076

基线 `origin/main` @ `03e5f972a160998a694742bd7c72149ae2fa3d8e`(卡面读数取自 `6098ecd08`,本 PR 在 `03e5f972a` 上逐行复测,行号与判定完全一致)。

## 前提复测:卡面四行照抄复核,全部成立

```
$ git grep -nw -E "formComponents|gridComponents|viewComponents|dashboardComponents" -- content/docs
content/docs/plugins/plugin-dashboard.mdx:73:import { dashboardComponents } from '@object-ui/plugin-dashboard';
content/docs/plugins/plugin-dashboard.mdx:76:Object.entries(dashboardComponents).forEach(([type, component]) => {
content/docs/plugins/plugin-form.mdx:165:import { formComponents } from '@object-ui/plugin-form';
content/docs/plugins/plugin-form.mdx:168:Object.entries(formComponents).forEach(([type, component]) => {
content/docs/plugins/plugin-grid.mdx:121:import { gridComponents } from '@object-ui/plugin-grid';
content/docs/plugins/plugin-grid.mdx:124:Object.entries(gridComponents).forEach(([type, component]) => {
content/docs/plugins/plugin-view.mdx:70:import { viewComponents } from '@object-ui/plugin-view';
content/docs/plugins/plugin-view.mdx:73:Object.entries(viewComponents).forEach(([type, component]) => {

$ git grep -nw formComponents -- packages/plugin-form/src   # 零命中
$ git grep -nw gridComponents -- packages/plugin-grid/src   # 零命中
$ git grep -nw viewComponents -- packages/plugin-view/src   # 零命中
```

邻近词反查(全仓 `git grep -nw`)确认三个名字只出现在这三个 mdx 与三份已落地 changeset 的**引述**里,源码零命中。

### 三文件判定表

| 文件 | 行(`6098ecd08` / `03e5f972a` 一致) | 名字 | 该名字在对应包 `dist/index.d.ts` 导出面 | 判定 | 本 PR |
| --- | --- | --- | --- | --- | --- |
| `content/docs/plugins/plugin-form.mdx` | `:165` / `:168` | `formComponents` | 不在(51 个导出名) | **虚构**,照抄抛 TypeError / 编译 TS2305 | ✅ 改写 |
| `content/docs/plugins/plugin-grid.mdx` | `:121` / `:124` | `gridComponents` | 不在(49 个导出名) | **虚构**,同上 | ✅ 改写 |
| `content/docs/plugins/plugin-view.mdx` | `:70` / `:73` | `viewComponents` | 不在(39 个导出名) | **虚构**,同上 | ✅ 改写 |
| `content/docs/plugins/plugin-dashboard.mdx` | `:73` / `:76` | `dashboardComponents` | 名字真实(`packages/plugin-dashboard/src/index.tsx`) | 错的是键词汇表,归 #5064 | ⛔ 未碰 |

`content/docs/plugins/plugin-map.mdx` 归 #5019,未碰。`content/docs/releases/**` 零触碰。未新增任何导出或 re-export。

## 改法

与 README 侧已落地的三单同一口径(#5011 → PR #5079、#5013 → PR #5071、#5014 → PR #5078,先读了这三个 PR 的对应节作基准)。每处删掉虚构段,换成三节真话:

1. **注册是 import 的副作用** —— 没有可迭代的组件表;
2. **各包真实 register 键表** —— namespaced 键 + bare 兜底,含 `skipFallback` 语义;
3. **「把导出组件挂到自己的键上」才是这里的手动注册** —— 示例用真实导出名。

### 键表出处:从 `ComponentRegistry.register(` 调用现场抄,⛔ 不从文档反推

```
$ git grep -nE "ComponentRegistry\.register\(" -- packages/plugin-form/src packages/plugin-grid/src packages/plugin-view/src
packages/plugin-form/src/index.tsx:100:  ComponentRegistry.register('object-form', ObjectFormRenderer, {
packages/plugin-form/src/index.tsx:159:  ComponentRegistry.register('form', ObjectFormRenderer, {
packages/plugin-form/src/index.tsx:211:  ComponentRegistry.register('embeddable-form', EmbeddableFormRenderer, {
packages/plugin-form/src/index.tsx:232:  ComponentRegistry.register('form-analytics', FormAnalyticsRenderer, {
packages/plugin-form/src/index.tsx:276:  ComponentRegistry.register('object-master-detail-form', MasterDetailFormRenderer, {
packages/plugin-form/src/index.tsx:356:  ComponentRegistry.register('line_items', LineItemsPanelRenderer, {
packages/plugin-grid/src/index.tsx:181:  ComponentRegistry.register('object-grid', ObjectGridRenderer, {
packages/plugin-grid/src/index.tsx:193:  ComponentRegistry.register('grid', ObjectGridRenderer, {
packages/plugin-grid/src/index.tsx:216:  ComponentRegistry.register('import-wizard', ImportWizardRenderer, {
packages/plugin-view/src/index.tsx:66:  ComponentRegistry.register('object-view', ObjectViewRenderer, {
packages/plugin-view/src/index.tsx:100:  ComponentRegistry.register('view', ObjectViewRenderer, {
packages/plugin-view/src/index.tsx:106:  ComponentRegistry.register('view-switcher', ViewSwitcher, {
packages/plugin-view/src/index.tsx:132:  ComponentRegistry.register('filter-ui', FilterUI, {
packages/plugin-view/src/index.tsx:160:  ComponentRegistry.register('sort-ui', SortUI, {
packages/plugin-view/src/index.tsx:183:  ComponentRegistry.register('shared-view-link', SharedViewLink, {
packages/plugin-view/src/index.tsx:217:  ComponentRegistry.register('view:simple', SimpleViewRenderer, {
```

`skipFallback` 语义来自 `packages/core/src/registry/Registry.ts:194`(`register` 签名),兜底分支在 `:226`(`if (meta?.namespace && !meta?.skipFallback)`)。全仓 `skipFallback: true` 在这三个包里只有三处:

```
$ git grep -n "skipFallback" -- packages/plugin-view/src packages/plugin-grid/src packages/plugin-form/src
packages/plugin-form/src/index.tsx:161:  skipFallback: true,     # 'form' + namespace 'view'  -> 只有 view:form
packages/plugin-form/src/index.tsx:358:  skipFallback: true,     # 'line_items' + namespace 'record' -> 只有 record:line_items
packages/plugin-grid/src/index.tsx:195:  skipFallback: true,     # 'grid' + namespace 'view'  -> 只有 view:grid
```

因此 plugin-view 的七处**全部**同时有 namespaced 键与 bare 兜底(页面里明写 "No call in this package sets `skipFallback`"),plugin-form 与 plugin-grid 各有 bare 键被刻意让出 —— bare `form` 留给 `@object-ui/components` 的基础表单,bare `line_items` 留给别的认领者,bare `grid` 留给 `packages/components/src/renderers/layout/grid.tsx:50` 的 CSS Grid 布局容器。

## 名集合核对与探针

导出名逐一对**已构建的** `dist/index.d.ts` 核过,方法照 #5043 规格(TS 编译器 API `checker.getExportsOfModule`),不是 grep src。

- **import 位**:三个 mdx 代码块里所有 `@object-ui/*` 具名导入 —— 改前 8 条不成立,改后 5 条(全部是本卡边界外、已另立卡的**错包路径**类型导入,见文末)。
- **散文位**:三段新文字里以「在导出面上」名义提到的 46 个标识符全部核过,含 3 条**缺席断言**(`ObjectViewRenderer` / `SimpleViewRenderer` 不导出、`formComponents` / `gridComponents` 不导出)—— 断言缺席与断言在场同样可证伪,同一趟跑。

```
Checked 46 prose-named identifier(s).
OK  every prose claim holds against dist.
```

- **可编译处探针**:三段新示例块逐字抽出,在 `strict` 下对同一批 `dist/index.d.ts` 编译 —— `TSC_EXIT=0`。⚠️ 键面盲区纪律:这条只证明**示例块**能编译,**不冒充键表的证据** —— 键表的证据是上面的 register 调用现场。

## 反向验证(预判先写,再跑)

**(a) 改前 mdx 段回填 —— 预判:核对/探针必须抓出三个虚构名。符合。**

改前整树跑名集合核对,预判 8 条(3 个虚构名 + 5 条错包路径),实测逐字命中:

```
8 problem(s):
  content/docs/plugins/plugin-form.mdx:165  formComponents is NOT exported by @object-ui/plugin-form
  content/docs/plugins/plugin-form.mdx:251  FormSchema is NOT exported by @object-ui/plugin-form
  content/docs/plugins/plugin-form.mdx:251  FormField is NOT exported by @object-ui/plugin-form
  content/docs/plugins/plugin-grid.mdx:121  gridComponents is NOT exported by @object-ui/plugin-grid
  content/docs/plugins/plugin-grid.mdx:336  GridSchema is NOT exported by @object-ui/plugin-grid
  content/docs/plugins/plugin-grid.mdx:336  GridColumn is NOT exported by @object-ui/plugin-grid
  content/docs/plugins/plugin-view.mdx:70  viewComponents is NOT exported by @object-ui/plugin-view
  content/docs/plugins/plugin-view.mdx:263  ObjectViewSchema is NOT exported by @object-ui/plugin-view
```

改后剩 5 条,恰为边界外的错包路径类型导入(本 PR 不动,见文末)。

被删的那段逐字回填进探针,预判 TS2305,实测:

```
snippet-old-form.ts(2,10): error TS2305: Module '"@object-ui/plugin-form"' has no exported member 'formComponents'.
```

**(b) 名集合塞假名自证 —— 预判:必须被抓。符合。** 往 grid 的新示例块塞 `gridComponentsRedux`:

```
content/docs/plugins/plugin-grid.mdx:146  gridComponentsRedux is NOT exported by @object-ui/plugin-grid
```

随即还原,`git diff --stat` 回到 40/5,无残留。

**⚠️ 一条如实记录的反常读数**:`check-doc-component-types` 改前改后**计数完全一致**(632 code blocks / 558 `type` literals / 469 registered / 89 exempted)。这**不是**本修复生效的证据 —— 该门禁核的是组件 `type` 值,不是 import 的**名字**,#5076 正文已指出这一族从它下面穿过去了。它的绿只说明本 PR 没有碰坏它;修复本身的证据是上面的名集合核对与 tsc 探针。

## 门禁读数

| 命令 | 结果 |
| --- | --- |
| `node scripts/check-doc-component-types.mjs` | ✅ `Every documented component type is registered.`(143 mdx / 632 blocks / 558 type literals / 659 registered keys;改前改后同数,见上) |
| `node scripts/check-doc-links.mjs` | ✅ `Links are valid across 13 scan roots.` |
| `node scripts/check-control-bytes.mjs` | ✅ `OK (scanned 4522 tracked text file(s); skipped 85 binary)` |
| 改动文件自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` | ✅ 零命中(超出门禁扫描面的自查) |
| `pnpm exec turbo run type-check --concurrency=2`(仓根) | ✅ `81 successful, 81 total` |
| MDX 3 编译(仓内 `@mdx-js/mdx@3.1.1`) | ✅ 三文件全 OK(散文里零裸 `{`) |

重活一律经 `flock -w 3600 /tmp/os-heavy-verify.lock` + `NODE_OPTIONS=--max-old-space-size=4096`。

## changeset:门禁实测判定「不需要」

卡面判断 `.mdx` 不随 npm 发布故不需要 changeset,**以门禁实测为准**而非沿用判断:

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with 03e5f972a (merge-base with origin/main): 3 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

`changeset:check`(`check-changeset-fixed` + `check-changeset-no-major`)同样绿。故本 PR 不带 changeset —— 是门禁**明确判定不欠**,不是省略。

## 边界外发现(已另立 issue,本 PR 一行未动)

改写过程中名集合核对稳定抓到的、与本卡**不同性质**的缺陷,按 Prime Directive #10 另立、未认领、未打 `finding` 标签(都是读者今天照抄就撞得上的具体缺陷,交 PM 分诊):

- **#5086** —— 三页 `import type` 从错误的包导入真实类型(TS2305,**非**虚构名):`plugin-form.mdx:251` 的 `FormSchema` / `FormField`、`plugin-grid.mdx:336` 的 `GridSchema` / `GridColumn`、`plugin-view.mdx:263` 的 `ObjectViewSchema`。是 #5011 / #5013 / #5014 第二条的文档站镜像,也正是本 PR 改后名集合核对剩下的那 5 条。
- **#5087** —— `plugin-grid.mdx` 整片示例的 `type: 'grid'`(落到 CSS Grid 布局容器)与 `header` / `accessorKey` 列词汇表(被 strict 的 `ListColumn` 拒绝)。#5065(README 侧)的文档站镜像,与渲染器侧的 #5068 同族不同层。
- **#5088** —— `plugin-view.mdx` 整片示例的 `object` / `viewMode` / `fields` 键面在 `ObjectViewSchema` 上一个都不成立(必填的是 `objectName`),照抄即空视图。#5077(README 侧)的文档站镜像。

三者的修都**不落在** #5065 / #5077 的完成范围内(那两单的范围是 `packages/*/README.md`),故按 #5076 自身「为什么单立一卡」的同一理由独立立卡,而非挂为子 issue。立卡前已按关键词 + 文件路径检索过 open issues,未见孪生。