### PR TITLE
fix(plugin-view,plugin-list): flatten the `map` block through a whitelist, not a raw spread

### DIFF
--- a/.changeset/flat-map-config-whitelist-5177.md
+++ b/.changeset/flat-map-config-whitelist-5177.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-view': minor
+'@object-ui/plugin-list': minor
+'@object-ui/plugin-map': minor
+---
+
+`ObjectView` and `ListView` now flatten a view's `map` block through a
+whitelist instead of spreading the whole (untyped) block to the top level.
+
+Both `case 'map'` flatteners used to build the `object-map` schema with
+`...(options.map || {})` — a raw spread of an untyped bag
+(`NamedListView.options?: Record<string, any>`), so any key an author wrote in
+the `map` block reached the top level unfiltered. `ObjectMap`'s own
+`FlatMapConfigKeys = Omit<ObjectMapConfig, 'style'>` declares `style` OUT of
+this flat form (`style` is also `BaseSchema.style`, inline CSS legal on every
+node), so the two disagreed about the same shape. `style` was the live
+specimen: `map: { style: '<url>' }` reached the top level as a CSS-shaped
+`style` key it was never supposed to carry.
+
+Behavior narrowing, stated because it changes what reaches the flattened
+schema: a `map` block key that is not one of `ObjectMapConfig`'s declared
+flat keys (`latitudeField` / `longitudeField` / `locationField` / `titleField`
+/ `descriptionField` / `zoom` / `center`) — including `style` — no longer
+reaches the top level of the flattened `object-map` schema. This closes a gap
+rather than removing working behavior: the pinned strict spec view schemas
+accept no `map` block at all today, so no author-facing surface could reach
+this path, and `ObjectMap` already stopped reading a top-level `style` as a
+map style (a dev warning names the correct spelling instead).
+
+The whitelist is DERIVED from `ObjectMapConfigSchema` (`@object-ui/types/zod`)
+rather than hand-listed, so the flatteners and the declaration cannot drift
+apart again — a key added to (or removed from) the schema reaches both
+flatteners without a second edit. `ObjectMap`'s own `FLAT_MAP_CONFIG_KEYS` is
+derived from the same schema for the same reason.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -20,10 +20,38 @@ import type { LoadErrorKind } from '@object-ui/react';
 import { useDensityMode } from '@object-ui/react';
 import type { ListViewSchema } from '@object-ui/types';
 import { detectStatusField } from '@object-ui/types';
+import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, resolveEffectiveCrudAffordances, isObjectInlineEditable, normalizeListViewSchema, rowHeightToDensityMode, mergeFilterNodes, columnIdentity, collectPredicateFieldRefs, listViewPredicates, PLATFORM_RECORD_COLUMNS, EXPANDABLE_FIELD_TYPES, UNMATERIALIZED_FIELD_TYPES } from '@object-ui/core';
 import { useObjectTranslation, useObjectLabel, useSafeFieldLabel, createSafeTranslation } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
