### PR TITLE
docs(plugin-grid): 文档站示例整片按 object-grid 真实键面重写,TypeScript 导入改指 @object-ui/types

### DIFF
--- a/.changeset/plugin-grid-docs-site-example-key-face.md
+++ b/.changeset/plugin-grid-docs-site-example-key-face.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+The plugin-grid documentation-site page now spells keys the grid actually reads.
+
+`content/docs/plugins/plugin-grid.mdx` is the docs-site mirror of the README pass
+in objectui#5065, and carried the same defect end to end: the `### Grid` sketch,
+the column definition and every example block declared `type: 'grid'` with
+`header` / `accessorKey` columns.
+
+Bare `grid` is deliberately not this plugin's key — the `view:grid` registration
+passes `skipFallback: true` (`packages/plugin-grid/src/index.tsx`), because `grid`
+belongs to the CSS Grid *layout* container in `@object-ui/components`, whose
+`columns` is a column **count** rather than a column list. A reader copying an
+example therefore rendered a layout container, not a data grid. The registry
+confirms this in both plausible host import orders: `object-grid`,
+`plugin-grid:object-grid` and `view:grid` all resolve to `ObjectGridRenderer`,
+while bare `grid` resolves to the layout container.
+
+The column vocabulary was rejected rather than ignored: `ListColumnSchema`
+(`@objectstack/spec/ui`) is a **strict** Zod object, so `header` and `accessorKey`
+fail validation with `unrecognized_keys` — the identity key is `field` and the
+header is `label`. Likewise `object` is not a key (`objectName` is required and
+there is no `object`), `pagination` carried a `showSizeChanger` that the strict
+`PaginationConfig` rejects, `rowActions` was written as inline definitions with
+callbacks and then as `true` when it is a `string[]` of action names, and the
+top-level `sortable` / `filterable` switches have zero read points anywhere in the
+package — sorting is the per-column `ListColumn.sortable` and filtering is the
+metadata `filter` plus `searchableFields`.
+
+The five `on*` names were taught as schema keys; they are React props on
+`ObjectGridComponentProps`. A schema is a serialisable document and cannot hold a
+function, and the renderer never reads a callback off the schema.
+
+Every block is rewritten against the declared authoring surface
+(`GRID_QUERY_INPUTS`), matching the README pass so the two teaching surfaces no
+longer disagree. The TypeScript section additionally fixes the grid third of
+objectui#5086: it imported `GridSchema` / `GridColumn` from
+`@object-ui/plugin-grid`, and neither name is on that package's 49-name export
+surface — both are taken elsewhere by unrelated types (`GridSchema` in
+`@object-ui/types` is the CSS Grid layout container; `GridColumn` in
+`@object-ui/fields` is a column of the line-items form widget, keyed `name`). It
+now imports `ObjectGridSchema` / `ListColumn` from `@object-ui/types`, with no new
+re-export added to make the old path work.
+
+Documentation only — no renderer behaviour changes, and no capability was added to
+make an example true.

--- a/content/docs/plugins/plugin-grid.mdx
+++ b/content/docs/plugins/plugin-grid.mdx
@@ -34,33 +34,78 @@ npm install @object-ui/plugin-grid
 
 ### Grid
 
