### PR TITLE
fix(app-shell): a linkless notification opens the inbox from the bell (#5190)

### DIFF
--- a/.changeset/bell-linkless-notification-opens-inbox.md
+++ b/.changeset/bell-linkless-notification-opens-inbox.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/app-shell': patch
+---
+
+A notification with no link now opens the full inbox from the bell instead of being consumed silently.
+
+`InboxPopover`'s notification click handler marked the row read and then, when
+nothing resolved a target, returned. A linkless row was therefore spent — the
+mark-read is server-authoritative — while the user was taken nowhere and the
+popover stayed open on the row it had just greyed out.
+
+Linkless rows are a routine state, not a corner case: `service-messaging` leaves
+`action_url` undefined whenever an emit carries neither a `payload.url` nor a
+`source`. Home's action centre already answers that state deliberately by
+opening the user-scoped full inbox (objectui#4074); the bell was the unruled
+half of one behaviour. It now reuses the drill it already had one screen up, so
+the click closes the popover and lands on
+`/apps/{host app}/sys_inbox_message?view=mine` — the same page the row came
+from, resolved through `resolveHostAppSegment` like every other app-independent
+drill in the file (never a bare or empty app segment, which matches no route).
+
+Also removes the pre-ADR-0030 `source_object`/`source_id` back-compat arm and
+the two fields from the `InboxNotification` shape. `mergeInboxRows` — the single
+producer of every row both the bell and Home render — mapped neither, and
+`sys_inbox_message` declares `action_url` with no source columns to map from, so
+the arm was unreachable in the shipped tree. A declared input that no producer
+fills, read by a handler that silently does nothing, is a standing invitation to
+wire it up; the fields are removed rather than maintained (objectui#5190).

--- a/packages/app-shell/src/layout/InboxPopover.tsx
+++ b/packages/app-shell/src/layout/InboxPopover.tsx
@@ -168,20 +168,23 @@ export function InboxPopover({
     // resolver dropped the user on the default app's home: objectui#5179.
     // Reusing the drills' own resolver also stops an unchecked remembered app
     // from addressing a link into an app that has since been deactivated.
-    //
-    // The `source_object`/`source_id` arm below is the pre-ADR-0030 pointer,
-    // kept because it is this component's declared input shape — but note the
-    // shared feed does not populate either field today (`mergeInboxRows` maps
-    // neither), so nothing in this repo can currently reach it. It is resolved
-    // through the SAME helper rather than left building a bare
-    // `/objects/{object}/{id}`, which matches no route and lands on the app
-    // landing page for exactly the reason above.
-    const target =
-      resolveNotificationTarget(n.action_url, hostAppSegment) ??
-      (n.source_object && n.source_id
-        ? resolveNotificationTarget(`/${n.source_object}/${n.source_id}`, hostAppSegment)
-        : null);
-    if (!target) return;
+    const target = resolveNotificationTarget(n.action_url, hostAppSegment);
+    if (!target) {
+      // No link at all — a real state, not a defect: the producer leaves
+      // `action_url` undefined when an emit carries neither a `payload.url` nor
+      // a `source`. `onMarkRead` above has already consumed the row, so
+      // returning here spent the notification and left the popover sitting open
+      // on it, having navigated nowhere (objectui#5190).
+      //
+      // Home's action centre answers this by opening the full inbox
+      // (objectui#4074), and that is the ruled behaviour — so the bell reuses
+      // the drill it already has one screen up rather than writing a second
+      // answer to the same question. `goToAllNotifications` closes the popover
+      // and lands on the same `?view=mine` page the row came from, which is
+      // where a linkless notification can still be read in full.
+      goToAllNotifications();
+      return;
+    }
     setOpen(false);
     if (target.kind === 'external') {
       window.open(target.url, '_blank', 'noopener,noreferrer');

--- a/packages/app-shell/src/layout/__tests__/InboxPopover.linklessFallback.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/InboxPopover.linklessFallback.test.tsx
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * A notification with NO link still opens something from the bell, and the two
+ * dead back-compat fields are gone (objectui#5190).
+ *
+ * ## The defect
+ *
+ * `handleNotificationClick` called `onMarkRead(n.id)` and then, when nothing
+ * resolved a target, `return`ed. A linkless row was therefore CONSUMED — the
+ * mark-read is server-authoritative — while the user was taken nowhere and the
+ * popover stayed open on the row it had just greyed out.
+ *
+ * Linkless rows are not a corner case: `service-messaging` leaves `action_url`
+ * undefined whenever an emit carries neither a `payload.url` nor a `source`
+ * (pinned upstream as "leaves action_url undefined when there is neither a url
+ * nor a source"). Home's action centre already handles exactly this state
+ * deliberately — it opens the full inbox (objectui#4074) — so the bell was the
+ * unruled half of one behaviour, and this aligns it to the ruled half.
+ *
+ * The second half of the card: `InboxNotification` declared
+ * `source_object`/`source_id` and this handler read them as a pre-ADR-0030
+ * fallback, but `mergeInboxRows` — the single producer of every row the bell
+ * and Home render — maps neither, and `sys_inbox_message` declares `action_url`
+ * with no source columns to map from. Declared-and-never-filled, so removed.
+ *
+ * ## What these cases assert
+ *
+ * The RESOLVED TARGET `navigate()` receives, the popover's open state across
+ * the click, and that the row is still marked read — the three things that
+ * together distinguish "opened the inbox" from the silent consumption above.
+ * `?view=mine` is asserted verbatim because it is what makes the destination
+ * the user-scoped page the row came from rather than the org-wide list.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const navigateMock = vi.fn();
+
+let currentAppNameFixture: string | undefined;
+let routeAppNameFixture: string | undefined;
+let appsFixture: any[] = [];
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ appName: routeAppNameFixture }),
+}));
+
+vi.mock('../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ currentAppName: currentAppNameFixture }),
+}));
+
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: appsFixture, loading: false }),
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    language: 'en',
+    t: (key: string, options?: Record<string, unknown>) =>
+      String(options?.defaultValue ?? key).replace(/\{\{(\w+)\}\}/g, (_m, name: string) =>
+        String(options?.[name] ?? ''),
+      ),
+  }),
+}));
+
+// Passthrough primitives, as in the sibling suites — except `Popover`, which
+// here REPORTS the controlled `open` prop and exposes an opener that drives
+// `onOpenChange`. The sibling mocks swallow both, which is fine for asserting a
+// navigation target but makes "the popover closes" unobservable, and staying
+// open on a spent row is half of what this card reported.
+vi.mock('@object-ui/components', () => ({
+  Button: ({ children, ...p }: any) => <button type="button" {...p}>{children}</button>,
+  Popover: ({ open, onOpenChange, children }: any) => (
+    <div data-testid="popover" data-open={String(Boolean(open))}>
+      <button type="button" data-testid="open-popover" onClick={() => onOpenChange?.(true)}>
+        open inbox popover
+      </button>
+      {children}
+    </div>
+  ),
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  TabsList: ({ children }: any) => <div>{children}</div>,
+  TabsTrigger: ({ children }: any) => <button type="button">{children}</button>,
+  TabsContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('lucide-react', () => ({
+  Bell: () => <span />,
+  CheckSquare: () => <span />,
+  Activity: () => <span />,
+  ChevronRight: () => <span />,
+}));
+
+import { InboxPopover, type InboxNotification } from '../InboxPopover';
+
+const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
+
+const notif = (over: Partial<InboxNotification> & { id: string }): InboxNotification => ({
+  type: 'collab.assignment',
+  title: 'Assigned to you',
+  is_read: false,
+  created_at: '2026-08-10T10:00:00Z',
+  ...over,
+});
+
+const markRead = vi.fn();
+
+/**
+ * Open the popover, click the seeded row, and hand back everything the card is
+ * about: what `navigate()` got and whether the popover is still open.
+ */
+async function clickNotification(n: InboxNotification) {
+  const user = userEvent.setup();
+  render(
+    <InboxPopover
+      notifications={[n]}
+      unreadCount={1}
+      pendingApprovalsCount={0}
+      activities={[]}
+      onMarkAllRead={vi.fn()}
+      onMarkRead={markRead}
+    />,
+  );
+  await user.click(screen.getByTestId('open-popover'));
+  expect(screen.getByTestId('popover')).toHaveAttribute('data-open', 'true');
+  await user.click(screen.getByText(n.title));
+  return {
+    target: navigateMock.mock.calls[0]?.[0] as string | undefined,
+    isOpen: screen.getByTestId('popover').getAttribute('data-open') === 'true',
+  };
+}
+
+describe('A linkless bell notification opens the full inbox (objectui#5190)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    markRead.mockReset();
+    appsFixture = [app('setup'), app('crm')];
+    currentAppNameFixture = 'crm';
+    routeAppNameFixture = 'crm';
+  });
+
+  it('navigates to the user-scoped inbox when the row carries no action_url', async () => {
+    const { target } = await clickNotification(notif({ id: 'n1' }));
+    expect(target).toBe('/apps/crm/sys_inbox_message?view=mine');
+  });
+
+  it('closes the popover instead of sitting open on the consumed row', async () => {
+    const { isOpen } = await clickNotification(notif({ id: 'n1' }));
+    expect(isOpen).toBe(false);
+  });
+
+  it('still marks the linkless row read — the fallback adds a destination, it does not trade one behaviour for the other', async () => {
+    await clickNotification(notif({ id: 'n1' }));
+    expect(markRead).toHaveBeenCalledWith('n1');
+  });
+
+  it('treats a blank action_url as linkless, not as a route to ""', async () => {
+    // `resolveNotificationTarget` returns null for a blank url precisely so the
+    // caller can fall back rather than navigate a fabricated target.
+    const { target } = await clickNotification(notif({ id: 'n1', action_url: '   ' }));
+    expect(target).toBe('/apps/crm/sys_inbox_message?view=mine');
+  });
+
+  it('hosts the fallback under a RESOLVED app segment, never an empty one', async () => {
+    // The bell mounts on `/home`, `/organizations` and the AI screen, none of
+    // which name an app — the state that made objectui#5179 a bare path. The
+    // fallback resolves a host app there like every other drill in this file;
+    // `/apps//sys_inbox_message` would match no route.
+    appsFixture = [app('hr'), app('crm')];
+    currentAppNameFixture = undefined;
+    routeAppNameFixture = undefined;
+    const { target } = await clickNotification(notif({ id: 'n1' }));
+    expect(target).toBe('/apps/hr/sys_inbox_message?view=mine');
+    expect(target).not.toContain('/apps//');
+  });
+
+  it('sends the fallback to the same page the "View all notifications" drill does', async () => {
+    // One question, one answer: the footer drill and the linkless click are the
+    // same navigation, so they must not be able to drift apart.
+    const { target } = await clickNotification(notif({ id: 'n1' }));
+    const user = userEvent.setup();
+    await user.click(screen.getByText('View all notifications'));
+    expect(navigateMock.mock.calls.at(-1)?.[0]).toBe(target);
+  });
+
+  it('CONTROL: a row that DOES carry a link still goes to the record', async () => {
+    // The fallback must not swallow the linked path — that would trade this
+    // card's defect for objectui#5179's.
+    const { target, isOpen } = await clickNotification(
+      notif({ id: 'n1', action_url: '/showcase_task/t_42' }),
+    );
+    expect(target).toBe('/apps/crm/showcase_task/t_42');
+    expect(isOpen).toBe(false);
+  });
+});
+
+describe('The pre-ADR-0030 source_object/source_id arm is gone (objectui#5190)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    markRead.mockReset();
+    appsFixture = [app('setup'), app('crm')];
+    currentAppNameFixture = 'crm';
+    routeAppNameFixture = 'crm';
+  });
+
+  it('no longer builds a target out of a source pointer — such a row is linkless', async () => {
+    // Cast because the fields are no longer part of the declared shape; a row
+    // like this cannot come from `mergeInboxRows`, which never mapped them. The
+    // behavioural half of the deletion: reinstating the arm turns this red.
+    const stray = notif({ id: 'n1' }) as InboxNotification & Record<string, unknown>;
+    stray.source_object = 'showcase_task';
+    stray.source_id = 't_42';
+    const { target } = await clickNotification(stray);
+    expect(target).toBe('/apps/crm/sys_inbox_message?view=mine');
+    expect(target).not.toBe('/apps/crm/showcase_task/t_42');
+  });
+
+  it('TYPE PIN: the fields are not part of InboxNotification', () => {
+    const row: InboxNotification = {
+      id: 'n1',
+      type: 'collab.assignment',
+      title: 'Assigned to you',
+      // @ts-expect-error objectui#5190 removed `source_object` from the shape —
+      // re-declaring it makes this line compile and fails the pin.
+      source_object: 'showcase_task',
+    };
+    const row2: InboxNotification = {
+      id: 'n2',
+      type: 'collab.assignment',
+      title: 'Assigned to you',
+      // @ts-expect-error objectui#5190 removed `source_id` from the shape.
+      source_id: 't_42',
+    };
+    // Runtime half is trivial; `tsc -p tsconfig.test.json` is what checks the
+    // assertions above (see this package's `type-check` script).
+    expect([row.id, row2.id]).toEqual(['n1', 'n2']);
+  });
+});