+
+/**
+ * The `case 'map'` branch below builds an `object-map` schema by flattening
+ * `schema.options.map`'s CONTENTS to the top level. Whitelisted to these keys —
+ * `ObjectMapConfigSchema`'s shape minus `style` — rather than the whole bag:
+ * `style` is ALSO `BaseSchema.style` (inline CSS, legal on every node), and
+ * spreading the raw `map` block collapsed the two namespaces onto one key
+ * (objectui#5177).
+ *
+ * DERIVED, not hand-listed: `ObjectMapConfigSchema` (`@object-ui/types/zod`) is
+ * the same declaration `plugin-map`'s `ObjectMap.tsx` validates the `map` block
+ * against and derives its own `FLAT_MAP_CONFIG_KEYS` from, so a key added there
+ * reaches this flattener without a second edit. Read from `@object-ui/types`
+ * rather than imported from `@object-ui/plugin-map` deliberately: `plugin-map`
+ * is loaded lazily (`ComponentRegistry.registerLazy('object-map', ...)`)
+ * specifically so its `maplibre-gl` / `react-map-gl` weight is paid only when a
+ * map view actually renders — a static import here would defeat that for every
+ * `ListView`, map or not.
+ */
+const FLAT_MAP_CONFIG_KEYS = Object.keys(ObjectMapConfigSchema.shape).filter((key) => key !== 'style');
+
+/** Pick only the declared flat map keys present on an authored `map` block. */
+function pickFlatMapConfig(mapConfig: unknown): Record<string, unknown> {
+  if (!mapConfig || typeof mapConfig !== 'object') return {};
+  const source = mapConfig as Record<string, unknown>;
+  return Object.fromEntries(FLAT_MAP_CONFIG_KEYS.filter((key) => key in source).map((key) => [key, source[key]]));
+}
 
 /**
  * The list view's props.
@@ -2013,11 +2041,15 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           ...(schema.gantt || {}),
         };
       case 'map':
+        // Whitelisted flatten (objectui#5177) — see `FLAT_MAP_CONFIG_KEYS`.
+        // `schema.options.map` is an untyped bag; a raw spread here forwarded
+        // every key the author wrote, including `style`, which `ObjectMap`'s
+        // `FlatMapConfigKeys` declares OUT of this flat form.
         return {
           type: 'object-map',
           ...baseProps,
           locationField: schema.options?.map?.locationField || 'location',
-          ...(schema.options?.map || {}),
+          ...pickFlatMapConfig(schema.options?.map),
         };
       case 'tree': {
         // Self-referencing tree-grid. Config lives under view.tree.* (direct)

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -18,9 +18,8 @@ import { UserFilters } from './UserFilters';
 import { SchemaRenderer, useNavigationOverlay, classifyLoadError } from '@object-ui/react';
 import type { LoadErrorKind } from '@object-ui/react';
 import { useDensityMode } from '@object-ui/react';
-import type { ListViewSchema } from '@object-ui/types';
+import type { ListViewSchema, ObjectMapConfig } from '@object-ui/types';
 import { detectStatusField } from '@object-ui/types';
-import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, resolveEffectiveCrudAffordances, isObjectInlineEditable, normalizeListViewSchema, rowHeightToDensityMode, mergeFilterNodes, columnIdentity, collectPredicateFieldRefs, listViewPredicates, PLATFORM_RECORD_COLUMNS, EXPANDABLE_FIELD_TYPES, UNMATERIALIZED_FIELD_TYPES } from '@object-ui/core';
 import { useObjectTranslation, useObjectLabel, useSafeFieldLabel, createSafeTranslation } from '@object-ui/i18n';
@@ -34,17 +33,37 @@ import { usePermissions } from '@object-ui/permissions';
  * spreading the raw `map` block collapsed the two namespaces onto one key
  * (objectui#5177).
  *
- * DERIVED, not hand-listed: `ObjectMapConfigSchema` (`@object-ui/types/zod`) is
- * the same declaration `plugin-map`'s `ObjectMap.tsx` validates the `map` block
- * against and derives its own `FLAT_MAP_CONFIG_KEYS` from, so a key added there
- * reaches this flattener without a second edit. Read from `@object-ui/types`
- * rather than imported from `@object-ui/plugin-map` deliberately: `plugin-map`
- * is loaded lazily (`ComponentRegistry.registerLazy('object-map', ...)`)
- * specifically so its `maplibre-gl` / `react-map-gl` weight is paid only when a
- * map view actually renders — a static import here would defeat that for every
- * `ListView`, map or not.
+ * HAND-LISTED, not derived at runtime — deliberately, and only here (`plugin-
+ * map`'s own `FLAT_MAP_CONFIG_KEYS` in `ObjectMap.tsx` DOES derive from
+ * `ObjectMapConfigSchema.shape`, and should stay that way): this file is
+ * reachable from `examples/console-starter`'s own `src/`, so it is part of the
+ * import graph `vite-alias-closure.test.ts` walks. That walker resolves a bare
+ * `@object-ui/*` specifier with plain `index.<ext>` conventions and cannot find
+ * `@object-ui/types/zod`'s actual barrel file (`zod/index.zod.ts` — a
+ * non-standard name) — a REAL runtime import of it here reproducibly fails
+ * that gate (measured on objectui#5177's first PR, PR #5231, CI run
+ * 32160288416), even though Vite's own alias table already resolves the
+ * specifier correctly (`examples/console-starter/vite.config.ts` has carried
+ * an explicit `@object-ui/types/zod` entry since PR #5156). `ObjectMap.tsx`
+ * gets away with the runtime import only because nothing in
+ * console-starter's graph reaches `@object-ui/plugin-map` today.
+ *
+ * Anti-drift is a TEST, not this comment: `ListView.mapFlatten.test.tsx` pins
+ * this exact list against `ObjectMapConfigSchema.shape` — imported only from
+ * that TEST file, which the alias-closure walker explicitly excludes from
+ * traversal — so a key added to or removed from the declaration still fails
+ * here, loudly and by name, without reintroducing the runtime edge that
+ * breaks the walker.
  */
