### PR TITLE
fix(auth,app-shell): purge the signed-out principal's client caches and key the metadata seed by session

### DIFF
--- a/.changeset/signout-purges-principal-caches-5198.md
+++ b/.changeset/signout-purges-principal-caches-5198.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/auth': patch
+'@object-ui/app-shell': patch
+---
+
+Sign-out now drops the client-side caches that belonged to the session it ends,
+and the metadata seed cache is keyed by session identity.
+
+`sessionStorage` is per-tab, not per-session, and no sign-out call site reloads
+the page — so the `objectui:metadata:*` entries (the app list the server
+permission-filters per session) and the active-organization id survived into
+whatever happened next in that tab. A second person signing in on a shared,
+kiosk or handover browser was seeded with the previous user's filtered app list.
+Organization scoping did not close this: two users in the same organization
+computed the same cache key.
+
+`AuthProvider.signOut()` now purges the `objectui:metadata:` entries and clears
+`ActiveOrganizationStorage` (and the in-memory organization block) on both the
+success and failure paths, and `MetadataProvider` keys each entry by a
+fingerprint of the session token, so an entry that escapes the purge is
+unreadable by the next principal rather than merely undeleted. Entries left by
+another principal are deleted the first time a console mounts.

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
 } from 'react';
 import { expandViewContainer } from '@objectstack/spec/ui';
-import { ActiveOrganizationStorage, useAuth } from '@object-ui/auth';
+import { ActiveOrganizationStorage, TokenStorage, useAuth } from '@object-ui/auth';
 import { type ObjectStackAdapter } from '@object-ui/data-objectstack';
 import { normalizeSchemaReferenceKeys } from '@object-ui/core';
 import { resolveInlineMode } from '@object-ui/plugin-form';
@@ -112,25 +112,123 @@ function activeOrgScope(): string {
   }
 }
 
-/** `objectui:metadata:<type>:<orgId>` — see {@link activeOrgScope}. */
-function sessionKeyFor(type: string): string {
-  return `${SESSION_STORAGE_PREFIX}${type}:${activeOrgScope()}`;
+/**
+ * Storage scope for "nobody is signed in" — see {@link principalScope}. Shares
+ * the `@` convention with {@link NO_ORG_SCOPE}; {@link fingerprintToken} emits
+ * base-36 digits only, so a real principal can never produce it.
+ */
+const ANON_PRINCIPAL = '@anon';
+
+/**
+ * 64 bits of non-reversible key material derived from the session token — two
+ * FNV-1a passes with different constants and finalizers, each emitted as a
+ * zero-padded base-36 word so the halves cannot re-associate into a colliding
+ * pair.
+ *
+ * Deliberately NOT `crypto.subtle.digest`: that is ASYNC and this value is
+ * needed synchronously on the mount path. It is not standing in for a security
+ * primitive either — the token itself already sits in same-origin
+ * `localStorage`, so hashing hides nothing from anyone who can read this key.
+ * It exists so the key can DISCRIMINATE principals without printing a live
+ * credential into a storage key name.
+ */
+function fingerprintToken(token: string): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0xc2b2ae35;
+  for (let i = 0; i < token.length; i += 1) {
+    const code = token.charCodeAt(i);
+    h1 = Math.imul(h1 ^ code, 0x01000193);
+    h2 = Math.imul(h2 ^ code, 0x85ebca6b);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 15), 0x2545f491);
+  h2 = Math.imul(h2 ^ (h2 >>> 13), 0x27d4eb2f);
+  const word = (h: number) => (h >>> 0).toString(36).padStart(7, '0');
+  return `${word(h1)}${word(h2)}`;
 }
 
 /**
- * Drop the pre-#4486 unscoped entry (`objectui:metadata:<type>`).
+ * Fingerprint of the session this cache was filled under (objectui#5198).
  *
- * Re-keying alone only fixes tabs going FORWARD: a tab that was already open
- * across the upgrade still holds an org-blind blob under the old key. Nothing
- * reads that key any more, so it is inert — but it is another organization's
- * app list sitting in storage, and the cheapest correct answer to "does already
- * cached data need invalidating on upgrade" is to delete it the first time the
- * new code looks.
+ * `sessionStorage` is per-TAB, not per-session, and no sign-out call site
+ * reloads the page — so signing out and signing a DIFFERENT person in inside
+ * the same tab used to seed them from the previous user's entry. What sits
+ * there is that user's PERMISSION-FILTERED app list (the server filters
+ * `GET /api/v1/meta/:type` per session), which makes it a cross-principal
+ * disclosure rather than ordinary staleness. Org-scoping does not close it:
+ * two users in the SAME org compute the same {@link activeOrgScope}.
+ *
+ * `AuthProvider.signOut` purges these entries, and that is the commissioned
+ * fix; this scope is the half that does not depend on remembering it. An entry
+ * written under one session is not AT the key the next session computes, so it
+ * is unreadable by construction however sign-out paths evolve.
+ *
+ * Why the TOKEN rather than `useAuth().user?.id` — the same reason
+ * {@link activeOrgScope} reads storage instead of the context: the user
+ * resolves ASYNCHRONOUSLY (`AuthProvider` fetches the session after mount), so
+ * at seed time, which is the entire point of this cache, it is still `null`
+ * and every boot would miss its own entry. `TokenStorage` is the one identity
+ * already correct synchronously at mount, and it is the SAME credential the
+ * request that filled the cache authenticated with — so, exactly as with the
+ * tenant scope, the key cannot claim a principal the server did not filter for.
+ *
+ * A token ROTATION (impersonation, objectui#4467) changes the fingerprint,
+ * which is correct — the principal genuinely changed. The cost of any change
+ * here is one cache MISS, i.e. a refetch, never stale data.
+ *
+ * Client-local by construction: no new field on the session response and no
+ * extra request — see the issue's scope ruling.
  */
