### PR TITLE
fix(plugin-map): 顶层 `style` 是内联 CSS,不再被当作 MapLibre style 读 (#5017)

### DIFF
--- a/.changeset/map-top-level-style-is-css-not-a-map-style.md
+++ b/.changeset/map-top-level-style-is-css-not-a-map-style.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/plugin-map': patch
+---
+
+A map node's top-level `style` is inline CSS again, not a MapLibre style URL.
+
+`ObjectMap.getMapConfig` resolved the map style from three spellings with the
+top-level `style` FIRST — `schema.style || schema.mapStyle || schema.map?.style`
+— but `style` is `BaseSchema.style`, a record of inline CSS properties that
+every schema node may legally carry. Writing the base face's own
+`style: { height: '400px' }` on a map node therefore handed that object to
+MapGL's `mapStyle` prop: it never passed the config `safeParse` (which only ever
+looked at `schema.map`), so there was no validation and no diagnostic either.
+
+`@object-ui/types` had already named the map's key `mapStyle` — explicitly "not
+`style`, to avoid colliding with `BaseSchema.style`" — so the consumer was
+reading, at top priority, the very name the declaration went out of its way to
+avoid. The declaration is now what is enforced: the map style comes from
+`mapStyle` on the schema or `style` inside the declared `map` block, and a
+top-level `style` is not consumed as a map style in any shape.
+
+Behaviour change, stated because it is one: a map configured through a top-level
+`style` URL now renders with the default public demo tiles. That spelling was
+never documented (the README teaches `map.style`) and no metadata in this repo
+used it, but it was runtime-reachable one way — `ObjectView` / `ListView`
+flatten `options.map`'s CONTENTS to the top level, so a view authored with
+`map: { style: '<url>' }` arrived here as a top-level string. That shape is not
+spec-authorable (`@objectstack/spec`'s list-view schemas are strict and declare
+no `map` block at all, so such a view fails validation outright), and it now
+gets a dev warning naming both surviving spellings rather than silently painting
+the demo tiles. The object form gets no warning: legal base-face authoring, and
+dropping it is the fix.

