### PR TITLE
fix(cli): resolve a directory argument through file-system routing (#5037)

### DIFF
--- a/.changeset/cli-directory-argument-5037.md
+++ b/.changeset/cli-directory-argument-5037.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/cli': patch
+---
+
+`dev`, `serve` and `build` accept the documented directory argument from anywhere, and refuse a non-project directory in plain language.
+
+`content/docs/utilities/cli.mdx` has recorded the positional argument as "Path
+to JSON/YAML schema file or `pages/` directory" and printed `objectui dev
+pages/` as the file-system-routing example. That promise had never actually been
+parsed. Detection's first step required `statSync(...).isFile()`, so a directory
+argument fell straight through it; the one spelling that worked — `objectui dev
+pages/` from inside the project — worked by coincidence of position, caught by
+the working-directory fallback rather than read as an argument. Every pathful
+spelling reached single-schema mode and handed a directory to `readFileSync`:
+
+```
+$ objectui dev my-app/pages
+Error: Invalid schema file: EISDIR: illegal operation on a directory, read
+```
+
+A directory argument now resolves through file-system routing in the shared
+resolution step the three commands were centralized on (objectui#4923), in
+either of the two shapes a user can mean: the directory **is** a `pages`
+directory, or it **contains** one. Both produce the same routed answer as naming
+the app config beside them — same project root, same routes, same app config —
+so `objectui dev my-app/pages`, `objectui dev my-app` and `objectui dev
+my-app/app.json` agree, from any working directory, across all three commands.
+The limb lives in the shared resolver, not in three command branches.
+
+The remaining directory-shaped miss is now diagnosed instead of leaking a
+`readFileSync` errno: a directory that is neither shape is refused by name,
+saying what would have been accepted. The refusal sits **after** the
+working-directory fallback, so nothing that resolves today stops resolving: this
+change accepts strictly more than before and rejects nothing that worked.

--- a/content/docs/utilities/cli.mdx
+++ b/content/docs/utilities/cli.mdx
@@ -59,12 +59,13 @@ Start the development server with hot reload. Opens the browser automatically.
 ```bash
 objectui dev app.json
 objectui dev pages/                    # file-system routing
+objectui dev my-app/pages              # ...from anywhere, not just inside my-app
 objectui dev --port 8080 --no-open
 ```
 
 | Argument / Flag | Default | Description |
 |---|---|---|
-| `[schema]` (positional) | `app.json` | Path to JSON/YAML schema file or `pages/` directory |
+| `[schema]` (positional) | `app.json` | Path to JSON/YAML schema file, or a project / `pages/` directory |
 | `-p, --port <port>` | `3000` | Port to bind |
 | `-h, --host <host>` | `localhost` | Host to bind |
 | `--no-open` | — | Do not open the browser |
@@ -85,7 +86,7 @@ objectui build --out-dir build --clean
 
 | Argument / Flag | Default | Description |
 |---|---|---|
-| `[schema]` (positional) | `app.json` | Path to JSON/YAML schema file |
+| `[schema]` (positional) | `app.json` | Path to JSON/YAML schema file, or a project / `pages/` directory |
 | `-o, --out-dir <dir>` | `dist` | Output directory |
 | `--clean` | `false` | Clean output directory before build |
 
@@ -247,11 +248,16 @@ three commands answer one invocation the same way from anywhere:
 
 1. The directory the schema argument points into — `objectui build my-app/app.json`
    run from above `my-app/` routes from `my-app/pages/`, with `my-app/app.json`
-   as the app config.
+   as the app config. A **directory** argument counts here too: it may be the
+   `pages/` directory itself (`objectui dev my-app/pages`) or the project
+   directory holding it (`objectui dev my-app`), and both answer exactly as
+   naming the app config beside them does — from any working directory.
 2. Otherwise the current working directory — `cd my-app && objectui dev` routes
    from `./pages/`, with `./app.json` as the app config when present.
 3. Otherwise the named file is rendered on its own (single-schema mode), which
-   is what a lone `.json`/`.yaml` schema with no `pages/` beside it does.
+   is what a lone `.json`/`.yaml` schema with no `pages/` beside it does. A
+   directory that reaches this step is no project, and is refused by name — it
+   is neither a `pages/` directory nor does it contain one.
 
 ## Programmatic API
 

--- a/packages/cli/src/__tests__/project-source.test.ts
+++ b/packages/cli/src/__tests__/project-source.test.ts
@@ -99,6 +99,21 @@ function writeProject(parent: string, name = 'app'): string {
   return root;
 }
 
+/**
+ * The three commands, each reduced to "resolve, then render".
+ *
+ * Every input handed to these below is decided inside the detection step, so
+ * none of the calls reaches Vite: they are the command layer's own answer to
+ * "what is this project", read off the thrown error. Shared by both parity
+ * groups (objectui#4923, objectui#5037) so "all three answer identically" is
+ * asserted against one list rather than two copies of it.
+ */
+const commands: ReadonlyArray<readonly [string, (schema: string) => Promise<unknown>]> = [
+  ['dev', (schema) => dev(schema, { port: '0', host: 'localhost', open: false })],
+  ['serve', (schema) => serve(schema, { port: '0', host: 'localhost' })],
+  ['build', (schema) => buildApp(schema, { outDir: 'dist' })]
+];
+
 describe('resolveProjectSource — anchoring on the argument (objectui#4923)', () => {
   it('finds the project from a directory above it', async () => {
     await withParentDir((parent) => {
@@ -181,11 +196,17 @@ describe('resolveProjectSource — anchoring on the argument (objectui#4923)', (
       expect(noAppConfig.appConfig).toBeNull();
       expect(noAppConfig.appConfigPath).toBeNull();
 
+      // `objectui dev pages/` from inside the project reaches the SAME routed
+      // answer, but since objectui#5037 it is step ① that gives it: the
+      // argument names the pages directory, so it no longer needs the cwd
+      // fallback to catch it by coincidence. Only the origin label moved.
       writeJson(join(parent, 'app.json'), APP_CONFIG);
       const viaPagesDir = resolveProjectSource(parent, 'pages');
       expect(viaPagesDir.mode).toBe('routes');
       if (viaPagesDir.mode !== 'routes') return;
-      expect(viaPagesDir.pagesDirOrigin).toBe('cwd');
+      expect(viaPagesDir.pagesDirOrigin).toBe('argument-dir');
+      expect(viaPagesDir.projectRoot).toBe(parent);
+      expect(viaPagesDir.pagesDir).toBe(join(parent, 'pages'));
       expect(viaPagesDir.appConfig).toEqual(APP_CONFIG);
     });
   });
@@ -318,19 +339,6 @@ describe('dev / serve / build detection parity (objectui#4923)', () => {
     vi.restoreAllMocks();
   });
 
-  /**
-   * The three commands, each reduced to "resolve, then render".
-   *
-   * Every input below is decided inside the detection step, so none of these
-   * calls reaches Vite: they are the command layer's own answer to "what is this
-   * project", read off the thrown error.
-   */
-  const commands: ReadonlyArray<readonly [string, (schema: string) => Promise<unknown>]> = [
-    ['dev', (schema) => dev(schema, { port: '0', host: 'localhost', open: false })],
-    ['serve', (schema) => serve(schema, { port: '0', host: 'localhost' })],
-    ['build', (schema) => buildApp(schema, { outDir: 'dist' })]
-  ];
-
   it.each(commands)('%s anchors the project on the argument, not on cwd', async (_name, run) => {
     await withParentDir(async (parent) => {
       const root = join(parent, 'app');
@@ -365,6 +373,180 @@ describe('dev / serve / build detection parity (objectui#4923)', () => {
       vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await expect(run('nope.json')).rejects.toThrow('Schema file not found: nope.json');
+    });
+  });
+});
+
+
+/**
+ * The documented directory form (objectui#5037).
+ *
+ * `content/docs/utilities/cli.mdx` records the positional argument as "Path to
+ * JSON/YAML schema file or `pages/` directory" and shows `objectui dev pages/`.
+ * Before this fix that promise had never been parsed: step ① required
+ * `statSync(...).isFile()`, so a directory argument fell straight through it,
+ * and only the one spelling that happened to BE `<cwd>/pages` was caught — by
+ * the cwd fallback, as a coincidence of position rather than a reading of the
+ * argument. Every pathful spelling reached step ③ and handed a directory to
+ * `readFileSync`:
+ *
+ *     $ objectui dev my-app/pages
+ *     Error: Invalid schema file: EISDIR: illegal operation on a directory, read
+ *
+ * Ruled 2026-08-17 (「同意」): support it, in step ① so all three commands
+ * answer identically, and refuse the remaining directory-shaped miss in plain
+ * language instead of leaking EISDIR.
+ */
+describe('resolveProjectSource — directory arguments (objectui#5037)', () => {
+  it('routes from a pathful `pages/` argument, invoked from outside the project', async () => {
+    await withParentDir((parent) => {
+      // The card's own invocation: `objectui dev my-app/pages`, run from ABOVE
+      // `my-app`. The cwd-relative spelling passes on the unfixed code, so it
+      // is this one that carries the defect.
+      const root = writeProject(parent);
+      const source = resolveProjectSource(parent, 'app/pages');
+
+      expect(source.mode).toBe('routes');
+      if (source.mode !== 'routes') return;
+      expect(source.projectRoot).toBe(root);
+      expect(source.pagesDir).toBe(join(root, 'pages'));
+      expect(source.pagesDirOrigin).toBe('argument-dir');
+      expect(source.routes.map((route) => route.path)).toEqual(['/']);
+      expect(source.appConfig).toEqual(APP_CONFIG);
+      expect(source.appConfigPath).toBe(join(root, 'app.json'));
+      expect(source.warnings).toEqual([]);
+    });
+  });
+
+  it('routes from a project directory that contains a `pages/`', async () => {
+    await withParentDir((parent) => {
+      const root = writeProject(parent);
+      const source = resolveProjectSource(parent, 'app');
+
+      expect(source.mode).toBe('routes');
+      if (source.mode !== 'routes') return;
+      expect(source.projectRoot).toBe(root);
+      expect(source.pagesDir).toBe(join(root, 'pages'));
+      expect(source.pagesDirOrigin).toBe('argument-dir');
+      expect(source.appConfig).toEqual(APP_CONFIG);
+      expect(source.appConfigPath).toBe(join(root, 'app.json'));
+    });
+  });
+
+  it('answers a directory argument exactly as it answers the app config beside it', async () => {
+    await withParentDir((parent) => {
+      const root = writeProject(parent);
+      writeJson(join(root, 'pages/about.json'), PAGE);
+
+      const viaAppConfig = resolveProjectSource(parent, 'app/app.json');
+      const spellings = [
+        resolveProjectSource(parent, 'app'),
+        resolveProjectSource(parent, 'app/pages'),
+        resolveProjectSource(parent, 'app/pages/'),
+        resolveProjectSource(parent, join(root, 'pages'))
+      ];
+
+      expect(viaAppConfig.mode).toBe('routes');
+      if (viaAppConfig.mode !== 'routes') return;
+      for (const source of spellings) {
+        expect(source.mode).toBe('routes');
+        if (source.mode !== 'routes') continue;
+        expect(source.projectRoot).toBe(viaAppConfig.projectRoot);
+        expect(source.pagesDir).toBe(viaAppConfig.pagesDir);
+        expect(source.routes).toEqual(viaAppConfig.routes);
+        expect(source.appConfig).toEqual(viaAppConfig.appConfig);
+        expect(source.appConfigPath).toBe(viaAppConfig.appConfigPath);
+        expect(source.warnings).toEqual([]);
+      }
+    });
+  });
+
+  it('refuses a directory that is neither, naming what was expected', async () => {
+    await withParentDir((parent) => {
+      mkdirSync(join(parent, 'not-a-project/src'), { recursive: true });
+
+      // A non-zero exit is NOT the assertion: `EISDIR` exits non-zero too, so an
+      // exit-code pin cannot tell the fix from the bug. What must hold is that
+      // the sentence names the directory and what was expected of it.
+      const refuse = () => resolveProjectSource(parent, 'not-a-project');
+      expect(refuse).toThrow('Not a project directory: not-a-project');
+      expect(refuse).toThrow(/'pages' directory/);
+      expect(refuse).not.toThrow(/EISDIR/);
+    });
+  });
+
+  it('leaves the working-directory fallback ahead of the refusal', async () => {
+    // A directory argument that resolves to nothing does not become fatal while
+    // the cwd still names a project: the fallback that answers every unresolved
+    // argument today keeps answering this one. objectui#5037 adds a limb and a
+    // diagnosis; it narrows nothing.
+    await withParentDir((parent) => {
+      writeJson(join(parent, 'pages/index.json'), PAGE);
+      mkdirSync(join(parent, 'not-a-project'), { recursive: true });
+
+      const source = resolveProjectSource(parent, 'not-a-project');
+      expect(source.mode).toBe('routes');
+      if (source.mode !== 'routes') return;
+      expect(source.pagesDir).toBe(join(parent, 'pages'));
+      expect(source.pagesDirOrigin).toBe('cwd');
+    });
+  });
+
+  it('keeps a directory named `pages` legible when it holds no schema', async () => {
+    await withParentDir((parent) => {
+      mkdirSync(join(parent, 'app/pages'), { recursive: true });
+
+      expect(() => resolveProjectSource(parent, 'app/pages')).toThrow(
+        `No schema files found in ${join(parent, 'app/pages')}`
+      );
+    });
+  });
+});
+
+describe('dev / serve / build answer a directory argument identically (objectui#5037)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(commands)('%s routes a pathful `pages/` argument to the argument\'s project', async (_name, run) => {
+    await withParentDir(async (parent) => {
+      const root = join(parent, 'app');
+      writeJson(join(root, 'app.json'), APP_CONFIG);
+      mkdirSync(join(root, 'pages'), { recursive: true });
+      vi.spyOn(process, 'cwd').mockReturnValue(parent);
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // The `pages/` is left empty so the verdict is reached inside detection,
+      // before Vite: naming this directory is the proof that the pathful
+      // argument — not cwd, which is not a project at all here — got scanned.
+      await expect(run('app/pages')).rejects.toThrow(
+        `No schema files found in ${join(root, 'pages')}`
+      );
+    });
+  });
+
+  it.each(commands)('%s routes a pathful project directory to the same place', async (_name, run) => {
+    await withParentDir(async (parent) => {
+      const root = join(parent, 'app');
+      writeJson(join(root, 'app.json'), APP_CONFIG);
+      mkdirSync(join(root, 'pages'), { recursive: true });
+      vi.spyOn(process, 'cwd').mockReturnValue(parent);
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await expect(run('app')).rejects.toThrow(`No schema files found in ${join(root, 'pages')}`);
+    });
+  });
+
+  it.each(commands)('%s refuses a non-project directory in plain language', async (_name, run) => {
+    await withParentDir(async (parent) => {
+      mkdirSync(join(parent, 'not-a-project'), { recursive: true });
+      vi.spyOn(process, 'cwd').mockReturnValue(parent);
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await expect(run('not-a-project')).rejects.toThrow(
+        'Not a project directory: not-a-project'
+      );
+      await expect(run('not-a-project')).rejects.toThrow(/'pages' directory/);
     });
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -45,7 +45,7 @@ program
 program
   .command('serve')
   .description('Start a development server with your JSON/YAML schema')
-  .argument('[schema]', 'Path to JSON/YAML schema file', 'app.json')
+  .argument('[schema]', 'Path to JSON/YAML schema file, or a project / pages directory', 'app.json')
   .option('-p, --port <port>', 'Port to run the server on', '3000')
   .option('-h, --host <host>', 'Host to bind the server to', 'localhost')
   .action(async (schema, options) => {
@@ -60,7 +60,7 @@ program
 program
   .command('dev')
   .description('Start development server (alias for serve)')
-  .argument('[schema]', 'Path to JSON/YAML schema file', 'app.json')
+  .argument('[schema]', 'Path to JSON/YAML schema file, or a project / pages directory', 'app.json')
   .option('-p, --port <port>', 'Port to run the server on', '3000')
   .option('-h, --host <host>', 'Host to bind the server to', 'localhost')
   .option('--no-open', 'Do not open browser automatically')
@@ -76,7 +76,7 @@ program
 program
   .command('build')
   .description('Build application for production')
-  .argument('[schema]', 'Path to JSON/YAML schema file', 'app.json')
+  .argument('[schema]', 'Path to JSON/YAML schema file, or a project / pages directory', 'app.json')
   .option('-o, --out-dir <dir>', 'Output directory', 'dist')
   .option('--clean', 'Clean output directory before build', false)
   .action(async (schema, options) => {

--- a/packages/cli/src/utils/project-source.ts
+++ b/packages/cli/src/utils/project-source.ts
@@ -48,14 +48,20 @@
  */
 
 import { existsSync, statSync } from 'fs';
-import { dirname, join, relative, resolve } from 'path';
+import { basename, dirname, join, relative, resolve } from 'path';
 
 import chalk from 'chalk';
 
 import { parseSchemaFile, scanPagesDirectory, type RouteInfo } from './app-generator.js';
 
-/** Where the `pages/` directory that won was found. */
-export type PagesDirOrigin = 'schema-dir' | 'cwd';
+/**
+ * Where the `pages/` directory that won was found.
+ *
+ * - `schema-dir` — beside the schema FILE the argument named.
+ * - `argument-dir` — the argument was itself a directory (objectui#5037).
+ * - `cwd` — the working-directory fallback.
+ */
+export type PagesDirOrigin = 'schema-dir' | 'argument-dir' | 'cwd';
 
 /** File-system routing: a `pages/` directory decides the routes. */
 export interface RoutedProjectSource {
@@ -64,7 +70,7 @@ export interface RoutedProjectSource {
   projectRoot: string;
   /** Absolute path of the `pages/` directory being scanned. */
   pagesDir: string;
-  /** Which of the two candidate locations `pagesDir` came from. */
+  /** Which of the candidate locations `pagesDir` came from. */
   pagesDirOrigin: PagesDirOrigin;
   routes: RouteInfo[];
   /** Parsed app config, when one was found and readable. */
@@ -114,37 +120,47 @@ function readAppConfig(path: string, warnings: string[]): unknown {
  *
  * Resolution order — first match wins:
  *
- * 1. `<schemaArg>` is an existing file and `pages/` sits beside it → routing
+ * 1. `<schemaArg>` names an existing file and `pages/` sits beside it → routing
  *    from there, with the named file as the app config. This is the limb
- *    `serve`/`build` never had.
+ *    `serve`/`build` never had. `<schemaArg>` names an existing DIRECTORY that
+ *    either IS a `pages` directory or contains one → routing from it, with
+ *    `<projectRoot>/app.json` as the app config when it exists (objectui#5037).
  * 2. `<cwd>/pages` exists → routing from there, with `<cwd>/app.json` as the app
  *    config when it exists. Invoking inside the project keeps working, including
- *    with the default `app.json` argument and with a `pages/` argument.
+ *    with the default `app.json` argument.
  * 3. Otherwise → single schema file mode.
  *
  * Throws when the resolved input cannot be rendered at all: a missing schema
- * file, an unparsable one, or a `pages/` directory holding no schema.
+ * file, an unparsable one, a `pages/` directory holding no schema, or a
+ * directory argument that is no project.
  */
 export function resolveProjectSource(cwd: string, schemaArg: string): ProjectSource {
   const warnings: string[] = [];
   const absoluteSchemaPath = resolve(cwd, schemaArg);
 
-  // 1. Anchored on the argument: a project is the directory the schema lives in.
-  if (existsSync(absoluteSchemaPath) && statSync(absoluteSchemaPath).isFile()) {
-    const projectRoot = dirname(absoluteSchemaPath);
-    const pagesDir = join(projectRoot, 'pages');
+  // 1. Anchored on the argument, whether it names a file or a directory.
+  if (existsSync(absoluteSchemaPath)) {
+    const argumentStats = statSync(absoluteSchemaPath);
 
-    if (existsSync(pagesDir)) {
-      return {
-        mode: 'routes',
-        projectRoot,
-        pagesDir,
-        pagesDirOrigin: 'schema-dir',
-        routes: scanRoutes(pagesDir),
-        appConfig: readAppConfig(absoluteSchemaPath, warnings),
-        appConfigPath: absoluteSchemaPath,
-        warnings
-      };
+    if (argumentStats.isFile()) {
+      const projectRoot = dirname(absoluteSchemaPath);
+      const pagesDir = join(projectRoot, 'pages');
+
+      if (existsSync(pagesDir)) {
+        return {
+          mode: 'routes',
+          projectRoot,
+          pagesDir,
+          pagesDirOrigin: 'schema-dir',
+          routes: scanRoutes(pagesDir),
+          appConfig: readAppConfig(absoluteSchemaPath, warnings),
+          appConfigPath: absoluteSchemaPath,
+          warnings
+        };
+      }
+    } else if (argumentStats.isDirectory()) {
+      const fromDirectory = resolveDirectoryArgument(absoluteSchemaPath, warnings);
+      if (fromDirectory) return fromDirectory;
     }
   }
 
@@ -173,6 +189,19 @@ export function resolveProjectSource(cwd: string, schemaArg: string): ProjectSou
     );
   }
 
+  // A directory can never be a schema file. Before objectui#5037 this fell into
+  // `parseSchemaFile` and surfaced the raw `EISDIR: illegal operation on a
+  // directory, read` from `readFileSync` — an error that names neither the
+  // argument's shape nor what would have been accepted instead.
+  if (statSync(absoluteSchemaPath).isDirectory()) {
+    throw new Error(
+      `Not a project directory: ${schemaArg}\n` +
+        `A directory argument must be a 'pages' directory, or contain one, for file-system ` +
+        `routing — ${absoluteSchemaPath} is neither.\n` +
+        `Pass a JSON/YAML schema file instead, or run 'objectui init' to create a project.`
+    );
+  }
+
   let schema: unknown;
   try {
     schema = parseSchemaFile(absoluteSchemaPath);
@@ -189,6 +218,46 @@ export function resolveProjectSource(cwd: string, schemaArg: string): ProjectSou
     projectRoot: dirname(absoluteSchemaPath),
     schemaFile: absoluteSchemaPath,
     schema,
+    warnings
+  };
+}
+
+/**
+ * Resolve a DIRECTORY argument to a routed project, or `null` when it is no
+ * project (objectui#5037).
+ *
+ * Two shapes are accepted, in this order: the directory IS the `pages`
+ * directory (`objectui dev my-app/pages`, the form the docs print), or it
+ * CONTAINS one (`objectui dev my-app`). Both produce the same answer as naming
+ * the app config beside them would — which is what "the three commands answer
+ * one invocation the same way" has to mean for the documented directory form
+ * too, and the reason this lives in step ① rather than in each command.
+ *
+ * Returning `null` rather than throwing keeps the working-directory fallback
+ * ahead of the refusal: an argument that resolves to nothing is answered by
+ * `<cwd>/pages` exactly as any other unresolved argument is, and only reaches
+ * the diagnosis in step ③ when there is no such fallback either.
+ */
+function resolveDirectoryArgument(argumentDir: string, warnings: string[]): RoutedProjectSource | null {
+  const isPagesDir = basename(argumentDir) === 'pages';
+  const pagesDir = isPagesDir ? argumentDir : join(argumentDir, 'pages');
+
+  if (!isPagesDir && !(existsSync(pagesDir) && statSync(pagesDir).isDirectory())) {
+    return null;
+  }
+
+  const projectRoot = isPagesDir ? dirname(argumentDir) : argumentDir;
+  const appConfigPath = join(projectRoot, 'app.json');
+  const hasAppConfig = existsSync(appConfigPath) && statSync(appConfigPath).isFile();
+
+  return {
+    mode: 'routes',
+    projectRoot,
+    pagesDir,
+    pagesDirOrigin: 'argument-dir',
+    routes: scanRoutes(pagesDir),
+    appConfig: hasAppConfig ? readAppConfig(appConfigPath, warnings) : null,
+    appConfigPath: hasAppConfig ? appConfigPath : null,
     warnings
   };
 }


