### PR TITLE
docs(plugin-map): API provider 节如实化为未实现 (#5019)

### DIFF
--- a/.changeset/plugin-map-docs-api-provider-not-implemented-5019.md
+++ b/.changeset/plugin-map-docs-api-provider-not-implemented-5019.md
@@ -1,0 +1,27 @@
+---
+---
+
+Docs-only (objectui#5019). `content/docs/plugins/plugin-map.mdx` no longer teaches
+`data.provider: 'api'` as a working configuration.
+
+The "API Provider" section showed `data: { provider: 'api', endpoint: '/api/locations',
+method: 'GET' }` next to a `map` block, as one of three interchangeable providers.
+`ObjectMap` has no fetch implementation on that path: the branch logs
+`API provider not yet implemented for ObjectMap` and sets the record set to empty, and
+`endpoint` / `method` have no read point anywhere in the package — a reader who copied the
+section got an empty map and a console warning, with nothing to say why. Without a
+`DataSource` the same schema fails one step earlier, on
+`DataSource required for object/api providers`.
+
+The section now states that plainly and points at the object and value providers instead;
+the example that configured the dead branch is gone. Implementing `provider: 'api'` was
+deliberately out of scope — that is capability expansion, not documentation alignment — so
+the page promises nothing about it either way.
+
+The page's other known defect from the same report, the `MapConfig` import that
+`@object-ui/types` never exported, is fixed in objectui#5156 (implementing objectui#5018's
+ruling, which lifts the config into the published type surface as `ObjectMapConfig`) and is
+untouched here.
+
+No published package source was touched — documentation only, so nothing is released by
+this changeset.

--- a/content/docs/plugins/plugin-map.mdx
+++ b/content/docs/plugins/plugin-map.mdx
@@ -229,23 +229,16 @@ the centre of the records, `center` on its own at a continental zoom.
 }
 ```
 
-### API Provider
+### API Provider — not implemented
 
-```tsx
-{
-  type: 'object-map',
-  data: {
-    provider: 'api',
-    endpoint: '/api/locations',
-    method: 'GET'
-  },
-  map: {
-    latitudeField: 'latitude',
-    longitudeField: 'longitude',
-    titleField: 'locationName'
-  }
-}
-```
+`data.provider: 'api'` has no fetch implementation in `ObjectMap`. A schema that
+reaches this branch logs `API provider not yet implemented for ObjectMap`, sets
+the record set to empty and renders a map with no markers; `endpoint` and
+`method` have no read point anywhere in the package. Without a `DataSource` it
+fails one step earlier, with `DataSource required for object/api providers`.
+
+Read from the database with the **Object Provider** above, or pass records you
+already hold with the **Value Provider**.
 
 ## Event Handling
 


### PR DESCRIPTION
Fixes #5019

## 范围(收窄后:只覆盖卡面第二处)

卡面报了两处。**第一处(`MapConfig` 从 `@object-ui/types` 的虚构导入)由 PR #5156 接管**——它落实维护者 2026-08-17 在 #5018 上的裁定,把包内私有配置抬进已发布类型面为 `ObjectMapConfig` / `ObjectMapConfigSchema`,其 diff 已经把该页 "TypeScript Support" 节改成 `import type { ObjectMapSchema, ObjectMapConfig }`。**本 PR 一行不碰第一处**,也不碰该页 `map: {…}` 键面(同属 PR #5156 的活动 diff)。

同文件撞车核对:PR #5156 对本页三处 hunk 落在旧行 101-116 / 120-126 / 470-487;本 PR 唯一 hunk 落在旧行 229-251。**零行重叠**。

## 第二处:API Provider 节

`content/docs/plugins/plugin-map.mdx` 的 "API Provider" 节把 `data: { provider: 'api', endpoint, method }` 教成三个可互换 provider 之一。`packages/plugin-map/src/ObjectMap.tsx` 在这条路上没有取数实现:

```
} else if (dataConfig?.provider === 'api') {
  console.warn('API provider not yet implemented for ObjectMap');
  setData([]);
}
```

`endpoint` / `method` 在整个包里没有任何读取点(全包 grep 零命中)。照抄该节得到的是一张空地图加一条控制台告警,页面上没有一个字解释为什么;缺 `DataSource` 时更早一步抛 `DataSource required for object/api providers`。与 #5002 同类(照抄即空地图),这次落在被 `check-doc-component-types` 扫的那一页上。

改法按 docs retreat:该节如实陈述当前行为,并把读者指回 Object / Value provider;配置未实现分支的示例删除。**不实现 `provider: 'api'`**(能力扩张,非文档对齐;若日后有拉力,另开决策卡),**也不写任何「coming soon」类预告**。

## 前提复测(基线 origin/main = cdac3cc20)

- 第一处仍成立但已被接管:`grep -rn "MapConfig" packages/types/src` 零命中;声明式 `grep -rnE "^(export )?interface MapConfig\b"` 唯一命中 `packages/plugin-map/src/ObjectMap.tsx:74`(无 `export`,包内私有,`plugin-map/src/index.tsx` 也未导出)。反查确认 grep 面无误:同行的 `ObjectGridSchema` 在 `packages/types/src/index.ts:376` 真实存在。
- 第二处成立:上述 warn + `setData([])` 分支今天仍是未实现的降级路径。

## 门禁

| 门 | 结果 | 对本改动是否有牙 |
| --- | --- | --- |
| `node scripts/check-doc-component-types.mjs` | ✅ 143 mdx / 632 块 / 568 个 `type` 字面量 | **无牙**——只校 `type` 字面量是否被注册;脚本头注释明写不管片段里其它键有没有读取点 |
| `node scripts/check-doc-links.mjs` | ✅ Links are valid across 13 scan roots | 无牙(本节无链接) |
| `node scripts/check-control-bytes.mjs` | ✅ 4572 tracked text file(s) | 无牙(字节层) |
| `check-changeset-presence / no-major / fixed` | ✅ | 通过(docs-only,不欠 changeset) |

**反向验证**(先书面预判,再变异,再还原):预判「把该节原样改回去,三个门全绿,只有计数变化;因为没有任何门对 mdx 片段的键/provider 有牙,且该页无 pin 测试(`*.test.ts(x)` 中 `plugin-map.mdx` 零命中)、`tsx` 围栏不进 tsc」。实测完全相符:还原后 `check-doc-component-types` 仍 ✅,计数 632→633 块、568→569 个 `type` 字面量;links / control-bytes 亦全绿。**这条 null 读数本身就是卡面预言的门禁缺口的实证**——现有 docs 门校的是组件类型名,不是片段教的键有没有读取点。

## Changeset

`.changeset/plugin-map-docs-api-provider-not-implemented-5019.md`,空 frontmatter(仓内 docs-only 先例,如 `app-shell-docs-nav-examples.md`):未动任何发版包 `src/`,不触发发版,但按 AGENTS.md「声明一次」留痕。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_