### PR TITLE
fix(plugin-map): correct residual "object/api/value" claim to "object/value"

### DIFF
--- a/.changeset/plugin-map-features-list-api-value-5163.md
+++ b/.changeset/plugin-map-features-list-api-value-5163.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/plugin-map": patch
+---
+
+Fix the two remaining `object/api/value` claims that objectui#5019 (PR #5162) left
+behind — its dispatch was scoped to only the "API Provider" section of
+`content/docs/plugins/plugin-map.mdx`, so the same false claim survived in the Features
+list and in the `ObjectMap.tsx` file-header JSDoc:
+
+- `content/docs/plugins/plugin-map.mdx:24` (Features list): "Works seamlessly with
+  object/api/value data providers" → "Works seamlessly with object/value data providers".
+- `packages/plugin-map/src/ObjectMap.tsx:20` (file-header JSDoc): "Works with
+  object/api/value data providers" → "Works with object/value data providers".
+
+`provider: 'api'` still hits `console.warn('API provider not yet implemented for
+ObjectMap')` and returns an empty record set (`ObjectMap.tsx:584`); `endpoint`/`method`
+have no read point in the package. Implementing the `api` provider is capability
+expansion and is explicitly out of scope here, same as it was for #5019.
+
+No runtime behaviour changes — a source comment and a docs line only.

--- a/content/docs/plugins/plugin-map.mdx
+++ b/content/docs/plugins/plugin-map.mdx
@@ -21,7 +21,7 @@ The `@object-ui/plugin-map` plugin provides map visualization for ObjectQL data 
 
 ## Features
 
-- **ObjectQL Integration**: Works seamlessly with object/api/value data providers
+- **ObjectQL Integration**: Works seamlessly with object/value data providers
 - **Automatic Field Mapping**: Maps database fields to map markers
 - **Location Support**: Handle latitude/longitude or combined location fields
 - **Marker Customization**: Configurable marker titles and descriptions

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -17,7 +17,7 @@
  * - Interactive map with markers
  * - Location-based data visualization
  * - Popup/tooltip on marker click
- * - Works with object/api/value data providers
+ * - Works with object/value data providers
  */
 
 import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';


### PR DESCRIPTION
Fixes #5163

## What

Two residual `object/api/value` claims corrected to `object/value`, left behind by
objectui#5019 (PR #5162) because that dispatch was scoped only to the "API Provider"
section of `content/docs/plugins/plugin-map.mdx`:

- `content/docs/plugins/plugin-map.mdx:24` (Features list) — "Works seamlessly with
  object/api/value data providers" → "Works seamlessly with object/value data providers".
- `packages/plugin-map/src/ObjectMap.tsx:20` (file-header JSDoc) — "Works with
  object/api/value data providers" → "Works with object/value data providers".

`provider: 'api'` still hits `console.warn('API provider not yet implemented for
ObjectMap')` and returns an empty record set (`ObjectMap.tsx:584` on current `main`;
the issue's `:475` is stale — PR #5156 and PR #5175 pushed it down); `endpoint`/`method`
have zero read points anywhere in `packages/plugin-map/src`. Implementing the `api`
provider is capability expansion and is explicitly **not** proposed here, same scope
line #5163 draws.

## Scope discipline

`object/api/value` appears at 7 sites repo-wide; this PR touches exactly the 2 that are
plugin-map's. The other 5 were checked and are **not** the same defect:

- `plugin-calendar` (3 sites) — same false claim, same stub shape. Out of this PR's
  surface; filed separately as objectui#5180.
- `plugin-gantt` (2 sites) — the identical sentence, but there it is **true**:
  `provider: 'api'` is really implemented for gantt (`ObjectGantt.tsx:442-445`, `:1155`).
  Left untouched deliberately.

## Diff

Exactly 2 source/doc lines + 1 changeset. No reflow, no re-wrap.

## Gates run locally

- `node scripts/check-control-bytes.mjs` — pass (4591 tracked text files scanned).
- `node scripts/check-doc-links.mjs` — pass (13 scan roots, Internal Docs Link Check
  equivalent).
- `node scripts/check-doc-component-types.mjs` — pass (Doc Component Type Check
  equivalent).
- `node scripts/check-doc-snippet-types.mjs --build-filter` — plugin-map is absent from
  the derived build filter (no compiled `tsx` snippet imports `@object-ui/plugin-map`),
  so Doc Snippet Type Check is not exercised by this diff; confirmed rather than assumed.
- `pnpm turbo run build --filter='@object-ui/site' --concurrency=2` (Build Docs
  equivalent) — 29/29 tasks succeeded, including the edited `plugin-map.mdx` page.
- `pnpm --filter '@object-ui/plugin-map^...' build` then `pnpm --filter
  '@object-ui/plugin-map' build` — both succeed (built dependency closure before
  judging anything).
- `pnpm --filter '@object-ui/plugin-map' type-check` — pass (`tsc --noEmit && tsc -p
  tsconfig.test.json`).
- `pnpm exec vitest run packages/plugin-map/ --maxWorkers=2` (repo-root invocation,
  per AGENTS.md) — 9 test files / 61 tests passed.
- `node scripts/check-changeset-presence.mjs` — pass (1 changeset covers the 1 released
  source file changed).
- `node scripts/check-changeset-no-major.mjs` — pass.

Verified at `09c0a385c` (branch head, matches the commit this PR carries).

## Changeset

`.changeset/plugin-map-features-list-api-value-5163.md` — `@object-ui/plugin-map` patch.
A source-comment + docs correction still ships a changeset in this repo per AGENTS.md.

_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_