### PR TITLE
fix(plugin-grid,plugin-kanban): honour a declared option hex on every badge surface

### DIFF
--- a/.changeset/badge-hex-cross-surface-5183.md
+++ b/.changeset/badge-hex-cross-surface-5183.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-grid': patch
+'@object-ui/plugin-kanban': patch
+---
+
+Grid group headers, compact cards and kanban card badges honour an author-declared option hex, matching the grid cell.
+
+objectui#5141 taught the grid's cell renderer (`SelectCellRenderer`) to render an
+explicitly declared `options[].color` hex as declared instead of quantizing it
+onto one of nine palette families. Four badge call sites in `plugin-grid` and
+`plugin-kanban` still resolved through `getBadgeColorClasses`, which returns a
+class string and therefore cannot carry a runtime colour — Tailwind can only
+emit classes it saw in the source at build time.
+
+The result was worse than the bug it replaced: the same option in the same
+object rendered one colour in a desktop grid cell and a different one in the
+group header above it or on the kanban card beside it. The pre-#5141 state was
+at least uniformly wrong.
+
+All four sites now resolve exactly as the cell does — prefer
+`getBadgeHexAppearance(color)` and use its `className` **and** its `style`,
+falling back to `getBadgeColorClasses` for palette-family names, no colour, and
+every other declaration. The compact card keeps its pipeline-stage heuristic
+when the author declared no colour at all.
+
+Two carriers were widened so the style can reach the element, because these
+badges are not all plain JSX: `GroupRow` takes a `labelColorStyle` alongside
+`labelColorClass`, and a kanban card badge takes `colorStyle` alongside
+`colorClass` (`KanbanCard.badges[]`). Both additions are optional and additive;
+a badge that carries only a class renders exactly as before. The colours ride
+CSS custom properties that the class reads, so a class passed without its style
+paints against undefined variables — the two halves have to travel together.
+
+Behaviour is unchanged for every declaration that is not an explicit hex.

