### PR TITLE
fix(types): align FieldConstraintsSchema to the FieldValidationRules contract (zod face of FormFieldSchema.validation)

### DIFF
--- a/.changeset/field-constraints-zod-mirror-5186.md
+++ b/.changeset/field-constraints-zod-mirror-5186.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/types': minor
+---
+
+Align `FieldConstraintsSchema` (the zod face of `FormFieldSchema.validation`) to the public TS contract `FieldValidationRules`. Behaviour change in `objectui validate`: `validation` written to the TS contract — `required: string | boolean`, `minLength`/`maxLength`/`min`/`max` as `{ value, message }` objects, `validate` function — is now accepted (it was rejected before), and the flat scalar dialect (`minLength: 3`, `pattern: '^[a-z]+$'`) that react-hook-form never runs is now rejected (it passed before, validating nothing — the objectui#5099 symptom on the zod face). `pattern.value` must be a compiled RegExp per the objectui#5099 ruling; JSON/YAML cannot express one, so a string `pattern.value` is rejected by name with guidance toward the metadata route (`FieldSchema.pattern`). No silent strip, no string-to-RegExp coercion.

--- a/packages/types/src/__tests__/form-field-zod-coverage.test.ts
+++ b/packages/types/src/__tests__/form-field-zod-coverage.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { FormFieldSchema } from '../zod/form.zod.js';
+import { FieldConstraintsSchema, FormFieldSchema } from '../zod/form.zod.js';
 
 /** Every key `FormField` (../form.ts) declares by name, in declaration order. */
 const DECLARED_KEYS = [
@@ -98,5 +98,109 @@ describe('FormFieldSchema covers the FormField contract', () => {
     // @object-ui/plugin-form, not a dual-key read here. (#3090 PR2 upgrades
     // the CLI's error MESSAGE for this case; the verdict must not change.)
     expect(FormFieldSchema.safeParse({ field: 'email', required: true }).success).toBe(false);
+  });
+});
+
+/**
+ * `FieldConstraintsSchema` ↔ `FieldValidationRules` inner-shape pin (#5186).
+ *
+ * The #3090 block above pins `FormFieldSchema`'s TOP-LEVEL keys only — which
+ * is exactly why `validation`'s inner shape drifted silently: the zod side
+ * declared a flat scalar dialect (`minLength: number`, `pattern: string`)
+ * while the TS contract (`FieldValidationRules`, ../form.ts) and the
+ * renderer's only read point (`form.tsx` → react-hook-form) consume
+ * `{ value, message }` objects. `objectui validate` was wrong in both
+ * directions at once: it rejected metadata written to the public TS contract
+ * and passed a dialect react-hook-form silently drops — #5099's "looks
+ * validated, executes nothing", hidden on the zod face. These tests pin the
+ * inner shape so that drift cannot re-open under a green top-level guard.
+ */
+describe('FieldConstraintsSchema mirrors FieldValidationRules (#5186)', () => {
+  it('declares exactly the FieldValidationRules key set', () => {
+    // Same #3017-style set-coverage pin as the block above, one level down:
+    // a key added to either side must touch this list in the same PR.
+    expect(Object.keys(FieldConstraintsSchema.shape).sort()).toEqual(
+      ['required', 'minLength', 'maxLength', 'min', 'max', 'pattern', 'validate'].sort(),
+    );
+  });
+
+  it('ACCEPTS validation written to the public TS contract', () => {
+    const contractShaped = {
+      required: 'Email is required', // string = the message itself (react-hook-form semantics)
+      minLength: { value: 3, message: 'At least 3 characters' },
+      maxLength: { value: 64, message: 'At most 64 characters' },
+      min: { value: 1, message: 'Must be at least 1' },
+      max: { value: 99, message: 'Must be at most 99' },
+      validate: (v: unknown) => (v ? true : 'Required'),
+    };
+    const parsed = FieldConstraintsSchema.safeParse(contractShaped);
+    expect(parsed.success).toBe(true);
+    // `required` is the one rule that does NOT follow { value, message }:
+    // the TS contract says `string | boolean`, and both faces must pass.
+    expect(FieldConstraintsSchema.safeParse({ required: true }).success).toBe(true);
+    expect(FieldConstraintsSchema.safeParse({ required: false }).success).toBe(true);
+  });
+
+  it('REJECTS the flat scalar dialect no read point consumes', () => {
+    // This exact object parsed clean before #5186 while `form.tsx` spread it
+    // into react-hook-form where not one of these rules ran.
+    const flat = {
+      minLength: 3,
+      maxLength: 10,
+      min: 1,
+      max: 99,
+      pattern: '^[a-z]+$',
+    };
+    const parsed = FieldConstraintsSchema.safeParse(flat);
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      // Every flat key must be individually rejected — a verdict that hinged
+      // on one key would let the other four ride back in one at a time.
+      const rejectedKeys = new Set(parsed.error.issues.map((i) => String(i.path[0])));
+      expect([...rejectedKeys].sort()).toEqual(['max', 'maxLength', 'min', 'minLength', 'pattern']);
+    }
+  });
+
+  it('rejects a string pattern.value BY NAME, with guidance toward the metadata route', () => {
+    // JSON cannot express a RegExp, so on the JSON face a hand-written
+    // pattern can never be satisfied — the honest answer is a named
+    // rejection pointing at the route that CAN carry it (#5099 ruling,
+    // JSON-face half). Never a silent strip, never a string→RegExp coercion.
+    const parsed = FieldConstraintsSchema.safeParse({
+      pattern: { value: '^[a-z0-9-]+$', message: 'Lowercase letters, digits, dashes' },
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const issue = parsed.error.issues.find(
+        (i) => i.path.join('.') === 'pattern.value',
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.message).toMatch(/RegExp/);
+      expect(issue?.message).toMatch(/FieldSchema\.pattern/);
+    }
+  });
+
+  it('accepts a compiled RegExp pattern.value — the TS-contract face stays intact', () => {
+    // Programmatic (in-memory) callers hold real RegExp instances; the named
+    // rejection above is about what JSON can carry, not a key retirement.
+    const parsed = FieldConstraintsSchema.safeParse({
+      pattern: { value: /^[a-z0-9-]+$/, message: 'Lowercase letters, digits, dashes' },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('parses a FormField carrying contract-shaped validation', () => {
+    const parsed = FormFieldSchema.parse({
+      name: 'email',
+      type: 'input',
+      validation: {
+        required: 'Email is required',
+        minLength: { value: 3, message: 'At least 3 characters' },
+      },
+    });
+    expect(parsed.validation).toEqual({
+      required: 'Email is required',
+      minLength: { value: 3, message: 'At least 3 characters' },
+    });
   });
 });

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -95,15 +95,55 @@ export const CommandGroupSchema = z.object({
 });
 
 /**
- * Validation Rule Schema
+ * Bounded numeric rule — the `{ value, message }` object react-hook-form
+ * consumes for `minLength` / `maxLength` / `min` / `max`.
+ */
+const BoundedRuleSchema = (valueDescription: string) =>
+  z.object({
+    value: z.number().describe(valueDescription),
+    message: z.string().describe('Error message shown when the rule fails'),
+  });
+
+/**
+ * Validation Rule Schema — the zod mirror of `FieldValidationRules`
+ * (`../form.ts`), which is the shape `form.tsx`'s read point spreads into
+ * react-hook-form. Every rule except `required` is a `{ value, message }`
+ * object; `required` is `string | boolean` (a string IS the message —
+ * react-hook-form semantics).
+ *
+ * Until objectui#5186 this schema declared a flat scalar dialect
+ * (`minLength: z.number()`, `pattern: z.string()`) that NO read point
+ * consumed: `objectui validate` rejected metadata written to the public TS
+ * contract and passed a dialect react-hook-form silently drops — #5099's
+ * "looks validated, executes nothing", hidden on the zod face. The inner
+ * shape is pinned by `__tests__/form-field-zod-coverage.test.ts`.
+ *
+ * `pattern.value` must be a compiled `RegExp` (#5099 ruling): react-hook-form
+ * applies `pattern` only when `value instanceof RegExp`, and JSON/YAML cannot
+ * express one — so on the JSON face a hand-written `pattern` is rejected BY
+ * NAME with guidance toward the metadata route (`FieldSchema.pattern`, a
+ * string the field pipeline compiles via `new RegExp(...)` in
+ * `buildValidationRules`, `@object-ui/fields`, before it reaches this shape).
+ * Deliberately NOT a string→RegExp coercion here — consumer-side tolerance
+ * would re-open exactly what #5099 closed (AGENTS.md #0.1).
  */
 export const FieldConstraintsSchema = z.object({
-  required: z.boolean().optional().describe('Whether field is required'),
-  minLength: z.number().optional().describe('Minimum length'),
-  maxLength: z.number().optional().describe('Maximum length'),
-  min: z.number().optional().describe('Minimum value'),
-  max: z.number().optional().describe('Maximum value'),
-  pattern: z.string().optional().describe('Validation pattern (regex)'),
+  required: z.union([z.boolean(), z.string()]).optional()
+    .describe('Required rule — boolean flag, or the error message itself (string implies required)'),
+  minLength: BoundedRuleSchema('Minimum length').optional().describe('Minimum length rule'),
+  maxLength: BoundedRuleSchema('Maximum length').optional().describe('Maximum length rule'),
+  min: BoundedRuleSchema('Minimum value').optional().describe('Minimum value rule (numbers)'),
+  max: BoundedRuleSchema('Maximum value').optional().describe('Maximum value rule (numbers)'),
+  pattern: z.object({
+    value: z.custom<RegExp>((v) => v instanceof RegExp, {
+      message:
+        'pattern.value must be a compiled RegExp — react-hook-form runs `pattern` only when ' +
+        'value instanceof RegExp, and JSON/YAML metadata cannot express one (objectui#5099). ' +
+        'Declare the pattern on the field metadata route instead: `FieldSchema.pattern` (a ' +
+        'string), which is compiled before it reaches this shape.',
+    }).describe('Compiled RegExp — never a string; JSON authors use FieldSchema.pattern'),
+    message: z.string().describe('Error message shown when the pattern fails'),
+  }).optional().describe('Pattern rule (RegExp value + message)'),
   validate: z.function().optional().describe('Custom validation function'),
 });
 


### PR DESCRIPTION
Fixes #5186

## What

`FormFieldSchema.validation`'s zod face (`FieldConstraintsSchema`, `packages/types/src/zod/form.zod.ts`) declared a flat scalar dialect (`minLength: z.number()`, `pattern: z.string()`) that no read point consumes. The public TS contract (`FieldValidationRules`, `packages/types/src/form.ts`) and the renderer's only read point (`form.tsx`, spread into react-hook-form) use `{ value, message }` objects. So `objectui validate` — a live authoring-time surface — was wrong in both directions: it rejected contract-shaped `validation` (teaching the correct shape as wrong) and passed a dialect react-hook-form silently drops (the #5099 "looks validated, executes nothing" symptom, hidden on the zod face).

Per the triage ruling, the TS contract and the renderer read point are the reference; the zod mirror moves to them:

- `required`: `boolean | string` — a string IS the message (react-hook-form semantics); the one rule that does not follow `{ value, message }`.
- `minLength` / `maxLength` / `min` / `max`: `{ value: number, message: string }`.
- `pattern`: `{ value: RegExp, message: string }`. A non-RegExp `pattern.value` is rejected **by name** with guidance toward the metadata route (`FieldSchema.pattern`, compiled by `buildValidationRules` in `@object-ui/fields` before it reaches this shape) — JSON/YAML cannot carry a RegExp, so this is the JSON-face half of the #5099 ruling. No silent strip, no string-to-RegExp coercion (that would re-open #5099). Compiled RegExp instances still pass for programmatic callers.
- `validate`: function, unchanged.

## Why the drift survived, and the pin that stops it re-opening

`form-field-zod-coverage.test.ts` pinned `FormFieldSchema`'s top-level keys only (#3090) — `validation`'s inner shape lived under a green guard. New describe block pins: the contract shape is accepted; the flat dialect is rejected **per key** (each of the five flat keys individually, so none can ride back alone); `pattern.value` is rejected by name with the guidance text; a compiled RegExp still passes; a `FormField` carrying contract-shaped validation round-trips; and a key-set coverage pin one level down. Red-before measured at the unfixed schema: 5 of the 6 new pins failed, including both directions the card measured; all green after.

## Verification (all at `9f85e039c`, the head commit)

- Re-measured the card's probe against the current source tree (post-#5209/#5218) before changing anything: both directions still wrong (contract shape `success:false`, flat dialect `success:true`).
- `pnpm --filter @object-ui/types run build` and `run type-check` (3 tsconfigs incl. examples + tests) — green, script names echoed.
- Consumer radius (downstream direction — packages that depend on `@object-ui/types` and parse through its zod face): `pnpm exec vitest run packages/types/ packages/cli/ packages/core/ packages/react/ packages/plugin-form/` from repo root — 236 files / 3710 tests, all green. Narrowing declared: `packages/components` / `packages/fields` / other plugins excluded locally (held by other claims; renderers read plain objects and never parse this schema — CI shards run the full farm). No `z.infer` of `FieldConstraintsSchema` exists anywhere, so the type-level radius is nil.
- Fixture triage across the rule's consumer radius: every `validation:` literal repo-wide is either already contract-shaped (renderer tests, `packages/types/examples/login-form.ts`) or an unrelated `validation` key (i18n catalogs, object-rule preview sample). No flat-scalar fixture feeds the zod face — the flat dialect is load-bearing nowhere.
- `eslint` on touched files, `node scripts/check-control-bytes.mjs`, `node scripts/check-changeset-presence.mjs`, `node scripts/check-changeset-no-major.mjs` — all green at `9f85e039c`.
- Changeset: `minor` for `@object-ui/types` with the accept/reject behaviour change described in the body (never `major`, per AGENTS.md 版本号策略).

## Out of scope, filed

- #5229 — `content/docs/blocks/forms.mdx` "Add Validation" teaches a third dialect (flat string `pattern` + a sibling `message` key that exists in neither declaration); docs-only follow-up. #5229 remains open; it is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_