### PR TITLE
fix(plugin-grid): object-grid 的 data 输入按契约声明为 ViewData 对象

### DIFF
--- a/.changeset/grid-data-input-declares-viewdata-5090.md
+++ b/.changeset/grid-data-input-declares-viewdata-5090.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+`object-grid` now declares its `data` input as the object its contract actually
+accepts, instead of as an array (objectui#5090).
+
+The declaration published `{ name: 'data', type: 'array', label: 'Static Data',
+description: 'Inline rows, …' }` — which is the shape of `staticData`, the
+deprecated alias the objectui#4648 carve-out deliberately leaves unpublished,
+under the canonical key's name. The contract is
+`ObjectGridSchema.data?: ViewData`: the spec's discriminated union on
+`provider`, four strict object arms (`object` / `api` / `value` / `schema`),
+none of them an array.
+
+Both halves of that misdeclaration were user-visible. An author following the
+designer panel or the generated `sdui-intrinsics.d.ts` wrote `data: [ …rows… ]`
+and got a grid that renders but a document `tsc` rejects (TS2322) and spec
+parsing refuses; meanwhile the one form that satisfies both,
+`{ provider: 'value', items: [...] }`, was reported as `type-mismatch` by the
+save gate, because a declared `array` arm accepts only arrays. Writing the
+inline-rows form the README already documents now validates clean, and the
+designer labels the key `Data Source` with a description that names all four
+providers rather than only the deprecated shortcut's shape.
+
+The renderer is unchanged: a bare array is still honoured as back-compat
+(`getDataConfig` folds it to `{ provider: 'value', items }`), it is simply no
+longer advertised as authoring surface — the same standing `staticData` has.
+Authors who wrote the array shorthand keep working and will now see a
+`type-mismatch` hint pointing at the spec-valid spelling.

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -48,9 +48,9 @@ three calls in `src/index.tsx` claim exactly these keys:
 
 | `register(…)` call | Namespaced key | Bare fallback |
 | --- | --- | --- |
-| `('object-grid', ObjectGridRenderer, { namespace: 'plugin-grid' })` — `src/index.tsx:181` | `plugin-grid:object-grid` | `object-grid` |
-| `('grid', ObjectGridRenderer, { namespace: 'view', skipFallback: true })` — `src/index.tsx:193` | `view:grid` | **none** — `skipFallback: true` |
-| `('import-wizard', ImportWizardRenderer, { namespace: 'plugin-grid' })` — `src/index.tsx:216` | `plugin-grid:import-wizard` | `import-wizard` |
+| `('object-grid', ObjectGridRenderer, { namespace: 'plugin-grid' })` — `src/index.tsx:202` | `plugin-grid:object-grid` | `object-grid` |
+| `('grid', ObjectGridRenderer, { namespace: 'view', skipFallback: true })` — `src/index.tsx:214` | `view:grid` | **none** — `skipFallback: true` |
+| `('import-wizard', ImportWizardRenderer, { namespace: 'plugin-grid' })` — `src/index.tsx:237` | `plugin-grid:import-wizard` | `import-wizard` |
 
 **Bare `grid` is deliberately not ours.** `skipFallback: true` on the second call
 keeps this plugin from claiming it, because `grid` belongs to the CSS Grid *layout*
@@ -148,7 +148,7 @@ contract rather than this package's component API.
 
 A grid node is an `ObjectGridSchema`: one required `objectName`, and keys drawn
 from the list this package **declares** as its authoring surface
-(`GRID_QUERY_INPUTS`, `src/index.tsx:145`) — the same list that feeds the designer
+(`GRID_QUERY_INPUTS`, `src/index.tsx:166`) — the same list that feeds the designer
 panel and the generated `sdui-intrinsics.d.ts`, so what is authorable here is what
 the renderer reads.
 

--- a/packages/plugin-grid/src/__tests__/gridDataInputContract.test.ts
+++ b/packages/plugin-grid/src/__tests__/gridDataInputContract.test.ts
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `object-grid` — the DECLARED coarse type of `data` must be the one its
+ * contract accepts (objectui#5090).
+ *
+ * ## What was wrong
+ *
+ * `GRID_QUERY_INPUTS` declared `{ name: 'data', type: 'array', label: 'Static
+ * Data', description: 'Inline rows, …' }`, but the contract is
+ * `ObjectGridSchema.data?: ViewData` — the spec's discriminated union on
+ * `provider`, four strict OBJECT arms (`object` / `api` / `value` / `schema`),
+ * none of them an array. The declaration published the shape of `staticData`,
+ * the deprecated alias the objectui#4648 carve-out deliberately refuses to
+ * publish, under the canonical key's name.
+ *
+ * Both halves failed quietly, in opposite directions — objectui#4041's shape,
+ * one field over:
+ *
+ *   - an author following the published declaration wrote `data: [ …rows… ]`,
+ *     which the renderer does honour (`getDataConfig`'s `Array.isArray` branch)
+ *     but which `tsc` refuses (`TS2322`, measured) and `ViewDataSchema` refuses;
+ *   - the one form that satisfies both — `{ provider: 'value', items: [...] }` —
+ *     drew `type-mismatch` from this repo's own save gate, because
+ *     `checkType`'s `'array'` arm (`sdui-parser/src/validate.ts`) accepts only
+ *     arrays. The platform reported the only legal write as a type error.
+ *
+ * ## What these tests pin, and why it is DERIVED
+ *
+ * The subject is the declaration read out of the registry, never a constant
+ * restated here — a test spelling `'object'` on both sides would keep passing
+ * through exactly the drift it exists to catch. So the expected arms come from
+ * `ViewDataSchema`'s own verdicts: one representative value per coarse arm, in
+ * the vocabulary `armAccepts` uses, filtered by what the schema accepts. Either
+ * side moving turns the comparison red — a spec release that widens `ViewData`
+ * to accept an array, or a declaration that grows an arm the contract rejects.
+ * That derivation is the discipline `component-input-union-specimens.test.ts`
+ * and `text-input-inputs-spec-parity.test.ts` adopted, and it is the only gate
+ * on this fact: whether a declared arm matches the contract is otherwise
+ * nobody's (objectui#4971).
+ *
+ * The renderer's array tolerance is NOT asserted away here. It stays as
+ * back-compat and is objectui#5068's family; what this file forbids is
+ * ADVERTISING it, which is the carve-out's own reasoning applied to an arm
+ * instead of a key.
+ *
+ * The compile-time half needs this package's `tsconfig.test.json`
+ * (objectui#3181) — without it the `@ts-expect-error` below is erased before
+ * vitest runs and proves nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { ViewDataSchema } from '@objectstack/spec/ui';
+import type { ObjectGridSchema } from '@object-ui/types';
+// Registers `object-grid` and its `view:grid` alias.
+import '../index';
+
+/** The two tags this one renderer is published under, sharing one input list. */
+const GRID_TAGS = [
+  { label: 'object-grid', type: 'object-grid', namespace: undefined },
+  { label: 'view:grid', type: 'grid', namespace: 'view' },
+] as const;
+
+/**
+ * One representative value per coarse arm, in the vocabulary `armAccepts` uses
+ * (`packages/sdui-parser/src/validate.ts`).
+ *
+ * The `object` probe is the INLINE ROWS form specifically — the shape the old
+ * declaration was reaching for and got wrong — so a spec rename of `items`
+ * empties the derived set and reds this file with a message about the probe
+ * rather than silently agreeing with a broken declaration.
+ */
+const COARSE_ARM_PROBES = [
+  ['string', 'users'],
+  ['number', 42],
+  ['boolean', true],
+  ['object', { provider: 'value', items: [{ id: 1 }] }],
+  ['array', [{ id: 1 }]],
+] as const;
+
+/** The coarse arms the CONTRACT accepts, from the schema's own verdicts. */
+const contractAcceptedArms = (): string[] =>
+  COARSE_ARM_PROBES.filter(([, value]) => ViewDataSchema.safeParse(value).success).map(
+    ([arm]) => arm,
+  );
+
+/** The `data` input as the registration publishes it. */
+function declaredDataInput(type: string, namespace?: string) {
+  const inputs = (ComponentRegistry.getConfig(type, namespace) as any)?.inputs ?? [];
+  return inputs.find((i: any) => i?.name === 'data');
+}
+
+/** Declared arms, normalised across the single-kind and array forms. */
+const declaredArms = (type: string, namespace?: string): string[] => {
+  const declared = declaredDataInput(type, namespace)?.type;
+  return Array.isArray(declared) ? [...declared] : [declared];
+};
+
+describe('object-grid `data` — declaration matches the contract (objectui#5090)', () => {
+  it.each(GRID_TAGS)('$label registers and declares a `data` input', ({ type, namespace }) => {
+    // Reachability before absence: an unregistered or renamed block would
+    // satisfy every assertion below by never resolving an input at all.
+    expect(ComponentRegistry.getConfig(type, namespace), `${type} is not registered`).toBeDefined();
+    expect(declaredDataInput(type, namespace), `${type} declares no \`data\` input`).toBeDefined();
+  });
+
+  it('the contract accepts exactly the object arm (the derivation, stated)', () => {
+    // Non-vacuity for everything below: if `ViewDataSchema` stopped resolving
+    // through `lazySchema`, or the probe went stale, this set would empty out
+    // and the comparison would pass on nothing.
+    expect(contractAcceptedArms()).toEqual(['object']);
+  });
+
+  it('each of the four providers parses, and none of them is an array', () => {
+    // What makes "the object arm" a real four-armed union rather than one
+    // accidental shape, and the direct measurement of the card's premise.
+    const providers = [
+      { provider: 'object', object: 'users' },
+      { provider: 'api', read: { url: 'https://example.test/rows' } },
+      { provider: 'value', items: [{ id: 1 }] },
+      { provider: 'schema', schemaId: 'report' },
+    ];
+    for (const value of providers) {
+      expect(ViewDataSchema.safeParse(value).success, `${value.provider} provider`).toBe(true);
+      expect(Array.isArray(value)).toBe(false);
+    }
+  });
+
+  it.each(GRID_TAGS)('$label declares the arms the contract accepts', ({ type, namespace }) => {
+    expect(declaredArms(type, namespace)).toEqual(contractAcceptedArms());
+  });
+
+  it.each(GRID_TAGS)('$label does not declare the array shorthand', ({ type, namespace }) => {
+    // The regression named. `data: [ …rows… ]` is honoured by the renderer as
+    // back-compat (objectui#5068's family) but refused by `ViewData`, so
+    // declaring the arm would publish a shape `tsc` and the spec both reject —
+    // the same reason the objectui#4648 carve-out leaves `staticData` undeclared.
+    expect(declaredArms(type, namespace)).not.toContain('array');
+    expect(ViewDataSchema.safeParse([{ id: 1 }]).success).toBe(false);
+  });
+
+  it('declares one shape across both tags, so the alias cannot drift', () => {
+    const [a, b] = GRID_TAGS.map(({ type, namespace }) => declaredArms(type, namespace));
+    expect(a).toEqual(b);
+  });
+
+  it('is pinned at compile time too', () => {
+    // The runtime half above reads a declaration; this half reads the contract
+    // the declaration is supposed to describe. Erased before vitest runs — its
+    // value is that `tsc -p tsconfig.test.json` compiles it.
+
+    // The inline-rows form the description now teaches must type-check.
+    const inlineRows: ObjectGridSchema['data'] = { provider: 'value', items: [{ id: 1 }] };
+    expect(inlineRows).toBeDefined();
+
+    // …and the array shorthand must NOT. If `ViewData` ever widens to accept an
+    // array, this directive stops suppressing anything and `tsc` fails with
+    // "Unused '@ts-expect-error' directive" — which is the tripwire firing:
+    // re-derive the declared arms above instead of deleting this line.
+    // @ts-expect-error `ViewData` has no array arm — objectui#5090.
+    const bareArray: ObjectGridSchema['data'] = [{ id: 1 }];
+    expect(bareArray).toBeDefined();
+  });
+});

--- a/packages/plugin-grid/src/index.tsx
+++ b/packages/plugin-grid/src/index.tsx
@@ -141,6 +141,27 @@ export const ObjectGridRenderer: React.FC<{ schema: any; [key: string]: any }> =
  * spellings — `columns`, `data`, `selection`, `pagination`, `searchableFields`,
  * `sort`, `filter`, `resizable`, `label` — are all declared here, and each
  * description below says so, so the exemption teaches rather than merely omits.
+ *
+ * ## `data` declares the CONTRACT's shape, not the shortcut's (objectui#5090)
+ *
+ * The key landed above with `type: 'array'`, labelled "Static Data" and described
+ * as inline rows — which is the shape of `staticData`, the very alias the
+ * carve-out above refuses to publish, not the shape of `data`. The contract is
+ * `ObjectGridSchema.data?: ViewData` (`packages/types/src/objectql.ts`), and
+ * `ViewData` is the spec's discriminated union on `provider` — four strict object
+ * arms (`object` / `api` / `value` / `schema`), none of them an array. So the
+ * declaration published a shape `tsc` rejects (`TS2322`) and `ViewDataSchema`
+ * refuses, while the one form that satisfies both — `{ provider: 'value', items:
+ * [...] }` — drew `type-mismatch` from this repo's own save gate, because
+ * `checkType`'s `'array'` arm accepts only arrays. The platform contradicted
+ * itself on the only legal write: objectui#4041's shape again, one field over.
+ *
+ * `ObjectGrid`'s renderer does still accept a bare array (`getDataConfig` folds
+ * it to `{ provider: 'value', items }`), and that tolerance is deliberately left
+ * alone here — it is objectui#5068's family, and declaring an arm for it would
+ * publish a shape the contract rejects, which is precisely the carve-out's own
+ * reasoning. An array `data` therefore has the same standing as `staticData`:
+ * read as back-compat, not advertised as authoring surface.
  */
 const GRID_QUERY_INPUTS: ComponentInput[] = [
   { name: 'objectName', type: 'string', label: 'Object Name', required: true },
@@ -152,7 +173,7 @@ const GRID_QUERY_INPUTS: ComponentInput[] = [
   { name: 'sort', type: 'array', label: 'Sort', description: 'Initial sort order, `[{ field, order }]`. The canonical spelling — the deprecated single-sort `defaultSort` is only read when this is absent.' },
   { name: 'pagination', type: 'object', label: 'Pagination', description: 'Pagination config, `{ pageSize, pageSizeOptions, … }`. Its presence is what enables paging; prefer it over the deprecated flat `pageSize` / `showPagination` pair.' },
   { name: 'searchableFields', type: 'array', label: 'Searchable Fields', description: 'Fields the toolbar search box queries. A non-empty list is what enables search — prefer it over the deprecated boolean `showSearch`, which cannot say WHICH fields to search.' },
-  { name: 'data', type: 'array', label: 'Static Data', description: 'Inline rows, which bypass the object query entirely. For demos and fixtures; the canonical spelling — the deprecated `staticData` is the same thing.' },
+  { name: 'data', type: 'object', label: 'Data Source', description: 'Data source configuration — a `ViewData` object discriminated by `provider`: `{ provider: "object", object }` (what an omitted `data` falls back to, using `objectName`), `{ provider: "api", read, write }`, `{ provider: "value", items: [...] }` for inline rows that bypass the object query, or `{ provider: "schema", schemaId }`. The canonical spelling — the deprecated `staticData` is the array-only shortcut for the `value` provider, so inline rows go under `items` here rather than in a bare array.' },
   // ── presentation ──────────────────────────────────────────────────────────
   { name: 'rowHeight', type: 'enum', label: 'Row Height', enum: ['compact', 'short', 'medium', 'tall', 'extra_tall'], description: 'Row density. An unrecognised value falls back to `compact` rather than erroring.' },
   { name: 'frozenColumns', type: 'number', label: 'Frozen Columns', description: 'How many leading columns stay pinned while the grid scrolls horizontally.' },


### PR DESCRIPTION
Fixes #5090

## 问题

`GRID_QUERY_INPUTS`(`packages/plugin-grid/src/index.tsx`)把 `data` 声明成
`{ type: 'array', label: 'Static Data', description: 'Inline rows, …' }`,
而契约是 `ObjectGridSchema.data?: ViewData`(`packages/types/src/objectql.ts:556`)。
`ViewData` 是 spec 以 `provider` 辨识的联合,四支**全是 strict 对象**
(`object` / `api` / `value` / `schema`),没有数组那一支。

也就是说:这条声明描述的是 `staticData`(`objectql.ts:637`,`any[]`,已 `@deprecated`,
其 JSDoc 明写 "Use data with provider: 'value' instead")的形状 —— 而 `staticData`
正是 #4648 裁定明确**不发布**的那批已弃用别名之一 —— 却挂在 canonical 键 `data` 的名下。

两个方向都会伤到作者,实测:

| 写法 | 契约(tsc / spec) | 保存门禁(改前) |
| --- | --- | --- |
| `data: [ …行… ]`(照声明面写) | TS2322,拒绝 | 通过 |
| `data: { provider: 'value', items: [...] }`(唯一合法) | 通过 | `type-mismatch` |

编译探针(strict,对 `packages/types/dist`)复现卡面第 4 条:

```
error TS2322: Type '{ id: number; }[]' is not assignable to type
'{ provider: "object"; object: string; } | { provider: "api"; … } | …'
```

保存门禁那一侧实测(`manifestFromConfigs` + `validateTree`,真实注册表):改前
`{ provider: 'value', items: [...] }` 得到 `type-mismatch: prop "data" expected an array`
—— 平台在它**唯一合法**的写法上自相矛盾。这是 #4041 的形状换了一个键:
声明面与实现/契约指向相反的东西。

## 改法(只动声明面)

- `type`: `'array'` → `'object'`。词汇表侦查结论:`ComponentInputControlType`
  (`packages/types/src/base.ts:362`)的 11 个字面量里 `'object'` 就是正确值,
  **无需扩词汇表、无需改生成器**,故未触及契约面。
- `label`: `Static Data` → `Data Source`(按词面如实 —— 这个键是整个 data 通道,
  内联行只是四支里的一支)。
- `description`: 如实列出四支 provider,并写明内联行走 `{ provider: 'value', items: [...] }`;
  `staticData` 的提法改为「已弃用的**纯数组捷径**」,而不是原来的「is the same thing」
  (二者效果等价但**形状不同**,这正是本卡的病根)。
- 声明块顶部补一段 #5090 的说明,与既有的 #4041 / #4648 段同体例。

### 关于 `type` 是否应声明成 `['object', 'array']`

不。`ComponentInput.type` 的数组形(#3832)语义是「任一支接受即放行」,而其文档明确要求
**「只声明契约接受 AND 渲染器解析的支」**。数组这一支渲染器解析、契约拒绝,不满足合取;
声明它等于继续发布一个 `tsc` 与 spec 都拒绝的形状,正是 #4648 carve-out 拒绝的那一步。

## 与 #5068 / #4648 的关系

- **#5068(未动)**:`ObjectGrid.tsx:392` `getDataConfig` 的 `Array.isArray(schema.data)`
  容忍支路**一行未碰**。它继续作为后向兼容工作,原来写数组的作者不会被打断。本 PR 只是
  不再把它**当作授权面发布** —— 于是数组 `data` 获得与 `staticData` 完全相同的地位:
  被读取,不被广告。这与 #4648 carve-out 的理由是同一条。
- **#4648(本卡是其残留)**:那次裁定(option B + carve-out)把「渲染器读得到但声明面否认」
  的键补进 `GRID_QUERY_INPUTS`;`data` 补进去了,但**类型标注没跟上契约**。本 PR 收尾这一格。
  控制台 parity 门禁判的是**键**不是**支**,所以它改前改后都绿 —— 这也是这条缺陷能活到今天的原因。
- README(#5065 已重写)本来就是对的:「give it a `ViewData` with the `value` provider …
  a bare array is the deprecated `staticData` spelling」。声明面是最后一个没对齐的。
  `content/docs/**` 一行未动(#5087 / PR #5103 在飞)。

## 钉子(提取式,非化石值)

新增 `packages/plugin-grid/src/__tests__/gridDataInputContract.test.ts`,两侧都不写死:

- 声明面的支**从注册表读出**;
- 期望值**由 `ViewDataSchema` 自己的判定推导**(每个粗粒度支一个代表值,取 schema 接受的那些)。
  任一侧漂移即红:spec 若放宽 `ViewData` 接受数组,或声明面长出契约拒绝的支。
- 编译期一半用 `@ts-expect-error` 钉住「`ViewData` 没有数组支」;它由本包
  `tsconfig.test.json` 编译(#3181),`ViewData` 一旦放宽,该指令变成未使用 → tsc 红。

之所以自建钉子:**「声明的支是否匹配契约」本来就没有门禁**(#4971 已就此立卡),
现有 parity 门禁只判键名。

## 验证

- `pnpm exec vitest run packages/plugin-grid/` → **75 files / 668 tests passed**
- 控制台声明面消费方 4 个套件(parity / union-specimens / ga-honoured / binding-reach)
  → **95 passed**
- 仓根 `turbo run type-check --concurrency=2` → **81 successful, 81 total**
- `node scripts/check-control-bytes.mjs` → OK

### 反向验证(先书面预判,再跑)

| 变异 | 预判 | 实测 |
| --- | --- | --- |
| (a) 声明退回 `type: 'array'` | 新钉子 4 条红(两个 tag × 两条断言);编译期一半**保持绿**(它读契约不读声明) | 一致:`4 failed / 6 passed`,`expected [ 'array' ] to deeply equal [ 'object' ]` |
| (a') 同一变异下的保存门禁 | 方向翻转 | 一致:`{ provider: 'value', … }` → `expected an array`;裸数组 → 无诊断 |
| (b) 探针塞假 provider 名 | 推导集塌成 `[]`,比较两侧同时红 → 自证期望值真来自 schema | 一致:`expected [] to deeply equal [ 'object' ]` 与 `expected [ 'object' ] to deeply equal []` |
| (c) spec 声明的 alias(`rows` / `data` / `objectName`)是否 parse 时折叠 | **我预判会折叠**(类比 `VIEW_FILTER_OPERATOR_ALIASES` 的 "folded to canonical on parse") | **预判错**,如实记录:四个 alias 拼写全部 `safeParse` **失败**。ViewData 的 `strictObject` aliases 是**拒绝时的报错提示**机制,不是接受。结论对本 PR 有利 —— description 里教的 `items` / `object` / `schemaId` / `read` 四个 canonical 键实测全绿,教任何 alias 都会是错的 |

(c) 这条把预判写反了,按纪律照实报,不修饰成「符合预期」。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_