### PR TITLE
fix(components): span renders its declared `value` key, child content winning

### DIFF
--- a/.changeset/span-reads-declared-value-key.md
+++ b/.changeset/span-reads-declared-value-key.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/components': patch
+---
+
+`span` renders the `value` its type and its published doc both declare, with child content winning when both are present.
+
+Two declared authoring surfaces named `value` the text content of a span and the
+renderer read neither: `TextSpanSchema` declares `value?: string` commented
+`Text content` (`packages/types/src/layout.ts`), and the published doc's Schema
+block lists the same key with the same comment. Before objectui#5027 the
+renderer read `body`, which no producer emits; #5027 moved it to the canonical
+`children`. Neither version ever read `value`. So an author writing
+`{ "type": "span", "value": "hello" }` — exactly what the type and the docs
+instruct — got an empty element, with no warning and no diagnostic. Same failure
+shape as #5027 (content silently dropped), one key over, and not catchable on
+the type surface: `BaseSchema` carries an index signature, so no spelling on
+this node is ever a TS error.
+
+Precedence, ruled 2026-08-17: `children` wins, `value` is the fallback. This is
+the shape the sibling type in the same family already sets — `basic/text.tsx`
+renders `schema.content || schema.value` — so `span` stops being the odd one out
+rather than growing a rule of its own. "No child content" means an absent, empty
+or empty-array `children`; that is exactly when `value` renders.
+
+Both declared faces stay as written. The fix makes them true instead of
+retracting a key that has been published as authorable. `body` remains refused
+(objectui#5027): it is declared nowhere for this type, whereas `value` is
+declared twice — the question is whether a key was published as authorable, not
+whether a tolerant read would be convenient.

--- a/content/docs/components/basic/span.mdx
+++ b/content/docs/components/basic/span.mdx
@@ -58,6 +58,8 @@ interface SpanSchema {
   // Content
   value?: string;                        // Text content
   children?: SchemaNode | SchemaNode[];  // Child components (the child key this component reads)
+  // Both keys are read. When both are authored, child content wins and `value`
+  // is ignored — the same precedence `text` uses for `content` over `value`.
   
   // Styling
   className?: string;                    // Tailwind CSS classes

--- a/packages/components/src/__tests__/span-value-fallback.test.tsx
+++ b/packages/components/src/__tests__/span-value-fallback.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `span` renderer reads the `value` key its own type and its published doc
+ * both declare (objectui#5050), with child content winning when both are there.
+ *
+ * The defect: two declared authoring surfaces named `value` the text content of
+ * a span, and the renderer read neither it nor — before objectui#5027 — any key
+ * a producer emits.
+ *
+ *   - `TextSpanSchema` (`packages/types/src/layout.ts`) declares
+ *     `value?: string`, commented `Text content`.
+ *   - the published doc `content/docs/components/basic/span.mdx` lists the same
+ *     `value?: string  // Text content` in its Schema block.
+ *
+ * So `{ type: 'span', value: 'hello' }` — written exactly as the type and the
+ * docs instruct — rendered an EMPTY element, with no warning and no diagnostic.
+ * Same failure shape as #5027 (content silently dropped), one key over.
+ *
+ * Ruled 2026-08-17: wire it. Both declared faces stay as written, and the
+ * renderer makes them true, rather than the declarations being retracted.
+ *
+ * PRECEDENCE, and why it is not a bespoke rule: `basic/text.tsx` renders
+ * `schema.content || schema.value`, so on the sibling type in the same family
+ * the richer key already wins and the scalar is already the fallback. `span`
+ * follows that, with `children` (its canonical child key, #5027) in the winning
+ * position. `body` stays refused — see `span-children-rendering.test.tsx`; it is
+ * declared nowhere for this type, whereas `value` is declared twice.
+ *
+ * What the type surface can and cannot say, same as on #5027: `BaseSchema`
+ * carries an index signature, so no spelling here is ever a TS error. The read
+ * side is the only place the contract can be stated, which is why it is pinned
+ * rather than left to review.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+import type { TextSpanSchema } from '@object-ui/types';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+describe('span reads its declared `value` key (#5050)', () => {
+  it('renders the plain `{ type: "span", value }` the card reports rendering empty', () => {
+    // The reproduction from the card, written exactly as `TextSpanSchema` and
+    // the published doc instruct. Before the fix this element was empty.
+    const schema: TextSpanSchema = {
+      type: 'span',
+      className: 'value-only',
+      value: 'hello from value',
+    };
+
+    const { container } = render(<SchemaRenderer schema={schema} />);
+
+    const span = container.querySelector('span.value-only');
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toBe('hello from value');
+  });
+
+  it('lets child content win when both `children` and `value` are authored', () => {
+    // The precedence half of the ruling. `text`'s `content || value` is the
+    // family precedent: the richer key renders, the scalar does not — and the
+    // scalar must not be appended either, which is what the second assertion
+    // rules out (a `+` instead of a `||` would keep the first one green).
+    const schema: TextSpanSchema = {
+      type: 'span',
+      className: 'both-keys',
+      value: 'value must not render',
+      children: [{ type: 'text', value: 'children win' }],
+    };
+
+    const { container } = render(<SchemaRenderer schema={schema} />);
+
+    const span = container.querySelector('span.both-keys');
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toBe('children win');
+    expect(container.textContent).not.toContain('value must not render');
+  });
+
+  it('lets a single (non-array) child node win over `value` too', () => {
+    // `children` is declared `SchemaNode | SchemaNode[]`, and the two arms take
+    // different branches inside `renderChildren`. Precedence is a property of
+    // the contract, not of which arm the author happened to write.
+    const schema: TextSpanSchema = {
+      type: 'span',
+      className: 'single-child-wins',
+      value: 'value must not render',
+      children: { type: 'text', value: 'lone child wins' },
+    };
+
+    const { container } = render(<SchemaRenderer schema={schema} />);
+
+    expect(container.querySelector('span.single-child-wins')?.textContent).toBe('lone child wins');
+    expect(container.textContent).not.toContain('value must not render');
+  });
+
+  it('falls back to `value` when `children` is present but carries no content', () => {
+    // An empty array is authored content-free, so it is the fallback case, not
+    // the precedence case: `renderChildren` returns null for it and `value` is
+    // what the author still has on the node. Pinned because the empty array is
+    // truthy in JS — the one input where "has a children key" and "has child
+    // content" come apart.
+    const schema: TextSpanSchema = {
+      type: 'span',
+      className: 'empty-children',
+      value: 'fallback rendered',
+      children: [],
+    };
+
+    const { container } = render(<SchemaRenderer schema={schema} />);
+
+    expect(container.querySelector('span.empty-children')?.textContent).toBe('fallback rendered');
+  });
+
+  it('renders an empty element when neither key is authored — no crash, no placeholder', () => {
+    // The negative control. Wiring a fallback must not invent content for a
+    // node that declares none; this is also what keeps the `body`-refusal pin
+    // in span-children-rendering.test.tsx meaningful.
+    const { container } = render(
+      <SchemaRenderer schema={{ type: 'span', className: 'no-content' } as TextSpanSchema} />,
+    );
+
+    const span = container.querySelector('span.no-content');
+    expect(span).toBeTruthy();
+    expect(span?.textContent).toBe('');
+  });
+});

--- a/packages/components/src/renderers/basic/span.tsx
+++ b/packages/components/src/renderers/basic/span.tsx
@@ -117,8 +117,30 @@ const SpanRenderer = forwardRef<HTMLSpanElement, { schema: TextSpanSchema; class
         one type whose declaration never named it (Commandment #0.1), and the
         sweep for this issue found nothing in the repo authoring it on this tag.
         `__tests__/span-children-rendering.test.tsx` pins both halves.
+
+        `value` IS read, as the fallback (objectui#5050). It is not an alias
+        anybody invented on the read side: `TextSpanSchema` declares it
+        (`packages/types/src/layout.ts`) and the published doc's Schema block
+        lists it, both calling it the text content — and the renderer read
+        neither `value` nor, before #5027, any key a producer emits. So an
+        author following the type or the docs got the same empty element the
+        html tier got, one key over. Ruled 2026-08-17: wire it, rather than
+        retract two declared surfaces that have been published as true.
+
+        PRECEDENCE — child content wins. This is the family shape `text`
+        already sets one file over (`schema.content || schema.value` in
+        `basic/text.tsx`), not a rule invented for this type: the richer key
+        wins and the scalar is what you fall back to. `renderChildren` returns
+        `null` for an absent, empty-string or empty-array `children`, so "no
+        child content" is exactly when `value` renders.
+
+        Note the asymmetry with the `body` paragraph above, since both
+        paragraphs are about a key this renderer did not use to read: `body` is
+        declared NOWHERE for this type and refused; `value` is declared TWICE
+        for it and honored. The question is never "is a tolerant read
+        convenient" but "did we publish this key as authorable".
       */}
-      {renderChildren(schema.children)}
+      {renderChildren(schema.children) || schema.value}
     </span>
   );
   }


### PR DESCRIPTION
Fixes #5050

`span` now renders the `value` key that both of its declared authoring surfaces
name, with child content winning when both are present.

## The defect

Two declared surfaces called `value` the text content of a span, and the
renderer read neither it nor — before #5027 — any key a producer emits:

- `packages/types/src/layout.ts` — `TextSpanSchema` declares `value?: string`,
  commented `Text content`.
- `content/docs/components/basic/span.mdx` — the published Schema block lists
  the same `value?: string  // Text content`.

#5027 moved the read from the nonexistent `body` to the canonical `children`;
`value` was unread on both sides of that change. So an author writing
`{ "type": "span", "value": "hello" }` — exactly what the type and the docs
instruct — got an empty element, silently. Not catchable on the type surface
either: `BaseSchema` carries an index signature, so no spelling on this node is
ever a TS error, which is why the contract is stated on the read side and pinned.

## The fix

Ruled 2026-08-17: wire it, rather than retract two published declarations.
One line in `packages/components/src/renderers/basic/span.tsx`:

```tsx
{renderChildren(schema.children) || schema.value}
```

Precedence is the family shape `basic/text.tsx` already sets one file over
(`schema.content || schema.value`) — the richer key wins, the scalar is the
fallback — so `span` stops being the odd one out instead of growing a bespoke
rule. `renderChildren` returns `null` for an absent, empty-string or empty-array
`children`, so "no child content" is exactly when `value` renders.

Both declared faces stay as written. The docs block gains only a precedence note
next to the two keys it already lists; nothing is retracted.

## Premise correction — there is no `body` compat path to preserve

The card and the ruling both mention "the `body` compat path from #5027". Read
against `origin/main`, that path does not exist: #5027 deliberately refused
`body` as a second spelling and pinned the refusal
(`span-children-rendering.test.tsx`, "does not accept a `body` alias"). Nothing
here reopens it — the refusal pin is untouched and still green. The asymmetry is
the point and is written into the renderer comment: `body` is declared nowhere
for this type and stays refused; `value` is declared twice and is honored. The
question is whether a key was published as authorable, never whether a tolerant
read would be convenient.

## Sibling sweep — reported, not fixed

Swept `packages/types/src/**` for the same shape (a declared `value` that no
renderer reads). Only two types declare `value` as text content: `TextSpanSchema`
(this card) and `TextSchema`, where `basic/text.tsx` does read it. The other
`value` declarations (`TabsSchema`, the three form types) are controlled-input
values with different semantics and are read by their renderers. No sibling
inline element has this gap, so nothing new was filed.

The inverse asymmetry on the same family — `TextSchema` not declaring the
`content` key the renderer actually prefers — is already recorded in this card's
body and is a sample of the class card #4631 (`pm:on-hold`). No duplicate filed.

## Tests

New pins in `packages/components/src/__tests__/span-value-fallback.test.tsx`:

1. the plain `{ type: 'span', value }` case the card reports rendering empty;
2. precedence — both keys authored, child content renders and `value` does not
   (asserted on exact text, so an append instead of a fallback also goes red);
3. precedence for a single non-array child node, the other `children` arm;
4. fallback when `children` is authored but empty — the one input where "has a
   children key" and "has child content" come apart;
5. negative control — neither key authored renders an empty element, no crash
   and no invented placeholder.

### Reverse verification (two legs, prediction recorded before the run)

Both legs were run from the committed state; the file was restored with
`git checkout` and confirmed byte-identical to HEAD afterwards.

| Ablation | Predicted red | Observed |
| --- | --- | --- |
| Delete the fallback (`renderChildren(schema.children)`) | pins 1 and 4 | exactly those; 2 failed / 7 passed |
| Invert precedence (`schema.value || renderChildren(...)`) | pins 2 and 3 | exactly those; 2 failed / 7 passed |

The second leg is the one worth having: under leg A the precedence pins stay
green by construction, so only an inversion proves they can fail at all.

### Gates run, all at `fbb2973` (the head commit of this PR)

- `pnpm exec vitest run packages/components/` — 156 files, 1433 tests passed.
- `pnpm --filter @object-ui/components type-check` — clean (after
  `pnpm --filter '@object-ui/components^...' build`, which a fresh worktree
  needs; without it `tsc` reports missing workspace `.d.ts` files).
- `pnpm --filter @object-ui/components lint` — 0 errors. The 2 warnings on
  `span.tsx` are pre-existing, on the untouched `forwardRef` declaration; the
  new test file is clean.
- `pnpm run check:doc-types` — green (the docs Schema block changed).
- `pnpm run check:control-bytes` — green.

Changeset: `.changeset/span-reads-declared-value-key.md` (`@object-ui/components`
patch) — user-visible renderer behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_