### PR TITLE
retire(studio): drop page:accordion title/items.value dead designer inputs (#5212)

### DIFF
--- a/.changeset/studio-accordion-dead-designer-inputs.md
+++ b/.changeset/studio-accordion-dead-designer-inputs.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Studio 页面设计器不再为 `page:accordion` 提供 `title` 与分区 `value` 编辑框(objectui#5212)
+
+`PageAccordionRenderer`(`renderers/layout/containers.tsx`)只读 `items`/`allowMultiple`/
+`variant`,从未有过 accordion 级别的标题;`@objectstack/spec` 的 `PageAccordionProps` 也
+从未声明 `title`。分区 `value` 更隐蔽:渲染器在渲染前用 `panel-${idx}` **覆盖**每个分区
+的 `value`(`itemsWithValue = items.map((it, idx) => ({ ...it, value: \`panel-${idx}\` }))`),
+所以作者写入的值永远到不了 Radix item——这与一栏之隔的 `page:tabs` 不对称:那里作者写的
+`items[].value`(设计器字段名 `key`)确实被读取,仅在缺省时才落到 `tab-${idx}`。
+
+两个键此前都能在 Studio 中配置、保存,却对渲染结果毫无影响,也没有任何诊断提示——本次移除
+让设计器诚实反映渲染器真正读取的形状,并移除随之成为孤儿的两条 i18n 键(en / zh 同一次改
+动,两张表的键集保持一致)。`page:tabs` 未受影响,`不得回潮` 钉在
+`previews/__tests__/block-config.test.ts`。
+
+原三键中的第三个——`page:header.icon`——已在 objectui#3829 / PR #4794 移除,先于本 issue
+被测量到,不在本次改动范围内。

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -659,10 +659,12 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.add.page:tabs.items': 'Add tab',
   'engine.inspector.pageBlock.field.page:tabs.items.key': 'Key',
   'engine.inspector.pageBlock.field.page:tabs.items.label': 'Label',
-  'engine.inspector.pageBlock.field.page:accordion.title': 'Title',
+  // `…field.page:accordion.title` and `…field.page:accordion.items.value`
+  // retired with their designer fields (objectui#5212): neither is read by
+  // `PageAccordionRenderer` nor declared by `PageAccordionProps`, so a key kept
+  // past its field is dead vocabulary the next author reads as a live surface.
   'engine.inspector.pageBlock.field.page:accordion.items': 'Sections',
   'engine.inspector.pageBlock.add.page:accordion.items': 'Add section',
-  'engine.inspector.pageBlock.field.page:accordion.items.value': 'Key',
   'engine.inspector.pageBlock.field.page:accordion.items.label': 'Label',
   'engine.inspector.pageBlock.field.record:related_list.objectName': 'Object',
   'engine.inspector.pageBlock.field.record:related_list.relationshipField': 'Relationship field',
@@ -2428,10 +2430,11 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.add.page:tabs.items': '添加标签页',
   'engine.inspector.pageBlock.field.page:tabs.items.key': '键',
   'engine.inspector.pageBlock.field.page:tabs.items.label': '标签',
-  'engine.inspector.pageBlock.field.page:accordion.title': '标题',
+  // `…field.page:accordion.title` / `…items.value` retired with their designer
+  // fields — see the matching note in the `en` table above. Removed from BOTH
+  // tables in the same edit so the two key sets stay identical.
   'engine.inspector.pageBlock.field.page:accordion.items': '分区',
   'engine.inspector.pageBlock.add.page:accordion.items': '添加分区',
-  'engine.inspector.pageBlock.field.page:accordion.items.value': '键',
   'engine.inspector.pageBlock.field.page:accordion.items.label': '标签',
   'engine.inspector.pageBlock.field.record:related_list.objectName': '对象',
   'engine.inspector.pageBlock.field.record:related_list.relationshipField': '关联字段',

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   ACTION_LOCATIONS,
+  PageAccordionProps,
   PageComponentType,
   PageHeaderProps,
   RecordDetailsProps,
@@ -148,8 +149,10 @@ describe('record:details sections ↔ spec section-entry coverage (#3819)', () =
   });
 
   it('lists `name` before `label` — the entry identity comes first', () => {
-    // Matches `page:tabs` (`key`) and `page:accordion` (`value`), where the
-    // stable identifier precedes the human label.
+    // Matches `page:tabs` (`key`), where the stable identifier precedes the
+    // human label. `page:accordion` items no longer have an identifier field
+    // to compare against — its `value` was removed as dead input (#5212): the
+    // renderer derives the panel id and never reads what was authored.
     const order = (sectionsField?.itemFields ?? []).map((f) => f.name);
     expect(order.indexOf('name')).toBeGreaterThanOrEqual(0);
     expect(order.indexOf('name')).toBeLessThan(order.indexOf('label'));
@@ -360,6 +363,121 @@ describe('page:header `icon` — the designer field retired with the spec key (#
     for (const key of [
       'engine.inspector.pageBlock.field.page:header.icon',
       'engine.inspector.pageBlock.placeholder.page:header.icon',
+    ]) {
+      expect(t(key, 'en-US')).toBe(key);
+      expect(t(key, 'zh-CN')).toBe(key);
+    }
+  });
+});
+
+/**
+ * `page:accordion` `title` / items `value` — designer inputs no renderer
+ * reads (#5212).
+ *
+ * Same PUBLISH-FACE-with-no-parity-gate reasoning as the `page:header.icon`
+ * describe above: nothing diffs the designer's field set against
+ * `ComponentPropsMap`, so a field can go on offering a key nothing on the
+ * render path honours and every derived check stays green.
+ *
+ * What was wrong, verified against the CURRENT tree (the card that reported
+ * this was six days stale and one of its three findings had already been
+ * fixed elsewhere — objectui#3829 / PR #4794 dropped `page:header.icon`
+ * before this issue was even filed):
+ *   - `title`: `PageAccordionRenderer` (`renderers/layout/containers.tsx`)
+ *     reads `items`, `allowMultiple`, `variant` — never `schema.title`, and
+ *     there is no accordion-level heading in the rendered output.
+ *     `PageAccordionProps` never declared a `title` member either, so this
+ *     was dead on BOTH sides, not merely unread by one renderer.
+ *   - items `value`: the renderer OVERWRITES it — `itemsWithValue =
+ *     items.map((it, idx) => ({ ...it, value: `panel-${idx}` }))` — so an
+ *     authored value never reaches the Radix item. `PageAccordionProps.items[]`
+ *     deliberately does not declare `value` either, and carries a `guidance`
+ *     prescription (added with the #5212 spec-side half) telling an author
+ *     who writes it by hand to remove the key.
+ *
+ * Neither is symmetric with `page:tabs`: one component over, an authored
+ * `items[].value` (designer field name `key`) IS read, with a `tab-${idx}`
+ * fallback only when absent (`itemsWithValue` for `page:tabs`, same file).
+ * `PageTabsProps.items[].value` is a real, declared schema member. The
+ * accordion's panel id is unconditionally derived; the tabs one is genuinely
+ * live — this suite touches the accordion only.
+ */
+describe('page:accordion `title` / items `value` — dead designer inputs (#5212)', () => {
+  const fieldNames = () => BLOCK_CONFIG['page:accordion'].map((f) => f.name);
+  const itemsField = () =>
+    BLOCK_CONFIG['page:accordion'].find((f) => f.name === 'items') as
+      | { kind: 'array'; itemFields: Array<{ name: string }> }
+      | undefined;
+
+  // POSITIVE half: without it the negative pins below would pass just as
+  // happily on a designer panel that lost ALL of its fields.
+  it('still offers the item fields the renderer does implement', () => {
+    expect(fieldNames()).toEqual(['items']);
+    expect(itemsField()?.itemFields.map((f) => f.name)).toEqual(['label']);
+  });
+
+  it('does NOT offer the accordion-level `title` field', () => {
+    expect(fieldNames().length, 'field list is empty — the pin would be vacuous').toBeGreaterThan(0);
+    expect(fieldNames()).not.toContain('title');
+  });
+
+  it('does NOT offer an item `value` field', () => {
+    const names = itemsField()?.itemFields.map((f) => f.name) ?? [];
+    expect(names.length, 'item field list is empty — the pin would be vacuous').toBeGreaterThan(0);
+    expect(names).not.toContain('value');
+  });
+
+  // The spec side: unlike `page:header.icon` (a tombstoned `z.never()`
+  // member — the key still exists on the shape), `title` and items `value`
+  // were never declared at all, so a strict-object rejection is the right
+  // envelope to assert (same `unrecognized_keys` pattern as
+  // `text-input-inputs-spec-parity.test.ts`), not a tombstone-type probe.
+  it('the spec rejects an authored `title` — not a member of PageAccordionProps', () => {
+    const result = PageAccordionProps.safeParse({
+      title: 'Section heading',
+      items: [{ label: 'One', children: [] }],
+    });
+    expect(result.success).toBe(false);
+    const codes = result.success ? [] : result.error.issues.map((i) => i.code);
+    expect(codes).toContain('unrecognized_keys');
+    const refused = result.success
+      ? []
+      : result.error.issues.flatMap((i) => (i as unknown as { keys?: string[] }).keys ?? []);
+    expect(refused).toContain('title');
+  });
+
+  it('the spec rejects an authored item `value` — not a member of the item shape', () => {
+    const result = PageAccordionProps.safeParse({
+      items: [{ label: 'One', value: 'panel-custom', children: [] }],
+    });
+    expect(result.success).toBe(false);
+    const codes = result.success ? [] : result.error.issues.map((i) => i.code);
+    expect(codes).toContain('unrecognized_keys');
+    const refused = result.success
+      ? []
+      : result.error.issues.flatMap((i) => (i as unknown as { keys?: string[] }).keys ?? []);
+    expect(refused).toContain('value');
+  });
+
+  // Non-vacuity for both safeParse probes above: a base accordion with only
+  // the declared keys must parse clean, or the rejections above could be
+  // attributable to something other than the extra key under test.
+  it('a base accordion with only declared keys parses clean', () => {
+    const result = PageAccordionProps.safeParse({
+      items: [{ label: 'One', children: [] }],
+      allowMultiple: true,
+      variant: 'card',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // The i18n side, exactly as the `page:header.icon` removal above: a key
+  // kept past its field is dead vocabulary the next author reads as a live
+  // surface, so BOTH locale tables lost these two keys.
+  it('has no leftover translation for the retired fields in either locale', () => {
+    for (const key of [
+      'engine.inspector.pageBlock.field.page:accordion.title',
+      'engine.inspector.pageBlock.field.page:accordion.items.value',
     ]) {
       expect(t(key, 'en-US')).toBe(key);
       expect(t(key, 'zh-CN')).toBe(key);

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -385,15 +385,32 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
       ],
     },
   ],
+  // No top-level `title` field, and no `value` on an item: neither is read by
+  // `PageAccordionRenderer` (`renderers/layout/containers.tsx`) and neither is
+  // a member of `PageAccordionProps` in `@objectstack/spec` — an author who
+  // filled either in got no effect and no diagnostic (objectui#5212).
+  //   - `title`: the renderer reads `items`, `allowMultiple`, `variant`; there
+  //     is no accordion-level heading. `PageAccordionProps`'s shape has no
+  //     `title` key at all — a strict-object rejection, not a silent drop, once
+  //     the value reaches metadata validation.
+  //   - `items[].value`: the renderer OVERWRITES it before render —
+  //     `itemsWithValue = items.map((it, idx) => ({ ...it, value:
+  //     \`panel-${idx}\` }))` — so an authored value never reaches the Radix
+  //     item. This is NOT the `page:tabs` case one component over: there, an
+  //     authored `items[].value` (designer field name `key`) really is read,
+  //     with a `tab-${idx}` fallback only when absent. The accordion's panel id
+  //     is unconditionally derived; the tabs one is genuinely live. The spec
+  //     mirrors the asymmetry — `PageAccordionProps.items[]` deliberately does
+  //     not declare `value` and carries a `guidance` prescription pointing an
+  //     author at the same fact, while `PageTabsProps.items[].value` is a real
+  //     schema member.
   'page:accordion': [
-    { name: 'title', label: 'engine.inspector.pageBlock.field.page:accordion.title', kind: 'text' },
     {
       name: 'items',
       label: 'engine.inspector.pageBlock.field.page:accordion.items',
       kind: 'array',
       addLabel: 'engine.inspector.pageBlock.add.page:accordion.items',
       itemFields: [
-        { name: 'value', label: 'engine.inspector.pageBlock.field.page:accordion.items.value', kind: 'text' },
         { name: 'label', label: 'engine.inspector.pageBlock.field.page:accordion.items.label', kind: 'text' },
       ],
     },


### PR DESCRIPTION
Fixes #5212

## What

Studio's page-block designer was publishing three `page:*` inputs that nothing on the
render path reads — an author configures them in the designer, saves, and gets no effect
and no diagnostic. This drops the two that are still live in `previews/block-config.ts`:

- `page:accordion` → `title` (no accordion-level heading exists; `PageAccordionRenderer`
  never reads `schema.title`, and `PageAccordionProps` in `@objectstack/spec` never
  declared a `title` member)
- `page:accordion` → `items[].value` (the renderer **overwrites** it before render —
  `itemsWithValue = items.map((it, idx) => ({ ...it, value: \`panel-${idx}\` }))` — so an
  authored value never reaches the Radix item; `PageAccordionProps.items[]` deliberately
  does not declare `value` either, and now carries a `guidance` prescription pointing an
  author at this exact fact)

Also removes the two now-orphaned i18n keys from both locale tables
(`engine.inspector.pageBlock.field.page:accordion.title` /
`…field.page:accordion.items.value`), in `packages/app-shell/src/views/metadata-admin/i18n.ts`.

**`page:tabs` is untouched.** One component over, an authored `items[].value` (designer
field name `key`) really is read, with a `tab-${idx}` fallback only when absent — the
accordion's panel id is unconditionally derived, the tabs one is genuinely live. The two
are not symmetric and this PR only touches the accordion.

`packages/components/src/renderers/layout/containers.tsx` is unchanged — it is the
evidence these inputs are dead, not something this PR modifies.

## Premise check (the card was measured six days stale)

The issue's baseline was `objectui@d8d0d66` from 2026-08-12. Re-derived all three verdicts
against the current tree before touching anything:

1. `PageAccordionRenderer` reads `items` / `allowMultiple` / `variant`, never `title` —
   **holds**.
2. The accordion renderer overwrites `items[].value` with `panel-${idx}` — **holds**.
3. `page:header.icon` — **does not hold anymore**. It was already removed from
   `block-config.ts` on 2026-08-16 by #3829 / PR #4794 (`retire(studio): drop the
   canonical page:header icon field…`), two days before this issue was even filed (and
   before the objectstack#7973 → objectui#5212 move). The `page:header` entry in
   `previews/block-config.ts` already lists only `title` / `subtitle` / `breadcrumb`,
   with a comment citing the same retirement (ADR-0087 D2, `@objectstack/spec` 17.0.0)
   this issue describes. **No action needed for `page:header.icon` in this PR** — it is
   not part of the diff.

So this PR is two of the three originally-reported deletions; the third had already
landed under a separate issue before this card reached the queue.

## Tests

- New `describe('page:accordion \`title\` / items \`value\` — dead designer inputs
  (#5212)', …)` in `previews/__tests__/block-config.test.ts`, mirroring the existing
  `page:header icon` (#3829) pin:
  - positive half: the panel still offers `items` → `label`
  - negative half: `title` / `value` are absent from the designer config
  - spec-side: `PageAccordionProps.safeParse(...)` rejects an authored `title` and an
    authored item `value` with `unrecognized_keys` naming the refused key (same envelope
    pattern as `text-input-inputs-spec-parity.test.ts`), plus a non-vacuity check that a
    base accordion with only declared keys parses clean
  - i18n side: the two retired keys resolve to themselves (no translation) in both
    `en-US` and `zh-CN`
- Updated a stale comment in the same file's `record:details` ordering test that used
  `page:accordion` (`value`) as a "stable identifier precedes label" example — that
  pattern no longer exists on the accordion now that `value` is gone.

```
pnpm exec vitest run packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
  Test Files  2 passed (2)
       Tests  45 passed (45)

pnpm --filter @object-ui/app-shell type-check   # clean

node scripts/check-i18n-call-site-keys.mjs   # every call-site key still resolves (2903 en keys)
node scripts/check-i18n-en-drift.mjs         # 0 findings (change is app-shell-local, not the 10 locale packs)
node scripts/check-changeset-presence.mjs    # ✅ 1 changeset declared for the 1 released package touched
node scripts/check-control-bytes.mjs         # ✅ OK
```

**Lint narrowing, declared:** the full `pnpm --filter @object-ui/app-shell lint` got
queued behind the shared verify lock (5 concurrent devs on this seat) long enough that I
abandoned the wait rather than stall on it. Ran `eslint` directly on just the three
changed files instead:

```
pnpm exec eslint packages/app-shell/src/views/metadata-admin/previews/block-config.ts \
  packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts \
  packages/app-shell/src/views/metadata-admin/i18n.ts
  4 problems (0 errors, 4 warnings)   # all 4 are pre-existing `no-explicit-any` on lines this diff doesn't touch
```

CI runs the full lint farm regardless; flagging this as a declared narrowing rather than
a silent skip.

## Changeset

`.changeset/studio-accordion-dead-designer-inputs.md` — `@object-ui/app-shell` patch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_