### PR TITLE
fix(data-objectstack,app-shell): a view overlay contributes only the keys it owns

### DIFF
--- a/.changeset/view-overlay-contributes-only-what-it-owns-5233.md
+++ b/.changeset/view-overlay-contributes-only-what-it-owns-5233.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/data-objectstack": patch
+"@object-ui/app-shell": patch
+---
+
+A view personalization overlay no longer freezes the view it was laid over. `ObjectView`'s
+`persistViewPatch` sends `{ ...baseViewDef, ...patch }`, so a row written by a mere column
+drag or sort change stored the view's whole body — its effective `filter`, `columns`,
+`label`, `type`, `isDefault` — as of that moment, and the display merge
+(`{ ...source, ...override }`) then let that snapshot outrank the source view indefinitely:
+an admin edited a view's filter and everyone who had ever resized a column silently kept the
+old filter, with nothing reporting it.
+
+An overlay now contributes only the keys it owns — `rowHeight`, `sort`, `hiddenFields`,
+`columnState`, `inlineEdit` (`VIEW_OVERLAY_OWNED_KEYS`, new export from
+`@object-ui/data-objectstack` alongside `narrowPersonalizationOverlay`) — so a later change
+to the source view reaches every user, including those whose stored row still carries the
+old snapshot: rows written before this change stop shadowing the source on the next read,
+with no migration to run and nothing rewritten at rest. A genuine saved view's own body is
+untouched — it is classified by the same predicate `listViews()` already excludes overlay
+rows by, so a row cannot be an overlay for one reader and a saved view for the other
+(objectui#5233, ruled on objectstack#7494).

--- a/packages/app-shell/src/views/ObjectView.overlayPatchOnly.test.ts
+++ b/packages/app-shell/src/views/ObjectView.overlayPatchOnly.test.ts
@@ -1,0 +1,282 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5233 — a personalization overlay must not freeze the source view.
+ *
+ * `persistViewPatch` sends `{ ...baseViewDef, ...patch }`, so an overlay
+ * written by a mere column drag copies the view's CURRENT effective `filter`
+ * (and `columns`, `label`, `type`, `isDefault` …) into the stored row. The
+ * display merge is `{ ...source, ...override }`, so that copy then outranks
+ * the source view forever: an admin edits the view's filter and every user who
+ * once resized a column keeps the old filter, with nothing reporting it.
+ *
+ * Ruled by the maintainer on 2026-08-12 (objectstack#7494, comment
+ * 5261754173): "`persistViewPatch` 只存 patch,不存 merged base … 这与 per-user
+ * 之争无关,是纯粹的存储形状错误."
+ *
+ * The half pinned HERE is the read: an overlay contributes only the keys it
+ * owns (`VIEW_OVERLAY_OWNED_KEYS`), so every base key already frozen into
+ * every stored row stops shadowing the source. That is the issue's third
+ * disposition for existing rows — tolerate on read — chosen deliberately and
+ * pinned rather than assumed, which is the difference the issue draws between
+ * tolerance and SILENT tolerance. See the PR body for why strip-on-next-write
+ * and migrate were not chosen, and for the measured platform constraint that
+ * keeps the write half (patch-only at rest) out of this change.
+ *
+ * Written round-trip through the REAL adapter write + read and the REAL
+ * consumer merge (`loadViewOverrides` → `buildViewTabs`), not against a
+ * hand-written override fixture: the defect lives in what the write path
+ * stores, so a fixture is exactly where it would hide.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ObjectStackAdapter, VIEW_OVERLAY_OWNED_KEYS } from '@object-ui/data-objectstack';
+import { buildViewTabs, loadViewOverrides, sanitizeViewOverride } from './ObjectView';
+
+const OBJECT_NAME = 'crm_lead';
+const VIEW_ID = 'crm_lead.default';
+
+/** The code-defined view, as the object metadata declares it TODAY. */
+const SOURCE_VIEW_AT_WRITE_TIME = {
+    name: VIEW_ID,
+    label: 'All Leads',
+    type: 'grid',
+    columns: ['name', 'status'],
+    filter: [{ field: 'status', operator: 'equals', value: 'open' }],
+    isDefault: true,
+};
+
+/** The same view AFTER an admin edits its filter (and its column set). */
+const SOURCE_VIEW_AFTER_ADMIN_EDIT = {
+    ...SOURCE_VIEW_AT_WRITE_TIME,
+    label: 'All Leads (active)',
+    columns: ['name', 'status', 'owner'],
+    filter: [{ field: 'status', operator: 'equals', value: 'qualified' }],
+};
+
+/** A stub metadata store keyed the way `sys_metadata` is: `type` + `name`. */
+function makeMetaStore() {
+    const rows = new Map<string, any>();
+    const meta = {
+        getItems: vi.fn(async (type: string) => ({
+            type,
+            items: [...rows.entries()].filter(([k]) => k.startsWith(`${type}::`)).map(([, v]) => v),
+        })),
+        getItem: vi.fn(async (type: string, name: string) => {
+            const item = rows.get(`${type}::${name}`);
+            if (!item) {
+                const err: any = new Error(`Not found: ${type}/${name}`);
+                err.status = 404;
+                throw err;
+            }
+            return { type, name, item };
+        }),
+        saveItem: vi.fn(async (type: string, name: string, item: any) => {
+            rows.set(`${type}::${name}`, { ...item });
+            return { success: true, item: rows.get(`${type}::${name}`) };
+        }),
+    };
+    return { meta, rows };
+}
+
+function makeAdapter(meta: any) {
+    const ds: any = new ObjectStackAdapter({
+        baseUrl: 'http://test.local',
+        fetch: vi.fn(async () =>
+            new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            })),
+    });
+    ds.connected = true;
+    ds.connectionState = 'connected';
+    ds.client = { meta };
+    return ds;
+}
+
+const fallbackTab = () => ({ id: 'all', label: 'All records', type: 'grid', columns: [] });
+
+/** The tab the switcher renders for `VIEW_ID`, built the way `ObjectView` builds it. */
+async function tabAfterAdminEdit(ds: any) {
+    const viewOverrides = await loadViewOverrides(ds, OBJECT_NAME, [VIEW_ID]);
+    const tabs = buildViewTabs({
+        definedViews: { [VIEW_ID]: SOURCE_VIEW_AFTER_ADMIN_EDIT },
+        savedViews: [],
+        viewOverrides,
+        fallbackTab,
+    });
+    return tabs.find((t) => t.id === VIEW_ID)!;
+}
+
+describe('objectui#5233 — a source-view filter change reaches users who have an overlay', () => {
+    it('a column drag writes an overlay; the admin then edits the filter; the user sees the NEW filter', async () => {
+        const { meta } = makeMetaStore();
+        const ds = makeAdapter(meta);
+
+        // EXACTLY what `persistViewPatch` sends for a column drag on a system
+        // view: the whole active tab, plus the one key the user actually
+        // changed. `isSavedView` is omitted — this is the system-view case,
+        // the one that lays an overlay ON TOP of a code-defined view.
+        await ds.updateViewConfig(OBJECT_NAME, VIEW_ID, {
+            ...SOURCE_VIEW_AT_WRITE_TIME,
+            columnState: { order: ['status', 'name'], widths: { name: 220 } },
+        });
+
+        // The row really did capture the source view verbatim — the defect in
+        // one assertion, measured at rest rather than assumed.
+        const stored = (await ds.listViewOverrides(OBJECT_NAME))[VIEW_ID];
+        expect(stored.filter).toEqual(SOURCE_VIEW_AT_WRITE_TIME.filter);
+
+        const tab = await tabAfterAdminEdit(ds);
+
+        // The whole card: the admin's edit reaches this user.
+        expect(tab.filter).toEqual(SOURCE_VIEW_AFTER_ADMIN_EDIT.filter);
+        // …and so does every other key the overlay had frozen alongside it.
+        expect(tab.columns).toEqual(SOURCE_VIEW_AFTER_ADMIN_EDIT.columns);
+        expect(tab.label).toBe(SOURCE_VIEW_AFTER_ADMIN_EDIT.label);
+    });
+
+    it('the overlay still carries what it was written for', async () => {
+        const { meta } = makeMetaStore();
+        const ds = makeAdapter(meta);
+
+        await ds.updateViewConfig(OBJECT_NAME, VIEW_ID, {
+            ...SOURCE_VIEW_AT_WRITE_TIME,
+            columnState: { order: ['status', 'name'], widths: { name: 220 } },
+            sort: [{ field: 'created_at', order: 'desc' }],
+            hiddenFields: ['owner'],
+            rowHeight: 'compact',
+            inlineEdit: true,
+        });
+
+        const tab = await tabAfterAdminEdit(ds);
+
+        expect(tab.columnState).toEqual({ order: ['status', 'name'], widths: { name: 220 } });
+        expect(tab.sort).toEqual([{ field: 'created_at', order: 'desc' }]);
+        expect(tab.hiddenFields).toEqual(['owner']);
+        expect(tab.rowHeight).toBe('compact');
+        expect(tab.inlineEdit).toBe(true);
+        // Narrowing is not amnesia: the personalization survives a reload,
+        // which is the whole reason these rows exist.
+        expect(tab.filter).toEqual(SOURCE_VIEW_AFTER_ADMIN_EDIT.filter);
+    });
+});
+
+describe('objectui#5233 — rows written BEFORE this fix (the disposition, pinned)', () => {
+    /**
+     * The decision this test encodes: existing rows are TOLERATED ON READ, not
+     * stripped-on-next-write and not migrated. So a row already carrying the
+     * frozen body behaves correctly on the very next page load, without its
+     * user having to touch that view again and without an operator running
+     * anything.
+     */
+    it('a row stored in the old shape stops shadowing the source on the NEXT READ — no write, no migration', async () => {
+        const { meta, rows } = makeMetaStore();
+        const ds = makeAdapter(meta);
+
+        // Put the row in the store directly: this is the state of an install
+        // that has been running the pre-fix write path, not something this
+        // code path just produced.
+        rows.set(`view::${VIEW_ID}`, {
+            ...SOURCE_VIEW_AT_WRITE_TIME,
+            object: OBJECT_NAME,
+            viewKind: 'list',
+            columnState: { order: ['status', 'name'] },
+            _isOverride: true,
+        });
+
+        const tab = await tabAfterAdminEdit(ds);
+
+        expect(tab.filter).toEqual(SOURCE_VIEW_AFTER_ADMIN_EDIT.filter);
+        expect(tab.columns).toEqual(SOURCE_VIEW_AFTER_ADMIN_EDIT.columns);
+        expect(tab.columnState).toEqual({ order: ['status', 'name'] });
+        // Nothing was rewritten to achieve that — the row is untouched at rest.
+        expect(meta.saveItem).not.toHaveBeenCalled();
+    });
+
+    it('a PRE-MARKER legacy row is narrowed by the same predicate listViews() excludes it by', async () => {
+        const { meta, rows } = makeMetaStore();
+        const ds = makeAdapter(meta);
+
+        // Written before `_isOverride` existed (objectui#4227): flat body, and
+        // a `viewKind` only the platform's registry-backed identity heal can
+        // have put there.
+        rows.set(`view::${VIEW_ID}`, {
+            ...SOURCE_VIEW_AT_WRITE_TIME,
+            object: OBJECT_NAME,
+            viewKind: 'list',
+            sort: [{ field: 'created_at', order: 'desc' }],
+        });
+
+        const tab = await tabAfterAdminEdit(ds);
+
+        expect(tab.filter).toEqual(SOURCE_VIEW_AFTER_ADMIN_EDIT.filter);
+        expect(tab.sort).toEqual([{ field: 'created_at', order: 'desc' }]);
+    });
+});
+
+describe('objectui#5233 — what must NOT be narrowed', () => {
+    it("a saved view's OWN body keeps every key its author wrote", async () => {
+        // The runtime "Add View" shape (app-shell's `viewEnvelope`): nested
+        // `config`, no marker. For this row the body IS the view — narrowing it
+        // would delete a user's own view definition on read.
+        const savedRow = {
+            name: 'crm_lead.my_pipeline',
+            object: OBJECT_NAME,
+            viewKind: 'list',
+            label: 'My Pipeline',
+            config: { type: 'kanban', columns: ['name'] },
+            filter: [{ field: 'owner', operator: 'equals', value: 'u1' }],
+        };
+        expect(sanitizeViewOverride(savedRow)).toBe(savedRow);
+    });
+
+    it('an explicit-save override still wins over the source filter (#4155 contract)', () => {
+        // No marker, no legacy signature → not a personalization overlay. This
+        // is the case `ObjectView.overlayFilterRecovery.test.tsx` already pins;
+        // restated here because #5233's narrowing runs FIRST and must not eat it.
+        const saved = { name: 'wo.mine', filter: [{ field: 'owner', operator: 'equals', value: 'u1' }] };
+        expect(sanitizeViewOverride(saved)).toEqual(saved);
+    });
+});
+
+describe('objectui#5233 ratchet — the owned-key list tracks the writers', () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const objectViewSrc = readFileSync(path.join(here, 'ObjectView.tsx'), 'utf8');
+
+    /**
+     * Every `persistViewPatch(…, { key … })` in the file. The overlay's owned
+     * keys and the calls that WRITE them are two statements of one fact, in two
+     * packages; when they drift, the read silently drops a key the user just
+     * set and nothing fails. This is the guard that makes that drift loud.
+     */
+    const PERSIST_CALLS = /persistViewPatch\s*\([^;]*?\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*[:,}]/gs;
+
+    it('the ratchet is reading real source', () => {
+        expect(objectViewSrc.length).toBeGreaterThan(10_000);
+        expect(objectViewSrc).toContain('persistViewPatch');
+    });
+
+    it('every key the toolbar persists is a key the overlay is allowed to own', () => {
+        const written = [...new Set([...objectViewSrc.matchAll(PERSIST_CALLS)].map((m) => m[1]!))];
+        // Vacuous-pass guard: the call sites are the evidence, so an empty
+        // match set means the regex stopped matching, not that nothing writes.
+        expect(written.length).toBeGreaterThanOrEqual(5);
+        for (const key of written) {
+            expect(
+                VIEW_OVERLAY_OWNED_KEYS as readonly string[],
+                `\`persistViewPatch\` writes \`${key}\`, which a personalization overlay is not allowed to own — `
+                + 'add it to VIEW_OVERLAY_OWNED_KEYS (@object-ui/data-objectstack) or stop persisting it (objectui#5233)',
+            ).toContain(key);
+        }
+    });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -15,6 +15,7 @@ import { resolveFilterPlaceholders, DENSITY_MODE_TO_ROW_HEIGHT, normalizeListVie
 import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
 import { buildListFilterKey, readListFilterState, writeListFilterState } from './listFilterStorage';
 import { VALUELESS_FILTER_OPERATORS } from './viewFilterFold';
+import { narrowPersonalizationOverlay } from '@object-ui/data-objectstack';
 const ObjectChart = lazy(() =>
   import('@object-ui/plugin-charts').then((m) => ({ default: m.ObjectChart })),
 );
@@ -325,6 +326,18 @@ export function defaultListColumnsFromObject(
  */
 export function sanitizeViewOverride(override: any): any {
     if (!override || typeof override !== 'object') return override;
+    // objectui#5233 — a PERSONALIZATION overlay contributes only the keys it
+    // owns (density / sort / hiddenFields / columnState / inlineEdit). Every
+    // other key on such a row is a copy of the source view taken when the
+    // user last dragged a column, and the merge below hands it authority over
+    // the source declaration it was copied from. Narrowed FIRST and returned:
+    // a narrowed row can no longer carry a `filter` at all, so the
+    // recovery pass below has nothing left to do for it. The predicate is the
+    // adapter's (`@object-ui/data-objectstack` owns the row's shape and stamps
+    // its marker) so a saved view's OWN body — enumerated by the same batch
+    // read — is returned untouched, exactly as `listViews()` classifies it.
+    const narrowed = narrowPersonalizationOverlay(override);
+    if (narrowed !== override) return narrowed;
     if (!Array.isArray(override.filter)) return override;
 
     const kept = override.filter.filter((entry: any) => {

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1141,6 +1141,108 @@ function isPersonalizationOverlayRow(item: any, spec: any): boolean {
 }
 
 /**
+ * The keys a personalization overlay row legitimately OWNS (objectui#5233).
+ *
+ * One per `persistViewPatch` call site in app-shell's `ObjectView` — the ONLY
+ * production writer of these rows — read off the tree rather than recalled:
+ * `rowHeight` (the density toggle, spec-canonical since #2890), `sort`,
+ * `hiddenFields`, `columnState` and `inlineEdit`. Nothing else in such a row
+ * is an opinion the user expressed; it is a COPY of the source view as it
+ * stood at write time, because `persistViewPatch` sends
+ * `{ ...baseViewDef, ...patch }` and this adapter persists what it is given.
+ *
+ * That copy is the defect the maintainer ruled on (objectstack#7494, comment
+ * 5261754173): an overlay written by a mere column drag freezes the view's
+ * effective `filter` — and its `columns`, `label`, `type`, `isDefault` … — as
+ * of that moment, and because the display merge is `{ ...source, ...override }`
+ * the frozen copy SHADOWS the source view forever. An admin then edits the
+ * view's filter and every user who once resized a column keeps the old one,
+ * with nothing anywhere reporting it.
+ *
+ * ⛔ Do not grow this list to make some other key "stick" through an overlay.
+ * A key that belongs to the view belongs in the view; the overlay is a patch,
+ * and a patch that carries the whole document is what this list exists to
+ * stop. Adding a sixth entry is only correct alongside a sixth
+ * `persistViewPatch` call site — {@link narrowPersonalizationOverlay} is what
+ * a reader checks that against.
+ */
+export const VIEW_OVERLAY_OWNED_KEYS = Object.freeze([
+  'rowHeight',
+  'sort',
+  'hiddenFields',
+  'columnState',
+  'inlineEdit',
+] as const);
+
+/**
+ * Identity, not content — kept so a narrowed row is still addressable and
+ * still says what KIND of row it is.
+ *
+ * `label` is deliberately NOT here even though the platform stamps it onto
+ * these rows: `viewIdentityPatch` (`@objectstack/metadata-protocol`, #2555)
+ * inherits `viewKind`/`object`/`label` from the registry entry an overlay
+ * shadows, so a stored `label` is a snapshot of the source view's label at
+ * write time — content, and exactly the class of frozen key this narrowing
+ * exists to stop shadowing the source.
+ */
+const VIEW_OVERLAY_IDENTITY_KEYS = Object.freeze([
+  'name',
+  'object',
+  'viewKind',
+  VIEW_OVERLAY_MARKER,
+] as const);
+
+/**
+ * Reduce a personalization overlay row to the keys it owns — the read-side
+ * half of objectui#5233, and the half that reaches rows ALREADY STORED.
+ *
+ * Rows written before this shipped carry the whole source view (see
+ * {@link VIEW_OVERLAY_OWNED_KEYS}). Of the three dispositions the issue names
+ * for them — strip on next write, migrate, tolerate on read — this is the
+ * third, chosen deliberately and stated here rather than left implicit,
+ * because it is the only one that is already true for every existing row the
+ * moment it ships: strip-on-next-write heals a row only when its user happens
+ * to touch that view again (and leaves the frozen filter live until then),
+ * and a migration needs a runner this product does not have for `sys_metadata`
+ * rows an operator may not even know exist. What the issue forbids is SILENT
+ * tolerance; this is the explicit, pinned kind (`viewOverlayPatchOnly.test.ts`
+ * in this package, `ObjectView.overlayPatchOnly.test.tsx` in app-shell).
+ *
+ * Applied by the consumer that MERGES an override over a source view
+ * (app-shell's `sanitizeViewOverride`, the one seam both of
+ * `loadViewOverrides`' read branches pass through), NOT by
+ * {@link ObjectStackAdapter.listViewOverrides} / {@link ObjectStackAdapter.getView}:
+ * those two answer with the stored DOCUMENT, their equality is itself pinned
+ * ("same key space, same document" — `listViewOverrides.test.ts`), and
+ * `InterfaceListPage` hydrates a hollow view out of that document. Narrowing
+ * belongs where a row is read AS A PATCH, not where it is read as a row.
+ *
+ * Non-overlay rows — a genuine saved view's own body, which the same batch
+ * read enumerates — are returned by REFERENCE, untouched: for those the row
+ * IS the view, and every key on it is an opinion its author expressed.
+ * Classification is {@link isPersonalizationOverlayRow}, the same predicate
+ * {@link ObjectStackAdapter.listViews} excludes rows by, so a row cannot be a
+ * saved view for one reader and an overlay for the other.
+ */
+export function narrowPersonalizationOverlay<T>(row: T): T {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) return row;
+  const item = row as Record<string, any>;
+  // Same unwrap the other readers of this namespace use — a `{list: {...}}`
+  // artifact wrapper is a view CONTAINER, never an overlay, and
+  // `isPersonalizationOverlayRow` reads both levels.
+  const spec = item.list ?? item;
+  if (!isPersonalizationOverlayRow(item, spec)) return row;
+  const narrowed: Record<string, any> = {};
+  for (const key of VIEW_OVERLAY_IDENTITY_KEYS) {
+    if (item[key] !== undefined) narrowed[key] = item[key];
+  }
+  for (const key of VIEW_OVERLAY_OWNED_KEYS) {
+    if (item[key] !== undefined) narrowed[key] = item[key];
+  }
+  return narrowed as T;
+}
+
+/**
  * Unwrap a `?state=draft` view read into its bare body, or `null` when there
  * is nothing pending (#4139).
  *

--- a/packages/data-objectstack/src/viewOverlayPatchOnly.test.ts
+++ b/packages/data-objectstack/src/viewOverlayPatchOnly.test.ts
@@ -1,0 +1,205 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5233 — an overlay row is a PATCH, and only the keys it owns may
+ * reach the view it is merged over.
+ *
+ * `ObjectView.persistViewPatch` sends `{ ...baseViewDef, ...patch }` and this
+ * adapter persists what it is given, so a row written by a column drag carries
+ * the whole source view — `filter` included — as of that moment. The display
+ * merge is `{ ...source, ...override }`, which hands that stale copy authority
+ * over the source declaration it was copied from.
+ *
+ * {@link narrowPersonalizationOverlay} is the read-side half: the policy for
+ * WHAT an overlay may contribute, owned by this package because this package
+ * owns the row's shape (it stamps the marker `listViews()` excludes rows by).
+ * The end-to-end pin — write, read, merge, admin edits the source filter, user
+ * sees the new one — lives beside the consumer that does the merging,
+ * `packages/app-shell/src/views/ObjectView.overlayPatchOnly.test.ts`.
+ *
+ * Deliberately NOT applied inside {@link ObjectStackAdapter.listViewOverrides}
+ * or {@link ObjectStackAdapter.getView}: both answer with the stored DOCUMENT,
+ * their equality is pinned in `listViewOverrides.test.ts` ("same key space,
+ * same document"), and `InterfaceListPage` hydrates a hollow view out of it.
+ * A row is narrowed where it is read AS A PATCH, not where it is read as a row
+ * — and that boundary is pinned below.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ObjectStackAdapter,
+  VIEW_OVERLAY_OWNED_KEYS,
+  narrowPersonalizationOverlay,
+} from './index';
+
+/** A stub metadata store keyed the way `sys_metadata` is: `type` + `name`. */
+function makeMetaStore() {
+  const rows = new Map<string, any>();
+  const meta = {
+    getItems: vi.fn(async (type: string) => ({
+      type,
+      items: [...rows.entries()].filter(([k]) => k.startsWith(`${type}::`)).map(([, v]) => v),
+    })),
+    getItem: vi.fn(async (type: string, name: string) => {
+      const item = rows.get(`${type}::${name}`);
+      if (!item) {
+        const err: any = new Error(`Not found: ${type}/${name}`);
+        err.status = 404;
+        throw err;
+      }
+      return { type, name, item };
+    }),
+    saveItem: vi.fn(async (type: string, name: string, item: any) => {
+      rows.set(`${type}::${name}`, { ...item });
+      return { success: true, item: rows.get(`${type}::${name}`) };
+    }),
+  };
+  return { meta, rows };
+}
+
+function makeDS(meta: any) {
+  const ds: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })),
+  });
+  ds.connected = true;
+  ds.connectionState = 'connected';
+  ds.client = { meta };
+  return ds;
+}
+
+/** What `persistViewPatch` sends for a column drag: the whole tab + one key. */
+const FAT_WRITE = {
+  name: 'crm_lead.default',
+  label: 'All Leads',
+  type: 'grid',
+  data: { provider: 'object', object: 'crm_lead' },
+  columns: ['name', 'status'],
+  filter: [{ field: 'status', operator: 'equals', value: 'open' }],
+  isDefault: true,
+  columnState: { order: ['status', 'name'] },
+};
+
+describe('narrowPersonalizationOverlay — what an overlay may contribute', () => {
+  it('keeps the five keys the toolbar owns and drops the copied view body', () => {
+    const narrowed: any = narrowPersonalizationOverlay({
+      ...FAT_WRITE,
+      object: 'crm_lead',
+      viewKind: 'list',
+      sort: [{ field: 'created_at', order: 'desc' }],
+      hiddenFields: ['owner'],
+      rowHeight: 'compact',
+      inlineEdit: true,
+      _isOverride: true,
+    });
+
+    expect(narrowed).toEqual({
+      name: 'crm_lead.default',
+      object: 'crm_lead',
+      viewKind: 'list',
+      _isOverride: true,
+      rowHeight: 'compact',
+      sort: [{ field: 'created_at', order: 'desc' }],
+      hiddenFields: ['owner'],
+      columnState: { order: ['status', 'name'] },
+      inlineEdit: true,
+    });
+    // Named individually as well as by the shape above: these four are the
+    // ones that silently outranked the source view.
+    for (const key of ['filter', 'columns', 'label', 'isDefault']) {
+      expect(key in narrowed, `an overlay must not carry \`${key}\``).toBe(false);
+    }
+  });
+
+  it('omits an owned key the row does not carry rather than writing it as undefined', () => {
+    // `{ ...source, ...override }` treats a present-but-undefined key as an
+    // override that blanks the source — the same trap `buildViewTabs` strips
+    // for saved views ("Drop undefined fields so a partial overlay does not
+    // stomp isDefault/columns").
+    const narrowed: any = narrowPersonalizationOverlay({
+      name: 'crm_lead.default', object: 'crm_lead', viewKind: 'list',
+      rowHeight: 'compact', _isOverride: true,
+    });
+    expect(Object.keys(narrowed).sort()).toEqual(
+      ['_isOverride', 'name', 'object', 'rowHeight', 'viewKind'],
+    );
+  });
+
+  it('narrows a PRE-MARKER legacy row — flat body plus an inherited `viewKind`', () => {
+    // objectui#4227's best-effort signature: only the platform's registry-backed
+    // identity heal can put `viewKind` on a flat row, so this is an override on
+    // a system view. Same predicate `listViews()` excludes the row by, so a row
+    // cannot be an overlay for one reader and a saved view for the other.
+    const narrowed: any = narrowPersonalizationOverlay({
+      ...FAT_WRITE, object: 'crm_lead', viewKind: 'list',
+    });
+    expect('filter' in narrowed).toBe(false);
+    expect(narrowed.columnState).toEqual({ order: ['status', 'name'] });
+  });
+
+  it("returns a saved view's own body BY REFERENCE — untouched", () => {
+    // The runtime "Add View" shape (app-shell's `viewEnvelope`): nested
+    // `config`, no marker. The row IS the view; every key on it is an opinion
+    // its author expressed.
+    const savedRow = {
+      name: 'crm_lead.my_pipeline',
+      object: 'crm_lead',
+      viewKind: 'list',
+      label: 'My Pipeline',
+      config: { type: 'kanban', columns: ['name'] },
+    };
+    expect(narrowPersonalizationOverlay(savedRow)).toBe(savedRow);
+  });
+
+  it('leaves a flat row with no marker and no inherited viewKind alone', () => {
+    const legacyBareSpec = { name: 'crm_lead.mine', object: 'crm_lead', type: 'grid', columns: ['name'] };
+    expect(narrowPersonalizationOverlay(legacyBareSpec)).toBe(legacyBareSpec);
+  });
+
+  it('leaves a `{ list: … }` container, non-objects and arrays alone', () => {
+    const container = { list: { type: 'grid', columns: ['name'] }, object: 'crm_lead' };
+    expect(narrowPersonalizationOverlay(container)).toBe(container);
+    expect(narrowPersonalizationOverlay(null)).toBe(null);
+    expect(narrowPersonalizationOverlay(undefined)).toBe(undefined);
+    const arr = [{ _isOverride: true }];
+    expect(narrowPersonalizationOverlay(arr)).toBe(arr);
+  });
+
+  it('the owned-key list is the five the toolbar writes, and is frozen', () => {
+    expect([...VIEW_OVERLAY_OWNED_KEYS]).toEqual(
+      ['rowHeight', 'sort', 'hiddenFields', 'columnState', 'inlineEdit'],
+    );
+    expect(Object.isFrozen(VIEW_OVERLAY_OWNED_KEYS)).toBe(true);
+  });
+});
+
+describe('narrowPersonalizationOverlay — the round trip it is defined against', () => {
+  it('a real updateViewConfig write comes back narrowed to its patch', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeDS(meta);
+
+    await ds.updateViewConfig('crm_lead', 'crm_lead.default', { ...FAT_WRITE });
+
+    const stored = (await ds.listViewOverrides('crm_lead'))['crm_lead.default'];
+    // The document readers still get the document — this is the boundary, and
+    // the reason the narrowing is not applied inside the adapter's reads.
+    expect(stored.filter).toEqual(FAT_WRITE.filter);
+    expect(stored.columns).toEqual(FAT_WRITE.columns);
+    expect(await ds.getView('crm_lead', 'crm_lead.default')).toEqual(stored);
+
+    // Read AS A PATCH, the same row contributes only what the user changed.
+    const asPatch: any = narrowPersonalizationOverlay(stored);
+    expect(asPatch.columnState).toEqual({ order: ['status', 'name'] });
+    expect('filter' in asPatch).toBe(false);
+  });
+});

