### PR TITLE
docs(plugin-calendar): 删除重复的 ObjectCalendar Component 标题与引言 (#4517)

### DIFF
--- a/.changeset/plugin-calendar-doc-dup-heading-4517.md
+++ b/.changeset/plugin-calendar-doc-dup-heading-4517.md
@@ -1,0 +1,23 @@
+---
+---
+
+Docs only: `content/docs/plugins/plugin-calendar.mdx` printed the `## ObjectCalendar
+Component` heading and its intro sentence ("Calendar component designed for use with
+ObjectQL data sources.") twice, back to back, with nothing between the two copies
+(objectui#4517). The first pair is removed; the second one and everything under it —
+`### Features` onwards — is untouched, and the section keeps exactly the content it
+always had.
+
+Nothing rendered wrong, but the duplication was visible in two places a reader lands on:
+the docs site builds its table of contents from headings, so the page nav listed
+"ObjectCalendar Component" twice with the first entry pointing at an anchor that had no
+content beneath it, and two headings with the same text produce two slugs — the plain
+`#objectcalendar-component` plus a de-duplicated variant — which makes a deep link to the
+section ambiguous about which of the two it lands on.
+
+No package source, types or runtime behaviour changed, so this declares no release; the
+mechanical presence gate (`scripts/check-changeset-presence.mjs`) does not owe one for a
+`content/docs/**` diff either. It is declared anyway because that is what this repo does
+with docs-only work — the same empty-frontmatter shape as the `content/docs` corrections
+in objectui#4793, #4808, #4823, #4827 — so the change is recorded once rather than
+arriving unannounced.

--- a/content/docs/plugins/plugin-calendar.mdx
+++ b/content/docs/plugins/plugin-calendar.mdx
@@ -173,10 +173,6 @@ replaces the action dispatch rather than running alongside it.
 
 Calendar component designed for use with ObjectQL data sources.
 
-## ObjectCalendar Component
-
-Calendar component designed for use with ObjectQL data sources.
-
 ### Features
 
 - **ObjectQL Integration**: Works seamlessly with object/api/value data providers


### PR DESCRIPTION
Fixes #4517

## 改了什么

`content/docs/plugins/plugin-calendar.mdx` 在「CalendarView Schema API」一节之后,把 `## ObjectCalendar Component` 这个 h2 与它的引言句(Calendar component designed for use with ObjectQL data sources.)一字不差地连写了两遍,两份之间没有任何内容。本次删掉**第一份**,保留第二份及其后从 `### Features` 起的全部正文。

单文件单 hunk,4 行删除;`### Features` 本身只有一份,不在重复范围内,该节内容与改动前完全一致。⛔ 未顺手改该页其它任何内容,未触碰 `content/docs/releases/`。

## 为什么值得改

渲染不出错,但读者会在两处看见它:

1. 文档站的目录由标题生成,页内导航因此出现两条「ObjectCalendar Component」,其中第一条指向一个底下没有内容的锚点。
2. 同名标题会产出两个 slug(裸的 `#objectcalendar-component` 与一个去重变体),深链到该节时落在哪一个是不确定的。

## 前提复测

按 origin/main `cdac3cc20` 复测,与 issue 描述一致:改前 `grep -c '^## ObjectCalendar Component$'` = 2(172 行与 176 行),两者之间只有引言与空行;`### Features` 只有一份。前提成立。

同时确认没有任何测试钉住该页的标题结构 —— 全仓 grep `plugin-calendar` 只在 `packages/plugin-calendar/src/calendar-view-renderer.tsx:70` 的注释里出现该 mdx 路径,不是断言。

## 门禁

覆盖 `content/docs/**` 的三道门,加 changeset 三道,全绿:

| 门 | 结果 |
| --- | --- |
| `node scripts/check-doc-component-types.mjs` | `✅ Every documented component type is registered.`(143 mdx / 633 code block / 569 type 字面量) |
| `node scripts/check-doc-links.mjs` | `Links are valid across 13 scan roots.` |
| `node scripts/check-control-bytes.mjs` | `✅ OK (scanned 4573 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-fixed.mjs` | `✅ All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |
| `node scripts/check-changeset-presence.mjs` | `✅ No source of a released package changed in this range, so no changeset is owed.` |

另跑自查 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,两个改动文件均无原始控制字节。

未跑包级 `test` / `type-check`:本 PR 不含任何 `src/`、类型或运行时改动,作用面只有一个 mdx 与一个 changeset。

## 反向验证(预判在先)

**预判:全绿。** 本仓没有任何一道门判标题唯一性或目录/锚点重复 —— doc-links 解析链接目标,doc-types 读代码块里的 `type` 字面量,control-bytes 看字节,三者判的都不是这件事。

**实测:** 把重复的标题+引言对放回工作区(`grep -c` 回到 2)后重跑三道门,逐一仍 `rc=0`、输出与修复后一字不差。**与预判一致。**

这不是「门失效」,而是这一类缺陷在本仓本就无门可依 —— 也正是它能一直留到被当作 observation-class finding 记下来、而不是被 CI 拦住的原因。跑完已还原,索引与工作区一致。

## changeset

按本仓 docs-only 惯例写空 frontmatter(声明一次、不发版)。证据:机械门 `check-changeset-presence.mjs` 明说这次不欠 changeset(「0 of them under the src/ of a package the release covers」),但 `.changeset/` 里 `content/docs` 更正一律留了同形状的一份 —— #4793、#4808、#4823、#4827 等 8 份先例,故照形补上而非省略。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_