### PR TITLE
docs(plugin-report): teach the dataset-bound report as the sole authoring shape (#5047)

### DIFF
--- a/.changeset/plugin-report-docs-dataset-bound-5047.md
+++ b/.changeset/plugin-report-docs-dataset-bound-5047.md
@@ -1,0 +1,16 @@
+---
+'@object-ui/plugin-report': patch
+---
+
+docs(plugin-report): teach the dataset-bound report as the sole authoring shape
+
+`packages/plugin-report/README.md` and `content/docs/plugins/plugin-report.mdx`
+still taught the pre-9.0 query form (`objectName` + column-definition `columns` +
+`groupingsDown` / `groupingsAcross`) as the live way to write a report, and named
+three renderers plus `applyInMemoryAggregation` that were removed at the ADR-0021
+cutover. The current `ReportSchema` is strict and rejects that form outright, so
+every copyable example on both pages now authors the dataset-bound shape
+(`dataset` + `rows` / `columns` / `values`, `runtimeFilter`, `order`, `drilldown`,
+`chart`) through `defineReport`. Stored pre-9.0 documents keep one clearly
+labelled migration-only section describing the lossy bridge that renders them and
+the key-by-key direction of migration.

--- a/content/docs/plugins/plugin-report.mdx
+++ b/content/docs/plugins/plugin-report.mdx
@@ -1,14 +1,19 @@
 ---
 title: "Plugin Report"
-description: "Spec-driven reports for Object UI — Tabular, Summary, Matrix and Joined views over any object, with server-side aggregation, drill-down and printable export"
+description: "Dataset-bound reports for Object UI — tabular, summary, matrix and joined views over a semantic-layer dataset, with server-computed totals, declared ordering, drill-down and printable export"
 ---
 
 # @object-ui/plugin-report
 
-Spec-driven report engine for Object UI. Renders the four report variants
-defined by `@objectstack/spec` (`tabular` / `summary` / `matrix` / `joined`)
-on top of any `objectName`, with server-side aggregation, multi-level
-grouping, date bucketing, cell drill-down and printable export.
+Report engine for Object UI. It renders the four report variants defined by
+`@objectstack/spec` (`tabular` / `summary` / `matrix` / `joined`).
+
+Since the ADR-0021 single-form cutover a report is **dataset-bound**: it names a
+semantic-layer `dataset` and selects that dataset's measures (`values`) grouped
+by that dataset's dimensions (`rows`, and for a matrix also `columns`). Every
+name in a report is a name **defined in the dataset** — the report never
+declares an object, a field, an aggregate or a date bucket of its own, and the
+aggregation runs in the semantic layer rather than in the browser.
 
 ## Installation
 
@@ -18,173 +23,268 @@ pnpm add @object-ui/plugin-report
 
 ## At a glance
 
-| Variant   | What it shows                                   | Renderer              |
-| --------- | ----------------------------------------------- | --------------------- |
-| `tabular` | Flat rows, one per record                        | `SpecReportGrid`      |
-| `summary` | Grouped rows + aggregates (single axis)          | `SpecReportGrid`      |
-| `matrix`  | Pivot table — rows × columns + cell aggregates   | `MatrixRenderer`      |
-| `joined`  | Vertically stacked sub-reports (independent data)| `JoinedReportRenderer`|
+| Variant   | What it shows                                                                     |
+| --------- | --------------------------------------------------------------------------------- |
+| `tabular` | The selection as a flat list — `rows` + `values`, no totals                        |
+| `summary` | The same table plus a server-computed grand-total footer                           |
+| `matrix`  | A cross-tab: `rows` down × `columns` across, measures in the cells, plus subtotals |
+| `joined`  | A vertical stack of blocks, each its own dataset-bound table                       |
 
-All four are dispatched by a single `<ReportRenderer schema={...}>` based
-on `schema.type`. The same schema can also be embedded via the JSON
-component registry as `{ "type": "spec-report", "report": { ... } }` —
-the dispatcher unwraps either shape automatically.
+All four are dispatched by a single `<ReportRenderer schema={...} />`. The
+**declared `type` picks the presentation** — never the shape of the data that
+comes back. The same report can be embedded in any JSON schema tree as
+`{ "type": "spec-report", "report": { ... } }`; the dispatcher unwraps either
+shape.
+
+## The authoring shape
+
+| Key             | Type                              | Meaning                                                                        |
+| --------------- | --------------------------------- | ------------------------------------------------------------------------------ |
+| `name`          | `string` (required)               | Identifier, at least 2 characters.                                              |
+| `label`         | `string` \| `Record<string,string>` (required) | Display title; the record form is the i18n shape.                  |
+| `type`          | `tabular` \| `summary` \| `matrix` \| `joined` | Defaults to `tabular`.                                             |
+| `dataset`       | `string`                          | The semantic-layer dataset this report reads.                                   |
+| `rows`          | `string[]`                        | Dimension **names** to group down.                                              |
+| `columns`       | `string[]`                        | Dimension **names** across — the matrix pivot axis.                             |
+| `values`        | `string[]`                        | Measure **names** to display.                                                   |
+| `runtimeFilter` | filter condition                  | Scope filter, merged with any filter the host passes at render time.            |
+| `order`         | `{ by, direction }[]`             | Result ordering, most significant key first.                                    |
+| `drilldown`     | `boolean`                         | Defaults to `true`; set `false` to make rows and cells unclickable.             |
+| `chart`         | object                            | Embedded visualization over the same selection (see below).                     |
+| `blocks`        | report[]                          | `joined` only — the stacked sub-reports.                                        |
+
+The schema is **strict**: a key it does not declare is rejected, not ignored.
+`columns` in particular is a list of dimension *names* — passing column
+*definition objects* fails validation.
 
 ## Quick start
 
-```ts
-import type { ReportInput } from '@objectstack/spec/ui';
+`defineReport` validates the definition at authoring time, so a typo is a build
+error rather than an empty grid:
 
-export const OpportunitiesByStage: ReportInput = {
+```ts
+import { defineReport } from '@objectstack/spec/ui';
+
+export const OpportunitiesByStage = defineReport({
   name: 'opp_by_stage',
   label: 'Opportunities by Stage',
-  objectName: 'opportunity',
   type: 'summary',
-  columns: [
-    { field: 'stage',  label: 'Stage' },
-    { field: 'amount', label: 'Amount', aggregate: 'sum' },
-    { field: 'id',     label: 'Deals',  aggregate: 'count' },
-  ],
-  groupingsDown: [{ field: 'stage', sortOrder: 'asc' }],
-};
+  dataset: 'opportunity_pipeline',
+  rows: ['stage'],
+  values: ['amount_sum', 'deal_count'],
+});
 ```
+
+`amount_sum` and `deal_count` are measures the `opportunity_pipeline` dataset
+defines; `stage` is one of its dimensions. The report picks from that
+vocabulary and adds nothing to it.
 
 ```tsx
 import { ReportRenderer } from '@object-ui/plugin-report';
