### PR TITLE
docs(agents): AGENTS.md §9 gains the shared-scratchpad rule — keep commit messages and PR bodies off shared disk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,21 @@ AGENTS.md 的「只跑受影响的包」指的是**用上面的路径过滤缩�
   ```
 
   三者的共同点是**先把未提交状态捕获下来**再动工作区;任何「先覆盖、事后再从某个 ref 取回」的写法都**不是**替代做法 —— 它假设你的改动已经提交,而反向验证时通常没有(objectstack#7800:那条推荐语害一个 agent 丢了在途改动)。一个 **PreToolUse 钩子**(`.claude/hooks/guard-shared-stash.sh`)**强制**此规则:拦截 push/pop/drop/clear 共享栈的 `Bash` 命令,放行拿不到别人条目的形式 —— `git stash list`/`show`/`create`,以及 `git stash apply <sha>` / `store <sha>` 且 sha 为**字面十六进制 object id**(绝不用 `stash@{N}` —— 那是你并不拥有的那个栈里的一个**位置**)。确知栈只属于你时用 `OS_ALLOW_STASH=1` 放行;改了钩子就重跑 `.claude/hooks/guard-shared-stash.selftest.sh`。
+- **临时文件所在的 scratchpad 目录跨会话共享 —— 提交信息与 PR 正文一律别落到那里。** 容器发给每个会话的「scratchpad」临时目录事实上被多个并行会话映射到**同一个路径**,和上一条的 stash 栈同族:一块位于 worktree 之外的共享可写状态,worktree 隔离**管不到它**。两个 agent 各写一份同名的 `commitmsg.txt` / `pr-body.md`,后写的整份顶掉先写的;而 `git commit -F` 读到别人的文件**不报错**,每一步都报成功 —— 受害的是**另一个** agent 的产出(你的提交信息落到别人的 commit 上,你这边什么都看不出来),没有任何错误可供发现。实测在 20 分钟内撞了两次,可见的损伤是 `main` 上一条 squash commit:提交信息描述的是一张卡、diff 实施的是另一张卡,两者毫无关系;`main` 不重写,于是这条误导永久留在 git 考古里 —— 下一个人按 `git log --grep` 找那张卡,会得出「已经做过了」的错误结论。两条做法,**有先后之分**:
+
+  1. **首选机制:让内容根本不落共享盘。** 提交信息用 `git commit -F -` 配 heredoc(或多个 `-m`),PR 正文直接作为工具参数传(用 `gh` 就把正文写成进程内的 heredoc,别先写文件再 `--body-file`)。内容不落盘,就无从被顶掉。
+
+  ```bash
+  git commit -F - <<'"'"'EOF'"'"'
+  fix(scope): 一句话主题
+
+  正文……
+  EOF
+  ```
+
+  2. **次选纪律:确实需要临时文件时,文件名一律带卡号/分支号前缀**(该目录里既有的 `3309-pr.md` 就是这个惯例),**且用完即删**;写完要用之前先读回一遍,确认拿到的还是自己那份。
+
+  两条不是并列的两个建议:前缀与删除要求每个作者每一次都记得,记性会衰减,而衰减是静默的(见上:撞车不报错);`git commit -F -` 那种形式让撞车**不可能发生**,不依赖任何人的记性。所以能用形式解决的,就别退回到纪律。这一族目前**没有钩子**兜底(上面 worktree 与 stash 两条各有一个 PreToolUse 钩子),因此这条规则的全部效力就在于你选哪种形式。
 - **一个任务一个 feature 分支 + 一个 PR**;**绝不**把任务改动直接提交到 `main`。
 - **绝不 `git push --force`/`--force-with-lease`,绝不推 `main`**(会覆盖并行 agent 的工作;`main` 共享,一律走 PR)。
 - **每次 commit/push 前先确认当前分支**(`git rev-parse --abbrev-ref HEAD`);HEAD 可能被别的 agent 切走 —— 不是你的分支就停下重新 checkout。


### PR DESCRIPTION
Fixes #4994

Implements the recorded maintainer ruling (2026-08-17, verbatim 「同意」): **directions 1 + 2 together; direction 3 (a PreToolUse hook) is deferred until recurrence and is deliberately NOT built here.**

## What changed

One new bullet in `AGENTS.md` §9 多 agent 协作纪律, placed immediately after the `git stash` rule — the two belong to the same family: a shared writable state that sits *outside* worktree isolation. It is written as operative prose in place (failure mode, discipline, boundary), in the register of its two neighbours, and it cites no issue numbers in the operative sentences.

The rule carries its two halves **ranked, not paired**:

1. **Mechanism first (the load-bearing half)** — commit messages via `git commit -F -` with a heredoc, or repeated `-m`; PR bodies passed directly as tool arguments rather than written to a file first. Content that never lands on shared disk cannot be clobbered.
2. **Discipline second (the fallback)** — when a temp file is genuinely needed, the filename carries the card/branch prefix (the `3309-pr.md` convention already in that directory) and is deleted after use; read it back before using it.

The closing sentence states plainly *why* the order is what it is: prefix-and-delete asks every author to remember, every time, and that memory decays silently because the collision reports success at every step; the `git commit -F -` form makes the collision impossible and depends on nobody's memory. The bullet also states the boundary honestly — unlike the worktree rule and the stash rule, this family has **no hook** behind it, so the form you choose is the whole of the enforcement.

Measured facts carried as prose (no card pointers): two parallel agents collided on generic scratch names twice inside 20 minutes; the visible damage was a squash commit on `main` whose message describes one card and whose diff implements another; `main` is not rewritten, so the misdirection is permanent for git archaeology.

This PR dogfoods its own rule — the commit message was written through `git commit -F -` with a heredoc and this body was passed as a tool argument. Nothing transited the shared scratchpad.

## Out of scope, deliberately

- **No PreToolUse hook** (deferred by the ruling).
- **No history rewrite, `main` untouched.** The explanatory comment already on PR #4988 is the accepted record; the same one-liner has been added as a comment on #4016. Neither is a code change.
- No release-notes edit.

## Gates — union derived from the actual changed path (`AGENTS.md`), verbatim exit codes

objectui has no `dispatch-gates` equivalent, so the union was derived by reading each `check:*` script's scan surface and each workflow's triggers rather than recalled. All run at HEAD `19a816d`, which is the final commit of this branch.

| Gate | Why it is in the union | Result | Exit |
|---|---|---|---|
| `node scripts/check-doc-links.mjs` (`docs-links.yml`) | `SCAN_ROOTS` carries a literal `AGENTS.md` row (rule `disk`) | `Links are valid across 13 scan roots.` | `0` |
| `node scripts/check-control-bytes.mjs` (`control-bytes.yml`) | scans every tracked text file via `git ls-files` | `OK (scanned 4562 tracked text file(s); skipped 85 binary).` | `0` |
| `node scripts/check-changeset-presence.mjs` (`changeset-presence.yml`) | runs on every PR, path-unfiltered | `No source of a released package changed in this range, so no changeset is owed.` | `0` |
| `node scripts/check-skills-paths.mjs` (`skills-paths.yml`) | runs on every PR (scan root is `skills/`, so unaffected — run to confirm, not assumed) | `OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined).` | `0` |
| `node scripts/check-doc-component-types.mjs` (`doc-component-types.yml`) | runs on every PR (scans `.mdx`, so unaffected — run to confirm) | `Every documented component type is registered.` | `0` |

Self-scan for control characters beyond the gate: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' AGENTS.md` → no matches (exit `1`).

