### PR TITLE
docs(plugin-view): README 的 13 个 schema 示例按 ObjectView 真读的键面重写

### DIFF
--- a/.changeset/plugin-view-readme-real-schema-keys.md
+++ b/.changeset/plugin-view-readme-real-schema-keys.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/plugin-view': patch
+---
+
+The plugin-view README now documents the keys `ObjectView` actually reads, so a
+copied example renders instead of coming up empty.
+
+Every untyped schema literal in the README was written against a key vocabulary
+`ObjectViewSchema` does not declare and `ObjectView` does not read. The object
+name was spelled `object` — the real key is `objectName`, and it is the only
+required key besides `type` — so a copied example left the component with no
+object to query. Three "view modes" were organized around a `viewMode` key that
+exists nowhere, and `fields`, `mode`, `recordId`, `fieldConfig`, `nestedFields`,
+`tabs`, `searchable`, `sortable`, `filters` and `enableDelete` were documented
+the same way. None of it failed loudly: `ObjectViewSchema` extends a base schema
+carrying a `[key: string]: any` index signature, so excess-property checking is
+defeated on this type, and the blocks carried no type annotation to trip even
+the one assertion that does bite.
+
+The thirteen affected blocks are rewritten against the declared surface, each
+one measured against the renderer before being written: `defaultViewType` (plus
+`listViews` / `defaultListView`) for the list type, `layout` with its
+drawer/modal/page record surface for what the README called form and detail
+views, `table` and `form` for grid and form configuration, `operations`
+booleans and `onNavigate` in place of the `onCreate` / `onUpdate` / `onDelete` /
+`onSubmit` callbacks that were never part of this contract, and the `show*`
+toolbar toggles. Examples now carry `ObjectViewSchema` annotations, which makes
+a missing `objectName` a compile error in all fifteen of them.
+
+Three structural facts are stated outright rather than left to be inferred:
+`dataSource` is a required prop of `ObjectViewProps` and not a schema key, so
+putting it in the schema does nothing; create/edit/read are internal states of
+one record surface rather than authored modes, which is why `ObjectViewSchema`
+omits `mode` from its `form` block; and `ObjectView` forwards a fixed list of
+keys out of `table` and `form` rather than passing those objects through, so the
+README now names exactly which ones — including that page size is `table.pageSize`
+on this path, the spelling the component forwards.
+
+The `ViewSwitcher`, `FilterUI` and `SortUI` sections are untouched: their keys
+were checked against the registered `inputs` and already matched.

--- a/packages/plugin-view/README.md
+++ b/packages/plugin-view/README.md
@@ -26,14 +26,19 @@ pnpm add @object-ui/plugin-view
 ```typescript
 // In your app entry point (e.g., App.tsx or main.tsx)
 import '@object-ui/plugin-view';
+import type { ObjectViewSchema } from '@object-ui/types';
 
 // Now you can use view types in your schemas
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'grid'
+  objectName: 'users', // required — the ObjectQL object name
+  defaultViewType: 'grid',
 };
 ```
+
+The object name key is **`objectName`**, and it is the only required key besides
+`type`. There is no `object`, `viewMode`, `fields`, `mode` or `recordId` key on
+this node — see "Schema API" below for the keys `ObjectView` actually reads.
 
 ### What the side-effect import registers
 
