### PR TITLE
docs(styling): carve out author-declared data-driven colour from the inline-style ban

### DIFF
--- a/.changeset/styling-data-driven-colour-carveout-5185.md
+++ b/.changeset/styling-data-driven-colour-carveout-5185.md
@@ -1,0 +1,9 @@
+---
+---
+
+Docs only: `AGENTS.md` §2 and `skills/objectui/rules/styling.md` now carve out
+author-declared, data-driven colour from the flat inline-style ban — permitted only as CSS
+custom properties consumed by static Tailwind utilities, so `dark:` stays a real variant.
+Component-authored static colour, colour literals in class strings, and any inline style
+that hard-codes a colour such that dark mode renders identically remain banned. No package
+source changes, so this declares no package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,17 @@ You don't just build components — you build a **Renderer** that interprets JSO
 - **Styling:** Tailwind CSS (utility-first).
   - ✅ Use `class-variance-authority` (cva) for component variants.
   - ✅ Use `tailwind-merge` + `clsx` (via `cn()`) for class overrides.
-  - ❌ No inline styles (`style={{}}`), CSS Modules, or styled-components.
+  - ❌ No inline styles (`style={{}}`), CSS Modules, or styled-components. The
+    hazard the ban exists to stop: an inline value that hard-codes a colour, so
+    dark mode renders identically and the design system loses theme control.
+    - ⚠️ **One carve-out — author-declared, data-driven colour.** A colour the
+      *author* declared in metadata (e.g. `options[].color`) may reach the DOM
+      through `style={{}}`, but **only** as CSS custom properties that *static*
+      Tailwind utilities consume, so `dark:` stays a real variant. Never a
+      colour-bearing property (`backgroundColor`, `color`) written inline, and
+      never a colour the *component* chose. Colour only — layout, spacing and
+      sizing stay on utilities. Full rule and worked example:
+      `skills/objectui/rules/styling.md`.
 - **UI primitives:** Shadcn UI (Radix) + Lucide icons.
 - **State:** Zustand (global store), React Context (scoped data).
 - **Testing:** Vitest + React Testing Library.

--- a/skills/objectui/rules/styling.md
+++ b/skills/objectui/rules/styling.md
@@ -1,6 +1,8 @@
 # Styling Rules
 
 > **Critical:** ObjectUI uses Tailwind CSS exclusively. No inline styles, CSS modules, or styled-components.
+> The single carve-out — *author-declared, data-driven* colour published as CSS custom
+> properties — is stated in full under **Rule: Author-Declared, Data-Driven Colour**.
 
 ## Rule: Use Tailwind Utility Classes Only
 
@@ -17,6 +19,11 @@
 // Never do this in ObjectUI
 <Card style={{ padding: '24px', color: 'red' }} />
 ```
+
+Both halves are wrong, for different reasons: `padding` has a utility, and `color: 'red'`
+is a colour the *component* chose. A colour the *author* declared is the one case inline
+`style` is permitted, and only in one shape — see **Rule: Author-Declared, Data-Driven
+Colour**.
 
 ## Rule: Use `cn()` for Class Merging
 
@@ -50,10 +57,79 @@ className="border-border"
 **❌ FORBIDDEN:**
 ```typescript
 className="bg-blue-500 text-white"  // ❌ Hard-coded color