## Changeset

**None, and none is owed** — precedent followed is the gate's own verdict, quoted above: `check-changeset-presence.mjs` scopes the requirement to `packages/**` and `apps/**` sources, and a root-level `AGENTS.md` edit publishes nothing. objectui has no `skip-changeset` label mechanism (that label belongs to the framework repo); the declaration form here would be an empty-frontmatter changeset, and it is not needed because the gate does not ask for one. No label was created or applied.

## Reverse verification — prediction stated before running

**Predicted:** (a) the *substance* of this prose is unguarded — no gate evaluates what the rule says, so a wrong rule cannot go red; (b) the *bytes* are guarded — the added lines sit inside two gates' scan sets, so a machine-checkable defect inside the new block must go red.

**Observed:** both, as predicted.

- (a) is a true finding about the surface, reported rather than papered over: no gate in this repo reads these lines for meaning. `check-doc-links` resolves link targets, `check-control-bytes` inspects byte values; neither can tell a correct rule from an incorrect one. Substance review here is human review.
- (b) was proved by temporary mutation from the committed state: a relative link to a non-existent file inserted **inside the added block** turned `check-doc-links` red at the exact new line —

  ```
  Found 1 broken link (1 distinct target):
  - [example-relative] AGENTS.md:227 -> ./docs/does-not-exist-4994.md
  exit=1
  ```

  Restored with `git checkout` against the branch (the fix was committed first, so a real restore point existed), and the gate returned `Links are valid across 13 scan roots.` / exit `0`. The line number confirms the reach applies to the new prose, not merely to the file in general.

Draft on purpose: not marked ready, no auto-merge, not enqueued.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_