--- a/packages/plugin-grid/src/GroupRow.tsx
+++ b/packages/plugin-grid/src/GroupRow.tsx
@@ -29,12 +29,24 @@ export interface GroupRowProps {
    */
   fieldLabel?: string;
   /**
-   * Optional Tailwind class string applied to the group label "pill". Use
-   * `getBadgeColorClasses(...)` from `@object-ui/fields` to derive a color
-   * matching the cell badge of the same field value. When omitted, the
-   * label renders as plain text with a subtle muted background.
+   * Optional Tailwind class string applied to the group label "pill".
+   *
+   * Derive it the way the cell renderer of the same field value derives it,
+   * or the header and the cell under it disagree on one option's colour
+   * (objectui#5183): prefer `getBadgeHexAppearance(color)` from
+   * `@object-ui/fields` and use its `className`, falling back to
+   * `getBadgeColorClasses(color, value)` when it returns `undefined`. When
+   * omitted, the label renders as plain text with a subtle muted background.
    */
   labelColorClass?: string;
+  /**
+   * Inline style accompanying `labelColorClass`. **Required whenever the
+   * class string came from `getBadgeHexAppearance`** — that className reads
+   * CSS custom properties which only this style declares, so passing the
+   * class alone paints a pill against undefined variables. Pass the helper's
+   * `style` verbatim; leave unset on the palette-family path.
+   */
+  labelColorStyle?: React.CSSProperties;
   /** Callback when the group header is clicked to toggle collapse */
   onToggle: (key: string) => void;
   /** Children to render when not collapsed (the group content) */
@@ -58,6 +70,7 @@ export const GroupRow: React.FC<GroupRowProps> = ({
   aggregations,
   fieldLabel,
   labelColorClass,
+  labelColorStyle,
   onToggle,
   children,
 }) => {
@@ -81,7 +94,7 @@ export const GroupRow: React.FC<GroupRowProps> = ({
         {collapsed
           ? <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           : <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
-        <span className={cn(pillClass, 'group-label')}>{label}</span>
+        <span className={cn(pillClass, 'group-label')} style={labelColorStyle}>{label}</span>
         <span className="text-xs text-muted-foreground tabular-nums group-count">{count}</span>
         {aggregations && aggregations.length > 0 && (
           <span className="ml-2 text-xs text-muted-foreground group-aggregations">

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -27,7 +27,7 @@ import { isSystemManagedField } from '@object-ui/types';
 import type { I18nLabel } from '@objectstack/spec/ui';
 import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useSafeFieldLabel, usePredicateScope, useRelatedRecordActions } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
-import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses, FieldEditWidget, hasFieldEditWidget, DISCRETE_EDIT_TYPES, coerceToSafeValue } from '@object-ui/fields';
+import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses, getBadgeHexAppearance, FieldEditWidget, hasFieldEditWidget, DISCRETE_EDIT_TYPES, coerceToSafeValue } from '@object-ui/fields';
 import { useLocalization, useDisplayLocale, resolveFieldCurrency } from '@object-ui/i18n';
 import { stateMachineNextValues, isFieldInlineEditable } from './inline-edit-options';
 import {
@@ -3124,17 +3124,29 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
                     {stageCol && row[stageCol.accessorKey] && (() => {
                       const rawValue = row[stageCol.accessorKey];
                       const optMeta = resolveOptionMeta(stageCol.accessorKey, rawValue);
-                      // Explicit option color wins (matches desktop grid via
-                      // getBadgeColorClasses); fall back to the pipeline-stage
-                      // heuristics keyed on the raw value, which stays stable
-                      // across locales.
-                      const badgeClasses = optMeta.color
-                        ? getBadgeColorClasses(optMeta.color, rawValue)
-                        : stageBadgeColor(String(rawValue));
+                      // Explicit option color wins, resolved EXACTLY as the
+                      // desktop cell resolves it (`SelectCellRenderer` in
+                      // `@object-ui/fields`): a declared hex renders as
+                      // declared via `getBadgeHexAppearance` (objectui#5141,
+                      // adopted here by objectui#5183), a family name keeps
+                      // going through `getBadgeColorClasses`. The `style` is
+                      // load-bearing — the hex ships as CSS custom properties
+                      // that the returned className reads, so dropping it
+                      // yields a badge referencing undefined variables.
+                      // With no declared colour at all we keep the
+                      // pipeline-stage heuristic keyed on the raw value,
+                      // which stays stable across locales.
+                      const hexBadge = getBadgeHexAppearance(optMeta.color);
+                      const badgeClasses = hexBadge
+                        ? hexBadge.className
+                        : optMeta.color
+                          ? getBadgeColorClasses(optMeta.color, rawValue)
+                          : stageBadgeColor(String(rawValue));
                       return (
                         <Badge
                           variant="outline"
                           className={`text-xs shrink-0 max-w-[140px] truncate ${badgeClasses}`}
+                          style={hexBadge?.style}
                         >
                           {optMeta.label}
                         </Badge>
@@ -3320,6 +3332,7 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
       ? resolveFieldLabel(schema.objectName, field, fieldDef?.label || field)
       : (fieldDef?.label || field);
     let labelColorClass: string | undefined;
+    let labelColorStyle: React.CSSProperties | undefined;
     const ftype = fieldDef?.type;
     if (ftype === 'select' || ftype === 'status') {
       const opts = fieldDef?.options
@@ -3328,13 +3341,22 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
       const matched = Array.isArray(opts)
         ? opts.find((o: any) => String(o.label) === label || String(o.value) === label)
         : undefined;
-      labelColorClass = getBadgeColorClasses(matched?.color, matched?.value ?? label);
+      // Same resolution as the cell below the header (`SelectCellRenderer`):
+      // a declared hex renders as declared (objectui#5141/#5183), everything
+      // else keeps resolving to a palette family. `labelColorStyle` carries
+      // the CSS custom properties the hex className reads — the pill needs
+      // BOTH halves or it references undefined variables.
+      const hexBadge = getBadgeHexAppearance(matched?.color);
+      labelColorClass = hexBadge
+        ? hexBadge.className
+        : getBadgeColorClasses(matched?.color, matched?.value ?? label);
+      labelColorStyle = hexBadge?.style;
     }
-    return { fieldLabel, labelColorClass };
+    return { fieldLabel, labelColorClass, labelColorStyle };
   };
 
   const renderGroup = (group: typeof groups[number]): React.ReactNode => {
-    const { fieldLabel, labelColorClass } = resolveGroupHeader(group.field, group.label);
+    const { fieldLabel, labelColorClass, labelColorStyle } = resolveGroupHeader(group.field, group.label);
     return (
       <div key={group.key}>
         <GroupRow
@@ -3345,6 +3367,7 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
           aggregations={group.aggregations}
           fieldLabel={group.depth === 0 ? fieldLabel : undefined}
           labelColorClass={labelColorClass}
+          labelColorStyle={labelColorStyle}
           onToggle={toggleGroup}
         >
           {group.subgroups.length > 0 ? (

--- a/packages/plugin-grid/src/__tests__/badgeHexCrossSurface.test.tsx
+++ b/packages/plugin-grid/src/__tests__/badgeHexCrossSurface.test.tsx
@@ -24,6 +24,16 @@
  * is rendered through all three of the grid's badge surfaces and the resolved
  * custom properties must be byte-identical across them.
  *
+ * ── Why every lookup is SCOPED to one surface ────────────────────────────
+ * Load-bearing, and measured: a grouped grid renders the group pill AND the
+ * leaf table's desktop cells, and both carry the option's label as their whole
+ * text content. An unscoped "find the element labelled Emerald that declares
+ * `--os-badge-bg`" therefore reads whichever comes first in document order —
+ * so with the fix reverted the group-header case still went GREEN off the
+ * CELL's variables, asserting nothing about the header. Each surface is
+ * addressed by its own selector below, and the two single-surface renders
+ * assert that no group pill exists to be confused with.
+ *
  * ── Why these two hexes ──────────────────────────────────────────────────
  * `#2ecc71` and `#1e8449` are the pair from #5141's report. Their hues differ
  * by 0.1°, so `hexToPaletteName` buckets BOTH into the `green` family — under
@@ -97,9 +107,9 @@ const BADGE_VARS = ['--os-badge-bg', '--os-badge-fg', '--os-badge-border'] as co
 
 type BadgeVars = Record<string, string>;
 
-/** Custom properties declared by the badge-ish element labelled `label`. */
-function badgeVarsFor(root: HTMLElement, label: string): BadgeVars | undefined {
-  const carrier = Array.from(root.querySelectorAll<HTMLElement>('[style]')).find(
+/** Custom properties declared by the labelled element within `candidates`. */
+function badgeVarsAmong(candidates: HTMLElement[], label: string): BadgeVars | undefined {
+  const carrier = candidates.find(
     (el) =>
       el.textContent?.trim() === label &&
       el.style.getPropertyValue('--os-badge-bg').trim() !== '',
@@ -109,6 +119,14 @@ function badgeVarsFor(root: HTMLElement, label: string): BadgeVars | undefined {
   for (const name of BADGE_VARS) out[name] = carrier.style.getPropertyValue(name).trim();
   return out;
 }
+
+/** Group-header pills only — never the cells in the group's leaf table. */
+const groupPills = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>('.group-label'));
+
+/** Everything styled on a render that has no group pills at all. */
+const styledNodes = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>('[style]'));
 
 function gridSchema(extra: Record<string, unknown> = {}) {
   return {
@@ -138,16 +156,16 @@ function renderGrid(schema: any) {
 async function desktopCellVars(label: string): Promise<BadgeVars | undefined> {
   const { container } = renderGrid(gridSchema());
   await waitFor(() => expect(screen.getAllByText(label).length).toBeGreaterThan(0));
-  return badgeVarsFor(container, label);
+  // Ungrouped: nothing here can be a group pill, so the lookup is unambiguous.
+  expect(groupPills(container)).toHaveLength(0);
+  return badgeVarsAmong(styledNodes(container), label);
 }
 
 /** Surface 2 — the group-header pill (`resolveGroupHeader` -> `GroupRow`). */
 async function groupHeaderVars(label: string): Promise<BadgeVars | undefined> {
   const { container } = renderGrid(gridSchema({ grouping: { fields: [{ field: 'stage' }] } }));
-  await waitFor(() =>
-    expect(container.querySelectorAll('.group-label').length).toBeGreaterThan(0),
-  );
-  return badgeVarsFor(container, label);
+  await waitFor(() => expect(groupPills(container).length).toBeGreaterThan(0));
+  return badgeVarsAmong(groupPills(container), label);
 }
 
 /** Surface 3 — the compact card / mobile stage badge. */
@@ -155,7 +173,8 @@ async function mobileCardVars(label: string): Promise<BadgeVars | undefined> {
   setMobileWidth();
   const { container } = renderGrid(gridSchema());
   await waitFor(() => expect(screen.getAllByText(label).length).toBeGreaterThan(0));
-  return badgeVarsFor(container, label);
+  expect(groupPills(container)).toHaveLength(0);
+  return badgeVarsAmong(styledNodes(container), label);
 }
 
 describe('objectui#5183 — a declared hex renders the same on every grid surface', () => {
@@ -182,13 +201,12 @@ describe('objectui#5183 — a declared hex renders the same on every grid surfac
     expect(card).toEqual(cell);
   });
 
-  it('two same-family hexes stay distinguishable (agreement is not quantization)', async () => {
+  it('two same-family hexes stay distinguishable in the group headers', async () => {
     const { container } = renderGrid(gridSchema({ grouping: { fields: [{ field: 'stage' }] } }));
-    await waitFor(() =>
-      expect(container.querySelectorAll('.group-label').length).toBeGreaterThan(1),
-    );
-    const emerald = badgeVarsFor(container, 'Emerald');
-    const forest = badgeVarsFor(container, 'Forest');
+    await waitFor(() => expect(groupPills(container).length).toBeGreaterThan(1));
+    const pills = groupPills(container);
+    const emerald = badgeVarsAmong(pills, 'Emerald');
+    const forest = badgeVarsAmong(pills, 'Forest');
     expect(emerald?.['--os-badge-bg']).toBeTruthy();
     expect(forest?.['--os-badge-bg']).toBeTruthy();
     expect(emerald!['--os-badge-bg']).not.toBe(forest!['--os-badge-bg']);

--- a/packages/plugin-grid/src/__tests__/badgeHexCrossSurface.test.tsx
+++ b/packages/plugin-grid/src/__tests__/badgeHexCrossSurface.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5183 — one option, one colour, whatever surface renders it.
+ *
+ * objectui#5141 taught the DESKTOP CELL (`SelectCellRenderer`) to render an
+ * author-declared hex as declared, via `getBadgeHexAppearance`, instead of
+ * quantizing it onto one of nine palette families. The grid's other two badge
+ * surfaces kept calling `getBadgeColorClasses`, which returns a class string
+ * and therefore cannot carry a runtime colour at all. The result was worse
+ * than the bug it replaced: the same option in the same object rendered one
+ * colour in a grid cell and a different one in the group header above it.
+ *
+ * ── Why the assertion is CROSS-SURFACE rather than per-site ───────────────
+ * Four independent per-site tests would each have passed against a site that
+ * quantizes, as long as it quantized consistently with itself. What broke is
+ * agreement BETWEEN surfaces, so that is what is pinned here: the same option
+ * is rendered through all three of the grid's badge surfaces and the resolved
+ * custom properties must be byte-identical across them.
+ *
+ * ── Why these two hexes ──────────────────────────────────────────────────
+ * `#2ecc71` and `#1e8449` are the pair from #5141's report. Their hues differ
+ * by 0.1°, so `hexToPaletteName` buckets BOTH into the `green` family — under
+ * the old class-only path every surface agreed by rendering them identically,
+ * which is agreement without fidelity. The last case pins that they stay
+ * distinguishable, so "the surfaces agree" can never be satisfied by
+ * quantizing every surface back to one family.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, waitFor, cleanup, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectGrid } from '../ObjectGrid';
+
+registerAllFields();
+
+/** The reported pair: same palette family, visibly different colours. */
+const EMERALD = '#2ecc71';
+const FOREST = '#1e8449';
+
+const OPTIONS = [
+  { value: 'emerald', label: 'Emerald', color: EMERALD },
+  { value: 'forest', label: 'Forest', color: FOREST },
+];
+
+const ROWS = [
+  { id: 'r1', name: 'Row one', stage: 'emerald' },
+  { id: 'r2', name: 'Row two', stage: 'forest' },
+];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: ROWS, total: ROWS.length, hasMore: false, pageSize: 50 })),
+    getObjectSchema: vi.fn(async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text', label: 'Name' },
+        stage: { type: 'select', label: 'Stage', options: OPTIONS },
+      },
+    })),
+  } as any;
+}
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+
+function setMobileWidth() {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 390 });
+}
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: ORIGINAL_INNER_WIDTH });
+  cleanup();
+});
+
+/**
+ * The declared colours ride CSS custom properties (the className that reads
+ * them is a build-time-static Tailwind string, identical on every surface —
+ * so the class alone proves nothing and the STYLE is the whole payload).
+ */
+const BADGE_VARS = ['--os-badge-bg', '--os-badge-fg', '--os-badge-border'] as const;
+
+type BadgeVars = Record<string, string>;
+
+/** Custom properties declared by the badge-ish element labelled `label`. */
+function badgeVarsFor(root: HTMLElement, label: string): BadgeVars | undefined {
+  const carrier = Array.from(root.querySelectorAll<HTMLElement>('[style]')).find(
+    (el) =>
+      el.textContent?.trim() === label &&
+      el.style.getPropertyValue('--os-badge-bg').trim() !== '',
+  );
+  if (!carrier) return undefined;
+  const out: BadgeVars = {};
+  for (const name of BADGE_VARS) out[name] = carrier.style.getPropertyValue(name).trim();
+  return out;
+}
+
+function gridSchema(extra: Record<string, unknown> = {}) {
+  return {
+    type: 'object-grid',
+    objectName: 'test_object',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'stage', label: 'Stage', type: 'select' },
+    ],
+    pagination: { pageSize: 50 },
+    ...extra,
+  } as any;
+}
+
+function renderGrid(schema: any) {
+  const ds = makeDataSource();
+  return render(
+    <ActionProvider>
+      <SchemaRendererProvider dataSource={ds}>
+        <ObjectGrid schema={schema} dataSource={ds} />
+      </SchemaRendererProvider>
+    </ActionProvider>,
+  );
+}
+
+/** Surface 1 — the desktop cell (`SelectCellRenderer`, fixed by #5141). */
+async function desktopCellVars(label: string): Promise<BadgeVars | undefined> {
+  const { container } = renderGrid(gridSchema());
+  await waitFor(() => expect(screen.getAllByText(label).length).toBeGreaterThan(0));
+  return badgeVarsFor(container, label);
+}
+
+/** Surface 2 — the group-header pill (`resolveGroupHeader` -> `GroupRow`). */
+async function groupHeaderVars(label: string): Promise<BadgeVars | undefined> {
+  const { container } = renderGrid(gridSchema({ grouping: { fields: [{ field: 'stage' }] } }));
+  await waitFor(() =>
+    expect(container.querySelectorAll('.group-label').length).toBeGreaterThan(0),
+  );
+  return badgeVarsFor(container, label);
+}
+
+/** Surface 3 — the compact card / mobile stage badge. */
+async function mobileCardVars(label: string): Promise<BadgeVars | undefined> {
+  setMobileWidth();
+  const { container } = renderGrid(gridSchema());
+  await waitFor(() => expect(screen.getAllByText(label).length).toBeGreaterThan(0));
+  return badgeVarsFor(container, label);
+}
+
+describe('objectui#5183 — a declared hex renders the same on every grid surface', () => {
+  it('group header agrees with the desktop cell under it', async () => {
+    const cell = await desktopCellVars('Emerald');
+    cleanup();
+    const header = await groupHeaderVars('Emerald');
+
+    // Both surfaces resolved SOMETHING — a missing style is the pre-fix state
+    // (class-only), and `toEqual(undefined)` on both sides would otherwise
+    // read as agreement.
+    expect(cell?.['--os-badge-bg']).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(header?.['--os-badge-bg']).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(header).toEqual(cell);
+  });
+
+  it('compact card badge agrees with the desktop cell', async () => {
+    const cell = await desktopCellVars('Emerald');
+    cleanup();
+    const card = await mobileCardVars('Emerald');
+
+    expect(cell?.['--os-badge-bg']).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(card?.['--os-badge-bg']).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(card).toEqual(cell);
+  });
+
+  it('two same-family hexes stay distinguishable (agreement is not quantization)', async () => {
+    const { container } = renderGrid(gridSchema({ grouping: { fields: [{ field: 'stage' }] } }));
+    await waitFor(() =>
+      expect(container.querySelectorAll('.group-label').length).toBeGreaterThan(1),
+    );
+    const emerald = badgeVarsFor(container, 'Emerald');
+    const forest = badgeVarsFor(container, 'Forest');
+    expect(emerald?.['--os-badge-bg']).toBeTruthy();
+    expect(forest?.['--os-badge-bg']).toBeTruthy();
+    expect(emerald!['--os-badge-bg']).not.toBe(forest!['--os-badge-bg']);
+  });
+});

--- a/packages/plugin-kanban/src/KanbanEnhanced.tsx
+++ b/packages/plugin-kanban/src/KanbanEnhanced.tsx
@@ -37,7 +37,12 @@ export interface KanbanCard {
   id: string
   title: string
   description?: string
-  badges?: Array<{ label: string; variant?: "default" | "secondary" | "destructive" | "outline"; colorClass?: string }>
+  /**
+   * `colorStyle` carries the CSS custom properties a hex-derived `colorClass`
+   * reads (objectui#5183) — see `KanbanCard.badges` in `./types` for how to
+   * derive the pair.
+   */
+  badges?: Array<{ label: string; variant?: "default" | "secondary" | "destructive" | "outline"; colorClass?: string; colorStyle?: React.CSSProperties }>
   coverImage?: string
   [key: string]: any
 }
@@ -129,6 +134,7 @@ function SortableCard({ card, conditionalFormatting }: { card: KanbanCard; condi
                   key={index}
                   variant={badge.colorClass ? "outline" : (badge.variant || "default")}
                   className={cn("text-xs font-normal", badge.colorClass)}
+                  style={badge.colorStyle}
                 >
                   {badge.label}
                 </Badge>

--- a/packages/plugin-kanban/src/KanbanImpl.tsx
+++ b/packages/plugin-kanban/src/KanbanImpl.tsx
@@ -68,7 +68,12 @@ export interface KanbanCard {
    * Takes precedence over `cardSubtitle` / `description` when present.
    */
   cardFieldCells?: Array<{ field: string; label?: string; node: React.ReactNode }>
-  badges?: Array<{ label: string; variant?: "default" | "secondary" | "destructive" | "outline"; colorClass?: string }>
+  /**
+   * `colorStyle` carries the CSS custom properties a hex-derived `colorClass`
+   * reads (objectui#5183) — see `KanbanCard.badges` in `./types` for how to
+   * derive the pair.
+   */
+  badges?: Array<{ label: string; variant?: "default" | "secondary" | "destructive" | "outline"; colorClass?: string; colorStyle?: React.CSSProperties }>
   coverImage?: string
   [key: string]: any
 }
@@ -197,6 +202,7 @@ function SortableCard({ card, onCardClick, conditionalFormatting, objectFields }
                     key={index}
                     variant={badge.colorClass ? "outline" : (badge.variant || "default")}
                     className={cn("text-xs font-normal", badge.colorClass)}
+                    style={badge.colorStyle}
                   >
                     {badge.label}
                   </Badge>

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -20,7 +20,7 @@ import { toast } from '@object-ui/components';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { RecordDetailDrawer, deriveRecordPageHref } from '@object-ui/plugin-detail';
 import { extractRecords, buildExpandFields, getRecordDisplayName } from '@object-ui/core';
-import { getBadgeColorClasses, getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
+import { getBadgeColorClasses, getBadgeHexAppearance, getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
 import { KanbanRenderer, KANBAN_UNCOLUMNED_ID } from './index';
 import { KanbanSchema } from './types';
 import {
@@ -370,7 +370,12 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
         'display_name',
       ]);
 
-      const cardBadges: Array<{ label: string; variant?: any; colorClass?: string }> = [];
+      const cardBadges: Array<{
+        label: string;
+        variant?: any;
+        colorClass?: string;
+        colorStyle?: React.CSSProperties;
+      }> = [];
       const cardFieldCells: Array<{ field: string; label?: string; node: React.ReactNode }> = [];
 
       if (explicitCardFields.length > 0) {
@@ -399,8 +404,17 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
               ? translateOptions(objectKey, f, [{ value: String(opt?.value ?? raw), label: rawLabel }])[0]?.label
                   ?? rawLabel
               : rawLabel;
-            const colorClass = getBadgeColorClasses(opt?.color, raw);
-            cardBadges.push({ label: translatedLabel, colorClass });
+            // Resolved exactly as the grid cell resolves it
+            // (`SelectCellRenderer` in `@object-ui/fields`): a declared hex
+            // renders as declared (objectui#5141/#5183), a family name keeps
+            // going through `getBadgeColorClasses`. `colorStyle` carries the
+            // CSS custom properties the hex className reads and travels with
+            // the badge to the renderer — the class alone is not a colour.
+            const hexBadge = getBadgeHexAppearance(opt?.color);
+            const colorClass = hexBadge
+              ? hexBadge.className
+              : getBadgeColorClasses(opt?.color, raw);
+            cardBadges.push({ label: translatedLabel, colorClass, colorStyle: hexBadge?.style });
           } else {
             // Route through the same registry that Grid/Gallery use so
             // every field type renders with its canonical widget.
@@ -451,8 +465,14 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
               String(o.value).toLowerCase() === String(v).toLowerCase()
             );
             const label = option?.label || String(v);
-            const colorClass = getBadgeColorClasses(option?.color, v);
-            cardBadges.push({ label, colorClass });
+            // Same hex-first resolution as the explicit-card-fields branch
+            // above (objectui#5141/#5183); see the comment there for why the
+            // style has to travel with the class.
+            const hexBadge = getBadgeHexAppearance(option?.color);
+            const colorClass = hexBadge
+              ? hexBadge.className
+              : getBadgeColorClasses(option?.color, v);
+            cardBadges.push({ label, colorClass, colorStyle: hexBadge?.style });
             if (cardBadges.length >= 2) break;
           }
         }

--- a/packages/plugin-kanban/src/badgeHexCrossSurface.test.tsx
+++ b/packages/plugin-kanban/src/badgeHexCrossSurface.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5183 — a kanban card badge and the grid cell beside it must render
+ * one option in one colour.
+ *
+ * objectui#5141 taught the grid's cell renderer to honour an author-declared
+ * hex; the kanban card kept resolving through `getBadgeColorClasses`, which
+ * returns a class string and so cannot carry a runtime colour. The same
+ * option then rendered one colour in a grid cell and another on the card
+ * beside it — the user-visible bar from #5141's reporter.
+ *
+ * ── The comparison surface ───────────────────────────────────────────────
+ * `getCellRenderer('select')` is the exact lookup ObjectGrid performs for a
+ * select cell, so the component rendered here IS the desktop grid's cell —
+ * not a re-implementation of it. `plugin-kanban` does not (and should not)
+ * depend on `plugin-grid`, so the shared renderer is the honest join point.
+ *
+ * ── The card badge travels as DATA ───────────────────────────────────────
+ * The card badge crosses a data boundary (`KanbanCard.badges[]`) rather than
+ * being a JSX element the resolver can style directly, which is why the class
+ * needed a `colorStyle` sibling to travel with it. A test that only checked
+ * the className would have passed with the style dropped in transit — the
+ * className is a build-time-static Tailwind string, identical on both
+ * surfaces, and the custom properties are the entire payload.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import { getCellRenderer } from '@object-ui/fields';
+// Registers `object-kanban`.
+import './index';
+// The board renders inside `KanbanRenderer`'s `React.lazy` boundary. Importing
+// the chunk at module scope bills the cold transform to the import phase
+// (unbounded) instead of racing a `waitFor` budget under full parallelism —
+// the objectui#3010 rule, same specifier as `index.tsx`'s factory so ESM's
+// module cache makes that factory resolve immediately.
+import './KanbanImpl';
+
+/** The reported pair from #5141: one palette family, two distinct colours. */
+const EMERALD = '#2ecc71';
+const FOREST = '#1e8449';
+
+const OPTIONS = [
+  { value: 'emerald', label: 'Emerald', color: EMERALD },
+  { value: 'forest', label: 'Forest', color: FOREST },
+];
+
+const PRIORITY_FIELD = { name: 'priority', type: 'select', label: 'Priority', options: OPTIONS };
+
+const ROWS = [
+  { id: 'c1', name: 'Card one', status: 'open', priority: 'emerald' },
+  { id: 'c2', name: 'Card two', status: 'open', priority: 'forest' },
+];
+
+const LANES = [{ id: 'open', title: 'Open' }];
+
+function makeDataSource() {
+  return {
+    find: vi.fn().mockResolvedValue({ data: ROWS, total: ROWS.length }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'test_object',
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text', label: 'Name' },
+        status: { type: 'text' },
+        priority: PRIORITY_FIELD,
+      },
+    }),
+  } as any;
+}
+
+afterEach(cleanup);
+
+const BADGE_VARS = ['--os-badge-bg', '--os-badge-fg', '--os-badge-border'] as const;
+
+type BadgeVars = Record<string, string>;
+
+/** Custom properties declared by the badge-ish element labelled `label`. */
+function badgeVarsFor(root: HTMLElement, label: string): BadgeVars | undefined {
+  const carrier = Array.from(root.querySelectorAll<HTMLElement>('[style]')).find(
+    (el) =>
+      el.textContent?.trim() === label &&
+      el.style.getPropertyValue('--os-badge-bg').trim() !== '',
+  );
+  if (!carrier) return undefined;
+  const out: BadgeVars = {};
+  for (const name of BADGE_VARS) out[name] = carrier.style.getPropertyValue(name).trim();
+  return out;
+}
+
+/** The grid's select cell, obtained through the registry the grid itself uses. */
+function renderGridCell(value: string) {
+  const SelectCell = getCellRenderer('select');
+  return render(<SelectCell value={value} field={PRIORITY_FIELD as any} />);
+}
+
+async function renderBoard() {
+  const adapter = makeDataSource();
+  const result = render(
+    <SchemaRendererProvider dataSource={adapter as any}>
+      <SchemaRenderer
+        schema={
+          {
+            type: 'object-kanban',
+            objectName: 'test_object',
+            groupBy: 'status',
+            columns: LANES,
+            cardFields: ['priority'],
+          } as any
+        }
+      />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(result.container.textContent).toContain('Card one'));
+  return result;
+}
+
+describe('objectui#5183 — kanban card badges agree with the grid cell', () => {
+  it('a declared hex resolves identically on the card and in the cell', async () => {
+    const cell = renderGridCell('emerald');
+    const cellVars = badgeVarsFor(cell.container, 'Emerald');
+    cleanup();
+
+    const board = await renderBoard();
+    const cardVars = badgeVarsFor(board.container, 'Emerald');
+
+    // Both surfaces resolved SOMETHING. Without this, two `undefined`s would
+    // read as agreement — and "no style at all" is exactly the pre-fix state.
+    expect(cellVars?.['--os-badge-bg']).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(cardVars?.['--os-badge-bg']).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(cardVars).toEqual(cellVars);
+  });
+
+  it('two same-family hexes stay distinguishable on the card', async () => {
+    const board = await renderBoard();
+    const emerald = badgeVarsFor(board.container, 'Emerald');
+    const forest = badgeVarsFor(board.container, 'Forest');
+
+    // `hexToPaletteName` buckets both into `green`: under the class-only path
+    // the two cards were byte-identical, which is agreement without fidelity.
+    expect(emerald?.['--os-badge-bg']).toBeTruthy();
+    expect(forest?.['--os-badge-bg']).toBeTruthy();
+    expect(emerald!['--os-badge-bg']).not.toBe(forest!['--os-badge-bg']);
+  });
+});

--- a/packages/plugin-kanban/src/types.ts
+++ b/packages/plugin-kanban/src/types.ts
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type React from 'react';
 import type { BaseSchema, GroupingConfig, KanbanConditionalFormattingRule } from '@object-ui/types';
 
 /**
@@ -20,10 +21,24 @@ export interface KanbanCard {
     variant?: "default" | "secondary" | "destructive" | "outline";
     /**
      * Optional Tailwind class string applied to the badge. When set, it
-     * overrides `variant` so callers can reuse the same color palette as
-     * list/grid cells (see `getBadgeColorClasses` in `@object-ui/fields`).
+     * overrides `variant` so callers can reuse the same colors as list/grid
+     * cells.
+     *
+     * Derive it the way the grid cell derives it, or the same option renders
+     * two colours on one screen (objectui#5183): prefer
+     * `getBadgeHexAppearance(color)` from `@object-ui/fields` and use its
+     * `className` — passing its `colorStyle` too — and fall back to
+     * `getBadgeColorClasses(color, value)` only when it returns `undefined`.
      */
     colorClass?: string;
+    /**
+     * Inline style accompanying `colorClass`. **Required whenever the class
+     * string came from `getBadgeHexAppearance`** — that className reads CSS
+     * custom properties which only this style declares, so a badge carrying
+     * the class without the style references undefined variables. Pass the
+     * helper's `style` verbatim; leave unset on the palette-family path.
+     */
+    colorStyle?: React.CSSProperties;
   }>;
   [key: string]: any;
 }


### PR DESCRIPTION
Fixes #5183

objectui#5141 taught the grid's cell renderer (`SelectCellRenderer`) to render an author-declared `options[].color` hex as declared instead of quantizing it onto one of nine palette families. Four badge call sites in `plugin-grid` and `plugin-kanban` still resolved through `getBadgeColorClasses`, which returns a class string and therefore cannot carry a runtime colour — Tailwind can only emit classes it saw in the source at build time.

The result was worse than the bug it replaced: the same option in the same object rendered one colour in a desktop grid cell and a different one in the group header above it or on the Kanban card beside it. The pre-#5141 state was at least uniformly wrong.

## What changed

All four sites now resolve exactly as the cell does — prefer `getBadgeHexAppearance(color)` and pass its `className` **and** its `style`, falling back to `getBadgeColorClasses` for palette-family names, no colour, and every other declaration.

| Site | Surface |
|---|---|
| `plugin-grid/src/ObjectGrid.tsx` | compact card / mobile stage badge |
| `plugin-grid/src/ObjectGrid.tsx` (`resolveGroupHeader`) | group-header pills |
| `plugin-kanban/src/ObjectKanban.tsx` | card badges, explicit `cardFields` branch |
| `plugin-kanban/src/ObjectKanban.tsx` | card badges, legacy semantic-field branch |

The compact card keeps its pipeline-stage heuristic (`stageBadgeColor`) when the author declared no colour at all — that fallback is not `getBadgeColorClasses` and was deliberately left in place.

**Two carriers had to widen**, because these badges are not all plain JSX. The colours ride CSS custom properties that the className reads, so a class passed without its style paints against undefined variables; the two halves have to travel together:

- `GroupRow` takes `labelColorStyle` alongside `labelColorClass` — the pill crosses a component prop boundary.
- A Kanban card badge takes `colorStyle` alongside `colorClass` (`KanbanCard.badges[]`, plus the two renderers that consume it) — the badge crosses a **data** boundary.

Both additions are optional and additive; a badge carrying only a class renders exactly as before. Behaviour is unchanged for every declaration that is not an explicit hex.

The two stale comments that claimed these surfaces matched the grid "via `getBadgeColorClasses`" — `GroupRow.tsx` and `plugin-kanban/src/types.ts` — are corrected. They stopped being true the moment the desktop path was fixed, and nothing caught it.

## The design call, and why it went this way

The card asked whether the four sites should each adopt the helpers or route through **one shared helper** so a fifth caller cannot silently reintroduce the split. Measured, one helper cannot serve all four:

1. **No shared home is in surface.** The only package both plugins depend on that owns the palette is `@object-ui/fields`, held out of this round — and a resolver there is a new public export on a published package.
2. **The resolution chains differ.** The compact-card site's non-hex fallback is a *local* pipeline-stage heuristic, not `getBadgeColorClasses`. A `(color, value)` resolver would have to grow a per-site fallback argument, which puts the divergence back into a parameter.
3. **The carriers differ, and widening them is the actual work.** One site styles a JSX element directly; one crosses a component prop boundary; two cross a data boundary. A shared resolver cannot make those carriers carry a style — that is per-site by construction.
4. **A resolver would not close the trap anyway.** `getBadgeColorClasses` stays exported and class-only, so the next caller can still reach for it.

So: four adoptions of **one pattern**, plus cross-surface tests, plus doc comments on both widened carriers stating that the style is mandatory whenever the class came from `getBadgeHexAppearance`. **No new public export was minted.** What actually makes a fifth caller's mistake impossible is a mechanical check, which lands in `packages/fields` — filed as #5191 with the measurements above, so it is not re-derived. That card is a proposal, not a defect; nothing currently shipped is wrong. It is not addressed here.

## Tests — cross-surface, not per-site

Four independent per-site tests would each have passed against a site that quantizes, as long as it quantized consistently with itself. What broke is agreement *between* surfaces, so that is what is pinned:

- `plugin-grid/src/__tests__/badgeHexCrossSurface.test.tsx` — renders the same option through the desktop cell, the group-header pill and the compact card, and asserts the resolved custom properties are byte-identical across them.
- `plugin-kanban/src/badgeHexCrossSurface.test.tsx` — asserts the card badge agrees with `getCellRenderer('select')`, the exact lookup ObjectGrid performs for a select cell, so the comparison surface is the real grid cell rather than a re-implementation.

Both files use `#2ecc71` / `#1e8449` — the pair from #5141's report. Their hues differ by 0.1°, so both bucket into the `green` family: under the class-only path every surface agreed by rendering them identically, which is agreement without fidelity. A final case in each file pins that they stay distinguishable, so "the surfaces agree" can never be satisfied by quantizing every surface back to one family.

### Reverse verification (and what it caught)

With the six source files reverted to `origin/main` and the tests untouched, **all 5 cases go red**; restored, all 5 green. The restored files were confirmed byte-identical to the committed state before the numbers were taken.

The first ablation pass turned only 3 of 5 red — and the two false greens were a defect in my own test, worth recording: a grouped grid renders the group pill **and** the leaf table's desktop cells, and both carry the option label as their entire text content. An unscoped "find the element labelled Emerald that declares `--os-badge-bg`" resolved to whichever came first in document order, so the group-header case passed off the *cell's* variables while asserting nothing about the header. Each lookup is now scoped to its own surface (`.group-label` for pills), and the two single-surface renders assert no group pill exists to be confused with (commit `3a6477c31`).

## Gates run locally, at `3a6477c31` (= head of this branch)

```
pnpm exec vitest run packages/plugin-grid/ packages/plugin-kanban/
  -> Test Files 91 passed (91) | Tests 762 passed (762)
pnpm --filter @object-ui/plugin-grid --filter @object-ui/plugin-kanban type-check   -> Done (both)
pnpm --filter @object-ui/plugin-grid --filter @object-ui/plugin-kanban lint         -> 0 errors, 633 warnings (baseline)
node scripts/check-changeset-presence.mjs / -fixed / -no-major                      -> OK
node scripts/check-control-bytes.mjs   -> OK (4608 files)
node scripts/check-phantom-dependencies.mjs / check-package-self-import.mjs         -> OK
node scripts/check-lint-coverage.mjs / check-type-check-coverage.mjs                -> OK
pnpm check:spec-symbols / check:action-forward-parity / check:i18n-keys / check:i18n-drift -> OK
```

Changeset: `.changeset/badge-hex-cross-surface-5183.md` (`patch` for both packages; never `major`, per the fixed-group rule).

## On #5141's closure

#5141 carries `Blocked-by: #5183`. With this PR the cross-surface inconsistency is closed for every surface that resolves an option colour through the `@object-ui/fields` badge helpers: the grid cell, the grid group header, the grid compact card, and the Kanban card badge all agree. `plugin-gantt` is deliberately untouched — it consumes `getSemanticColorName` / `getSemanticHex` and needs family names, per the card's ruling. `plugin-calendar` was swept and is not a call site: it resolves `event.color` on its own path and already renders a hex directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHbqfPiETJHA95r6WzZWS)_