-```plaintext
+A grid node is an `ObjectGridSchema`: one required `objectName`, plus keys drawn
+from the list this plugin **declares** as its authoring surface
+(`GRID_QUERY_INPUTS`, `packages/plugin-grid/src/index.tsx`) — the same list that
+feeds the designer panel and the generated `sdui-intrinsics.d.ts`, so what is
+authorable here is what the renderer reads.
+
+```json
 {
-  type: 'grid',
-  columns: GridColumn[],
-  data?: any[],
-  sortable?: boolean,
-  filterable?: boolean,
-  pagination?: boolean | PaginationConfig,
-  selectable?: boolean,
-  onRowClick?: (row) => void,
-  className?: string
+  "type": "object-grid",
+  "objectName": "users",
+  "columns": ["name", "email"],
+  "sort": [{ "field": "created", "order": "desc" }],
+  "pagination": { "pageSize": 20 }
 }
 ```
+
+Note the `type`. It is `object-grid` (or `view:grid`), **never `grid`** — bare
+`grid` is the CSS Grid *layout container* from `@object-ui/components`, whose
+`columns` is a column **count**. See [Registration](#registration-is-a-side-effect-of-the-import)
+below for why this plugin deliberately does not claim it.
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `objectName` | `string` (**required**) | The object queried. There is no `object`. |
+| `columns` | `string[] \| ListColumn[]` | Field names or column objects — see below. |
+| `label` | `I18nLabel` | Table caption and export file title. |
+| `filter` | `ViewFilterRule[]` | Baked into the query, lowered to `$filter`. |
+| `sort` | `[{ field, order }]` | Initial order; a header click replaces it. |
+| `pagination` | `PaginationConfig` | `{ pageSize?, pageSizeOptions? }` — **strict**, and its presence is what enables paging. |
+| `searchableFields` | `string[]` | A non-empty list is what puts the search box in the toolbar. |
+| `data` | `ViewData` | Inline rows that bypass the object query — see [Inline data](#inline-data). |
+| `selection` | `SelectionConfig` | `{ type: 'none' \| 'single' \| 'multiple' }`. |
+| `rowActions` / `bulkActions` | `string[]` | **Names** of actions, not inline definitions. |
+| `editable` / `singleClickEdit` | `boolean` | Inline editing — see [Inline Editing](#inline-editing). |
+| `navigation` | `NavigationConfig` | What a row click does: `{ mode: 'page' \| 'drawer' \| 'modal' \| 'split' \| 'none', … }`. |
+| `operations` | `object` | Toggles the built-in CRUD/export/import affordances, e.g. `{ delete: false }`. |
+| `rowHeight`, `frozenColumns`, `resizable`, `reorderableColumns`, `showColumnTypeIcons`, `rowColor`, `conditionalFormatting`, `grouping`, `aggregations`, `exportOptions`, `className` | | The rest of the declared surface. |
+
+**There is no `sortable`, `filterable`, `onRowClick`, `onSelectionChange`,
+`onCellChange`, `onRowSave`, `onBatchSave` or `object` on this schema.** The two
+booleans do not exist at all; the five `on*` names are **component props**
+(`ObjectGridComponentProps`), which no metadata document can carry — see
+[Row callbacks are component props](#row-callbacks-are-component-props).
 
 ### Column Definition
 
-```plaintext
-interface GridColumn {
-  header: string;
-  accessorKey: string;
-  sortable?: boolean;
-  filterable?: boolean;
-  width?: number | string;
-  align?: 'left' | 'center' | 'right';
-  cell?: (value, row) => ReactNode;
-}
-```
+A column is either a **field name** (`"name"`) or a `ListColumn` object.
+`ListColumn` is declared by `@objectstack/spec/ui` (`ListColumnSchema`) and
+re-exported from `@object-ui/types`; it is the type of `ObjectGridSchema`'s
+`columns`, so it is the same column vocabulary the saved-view metadata uses.
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `field` | `string` (**required**) | The field this column reads. There is no `accessorKey`. |
+| `label` | `string \| Record<string, string>` | Header text, or an inline locale map. There is no `header`. |
+| `width` | `number` | Column width in pixels. |
+| `align` | `'left' \| 'center' \| 'right'` | Cell alignment. |
+| `hidden` | `boolean` | Hidden by default, revealable in the column chooser. |
+| `sortable` | `boolean` | Allow sorting on this column. |
+| `resizable` | `boolean` | Allow dragging this column's width. |
+| `wrap` | `boolean` | Wrap long cell text instead of eliding it. |
+| `type` | `string` | Override the rendered cell type instead of inferring it from the field. |
+| `pinned` | `'left' \| 'right'` | Freeze the column to one edge. |
+| `summary` | `ColumnSummary \| { type, field? }` | Footer aggregation — see [Column Summaries](#column-summaries). |
+| `prefix` | `{ field, type? }` | Render a second field inline before the value. |
+| `link` | `boolean` | Render the value as a link to the record. |
+| `action` | `string` | Run a named action when the cell is clicked. |
+
+`ListColumnSchema` is a **strict** Zod object, so an unknown key is *rejected*
+rather than ignored — a column is spelled this one way. `header` and
+`accessorKey` are not softer spellings of `label` and `field`; they fail
+validation.
 
 ### Column Summaries
 
@@ -163,34 +208,70 @@ than this package's component API.
 
 ## Examples
 
-### Grid with Custom Cells
+### Basic Grid
 
 ```json
 {
-  "type": "grid",
+  "type": "object-grid",
+  "objectName": "users",
   "columns": [
-    { "header": "Name", "accessorKey": "name" },
-    { 
-      "header": "Status", 
-      "accessorKey": "status",
-      "cell": {
-        "type": "badge",
-        "label": "${value}",
-        "variant": "${value === 'Active' ? 'success' : 'default'}"
-      }
-    },
-    {
-      "header": "Actions",
-      "accessorKey": "id",
-      "cell": {
-        "type": "button-group",
-        "buttons": [
-          { "label": "Edit" },
-          { "label": "Delete", "variant": "destructive" }
-        ]
-      }
-    }
+    { "field": "name", "label": "Name", "width": 200, "sortable": true },
+    { "field": "email", "label": "Email" },
+    { "field": "role", "label": "Role" },
+    { "field": "status", "label": "Status", "type": "select" }
+  ],
+  "sort": [{ "field": "name", "order": "asc" }],
+  "pagination": { "pageSize": 20 }
+}
+```
+
+### Cell appearance
+
+A column does not carry a render function. What it *can* say is which **cell
+type** to use and how to decorate the value — the same vocabulary the saved-view
+metadata uses, so a grid authored by hand and one authored in the designer
+render alike.
+
+```json
+{
+  "type": "object-grid",
+  "objectName": "opportunities",
+  "columns": [
+    { "field": "stage", "type": "select" },
+    { "field": "amount", "type": "currency", "align": "right", "summary": "sum" },
+    { "field": "name", "link": true, "prefix": { "field": "health", "type": "badge" } },
+    { "field": "owner_id", "action": "reassign" }
   ]
+}
+```
+
+`link: true` renders the value as a link to the record and `action: "reassign"`
+runs a named action on click — that is the metadata form of the "Actions column"
+a render function used to be written for. A genuinely custom cell **renderer** is
+a component-layer concern: `VirtualGridColumn.cell` on `VirtualGrid`, a React
+prop, not an authoring key.
+
+### Inline data
+
+A grid normally queries `objectName`. To render fixed rows instead — demos,
+fixtures, tests — give it a `ViewData` with the `value` provider. The rows go
+under `items`.
+
+```json
+{
+  "type": "object-grid",
+  "objectName": "users",
+  "columns": [
+    { "field": "name", "label": "Name" },
+    { "field": "email", "label": "Email" }
+  ],
+  "data": {
+    "provider": "value",
+    "items": [
+      { "id": 1, "name": "John Doe", "email": "john@example.com", "status": "Active" },
+      { "id": 2, "name": "Jane Smith", "email": "jane@example.com", "status": "Active" }
+    ]
+  }
 }
 ```
 
@@ -198,91 +279,147 @@ than this package's component API.
 
 ```json
 {
-  "type": "grid",
-  "columns": [...],
-  "data": [...],
-  "selectable": true,
-  "onSelectionChange": "handleSelection"
+  "type": "object-grid",
+  "objectName": "users",
+  "columns": ["name", "email"],
+  "selection": { "type": "multiple" },
+  "bulkActions": ["delete", "export"]
 }
 ```
+
+`selection.type` is the canonical spelling; the boolean `selectable` is a
+deprecated legacy alias, read only when `selection` is absent. Declaring bulk
+actions auto-enables multi-select, so the two keys agree by construction.
+
+To react to a selection in React, pass the `onRowSelect` **component prop** —
+see [Row callbacks are component props](#row-callbacks-are-component-props).
 
 ### Grid with Pagination
 
 ```json
 {
-  "type": "grid",
-  "columns": [...],
-  "data": [...],
-  "pagination": {
-    "pageSize": 10,
-    "showSizeChanger": true,
-    "pageSizeOptions": [10, 20, 50, 100]
-  }
+  "type": "object-grid",
+  "objectName": "users",
+  "columns": ["name", "email"],
+  "pagination": { "pageSize": 10, "pageSizeOptions": [10, 20, 50, 100] }
 }
 ```
 
+`PaginationConfig` is a **strict** object of exactly `pageSize` and
+`pageSizeOptions` — there is no `showSizeChanger`, and none is needed: the pager
+always carries a rows-per-page picker, and `pageSizeOptions` only replaces the
+choices it offers with your own.
+
 ### ObjectQL Integration
+
+The object comes from `objectName`; there is no `object` key. Filtering is the
+metadata `filter` (lowered to `$filter`) and search is `searchableFields`
+(lowered to `$searchFields`).
 
 ```json
 {
   "type": "object-grid",
-  "object": "users",
+  "objectName": "users",
   "columns": [
-    { "header": "Name", "accessorKey": "name" },
-    { "header": "Email", "accessorKey": "email" },
-    { "header": "Created", "accessorKey": "created_at" }
+    { "field": "name", "label": "Name" },
+    { "field": "email", "label": "Email" },
+    { "field": "created_at", "label": "Created", "type": "datetime" }
   ],
-  "pagination": true,
-  "sortable": true,
-  "filterable": true
+  "filter": [{ "field": "status", "operator": "equals", "value": "active" }],
+  "searchableFields": ["name", "email"],
+  "pagination": { "pageSize": 20 }
 }
 ```
+
+The adapter itself is **not** a schema key: a schema is a serialisable document,
+while a live adapter is an object with methods. The grid reads its adapter from
+React context, which the host installs once above the whole tree with
+`<SchemaRendererProvider dataSource={...} />`.
 
 ## Features
 
 ### Sorting
 
-Enable sorting on all or specific columns:
+Columns sort by default. `sortable` is a **per-column** key, used to turn a
+column off; the grid-level `sort` declares the order the grid opens with. There
+is no top-level `sortable` switch.
 
 ```json
 {
-  "type": "grid",
-  "sortable": true,
+  "type": "object-grid",
+  "objectName": "users",
+  "sort": [{ "field": "created", "order": "desc" }],
   "columns": [
-    { "header": "Name", "accessorKey": "name", "sortable": true },
-    { "header": "Email", "accessorKey": "email", "sortable": false }
+    { "field": "name", "label": "Name" },
+    { "field": "email", "label": "Email", "sortable": false }
   ]
 }
 ```
 
-### Filtering
+### Filtering and search
 
-Enable column-level filtering:
+There is no per-column filter key and no top-level `filterable` switch. A grid
+narrows its query two ways: a `filter` baked into the metadata, and a toolbar
+search over the fields named in `searchableFields`.
 
 ```json
 {
-  "type": "grid",
-  "filterable": true,
-  "columns": [
-    { "header": "Status", "accessorKey": "status", "filterable": true }
-  ]
+  "type": "object-grid",
+  "objectName": "users",
+  "filter": [
+    { "field": "status", "operator": "equals", "value": "active" },
+    { "field": "created", "operator": "after", "value": "2026-01-01" }
+  ],
+  "searchableFields": ["name", "email"],
+  "columns": ["name", "email", "status"]
 }
 ```
 
 ### Row Actions
 
-Add action buttons to each row:
+`rowActions` and `bulkActions` are lists of **action names** — the actions
+themselves live in the object's action set, so the same action behaves
+identically wherever it is offered. They are `string[]`, not inline definitions
+carrying callbacks.
 
 ```json
 {
-  "type": "grid",
-  "rowActions": [
-    { "label": "View", "onClick": "viewRow" },
-    { "label": "Edit", "onClick": "editRow" },
-    { "label": "Delete", "onClick": "deleteRow" }
-  ]
+  "type": "object-grid",
+  "objectName": "users",
+  "columns": ["name", "email"],
+  "rowActions": ["view", "edit", "delete"],
+  "selection": { "type": "multiple" },
+  "bulkActions": ["delete", "export"]
 }
 ```
+
+### Row callbacks are component props
+
+`onRowClick`, `onRowSelect`, `onCellChange`, `onRowSave`, `onBatchSave`,
+`onEdit`, `onDelete`, `onBulkDelete` and `onAddRecord` are React props on
+`ObjectGridComponentProps`. They are functions, so no metadata document can hold
+them, and writing one into a schema does nothing at all: the grid builds the
+inner table's handlers itself and never reads a callback off the schema.
+
+```tsx
+import { ObjectGrid } from '@object-ui/plugin-grid';
+import type { ObjectGridComponentProps } from '@object-ui/plugin-grid';
+
+export const Grid = (props: ObjectGridComponentProps) => (
+  <ObjectGrid
+    {...props}
+    onRowClick={(record) => console.log('Row clicked:', record)}
+    onRowSelect={(rows) => console.log('Selection changed:', rows)}
+  />
+);
+```
+
+Note `onRowSelect` — the prop that reports a selection change is spelled that
+way; there is no `onSelectionChange` on this component.
+
+The declarative alternative, which *is* metadata and survives a round trip
+through storage, is `navigation`: its `mode` decides what a row click does
+without any host code.
 
 ### Inline Editing
 
@@ -293,91 +430,124 @@ Enable inline cell editing for quick data updates:
   "type": "object-grid",
   "objectName": "users",
   "columns": [
-    { "header": "ID", "accessorKey": "id", "editable": false },
-    { "header": "Name", "accessorKey": "name" },
-    { "header": "Email", "accessorKey": "email" },
-    { "header": "Status", "accessorKey": "status" }
+    { "field": "id", "label": "ID" },
+    { "field": "name", "label": "Name" },
+    { "field": "email", "label": "Email" },
+    { "field": "status", "label": "Status", "type": "select" }
   ],
   "editable": true,
-  "onCellChange": "handleCellChange"
+  "singleClickEdit": false
 }
 ```
