### PR TITLE
fix(plugin-report): stop reading `report.filter` as an alias for `runtimeFilter`

### DIFF
--- a/.changeset/report-filter-alias-removed-5137.md
+++ b/.changeset/report-filter-alias-removed-5137.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/plugin-report': minor
+---
+
+`DatasetReportRenderer` no longer reads `filter` as an alias for `runtimeFilter`.
+
+`filter` is not an authorable key. `ReportSchema` in `@objectstack/spec` (17.0.0)
+is `z.core.$strict` and rejects it outright, going out of its way to name the
+replacement: ``Unrecognized key(s) on this report: `filter`. Did you mean
+`filter` → `runtimeFilter`?`` The renderer accepted the rejected spelling anyway,
+at two sites — the report-level `report.runtimeFilter ?? report.filter` and the
+per-joined-block `block.runtimeFilter ?? block.filter`. Metadata that could not
+be authored through the validated path still rendered when it arrived by some
+other route, so the strictness the spec promises was not the strictness the
+runtime enforced. It matters most for AI-authored metadata: a generator emitting
+`filter` got a working report from this renderer and a hard validation failure
+from anything that parsed the document first, and which one the author met was a
+function of which path the document travelled.
+
+**Behaviour change — read this if you store report documents.** A stored document
+still carrying `filter` no longer has that filter applied: it renders
+**unfiltered**, showing rows the report was scoped to exclude. Server-side
+permissions are unaffected and still apply, so this is not an access-control
+change — it is a report showing more rows than its author intended. Scored
+`minor` per this repo's version policy (AGENTS.md §版本号策略), which reserves
+`major` for the synchronized `@objectstack` major bump; the narrowing is
+described here rather than encoded in the number.
+
+Because rendering unfiltered *in silence* would be worse than an error, the
+dropped key is not silent. When a document carrying `filter` reaches the
+renderer, a dev-mode warning fires once per offending report or block, naming the
+key, quoting the spec's own rename hint verbatim (so an author meets one message
+rather than two dialects of one message), and stating that no filter was applied.
+It is a no-op under `NODE_ENV=production` and changes no types.
+
+Fix your documents by renaming `filter` to `runtimeFilter` — the key the schema
+actually declares, and the one the suggestion has always pointed at. Reports that
+already author `runtimeFilter`, and hosts that pass the `runtimeFilter` prop, are
+entirely unaffected.

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -140,6 +140,17 @@ interface DatasetReportLike {
   columns?: string[];
   values?: string[];
   runtimeFilter?: Record<string, unknown>;
+  /**
+   * ⛔ NOT an authorable key, and NEVER applied as a filter (objectui#5137).
+   *
+   * `ReportSchema` (`@objectstack/spec`) is `z.core.$strict` and rejects
+   * `filter` outright, naming the replacement itself
+   * (`Did you mean … → runtimeFilter?`) — so a document carrying it did not
+   * arrive through the validated path. It stays declared for exactly one reason:
+   * so {@link warnOnRejectedFilterAlias} can SEE it on a stored document and
+   * say out loud that no filter was applied. Reading it AS a scope filter is
+   * the consumer tolerance this card removed. Author `runtimeFilter`.
+   */
   filter?: Record<string, unknown>;
   /**
    * Result ordering, most significant key first (framework#3916). Each `by`
@@ -177,6 +188,75 @@ export function isDatasetReport(value: unknown): value is DatasetReportLike {
   if (typeof v.dataset === 'string' && v.dataset.length > 0) return true;
   // A joined report whose blocks are dataset-bound.
   return v.type === 'joined' && Array.isArray(v.blocks) && v.blocks.some((b) => typeof b?.dataset === 'string');
+}
+
+// Warn-once memo for the rejected `filter` key. Keyed by SITE (which already
+// carries the report / block name) plus the offending value's key set, so two
+// different stale filters on one page both report — the author has to fix every
+// producer, not just the first one seen, and a bare site key would mute the
+// second. The key set rather than a full serialization because this reads
+// stored JSON that crosses the repo boundary: a warning must not be able to
+// throw on its way out.
+const warnedFilterAliases = new Set<string>();
+
+/** Reset the warn-once memo. Exported for tests. */
+export function resetReportFilterAliasWarnings(): void {
+  warnedFilterAliases.clear();
+}
+
+const isDev = (): boolean =>
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.NODE_ENV !==
+  'production';
+
+/**
+ * Dev-mode only: say out loud that a stored document's `filter` was NOT applied.
+ *
+ * objectui#5137 removed the `report.runtimeFilter ?? report.filter` alias read
+ * (and its per-block twin). `filter` is not an authorable key — `ReportSchema`
+ * (`@objectstack/spec`) is `z.core.$strict` and refuses it, naming the
+ * replacement itself — so honouring it here made the runtime looser than the
+ * contract the spec publishes, and which message an author met was a function
+ * of which path their document travelled.
+ *
+ * Deleting the read ALONE would have been a silent narrowing: a stored document
+ * still carrying `filter` renders **unfiltered**, which for a scoped report is
+ * worse than an error. (Server-side permissions still apply, so this is not an
+ * access-control hole — it is rows the AUTHOR meant to exclude, shown without
+ * anyone being told.) So the key does not go quiet: it is said out loud, once
+ * per offending document.
+ *
+ * The rename hint is copied verbatim from the spec's own `unrecognized_keys`
+ * message (`@objectstack/spec` 17.0.0) so an author meets one message rather
+ * than two dialects of one message.
+ *
+ * Non-breaking by construction: changes no types, rejects nothing, renders
+ * everything it rendered before, and is a no-op under `NODE_ENV=production`.
+ */
+function warnOnRejectedFilterAlias(node: DatasetReportLike, site: string): void {
+  if (!isDev()) return;
+  const rejected = node.filter;
+  if (rejected === undefined) return;
+  const shape =
+    rejected && typeof rejected === 'object'
+      ? Object.keys(rejected as Record<string, unknown>).sort().join(',')
+      : String(rejected);
+  const memo = `${site}:${shape}`;
+  if (warnedFilterAliases.has(memo)) return;
+  warnedFilterAliases.add(memo);
+  console.warn(
+    `[ObjectUI] ${site} carries \`filter\`, which is not an authorable key. ` +
+      'Did you mean `filter` → `runtimeFilter`? ' +
+      'NO filter was applied — it renders UNFILTERED, showing rows the report ' +
+      'was scoped to exclude. `ReportSchema` (`@objectstack/spec`) is strict and ' +
+      'rejects `filter`, so this document did not come through the validated ' +
+      'path; the renderer no longer reads it either. Fix the producer: rename ' +
+      '`filter` to `runtimeFilter`. (objectui#5137)',
+  );
+}
+
+/** How a report / block names itself in the warning above. */
+function describeReportSite(report: DatasetReportLike): string {
+  return `Report \`${report.name ?? '(unnamed)'}\``;
 }
 
 function resolveText(label: unknown, fallback: string): string {
@@ -1242,10 +1322,11 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
   onDrill,
   className,
 }) => {
-  const outerFilter = mergeFilters(
-    (report.runtimeFilter ?? report.filter) as Record<string, unknown> | undefined,
-    runtimeFilter,
-  );
+  // objectui#5137 — `runtimeFilter` ONLY. `filter` is rejected by the strict
+  // spec, so it is not read here either; it is reported instead of applied.
+  const reportSite = describeReportSite(report);
+  warnOnRejectedFilterAlias(report, reportSite);
+  const outerFilter = mergeFilters(report.runtimeFilter, runtimeFilter);
   // ADR-0021 D2: `drilldown` defaults on; the host must still supply a sink.
   const drillSink = report.drilldown === false ? undefined : onDrill;
   // The DECLARED type drives the branch (#2941) — never the data shape.
@@ -1261,7 +1342,9 @@ export const DatasetReportRenderer: React.FC<DatasetReportRendererProps> = ({
         style={{ display: 'flex', flexDirection: 'column', gap: 24 }}
       >
         {report.blocks.map((block, index) => {
-          const blockFilter = mergeFilters(outerFilter, (block.runtimeFilter ?? block.filter) as Record<string, unknown> | undefined);
+          // objectui#5137 — same rule per block: `runtimeFilter` only.
+          warnOnRejectedFilterAlias(block, `${reportSite} block \`${block.name ?? index}\``);
+          const blockFilter = mergeFilters(outerFilter, block.runtimeFilter);
           const blockAcross = readNames(block.columns);
           // #3916 — each block orders ITSELF. A joined container selects nothing
           // of its own (the schema rejects `order` on it), and every block is an

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.rejectedFilterAlias.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.rejectedFilterAlias.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * `filter` is REJECTED by the renderer, not honoured as an alias (objectui#5137).
+ *
+ * `DatasetReportRenderer` used to read `report.runtimeFilter ?? report.filter`
+ * (and the per-block twin). `filter` is not an authorable key — `ReportSchema`
+ * in `@objectstack/spec` is strict and refuses it, naming the replacement
+ * itself — so honouring it made the runtime looser than the published contract.
+ *
+ * Three facts are pinned here, and the THIRD is the one that separates this
+ * from a silent regression:
+ *
+ *  1. `runtimeFilter` still applies, unchanged, at the report level and per
+ *     joined block — the removal narrowed nothing an author authored correctly.
+ *  2. A stored document carrying ONLY `filter` gets NO filter applied. The
+ *     assertion is on the SELECTION the renderer sends, not merely on the
+ *     absence of the alias value: an unfiltered query is what the document now
+ *     produces, and that is the behaviour change worth pinning.
+ *  3. That case is LOUD. Deleting the read alone would render such a report
+ *     unfiltered in silence — for a scoped report, worse than an error — so the
+ *     key is reported instead of applied, in the spec's own wording.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+import { ReportSchema } from '@objectstack/spec/ui';
+import { DatasetReportRenderer, resetReportFilterAliasWarnings } from '../DatasetReportRenderer';
+
+type MockRows = Array<Record<string, unknown>>;
+
+function makeSource(byDataset: Record<string, MockRows>) {
+  const calls: Array<{ dataset: string; selection: any }> = [];
+  return {
+    calls,
+    queryDataset: vi.fn(async (dataset: string, selection: unknown) => {
+      calls.push({ dataset, selection: selection as any });
+      return { rows: byDataset[dataset] ?? [] };
+    }),
+  };
+}
+
+const ROWS: MockRows = [
+  { stage: 'won', revenue: 10 },
+  { stage: 'lost', revenue: 4 },
+];
+
+const renderReport = (report: Record<string, unknown>, src: ReturnType<typeof makeSource>) =>
+  render(
+    <I18nProvider>
+      <DatasetReportRenderer report={report as never} dataSource={src} />
+    </I18nProvider>,
+  );
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetReportFilterAliasWarnings();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+const warnings = (): string[] => warnSpy.mock.calls.map((c) => String(c[0]));
+const aliasWarnings = (): string[] => warnings().filter((m) => m.includes('objectui#5137'));
+
+describe('DatasetReportRenderer — `runtimeFilter` still applies (unchanged)', () => {
+  it('lowers a report-level `runtimeFilter` onto the dataset selection', async () => {
+    const src = makeSource({ sales: ROWS });
+    renderReport(
+      {
+        name: 'pipeline',
+        type: 'summary',
+        dataset: 'sales',
+        rows: ['stage'],
+        values: ['revenue'],
+        runtimeFilter: { won: true },
+      },
+      src,
+    );
+
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect(src.calls[0].selection.runtimeFilter).toMatchObject({ won: true });
+    // The correct spelling is not the noisy one.
+    expect(aliasWarnings()).toEqual([]);
+  });
+
+  it('lowers each joined block’s own `runtimeFilter`', async () => {
+    const src = makeSource({ sales: ROWS });
+    renderReport(
+      {
+        name: 'pipeline',
+        type: 'joined',
+        blocks: [
+          { name: 'open', dataset: 'sales', rows: ['stage'], values: ['revenue'], runtimeFilter: { done: false } },
+          { name: 'closed', dataset: 'sales', rows: ['stage'], values: ['revenue'], runtimeFilter: { done: true } },
+        ],
+      },
+      src,
+    );
+
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalledTimes(2));
+    expect(src.queryDataset).toHaveBeenCalledWith('sales', expect.objectContaining({ runtimeFilter: { done: false } }));
+    expect(src.queryDataset).toHaveBeenCalledWith('sales', expect.objectContaining({ runtimeFilter: { done: true } }));
+    expect(aliasWarnings()).toEqual([]);
+  });
+});
+
+describe('DatasetReportRenderer — `filter` applies NOTHING', () => {
+  it('a report carrying only `filter` queries the dataset UNFILTERED', async () => {
+    const src = makeSource({ sales: ROWS });
+    renderReport(
+      { name: 'pipeline', type: 'summary', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { won: true } },
+      src,
+    );
+
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    const { selection } = src.calls[0];
+    expect(selection.runtimeFilter).toBeUndefined();
+    // Nothing anywhere in the selection carries the rejected value — the alias
+    // is not re-entering under another name.
+    expect(JSON.stringify(selection)).not.toContain('won');
+    // The report still RENDERS; the narrowing is the filter, not the report.
+    expect(await screen.findByText('won')).toBeInTheDocument();
+  });
+
+  it('a joined block carrying only `filter` queries UNFILTERED too', async () => {
+    const src = makeSource({ sales: ROWS });
+    renderReport(
+      {
+        name: 'pipeline',
+        type: 'joined',
+        blocks: [{ name: 'open', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { done: false } }],
+      },
+      src,
+    );
+
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect(src.calls[0].selection.runtimeFilter).toBeUndefined();
+    expect(JSON.stringify(src.calls[0].selection)).not.toContain('done');
+  });
+
+  it('a report-level `filter` does not shadow the host-supplied `runtimeFilter` prop', async () => {
+    const src = makeSource({ sales: ROWS });
+    render(
+      <I18nProvider>
+        <DatasetReportRenderer
+          report={{ name: 'pipeline', type: 'summary', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { won: true } } as never}
+          runtimeFilter={{ owner: 'me' }}
+          dataSource={src}
+        />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    // The host's scope survives intact — it is merged with nothing, not with `filter`.
+    expect(src.calls[0].selection.runtimeFilter).toMatchObject({ owner: 'me' });
+    expect(JSON.stringify(src.calls[0].selection)).not.toContain('won');
+  });
+});
+
+describe('DatasetReportRenderer — the dropped `filter` is LOUD, not silent', () => {
+  it('warns once, naming the key, the rename, and that no filter was applied', async () => {
+    const src = makeSource({ sales: ROWS });
+    renderReport(
+      { name: 'pipeline', type: 'summary', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { won: true } },
+      src,
+    );
+
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    const hits = aliasWarnings();
+    expect(hits).toHaveLength(1);
+    const message = hits[0];
+    // Which document. Which key. What happened to it.
+    expect(message).toContain('pipeline');
+    expect(message).toContain('`filter`');
+    expect(message).toContain('`runtimeFilter`');
+    expect(message).toContain('UNFILTERED');
+  });
+
+  it('says it in the SPEC’s words — one message, not two dialects of one message', () => {
+    // The producer side already answers `filter` with an explicit rename hint.
+    // The renderer quotes that hint verbatim, so an author who meets both meets
+    // the same sentence twice rather than two spellings of one instruction.
+    const parsed = ReportSchema.safeParse({
+      name: 'pipeline',
+      label: 'Pipeline',
+      type: 'summary',
+      dataset: 'sales',
+      rows: ['stage'],
+      values: ['revenue'],
+      filter: { won: true },
+    });
+    expect(parsed.success, '`filter` must still be rejected by the spec').toBe(false);
+    const specMessage = parsed.success ? '' : parsed.error.issues.map((i) => i.message).join('\n');
+
+    const RENAME_HINT = 'Did you mean `filter` → `runtimeFilter`?';
+    expect(specMessage).toContain(RENAME_HINT);
+
+    const src = makeSource({ sales: ROWS });
+    renderReport(
+      { name: 'pipeline', type: 'summary', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { won: true } },
+      src,
+    );
+    expect(aliasWarnings()[0]).toContain(RENAME_HINT);
+  });
+
+  it('warns per offending block, and only once each across re-renders', async () => {
+    const src = makeSource({ sales: ROWS });
+    const report = {
+      name: 'pipeline',
+      type: 'joined',
+      blocks: [
+        { name: 'open', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { done: false } },
+        { name: 'closed', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { done: true } },
+        { name: 'clean', dataset: 'sales', rows: ['stage'], values: ['revenue'], runtimeFilter: { done: true } },
+      ],
+    };
+    const view = renderReport(report, src);
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+
+    // One per offending block; the correctly-spelled block is silent.
+    let hits = aliasWarnings();
+    expect(hits).toHaveLength(2);
+    expect(hits.some((m) => m.includes('open'))).toBe(true);
+    expect(hits.some((m) => m.includes('closed'))).toBe(true);
+    expect(hits.some((m) => m.includes('clean'))).toBe(false);
+
+    // Re-rendering the same document does not re-spam the console.
+    view.rerender(
+      <I18nProvider>
+        <DatasetReportRenderer report={report as never} dataSource={src} />
+      </I18nProvider>,
+    );
+    hits = aliasWarnings();
+    expect(hits).toHaveLength(2);
+  });
+
+  it('stays silent under NODE_ENV=production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    try {
+      const src = makeSource({ sales: ROWS });
+      renderReport(
+        { name: 'pipeline', type: 'summary', dataset: 'sales', rows: ['stage'], values: ['revenue'], filter: { won: true } },
+        src,
+      );
+      await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+      expect(aliasWarnings()).toEqual([]);
+      // Still no filter applied — production is quieter, not more tolerant.
+      expect(src.calls[0].selection.runtimeFilter).toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.rejectedFilterAlias.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.rejectedFilterAlias.test.tsx
@@ -29,11 +29,11 @@ import { DatasetReportRenderer, resetReportFilterAliasWarnings } from '../Datase
 type MockRows = Array<Record<string, unknown>>;
 
 function makeSource(byDataset: Record<string, MockRows>) {
-  const calls: Array<{ dataset: string; selection: any }> = [];
+  const calls: Array<{ dataset: string; selection: Record<string, unknown> }> = [];
   return {
     calls,
     queryDataset: vi.fn(async (dataset: string, selection: unknown) => {
-      calls.push({ dataset, selection: selection as any });
+      calls.push({ dataset, selection: selection as Record<string, unknown> });
       return { rows: byDataset[dataset] ?? [] };
     }),
   };
@@ -51,18 +51,21 @@ const renderReport = (report: Record<string, unknown>, src: ReturnType<typeof ma
     </I18nProvider>,
   );
 
-let warnSpy: ReturnType<typeof vi.spyOn>;
+// Inferred rather than annotated: the spy's own type is what `vi.spyOn`
+// returns for THIS console method, and spelling it out by hand drifts.
+const spyOnWarn = () => vi.spyOn(console, 'warn').mockImplementation(() => {});
+let warnSpy: ReturnType<typeof spyOnWarn>;
 
 beforeEach(() => {
   resetReportFilterAliasWarnings();
-  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  warnSpy = spyOnWarn();
 });
 
 afterEach(() => {
   warnSpy.mockRestore();
 });
 
-const warnings = (): string[] => warnSpy.mock.calls.map((c) => String(c[0]));
+const warnings = (): string[] => warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
 const aliasWarnings = (): string[] => warnings().filter((m) => m.includes('objectui#5137'));
 
 describe('DatasetReportRenderer — `runtimeFilter` still applies (unchanged)', () => {


### PR DESCRIPTION
Fixes #5137

`DatasetReportRenderer` read `filter` as a lenient alias for `runtimeFilter` — a key the strict `ReportSchema` in `@objectstack/spec` already rejects, and rejects while naming the replacement itself:

```
Unrecognized key(s) on this report: `filter`. Did you mean `filter` -> `runtimeFilter`?
```

So the producer side was unambiguous and even shipped the migration hint, while the consumer quietly accepted the rejected spelling anyway. Metadata that could not be authored through the validated path still rendered when it arrived by another route, which is the consumer-tolerance shape the declared=enforced doctrine retires. Triage ruled this needs no maintainer decision: the spec has already spoken.

## What changed

Both alias reads are gone, in `packages/plugin-report/src/DatasetReportRenderer.tsx`:

- the report-level `report.runtimeFilter ?? report.filter`
- the per-joined-block `block.runtimeFilter ?? block.filter`

`DatasetReportLike.filter` also stops being an undocumented equal-status alias. It stays declared, but now carries a doc comment saying it is not authorable, is never applied, and exists only so the renderer can notice it.

## The consequence, and why the key does not go quiet

Removing the read alone would have been a **silent** narrowing: a stored document still carrying `filter` now renders **unfiltered**, which for a scoped report is worse than an error. Server-side permissions are unaffected and still apply, so this is **not** an access-control hole — it is a report showing rows its author meant to exclude, with nobody told.

So the dropped key is reported rather than applied. When a document carrying `filter` reaches the renderer, a dev-mode `console.warn` fires **once per offending report or block**, naming the key, quoting the spec's own rename hint **verbatim**, and stating that no filter was applied. It is a no-op under `NODE_ENV=production`, changes no types, and rejects nothing.

The rename hint was copied from the spec rather than paraphrased — verified by running `ReportSchema.safeParse` against the pinned `@objectstack/spec` 17.0.0 and matching the exact substring, including its `→` (U+2192), which the issue body transcribed as ASCII `->`. A test pins the two strings together so an author meets one message, not two dialects of one message.

Placement check, since the ruling asked for it: `console.warn` is this repo's established dev channel for exactly this class of finding (`@object-ui/core` column-identity conflicts, i18n missing keys, `ObjectMap`, `actionKeys`), so the warning does land somewhere a human sees it. Worth stating plainly, though: it reaches a **developer or metadata author** at the devtools console, not the end user looking at the report. Making the unfiltered render visible in the UI itself would be a larger behaviour change than the ruling authorises, so it was not attempted here.

## Tests

`packages/plugin-report/src/__tests__/DatasetReportRenderer.rejectedFilterAlias.test.tsx` — 9 tests pinning all three required facts:

1. **`runtimeFilter` still applies, unchanged** — report-level and per joined block, and the correct spelling stays silent.
2. **A document carrying only `filter` applies nothing** — asserted on the selection the renderer sends, not merely on the alias value's absence; also that the rejected value does not re-enter the selection under another name, that the report still renders, and that a stored `filter` cannot shadow the host-supplied `runtimeFilter` prop.
3. **That case is loud** — the warning fires, names the document, the key, the rename and `UNFILTERED`; it quotes the spec's own hint; it fires once per offending block and does not re-spam across re-renders; and it is silent under `NODE_ENV=production` while still applying no filter.

Reverse-verified in two legs from the committed fix, each isolating one fact:

- **Leg A** — restore the two alias reads, keep the warning: **4 red**, exactly the "applies nothing" assertions. The `runtimeFilter` tests stayed green.
- **Leg B** — remove the two warn calls, keep the alias removal: **3 red**, exactly the loudness assertions.

Restored after each leg and confirmed byte-identical to the committed fix (`git diff HEAD` empty).

## Verification

Gate union run at `e9a7dfb36` (final commit):

- `pnpm exec vitest run packages/plugin-report/` — **13 files, 149 tests passed**
- `pnpm --filter @object-ui/plugin-report type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`)
- `pnpm exec eslint` on both changed sources — **0 errors** (remaining warnings are pre-existing lines this PR does not touch)
- `check:control-bytes`, `check:phantom-deps`, `check:self-import` — green
- `check-changeset-presence`, `check-changeset-no-major` — green

Test scope was deliberately narrowed to `packages/plugin-report`; the full farm is left to CI. `check:published-dist` builds every published package and exceeded the local 10-minute cap, so it too is left to CI. The published surface is unchanged either way — the new `resetReportFilterAliasWarnings` export (test-only, house precedent from `resetColumnIdentityWarnings`) is not re-exported from the package barrel.

## Changeset

`@object-ui/plugin-report`: **`minor`**, with the break described in the body per AGENTS.md §版本号策略. Deliberately not `major` — that trips the fixed-group gate and versions all 39 packages.

## Scope

Three files: the renderer, its new test, the changeset. Nothing in `content/docs` (#5047 is the docs half and is docs-only). The rest of the lenient-alias family — #5116, #5120, #5067 and #5068 — is untouched here; those are separate cards with separate consumers and remain open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_