### PR TITLE
docs(plugin-grid): README 示例按 ObjectGrid 真读的键面重写,type 从 grid 改回 object-grid

### DIFF
--- a/.changeset/plugin-grid-readme-example-key-face.md
+++ b/.changeset/plugin-grid-readme-example-key-face.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+plugin-grid's README examples now spell keys the grid actually reads.
+
+Ten example blocks and the `### Grid` sketch documented an authoring surface that
+does not exist. Every one declared `type: 'grid'`, which is deliberately NOT this
+plugin's key — the bare `grid` registration is `skipFallback: true`
+(`src/index.tsx:193`), because `grid` belongs to the CSS Grid *layout* container in
+`@object-ui/components`. A reader copying an example therefore rendered a layout
+container, not a data grid, and its unrecognised props leaked into the DOM as
+invalid HTML attributes (objectui#4787 is that runtime symptom; this is its
+documentation-side cause).
+
+The keys inside those blocks fared no better. `sortable`, `filterable` and `object`
+have zero read points anywhere in the repo — sorting is per column
+(`ListColumn.sortable`), filtering is the metadata `filter` plus `searchableFields`,
+and the object is `objectName` (required). `onRowClick`, `onSelectionChange`,
+`onCellChange`, `onRowSave` and `onBatchSave` are React props on
+`ObjectGridComponentProps`; a schema is a serialisable document and cannot carry a
+function, and the grid builds the inner table's handlers itself rather than reading
+any callback off the schema. Columns were written `{ header, accessorKey }` against
+a **strict** `ListColumnSchema` whose column is `{ field, label, … }`; `data` was
+written as a bare row array against a `ViewData`; `pagination` carried a
+`showSizeChanger` that its strict config has no room for; and `rowActions` was
+written as inline definitions with callbacks, then as `true`, against a `string[]`
+of action names.
+
+Every block is rewritten to the declared surface (`GRID_QUERY_INPUTS`,
+`src/index.tsx:145`) and annotated `ObjectGridSchema` — the annotation is the point,
+since an un-annotated `const schema = { … }` type-checks whatever is written in it.
+Documentation only; no renderer behaviour changes, and no capability was added to
+make an example true.

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -4,12 +4,13 @@ Grid plugin for Object UI - Advanced data grid with sorting, filtering, and pagi
 
 ## Features
 
-- **Data Grid** - Enterprise-grade data grid component
-- **Sorting** - Multi-column sorting support
-- **Filtering** - Column-level filtering
-- **Pagination** - Built-in pagination controls
-- **Row Selection** - Single and multi-row selection
-- **Customizable** - Tailwind CSS styling support
+- **Data grid** — enterprise-grade grid over one ObjectQL object
+- **Sorting** — per column (`ListColumn.sortable`), with an initial `sort` order
+- **Filtering & search** — a metadata `filter` on the query, plus a toolbar search
+  over `searchableFields`
+- **Pagination** — `pagination: { pageSize, pageSizeOptions }`
+- **Row selection** — `selection: { type: 'single' | 'multiple' }`
+- **Inline editing** — `editable`, persisted through the host's data source
 
 ## Installation
 
@@ -145,22 +146,47 @@ contract rather than this package's component API.
 
 ### Grid
 
