### PR TITLE
fix(app-shell): References 面板区分「检查失败」与「确实无引用」(#5110)

### DIFF
--- a/.changeset/references-panel-failed-check-vs-empty-5110.md
+++ b/.changeset/references-panel-failed-check-vs-empty-5110.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The metadata References panel distinguishes a FAILED reference check from a completed one that found nothing.
+
+`ResourceEditPage`'s References loader held `refs: MetadataReference[] | null`
+plus a `refsLoading` boolean, and the panel read `refs == null` as "still
+loading". There was no value left to mean "the check failed", so the catch wrote
+`setRefs([])` — the exact state a successful scan finding zero references
+produces — and the panel rendered it as "Nothing in the metadata graph points at
+this item. Safe to delete."
+
+Every failure took that path: a refused request, a dropped connection, an
+expired session, an unparseable body, and the truthful `501 NOT_IMPLEMENTED`
+that `@objectstack/rest` now returns when the resolved protocol has no
+`findReferencesToMeta` (objectstack#9326). `MetadataClient.references()` was
+already correct — it returns `[]` only for a `404` and throws for every other
+non-ok status — so the fault reached the component intact and was discarded
+here. The single trace was a `console.error`. An operator is on this panel
+precisely because they are about to delete something, and a failed safety check
+was shown to them as an affirmative all-clear.
+
+The pair is replaced by a four-arm discriminated union (`idle` / `loading` /
+`loaded` / `error`), so a failure and a measurement are no longer expressible as
+the same value. The error arm renders a distinct state: it says the check did
+not complete, shows the cause, and deliberately makes no claim in either
+direction about whether deleting is safe — the honest answer when the question
+was not answered. It offers a Retry that re-runs the same loader (the old
+re-entry guard, `refs != null`, would have refused a second attempt because the
+catch had left `refs = []`). The reference count badge renders only for a
+completed scan, so a failed check no longer displays a false `0`. New
+`engine.edit.refsErrorTitle` / `refsErrorDesc` / `refsRetry` keys in the
+designer's `en` and `zh` tables.
+
+The empty state is unchanged and still reserved for a scan that completed and
+found nothing — the one case where "Safe to delete" is true.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.referencesErrorState.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.referencesErrorState.test.tsx
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The References panel must tell three facts apart — objectui#5110.
+ *
+ * ## The defect
+ *
+ * `loadReferences()` held two pieces of state, `refs: MetadataReference[] |
+ * null` and `refsLoading: boolean`, and the panel read `refs == null` as
+ * "still loading". That left no value to mean "the check failed", so the
+ * catch wrote `setRefs([])` — the SAME state a successful scan finding
+ * nothing produces — and the panel rendered it as, verbatim:
+ *
+ *     "Nothing in the metadata graph points at this item. Safe to delete."
+ *
+ * Every failure took that path: a refused request, a dropped connection, an
+ * expired session, an unparseable body, and (after objectstack#9326 / PR
+ * #9425 made the wire honest) a truthful `501 NOT_IMPLEMENTED`. The producer
+ * fix converted "we cannot answer" from a lying `200 {references: []}` into
+ * a correct refusal, and this catch converted it straight back into the lie.
+ * The only trace was a `console.error`. The operator is on this panel
+ * *because* they are about to delete something.
+ *
+ * ## What is pinned here
+ *
+ * One test per arm of the union that replaced the pair, because the defect
+ * was precisely that two of the three arms were the same value:
+ *
+ *   1. loading  — in flight, scanning indicator, no verdict of any kind
+ *   2. empty    — a COMPLETED scan that found nothing still says "Safe to
+ *                 delete"; the fix must not buy honesty by deleting the one
+ *                 case where that sentence is true
+ *   3. error    — the failure is shown as a failure, the "Safe to delete"
+ *                 sentence is absent from the document, the count badge does
+ *                 not render a false `0`, and Retry re-runs the same loader
+ *
+ * Case 2 is what makes case 3 an assertion rather than a tautology: without
+ * it, deleting the empty state entirely would also make "Safe to delete"
+ * unreachable and every error assertion would pass for the wrong reason.
+ *
+ * ## Why the retry pin asserts the SECOND call, not just the button
+ *
+ * The pre-fix re-entry guard was `if (refs != null || refsLoading) return;`.
+ * Under the old shape a failure left `refs = []`, i.e. non-null — so even if
+ * the old code had grown a retry button, the loader would have refused to run
+ * again and the button would have been decorative. The guard now falls
+ * through on `idle` and `error` and holds on `loading` and `loaded`, so the
+ * suite asserts both directions: retry after an error DOES re-request, and
+ * reopening the sheet after a success does NOT.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { MetadataReference } from '@object-ui/data-objectstack';
+import { t } from './i18n';
+
+/** The exact sentence this card exists to keep off a failed check. */
+const SAFE_TO_DELETE = /Safe to delete/i;
+
+const objectDef = {
+  name: 'showcase_account',
+  label: 'Account',
+  fields: [{ name: 'title', label: 'Title', type: 'text' }],
+};
+
+/** A plain packaged entry — this suite is about the References sheet only. */
+const LAYERED = {
+  code: { ...objectDef, _packageId: 'com.example.showcase', _provenance: 'package' },
+  overlay: null,
+  effective: { ...objectDef },
+  provenance: 'package',
+  packageId: 'com.example.showcase',
+  editable: true,
+  deletable: true,
+  resettable: true,
+};
+
+/** Swapped per case; `mockClient.references` forwards to whatever is current. */
+const referencesImpl = { current: vi.fn() };
+
+const mockClient = {
+  list: vi.fn(async () => []),
+  listDrafts: vi.fn(async () => []),
+  get: vi.fn(async () => null),
+  getDraft: vi.fn(async () => null),
+  layered: vi.fn(async () => LAYERED),
+  reset: vi.fn(async () => ({ success: true })),
+  references: vi.fn(async (...args: unknown[]) => referencesImpl.current(...args)),
+};
+
+vi.mock('./useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({
+      loading: false,
+      error: null,
+      entries: [
+        {
+          type: 'object',
+          name: 'object',
+          label: 'Object',
+          allowOrgOverride: true,
+          allowRuntimeCreate: true,
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' }, label: { type: 'string' } },
+          },
+        },
+      ],
+    }),
+  };
+});
+
+import { MetadataResourceEditPage } from './ResourceEditPage';
+
+const START_PATH = '/metadata/object/showcase_account';
+
+function editorUnderRoute() {
+  return (
+    <MemoryRouter initialEntries={[START_PATH]}>
+      <Routes>
+        <Route
+          path="/metadata/:type/:name"
+          element={<MetadataResourceEditPage type="object" name="showcase_account" />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+/**
+ * Mount the editor and open the References sheet, which is what triggers the
+ * lazy load. Returns the trigger so a case can close and reopen it.
+ */
+async function openReferencesSheet() {
+  render(editorUnderRoute());
+  await waitFor(() => expect(mockClient.layered).toHaveBeenCalled());
+  const trigger = await screen.findByTitle('References');
+  await userEvent.click(trigger);
+  return trigger;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('References panel — error ≠ empty ≠ loading (#5110)', () => {
+  it('loading: while the scan is in flight, neither verdict is rendered', async () => {
+    // A promise held open on purpose: this is the state `refs == null` used
+    // to mean, and it must stay reachable after the union replaced the pair.
+    let release!: (v: MetadataReference[]) => void;
+    referencesImpl.current = vi.fn(
+      () => new Promise<MetadataReference[]>((res) => { release = res; }),
+    );
+
+    await openReferencesSheet();
+
+    expect(await screen.findByTestId('refs-scanning')).toBeInTheDocument();
+    // No verdict of any kind while the question is still open.
+    expect(screen.queryByText(SAFE_TO_DELETE)).toBeNull();
+    expect(screen.queryByTestId('refs-error')).toBeNull();
+    expect(screen.queryByTestId('refs-count-badge')).toBeNull();
+
+    // Settle it so the test does not leave a pending promise behind.
+    release([]);
+    await screen.findByTestId('refs-empty');
+  });
+
+  it('empty: a scan that COMPLETED and found nothing still says "Safe to delete"', async () => {
+    // The one case where the sentence is true. Keeping it is what makes the
+    // error case's absence assertion meaningful rather than vacuous.
+    referencesImpl.current = vi.fn(async () => []);
+
+    await openReferencesSheet();
+
+    expect(await screen.findByTestId('refs-empty')).toBeInTheDocument();
+    expect(screen.getByText(SAFE_TO_DELETE)).toBeInTheDocument();
+    expect(screen.queryByTestId('refs-error')).toBeNull();
+    // A completed scan MAY show its count, and it is a real zero.
+    expect(screen.getByTestId('refs-count-badge')).toHaveTextContent('0');
+  });
+
+  it('error: the failure is shown as a failure, asserts nothing about deleting, and Retry re-runs the check', async () => {
+    // The honest `501` from objectstack PR #9425 — the exact payload the old
+    // catch turned back into "Safe to delete."
+    referencesImpl.current = vi.fn(async () => {
+      throw new Error('NOT_IMPLEMENTED: this protocol cannot resolve references');
+    });
+
+    await openReferencesSheet();
+
+    const panel = await screen.findByTestId('refs-error');
+    expect(panel).toBeInTheDocument();
+
+    // 1. The claim that must not appear — anywhere in the document, not just
+    //    inside the panel: this is the whole card. Asserted against the empty
+    //    state's own string, read from the table, so a reword of that copy
+    //    cannot quietly narrow what this test forbids.
+    expect(screen.queryByText(SAFE_TO_DELETE)).toBeNull();
+    expect(document.body.textContent ?? '').not.toMatch(SAFE_TO_DELETE);
+    expect(document.body.textContent ?? '').not.toContain(
+      t('engine.edit.refsEmptyDesc', 'en-US'),
+    );
+    expect(screen.queryByTestId('refs-empty')).toBeNull();
+
+    // 2. What IS said: the check failed, and the copy makes no claim in
+    //    either direction about deletion safety.
+    expect(screen.getByText('Reference check failed')).toBeInTheDocument();
+    expect(
+      screen.getByText(/did not complete, so what depends on this item is unknown/i),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('refs-error-cause')).toHaveTextContent(
+      'NOT_IMPLEMENTED: this protocol cannot resolve references',
+    );
+
+    // 3. No count badge: a `0` over a failed check is the same false
+    //    measurement in miniature.
+    expect(screen.queryByTestId('refs-count-badge')).toBeNull();
+
+    // 4. Retry re-runs the SAME loader — under the old `refs != null` guard a
+    //    failure left `refs = []` and this second call was unreachable.
+    expect(mockClient.references).toHaveBeenCalledTimes(1);
+    referencesImpl.current = vi.fn(async () => [
+      { fromType: 'view', fromName: 'account_list', path: 'objectName' },
+    ]);
+    await userEvent.click(screen.getByTestId('refs-retry'));
+
+    await waitFor(() => expect(mockClient.references).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('account_list')).toBeInTheDocument();
+    expect(screen.queryByTestId('refs-error')).toBeNull();
+    expect(screen.getByTestId('refs-count-badge')).toHaveTextContent('1');
+  });
+
+  it('the lazy-load contract survives: a completed scan is not re-requested when the sheet reopens', async () => {
+    // The other half of the re-entry guard. `error` falls through so Retry
+    // works; `loaded` must still hold, or every reopen re-hits the server.
+    referencesImpl.current = vi.fn(async () => []);
+
+    const trigger = await openReferencesSheet();
+    await screen.findByTestId('refs-empty');
+    expect(mockClient.references).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard('{Escape}');
+    await userEvent.click(trigger);
+    await screen.findByTestId('refs-empty');
+
+    expect(mockClient.references).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The designer table carries `en` and `zh` in one file and is deliberately
+   * out of reach of the pack gates (see `metadata-admin/i18n.ts`'s header and
+   * `packages/i18n/README.md`, "Scope — the `engine.*` carve-out"), so a new
+   * key added to only one of the two tables fails nowhere. This is that file's
+   * parity check for the three keys this card adds.
+   *
+   * The semantic property — the error copy asserts nothing about deletion
+   * safety — is NOT mechanically checkable and is not claimed to be: no gate
+   * can read a sentence's meaning. What is checkable is the fact that made the
+   * defect, and it is asserted: the error copy is not the empty copy, in
+   * either locale.
+   */
+  it('i18n: the three error-state keys exist in both locales and are not the empty copy', () => {
+    for (const key of [
+      'engine.edit.refsErrorTitle',
+      'engine.edit.refsErrorDesc',
+      'engine.edit.refsRetry',
+    ] as const) {
+      const en = t(key, 'en-US');
+      const zh = t(key, 'zh-CN');
+      // `t()` echoes the key back when the table has no entry for it.
+      expect(en, `EN missing ${key}`).not.toBe(key);
+      expect(zh, `ZH missing ${key}`).not.toBe(key);
+      expect(en, `${key} is untranslated`).not.toBe(zh);
+    }
+
+    for (const locale of ['en-US', 'zh-CN'] as const) {
+      const errorCopy = t('engine.edit.refsErrorDesc', locale);
+      const emptyCopy = t('engine.edit.refsEmptyDesc', locale);
+      expect(errorCopy, `${locale} error copy collapsed into the empty copy`)
+        .not.toBe(emptyCopy);
+      expect(errorCopy).not.toContain(emptyCopy);
+      expect(
+        t('engine.edit.refsErrorTitle', locale),
+        `${locale} error title collapsed into the empty title`,
+      ).not.toBe(t('engine.edit.refsEmptyTitle', locale));
+    }
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -240,6 +240,40 @@ export function MetadataResourceEditPage({
   );
 }
 
+/**
+ * References panel data — one discriminated union, not a `refs` / `refsLoading`
+ * pair (objectui#5110).
+ *
+ * The pair could only spell two of the three facts this panel has to tell
+ * apart. `refs == null` was already overloaded as "still loading", so a failed
+ * `client.references()` call had nowhere to go: the catch wrote `setRefs([])`,
+ * which is byte-identical to a *successful* scan that found nothing — and the
+ * panel renders that state as "Nothing in the metadata graph points at this
+ * item. Safe to delete." A refused request, a dropped connection, an expired
+ * session and a `501 NOT_IMPLEMENTED` were therefore all shown to the operator
+ * as an affirmative, measured all-clear, with a `console.error` nobody reads as
+ * the only trace. The operator is on this panel precisely because they are
+ * about to delete something.
+ *
+ * `status` makes the third fact representable, and makes the wrong combination
+ * unrepresentable: no value of this type is both `error` and `loaded`, so no
+ * render path can read a failure as a measurement. The `error` arm carries the
+ * cause and asserts NOTHING about deletion safety — the honest answer when the
+ * question was never answered — and the panel offers a retry so the operator
+ * can ask it again.
+ *
+ * `idle` is deliberately distinct from `loading`: the sheet is lazy, and
+ * "never asked" is what re-enables a retry after a failure (see
+ * `loadReferences`'s re-entry guard).
+ *
+ * ADR-0110 D3 — a miss and a fault are different facts.
+ */
+type ReferencesState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; items: MetadataReference[] }
+  | { status: 'error'; message: string };
+
 interface MetadataResourceEditPageImplProps {
   type: string;
   name: string;
@@ -288,7 +322,7 @@ function MetadataResourceEditPageImpl({
   const [draft, setDraft] = React.useState<Record<string, unknown>>(() =>
     createMode ? { ...(config.createDefaults ?? {}), [identityField]: '' } : {},
   );
-  const [refs, setRefs] = React.useState<MetadataReference[] | null>(null);
+  const [refsState, setRefsState] = React.useState<ReferencesState>({ status: 'idle' });
   const [loading, setLoading] = React.useState(!createMode);
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -791,19 +825,22 @@ function MetadataResourceEditPageImpl({
   }, [client, type, name, ownerPackageId, createMode, reloadKey, locale]);
 
   // Lazy-load references the first time the References sheet opens.
-  const [refsLoading, setRefsLoading] = React.useState(false);
+  //
+  // Re-entry guard: a request already in flight is not duplicated, and a
+  // completed scan is not re-run when the sheet is reopened. `idle` and
+  // `error` both fall through — which is what makes the panel's Retry work
+  // without a second code path: it calls this same loader (objectui#5110).
   async function loadReferences() {
-    if (refs != null || refsLoading) return;
-    setRefsLoading(true);
+    if (refsState.status === 'loading' || refsState.status === 'loaded') return;
+    setRefsState({ status: 'loading' });
     try {
       const r = await client.references(type, name);
-      setRefs(r);
+      setRefsState({ status: 'loaded', items: r });
     } catch (err: any) {
-      // Surface as empty list; non-blocking.
-      setRefs([]);
-      console.error('references() failed', err);
-    } finally {
-      setRefsLoading(false);
+      // NOT `{ status: 'loaded', items: [] }`: an unanswered question is not
+      // an answer of "nothing". The panel renders this arm as a failed check
+      // with a retry and says nothing about whether deleting is safe.
+      setRefsState({ status: 'error', message: String(err?.message ?? err) });
     }
   }
 
@@ -1724,9 +1761,9 @@ function MetadataResourceEditPageImpl({
               className="h-7 w-7 p-0 relative"
             >
               <Link2 className="h-3.5 w-3.5" />
-              {refs && refs.length > 0 && (
+              {refsState.status === 'loaded' && refsState.items.length > 0 && (
                 <span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] px-1 rounded-full bg-muted text-foreground text-[9px] leading-[14px] text-center font-medium border">
-                  {refs.length}
+                  {refsState.items.length}
                 </span>
               )}
             </Button>
@@ -2562,9 +2599,15 @@ function MetadataResourceEditPageImpl({
           <SheetHeader className="px-4 py-3 border-b">
             <SheetTitle className="text-base">
               {t('engine.edit.references', locale)}
-              {refs && (
-                <Badge variant="outline" className="ml-2 text-[10px]">
-                  {refs.length}
+              {/* Only a completed scan may show a count — a `0` badge over a
+                  failed check is the same false measurement in miniature. */}
+              {refsState.status === 'loaded' && (
+                <Badge
+                  variant="outline"
+                  className="ml-2 text-[10px]"
+                  data-testid="refs-count-badge"
+                >
+                  {refsState.items.length}
                 </Badge>
               )}
             </SheetTitle>
@@ -2573,7 +2616,11 @@ function MetadataResourceEditPageImpl({
             </SheetDescription>
           </SheetHeader>
           <div className="flex-1 min-h-0 overflow-auto p-4">
-            <ReferencesPanel refs={refs} loading={refsLoading} locale={locale} />
+            <ReferencesPanel
+              state={refsState}
+              locale={locale}
+              onRetry={() => void loadReferences()}
+            />
           </div>
         </SheetContent>
       </Sheet>
@@ -2716,25 +2763,64 @@ function MetadataResourceEditPageImpl({
   );
 }
 
+/**
+ * Renders exactly one arm of `ReferencesState` — the union is the whole point
+ * (objectui#5110), so the error arm is checked FIRST and there is no path from
+ * a failure to the empty state's "Safe to delete."
+ */
 function ReferencesPanel({
-  refs,
-  loading,
+  state,
   locale,
+  onRetry,
 }: {
-  refs: MetadataReference[] | null;
-  loading: boolean;
+  state: ReferencesState;
   locale?: string;
+  onRetry: () => void;
 }) {
-  if (loading || refs == null) {
+  if (state.status === 'error') {
     return (
-      <div className="text-sm text-muted-foreground flex items-center gap-2">
+      <Empty data-testid="refs-error">
+        <EmptyTitle className="flex items-center justify-center gap-2">
+          <AlertTriangle className="h-4 w-4 text-amber-600" />
+          {t('engine.edit.refsErrorTitle', locale)}
+        </EmptyTitle>
+        <EmptyDescription>
+          {t('engine.edit.refsErrorDesc', locale)}
+        </EmptyDescription>
+        {state.message ? (
+          <p
+            data-testid="refs-error-cause"
+            className="mt-2 max-w-full break-words font-mono text-xs text-muted-foreground"
+          >
+            {state.message}
+          </p>
+        ) : null}
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          data-testid="refs-retry"
+          onClick={onRetry}
+        >
+          {t('engine.edit.refsRetry', locale)}
+        </Button>
+      </Empty>
+    );
+  }
+  if (state.status !== 'loaded') {
+    return (
+      <div
+        data-testid="refs-scanning"
+        className="text-sm text-muted-foreground flex items-center gap-2"
+      >
         <Loader2 className="h-4 w-4 animate-spin" /> {t('engine.edit.refsScanning', locale)}
       </div>
     );
   }
+  const refs = state.items;
   if (refs.length === 0) {
     return (
-      <Empty>
+      <Empty data-testid="refs-empty">
         <EmptyTitle>{t('engine.edit.refsEmptyTitle', locale)}</EmptyTitle>
         <EmptyDescription>
           {t('engine.edit.refsEmptyDesc', locale)}

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -881,6 +881,16 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.edit.refsScanning': 'Scanning references…',
   'engine.edit.refsEmptyTitle': 'No references found',
   'engine.edit.refsEmptyDesc': 'Nothing in the metadata graph points at this item. Safe to delete.',
+  // …and its FAILED state (objectui#5110), which must never be confusable with
+  // the empty one above: the copy states that the check did not complete and
+  // deliberately makes no claim — in either direction — about whether deleting
+  // is safe, because the question was not answered. Any wording change here
+  // must keep that property; "no references were found" is exactly the
+  // sentence this state exists to avoid.
+  'engine.edit.refsErrorTitle': 'Reference check failed',
+  'engine.edit.refsErrorDesc':
+    'The reference scan did not complete, so what depends on this item is unknown. This is not a statement that deleting it is safe — run the check again before you decide.',
+  'engine.edit.refsRetry': 'Retry check',
   // Destructive-change (force save) dialog (ResourceEditPage).
   'engine.edit.destructiveTitle': 'Destructive change detected',
   'engine.edit.destructiveDesc':
@@ -2680,6 +2690,13 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.edit.refsScanning': '正在扫描引用…',
   'engine.edit.refsEmptyTitle': '未找到引用',
   'engine.edit.refsEmptyDesc': '元数据图中没有任何项指向它,可以安全删除。',
+  // …以及它的失败态(objectui#5110):必须与上面的空态不可混淆 —— 文案只说明检查
+  // 没有完成,对「删除是否安全」不做任何方向的断言,因为这个问题根本没有被回答。
+  // 后续改写务必保留这一性质;「未找到引用」正是此状态要避免的那句话。
+  'engine.edit.refsErrorTitle': '引用检查失败',
+  'engine.edit.refsErrorDesc':
+    '引用扫描没有完成，因此无法得知哪些内容依赖此项。这并不表示删除它是安全的 —— 请重新执行检查后再做决定。',
+  'engine.edit.refsRetry': '重新检查',
   // 破坏性变更(强制保存)对话框(ResourceEditPage)。
   'engine.edit.destructiveTitle': '检测到破坏性变更',
   'engine.edit.destructiveDesc': '框架拒绝了本次保存,因为它会丢弃或收窄正在使用的数据。请检查这些问题并确认以强制覆盖。',


### PR DESCRIPTION
Fixes #5110

## 缺陷

`ResourceEditPage` 的 References 加载器只握有两份状态 —— `refs: MetadataReference[] | null` 与 `refsLoading: boolean` —— 而面板把 `refs == null` 读作「仍在加载」。于是没有任何取值能表达第三个事实「检查失败」,catch 只能写 `setRefs([])`;这与一次**成功**但零引用的扫描产生的是同一个值,面板据此渲染出(逐字取自 `metadata-admin/i18n.ts`):

```
'engine.edit.refsEmptyDesc': 'Nothing in the metadata graph points at this item. Safe to delete.'
```

所有失败都走这一条路:请求被拒、连接中断、会话过期、响应无法解析,以及 objectstack#9326 / PR #9425 之后 `@objectstack/rest` 在解析出的 protocol 没有 `findReferencesToMeta` 时如实返回的 `501 NOT_IMPLEMENTED`。生产者那半边的修复让线上答复变诚实,而这个 catch 把诚实的 501 又翻译回了那句谎话。

`MetadataClient.references()` 本身没有问题:只有 404 返回 `[]`,其余非 ok 一律 `throw parseError(res)`。故障完整地抵达了组件,在这里被丢弃,唯一痕迹是一行没人在看的 `console.error`。而操作者打开这个面板,正是因为他准备删掉某样东西。

## 改动

**状态形状**:`refs` / `refsLoading` 这一对,换成一个四臂判别联合

```ts
type ReferencesState =
  | { status: 'idle' }
  | { status: 'loading' }
  | { status: 'loaded'; items: MetadataReference[] }
  | { status: 'error'; message: string };
```

关键不在于「多了一个 error 字段」,而在于**错误与测量结果不再可能是同一个取值** —— 没有哪个取值既是 `error` 又是 `loaded`,所以没有任何渲染分支能把故障读成测量。这也是选联合而不是「加一个 `refsError` 布尔/字符串」的理由:后者仍然允许 `error` 与 `items: []` 同时成立,而那正是本卡的缺陷形状。

**错误态**:面板先判 `error` 臂,渲染独立状态 —— 说明检查未完成、展示原因、并且对「删除是否安全」**不做任何方向的断言**。问题没有被回答时,这是唯一诚实的答案:既不说 safe,也不说 unsafe。

**Retry**:错误态提供重试,重跑的是同一个 `loadReferences()`,不是第二条代码路径。重入守卫相应改为在 `loading` / `loaded` 时拦截、在 `idle` / `error` 时放行 —— 旧守卫是 `if (refs != null || refsLoading) return;`,失败后 `refs` 已被置成 `[]` 即非 null,所以**即使旧代码长出一个重试按钮,它也点不动**。守卫的另一半仍然成立:成功扫描后重开侧栏不会重新请求。

**计数徽章**:只在扫描完成时渲染。失败时显示 `0`,是同一个谎报的缩微版。

**i18n**:新增 `engine.edit.refsErrorTitle` / `refsErrorDesc` / `refsRetry`,en 与 zh 双表同步,紧邻既有 `refs*` 键;两张表各带一条注释,写明这段文案的不变量是「对删除安全性零断言」,后续改写必须保留。

**空态原样保留**,仍然专属于「扫描完成且零引用」—— 「Safe to delete」为真的唯一情形。

## 测试

新增 `ResourceEditPage.referencesErrorState.test.tsx`,联合的每一臂各一钉:

1. **loading** —— 请求在飞,渲染扫描指示,不出现任何结论,不出现计数徽章。
2. **真空** —— 扫描**完成**且零引用,仍然说 "Safe to delete",徽章为真实的 `0`。这一钉是让第 3 钉不至于空转的前提:如果直接删掉空态,那句话同样不可达,错误态的所有「不出现」断言都会因为错误的理由而通过。
3. **error** —— `refs-error` 出现;`Safe to delete` 不出现在整个 document(并按表里读出的空态原文再断言一次,避免那句文案改写后本钉悄悄放宽);错误标题与「未回答」文案出现;原因可见;**无计数徽章**;`references` 此时被调用 1 次,点击 Retry 后变 2 次,第二次成功则渲染引用表格、徽章变 1。
4. **懒加载契约** —— 成功扫描后关闭再打开侧栏,不重新请求(守卫的另一半)。
5. **i18n** —— 三个新键在 en / zh 均解析(`t()` 未回落成 key 本身)且两语不同;两种 locale 下错误文案与标题都不等于空态文案与标题。语义性质(「零断言」)不可机检,注释里明说了这一点,没有假装它被门守着。

命令与结果:

- `pnpm exec vitest run .../ResourceEditPage.referencesErrorState.test.tsx` → `Test Files 1 passed (1) / Tests 5 passed (5)`
- 邻域回归(`resetVerdict` / `artifactTier` / `celGate` / `defaultGate` / `studio-locale.i18n` / `artifact-locked-banner.i18n` + 本文件)→ `7 passed (7) / 27 passed (27)`
- 整个 `packages/app-shell/src/views/metadata-admin` 切片 → `Test Files 181 passed (181) / Tests 1863 passed | 1 skipped`
- `pnpm --filter @object-ui/app-shell type-check` → 通过(`tsc --noEmit` + `tsc -p tsconfig.test.json`)
- `pnpm exec eslint`(三个改动文件)→ `0 errors`;唯一落在新增代码上的 warning 是 `catch (err: any)` 的 `no-explicit-any`,与改动前同一行同一条,本文件其余 catch 亦然
- `node scripts/check-control-bytes.mjs` → OK(4572 个文件);改动文件另做了一次 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自查,零命中
- `node scripts/check-i18n-call-site-keys.mjs` → 通过;`check-i18n-en-drift.mjs` → `0 en value(s) changed`(本改动不触碰十个 locale pack);`check-i18n-dead-keys.mjs`(report-only)未涉及新键

### 反向验证

两次变异,方向都是**先写预判再跑**,两次都与预判一致:

**A. 把删掉的那条肢体装回去** —— catch 改回 `{ status: 'loaded', items: [] }`(即旧的 `setRefs([])`)。
预判:红,且只红第 3 钉,失败点在 `findByTestId('refs-error')`(错误臂不再产生,元素永不出现),1/2/4/5 保持绿。
实测:`Tests 1 failed | 4 passed (5)`,失败位置 `referencesErrorState.test.tsx:198`,即 `findByTestId('refs-error')`。**一致。**

**B. 把重入守卫改回会拦住 error 的写法** —— `if (refsState.status !== 'idle') return;`。
预判:红,且只红第 3 钉,但失败点后移到 `expect(mockClient.references).toHaveBeenCalledTimes(2)` —— 错误态照常渲染,只是 Retry 变成装饰。
实测:`Tests 1 failed | 4 passed (5)`,`AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times`,位置 `referencesErrorState.test.tsx:234`。**一致。**

两次均以 `git checkout --` 还原,还原后重跑 5 passed。这里是常规的「红」方向,不是 inverted 也不是 more-diagnostics:被变异的是一个直接以该取值为键的渲染分支,而第 2 钉保证了错误态的「不出现」断言不是因为文案整体消失而通过的。

## 兄弟 tab 普查(测量,不夹带修复)

按卡面要求清点同页 loader 的 `catch → empty` 同形。三个已经是三态,这正是本次普查确有分辨力的对照:

| loader | 读点 | 判定 |
| --- | --- | --- |
| history | `ResourceHistoryPage.tsx`,catch 只 `setError`,不动 `events` | 干净 |
| related | `RelatedPanel.tsx`,每组带 `error` 字段,渲染时 error 分支先于 empty 分支 | 干净 |
| diagnostics | `DiagnosticsPage.tsx`,`!loading && error` 与 `!loading && !error && groups.length === 0` 互斥 | 干净 |
| audit | `AuditPanel.tsx`,catch 同时 `setError(...)` **与** `setEvents([])`;错误横幅之下照样渲染 "No audit events yet" 与 `0 events` | **命中** |

另有三处同形出现在本文件内、但在 References 半径之外:object 名称、object 字段 + actions、object 视图三个选择器 loader,`catch` 写空数组且**连 `console.error` 都没有**。

两处均已开卡,不 assign、不带 `pm:queue`,均按 `finding` 归档并附查重与对照查询:

- objectui#5169 —— Audit tab 与失败横幅同屏渲染「暂无审计记录」与 `0`
- objectui#5170 —— ResourceEditPage 三个选择器 loader 把失败吞成空选项列表

⛔ 两者都**没有**在本 PR 中动过一行。

## 半径

- `packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx`(References loader + `ReferencesPanel` + 两处徽章读点)
- `packages/app-shell/src/views/metadata-admin/i18n.ts`(en / zh 各三个新键)
- `packages/app-shell/src/views/metadata-admin/ResourceEditPage.referencesErrorState.test.tsx`(新增)
- `.changeset/references-panel-failed-check-vs-empty-5110.md`

`ReferencesPanel` 是模块内私有函数,全仓仅此一处调用;`client.references(` 全仓亦仅此一处消费 —— 消费半径已闭合,无其它包的 fixture 需要跟改。未触碰 `plugin-view/ObjectView.tsx`、`scripts/`、plugin-map,与在飞席位零重叠。

## 相关

objectstack#9326 / objectstack PR #9425(生产者那半边:REST 路由改为拒绝而不是答空) · objectstack#9426(audit 路由上的同类生产者侧缺陷) · ADR-0110 D3,"a miss and a fault are different facts" · objectui#4408(同一族的既往判例:`OBJECT_API_DISABLED` 的 404 被渲染成通用空态)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_