### PR TITLE
test(plugin-grid): record the three grid keys ruled non-author surface, and stop at the fourth

### DIFF
--- a/.changeset/grid-non-author-keys-5091.md
+++ b/.changeset/grid-non-author-keys-5091.md
@@ -1,0 +1,18 @@
+---
+---
+
+Internal only — no package is released by this change.
+
+`ObjectGrid` reads `columnState`, `hideRowHeightToggle` and `maxInlineRowActions`
+through `(schema as any)`, and the maintainer ruling of 2026-08-18 on
+objectui#5091 keeps all three OUT of `GRID_QUERY_INPUTS`: they are host/user-state
+channels, not authoring surface. What lands here is the record of that decision —
+an exemption comment at each read site and
+`packages/plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx`, which pins that
+they stay unpublished, that `@objectstack/spec` rejects them by name, that the
+parser therefore reports them as unknown props, and that the renderer still reads
+every one of them.
+
+No published surface moves: `GRID_QUERY_INPUTS` is byte-for-byte unchanged, the
+generated manifest and `sdui-intrinsics.d.ts` are unchanged, and the only edits to
+`ObjectGrid.tsx` are comments.

--- a/packages/plugin-grid/package.json
+++ b/packages/plugin-grid/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@object-ui/data-objectstack": "workspace:*",
+    "@object-ui/sdui-parser": "workspace:*",
     "@objectstack/spec": "^17.0.0",
     "@vitejs/plugin-react": "^6.0.5",
     "msw": "^2.15.0",

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -605,6 +605,28 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
       : `grid-columns-${schema.objectName}`;
   }, [schema.objectName, schema.id]);
 