-<ReportRenderer schema={OpportunitiesByStage} dataSource={ds} />
+
+<ReportRenderer schema={OpportunitiesByStage} dataSource={dataSource} />
 ```
+
+The `dataSource` must implement `queryDataset(dataset, selection)`. A data
+source without it renders an explicit error — "This data source does not
+support dataset queries" — rather than an empty table.
 
 ## Matrix reports (row × column pivot)
 
-A `matrix` report adds `groupingsAcross` to create columns. Combined with
-`dateGranularity`, you get classic period pivots without writing any SQL:
+A `matrix` adds `columns`: a second list of **dimension names**, used as the
+across axis.
 
 ```ts
-export const PipelineByQuarter: ReportInput = {
-  name: 'pipeline_coverage_by_quarter',
-  objectName: 'opportunity',
+import { defineReport } from '@objectstack/spec/ui';
+
+export const PipelineByQuarter = defineReport({
+  name: 'pipeline_by_quarter',
+  label: 'Pipeline Coverage by Quarter',
   type: 'matrix',
-  columns: [{ field: 'amount', label: 'Pipeline', aggregate: 'sum' }],
-  groupingsDown:   [{ field: 'forecast_category', sortOrder: 'asc' }],
-  groupingsAcross: [{ field: 'close_date', dateGranularity: 'quarter', sortOrder: 'asc' }],
-};
+  dataset: 'opportunity_pipeline',
+  rows: ['forecast_category'],
+  columns: ['close_quarter'],
+  values: ['amount_sum'],
+});
 ```
 
-Supported `dateGranularity` values: `day` / `week` / `month` / `quarter` /
-`year`. The plugin routes these to the server-side aggregator via
-`POST /api/v1/data/:object/query` (spec `{ groupBy, aggregations }`
-shape). When the server can't natively bucket a granularity, the engine
-falls back to in-memory `applyInMemoryAggregation()` — fully transparent
-to the report author.
+Period pivots come from the **dataset**: `close_quarter` is a time dimension the
+dataset declares at that grain. A report cannot bucket a date itself — there is
+no per-grouping granularity key in the report shape, because the grain a
+measure is valid at is a property of the semantic layer, not of one report.
 
-`MatrixRenderer` renders row totals, column totals and grand total
-automatically and makes every cell click-drillable.
+Row subtotals, column subtotals and the grand total are **server-computed**: the
+selection asks for them and the renderer only places the pre-aggregated rows it
+is handed. It never re-combines bucketed values client-side, since measures like
+an average cannot be recombined without drifting from the semantic layer. An
+older server that returns no totals renders the plain cross-tab without the
+totals row and column, and a `matrix` that declares no `columns` degrades to the
+flat grouped table.
 
-## Joined reports (M3)
+## Joined reports
 
-A `joined` report stacks N independent sub-reports vertically — perfect
-for early-warning dashboards where each panel asks a different question
-about different data:
+A `joined` report stacks independent blocks vertically — each block is its own
+dataset-bound report, so different panels may read different datasets.
 
 ```ts
-export const CustomerChurnSignals: ReportInput = {
+import { defineReport } from '@objectstack/spec/ui';
+
+export const CustomerChurnSignals = defineReport({
   name: 'customer_churn_signals',
   label: 'Customer Churn Signals',
-  objectName: 'account',          // container default
   type: 'joined',
-  columns: [],                    // intentionally empty at container level
   blocks: [
     {
       name: 'at_risk_accounts',
       label: 'At-Risk Accounts',
       type: 'summary',
-      objectName: 'account',
-      columns: [{ field: 'id', label: 'Accounts', aggregate: 'count' }],
-      groupingsDown: [{ field: 'industry', sortOrder: 'asc' }],
-      filter: { is_active: true, last_activity_date: { $lt: '2026-04-19' } },
+      dataset: 'account_health',
+      rows: ['industry'],
+      values: ['account_count'],
+      runtimeFilter: { is_active: true },
     },
     {
       name: 'recently_lost',
       label: 'Recently Lost Opportunities',
       type: 'summary',
-      objectName: 'opportunity',  // different object than container — OK
-      columns: [
-        { field: 'amount', label: 'Lost Revenue', aggregate: 'sum' },
-        { field: 'id',     label: 'Deals',        aggregate: 'count' },
-      ],
-      groupingsDown: [{ field: 'owner', sortOrder: 'asc' }],
-      filter: { stage: 'closed_lost', close_date: { $gte: '2026-04-19' } },
+      dataset: 'opportunity_pipeline',
+      rows: ['owner'],
+      values: ['amount_sum', 'deal_count'],
+      runtimeFilter: { stage: 'closed_lost' },
     },
   ],
-};
+});
 ```
 
-Block inheritance rules:
-- `objectName` falls back to the container's if a block omits it.
-- `filter` is ANDed with the container's filter (block keys win on
-  collision).
-- Each block runs its own `useReportData()` call — failures are
-  isolated to that block.
-- `block.type` may be `tabular` / `summary` / `matrix` but **not**
-  `joined` (no recursive composition).
+Block rules, as the renderer applies them:
+
+- Each block names its **own** `dataset` — there is no container-level dataset to
+  inherit.
+- The container's `runtimeFilter` is merged into every block; the block's own
+  keys win on collision.
+- Each block orders itself through its own `order`; a joined container has no
+  report-level ordering to hand down.
+- A block's declared `type` picks its presentation, exactly as at top level, and
+  a block must not itself be `joined` (no recursion).
+
+## Ordering
+
+`order` is a list, most significant key first, and it is lowered onto the
+dataset selection — the **server** orders the query:
+
+```ts
+order: [
+  { by: 'stage', direction: 'asc' },
+  { by: 'amount_sum', direction: 'desc' },
+]
+```
+
+`by` names a dimension the report groups by or a measure it displays. Because
+the server sorts, ordering by a derived measure works and the sort applies to
+the whole result rather than to one fetched page. For a matrix the across axis
+reads left-to-right in row-arrival order, so ordering by the across dimension is
+what makes the columns come out in that order; declaring nothing still reads
+correctly, because a selected time dimension defaults to ascending.
+
+## Embedded chart
+
+A report may carry a `chart` object rendered over the same selection. Its
+`type` is one of the spec's chart names, and `xAxis` / `yAxis` are **bare
+dimension and measure names** taken from the report's own selection — not field
+paths and not expressions. `title`, `subtitle`, `series`, `colors`, `height`,
+`showLegend`, `showDataLabels`, `annotations` and `interaction` are passed
+through as authored. See the [package README](https://github.com/objectstack-ai/objectui/tree/main/packages/plugin-report)
+for a complete `chart` block.
 
 ## Drill-down
 
-Every aggregated row / cell is drill-aware. When the user clicks a cell,
-the renderer dispatches a `drill` action (built by `buildDrillAction`)
-through the host's `ActionRunner`. The default handler opens the
-underlying records:
+Drill-down is a **host callback**, not a registered handler. Pass `onDrill` and
+every aggregated row and matrix cell becomes clickable; supply nothing and
+nothing is clickable. The report emits *what was clicked* and the host decides
+where that goes, because the renderer only knows dimension names:
 
 ```tsx