### PR DESCRIPTION
Fixes #5037

Implements the maintainer ruling recorded 2026-08-17 (verbatim 「同意」): **support it**.

## The defect

`content/docs/utilities/cli.mdx` records the positional argument as "Path to JSON/YAML schema file or `pages/` directory" and prints `objectui dev pages/` as the file-system-routing example. That promise had never been parsed. Step ① of the shared resolution required `statSync(...).isFile()`, so a directory argument fell straight through it; the one spelling that worked — `objectui dev pages/` from inside the project — worked by **coincidence of position**, caught by the cwd fallback in step ② rather than read as an argument. Any pathful spelling reached step ③ and handed a directory to `readFileSync`:

```
$ objectui dev my-app/pages
Error: Invalid schema file: EISDIR: illegal operation on a directory, read
```

## The change

One limb, in `packages/cli/src/utils/project-source.ts` **step ①** — the resolution point #4923 centralized — so all three commands answer identically by construction. No per-command branch was added; the three call sites are untouched.

- A directory argument resolves through file-system routing in either shape a user can mean: the directory **is** a `pages` directory (`objectui dev my-app/pages`), or it **contains** one (`objectui dev my-app`). Both produce the same routed answer as naming the app config beside them — same project root, same pages dir, same routes, same app config.
- New `PagesDirOrigin` member `argument-dir`, so the diagnostic label says the argument named it rather than mislabelling it `schema-dir` or `cwd`.
- The remaining directory-shaped miss is refused **by name** in step ③, saying what would have been accepted, instead of leaking a `readFileSync` errno.
- The refusal sits **after** the cwd fallback (`resolveDirectoryArgument` returns `null` rather than throwing), so nothing that resolves today stops resolving. This change accepts strictly more than before and rejects nothing that worked.

