### PR TITLE
fix(plugin-calendar): correct the false "object/api/value" claim to "object/value"

### DIFF
--- a/.changeset/plugin-calendar-api-provider-claim-5180.md
+++ b/.changeset/plugin-calendar-api-provider-claim-5180.md
@@ -1,0 +1,33 @@
+---
+"@object-ui/plugin-calendar": patch
+---
+
+Correct the published "works with the `api` data provider" claim for plugin-calendar,
+which `ObjectCalendar` does not implement. `data.provider: 'api'` reaches
+`console.warn('API provider not yet implemented for ObjectCalendar')`
+(`ObjectCalendar.tsx:294-296`), sets the record set to empty and renders a calendar
+with no events; `endpoint` and `method` have no read point anywhere in
+`packages/plugin-calendar/src`, and the package never resolves an `ApiDataSource`.
+
+Four publication sites corrected:
+
+- `packages/plugin-calendar/src/ObjectCalendar.tsx:22` (file-header JSDoc): "Works
+  with object/api/value data providers" → "Works with object/value data providers".
+- `content/docs/plugins/plugin-calendar.mdx:178` (Features list): "Works seamlessly
+  with object/api/value data providers" → "Works seamlessly with object/value data
+  providers".
+- `content/docs/plugins/index.md:168` (Calendar Plugin section): "Works with
+  object/api/value providers" → "Works with object/value providers".
+- `content/docs/plugins/plugin-calendar.mdx` "API Provider" section: the
+  copy-pasteable `provider: 'api'` + `endpoint` + `method` recipe is replaced by a
+  statement of the real behaviour, matching the merged plugin-map wording.
+
+The identical sentence published for **plugin-gantt** is left untouched: there
+`provider: 'api'` is genuinely implemented (`ObjectGantt.tsx:442-445` resolves a real
+`ApiDataSource` through `resolveDataSource`, and `:1155` / `:1495` route write-backs
+through it), so the gantt claim is true and this is a shared sentence, not a shared
+defect.
+
+Implementing the `api` provider for calendar is capability expansion and is explicitly
+out of scope here, the same line objectui#5163 drew for plugin-map. No runtime
+behaviour changes: a source comment and docs prose only.

--- a/content/docs/plugins/index.md
+++ b/content/docs/plugins/index.md
@@ -165,7 +165,7 @@ npm install @object-ui/plugin-calendar-view
 - ObjectQL integration
 - Automatic field mapping
 - Database-driven events
-- Works with object/api/value providers
+- Works with object/value providers
 
 ```bash
 npm install @object-ui/plugin-calendar

--- a/content/docs/plugins/plugin-calendar.mdx
+++ b/content/docs/plugins/plugin-calendar.mdx
@@ -175,7 +175,7 @@ Calendar component designed for use with ObjectQL data sources.
 
 ### Features
 
-- **ObjectQL Integration**: Works seamlessly with object/api/value data providers
+- **ObjectQL Integration**: Works seamlessly with object/value data providers
 - **Automatic Field Mapping**: Maps database fields to calendar events
 - **Multiple View Modes**: Month, week, and day calendar views
 - **Date Filtering**: Automatically filters records by date range
@@ -307,23 +307,17 @@ Map your database fields to calendar properties:
 }
 ```
 
-#### API Provider
+#### API Provider — not implemented
 
-```tsx
-{
-  type: 'object-calendar',
-  data: {
-    provider: 'api',
-    endpoint: '/api/events',
-    method: 'GET'
-  },
-  calendar: {
-    startDateField: 'startTime',
-    endDateField: 'endTime',
-    titleField: 'eventName'
-  }
-}
-```
+`data.provider: 'api'` has no fetch implementation in `ObjectCalendar`. A schema
+that reaches this branch logs `API provider not yet implemented for
+ObjectCalendar`, sets the record set to empty and renders a calendar with no
+events; `endpoint` and `method` have no read point anywhere in the package.
+Without a `DataSource` it fails one step earlier, with `DataSource required for
+object/api providers`.
+
+Read from the database with the **Object Provider** above, or pass events you
+already hold with the **Value Provider**.
 
 ## Comparison: CalendarView vs ObjectCalendar
 

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -19,7 +19,7 @@
  * - Date range filtering
  * - Event click handling
  * - Color coding support
- * - Works with object/api/value data providers
+ * - Works with object/value data providers
  */
 
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';


### PR DESCRIPTION
Fixes #5180

## What

