### PR TITLE
docs: stop five published pages teaching imports their packages do not export

### DIFF
--- a/content/docs/guide/objectos-integration.mdx
+++ b/content/docs/guide/objectos-integration.mdx
@@ -325,22 +325,26 @@ const schema = {
 
 ### Custom Data Hooks
 
+`@object-ui/data-objectstack` ships the *adapter*, not hooks. Reads and writes
+go through `useViewData` from `@object-ui/react`, which resolves the adapter
+from context and hands back both the rows and the `DataSource` to write with.
+
 ```typescript
-// Implement custom hooks for data operations
-import { useObjectQuery, useObjectMutation } from '@object-ui/data-objectstack';
+import { useViewData } from '@object-ui/react';
 
 function ContactList() {
-  const { data, loading, error } = useObjectQuery('contact', {
-    filter: { field: 'status', operator: 'eq', value: 'active' },
-    sort: [{ field: 'name', order: 'asc' }],
-    page: 1,
-    pageSize: 20
+  const { data, loading, error, dataSource, refresh } = useViewData({
+    resource: 'contact',
+    params: {
+      $filter: { status: 'active' },
+      $orderby: [{ field: 'name', order: 'asc' }],
+      $top: 20,
+    },
   });
 
-  const { mutate: createContact } = useObjectMutation('contact', 'create');
-  
-  const handleCreate = async (formData: any) => {
-    await createContact(formData);
+  const handleCreate = async (formData: Record<string, unknown>) => {
+    await dataSource?.create('contact', formData);
+    await refresh();
   };
 
   if (loading) return <div>Loading...</div>;
@@ -350,7 +354,7 @@ function ContactList() {
     <SchemaRenderer
       schema={{
         type: 'object-grid',
-        rowData: data.records,
+        rowData: data,
         // ... other props
       }}
     />

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -8,7 +8,8 @@ A lightweight, framework-agnostic rendering engine that enables third-party syst
 
 This package provides the essential building blocks for rendering ObjectUI schemas:
 - Basic layout components (AppShell, Sidebar, Main)
-- Renderer components for objects, dashboards, pages, and forms
+- Route-level views for objects, dashboards, pages and records
+  (`ObjectView`, `DashboardView`, `PageView`, `RecordDetailView`)
 - Zero console-specific dependencies
 - Bring-your-own-router design
 
@@ -23,15 +24,18 @@ pnpm add @object-ui/app-shell
 ### Basic Setup
 
 ```tsx
-import { AppShell, ObjectRenderer } from '@object-ui/app-shell';
+import { AppShell } from '@object-ui/app-shell';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const contactView: ObjectViewSchema = { type: 'object-view', objectName: 'contact' };
 
 function MyCustomConsole() {
   return (
     <AppShell sidebar={<MySidebar />}>
-      <ObjectRenderer
-        objectName="contact"
-        dataSource={myDataSource}
-      />
+      <SchemaRendererProvider dataSource={myDataSource}>
+        <SchemaRenderer schema={contactView} />
+      </SchemaRendererProvider>
     </AppShell>
   );
 }
@@ -39,8 +43,11 @@ function MyCustomConsole() {
 
 ### With Dashboard
 
+`DashboardRenderer` ships from `@object-ui/plugin-dashboard` — this package's
+own `DashboardView` imports it from there.
+
 ```tsx
-import { DashboardRenderer } from '@object-ui/app-shell';
+import { DashboardRenderer } from '@object-ui/plugin-dashboard';
 
 function MyDashboard() {
   return (
@@ -103,39 +110,37 @@ Basic layout container with sidebar support.
 </AppShell>
 ```
 
-### ObjectRenderer
+### ObjectView
 
-Renders object views (Grid, Kanban, List, etc.).
-
-```tsx
-<ObjectRenderer
-  objectName="contact"
-  viewId="grid-view"
-  dataSource={dataSource}
-  onRecordClick={(record) => navigate(`/detail/${record.id}`)}
-/>
-```
-
-### DashboardRenderer
-
-Renders dashboard layouts from schema.
+The route-level object surface (Grid, Kanban, List, etc.). It resolves the
+object and view from the host's route, so it takes no `objectName` prop —
+mount it on a route that supplies them, as the console does with
+`/apps/:appName/:objectName` and `/apps/:appName/:objectName/view/:viewId`.
 
 ```tsx
-<DashboardRenderer
-  schema={dashboardSchema}
-  dataSource={dataSource}
-/>
+<ObjectView dataSource={dataSource} />
 ```
 
-### PageRenderer
+To render an object view from a schema instead of from a route, use
+`SchemaRenderer` from `@object-ui/react` — see [Basic Setup](#basic-setup).
 
-Renders custom page schemas.
+### DashboardView / PageView
+
+`DashboardView` and `PageView` are the route-level equivalents for dashboards
+and custom pages; like `ObjectView` they resolve their target from the route
+(`dashboardName` / `pageName`) rather than from a `schema` prop.
 
 ```tsx
-<PageRenderer
-  schema={pageSchema}
-/>
+<DashboardView dataSource={dataSource} />
 ```
+
+```tsx
+<PageView />
+```
+
+The schema-driven renderers live elsewhere: `DashboardRenderer` in
+`@object-ui/plugin-dashboard`, and everything else through `SchemaRenderer` in
+`@object-ui/react`, which resolves `type` against the component registry.
 
 ### ActionParamDialog
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -70,10 +70,14 @@ entry goes on generating the classes your own source uses, as it always did.
 ### 2. Register Components
 
 ```tsx
-import { registerDefaultRenderers } from '@object-ui/components'
+import { initializeComponents } from '@object-ui/components'
 
-registerDefaultRenderers()
+initializeComponents()
 ```
+
+Importing the package already registers its components as a side effect;
+`initializeComponents()` is the explicit call for bundlers that would otherwise
+tree-shake that import away.
 
 ## Usage
 
@@ -81,9 +85,9 @@ registerDefaultRenderers()
 
 ```tsx
 import { SchemaRenderer } from '@object-ui/react'
-import { registerDefaultRenderers } from '@object-ui/components'
+import { initializeComponents } from '@object-ui/components'
 
-registerDefaultRenderers()
+initializeComponents()
 
 const schema = {
   type: 'card',
@@ -200,15 +204,19 @@ All components accept `className` for Tailwind classes:
 Register your own components:
 
 ```tsx
-import { registerRenderer } from '@object-ui/react'
+import { ComponentRegistry } from '@object-ui/core'
 import { Button } from '@object-ui/components'
 
-function CustomButton(props) {
+function CustomButton(props: Record<string, unknown>) {
   return <Button {...props} className="my-custom-style" />
 }
 
-registerRenderer('custom-button', CustomButton)
+ComponentRegistry.register('custom-button', CustomButton)
 ```
+
+`ComponentRegistry` is a process-level singleton exported by `@object-ui/core`;
+`SchemaRenderer` resolves every `type` against it, so a component registered
+here is renderable from schema anywhere in the app.
 
 ## API Reference
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,8 @@ Core logic, types, and validation for Object UI. Zero React dependencies.
 
 ## Features
 
-- 🎯 **Type Definitions** - Complete TypeScript schemas for all components
+- 🎯 **Type Definitions** - Re-exported runtime types; the component schema
+  vocabulary itself is `@object-ui/types`
 - 🔍 **Component Registry** - Framework-agnostic component registration system
 - 📊 **Data Scope** - Data scope management and expression evaluation
 - ✅ **Validation** - Zod-based schema validation
@@ -20,15 +21,20 @@ npm install @object-ui/core
 
 ### Type Definitions
 
-```typescript
-import type { 
-  PageSchema, 
-  FormSchema, 
-  InputSchema,
-  BaseSchema 
-} from '@object-ui/core'
+The component schema vocabulary lives in `@object-ui/types`. Core depends on
+that package and does not re-export it, so import the types from there. The
+page node type is `PageNodeSchema` — the SDUI node, as distinct from the
+authored page document.
 
-const mySchema: PageSchema = {
+```typescript
+import type {
+  PageNodeSchema,
+  FormSchema,
+  InputSchema,
+  BaseSchema
+} from '@object-ui/types'
+
+const mySchema: PageNodeSchema = {
   type: 'page',
   title: 'My Page',
   body: []
@@ -47,15 +53,20 @@ const metadata = registry.get('button')
 
 ### Data Scope
 
+`DataScopeManager` owns the named scopes a component tree reads from, and
+`evaluateExpression` evaluates a `${...}` expression against a context. They
+are separate exports: a scope holds data, it does not evaluate.
+
 ```typescript
-import { DataScope } from '@object-ui/core'
+import { DataScopeManager, evaluateExpression } from '@object-ui/core'
 
-const scope = new DataScope({ 
-  user: { name: 'John', role: 'admin' } 
-})
+const manager = new DataScopeManager()
+manager.registerScope('user', { data: { name: 'John', role: 'admin' } })
 
-const userName = scope.get('user.name') // 'John'
-const isAdmin = scope.evaluate('${user.role === "admin"}') // true
+const userName = manager.getScope('user')?.data.name // 'John'
+const isAdmin = evaluateExpression('${user.role === "admin"}', {
+  user: { name: 'John', role: 'admin' },
+}) // true
 ```
 
 ### Server Action Dispatch (`createServerActionHandler`)
@@ -87,16 +98,16 @@ action identity (ADR-0110), the record-id resolution dance (`_rowRecord`,
 guard, and the `/actions` response-envelope rule (`interpretActionResponse` /
 `readActionPayload`, also exported).
 
-### System Views (`defineView`)
+### System Views (`defineSystemView`)
 
 Schemas authored in source code are part of the product contract and must
-not be mutated at runtime. Wrap them with `defineView()` to deep-freeze the
-graph and tag it as a *System View*.
+not be mutated at runtime. Wrap them with `defineSystemView()` to deep-freeze
+the graph and tag it as a *System View*.
 
 ```typescript
-import { defineView, cloneAsOverride, isSystemView } from '@object-ui/core'
+import { defineSystemView, cloneAsOverride, isSystemView } from '@object-ui/core'
 
-export const userListView = defineView({
+export const userListView = defineSystemView({
   type: 'list',
   data: { object: 'User' },
   columns: [{ name: 'email' }],
@@ -115,7 +126,7 @@ isSystemView(draft)                          // false — clone is no longer Sys
 
 | Tier        | Source                | Mutable? | API                         |
 | ----------- | --------------------- | -------- | --------------------------- |
-| System View | code (`import` / `as const`) | ❌ frozen | `defineView()`              |
+| System View | code (`import` / `as const`) | ❌ frozen | `defineSystemView()`        |
 | Tenant View | backend / DB          | ⚠️ admin only | `cloneAsOverride()` + persist |
 | User View   | localStorage / API    | ✅ user-editable | `cloneAsOverride()` + persist |
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -158,18 +158,19 @@ falling back to the object's full scope. Use `useElementDataSourceSchema` (plus
 the exported `ElementDataSourceErrorPanel` / `ElementDataSourceLoadingPanel`) when
 a block cannot be wrapped — a renderer whose hooks must run before the panels.
 
-### useRegistry
+### ComponentRegistry
 
-Access the component registry:
+There is no registry hook: the registry is a process-level singleton exported
+by `@object-ui/core`, so read it directly. Subscribe to it only when a lazily
+registered plugin must trigger a re-render.
 
 ```tsx
-import { useRegistry } from '@object-ui/react'
+import { ComponentRegistry } from '@object-ui/core'
 
-function MyComponent() {
-  const registry = useRegistry()
-  const Component = registry.get('button')
-  
-  return <Component {...props} />
+function MyComponent(props: Record<string, unknown>) {
+  const Component = ComponentRegistry.get('button')
+
+  return Component ? <Component {...props} /> : null
 }
 ```
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -211,7 +211,7 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  */
 const UNGATED_DOCS = {
   'content/docs/guide/objectos-integration.mdx':
-    '36 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 7 unresolved-module diagnostic(s); plus TS2305x3 TS2339x1 — candidate real defects, un-triaged',
+    '36 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 7 unresolved-module diagnostic(s); plus TS2305x1 TS2339x1 — candidate real defects, un-triaged',
   'content/docs/plugins/plugin-calendar-view.mdx':
     '2 unresolved-module diagnostic(s) — and NOT a defect: the page is a migration guide whose ' +
     '"Before" blocks quote the retired `@object-ui/plugin-calendar-view` import on purpose. Covering ' +
@@ -238,15 +238,15 @@ const UNGATED_DOCS = {
   'content/docs/utilities/runner.mdx':
     '5 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 3 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 3 unresolved-module diagnostic(s)',
   'packages/app-shell/README.md':
-    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 18 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2305x2 — candidate real defects, un-triaged',
+    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 14 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/auth/README.md':
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 15 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2741x1 — candidate real defects, un-triaged',
   'packages/collaboration/README.md':
     '13 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 TS2353x1 TS2554x1 TS2739x1 — candidate real defects, un-triaged',
   'packages/components/README.md':
-    '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2305x3 — candidate real defects, un-triaged',
+    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/core/README.md':
-    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2305x6 TS2351x1 — candidate real defects, un-triaged',
+    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 TS2351x1 — candidate real defects, un-triaged',
   'packages/data-objectstack/README.md':
     '10 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 41 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/fields/README.md':
@@ -298,7 +298,7 @@ const UNGATED_DOCS = {
   'packages/react-runtime/README.md':
     '25 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2813x1 TS2814x1 — candidate real defects, un-triaged',
   'packages/react/README.md':
-    '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2305x1 TS2339x2 — candidate real defects, un-triaged',
+    '9 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 — candidate real defects, un-triaged',
   'packages/types/README.md':
     '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 3 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
 };


### PR DESCRIPTION
Part of #5160

14 of the 15 TS2305s are settled. The 15th (`AppManifest`) is a contract question and is deliberately left — see "The one left" below. `Part of`, not `Fixes`, so merging does not close the card.

Verified at `cf2a91b8b`, which is the tip of this branch and the tree every result below was produced on.

## Re-measured against `main`, not against the card

The card was written against the unlanded gate branch. The gate is on `main` now, so everything was re-measured there with the packages built:

```
pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter)
```

Still exactly 15 TS2305, same names, same five documents. Every name below was decided against the package's **built `dist/index.d.ts`** — resolved through the package's own `exports.types`, the way the gate resolves it — never a grep of `src/`. Harness controls on every measurement run: resolution landed on `packages/types/dist/index.d.ts`, the planted sentinel produced TS2305, the positive control produced 0, and 0 source files under any package's `src/` entered the program.

## Disposition per name

| # | document:line | name | imported from | disposition | evidence |
| --- | --- | --- | --- | --- | --- |
| 1 | app-shell:26 | `ObjectRenderer` | `@object-ui/app-shell` | **removed, no same-shape replacement** | `54e3dfbbf refactor(app-shell)!: remove unused stub renderers` — *"never wired up. Real implementations ship from @object-ui/plugin-dashboard and SchemaRenderer in @object-ui/react"* |
| 2 | app-shell:43 | `DashboardRenderer` | `@object-ui/app-shell` | **neighbour package** | exported by `@object-ui/plugin-dashboard`; app-shell's own `src/views/DashboardView.tsx:14` imports it from there |
| 3,4 | components:73,84 | `registerDefaultRenderers` | `@object-ui/components` | **never existed** | zero hits for `git log -S` across all history under `packages/*/src`; the exported init function is `initializeComponents` |
| 5 | components:203 | `registerRenderer` | `@object-ui/react` | **never existed** | same; registration goes through `ComponentRegistry` in `@object-ui/core` |
| 6 | core:25 | `PageSchema` | `@object-ui/core` | **renamed + neighbour** | `@object-ui/types` exports `PageNodeSchema`, whose JSDoc says *"Aligned with @objectstack/spec PageSchema"*; it has `type: 'page'`, `title?` and `body?: SchemaNode[]`, matching the literal exactly |
| 7,8,9 | core:26,27,28 | `FormSchema`, `InputSchema`, `BaseSchema` | `@object-ui/core` | **neighbour package** | all three exported by `@object-ui/types`; core depends on it and re-exports none of it. Confirms the card's hypothesis |
| 10 | core:51 | `DataScope` | `@object-ui/core` | **removed, teach the real surface** | the name exists in `@object-ui/types` but as an **interface** (`data.d.ts:1120`), not a constructible class. Path-only fix trades TS2305 for TS2351. The class is `DataScopeManager`; expression evaluation is a separate export, `evaluateExpression` |
| 11 | core:97 | `defineView` | `@object-ui/core` | **renamed** | `freeze-schema.d.ts`: *"Named `defineView` until objectstack#4115, which is a name @objectstack/spec owns for something else entirely"* → `defineSystemView` |
| 12 | react:166 | `useRegistry` | `@object-ui/react` | **never existed** | zero hits in history; there is no registry hook because the registry is a process-level singleton |
| 13 | guide:80 | `AppManifest` | `@objectstack/spec` | **left — contract question** | see below |
| 14,15 | guide:330 | `useObjectQuery`, `useObjectMutation` | `@object-ui/data-objectstack` | **never existed** | zero hits in history; that package ships the adapter, not hooks. Reads and writes go through `useViewData` in `@object-ui/react` |

Every replacement was checked against the built declaration before being written, and two were additionally checked at runtime rather than by reading types: `evaluateExpression('${user.role === "admin"}', { user: { role: 'admin' } })` returns `true`, and `DataScopeManager.registerScope` / `getScope` round-trips. The `ObjectView` / `DashboardView` / `PageView` prose claim that they resolve their target from the route rather than from props is read off `useParams()` in each source file, and the route shapes quoted are the console's real ones from `console/AppContent.tsx`.

## The one left: `AppManifest`

`AppManifest` **does** exist — at `@objectstack/spec/system`, not the root subpath the guide imports from. Fixing only the path would still be wrong, and would trade one type error for another. `AppManifestSchema` is:

```ts
name: string; label: string; version: string; description?: string;
objects: string[];   // object NAMES
views: string[]; flows: string[]; dependencies: string[]; …
```

The literal beneath the annotation has no `label`, and its `objects` is a **map of full object definitions** (`{ contact: { name, label, fields: { … } } }`), plus `pages` and `navigation`. That is stack-config vocabulary, not an app manifest. The repo's own canonical form for the file it is titled after (`objectstack.config.ts`) is documented in `packages/types/src/index.ts`:

```ts
defineStack({ manifest: { id, version, type: 'app', name }, objects: [], apps: [] })
```

Converting to it means deciding where `name` / `version` / `description` move (into `manifest`), and what `pages[].component` and `navigation` become — `ObjectStackDefinitionSchema` has `pages` but no top-level `navigation`. That is an authoring decision about a **server-project** config whose runtime packages (`@objectstack/runtime`, `@objectstack/objectql`, `@objectstack/plugin-app`, `@objectstack/plugin-hono-server` — all four already unresolvable here, 7 of the page's TS2307s) live in another repo. Guessing it is how a doc acquires its next falsehood, so it is reported instead of written.

## Ledger: five entries re-measured, none added, widened or deleted

Fixing the TS2305s does **not** make any of these documents gateable — each still fails on other diagnostics — so every entry is still required, and each one's reason text is now the freshly measured mix rather than a stale count:

| document | before | after |
| --- | --- | --- |
| `packages/app-shell/README.md` | 1 parse + 18 undefined-name + **TS2305x2** | 1 parse + 14 undefined-name |
| `packages/components/README.md` | 2 undefined-name + **TS2305x3** | 1 undefined-name |
| `packages/core/README.md` | 5 undefined-name + **TS2305x6** + TS2351x1 | 5 undefined-name + TS2339x2 + TS2351x1 |
| `packages/react/README.md` | 10 undefined-name + **TS2305x1** + TS2339x2 | 9 undefined-name + TS2339x2 |
| `content/docs/guide/objectos-integration.mdx` | 36 parse + 10 undefined-name + 7 unresolved-module + **TS2305x3** + TS2339x1 | 36 parse + 10 undefined-name + 7 unresolved-module + **TS2305x1** + TS2339x1 |

The reason strings were produced by a generator whose categorisation was first proven by reproducing all five **current** entries byte-for-byte from the pre-change measurement, then re-run against the ledger as written here — it reads all five back as matching. No entry is added, none is widened, the gate is untouched apart from those five strings, and `--build-filter` is byte-identical before and after, so CI build cost does not move.

`packages/core/README.md`'s count went **up** in one category, which is the honest direction and not a regression: with `defineView` unresolved, `userListView` was an error type and the two `.push` demonstration lines were never checked. Fixing the import is what surfaced them. Both are pre-existing and are filed as #5257.

## Verification

All at `cf2a91b8b`, working tree clean, foreground:

- `node scripts/check-doc-snippet-types.mjs` → **exit 0**; 67 of 67 blocks judged, 0 failed; all three controls proven in the same run.
- `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts` → **20 passed**. Running the script is not running its test; both were run.
- `pnpm exec vitest run` over the five suites that read these documents (`forwardref-props-erasure.guard`, `check-doc-links`, `doc-version-claims`, `readme-shadcn-sync-categories`, `SchemaRenderer.propsResolution`) → **114 passed**.
- `node scripts/check-doc-links.mjs` → valid across 13 scan roots.
- `node scripts/check-control-bytes.mjs` → OK, 4652 files; plus a direct control-byte scan of the changed files only.
- `node scripts/check-doc-component-types.mjs` → every documented component type registered.
- `pnpm turbo run build --filter='@object-ui/site'` → **29/29 successful** (this PR changes `content/`, so CI's docs job builds the site).
- `pnpm lint:root` → 0 errors (24 pre-existing warnings, none in these files); `pnpm type-check:scripts` → clean.

One regression was caught by re-measuring and fixed before commit: the rewritten app-shell section briefly put two root JSX elements in one fence (TS2657). It is two fences now.

## Changeset

`node scripts/check-changeset-presence.mjs` → *"No source of a released package changed in this range, so no changeset is owed"* — 6 files changed, 0 under any released package's `src/`. Following its verdict, no changeset is added.

## Filed, not fixed here

- #5257 — `cloneAsOverride` keeps its input's deep-readonly type, so the documented Tenant/User override clone does not type-check as mutable. Export surface, and this card changes documentation only.
- #5258 — `packages/core/README.md` teaches `new ComponentRegistry()`, but that export is a singleton instance, not a class (TS2351). Different diagnostic class from this card.
- #5259 — `packages/components/README.md` is now one declared fragment from leaving the ledger; the trade is `@object-ui/components` entering the gate's build filter, which is a cost decision under the #4846 ruling rather than a rider on a docs card.

Untouched, as scoped: every package `src/`, `packages/plugin-view` (#5097), `components/renderers/form` (#5201), `examples/hello-world` (#5236).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_