### PR TITLE
fix(cli): `objectui check` reads `.json` as JSONC, so a tsconfig no longer fails the run

### DIFF
--- a/.changeset/cli-check-reads-json-as-jsonc.md
+++ b/.changeset/cli-check-reads-json-as-jsonc.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/cli': patch
+---
+
+`objectui check` reads `.json` as JSONC, so a `tsconfig.json` no longer fails the run.
+
+`check` globbed every `**/*.{json,yaml,yml}` and handed each `.json` straight to
+`JSON.parse`. A throw there is the only thing that increments the error count, and
+a non-zero error count is the only thing that calls `process.exit(1)` — so a `//`
+comment or a trailing comma, which is how TypeScript documents `tsconfig.json`,
+was reported as a malformed file and **failed the command**. Every TypeScript
+project hit this: `objectui check` exited 1 for anyone who ran it, and at this
+repository's own root it reported 64 errors, all of them `tsconfig*.json`
+(objectui#5237).
+
+`.json` on disk means JSONC in practice — `tsconfig.json`, `.eslintrc.json`,
+`devcontainer.json` and VS Code's own settings are all written that way — so the
+file is now read with `jsonc-parser`, which permits comments and trailing commas.
+No new package enters what users install: `jsonc-parser` is already a runtime
+dependency of `@object-ui/app-shell`, it is already at the version the lockfile
+resolves, and it declares no dependencies of its own.
+
+The reader is a real JSONC parser and **not** a comment-stripping regex, because
+a `//` inside a string value — a URL, say — is not a comment, and a stripper that
+cannot tell the difference corrupts valid files instead of reading them.
+
+Genuinely malformed JSON still errors and still exits 1. That needed saying in
+code as well as in tests: `jsonc-parser`'s reader is error-tolerant and returns a
+best-effort value rather than throwing, so the command consults its reported-error
+array instead of inferring success from the absence of a throw. Error output now
+names the reason and the line and column.
+
+The unknown-schema-type warning arm is deliberately untouched: it still warns, and
+it still does not affect the exit code. Files that previously died at the parse
+step now reach it, so a JSONC file carrying an unrecognised root `type` warns
+where it used to error — the verdict and the exit-code neutrality are unchanged.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
     "express-rate-limit": "^8.6.2",
     "glob": "^13.0.6",
     "js-yaml": "^5.2.3",
+    "jsonc-parser": "^3.3.1",
     "vite": "^8.2.1"
   },
   "devDependencies": {

--- a/packages/cli/src/__tests__/check-jsonc-parse.test.ts
+++ b/packages/cli/src/__tests__/check-jsonc-parse.test.ts
@@ -1,0 +1,241 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `objectui check`'s JSON parse arm (objectui#5237).
+ *
+ * `.json` on disk means JSONC in practice, and `JSON.parse` counted every
+ * `tsconfig.json` in a project as a malformed file. Because a parse failure is
+ * the only thing that increments the error count, and a non-zero error count is
+ * the only thing that calls `process.exit(1)`, the command exited 1 in every
+ * TypeScript project — 64 errors at this repository's own root.
+ *
+ * The other half of this file is the assertion that the fix did not become
+ * "never fail on anything": `jsonc-parser`'s reader is error-TOLERANT and
+ * returns a best-effort value instead of throwing, so genuinely malformed JSON
+ * only still fails because the command consults the reported-error array.
+ *
+ * Fixtures live under `os.tmpdir()`, never in the repo tree: `check()` globs
+ * every JSON file under the directory it is handed, so a fixture committed
+ * inside this workspace would be scanned by every other run of the command as
+ * well — including the repo's own `pnpm check`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { check } from '../commands/check.js';
+
+let cwd: string;
+let lines: string[];
+let restoreLog: () => void;
+let exitCodes: number[];
+
+/** Write a fixture verbatim — these are JSONC sources, not `JSON.stringify` output. */
+function writeFile(name: string, body: string): void {
+  writeFileSync(join(cwd, name), body);
+}
+
+/**
+ * The CSI sequences chalk may add. The escape byte is built with
+ * `String.fromCharCode` rather than spelled into the source, so this file holds
+ * no raw control character and no escape a tooling pass could materialise into
+ * one (objectui AGENTS.md byte discipline).
+ */
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+function stripAnsi(line: string): string {
+  return line.replace(ANSI, '');
+}
+
+function plainLines(): string[] {
+  return lines.map(stripAnsi);
+}
+
+function parseErrorLines(): string[] {
+  return plainLines().filter((l) => l.includes('Invalid JSON in'));
+}
+
+function unknownTypeWarnings(): string[] {
+  return plainLines().filter((l) => l.includes('Unknown schema type'));
+}
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'objectui-check-jsonc-'));
+  lines = [];
+  exitCodes = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  };
+  // `check()` calls `process.exit(1)` itself; record the call instead of
+  // letting it tear the Vitest worker down.
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCodes.push(code ?? 0);
+    return undefined as never;
+  }) as never);
+  restoreLog = () => {
+    console.log = original;
+    exitSpy.mockRestore();
+  };
+});
+
+afterEach(() => {
+  restoreLog();
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe('objectui check — `.json` is read as JSONC', () => {
+  it('accepts a tsconfig.json with a line comment AND a trailing comma', async () => {
+    // The exact shape that produced all 64 errors: TypeScript documents both.
+    writeFile(
+      'tsconfig.json',
+      [
+        '{',
+        '  // Type-checking for the workspace, as tsconfig permits',
+        '  /* block comments too */',
+        '  "compilerOptions": {',
+        '    "strict": true,',
+        '  },',
+        '}',
+        '',
+      ].join('\n')
+    );
+
+    await check(cwd);
+
+    expect(parseErrorLines()).toEqual([]);
+    expect(plainLines()).toContain('✓ All checks passed');
+    expect(exitCodes).toEqual([]);
+  });
+
+  it('does not mistake a `//` inside a string value for a comment', async () => {
+    // Why the reader is a real JSONC parser and not a comment-stripping regex:
+    // a stripper that cannot tell a comment from a URL corrupts valid files.
+    writeFile(
+      'urls.json',
+      '{\n  // a genuine comment\n  "homepage": "https://www.objectui.org//docs",\n  "note": "a // b"\n}\n'
+    );
+
+    await check(cwd);
+
+    expect(parseErrorLines()).toEqual([]);
+    expect(exitCodes).toEqual([]);
+  });
+
+  it('still reads plain, comment-free JSON', async () => {
+    writeFile('plain.json', '{"compilerOptions":{"strict":true}}');
+
+    await check(cwd);
+
+    expect(parseErrorLines()).toEqual([]);
+    expect(exitCodes).toEqual([]);
+  });
+});
+
+describe('objectui check — genuinely malformed JSON still fails the run', () => {
+  it('reports a missing value and exits 1', async () => {
+    // `jsonc-parser` RECOVERS from this and returns `{}` rather than throwing.
+    // If the command trusted the absence of a throw, this file would pass.
+    writeFile('broken.json', '{ "compilerOptions": }');
+
+    await check(cwd);
+
+    expect(parseErrorLines()).toHaveLength(1);
+    expect(parseErrorLines()[0]).toContain('Invalid JSON in broken.json');
+    expect(plainLines()).toContain('Found 1 errors');
+    expect(exitCodes).toEqual([1]);
+  });
+
+  it.each([
+    ['an unterminated object', 'unclosed.json', '{ "a": 1'],
+    ['a bare unquoted word', 'bare.json', '{ broken }'],
+    ['trailing garbage after the value', 'garbage.json', '{"a":1} oops'],
+    ['single-quoted keys', 'quotes.json', "{'a':1}"],
+    ['an empty file', 'empty.json', ''],
+  ])('reports %s and exits 1', async (_label, name, body) => {
+    writeFile(name, body);
+
+    await check(cwd);
+
+    expect(parseErrorLines()).toHaveLength(1);
+    expect(parseErrorLines()[0]).toContain(`Invalid JSON in ${name}`);
+    expect(exitCodes).toEqual([1]);
+  });
+
+  it('names the line and column of the failure', async () => {
+    writeFile('located.json', '{\n  "a": 1,\n  "b": \n}\n');
+
+    await check(cwd);
+
+    expect(parseErrorLines()[0]).toMatch(
+      /Invalid JSON in located\.json: \w+ at line \d+ column \d+/
+    );
+    expect(exitCodes).toEqual([1]);
+  });
+
+  it('counts a real error even when a valid JSONC file sits beside it', async () => {
+    writeFile('tsconfig.json', '{\n  // fine\n  "compilerOptions": {},\n}\n');
+    writeFile('broken.json', '{ "a": }');
+
+    await check(cwd);
+
+    expect(parseErrorLines()).toHaveLength(1);
+    expect(parseErrorLines()[0]).toContain('broken.json');
+    expect(plainLines()).toContain('Found 1 errors');
+    expect(exitCodes).toEqual([1]);
+  });
+});
+
+describe('objectui check — the unknown-type warning arm is untouched (objectui#5127)', () => {
+  it('still warns for an unrecognised root type, and still does not fail the run', async () => {
+    writeFile('bogus.json', '{"type":"totally-made-up-xyz"}');
+
+    await check(cwd);
+
+    expect(unknownTypeWarnings()).toHaveLength(1);
+    expect(unknownTypeWarnings()[0]).toContain('Unknown schema type "totally-made-up-xyz"');
+    expect(plainLines()).toContain('✓ All checks passed');
+    expect(exitCodes).toEqual([]);
+  });
+
+  it('reaches the warning arm for a type declared in a JSONC file', async () => {
+    // Files that previously died at the parse step now reach the type check —
+    // the warning arm's reach grows, but its verdict and its exit-code
+    // neutrality are unchanged.
+    writeFile('commented.json', '{\n  // a comment\n  "type": "totally-made-up-xyz",\n}\n');
+
+    await check(cwd);
+
+    expect(unknownTypeWarnings()).toHaveLength(1);
+    expect(exitCodes).toEqual([]);
+  });
+
+  it('stays silent for a registered type', async () => {
+    writeFile('grid.json', '{"type":"object-grid","objectApiName":"account"}');
+
+    await check(cwd);
+
+    expect(unknownTypeWarnings()).toEqual([]);
+    expect(exitCodes).toEqual([]);
+  });
+
+  it('does not run the type check on a file that failed to parse', async () => {
+    // A parse failure short-circuits before the schema arm, exactly as the
+    // thrown `JSON.parse` used to.
+    writeFile('broken-typed.json', '{ "type": "totally-made-up-xyz", }}');
+
+    await check(cwd);
+
+    expect(parseErrorLines()).toHaveLength(1);
+    expect(unknownTypeWarnings()).toEqual([]);
+    expect(exitCodes).toEqual([1]);
+  });
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -10,8 +10,21 @@ import chalk from 'chalk';
 import { globSync } from 'glob';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { parse as parseJsonc, printParseErrorCode, type ParseError } from 'jsonc-parser';
 
 import { isKnownSchemaType } from '../utils/known-schema-types.js';
+
+/**
+ * Render a `jsonc-parser` error the way `JSON.parse` renders its own: a reason,
+ * then where it happened. The parser reports a byte offset; the line/column is
+ * derived here because a bare offset is not actionable in an editor.
+ */
+function describeParseError(text: string, error: ParseError): string {
+  const upTo = text.slice(0, error.offset);
+  const line = upTo.split('\n').length;
+  const column = error.offset - (upTo.lastIndexOf('\n') + 1) + 1;
+  return `${printParseErrorCode(error.error)} at line ${line} column ${column}`;
+}
 
 /**
  * @param cwd Directory to scan. Defaults to the process working directory,
@@ -36,7 +49,37 @@ export async function check(cwd: string = process.cwd()) {
     try {
       // Basic JSON parsing check
       if (file.endsWith('.json')) {
-        const content = JSON.parse(readFileSync(join(cwd, file), 'utf-8'));
+        // `.json` on disk means JSONC in practice — comments and trailing
+        // commas are how `tsconfig.json`, `.eslintrc.json`, `devcontainer.json`
+        // and VS Code's own settings are documented to be written. `JSON.parse`
+        // rejected every one of them, and because a parse failure is the only
+        // thing that increments `errors`, `objectui check` exited 1 in any
+        // TypeScript project — 64 errors in this repository alone (objectui#5237).
+        //
+        // The reader is `jsonc-parser` (already shipped by `@object-ui/app-shell`),
+        // NOT a comment-stripping regex: a `//` inside a string value — say a
+        // URL — is not a comment, and a stripper that cannot tell the
+        // difference corrupts valid files instead of reading them.
+        const text = readFileSync(join(cwd, file), 'utf-8');
+        const parseErrors: ParseError[] = [];
+        // Comments are permitted by default; trailing commas are opt-in.
+        // `allowEmptyContent` stays off so an empty `.json` is still an error,
+        // exactly as `JSON.parse('')` was.
+        const content = parseJsonc(text, parseErrors, { allowTrailingComma: true });
+
+        // `parseJsonc` is error-TOLERANT: it recovers and returns a best-effort
+        // value rather than throwing, so genuinely malformed JSON is caught by
+        // consulting this array. Dropping this check would turn the fix into
+        // "never fail on anything".
+        if (parseErrors.length > 0) {
+          const [first] = parseErrors;
+          console.log(
+            chalk.red(`x Invalid JSON in ${file}: ${describeParseError(text, first)}`)
+          );
+          errors++;
+          continue;
+        }
+
         // Schema validation: check for ObjectUI schema patterns
         if (content && typeof content === 'object' && content.type) {
           // The known-type universe is DERIVED from the repository's

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -917,6 +917,9 @@ importers:
       js-yaml:
         specifier: ^5.2.3
         version: 5.2.3
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)


### PR DESCRIPTION
Fixes #5237

`objectui check` globbed every `**/*.{json,yaml,yml}` and handed each `.json` straight to `JSON.parse`. A throw there is the only thing that increments the error count, and a non-zero error count is the only thing that calls `process.exit(1)` — so a `//` comment or a trailing comma, which is how TypeScript documents `tsconfig.json`, was reported as a malformed file and **failed the run**. Every TypeScript project hit it, and this repository's own `pnpm check` was red on `main`.

`.json` on disk means JSONC in practice — `tsconfig.json`, `.eslintrc.json`, `devcontainer.json` and VS Code's own settings are all written that way — so the file is now read with `jsonc-parser` (comments allowed, `allowTrailingComma: true`, `allowEmptyContent` left off so an empty `.json` is still an error exactly as `JSON.parse('')` was).

## Measured, before and after

Reproduced at this repo's root with the CLI built from source, per the issue's recipe:

| | errors | exit | warnings |
|---|---|---|---|
| `main` (`118419214`) | **64** | **1** | 47 |
| this branch (`565cfad06`) | **0** | **0** | 47 |

All 64 error files were `tsconfig*.json` — nothing else in the tree failed to parse. The 47 warnings are unchanged and are not this card's; see the scope note below.

## Two things this deliberately is not

**Not a comment-stripping regex.** A `//` inside a string value — a URL, say — is not a comment, and a stripper that cannot tell the difference corrupts valid files instead of reading them. There is a test for exactly that fixture.

**Not "never fail on anything".** This is the subtle half. `jsonc-parser`'s reader is error-**tolerant**: it recovers and returns a best-effort value rather than throwing, so a command that inferred success from the absence of a throw would silently accept genuinely broken files. Measured on the real library:

```
'{ "compilerOptions": }'  ->  errors=1 ValueExpected@21   value={}     (returns, does not throw)
'{ "a": 1'                ->  errors=1 CloseBraceExpected value={"a":1}
```

So the command consults the reported-error array, and six malformed shapes are pinned as still erroring and still exiting 1. Error output now names the reason plus line and column, since a bare byte offset is not actionable in an editor.

## The dependency

`jsonc-parser` is **already** a declared runtime dependency of `@object-ui/app-shell` and already resolved in the lockfile, so this is a new dependency edge, not a new dependency to the fleet. `@object-ui/cli` is published, so that was verified rather than assumed:

- `jsonc-parser@3.3.1` declares **no `dependencies` and no `peerDependencies`** — only devDependencies. Its lockfile snapshot is literally `jsonc-parser@3.3.1: {}`.
- The whole `pnpm-lock.yaml` delta is **3 lines**, all of them the `packages/cli` importer entry. Zero new resolutions, zero new snapshots, no version bump anywhere.

Net effect on what users install: one package that the product already ships.

## Scope

Direction 1 of the three the issue lists, only. Directions 2 and 3 (demoting parse failures to warnings; narrowing the scan) encode a decision that belongs to the maintainer, and were not taken.

The unknown-schema-type warning arm is untouched — #5127 is not addressed here and remains open. It still warns and still does not affect the exit code, with tests pinning both. One honest consequence worth naming: files that previously died at the parse step now reach that arm, so a JSONC file carrying an unrecognised root `type` warns where it used to error. The arm's verdict and its exit-code neutrality are unchanged; only its reach grows, and it grows because the parse step stopped rejecting files that were never malformed.

## Verification

Everything below was run on `565cfad06` with a clean tree.

- `pnpm exec vitest run packages/cli/` — **8 files, 179 tests passed** (15 of them new). Run from the repo root: this repo's guard rejects package-directory vitest as a false-green trap (objectui#3378).
- `pnpm --filter @object-ui/cli type-check` — clean. `lint` — 0 errors (11 pre-existing warnings, none in the changed files).
- Gates derived from the diff: `check:phantom-deps`, `check:control-bytes`, `check:self-import`, `check:published-dist`, `changeset:check`, `check:esm-specifiers`, `check:node-esm-load` — all exit 0. `@object-ui/cli` is in the ESM-load gate's scope and is not among its (pre-existing, ledgered) failures.
- `jsonc-parser` stays **external** in the tsup output, so its resolution is real at runtime rather than bundled away; the built `dist/cli.js` was executed end to end for the table above.

**Reverse verification.** With `check.ts` restored to `main` and the tests kept, the prediction recorded before running was 5 red / 10 green, naming the five. Observed: 5 red / 10 green, the same five —

1. tsconfig with a comment and a trailing comma
2. a `//` inside a string value
3. the line/column message shape
4. a real error counted beside a valid JSONC sibling
5. the warning arm reached through a JSONC file

The six genuinely-malformed cases stayed **green** under the old code, which is what makes them load-bearing: they pin behaviour the fix had to preserve, not behaviour it introduced. The tests import `../commands/check.js`, a relative specifier resolved to TypeScript source rather than through the package's `exports` to `dist/`, so no rebuild is involved in either leg — confirmed empirically, since the new tests passed while `dist/` still held the pre-change build.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_