### PR TITLE
fix(fields): the lookup recents rail obeys lookupFilters and the dependsOn cascade

### DIFF
--- a/.changeset/lookup-recents-declared-filters.md
+++ b/.changeset/lookup-recents-declared-filters.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/fields': patch
+---
+
+Lookup "recently used" now obeys the field's declared filters. The recents rail
+re-fetched its rows without merging either `lookupFilters` or the `dependsOn`
+cascade, so a record the author's metadata excludes stayed visible and
+selectable — pick a product under project A, switch the form to project B, and
+project A's product was still offered. Both re-fetch channels are fixed: the
+inline dropdown (which re-read each remembered id with an unfiltered `findOne`)
+and the search-first picker (which batched recents into an unfiltered `$in`
+query). The currently-selected value still resolves unfiltered, so an existing
+value keeps its label and a selection tray is never silently emptied.

--- a/packages/fields/src/complex-widgets.test.tsx
+++ b/packages/fields/src/complex-widgets.test.tsx
@@ -435,8 +435,19 @@ describe('Complex & Relationship Widgets', () => {
 
         it('shows a recently-used section on empty focus', async () => {
             localStorage.setItem('objectui:lookup:recent:customers', JSON.stringify(['r1']));
-            mockDataSource.find.mockResolvedValue({ data: [{ id: 'a', name: 'Acme Corp' }], total: 1 });
-            mockDataSource.findOne.mockResolvedValue({ id: 'r1', name: 'Recent Co' });
+            // The rail resolves its remembered ids through `find`, carrying the
+            // field's merged filter, rather than the unfiltered per-id `findOne`
+            // it used before (#5195) — so the fixture answers the id-restricted
+            // query. Behaviour under test is unchanged: recents still appear on
+            // empty focus, in their own section.
+            mockDataSource.find.mockImplementation(async (_obj: string, params: any) => {
+                const ids = params?.$filter?.id?.$in as string[] | undefined;
+                if (ids) {
+                    const data = [{ id: 'r1', name: 'Recent Co' }].filter(r => ids.includes(r.id));
+                    return { data, total: data.length };
+                }
+                return { data: [{ id: 'a', name: 'Acme Corp' }], total: 1 };
+            });
 
             render(<LookupField {...dynamicProps} />);
 

--- a/packages/fields/src/widgets/LookupField.recentsFilters.test.tsx
+++ b/packages/fields/src/widgets/LookupField.recentsFilters.test.tsx
@@ -1,0 +1,380 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The "recently used" rail must obey the declared filters — objectui#5195.
+ *
+ * Reported from a deployed project: a `product` lookup declaring
+ * `lookupFilters: [{ field: 'status', operator: 'eq', value: 'active' }]` plus
+ * `dependsOn: [{ field: 'project', param: 'project' }]` served its recents rail
+ * from a re-fetch that merged NEITHER filter. Pick a product under project A,
+ * switch the form to project B, reopen the lookup, and project A's product was
+ * still offered — and selecting it produced a cross-project value the author's
+ * metadata had excluded. The main candidate query was filtered correctly the
+ * whole time; only the recents channel was not, which left the application a
+ * server-side `beforeInsert`/`beforeUpdate` hook as its only defence.
+ *
+ * There are TWO such channels and they failed differently, so both are pinned
+ * here, against both filter kinds — four pins:
+ *
+ *   inline dropdown (`LookupField`'s quick-select popover)
+ *     re-read each remembered id with `dataSource.findOne(object, id)`, which
+ *     takes no filter argument at all.
+ *   search-first picker (`PeoplePicker`, the Level-2 picker `LookupField`
+ *   renders for `picker: 'search'` fields)
+ *     batched value ids + recent ids into one `{ [idField]: { $in: ids } }`
+ *     query that merged neither the base `lookupFilters` nor the `dependsOn`
+ *     cascade — while the main candidate query beside it merged both.
+ *
+ * The cascade pins drive the reporter's sequence for real (select under project
+ * A, which pushes the record into the recents store, then re-render under
+ * project B and reopen) rather than seeding the store by hand, so the whole
+ * loop is under test.
+ *
+ * Two further pins guard the deliberate scope boundary this fix draws: the
+ * current VALUE's re-fetch stays unfiltered (it reports a choice already made,
+ * so narrowing it would only hide the record's own label and could empty a
+ * selection tray), and a gated cascade shows no rail at all.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LookupField } from './LookupField';
+import { PeoplePicker } from './PeoplePicker';
+import { pushRecentLookupId } from './recentLookups';
+
+type Row = Record<string, any>;
+
+const products: Row[] = [
+  { id: 'p1', name: 'Alpha Widget', status: 'active', project: 'projA' },
+  { id: 'p2', name: 'Beta Widget', status: 'active', project: 'projB' },
+  { id: 'p3', name: 'Retired Widget', status: 'archived', project: 'projB' },
+];
+
+/**
+ * A fake backend that evaluates BOTH `$filter` shapes the pickers emit: the
+ * `QueryParams.$filter` record form, and the ObjectQL AST node `mergeFilterNodes`
+ * lowers a conjunction to. Evaluating rather than shape-matching is the point —
+ * a pin that asserted a query shape would pass for a merge that is syntactically
+ * present and semantically wrong, and these tests exist to answer "can the user
+ * still see the excluded record", which only a real filter evaluation answers.
+ * Unsupported operators throw instead of matching everything, so a widened
+ * filter can never read as a passing test.
+ */
+function matchesOp(actual: any, op: string, v: any): boolean {
+  switch (op) {
+    case '$eq': return actual === v;
+    case '$ne': return actual !== v;
+    case '$in': return (v as any[]).map(String).includes(String(actual));
+    case '$nin': return !(v as any[]).map(String).includes(String(actual));
+    case '$contains': return String(actual ?? '').includes(String(v));
+    default: throw new Error(`fake backend: unsupported record operator '${op}'`);
+  }
+}
+
+function matchesNode(row: Row, node: any): boolean {
+  if (!Array.isArray(node)) return matchesRecord(row, node);
+  if (node.length === 0) return true;
+  const head = node[0];
+  if (head === 'and') return node.slice(1).every((n: any) => matchesNode(row, n));
+  if (head === 'or') return node.slice(1).some((n: any) => matchesNode(row, n));
+  // A bare array of nodes (no boolean head) is a conjunction.
+  if (Array.isArray(head)) return node.every((n: any) => matchesNode(row, n));
+  const [field, op, v] = node as [string, string, any];
+  switch (op) {
+    case '=': return row[field] === v;
+    case '!=': return row[field] !== v;
+    case 'in': return (v as any[]).map(String).includes(String(row[field]));
+    case 'nin': return !(v as any[]).map(String).includes(String(row[field]));
+    case 'contains': return String(row[field] ?? '').includes(String(v));
+    default: throw new Error(`fake backend: unsupported AST operator '${op}'`);
+  }
+}
+
+function matchesRecord(row: Row, filter: any): boolean {
+  if (filter === undefined || filter === null) return true;
+  if (typeof filter !== 'object') return true;
+  return Object.entries(filter).every(([field, cond]) => {
+    if (cond !== null && typeof cond === 'object' && !Array.isArray(cond)) {
+      return Object.entries(cond as Row).every(([op, v]) => matchesOp(row[field], op, v));
+    }
+    return row[field] === cond;
+  });
+}
+
+function matchesFilter(row: Row, filter: any): boolean {
+  if (Array.isArray(filter)) return matchesNode(row, filter);
+  return matchesRecord(row, filter);
+}
+
+function makeDataSource(rows: Row[] = products) {
+  const find = vi.fn(async (_obj: string, params: any) => {
+    let data = rows.filter(r => matchesFilter(r, params?.$filter));
+    const search: string | undefined = params?.$search;
+    if (search) {
+      data = data.filter(r => String(r.name).toLowerCase().includes(search.toLowerCase()));
+    }
+    const skip: number = params?.$skip ?? 0;
+    const top: number = params?.$top ?? data.length;
+    return { data: data.slice(skip, skip + top), total: data.length };
+  });
+  // The unfiltered by-id read the inline dropdown used to resolve recents with.
+  // Kept on the fake on purpose: without it the pre-fix rail would come up empty
+  // and these pins would pass against the very code they exist to reject.
+  const findOne = vi.fn(async (_obj: string, id: any) =>
+    rows.find(r => String(r.id) === String(id)) ?? null,
+  );
+  return { find, findOne } as any;
+}
+
+/** Labels currently offered in the inline dropdown's candidate list. */
+function optionLabels(): string[] {
+  return screen.queryAllByRole('option').map(el => el.textContent ?? '');
+}
+
+/** Names currently offered as rows in the search-first picker. */
+function personRowNames(): string[] {
+  return screen.queryAllByTestId('person-row').map(el => el.textContent ?? '');
+}
+
+beforeEach(() => {
+  // jsdom has no matchMedia; PeoplePicker's useIsMobile needs it. Desktop width.
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as any;
+  try {
+    localStorage.clear();
+  } catch {
+    /* jsdom */
+  }
+});
+
+// The reporter's field, spelled the way the report spells it — camelCase
+// `lookupFilters` / `dependsOn`, which the widget accepts alongside the
+// snake_case ObjectStack convention.
+const staticFilterField = {
+  name: 'product',
+  label: 'Product',
+  reference_to: 'product',
+  reference_field: 'name',
+  lookupFilters: [{ field: 'status', operator: 'eq', value: 'active' }],
+} as any;
+
+const cascadeField = {
+  name: 'product',
+  label: 'Product',
+  reference_to: 'product',
+  reference_field: 'name',
+  dependsOn: [{ field: 'project', param: 'project' }],
+} as any;
+
+describe('inline dropdown — the recents rail merges the declared filters (#5195)', () => {
+  it('drops a recent record the static lookupFilters exclude', async () => {
+    // Both were picked before; only one is still `status: active`.
+    pushRecentLookupId('product', 'p3');
+    pushRecentLookupId('product', 'p2');
+    const ds = makeDataSource();
+
+    render(
+      <LookupField
+        field={staticFilterField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={ds}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+
+    await waitFor(() => expect(optionLabels().join('|')).toContain('Beta Widget'));
+    // The rail is alive (positive control) and the archived record is gone.
+    expect(screen.getByText(/recently used/i)).toBeTruthy();
+    expect(optionLabels().join('|')).not.toContain('Retired Widget');
+  });
+
+  it("stops offering project A's product after the parent switches to project B", async () => {
+    const ds = makeDataSource();
+    const onChange = vi.fn();
+
+    // 1. Under project A, pick Alpha Widget — this is what fills the recents store.
+    const { rerender } = render(
+      <LookupField
+        field={cascadeField}
+        value={undefined}
+        onChange={onChange}
+        readonly={false}
+        dataSource={ds}
+        {...({ dependentValues: { project: 'projA' } } as any)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+    await waitFor(() => expect(optionLabels().join('|')).toContain('Alpha Widget'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Alpha Widget'));
+    });
+    expect(onChange).toHaveBeenCalledWith('p1');
+
+    // 2. The form's project moves to B. Reopen the lookup.
+    rerender(
+      <LookupField
+        field={cascadeField}
+        value={undefined}
+        onChange={onChange}
+        readonly={false}
+        dataSource={ds}
+        {...({ dependentValues: { project: 'projB' } } as any)}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+
+    // 3. Project B's products are offered; project A's recent is not.
+    await waitFor(() => expect(optionLabels().join('|')).toContain('Beta Widget'));
+    expect(optionLabels().join('|')).not.toContain('Alpha Widget');
+  });
+
+  it('shows no rail at all while the cascade is still gated', async () => {
+    pushRecentLookupId('product', 'p1');
+    const ds = makeDataSource();
+
+    render(
+      <LookupField
+        field={cascadeField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={ds}
+        {...({ dependentValues: { project: null } } as any)}
+      />,
+    );
+
+    // The gated trigger cannot open the popover; nothing may be offered, and in
+    // particular no leftover recent may be resolved behind the gate.
+    await waitFor(() => expect(screen.getByTestId('lookup-trigger-gated')).toBeDisabled());
+    expect(optionLabels()).toHaveLength(0);
+    expect(screen.queryByText('Alpha Widget')).toBeNull();
+  });
+});
+
+describe('search-first picker — the seed re-fetch merges the declared filters (#5195)', () => {
+  it('drops a recent record the static lookupFilters exclude', async () => {
+    pushRecentLookupId('product', 'p3');
+    pushRecentLookupId('product', 'p2');
+    const ds = makeDataSource();
+
+    render(
+      <PeoplePicker
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="product"
+        displayField="name"
+        onSelect={vi.fn()}
+        lookupFilters={[{ field: 'status', operator: 'eq', value: 'active' }]}
+      />,
+    );
+
+    await waitFor(() => expect(personRowNames().join('|')).toContain('Beta Widget'));
+    expect(screen.getByText(/recently used/i)).toBeTruthy();
+    expect(personRowNames().join('|')).not.toContain('Retired Widget');
+  });
+
+  it("stops offering project A's product after the parent switches to project B", async () => {
+    const ds = makeDataSource();
+    const onSelect = vi.fn();
+
+    // 1. Under project A, pick Alpha Widget.
+    const { rerender } = render(
+      <PeoplePicker
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="product"
+        displayField="name"
+        onSelect={onSelect}
+        baseFilter={{ project: 'projA' }}
+      />,
+    );
+
+    await waitFor(() => expect(personRowNames().join('|')).toContain('Alpha Widget'));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Alpha Widget'));
+    });
+    expect(onSelect).toHaveBeenCalledWith('p1');
+
+    // 2. The cascade moves to project B; the picker reopens.
+    rerender(
+      <PeoplePicker
+        open={false}
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="product"
+        displayField="name"
+        onSelect={onSelect}
+        baseFilter={{ project: 'projB' }}
+      />,
+    );
+    rerender(
+      <PeoplePicker
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="product"
+        displayField="name"
+        onSelect={onSelect}
+        baseFilter={{ project: 'projB' }}
+      />,
+    );
+
+    // 3. Project B's products are offered; project A's recent is not.
+    await waitFor(() => expect(personRowNames().join('|')).toContain('Beta Widget'));
+    expect(personRowNames().join('|')).not.toContain('Alpha Widget');
+  });
+
+  it('still hydrates a current value the filters exclude (the value leg stays unfiltered)', async () => {
+    const ds = makeDataSource();
+
+    render(
+      <PeoplePicker
+        open
+        multiple
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="product"
+        displayField="name"
+        value={['p3']}
+        onSelect={vi.fn()}
+        onSelectRecords={vi.fn()}
+        lookupFilters={[{ field: 'status', operator: 'eq', value: 'active' }]}
+      />,
+    );
+
+    // `p3` is archived, so it is not a candidate and not a recent — but it IS
+    // what the record holds, and the tray must say so rather than silently
+    // dropping it (a no-op Confirm would otherwise clear the field).
+    await waitFor(() => expect(screen.getAllByTestId('selection-chip')).toHaveLength(1));
+    expect(screen.getByTestId('selection-tray').textContent).toContain('Retired Widget');
+    expect(personRowNames().join('|')).not.toContain('Retired Widget');
+  });
+});

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -18,7 +18,7 @@ import type { RecordPickerFilterColumn } from './RecordPickerDialog';
 import { PeoplePicker } from './PeoplePicker';
 import { useRecordQuery } from './useRecordQuery';
 import { deriveLookupColumns } from './deriveLookupColumns';
-import { getRecordDisplayName } from '@object-ui/core';
+import { getRecordDisplayName, mergeFilterNodes } from '@object-ui/core';
 import { getRecentLookupIds, pushRecentLookupId } from './recentLookups';
 import { getPersonInitials } from './personDisplay';
 import { getCellRendererResolver } from './_cell-renderer-bridge';
@@ -493,6 +493,15 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
    * but no option resolves it yet. Fetches the referenced record(s) via
    * the DataSource and caches them in `pickerResolvedRecords` so the chip
    * shows a friendly label instead of an empty placeholder.
+   *
+   * Deliberately UNFILTERED, unlike the recents rail below (#5195). These ids
+   * are what the record already holds, not candidates being offered: the value
+   * is committed, so hiding it cannot prevent a bad pick — it can only replace
+   * a readable label with a raw id and hide the mismatch from the user who
+   * needs to see it. A record that was admissible when chosen and is not any
+   * more (a product deactivated last week) must still render its name. The
+   * narrowing belongs on every surface that OFFERS a choice; this one reports
+   * one already made.
    */
   useEffect(() => {
     if (!hasDataSource || !dataSource || !referenceTo) return;
@@ -750,29 +759,71 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
   );
 
   // ── Recently-used, quick-create, combined option list ────────────────────
+  //
+  // The recents rail lists CANDIDATES, so its re-fetch must answer the same
+  // question the main popover query answers: "which records may this field
+  // take right now?" (#5195). It used to answer a different one — it re-read
+  // each remembered id with `dataSource.findOne(referenceTo, id)`, which
+  // carries no filter at all, so a record the author's `lookupFilters`
+  // exclude, or one belonging to the PREVIOUS value of a `depends_on` parent,
+  // stayed visible and selectable. Reported from a deployed project: pick a
+  // product under project A, switch to project B, and the rail still offered
+  // project A's product — the declared filter was enforced on every surface
+  // except this one, leaving a server-side hook as the app's only defence.
+  //
+  // The fix is one filtered query, not a client-side prune: `popoverFilter`
+  // (base `lookupFilters` + the `depends_on` chain) is merged with the id
+  // restriction through `mergeFilterNodes`, the repo's single filter sink, so
+  // the SERVER decides admissibility exactly as it does for the main query.
+  // Merging as a conjunction rather than spreading matters — a spread would
+  // let the `$in` overwrite a declared filter that happens to key on the same
+  // field, widening the accept set at the one place we are narrowing it.
+  //
+  // Two bypasses close with it: the per-id `findOption` cache could return a
+  // record resolved under the old parent (the cache has no idea a filter
+  // moved), and a gated cascade (`dependenciesMissing`) disabled the main
+  // query while leaving this one running. Membership now comes only from the
+  // filtered response; ids it does not return are dropped, whether they fail
+  // the filters or no longer exist. It is also one request instead of up to
+  // MAX_RECENT serial round-trips.
   const [recentOptions, setRecentOptions] = useState<LookupOption[]>([]);
   useEffect(() => {
     if (!isOpen || !hasDataSource || !dataSource || !referenceTo || searchQuery) return;
+    if (dependenciesMissing) { setRecentOptions([]); return; }
     const ids = getRecentLookupIds(referenceTo);
     if (!ids.length) { setRecentOptions([]); return; }
     let cancelled = false;
     (async () => {
       try {
-        const recs: LookupOption[] = [];
-        for (const id of ids) {
-          const cached = findOption(id);
-          if (cached) { recs.push(cached); continue; }
-          if (typeof (dataSource as any).findOne === 'function') {
-            const r = await (dataSource as any).findOne(referenceTo, id);
-            if (r) recs.push(recordToOption(r, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema));
+        const idRestriction = { [idField]: { $in: ids } };
+        const res = await dataSource.find(referenceTo, {
+          $filter: popoverFilter
+            ? mergeFilterNodes(popoverFilter, idRestriction)
+            : idRestriction,
+          $top: ids.length,
+        } as QueryParams);
+        const rows = (res as any)?.data ?? res ?? [];
+        const byId = new Map<string, any>();
+        if (Array.isArray(rows)) {
+          for (const row of rows) {
+            const rid = row?.[idField] ?? row?.id ?? row?._id;
+            if (rid !== undefined && rid !== null) byId.set(String(rid), row);
           }
         }
+        // Most-recent-first order is preserved; the response only decides
+        // WHICH ids survive, never their order.
+        const recs = ids
+          .map((id) => byId.get(String(id)))
+          .filter(Boolean)
+          .map((r) =>
+            recordToOption(r, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema),
+          );
         if (!cancelled) setRecentOptions(recs);
       } catch { if (!cancelled) setRecentOptions([]); }
     })();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, hasDataSource, referenceTo, searchQuery]);
+  }, [isOpen, hasDataSource, referenceTo, searchQuery, dependenciesMissing, popoverFilter, idField]);
 
   // Recently-used first (only before the user types), then live results — one
   // de-duped list that drives BOTH rendering and arrow-key navigation.

--- a/packages/fields/src/widgets/PeoplePicker.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.tsx
@@ -30,6 +30,10 @@ import {
 import { Search, Loader2, AlertCircle } from 'lucide-react';
 import type { DataSource, LookupFilterDef } from '@object-ui/types';
 import { useRecordQuery } from './useRecordQuery';
+// The repo's single filter sink — conjoins filter sources under one `and`
+// instead of spreading them, so an id restriction can never overwrite a
+// declared filter on the same field (#5195).
+import { mergeFilterNodes } from '@object-ui/core';
 import { lookupFiltersToRecord } from './RecordPickerDialog';
 import { getPersonId } from './personDisplay';
 import { PersonRow } from './PersonRow';
@@ -172,30 +176,65 @@ export function PeoplePicker({
     return value != null && value !== '' ? [value] : [];
   }, [multiple, value]);
 
-  // One extra query resolves both recents and the current selection to records.
-  const seedIds = useMemo(
-    () => Array.from(new Set([...valueIds, ...recentIds].map(v => v))),
-    [valueIds, recentIds],
-  );
-  const seedQuery = useRecordQuery({
+  // Recents and the current value used to ride ONE unfiltered `$in` query
+  // (`seedIds = valueIds + recentIds`), which is the defect in #5195: the main
+  // candidate query above merges `baseFilter` (the author's `lookupFilters`
+  // plus the `depends_on` cascade the host passes down) and this one merged
+  // nothing, so the "Recently used" rail kept offering records the declared
+  // filters exclude — a product from the previously-selected project, still
+  // selectable after switching parents.
+  //
+  // They are split because they answer DIFFERENT questions, and only one of
+  // them is about candidates:
+  //
+  //   valueQuery  — what does the record already hold? Stays UNFILTERED. The
+  //                 value is committed; dropping it here would empty the tray
+  //                 and make a no-op Confirm silently clear the field, which
+  //                 is a worse bug than the one being fixed.
+  //   recentQuery — what may the user pick right now? Carries the SAME merged
+  //                 filter as the main candidate query, so the server decides
+  //                 admissibility once, in one vocabulary.
+  //
+  // `mergeFilterNodes` (the repo's single filter sink) conjoins rather than
+  // spreads, so an id restriction can never overwrite a declared filter keyed
+  // on the same field and widen what we are here to narrow. With nothing
+  // declared there is nothing to enforce, and the plain record form goes out
+  // exactly as before.
+  const valueQuery = useRecordQuery({
     dataSource,
     objectName,
-    enabled: open && seedIds.length > 0,
-    pageSize: Math.max(1, seedIds.length),
-    filter: { [idField]: { $in: seedIds } },
+    enabled: open && valueIds.length > 0,
+    pageSize: Math.max(1, valueIds.length),
+    filter: { [idField]: { $in: valueIds } },
     expand: effectiveExpand,
   });
 
+  const recentFilter = useMemo<unknown>(() => {
+    const idRestriction = { [idField]: { $in: recentIds } };
+    return baseFilter ? mergeFilterNodes(baseFilter, idRestriction) : idRestriction;
+  }, [baseFilter, idField, recentIds]);
+
+  const recentQuery = useRecordQuery({
+    dataSource,
+    objectName,
+    enabled: open && recentIds.length > 0,
+    pageSize: Math.max(1, recentIds.length),
+    filter: recentFilter,
+    expand: effectiveExpand,
+  });
+
+  // Tray hydration reads the value leg only — a recents hit must never stand in
+  // for a value the value query did not return.
   const recordsById = useMemo(() => {
     const m = new Map<string, any>();
-    for (const r of seedQuery.records) m.set(String(getPersonId(r, idField)), r);
+    for (const r of valueQuery.records) m.set(String(getPersonId(r, idField)), r);
     return m;
-  }, [seedQuery.records, idField]);
+  }, [valueQuery.records, idField]);
 
   // --- selection state (full records so the tray can show avatar + name) ---
   const [selectedRecords, setSelectedRecords] = useState<any[]>([]);
   const seededRef = useRef(false);
-  // On open, seedQuery.loading is still false for one render (its fetch is
+  // On open, valueQuery.loading is still false for one render (its fetch is
   // kicked off in an effect that runs after this one), so an eager seed would
   // read an empty recordsById, seed nothing, and lock — wiping an existing
   // selection on confirm. Only seed after we've observed the fetch start.
@@ -216,7 +255,7 @@ export function PeoplePicker({
       seededRef.current = true;
       return;
     }
-    if (seedQuery.loading) {
+    if (valueQuery.loading) {
       sawSeedLoadingRef.current = true;
       return;
     }
@@ -225,7 +264,7 @@ export function PeoplePicker({
     const seeded = valueIds.map(id => recordsById.get(String(id))).filter(Boolean);
     setSelectedRecords(seeded);
     seededRef.current = true;
-  }, [open, valueIds, seedQuery.loading, recordsById]);
+  }, [open, valueIds, valueQuery.loading, recordsById]);
 
   const selectedIds = useMemo(
     () => new Set(selectedRecords.map(r => String(getPersonId(r, idField)))),
@@ -291,10 +330,20 @@ export function PeoplePicker({
   const hasSearch = query.search.trim().length > 0;
 
   // Recent contacts (only when not searching), in MRU order.
+  //
+  // Membership comes from the FILTERED recents query alone (#5195), never from
+  // the value leg: the currently-selected record is usually also the most
+  // recent one, and reading it out of the unfiltered tray map is exactly how a
+  // record the declared filters exclude used to walk back onto the rail. An id
+  // the filtered query did not return is dropped — it fails the filters, or it
+  // no longer exists, and neither is offerable.
   const recentRecords = useMemo(() => {
     if (hasSearch) return [];
-    return recentIds.map(id => recordsById.get(String(id))).filter(Boolean);
-  }, [hasSearch, recentIds, recordsById]);
+    const admissible = new Map<string, any>(
+      recentQuery.records.map(r => [String(getPersonId(r, idField)), r]),
+    );
+    return recentIds.map(id => admissible.get(String(id))).filter(Boolean);
+  }, [hasSearch, recentIds, recentQuery.records, idField]);
 
   // Candidate list; drop recents when idle to avoid showing them twice.
   const resultRecords = useMemo(() => {


### PR DESCRIPTION
Fixes #5195

A lookup field's "recently used" section re-fetched its rows without merging either declared filter, so a record the author's metadata excludes stayed visible **and selectable**. The reporter's case, from a deployed project: pick a product under project A, switch the form to project B, reopen the lookup — project A's product was still offered, and selecting it produced a cross-project value the metadata had ruled out. The main candidate query was filtered correctly the whole time; only the recents channel was not, which left the application a server-side `beforeInsert`/`beforeUpdate` hook as its only defence.

All verification below was run on `6a42db1fd`, the head of this branch.

## The premise check moved one of the two channels

The card and the dispatch both located channel 2 in `RecordPickerDialog` ("the grid picker batches value + recent ids as `{ [idField]: { $in: ids } }`"). Verified against `origin/main` before writing code, that is **not where it lives**:

- `RecordPickerDialog.tsx` has **exactly one** query, and its `mergedFilter` already folds `lookupFilters` + filter-bar values + the `baseFilter` cascade through `mergeFilterNodes`. It never imports `recentLookups`, has no recents rail, and has no value re-fetch. **Nothing to fix there** — it is the file that was already doing it right.
- `grep -rn '\$in' packages/fields/src` puts the batch in **`PeoplePicker.tsx`**, and it is exactly the reported shape: `seedIds = valueIds + recentIds`, fetched by a second `useRecordQuery` passing `filter: { [idField]: { $in: seedIds } }` — merging neither filter, twenty lines below a main query that merges both. The reporter's minified reading maps onto this file cleanly (their `n9({filter: fe})` is `useRecordQuery({ filter: baseFilter })`, their `i9` is `lookupFiltersToRecord`).

`PeoplePicker` is reached **from `LookupField` itself** for `picker: 'search'` fields, which hands it both `lookupFilters` and `baseFilter={dependentFilter}` — so a cascaded lookup on that variant hits the reporter's bug through this seed query. The dispatch had ruled `PeoplePicker` out of scope as "a different consumer of `lookupFilters`"; that rationale was written on the belief the channel lived elsewhere. Its seed query is not another read site — it **is** the second channel, so the fix is bounded to that query alone. Everything else in `PeoplePicker`, all of `UserField.tsx`, and all of `app-shell` are untouched. `UserField` needed no edit: it reaches this channel through `PeoplePicker`. The amended file surface was declared on the issue before the first edit.

## The two fixes

**Inline dropdown (`LookupField.tsx`).** Re-read each remembered id with `dataSource.findOne(object, id)`, which takes no filter argument at all. Now one batched query whose `$filter` merges `popoverFilter` (base `lookupFilters` plus the `depends_on` chain) with the id restriction. Two further bypasses close with it: the per-id `findOption` cache could return a record resolved under the *previous* parent value, and a gated cascade (`dependenciesMissing`) disabled the main query while leaving this one running. Membership now comes only from the filtered response. It is also one request instead of up to `MAX_RECENT` serial round-trips.

**Search-first picker (`PeoplePicker.tsx`).** The one unfiltered seed query is split by purpose, because the two legs answer different questions and only one is about candidates:

- `valueQuery` — what does the record already hold? Stays **unfiltered** (see below).
- `recentQuery` — what may the user pick right now? Carries the **same merged filter** as the main candidate query.

The rail's membership now reads from `recentQuery` alone. Sourcing it from the shared map was itself part of the bug: the selected record is usually also the most recent one, so an excluded record could walk back onto the rail through the value leg.

## Decisions the dispatch asked me to make and state

**Merged query, not client-side pruning.** Both channels permitted the merged filter, so the sanctioned pruning fallback was not needed. Pruning would still spend the round-trip, and — more to the point — it cannot faithfully re-evaluate operators, coercion, or the server's own sharing rules client-side, which is the lenient-consumer shape AGENTS.md #0.1 rules out.

Merging is a **conjunction** via `mergeFilterNodes`, the repo's single filter sink, not a spread. A spread would let the `$in` overwrite a declared filter keyed on the same field — widening the accept set at the one place this PR exists to narrow it. Where nothing is declared there is nothing to enforce, and the plain record form goes out exactly as before.

**The currently-selected `value` re-fetch stays unfiltered — deliberately, on both channels.** The reporter's reading that it rides the same channel was correct, and I did *not* extend the narrowing to it. These ids are what the record already holds, not candidates being offered: the value is committed, so hiding it cannot prevent a bad pick — it can only replace a readable label with a raw id and hide the mismatch from the user who most needs to see it. A record that was admissible when chosen and is not any more (a product deactivated last week) must still render its name. On `PeoplePicker` the stakes are higher still: dropping the value from the seed empties the selection tray, so a no-op Confirm would **silently clear the field** — a worse bug than the one being fixed. Pinned as a test, not just asserted.

## Tests — four pins, one per channel per filter kind

New `LookupField.recentsFilters.test.tsx` automates the reporter's repro rather than re-deriving one. The cascade pins drive the real sequence (select under project A, which pushes the record into the recents store, re-render under project B, reopen) instead of seeding the store by hand.

The fake backend **evaluates** both `$filter` shapes — the record form and the lowered AST — rather than shape-matching, because a shape assertion passes for a merge that is syntactically present and semantically wrong. Unsupported operators throw rather than matching everything, so a widened filter can never read as a pass. It also still implements the unfiltered `findOne`, so the pins cannot pass vacuously against the pre-fix code.

Reverse-verified. With both source files reverted to `origin/main` and the pins kept, **exactly the four rail pins fail**, each showing the excluded record being offered:

```
× drops a recent record the static lookupFilters exclude          (inline dropdown)
× stops offering project A's product after the parent switches…   (inline dropdown)
× drops a recent record the static lookupFilters exclude          (search-first picker)
× stops offering project A's product after the parent switches…   (search-first picker)

AssertionError: expected 'Beta Widget|Retired Widget|Alpha Widg…' not to contain 'Retired Widget'
AssertionError: expected 'Alpha Widget|Beta Widget|Retired Widg…' not to contain 'Alpha Widget'
Tests  4 failed | 2 passed (6)
```

The two guard pins (value leg stays unfiltered; gated cascade shows no rail) stayed green pre-fix, which is their point — they pin what must *not* change. Restoring the fix returns 6/6, and the restored files are byte-identical to the commit (`git diff HEAD` empty). No rebuild was needed for either leg and none is being claimed: `vitest.config.mts` aliases `@object-ui/core` to `packages/core/src`, and the subjects are same-package relative imports, so nothing in this test resolves through a `dist/`.

One existing fixture needed triage, not a sweep. `complex-widgets.test.tsx`'s "shows a recently-used section on empty focus" stubbed `findOne` because that was how the rail used to resolve ids — the behaviour it pins is unchanged and still correct, so it is **re-pointed** at the filtered channel rather than replaced. Scanned by the rule's consumer radius rather than by package: the recents store has read sites only in `packages/fields`, and the cross-package consumers that render these widgets were run too.

## Verification (all on `6a42db1fd`)

| Gate | Result |
|---|---|
| `pnpm exec vitest run packages/fields/` | 107 files, **1801 passed** |
| `pnpm --filter @object-ui/fields type-check` | pass (`tsc --noEmit` + `tsconfig.test.json`) |
| `pnpm --filter @object-ui/fields lint` | **0 errors** (839 pre-existing warnings) |
| `check-control-bytes.mjs` | OK, 4626 files; plus a direct scan of the 5 changed files |
| `check-changeset-presence.mjs` / `check-changeset-no-major.mjs` | pass — `@object-ui/fields` patch |
| `check-lint-coverage.mjs` / `check-type-check-coverage.mjs` | 46/46 linted, 0 errors outstanding |
| cross-package consumers (`components`, `plugin-detail`, `app-shell`) | 6 files, 75 passed |

## Out of scope

`PeoplePicker`'s other internals, `UserField.tsx`, and app-shell's metadata-admin inspectors are untouched. No separate card was filed: the one defect-shaped finding in this area turned out to *be* this card's channel 2 and is fixed here, and #5195 is the only issue addressed by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_