### PR TITLE
fix(app-shell): seed record_header recordIdParam from the URL record id during the page-record load window

### DIFF
--- a/.changeset/record-header-recordid-load-window-5176.md
+++ b/.changeset/record-header-recordid-load-window-5176.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Fix `record_header` actions dispatching without their record id while the record page is still loading.
+
+The record header does not wait for the page record: the skeleton's `isLoading`
+flag is cleared in a route-keyed microtask, but `pageRecord` only lands one
+`findOne` round-trip later, so the real header renders with every
+`record_header` action live for that whole window. An `api` action clicked
+inside it had no seed for its `recordIdParam` — the fallback chain stopped at
+`pageRecord` and never consulted the record id carried in the URL — so the
+request was dispatched naming no record and the backend rejected it with
+`missing_record_id`. Users saw a button that "did nothing until you clicked it
+again".
+
+The id the page is addressed by now seeds the parameter as a last resort, which
+is the same fallback this view's other dispatch paths already use. A stashed row
+and an explicit `recordId` override still take precedence, actions retargeting
+another object are still never handed this page's id, and an action keyed on a
+non-default `recordIdField` now takes a named refusal instead of emitting an
+under-specified request.

--- a/packages/app-shell/src/views/RecordDetailView.headerRecordIdLoadWindow.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.headerRecordIdLoadWindow.test.tsx
@@ -1,0 +1,402 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record_header` actions must carry the record id even while the page record
+ * is still being fetched (objectui#5176).
+ *
+ * The header is NOT gated on the record load. `isLoading` — the only state the
+ * `<SkeletonDetail>` early return reads — is flipped false in a `queueMicrotask`
+ * keyed on the route, while `pageRecord` arrives one `dataSource.findOne`
+ * round-trip later. So for the whole duration of that fetch the page renders its
+ * real header, with every `record_header` action live and clickable, and
+ * `pageRecord` still `null`.
+ *
+ * In that window the `type:'api'` handler's `recordIdParam` seeding used to have
+ * no source at all. Its fallback chain was row -> literal `recordId` override ->
+ * `pageRecord`, and it stopped there — it never consulted `pureRecordId`, the id
+ * this page is *addressed by*, which is read straight off the URL and is
+ * therefore available on the very first render. Handed a `null` seed record,
+ * `resolveRecordIdParamSeed` deliberately abstains (`{}` — no value, and no
+ * error, because "no row context" is not that guard's business), so the caller
+ * injected nothing, raised nothing, and dispatched anyway. What went out was a
+ * mutation naming no record, and the backend answered `missing_record_id`.
+ *
+ * That is the user-visible "click does nothing, click again and it works": the
+ * second click lands after the fetch settled. The reporter's one-to-one
+ * correlation with a differently-shaped header DOM is real but is a co-symptom,
+ * not the cause — the same unresolved `pageRecord` that starves the seed also
+ * withholds the title/highlights chrome that makes the header render differently.
+ *
+ * The three sibling dispatch paths in this file (the legacy `dataSource.update`
+ * default branch, the flow trigger, and the server-action bridge) all already
+ * fall back to `pureRecordId`. This pins the api path to the same source, and
+ * pins the one case the URL id cannot serve — a non-default `recordIdField` —
+ * to a refusal rather than an under-specified request.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const authFetchSpy = vi.fn(async () =>
+  new Response(JSON.stringify({ data: [] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }),
+);
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => authFetchSpy,
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => [],
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+vi.mock('../hooks/useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: vi.fn(async () => ({ success: true })),
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: vi.fn(async () => null),
+  }),
+}));
+
+vi.mock('../utils/consoleServerAction', () => ({
+  createConsoleServerActionHandler: () => vi.fn(async () => ({ success: true })),
+}));
+
+// Same capture posture as the sibling `recordIdParamSeed` pin — keep the real
+// provider, record every handler set it is handed. The discriminator differs
+// and that difference is the whole point of this file: the sibling waits for
+// the capture whose context carries the LOADED record, which by construction
+// sits after the window under test here.
+const captured: Array<{ handlers: Record<string, (action: any) => Promise<any>>; context: any }> = [];
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    ActionProvider: (props: any) => {
+      captured.push({ handlers: props.handlers, context: props.context });
+      return React.createElement(actual.ActionProvider as any, props);
+    },
+    SchemaRenderer: () => null,
+  };
+});
+
+import { MetadataCtx } from '@object-ui/react';
+import { RecordDetailView } from './RecordDetailView';
+
+const OBJECT_NAME = 'os_production_plan';
+const RECORD_ID = 'rec-plan-1';
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'Production Plan',
+    fields: {
+      id: { type: 'text', label: 'Id' },
+      name: { type: 'text', label: 'Name' },
+      code: { type: 'text', label: 'Code' },
+    },
+  },
+];
+
+const METADATA = {
+  objects: OBJECTS,
+  pages: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invalidate: () => {},
+  ensureType: async () => [],
+  getItem: async () => null,
+  getItemsByType: () => [],
+} as any;
+
+/**
+ * A data source whose `findOne` is held open until the test releases it. This
+ * is what makes the 1-in-10 timing report a deterministic case: the failure
+ * window is not sampled, it is held.
+ */
+function makeDeferredDataSource() {
+  let release!: (rec: unknown) => void;
+  const settled = new Promise<unknown>((resolve) => {
+    release = resolve;
+  });
+  const ds = {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(() => settled),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+  return { ds, release: () => release({ id: RECORD_ID, name: 'Plan A' }) };
+}
+
+/**
+ * The record page's own provider, captured WHILE the record load is still in
+ * flight: `context.objectName` identifies this page, and the absence of a
+ * record id in the context is precisely the half-loaded state
+ * (`record: pageRecord || {}`).
+ */
+function loadWindowCapture() {
+  return [...captured]
+    .reverse()
+    .find((c) => c.handlers && c.context?.objectName === OBJECT_NAME && !c.context?.record?.id);
+}
+
+async function mountMidLoadAndCaptureHandlers(ds: any) {
+  render(
+    <MemoryRouter initialEntries={[`/app/demo/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={METADATA}>
+        <RecordDetailView
+          dataSource={ds}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={RECORD_ID}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(loadWindowCapture()).toBeTruthy());
+  authFetchSpy.mockClear();
+  return loadWindowCapture()!;
+}
+
+beforeEach(() => {
+  cleanup();
+  captured.length = 0;
+  authFetchSpy.mockClear();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('RecordDetailView record_header actions during the page-record load window (objectui#5176)', () => {
+  it('the header renders live actions while the record is still loading', async () => {
+    // The premise the whole card rests on. If the header were gated on the
+    // record load there would be no window to dispatch in, and the reported
+    // failure would be unreachable.
+    const { ds } = makeDeferredDataSource();
+    const capture = await mountMidLoadAndCaptureHandlers(ds);
+
+    expect(ds.findOne).toHaveBeenCalled();
+    expect(typeof capture.handlers.api).toBe('function');
+    // Half-loaded by construction: the provider is up, the record is not.
+    expect(capture.context?.record?.id).toBeUndefined();
+  });
+
+  it('seeds recordIdParam from the URL record id when the page record has not resolved', async () => {
+    const { ds, release } = makeDeferredDataSource();
+    const { handlers } = await mountMidLoadAndCaptureHandlers(ds);
+
+    let r: any;
+    await act(async () => {
+      // A record_header action exactly as authored: no `_rowRecord` stash, no
+      // literal `recordId` override, `recordIdField` defaulting to `id`.
+      r = await handlers.api({
+        name: 'archive_plan',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/archive`,
+        recordIdParam: 'planId',
+      });
+    });
+
+    expect(r.success).toBe(true);
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    // The defect: this key was absent, and the request went out anyway.
+    expect(body).toMatchObject({ planId: RECORD_ID });
+
+    release();
+  });
+
+  it('injects identically before and after the record resolves', async () => {
+    // The triage floor's first limb, stated as one assertion: the two header
+    // render states are not allowed to disagree about the request body.
+    const { ds, release } = makeDeferredDataSource();
+    const { handlers: midLoadHandlers } = await mountMidLoadAndCaptureHandlers(ds);
+
+    const action = {
+      name: 'archive_plan',
+      type: 'api',
+      method: 'POST',
+      target: `/api/v1/data/${OBJECT_NAME}/archive`,
+      recordIdParam: 'planId',
+    };
+
+    await act(async () => {
+      await midLoadHandlers.api({ ...action });
+    });
+    const [, midInit] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    const midBody = JSON.parse(String(midInit.body));
+
+    authFetchSpy.mockClear();
+    await act(async () => {
+      release();
+    });
+    await waitFor(() =>
+      expect(
+        [...captured].reverse().find((c) => c.handlers && c.context?.record?.id === RECORD_ID),
+      ).toBeTruthy(),
+    );
+    const loadedHandlers = [...captured]
+      .reverse()
+      .find((c) => c.handlers && c.context?.record?.id === RECORD_ID)!.handlers;
+
+    await act(async () => {
+      await loadedHandlers.api({ ...action });
+    });
+    const [, loadedInit] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    const loadedBody = JSON.parse(String(loadedInit.body));
+
+    expect(midBody).toEqual(loadedBody);
+    expect(midBody).toMatchObject({ planId: RECORD_ID });
+  });
+
+  it('refuses rather than under-specifying when recordIdField names a field the URL id cannot supply', async () => {
+    // The floor's second limb, for the residue the first cannot cover: the URL
+    // carries the record's *id*, so an action keyed on some other field still
+    // has no seed mid-load. It must refuse — never emit the body-incomplete
+    // request this card is about.
+    const { ds, release } = makeDeferredDataSource();
+    const { handlers } = await mountMidLoadAndCaptureHandlers(ds);
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'link_code',
+        label: 'Link by Code',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/link`,
+        recordIdParam: 'targetCode',
+        recordIdField: 'code',
+      });
+    });
+
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('Link by Code');
+    expect(r.error).toContain('code');
+    expect(authFetchSpy).not.toHaveBeenCalled();
+
+    release();
+  });
+
+  it('still prefers a stashed row over the URL id', async () => {
+    // The new fallback is a LAST resort: it must not outrank the row a
+    // related-list dispatch stashes, which may name a different record.
+    const { ds, release } = makeDeferredDataSource();
+    const { handlers } = await mountMidLoadAndCaptureHandlers(ds);
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'archive_plan',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/archive`,
+        recordIdParam: 'planId',
+        params: { _rowRecord: { id: 'row-child-7' } },
+      });
+    });
+
+    expect(r.success).toBe(true);
+    const [, init] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({ planId: 'row-child-7' });
+
+    release();
+  });
+
+  it('still prefers a literal recordId override over the URL id', async () => {
+    const { ds, release } = makeDeferredDataSource();
+    const { handlers } = await mountMidLoadAndCaptureHandlers(ds);
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'archive_plan',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/archive`,
+        recordIdParam: 'planId',
+        recordId: 'explicit-plan-9',
+      } as any);
+    });
+
+    expect(r.success).toBe(true);
+    const [, init] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({ planId: 'explicit-plan-9' });
+
+    release();
+  });
+
+  it('does not seed this page id into an action retargeting another object', async () => {
+    // Same guard `interpolationRecord` uses: a child-object action must never
+    // be handed the parent page's id. Mid-load it has no seed, so it refuses.
+    const { ds, release } = makeDeferredDataSource();
+    const { handlers } = await mountMidLoadAndCaptureHandlers(ds);
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'archive_other',
+        label: 'Archive Other',
+        type: 'api',
+        method: 'POST',
+        objectName: 'other_object',
+        target: '/api/v1/data/other_object/archive',
+        recordIdParam: 'planId',
+        params: { _rowRecord: { name: 'no id here' } },
+      });
+    });
+
+    expect(r.success).toBe(false);
+    expect(authFetchSpy).not.toHaveBeenCalled();
+
+    release();
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -638,16 +638,42 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           // refusal only once every source has been tried, instead of the
           // silent drop this call site used to fall back to
           // (objectstack#8018, objectui#4669).