-const FLAT_MAP_CONFIG_KEYS = Object.keys(ObjectMapConfigSchema.shape).filter((key) => key !== 'style');
+export const FLAT_MAP_CONFIG_KEYS = [
+  'latitudeField',
+  'longitudeField',
+  'locationField',
+  'titleField',
+  'descriptionField',
+  'zoom',
+  'center',
+] as const satisfies readonly (keyof Omit<ObjectMapConfig, 'style'>)[];
 
 /** Pick only the declared flat map keys present on an authored `map` block. */
 function pickFlatMapConfig(mapConfig: unknown): Record<string, unknown> {

--- a/packages/plugin-list/src/__tests__/ListView.mapFlatten.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.mapFlatten.test.tsx
@@ -16,12 +16,13 @@
  * legal on every node), so a `map: { style: '<url>' }` authoring intent
  * arrived at the top level as that CSS-shaped key.
  *
- * These pin the whitelist (`FLAT_MAP_CONFIG_KEYS`, derived from
- * `ObjectMapConfigSchema` in `@object-ui/types/zod` — the same declaration
- * `ObjectMap.tsx`'s own `FLAT_MAP_CONFIG_KEYS` derives from) rather than the
- * raw spread: a declared key still travels, `style` does not, and neither
- * does an arbitrary undeclared one. Mirrors
- * `ObjectView.mapFlatten.test.tsx`'s #5177 coverage for the sibling
+ * These pin the whitelist (`FLAT_MAP_CONFIG_KEYS`, hand-listed in
+ * `ListView.tsx` itself — see the comment on that constant for why it is not
+ * derived from `ObjectMapConfigSchema` at runtime there) rather than the raw
+ * spread: a declared key still travels, `style` does not, and neither does an
+ * arbitrary undeclared one. The bottom of this file also pins the hand list
+ * against `ObjectMapConfigSchema` directly, so it cannot silently drift.
+ * Mirrors `ObjectView.mapFlatten.test.tsx`'s #5177 coverage for the sibling
  * flattener.
  */
 
@@ -29,8 +30,14 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
 import { render, waitFor } from '@testing-library/react';
-import { ListView } from '../ListView';
+import { ListView, FLAT_MAP_CONFIG_KEYS } from '../ListView';
 import { SchemaRendererProvider } from '@object-ui/react';
+// Test-only: `ListView.tsx` hand-lists `FLAT_MAP_CONFIG_KEYS` rather than
+// importing this schema at runtime, precisely so this module never appears in
+// `examples/console-starter`'s walked import graph (see the comment on the
+// constant). A test file is explicitly excluded from that walk, so pinning
+// against the real declaration HERE is safe.
+import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 
 let captured: Array<Record<string, any>> = [];
 
@@ -112,5 +119,24 @@ describe('ListView flattens `options.map` through a whitelist, not a raw spread 
     const schema = await mapSchemaFor({});
 
     expect(schema.locationField).toBe('location');
+  });
+});
+
+/**
+ * `FLAT_MAP_CONFIG_KEYS` is hand-listed in `ListView.tsx` itself (not derived
+ * at runtime — see the comment on the constant for why), so THIS is the
+ * mechanism that keeps it from silently drifting off `ObjectMapConfigSchema`
+ * — the same role `packages/core/src/actions/__tests__/actionKeys.pin.test.ts`
+ * plays for `SPEC_ACTION_KEYS`. A key added to or removed from the schema
+ * fails this test by name, without requiring a runtime import of
+ * `@object-ui/types/zod` from production code that reaches
+ * `examples/console-starter`.
+ */
+describe('FLAT_MAP_CONFIG_KEYS pins against ObjectMapConfigSchema (objectui#5177)', () => {
+  it('matches the schema minus `style`, so the hand list cannot silently drift', () => {
+    const declared = Object.keys(ObjectMapConfigSchema.shape)
+      .filter((key) => key !== 'style')
+      .sort();
+    expect([...FLAT_MAP_CONFIG_KEYS].sort()).toEqual(declared);
   });
 });

