### PR TITLE
fix(app-shell): metadata 详情抽屉的 SchemaForm 按实例作用域取 id (#5092)

### DIFF
--- a/.changeset/quiet-donkeys-hear.md
+++ b/.changeset/quiet-donkeys-hear.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin: scope the detail drawer's form ids so its labels stop addressing the page form's controls
+
+`MetadataDetailDrawer` is a Radix `Sheet`, so opening it leaves the page's own
+`SchemaForm` in the DOM underneath. Top-level field ids were spelled
+`mdf-{field}` with no instance dimension, so every field name the two forms
+share (`name`, `label`, `description`) was one id twice — and a `label[for]`
+resolves to the FIRST match in document order. Clicking a label in the drawer
+focused the control of the form hidden behind it, and assistive tech announced
+that control under the drawer field's name.
+
+Both drawer-side mount points now pass a scope segment as their form's
+`idPath`, so their top-level ids read `mdf-drawer-metadata.{field}` /
+`mdf-drawer-embedded-item.{field}`. The page form passes nothing and its ids are
+unchanged. Dev builds additionally report any duplicate `mdf-` host id in the
+document, so a future second-form mount point that forgets a segment fails
+loudly instead of silently re-crossing the wires.

--- a/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
@@ -28,7 +28,11 @@
 import * as React from 'react';
 import { Loader2, Save, AlertTriangle } from 'lucide-react';
 import { Button } from '@object-ui/components';
-import { SchemaForm, type SchemaFormIssue } from './SchemaForm';
+import {
+  SchemaForm,
+  DRAWER_EMBEDDED_ITEM_ID_SCOPE,
+  type SchemaFormIssue,
+} from './SchemaForm';
 import { getMetadataPreview } from './preview-registry';
 import { useMetadataClient, useMetadataTypes } from './useMetadata';
 import { useMetadataLocale, t, tFormat, translateValidationMessage } from './i18n';
@@ -218,8 +222,13 @@ export function EmbeddedItemEditor({
         />
       )}
 
+      {/* This editor only ever renders inside `MetadataDetailDrawer`, i.e. on
+          top of a page that is still rendering its own form. The scope segment
+          keeps the two instances' top-level ids apart so this form's labels
+          address THIS form's controls (objectui#5092). */}
       <SchemaForm
         schema={schema}
+        idPath={DRAWER_EMBEDDED_ITEM_ID_SCOPE}
         form={form}
         value={draft}
         onChange={setDraft}

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -88,7 +88,11 @@ import { PageShell } from './PageShell';
 import { MetadataTypeActions } from './MetadataTypeActions';
 import { LayeredDiff, countOverlaidFields } from './LayeredDiff';
 import { DraftReviewPanel, computeDraftChangeCount } from './DraftReviewPanel';
-import { SchemaForm, type SchemaFormIssue } from './SchemaForm';
+import {
+  SchemaForm,
+  DRAWER_METADATA_ID_SCOPE,
+  type SchemaFormIssue,
+} from './SchemaForm';
 import { collectPageComponentIds } from './widgets';
 import {
   useMetadataClient,
@@ -1602,6 +1606,14 @@ function MetadataResourceEditPageImpl({
       ? getMetadataPreview(type)
       : undefined;
 
+  // The id scope for THIS editor's form (objectui#5092). Embedded means we are
+  // mounted inside `MetadataDetailDrawer`, which slides over a page that is
+  // still rendering its own form: without a scope segment both forms emit the
+  // same `mdf-{field}` ids for every field name they share, and the drawer's
+  // labels — later in document order — resolve to the page's controls.
+  // The page editor passes `undefined` and its ids stay exactly as they were.
+  const formIdPath = embedded ? DRAWER_METADATA_ID_SCOPE : undefined;
+
   // Optional scoped inspector for the selected sub-element (e.g. a
   // dashboard widget). Registered separately via
   // `registerMetadataInspector()` so a type can opt in independently
@@ -2458,6 +2470,7 @@ function MetadataResourceEditPageImpl({
                         ) : (
                           <SchemaForm
                             schema={schema}
+                            idPath={formIdPath}
                             form={createMode && config.createSchema ? undefined : (entry?.form as any)}
                             value={draft}
                             onChange={handleCreateAwareChange}
@@ -2481,6 +2494,7 @@ function MetadataResourceEditPageImpl({
             ) : (
               <SchemaForm
                 schema={schema}
+                idPath={formIdPath}
                 form={createMode && config.createSchema ? undefined : (entry?.form as any)}
                 value={draft}
                 onChange={handleCreateAwareChange}

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.instanceIdScope.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.instanceIdScope.test.tsx
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5092 — two `SchemaForm` instances in ONE document must not share
+ * their top-level ids.
+ *
+ * ## What was measured (baseline `fc1511152`, real `SchemaForm` renders)
+ *
+ * Two instances mounted at once, both with fields `name` / `label`:
+ *
+ * ```
+ * ids: ["mdf-name","mdf-label","mdf-name","mdf-label"]
+ * DUPLICATES: ["mdf-name","mdf-label"]
+ * Name[0] host=page   -> target in=page value=page
+ * Name[1] host=drawer -> target in=page value=page   <- the drawer's label,
+ *                                                      wired to the PAGE control
+ * ```
+ *
+ * objectui#5062 scoped NESTED rows by path and deliberately left top-level ids
+ * spelled `mdf-{field}` — no instance dimension. That is fine for one form and
+ * wrong the moment a second one is mounted: `MetadataDetailDrawer` is a Radix
+ * `Sheet`, so opening it leaves the page's form IN THE DOM underneath, and a
+ * `label[for]` resolves to the FIRST match in document order. Every field name
+ * the two forms share (`name`, `label`, `description` — nearly always) made the
+ * drawer's label focus, and assistive tech read, the control of the form the
+ * drawer is covering. Resolved-to-the-wrong-element, not dangling — the same
+ * failure class as #5062 / #3343, one scope up.
+ *
+ * ## What this file pins
+ *
+ *  1. the CROSS-WIRING, through the REAL mount points (`MetadataDetailDrawer`
+ *     over `MetadataResourceEditPage`, for both drawer bodies) — not through a
+ *     hand-passed `idPath`, which would stay green if a mount point dropped its
+ *     scope segment;
+ *  2. the PAGE contract: the page form's top-level ids are still exactly
+ *     `mdf-{field}`. The scoping is additive, and #5062's "top level does not
+ *     move" ruling survives this change untouched;
+ *  3. the ASSERTION itself: a document that really does hold duplicate host ids
+ *     makes the dev build shout. Scoping by mount point relies on every future
+ *     host remembering to pass a segment; this is what stops a forgotten one
+ *     from regressing in silence.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+/** Bodies for the two metadata items the two forms edit. */
+const BODIES: Record<string, Record<string, unknown>> = {
+  page_item: { name: 'page_item', label: 'PAGE VALUE' },
+  drawer_item: { name: 'drawer_item', label: 'DRAWER VALUE' },
+};
+
+const mockClient = {
+  list: vi.fn(async () => []),
+  listDrafts: vi.fn(async () => []),
+  get: vi.fn(async () => null),
+  getDraft: vi.fn(async () => null),
+  references: vi.fn(async () => []),
+  layered: vi.fn(async (_type: string, name: string) => ({
+    code: BODIES[name] ?? {},
+    overlay: null,
+    overlayScope: null,
+    effective: BODIES[name] ?? {},
+    packageId: 'sys_metadata',
+    editable: true,
+  })),
+};
+
+// `object` (the page + drawer editors) and `field` (the drawer's embedded-item
+// editor) both expose top-level `name` / `label` — the field names that collide.
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', title: 'Name' },
+    label: { type: 'string', title: 'Label' },
+  },
+};
+
+vi.mock('./useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({
+      loading: false,
+      error: null,
+      entries: [
+        { type: 'object', name: 'object', label: 'Object', allowRuntimeCreate: true, schema: SCHEMA },
+        { type: 'field', name: 'field', label: 'Field', allowRuntimeCreate: true, schema: SCHEMA },
+      ],
+    }),
+  };
+});
+
+import { SchemaForm, DRAWER_METADATA_ID_SCOPE, DRAWER_EMBEDDED_ITEM_ID_SCOPE } from './SchemaForm';
+import { MetadataResourceEditPage } from './ResourceEditPage';
+import { MetadataDetailDrawer } from './MetadataDetailDrawer';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/** Every `mdf-` id in the document, and the ones that appear more than once. */
+function idCensus() {
+  const ids = Array.from(document.querySelectorAll('[id^="mdf-"]')).map((e) => e.id);
+  return { ids, duplicates: Array.from(new Set(ids.filter((id, i) => ids.indexOf(id) !== i))) };
+}
+
+/** The element THIS label's `for` actually resolves to. */
+function controlFor(label: HTMLElement): HTMLInputElement | null {
+  const target = label.closest('label')!.getAttribute('for');
+  return target ? (document.getElementById(target) as HTMLInputElement | null) : null;
+}
+
+/**
+ * The page's form and the drawer's form, in one document — the production
+ * arrangement: `ResourceEditPage` renders its own `SchemaForm` and then, as a
+ * SIBLING, the drawer, which mounts a second editor on top without unmounting
+ * the first.
+ */
+function renderPageWithDrawer(target: React.ComponentProps<typeof MetadataDetailDrawer>['target']) {
+  return render(
+    <MemoryRouter initialEntries={['/metadata/object/page_item']}>
+      <div data-host="page">
+        <MetadataResourceEditPage type="object" name="page_item" />
+      </div>
+      <div data-host="drawer-host">
+        <MetadataDetailDrawer target={target} onClose={() => {}} parentContext={{ type: 'object', name: 'page_item' }} />
+      </div>
+    </MemoryRouter>,
+  );
+}
+
+describe('#5092 — the drawer form and the page form do not share ids', () => {
+  it('metadata drawer body: the drawer label resolves to the DRAWER control', async () => {
+    renderPageWithDrawer({ kind: 'metadata', type: 'object', name: 'drawer_item' });
+
+    // Both editors have loaded once both bodies are on screen.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('PAGE VALUE')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('DRAWER VALUE')).toBeInTheDocument();
+    });
+
+    // The measured defect: `["mdf-name","mdf-label"]`.
+    expect(idCensus().duplicates).toEqual([]);
+
+    // Assert on the VALUE behind each association, not on id inequality — two
+    // distinct ids can still be wired to one element.
+    const labels = screen.getAllByText('Label');
+    expect(labels).toHaveLength(2);
+    const [pageLabel, drawerLabel] = labels;
+    expect(controlFor(pageLabel)).toHaveValue('PAGE VALUE');
+    // Before: this read 'PAGE VALUE' — the control behind the drawer.
+    expect(controlFor(drawerLabel)).toHaveValue('DRAWER VALUE');
+    expect(controlFor(pageLabel)).not.toBe(controlFor(drawerLabel));
+
+    // The drawer's own ids carry its scope segment; the page's do not.
+    expect(document.getElementById(`mdf-${DRAWER_METADATA_ID_SCOPE}.label`)).toHaveValue('DRAWER VALUE');
+    expect(document.getElementById('mdf-label')).toHaveValue('PAGE VALUE');
+  });
+
+  it('embedded-item drawer body: the drawer label resolves to the DRAWER control', async () => {
+    renderPageWithDrawer({
+      kind: 'embedded',
+      parentType: 'object',
+      parentName: 'page_item',
+      groupLabel: 'Fields',
+      itemName: 'email',
+      editAs: 'field',
+      embeddedPath: 'fields',
+      raw: { name: 'email', label: 'DRAWER VALUE' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('PAGE VALUE')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('DRAWER VALUE')).toBeInTheDocument();
+    });
+
+    expect(idCensus().duplicates).toEqual([]);
+
+    const [pageLabel, drawerLabel] = screen.getAllByText('Label');
+    expect(controlFor(pageLabel)).toHaveValue('PAGE VALUE');
+    expect(controlFor(drawerLabel)).toHaveValue('DRAWER VALUE');
+    expect(document.getElementById(`mdf-${DRAWER_EMBEDDED_ITEM_ID_SCOPE}.label`)).toHaveValue('DRAWER VALUE');
+    expect(document.getElementById('mdf-label')).toHaveValue('PAGE VALUE');
+  });
+});
+
+describe('#5092 — the page form keeps the historical top-level id spelling', () => {
+  it('the page editor still spells its top-level ids `mdf-{field}`', async () => {
+    render(
+      <MemoryRouter initialEntries={['/metadata/object/page_item']}>
+        <MetadataResourceEditPage type="object" name="page_item" />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByDisplayValue('PAGE VALUE')).toBeInTheDocument());
+
+    // The #5062 promise, re-pinned from the page side: the selector surface the
+    // other metadata-admin suites read must not move because of this change.
+    expect(document.getElementById('mdf-name')).toHaveValue('page_item');
+    expect(document.getElementById('mdf-label')).toHaveValue('PAGE VALUE');
+    expect(screen.getByText('Label').closest('label')).toHaveAttribute('for', 'mdf-label');
+  });
+
+  it('a bare SchemaForm with no idPath is byte-for-byte unchanged', () => {
+    render(
+      <SchemaForm schema={SCHEMA as never} value={{ name: 'n', label: 'l' }} onChange={() => {}} />,
+    );
+    expect(screen.getByText('Name').closest('label')).toHaveAttribute('for', 'mdf-name');
+    expect(document.getElementById('mdf-name')).toHaveValue('n');
+    expect(document.getElementById('mdf-label')).toHaveValue('l');
+  });
+});
+
+describe('#5092 — the scope segments themselves', () => {
+  it('are distinct, whitespace-free, and unspellable as a field name', () => {
+    // Two scoped forms must not collide with each other either.
+    expect(DRAWER_METADATA_ID_SCOPE).not.toBe(DRAWER_EMBEDDED_ITEM_ID_SCOPE);
+    for (const seg of [DRAWER_METADATA_ID_SCOPE, DRAWER_EMBEDDED_ITEM_ID_SCOPE]) {
+      // These ids are read as `aria-labelledby` IDREFs, which tokenize on
+      // whitespace (#5062).
+      expect(seg).not.toMatch(/\s/);
+      // A `-` cannot occur in a metadata machine name (`^[a-z][a-z0-9_]*$`) nor
+      // in the camelCase property names the metadata JSON-Schemas use, so
+      // `mdf-{seg}.{field}` is not reachable from any real field path.
+      expect(seg).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)+$/);
+    }
+  });
+});
+
+describe('#5092 — the dev-only duplicate-host-id assertion', () => {
+  it('shouts, naming the colliding ids, when two unscoped forms are mounted', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // The pre-fix arrangement, reconstructed on purpose: a second form with no
+    // scope segment. This is what a NEW mount point that forgets one looks like.
+    render(
+      <div>
+        <SchemaForm schema={SCHEMA as never} value={{ name: 'a', label: 'a' }} onChange={() => {}} />
+        <SchemaForm schema={SCHEMA as never} value={{ name: 'b', label: 'b' }} onChange={() => {}} />
+      </div>,
+    );
+
+    expect(idCensus().duplicates).toEqual(['mdf-name', 'mdf-label']);
+    const shouted = spy.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('[SchemaForm]'));
+    expect(shouted.length).toBeGreaterThan(0);
+    expect(shouted[0]).toContain('mdf-name');
+    expect(shouted[0]).toContain('mdf-label');
+    expect(shouted[0]).toContain('objectui#5092');
+    spy.mockRestore();
+  });
+
+  it('stays quiet when the second form carries a scope segment', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <div>
+        <SchemaForm schema={SCHEMA as never} value={{ name: 'a', label: 'a' }} onChange={() => {}} />
+        <SchemaForm
+          schema={SCHEMA as never}
+          idPath={DRAWER_METADATA_ID_SCOPE}
+          value={{ name: 'b', label: 'b' }}
+          onChange={() => {}}
+        />
+      </div>,
+    );
+
+    expect(idCensus().duplicates).toEqual([]);
+    expect(spy.mock.calls.filter((c) => String(c[0]).includes('[SchemaForm]'))).toEqual([]);
+    spy.mockRestore();
+  });
+
+  it('does no work in a production build', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      render(
+        <div>
+          <SchemaForm schema={SCHEMA as never} value={{ name: 'a', label: 'a' }} onChange={() => {}} />
+          <SchemaForm schema={SCHEMA as never} value={{ name: 'b', label: 'b' }} onChange={() => {}} />
+        </div>,
+      );
+      // The collision is real; the diagnostic is a dev-build affordance only.
+      expect(idCensus().duplicates).toEqual(['mdf-name', 'mdf-label']);
+      expect(spy.mock.calls.filter((c) => String(c[0]).includes('[SchemaForm]'))).toEqual([]);
+    } finally {
+      process.env.NODE_ENV = prev;
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -712,9 +712,17 @@ export interface SchemaFormProps {
   /** JSONSchema for the root object. */
   schema: JsonSchema | undefined;
   /**
-   * Ancestor id path this form is nested under — set ONLY by the recursive
-   * render inside {@link FieldControl} (objectui#5062). A top-level form leaves
-   * it undefined, which is what keeps top-level ids spelled `mdf-{field}`.
+   * Ancestor id path this form is nested under. Two kinds of caller set it:
+   *
+   *  - the recursive render inside {@link FieldControl}, which passes the path
+   *    of the field hosting this form (objectui#5062);
+   *  - a host that mounts a SECOND form into a document that already has one,
+   *    which passes an artificial ancestor SEGMENT to scope the whole instance
+   *    (objectui#5092 — see {@link DRAWER_METADATA_ID_SCOPE}). The semantics
+   *    are unchanged: it is still just an ancestor path.
+   *
+   * The PAGE-level form leaves it undefined, which is what keeps top-level ids
+   * spelled `mdf-{field}`.
    */
   idPath?: string;
   /**
@@ -745,7 +753,7 @@ export interface SchemaFormProps {
   widgetContext?: WidgetContext;
 }
 
-export function SchemaForm({
+function SchemaFormBody({
   schema,
   form,
   value,
@@ -885,6 +893,115 @@ export function SchemaForm({
         />
       ))}
     </div>
+  );
+}
+
+/* ----- instance scoping (objectui#5092) ----------------------------------- */
+
+/**
+ * Scope segments for the SECOND `SchemaForm` a metadata-admin document can
+ * host (objectui#5092).
+ *
+ * `MetadataDetailDrawer` is a Radix `Sheet`: when it opens, the page's own
+ * form STAYS IN THE DOM behind it. Both forms render top-level fields, and
+ * top-level ids are `mdf-{field}` with no instance dimension — so a field
+ * name both forms have (`name`, `label`, `description` — nearly always) is
+ * one id twice, and a `label[for]` resolves to the FIRST match in document
+ * order, i.e. the PAGE form. The drawer's labels then name and focus the
+ * controls of the form hidden behind the drawer.
+ *
+ * The fix is the ancestor path {@link joinIdPath} already threads: each
+ * drawer-side mount point passes a scope segment as its form's `idPath`, so
+ * its top-level fields become `mdf-{scope}.{field}`. The PAGE form passes
+ * nothing and its ids are byte-for-byte what they always were — the selector
+ * surface the metadata-admin tests read does not move (the same additive
+ * contract objectui#5062 kept for nested rows).
+ *
+ * Requirements on a segment, and why these two satisfy them:
+ *
+ *  - **Distinct per mount point** — two scoped forms must not collide with
+ *    each other either. Pinned by `SchemaForm.instanceIdScope.test.tsx`.
+ *  - **Whitespace-free** — these ids are consumed as `aria-labelledby` IDREFs,
+ *    which tokenize on whitespace (objectui#5062, `joinIdPath`).
+ *  - **Cannot be spelled by a real field** — a segment equal to some top-level
+ *    field name would let `mdf-{scope}.{field}` be reached from two different
+ *    paths. Both segments contain `-`, which is outside the metadata
+ *    machine-name grammar (`^[a-z][a-z0-9_]*$`) and outside the camelCase
+ *    property names the metadata JSON-Schemas use.
+ */
+export const DRAWER_METADATA_ID_SCOPE = 'drawer-metadata';
+
+/** @see DRAWER_METADATA_ID_SCOPE — the drawer's embedded-item editor. */
+export const DRAWER_EMBEDDED_ITEM_ID_SCOPE = 'drawer-embedded-item';
+
+/**
+ * True inside any `SchemaForm`, so the OUTERMOST form of a subtree runs the
+ * duplicate-id scan and the nested ones (a composite/repeater page mounts
+ * dozens) do not repeat it.
+ *
+ * Per SUBTREE, not per document: the page form and the drawer's form are
+ * siblings, so both are outermost and both scan. That is intended — the scan
+ * is precisely what tells the two of them apart.
+ */
+const SchemaFormNestingContext = React.createContext(false);
+
+const isDevBuild = (): boolean =>
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+    ?.NODE_ENV !== 'production';
+
+/**
+ * Dev-only: say out loud that two field host ids collide in this document.
+ *
+ * Scoping by mount point (above) relies on every host that mounts a SECOND
+ * form remembering to pass a segment — a new mount point that forgets brings
+ * the cross-wiring back SILENTLY, because a duplicate id is not an error to
+ * the DOM and the association still resolves, just to the wrong element.
+ * This is the half that makes that failure loud. Production is untouched:
+ * the whole body is behind the dev gate, so the effect does no work.
+ */
+function useDuplicateFieldHostIdCheck(enabled: boolean): void {
+  // Report a given collision set once per form instance instead of on every
+  // keystroke; a fresh mount reports again, which is what makes it visible.
+  const lastReported = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    if (!enabled || !isDevBuild() || typeof document === 'undefined') return;
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+    for (const el of Array.from(document.querySelectorAll('[id^="mdf-"]'))) {
+      const id = el.id;
+      if (!seen.has(id)) seen.add(id);
+      else if (!duplicates.includes(id)) duplicates.push(id);
+    }
+    const signature = duplicates.join(',');
+    if (signature === lastReported.current) return;
+    lastReported.current = signature;
+    if (duplicates.length === 0) return;
+    console.error(
+      `[SchemaForm] duplicate field host id(s) in this document: ${duplicates.join(', ')}. ` +
+        'Two SchemaForm instances are mounted at once — the metadata detail drawer sits on ' +
+        'top of the page form, which stays in the DOM — and at least one of them renders ' +
+        'unscoped top-level ids. A `label[for]` resolves to the FIRST match in the document, ' +
+        "so the later form's labels name and focus the earlier form's controls " +
+        '(objectui#5092). Give the secondary form a distinct `idPath` scope segment — see ' +
+        'DRAWER_METADATA_ID_SCOPE / DRAWER_EMBEDDED_ITEM_ID_SCOPE in SchemaForm.tsx.',
+    );
+  });
+}
+
+/**
+ * Renders a metadata form for `schema` (see {@link SchemaFormProps}).
+ *
+ * The wrapper exists for the two document-level concerns above: it marks the
+ * subtree as "inside a SchemaForm" so nested forms know they are not the
+ * outermost one, and it runs the dev-only duplicate-host-id check.
+ */
+export function SchemaForm(props: SchemaFormProps) {
+  const nested = React.useContext(SchemaFormNestingContext);
+  useDuplicateFieldHostIdCheck(!nested);
+  return (
+    <SchemaFormNestingContext.Provider value={true}>
+      <SchemaFormBody {...props} />
+    </SchemaFormNestingContext.Provider>
   );
 }
 