--- a/packages/data-objectstack/src/viewOverlayPatchOnly.test.ts
+++ b/packages/data-objectstack/src/viewOverlayPatchOnly.test.ts
@@ -128,6 +128,11 @@ describe('narrowPersonalizationOverlay — what an overlay may contribute', () =
     // stomp isDefault/columns").
     const narrowed: any = narrowPersonalizationOverlay({
       name: 'crm_lead.default', object: 'crm_lead', viewKind: 'list',
+      // A base key rides along deliberately: without one this fixture's key
+      // set is already the narrowed one, and the assertion below would hold
+      // just as well against a narrowing that never ran (measured — it stayed
+      // green under the ablation leg that makes the policy inert).
+      filter: [{ field: 'status', operator: 'equals', value: 'open' }],
       rowHeight: 'compact', _isOverride: true,
     });
     expect(Object.keys(narrowed).sort()).toEqual(


### PR DESCRIPTION
Part of #5233

Not `Fixes` — deliberately. This lands the half that is entirely ours (the read), and
escalates the half the ruling names (the write at rest) with the measurement that blocks
it. Details in "What does not ship" below; the issue should stay open on that decision.

## The defect

`persistViewPatch` sends `{ ...baseViewDef, ...patch }`, so an overlay written by a mere
column drag copies the view's **current effective `filter`** — and its `columns`, `label`,
`type`, `isDefault` — into the stored row. The display merge is `{ ...source, ...override }`
(`buildViewTabs` / `viewEntry`), so that snapshot then outranks the source view
indefinitely: an admin edits the view's filter and everyone who once resized a column keeps
the old filter, with nothing anywhere reporting it.

Ruled by the maintainer on 2026-08-12 (objectstack#7494, comment `5261754173`):

> **`persistViewPatch` 只存 patch,不存 merged base** —— 独立小修,现在做:它把写入时的有效
> filter 冻进 overlay,导致源视图后续的 filter 变更到不了带 overlay 的用户,这与 per-user
> 之争无关,是纯粹的存储形状错误。

### Premise re-verified on `main` — one correction

The card attributes `persistViewPatch` to `packages/data-objectstack/src/index.ts`. On
current `main` the function — and the `{ ...baseViewDef, ...patch }` spread — live in
`packages/app-shell/src/views/ObjectView.tsx` (the `useCallback` around line 698, the write
around line 727). The adapter's `updateViewConfig` is what *persists* that body verbatim.
The defect itself reproduces exactly as described; only the file attribution was off. The
declared file surface for this claim is amended accordingly (comment on the issue), and it
is why this PR touches app-shell as well as the adapter.

## What ships: an overlay contributes only the keys it owns

`@object-ui/data-objectstack` gains two exports, because it is the package that owns the
overlay row's shape (it stamps the `_isOverride` marker that `listViews()` excludes rows by):

- `VIEW_OVERLAY_OWNED_KEYS` — `rowHeight`, `sort`, `hiddenFields`, `columnState`,
  `inlineEdit`: one per `persistViewPatch` call site, read off the tree.
- `narrowPersonalizationOverlay(row)` — reduces a **personalization overlay** row to
  identity plus those five. A saved view's own body is returned by reference, untouched;
  classification is the existing `isPersonalizationOverlayRow`, so a row cannot be an
  overlay for one reader and a saved view for another.

`sanitizeViewOverride` (app-shell) applies it. That is the one seam both branches of
`loadViewOverrides` pass through — already pinned as such by
`ObjectView.overlayFilterRecovery.test.tsx` — and it is where a row is read **as a patch**.

Deliberately **not** applied inside `listViewOverrides` / `getView`: both answer with the
stored *document*, their equality is itself pinned ("same key space, same document",
`listViewOverrides.test.ts`), and `InterfaceListPage` hydrates a hollow view out of it.
Narrowing the document read would have broken that pin and that hydration.

`label` is dropped from the overlay on purpose, even though the platform stamps it there:
`viewIdentityPatch` (`@objectstack/metadata-protocol`, #2555) inherits `viewKind`/`object`/
`label` from the registry entry an overlay shadows, so a stored `label` is a snapshot of the
source view's label — content, not identity. Same for `isDefault`, which the tab carries and
the fat write therefore froze.

### The existing-rows decision: tolerate on read — explicitly, and pinned

Rows already stored carry the frozen body. Of the three dispositions the card names:

- **Strip on next write** — heals a row only if that view's user happens to touch it again,
  and leaves the frozen filter authoritative until then. It also cannot ship on its own
  right now (see below).
- **Migrate** — clean end state, but needs a runner over `sys_metadata` rows an operator may
  not know exist, and buys nothing the read-side narrowing does not already deliver.
- **Tolerate on read** — chosen. Every existing row stops shadowing its source on the next
  page load: no migration, no rewrite at rest, no user action.

The card forbids *silent* tolerance, not tolerance. This one is documented at the function,
declared here, and pinned by tests that say which decision they encode
(`ObjectView.overlayPatchOnly.test.ts`, "rows written BEFORE this fix (the disposition,
pinned)"), including the pre-marker legacy shape.

## What does not ship, and why: the write at rest

The ruling's own words are "store the patch only". Measured against the platform's live
contract before writing any of it, that shape is **refused** for one of the five keys:

```
ViewMetadataSchema.safeParse({ columnState: {...}, object, name, viewKind, _isOverride })
  REFUSE  Not a `view` body: no recognized `view` key. Expected at least one of a container
          slot (`list` / `form` / `listViews` / `formViews`), a ViewItem record (`viewKind`
          + `config`), or an inline view config (`type`, `columns`, `sections`, `filter`, …).
          Received unrecognized keys `columnState`, `_isOverride` …
```

Measured with `@objectstack/spec` 17.0.0 as installed here; `columnState` appears nowhere in
the framework's `packages/spec/src` either. `sort`, `rowHeight`, `hiddenFields` and
`inlineEdit` all parse fine on their own — `columnState` does not, because it is objectui's
own **non-author** runtime key (`plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx`).
`saveMetaItem` validates every `view` write (after `normalizeViewMetadata` inherits identity
from the registry baseline), so a patch-only write for a **column resize or reorder** — the
most frequent toolbar toggle, and one that travels alone — would come back 422
`INVALID_METADATA` and the user's resize would not persist at all. Today it survives only
because the copied base rides along and supplies a recognized key.

So the storage-shape half needs a decision that is not this card's to take:

1. Teach the platform's `view` schema the runtime overlay keys, then narrow the write
   (contract-first: the refusal is the producer's, and the row is a real, already-persisted
   shape it declines to describe). Costs a framework change and a release.
2. Narrow the write anyway and lose `columnState` persistence until (1) lands. Cheapest to
   write, but it removes a working feature.
3. Keep the fat write, as this PR does, and rely on the read-side narrowing: no frozen key
   reaches a user, but the stale bytes stay at rest and any reader outside objectui (Studio,
   server-side switcher) still sees a snapshot.
4. Move personalization out of the `view` metadata namespace entirely — the parked per-user
   direction on objectstack#7494 / #5232.

Recommendation: (1) with (3) shipped now as the harm-elimination half. (2) trades a silent
staleness for a visible regression; (4) is parked and much larger.

## Tests

- `packages/app-shell/src/views/ObjectView.overlayPatchOnly.test.ts` — the defect pin, round
  trip through the **real** adapter write + read and the **real** consumer merge
  (`loadViewOverrides` → `buildViewTabs`): a column drag writes the overlay, the admin then
  edits the source view's filter and columns, and the tab shows the new ones while keeping
  the `columnState`/`sort`/`hiddenFields`/`rowHeight`/`inlineEdit` the overlay was written
  for. Plus the disposition pins, the two "must NOT be narrowed" controls, and a ratchet
  that reads `ObjectView.tsx` and fails if `persistViewPatch` ever writes a key the overlay
  is not allowed to own (the drift that would otherwise silently drop a user's setting).
- `packages/data-objectstack/src/viewOverlayPatchOnly.test.ts` — the policy itself, and the
  document/patch boundary this PR deliberately keeps.

### Reverse verification (predicted before running)

Two legs, both against committed code. No rebuild needed and none can hide a stale result:
the root `vitest.config.mts` aliases `@object-ui/data-objectstack` to
`packages/data-objectstack/src`, so tests resolve source, not `dist` — and the ablations
turning red is itself the proof of that resolution.

| leg | predicted | observed |
|---|---|---|
| wiring removed from `sanitizeViewOverride` | 4 red in the app-shell pin, 8 green in the adapter pin | exactly that — the reds report the frozen `status: open` where `qualified` was expected |
| `narrowPersonalizationOverlay` made inert | 4 red / 4 green in the adapter pin, same 4 red in app-shell | **3** red / 5 green in the adapter pin; app-shell as predicted |

The miss is reported rather than smoothed over, and it found a real weakness: "omits an
owned key the row does not carry" used a fixture of identity plus one owned key, whose key
set is *already* the narrowed one — so it held against a narrowing that never ran. The
fixture now carries a base key (second commit) and the leg re-run gives 4 red / 4 green.

## Gates

Run at `670380763`, the tree this PR points at:

- `pnpm exec vitest run packages/data-objectstack/` — 41 files, 556 tests, all pass.
- `pnpm exec vitest run packages/app-shell/` — 447 files, 4313 pass, 1 skipped (run at
  `f0b6bf59a`; the only later change is five lines inside one data-objectstack test file,
  re-run green, so no app-shell input moved).
- `pnpm --filter @object-ui/data-objectstack --filter @object-ui/app-shell type-check` and
  `lint` — pass (app-shell's `type-check` covers the test tsconfig; both script names echoed
  in the output, so neither was a zero-match silent pass).
- `pnpm check:control-bytes`, `check:phantom-deps` (this PR adds a cross-package import),
  `check:self-import`, `check:spec-symbols`, `check:esm-specifiers`, plus
  `check-changeset-no-major.mjs` and `check-changeset-fixed.mjs` — all pass.

Changeset: `patch` for `@object-ui/data-objectstack` and `@object-ui/app-shell`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_