--- a/packages/plugin-list/src/__tests__/ListView.mapFlatten.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.mapFlatten.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5177 — `ListView`'s `case 'map'` flattener used to be a WHOLE-BAG
+ * spread (`...(schema.options?.map || {})`), so any key an author wrote in
+ * the `map` block landed at the top level of the `object-map` schema it
+ * builds — including keys `ObjectMap`'s `FlatMapConfigKeys = Omit<
+ * ObjectMapConfig, 'style' >` declares OUT of this flat form. `style` is the
+ * specimen the card measured: it is ALSO `BaseSchema.style` (inline CSS,
+ * legal on every node), so a `map: { style: '<url>' }` authoring intent
+ * arrived at the top level as that CSS-shaped key.
+ *
+ * These pin the whitelist (`FLAT_MAP_CONFIG_KEYS`, derived from
+ * `ObjectMapConfigSchema` in `@object-ui/types/zod` — the same declaration
+ * `ObjectMap.tsx`'s own `FLAT_MAP_CONFIG_KEYS` derives from) rather than the
+ * raw spread: a declared key still travels, `style` does not, and neither
+ * does an arbitrary undeclared one. Mirrors
+ * `ObjectView.mapFlatten.test.tsx`'s #5177 coverage for the sibling
+ * flattener.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { render, waitFor } from '@testing-library/react';
+import { ListView } from '../ListView';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+let captured: Array<Record<string, any>> = [];
+
+ComponentRegistry.register(
+  'object-map',
+  (props: Record<string, any>) => {
+    captured.push(props);
+    return <div data-testid="map-spy" />;
+  },
+  { namespace: 'test', label: 'Map spy', category: 'view' },
+);
+
+const makeDataSource = () => ({
+  find: vi.fn().mockResolvedValue([]),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn().mockResolvedValue({ name: 'store', fields: {} }),
+});
+
+const BASE = {
+  type: 'list-view',
+  objectName: 'store',
+  viewType: 'map',
+  columns: ['name'],
+} as const;
+
+/** Mount ListView on a `map`-typed view and return the schema handed to `object-map`. */
+async function mapSchemaFor(mapOptions: Record<string, unknown>) {
+  captured = [];
+  const dataSource = makeDataSource() as any;
+  render(
+    <SchemaRendererProvider dataSource={dataSource}>
+      <ListView
+        schema={{ ...BASE, options: { map: mapOptions } } as never}
+        dataSource={dataSource}
+      />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(captured.length).toBeGreaterThan(0));
+  return captured[captured.length - 1].schema as Record<string, unknown>;
+}
+
+describe('ListView flattens `options.map` through a whitelist, not a raw spread (objectui#5177)', () => {
+  beforeEach(() => {
+    captured = [];
+  });
+
+  it('produces an object-map schema and still reaches a declared key', async () => {
+    const schema = await mapSchemaFor({ latitudeField: 'lat', longitudeField: 'lng' });
+
+    expect(schema.type).toBe('object-map');
+    expect(schema.latitudeField).toBe('lat');
+    expect(schema.longitudeField).toBe('lng');
+  });
+
+  it('does NOT let `style` in the `map` block reach the top level — the specimen the card measured', async () => {
+    const schema = await mapSchemaFor({
+      latitudeField: 'lat',
+      longitudeField: 'lng',
+      style: 'https://tiles.example.com/style.json',
+    });
+
+    expect(schema.latitudeField).toBe('lat');
+    expect(schema.style).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(schema, 'style')).toBe(false);
+  });
+
+  it('does NOT let an arbitrary undeclared key reach the top level', async () => {
+    const schema = await mapSchemaFor({ latitudeField: 'lat', totallyUndeclaredKey: 'nope' });
+
+    expect(schema.latitudeField).toBe('lat');
+    expect(schema.totallyUndeclaredKey).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(schema, 'totallyUndeclaredKey')).toBe(false);
+  });
+
+  it('still emits the `locationField` default when nothing is configured', async () => {
+    const schema = await mapSchemaFor({});
+
+    expect(schema.locationField).toBe('location');
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -79,18 +79,22 @@ type FlatMapConfigKeys = Omit< ObjectMapConfig, 'style' >;
 type MapConfigSource = ObjectMapSchema & FlatMapConfigKeys;
 
 /**
- * The flat keys, in one place, so the shadow diagnostic below and the reader
- * cannot fall out of step.
+ * The flat keys, DERIVED from `ObjectMapConfigSchema` — the same zod object
+ * `getMapConfig` validates the `map` block against — rather than hand-listed,
+ * so a key added to (or removed from) the declaration reaches the shadow
+ * diagnostic below without a second edit (objectui#5177). `style` is excluded
+ * because the FLAT form is where its namespace collides with `BaseSchema.style`
+ * (see `FlatMapConfigKeys` above and `warnOnTopLevelStyleUrl`) — not because
+ * the declaration omits it; `ObjectMapConfigSchema` carries `style` too.
+ *
+ * `ObjectView` / `ListView` derive their own flatten whitelist from this exact
+ * schema (imported from `@object-ui/types/zod`, already a dependency of both —
+ * no new coupling to this package's heavier `react-map-gl` / `maplibre-gl`
+ * dependencies), so all three sites read one canonical set of keys.
  */
-const FLAT_MAP_CONFIG_KEYS = [
-  'latitudeField',
-  'longitudeField',
-  'locationField',
-  'titleField',
-  'descriptionField',
-  'zoom',
-  'center',
-] as const satisfies readonly (keyof FlatMapConfigKeys)[];
+const FLAT_MAP_CONFIG_KEYS = (Object.keys(ObjectMapConfigSchema.shape) as (keyof ObjectMapConfig)[]).filter(
+  (key): key is keyof FlatMapConfigKeys => key !== 'style',
+);
 
 /**
  * Helper to get data configuration from schema

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -58,6 +58,7 @@ import { Plus } from 'lucide-react';
 import { useObjectTranslation, createSafeTranslation } from '@object-ui/i18n';
 import { buildExpandFields, normalizeListViewSchema, mergeFilterNodes } from '@object-ui/core';
 import { SchemaRenderer as ImportedSchemaRenderer } from '@object-ui/react';
+import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 import { ViewSwitcher } from './ViewSwitcher';
 import { deriveRecordSurface } from './recordSurface';
 
@@ -65,6 +66,33 @@ import { deriveRecordSurface } from './recordSurface';
  * SchemaRenderer from @object-ui/react, used to render sub-view schemas.
  */
 const SchemaRendererComponent: React.FC<any> = ImportedSchemaRenderer;
+
+/**
+ * The `case 'map'` branch below builds an `object-map` schema by flattening
+ * `viewOptions.map`'s CONTENTS to the top level. Whitelisted to these keys —
+ * `ObjectMapConfigSchema`'s shape minus `style` — rather than the whole bag:
+ * `style` is ALSO `BaseSchema.style` (inline CSS, legal on every node), and
+ * spreading the raw `map` block collapsed the two namespaces onto one key
+ * (objectui#5177).
+ *
+ * DERIVED, not hand-listed: `ObjectMapConfigSchema` (`@object-ui/types/zod`) is
+ * the same declaration `plugin-map`'s `ObjectMap.tsx` validates the `map` block
+ * against and derives its own `FLAT_MAP_CONFIG_KEYS` from, so a key added there
+ * reaches this flattener without a second edit. Read from `@object-ui/types`
+ * rather than imported from `@object-ui/plugin-map` deliberately: `plugin-map`
+ * is loaded lazily (`ComponentRegistry.registerLazy('object-map', ...)`)
+ * specifically so its `maplibre-gl` / `react-map-gl` weight is paid only when a
+ * map view actually renders — a static import here would defeat that for every
+ * `ObjectView`, map or not.
+ */
+const FLAT_MAP_CONFIG_KEYS = Object.keys(ObjectMapConfigSchema.shape).filter((key) => key !== 'style');
+
+/** Pick only the declared flat map keys present on an authored `map` block. */
+function pickFlatMapConfig(mapConfig: unknown): Record<string, unknown> {
+  if (!mapConfig || typeof mapConfig !== 'object') return {};
+  const source = mapConfig as Record<string, unknown>;
+  return Object.fromEntries(FLAT_MAP_CONFIG_KEYS.filter((key) => key in source).map((key) => [key, source[key]]));
+}
 
 /**
  * Record-create verb, shared with the runtime object pages: both surfaces
@@ -768,11 +796,15 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           ...(viewOptions.gantt || {}),
         };
       case 'map':
+        // Whitelisted flatten (objectui#5177) — see `FLAT_MAP_CONFIG_KEYS`.
+        // `viewOptions.map` is an untyped bag (`NamedListView.options`); a raw
+        // spread here forwarded every key the author wrote, including `style`,
+        // which `ObjectMap`'s `FlatMapConfigKeys` declares OUT of this flat form.
         return {
           type: 'object-map',
           ...baseProps,
           locationField: viewOptions.map?.locationField || 'location',
-          ...(viewOptions.map || {}),
+          ...pickFlatMapConfig(viewOptions.map),
         };
       case 'tree':
         return {

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -32,6 +32,7 @@ import type {
   ViewType,
   NamedListView,
   ViewNavigationConfig,
+  ObjectMapConfig,
 } from '@object-ui/types';
 import { ObjectGrid } from '@object-ui/plugin-grid';
 import { ObjectForm } from '@object-ui/plugin-form';
@@ -58,7 +59,6 @@ import { Plus } from 'lucide-react';
 import { useObjectTranslation, createSafeTranslation } from '@object-ui/i18n';
 import { buildExpandFields, normalizeListViewSchema, mergeFilterNodes } from '@object-ui/core';
 import { SchemaRenderer as ImportedSchemaRenderer } from '@object-ui/react';
-import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 import { ViewSwitcher } from './ViewSwitcher';
 import { deriveRecordSurface } from './recordSurface';
 
@@ -75,17 +75,37 @@ const SchemaRendererComponent: React.FC<any> = ImportedSchemaRenderer;
  * spreading the raw `map` block collapsed the two namespaces onto one key
  * (objectui#5177).
  *
- * DERIVED, not hand-listed: `ObjectMapConfigSchema` (`@object-ui/types/zod`) is
- * the same declaration `plugin-map`'s `ObjectMap.tsx` validates the `map` block
- * against and derives its own `FLAT_MAP_CONFIG_KEYS` from, so a key added there
- * reaches this flattener without a second edit. Read from `@object-ui/types`
- * rather than imported from `@object-ui/plugin-map` deliberately: `plugin-map`
- * is loaded lazily (`ComponentRegistry.registerLazy('object-map', ...)`)
- * specifically so its `maplibre-gl` / `react-map-gl` weight is paid only when a
- * map view actually renders — a static import here would defeat that for every
- * `ObjectView`, map or not.
+ * HAND-LISTED, not derived at runtime — deliberately, and only here (`plugin-
+ * map`'s own `FLAT_MAP_CONFIG_KEYS` in `ObjectMap.tsx` DOES derive from
+ * `ObjectMapConfigSchema.shape`, and should stay that way): this file is
+ * reachable from `examples/console-starter`'s own `src/`, so it is part of the
+ * import graph `vite-alias-closure.test.ts` walks. That walker resolves a bare
+ * `@object-ui/*` specifier with plain `index.<ext>` conventions and cannot find
+ * `@object-ui/types/zod`'s actual barrel file (`zod/index.zod.ts` — a
+ * non-standard name) — a REAL runtime import of it here reproducibly fails
+ * that gate (measured on objectui#5177's first PR, PR #5231, CI run
+ * 32160288416), even though Vite's own alias table already resolves the
+ * specifier correctly (`examples/console-starter/vite.config.ts` has carried
+ * an explicit `@object-ui/types/zod` entry since PR #5156). `ObjectMap.tsx`
+ * gets away with the runtime import only because nothing in
+ * console-starter's graph reaches `@object-ui/plugin-map` today.
+ *
+ * Anti-drift is a TEST, not this comment: `ObjectView.mapFlatten.test.tsx`
+ * pins this exact list against `ObjectMapConfigSchema.shape` — imported only
+ * from that TEST file, which the alias-closure walker explicitly excludes
+ * from traversal — so a key added to or removed from the declaration still
+ * fails here, loudly and by name, without reintroducing the runtime edge that
+ * breaks the walker.
  */
