### PR TITLE
fix(app-shell): host a notification's app-relative deep link under an app

### DIFF
--- a/.changeset/notification-deep-link-host-app.md
+++ b/.changeset/notification-deep-link-host-app.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Notification deep links now open the record instead of the app landing page.
+
+A notification's `action_url` is app-relative by contract — the messaging
+service synthesizes `/{object}/{id}` from the event's source (ADR-0030 L5), so
+it names a record and the console has to host it under an app. Home's action
+centre navigated the field verbatim, and the top-bar bell navigated it bare on
+every surface that mounts outside `/apps/:appName/*` (`/home`, `/organizations`,
+the full-page AI screen). Either way the path matched no route, so the console
+catch-all forwarded it to `/` and the landing resolver dropped the user on the
+default app's home — with the notification already marked read, which destroyed
+the pointer to the record rather than merely misdirecting it.
+
+Both surfaces now resolve the target through one shared helper, which reuses the
+same host-app resolution the inbox and activity drills already use, leaves an
+explicit `/apps/...` target untouched, and opens off-console links in a new tab
+instead of routing them.

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -28,7 +28,12 @@ import { HomeAppsStrip } from './HomeAppsStrip';
 import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
 import { useNavigationContext } from '../../context/NavigationContext';
-import { appRouteSegment, filterActiveApps, resolveHostAppSegment } from '../../utils';
+import {
+  appRouteSegment,
+  filterActiveApps,
+  resolveHostAppSegment,
+  resolveNotificationTarget,
+} from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
 import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText, Hammer, LayoutTemplate } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
