### PR TITLE
docs(blocks): teach a validation shape the input node actually declares (#5229)

### DIFF
--- a/content/docs/blocks/forms.mdx
+++ b/content/docs/blocks/forms.mdx
@@ -39,18 +39,57 @@ Customize form blocks for your application:
 
 ### Add Validation
 
+The blocks on this page are built from plain `input` nodes, and an `input`
+declares its own validation keys — `required`, `pattern`, `maxLength`, `min`,
+`max` and `step` — which the renderer forwards to the native HTML input
+attributes:
+
 ```json
 {
   "type": "input",
   "name": "email",
   "inputType": "email",
   "required": true,
-  "validation": {
-    "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$",
-    "message": "Please enter a valid email address"
-  }
+  "pattern": "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$"
 }
 ```
+
+`inputType: "email"` already gets the browser's own email check; `pattern`
+tightens it. The browser enforces these constraints when the input is submitted
+inside a `<form>`.
+
+An `input` node has **no `validation` key**. Rule objects with custom messages
+belong to the [form component](/docs/components/form/form), whose `fields[]`
+entries carry them. Every rule there is a `{ value, message }` object, and
+`validation.required` supplies the message only — whether the field is required
+is decided by `required` on the field itself:
+
+```json
+{
+  "type": "form",
+  "fields": [
+    {
+      "name": "message",
+      "type": "textarea",
+      "label": "How can we help?",
+      "required": true,
+      "validation": {
+        "required": "Please tell us how we can help",
+        "minLength": { "value": 20, "message": "Please use at least 20 characters" },
+        "maxLength": { "value": 2000, "message": "Please keep it under 2000 characters" }
+      }
+    }
+  ]
+}
+```
+
+`pattern` is the one rule that route cannot take from JSON: react-hook-form runs
+it only when the rule's `value` is a compiled `RegExp`, and no JSON document can
+hold one. Declare the pattern on the object field's metadata instead (`pattern`,
+a string, which `@object-ui/fields` compiles before the rule reaches the form),
+or in a TypeScript-authored schema pass the real thing —
+`pattern: { value: /.../, message: '...' }`. The full rule table is in the
+[Form Plugin](/docs/plugins/plugin-form) reference.
 
 ### Add Submit Action
 


### PR DESCRIPTION
Fixes #5229

Docs-only. One file: `content/docs/blocks/forms.mdx`.

## The card's premise did not survive verification — the state is quieter, not louder

