### PR TITLE
feat(types,core,plugin-grid): retire the structured confirm arm — one confirm spelling

### DIFF
--- a/.changeset/retire-structured-confirm.md
+++ b/.changeset/retire-structured-confirm.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/types": minor
+"@object-ui/core": minor
+"@object-ui/plugin-grid": minor
+---
+
+Retire the structured `confirm` object on actions (objectui#4314, maintainer ruling
+2026-08-17, ADR-0049 enforce-or-remove). `confirmText` is now the one confirm
+spelling — the only one the translation bundle can address
+(`{ns}.objects.{obj}._actions.{name}.confirmText`), matching `@objectstack/spec`'s
+action surface.
+
+Breaking semantics (flagged `minor` per this repo's version-alignment policy):
+
+- `@object-ui/types`: `ActionSchema.confirm` is a `?: never` tombstone — authoring
+  it is now a tsc error, and the Zod twin rejects any authored value at parse time
+  (it previously accepted the object). The backwards `@deprecated` note that
+  steered authors from `confirmText` INTO the structured arm is gone.
+- `@object-ui/core`: `ActionRunner` no longer reads `confirm.message` (which used
+  to outrank `confirmText`, untranslated). `ActionDef.confirm` carries the same
+  `never` tombstone. The `ConfirmationHandler` signature is unchanged, but the
+  runner now invokes it without the `options` argument.
+- `@object-ui/plugin-grid`: `resolveBulkActions` no longer falls back to
+  `confirm.message` when promoting an object action — spec metadata can never
+  deliver that key.
+
+Nothing in the repo, the example apps, or the schema catalog authored the
+structured form (verified on the issue); a dialog authored that way silently lost
+localization. Reopen condition recorded on objectui#4314: real demand returns the
+arm WITH bundle keys designed in.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -620,12 +620,7 @@ A powerful action definition supporting API calls, confirmations, dialogs, chain
   "api": "/api/orders",
   "method": "POST",
   "data": { "status": "submitted" },
-  "confirm": {
-    "title": "Submit Order?",
-    "message": "This will send the order to the warehouse.",
-    "confirmText": "Yes, Submit",
-    "confirmVariant": "default"
-  },
+  "confirmText": "This will send the order to the warehouse.",
   "successMessage": "Order submitted successfully",
   "errorMessage": "Failed to submit order",
   "chain": [
@@ -656,7 +651,7 @@ A powerful action definition supporting API calls, confirmations, dialogs, chain
 | `api` | `string` | API endpoint for `ajax` actions. |
 | `method` | `string` | HTTP method: `"GET"`, `"POST"`, `"PUT"`, `"DELETE"`, `"PATCH"`. |
 | `data` | `any` | Request body data. |
-| `confirm` | `object` | Confirmation dialog with `title`, `message`, `confirmText`, `cancelText`. |
+| `confirmText` | `string` | Confirmation message shown before executing — the one confirm spelling, addressed by the translation bundle. (A structured `confirm` object was retired in objectui#4314.) |
 | `dialog` | `object` | Modal dialog with `title`, `content`, `size`, `actions`. |
 | `chain` | `ActionSchema[]` | Actions to execute after this action completes. |
 | `chainMode` | `"sequential" \| "parallel"` | How chained actions execute. |

--- a/content/docs/core/enhanced-actions.mdx
+++ b/content/docs/core/enhanced-actions.mdx
@@ -80,24 +80,19 @@ const confirmAction: ActionSchema = {
   type: 'action',
   label: 'Delete Record',
   actionType: 'confirm',
-  confirm: {
-    title: 'Confirm Deletion',
-    message: 'Are you sure you want to delete this record?',
-    confirmText: 'Yes, Delete',
-    cancelText: 'Cancel',
-    confirmVariant: 'destructive'
-  },
+  confirmText: 'Are you sure you want to delete this record?',
   api: '/api/records/123',
   method: 'DELETE'
 };
 ```
 
 **Confirm Properties:**
-- `title` - Dialog title
-- `message` - Confirmation message
-- `confirmText` - Confirm button text
-- `cancelText` - Cancel button text
-- `confirmVariant` - Button style
+- `confirmText` - Confirmation message shown in the dialog. This is the one
+  confirm spelling — it is what the translation bundle addresses
+  (`{ns}.objects.{obj}._actions.{name}.confirmText`), matching
+  `@objectstack/spec`'s action surface. A structured `confirm` object
+  (`{ title, message, ... }`) was retired in objectui#4314: it had no
+  translation key, so its dialogs could never be localized.
 
 ### Dialog Actions
 
@@ -231,10 +226,7 @@ const conditionalAction: ActionSchema = {
       type: 'action',
       label: 'Require Manager Approval',
       actionType: 'confirm',
-      confirm: {
-        title: 'Manager Approval Required',
-        message: 'Amount exceeds $1000. Manager approval needed.'
-      }
+      confirmText: 'Amount exceeds $1000. Manager approval needed.'
     },
     else: {
       type: 'action',
@@ -348,12 +340,7 @@ const complexAction: ActionSchema = {
   
   // Confirm before processing
   actionType: 'confirm',
-  confirm: {
-    title: 'Confirm Order',
-    message: 'Process this order for ${data.customerName}?',
-    confirmText: 'Process Order',
-    confirmVariant: 'default'
-  },
+  confirmText: 'Process this order for ${data.customerName}?',
   
   // Conditional logic
   condition: {

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -142,10 +142,22 @@ export interface ActionDef {
    * it — the two TS2353s the deletion produced repo-wide were both this key.
    */
   description?: UIActionSchema['description'];
-  /** Confirmation text — shows a confirm dialog before executing */
+  /**
+   * Confirmation text — shows a confirm dialog before executing. The ONE
+   * confirm spelling: `@objectstack/spec`'s action surface and the
+   * TranslationBundle key (`{ns}.objects.{obj}._actions.{name}.confirmText`)
+   * both stand on it.
+   */
   confirmText?: string;
-  /** Structured confirmation (from crud.ts) */
-  confirm?: { title?: string; message?: string; confirmText?: string; cancelText?: string };
+  /**
+   * RETIRED (objectui#4314): the structured confirm object used to sit here
+   * and its `message` OUTRANKED `confirmText` — untranslated, since no bundle
+   * key exists for it. `?: never` so constructing an action with it is a tsc
+   * error rather than a silently-ignored key; the authorable twin
+   * (`@object-ui/types` `crud.ts`) carries the same tombstone.
+   * @deprecated Retired — author `confirmText` instead.
+   */
+  confirm?: never;
   /**
    * Condition predicate — the action executes only while it holds.
    *
@@ -967,16 +979,14 @@ export class ActionRunner {
         }
       }
 
-      // Confirmation (structured or simple)
-      const confirmMessage = action.confirm?.message || action.confirmText;
-      if (confirmMessage) {
+      // Confirmation. One spelling: `confirmText` — the only one the
+      // translation bundle can address (`…._actions.{name}.confirmText`). The
+      // structured `confirm.message` read that used to OUTRANK it is retired
+      // (objectui#4314): it had zero producers and no bundle key, so a dialog
+      // authored that way silently lost localization.
+      if (action.confirmText) {
         const confirmed = await this.confirmHandler(
-          this.evaluator.evaluate(confirmMessage) as string,
-          action.confirm ? {
-            title: action.confirm.title,
-            confirmText: action.confirm.confirmText,
-            cancelText: action.confirm.cancelText,
-          } : undefined,
+          this.evaluator.evaluate(action.confirmText) as string,
         );
         if (!confirmed) {
           return { success: false, error: 'Action cancelled by user' };

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -166,7 +166,7 @@ describe('ActionRunner', () => {
         onClick,
       });
 
-      expect(confirmHandler).toHaveBeenCalledWith('Are you sure?', undefined);
+      expect(confirmHandler).toHaveBeenCalledWith('Are you sure?');
       expect(result.success).toBe(true);
       expect(onClick).toHaveBeenCalledOnce();
     });
@@ -186,25 +186,25 @@ describe('ActionRunner', () => {
       expect(onClick).not.toHaveBeenCalled();
     });
 
-    it('should support structured confirmation', async () => {
-      const confirmHandler = vi.fn().mockResolvedValue(true);
+    it('ignores the retired structured confirm object (objectui#4314)', async () => {
+      const confirmHandler = vi.fn().mockResolvedValue(false);
       runner.setConfirmHandler(confirmHandler);
 
-      await runner.execute({
-        confirm: {
-          title: 'Delete',
-          message: 'Delete this item?',
-          confirmText: 'Yes, delete',
-          cancelText: 'Cancel',
-        },
-        onClick: vi.fn(),
-      });
+      const onClick = vi.fn();
+      // Metadata that still carries the retired arm (e.g. stored before the
+      // retirement) — cast, because `ActionDef.confirm` is a `never` tombstone
+      // and the key cannot be AUTHORED in TypeScript at all.
+      const result = await runner.execute({
+        confirm: { title: 'Delete', message: 'Delete this item?' },
+        onClick,
+      } as unknown as ActionDef);
 
-      expect(confirmHandler).toHaveBeenCalledWith('Delete this item?', {
-        title: 'Delete',
-        confirmText: 'Yes, delete',
-        cancelText: 'Cancel',
-      });
+      // No confirm gate: the runner reads only `confirmText`. Under the old
+      // precedence read, the REJECTING handler above would have cancelled the
+      // action — success here is what pins the read's removal.
+      expect(confirmHandler).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(onClick).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
+++ b/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
@@ -151,7 +151,7 @@ describe('resolveBulkActions', () => {
       name: 'push_down',
       icon: 'send',
       variant: 'danger',
-      confirm: { message: '确认下推?' },
+      confirmText: '确认下推?',
       visible: { dialect: 'cel', source: 'current_user.is_admin' },
     };
     const { defs } = resolveBulkActions({
@@ -165,6 +165,20 @@ describe('resolveBulkActions', () => {
       confirmText: '确认下推?',
       visible: { dialect: 'cel', source: 'current_user.is_admin' },
     });
+  });
+
+  // [objectui#4314] The structured `confirm` object is retired. Spec's action
+  // surface carries only `confirmText`, so `objectDef.actions` can never
+  // deliver this key — and the fallback read that used to sit in
+  // `toBulkActionDef` was the last thing keeping the second dialect alive.
+  it('ignores the retired structured confirm object (objectui#4314)', () => {
+    const stale = { name: 'push_down', confirm: { message: '确认下推?' } };
+    const { defs } = resolveBulkActions({
+      bulkActions: ['push_down'],
+      objectActions: [stale],
+    });
+
+    expect(defs[0].confirmText).toBeUndefined();
   });
 
   // [objectui#3492] The capability gate must travel with the promoted action:

--- a/packages/plugin-grid/src/resolveBulkActions.ts
+++ b/packages/plugin-grid/src/resolveBulkActions.ts
@@ -118,12 +118,11 @@ function toBulkActionDef(action: NamedActionDef, localize?: ActionLabelResolver)
   const variant = typeof action.variant === 'string' && BULK_VARIANTS.has(action.variant)
     ? (action.variant as BulkActionDef['variant'])
     : undefined;
-  const confirmText =
-    typeof action.confirmText === 'string'
-      ? action.confirmText
-      : typeof (action.confirm as { message?: unknown } | undefined)?.message === 'string'
-        ? String((action.confirm as { message: string }).message)
-        : undefined;
+  // `confirmText` only. The structured `confirm.message` fallback that used to
+  // sit here is retired (objectui#4314): spec's action surface carries no
+  // structured confirm, so the branch read a key `objectDef.actions` can never
+  // deliver — and tolerating it kept a second confirm dialect alive (#0.1).
+  const confirmText = typeof action.confirmText === 'string' ? action.confirmText : undefined;
   // A non-string `I18nLabel` (the `{ en, zh }` map form) is dropped rather than
   // forwarded: the bar renders `def.label` as a React child, so an object here
   // would take the page down. Falling through to `formatActionLabel(name)`

--- a/packages/types/src/__tests__/phase2-schemas.test.ts
+++ b/packages/types/src/__tests__/phase2-schemas.test.ts
@@ -29,6 +29,7 @@ import {
   AnyComponentSchema,
   ListViewSchema,
 } from '../zod/index.zod';
+import type { ActionSchema as CrudActionSchema } from '../crud';
 
 describe('Phase 2: AppComponentSchema Zod Validation', () => {
   it('should validate a complete AppComponentSchema', () => {
@@ -360,19 +361,48 @@ describe('Phase 2: Enhanced ActionSchema Zod Validation', () => {
       type: 'action',
       label: 'Delete Record',
       actionType: 'confirm',
-      confirm: {
-        title: 'Confirm Deletion',
-        message: 'Are you sure you want to delete this record?',
-        confirmText: 'Delete',
-        cancelText: 'Cancel',
-        confirmVariant: 'destructive',
-      },
+      confirmText: 'Are you sure you want to delete this record?',
       api: '/api/records/123',
       method: 'DELETE',
     };
 
     const result = ActionSchema.safeParse(confirmAction);
     expect(result.success).toBe(true);
+  });
+
+  it('refuses the retired structured confirm object (objectui#4314)', () => {
+    const structured = {
+      type: 'action',
+      label: 'Delete Record',
+      actionType: 'confirm',
+      confirm: { title: 'Confirm Deletion', message: 'Are you sure?' },
+    };
+
+    // Zod half of the `crud.ts` `confirm?: never` tombstone: any authored
+    // value is a LOUD parse rejection — never a silent strip, which would let
+    // the author believe the dialog they configured exists. Absent stays
+    // valid (accept case above).
+    const result = ActionSchema.safeParse(structured);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((i) => i.path.join('.'))).toContain('confirm');
+    }
+  });
+
+  it('carries the retirement to TypeScript authors (confirm is `never`)', () => {
+    const action: CrudActionSchema = {
+      type: 'action',
+      label: 'Delete',
+      // @ts-expect-error `confirm` is retired (objectui#4314) — its `message`
+      // outranked `confirmText`, the only spelling the translation bundle
+      // knows. `?: never` carries the retirement to authors writing
+      // TypeScript; the Zod refusal above carries it to JSON.
+      confirm: { message: 'Delete this item?' },
+    };
+    // The contract lives in the directive above: per this package's
+    // `type-check` (tsc -p tsconfig.test.json compiles every test file),
+    // putting the key back makes the directive unused and fails the build.
+    expect(action.type).toBe('action');
   });
 
   it('should validate dialog action type', () => {

--- a/packages/types/src/crud.ts
+++ b/packages/types/src/crud.ts
@@ -131,33 +131,26 @@ export interface ActionSchema extends BaseSchema {
    */
   headers?: Record<string, string>;
   /**
-   * Confirmation dialog configuration (for confirm actions)
+   * RETIRED (objectui#4314, maintainer ruling 2026-08-17, ADR-0049
+   * enforce-or-remove): the structured confirm object
+   * (`{ title, message, confirmText, cancelText, confirmVariant }`) had zero
+   * producers, and in `ActionRunner` its `message` OUTRANKED `confirmText` —
+   * the only spelling the translation bundle knows
+   * (`{ns}.objects.{obj}._actions.{name}.confirmText`) — so a dialog authored
+   * this way silently lost localization. `?: never` is this package's
+   * tombstone convention (see `complex.ts` `DashboardWidgetSchema`): authoring
+   * the key is a tsc error here and a parse rejection in the Zod twin
+   * (`zod/crud.zod.ts`); reading it still type-checks (`never | undefined`)
+   * during migration. Reopen condition, recorded on objectui#4314: real demand
+   * for structured confirm dialogs — the arm returns WITH its bundle keys
+   * (`_actions.{name}.confirm.*`) designed in, never before.
+   * @deprecated Retired — author `confirmText` instead.
    */
-  confirm?: {
-    /**
-     * Confirmation title
-     */
-    title?: string;
-    /**
-     * Confirmation message
-     */
-    message?: string;
-    /**
-     * Confirm button text
-     */
-    confirmText?: string;
-    /**
-     * Cancel button text
-     */
-    cancelText?: string;
-    /**
-     * Confirm button variant
-     */
-    confirmVariant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost';
-  };
+  confirm?: never;
   /**
-   * Legacy confirmation message (deprecated - use confirm object instead)
-   * @deprecated Use confirm.message instead
+   * Confirmation message — shows a confirm dialog before executing.
+   * The ONE confirm spelling: `@objectstack/spec`'s action surface and the
+   * TranslationBundle both stand on `confirmText`.
    */
   confirmText?: string;
   /**

--- a/packages/types/src/zod/crud.zod.ts
+++ b/packages/types/src/zod/crud.zod.ts
@@ -63,14 +63,12 @@ export const ActionSchema: z.ZodType<any> = z.lazy(() => BaseSchema.extend({
   method: z.enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH']).optional().default('POST').describe('HTTP method'),
   data: z.any().optional().describe('Request body/data'),
   headers: z.record(z.string(), z.string()).optional().describe('Request headers'),
-  confirm: z.object({
-    title: z.string().optional().describe('Confirmation title'),
-    message: z.string().optional().describe('Confirmation message'),
-    confirmText: z.string().optional().describe('Confirm button text'),
-    cancelText: z.string().optional().describe('Cancel button text'),
-    confirmVariant: z.enum(['default', 'destructive', 'outline', 'secondary', 'ghost']).optional().describe('Confirm button variant'),
-  }).optional().describe('Confirmation dialog configuration (for confirm actions)'),
-  confirmText: z.string().optional().describe('Legacy confirmation message (deprecated - use confirm object instead)'),
+  // RETIRED (objectui#4314): the structured confirm object is a tombstone.
+  // The TS twin (`crud.ts`) types it `?: never`; here any authored value is a
+  // loud parse rejection (absent stays valid), mirroring how `@objectstack/spec`
+  // retires keys. One confirm spelling: `confirmText` below.
+  confirm: z.never().optional().describe('RETIRED (objectui#4314) — author confirmText instead'),
+  confirmText: z.string().optional().describe('Confirmation message — shows a confirm dialog before executing'),
   dialog: z.object({
     title: z.string().optional().describe('Dialog title'),
     content: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Dialog content'),


### PR DESCRIPTION
Fixes #4314

Maintainer ruling 2026-08-17 (verbatim 「同意」, disposition 1 — ADR-0049 enforce-or-remove, remove arm), re-scoped to Option A after the fork report on the card: the structured `confirm` object had zero producers, no translation-bundle key, and its `message` OUTRANKED `confirmText` — the only spelling the bundle knows (`{ns}.objects.{obj}._actions.{name}.confirmText`) — so a dialog authored that way silently lost localization, while four surfaces steered authors INTO it.

## What changed

- **`@object-ui/types`** — `packages/types/src/crud.ts`: the structured arm is now a `?: never` tombstone and the backwards `@deprecated` note on `confirmText` is gone. `packages/types/src/zod/crud.zod.ts`: the Zod twin refuses any authored `confirm` value (absent stays valid) instead of accepting the object; its backwards describe-text is fixed.
- **`@object-ui/core`** — `packages/core/src/actions/ActionRunner.ts`: the precedence read (`action.confirm?.message || action.confirmText`) is deleted; the runner reads only `confirmText`. `ActionDef.confirm` carries the same `never` tombstone. `ConfirmationHandler`'s signature is untouched (see scope note below); the runner now invokes it without the options argument.
- **`@object-ui/plugin-grid`** — `packages/plugin-grid/src/resolveBulkActions.ts`: the `confirm.message` fallback is dropped — spec's action surface carries only `confirmText` (verified against the installed `@objectstack/spec` dist), so that branch read a key `objectDef.actions` can never deliver.
- **Docs** — `content/docs/core/enhanced-actions.mdx` (three snippets plus the Confirm Properties reference) and `content/docs/api/schema-reference.md` (example plus property table) now teach `confirmText`. These were the remaining steering faces.
- Changeset: `minor` for all three packages per this repo's no-major policy, breaking semantics spelled out in the changeset body.

## Retirement convention applied, and why

This repo's tombstone convention for retired authorable keys (precedent: `packages/types/src/complex.ts` `DashboardWidgetSchema`, mirroring `@objectstack/spec`'s `retiredKey` doctrine), rather than a bare deletion:

1. **TS half**: `confirm?: never` — authoring the key is a tsc error at the author's desk, not a silently-ignored key at runtime; reading it still type-checks during migration.
2. **Zod half**: `z.never().optional()` — any authored value is a loud parse rejection, never a silent strip that would let an author believe the dialog they configured exists.
3. **Pins**: a `@ts-expect-error` literal pin (enforced by the types package's `type-check`, which compiles every test file and fails on an unused directive), a Zod refusal pin, an ActionRunner pin (a rejecting confirm handler is NOT invoked by the retired arm — under the old precedence read that handler would have cancelled the action), and a resolveBulkActions pin (structured object promotes to no `confirmText`).

A bare deletion would have left excess-property checking as the only compile-time signal (which spread/indirect objects bypass) and Zod strip-mode acceptance as the runtime behaviour — the silent-behaviour-change shape the dispatch prohibited.

## Scope notes

- `packages/app-shell` is deliberately NOT in this diff (held by another session this round). `ConfirmationHandler`'s optional options parameter — fed only by the retired arm — stays as declared; the follow-up recording that it is now declared-but-never-produced (ADR-0049 shape) is #5205. #5205 remains open and is not addressed here.
- Reopen condition recorded on the card: real demand for structured confirm dialogs returns the arm WITH its bundle keys (`_actions.{name}.confirm.*`) designed in.
- Overlap scan: today's main landings (#5196, #5204, #5200, #5199, #5193, #5188) touch app-shell/components/fields/docs-styling — none intersect this diff's files; `origin/main` (4eac264) is merged into the branch.

## Verification (all at head `4e65597eb` unless noted)

- Build: turbo `--filter="...@object-ui/types"` — 43/43 tasks green.
- Tests (repo root, path-filtered): `pnpm exec vitest run packages/types/ packages/core/ packages/plugin-grid/` — 204 files, 3011 tests, all green.
- **Consumer radius for `@object-ui/types`** — direction: dependents (prefix filter `...@object-ui/types`): turbo `type-check` — 78/78 tasks green, including app-shell, components, fields, examples, console (read-only type-check; no files edited there).
- Reverse verification (at `9621a62`, pre-merge; the merge touched none of this diff's files): a temp probe in `packages/core` authoring `confirm: { message: … }` against the REBUILT `@object-ui/types` dist — `error TS2322: Type '{ message: string; }' is not assignable to type 'undefined'` — then removed; observed direction: red, as expected.
- Gates: `check-changeset-presence`, `changeset:check` (no-major), `check:control-bytes`, `check:doc-snippets` (67/67 blocks), `docs:check-links` — green at `4e65597eb`; `check:action-forward-parity`, `check:doc-types`, `check:spec-symbols`, package `lint` (3 pkgs), package `type-check` (3 pkgs, includes the `@ts-expect-error` enforcement) — green at `9621a62`, diff unchanged since.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_