--- a/packages/app-shell/src/layout/inboxGrouping.ts
+++ b/packages/app-shell/src/layout/inboxGrouping.ts
@@ -22,10 +22,22 @@ export interface InboxNotification {
   type: string;
   title: string;
   body?: string | null;
-  /** Deep-link target carried by the inbox materialization. */
+  /**
+   * Deep-link target carried by the inbox materialization — the ONLY pointer a
+   * row carries (ADR-0030 L5).
+   *
+   * The pre-ADR-0030 `source_object`/`source_id` pair used to sit here as a
+   * back-compat fallback. It was declared and never filled: `mergeInboxRows`
+   * (`hooks/sharedUserFeeds.ts`), the single producer of every row both the bell
+   * and Home render, maps neither, and the `sys_inbox_message` object declares
+   * `action_url` with no source columns to map FROM. A declared input no
+   * producer fills is a standing invitation to wire it up; removed rather than
+   * maintained (objectui#5190). A row that carries no link at all is a real
+   * state — the producer leaves `action_url` undefined when an emit has neither
+   * a `payload.url` nor a `source` — and both consumers now answer it the same
+   * way, by opening the full inbox.
+   */
   action_url?: string | null;
-  source_object?: string | null;
-  source_id?: string | null;
   actor_name?: string | null;
   is_read?: boolean;
   created_at?: string;


### PR DESCRIPTION
Fixes #5190

Implements triage's **reading 1** ruling on the card: drop the dead `source_object`/`source_id` back-compat arm, and give the bell the same deliberate linkless fallback Home already has.

## The defect

`InboxPopover`'s `handleNotificationClick` called `onMarkRead(n.id)` and then `return`ed whenever nothing resolved a target. A notification with no `action_url` was therefore **consumed** — the mark-read is server-authoritative — while the user was taken nowhere and the popover kept sitting open on the row it had just greyed out.

Linkless rows are a routine producer state, not a corner case: `service-messaging` leaves `action_url` undefined whenever an emit carries neither a `payload.url` nor a `source` (pinned upstream as *"leaves action_url undefined when there is neither a url nor a source"*). Home's action centre already answers exactly that state deliberately, by opening the user-scoped full inbox (objectui#4074) — so the bell was the unruled half of one behaviour, and the ruling was to align to the ruled half rather than double-write.

## What changed

- **`layout/InboxPopover.tsx`** — the linkless arm now calls the file's own `goToAllNotifications()` drill, which closes the popover and navigates to `/apps/{host app}/sys_inbox_message?view=mine`. Reusing the drill (rather than restating the path) is what stops the bell and Home from drifting into two answers again, and it inherits `resolveHostAppSegment` so the app segment is always resolved.
- **`layout/InboxPopover.tsx`** — the `source_object`/`source_id` fallback arm is deleted.
- **`layout/inboxGrouping.ts`** — the two fields are removed from `InboxNotification`, with the reasoning recorded on `action_url` where the next reader will meet it.

### Note on the ruling's rendered path

The ruling text renders the fallback as `/apps//sys_inbox_message?view=mine`. That empty segment is a rendering artifact of the quoted text, **not** the behaviour: the real path is `HomePage.tsx:624`, which interpolates `hostAppSegment`. Nothing here hardcodes a double slash, and a case asserts `not.toContain('/apps//')` on the surfaces that name no app (`/home`, `/organizations`, the AI screen) — the very state that made objectui#5179 a bare path.

### Scope

`mergeInboxRows` needed no change: it never mapped either field, which is why the arm was unreachable. Nothing else in the repo referenced them — the other `source_object`/`source_id` hits (`plugin-detail/renderers/recordActivityFeed.ts`, `views/RecordDetailView.tsx`) are on the unrelated activity-row shape. No file outside the declared surface was touched.

## Tests

New suite `layout/__tests__/InboxPopover.linklessFallback.test.tsx` (9 cases). It pins the fallback target, that the popover **closes** rather than sitting open on the consumed row, and that the row is still marked read — the three facts that together separate "opened the inbox" from the silent consumption above. Plus a control that a linked row still reaches its record (so the fallback cannot swallow objectui#5179's fix), a behavioural pin that a row carrying a stray source pointer is now treated as linkless, and two `@ts-expect-error` type pins that the fields are gone from the shape.

Its `Popover` mock reports the controlled `open` prop and exposes an opener; the sibling suites' passthrough mock swallows both, which is fine for asserting a navigation target but makes "the popover closes" unobservable.

### Reverse verification

Ablated by restoring both source files from `origin/main` with the new tests kept (fix committed first, so the restore had a real restore point). Both legs read this package's **own source** through relative specifiers, so no `dist` sits in the resolution path.

- **vitest, ablated:** `6 failed | 3 passed (9)` — e.g. `expected undefined to be '/apps/crm/sys_inbox_message?view=mine'` (no navigation at all), `expected true to be false` (popover left open), and `expected '/apps/crm/showcase_task/t_42' to be '/apps/crm/sys_inbox_message?view=mine'` (the dead arm proving live-reachable when handed a row that carries the fields). The 3 that stay green are the ones that should: mark-read and the linked-row control both worked before this change, and the type pin's runtime half is trivial by construction.
- **`tsc`, ablated:** both type pins turn red — `error TS2578: Unused '@ts-expect-error' directive.` at the two directives.
- **Restored:** green again on both legs.

### Gates run locally, all against the final commit `0b41908`

- `pnpm exec vitest run packages/app-shell/src/hooks/ packages/app-shell/src/console/home/ packages/app-shell/src/layout/` — **59 files, 461 tests passed** (producer, Home's action centre, and the bell).
- `pnpm --filter @object-ui/app-shell type-check` — pass (`tsc --noEmit` + `tsc -p tsconfig.test.json`, which is what compiles the type pins).
- `pnpm --filter @object-ui/app-shell lint` — exit 0 (warnings only, all pre-existing `no-explicit-any` in test mocks, matching the sibling suites).
- `pnpm check:control-bytes` — OK across 4616 tracked files; changed files also scanned directly, no hits.
- `node scripts/check-changeset-presence.mjs` and `pnpm changeset:check` — pass; changeset is `patch`, never `major`.

The full `packages/app-shell/` run exceeded the 10-minute foreground budget while the shared verify lock was held by another agent's build, so it was narrowed to the three directories above rather than backgrounded; CI shards the farm anyway.

## Out-of-scope finding

Filed as #5203 (unassigned, `finding`): `InboxNotification.actor_name` is the last remaining declared-but-unfilled field on the same interface — no producer maps it, no consumer reads it. Deliberately **not** fixed here: the ruling scoped to the source pair, and unlike them nothing reads `actor_name`, so retiring versus wiring it up is a product call rather than a mechanical one. #5203 is not addressed by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_