-import { registerDrillHandler } from '@object-ui/plugin-report';
-registerDrillHandler(actionRunner, { navigate: router.push });
+import { ReportRenderer, type DatasetDrillArgs } from '@object-ui/plugin-report';
+
+<ReportRenderer
+  schema={OpportunitiesByStage}
+  dataSource={dataSource}
+  onDrill={(args: DatasetDrillArgs) => {
+    const filter = { ...args.objectFilter, ...args.runtimeFilter };
+    router.push(`/records/${args.object}?filter=${encodeURIComponent(JSON.stringify(filter))}`);
+  }}
+/>
 ```
 
-Two drill targets are supported:
+| `DatasetDrillArgs` | Meaning                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------- |
+| `dataset`          | Dataset the clicked aggregate was computed over.                                     |
+| `groupKey`         | Dimension **name** → clicked bucket value (row dimensions, plus across dimensions for a matrix cell). |
+| `runtimeFilter`    | The effective render-time scope filter, if any.                                      |
+| `object`           | The dataset's base object, when the server supplied it.                              |
+| `objectFilter`     | Exact record-list filter (object **field** name → raw stored value) for the clicked bucket, present only when the server returned the dimension→field mapping and the raw grouped values. It is what lets select and lookup dimensions filter precisely instead of by display label. |
 
-1. **List view** (default): navigates to `/console/apps/<app>/<object>?filter=...`
-2. **Report drawer** (M3): if the calling widget (e.g., a Dashboard
-   pivot) declares `drillDown.report`, the click opens a side drawer
-   that renders that report with the cell's group key merged into its
-   filter — composing **dashboard → report → record** in three clicks.
+A report can opt out with `drilldown: false` even when the host passes
+`onDrill`.
 
-## Server-side aggregation (M3)
+## Where the numbers come from
 
-`useReportData()` translates a `Report` into a spec `QueryAST`
-(`{ groupBy, aggregations, where, limit }`) and posts it to
-`POST /api/v1/data/:object/query`. The framework routes the request
-through `engine.aggregate()`, which **pushes structured `groupBy`
-entries** (`{ field, dateGranularity }`) down to the driver as native
-SQL date functions:
+The renderer posts one dataset selection — dimensions, measures, and optionally
+`runtimeFilter`, `totals` and `order` — through `dataSource.queryDataset`. That
+is the same governed path dataset-bound dashboard widgets and the dataset
+preview use, which is why a number shown in a report matches the same number
+shown on a dashboard.
 
-| Dialect    | `day` / `month` / `quarter` / `year` | `week` (ISO-8601) |
-| ---------- | ------------------------------------ | ----------------- |
-| PostgreSQL | `to_char(... AT TIME ZONE 'UTC', ...)` | ✅ `IYYY-"W"IW`  |
-| MySQL      | `date_format(convert_tz(...), ...)`  | ✅ `%x-W%v`      |
-| SQLite     | `strftime(...)`                      | ⚠️ in-memory fallback (no `%V`) |
+Presentation follows from what the server returns: column headers use the
+dataset's server-supplied display label, and measure cells are formatted with
+the field's declared currency and numeral format rather than the raw measure
+name.
 
-The driver advertises per-granularity support via
-`supports.queryDateGranularity`. When a granularity isn't supported by
-the current dialect (notably `week` on SQLite), the engine transparently
-falls back to fetching raw rows and bucketing in-memory with
-`bucketDateValue()` — the resulting group key strings are
-**byte-for-byte identical** so drill filters compose without drift.
+## Stored pre-9.0 documents — migration only
 
-If the endpoint is unavailable or returns an error, the hook
-**transparently degrades** to `dataSource.find()` + client-side
-aggregation. No application code changes required.
+<Callout type="warn" title="Not an authoring option">
+  **This section is about documents that already exist in storage. The shape it
+  describes is not available for authoring.** Everything above is how a report is
+  written; nothing below is.
+</Callout>
 
-## Filter-time date helpers (current limitation)
+Before the ADR-0021 cutover a report carried its own query: an `objectName`,
+`columns` as column definition objects with `aggregate`, and
+`groupingsDown` / `groupingsAcross` with `sortOrder` and `dateGranularity`.
+That form is **rejected by the current schema** — `objectName` and
+`groupingsDown` come back as unrecognized keys, and object-shaped `columns`
+fails as the wrong type.
 
-> ⚠️ **Heads-up:** the server does **not** currently evaluate
-> ``cel`...` `` expressions embedded inside filter values (e.g.
-> ``{ close_date: { $gte: cel`daysAgo(30)` } }``). The unevaluated
-> template object reaches the SQL driver and triggers
-> `SQLite3 can only bind numbers, strings, bigints, buffers, and null`.
+Stored documents in that shape still render, through a deliberately lossy
+bridge: the dispatcher converts them to a presentation-layer report and hands
+them to the viewer. The conversion reads the *current* keys, so a pre-9.0
+document arrives with none of them — what it produces is the report's title and
+an **empty column set**. The document renders; its columns, groupings,
+aggregates and sort do not. There is no diagnostic, which is exactly why the
+bridge is a waiting room and not a supported way to write a report.
 
-**Workaround pattern** (used by the bundled CRM `customer_churn_signals`
-demo): compute concrete ISO date strings at module load time and treat
-the report as a snapshot of "now".
+Migrating one is a re-expression against the dataset:
+
+| Pre-9.0 key                                    | Where it goes now                                                     |
+| ---------------------------------------------- | --------------------------------------------------------------------- |
+| `objectName`                                   | Gone from the report — the `dataset` owns the object.                  |
+| `columns: [{ field, aggregate }]`              | `values: string[]`; the aggregate becomes a **measure** in the dataset.|
+| `columns: [{ field }]` (non-aggregated)        | `rows: string[]`, as a dimension.                                      |
+| `groupingsDown: [{ field }]`                   | `rows: string[]`.                                                      |
+| `groupingsAcross: [{ field }]`                 | `columns: string[]`.                                                   |
+| `sortOrder` on a grouping                      | `order: [{ by, direction }]` on the report.                            |
+| `dateGranularity` on a grouping                | A time dimension declared at that grain **in the dataset**.            |
+| `filter`                                       | `runtimeFilter`.                                                       |
+
+The work that has no mechanical equivalent is the dataset itself: measures and
+time dimensions the old report declared inline have to exist in the semantic
+layer before the migrated report can name them.
+
+## Filter-time date helpers — current limitation
+
+The server does **not** currently evaluate `` cel`...` `` expressions embedded
+inside filter values; the unevaluated template object reaches the driver.
+Compute concrete ISO date strings instead and treat the report as a snapshot:
 
 ```ts
 // Module-load helper. Re-evaluates each time the app boots.