-const FLAT_MAP_CONFIG_KEYS = Object.keys(ObjectMapConfigSchema.shape).filter((key) => key !== 'style');
+export const FLAT_MAP_CONFIG_KEYS = [
+  'latitudeField',
+  'longitudeField',
+  'locationField',
+  'titleField',
+  'descriptionField',
+  'zoom',
+  'center',
+] as const satisfies readonly (keyof Omit<ObjectMapConfig, 'style'>)[];
 
 /** Pick only the declared flat map keys present on an authored `map` block. */
 function pickFlatMapConfig(mapConfig: unknown): Record<string, unknown> {

--- a/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
@@ -103,3 +103,48 @@ describe('ObjectView flattens `options.map` and emits NO `map` key (objectui#501
     expect(Object.prototype.hasOwnProperty.call(schema, 'map')).toBe(false);
   });
 });
+
+/**
+ * objectui#5177 — the flatten above used to be a WHOLE-BAG spread
+ * (`...(viewOptions.map || {})`), so any key an author wrote in the `map`
+ * block landed at the top level, including keys `ObjectMap`'s
+ * `FlatMapConfigKeys = Omit<ObjectMapConfig, 'style'>` declares OUT of this
+ * flat form. `style` is the specimen the card measured: it collides with
+ * `BaseSchema.style` (inline CSS, legal on every node), so a `map: { style:
+ * '<url>' }` authoring intent arrived as a top-level CSS-shaped key.
+ *
+ * These pin the whitelist (`FLAT_MAP_CONFIG_KEYS`, derived from
+ * `ObjectMapConfigSchema` in `@object-ui/types/zod`) rather than the raw
+ * spread: a declared key still travels, `style` does not, and neither does an
+ * arbitrary undeclared one.
+ */
+describe('ObjectView flattens `map` through a whitelist, not a raw spread (objectui#5177)', () => {
+  it('still reaches a declared key (locationField) in the flattened product', async () => {
+    const schema = await renderMapView({ locationField: 'geo' });
+
+    expect(schema.locationField).toBe('geo');
+  });
+
+  it('does NOT let `style` in the `map` block reach the top level — the specimen the card measured', async () => {
+    const schema = await renderMapView({
+      latitudeField: 'lat',
+      longitudeField: 'lng',
+      style: 'https://tiles.example.com/style.json',
+    });
+
+    expect(schema.latitudeField).toBe('lat');
+    expect(schema.style).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(schema, 'style')).toBe(false);
+  });
+
+  it('does NOT let an arbitrary undeclared key reach the top level', async () => {
+    const schema = await renderMapView({
+      latitudeField: 'lat',
+      totallyUndeclaredKey: 'nope',
+    });
+
+    expect(schema.latitudeField).toBe('lat');
+    expect(schema.totallyUndeclaredKey).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(schema, 'totallyUndeclaredKey')).toBe(false);
+  });
+});