+
+`editable` is the only switch: it is a grid-level flag, and edits persist
+through the host's data source (`dataSource.update`) with no callback to wire.
 
 **Features:**
-- Double-click or press Enter on a cell to start editing
-- Press Enter to save changes
-- Press Escape to cancel editing
-- Column-level control: Set `editable: false` on specific columns to prevent editing
-- Callback support: Use `onCellChange` to handle cell value updates
+- **Double-click to edit**: double-click any editable cell to enter edit mode
+  (`singleClickEdit: true` opens it on the first click instead)
+- **Keyboard shortcuts**: press Enter on a focused cell to start editing, Enter
+  again to save, Escape to cancel
+- **Per-field read-only**: which cells open is decided by the **field
+  definition**, not by a column key — a field marked `readonly`, and
+  computed/binary field types (formula, autonumber, file, …), never open an
+  editor. There is no `editable` key on `ListColumn`.
+- **Visual feedback**: editable cells show a hover state, and the input is
+  focused and selected when editing begins
 
-**Example Handler:**
-```javascript
-function handleCellChange(rowIndex, columnKey, newValue, row) {
-  console.log(`Cell at row ${rowIndex}, column ${columnKey} changed to:`, newValue);
-  console.log('Full row data:', row);
-  // Update your data source here
-}
-```
+To own persistence in a React host, supply `onCellChange` as a **component
+prop** — it is not a schema key.
 
 ### Batch Editing & Multi-Row Save
 