+          //
+          // objectui#5176 — the page-record fallback is not enough on its own,
+          // because the header does not wait for the page record. `isLoading`
+          // (the only state the <SkeletonDetail> early return reads) is flipped
+          // false in a route-keyed microtask, while `pageRecord` lands one
+          // `findOne` round-trip later; for that whole window the real header
+          // renders with every `record_header` action live. Clicking inside it
+          // seeded from `null`, which `resolveRecordIdParamSeed` deliberately
+          // abstains on (no value AND no error — "no row context" is not that
+          // guard's business), so the request went out naming no record and the
+          // backend answered `missing_record_id`. That is the reported "click
+          // does nothing, click again and it works".
+          //
+          // `pureRecordId` is the id this page is ADDRESSED by — read off the
+          // URL, present on the first render, and already the fallback the
+          // other three dispatch paths in this file use. Seeding a minimal row
+          // from it makes this path agree with them. It stays a LAST resort
+          // (row and override still outrank it) and keeps the same
+          // retarget guard `interpolationRecord` uses, so a child-object action
+          // is never handed the parent page's id. An action keyed on some other
+          // field via `recordIdField` gets a row without that key, which is the
+          // helper's named refusal — deliberately, since the URL carries the
+          // record's id and nothing else: refusing beats under-specifying.
           const recordIdOverride = (action as { recordId?: unknown }).recordId;
           const rowHasValue = !!rowRecord && rowRecord[rowField] != null;
           if (!rowHasValue && recordIdOverride != null) {
             body[action.recordIdParam] = recordIdOverride;
           } else {
+            const targetsThisRecord = !action.objectName || action.objectName === objectName;
+            const thisRecordSeed: Record<string, any> | undefined = targetsThisRecord
+              ? ((pageRecord as Record<string, any> | undefined)
+                  ?? (pureRecordId != null ? { id: pureRecordId } : undefined))
+              : undefined;
             const seedRecord: Record<string, any> | undefined = rowHasValue
               ? rowRecord
-              : ((!action.objectName || action.objectName === objectName
-                  ? (pageRecord as Record<string, any> | undefined)
-                  : undefined) ?? rowRecord);
+              : (thisRecordSeed ?? rowRecord);
             const seed = resolveRecordIdParamSeed(action, seedRecord);
             if (seed.error) return { success: false, error: seed.error };
             if (seed.value !== undefined) body[action.recordIdParam] = seed.value;


### PR DESCRIPTION
Fixes #5176

## Diagnosis (this was the deliverable, ahead of the patch)

The card's framing — "the header has two DOM variants, and only one of them injects" — does not survive contact with the source, but the reporter's measurement does. There is no second dispatch path and no second injection site. There is **one** path, and its seed value depends on when you click.

**Why a window exists at all.** The header is not gated on the record load. `isLoading` — the only state the SkeletonDetail early return reads — is flipped false in a route-keyed `queueMicrotask` (`RecordDetailView.tsx`, the effect keyed on `[objectName, recordId]`). `pageRecord` lands one `dataSource.findOne` round-trip later, in a separate effect with its own `pageRecordStatus`. Between those two moments the *real* header renders, with every `record_header` action live and clickable, and `pageRecord` still `null`. The window is not a rare hydration edge — it is the full duration of the record fetch, which is exactly why a user samples it about 1 click in 10.

**Why the request went out empty.** In the `type:'api'` handler the `recordIdParam` seeding chain was: stashed row -> literal `recordId` override -> `pageRecord`. It stopped there. It never consulted `pureRecordId`, the id the page is *addressed by*, which is read straight off the URL (`recordIdOverride ?? params.recordId`) and is therefore present on the very first render. Mid-load the chain resolves to `null`, and `resolveRecordIdParamSeed` **deliberately abstains** on a null row — returning neither a value nor an error, because "no row context at all" is documented as not that guard's business. So the call site injected nothing, raised nothing, and dispatched anyway. The body that went out was literally `{}`; the backend answered `missing_record_id`.

**The reporter's DOM correlation is real but is a co-symptom, not the cause.** The same unresolved `pageRecord` that starves the seed also withholds the title and highlights chrome, so the header genuinely renders a different shape in exactly the failing window. Correlation 1:1, causation neither direction — one condition produces both.

**The paths disagreed, and this one was the odd one out.** The three sibling dispatch paths in the same file all already fall back to `pureRecordId`: the legacy `dataSource.update` default branch, the flow trigger, and the server-action bridge. Only the api path did not.

## Which limb of the triage ruling, and why

The ruling allowed either "both variants inject identically" or "disable the action while the record id is unavailable". The measurement picks the first limb, and rules the second one out on the facts: **the record id is not unavailable.** It is in the URL, synchronously, before the first paint. Only the record *body* is pending. Disabling every header action for the whole duration of every record fetch would be a real UX regression imposed to work around an id the platform already holds. So this makes the paths agree instead.

The second limb still does the work the first cannot cover, and is pinned as such: an action naming a non-default `recordIdField` cannot be served by the URL (which carries the id and nothing else), so it now takes the helper's named refusal rather than emitting an under-specified request. Both halves of the acceptance floor are therefore satisfied, each where it actually applies.

## Change

One seeding site in `packages/app-shell/src/views/RecordDetailView.tsx`. A minimal row synthesized from `pureRecordId` becomes the **last** resort in the chain:

- a stashed row and an explicit `recordId` override still outrank it (pinned);
- the existing retarget guard is preserved verbatim, so a child-object action is never handed the parent page's id (pinned);
- a non-default `recordIdField` gets a row without that key and takes the named refusal (pinned).

No `as any` was added or broadened — the two type annotations in the diff are the ones already on the lines they replace.

## Tests

New sibling `RecordDetailView.headerRecordIdLoadWindow.test.tsx`. The 1-in-10 timing report is made deterministic by *holding* the window rather than sampling it: `findOne` returns a promise the test releases on demand, and the harness captures the ActionProvider handlers built while the record is still in flight. That discriminator is the point of the new file — the existing pin `RecordDetailView.recordIdParamSeed.test.tsx` waits for the capture whose context carries the **loaded** record, which by construction sits after the failure window, which is why it never caught this.

Red on unpatched `main` (3 of 7 failing, `expected {} to deeply equal { planId: 'rec-plan-1' }` — the empty body is the defect itself), green after. The first test in the file pins the premise the card rests on: the header really does render live actions while the record is loading.

No existing test was weakened, skipped, or quarantined; the 6 pre-existing pins in the sibling file pass unchanged.

Verified at `f08cfa8ec`:

- `vitest run packages/app-shell/src/views/` — 272 files, 2680 passed, 1 skipped
- `vitest run` on the new file + `RecordDetailView.recordIdParamSeed.test.tsx` + `packages/core/src/actions/__tests__/recordIdParam.test.ts` — 3 files, 23 passed
- `turbo run type-check --filter @object-ui/app-shell` — 30 tasks successful (app-shell runs `tsc --noEmit` plus `tsc -p tsconfig.test.json`, so the new test compiles too)
- `turbo run lint --filter @object-ui/app-shell` — 0 errors (2412 pre-existing `no-explicit-any` warnings, unchanged)
- `check-control-bytes`, `check-lint-coverage`, `check-type-check-coverage`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed` — all pass
- `check:action-forward-parity`, `check:phantom-deps`, `check:self-import`, `check:spec-symbols`, `check:i18n-keys`, `check:i18n-drift` — all pass

Changeset: `@object-ui/app-shell` patch.

## Scope

Stayed inside the dispatched file surface. `DeclaredActionsBar.tsx` was **not** touched — the second dispatch path the dispatch allowed for does not live there, because there is no second path.

One adjacent observation, deliberately left alone: if `pureRecordId` were itself absent the chain would still end in the helper's silent abstention. That is unreachable on this route (the record route cannot resolve without it) and closing it would mean changing behaviour for a case I could not reproduce, so it is reported rather than patched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_