@@ -130,21 +135,84 @@ ComponentRegistry.register('my-switcher', ViewSwitcher, {
 
 ### ObjectView
 
-Unified view component for ObjectQL objects:
+Unified view component for ObjectQL objects. The keys below are the ones
+`ObjectView` reads off the schema node (`src/ObjectView.tsx`); every example in
+this README is typed with `ObjectViewSchema` from `@object-ui/types`, so a
+missing `objectName` fails to compile.
 
 ```typescript
-{
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const shape: ObjectViewSchema = {
   type: 'object-view',
-  object: string,                 // ObjectQL object name
-  viewMode?: 'grid' | 'form' | 'detail',
-  fields?: string[],              // Fields to display
-  dataSource?: DataSource,
-  onCreate?: (data) => void,
-  onUpdate?: (id, data) => void,
-  onDelete?: (id) => void,
-  className?: string
-}
+  objectName: 'users', // required — ObjectQL object name
+  title: 'Users',
+  description: 'Everyone with an account',
+
+  // --- List surface ---
+  defaultViewType: 'grid', // grid | kanban | gallery | calendar | timeline | gantt | map
+  listViews: { all: { label: 'All Users' } }, // named views; each needs a `label`
+  defaultListView: 'all',
+  table: { columns: ['name', 'email'] }, // grid configuration (see below)
+
+  // --- Record surface (create / edit / read) ---
+  layout: 'drawer', // drawer | modal | page
+  form: { showSubmit: true }, // form configuration (see below)
+  navigation: { mode: 'drawer' }, // row-click behaviour
+  onNavigate: (recordId, mode) => {}, // required by layout/navigation 'page'
+
+  // --- Toolbar ---
+  showSearch: true,
+  showFilters: true,
+  showSort: true,
+  showCreate: true,
+  showViewSwitcher: false, // default false
+  allowCreateView: false,
+  viewActions: [{ type: 'share' }],
+
+  // --- Built-in CRUD toggles ---
+  operations: { create: true, read: true, update: true, delete: true },
+};
 ```
+
+Three structural facts this component's schema does **not** work the way an
+older version of this README claimed:
+
+- **`dataSource` is not a schema key.** It is a **required prop** of
+  `ObjectViewProps` (`src/ObjectView.tsx`). Pass it to `<ObjectView>` directly,
+  or let the registered renderer pull it off `SchemaRendererProvider` context.
+  Putting `dataSource` inside the schema object does nothing.
+- **There is no `viewMode`, and no per-record `mode` / `recordId`.** The list
+  type is `defaultViewType` (plus `listViews` / `defaultListView`); create,
+  edit and read are internal states of one record surface, opened by the
+  toolbar's create button and by row actions, and rendered as a drawer, a modal
+  or a page according to `layout`. Accordingly `ObjectViewSchema['form']` omits
+  `mode` — the component sets it.
+- **There are no `onCreate` / `onUpdate` / `onDelete` / `onSubmit` callbacks.**
+  The component performs mutations itself through the `dataSource`. What you
+  can author is `operations` (booleans that enable or disable each built-in)
+  and `onNavigate(recordId, mode)`, which hands off to your router when the
+  record surface is a page.
+
+#### `table` and `form` sub-configuration
+
+`table` carries grid configuration and `form` carries form configuration, but
+`ObjectView` forwards a **fixed set of keys** from each rather than passing the
+object through. Anything else you put in them is ignored:
+
+| Sub-config | Keys `ObjectView` forwards |
+| --- | --- |
+| `table` | `columns`, `fields`, `title`, `description`, `defaultFilters`, `defaultSort`, `pageSize`, `selectable`, `operations`, `className` |
+| `form` | `fields`, `customFields`, `sections`, `groups`, `layout`, `columns`, `title`, `description`, `subforms`, `buttons`, `defaults`, `initialValues`, `readOnly`, `showSubmit`, `submitText`, `showCancel`, `cancelText`, `showReset`, `className` |
+
+Note that several of the forwarded `table` keys are the ones `ObjectGridSchema`
+marks legacy — `fields`, `pageSize`, `selectable`, `defaultFilters` and
+`defaultSort` each have a newer counterpart there (`columns`, `pagination`,
+`selection`, `filter`, `sort`). `ObjectView` forwards the legacy spellings, so
+on an `object-view` node those are the ones that take effect; `columns` is the
+exception, forwarded alongside `fields` and preferred here. Shapes follow
+`ObjectGridSchema`: `defaultSort` is a single `{ field, order }` object and
+`defaultFilters` is a plain `Record` of field to value.
 
 ### ViewSwitcher
 
@@ -205,111 +273,165 @@ Configure sorting with dropdowns or buttons:
 
 ## Examples
 
-### Grid View
+### Choosing the list type
 
-Display objects in a data grid:
+The list is always rendered; `defaultViewType` picks which renderer draws it,
+and `table` configures the grid:
 
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'grid',
-  fields: ['name', 'email', 'role', 'created_at'],
-  dataSource: myDataSource
+  objectName: 'users',
+  defaultViewType: 'grid',
+  table: {
+    columns: ['name', 'email', 'role', 'created_at'],
+    defaultSort: { field: 'created_at', order: 'desc' },
+  },
 };
 ```
 
-### Form View
+Non-grid types (`kanban`, `gallery`, `calendar`, `timeline`, `gantt`, `map`)
+are rendered through `SchemaRenderer`, so `@object-ui/react` and the matching
+plugin must be installed for those.
 
-Create or edit objects with a form:
+### Configuring the record form
+
+Create and edit share one record surface. `layout` chooses where it opens and
+`form` configures what it contains — there is no separate "form view" node and
+no authored `mode`:
 
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'form',
-  mode: 'create',
-  fields: ['name', 'email', 'role'],
-  onSubmit: (data) => {
-    console.log('Form submitted:', data);
-  }
+  objectName: 'users',
+  layout: 'drawer', // drawer | modal | page
+  form: {
+    fields: ['name', 'email', 'role'],
+    submitText: 'Save user',
+    showCancel: true,
+  },
 };
 ```
 
-### Detail View
+When `layout` is omitted, the surface is derived from how heavy the object is
+(`deriveRecordSurface`): a field-heavy object opens as a page, a light one as a
+drawer, and mobile always pages.
 
-Display a single object's details:
+### Opening a record
+
+Reading a record is the same surface in its read state, reached by clicking a
+row. `navigation.mode` decides how, and `onNavigate` is what hands a page-mode
+record off to your router:
 
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'detail',
-  recordId: '123',
-  fields: ['name', 'email', 'role', 'bio', 'created_at']
+  objectName: 'users',
+  layout: 'page',
+  navigation: { mode: 'page' }, // none | drawer | modal | page | split | popover | new_window
+  onNavigate: (recordId, mode) => {
+    // mode is 'view' or 'edit'
+    router.push(`/users/${recordId}${mode === 'edit' ? '/edit' : ''}`);
+  },
 };
 ```
+
+Without an `onNavigate` handler, `page` mode has nowhere to send the user, so
+keep the two together. `navigation: { mode: 'none' }` (or `preventNavigation`)
+makes rows inert.
 
 ## CRUD Operations
 
+All four operations are built in and run against the `dataSource` prop. You do
+not wire handlers for them — you switch them on or off with `operations`, and
+`show*` controls whether the matching toolbar affordance is visible.
+
 ### Create
 
+`operations.create` enables record creation; `showCreate` shows the button.
+Both default to on, and the new-record form opens on the `layout` surface:
+
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'products',
-  viewMode: 'form',
-  mode: 'create',
-  onCreate: async (data) => {
-    const newProduct = await dataSource.create('products', data);
-    console.log('Created:', newProduct);
-  }
+  objectName: 'products',
+  showCreate: true,
+  operations: { create: true },
+  layout: 'drawer',
+  form: { fields: ['name', 'price', 'category'] },
 };
 ```
 