@@ -602,12 +607,29 @@ export function HomePage() {
               unreadTopicCount={unreadTopicCount}
               notificationsStatus={notificationsStatus}
               onOpenApprovals={() => navigate(`/apps/${hostAppSegment}/system/approvals`)}
-              /* The fallback arm runs whenever a notification carries no
-                 `action_url`; `?view=mine` selects the user-scoped view, so the
-                 full page matches what the card showed (objectui#4074). */
-              onOpenNotification={(n) =>
-                navigate(n.actionUrl || `/apps/${hostAppSegment}/sys_inbox_message?view=mine`)
-              }
+              /* `action_url` is APP-RELATIVE (`/{object}/{id}`, ADR-0030 L5),
+                 so it has to be hosted under an app before it is a route —
+                 navigating it verbatim is objectui#5179, where the console
+                 catch-all forwarded the unmatched path to `/` and the landing
+                 resolver dropped the user on the default app's home with the
+                 notification already marked read. `resolveNotificationTarget`
+                 is shared with the top-bar bell so the two cannot answer this
+                 differently. The fallback arm runs whenever a notification
+                 carries no link at all; `?view=mine` selects the user-scoped
+                 view, so the full page matches what the card showed
+                 (objectui#4074). */
+              onOpenNotification={(n) => {
+                const target = resolveNotificationTarget(n.actionUrl, hostAppSegment);
+                if (!target) {
+                  navigate(`/apps/${hostAppSegment}/sys_inbox_message?view=mine`);
+                  return;
+                }
+                if (target.kind === 'external') {
+                  window.open(target.url, '_blank', 'noopener,noreferrer');
+                  return;
+                }
+                navigate(target.path);
+              }}
               t={t}
             />
           </div>

--- a/packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Home's "Needs your attention" rows follow a notification's deep link INTO an
+ * app (objectui#5179).
+ *
+ * ## The defect
+ *
+ * `action_url` is **app-relative** by contract. The producer says so in as many
+ * words — `service-messaging`'s `actionUrlFor()` synthesizes
+ * `/{object}/{id}` "so the materialization is self-sufficient for navigation
+ * (ADR-0030 L5)" — and its own pins carry that shape (`/showcase_task/t_42`,
+ * `/opportunities/42`). It names a RECORD, not a console route: the app that
+ * hosts it is the client's to resolve, exactly as for `sys_inbox_message` and
+ * `sys_activity` next door.
+ *
+ * `onOpenNotification` navigated `n.actionUrl` verbatim, so the app-relative
+ * path was handed to the router as if it were absolute. `/showcase_task/t_42`
+ * matches no route, the console's catch-all (`apps/console/src/App.tsx`,
+ * `<Route path="*" element={<Navigate to="/" replace />} />`) forwards it to
+ * `/`, and `RootLandingRedirect` resolves that to `/apps/<default app>` — the
+ * app landing page, which is precisely what the card reports.
+ *
+ * ## Why the existing pin did not catch it
+ *
+ * `HomePage.inboxLinksTarget.test.tsx`'s CONTROL case seeds
+ * `actionUrl: '/apps/acme/invoice/42'` — a path already carrying its `/apps/`
+ * segment, i.e. the one shape that survives being navigated verbatim. The
+ * producer never emits it. These cases seed the shape the producer actually
+ * emits.
+ *
+ * ## What these cases assert
+ *
+ * The RESOLVED TARGET — the argument `navigate()` receives — per the card's
+ * ruling that a test asserting only "navigation happened" passes against the
+ * bug. Nothing about the far end: whether the record renders is the card's
+ * second, already-verified control.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', email: 'ada@example.com' } }),
+  useIsWorkspaceAdmin: () => false,
+}));
+
+vi.mock('@object-ui/plugin-chatbot', () => ({
+  useAgents: () => ({ agents: [] }),
+  isAskAgent: () => false,
+  agentHasCapability: () => false,
+}));
+
+let appsFixture: any[] = [];
+let currentAppNameFixture: string | undefined;
+
+vi.mock('../../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: appsFixture, loading: false }),
+}));
+
+vi.mock('../../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ currentAppName: currentAppNameFixture }),
+}));
+
+let notificationsFixture: any[] = [];
+
+vi.mock('../../../hooks/useRecentItems', () => ({ useRecentItems: () => ({ recentItems: [] }) }));
+vi.mock('../../../hooks/useFavorites', () => ({ useFavorites: () => ({ favorites: [] }) }));
+vi.mock('../../../hooks/useHomeInbox', () => ({
+  useHomeInbox: () => ({
+    pendingApprovalsCount: 0,
+    notifications: notificationsFixture,
+    unreadTopicCount: notificationsFixture.length,
+    activities: [],
+  }),
+}));
+vi.mock('../../../hooks/useAiSurface', () => ({ resolveAiApiBase: () => '' }));
+vi.mock('../../../views/metadata-admin/useMetadata', () => ({
+  useMetadataClient: () => ({ listDrafts: async () => [] }),
+}));
+vi.mock('../../../preview/usePublishAllDrafts', () => ({
+  usePublishAllDrafts: () => ({ publishAll: async () => ({ ok: true }), publishing: false }),
+}));
+vi.mock('../../../runtime-config', () => ({
+  getRuntimeConfig: () => ({ branding: { productName: 'ObjectStack' } }),
+}));
+
+import { HomePage } from '../HomePage';
+
+const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
+
+/** Click the seeded notification row and read the argument `navigate()` got. */
+async function clickNotification(): Promise<string> {
+  const user = userEvent.setup();
+  render(<HomePage />);
+  await user.click(screen.getByText('Weekly digest'));
+  expect(navigateMock).toHaveBeenCalledTimes(1);
+  return navigateMock.mock.calls[0][0] as string;
+}
+
+describe('Home notification rows follow the deep link to the record (objectui#5179)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    appsFixture = [app('setup'), app('crm')];
+    currentAppNameFixture = 'crm';
+    notificationsFixture = [
+      { id: 'n1', title: 'Weekly digest', actionUrl: '/showcase_task/t_42' },
+    ];
+  });
+
+  it('hosts the app-relative action_url under the app the user last had open', async () => {
+    // The exact shape `actionUrlFor()` synthesizes from `source: {object, id}`.
+    expect(await clickNotification()).toBe('/apps/crm/showcase_task/t_42');
+  });
+
+  it('does NOT navigate the app-relative path verbatim', async () => {
+    // The bug, stated as its own case: `/showcase_task/t_42` matches no route,
+    // so the console catch-all forwards it to `/` and the landing resolver
+    // lands the user on the default app's home — with the notification already
+    // marked read, so the pointer to the record is gone.
+    const target = await clickNotification();
+    expect(target).not.toBe('/showcase_task/t_42');
+    expect(target.startsWith('/apps/')).toBe(true);
+  });
+
+  it('resolves the host app on a cold landing at /home, where no app is remembered', async () => {
+    // Home renders OUTSIDE `/apps/:appName/*`, so there is no route segment to
+    // read and `currentAppName` is undefined until the user has opened an app.
+    // An unresolved host is what produced the bare path in the first place.
+    appsFixture = [app('crm'), app('hr')];
+    currentAppNameFixture = undefined;
+    expect(await clickNotification()).toBe('/apps/crm/showcase_task/t_42');
+  });
+
+  it('does not resurrect a remembered app that is no longer active', async () => {
+    // Same re-check `resolveHostAppSegment` already applies to the inbox and
+    // activity drills — a link into a deactivated app is not reachable either.
+    appsFixture = [app('hr')];
+    currentAppNameFixture = 'crm';
+    expect(await clickNotification()).toBe('/apps/hr/showcase_task/t_42');
+  });
+
+  it('CONTROL: a target that already names its app is followed verbatim', async () => {
+    // An explicit `payload.url` wins over the synthesized link at the producer
+    // and may already be a full console route. Hosting it twice
+    // (`/apps/crm/apps/acme/...`) would break the case that works today.
+    notificationsFixture = [
+      { id: 'n1', title: 'Weekly digest', actionUrl: '/apps/acme/invoice/42' },
+    ];
+    expect(await clickNotification()).toBe('/apps/acme/invoice/42');
+  });
+
+  it('CONTROL: a notification with no action_url still opens the full inbox', async () => {
+    // The objectui#4074 fallback arm — unchanged, and pinned next door in
+    // `HomePage.inboxLinksTarget.test.tsx`. Repeated here so a change to the
+    // deep-link path cannot quietly swallow the no-link case.
+    notificationsFixture = [{ id: 'n1', title: 'Weekly digest' }];
+    expect(await clickNotification()).toBe('/apps/crm/sys_inbox_message?view=mine');
+  });
+});

