### PR TITLE
fix(types,plugin-map): declare what ObjectMap reads; the `map` block outranks the flat spelling

### DIFF
--- a/.changeset/objectmap-schema-alignment-5018.md
+++ b/.changeset/objectmap-schema-alignment-5018.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-map': minor
+---
+
+`ObjectMapSchema` declares what ObjectMap reads, and the `map` block outranks the flat spelling
+
+`object-map` carried three disagreeing shapes for one component. The declared face
+(`ObjectMapSchema`) had four keys — `type`, `objectName`, `locationField`,
+`titleField`, `mapStyle`. The renderer read about fifteen. And `ObjectMapProps.schema`
+was typed `ObjectGridSchema`, so every map-specific read went through
+`(schema as any)`. A TypeScript author could not write the `map` block the docs teach,
+and misspelling `latitudeField` as `latitudeFieId` was caught by nothing: the map
+rendered empty and looked like bad data.
+
+Declared now, each with a read site in `ObjectMap.tsx`: `data`, `staticData`, `filter`,
+`sort`, `map`, `enableClustering`, `navigation`. `ObjectMapConfig` (interface) and
+`ObjectMapConfigSchema` (zod) are lifted out of `plugin-map`, where the zod was
+package-private and called `MapConfigSchema`, into `@object-ui/types` and
+`@object-ui/types/zod` — so the declared authoring face and the validation the renderer
+performs are one schema rather than two that can drift. The `Object` prefix is not
+decoration: `@objectstack/spec/automation` already exports `MapConfigSchema` for an
+unrelated concept, and a local declaration under a spec export's name is what
+`check:spec-symbols` exists to refuse. `ObjectMapProps.schema` is `ObjectMapSchema`, and the `as any` map reads
+are gone.
+
+Behavior change, ruled by the maintainer on objectui#5018 (2026-08-17): the `map` block
+is the author face and the flat top-level spelling (`schema.latitudeField`, …) is the
+internal form ObjectView / ListView produce when they flatten `options.map`. When a
+schema carries both, **the `map` block now wins** — the reverse of the previous order,
+under which the flatten product silently shadowed an authored block — and a dev-mode
+warning names the top-level keys that were ignored. The flat spelling stays out of the
+declared surface and out of the docs.
+
+Nothing changes for views built by ObjectView / ListView: both flatteners emit the flat
+keys and no `map` key at all, so the branch the flip reorders is never reached for their
+output. That property is now pinned rather than assumed
+(`plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx`).
+
+Bound worth stating, because it limits what the typed surface can promise: `BaseSchema`
+carries an index signature (`[key: string]: any`), so a misspelled key at the TOP level
+still type-checks — for every component schema in the repo. The `map` BLOCK is closed,
+which is what makes the card's headline typo a compile error.

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -126,6 +126,12 @@ const workspaceAliases: Record<string, string> = {
   '@object-ui/plugin-form': path.resolve(import.meta.dirname, '../../packages/plugin-form/src'),
   '@object-ui/plugin-grid': path.resolve(import.meta.dirname, '../../packages/plugin-grid/src'),
   '@object-ui/react': path.resolve(import.meta.dirname, '../../packages/react/src'),
+  // The `/zod` subpath must be aliased BEFORE the bare package: a vite string
+  // alias matches by PREFIX, so `@object-ui/types/zod` would otherwise resolve to
+  // the `src/zod` DIRECTORY, which has no `index.ts` (the barrel is
+  // `index.zod.ts`) — UNLOADABLE_DEPENDENCY at build time. Mirrors the pairing
+  // in the root `vitest.config.mts`.
+  '@object-ui/types/zod': path.resolve(import.meta.dirname, '../../packages/types/src/zod/index.zod.ts'),
   '@object-ui/types': path.resolve(import.meta.dirname, '../../packages/types/src'),
   '@object-ui/data-objectstack': path.resolve(import.meta.dirname, '../../packages/data-objectstack/src'),
   '@object-ui/auth': path.resolve(import.meta.dirname, '../../packages/auth/src'),

--- a/content/docs/plugins/plugin-map.mdx
+++ b/content/docs/plugins/plugin-map.mdx
@@ -101,16 +101,21 @@ const schema = {
 ```plaintext
 {
   type: 'object-map',
-  objectName?: string,              // ObjectQL object name
+  objectName: string,               // ObjectQL object name
   staticData?: Array<any>,          // Static data array
   data?: ViewData,                  // Advanced data configuration
-  map?: MapConfig,                  // Map-specific configuration
+  filter?: Array<any>,              // Query filter, sent as $filter
+  sort?: string | SortConfig[],     // Sort, sent as $orderby
+  map?: ObjectMapConfig,            // Map-specific configuration
+  enableClustering?: boolean,       // Cluster nearby markers (auto past 100)
+  navigation?: NavigationConfig,    // Record navigation (drawer/dialog/page)
+  mapStyle?: string,                // MapLibre style URL/spec
   onMarkerClick?: (record: any) => void,
   className?: string
 }
 ```
 
-### MapConfig
+### ObjectMapConfig
 
 ```plaintext
 {
@@ -120,7 +125,8 @@ const schema = {
   titleField?: string,         // Field to use as marker title
   descriptionField?: string,   // Field for marker description
   zoom?: number,               // Zoom level (1-20) — opts out of the auto-fit
-  center?: [number, number]    // Center coordinates [lat, lng] — opts out of the auto-fit
+  center?: [number, number],   // Center coordinates [lat, lng] — opts out of the auto-fit
+  style?: string               // MapLibre style URL/spec (overrides the demo default)
 }
 ```
 
@@ -470,9 +476,9 @@ Consider using one of the full-featured mapping libraries above.
 ## TypeScript Support
 
 ```plaintext
-import type { ObjectGridSchema, MapConfig } from '@object-ui/types'
+import type { ObjectMapSchema, ObjectMapConfig } from '@object-ui/types'
 
-const mapConfig: MapConfig = {
+const mapConfig: ObjectMapConfig = {
   latitudeField: 'lat',
   longitudeField: 'lng',
   titleField: 'name',
@@ -481,7 +487,7 @@ const mapConfig: MapConfig = {
   center: [37.7749, -122.4194]
 }
 
-const mapSchema: ObjectGridSchema = {
+const mapSchema: ObjectMapSchema = {
   type: 'object-map',
   objectName: 'locations',
   map: mapConfig

--- a/examples/console-starter/vite.config.ts
+++ b/examples/console-starter/vite.config.ts
@@ -52,6 +52,8 @@ const workspaceAliases: Record<string, string> = {
   '@object-ui/react': path.resolve(__dirname, '../../packages/react/src'),
   '@object-ui/react-runtime': path.resolve(__dirname, '../../packages/react-runtime/src'),
   '@object-ui/sdui-parser': path.resolve(__dirname, '../../packages/sdui-parser/src'),
+  // Subpath before bare package — see the note in `apps/console/vite.config.ts`.
+  '@object-ui/types/zod': path.resolve(__dirname, '../../packages/types/src/zod/index.zod.ts'),
   '@object-ui/types': path.resolve(__dirname, '../../packages/types/src'),
 };
 

--- a/packages/fields/vite.config.ts
+++ b/packages/fields/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@object-ui/core': path.resolve(__dirname, '../core/src'),
+      // Subpath before bare package — see the note in `apps/console/vite.config.ts`.
+      '@object-ui/types/zod': path.resolve(__dirname, '../types/src/zod/index.zod.ts'),
       '@object-ui/types': path.resolve(__dirname, '../types/src'),
       '@object-ui/react': path.resolve(__dirname, '../react/src'),
       '@object-ui/components': path.resolve(__dirname, '../components/src'),

--- a/packages/plugin-map/src/ObjectMap.filterConfig.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.filterConfig.test.tsx
@@ -161,7 +161,26 @@ describe('the declared `map` input is what configures the map (control)', () => 
     expect(warnings()).not.toContain('[ObjectMap]');
   });
 
-  it('keeps the top-level `latitudeField` branch intact', async () => {
+  /**
+   * History — objectui#5018, maintainer ruling 2026-08-17 (「同意」).
+   *
+   * This pin predates that ruling, which reversed `getMapConfig`'s order: the
+   * declared `map` block is now consulted FIRST and wins outright, and the flat
+   * top-level spelling is the internal form (ObjectView / ListView flattening
+   * `options.map`) consulted only in its absence.
+   *
+   * What this pin asserts is UNCHANGED by the flip and was never the precedence
+   * itself: the schema below carries no `map` block, so the flat branch is the
+   * only branch there is. The card that dispatched #5018 read this pin as
+   * recording the old top-level-wins precedence — it does not, and no pin did;
+   * the old order was unpinned. The precedence, in both directions, is now
+   * pinned in `ObjectMap.schemaAlignment.test.tsx`, and the producer path that
+   * makes the flip safe in `plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx`.
+   *
+   * Keeping this one is the point: the internal form still has to render, or
+   * every ObjectView/ListView map goes blank.
+   */
+  it('keeps the top-level `latitudeField` branch intact (internal flat form)', async () => {
     await renderMap({
       type: 'object-map',
       data: { provider: 'value', items: ROWS },

--- a/packages/plugin-map/src/ObjectMap.schemaAlignment.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.schemaAlignment.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `ObjectMapSchema` declares what `ObjectMap` reads, and the `map` block wins
+ * over the internal flat spelling (objectui#5018).
+ *
+ * Before this card the component had three disagreeing shapes for one thing:
+ * `ObjectMapSchema` declared four keys, the renderer read about fifteen, and
+ * `ObjectMapProps.schema` was typed `ObjectGridSchema` — so every map-specific
+ * read went through `(schema as any)`. A TypeScript author could not write the
+ * `map` block the docs teach, and misspelling `latitudeField` as
+ * `latitudeFieId` was caught by nothing at all: the map rendered, empty, and
+ * looked like bad data.
+ *
+ * Two halves are pinned here:
+ *
+ *  (a) TYPE — the `map` block exists on the declared surface and is CLOSED, so
+ *      the misspelling is a compile error. These are `@ts-expect-error` pins:
+ *      they fail loudly (TS2578, "Unused '@ts-expect-error' directive") the day
+ *      the type stops rejecting what it must reject. `tsconfig.test.json`
+ *      compiles this file, which is what makes them enforcement rather than
+ *      decoration. The boundary of what (a) can promise — `BaseSchema`'s index
+ *      signature leaves the TOP level open — is measured and pinned too, rather
+ *      than claimed.
+ *
+ *  (b) RUNTIME — precedence. Maintainer ruling, 2026-08-17 (「同意」, recorded
+ *      on objectui#5018): the `map` block is the author face, the flat
+ *      top-level spelling is the internal form ObjectView/ListView produce when
+ *      they flatten `options.map`, and when both are present the block wins —
+ *      what the author wrote outranks what internal flattening produced — with
+ *      a dev-mode warning naming the top-level keys that were ignored.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ObjectMapSchema, ObjectMapConfig } from '@object-ui/types';
+import { ObjectMap } from './ObjectMap';
+
+let capturedProps: any = null;
+
+vi.mock('react-map-gl/maplibre', () => ({
+  default: (props: any) => {
+    capturedProps = props;
+    return <div aria-label="Map">{props.children}</div>;
+  },
+  Map: ({ children }: any) => <div aria-label="Map">{children}</div>,
+  NavigationControl: () => <div data-testid="nav-control" />,
+  Marker: ({ children, longitude, latitude }: any) => (
+    <div data-testid="map-marker" data-lat={latitude} data-lng={longitude}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
+}));
+
+/**
+ * One record carrying BOTH spellings' coordinates, at places far enough apart
+ * that the rendered marker says which configuration was consulted.
+ */
+const ROWS = [
+  { id: '1', name: 'Authored', lat: 40, lng: -74, flat_lat: 1, flat_lng: 2 },
+];
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  capturedProps = null;
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+const renderMap = async (schema: Record<string, unknown>) => {
+  const utils = render(<ObjectMap schema={schema as unknown as ObjectMapSchema} />);
+  await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+  return utils;
+};
+
+const warnings = () => warnSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+
+// ---------------------------------------------------------------------------
+// (a) The declared surface — compile-time pins.
+// ---------------------------------------------------------------------------
+describe('ObjectMapSchema declares what the renderer reads (type pins)', () => {
+  it('accepts every key ObjectMap.tsx actually consumes', () => {
+    const schema: ObjectMapSchema = {
+      type: 'object-map',
+      objectName: 'stores',
+      staticData: [{ id: '1' }],
+      data: { provider: 'value', items: [{ id: '1' }] },
+      filter: [['status', '=', 'open']],
+      sort: 'name desc',
+      map: {
+        latitudeField: 'lat',
+        longitudeField: 'lng',
+        locationField: 'location',
+        titleField: 'name',
+        descriptionField: 'address',
+        zoom: 12,
+        center: [37.7749, -122.4194],
+        style: 'https://tiles.example.com/style.json',
+      },
+      enableClustering: true,
+      navigation: { mode: 'drawer' },
+      mapStyle: 'https://tiles.example.com/style.json',
+    };
+
+    expect(schema.map?.latitudeField).toBe('lat');
+  });
+
+  it('REJECTS a misspelled key inside the `map` block', () => {
+    const config: ObjectMapConfig = {
+      longitudeField: 'lng',
+      // @ts-expect-error `latitudeFieId` (capital i, not l) is not an ObjectMapConfig key.
+      // This exact typo is objectui#5018's headline symptom: before the block was
+      // declared it reached the renderer unchallenged and painted an empty map.
+      latitudeFieId: 'lat',
+    };
+
+    expect(config.longitudeField).toBe('lng');
+  });
+
+  /**
+   * The bound on (a), measured rather than assumed — the first draft of this
+   * file pinned the opposite and `tsc` said otherwise (TS2578 on both).
+   *
+   * `BaseSchema` carries `[key: string]: any` ("additional properties specific
+   * to the component type"), and `ObjectMapSchema extends BaseSchema`. So a
+   * misspelled key at the TOP level type-checks — for every component schema in
+   * the repo, not just this one. That index signature is a platform-wide
+   * decision well outside objectui#5018, and removing it here would only move
+   * the hole.
+   *
+   * What #5018 buys is the half that matters for the card's symptom: `ObjectMapConfig`
+   * is a plain interface with no index signature, so the `map` BLOCK is closed
+   * and `latitudeFieId` is rejected — the exact typo that rendered a silent
+   * empty map. Pinning the real boundary keeps the next reader from believing
+   * the whole surface is closed.
+   */
+  it('does NOT reject a misspelled TOP-LEVEL key — BaseSchema is open', () => {
+    const schema: ObjectMapSchema = {
+      type: 'object-map',
+      objectName: 'stores',
+      // No `@ts-expect-error`: `BaseSchema`'s index signature admits this, and
+      // saying otherwise is what the first draft got wrong.
+      enableClusterng: true,
+    };
+
+    expect(schema.objectName).toBe('stores');
+  });
+
+  it('leaves the internal flat spelling undeclared (documented, not enforced)', () => {
+    // `latitudeField` is deliberately absent from `ObjectMapSchema`: it is the
+    // ObjectView/ListView flatten product, not an authoring surface (maintainer
+    // ruling on objectui#5018, 2026-08-17). The index signature above means the
+    // omission is documentation rather than a compile error, so what is pinned
+    // is the declaration itself — `map.latitudeField` is the typed spelling.
+    const authored: ObjectMapConfig = { latitudeField: 'lat' };
+    expect(authored.latitudeField).toBe('lat');
+
+    // `map` is genuinely typed as `ObjectMapConfig`, not widened to `any` by the
+    // index signature — a wrong VALUE type is rejected too, not just a wrong key.
+    const block: NonNullable< ObjectMapSchema['map'] > = {
+      // @ts-expect-error `zoom` is a number.
+      zoom: 'far',
+    };
+    expect(block).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) Precedence — the ruled behaviour.
+// ---------------------------------------------------------------------------
+describe('the `map` block outranks the internal flat spelling (objectui#5018)', () => {
+  it('reads the `map` block when both spellings are present', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      map: { latitudeField: 'lat', longitudeField: 'lng', titleField: 'name' },
+      // The internal form, pointing somewhere else entirely.
+      latitudeField: 'flat_lat',
+      longitudeField: 'flat_lng',
+    });
+
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers).toHaveLength(1);
+    // 40 / -74 is the `map` block's answer; 1 / 2 would be the flat one's.
+    expect(markers[0]).toHaveAttribute('data-lat', '40');
+    expect(markers[0]).toHaveAttribute('data-lng', '-74');
+  });
+
+  it('names the ignored top-level keys in a dev-mode warning', async () => {
+    await renderMap({
+      type: 'object-map',
+      objectName: 'stores',
+      data: { provider: 'value', items: ROWS },
+      map: { latitudeField: 'lat', longitudeField: 'lng', titleField: 'name' },
+      latitudeField: 'flat_lat',
+      longitudeField: 'flat_lng',
+      zoom: 3,
+    });
+
+    const text = warnings();
+    expect(text).toContain('[ObjectMap]');
+    expect(text).toContain('latitudeField');
+    expect(text).toContain('longitudeField');
+    expect(text).toContain('zoom');
+    expect(text).toContain('objectui#5018');
+    // A key that was NOT authored must not be named — the diagnostic reports
+    // what happened, it does not recite the key list.
+    expect(text).not.toContain('descriptionField');
+  });
+
+  it('says nothing when only the `map` block is present', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      map: { latitudeField: 'lat', longitudeField: 'lng', titleField: 'name' },
+    });
+
+    expect(screen.getAllByTestId('map-marker')).toHaveLength(1);
+    expect(warnings()).not.toContain('[ObjectMap]');
+  });
+
+  it('still honours a `map.style` alongside the shadowed flat keys', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      map: {
+        latitudeField: 'lat',
+        longitudeField: 'lng',
+        style: 'https://tiles.example.com/style.json',
+      },
+      latitudeField: 'flat_lat',
+    });
+
+    expect(capturedProps.mapStyle).toBe('https://tiles.example.com/style.json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) The producer path — what the precedence flip is allowed to leave alone.
+// ---------------------------------------------------------------------------
+describe('the ObjectView / ListView flatten product still renders (control)', () => {
+  /**
+   * Byte-for-byte the shape `plugin-view/src/ObjectView.tsx` `case 'map'` and
+   * `plugin-list/src/ListView.tsx` `case 'map'` build: `...baseProps`, a
+   * `locationField` that always defaults to `'location'`, then the CONTENTS of
+   * `options.map` spread flat. There is no `map` key in it, which is exactly
+   * why flipping the precedence cannot change what these views render — the
+   * companion pin lives in `plugin-view/src/__tests__/`.
+   */
+  it('reads the flat keys when no `map` block is present', async () => {
+    await renderMap({
+      type: 'object-map',
+      objectName: 'stores',
+      className: 'h-full w-full',
+      data: { provider: 'value', items: ROWS },
+      locationField: 'location',
+      latitudeField: 'flat_lat',
+      longitudeField: 'flat_lng',
+      titleField: 'name',
+    });
+
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toHaveAttribute('data-lat', '1');
+    expect(markers[0]).toHaveAttribute('data-lng', '2');
+    // No block, nothing shadowed, nothing to say.
+    expect(warnings()).not.toContain('[ObjectMap]');
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -21,11 +21,11 @@
  */
 
 import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
-import type { ObjectGridSchema, DataSource, ViewData } from '@object-ui/types';
+import type { ObjectMapSchema, ObjectMapConfig, DataSource, ViewData } from '@object-ui/types';
+import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 import { useNavigationOverlay } from '@object-ui/react';
 import { NavigationOverlay, cn, useIsMobile } from '@object-ui/components';
 import { extractRecords, buildExpandFields, convertSortToQueryParams } from '@object-ui/core';
-import { z } from 'zod';
 import MapGL, { NavigationControl, Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -38,17 +38,6 @@ import {
   UNFITTED_CENTER_ZOOM,
 } from './camera';
 
-const MapConfigSchema = z.object({
-  latitudeField: z.string().optional(),
-  longitudeField: z.string().optional(),
-  locationField: z.string().optional(),
-  titleField: z.string().optional(),
-  descriptionField: z.string().optional(),
-  zoom: z.number().optional(),
-  center: z.tuple([z.number(), z.number()]).optional(),
-  style: z.string().optional(),
-});
-
 /**
  * Public MapLibre demo style — free, unauthenticated, but not intended for
  * production traffic (rate-limited, no uptime guarantee). Used only when no
@@ -58,7 +47,7 @@ const MapConfigSchema = z.object({
 const DEFAULT_MAP_STYLE = 'https://demotiles.maplibre.org/style.json';
 
 export interface ObjectMapProps {
-  schema: ObjectGridSchema;
+  schema: ObjectMapSchema;
   dataSource?: DataSource;
   className?: string;
   onMarkerClick?: (record: any) => void;
@@ -71,36 +60,42 @@ export interface ObjectMapProps {
   clusterRadius?: number;
 }
 
-interface MapConfig {
-  /** Field containing latitude value */
-  latitudeField?: string;
-  /** Field containing longitude value */
-  longitudeField?: string;
-  /** Field containing combined location (e.g., "lat,lng" or location object) */
-  locationField?: string;
-  /** Field to use for marker title/label */
-  titleField?: string;
-  /** Field to use for marker description */
-  descriptionField?: string;
-  /**
-   * Zoom level (1-20). Declaring it opts the view OUT of fitting the camera to
-   * its records — the declaration wins (objectui#4941).
-   */
-  zoom?: number;
-  /**
-   * Center coordinates [lat, lng] — latitude first, as documented and as the
-   * `map` block's shape has always been read. Declaring it opts the view OUT of
-   * fitting the camera to its records.
-   */
-  center?: [number, number];
-  /** MapLibre style URL/spec (overrides the public demo default) */
-  style?: string;
-}
+/**
+ * The FLAT spelling of `ObjectMapConfig`'s keys, as ObjectView / ListView emit it.
+ *
+ * Both flatteners build an `object-map` schema by spreading `options.map`'s
+ * CONTENTS at the top level (`plugin-view/src/ObjectView.tsx` `case 'map'`,
+ * `plugin-list/src/ListView.tsx` `case 'map'`) — the product carries these keys
+ * and NO `map` key at all. That is an internal transport form, not an authoring
+ * surface, so it is declared here in the consumer rather than in
+ * `ObjectMapSchema` (maintainer ruling on objectui#5018, 2026-08-17).
+ *
+ * `locationField` / `titleField` are the two that `ObjectMapSchema` still
+ * publishes as well, from before the ruling; the rest exist only here.
+ */
+type FlatMapConfigKeys = Omit< ObjectMapConfig, 'style' >;
+
+/** What `getMapConfig` may read: the declared schema plus the internal flat form. */
+type MapConfigSource = ObjectMapSchema & FlatMapConfigKeys;
+
+/**
+ * The flat keys, in one place, so the shadow diagnostic below and the reader
+ * cannot fall out of step.
+ */
+const FLAT_MAP_CONFIG_KEYS = [
+  'latitudeField',
+  'longitudeField',
+  'locationField',
+  'titleField',
+  'descriptionField',
+  'zoom',
+  'center',
+] as const satisfies readonly (keyof FlatMapConfigKeys)[];
 
 /**
  * Helper to get data configuration from schema
  */
-function getDataConfig(schema: ObjectGridSchema): ViewData | null {
+function getDataConfig(schema: ObjectMapSchema): ViewData | null {
   if (schema.data) {
     return schema.data;
   }
@@ -155,22 +150,25 @@ const warnedLegacyFilterMapConfigs = new Set<string>();
  * - object-valued only. `filter: { map: 'x' }` reads as a filter on a field
  *   named `map`, not as a stashed MapConfig.
  */
-function warnOnLegacyFilterMapConfig(schema: ObjectGridSchema | any): void {
+function warnOnLegacyFilterMapConfig(schema: MapConfigSource): void {
   if (!isDev()) return;
 
-  const filter = (schema as any)?.filter;
+  // `filter` is declared as a JSON-Rules array; the legacy stash this probe
+  // exists for is an OBJECT, which is why the shape is re-tested at runtime
+  // rather than trusted from the declaration.
+  const filter: unknown = schema.filter;
   if (!filter || typeof filter !== 'object' || Array.isArray(filter)) return;
   if (!Object.prototype.hasOwnProperty.call(filter, 'map')) return;
 
-  const legacy = (filter as any).map;
+  const legacy = (filter as Record<string, unknown>).map;
   if (!legacy || typeof legacy !== 'object') return;
 
   let memo: string;
   try {
-    memo = `${(schema as any).type ?? 'map'}::${(schema as any).objectName ?? ''}::${JSON.stringify(legacy)}`;
+    memo = `${schema.type ?? 'map'}::${schema.objectName ?? ''}::${JSON.stringify(legacy)}`;
   } catch {
     // Circular author data — still worth one warning, just not a keyed one.
-    memo = `${(schema as any).type ?? 'map'}::${(schema as any).objectName ?? ''}::<unserializable>`;
+    memo = `${schema.type ?? 'map'}::${schema.objectName ?? ''}::<unserializable>`;
   }
   if (warnedLegacyFilterMapConfigs.has(memo)) return;
   warnedLegacyFilterMapConfigs.add(memo);
@@ -188,42 +186,95 @@ function warnOnLegacyFilterMapConfig(schema: ObjectGridSchema | any): void {
 }
 
 /**
- * Helper to get map configuration from schema
+ * Warn once per distinct shadowing, for the same reason `getMapConfig` warns
+ * once per legacy stash: this runs on every render of the map.
  */
-function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
+const warnedShadowedFlatKeys = new Set<string>();
+
+/**
+ * The `map` block won and the internal flat keys alongside it were ignored —
+ * say which ones, in dev.
+ *
+ * Silence here is what the precedence rule costs if it is not diagnosed: two
+ * spellings of the same configuration in one schema, one of them inert. The
+ * ruling picks the author's block over the flatten product deliberately
+ * (maintainer, objectui#5018, 2026-08-17), so the diagnostic names what was
+ * dropped rather than leaving the author to discover it from the markers.
+ *
+ * It cannot fire on the ordinary ObjectView / ListView path: both flatteners
+ * emit the flat keys and NO `map` key, so this branch is not even reached for
+ * their output. Reaching it means one schema carries both spellings.
+ */
+function warnOnShadowedFlatMapKeys(schema: MapConfigSource): void {
+  if (!isDev()) return;
+
+  const shadowed = FLAT_MAP_CONFIG_KEYS.filter(
+    (key) => (schema as Record<string, unknown>)[key] !== undefined,
+  );
+  if (shadowed.length === 0) return;
+
+  const memo = `${schema.type ?? 'map'}::${schema.objectName ?? ''}::${shadowed.join(',')}`;
+  if (warnedShadowedFlatKeys.has(memo)) return;
+  warnedShadowedFlatKeys.add(memo);
+
+  console.warn(
+    `[ObjectMap] The \`map\` block configures this map, so these top-level keys are ` +
+      `IGNORED: ${shadowed.map((k) => `\`${k}\``).join(', ')}. The \`map\` block is the ` +
+      'authoring shape; the flat top-level spelling is the internal form ObjectView/ListView ' +
+      'produce when they flatten `options.map`, and what the author wrote outranks it. Move ' +
+      'anything you still need into `map`, or drop the `map` block. objectui#5018.',
+  );
+}
+
+/**
+ * Helper to get map configuration from schema
+ *
+ * PRECEDENCE (maintainer ruling on objectui#5018, 2026-08-17): the declared
+ * `map` block is checked FIRST and wins outright; the flat top-level spelling
+ * is consulted only when no `map` block is present. This is the reverse of the
+ * pre-#5018 order, which let the internal flatten product silently shadow an
+ * authored block. Safe for the producer path because neither flattener emits a
+ * `map` key at all — see `FlatMapConfigKeys`.
+ */
+function getMapConfig(schema: MapConfigSource): ObjectMapConfig {
   warnOnLegacyFilterMapConfig(schema);
 
   // A custom style may be set alongside any of the shapes below — read it
   // once so every return path can carry it through.
+  //
+  // `BaseSchema.style` is an inline-CSS object, not a MapLibre style URL: that
+  // collision is objectui#5017's to rule, and this read deliberately keeps its
+  // exact pre-#5018 runtime behaviour, cast and all, rather than settling it
+  // here.
   const style: string | undefined =
-    (schema as any).style || (schema as any).mapStyle || (schema as any).map?.style;
+    (schema.style as unknown as string | undefined) || schema.mapStyle || schema.map?.style;
 
-  // 1. Check top-level properties (ObjectMapSchema style)
-  if (schema.locationField || schema.latitudeField) {
-      return {
-          locationField: schema.locationField,
-          latitudeField: schema.latitudeField,
-          longitudeField: schema.longitudeField,
-          titleField: schema.titleField || 'name',
-          descriptionField: schema.descriptionField,
-          zoom: schema.zoom,
-          center: schema.center,
-          style,
-      };
-  }
-
-  // 2. The declared configuration input: `{ name: 'map', type: 'object' }` at
-  // the `object-map` / `map` registrations. The only shape consumed here.
-  const config: MapConfig | null = (schema as any).map
-    ? ((schema as any).map as MapConfig)
-    : null;
+  // 1. The declared configuration input: `{ name: 'map', type: 'object' }` at
+  // the `object-map` / `map` registrations. The author face, and the winner
+  // whenever it is present.
+  const config: ObjectMapConfig | null = schema.map ?? null;
 
   if (config) {
-     const result = MapConfigSchema.safeParse(config);
-     if (!result.success) {
-       console.warn(`[ObjectMap] Invalid map configuration:`, result.error.format());
-     }
-     return { ...config, style: config.style || style };
+    const result = ObjectMapConfigSchema.safeParse(config);
+    if (!result.success) {
+      console.warn(`[ObjectMap] Invalid map configuration:`, result.error.format());
+    }
+    warnOnShadowedFlatMapKeys(schema);
+    return { ...config, style: config.style || style };
+  }
+
+  // 2. The internal flat form — the ObjectView / ListView flatten product.
+  if (schema.locationField || schema.latitudeField) {
+    return {
+      locationField: schema.locationField,
+      latitudeField: schema.latitudeField,
+      longitudeField: schema.longitudeField,
+      titleField: schema.titleField || 'name',
+      descriptionField: schema.descriptionField,
+      zoom: schema.zoom,
+      center: schema.center,
+      style,
+    };
   }
 
   // Default configuration — field names only. No camera is synthesized here
@@ -247,7 +298,7 @@ function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
 /**
  * Extract coordinates from a record based on configuration
  */
-function extractCoordinates(record: any, config: MapConfig): [number, number] | null {
+function extractCoordinates(record: any, config: ObjectMapConfig): [number, number] | null {
   // Try latitude/longitude fields
   if (config.latitudeField && config.longitudeField) {
     const lat = record[config.latitudeField];
@@ -440,8 +491,8 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
         }
 
         // Check schema.data next
-        if ((schema as any).data) {
-             const passed = (schema as any).data;
+        if (schema.data) {
+             const passed: unknown = schema.data;
              if (Array.isArray(passed)) {
                  setData(passed);
                  setLoading(false);
@@ -551,7 +602,7 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
   const [currentZoom, setCurrentZoom] = useState(mapConfig.zoom || 3);
 
   const navigation = useNavigationOverlay({
-    navigation: (schema as any).navigation,
+    navigation: schema.navigation,
     objectName: schema.objectName,
     onRowClick,
   });
@@ -567,7 +618,7 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
 
   // Cluster markers when clustering is enabled
   const clusteredData = useMemo(() => {
-    const shouldCluster = enableClustering ?? ((schema as any).enableClustering || filteredMarkers.length > 100);
+    const shouldCluster = enableClustering ?? (schema.enableClustering || filteredMarkers.length > 100);
     if (!shouldCluster) {
       return filteredMarkers.map(m => ({
         id: m.id,

--- a/packages/plugin-map/vite.config.ts
+++ b/packages/plugin-map/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
           '@object-ui/core': 'ObjectUICore',
           '@object-ui/react': 'ObjectUIReact',
           '@object-ui/types': 'ObjectUITypes',
+          '@object-ui/types/zod': 'ObjectUITypesZod',
           'lucide-react': 'LucideReact',
         },
       },

--- a/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The map schema this view PRODUCES — and the one property that makes
+ * objectui#5018's precedence flip safe.
+ *
+ * `generateViewSchema('map')` builds an `object-map` schema by spreading the
+ * CONTENTS of `options.map` at the top level (plus a `locationField` that always
+ * falls back to `'location'`). The product therefore carries the flat spelling
+ * and **no `map` key at all**.
+ *
+ * That is load-bearing, not incidental. The maintainer ruling on objectui#5018
+ * (2026-08-17, 「同意」) made the `map` block outrank the flat spelling inside
+ * `ObjectMap.getMapConfig`, reversing the previous order. The flip can only
+ * change what a view renders if some schema carries BOTH spellings — so the
+ * question "is the flip safe for the producer path" reduces exactly to "does the
+ * flattener emit a `map` key", and the answer is pinned here rather than left to
+ * be re-derived by whoever next edits this branch.
+ *
+ * If a future change makes this branch emit `map: {...}` (a reasonable-looking
+ * cleanup!), the flat keys it emits alongside would become silently ignored
+ * shadows. This test goes red first, which is the point.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ObjectView } from '../ObjectView';
+import type { ObjectViewSchema } from '@object-ui/types';
+
+/** Every schema the view hands to SchemaRenderer, in order. */
+const rendered: any[] = [];
+
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
+  return {
+    SchemaRenderer: ({ schema }: any) => {
+      rendered.push(schema);
+      return <div data-testid="schema-renderer">{schema?.type}</div>;
+    },
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+vi.mock('@object-ui/plugin-grid', () => ({ ObjectGrid: () => <div data-testid="object-grid" /> }));
+vi.mock('@object-ui/plugin-form', () => ({ ObjectForm: () => <div data-testid="object-form" /> }));
+
+async function renderMapView(mapOptions: Record<string, unknown>) {
+  rendered.length = 0;
+  const ds: any = {
+    find: vi.fn().mockResolvedValue({ data: [], total: 0 }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({ name: 'store', fields: {} }),
+  };
+  render(
+    <ObjectView
+      schema={{ type: 'object-view', objectName: 'store' } as ObjectViewSchema}
+      views={[{ id: 'm', label: 'Map', type: 'map' as any, map: mapOptions }]}
+      dataSource={ds}
+    />,
+  );
+  await waitFor(() => expect(rendered.length).toBeGreaterThan(0));
+  return rendered[rendered.length - 1];
+}
+
+describe('ObjectView flattens `options.map` and emits NO `map` key (objectui#5018)', () => {
+  it('produces an object-map schema carrying the FLAT spelling', async () => {
+    const schema = await renderMapView({
+      latitudeField: 'lat',
+      longitudeField: 'lng',
+      titleField: 'store_name',
+    });
+
+    expect(schema.type).toBe('object-map');
+    expect(schema.latitudeField).toBe('lat');
+    expect(schema.longitudeField).toBe('lng');
+    expect(schema.titleField).toBe('store_name');
+  });
+
+  it('emits no `map` key, so the `map`-block-wins rule cannot shadow it', async () => {
+    const schema = await renderMapView({
+      latitudeField: 'lat',
+      longitudeField: 'lng',
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(schema, 'map')).toBe(false);
+    expect(schema.map).toBeUndefined();
+  });
+
+  it('still emits the `locationField` default when nothing is configured', async () => {
+    const schema = await renderMapView({});
+
+    expect(schema.locationField).toBe('location');
+    expect(Object.prototype.hasOwnProperty.call(schema, 'map')).toBe(false);
+  });
+});

--- a/packages/runner/vite.config.ts
+++ b/packages/runner/vite.config.ts
@@ -85,6 +85,8 @@ export default defineConfig({
       "@object-ui/components": path.resolve(__dirname, "../../packages/components/src"),
       "@object-ui/react": path.resolve(__dirname, "../../packages/react/src"),
       "@object-ui/core": path.resolve(__dirname, "../../packages/core/src"),
+      // Subpath before bare package — see the note in `apps/console/vite.config.ts`.
+      "@object-ui/types/zod": path.resolve(__dirname, "../../packages/types/src/zod/index.zod.ts"),
       "@object-ui/types": path.resolve(__dirname, "../../packages/types/src"),
       "@object-ui/plugin-kanban": path.resolve(__dirname, "../../packages/plugin-kanban/src"),
       "@object-ui/plugin-charts": path.resolve(__dirname, "../../packages/plugin-charts/src"),

--- a/packages/types/src/__tests__/view-navigation-config-spec-parity.test.ts
+++ b/packages/types/src/__tests__/view-navigation-config-spec-parity.test.ts
@@ -32,6 +32,7 @@ import type {
   NamedListView,
   NavigationConfig,
   ObjectGridSchema,
+  ObjectMapSchema,
   ObjectViewSchema,
   ViewNavigationConfig,
 } from '../index';
@@ -93,7 +94,9 @@ type _ModeMembershipIsTheSevenSpecModes = Expect<
 /* ── The three schema sites use the shared type ──────────────────────────── */
 
 /**
- * `objectql.ts` spells `navigation?: ViewNavigationConfig` in three interfaces.
+ * `objectql.ts` spells `navigation?: ViewNavigationConfig` in four interfaces
+ * (`ObjectMapSchema` joined them with objectui#5018, which declared the keys
+ * `ObjectMap` actually reads).
  * Each must be the spec type itself, so one authoring surface cannot outgrow
  * another — the same guard `objectql.exportOptions.test.ts` puts on
  * `exportOptions`.
@@ -106,6 +109,9 @@ type _ObjectViewUsesTheSharedType = Expect<
 >;
 type _NamedViewUsesTheSharedType = Expect<
   Equal< NonNullable< NamedListView['navigation'] >, ViewNavigationConfig >
+>;
+type _ObjectMapUsesTheSharedType = Expect<
+  Equal< NonNullable< ObjectMapSchema['navigation'] >, ViewNavigationConfig >
 >;
 
 /* ── Runtime half ────────────────────────────────────────────────────────── */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -364,6 +364,7 @@ export type {
   ConditionalFormattingRule,
   // Component schemas
   ObjectMapSchema,
+  ObjectMapConfig,
   ObjectGanttSchema,
   ObjectCalendarSchema,
   ObjectKanbanSchema,

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1808,13 +1808,108 @@ export interface ListViewRuntimeProps {
   refreshTrigger?: number;
 }
 
+/**
+ * Object Map Configuration — the AUTHOR-FACING shape of an `object-map`'s
+ * type-specific configuration, carried under `ObjectMapSchema.map`.
+ *
+ * ONE declaration, two consumers: this interface is what a TypeScript author
+ * writes, and `ObjectMapConfigSchema` (`zod/objectql.zod.ts`) is what `ObjectMap`
+ * validates the authored block against at runtime. They are kept as a pair
+ * here, in `@object-ui/types`, precisely so the declared face and the runtime
+ * validation cannot drift — before objectui#5018 the zod lived package-private
+ * inside `plugin-map/src/ObjectMap.tsx` and the declared face did not exist at
+ * all, so a misspelled `latitudeFieId` reached the renderer unchallenged by
+ * either layer and painted an empty map.
+ *
+ * The FLAT top-level spelling of these same keys (`schema.latitudeField`, …)
+ * is deliberately NOT declared here: it is the internal product of ObjectView /
+ * ListView flattening `options.map` into the component schema, not an authoring
+ * surface (maintainer ruling on objectui#5018, 2026-08-17). Authors write the
+ * `map` block; when both are present, the block wins.
+ */
+export interface ObjectMapConfig {
+  /** Field containing latitude value */
+  latitudeField?: string;
+  /** Field containing longitude value */
+  longitudeField?: string;
+  /** Field with a combined location (`"lat,lng"`, `[lat, lng]` or `{ lat, lng }`) */
+  locationField?: string;
+  /** Field to use for the marker title/label */
+  titleField?: string;
+  /** Field to use for the marker description */
+  descriptionField?: string;
+  /**
+   * Zoom level (1-20). Declaring it opts the view OUT of fitting the camera to
+   * its records — the declaration wins (objectui#4941).
+   */
+  zoom?: number;
+  /**
+   * Center coordinates `[lat, lng]` — latitude first, as documented and as the
+   * `map` block has always been read. Declaring it opts the view OUT of fitting
+   * the camera to its records.
+   */
+  center?: [number, number];
+  /** MapLibre style URL/spec (overrides the public demo default) */
+  style?: string;
+}
+
+/**
+ * ObjectMap Component Schema
+ *
+ * Every key here has a read site in `plugin-map/src/ObjectMap.tsx`; nothing is
+ * declared that the renderer does not consume (objectui#5018 — the card exists
+ * because the reverse was true, and a declared-but-unread key re-creates the
+ * same defect pointing the other way).
+ */
 export interface ObjectMapSchema extends BaseSchema {
   type: 'object-map';
   /** ObjectQL object name */
   objectName: string;
-  /** Field containing location data (or lat/long pair) */
+  /**
+   * Data source configuration. Preferred over `staticData` / `objectName`
+   * (`getDataConfig`).
+   */
+  data?: ViewData;
+  /** Inline records, wrapped into a `{ provider: 'value' }` data config */
+  staticData?: any[];
+  /** Query filter, forwarded verbatim as `$filter` */
+  filter?: any[];
+  /** Sort configuration, forwarded as `$orderby` */
+  sort?: string | SortConfig[];
+  /**
+   * Map configuration — the author face. See `ObjectMapConfig`.
+   *
+   * Named `ObjectMapConfig`, not `MapConfig`: `@objectstack/spec/automation`
+   * already owns `MapConfig` / `MapConfigSchema` for an unrelated automation
+   * concept, and `check:spec-symbols` (rightly) refuses a local declaration
+   * under a spec export's name — a colliding name is read by the next agent as
+   * the spec's own definition.
+   */
+  map?: ObjectMapConfig;
+  /**
+   * Group nearby markers into clusters. Clustering also engages automatically
+   * past 100 markers; the `enableClustering` prop overrides this key.
+   */
+  enableClustering?: boolean;
+  /**
+   * Record navigation behaviour (drawer / dialog / page).
+   * Aligned with @objectstack/spec ListView.navigation.
+   */
+  navigation?: ViewNavigationConfig;
+  /**
+   * Field containing location data (or lat/long pair).
+   *
+   * INTERNAL FORM. This is the flat spelling ObjectView / ListView produce when
+   * they flatten `options.map`; it predates the `map` block and stays declared
+   * only so that already-published authoring keeps type-checking. New authoring
+   * belongs in `map.locationField`, which wins when both are present
+   * (objectui#5018).
+   */
   locationField?: string;
-  /** Field for marker title */
+  /**
+   * Field for marker title. INTERNAL FORM — see `locationField`; prefer
+   * `map.titleField`.
+   */
   titleField?: string;
   /**
    * MapLibre style URL/spec. Overrides the default demo style

--- a/packages/types/src/zod/index.zod.ts
+++ b/packages/types/src/zod/index.zod.ts
@@ -253,6 +253,7 @@ export {
   ObjectFormSchema,
   ObjectViewSchema,
   ObjectMapSchema,
+  ObjectMapConfigSchema,
   ObjectGanttSchema,
   ObjectCalendarSchema,
   ObjectKanbanSchema,

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -31,6 +31,7 @@ import {
   PaginationConfigSchema as SpecPaginationConfigSchema,
   UserActionsConfigSchema as SpecUserActionsConfigSchema,
   AriaPropsSchema as SpecAriaPropsSchema,
+  NavigationConfigSchema as SpecNavigationConfigSchema,
 } from '@objectstack/spec/ui';
 import { BaseSchema, specFieldsExcept } from './base.zod.js';
 
@@ -531,13 +532,51 @@ export const ListViewSchema = BaseSchema
 export type ListViewInferred = z.input<typeof ListViewSchema>;
 
 /**
+ * Object Map Configuration Schema — the runtime half of `ObjectMapConfig`
+ * (`objectql.ts`).
+ *
+ * NOT named `MapConfigSchema`: `@objectstack/spec/automation` exports that name
+ * for an unrelated automation concept, and `check:spec-symbols` refuses a local
+ * declaration under a spec export's name.
+ *
+ * Lifted out of `plugin-map/src/ObjectMap.tsx`, where it was package-private,
+ * so the declared authoring face and the validation the renderer performs are
+ * ONE schema rather than two that can drift (objectui#5018). `ObjectMap`
+ * imports this exact object; it no longer declares its own.
+ */
+export const ObjectMapConfigSchema = z.object({
+  latitudeField: z.string().optional().describe('Field containing latitude'),
+  longitudeField: z.string().optional().describe('Field containing longitude'),
+  locationField: z.string().optional().describe('Field with a combined location value'),
+  titleField: z.string().optional().describe('Field used as the marker title'),
+  descriptionField: z.string().optional().describe('Field used as the marker description'),
+  zoom: z.number().optional().describe('Zoom level (1-20); declaring it opts out of the auto-fit'),
+  center: z.tuple([z.number(), z.number()]).optional().describe('Center [lat, lng]; declaring it opts out of the auto-fit'),
+  style: z.string().optional().describe('MapLibre style URL/spec (overrides the public demo default)'),
+});
+
+/**
  * ObjectMap Schema
+ *
+ * Mirrors the `ObjectMapSchema` interface in `objectql.ts` key for key. Every
+ * key has a read site in `plugin-map/src/ObjectMap.tsx`; the FLAT spelling of
+ * the `map` block's keys is the ObjectView/ListView flatten product and stays
+ * out of this declaration (maintainer ruling on objectui#5018, 2026-08-17) —
+ * except `locationField` / `titleField`, which were published before the
+ * ruling and stay for compatibility.
  */
 export const ObjectMapSchema = BaseSchema.extend({
   type: z.literal('object-map'),
   objectName: z.string().describe('ObjectQL object name'),
-  locationField: z.string().optional().describe('Location field'),
-  titleField: z.string().optional().describe('Title field'),
+  data: ViewDataSchema.optional().describe('Data source configuration'),
+  staticData: z.array(z.any()).optional().describe('Inline records'),
+  filter: z.array(z.any()).optional().describe('Query filter, forwarded as $filter'),
+  sort: z.union([z.string(), z.array(SortConfigSchema)]).optional().describe('Sort configuration, forwarded as $orderby'),
+  map: ObjectMapConfigSchema.optional().describe('Map configuration (the author face)'),
+  enableClustering: z.boolean().optional().describe('Group nearby markers into clusters'),
+  navigation: SpecNavigationConfigSchema.optional().describe('Record navigation behaviour (drawer/dialog/page)'),
+  locationField: z.string().optional().describe('Location field (internal flat form; prefer map.locationField)'),
+  titleField: z.string().optional().describe('Title field (internal flat form; prefer map.titleField)'),
   mapStyle: z.string().optional().describe('MapLibre style URL/spec (overrides the public demo default)'),
 });
 


### PR DESCRIPTION
Fixes #5018

Implements the maintainer ruling recorded on the card (2026-08-17, 「同意」): direction 1, full alignment, with the `map` block as the author face and the flat top-level spelling as an internal form.

## Declared vs consumed, key by key

Derived from `packages/plugin-map/src/ObjectMap.tsx` at `origin/main`, not from the card's list. Every key in `ObjectMapSchema` has a read site; nothing plausible-looking was added.

| Key | Read site in `ObjectMap.tsx` | Before | After |
| --- | --- | --- | --- |
| `type` | `:170`, `:173` (warn memo) | declared | declared |
| `objectName` | `getDataConfig` `:115`; `:497`; `:555` | declared | declared |
| `data` | `getDataConfig` `:104`; `:491` | **undeclared** | declared (`ViewData`) |
| `staticData` | `getDataConfig` `:108` | **undeclared** | declared (`any[]`) |
| `filter` | `:161` (legacy probe); `:467` (`$filter`) | **undeclared** | declared (`any[]`) |
| `sort` | `:468` (`$orderby`) | **undeclared** | declared (`string \| SortConfig[]`) |
| `map` | `:199` (`.style`); `:217` | **undeclared** | declared (`ObjectMapConfig`) |
| `enableClustering` | `:570` | **undeclared** | declared (`boolean`) |
| `navigation` | `:554` | **undeclared** | declared (`ViewNavigationConfig`) |
| `locationField` | `:202`, `:204` — internal flat form | declared | declared, documented as internal |
| `titleField` | `:207` — internal flat form | declared | declared, documented as internal |
| `mapStyle` | `:199` | declared | declared |
| `style` | `:199` | inherited from `BaseSchema` | unchanged — the collision is #5017's, not touched here |

Consumed but deliberately NOT declared, per the ruling: the flat `latitudeField` / `longitudeField` / `descriptionField` / `zoom` / `center` (`:202-213`). They are the ObjectView / ListView flatten product, declared in the consumer as `FlatMapConfigKeys` instead.

### Discrepancies with the card's key list

- The card listed `style` / `mapStyle` among the keys to reckon with. `mapStyle` was already declared; `style` is `BaseSchema`'s inline-CSS key and its collision is #5017. The read at `:199` keeps its exact prior runtime behaviour here, cast and all, with a comment pointing at #5017. Nothing about that collision is settled by this PR.
- Everything else the card named was confirmed present at the stated read sites.
- One key the card did not name: `type`, read by the legacy-warning memo. Already declared, so no action.

## What changed

- `ObjectMapSchema` gains the seven keys above (TS interface + zod mirror).
- The package-private zod at `ObjectMap.tsx:41-50` is lifted into `@object-ui/types` so the declared face and the runtime validation are one schema.
- `ObjectMapProps.schema` is `ObjectMapSchema`. Every `(schema as any)` map read is gone; the only remaining `as any` in the file are on `rest` (props), `dataConfig.items` and a `ref`.
- Precedence flip in `getMapConfig`: the `map` block is checked first and wins outright, with a dev-mode warn-once diagnostic naming the ignored top-level keys.
- Docs: `content/docs/plugins/plugin-map.mdx` had `import type { ObjectGridSchema, MapConfig }` in its TypeScript section — a line that did not compile against anything. Corrected, plus the declared keys added to the Schema API block and `objectName` marked required. The `map` block teaching is unchanged.

### Naming: `ObjectMapConfig`, not `MapConfig`

The ruling names the lifted schema `MapConfigSchema`. That name cannot be used in `@object-ui/types`: `@objectstack/spec/automation` already exports `MapConfigSchema` for an unrelated automation concept, and `pnpm check:spec-symbols` refuses a local declaration under a spec export's name — verbatim, on the first run:

```
    • @object-ui/types declares 2 spec-named symbols the spec already owns:
        interface `MapConfig`  packages/types/src/objectql.ts:1830  (exported by `@objectstack/spec/automation`)
        const `MapConfigSchema`  packages/types/src/zod/objectql.zod.ts:542  (exported by `@objectstack/spec/automation`)
```

The gate stayed silent before this PR because the plugin-map declaration was module-private. Exported as `ObjectMapConfig` / `ObjectMapConfigSchema`, which the spec does not own; the gate is green.

## The stop-and-report condition was NOT reached

The ruling asked for a stop if the flip is unsafe for ObjectView's producer path. It is safe, and the reason is structural rather than a judgement call: **neither flattener emits a `map` key.**

`plugin-view/src/ObjectView.tsx` `case 'map'` and `plugin-list/src/ListView.tsx` `case 'map'` both build the schema as `{ ...baseProps, locationField: options.map?.locationField || 'location', ...(options.map || {}) }` — the block's CONTENTS spread flat, no `map` key in the product. So the branch the flip reorders is never reached for their output, and the flip cannot change what any ObjectView / ListView map renders. That property is now pinned rather than left to be re-derived: `plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx`.

## The `ObjectMap.filterConfig.test.tsx:164` pin

Read before touching it, and it does **not** record the old precedence. It is `it('keeps the top-level latitudeField branch intact')`, and its schema carries no `map` block at all — so the flat branch is the only branch there is, and the assertion is unchanged by the flip. The old top-level-wins order was **unpinned**; the card's reading of this pin is the one thing in it that did not survive verification.

Kept and annotated rather than rewritten: a history note citing the ruling, saying what it does and does not pin, and pointing at where the precedence is now pinned in both directions. The test still guards the thing that matters most about that branch — the internal flat form has to keep rendering, or every ObjectView / ListView map goes blank.

## Reverse verification

Direction predicted before each run; all four matched.

| Ablation | Predicted | Observed |
| --- | --- | --- |
| Restore the old branch order in `getMapConfig` | 2 red: "map block wins" + the shadow warning; controls green | exactly 2 failed, 50 passed — `expected '1' to be '40'` and `expected '' to contain '[ObjectMap]'` |
| Remove the `warnOnShadowedFlatMapKeys` call | 1 red: only the warning pin | 1 failed, 51 passed |
| Make the flattener emit `map: viewOptions.map` | red in `ObjectView.mapFlatten` | 2 failed, 112 passed — `expected true to be false` on the `hasOwnProperty('map')` assertions |
| Correct `latitudeFieId` to `latitudeField` in the type pin | `tsc` red, TS2578 unused directive | `src/ObjectMap.schemaAlignment.test.tsx(121,7): error TS2578: Unused '@ts-expect-error' directive.` |

Each ablation was restored with `git checkout` against the committed branch; the tree was confirmed byte-identical (`git status --porcelain` empty) before the gate union ran.

### A measured boundary, stated because it limits the claim

The first draft of the type pins asserted that a misspelled TOP-LEVEL key is a compile error too. `tsc` said otherwise — TS2578 on both pins. `BaseSchema` carries `[key: string]: any`, so excess-property checking is off for every component schema in the repo, and `enableClusterng` type-checks. What #5018 buys is the half that matters for its symptom: `ObjectMapConfig` is a plain interface with no index signature, so the `map` BLOCK is closed and `latitudeFieId` is rejected. The pins now record the real boundary instead of the assumed one. Filed as an observation-class finding: #5155.

## Bounding sweep, named

Lifting a runtime schema into `@object-ui/types/zod` broke the workspace build: a vite string alias matches by PREFIX, so in the four configs that alias `@object-ui/types` to source, `@object-ui/types/zod` resolved to the `src/zod` DIRECTORY, which has no `index.ts` (the barrel is `index.zod.ts`).

```
[UNLOADABLE_DEPENDENCY] Could not load ../../packages/types/src/zod
    ../../packages/plugin-map/src/ObjectMap.tsx:22:39
    Is a directory (os error 21)
```

The correct form is already pinned in the repo: the root `vitest.config.mts:250-251` aliases the `/zod` subpath immediately before the bare package. The same two-line pairing is added to `apps/console/vite.config.ts`, `examples/console-starter/vite.config.ts`, `packages/runner/vite.config.ts` and `packages/fields/vite.config.ts` — mechanical, one form, closing the class rather than only the config that happened to fail first.

## Verification

All at `aad4609`, the final commit, tree clean.

- `pnpm --filter '@object-ui/plugin-map^...' build` — exit 0 (dependency closure built before anything was judged)
- `pnpm --filter @object-ui/plugin-map test` — exit 0, 8 files / 52 tests passed
- `pnpm --filter @object-ui/plugin-view test` — exit 0, 12 files / 114 tests passed
- `pnpm exec turbo run type-check` — exit 0, 81/81 tasks (the DOWNSTREAM consumer sweep: every package depending on `@object-ui/types`)
- `pnpm exec turbo run build --filter='!@object-ui/site'` — exit 0, 43/43
- lint on the three touched packages — exit 0, 0 errors
- `@object-ui/types` has no `test` script; its suites run from the root vitest project. `npx vitest run packages/types/src/__tests__/view-navigation-config-spec-parity.test.ts` — exit 0, 5 passed (that file gained a fourth `navigation` identity pin for `ObjectMapSchema`).

Gate union, derived from the actual changed paths (`node scripts/…` via `pnpm check:*`), every gate in `package.json` run at `aad4609`:

| Gate | Exit |
| --- | --- |
| `check:control-bytes` | 0 |
| `check:spec-symbols` | 0 |
| `check:phantom-deps` | 0 |
| `check:self-import` | 0 |
| `check:published-dist` | 0 |
| `check:doc-types` | 0 |
| `check:i18n-keys` | 0 |
| `check:i18n-drift` | 0 |
| `check:i18n-dead-keys` | 0 |
| `check:action-forward-parity` | 0 |
| `check:skills-paths` | 0 |

## Changeset

`.changeset/objectmap-schema-alignment-5018.md`, `minor` for `@object-ui/types` and `@object-ui/plugin-map`. `minor` rather than `patch` because this adds published exports (`ObjectMapConfig`, `ObjectMapConfigSchema`) and widens a published interface — the level this repo uses for declared-surface additions. `@object-ui/plugin-view` is not listed: its only change is a new test file.

## Deliberately not pulled in

#5017 (the `style` / `mapStyle` collision), #5003 and #5020.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_