@@ -194,76 +294,37 @@ const daysAgo = (n: number): string => {
   return d.toISOString().slice(0, 10); // 'YYYY-MM-DD'
 };
 
-filter: {
-  is_active: true,
-  last_activity_date: { $lt: daysAgo(60) },
-}
+runtimeFilter: { last_activity_date: { $lt: daysAgo(60) } }
 ```
 
-For long-lived processes that need a sliding window, recompute the
-report on each page render (the hook re-runs on filter change) or wrap
-the date helper in a `useMemo` keyed on a 1-hour bucket.
-
-Native CEL filter-time evaluation is tracked for a future major version
-alongside server-side schedule execution.
-
-## Type-aware cell rendering
-
-Report cells use the shared `getCellRenderer` registry from
-`@object-ui/fields`, the same renderer used by `ObjectGrid` and list
-views. Each column gets the right component for its type —
-`select` becomes a coloured `Badge`, `lookup` becomes a deep link,
-`boolean` becomes ✓/✗, `email`/`url`/`phone` become `mailto:`/external/
-`tel:` links, `image` becomes a thumbnail, and so on.
-
-When a report binds an `objectName`, columns auto-hydrate `type`,
-`options`, `referenceTo`, and `label` from the underlying object so
-authors don't need to duplicate field metadata. Per-column overrides
-always win.
-
-```ts
-{
-  name: 'contacts_by_account',
-  objectName: 'contact',
-  columns: [
-    { field: 'email' },       // mailto: link
-    { field: 'phone' },       // tel: link
-    { field: 'is_primary' },  // ✓/✗
-    { field: 'status' },      // Badge with option color
-    { field: 'account' },     // Linked account record
-  ],
-}
-```
+For a sliding window, recompute on each render or key a `useMemo` on a one-hour
+bucket. Native filter-time CEL evaluation is tracked for a future major version.
 
 ## Schema-driven embedding
 
-Components auto-register with `ComponentRegistry` on import. To embed a
-report inside any JSON schema tree:
+Importing the package registers three component types with `ComponentRegistry`:
+`report` and `spec-report` (both the dispatcher) and `report-viewer` (the
+presentation-layer viewer). To embed a report in any JSON schema tree:
 
 ```json
 {
   "type": "spec-report",
   "report": {
     "name": "opp_by_stage",
-    "objectName": "opportunity",
+    "label": "Opportunities by Stage",
     "type": "summary",
-    "columns": [{ "field": "amount", "aggregate": "sum" }],
-    "groupingsDown": [{ "field": "stage" }]
+    "dataset": "opportunity_pipeline",
+    "rows": ["stage"],
+    "values": ["amount_sum"]
   }
 }
 ```
 
-The dispatcher unwraps `{type:'spec-report', report:{...}}` and routes
-the inner `type` (`summary`/`matrix`/`joined`) to the correct renderer.
-Passing the report as the top-level schema also works:
-
-```json
-{ "type": "summary", "name": "...", "objectName": "...", "columns": [...] }
-```
+There is no `report-builder` component type: report authoring lives in the
+console designer, not in this package.
 
 ## Further reading
 
 - 📦 [`@object-ui/plugin-report` on npm](https://www.npmjs.com/package/@object-ui/plugin-report)
 - 📝 [Package README](https://github.com/objectstack-ai/objectui/tree/main/packages/plugin-report)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)
-

--- a/packages/plugin-report/README.md
+++ b/packages/plugin-report/README.md
@@ -6,11 +6,11 @@ Report components for Object UI — render, view and export reports, with schedu
 
 - 🧩 **Four spec report variants** — `tabular` / `summary` / `matrix` / `joined`, dispatched by a single `<ReportRenderer schema={...}>`
 - 🧮 **Server-side aggregation** — a dataset-bound report selects measures by name through `dataSource.queryDataset`; totals come back pre-aggregated (ADR-0021)
-- 📅 **Date bucketing** — `dateGranularity: day|week|month|quarter|year` on `groupingsAcross` / `groupingsDown`
-- 🪜 **Multi-level grouping + totals** — row totals, column totals, grand totals for matrix; tabular/summary delegate to `ObjectGrid`
+- 📅 **Period pivots** — the across axis is a dimension the dataset declares at the grain it needs; a report buckets nothing itself
+- 🪜 **Multi-level grouping + totals** — row subtotals, column subtotals and grand total for `matrix`, a grand-total footer for `summary`, all server-computed
 - 🎯 **Cell drill-down** — aggregated rows and matrix cells emit `DatasetDrillArgs` to the host's `onDrill` callback; the host owns navigation (ADR-0021 D2)
-- 🧱 **Joined reports** — vertically stacked sub-reports; each block owns its own `objectName`, filter and data fetch
-- 🎨 **Type-aware cells** — `select` → Badge, `lookup` → link, `boolean` → ✓/✗, `email`/`url`/`phone` → links, `image` → thumbnail (auto-hydrated from object metadata)
+- 🧱 **Joined reports** — vertically stacked sub-reports; each block names its own `dataset`, filter and ordering
+- 🎨 **Type-aware cells** — the presentation-layer `ReportViewer` renders `select` → Badge, `lookup` → link, `boolean` → ✓/✗, `email`/`url`/`phone` → links, `image` → thumbnail
 - 🖨️ **Multi-format export** — CSV, JSON, HTML, PDF, Excel; live-data and Excel-formula variants
 - 📦 **Auto-registered** — components register with `ComponentRegistry` on import; embed via `{ "type": "spec-report", "report": {...} }`
 
@@ -82,68 +82,157 @@ function LegacyReportPage() {
 
 ## Spec Reports — the four variants
 
-The plugin renders any `Report` defined by `@objectstack/spec`:
+A report is **dataset-bound**: it names a semantic-layer `dataset` and selects
+that dataset's measures (`values`) grouped by its dimensions (`rows`, and for a
+matrix also `columns`). Every name in a report is a name the dataset defines —
+the report declares no object, no field, no aggregate and no date bucket of its
+own. `defineReport` validates at authoring time and returns the parsed shape
+`ReportRenderer` takes as `schema`:
 
 ```ts
