### PR TITLE
fix(app-shell): diagnose non-literal elements in predicate `in` sets

### DIFF
--- a/.changeset/predicate-in-array-parse-catch-diagnostic-4266.md
+++ b/.changeset/predicate-in-array-parse-catch-diagnostic-4266.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`predicate.ts`'s `in [...]` membership check now names an element it cannot
+parse instead of silently discarding the whole set.
+
+`path in [...]` hands the bracketed text to `parseLiteral`'s array branch,
+which JSON-parses it after normalising quotes. An element that is not a JSON
+literal — a path, a bare identifier, a trailing comma — made that
+`JSON.parse` throw, and the `catch` returned `[]` with nothing in the
+console. `[].includes(anything)` is `false`, so the predicate silently read
+FALSE FOR EVERY ROW, and — because the parse is whole-set, not per-element —
+one bad element discarded every good literal sitting next to it too:
+`data.type in ['text', data.a]` collapsed exactly as hard as `data.type in
+[data.a]` alone.
+
+Same family as objectui#4049 (a silently wrong verdict, zero warning) and the
+same ruling: **diagnose only, zero semantic change.** The `catch` still
+returns `[]` — an `in` set that fails to parse is still, and remains, the
+empty set; this evaluator does not gain the ability to resolve a path inside
+`in [...]` (that stays outside the declared subset). All that changes is that
+a dev-mode `console.warn` now names the predicate and, best-effort, the
+element that broke the parse.
+
+Fixes objectui#4266.

--- a/packages/app-shell/src/views/metadata-admin/predicate.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/predicate.test.ts
@@ -454,3 +454,106 @@ describe('a path-shaped right-hand side is diagnosed, not resolved (objectui#404
     expect(evaluatePredicate(expr as string, scope(row as Record<string, unknown>))).toBe(expected);
   });
 });
