### PR TITLE
fix(plugin-form): EmbeddableForm 致谢重定向按 host mount 导航 (#5112)

### DIFF
--- a/.changeset/embeddable-form-thank-you-host-navigation-5112.md
+++ b/.changeset/embeddable-form-thank-you-host-navigation-5112.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+`EmbeddableForm`'s thank-you redirect stops being mount-blind: an in-app destination now goes through the host's injected navigate.
+
+The redirect ended in one unconditional `window.location.href = url`. That is
+right for the external destination this key deliberately admits, and wrong for
+the in-app one it equally admits: a rooted path such as `/thanks` assigned to
+`location.href` resolves against the ORIGIN root, so under a host mounted at a
+sub-path — the framework CLI configures one for every embedded deployment, and
+the console runs at basename `/_console` — the submitter landed outside the
+application, usually on the host's own 404. Nothing refused either half of that
+authoring, so the failure was silent. This is objectui#4989 defect 4 on the key
+that card explicitly did not cover, and it is fixed here through the seam
+objectui#5111 landed (`HostNavigationContext`, `@object-ui/react`).
+
+The destinations are now split by who can travel to them:
+
+- an **app-relative** destination (`/thanks`, `thanks`, `?ok=1`, `#done`) is
+  handed to the host's navigate when a host supplied one, so a mounted host
+  places it inside its mount; with no provider the behaviour is byte-for-byte
+  what it was — a host with no router has no basename, so origin-rooted
+  resolution is already correct there;
+- an **external** destination admitted by `allowedRedirectHosts` keeps
+  browser-level navigation **unconditionally**. This is the seam's own declared
+  input contract, not a conservatism: `HostNavigationValue.navigate` documents
+  `to` as an application-relative path, "never an absolute URL", because a host
+  navigate is a client-side router transition. Since a relative reference cannot
+  carry an authority, the seam is now structurally incapable of being handed a
+  cross-origin URL.
+
+A same-origin **absolute** URL — the one shape those two arms do not name — also
+keeps browser-level navigation. Routing it through the seam would mean rewriting
+the author's full address into a path a mounted router then places at a
+different address; an author who spelled out the whole address asked for that
+address.
+
+Not changed, deliberately: `isRedirectUrlSafe` and `allowedRedirectHosts` —
+WHICH destinations are followed. That acceptance set (same-origin OR the
+author's allowlist) is this key's own contract, a refused destination reaches
+neither the seam nor the browser, and objectstack#7496's relative-only ruling
+belongs to `submitBehavior.url` and is not imported onto this key. The wait's
+ownership (objectui#5049) and the thank-you panel's copy (objectui#5073) are
+carried over unchanged: unmounting or pressing "Submit Another Response" still
+cancels a pending redirect, seam or no seam.

--- a/content/docs/guide/public-forms.md
+++ b/content/docs/guide/public-forms.md
@@ -132,6 +132,53 @@ leave it undeclared and the panel stays silent. Either way the refusal is
 logged with `console.warn`, which is where to look if a redirect you expected
 never happens.
 
+### Who performs the redirect (mounted hosts)
+
+The guard decides **whether** a destination is followed; who travels to it
+depends on the shape of the destination:
+
+| Destination | Travelled by |
+|---|---|
+| App-relative — `/thanks`, `thanks`, `?ok=1`, `#done` | the host's navigate, when one is supplied; otherwise a browser navigation |
+| External — a host you listed in `allowedRedirectHosts` | a browser navigation, always |
+| Same-origin but **absolute** — `https://your.app/thanks` | a browser navigation, always |
+
+This matters when your application is mounted at a sub-path (the console runs
+at basename `/_console`). A browser navigation resolves `/thanks` against the
+**origin root**, which leaves the application — so an in-app thank-you page
+needs the host to place the path. Supply one with `HostNavigationProvider`
+from `@object-ui/react` and the form hands app-relative destinations to it:
+
+```tsx
+import { HostNavigationProvider } from '@object-ui/react';
+import { EmbeddableForm, type EmbeddableFormConfig } from '@object-ui/plugin-form';
+import type { DataSource } from '@object-ui/types';
+
+export function MountedPublicForm(props: {
+  /** Your own router's navigate — it already knows the basename. */
+  navigate: (to: string) => void;
+  config: EmbeddableFormConfig;
+  dataSource: DataSource;
+}) {
+  return (
+    <HostNavigationProvider value={{ navigate: props.navigate }}>
+      <EmbeddableForm config={props.config} dataSource={props.dataSource} />
+    </HostNavigationProvider>
+  );
+}
+```
+
+Supplying it is optional and changes nothing for an unmounted host: with no
+provider — or with no router at all, where there is no basename to miss —
+every destination keeps the browser navigation it always had.
+
+An external destination is never handed to your navigate. A host navigate is a
+client-side router transition, so it takes an application-relative path, and a
+form holding a cross-origin address must not route it through your router. A
+same-origin **absolute** URL is treated the same way for a different reason:
+you spelled out the whole address, so that is the address the submitter gets —
+write the destination relatively if you want it placed inside your mount.
+
 ### GDPR consent
 
 ```tsx

--- a/packages/plugin-form/src/EmbeddableForm.redirectHostNavigation.test.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.redirectHostNavigation.test.tsx
@@ -1,0 +1,400 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5112 — `EmbeddableForm`'s thank-you redirect stops being mount-blind.
+ *
+ * The redirect used to end in one unconditional `window.location.href = url`.
+ * That is correct for the external destination this key deliberately admits, and
+ * wrong for the in-app one it equally admits: a rooted path such as `/thanks`
+ * assigned to `location.href` resolves against the ORIGIN root, so under a host
+ * mounted at a sub-path (the console runs at basename `/_console`) the submitter
+ * lands outside the application — usually on the host's own 404. This is
+ * objectui#4989 defect 4 on the key that card explicitly did not cover, and the
+ * seam that fixes it (`HostNavigationContext`, `@object-ui/react`) landed with
+ * PR #5111.
+ *
+ * ## The arm split this file pins, and the one thing it must NOT do
+ *
+ * Per the ruling on this card: an app-relative destination goes through the host
+ * navigate when a host supplied one and falls back to the browser navigation
+ * when none was; an external destination admitted by `allowedRedirectHosts`
+ * keeps browser-level navigation **unconditionally**. The nail on that second
+ * arm is the point of half this file — the seam's own type contract says `to` is
+ * "an already-resolved, application-relative path, never an absolute URL", so a
+ * renderer handing a router a cross-origin address would be laundering an
+ * external destination through the host.
+ *
+ * What is NOT touched: `isRedirectUrlSafe` and `allowedRedirectHosts` — WHICH
+ * destinations are followed. That acceptance set (same-origin OR allowlist) is
+ * this key's own contract and is not this card's to change; objectstack#7496's
+ * relative-only ruling belongs to `submitBehavior.url` and is deliberately not
+ * imported here. The last describe block below re-measures the guard's verdicts
+ * so a future edit to the arm split cannot quietly widen or narrow them.
+ *
+ * ## Reverse verification — direction predicted before it was run
+ *
+ * Restoring the executor to an unconditional `window.location.href = url` (the
+ * pre-change body) was predicted to turn red **exactly** the cases that assert a
+ * host navigate RECEIVED the destination, and to leave every browser-arm case
+ * green — because those describe behaviour that was already correct and is
+ * deliberately unchanged. The measured result is recorded in the PR.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+import { HostNavigationProvider } from '@object-ui/react';
+
+import { EmbeddableForm, isRedirectUrlSafe, type EmbeddableFormConfig } from './EmbeddableForm';
+import { isAppRelativeDestination } from './thankYouRedirectNavigation';
+
+// ObjectForm resolves field widgets through the global registry.
+registerAllFields();
+
+/** The mount the framework CLI configures for an embedded deployment. */
+const MOUNT = '/_console';
+
+/** Same-origin, app-relative — the destination this card is about. */
+const RELATIVE_DESTINATION = '/thanks-5112';
+/** Cross-origin but explicitly allowlisted below — accepted, and external. */
+const ALLOWED_HOST = 'trusted.example.com';
+const EXTERNAL_DESTINATION = `https://${ALLOWED_HOST}/ok`;
+/** Cross-origin and NOT allowlisted — the guard refuses it. */
+const REFUSED_DESTINATION = 'https://evil.example.com/phish';
+
+/** Short enough to observe inside a test, long enough to act before it fires. */
+const SHORT_DELAY_MS = 120;
+/** Long enough that nothing can have fired by the time the test looks. */
+const LONG_DELAY_MS = 10_000;
+
+const realSetTimeout = globalThis.setTimeout;
+/** Real-clock sleep — this file never fakes the clock (see the sibling files). */
+const sleep = (ms: number) => new Promise((resolve) => { realSetTimeout(resolve, ms); });
+
+function buildDataSource() {
+  return {
+    create: vi.fn(async (_obj: string, data: Record<string, unknown>) => ({ id: '1', ...data })),
+    update: vi.fn(),
+    delete: vi.fn(),
+    findOne: vi.fn(),
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+  };
+}
+
+function baseConfig(overrides: Partial<EmbeddableFormConfig> = {}): EmbeddableFormConfig {
+  return {
+    formId: 'f5112',
+    objectName: 'lead',
+    customFields: [{ name: 'email', label: 'Email', type: 'email', required: true } as any],
+    // The anti-bot minimum fill time is a different gate; disable it so submit
+    // reaches the redirect arm without fighting a 1.5s timer.
+    minFillTime: 0,
+    ...overrides,
+  };
+}
+
+let hrefSetter: ReturnType<typeof vi.fn<(url: string) => void>>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  hrefSetter = vi.fn<(url: string) => void>();
+
+  // `window.location.href = url` is the component's browser-level navigation.
+  // Shadow just that accessor on the real Location instance (the prototype's is
+  // configurable) so `origin` — which `isRedirectUrlSafe` reads — stays
+  // genuinely real and the guard therefore genuinely runs on every fixture
+  // below. `delete` restores the prototype accessor in the teardown.
+  const realHref = window.location.href;
+  Object.defineProperty(window.location, 'href', {
+    configurable: true,
+    get: () => realHref,
+    set: (value: string) => { hrefSetter(value); },
+  });
+
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  delete (window.location as any).href;
+});
+
+interface SubmitOptions {
+  /** The host's navigate, or `undefined` for a host that wires no seam. */
+  navigate?: (to: string, options?: { replace?: boolean }) => void;
+}
+
+/** Renders the form (optionally inside a host seam) and drives one submit. */
+async function submitOnce(
+  config: EmbeddableFormConfig,
+  ds: ReturnType<typeof buildDataSource>,
+  opts: SubmitOptions = {},
+) {
+  const form = (
+    <EmbeddableForm
+      config={config}
+      // Prefilled programmatically so react-hook-form's required-field
+      // validation passes without racing a typed value into its state — the
+      // same reason the sibling EmbeddableForm suites prefill.
+      prefillParams={{ email: 'a@b.com' }}
+      dataSource={ds as any}
+    />
+  );
+  const view = render(
+    // No provider at all in the absent-seam cases: the default context value is
+    // what a router-less host actually sees, and mounting a provider carrying
+    // `navigate: undefined` would test a different (and easier) thing.
+    opts.navigate
+      ? <HostNavigationProvider value={{ navigate: opts.navigate }}>{form}</HostNavigationProvider>
+      : form,
+  );
+  await screen.findByLabelText(/email/i);
+  fireEvent.click(await screen.findByRole('button', { name: /^submit$/i }));
+  await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+  return view;
+}
+
+// ─── The predicate that picks who travels ──────────────────────────────────
+
+describe('isAppRelativeDestination', () => {
+  it('accepts the references a host router can place', () => {
+    expect(isAppRelativeDestination('/thanks')).toBe(true);
+    expect(isAppRelativeDestination('thanks')).toBe(true);
+    expect(isAppRelativeDestination('/a/b?ok=1#done')).toBe(true);
+    expect(isAppRelativeDestination('?ok=1')).toBe(true);
+    expect(isAppRelativeDestination('#done')).toBe(true);
+  });
+
+  it('refuses anything carrying its own authority or scheme', () => {
+    expect(isAppRelativeDestination(EXTERNAL_DESTINATION)).toBe(false);
+    // Protocol-relative: no scheme, but it still supplies a host.
+    expect(isAppRelativeDestination(`//${ALLOWED_HOST}/ok`)).toBe(false);
+    expect(isAppRelativeDestination('javascript:alert(1)')).toBe(false);
+    expect(isAppRelativeDestination('http://[invalid-host')).toBe(false);
+  });
+
+  it('refuses a same-origin ABSOLUTE url — deliberately, not by omission', () => {
+    // The one shape the card's two named arms do not cover. Routing it through
+    // the seam would mean rewriting the author's full address into a path a
+    // mounted router then places somewhere else; an author who spelled the whole
+    // address asked for that address. See the module docblock.
+    expect(isAppRelativeDestination(`${window.location.origin}/thanks`)).toBe(false);
+    // …and it is still an ACCEPTED destination — the guard is untouched.
+    expect(isRedirectUrlSafe(`${window.location.origin}/thanks`)).toBe(true);
+  });
+
+  it('the invariant: an accepted app-relative reference is always same-origin', () => {
+    // A relative reference cannot carry an authority (RFC 3986), so it resolves
+    // to the base's origin whatever it says. This is what makes "the host seam
+    // can never be handed a cross-origin URL" structural rather than a promise.
+    for (const raw of ['/thanks', 'thanks', '?ok=1', '#done', 'not a url at all']) {
+      expect(isAppRelativeDestination(raw)).toBe(true);
+      expect(new URL(raw, window.location.href).origin).toBe(window.location.origin);
+    }
+  });
+});
+
+// ─── Arm 1: an app-relative destination ────────────────────────────────────
+
+describe('objectui#5112 — an app-relative thank-you destination', () => {
+  it('goes to the host navigate, and the browser navigates nowhere', async () => {
+    const navigate = vi.fn();
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({ thankYouPage: { redirectUrl: RELATIVE_DESTINATION, redirectDelay: SHORT_DELAY_MS } }),
+      ds,
+      { navigate },
+    );
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith(RELATIVE_DESTINATION));
+    // The whole defect: `location.href = '/thanks-5112'` resolves against the
+    // ORIGIN root, so under a mounted host it left the app. It must not happen
+    // at all when a host offered to place the path itself.
+    expect(hrefSetter).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the browser navigation when no host supplied a seam', async () => {
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({ thankYouPage: { redirectUrl: RELATIVE_DESTINATION, redirectDelay: SHORT_DELAY_MS } }),
+      ds,
+    );
+
+    // Byte-for-byte the previous behaviour: one `location.href` assignment of
+    // the authored destination. A host with no router has no basename, so
+    // origin-rooted resolution is already right there — absent seam is a
+    // supported state, not a degraded one.
+    await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith(RELATIVE_DESTINATION));
+    expect(hrefSetter).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a mounted host place the destination inside its mount', async () => {
+    // A STUB host navigate that joins its mount, standing in for a router with a
+    // basename — this asserts the seam's consequence at this layer (the renderer
+    // hands over a path a host can still place), not React Router's behaviour,
+    // which is pinned against a real router in the app-shell bridge's own test.
+    const visited: string[] = [];
+    const navigate = (to: string) => visited.push(new URL(`.${to}`, `https://h${MOUNT}/`).pathname);
+    const ds = buildDataSource();
+
+    await submitOnce(
+      baseConfig({ thankYouPage: { redirectUrl: RELATIVE_DESTINATION, redirectDelay: SHORT_DELAY_MS } }),
+      ds,
+      { navigate },
+    );
+
+    await waitFor(() => expect(visited).toEqual([`${MOUNT}${RELATIVE_DESTINATION}`]));
+    // The counterfactual, measured rather than asserted in prose: the same
+    // string through a browser-level navigation resolves at the origin root and
+    // leaves the application.
+    expect(new URL(RELATIVE_DESTINATION, `https://h${MOUNT}/`).pathname).toBe(RELATIVE_DESTINATION);
+  });
+
+  it('uses the LATEST injected navigate, exactly once, when the host rebuilds it', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const ds = buildDataSource();
+    const config = baseConfig({
+      thankYouPage: { redirectUrl: RELATIVE_DESTINATION, redirectDelay: SHORT_DELAY_MS },
+    });
+    const tree = (navigate: (to: string) => void) => (
+      <HostNavigationProvider value={{ navigate }}>
+        <EmbeddableForm config={config} prefillParams={{ email: 'a@b.com' }} dataSource={ds as any} />
+      </HostNavigationProvider>
+    );
+
+    const view = render(tree(first));
+    await screen.findByLabelText(/email/i);
+    fireEvent.click(await screen.findByRole('button', { name: /^submit$/i }));
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+
+    // An inline arrow in a host's JSX is a NEW function every render, which is
+    // the ordinary shape. Re-rendering mid-wait must not lose the navigation,
+    // must not duplicate it, and must not restart the declared pause.
+    view.rerender(tree(second));
+
+    await waitFor(() => expect(second).toHaveBeenCalledWith(RELATIVE_DESTINATION));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+
+  it('cancels on unmount — a host navigate must not fire into a form that is gone', async () => {
+    const navigate = vi.fn();
+    const ds = buildDataSource();
+    const view = await submitOnce(
+      baseConfig({ thankYouPage: { redirectUrl: RELATIVE_DESTINATION, redirectDelay: SHORT_DELAY_MS } }),
+      ds,
+      { navigate },
+    );
+
+    view.unmount();
+    await sleep(SHORT_DELAY_MS * 5);
+
+    // objectui#5049's property, restated for the injected path: an SPA
+    // transition yanking a submitter who has moved on is worse than a full page
+    // load doing it, not better.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+
+  it('does not shorten the declared wait just because a seam is present', async () => {
+    const navigate = vi.fn();
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({ thankYouPage: { redirectUrl: RELATIVE_DESTINATION, redirectDelay: LONG_DELAY_MS } }),
+      ds,
+      { navigate },
+    );
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Arm 2: an external destination ────────────────────────────────────────
+
+describe('objectui#5112 — an external thank-you destination never reaches the seam', () => {
+  it('keeps browser-level navigation even when a host supplied a navigate', async () => {
+    const navigate = vi.fn();
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({
+        thankYouPage: { redirectUrl: EXTERNAL_DESTINATION, redirectDelay: SHORT_DELAY_MS },
+        allowedRedirectHosts: [ALLOWED_HOST],
+      }),
+      ds,
+      { navigate },
+    );
+
+    await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith(EXTERNAL_DESTINATION));
+    // The nail: a host navigate is a client-side router transition, and the
+    // seam's declared input is an application-relative path. A cross-origin
+    // address is not the router's to attempt, and handing it over would launder
+    // an external destination through the host.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(hrefSetter).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps browser-level navigation for a same-origin ABSOLUTE url too', async () => {
+    const navigate = vi.fn();
+    const ds = buildDataSource();
+    const absolute = `${window.location.origin}/thanks-5112-absolute`;
+    await submitOnce(
+      baseConfig({ thankYouPage: { redirectUrl: absolute, redirectDelay: SHORT_DELAY_MS } }),
+      ds,
+      { navigate },
+    );
+
+    await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith(absolute));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('a refused destination reaches neither the seam nor the browser', async () => {
+    const navigate = vi.fn();
+    const ds = buildDataSource();
+    await submitOnce(
+      baseConfig({
+        thankYouPage: { redirectUrl: REFUSED_DESTINATION, redirectDelay: SHORT_DELAY_MS },
+      }),
+      ds,
+      { navigate },
+    );
+
+    await sleep(SHORT_DELAY_MS * 5);
+    // The verdict is taken before anything reaches a navigation, by design: an
+    // injected host navigate is not a way around `isRedirectUrlSafe`.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(hrefSetter).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[EmbeddableForm] Blocked unsafe redirect target:',
+      REFUSED_DESTINATION,
+    );
+    // The write itself succeeded — refusing the redirect does not undo it.
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── The acceptance set this card does not touch ───────────────────────────
+
+describe('objectui#5112 — `isRedirectUrlSafe` verdicts are unchanged', () => {
+  it('answers exactly what it answered before the arm split', () => {
+    // Restated here, next to the arm split, so an edit that widens or narrows
+    // WHICH destinations are followed cannot pass as an edit to WHO travels.
+    // The exhaustive table lives in `__tests__/EmbeddableForm.test.tsx`.
+    expect(isRedirectUrlSafe(RELATIVE_DESTINATION)).toBe(true);
+    expect(isRedirectUrlSafe('thanks')).toBe(true);
+    expect(isRedirectUrlSafe(`${window.location.origin}/thanks`)).toBe(true);
+    expect(isRedirectUrlSafe(REFUSED_DESTINATION)).toBe(false);
+    expect(isRedirectUrlSafe(EXTERNAL_DESTINATION)).toBe(false);
+    expect(isRedirectUrlSafe(EXTERNAL_DESTINATION, [ALLOWED_HOST])).toBe(true);
+    expect(isRedirectUrlSafe('https://app.example.com/ok', ['*.example.com'])).toBe(true);
+    expect(isRedirectUrlSafe('https://example.com/ok', ['*.example.com'])).toBe(false);
+    expect(isRedirectUrlSafe('javascript:alert(1)')).toBe(false);
+    expect(isRedirectUrlSafe('http://[invalid-host')).toBe(false);
+  });
+});

--- a/packages/plugin-form/src/EmbeddableForm.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.tsx
@@ -25,6 +25,10 @@ import type { DataSource, FormField } from '@object-ui/types';
 import { Button } from '@object-ui/components';
 import { CheckCircle2, Lock, Loader2, ShieldCheck } from 'lucide-react';
 import { ObjectForm } from './ObjectForm';
+import {
+  useThankYouRedirectNavigation,
+  type PendingThankYouRedirect,
+} from './thankYouRedirectNavigation';
 
 export interface EmbeddableFormTexts {
   submit?: string;
@@ -223,9 +227,7 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
   // `config.thankYouPage` at wait time: the value honoured is the one declared
   // when the write was accepted, so a host re-rendering with a different
   // `redirectDelay` mid-wait cannot restart the pause under the submitter.
-  const [pendingRedirect, setPendingRedirect] = useState<
-    { url: string; delayMs: number } | null
-  >(null);
+  const [pendingRedirect, setPendingRedirect] = useState<PendingThankYouRedirect | null>(null);
 
   // Whether the guard below refused the authored destination (objectui#5073).
   //
@@ -252,20 +254,20 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
     if (!submitted) mountedAtRef.current = Date.now();
   }, [submitted]);
 
-  // The delayed leg of a thank-you redirect.
+  // The delayed leg of a thank-you redirect: the wait, and who travels at the
+  // end of it (`thankYouRedirectNavigation.ts`).
   //
   // Which destinations are followed and which are refused is decided before a
   // destination ever reaches this state (`isRedirectUrlSafe` in the submit
-  // handler); nothing here re-judges a URL. What changed is who owns the wait:
-  // unmounting, or dropping the destination, cancels it instead of leaving it to
-  // fire into a page the submitter has moved on from.
-  useEffect(() => {
-    if (!pendingRedirect) return;
-    const timer = setTimeout(() => {
-      window.location.href = pendingRedirect.url;
-    }, pendingRedirect.delayMs);
-    return () => clearTimeout(timer);
-  }, [pendingRedirect]);
+  // handler); nothing downstream re-judges a URL, and the seam is never a route
+  // around that verdict. What the hook owns is the wait — unmounting, or
+  // dropping the destination, cancels it (objectui#5049) — and the arm split
+  // objectui#5112 added on top of it: an app-relative destination goes through
+  // the host's injected navigate when a host supplied one, so a mounted host
+  // keeps the submitter inside the application, while an external destination
+  // admitted by `allowedRedirectHosts` stays a browser-level navigation
+  // unconditionally.
+  useThankYouRedirectNavigation(pendingRedirect);
 
   const honeypotName = config.honeypot === false ? null : config.honeypot || DEFAULT_HONEYPOT_NAME;
   const minFillTime = config.minFillTime ?? DEFAULT_MIN_FILL_MS;

--- a/packages/plugin-form/src/thankYouRedirectNavigation.ts
+++ b/packages/plugin-form/src/thankYouRedirectNavigation.ts
@@ -1,0 +1,170 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * WHO travels to an ACCEPTED `thankYouPage.redirectUrl` — objectui#5112, the
+ * mount-blindness of `EmbeddableForm`'s thank-you redirect.
+ *
+ * `EmbeddableForm.isRedirectUrlSafe` answers WHETHER a destination may be
+ * followed. This module answers who performs the navigation, and it is a
+ * separate question for the reason objectui#4989 defect 4 established: a rooted
+ * path such as `/thanks` handed to a browser-level navigation resolves against
+ * the ORIGIN root, so under a host mounted at a sub-path (the framework CLI
+ * configures one for every embedded deployment; the console runs at basename
+ * `/_console`) a same-origin in-app destination leaves the application. Only the
+ * host knows its mount, and it offers its mount-aware navigate through
+ * `HostNavigationContext` (`@object-ui/react`, landed by PR #5111).
+ *
+ * ## Why this is a sibling of `submitRedirectNavigation.ts` and not a call into it
+ *
+ * That module serves `submitBehavior.url`, whose accepted set objectstack#7496
+ * ruled **relative-only**: every destination it ever holds is already in-app, so
+ * it hands the seam whatever it was given. This key is deliberately more
+ * permissive — same-origin OR a host in the author's `allowedRedirectHosts`
+ * allowlist — because a public form's thank-you page is often a real external
+ * marketing page. So this key needs an arm the other one does not have, and
+ * putting that arm inside the shared hook would make every `submitBehavior`
+ * consumer carry a branch its contract can never reach. The acceptance set
+ * itself is untouched here (objectui#5112 is explicitly not the card that
+ * revisits it, and objectstack#7496's relative-only rule is NOT imported onto
+ * this key).
+ *
+ * ## The arm split, and the invariant it buys
+ *
+ * - **an app-relative destination** goes through the host's navigate when a
+ *   host supplied one, and falls back to today's browser navigation when none
+ *   was supplied;
+ * - **anything else** — an external destination admitted by the allowlist, and
+ *   equally an ABSOLUTE same-origin URL the author spelled out in full — keeps
+ *   browser-level navigation unconditionally.
+ *
+ * The second arm is not a conservatism, it is the seam's own declared input
+ * contract: `HostNavigationValue.navigate` documents `to` as "an already-resolved,
+ * application-relative path, never an absolute URL: a renderer that holds an
+ * external destination must not launder it through the host's router". A host
+ * navigate is a client-side router transition; an absolute URL is not a path a
+ * router can match, and a cross-origin one is not the router's to attempt at
+ * all. So the discriminant is the seam's admission rule restated as a predicate
+ * on the string, which yields the invariant worth stating out loud and pinning:
+ * **the host seam can never be handed a cross-origin URL**, because a relative
+ * reference cannot carry an authority (RFC 3986) and therefore always resolves
+ * to the base's origin.
+ *
+ * An absolute same-origin URL landing in the browser arm is a deliberate call,
+ * not an oversight. It is the one destination shape the card's two named arms do
+ * not cover, and routing it through the seam would mean this package rewriting
+ * `https://forms.example/thanks` into `/thanks` for a router that would then
+ * place it at `/_console/thanks` — a DIFFERENT address from the one the author
+ * wrote. An author who spelled the whole address asked for that address; the
+ * mount-blindness this card fixes is the one where the author wrote no origin at
+ * all and had no way to express the mount.
+ *
+ * ## Absent seam is not a degraded mode
+ *
+ * With no provider the behaviour is byte-for-byte what it was: one
+ * `window.location.href` assignment of the authored destination after the
+ * declared delay. A host with no router has no basename, so origin-rooted
+ * resolution is already correct there.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useHostNavigation } from '@object-ui/react';
+
+/**
+ * An accepted thank-you destination plus the delay declared with it, captured at
+ * the moment the write was accepted (objectui#5049) — see the state's own
+ * comment in `EmbeddableForm`.
+ */
+export interface PendingThankYouRedirect {
+  url: string;
+  delayMs: number;
+}
+
+/**
+ * Two bases that share nothing but their scheme. A relative reference takes its
+ * authority from whichever base it is resolved against; anything carrying its
+ * own scheme or its own authority ignores the base and answers the same origin
+ * for both. `.invalid` is reserved by RFC 2606, so neither can collide with a
+ * real deployment origin, and comparing against BOTH means an author who
+ * literally writes one of these sentinels is still classified as absolute.
+ */
+const PROBE_BASE_A = 'https://a.invalid/';
+const PROBE_BASE_B = 'https://b.invalid/';
+
+/**
+ * Is `rawUrl` an application-relative reference — i.e. a destination the host's
+ * router can be asked to place?
+ *
+ * True for `/thanks`, `thanks`, `?ok=1`, `#done`. False for `https://x/y`,
+ * `//x/y` (protocol-relative carries an authority), `javascript:…`, and for a
+ * same-origin ABSOLUTE URL — see the module docblock for why that last one is
+ * deliberate.
+ *
+ * The question is answered by the URL parser rather than by a hand-written
+ * scheme grammar, so leading whitespace and C0 controls are handled exactly the
+ * way the parser handles them and there is no second spelling of RFC 3986 in
+ * this repo to drift from the first.
+ *
+ * This predicate does NOT judge whether a destination may be followed —
+ * `isRedirectUrlSafe` already did that, and this runs only on values it
+ * accepted. It picks who travels, nothing more.
+ */
+export function isAppRelativeDestination(rawUrl: string): boolean {
+  try {
+    return (
+      new URL(rawUrl, PROBE_BASE_A).origin === 'https://a.invalid'
+      && new URL(rawUrl, PROBE_BASE_B).origin === 'https://b.invalid'
+    );
+  } catch {
+    // Unparseable against any base is not a path a router can place. It is also
+    // already refused upstream, so this is a fail-closed default rather than a
+    // reachable branch.
+    return false;
+  }
+}
+
+/**
+ * Own the delayed leg of an accepted thank-you redirect: wait the declared
+ * `delayMs`, then travel to `pending.url` through the host's navigate if one was
+ * injected AND the destination is app-relative, else through
+ * `window.location.href`.
+ *
+ * Unmounting, or dropping the destination, cancels the wait — the property
+ * objectui#5049 bought, preserved here unchanged: this hook is the effect
+ * `EmbeddableForm` used to declare inline, with the seam added and nothing else
+ * moved.
+ *
+ * Pass `null` when nothing is pending.
+ */
+export function useThankYouRedirectNavigation(pending: PendingThankYouRedirect | null): void {
+  const { navigate: hostNavigate } = useHostNavigation();
+
+  // Latest-wins ref, so the injected function's IDENTITY is not a dependency of
+  // the wait below. A host that rebuilds its callback each render (the ordinary
+  // shape of an inline arrow in JSX) would otherwise re-run that effect on every
+  // parent re-render, and its cleanup would restart the declared pause under the
+  // submitter — the same "the wait must not be restartable mid-flight" property
+  // the captured `delayMs` protects on the other side. Same reasoning, same
+  // shape, as `submitRedirectNavigation.ts`.
+  const hostNavigateRef = useRef(hostNavigate);
+  useEffect(() => {
+    hostNavigateRef.current = hostNavigate;
+  }, [hostNavigate]);
+
+  useEffect(() => {
+    if (!pending) return;
+    const timer = setTimeout(() => {
+      // Read at fire time, not at arm time: a host that mounts its provider
+      // asynchronously (auth/router settling) still gets its navigate used, and
+      // a seam that goes away mid-wait falls back rather than calling a stale
+      // closure.
+      const navigate = isAppRelativeDestination(pending.url) ? hostNavigateRef.current : undefined;
+      if (navigate) {
+        navigate(pending.url);
+        return;
+      }
+      window.location.href = pending.url;
+    }, pending.delayMs);
+    return () => clearTimeout(timer);
+  }, [pending]);
+}


### PR DESCRIPTION
Fixes #5112

## 问题

`EmbeddableForm` 的致谢重定向落在一句无条件的浏览器级导航上（`EmbeddableForm.tsx`,
`window.location.href = pendingRedirect.url`）。这对本键**故意放行**的外部目的地是对的，
对它**同样放行**的 in-app 目的地是错的：`isRedirectUrlSafe` 的第一臂
（`new URL(rawUrl, window.location.href)` 后 `url.origin === window.location.origin`）
放行相对路径 `/thanks`，而 `location.href` 把 rooted path 解析到 **origin 根**。于是在
挂载于子路径的 host 下（framework CLI 为每个 embedded 部署都配一个；console 跑在
basename `/_console`），提交者被送出应用，通常落到 host 自己的 404。两侧授权都合法、
哪里都不报错，所以失败是静默的。

这就是 objectui#4989 defect 4 的同形，落在那张卡明确未覆盖的键上；修它所需的 seam
（`HostNavigationContext`,`@object-ui/react`）已由 PR #5111 落地。

## 改动

新增 `packages/plugin-form/src/thankYouRedirectNavigation.ts`，把「谁去执行导航」按目的地
形态拆臂，`EmbeddableForm` 原来的内联 effect 换成这个 hook：

- **app-relative 目的地**（`/thanks`、`thanks`、`?ok=1`、`#done`）：host 提供了 navigate
  就走 seam，挂载的 host 因此把它放进自己的 mount；**没有 supplier 时逐字节保持原行为**
  —— 无 router 的 host 没有 basename，origin 根解析本来就是对的。
- **外部目的地**（由 `allowedRedirectHosts` 放行的跨源）：**无条件**保持浏览器级导航。

第二臂不是保守，而是 seam 自己声明的入参契约：`HostNavigationValue.navigate` 写明 `to` 是
"an already-resolved, application-relative path, never an absolute URL"。host navigate 是
客户端 router 跳转，跨源地址不是它该尝试的东西。

### 相对 vs 外部的判据（出处与钉子）

判据即 seam 入参契约在字符串上的复述：**目的地是不是 relative reference**。实现不手写
scheme 文法，交给 URL parser 判——同一个字符串对两个不同 base（`https://a.invalid/` /
`https://b.invalid/`）解析，各自回到各自 base 的 origin 才算相对；自带 scheme 或自带
authority（含 protocol-relative `//host/x`）会忽略 base，两次得到同一个 origin。

由此得到一条**结构性**不变量，已单独钉住：**host seam 永远不可能拿到跨源 URL** —— 相对
引用按 RFC 3986 无法携带 authority，必然解析回 base 的 origin。

同源**绝对** URL 是两条命名臂都没覆盖的第三种形态，本 PR 把它归入浏览器导航，并写明这是
主动裁决而非遗漏：把它送进 seam 意味着本包把作者写全的地址改写成路径、再由挂载 router 放到
**另一个**地址上；作者写全了地址就是要那个地址。本卡要修的是「作者根本没写 origin、也没有
途径表达 mount」的那种失明。

### 明确不动

`isRedirectUrlSafe` 与 `allowedRedirectHosts`（**哪些**目的地被放行）原样未动：准入集
（same-origin OR 作者 allowlist）是这个键自己的契约，不是本卡的；objectstack#7496 的
relative-only 规则留在 `submitBehavior.url` 上，没有被引到这个键。被拒的目的地既到不了
seam 也到不了浏览器。#5049 的等待归属与 #5073 的面板文案原样保留：unmount 与
「Submit Another Response」照旧取消在途重定向，有无 seam 皆然。

## 验证

新增 `EmbeddableForm.redirectHostNavigation.test.tsx`（14 例），四钉齐备：相对 + seam ⇒
host navigate 收到且浏览器未导航；相对 + 无 seam ⇒ 回落现行为；外部 allowlist + seam ⇒
仍浏览器导航且 seam 未被调用；`isRedirectUrlSafe` 判决集重新测量不变。另含挂载放置演示、
latest-wins navigate、unmount 取消、不缩短声明等待、同源绝对 URL 走浏览器臂、被拒目的地
两侧皆不到达。

```
pnpm exec vitest run packages/plugin-form --maxWorkers=2
  Test Files  55 passed (55)
       Tests  571 passed (571)

pnpm --filter @object-ui/plugin-form type-check   # 绿（需先 build 依赖，见下）
pnpm --filter @object-ui/plugin-form lint         # 0 errors
node scripts/check-control-bytes.mjs              # OK
```

注：全新 worktree 里 `type-check` 先报一批 `TS2307 Cannot find module '@object-ui/*'`
（`submitRedirectNavigation.ts` 这类未改文件同样报），是 dist 尚未构建所致；
`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-form^...' build` 之后全绿。

### 反向验证（先预判，后测量）

预判：把执行点还原成无条件 `window.location.href = url`（删掉整个 seam 读），**恰好**三例
转红——即断言 host navigate 收到目的地的那三例；其余 11 例与三个同文件既有测试套件全绿，
因为它们描述的是本来就正确、且本 PR 刻意未改的行为。

实测一致：

```
❯ EmbeddableForm.redirectHostNavigation.test.tsx (14 tests | 3 failed)
   × goes to the host navigate, and the browser navigates nowhere
   × lets a mounted host place the destination inside its mount
   × uses the LATEST injected navigate, exactly once, when the host rebuilds it
 Test Files  1 failed | 3 passed (4)
      Tests  3 failed | 39 passed (42)
```

已 `git checkout --` 还原。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_