### PR TITLE
feat(react): 未求值的 ${…} 到达 DOM 时给出开发期响亮诊断 (#4795 方向 3)

### DIFF
--- a/.changeset/unevaluated-expression-dev-diagnostic-4795.md
+++ b/.changeset/unevaluated-expression-dev-diagnostic-4795.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/react': patch
+---
+
+Dev builds now shout when an unevaluated `${…}` expression reaches the DOM.
+
+A value only reaches the user if `SchemaRenderer` EVALUATES it and the renderer
+READS IT BACK, and those two sets do not fully overlap. Where they miss, the
+failure was silent. Measured on a real render with `dataSource: { n: 99 }`:
+`{ type: 'ui:statistic', value: '${data.n}' }` puts the literal text `${data.n}`
+on screen, because the evaluation memo covers `content`, the `properties` /
+`props` bags and the predicate keys and passes every other top-level key through
+untouched. An author — increasingly, an AI authoring metadata — got no signal at
+all: a literal `${data.n}` in front of a user reads like a data problem rather
+than a contract violation.
+
+`SchemaRenderer` now reports such a value once per node via `console.error`,
+naming the node type and id, the key the raw source survived on (spelled the way
+it was authored — `properties.value`, not the hoisted top-level copy), the
+expression source verbatim, and the channels that do work today. It also catches
+the second, harder shape: an expression that WAS evaluated but THREW, which
+`ExpressionEvaluator` returns as its source text — indistinguishable on screen
+from a key that was never evaluated.
+
+Diagnostic only. No evaluation behaviour changes, no DOM attribute is added, and
+the whole module is behind the module-load `NODE_ENV` constant a bundler folds
+away, so production pays nothing.
+
+Two boundaries are deliberate. The scan is exactly as deep as evaluation is —
+shallow — because a nested `aria: { label: '${…}' }` keeps its raw source today
+by decision (objectui#4799 pinned that shallowness on both bags), and a deeper
+scan would report a shape the engine has not yet decided to change. And schema
+METADATA is never reported: `visible` / `visibleWhen` / `hidden` / `disabled` /
+… hold raw predicate source by design, and the diagnostic reads the set of
+values that actually leaves for the DOM, after those keys have been stripped.
+
+Part of objectui#4795 (Direction 3, per the maintainer's 2026-08-17 ruling).
+Widening the set of evaluated text keys is Direction 1 and stays deferred behind
+its named restart condition; this change deliberately does not pre-empt it.

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -28,6 +28,7 @@ import { SchemaRendererContext } from './context/SchemaRendererContext';
 import { usePredicateScope } from './hooks/useExpression';
 import { usePageVariables } from './hooks/usePageVariables';
 import { resolveKeyedI18nLabel } from './utils/i18n';
+import { reportUnevaluatedExpressions } from './utils/unevaluatedExpression';
 
 /**
  * Dev-mode schema validation.
@@ -619,6 +620,32 @@ export const SchemaRenderer: ForwardRefExoticComponent<
     responsiveStyles: _responsiveStyles, // stripped: compiled to scoped CSS, not a DOM prop
     ...componentProps
   } = evaluatedSchema;
+
+  // Dev-build loud diagnostic (objectui#4795, Direction 3): an unevaluated
+  // `${…}` about to be placed verbatim in front of a user.
+  //
+  // Sited HERE, after the metadata destructure, on purpose. `componentProps` is
+  // precisely the set of values that leaves this component for the DOM — it is
+  // spread as React props below, and the same values are what renderers read as
+  // `schema.<key>`. Everything the destructure stripped is schema METADATA:
+  // `visible` / `visibleWhen` / `hidden` / `disabled` / … hold raw predicate
+  // SOURCE by design (they are evaluated as conditions, never placed), so
+  // scanning before the strip would report every correctly-authored predicate
+  // in the repo. The strip list is therefore the diagnostic's exclusion list,
+  // for free and without a second copy of it to drift.
+  //
+  // Read-only: it reports what evaluation already produced and changes nothing
+  // about what is rendered — no DOM attribute either, so no snapshot moves.
+  if (__DEV__) {
+    reportUnevaluatedExpressions(
+      schema as object,
+      evaluatedSchema.type,
+      evaluatedSchema.id,
+      componentProps,
+      evaluatedSchema.properties,
+      evaluatedSchema.props
+    );
+  }
 
   // SDUI scoped styling (ADR-0065): a node's `responsiveStyles` compiles to
   // id-scoped CSS injected as a <style> tag, and a scope class is appended to

--- a/packages/react/src/__tests__/SchemaRenderer.unevaluatedExpressionDiagnostic.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.unevaluatedExpressionDiagnostic.test.tsx
@@ -1,0 +1,330 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4795 (Direction 3) — a loud dev-build diagnostic when an
+ * UNEVALUATED `${…}` expression reaches the DOM.
+ *
+ * The defect it names, measured on this baseline with `dataSource: { n: 99 }`:
+ * `{ type: 'ui:statistic', value: '${data.n}' }` renders the literal text
+ * `${data.n}`, silently — SchemaRenderer evaluates `content`, the
+ * `properties` / `props` bags and the predicate keys, and passes every other
+ * top-level key through untouched. The maintainer's ruling (2026-08-17) took
+ * Direction 3 (name the failure) and DEFERRED Direction 1 (evaluate a declared
+ * set of text keys), so these pins assert the SHOUT, never a changed value.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+import { SchemaRendererContext } from '../context/SchemaRendererContext';
+import {
+  collectUnevaluatedExpressions,
+  findExpressionSources,
+  formatUnevaluatedExpressionMessage,
+  UNEVALUATED_EXPRESSION_PREFIX,
+} from '../utils/unevaluatedExpression';
+
+const DATA = { n: 99, total: 99, label: 'Widgets' };
+
+/**
+ * Stands in for a `ui:*` renderer: reads its text out of `schema.<key>`, which
+ * is what `statistic` / `card` / `button` all do
+ * (`packages/components/src/renderers/data-display/statistic.tsx` reads
+ * `schema.value`). Not imported from `@object-ui/components` — this package
+ * deliberately does not depend on it; the end-to-end reading through the real
+ * renderers is recorded in the PR.
+ */
+const TextKeyProbe = ({ schema }: any) => (
+  <div data-testid="probe">{String(schema.value ?? schema.title ?? '')}</div>
+);
+
+/** Reads only what it is spread, like a plain component. */
+const SpreadProbe = (props: any) => (
+  <div data-testid="spread">{String(props.content ?? '')}</div>
+);
+
+const renderWithData = (schema: any) =>
+  render(
+    <SchemaRendererContext.Provider value={{ dataSource: DATA } as any}>
+      <SchemaRenderer schema={schema} />
+    </SchemaRendererContext.Provider>
+  );
+
+/** Only the diagnostic's own lines — never the whole console.error traffic. */
+const shouts = (spy: { mock: { calls: any[][] } }): string[] =>
+  spy.mock.calls
+    .map(c => String(c[0]))
+    .filter(m => m.includes(UNEVALUATED_EXPRESSION_PREFIX));
+
+describe('SchemaRenderer — unevaluated `${…}` diagnostic (objectui#4795)', () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    ComponentRegistry.register('probe-4795', TextKeyProbe, { namespace: 'test' });
+    ComponentRegistry.register('spread-4795', SpreadProbe, { namespace: 'test' });
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    ComponentRegistry.unregister?.('probe-4795', 'test');
+    ComponentRegistry.unregister?.('spread-4795', 'test');
+  });
+
+  // (a) the defect: a top-level text key is never evaluated, so the literal
+  //     source text goes on screen — and now says so.
+  describe('a top-level text key carrying a literal expression', () => {
+    it('shouts, and the value still renders literally (read-only diagnostic)', () => {
+      const { getByTestId } = renderWithData({
+        type: 'test:probe-4795',
+        id: 'stat-1',
+        value: '${data.n}',
+      });
+
+      // The behaviour is UNCHANGED — Direction 1 stays deferred.
+      expect(getByTestId('probe')).toHaveTextContent('${data.n}');
+
+      const messages = shouts(spy);
+      expect(messages).toHaveLength(1);
+      // Names the node, the landing key, and the expression source verbatim.
+      expect(messages[0]).toContain('test:probe-4795');
+      expect(messages[0]).toContain('stat-1');
+      expect(messages[0]).toContain('value');
+      expect(messages[0]).toContain('${data.n}');
+      // ...and points at the channels that actually work today.
+      expect(messages[0]).toContain('content');
+    });
+
+    it('shouts for `title` / `label` / `description` alike', () => {
+      for (const key of ['title', 'label', 'description']) {
+        spy.mockClear();
+        renderWithData({ type: 'test:probe-4795', [key]: '${data.total}' });
+        expect(shouts(spy)[0]).toContain(key);
+      }
+    });
+
+    it('reports once per schema object, however many times it re-renders', () => {
+      const schema = { type: 'test:probe-4795', value: '${data.n}' };
+      const { rerender } = renderWithData(schema);
+      rerender(
+        <SchemaRendererContext.Provider value={{ dataSource: DATA } as any}>
+          <SchemaRenderer schema={schema} />
+        </SchemaRendererContext.Provider>
+      );
+      expect(shouts(spy)).toHaveLength(1);
+    });
+  });
+
+  // (b) every channel that DOES evaluate must stay silent.
+  describe('correctly-authored nodes stay silent', () => {
+    it('says nothing for a top-level `content`', () => {
+      const { getByTestId } = renderWithData({
+        type: 'test:spread-4795',
+        content: 'Total: ${data.total}',
+      });
+      expect(getByTestId('spread')).toHaveTextContent('Total: 99');
+      expect(shouts(spy)).toEqual([]);
+    });
+
+    it('says nothing for a `props` bag', () => {
+      renderWithData({ type: 'test:spread-4795', props: { content: '${data.total}' } });
+      expect(shouts(spy)).toEqual([]);
+    });
+
+    it('says nothing for a `properties` bag (evaluated since objectui#4799)', () => {
+      const { getByTestId } = renderWithData({
+        type: 'test:probe-4795',
+        properties: { value: '${data.n}' },
+      });
+      expect(getByTestId('probe')).toHaveTextContent('99');
+      expect(shouts(spy)).toEqual([]);
+    });
+
+    it('says nothing for a static schema with no expressions at all', () => {
+      renderWithData({ type: 'test:probe-4795', value: 'plain text' });
+      expect(shouts(spy)).toEqual([]);
+    });
+
+    it('says nothing when an expression resolves to nothing (missing data is not this defect)', () => {
+      // `${data.missing}` evaluates to undefined / '' — no source text survives,
+      // so there is nothing placed verbatim and nothing to report.
+      renderWithData({ type: 'test:spread-4795', content: 'x ${data.missing} y' });
+      expect(shouts(spy)).toEqual([]);
+    });
+  });
+
+  /**
+   * The predicate keys are the diagnostic's biggest false-positive risk: they
+   * hold raw `${…}` SOURCE by design and are evaluated as conditions, never
+   * placed. The metadata destructure in SchemaRenderer strips them before the
+   * scan, which is what makes this silent — pinned so a future edit to that
+   * destructure cannot quietly turn every correctly-authored predicate in the
+   * repo into a shout.
+   */
+  describe('predicate keys are never reported', () => {
+    it.each([
+      ['visible', '${data.n > 0}'],
+      ['visibleWhen', '${data.n > 0}'],
+      ['visibleOn', '${data.n > 0}'],
+      ['visibility', '${data.n > 0}'],
+      ['hiddenOn', '${data.n < 0}'],
+      ['disabled', '${data.n < 0}'],
+      ['disabledOn', '${data.n < 0}'],
+    ])('stays silent for a declared `%s`', (key, expr) => {
+      renderWithData({ type: 'test:probe-4795', value: 'ok', [key]: expr });
+      expect(shouts(spy)).toEqual([]);
+    });
+  });
+
+  // The second class the ruling named: evaluation ran, but THREW, and the
+  // evaluator returns the source verbatim — indistinguishable on screen from a
+  // key that was never evaluated.
+  describe('evaluation-failure residue', () => {
+    it('shouts when an expression throws and its source survives evaluation', () => {
+      renderWithData({ type: 'test:spread-4795', content: 'Total: ${1 +}' });
+      const messages = shouts(spy);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toContain('${1 +}');
+      expect(messages[0]).toContain('content');
+    });
+  });
+
+  /**
+   * The scan is as deep as evaluation is, and no deeper. A nested
+   * `aria: { label: '${…}' }` keeps its raw source today BY DECISION
+   * (objectui#4799 pinned the shallowness on both bags), so reporting it would
+   * make the diagnostic louder than the contract it speaks for.
+   */
+  describe('depth matches the evaluator exactly', () => {
+    it('does not report a nested value under `properties`', () => {
+      renderWithData({
+        type: 'test:probe-4795',
+        properties: { value: 1, aria: { label: '${data.total}' } },
+      });
+      expect(shouts(spy)).toEqual([]);
+    });
+
+    it('does not report a nested value under `props`', () => {
+      renderWithData({
+        type: 'test:spread-4795',
+        props: { content: 'x', aria: { label: '${data.total}' } },
+      });
+      expect(shouts(spy)).toEqual([]);
+    });
+  });
+
+  // (c) production build: no work, no output.
+  describe('production build', () => {
+    it('emits nothing when NODE_ENV is production', async () => {
+      // `__DEV__` in SchemaRenderer is a MODULE-LOAD constant (so a bundler can
+      // constant-fold the branch and drop the diagnostic from the production
+      // bundle entirely). Flipping the env therefore needs a fresh module graph
+      // — the deliberate `vi.resetModules()` re-import that AGENTS.md §测试纪律
+      // exempts, done in the test body rather than a hook.
+      vi.resetModules();
+      vi.stubEnv('NODE_ENV', 'production');
+      try {
+        const prodSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const { SchemaRenderer: ProdRenderer } = await import('../SchemaRenderer');
+        const { SchemaRendererContext: ProdContext } = await import(
+          '../context/SchemaRendererContext'
+        );
+        const { ComponentRegistry: ProdRegistry } = await import('@object-ui/core');
+        ProdRegistry.register('probe-4795', TextKeyProbe, { namespace: 'test' });
+
+        const { getByTestId } = render(
+          <ProdContext.Provider value={{ dataSource: DATA } as any}>
+            <ProdRenderer schema={{ type: 'test:probe-4795', value: '${data.n}' }} />
+          </ProdContext.Provider>
+        );
+
+        // The defect is still there — the diagnostic is a dev affordance only.
+        expect(getByTestId('probe')).toHaveTextContent('${data.n}');
+        expect(shouts(prodSpy)).toEqual([]);
+        prodSpy.mockRestore();
+        ProdRegistry.unregister?.('probe-4795', 'test');
+      } finally {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+      }
+    });
+  });
+});
+
+/**
+ * (d) The diagnostic's own positive guard.
+ *
+ * objectui#5092's lesson: a diagnostic whose only coverage is "a spy was
+ * called" goes green the moment someone no-ops the assertion. The scan and the
+ * message are pure functions for exactly this reason — these assert the
+ * RETURNED findings and the RENDERED words, so stubbing either one out is red.
+ */
+describe('the diagnostic itself (objectui#4795)', () => {
+  it('finds expression sources using the evaluator\'s own definition', () => {
+    expect(findExpressionSources('${data.n}')).toEqual(['${data.n}']);
+    expect(findExpressionSources('a ${x} b ${y}')).toEqual(['${x}', '${y}']);
+    // The evaluator's interpolation regex requires at least one character, so
+    // `${}` is not an expression to it — measured: it is returned verbatim and
+    // is not a defect to report.
+    expect(findExpressionSources('a ${} b')).toEqual([]);
+    // An unterminated `${` is not an expression either — this is what keeps
+    // prose and code samples out of the diagnostic.
+    expect(findExpressionSources('write ${ like so')).toEqual([]);
+    expect(findExpressionSources('no expressions here')).toEqual([]);
+  });
+
+  it('is not stateful across calls (the /g regex is reset per value)', () => {
+    // A module-scope /g literal keeps `lastIndex` between calls; without the
+    // reset the SECOND identical call returns nothing and the diagnostic goes
+    // quiet exactly when it is used most.
+    expect(findExpressionSources('${a}')).toEqual(['${a}']);
+    expect(findExpressionSources('${a}')).toEqual(['${a}']);
+  });
+
+  it('collects findings per channel, naming the authored spelling', () => {
+    expect(collectUnevaluatedExpressions({ value: '${data.n}' })).toEqual([
+      { key: 'value', channel: 'schema', value: '${data.n}', expressions: ['${data.n}'] },
+    ]);
+    expect(collectUnevaluatedExpressions(undefined, undefined, { c: '${x}' })).toEqual([
+      { key: 'c', channel: 'props', value: '${x}', expressions: ['${x}'] },
+    ]);
+  });
+
+  it('reports a hoisted `properties` value once, at the key the author wrote', () => {
+    // SchemaRenderer copies every `properties.*` onto the node's top level, so
+    // the same residue is visible twice. One finding, spelled `properties.x`.
+    const findings = collectUnevaluatedExpressions({ x: '${bad(}' }, { x: '${bad(}' });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].channel).toBe('properties');
+    expect(formatUnevaluatedExpressionMessage('ui:card', undefined, findings)).toContain(
+      'properties.x'
+    );
+  });
+
+  it('ignores non-string values and degenerate bags', () => {
+    expect(collectUnevaluatedExpressions({ n: 7, ok: true, nested: { a: '${x}' } })).toEqual([]);
+    expect(collectUnevaluatedExpressions(undefined, ['${x}'] as any, null)).toEqual([]);
+    expect(collectUnevaluatedExpressions(null, null, null)).toEqual([]);
+  });
+
+  it('renders a message that names node, site, source and the way out', () => {
+    const message = formatUnevaluatedExpressionMessage('ui:statistic', 'stat-1', [
+      { key: 'value', channel: 'schema', value: '${data.n}', expressions: ['${data.n}'] },
+    ]);
+    expect(message).toContain(UNEVALUATED_EXPRESSION_PREFIX);
+    expect(message).toContain('ui:statistic');
+    expect(message).toContain('stat-1');
+    expect(message).toContain('value');
+    expect(message).toContain('${data.n}');
+    expect(message).toContain('content');
+    expect(message).toContain('host');
+  });
+});

