### PR TITLE
fix(plugin-dashboard,i18n): the KPI sub-caption translates from its own `subCaption` key (#4032)

### DIFF
--- a/.changeset/metric-subcaption-own-i18n-key-4032.md
+++ b/.changeset/metric-subcaption-own-i18n-key-4032.md
@@ -1,0 +1,52 @@
+---
+'@object-ui/plugin-dashboard': patch
+'@object-ui/i18n': patch
+---
+
+A KPI card's sub-caption now translates from its own convention key
+
+objectui#4032 item 4. The metric card renders two authored strings, and they
+are two different authored fields:
+
+| authored field        | rendered as             | bundle key                                |
+|-----------------------|-------------------------|-------------------------------------------|
+| `widget.description`  | the shared card header  | `dashboards.<d>.widgets.<id>.description` |
+| `options.description` | the KPI sub-caption     | `dashboards.<d>.widgets.<id>.subCaption`  |
+
+Only the first resolved. The metric dispatch spread `...options` straight
+through, so the sub-caption reached `MetricWidget` as the raw authored English
+and a `zh` dashboard showed a translated header above an untranslated caption.
+
+They get two keys, not one — the objectstack#5428 item-4 ruling (2026-08-06):
+"两个作者字段两个 key". That is why PR #4358 landed items 1-3 and deliberately
+stopped here: at the time `@objectstack/spec` accepted no segment for the
+sub-caption and the only key it would take was `description`, the shared key the
+ruling forbids. objectstack#8056 added `subCaption` to the widget translation
+node, and it ships in `@objectstack/spec@17.0.0` — the version this repo pins.
+
+The server half already existed: `translateDashboard` overlays `subCaption` onto
+`options.description` on the `/meta` path, so a served document was already
+correct. This is the client half — the same key path, for the app bundles
+objectui loads into `I18nProvider` itself.
+
+- `@object-ui/i18n` gains `widgetSubCaption(dashboardName, widgetId, fallback?)`,
+  mirroring `widgetDescription` limb for limb rather than re-implementing
+  namespace discovery inside the plugin.
+- `DashboardRenderer`'s `tWidgetSubCaption` composes the two channels in the
+  order `tWidgetTitle` already fixed — the authored value is collapsed to the
+  active language first (an inline per-locale map, the `pickLocalized` seam),
+  and the plain string that falls out is offered to the bundle as its fallback —
+  so a bundle entry always wins over an inline map, and neither channel is
+  replaced by the other. The resolved value is assigned after the `...options`
+  spread in both the `object-metric` and static-value branches.
+
+The separation is pinned in both directions, because a shared key is exactly
+what a later tidy-up would reach for: the `description` key never reaches
+`options.description`, and `subCaption` never reaches `widget.description`. On a
+`kpi` / `gauge` / `bullet` widget both are on screen at once, so one shared key
+would make a single translation entry overwrite the other field's text.
+
+Untranslated dashboards are unchanged: with no bundle entry the resolver hands
+back exactly what the spread would have, and with nothing authored and nothing
+translated it answers `undefined` rather than `''`, so a card that has no
+sub-caption grows no caption row.

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -358,6 +358,34 @@ export function useObjectLabel() {
     },
 
     /**
+     * Resolve a translated metric-widget SUB-CAPTION within a dashboard.
+     * Convention: `{ns}.dashboards.{dashboardName}.widgets.{widgetId}.subCaption`.
+     * Returns undefined when neither metadata nor translation provides one.
+     *
+     * Deliberately its OWN key, not a second reader of `widgets.{id}.description`.
+     * The KPI card renders two authored strings from two different fields — the
+     * shared card header's `widget.description`, and the sub-caption under the
+     * value, which is authored as `widget.options.description` — and the
+     * objectstack#5428 item-4 ruling (2026-08-06) settled that they get two
+     * keys, not one: 「两个作者字段两个 key」. Collapsing them would make one
+     * translation entry silently retarget the other field on any widget type
+     * that renders both at once (`kpi`, `gauge`, `bullet` — every metric-family
+     * type except the self-contained `metric`).
+     *
+     * `subCaption` is the member objectstack#8056 added to the widget
+     * translation node for exactly this, shipped in `@objectstack/spec@17.0.0`.
+     * The server-side resolver reads the SAME key and overlays it onto
+     * `options.description` (`translateDashboard`), so a document served
+     * through `/meta` and a document translated here land on the same string —
+     * this is the client half of one convention, not a second dialect.
+     */
+    widgetSubCaption: (dashboardName: string, widgetId: string, fallback?: string) => {
+      const fb = fallback ?? '';
+      const resolved = resolve(dashboardSuffixes(dashboardName, `widgets.${widgetId}.subCaption`), fb);
+      return resolved || undefined;
+    },
+
+    /**
      * Resolve translated page label, falling back to pageDef.label.
      * Convention: `{ns}.pages.{pageName}.label`.
      */

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -285,7 +285,7 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
     // ── i18n: convention-based label resolution for dashboard / widget /
     // action text. The dashboard name (`schema.name`) keys all lookups; when
     // it's missing we silently degrade to the raw English fallbacks.
-    const { dashboardLabel, dashboardDescription, dashboardActionLabel, widgetTitle, widgetDescription, fieldLabel } = useObjectLabel();
+    const { dashboardLabel, dashboardDescription, dashboardActionLabel, widgetTitle, widgetDescription, widgetSubCaption, fieldLabel } = useObjectLabel();
     const { t, language } = useObjectTranslation();
 
     /**
@@ -371,6 +371,50 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
         return widgetDescription(dashName, widget.id, fallback);
       },
       [dashName, widgetDescription, resolveLabel],
+    );
+
+    /**
+     * Translate a metric card's SUB-CAPTION — the line under the big number —
+     * using the `{ns}.dashboards.{dashName}.widgets.{widgetId}.subCaption`
+     * convention (objectui#4032 item 4).
+     *
+     * The authored field is `widget.options.description`, NOT
+     * `widget.description`. They are two different authored fields with two
+     * different keys (objectstack#5428 item-4 ruling: 「两个作者字段两个
+     * key」), which is why PR #4358 stopped here instead of routing the
+     * sub-caption through `tWidgetDescription`: `widget.description` feeds the
+     * shared Card header, and on a `kpi` / `gauge` / `bullet` widget BOTH are
+     * on screen at once, so one shared key would make a single translation
+     * entry overwrite the other field's text.
+     *
+     * `subCaption` is the widget-translation-node member objectstack#8056
+     * added, shipped in `@objectstack/spec@17.0.0` (the version this repo
+     * pins). The server already reads the same key on the `/meta` path —
+     * `translateDashboard` overlays it onto `options.description` — so a served
+     * document needs no client work; this is the same key path resolved for the
+     * app bundles objectui loads into `I18nProvider` itself.
+     *
+     * Composition order is the one `tWidgetTitle` fixed: the authored value is
+     * collapsed to the active language FIRST (an inline per-locale map — the
+     * #4208 `pickLocalized` seam), and the plain string that falls out is
+     * offered to the bundle as its fallback, so a bundle entry always wins over
+     * an inline map and the two channels can never disagree about what "the
+     * authored sub-caption" is.
+     *
+     * A translation with no authored counterpart is legitimate and matches the
+     * server: `translateDashboard` writes `options.description` whenever the
+     * bundle carries a non-empty `subCaption`, whether or not the author wrote
+     * one. Absent both, this answers `undefined` rather than `''` —
+     * `MetricWidget` gates its whole caption row on the value's truthiness.
+     */
+    const tWidgetSubCaption = useCallback(
+      (widget: DashboardWidgetSchema): string | undefined => {
+        const authored = (widget.options as Record<string, unknown> | undefined)?.description;
+        const fallback = resolveLabel(authored);
+        if (!dashName || !widget.id) return fallback;
+        return widgetSubCaption(dashName, widget.id, fallback);
+      },
+      [dashName, widgetSubCaption, resolveLabel],
     );
 
     // Install host-supplied modal/script handlers on the underlying ActionRunner.
@@ -636,6 +680,16 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                 // spec-valid inline map that `resolveLabel` could not read, so
                 // an authored title silently became the string `"metric"`.
                 const label = tWidgetTitle(widget) || widgetType;
+                // objectui#4032 item 4 — and the card's SUB-CAPTION comes from
+                // its own key, `…widgets.{id}.subCaption`, because it is a
+                // different authored field (`options.description`) from the
+                // shared header's `widget.description`. Assigned AFTER the
+                // `...options` spread in both branches below: the spread is
+                // what carries the raw authored `options.description` through,
+                // and this is the resolved value that replaces it. When nothing
+                // translates it, `tWidgetSubCaption` hands back exactly what the
+                // spread would have — so an untranslated dashboard is byte-identical.
+                const subCaption = tWidgetSubCaption(widget);
                 // provider: 'object' — ObjectMetricWidget aggregates server-side.
                 if (isObjectProvider(widgetData)) {
                     const providerAgg = widgetData.aggregate;
@@ -644,6 +698,7 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                         ...options,
                         objectName: widgetData.object,
                         label,
+                        description: subCaption,
                         aggregate: providerAgg ? {
                             field: providerAgg.field,
                             function: providerAgg.function,
@@ -660,6 +715,7 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                     type: 'metric',
                     ...options,
                     label,
+                    description: subCaption,
                     value: options.value ?? rows[0]?.[valueField] ?? '—',
                 };
             }

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.metricSubCaption.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.metricSubCaption.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4032 item 4 — the KPI card's SUB-CAPTION.
+ *
+ * The metric card renders two authored strings, and they are two DIFFERENT
+ * authored fields with two DIFFERENT convention keys (objectstack#5428 item-4
+ * ruling, 2026-08-06: 「两个作者字段两个 key」):
+ *
+ *   | authored field         | rendered as              | bundle key                                    |
+ *   |------------------------|--------------------------|-----------------------------------------------|
+ *   | `widget.description`   | the SHARED card header   | `dashboards.<d>.widgets.<id>.description`      |
+ *   | `options.description`  | the KPI card sub-caption | `dashboards.<d>.widgets.<id>.subCaption`       |
+ *
+ * `subCaption` is the member objectstack#8056 added to the widget translation
+ * node (shipped in `@objectstack/spec@17.0.0`, the version this repo pins).
+ * PR #4358 landed items 1-3 and deliberately STOPPED here, because at the time
+ * every candidate segment was rejected by the spec and the only accepted key
+ * was `description` — the shared key the ruling forbids.
+ *
+ * The server half already exists: `translateDashboard` overlays `subCaption`
+ * onto `options.description` on the `/meta` path. These tests pin the CLIENT
+ * half — the same key path, resolved through the #4358 seam, for the app
+ * bundles objectui loads into `I18nProvider` itself.
+ *
+ * DIRECTIONS, written before the reverse verification was run:
+ *
+ *  - **(a) bundle `subCaption` → sub-caption: RED before the change.** Nothing
+ *    in the renderer reads `subCaption`; the metric dispatch spreads
+ *    `...options` straight through, so `options.description` reaches
+ *    `MetricWidget` as the raw authored English.
+ *  - **(c) bundle `subCaption` AND `description` on ONE widget: HALF-RED.** The
+ *    shared card header already translates from `description` (#4358), so that
+ *    half is GREEN before the change; the sub-caption half is RED. This is the
+ *    separation pin, and the asymmetry is the point — the two keys must land in
+ *    two different places, and a future tidy-up that collapses them to one key
+ *    would turn (b)/(c) red rather than passing quietly.
+ *  - **(f) bundle beats an inline per-locale map: RED before the change.**
+ *  - **(b) `description` must NOT reach the sub-caption: GREEN on both sides.**
+ *    Nothing routes it today; the pin exists so nothing starts to.
+ *  - **(d) no `subCaption` entry → untouched: GREEN on both sides.** Same
+ *    reference semantics as `title`: an app with no translations keeps the exact
+ *    bytes it renders today, and a widget with no authored sub-caption grows no
+ *    caption row (the resolver must answer `undefined`, never `''`).
+ *  - **(e) inline per-locale map alone: GREEN on both sides.** `MetricWidget`
+ *    already collapses it via `pickLocalized` (#4208's seam). The fix must
+ *    compose the two channels in the SAME fixed order `tWidgetTitle` uses —
+ *    collapse the authored value to the active language FIRST, then offer the
+ *    plain string to the bundle as its fallback — not replace this channel.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import type { DashboardComponentSchema } from '@object-ui/types';
+// Module scope, never a hook — AGENTS.md §测试纪律. The dashboard renders each
+// widget through `SchemaRenderer`, which resolves `metric` / `kpi` from the
+// registry, populated as a side effect of this barrel.
+import { DashboardRenderer } from '../index';
+
+afterEach(cleanup);
+
+/**
+ * `crm` is discovered as an app namespace because it carries a `dashboards`
+ * sub-key — the same discovery every other convention lookup performs.
+ *
+ * `revenue` carries BOTH keys with visibly different values, which is what
+ * makes the separation assertions in (c) meaningful: if the two ever collapse
+ * onto one key, one of the two strings goes missing.
+ */
+const ZH_BUNDLE = {
+  zh: {
+    crm: {
+      dashboards: {
+        sales: {
+          widgets: {
+            revenue: {
+              title: '总收入',
+              description: '卡片头部描述',
+              subCaption: '本季度已赢单',
+            },
+            // A widget whose bundle entry has `description` but NO
+            // `subCaption` — the (b) direction.
+            winrate: {
+              title: '赢单率',
+              description: '只属于卡片头部',
+            },
+            // Sub-caption only, no `description` — used by (e)'s precedence
+            // control is NOT this one; this one pins that a `subCaption`
+            // entry alone is enough.
+            pipeline: {
+              subCaption: '按阶段推进',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+function dashboard(...widgets: Record<string, unknown>[]): DashboardComponentSchema {
+  return {
+    type: 'dashboard',
+    name: 'sales',
+    widgets,
+  } as unknown as DashboardComponentSchema;
+}
+
+function renderIn(language: string, schema: DashboardComponentSchema) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false, resources: ZH_BUNDLE }}>
+      <DashboardRenderer schema={schema} />
+    </I18nProvider>,
+  );
+}
+
+describe('DashboardRenderer — the KPI sub-caption translates from its OWN convention key (#4032 item 4)', () => {
+  it('(a) renders the bundle `subCaption` on a self-contained metric card', () => {
+    renderIn('zh', dashboard({
+      id: 'revenue',
+      type: 'metric',
+      title: 'Total Revenue',
+      options: { value: 1930000, description: 'Won this quarter' },
+    }));
+
+    expect(screen.getByText('本季度已赢单')).toBeTruthy();
+    // The authored English must not survive beside the translation.
+    expect(screen.queryByText('Won this quarter')).toBeNull();
+  });
+
+  it('(a2) resolves a `subCaption`-only bundle entry (no `description` sibling)', () => {
+    renderIn('zh', dashboard({
+      id: 'pipeline',
+      type: 'metric',
+      title: 'Pipeline',
+      options: { value: 42, description: 'Advancing by stage' },
+    }));
+
+    expect(screen.getByText('按阶段推进')).toBeTruthy();
+    expect(screen.queryByText('Advancing by stage')).toBeNull();
+  });
+
+  it('(b) SEPARATION — the `description` key never reaches `options.description`', () => {
+    // `winrate` has a `description` entry and NO `subCaption`. The sub-caption
+    // must stay the authored English: the card header's translation is not a
+    // substitute for the sub-caption's, and borrowing it is exactly the shared
+    // key the item-4 ruling forbids.
+    renderIn('zh', dashboard({
+      id: 'winrate',
+      type: 'metric',
+      title: 'Win Rate',
+      options: { value: '42%', description: 'Closed-won share' },
+    }));
+
+    expect(screen.getByText('Closed-won share')).toBeTruthy();
+    expect(screen.queryByText('只属于卡片头部')).toBeNull();
+  });
+
+  it('(c) SEPARATION — one widget, both keys, two destinations', () => {
+    // `kpi` is metric-family but NOT self-contained, so it takes the shared
+    // Card header (fed by `widget.description` → the `description` key) AND
+    // renders a metric card inside it (fed by `options.description` → the
+    // `subCaption` key). Both are visible at once, which is the only place the
+    // two-fields-two-keys contract can be observed end to end in the renderer.
+    renderIn('zh', dashboard({
+      id: 'revenue',
+      type: 'kpi',
+      title: 'Total Revenue',
+      description: 'Card header caption',
+      options: { value: 1930000, description: 'Won this quarter' },
+    }));
+
+    // Header half — already green since #4358.
+    expect(screen.getByText('卡片头部描述')).toBeTruthy();
+    expect(screen.queryByText('Card header caption')).toBeNull();
+    // Sub-caption half — this card.
+    expect(screen.getByText('本季度已赢单')).toBeTruthy();
+    expect(screen.queryByText('Won this quarter')).toBeNull();
+    // And they are DISTINCT strings in distinct nodes: a collapse onto one key
+    // would render one of them twice and drop the other.
+    expect(screen.getAllByText('卡片头部描述')).toHaveLength(1);
+    expect(screen.getAllByText('本季度已赢单')).toHaveLength(1);
+  });
+
+  it('(d) leaves a metric with no `subCaption` entry exactly as authored', () => {
+    renderIn('zh', dashboard({
+      id: 'untranslated',
+      type: 'metric',
+      title: 'Bookings',
+      options: { value: 12, description: 'Signed this week' },
+    }));
+
+    expect(screen.getByText('Signed this week')).toBeTruthy();
+  });
+
+  it('(d2) grows no caption row when nothing authored one and nothing translates it', () => {
+    // The resolver must answer `undefined`, not `''`: `MetricWidget` gates the
+    // whole caption row on `(trend || description)`, so an empty string is the
+    // difference between "no row" and "an empty row with the muted styling".
+    const { container } = renderIn('zh', dashboard({
+      id: 'untranslated',
+      type: 'metric',
+      title: 'Win Rate',
+      options: { value: '42%' },
+    }));
+
+    expect(container.textContent).toBe('Win Rate42%');
+  });
+
+  it('(e) still collapses an inline per-locale map on `options.description`', () => {
+    // The #4208 channel `MetricWidget` already owns. It must survive: the fix
+    // composes the two channels, it does not replace this one.
+    renderIn('zh', dashboard({
+      id: 'untranslated',
+      type: 'metric',
+      title: 'Bookings',
+      options: {
+        value: 12,
+        description: { en: 'Signed this week', 'zh-CN': '本周已签' },
+      },
+    }));
+
+    expect(screen.getByText('本周已签')).toBeTruthy();
+    expect(screen.queryByText('Signed this week')).toBeNull();
+  });
+
+  it('(f) prefers the bundle `subCaption` over an inline per-locale map', () => {
+    // Same fixed composition order `tWidgetTitle` applies: the authored value
+    // is collapsed to the active language FIRST and handed to the bundle as its
+    // fallback, so a bundle entry always wins.
+    renderIn('zh', dashboard({
+      id: 'revenue',
+      type: 'metric',
+      title: 'Total Revenue',
+      options: {
+        value: 1930000,
+        description: { en: 'Won this quarter', 'zh-CN': '内联副标题' },
+      },
+    }));
+
+    expect(screen.getByText('本季度已赢单')).toBeTruthy();
+    expect(screen.queryByText('内联副标题')).toBeNull();
+  });
+
+  it('(g) falls back to the authored sub-caption when the dashboard has no name', () => {
+    // No `name` → no convention key to build. The authored value is all there
+    // is, and it must still render.
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false, resources: ZH_BUNDLE }}>
+        <DashboardRenderer
+          schema={{
+            type: 'dashboard',
+            widgets: [{
+              id: 'revenue',
+              type: 'metric',
+              title: 'Total Revenue',
+              options: { value: 1930000, description: 'Won this quarter' },
+            }],
+          } as unknown as DashboardComponentSchema}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('Won this quarter')).toBeTruthy();
+    expect(screen.queryByText('本季度已赢单')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #4032

Item 4 of the objectstack#5428 ruling (2026-08-06) — the half PR #4358 deliberately stopped on. Items 1-3 landed there on 2026-08-11 and are untouched here.

## What was broken

A metric card renders two authored strings, and they are two different authored fields:

| authored field | rendered as | bundle key |
|---|---|---|
| `widget.description` | the shared card header | `dashboards.{dash}.widgets.{id}.description` |
| `widget.options.description` | the KPI sub-caption, under the big number | `dashboards.{dash}.widgets.{id}.subCaption` |

Only the first resolved. The metric dispatch in `DashboardRenderer` spread `...options` straight through, so the sub-caption reached `MetricWidget` as the raw authored English — a `zh` dashboard showed a translated header above an untranslated caption.

They get two keys, not one. The ruling's own words: 「两个作者字段两个 key」. That is why #4358 stopped rather than working around it — at the time `@objectstack/spec` accepted no segment for the sub-caption and the only key it would take was `description`, the shared key the ruling forbids. objectstack#8056 added `subCaption` to the widget translation node, and it ships in `@objectstack/spec@17.0.0`, the version this repo pins (verified in the resolved dist, not by merge date: `subCaption` appears in `node_modules/@objectstack/spec/dist/index.d.mts`, `dist/system/index.d.ts` and `dist/index.mjs`).

The server half already existed — `translateDashboard` overlays `subCaption` onto `options.description` on the `/meta` path, so a served document was already correct. This is the client half: the same key path, for the app bundles objectui loads into `I18nProvider` itself.

## What changed

- **`packages/i18n/src/useObjectLabel.ts`** gains `widgetSubCaption(dashboardName, widgetId, fallback?)`, mirroring `widgetDescription` limb for limb.
- **`packages/plugin-dashboard/src/DashboardRenderer.tsx`** gains `tWidgetSubCaption`, composing the two channels in the order `tWidgetTitle` already fixed: the authored value is collapsed to the active language first (an inline per-locale map, the `pickLocalized` seam from #4208), and the plain string that falls out is offered to the bundle as its fallback. So a bundle entry always wins over an inline map, and neither channel replaces the other. The result is assigned **after** the `...options` spread in both the `object-metric` and the static-value branch.

### Surface note — `packages/i18n` is outside the dispatched file surface

The dispatch named `packages/plugin-dashboard/src/**`. The resolver had to land in `packages/i18n` instead, and this is why: `useObjectLabel`'s namespace discovery, the `stripNamespace` candidate fallback and the `I18N_PROBE_FLAG` probe semantics are all closures private to that hook — none is exported. Implementing the lookup inside the plugin would have meant re-implementing all three, which is the "fourth dialect" the existing `resolveLabel` comment in `DashboardRenderer` (and objectstack#4115) exists to prevent. The addition is purely additive — one new member on the hook's returned object, no existing behaviour touched — and nothing else in the repo pins that object's key set.

## The separation pin, in both directions

A shared key is exactly what a later tidy-up would reach for, so the renderer half is pinned:

- the `description` key never reaches `options.description`
- `subCaption` never reaches `widget.description`

Test `(c)` observes both at once on a `kpi` widget — metric-family but not self-contained, so it takes the shared card header **and** renders a metric card inside it. One widget, both keys, two destinations, asserted as two distinct nodes.

## Reverse verification — predictions written before the run

Predictions are in the test file header, committed before the implementation. Pre-change run on `ebbafa59c`:

```
Tests  4 failed | 5 passed (9)
  x (a)  bundle subCaption on a self-contained metric
  x (a2) subCaption-only bundle entry
  x (c)  SEPARATION — one widget, both keys, two destinations
  x (f)  bundle beats an inline per-locale map
  ok (b) (d) (d2) (e) (g)
```

**Predicted vs observed: exact match**, including the deliberate asymmetries — `(c)` was predicted half-red (its header half has been green since #4358, only its sub-caption half was red), and `(b)`/`(d)`/`(d2)`/`(e)`/`(g)` were predicted green on **both** sides: they pin that nothing routes the header key into the sub-caption today, that an untranslated dashboard is byte-identical, that a card with no sub-caption grows no caption row (the resolver answers `undefined`, never `''` — `MetricWidget` gates the whole row on truthiness), and that the pre-existing inline-map channel survives.

Post-change, all 9 pass and the #4358 title suite (`DashboardRenderer.metricI18n.test.tsx`, 6 tests) is unregressed.

A second reverse verification covers the cross-package type change: renaming the destructured member to `widgetSubCaptionZZ` was predicted to turn `tsc` red, and did — `src/DashboardRenderer.tsx(288,105): error TS2339: Property 'widgetSubCaptionZZ' does not exist`, exit 2 — which proves the type-check reads the rebuilt `packages/i18n/dist/useObjectLabel.d.ts` rather than a cached declaration. Restored from the commit; working tree verified clean.

## Local gates — all run at `3b1238bea` (the final commit)

| gate | result |
|---|---|
| `pnpm exec vitest run packages/plugin-dashboard packages/i18n` | 110 files, 1415 tests, all pass |
| `type-check` for `plugin-dashboard`, `i18n`, `react` | pass (script names echoed, no zero-match) |
| `lint` for `plugin-dashboard`, `i18n` | 0 errors (317 pre-existing warnings) |
| `check:control-bytes` | pass — 4658 tracked text files |
| `check:i18n-keys` | pass |
| `check:i18n-drift` | pass — 0 en values changed |
| `check:changeset-presence` / `no-major` / `fixed` | pass |
| `check:spec-symbols`, `check:action-forward-parity`, `check:phantom-deps`, `check:self-import`, `check:esm-specifiers` | pass |

Narrowed deliberately to the derived set; the full farm is CI's. Dependency closure built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-dashboard^...' build`) so `tsc` read real declarations — the package tsconfig overrides `paths` to `@/*` only, so its `@object-ui/*` imports resolve through each dependency's `dist`.

Changeset: `.changeset/metric-subcaption-own-i18n-key-4032.md`, `patch` for both packages (never `major` — the fixed group would carry all 39 packages up with it).

## Deliberately not changed

`widget.description` still renders nowhere on a **self-contained** `metric`, which has no shared card header. That is the ruling's design, not a leftover: routing it into the sub-caption is precisely the shared key item 4 forbids. An author who wants a caption on that card writes `options.description` and translates it under `subCaption`, which is what this change makes work. Named here so the closure is auditable rather than silent.

Also untouched, per the dispatch: `packages/types`, `packages/app-shell/src/views/metadata-admin/**` (#5227 in flight), and the `dashboardComponents` keying surface (#5064 / PR #5207, parked on the #5208 decision).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_