+  /**
+   * NON-AUTHOR SURFACE — `columnState` is deliberately absent from
+   * `GRID_QUERY_INPUTS` (`index.tsx`), by the maintainer ruling of 2026-08-18
+   * on objectui#5091. The cast reads in this block are therefore DELIBERATELY
+   * unlisted, not missed.
+   *
+   * It is the USER-STATE persistence payload, not authoring surface: the host
+   * hands in whatever the user last saved (`app-shell/src/views/ObjectView.tsx`
+   * :1848 reads it off the view def) and writes their drags back through
+   * `dataSource.updateViewConfig` (`persistViewPatch`, same file :1867;
+   * `saveColumnState` below is the outbound half). Publishing it would put
+   * column widths and order in the designer panel and in the generated
+   * `sdui-intrinsics.d.ts` — i.e. bless hand-authoring a payload the product
+   * writes on the user's behalf.
+   *
+   * The contract says the same thing independently: `ComponentPropsMap
+   * ['object-grid']` (`@objectstack/spec@17`) is a `strictObject` and rejects
+   * `columnState` BY NAME (`unrecognized_keys`), so an author who took the
+   * offer could not save the document. Both halves — unlisted here, rejected
+   * there — are pinned by `__tests__/gridNonAuthorKeys.test.tsx`, together with
+   * the reads themselves, so this exemption cannot decay into a silent drop.
+   */
   const [columnState, setColumnState] = useState<ObjectGridColumnState>(() => {
     // Priority: 1) externally provided (e.g. persisted view override),
     // 2) localStorage (per-browser fallback), 3) empty.
@@ -621,6 +643,8 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // Sync when external columnState changes (e.g. switching views, reload pulls
   // a saved override from the server). Wrapped in a stable string key to
   // avoid re-renders when the parent passes a fresh-but-equal object.
+  // Non-author surface, same ruling as the seed above (objectui#5091): these
+  // two reads are the host's inbound channel, never an authored key.
   const externalColumnStateKey = React.useMemo(
     () => JSON.stringify((schema as any).columnState ?? null),
     [(schema as any).columnState]
@@ -2100,6 +2124,17 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
           rowActions={customRowActions}
           rowActionDefs={resolvedRowActionDefs as any[]}
           objectFields={objectSchema?.fields}
+          // NON-AUTHOR SURFACE — `maxInlineRowActions` is deliberately
+          // absent from `GRID_QUERY_INPUTS` (maintainer ruling, 2026-08-18,
+          // objectui#5091), so this cast read is deliberate, not missed. It is
+          // a host/internal switch for the inline-button budget before the
+          // rest fold into the "⋮" menu — an embedder's layout call, set from
+          // code (`apps/console/src/dev/DevRowActions.tsx:51`), never from a
+          // view document. `ComponentPropsMap['object-grid']` is a
+          // `strictObject` and rejects the key by name, so publishing it would
+          // advertise a key the save gate refuses. The `?? 1` default is the
+          // published behaviour and stays the one an author sees. Pinned by
+          // `__tests__/gridNonAuthorKeys.test.tsx`.
           maxInlineActions={(schema as any).maxInlineRowActions ?? 1}
           // [#4296] The object verdict ANDed with THIS row's record-level one.
           // It rides the same per-row channel the #2614 predicates ride —
@@ -3229,6 +3264,16 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // Grid toolbar (row height toggle + export)
   // Hide row-height toggle when parent (e.g., ListView) controls density externally,
   // signaled by `hideRowHeightToggle` prop on schema.
+  //
+  // NON-AUTHOR SURFACE — `hideRowHeightToggle` is deliberately absent from
+  // `GRID_QUERY_INPUTS` (maintainer ruling, 2026-08-18, objectui#5091), so this
+  // cast read is deliberate, not missed. It is the host's own signal, written
+  // by the embedding view when IT owns density (`plugin-list/src/ListView.tsx`
+  // :1866 sets it unconditionally); the author-facing way to ask for a density
+  // is `rowHeight`, which IS declared. `ComponentPropsMap['object-grid']` is a
+  // `strictObject` and rejects this key by name, so publishing it would offer a
+  // key the save gate refuses. Pinned by
+  // `__tests__/gridNonAuthorKeys.test.tsx`.
   const showRowHeightToggle = schema.rowHeight !== undefined && !(schema as any).hideRowHeightToggle;
   // Export is offered only when configured AND not blocked by object-level perms
   // — including the server's effective API operation set (#3391): when present

--- a/packages/plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx
+++ b/packages/plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `object-grid` — the three keys ruled NON-AUTHOR SURFACE stay unlisted, and
+ * stay read (objectui#5091).
+ *
+ * ## The card, and the ruling
+ *
+ * objectui#5091 found four keys `ObjectGrid` reads through `(schema as any)`
+ * that `GRID_QUERY_INPUTS` does not publish. `inputs` is not documentation: it
+ * is the published AUTHORING surface, serialized by `sdui-parser`'s
+ * `gen-manifest.ts` into `sdui.manifest.json` (the save gate and parser
+ * whitelist) and into `sdui-intrinsics.d.ts`, and read by the designer panel.
+ * A key the renderer honours and `inputs` omits therefore draws `unknown-prop`
+ * from the parser on a key that works — objectui#4648's complaint.
+ *
+ * The maintainer ruled per key on 2026-08-18. THREE of them — `columnState`,
+ * `hideRowHeightToggle`, `maxInlineRowActions` — are NOT authoring surface and
+ * stay out of the manifest and the docs: a cast read of theirs is deliberate,
+ * not missed. This file is where that word "deliberate" is said to the tooling,
+ * so the next census re-files the card only if something really changed.
+ *
+ * (The fourth, `rowActionDefs`, was ruled INTO the manifest on the reading that
+ * it is the symmetric partner of the declared `bulkActionDefs`. It is not
+ * declared here: the spec's `ObjectGridPropsSchema` is a `strictObject` that
+ * accepts `bulkActionDefs` and REJECTS `rowActionDefs` by name, and
+ * `app-shell/src/views/ObjectView.tsx:1924` DERIVES the grid's `rowActionDefs`
+ * from `objectDef.actions` filtered by `locations: ['list_item']` rather than
+ * passing an authored key through — so the two are asymmetric by construction,
+ * and declaring it here would publish a key the save gate refuses. That is back
+ * with the maintainer on objectui#5091; this file states only what was ruled
+ * AND holds.)
+ *
+ * ## The shape of the pin — four assertions per key, and why each is needed
+ *
+ * Reusable as-is for the same census one and two packages over (objectui#5097
+ * on `record:*` / `view:object`, objectui#5102):
+ *
+ *   1. NOT PUBLISHED, on every tag the renderer is registered under. One
+ *      renderer registered twice is two chances to disagree with itself.
+ *   2. THE CONTRACT REJECTS IT BY NAME. `ComponentPropsMap['object-grid']` is
+ *      strict, so the key comes back in `unrecognized_keys` — asserted as a KEY
+ *      verdict (the fixture is otherwise legal), never as a whole-document
+ *      `success`, which would confuse "this key is refused" with "this document
+ *      is well-formed". This is the half that makes the exemption checkable
+ *      rather than an opinion: publishing the key would put the manifest at
+ *      odds with the gate that stores the document.
+ *   3. THE PARSER SAYS SO OUT LOUD, through the real validator over a manifest
+ *      built from the LIVE registry — never a hand-written one that could agree
+ *      with itself. `unknown-prop` on these keys is the intended, ruled outcome,
+ *      not a defect; pinning it is what stops a later "tidy-up" from declaring
+ *      them to silence a warning.
+ *   4. THE RENDERER STILL READS IT. The ruling kept every read site; only the
+ *      status changed. Deleting a read is the one move that would make an
+ *      author's stored document quietly do nothing, and it is exactly what a
+ *      reader who sees "non-author surface" might think is the tidy finish.
+ *
+ * The control in 1-3 is `bulkActionDefs`: declared, spec-accepted, clean
+ * through the parser. Without it, all three assertions would pass just as
+ * happily against a registry that published nothing at all.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ComponentPropsMap } from '@objectstack/spec/ui';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+import { ObjectGrid } from '../ObjectGrid';
+// Module scope, not a hook: this import IS the registration (AGENTS.md's
+// test-discipline section — an unbounded module load must not be billed to a
+// bounded window).
+import '../index';
+
+registerAllFields();
+
+/** The two tags this one renderer is published under. */
+const GRID_TAGS = [
+  { label: 'object-grid', type: 'object-grid', namespace: undefined },
+  { label: 'view:grid', type: 'grid', namespace: 'view' },
+] as const;
+
+/**
+ * The three keys ruled NON-AUTHOR SURFACE, each with the producer that writes
+ * it. The producer is the evidence: "non-author" is a claim about who WRITES
+ * the key, so a reader can check it rather than trust it.
+ */
+const NON_AUTHOR_KEYS = [
+  {
+    key: 'columnState',
+    producer: 'app-shell/src/views/ObjectView.tsx:1848 in, :1867 back out via persistViewPatch',
+    sample: { order: ['name'] },
+  },
+  {
+    key: 'hideRowHeightToggle',
+    producer: 'plugin-list/src/ListView.tsx:1866 — the embedding view owns density',
+    sample: true,
+  },
+  {
+    key: 'maxInlineRowActions',
+    producer: 'apps/console/src/dev/DevRowActions.tsx:51 — an embedder layout call',
+    sample: 2,
+  },
+] as const;
+
+/** The declared control: ruled-in surface, spec-accepted, parser-clean. */
+const DECLARED_CONTROL = 'bulkActionDefs';
+
+const declaredInputNames = (type: string, namespace?: string): string[] =>
+  ((ComponentRegistry.getConfig(type, namespace) as any)?.inputs ?? []).map((i: any) => i.name);
+
+/**
+ * A manifest built the way `gen-manifest.ts` and the JSX-page compiler build
+ * theirs — from the live registry — so these verdicts are the ones a real
+ * author gets, not the ones a fixture was written to produce.
+ */
+const liveManifest = () =>
+  manifestFromConfigs(
+    ComponentRegistry.getKnownTypes().map((type) => {
+      const meta = ComponentRegistry.getMeta(type);
+      return { type, namespace: meta?.namespace, isContainer: meta?.isContainer, inputs: meta?.inputs };
+    }) as unknown as Parameters<typeof manifestFromConfigs>[0],
+  );
+
+/** Diagnostics a one-node `object-grid` document draws for `props`. */
+const diagnose = (props: Record<string, unknown>) =>
+  validateTree(
+    { type: 'object-grid', objectName: 'account', ...props } as never,
+    liveManifest(),
+  ).diagnostics;
+
+/** The spec's verdict on ONE key added to an otherwise legal grid document. */
+const specVerdict = (key: string, value: unknown) =>
+  (ComponentPropsMap as Record<string, any>)['object-grid'].safeParse({
+    objectName: 'account',
+    [key]: value,
+  });
+
+describe('the three ruled non-author keys are not published (objectui#5091)', () => {
+  it.each(GRID_TAGS)('$label publishes none of them', ({ type, namespace }) => {
+    const declared = declaredInputNames(type, namespace);
+    for (const { key, producer } of NON_AUTHOR_KEYS) {
+      expect(
+        declared,
+        [
+          `\`${type}\` publishes \`${key}\` as authoring surface. The 2026-08-18 ruling on`,
+          'objectui#5091 put it out of the manifest deliberately: it is written by the HOST',
+          `(${producer}), and the spec's \`ObjectGridPropsSchema\` rejects it by name, so an`,
+          'author who accepted the offer could not save the document.',
+        ].join('\n'),
+      ).not.toContain(key);
+    }
+  });
+
+  it.each(GRID_TAGS)('$label does publish the declared control, so absence means something', ({ type, namespace }) => {
+    // Without this, "not published" would pass against an empty registration.
+    expect(declaredInputNames(type, namespace)).toContain(DECLARED_CONTROL);
+  });
+});
+
+describe('the contract rejects the three by name — the exemption is checkable (objectui#5091)', () => {
+  it.each(NON_AUTHOR_KEYS)('the spec refuses $key as an unrecognized key', ({ key, sample }) => {
+    const result = specVerdict(key, sample);
+    expect(result.success, `\`@objectstack/spec\` now ACCEPTS object-grid.${key} — re-open the ruling`).toBe(false);
+    // A KEY verdict, not a document verdict: the rest of the fixture is legal,
+    // so the only thing that can be reported is this key's rejection.
+    const unrecognized = (result as { error: { issues: Array<{ code: string; keys?: string[] }> } }).error.issues
+      .filter((issue) => issue.code === 'unrecognized_keys')
+      .flatMap((issue) => issue.keys ?? []);
+    expect(unrecognized).toContain(key);
+  });
+
+  it(`accepts the declared control ${DECLARED_CONTROL}`, () => {
+    // The control that separates "this key is refused" from "this schema
+    // refuses everything". A FULL parse, because the claim here is that the
+    // whole document is legal — the asymmetry the ruling rests on.
+    const result = specVerdict(DECLARED_CONTROL, []);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('the parser reports them as unknown props — the ruled outcome (objectui#5091)', () => {
+  it.each(NON_AUTHOR_KEYS)('$key draws unknown-prop from the real validator', ({ key, sample }) => {
+    const codes = diagnose({ [key]: sample }).filter((d) => d.code === 'unknown-prop');
+    expect(
+      codes.map((d) => d.message).join('\n'),
+      `\`${key}\` no longer draws \`unknown-prop\`. If that is deliberate it means the key was`
+        + ' declared — which the 2026-08-18 ruling forbids for this key.',
+    ).toContain(key);
+  });
+
+  it('a declared key draws nothing, so the diagnosis is not vacuous', () => {
+    // `rowHeight` is declared and its value is legal, so a clean run here is
+    // what proves the three above are reporting the KEY and not the fixture.
+    expect(diagnose({ rowHeight: 'compact' }).filter((d) => d.code === 'unknown-prop')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The reads themselves — unchanged by the ruling, and the half a reader of
+// "non-author surface" is most likely to delete.
+// ---------------------------------------------------------------------------
+
+const rows = [
+  { id: '1', name: 'Alice', email: 'alice@example.com' },
+  { id: '2', name: 'Bob', email: 'bob@example.com' },
+];
+
+function makeAdapter(objectSchema?: Record<string, unknown>) {
+  return {
+    find: vi.fn().mockResolvedValue({ data: rows, total: rows.length }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'test_object',
+      fields: { id: { type: 'text' }, name: { type: 'text' }, email: { type: 'text' } },
+      ...objectSchema,
+    }),
+  };
+}
+
+function renderGrid(extra: Record<string, unknown>, objectSchema?: Record<string, unknown>) {
+  const schema = {
+    type: 'object-grid',
+    objectName: 'test_object',
+    columns: [{ field: 'name', label: 'Name' }, { field: 'email', label: 'Email' }],
+    data: { provider: 'value', items: rows },
+    ...extra,
+  } as any;
+  // `dataSource` is a PROP of this component, not something it reads from the
+  // provider context (`ObjectGrid.tsx:371`) — the provider is what threads it
+  // through in the `SchemaRenderer` path. Passing it here is what lets the grid
+  // fetch `objectSchema` for inline data (`ObjectGrid.tsx:967`), which is where
+  // the object's action declarations come from.
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} dataSource={makeAdapter(objectSchema) as any} />
+    </ActionProvider>,
+  );
+}
+
+const settled = async () => {
+  await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+};
+
+beforeEach(() => {
+  // The `columnState` seed falls back to localStorage per storage key; a
+  // leaked entry would make the next case pass for the wrong reason.
+  localStorage.clear();
+});
+
+describe('the renderer still reads all three (objectui#5091 kept every read site)', () => {
+  it('columnState.order still reorders the columns', async () => {
+    const { container } = renderGrid({ id: 'ordered', columnState: { order: ['email', 'name'] } });
+    await settled();
+    const headers = Array.from(container.querySelectorAll('thead th')).map((th) => th.textContent?.trim());
+    // The two data columns, in the order the HOST's saved state asked for.
+    expect(headers.filter((h) => h === 'Name' || h === 'Email')).toEqual(['Email', 'Name']);
+  });
+
+  it('columnState absent leaves the authored column order alone', async () => {
+    const { container } = renderGrid({ id: 'unordered' });
+    await settled();
+    const headers = Array.from(container.querySelectorAll('thead th')).map((th) => th.textContent?.trim());
+    expect(headers.filter((h) => h === 'Name' || h === 'Email')).toEqual(['Name', 'Email']);
+  });
+
+  it('hideRowHeightToggle still hides the toolbar toggle a declared rowHeight offers', async () => {
+    const shown = renderGrid({ id: 'toggle-on', rowHeight: 'compact' });
+    await settled();
+    expect(screen.getByTitle(/^Row height:/)).toBeInTheDocument();
+    shown.unmount();
+
+    renderGrid({ id: 'toggle-off', rowHeight: 'compact', hideRowHeightToggle: true });
+    await settled();
+    expect(screen.queryByTitle(/^Row height:/)).toBeNull();
+  });
+
+  it('maxInlineRowActions still widens the inline-button budget', async () => {
+    const actions = [
+      { name: 'approve', label: 'Approve', variant: 'primary' },
+      { name: 'reject', label: 'Reject', variant: 'primary' },
+    ];
+    const rowActions = ['approve', 'reject'];
+
+    // Default budget (the `?? 1` at the read site): one primary inline, the
+    // other folded into the "⋮" menu, which renders nothing until it is opened.
+    const single = renderGrid({ id: 'budget-default', rowActions }, { actions });
+    await settled();
+    await waitFor(() => expect(screen.getAllByTestId('row-action-inline-approve').length).toBe(rows.length));
+    expect(screen.queryAllByTestId('row-action-inline-reject')).toEqual([]);
+    single.unmount();
+
+    // The host raises the budget to two: both render inline.
+    renderGrid({ id: 'budget-two', rowActions, maxInlineRowActions: 2 }, { actions });
+    await settled();
+    await waitFor(() => expect(screen.getAllByTestId('row-action-inline-reject').length).toBe(rows.length));
+    expect(screen.getAllByTestId('row-action-inline-approve').length).toBe(rows.length);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2127,6 +2127,9 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
+      '@object-ui/sdui-parser':
+        specifier: workspace:*
+        version: link:../sdui-parser
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
Part of #5091 — deliberately not a closing keyword: three of the four ruled keys land here, and the fourth (`rowActionDefs`) is back with the maintainer with new evidence, below. #5091 stays open until that half is settled.

## What landed

The maintainer ruling of 2026-08-18 on #5091 put `columnState`, `hideRowHeightToggle` and `maxInlineRowActions` OUT of `GRID_QUERY_INPUTS` as non-author surface, kept every read site, and asked that the sweep tooling treat them as deliberately unlisted rather than missed. That is what this PR is:

- an exemption comment at each of the read sites in `packages/plugin-grid/src/ObjectGrid.tsx` (4 sites, `columnState` has two);
- `packages/plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx` — 16 assertions, four per key;
- an empty-frontmatter changeset: nothing is released. `GRID_QUERY_INPUTS` is byte-for-byte unchanged, so the generated `sdui.manifest.json` and `sdui-intrinsics.d.ts` are unchanged, and **every edit to `ObjectGrid.tsx` is a comment** (`git diff` on that file: 45 insertions, 0 deletions).

One dependency edge is added: `@object-ui/sdui-parser` as a **devDependency** of `plugin-grid`, so the test can pin the parser's verdict over a manifest built from the live registry rather than restating the table's contents. Same precedent as `packages/layout` (devDependency) and `packages/components`.

## What did NOT land, and the evidence for stopping

The ruling's fourth line reads: "`rowActionDefs` → into `GRID_QUERY_INPUTS` (the symmetric partner `bulkActionDefs` is already declared; this is the pure omission)."

That premise does not survive measurement. The two keys are asymmetric by construction, in three independent places:

1. **The contract rejects it by name.** `ObjectGridPropsSchema` in `@objectstack/spec@17.0.0` is a `strictObject`. It accepts `bulkActionDefs` and answers `unrecognized_keys` for `rowActionDefs`:

   ```
   node --input-type=module -e "import {ComponentPropsMap} from '@objectstack/spec/ui';
     const s=ComponentPropsMap['object-grid'];
     console.log('bulkActionDefs', s.safeParse({objectName:'a',bulkActionDefs:[]}).success);   // true
     console.log('rowActionDefs',  s.safeParse({objectName:'a',rowActionDefs:[]}).success);"   // false
   ```

2. **The producer derives it; it is not an authored key.** `packages/app-shell/src/views/ObjectView.tsx:1924` builds the grid's `rowActionDefs` from `objectDef.actions` filtered by `locations.includes('list_item')`, then localises them — its own comment says so. Two lines below, `bulkActionDefs` is passed straight through from the view author (`viewDef.bulkActionDefs ?? listSchema.bulkActionDefs`), with a comment explaining why that one is not resolved there. The authored way to put an action on a row is `locations: ['list_item']` on the object's action, plus the declared legacy `rowActions` name list.

3. **`@object-ui/types` says the same.** `ObjectGridSchema` declares `bulkActionDefs` (`packages/types/src/objectql.ts:874`) and no `rowActionDefs` — which is why the read is a cast in the first place.

Declaring it here alone would therefore publish, to the designer panel and to `sdui-intrinsics.d.ts`, a key the save gate refuses by name. Measured rather than argued — with the declaration added as a probe, the repo-wide forward-parity gate fails:

```
FAIL apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
 > object-grid declares no top-level input the spec does not accept
AssertionError: expected [ 'rowActionDefs' ] to deeply equal []
```

`OFF_SPEC_EXEMPTIONS` in that gate is deliberately empty today, and its own doctrine names this case: "A key the renderer reads is a key worth declaring SOMEWHERE — it is not a key worth declaring in a place the contract rejects." Getting past it needs a decision that shapes the public contract (declare `rowActionDefs` upstream in `ObjectGridPropsSchema` first, or rule the key non-author surface like the other three), so this PR does not guess. See the report on #5091.

`schema.onNavigate` is untouched — #5234 owns it.

## Reverse verification (predicted before running, both matched)

| ablation | predicted | observed |
| --- | --- | --- |
| drop the `hideRowHeightToggle` read | exactly 1 red — the toggle behaviour pin; the declaration/spec/parser pins stay green (independent halves) | `1 failed \| 15 passed`, the predicted test |
| declare `columnState` (the "tidy-up" the ruling forbids) | 3 red in the package suite (both tags + the parser pin), spec-rejection and behaviour pins green; 1 red in the console parity gate | `3 failed \| 13 passed` exactly those, and `expected [ 'columnState' ] to deeply equal []` in the parity gate |

No rebuild leg is owed: the root vitest config aliases `@object-ui/*` to `src` (`vitest.config.mts:245+`) and the suite imports `../ObjectGrid` relatively, so no `dist` is in the resolution path; `@objectstack/spec` is the untouched published build in `node_modules`. Both ablations were taken from the committed state and restored with `git checkout branch -- path`; both suites are green again at the head sha below.

## Gates run locally — at `cd8ea9cb`, the head of this branch

```
pnpm exec vitest run packages/plugin-grid/ --maxWorkers=2      78 files, 700 tests passed
pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
                                                               65 passed (the gate my change must not move)
pnpm --filter @object-ui/plugin-grid type-check                tsc --noEmit && tsc -p tsconfig.test.json, exit 0
pnpm --filter @object-ui/plugin-grid lint                      0 errors (638 pre-existing warnings)
node scripts/check-phantom-dependencies.mjs                    OK (covers the new devDependency)
node scripts/check-package-self-import.mjs                     OK
node scripts/check-control-bytes.mjs                           OK
node scripts/check-lint-coverage.mjs                           OK
node scripts/check-type-check-coverage.mjs                     OK
node scripts/check-changeset-presence.mjs                      OK — empty frontmatter, the explicit exemption
node scripts/check-changeset-no-major.mjs                      OK
node scripts/check-changeset-fixed.mjs                         OK
```

Declared narrowing: `check:published-dist` was **not** run locally — it builds every published package and exceeded the budget on a container shared with other agents. The added file is in `packages/plugin-grid/src/__tests__/`, the directory `packages/plugin-grid/tsconfig.json` already excludes for exactly that gate, alongside 57 existing files. CI runs it.

## The reusable pattern (for #5097 and #5102)

Those two are this shape one and two packages over, so this is written to be copied verbatim.

**At the read site**, four elements, in this order: the verdict in the words "deliberately absent from `GRID_QUERY_INPUTS`" (so a search from the manifest side lands on a statement, not silence); the ruling that made it deliberate (maintainer, date, issue); **who writes the key**, as `file:line` — that is what makes "non-author" checkable rather than an opinion; and the contract's own verdict on the key, plus a pointer to the test.

**In one test per package**, four assertions per key, and one declared control key that must pass all of them the other way:

1. not published, **on every tag the renderer is registered under** (one renderer registered twice is two chances to disagree with itself);
2. the spec rejects it **by name** — assert the key appears in `unrecognized_keys` on an otherwise legal fixture, never a whole-document `success`, which would confuse "this key is refused" with "this document is well-formed";
3. the real validator reports `unknown-prop` for it, over a manifest built from the **live registry** — this is the ruled outcome, and pinning it is what stops a later tidy-up from declaring the key to silence a warning;
4. the renderer **still reads it** — deleting a read is the one move that silently blanks a stored document, and it is what a reader of "non-author surface" is most likely to think is the tidy finish.

**Nothing is owed to the repo-wide gate.** `registry-inputs-spec-parity` derives its expectations from `ComponentPropsMap`, so a key the spec does not declare is never demanded in the reverse direction — a non-author key needs no exemption entry there, only a package-level test that says out loud that it stays unlisted. The exemption list is for the opposite case: a key that IS declared while the contract refuses it, which is precisely why `rowActionDefs` could not be quietly folded in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_