### PR TITLE
fix(app-shell): `/data` 面的「New」读取完整 CRUD affordance 矩阵 (#5164)

### DIFF
--- a/.changeset/data-surface-create-affordance-matrix-5164.md
+++ b/.changeset/data-surface-create-affordance-matrix-5164.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The `/data` surface's "New" button now reads the whole CRUD affordance matrix, not just the permission.
+
+`ObjectDataPage` — the parameterized bare data surface (ADR-0055, objectui#2251,
+route `/apps/:appName/:objectName/data`) — gated its "New" on
+`can(objectDef.name, 'create')` and nothing else. It never called
+`resolveEffectiveCrudAffordances` at all, so every layer below the principal's
+grant was missing at once, and one authored object got a different affordance
+here than it gets on the object-list page next door:
+
+- the `managedBy` bucket default was ignored — `append-only`, `engine-owned` and
+  `better-auth` all resolve `create: false`, yet this surface still offered a
+  "New" that navigates to `../new`;
+- the object-level `userActions: { create: false }` opt-out did not close the
+  button;
+- the effective API operations intersection (objectui#3391) was absent, so the
+  toolbar could offer a create the server would answer with a 405;
+- and `createPredicates` — the layer objectui#5153 gave the object-list page —
+  was unread here as a consequence of the wider gap.
+
+The server is the enforcement point throughout, so this was a UI-truthfulness
+defect rather than a privilege escalation: the button was offered, the write was
+still refused. It is now resolved exactly as `ObjectView` resolves it — the
+spec's bucket/`userActions` matrix intersected with the server-resolved
+effective operations, then the toolbar-scope predicate layer on top.
+
+Predicate binding and failure posture are the family's, unchanged and not
+reinvented here: `visibleWhen` fails CLOSED with declared-ness read by `?? true`
+(so `visibleWhen: false` hides the button rather than reading as "ungated"), and
+`disabledWhen` fails SOFT with its `!= null` declared-ness gate outside the
+evaluation (so `disabledWhen: ''` reads as "no condition", and an unevaluable
+predicate never greys a button forever). Like the standalone object list, this
+surface has no record in scope, so a predicate reading `record.*` has nothing to
+bind and fails closed — the spec's documented binding for a toolbar predicate.
+
+The layers only ever narrow. The pre-existing permission gate is not replaced,
+it is one conjunct of the new one: a passing predicate cannot re-open what the
+bucket, the effective operations or the principal's grant have closed.

--- a/packages/app-shell/src/views/ObjectDataPage.createAffordances.test.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.createAffordances.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * [#5164] `ObjectDataPage` — the parameterized bare data surface (ADR-0055,
+ * #2251, route `/apps/:appName/:objectName/data`) — and the CRUD affordance
+ * matrix its "New" button did not read.
+ *
+ * Before this change the button was gated on `can(objectDef.name, 'create')`
+ * and NOTHING else: `resolveEffectiveCrudAffordances` was never called in that
+ * file, so all FOUR layers below the permission were missing at once, and this
+ * surface contradicted every sibling console surface for the same object —
+ *
+ *   1. the `managedBy` bucket default (`append-only` / `engine-owned` /
+ *      `better-auth` all resolve `create: false`, yet `/data` offered "New");
+ *   2. the object-level `userActions: { create: false }` opt-out;
+ *   3. the #3391 effective-API-operation intersection (the toolbar could offer
+ *      a create the server would 405);
+ *   4. `createPredicates` — the #5153 defect, here as a consequence of the
+ *      wider gap rather than the gap itself.
+ *
+ * One test file for all four because they are one gate: the issue is not "a
+ * predicate is unread", it is that ONE authored object produced a DIFFERENT
+ * affordance depending on which surface drew the button. The layers are
+ * therefore pinned in the order they compose, with the permission control kept
+ * alongside them so a regression that deletes the whole conjunction is
+ * distinguishable from one that deletes a single conjunct.
+ *
+ * BINDING under test is the spec docblock's, identical to `ObjectView`'s
+ * (#5153 / PR #5165) and the import half's (#5142): a toolbar predicate
+ * evaluates ONCE per toolbar against the record of the scope the toolbar sits
+ * in — and this surface, like the standalone object list, has NO record in
+ * scope. That is the documented binding, not a gap in this harness, so a
+ * `record.*` read fails closed and is pinned as its own case.
+ *
+ * ONE RENDER POINT, unlike `ObjectView`: this page has no phone FAB (the whole
+ * PageHeader lives under `hidden sm:block`), so there is exactly one entry to
+ * assert and no two-points-one-verdict parity to keep.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed;
+ * see the PR body. Restoring the pre-change gate (a bare
+ * `can(objectDef.name, 'create')`, no affordance resolution, no predicate
+ * layer, no `disabled`) turns the bucket, the object-level opt-out, the
+ * effective-operations and both predicate cases RED, while the
+ * permission-denied and default-open cases stay GREEN — the latter are the
+ * controls: they never reach the layers this change added, which is exactly
+ * what makes them controls rather than coverage.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/** Controllable principal verdict, keyed by action (`can()` is permissive by default). */
+let principal: Record<string, boolean> = {};
+/** Controllable server-resolved effective API operations (#3391); `undefined` = unrestricted. */
+let apiOperations: string[] | undefined;
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    check: () => ({ allowed: true }),
+    checkField: () => true,
+    getFieldPermissions: () => [],
+    getRowFilter: () => undefined,
+    getObjectApiOperations: () => apiOperations,
+    roles: [],
+    isLoaded: false,
+    hasCapabilities: () => true,
+    can: (_object: string, action: string) => principal[action] ?? true,
+    cannot: (_object: string, action: string) => !(principal[action] ?? true),
+  }),
+  useFieldPermissions: () => ({ canRead: () => true, canWrite: () => true, permissions: [] }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada' }, activeOrganization: null }),
+  useIsWorkspaceAdmin: () => false,
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+// Heavy children, all orthogonal to the toolbar gate under test and each
+// dragging in a plugin bundle. Same posture as the sibling create/import
+// predicate tests on `ObjectView`.
+vi.mock('@object-ui/plugin-list', () => ({ ListView: () => null }));
+vi.mock('./RecordDetailView', () => ({ RecordDetailView: () => null }));
+vi.mock('./CreateViewDialog', () => ({ CreateViewDialog: () => null }));
+vi.mock('./metadata-admin/useMetadata', () => ({ useMetadataClient: () => ({}) }));
+
+import { ObjectDataPage } from './ObjectDataPage';
+import { ExpressionProvider } from '../providers/ExpressionProvider';
+
+const OBJECT_NAME = 'showcase_invoice';
+
+/** The signed-in principal the host shell publishes into the predicate scope. */
+const USER = { id: 'u1', name: 'Ada', profile: 'admin' };
+
+/**
+ * Predicates over the toolbar's SCOPE (`os.user.*`) — the meaningful shape on
+ * a surface with no record in scope. Same aliases the real `ExpressionProvider`
+ * publishes, so these are authored exactly as they would be in served metadata.
+ */
+const SCOPE_TRUE = "os.user.profile == 'admin'";
+const SCOPE_FALSE = "os.user.profile == 'guest'";
+/** A predicate over `record.*` — nothing to bind here, per the spec binding. */
+const RECORD_BOUND = 'record.frozen != true';
+
+/** One object, with an arbitrary bucket and `userActions` shape. */
+function objects(overrides: Record<string, unknown> = {}) {
+  return [
+    {
+      name: OBJECT_NAME,
+      label: 'Invoice',
+      managedBy: 'platform',
+      fields: {
+        id: { type: 'text', label: 'Id' },
+        name: { type: 'text', label: 'Name' },
+      },
+      ...overrides,
+    },
+  ];
+}
+
+/** The common case: a `platform` object carrying the given `userActions.create`. */
+function objectsWith(createOverride: unknown) {
+  return objects({
+    userActions: createOverride === undefined ? undefined : { create: createOverride },
+  });
+}
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+function renderDataPage(objs: any[]) {
+  return render(
+    <ExpressionProvider user={USER}>
+      <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}/data`]}>
+        <Routes>
+          <Route
+            path="/apps/:appName/:objectName/data"
+            element={<ObjectDataPage dataSource={makeDataSource()} objects={objs} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ExpressionProvider>,
+  );
+}
+
+/** The one create entry on this surface. */
+const newButton = () =>
+  document.querySelector('[data-testid="object-data-new-button"]') as HTMLButtonElement | null;
+
+function expectCreateEntry(expected: { rendered: boolean; disabled?: boolean }) {
+  if (!expected.rendered) {
+    expect(newButton()).toBeNull();
+    return;
+  }
+  expect(newButton()).toBeTruthy();
+  expect(newButton()!.disabled).toBe(expected.disabled ?? false);
+}
+
+beforeEach(() => {
+  principal = {};
+  apiOperations = undefined;
+  cleanup();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('#5164 — the /data surface reads the whole create affordance matrix', () => {
+  it('CONTROL: still renders "New" for an ordinary object with everything open', () => {
+    // The pre-change behaviour, deliberately unchanged. Nothing declared →
+    // nothing to evaluate → the gate is the permission and a literal `true`.
+    renderDataPage(objectsWith(undefined));
+    expectCreateEntry({ rendered: true });
+  });
+
+  it('CONTROL: the permission gate still hides "New" on its own', () => {
+    principal = { create: false };
+    renderDataPage(objectsWith(undefined));
+    expectCreateEntry({ rendered: false });
+  });
+
+  // ── Layer 1: the `managedBy` bucket default ────────────────────────────
+  it('hides "New" for an `append-only` object — the bucket resolves `create: false`', () => {
+    renderDataPage(objects({ managedBy: 'append-only' }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('hides "New" for an `engine-owned` object', () => {
+    renderDataPage(objects({ managedBy: 'engine-owned' }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('hides "New" for a `better-auth` object', () => {
+    renderDataPage(objects({ managedBy: 'better-auth' }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('a bucket that grants no create is not re-opened by a passing predicate', () => {
+    renderDataPage(
+      objects({ managedBy: 'append-only', userActions: { create: { visibleWhen: SCOPE_TRUE } } }),
+    );
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('an object that OPTS IN over a closed bucket gets "New" back', () => {
+    // The bucket default is a default, not a ceiling: `userActions.create:
+    // true` is the documented opt-in, and this surface must honour it too.
+    renderDataPage(objects({ managedBy: 'append-only', userActions: { create: true } }));
+    expectCreateEntry({ rendered: true });
+  });
+
+  // ── Layer 2: the object-level `userActions` opt-out ────────────────────
+  it('honours `userActions: { create: false }` — the object-level opt-out', () => {
+    renderDataPage(objectsWith(false));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('honours `enabled: false` in the object form, predicates or not', () => {
+    renderDataPage(objectsWith({ enabled: false, visibleWhen: SCOPE_TRUE }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('renders "New" for the plain boolean arm of the union (no regression)', () => {
+    renderDataPage(objectsWith(true));
+    expectCreateEntry({ rendered: true });
+  });
+
+  // ── Layer 3: the #3391 effective API operations intersection ───────────
+  it('hides "New" when the effective operations from the server exclude `create`', () => {
+    apiOperations = ['read', 'update'];
+    renderDataPage(objectsWith(undefined));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('keeps "New" when the effective operations include `create`', () => {
+    apiOperations = ['read', 'create', 'update'];
+    renderDataPage(objectsWith(undefined));
+    expectCreateEntry({ rendered: true });
+  });
+
+  it('an empty effective set means "expose nothing"', () => {
+    apiOperations = [];
+    renderDataPage(objectsWith(undefined));
+    expectCreateEntry({ rendered: false });
+  });
+
+  // ── Layer 4: `createPredicates` ────────────────────────────────────────
+  it('HIDES "New" when `visibleWhen` evaluates false', () => {
+    renderDataPage(objectsWith({ enabled: true, visibleWhen: SCOPE_FALSE }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('keeps "New" when `visibleWhen` evaluates true', () => {
+    renderDataPage(objectsWith({ enabled: true, visibleWhen: SCOPE_TRUE }));
+    expectCreateEntry({ rendered: true });
+  });
+
+  it('`visibleWhen: false` — the literal objectui#3492 shape — hides "New"', () => {
+    // Declared-ness by `?? true`, not by truthiness: a literal `false` must
+    // hide the button rather than read as "ungated".
+    renderDataPage(objectsWith({ enabled: true, visibleWhen: false }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('GREYS "New" (rendered, disabled) when `disabledWhen` holds — hidden and disabled stay distinct', () => {
+    renderDataPage(objectsWith({ enabled: true, disabledWhen: SCOPE_TRUE }));
+    expectCreateEntry({ rendered: true, disabled: true });
+  });
+
+  it('leaves "New" enabled when `disabledWhen` does not hold', () => {
+    renderDataPage(objectsWith({ enabled: true, disabledWhen: SCOPE_FALSE }));
+    expectCreateEntry({ rendered: true, disabled: false });
+  });
+
+  it('treats `disabledWhen: ""` as "no condition", not as "disable"', () => {
+    renderDataPage(objectsWith({ enabled: true, disabledWhen: '' }));
+    expectCreateEntry({ rendered: true, disabled: false });
+  });
+
+  it('fails CLOSED on a `visibleWhen` that cannot bind — this surface has no record in scope', () => {
+    // Not a defect of this harness: the spec binds a toolbar predicate to the
+    // record of the scope the toolbar sits in, and this surface has none, so a
+    // `record.*` read hides the button.
+    renderDataPage(objectsWith({ enabled: true, visibleWhen: RECORD_BOUND }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('fails SOFT on a `disabledWhen` that cannot bind — an unevaluable predicate never greys forever', () => {
+    renderDataPage(objectsWith({ enabled: true, disabledWhen: RECORD_BOUND }));
+    expectCreateEntry({ rendered: true, disabled: false });
+  });
+
+  // ── Layering: the conjunction only ever narrows ────────────────────────
+  it('a passing predicate cannot RE-OPEN what the principal closed (#4096 layering)', () => {
+    principal = { create: false };
+    renderDataPage(objectsWith({ enabled: true, visibleWhen: SCOPE_TRUE }));
+    expectCreateEntry({ rendered: false });
+  });
+
+  it('a passing predicate cannot RE-OPEN what the effective operations closed', () => {
+    apiOperations = ['read'];
+    renderDataPage(objectsWith({ enabled: true, visibleWhen: SCOPE_TRUE }));
+    expectCreateEntry({ rendered: false });
+  });
+});
+
+/**
+ * FAMILY PARITY — the point of the issue, asserted directly.
+ *
+ * The defect was never "a layer is unread" in the abstract; it was that ONE
+ * authored object got a DIFFERENT affordance on `/data` than it gets on the
+ * object-list page next door. So the parity itself is pinned: for each shape
+ * that closes the affordance, both surfaces are rendered under one scope and
+ * required to agree.
+ *
+ * The subject shapes are the ones whose binding is surface-independent (bucket,
+ * object-level opt-out, effective operations, and `os.user.*` predicates). A
+ * `record.*` predicate deliberately does NOT agree across every surface in the
+ * family — the related list binds the host record and neither of these two
+ * pages has one — which is the spec's binding, not a defect, and is pinned as
+ * its own case above.
+ */
+describe('#5164 — /data and the object-list page agree on one declaration', () => {
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ['an `append-only` bucket', { managedBy: 'append-only' }],
+    ['an `engine-owned` bucket', { managedBy: 'engine-owned' }],
+    ['the object-level opt-out', { userActions: { create: false } }],
+    ['`visibleWhen` false', { userActions: { create: { enabled: true, visibleWhen: SCOPE_FALSE } } }],
+    ['`visibleWhen: false`', { userActions: { create: { enabled: true, visibleWhen: false } } }],
+  ];
+
+  it.each(cases)('%s closes "New" on /data exactly as it closes the object list', (_name, overrides) => {
+    renderDataPage(objects(overrides));
+    expect(newButton()).toBeNull();
+  });
+
+  it('an open declaration shows "New" on /data, as on the object list', () => {
+    renderDataPage(objects({ userActions: { create: { enabled: true, visibleWhen: SCOPE_TRUE } } }));
+    expect(newButton()).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -29,7 +29,7 @@
 import * as React from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { ListView } from '@object-ui/plugin-list';
-import { useNavigationOverlay } from '@object-ui/react';
+import { useNavigationOverlay, useRowPredicate } from '@object-ui/react';
 import {
   Button,
   Empty,
@@ -70,6 +70,7 @@ import {
   PREVIEW_QUERY_VALUE,
 } from '../preview/PreviewModeContext';
 import { useTenancyPosture } from '../hooks/useTenancyPosture';
+import { resolveEffectiveCrudAffordances, type RowCrudPredicates } from '../utils/crudAffordances';
 
 /** Field types the auto-derived user-filter bar offers as dropdowns. */
 const USER_FILTER_TYPES = new Set(['select', 'multiselect', 'radio', 'enum', 'boolean']);
@@ -189,7 +190,7 @@ export function ObjectDataPage({ dataSource, objects }: any) {
   const { objectLabel, fieldLabel } = useObjectLabel();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { can } = usePermissions();
+  const { can, getObjectApiOperations } = usePermissions();
   const { canRead } = useFieldPermissions(objectName ?? '');
   const { user, activeOrganization } = useAuth();
   const isAdmin = useIsWorkspaceAdmin();
@@ -389,6 +390,78 @@ export function ObjectDataPage({ dataSource, objects }: any) {
     [columns, urlFilters, metadataClient, dataSource, navigate, objectName, previewDrafts],
   );
 
+  // ─── The CRUD affordance matrix for this surface (#5164) ──────────────
+  //
+  // Until #5164 this page gated its "New" on `can(objectDef.name, 'create')`
+  // and nothing else — `resolveEffectiveCrudAffordances` was not called here at
+  // all. The bare data surface therefore contradicted every other console
+  // surface for the same object: `append-only` / `engine-owned` /
+  // `better-auth` objects (whose bucket resolves `create: false`) were still
+  // offered a "New" that navigates to `../new`, an object-level
+  // `userActions: { create: false }` opt-out did not close the button, and the
+  // #3391 effective-API-operation intersection was absent, so the toolbar could
+  // offer a create the server would 405.
+  //
+  // Resolved exactly as `ObjectView` does: the spec's bucket/`userActions`
+  // matrix (ADR-0103, delegated to `resolveCrudAffordances`), INTERSECTED with
+  // the server-resolved effective API operations for this object. `undefined`
+  // (unrestricted object / old backend) leaves the bucket affordances as-is.
+  const affordances = React.useMemo(
+    () =>
+      resolveEffectiveCrudAffordances(
+        objectDef as any,
+        objectDef ? getObjectApiOperations(objectDef.name) : undefined,
+      ),
+    [objectDef, getObjectApiOperations],
+  );
+
+  /**
+   * [#5164] The create affordance's PREDICATE layer, the fourth of the four
+   * this surface was missing. Binding, layering and the fail-CLOSED /
+   * fail-SOFT split are `ObjectView`'s (#5153 / PR #5165) verbatim — the spec
+   * types the toolbar keys once and binds them in one breath, so a
+   * `userActions.create` declaration must not get a different verdict because
+   * a different surface drew the button.
+   *
+   * BINDING: a toolbar predicate evaluates ONCE per toolbar against the record
+   * of the scope the toolbar sits in — and this surface, like the standalone
+   * object list, has NO record in scope. `null` is therefore passed
+   * deliberately: a predicate reading `record.*` has nothing to bind, faults,
+   * and — per the fail-closed rule — hides the button, exactly as the spec
+   * spells out. Predicates over the host scope (`os.user.*` / `features.*`)
+   * bind normally and are the meaningful shape here.
+   *
+   * LAYERING: surfaced only when the object-level verdict already passed. A
+   * predicate may not RE-OPEN what the bucket, the effective API operations
+   * (#3391) or the principal's grant have closed; it only narrows further. The
+   * pre-existing `can(...)` gate is not removed, it is one conjunct of this.
+   *
+   * ONE RENDER POINT here, unlike `ObjectView`: this page has no phone FAB —
+   * the whole PageHeader lives under `hidden sm:block`.
+   */
+  const objectCanCreate = !!objectDef && affordances.create && can(objectDef.name, 'create');
+  const createPredicates: RowCrudPredicates | undefined = objectCanCreate
+    ? affordances.createPredicates
+    : undefined;
+  /** `visibleWhen` — fails CLOSED, declared-ness by `?? true` rather than by
+   *  truthiness, so `visibleWhen: false` (the objectui#3492 shape) hides "New"
+   *  instead of reading as "ungated". The `true` default is a boolean, which
+   *  the evaluator short-circuits without touching the engine. */
+  const createVisible = useRowPredicate(createPredicates?.visibleWhen ?? true, null, {
+    fallback: false,
+    warnOnError: true,
+    label: 'builtin:create:visibleWhen',
+  });
+  /** `disabledWhen` — fails SOFT (an unevaluable predicate must not grey a
+   *  button forever), with the `!= null` declared-ness gate OUTSIDE the
+   *  evaluation so `disabledWhen: ''` reads as "no condition", not "disable". */
+  const createDisabledPred = useRowPredicate(createPredicates?.disabledWhen, null, {
+    fallback: false,
+    warnOnError: true,
+    label: 'builtin:create:disabledWhen',
+  });
+  const createDisabled = createPredicates?.disabledWhen != null && createDisabledPred;
+
   if (!objectDef) {
     return (
       <div className="h-full flex items-center justify-center p-8">
@@ -444,10 +517,16 @@ export function ObjectDataPage({ dataSource, objects }: any) {
           icon={React.createElement(getIcon((objectDef as any)?.icon), { className: 'h-4 w-4' })}
           actions={
             <>
-              {can(objectDef.name, 'create') && (
+              {/* [#5164] `objectCanCreate && createVisible` — the bucket +
+                  object-level `userActions` + #3391 effective-operations
+                  verdict (all folded into `affordances.create`) AND the
+                  principal's grant, then the toolbar-scope `visibleWhen` layer
+                  on top of it. Greyed, not gone, is the `disabledWhen` case. */}
+              {objectCanCreate && createVisible && (
                 <Button
                   size="sm"
                   onClick={() => navigate('../new', { relative: 'path' })}
+                  disabled={createDisabled}
                   className="shadow-none gap-1.5 h-8 sm:h-9"
                   data-testid="object-data-new-button"
                 >


### PR DESCRIPTION
Fixes #5164

## 背景

`ObjectDataPage` —— 参数化裸数据面(ADR-0055、#2251,路由 `/apps/:appName/:objectName/data`)—— 的「New」按钮此前只有 `can(objectDef.name, 'create')` 一个门。该文件从头到尾**没有调用过** `resolveEffectiveCrudAffordances`,所以主体授权之下的四层同时缺席,同一份对象元数据在这个面上得到的 affordance 与隔壁对象列表页不一致:

1. **`managedBy` bucket 默认被忽略** —— `append-only` / `engine-owned` / `better-auth` 都解析出 `create: false`,而 `/data` 仍然给出一个指向 `../new` 的「New」;
2. **对象级 `userActions: { create: false }` 退出开关**关不掉按钮;
3. **#3391 有效 API 操作交集**缺失,工具条可以给出服务端会 405 的 create;
4. **`createPredicates`** 谓词层在此未被读取 —— 即 #5153 的缺陷,但在这里是上述更大缺口的**后果**而非缺口本身。

服务端始终是执行点,所以这是 **UI 真实性缺陷**而非提权:按钮被给出,写入照样被拒。但今日用户可达,且与控制台其余部分渲染所依据的 affordance 矩阵自相矛盾。

## 改动

门形完全照 `ObjectView` 的现形(#5153 / PR #5165、#5142 / PR #5154 同族),不作二次发明:

```
affordances = resolveEffectiveCrudAffordances(objectDef, getObjectApiOperations(objectDef.name))
objectCanCreate = affordances.create && can(objectDef.name, 'create')
createPredicates = objectCanCreate ? affordances.createPredicates : undefined
渲染门 = objectCanCreate && createVisible,disabled = createDisabled
```

- **`visibleWhen` fail-CLOSED**,声明性由 `?? true` 判定而非由真值判定 —— 所以字面 `visibleWhen: false`(objectui#3492 的形)是隐藏按钮,而不是读作「未设门」;默认值是布尔,求值器直接短路,未声明谓词的对象不付任何求值代价。
- **`disabledWhen` fail-SOFT**,`!= null` 的声明性判定放在求值**之外** —— 所以 `disabledWhen: ''` 读作「无条件」而非「禁用」,不可求值的谓词也永远不会把按钮永久置灰。
- **绑定**:工具条谓词按 spec 的规定,针对工具条所处 scope 的记录求值**一次**;本面与独立对象列表一样**没有记录在 scope 内**,故 `useRowPredicate(..., null, ...)` 是刻意的 —— 读 `record.*` 的谓词无从绑定,按 fail-closed 规则隐藏按钮,这正是 spec 写明的绑定,不是本 harness 的缺口。`os.user.*` / `features.*` 正常绑定,是这里有意义的形。
- **分层只收窄不重开**:既有权限门未被删除,它成为新合取式的一个合取项。谓词无法重新打开 bucket、有效操作或主体授权已关闭的东西。

半径严格限定在 `ObjectDataPage.tsx` + 测试 + changeset,未触碰 `ObjectView.tsx`。

## 其它 CRUD 入口普查(只测量,未夹带)

按派发要求普查了本文件是否还有同形缺门的 edit/delete 入口,**结论为无**,故未开 finding 卡:

- 「Save as view」按 `isAdmin` 设门,写的是 `view` 元数据记录,不是该对象的 CRUD affordance,不属本矩阵;
- 行级 edit/delete 本文件根本不渲染 —— 这里组装的 `list-view` schema 不声明 `rowActions`,也不传 `onEdit`/`onDelete`,行 affordance 由 `plugin-list` / `plugin-grid` 内部解析,而那两处已各自调用 `resolveEffectiveCrudAffordances` / `isObjectInlineEditable`;
- 抽屉里的 `RecordDetailView` 是另一张面,有自己的门(此处 `onEdit` 传的是空函数);
- 本面没有 Import/Export 入口 —— 「按钮不存在」不构成不真实的 affordance,是面设计问题,不在本卡范围。

另:卡面已核实、此处复核一次 —— 文件内 `userActions:`(schema 组装处)是**视图工具条词汇**(`search` / `sort` / `filter` / `rowHeight` / `group` / `hideFields`,#2890),与对象级 CRUD `userActions` 不是同一键空间,未混用。

## 测试

新增 `packages/app-shell/src/views/ObjectDataPage.createAffordances.test.tsx`,29 钉,按四层组合的顺序钉,并把两个 CONTROL 留在旁边,使「整条合取式被删」与「单个合取项被删」可区分:

- bucket 三钉(`append-only` / `engine-owned` / `better-auth`)+ 谓词不得复活已关 bucket + 已关 bucket 上的显式 `create: true` opt-in 仍开;
- 对象级 `create: false` / `enabled: false`(带谓词)/ 纯布尔臂;
- #3391 有效操作:排除 `create` 关门、包含 `create` 开门、空集「什么都不暴露」;
- 谓词层:`visibleWhen` 真/假、字面 `visibleWhen: false`、`disabledWhen` 置灰(渲染且 disabled,隐藏与置灰保持可区分)、`disabledWhen` 不成立、`disabledWhen: ''`、`record.*` 的 `visibleWhen` fail-closed、`record.*` 的 `disabledWhen` fail-soft;
- 分层:谓词不得重开主体授权关闭的、不得重开有效操作关闭的;
- 家族 parity 一组:同一份声明在 `/data` 上与对象列表页取得一致的关门结论。

```
pnpm exec vitest run packages/app-shell/src/views/ObjectDataPage.createAffordances.test.tsx
  Test Files  1 passed (1)
       Tests  29 passed (29)

# 同族三面回归
pnpm exec vitest run ObjectDataPage.createAffordances ObjectDataPage.saveAsViewFilterFold \
  ObjectView.createPredicates ObjectView.importPredicates RelatedRecordActionsBridge.createPredicates
  Test Files  5 passed (5)
       Tests  91 passed (91)

# 消费半径全扫(app-shell/src/views 全量)
pnpm exec vitest run packages/app-shell/src/views
  Test Files  270 passed (270)
       Tests  2668 passed | 1 skipped (2669)

pnpm --filter @object-ui/app-shell type-check   # tsc --noEmit && tsc -p tsconfig.test.json,通过
pnpm --filter @object-ui/app-shell lint         # 0 errors
pnpm run check:control-bytes                    # OK(4581 tracked text files)
```

## 反向验证

**先书面预判,再跑变异。** 预判:把门改回改动前的裸 `can(objectDef.name, 'create')`(不解析 affordances、不加谓词层、不传 `disabled`),应有 **18 钉转红、11 钉保持绿**;绿的那 11 钉是**对照**而非覆盖 —— 它们本就走不到本次新增的层。

观测:

```
Tests  18 failed | 11 passed (29)
```

红的 18 钉逐条与预判名单一致:三个 bucket 钉、bucket 不被谓词复活、对象级 opt-out、`enabled: false`、有效操作排除 `create`、空有效集、`visibleWhen` 假、字面 `visibleWhen: false`、`disabledWhen` 置灰、`record.*` fail-closed、谓词不得重开有效操作,以及 parity 五钉。绿的 11 钉:两个 CONTROL、已关 bucket 上的 opt-in、纯布尔臂、有效操作含 `create`、`visibleWhen` 真、`disabledWhen` 不成立、`disabledWhen: ''`、`record.*` 的 `disabledWhen` fail-soft、谓词不得重开主体授权、parity 开门钉。

**预判与观测完全吻合(matched)**,无反转、无「更多诊断」情形。还原后 29/29 复绿。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_