+With `layout: 'page'`, creation calls `onNavigate('new', 'edit')` instead of
+opening a drawer, so the host route owns the form.
+
 ### Read/List
 
+Search, filter and sort are toolbar toggles; column set, default filter,
+default sort and page size live in `table`:
+
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'products',
-  viewMode: 'grid',
-  pagination: true,
-  searchable: true,
-  filters: {
-    category: 'electronics'
-  }
+  objectName: 'products',
+  defaultViewType: 'grid',
+  showSearch: true,
+  showFilters: true,
+  showSort: true,
+  table: {
+    columns: ['name', 'price', 'category'],
+    defaultFilters: { category: 'electronics' },
+    pageSize: 25,
+  },
+};
+```
+
+Saved views are `listViews`, keyed by view name, with `defaultListView`
+selecting which opens first:
+
+```typescript
+const schema: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  listViews: {
+    all: { label: 'All Products', type: 'grid', columns: ['name', 'price'] },
+    cheap: {
+      label: 'Under 100',
+      type: 'grid',
+      filter: [{ field: 'price', operator: 'lessThan', value: 100 }],
+    },
+  },
+  defaultListView: 'all',
 };
 ```
 
 ### Update
 
+Editing is reached from a row's edit action; `operations.update` is what gates
+it. The edited record is chosen by the click, never by an authored `recordId`:
+
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'products',
-  viewMode: 'form',
-  mode: 'edit',
-  recordId: '123',
-  onUpdate: async (id, data) => {
-    await dataSource.update('products', id, data);
-    console.log('Updated product:', id);
-  }
+  objectName: 'products',
+  operations: { update: true },
+  layout: 'modal',
+  form: { fields: ['name', 'price'], submitText: 'Update' },
 };
 ```
 
