### PR TITLE
test(scripts): side-effects 门读全 24 张 vite alias 表,70 → 196 条 (#5158)

### DIFF
--- a/scripts/__tests__/side-effects-declaration-consistency.test.ts
+++ b/scripts/__tests__/side-effects-declaration-consistency.test.ts
@@ -101,19 +101,19 @@ import { fileURLToPath } from 'node:url';
  *
  * ## The workspace-alias trap
  *
- * The published paths are NOT the only consumption surface. Three in-repo
- * bundler configs alias `@object-ui/*` specifiers at a package's `src`
- * (`apps/console/vite.config.ts`, `examples/console-starter/vite.config.ts`,
- * `packages/fields/vite.config.ts`), and a bundler reads the SAME
- * `package.json` for those source files. PR #3940 measured it: with only the
- * `dist/*` forms declared, the console's alias shape still produced a 0-byte
- * bundle. A gate that skipped alias entries would hand a green light to a
- * package that still breaks, so the alias tables are parsed and folded into the
- * entry forms below.
+ * The published paths are NOT the only consumption surface. In-repo bundler
+ * configs alias `@object-ui/*` specifiers at a package's `src`, and a bundler
+ * reads the SAME `package.json` for those source files. PR #3940 measured it:
+ * with only the `dist/*` forms declared, the console's alias shape still
+ * produced a 0-byte bundle. A gate that skipped alias entries would hand a
+ * green light to a package that still breaks, so the alias tables are parsed
+ * and folded into the entry forms below.
  *
- * The root `vitest.config.mts` has a fourth such table and is deliberately NOT
- * read: Vitest transforms and executes modules, it does not tree-shake them, so
- * `sideEffects` has no effect on that path. It is not a bundling surface.
+ * The root `vitest.config.mts` has such a table and is deliberately NOT read:
+ * Vitest transforms and executes modules, it does not tree-shake them, so
+ * `sideEffects` has no effect on that path. It is not a bundling surface. The
+ * same reasoning scopes the parse below to `resolve.alias` and not to a
+ * `test.alias` inside a `vite.config.*`.
  *
  * ## What this gate deliberately does NOT prove
  *
@@ -257,18 +257,181 @@ interface AliasEntry {
  */
 const BUNDLER_CONFIG_RE = /^vite\.config\.(ts|mts|cts|js|mjs|cjs)$/;
 
+/** Only workspace packages are a `sideEffects` surface this repo can fix. */
+const ALIAS_SPECIFIER_PREFIX = '@object-ui/';
+
 /**
- * Alias tables parsed out of every bundler config in the workspace, as TEXT.
+ * An `@object-ui/*` key sitting in a `resolve.alias` table that the parser
+ * below could not turn into an entry. Never a silent skip: the whole failure
+ * mode this shape exists to end is a surface that shrinks without saying so.
+ */
+interface AliasParseGap {
+  config: string;
+  /** The specifier, or a description of the table when the table itself is unreadable. */
+  what: string;
+  /** The source text that was not understood, first line, clipped. */
+  text: string;
+}
+
+const aliasParseGaps: AliasParseGap[] = [];
+
+/** `x as T`, `x satisfies T`, `(x)` — spellings that wrap the node we want. */
+function unwrapExpression(node: ts.Expression): ts.Expression {
+  let current = node;
+  while (
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isParenthesizedExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** A property's name as text, for the spellings a config uses (`k`, `'k'`, `"k"`). */
+function propertyKey(prop: ts.PropertyAssignment): string | undefined {
+  const name = prop.name;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) {
+    return name.text;
+  }
+  return undefined;
+}
+
+/**
+ * A `resolve()`-shaped call, whatever the callee is spelled as: bare `resolve`
+ * from `import { resolve } from 'path'`, `path.resolve`, or a renamed import
+ * like `nodePath.resolve`. The ARGUMENTS are what make it an alias target —
+ * `(__dirname | import.meta.dirname, '<relative>')` — so the callee only has to
+ * be the right function name, not the right import style.
+ */
+function resolveCallTarget(value: ts.Expression): string | undefined {
+  const call = unwrapExpression(value);
+  if (!ts.isCallExpression(call)) return undefined;
+
+  const callee = call.expression;
+  const isResolve =
+    (ts.isIdentifier(callee) && callee.text === 'resolve') ||
+    (ts.isPropertyAccessExpression(callee) && callee.name.text === 'resolve');
+  if (!isResolve) return undefined;
+
+  if (call.arguments.length !== 2) return undefined;
+  const base = call.arguments[0];
+  const isDirname =
+    (ts.isIdentifier(base) && base.text === '__dirname') ||
+    (ts.isPropertyAccessExpression(base) && base.name.text === 'dirname' && ts.isMetaProperty(base.expression));
+  if (!isDirname) return undefined;
+
+  const relative = call.arguments[1];
+  if (!ts.isStringLiteral(relative) && !ts.isNoSubstitutionTemplateLiteral(relative)) return undefined;
+  return relative.text;
+}
+
+/**
+ * The `resolve.alias` tables of one config, as expressions.
+ *
+ * Scoped to `alias` under a `resolve` property on purpose. A blind search for
+ * any `alias:` would also pick up a `test.alias`, and the header above says why
+ * that must not count: Vitest executes modules rather than tree-shaking them,
+ * so a Vitest-only alias is not a bundling surface and folding it in here would
+ * widen this gate past what it can justify.
+ *
+ * One hop of identifier indirection is followed, because two of the three
+ * tables the previous regex DID read are spelled that way — `apps/console` and
+ * `examples/console-starter` both declare `const workspaceAliases = { … }` and
+ * then write `alias: workspaceAliases`. Reading only inline literals would drop
+ * 63 of the entries this gate has been resting on, i.e. narrow the surface
+ * while claiming to widen it.
+ */
+function aliasTableExpressions(source: ts.SourceFile, config: string): ts.Expression[] {
+  const declarations = new Map<string, ts.Expression>();
+  const tables: ts.Expression[] = [];
+
+  const collectDeclarations = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      declarations.set(node.name.text, unwrapExpression(node.initializer));
+    }
+    ts.forEachChild(node, collectDeclarations);
+  };
+  collectDeclarations(source);
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAssignment(node) && propertyKey(node) === 'alias') {
+      const owner = node.parent.parent;
+      const underResolve = ts.isPropertyAssignment(owner) && propertyKey(owner) === 'resolve';
+      if (underResolve) {
+        let table = unwrapExpression(node.initializer);
+        if (ts.isIdentifier(table)) {
+          const declared = declarations.get(table.text);
+          if (declared === undefined) {
+            aliasParseGaps.push({
+              config,
+              what: `resolve.alias -> \`${table.text}\``,
+              text: 'alias table is an identifier this file does not declare',
+            });
+            ts.forEachChild(node, visit);
+            return;
+          }
+          table = declared;
+        }
+        tables.push(table);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return tables;
+}
+
+/**
+ * Alias tables parsed out of every bundler config in the workspace.
  *
  * Read as source rather than imported, for the reason
  * `vitest-config-alias-targets-3944.test.ts` gives: these configs pull in the
  * whole Vite plugin surface at module scope, and a guard that only needs a list
  * of strings should not boot that.
  *
- * Whole comment lines are stripped first so a commented-out entry cannot be
- * counted (and `examples/console-starter/vite.config.ts` documents that it
- * deliberately avoids spelling a quoted specifier inside a comment, because
- * that decoy already fooled one scan).
+ * ## Why a parser and not a regex (objectui#5158)
+ *
+ * Until #5158 this read the source TEXT with one regex that required the exact
+ * characters `path.resolve(` after a SINGLE-quoted key inside an object
+ * literal. Every config that spelled the same table any other way was not
+ * checked-and-passed, it was never looked at — measured on `main@da6eda06e`:
+ * 70 of 196 entries read, 15 configs contributing zero. Three independent
+ * spellings were invisible, and only the first is the one #5158 opened on:
+ *
+ *   - `import { resolve } from 'path'` + `resolve(__dirname, …)` — 15 configs,
+ *     105 entries (every `packages/plugin-*` that has a table);
+ *   - the ARRAY table form, `alias: [{ find, replacement }]` — 7 entries in
+ *     `packages/components`, which a widened `(?:path\.)?resolve` regex would
+ *     still have missed because there is no `'key':` at all;
+ *   - DOUBLE-quoted keys — 14 entries in `packages/runner`, missed for a reason
+ *     that has nothing to do with `resolve` and everything to do with `'`.
+ *
+ * Three spellings of one structure is the argument against enumerating
+ * spellings. The AST reads the structure: a property of an alias table whose
+ * value is a `resolve(dirname, '<relative>')` call, however the callee, the
+ * quotes and the table are written.
+ *
+ * It also retires two decoys by construction rather than by heuristic. A
+ * `rollupOptions.output.globals` map is keyed by the same specifiers
+ * (`'@object-ui/core': 'ObjectUICore'`) and is not an alias table — outside
+ * `resolve.alias`, so it is never reached, and its values are strings, so it
+ * could not parse anyway. And a specifier quoted inside a COMMENT is not a
+ * node: the previous reader stripped whole comment LINES to approximate that,
+ * which left an entry inside a multi-line block comment counted as live, and
+ * `examples/console-starter/vite.config.ts` still carries a note that it avoids
+ * spelling a quoted specifier in prose because "that decoy already fooled one
+ * scan". The parser makes the note unnecessary rather than load-bearing.
+ *
+ * ## What is still out of reach, named
+ *
+ * `apps/console` mutates its table at runtime under an env var
+ * (`Object.assign(workspaceAliases, specDistInjection.aliases)`, gated on
+ * `OBJECTSTACK_SPEC_DIST`). A static read sees the baseline literal, which is
+ * the table every ordinary build uses, and the injected entries alias
+ * `@objectstack/spec` — not an `@object-ui/*` package, so they could not
+ * contribute an entry form here in any case.
  */
 function readAliasEntries(): AliasEntry[] {
   const entries: AliasEntry[] = [];
@@ -277,19 +440,65 @@ function readAliasEntries(): AliasEntry[] {
     for (const name of fs.readdirSync(dir)) {
       if (!BUNDLER_CONFIG_RE.test(name)) continue;
       const configPath = path.join(dir, name);
-      const source = fs
-        .readFileSync(configPath, 'utf8')
-        .split('\n')
-        .filter((line) => !/^\s*\/\//.test(line) && !/^\s*\/\*.*\*\/\s*$/.test(line))
-        .join('\n');
+      const config = path.relative(repoRoot, configPath).split(path.sep).join('/');
+      const source = ts.createSourceFile(
+        configPath,
+        fs.readFileSync(configPath, 'utf8'),
+        ts.ScriptTarget.Latest,
+        true,
+      );
+      const clip = (node: ts.Node): string => node.getText(source).split('\n')[0].trim().slice(0, 120);
 
-      const re = /'(@object-ui\/[^']+)':\s*path\.resolve\(\s*(?:import\.meta\.dirname|__dirname)\s*,\s*'([^']+)'\s*\)/g;
-      for (const match of source.matchAll(re)) {
-        entries.push({
-          config: path.relative(repoRoot, configPath).split(path.sep).join('/'),
-          specifier: match[1],
-          target: path.resolve(dir, match[2]),
-        });
+      for (const table of aliasTableExpressions(source, config)) {
+        /** `[specifier, value node, node to quote in a gap report]` */
+        const pairs: [string, ts.Expression, ts.Node][] = [];
+
+        if (ts.isObjectLiteralExpression(table)) {
+          for (const prop of table.properties) {
+            if (!ts.isPropertyAssignment(prop)) continue;
+            const key = propertyKey(prop);
+            if (key === undefined || !key.startsWith(ALIAS_SPECIFIER_PREFIX)) continue;
+            pairs.push([key, prop.initializer, prop]);
+          }
+        } else if (ts.isArrayLiteralExpression(table)) {
+          for (const element of table.elements) {
+            const entry = unwrapExpression(element);
+            if (!ts.isObjectLiteralExpression(entry)) continue;
+            let find: ts.Expression | undefined;
+            let replacement: ts.Expression | undefined;
+            for (const prop of entry.properties) {
+              if (!ts.isPropertyAssignment(prop)) continue;
+              if (propertyKey(prop) === 'find') find = unwrapExpression(prop.initializer);
+              if (propertyKey(prop) === 'replacement') replacement = prop.initializer;
+            }
+            // A `find` that is not a plain string is a RegExp matcher, which
+            // names no single specifier and cannot yield an entry form.
+            if (find === undefined) continue;
+            if (!ts.isStringLiteral(find) && !ts.isNoSubstitutionTemplateLiteral(find)) continue;
+            if (!find.text.startsWith(ALIAS_SPECIFIER_PREFIX)) continue;
+            if (replacement === undefined) {
+              aliasParseGaps.push({ config, what: find.text, text: clip(entry) });
+              continue;
+            }
+            pairs.push([find.text, replacement, entry]);
+          }
+        } else {
+          aliasParseGaps.push({
+            config,
+            what: `resolve.alias (${ts.SyntaxKind[table.kind]})`,
+            text: clip(table),
+          });
+          continue;
+        }
+
+        for (const [specifier, value, node] of pairs) {
+          const relative = resolveCallTarget(value);
+          if (relative === undefined) {
+            aliasParseGaps.push({ config, what: specifier, text: clip(node) });
+            continue;
+          }
+          entries.push({ config, specifier, target: path.resolve(dir, relative) });
+        }
       }
     }
   }
@@ -791,19 +1000,49 @@ describe('`sideEffects` declarations match load-time behaviour (objectui#3943)',
     expect(Array.isArray(layout!.declared), '@object-ui/layout must still declare the ARRAY form').toBe(true);
   });
 
-  it('parses the workspace alias tables (the surface `exports` cannot see)', () => {
-    // Anti-vacuity for the alias derivation specifically. If the regex stops
-    // matching — a config reformatted, `import.meta.dirname` swapped for
-    // something else — every alias entry silently disappears from the entry
-    // forms, and this gate goes back to blessing exactly the shape PR #3940
-    // measured as still-broken.
+  it('reads every `@object-ui/*` alias table entry in the workspace, whatever its spelling', () => {
+    // objectui#5158's assertion, and the one that has to be DERIVED rather than
+    // listed. The defect it closes was not a wrong verdict, it was a
+    // measurement surface that had quietly stopped covering most of the
+    // workspace while every assertion below it stayed green — 70 of 196 entries
+    // read, 15 configs contributing zero. A census written out as a literal
+    // list is the same failure waiting to happen, so both sides of this
+    // reconciliation come out of the scan.
+    //
+    // The independent side is the KEY census: every `@object-ui/*` key that
+    // sits in a `resolve.alias` table, counted without looking at its value.
+    // The parsed side additionally has to understand the value. They agree
+    // exactly when no spelling escaped — so the gap list IS the reconciliation,
+    // and a fourth spelling arriving tomorrow fails here by name instead of
+    // shrinking the surface in silence.
+    expect(
+      aliasParseGaps.map((gap) => `${gap.config}: ${gap.what} — ${gap.text}`),
+      [
+        'An `@object-ui/*` entry sits in a `resolve.alias` table and this guard could not read it,',
+        'so the package it aliases is missing an entry form and is being judged on an incomplete',
+        'surface — the exact objectui#5158 defect, in a new spelling.',
+        '',
+        'Teach `readAliasEntries()` the spelling. Do NOT narrow the table or delete the entry to',
+        'make this pass: a surface that shrinks is how this went unnoticed for so long.',
+        '',
+        ...aliasParseGaps.map((gap) => `  ${gap.config}: ${gap.what} — ${gap.text}`),
+      ].join('\n'),
+    ).toEqual([]);
+
+    // A floor, not a fossil: it catches the collapse (a broken walk, a renamed
+    // field, a parser that stopped matching) without going red every time a
+    // package gains an alias. Measured on main@cdac3cc20: 196 entries across 20
+    // configs, up from the 70 across 3 that the pre-#5158 regex could see.
     const configs = [...new Set(aliasEntries.map((a) => a.config))].sort();
-    expect(configs).toEqual([
-      'apps/console/vite.config.ts',
-      'examples/console-starter/vite.config.ts',
-      'packages/fields/vite.config.ts',
-    ]);
-    expect(aliasEntries.length).toBeGreaterThanOrEqual(60);
+    expect(aliasEntries.length, 'the alias surface collapsed — see readAliasEntries()').toBeGreaterThanOrEqual(150);
+    expect(configs.length, 'the alias surface collapsed to a handful of configs').toBeGreaterThanOrEqual(18);
+
+    // Named specimens of the three spellings #5158 found invisible, so a
+    // regression to "only `path.resolve(` after a single-quoted key" fails here
+    // with the reason attached rather than as a number that moved.
+    expect(configs, 'bare `resolve(` (objectui#5158)').toContain('packages/plugin-editor/vite.config.ts');
+    expect(configs, 'the `{ find, replacement }` table form').toContain('packages/components/vite.config.ts');
+    expect(configs, 'double-quoted keys').toContain('packages/runner/vite.config.ts');
 
     // The trap, named: `@object-ui/layout` aliased at `packages/layout/src` is
     // the entry form that made the console's bundle 0 bytes while every
@@ -815,6 +1054,56 @@ describe('`sideEffects` declarations match load-time behaviour (objectui#3943)',
     ]);
     for (const alias of layoutAliases) {
       expect(alias.target).toBe(path.join(repoRoot, 'packages/layout/src'));
+    }
+  });
+
+  it('the three spellings objectui#5158 uncovered each parse to a real target', () => {
+    // The widening asserted as CONTENT, not only as a count. Each case is a
+    // different reason the pre-#5158 regex read nothing, and each is pinned on
+    // an entry that must resolve to a module — so "the config is in the census"
+    // cannot pass on an entry that parsed to nonsense.
+    const entryFor = (config: string, specifier: string): AliasEntry | undefined =>
+      aliasEntries.find((a) => a.config === config && a.specifier === specifier);
+
+    // 1. `import { resolve } from 'path'` — 15 `packages/plugin-*` configs.
+    const bare = entryFor('packages/plugin-editor/vite.config.ts', '@object-ui/core');
+    expect(bare?.target).toBe(path.join(repoRoot, 'packages/core/src'));
+
+    // 2. The array table form, `alias: [{ find, replacement }]`.
+    const arrayForm = entryFor('packages/components/vite.config.ts', '@object-ui/core');
+    expect(arrayForm?.target).toBe(path.join(repoRoot, 'packages/core/src'));
+
+    // 3. Double-quoted keys.
+    const doubleQuoted = entryFor('packages/runner/vite.config.ts', '@object-ui/core');
+    expect(doubleQuoted?.target).toBe(path.join(repoRoot, 'packages/core/src'));
+
+    // And a target spelled as a FILE rather than a directory, which is the one
+    // shape where `resolveAliasModule` has to not append `index.*`.
+    const file = entryFor('packages/plugin-map/vite.config.ts', '@object-ui/core');
+    expect(file?.target).toBe(path.join(repoRoot, 'packages/core/src/index.ts'));
+    for (const entry of [bare, arrayForm, doubleQuoted, file]) {
+      expect(resolveAliasModule(entry!.target), `${entry!.config}: ${entry!.specifier} resolves to no module`).toBeDefined();
+    }
+  });
+
+  it('a `globals` map keyed by the same specifiers is not read as an alias table', () => {
+    // The false positive the widening had to avoid. Every `plugin-*` library
+    // config carries `rollupOptions.output.globals`, keyed by the SAME
+    // `@object-ui/*` specifiers and valued with UMD global names, and
+    // `packages/plugin-calendar` / `plugin-chatbot` / `plugin-gantt` carry one
+    // while their `resolve.alias` table has no `@object-ui/*` entry at all.
+    // Those three are therefore the clean control: if a globals map were being
+    // read as aliases, they would appear in the census.
+    const configs = new Set(aliasEntries.map((a) => a.config));
+    for (const config of [
+      'packages/plugin-calendar/vite.config.ts',
+      'packages/plugin-chatbot/vite.config.ts',
+      'packages/plugin-gantt/vite.config.ts',
+    ]) {
+      expect(fs.readFileSync(path.join(repoRoot, config), 'utf8'), `${config} must still carry the decoy`).toContain(
+        "'@object-ui/core': 'ObjectUICore'",
+      );
+      expect(configs.has(config), `${config}: a \`globals\` map was read as an alias table`).toBe(false);
     }
   });
 

--- a/scripts/__tests__/side-effects-declaration-consistency.test.ts
+++ b/scripts/__tests__/side-effects-declaration-consistency.test.ts
@@ -396,7 +396,7 @@ function aliasTableExpressions(source: ts.SourceFile, config: string): ts.Expres
  * Until #5158 this read the source TEXT with one regex that required the exact
  * characters `path.resolve(` after a SINGLE-quoted key inside an object
  * literal. Every config that spelled the same table any other way was not
- * checked-and-passed, it was never looked at — measured on `main@da6eda06e`:
+ * checked-and-passed, it was never looked at — measured on `main@cdac3cc20`:
  * 70 of 196 entries read, 15 configs contributing zero. Three independent
  * spellings were invisible, and only the first is the one #5158 opened on:
  *
@@ -408,8 +408,10 @@ function aliasTableExpressions(source: ts.SourceFile, config: string): ts.Expres
  *   - DOUBLE-quoted keys — 14 entries in `packages/runner`, missed for a reason
  *     that has nothing to do with `resolve` and everything to do with `'`.
  *
- * Three spellings of one structure is the argument against enumerating
- * spellings. The AST reads the structure: a property of an alias table whose
+ * Three invisible spellings of one structure is the argument against
+ * enumerating spellings — the widened `(?:path\.)?` regex #5158 proposed closes
+ * the first and leaves the other two, because they do not differ on `resolve`.
+ * The AST reads the structure instead: a property of an alias table whose
  * value is a `resolve(dirname, '<relative>')` call, however the callee, the
  * quotes and the table are written.
  *


### PR DESCRIPTION
Fixes #5158

## 前提复测(逐条,基线 `cdac3cc20`,含 PR #5159)

| # | issue 的判断 | 复测结论 |
|---|---|---|
| 1 | `readAliasEntries()` entry 正则只认字面量 `path.resolve(`,15 个 vite.config 写裸 `resolve(` | **成立**,15 个 config 名单逐字复现(plugin-ai/charts/dashboard/designer/detail/editor/form/grid/kanban/list/map/markdown/report/timeline/tree),读到的 3 个(fields 7 / apps-console 34 / console-starter 29)也复现 |
| 2 | 门实际只读到 70 条,宽松口径 175 条 | **成立**,70 / 175 / 15 三个数逐字复现;但**宽松口径本身仍然不够** —— 见下 |
| 3 | 这是 #3944 那类死 alias 条目的藏身处 | **风险成立,当日无实例**:扩面后 196 条 alias 全部解析出可达模块,死条目 **0 条**。所以本 PR 不含任何 vite.config 修改 |

### 第 2 条复测时多出来的事实:不是两种拼法,是四种

issue 提议把 `path\.` 放宽成 `(?:path\.)?` 能把 70 拉到 175。复测发现真实测量面是 **196**,放宽正则仍然读不到另外 21 条,而且漏的原因跟 `resolve` 没关系:

- `packages/components/vite.config.ts` 用的是**数组表形式** `alias: [{ find, replacement }]` —— 根本没有 `'key':`,7 条;
- `packages/runner/vite.config.ts` 用的是**双引号 key** `"@object-ui/core": path.resolve(...)` —— 正则里写死了单引号,14 条。

一个结构三种拼法,正是"枚举拼法"这条路本身的反例。

## 实现

改用 AST(本文件已为模块扫描引入 `typescript`)读 `resolve.alias` 的**结构**而不是文本:alias 表里取值为 `resolve(dirname, '相对路径')` 调用的属性,不论 callee 怎么写(裸 `resolve` / `path.resolve` / 改名导入)、key 用什么引号、表是对象还是数组。

同时按 issue 的处置方向 2 立**漂移自检**:落在 `resolve.alias` 表里、解析器读不出取值形状的 `@object-ui/*` key 一律进 `aliasParseGaps` 并让门红,报错文案带"教会解析器,别缩表"的处方。第四种拼法到来时报错,而不是静默缩面。

三个刻意的取舍,都写进了文件注释:

1. **只读 `resolve.alias`,不读 `test.alias`** —— 文件头本来就论证过 Vitest 不 tree-shake、不是打包面;盲搜 `alias:` 会把 Vitest-only 的表悄悄折进来。
2. **跟一跳标识符间接** —— `apps/console` 与 `examples/console-starter` 都写 `const workspaceAliases = { … }` + `alias: workspaceAliases`。只读内联字面量会把门本来就依赖的 63 条丢掉,即"号称扩面、实际缩面"。
3. **`rollupOptions.output.globals` 与注释里的诱饵由结构排除,不靠启发式**。globals 表 key 完全相同(`'@object-ui/core': 'ObjectUICore'`),但它在 `resolve.alias` 之外、取值是字符串,走不进来;注释里的引号规格根本不是节点 —— 原来靠"剔掉整行注释"近似,块注释里的条目仍会被当成活条目,`console-starter` 至今留着一条"别在散文里写带引号的 specifier,那个诱饵骗过一次扫描"的告示,现在这条告示不再是承重结构。

计数钉按"提取式对账"写,不写化石值:**key 普查**(alias 表里的 `@object-ui/*` key,不看取值)对账**解析结果**,两边同源于扫描,gap 列表即对账差额;另加塌陷下限(196 → 下限 150 条 / 20 → 下限 18 个 config)+ 三种拼法的具名样本,注释里注明"196 条 / 20 个 config 实测于 `main@cdac3cc20`"。

## 扩面前后

| 口径 | alias 条数 | 贡献 config 数 |
|---|---|---|
| 门原本(字面量 `path.resolve(` + 单引号 key + 对象表) | 70 | 3 |
| issue 提议的放宽正则 `(?:path\.)?resolve` | 175 | 18 |
| 本 PR(AST) | **196** | **20** |

覆盖增幅最大的两个 declaring package:`@object-ui/core` 3 → 20 个 config,`@object-ui/types` 3 → 18 个 config。

**当日判定零变化,这一点如实写明**:新纳入的 alias 全部指向 declaring package 已被覆盖的同一个 `src` barrel,六个 declaring package 的 entry form 集合 `ADDED=[]`。也就是说本 PR 修的是**测量面**,不是某条今天红的判定 —— 与 issue 的定性一致("不是检查后通过,是根本没看")。

## 死条目处置清单

**空**。196 条全部解析出可达模块,`resolveAliasModule()` 无一返回 undefined。所以没有夹带任何 vite.config 修改。

顺带钉清这道门对死条目的**既有行为**(反向验证 b 实测):目标不可达时 `resolveAliasModule()` 返回 undefined、`resolvableEntryPaths()` 直接 `continue` —— 这道门对死 alias **不红**,这是它的契约边界而非疏漏(死 alias 贡献不了 entry form,`sideEffects` 判定无从与之冲突)。

## 反向验证(方向均为跑之前书面预判)

| 变异 | 预判 | 实测 |
|---|---|---|
| (a1) `resolveCallTarget` 退回要求 `path.` 限定 callee(保留 gap 机制) | 红,gap 列表非空约 112 条(105 裸 resolve + 7 数组表;runner 的 14 条因写 `path.resolve` 存活) | **符合**:gap 恰好 **112** 条,逐条列出 config + specifier + 源文 |
| (a2) `readAliasEntries()` 整体退回 #5158 前的正则 | 塌陷下限 + 具名样本 + 拼法内容测试红;**gap 断言保持绿** | **符合**:`expected 70 to be greater than or equal to 150`(直接把 70 这个数打在报错里),gap 列表确实为空 |
| (b) 在新纳入的 plugin-editor 塞一条**死** alias | **不红**(与派发模板预设的"扩面有牙 = 门红"相反) | **符合**:30/30 全绿。派发单预设的方向在这道门上不成立,如实记录:条数 196 → 197,gap 为空(取值解析得动,是**目标**死),无任何断言移动。同一条死 alias 交给 #3944 那道门也是 58/58 全绿 —— 它只读根 `vitest.config.mts` 与 `tsconfig.json` |
| (c) 塞一条**会改判定**的 alias(plugin-editor 把 `@object-ui/layout` 指向 `../layout/src/AppShell.tsx`) | 扩面后红 / 退回旧正则后绿 的成对证据 | **符合**:扩面后 **4 个测试红**,含真实 bundler 探针(门为新 entry form 现场生成探针并跑了一次 Vite 构建),报 `"src/AppShell.tsx" is a resolvable module form and is not in sideEffects`;保留同一条 alias、只把解析器退回旧正则 → 判定测试**全绿**,失败集与 (a2) 完全一致(即这条被植入的缺陷在旧正则下贡献为零) |
| (d) 塞**第四种拼法** `'@object-ui/auth': join(__dirname, '../auth/src')` | gap 自检红,点名该条 | **符合**:1 个测试红,报 `packages/plugin-editor/vite.config.ts: @object-ui/auth — '@object-ui/auth': join(__dirname, '../auth/src')`,附"教会解析器、别缩表"处方 |

(a1) 的一处措辞修正:预判写了"gap 断言**和**下限同时红",实际同一个 `it` 里 gap 断言先触发、下限没跑到。方向没错,顺序上短路了,照实记。

## 与 #3944 / #3592 的边界

- **#3944**(以及扩容它的 #4804):管的是"被读到的那张表里有没有死条目",覆盖面是**根 `vitest.config.mts` + `tsconfig.json` 的 `paths`**。本 PR 不碰它,也不把"目标存在性"塞进 side-effects 门 —— 两个契约,合并会让"declaration 与 module body 是否一致"这道门去替 alias 表做体检。
- **#3592**:管的是这些 config 里 `__dirname` 这个写法本身。本 PR 只**读**这些 config,一行没改。
- 本 PR:管的是"门看不看得见这些表"。

## 半径外发现

24 个 `vite.config.ts` 的 alias 表(196 条)的**目标存在性无人把关**:#3944 那道门只覆盖根 `vitest.config.mts` 与 `tsconfig.json`,本门按契约对死条目不红(上表 b 行双向实测)。今天 0 实例,故按 observation-class 另立卡,不夹带。

## 验证

```
pnpm exec vitest run scripts/__tests__ --maxWorkers=2   53 files / 1224 tests 全绿
pnpm exec turbo run type-check --concurrency=2          81/81 successful
pnpm run lint:root                                      0 errors(24 条既有 warning,均不在本文件)
pnpm run type-check:scripts                             绿
node scripts/check-control-bytes.mjs                    OK(4572 tracked text files)
node scripts/check-changeset-presence.mjs               "no changeset is owed"(0 个已发布包的 src 变更)
```

changeset:门自身判定不欠 —— 本改动只动 `scripts/__tests__/`,无任何已发布包的 `src/` 变更,无用户可见行为变化。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_