### PR TITLE
test(fields): pin 'user' in FORM_WIDGET_TYPES to close one-way blindness

### DIFF
--- a/.changeset/field-type-coverage-user-form-widget-4855.md
+++ b/.changeset/field-type-coverage-user-form-widget-4855.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only: `field-type-coverage.test.ts` now pins `'user'` in `FORM_WIDGET_TYPES`,
+closing a one-way blindness in the field-type → renderer coverage guard —
+`CELL_RENDERER_TYPES` already pinned `'user'`, but the form half did not, so
+deleting the `user: 'field:user'` alias would have silently fallen back to
+`field:text` on the form path while the guard stayed green. No published
+behaviour changes.

--- a/packages/fields/src/field-type-coverage.test.ts
+++ b/packages/fields/src/field-type-coverage.test.ts
@@ -23,7 +23,7 @@ const FORM_WIDGET_TYPES = [
   'date', 'datetime', 'time',
   'boolean', 'toggle',
   'select', 'multiselect', 'radio', 'checkboxes', 'tags',
-  'lookup', 'master_detail', 'tree',
+  'lookup', 'master_detail', 'tree', 'user',
   'file', 'image', 'avatar', 'video', 'audio', 'signature',
   'location', 'geolocation', 'address', 'color', 'code', 'json', 'qrcode', 'vector',
   'object', 'composite', 'record', 'repeater',


### PR DESCRIPTION
Fixes #4855

## What

`packages/fields/src/field-type-coverage.test.ts` is the regression guard for
the field-type to renderer mapping tables. It pins two lists — one for the form
half (`FORM_WIDGET_TYPES`, via `mapFieldTypeToFormType`) and one for the cell/
read half (`CELL_RENDERER_TYPES`, via `getCellRenderer`). `CELL_RENDERER_TYPES`
already pinned `'user'`; `FORM_WIDGET_TYPES` did not. That asymmetry meant
deleting `user: 'field:user'` from `field-type-alias.ts` would make only the
cell half of the guard go red, while the form half silently fell back to
`field:text` via `mapFieldTypeToFormType`'s `|| 'field:text'` tail — the exact
one-way blindness the guard's own header says it exists to prevent.

Adds `'user'` to `FORM_WIDGET_TYPES` (one line). `owner` is intentionally left
out — it was already retired (#4814 ruling A′; tombstone at
`field-type-alias.ts:74-81`), and re-adding it to `FORM_WIDGET_TYPES` would
reassert a retired key and contradict the opposite-direction pin in
`__tests__/owner-retired.test.tsx`.

## Reverse verification (the point of this card)

**Prediction (before running):** `getCellRenderer('user')` resolves through an
independent registration (`registerFieldRenderer('user', UserCellRenderer)` in
`index.tsx`, plus a literal map entry), which never consults
`field-type-alias.ts`'s `typeMap`. So deleting `user: 'field:user'` from
`field-type-alias.ts` should turn only the newly-added form-half assertion red
— the cell half (already pinned) should stay green, since it never depended on
this alias table.

**Observed:** with `user: 'field:user'` deleted and the fix applied, exactly 1
test failed —

```
x maps "user" to a dedicated form widget (not field:text)
  AssertionError: expected 'field:text' not to be 'field:text'
Tests  1 failed | 87 passed (88)
```

— matching the prediction: only the form-half `'user'` assertion went red;
all 87 others, including the cell-half `'user'` test, stayed green. The alias
line was restored immediately after (`git checkout -- packages/fields/src/field-type-alias.ts`),
confirmed clean via `git status`/`git diff --stat`.

## Scope

File surface: `packages/fields/src/field-type-coverage.test.ts` only (plus an
empty-frontmatter changeset, confirmed required by
`node scripts/check-changeset-presence.mjs`). `field-type-alias.ts` was read
and temporarily mutated only for the ablation above, then restored — it ships
unchanged.

## Tests

All run from the repo root, all against HEAD `07d895cfd`:

- `pnpm exec vitest run packages/fields/src/field-type-coverage.test.ts` — 88/88 passed.
- `pnpm exec vitest run packages/fields/` (full package suite, exercises `owner-retired.test.tsx` alongside this change) — 107 files / 1802 tests, all passed.
- `pnpm --filter '@object-ui/fields^...' build` (dependency closure — required before type-check, otherwise stale/missing `dist` gives false `TS2307` "cannot find module" errors unrelated to this change)
- `pnpm --filter @object-ui/fields type-check` — clean.
- `pnpm --filter @object-ui/fields lint` — 0 errors, 839 pre-existing warnings (none touch `field-type-coverage.test.ts` or the changeset).
- `node scripts/check-control-bytes.mjs` — OK.
- `node scripts/check-changeset-presence.mjs` — OK (declares the empty-frontmatter changeset above).

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_