### PR TITLE
fix(plugin-dashboard)!: re-key dashboardComponents to the 8 registered schema types

### DIFF
--- a/.changeset/dashboard-components-rekey-5064.md
+++ b/.changeset/dashboard-components-rekey-5064.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/plugin-dashboard': major
+'@object-ui/plugin-dashboard': minor
 ---
 
 BREAKING: `dashboardComponents` is re-keyed from 11 PascalCase component class
@@ -14,5 +14,7 @@ three config-panel components (`DashboardConfigPanel`, `WidgetConfigPanel`,
 `DashboardWithConfig`) leave the map; they remain named exports. Any code
 reading the old keys (e.g. `dashboardComponents.DashboardRenderer`) breaks —
 two independent word-boundary greps measured zero such consumers in-tree.
-The maintainer authorized a one-PR exception to `check-changeset-no-major`
-for this re-key; the `major` score here is that exception.
+Per AGENTS.md §版本号策略, objectui's major tracks `@objectstack`'s major, not
+its own breaking-change count — this package's own breaking changes are
+scored `minor` with the break spelled out in this body, which is what makes
+this a `minor` (maintainer ruling, 2026-08-19).

--- a/.changeset/dashboard-components-rekey-5064.md
+++ b/.changeset/dashboard-components-rekey-5064.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/plugin-dashboard': major
+---
+
+BREAKING: `dashboardComponents` is re-keyed from 11 PascalCase component class
+names to the 8 schema `type` keys the package actually registers
+(`dashboard`, `metric`, `metric-card`, `object-metric`, `pivot`,
+`object-pivot`, `dashboard-grid`, `object-data-table`), aligning the map with
+its four sibling `*Components` maps (objectui#5064, Route A per the
+2026-08-18 maintainer ruling). Every value is the exact component the
+side-effect import registers for that type — for the two `object-*` types
+that is the internal data-source-gate wrapper, not the exported widget. The
+three config-panel components (`DashboardConfigPanel`, `WidgetConfigPanel`,
+`DashboardWithConfig`) leave the map; they remain named exports. Any code
+reading the old keys (e.g. `dashboardComponents.DashboardRenderer`) breaks —
+two independent word-boundary greps measured zero such consumers in-tree.
+The maintainer authorized a one-PR exception to `check-changeset-no-major`
+for this re-key; the `major` score here is that exception.

--- a/content/docs/plugins/plugin-dashboard.mdx
+++ b/content/docs/plugins/plugin-dashboard.mdx
@@ -114,14 +114,17 @@ ComponentRegistry.register('my-metric', MetricCard, {
 });
 ```
 
-The package also exports a `dashboardComponents` object, and two measured facts
-about it are worth stating, because iterating it is not the registration above:
-its eleven keys are **component class names** (`DashboardRenderer`, `MetricCard`,
-`WidgetConfigPanel`, …) rather than schema types, so feeding each key to
-`ComponentRegistry.register` registers eleven names no schema author writes,
-while the eight types in the table stay exactly as the import left them. Each
-such call also passes no `meta`, so it trips the no-namespace deprecation warning
-in `register` (`packages/core/src/registry/Registry.ts:198`).
+The package also exports a `dashboardComponents` object: the manual-integration
+map, keyed by the **same eight schema types** as the table above (objectui#5064
+re-keyed it from component class names). Each key maps to the exact component
+the import registers for that type — for the two `object-*` types that is the
+internal data-source-gate wrapper, not the exported widget. Iterating it with
+`ComponentRegistry.register(type, component)` therefore re-registers the eight
+types the import has already claimed, which is still not the registration above:
+each such call passes no `meta`, so it trips the no-namespace deprecation
+warning in `register` (`packages/core/src/registry/Registry.ts:198`) and
+rewrites each bare-name registry entry without its `label`/`category` metadata
+(the `namespace:type` entries are untouched).
 
 ## Examples
 

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -82,15 +82,18 @@ ComponentRegistry.register('my-metric', MetricCard, {
 });
 ```
 
