### PR TITLE
docs(plugin-view): 文档站页面整片示例按 ObjectView 真读的键面重写 (#5088, #5086 的 view 三分之一)

### DIFF
--- a/.changeset/plugin-view-docs-site-real-schema-keys.md
+++ b/.changeset/plugin-view-docs-site-real-schema-keys.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-view': patch
+---
+
+The plugin-view documentation-site page now teaches the keys `ObjectView`
+actually reads, so a copied example renders instead of coming up empty.
+
+`content/docs/plugins/plugin-view.mdx` carried the same fictional key surface
+the README did before it was rewritten: the object name was spelled `object`
+(the real key is `objectName`, the only required one besides `type`), the page
+was organised around a `viewMode` trichotomy that does not exist, and
+`fields` / `mode` / `recordId` / `fieldConfig` / `nestedFields` / `tabs` /
+`filters` / `searchable` / `enableDelete` went with it. None of those is a
+declared member of `ObjectViewSchema`, and none is read anywhere in
+`packages/plugin-view/src`. Because `type: 'object-view'` is genuinely
+registered, a copied example still resolved to a renderer — it just never
+received an `objectName`, and the component's data effects are all guarded on
+it, so the reader got a silent empty view rather than an error.
+
+The Schema API section and every example after it were rewritten against the
+declared surface, with each key measured against the renderer's read points
+before being written: `defaultViewType` (plus `listViews` / `defaultListView`)
+for the list type, `layout` and its drawer/modal/page record surface in place of
+the separate "form view" and "detail view" narratives, `table` and `form` for
+grid and form configuration, `operations` booleans and `onNavigate` in place of
+the `onCreate` / `onUpdate` / `onDelete` callbacks that were never part of this
+contract, and the `show*` toolbar toggles. The examples are now typed
+`ObjectViewSchema` blocks rather than untyped JSON, which makes a missing
+`objectName` a compile error in all fourteen of them — the page previously had
+no assertion at all, since `ObjectViewSchema` inherits an index signature from
+`BaseSchema` that accepts any undeclared key.
+
+Three structural facts are stated outright: `dataSource` is a required prop of
+`ObjectViewProps` and not a schema key; create, edit and read are internal
+states of one record surface rather than authored modes; and `ObjectView`
+forwards a fixed list of keys out of `table` and `form` rather than passing
+those objects through, so the page names exactly which ones — including that
+page size on this path is `table.pageSize`, not `table.pagination`.
+
+The TypeScript Support snippet's `import type { ObjectViewSchema }` also moves
+from `@object-ui/plugin-view`, which does not export it, to `@object-ui/types`,
+where it is declared. Copying the old line produced a TS2305.

--- a/content/docs/plugins/plugin-view.mdx
+++ b/content/docs/plugins/plugin-view.mdx
@@ -42,19 +42,101 @@ npm install @object-ui/plugin-view
 
 ### ObjectView
 
-```plaintext
-{
+The keys below are the ones `ObjectView` actually reads off the schema node
+(`packages/plugin-view/src/ObjectView.tsx`). The node is typed by
+`ObjectViewSchema` in `@object-ui/types` — `objectName` and `type` are its only
+required keys, and every example on this page carries the annotation, so a
+missing `objectName` fails to compile rather than rendering an empty view.
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const shape: ObjectViewSchema = {
   type: 'object-view',
-  object: string,                 // ObjectQL object name
-  viewMode?: 'grid' | 'form' | 'detail',
-  fields?: string[],              // Fields to display
-  dataSource?: DataSource,
-  onCreate?: (data) => void,
-  onUpdate?: (id, data) => void,
-  onDelete?: (id) => void,
-  className?: string
-}
+  objectName: 'users', // required — the ObjectQL object name
+  title: 'Users',
+  description: 'Everyone with an account',
+
+  // --- List surface ---
+  defaultViewType: 'grid', // grid | kanban | gallery | calendar | timeline | gantt | map
+  listViews: { all: { label: 'All Users' } }, // named views; each needs a `label`
+  defaultListView: 'all',
+  table: { columns: ['name', 'email'] }, // grid configuration (see below)
+
+  // --- Record surface (create / edit / read) ---
+  layout: 'drawer', // drawer | modal | page
+  form: { showSubmit: true }, // form configuration (see below)
+  navigation: { mode: 'drawer' }, // row-click behaviour
+  onNavigate: (recordId, mode) => {}, // required by layout/navigation 'page'
+
+  // --- Toolbar ---
+  showSearch: true,
+  showFilters: true,
+  showSort: true,
+  showCreate: true,
+  showRefresh: true,
+  showViewSwitcher: false, // default false
+  allowCreateView: false,
+
+  // --- Built-in CRUD toggles ---
+  operations: { create: true, read: true, update: true, delete: true },
+};
 ```
+
+The object name key is **`objectName`**. There is no `object`, `viewMode`,
+`fields`, `mode`, `recordId`, `fieldConfig`, `nestedFields`, `tabs`,
+`enableDelete`, `filters` or `searchable` key on this node — none of them is a
+declared member of `ObjectViewSchema`, and none is read anywhere in
+`packages/plugin-view/src`. Because `type: 'object-view'` *is* registered, a
+node built from those keys still resolves to a renderer; it just never receives
+an `objectName`, and the component's data effects are all guarded on it
+(`ObjectView.tsx:403`, `:420`), so the result is a silent empty view rather than
+an error.
+
+Three structural facts about this node:
+
+- **`dataSource` is not a schema key.** It is a **required prop** of
+  `ObjectViewProps` (`ObjectView.tsx:146`). Pass it to `<ObjectView>` directly,
+  or let the registered renderer pull it off `SchemaRendererProvider` context.
+  Putting `dataSource` inside the schema object does nothing.
+- **There is no `viewMode`, and no per-record `mode` / `recordId`.** The list
+  type is `defaultViewType` (plus `listViews` / `defaultListView`); create, edit
+  and read are internal states of one record surface, opened by the toolbar's
+  create button and by row actions and rendered as a drawer, a modal or a page
+  according to `layout`. Accordingly `ObjectViewSchema['form']` omits `mode` —
+  the component sets it.
+- **There are no `onCreate` / `onUpdate` / `onDelete` callbacks.** The component
+  performs mutations itself through the `dataSource`. What you can author is
+  `operations` (booleans that enable or disable each built-in) and
+  `onNavigate(recordId, mode)`, which hands off to your router when the record
+  surface is a page.
+
+#### `table` and `form` sub-configuration
+
+`table` carries grid configuration and `form` carries form configuration, but
+`ObjectView` forwards a **fixed set of keys** from each rather than passing the
+object through. Anything else you put in them is ignored:
+
+| Sub-config | Keys `ObjectView` forwards |
+| --- | --- |
+| `table` | `columns`, `fields`, `title`, `description`, `defaultFilters`, `defaultSort`, `pageSize`, `selectable`, `operations`, `className` |
+| `form` | `fields`, `customFields`, `sections`, `groups`, `layout`, `columns`, `title`, `description`, `subforms`, `buttons`, `defaults`, `initialValues`, `readOnly`, `showSubmit`, `submitText`, `showCancel`, `cancelText`, `showReset`, `className` |
+
+The forwarding is literal, key by key (`ObjectView.tsx:833-848` for `table`,
+`:857-890` for `form`), which is why the list is worth reading: page size is
+`table.pageSize` and **not** `table.pagination` — the latter is a declared
+`ObjectGridSchema` key, but it is not one of the keys `ObjectView` forwards, so
+on an `object-view` node it has no effect.
+
+That is one instance of a general point: several of the forwarded `table` keys
+are the ones `ObjectGridSchema` marks legacy — `fields`, `pageSize`,
+`selectable`, `defaultFilters` and `defaultSort` each have a newer counterpart
+there (`columns`, `pagination`, `selection`, `filter`, `sort`). `ObjectView`
+forwards the legacy spellings, so on an `object-view` node those are the ones
+that take effect. `columns` is the exception — it is forwarded alongside
+`fields` and preferred over it. Shapes follow `ObjectGridSchema`:
+`defaultSort` is a single `{ field, order }` object and `defaultFilters` is a
+plain record of field to value.
 
 ## Usage
 
@@ -113,196 +195,337 @@ them, and no schema types — the authored `object-view` node is typed by
 
 ## Examples
 
-### Grid View
+### Choosing the list type
 
-Display objects in a data grid:
+The list is always rendered. `defaultViewType` picks which renderer draws it,
+and `table` configures the grid:
 
-```json
-{
-  "type": "object-view",
-  "object": "users",
-  "viewMode": "grid",
-  "fields": ["name", "email", "role", "created_at"]
-}
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const userDirectory: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'users',
+  defaultViewType: 'grid',
+  table: {
+    columns: ['name', 'email', 'role', 'created_at'],
+    defaultSort: { field: 'created_at', order: 'desc' },
+  },
+};
 ```
 
-### Form View
+Non-grid types (`kanban`, `gallery`, `calendar`, `timeline`, `gantt`, `map`) are
+rendered through `SchemaRenderer`, so `@object-ui/react` and the matching plugin
+must be installed for those. On that path the field list comes from
+`table.fields` (or from the active named view's `columns`), not from
+`table.columns`.
 
-Create or edit objects with a form:
+### Configuring the record form
 
-```json
-{
-  "type": "object-view",
-  "object": "users",
-  "viewMode": "form",
-  "mode": "create",
-  "fields": ["name", "email", "role"]
-}
+Create and edit share one record surface. `layout` chooses where it opens and
+`form` configures what it contains — there is no separate "form view" node and
+no authored `mode`:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const userForm: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'users',
+  layout: 'drawer', // drawer | modal | page
+  form: {
+    fields: ['name', 'email', 'role'],
+    submitText: 'Save user',
+    showCancel: true,
+  },
+};
 ```
 
-### Detail View
+When `layout` is omitted, the surface is derived from how heavy the object is
+(`deriveRecordSurface`): a field-heavy object opens as a page, a light one as a
+drawer, and mobile always pages.
 
-Display a single object's details:
+### Opening a record
 
-```json
-{
-  "type": "object-view",
-  "object": "users",
-  "viewMode": "detail",
-  "recordId": "123",
-  "fields": ["name", "email", "role", "bio", "created_at"]
-}
+Reading a record is the same surface in its read state, reached by clicking a
+row — there is no `recordId` to author, because the click chooses the record.
+`navigation.mode` decides how it opens, and `onNavigate` is what hands a
+page-mode record off to your router:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const userDetail: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'users',
+  layout: 'page',
+  navigation: { mode: 'page' }, // none | drawer | modal | page | split | popover | new_window
+  onNavigate: (recordId, mode) => {
+    // mode is 'view' or 'edit'
+    router.push(`/users/${recordId}${mode === 'edit' ? '/edit' : ''}`);
+  },
+};
 ```
+
+Without an `onNavigate` handler, `page` mode has nowhere to send the user, so
+keep the two together. `navigation: { mode: 'none' }` (or `preventNavigation`)
+makes rows inert.
 
 ## CRUD Operations
 
+All four operations are built in and run against the `dataSource` prop. You do
+not wire handlers for them — you switch them on or off with `operations`, and
+the `show*` flags control whether the matching toolbar affordance is visible.
+
 ### Create
 
-```json
-{
-  "type": "object-view",
-  "object": "products",
-  "viewMode": "form",
-  "mode": "create"
-}
+`operations.create` enables record creation; `showCreate` shows the button. Both
+default to on, and the new-record form opens on the `layout` surface:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const productCreate: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  showCreate: true,
+  operations: { create: true },
+  layout: 'drawer',
+  form: { fields: ['name', 'price', 'category'] },
+};
 ```
+
+With `layout: 'page'`, creation calls `onNavigate('new', 'edit')` instead of
+opening a drawer, so the host route owns the form.
 
 ### Read/List
 
-```json
-{
-  "type": "object-view",
-  "object": "products",
-  "viewMode": "grid",
-  "pagination": true,
-  "searchable": true,
-  "filters": {
-    "category": "electronics"
-  }
-}
+Search, filter and sort are toolbar toggles; the column set, default filter,
+default sort and page size live in `table`:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const productList: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  defaultViewType: 'grid',
+  showSearch: true,
+  showFilters: true,
+  showSort: true,
+  table: {
+    columns: ['name', 'price', 'category'],
+    defaultFilters: { category: 'electronics' },
+    pageSize: 25,
+  },
+};
+```
+
+Saved views are `listViews`, keyed by view name, with `defaultListView`
+selecting which opens first:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const productViews: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  listViews: {
+    all: { label: 'All Products', type: 'grid', columns: ['name', 'price'] },
+    cheap: {
+      label: 'Under 100',
+      type: 'grid',
+      filter: [{ field: 'price', operator: 'lessThan', value: 100 }],
+    },
+  },
+  defaultListView: 'all',
+};
 ```
 
 ### Update
 
-```json
-{
-  "type": "object-view",
-  "object": "products",
-  "viewMode": "form",
-  "mode": "edit",
-  "recordId": "123"
-}
+Editing is reached from a row's edit action, and `operations.update` is what
+gates it. The edited record is chosen by the click, never by an authored
+`recordId`:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const productEdit: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  operations: { update: true },
+  layout: 'modal',
+  form: { fields: ['name', 'price'], submitText: 'Update' },
+};
 ```
+
+Under `layout: 'page'` this becomes `onNavigate(recordId, 'edit')`.
 
 ### Delete
 
-```json
-{
-  "type": "object-view",
-  "object": "products",
-  "viewMode": "grid",
-  "enableDelete": true
-}
+`operations.delete` enables both the per-row delete and bulk delete. There is no
+`enableDelete` key and no `onDelete` callback:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const productNoDelete: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  operations: { create: true, read: true, update: true, delete: false },
+};
 ```
 
 ## Field Configuration
 
-Customize field display and behavior:
+There is no `fieldConfig` key. Labels, types, requiredness and validation come
+from the object's own metadata, which the view reads through the `dataSource` —
+that is what makes the view "automatic". What the schema node chooses is
+**which** fields appear and how they are grouped:
 
-```json
-{
-  "type": "object-view",
-  "object": "users",
-  "viewMode": "form",
-  "fieldConfig": {
-    "name": {
-      "label": "Full Name",
-      "required": true,
-      "placeholder": "Enter name"
-    },
-    "email": {
-      "label": "Email Address",
-      "type": "email",
-      "required": true
-    },
-    "role": {
-      "label": "User Role",
-      "type": "select",
-      "options": [
-        { "label": "Admin", "value": "admin" },
-        { "label": "User", "value": "user" }
-      ]
-    }
-  }
-}
-```
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
 
-## Advanced Features
-
-### Nested Objects
-
-```json
-{
-  "type": "object-view",
-  "object": "orders",
-  "viewMode": "detail",
-  "fields": ["order_number", "customer.name", "items", "total"],
-  "nestedFields": {
-    "items": {
-      "type": "object-grid",
-      "object": "order_items",
-      "fields": ["product.name", "quantity", "price"]
-    }
-  }
-}
-```
-
-### Tabs View
-
-```json
-{
-  "type": "object-view",
-  "object": "users",
-  "viewMode": "tabs",
-  "tabs": [
-    { "label": "Details", "fields": ["name", "email", "bio"] },
-    { "label": "Settings", "fields": ["theme", "notifications", "timezone"] },
-    { "label": "Activity", "type": "object-grid", "object": "user_activities" }
-  ]
-}
-```
-
-## Integration with ObjectQL
-
-```plaintext
-import { createObjectStackAdapter } from '@object-ui/data-objectstack';
-
-const dataSource = createObjectStackAdapter({
-  baseUrl: 'https://api.example.com',
-  token: 'your-auth-token'
-});
-
-const schema = {
+const userFields: ObjectViewSchema = {
   type: 'object-view',
-  object: 'contacts',
-  viewMode: 'grid',
-  dataSource,
-  fields: ['first_name', 'last_name', 'email', 'company'],
-  searchable: true,
-  sortable: true
+  objectName: 'users',
+  table: {
+    columns: ['name', 'email', 'role'], // grid columns
+  },
+  form: {
+    fields: ['name', 'email', 'role'], // flat field list, or use sections
+    sections: [
+      { label: 'Identity', fields: ['name', 'email'] },
+      { label: 'Access', fields: ['role'] },
+    ],
+    columns: 2,
+  },
 };
 ```
 
+To override a field's rendering beyond what the object metadata says, use
+`form.customFields` (full field definitions) rather than a per-field patch on
+the view node.
+
+## Advanced Features
+
+### Child records (master-detail)
+
+There is no `nestedFields` key. A child collection is declared as a **subform**
+on the record form, which is where an order's line items belong:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const orderView: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'orders',
+  layout: 'page',
+  form: {
+    fields: ['order_number', 'customer', 'total'],
+    subforms: [
+      {
+        childObject: 'order_items',
+        title: 'Line items',
+        columns: ['product', 'quantity', 'price'],
+      },
+    ],
+  },
+};
+```
+
+Only `childObject` is required — the relationship field and the grid columns are
+derived from the child object's metadata unless you override them
+(`relationshipField`, `columns`).
+
+### View tabs
+
+There is no `tabs` key, and `form.layout` has no tabbed value
+(`vertical | horizontal | inline | grid`). The tab strip this package ships is
+the **saved-view** tab bar: declare the views and render `<ViewTabBar>` (or let
+a host such as `@object-ui/app-shell` do it):
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const userTabs: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'users',
+  showViewSwitcher: true,
+  allowCreateView: true,
+  listViews: {
+    active: { label: 'Active', type: 'grid', columns: ['name', 'email'] },
+    admins: {
+      label: 'Admins',
+      type: 'grid',
+      filter: [{ field: 'role', operator: 'equals', value: 'admin' }],
+    },
+  },
+  defaultListView: 'active',
+};
+```
+
+To group a *form's* fields instead, use `form.sections` as shown under "Field
+Configuration".
+
+## Integration with ObjectQL
+
+The adapter is the `dataSource` **prop**, not part of the schema:
+
+```typescript
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+import { ObjectView } from '@object-ui/plugin-view';
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const dataSource = createObjectStackAdapter({
+  baseUrl: 'https://api.example.com',
+  token: 'your-auth-token',
+});
+
+const contactView: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'contacts',
+  defaultViewType: 'grid',
+  showSearch: true,
+  showSort: true,
+  table: {
+    columns: ['first_name', 'last_name', 'email', 'company'],
+    pageSize: 25,
+  },
+};
+
+<ObjectView schema={contactView} dataSource={dataSource} />;
+```
+
+Rendering the same node through the registry instead (`type: 'object-view'` in a
+larger schema tree) works because `ObjectViewRenderer` reads the `dataSource`
+off `SchemaRendererProvider` context — again, not off the schema.
+
 ## TypeScript Support
 
-```plaintext
-import type { ObjectViewSchema } from '@object-ui/plugin-view';
+This package's type export surface is the component `*Props` types plus the
+record-surface and field-option types listed under "Registering a component
+under your own key" — it ships **no schema types**. The authored
+`type: 'object-view'` node is typed by `@object-ui/types`, which
+`@object-ui/plugin-view` imports without re-exporting, so import it from there:
+
+| Import from `@object-ui/types` | What it types |
+| --- | --- |
+| `ObjectViewSchema` | the whole `type: 'object-view'` node — `objectName` (required), `title`, `description`, `layout`, `defaultViewType`, `listViews`, `defaultListView`, `navigation`, `table`, `form`, `searchableFields`, `filterableFields`, the `show*` flags, `operations`, `onNavigate`, `viewTabBar`, `viewActions` |
+| `NamedListView` | one entry of `listViews` |
+| `ViewNavigationConfig` | `navigation` — row/item click behaviour |
+| `ViewTabBarConfig` | `viewTabBar` — tab-bar UX (inline add, overflow, indicators) |
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
 
 const userView: ObjectViewSchema = {
   type: 'object-view',
-  object: 'users',
-  viewMode: 'grid',
-  fields: ['name', 'email', 'role']
+  objectName: 'users',
+  defaultViewType: 'grid',
+  // Displayed columns are grid configuration, inherited from ObjectGridSchema.
+  table: { columns: ['name', 'email', 'role'] },
 };
 ```
 


### PR DESCRIPTION
Fixes #5088
Part of #5086

基线 `origin/main` @ `405d54e4d`(已含 PR #5101,即 #5077 的 README 半)。

## 前提验证(卡面逐条复测,判定全部成立)

卡面读数取自 `03e5f972a`,行号有漂移,判定不变。复测在 `405d54e4d` 上重做:

| 卡面判断 | 复测结论 |
| --- | --- |
| `object` 无此键,必填是 `objectName` | 成立。`ObjectViewSchema` 自有声明成员 25 个,必填仅 `type` + `objectName`(`packages/types/src/objectql.ts:1387` 起,`objectName` 在 `:1393`) |
| `viewMode` 无此键,视图类型是 `defaultViewType` | 成立。见下方 cast 感知复测 |
| `fields` 无此键,列走 `table.columns` | 成立。`schema.fields` 零读点;`gridSchema` 逐键白名单 `:833-848` |
| `mode`/`recordId`/`fieldConfig`/`nestedFields`/`tabs`/`enableDelete`/`filters`/`searchable` 均非声明成员 | 成立。八个键在声明成员表里一个不在,读点全数零命中 |
| `type` 值 `object-view` 本身是对的,照抄得空视图而非报错 | 成立。`packages/plugin-view/src/index.tsx:66` 注册;取数副作用守在 `objectName` 上(`ObjectView.tsx:403`、`:420`),无 throw |

**`viewMode` 用 cast 感知读取点 grep 复测**(#5077 的前车:`pagination` 曾被 `(schema as any)` 读点推翻,裸 grep 零命中不作数)。五形全测 —— 裸读 / `(schema as X).K` / 方括号字符串下标 / 解构 / spread:

- 裸 grep 零命中;邻近词反查只得到 `viewType`(`generateViewSchema` 的局部形参与 `ViewType` 类型)与 `currentViewType`(组件 state),**没有一处是 schema 键读取**。
- 解构形与 spread 形在 `packages/plugin-view/src` 全包零命中(无 `= schema` 解构、无 spread of schema)。
- 全包 `schema.K` / `(schema as X).K` 枚举后逐键定位:`fields` 的三处命中属 `SortUI` 自己的 `SortUISchema`,`filters` 的一处属 `FilterUI` 自己的 `FilterUISchema`,均非本节点。

**分页的可达性分层**(直通 #5077 席证据并复核):`table.pagination` 不在 `ObjectView` 的 `table` 转发白名单里,分页唯一转发键是 `table.pageSize`(`ObjectView.tsx:846`)。另有一处根级 `(schema as any).pagination`(`:1032`),但它在 `if (renderListView)` 分支内(`:980`)—— `renderListView` 是 `ObjectView` 的可选 prop,注册路径 `ObjectViewRenderer` 不传,故**不在本页所教的注册路径上可达**。本页因此一律教 `table.pageSize`,并写明 legacy 落差(`ObjectGridSchema` 把 `fields`/`pageSize`/`selectable`/`defaultFilters`/`defaultSort` 标记为 legacy,而 `ObjectView` 转发的正是 legacy 拼法)。#5102 的类型塌陷决策不在本 PR 预断。

## 改了什么

半径:`content/docs/plugins/plugin-view.mdx` + changeset。⛔ 未动 README(PR #5101 已修)、其它 mdx、`src`。

Schema API 节与其后每个示例按声明面重写,每个键落笔前对渲染器实测过读点,**不盲抄 README**(`table`/`form` 转发白名单、`ObjectGridSchema` 各键形状、`subforms` 形状、`NavigationConfig` 的 mode 枚举均逐条从声明与调用现场取):

- 列表类型 `defaultViewType`,加 `listViews` / `defaultListView`;
- 原「form view」/「detail view」两种叙事的真身是 `layout` 的 drawer/modal/page 单一记录面;
- 网格与表单配置落 `table` / `form`,只教白名单里真转发的键;
- 回调族真身是 `operations` 布尔开关 + `onNavigate`;工具栏用 `show*`。

示例从无标注 JSON 块改为带 `ObjectViewSchema` 标注的 typescript 块 —— 这是本页此前**没有任何断言**的原因:`ObjectViewSchema` 继承的 `BaseSchema` 带 `[key: string]: any` 索引签名,未声明键一律放行,而无标注的块连「缺必填 `objectName`」这唯一有牙的断言也不触发。

`viewActions` 只在类型表里列出、未写进代码块 —— 它的 `type` 值 `share` 会触发 `check-doc-component-types`,而豁免表在 `scripts/` 内、属半径外。

## #5086 的 view 三分之一

同块内 `import type { ObjectViewSchema }` 从 `@object-ui/plugin-view` 改指真身 `@object-ui/types`。合单理由:该 import 行就在 TypeScript Support 代码块里,与本卡键面重写同块,拆开修会互踩 —— import 改指后紧跟其下的示例字面量必须同时补 `objectName`、去掉 `viewMode`/`fields`,否则标注了 `ObjectViewSchema` 的示例自身不成立(与 PR #5103 处理 grid 三分之一时同一理由)。

证据取自**已构建**的 `dist/index.d.ts`,用 TS 编译器 API `checker.getExportsOfModule`(#5043 规格),非 grep src:`@object-ui/plugin-view` 共 **39** 个导出名,`ObjectViewSchema` **ABSENT**;`@object-ui/types` 675 个导出名,`ObjectViewSchema` / `NamedListView` / `ViewNavigationConfig` / `ViewTabBarConfig` 均 **PRESENT**。按 #5011 定调,**未**为让旧路径成立而新增 re-export。

`#5086` 至此仅余 form 处(`content/docs/plugins/plugin-form.mdx`),已在该卡留评论记录(comment 5322052371)。

