### PR TITLE
fix(fields): render the author's declared option hex instead of quantizing it to nine palette families

### DIFF
--- a/.changeset/badge-declared-hex-fidelity-5141.md
+++ b/.changeset/badge-declared-hex-fidelity-5141.md
@@ -1,0 +1,56 @@
+---
+'@object-ui/fields': minor
+---
+
+fix(fields): render the option colour an author declared as an explicit hex, instead of quantizing it to nine palette families (objectui#5141)
+
+`options[].color` accepts any hex, but the badge renderer answered a lossy
+question with it: `hexToPaletteName` bucketed the value by hue into nine
+families (`red`/`orange`/`yellow`/`green`/`blue`/`indigo`/`purple`/`pink`, plus
+`gray` below 22% saturation), and `BADGE_COLOR_MAP` held exactly one class set
+per family. Two tiers an author declared as distinct therefore rendered
+byte-identical: `#2ecc71` ("in progress") and `#1e8449` ("completed") differ by
+0.1 degree of hue, both landed in `green`, and both emitted
+`bg-green-50 text-green-700 border-green-200`. Pressing the second colour darker
+still changed nothing. End users could not tell the two states apart in a list.
+
+`plugin-gantt` had already settled this class of conflict the other way —
+*explicit colorField value (hex or semantic name) — metadata wins* — and
+Studio's own option editor paints the author's swatch straight from the raw hex.
+Badges were the odd surface out.
+
+Now an explicitly declared hex is rendered as declared: the soft-pill surface,
+label and border are derived from that hex rather than snapped to a family, for
+both `appearance: 'badge'` and `appearance: 'dot'`.
+
+Two properties the family maps gave us for free are kept deliberately:
+
+- **The design system keeps control of theming.** The derived colours are
+  published as CSS custom properties and consumed by *static* Tailwind
+  utilities, so light and dark remain ordinary `dark:` variants
+  (`.dark\:bg-...:where(.dark, .dark *)` in the built sheet) rather than a
+  hard-coded inline background that would render identically in dark mode.
+  Tailwind cannot generate a class for a runtime value, so the custom property —
+  not the colour — has to be the dynamic part.
+- **Contrast is pinned, not just colour identity.** The label is the lightness
+  along the declared hue nearest the declared one that still clears WCAG AA
+  (4.5:1) against the surface actually rendered. Authors can and do declare
+  colours that are unreadable under a label; honoring the declaration must not
+  turn legibility loose across every list view. Dots are held to 1.9:1 against
+  the row, the measured floor of the `-500` shades shipped today.
+
+**What changes for an author relying on the current look:** every select/status
+badge whose option colour is declared as a hex — which the renderer's own notes
+describe as almost all of them — will render in that declared colour rather than
+its palette family's fixed pill. Colours near a family's canonical shade look
+much as before; a colour the author picked deliberately *away* from it (a deep
+green, a muted red) now looks like what was written, and the pill's depth tracks
+the declared lightness. Declarations that are not an explicit hex are untouched:
+family names, the semantic value map and the deterministic hash fallback all
+resolve exactly as they did, and `getSemanticColorName` still returns family
+names, so the Gantt path is unaffected.
+
+The badge classes exported by `getBadgeColorClasses` are unchanged, so callers
+that consume only a class string (the grid's compact card view and group-header
+pills, Kanban) keep today's quantized rendering until they adopt the new
+`getBadgeHexAppearance` / `getDotHexAppearance` helpers.

--- a/packages/fields/src/__tests__/badge-hex-fidelity-5141.test.tsx
+++ b/packages/fields/src/__tests__/badge-hex-fidelity-5141.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * Regression for objectstack-ai/objectui#5141: an author's explicit `options[].color`
+ * hex was quantized to one of nine palette families before it reached the badge, so
+ * two same-hue tiers the author declared as distinct — `#2ecc71` ("in progress") and
+ * `#1e8449` ("completed") — rendered BYTE-IDENTICAL (`bg-green-50 text-green-700
+ * border-green-200` for both) and end users could not tell the two states apart.
+ * `plugin-gantt` had already settled the same class of conflict the other way
+ * ("explicit colorField value (hex or semantic name) — metadata wins").
+ *
+ * The pins below are deliberately about MEASURED properties, not colour identity:
+ *
+ *   1. Two distinct declarations must be PERCEPTIBLY distinct, not merely unequal.
+ *      Any naive "compute a pale pill from the hex" would satisfy `!==` while still
+ *      leaving the reported pair under the just-noticeable difference — closing the
+ *      issue on paper with the bug intact. So the bar is a CIE76 ΔE threshold.
+ *   2. The label must stay readable against the surface actually rendered, in BOTH
+ *      themes, including for declarations that are unreadable as declared. Honoring
+ *      author metadata must not turn legibility loose across every list view.
+ *   3. Non-hex declarations (family names, the semantic value map, the hash
+ *      fallback) must be untouched.
+ *
+ * The colour math here is written out independently of the implementation on
+ * purpose: a contrast pin that reuses the code under test would agree with that
+ * code by construction and prove nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import {
+  SelectCellRenderer,
+  getBadgeColorClasses,
+  getBadgeHexAppearance,
+  getDotHexAppearance,
+  getSemanticColorName,
+  deriveHexBadgePalette,
+} from '../index';
+
+/* ---------------------------------------------------------------- colour math */
+
+interface Rgb { r: number; g: number; b: number }
+
+function parseHex(hex: string): Rgb {
+  const h = hex.replace('#', '');
+  const full = h.length === 3 ? h.split('').map((c) => c + c).join('') : h;
+  return {
+    r: parseInt(full.slice(0, 2), 16),
+    g: parseInt(full.slice(2, 4), 16),
+    b: parseInt(full.slice(4, 6), 16),
+  };
+}
+
+const linear = (v: number): number => {
+  const c = v / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+};
+
+const luminance = ({ r, g, b }: Rgb): number =>
+  0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+
+function contrast(a: string, b: string): number {
+  const la = luminance(parseHex(a));
+  const lb = luminance(parseHex(b));
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** sRGB -> CIE L*a*b* (D65), for a perceptual distance between two rendered pills. */
+function lab(hex: string): [number, number, number] {
+  const { r, g, b } = parseHex(hex);
+  const R = linear(r), G = linear(g), B = linear(b);
+  const X = (0.4124 * R + 0.3576 * G + 0.1805 * B) / 0.95047;
+  const Y = 0.2126 * R + 0.7152 * G + 0.0722 * B;
+  const Z = (0.0193 * R + 0.1192 * G + 0.9505 * B) / 1.08883;
+  const f = (t: number): number => (t > 216 / 24389 ? Math.cbrt(t) : (841 / 108) * t + 4 / 29);
+  return [116 * f(Y) - 16, 500 * (f(X) - f(Y)), 200 * (f(Y) - f(Z))];
+}
+
+/** CIE76 colour difference. ~2.3 is the just-noticeable difference. */
+function deltaE(a: string, b: string): number {
+  const [l1, a1, b1] = lab(a);
+  const [l2, a2, b2] = lab(b);
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2);
+}
+
+/**
+ * "Two badges a user can actually tell apart at a glance." ΔE 2.3 is one JND;
+ * this asks for comfortably more than one, so an implementation that merely
+ * un-breaks byte-identity cannot pass.
+ */
+const PERCEPTIBLE = 5.0;
+
+/** WCAG AA for normal text. */
+const AA = 4.5;
+
+/**
+ * Measured floor of the -500 dot shades shipped today: yellow-500 `#eab308`
+ * sits at 1.92:1 on white, the weakest of the nine. A declared dot must never
+ * be LESS visible than the palette dot it replaces.
+ */
+const DOT_FLOOR = 1.9;
+
+const REPORTED_LIGHT = '#2ecc71'; // "in progress" — green
+const REPORTED_DARK = '#1e8449'; // "completed"   — deep green
+const REPORTED_DARKER = '#145A32'; // the reporter's re-test, pressed darker still
+
+/* ------------------------------------------------------------------- helpers */
+
+function styleOf(el: HTMLElement, prop: string): string {
+  return el.style.getPropertyValue(prop).trim();
+}
+
+function renderSelect(color: string, appearance?: 'badge' | 'dot') {
+  const field = {
+    type: 'select',
+    ...(appearance ? { appearance } : {}),
+    options: [{ label: 'State', value: 'state', color }],
+  } as any;
+  const { container } = render(<SelectCellRenderer value="state" field={field} />);
+  return container;
+}
+
+describe('objectui#5141 — declared option hex reaches the badge intact', () => {
+  it('the reported pair no longer renders identically, and is perceptibly distinct', () => {
+    const a = deriveHexBadgePalette(REPORTED_LIGHT)!;
+    const b = deriveHexBadgePalette(REPORTED_DARK)!;
+
+    // The literal defect: byte-identical output for two distinct declarations.
+    expect(a.bg).not.toBe(b.bg);
+    expect(a.fg).not.toBe(b.fg);
+    expect(a.border).not.toBe(b.border);
+
+    // ...and distinct ENOUGH to be seen, which mere inequality does not imply.
+    expect(deltaE(a.bg, b.bg)).toBeGreaterThanOrEqual(PERCEPTIBLE);
+    expect(deltaE(a.bgDark, b.bgDark)).toBeGreaterThanOrEqual(PERCEPTIBLE);
+
+    // The reporter's harder re-test: pressing the second colour darker still
+    // has to keep moving the rendered pill, in both themes.
+    const c = deriveHexBadgePalette(REPORTED_DARKER)!;
+    expect(deltaE(b.bg, c.bg)).toBeGreaterThanOrEqual(PERCEPTIBLE);
+    expect(deltaE(b.bgDark, c.bgDark)).toBeGreaterThanOrEqual(PERCEPTIBLE);
+  });
+
+  it('renders the declared hex through the DOM, not a palette family class', () => {
+    const container = renderSelect(REPORTED_DARK);
+    const badge = screen.getByTitle('State');
+    const palette = deriveHexBadgePalette(REPORTED_DARK)!;
+
+    expect(styleOf(badge, '--os-badge-bg')).toBe(palette.bg);
+    expect(styleOf(badge, '--os-badge-fg')).toBe(palette.fg);
+    expect(styleOf(badge, '--os-badge-border')).toBe(palette.border);
+
+    // The quantized family classes must be gone for this path.
+    expect(badge.className).not.toMatch(/bg-green-50|text-green-700|border-green-200/);
+    expect(container.innerHTML).toContain('--os-badge-bg');
+  });
+
+  it('two declared greens produce different DOM, which is the user-visible bug', () => {
+    const first = renderSelect(REPORTED_LIGHT).innerHTML;
+    const second = renderSelect(REPORTED_DARK).innerHTML;
+    expect(first).not.toBe(second);
+  });
+
+  it('keeps the pill under the design system: light/dark stay `dark:` variants', () => {
+    // The colours are carried by custom properties precisely so the utilities
+    // themselves remain static and theme-aware. A hard-coded inline background
+    // would render the same in dark mode, which is the cost this avoids.
+    const appearance = getBadgeHexAppearance(REPORTED_DARK)!;
+    expect(appearance.className).toContain('dark:bg-[color:var(--os-badge-bg-dark)]');
+    expect(appearance.className).toContain('dark:text-[color:var(--os-badge-fg-dark)]');
+    expect(appearance.className).toContain('dark:border-[color:var(--os-badge-border-dark)]');
+    // No raw colour baked into the class string.
+    expect(appearance.className).not.toMatch(/#[0-9a-fA-F]{6}/);
+  });
+});
+
+describe('objectui#5141 — contrast is pinned, not just colour identity', () => {
+  // Includes declarations that are unreadable as declared: pure white, pure
+  // black, neon yellow, a near-white cream, and a fully desaturated grey.
+  const declarations = [
+    REPORTED_LIGHT, REPORTED_DARK, REPORTED_DARKER,
+    '#ffffff', '#000000', '#ffff00', '#fffbe6', '#7f7f7f', '#0a0a0a',
+    '#ef4444', '#3b82f6', '#a855f7', '#eab308', '#00ffff', '#ff00ff',
+    '#abcdef', '#123456', '#f5f5f4', '#27ae60', '#16a085',
+  ];
+
+  it.each(declarations)('%s: label clears WCAG AA in both themes', (hex) => {
+    const p = deriveHexBadgePalette(hex)!;
+    expect(p).toBeDefined();
+    expect(contrast(p.fg, p.bg)).toBeGreaterThanOrEqual(AA);
+    expect(contrast(p.fgDark, p.bgDark)).toBeGreaterThanOrEqual(AA);
+  });
+
+  it.each(declarations)('%s: dot stays at least as visible as the palette dot', (hex) => {
+    const p = deriveHexBadgePalette(hex)!;
+    expect(contrast(p.dot, '#ffffff')).toBeGreaterThanOrEqual(DOT_FLOOR);
+    expect(contrast(p.dotDark, '#0a0a0a')).toBeGreaterThanOrEqual(DOT_FLOOR);
+  });
+
+  it('a declaration that is unreadable as-declared is corrected, not rendered as-is', () => {
+    // Pure yellow as a label on its own pale pill would be illegible; the
+    // foreground must move off the declared value to clear AA.
+    const p = deriveHexBadgePalette('#ffff00')!;
+    expect(p.fg.toLowerCase()).not.toBe('#ffff00');
+    expect(contrast(p.fg, p.bg)).toBeGreaterThanOrEqual(AA);
+  });
+});
+
+describe('objectui#5141 — appearance: dot honours the declaration too', () => {
+  it('paints the declared hex rather than a per-family -500 shade', () => {
+    const container = renderSelect(REPORTED_DARK, 'dot');
+    const dot = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    const palette = deriveHexBadgePalette(REPORTED_DARK)!;
+
+    expect(dot).toBeTruthy();
+    expect(styleOf(dot, '--os-dot-bg')).toBe(palette.dot);
+    expect(styleOf(dot, '--os-dot-bg-dark')).toBe(palette.dotDark);
+    expect(dot.className).not.toContain('bg-green-500');
+  });
+
+  it('two declared greens give two different dots', () => {
+    const a = deriveHexBadgePalette(REPORTED_LIGHT)!;
+    const b = deriveHexBadgePalette(REPORTED_DARKER)!;
+    expect(a.dot).not.toBe(b.dot);
+    expect(deltaE(a.dot, b.dot)).toBeGreaterThanOrEqual(PERCEPTIBLE);
+  });
+});
+
+describe('objectui#5141 — every non-hex path is untouched', () => {
+  it('family names still resolve to their exact palette classes', () => {
+    expect(getBadgeColorClasses('green')).toBe(
+      'bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-900/60',
+    );
+    expect(getBadgeColorClasses('red')).toBe(
+      'bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900/60',
+    );
+  });
+
+  it('the semantic value map still wins when no colour is declared', () => {
+    // '完成' maps to green in SEMANTIC_COLOR_MAP.
+    expect(getBadgeColorClasses(undefined, '完成')).toContain('bg-green-50');
+    expect(getBadgeColorClasses(undefined, '已取消')).toContain('bg-red-50');
+  });
+
+  it('the deterministic hash fallback is still deterministic', () => {
+    const first = getBadgeColorClasses(undefined, 'some_unmapped_value');
+    const second = getBadgeColorClasses(undefined, 'some_unmapped_value');
+    expect(first).toBe(second);
+    expect(first).toMatch(/^bg-/);
+  });
+
+  it('an empty value still renders the muted pill', () => {
+    expect(getBadgeColorClasses(undefined, '')).toBe(
+      'bg-muted text-muted-foreground border-border',
+    );
+  });
+
+  it('non-hex declarations get no hex appearance at all', () => {
+    expect(getBadgeHexAppearance('green')).toBeUndefined();
+    expect(getBadgeHexAppearance(undefined)).toBeUndefined();
+    expect(getBadgeHexAppearance('rgb(1,2,3)')).toBeUndefined();
+    expect(getDotHexAppearance('green')).toBeUndefined();
+    // A '#'-prefixed value that is not a valid hex must not fabricate a palette.
+    expect(getBadgeHexAppearance('#nothex')).toBeUndefined();
+    expect(deriveHexBadgePalette('#nothex')).toBeUndefined();
+  });
+
+  it('the family quantizer itself is unchanged, so the Gantt path still resolves', () => {
+    // plugin-gantt reads semantic NAMES, not pill classes; both reported greens
+    // legitimately remain 'green' there. That path was never the defect.
+    expect(getSemanticColorName(REPORTED_LIGHT)).toBe('green');
+    expect(getSemanticColorName(REPORTED_DARK)).toBe('green');
+    expect(getSemanticColorName('#ef4444')).toBe('red');
+    expect(getSemanticColorName('#3b82f6')).toBe('blue');
+    expect(getSemanticColorName('#808080')).toBe('gray');
+  });
+
+  it('a field with no declared colour renders exactly the family classes', () => {
+    const field = { type: 'select', options: [{ label: 'Open', value: 'open' }] } as any;
+    render(<SelectCellRenderer value="open" field={field} />);
+    const badge = screen.getByTitle('Open');
+    expect(badge.getAttribute('style')).toBeFalsy();
+    expect(badge.className).toMatch(/bg-\w+-50/);
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1167,6 +1167,276 @@ function resolveColorName(color?: string): string | undefined {
   return undefined;
 }
 
+/* ---------------------------------------------------------------------------
+ * Explicit-hex badge rendering (objectui#5141).
+ *
+ * `hexToPaletteName` above answers "which of the nine palette families is this
+ * hex nearest?" — a deliberately lossy question. Two same-hue tiers an author
+ * declared as distinct (`#2ecc71` "in progress" vs `#1e8449` "completed") land
+ * in the same bucket and render byte-identical, so the declaration is silently
+ * discarded. `plugin-gantt` already settled this class of conflict the other
+ * way ("explicit colorField value (hex or semantic name) — metadata wins"), and
+ * Studio's own option editor paints the author's swatch straight from the raw
+ * hex. Badges were the odd one out.
+ *
+ * So when the author declared a hex we render THAT hex, deriving the soft-pill
+ * surface / label / border from it instead of snapping to a family. The
+ * derivation deliberately keeps the two properties the family maps gave us for
+ * free:
+ *
+ *   1. Theme control. The derived colors are published as CSS custom
+ *      properties and consumed by *static* Tailwind utilities, so light and
+ *      dark remain ordinary `dark:` variants rather than a hard-coded inline
+ *      background that ignores the theme. Tailwind can never generate a class
+ *      for a runtime value (`bg-[#1e8449]` built from metadata is not in the
+ *      source at build time), so the custom property — not the colour — has to
+ *      be the dynamic part.
+ *   2. Contrast. The label is not "the hex" but the lightness along the
+ *      declared hue nearest the declared one that still clears WCAG AA against
+ *      the derived surface. Authors can and do declare colours that are
+ *      unreadable under a label; honoring the declaration must not turn that
+ *      into a legibility bug across every list view.
+ *
+ * Non-hex declarations (family names, the semantic value map, the hash
+ * fallback) are untouched and keep resolving exactly as before.
+ * -------------------------------------------------------------------------*/
+
+/** WCAG AA floor for badge label text against its own pill surface. */
+const BADGE_TEXT_CONTRAST = 4.5;
+
+/**
+ * Visibility floor for the `appearance: 'dot'` marker. A dot carries no text,
+ * so the AA *text* ratio does not apply; this is the measured floor of the
+ * -500 shades `DOT_COLOR_MAP` ships today (yellow-500 `#eab308` is the weakest
+ * at 1.92:1 on white). Pinning it here means an author-declared dot is never
+ * less visible than the palette dot it replaces.
+ */
+const DOT_CONTRAST_FLOOR = 1.9;
+
+interface Rgb { r: number; g: number; b: number }
+
+/** Surfaces a dot sits on — used only to keep the dot itself visible. */
+const LIGHT_SURFACE: Rgb = { r: 255, g: 255, b: 255 };
+const DARK_SURFACE: Rgb = { r: 10, g: 10, b: 10 };
+
+const clampNum = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
+
+function parseHexColor(hex: string): Rgb | undefined {
+  const m = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!m) return undefined;
+  let h = m[1];
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+function rgbToHsl({ r, g, b }: Rgb): { h: number; s: number; l: number } {
+  const rn = r / 255, gn = g / 255, bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const d = max - min;
+  const l = (max + min) / 2;
+  const s = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1));
+  let h = 0;
+  if (d !== 0) {
+    if (max === rn) h = (((gn - bn) / d) % 6 + 6) % 6;
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h *= 60;
+  }
+  return { h, s, l };
+}
+
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  const hue = ((h % 360) + 360) % 360;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = l - c / 2;
+  let p: [number, number, number];
+  if (hue < 60) p = [c, x, 0];
+  else if (hue < 120) p = [x, c, 0];
+  else if (hue < 180) p = [0, c, x];
+  else if (hue < 240) p = [0, x, c];
+  else if (hue < 300) p = [x, 0, c];
+  else p = [c, 0, x];
+  return {
+    r: Math.round((p[0] + m) * 255),
+    g: Math.round((p[1] + m) * 255),
+    b: Math.round((p[2] + m) * 255),
+  };
+}
+
+const rgbToHex = ({ r, g, b }: Rgb): string =>
+  '#' + [r, g, b].map((v) => clampNum(Math.round(v), 0, 255).toString(16).padStart(2, '0')).join('');
+
+/** WCAG relative luminance of an sRGB color. */
+function relativeLuminance({ r, g, b }: Rgb): number {
+  const channel = (v: number): number => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/** WCAG contrast ratio between two colors (1..21). */
+function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/**
+ * Walk the declared hue for the lightness *closest to the declared one* that
+ * still clears `target` against `surface`.
+ *
+ * Choosing the closest passing lightness rather than simply maximizing
+ * contrast is what keeps the author's colour recognizable — maximizing would
+ * collapse every badge label to black or white and re-lose the declaration we
+ * are here to preserve. Only when the hue cannot reach the target at any
+ * lightness (a very low-chroma declaration against a mid surface) do we fall
+ * back to black or white, whichever is further from the surface: legibility
+ * outranks fidelity.
+ */
+function readableOnSurface(
+  h: number,
+  s: number,
+  declaredL: number,
+  surface: Rgb,
+  target: number,
+): Rgb {
+  let best: Rgb | undefined;
+  let bestDistance = Infinity;
+  for (let step = 0; step <= 100; step++) {
+    const lightness = step / 100;
+    const candidate = hslToRgb(h, s, lightness);
+    if (contrastRatio(candidate, surface) < target) continue;
+    const distance = Math.abs(lightness - declaredL);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  if (best) return best;
+  const black: Rgb = { r: 0, g: 0, b: 0 };
+  const white: Rgb = { r: 255, g: 255, b: 255 };
+  return contrastRatio(black, surface) >= contrastRatio(white, surface) ? black : white;
+}
+
+/** The six pill colors plus the two dot colors derived from one declared hex. */
+export interface HexBadgePalette {
+  bg: string;
+  fg: string;
+  border: string;
+  bgDark: string;
+  fgDark: string;
+  borderDark: string;
+  dot: string;
+  dotDark: string;
+}
+
+/**
+ * Derive a full soft-pill palette from an author-declared hex.
+ *
+ * The declared LIGHTNESS is what separates two same-hue tiers (`#2ecc71` is
+ * l=0.49, `#1e8449` is l=0.32 — their hues differ by 0.1°), so it has to
+ * survive into the *surface*. A fixed pale tint — the obvious reading of
+ * "compute a soft pill from the hex" — does not carry it: measured, that
+ * leaves the reported pair ΔE 2.3 apart in Lab, at the ~2.3 just-noticeable
+ * threshold, which would close this issue on paper while the user still cannot
+ * tell the two badges apart. Letting the tint depth track the declared
+ * lightness puts them ΔE 8.0 apart instead.
+ */
+export function deriveHexBadgePalette(color: string): HexBadgePalette | undefined {
+  const rgb = parseHexColor(color);
+  if (!rgb) return undefined;
+  const { h, s, l } = rgbToHsl(rgb);
+  // Keep a usable chroma at both ends: a fully desaturated declaration stays
+  // neutral instead of being pushed into a hue it never declared, and a neon
+  // one is reined in so the pill never fights the row it sits in.
+  const sat = clampNum(s, 0.18, 0.92);
+
+  // Light theme: pale for light declarations (the -50 look we ship today),
+  // deepening as the declared colour darkens.
+  const bgLightness = 0.95 - 0.32 * (1 - l);
+  const bg = hslToRgb(h, sat * (0.55 + 0.25 * (1 - l)), bgLightness);
+  const border = hslToRgb(h, sat * 0.62, clampNum(bgLightness - 0.14, 0, 1));
+  const fg = readableOnSurface(h, sat, l, bg, BADGE_TEXT_CONTRAST);
+
+  // Dark theme: the same idea mirrored — a dark surface whose depth tracks the
+  // declared lightness, with the label lifted until it clears AA against it.
+  const bgDarkLightness = 0.10 + 0.30 * l;
+  const bgDark = hslToRgb(h, sat * 0.6, bgDarkLightness);
+  const borderDark = hslToRgb(h, sat * 0.55, clampNum(bgDarkLightness + 0.12, 0, 1));
+  const fgDark = readableOnSurface(h, sat, l, bgDark, BADGE_TEXT_CONTRAST);
+
+  return {
+    bg: rgbToHex(bg),
+    fg: rgbToHex(fg),
+    border: rgbToHex(border),
+    bgDark: rgbToHex(bgDark),
+    fgDark: rgbToHex(fgDark),
+    borderDark: rgbToHex(borderDark),
+    dot: rgbToHex(readableOnSurface(h, sat, l, LIGHT_SURFACE, DOT_CONTRAST_FLOOR)),
+    dotDark: rgbToHex(readableOnSurface(h, sat, l, DARK_SURFACE, DOT_CONTRAST_FLOOR)),
+  };
+}
+
+/**
+ * Static utility strings. Tailwind has to SEE these at build time — they are
+ * scanned out of this file by `packages/fields/src/index.css` — which is
+ * exactly why the custom properties carry the colours.
+ */
+const HEX_BADGE_CLASSES =
+  'bg-[color:var(--os-badge-bg)] text-[color:var(--os-badge-fg)] border-[color:var(--os-badge-border)] ' +
+  'dark:bg-[color:var(--os-badge-bg-dark)] dark:text-[color:var(--os-badge-fg-dark)] dark:border-[color:var(--os-badge-border-dark)]';
+
+const HEX_DOT_CLASSES = 'bg-[color:var(--os-dot-bg)] dark:bg-[color:var(--os-dot-bg-dark)]';
+
+/** A className plus the custom properties it reads. */
+export interface HexColorAppearance {
+  className: string;
+  style: React.CSSProperties;
+}
+
+/**
+ * Soft-pill appearance for an explicitly declared hex, or `undefined` for
+ * every other kind of declaration (family name, no colour at all) so the
+ * caller falls back to `getBadgeColorClasses`.
+ */
+export function getBadgeHexAppearance(color?: string): HexColorAppearance | undefined {
+  if (!color || color.charAt(0) !== '#') return undefined;
+  const palette = deriveHexBadgePalette(color);
+  if (!palette) return undefined;
+  return {
+    className: HEX_BADGE_CLASSES,
+    style: {
+      '--os-badge-bg': palette.bg,
+      '--os-badge-fg': palette.fg,
+      '--os-badge-border': palette.border,
+      '--os-badge-bg-dark': palette.bgDark,
+      '--os-badge-fg-dark': palette.fgDark,
+      '--os-badge-border-dark': palette.borderDark,
+    } as React.CSSProperties,
+  };
+}
+
+/** Dot appearance for an explicitly declared hex (see `getBadgeHexAppearance`). */
+export function getDotHexAppearance(color?: string): HexColorAppearance | undefined {
+  if (!color || color.charAt(0) !== '#') return undefined;
+  const palette = deriveHexBadgePalette(color);
+  if (!palette) return undefined;
+  return {
+    className: HEX_DOT_CLASSES,
+    style: {
+      '--os-dot-bg': palette.dot,
+      '--os-dot-bg-dark': palette.dotDark,
+    } as React.CSSProperties,
+  };
+}
+
 export function getBadgeColorClasses(color?: string, val?: unknown): string {
   const named = resolveColorName(color);
   if (named && BADGE_COLOR_MAP[named]) return BADGE_COLOR_MAP[named];
@@ -1262,22 +1532,32 @@ export function SelectCellRenderer({ value, field }: CellRendererProps): React.R
     if (appearance === 'dot') {
       // Resolve a real CSS color for the dot. Prefer explicit option color,
       // then semantic mapping for the value, then deterministic palette.
+      // An explicitly declared hex is painted as declared (objectui#5141);
+      // every other declaration keeps resolving to a palette family below.
+      const hexDot = getDotHexAppearance(option?.color);
       const colorName = resolveColorName(option?.color)
         || SEMANTIC_COLOR_MAP[String(val).toLowerCase().replace(/[\s-]/g, '_')]
         || hashToColor(String(val).toLowerCase().replace(/[\s-]/g, '_'));
-      const dotClass = DOT_COLOR_MAP[colorName] || DOT_COLOR_MAP.gray;
+      const dotClass = hexDot ? hexDot.className : (DOT_COLOR_MAP[colorName] || DOT_COLOR_MAP.gray);
       // max-w-full bounds the (otherwise content-sized) inline-flex box so the
       // inner truncate can engage; title keeps the full label on hover
       // (objectui#3466, same class of bug as the badge branch below).
       return (
         <span key={key} className="inline-flex max-w-full items-center gap-1.5 text-sm" title={label}>
-          <span className={cn('h-1.5 w-1.5 rounded-full shrink-0', dotClass)} aria-hidden="true" />
+          <span
+            className={cn('h-1.5 w-1.5 rounded-full shrink-0', dotClass)}
+            style={hexDot?.style}
+            aria-hidden="true"
+          />
           <span className="min-w-0 truncate">{label}</span>
         </span>
       );
     }
 
-    const colorClasses = getBadgeColorClasses(option?.color, val);
+    // An explicitly declared hex renders as declared (objectui#5141); family
+    // names, the semantic value map and the hash fallback are unchanged.
+    const hexBadge = getBadgeHexAppearance(option?.color);
+    const colorClasses = hexBadge ? hexBadge.className : getBadgeColorClasses(option?.color, val);
     // max-w-full + inner truncate: in bounded containers (detail highlight
     // strip columns, grid cells) an overlong label used to clip mid-glyph at
     // the container edge; now the badge shrinks and ellipsizes, with the full
@@ -1287,6 +1567,7 @@ export function SelectCellRenderer({ value, field }: CellRendererProps): React.R
         key={key}
         variant="outline"
         className={cn('max-w-full min-w-0', colorClasses)}
+        style={hexBadge?.style}
         title={label}
       >
         <span className="truncate">{label}</span>


### PR DESCRIPTION
Part of #5141

`options[].color` accepts any hex, but the badge renderer answered a lossy question with it. `hexToPaletteName` bucketed the value by hue into nine families and `BADGE_COLOR_MAP` held exactly one class set per family, so `#2ecc71` ("in progress") and `#1e8449` ("completed") — 0.1 degree of hue apart — both emitted `bg-green-50 text-green-700 border-green-200`. The declaration was discarded and users could not tell the two states apart.

## The stop-clause: I looked for a recorded rationale, and report a measured absence

The triage comment made this binding: *"If the implementer finds the quantization is a deliberate design system constraint with a recorded rationale, stop and flag back instead of forcing the fix."*

There is **no recorded rationale for the quantization**. What the repo actually records points the other way:

- `hexToPaletteName`'s own docstring says it exists so that *"the explicit author color is [not] ignored"* — it is an approximation **in service of** metadata-wins, not a decision to discard precision.
- `BADGE_COLOR_MAP`'s docstring records a rationale for the **soft-pill look** (`-50` surface, `-700` text, hairline `-200`, dark `-950/40` + `-300`) — a real constraint about appearance, which this PR preserves. It says nothing about bucketing.
- `packages/fields/src/index.tsx` already notes that *"Tailwind classes can't be applied to dynamic `style={}` values"* — the repo's own record of why a runtime colour cannot be a class.
- Git archaeology is inconclusive by construction: this checkout is shallow (51 commits) and the whole cluster traces to one squashed commit.

There **is** a documented design-system constraint that bears on the route: AGENTS.md section 2 and `skills/objectui/rules/styling.md` both say no inline styles, and the latter also forbids hard-coded colours and arbitrary values such as `bg-[#3b82f6]`. I treated that as constraining *how*, not *whether* — because it is about component-authored **static** styling, it is not mechanically enforced (no ESLint rule; 254 `style={{` occurrences across `packages/*/src`), and data-driven author colour already reaches inline style in three places, including the other end of this exact metadata key: `SchemaForm.tsx` paints the option swatch in Studio straight from `opt.color`, and `plugin-gantt` paints bars from it under the comment this card cites. So an author picks `#1e8449`, sees `#1e8449` while authoring, and saw a different colour when rendered.

## Route chosen, and the measurement that chose it

The card named two routes. I took (a) — render the declared hex — but **not** the naive form of it, because measurement rejected that form.

The obvious reading of "compute a soft pill from the hex" is a fixed pale tint. Measured against the reported pair, that fails: at `-50`-equivalent lightness the chroma is so small that hue and saturation differences round away in 8-bit, and both colours produce the **byte-identical** background `#eef7f2`. It would have closed this issue while reproducing the exact defect. This is pinned as an ablation, below.

The reason is structural and worth stating: `#2ecc71` and `#1e8449` differ **only in lightness** (l=0.49 vs l=0.32; hue 145.4 vs 145.3). Lightness is therefore the one dimension that must survive. It cannot survive in the label, because a WCAG AA floor on a near-white pill compresses every sufficiently light colour down to the same floor. So the declared lightness is carried by the **surface**, whose tint depth tracks it, and the label is derived against that surface.

Route (b) (two tiers per family) was rejected: it still discards the declaration, just at 18 buckets instead of 9, and two mid-greens still collide.

## What the implementation keeps

1. **Theming stays inside the design system.** The derived colours are published as CSS custom properties and consumed by *static* Tailwind utilities, so light and dark remain ordinary `dark:` variants. Verified in the built sheet — all eight utilities are emitted and the dark ones are correctly gated:

   ```
   .bg-\[color\:var\(--os-badge-bg\)\] { background-color: var(--os-badge-bg); }
   .dark\:bg-\[color\:var\(--os-badge-bg-dark\)\]:where(.dark, .dark *) { background-color: var(--os-badge-bg-dark); }
   ```

   This is the main cost the PM flagged, and it is largely bought back: a hard-coded inline background would have rendered identically in dark mode.

2. **Contrast is pinned, not colour identity.** The label is the lightness along the declared hue *nearest the declared one* that still clears 4.5:1 against the surface actually rendered — nearest rather than maximal, because maximising collapses every badge to black or white and re-loses the declaration. Across a 20-colour stress sample including pure white, pure black, neon yellow and a near-white cream, the worst measured ratio is 4.51:1 in dark and 4.52:1 in light. Dots are held to 1.9:1 against the row, which is the **measured** floor of the `-500` shades shipped today (yellow-500 is the weakest at 1.92:1), so a declared dot is never less visible than the palette dot it replaces.

3. **`appearance: 'dot'` is fixed too**, not just the badge.

4. **Every non-hex path is untouched** — family names, the semantic value map and the hash fallback resolve exactly as before, and `getSemanticColorName` still returns family names, so the Gantt path is unaffected.

## Verification

Union re-run at `26e78af0f`, working tree clean at that sha.

- `pnpm exec vitest run packages/fields/` — **106 files, 1795 tests passed**
- `pnpm exec vitest run packages/fields/src/__tests__/badge-hex-fidelity-5141.test.tsx` — **54 passed**
- `pnpm --filter @object-ui/fields type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`)
- `pnpm --filter @object-ui/fields lint` — **0 errors** (814 warnings, the pre-existing baseline)
- `check:control-bytes` — OK, 4593 files; `check:self-import`, `check:phantom-deps` — OK
- `check-changeset-presence`, `check-changeset-no-major` — OK
- `check:published-dist` needs a full-farm build and is left to CI; its specific concern — a new test file leaking into published `dist/` — was checked directly: `packages/fields/dist` contains no `__tests__`, no `*.test.*`, and the new exports are present in `dist/index.d.ts`.

**Ablation.** Replacing the lightness-tracking tint with the fixed pale tint (the naive route) turns the pin red, and reproduces the original defect exactly:

```
× the reported pair no longer renders identically, and is perceptibly distinct
AssertionError: expected '#eef7f2' not to be '#eef7f2'
Tests  1 failed | 53 passed (54)
```

The mutation was applied and reverted in source, and the test imports the module under test by relative path (`../index`), not through the package `exports` — so no `dist/` rebuild is involved in either leg and neither leg can read a stale artifact. The fix was committed before the ablation, so the restore came from the branch, byte-identical.

Note that the *byte-inequality* assertion still passed under ablation while the perceptual one failed — which is why the test pins a CIE76 deltaE threshold (5.0, against a just-noticeable difference of about 2.3) rather than `not.toBe`, and computes the colour maths independently of the implementation.

## Deliberately not in this PR

`getBadgeColorClasses` returns a class string, which cannot carry a runtime colour, so it was left behaviour-identical and four call sites outside this card's ruled file surface still quantize: two in `ObjectGrid` (compact card badge, group-header pills) and two in `ObjectKanban`. That leaves one option colour rendering two ways depending on surface, so it is filed as #5183 rather than left silent. That issue is not resolved by this PR.

This is `Part of` rather than `Fixes` for that reason: the reported symptom (list and detail select cells, badge and dot) is fixed, the mechanism repo-wide is not.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_