### PR TITLE
fix(react): evaluate expressions under a node's `properties`, not just `props` (#4799)

### DIFF
--- a/.changeset/lucky-donkeys-grin.md
+++ b/.changeset/lucky-donkeys-grin.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/react": patch
+---
+
+Evaluate expressions written under a node's `properties`, not just under `props`
+
+`properties` is the spec spelling of a node's config bag and `props` is the
+legacy alias, but `SchemaRenderer`'s evaluation memo only ran the expression
+evaluator over `props`. Renderers in the `element:*` namespace read
+`schema.properties` first, so a node written the canonical way handed the
+renderer the raw `${…}` source and rendered it verbatim, while the same node
+written with the alias evaluated correctly — writing the spec-compliant form
+was the way to lose your expressions.
+
+`schema.properties` values are now evaluated per value, exactly as `props`
+already was, and the evaluation runs before the existing
+`properties`-to-top-level hoist so a key means the same thing whether it is read
+as `schema.properties.x`, as `schema.x`, or as the spread `x` React prop.
+Evaluation stays shallow on both spellings (nested objects and arrays are passed
+through, not walked), and `properties` keeps its precedence over `props`.

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -338,6 +338,51 @@ export const SchemaRenderer: ForwardRefExoticComponent<
     // Shallow copy
     const newSchema = { ...schema };
 
+    // Evaluate 'properties' — the SPEC spelling of a node's config bag, of
+    // which `props` (evaluated below) is the legacy alias.
+    //
+    // objectui#4799: only `props` used to be evaluated here. Renderers in the
+    // `element:*` namespace read their config out of `schema.properties` FIRST
+    // (`readProps()` merges `{ ...schema.props, ...schema.properties }`), so a
+    // node written the canonical way handed the renderer the RAW `${…}` source
+    // and put it on screen verbatim, while the same node written with the
+    // "legacy alias" evaluated correctly. Measured through a real render with
+    // `dataSource: { total: 99 }`: `props: { content: '${data.total}' }` → `99`,
+    // `properties: { content: '${data.total}' }` → `${data.total}`. That is the
+    // inverse of contract-first (AGENTS.md #0.1) — the tolerant spelling was
+    // fed and the canonical one starved — so the fix belongs HERE, at the one
+    // producer of evaluated schema, not as a second read in each consumer.
+    //
+    // Order matters: this runs BEFORE the hoist block below, because that block
+    // copies every `properties.*` value onto the node's top level (and those
+    // copies are spread as React props at render). Evaluating first is what
+    // makes one key mean one thing whether it is read as `schema.properties.x`,
+    // as `schema.x`, or as the `x` prop. It also leaves the `content` leg below
+    // idempotent: a value evaluated here no longer carries a `${…}`.
+    //
+    // Per-value and SHALLOW, matching the `props` branch exactly:
+    // `evaluator.evaluate` returns every non-string untouched, so a nested
+    // object/array value is passed through rather than walked (measured: an
+    // `aria: { label: '${data.total}' }` nested under EITHER key renders the raw
+    // source today). Deepening that is a separate decision and would have to be
+    // taken for both spellings at once — not smuggled in on one side here.
+    //
+    // The guard is wider than the `props` branch's bare truthiness on purpose:
+    // this value FEEDS the hoist, so re-shaping a degenerate `properties`
+    // (a string, an array) via the object spread would propagate. Non-objects
+    // skip evaluation and reach the hoist exactly as they do today.
+    if (
+      newSchema.properties &&
+      typeof newSchema.properties === 'object' &&
+      !Array.isArray(newSchema.properties)
+    ) {
+      const newProperties: Record<string, any> = { ...newSchema.properties };
+      for (const [key, val] of Object.entries(newProperties)) {
+        newProperties[key] = evaluator.evaluate(val as any);
+      }
+      newSchema.properties = newProperties;
+    }
+
     // COMPAT: Hoist 'properties' up to schema level
     // This allows support for strict configs that wrap all props in 'properties'.
     // IMPORTANT: never let inner `properties.type` / `properties.id` shadow the