The card and the dispatch both hold that PR5230 (#5186) turned this example from quietly wrong into **loudly** wrong, and that `objectui validate` now "rejects this example by name". Measured on `origin/main` at `56735762f`, it does not:

```
$ sed -n '43,52p' content/docs/blocks/forms.mdx > before.json
$ objectui validate before.json
✓ Schema is valid!
  Type: input
```

The reason is a layer the card did not account for. The documented node is `"type": "input"` → `InputSchema`, and **`InputSchema` declares no `validation` key at all**. `BaseSchemaCore` ends `.passthrough()`, so the whole `validation` object rides through unvalidated. `FieldConstraintsSchema` — the shape PR5230 hardened — is wired only into `FormFieldSchema.validation` (`packages/types/src/zod/form.zod.ts:465`), which belongs to a **form** node's `fields[]`, not to an `input` node.

The same block on the face where that schema does apply is rejected, which confirms the hardening is real and simply out of reach here:

```
$ objectui validate probe-formfield.json     # same validation block, inside {"type":"form","fields":[…]}
✗ Schema validation failed!
1. Invalid input   Code: invalid_union
```

So the published example was never reached by the named rejection, and is not reached today.

## What the defect actually is — worse than "a third dialect"

It is not a mis-spelling of a real key. It is an **inert key on the wrong node type**, invisible to every tool we ship:

| Surface | Verdict on the published example |
| --- | --- |
| `objectui validate` | accepts — `validation` is undeclared, `BaseSchema` is `.passthrough()` |
| `InputRenderer` | never reads `schema.validation`; it reads `schema.pattern` (`input.tsx:56`) |
| `form.tsx`'s #5099 diagnostic | walks a form node's `fields[]`; a standalone `input` node is not in it |
| `check-doc-component-types.mjs` | passes — it judges the `type` literal only, deliberately |
| `check-doc-snippet-types.mjs` | never sees it — `TS_FENCE_LANGUAGES` is ts/tsx only; this file is all `json` |

A reader copying it got zero validation **and** zero diagnostics. That is #5099's symptom, still fully alive on this surface and untouched by PR5230.

How far outside the validator the old key sat, measured:

```
$ echo '{"type":"input","name":"email","validation":{"pattern":12345,"message":false,"nonsense":[1,2]}}' | …
✓ Schema is valid!                 # complete garbage, accepted

$ echo '{"type":"input","name":"email","pattern":12345}' | …
✗ Schema validation failed!        # the DECLARED key, wrong type — rejected
```

## The teaching decision

The four blocks this page documents (`forms/contact-form`, `settings-form`, `newsletter-signup`, `payment-form`) are presentational trees of `card`/`stack`/`label`/`input` — **zero** `validation` keys, no `"type": "form"` node anywhere. Their inputs read exactly `type`/`id`/`name`/`inputType`/`placeholder`/`required`. So the honest route for *this* page is the input node's own declared keys, which `InputRenderer` forwards to the native HTML input attributes:

- `required`, `pattern` (a **string** — `InputSchema.pattern` is `z.string()`), `maxLength`, `min`, `max`, `step`

That is not a fourth dialect: `pattern` is a first-class declared key on the exact node type the example uses, and it is the one the renderer actually reads.

The section then hands off to the `form` component for rule objects with custom messages, in the `{ value, message }` shape `FieldConstraintsSchema` pins, and states why `pattern` alone cannot come from JSON there (react-hook-form runs it only when `value instanceof RegExp`) — pointing at the field-metadata route and the TypeScript form instead. Per the dispatch, no JSON snippet shows a `pattern` object implying it validates.

## File sweep

Swept all 82 lines / 4 json fences. **One** occurrence of the flat dialect (the "Add Validation" block), now fixed. "Add Submit Action" and "Customize Layout" contain no `validation`, no flat `pattern`, and no stray sibling `message`.

## Verification

Both published snippets validate, at `6297e3b3e`:

```
$ objectui validate after-input.json    →  ✓ Schema is valid!   Type: input
$ objectui validate after-form.json     →  ✓ Schema is valid!   Type: form
```

Gate union re-run on the final commit **`6297e3b3e`**, all green:

```
check-doc-component-types    PASS   482 registered, 88 exempted — "Every documented component type is registered."
check-doc-links              PASS   "Links are valid across 13 scan roots."
check-control-bytes          PASS   scanned 4645 tracked text file(s)
check-changeset-presence     PASS   "1 file(s) changed, 0 of them under the src/ of a package the release covers … no changeset is owed."
check-doc-snippet-types      PASS   67 of 67 block(s) judged, 0 failed (after a full packages build)
Build Docs                   PASS   pnpm turbo run build --filter='@object-ui/site' → 29 successful, 29 total
```

`check-changeset-presence.mjs` was run rather than assumed: it reports no changeset owed, so none is added. The new `type` literals (`form`, `textarea`) are both registered, so the existing `forms.mdx` exemption in `check-doc-component-types.mjs` (`submit`) needed no amendment.

## ⚠️ Nothing we ship can check the corrected example

Stated plainly, as the card asked. `check-doc-snippet-types.mjs` compiles `ts`/`tsx`/`typescript` fences only — this file is entirely `json`, so its snippets never enter the compile set (corroborating #5174 from a different angle: the **fence-language** filter, not the `.md`/`.mdx` collection filter). `check-doc-component-types.mjs` judges the `type` literal only, by design. And `objectui validate` cannot discriminate here at all, because the keys in question are passthrough.

The corrected example is nevertheless a real improvement *in checkability*: it moves the declaration out of a key the validator cannot see and into `pattern`, which the validator does enforce (shown above). Filed as #5250 so the gap is tracked rather than implied — #5138 filed this class and was closed by PR #5161, which built the TypeScript half only.

## Out of scope, filed not fixed

- **#5249** — `content/docs/plugins/plugin-form.mdx:108` still types `pattern.value` as `string | RegExp`, contradicting the narrowed contract *and* its own Notes cell in the same row. Different file; #5118's territory.
- **#5250** — the structural gap above.

`packages/types` was not touched: per the dispatch it is the reference, and it is correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_