--- a/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
@@ -30,8 +30,14 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
-import { ObjectView } from '../ObjectView';
+import { ObjectView, FLAT_MAP_CONFIG_KEYS } from '../ObjectView';
 import type { ObjectViewSchema } from '@object-ui/types';
+// Test-only: `ObjectView.tsx` hand-lists `FLAT_MAP_CONFIG_KEYS` rather than
+// importing this schema at runtime, precisely so this module never appears in
+// `examples/console-starter`'s walked import graph (see the comment on the
+// constant). A test file is explicitly excluded from that walk, so pinning
+// against the real declaration HERE is safe.
+import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 
 /** Every schema the view hands to SchemaRenderer, in order. */
 const rendered: any[] = [];
@@ -146,5 +152,24 @@ describe('ObjectView flattens `map` through a whitelist, not a raw spread (objec
     expect(schema.latitudeField).toBe('lat');
     expect(schema.totallyUndeclaredKey).toBeUndefined();
     expect(Object.prototype.hasOwnProperty.call(schema, 'totallyUndeclaredKey')).toBe(false);
+  });
+});
+
+/**
+ * `FLAT_MAP_CONFIG_KEYS` is hand-listed in `ObjectView.tsx` itself (not
+ * derived at runtime — see the comment on the constant for why), so THIS is
+ * the mechanism that keeps it from silently drifting off `ObjectMapConfigSchema`
+ * — the same role `packages/core/src/actions/__tests__/actionKeys.pin.test.ts`
+ * plays for `SPEC_ACTION_KEYS`. A key added to or removed from the schema
+ * fails this test by name, without requiring a runtime import of
+ * `@object-ui/types/zod` from production code that reaches
+ * `examples/console-starter`.
+ */
+describe('FLAT_MAP_CONFIG_KEYS pins against ObjectMapConfigSchema (objectui#5177)', () => {
+  it('matches the schema minus `style`, so the hand list cannot silently drift', () => {
+    const declared = Object.keys(ObjectMapConfigSchema.shape)
+      .filter((key) => key !== 'style')
+      .sort();
+    expect([...FLAT_MAP_CONFIG_KEYS].sort()).toEqual(declared);
   });
 });