-Data grid with advanced features:
+A grid node is an `ObjectGridSchema`: one required `objectName`, and keys drawn
+from the list this package **declares** as its authoring surface
+(`GRID_QUERY_INPUTS`, `src/index.tsx:145`) — the same list that feeds the designer
+panel and the generated `sdui-intrinsics.d.ts`, so what is authorable here is what
+the renderer reads.
 
 ```typescript
-{
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const grid: ObjectGridSchema = {
   type: 'object-grid',
-  objectName: string,
-  columns?: string[] | ListColumn[],
-  data?: any[],
-  sortable?: boolean,
-  filterable?: boolean,
-  pagination?: boolean | PaginationConfig,
-  selectable?: boolean,
-  onRowClick?: (row) => void,
-  className?: string
-}
+  objectName: 'users',
+  columns: ['name', 'email'],
+  sort: [{ field: 'created', order: 'desc' }],
+  pagination: { pageSize: 20 },
+  selection: { type: 'multiple' },
+};
 ```
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `objectName` | `string` (**required**) | The object queried. There is no `object`. |
+| `columns` | `string[] \| ListColumn[]` | Field names or column objects — see below. |
+| `label` | `I18nLabel` | Table caption and export title. |
+| `filter` | `ViewFilterRule[]` | Lowered to `$filter`. |
+| `sort` | `[{ field, order }]` | Initial order; a header click replaces it. |
+| `pagination` | `PaginationConfig` | `{ pageSize?, pageSizeOptions? }` — **strict**, and its presence is what enables paging. |
+| `searchableFields` | `string[]` | A non-empty list is what enables the toolbar search. |
+| `data` | `ViewData` | Bypasses the object query — see [Inline data](#inline-data). |
+| `selection` | `SelectionConfig` | `{ type: 'none' \| 'single' \| 'multiple' }`. |
+| `rowActions` / `bulkActions` | `string[]` | **Names** of actions, not definitions. |
+| `editable` / `singleClickEdit` | `boolean` | Inline editing — see [Inline Editing](#inline-editing). |
+| `navigation` | `NavigationConfig` | What a row click does, `{ mode: 'page' \| 'drawer' \| 'modal' \| 'split' \| 'none', … }`. |
+| `operations` | `object` | Toggles the built-in CRUD/export/import affordances, e.g. `{ delete: false }`. |
+| `rowHeight`, `frozenColumns`, `resizable`, `reorderableColumns`, `showColumnTypeIcons`, `rowColor`, `conditionalFormatting`, `grouping`, `aggregations`, `exportOptions`, `className` | | The rest of the declared surface. |
+
+**There is no `sortable`, `filterable`, `onRowClick`, `onSelectionChange`,
+`onCellChange`, `onRowSave`, `onBatchSave` or `object` on this schema.** The
+booleans do not exist at all; the five `on*` names are **component props**
+(`ObjectGridComponentProps`), which no metadata document can carry — see
+[Row callbacks are component props](#row-callbacks-are-component-props).
 
 ### Column Definition
 
@@ -247,199 +273,305 @@ view whose columns are all `none` (or carry no `summary`) has no footer.
 
 ## Examples
 
+Every example below is annotated `ObjectGridSchema`, which is the point: an
+un-annotated `const schema = { … }` type-checks no matter what is written in it,
+so a snippet that carries no annotation cannot tell you whether its keys are real.
+And note the `type` — `object-grid`, never `grid`. Bare `grid` renders the CSS Grid
+*layout container* from `@object-ui/components`
+([above](#the-schema-types-this-package-claims)), which is how a copied example ends
+up leaking `columns="[object Object]"` into the DOM instead of drawing a table
+(objectui#4787).
+
 ### Basic Grid
 
 ```typescript
-const schema = {
-  type: 'grid',
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
   columns: [
-    { header: 'ID', accessorKey: 'id', width: 80 },
-    { header: 'Name', accessorKey: 'name' },
-    { header: 'Email', accessorKey: 'email' },
-    { header: 'Role', accessorKey: 'role' },
-    { header: 'Status', accessorKey: 'status' }
+    { field: 'name', label: 'Name', width: 200, sortable: true },
+    { field: 'email', label: 'Email' },
+    { field: 'role', label: 'Role' },
+    { field: 'status', label: 'Status', type: 'select' },
   ],
-  data: [
-    { id: 1, name: 'John Doe', email: 'john@example.com', role: 'Admin', status: 'Active' },
-    { id: 2, name: 'Jane Smith', email: 'jane@example.com', role: 'User', status: 'Active' }
-  ],
-  sortable: true,
-  filterable: true,
-  pagination: true
+  sort: [{ field: 'name', order: 'asc' }],
+  pagination: { pageSize: 20 },
 };
 ```
 
-### Grid with Custom Cells
+Sorting is declared **per column** (`ListColumn.sortable`) — there is no top-level
+`sortable` switch, and none is needed: a column is sortable by default, so the key
+is there to turn one off.
+
+### Inline data
+
+A grid normally queries `objectName`. To render fixed rows instead — demos,
+fixtures, tests — give it a `ViewData` with the `value` provider. The rows go
+under `items`; a bare array is the deprecated `staticData` spelling.
 
 ```typescript
-const schema = {
-  type: 'grid',
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
   columns: [
-    { header: 'Name', accessorKey: 'name' },
-    { 
-      header: 'Status', 
-      accessorKey: 'status',
-      cell: (value) => ({
-        type: 'badge',
-        label: value,
-        variant: value === 'Active' ? 'success' : 'default'
-      })
-    },
-    {
-      header: 'Actions',
-      accessorKey: 'id',
-      cell: (value, row) => ({
-        type: 'button-group',
-        buttons: [
-          { label: 'Edit', onClick: () => console.log('Edit', row) },
-          { label: 'Delete', variant: 'destructive', onClick: () => console.log('Delete', row) }
-        ]
-      })
-    }
+    { field: 'name', label: 'Name' },
+    { field: 'email', label: 'Email' },
   ],
-  data: [/* data */]
+  data: {
+    provider: 'value',
+    items: [
+      { id: 1, name: 'John Doe', email: 'john@example.com', status: 'Active' },
+      { id: 2, name: 'Jane Smith', email: 'jane@example.com', status: 'Active' },
+    ],
+  },
 };
 ```
+
+### Cell appearance
+
+A column does not carry a render function. What it can say is which **cell type**
+to use and how to decorate the value — the same vocabulary the saved-view metadata
+uses, so a grid authored by hand and one authored in the designer render alike.
+
+```typescript
+import type { ListColumn } from '@object-ui/types';
+
+const columns: ListColumn[] = [
+  { field: 'status', type: 'select' },
+  { field: 'amount', type: 'currency', align: 'right', summary: 'sum' },
+  { field: 'name', link: true, prefix: { field: 'health', type: 'badge' } },
+  { field: 'owner_id', action: 'reassign' },
+];
+```
+
+`link: true` renders the value as a link to the record and `action: 'reassign'`
+runs a named action on click — that is the metadata form of the "Actions column"
+a render function used to be written for. A genuinely custom cell **renderer** is
+a component-layer concern: `VirtualGridColumn.cell` on `VirtualGrid`, a React prop,
+not an authoring key.
 
 ### Selectable Grid
 
 ```typescript
-const schema = {
-  type: 'grid',
-  columns: [/* columns */],
-  data: [/* data */],
-  selectable: true,
-  onRowClick: (row) => {
-    console.log('Row clicked:', row);
-  },
-  onSelectionChange: (selectedRows) => {
-    console.log('Selection changed:', selectedRows);
-  }
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
+  columns: ['name', 'email'],
+  selection: { type: 'multiple' },
+  bulkActions: ['delete', 'export'],
 };
 ```
+
+`selection.type` is the canonical spelling; the boolean `selectable` is a
+deprecated legacy alias, read only when `selection` is absent. Declaring bulk
+actions auto-enables multi-select, so the two keys agree by construction.
+
+To react to a selection in React, pass the `onRowSelect` **component prop** —
+see [Row callbacks are component props](#row-callbacks-are-component-props).
 
 ### Grid with Pagination
 
 ```typescript
-const schema = {
-  type: 'grid',
-  columns: [/* columns */],
-  data: [/* data */],
-  pagination: {
-    pageSize: 10,
-    showSizeChanger: true,
-    pageSizeOptions: [10, 20, 50, 100]
-  }
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
+  columns: ['name', 'email'],
+  pagination: { pageSize: 10, pageSizeOptions: [10, 20, 50, 100] },
 };
 ```
+
+`PaginationConfig` is a **strict** object of exactly `pageSize` and
+`pageSizeOptions` — a page-size picker is offered whenever `pageSizeOptions` is
+set, so there is no separate `showSizeChanger` toggle to write.
 
 ## Integration with Data Sources
 
-Connect grid to backend APIs:
+**The adapter is not a schema key.** A schema is a serialisable document; a live
+adapter is an object with methods, so it cannot travel in one. The grid reads its
+adapter from React context — `useSchemaContext()` at `src/index.tsx:80` — which the
+host installs once, above the whole tree:
 
-```typescript
+```tsx
+import { SchemaRendererProvider, SchemaRenderer } from '@object-ui/react';
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+import '@object-ui/plugin-grid';
+import type { ObjectGridSchema } from '@object-ui/types';
 
 const dataSource = createObjectStackAdapter({
   baseUrl: 'https://api.example.com',
-  token: 'your-auth-token'
+  token: 'your-auth-token',
 });
 
-const schema = {
+const schema: ObjectGridSchema = {
   type: 'object-grid',
-  dataSource,
-  object: 'users',
+  objectName: 'users',
   columns: [
-    { header: 'Name', accessorKey: 'name' },
-    { header: 'Email', accessorKey: 'email' },
-    { header: 'Created', accessorKey: 'created_at' }
+    { field: 'name', label: 'Name' },
+    { field: 'email', label: 'Email' },
+    { field: 'created', label: 'Created', type: 'datetime' },
   ],
-  pagination: true,
-  sortable: true,
-  filterable: true
+  filter: [{ field: 'status', operator: 'equals', value: 'active' }],
+  searchableFields: ['name', 'email'],
+  pagination: { pageSize: 20 },
 };
+
+export const App = () => (
+  <SchemaRendererProvider dataSource={dataSource}>
+    <SchemaRenderer schema={schema} />
+  </SchemaRendererProvider>
+);
 ```
+
+The object comes from `objectName`; there is no `object` key. Filtering is the
+metadata `filter` (lowered to `$filter`) and search is `searchableFields` (lowered
+to `$searchFields`) — a non-empty list is what puts the search box in the toolbar.
+
+> A top-level `dataSource` **does** mean something on a schema node, but it is not
+> this: it is the spec's element **binding** (`PageComponentSchema.dataSource`,
+> objectstack#6953) — a descriptor such as `{ object: 'users', view: 'my_view' }`,
+> resolved by `useElementDataSource`
+> (`packages/react/src/hooks/useElementDataSource.ts:139`) and mapped onto this
+> grid's keys by the gate at `src/index.tsx:88`. Handing that slot a live adapter is
+> rejected on purpose: the predicate refuses any value carrying a `find` method
+> (`packages/core/src/data-scope/element-data-source.ts:131`), so an adapter written
+> there is silently ignored rather than mistaken for a binding. Pass adapters
+> through the provider above; see the spec for the binding's own surface.
 
 ## Features
 
 ### Sorting
 
-Enable sorting on columns:
+Columns sort by default. `sortable` is a **per-column** key, used to turn a column
+off; the grid-level `sort` declares the order the grid opens with.
 
 ```typescript
-const schema = {
-  type: 'grid',
-  sortable: true,  // Enable sorting on all columns
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
+  sort: [{ field: 'created', order: 'desc' }],
   columns: [
-    { header: 'Name', accessorKey: 'name', sortable: true },
-    { header: 'Email', accessorKey: 'email', sortable: false }  // Disable for specific column
-  ]
+    { field: 'name', label: 'Name' },
+    { field: 'email', label: 'Email', sortable: false },
+  ],
 };
 ```
 
-### Filtering
+### Filtering and search
 
-Enable column filtering:
+There is no per-column filter key. A grid narrows its query two ways: a `filter`
+baked into the metadata, and a toolbar search over the fields named in
+`searchableFields`.
 
 ```typescript
-const schema = {
-  type: 'grid',
-  filterable: true,
-  columns: [
-    { header: 'Status', accessorKey: 'status', filterable: true }
-  ]
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
+  filter: [
+    { field: 'status', operator: 'equals', value: 'active' },
+    { field: 'created', operator: 'after', value: '2026-01-01' },
+  ],
+  searchableFields: ['name', 'email'],
+  columns: ['name', 'email', 'status'],
 };
 ```
 
 ### Row Actions
 
-Add actions to rows:
+`rowActions` and `bulkActions` are lists of **action names** — the actions
+themselves live in the object's action set, so the same action behaves identically
+wherever it is offered. They are `string[]`, not inline definitions with callbacks.
 
 ```typescript
-const schema = {
-  type: 'grid',
-  columns: [/* columns */],
-  rowActions: [
-    { label: 'View', onClick: (row) => console.log('View', row) },
-    { label: 'Edit', onClick: (row) => console.log('Edit', row) },
-    { label: 'Delete', onClick: (row) => console.log('Delete', row) }
-  ]
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
+  columns: ['name', 'email'],
+  rowActions: ['view', 'edit', 'delete'],
+  selection: { type: 'multiple' },
+  bulkActions: ['delete', 'export'],
 };
 ```
+
+### Row callbacks are component props
+
+`onRowClick`, `onRowSelect`, `onCellChange`, `onRowSave`, `onBatchSave`, `onEdit`,
+`onDelete`, `onBulkDelete` and `onAddRecord` are React props on
+`ObjectGridComponentProps` — they are functions, so no metadata document can hold
+them, and writing one into a schema does nothing at all: the grid builds the inner
+table's handlers itself and never reads a callback off the schema.
+
+```tsx
+import { ObjectGrid } from '@object-ui/plugin-grid';
+import type { ObjectGridComponentProps } from '@object-ui/plugin-grid';
+
+export const Grid = (props: ObjectGridComponentProps) => (
+  <ObjectGrid
+    {...props}
+    onRowClick={(record) => console.log('Row clicked:', record)}
+    onRowSelect={(rows) => console.log('Selection changed:', rows)}
+  />
+);
+```
+
+Note `onRowSelect` — the prop that reports a selection change is spelled that way;
+there is no `onSelectionChange` on this component.
+
+The declarative alternative, which *is* metadata and survives a round trip through
+storage, is `navigation`: `{ mode: 'page' | 'drawer' | 'modal' | 'split' | 'none' }`
+decides what a row click does without any host code.
 
 ### Inline Editing
 
 Enable inline cell editing for quick updates:
 
 ```typescript
-const schema = {
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
   type: 'object-grid',
   objectName: 'users',
   columns: [
-    { header: 'ID', accessorKey: 'id', editable: false },  // Read-only column
-    { header: 'Name', accessorKey: 'name' },  // Editable
-    { header: 'Email', accessorKey: 'email' },  // Editable
-    { header: 'Status', accessorKey: 'status' }  // Editable
+    { field: 'id', label: 'ID' },
+    { field: 'name', label: 'Name' },
+    { field: 'email', label: 'Email' },
+    { field: 'status', label: 'Status', type: 'select' },
   ],
-  editable: true,  // Enable editing globally
-  onCellChange: (rowIndex, columnKey, newValue, row) => {
-    console.log(`Cell at row ${rowIndex}, column ${columnKey} changed to:`, newValue);
-    console.log('Full row data:', row);
-    // Update your data source here
-    // Example: await dataSource.update(row.id, { [columnKey]: newValue });
-  }
+  editable: true,
+  singleClickEdit: false,
 };
 ```
 
+`editable` is the only switch: it is a grid-level flag, and edits persist through
+the host's data source (`dataSource.update`) with no callback to wire.
+
 **Inline Editing Features:**
-- **Double-click to edit**: Double-click any editable cell to enter edit mode
-- **Keyboard shortcuts**: 
+- **Double-click to edit**: double-click any editable cell to enter edit mode
+  (`singleClickEdit: true` opens it on the first click instead)
+- **Keyboard shortcuts**:
   - Press `Enter` on a focused cell to start editing
   - Press `Enter` while editing to save changes
   - Press `Escape` to cancel editing
-- **Column-level control**: Set `editable: false` on specific columns to prevent editing
-- **Visual feedback**: Editable cells show hover state to indicate they can be edited
-- **Automatic focus**: Input field is automatically focused and selected when entering edit mode
+- **Per-field read-only**: which cells open is decided by the **field definition**,
+  not by a column key — a field marked `readonly`, and computed/binary field types
+  (formula, autonumber, file, …), never open an editor
+  (`isFieldInlineEditable`, `src/inline-edit-options.ts:82`). There is no
+  `editable` key on `ListColumn`.
+- **Visual feedback**: editable cells show a hover state
+- **Automatic focus**: the input is focused and selected when editing begins
 
 **Use Cases:**
 - Quick data corrections
@@ -451,33 +583,47 @@ const schema = {
 
 Edit multiple cells across multiple rows and save them individually or all at once:
 
+The schema half is just `editable` — the save/cancel affordances appear on their
+own once a row has pending changes:
+
 ```typescript
-const schema = {
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
   type: 'object-grid',
   objectName: 'products',
   columns: [
-    { header: 'SKU', accessorKey: 'sku', editable: false },
-    { header: 'Name', accessorKey: 'name' },
-    { header: 'Price', accessorKey: 'price' },
-    { header: 'Stock', accessorKey: 'stock' }
+    { field: 'sku', label: 'SKU' },
+    { field: 'name', label: 'Name' },
+    { field: 'price', label: 'Price', type: 'currency', align: 'right' },
+    { field: 'stock', label: 'Stock', type: 'number', align: 'right' },
   ],
   editable: true,
-  rowActions: true,  // Show row-level save/cancel buttons
+};
+```
+
+Left alone, saving goes through the host's data source. A React host that needs to
+own persistence supplies `onRowSave` / `onBatchSave` as **component props** — and
+because they are props, they take the adapter from the host's own scope rather than
+from anything in the schema:
+
+```tsx
+import type { ObjectGridComponentProps } from '@object-ui/plugin-grid';
+
+type Persistence = Pick<ObjectGridComponentProps, 'onRowSave' | 'onBatchSave'>;
+
+const persistence = (
+  dataSource: NonNullable<ObjectGridComponentProps['dataSource']>,
+): Persistence => ({
   onRowSave: async (rowIndex, changes, row) => {
-    // Save a single row
-    console.log('Saving row:', rowIndex, changes);
-    await dataSource.update(row.id, changes);
+    await dataSource.update('products', row.id, changes);
   },
   onBatchSave: async (allChanges) => {
-    // Save all modified rows at once
-    console.log('Batch saving:', allChanges);
     await Promise.all(
-      allChanges.map(({ row, changes }) => 
-        dataSource.update(row.id, changes)
-      )
+      allChanges.map(({ row, changes }) => dataSource.update('products', row.id, changes)),
     );
-  }
-};
+  },
+});
 ```
 
 **Batch Editing Features:**
@@ -490,10 +636,10 @@ const schema = {
 - **Batch operations**: 
   - "Save All" button to save all modified rows at once
   - "Cancel All" button to discard all pending changes
-- **Flexible callbacks**:
-  - `onRowSave`: Called when saving a single row
-  - `onBatchSave`: Called when saving multiple rows at once
-  - `onCellChange`: Still called for immediate cell updates (legacy support)
+- **Flexible callbacks** — all three are `ObjectGridComponentProps`, never schema keys:
+  - `onRowSave`: called when saving a single row
+  - `onBatchSave`: called when saving multiple rows at once
+  - `onCellChange`: called for each staged cell edit
 
 **Example Workflow:**
 1. User edits multiple cells across different rows

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -389,8 +389,9 @@ const schema: ObjectGridSchema = {
 ```
 
 `PaginationConfig` is a **strict** object of exactly `pageSize` and
-`pageSizeOptions` — a page-size picker is offered whenever `pageSizeOptions` is
-set, so there is no separate `showSizeChanger` toggle to write.
+`pageSizeOptions` — there is no `showSizeChanger`, and none is needed: the pager
+always carries a rows-per-page picker, and `pageSizeOptions` only replaces the
+choices it offers with your own.
 
 ## Integration with Data Sources
 


### PR DESCRIPTION
Fixes #5065

`packages/plugin-grid/README.md` 的 10 个示例块 + `### Grid` 速写块整片按 ObjectGrid
真读的键面重写。纯文档,不改渲染器行为,不新增任何能力。

基线 `origin/main` = `d2cf8fd068d66ad5515ba2fc28d165bf51764b97`(含前置 PR #5071 的
`90517e1a2`,已验为祖先)。

## ⚠️ 前提门:`dataSource` 一行被推翻(卡面证据表有误,结论不变)

按 #5057 教训做 cast 感知复测,**9 个键里 8 个站得住,`dataSource` 被推翻**。卡面写
「`dataSource` | 0 | 从 `useSchemaContext()` 取,不从 schema 取」—— 这只在
`ObjectGrid.tsx` 内成立。实际上 `schema.dataSource` **有读取点**,且正是 #5057 那种
形状:cast 形、在**另一个包**里。

- `packages/plugin-grid/src/index.tsx:88` —— `ObjectGridRenderer` 用
  `ElementDataSourceGate` 包住 ObjectGrid,`mapping={OBJECT_GRID_DATA_SOURCE}`。
- `packages/react/src/hooks/useElementDataSource.ts:139` —— 真读取点,cast 形:
  `const raw = isRecord(schema) ? (schema as Record< string, unknown >).dataSource : undefined;`
- 语义是 spec 的 `PageComponentSchema.dataSource` **绑定**(objectstack#6953),
  形如 `{ object: 'users', view: 'my_view' }`,并把 `dataSource.object` 映射到
  `objectName`。
- 且 README 原文那个值形是被**主动拒绝**的:`packages/core/src/data-scope/element-data-source.ts:131`
  的 `isElementDataSourceConfig` 对任何带 `find` 方法的值返回 false —— 适配器实例塞进
  这个槽会被静默忽略,守卫就是为了防止把适配器错认成绑定。

按派发的前提门要求,**该键我停在事实层、不外推**:README 里只写了「适配器走
`SchemaRendererProvider`」这条已证的路,加一条注明「顶层 `dataSource` 是 spec 的元素
绑定、不是适配器槽」的引用块(带 file:line),**没有**把绑定的键面写成 plugin-grid
自己的授权面 —— 那需要渲染器契约裁定。见文末 open question。

卡面**主论点不受影响**:示例块整片键面不成立,已由 cast 感知普查 + 探针双向证实。

## cast 感知逐键复测表

口径:`schema.KEY` / `(schema as X).KEY` / `schema['KEY']` / 解构 / 中间变量转手,
先扫 `packages/plugin-grid/src`(非测试),再全仓扫一遍(消费半径)。

| 键 | plugin-grid 平/cast/括号 | 全仓复扫 | 判定 |
| --- | --- | --- | --- |
| `sortable` | 0 / 0 / 0 | 0 | 死键。真键是每列 `ListColumn.sortable` |
| `filterable` | 0 / 0 / 0 | 0(标识符在 plugin-grid src 内根本不存在) | 死键 |
| `onRowClick` | 0 / 0 / 0 | data-table 元素上 7 处,由 ObjectGrid 自己填 `navigation.handleClick` | 对 object-grid 是死键 |
| `onSelectionChange` | 0 / 0 / 0 | data-table 上 4 处,ObjectGrid 自填 | 死键;组件 prop 叫 `onRowSelect` |
| `onCellChange` | 0 / 0 / 0 | data-table 上 2 处,由 `ObjectGridComponentProps` 的 prop 喂 | 死键 |
| `onRowSave` | 0 / 0 / 0 | data-table 上 3 处,同上 | 死键 |
| `onBatchSave` | 0 / 0 / 0 | data-table 上 3 处,同上 | 死键 |
| `object` | 0 / 0 / 0 | 0 | 死键。真名 `objectName`(必填) |
| `dataSource` | 0 / 0 / 0 | **1 处 cast 形**(见上) | **推翻** |

正对照(证明口径抓得住 cast):`objectName` 44 处平读;`columnState` **4 处全是
`(schema as any)` cast 形**;`rowActionDefs` **3 处 cast 形** —— 同一份脚本在同一批文件
上把 cast 读点全抓出来了,零读数不是模式失灵。

关键否定证据:`ObjectGrid.tsx` 里**没有任何 `...schema` 展开**(grep 零命中),内层
data-table 的 schema 是逐键构造的(`:2727-2737`),每个回调槽都由 ObjectGrid 自己的
组件 prop / 内部 handler 填。所以作者写在 object-grid 节点上的回调既不被读、也不被转发。

### 复测口径自证(反向验证 a)

不改真 src:把 `ObjectGrid.tsx` 复制到 scratch,植入三种 cast 读点后跑同一脚本 ——

```
planted: (schema as any).sortable / schema['filterable'] / (schema as Record< string, any >).onRowClick
sortable       plain=0 cast=1 bracket=0 TOTAL=1
filterable     plain=0 cast=0 bracket=1 TOTAL=1
onRowClick     plain=0 cast=1 bracket=0 TOTAL=1
onCellChange   plain=0 cast=0 bracket=0 TOTAL=0   ← 未植入的对照,无误报
```

三种形态全部抓出,未植入的键保持 0。

## 读取点考古(数据路径与真键)

- `getDataConfig`(`ObjectGrid.tsx:388`)是数据路径的唯一入口:`schema.data`(ViewData)
  → 若是数组则转 `{ provider:'value', items }` → 否则原样;再 `schema.staticData`
  (已 `@deprecated`)→ 最后 `schema.objectName` 兜底成 `{ provider:'object', object }`。
  README 原文的 `data: [ …行… ]` 因此落在**运行时容忍支路**上,而声明类型是 `ViewData`。
  重写统一用 `{ provider: 'value', items: [...] }`,同时满足类型与运行时。
- 适配器:`src/index.tsx:80` `const { dataSource } = useSchemaContext() || {}` ——
  由宿主 `SchemaRendererProvider dataSource={…}` 注入,不是 schema 键。
- 授权面权威清单:`GRID_QUERY_INPUTS`(`src/index.tsx:145`),即发布给设计器 /
  `sdui-intrinsics.d.ts` 的那份;重写只用这份里的名字。
- 每列可编辑性由**字段定义**决定(`isFieldInlineEditable`,`src/inline-edit-options.ts:82`
  读 `readonly` 与不可内联的字段类型),`ListColumn` 上没有 `editable` 键。
- `PaginationConfig` = strict `{ pageSize?, pageSizeOptions? }`;`SelectionConfig` =
  strict `{ type }`;`ListColumnSchema` = strict,列键共 14 个,无 `header` /
  `accessorKey` / `cell` / `editable` / `filterable`。
- `rowActions` 真形:`ObjectGrid.tsx:747` `Array.isArray(schema.rowActions) ? … : []`,
  声明 `rowActions?: string[]` —— 动作**名**列表。

## 逐块判定 / 改因表

| # | 块 | 判定 | 因 |
| --- | --- | --- | --- |
| 1 | Features 顶部要点 | 改写 | 「Filtering - Column-level filtering」无对应键;改为点名真键(`filter` / `searchableFields` / 每列 `sortable`) |
| 2 | `### Grid` 速写 | 整块换 | 伪类型字面量,且 `sortable` / `filterable` / `onRowClick` 死键、`data?: any[]` 与 `pagination?: boolean \| PaginationConfig` 均与真类型不符。换成可编译的真值 + 授权键表 |
| 3 | Basic Grid | 整块换 | `type:'grid'` + `header/accessorKey` 列 + 裸数组 `data` + `sortable` / `filterable` + `pagination: true` |
| 4 | Inline data(新拆) | 新增 | 原 Basic 块把内联数据混在里面;`ViewData` 的 `value` 档单独讲清,并点名 `staticData` 已弃用 |
| 5 | Grid with Custom Cells | 改范围 | `cell:` 渲染函数不是 `ListColumn` 键(strict 拒收)。改为「Cell appearance」:`type` / `prefix` / `link` / `action` 这些真键;并说明自定义渲染函数属组件层(`VirtualGridColumn.cell`) |
| 6 | Selectable Grid | 整块换 | `selectable: true` 是弃用别名 → `selection: { type: 'multiple' }`;两个回调移交组件 prop 节 |
| 7 | Grid with Pagination | 整块换 | `type:'grid'`;`showSizeChanger` 不在 strict `PaginationConfig` 里 |
| 8 | Integration with Data Sources | 整块换 | 适配器改走 `SchemaRendererProvider`;`object` → `objectName`;`sortable`/`filterable` → `filter`/`searchableFields`;加 `dataSource` 绑定的事实引用块(见上,不外推) |
| 9 | Sorting | 整块换 | 顶层 `sortable` 不存在;改为每列 `sortable` + 顶层 `sort` |
| 10 | Filtering | 整块换 | `filterable` 顶层与每列都不存在;改为 `filter` + `searchableFields`,并明说没有按列筛选键 |
| 11 | Row Actions | 整块换 | `rowActions` 写成带 `onClick` 的内联定义,真形是动作名 `string[]` |
| 12 | Row callbacks are component props(新增) | 新增 | 五个 `on*` 需要一个正确去处,否则读者只知「不能写在 schema」不知写哪;附 `navigation` 这个声明式替代 |
| 13 | Inline Editing | 整块换 | 列上的 `editable: false` 不是列键;`onCellChange` 是组件 prop;补 `singleClickEdit` |
| 14 | Batch Editing | 整块换 | `rowActions: true` 对 `string[]` 是错形;两个 save 回调移交组件 prop,顺带修掉卡面点名的 `TS2304 Cannot find name 'dataSource'` |
| 15 | Batch Editing 要点列表 | 改写 | 三个回调标注为 `ObjectGridComponentProps`,并删掉 `onCellChange` 的「legacy support」误述 |
| — | Column Definition / Column Summaries / TypeScript Support / Exports | **不动** | PR #5071 已按真实面写对 |

`#5068`(accessorKey 运行时容忍分支)按派发要求未触碰:README 只按 strict
`ListColumnSchema` 的规范拼写写,不对那条支路作任何表述。

## 探针读数(含「预判不红」项)

⛔ 先声明纪律:**探针对授权 schema 键面全盲**,因为 `ObjectGridSchema extends BaseSchema`
而 `BaseSchema` 带索引签名 `[key: string]: any`(`packages/types/src/base.ts:318`)。
下面的绿**不能**用来证明键面正确;键面证据只认上面的读取点 grep。

抽块编译探针:抽 README 全部 typescript / tsx 代码块,各成一文件,strict、对已构建的
`dist/*.d.ts`。两种模式:`asis`(原样)与 `annotated`(把 `const schema = {` 补成
`const schema: ObjectGridSchema = {`,探针能取到的最强形)。

**改前(预判先写,再跑)**

预判会红:`type:'grid'` 字面量、缺必填 `objectName`、列的 `header/accessorKey`、
裸数组 `data`、`pagination: true`、`showSizeChanger`、`rowActions` 错形。
预判**不会**红(索引签名盲区):`sortable`、`filterable`、`onRowClick`、
`onSelectionChange`、`onCellChange`、`onRowSave`、`onBatchSave`、`dataSource`(作为键)、
`object`。

实测:

- `asis` rc=2,21 条 —— 17×TS7006 + 2×TS7031(无标注 schema 里的回调形参隐式 any)
  + 2×TS2304(`dataSource` 未声明标识符)。**9 个键面错误一条没报**,与预判一致。
- `annotated` rc=2 —— 新增 TS2322(`Type '"grid"' is not assignable to type '"object-grid"'`,
  7 块)、TS2353(`'header' does not exist in type …`)、TS2322(数组 vs ViewData)、
  TS2559(`Type 'true' has no properties in common with … pageSize/pageSizeOptions`)、
  TS2353(`'showSizeChanger' does not exist in type …`)、TS2322(`rowActions` 错形)。
  **仍然:9 个键一条没报。**

预判不符,如实记录两条:

1. **P2「缺必填 `objectName` 会红 TS2741」在 README 各块上并未出现。** 单独复现后确认
   机制:TS2741 只在该字面量**没有别的错**时才报 —— 同一字面量里只要有属性级错误
   (`type` 字面量不符、或嵌套列字面量的多余键),缺必填键就被抑制。最小复现:

   ```
   A: 只缺 objectName                      -> TS2741 ✅ 报
   B: 缺 objectName + sortable/filterable   -> 只报 TS2741(两个键零诊断,盲区实证)
   E: 缺 objectName + 列里有 header         -> 只报 TS2353,TS2741 被抑制
   F: 缺 objectName + type:'grid'           -> 只报 TS2322,TS2741 被抑制
   ```

   结论:探针的红**不是**问题清单,绿更说明不了什么。B 行同时是索引签名盲区最干净的
   实证 —— 加两个假键,诊断数不变。
2. **S1「加标注会让隐式 any 诊断消失」不成立。** 我预判索引签名会给回调提供 `any` 的
   上下文类型从而吞掉 TS7006;实测两模式的 17×TS7006 + 2×TS7031 完全相同,标注只增不减。

**改后**:`asis` rc=0、`annotated` rc=0(19 块,含新增的 tsx 块)。

诚实附注:改后两种模式跑的其实是同一个程序 —— 重写已给每个 schema 块加了标注,
`annotated` 模式再无 `const schema = {` 可替换。所以「改后 annotated 绿」不是独立证据。

## 名集合核对(反向验证 c)

重写后示例里出现的全部顶层 schema 键,逐个回查读取点:

```
bulkActions 1  columns 5  data 5  editable 3  filter 3  objectName 44
pagination 7  rowActions 2  searchableFields 5  selection 3
singleClickEdit 1  sort 3  type 0
```

`type` 的 0 是正确的:它由注册表消费而非 ObjectGrid —— `ComponentRegistry.get(evaluatedSchema.type)`
(`packages/react/src/SchemaRenderer.tsx:502`),拼写不是 `schema.` 前缀所以计数为 0。
其余全部 ≥1。所有 import 符号另跑一遍解析探针(`SchemaRendererProvider`、`SchemaRenderer`、
`createObjectStackAdapter`、`ObjectGrid`、`VirtualGrid`、`ObjectGridComponentProps`、
`VirtualGridColumn`、`ObjectGridSchema`、`ListColumn`、`PaginationConfig`、
`SelectionConfig`、`NavigationConfig`、`ViewData`)零 TS2307。无新假名。

## 验证

- `pnpm exec turbo run type-check --concurrency=2` —— **81 successful, 81 total**(4m8s)
- `node scripts/check-doc-links.mjs` —— `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` —— OK(4521 文件);改动文件另做
  `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中
- 重活均经 `flock -w 3600 /tmp/os-heavy-verify.lock` 串行 + `--max-old-space-size=4096`

## 待裁定(不在本 PR 内擅自决定)

顶层 `dataSource` 绑定既然对 object-grid 是活键,plugin-grid README 要不要把它的键面
(`{ object, view, filter, sort, limit }`)作为本元素的授权面正式写出来?这牵涉渲染器
契约边界(该绑定由 `@object-ui/react` 的 gate 统一消费,八个 block 共用),本 PR 只陈述
了「它不是适配器槽」这一条已证事实并给出引用,未作扩展表述。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_