--- a/packages/plugin-map/src/ObjectMap.styleFallback.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.styleFallback.test.tsx
@@ -36,10 +36,16 @@ vi.mock('react-map-gl/maplibre', () => ({
 const mockData = [{ id: '1', name: 'Loc 1', latitude: 40, longitude: -74 }];
 
 describe('ObjectMap — style/load-failure fallback', () => {
+  // Spelled `mapStyle`, not `style`: this case pre-dates the naming and used the
+  // top-level `style` leg, which objectui#5017 deleted (it is `BaseSchema.style`,
+  // inline CSS). The behaviour under test — a configured style beats the public
+  // demo default — is unchanged and its assertion is untouched; only the key it
+  // is configured with moved to the declared name. The deleted leg's own verdict
+  // is pinned in `ObjectMap.topLevelStyle.test.tsx`.
   it('uses the configured style over the public demo default', async () => {
     const schema: any = {
       type: 'map',
-      style: 'https://tiles.example.com/style.json',
+      mapStyle: 'https://tiles.example.com/style.json',
       map: { latitudeField: 'latitude', longitudeField: 'longitude', titleField: 'name' },
       data: { provider: 'value', items: mockData },
     };

--- a/packages/plugin-map/src/ObjectMap.topLevelStyle.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.topLevelStyle.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `BaseSchema.style` is inline CSS and NEVER a MapLibre style (objectui#5017).
+ *
+ * `getMapConfig` used to resolve the map style from three spellings with the
+ * top-level `style` FIRST:
+ *
+ *     (schema as any).style || schema.mapStyle || schema.map?.style
+ *
+ * `style` is declared on the base face as a record of CSS properties
+ * (`packages/types/src/zod/base.zod.ts`), which every node may legally carry, so
+ * `style: { height: '400px' }` on a map node was handed to MapGL's `mapStyle`
+ * prop — unvalidated (the `safeParse` only ever looked at `schema.map`) and
+ * undiagnosed. `@object-ui/types` had already named the map's key `mapStyle`
+ * (NOT `style`) to avoid precisely this collision, so the consumer was
+ * contradicting the declaration it was named after.
+ *
+ * What this file pins is the invariant, not the implementation: a CSS-meaning
+ * `style` is never consumed as a map style. That survives whatever
+ * canonicalization objectui#5018's follow-ups settle on, because it is a
+ * statement about the OTHER key.
+ *
+ * The string half matters just as much and is easy to lose: `ObjectView` /
+ * `ListView` flatten `options.map`'s CONTENTS to the top level, so a view
+ * authored with `map: { style: '<url>' }` reaches this component as a top-level
+ * STRING `style`. That shape is not spec-authorable — `@objectstack/spec@17`'s
+ * list-view schemas are strict and declare no `map` block at all, so a view
+ * carrying one fails validation with `unrecognized_keys` — but it IS
+ * runtime-reachable, which is why it gets a dev diagnostic rather than silence.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ObjectMap } from './ObjectMap';
+
+let capturedProps: any = null;
+
+vi.mock('react-map-gl/maplibre', () => ({
+  default: (props: any) => {
+    capturedProps = props;
+    return <div aria-label="Map">{props.children}</div>;
+  },
+  Map: ({ children }: any) => <div aria-label="Map">{children}</div>,
+  NavigationControl: () => <div data-testid="nav-control" />,
+  Marker: ({ children }: any) => <div data-testid="map-marker">{children}</div>,
+  Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
+}));
+
+const DEMO_STYLE = 'https://demotiles.maplibre.org/style.json';
+const mockData = [{ id: '1', name: 'Loc 1', latitude: 40, longitude: -74 }];
+const DECLARED_MAP = {
+  latitudeField: 'latitude',
+  longitudeField: 'longitude',
+  titleField: 'name',
+};
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  capturedProps = null;
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+async function renderMap(schema: any) {
+  render(<ObjectMap schema={schema} />);
+  await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+}
+
+/** The warnings this file cares about, one string per call. */
+function styleWarnings(): string[] {
+  return (warnSpy.mock.calls as unknown[][])
+    .map((args): string => String(args[0]))
+    .filter((msg: string) => msg.includes('objectui#5017'));
+}
+
+describe('ObjectMap — top-level `style` is inline CSS, not a map style (objectui#5017)', () => {
+  it('never hands a CSS-meaning `style` object to MapGL', async () => {
+    await renderMap({
+      type: 'map',
+      // Legal `BaseSchema.style`: a record of CSS properties. Every node may
+      // carry it. Before #5017 this exact object became MapGL's `mapStyle`.
+      style: { height: '400px', border: '1px solid red' },
+      map: DECLARED_MAP,
+      data: { provider: 'value', items: mockData },
+    });
+
+    expect(capturedProps.mapStyle).toBe(DEMO_STYLE);
+    expect(typeof capturedProps.mapStyle).toBe('string');
+  });
+
+  it('does not let a CSS-meaning `style` outrank the declared `mapStyle`', async () => {
+    await renderMap({
+      type: 'map',
+      style: { height: '400px' },
+      mapStyle: 'https://tiles.example.com/style.json',
+      map: DECLARED_MAP,
+      data: { provider: 'value', items: mockData },
+    });
+
+    expect(capturedProps.mapStyle).toBe('https://tiles.example.com/style.json');
+  });
+
+  it('does not let a CSS-meaning `style` outrank the declared `map.style`', async () => {
+    await renderMap({
+      type: 'map',
+      style: { height: '400px' },
+      map: { ...DECLARED_MAP, style: 'https://tiles.example.com/style.json' },
+      data: { provider: 'value', items: mockData },
+    });
+
+    expect(capturedProps.mapStyle).toBe('https://tiles.example.com/style.json');
+  });
+
+  it('says nothing about a legal inline-CSS `style` — dropping it IS the fix', async () => {
+    await renderMap({
+      type: 'map',
+      style: { height: '400px' },
+      map: DECLARED_MAP,
+      data: { provider: 'value', items: mockData },
+    });
+
+    expect(styleWarnings()).toEqual([]);
+  });
+
+  it('drops a top-level STRING `style` and says so, naming both declared spellings', async () => {
+    await renderMap({
+      type: 'map',
+      style: 'https://tiles.example.com/style.json',
+      map: DECLARED_MAP,
+      data: { provider: 'value', items: mockData },
+    });
+
+    expect(capturedProps.mapStyle).toBe(DEMO_STYLE);
+
+    const warnings = styleWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('https://tiles.example.com/style.json');
+    expect(warnings[0]).toContain('mapStyle');
+    expect(warnings[0]).toContain('map: { style:');
+  });
+
+  it('warns once per distinct dropped URL, not once per render', async () => {
+    const schema = {
+      type: 'map',
+      style: 'https://repeat.example.com/style.json',
+      map: DECLARED_MAP,
+      data: { provider: 'value', items: mockData },
+    };
+    await renderMap(schema);
+    await renderMap(schema);
+
+    expect(styleWarnings()).toHaveLength(1);
+  });
+
+  it('leaves the two declared spellings untouched', async () => {
+    await renderMap({
+      type: 'map',
+      mapStyle: 'https://top.example.com/style.json',
+      map: DECLARED_MAP,
+      data: { provider: 'value', items: mockData },
+    });
+    expect(capturedProps.mapStyle).toBe('https://top.example.com/style.json');
+
+    await renderMap({
+      type: 'map',
+      map: { ...DECLARED_MAP, style: 'https://block.example.com/style.json' },
+      data: { provider: 'value', items: mockData },
+    });
+    expect(capturedProps.mapStyle).toBe('https://block.example.com/style.json');
+  });
+});
+
+/**
+ * The producer-side shape, pinned on the consumer side.
+ *
+ * `ObjectView.generateViewSchema('map')` / `ListView`'s `case 'map'` build their
+ * `object-map` schema as `{ type: 'object-map', ...baseProps, locationField,
+ * ...(options.map || {}) }` — the CONTENTS of the `map` block at the top level
+ * and no `map` key at all. That product shape is pinned at the producer by
+ * `plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx` (objectui#5018);
+ * measured against this branch it flattens `map: { style: '<url>' }` into a
+ * top-level string `style`, and `map: { mapStyle: '<url>' }` into a top-level
+ * `mapStyle`.
+ *
+ * So this describe block feeds those two literal products to the consumer. It is
+ * the half the producer's pin cannot state: what the flattened key MEANS once it
+ * arrives. Without it, #5017's deletion looks like a pure subtraction with no
+ * reachable caller — it is not; the caller is spec-invalid, not absent.
+ */
+describe('ObjectMap — the ObjectView/ListView flatten product (objectui#5017)', () => {
+  it('ignores the `style` a flattened `map: { style }` lands at the top level', async () => {
+    await renderMap({
+      type: 'object-map',
+      objectName: 'store',
+      className: 'h-full w-full',
+      locationField: 'location',
+      latitudeField: 'latitude',
+      longitudeField: 'longitude',
+      // `...(options.map || {})` put the block's `style` here.
+      style: 'https://flattened.example.com/style.json',
+      data: { provider: 'value', items: mockData },
+    });
+
+    expect(capturedProps.mapStyle).toBe(DEMO_STYLE);
+    expect(styleWarnings()).toHaveLength(1);
+    expect(styleWarnings()[0]).toContain('options.map` is FLATTENED');
+  });
+
+  it('honours the flattened `mapStyle`, which is the spelling that survives', async () => {
+    await renderMap({
+      type: 'object-map',
+      objectName: 'store',
+      className: 'h-full w-full',
+      locationField: 'location',
+      latitudeField: 'latitude',
+      longitudeField: 'longitude',
+      // `map: { mapStyle: '<url>' }` on the view flattens to exactly this.
+      mapStyle: 'https://flattened.example.com/style.json',
+      data: { provider: 'value', items: mockData },
+    });
+
+    expect(capturedProps.mapStyle).toBe('https://flattened.example.com/style.json');
+    expect(styleWarnings()).toEqual([]);
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -186,6 +186,62 @@ function warnOnLegacyFilterMapConfig(schema: MapConfigSource): void {
 }
 
 /**
+ * Warn once per distinct dropped URL, for the same reason the diagnostics
+ * around it warn once: this runs on every render of the map.
+ */
+const warnedTopLevelStyleUrls = new Set<string>();
+
+/**
+ * Top-level `style` is `BaseSchema.style` — inline CSS — and is NOT a map style
+ * (objectui#5017).
+ *
+ * `getMapConfig` used to read it FIRST, ahead of both declared spellings, so a
+ * map node carrying the base face's own `style: { height: '400px' }` handed that
+ * object to MapGL's `mapStyle` prop: no validation, no diagnostic, and a
+ * collision `@object-ui/types` had already gone out of its way to avoid — it
+ * named the key `mapStyle` (not `style`) for exactly this reason
+ * (`objectql.ts`, `ObjectMapSchema.mapStyle`). The consumer contradicted the
+ * declaration it was named after; that read is gone.
+ *
+ * The OBJECT form needs no diagnostic: it is legal base-face authoring, and
+ * dropping it is the fix. The STRING form does, because it is the one shape
+ * that used to work:
+ * - `ObjectView` / `ListView` build an `object-map` schema by spreading the
+ *   CONTENTS of `options.map` at the top level (see `FlatMapConfigKeys`), so a
+ *   view authored with `map: { style: '<url>' }` arrives here as a top-level
+ *   STRING `style` — the flatten crosses the two keys' namespaces. That shape
+ *   is not spec-authorable (`@objectstack/spec`'s list-view schemas are strict
+ *   and declare no `map` block at all), but it is runtime-reachable, so say
+ *   what happened instead of silently painting the demo tiles.
+ * - A string is not valid `BaseSchema.style` either (that is a record), so a
+ *   string here is unambiguously "the author meant a map style" — there is no
+ *   legitimate CSS reading to mistake it for.
+ */
+function warnOnTopLevelStyleUrl(schema: MapConfigSource): void {
+  if (!isDev()) return;
+
+  // Re-tested at runtime rather than trusted from the declaration: the
+  // declaration says this key is a CSS record, and the shape this probe exists
+  // for is precisely the one that violates it.
+  const raw: unknown = schema.style;
+  if (typeof raw !== 'string' || raw === '') return;
+
+  const memo = `${schema.type ?? 'map'}::${schema.objectName ?? ''}::${raw}`;
+  if (warnedTopLevelStyleUrls.has(memo)) return;
+  warnedTopLevelStyleUrls.add(memo);
+
+  console.warn(
+    '[ObjectMap] A top-level `style` is NOT read as a map style, so this map is rendering with ' +
+      `the DEFAULT public demo tiles and \`${raw}\` was dropped. \`style\` is the base schema's ` +
+      'INLINE CSS key (a record of CSS properties), which every node may carry; the map style is ' +
+      '`mapStyle` — named that way precisely to avoid this collision. Write `mapStyle: ' +
+      `'${raw}'\` at the top level, or \`map: { style: '${raw}' }\` in the declared config block. ` +
+      'On a view, note that `options.map` is FLATTENED into the top level, so its `style` lands ' +
+      'here as this same top-level key — spell it `map: { mapStyle }` there. objectui#5017.',
+  );
+}
+
+/**
  * Warn once per distinct shadowing, for the same reason `getMapConfig` warns
  * once per legacy stash: this runs on every render of the map.
  */
@@ -238,16 +294,18 @@ function warnOnShadowedFlatMapKeys(schema: MapConfigSource): void {
  */
 function getMapConfig(schema: MapConfigSource): ObjectMapConfig {
   warnOnLegacyFilterMapConfig(schema);
+  warnOnTopLevelStyleUrl(schema);
 
   // A custom style may be set alongside any of the shapes below — read it
   // once so every return path can carry it through.
   //
-  // `BaseSchema.style` is an inline-CSS object, not a MapLibre style URL: that
-  // collision is objectui#5017's to rule, and this read deliberately keeps its
-  // exact pre-#5018 runtime behaviour, cast and all, rather than settling it
-  // here.
-  const style: string | undefined =
-    (schema.style as unknown as string | undefined) || schema.mapStyle || schema.map?.style;
+  // The two DECLARED spellings, and only those: `mapStyle` on the schema
+  // (`ObjectMapSchema.mapStyle`) and `style` inside the declared config block
+  // (`ObjectMapConfig.style`). The top-level `style` this used to read first is
+  // `BaseSchema.style` — inline CSS, a different key with a different meaning —
+  // and is no longer consumed here at all (objectui#5017; see
+  // `warnOnTopLevelStyleUrl`).
+  const style: string | undefined = schema.mapStyle || schema.map?.style;
 
   // 1. The declared configuration input: `{ name: 'map', type: 'object' }` at
   // the `object-map` / `map` registrations. The author face, and the winner


### PR DESCRIPTION
Fixes #5017

基线 `7956b9c25`(含 PR #5156 的 `578e02516`)。按分诊评论 5317411990 的 **option 1** 实施:删掉 `schema.style` 那一腿,保留 `mapStyle` 与 `map.style`。

## 改了什么

`getMapConfig` 原先按三个拼法取地图样式,顶层 `style` 排最前:

```ts
const style = schema.style || schema.mapStyle || schema.map?.style;
```

但 `style` 是 `BaseSchema.style` —— 内联 CSS 属性记录(`packages/types/src/zod/base.zod.ts`),每个 schema 节点都可以合法携带。于是 map 节点上一句基面自己的 `style: { height: '400px' }`,这个对象就被交给 MapGL 的 `mapStyle` prop:它不经过配置的 `safeParse`(那次只看 `schema.map`),既无校验也无诊断。

`@object-ui/types` 早已为这件事改过名 —— `mapStyle`「not `style`, to avoid colliding with BaseSchema.style」—— 而消费端仍以最高优先级读那个被特意避开的名字。现在以声明为准:

```ts
const style: string | undefined = schema.mapStyle || schema.map?.style;
```

## 前置核验:摊平能不能把 `style` 送到顶层?(逐面实测,结论 = (b))

派发口径规定「任一面证实存在**受支持的授权路径** ⇒ 停下报 needs_decision,零删除」。三面都量了:

**spec 面 —— 拒。** 对 pinned `@objectstack/spec@17.0.0` 实跑 `safeParse`:`ObjectListViewSchema` / `ListViewSchema` 都是 strict,**根本没有声明 `map` 块**,连 `type: 'map'` 都不在枚举里,也没有 `options` 键:

```
ObjectListViewSchema shape has `options`: false
ObjectListViewSchema shape has `map`:     false
options.map.style  => REJECTED  [{"code":"unrecognized_keys","keys":["options"]}]
map.style (direct) => REJECTED  [{"code":"unrecognized_keys","keys":["map"]}]
`type` enum accepts "map"? false
```

而且这一面**未来也不会开**给 `style`:#5042 记录的 spec 侧新块 `ListMapConfigSchema`(objectstack#9340 / #9370,尚未进本仓 pinned spec)是 strict 的**七键** —— `latitudeField` / `longitudeField` / `locationField` / `titleField` / `descriptionField` / `zoom` / `center` —— **不含 `style`**。所以视图级 `map.style` 在 spec 面上现在不可授权、将来也不可授权。

**类型面 —— 不拒,但也不声明。** `NamedListView.options?: Record< string, any >`,`generateViewSchema` 返回 `any`,是个无类型口袋。反过来,PR #5156 落的**内部摊平形声明**明确把 `style` 排除在外:`type FlatMapConfigKeys = Omit< ObjectMapConfig, 'style' >`。

**运行时 —— 可达。** 按 PR #5156 新钉 `ObjectView.mapFlatten.test.tsx` 的手法写探测跑了一遍(探测文件已删,未入库;URL 占位一律写成实际用的字面量):

```
PROBE-A  views[].map = { style: 'https://tiles.example.com/style.json' }
         flatten product keys: [... ,"locationField","latitudeField","longitudeField","style"]
         top-level style: "https://tiles.example.com/style.json"   ← 可达
         has map key: false
PROBE-B  views[].map = { mapStyle: 'https://tiles.example.com/style.json' }
         top-level mapStyle: "https://tiles.example.com/style.json"  ← 仍然有效的拼法
         top-level style: undefined
PROBE-C  views[].options.map = { style }
         top-level style: undefined  (`views` prop 路径读的是 view 自身,不读其 options)
```

**结论 (b):类型面不拒但运行时可达,故仍动刀,并按口径给摊平运行时形补处置** —— 不是留一条宽容读腿(那正是 #5017 要拦的形状),而是:① dev warn-once 诊断,点名两个仍有效的拼法;② 在消费端钉住摊平产物的两种形。

## 摊平运行时形的处置

- **字符串形**才诊断:字符串不是合法的 `BaseSchema.style`(那是 record),所以顶层字符串 `style` 明确就是「作者想配地图样式」,没有第二种读法。诊断按 PR #5156 引入的 warn-once 惯用形写(每个 distinct URL 一次,`getMapConfig` 每帧都跑)。
- **对象形不诊断**:那是合法的基面写法,丢掉它正是本次修复本身 —— 对它报警会在每个写了 `style: { height }` 的地图上刷屏。(顺带说明:ObjectMap 本来也从不把 `schema.style` 贴到自己的根节点上,所以这次变的只是「不再被误读为地图样式」。)
- 视图侧的迁移写法是 `map: { mapStyle: 'https://tiles.example.com/style.json' }` —— 摊平后落成顶层 `mapStyle`,第二腿照读(PROBE-B 已证)。

## 钉子

新增 `packages/plugin-map/src/ObjectMap.topLevelStyle.test.tsx`(9 例),钉的是**不变量而非实现** ——「CSS 语义的 `style` 永不被当作地图样式消费」—— 该形状在 #5018 后续裁定落地后依然成立:

- CSS 对象形永不进 MapGL(落回 demo 默认),且不越过 `mapStyle` / `map.style`;
- 顶层字符串形被丢弃并诊断,warn-once;
- 合法 CSS 对象形**不**诊断;
- 两个声明拼法行为不变;
- 摊平产物两形:`style` 被忽略并诊断、`mapStyle` 生效 —— 这是生产端钉 `ObjectView.mapFlatten.test.tsx` 无法陈述的那一半(它钉产物形状,这里钉产物到达消费端后的语义)。

`ObjectMap.styleFallback.test.tsx` 首例原本用顶层 `style` 配置(写于 #2620,早于该命名之争),按 fixture 三分诊的「改拼法」一档改为 `mapStyle`,**断言一字未动**;`filterConfig` 系列未改。

## 反向验证(commit 后做,如实记录:书面预判漏了一例)

把删掉的腿加回链首、诊断保持原样,预判「恰好 3 例红」:CSS 对象形进 MapGL、顶层字符串被丢弃、摊平 `style` 被忽略。实测 **4 例红** —— 多出的一例是「CSS 语义 `style` 不越过声明的 `mapStyle`」。它在分析时判过红,写预判清单时漏抄了,不是行为意外;`matched=false` 如实记。

```
× never hands a CSS-meaning `style` object to MapGL
    expected { height: '400px', …(1) } to be 'https://demotiles.maplibre.org/style.…'
× does not let a CSS-meaning `style` outrank the declared `mapStyle`
    expected { height: '400px' } to be 'https://tiles.example.com/style.json'
× drops a top-level STRING `style` and says so, naming both declared spellings
    expected 'https://tiles.example.com/style.json' to be 'https://demotiles.maplibre.org/style.…'
× ignores the `style` a flattened `map: { style }` lands at the top level
    expected 'https://flattened.example.com/style.j…' to be 'https://demotiles.maplibre.org/style.…'
 Tests  4 failed | 21 passed (25)
```

预判为绿的都绿了,其中「CSS `style` 不越过 `map.style`」一例**对本次变更不敏感**(它靠 `config.style || style` 的次序保护,不靠删腿),照口径写明,免得被当成覆盖率。`git checkout --` 还原后全绿。

## 验证

```
pnpm exec vitest run packages/plugin-map/src packages/plugin-view/src --maxWorkers=2
  Test Files  21 passed (21)      Tests  175 passed (175)

pnpm --filter @object-ui/plugin-map --filter @object-ui/plugin-view type-check   → Done / Done
pnpm exec turbo run type-check --concurrency=2                                   → 81 successful, 81 total
node scripts/check-control-bytes.mjs      → OK (4582 tracked text files)
node scripts/check-changeset-presence.mjs → OK (1 changeset)
```

消费半径扫过一遍:仓内除 plugin-map 自己的测试外,无任何 fixture / metadata / 文档用顶层 `style` 配地图(README 教的是 `map.style`)。

## 半径

`packages/plugin-map/src/ObjectMap.tsx` + 测试 + changeset(`@object-ui/plugin-map` patch)。类型面零改动,故未动 types 包;未碰 ObjectView / ListView 摊平实现,未碰 PR #5156 刚落的声明面与优先级语义。