### PR TITLE
fix(app-shell,core): 对象列表工具栏 Import 消费 importPredicates (#5142)

### DIFF
--- a/.changeset/object-list-import-predicates-5142.md
+++ b/.changeset/object-list-import-predicates-5142.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/core': patch
+---
+
+The object list's Import button now honours `userActions.import`'s CEL predicates.
+
+`@objectstack/spec@17.0.0` widened BOTH toolbar-scope keys, not just `create`:
+`userActions.create` and `userActions.import` are typed identically
+(`z.union([z.boolean(), RowCrudActionOverrideSchema])`) and
+`resolveCrudAffordances` emits a predicate envelope for each, with the docblock
+binding them in one breath ("`importPredicates` — same binding as
+`createPredicates`"). objectui#4646 gave the `create` half a consumer and left
+the `import` half declared-and-inert: `importPredicates` had zero readers in
+objectui. An author could write `userActions.import.visibleWhen`, have the spec
+accept it and the resolver parse it, and watch the object-list toolbar offer the
+CSV import wizard unconditionally.
+
+The toolbar now evaluates them, mirroring the related list's create half:
+`visibleWhen` fails CLOSED (an unevaluable predicate hides the entry and warns
+once), `disabledWhen` fails SOFT (an unevaluable one leaves the button enabled),
+and the declared-ness rules are the family's — `?? true` for `visibleWhen` so
+`visibleWhen: false` hides rather than reading as "ungated", `!= null` for
+`disabledWhen` so an empty predicate reads as "no condition". The layer sits on
+TOP of the object-level verdict: a predicate can narrow what the `managedBy`
+bucket, the server's effective API operations and the principal's grant already
+allow, never re-open what they closed.
+
+Per the spec's binding, a toolbar predicate evaluates once per toolbar against
+the record of the scope the toolbar sits in — and a standalone object list has
+no record in scope. Predicates over the host scope (`os.user.*`, `features.*`)
+are the meaningful shape there; one reading `record.*` has nothing to bind and
+hides the entry, which is the fail-closed rule the spec spells out for exactly
+this surface.
+
+`UserActionsOverride.import` widens from `boolean` to the same union as
+`create`, deliberately in this same change: objectui#4646 kept it narrow on
+purpose because widening a type ahead of its consumer re-declares the
+inert-metadata defect one key over. Type and consumer travel together.

--- a/packages/app-shell/src/views/ObjectView.importPredicates.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.importPredicates.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * [#5142] The object-list toolbar's Import button and `userActions.import`.
+ *
+ * `@objectstack/spec@17.0.0` widened BOTH toolbar-scope keys, not just
+ * `create`: `userActions.create` and `userActions.import` are typed
+ * identically (`z.union([z.boolean(), RowCrudActionOverrideSchema])`) and
+ * `resolveCrudAffordances` emits a predicate envelope for each. objectui#4646
+ * gave `createPredicates` a consumer (the related-list toolbar); `importPredicates`
+ * had ZERO consumers in objectui src, so an author could write
+ * `userActions.import.visibleWhen`, have the spec accept it and the resolver
+ * parse it, and watch this toolbar offer the CSV wizard unconditionally.
+ *
+ * BINDING under test is the spec docblock's: a toolbar predicate evaluates ONCE
+ * per toolbar against the record of the scope the toolbar sits in — and a
+ * STANDALONE object list (this surface) has no record in scope. That is not a
+ * gap in this test's setup, it is the documented binding: "On a standalone
+ * object list there is no record in scope, so a predicate reading `record.*`
+ * has nothing to bind and — per the fail-closed rule above — hides the button."
+ * Both halves are pinned below: the scope-bound predicates (`os.user.*` and
+ * plain constants) that are the meaningful shape here, and the `record.*` one
+ * that fails closed.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed;
+ * see the PR body. Restoring the pre-change gate
+ * (`affordances.import && can(objectDef.name, 'create')` with no predicate
+ * layer and no `disabled`) turns the `visibleWhen` and `disabledWhen` cases
+ * RED — the button renders, enabled, in all of them — while the boolean-arm,
+ * no-predicate and permission-gate cases stay GREEN in both worlds: they never
+ * reach the predicate layer, which is exactly what makes them the controls.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/** Controllable principal verdict, keyed by action (`can()` is permissive by default). */
+let principal: Record<string, boolean> = {};
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    check: () => ({ allowed: true }),
+    checkField: () => true,
+    getFieldPermissions: () => [],
+    getRowFilter: () => undefined,
+    getObjectApiOperations: () => undefined,
+    roles: [],
+    isLoaded: false,
+    hasCapabilities: () => true,
+    can: (_object: string, action: string) => principal[action] ?? true,
+    cannot: (_object: string, action: string) => !(principal[action] ?? true),
+  }),
+  useFieldPermissions: () => ({ canRead: () => true, canWrite: () => true, permissions: [] }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada' }, activeOrganization: null }),
+  useIsWorkspaceAdmin: () => false,
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRealtimeSubscription: () => ({ lastMessage: null }),
+  useConflictResolution: () => ({ hasConflicts: false, resolveAllConflicts: () => {} }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// Heavy children: orthogonal to the toolbar gate under test, and each drags in
+// a plugin bundle. Same posture as the sibling RecordDetailView render tests.
+vi.mock('@object-ui/plugin-list', () => ({ ListView: () => null }));
+vi.mock('@object-ui/plugin-view', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ObjectView: () => null,
+  ViewTabBar: () => null,
+  ManageViewsDialog: () => null,
+}));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+vi.mock('./RecordDetailView', () => ({ RecordDetailView: () => null }));
+
+import { ObjectView } from './ObjectView';
+import { ExpressionProvider } from '../providers/ExpressionProvider';
+
+const OBJECT_NAME = 'showcase_invoice';
+
+/** The signed-in principal the host shell publishes into the predicate scope. */
+const USER = { id: 'u1', name: 'Ada', profile: 'admin' };
+
+/**
+ * Predicates over the toolbar's SCOPE (`os.user.*`) — the meaningful shape on a
+ * standalone list, where there is no record to bind. Same aliases the real
+ * `ExpressionProvider` publishes, so these are authored exactly as they would
+ * be in served metadata.
+ */
+const SCOPE_TRUE = "os.user.profile == 'admin'";
+const SCOPE_FALSE = "os.user.profile == 'guest'";
+/** A predicate over `record.*` — nothing to bind here, per the spec binding. */
+const RECORD_BOUND = 'record.frozen != true';
+
+/** An object whose `userActions.import` carries the given override. */
+function objectsWith(importOverride: unknown) {
+  return [
+    {
+      name: OBJECT_NAME,
+      label: 'Invoice',
+      managedBy: 'platform',
+      fields: {
+        id: { type: 'text', label: 'Id' },
+        name: { type: 'text', label: 'Name' },
+      },
+      userActions: importOverride === undefined ? undefined : { import: importOverride },
+    },
+  ];
+}
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+function renderList(objects: any[]) {
+  return render(
+    <ExpressionProvider user={USER}>
+      <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}`]}>
+        <Routes>
+          <Route
+            path="/apps/:appName/:objectName"
+            element={<ObjectView dataSource={makeDataSource()} objects={objects} onEdit={() => {}} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ExpressionProvider>,
+  );
+}
+
+const importButton = () =>
+  document.querySelector('[data-testid="object-view-import-button"]') as HTMLButtonElement | null;
+
+beforeEach(() => {
+  principal = {};
+  cleanup();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('#5142 — the object-list toolbar honours `userActions.import` predicates', () => {
+  it('renders Import for the plain boolean arm of the union (no regression)', () => {
+    renderList(objectsWith(true));
+    expect(importButton()).toBeTruthy();
+    expect(importButton()!.disabled).toBe(false);
+  });
+
+  it('renders Import when the object declares no `userActions` at all', () => {
+    // `platform` is the only bucket granting import by default — the pre-change
+    // behaviour, unchanged: with no predicates there is nothing to evaluate.
+    renderList(objectsWith(undefined));
+    expect(importButton()).toBeTruthy();
+    expect(importButton()!.disabled).toBe(false);
+  });
+
+  it('renders Import when the object form declares `enabled` but no predicates', () => {
+    renderList(objectsWith({ enabled: true }));
+    expect(importButton()).toBeTruthy();
+    expect(importButton()!.disabled).toBe(false);
+  });
+
+  it('HIDES Import when `visibleWhen` evaluates false', () => {
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_FALSE }));
+    expect(importButton()).toBeNull();
+  });
+
+  it('keeps Import when `visibleWhen` evaluates true', () => {
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_TRUE }));
+    expect(importButton()).toBeTruthy();
+  });
+
+  it('GREYS Import (renders, disabled) when `disabledWhen` holds — hidden and disabled stay distinct', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: SCOPE_TRUE }));
+    const btn = importButton();
+    expect(btn).toBeTruthy();
+    expect(btn!.disabled).toBe(true);
+  });
+
+  it('leaves Import enabled when `disabledWhen` does not hold', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: SCOPE_FALSE }));
+    expect(importButton()).toBeTruthy();
+    expect(importButton()!.disabled).toBe(false);
+  });
+
+  it('fails CLOSED on a `visibleWhen` that cannot bind — the standalone list has no record in scope', () => {
+    // Not a defect of this harness: the spec binds a toolbar predicate to the
+    // record of the scope the toolbar sits in, and says in as many words that a
+    // standalone object list has none, so a `record.*` read hides the button.
+    renderList(objectsWith({ enabled: true, visibleWhen: RECORD_BOUND }));
+    expect(importButton()).toBeNull();
+  });
+
+  it('fails SOFT on a `disabledWhen` that cannot bind — an unevaluable predicate never greys forever', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: RECORD_BOUND }));
+    const btn = importButton();
+    expect(btn).toBeTruthy();
+    expect(btn!.disabled).toBe(false);
+  });
+
+  it('treats `disabledWhen: ""` as "no condition", not as "disable"', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: '' }));
+    expect(importButton()).toBeTruthy();
+    expect(importButton()!.disabled).toBe(false);
+  });
+
+  it('honours the object-level opt-out — `import: false` hides it, predicates or not', () => {
+    renderList(objectsWith({ enabled: false, visibleWhen: SCOPE_TRUE }));
+    expect(importButton()).toBeNull();
+  });
+
+  it('a passing predicate cannot RE-OPEN what the principal closed (#4096 layering)', () => {
+    // The permission gate objectui#4647 fixed and the predicate layer stack;
+    // neither short-circuits the other. `visibleWhen` is true here, so if the
+    // layer order were inverted the button would come back.
+    principal = { create: false };
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_TRUE }));
+    expect(importButton()).toBeNull();
+  });
+
+  it('the permission gate still hides Import with no predicates declared', () => {
+    principal = { create: false };
+    renderList(objectsWith(true));
+    expect(importButton()).toBeNull();
+  });
+
+  it('a non-platform bucket that never opted in shows no Import, predicates or not', () => {
+    // `config` makes import opt-in; the predicate must not resurrect it.
+    renderList([
+      {
+        name: OBJECT_NAME,
+        label: 'Invoice',
+        managedBy: 'config',
+        fields: { id: { type: 'text' }, name: { type: 'text' } },
+        userActions: { import: { visibleWhen: SCOPE_TRUE } },
+      },
+    ]);
+    expect(importButton()).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -56,7 +56,7 @@ import { useMobileViewSwitcherRegistration } from '../layout/MobileViewSwitcherC
 import type { MobileViewSwitcherItem } from '../layout/MobileViewSwitcherContext';
 import { ManagedByBadge } from '../components/ManagedByBadge';
 import { RecordDetailView } from './RecordDetailView';
-import { resolveEffectiveCrudAffordances } from '../utils/crudAffordances';
+import { resolveEffectiveCrudAffordances, type RowCrudPredicates } from '../utils/crudAffordances';
 import { createIdentityImportDataSource, IDENTITY_IMPORT_OBJECT, type IdentityPasswordPolicy } from './identityImport';
 import { IdentityImportOptions, IdentityImportResultExtra, identityImportFields } from './IdentityImportPanels';
 import { importTargetFields } from './importTargetFields';
@@ -70,7 +70,7 @@ import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useRealtimeSubscription, useConflictResolution } from '@object-ui/collaboration';
-import { ActionProvider, useNavigationOverlay, SchemaRenderer, useActionTextLocalizer, RelatedRecordActionsProvider } from '@object-ui/react';
+import { ActionProvider, useNavigationOverlay, SchemaRenderer, useActionTextLocalizer, useRowPredicate, RelatedRecordActionsProvider } from '@object-ui/react';
 import type { RelatedRecordActionsValue, RelatedRecordHandlers } from '@object-ui/react';
 import { toast } from 'sonner';
 import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
@@ -937,6 +937,66 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         if (externalRefreshKey === undefined || externalRefreshKey === 0) return;
         setRefreshKey(k => k + 1);
     }, [externalRefreshKey]);
+
+    /**
+     * [#5142] The object-list toolbar's IMPORT predicates — the `import` half
+     * of the toolbar-scope pair the spec resolver emits, mirroring what
+     * `RelatedRecordActionsBridge` does for `create` (objectui#4646).
+     *
+     * `@objectstack/spec@17.0.0` types `userActions.create` and
+     * `userActions.import` identically and `resolveCrudAffordances` emits a
+     * predicate envelope for each; the docblock binds them in one breath
+     * ("`importPredicates` — same binding as `createPredicates`"). #4646 gave
+     * `create` a consumer and left `import` declared-and-inert: an author could
+     * write `userActions.import.visibleWhen`, have the spec accept it and the
+     * resolver parse it, and watch this toolbar offer the CSV wizard anyway.
+     *
+     * BINDING (the spec docblock's, not an invention here). Unlike the ROW
+     * predicates, a toolbar predicate evaluates ONCE per toolbar against the
+     * record of the scope the toolbar sits in — the host parent record on a
+     * related list, and **no record at all on a standalone object list**, which
+     * is what this surface is. So `null` is passed deliberately below: a
+     * predicate reading `record.*` has nothing to bind, faults, and — per the
+     * fail-CLOSED rule — hides the button, exactly as the spec spells out.
+     * Predicates over the host scope (`os.user.*` / `features.*`) bind normally
+     * and are the meaningful shape here.
+     *
+     * LAYERING: surfaced only when the object-level verdict already passed —
+     * the same posture the related-list bridge takes, because a predicate may
+     * not RE-OPEN what the bucket, the effective API operations (#3391) or the
+     * principal's grant have closed. The identity-import bypass below is a
+     * different affordance entirely (it does not read `affordances.import`) and
+     * is deliberately left outside this layer.
+     */
+    const objectCanImport = affordances.import && can(objectDef.name, 'create');
+    const importPredicates: RowCrudPredicates | undefined = objectCanImport
+      ? affordances.importPredicates
+      : undefined;
+    /**
+     * `visibleWhen` — fails CLOSED, and counts as DECLARED by `?? true` rather
+     * than by truthiness, so `visibleWhen: false` hides Import instead of
+     * reading as "ungated" (the objectui#3492 invariant). The `true` default is
+     * a boolean, which the evaluator short-circuits without touching the engine
+     * — an object with no import predicates pays no evaluation at all.
+     */
+    const importVisible = useRowPredicate(importPredicates?.visibleWhen ?? true, null, {
+      fallback: false,
+      warnOnError: true,
+      label: 'builtin:import:visibleWhen',
+    });
+    /**
+     * `disabledWhen` — fails SOFT (an unevaluable predicate must not grey a
+     * button forever), with the `!= null` declared-ness gate OUTSIDE the
+     * evaluation so `disabledWhen: ''` reads as "no condition" rather than as
+     * "disable". Verbatim the posture of the record header (PR #4515), the
+     * row kebab, and the related-list toolbar.
+     */
+    const importDisabledPred = useRowPredicate(importPredicates?.disabledWhen, null, {
+      fallback: false,
+      warnOnError: true,
+      label: 'builtin:import:disabledWhen',
+    });
+    const importDisabled = importPredicates?.disabledWhen != null && importDisabledPred;
 
     // Import wizard open/close state — toolbar entry triggers it.
     const [showImport, setShowImport] = useState(false);
@@ -2137,11 +2197,15 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                         are inherently a desk/laptop workflow; the button
                         was eating header space on mobile next to the
                         primary "+" action. */}
-                    {(identityImportEnabled || (affordances.import && can(objectDef.name, 'create'))) && (
+                    {/* [#5142] `objectCanImport && importVisible` — the object-level
+                        verdict, then the toolbar-scope `visibleWhen` layer on top of
+                        it. Greyed, not gone, is the `disabledWhen` case below. */}
+                    {(identityImportEnabled || (objectCanImport && importVisible)) && (
                     <Button
                         size="sm"
                         variant="outline"
                         onClick={() => setShowImport(true)}
+                        disabled={importDisabled}
                         className="hidden sm:inline-flex shadow-none gap-1.5 sm:gap-2 h-8 sm:h-9"
                         title={t('console.objectView.importTitle')}
                         data-testid="object-view-import-button"

--- a/packages/core/src/utils/managedBy.test.ts
+++ b/packages/core/src/utils/managedBy.test.ts
@@ -7,6 +7,7 @@ import {
   isObjectInlineEditable,
   normalizeUserAction,
   userActionPredicates,
+  type UserActionsOverride,
 } from './managedBy';
 
 describe('resolveEffectiveCrudAffordances — bucket half, delegated to the spec', () => {
@@ -228,5 +229,69 @@ describe('isObjectInlineEditable — effective API operations (#3546)', () => {
 
   it('empty effective set → not inline-editable (deny-all)', () => {
     expect(isObjectInlineEditable({ managedBy: 'platform' }, [])).toBe(false);
+  });
+});
+
+/**
+ * [#5142] The `import` half of the toolbar-scope predicate pair.
+ *
+ * `@objectstack/spec@17.0.0` types `userActions.create` and `userActions.import`
+ * identically and emits a predicate envelope for each; objectui#4646 consumed
+ * only the `create` half and deliberately left this local type narrow
+ * (`import?: boolean`) so the declaration stayed an honest statement of what the
+ * renderer honoured. The consumer landed with #5142, so the type widened with
+ * it.
+ *
+ * The pin below is COMPILE-time, and it is the only kind that can observe this
+ * property: the widening erases at runtime, so vitest cannot see it. `tsc` can
+ * — `packages/core/tsconfig.test.json` compiles this file and is chained from
+ * the package's `type-check` script (objectui#3181), which is what CI runs.
+ * Restore `import?: boolean` and the annotated constant below fails to compile.
+ */
+describe('#5142 — userActions.import carries the same object form as create', () => {
+  /** COMPILE-TIME pin: the object form is assignable to the `import` key. */
+  const IMPORT_OBJECT_FORM: UserActionsOverride['import'] = {
+    enabled: true,
+    visibleWhen: "os.user.profile == 'admin'",
+    disabledWhen: 'features.readOnly == true',
+  };
+
+  it('carries importPredicates through the objectui-side #3391 intersection', () => {
+    const aff = resolveEffectiveCrudAffordances({
+      managedBy: 'platform',
+      userActions: { import: IMPORT_OBJECT_FORM },
+    });
+    expect(aff.import).toBe(true);
+    expect(aff.importPredicates).toEqual({
+      visibleWhen: "os.user.profile == 'admin'",
+      disabledWhen: 'features.readOnly == true',
+    });
+    // The `create` half is untouched by an `import`-only override — the two
+    // envelopes are separate keys, not one shared toolbar bag.
+    expect(aff.createPredicates).toBeUndefined();
+  });
+
+  it('the boolean arm of the union still carries no predicates', () => {
+    const aff = resolveEffectiveCrudAffordances({ managedBy: 'platform', userActions: { import: true } });
+    expect(aff.import).toBe(true);
+    expect(aff.importPredicates).toBeUndefined();
+  });
+
+  it('predicates survive `enabled: false` — the object-level bit is what closes', () => {
+    // The resolver reports both facts; refusing to surface a predicate for a
+    // closed affordance is the CONSUMER's layering rule (ObjectView, #5142),
+    // not the resolver's.
+    const aff = resolveEffectiveCrudAffordances({
+      managedBy: 'platform',
+      userActions: { import: { enabled: false, visibleWhen: 'x' } },
+    });
+    expect(aff.import).toBe(false);
+    expect(aff.importPredicates).toEqual({ visibleWhen: 'x' });
+  });
+
+  it('the widened key is the union, not `any` — a number is still a compile error', () => {
+    // @ts-expect-error — widened to `boolean | RowCrudActionOverride`, and no further.
+    const bad: UserActionsOverride['import'] = 42;
+    expect(bad).toBe(42);
   });
 });

--- a/packages/core/src/utils/managedBy.ts
+++ b/packages/core/src/utils/managedBy.ts
@@ -71,14 +71,24 @@ export interface UserActionsOverride {
    * accepts, and that the related-list toolbar now honours
    * (`RelatedRecordActionsBridge`, objectui#4646), was rejected by objectui's
    * own type while the runtime handled it.
-   *
-   * `import` below is deliberately NOT widened. The spec accepts the object
-   * form there too and emits `importPredicates`, but nothing in objectui reads
-   * them yet; widening the type ahead of a consumer would re-declare the
-   * inert-metadata defect this change removes, one key over.
    */
   create?: UserActionOverride;
-  import?: boolean;
+  /**
+   * Bare boolean or the object form — the SAME union as `create` above, which
+   * is how `@objectstack/spec@17.0.0` types the two toolbar keys
+   * (`z.union([z.boolean(), RowCrudActionOverrideSchema])` for each), and its
+   * resolver emits `CrudAffordances.importPredicates` beside
+   * `createPredicates`.
+   *
+   * Widened in objectui#5142, deliberately IN THE SAME change that gave the
+   * object-list toolbar's Import button a consumer for those predicates
+   * (`ObjectView`). objectui#4646 left this key narrow on purpose and said why:
+   * widening a type ahead of its consumer re-declares the inert-metadata defect
+   * — objectui would have *claimed* to accept the object form while still
+   * dropping the predicate. Type and consumer travel together, so the
+   * declaration stays an honest statement of what this renderer honours.
+   */
+  import?: UserActionOverride;
   edit?: UserActionOverride;
   delete?: UserActionOverride;
   exportCsv?: boolean;


### PR DESCRIPTION
Fixes #5142

## 背景：与 #4646 / PR #5145 的镜像关系

`@objectstack/spec@17.0.0` 同时放宽了**两个** toolbar-scope 键,不只 `create`。二者在 spec 中类型完全相同,resolver 对两键各发一个谓词信封,docblock 一句话把绑定绑在一起(`importPredicates` — same binding as `createPredicates`)。#4646 补上了 create 半(PR #5145,关联列表工具栏),import 半仍是「已声明、零消费」。

本 PR 是 import 半,逐一镜像 PR #5145 的 `evalCreatePredicate` 形。

前提三条逐条复测(基线 `b4089beca`,含 PR #5145 与 #5147):

1. **spec 两键同型、双发信封** —— 对已装 `@objectstack/spec@17.0.0` 实测:`userActions.import` 的对象形经 `resolveCrudAffordances` 返回 `importPredicates: { visibleWhen, disabledWhen }`,与 `create` 半逐字对称;`.d.ts` 中 `create:` / `import:` 都是 `z.ZodUnion` of `[ZodBoolean, RowCrudActionOverrideSchema]`(1208 / 1253 行)。**成立**。
2. **objectui src 零消费** —— cast 感知 grep 在含 PR5145 的新基线上只命中一处,且是 `packages/core/src/utils/managedBy.ts:76` 那条「刻意不放宽」的注释本身,不是读取点。**成立**。
3. **PR #5145 刻意留窄型并写明理由** —— 注释在 `managedBy.ts` `UserActionsOverride.create` 的 docblock 尾部,原话是「widening the type ahead of a consumer would re-declare the inert-metadata defect this change removes, one key over」。本单正是它指名的那一单。**成立**。

## 消费落点清点

对象列表工具栏的 Import 入口**只有一处**:`ObjectView.tsx` 头部按钮(`data-testid="object-view-import-button"`)。与 create 半不同 —— create 在同文件有两个渲染点(头部按钮 + 手机端浮动 `+`),而 Import 按设计没有移动端对应物(源注释:CSV 导入本质是桌面工作流,移动端不占位)。因此本 PR 关掉的就是全部入口。

## 实施

- `ObjectView.tsx`:`objectCanImport && importVisible` 作可见门,`disabled={importDisabled}` 作置灰门。`visibleWhen` fail-CLOSED、`disabledWhen` fail-SOFT;声明判定沿用家族规则 —— `?? true`(而非真值)使 `visibleWhen: false` 真的隐藏而不是读成「未设门」(#3492 不变量),`!= null` 且在求值之外,使空谓词读成「无条件」而不是「禁用」。求值走 `useRowPredicate(..., { fallback: false, warnOnError: true })`,即记录页头(PR #4515)/ 行 kebab / DetailView 在同一位置的既有形。
- **分层**:谓词层只叠在对象级判定通过之后(`affordances.import && can(object,'create')`),谓词不能重新打开 bucket / 有效 API 操作集(#3391)/ 主体授权(#4096、#4647)已关闭的东西。identity-import 旁路不读 `affordances.import`,是另一个 affordance,刻意留在该层之外。
- **scope 记录语义(按 spec docblock 实测判定,不外推)**:toolbar 谓词对「工具栏所在 scope 的记录」求值一次;spec 明写「On a standalone object list there is no record in scope, so a predicate reading `record.*` has nothing to bind and — per the fail-closed rule above — hides the button」。对象列表顶层工具栏正是该面,故此处**故意传 `null`**:`os.user.*` / `features.*` 这类作用域谓词正常绑定(这里有意义的形态),读 `record.*` 的谓词无处绑定 → fail-closed 隐藏。这是 spec 为该面明写的规则,不是本实现的取舍;测试里两半都钉住了。
- `core/managedBy.ts`:`UserActionsOverride.import` 由 `boolean` 放宽为与 `create` 同一 union,与消费者同车;把那条「刻意窄型」注释改写为指向本单的落地说明。

⛔ 未动 spec、未动 ObjectGrid。

## 测试

新增 `ObjectView.importPredicates.test.tsx`(14 例,真渲染 + `data-testid` 断言,不是纯函数替身):visibleWhen 假 ⇒ 隐藏 / 真 ⇒ 保留;disabledWhen 真 ⇒ 置灰、假 ⇒ 可用、空串 ⇒ 无条件;纯 boolean 旧形与无 `userActions` 不回归;`enabled: false` 对象级关断;权限门(#4647)与谓词层叠加互不短路(谓词为真也无法重开被主体关掉的);`config` bucket 未 opt-in 时谓词不能复活按钮;`record.*` 不可绑定的 fail-CLOSED / fail-SOFT 两向。

`managedBy.test.ts` 增 4 例,其中一例是**编译期**钉:类型放宽在运行时被擦除,vitest 看不见,只有 `tsc` 能看见 —— `packages/core/tsconfig.test.json` 编译该文件且由包 `type-check` 串起(#3181),即 CI 跑的那条。

证据:

```
vitest packages/app-shell        → Test Files 428 passed | Tests 4116 passed | 1 skipped
vitest packages/core             → Test Files  89 passed | Tests 1886 passed
vitest ObjectView.importPredicates + managedBy → 44 passed (44)
turbo run type-check --concurrency=2 → Tasks: 81 successful, 81 total
eslint（三个改动文件）            → 0 errors（161 warnings 全为既有 any）
check-control-bytes              → OK（4571 tracked text files）+ 自扫含 ESC 位 0 命中
```

## 反向验证（先书面预判,再跑;结果与预判一致,含一处「反直觉但预判正确」的方向）

**(a) 摘消费** —— 还原改前门(`affordances.import && can(...)`,去掉 `disabled`)。预判:恰 3 例红 —— visibleWhen 假、disabledWhen 真、`record.*` fail-CLOSED;其余 11 例是控制组,压根不进谓词层,两个世界都绿。实测:`Tests 3 failed | 11 passed (14)`,红的正是预判那三条。

**(b) 塞假谓词键** —— 把隐藏用例的 `visibleWhen` 改拼成 `visible_when`。预判:该例翻红(按钮照出),证明门是钉在规范键上,而不是「只要有个像谓词的键就算」。实测:`1 failed | 13 passed`,`AssertionError: expected button… to be null`。

**(c) 自选非显然方向:只回滚类型、保留消费者** —— 预判:**全部运行时用例仍绿**(放宽在运行时被擦除,resolver 是 spec 的,从不查 objectui 本地类型),只有 `tsc` 会红。实测正如预判:`vitest … 44 passed (44)`,而 `tsc -p packages/core/tsconfig.test.json` 报

```
src/utils/managedBy.test.ts(253,9): error TS2322: Type '{ enabled: boolean; visibleWhen: string; disabledWhen: string; }' is not assignable to type 'boolean | undefined'.
src/utils/managedBy.test.ts(286,22): error TS2322: ... is not assignable to type 'boolean | undefined'.
```

这条正是加编译期钉的理由:类型那一半对整个运行时套件不可见,窄型在仓内也从不承重 —— 它承的是**下游作者 tsc 的判词**。同一次变异下 `@ts-expect-error`（`42` 那行）没有报「未使用」,说明放宽到的是 union 而非 `any`。

三次变异均已还原,commit 后重跑复绿。

## 半径外发现

- 已立 #5153（unassigned,PM 分诊）:对象列表页自己的「New」按钮与手机端浮动 `+` 同样不消费 `createPredicates` —— create 半只在关联列表落地。按 spec 同一段 docblock,独立列表这个面**在 toolbar 谓词的适用范围内**(缺的只是记录),所以同一份 `userActions.create` 声明会因渲染面不同得到两种判词。立卡前已按关键字 + 文件路径查重,只回到 #4646(已关)与 #5142,非重复件。刻意未在本 PR 内修:本单只点名 `import` 键。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_