### PR DESCRIPTION
Fixes #5092

按 PM 裁定评论 https://github.com/objectstack-ai/objectui/issues/5092#issuecomment-5321636425 取**方向 3**(= 方向 2「宿主显式传作用域」+ 开发期重复 id 断言)。方向 1(`useId()` 实例命名空间)是顶层 id 契约变更,属维护者题,裁定里留了否决窗 —— 本 PR 落的 3 对既有面是纯加法,不构成 1 的障碍。

基线 `fc1511152`(已含 PR #5096 的 `idPath` 贯穿,本卡直接复用)。

## 前提复测(在含 #5096 的新基线上逐条重测,卡面读数全部成立)

1. 在途路径与卡面**逐行一致**、行号未漂移:`ResourceEditPage.tsx` 先渲染自己的 `SchemaForm`(第 2459 / 2482 行,两条互斥分支之一),再在第 2647 行渲染 `MetadataDetailDrawer`;后者是 Radix `Sheet`,打开时页面表单仍在 DOM 里,Sheet 内挂 `MetadataResourceEditPage`(embedded)或 `EmbeddedItemEditor`(第 221 行)。
2. 实测形复现(真 `SchemaForm` 渲染,两实例同挂,字段 name / label):

```
ids: ["mdf-name","mdf-label","mdf-name","mdf-label"]
DUPLICATES: ["mdf-name","mdf-label"]
Name[0] host=page   -> target in=page value=page
Name[1] host=drawer -> target in=page value=page   <- 抽屉的标签,指向页面表单的控件
```

3. `idPath` 贯穿(`SchemaFormProps.idPath` / `joinIdPath` / `fieldHostId`)已在基线到位,形状可直接复用。

**补充读数(卡面未写,影响落点)**:`PreviewComponent` 由 `!embedded && …` 求值,embedded 下恒为 `undefined`,所以抽屉里**只会**走第 2482 行那条分支;第 2459 行那条恒属页面侧。两处仍统一传同一个 `formIdPath`(embedded 时才有值),这样即便将来该门放开,作用域也不会漏。

## 改动

- 两个抽屉侧挂载点各传一个稳定作用域段作为其内部 `SchemaForm` 的 `idPath`:embedded 的 `MetadataResourceEditPage` 用 `drawer-metadata`,`EmbeddedItemEditor` 用 `drawer-embedded-item`。顶层 id 变 `mdf-drawer-metadata.{字段名}` / `mdf-drawer-embedded-item.{字段名}`。
- **页面主表单不传,顶层 id `mdf-{字段名}` 一字不动**(#5062 裁定的承诺),由钉子逐字锁住。
- 语义未变:作用域段就是一个人工祖先段,`idPath` 仍是祖先路径。
- 段的三条约束都有钉:两段互不相同;无空白(这些 id 会被当 `aria-labelledby` IDREF 消费,按空白切分);含 `-`,而 `-` 不在 metadata machine name 文法(`^[a-z][a-z0-9_]*$`)内、也不在这些 JSON-Schema 用的 camelCase 属性名内,因此 `mdf-{段}.{字段}` 不可能被任何真实字段路径拼出。
- `SchemaForm` 增开发期重复 id 断言:检测同文档重复的 `mdf-` 宿主 id 并 `console.error` 响亮告警,消息点名冲突 id 与成因。生产构建零开销(`NODE_ENV` 门);只有子树最外层那个表单扫,嵌套的几十个不重复扫。这是把方向 2「漏传新并挂点就静默复发」变响亮的那一半。

## 测试

新增 `SchemaForm.instanceIdScope.test.tsx`(8 个)。复现钉走**真实挂载点**(`MetadataDetailDrawer` 盖在 `MetadataResourceEditPage` 上,两种抽屉体各一)而非手传 `idPath` —— 手传的话挂载点漏传时钉子照绿,就是个幻检查。

- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/` → **180 files / 1858 passed | 1 skipped**
- 四个红线文件计数逐一吻合:widgetLabelling **62**、nonRegistryLabelling **40**、nestedIdScope **7**、gridCellNaming **5**(合计 114 全绿)
- 仓根 `turbo run type-check` → **81 successful, 81 total**
- eslint(4 个改动文件)→ **0 errors**;新增代码块内 0 warning

## 反向验证(先书面预判,commit 后变异,`git checkout --` 还原;四条方向全部与预判相符)

| 变异 | 预判 | 实测 |
|---|---|---|
| (a) 摘掉 `EmbeddedItemEditor` 的作用域段 | 仅 embedded-item 那条钉红,首失在 `duplicates` | 1 red:`expected [ 'mdf-name', 'mdf-label' ] to deeply equal []`,且 dev 断言把完整诊断打了出来;metadata 抽屉那条仍绿 |
| (b) 作用域段改成含空格串 | **只有段契约钉抓得住**;两条 DOM 钉仍绿 —— `getElementById` / `label[for]` 都是整串精确匹配,happy-dom 不做 IDREF 切分 | 1 red:`expected 'drawer metadata' not to match /\s/`,两条 DOM 钉果然全绿 |
| (c) 页面主表单也传同一个段 | 3 red(两条抽屉钉 + 顶层拼写钉);裸 SchemaForm 那条不过 ResourceEditPage,仍绿 | 3 red,首失为 `expected [ 'mdf-drawer-metadata.name', …(1) ] to deeply equal []` —— 全局共用一个段只是把碰撞挪了个位置,证实段必须按挂载点分 |
| (d) 把 dev 断言改成 no-op | 仅「shouts…」红;另两条断言钉**仍绿**,因为它们断的是"不发生" | 1 red:`expected 0 to be greater than 0`,另两条如实绿 |

(b) 与 (d) 两条的方向值得写明:它们**不是** before-green/after-red 的常规形。(b) 说明含空白的段在 DOM 侧不会自己报错,契约钉是唯一防线;(d) 说明三条断言钉里只有一条是正向守卫,另两条是条件钉 —— 如实记下,免得下一个人误读成三条都在守断言器。

## 界外

未发现新的半径外缺陷。另有几个 `SchemaForm` 挂载点(`PackageFormDialog`、`ObjectHooksPanel`、各 inspector)经核不与页面表单同文档并挂:inspector 那几处与第 2459/2482 行是互斥三元分支,同一时刻页面上只有一个表单。若将来真并挂,新加的开发期断言会当场响。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_