+
+/* ── 8. a non-literal element inside `in [...]` is diagnosed (objectui#4266) ── */
+
+/**
+ * objectui#4266. `parseLiteral`'s array branch JSON-parses the bracketed text
+ * after normalising quotes; an element that is not a JSON literal (a path, a
+ * bare identifier, a trailing comma) makes that `JSON.parse` throw, and the
+ * `catch` returned `[]` with nothing in the console — `in` reads FALSE FOR
+ * EVERY ROW, and because the parse is whole-set, one bad element discards the
+ * good literals sitting next to it too.
+ *
+ * Ruling on this card: **diagnose only, zero semantic change** — the same
+ * posture #4049 took for the right-hand-literal tail. The `catch` still
+ * returns `[]`; the verdicts are pinned IDENTICAL before and after (§8.3);
+ * all that changes is that the console stops being silent.
+ */
+describe('a non-literal element inside `in [...]` is diagnosed, not resolved (objectui#4266)', () => {
+  /* 8.1 — it fires, and it names the predicate and the culprit element */
+
+  it('`data.type in [data.a]` warns, naming the predicate and the unparseable element', () => {
+    expect(evaluatePredicate('data.type in [data.a]', scope({ type: 'text', a: 'text' }))).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warnings()).toContain('data.type in [data.a]');
+    expect(warnings()).toContain('`data.a`');
+  });
+
+  it('a bare (unresolvable-shaped) identifier element is named too', () => {
+    expect(evaluatePredicate("data.type in ['text', foo]", scope({ type: 'text' }))).toBe(false);
+    expect(warnings()).toContain('`foo`');
+  });
+
+  it('a trailing comma with otherwise-literal elements still warns, falling back to the whole set', () => {
+    // No single element is at fault here — every element parses fine on its
+    // own, so `findUnparseableSetElement` finds none, and the warning names
+    // the whole broken set instead of guessing at (and misnaming) a culprit.
+    expect(evaluatePredicate("data.type in ['a','b',]", scope({ type: 'a' }))).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warnings()).toContain("data.type in ['a','b',]");
+    expect(warnings()).not.toContain('containing `');
+  });
+
+  /* 8.2 — one bad element still discards the good literals beside it, and the
+     warning names the ONE that actually broke the parse, not the whole set
+     blindly */
+
+  it('one non-literal element collapses the WHOLE set, including the good literals next to it', () => {
+    // Both sides hold 'text' — a working `in` would be true. It is false,
+    // matching the pre-fix whole-set collapse; only the console changes.
+    expect(evaluatePredicate("data.type in ['text', data.a]", scope({ type: 'text', a: 'text' }))).toBe(
+      false,
+    );
+    expect(warnings()).toContain('`data.a`');
+    // The warning names the culprit, not the innocent literal beside it.
+    expect(warnings()).not.toContain("containing `'text'`");
+  });
+
+  /* 8.3 — the zero-semantics proof: verdicts identical to pre-change */
+
+  it.each([
+    ['data.type in [data.a]', { type: 'text', a: 'text' }, false], // would be true if paths resolved
+    ["data.type in ['text', data.a]", { type: 'text', a: 'text' }, false], // good literal discarded too
+    ["data.type in [data.a,]", { type: 'text', a: 'text' }, false],
+  ])('%s over %j is still %s — the diagnostic changes no verdict', (expr, row, expected) => {
+    expect(evaluatePredicate(expr, scope(row as Record<string, unknown>))).toBe(expected);
+  });
+
+  /* 8.4 — controls: literal-only `in` sets are completely unaffected */
+
+  it.each([
+    ["data.type in ['text','textarea']", { type: 'text' }, true],
+    ["data.type in ['number','currency']", { type: 'text' }, false],
+    ["data.type in ['a', 'b', 'c']", {}, false],
+  ])('%s over %j → %s, silently (literal path unperturbed)', (expr, row, expected) => {
+    expect(evaluatePredicate(expr, scope(row as Record<string, unknown>))).toBe(expected);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  /* 8.5 — warn-once discipline, same bar as #6936 and #4049 */
+
+  it('warns ONCE per (predicate, set) pair, not once per evaluation', () => {
+    for (let i = 0; i < 5; i++) evaluatePredicate('data.type in [data.a]', scope({ type: 'text', a: 'x' }));
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('but a different predicate carrying the same broken set gets its own warning', () => {
+    evaluatePredicate('data.type in [data.a]', scope({ type: 'text', a: 'x' }));
+    evaluatePredicate('data.kind in [data.a]', scope({ kind: 'text', a: 'x' }));
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  /* 8.6 — dev-mode only */
+
+  it('the diagnostic is dev-mode only', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      expect(evaluatePredicate('data.type in [data.a]', scope({ type: 'text', a: 'text' }))).toBe(false);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/predicate.ts
+++ b/packages/app-shell/src/views/metadata-admin/predicate.ts
@@ -104,6 +104,43 @@
  * header says, this file is an interim stand-in for `@objectstack/formula`, so
  * **this diagnostic retires with the file** when ROADMAP M9 lands CEL. Do not
  * grow it into a second evaluator.
+ *
+ * ## An unparseable element inside `in [...]` also fails silently (objectui#4266)
+ *
+ * `path in [...]` hands the bracketed text to `parseLiteral`'s array branch,
+ * which JSON-parses it after normalising quotes. An element that is not a JSON
+ * literal — a path, a bare identifier, a trailing comma — makes that
+ * `JSON.parse` throw, and the `catch` returned `[]` with nothing in the
+ * console. `[].includes(anything)` is `false`, so the predicate silently reads
+ * FALSE FOR EVERY ROW, and — because the parse is whole-set, not per-element —
+ * one bad element discards every good literal sitting next to it too:
+ * `data.type in ['text', data.a]` collapsed exactly as hard as `data.type in
+ * [data.a]` alone.
+ *
+ * Same family as objectui#4049 (silently wrong verdict, zero warning) and the
+ * same ruling: **diagnose only, zero semantic change.** The `catch` still
+ * returns `[]` — an `in` set that fails to parse is still, and remains, the
+ * empty set — this file does not gain the ability to resolve a path inside
+ * `in [...]` (that stays outside the declared subset; #4049 already draws
+ * that boundary for the right side of `==`/`!=` and it is not reopened here).
+ * All that changes is that the console names the predicate and, best-effort,
+ * the element that broke the parse, instead of staying silent. Verdicts are
+ * pinned identical before and after in `predicate.test.ts` §8.3, the same
+ * shape as #4049's §7.3.
+ *
+ * A louder option — making the whole predicate throw so the top-level
+ * fail-open in {@link evaluatePredicate} turns it `true`, mirroring
+ * objectstack#6936's unresolved-path ruling — was considered and rejected:
+ * #6936's `true` verdict corrects a fail-CLOSED bug (a hidden field is worse
+ * than a shown one), but here the existing verdict (`false`, i.e. hidden) is
+ * not a bug — it is the documented behaviour for a set this evaluator cannot
+ * parse, same as `#4049`'s tail returning the right-hand text verbatim
+ * instead of resolving it. Flipping it to fail-open `true` would be a
+ * semantic change with no ruling behind it, and would make an authoring
+ * mistake (a stray non-literal element) MORE visible than a correctly
+ * authored predicate that legitimately evaluates false — exactly backwards.
+ *
+ * This diagnostic retires with the file at ROADMAP M9, same as #4049's.
  */
 
 export function evaluatePredicate(
@@ -151,10 +188,20 @@ const warnedUnresolvedPaths = new Set<string>();
  */
 const warnedPathShapedLiterals = new Set<string>();
 
+/**
+ * The same warn-once discipline for the `in`-array parse-failure diagnostic
+ * (objectui#4266), keyed on (raw set text, predicate) for the same reason as
+ * the two Sets above: keying on the set text alone would report the first
+ * predicate carrying it and stay silent about a sibling predicate that
+ * happens to spell the same broken set.
+ */
+const warnedUnparseableInSets = new Set<string>();
+
 /** Reset the warn-once memos. Exported for tests. */
 export function resetPredicateWarnings(): void {
   warnedUnresolvedPaths.clear();
   warnedPathShapedLiterals.clear();
+  warnedUnparseableInSets.clear();
 }
 
 const isDev = (): boolean =>
@@ -207,6 +254,56 @@ function warnPathShapedLiteral(text: string, source: string): void {
       'paths, that is outside this evaluator\'s subset: it is an interim stand-in for ' +
       '`@objectstack/formula` until CEL lands (ROADMAP M9), and predicate expressions are ' +
       'validated at publish time (objectstack#7010). objectui#4049.',
+  );
+}
+
+/**
+ * Best-effort identification of WHICH element inside an unparseable `in [...]`
+ * set actually broke the parse — for the warning text only, never to change
+ * the return value. Splits on top-level commas (reusing `splitTopLevel`,
+ * which already tracks bracket depth and quotes for the `&&`/`||` splitters
+ * above) and re-runs the exact same quote-normalising `JSON.parse` the array
+ * branch itself uses, one element at a time, so the reported culprit is
+ * judged by literally the same rule that judged the whole set. Returns `null`
+ * when every individual element parses fine on its own (e.g. a stray trailing
+ * comma broke the whole-string parse but no single element is at fault) —
+ * the warning then falls back to naming the whole set.
+ */
+function findUnparseableSetElement(raw: string): string | null {
+  const inner = raw.slice(1, -1);
+  if (!inner.trim()) return null;
+  for (const part of splitTopLevel(inner, ',')) {
+    const el = part.trim();
+    if (!el) continue;
+    try {
+      const json = el.replace(/'([^']*)'/g, (_, innerStr) => JSON.stringify(innerStr));
+      JSON.parse(json);
+    } catch {
+      return el;
+    }
+  }
+  return null;
+}
+
+function warnUnparseableInSet(raw: string, source: string): void {
+  if (!isDev()) return;
+  const memo = `${raw}::${source}`;
+  if (warnedUnparseableInSets.has(memo)) return;
+  warnedUnparseableInSets.add(memo);
+  const element = findUnparseableSetElement(raw);
+  console.warn(
+    `[metadata-admin] visibility predicate \`${source}\` has an \`in\` set \`${raw}\`` +
+      (element != null
+        ? ` containing \`${element}\`, which is not a literal this evaluator can parse — `
+        : ', which this evaluator could not parse — ') +
+      'the WHOLE set was treated as EMPTY, so the predicate is FALSE for every row (not just the ' +
+      'element that failed — one bad element discards the good literals next to it too). This ' +
+      "evaluator only supports literal elements inside `in [...]` (supported subset: `path in " +
+      "['a','b']`); it does not resolve paths there — paths resolve only on the LEFT of an operator " +
+      '(objectui#4049). If you meant a literal, quote it. If you meant to test membership against ' +
+      "another field, that is outside this evaluator's subset: it is an interim stand-in for " +
+      '`@objectstack/formula` until CEL lands (ROADMAP M9), and predicate expressions are validated ' +
+      'at publish time (objectstack#7010). objectui#4266.',
   );
 }
 
@@ -334,6 +431,11 @@ function parseLiteral(raw: string, source: string): unknown {
       const json = s.replace(/'([^']*)'/g, (_, inner) => JSON.stringify(inner));
       return JSON.parse(json);
     } catch {
+      // Whole-set parse failure (a non-literal element, a trailing comma, …).
+      // Diagnose only (objectui#4266) — the verdict is UNTOUCHED: the set is
+      // still `[]`, `in` is still false for every row. See the header section
+      // "An unparseable element inside `in [...]` also fails silently".
+      warnUnparseableInSet(s, source);
       return [];
     }
   }


### PR DESCRIPTION
Fixes #4266

## What

`predicate.ts`'s `in [...]` array branch JSON-parses the bracketed text and, on any parse failure (a non-literal element — a path, a bare identifier, a trailing comma), the `catch` returned `[]` with nothing in the console. `[].includes(anything)` is `false`, so the predicate silently read **FALSE FOR EVERY ROW** — and because the parse is whole-set, not per-element, one bad element discarded every good literal sitting next to it too: `data.type in ['text', data.a]` collapsed exactly as hard as `data.type in [data.a]` alone.

## Fix

**Diagnose only, zero semantic change** — the ruling this card asked me to measure against #4049's precedent, and matched it: the `catch` still returns `[]`; an `in` set that fails to parse is still, and remains, the empty set. A dev-mode `console.warn` now names the predicate and, best-effort, the element that broke the parse (`findUnparseableSetElement`, which re-parses each top-level comma-separated element with the same quote-normalising `JSON.parse` the array branch already uses — for the warning text only, never to change the return value). Falls back to naming the whole set when no single element is individually at fault (e.g. a bare trailing comma). Warn-once keyed on `(raw set text, predicate)`, same discipline as the two existing diagnostics in this file (#6936, #4049).

⛔ Does **not** widen the declared subset — a path inside `in [...]` still does not resolve; it is still reported as broken, just no longer silently.

A louder alternative (throw so the whole predicate fails open `true`, mirroring #6936) was considered and rejected — see the new header section in `predicate.ts` for the reasoning: `false` here is the *documented* behavior for an unparseable set, not a bug the way an unresolved path was, so flipping it to fail-open would be an unruled semantic change.

## Premise re-verification

Triage verified on `origin/main` @ `b954120` (a week old). Re-verified on current `main` @ `bc2922a8` (post the two merges from #5227/PR5263 that touched `widgets.tsx`/`loadState.ts` in the same directory) — the array branch and its whole-set `catch { return []; }` were still exactly as described. Also checked whether ROADMAP M9 (real CEL) has landed: `@objectstack/formula`'s `cel-engine.ts` exists and is already used elsewhere in `app-shell` (`ExpressionProvider.tsx`, `celAuthoring.ts`, `clientValidation.ts`, …), but `SchemaForm.tsx` is still the sole consumer of `predicate.ts`'s `evaluatePredicate` — M9 has not replaced this specific evaluator, so the card is live.

## Tests

`predicate.test.ts` §8 (new): non-literal element fires + names it (bare identifier, path-shaped, amid good literals, trailing-comma fallback), warn-once per (predicate, set) pair, dev-mode-only, and a `§8.3` zero-semantics table pinning verdicts identical to the pre-fix `[]` shape — the same proof-shape as #4049's §7.3. §8.4 pins literal-only `in` sets completely unaffected (same verdict, silent).

Reverse-verification: restored the pre-fix two-line `catch { return []; }`, predicted exactly the 6 new assertions that reference the warning would go red (the two `toHaveBeenCalledTimes` warn-count tests and the four `toContain(...)` on warning text) while the rest of the file (88 tests, including the new §8.3/§8.4 verdict-only pins) stays green. Observed: **exactly those 6 red, 88 green** — restored the fix afterward from the committed branch state and re-ran to confirm 94/94 green again.

## Gates run locally

- `pnpm --filter '@object-ui/app-shell^...' build` (dependency closure) — clean
- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/predicate.test.ts` — 94/94 passed (run from repo root per the package-level-vitest guard in this repo, objectui#3378)
- `pnpm --filter @object-ui/app-shell type-check` — clean
- `pnpm --filter @object-ui/app-shell exec eslint src/views/metadata-admin/predicate.ts src/views/metadata-admin/predicate.test.ts` — 0 errors (1 pre-existing `no-explicit-any` warning, unrelated line in `resolveValue`)
- `node scripts/check-control-bytes.mjs` + explicit control-byte grep on both changed files — clean
- `node scripts/check-changeset-presence.mjs` — 1 changeset present for the 1 released package touched
- i18n gates (`check:i18n-keys`/`check:i18n-drift`): N/A — this diagnostic is a dev-mode `console.warn`, same as the two existing diagnostics in this file, neither of which goes through `t()`/i18n

Final commit: `bb75ca165`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_