### PR TITLE
fix(plugin-detail): RelatedList 对象列在交给表格前写回解析出的 accessorKey (#5022)

### DIFF
--- a/.changeset/quiet-donkeys-shout.md
+++ b/.changeset/quiet-donkeys-shout.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+修复相关列表(`RelatedList`)以 spec 规范拼写 `field` 声明的对象列只出表头、单元格全空的问题(objectui#5022)。
+
+`RelatedList` 的所有身份读点都经由 `columnIdentity` 规范优先解析,因此
+`{ field: 'status', label: 'Status' }` 能通过 FLS 过滤、外键过滤、空列裁剪与排序判定;而它喂给的
+`data-table` 只按 `col.accessorKey || col.name` 归一化访问键,从不读 `field`,于是每个单元格取的是
+`row[undefined]`,渲染成空值占位符 —— 与 objectui#3951 同形,只差一种拼写。
+
+现在 `normalizeColumn` 在把对象列交给表格前,把解析出的身份写回 `accessorKey`:
+词表解析留在 `RelatedList` 一侧,不并入表格适配器(`column-identity.ts` 有意画下的
+`TABLE_ADAPTER_COLUMN_KEY` 边界)。作者已显式声明的 `accessorKey` 不被覆盖,原有拼写一并保留,
+无法解析出身份的条目原样返回。legacy `name` 拼写、字符串列与显式 `accessorKey` 列行为不变。
+
+同一处身份现在同时供给单元格取数与表头排序 —— 此前 `field` 列的表头排序派发的是
+`undefined` 字段(被 `RelatedList` 丢弃),该列在取数与排序两个方向上同时失效。

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -927,15 +927,48 @@ export const RelatedList: React.FC<RelatedListProps> = ({
      // would see raw values (e.g. `planned`, unformatted numbers).
      const normalizeColumn = (c: any): any => {
        if (typeof c !== 'string') {
-         // Object column: attach a cell renderer when it lacks one and we can
-         // resolve the field def — preserves any author-supplied cell/render.
+         // Object column: resolve the identity ONCE, then hand the table an
+         // entry that already speaks the table's own vocabulary.
+         //
+         // Every read in this file resolves identity canonical-first through
+         // the shared `columnIdentity` reader (objectui#3104), so
+         // `{ field: 'status' }` passes
+         // the FLS filter, the FK filter, `pruneEmpty` and the sort row. The
+         // data-table it feeds does NOT: it normalizes its accessor as
+         // `accessorKey: col.accessorKey || col.name` and never looks at
+         // `field`. An entry authored in the spec-canonical spelling therefore
+         // used to survive every metadata-aware filter and then render a header
+         // over `row[undefined]` — blank cells, no warning (objectui#5022; the
+         // objectui#3951 shape, one spelling over).
+         //
+         // The stamp goes HERE rather than in the table's normalization
+         // because `accessorKey` is the table LIBRARY's key, not metadata:
+         // `column-identity.ts` names it `TABLE_ADAPTER_COLUMN_KEY` and keeps
+         // the canonicalizing fold away from it on purpose. Resolving the
+         // metadata vocabulary inside the adapter would merge the two
+         // vocabularies in the one place that module says must stay separate;
+         // translating at the boundary keeps the adapter monolingual.
+         //
+         // Mirror, don't move: the authored spelling is left in place (a host
+         // reading `field`/`name` off these columns keeps working), and an
+         // author-supplied `accessorKey` is never overwritten — a deliberate
+         // divergence between the table slot and the metadata key belongs to
+         // the author. An entry with no resolvable identity is returned
+         // untouched, so nothing is invented for it.
          const key = c?.accessorKey || columnIdentity(c);
-         if (c && !c.cell && !c.render && key) {
+         if (!c || !key) return c;
+         const patch: Record<string, unknown> = {};
+         if (!c.accessorKey) patch.accessorKey = key;
+         // Attach a cell renderer when it lacks one and we can resolve the
+         // field def — preserves any author-supplied cell/render.
+         if (!c.cell && !c.render) {
            const def = (objectSchema?.fields as any)?.[key];
            const cell = def ? makeCell(String(key), def) : undefined;
-           if (cell) return { ...c, cell };
+           if (cell) patch.cell = cell;
          }
-         return c;
+         // Nothing to add: return the INPUT entry by reference, so the
+         // downstream `useMemo`s keep a stable dependency on the common path.
+         return Object.keys(patch).length > 0 ? { ...c, ...patch } : c;
        }
        const fieldDef = objectSchema?.fields?.[c] as any;
        const header = fieldDef?.label || resolveFieldLabel(relatedObjectName, c, fieldDef) || c;

--- a/packages/plugin-detail/src/__tests__/RelatedList.columnIdentityAccessor.schema.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.columnIdentityAccessor.schema.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5022, the boundary half — WHERE the column identity is resolved.
+ *
+ * `column-identity.ts` draws a deliberate line at `TABLE_ADAPTER_COLUMN_KEY`:
+ * `accessorKey` names a slot in the table LIBRARY's column model, not a field
+ * in ObjectStack metadata, and the canonicalizing fold "neither reads nor
+ * writes it". So the fix for the blank-cell defect belongs on RelatedList's
+ * side of that line — `normalizeColumn` speaks the adapter's vocabulary to the
+ * adapter — and not inside `data-table`'s accessor normalization, which would
+ * merge the two vocabularies in the one place the module says it must not.
+ *
+ * These pins assert exactly that: the column objects handed to the table
+ * already carry `accessorKey`, and an author-supplied one is never rewritten.
+ * The rendered-cell half lives in `RelatedList.columnIdentityAccessor.test.tsx`
+ * — this file mocks `SchemaRenderer`, so it cannot see real cells.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { RelatedList } from '../RelatedList';
+
+// Capture the schema RelatedList hands to SchemaRenderer (the data-table) —
+// the same lever `RelatedList.headerSort.test.tsx` uses.
+const h = vi.hoisted(() => ({ schema: null as any }));
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    SchemaRenderer: (props: any) => {
+      h.schema = props.schema;
+      return null;
+    },
+  };
+});
+
+const fields = {
+  subject: { type: 'text', label: 'Subject' },
+  status: { type: 'text', label: 'Status' },
+};
+
+const rows = [
+  { id: 't1', subject: 'Fix the pump', status: 'planned' },
+  { id: 't2', subject: 'Replace filter', status: 'running' },
+];
+
+const makeDS = () => ({
+  find: vi.fn(async () => rows),
+  getObjectSchema: vi.fn(async () => ({ name: 'task', fields })),
+});
+
+function renderList(columns: any[]) {
+  h.schema = null;
+  return render(
+    <RelatedList
+      title="Tasks"
+      type="table"
+      api="task"
+      objectName="task"
+      columns={columns}
+      data={rows}
+      dataSource={makeDS() as any}
+    />,
+  );
+}
+
+const firstColumn = async () => {
+  await waitFor(() => expect(h.schema?.columns?.length).toBe(1));
+  return h.schema.columns[0];
+};
+
+describe('objectui#5022 — the identity is resolved before the table adapter, not inside it', () => {
+  it('stamps the resolved identity onto `accessorKey` for a `field` entry', async () => {
+    renderList([{ field: 'status', label: 'Status' }]);
+    const col = await firstColumn();
+
+    expect(col.accessorKey).toBe('status');
+    // The authored spelling survives — the stamp mirrors, it does not move.
+    expect(col.field).toBe('status');
+  });
+
+  it('stamps the resolved identity onto `accessorKey` for a legacy `name` entry', async () => {
+    renderList([{ name: 'status', label: 'Status' }]);
+    const col = await firstColumn();
+
+    expect(col.accessorKey).toBe('status');
+    expect(col.name).toBe('status');
+  });
+
+  it('does not overwrite an author-supplied `accessorKey`', async () => {
+    // A deliberate divergence — the table column reads one slot while the
+    // metadata names another — belongs to the author, not to this resolver.
+    renderList([{ accessorKey: 'status', field: 'subject', header: 'Status' }]);
+    const col = await firstColumn();
+
+    expect(col.accessorKey).toBe('status');
+    expect(col.field).toBe('subject');
+  });
+
+  it('leaves an entry with no resolvable identity untouched', async () => {
+    // `columnIdentity` returns undefined rather than '' precisely so callers
+    // can tell "no identity" apart from an empty one; nothing is invented here.
+    renderList([{ label: 'Nothing' }]);
+    const col = await firstColumn();
+
+    expect(col.accessorKey).toBeUndefined();
+  });
+
+  it('gives the cells the same identity the sort already used', async () => {
+    // The card's asymmetry: the sort path resolved `status` through
+    // `columnIdentity` and sorted correctly while the cells read
+    // `row[undefined]`. One identity now feeds both.
+    renderList([{ field: 'status', label: 'Status' }]);
+    const col = await firstColumn();
+
+    expect(col.accessorKey).toBe('status');
+    expect(typeof h.schema.onSortChange).toBe('function');
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RelatedList.columnIdentityAccessor.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.columnIdentityAccessor.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5022 — a related-list column object keyed with the spec-canonical
+ * `field` spelling must reach the screen with VALUES, not just a header.
+ *
+ * The seam this pins: `RelatedList` resolves column identity through
+ * `columnIdentity()` (canonical-first on `field`, objectui#3104), so
+ * `{ field: 'status', label: 'Status' }` passes the FLS filter, the FK filter,
+ * `pruneEmpty`, the sort-button row, and even collects a type-aware `cell`.
+ * The `data-table` it feeds then normalizes the accessor as
+ * `accessorKey: col.accessorKey || col.name` — it never reads `field` — so
+ * every cell read `row[undefined]` and rendered the empty placeholder: the
+ * objectui#3951 blank-cell shape, one spelling over.
+ *
+ * These pins render the REAL `data-table` and read the REAL cells, because the
+ * defect was invisible to every schema-level assertion — the column object
+ * looked complete at every RelatedList read site. The boundary half (the
+ * identity is resolved before the adapter, not inside it) is pinned in
+ * `RelatedList.columnIdentityAccessor.schema.test.tsx`, which has to mock
+ * `SchemaRenderer` and therefore cannot live in this file.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { RelatedList } from '../RelatedList';
+
+// `status` is a `select` on purpose: its cell renderer resolves the stored
+// value to the option LABEL, so a cell reading the right field says "Planned"
+// while a cell reading `row[undefined]` falls into `makeCell`'s null branch and
+// says "—". That makes the two outcomes textually distinguishable — with a
+// plain `text` column both a broken accessor and an empty value render as the
+// empty string, and the pin could not tell them apart.
+const fields = {
+  subject: { type: 'text', label: 'Subject' },
+  status: {
+    type: 'select',
+    label: 'Status',
+    options: [
+      { value: 'planned', label: 'Planned' },
+      { value: 'running', label: 'Running' },
+    ],
+  },
+};
+
+const rows = [
+  { id: 't1', subject: 'Fix the pump', status: 'planned' },
+  { id: 't2', subject: 'Replace filter', status: 'running' },
+];
+
+const makeDS = () => ({
+  find: vi.fn(async () => rows),
+  getObjectSchema: vi.fn(async () => ({ name: 'task', fields })),
+});
+
+/** Render a `table` related list over the given rows with the given columns. */
+function renderList(columns: any[], data: any[] = rows) {
+  return render(
+    <RelatedList
+      title="Tasks"
+      type="table"
+      api="task"
+      objectName="task"
+      columns={columns}
+      data={data}
+      dataSource={makeDS() as any}
+    />,
+  );
+}
+
+/**
+ * The placeholder `makeCell` renders for a null/undefined value. Its presence
+ * in a column whose rows all HAVE values is the defect's fingerprint.
+ */
+const EM_DASH = '—';
+
+/** Every rendered body cell's text, in DOM order. */
+const cellTexts = () =>
+  screen.getAllByRole('cell').map((c) => (c.textContent || '').trim());
+
+describe('objectui#5022 — RelatedList object columns render cells for every identity spelling', () => {
+  it('renders real cell values for the spec-canonical `field` spelling', async () => {
+    renderList([{ field: 'status', label: 'Status' }]);
+
+    // The header always rendered — that is what made the defect silent.
+    await waitFor(() => expect(screen.getByText('Status')).toBeInTheDocument());
+
+    // The cells are what was blank: both rows' values, no placeholder.
+    // Waited on, not sampled — the option labels only appear once the object
+    // schema resolves and `makeCell` attaches the select renderer.
+    await waitFor(() =>
+      expect(cellTexts()).toEqual(expect.arrayContaining(['Planned', 'Running'])),
+    );
+    expect(screen.queryAllByText(EM_DASH)).toHaveLength(0);
+  });
+
+  it('keeps the legacy `name` spelling working end to end', async () => {
+    // `column-identity.ts` documents `name` as objectui-side legacy for list
+    // surfaces; it is the ONE object spelling that worked before this fix, and
+    // must not be traded away for the canonical one.
+    renderList([{ name: 'status', label: 'Status' }]);
+
+    await waitFor(() => expect(screen.getByText('Status')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(cellTexts()).toEqual(expect.arrayContaining(['Planned', 'Running'])),
+    );
+    expect(screen.queryAllByText(EM_DASH)).toHaveLength(0);
+  });
+
+  it('leaves an explicit `accessorKey` entry rendering as before', async () => {
+    // The table's own vocabulary, authored directly: the resolver must not
+    // second-guess it.
+    renderList([{ accessorKey: 'status', header: 'Status' }]);
+
+    await waitFor(() => expect(screen.getByText('Status')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(cellTexts()).toEqual(expect.arrayContaining(['Planned', 'Running'])),
+    );
+    expect(screen.queryAllByText(EM_DASH)).toHaveLength(0);
+  });
+
+  it('keeps bare-string entries hydrating as before', async () => {
+    renderList(['status']);
+
+    // The string path resolves the header from the object schema's field label.
+    await waitFor(() => expect(screen.getByText('Status')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(cellTexts()).toEqual(expect.arrayContaining(['Planned', 'Running'])),
+    );
+    expect(screen.queryAllByText(EM_DASH)).toHaveLength(0);
+  });
+
+  it('renders a mixed-spelling column set without blanking either column', async () => {
+    renderList([
+      { field: 'subject', label: 'Subject' },
+      { name: 'status', label: 'Status' },
+    ]);
+
+    await waitFor(() => expect(screen.getByText('Subject')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(cellTexts()).toEqual(
+        expect.arrayContaining(['Fix the pump', 'Planned', 'Replace filter', 'Running']),
+      ),
+    );
+    expect(screen.queryAllByText(EM_DASH)).toHaveLength(0);
+  });
+
+  it('makes a header sort order by the field the cells display', async () => {
+    // One identity has to feed BOTH halves. On a `table` list the sort control
+    // is the column header, and the table resolves what it sorts by from
+    // `col.accessorKey` — the same slot the cells read. So an unstamped `field`
+    // column did not merely render blank: its header sort dispatched an
+    // undefined field, which `RelatedList` drops (`!sortField` → unsorted), and
+    // the column was inert in both directions at once.
+    renderList([{ field: 'status', label: 'Status' }], [rows[1], rows[0]]);
+
+    await waitFor(() =>
+      expect(cellTexts()).toEqual(expect.arrayContaining(['Planned', 'Running'])),
+    );
+    // As supplied: Running first.
+    expect(cellTexts()[0]).toBe('Running');
+
+    fireEvent.click(screen.getByText('Status'));
+
+    // Ascending by the stored value (`planned` < `running`) — the field the
+    // cells are showing, not `undefined`.
+    await waitFor(() => expect(cellTexts()[0]).toBe('Planned'));
+  });
+});


### PR DESCRIPTION
Fixes #5022

## 问题

以 spec 规范拼写声明的相关列表对象列 —— `{ field: 'status', label: 'Status' }` —— 只渲染表头,单元格全空。

`RelatedList` 的每个身份读点都经 `columnIdentity` 规范优先解析(objectui#3104 的 22 点收敛),该条目因此通过 FLS 过滤、外键过滤、`pruneEmpty` 与排序判定,还拿到了类型感知的 `cell`;而它喂给的 `data-table` 只按 `col.accessorKey || col.name` 归一化访问键(`packages/components/src/renderers/complex/data-table.tsx:777`),从不读 `field`。访问键解析成 `undefined`,每格取 `row[undefined]`,落进 `makeCell` 的空值分支渲染成占位符 —— 与 objectui#3951 同形,只差一种拼写。

## 方向 2:词表解析不进 table 适配器

修复放在 `RelatedList.normalizeColumn`:对象列在交给表格前,把解析出的身份写回 `accessorKey`。

刻意**不**把 `columnIdentity` 折进 `data-table.tsx`(卡面的方向 1)。`accessorKey` 是表格库(TanStack)的列键,不是 ObjectStack 的元数据身份 —— `packages/core/src/utils/column-identity.ts` 把它命名为 `TABLE_ADAPTER_COLUMN_KEY`,并明确写下该模块「既不读也不写」它:

> `accessorKey` is TanStack Table's own column key … Reads like `RelatedList`'s `accessorKey || field || name` therefore merge two different vocabularies in one expression; canonicalizing across that boundary would fossilize the merge.

把元数据词表的解析搬进适配器,正是这句话要防的合并。在边界上翻译一次,适配器保持单一词表。

镜像而非搬移:

- 作者已显式声明的 `accessorKey` **不覆盖**(表格槽位与元数据键的有意分歧属于作者);
- 原拼写(`field` / `name`)一并保留,宿主若从这些列上回读仍然成立;
- 解析不出身份的条目原样返回,不凭空发明键;
- 无补丁可加时按引用返回原条目,下游 `useMemo` 依赖保持稳定。

## 卡面之外实测到的一条

卡面说「sort 按钮却能按 `status` 排序」—— 那是 `list` 型的按钮行路径(它自己用 `accessorKey || columnIdentity` 解析)。`table` 型的排序控件是表头,而表格按 `col.accessorKey` 决定排序字段:`field` 列的表头点击派发的是 `undefined`,`RelatedList.handleTableSort` 收下后 `sortField` 为空,`sortedData` 直接返回未排序数据。也就是说该列在**取数与排序两个方向上同时失效**,不止是格子空。修复后同一处身份同时供给两者,已入钉。

## 邻仓状态

objectstack#9227(spec 侧把 `Field.relatedListColumns` 收窄为字符串)已由 PR 9355 合并关闭,本仓无文件重叠。因此本卡剩下的对象条目生产面是:宿主直接传给 `RelatedList` 组件的 `columns`(公开 prop 声明为 `any[]`,且本文件所有读点把 `field` 当一等公民)。

一处如实更正:卡面把 `record:related_list.columns` 也列为活缝,但 spec 里该键声明为 `z.array(z.string())`(`@objectstack/spec/ui`),spec-valid 的页面 schema 只会传字符串 —— 字符串路径本就正常。页面 schema 的对象条目属未声明输入,渲染器不校验因而仍会流经此处。

## 测试

新增两个钉子文件:

- `RelatedList.columnIdentityAccessor.test.tsx` —— 渲染**真实** `data-table`、读**真实**单元格。`status` 特意用 `select` 类型:取到正确字段时渲染选项标签(`Planned`),取到 `row[undefined]` 时落进占位符,两种结局在文本上可区分(纯 `text` 列两者都渲染成空串,钉不住)。覆盖 `field` / legacy `name` / 显式 `accessorKey` / 字符串 / 混合拼写 / 表头排序同源。
- `RelatedList.columnIdentityAccessor.schema.test.tsx` —— 适配器边界断言:交给表格的列已带 `accessorKey`,作者声明的不被覆盖,无身份条目原样。

反向验证读数随后以评论附上。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_