### PR TITLE
fix(types,components): FieldValidationRules.pattern.value is RegExp-only; unrecognized rule names shout (#5099)

### DIFF
--- a/.changeset/field-validation-rules-pattern-regexp-5099.md
+++ b/.changeset/field-validation-rules-pattern-regexp-5099.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+---
+
+`FieldValidationRules.pattern.value` narrows to `RegExp`, and the form renderer reports unrecognized validation rule names loudly (objectui#5099, maintainer ruling 2026-08-18).
+
+**BREAKING for hand-written form schemas — deliberately declared `minor`.** This
+repo's version policy reserves `major` for tracking `@objectstack` majors and is
+mechanically enforced (`scripts/check-changeset-no-major.mjs`); per that policy,
+objectui's own breaking changes ship as `minor` with the breaking semantics
+stated plainly here:
+
+- **What breaks:** `validation: { pattern: { value: '^…$', message } }` with a
+  **string** value no longer compiles. Write a `RegExp` literal instead:
+  `pattern: { value: /^…$/, message }`.
+- **Why red is the fix, not the damage:** react-hook-form applies `pattern`
+  only when `value instanceof RegExp`, and the renderer's single read point
+  spreads `validation` verbatim — so every string pattern accepted by the old
+  type ran **zero** validations, silently. Callers turning red were not
+  validating anything yesterday; the error converts silent non-validation into
+  explicit failure at authoring time.
+- **Unaffected:** the metadata route. `FieldSchema.pattern` (a string in field
+  metadata) is still compiled by `buildValidationRules` in `@object-ui/fields`
+  via `new RegExp(...)` before it reaches the renderer.
+
+Also, per the same ruling's second limb, the form renderer now reports rule
+names react-hook-form does not run (`console.error`, message doubles as the fix
+instruction): a misspelled `minlength`, an invented `email`, or numeric keys
+left by spreading an array into `validation` shout instead of vanishing. The
+recognized set is pinned against the installed react-hook-form bundle so a
+future bump cannot silently rot the diagnostic. The ruling's rejected half is
+equally binding and equally pinned by test: the read point does **not** compile
+string patterns — that consumer-side tolerance would harden the ambiguous
+declaration into contract (AGENTS.md #0.1).

--- a/packages/components/src/renderers/form/__tests__/rhf-recognized-rule-keys.test.ts
+++ b/packages/components/src/renderers/form/__tests__/rhf-recognized-rule-keys.test.ts
@@ -1,0 +1,83 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RHF_RECOGNIZED_RULE_KEYS` is pinned against the INSTALLED react-hook-form
+ * bundle, not against prose (objectui#5099).
+ *
+ * The unrecognized-rule-name diagnostic in `form.tsx` is only as truthful as
+ * its recognized set. That set is a claim about someone else's code —
+ * react-hook-form's field validator destructures a fixed key set off the
+ * field descriptor (`…}=e._f`) and silently drops everything else — so a
+ * react-hook-form bump that adds or removes a destructured key would rot the
+ * diagnostic in the worst direction: it would keep reporting confidently
+ * from a stale set, flagging rules that now run or blessing rules that no
+ * longer do, and nothing would go red.
+ *
+ * This test therefore RE-DERIVES the set from the bundle the workspace
+ * actually installed, at test time:
+ *
+ *   1. Resolve `react-hook-form`'s CJS bundle exactly as Node would from this
+ *      package (createRequire — no vitest alias applies to it).
+ *   2. Extract the validator's `._f` destructure and parse its key names.
+ *   3. Subtract the descriptor internals (`RHF_DESCRIPTOR_NON_RULE_KEYS`) and
+ *      require exact set equality with `RHF_RECOGNIZED_RULE_KEYS`.
+ *
+ * On a bump that changes the shape, step 2 or 3 fails loudly and a human
+ * re-sorts the new key into rule / non-rule — the one judgment that cannot
+ * be automated. The regexes are deliberately shape-based (minifier-safe:
+ * they key on `ref:`…`=<ident>._f`, not on the one-letter aliases).
+ *
+ * Also pinned here: the premise of the #5099 narrowing itself — the bundle's
+ * `instanceof RegExp` gate, the reason a string `pattern.value` validates
+ * nothing and `FieldValidationRules.pattern.value` is now `RegExp`-only.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import {
+  RHF_RECOGNIZED_RULE_KEYS,
+  RHF_DESCRIPTOR_NON_RULE_KEYS,
+} from '../validationRuleKeys';
+
+const require = createRequire(import.meta.url);
+// The "require" export condition resolves to dist/index.cjs.js — the same
+// artifact the issue quoted and the one Node actually loads.
+const bundlePath = require.resolve('react-hook-form');
+const bundle = readFileSync(bundlePath, 'utf8');
+
+describe('RHF_RECOGNIZED_RULE_KEYS matches the installed react-hook-form (objectui#5099)', () => {
+  it('the field validator destructures exactly one fixed key set off `._f`', () => {
+    const matches = [...bundle.matchAll(/const\{(ref:[^{}]*?)\}=[$\w]+\._f/g)];
+    // 0 matches ⇒ the bundle no longer holds the shape this pin greps for
+    // (refactor or major bump): re-derive the rule set from the new source by
+    // hand and update BOTH lists in validationRuleKeys.ts plus this regex.
+    // >1 ⇒ the extraction is ambiguous; disambiguate before trusting it.
+    expect(matches.length).toBe(1);
+
+    const destructured = matches[0][1].split(',').map((entry) => entry.split(':')[0]);
+    const derivedRuleKeys = destructured.filter(
+      (k) => !RHF_DESCRIPTOR_NON_RULE_KEYS.includes(k),
+    );
+
+    // Exact set equality, both directions: a key react-hook-form gained that
+    // we do not recognize fails here (the diagnostic would wrongly flag it),
+    // and a key it dropped that we still recognize fails here too (the
+    // diagnostic would wrongly bless it).
+    expect([...derivedRuleKeys].sort()).toEqual([...RHF_RECOGNIZED_RULE_KEYS].sort());
+  });
+
+  it('pattern only applies to RegExp instances — the premise of the narrowing', () => {
+    // The isRegex guard (`Z=e=>e instanceof RegExp` in 7.85.0). If this
+    // disappears, the ground under FieldValidationRules.pattern.value being
+    // RegExp-only has shifted: re-read the new validator before touching the
+    // type.
+    expect(bundle).toMatch(/=\(?[$\w]+\)?=>[$\w]+ instanceof RegExp/);
+  });
+});

--- a/packages/components/src/renderers/form/__tests__/unrecognized-validation-rules.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/unrecognized-validation-rules.test.tsx
@@ -28,6 +28,14 @@
  * read point (consumer tolerance, AGENTS.md #0.1), so the last test asserts
  * the string is handed to react-hook-form UNCOMPILED — if someone "helpfully"
  * adds `new RegExp(...)` in form.tsx, that assertion goes red.
+ *
+ * Also pinned, because a later refactor dropping either would be invisible:
+ * the diagnostic is DEV-ONLY (the ruling says dev-time; production consoles
+ * are not the audience — same gate as `basic/div.tsx`, including its order
+ * property: the production check must return before the seen-set is marked),
+ * and it reports ONCE per field + rule-set however often a schema-driven
+ * caller rebuilds the `fields` array (`basic/div.tsx` / `ObjectMap.tsx`
+ * once-memo shape; objectui#3965 measured what unthrottled repetition costs).
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
@@ -51,6 +59,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}, onSubmit?: any) {
@@ -162,6 +171,63 @@ describe('form renderer — unrecognized validation rule names (objectui#5099)',
       expect(screen.getByText('Lowercase letters, digits, dashes')).toBeInTheDocument();
     });
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('is silent in production builds, and the gate does not eat the dev notice', () => {
+    // The ruling's second limb says DEV-TIME error — a customer's production
+    // console is not the audience. Same gate as `basic/div.tsx` /
+    // `basic/span.tsx`, and this pins the documented order property too: the
+    // production check returns BEFORE the seen-set is marked, so a production
+    // render must never suppress the later dev notice for the same field.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const Form = ComponentRegistry.get('form')!;
+    const schemaWith = (fields: any[]) => ({
+      type: 'form',
+      mode: 'create',
+      showSubmit: true,
+      submitLabel: 'Create',
+      fields,
+      onSubmit: () => {},
+    });
+    const badField = () => [
+      { name: 'prod_probe', label: 'P', type: 'input', validation: { minlength: { value: 3, message: 'x' } } },
+    ];
+
+    vi.stubEnv('NODE_ENV', 'production');
+    const view = render(<Form schema={schemaWith(badField())} />);
+    expect(ruleErrors(spy)).toHaveLength(0);
+
+    vi.unstubAllEnvs();
+    // Fresh fields array ⇒ the reporting effect re-runs; now in dev it must
+    // fire — a production render marking the seen-set would swallow this.
+    view.rerender(<Form schema={schemaWith(badField())} />);
+    expect(ruleErrors(spy)).toHaveLength(1);
+  });
+
+  it('reports once per field + rule-set, however often the caller rebuilds `fields`', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const Form = ComponentRegistry.get('form')!;
+    const schemaWith = (validation: any) => ({
+      type: 'form',
+      mode: 'create',
+      showSubmit: true,
+      submitLabel: 'Create',
+      // A fresh array every call — the schema-driven caller shape that made
+      // the effect re-run per render and would repeat the notice forever.
+      fields: [{ name: 'dedupe_probe', label: 'D', type: 'input', validation }],
+      onSubmit: () => {},
+    });
+
+    const view = render(<Form schema={schemaWith({ minlength: { value: 3, message: 'x' } })} />);
+    expect(ruleErrors(spy)).toHaveLength(1);
+
+    view.rerender(<Form schema={schemaWith({ minlength: { value: 3, message: 'x' } })} />);
+    expect(ruleErrors(spy)).toHaveLength(1); // same field, same keys: silent
+
+    // The memo includes the offending KEYS, not just the field name: metadata
+    // that grows a NEW bad rule after the first report must still shout.
+    view.rerender(<Form schema={schemaWith({ email: true })} />);
+    expect(ruleErrors(spy)).toHaveLength(2);
   });
 
   it('does NOT compile string patterns at the read point — rejected by the ruling', async () => {

--- a/packages/components/src/renderers/form/__tests__/unrecognized-validation-rules.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/unrecognized-validation-rules.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Unrecognized validation-rule names SHOUT instead of vanishing
+ * (objectui#5099, B's error half of the 2026-08-18 maintainer ruling).
+ *
+ * The form renderer's single read point spreads a field's `validation`
+ * verbatim into react-hook-form rules, and react-hook-form's field validator
+ * destructures a fixed rule set and drops everything else without a trace. A
+ * misspelled `minlength`, an invented `email`, or the numeric keys left by
+ * spreading an ARRAY into `validation` therefore produced a form that LOOKED
+ * validated and ran nothing — the exact place AI-authored metadata hides its
+ * mistakes.
+ *
+ * These fixtures reach the renderer as plain JSON (`as any`), where
+ * TypeScript never ran — precisely the gap the dev-time diagnostic covers;
+ * the compile-time half of the ruling is pinned in
+ * `packages/types/src/__tests__/field-validation-rules-pattern-regexp.test.ts`.
+ *
+ * Scope pin, both directions: the diagnostic REPORTS and must do nothing
+ * else. The ruling explicitly rejected compiling string patterns at this
+ * read point (consumer tolerance, AGENTS.md #0.1), so the last test asserts
+ * the string is handed to react-hook-form UNCOMPILED — if someone "helpfully"
+ * adds `new RegExp(...)` in form.tsx, that assertion goes red.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+beforeAll(() => {
+  // Ensure the form renderer is registered (imported above).
+  expect(ComponentRegistry.get('form')).toBeTruthy();
+}, 30000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}, onSubmit?: any) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues,
+        fields,
+        onSubmit: onSubmit ?? (() => {}),
+      }}
+    />,
+  );
+}
+
+/** The diagnostic lines this feature owns, ignoring React's own noise. */
+const ruleErrors = (spy: { mock: { calls: unknown[][] } }) =>
+  spy.mock.calls
+    .map((args) => String(args[0]))
+    .filter((msg) => msg.includes('validation rule(s)'));
+
+describe('form renderer — unrecognized validation rule names (objectui#5099)', () => {
+  it('reports a misspelled and an invented rule name, naming field and keys', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    renderForm([
+      {
+        name: 'username',
+        label: 'Username',
+        type: 'input',
+        validation: {
+          minlength: { value: 3, message: 'too short' }, // misspelled: minLength
+          email: true, // invented: not a react-hook-form rule
+        },
+      },
+    ]);
+
+    const msgs = ruleErrors(spy);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toContain("form field 'username'");
+    expect(msgs[0]).toContain("'minlength'");
+    expect(msgs[0]).toContain("'email'");
+    // The message doubles as the fix instruction.
+    expect(msgs[0]).toContain('minLength');
+    expect(msgs[0]).toContain('pattern');
+  });
+
+  it('reports the numeric keys left by spreading an array into `validation`', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // The #5075 group-1 shape: an ARRAY of rules, which spreads into numeric
+    // keys react-hook-form never reads.
+    renderForm([
+      {
+        name: 'code',
+        label: 'Code',
+        type: 'input',
+        validation: [{ required: 'Code is required' }],
+      },
+    ]);
+
+    const msgs = ruleErrors(spy);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toContain("form field 'code'");
+    expect(msgs[0]).toContain("'0'");
+  });
+
+  it('stays silent for a validation object made only of recognized rules', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    renderForm([
+      {
+        name: 'slug',
+        label: 'Slug',
+        type: 'input',
+        validation: {
+          required: 'Slug is required',
+          minLength: { value: 3, message: 'At least 3 characters' },
+          pattern: { value: /^[a-z0-9-]+$/, message: 'Lowercase letters, digits, dashes' },
+        },
+      },
+    ]);
+
+    expect(ruleErrors(spy)).toHaveLength(0);
+  });
+
+  it('a RegExp pattern actually validates — the recognized path runs', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onSubmit = vi.fn();
+    renderForm(
+      [
+        {
+          name: 'slug',
+          label: 'Slug',
+          type: 'input',
+          validation: {
+            pattern: { value: /^[a-z0-9-]+$/, message: 'Lowercase letters, digits, dashes' },
+          },
+        },
+      ],
+      { slug: 'NOT VALID!' },
+      onSubmit,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Lowercase letters, digits, dashes')).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does NOT compile string patterns at the read point — rejected by the ruling', async () => {
+    // A string pattern (illegal on the narrowed type, smuggled in as JSON) is
+    // reported by no diagnostic here — `pattern` IS a recognized rule name —
+    // and must reach react-hook-form UNCOMPILED, where it validates nothing:
+    // submit goes straight through despite the value violating the "pattern".
+    // If this submit starts being blocked, someone added the normalization
+    // the maintainer rejected (or react-hook-form started accepting strings —
+    // either way, re-read #5099 before touching this).
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onSubmit = vi.fn();
+    renderForm(
+      [
+        {
+          name: 'slug',
+          label: 'Slug',
+          type: 'input',
+          validation: {
+            pattern: { value: '^[a-z0-9-]+$', message: 'never shown' },
+          },
+        },
+      ],
+      { slug: 'NOT VALID!' },
+      onSubmit,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('never shown')).not.toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../ui/select';
 import { renderChildren } from '../../lib/utils';
 import { toControlValue, matchOptionValue, type OptionValue } from './option-value';
+import { RHF_RECOGNIZED_RULE_KEYS } from './validationRuleKeys';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../ui/tabs';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../../custom/resizable';
 import { Alert, AlertDescription } from '../../ui/alert';
@@ -799,6 +800,37 @@ ComponentRegistry.register('form',
         }
       }
     }, [rawFields, specVocabularyFields]);
+
+    // ── Unrecognized validation-rule names fail LOUDLY (#5099) ────────────
+    // react-hook-form's field validator destructures a FIXED rule set (see
+    // validationRuleKeys.ts, pinned against the installed bundle) and drops
+    // every other key without a trace — a misspelled `minlength`, an invented
+    // `email`, or the numeric keys left by spreading an ARRAY into
+    // `validation` all yield a form that LOOKS validated and runs nothing.
+    // `FieldValidationRules` already rejects these at compile time; this
+    // catches the metadata that reaches the renderer as plain JSON, where
+    // TypeScript never ran. Report-only by design: the maintainer ruling on
+    // #5099 explicitly rejected normalizing/compiling at this read point
+    // (consumer tolerance, AGENTS.md #0.1) — the fix belongs at the producer.
+    React.useEffect(() => {
+      for (const f of rawFields as any[]) {
+        const v = f?.validation;
+        if (v == null || typeof v !== 'object') continue;
+        const unrecognized = Object.keys(v).filter((k) => !RHF_RECOGNIZED_RULE_KEYS.has(k));
+        if (unrecognized.length === 0) continue;
+        // The message doubles as the fix instruction — it is what an agent
+        // iterating on the metadata will read and follow.
+        console.error(
+          `[object-ui] form field '${f?.name}': validation rule(s) ${unrecognized
+            .map((k) => `'${k}'`)
+            .join(', ')} are not rules react-hook-form runs — the field renders, but these rules ` +
+            `validate NOTHING. Recognized rules: ${[...RHF_RECOGNIZED_RULE_KEYS].join(', ')}. ` +
+            `Check the spelling (\`minLength\`, not \`minlength\`); express email/url checks as a ` +
+            `\`pattern\` whose \`value\` is a RegExp; and declare \`validation\` as an OBJECT — ` +
+            `spreading an array leaves numeric keys that run nothing.`,
+        );
+      }
+    }, [rawFields]);
 
     // A two-state control has no third state, so a boolean field that nobody
     // supplied a value for starts at `false` — not `undefined`. Without this

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -234,6 +234,46 @@ const BOOLEAN_WIDGET_TYPES = new Set([
 const resolveWidgetType = (f: any): string => f?.widget || f?.field?.widget || f?.type;
 
 const BUILTIN_FIELD_TYPES = new Set(['input', 'textarea', 'checkbox', 'switch', 'select']);
+
+/**
+ * Fields whose unrecognized validation-rule names were already reported, keyed
+ * by field name + the sorted offending keys. Module-level for the same reason
+ * as `basic/div.tsx`'s `_warnedDeprecations`: `rawFields` is a caller-owned
+ * prop, and a schema-driven caller that rebuilds the array per render re-runs
+ * the reporting effect every render — a diagnostic that repeats forever gets
+ * muted by the very reader the message is written for (objectui#3965 measured
+ * ~190 identical notices burying the real errors).
+ */
+const _reportedUnrecognizedRules = new Set<string>();
+
+/**
+ * Report a field's unrecognized validation-rule names ONCE per module load,
+ * dev builds only (#5099's "dev-time error" limb — a customer's production
+ * console is not the audience).
+ *
+ * Same shape as `warnDeprecatedOnce` in `basic/div.tsx` / `basic/span.tsx`,
+ * and order matters the same way there and here: the production check returns
+ * BEFORE the seen-set is marked, so a production render never suppresses the
+ * dev notice. The memo includes the offending keys, not just the field name —
+ * metadata that grows a NEW bad rule after the first report must still shout.
+ */
+function reportUnrecognizedRulesOnce(fieldName: string, unrecognized: string[]): void {
+  if (process.env.NODE_ENV === 'production') return;
+  const memo = `${fieldName}::${[...unrecognized].sort().join(',')}`;
+  if (_reportedUnrecognizedRules.has(memo)) return;
+  _reportedUnrecognizedRules.add(memo);
+  // The message doubles as the fix instruction — it is what an agent
+  // iterating on the metadata will read and follow.
+  console.error(
+    `[object-ui] form field '${fieldName}': validation rule(s) ${unrecognized
+      .map((k) => `'${k}'`)
+      .join(', ')} are not rules react-hook-form runs — the field renders, but these rules ` +
+      `validate NOTHING. Recognized rules: ${[...RHF_RECOGNIZED_RULE_KEYS].join(', ')}. ` +
+      `Check the spelling (\`minLength\`, not \`minlength\`); express email/url checks as a ` +
+      `\`pattern\` whose \`value\` is a RegExp; and declare \`validation\` as an OBJECT — ` +
+      `spreading an array leaves numeric keys that run nothing.`,
+  );
+}
 /**
  * Widget-hint pickers that resolve records / object catalogs and read sibling
  * field values — they need `dataSource` and `dependentValues` threaded exactly
@@ -812,23 +852,14 @@ ComponentRegistry.register('form',
     // TypeScript never ran. Report-only by design: the maintainer ruling on
     // #5099 explicitly rejected normalizing/compiling at this read point
     // (consumer tolerance, AGENTS.md #0.1) — the fix belongs at the producer.
+    // Dev-only and once per field+rule-set: see reportUnrecognizedRulesOnce.
     React.useEffect(() => {
       for (const f of rawFields as any[]) {
         const v = f?.validation;
         if (v == null || typeof v !== 'object') continue;
         const unrecognized = Object.keys(v).filter((k) => !RHF_RECOGNIZED_RULE_KEYS.has(k));
         if (unrecognized.length === 0) continue;
-        // The message doubles as the fix instruction — it is what an agent
-        // iterating on the metadata will read and follow.
-        console.error(
-          `[object-ui] form field '${f?.name}': validation rule(s) ${unrecognized
-            .map((k) => `'${k}'`)
-            .join(', ')} are not rules react-hook-form runs — the field renders, but these rules ` +
-            `validate NOTHING. Recognized rules: ${[...RHF_RECOGNIZED_RULE_KEYS].join(', ')}. ` +
-            `Check the spelling (\`minLength\`, not \`minlength\`); express email/url checks as a ` +
-            `\`pattern\` whose \`value\` is a RegExp; and declare \`validation\` as an OBJECT — ` +
-            `spreading an array leaves numeric keys that run nothing.`,
-        );
+        reportUnrecognizedRulesOnce(String(f?.name), unrecognized);
       }
     }, [rawFields]);
 

--- a/packages/components/src/renderers/form/validationRuleKeys.ts
+++ b/packages/components/src/renderers/form/validationRuleKeys.ts
@@ -1,0 +1,62 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The validation-rule names react-hook-form actually RUNS (objectui#5099).
+ *
+ * react-hook-form's field validator destructures a FIXED key set off the
+ * field descriptor and silently drops every other key. From the installed
+ * 7.85.0 bundle (`dist/index.cjs.js`, minified):
+ *
+ *     const{ref:c,refs:f,required:m,maxLength:y,minLength:p,min:g,max:b,
+ *           pattern:V,validate:A,name:x,valueAsNumber:S,mount:k}=e._f
+ *
+ * Of those twelve, seven are authorable validation rules — the rest are
+ * field-descriptor internals react-hook-form writes itself and an author
+ * never supplies through `FieldValidationRules`. Any rule name outside the
+ * seven — a misspelled `minlength`, an invented `email`, the numeric keys
+ * left by spreading an ARRAY into `validation` — is dropped without a trace:
+ * the field renders, the form looks validated, and the rule never runs. The
+ * form renderer reports such names loudly (dev-time `console.error`; see
+ * `form.tsx`).
+ *
+ * Both lists are PINNED against the installed react-hook-form bundle by
+ * `__tests__/rhf-recognized-rule-keys.test.ts`, which re-derives the
+ * destructured set from `dist/index.cjs.js` at test time. A react-hook-form
+ * bump that changes the set turns that test red — forcing a human to re-sort
+ * the new key into one of these two lists — instead of silently rotting the
+ * diagnostic.
+ */
+
+/**
+ * Keys react-hook-form's validator destructures that are NOT authorable
+ * rules: descriptor internals the library maintains itself.
+ */
+export const RHF_DESCRIPTOR_NON_RULE_KEYS: readonly string[] = [
+  'ref',
+  'refs',
+  'name',
+  'valueAsNumber',
+  'mount',
+];
+
+/**
+ * The authorable rule names react-hook-form's validator reads. Exactly the
+ * declared key set of `FieldValidationRules` in `@object-ui/types` —
+ * declared = enforced; anything else in a field's `validation` object is a
+ * bug in the metadata, not a rule.
+ */
+export const RHF_RECOGNIZED_RULE_KEYS: ReadonlySet<string> = new Set([
+  'required',
+  'minLength',
+  'maxLength',
+  'min',
+  'max',
+  'pattern',
+  'validate',
+]);

--- a/packages/types/src/__tests__/field-validation-rules-pattern-regexp.test.ts
+++ b/packages/types/src/__tests__/field-validation-rules-pattern-regexp.test.ts
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FieldValidationRules.pattern.value` is `RegExp` — never `string` — on the
+ * hand-written surface (objectui#5099, maintainer ruling 2026-08-18).
+ *
+ * The old declaration said `string | RegExp`, and `string` was a lie the type
+ * system told on behalf of a runtime that never honored it: the form
+ * renderer's single read point spreads `validation` verbatim into
+ * react-hook-form rules, and react-hook-form's field validator applies
+ * `pattern` only when `value instanceof RegExp` (verified against the
+ * installed 7.85.0 bundle — see
+ * `packages/components/src/renderers/form/__tests__/rhf-recognized-rule-keys.test.ts`,
+ * which re-derives that premise from the bundle at test time). So
+ *
+ *     validation: { pattern: { value: '^[a-zA-Z0-9_]+$', message: '…' } }
+ *
+ * — a declaration the old type accepted without complaint — ran ZERO
+ * validations and raised zero errors. The form looked validated; nothing was.
+ *
+ * The ruling settles the direction as producer-side strictness (AGENTS.md
+ * #0.1): the hand-written surface narrows to `RegExp`, so a string pattern is
+ * a compile-time error instead of a silently-unvalidated field. Strings stay
+ * legal exactly where they are actually compiled — the metadata route's field
+ * declaration (`FieldSchema.pattern`), which `buildValidationRules` in
+ * `@object-ui/fields` turns into `new RegExp(...)` before the renderer sees
+ * it. The renderer deliberately does NOT compile strings at its read point:
+ * the ruling explicitly rejected that normalization as consumer tolerance
+ * that would harden the ambiguous declaration into contract.
+ *
+ * The `@ts-expect-error` below is REAL enforcement, not decoration: this
+ * package's `type-check` script compiles the tests (`tsc -p
+ * tsconfig.test.json`), so if someone widens `pattern.value` back to
+ * `string | RegExp`, the directive turns into an "unused '@ts-expect-error'"
+ * compile error and this file goes red.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { FieldValidationRules } from '../form';
+
+describe('FieldValidationRules.pattern.value is RegExp-only (objectui#5099)', () => {
+  it('accepts a compiled RegExp', () => {
+    const rules: FieldValidationRules = {
+      pattern: { value: /^[a-zA-Z0-9_]+$/, message: 'Letters, digits and underscores only' },
+    };
+    expect(rules.pattern?.value).toBeInstanceOf(RegExp);
+    expect(rules.pattern?.value.test('valid_name_1')).toBe(true);
+    expect(rules.pattern?.value.test('invalid name!')).toBe(false);
+  });
+
+  it('rejects a string pattern at compile time', () => {
+    const rules: FieldValidationRules = {
+      // @ts-expect-error a string pattern type-checked for years and then
+      // validated NOTHING — react-hook-form only applies `pattern` when the
+      // value is a RegExp instance. Strings belong to the metadata route
+      // (`FieldSchema.pattern`), which `buildValidationRules` compiles.
+      pattern: { value: '^[a-zA-Z0-9_]+$', message: 'silently dead until #5099' },
+    };
+    // Runtime half of the pin: the string really is inert exactly the way the
+    // issue measured — the check react-hook-form gates on is `instanceof`.
+    expect(rules.pattern!.value instanceof RegExp).toBe(false);
+  });
+});

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -764,8 +764,21 @@ export interface FieldValidationRules {
   max?: { value: number; message: string };
   /**
    * Pattern validation (regex)
+   *
+   * `value` must be a compiled `RegExp` on this hand-written surface — never a
+   * string. react-hook-form's field validator applies `pattern` only when
+   * `value instanceof RegExp` (verified against the installed 7.85.0 bundle),
+   * so a string here type-checked and then validated NOTHING, silently: the
+   * form looked validated while the rule never ran (objectui#5099, maintainer
+   * ruling 2026-08-18). String patterns belong to the metadata route's field
+   * declaration (`FieldSchema.pattern`), which `buildValidationRules` in
+   * `@object-ui/fields` compiles via `new RegExp(...)` before it reaches this
+   * shape. The renderer deliberately does NOT compile strings at its read
+   * point — that consumer-side tolerance would harden the ambiguous
+   * declaration into contract (AGENTS.md #0.1); the declaration is narrowed
+   * at the producer instead.
    */
-  pattern?: { value: string | RegExp; message: string };
+  pattern?: { value: RegExp; message: string };
   /**
    * Custom validation function
    * @param value - The field value to validate


### PR DESCRIPTION
Fixes #5099

Implements the maintainer ruling of 2026-08-18 (comment-5322881617, verbatim 「同意」), all three limbs:

## 1. A — the declaration narrows (producer-side strict)

`FieldValidationRules.pattern.value` is now `RegExp` — no longer `string | RegExp` (`packages/types/src/form.ts`). react-hook-form's field validator applies `pattern` only when `value instanceof RegExp` (re-derived from the installed 7.85.0 bundle, see below), so a string here type-checked for years and then validated nothing, silently. A hand-written string pattern is now a compile-time error. `string` survives only on the metadata route's field declaration (`FieldSchema.pattern`), which `buildValidationRules` in `@object-ui/fields` compiles — that route is untouched (read-only reference in this PR).

**In-repo callers turning red: zero.** Repo-wide sweep (turbo `type-check`, 81/81 tasks) found no caller authoring a string pattern; the docs example (`content/docs/plugins/plugin-form.mdx`) and `packages/types/examples/login-form.ts` already pass RegExp literals.

## 2. B's error half — unrecognized rule names shout

At the single read point's field list, the renderer now reports rule names react-hook-form does not run (`console.error`, house style of the #3090 vocabulary diagnostic: the message doubles as the fix instruction). A misspelled `minlength`, an invented `email`, and the numeric keys left by spreading an array into `validation` (the #5075 group-1 shape) all shout instead of vanishing.

The recognized set lives in `packages/components/src/renderers/form/validationRuleKeys.ts` and is **pinned against the installed react-hook-form bundle**, not prose: `rhf-recognized-rule-keys.test.ts` re-derives the validator's fixed `._f` destructure (`ref, refs, required, maxLength, minLength, min, max, pattern, validate, name, valueAsNumber, mount` in 7.85.0) from `dist/index.cjs.js` at test time with shape-based (minifier-safe) regexes, subtracts the descriptor internals, and requires exact set equality — a react-hook-form bump that changes the set turns the test red instead of silently rotting the diagnostic. The `instanceof RegExp` gate (the premise of limb 1) is pinned in the same file.

## 3. B's normalization half — NOT implemented, and pinned that way

No `new RegExp(...)` was added at the read point: the ruling explicitly rejected compiling strings there as consumer tolerance that would harden the ambiguous declaration into contract (AGENTS.md #0.1). This is pinned by test in both directions — `unrecognized-validation-rules.test.tsx` asserts a smuggled string pattern reaches react-hook-form uncompiled and validates nothing (submit passes), so if someone "helpfully" adds the normalization later, the suite goes red.

## Breaking change vs. the no-major gate — the deliberate reconciliation

This narrows a published type, and `scripts/check-changeset-no-major.mjs` forbids `major`. These do not conflict: this repo's version policy (AGENTS.md §版本号策略) reserves `major` exclusively for tracking `@objectstack` majors ("major 相同即兼容") and directs objectui's own breaking changes to ship as **`minor` with the breaking semantics stated plainly in the body** — which is also what the ruling ordered. The changeset (`.changeset/field-validation-rules-pattern-regexp-5099.md`) declares `minor` for `@object-ui/types` + `@object-ui/components` and states the breaking semantics up front: string patterns stop compiling, and red is the fix — every such caller was running zero validations already, so the error converts silent non-validation into explicit failure at authoring time.

## Verification (all at `0b27ef102`)

- New tests: 3 files, 9 tests passed (type pin, bundle pin, diagnostic behavior).
- Blast radius: `pnpm exec vitest run packages/components/src/renderers/form/ packages/types/` — 80 files, 683 tests passed.
- `pnpm --filter @object-ui/types type-check` and `...components type-check` green; full consumer radius `turbo run type-check` 81/81 green (every package is downstream of `@object-ui/types`, so the full run covers the whole radius).
- Lint (types, components) 3/3; `check-changeset-presence` / `check-changeset-fixed` / `check-changeset-no-major` / `check:control-bytes` / `check:doc-types` / `check:phantom-deps` / `check:self-import` green; `check:doc-snippets` green after a full workspace build (doc snippets compile against the narrowed built types).
- **Reverse verifications, from the committed state:**
  1. Cross-package `.d.ts` probe: a temp components file with a string pattern → `tsc` red with `Type 'string' is not assignable to type 'RegExp'` → probe deleted. Proves consumers read the rebuilt declaration, not a cache.
  2. Type ablation: restored `form.ts` from origin/main → types `tsc -p tsconfig.test.json` red (3 errors incl. `TS2578: Unused '@ts-expect-error'`) → restored. This leg's reader is tsc over src (relative import), no dist in the path.
  3. Diagnostic ablation: restored `form.tsx` from origin/main → the two reporting tests red, the other three green as expected (they pin behavior identical on main: silence for recognized rules, RegExp path validating, strings not compiled), bundle-pin test unaffected → restored. Reader is vitest over src via relative imports, no dist in the path.

## Out of scope, filed

#5186 — `FormFieldSchema.validation`'s zod mirror (`FieldConstraintsSchema`) contradicts `FieldValidationRules` in both directions (rejects the TS-legal object shape, accepts a flat shape the renderer never reads). Adjacent surface, measured evidence in the issue; not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_