-There is also a `dashboardComponents` export, and two measured facts about it
-are worth stating, because iterating it is not the manual registration above:
-its eleven keys are **component class names** (`DashboardRenderer`,
-`MetricCard`, `WidgetConfigPanel`, …) rather than schema types, and passing each
-key straight to `ComponentRegistry.register` therefore registers eleven names no
-schema author writes — while the eight types in the table stay untouched, having
-already been registered by the import. Each such call also passes no `meta`, so
-it trips the no-namespace deprecation warning in `register`
-(`packages/core/src/registry/Registry.ts:198`).
+There is also a `dashboardComponents` export: the manual-integration map, keyed
+by the **same eight schema types** as the table above (objectui#5064 re-keyed it
+from component class names). Each key maps to the exact component the import
+registers for that type — for the two `object-*` types that is the internal
+data-source-gate wrapper, not the exported widget. Iterating it with
+`ComponentRegistry.register(type, component)` therefore re-registers the eight
+types the import has already claimed, which is still not the manual registration
+above: each such call passes no `meta`, so it trips the no-namespace deprecation
+warning in `register` (`packages/core/src/registry/Registry.ts:198`) and
+rewrites each bare-name registry entry without its `label`/`category` metadata
+(the `namespace:type` entries are untouched). The side-effect import remains the
+whole of registration.
 
 ## Schema API
 

--- a/packages/plugin-dashboard/src/__tests__/dashboardComponents.mapParity.test.ts
+++ b/packages/plugin-dashboard/src/__tests__/dashboardComponents.mapParity.test.ts
@@ -1,0 +1,60 @@
+/**
+ * objectui#5064 — `dashboardComponents` map parity pin.
+ *
+ * The map is the package's "Standard Export Protocol - for manual
+ * integration": iterating it feeds each key straight into
+ * `ComponentRegistry.register(type, component)`. That contract is invisible
+ * to every static gate — the export-name check is green because the export
+ * exists, and a wrong key vocabulary compiles because the keys are runtime
+ * strings into `register(type: string, …)`. Until objectui#5064 the map
+ * carried 11 PascalCase component class names, so the documented loop
+ * registered 11 types no schema author writes while the 8 real types went
+ * unregistered by it. This file is the missing dynamic check: the map's keys
+ * must be exactly the schema types the barrel's side-effect registration
+ * claims, and each value must be the very component registered for that type
+ * (for the two `object-*` types that is the internal data-source-gate
+ * wrapper, not the exported widget).
+ */
+import { describe, expect, it } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+// Side-effect import: the package barrel runs the eight
+// `ComponentRegistry.register(...)` calls, and is also where
+// `dashboardComponents` is defined.
+import { dashboardComponents } from '../index';
+
+/** The 8 schema types read off the `ComponentRegistry.register` call sites. */
+const REGISTERED_TYPES = [
+  'dashboard',
+  'metric',
+  'metric-card',
+  'object-metric',
+  'pivot',
+  'object-pivot',
+  'dashboard-grid',
+  'object-data-table',
+];
+
+describe('dashboardComponents map parity (objectui#5064)', () => {
+  it('keys are exactly the 8 schema types the barrel registers', () => {
+    expect(Object.keys(dashboardComponents).sort()).toEqual(
+      [...REGISTERED_TYPES].sort(),
+    );
+  });
+
+  it('each value is the exact component registered for its type', () => {
+    for (const [type, component] of Object.entries(dashboardComponents)) {
+      // Bare-type lookup resolves the back-compat fallback entry, which holds
+      // the same component reference the barrel registered.
+      expect(ComponentRegistry.get(type), `type "${type}"`).toBe(component);
+    }
+  });
+
+  it('the pre-#5064 vocabulary stays gone: no PascalCase class-name keys', () => {
+    // Schema types in this repo are lower-kebab; a key starting with an
+    // uppercase letter is a component class name leaking back in.
+    const classNameKeys = Object.keys(dashboardComponents).filter((key) =>
+      /^[A-Z]/.test(key),
+    );
+    expect(classNameKeys).toEqual([]);
+  });
+});