-import type { ReportInput } from '@objectstack/spec/ui';
+import { defineReport } from '@objectstack/spec/ui';
 import { ReportRenderer } from '@object-ui/plugin-report';
 
-const report: ReportInput = {
+const report = defineReport({
   name: 'opp_by_stage',
-  objectName: 'opportunity',
+  label: 'Opportunities by Stage',
   type: 'summary',
-  columns: [
-    { field: 'stage' },
-    { field: 'amount', aggregate: 'sum' },
-    { field: 'id', label: 'Deals', aggregate: 'count' },
-  ],
-  groupingsDown: [{ field: 'stage', sortOrder: 'asc' }],
-};
+  dataset: 'opportunity_pipeline',
+  rows: ['stage'],
+  values: ['amount_sum', 'deal_count'],
+  order: [{ by: 'amount_sum', direction: 'desc' }],
+});
 
 <ReportRenderer schema={report} dataSource={ds} />
 ```
 
-| `type`    | Description                                          |
-| --------- | ---------------------------------------------------- |
-| `tabular` | Flat record list                                     |
-| `summary` | Single-axis grouped + aggregated                     |
-| `matrix`  | Row × column pivot with cell aggregates and totals   |
-| `joined`  | Vertically stacked sub-reports, each with own data   |
+| Key             | Type                                           | Meaning                                                          |
+| --------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
+| `name`          | `string` (required)                            | Identifier, at least 2 characters.                                |
+| `label`         | `string` \| `Record< string, string >` (required) | Display title; the record form is the i18n shape.              |
+| `type`          | `tabular` \| `summary` \| `matrix` \| `joined` | Defaults to `tabular`.                                          |
+| `dataset`       | `string`                                       | The dataset this report reads.                                    |
+| `rows`          | `string[]`                                     | Dimension **names** to group down.                                |
+| `columns`       | `string[]`                                     | Dimension **names** across — the matrix pivot axis.               |
+| `values`        | `string[]`                                     | Measure **names** to display.                                     |
+| `runtimeFilter` | filter condition                               | Scope filter, merged with the filter the host passes at render.    |
+| `order`         | `{ by, direction }[]`                          | Result ordering, most significant key first.                      |
+| `drilldown`     | `boolean`                                      | Defaults to `true`.                                               |
+| `chart`         | object                                         | Embedded visualization over the same selection.                   |
+| `blocks`        | report[]                                       | `joined` only — the stacked sub-reports.                          |
+
+The schema is **strict**: a key it does not declare is rejected, not ignored.
+
+| `type`    | Description                                                                    |
+| --------- | ------------------------------------------------------------------------------ |
+| `tabular` | The selection as a flat list — `rows` + `values`, no totals                     |
+| `summary` | The same table plus a server-computed grand-total footer                        |
+| `matrix`  | Cross-tab: `rows` down × `columns` across, measures in the cells, plus subtotals |
+| `joined`  | A vertical stack of blocks, each its own dataset-bound table                    |
+
+The **declared type** picks the presentation — never the shape of the data that
+comes back.
 
 ### Matrix (row × column pivot)
 
+`columns` is a second list of dimension **names**, used as the across axis:
+
 ```ts
-{
+import { defineReport } from '@objectstack/spec/ui';
+
+defineReport({
   name: 'pipeline_by_quarter',
-  objectName: 'opportunity',
+  label: 'Pipeline Coverage by Quarter',
   type: 'matrix',
-  columns: [{ field: 'amount', label: 'Pipeline', aggregate: 'sum' }],
-  groupingsDown:   [{ field: 'forecast_category' }],
-  groupingsAcross: [{ field: 'close_date', dateGranularity: 'quarter' }],
-}
+  dataset: 'opportunity_pipeline',
+  rows: ['forecast_category'],
+  columns: ['close_quarter'],
+  values: ['amount_sum'],
+});
 ```
 
-`dateGranularity` accepts `day | week | month | quarter | year` and is
-pushed down to the server-side aggregator.
+`close_quarter` is a time dimension the **dataset** declares at that grain. A
+report cannot bucket a date itself: the grain a measure is valid at belongs to
+the semantic layer, not to one report. A `matrix` with no `columns` degrades to
+the flat grouped table.
 
-### Joined (M3)
+### Joined
 
 ```ts