`ObjectCalendar` advertises an `api` data provider it does not implement. Corrected to
`object/value` at every calendar publication site, matching the wording of the merged
plugin-map correction (PR #5181).

## The measurement — this is the deliverable's proof

The sentence *"Works with object/api/value data providers"* is published for **three**
plugins. It is a **shared sentence, not a shared defect**, so each was re-measured
against the current ref (`6b73232d6`, this branch's merge-base) before a character was
changed. A grep-and-replace over `object/api/value` would have made the gantt docs
wrong.

| Plugin | Claim site(s) | `provider: 'api'` implementation | Verdict |
|---|---|---|---|
| **plugin-calendar** | `plugin-calendar.mdx:178`, `ObjectCalendar.tsx:22`, `index.md:168`, plus the `plugin-calendar.mdx` "API Provider" recipe | `ObjectCalendar.tsx:294-296` — `console.warn('API provider not yet implemented for ObjectCalendar')` then `setData([])`. No `resolveDataSource` / `ApiDataSource` anywhere in the package; `endpoint` / `method` have **zero** read points in `packages/plugin-calendar/src`. | **FALSE — corrected here** |
| **plugin-gantt** | `plugin-gantt.mdx:24`, `ObjectGantt.tsx:22` | `ObjectGantt.tsx:442-445` resolves a real `ApiDataSource` via `resolveDataSource(dataConfig, ...)`; every read **and** write-back goes through it (`:1155` reschedule/dependency, `:1495` delete/inline-edit). No "not yet implemented" branch exists. | **TRUE — deliberately untouched** |
| **plugin-map** | `plugin-map.mdx:24`, `ObjectMap.tsx:20` | Already corrected to `object/value` by PR #5181 (merged today). Nothing left to do. | **FALSE — already corrected, not re-touched** |

Verification that the sweep did **not** happen: after this diff,
`git grep -n "object/api/value"` still returns gantt's two sites intact.

## Diff — four sites, one of them beyond the card's three

Three are the sites the card enumerated:

- `packages/plugin-calendar/src/ObjectCalendar.tsx:22` (file-header JSDoc) — the **only**
  change to this file is that one comment line; no runtime behaviour changes.
- `content/docs/plugins/plugin-calendar.mdx:178` (Features list).
- `content/docs/plugins/index.md:168` (Calendar Plugin section only; the Gantt and Map
  sections at `:178` / `:195` do not carry the sentence).

**The fourth site is a disclosed in-scope addition, and it is the strongest form of the
same false claim.** `content/docs/plugins/plugin-calendar.mdx` also carried a
copy-pasteable `#### API Provider` recipe (`provider: 'api'` + `endpoint: '/api/events'`
+ `method: 'GET'`) — an author copying it ships a silently empty calendar, which is
exactly the harm the card records. The card's site list came from grepping one string,
so this site was not in it.

It is corrected rather than deferred because all four bounded-fix conditions hold:
same defect class (the identical false `api` claim, same plugin); mechanically pinned by
merged evidence (`plugin-map.mdx:238-247`, the sibling PR #5162/#5181 landed, which I
matched in form and adapted with calendar's measured facts); no other claim holds this
file (no open PR or issue touches `plugin-calendar` or `content/docs/plugins/**` —
checked); and no new gate surface. Deferring it would have shipped a
**self-contradictory document** — a Features list reading `object/value` with a working-
looking `api` recipe 130 lines below — as the result of a documentation-correctness fix.

Boundary scan: `#5045` is a live plugin-calendar finding but concerns
`packages/plugin-calendar/README.md` schema-key coverage, a file this PR does not touch.

## Explicitly out of scope

Whether calendar's `api` provider should be **implemented** is capability expansion —
the same line #5163 and this card both drew. Not proposed here.

## Gates run locally

All verified at `a89bbb207` (this branch's head, worktree clean):

- `node scripts/check-control-bytes.mjs` — pass (4653 tracked text files). Plus a direct
  control-byte scan of the four changed paths: clean.
- `node scripts/check-doc-links.mjs` — pass, 13 scan roots (Internal Docs Link Check).
- `node scripts/check-doc-component-types.mjs` — pass, 143 mdx / 632 code blocks
  (Doc Component Type Check).
- `pnpm turbo run build --filter='@object-ui/site' --concurrency=2` — 29/29 tasks
  (Build Docs).
- `node scripts/check-changeset-presence.mjs` — pass, 1 changeset covers the 1 released
  source file changed.
- `node scripts/check-changeset-no-major.mjs` — pass.
- `pnpm --filter '@object-ui/plugin-calendar^...' build` then
  `pnpm --filter '@object-ui/plugin-calendar' build` — both succeed (dependency closure
  built before judging anything).
- `pnpm --filter '@object-ui/plugin-calendar' type-check` — pass (script name echoed in
  the output, so this is not a zero-match silent pass).
- `pnpm exec vitest run packages/plugin-calendar/ --maxWorkers=2` — 10 files / 79 tests
  passed. (The `ECONNREFUSED 127.0.0.1:3000` line in that output is a deliberate
  network-failure path logged inside a passing test, not a failure.)
- `node scripts/check-doc-snippet-types.mjs --build-filter` — `@object-ui/plugin-calendar`
  is **absent** from the derived filter, so Doc Snippet Type Check compiles no snippet
  importing this package and is not exercised by this diff. Confirmed, not assumed.

**No gate covers the truth of the claim itself.** The doc gates check links, registered
component types and that the site builds — none of them can tell a true capability claim
from a false one. The measurement table above is the verification; per the card, no
sentence-grepping test was invented, since that is the forbidden sweep wearing a test's
clothes.

## Changeset

`.changeset/plugin-calendar-api-provider-claim-5180.md` — `@object-ui/plugin-calendar`
**patch**, following PR #5181's precedent for the equivalent map change. The presence
gate demanded one (a released package's `src/` changed); never `major`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_