--- a/packages/plugin-dashboard/src/index.tsx
+++ b/packages/plugin-dashboard/src/index.tsx
@@ -334,17 +334,18 @@ ComponentRegistry.register(
   }
 );
 
-// Standard Export Protocol - for manual integration
+// Standard Export Protocol - for manual integration. Keyed by the schema
+// `type` each entry serves (objectui#5064 — aligned with the four sibling
+// `*Components` maps); every value is the exact component the side-effect
+// import registers for that type, including the two internal
+// data-source-gate wrappers for the `object-*` types.
 export const dashboardComponents = {
-  DashboardRenderer,
-  DashboardGridLayout,
-  MetricWidget,
-  MetricCard,
-  ObjectMetricWidget,
-  PivotTable,
-  ObjectPivotTable,
-  ObjectDataTable,
-  DashboardConfigPanel,
-  WidgetConfigPanel,
-  DashboardWithConfig,
+  'dashboard': DashboardRenderer,
+  'metric': MetricWidget,
+  'metric-card': MetricCard,
+  'object-metric': ObjectMetricBlock,
+  'pivot': PivotTable,
+  'object-pivot': ObjectPivotBlock,
+  'dashboard-grid': DashboardGridLayout,
+  'object-data-table': ObjectDataTable,
 };


### PR DESCRIPTION
Fixes #5064

Implements **Route A** per the 2026-08-18 maintainer ruling (verbatim 「同意」, recorded on the issue): `dashboardComponents` — the only `*Components` map in the repo keyed by PascalCase component class names — is re-keyed to the 8 schema types the package's `ComponentRegistry.register` calls actually claim, aligning it with its four sibling maps. 11 keys become 8. No new exports, no new types.

## What changed

