### PR TITLE
fix(docs): restore the intended bytes of the AGENTS.md heredoc example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ AGENTS.md 的「只跑受影响的包」指的是**用上面的路径过滤缩�
   1. **首选机制:让内容根本不落共享盘。** 提交信息用 `git commit -F -` 配 heredoc(或多个 `-m`),PR 正文直接作为工具参数传(用 `gh` 就把正文写成进程内的 heredoc,别先写文件再 `--body-file`)。内容不落盘,就无从被顶掉。
 
   ```bash
-  git commit -F - <<'"'"'EOF'"'"'
+  git commit -F - <<'EOF'
   fix(scope): 一句话主题
 
   正文……


### PR DESCRIPTION
Fixes #5150

One line. The shared-scratchpad clause in `AGENTS.md` §9 recommends `git commit -F -` with a heredoc as the *mechanism* half of the rule, but the line landed carrying the single-quote-inside-single-quotes shell escape, leaked in by the write that created it. Copied verbatim, the heredoc's terminator is no longer `EOF`, so the closing line never matches and the command hangs with no error — pushing the reader back to the temp-file fallback that the very same paragraph argues against.

Surrounding prose, the numbered ordering, and the paragraph arguing why mechanism outranks discipline are untouched, per the card. The diff is 1 insertion, 1 deletion.

## Byte verification (not rendering)

A diff view escapes quotes and looks fine either way, so these are read back from the committed object at `55ab4c9`.

```
$ git show HEAD:AGENTS.md | cat -A | grep -n "EOF"
230:  git commit -F - <<'EOF'$
234:  EOF$
```

```
$ git show HEAD:AGENTS.md | grep -n "commit -F -"
227:  1. **首选机制:让内容根本不落共享盘。** 提交信息用 `git commit -F -` 配 heredoc(或多个 `-m`),PR 正文直接作为工具参数传(用 `gh` 就把正文写成进程内的 heredoc,别先写文件再 `--body-file`)。内容不落盘,就无从被顶掉。
230:  git commit -F - <<'EOF'
239:  两条不是并列的两个建议:前缀与删除要求每个作者每一次都记得,记性会衰减,而衰减是静默的(见上:撞车不报错);`git commit -F -` 那种形式让撞车**不可能发生**,不依赖任何人的记性。所以能用形式解决的,就别退回到纪律。这一族目前**没有钩子**兜底(上面 worktree 与 stash 两条各有一个 PreToolUse 钩子),因此这条规则的全部效力就在于你选哪种形式。
```

A residue scan over the committed blob returns nothing (grep exit 1). The fix was applied with an editing tool, never a nested-quoted shell heredoc — that write path is what produced the defect in the first place.

## Gates

Derived from the changed path (`AGENTS.md`) by inspecting each script's actual scan set, not from recall. All run at `55ab4c9`, the final commit:

| Gate | Exit |
|---|---|
| `node scripts/check-control-bytes.mjs` | `0` |
| `node scripts/check-doc-links.mjs` | `0` |
| `node scripts/check-changeset-presence.mjs` | `0` |
| `node scripts/check-changeset-no-major.mjs` | `0` |

Included because `AGENTS.md` is genuinely in scope: `check-control-bytes` enumerates via `git ls-files` (all tracked text files), and `check-doc-links` lists `{ path: 'AGENTS.md', rule: 'disk' }` explicitly. Excluded with reason: `check-skills-paths` has `SCAN_ROOT = 'skills'`, so a root file is outside it; the remaining `check:*` scripts reference `AGENTS.md` only in header comments, not in a scan set.

## Changeset

None, and none is owed — `check-changeset-presence` decides this itself and says so:

```
Compared the working tree with 51e65d423 (merge-base with origin/main): 1 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

Its guarded surface is `<` pkg `>/src/**` for packages in the `fixed` group of `.changeset/config.json`; a root `AGENTS.md` edit is outside it. Note for the reviewer: no `skip-changeset` label was applied, because that mechanism does not exist in this repository — `content/docs/guide/ci-cd-pipeline.md` records it explicitly ("None of it existed"), and the exemption form here is an empty-frontmatter changeset, which this change does not need either.

## Reverse verification

Predicted before running: **nothing goes red**. Observed: exactly that.

Re-introducing the corrupted bytes and re-running the full derived union left all four gates at exit `0`. The re-introduction was byte-identical to `origin/main` — independently confirmed by `check-changeset-presence` then reporting `0 file(s) changed` against the merge-base.

Reasons, all by design rather than oversight: `check-control-bytes` judges control bytes only, and `'` (0x27) / `"` (0x22) are printable ASCII; `check-doc-links` parses links and paths, and its own header notes this file has no markdown links at all; the changeset gates never read file content.

The generalized hole — no gate anywhere validates whether a fenced shell example in any markdown file is executable — is filed separately, unassigned, as #5151 with the measurement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_