-className="bg-[#3b82f6]"             // ❌ Arbitrary value
+className="bg-[#3b82f6]"             // ❌ Arbitrary value — a colour literal
 ```
 
 **Why:** Semantic tokens support theming and dark mode automatically.
+
+What is banned is the colour **literal**, not the arbitrary-value syntax itself:
+`bg-[color:var(--os-badge-bg)]` carries a custom property rather than a colour, and is the
+sanctioned carrier for author-declared colour — see the next rule.
+
+## Rule: Author-Declared, Data-Driven Colour (the one carve-out)
+
+The rules above ban **component-authored** colour. They do not ban rendering a colour the
+*author* declared — an `options[].color` on a select field, a Gantt task's `color`, a
+conditional-formatting rule's `backgroundColor`. Those values exist only at runtime, so no
+class string can carry them, and quietly discarding or quantizing them is a bug in its own
+right.
+
+The permitted shape is narrow: publish the declared colour as **CSS custom properties** on
+the element, and let **static** Tailwind utilities consume them.
+
+**✅ CORRECT:**
+```typescript
+// The utility string is a literal, so Tailwind emits these classes at build time —
+// and `dark:` stays a real variant that the theme still controls.
+const HEX_BADGE_CLASSES =
+  'bg-[color:var(--os-badge-bg)] text-[color:var(--os-badge-fg)] ' +
+  'dark:bg-[color:var(--os-badge-bg-dark)] dark:text-[color:var(--os-badge-fg-dark)]';
+
+<span
+  className={HEX_BADGE_CLASSES}
+  style={{
+    '--os-badge-bg': surface,
+    '--os-badge-fg': label,
+    '--os-badge-bg-dark': surfaceDark,
+    '--os-badge-fg-dark': labelDark,
+  } as React.CSSProperties}
+/>
+```
+
+**❌ FORBIDDEN — the same author value, painted straight in:**
+```typescript
+<span style={{ backgroundColor: option.color }} />  // ❌ dark mode renders identically
+```
+
+**Still banned, unchanged:**
+
+- colour the **component** chose, in any form — that is what semantic tokens are for;
+- colour **literals** in class strings (`bg-blue-500`, `bg-[#3b82f6]`);
+- **any** inline style that hard-codes a colour such that dark mode renders identically.
+  That last one is the property that actually decides a case — not whether the word
+  `style` appears in the diff.
+
+**Why:** semantic tokens exist so that theming and dark mode work automatically. A pattern
+that preserves that property satisfies the rule; a pattern that defeats it does not.
+Routing an author's value through custom properties keeps both themes under the design
+system's control — the component supplies *values*, the stylesheet still supplies the
+*rules*, and a theme can still restyle or override them. Writing the value into
+`backgroundColor` hands the component the rules as well, and dark mode is the first thing
+that is lost.
+
+Read that rationale as the test. It decides cases this page does not list: a new widget
+that paints an author's colour, a token added to the palette, a helper that returns a
+style object. If the design system keeps theme control, the pattern is in; if the rendered
+colour is the same byte in both themes, it is out.
+
+Scope: **colour only**, and only where the value is an author's declaration. This is not a
+general licence for `style={{}}` — layout, spacing and sizing stay on utilities, and a
+runtime *geometry* value (a computed bar offset, a virtualiser's row height) is a separate
+question this carve-out does not answer.
+
+**Worked reference:** `getBadgeHexAppearance` / `getDotHexAppearance` in
+`packages/fields/src/index.tsx`, added by PR #5184 — the derived surface, label and border
+are published as custom properties and consumed by the static utility pair above.
 
 ## Rule: Use Component Variants (CVA)
 
@@ -122,6 +198,11 @@ className="bg-white dark:bg-gray-900"
 // ✅ Semantic tokens handle dark mode automatically
 className="bg-background text-foreground"
 ```
+
+The one exception is the custom-property carrier for author-declared colour, where an
+explicit `dark:` variant is what *keeps* dark mode real rather than bypassing it — see
+**Rule: Author-Declared, Data-Driven Colour**. Hand-picking a `dark:` colour the component
+chose is still wrong.
 
 ## Rule: No Manual Z-Index
 


### PR DESCRIPTION
Fixes #5185

⛔ **Governed surface — do not merge this by machine.** `AGENTS.md` and `skills/**` are agent-instruction files. This PR is deliberately left **draft**: no auto-merge, no queue, no merge by any AI seat. "Reviewed and green" is not an exception. The maintainer merges it by hand.

Implements the maintainer's 2026-08-18 ruling, option A of three: amend the docs to carve out data-driven author-declared colour, keeping the ban on component-authored static colour. Options B (per-PR argument) and C (an ESLint rule) were not chosen, and nothing here adds, scaffolds or proposes a lint rule.

## The gap

`AGENTS.md` §2 and `skills/objectui/rules/styling.md` stated a flat ban: no inline styles, no hard-coded colour. Author metadata such as `options[].color` only exists at runtime, so no class string can carry it, and the repo already publishes such values through inline style. An agent hitting a data-driven-colour card had to decide for itself whether an unenforced written rule constrained *how* or *whether*.

## What the carve-out permits, and what it still bans

**Permitted:** author-declared colour published as CSS custom properties that **static** Tailwind utilities consume — so `dark:` stays a real variant and the design system keeps theme control.

**Still banned:** component-authored static colour; colour literals in class strings; and **any inline style that hard-codes a colour such that dark mode renders identically**. That last clause is named explicitly in both files, because it is the property that actually decides a case — not whether the word `style` appears in the diff.

The rationale ships with the rule rather than just the list: semantic tokens exist so theming and dark mode work automatically, so a pattern preserving that property is in and one defeating it is out. That is what lets a reader decide a case the text did not anticipate.

Scope is stated as colour only. Layout, spacing and sizing stay on utilities, and runtime *geometry* is explicitly called out as a separate question this carve-out does not answer — the failure mode being guarded against is a carve-out loose enough to read as "inline styles are fine now".

## Amended in place, not appended

Three sections would otherwise have disagreed with the new rule, so each now points at the one section that owns it:

- the top-of-file summary blockquote;
- **Rule: Use Tailwind Utility Classes Only** — its forbidden example mixes a layout value and a component-chosen colour, which are wrong for different reasons;
- **Rule: Dark Mode with Semantic Tokens** — the direct tension. Its "do not manually add `dark:` variants" line is correct for component-chosen colour and exactly backwards for the carrier pattern, where an explicit `dark:` variant is what *keeps* dark mode real.

**Rule: Use Semantic Color Tokens** is sharpened rather than cross-referenced: what is banned is the colour **literal**, not arbitrary-value syntax as such, since the sanctioned carrier `bg-[color:var(--os-badge-bg)]` is itself an arbitrary value carrying a custom property. Leaving that unstated would have made the new rule contradict the old one on its own worked example.

## Verification of the card's evidence (re-derived, not taken on trust)

The card's measurements were a clue, not a spec, and one of them moved:

- **the count drifted the same day.** `grep -rn 'style={{' packages/*/src` re-derives to **260**, against the 254 the card measured on this same `origin/main`. That is the argument for the card's own preference, which this PR follows: **no raw count appears in the doc text.** A census rots on the next call site; the shape does not.
- **the three author-colour paths are real**, and each was located rather than assumed: `packages/plugin-gantt/src/GanttView.tsx:3637` (`backgroundColor: task.color || '#3b82f6'`), `ruleToStyle` in `packages/core/src/evaluator/listConditional.ts:381` (`backgroundColor` / `textColor` / `borderColor` straight onto a style map), and `packages/app-shell/src/views/metadata-admin/SchemaForm.tsx:1701` (`backgroundColor: opt.color`).

Worth noting for review, since it shapes the text: **all three use the direct form the new rule does not permit** — they paint the author's value into a colour-bearing property. So the doc cites them as the practice that made the flat rule untrue, and does **not** hold them up as conforming examples. The worked reference is the custom-property pattern instead. Per the ruling, none of these sites is audited or changed here.

The worked reference `getBadgeHexAppearance` / `getDotHexAppearance` was read from PR #5184's head (`26e78af0f`), not assumed. Those symbols are not on `main` yet — that PR is still open — so the doc attributes them to PR #5184, and the fenced example in `styling.md` states the pattern in full so the rule stands on its own if that reference ever moves. The cited path `packages/fields/src/index.tsx` does exist on `main`, which is what `Skill Guide Path Check` asserts.

## Gates

Re-derived from the actual diff (two markdown files plus one changeset), then run at the final commit **`3c146dd0b`** with a clean working tree:

```
check-control-bytes          exit=0  OK (scanned 4595 tracked text files; skipped 85 binary)
check-skills-paths           exit=0  OK (94/95 stated paths resolve across 18 guide files; 1 baselined)
check-doc-links              exit=0  Links are valid across 13 scan roots
check-changeset-presence     exit=0  No source of a released package changed in this range
check-changeset-fixed        exit=0  All workspace packages are in the changeset fixed group
check-changeset-no-major     exit=0  No changeset declares a major bump
```

`Skill Guide Path Check` is the live one here — the diff edits under `skills/`, and its checked-assertion count rises with this change while staying green. `check-links.yml` (external links) is `schedule` + `workflow_dispatch` only and does not run on PRs. Beyond the gate, the changed files were scanned directly for control bytes: no hits.

**Changeset:** empty-frontmatter, the sanctioned declaration — the diff touches no `packages/*/src`, so no released package changes. This repo has no `skip-changeset` label and none was minted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_