## Both pins, red before / green after

Measured on the same fixture, invoked from the directory **above** the project — the cwd-relative case passes on the unfixed code and proves nothing.

| Pin | Before | After |
|---|---|---|
| `objectui dev my-app/pages` from outside cwd | `Invalid schema file: EISDIR: illegal operation on a directory, read` | routed: `Detected project structure at .../my-app`, `Found 1 route(s)` |
| non-project directory argument | same raw `EISDIR` | `Not a project directory: not-a-project` + what was expected |

Whole-file pre-fix run of the amended test file: **15 failed / 25 passed**, every failure receiving `Invalid schema file: EISDIR`. After the fix, the package's full suite is **164 passed (164)**, 7 files, exit 0, at `3e26e38`.

The refusal pin asserts the **message**, not the exit code — `EISDIR` also exits non-zero, so an exit-code pin cannot tell the fix from the bug. It also asserts the message does **not** contain `EISDIR`.

## Three-command identity

The three are `dev`, `serve` and `build` (`start` serves a prebuilt `dist/` and takes no schema argument; `validate` is a separate surface). All three route through `resolveProjectSource(cwd, schemaPath)` — verified in source, and the existing #4923 group already pins that call. The identity is now pinned **behaviourally** for the directory form too, rather than assumed from the shared call site: a new `it.each` group runs all three against a pathful `pages/` argument, a pathful project directory, and a non-project directory, asserting each answers identically. The `commands` table was hoisted to module scope so both parity groups assert against one list.

