### PR TITLE
docs(core): fix ComponentRegistry singleton example in README

### DIFF
--- a/.changeset/core-readme-registry-singleton-5258.md
+++ b/.changeset/core-readme-registry-singleton-5258.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/core': patch
+---
+
+Fix `packages/core/README.md`'s Component Registry example, which taught
+`new ComponentRegistry()` against an exported singleton **instance**, not a
+class — the built `packages/core/dist/registry/Registry.d.ts` declares
+`export declare const ComponentRegistry: Registry<any>`, so the snippet did
+not compile (`TS2351: This expression is not constructable`, measured by the
+objectui#5138 doc-snippet type gate). A reader who copied it got a compile
+error; if `new ComponentRegistry()` had compiled it would have produced a
+second, empty registry nothing renders from, the more expensive half of the
+mistake.
+
+The snippet now calls `ComponentRegistry.register(...)` /
+`ComponentRegistry.get(...)` directly on the singleton, with one line stating
+it is the process-level shared instance `SchemaRenderer` resolves every
+`type` against — the same wording `packages/components/README.md` was given
+in objectui#5160, kept consistent across both READMEs. Readers who want their
+own isolated registry still have `Registry` itself, separately exported as a
+real class.
+
+`scripts/check-doc-snippet-types.mjs`'s `UNGATED_DOCS` entry for
+`packages/core/README.md` is updated to match: `TS2351x1` is dropped from its
+reason text now that the diagnostic is gone. The entry is not deleted — the
+document's remaining `TS2339x2` pair (a different, pre-existing defect) is
+out of scope for this change; it's tracked as objectui#5257.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,10 +46,13 @@ const mySchema: PageNodeSchema = {
 ```typescript
 import { ComponentRegistry } from '@object-ui/core'
 
-const registry = new ComponentRegistry()
-registry.register('button', buttonMetadata)
-const metadata = registry.get('button')
+ComponentRegistry.register('button', buttonMetadata)
+const metadata = ComponentRegistry.get('button')
 ```
+
+`ComponentRegistry` is a process-level singleton exported by `@object-ui/core`;
+`SchemaRenderer` resolves every `type` against it, so a component registered
+here is renderable from schema anywhere in the app.
 
 ### Data Scope
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -246,7 +246,7 @@ const UNGATED_DOCS = {
   'packages/components/README.md':
     '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/core/README.md':
-    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 TS2351x1 — candidate real defects, un-triaged',
+    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 — candidate real defects, un-triaged',
   'packages/data-objectstack/README.md':
     '10 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 41 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/fields/README.md':


### PR DESCRIPTION
Fixes #5258

## What

`packages/core/README.md`'s Component Registry example taught `new ComponentRegistry()`, but `ComponentRegistry` is an exported **singleton instance**, not a class. Built `packages/core/dist/registry/Registry.d.ts` declares:

```ts
export declare const ComponentRegistry: Registry< any >;
```

The #5138 doc-snippet type gate (`scripts/check-doc-snippet-types.mjs`) measured this as `TS2351: This expression is not constructable`. The README ships to npm inside the package's `files`, so a reader who copied the snippet got a compile error.

Verified against the **built** `packages/core/dist/index.d.ts` before editing: `ComponentRegistry` is a `const` instance and `Registry` is separately exported as a real class (`export declare class Registry< T = any >`) — the premise held.

## Fix

Dropped the `new`, call `register`/`get` directly on the singleton, and added one line stating it is the process-level shared instance (the part a reader cannot infer from the example) — copied verbatim from the wording `packages/components/README.md` was given in #5160, so both READMEs stay consistent:

```ts
import { ComponentRegistry } from '@object-ui/core'

ComponentRegistry.register('button', buttonMetadata)
const metadata = ComponentRegistry.get('button')
```

## UNGATED_DOCS ledger — please read before reviewing the diff

`packages/core/README.md` has a live entry in `scripts/check-doc-snippet-types.mjs`'s `UNGATED_DOCS`. Before this change it read:

```
'5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 TS2351x1 — candidate real defects, un-triaged'
```

Measured by temporarily un-gating the file and running the gate against the built types, the diagnostics were exactly: `TS2351` at line 49 (this card), five `TS2304` undefined-name diagnostics, and `TS2339x2` at lines 116/121.

This PR fixes only the `TS2351`. **The ledger entry is intentionally NOT deleted** — the `TS2339x2` pair is a separate, pre-existing defect on the same document and the same ledger line, tracked as out of scope: #5257 (not fixed here, not dispatched at the time this PR was opened). Re-measured after the fix, the entry now reads:

```
'5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 — candidate real defects, un-triaged'
```

Only `TS2351x1` is dropped from the reason text. A reviewer should read the surviving `TS2339x2` clause as expected, not as an incomplete fix on this card — the document is genuinely still ungated because #5257's defects remain, out of scope: #5257.

## Verification

Built `@object-ui/core`'s dependency closure plus every package the currently-covered doc snippets import (`node scripts/check-doc-snippet-types.mjs --build-filter`), then:

- `node scripts/check-doc-snippet-types.mjs` — passes (exit 0); "Every covered documentation snippet compiles against the built types."
- Before/after measurement (ledger entry temporarily removed, not committed that way) confirms `TS2351` at `packages/core/README.md:49` is gone and only the five `TS2304` + `TS2339x2` (out of scope, #5257) remain.
- `node scripts/check-control-bytes.mjs` — passes
- `node scripts/check-doc-links.mjs` — passes ("Links are valid across 13 scan roots.")
- `node scripts/check-changeset-presence.mjs` — passes
- `node scripts/check-changeset-fixed.mjs` — passes
- `node scripts/check-changeset-no-major.mjs` — passes
- `node scripts/check-doc-component-types.mjs` — passes (unaffected, run for completeness)

Diff is surgically narrow — one README snippet + one ledger reason-text line — so #5257 can land on this same file/ledger entry afterward without conflict.

Changeset: `@object-ui/core` patch (README correction; `packages/core` is a released package and its README ships in `files`).

## Hard limits observed

No edits to `docs/adr/**`, `.claude/**`, `skills/**`, `AGENTS.md`, or `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_