### PR DESCRIPTION
Fixes #5177

## What

`ObjectView`'s and `ListView`'s `case 'map'` flatteners built the `object-map` schema with `...(options.map || {})` — spreading the CONTENTS of an untyped bag (`NamedListView.options?: Record<string, any>`) to the top level. Whatever an author wrote in the `map` block landed there unfiltered, while `ObjectMap`'s own `FlatMapConfigKeys = Omit<ObjectMapConfig, 'style'>` declares `style` OUT of this flat form — `style` is ALSO `BaseSchema.style` (inline CSS, legal on every node), so the raw spread collapsed the two namespaces onto one key. Declaration and production disagreed about the same shape.

Per triage's binding disposition (option 1): both flatteners now pick only the keys the declaration allows, instead of spreading the whole bag.

## Design — revised after a CI-caught constraint (read this before the diff)

The first version of this PR derived `FLAT_MAP_CONFIG_KEYS` at all three call sites from `ObjectMapConfigSchema` (`@object-ui/types/zod`) at runtime. CI (`Test (shard 3/4)`, run 32160288416) caught a real break that local package-level testing missed: `examples/console-starter/test/vite-alias-closure.test.ts` walks the example's actual import graph and failed with

```
"@object-ui/types/zod (unresolvable under src, imported by packages/plugin-list/src/ListView.tsx)"
"@object-ui/types/zod (unresolvable under src, imported by packages/plugin-view/src/ObjectView.tsx)"
```

