### PR TITLE
fix(app-shell): 对象列表页「New」与移动端浮动 + 消费 createPredicates (#5153)

### DIFF
--- a/.changeset/object-list-new-consumes-create-predicates-5153.md
+++ b/.changeset/object-list-new-consumes-create-predicates-5153.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The object-list page's "New" button and its phone floating "+" now consume `userActions.create` predicates.
+
+`createPredicates` had exactly one consumer in objectui: the related-list toolbar
+(objectui#4646). The standalone object-list page renders the same create
+affordance twice — a PageHeader button and the phone-only floating "+" that
+stands in for it once the header is hidden — and neither read the key. Both
+gated on the object-level verdict alone (`affordances.create` plus the
+principal's `create` grant), so one `userActions.create` object form produced two
+different answers depending on which surface drew the button: honoured on a
+record page's related list, ignored on the object list. `visibleWhen: false` —
+the objectui#3492 shape — did not hide this "New".
+
+Both entry points now layer the toolbar-scope predicates on top of that verdict,
+mirroring the `import` half landed in the same file (objectui#5142):
+`visibleWhen` fails CLOSED and counts as declared by `?? true` (so
+`visibleWhen: false` hides rather than reading as "ungated"), `disabledWhen`
+fails SOFT with its `!= null` declared-ness gate outside the evaluation (so
+`disabledWhen: ''` is "no condition", not "disable"). Hidden and greyed stay
+distinct at both points; the phone "+" takes the native `disabled` plus the same
+`disabled:` utilities the design system's `Button` carries, rather than
+collapsing the greyed state onto "hidden".
+
+The binding is the spec's, unchanged: a toolbar predicate evaluates once per
+toolbar against the record of the scope the toolbar sits in, and a standalone
+object list has no record in scope — so predicates over `os.user.*` / `features.*`
+bind normally and are the meaningful shape here, while one reading `record.*` has
+nothing to bind and fails closed. A predicate can only narrow: it never re-opens
+what the `managedBy` bucket, the object's effective API operations or the
+principal's grant have already closed.

--- a/packages/app-shell/src/views/ObjectView.createPredicates.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.createPredicates.test.tsx
@@ -1,0 +1,425 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * [#5153] The object-list page's "New" button, its phone-only floating "+",
+ * and `userActions.create`.
+ *
+ * `createPredicates` had exactly ONE consumer in objectui before this change:
+ * `RelatedRecordActionsBridge` (objectui#4646, PR #5145), which closed the
+ * **related-list** toolbar. The standalone object-list page renders the same
+ * affordance twice — a PageHeader button and the phone FAB that stands in for
+ * it once the header is hidden — and neither read the key: both gated on
+ * `affordances.create && can(objectDef.name, 'create')`, the object-level
+ * verdict alone. One `userActions.create` object form therefore got two
+ * different verdicts depending on which surface rendered the button, and
+ * `visibleWhen: false` (the objectui#3492 shape) did not hide this "New".
+ *
+ * BINDING under test is the spec docblock's, identical to the import half
+ * (#5142) landed in this same file: a toolbar predicate evaluates ONCE per
+ * toolbar against the record of the scope the toolbar sits in — and a
+ * STANDALONE object list (this surface) has no record in scope. That is not a
+ * gap in this harness, it is the documented binding: "On a standalone object
+ * list there is no record in scope, so a predicate reading `record.*` has
+ * nothing to bind and — per the fail-closed rule above — hides the button."
+ * Both halves are pinned below: the scope-bound predicates (`os.user.*`) that
+ * are the meaningful shape here, and the `record.*` one that fails closed.
+ *
+ * TWO RENDER POINTS. Every case asserts BOTH entry points, because they are
+ * one affordance rendered twice: a phone user and a desktop user must not get
+ * different answers for one declaration. (`sm:hidden` / `hidden sm:block` are
+ * CSS-only, so both are in the DOM here and each is asserted directly.)
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed;
+ * see the PR body. Restoring the pre-change gate at EITHER render point (the
+ * bare `affordances.create && can(...)` conjunction, no predicate layer and no
+ * `disabled`) turns that point's `visibleWhen` / `disabledWhen` cases RED while
+ * the OTHER point's stay green — which is what makes the two entries
+ * separately observable rather than one assertion counted twice. The
+ * boolean-arm, no-predicate, bucket and permission cases stay GREEN in both
+ * worlds: they never reach the predicate layer, which is exactly what makes
+ * them the controls.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/** Controllable principal verdict, keyed by action (`can()` is permissive by default). */
+let principal: Record<string, boolean> = {};
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    check: () => ({ allowed: true }),
+    checkField: () => true,
+    getFieldPermissions: () => [],
+    getRowFilter: () => undefined,
+    getObjectApiOperations: () => undefined,
+    roles: [],
+    isLoaded: false,
+    hasCapabilities: () => true,
+    can: (_object: string, action: string) => principal[action] ?? true,
+    cannot: (_object: string, action: string) => !(principal[action] ?? true),
+  }),
+  useFieldPermissions: () => ({ canRead: () => true, canWrite: () => true, permissions: [] }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada' }, activeOrganization: null }),
+  useIsWorkspaceAdmin: () => false,
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRealtimeSubscription: () => ({ lastMessage: null }),
+  useConflictResolution: () => ({ hasConflicts: false, resolveAllConflicts: () => {} }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// Heavy children: orthogonal to the toolbar gate under test, and each drags in
+// a plugin bundle. Same posture as the sibling import-predicate test.
+vi.mock('@object-ui/plugin-list', () => ({ ListView: () => null }));
+vi.mock('@object-ui/plugin-view', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ObjectView: () => null,
+  ViewTabBar: () => null,
+  ManageViewsDialog: () => null,
+}));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+vi.mock('./RecordDetailView', () => ({ RecordDetailView: () => null }));
+
+import { ObjectView } from './ObjectView';
+import { RelatedRecordActionsBridge } from './RelatedRecordActionsBridge';
+import { useRelatedRecordActions } from '@object-ui/react';
+import { ExpressionProvider } from '../providers/ExpressionProvider';
+
+const OBJECT_NAME = 'showcase_invoice';
+
+/** The signed-in principal the host shell publishes into the predicate scope. */
+const USER = { id: 'u1', name: 'Ada', profile: 'admin' };
+
+/**
+ * Predicates over the toolbar's SCOPE (`os.user.*`) — the meaningful shape on a
+ * standalone list, where there is no record to bind. Same aliases the real
+ * `ExpressionProvider` publishes, so these are authored exactly as they would
+ * be in served metadata.
+ */
+const SCOPE_TRUE = "os.user.profile == 'admin'";
+const SCOPE_FALSE = "os.user.profile == 'guest'";
+/** A predicate over `record.*` — nothing to bind here, per the spec binding. */
+const RECORD_BOUND = 'record.frozen != true';
+
+/** An object whose `userActions.create` carries the given override. */
+function objectsWith(createOverride: unknown) {
+  return [
+    {
+      name: OBJECT_NAME,
+      label: 'Invoice',
+      managedBy: 'platform',
+      fields: {
+        id: { type: 'text', label: 'Id' },
+        name: { type: 'text', label: 'Name' },
+      },
+      userActions: createOverride === undefined ? undefined : { create: createOverride },
+    },
+  ];
+}
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+function renderList(objects: any[]) {
+  return render(
+    <ExpressionProvider user={USER}>
+      <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}`]}>
+        <Routes>
+          <Route
+            path="/apps/:appName/:objectName"
+            element={<ObjectView dataSource={makeDataSource()} objects={objects} onEdit={() => {}} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ExpressionProvider>,
+  );
+}
+
+/** The PageHeader "New" (desktop). */
+const newButton = () =>
+  document.querySelector('[data-testid="object-view-new-button"]') as HTMLButtonElement | null;
+/** Its phone-only floating counterpart. */
+const fab = () =>
+  document.querySelector('[data-testid="mobile-fab-create"]') as HTMLButtonElement | null;
+
+/**
+ * Both render points at once. They are one affordance, so every case states the
+ * expected verdict once and this asserts it against each entry separately —
+ * a regression at either point fails here, naming which one.
+ */
+function expectBothCreateEntries(expected: { rendered: boolean; disabled?: boolean }) {
+  if (!expected.rendered) {
+    expect(newButton()).toBeNull();
+    expect(fab()).toBeNull();
+    return;
+  }
+  expect(newButton()).toBeTruthy();
+  expect(fab()).toBeTruthy();
+  expect(newButton()!.disabled).toBe(expected.disabled ?? false);
+  expect(fab()!.disabled).toBe(expected.disabled ?? false);
+}
+
+beforeEach(() => {
+  principal = {};
+  cleanup();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('#5153 — the object-list page honours `userActions.create` predicates', () => {
+  it('renders New + FAB for the plain boolean arm of the union (no regression)', () => {
+    renderList(objectsWith(true));
+    expectBothCreateEntries({ rendered: true });
+  });
+
+  it('renders New + FAB when the object declares no `userActions` at all', () => {
+    // The pre-change behaviour, unchanged: with no predicates declared there is
+    // nothing to evaluate and the gate is a literal `true`.
+    renderList(objectsWith(undefined));
+    expectBothCreateEntries({ rendered: true });
+  });
+
+  it('renders New + FAB when the object form declares `enabled` but no predicates', () => {
+    renderList(objectsWith({ enabled: true }));
+    expectBothCreateEntries({ rendered: true });
+  });
+
+  it('HIDES New AND the FAB when `visibleWhen` evaluates false', () => {
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_FALSE }));
+    expectBothCreateEntries({ rendered: false });
+  });
+
+  it('keeps New + FAB when `visibleWhen` evaluates true', () => {
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_TRUE }));
+    expectBothCreateEntries({ rendered: true });
+  });
+
+  it('GREYS New AND the FAB (render, disabled) when `disabledWhen` holds — hidden and disabled stay distinct', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: SCOPE_TRUE }));
+    expectBothCreateEntries({ rendered: true, disabled: true });
+  });
+
+  it('leaves New + FAB enabled when `disabledWhen` does not hold', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: SCOPE_FALSE }));
+    expectBothCreateEntries({ rendered: true, disabled: false });
+  });
+
+  it('fails CLOSED on a `visibleWhen` that cannot bind — the standalone list has no record in scope', () => {
+    // Not a defect of this harness: the spec binds a toolbar predicate to the
+    // record of the scope the toolbar sits in, and says in as many words that a
+    // standalone object list has none, so a `record.*` read hides the button.
+    renderList(objectsWith({ enabled: true, visibleWhen: RECORD_BOUND }));
+    expectBothCreateEntries({ rendered: false });
+  });
+
+  it('fails SOFT on a `disabledWhen` that cannot bind — an unevaluable predicate never greys forever', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: RECORD_BOUND }));
+    expectBothCreateEntries({ rendered: true, disabled: false });
+  });
+
+  it('treats `disabledWhen: ""` as "no condition", not as "disable"', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: '' }));
+    expectBothCreateEntries({ rendered: true, disabled: false });
+  });
+
+  it('honours the object-level opt-out — `create: false` hides both, predicates or not', () => {
+    renderList(objectsWith({ enabled: false, visibleWhen: SCOPE_TRUE }));
+    expectBothCreateEntries({ rendered: false });
+  });
+
+  it('a passing predicate cannot RE-OPEN what the principal closed (#4096 layering)', () => {
+    // The permission gate and the predicate layer stack; neither short-circuits
+    // the other. `visibleWhen` is true here, so if the layer order were
+    // inverted the button would come back.
+    principal = { create: false };
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_TRUE }));
+    expectBothCreateEntries({ rendered: false });
+  });
+
+  it('the permission gate still hides both with no predicates declared', () => {
+    principal = { create: false };
+    renderList(objectsWith(true));
+    expectBothCreateEntries({ rendered: false });
+  });
+
+  it('a bucket that grants no create shows neither entry, predicates or not', () => {
+    // `append-only` resolves `create: false`; a predicate must not resurrect it.
+    renderList([
+      {
+        name: OBJECT_NAME,
+        label: 'Invoice',
+        managedBy: 'append-only',
+        fields: { id: { type: 'text' }, name: { type: 'text' } },
+        userActions: { create: { visibleWhen: SCOPE_TRUE } },
+      },
+    ]);
+    expectBothCreateEntries({ rendered: false });
+  });
+});
+
+/**
+ * PER-ENTRY OBSERVABILITY. The cases above assert both render points inside one
+ * test, which is the right economy for thirteen cases but means a regression at
+ * EITHER point fails the SAME test name. These four pin the two headline
+ * verdicts one entry at a time, so removing the predicate layer from a single
+ * render point produces a crisp two-red / two-green split naming the point that
+ * broke, instead of a wall of ambiguous failures. This is the shape the reverse
+ * verification in the PR body is read against.
+ */
+describe('#5153 — each create render point is separately observable', () => {
+  it('the header "New" alone: hidden when `visibleWhen` is false', () => {
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_FALSE }));
+    expect(newButton()).toBeNull();
+  });
+
+  it('the phone FAB alone: hidden when `visibleWhen` is false', () => {
+    renderList(objectsWith({ enabled: true, visibleWhen: SCOPE_FALSE }));
+    expect(fab()).toBeNull();
+  });
+
+  it('the header "New" alone: greyed when `disabledWhen` holds', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: SCOPE_TRUE }));
+    expect(newButton()).toBeTruthy();
+    expect(newButton()!.disabled).toBe(true);
+  });
+
+  it('the phone FAB alone: greyed when `disabledWhen` holds', () => {
+    renderList(objectsWith({ enabled: true, disabledWhen: SCOPE_TRUE }));
+    expect(fab()).toBeTruthy();
+    expect(fab()!.disabled).toBe(true);
+  });
+});
+
+/**
+ * FAMILY PARITY — the point of the issue, asserted directly.
+ *
+ * `create` now has three render points across the app: the related list's
+ * "+ New" (#4646 / PR #5145), and this page's header button and phone FAB
+ * (#5153). The defect was never "a predicate is unread" in the abstract; it was
+ * that ONE authored declaration produced DIFFERENT verdicts depending on which
+ * surface drew the button. So the parity is what gets pinned, in a single
+ * render of all three under one scope.
+ *
+ * The subject must be a SCOPE-only predicate (`os.user.*`): that is the shape
+ * which binds identically everywhere, and the only one for which "the same
+ * answer on all three" is the correct expectation. A `record.*` predicate
+ * deliberately does NOT agree across these surfaces — the related list binds
+ * the host record and this page has none — which is the spec's binding, not a
+ * defect, and is pinned as its own case above.
+ */
+describe('#5153 — one `userActions.create` declaration, one verdict on all three create surfaces', () => {
+  const CHILD_PARENT = { id: 'p1', name: 'Order', frozen: false };
+
+  function renderAllThree(createOverride: unknown) {
+    const verdicts = { relatedList: undefined as boolean | undefined };
+    function Probe() {
+      const api = useRelatedRecordActions();
+      const handlers =
+        api?.resolve({ objectName: OBJECT_NAME, relationshipField: 'order', parentId: 'p1' }) ?? {};
+      verdicts.relatedList = typeof handlers.onCreate === 'function';
+      return null;
+    }
+    render(
+      <ExpressionProvider user={USER}>
+        <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}`]}>
+          <>
+            <Routes>
+              <Route
+                path="/apps/:appName/:objectName"
+                element={
+                  <ObjectView
+                    dataSource={makeDataSource()}
+                    objects={objectsWith(createOverride)}
+                    onEdit={() => {}}
+                  />
+                }
+              />
+            </Routes>
+            <RelatedRecordActionsBridge
+              appName="demo"
+              objects={objectsWith(createOverride)}
+              dataSource={{ delete: vi.fn() } as any}
+              parentObjectName="order"
+              parentRecordId="p1"
+              parentRecord={CHILD_PARENT}
+              parentObjectFields={{ id: { type: 'text' }, frozen: { type: 'boolean' } }}
+            >
+              <Probe />
+            </RelatedRecordActionsBridge>
+          </>
+        </MemoryRouter>
+      </ExpressionProvider>,
+    );
+    return {
+      relatedList: verdicts.relatedList,
+      objectListNew: newButton() != null,
+      mobileFab: fab() != null,
+    };
+  }
+
+  it('`visibleWhen` false: all three agree on HIDDEN', () => {
+    const v = renderAllThree({ enabled: true, visibleWhen: SCOPE_FALSE });
+    expect(v).toEqual({ relatedList: false, objectListNew: false, mobileFab: false });
+  });
+
+  it('`visibleWhen` true: all three agree on SHOWN', () => {
+    const v = renderAllThree({ enabled: true, visibleWhen: SCOPE_TRUE });
+    expect(v).toEqual({ relatedList: true, objectListNew: true, mobileFab: true });
+  });
+
+  it('`visibleWhen: false` — the literal objectui#3492 shape — hides all three', () => {
+    const v = renderAllThree({ enabled: true, visibleWhen: false });
+    expect(v).toEqual({ relatedList: false, objectListNew: false, mobileFab: false });
+  });
+
+  it('the plain boolean arm still shows all three', () => {
+    const v = renderAllThree(true);
+    expect(v).toEqual({ relatedList: true, objectListNew: true, mobileFab: true });
+  });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -939,6 +939,46 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     }, [externalRefreshKey]);
 
     /**
+     * [#5153] The object-list toolbar's CREATE predicates — the `create` half
+     * of the toolbar-scope pair on THIS surface. #4646 (PR #5145) gave
+     * `createPredicates` a consumer on the **related list**
+     * (`RelatedRecordActionsBridge`); the standalone object-list page kept
+     * gating its "New" on the object-level verdict alone, so one
+     * `userActions.create` object form got two different verdicts depending on
+     * which surface rendered the button — honoured on a record page's related
+     * list, ignored here. `visibleWhen: false` (the objectui#3492 shape) did
+     * not hide this "New".
+     *
+     * BINDING, LAYERING and the fail-CLOSED / fail-SOFT split are the import
+     * half's, immediately below, verbatim — the spec types the two toolbar keys
+     * identically and binds them in one breath. See that docblock for the
+     * reasoning; the only thing that differs here is which affordance is gated.
+     *
+     * TWO RENDER POINTS, ONE VERDICT. The affordance surfaces twice on this
+     * page — the PageHeader button (desktop) and the phone-only floating "+"
+     * that stands in for it once the header is hidden. They are one affordance
+     * rendered twice, so both consume these SAME two values; computing the
+     * predicate once here is what keeps them from disagreeing with each other.
+     */
+    const objectCanCreate = affordances.create && can(objectDef.name, 'create');
+    const createPredicates: RowCrudPredicates | undefined = objectCanCreate
+      ? affordances.createPredicates
+      : undefined;
+    /** `visibleWhen` — fails CLOSED, declared-ness by `?? true`. As Import. */
+    const createVisible = useRowPredicate(createPredicates?.visibleWhen ?? true, null, {
+      fallback: false,
+      warnOnError: true,
+      label: 'builtin:create:visibleWhen',
+    });
+    /** `disabledWhen` — fails SOFT, `!= null` declared-ness OUTSIDE the eval. */
+    const createDisabledPred = useRowPredicate(createPredicates?.disabledWhen, null, {
+      fallback: false,
+      warnOnError: true,
+      label: 'builtin:create:disabledWhen',
+    });
+    const createDisabled = createPredicates?.disabledWhen != null && createDisabledPred;
+
+    /**
      * [#5142] The object-list toolbar's IMPORT predicates — the `import` half
      * of the toolbar-scope pair the spec resolver emits, mirroring what
      * `RelatedRecordActionsBridge` does for `create` (objectui#4646).
@@ -2185,9 +2225,20 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                       </Button>
                     )}
 
-                    {/* Primary action - always visible */}
-                    {affordances.create && can(objectDef.name, 'create') && (
-                    <Button size="sm" onClick={actions.create} className="shadow-none gap-1.5 sm:gap-2 h-8 sm:h-9">
+                    {/* Primary action.
+                        [#5153] `objectCanCreate && createVisible` — the
+                        object-level verdict, then the toolbar-scope
+                        `visibleWhen` layer on top of it. Greyed, not gone, is
+                        the `disabledWhen` case. Same pair drives the phone FAB
+                        below, so the two render points cannot disagree. */}
+                    {objectCanCreate && createVisible && (
+                    <Button
+                        size="sm"
+                        onClick={actions.create}
+                        disabled={createDisabled}
+                        className="shadow-none gap-1.5 sm:gap-2 h-8 sm:h-9"
+                        data-testid="object-view-new-button"
+                    >
                         <Plus className="h-4 w-4" />
                         <span className="hidden sm:inline">{t('console.objectView.new')}</span>
                     </Button>
@@ -2254,12 +2305,30 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                  PageHeader's primary create action we just hid. Positioned
                  above the bottom mobile-nav (h-12 + safe-area) so it
                  doesn't collide with it. Hidden on tablets/desktops
-                 because the inline header button is already visible. */}
-             {affordances.create && can(objectDef.name, 'create') && (
+                 because the inline header button is already visible.
+
+                 [#5153] Second render point of the SAME affordance, so it
+                 consumes the SAME `objectCanCreate && createVisible` /
+                 `createDisabled` pair as the header button — a phone user and a
+                 desktop user must not get different verdicts for one
+                 `userActions.create` declaration.
+
+                 DISABLED, on a control with no greyed form of its own: this is
+                 a bare `<button>`, not the design system's `Button`, so it
+                 carries none of the latter's `disabled:` treatment. Rather than
+                 collapse the three states to two (which would map
+                 `disabledWhen` onto "hidden" and lose the distinction the spec
+                 draws between hidden and greyed), it takes the native
+                 `disabled` — which is what conveys the state to assistive tech
+                 — plus the same `disabled:opacity-50
+                 disabled:pointer-events-none` utilities `Button` itself uses,
+                 so the visual affordance matches the header button's. */}
+             {objectCanCreate && createVisible && (
                <button
                  type="button"
                  onClick={actions.create}
-                 className="sm:hidden fixed right-4 bottom-36 z-40 h-12 w-12 rounded-full bg-primary text-primary-foreground shadow-lg active:scale-95 transition-transform inline-flex items-center justify-center"
+                 disabled={createDisabled}
+                 className="sm:hidden fixed right-4 bottom-36 z-40 h-12 w-12 rounded-full bg-primary text-primary-foreground shadow-lg active:scale-95 transition-transform inline-flex items-center justify-center disabled:opacity-50 disabled:pointer-events-none"
                  aria-label={t('console.objectView.new')}
                  data-testid="mobile-fab-create"
                >


### PR DESCRIPTION
Fixes #5153

## 背景:这是 create 一族的最后一块

`createPredicates` 在 objectui 里此前只有**一个**消费方 —— 关联列表工具栏(`RelatedRecordActionsBridge`,#4646 / PR #5145)。独立对象列表页把**同一个** create affordance 渲染了**两次**(PageHeader 按钮 + 手机端顶掉 header 后顶上的浮动 +),两处都只看对象级判词 `affordances.create && can(objectDef.name, 'create')`,谓词信封整个被丢掉。

于是作者写一份 `userActions.create` 对象形,会拿到**两种不同判词**,取决于是哪个界面画的按钮:关联列表认,对象列表不认。`visibleWhen: false`(objectui#3492 的形)关不掉这个「New」。

本单补齐消费方,家族闭环:

| issue | 半 | 界面 | 状态 |
|---|---|---|---|
| #4646 | create | 关联列表工具栏 | PR #5145 已落 |
| #5142 | import | 对象列表工具栏 | PR #5154 已落 |
| **#5153** | **create** | **对象列表页 New + 浮动 +** | **本 PR** |

## 修法:逐字镜像同文件刚落的 import 半

PR #5154 的 `importVisible` / `importDisabled` 就在同一个文件里,本 PR 照抄其语义,不自创、不抽共享 helper(各调用方自答,沿用 PR #5154 的取舍先例):

- `visibleWhen` —— fail **CLOSED**,且用 `?? true` 而非真值性判定「是否声明」,所以 `visibleWhen: false` 是隐藏而不是读成「未设门」(#3492 不变量);默认值是 boolean,求值器直接短路,没声明谓词的对象一次引擎调用都不付。
- `disabledWhen` —— fail **SOFT**(算不出的谓词不能把按钮永久置灰),`!= null` 的声明性判定放在**求值之外**,所以 `disabledWhen: ''` 读作「无条件」而不是「禁用」。
- **scope 记录传 `null`** —— spec 原文语义:工具栏谓词每工具栏求值一次,绑定该工具栏所在 scope 的记录;独立对象列表**没有记录在 scope 里**,所以读 `record.*` 的谓词无从绑定、按 fail-closed 隐藏按钮。`os.user.*` / `features.*` 正常绑定,是这里有意义的形。
- **分层**:谓词叠在既有门**之上**,只在对象级判词已经通过时才浮现 —— 谓词只能收窄,绝不能重新打开 bucket / #3391 有效 API 操作 / principal 授权已经关掉的东西。既有权限门与 affordance 门一律未动。

谓词**只算一次**,两个渲染点消费**同一对**值 —— 这正是让它们不会互相打架的原因。

### 浮动 + 的 disabled 三态如实分层

浮动 + 是个裸 `button`,不是设计系统的 `Button`,自身没有任何置灰形态。这里**没有**把三态压成两态(那会把 `disabledWhen` 映射成「隐藏」,丢掉 spec 明确区分的 hidden vs greyed),而是:原生 `disabled`(这是传达给辅助技术的那一半)+ `Button` 自己用的同一组 `disabled:opacity-50 disabled:pointer-events-none`,让视觉可及性与 header 按钮对齐。

### 无类型改动

`UserActionsOverride.create` 早在 #4646 就已是放宽后的联合类型,core 未动;`RelatedRecordActionsBridge` / RelatedList 未动。半径:`ObjectView.tsx` + 测试 + changeset(patch)。

## 前提复验(先行门)

卡面三条判断逐条复测,**全部成立**(行号因 PR #5154 漂移,现场定位):

1. 两个 create 入口 `ObjectView.tsx:2129/:2194` → 现为 **:2189 / :2258**,确认两处都只有 `affordances.create && can(...)` 合取,无谓词层。
2. spec docblock 复核 —— `node_modules/@objectstack/spec@17.0.0` 的 `RowCrudActionOverrideSchema` docblock 与 `CrudAffordances.createPredicates` 逐字含卡面引文:「On a standalone object list there is no record in scope … hides the button」。独立列表**在**工具栏谓词适用范围内,缺的只是记录。
3. **入口全量清点**:仓内 `affordances.create` 的 UI 消费方共三处 —— 关联列表(已落)+ 本文件两处。同文件**无第三个** create 入口(`showCreate: false` 已显式关掉插件自带的 create 按钮)。

## 反向验证(先书面预判,再跑;四组预判全部逐条命中)

| 变异 | 预判 | 实测 |
|---|---|---|
| **A1** 只摘浮动 + 的消费 | 7 红 / 15 绿;两条 **FAB-alone 红**、两条 **header-alone 绿** | ✅ 完全一致 |
| **A2** 只摘 header New 的消费 | 镜像:两条 **header-alone 红**、两条 **FAB-alone 绿** | ✅ 完全一致 |
| **C** 两处同时还原(改前世界) | 9 红 / 13 绿;家族判词呈现卡面原话 | ✅ 完全一致 |
| **B** fixture 塞假谓词键 `visibleWhenX` | 1 红且**不抛错**(未知键被忽略 → `?? true` → 按钮渲染) | ✅ 完全一致 |

A1/A2 互为镜像,是「逐入口可观测」的实证:摘掉任一入口,**另一入口的钉子仍然绿**,所以两个渲染点是分别被钉住的,不是一条断言数了两遍。为此专门加了一组 per-entry 钉子 —— 合并断言省事,但会让任一入口的回归都失败在同一个测试名下。

变异 C 的价值在于它把**卡面主张复现成了机器可判的 diff**:

```
-   "mobileFab": false,        +   "mobileFab": true,
-   "objectListNew": false,    +   "objectListNew": true,
    "relatedList": false,          "relatedList": false,
```

关联列表认这份声明(false = 已隐藏),对象列表两处不认(true = 照样显示)—— 这正是 #5153 描述的缺陷本身。

变异 B 证明「隐藏」是 `visibleWhen` **这个键**造成的,而非任何对象形 `userActions.create` 的存在;顺带确认拼错的键不会抛错。这不构成新缺陷:spec 的 `RowCrudActionOverrideSchema` 声明为 `z.core.$strict`,未知键由**生产方**在发布期严格拒绝,渲染方的宽容位于严格 schema 的下游 —— 契约优先,消费端无需再设兜底。

## 测试

新增 `ObjectView.createPredicates.test.tsx`,22 钉(镜像 import 半 14 钉 + 4 条 per-entry + 4 条家族判词一致性)。家族判词一致性一次渲染三面(关联列表 / 对象列表 New / 浮动 +),对同一份声明断言三者同判 —— 主语必须是 **scope-only** 谓词(`os.user.*`),因为那才是三面都能同样绑定的形;`record.*` 谓词三面**本就不该**一致(关联列表绑宿主记录,本页没有),那是 spec 的绑定规则而非缺陷,单独钉在 fail-closed 用例里。

```
vitest run packages/app-shell/                                   429 files | 4134 passed | 1 skipped
vitest run <本单 + PR5154 + PR5145 三个谓词测试>                    3 files  |   52 passed
pnpm type-check                                                  81 successful, 81 total
eslint packages/app-shell/src/views/ObjectView.tsx               0 errors (159 warnings,
                                                                 与基线 cdac3cc20 逐一相同 —— 本改动 0 新增)
node scripts/check-control-bytes.mjs                             OK (4572 files)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' 三个改动文件               clean
```

基线 sha:`cdac3cc20`(含 PR #5154 的 import 半 `9f23d2b32`)。

## 顺带发现(半径外,已单独立卡,未在本 PR 修)

入口清点时发现 **#5164**:`ObjectDataPage`(ADR-0055 的 `/data` 界面)的「New」只看 `can(objectDef.name, 'create')`,整个 CRUD affordance 矩阵在该文件里从未解析 —— 连 `managedBy` bucket 与 `userActions.create: false` 都关不掉它,比本单的缺陷更宽一层。已按查重后 unassigned 立卡,交 PM 分诊;本 PR 半径严守 `ObjectView.tsx`,未动该文件。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_