--- a/packages/react/src/utils/unevaluatedExpression.ts
+++ b/packages/react/src/utils/unevaluatedExpression.ts
@@ -1,0 +1,244 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Dev-build diagnostic: an UNEVALUATED template expression reached the DOM.
+ *
+ * ## The defect this names (objectui#4795, Direction 3)
+ *
+ * A value only reaches the user if it passes two gates: `SchemaRenderer`
+ * must EVALUATE it, and the renderer must READ IT BACK. Those two sets do not
+ * fully overlap, and where they miss, the failure is SILENT — measured on a
+ * real render with `dataSource: { total: 99 }`:
+ *
+ *   { type: 'ui:statistic', value: '${data.n}' }            -> screen shows
+ *                                                              `${data.n}`
+ *   { type: 'ui:card', props: { title: '${data.total}' } }  -> card body EMPTY
+ *                                                              (the evaluated
+ *                                                              `99` landed on a
+ *                                                              DOM attribute)
+ *
+ * The first shape is what this module catches: the memo in `SchemaRenderer`
+ * evaluates `content`, the `properties` / `props` bags and the predicate keys,
+ * and passes every other top-level key through untouched — so the raw source
+ * text is what the renderer receives, and it is placed verbatim. An author
+ * (increasingly, an AI authoring metadata) gets no signal at all: a literal
+ * `${data.n}` on screen reads like a data problem, not a contract violation.
+ *
+ * The second shape this module also catches, in its residue form: when an
+ * expression IS evaluated but the evaluation THROWS, `ExpressionEvaluator`
+ * returns the original source verbatim (`return match` in its interpolation
+ * branch, `defaultValue ?? expression` in its outer catch), so a failed
+ * evaluation is indistinguishable on screen from a key that was never
+ * evaluated at all. Both end as raw `${…}` in front of a user.
+ *
+ * ## What this deliberately does NOT do
+ *
+ * It changes NO evaluation behaviour — it reads the schema after the memo has
+ * run and reports. Widening the set of evaluated keys is objectui#4795's
+ * Direction 1, which the maintainer DEFERRED behind a named restart condition
+ * (ruling of 2026-08-17); this diagnostic is Direction 3 and must not
+ * pre-empt it. Merging `props` into the node (Direction 2) is permanently
+ * rejected.
+ *
+ * ## Depth: exactly the evaluator's own radius, and not one level more
+ *
+ * The scan is SHALLOW because evaluation is shallow. `ExpressionEvaluator`
+ * returns every non-string untouched, so a nested `aria: { label: '${…}' }`
+ * under either bag keeps its raw source today — deliberately, and pinned as
+ * such by objectui#4799's parity tests. A deeper scan would therefore report,
+ * as a defect, a shape the repo has explicitly decided not to change yet: the
+ * diagnostic would be louder than the contract it speaks for. Deepening
+ * evaluation is a separate decision, and this scan follows it the day it is
+ * taken, not before.
+ */
+
+/** What counts as an expression — the evaluator's own definition. */
+const EXPRESSION_PATTERN = /\$\{([^}]+)\}/g;
+
+/**
+ * Mirrors `ExpressionEvaluator.evaluate`: a `${` with no closing brace, or an
+ * empty `${}`, is not an expression to the evaluator (its interpolation regex
+ * requires at least one character), so it is not one here either. Matching the
+ * PRODUCER's definition is what keeps this from reporting strings the engine
+ * never intended to touch — prose and code samples that merely contain `${`.
+ */
+export function findExpressionSources(value: string): string[] {
+  const found: string[] = [];
+  // `matchAll` needs the /g flag and a fresh lastIndex per call; the literal
+  // above is module-scope, so reset before use rather than allocating a regex
+  // per value (this runs per key, per node, per render, in dev).
+  EXPRESSION_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null = EXPRESSION_PATTERN.exec(value);
+  while (match !== null) {
+    found.push(match[0]);
+    match = EXPRESSION_PATTERN.exec(value);
+  }
+  return found;
+}
+
+/** Which authored channel a residual expression was found on. */
+export type UnevaluatedChannel = 'schema' | 'properties' | 'props';
+
+export interface UnevaluatedExpressionFinding {
+  /** The key holding the raw source. */
+  key: string;
+  /** The authored channel the key was read from. */
+  channel: UnevaluatedChannel;
+  /** The value, verbatim, as it will be handed to the renderer. */
+  value: string;
+  /** The `${…}` fragments inside it. */
+  expressions: string[];
+}
+
+function scanBag(
+  bag: unknown,
+  channel: UnevaluatedChannel,
+  into: UnevaluatedExpressionFinding[],
+  skip?: (key: string, value: string) => boolean
+): void {
+  if (!bag || typeof bag !== 'object' || Array.isArray(bag)) return;
+  for (const [key, value] of Object.entries(bag as Record<string, unknown>)) {
+    if (typeof value !== 'string') continue;
+    if (skip?.(key, value)) continue;
+    const expressions = findExpressionSources(value);
+    if (expressions.length > 0) {
+      into.push({ key, channel, value, expressions });
+    }
+  }
+}
+
+/**
+ * Collect every unevaluated `${…}` that is about to be handed to a renderer.
+ *
+ * Pure and side-effect free — the reporting half is {@link reportUnevaluatedExpressions}.
+ * Kept separate so the scan can be asserted directly: a diagnostic whose only
+ * test is "a spy was called" goes green the moment someone no-ops it.
+ *
+ * @param spread  The post-strip top-level bag — exactly what `SchemaRenderer`
+ *   spreads as React props, which is also what renderers read as `schema.<key>`.
+ *   Schema METADATA (`visible` / `hidden` / `disabled` / … ) must already be
+ *   removed by the caller: those keys carry raw predicate source BY DESIGN and
+ *   are evaluated as conditions, never placed.
+ * @param properties  The node's `properties` bag, if any. Reported in
+ *   preference to the top-level copy the hoist makes of it, so the finding
+ *   names the key the author actually wrote.
+ * @param props  The node's legacy `props` bag, if any.
+ */
+export function collectUnevaluatedExpressions(
+  spread: Record<string, unknown> | undefined | null,
+  properties?: unknown,
+  props?: unknown
+): UnevaluatedExpressionFinding[] {
+  const findings: UnevaluatedExpressionFinding[] = [];
+
+  scanBag(properties, 'properties', findings);
+
+  // The hoist copies every `properties.*` value onto the node's top level, so
+  // the same residue is visible twice. Report the authored spelling only.
+  const hoisted =
+    properties && typeof properties === 'object' && !Array.isArray(properties)
+      ? (properties as Record<string, unknown>)
+      : undefined;
+  scanBag(spread, 'schema', findings, (key, value) => hoisted?.[key] === value);
+
+  scanBag(props, 'props', findings);
+
+  return findings;
+}
+
+/**
+ * Prefix every diagnostic line starts with. Exported so tests can match on it
+ * and so an app can filter it out of its console transport if it must.
+ */
+export const UNEVALUATED_EXPRESSION_PREFIX =
+  '[ObjectUI] Unevaluated expression reached the DOM';
+
+/** Where a finding sits, spelled the way an author would search for it. */
+function locate(finding: UnevaluatedExpressionFinding): string {
+  switch (finding.channel) {
+    case 'properties':
+      return 'properties.' + finding.key;
+    case 'props':
+      return 'props.' + finding.key;
+    default:
+      return finding.key;
+  }
+}
+
+/**
+ * Build the message. Separate from the emit so a test can assert the words a
+ * developer is going to read, not merely that something was logged.
+ */
+export function formatUnevaluatedExpressionMessage(
+  type: unknown,
+  id: unknown,
+  findings: UnevaluatedExpressionFinding[]
+): string {
+  const node = typeof type === 'string' && type ? '"' + type + '"' : '(untyped node)';
+  const where = typeof id === 'string' && id ? ' (id: "' + id + '")' : '';
+  const lines = findings.map(f => {
+    const site = locate(f);
+    return (
+      '  - ' + site + ': ' + JSON.stringify(f.value) +
+      '  [' + f.expressions.join(', ') + ']'
+    );
+  });
+  return (
+    UNEVALUATED_EXPRESSION_PREFIX + ' - node ' + node + where + '\n' +
+    lines.join('\n') + '\n' +
+    'The value above is placed VERBATIM: it is handed to the renderer, and spread\n' +
+    'to the DOM, with its source text intact. Either SchemaRenderer does not\n' +
+    'evaluate this key, or the expression threw and the evaluator returned the\n' +
+    'source unchanged.\n' +
+    'Channels that do evaluate and read back today: `content`, or resolve the\n' +
+    'value in the host before handing the schema to SchemaRenderer.'
+  );
+}
+
+/**
+ * Reported nodes, so a re-render (or the post-mount forceUpdate that picks up
+ * lazy plugin registrations) does not repeat the message. Keyed on the ORIGINAL
+ * schema object, matching `validateSchemaOnce`'s dedup: the evaluated copy is a
+ * fresh object on every memo recompute and would dedup nothing.
+ */
+const _reportedNodes: WeakSet<object> =
+  typeof WeakSet !== 'undefined'
+    ? new WeakSet()
+    : ({ add() {}, has() { return false; } } as unknown as WeakSet<object>);
+
+/**
+ * Dev-build only. Scans, and on a hit reports once per schema object via
+ * `console.error`.
+ *
+ * `console.error` and not `warn`: this is the loud refusal objectui#4795's
+ * ruling asked for, and it follows the assertion shape objectui#5092 landed in
+ * SchemaForm. (It is also the level that survives happy-dom, which swallows
+ * `console.log`.)
+ *
+ * The caller applies the production gate, so this stays a single dev-only
+ * branch at the call site and the whole module is dead code in a production
+ * build.
+ */
+export function reportUnevaluatedExpressions(
+  schema: object | null | undefined,
+  type: unknown,
+  id: unknown,
+  spread: Record<string, unknown> | undefined | null,
+  properties?: unknown,
+  props?: unknown
+): UnevaluatedExpressionFinding[] {
+  const findings = collectUnevaluatedExpressions(spread, properties, props);
+  if (findings.length === 0) return findings;
+  if (schema && typeof schema === 'object') {
+    if (_reportedNodes.has(schema)) return findings;
+    _reportedNodes.add(schema);
+  }
+  console.error(formatUnevaluatedExpressionMessage(type, id, findings));
+  return findings;
+}