--- a/packages/app-shell/src/layout/InboxPopover.tsx
+++ b/packages/app-shell/src/layout/InboxPopover.tsx
@@ -37,7 +37,7 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import type { ActivityItem } from './ActivityFeed';
 import { useNavigationContext } from '../context/NavigationContext';
 import { useMetadata } from '../providers/MetadataProvider';
-import { resolveHostAppSegment } from '../utils/appRoute';
+import { resolveHostAppSegment, resolveNotificationTarget } from '../utils/appRoute';
 import { timeAgo } from '../utils/relativeTime';
 import { groupNotifications } from './inboxGrouping';
 import type { InboxNotification, NotificationGroup } from './inboxGrouping';
@@ -154,33 +154,40 @@ export function InboxPopover({
 
   const handleNotificationClick = (n: InboxNotification) => {
     onMarkRead(n.id);
-    const app = currentAppName ?? params.appName;
     // Prefer the materialization's action_url (ADR-0030). The messaging
     // pipeline synthesizes an app-relative `/{object}/{id}` link from the
-    // event's source when a producer didn't set an explicit url.
-    if (n.action_url) {
-      setOpen(false);
-      const url = n.action_url;
-      if (/^https?:\/\//i.test(url)) {
-        window.open(url, '_blank', 'noopener,noreferrer');
-        return;
-      }
-      if (url.startsWith('/apps/')) {
-        navigate(url);
-        return;
-      }
-      const rel = url.startsWith('/') ? url : `/${url}`;
-      navigate(app ? `/apps/${app}${rel}` : rel);
+    // event's source when a producer didn't set an explicit url — so it names
+    // a RECORD, and `hostAppSegment` (already resolved above for the two "see
+    // all" drills) is what turns it into a route.
+    //
+    // This used to host it under a raw `currentAppName ?? params.appName` and
+    // navigate BARE when neither named an app — which is the state on every
+    // surface outside `/apps/:appName/*` that mounts this bell (`/home`,
+    // `/organizations`, the full-page AI screen). The bare path matched no
+    // route, the console catch-all forwarded it to `/`, and the landing
+    // resolver dropped the user on the default app's home: objectui#5179.
+    // Reusing the drills' own resolver also stops an unchecked remembered app
+    // from addressing a link into an app that has since been deactivated.
+    //
+    // The `source_object`/`source_id` arm below is the pre-ADR-0030 pointer,
+    // kept because it is this component's declared input shape — but note the
+    // shared feed does not populate either field today (`mergeInboxRows` maps
+    // neither), so nothing in this repo can currently reach it. It is resolved
+    // through the SAME helper rather than left building a bare
+    // `/objects/{object}/{id}`, which matches no route and lands on the app
+    // landing page for exactly the reason above.
+    const target =
+      resolveNotificationTarget(n.action_url, hostAppSegment) ??
+      (n.source_object && n.source_id
+        ? resolveNotificationTarget(`/${n.source_object}/${n.source_id}`, hostAppSegment)
+        : null);
+    if (!target) return;
+    setOpen(false);
+    if (target.kind === 'external') {
+      window.open(target.url, '_blank', 'noopener,noreferrer');
       return;
     }
-    // Back-compat fallback: explicit source object/record pointer.
-    if (n.source_object && n.source_id) {
-      setOpen(false);
-      const target = app
-        ? `/apps/${app}/${n.source_object}/${n.source_id}`
-        : `/objects/${n.source_object}/${n.source_id}`;
-      navigate(target);
-    }
+    navigate(target.path);
   };
 
   const toggleGroup = (key: string) => {

--- a/packages/app-shell/src/layout/__tests__/InboxPopover.notificationDeepLink.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/InboxPopover.notificationDeepLink.test.tsx
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The bell popover follows a notification's deep link INTO an app
+ * (objectui#5179) — the same defect Home's action centre carries, pinned in
+ * `console/home/__tests__/HomePage.notificationDeepLink.test.tsx`.
+ *
+ * ## The defect
+ *
+ * `handleNotificationClick` hosted the app-relative `action_url` under
+ * `currentAppName ?? params.appName` and navigated it BARE when neither names
+ * an app. That is not a rare state: this popover mounts on `/home`,
+ * `/organizations` and the full-page AI screen, all of which render OUTSIDE
+ * `/apps/:appName/*` — so there is no route segment, and `currentAppName` is
+ * undefined until the user has opened an app. On those surfaces the bare
+ * `/showcase_task/t_42` matches no route, the console catch-all forwards it to
+ * `/`, and the landing resolver drops the user on the default app's home.
+ *
+ * The two "see all" drills one screen up already resolve this correctly, via
+ * `resolveHostAppSegment` (objectui#4074) — the SAME question, answered two
+ * different ways in one file. This aligns them.
+ *
+ * A second, milder arm: `currentAppName` was used unchecked, so a remembered
+ * app that has since been deactivated produced `/apps/<dead app>/...`. The
+ * drills re-check it against the live active list; the deep link now does too.
+ *
+ * ## What these cases assert
+ *
+ * The RESOLVED TARGET — the argument `navigate()` receives (or the URL handed
+ * to `window.open` for an external link) — per the card's ruling that
+ * asserting "navigation happened" passes against the bug.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const navigateMock = vi.fn();
+
+let currentAppNameFixture: string | undefined;
+let routeAppNameFixture: string | undefined;
+let appsFixture: any[] = [];
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ appName: routeAppNameFixture }),
+}));
+
+vi.mock('../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ currentAppName: currentAppNameFixture }),
+}));
+
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: appsFixture, loading: false }),
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    language: 'en',
+    t: (key: string, options?: Record<string, unknown>) =>
+      String(options?.defaultValue ?? key).replace(/\{\{(\w+)\}\}/g, (_m, name: string) =>
+        String(options?.[name] ?? ''),
+      ),
+  }),
+}));
+
+vi.mock('@object-ui/components', () => ({
+  Button: ({ children, ...p }: any) => <button type="button" {...p}>{children}</button>,
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  TabsList: ({ children }: any) => <div>{children}</div>,
+  TabsTrigger: ({ children }: any) => <button type="button">{children}</button>,
+  TabsContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('lucide-react', () => ({
+  Bell: () => <span />,
+  CheckSquare: () => <span />,
+  Activity: () => <span />,
+  ChevronRight: () => <span />,
+}));
+
+import { InboxPopover, type InboxNotification } from '../InboxPopover';
+
+const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
+
+const notif = (over: Partial<InboxNotification> & { id: string }): InboxNotification => ({
+  type: 'collab.assignment',
+  title: 'Assigned to you',
+  is_read: false,
+  created_at: '2026-08-10T10:00:00Z',
+  ...over,
+});
+
+const markRead = vi.fn();
+
+/** Click the seeded notification row and read the argument `navigate()` got. */
+async function clickNotification(n: InboxNotification): Promise<string> {
+  const user = userEvent.setup();
+  render(
+    <InboxPopover
+      notifications={[n]}
+      unreadCount={1}
+      pendingApprovalsCount={0}
+      activities={[]}
+      onMarkAllRead={vi.fn()}
+      onMarkRead={markRead}
+    />,
+  );
+  await user.click(screen.getByText(n.title));
+  expect(navigateMock).toHaveBeenCalledTimes(1);
+  return navigateMock.mock.calls[0][0] as string;
+}
+
+describe('Bell notification rows follow the deep link to the record (objectui#5179)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    markRead.mockReset();
+    appsFixture = [app('setup'), app('crm')];
+    currentAppNameFixture = 'crm';
+    routeAppNameFixture = 'crm';
+  });
+
+  it('hosts the app-relative action_url under the app the user is in', async () => {
+    const target = await clickNotification(notif({ id: 'n1', action_url: '/showcase_task/t_42' }));
+    expect(target).toBe('/apps/crm/showcase_task/t_42');
+  });
+
+  it('resolves a host app on the surfaces that have no app segment at all', async () => {
+    // `/home`, `/organizations` and the full-page AI screen all mount this bell
+    // outside `/apps/:appName/*`. This is the arm that produced the reported
+    // symptom: a bare path, the catch-all, then the app landing page.
+    appsFixture = [app('crm'), app('hr')];
+    currentAppNameFixture = undefined;
+    routeAppNameFixture = undefined;
+    const target = await clickNotification(notif({ id: 'n1', action_url: '/showcase_task/t_42' }));
+    expect(target).toBe('/apps/crm/showcase_task/t_42');
+    expect(target).not.toBe('/showcase_task/t_42');
+  });
+
+  it('does not resurrect a remembered app that is no longer active', async () => {
+    appsFixture = [app('hr')];
+    currentAppNameFixture = 'crm';
+    routeAppNameFixture = undefined;
+    expect(await clickNotification(notif({ id: 'n1', action_url: '/showcase_task/t_42' }))).toBe(
+      '/apps/hr/showcase_task/t_42',
+    );
+  });
+
+  it('marks the notification read on the same click that navigates', async () => {
+    // The card's first control: mark-read is server-authoritative and fires.
+    // It is what makes a wrong target destroy the pointer rather than merely
+    // misdirect, so the fix must not trade one for the other.
+    await clickNotification(notif({ id: 'n1', action_url: '/showcase_task/t_42' }));
+    expect(markRead).toHaveBeenCalledWith('n1');
+  });
+
+  it('CONTROL: a target that already names its app is followed verbatim', async () => {
+    expect(await clickNotification(notif({ id: 'n1', action_url: '/apps/acme/invoice/42' }))).toBe(
+      '/apps/acme/invoice/42',
+    );
+  });
+
+  it('CONTROL: an external link opens in a new tab and is never routed', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const user = userEvent.setup();
+    render(
+      <InboxPopover
+        notifications={[notif({ id: 'n1', action_url: 'https://status.example.com/incident/7' })]}
+        unreadCount={1}
+        pendingApprovalsCount={0}
+        activities={[]}
+        onMarkAllRead={vi.fn()}
+        onMarkRead={markRead}
+      />,
+    );
+    await user.click(screen.getByText('Assigned to you'));
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://status.example.com/incident/7',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});

--- a/packages/app-shell/src/utils/__tests__/resolveNotificationTarget.test.ts
+++ b/packages/app-shell/src/utils/__tests__/resolveNotificationTarget.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `resolveNotificationTarget` — the one answer to "where does this
+ * notification's `action_url` take the user" (objectui#5179).
+ *
+ * The two producers that navigate a notification (Home's action centre and the
+ * top-bar bell) each had their own, and the two disagreed. These cases pin the
+ * policy itself; the two component test files pin that each producer actually
+ * routes through it.
+ *
+ * The input contract under test: `action_url` is APP-RELATIVE. The producer
+ * (`service-messaging`'s `actionUrlFor()`) takes an explicit `payload.url` when
+ * given one and otherwise synthesizes `/{object}/{id}` from the emit's source,
+ * "so the materialization is self-sufficient for navigation" (ADR-0030 L5).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveNotificationTarget } from '../appRoute';
+
+describe('resolveNotificationTarget', () => {
+  describe('the app-relative link the producer synthesizes', () => {
+    it('hosts /{object}/{id} under the resolved app', () => {
+      expect(resolveNotificationTarget('/showcase_task/t_42', 'crm')).toEqual({
+        kind: 'route',
+        path: '/apps/crm/showcase_task/t_42',
+      });
+    });
+
+    it('is the shape the producer actually emits', () => {
+      // `messaging-service.test.ts` pins `/showcase_task/t_42`;
+      // `inbox-channel.test.ts` pins `/opportunities/42`. Both are bare object
+      // paths — neither carries an `/apps/` segment, which is why navigating
+      // the field verbatim reached the console catch-all.
+      expect(resolveNotificationTarget('/opportunities/42', 'sales')).toEqual({
+        kind: 'route',
+        path: '/apps/sales/opportunities/42',
+      });
+    });
+
+    it('tolerates a producer that omits the leading slash', () => {
+      expect(resolveNotificationTarget('showcase_task/t_42', 'crm')).toEqual({
+        kind: 'route',
+        path: '/apps/crm/showcase_task/t_42',
+      });
+    });
+
+    it('carries a query string through untouched', () => {
+      expect(resolveNotificationTarget('/invoice/9?tab=lines', 'crm')).toEqual({
+        kind: 'route',
+        path: '/apps/crm/invoice/9?tab=lines',
+      });
+    });
+  });
+
+  describe('a target that already names its app', () => {
+    it('is left alone rather than hosted twice', () => {
+      // Hosting it again would build `/apps/crm/apps/acme/invoice/42` and break
+      // the one case that worked before this fix.
+      expect(resolveNotificationTarget('/apps/acme/invoice/42', 'crm')).toEqual({
+        kind: 'route',
+        path: '/apps/acme/invoice/42',
+      });
+    });
+
+    it('treats the bare app launcher as a console route too', () => {
+      expect(resolveNotificationTarget('/apps', 'crm')).toEqual({ kind: 'route', path: '/apps' });
+    });
+
+    it('does NOT mistake an object whose name merely starts with "apps" for one', () => {
+      // `/appsettings/1` is a record path, not `/apps/…`. A `startsWith('/apps')`
+      // test without the separator would silently strand it.
+      expect(resolveNotificationTarget('/appsettings/1', 'crm')).toEqual({
+        kind: 'route',
+        path: '/apps/crm/appsettings/1',
+      });
+    });
+  });
+
+  describe('off-console links', () => {
+    it('reports an https url as external instead of hosting it', () => {
+      // `/apps/crm/https://…` is not a route; the caller opens it instead.
+      expect(resolveNotificationTarget('https://status.example.com/incident/7', 'crm')).toEqual({
+        kind: 'external',
+        url: 'https://status.example.com/incident/7',
+      });
+    });
+
+    it('treats any other scheme as external, not just http(s)', () => {
+      expect(resolveNotificationTarget('mailto:ops@example.com', 'crm')).toEqual({
+        kind: 'external',
+        url: 'mailto:ops@example.com',
+      });
+    });
+
+    it('treats a protocol-relative url as external', () => {
+      // `//host/path` is another origin whatever the current scheme is.
+      expect(resolveNotificationTarget('//cdn.example.com/report.pdf', 'crm')).toEqual({
+        kind: 'external',
+        url: '//cdn.example.com/report.pdf',
+      });
+    });
+  });
+
+  describe('no link to follow', () => {
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['empty', ''],
+      ['blank', '   '],
+    ])('returns null for %s so the caller keeps its own fallback', (_label, input) => {
+      // Home opens the full inbox; the bell has nothing to open. Fabricating a
+      // target here would send both somewhere neither chose.
+      expect(resolveNotificationTarget(input as string | null | undefined, 'crm')).toBeNull();
+    });
+  });
+});

--- a/packages/app-shell/src/utils/appRoute.ts
+++ b/packages/app-shell/src/utils/appRoute.ts
@@ -241,3 +241,77 @@ function studioPackageId(app: AppLike | null | undefined): string | null {
   if (typeof packageId !== 'string' || !packageId || packageId === 'sys_metadata') return null;
   return packageId;
 }
+
+/**
+ * Where a notification's `action_url` should actually take the user
+ * (objectui#5179).
+ *
+ * ## The contract this reads
+ *
+ * `action_url` is **app-relative**, and the producer says so in as many words.
+ * `service-messaging`'s `actionUrlFor()` takes an explicit `payload.url` when
+ * one is given, and otherwise synthesizes `/{object}/{id}` from the emit's
+ * `source` "so the materialization is self-sufficient for navigation (the bell
+ * no longer has the L2 event's `source_object/source_id` to fall back on —
+ * ADR-0030 L5)". Its own pins carry that shape: `/showcase_task/t_42`,
+ * `/opportunities/42`.
+ *
+ * So the field names a RECORD, not a console route. Which app hosts it is the
+ * client's question — the same one {@link resolveHostAppSegment} answers for
+ * `sys_inbox_message` and `sys_activity`, and for the same reason: notifications
+ * are app-independent, so the app segment in the URL is a statement about WHERE
+ * THE USER IS.
+ *
+ * Navigating the field verbatim is what objectui#5179 reported. `/showcase_task/t_42`
+ * matches no route, so the console's catch-all (`<Route path="*" element={<Navigate
+ * to="/" replace />} />`) forwards it to `/`, and `RootLandingRedirect` resolves
+ * that to `/apps/<default app>` — the app landing page. Mark-as-read has already
+ * fired by then, so the user's pointer to the record is not misdirected but gone.
+ *
+ * ## Why a resolver rather than a prefix at each call site
+ *
+ * Both producers of this navigation — Home's action centre and the top-bar bell
+ * — had their own answer, and the two disagreed with each other AND with the
+ * two "see all" drills sitting in the same files. One resolver is what makes
+ * them incapable of drifting again; it is the same argument objectui#4074 made
+ * for `resolveHostAppSegment` one screen up.
+ *
+ * ## The three shapes, and why each is distinguished
+ *
+ * - **external** (`https://…`, or any other scheme) — a producer-supplied
+ *   `payload.url` pointing off-console. It must never be hosted: prefixing
+ *   would build `/apps/crm/https://…`, a route that does not exist. The caller
+ *   decides how to open it, because "new tab" is a UI decision, not a routing one.
+ * - **already a console route** (`/apps/…`) — an explicit `payload.url` that has
+ *   already named its app. Hosting it twice (`/apps/crm/apps/acme/…`) would
+ *   break the one case that worked before this fix.
+ * - **app-relative** (everything else) — the synthesized `/{object}/{id}`, and
+ *   the case this exists for. Hosted under `hostAppSegment`.
+ *
+ * Returns `null` for an absent or blank url, so callers keep their own fallback
+ * (Home opens the full inbox; the bell has no link to follow) rather than
+ * receiving a fabricated target. A protocol-relative `//host/path` counts as
+ * external — it is a URL to another origin, whatever the current scheme.
+ */
+export type NotificationTarget =
+  /** Off-console. Hand to `window.open`, never to the router. */
+  | { kind: 'external'; url: string }
+  /** An in-console path, ready for `navigate()`. */
+  | { kind: 'route'; path: string };
+
+export function resolveNotificationTarget(
+  actionUrl: string | null | undefined,
+  hostAppSegment: string,
+): NotificationTarget | null {
+  const url = (actionUrl ?? '').trim();
+  if (!url) return null;
+  // Any scheme (`https:`, `mailto:`, …) or a protocol-relative `//host` is off
+  // this console's router. Deliberately broader than an http(s) test: a
+  // `mailto:` link prefixed into `/apps/crm/mailto:…` is just as broken.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith('//')) return { kind: 'external', url };
+  const rel = url.startsWith('/') ? url : `/${url}`;
+  // Already addressed to an app — `/apps` alone included, which is the app
+  // launcher rather than a record, but still this console's own route.
+  if (rel === '/apps' || rel.startsWith('/apps/')) return { kind: 'route', path: rel };
+  return { kind: 'route', path: `/apps/${hostAppSegment}${rel}` };
+}

--- a/packages/app-shell/src/utils/index.ts
+++ b/packages/app-shell/src/utils/index.ts
@@ -40,7 +40,9 @@ export {
   appStudioDesignPath,
   appStudioSurfacePath,
   appStudioRoutePath,
+  resolveNotificationTarget,
 } from './appRoute';
+export type { NotificationTarget } from './appRoute';
 
 /**
  * Resolves objectui's KEYED i18n label to a plain string.


### PR DESCRIPTION
Fixes #5179

## Diagnosis — where the deep link is built, and why it resolved to the app root

The card asked for the answer, not just the symptom. It is a **consumer** defect, in link construction, exactly as the card scoped it. The server payload is fine, so the fork clause does not apply.

**The contract.** `action_url` is **app-relative**, and the producer says so in as many words. `service-messaging`'s `actionUrlFor()` takes an explicit `payload.url` when given one, and otherwise synthesizes `/{object}/{id}` from the emit's `source` — its own comment: *"so the materialization is self-sufficient for navigation (the bell no longer has the L2 event's `source_object/source_id` to fall back on — ADR-0030 L5)"*. Its pins carry that shape: `/showcase_task/t_42` (`messaging-service.test.ts`), `/opportunities/42` (`inbox-channel.test.ts`). The field names a **record**, not a console route — which app hosts it is the client's question.

**The failure.** Neither producer of this navigation answered that question reliably:

| producer | before | result |
|---|---|---|
| `console/home/HomePage.tsx` — "Needs your attention" | `navigate(n.actionUrl \|\| fallback)` — **verbatim** | always bare |
| `layout/InboxPopover.tsx` — the bell | hosted under raw `currentAppName ?? params.appName`, `navigate(rel)` when neither names an app | bare on every surface outside `/apps/:appName/*` |

A bare `/showcase_task/t_42` matches no route. `apps/console/src/App.tsx` ends in a catch-all route on path `"*"` whose element is a `Navigate` to `/` with `replace`; `/` is `RootLandingRedirect`, whose `resolveLandingPath()` returns `/apps/` + the default app's segment. **That is the app landing page in the report** — reached by catch-all, not by a broken route or a rendering failure.

The bell's bare arm is not an edge case: it mounts on `/home`, `/organizations` and the full-page AI screen, all of which render outside `/apps/:appName/*`, so there is no `params.appName` and `currentAppName` is undefined until the user has opened an app.

Both surfaces sat **feet from the correct answer** — the two "see all" drills in these same two files already resolve this with `resolveHostAppSegment` (#4074). One question, three answers in two files.

## Why the existing pin missed it

`HomePage.inboxLinksTarget.test.tsx`'s CONTROL seeds `actionUrl: '/apps/acme/invoice/42'` — a path that already carries its `/apps/` segment, i.e. the single shape that survives being navigated verbatim. The producer never emits it.

## The fix

`resolveNotificationTarget(actionUrl, hostAppSegment)` in `utils/appRoute.ts`, beside `resolveHostAppSegment` and reusing it, now the one answer both producers call. Three shapes, each distinguished for a measured reason:

- **app-relative** (`/showcase_task/t_42`) → hosted under the resolved app;
- **already a console route** (`/apps/...`) → untouched, so the case that worked is not double-hosted into `/apps/crm/apps/acme/...`;
- **off-console** (any scheme, or protocol-relative `//host`) → reported external and opened in a new tab, never prefixed into `/apps/crm/https://...`.

`null` for a blank url, so each caller keeps its own fallback (Home opens the full inbox; the bell has nothing to follow). Routing through `resolveHostAppSegment` also re-checks the remembered app against the live active list, so a deactivated app no longer addresses the link.

## Scope note — files beyond the claimed region, named per the exemption

The claim declared `console/home/**`, `hooks/sharedInboxFeed*` and `chrome/notificationToast.tsx`. Two files outside that were edited, under the bounded in-place rule — same defect class, mechanical, correct shape already pinned by `resolveHostAppSegment`, no competing claim, same gate family:

- **`layout/InboxPopover.tsx`** — the notification centre itself, and the second carrier of the identical defect. Measured red before the fix (see below).
- **`utils/appRoute.ts`** + `utils/index.ts` — where `resolveHostAppSegment` lives. `HomePage.tsx`'s own comment already rules this the correct home: the policy lives there *"so Home and the top-bar bell (`InboxPopover`) cannot drift into two different answers for the same question"*.

`views/RecordDetailView.tsx` (held by #5176) was **not** edited — not read into the diff, not touched. `hooks/sharedInboxFeed*` does not exist; the hook is `hooks/useHomeInbox.ts` over `hooks/sharedUserFeeds.ts`, and neither needed changing.

`origin/main` was merged before opening this PR, and #5176 had already landed at that point — merged clean, no conflict.

## Reverse verification

The card's acceptance floor is that the test must fail on unfixed `main`. Reverting **only** the two component files (`git checkout origin/main -- HomePage.tsx InboxPopover.tsx`) and re-running:

```
Test Files  2 failed (2)
     Tests  6 failed | 6 passed (12)

FAIL  HomePage.notificationDeepLink : hosts the app-relative action_url under the app the user last had open
FAIL  HomePage.notificationDeepLink : does NOT navigate the app-relative path verbatim
FAIL  HomePage.notificationDeepLink : resolves the host app on a cold landing at /home
FAIL  HomePage.notificationDeepLink : does not resurrect a remembered app that is no longer active
FAIL  InboxPopover.notificationDeepLink : resolves a host app on the surfaces that have no app segment at all
FAIL  InboxPopover.notificationDeepLink : does not resurrect a remembered app that is no longer active

AssertionError: expected '/showcase_task/t_42' to be '/apps/crm/showcase_task/t_42'
```

The 6 that stay green across both states are the CONTROLs (already-`/apps/` target, external link, no-link fallback, mark-read still fires) — they must pass in both, and do. Every assertion is on the **navigated URL**, never on "navigation occurred".

## Gates run — all on `6ff57bb9e` (final commit, post-merge)

| gate | result |
|---|---|
| `vitest run packages/app-shell/src/{utils,layout,console/home}/` | **56 files / 593 tests passed** |
| `vitest run packages/app-shell/src/{console,hooks}/` | 76 files / 603 tests passed |
| `pnpm --filter @object-ui/app-shell type-check` | pass (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/app-shell lint` | **0 errors** (2423 pre-existing warnings) |
| `node scripts/check-control-bytes.mjs` | OK — 4600 files |
| `node scripts/check-changeset-presence.mjs` | OK — 1 changeset for 7 source files |
| `node scripts/check-changeset-no-major.mjs` | OK — no `major` |

Changeset: `@object-ui/app-shell` **patch**.

## Out of scope — filed as #5190, not fixed here

`mergeInboxRows` (`hooks/sharedUserFeeds.ts`) never maps `source_object` / `source_id`, though `InboxNotification` declares both and the bell's back-compat arm reads them — so that arm is unreachable in the shipped tree. A notification carrying neither an `action_url` nor those fields marks itself read on click and navigates nowhere. Different root cause, different fix; the arm is preserved here (routed through the same helper rather than left building a bare `/objects/{object}/{id}`) instead of being removed.

_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_