-{
+import { defineReport } from '@objectstack/spec/ui';
+
+defineReport({
   name: 'churn_signals',
-  objectName: 'account',          // container default
+  label: 'Customer Churn Signals',
   type: 'joined',
-  columns: [],
   blocks: [
-    { name: 'at_risk', type: 'summary', columns: [...], filter: {...} },
-    { name: 'lost',    type: 'summary', objectName: 'opportunity', columns: [...], filter: {...} },
+    {
+      name: 'at_risk',
+      label: 'At-Risk Accounts',
+      type: 'summary',
+      dataset: 'account_health',
+      rows: ['industry'],
+      values: ['account_count'],
+      runtimeFilter: { is_active: true },
+    },
+    {
+      name: 'lost',
+      label: 'Recently Lost',
+      type: 'summary',
+      dataset: 'opportunity_pipeline',
+      rows: ['owner'],
+      values: ['amount_sum'],
+      runtimeFilter: { stage: 'closed_lost' },
+    },
   ],
-}
+});
 ```
 
-Block rules: `objectName` falls back to the container; `filter` is ANDed
-with the container's; each block runs an isolated `useReportData()` call;
-`block.type` must not be `joined` (no recursion).
+Block rules: every block names its **own** `dataset` (there is no container
+dataset to inherit); the container's `runtimeFilter` is merged into each block
+and the block's own keys win; each block orders itself through its own `order`;
+a block's declared `type` picks its presentation; `block.type` must not be
+`joined` (no recursion).
+
+### Ordering
+
+`order` is a list, most significant key first, lowered onto the dataset
+selection so the **server** orders the query — which is why ordering by a
+derived measure works and the sort applies to the whole result rather than to
+one fetched page. `by` names a dimension the report groups by or a measure it
+displays. For a matrix the across axis reads left-to-right in row-arrival
+order, so ordering by the across dimension is what fixes the column order;
+declaring nothing still reads correctly, because a selected time dimension
+defaults to ascending.
+
+### Embedded chart
+
+`chart.type` is one of the spec's chart names; `xAxis` / `yAxis` are **bare
+dimension and measure names** from the report's own selection, not field paths
+and not expressions:
+
+```ts
+import { defineReport } from '@objectstack/spec/ui';
+
+defineReport({
+  name: 'pipeline_by_stage',
+  label: 'Pipeline by Stage',
+  type: 'summary',
+  dataset: 'opportunity_pipeline',
+  rows: ['stage'],
+  values: ['amount_sum'],
+  chart: {
+    type: 'bar',
+    title: 'Pipeline by Stage',
+    xAxis: 'stage',
+    yAxis: 'amount_sum',
+    showLegend: false,
+  },
+});
+```
+
+`series`, `colors`, `height`, `showDataLabels`, `annotations` and `interaction`
+are passed through to the chart as authored.
 
 ## Server-side aggregation + drill-down
 
@@ -201,11 +290,54 @@ const daysAgo = (n: number): string => {
   return d.toISOString().slice(0, 10);
 };
 
-filter: { close_date: { $gte: daysAgo(30) } }
+runtimeFilter: { close_date: { $gte: daysAgo(30) } }
 ```
 
 See the bundled CRM `customer_churn_signals` demo for the full pattern.
 Native filter-time CEL evaluation is tracked for a future major version.
+
+## Stored pre-9.0 documents — migration only
+
+> ⚠️ **This section is about documents that already exist in storage. The shape
+> it describes is NOT available for authoring** — everything above is how a
+> report is written, nothing here is.
+
+Before the ADR-0021 cutover a report carried its own query: an `objectName`,
+`columns` as column *definition objects* with `aggregate`, and
+`groupingsDown` / `groupingsAcross` with `sortOrder` and `dateGranularity`.
+That form is **rejected by the current schema** — `objectName` and
+`groupingsDown` come back as unrecognized keys, and object-shaped `columns`
+fails as the wrong type (`columns` is now a list of dimension names).
+
+Stored documents in that shape still render, through a deliberately lossy
+bridge: `ReportRenderer` converts them to a presentation report and hands that
+to `ReportViewer`. The converter reads the *current* keys (`values`, `rows`), so
+a pre-9.0 document arrives with none of them and what comes out is the report's
+title over an **empty column set**. The document renders; its columns,
+groupings, aggregates and sort do not, and nothing reports an error. That is why
+the bridge is a waiting room rather than a supported way to write a report.
+
+Migrating one is a re-expression against the dataset:
+
+| Pre-9.0 key                        | Where it goes now                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------- |
+| `objectName`                       | Gone from the report — the `dataset` owns the object.                    |
+| `columns: [{ field, aggregate }]`  | `values: string[]`; the aggregate becomes a **measure** in the dataset.  |
+| `columns: [{ field }]`             | `rows: string[]`, as a dimension.                                        |
+| `groupingsDown: [{ field }]`       | `rows: string[]`.                                                        |
+| `groupingsAcross: [{ field }]`     | `columns: string[]`.                                                     |
+| `sortOrder` on a grouping          | `order: [{ by, direction }]` on the report.                              |
+| `dateGranularity` on a grouping    | A time dimension declared at that grain **in the dataset**.              |
+| `filter`                           | `runtimeFilter`.                                                         |
+
+The part with no mechanical equivalent is the dataset itself: measures and time
+dimensions the old report declared inline must exist in the semantic layer
+before the migrated report can name them.
+
+The query-form renderers that used to draw these documents inline
+(`SpecReportGrid`, `MatrixRenderer`, `JoinedReportRenderer`) were removed at the
+cutover and have no replacement export — the bridge above is what renders a
+stored old-shape document now.
 
 ## Legacy presentation layer
 
@@ -406,40 +538,11 @@ component appropriate for its type — instead of `String(value)`.
 | `richtext` / `html` / `markdown` | Sanitised inline content                   |
 | `json`                        | Collapsed code preview                        |
 
