### PR TITLE
fix(app-shell,plugin-list): 关联列表「+ New」消费 create 谓词,行内编辑开关补 update 权限门 (#4646, #4647)

### DIFF
--- a/.changeset/toolbar-create-predicates-and-inline-edit-gate-4646-4647.md
+++ b/.changeset/toolbar-create-predicates-and-inline-edit-gate-4646-4647.md
@@ -1,0 +1,64 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/plugin-detail": patch
+"@object-ui/plugin-list": patch
+"@object-ui/react": patch
+"@object-ui/core": patch
+---
+
+Related-list "+ New" now honours `userActions.create` predicates, and the grid
+toolbar's inline-edit affordance is gated on `update` permission (objectui#4646,
+objectui#4647).
+
+Two declared-but-unenforced gaps on the same toolbar surface.
+
+**#4646 — `createPredicates` had a producer and no consumer.**
+`@objectstack/spec@17.0.0` widened `userActions.create` to
+`z.union([z.boolean(), RowCrudActionOverrideSchema])`, so `resolveCrudAffordances`
+emits `createPredicates` — and nothing in objectui read them, against roughly
+fifteen consumption sites apiece for `editPredicates` / `deletePredicates`. The
+symptom: a parent record entering a frozen state correctly greyed its children's
+row Edit/Delete while the related list's "+ New" stayed fully live, so the user
+filled in the whole child form to earn a server 409. The related-list toolbar now
+evaluates `visibleWhen` / `disabledWhen` **once against the host parent record**,
+per the spec docblock's binding for this key, on top of the existing
+`o.create ∧ can(child, 'create')` check. `visibleWhen` hides "+ New" and fails
+CLOSED; `disabledWhen` greys it and fails SOFT — the same evaluator, fail
+directions and hidden-vs-disabled split the record header already uses for
+edit/delete (objectui#4419 / PR #4515). A bare-boolean `userActions.create` is
+untouched: with no predicates there is nothing to evaluate.
+
+**#4647 — the inline-edit toggle was the one ungated affordance on its toolbar.**
+It rendered on "grid view ∧ the host wired `onInlineEditChange` ∧ not the compact
+toolbar", and every host wires that callback unconditionally. New and Import are
+hidden for an account without the grant and the bulk-delete entry on the same
+toolbar ANDs `can(obj, 'delete')`, but a read-only principal could flip inline
+edit, modify cells and press "Save all" to earn a server 403. It is now gated on
+the object's resolved edit affordance ∧ `can(object, 'update')`, mirroring that
+bulk-delete gate. The gate is applied at all three sites that carry this
+affordance — the wide toolbar's toggle, the compact toolbar's settings-popover
+entry (which previously had no gate at all, not even the callback), and the
+`editable` mode handed to the grid, so a stored view carrying `inlineEdit: true`
+can no longer drop a read-only principal into editable cells with no toggle to
+press.
+
+`ListViewSchema.userActions.editInline` is also consumed now: an explicit `false`
+withholds the affordance wholesale, which authors previously could not do.
+
+**Behaviour change for read-only users, stated plainly.** Where the UI used to
+offer inline editing and let the server refuse it, it now declines to offer the
+entry point at all. No data access changes — the server gate was and remains the
+enforcement boundary; this only stops the UI walking users into round-trips
+guaranteed to fail. Accounts *with* the grant see no change, and hosts with no
+`PermissionProvider` mounted (standalone embeds, the Studio designer) keep
+today's behaviour, since `can()` answers `true` there by design.
+
+One deliberate non-change: the absent case of `userActions.editInline` defers to
+the host's existing `inlineEdit` channel rather than enforcing the spec's
+`.default(false)`. Enforcing that default would remove the toggle from every
+stored console list view in one release, since nothing folds a legacy key into
+`editInline` and no existing view declares it. This follows the rule the
+surrounding toolbar-flag block already states for itself — defaults chosen to
+match what the flags have always done. `InterfaceListPage`, the key's other
+consumer, reads the absent case as OFF, because the ADR-0047 interface page has
+no such host channel to defer to.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -2335,6 +2335,14 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                 parentObjectName={objectName}
                 parentRecordId={pureRecordId ?? undefined}
                 parentTitle={recordTitle}
+                /* [#4646] The related-list toolbars under this page evaluate
+                   their child objects' `userActions.create` predicates against
+                   THIS record — the spec's "record in scope where the toolbar
+                   renders". Same record and same field definitions the header's
+                   edit/delete predicates above are evaluated against, so one
+                   page cannot hold two answers to "is this record frozen". */
+                parentRecord={pageRecord}
+                parentObjectFields={predicateFields}
               >
                 <SchemaRenderer schema={withPageTabsUrlSync(renderedPage, { defaultTab: activeTabParam, onTabChange: handleTabChange }) as any} />
               </RelatedRecordActionsBridge>

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -36,6 +36,34 @@
  * Each affordance is gated by {@link resolveEffectiveCrudAffordances} so system /
  * append-only children never show New / Edit / Delete. When this bridge is
  * absent (e.g. the Studio designer) the related list stays read-only.
+ *
+ * ## The related-list toolbar's create predicates (objectui#4646)
+ *
+ * `@objectstack/spec@17.0.0` widened `userActions.create` from a bare boolean
+ * to `z.union([z.boolean(), RowCrudActionOverrideSchema])`, so
+ * `resolveCrudAffordances` now emits `createPredicates` beside the
+ * `editPredicates` / `deletePredicates` the row surfaces have consumed since
+ * objectui#2614. Nothing read them: the spec's CHANGELOG named "the
+ * related-list toolbar honouring `create.visibleWhen`" as objectui's downstream
+ * card, and this is that card. A parent record entering a frozen state greyed
+ * its children's row Edit/Delete correctly while "+ New" stayed live, so the
+ * user filled in the whole child form to earn a 409.
+ *
+ * The binding is the spec docblock's, not an invention here: unlike the ROW
+ * predicates, `createPredicates` evaluates **once per toolbar, against the
+ * record of the scope the toolbar sits in** — on a record page's related list
+ * that is the HOST PARENT record, which is why `parentRecord` had to be
+ * threaded in beside the `parentRecordId` this bridge already carried. (An id
+ * cannot answer `record.status != 'frozen'`.) A standalone object list has no
+ * record in scope and evaluates nothing — it never reaches this bridge at all.
+ *
+ * Evaluated WITHOUT a hook, deliberately: `resolve` answers for a VARIABLE
+ * number of related lists inside one `useMemo`, so a `useRowPredicate` per
+ * child object would tie the hook count to the page's related-list count. This
+ * is the same constraint — and the same resolution — as `plugin-grid`'s
+ * `evalRowActionVisibility`, whose row loop faces it per action. The evaluator
+ * underneath is the canonical one either way (`evalRowPredicate`), and the fail
+ * directions below are the record header's verbatim.
  */
 
 import { useCallback, useMemo } from 'react';
@@ -45,12 +73,13 @@ import {
   notifyDataChanged,
   useAction,
   useActionTextLocalizer,
+  usePredicateScope,
   type ActionTextLocalizer,
   type RelatedRecordActionsValue,
   type RelatedRecordHandlers,
   type RelatedRowActionDef,
 } from '@object-ui/react';
-import type { ActionDef } from '@object-ui/core';
+import { evalRowPredicate, type ActionDef, type RowCrudPredicates } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { resolveEffectiveCrudAffordances } from '../utils/crudAffordances';
 import { RECORD_FORM_PARAM, RECORD_FORM_OBJECT_PARAM, RECORD_FORM_LINK_PARAM, RECORD_TRAIL_PARAM, appendRecordTrail } from '../urlParams';
@@ -69,6 +98,43 @@ export function notifyRelatedChanged(objectName: string): void {
   notifyDataChanged({ objectName });
 }
 
+/**
+ * [#4646] Evaluate one toolbar-scope create predicate the way the record
+ * header's edit/delete predicates are evaluated — on the canonical CEL engine,
+ * failing CLOSED with a diagnosable warning — but WITHOUT a hook.
+ *
+ * Mirrors `useRowPredicate(pred, record, { fallback: false, warnOnError: true,
+ * label, fields })` exactly, boolean short-circuit included. The short-circuit
+ * is not an optimisation: a boolean handed to the engine faults ("AST-only
+ * evaluation not yet supported") and would fail closed, which is how
+ * `visible: true` once hid a bulk button from everyone (objectui#3492).
+ *
+ * Hook-free for the reason `plugin-grid`'s `evalRowActionVisibility` is: the
+ * caller answers for a VARIABLE number of related lists inside one `useMemo`.
+ *
+ * Whether a gate was DECLARED is not decided here — each caller below answers
+ * that first, by its own rule (`?? true` for `visibleWhen`, `!= null` for
+ * `disabledWhen`). An empty predicate that reaches an evaluator is unevaluable
+ * and fails closed like any other.
+ */
+function evalCreatePredicate(
+  pred: unknown,
+  record: Record<string, any> | null | undefined,
+  scope: Record<string, unknown>,
+  label: string,
+  fields: unknown,
+): boolean {
+  if (typeof pred === 'boolean') return pred;
+  if (pred == null || pred === '') return false;
+  return evalRowPredicate(pred as never, record ?? {}, {
+    fallback: false,
+    scope,
+    warnOnError: true,
+    label,
+    fields: fields as never,
+  });
+}
+
 export interface RelatedRecordActionsBridgeProps {
   /** Current app segment used to build `/apps/:appName/...` routes. */
   appName?: string;
@@ -85,6 +151,31 @@ export interface RelatedRecordActionsBridgeProps {
   parentObjectName?: string;
   parentRecordId?: string;
   parentTitle?: string;
+  /**
+   * [#4646] The parent record ITSELF — the subject the child objects'
+   * `userActions.create` predicates are evaluated against, per the spec
+   * docblock ("the record in scope where the toolbar renders"). `parentRecordId`
+   * above cannot stand in for it: `record.status != 'frozen'` needs the fields,
+   * not the key.
+   *
+   * Omitting it leaves every create predicate unevaluable, which fails CLOSED
+   * for `visibleWhen` exactly as it does on the record header — so a host that
+   * gates creation on the parent must pass the record, and a host with no
+   * parent record in hand should not be declaring create predicates on its
+   * children. Hosts that declare none are untouched either way: with no
+   * `createPredicates` there is nothing to evaluate.
+   */
+  parentRecord?: Record<string, any> | null;
+  /**
+   * [#4646] The PARENT object's field definitions, handed to the predicate for
+   * the same reason the row kebab and the record header pass theirs: a relation
+   * field must bind as the stored FOREIGN KEY rather than whatever `$expand`
+   * substituted for it on this surface, or `record.owner == os.user.id` answers
+   * a different question here than it does on the list.
+   *
+   * The parent's, not the child's — the record being bound is the parent.
+   */
+  parentObjectFields?: unknown;
   children: React.ReactNode;
 }
 
@@ -115,12 +206,21 @@ export function RelatedRecordActionsBridge({
   parentObjectName,
   parentRecordId,
   parentTitle,
+  parentRecord,
+  parentObjectFields,
   children,
 }: RelatedRecordActionsBridgeProps) {
   const navigate = useNavigate();
   const { execute } = useAction();
   const [, setSearchParams] = useSearchParams();
   const { getObjectApiOperations, can } = usePermissions();
+  // [#4646] The host predicate scope (`features.*` / `os.user.*` / …), read
+  // ONCE here rather than per resolved child list — `resolve` is hook-free by
+  // construction (see the module note). This is the same scope
+  // `useRowPredicate` reads for the record header's edit/delete predicates, so
+  // a `create` predicate and an `edit` predicate on the same page see the same
+  // globals.
+  const predicateScope = usePredicateScope();
   // The child action's authored strings go through the ONE shared resolver
   // (objectui#4265). This used to arrive as an `actionLabel` prop injected by
   // RecordDetailView — an injection point that could only ever carry the LABEL,
@@ -248,9 +348,51 @@ export function RelatedRecordActionsBridge({
         // answers `true` with no `PermissionProvider`, which keeps standalone
         // embeds exactly where they were.
         const rawAff = resolveEffectiveCrudAffordances(childDef, getObjectApiOperations(objectName));
+        const objectCanCreate = rawAff.create && can(objectName, 'create');
+        // [#4646] The per-scope layer, on top of the object-level verdict above.
+        // Surfaced only when that verdict passed — the same posture
+        // `resolveRowCrudAffordances` takes for the row predicates
+        // (`editPredicates: canEdit ? aff.editPredicates : undefined`): a
+        // predicate cannot re-open an affordance the bucket, the effective API
+        // operations or the principal's grant already closed.
+        const createPredicates: RowCrudPredicates | undefined = objectCanCreate
+          ? rawAff.createPredicates
+          : undefined;
+        /**
+         * `visibleWhen` — fails CLOSED, and counts as DECLARED by `!= null`
+         * rather than by truthiness, so `visibleWhen: false` hides "+ New"
+         * instead of reading as "ungated" (the objectui#3492 invariant).
+         * `?? true` expresses the ungated default as a boolean, which the
+         * evaluator short-circuits without touching the engine — so a child
+         * object with no `userActions.create` predicates takes no evaluation at
+         * all and this gate is a literal `true`.
+         */
+        const createVisible = evalCreatePredicate(
+          createPredicates?.visibleWhen ?? true,
+          parentRecord,
+          predicateScope,
+          'builtin:create:visibleWhen',
+          parentObjectFields,
+        );
+        /**
+         * `disabledWhen` — fails SOFT (an unevaluable predicate must not grey a
+         * button forever), and the `!= null` gate lives OUTSIDE the evaluation,
+         * so `disabledWhen: ''` reads as "no condition" rather than as
+         * "disable". Verbatim the posture of the record header (PR #4515) and
+         * of `DataTableBuiltinRowActionItem`.
+         */
+        const createDisabled =
+          createPredicates?.disabledWhen != null &&
+          evalCreatePredicate(
+            createPredicates.disabledWhen,
+            parentRecord,
+            predicateScope,
+            'builtin:create:disabledWhen',
+            parentObjectFields,
+          );
         const aff = {
           ...rawAff,
-          create: rawAff.create && can(objectName, 'create'),
+          create: objectCanCreate && createVisible,
           edit: rawAff.edit && can(objectName, 'update'),
           delete: rawAff.delete && can(objectName, 'delete'),
         };
@@ -261,6 +403,10 @@ export function RelatedRecordActionsBridge({
         };
 
         if (aff.create) {
+          // [#4646] Greyed, not gone: `onCreate` is still supplied so the list
+          // keeps offering "+ New" as a visible-but-inert affordance. The
+          // hidden case is `aff.create` being false above.
+          if (createDisabled) handlers.createDisabled = true;
           handlers.onCreate = () => {
             const canLink =
               relationshipField && parentId != null && parentId !== '';
@@ -305,7 +451,11 @@ export function RelatedRecordActionsBridge({
       recordHref,
       openRecord,
     }),
-    [objects, base, dataSource, localizeActionTexts, runRowAction, openChildForm, recordHref, openRecord, getObjectApiOperations, can],
+    // `parentRecord` / `parentObjectFields` / `predicateScope` join the deps for
+    // the #4646 create predicates: a parent record that changes (a save, a
+    // status transition) must re-resolve "+ New" for every related list under
+    // it, or the toolbar keeps answering for the record's previous state.
+    [objects, base, dataSource, localizeActionTexts, runRowAction, openChildForm, recordHref, openRecord, getObjectApiOperations, can, parentRecord, parentObjectFields, predicateScope],
   );
 
   return (

--- a/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.createPredicates.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.createPredicates.test.tsx
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#4646] The related-list toolbar's "+ New" and the child object's
+ * `userActions.create` predicates.
+ *
+ * `@objectstack/spec@17.0.0` widened `userActions.create` to
+ * `z.union([z.boolean(), RowCrudActionOverrideSchema])`, so
+ * `resolveCrudAffordances` emits `createPredicates` — and, until this change,
+ * nothing in objectui read them: `createPredicates` had ZERO consumers against
+ * roughly fifteen apiece for `editPredicates` / `deletePredicates`. A parent
+ * record entering a frozen state greyed its children's row Edit/Delete
+ * correctly while "+ New" stayed fully live.
+ *
+ * The binding under test is the spec docblock's: unlike the ROW predicates,
+ * these evaluate ONCE per toolbar against the record of the scope the toolbar
+ * sits in — on a record page's related list, the HOST PARENT record. So the
+ * subject of every predicate below is the parent, never a child row.
+ *
+ * Pinned here: hidden vs disabled kept distinct (`visibleWhen` removes the
+ * button, `disabledWhen` greys it), both fail directions, the boolean arm of
+ * the union left untouched, and the ordering against the object-level gates.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+// Controllable principal verdict, keyed by action — same double the sibling
+// `RelatedRecordActionsBridge.effectiveOps.test.tsx` uses. `undefined` entries
+// default to allowed, matching `can()`'s permissive fallback.
+let principal: Record<string, boolean> = {};
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    getObjectApiOperations: () => undefined,
+    can: (_name: string, action: string) => principal[action] ?? true,
+  }),
+}));
+
+import { RelatedRecordActionsBridge } from '../RelatedRecordActionsBridge';
+import { useRelatedRecordActions } from '@object-ui/react';
+
+const CHILD = 'invoice';
+
+/** The real `userActions.create.visibleWhen` shape, on the PARENT's fields. */
+const NOT_FROZEN = 'record.frozen != true';
+/** Its `disabledWhen` counterpart — HOLDS for the frozen parent, so it greys. */
+const IS_FROZEN = 'record.frozen == true';
+
+/** Host parent records. The predicates above are evaluated against THESE. */
+const FROZEN_PARENT = { id: 'p1', name: 'Published Order', frozen: true };
+const DRAFT_PARENT = { id: 'p2', name: 'Draft Order', frozen: false };
+
+/** The parent object's field definitions, threaded through like the real host. */
+const PARENT_FIELDS = {
+  id: { type: 'text' },
+  name: { type: 'text' },
+  frozen: { type: 'boolean' },
+};
+
+/** A child object whose `userActions.create` carries the given override. */
+function childObjects(create: unknown) {
+  return [{ name: CHILD, managedBy: 'platform', userActions: { create } }];
+}
+
+interface Resolved {
+  onCreate: boolean;
+  createDisabled: boolean | undefined;
+  onEdit: boolean;
+  onDelete: boolean;
+}
+
+/** Probe: resolves the child's handlers and reports the create verdicts. */
+function Probe({ onResolve }: { onResolve: (r: Resolved) => void }) {
+  const api = useRelatedRecordActions();
+  const handlers = api?.resolve({ objectName: CHILD, relationshipField: 'order', parentId: 'p1' }) ?? {};
+  onResolve({
+    onCreate: typeof handlers.onCreate === 'function',
+    createDisabled: handlers.createDisabled,
+    onEdit: typeof handlers.onEdit === 'function',
+    onDelete: typeof handlers.onDelete === 'function',
+  });
+  return null;
+}
+
+function resolveWith(opts: {
+  create: unknown;
+  parentRecord?: Record<string, any> | null;
+}): Resolved {
+  let captured = {} as Resolved;
+  render(
+    <MemoryRouter>
+      <RelatedRecordActionsBridge
+        appName="crm"
+        objects={childObjects(opts.create)}
+        dataSource={{ delete: vi.fn() }}
+        parentObjectName="order"
+        parentRecordId="p1"
+        parentRecord={'parentRecord' in opts ? opts.parentRecord : DRAFT_PARENT}
+        parentObjectFields={PARENT_FIELDS}
+      >
+        <Probe onResolve={(r) => { captured = r; }} />
+      </RelatedRecordActionsBridge>
+    </MemoryRouter>,
+  );
+  return captured;
+}
+
+beforeEach(() => {
+  principal = {};
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe('#4646 — related-list "+ New" consumes userActions.create.visibleWhen', () => {
+  it('a FROZEN parent hides "+ New" on the child list', () => {
+    const h = resolveWith({
+      create: { enabled: true, visibleWhen: NOT_FROZEN },
+      parentRecord: FROZEN_PARENT,
+    });
+    expect(h.onCreate).toBe(false);
+    // Control group: the other affordances are untouched by a CREATE predicate,
+    // so the absence above is the predicate's doing and not a dead bridge.
+    expect(h.onEdit).toBe(true);
+    expect(h.onDelete).toBe(true);
+  });
+
+  it('a DRAFT parent keeps "+ New", undisabled', () => {
+    const h = resolveWith({
+      create: { enabled: true, visibleWhen: NOT_FROZEN },
+      parentRecord: DRAFT_PARENT,
+    });
+    expect(h.onCreate).toBe(true);
+    expect(h.createDisabled).toBeFalsy();
+  });
+
+  it('`visibleWhen: false` hides it — a declared gate, not an "ungated" reading', () => {
+    // The objectui#3492 invariant: declared-ness is `!= null`, never truthiness.
+    const h = resolveWith({
+      create: { enabled: true, visibleWhen: false },
+      parentRecord: DRAFT_PARENT,
+    });
+    expect(h.onCreate).toBe(false);
+  });
+
+  it('an unevaluable visibleWhen fails CLOSED', () => {
+    const h = resolveWith({
+      create: { enabled: true, visibleWhen: 'record.frozen ==' },
+      parentRecord: DRAFT_PARENT,
+    });
+    expect(h.onCreate).toBe(false);
+  });
+
+  it('no parent record in scope fails CLOSED for a declared visibleWhen', () => {
+    // A `record.*` predicate with nothing to bind cannot answer; the safe
+    // direction for a visibility gate is to withhold the affordance.
+    const h = resolveWith({
+      create: { enabled: true, visibleWhen: NOT_FROZEN },
+      parentRecord: null,
+    });
+    expect(h.onCreate).toBe(false);
+  });
+});
+
+describe('#4646 — disabledWhen greys "+ New" instead of removing it', () => {
+  it('a FROZEN parent leaves the button present but disabled', () => {
+    const h = resolveWith({
+      create: { enabled: true, disabledWhen: IS_FROZEN },
+      parentRecord: FROZEN_PARENT,
+    });
+    // The whole point of the second channel: still offered, just not pressable.
+    expect(h.onCreate).toBe(true);
+    expect(h.createDisabled).toBe(true);
+  });
+
+  it('a DRAFT parent leaves it enabled', () => {
+    const h = resolveWith({
+      create: { enabled: true, disabledWhen: IS_FROZEN },
+      parentRecord: DRAFT_PARENT,
+    });
+    expect(h.onCreate).toBe(true);
+    expect(h.createDisabled).toBeFalsy();
+  });
+
+  it("`disabledWhen: ''` reads as no condition, not as disable", () => {
+    // The `!= null` gate lives OUTSIDE the evaluation, so an empty predicate is
+    // "nothing declared" rather than an unevaluable one that greys forever.
+    const h = resolveWith({
+      create: { enabled: true, disabledWhen: '' },
+      parentRecord: FROZEN_PARENT,
+    });
+    expect(h.onCreate).toBe(true);
+    expect(h.createDisabled).toBeFalsy();
+  });
+
+  it('an unevaluable disabledWhen fails SOFT — the button stays pressable', () => {
+    // Opposite fail direction from visibleWhen, deliberately: a broken predicate
+    // must not grey an affordance forever.
+    const h = resolveWith({
+      create: { enabled: true, disabledWhen: 'record.frozen ==' },
+      parentRecord: FROZEN_PARENT,
+    });
+    expect(h.onCreate).toBe(true);
+    expect(h.createDisabled).toBeFalsy();
+  });
+
+  it('visibleWhen wins over disabledWhen — hidden beats greyed', () => {
+    const h = resolveWith({
+      create: { enabled: true, visibleWhen: NOT_FROZEN, disabledWhen: IS_FROZEN },
+      parentRecord: FROZEN_PARENT,
+    });
+    expect(h.onCreate).toBe(false);
+  });
+});
+
+describe('#4646 — the boolean arm of the union is untouched', () => {
+  it('`create: true` (bare boolean) offers "+ New" with no predicate evaluation', () => {
+    const h = resolveWith({ create: true, parentRecord: FROZEN_PARENT });
+    expect(h.onCreate).toBe(true);
+    expect(h.createDisabled).toBeFalsy();
+  });
+
+  it('`create: false` (bare boolean) still hides it', () => {
+    const h = resolveWith({ create: false, parentRecord: DRAFT_PARENT });
+    expect(h.onCreate).toBe(false);
+  });
+
+  it('no `userActions` at all keeps the platform-bucket default', () => {
+    let captured = {} as Resolved;
+    render(
+      <MemoryRouter>
+        <RelatedRecordActionsBridge
+          appName="crm"
+          objects={[{ name: CHILD, managedBy: 'platform' }]}
+          dataSource={{ delete: vi.fn() }}
+          parentRecord={FROZEN_PARENT}
+        >
+          <Probe onResolve={(r) => { captured = r; }} />
+        </RelatedRecordActionsBridge>
+      </MemoryRouter>,
+    );
+    expect(captured.onCreate).toBe(true);
+    expect(captured.createDisabled).toBeFalsy();
+  });
+
+  it('a host that threads NO parent record keeps predicate-less children working', () => {
+    // The overwhelmingly common case, and the one that must not regress: with
+    // nothing declared there is nothing to evaluate, so the missing record is
+    // never consulted.
+    const h = resolveWith({ create: true, parentRecord: null });
+    expect(h.onCreate).toBe(true);
+  });
+});
+
+describe('#4646 — predicates sit UNDER the object-level gates, never over them', () => {
+  it('a principal without `create` loses "+ New" even when the predicate passes', () => {
+    principal = { create: false };
+    const h = resolveWith({
+      create: { enabled: true, visibleWhen: NOT_FROZEN },
+      parentRecord: DRAFT_PARENT,
+    });
+    expect(h.onCreate).toBe(false);
+    // …and the disabled channel must not light up for a hidden affordance.
+    expect(h.createDisabled).toBeFalsy();
+  });
+
+  it('`enabled: false` closes it regardless of a passing visibleWhen', () => {
+    const h = resolveWith({
+      create: { enabled: false, visibleWhen: NOT_FROZEN },
+      parentRecord: DRAFT_PARENT,
+    });
+    expect(h.onCreate).toBe(false);
+  });
+});

--- a/packages/core/src/utils/managedBy.ts
+++ b/packages/core/src/utils/managedBy.ts
@@ -62,7 +62,22 @@ export type UserActionOverride =
     };
 
 export interface UserActionsOverride {
-  create?: boolean;
+  /**
+   * Bare boolean or the object form. Widened from `boolean` in objectui#4646:
+   * `@objectstack/spec@17.0.0` types this key
+   * `z.union([z.boolean(), RowCrudActionOverrideSchema])`, and the spec's
+   * resolver emits the parsed predicates as `CrudAffordances.createPredicates`.
+   * The local type said `boolean` — so an author writing the shape the spec
+   * accepts, and that the related-list toolbar now honours
+   * (`RelatedRecordActionsBridge`, objectui#4646), was rejected by objectui's
+   * own type while the runtime handled it.
+   *
+   * `import` below is deliberately NOT widened. The spec accepts the object
+   * form there too and emits `importPredicates`, but nothing in objectui reads
+   * them yet; widening the type ahead of a consumer would re-declare the
+   * inert-metadata defect this change removes, one key over.
+   */
+  create?: UserActionOverride;
   import?: boolean;
   edit?: UserActionOverride;
   delete?: UserActionOverride;

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -70,6 +70,17 @@ export interface RelatedListProps {
   objectName?: string;
   /** Callback when "New" button is clicked */
   onNew?: () => void;
+  /**
+   * [#4646] Render "New" GREYED rather than clickable. Supplied by the host
+   * alongside `onNew` when the create affordance exists for this list but its
+   * `userActions.create.disabledWhen` predicate answers true for the record in
+   * scope (the parent record, on a record page's related list).
+   *
+   * Deliberately distinct from omitting `onNew` — which HIDES the button. Same
+   * hidden-vs-disabled split the row Edit/Delete predicates have had since
+   * objectui#2614.
+   */
+  newDisabled?: boolean;
   /** Callback when "View All" button is clicked */
   onViewAll?: () => void;
   /** Callback when a row Edit action is clicked */
@@ -304,6 +315,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   dataSource,
   objectName,
   onNew,
+  newDisabled,
   onViewAll,
   onRowEdit,
   onRowDelete,
@@ -1309,6 +1321,12 @@ export const RelatedList: React.FC<RelatedListProps> = ({
               <Button
                 variant={isEmpty ? 'ghost' : 'outline'}
                 size="sm"
+                /* [#4646] `userActions.create.disabledWhen` for the record this
+                   list hangs off. `visibleWhen` never reaches here — a false
+                   one makes the host omit `onNew`, so the button is absent
+                   rather than greyed. */
+                disabled={newDisabled}
+                data-testid="related-list-new"
                 onClick={(e) => { e.stopPropagation(); onNew(); }}
                 className="gap-1 h-9 sm:h-7 text-xs shadow-none"
               >

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -233,6 +233,11 @@ const RecordRelatedListBody: React.FC<RecordRelatedListRendererProps> = ({
         // Create a new child, pre-linked to this parent (增). Host omits when
         // create is denied by lifecycle/permissions, hiding the "New" button.
         onNew={handlers?.onCreate}
+        // [#4646] …and greys it — without hiding it — when the child object's
+        // `userActions.create.disabledWhen` holds for THIS parent record. The
+        // host owns both verdicts (it is the side that has the parent record
+        // and the predicate evaluator); this renderer only wires them.
+        newDisabled={handlers?.createDisabled}
         // Open the child record's detail page on row click (查看记录详情).
         onRowClick={
           handlers?.onView

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -21,7 +21,7 @@ import { useDensityMode } from '@object-ui/react';
 import type { ListViewSchema } from '@object-ui/types';
 import { detectStatusField } from '@object-ui/types';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, resolveEffectiveCrudAffordances, normalizeListViewSchema, rowHeightToDensityMode, mergeFilterNodes, columnIdentity, collectPredicateFieldRefs, listViewPredicates, PLATFORM_RECORD_COLUMNS, EXPANDABLE_FIELD_TYPES, UNMATERIALIZED_FIELD_TYPES } from '@object-ui/core';
+import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, resolveEffectiveCrudAffordances, isObjectInlineEditable, normalizeListViewSchema, rowHeightToDensityMode, mergeFilterNodes, columnIdentity, collectPredicateFieldRefs, listViewPredicates, PLATFORM_RECORD_COLUMNS, EXPANDABLE_FIELD_TYPES, UNMATERIALIZED_FIELD_TYPES } from '@object-ui/core';
 import { useObjectTranslation, useObjectLabel, useSafeFieldLabel, createSafeTranslation } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
 
@@ -1066,6 +1066,68 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     return declared.filter((a: unknown) => String(a).toLowerCase() !== 'delete');
   }, [schema.bulkActions, schema.objectName, objectDef, effectiveApiOps, canDo]);
 
+  /**
+   * [#4647] Is the grid toolbar's inline-edit toggle offered at all?
+   *
+   * Two gaps closed together, because both end at this one render condition.
+   *
+   * ## Gap 1 — the permission gate
+   *
+   * The toggle used to render on the sole conditions "grid view", "the host
+   * wired `onInlineEditChange`" and "not the compact toolbar" — and every host
+   * passes that callback unconditionally. It was the ONE affordance on this
+   * toolbar with no permission check: New and Import are hidden for an account
+   * without the grant, the bulk-delete entry directly above ANDs
+   * `can(obj, 'delete')`, and inline edit alone stayed available to a read-only
+   * principal, who could flip it, edit cells and press "Save all" to earn a
+   * server 403. No data ever landed (the server gate is solid), but the UI
+   * walked the user through a round-trip guaranteed to fail.
+   *
+   * The gate is `permittedBulkActions`' verbatim, with the operation moved from
+   * `delete` to `update`: the object's resolved affordance — ADR-0103 bucket ∧
+   * `userActions.edit` ∧ the server's effective API operations (#3391) — AND
+   * the CURRENT PRINCIPAL's grant (#4096). The first half is spelled
+   * `isObjectInlineEditable`, which IS
+   * `resolveEffectiveCrudAffordances(...).edit` under the name that says what
+   * this surface is asking; it is the same helper the record body's
+   * double-click/pencil affordances read, so a list and a record page cannot
+   * disagree about whether an object's rows are editable in place.
+   *
+   * `can()` answers `true` with no `PermissionProvider`, so standalone embeds
+   * and the Studio designer keep today's behavior — the same fail-open the
+   * bulk gate above relies on.
+   *
+   * ## Gap 2 — consuming the declared `userActions.editInline`
+   *
+   * `ListViewSchema.userActions.editInline` is spec-declared and, on this
+   * toolbar, was read by nothing: an author could not switch inline editing off
+   * even unconditionally. It is read here as an explicit opt-OUT (`!== false`).
+   *
+   * That default is deliberate and it does NOT enforce the spec's
+   * `.default(false)`. Enforcing it would take the toggle away from every
+   * existing console list view in one release, since nothing folds a legacy key
+   * into `editInline` and no stored view declares it — the console's own
+   * channel for this capability is the view's `inlineEdit` property, which the
+   * host relays as `onInlineEditChange`. This is `toolbarFlags`' stated rule
+   * for exactly this block (defaults "matching what these flags have always
+   * done"; `hideFields`/`rowColor` keep their historical OFF because flipping
+   * them "would grow two buttons on every existing view") applied in the
+   * direction that would REMOVE one. So: an explicit `false` is honoured, an
+   * explicit `true` is honoured, and absence defers to the host channel that
+   * already governs this surface. `InterfaceListPage` — the other consumer of
+   * this key — reads the absent case as OFF (`=== true`), because the
+   * ADR-0047 interface page has no such host channel to defer to.
+   */
+  const inlineEditOffered = React.useMemo(() => {
+    if ((schema.userActions as Record<string, boolean | undefined> | undefined)?.editInline === false) {
+      return false;
+    }
+    return (
+      isObjectInlineEditable(objectDef as any, effectiveApiOps) &&
+      (schema.objectName ? canDo(schema.objectName, 'update') : true)
+    );
+  }, [schema.userActions, schema.objectName, objectDef, effectiveApiOps, canDo]);
+
   // Normalize exportOptions: support both ObjectUI object format and spec string[] format
   const resolvedExportOptions = React.useMemo(() => {
     if (!schema.exportOptions) return undefined;
@@ -1820,7 +1882,14 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           ...baseProps,
           columns: effectiveFields,
           ...(schema.conditionalFormatting ? { conditionalFormatting: schema.conditionalFormatting } : {}),
-          editable: inlineEdit,
+          // [#4647] The MODE, not just its toggle. Gating only the toggle would
+          // leave the issue's own consequence reachable by a different door: a
+          // stored view carrying `inlineEdit: true` (the console persists it
+          // per view) drops a read-only principal straight into editable cells
+          // with no toggle to press, and "Save all" still earns the 403. The
+          // toggle can only ever be the cheapest entrance to this state; the
+          // state is what needs the grant.
+          editable: inlineEdit && inlineEditOffered,
           ...(schema.wrapHeaders != null ? { wrapHeaders: schema.wrapHeaders } : {}),
           ...(schema.resizable != null ? { resizable: schema.resizable } : {}),
           ...(schema.selection ? { selection: schema.selection } : {}),
@@ -2014,7 +2083,11 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // objectDef is in the deps because the kanban default lane field derives
   // from it (ADR-0085 stageField) and it loads async — without it the board
   // would keep the null-def result forever.
-  }, [currentView, schema, currentSort, effectiveFields, groupingConfig, rowColorConfig, navigation.handleClick, density.mode, galleryCardSize, inlineEdit, objectDef]);
+  // `inlineEditOffered` joins the deps for #4647: the permission verdict lands
+  // asynchronously (`/me/permissions`) and `objectDef` loads into state, so a
+  // grid schema built before either resolved must be rebuilt when they do —
+  // otherwise `editable` keeps the pre-verdict answer for the session.
+  }, [currentView, schema, currentSort, effectiveFields, groupingConfig, rowColorConfig, navigation.handleClick, density.mode, galleryCardSize, inlineEdit, inlineEditOffered, objectDef]);
 
   const hasFilters = currentFilters.conditions && currentFilters.conditions.length > 0;
 
@@ -2449,8 +2522,11 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
             </>
           )}
           {/* Inline edit — toggle record editing for this (grid) view. Persists
-              `inlineEdit` on the view via onInlineEditChange. */}
-          {currentView === 'grid' && onInlineEditChange && !toolbarFlags.compactToolbar && (
+              `inlineEdit` on the view via onInlineEditChange.
+              [#4647] `inlineEditOffered` carries BOTH the `can(obj,'update')`
+              permission gate this affordance was missing and the declared
+              `userActions.editInline` switch — see its definition above. */}
+          {currentView === 'grid' && onInlineEditChange && !toolbarFlags.compactToolbar && inlineEditOffered && (
             <Button
               variant="ghost"
               size="sm"
@@ -2837,7 +2913,13 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               showHideFields={toolbarFlags.showHideFields}
               hiddenFields={hiddenFields}
               updateHiddenFields={updateHiddenFields}
-              showInlineEdit={currentView === 'grid'}
+              /* [#4647] The compact toolbar's inline-edit entry — the SECOND
+                 render site for this affordance, and the one with no gate at
+                 all: it never even required `onInlineEditChange`. Same
+                 `inlineEditOffered` verdict as the wide toolbar's toggle, or a
+                 read-only principal would keep the entry on mobile after
+                 losing it on desktop. */
+              showInlineEdit={currentView === 'grid' && inlineEditOffered}
               inlineEdit={inlineEdit}
               setInlineEdit={updateInlineEdit}
             />

--- a/packages/plugin-list/src/__tests__/ListView.permissions.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.permissions.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, screen, cleanup } from '@testing-library/react';
+import { render, waitFor, screen, cleanup, fireEvent } from '@testing-library/react';
 import { ComponentRegistry } from '@object-ui/core';
 import { ListView } from '../ListView';
 import { SchemaRendererProvider } from '@object-ui/react';
@@ -249,5 +249,227 @@ describe('ListView – non-grid bulk delete vs the principal permission gate (#4
     renderGalleryBulk(null);
     await waitFor(() => expect(screen.getByTestId('bulk-actions-bar')).toBeInTheDocument());
     expect(screen.queryByTestId('bulk-action-delete')).not.toBeNull();
+  });
+});
+
+/**
+ * [#4647] The grid toolbar's inline-edit affordance — the permission gate it
+ * never had, and the declared switch nothing read.
+ *
+ * ## Gap 1
+ *
+ * The toggle rendered on "grid view ∧ the host wired `onInlineEditChange` ∧ not
+ * the compact toolbar", and every host wires that callback unconditionally. It
+ * was the ONE affordance on this toolbar with no permission check: New and
+ * Import are hidden for an account without the grant and the bulk-delete entry
+ * pinned above ANDs `can(obj, 'delete')`, but a read-only principal could flip
+ * inline edit, modify cells and press "Save all" to earn a server 403.
+ *
+ * ## Gap 2
+ *
+ * `userActions.editInline` is spec-declared and, on this toolbar, was read by
+ * nothing — an author could not switch inline editing off even unconditionally.
+ *
+ * Three render sites carry the verdict, and all three are pinned: the wide
+ * toolbar's toggle, the COMPACT toolbar's popover entry (which had no gate at
+ * all, not even the callback), and the `editable` MODE handed to the grid —
+ * because a stored view carrying `inlineEdit: true` drops a read-only principal
+ * into editable cells with no toggle to press.
+ */
+function makeUpdatePermissions(allowUpdate: boolean): ObjectPermissionConfig {
+  return {
+    object: 'account',
+    roles: {
+      restricted: {
+        actions: allowUpdate ? ['read', 'update'] : ['read'],
+      },
+    },
+  };
+}
+
+const inlineEditSchema: ListViewSchema = {
+  type: 'list-view',
+  objectName: 'account',
+  viewType: 'grid',
+  fields: ['name', 'industry'],
+};
+
+/** Records the `editable` prop the grid is rendered with. */
+let gridEditableCalls: Array<boolean | undefined> = [];
+
+function registerRecordingGrid() {
+  ComponentRegistry.register('object-grid', (props: any) => {
+    gridEditableCalls.push(props.editable);
+    return <div data-testid="grid-stub">{String(!!props.editable)}</div>;
+  });
+}
+
+/** `permissions: null` renders with NO PermissionProvider at all. */
+function renderInlineEdit(
+  permissions: ObjectPermissionConfig | null,
+  schemaOverride?: Partial<ListViewSchema>,
+) {
+  const view = (
+    <ListView
+      schema={{ ...inlineEditSchema, ...schemaOverride } as ListViewSchema}
+      dataSource={mockDataSource as any}
+      onInlineEditChange={vi.fn()}
+    />
+  );
+  return render(
+    <SchemaRendererProvider dataSource={mockDataSource as any}>
+      {permissions
+        ? (
+          <PermissionProvider roles={roles} permissions={[permissions]} userRoles={['restricted']}>
+            {view}
+          </PermissionProvider>
+        )
+        : view}
+    </SchemaRendererProvider>,
+  );
+}
+
+describe('ListView – inline-edit toggle vs the principal permission gate (#4647)', () => {
+  let prevGrid: ReturnType<typeof ComponentRegistry.get>;
+
+  beforeEach(() => {
+    mockDataSource.find.mockClear();
+    gridEditableCalls = [];
+    prevGrid = ComponentRegistry.get('object-grid');
+    registerRecordingGrid();
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (prevGrid) ComponentRegistry.register('object-grid', prevGrid);
+    else ComponentRegistry.unregister('object-grid');
+  });
+
+  it('a principal WITH update keeps the inline-edit toggle', async () => {
+    renderInlineEdit(makeUpdatePermissions(true));
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.queryByTestId('toolbar-inline-edit-toggle')).not.toBeNull();
+  });
+
+  it('a principal WITHOUT update loses it', async () => {
+    renderInlineEdit(makeUpdatePermissions(false));
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.queryByTestId('toolbar-inline-edit-toggle')).toBeNull();
+  });
+
+  it('with NO PermissionProvider the toggle survives (fail-open preserved)', async () => {
+    renderInlineEdit(null);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.queryByTestId('toolbar-inline-edit-toggle')).not.toBeNull();
+  });
+
+  it('a read-only principal cannot reach edit MODE through a stored inlineEdit:true view', async () => {
+    // The door that stays open if only the toggle is gated: the console
+    // persists `inlineEdit` per view, so the mode can be entered with no
+    // toggle press at all.
+    renderInlineEdit(makeUpdatePermissions(false), { inlineEdit: true } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.getByTestId('grid-stub')).toHaveTextContent('false');
+    expect(gridEditableCalls.at(-1)).toBeFalsy();
+  });
+
+  it('…while a permitted principal keeps that same stored view editable', async () => {
+    // Control group: proves the assertion above observes the PERMISSION and not
+    // a schema key that stopped being forwarded.
+    renderInlineEdit(makeUpdatePermissions(true), { inlineEdit: true } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.getByTestId('grid-stub')).toHaveTextContent('true');
+  });
+
+  it('the COMPACT toolbar entry is gated too', async () => {
+    // `showInlineEdit` on the settings popover was `currentView === 'grid'`
+    // alone — it never even required the host callback, so gating only the wide
+    // toolbar would have left the affordance reachable on mobile.
+    //
+    // Two layers have to be opened before an absence means anything, or the
+    // assertion passes for every input including a completely ungated one:
+    // the entry lives inside `PopoverContent` (closed until the trigger is
+    // clicked) and inside a `Section` that renders its children only when
+    // expanded — and that section's `defaultOpen` is `!!inlineEdit`. Hence the
+    // seeded `inlineEdit: true`, which is also the realistic shape of this
+    // regression: a stored view already in inline-edit mode, reopened by a
+    // principal who has since lost `update`.
+    renderInlineEdit(makeUpdatePermissions(false), {
+      compactToolbar: true,
+      inlineEdit: true,
+    } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('view-settings-trigger'));
+    await screen.findByTestId('view-settings-content');
+    expect(screen.queryByTestId('view-settings-inline-edit')).toBeNull();
+  });
+
+  it('…and a permitted principal keeps that compact entry', async () => {
+    // Control group for the case above: same two layers opened the same way,
+    // so the absence there is the permission gate and not a collapsed panel.
+    renderInlineEdit(makeUpdatePermissions(true), {
+      compactToolbar: true,
+      inlineEdit: true,
+    } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('view-settings-trigger'));
+    await screen.findByTestId('view-settings-content');
+    expect(screen.queryByTestId('view-settings-inline-edit')).not.toBeNull();
+  });
+});
+
+describe('ListView – the declared userActions.editInline switch (#4647 gap 2)', () => {
+  let prevGrid: ReturnType<typeof ComponentRegistry.get>;
+
+  beforeEach(() => {
+    mockDataSource.find.mockClear();
+    gridEditableCalls = [];
+    prevGrid = ComponentRegistry.get('object-grid');
+    registerRecordingGrid();
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (prevGrid) ComponentRegistry.register('object-grid', prevGrid);
+    else ComponentRegistry.unregister('object-grid');
+  });
+
+  it('`editInline: false` withholds the toggle from a fully-permitted principal', async () => {
+    renderInlineEdit(makeUpdatePermissions(true), {
+      userActions: { editInline: false },
+    } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.queryByTestId('toolbar-inline-edit-toggle')).toBeNull();
+  });
+
+  it('`editInline: false` also withholds edit MODE from a stored inlineEdit:true view', async () => {
+    renderInlineEdit(makeUpdatePermissions(true), {
+      inlineEdit: true,
+      userActions: { editInline: false },
+    } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.getByTestId('grid-stub')).toHaveTextContent('false');
+  });
+
+  it('`editInline: true` offers the toggle', async () => {
+    renderInlineEdit(makeUpdatePermissions(true), {
+      userActions: { editInline: true },
+    } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.queryByTestId('toolbar-inline-edit-toggle')).not.toBeNull();
+  });
+
+  it('an ABSENT editInline defers to the host channel, keeping existing views intact', async () => {
+    // The deliberate divergence from the spec's `.default(false)`, pinned so a
+    // future change to it is a decision rather than an accident: enforcing that
+    // default would take the toggle off every stored console view at once,
+    // since nothing folds a legacy key into `editInline`. `toolbarFlags`' own
+    // rule for this block — defaults matching what the flags have always done —
+    // applied in the direction that would REMOVE an affordance.
+    renderInlineEdit(makeUpdatePermissions(true), {
+      userActions: { search: false },
+    } as Partial<ListViewSchema>);
+    await waitFor(() => expect(screen.getByTestId('grid-stub')).toBeInTheDocument());
+    expect(screen.queryByTestId('toolbar-inline-edit-toggle')).not.toBeNull();
   });
 });

--- a/packages/react/src/context/RelatedRecordActionsContext.tsx
+++ b/packages/react/src/context/RelatedRecordActionsContext.tsx
@@ -65,6 +65,21 @@ export interface RelatedRecordHandlers {
    * argument is needed here (增).
    */
   onCreate?: () => void;
+  /**
+   * [#4646] Offer "+ New", but GREYED — the `userActions.create.disabledWhen`
+   * verdict for the scope this toolbar sits in (the host parent record on a
+   * record page's related list).
+   *
+   * A separate channel from omitting {@link onCreate} because hidden and
+   * disabled are different answers, exactly as they are for the row Edit/Delete
+   * predicates (objectui#2614) and for the record header's (objectui#4419 /
+   * PR #4515): `visibleWhen` decides whether the affordance exists at all,
+   * `disabledWhen` decides whether the existing affordance can be pressed. The
+   * host still supplies `onCreate` in the disabled case, so the button keeps
+   * its label and tooltip and the user can see that creating is a thing this
+   * list does — just not right now.
+   */
+  createDisabled?: boolean;
   /** Open an edit form for an existing child record (改). */
   onEdit?: (recordId: string | number, record?: unknown) => void;
   /**


### PR DESCRIPTION
Fixes #4646
Fixes #4647

## 为什么合单

两卡共享同一张工具栏面(记录页关联列表 / 列表视图工具栏),分诊席在两卡各自的 triage 评论里都留了 serial note:「shares the RecordDetailView/list-toolbar surface with #464x — dispatch serially or to one dev」。两者又是同一个病:**声明半已落、渲染半缺失**。一席双卡,一个 PR。

---

## 前提复核(dist 级证据 → src 级读点)

两卡的证据都是 dist 级(console@17.0.0)。落地前逐条转成 src 级,**其中两条需要修正**,如实记录:

| 卡 | 原始论断 | src 级复核结果 |
| --- | --- | --- |
| #4646 | `createPredicates` 零消费 | ✅ 成立。`grep -rn "createPredicates" packages/ apps/` → **0 命中**;生产者是 spec 的 `resolveCrudAffordances`,经 `@object-ui/core` 的 `resolveEffectiveCrudAffordances` 转出。对照 `editPredicates` 在 5 个文件有消费/定义点 |
| #4646 | 「`RecordDetailView` 的关联列表工具栏仍是旧两轴」 | ⚠️ **归属已迁移**。该两轴不在 `RecordDetailView.tsx`,而在 `RelatedRecordActionsBridge.tsx`(由 RecordDetailView 挂载):`create: rawAff.create && can(objectName, 'create')`。实质成立,位置更正 |
| #4646 | 「组件手里有 `parentId`」 | ⚠️ 成立但**不足**。`resolve()` 只拿到 `parentId`,拿不到父记录本身;`record.frozen != true` 要的是字段不是主键 —— 所以本 PR 必须把 `parentRecord` 也穿进桥接层 |
| #4646 | spec 声明半 | ✅ `object.zod.ts:1528` 确为 union;实装 `@objectstack/spec@17.0.0`;docblock 语义逐字核对 |
| #4647 | gap 1 渲染条件 / 宿主无条件传参 | ✅ 逐字成立。`ListView.tsx:2453`、`ObjectView.tsx:2013` |
| #4647 | gap 2「`editInline` 全 dist 只作 i18n 标签键,零消费」 | ⚠️ **部分证伪**。`InterfaceListPage.tsx:431` 就有一处消费:`inlineEdit: userActions.editInline === true`。dist 扫描看不见它,是因为该消费把键**映射成了** `inlineEdit`,键名没作为字符串留存。实质缺口仍在,但范围收窄为「对象列表工具栏路径零消费」 |

两处修正都不推翻卡的结论,故照常实施;记录在此以免下一位读者重蹈。

---

## #4646 半 —— 关联列表「+ New」消费 create 谓词

镜像模板 = **同面 `editPredicates` 的既有消费形**(`RecordDetailView.tsx:1063-1128`,即 #4419 / PR #4515 给记录页页头做的那一版),逐条对齐、不自创语义:

| 轴 | 记录页页头既有形 | 本 PR 关联列表工具栏 |
| --- | --- | --- |
| 求值器 | `useRowPredicate` → `evalRowPredicate` | `evalRowPredicate`(同一个,见下「为何无 hook」) |
| `visibleWhen` 缺省 | `?? true`,布尔短路 | 同 |
| `visibleWhen` 失败方向 | fail-**CLOSED**(`fallback: false`) | 同 |
| `visibleWhen` 声明判定 | `!= null`,非真值性(#3492 不变式) | 同 |
| `disabledWhen` 失败方向 | fail-**SOFT** | 同 |
| `disabledWhen` 声明判定 | `!= null` 门在求值**之外** | 同 |
| `fields` 传参 | 传对象字段定义,让关系字段按存储外键绑定 | 传**父对象**字段(被绑定的记录是父) |
| 隐藏 vs 置灰 | `visibleWhen` 折进 affordance 布尔;`disabledWhen` 走独立 `disabled` 标志 | 同 |

绑定域按 spec docblock:**对宿主父记录求值一次**(不是逐行)。独立对象列表没有 scope 记录 —— 它根本不经过这个桥接层。

**为何 hook-free**:`resolve` 要为**可变数量**的关联列表在**一个 `useMemo` 内**作答,每个子对象一次 `useRowPredicate` 会把 hook 数量绑到关联列表条数。这与 `plugin-grid` 的 `evalRowActionVisibility` 面对的是同一个约束(它的 row loop 逐 action 面对同一件事),故采同一解法;底层求值器两边都是 canonical 的 `evalRowPredicate`。

**新增的 disabled 通道**:`RelatedRecordHandlers` 原本只有「给 / 不给 `onCreate`」二值,契约明说「省略 = 隐藏该 affordance」。`disabledWhen` 需要第三态,故新增 `createDisabled` → `RelatedList` 的 `newDisabled` → 按钮 `disabled`。把 `disabledWhen` 折进隐藏是错的:它会让同一个键在这个面上的行为与其他所有面不同。

## #4647 半

**gap 1 挂点选择 —— 渲染侧,不是宿主侧。** 理由:

1. **同 bundle 既有实践**就在渲染侧。同文件 `ListView.tsx:1059` 的批量删除门 `resolveEffectiveCrudAffordances(objectDef, effectiveApiOps).delete && canDo(schema.objectName,'delete')` 就长在 ListView 自己身上,组件手里已经有 `usePermissions` 和 `objectDef`。
2. **一次设门覆盖全部宿主**。挂宿主侧只堵 `ObjectView` 一个入口;挂渲染侧连 `InterfaceListPage` 和任何嵌入宿主一起覆盖。

门形与批量删除逐字同构,只把 operation 从 `delete` 换成 `update`;第一段写作 `isObjectInlineEditable(...)`,它就是 `resolveEffectiveCrudAffordances(...).edit`,但用的是**说清这个面在问什么**的那个名字 —— 记录页正文的双击/铅笔也读同一个 helper,于是列表页和记录页不会对「这个对象的行能否就地编辑」给出两个答案。

**三个渲染点,不是一个。** 按消费半径清点后发现该 affordance 有三个入口,只堵卡里点名的那个会留下两扇门:

1. 宽工具栏开关(`ListView.tsx:2453`)—— 卡里点名的
2. **紧凑工具栏设置浮层入口**(`ListView.tsx:2905`,`showInlineEdit={currentView === 'grid'}`)—— 此前**完全无门**,连 `onInlineEditChange` 都不要求
3. **交给 grid 的 `editable` 模式本身**(`ListView.tsx:1885`)—— 存量视图存着 `inlineEdit: true` 时,只读账号连开关都不用按就直接落进可编辑单元格,「改单元格 → 全部保存 → 403」这条卡里描述的往返原样可达

只堵 1 会让卡自己描述的后果仍然可达,故三处同用一个 `inlineEditOffered` 判定。

**gap 2 缺省语义 —— 如实写明,并未强制 spec 的 `.default(false)`。**

`editInline` 显式 `false` ⇒ 不提供;显式 `true` ⇒ 提供;**缺省 ⇒ 沿用宿主既有的 `inlineEdit` 通道**。这是与 spec 声明缺省的一处有意分歧,理由:强制 `.default(false)` 会一次性抹掉**所有**存量 console 列表视图的行内编辑 —— 没有任何 legacy 键折叠进 `editInline`(`SHOW_FLAG_TO_USER_ACTION` 无此条目),存量视图也都没声明它。这正是相邻 `toolbarFlags` 块为自己写下的规则(缺省取「这些开关一直以来的行为」;`hideFields`/`rowColor` 保持历史 OFF,因为翻转「会在每个存量视图上多长两个按钮」)在**会删掉一个入口**方向上的同一应用。

该分歧连同「收敛到 spec 缺省」的两条路径,已另立 finding #5144 交维护者裁决,并在测试里钉了一条同名用例,使日后改动缺省是决策而非事故。

---

## 反向验证(**先书面预判,后跑;commit 后变异、跑完还原**)

预判写在 `4646-reverse-predictions.md`(scratch,已删),三条**全部命中**,其中 (c) 的细节值得单独说:

**(a) 摘掉 create 谓词消费** → 预判 RED,且恰是 6 条依赖谓词的用例;boolean 臂与对象级门用例须**保持绿**。
实测 `6 failed | 19 passed`,红的正是预判的 6 条,boolean 臂与对象级门全绿,兄弟文件 `effectiveOps` 全绿。

**(b) 摘掉 `can(update)` 门** → 预判 RED 3 条。
实测 `3 failed | 14 passed`,恰为预判三条(无权限失开关 / 存量视图仍进编辑模式 / 紧凑入口),gap-2 用例与 fail-open 用例保持绿。

**(c) 自选非显然方向 —— 隐藏 vs 置灰的分界实测。** 变异:把 `disabledWhen` 也折成隐藏(`create: … && !createDisabled`)。
预判里明确写了一件事:这条变异**只会被一条断言抓住**,而且不是那条看起来最相关的 —— soft-fail 用例在两种实现下 `createDisabled` 都是 false,**不具区分力**;真正把线守住的是 disabled 用例里的 `expect(h.onCreate).toBe(true)`。
实测 `1 failed | 15 passed`,失败信息 `AssertionError: expected false to be true`,正是那一行。

第三条如实记录而非套模板:**这条边界目前由单一断言承载**。若日后有人在 disabled 用例里只留 `createDisabled` 的断言、删掉 `onCreate` 那行,折叠式回归会以「什么都没产出」的方式变绿(#5046 subtraction case 的同款陷阱)。

---

## 验证

- 仓根 `pnpm type-check`:**81/81 successful**
- 受影响包依赖预构建后跑测:
  - `plugin-list` + `plugin-detail`:**126 files / 1442 passed**
  - `app-shell/src/views` + `react` + `core`:**404 files / 5150 passed | 1 skipped**
  - `plugin-grid` + `components` + `app-shell` 全量:**658 files / 6203 passed | 1 skipped**
- 家族既有钉子(#4096/PR4108、#4419/PR4515 及同族)7 文件:**125/125 passed**
- 改动文件 `eslint`:**0 errors**(413 warnings 全是既有 `no-explicit-any` 风格告警)
- `check:control-bytes` OK;改动文件自扫(含 ESC 位)`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` → 0

新增测试:`RelatedRecordActionsBridge.createPredicates.test.tsx`(16 例)+ `ListView.permissions.test.tsx` 追加两个 describe(11 例)。

一处测试写法值得记:紧凑工具栏那两例必须**先点开 popover、且让 `Section` 展开**(`defaultOpen={!!inlineEdit}`)才有意义 —— 对着关着的浮层断言「不存在」,对任何实现都会绿。正例对照组一开始就是这么红的,红得对。

## 半径与刻意未动

- ⛔ 未动 spec、未动 data-adapter 生产侧、未动 `packages/react/SchemaRenderer`
- `DetailView.tsx:1538/1659` 的 `(related as any).onNew` 是 schema 作者自带回调通道,不经桥接层、不带对象元数据,**正确地未受影响**
- changeset:patch,如实写明只读用户的行为变化(UI 从「能进编辑再 403」变「不提供入口」;数据访问权限未变,服务端始终是执行边界)

## 半径外发现(均已查重、未指派)

- **#5142** —— `importPredicates` 同样产出、零消费,与 #4646 同族只差一个键。本 PR 刻意**未**放宽 `UserActionsOverride.import` 的类型:先放宽类型再补消费者,等于把刚修掉的病在隔壁键上重写一遍
- **#5143** —— `ObjectGrid` 的 `editable` schema 键无 `can(object,'update')` 门(`permissionUpdate` 在该文件已算出,却只喂给行 kebab)。#4647 的 ListView 层已堵,SDUI 直写 `editable: true` 的 grid 路径未堵,属不同组件、不同声明通道
- **#5144** `[finding]` —— 上文那处 `editInline` 跨面缺省分歧

## 家族关系

- **#4419 / #4213**(edit/delete 到记录页页头)—— 本 PR #4646 半的直接镜像模板,同为「谓词到了某些面没到另一些面」
- **#2614** —— 行 CRUD 谓词特性原点(仅 edit/delete)
- **#4096 / PR #4108**、**#3492** —— 「同工具栏上兄弟 affordance 都有门、唯独这个没有」的原型,本 PR #4647 半的门形来源

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_