-function dropLegacyUnscopedEntry(type: string): void {
+function principalScope(): string {
+  let token: string | null = null;
+  try {
+    token = TokenStorage.get();
+  } catch {
+    /* SSR / storage unavailable */
+  }
+  return token ? fingerprintToken(token) : ANON_PRINCIPAL;
+}
+
+/**
+ * `objectui:metadata:<type>:<orgId>:<principal>` — see {@link activeOrgScope}
+ * and {@link principalScope}. Both scopes come from the same client-local
+ * storage the request that filled the entry tenanted and authenticated itself
+ * with, so a key can never describe a principal/tenant pair the server did not
+ * filter for.
+ */
+function sessionKeyFor(type: string): string {
+  return `${SESSION_STORAGE_PREFIX}${type}:${activeOrgScope()}:${principalScope()}`;
+}
+
+/**
+ * Delete every seed entry belonging to a principal other than the one reading
+ * now — the pre-#4486 unscoped entry (`objectui:metadata:<type>`), the
+ * pre-#5198 principal-blind one (`objectui:metadata:<type>:<orgId>`), and
+ * anything a previous user of this tab left behind.
+ *
+ * Re-keying alone only fixes tabs going FORWARD: a tab already open across the
+ * upgrade — or across a sign-out on a build without the purge — still holds
+ * the older blob under its old key. Nothing reads those keys any more, so they
+ * are inert; but an inert blob is still another organization's (objectui#4486)
+ * or another person's (objectui#5198) app list sitting in storage, and the
+ * cheapest correct answer to "does already cached data need invalidating" is to
+ * delete it the first time the new code looks.
+ *
+ * Entries of the CURRENT principal are kept whatever their org: those are this
+ * user's own other workspaces, which #4486 already keys correctly and which a
+ * switch back is entitled to seed from.
+ */
+function dropForeignPrincipalEntries(): void {
   if (typeof sessionStorage === 'undefined') return;
   try {
-    sessionStorage.removeItem(SESSION_STORAGE_PREFIX + type);
+    const mine = `:${principalScope()}`;
+    // Snapshot the keys first (`Object.keys`) — removing entries during a live
+    // index walk shifts the ones behind it, skipping half of them. Same idiom
+    // as the `MarketplacePackagePage` purge loop.
+    for (const key of Object.keys(sessionStorage)) {
+      if (key.startsWith(SESSION_STORAGE_PREFIX) && !key.endsWith(mine)) {
+        sessionStorage.removeItem(key);
+      }
+    }
   } catch {
     /* storage unavailable */
   }
@@ -752,7 +850,7 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
     // Session-cached apps are PUBLISHED-world data — seeding them while in
     // draft preview would flash the wrong universe before the fetch lands.
     const cached = previewDrafts ? null : loadFromSession('app');
-    dropLegacyUnscopedEntry('app');
+    dropForeignPrincipalEntries();
     // A cached EMPTY list is a MISS, not a hit (objectui#4486).
     //
     // `[]` is truthy, so an empty cached list used to take this branch and

--- a/packages/app-shell/src/providers/__tests__/MetadataProvider.crossPrincipalSeed.test.tsx
+++ b/packages/app-shell/src/providers/__tests__/MetadataProvider.crossPrincipalSeed.test.tsx
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5198 — the seed cache belongs to ONE principal.
+ *
+ * ## The invariant
+ *
+ * User A signs in, their app list is cached, A signs out, user B signs in IN
+ * THE SAME TAB: a `useMetadata().apps` read in B's seed window must never
+ * return A's list.
+ *
+ * That is a different boundary from objectui#4486, and org-scoping deliberately
+ * does not close it — the two users here are in the SAME organization, so they
+ * compute the same org scope. What sits in storage is the PERMISSION-FILTERED
+ * list (the server filters `GET /api/v1/meta/:type` per session), so the reader
+ * is a different principal seeing what the previous person was allowed to see:
+ * a cross-principal disclosure, not staleness. `sessionStorage` is per-TAB, not
+ * per-session, and no sign-out call site reloads the page, so nothing evicted
+ * it.
+ *
+ * ## Why the whole stack is rendered here
+ *
+ * The two halves of the fix live in different packages — the purge in
+ * `AuthProvider.signOut` (`@object-ui/auth`) and the principal-scoped key in
+ * `MetadataProvider` (`@object-ui/app-shell`) — and `app-shell` depends on
+ * `auth`, so the storage prefix cannot be a shared constant without a cycle.
+ * Filling the cache by RUNNING the provider and emptying it by signing out
+ * through the real provider is what keeps the two spellings from drifting: a
+ * prefix that changes on either side fails here rather than purging nothing.
+ * Nothing writes `sessionStorage` by hand, so these tests cannot silently agree
+ * with a wrong key format.
+ *
+ * ## The two halves, pinned separately
+ *
+ * 1. Sign-out purges what it cached (the commissioned fix).
+ * 2. An entry that ESCAPES the purge — a tab open across the upgrade, a
+ *    session ended by expiry or by another tab — is unreadable anyway, because
+ *    the key carries the session fingerprint. The counter-pin below keeps that
+ *    from being satisfied by disabling the cache.
+ */
+
+import React, { useEffect } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, cleanup } from '@testing-library/react';
+import {
+  ActiveOrganizationStorage,
+  AuthProvider,
+  TokenStorage,
+  useAuth,
+  type AuthClient,
+  type AuthContextValue,
+} from '@object-ui/auth';
+import { MetadataProvider, useMetadata } from '../MetadataProvider';
+
+const ORG = { id: 'org_a', name: 'Acme', slug: 'acme' };
+
+interface AppItem {
+  name: string;
+}
+
+/**
+ * The auth double. It implements the methods the provider reaches, and it
+ * reproduces the one side effect that matters here: the REAL client writes the
+ * session token to `TokenStorage` on sign-in and clears it on sign-out
+ * (`createAuthClient.ts` — `TokenStorage.set(payload.session.token)` and, in
+ * `signOut`, `TokenStorage.clear()` before any rethrow).
+ */
+function authClientFor(user: { id: string; name: string }, token: string): AuthClient {
+  const account = { id: user.id, name: user.name, email: `${user.id}@test.com` };
+  return {
+    getSession: vi.fn().mockResolvedValue({ user: account, session: { token } }),
+    signIn: vi.fn().mockImplementation(async () => {
+      TokenStorage.set(token);
+      return { user: account, session: { token } };
+    }),
+    signOut: vi.fn().mockImplementation(async () => {
+      TokenStorage.clear();
+    }),
+    // Same org for both people — that is the point of the card.
+    listOrganizations: vi.fn().mockResolvedValue([ORG]),
+    getActiveOrganization: vi.fn().mockResolvedValue(ORG),
+    setActiveOrganization: vi.fn().mockResolvedValue(ORG),
+    getActiveMember: vi.fn().mockResolvedValue({
+      id: `mem_${user.id}`, organizationId: ORG.id, userId: user.id, role: 'member',
+    }),
+  } as unknown as AuthClient;
+}
+
+/**
+ * `apps: 'pending'` returns a promise that never settles — that IS the seed
+ * window: the provider has whatever the cache gave it and nothing else.
+ *
+ * The adapter refuses when no bearer is stored, exactly as the server does
+ * (401) for the metadata requests `MetadataProvider` fires after a sign-out.
+ * Without that, the double would answer a signed-out fetch and cache a list
+ * nobody could have been served — a phantom this file must not create.
+ */
+function makeAdapter(opts: { apps: AppItem[] | 'pending' }) {
+  return {
+    clearCache: vi.fn(),
+    getClient: () => ({
+      meta: {
+        getItems: (type: string) => {
+          if (!TokenStorage.get()) return Promise.reject(new Error('401 Unauthorized'));
+          if (type !== 'app') return Promise.resolve({ type, items: [] });
+          if (opts.apps === 'pending') return new Promise<never>(() => {});
+          return Promise.resolve({ type, items: opts.apps });
+        },
+        getItem: () => Promise.resolve({ item: null }),
+      },
+    }),
+  } as unknown as Parameters<typeof MetadataProvider>[0]['adapter'];
+}
+
+/**
+ * Holder + effect rather than a bare outer assignment during render — the
+ * pattern the other provider tests use and what the react-compiler lint rule
+ * requires.
+ */
+const authRef: { current: AuthContextValue | null } = { current: null };
+
+function Probe() {
+  const auth = useAuth();
+  const { apps, loading } = useMetadata();
+  useEffect(() => {
+    authRef.current = auth;
+  }, [auth]);
+  return (
+    <div>
+      <span data-testid="apps">{apps.map((a: AppItem) => a.name).join(',')}</span>
+      <span data-testid="loading">{String(loading)}</span>
+    </div>
+  );
+}
+
+function renderConsole(client: AuthClient, adapter: ReturnType<typeof makeAdapter>) {
+  return render(
+    <AuthProvider authUrl="/api/auth" client={client}>
+      <MetadataProvider adapter={adapter}>
+        <Probe />
+      </MetadataProvider>
+    </AuthProvider>,
+  );
+}
+
+/** Let every pending microtask and the provider's `queueMicrotask` bump settle. */
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+/** Every `objectui:metadata:*` key currently in sessionStorage. */
+function metadataKeys(): string[] {
+  return Object.keys(sessionStorage).filter((k) => k.startsWith('objectui:metadata:'));
+}
+
+/**
+ * Put the tab in the state a returning browser is in: a bearer for `token` and
+ * an already-known active organization.
+ *
+ * Seeding `ActiveOrganizationStorage` before the render is not decoration — it
+ * is what makes both principals compute the SAME org scope, which is the
+ * situation the card is about (`AuthProvider` resolves the active org
+ * asynchronously, so a mount that has never seen this browser before would
+ * compute the no-org scope and miss for a reason that has nothing to do with
+ * identity). Same modelling as `primeCacheFor` in
+ * `MetadataProvider.orgScopedCache.test.tsx`.
+ */
+function enterTabAs(token: string): void {
+  ActiveOrganizationStorage.set(ORG.id);
+  TokenStorage.set(token);
+}
+
+/**
+ * Sign `user` in and let the console cache their app list — by running the real
+ * provider until its fetch lands, never by writing storage by hand.
+ */
+async function signInAndCache(
+  user: { id: string; name: string },
+  token: string,
+  apps: AppItem[],
+): Promise<void> {
+  enterTabAs(token);
+  const view = renderConsole(authClientFor(user, token), makeAdapter({ apps }));
+  await waitFor(() =>
+    expect(view.getByTestId('apps').textContent).toBe(apps.map((a) => a.name).join(',')),
+  );
+  view.unmount();
+}
+
+beforeEach(() => {
+  authRef.current = null;
+  sessionStorage.clear();
+  localStorage.clear();
+  TokenStorage.clear();
+  ActiveOrganizationStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('MetadataProvider seed cache is per-principal (objectui#5198)', () => {
+  it('does not seed user B from user A’s list after A signs out in the same tab', async () => {
+    // A signs in and the console caches the list the server filtered for A.
+    enterTabAs('tok-alice');
+    const view = renderConsole(
+      authClientFor({ id: 'u_alice', name: 'Alice' }, 'tok-alice'),
+      makeAdapter({ apps: [{ name: 'setup' }, { name: 'crm' }] }),
+    );
+    await waitFor(() => expect(view.getByTestId('apps').textContent).toBe('setup,crm'));
+    expect(metadataKeys()).not.toEqual([]);
+    expect(ActiveOrganizationStorage.get()).toBe('org_a');
+
+    // A signs out — no page reload, exactly like every sign-out call site.
+    await act(async () => {
+      await authRef.current!.signOut();
+    });
+
+    // The commissioned fix, measured against the REAL writer's keys: both
+    // stores are empty, so the prefix the purge sweeps and the prefix the
+    // cache writes cannot have drifted apart.
+    expect(metadataKeys()).toEqual([]);
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+    view.unmount();
+
+    // B signs in in the SAME tab. Same organization, so #4486's org scope is
+    // identical; the fetch never lands, so anything rendered came from cache.
+    TokenStorage.set('tok-bob');
+    const bob = renderConsole(
+      authClientFor({ id: 'u_bob', name: 'Bob' }, 'tok-bob'),
+      makeAdapter({ apps: 'pending' }),
+    );
+    await settle();
+
+    // The invariant. Before the fix this read 'setup,crm' — Alice's
+    // permission-filtered list, rendered for Bob.
+    expect(bob.getByTestId('apps').textContent).toBe('');
+    // And the honest posture while B's own list is in flight is "still
+    // loading", not "this user has no apps".
+    expect(bob.getByTestId('loading').textContent).toBe('true');
+  });
+
+  it('is unreadable by the next principal even when the purge never ran', async () => {
+    // The half that does not depend on remembering the cleanup: a tab that was
+    // open across the upgrade, a session ended by expiry, or a sign-out
+    // performed in another tab all leave the entry in place.
+    await signInAndCache({ id: 'u_alice', name: 'Alice' }, 'tok-alice', [
+      { name: 'setup' },
+      { name: 'crm' },
+    ]);
+    expect(metadataKeys()).not.toEqual([]);
+
+    // No signOut() anywhere — Bob's session simply replaces Alice's. The org
+    // id is untouched, so both consoles resolve the SAME org scope: what makes
+    // the seed miss below is the identity, not objectui#4486's tenant key.
+    expect(ActiveOrganizationStorage.get()).toBe(ORG.id);
+    TokenStorage.set('tok-bob');
+    const bob = renderConsole(
+      authClientFor({ id: 'u_bob', name: 'Bob' }, 'tok-bob'),
+      makeAdapter({ apps: 'pending' }),
+    );
+    await settle();
+
+    expect(bob.getByTestId('apps').textContent).toBe('');
+    expect(bob.getByTestId('loading').textContent).toBe('true');
+    // Inert is not enough — it is another person's app list sitting in storage,
+    // so it is deleted the first time a different principal's console looks.
+    expect(metadataKeys()).toEqual([]);
+  });
+
+  it('still seeds instantly for the SAME principal (the cache is not just disabled)', async () => {
+    // The counter-pin: deleting or disabling the cache would satisfy both tests
+    // above and destroy the optimization the cache exists for.
+    await signInAndCache({ id: 'u_alice', name: 'Alice' }, 'tok-alice', [
+      { name: 'setup' },
+      { name: 'crm' },
+    ]);
+
+    // Same person, same tab, fresh mount, a fetch that never lands: everything
+    // shown here came from the seed.
+    enterTabAs('tok-alice');
+    const again = renderConsole(
+      authClientFor({ id: 'u_alice', name: 'Alice' }, 'tok-alice'),
+      makeAdapter({ apps: 'pending' }),
+    );
+
+    await waitFor(() => expect(again.getByTestId('apps').textContent).toBe('setup,crm'));
+    expect(again.getByTestId('loading').textContent).toBe('false');
+  });
+});

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -13,6 +13,68 @@ import { AuthCtx, type AuthContextValue } from './AuthContext';
 import { createAuthClient, TokenStorage } from './createAuthClient';
 import { ActiveOrganizationStorage } from './createAuthenticatedFetch';
 
+/**
+ * Prefix of every `MetadataProvider` seed entry in `sessionStorage`
+ * (`objectui:metadata:<type>:<orgId>:<principal>`, `@object-ui/app-shell`).
+ *
+ * Spelled out here rather than imported: `@object-ui/app-shell` depends on
+ * `@object-ui/auth`, so the constant cannot travel in that direction without a
+ * dependency cycle. The two ends are held together by BEHAVIOUR instead of by
+ * a shared symbol — `MetadataProvider.crossPrincipalSeed.test.tsx` fills the
+ * cache by running the real `MetadataProvider` and empties it by signing out
+ * through this provider, so a prefix that drifts on either side fails there
+ * rather than silently purging nothing.
+ */
+const METADATA_SEED_CACHE_PREFIX = 'objectui:metadata:';
+
+/**
+ * Drop the client-side caches that belong to the session being ended
+ * (objectui#5198).
+ *
+ * `sessionStorage` is per-TAB, not per-session, and no sign-out call site
+ * reloads the page — `AppSidebar`, `AppHeader`, `UserMenu` and
+ * `RemediationOverlay` all just call `signOut()` and let the SPA keep running.
+ * So without this the next person to sign in in the same tab (a shared or
+ * kiosk browser, a handover, a support session) is SEEDED from the previous
+ * user's entry, and what is in it is that user's PERMISSION-FILTERED app list —
+ * the server filters `GET /api/v1/meta/:type` per session. That makes it a
+ * cross-principal disclosure, not ordinary staleness, which is why it is
+ * cleared here and not left to the tab being closed.
+ *
+ * Two properties of the loop are load-bearing:
+ *
+ *  - It matches by PREFIX. The keys are org-scoped (objectui#4486), so a purge
+ *    that recomputed the scope would depend on `ActiveOrganizationStorage`
+ *    still holding the org those entries were written under. A prefix sweep has
+ *    no such dependency and therefore no ordering hazard of its own.
+ *  - It runs BEFORE `ActiveOrganizationStorage.clear()` anyway, so the ordering
+ *    stays correct for anything scope-derived added later: clearing the org
+ *    first would leave such a purge computing the no-org scope and deleting
+ *    nothing while the real entries survived.
+ *
+ * `MetadataProvider` additionally keys the entry by session fingerprint, so a
+ * blob that escapes this purge (a tab open across the upgrade, a session ended
+ * by expiry rather than by this call) is unreadable rather than merely
+ * undeleted. The two halves are deliberately independent.
+ */
+function purgeSignedOutClientCaches(): void {
+  if (typeof sessionStorage !== 'undefined') {
+    try {
+      // Snapshot the keys first (`Object.keys`) — removing entries during a
+      // live index walk shifts the ones behind it and skips half of them.
+      // Same idiom as the `MarketplacePackagePage` purge loop.
+      for (const key of Object.keys(sessionStorage)) {
+        if (key.startsWith(METADATA_SEED_CACHE_PREFIX)) {
+          sessionStorage.removeItem(key);
+        }
+      }
+    } catch {
+      /* storage unavailable */
+    }
+  }
+  ActiveOrganizationStorage.clear();
+}
+
 export interface AuthProviderProps extends AuthProviderOptions {
   children: React.ReactNode;
   /**
@@ -276,9 +338,25 @@ export function AuthProvider({
       setUser(null);
       setSession(null);
       setError(null);
+      // The organization block is the previous principal's data too: the list
+      // is the workspaces THAT user belongs to (the switcher renders it), and
+      // a lingering `activeOrganization` would additionally suppress the
+      // re-resolution below — `refreshOrganizations` only asks the server for
+      // the active org `if (orgs.length > 0 && !activeOrganization)`, so the
+      // next sign-in in this tab would inherit the previous user's active
+      // workspace in context while storage had (correctly) forgotten it.
+      // `activeMember` follows from the effect that watches `activeOrganization`.
+      // Same pairing `deleteOrganization` / `leaveOrganization` already use in
+      // this file: drop the in-memory reference and the stored id together.
+      setOrganizations([]);
+      setActiveOrganization(null);
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)));
     } finally {
+      // Unconditional: `createAuthClient.signOut` clears `TokenStorage` BEFORE
+      // it rethrows a server error, so a failed call still leaves this tab
+      // without a session — the caches it authenticated for must go with it.
+      purgeSignedOutClientCaches();
       setIsLoading(false);
     }
   }, [client]);

--- a/packages/auth/src/__tests__/signOut-client-cache-purge-5198.test.tsx
+++ b/packages/auth/src/__tests__/signOut-client-cache-purge-5198.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * objectui#5198 — sign-out drops the client-side caches of the session it ends.
+ *
+ * ## The defect
+ *
+ * `sessionStorage` is per-TAB, not per-session, and no sign-out call site in
+ * the console reloads the page (`AppSidebar`, `AppHeader`, `UserMenu` and
+ * `RemediationOverlay` all just call `signOut()` and let the SPA keep running).
+ * So everything `MetadataProvider` cached under `objectui:metadata:*` — the
+ * app list the server PERMISSION-FILTERED for that session — plus the active
+ * organization id in `localStorage` survived into whatever happened next in
+ * that tab. On a shared or kiosk browser, a handover, or a support session,
+ * "whatever happened next" is a DIFFERENT person signing in, and they were
+ * seeded from the previous user's list. Cross-principal, not merely stale.
+ *
+ * ## What is pinned here, and what is pinned elsewhere
+ *
+ * This file is the unit half: `signOut()` empties both stores, on the failure
+ * path too, and in an order that stays correct. The end-to-end pin — user A
+ * signs in, the list is cached by the real provider, A signs out, user B signs
+ * in in the same tab and must not read A's list — lives in app-shell
+ * (`MetadataProvider.crossPrincipalSeed.test.tsx`) because it needs the real
+ * cache writer. That is also what keeps the storage prefix spelled here
+ * honest: `@object-ui/app-shell` depends on `@object-ui/auth`, so the constant
+ * cannot be imported in this direction and the two ends are held together by
+ * behaviour instead.
+ */
+
+import React, { useEffect } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, waitFor, cleanup } from '@testing-library/react';
+import { AuthProvider } from '../AuthProvider';
+import { useAuth } from '../useAuth';
+import { TokenStorage } from '../createAuthClient';
+import { ActiveOrganizationStorage } from '../createAuthenticatedFetch';
+import type { AuthClient } from '../types';
+import type { AuthContextValue } from '../AuthContext';
+
+const ORG = { id: 'org_a', name: 'Acme', slug: 'acme' };
+
+/**
+ * Implements the handful of methods the provider reaches on these paths — the
+ * same shape (and the same one-place cast) as `AuthProvider.test.tsx` and
+ * every other double in this package.
+ *
+ * `signOut` clears `TokenStorage` because the REAL client does, in
+ * `createAuthClient.ts`: `betterAuth.signOut()`, then `TokenStorage.clear()`,
+ * then the rethrow — which is why the clear happens even on the error path.
+ */
+function createMockClient(overrides: Partial<AuthClient> = {}): AuthClient {
+  return {
+    signIn: vi.fn().mockResolvedValue({
+      user: { id: 'u_alice', name: 'Alice', email: 'alice@test.com' },
+      session: { token: 'tok-alice' },
+    }),
+    signOut: vi.fn().mockImplementation(async () => {
+      TokenStorage.clear();
+    }),
+    getSession: vi.fn().mockResolvedValue({
+      user: { id: 'u_alice', name: 'Alice', email: 'alice@test.com' },
+      session: { token: 'tok-alice' },
+    }),
+    listOrganizations: vi.fn().mockResolvedValue([ORG]),
+    getActiveOrganization: vi.fn().mockResolvedValue(ORG),
+    setActiveOrganization: vi.fn().mockResolvedValue(ORG),
+    getActiveMember: vi.fn().mockResolvedValue({
+      id: 'mem_1', organizationId: ORG.id, userId: 'u_alice', role: 'owner',
+    }),
+    ...overrides,
+  } as unknown as AuthClient;
+}
+
+/**
+ * Holder + effect rather than a bare outer assignment during render — the
+ * pattern the other console tests use and what the react-compiler lint rule
+ * requires.
+ */
+const authRef: { current: AuthContextValue | null } = { current: null };
+
+function Probe() {
+  const auth = useAuth();
+  useEffect(() => {
+    authRef.current = auth;
+  }, [auth]);
+  return (
+    <div>
+      <span data-testid="user">{auth.user?.name ?? 'none'}</span>
+      <span data-testid="orgs">{auth.organizations.map((o) => o.name).join(',')}</span>
+      <span data-testid="active-org">{auth.activeOrganization?.name ?? 'none'}</span>
+    </div>
+  );
+}
+
+/** Render a signed-in console and wait until the org block has resolved. */
+async function renderSignedIn(client: AuthClient) {
+  const view = render(
+    <AuthProvider authUrl="/api/auth" client={client}>
+      <Probe />
+    </AuthProvider>,
+  );
+  await waitFor(() => expect(view.getByTestId('user').textContent).toBe('Alice'));
+  await waitFor(() => expect(view.getByTestId('active-org').textContent).toBe('Acme'));
+  return view;
+}
+
+/** The state the previous session leaves behind in this tab. */
+function seedPreviousSessionCaches() {
+  sessionStorage.setItem('objectui:metadata:app:org_a:abc', JSON.stringify([{ name: 'crm' }]));
+  sessionStorage.setItem('objectui:metadata:object:org_a:abc', JSON.stringify([{ name: 'account' }]));
+  // The pre-#4486 key shape can still be present in a tab open across upgrades.
+  sessionStorage.setItem('objectui:metadata:view', JSON.stringify([{ name: 'v' }]));
+  ActiveOrganizationStorage.set('org_a');
+}
+
+/** Every `objectui:metadata:*` key currently in sessionStorage. */
+function metadataKeys(): string[] {
+  return Object.keys(sessionStorage).filter((k) => k.startsWith('objectui:metadata:'));
+}
+
+beforeEach(() => {
+  authRef.current = null;
+  sessionStorage.clear();
+  localStorage.clear();
+  TokenStorage.clear();
+  ActiveOrganizationStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('signOut purges the signed-out principal’s client caches (#5198)', () => {
+  it('removes every objectui:metadata entry and the active-org id', async () => {
+    const client = createMockClient();
+    await renderSignedIn(client);
+    seedPreviousSessionCaches();
+    sessionStorage.setItem('objectui:sidebar:collapsed', 'true');
+    localStorage.setItem('objectui:theme', 'dark');
+
+    await act(async () => {
+      await authRef.current!.signOut();
+    });
+
+    expect(metadataKeys()).toEqual([]);
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+    // Scoped to the caches of the ended session: unrelated client state — a UI
+    // preference, a theme — is nobody's permission-filtered data and stays.
+    expect(sessionStorage.getItem('objectui:sidebar:collapsed')).toBe('true');
+    expect(localStorage.getItem('objectui:theme')).toBe('dark');
+  });
+
+  it('purges even when the sign-out request FAILS', async () => {
+    // The real client clears `TokenStorage` before rethrowing, so a failed
+    // call still leaves this tab without a session — the caches that session
+    // authenticated for must not outlive it.
+    const client = createMockClient({
+      signOut: vi.fn().mockImplementation(async () => {
+        TokenStorage.clear();
+        throw new Error('network down');
+      }),
+    });
+    await renderSignedIn(client);
+    seedPreviousSessionCaches();
+
+    await act(async () => {
+      await authRef.current!.signOut();
+    });
+
+    expect(metadataKeys()).toEqual([]);
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  it('purges the metadata entries BEFORE clearing the active-org id', async () => {
+    // Ordering pin. The purge above matches by prefix and so does not read the
+    // org scope — but the keys it targets ARE org-scoped (#4486), so anything
+    // scope-derived added later would compute the no-org scope and delete
+    // nothing if the org id had already been dropped. Recording what storage
+    // looks like at the moment the org is cleared keeps that order enforced
+    // rather than merely commented.
+    const observed: string[][] = [];
+    const realClear = ActiveOrganizationStorage.clear.bind(ActiveOrganizationStorage);
+    vi.spyOn(ActiveOrganizationStorage, 'clear').mockImplementation(() => {
+      observed.push(metadataKeys());
+      realClear();
+    });
+
+    const client = createMockClient();
+    await renderSignedIn(client);
+    seedPreviousSessionCaches();
+
+    await act(async () => {
+      await authRef.current!.signOut();
+    });
+
+    expect(observed.length).toBeGreaterThan(0);
+    expect(observed[observed.length - 1]).toEqual([]);
+  });
+
+  it('drops the previous principal’s organization block from context', async () => {
+    // The list is the workspaces THAT user belongs to (the switcher renders
+    // it), and a surviving `activeOrganization` would also suppress the
+    // re-resolution for the next user: `refreshOrganizations` only asks the
+    // server for the active org `if (orgs.length > 0 && !activeOrganization)`.
+    // Same pairing `deleteOrganization` / `leaveOrganization` already use.
+    const client = createMockClient();
+    const view = await renderSignedIn(client);
+    expect(view.getByTestId('orgs').textContent).toBe('Acme');
+
+    await act(async () => {
+      await authRef.current!.signOut();
+    });
+
+    expect(view.getByTestId('orgs').textContent).toBe('');
+    expect(view.getByTestId('active-org').textContent).toBe('none');
+  });
+});


### PR DESCRIPTION
Fixes #5198

`sessionStorage` is per-TAB, not per-session, and no sign-out call site reloads the page (`AppSidebar`, `AppHeader`, `UserMenu` and `RemediationOverlay` all just call `signOut()` and let the SPA keep running). So the `objectui:metadata:*` entries `MetadataProvider` writes — the app list the server PERMISSION-filters per session — plus the active-organization id survived a sign-out into whatever happened next in that tab. When that is a different person signing in (shared or kiosk browser, handover, support session) they were seeded from the previous user's filtered list: a cross-principal disclosure, not ordinary staleness.

Org-scoping (#4486) does not close it, and the card is explicit about why: two users in the SAME organization compute the same org scope, so the seed still hits.

## What changed

**`packages/auth/src/AuthProvider.tsx` — the commissioned fix.** `signOut()` now purges every `objectui:metadata:` key by prefix and then clears `ActiveOrganizationStorage`, in a `finally` so it runs on the failure path too (the real client clears `TokenStorage` before rethrowing, so a failed sign-out still leaves the tab without a session). Two properties are load-bearing and are stated in the code:

- the sweep matches by PREFIX (the `MarketplacePackagePage` precedent), so it never has to recompute the org scope the keys were written under;
- it still runs BEFORE `ActiveOrganizationStorage.clear()`, so anything scope-derived added later cannot end up computing the no-org scope against an already-cleared org id and deleting nothing.

**`packages/app-shell/src/providers/MetadataProvider.tsx` — the error-resistant half.** Each seed entry is now keyed `objectui:metadata:` + type + org + principal, where the principal is a 64-bit non-reversible fingerprint of the session token. An entry that escapes the purge is then unreadable rather than merely undeleted, which is what the triage ruling asked for. Two details worth reviewing:

- The token, not `useAuth().user?.id` — for exactly the reason `activeOrgScope` reads storage instead of context: identity resolves ASYNCHRONOUSLY after mount, so at seed time it is still null and every boot would miss its own entry. `TokenStorage` is correct synchronously at mount and is the same credential the request that filled the cache authenticated with.
- The migration `dropLegacyUnscopedEntry` is generalized to `dropForeignPrincipalEntries`: any entry whose principal is not the one reading now is deleted the first time a console mounts. That subsumes #4486's unscoped-entry drop (still pinned) and covers sessions that ended without this purge running. Entries of the CURRENT principal survive whatever their org.

This stays **client-local** as the ruling required: no new field on the session response, no extra request, nothing beyond the client cache key. Nothing to escalate on that axis.

## Bounded in-place addition, named explicitly

`signOut()` also drops the in-memory organization block (`setOrganizations([])`, `setActiveOrganization(null)`). Same defect class, and the correct shape is already pinned by two sibling declarations in this very file: `deleteOrganization` and `leaveOrganization` both drop the in-memory reference and the stored id together. Clearing only the stored id would have desynced the pair, and a surviving `activeOrganization` also suppresses the re-resolution for the next user — `refreshOrganizations` only asks the server for the active org `if (orgs.length > 0 && !activeOrganization)`. `activeMember` follows from the effect that already watches `activeOrganization`.

## Tests

`packages/app-shell/src/providers/__tests__/MetadataProvider.crossPrincipalSeed.test.tsx` renders the real `AuthProvider` + `MetadataProvider` together, because the two halves live in packages that cannot share a constant (app-shell depends on auth, so the prefix would be a cycle). The cache is filled by RUNNING the provider and emptied by signing out through the real provider, so a prefix that drifts on either side fails there instead of purging nothing. Both principals are put in the same organization on purpose, and the test asserts the org id is unchanged at the second mount — so what makes the seed miss is identity, not #4486's tenant key.

`packages/auth/src/__tests__/signOut-client-cache-purge-5198.test.tsx` is the unit half: both stores empty, unrelated client state (a sidebar preference, a theme) untouched, purge on the failure path, and an ordering pin that records what storage looks like at the moment the org id is cleared.

`MetadataProvider.orgScopedCache.test.tsx` (#4486's six pins) is **unedited and green** — it was written key-shape-agnostic on purpose, which is what let the principal segment be added without touching it.

Verification at `92558f12d`:

- `pnpm exec eslint` on the four changed files: 0 errors (53 pre-existing warnings, unchanged).
- `pnpm --filter @object-ui/auth --filter @object-ui/app-shell run type-check`: Done for both (after building the dependency closure — a fresh worktree resolves `@object-ui/*` through `dist`).
- `pnpm exec vitest run packages/auth/ packages/app-shell/src/providers/`: 24 files, 229 tests passed.
- `pnpm exec vitest run packages/app-shell/ --shard=1/2` and `--shard=2/2`: 445 files, 4296 tests passed, 1 skipped.
- `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`, `check-lint-coverage`, `check-type-check-coverage`, `check-phantom-dependencies`, `check:self-import`, `check:i18n-keys`, `check:spec-symbols`, `check:action-forward-parity`: all green.

Reverse verification, three legs, predictions written before running and all three matched. No build step is involved on either leg: vitest aliases `@object-ui/auth` and `@object-ui/app-shell` to their `src`, so restoring a source file is visible immediately; each leg greps the restored file to prove the ablation reached the tree, and the tree is byte-identical to HEAD afterwards.

- Both halves removed (pre-fix source): 6 red / 7 green — all 4 auth pins, plus the end-to-end pin and the escaped-entry pin. The cross-principal read reproduces exactly: `expected 'setup,crm' to be ''` — Alice's list rendered for Bob.
- Only the sign-out purge removed: 5 red — the 4 auth pins and the end-to-end pin's storage assertions. The escaped-entry pin stays GREEN, which is the point of the second half.
- Only the principal key removed: 1 red — the escaped-entry pin, `expected 'setup,crm' to be ''`. The end-to-end pin stays green because the purge still runs.

Changeset: `patch` for `@object-ui/auth` and `@object-ui/app-shell`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_