- `packages/plugin-dashboard/src/index.tsx` — the map's keys are now `dashboard`, `metric`, `metric-card`, `object-metric`, `pivot`, `object-pivot`, `dashboard-grid`, `object-data-table`, read off the register call sites in this tree. The three config-panel components (`DashboardConfigPanel`, `WidgetConfigPanel`, `DashboardWithConfig`) leave the map; they remain named exports on the barrel, untouched.
- **Value-side call, stated for review**: each key maps to the *exact component the side-effect import registers for that type*. For `object-metric` and `object-pivot` that is the internal data-source-gate wrapper (`ObjectMetricBlock` / `ObjectPivotBlock`, named locals in `index.tsx`), **not** the exported widgets. Mapping to the widgets instead would fix the key vocabulary while lying on the value axis — a manual registrant would register components with different binding behavior than the plugin itself does, and nothing static would catch that either. No new named exports are added by this (condition d holds: the map is the same export; its values reference existing components).
- `packages/plugin-dashboard/src/__tests__/dashboardComponents.mapParity.test.ts` — new pin test. The card's own quantified finding is that this contract is invisible to every static gate (the export-name check is green because the export exists; the old loop compiled because the keys are runtime strings). The pin asserts: keys are exactly the 8 registered types; each value is identical to what `ComponentRegistry.get(type)` serves after the barrel import; no PascalCase key ever leaks back in.
- `packages/plugin-dashboard/README.md` — condition (c): the "two measured facts" paragraph (landed by PR #5093) asserted the map's eleven keys are component class names; the re-key falsifies it, so it now states the new truth: keys match the table's 8 types, values are the registered components (gate wrappers for the two `object-*` types), and iterating the map is still not the recommended path — meta-less `register` calls trip the no-namespace deprecation warning and rewrite the bare-name entries without `label`/`category` metadata. The side-effect import remains the whole of registration.
- `content/docs/plugins/plugin-dashboard.mdx` — **the conditional edit, call stated as required**: its copy of the same paragraph says "its eleven keys are component class names … registers eleven names no schema author writes". The re-key makes that measured statement false, so this PR updates **that one paragraph and nothing else** in the file. The page-level duplication remains #5094's scope and is not touched.
- `.changeset/dashboard-components-rekey-5064.md` — scores `@object-ui/plugin-dashboard` **`minor`**, with the breaking semantics spelled out in the body. (condition b, corrected 2026-08-19 — see below: the honest label under AGENTS.md §版本号策略 was always `minor`, not `major`.)

## 2026-08-19 correction — `minor`, not `major`

This section previously argued `major` was the honest label and that the two red gates below were an authorized one-PR exception. That was wrong. Maintainer ruling, 2026-08-19, verbatim:

> **objectui ui 的 major 是要跟着 objectstack 走的，不可以自己发 major**

This confirms AGENTS.md §版本号策略 as written, not as a new policy: objectui's major tracks `@objectstack`'s major — it does **not** count objectui's own breaking-change history. objectui's own breaking changes (this re-key included) are scored `minor`, with the breaking semantics stated explicitly in the changeset body. That is exactly what the changeset now does.

So the two gates below were never being overridden by an authorized exception — there was no exception in play. They were the gate correctly enforcing §版本号策略 against a changeset that had the wrong bump level. Both are green now, for the right reason (re-verified at `855afa5`, this PR's current head):

1. `node scripts/check-changeset-no-major.mjs` — was exit 1 on this changeset, now exit 0.
2. `pnpm exec vitest run scripts/__tests__/check-changeset-no-major.test.ts` (repo root) — the repo-state assertion at `:117` ("the repository itself has no pending changeset declaring a `major` bump") was failing, now passes: `7 passed (7)`.

No other file changed in this amendment — code, the pin test, the README paragraph, and the mdx paragraph are unchanged from the version already reviewed.

## Binding condition (a) — re-run at claim, holds

Word-boundary `grep -rnw dashboardComponents packages apps examples content docs e2e` at `4eac264e6` (my branch point): exactly three hits — the definition (`src/index.tsx:338`), README prose (`:85`), the mdx copy (`:117`). None a consumer. Counter-probe `kanbanComponents` returns its definition, README loop, **and** real consumers (`packages/runner/src/plugin-integration.test.ts` key-accesses `kanbanComponents.kanban`), so the zero is a real zero.

## Verification (local, targeted; full farm belongs to CI)

At `a31ea2619` (working tree byte-identical to the run):

- `pnpm exec vitest run packages/plugin-dashboard/` — **63 files, 569 tests, all passed** (includes the new pin test; also run standalone).
- `node scripts/check-changeset-presence.mjs` — green. `node scripts/check-control-bytes.mjs` — green. `node scripts/check-doc-component-types.mjs` — green. `node scripts/check-doc-links.mjs` — green.
- `node scripts/check-doc-snippet-types.mjs` — refused loudly (needs the full publishable set built locally); my mdx edit changes prose only, no fenced snippet, CI's run is authoritative.
- `turbo run type-check lint --filter=@object-ui/plugin-dashboard` — queued behind the container's shared verify lock at report time; status recorded honestly in the issue report as in_progress if still queued.

At `855afa5` (this amendment's head, re-run after the changeset edit above):

- `node scripts/check-changeset-no-major.mjs` — green (was red; see the 2026-08-19 correction above).
- `pnpm exec vitest run scripts/__tests__/check-changeset-no-major.test.ts` — green, 7/7 (was 1 failing at `:117`).
- `node scripts/check-changeset-presence.mjs` — green. `node scripts/check-changeset-fixed.mjs` — green. `node scripts/check-control-bytes.mjs` — green.
- Package test suite not re-run for this amendment — no source file changed, only `.changeset/dashboard-components-rekey-5064.md`.

## Overlap

`packages/plugin-dashboard` is free this round — PR #5093 (the README truth-table half) is merged; this PR deliberately updates the paragraph #5093 landed, which is condition (c)'s point. #5094 (docs-page duplication) remains open and untouched by this PR beyond the single falsified paragraph.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_