-Authors do **not** need to repeat type metadata on every report column:
-when a report binds an `objectName`, the runtime auto-hydrates each
-column's `type`, `options`, `referenceTo`, and `label` from the
-corresponding `ObjectField`. Author-provided values always win.
-
-Minimal report leveraging type-aware cells:
-
-```ts
-import type { ReportInput } from '@objectstack/spec/ui';
-
-export const ContactsReport: ReportInput = {
-  name: 'contacts_by_account',
-  label: 'Contacts by Account',
-  objectName: 'contact', // ← enables auto-hydration
-  type: 'tabular',
-  columns: [
-    { field: 'full_name', label: 'Name' },
-    { field: 'email',      label: 'Email' },     // → mailto:
-    { field: 'phone',      label: 'Phone' },     // → tel:
-    { field: 'is_primary', label: 'Primary' },   // → ✓/✗
-    { field: 'account',    label: 'Account' },   // → linked record
-    { field: 'status',     label: 'Status' },    // → Badge with option color
-  ],
-};
-```
-
-Override per column when needed:
-
-```ts
-columns: [
-  { field: 'tier', label: 'Tier', type: 'select',
-    options: [{ value: 'gold', label: 'Gold', color: 'amber' }] },
-]
-```
+These are presentation-layer columns: each entry in `report.fields` carries its
+own `name`, `label` and `type`, and that declared `type` is what selects the
+renderer. This package resolves nothing from object metadata — there is no
+`objectName` on a report to hydrate from, and a column with no `type` renders
+as plain text.
 
 Legacy `renderAs: 'badge'` + `colorMap` is still honoured for plain
 string columns.


### PR DESCRIPTION
Fixes #5047

Implements the recorded maintainer ruling (2026-08-17, 「同意」): **migrate**. The
dataset-bound form becomes the sole authoring shape in both documents; the pre-9.0
query form survives only as one clearly labelled migration-only section. Docs only —
no `plugin-report` behaviour changed, the lossy bridge untouched, no release notes.

Base: `958d757`. Union run at `fc93cc7` (the final commit).

## The card's premise, re-derived from code

The card is correct, and the code is harsher than the prose it describes.

| Claim | Reading |
| --- | --- |
| Three renderers retired | ✅ `SpecReportGrid` / `MatrixRenderer` / `JoinedReportRenderer` — **zero implementation repo-wide**. The only source hit is the retirement comment at `ReportRenderer.tsx:17-18` itself. |
| `applyInMemoryAggregation` gone | ✅ Zero hits anywhere in the repo *except* the mdx that taught it — not even a retirement comment. |
| Query form is "silently degraded" | ✅ and sharper — see the bridge measurement below. |

**Discrepancy check the dispatch asked for: none.** All four names the card lists are
genuinely retired. Two names the card did **not** list turned out to be dead as well,
both inside the two documents in scope:

- `ReportInput` — both documents imported `import type { ReportInput } from '@objectstack/spec/ui'`.
  That symbol is **not on the spec's export surface** at 17.0.0 (0 occurrences in
  `dist/ui/index.d.ts`; the export list carries `Report`, `ReportParsed`, `ReportSchema`,
  `defineReport`). Every typed example in both files was annotated with a type that does
  not exist.
- `registerDrillHandler` — a fabricated export of this package, still live in the **mdx**
  at HEAD. #5053 fixed the README half; nothing ever touched the mdx half.

## Measured, not inferred

**1. The old form is rejected, not merely unsupported.** `ReportSchema` is `z.core.$strict`.
Running the mdx's own Quick-start literal through it:

```
unrecognized_keys: Unrecognized key(s) on this report: `objectName`, `groupingsDown`
invalid_type @columns.0: Invalid input: expected string, received object
```

`columns` was **repurposed**, not removed: it is now a list of across-dimension *names*.
An author copying the old prose writes `columns: [{ field: 'amount' }]` into a key that
now means something else — the most dangerous shape of stale doc there is.

The spec even names the replacement for the filter key itself:

```
unrecognized_keys: ... `filter`. Did you mean `filter` -> `runtimeFilter`?
```

**2. The bridge is lossier than "renders differently".** `specReportToPresentation` reads
the **current** keys (`values`, `rows`), which a pre-9.0 document does not have. Measured
on the built artifact with the card's own example document:

```
isSpecReport(stored) = true
bridge output = { "type": "report", "title": "Opportunities by Stage",
                  "reportType": "summary", "fields": [] }
```

Title and report type survive; **every column and grouping is dropped**, and nothing
reports an error. That is what the migration-only section now says, in those terms.

## What changed

`content/docs/plugins/plugin-report.mdx` — rewritten. Every example authors the
dataset-bound shape through `defineReport`; added an authoring-key table, ordering,
chart, and a "where the numbers come from" section; dropped the retired renderer table,
`applyInMemoryAggregation`, the `useReportData` SQL-dialect section and the
`registerDrillHandler` block.

`packages/plugin-report/README.md` — the stale surface the card enumerated
(`:9`, `:10`, `:12`, the "Spec Reports — the four variants" section) plus two the card
did not: the `ReportInput` example under "Type-aware cell rendering", and the
`objectName` auto-hydration claim there (**zero implementation** — `objectName` has no
read point in `packages/plugin-report/src`). Sections #5053 and #5060 landed (Quick
Start, Export, Live Export, Scheduled export, drill-down, Schema-Driven Usage) are
untouched apart from those lines.

Corrected while re-deriving, both previously false:

- `:10` "tabular/summary delegate to `ObjectGrid`" — `ObjectGrid` is a **zero-hit** name in
  this package.
- `:12` joined blocks "own their own `objectName`" — a block owns its own `dataset`.

Also re-spelled the filter-time example's `filter:` to `runtimeFilter:` in both files, per
the spec's own rename suggestion above. The CEL caveat's substance is a server-side claim
not derivable from this repo, so it is left as written.

## #5016 overlap check — outcome: no overlap, the constraint has expired

The dispatch carried "#5016 has an in-flight PR touching the same README". It is **not in
flight any more**:

| PR | For | State |
| --- | --- | --- |
| #5053 | #5016 | **merged** 2026-08-17T21:06:21Z, squash `f331f5a` |
| #5060 | #5048 | **merged** 2026-08-17T21:51:58Z, squash `82a9417` |

Both squash commits are ancestors of this branch's base `958d757`, so their work is
already under me rather than beside me. `is:open` PRs touching `plugin-report`: none
(the three open PRs are a release PR and two dependabot bumps). **Nothing was resolved
unilaterally, and neither PR was touched.** I edited on top of their landed text and
deliberately left every section they rewrote alone.

## Gate union — derived from the actual changed paths

Changed: `content/docs/plugins/plugin-report.mdx`, `packages/plugin-report/README.md`,
`.changeset/plugin-report-docs-dataset-bound-5047.md`. Derived by reading each gate's own
scan set rather than recalling a list. All run at `fc93cc7`:

| Gate | Why it applies | Exit |
| --- | --- | --- |
| `node scripts/check-doc-links.mjs` | `SCAN_ROOTS` includes `content/docs` and `packages/*/README.md` | **0** — `Links are valid across 13 scan roots.` |
| `node scripts/check-doc-component-types.mjs` | scans `content/docs/**.mdx` code blocks | **0** — `481 registered, 88 exempted` |
| `node scripts/check-control-bytes.mjs` | all tracked text files | **0** — `scanned 4562 tracked text file(s)` |
| `node scripts/check-changeset-no-major.mjs` | `.changeset/**` changed | **0** |
| `node scripts/check-changeset-presence.mjs` | `.changeset/**` changed | **0** |
| `vitest scripts/__tests__/doc-version-claims.test.ts` | ratchets `content/docs` + `packages/*/README.md`, **both directions** | **0** — 18 passed |
| `vitest scripts/__tests__/check-changeset-presence.test.ts` | companion to the presence gate | **0** — 49 passed with the above |

Two ratchet traps this diff walked into and cleared, both verified rather than assumed:

- `doc-version-claims` `KNOWN_CLAIMS` carries a row for `packages/plugin-report/README.md`
  (the react `^18 || ^19` peer restatement). The Peer Dependencies block is untouched, so
  the entry stays live.
- `DOC_TYPE_EXEMPTIONS` declares `matrix` and `joined` for the mdx, and a stale exemption
  is a **failure**. The rewrite keeps both as report-type literals; the exempted count is
  unchanged at 88.

The chart example is in the README rather than the mdx on purpose: `check-doc-component-types`
would read a `type: 'bar'` literal in an mdx code block as a component type, and that file
has no `bar` exemption. Placement, not contortion — the mdx documents `chart` in prose and
links to the README block.

## Snippet compile probe

All 20 ` ```ts ` / ` ```tsx ` blocks in both documents, **extracted by script** (not
hand-copied) and compiled `--strict` against the **built** `dist/index.d.ts` — the surface a
consumer sees. Resolution self-check confirms it read artifacts, not source:

```
Module name './DatasetReportRenderer' was successfully resolved to
  '.../packages/plugin-report/dist/DatasetReportRenderer.d.ts'
```

Forward leg: **rc=0, zero diagnostics**, 20/20 blocks.

The probe found two real doc defects, which are fixed in the docs rather than papered over
in the harness: the README's Matrix / Joined / chart examples called `defineReport` with no
import of their own, so a reader copying one block alone got an undefined name. Each block
is now self-contained.

## Reverse verification — prediction first, and it was half wrong

Predicted **before running**: restoring the old snippets goes red, but the diagnostic lands
on the *import* (`TS2305` on `ReportInput`) and the key-level errors are **masked**, because
an unresolved type annotation degrades the literal's contextual type; a second leg annotated
with the real `Report` type would be needed to surface `objectName` / object-shaped `columns`.

Observed — the masking prediction was exactly right, and the first run was a **false green**
I nearly reported:

**Leg A**, old mdx snippets verbatim from HEAD. The first run printed only five syntax errors
from two prose *fragments* (a bare `filter: { ... }` line), and **no semantic diagnostics at
all** — parse errors in those two files suppressed semantic checking program-wide. Removing
the two fragments produced the real reading:

```
rev-01.tsx(2,15): error TS2305: Module '...spec/dist/ui/index.js' has no exported member 'ReportInput'.
rev-03.tsx(2,33): error TS2304: Cannot find name 'ReportInput'.
rev-04.tsx(2,36): error TS2304: Cannot find name 'ReportInput'.
rev-05.tsx(2,10): error TS2305: Module '"@object-ui/plugin-report"' has no exported member 'registerDrillHandler'.
```

Not one diagnostic on any *key* of the old literals — the mask, confirmed. A planted
sentinel (`ThisNameIsDefinitelyNotExported`) also returned TS2305, proving the probe was not
silently resolving to `any`.

**Leg B**, same old literal annotated with the type that does exist:

```
rev-09.tsx(12,5): error TS2322: Type '{ field: string; label: string; }' is not assignable to type 'string'.
rev-09.tsx(13,5): error TS2322: Type '{ field: string; label: string; aggregate: string; }' is not assignable to type 'string'.
```

and, isolated so it is not masked by the `columns` error:

```
rev-11.tsx(6,3): error TS2353: Object literal may only specify known properties,
  and 'objectName' does not exist in type '{ name: string; label: ... }'.
```

Control: the new dataset-bound literal under the same annotation — **zero diagnostics**.

So the old form is rejected on **both** surfaces (type and runtime schema), which is what the
new prose claims.

## Changeset

`.changeset/plugin-report-docs-dataset-bound-5047.md`, `@object-ui/plugin-report: patch`.
`check-changeset-presence` reports **none is owed** (nothing under a package's `src/`), so
this is a deliberate choice following the precedent set twice in this exact file: #5053 and
#5060 both shipped a `patch` changeset for README-only changes, because the README is in the
package's published `files` and therefore reaches npm. There is no `skip-changeset` label in
this repository, and none was created.

## One deviation to flag

The ruling says retired renderer names go. They are gone from the mdx entirely. The README
keeps **one** sentence naming them, inside the migration-only section, as removed with no
replacement export — matching the convention #5053 established three paragraphs above it
(which likewise records `ReportBuilder` / `ScheduleConfig` / `ChartConfig` by name as
removed, so they are not re-added as live). Happy to drop it if the intent was zero mentions.

## Filed unassigned, not fixed here

- #5136 — `content/docs/core/report-schema.mdx` teaches the same `objectName` column
  hydration; same defect class, a third document, out of this card's two-document scope.
- #5137 — `DatasetReportRenderer` reads `report.filter` as a lenient alias for
  `runtimeFilter`, a key the strict spec rejects *with an explicit rename suggestion*.
  Contract-first: the producer is right and the consumer is being tolerant.
- #5138 — `finding`: no gate reads a doc snippet's schema **keys** against the spec.
  This is #4823's explicitly-deferred "second dimension", and #4823 is closed as completed.
- #5139 — `finding`: the `DOC_TYPE_EXEMPTIONS` reasons in `check-doc-component-types.mjs`
  cite `ReportInput`, the symbol this PR removed as non-existent.

**A gate that would have caught this defect class does not exist**, and none fired on the
current prose — see the baseline reading in #5138.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_