+Under `layout: 'page'` this becomes `onNavigate(recordId, 'edit')`.
+
 ### Delete
 
+`operations.delete` enables both the per-row delete and bulk delete; there is
+no `enableDelete` key and no `onDelete` callback:
+
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'products',
-  viewMode: 'grid',
-  enableDelete: true,
-  onDelete: async (id) => {
-    await dataSource.delete('products', id);
-    console.log('Deleted product:', id);
-  }
+  objectName: 'products',
+  operations: { create: true, read: true, update: true, delete: false },
 };
 ```
 
@@ -317,98 +439,122 @@ const schema = {
 
 The plugin works seamlessly with ObjectStack:
 
+The adapter is the `dataSource` **prop**, not part of the schema:
+
 ```typescript
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+import { ObjectView } from '@object-ui/plugin-view';
+import type { ObjectViewSchema } from '@object-ui/types';
 
 const dataSource = createObjectStackAdapter({
   baseUrl: 'https://api.example.com',
-  token: 'your-auth-token'
+  token: 'your-auth-token',
 });
 
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'contacts',
-  viewMode: 'grid',
-  dataSource,
-  fields: ['first_name', 'last_name', 'email', 'company'],
-  searchable: true,
-  sortable: true,
-  pagination: {
-    pageSize: 25
-  }
+  objectName: 'contacts',
+  defaultViewType: 'grid',
+  showSearch: true,
+  showSort: true,
+  table: {
+    columns: ['first_name', 'last_name', 'email', 'company'],
+    pageSize: 25,
+  },
 };
+
+<ObjectView schema={schema} dataSource={dataSource} />;
 ```
+
+Rendering the same node through the registry instead (`type: 'object-view'` in
+a larger schema tree) works because `ObjectViewRenderer` reads the
+`dataSource` off `SchemaRendererProvider` context — again, not off the schema.
 
 ## Field Configuration
 
-Customize field display and behavior:
+There is no `fieldConfig` key. Labels, types, requiredness and validation come
+from the object's own metadata, which the view reads through the `dataSource` —
+that is what makes the view "automatic". What the schema node chooses is
+**which** fields appear and how they are grouped:
 
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'form',
-  fieldConfig: {
-    name: {
-      label: 'Full Name',
-      required: true,
-      placeholder: 'Enter name'
-    },
-    email: {
-      label: 'Email Address',
-      type: 'email',
-      required: true,
-      validation: [
-        { type: 'email', message: 'Invalid email format' }
-      ]
-    },
-    role: {
-      label: 'User Role',
-      type: 'select',
-      options: [
-        { label: 'Admin', value: 'admin' },
-        { label: 'User', value: 'user' },
-        { label: 'Guest', value: 'guest' }
-      ]
-    }
-  }
+  objectName: 'users',
+  table: {
+    columns: ['name', 'email', 'role'], // grid columns
+  },
+  form: {
+    fields: ['name', 'email', 'role'], // flat field list, or use sections
+    sections: [
+      { label: 'Identity', fields: ['name', 'email'] },
+      { label: 'Access', fields: ['role'] },
+    ],
+    columns: 2,
+  },
 };
 ```
+
+To override a field's rendering beyond what the object metadata says, use
+`form.customFields` (full field definitions) rather than a per-field patch on
+the view node.
 
 ## Advanced Features
 
-### Nested Objects
+### Child records (master-detail)
+
+There is no `nestedFields` key. A child collection is declared as a **subform**
+on the record form, which is where an order's line items belong:
 
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'orders',
-  viewMode: 'detail',
-  fields: ['order_number', 'customer.name', 'items', 'total'],
-  nestedFields: {
-    items: {
-      type: 'object-grid',
-      object: 'order_items',
-      fields: ['product.name', 'quantity', 'price']
-    }
-  }
+  objectName: 'orders',
+  layout: 'page',
+  form: {
+    fields: ['order_number', 'customer', 'total'],
+    subforms: [
+      {
+        childObject: 'order_items',
+        title: 'Line items',
+        columns: ['product', 'quantity', 'price'],
+      },
+    ],
+  },
 };
 ```
 
-### Tabs View
+Only `childObject` is required — the relationship field and the grid columns are
+derived from the child object's metadata unless you override them
+(`relationshipField`, `columns`).
+
+### View tabs
+
+There is no `tabs` key, and `form.layout` has no tabbed value
+(`vertical | horizontal | inline | grid`). The tab strip this package ships is
+the **saved-view** tab bar: declare the views and render `<ViewTabBar>` (or let
+a host such as `@object-ui/app-shell` do it):
 
 ```typescript
