### PR TITLE
docs(plugin-form): 文档站 Form Field 参考块与校验示例按 FieldValidationRules 真身重写 (#5118)

### DIFF
--- a/.changeset/plugin-form-docs-site-validation-shape-5118.md
+++ b/.changeset/plugin-form-docs-site-validation-shape-5118.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+The plugin-form documentation-site page now teaches the `validation` shape the
+form renderer actually reads, so a copied example validates instead of only
+looking as though it does.
+
+`content/docs/plugins/plugin-form.mdx` carried the same two defects
+`packages/plugin-form/README.md` did before it was rewritten (objectui#5075 /
+objectui#5118): the README half was fixed and the documentation-site mirror was
+not touched.
+
+`### Form Field` redeclared a local `interface FormField` whose `validation` was
+`ValidationRule[]`. No `ValidationRule` type exists in this repository under any
+spelling, and `validation` is not an array — it is `FieldValidationRules`
+(`packages/types/src/form.ts`), an object keyed by rule name. The block also
+listed `defaultValue` and `className`, neither of which is a declared member of
+`FormField`, and marked `type` and `label` required when `name` is the only
+required key of the 23. The section no longer declares a local interface at all
+— a hand-written `interface` in a documentation snippet compiles nowhere, which
+is how it drifted this far — and references the declared keys instead, each one
+measured against the renderer's read points.
+
+`### Form with Validation` authored the array to match, and that spelling fails
+silently rather than loudly. The only reader of the key spreads it into the rule
+object handed to react-hook-form (`const rules: any = { ...validation }`,
+`packages/components/src/renderers/form/form.tsx:1652`); spreading an array
+produces numeric keys, react-hook-form recognises none of them, and every rule
+is dropped without an error. Measured against the real renderer: the old snippet
+submits a two-character username under `minLength: 3` with no message shown,
+while the rewritten one blocks it. The example is now annotated `FormSchema`, so
+the array spelling is a compile error (TS2559) rather than a runtime surprise,
+and a JSON variant is given alongside it for metadata authoring.
+
+Three facts a reader could previously only discover by experiment are now
+stated: `validation.required` supplies the required *message* while `required` /
+`requiredWhen` on the field decide whether it is required; there is no `email`
+rule name, an email check is a `pattern`; and a hand-authored `pattern` has to
+carry a RegExp, because react-hook-form applies a pattern only when its value is
+`instanceof RegExp` — it is the object-metadata path (`buildValidationRules`)
+that compiles a declared string into one.
+
+The two `DOC_TYPE_EXEMPTIONS` entries this page held in
+`scripts/check-doc-component-types.mjs` are deleted with it. They exempted
+`minLength` / `maxLength` as "ValidationRule discriminants under a field's
+`validation[]`" — a reason whose every clause was the fiction being removed —
+and without them the gate now fails if the array spelling returns.

--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -48,19 +48,76 @@ npm install @object-ui/plugin-form
 
 ### Form Field
 
-```plaintext
-interface FormField {
-  name: string;
-  type: string;                   // 'input', 'select', 'checkbox', etc.
-  label: string;
-  placeholder?: string;
-  required?: boolean;
-  validation?: ValidationRule[];
-  defaultValue?: any;
-  disabled?: boolean;
-  className?: string;
-}
-```
+`FormField` is declared once, in `@object-ui/types`
+(`packages/types/src/form.ts`) — this page does not redeclare it, because a
+locally written `interface` compiles no matter how far it has drifted from the
+real one. It has **23 declared keys**, and `name` is the only **required** one:
+`type` and `label` are both optional.
+
+| Key | Type | What it does |
+| --- | --- | --- |
+| `name` | `string` | **required** — the key the value is submitted under |
+| `id` | `string` | stable render key; falls back to `name` |
+| `label` | `string` | optional. With none, no label element is rendered at all, and validation messages fall back to `name` |
+| `description` | `string` | help text rendered under the control |
+| `type` | `string` | optional, defaults to `'input'`. Built-ins: `input`, `textarea`, `checkbox`, `switch`, `select`; any other value resolves through the registry (`field:<type>` first, then the bare name) |
+| `inputType` | `string` | HTML input type for `type: 'input'` — `'email'`, `'password'`, `'tel'`, … |
+| `widget` | `string` | widget override; wins over `type` (spec `FormField.widget`) |
+| `placeholder` | `string` | placeholder text |
+| `required` | `boolean` | the presence rule. `validation.required` does **not** make a field required — it only supplies the message |
+| `disabled` | `boolean` | not interactive, muted |
+| `readonly` | `boolean` | shown plainly, not editable — deliberately distinct from `disabled` |
+| `hidden` | `boolean` | the field is not rendered at all |
+| `options` | `SelectOption[] \| RadioOption[]` | choices for `select` / radio fields |
+| `validation` | `FieldValidationRules` | **an object keyed by rule name** — see below |
+| `condition` | `FieldCondition` | legacy `{ field, equals, notEquals, in, custom }` matcher |
+| `visibleWhen` / `readonlyWhen` / `requiredWhen` | `string \| { dialect?, source }` | CEL predicates over the live record, evaluated by `@objectstack/formula` — the same engine and dialect the server enforces. They fail open |
+| `visibleOn` | `string \| { dialect?, source }` | view-level visibility predicate (spec `FormField.visibleOn`) |
+| `dependsOn` | `DependsOnInput` | cascading parent(s): a bare name, a list of names, or `{ field, param }` entries |
+| `span` | `'auto' \| 'full'` | relative field width, independent of the column count (preferred) |
+| `colSpan` | `number` | legacy column span (1–4), clamped to the current column count |
+| `field` | `Record<string, any>` | the resolved object-field **metadata object**, stashed by the object-bound paths so widgets can read `precision`, `currency`, `reference_to`, … |
+
+`FormField` also declares `[key: string]: any`, so a misspelled or invented key
+is **not** a compile error — it is simply outside the contract. Two that a
+reader might expect here, and that are **not** declared members:
+
+| Not a `FormField` key | Write this instead |
+| --- | --- |
+| `defaultValue` | `FormSchema.defaultValues`, at form level. An object-bound form seeds from the object field's own declared `defaultValue` instead |
+| `className` | `span` / `colSpan` for width, `FormSchema.fieldContainerClass` for the field grid |
+
+An undeclared key still rides the props spread down to whichever component the
+field resolves to, so a field-level `className` can visibly land on a built-in
+control — but nothing in the contract promises that, and a registered widget
+honours it only if it happens to spread its leftover props. A field-level
+`defaultValue` reaches the widget the same way and changes nothing: the control
+is bound to react-hook-form, whose initial values come from the form.
+
+#### `validation` is an object keyed by rule name
+
+There is no `ValidationRule` type in this repository, under any spelling. The
+type of the key is `FieldValidationRules` (`packages/types/src/form.ts`), and it
+is **not** an array of `{ type, value, message }` entries:
+
+| Rule | Type | Notes |
+| --- | --- | --- |
+| `required` | `string \| boolean` | supplies the required **message** only. Whether the field is required is decided by `required` / `requiredWhen` **on the field** |
+| `minLength` / `maxLength` | `{ value: number; message: string }` | text length |
+| `min` / `max` | `{ value: number; message: string }` | numeric range |
+| `pattern` | `{ value: string \| RegExp; message: string }` | hand-authored schemas must pass a **RegExp**: react-hook-form applies a pattern only when its value is `instanceof RegExp`. It is the object-metadata path (`buildValidationRules` in `@object-ui/fields`) that compiles a declared string into one, so a `pattern` string written straight into a plain `form` schema never runs |
+| `validate` | `(value) => boolean \| string \| Promise<boolean \| string>` | custom check; TypeScript-authored schemas only |
+
+There is no `email` rule name — an email check is a `pattern`, which is exactly
+what `buildValidationRules` emits for an object field of type `email`.
+
+**Why the array spelling fails silently.** The only reader of this key is the
+basic form renderer, which spreads it into the rule object it hands to
+react-hook-form — `const rules: any = { ...validation }`
+(`packages/components/src/renderers/form/form.tsx:1652`). Spreading an **array**
+into an object literal produces numeric keys (`{ '0': …, '1': … }`), and
+react-hook-form recognises none of them: every rule is dropped, nothing throws,
+and the form looks validated while validating nothing.
 
 ### Column width of a sectioned form
 
@@ -212,6 +269,65 @@ aggregate map among them.
 
 ### Form with Validation
 
+One `validation` object per field, keyed by rule name. The annotation is part of
+the example: `FormField` and `FormSchema` both carry an index signature, so an
+un-annotated `const schema = { … }` type-checks whatever is written in it, while
+`const signUpForm: FormSchema` makes a wrong `validation` shape a compile error.
+
+```typescript
+import type { FormSchema } from '@object-ui/types';
+
+const signUpForm: FormSchema = {
+  type: 'form',
+  fields: [
+    {
+      name: 'username',
+      type: 'input',
+      label: 'Username',
+      required: true,                    // the presence rule lives here, not in `validation`
+      validation: {
+        minLength: { value: 3, message: 'Min 3 characters' },
+        maxLength: { value: 20, message: 'Max 20 characters' },
+      },
+    },
+    {
+      name: 'email',
+      type: 'input',
+      inputType: 'email',
+      label: 'Email',
+      required: true,
+      validation: {
+        // No `email` rule name exists — an email check is a `pattern`, and its
+        // value has to be a RegExp for react-hook-form to apply it at all.
+        pattern: { value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, message: 'Enter a valid email address' },
+      },
+    },
+    {
+      name: 'password',
+      type: 'input',
+      inputType: 'password',
+      label: 'Password',
+      required: true,
+      validation: {
+        minLength: { value: 8, message: 'Min 8 characters' },
+        required: 'Choose a password',   // message only — `required: true` above is the rule
+      },
+    },
+  ],
+  submitLabel: 'Sign Up',
+};
+```
+
+Spelled as an array instead — `validation: [{ type: 'minLength', value: 3, … }]`
+— every rule is dropped in silence: the field above accepts `ab` and the form
+submits it with no message shown. Under the annotation that spelling is a
+compile error (TS2559, "no properties in common with type
+`FieldValidationRules`") rather than a runtime surprise; a JSON metadata
+document, which cannot be annotated, has only this page to go by.
+
+The same shape as JSON metadata — the length and range rules carry over
+unchanged:
+
 ```json
 {
   "type": "form",
@@ -221,25 +337,21 @@ aggregate map among them.
       "type": "input",
       "label": "Username",
       "required": true,
-      "validation": [
-        { "type": "minLength", "value": 3, "message": "Min 3 characters" },
-        { "type": "maxLength", "value": 20, "message": "Max 20 characters" }
-      ]
-    },
-    {
-      "name": "password",
-      "type": "input",
-      "inputType": "password",
-      "label": "Password",
-      "required": true,
-      "validation": [
-        { "type": "minLength", "value": 8, "message": "Min 8 characters" }
-      ]
+      "validation": {
+        "minLength": { "value": 3, "message": "Min 3 characters" },
+        "maxLength": { "value": 20, "message": "Max 20 characters" }
+      }
     }
   ],
   "submitLabel": "Sign Up"
 }
 ```
+
+`pattern` and `validate` are the two rules a JSON document cannot express on
+this path: JSON has no RegExp literal and no function, and a `pattern` string
+reaches react-hook-form as a string, which it ignores. An object-bound form
+(`object-form`) does not have that limitation — it compiles the object field's
+own declared `pattern` into a RegExp before the form ever sees it.
 
 ### Multi-Step Form
 

--- a/scripts/__tests__/check-doc-component-types.test.ts
+++ b/scripts/__tests__/check-doc-component-types.test.ts
@@ -471,3 +471,50 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
     expect(imports.every((spec) => spec.startsWith('node:')), `non-builtin import in the gate: ${imports}`).toBe(true);
   });
 });