## 与相邻 PR / issue 的关系

- **PR #5101(#5077,已并入基线)** —— README 半。本页是它的文档站镜像,键面口径同源、措辞不同;README 未再动一行。
- **PR #5103(#5087 + #5086 的 grid 三分之一)** —— 同族、不同文件,不相交。
- **#5102** —— `table` 子配置的类型塌陷决策箱。本 PR 只按当前实现如实描述转发白名单与 legacy 落差,不预断该决策。

## 本正文的修订记录(正文侧,不涉仓库文件)

首版在描述「自扫控制字节」时,把转义写法实体化成了**真控制字节**(三个)并存进了 PR 正文 —— 正是 #4890 / #5140 / #5157 那一族「写规则时把字节写进去」的复发形。回读存储正文时抓到,已改为纯文字描述该区段;当前存储正文该类字节为零。仓库文件侧自始未受影响:改动文件自扫零命中,`check-control-bytes` 绿。

另记一条工具面观察,供后来者少走弯路:`create_pull_request` 存下的「尾部分隔线 + Generated by 页脚」经 `update_pull_request` 改写后会被剥掉,连试四版皆然(分隔线前置形试过引用块、有序列表、普通段落,分隔线本身试过三连字符与三星号),故本版改为不带分隔线直接收尾。两类问题都是「回读存储正文」这一步抓到的 —— 未认证 curl 读 PR 正文返回 403,会给出「零控制字节」的假绿,必须走已认证端点回读。