-Edit multiple cells across multiple rows and save them individually or all at once:
+Edit multiple cells across multiple rows and save them individually or all at
+once. The schema half is just `editable` — the save/cancel affordances appear on
+their own once a row has pending changes:
 
 ```json
 {
   "type": "object-grid",
   "objectName": "products",
   "columns": [
-    { "header": "SKU", "accessorKey": "sku", "editable": false },
-    { "header": "Name", "accessorKey": "name" },
-    { "header": "Price", "accessorKey": "price" }
+    { "field": "sku", "label": "SKU" },
+    { "field": "name", "label": "Name" },
+    { "field": "price", "label": "Price", "type": "currency", "align": "right" },
+    { "field": "stock", "label": "Stock", "type": "number", "align": "right" }
   ],
-  "editable": true,
-  "rowActions": true,
-  "onRowSave": "handleRowSave",
-  "onBatchSave": "handleBatchSave"
+  "editable": true
 }
+```
+
+Left alone, saving goes through the host's data source. A React host that needs
+to own persistence supplies `onRowSave` / `onBatchSave` as **component props** —
+and because they are props, they take the adapter from the host's own scope
+rather than from anything in the schema:
+
+```tsx
+import type { ObjectGridComponentProps } from '@object-ui/plugin-grid';
+
+type Persistence = Pick<ObjectGridComponentProps, 'onRowSave' | 'onBatchSave'>;
+
+const persistence = (
+  dataSource: NonNullable<ObjectGridComponentProps['dataSource']>,
+): Persistence => ({
+  onRowSave: async (rowIndex, changes, row) => {
+    await dataSource.update('products', row.id, changes);
+  },
+  onBatchSave: async (allChanges) => {
+    await Promise.all(
+      allChanges.map(({ row, changes }) => dataSource.update('products', row.id, changes)),
+    );
+  },
+});
 ```
 
 **Features:**