End-to-end with the built CLI, run from **outside** the project, detection output is byte-identical across all three spellings:

```
$ node packages/cli/dist/cli.js build my-app/pages   # and: my-app   and: my-app/app.json
Detected project structure at .../my-app
Loaded App Config from my-app/app.json
Using file-system routing from .../my-app/pages
Found 1 route(s)
  / -> my-app/pages/index.json
```

(All three then fail identically at `Installing dependencies` — no network in this container. The already-working `my-app/app.json` spelling fails at the same step, so it is the environment, not this change.)

## Reverse verification

**Predicted before running: RED**, failing with the defect's own `EISDIR` message. Two legs, so each pin proves it tests its own half. Source-level ablation on vitest, which transforms `src/` directly — no `dist/` is involved, so no rebuild applies.

| Ablation | Result |
|---|---|
| Leg 1 — restore the pre-fix `isFile()`-only step ① (keep the refusal) | **11 failed / 29 passed.** All routing pins red (`expected 'cwd' to be 'argument-dir'`; the command-level ones now hit `Not a project directory` where a route was expected). The 4 refusal pins stay **green** — correctly, they do not cover the routing half. |
| Leg 2 — remove only the step ③ refusal (keep step ①) | **4 failed / 36 passed.** Exactly the refusal pins, each receiving `Invalid schema file: EISDIR: illegal operation on a directory, read`. |