Root cause: that walker resolves a bare `@object-ui/*` specifier with plain `index.<ext>` conventions and cannot find `@object-ui/types/zod`'s real barrel file (`zod/index.zod.ts` — a non-standard name) — regardless of whether Vite's own alias table covers it (it already does; `examples/console-starter/vite.config.ts` has carried an explicit `@object-ui/types/zod` entry since PR #5156). `ObjectView.tsx` and `ListView.tsx` are both reachable from console-starter's own `src/`, so the new runtime import made them part of the walked graph for the first time. `ObjectMap.tsx` in `plugin-map` carries the identical import today without tripping this gate only because nothing in that graph reaches `@object-ui/plugin-map` (it's lazy-loaded via `ComponentRegistry.registerLazy`).

`vite-alias-closure.test.ts` itself is untouched — it's a real gate, not something to weaken.

**Current design:**
- `packages/plugin-map/src/ObjectMap.tsx` — `FLAT_MAP_CONFIG_KEYS` stays DERIVED at runtime (`Object.keys(ObjectMapConfigSchema.shape).filter(key => key !== 'style')`). Safe: this file is not reached by console-starter's walked graph, and it already imports the schema for `safeParse` regardless.
- `packages/plugin-view/src/ObjectView.tsx` and `packages/plugin-list/src/ListView.tsx` — `FLAT_MAP_CONFIG_KEYS` is now HAND-LISTED (no runtime `@object-ui/types/zod` import in either file), so neither is part of the walked graph.

Anti-drift for the two hand lists is a TEST, not just a comment — matching the established `packages/core/src/actions/__tests__/actionKeys.pin.test.ts` pattern for `SPEC_ACTION_KEYS`: `ObjectView.mapFlatten.test.tsx` and `ListView.mapFlatten.test.tsx` each import `ObjectMapConfigSchema` from `@object-ui/types/zod` **in the test file only** (the walker explicitly excludes `*.test.tsx` from traversal) and assert the exported `FLAT_MAP_CONFIG_KEYS` equals the schema's keys minus `style`. A key added to or removed from the declaration still fails loudly, by name, without reintroducing the runtime edge that breaks console-starter.

**Deviation, stated explicitly:** the two hand lists are independently maintained (each pin-tested against the same canonical schema) rather than one literal array physically shared by both call sites, which is what the original disposition asked for when practical. Every within-scope way to truly share one runtime value re-broke something: importing from `@object-ui/plugin-map` would statically pull its `maplibre-gl` / `react-map-gl` weight into every `ObjectView` / `ListView` (that package's single lib entry bundles everything together, and console-starter aliases it whole to `src`), and `packages/types` / `packages/core` are out of this task's scope (held by other in-flight work). Given the pin tests, a drift between the two is mechanically impossible to miss — same enforcement guarantee as one shared list, at the cost of two `it()` blocks instead of one.

## Scope

Hygiene only, per triage: nothing a user hits today (PR #5175 removed the consumer leg and added a dev diagnostic; the pinned strict spec view schemas accept no `map` block at all). Did not implement #5042's forwarding, and the whitelist matches its documented 7-key `ListMapConfigSchema` shape (no surprise there).

## Tests

Both `ObjectView.mapFlatten.test.tsx` and `ListView.mapFlatten.test.tsx` pin, for each package:
- a declared key in the `map` block still reaches the flattened product,
- `style` in the `map` block does **not** reach the top level (the specimen the card measured — confirmed red against the pre-fix source before this change, restored green after),
- an arbitrary undeclared key does not either,
- `FLAT_MAP_CONFIG_KEYS` matches `ObjectMapConfigSchema` minus `style` (the anti-drift pin, added in the CI-fix revision).

## Verification (at `8acdd877e`, rebased onto current `main`)

- `pnpm exec vitest run examples/console-starter/test/vite-alias-closure.test.ts` — 5/5 passed (was red on the prior revision; this is the gate CI caught).
- `pnpm --filter @object-ui/plugin-map type-check` / `@object-ui/plugin-view` / `@object-ui/plugin-list` — clean.
- `pnpm exec vitest run examples/console-starter/test/vite-alias-closure.test.ts packages/plugin-list/src packages/plugin-view/src packages/plugin-map/src` (canonical repo-root invocation) — 64 files / 816 tests passed.
- Reverse verification (first revision): checked out pre-fix `ObjectView.tsx` / `ListView.tsx` against the new tests — the `style` and undeclared-key tests failed as expected (red), declared-key/default tests stayed green; restored the fix and re-confirmed all green.
- `node scripts/check-control-bytes.mjs`, `node scripts/check-phantom-dependencies.mjs`, `node scripts/check-changeset-no-major.mjs` — all clean.
- Lint (`pnpm --filter @object-ui/plugin-view --filter @object-ui/plugin-list --filter @object-ui/plugin-map lint`) — 0 errors, 389 pre-existing-style `no-explicit-any` warnings only.

Changeset: `@object-ui/plugin-view`, `@object-ui/plugin-list`, `@object-ui/plugin-map` all `minor` (fixed group), with the behavior narrowing described in the body per AGENTS.md §版本号策略.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_
