### PR TITLE
fix(components): call FormSchema.onChange with live form values

### DIFF
--- a/.changeset/formschema-onchange-wiring-4259.md
+++ b/.changeset/formschema-onchange-wiring-4259.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/components': minor
+---
+
+fix(components): call `FormSchema.onChange` — the declared callback the form renderer never invoked (objectui#4259)
+
+`FormSchema` declares four lifecycle callbacks and the form renderer
+destructures all four off `schema` in one block: `onSubmit`, `onChange`,
+`onDirtyChange`, `onCancel`. Three were wired. `onChange` was destructured and
+then never referenced again — the destructure was its only occurrence in the
+whole file — so a consumer who authored it got a typed, exported, documented,
+autocompleted callback that did nothing at all. No warning, no dev-mode notice,
+no type error: the declaration said it was supported.
+
+It is now called with the live form values whenever a value changes, through the
+same `form.watch` subscription plumbing the `onDirtyChange` and `onAction`
+channels already use, so the value channel cannot drift into its own schedule.
+
+Two properties are deliberate and pinned by tests:
+
+- **The subscription is guarded.** A schema that authors no `onChange`
+  establishes no subscription at all, exactly like the existing `onAction`
+  channel and unlike the unconditional `onDirtyChange` one. Watching
+  unconditionally would have put a third `form.watch` on every form in the
+  product on behalf of callers who asked for nothing; honouring the declaration
+  is meant to be purely additive for everyone else.
+- **It runs in the layout phase**, matching the `defaultValues` reset and the
+  two subscriptions beside it. React runs every layout destroy before any layout
+  create, so a caller passing a fresh inline arrow each render — the common
+  shape — has the subscription torn down before the reset and re-established
+  after. That is what keeps a record landing in edit mode from being reported to
+  the host as if the user had edited every field it filled. A passive effect
+  inverts that order.
+
+The callback receives the form values, per its declared
+`(data) => void` signature — not a DOM event. A top-level `onChange` spread onto
+the form node is still stripped before it can reach the `form` element, where it
+would have fired with a SyntheticEvent instead; that block's behaviour is
+unchanged, only its now-outdated comment was corrected.
+
+No change to `@object-ui/types` — the declaration was already there and already
+correct. This is the renderer starting to honour it.

--- a/packages/components/src/renderers/form/__tests__/form-onchange-wiring.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-onchange-wiring.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FormSchema.onChange` must actually fire (#4259).
+ *
+ * It is one of four lifecycle callbacks the schema declares and the renderer
+ * destructures together — `onSubmit`, `onChange`, `onDirtyChange`, `onCancel`.
+ * Three were wired; `onChange` was destructured and then never referenced
+ * again, so a consumer handed a typed, exported, autocompleted callback got a
+ * silent no-op: no warning, no dev notice, no type error. Ruled 2026-08-17:
+ * wire it, using the same subscription plumbing `onDirtyChange` proves exists
+ * beside it. The pin has two halves and this file delivers both, plus the
+ * ordering property the layout phase exists to protect.
+ *
+ *   1. POSITIVE — an authored `onChange` fires on a value change and receives
+ *      the FORM VALUES, not a DOM event. (A `onChange` reaching the <form>
+ *      element instead would fire with a SyntheticEvent; that is a different
+ *      contract, and the top-level props strip keeps it off the DOM node.)
+ *   2. NEGATIVE — absence of `onChange` changes nothing, made observable
+ *      rather than asserted: a schema that authors no `onChange` must
+ *      establish NO subscription at all. The subscription is guarded (like
+ *      `onAction`) precisely so this stays literally true; watching
+ *      unconditionally (like `onDirtyChange`) would add a third `form.watch`
+ *      to every form in the product on behalf of callers who asked for
+ *      nothing. The probe below counts `form.watch(fn)` calls so the guard
+ *      cannot be dropped without turning this red.
+ *   3. RESET ORDERING — a `defaultValues` reset (a record landing in edit
+ *      mode) is not reported to `onChange` as a user edit. This is what the
+ *      LAYOUT phase buys: React runs every layout destroy before any layout
+ *      create, so a caller passing a fresh inline arrow each render — the
+ *      common case — has the subscription torn down before the reset and
+ *      re-established after. Move the effect to `React.useEffect` and the
+ *      order inverts: a landing record looks like the user editing every
+ *      field it filled (#2968). Pinned here, or the next refactor takes it
+ *      away silently.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../../../renderers';
+
+// Counts value-subscription establishment: every `form.watch(callback)` on the
+// form instance this renderer creates. `useForm` returns one stable object per
+// form (RHF keeps it in a ref), so the patch below applies exactly once per
+// form and does not perturb the `[form, onChangeProp]` effect deps it is there
+// to observe. `watch()` with no callback (the render-time read) is not a
+// subscription of this kind and is not counted.
+const watchProbe = vi.hoisted(() => ({ subscribeCalls: 0 }));
+
+vi.mock('react-hook-form', async () => {
+  const actual = await vi.importActual<typeof import('react-hook-form')>('react-hook-form');
+  return {
+    ...actual,
+    useForm: (...args: unknown[]) => {
+      const form = (actual.useForm as (...a: unknown[]) => Record<string, any>)(...args);
+      if (!form.__osWatchProbed) {
+        form.__osWatchProbed = true;
+        const realWatch = form.watch.bind(form);
+        form.watch = (...watchArgs: unknown[]) => {
+          if (typeof watchArgs[0] === 'function') watchProbe.subscribeCalls += 1;
+          return realWatch(...watchArgs);
+        };
+      }
+      return form;
+    },
+  };
+});
+
+const FIELDS = [
+  { name: 'name', label: 'Name', type: 'input' },
+  { name: 'note', label: 'Note', type: 'input' },
+];
+
+type Record_ = Record<string, unknown>;
+const getFormRenderer = () =>
+  ComponentRegistry.get('form') as React.ComponentType<{ schema: Record_ }>;
+
+const nameInput = (root: ParentNode) =>
+  root.querySelector('input[name="name"]') as HTMLInputElement | null;
+
+beforeEach(() => {
+  watchProbe.subscribeCalls = 0;
+});
+
+describe('form — FormSchema.onChange is honoured', () => {
+  it('calls an authored onChange with the form values on a value change', async () => {
+    const Form = getFormRenderer();
+    const received: unknown[] = [];
+    const onChange = (values: unknown) => { received.push(values); };
+
+    const { container } = render(
+      <Form
+        schema={{ type: 'form', fields: FIELDS, showSubmit: false, onChange }}
+      />,
+    );
+    await waitFor(() => {
+      if (!nameInput(container)) throw new Error('not ready');
+    });
+    received.length = 0;
+
+    fireEvent.change(nameInput(container)!, { target: { value: 'Alice' } });
+
+    // Pre-fix this never fires at all — `onChangeProp` was destructured and
+    // dropped on the floor.
+    await waitFor(() => expect(received.length).toBeGreaterThan(0));
+
+    // Assert on a VALUE, not on a call count: the declared contract is
+    // `(data: Record<string, any>) => void`, so the callback has to be handed
+    // the form values.
+    const last = received[received.length - 1] as Record_;
+    expect(last).toEqual(expect.objectContaining({ name: 'Alice' }));
+
+    // ...and specifically NOT a DOM event, which is what a top-level `onChange`
+    // landing on the <form> element would have delivered.
+    expect(last).not.toHaveProperty('nativeEvent');
+    expect(last).not.toHaveProperty('target');
+    expect(typeof (last as { preventDefault?: unknown }).preventDefault).not.toBe('function');
+
+    // A second edit keeps reporting live values — this is a channel, not a
+    // one-shot.
+    fireEvent.change(nameInput(container)!, { target: { value: 'Bob' } });
+    await waitFor(() =>
+      expect(received[received.length - 1]).toEqual(expect.objectContaining({ name: 'Bob' })),
+    );
+  });
+
+  it('establishes no extra subscription when the schema authors no onChange', async () => {
+    const Form = getFormRenderer();
+
+    // Case A — no lifecycle callback authored at all.
+    watchProbe.subscribeCalls = 0;
+    const a = render(
+      <Form schema={{ type: 'form', fields: FIELDS, showSubmit: false }} />,
+    );
+    await waitFor(() => {
+      if (!nameInput(a.container)) throw new Error('not ready');
+    });
+    const withoutOnChange = watchProbe.subscribeCalls;
+    a.unmount();
+
+    // Case B — byte-identical schema plus an authored `onChange`.
+    watchProbe.subscribeCalls = 0;
+    const onChange = vi.fn();
+    const b = render(
+      <Form schema={{ type: 'form', fields: FIELDS, showSubmit: false, onChange }} />,
+    );
+    await waitFor(() => {
+      if (!nameInput(b.container)) throw new Error('not ready');
+    });
+    const withOnChange = watchProbe.subscribeCalls;
+    b.unmount();
+
+    // The load-bearing assertion: authoring `onChange` costs exactly one
+    // subscription, and authoring nothing costs none. Drop the `if
+    // (onChangeProp)` guard and both counts become equal — this goes red.
+    expect(withOnChange).toBe(withoutOnChange + 1);
+
+    // Deliberate ratchet on the absolute number: a callback-free form
+    // establishes exactly ONE value subscription — the pre-existing
+    // unconditional `onDirtyChange` watcher. If a later change adds another
+    // unconditional `form.watch`, this is the line that says so.
+    expect(withoutOnChange).toBe(1);
+  });
+
+  it('leaves a form without onChange behaving identically', async () => {
+    const Form = getFormRenderer();
+    const submitted: Record_[] = [];
+
+    const { container } = render(
+      <Form
+        schema={{
+          type: 'form',
+          fields: FIELDS,
+          defaultValues: { name: 'seed' },
+          showSubmit: false,
+          onSubmit: (d: Record_) => { submitted.push(d); },
+        }}
+      />,
+    );
+    await waitFor(() => {
+      if (!nameInput(container)) throw new Error('not ready');
+    });
+
+    // Typing, the seeded default and submission all still work with no
+    // `onChange` in the schema — wiring the callback is additive.
+    expect(nameInput(container)!.value).toBe('seed');
+    fireEvent.change(nameInput(container)!, { target: { value: 'Alice' } });
+    await waitFor(() => expect(nameInput(container)!.value).toBe('Alice'));
+
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+    await waitFor(() => expect(submitted.length).toBe(1));
+    expect(submitted[0]).toEqual(expect.objectContaining({ name: 'Alice' }));
+  });
+
+  it('does not report a defaultValues reset to onChange as a user edit', async () => {
+    const Form = getFormRenderer();
+    const received: Record_[] = [];
+    let setDefaults!: (v: Record_) => void;
+
+    const Host = () => {
+      const [defaults, setD] = React.useState<Record_>({});
+      setDefaults = setD;
+      return (
+        <Form
+          schema={{
+            type: 'form',
+            fields: FIELDS,
+            defaultValues: defaults,
+            showSubmit: false,
+            // A FRESH inline arrow each render — the common caller shape, and
+            // the one the layout phase is written for. Its changing identity
+            // re-runs the effect, so the subscription is torn down (layout
+            // destroy) before the reset (layout create) and re-established
+            // after it.
+            onChange: (values: Record_) => { received.push(values); },
+          }}
+        />
+      );
+    };
+
+    const { container } = render(<Host />);
+    await waitFor(() => {
+      if (!nameInput(container)) throw new Error('not ready');
+    });
+    await act(async () => {});
+    received.length = 0;
+
+    // The record finishes loading after first paint and the form resets to it.
+    // That is the host's own data arriving, not the user typing.
+    await act(async () => { setDefaults({ name: 'Loaded', note: 'from server' }); });
+
+    // The reset must not come back to the host as an edit.
+    expect(
+      received.some(
+        (v) => v && (v as Record_).name === 'Loaded' && (v as Record_).note === 'from server',
+      ),
+    ).toBe(false);
+
+    // The reset itself still happened — this test pins the ordering, not the
+    // absence of the reset.
+    await waitFor(() => expect(nameInput(container)!.value).toBe('Loaded'));
+
+    // ...and the channel is still live afterwards: a real user edit that
+    // follows the reset IS reported.
+    fireEvent.change(nameInput(container)!, { target: { value: 'Edited' } });
+    await waitFor(() =>
+      expect(received[received.length - 1]).toEqual(expect.objectContaining({ name: 'Edited' })),
+    );
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -1566,6 +1566,35 @@ ComponentRegistry.register('form',
       return () => subscription.unsubscribe();
     }, [form, onDirtyChangeProp]);
 
+    // Surface live values to the host — `FormSchema.onChange`, the value-change
+    // sibling of the submit/dirty/cancel callbacks destructured beside it. It
+    // was declared, typed, exported and documented, but the renderer never
+    // invoked it: authoring `onChange` on a form schema was a silent no-op
+    // (#4259). Same subscription plumbing as the two effects above, so the
+    // value channel cannot drift into its own schedule.
+    //
+    // GUARDED, like the `onAction` subscription and unlike the `onDirtyChange`
+    // one: a form whose author wrote no `onChange` must establish no
+    // subscription at all. Watching unconditionally would put a third
+    // `form.watch` on every form in the product to serve callers who asked for
+    // nothing — a behaviour change for them, where honouring the declaration
+    // is meant to be purely additive.
+    //
+    // Layout-phase for the ordering reason spelled out above the `onAction`
+    // effect: React runs every layout DESTROY before any layout CREATE, so a
+    // caller passing a fresh inline arrow each render — the common case — has
+    // this torn down before the `defaultValues` reset runs and re-established
+    // after. That is what keeps a record landing from being reported to the
+    // host as a user edit. A passive effect inverts the order (#2968).
+    React.useLayoutEffect(() => {
+      if (onChangeProp) {
+        const subscription = form.watch((values) => {
+          onChangeProp(values as Record<string, any>);
+        });
+        return () => subscription.unsubscribe();
+      }
+    }, [form, onChangeProp]);
+
     /**
      * Scroll a field into view and focus a control inside it. The field wrapper
      * carries `data-field` (FormItem), so this reaches custom widgets that RHF's
@@ -2423,7 +2452,16 @@ ComponentRegistry.register('form',
         'data-obj-type': dataObjType,
         style,
         onSubmit: _ignoredOnSubmit, // Prevent overwriting our handleSubmit
-        onChange: _ignoredOnChange, // Prevent overwriting our onChange
+        // Keep a top-level `onChange` off the <form> DOM node. Some callers /
+        // the SDUI dispatch spread the whole form node at the top level in
+        // addition to `schema`, and a DOM `onChange` there fires with a
+        // SyntheticEvent — never with form values, so it is not the
+        // `FormSchema.onChange` contract at all. That schema-level callback is
+        // subscribed above (#4259) and is the only `onChange` this renderer
+        // honours; before it was wired there was in fact no "our onChange" for
+        // this line to protect. Dropping the top-level copy is all this does:
+        // it is not re-routed here, and nothing double-fires.
+        onChange: _ignoredOnChange,
         // Extract schema props that should not be spread to DOM (handled separately by schema destructuring above)
         submitLabel: _submitLabel,
         cancelLabel: _cancelLabel,


### PR DESCRIPTION
Fixes #4259

## What was wrong

`FormSchema` declares four lifecycle callbacks and the form renderer destructures all four off `schema` in one block. Three were wired; `onChange` was destructured and then never referenced again, so authoring it was a silent no-op — no warning, no dev-mode notice, no type error. The declaration said it was supported.

**Premise re-verified against `origin/main` before writing anything** (the card body's anchors were stale, and the dispatch's were re-taken too):

| | measured on `origin/main` @ `513e614f0` |
|---|---|
| destructure block | lines 995 to 998 of `packages/components/src/renderers/form/form.tsx` |
| `onChangeProp` occurrences | **1** — line 996, the destructure itself |
| counter-probe `onDirtyChangeProp` | 5 hits, so the single hit is a real reading, not a broken pattern |
| siblings wired | `onDirtyChangeProp` 1527 / 1562 / 1567, `onSubmitProp` 1694, `onCancelProp` 1772 |

## The ruling this implements

Maintainer, 2026-08-17, verbatim 「同意」, recorded on the card:

> **Ruled: wire it.** `FormSchema.onChange` gets called with live form values, using the same subscription plumbing `onDirtyChange` proves exists in the file. Enforce-or-remove is satisfied on the enforce side because it is the strictly cheaper arm here: wiring is additive; removal is a breaking public-type change plus a deprecation cycle for a hook whose siblings all work. Pin test: authored `onChange` fires on value change; absence of `onChange` changes nothing.

## What changed

One new `form.watch` subscription beside its two siblings, plus a comment correction. Two properties are deliberate.

**It is guarded (`if (onChangeProp)`).** Two subscription patterns already exist in this file within 40 lines of each other and they are not interchangeable: `onAction` guards, `onDirtyChange` subscribes unconditionally. The ruling's second half — *absence of `onChange` changes nothing* — is only literally true on the guarded pattern. An unconditional third `form.watch` on every form in the product would be a behaviour change for callers who authored nothing, which is the opposite of additive.

**It runs in the layout phase**, matching the `defaultValues` reset and both subscriptions beside it. React runs every layout destroy before any layout create, so a caller passing a fresh inline arrow each render — the common shape — has the subscription torn down before the reset and re-established after. That is what keeps a record landing in edit mode from being reported to the host as if the user had edited every field it filled. A passive effect inverts the order (#2968). No deviation from layout phase, so nothing to justify here.

The callback receives the form values, per its declared `(data) => void` signature — not a DOM event.

### The top-level props strip: comment only

The strip drops `onChange: _ignoredOnChange` under the comment *"Prevent overwriting our onChange"*, and until now there was no "our onChange" — the thing that comment protected did not exist. It becomes true for the first time with this change, so the comment now names what it actually protects: an `onChange` reaching the form DOM element would fire with a SyntheticEvent, not with form values, which is a different contract altogether.

**The strip's behaviour is byte-identical** — the destructured entry `onChange: _ignoredOnChange,` is unchanged, nothing is re-routed, nothing double-fires. Only the comment text moved.

## Tests

New file `packages/components/src/renderers/form/__tests__/form-onchange-wiring.test.tsx`, pinning both halves of the ruling plus the ordering property:

1. **Positive** — an authored `onChange` fires on a value change and is asserted on a **value** (`name: 'Alice'`, then `'Bob'`), not a call count; and asserted *not* to be an event (no `nativeEvent`, no `target`, no `preventDefault`).
2. **Negative, made observable** — a probe wraps the `useForm` result and counts `form.watch(callback)` calls, so "no extra subscription" is measured rather than asserted. Authoring `onChange` costs exactly one subscription; authoring nothing costs none. Drop the guard and this goes red.
3. **Behavioural equivalence** — a form with no `onChange` still seeds, types and submits identically.
4. **Reset ordering** — a `defaultValues` reset is not reported as a user edit, with a liveness tail proving the channel is still live afterwards.

### Reverse verification (predictions stated before running)

Restored `form.tsx` to `origin/main`, kept the new test file. **Observed matched predicted exactly, including which assertion fails in each case:**

| Test | Predicted | Observed |
|---|---|---|
| authored `onChange` fires with values | RED | RED — `expected 0 to be greater than 0` |
| no extra subscription when absent | RED | RED — `expected 1 to be 2` |
| behaves identically without `onChange` | **GREEN** | GREEN |
| reset not reported as a user edit | RED, on the **last** assertion only | RED — `expected undefined to deeply equal ObjectContaining {"name": "Edited"}` |

Result: 3 failed / 1 passed, as predicted.

**Two assertions stay green pre-fix and therefore pin nothing about this fix — stated plainly rather than counted as evidence:**

- Test 3 in full. It is a regression guard for the negative half (wiring must not disturb callback-free forms), not a pin on the wiring.
- The *ordering* assertion inside test 4 is **vacuously** green pre-fix: with `onChange` never called, `received` is empty, so "the reset is not among the calls" is trivially true. On its own it cannot tell correct ordering from never firing. That is exactly why the liveness tail is appended — and the tail is the assertion that actually goes red. Likewise `expect(withoutOnChange).toBe(1)` in test 2 is a deliberate ratchet on pre-existing behaviour (a callback-free form establishes exactly one value subscription), not a pin on this change.

The fix was committed before the reverse verification, and `form.tsx` was restored from the commit afterwards — `git diff HEAD` empty, so the numbers above come from a byte-identical tree.

## Gates run locally

All against the final commit, `ec223d150`:

| gate | result |
|---|---|
| `pnpm exec vitest run packages/components/` | **161 files / 1468 tests passed** |
| `pnpm --filter @object-ui/components run type-check` | pass (`tsc --noEmit && tsc -p tsconfig.test.json`; script name echoed, so not a zero-match) |
| `eslint` on both changed source files | 0 errors (54 pre-existing warnings in the 3.1k-line file) |
| `check:control-bytes` | pass — 4642 files scanned |
| `check:phantom-deps` | pass |
| `check:self-import` | pass |
| `check-changeset-presence` | pass — 1 source file, 1 changeset |
| `check-changeset-no-major` | pass |

**Declared narrowing:** the local test run is scoped to `packages/components/` — the package that changed — rather than the whole farm, which CI runs exactly once anyway. The dependency closure was built first (`pnpm --filter '@object-ui/components^...' build`); without it `type-check` fails on unbuilt siblings, which reads exactly like a real error.

Changeset: `@object-ui/components: minor`, matching the closest precedent (honouring a previously-ignored declaration). Never `major` — the 39 packages share one fixed version group.

## Scope

- **`packages/types` untouched.** The `onChange` declaration was already there and already correct; this is the renderer starting to honour it. No public type change, so nothing here collides with the in-flight work on `form.zod.ts`.
- **Found and filed separately, not fixed here: #5235** — the "a reset is not a user edit" guarantee is delivered by the callback's *identity* changing each render, so a caller who wraps it in `useCallback` keeps a live subscription across the reset and does receive it. Measured: a stable-identity `onChange` gets `{ name: 'Loaded', note: 'from server' }`. This is pre-existing on the `onAction` channel, `onChange` inherits it by following the ruled plumbing, and picking the right semantics is a design question rather than a mechanical fix — so it is filed unassigned for triage rather than decided in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_