### PR TITLE
docs(plugin-dashboard): README 的 onSchemaChange 持久化示例与手动注册段按真实契约重写

### DIFF
--- a/.changeset/plugin-dashboard-readme-truth-5066.md
+++ b/.changeset/plugin-dashboard-readme-truth-5066.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+`packages/plugin-dashboard/README.md`: two teaching snippets did not survive being
+copied. Both were verified against the package's **build artifact**
+(`dist/index.d.ts`) — export names via the TS compiler API
+(`checker.getExportsOfModule`), each changed TypeScript block compiled against
+those same declarations under `strict`.
+
+- **The `onSchemaChange` persistence example (`TS2345` as written).** The callback
+  receives a `DashboardComponentSchema`, whose `name` is optional (`BaseSchema.name`
+  in `@object-ui/types`), and `client.meta.saveItem(type, name, item)` declares
+  `name: string` (`@objectstack/client@17.0.0`) — so
+  `saveItem('dashboard', next.name, next)` is `Argument of type 'string | undefined'
+  is not assignable to parameter of type 'string'` in any `strict` consumer. This was
+  the one snippet on the page marked `✅ Preferred`, directly under the paragraph
+  telling readers that persistence is theirs to wire, i.e. the block most likely to be
+  copied whole. It now handles the missing name explicitly (narrow, then write) and
+  says why in prose: the type requires it, and what the server does with an absent
+  name is **not** measured here, so the example declines to send one rather than
+  guessing. No production code was touched to make the old line true — `name` stays
+  optional, and the identity question for SDUI dashboard nodes stays with objectui#4600.
+- **The `Object.entries(dashboardComponents).forEach(register)` loop.** `dashboardComponents`
+  is a real export, but its eleven keys are component class names
+  (`DashboardRenderer`, `MetricCard`, `WidgetConfigPanel`, …), not schema types — so
+  the loop registered eleven names no schema author writes, tripped the
+  no-namespace deprecation warning once per key
+  (`packages/core/src/registry/Registry.ts:198`), and registered none of the eight
+  types this package actually claims. It did not need to: those eight are already
+  registered by the side-effect import on the line above it. The section is replaced
+  by the family form used for the sibling plugins — the real register-key table
+  (`view:dashboard`, `plugin-dashboard:metric`, `metric-card`, `object-metric`,
+  `pivot`, `object-pivot`, `dashboard-grid`, `object-data-table`, with the bare-name
+  fallback rule and the two internal `object-*` wrappers named honestly), plus the
+  thing the old snippet was reaching for: registering an exported component under a
+  key of your own. `dashboardComponents` itself keeps only a statement of measured
+  fact, with no recommended usage, because the shape of that export is under
+  adjudication in objectui#5064.
+
+No code, types or runtime behaviour change — the diff is one README plus this
+changeset. It declares a patch because `README.md` is in the package's published
+`files`, so the correction reaches npm with the next release.

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -39,17 +39,58 @@ const schema = {
 };
 ```
 
-### Manual Registration
+### What the side-effect import registers
+
+That single import is the whole of registration — there is no components map to
+iterate over. Importing the entry runs the eight `ComponentRegistry.register(...)`
+calls in `src/index.tsx`, which claim exactly these schema types. The keys below
+are read off those calls:
+
+| Namespaced key | Bare-name fallback | Renderer behind it |
+| --- | --- | --- |
+| `view:dashboard` | `dashboard` | `DashboardRenderer` — the widget container |
+| `plugin-dashboard:metric` | `metric` | `MetricWidget` — one KPI value |
+| `plugin-dashboard:metric-card` | `metric-card` | `MetricCard` — KPI with trend and icon |
+| `plugin-dashboard:object-metric` | `object-metric` | internal wrapper around `ObjectMetricWidget` — aggregates over an object |
+| `plugin-dashboard:pivot` | `pivot` | `PivotTable` — pivot over rows you pass in |
+| `plugin-dashboard:object-pivot` | `object-pivot` | internal wrapper around `ObjectPivotTable` — pivot queried from an object |
+| `plugin-dashboard:dashboard-grid` | `dashboard-grid` | `DashboardGridLayout` — the drag/resize editable grid |
+| `plugin-dashboard:object-data-table` | `object-data-table` | `ObjectDataTable` — table queried from an object |
+
+`ComponentRegistry.register` publishes `namespace:type`, and — unless the call
+passes `skipFallback: true` — the bare `type` as a back-compat fallback
+(`packages/core/src/registry/Registry.ts:194`, fallback branch at `:226`). No
+call in this package passes `skipFallback`, so each type above resolves under
+both spellings. The two `object-*` types are served by internal wrappers that
+first resolve the spec's per-element `dataSource` binding (through
+`ElementDataSourceGate` from `@object-ui/react`) and then render the exported
+component, which is why those rows name a wrapper rather than an export.
+
+### Registering a component under your own key
+
+To serve one of this package's components under a key of your own, register the
+exported component — that is what a manual registration is here:
 
 ```typescript