--- a/packages/react/src/__tests__/SchemaRenderer.propertiesExpressions.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.propertiesExpressions.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4799 — `properties` is the SPEC spelling of a node's config bag and
+ * `props` is the legacy alias, but only `props` used to be evaluated in the
+ * SchemaRenderer memo. Renderers in the `element:*` namespace read
+ * `schema.properties` FIRST, so writing the canonical spelling put the raw
+ * `${…}` source on screen while the alias evaluated — the inverse of
+ * contract-first (AGENTS.md #0.1).
+ *
+ * The stand-in below reproduces `readProps()` from
+ * `packages/components/src/renderers/basic/elements.tsx` verbatim
+ * (`{ ...schema.props, ...schema.properties }`) — that merge, not the specific
+ * element renderer, is what makes the defect visible. The real `element:text`
+ * end-to-end reading is recorded in the PR; it cannot be pinned from this
+ * package, which by design does not depend on `@object-ui/components`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+import { SchemaRendererContext } from '../context/SchemaRendererContext';
+
+const DATA = { total: 99, label: 'Widgets' };
+
+/** Mirrors `readProps()` in `@object-ui/components` — `properties` wins. */
+function readProps(schema: any): Record<string, any> {
+  return { ...(schema?.props ?? {}), ...(schema?.properties ?? {}) };
+}
+
+/**
+ * Last `schema` / React props an element render received, for structural pins.
+ * Recorded from an effect, not during render: a render-phase write to a
+ * module-scope binding is an impurity (`react-hooks/globals`), and RTL's
+ * `render()` flushes effects inside `act()`, so this is settled by the time any
+ * assertion below reads it.
+ */
+const seen: { schema: any; props: any } = { schema: undefined, props: undefined };
+
+const ElementProbe = ({ schema, ...props }: any) => {
+  React.useEffect(() => {
+    seen.schema = schema;
+    seen.props = props;
+  });
+  const merged = readProps(schema);
+  return (
+    <p data-testid="element" data-variant={merged.variant}>
+      {String(merged.content)}
+    </p>
+  );
+};
+
+/** A plain (non-`element:*`) component: reads only what it is spread. */
+const PlainProbe = (props: any) => (
+  <div data-testid="plain">{String(props.content)}</div>
+);
+
+const renderWithData = (schema: any) =>
+  render(
+    <SchemaRendererContext.Provider value={{ dataSource: DATA } as any}>
+      <SchemaRenderer schema={schema} />
+    </SchemaRendererContext.Provider>
+  );
+
+describe('SchemaRenderer — expression evaluation of `properties` (objectui#4799)', () => {
+  beforeEach(() => {
+    seen.schema = undefined;
+    seen.props = undefined;
+    ComponentRegistry.register('probe', ElementProbe, {
+      namespace: 'element',
+      skipFallback: true,
+    });
+    ComponentRegistry.register('plain-probe', PlainProbe, { namespace: 'test' });
+  });
+
+  afterEach(() => {
+    ComponentRegistry.unregister?.('probe', 'element');
+    ComponentRegistry.unregister?.('plain-probe', 'test');
+  });
+
+  // (a) the defect itself
+  describe('the canonical spelling evaluates', () => {
+    it('evaluates an expression written under `properties`', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: '${data.total}' },
+      });
+      expect(screen.getByTestId('element')).toHaveTextContent('99');
+    });
+
+    it('leaves the evaluated value on `schema.properties`, which is what the renderer reads', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: '${data.total}' },
+      });
+      // The pre-fix bug was NOT that nothing was evaluated — the hoist put an
+      // evaluated `content` at the top level — but that `schema.properties`
+      // still pointed at the untouched original. Pin the object the renderer
+      // actually reads.
+      expect(seen.schema.properties.content).toBe(99);
+    });
+
+    it('evaluates an interpolated (multi-part) expression too', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: '${data.label}: ${data.total}' },
+      });
+      expect(screen.getByTestId('element')).toHaveTextContent('Widgets: 99');
+    });
+
+    it('evaluates every value in the bag, not just `content`', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: 'x', variant: '${data.label}' },
+      });
+      expect(seen.schema.properties.variant).toBe('Widgets');
+    });
+  });
+
+  // (b) the alias must not regress
+  describe('the legacy `props` alias keeps working', () => {
+    it('still evaluates an expression written under `props`', () => {
+      renderWithData({
+        type: 'element:probe',
+        props: { content: '${data.total}' },
+      });
+      expect(screen.getByTestId('element')).toHaveTextContent('99');
+      expect(seen.schema.props.content).toBe(99);
+    });
+  });
+
+  // (c) both keys present
+  describe('both spellings on one node', () => {
+    it('renders the `properties` value (it wins the merge) and evaluates both', () => {
+      renderWithData({
+        type: 'element:probe',
+        props: { content: '${data.label}' },
+        properties: { content: '${data.total}' },
+      });
+      expect(screen.getByTestId('element')).toHaveTextContent('99');
+      expect(seen.schema.properties.content).toBe(99);
+      expect(seen.schema.props.content).toBe('Widgets');
+    });
+  });
+
+  // (d) static values, both sides
+  describe('static values are untouched on both spellings', () => {
+    it('passes a static `properties.content` through unchanged', () => {
+      renderWithData({ type: 'element:probe', properties: { content: 'HELLO' } });
+      expect(screen.getByTestId('element')).toHaveTextContent('HELLO');
+    });
+
+    it('passes a static `props.content` through unchanged', () => {
+      renderWithData({ type: 'element:probe', props: { content: 'HELLO' } });
+      expect(screen.getByTestId('element')).toHaveTextContent('HELLO');
+    });
+
+    it('leaves non-string values (numbers, booleans) as they are', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: 7, variant: 'body', flag: true },
+      });
+      expect(seen.schema.properties.content).toBe(7);
+      expect(seen.schema.properties.flag).toBe(true);
+    });
+  });
+
+  // (e) nothing outside the `element:*` shape changes
+  describe('non-element namespaces are unaffected', () => {
+    it('still evaluates `props` for a component that only reads spread props', () => {
+      renderWithData({
+        type: 'test:plain-probe',
+        props: { content: '${data.total}' },
+      });
+      expect(screen.getByTestId('plain')).toHaveTextContent('99');
+    });
+
+    it('still evaluates the top-level `content` leg', () => {
+      renderWithData({ type: 'test:plain-probe', content: '${data.total}' });
+      expect(screen.getByTestId('plain')).toHaveTextContent('99');
+    });
+  });
+
+  // Interaction with the pre-existing `properties` -> top-level hoist.
+  describe('the properties-to-top-level hoist', () => {
+    it('hoists the EVALUATED value, so `schema.x` and `schema.properties.x` agree', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: 'x', variant: '${data.label}' },
+      });
+      expect(seen.schema.variant).toBe('Widgets');
+      expect(seen.schema.properties.variant).toBe('Widgets');
+      // ...and the hoisted value is spread as a React prop, which must agree too.
+      expect(seen.props.variant).toBe('Widgets');
+    });
+
+    it('still refuses to let inner `type` / `id` shadow the node descriptor', () => {
+      renderWithData({
+        type: 'element:probe',
+        id: 'outer',
+        properties: { type: 'body', id: 'inner', content: 'x' },
+      });
+      expect(seen.schema.type).toBe('element:probe');
+      expect(seen.schema.id).toBe('outer');
+      // Both remain readable through the bag, exactly as before.
+      expect(seen.schema.properties.type).toBe('body');
+      expect(seen.schema.properties.id).toBe('inner');
+    });
+  });
+
+  /**
+   * Evaluation is per-value and SHALLOW on BOTH spellings — measured, not
+   * assumed: `ExpressionEvaluator.evaluate` returns every non-string untouched,
+   * so a nested object/array is passed through rather than walked. This pins the
+   * PARITY, not the depth: deepening one side without the other is the defect
+   * this issue is about, in miniature.
+   */
+  describe('shallow, and equally shallow on both spellings', () => {
+    it('does not walk into a nested object under `properties`', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: 'x', aria: { label: '${data.total}' } },
+      });
+      expect(seen.schema.properties.aria.label).toBe('${data.total}');
+    });
+
+    it('does not walk into a nested object under `props` either', () => {
+      renderWithData({
+        type: 'element:probe',
+        props: { content: 'x', aria: { label: '${data.total}' } },
+      });
+      expect(seen.schema.props.aria.label).toBe('${data.total}');
+    });
+
+    it('does not walk into an array under `properties`', () => {
+      renderWithData({
+        type: 'element:probe',
+        properties: { content: 'x', items: ['${data.total}'] },
+      });
+      expect(seen.schema.properties.items[0]).toBe('${data.total}');
+    });
+  });
+
+  /**
+   * The evaluation guard is deliberately narrower than the `props` branch's bare
+   * truthiness, because this value feeds the hoist: a degenerate `properties`
+   * must reach it with its shape intact rather than re-spread into an object.
+   */
+  describe('degenerate `properties` values keep their existing behaviour', () => {
+    it('does not turn an array `properties` into a plain object', () => {
+      renderWithData({ type: 'element:probe', properties: ['a'] as any });
+      expect(Array.isArray(seen.schema.properties)).toBe(true);
+    });
+
+    it('renders without throwing when `properties` is null', () => {
+      renderWithData({ type: 'element:probe', properties: null as any });
+      expect(screen.getByTestId('element')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #4799

## 问题

`properties` 是节点配置袋的**规范拼写**,`props` 是 `readProps()` 注释里明写的 legacy alias。但 `SchemaRenderer` 的 evaluation memo 只对 `newSchema.props` 逐值求值,`properties` 没有对应分支;而 `element:*` 命名空间的渲染器(`packages/components/src/renderers/basic/elements.tsx` 的 `readProps()`)读的是 `{ ...schema.props, ...schema.properties }` —— **先读 `properties`,且它优先**。

于是按规范拼写写节点的作者,表达式静默失效、上屏字面量;写 "legacy alias" 的反而正常。
真实 SchemaRenderer 渲染探针实测(dataSource 为 `total: 99`):

改动前

| 节点 | 上屏 |
| --- | --- |
| `element:text` + `props: content` 表达式 | `99` |
| `element:text` + `properties: content` 表达式 | `${data.total}` ← 规范拼写丢表达式 |
| `element:text` + `props: content` 静态 | `HELLO` |
| `element:text` + `properties: content` 静态 | `HELLO` |

改动后

| 节点 | 上屏 |
| --- | --- |
| `element:text` + `props: content` 表达式 | `99` |
| `element:text` + `properties: content` 表达式 | `99` |
| `element:text` + `props: content` 静态 | `HELLO` |
| `element:text` + `properties: content` 静态 | `HELLO` |

memo 里原有一段把 `properties.*` 提升到节点顶层,顶层 `content` 随后会被求值 —— 但 `newSchema.properties` 仍指向**原始未求值对象**,而渲染器读的正是 `schema.properties`,所以提升那一步对 `element:*` 没有作用。这就是"求值结果必须**替换** `newSchema.properties`"的由来。

## 改法

`packages/react/src/SchemaRenderer.tsx` 的 evaluation memo 里,对 `newSchema.properties` 做与 `props` **同样的逐值求值**,并把结果**替换**回 `newSchema.properties`。

三点刻意的形状:

1. **放在提升段之前。** 提升段把每个 `properties.*` 拷到节点顶层,这些拷贝还会在渲染时被 spread 成 React prop。先求值,同一个键无论从 `schema.properties.x`、`schema.x` 还是 `x` prop 读才是同一个值(原先只有 `content` 一个键碰巧被顶层那条腿求值,其余顶层拷贝是生的)。顺带让后面的 `content` 腿幂等:这里求过值的字符串已不含 `${...}`。
2. **浅求值,而且两边一样浅。** `evaluator.evaluate` 对非字符串原样返回,所以嵌套对象/数组是穿过而不是走进去 —— 实测 `aria` 里嵌一层表达式,在**任一**拼写下、改动前后都渲染生字符串。加深是另一个决定,要加必须两边一起加,不在这里单边夹带;两条 pin 把这个 parity 钉住了。
3. **守卫比 `props` 分支的裸真值判断更窄**(多了 `typeof === 'object'` 与 `!Array.isArray`)。因为这个值要**喂给提升段**:退化形态的 `properties`(字符串、数组)若被对象 spread 重塑会顺着传下去。非对象直接跳过求值,原样进提升段。

`readProps` 的 `properties` 优先级保持不变,`packages/components/**` 零改动。

## 与 #4795 方向 3 的序列关系

本单是**先行的机械 alias parity**,不实施 #4795 的方向 3(未求值表达式的响亮诊断,维护者已在 #4795 评论 5312061331 裁定"方向 3 现在做、方向 2 永不")。两者落在**同一个 memo**:本单先行,D3 后续同文件。因此改动形状刻意保持局部 —— 只补一个求值分支,未重构 memo —— 给 D3 留干净落点。

## 测试

新增 `packages/react/src/__tests__/SchemaRenderer.propertiesExpressions.test.tsx`(18 项),覆盖派发的五条钉:`properties` + 表达式求值上屏、`props` 不回归、两键同现时 `properties` 优先且两边都已求值、静态值两边不回归、非 element 命名空间既有 props 求值不变;另加提升段一致性(顶层 / 配置袋 / React prop 三个读法同值)、`properties.type` 与 `properties.id` 仍不遮蔽节点描述符、浅求值两边同形、退化形态守卫。

跑过:react 全量 47 files / 636 tests;components 全量 155 / 1417;layout + plugin-detail + plugin-list + plugin-dashboard 203 / 2170;app-shell 全量 424 / 4079(1 skipped);仓根 turbo type-check 81/81;改动文件 eslint 0 errors;`check:control-bytes` + 自扫。

## 反向验证(先书面预判,再跑)

- **摘掉新分支**(`git checkout HEAD~1 -- SchemaRenderer.tsx`)。
  *预判*:6 项转红(4 条 `properties` 求值钉 + 两键同现钉 + 提升一致性钉),其余 12 项保持绿。这是**普通红向**,不是 #5009 那种倒置 —— 这里没有 `??` 链,新钉断言的是一个此前根本不存在的能力。
  *实测*:`Tests 6 failed | 12 passed (18)`,转红的正是预判点名的那 6 项。**预判命中。**
- **假场景自证**(判别性变异):保留逐值求值但**不替换** `newSchema.properties` —— 即复刻 issue 成因 (c):提升段拿到已求值的值,配置袋仍指向旧对象。
  *预判*:同样 6 项红;判别信息在提升一致性那一项**内部** —— 顶层与 React prop 两半会过,只有读配置袋的那半失败。
  *实测*:同样 `6 failed | 12 passed`,且提升一致性那项在**第 200 行**(`schema.properties.variant`)失败、第 199 行(`schema.variant`)通过;而摘掉整个分支时它是在**第 199 行**失败。两个变异的失败行不同,正是"evaluated"与"evaluated **且** replaced"的分界。**预判命中。**这也是那几条 `schema.properties.*` 断言存在的理由:去掉它们,套件会在 bug 仍在时转绿。
- **自选方向**(嵌套深度 parity):`properties` 内嵌套对象/数组的求值语义是否与 `props` 分支同形。
  *实测*(改动前后各一遍,真实渲染探针):`aria` 里嵌一层表达式,在**任一**拼写下、改动前后都渲染生字符串 —— 既有 `props` 分支本就浅求值。所以本改动是**浅同形**,**未**顺手加深,并用两条 pin 固定该 parity。这条与"红向"模板无关,如实记为「两边都不深、且改动前后不变」。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_