### PR TITLE
fix(app-shell): metadata-admin 嵌套字段 id 按路径作用域 + grid/table 单元格由列头命名 (#5062, #5063)

### DIFF
--- a/.changeset/schemaform-nested-id-scope-and-grid-cell-naming-5062.md
+++ b/.changeset/schemaform-nested-id-scope-and-grid-cell-naming-5062.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin 表单:嵌套字段 DOM id 按路径作用域,grid/table 单元格由列头命名
+
+**objectui#5062 —— 交叉接线的标签关联。** `FieldRow` 用字段的**本层**名字构造宿主 id
+(`mdf-{name}`),但它在四个嵌套点被递归调用(composite 子行、repeater 卡片行、record
+展开项、递归 `SchemaForm`)。不同父级下的同名子字段因此产生同一个 DOM id,而
+`<label for>` 只解析到文档中的**第一个**匹配。实测(两个 composite `a` / `b`,各带一个
+名为 `field` 的子字段,值 x / y):
+
+```
+ids: ["mdf-a-label","mdf-field","mdf-b-label","mdf-field"]
+DUPLICATES: ["mdf-field"]
+label "Field A" for=mdf-field  resolves to INPUT[value="x"]
+label "Field B" for=mdf-field  resolves to INPUT[value="x"]   <- Field A 的控件
+```
+
+即点击 "Field B" 聚焦到 Field A 的输入框,辅助技术把 Field A 的控件读成 "Field B"。
+这不是 #4871 / #4857 / #4788 / #5039 那一类「解析到无」,而是**解析到了错的元素** ——
+DOM 上看不出任何破绽。id 改为按字段**路径**派生(`mdf-a.field` / `mdf-b.field`);
+**顶层字段 id 保持 `mdf-{field}` 不变**,既有选择器面不动,只有嵌套行加前缀。record
+项入 id 的是它的**序号**而非作者输入的键名 —— 键名可能含空格,会把 `aria-labelledby`
+的 IDREF 切成两个引用。
+
+**objectui#5063 —— grid/table 单元格无可访问名。** `RepeaterField` 的 `widget: 'grid'`
+布局里,列名只作为 `th` 的可见文本存在:不是 `label`,没有 `id` 可供引用,也没有
+`scope`。实测每个单元格控件 `label[for]` / `aria-label` / `aria-labelledby` 三者全无,
+屏幕阅读器逐格听到的是「无名编辑框」。现在每个 `th` 发一个(同样路径作用域的)id 加
+`scope="col"`,单元格控件以 `aria-labelledby` 指向对应列头 —— 列名只写一次,改名不会
+漂移。卡片布局本就每行走 `FieldRow` 带真实 `label for`,不受影响。

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.gridCellNaming.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.gridCellNaming.test.tsx
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5063 — every control in a `RepeaterField` grid/table row is named by
+ * its column header.
+ *
+ * ## What was measured (baseline `90517e1a2`, real `SchemaForm` render,
+ * `widget: 'grid'`, two sub-fields `field` / `order`)
+ *
+ * ```
+ * cell id=rep-0-field label[for]=NONE aria-label=NONE aria-labelledby=NONE
+ * cell id=rep-0-order label[for]=NONE aria-label=NONE aria-labelledby=NONE
+ * th "Field" id=NONE scope=NONE
+ * th "Order" id=NONE scope=NONE
+ * th ""      id=NONE scope=NONE
+ * ```
+ *
+ * All three naming channels absent on every cell: the column name existed only
+ * as the header's visible TEXT — not a `label`, no `id` for an IDREF to reach,
+ * no `scope`. A screen reader walking the table announced a row of unnamed edit
+ * boxes. Same failure class as #3994 (a visible `Label` beside a control it is
+ * not associated with, leaving the name as orphan text), with the repeater's
+ * table as the host.
+ *
+ * The card layout is NOT affected and is asserted here as the control: each of
+ * its rows goes through `FieldRow`, which writes a real `<label for>`.
+ *
+ * ## The shape, and the one that was rejected
+ *
+ * Direction 1 (taken): the `<th>` publishes an id and `scope="col"`, and each
+ * cell control answers `aria-labelledby` — the column name is written once, in
+ * the header where table semantics already put it. Direction 2 (per-cell
+ * `aria-label`) was rejected: it copies the column name into every row and
+ * drifts the moment a column is renamed.
+ *
+ * Row identity is deliberately NOT part of the accessible name — the measured
+ * gap is the missing column name, and the `<td>`'s position in a real table
+ * already carries the row.
+ *
+ * ## What this file pins
+ *
+ *  1. every cell control's ACCESSIBLE NAME is its column's name — asserted
+ *     through the computed name and through the IDREF landing on a `<th>`, not
+ *     merely on the attribute being present;
+ *  2. `scope="col"` on the headers, including the nameless row-actions column;
+ *  3. the header ids are path-scoped (objectui#5062), so two repeaters with the
+ *     same column names in one form neither collide nor cross-name each other;
+ *  4. the card layout's own `label[for]` association is untouched.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+
+afterEach(cleanup);
+
+const ROW_ITEMS = {
+  type: 'object',
+  properties: { field: { type: 'string' }, order: { type: 'string', enum: ['asc', 'desc'] } },
+};
+
+function gridForm(fieldName: string, layout: 'grid' | 'card') {
+  return {
+    type: 'simple',
+    sections: [
+      {
+        label: 'S',
+        fields: [
+          {
+            field: fieldName,
+            type: 'repeater',
+            ...(layout === 'grid' ? { widget: 'grid' } : {}),
+            fields: [
+              { field: 'field', type: 'text', label: 'Field' },
+              { field: 'order', type: 'text', label: 'Order' },
+            ],
+          },
+        ],
+      },
+    ],
+  } as never;
+}
+
+/** The cell controls of the rendered table, in document order. */
+function cellControls() {
+  return Array.from(document.querySelectorAll('td input, td textarea, td [role="combobox"]')) as HTMLElement[];
+}
+
+describe('#5063 — grid/table repeater cells are named by their column header', () => {
+  it('each cell control resolves its name from the matching `th`', () => {
+    render(
+      <SchemaForm
+        schema={{ type: 'object', properties: { cols: { type: 'array', title: 'Cols', items: ROW_ITEMS } } } as never}
+        form={gridForm('cols', 'grid')}
+        value={{ cols: [{ field: 'name', order: 'asc' }] }}
+        onChange={() => {}}
+      />,
+    );
+
+    const cells = cellControls();
+    expect(cells).toHaveLength(2);
+
+    for (const [cell, columnName] of [
+      [cells[0], 'Field'],
+      [cells[1], 'Order'],
+    ] as const) {
+      // The channel: an IDREF that actually lands on the column's header cell.
+      const ref = cell.getAttribute('aria-labelledby');
+      expect(ref, 'cell has no aria-labelledby').not.toBeNull();
+      const header = document.getElementById(ref!);
+      expect(header, `aria-labelledby="${ref}" resolves to nothing`).not.toBeNull();
+      expect(header!.tagName).toBe('TH');
+      expect(header).toHaveTextContent(columnName);
+      // And the name that actually reaches assistive tech.
+      expect(cell).toHaveAccessibleName(columnName);
+    }
+  });
+
+  it('every column header carries `scope="col"`, the row-actions one included', () => {
+    render(
+      <SchemaForm
+        schema={{ type: 'object', properties: { cols: { type: 'array', title: 'Cols', items: ROW_ITEMS } } } as never}
+        form={gridForm('cols', 'grid')}
+        value={{ cols: [{ field: 'name', order: 'asc' }] }}
+        onChange={() => {}}
+      />,
+    );
+
+    const headers = Array.from(document.querySelectorAll('th'));
+    expect(headers).toHaveLength(3); // Field, Order, row actions
+    for (const th of headers) expect(th).toHaveAttribute('scope', 'col');
+    // Only the two NAMED columns publish an id — nothing points at the actions
+    // column, so an id there would be an unreferenced anchor.
+    expect(headers.filter((th) => th.id)).toHaveLength(2);
+  });
+
+  it('a cell that renders a select is named the same way as a plain input', () => {
+    render(
+      <SchemaForm
+        schema={{ type: 'object', properties: { cols: { type: 'array', title: 'Cols', items: ROW_ITEMS } } } as never}
+        form={
+          {
+            type: 'simple',
+            sections: [
+              {
+                label: 'S',
+                fields: [
+                  {
+                    field: 'cols',
+                    type: 'repeater',
+                    widget: 'grid',
+                    // No `type: 'text'` on `order`, so the schema enum wins and
+                    // the cell renders a Select instead of an Input.
+                    fields: [{ field: 'field', type: 'text', label: 'Field' }, { field: 'order', label: 'Order' }],
+                  },
+                ],
+              },
+            ],
+          } as never
+        }
+        value={{ cols: [{ field: 'name', order: 'asc' }] }}
+        onChange={() => {}}
+      />,
+    );
+
+    const select = document.querySelector('td [role="combobox"]')!;
+    expect(select).toHaveAccessibleName('Order');
+  });
+
+  it('two grid repeaters with the same column names neither collide nor cross-name', () => {
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: {
+              sortBy: { type: 'array', title: 'Sort By', items: ROW_ITEMS },
+              groupBy: { type: 'array', title: 'Group By', items: ROW_ITEMS },
+            },
+          } as never
+        }
+        form={
+          {
+            type: 'simple',
+            sections: [
+              {
+                label: 'S',
+                fields: [
+                  { field: 'sortBy', type: 'repeater', widget: 'grid', fields: [{ field: 'field', type: 'text', label: 'Field' }] },
+                  { field: 'groupBy', type: 'repeater', widget: 'grid', fields: [{ field: 'field', type: 'text', label: 'Field' }] },
+                ],
+              },
+            ],
+          } as never
+        }
+        value={{ sortBy: [{ field: 'a' }], groupBy: [{ field: 'b' }] }}
+        onChange={() => {}}
+      />,
+    );
+
+    const ids = Array.from(document.querySelectorAll('[id]')).map((e) => e.id);
+    expect(ids.filter((id, i) => ids.indexOf(id) !== i)).toEqual([]);
+
+    // Each cell must be named by ITS OWN table's header — with one shared id
+    // both would have resolved to the first table's `th`.
+    const [first, second] = Array.from(document.querySelectorAll('table')) as HTMLTableElement[];
+    for (const table of [first, second]) {
+      const cell = table.querySelector('td input')!;
+      const header = document.getElementById(cell.getAttribute('aria-labelledby')!)!;
+      expect(table.contains(header), "a cell is named by the other table's header").toBe(true);
+      expect(cell).toHaveAccessibleName('Field');
+    }
+  });
+});
+
+describe('#5063 — the card layout keeps its own `label for` association', () => {
+  it('control: each card row sub-field is labelled the plain way', () => {
+    render(
+      <SchemaForm
+        schema={{ type: 'object', properties: { cols: { type: 'array', title: 'Cols', items: ROW_ITEMS } } } as never}
+        form={gridForm('cols', 'card')}
+        value={{ cols: [{ field: 'name', order: 'asc' }] }}
+        onChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText(/#1/));
+
+    const label = screen.getByText('Field').closest('label')!;
+    const target = document.getElementById(label.getAttribute('for')!)!;
+    expect(target.tagName).toBe('INPUT');
+    expect(target).toHaveValue('name');
+    expect(target).toHaveAccessibleName('Field');
+    // The card row is named by its label, not by an IDREF — this layout was
+    // never part of the gap.
+    expect(target).not.toHaveAttribute('aria-labelledby');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.nestedIdScope.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.nestedIdScope.test.tsx
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5062 — `FieldRow`'s host id is derived from the field's PATH, not
+ * from its local name.
+ *
+ * ## What was measured (baseline `90517e1a2`, real `SchemaForm` renders)
+ *
+ * Two `composite` fields `a` / `b`, each with a sub-field named `field`
+ * (labels "Field A" / "Field B", values `x` / `y`):
+ *
+ * ```
+ * ids: ["mdf-a-label","mdf-field","mdf-b-label","mdf-field"]
+ * DUPLICATES: ["mdf-field"]
+ * label "Field A" for=mdf-field  resolves to INPUT[value="x"]
+ * label "Field B" for=mdf-field  resolves to INPUT[value="x"]   <- Field A's control
+ * ```
+ *
+ * `FieldRow` built `mdf-{name}` from the LOCAL field name while being called
+ * recursively at four nesting points (composite sub-rows, repeater card rows,
+ * record items, the recursive `SchemaForm`). Same-named sub-fields under
+ * different parents therefore produced the same DOM id, and a `<label for>`
+ * resolves to the FIRST match in the document: clicking "Field B" focused
+ * Field A's input and assistive tech read Field A's control as "Field B".
+ *
+ * Worse than the dangling associations of #4871 / #4857 / #4788 / #5039 —
+ * this one RESOLVES, to the wrong element, so nothing about the DOM looks
+ * broken. Same failure class as objectui#3343 (fixed-id sub-inputs in
+ * `packages/fields`), one host up.
+ *
+ * ## What this file pins
+ *
+ *  1. the CROSS-WIRING itself: at every nesting point, same-named sub-fields
+ *     get distinct ids AND each label resolves to its OWN control — asserted on
+ *     the value behind the association, not merely on id inequality, because
+ *     two distinct ids can still be wired to one element;
+ *  2. the TOP-LEVEL contract: a top-level field's id is still exactly
+ *     `mdf-{field}` (and its group label id `mdf-{field}-label`). The scoping
+ *     is additive — nested rows gain a prefix, the existing selector surface
+ *     the other metadata-admin tests read does not move;
+ *  3. the segment contract: row/item segments are numeric indices, so an
+ *     author-typed `record` key (runtime user input, may contain spaces) can
+ *     never reach an id that is consumed as an `aria-labelledby` IDREF.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+
+afterEach(cleanup);
+
+/** Every id in the document, and the ones that appear more than once. */
+function idCensus() {
+  const ids = Array.from(document.querySelectorAll('[id]')).map((e) => e.id);
+  return { ids, duplicates: Array.from(new Set(ids.filter((id, i) => ids.indexOf(id) !== i))) };
+}
+
+/** The element a visible label's `for` actually resolves to. */
+function controlFor(text: string): HTMLInputElement | null {
+  const label = screen.getByText(text).closest('label')!;
+  const target = label.getAttribute('for');
+  return target ? (document.getElementById(target) as HTMLInputElement | null) : null;
+}
+
+describe('#5062 — nested same-named sub-fields do not share an id', () => {
+  it('composite: two sub-fields named `field`, each label resolves to its own control', () => {
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: {
+              a: { type: 'object', title: 'A', properties: { field: { type: 'string' } } },
+              b: { type: 'object', title: 'B', properties: { field: { type: 'string' } } },
+            },
+          } as never
+        }
+        form={
+          {
+            type: 'simple',
+            sections: [
+              {
+                label: 'S',
+                fields: [
+                  { field: 'a', type: 'composite', fields: [{ field: 'field', type: 'text', label: 'Field A' }] },
+                  { field: 'b', type: 'composite', fields: [{ field: 'field', type: 'text', label: 'Field B' }] },
+                ],
+              },
+            ],
+          } as never
+        }
+        value={{ a: { field: 'x' }, b: { field: 'y' } }}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(idCensus().duplicates).toEqual([]);
+    expect(document.getElementById('mdf-a.field')).not.toBeNull();
+    expect(document.getElementById('mdf-b.field')).not.toBeNull();
+
+    // The measured defect: before, BOTH of these read "x".
+    expect(controlFor('Field A')).toHaveValue('x');
+    expect(controlFor('Field B')).toHaveValue('y');
+    expect(controlFor('Field A')).not.toBe(controlFor('Field B'));
+  });
+
+  it('repeater card rows: the row index is part of the path', () => {
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: {
+              tabs: {
+                type: 'array',
+                title: 'Tabs',
+                items: { type: 'object', properties: { label: { type: 'string' } } },
+              },
+            },
+          } as never
+        }
+        form={
+          {
+            type: 'simple',
+            sections: [
+              {
+                label: 'S',
+                fields: [{ field: 'tabs', type: 'repeater', fields: [{ field: 'label', type: 'text', label: 'Row label' }] }],
+              },
+            ],
+          } as never
+        }
+        value={{ tabs: [{ label: 'one' }, { label: 'two' }] }}
+        onChange={() => {}}
+      />,
+    );
+
+    // Open the SECOND row — its sub-field must carry the row's index, not a
+    // bare `mdf-label` that every row would share.
+    fireEvent.click(screen.getByText(/#2/));
+    expect(document.getElementById('mdf-tabs.1.label')).toHaveValue('two');
+    expect(document.getElementById('mdf-label')).toBeNull();
+    expect(controlFor('Row label')).toHaveValue('two');
+    expect(idCensus().duplicates).toEqual([]);
+  });
+
+  it('two repeaters with the same sub-field name, both expanded, stay distinct', () => {
+    const items = { type: 'object', properties: { label: { type: 'string' } } };
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: {
+              left: { type: 'array', title: 'Left', items },
+              right: { type: 'array', title: 'Right', items },
+            },
+          } as never
+        }
+        form={
+          {
+            type: 'simple',
+            sections: [
+              {
+                label: 'S',
+                fields: [
+                  { field: 'left', type: 'repeater', fields: [{ field: 'label', type: 'text', label: 'L' }] },
+                  { field: 'right', type: 'repeater', fields: [{ field: 'label', type: 'text', label: 'R' }] },
+                ],
+              },
+            ],
+          } as never
+        }
+        value={{ left: [{ label: 'l0' }], right: [{ label: 'r0' }] }}
+        onChange={() => {}}
+      />,
+    );
+
+    for (const toggle of screen.getAllByText(/#1/)) fireEvent.click(toggle);
+    expect(idCensus().duplicates).toEqual([]);
+    expect(controlFor('L')).toHaveValue('l0');
+    expect(controlFor('R')).toHaveValue('r0');
+  });
+
+  it('record items: the id carries the item INDEX, never the author-typed key', () => {
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: {
+              cfg: {
+                type: 'object',
+                title: 'Cfg',
+                additionalProperties: { type: 'object', properties: { title: { type: 'string' } } },
+              },
+            },
+          } as never
+        }
+        form={
+          {
+            type: 'simple',
+            sections: [
+              {
+                label: 'S',
+                fields: [{ field: 'cfg', type: 'record', fields: [{ field: 'title', type: 'text', label: 'Title' }] }],
+              },
+            ],
+          } as never
+        }
+        // A key with a space in it: legal for a Record, and exactly what must
+        // NOT reach an id that is read as an IDREF.
+        value={{ cfg: { 'my key': { title: 'first' }, other: { title: 'second' } } }}
+        onChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('my key'));
+    const titleInput = controlFor('Title')!;
+    expect(titleInput).toHaveValue('first');
+    expect(titleInput.id).toBe('mdf-cfg.0.title');
+    expect(titleInput.id).not.toMatch(/\s/);
+    expect(idCensus().duplicates).toEqual([]);
+  });
+
+  it('recursive SchemaForm: the inner field is scoped under the outer field', () => {
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: {
+              outer: {
+                type: 'object',
+                title: 'Outer',
+                properties: { inner: { type: 'string', title: 'Inner' } },
+              },
+              inner: { type: 'string', title: 'Top Inner' },
+            },
+          } as never
+        }
+        value={{ outer: { inner: 'nested' }, inner: 'top' }}
+        onChange={() => {}}
+      />,
+    );
+
+    // A top-level field and a nested one, both named `inner`: before, one id.
+    expect(idCensus().duplicates).toEqual([]);
+    expect(document.getElementById('mdf-outer.inner')).toHaveValue('nested');
+    expect(document.getElementById('mdf-inner')).toHaveValue('top');
+    expect(controlFor('Inner')).toHaveValue('nested');
+    expect(controlFor('Top Inner')).toHaveValue('top');
+  });
+});
+
+describe('#5062 — top-level ids are unchanged (the existing selector surface)', () => {
+  it('a control-channel field keeps `for`/`id` = `mdf-{field}`', () => {
+    render(
+      <SchemaForm
+        schema={{ type: 'object', properties: { title: { type: 'string', title: 'Title' } } } as never}
+        value={{ title: 'v' }}
+        onChange={() => {}}
+      />,
+    );
+
+    const label = screen.getByText('Title').closest('label')!;
+    expect(label).toHaveAttribute('for', 'mdf-title');
+    expect(document.getElementById('mdf-title')).toHaveValue('v');
+  });
+
+  it('a group-channel field keeps its label id `mdf-{field}-label` and the IDREF', () => {
+    render(
+      <SchemaForm
+        schema={
+          {
+            type: 'object',
+            properties: { a: { type: 'object', title: 'A', properties: { field: { type: 'string' } } } },
+          } as never
+        }
+        form={
+          {
+            type: 'simple',
+            sections: [{ label: 'S', fields: [{ field: 'a', type: 'composite', fields: [{ field: 'field', type: 'text' }] }] }],
+          } as never
+        }
+        value={{ a: { field: 'x' } }}
+        onChange={() => {}}
+      />,
+    );
+
+    const label = screen.getByText('A').closest('label')!;
+    expect(label).toHaveAttribute('id', 'mdf-a-label');
+    expect(label).not.toHaveAttribute('for');
+    const group = document.querySelector('[aria-labelledby="mdf-a-label"]')!;
+    expect(group).not.toBeNull();
+    expect(group).toHaveAccessibleName('A');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.nonRegistryLabelling.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.nonRegistryLabelling.test.tsx
@@ -36,7 +36,8 @@
  * out uniform:
  *
  *  - `composite` and `nested-object` do contain one labelable `<input>`, but it
- *    belongs to a SUB-field's own `<label for>` (`mdf-sub` / `mdf-inner`). The
+ *    belongs to a SUB-field's own `<label for>` (`mdf-probe.sub` /
+ *    `mdf-probe.inner` — path-scoped since objectui#5062). The
  *    outer field owns nothing of its own to address → container, `'group'`;
  *  - `repeater` / `array-of-obj` / `record` own only auxiliary buttons — collapse,
  *    add, remove — and just the collapse toggles when read-only → `'group'`;
@@ -442,9 +443,11 @@ describe('a group name does not swallow the sub-fields it contains', () => {
 
     // The inner field is a plain control on its own `control` channel, reached by
     // its own label — not by the outer one, and not by `aria-labelledby`.
+    // Its id is scoped under the host field's path (objectui#5062): a nested
+    // `inner` and a top-level `inner` are two fields and must not share an id.
     const innerLabel = within(group as HTMLElement).getByText('Inner').closest('label')!;
-    expect(innerLabel).toHaveAttribute('for', 'mdf-inner');
-    const innerInput = document.getElementById('mdf-inner')!;
+    expect(innerLabel).toHaveAttribute('for', `${HOST_ID}.inner`);
+    const innerInput = document.getElementById(`${HOST_ID}.inner`)!;
     expect(innerInput.tagName).toBe('INPUT');
     expect(innerInput).not.toHaveAttribute('aria-labelledby');
     expect(innerInput).toHaveAccessibleName('Inner');
@@ -475,9 +478,10 @@ describe('a group name does not swallow the sub-fields it contains', () => {
 
     const group = document.querySelector(`[aria-labelledby="${LABEL_ID}"]`)!;
     expect(group).toHaveAccessibleName(TITLE);
-    const subInput = document.getElementById('mdf-sub')!;
+    // Path-scoped under the composite's own field (objectui#5062).
+    const subInput = document.getElementById(`${HOST_ID}.sub`)!;
     expect(subInput.tagName).toBe('INPUT');
     expect(subInput).toHaveAccessibleName('Sub');
-    expect(within(group as HTMLElement).getByText('Sub').closest('label')).toHaveAttribute('for', 'mdf-sub');
+    expect(within(group as HTMLElement).getByText('Sub').closest('label')).toHaveAttribute('for', `${HOST_ID}.sub`);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -1339,14 +1339,25 @@ function FieldControl({
   formData,
 }: {
   /**
-   * The host field id — present only on the `labelling: 'control'` channel,
-   * `undefined` on the `'group'` one (objectui#4871). Every builtin branch below
-   * renders a labelable element and spreads it unconditionally; so does the JSON
-   * editor, whose `<textarea>` is exactly such an element (objectui#5039). The
-   * `'group'` faces never read it — `FieldRow` doesn't hand it to them.
+   * The host field id. From `FieldRow` it is present only on the
+   * `labelling: 'control'` channel and `undefined` on the `'group'` one
+   * (objectui#4871): every builtin branch below renders a labelable element and
+   * spreads it unconditionally, as does the JSON editor whose `<textarea>` is
+   * exactly such an element (objectui#5039), while the `'group'` faces never
+   * read it because `FieldRow` doesn't hand it to them.
    */
   id?: string;
-  /** The host label's id, on the `'group'` channel only. */
+  /**
+   * An IDREF naming whatever this control renders.
+   *
+   * From `FieldRow` this is the host label's id on the `'group'` channel only,
+   * and exactly one of `id` / `ariaLabelledBy` is ever defined — that mutual
+   * exclusion is `FieldRow`'s rule about a LABEL, not a rule about this
+   * component. A grid/table repeater cell has no `<label>` at all: its name is
+   * the column header, reached by IDREF, while the id stays on the control as a
+   * plain anchor. So a cell passes BOTH, and every branch below emits the IDREF
+   * alongside the id rather than treating them as alternatives (objectui#5063).
+   */
   ariaLabelledBy?: string;
   /** Machine field name — keys enum-option localization (e.g. flow `type`). */
   fieldName?: string;
@@ -1525,6 +1536,7 @@ function FieldControl({
         <div className="space-y-1">
           <RawJsonEditor
             id={id}
+            ariaLabelledBy={ariaLabelledBy}
             value={value as any}
             onChange={(v) => onChange(v)}
             readOnly={readOnly}
@@ -1535,7 +1547,9 @@ function FieldControl({
         </div>
       );
     }
-    return <RawJsonEditor id={id} value={value} onChange={onChange} readOnly={readOnly} small />;
+    return (
+      <RawJsonEditor id={id} ariaLabelledBy={ariaLabelledBy} value={value} onChange={onChange} readOnly={readOnly} small />
+    );
   }
 
   // The builtin scalar chain. For schemas authored as `anyOf` / `oneOf` (e.g.
@@ -1557,7 +1571,7 @@ function FieldControl({
         onValueChange={(v) => onChange(v)}
         disabled={readOnly}
       >
-        <SelectTrigger id={id}>
+        <SelectTrigger id={id} aria-labelledby={ariaLabelledBy}>
           <SelectValue placeholder={t('engine.form.selectEllipsis', locale)} />
         </SelectTrigger>
         <SelectContent>
@@ -1585,7 +1599,7 @@ function FieldControl({
         onValueChange={(v) => onChange(v)}
         disabled={readOnly}
       >
-        <SelectTrigger id={id}>
+        <SelectTrigger id={id} aria-labelledby={ariaLabelledBy}>
           <SelectValue placeholder={t('engine.form.selectEllipsis', locale)} />
         </SelectTrigger>
         <SelectContent>
@@ -1614,6 +1628,7 @@ function FieldControl({
     return (
       <Switch
         id={id}
+        aria-labelledby={ariaLabelledBy}
         checked={!!value}
         onCheckedChange={(c) => onChange(c)}
         disabled={readOnly}
@@ -1628,6 +1643,7 @@ function FieldControl({
     return (
       <Input
         id={id}
+        aria-labelledby={ariaLabelledBy}
         type="number"
         value={value == null ? '' : String(value)}
         min={min}
@@ -1654,6 +1670,7 @@ function FieldControl({
       return (
         <Textarea
           id={id}
+          aria-labelledby={ariaLabelledBy}
           rows={4}
           value={(value as string | undefined) ?? ''}
           maxLength={maxLength}
@@ -1665,6 +1682,7 @@ function FieldControl({
     return (
       <Input
         id={id}
+        aria-labelledby={ariaLabelledBy}
         value={(value as string | undefined) ?? ''}
         maxLength={maxLength}
         onChange={(e) => onChange(e.target.value || undefined)}
@@ -1685,6 +1703,7 @@ function FieldControl({
       return (
         <Input
           id={id}
+          aria-labelledby={ariaLabelledBy}
           value={arr.map(String).join(', ')}
           placeholder={t('engine.form.arrayPlaceholder', locale)}
           onChange={(e) => {
@@ -1718,7 +1737,9 @@ function FieldControl({
   // prove that correspondence, so this terminal stays — spelled as the same
   // `'control'`-channel JSON editor the `raw-json` face renders, so that if a
   // future edit did make it reachable the label channel would still be right.
-  return <RawJsonEditor id={id} value={value} onChange={onChange} readOnly={readOnly} small />;
+  return (
+    <RawJsonEditor id={id} ariaLabelledBy={ariaLabelledBy} value={value} onChange={onChange} readOnly={readOnly} small />
+  );
 }
 
 /* ----- composite / repeater (embedded structured values) ----------------- */
@@ -1883,6 +1904,23 @@ function RepeaterField({
   // into compact inline-table layout for short, atomic sub-fields.
   const useGrid = widget === 'grid' || widget === 'table';
 
+  /**
+   * Ids for the grid/table layout, path-scoped exactly like the card layout's
+   * rows (objectui#5062), so the same data cell has the same id under either
+   * layout and two repeaters carrying the same column names cannot collide.
+   *
+   * `cellId` replaces the flat `rep-{row}-{field}`, which was duplicated
+   * verbatim by every other grid repeater in the form
+   * (`DUPLICATES: ["rep-0-field"]`, measured).
+   *
+   * `columnHeaderId` names the `<th>` so the cells under it can point at it.
+   * The `-col` suffix (rather than `FieldRow`'s `-label`) says what it is: one
+   * header shared by a whole column, not one field's label — and it cannot be
+   * confused with the label id of a row at the same path.
+   */
+  const cellId = (idx: number, field: string) => fieldHostId(joinIdPath(joinIdPath(idPath, idx), field));
+  const columnHeaderId = (field: string) => `${fieldHostId(joinIdPath(idPath, field))}-col`;
+
   const update = (i: number, patch: Record<string, unknown>) => {
     const next = rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r));
     onChange(next);
@@ -1902,13 +1940,29 @@ function RepeaterField({
           <table className="w-full text-sm">
             <thead className="bg-muted/40">
               <tr>
+                {/*
+                  The column name is written ONCE, here, and every cell below
+                  points at it by IDREF (objectui#5063). Before, the name existed
+                  only as this header's visible text: no `label`, no `id` to
+                  reference, no `scope` — so each cell control had `label[for]`,
+                  `aria-label` and `aria-labelledby` all absent and read out as an
+                  unnamed edit box. Per-cell `aria-label` was the rejected
+                  alternative: it copies the column name into every row and drifts
+                  the moment a column is renamed.
+                */}
                 {specs.map((s) => (
-                  <th key={s.field} className="px-2 py-1.5 text-left text-xs font-medium">
+                  <th
+                    key={s.field}
+                    id={columnHeaderId(s.field)}
+                    scope="col"
+                    className="px-2 py-1.5 text-left text-xs font-medium"
+                  >
                     {s.label || prettify(s.field)}
                     {s.required && <span className="text-destructive ml-0.5">*</span>}
                   </th>
                 ))}
-                {!readOnly && <th className="w-8" />}
+                {/* Row actions: no name to publish, but still a column header. */}
+                {!readOnly && <th scope="col" className="w-8" />}
               </tr>
             </thead>
             <tbody>
@@ -1924,8 +1978,12 @@ function RepeaterField({
                     return (
                       <td key={s.field} className="p-1.5">
                         <FieldControl
-                          id={`rep-${idx}-${s.field}`}
+                          id={cellId(idx, s.field)}
+                          // This cell's only naming channel — there is no
+                          // `<label>` in a grid row (objectui#5063).
+                          ariaLabelledBy={columnHeaderId(s.field)}
                           fieldName={s.field}
+                          idPath={joinIdPath(joinIdPath(idPath, idx), s.field)}
                           schema={sub}
                           value={row?.[s.field]}
                           readOnly={readOnly || s.readonly}
@@ -2335,6 +2393,7 @@ function RecordField({
 
 function RawJsonEditor({
   id,
+  ariaLabelledBy,
   value,
   onChange,
   readOnly,
@@ -2349,6 +2408,12 @@ function RawJsonEditor({
    * label to associate.
    */
   id?: string;
+  /**
+   * An IDREF that names the `<textarea>` when the host has no `<label for>` to
+   * give it — a grid/table repeater cell, named by its column header
+   * (objectui#5063).
+   */
+  ariaLabelledBy?: string;
   value: unknown;
   onChange: (v: any) => void;
   readOnly?: boolean;
@@ -2370,6 +2435,7 @@ function RawJsonEditor({
     <div className="space-y-1">
       <Textarea
         id={id}
+        aria-labelledby={ariaLabelledBy}
         rows={small ? 4 : 12}
         className="font-mono text-xs"
         value={text}

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -712,6 +712,12 @@ export interface SchemaFormProps {
   /** JSONSchema for the root object. */
   schema: JsonSchema | undefined;
   /**
+   * Ancestor id path this form is nested under — set ONLY by the recursive
+   * render inside {@link FieldControl} (objectui#5062). A top-level form leaves
+   * it undefined, which is what keeps top-level ids spelled `mdf-{field}`.
+   */
+  idPath?: string;
+  /**
    * Optional FormView layout (sections, tabs, widget hints, visibleOn)
    * shipped by the framework alongside `schema`. When present, fields
    * are grouped into sections and visibility predicates are honoured.
@@ -750,6 +756,7 @@ export function SchemaForm({
   readOnly = false,
   createMode = false,
   widgetContext,
+  idPath,
 }: SchemaFormProps) {
   // Live app locale (follows the i18next language, not just the browser) —
   // hoisted above the no-schema early return so the hook order is stable.
@@ -833,6 +840,7 @@ export function SchemaForm({
         <SectionedSchemaForm
           form={form}
           props={props}
+          idPath={idPath}
           required={required}
           hiddenFields={hiddenFields}
           issuesByPath={issuesByPath}
@@ -861,6 +869,7 @@ export function SchemaForm({
         <FieldRow
           key={key}
           name={key}
+          idPath={idPath}
           schema={props[key]}
           value={(v as Record<string, unknown>)[key]}
           required={required.includes(key)}
@@ -895,6 +904,7 @@ function SectionedSchemaForm({
   readOnly,
   createMode,
   widgetContext,
+  idPath,
   onChange,
 }: {
   form: FormViewSpec;
@@ -906,6 +916,8 @@ function SectionedSchemaForm({
   readOnly?: boolean;
   createMode?: boolean;
   widgetContext?: WidgetContext;
+  /** Ancestor id path, forwarded from the hosting `SchemaForm` (#5062). */
+  idPath?: string;
   onChange: (key: string, val: unknown) => void;
 }) {
   const locale = useMetadataLocale();
@@ -958,6 +970,7 @@ function SectionedSchemaForm({
               >
                 <FieldRow
                   name={f.field}
+                  idPath={idPath}
                   schema={{
                     ...propSchema,
                     ...(f.label ? { title: f.label } : {}),
@@ -1073,10 +1086,48 @@ function SectionedSchemaForm({
   return <div className="space-y-4">{sections.map(renderSection)}</div>;
 }
 
+/* ----- id scoping (objectui#5062) ----------------------------------------- */
+
+/**
+ * Extend an ancestor id path with one more segment.
+ *
+ * DOM ids in this form are derived from the field's PATH, not from its local
+ * name: `FieldRow` is called recursively (composite sub-rows, repeater card
+ * rows, record items, the recursive `SchemaForm`), and two same-named
+ * sub-fields under different parents used to build the same id
+ * (`mdf-field` twice). A duplicate id is not a cosmetic problem here — a
+ * `<label for>` resolves to the FIRST match in the document, so the second
+ * field's label named and focused the first field's control: an association
+ * that is present, closed-looking to tooling, and cross-wired (objectui#5062;
+ * same failure class as the fixed-id collision objectui#3343 fixed in
+ * `packages/fields`).
+ *
+ * A TOP-LEVEL field passes no parent and keeps its historical `mdf-{field}`
+ * id — the selector surface the metadata-admin tests read stays exactly as it
+ * was; only nested rows gain a prefix.
+ *
+ * Segments are machine names (schema property / form-spec field names) and
+ * numeric row indices — the same class of input the flat `mdf-{field}` id
+ * already carried, so the ids stay derivable from the data path and
+ * whitespace-free for identifier-shaped names. Runtime user input is
+ * deliberately NOT a segment: a `record` item contributes its INDEX, never its
+ * author-typed key, which may contain spaces that an `aria-labelledby` IDREF
+ * would tokenize into two references.
+ */
+function joinIdPath(parent: string | undefined, segment: string | number): string {
+  return parent ? `${parent}.${segment}` : String(segment);
+}
+
+/** The host DOM id for a field at `path` — the `mdf-` namespace, path-scoped. */
+function fieldHostId(path: string): string {
+  return `mdf-${path}`;
+}
+
 /* ----- inner field row ---------------------------------------------------- */
 
 function FieldRow({
   name,
+  idPath,
   schema,
   value,
   required,
@@ -1088,6 +1139,14 @@ function FieldRow({
   onChange,
 }: {
   name: string;
+  /**
+   * The path of this row's ANCESTOR field, or undefined at the top level
+   * (objectui#5062). Each recursion point knows its own segment: a composite
+   * passes its own path, a repeater card row appends the row index, a record
+   * item appends the item index, and the recursive `SchemaForm` forwards the
+   * path of the field that hosts it.
+   */
+  idPath?: string;
   schema: JsonSchema;
   value: unknown;
   required: boolean;
@@ -1109,7 +1168,10 @@ function FieldRow({
   const description =
     (fieldSpec?.helpText as string | undefined) ||
     translateSchemaFieldHelp(name, schema?.description as string | undefined, locale);
-  const id = `mdf-${name}`;
+  // This row's own path — its id, and the ancestor path every nested row this
+  // field renders builds on (objectui#5062).
+  const path = joinIdPath(idPath, name);
+  const id = fieldHostId(path);
 
   // Auto-infer widget from fieldSpec.type or schema
   let widget = inferWidget(fieldSpec, schema);
@@ -1164,8 +1226,9 @@ function FieldRow({
   //    the id onto the radiogroup instead).
   const labelling = faceLabelling(face);
   const groupLabelled = labelling === 'group';
-  // Whitespace-free by construction (`mdf-` + a field name), and consumed as an
-  // `aria-labelledby` IDREF — a space in it would silently resolve to two ids.
+  // Whitespace-free by construction (`mdf-` + a dotted path of field names and
+  // row indices — see `joinIdPath`), and consumed as an `aria-labelledby`
+  // IDREF: a space in it would silently resolve to two ids.
   const labelId = groupLabelled ? `${id}-label` : undefined;
   // Exactly one of these two reaches the widget, ever.
   const channel = groupLabelled
@@ -1205,6 +1268,7 @@ function FieldRow({
           id={channel.id}
           ariaLabelledBy={channel.ariaLabelledBy}
           fieldName={name}
+          idPath={path}
           schema={schema}
           value={value}
           onChange={onChange}
@@ -1238,6 +1302,7 @@ function FieldRow({
         id={channel.id}
         ariaLabelledBy={channel.ariaLabelledBy}
         fieldName={name}
+        idPath={path}
         schema={schema}
         value={value}
         onChange={onChange}
@@ -1263,6 +1328,7 @@ function FieldControl({
   id,
   ariaLabelledBy,
   fieldName,
+  idPath,
   schema,
   value,
   onChange,
@@ -1284,6 +1350,12 @@ function FieldControl({
   ariaLabelledBy?: string;
   /** Machine field name — keys enum-option localization (e.g. flow `type`). */
   fieldName?: string;
+  /**
+   * The PATH of the field this control renders (objectui#5062) — the ancestor
+   * path for every nested row the structured faces below render. Distinct from
+   * `fieldName`, which is the local segment and keys localization only.
+   */
+  idPath?: string;
   schema: JsonSchema;
   value: unknown;
   onChange: (v: unknown) => void;
@@ -1322,6 +1394,7 @@ function FieldControl({
         widgetContext={widgetContext}
         fieldSpec={fieldSpec}
         ariaLabelledBy={ariaLabelledBy}
+        idPath={idPath}
         onChange={onChange}
       />
     );
@@ -1348,6 +1421,7 @@ function FieldControl({
         widgetContext={widgetContext}
         widget={fieldSpec?.widget}
         ariaLabelledBy={ariaLabelledBy}
+        idPath={idPath}
         onChange={onChange}
       />
     );
@@ -1371,6 +1445,7 @@ function FieldControl({
         keyField={(fieldSpec as any)?.keyField}
         formData={formData}
         ariaLabelledBy={ariaLabelledBy}
+        idPath={idPath}
         onChange={onChange}
       />
     );
@@ -1417,6 +1492,7 @@ function FieldControl({
           onChange={(v) => onChange(v)}
           readOnly={readOnly}
           widgetContext={widgetContext}
+          idPath={idPath}
         />
       </div>
     );
@@ -1434,6 +1510,7 @@ function FieldControl({
         widgetContext={widgetContext}
         widget={fieldSpec?.widget}
         ariaLabelledBy={ariaLabelledBy}
+        idPath={idPath}
         onChange={onChange}
       />
     );
@@ -1690,6 +1767,7 @@ function CompositeField({
   widgetContext,
   fieldSpec,
   ariaLabelledBy,
+  idPath,
   onChange,
 }: {
   value: unknown;
@@ -1704,6 +1782,8 @@ function CompositeField({
    * here is addressed by a SUB-field's own label.
    */
   ariaLabelledBy?: string;
+  /** This composite's own path — the ancestor path of its sub-rows (#5062). */
+  idPath?: string;
   onChange: (v: unknown) => void;
 }) {
   const obj = (value && typeof value === 'object' && !Array.isArray(value))
@@ -1717,6 +1797,7 @@ function CompositeField({
       <FieldRow
         key={spec.field}
         name={spec.field}
+        idPath={idPath}
         schema={subSchema}
         value={obj[spec.field]}
         required={Boolean(spec.required)}
@@ -1770,6 +1851,7 @@ function RepeaterField({
   widgetContext,
   widget,
   ariaLabelledBy,
+  idPath,
   onChange,
 }: {
   value: unknown;
@@ -1784,6 +1866,12 @@ function RepeaterField({
    * that label themselves, so the name belongs on the list, not on a control.
    */
   ariaLabelledBy?: string;
+  /**
+   * This repeater's own path. Each ROW appends its index to it, so two rows —
+   * and two repeaters carrying the same sub-field names — cannot build the same
+   * id (objectui#5062).
+   */
+  idPath?: string;
   onChange: (v: unknown) => void;
 }) {
   const locale = useMetadataLocale();
@@ -1911,6 +1999,7 @@ function RepeaterField({
                     <FieldRow
                       key={s.field}
                       name={s.field}
+                      idPath={joinIdPath(idPath, idx)}
                       schema={sub}
                       value={row?.[s.field]}
                       required={Boolean(s.required)}
@@ -1964,6 +2053,7 @@ function RecordField({
   keyField,
   formData,
   ariaLabelledBy,
+  idPath,
   onChange,
 }: {
   value: unknown;
@@ -1978,6 +2068,12 @@ function RecordField({
    * declaration holds in BOTH of this face's shapes.
    */
   ariaLabelledBy?: string;
+  /**
+   * This record field's own path. Each item appends its INDEX in display order
+   * — never its author-typed key, which is runtime user input and may contain
+   * whitespace an IDREF would tokenize (objectui#5062, `joinIdPath`).
+   */
+  idPath?: string;
   keyField?: {
     field?: string;
     label?: string;
@@ -2117,7 +2213,7 @@ function RecordField({
           {t('engine.list.empty', locale)}
         </div>
       )}
-      {entries.map(([key, row]) => {
+      {entries.map(([key, row], idx) => {
         const isOpen = openKey === key;
         const summary = specs
           .map((s) => row?.[s.field])
@@ -2180,6 +2276,7 @@ function RecordField({
               <div className="p-3 space-y-3">
                 <FieldRow
                   name={keyProp}
+                  idPath={joinIdPath(idPath, idx)}
                   schema={{ type: 'string' }}
                   value={key}
                   required
@@ -2197,6 +2294,7 @@ function RecordField({
                     <FieldRow
                       key={s.field}
                       name={s.field}
+                      idPath={joinIdPath(idPath, idx)}
                       schema={sub}
                       value={row?.[s.field]}
                       required={Boolean(s.required)}


### PR DESCRIPTION
Fixes #5062
Fixes #5063

两卡同文件、不同机制,按统一分诊席 22:11Z 批注合单:**一个 PR、两个清晰分隔的 commit,每卡一个**。

- 基线 `BASE = 90517e1a211c2e5579e3956786138830b0cae835`(含 PR #5061 `176843731`,SchemaForm 非注册表通道)
- `5ccc80422` — commit 1,#5062 路径作用域 id
- `fdb2493a5` — commit 2,#5063 grid/table 单元格由列头命名

两卡的前提都**先在基线上复现过**,读数与卡面逐字一致(见下)。

---

## commit 1 —— #5062:路径作用域 id

### 前提复现(基线 `90517e1a2`,真 SchemaForm 渲染)

两个 composite 字段 `a` / `b`,各带一个名为 `field` 的子字段(标签 "Field A" / "Field B",值 x / y):

```
ids: ["mdf-a-label","mdf-field","mdf-b-label","mdf-field"]
DUPLICATES: ["mdf-field"]
label "Field A" for=mdf-field  resolves to INPUT[value="x"]
label "Field B" for=mdf-field  resolves to INPUT[value="x"]   <- Field A 的控件
```

与卡面读数一致 —— 前提成立。这不是悬空,是**解析到了错的元素**:点 "Field B" 聚焦到 Field A 的输入框。

### 实施(分诊席级已裁方向 1)

`FieldRow` 新增 `idPath`(祖先路径,顶层为 undefined),id 由**路径**派生:

- composite 子行 → 传自己的路径
- repeater 卡片行 → 追加行序号
- record 展开项 → 追加**项序号**
- 递归 SchemaForm → 转发宿主字段的路径(`SchemaForm` / `SectionedSchemaForm` / `FieldControl` 各加一个透传 prop)

**顶层字段传不到父级,id 仍是 `mdf-{字段名}` 一字不动。** record 项入 id 的是序号而非作者输入的键名:键名是运行期用户输入,可能含空格,会把 `aria-labelledby` 的 IDREF 切成两个引用(这一条由 M4 变异钉住,见下)。

### 前后账本

```
前: ids ["mdf-a-label","mdf-field",  "mdf-b-label","mdf-field"]    DUPLICATES ["mdf-field"]
后: ids ["mdf-a-label","mdf-a.field","mdf-b-label","mdf-b.field"]  DUPLICATES []
    label "Field A" for=mdf-a.field  resolves to INPUT[value="x"]
    label "Field B" for=mdf-b.field  resolves to INPUT[value="y"]
```

### `mdf-` 消费方普查(编码前做)

全仓 `grep -rln 'mdf-'`(排除 node_modules / lockfile),**5 处,e2e 零命中** —— 与 #5039 席的报告一致:

| 消费方 | 读的 id | 是否变化 |
|---|---|---|
| `SchemaForm.colorPicker.labelling.test.tsx` | `mdf-colorVariant`(+`-label`) | 顶层,**不变** |
| `SchemaForm.widgetLabelling.test.tsx` | `mdf-${NAME}` | 顶层,**不变** |
| `SchemaForm.actionObjectPicker.test.tsx` | `mdf-objectName` / `mdf-name` | 顶层,**不变** |
| `SchemaForm.nonRegistryLabelling.test.tsx` | `mdf-${NAME}` 顶层 + **`mdf-inner` / `mdf-sub` 嵌套** | 嵌套两处 → `mdf-probe.inner` / `mdf-probe.sub`,**本 PR 已改** |
| `.changeset/schemaform-nonregistry-labelling-5039.md` | 散文里提到 `mdf-sub` / `mdf-inner` | 未动(见「未做」) |

`rep-` 只有一个生产端出现处,测试 / e2e 零消费方。

变的 id **只有嵌套行**,与预期一致。`nonRegistryLabelling` 那两处按「重新拼写」处置(fixture 只是引用了旧 id,断言的实质 —— 内层字段保有自己的 `for`、解析到自己的 INPUT、可访问名正确 —— 一条没动),不是「整体替换」那一类(它们本来就正面断言元素存在,不是靠「什么都没产生」而绿)。

### 钉子(`SchemaForm.nestedIdScope.test.tsx`,7 例)

嵌套侧 5 例:composite 交叉接线(断言**关联背后的值**,不止 id 不等)、repeater 行序号入路径、两个同名子字段 repeater 同时展开、record 项按序号且 id 无空白、递归 SchemaForm(顶层 `inner` 与嵌套 `inner` 并存)。顶层回归 2 例:control 通道 `for`/`id` 仍是 `mdf-{字段名}`,group 通道标签 id 仍是 `mdf-{字段名}-label` 且 IDREF 有应答者。

---

## commit 2 —— #5063:grid/table 单元格命名

### 前提复现(基线 `90517e1a2`,`widget: 'grid'`,子字段 field / order)

```
cell id=rep-0-field label[for]=NONE aria-label=NONE aria-labelledby=NONE
cell id=rep-0-order label[for]=NONE aria-label=NONE aria-labelledby=NONE
th "Field" id=NONE scope=NONE
th "Order" id=NONE scope=NONE
th ""      id=NONE scope=NONE
```

与卡面「三无」读数逐字一致 —— 前提成立。卡片布局对照绿(每行走 `FieldRow`,有真实 `label[for]`,解析到自己的控件、可访问名正确;本 PR 也把它钉住了)。

### 实施(分诊席级已裁方向 1)

每个 `th` 发一个 id + `scope="col"`,单元格控件以 `aria-labelledby` 指向对应列头 —— **列名只写一次**,改列名不会漂移。⛔ 未做方向 2 的逐格 `aria-label`(把列名复制进每行)。⛔ 行身份不入可访问名(分诊明示勿镀金;屏读语义上未实测出歧义,`td` 在真表格里已携带行位置)。

两处配套改动:

1. **列头 id 与单元格 id 都走 commit 1 的路径作用域**。基线上 `rep-{行}-{字段}` 会被同一表单里另一个 grid repeater 逐字复制 —— 实测 `DUPLICATES: ["rep-0-field"]`;现在是 `mdf-{路径}.{行}.{字段}`,与**卡片布局给同一数据格的 id 相同**。列头用 `-col` 后缀(而非 `FieldRow` 的 `-label`),说明它是「一整列共用的表头」而不是「某个字段的标签」,也不可能与同路径行的标签 id 混同。
2. `FieldControl` 的每条分支现在把 `aria-labelledby` **与** `id` 一起发,而不再当作二选一。「二者只有其一」是 `FieldRow` 关于**标签**的规则;grid 单元格根本没有标签,所以它两者都传 —— IDREF 供命名,id 只作锚点。`RawJsonEditor` 因此加了一个 `ariaLabelledBy` prop。

⛔ 未动 `WIDGET_LABELLING` / `WIDGETS` / `resolveFieldFace` 的任何判定逻辑,只在 id 与命名接线层动。

### 前后账本

```
前: cell id=rep-0-field       label[for]=NONE aria-label=NONE aria-labelledby=NONE
    th "Field" id=NONE                scope=NONE
后: cell id=mdf-cols.0.field   aria-labelledby=mdf-cols.field-col  (accessible name = "Field")
    cell id=mdf-cols.0.order   aria-labelledby=mdf-cols.order-col  (accessible name = "Order")
    th "Field" id=mdf-cols.field-col  scope=col
    th "Order" id=mdf-cols.order-col  scope=col
    th ""      id=NONE                scope=col      (行操作列:无名可发布,不做无人引用的锚点)

两个同名列 grid repeater:  前 DUPLICATES ["rep-0-field"] -> 后 DUPLICATES []
```

### 钉子(`SchemaForm.gridCellNaming.test.tsx`,5 例)

每格 IDREF 落在**对应的 `th`** 上且计算出的可访问名等于列名(不止断言属性存在)、三个 `th` 都带 `scope="col"` 且只有两个具名列发 id、Select 单元格与 Input 单元格一样具名、两个同名列 repeater 不撞 id **且各自被自己表格的列头命名**、卡片布局 `label[for]` 对照绿。

---

## 验证(全部实跑,读数如实)

```
依赖构建   pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build   -> Done

新钉子     pnpm exec vitest run .../SchemaForm.nestedIdScope.test.tsx     -> 7 passed (7)
           pnpm exec vitest run .../SchemaForm.gridCellNaming.test.tsx    -> 5 passed (5)
回归红线   pnpm exec vitest run .../SchemaForm.nonRegistryLabelling.test.tsx
                                .../SchemaForm.widgetLabelling.test.tsx   -> 102 passed (102)   (40 + 62)
           pnpm exec vitest run packages/app-shell/src/views/metadata-admin/
                                                                          -> 179 files, 1851 tests, 1 skipped, 0 failed
app-shell 全量  pnpm exec vitest run packages/app-shell/
                                                                          -> Test Files 424 passed (424)
                                                                             Tests 4076 passed | 1 skipped (4077)   exit 0
类型       pnpm exec turbo run type-check --concurrency=2                  -> Tasks: 81 successful, 81 total
lint       eslint 改动文件                                                 -> 0 errors;SchemaForm.tsx 的 16 个 warning
                                                                             与基线**逐条相同**(全部先存,未新增)
门禁       node scripts/check-changeset-presence.mjs -> OK(1 changeset)
           node scripts/check-changeset-no-major.mjs -> OK
           node scripts/check-control-bytes.mjs      -> OK(4520 个文件)
           改动文件自扫 grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' -> 零命中
```

测试一律在仓根、路径过滤、经 `flock /tmp/os-heavy-verify.lock` 串行,`--maxWorkers=2`。

## 反向验证(**先书面预判,commit 后变异,`git checkout --` 还原**)

| 变异 | 预判 | 实测 | 相符 |
|---|---|---|---|
| **M1** `path = joinIdPath(idPath, name)` 退回 `path = name` | nestedIdScope 嵌套 5 例红、顶层 2 例绿;nonRegistryLabelling 2 例红;**gridCellNaming 全绿**(grid 的 id 只依赖 repeater 自身路径,顶层 repeater 两种写法相同 —— 这一层看不见 #5062 的回归) | `7 failed / 107 passed`:嵌套 5 + nonRegistry 2 红,顶层 2 绿,gridCellNaming + widgetLabelling 两个文件全绿 | ✅ 完全相符 |
| **M2** `th` 不发 id(保留单元格的 `aria-labelledby`) | gridCellNaming 4 例红(IDREF 无应答者 → 可访问名算不出);卡片对照绿;nestedIdScope / widgetLabelling / nonRegistryLabelling 全绿 | `4 failed / 110 passed`,红的正是那 4 例 | ✅ 完全相符 |
| **M3**(自选的非显然方向)只从**短字符串 Input 这一条 scalar 分支**摘掉 `aria-labelledby` | 只有「读某一格计算出的可访问名」的断言抓得住:cell 命名 + 两 grid 各 1 例红;**同文件的 `scope`/列头 id 那例绿、Select 单元格那例绿**(分支不同);**全部既有套件绿** —— `FieldRow` 从不给 scalar 面发 IDREF,所以消费端断线在既有测试面上完全不可见 | `2 failed / 112 passed`,红的正是 cell 命名与两 grid 两例;列头/scope 例、Select 例、widgetLabelling 62 例、nonRegistryLabelling 40 例全绿 | ✅ 完全相符(列头侧的钉子对消费端断线**结构性失明**,两半各自独立钉住) |
| **M4** record 段位由**序号**改回**作者输入的键名** | 只有 nestedIdScope 的 record 那例红,其余全绿 | `1 failed / 113 passed`;`expected 'mdf-cfg.my key.title' to be 'mdf-cfg.0.title'` —— 空白直接进了 id | ✅ 完全相符(空格键名的危害是实测出来的,不是推测) |

四条变异全部与书面预判一致,无需改写模板。

## 未做 / 界外

- **行身份不入可访问名** —— 分诊明示勿镀金,屏读语义上也未实测出歧义。
- **同文件已存在的 16 个 lint warning** 未顺手清(与本 PR 无关)。
- **`.changeset/schemaform-nonregistry-labelling-5039.md`** 的散文里提到 `mdf-sub` / `mdf-inner`。那是 #5039 已落地改动的发布说明输入,它陈述的实质(可 label 元素属于子字段自己的标签)仍然成立,只是 id 拼法变了;发布说明输入不做搭车修改,故未动。
- **同一文档挂两个 SchemaForm(详情抽屉盖在编辑页表单上)→ 顶层 id 全量重复** —— 实测确有(`DUPLICATES: ["mdf-name","mdf-label"]`,抽屉侧标签解析到页面表单的控件),但作用域是**顶层**,恰是本次分诊裁定「不动」的那部分,修法也不同,已另开 **#5092** 未认领交 triage,不在本 PR 修。
- **顶层机器名含空白 → IDREF 被切成两个引用**:这条设想**实测不成立**,未开单。无 schema 的推断路径上带空格的键(`{'my key': {...}}`)落到的是 control 通道(`label[for]` 精确匹配,能用),文档里 `aria-labelledby` 元素为 0 个 —— 没有可报的缺陷。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_