### PR TITLE
docs(plugin-form): README 的 Schema API 与 Examples 按 form 真读的键面重写

### DIFF
--- a/.changeset/plugin-form-readme-key-face-5075.md
+++ b/.changeset/plugin-form-readme-key-face-5075.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+Docs only: `packages/plugin-form/README.md`'s Schema API and Examples now spell
+the keys the form renderers actually read (objectui#5075). Three connected
+drifts, judged against the build product's `dist/index.d.ts` under `strict`:
+
+- **`validation` was written as an ARRAY** of `{ type, value, message }` entries
+  in three places. The real key is `FormField.validation?: FieldValidationRules`
+  — an OBJECT keyed by rule name (`required`, `minLength`, `maxLength`, `min`,
+  `max`, `pattern`, `validate`). The array form is worse than a type error,
+  because its runtime failure is SILENT: the only reader spreads the value into
+  the rule object handed to react-hook-form (`const rules: any = { ...validation }`,
+  `packages/components/src/renderers/form/form.tsx:1652`), and spreading an array
+  into an object literal yields numeric keys (`{ '0': …, '1': … }`).
+  react-hook-form's field validator reads exactly `required`, `maxLength`,
+  `minLength`, `min`, `max`, `pattern`, `validate`, `valueAsNumber` off its
+  descriptor, so every documented rule was dropped with nothing thrown — a form
+  copied from this README looked validated while validating nothing. The rewrite
+  also records two facts a reader could not have guessed: `validation.required`
+  supplies the required MESSAGE only (presence is decided by the field's own
+  `required` / `requiredWhen`), and a hand-authored `pattern.value` must be a
+  RegExp, since react-hook-form only applies a pattern whose value
+  `instanceof RegExp` and it is the object-metadata path (`buildValidationRules`)
+  that compiles a declared string into one.
+
+- **`type: 'multi-step-form'` is registered nowhere**, and `steps` is not a key
+  on any form schema — so the whole "Multi-Step Form" example rendered the
+  unknown-component placeholder, with the fields inside `steps` never read. The
+  example is replaced by the two real entry points: an `object-form` with
+  `formType: 'wizard'`, whose steps are its `sections` (this is what
+  `ObjectForm` routes to `WizardForm`), and the exported `WizardForm` itself
+  with inline section fields and no data source — the shape closest to what the
+  old snippet was reaching for. No new schema type was registered to make the
+  old spelling true.
+
+- **The `FormField` reference block declared a local `interface FormField`**,
+  which type-checks whatever it says because it is unrelated to the real type.
+  Five of its rows were wrong (`type` and `label` are OPTIONAL; `validation` is
+  the object above; `defaultValue` and `className` are not declared keys — the
+  form-level `defaultValues` and `span` / `colSpan` / `fieldContainerClass` are),
+  it named a `ValidationRule` type that exists nowhere in the repo, and it listed
+  7 of the real 23 keys. The block is now a key table over the real declaration,
+  with `FormSchema`'s own keys beside it, and both examples are annotated with
+  their real types — the annotation is the point: `FormField` and `BaseSchema`
+  both declare `[key: string]: any`, so an un-annotated `const schema = { … }`
+  accepts any invented key and a nonexistent key is never a compile error.
+
+No renderer behaviour changes, and no capability, export or type was added to
+make an example true.

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -143,39 +143,114 @@ component the same way.
 
 ## Schema API
 
-### Form
+Two form schemas reach a renderer, and **both are declared in
+`@object-ui/types`** — this package imports them and declares neither. The
+tables below name the keys and point at the declaration; the declaration is the
+contract. (Restating an interface inside this README is what let this section
+drift away from the code in the first place — objectui#5075.)
 
-Complete form with fields and validation:
+| Schema | `type` | Declared in | Rendered by |
+|---|---|---|---|
+| `FormSchema` | `'form'` | `packages/types/src/form.ts` | the basic form in `@object-ui/components` — bare `form` is deliberately **not** claimed by this plugin (`skipFallback: true`, see the table above) |
+| `ObjectFormSchema` | `'object-form'` | `packages/types/src/objectql.ts` | `ObjectForm` here, through `plugin-form:object-form` / `object-form` |
 
-```typescript
-{
-  type: 'form',
-  fields: FormField[],
-  submitLabel?: string,
-  cancelLabel?: string,
-  onSubmit?: (data) => void,
-  onCancel?: () => void,
-  className?: string
-}
-```
+Both `type` slots are string **literals**. A schema whose `type` names something
+no registration claims does not fall back to a form — it renders the
+unknown-component placeholder.
+
+### Form (`type: 'form'`)
+
+| Key | Type | Notes |
+|---|---|---|
+| `type` | `'form'` | literal, not a free string |
+| `fields` | `FormField[]` | **optional** — a form may render `children` instead |
+| `defaultValues` | `Record<string, any>` | form-level initial values. There is no field-level `defaultValue` |
+| `submitLabel` / `cancelLabel` | `string` | button text |
+| `showCancel` / `showActions` | `boolean` | action-row composition |
+| `mobileStickyActions` | `boolean` | pin the action row on small viewports |
+| `layout` | `'vertical' \| 'horizontal'` | label placement |
+| `columns` | `number` | grid width (1–4) |
+| `validationMode` | `'onSubmit' \| 'onBlur' \| 'onChange' \| 'onTouched' \| 'all'` | when the rules run |
+| `resetOnSubmit` / `disabled` | `boolean` | |
+| `mode` | `'edit' \| 'read' \| 'disabled'` | whole-form mode |
+| `objectName` | `string` | enables metadata field locators `data-testid="field:{objectName}.{field}"` (ADR-0054 C4) |
+| `previousValues` | `Record<string, any>` | edit-mode hosts only — the persisted record, as evaluation context for `previous` / `readonlyWhen`. Never sent anywhere |
+| `fieldContainerClass` | `string` | class for the field grid inside the `<form>` |
+| `fieldTabs` / `defaultFieldTab` / `fieldTabsPosition` | see [Tabbed field layout](#tabbed-field-layout-fieldtabs) | |
+| `fieldPanes` / `fieldPanesOrientation` / `fieldPanesResizable` | see [Split field layout](#split-field-layout-fieldpanes) | |
+| `actions` | `SchemaNode[]` | extra nodes in the action row |
+| `children` | `SchemaNode \| SchemaNode[]` | custom body instead of `fields` |
+| `onSubmit` / `onChange` / `onDirtyChange` / `onCancel` | callbacks | **TypeScript-authored schemas only** — a JSON metadata document cannot carry a function. Metadata pages go through the object-form route instead |
+| `className`, `id`, `hidden`, … | — | inherited from `BaseSchema` |
+
+⚠️ `FormSchema` extends `BaseSchema`, which declares `[key: string]: any`
+(`packages/types/src/base.ts`), so an invented or misspelled key on a form schema
+is **not** a compile error — it is simply never read. That is why every example
+below is annotated with its real type *and* checked against these key tables:
+an un-annotated `const schema = { … }` type-checks whatever is written in it.
 
 ### Form Field
 
-Individual form field configuration:
+`FormField` (`packages/types/src/form.ts`) declares 23 keys, and `name` is the
+only **required** one:
 
-```typescript
-interface FormField {
-  name: string;
-  type: string;                   // 'input', 'select', 'checkbox', etc.
-  label: string;
-  placeholder?: string;
-  required?: boolean;
-  validation?: ValidationRule[];
-  defaultValue?: any;
-  disabled?: boolean;
-  className?: string;
-}
-```
+| Key | Type | What it does |
+|---|---|---|
+| `name` | `string` | **required** — the submit key |
+| `id` | `string` | stable render key; falls back to `name` |
+| `label` | `string` | optional — with none, no label element is rendered at all (validation messages fall back to `name`). The object-bound paths always fill it from the object field |
+| `description` | `string` | help text under the control |
+| `type` | `string` | optional, defaults to `'input'`. Built-ins: `input`, `textarea`, `checkbox`, `switch`, `select`; any other value resolves through the registry (`field:<type>` first, then the bare name) |
+| `inputType` | `string` | HTML input type for `type: 'input'` — `'email'`, `'password'`, `'tel'`, … |
+| `widget` | `string` | widget override; wins over `type` (spec `FormField.widget`) |
+| `placeholder` | `string` | |
+| `required` | `boolean` | the presence rule. `validation.required` does **not** make a field required — see below |
+| `disabled` | `boolean` | not interactive, muted |
+| `readonly` | `boolean` | shown plainly, not editable — deliberately distinct from `disabled` |
+| `hidden` | `boolean` | field is not rendered at all |
+| `options` | `SelectOption[] \| RadioOption[]` | for `select` / radio fields |
+| `validation` | `FieldValidationRules` | **an object keyed by rule name** — see below |
+| `condition` | `FieldCondition` | legacy `{ field, equals, notEquals, in, custom }` matcher |
+| `visibleWhen` / `readonlyWhen` / `requiredWhen` | `string \| { dialect?, source }` | CEL predicates over the live record, evaluated by `@objectstack/formula` — the same engine and dialect the server uses. Fail open |
+| `visibleOn` | `string \| { dialect?, source }` | view-level visibility predicate (spec `FormField.visibleOn`) |
+| `dependsOn` | `DependsOnInput` | cascading parent(s): a bare name, a list of names, or `{ field, param }` entries |
+| `span` | `'auto' \| 'full'` | relative width, independent of the column count (preferred) |
+| `colSpan` | `number` | legacy column span (1–4), clamped to the current column count |
+| `field` | `Record<string, any>` | the resolved object-field **metadata object**, stashed by the object-bound paths so widgets can read `precision`, `currency`, `reference_to`, … In the *spec* form-view vocabulary `field` is a string (the referenced field name); that shape ends at `normalizeSectionField` and never reaches a runtime `FormField` |
+
+`FormField` also declares `[key: string]: any`, so an invented key type-checks
+here too. Two that a reader might expect, and that are **not** declared:
+
+| Not a `FormField` key | Write this instead |
+|---|---|
+| `defaultValue` | `FormSchema.defaultValues` at form level. An object-bound form seeds from the object field's own declared `defaultValue` — see [What a create form opens with](#what-a-create-form-opens-with) |
+| `className` | `span` / `colSpan` for width, `FormSchema.fieldContainerClass` for the grid. (A field-level `className` is read on exactly one pseudo-field, `type: 'section-divider'`, where it styles the inline section header.) |
+
+There is no `ValidationRule` type in this repo, under any spelling.
+
+#### `validation` is an object keyed by rule name
+
+`FieldValidationRules` (`packages/types/src/form.ts`) is **not** an array of
+`{ type, value, message }` entries:
+
+| Rule | Type | Notes |
+|---|---|---|
+| `required` | `string \| boolean` | supplies the required **message** only. Whether the field is required is decided by `required` / `requiredWhen` **on the field** |
+| `minLength` / `maxLength` | `{ value: number; message: string }` | `message` is not optional when you author the rule by hand |
+| `min` / `max` | `{ value: number; message: string }` | numeric range |
+| `pattern` | `{ value: string \| RegExp; message: string }` | pass a **RegExp** in a hand-authored schema: react-hook-form only applies a pattern whose value `instanceof RegExp`, and it is the object-metadata path (`buildValidationRules` in `@object-ui/fields`) that compiles a declared string into one |
+| `validate` | `(value) => boolean \| string \| Promise<boolean \| string>` | custom check; TypeScript-authored schemas only |
+
+There is no `email` rule name — an email check is a `pattern`, which is exactly
+what `buildValidationRules` emits for an object field of type `email`.
+
+**Why the array spelling fails silently.** The only reader of this key is the
+basic form renderer, which spreads it into the rule object handed to
+react-hook-form — `const rules: any = { ...validation }`
+(`packages/components/src/renderers/form/form.tsx:1652`). Spreading an **array**
+into an object literal produces numeric keys (`{ '0': …, '1': … }`), which
+react-hook-form does not recognise: every rule is dropped, nothing throws, and
+the form looks validated while validating nothing.
 
 ### What a create form opens with
 
@@ -368,7 +443,9 @@ primary pane, the rest stack in the secondary one behind inline section headers.
 ### Basic Form
 
 ```typescript
-const schema = {
+import type { FormSchema } from '@object-ui/types';
+
+const schema: FormSchema = {
   type: 'form',
   fields: [
     {
@@ -384,9 +461,15 @@ const schema = {
       inputType: 'email',
       label: 'Email Address',
       required: true,
-      validation: [
-        { type: 'email', message: 'Invalid email format' }
-      ]
+      // Rule name → rule. Not an array (see Schema API above), and there is no
+      // 'email' rule: the email check is the pattern the metadata path builds
+      // for a field of type `email`.
+      validation: {
+        pattern: {
+          value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+          message: 'Invalid email format'
+        }
+      }
     },
     {
       name: 'country',
@@ -413,51 +496,111 @@ const schema = {
 
 ### Multi-Step Form
 
+A multi-step form is an **`object-form` with `formType: 'wizard'`**, and its
+steps are its `sections` — one step per section. There is no
+`multi-step-form` schema type (no registration anywhere claims that name) and no
+`steps` key on any form schema, so a schema written that way renders the
+unknown-component placeholder and the fields inside `steps` are never read.
+
 ```typescript
-const schema = {
-  type: 'multi-step-form',
-  steps: [
+import type { ObjectFormSchema } from '@object-ui/types';
+
+const schema: ObjectFormSchema = {
+  type: 'object-form',
+  objectName: 'contacts',        // required
+  mode: 'create',                // required
+  formType: 'wizard',            // routes to WizardForm — needs at least one section
+  sections: [
     {
-      title: 'Personal Info',
+      name: 'personal',
+      label: 'Personal Info',
+      fields: ['first_name', 'last_name']    // field NAMES, resolved from the object schema
+    },
+    {
+      name: 'contact',
+      label: 'Contact Info',
+      fields: ['email', 'phone']
+    }
+  ],
+  allowSkip: false,              // see "Wizard steps and allowSkip" above
+  showStepIndicator: true
+};
+```
+
+A section's `fields` accepts three shapes — a field **name**, a spec
+`FormFieldSchema` object (whose identity key is `field`), or an inline runtime
+`FormField` object. The inline shape is what lets a wizard run with no data
+source at all, which is the closest equivalent of the old snippet; note that
+`WizardForm` reports a data-source-less submit through `onSuccess` (there is no
+`onSubmit` on this schema):
+
+```tsx
+import { WizardForm } from '@object-ui/plugin-form';
+import type { WizardFormSchema } from '@object-ui/plugin-form';
+
+const wizard: WizardFormSchema = {
+  type: 'object-form',
+  formType: 'wizard',
+  objectName: 'contacts',
+  mode: 'create',
+  sections: [
+    {
+      name: 'personal',
+      label: 'Personal Info',
       fields: [
         { name: 'firstName', type: 'input', label: 'First Name', required: true },
         { name: 'lastName', type: 'input', label: 'Last Name', required: true }
       ]
     },
     {
-      title: 'Contact Info',
+      name: 'contact',
+      label: 'Contact Info',
       fields: [
         { name: 'email', type: 'input', inputType: 'email', label: 'Email', required: true },
         { name: 'phone', type: 'input', inputType: 'tel', label: 'Phone' }
       ]
-    },
-    {
-      title: 'Review',
-      fields: []
     }
   ],
-  onSubmit: (data) => {
+  onSuccess: (data) => {
     console.log('Multi-step form completed:', data);
   }
 };
+
+<WizardForm schema={wizard} />   // dataSource omitted: every step lists inline fields
 ```
+
+`WizardFormSchema` declares no index signature, so an invented key on *this*
+type is a real compile error — unlike `ObjectFormSchema`, which inherits
+`BaseSchema`'s `[key: string]: any`.
+
+One more route exists and is worth knowing about rather than reinventing: a flat
+`object-form` can be turned into a stepper on small viewports with
+`mobile: { stepper: true | 'auto', stepperFieldsPerStep, stepperMinFields }`,
+which feeds the same `WizardForm`.
 
 ### Form with Validation
 
 ```typescript
-const schema = {
+import type { FormSchema } from '@object-ui/types';
+
+const schema: FormSchema = {
   type: 'form',
+  validationMode: 'onBlur',
   fields: [
     {
       name: 'username',
       type: 'input',
       label: 'Username',
-      required: true,
-      validation: [
-        { type: 'minLength', value: 3, message: 'Username must be at least 3 characters' },
-        { type: 'maxLength', value: 20, message: 'Username must be less than 20 characters' },
-        { type: 'pattern', value: '^[a-zA-Z0-9_]+$', message: 'Only letters, numbers, and underscores' }
-      ]
+      required: true,                 // presence: this is the key that decides it
+      validation: {
+        required: 'Pick a username',   // the MESSAGE for the rule above, nothing more
+        minLength: { value: 3, message: 'Username must be at least 3 characters' },
+        maxLength: { value: 20, message: 'Username must be less than 20 characters' },
+        pattern: {
+          value: /^[a-zA-Z0-9_]+$/,    // a RegExp, not a string
+          message: 'Only letters, numbers, and underscores'
+        }
+      }
     },
     {
       name: 'password',
@@ -465,14 +608,23 @@ const schema = {
       inputType: 'password',
       label: 'Password',
       required: true,
-      validation: [
-        { type: 'minLength', value: 8, message: 'Password must be at least 8 characters' },
-        { type: 'pattern', value: '(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])', message: 'Must contain uppercase, lowercase, and number' }
-      ]
+      validation: {
+        minLength: { value: 8, message: 'Password must be at least 8 characters' },
+        pattern: {
+          value: /(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])/,
+          message: 'Must contain uppercase, lowercase, and number'
+        },
+        validate: (value) =>
+          String(value).toLowerCase() !== 'password' || 'Pick something less guessable'
+      }
     }
   ]
 };
 ```
+
+Each rule appears **once**, under its own name — an object, not a list. A second
+`minLength` cannot exist, which is the point: the shape the renderer hands
+react-hook-form is one rule per kind.
 
 ## Integration with Data Sources
 


### PR DESCRIPTION
Fixes #5075

`packages/plugin-form/README.md` 的 `## Schema API` 与 `## Examples` 两节整段重写。三组是**连体**的:只改参考块、留着两个示例继续教 `validation: [ … ]`,同一个 README 会自相矛盾。纯文档改动 —— 不改渲染器行为,不动 `form.tsx` 的读点,未新增任何能力、导出或类型。

基线 `origin/main` = `9fbb9b52ffa92432019a9a5ebfdd6a671d891f77`。

## 前提门:卡面三组读数逐条复测

| 卡面读数 | 复测 |
|---|---|
| README 三处 `validation: [ … ]` | 成立(改前 :387 / :456 / :468) |
| `FieldValidationRules` 是按规则名开键的**对象**(`types/src/form.ts:744`) | 成立 |
| 唯一读点 `components/src/renderers/form/form.tsx:1652` 的 `{ ...validation }` | 成立 |
| `multi-step-form` 全仓仅该 README 命中 | 成立 |
| 本包六个 register 调用 | 成立(`plugin-form/src/index.tsx` :100 / :159 / :211 / :232 / :276 / :356) |
| `steps` 不在 `FormSchema` 上 | 成立,且更强:`packages/types/src` **零声明**,全仓 `.steps` 读点全是 flow 执行日志(app-shell / console),与表单无关 |
| `FormField` 真身 23 键(`form.ts:898`) | 成立(逐键点数 = 23) |
| 参考块「只列了 23 个键里的 9 个、缺席 15 个」 | **修正为 7 / 16** —— 被数进「列了」的 `defaultValue`、`className` 本就不是真键;卡面的缺席清单漏了 `inputType`,而 README 自己的示例一直在用它 |
| 「五处漂移」 | 成立,但**证据分层**:`type`/`label` 可选性与 `validation` 形由编译探针证明;`defaultValue`/`className` **不能**由探针证明(见「探针有牙 / 致盲」) |

## 三组判定表

### 1 · `validation` 数组拼法 → 真身对象形

| README 写的 | 真身 | 处置 |
|---|---|---|
| `validation: [{ type: 'email', … }]`(Basic Form) | `FieldValidationRules` 无 `email` 规则名 | 改 `pattern`,正则取 `buildValidationRules` 对 `type === 'email'` 字段发出的同一条 |
| `validation: [{ type: 'minLength', value, message }, …]`(Form with Validation ×2) | `minLength?: { value: number; message: string }` 等按名开键 | 逐条改成对象成员;`message` 手写时不是可选的 |
| `validation?: ValidationRule[]`(参考块) | `validation?: FieldValidationRules` | 见第 3 组 |
| `{ type: 'pattern', value: '^…$' }` 的 string 正则 | 手写面必须给 RegExp | 示例改 RegExp 字面量,并写明原因;类型侧的二义留给另立的 #5099 |
| —— | `validation.required` 只提供**消息** | 新增说明:是否必填由字段自身的 `required` / `requiredWhen` 决定(`form.tsx:1704` 只把它当 message,presence 来自 `resolveFieldRuleState`) |

### 2 · `multi-step-form` / `steps` → 真实入口

| README 写的 | 真身 | 处置 |
|---|---|---|
| `type: 'multi-step-form'` | 全仓无任何注册认领该名 | 改 `object-form` + `formType: 'wizard'`(`ObjectForm.tsx:255` 的路由,条件是 `formType === 'wizard' && sections?.length`) |
| `steps: [{ title, fields }]` | 任何 form schema 都无 `steps` 键 | 步骤即 `sections`,每 section 一步;`ObjectFormSection.fields` 收 `(string \| FormField)[]` |
| 无 dataSource 的内联字段 | section 内联 runtime `FormField` 直通(`sectionFields.ts:164`) | 第二个示例用导出的 `WizardForm` + 内联字段,`dataSource` 省略 |
| `onSubmit` | `WizardFormSchema` 上没有这个键;无 dataSource 时回调是 `onSuccess`(`WizardForm.tsx:485`) | 改 `onSuccess` |
| —— | 另一条真实路线 | 补一句 `mobile: { stepper }` 的扁平表单自动分步(`ObjectForm.tsx:1279`),避免读者重新发明 |

⛔ 未注册任何新 type、未新增任何键去把旧拼法变真。

### 3 · `FormField` 参考块 → 真身 23 键

| 参考块 | 真身 | 判定 |
|---|---|---|
| `type: string`(必填) | `type?: string` | 错;缺省 `'input'` |
| `label: string`(必填) | `label?: string` | 错;缺省时**不渲染 label 元素**(校验消息才回落到 `name`)—— 卡面未涉及,按读点如实写 |
| `validation?: ValidationRule[]` | `validation?: FieldValidationRules` | 错;`ValidationRule` 这个名全仓不存在 |
| `defaultValue?: any` | 未声明 | 错;表单级是 `FormSchema.defaultValues` |
| `className?: string` | 未声明 | 错;宽度是 `span` / `colSpan`,栅格是 `FormSchema.fieldContainerClass`。**口径**:字段级 `className` 确有一个读点,但只在 `type: 'section-divider'` 这个伪字段上(`form.tsx:1646`),README 如实标注 |
| 缺席 16 键 | `id` `description` `inputType` `widget` `options` `condition` `visibleOn` `visibleWhen` `readonlyWhen` `requiredWhen` `dependsOn` `hidden` `readonly` `field` `colSpan` `span` | 全部补进键表 |

参考块不再现场声明本地 `interface FormField`(裸声明永远编译通过,正是本次漂移的成因),改为对真身声明的键表 + `FormSchema` 键表,示例逐块标注真类型。

## 静默失效:前提复现

第 1 组最要紧的一半是**运行时静默**,而不是类型红。机制复现(node,零 React):

```
const validation = [
  { type: 'minLength', value: 3, message: '…' },
  { type: 'pattern',   value: '^[a-zA-Z0-9_]+$', message: '…' },
];
const rules = { ...validation };            // form.tsx:1652 逐字
spread result keys : [ '0', '1' ]
recognised by RHF  : []
```

react-hook-form 7.85.0 的字段校验器只解构固定集合(`dist/index.cjs.js`):

```
const{ref:c,refs:f,required:m,maxLength:y,minLength:p,min:g,max:b,pattern:V,validate:A,name:x,valueAsNumber:S,mount:k}=e._f
```

数字键不在其中 —— README 教出来的 email / minLength / maxLength / pattern 一条不跑,且没有任何报错。照抄的表单看上去有校验,实际没有。

顺带同一读点的另一面(已另立 #5099,本 PR 不动代码):`pattern.value` 写 string 也是静默失效 —— RHF 只应用 `value instanceof RegExp` 的 pattern(`Z=e=>e instanceof RegExp`),把声明的 string 编译成正则的只有元数据路线的 `buildValidationRules`(`fields/src/index.tsx:2303`)。README 因此教 RegExp 字面量。

## 探针有牙 / 致盲(先实测,再声称)

探针一律对**构建产物** `dist/index.d.ts`,`strict`,逐块单文件编译。

**有牙**(声明键的类型压过索引签名):

| 探针 | 读数 |
|---|---|
| 三处 `validation: [ … ]` 标注 `FormSchema` | `TS2559: Type '{ type: string; message: string; }[]' has no properties in common with type 'FieldValidationRules'` ×3 |
| `type: 'multi-step-form'` 标注 `FormSchema` | `TS2322: Type '"multi-step-form"' is not assignable to type '"form"'` |
| real → doc(参考块) | `TS2322 … Types of property 'type' are incompatible … Type 'string \| undefined' is not assignable to type 'string'` |
| real → `{ name; label }` | `TS2322 … 'label' … 'string \| undefined' is not assignable to 'string'` |
| `const f: FormField = {}` | `TS2741: Property 'name' is missing` —— `name` 是唯一必填键 |
| doc → real(参考块) | `TS2322 … 'validation' … 'DocValidationRule[]' has no properties in common with type 'FieldValidationRules'` |

**致盲**(实测确认,不冒充键面证据):

| 探针 | 预判 | 实测 |
|---|---|---|
| `steps: [ … ]` 挂在 `FormSchema` 上 | 不报错 —— `FormSchema extends BaseSchema`,`base.ts:318` 有 `[key: string]: any` | 不报错 ✓ |
| `{ name: 'x', defaultValue: 'draft' }` 标注 `FormField` | 不报错 —— `FormField` 自带 `[key: string]: any`(`form.ts:1034`) | 不报错 ✓ |
| `{ name: 'x', className: 'col-span-2' }` 标注 `FormField` | 同上 | 不报错 ✓ |

所以 `steps` / `defaultValue` / `className` 三条**只**由「声明缺席 + 读点 grep」证明,PR 与 README 都按这个口径写。反面对照:`WizardFormSchema` 没有索引签名,标注它的示例里发明一个键就是真编译错误 —— README 也把这条差别写下来了。

改后:两个 after 探针(重写后的 Basic / Validation / 两条 wizard 示例,含 `WizardFormProps` 省略 `dataSource`)`rc=0`。

## 反向验证(预判先写,实测在后)

- **(a) 旧数组回填 → 预判红。** 实测红:`TS2559` ×3(见上)。
- **(b) 双向 pin 各砍一向 → 预判各漏一半。** 实测**部分不符,如实记录**:
  - 只留 doc → real:报 `validation` 形,对 `type`/`label` 被写成必填**沉默** —— 更严格的源赋给更宽松的目标本就合法,这一向结构上看不见「文档过度必填」。与预判一致(#5013 家族形)。
  - 只留 real → doc:报 `type` 可选性。
  - 追加的第三次砍(real → doc,但把 doc 的 `validation` 改回数组、optionality 修好):**也**报 `validation`(`FieldValidationRules is missing the following properties from type 'DocValidationRule[]': length, pop, push …`)。所以两向并不是「各自独占一个事实」:TS 每个赋值只报**第一个**不相容属性,覆盖面取决于属性顺序。双向仍然必要(方向 2 看不见过度必填),但理由是这个,不是模板预设的「一向一事实」。
- **(c) 名集合核对无新假名。** 见下。

## 名集合核对(#5043 规格)

对 README 的全部代码块做 AST 解析,收集 import 绑定与类型引用,逐个对**构建产物**的真实导出集合核验:

```
改前(origin/main 的 README):
  local     FormField      (declared in the block)      ← 本地假声明,正是本次漂移
  UNKNOWN   ValidationRule — no module exports this name
  verdict: 1 problem(s)

改后:
  README code blocks parsed: 16
  imported bindings: 53 个全部 OK(plugin-form / types / core / data-objectstack)
  type references : FormField, FormSchema, ObjectFormSchema, WizardFormSchema —— 全部 imported 且真实
  verdict: clean
```

## 门禁

| 命令 | 结果 |
|---|---|
| `pnpm exec turbo run type-check --concurrency=2`(仓根,经 flock) | `Tasks: 81 successful, 81 total`,`rc=0` |
| `node scripts/check-doc-links.mjs` | `Links are valid across 13 scan roots.` |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 4525 tracked text file(s))` |
| 改动文件自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` | 零命中 |

## 范围

只动 `packages/plugin-form/README.md` + 一个 changeset(`@object-ui/plugin-form` patch,docs 级)。与在飞 #5066 / #5062 / #5063 零交集。

实施中扫出、**未夹带**进本 PR 的两条,已另立卡:

- #5098 —— 同文件 `## Integration with Data Sources` 一节把 `dataSource` / `resource` 写在 form schema 上,两键全仓零读取点(真机制是 `SchemaRendererContext`,本 README 别处已写对,属自相矛盾)。不在本卡三组之内。
- #5099 —— 手写 `FieldValidationRules` 在唯一读点既不校验也不归一:`pattern.value` 写 string(类型明确允许)被 RHF 静默忽略,未识别的规则名同样静默丢弃。改法涉及公开类型/渲染器,附两方案与推荐,交维护者定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_