-- **Pending changes tracking**: Edit multiple cells across rows before saving
-- **Visual indicators**: Modified rows highlighted in amber, modified cells in bold
-- **Row-level save/cancel**: Individual row save and cancel buttons
+- **Pending changes tracking**: edit multiple cells across rows before saving
+- **Visual indicators**: modified rows highlighted in amber, modified cells in bold
+- **Row-level save/cancel**: individual row save and cancel buttons
 - **Batch operations**: Save All and Cancel All buttons for bulk actions
-- **Flexible callbacks**: `onRowSave` for single row, `onBatchSave` for multiple rows
-
-**Example Handlers:**
-```javascript
-function handleRowSave(rowIndex, changes, row) {
-  console.log('Saving row:', rowIndex, changes);
-  // Save single row to backend
-  await dataSource.update(row.id, changes);
-}
-
-function handleBatchSave(allChanges) {
-  console.log('Batch saving:', allChanges.length, 'rows');
-  // Save all changes at once
-  await Promise.all(
-    allChanges.map(({ row, changes }) => 
-      dataSource.update(row.id, changes)
-    )
-  );
-}
-```
+- **Flexible callbacks** — all three are `ObjectGridComponentProps`, never schema
+  keys: `onRowSave` for a single row, `onBatchSave` for many, `onCellChange` for
+  each staged cell edit
 
 ## TypeScript Support
 