-const schema = {
+const schema: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'tabs',
-  tabs: [
-    { label: 'Details', fields: ['name', 'email', 'bio'] },
-    { label: 'Settings', fields: ['theme', 'notifications', 'timezone'] },
-    { label: 'Activity', type: 'object-grid', object: 'user_activities' }
-  ]
+  objectName: 'users',
+  showViewSwitcher: true,
+  allowCreateView: true,
+  listViews: {
+    active: { label: 'Active', type: 'grid', columns: ['name', 'email'] },
+    admins: {
+      label: 'Admins',
+      type: 'grid',
+      filter: [{ field: 'role', operator: 'equals', value: 'admin' }],
+    },
+  },
+  defaultListView: 'active',
 };
 ```
+
+To group a *form's* fields instead, use `form.sections` as shown under "Field
+Configuration".
 
 ## TypeScript Support
 


### PR DESCRIPTION
Fixes #5077

基线 `671c0d320732345584038e45141f7175d044df8e`(显式实 sha)。仅动
`packages/plugin-view/README.md` + 一个 changeset。

## 前提门插曲(先读这一段)

按派发的 **cast 感知口径**复测卡面读数时,`pagination` 一格被推翻:
`src/ObjectView.tsx:1032` 有 `pagination: activeView?.pagination ?? (schema as any).pagination`,
普通 `schema\.[A-Za-z_]*` grep 看不见。据此停工报告(复测全表见
[#5077 评论](https://github.com/objectstack-ai/objectui/issues/5077#issuecomment-5321544762)),
PM 裁定取 A(只教声明成员,pagination 落规范位)。

**落地时又发现裁定所依据的那条机制本身不成立**,如实记录并据实改写:

- 裁定设想的规范位是 `table: { pagination: { pageSize: 25 } }`,依据是探针 E
  编译通过。但探针 E 的 rc=0 **不构成读点证据** —— `ObjectViewSchema['table']`
  的类型是 `Partial< Omit< ObjectGridSchema, 'type' | 'objectName' > >`,而
  `keyof ObjectGridSchema` 因 BaseSchema 的 `[key: string]: any` 退化成
  `string`,`Omit` 于是塌成纯索引签名:**该类型零声明成员**,塞任何键都编译通过
  (改前探针 H 的 `zzzNotAGridKey` rc=0 正是同一原因)。
- 实测 `ObjectView` 构建 `gridSchema` 是**逐键白名单**(`:833-848`),
  **不读也不转发 `table.pagination`**;本路径上唯一到得了 ObjectGrid 的分页键是
  `table.pageSize`(`:846`)。
- 因此没有把 `table.pagination` 写进 README —— 那会正好复制本卡要修的缺陷
  (教一个不被读的键)。两处按实测写 `table.pageSize`,并在 README 写明
  `pageSize` 在 `ObjectGridSchema` 上被标记为 legacy、而本组件不读 `pagination`。
  这一层已另立卡(见文末),本 PR 不引用其未来方向。

## cast 感知逐键复测表

口径 = plain `schema.K` + `schema['K']` + `(schema as X).K` + 解构 + 中间变量,
全包非测试文件。声明成员集取自构建产物(`checker.getPropertiesOfType` = 42,
required 仅 `objectName` / `type`,index signature `string -> any`),与卡面 ① 逐字一致。

| README 键 | 声明成员 | 复测读点 | 判定 |
| --- | --- | --- | --- |
| `object` / `viewMode` / `mode` / `recordId` / `fieldConfig` / `nestedFields` / `tabs` | 否 | 0 | 卡面吻合 |
| `searchable` / `sortable` / `enableDelete` | 否 | 0 | 卡面吻合 |
| `onCreate` / `onUpdate` / `onDelete` / `onSubmit` | 否 | 0 | 卡面吻合 |
| `dataSource`(写在 schema 里) | 否 | 0 | 卡面吻合;是 `ObjectViewProps` 必填 prop(`:145`) |
| `fields` | 否 | 0(object-view 上) | 3 处 `schema.fields` 在 `SortUI.tsx`(`sort-ui`,出半径) |
| `filters` | 否 | 0(object-view 上) | 1 处在 `FilterUI.tsx`(`filter-ui`,出半径) |
| `pagination` | 否 | **1**(`:1032`,`as any`) | ⛔ 卡面被推翻 → PM 裁定 A → 落 `table.pageSize` |

正对照:`objectName` 21、`form` 26 —— 与卡面 ② 的 20 行计数逐字相同。

## 逐块判定 / 删因表

| 块 | 原键面 | 改后 | 删因 |
| --- | --- | --- | --- |
| `:26` 自动注册 | `object` + `viewMode` | `objectName` + `defaultViewType`,加类型标注 | 两键均 0 读点 |
| `:135` Schema API 参考面 | `object` / `viewMode?` / `fields?` / `onCreate?` | 按真读键面重写为完整参考块 + 三条结构事实 + `table`/`form` 转发键表 | 参考面是最容易被照抄的一块 |
| `:212` Grid View | `viewMode:'grid'` + `fields` + `dataSource` | `defaultViewType` + `table.columns` / `defaultSort` | `dataSource` 是 prop |
| `:226` Form View | `viewMode:'form'` + `mode:'create'` + `onSubmit` | `layout`(drawer/modal/page)+ `form` 子配置 | 类型 omit 掉 `form.mode`,mode 是内部状态 |
| `:243` Detail View | `viewMode:'detail'` + `recordId` | `navigation.mode` + `onNavigate(recordId, mode)` | 记录由点击决定,非授权 |
| `:257` Create | `mode:'create'` + `onCreate` | `showCreate` + `operations.create`;page 布局走 `onNavigate('new','edit')` | 无该回调 |
| `:272` Read/List | `pagination:true` + `searchable` + `filters` | `show*` + `table.columns/defaultFilters/pageSize`,并补 `listViews`/`defaultListView` 示例 | 见前提门段 |
| `:287` Update | `mode:'edit'` + `recordId` + `onUpdate` | `operations.update` + `layout` | 同上 |
| `:303` Delete | `enableDelete` + `onDelete` | `operations.delete` | 两键均 0 读点 |
| `:320` ObjectQL 集成 | schema 里塞 `dataSource` + `pagination` | dataSource 作 prop 传入(或经 Provider context)+ `table.pageSize` | 结构事实 |
| `:346` Field Configuration | `fieldConfig` | `table.columns` + `form.fields`/`sections`/`customFields` | 字段元信息来自对象元数据 |
| `:382` Nested Objects | `nestedFields` | `form.subforms`(`childObject` 必填) | 真身是 subform |
| `:400` Tabs View | `viewMode:'tabs'` + `tabs` | saved-view 页签:`listViews` + `showViewSwitcher` + `allowCreateView` | `form.layout` 无 tabs 取值 |

`:153` / `:172` / `:193`(ViewSwitcher / FilterUI / SortUI)**未动**,diff 可验。

## 探针读数分层

改前 8 项(A-H)已在 #5077 评论中登记,预判 8/8 命中,此处不重复。改后新增:

| 项 | 结果 |
| --- | --- |
| 改后文本名集合核对(机械)| 20 个顶层键全部 `declared=true` 且读点 > 0;`table.*` 4 个、`form.*` 7 个全部在转发白名单内 —— **ALL KEYS VERIFIED** |
| 改后探针 F 复跑(全部 15 个带标注示例编译)| `tsc --strict --noEmit` **rc=0** |
| 反向:15 个示例逐一抽掉 `objectName` | **15/15 报 TS2741**,即类型标注在每一个示例上都真的有牙 |

⛔ 不拿探针绿冒充键面证据:上表第二行只证明「编译得过」,键面结论一律来自第一行的
读点核对与前述白名单实测。

## 门

- 仓根 `pnpm exec turbo run type-check --concurrency=2`:**81 successful, 81 total**
- `node scripts/check-doc-links.mjs`:`Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs`:`OK (scanned 4526 tracked text file(s))`;改动文件另行自扫 `[\x00-\x08\x0b\x0c\x0e-\x1f]` 无命中

## 顺带立卡(不在本 PR 修)

- **#5097** —— `ObjectView` 用 `(schema as any)` 读 31 个键转发给 `renderListView`,27 个非声明成员(已按 #5091 同族入决策箱)。
- 本 PR 落地时新发现的 `table` / `form` 声明面塌陷 + 转发白名单钉在 legacy 键上,另立卡见下条评论。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_