### PR DESCRIPTION
Part of #4795 —— 维护者裁定(评论 5312061331)的**方向 3**,render-time 半边。

## 做了什么

在 `SchemaRenderer` 渲染路径上加一条**仅开发构建**的响亮诊断:当一个**未求值的 `${…}`** 即将被原样交给 renderer / 展开进 DOM 时,`console.error` 点名 —— 节点 `type` 与 `id`、残留所在的键(按作者书写的通道拼写)、表达式原文,以及当下真正走得通的通道。

- ⛔ **不改变任何求值行为**。诊断只读:不写 schema、不加 DOM 属性(所以快照不动)。
- ⛔ 不实现方向 1(声明式文本键求值集),措辞也不预告它。
- ⛔ 方向 2 按裁定永久否决,未触碰。
- 生产零开销:整个模块挂在模块加载期的 `NODE_ENV` 常量之后,打包器直接折叠掉这个分支。

## 前提复测(基线 `0046d8f8c`,含 PR #5122)

卡面表格在新基线上**逐行实测**(真 renderer,`dataSource: { total: 99, n: 99 }`):

| 写法 | 实测渲染 | 诊断 |
|---|---|---|
| `{ type: 'ui:statistic', value: '${data.n}' }` | 字面量 `${data.n}` 上屏 | 响 ✅ |
| `{ type: 'ui:card', title: '${data.total}' }` | 字面量上屏,并落成 DOM 属性 `title="${data.total}"` | 响 ✅ |
| `{ type: 'ui:button', label: '${data.total}' }` | 字面量上屏 | 响 ✅ |
| `{ type: 'ui:statistic', props: { value: '${data.n}' } }` | **空白**(求出了 99,落成 React prop,而 renderer 读 `schema.value`) | 静默 —— 见下「不覆盖的那一类」 |
| `{ type: 'ui:statistic', properties: { value: '${data.n}' } }` | **`99`** | 静默 ✅ |
| `{ type: 'ui:text', content: 'Total: ${data.total}' }` | `Total: 99` | 静默 ✅ |