+
+describe('objectui#5118 — the plugin-form page teaches the real `validation` shape', () => {
+  // The `type` literals this gate judges were only half the drift on that page.
+  // `### Form Field` redeclared a local `interface FormField` whose `validation`
+  // was `ValidationRule[]` — a type name that exists nowhere in this repository
+  // — and `### Form with Validation` authored the array to match. Neither half
+  // was visible to any check: a hand-written `interface` in a ```plaintext block
+  // compiles nowhere, and the array's `type: 'minLength'` / `'maxLength'` were
+  // EXEMPTED here, with a reason ("ValidationRule discriminant under a field's
+  // `validation[]`") that restated the fiction. Deleting those entries is what
+  // gives this gate teeth over the example half; this block pins the rest.
+  const page = path.join(repoRoot, 'content/docs/plugins/plugin-form.mdx');
+  const body = fs.readFileSync(page, 'utf8');
+
+  it('no longer authors `ValidationRule`, and says outright that it does not exist', () => {
+    // Same shape as the `multi-step-form` pin above: the page still NAMES the
+    // fiction in prose, to tell the reader it is one. What must not come back is
+    // the declaration a reader copies.
+    expect(body).not.toMatch(/validation\??\s*:\s*ValidationRule/);
+    expect(body).toContain('There is no `ValidationRule` type in this repository');
+  });
+
+  it('authors `validation` as an object keyed by rule name, never an array', () => {
+    // Prose may still SHOW the array spelling (it is the counterexample); an
+    // authored one — JSON or TS, in a snippet or a table — may not come back.
+    const authoredArrays = [...body.matchAll(/^\s*"?validation"?\s*:\s*\[/gm)];
+    expect(authoredArrays.map((m) => m[0].trim())).toEqual([]);
+    expect(body).toContain('"minLength": { "value": 3, "message": "Min 3 characters" }');
+    expect(body).toContain('| `validation` | `FieldValidationRules` |');
+  });
+
+  it('names types that are really declared, so the pin fails if one moves', () => {
+    const types = fs.readFileSync(path.join(repoRoot, 'packages/types/src/form.ts'), 'utf8');
+    expect(types).toContain('export interface FieldValidationRules {');
+    expect(types).toContain('validation?: FieldValidationRules;');
+    // The keys the page's rule table teaches, as the interface declares them.
+    for (const rule of ['required?:', 'minLength?:', 'maxLength?:', 'min?:', 'max?:', 'pattern?:', 'validate?:']) {
+      expect(types.slice(types.indexOf('export interface FieldValidationRules {'))).toContain(rule);
+    }
+    // `defaultValue` / `className` are named as NON-members; that is only true
+    // while the interface really omits them.
+    const formField = types.slice(types.indexOf('export interface FormField {'));
+    const declaredKeys = formField.slice(0, formField.indexOf('\n}'));
+    expect(declaredKeys).not.toMatch(/^\s{2}defaultValue\??:/m);
+    expect(declaredKeys).not.toMatch(/^\s{2}className\??:/m);
+  });
+});

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -312,10 +312,13 @@ const DOC_TYPE_EXEMPTIONS = {
     comment: 'FeedItem kind in a `FeedItem[]` literal — `@object-ui/types` activity feed vocabulary.',
     field_change: 'FeedItem kind in a `FeedItem[]` literal — activity feed vocabulary.',
   },
-  'content/docs/plugins/plugin-form.mdx': {
-    minLength: 'ValidationRule discriminant under a field\'s `validation[]`, not a node type.',
-    maxLength: 'ValidationRule discriminant under a field\'s `validation[]`, not a node type.',
-  },
+  // `content/docs/plugins/plugin-form.mdx` used to need `minLength` / `maxLength`
+  // exempted here, as "ValidationRule discriminants under a field's
+  // `validation[]`". Both halves of that reason were fiction (objectui#5118): no
+  // `ValidationRule` type exists in this repository, and `validation` is not an
+  // array — it is `FieldValidationRules`, an object keyed by rule name, so a
+  // rule never carries a `type` discriminant at all. The page now authors the
+  // real shape, which spells no `type` there, and the entries went stale.
   'content/docs/plugins/plugin-grid.mdx': {
     count_unique: 'Column summary aggregation under `columns[].summary`, not a node type.',
     multiple:


### PR DESCRIPTION
Fixes #5118

`content/docs/plugins/plugin-form.mdx` 的 `### Form Field` 参考块与
`### Form with Validation` 示例,是 #5075(README 半,已闭,PR #5100)的文档站镜像:
README 侧修完,`content/docs/**` 的同内容一行未碰。半径严格限于这两块 + 被它们连坐的
门表项 + changeset。

## 前提验证:卡面三条判断逐条复测,全部成立

**1. `ValidationRule` 这个类型名全仓不存在。** 声明式 grep 零命中:

```
git grep -nE "(export )?(declare )?(const|type|interface|class|enum) ValidationRule($|[^A-Za-z])" -- packages content
# rc=1,无输出
# (写成不含反斜杠转义的等价式,避免正文里的 backslash-b 落成真控制字节 —— #5140/#5157 的教训)
```

零命中的邻近词反查只找到 `ValidationRuleSchema`(spec 的**对象级** validations,
另一层)、`DesignerValidationRule`、`ObjectValidationRule`、`AdvancedValidationRule`、
`ValidationRuleDraft` —— 没有一个是 `FormField.validation` 的类型。裸名 `ValidationRule`
在改前全仓仅两处:本页 `:58`,以及 PR #5100 changeset 里记录这件事的那句话。
真身是 `FieldValidationRules`(`packages/types/src/form.ts:744`),按规则名开键的对象。

**2. 数组拼法正是让校验静默失效的那个写法。** 读点复核(行号未漂移):

```
packages/components/src/renderers/form/form.tsx:1651  // Build validation rules
packages/components/src/renderers/form/form.tsx:1652  const rules: any = {
packages/components/src/renderers/form/form.tsx:1653    ...validation,
```

数组展开进对象字面量得到数字键,而 react-hook-form 的字段校验器只解构固定集合:

```
spread keys = ["0","1"]
RHF destructure = {}            // required/maxLength/minLength/min/max/pattern/validate 全 undefined
```

**真渲染器实测**(`ComponentRegistry.get('form')` + testing-library,jsdom):旧片段原样
喂进去,`minLength: 3` 的字段拿到两字符值 `ab` —— 表单**提交成功**,payload
`{"username":"ab"}`,页面上零提示。改后的对象形同一输入被拦住,显示 `Min 3 characters`。

**3. `defaultValue` / `className` 未声明,`type` / `label` 可选。** 对 **dist 产物**
(`packages/types/dist/form.d.ts`,`pnpm --filter @object-ui/types build` 后)复测:

```
members: 24                       // 23 个声明键 + 1 个 [key: string]: any
REQUIRED (non-optional, excl index sig): ["name"]
has index signature: true
defaultValue declared: false
className declared: false
```

一处**对卡面措辞的实测修正**,已写进页面而不是照抄:卡面说这两键「被索引签名吞掉,
永不被读」。渲染器把未解构的剩余键 `...fieldProps` 一路转发给解析出的组件
(`form.tsx:2031`),实测一个字段级 `className` **确实**落到内置 input 的 class 上
(探针:`… md:text-sm PROBE-CLASS`)。所以准确的说法不是「永不被读」,而是「不在契约里」:
页面写的是它不是声明键、能不能落到元素上取决于组件是否透传、契约不做承诺。
`defaultValue` 则实测确实不播种(字段级 `defaultValue: 'Beijing'` 下输入框值为 `""`,
表单级 `defaultValues` 下为 `"Beijing"`)—— 控件由 react-hook-form 托管,初值来自表单。

## 改了什么

- `### Form Field`:**不再现场声明本地类型**。文档里手写的 `interface` 在任何地方都不
  参与编译,永远「编译通过」,这正是它漂移至此的成因(PR #5100 的教训)。改为对真身
  `FormField` 的键表引用(23 键,逐条对 dist 与读点亲测),外加一张「不是键」表
  (`defaultValue` / `className` 各自该写什么),以及 `FieldValidationRules` 的规则表。
- `### Form with Validation`:改成按规则名开键的对象,并带 `FormSchema` 类型标注 —— 标注
  本身是示例的一部分,因为 `FormField` / `FormSchema` 都有索引签名,不标注的
  `const schema = { … }` 写什么都过。另附一份 JSON 变体供元数据作者照抄,并写明
  `pattern` / `validate` 是 JSON 这条路表达不了的两条(JSON 没有正则字面量和函数)。
- 三条此前只能靠试出来的事实进页面:`validation.required` 只供**消息**、是否必填由字段
  的 `required` / `requiredWhen` 决定(读点 `delete rules.required` 在 `form.tsx:1700`);
  不存在 `email` 规则名,邮箱校验是 `pattern`;手写 schema 的 `pattern.value` 必须是
  RegExp。
- `scripts/check-doc-component-types.mjs`:本页那两条 `DOC_TYPE_EXEMPTIONS` 被**连坐**
  删除。它们以「ValidationRule discriminant under a field's `validation[]`」为由豁免
  `minLength` / `maxLength` —— 这句理由的每个分句都是本次要清掉的虚构。改后页面不再在
  代码块里拼这两个 `type` 字面量,条目按门自身的规则变 `stale-exemption`(实测先红),
  删掉后转绿。
- `scripts/__tests__/check-doc-component-types.test.ts`:加一个 #5118 的 pin(3 条断言),
  理由见下面的反向验证 (a)。

## 验证

| 项 | 结果 |
| --- | --- |
| `node scripts/check-doc-component-types.mjs` | rc=0,`✅ Every documented component type is registered.` |
| `node scripts/check-doc-links.mjs` | rc=0 |
| `node scripts/check-control-bytes.mjs` | rc=0(4551 个跟踪文本文件) |
| 改动文件自扫(`grep -naP` 控制字符类,覆盖门不扫的 0x01 一族) | 零命中 |
| `pnpm exec turbo run type-check --concurrency=2`(仓根,flock 串行) | **81/81 successful** |
| `pnpm exec vitest run scripts/__tests__/check-doc-component-types.test.ts` | 27 passed(含新增 3) |
| `node scripts/check-changeset-presence.mjs` | rc=0,`no changeset is owed`(见下) |

**changeset 自判**:门只守 fixed 组包的 `PKG/src/**`,本 PR 四个文件都不在其中,故
**不欠**。仍然补了一份 —— 这是一页已发布文档的实质重写,与 PR #5109(同形状,补了)
同级;PR #5119 那种 17 行的 import 更正没补,是另一个量级。

**改后示例 strict 编译**(从 mdx 里**按发布原文**抽出,`tsc --ignoreConfig --strict --noEmit`,
解析真实的 `@object-ui/types` dist):

```
=== example-good.ts ===            rc=0
=== neg-missing-name.ts ===        rc=2
  error TS2741: Property 'name' is missing in type '{ type: string; label: string; … }'
  but required in type 'FormField'.
=== neg-array-validation.ts ===    rc=2
  error TS2559: Type '{ type: string; value: number; message: string; }[]' has no
  properties in common with type 'FieldValidationRules'.
```

两个负控都按**事先书面预判**落地(TS2741 / TS2559),页面里引用的正是 TS2559 这条原文。

**名集合核对**:页面新引入的每个类型名都对 dist 复核 —— `FormField`、`FormSchema`、
`FieldValidationRules`、`FieldCondition`、`SelectOption`、`RadioOption`、`DependsOnInput`
七个全部 DECLARED,且都在 `packages/types/dist/index.d.ts` 的导出面上;
`buildValidationRules` 在 `packages/fields/src/index.tsx:2246` 导出;
`@objectstack/formula` 是 `resolveFieldRuleState` 真正 import 的引擎。

**探针分层(案头版)**:`FormField` / `FormSchema` 带索引签名 ⇒ 「未声明键」的探针绿
不作数,`defaultValue` / `className` 的证据是**声明成员表 + 读点 + 上面那条 className
实测**,不是探针;有牙的是必填键(TS2741)与字面量键(门的 `unregistered-doc-type`)。

## 反向验证(先书面预判,再跑;commit 后变异、跑完还原)

**(a) 旧块回填 —— 预判「按门分层」,实测与预判一致,含一条对本仓不利的实话。**
两半分开灌:

- **a1 只回填 `### Form Field` 旧参考块**(带 `ValidationRule[]`):预判**各门全绿**,
  实测 `check-doc-component-types` / `check-doc-links` / `check-control-bytes` 全部
  rc=0。原因是门只扫代码块里**带引号的** `type:` 字面量,而 `type: string;` 这种
  伪代码不带引号 —— **这一半在本仓没有任何既有门看得见**,虚构可以原样回潮而 CI 全绿。
  这就是本 PR 补 pin 测试的唯一理由:a1 之下只有新加的 pin 红(3 条中 2 条)。
- **a2 只回填 `### Form with Validation` 旧数组示例**:预判**红**,实测红 ——
  `content/docs/plugins/plugin-form.mdx:282 / :283  [unregistered-doc-type]  type
  'minLength' / 'maxLength' (json)`。诚实的一半:同一个变异拿 **baseline 的门文件**
  (0046d8f8c,豁免尚在)去跑是**绿**的。也就是说这一半的牙是本 PR 删豁免**新造**出来的,
  不是既有的。

**(b) 塞假名自证**:在 JSON 示例里把 `type` 改成 `form-5118-fake-name`,预判红 ——
实测 `content/docs/plugins/plugin-form.mdx:333  [unregistered-doc-type]  type
'form-5118-fake-name' (json)`,rc=1。证明本文件在门的判定面上是活的,前面的绿不是空绿。

**(c) 自选方向:改后为真的可运行证据。** 把**发布后的 JSON 块从 mdx 里读出来、直接喂给
真 form 渲染器**(不是手抄的副本):

```
[F] published JSON block = {"type":"form","fields":[{"name":"username","type":"input",
    "label":"Username","required":true,"validation":{"minLength":{"value":3,
    "message":"Min 3 characters"},"maxLength":{"value":20,"message":"Max 20 characters"}}}],
    "submitLabel":"Sign Up"}
[F] the published snippet blocked a 2-char username, as documented
```

配套的 `pattern` 方向也实测:string 值 —— 不匹配的值照样提交、零提示;RegExp 值 ——
拦住。探针是 scratch(`5118-` 前缀),已随收尾删除,不在本 PR 里。

## 与相邻卡的关系

- **#5075**(README 半,已闭)/ **PR #5100**:同族基准。事实**不盲抄** —— 键表与措辞全部
  对 dist 产物与读点亲测;上面那条 `className` 的措辞就是因此与 README 的括注不同。
- **PR #5119**(`8378e9954`,已在 main):同文件 TypeScript Support 块的 import 更正。
  本 PR 基线含它,**未碰该块**。
- **#5099**(运行期读点与类型契约,在决策箱):本 PR 只改文档,不动 `form.tsx:1652` 的
  读点、不动 `FieldValidationRules` 的声明。页面写的是**今天的真实行为**(手写面必须给
  RegExp),该说法在 #5099 选 A 或选 B 之下都不会变假;若 A 落地,只有规则表里
  `pattern` 那一格的类型串需要跟着收。
- 同文件 `### Multi-Step Form` 块由 #4823 的门 PR 修过并被 pin 住,本 PR 未碰,其 pin 仍绿。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_