## 验证

- `check-doc-links` / `check-control-bytes` / `check-doc-component-types` 三门全绿;改动文件另做自扫,覆盖门禁不扫的那段低位 C0 控制码(即 NUL 与制表/换行/回车以外的整个 C0 区),零命中。
- 仓根 `turbo run type-check --concurrency=2`:**81/81 successful**。
- 编译探针(对构建产物,strict):改后 14 个带标注示例全部 `rc=0`;抽掉 `objectName` 负控 **14/14 全红 TS2741**。
- 名集合双向核对(#5043 AST 形):页内所有 `@object-ui/*` 具名导入与类型表四个名字,逐一对各包已构建导出面核验,全部 OK。

### 反向验证(先书面预判,再跑)

⚠️ 三个方向里只有一个是模板预设的「还原断肢即变红」,如实记录:

| 方向 | 预判 | 实测 | 一致? |
| --- | --- | --- | --- |
| **(a)** 回填旧键 `object`/`viewMode`/`fields` | **双绿**:`BaseSchema` 索引签名令未声明键通过 excess-property 检查;门禁只读 `type` 字面量,三个旧键都不是 `type` 键 | tsc `rc=0`、门禁 `rc=0` | ✅ |
| **(b)** 塞假 `type` 值(`object-view-nonesuch`) | 门禁红 `unregistered-doc-type` + tsc 红(`type` 是字面量类型) | 门禁 `rc=1` 报 `unregistered-doc-type`;tsc 报 `TS2322`,称 `object-view-nonesuch` 不可赋给字面量类型 `object-view` | ✅ |
| **(c)** 自选:把旧**意图**写到**规范键**(`defaultViewType` 取值 `detail`) | tsc 红 `TS2322`(闭合联合无 `detail`) | `TS2322`,称 `detail` 不可赋给 grid / kanban / gallery / calendar / timeline / gantt / map 这七个成员构成的联合。部分 case 因已有该键先报 `TS1117` 重复键 —— 仍是红,但直接原因与预判不同,记录在此 | ✅(带偏差说明) |

**(a) 是本 PR 最要紧的一条,且方向与模板相反**:回填缺陷后两道自动检查**都是绿的**。这正是 #4823 第二维度的形状 —— `check-doc-component-types` 头部明确把「snippet 的其它键是否被渲染器读」列在自己范围外,而编译探针撞上 `BaseSchema` 索引签名这个结构性盲区(#5077 探针 D/H 已证)。所以**探针绿不是键面证据**;本 PR 的键面证据是「声明成员表 + 读点/白名单亲测」,探针只用来钉住「必填 `objectName` 有牙」这一条(见负控 14/14 全红)。

**(a) 与 (c) 合起来量到了本次重写的实际收益**:同一个作者错误,写在未声明的 `viewMode` 上时全程隐形(`rc=0`),写在规范键 `defaultViewType` 上即成为编译期错误。重写把一类不可检测的错误换成了可检测的。

_Generated by [Claude Code](https://claude.ai/code)_