The two red sets are disjoint and their union is 15 — the pre-fix red count. No pin stayed green under the ablation of the thing it claims to test. The working tree was restored to byte-identity with `3e26e38` (`git diff HEAD` empty) before the gates were run.

## Gate union — derived from the actual changed paths

Changed: `packages/cli/src/utils/project-source.ts`, `packages/cli/src/cli.ts`, `packages/cli/src/__tests__/project-source.test.ts`, `content/docs/utilities/cli.mdx`, `.changeset/cli-directory-argument-5037.md`. The repo's `check:*` family is 11 scripts, so all 11 were run rather than a subset — cheaper than arguing about scan sets. All quoted verbatim, run at `3e26e38` with a clean tree:

```
check:spec-symbols          EXIT=0
check:action-forward-parity EXIT=0
check:phantom-deps          EXIT=0
check:self-import           EXIT=0
check:control-bytes         EXIT=0   (scanned 4566 tracked text files)
check:published-dist        EXIT=0
check:i18n-keys             EXIT=0
check:i18n-drift            EXIT=0
check:i18n-dead-keys        EXIT=0
check:skills-paths          EXIT=0
check:doc-types             EXIT=0
@object-ui/cli lint         EXIT=0   (11 pre-existing warnings, none in touched files)
@object-ui/cli type-check   EXIT=0
@object-ui/cli vitest       EXIT=0   (7 files, 164 tests)
```