成因判断复核通过:evaluation memo 处理 `content`、`properties.*`、`props.*` 与谓词键,`title` / `label` / `value` / `description` 原样透传(`SchemaRenderer.tsx` 求值 memo)。

### ⚠️ 请维护者过目:卡面标题那句话已被 #5122 改变

卡面写的是「**除 `content` 外没有任何文本键既被求值又被读回**」。在含 PR #5122 的新基线上**这句已不再成立**:写成 `properties` 信封时,`value` / `title` / `label` 三个键**都**既被求值又被读回(实测均为 `99`)—— 因为 #5122 让 `properties.*` 参与求值,而既有的 hoist 又把**求值后**的值抄到节点顶层,正好是 `StatisticRenderer` / `CardTitle` / `Button` 读的位置。

这条是裁定(2026-08-17)之后才由 #5122 造成的新事实,因此**诊断文案里我没有写它**:裁定原文把可用通道列为「`content`, or host pre-resolution」,而「`properties` 信封是不是 `ui:*` 的正式创作面」是契约/教学面判断(#4786 刚把 `props` 信封这个 workaround 从教学面撤掉),属维护者的裁量,不该由我在一条诊断消息里替仓库定下来。请裁:文案是否加上 `properties`。

### 不覆盖的那一类(如实记录)