-```plaintext
-import type { GridSchema, GridColumn } from '@object-ui/plugin-grid';
+The schema and column types come from `@object-ui/types`; this package exports
+the *component* types. Neither `GridSchema` nor `GridColumn` is on this
+package's export surface, and both names are taken elsewhere by different
+things — `GridSchema` in `@object-ui/types` is the CSS Grid **layout**
+container, and `GridColumn` in `@object-ui/fields` is a column of the
+line-items form widget (keyed `name`). The data-grid pair is
+`ObjectGridSchema` + `ListColumn`.
 
-const grid: GridSchema = {
-  type: 'grid',
-  columns: [...],
-  data: [],
-  sortable: true,
-  pagination: true
+```typescript
+import type { ObjectGridSchema, ListColumn } from '@object-ui/types';
+import type { ObjectGridComponentProps } from '@object-ui/plugin-grid';
+
+const nameColumn: ListColumn = {
+  field: 'name',
+  label: 'Full Name',
+  sortable: true
+};
+
+const grid: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'users',
+  columns: [nameColumn],
+  pagination: { pageSize: 20 }
+};
+
+// Row callbacks are COMPONENT props, not schema keys.
+const gridProps: ObjectGridComponentProps = {
+  schema: grid,
+  onRowClick: (record) => console.log('Row clicked:', record)
 };
 ```
+
+Annotating the literal is the point: an un-annotated `const schema = { … }`
+type-checks no matter what is written in it, so a snippet that carries no
+annotation cannot tell you whether its keys are real.
 
 ## License
 

--- a/content/docs/plugins/plugin-grid.mdx
+++ b/content/docs/plugins/plugin-grid.mdx
@@ -398,8 +398,9 @@ carrying callbacks.
 `onRowClick`, `onRowSelect`, `onCellChange`, `onRowSave`, `onBatchSave`,
 `onEdit`, `onDelete`, `onBulkDelete` and `onAddRecord` are React props on
 `ObjectGridComponentProps`. They are functions, so no metadata document can hold
-them, and writing one into a schema does nothing at all: the grid builds the
-inner table's handlers itself and never reads a callback off the schema.
+them, and writing one of them into a schema does nothing at all: the grid builds
+the inner table's handlers itself and never reads any of these nine off the
+schema.
 
 ```tsx
 import { ObjectGrid } from '@object-ui/plugin-grid';

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -318,6 +318,9 @@ const DOC_TYPE_EXEMPTIONS = {
   },
   'content/docs/plugins/plugin-grid.mdx': {
     count_unique: 'Column summary aggregation under `columns[].summary`, not a node type.',
+    multiple:
+      'SelectionConfig mode under `selection` — the spec\'s `none` / `single` / `multiple` ' +
+      'vocabulary (`SelectionConfigSchema`, @objectstack/spec/ui), not a node type.',
   },
   'content/docs/plugins/plugin-report.mdx': {
     matrix: 'ReportInput kind — a report definition\'s shape, sibling of `joined` / `summary`.',


### PR DESCRIPTION
Fixes #5087
Part of #5086

## 合单理由

#5086 的 grid 三分之一(TypeScript Support 块里的 `import type` 行)与本卡的键面重写**在同一个代码块内**。拆成两个 PR 会互相踩:import 行改指 `@object-ui/types` 之后,紧跟其下的示例字面量必须同时从 `type: 'grid'` 改成 `type: 'object-grid'`、`objectName` 补上,否则标注了 `ObjectGridSchema` 的示例自己就不成立。故按 PM 派发口径一并修。

#5086 剩下的 form / view 两处不在本 PR:form 处独立;view 处与 #5088 同文件需序,留给 PM 安排。

## 前提复测(在 `671c0d320` 基线逐条复测,四条卡面判断全部成立)

| 卡面判断 | 复测结论 |
| --- | --- |
| 裸 `grid` 不是本插件的,属 `@object-ui/components` 的 CSS Grid 布局容器 | 成立。`view:grid` 注册带 `skipFallback: true`;布局容器的 `columns` 是 `number` 或响应式对象,即列**数** |
| `ListColumnSchema` 是 strict,列身份键是 `field`、表头是 `label` | 成立。`safeParse({ header, accessorKey })` 返回 `unrecognized_keys` + `field` 缺失 |
| `ObjectGridSchema` 必填 `objectName`,没有 `object` | 成立(行号已前移至 `:549`,判定不变)。cast 感知读取点扫描:`schema.object` 零命中,`schema.objectName` 44 处 |
| `GridSchema` / `GridColumn` 不在 plugin-grid 的 49 个导出名里 | 成立。用 TS 编译器 API `checker.getExportsOfModule` 对**已构建的** `dist/index.d.ts` 取,两个名字均 ABSENT;`GridSchema` 在 `@object-ui/types` 是布局容器,`GridColumn` 在 `@object-ui/fields` 是行项控件的列(键为 `name`) |

## 改了什么

整页按 PR #5089(#5065,README 侧同内容)已对齐的口径重写:`type` 用 `object-grid`,对象名用 `objectName`,列用 `field` / `label`,并按声明面(`GRID_QUERY_INPUTS`)补齐 `selection` / `filter` / `searchableFields` / `navigation` 等真键。

被重写的块:Schema API、Column Definition、Basic Grid、Cell appearance、Inline data、Selectable Grid、Grid with Pagination、ObjectQL Integration、Sorting、Filtering and search、Row Actions、Row callbacks are component props、Inline Editing、Batch Editing、TypeScript Support。

`Column Summaries` 一节**未动** —— 它本来就用对了 `field` / `summary`。

TypeScript Support 的 import 改为从 `@object-ui/types` 导入 `ObjectGridSchema` / `ListColumn`。⛔ **没有**为了让旧路径成立而新增 re-export —— 加宽包公共面是契约变更不是文档修复(#5011 定调)。

## 名集合双向核对

对已构建 dist 产物核对,两个方向都干净:

- 页内每个 `import type` 的具名导入 → 全部在对应包的导出面(`getExportsOfModule`)。
- `ListColumn` 键表 **14 个 documented == 14 个 declared**(`ListColumnSchema.shape`),既无幻影键也无遗漏。
- 页面**声称不存在**的 8 个名字(`sortable` / `filterable` / 五个 `on*` / `object`)逐个反查,确认确实不在声明面上。
- 塞假名自证门有牙:把 `ObjectGridSchema` 改成 `ObjectGridSchemaZZZ` → 核对器 `FAIL — 1 phantom name(s)`,还原后 `PASS`。

## 反向验证(先书面预判再跑)

**(a) 改前示例键回填 —— 预判分层,结果与分层预判一致:**

- `check-doc-component-types` 在**改前**整页 6 处 `"type": "grid"` 上 **rc=0 全绿**。这不是漏网,正是本卡的成因:该门只问「type 是否被注册」,而裸 `grid` **确实**被注册(布局容器注册的)。
- 编译探针**分层**:grid 节点层**全盲** —— 只含多余键的字面量(`sortable` / `filterable` / `object` / `onRowClick`,甚至 `totallyMadeUpKey: 123`)编译**零报错**,因 `BaseSchema` 带 `[key: string]: any`。缺 `objectName` 单独出现时 TS2741 会报;一旦同字面量里还有别的属性级错误(`type: 'grid'` 的 TS2322),**TS2741 被抑制**,与案头铁律一致。
- ⚠️ **一处预判不符,如实记录**:我预判列对象上的 `header` / `accessorKey` 也会被索引签名吞掉,**实际会报 TS2353**。原因是索引签名的盲区**止于列边界** —— `ListColumn` 来自 `@objectstack/spec/ui`,是**闭合**对象类型,不继承 `BaseSchema`,所以多余属性检查照常触发。即「编译探针对键面全盲」这句话对 **grid 节点**成立,对 **列对象**不成立。
- 旧 import 行 → **TS2305 ×2**(`GridSchema` / `GridColumn`),#5086 的编译期证据。

**(c) 自选方向 —— 两种拼法是否都真实可达注册表:** 用真实 `Registry` 源码 replay 真实注册调用,**两种 host 导入顺序下结论一致**(`skipFallback` 使其与顺序无关):`object-grid`、`plugin-grid:object-grid`、`view:grid` 三者都解析到 `ObjectGridRenderer`;裸 `grid` 解析到布局容器;`plugin-grid:grid` 未注册。所以读者照抄改前示例拿到布局容器是**确定性**的,不是偶发。

## 门禁

`check-doc-component-types` / `check-doc-links` / `check-control-bytes` 均 rc=0;改动文件另做控制字节自扫(`grep -naP` 零命中)。仓根 `turbo run type-check` **81/81 successful**。MDX 编译通过(`@mdx-js/mdx` compile OK)。changeset 双守卫通过(fixed 组 / 无 major)。

## ⚠️ 半径偏离一处,请 PM 裁定

派发半径是「仅 mdx + changeset」,但 `selection: { "type": "multiple" }` 这个**规范拼法**一旦进代码块,`check-doc-component-types` 就会红 —— 该门把代码块里**每一个** `type` 字面量都当候选组件键,而 `multiple` 是 `SelectionConfigSchema` 的选择模式词汇,不是节点类型。这与本文件既有的 `count_unique` 条目**同类**。

我按该门自己写明的补救方式,在 `DOC_TYPE_EXEMPTIONS` 加了 1 条 (file, value) 键控、带书面理由的条目(共 3 行)。它不加宽任何契约、不影响运行时,且条目失配时该门会以 `stale-exemption` 自行报红。

替代方案是把 `selection` 只写进键表、示例里不出现 —— 但那样规范拼法在**任何可照抄的示例里都不出现**,而 README(#5089)恰恰是照抄这个写法的,两侧再次分叉正是本 issue 一族的成因。故选前者,并在此显式标注偏离。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_