A control-byte self-scan over the five changed files (`grep -naP` for the C0 range plus DEL) returns no matches, beyond the gate.

## Changeset

Added — `.changeset/cli-directory-argument-5037.md`, `@object-ui/cli: patch`. This changes published runtime behaviour, so the tests-only `skip-changeset` route does not apply (and that label does not exist in this repo). `patch` rather than `minor`: it makes an already-documented argument form work and replaces an errno with a sentence; it declares no new surface.

## Docs

The `pages/` promise in `content/docs/utilities/cli.mdx` needed **no correction** — it is now true, and stays as written. Three additions were made rather than fixes:

- the resolution-order list gained the directory limb (step 1) and the refusal (step 3), which it otherwise understated;
- the `build` table's positional description was brought in line with `dev`'s — the same argument was documented two different ways;
- one example line, `objectui dev my-app/pages`, showing the form that was broken.

`cli.ts`'s own `--help` text for all three commands said only "Path to JSON/YAML schema file" while the docs said otherwise; it now reads "Path to JSON/YAML schema file, or a project / pages directory". Named here rather than left as a silent drive-by: same defect class as the card, mechanical, and the CLI's own help is the other half of the promise being made true.

## Out of scope

Nothing else needed filing. One thing deliberately **not** changed: a directory argument that resolves to nothing is still answered by the cwd fallback when cwd is a project, exactly as every other unresolved argument is today. Making that fatal would narrow behaviour, which this card does not authorize; it is pinned as preserved rather than altered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_