-import { dashboardComponents } from '@object-ui/plugin-dashboard';
 import { ComponentRegistry } from '@object-ui/core';
+import { MetricCard } from '@object-ui/plugin-dashboard';
 
-// Register dashboard components
-Object.entries(dashboardComponents).forEach(([type, component]) => {
-  ComponentRegistry.register(type, component);
+ComponentRegistry.register('my-metric', MetricCard, {
+  namespace: 'my-app',
+  label: 'My Metric',
+  category: 'Dashboard',
 });
 ```
+
+There is also a `dashboardComponents` export, and two measured facts about it
+are worth stating, because iterating it is not the manual registration above:
+its eleven keys are **component class names** (`DashboardRenderer`,
+`MetricCard`, `WidgetConfigPanel`, …) rather than schema types, and passing each
+key straight to `ComponentRegistry.register` therefore registers eleven names no
+schema author writes — while the eight types in the table stay untouched, having
+already been registered by the import. Each such call also passes no `meta`, so
+it trips the no-namespace deprecation warning in `register`
+(`packages/core/src/registry/Registry.ts:198`).
 
 ## Schema API
 
@@ -464,9 +505,25 @@ through the `onSchemaChange` callback.
 <DashboardGridLayout
   schema={dashboard}
   // ✅ Preferred — write the updated schema through your data adapter.
-  onSchemaChange={(next) => client.meta.saveItem('dashboard', next.name, next)}
+  onSchemaChange={(next) => {
+    // `name` is optional on the schema, and `saveItem` requires it — decide
+    // what an unnamed dashboard means to your host instead of writing through.
+    if (!next.name) return;
+    client.meta.saveItem('dashboard', next.name, next);
+  }}
 />
 ```
+
+The guard is not defensive noise: the callback receives a
+`DashboardComponentSchema`, whose `name` is optional (`BaseSchema.name` in
+`@object-ui/types`), while `client.meta.saveItem(type, name, item)` declares
+`name: string`. Passing `next.name` straight through is `TS2345` under `strict`
+(`Argument of type 'string | undefined' is not assignable to parameter of type
+'string'`), so a copied snippet does not compile — and what the server does with
+an absent name has **not** been measured here, which is the other reason this
+example declines to send one rather than guessing. A host that already knows
+which metadata item the grid is editing should pass that name from its own state
+instead of reading it off the node.
 
 If `onSchemaChange` is **not** provided, layout edits stay in component
 state and are lost on refresh — a `console.warn` is emitted in development


### PR DESCRIPTION
Fixes #5066
Part of #5064

`packages/plugin-dashboard/README.md` 的两处教学片段照抄不成立。docs-only:diff 只有一个 README 与 changeset,无代码/类型/运行时改动。

⛔ 未动 `src/index.tsx` 的 `dashboardComponents` map 本体(A/B 键收敛裁定在 #5064 的决策箱,本 PR 因此 `Part of` 而不关那张卡);⛔ 未动 #5015 / PR #5069 已修的 TypeScript 一节;⛔ 未挂 `Blocked-by: #4600`(诚实处理可选性的示例在任何裁定下都为真)。

## 半 1(#5066)—— `onSchemaChange` 持久化示例

| 项 | 读数(已复测) |
| --- | --- |
| 回调签名 | `onSchemaChange?: (schema: DashboardComponentSchema) => void` —— `src/DashboardGridLayout.tsx:83`(卡面记 `:84`,漂移 1 行) |
| `name` 可选性 | `DashboardComponentSchema extends BaseSchema` 且不重声明 `name`;`name?: string` —— `packages/types/src/base.ts:86`(逐字命中) |
| `saveItem` 必填 | `saveItem: (type: string, name: string, item: any)` —— `@objectstack/client@17.0.0` `dist/*.d.ts:714`,`:2980` 再现(逐字命中) |

三条读数全部成立,前提为真。这是全页唯一标 `✅ Preferred` 的持久化片段,且紧跟「persistence is the parent's concern」的规则说明 —— 最可能被整段抄走的块。

改法(PM 代裁的最小形):示例先收窄 `next.name` 再写,并加一段散文说明为什么这不是防御性噪声 —— 类型要求它;而 `name` 缺省时服务端到底是 400 还是写出一条名为 "undefined" 的记录,**本单未量**(照卡面保留为未量陈述,⛔ 未擅测服务端),所以示例选择不发而不是猜。另加一句:宿主若已知道自己在编辑哪个元数据项,应从宿主自己的 state 传名字,而不是从节点上读。

**编译探针**(对构建产物 `packages/plugin-dashboard/dist/index.d.ts`,tsconfig paths 映射;`client.meta.saveItem` 按上表真签名声明,所以红的是 README 块本身,不是探针假设 —— #5015 探针先例):

```
改前(旧块逐字):  probe.tsx(29,65): error TS2345: Argument of type 'string | undefined'
                  is not assignable to parameter of type 'string'.
                    Type 'undefined' is not assignable to type 'string'.
                  PROBE-BEFORE rc=2
改后(新块逐字):  PROBE-AFTER rc=0
```

## 半 2(#5064 文档半)—— `:42-52` 手动注册循环

| 项 | 读数(已复测) |
| --- | --- |
| map 键 | `src/index.tsx:338-350`,11 个键全为 PascalCase 组件类名 |
| 8 个真 type | `dashboard`:44 / `metric`:65 / `metric-card`:80 / `object-metric`:151 / `pivot`:185 / `object-pivot`:260 / `dashboard-grid`:296 / `object-data-table`:316(卡面行号逐条命中,按调用现场抄) |
| 弃用告警 | `packages/core/src/registry/Registry.ts:198-208` 的 `if (!meta?.namespace)` 分支,循环每键一条 |
| 循环非必需 | 第一行 import 已触发入口副作用,8 个真 type 在循环执行前已注册 |
| 零消费点 | 词边界 grep:除 `src/index.tsx` 与本 README 外,仅 `content/docs/plugins/plugin-dashboard.mdx` 有同一段复制品(见下「另立卡」) |

删该段,改同族形(#5079 / #5078 / #5071 / #5085 的对应节):真实 register 键表(namespaced 键 + bare 兜底规则,`Registry.ts:194` 与 `:226`;本包无任何 `skipFallback`,故 8 个 type 两种拼法都可达)+ 两个 `object-*` 内部包装器诚实指名 + 旧片段真正想做的事(把已导出组件注册到自己的键上,新块 `PROBE-OWNKEY rc=0`)。

`dashboardComponents` 只保留实测事实陈述(键为组件类名、照抄注册的不是 schema type、每次调用触发弃用告警),⛔ 不写推荐用法、⛔ 不预断 A。

## 反向验证(方向预判先写,再跑)

| 预判 | 实测 | 符合? |
| --- | --- | --- |
| (a) #5066 旧写法回填 → 必红 TS2345 | `PROBE-BEFORE rc=2`,TS2345 落在 `next.name` 实参(29,65) | 是 |
| (b) 名集合塞假名 → 必红 | 注入 `MetricCardSchemaZZZ`:`FAIL MetricCardSchemaZZZ` / `NAME-SET FAIL (1)` rc=1 | 是 |
| (c) 半 2 改前段回填 → **两道门都抓不到** | 见下 | 是 |

(c) 是本单唯一「把抓不到写出来验证」的一格,预判与实测一致:

- **名集合核对抓不到**:`dashboardComponents` 是**真实导出**(dist 20 个导出里有它),门只判「导入的标识符是否存在」。实测改前 README:`OK dashboardComponents` / `NAME-SET OK` rc=0 —— 绿,幻影键完全不在它的视野里。
- **编译探针也抓不到**:11 个幻影键是 `Object.entries` 的**运行时字符串值**,而 `register` 首参声明为 `string`。预判 rc=0,实测 `PROBE-LOOP-OLD rc=0` —— 旧循环 strict 编译通过。若它真红,也只会红在组件可赋值性上,不可能提到键的词汇表。
- 因此半 2 的证据只能来自 **register 调用现场与 map 键的逐条比对**(上表)+ `Registry.ts:198` 的告警分支,不是任何门禁的输出。

## 仓级门禁

```
pnpm exec turbo run type-check --concurrency=2   →  Tasks: 81 successful, 81 total   (rc=0)
node scripts/check-doc-links.mjs                 →  Links are valid across 13 scan roots
node scripts/check-control-bytes.mjs             →  OK (4524 tracked text files)
node scripts/check-changeset-fixed.mjs           →  OK      check-changeset-no-major.mjs → OK
node scripts/check-doc-component-types.mjs       →  Every documented component type is registered
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' 改动文件 →  无命中(改动文件自扫,超出门禁扫描面)
```

重活经 `flock -w 3600 /tmp/os-heavy-verify.lock` 串行 + `NODE_OPTIONS=--max-old-space-size=4096`。baseline `a0f6f0eb524272e4719bf49df9ce56230800888c`。

## 另立卡(不在本 PR 修)

- 文档站镜像:`content/docs/plugins/plugin-dashboard.mdx:73-79` 是同一段循环的复制品(#5076 / PR #5085 只覆盖了 form/grid/view 三页)。
- `README.md` 有两个同名 H2「DashboardGridLayout — persisting drag / resize edits」(`:480` 与 `:495`),`### DashboardRenderer` 一节夹在第一个下面。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_