`props` 信封那一行(求值了但读不回 → 渲染成空白)诊断**不响**,而且按定义响不了:那里根本没有未求值的 `${…}` 到达 DOM,值已经变成 `99` 了,只是落错了地方。裁定的方向 3 只认「未求值的 `${…}` 到达 DOM」,所以这一类不在本 PR 的射程内 —— 它是卡面的另一半,随方向 1 / 契约裁量走。

## 设计取舍

**挂点**:放在 metadata 解构**之后**,扫 `componentProps`。那正是离开本组件去 DOM 的那组值(下面被展开成 React props,renderer 也从 `schema.` 加同名键读到同一批)。解构剥掉的全是 schema **元数据** —— `visible` / `visibleWhen` / `hidden` / `disabled` / … 按设计就装着**原始谓词源码**(它们被当条件求值,从不被放置)。所以**剥离清单天然就是诊断的排除清单**,不需要第二份会漂移的副本。这条不是注释里的说法,有 7 条钉盯着(见反向验证 (c))。

**深度**:与求值**完全同深** —— 只扫一层。嵌套的 `aria: { label: '${…}' }` 今天保留原文是**既定决定**(#4799 在两个信封上都钉住了这个浅层性),再深一层就会把仓库尚未决定要改的形态报成缺陷,诊断就比它所代表的契约更吵。求值哪天变深,这个扫描跟着变深,不提前。

**表达式的定义**:复用求值器自己的 `\$\{([^}]+)\}` —— 少一个字符的 `${}` 与未闭合的 `${` 对求值器都不是表达式(实测:原样返回),对诊断也就不是。这是把散文和代码示例挡在诊断之外的关键。

**开销**:每节点每渲染一次浅遍历 + `includes('${')`,仅 dev;命中后按 schema 对象 `WeakSet` 去重(与同文件 `validateSchemaOnce` 同一套路),重渲染不刷屏。

## 测试

`packages/react/src/__tests__/SchemaRenderer.unevaluatedExpressionDiagnostic.test.tsx`,25 钉:

- (a) 顶层 `value` / `title` / `label` / `description` 字面量 ⇒ 响,且**值照旧字面量渲染**(证明只读);消息点名 type / id / 键 / 表达式原文。
- (b) `content`、`props`、`properties` 正常求值 ⇒ 静默;静态值 ⇒ 静默;**表达式求值成空(数据缺失)⇒ 静默**(缺数据不是本缺陷)。
- (c) `NODE_ENV=production` ⇒ 零输出,缺陷本身照旧存在。
- (d) 诊断器自身的正向守卫:扫描器与消息都是纯函数并被直接断言 —— 参照 #5092 的教训,只钉「spy 被调用过」的诊断在被 no-op 化那天就会变绿。
- 另有 7 条谓词键静默钉、2 条深度边界钉、1 条求值抛错残留钉(`${1 +}` 经 `ExpressionEvaluator` 原样返回)。

**假阳性普查**:把诊断临时改成落盘记录(绕开测试里的 console mock),跑遍消费半径 —— `react` + `components` + `fields` + `plugin-dashboard` + `plugin-grid` + `plugin-list`,**488 文件 / 5682 测试全绿**,共 9 次触发,**全部来自我自己的测试与探针文件,既有测试零假阳性**。

```
 Test Files  488 passed (488)
      Tests  5682 passed (5682)
```

仓根 `type-check` **81/81**;eslint 改动文件 **0 errors**(23 条 `no-explicit-any` warning,与周边同款);`check-control-bytes` OK,另做了控制字节自扫。

## 反向验证(先书面预判,再跑;四条全部与预判一致,无反转)

| 变异 | 预判 | 实测 |
|---|---|---|
| (a) 摘掉调用点 | 4 条 render 级钉红,9 条纯函数钉**照绿** | `4 failed \| 21 passed`,正是那 4 条 |
| (b) 把收集器 no-op 化 | 上述 4 条 **+ 2 条纯函数钉**红(#5092 教训) | `6 failed \| 19 passed`,正是那 6 条 |
| (c) 把扫描挪到 metadata 解构**之前** | 7 条谓词钉红(证明「剥离清单=排除清单」是承重的) | `7 failed \| 18 passed`,正是那 7 条 |
| (d) 正则放宽成 `[^}]*` | 恰好 1 条(`${}` 那条)红 | `1 failed \| 24 passed` |

## 留后续

**publish-time 半边不做**:侦查后自然挂点落在 CLI 校验器文件,#5115 席正在飞,按不撞文件纪律留给后续,在此如实记录。

方向 1 的重启条件在裁定评论 5312061331 第 2 条(*第一个真实的 schema 编排仪表盘需求撞上这个缺口*),本 PR 未预告、未实现。**是否关卡留给 PM 验收时定** —— 卡面还载着方向 1 的重启条件。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_