### PR TITLE
fix(app-shell): the first-boot metadata seed is adopted onto the resolved org scope (#5243)

### DIFF
--- a/.changeset/first-boot-seed-org-scope-5243.md
+++ b/.changeset/first-boot-seed-org-scope-5243.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Fix the metadata seed cache delivering nothing on the boot right after a first login.
+
+On a browser that has never signed in, `ActiveOrganizationStorage` is empty at
+mount, so the eager `app` fetch — one round trip — lands long before
+`AuthProvider` resolves the active organization (`getSession` →
+`listOrganizations` → `getActiveOrganization`). The seed entry was therefore
+written under the no-org scope while every later boot computes the real
+organization id, so the entry was never read again and an orphaned no-org entry
+was left in `sessionStorage` until the tab closed.
+
+The entry is now moved onto the resolved organization's key at the moment the
+organization resolves, taken from the live cache entry — no extra request and no
+deferred render. This is a relabelling rather than a re-scoping: that first
+request carries no `X-Tenant-ID`, and the server does not read that header for
+tenant scoping (`resolveAuthzContext` derives the tenant from
+`session.activeOrganizationId` alone), so the response was already computed for
+exactly the organization being stamped.

--- a/packages/app-shell/src/providers/MetadataProvider.tsx
+++ b/packages/app-shell/src/providers/MetadataProvider.tsx
@@ -195,8 +195,12 @@ function principalScope(): string {
  * with, so a key can never describe a principal/tenant pair the server did not
  * filter for.
  */
+function sessionKeyForOrg(type: string, orgScope: string): string {
+  return `${SESSION_STORAGE_PREFIX}${type}:${orgScope}:${principalScope()}`;
+}
+
 function sessionKeyFor(type: string): string {
-  return `${SESSION_STORAGE_PREFIX}${type}:${activeOrgScope()}:${principalScope()}`;
+  return sessionKeyForOrg(type, activeOrgScope());
 }
 
 /**
@@ -511,12 +515,25 @@ function loadFromSession(type: string): any[] | null {
   }
 }
 
-function saveToSession(type: string, items: any[]): void {
+function saveToSession(type: string, items: any[], orgScope: string = activeOrgScope()): void {
   if (typeof sessionStorage === 'undefined') return;
   try {
-    sessionStorage.setItem(sessionKeyFor(type), JSON.stringify(items));
+    sessionStorage.setItem(sessionKeyForOrg(type, orgScope), JSON.stringify(items));
   } catch {
     /* quota or serialization failure */
+  }
+}
+
+/**
+ * Delete the entry a type wrote while the active organization was still
+ * unknown — see {@link NO_ORG_SCOPE} and objectui#5243.
+ */
+function removeNoOrgSeedEntry(type: string): void {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    sessionStorage.removeItem(sessionKeyForOrg(type, NO_ORG_SCOPE));
+  } catch {
+    /* storage unavailable */
   }
 }
 
@@ -527,6 +544,9 @@ function saveToSession(type: string, items: any[]): void {
 export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: MetadataProviderProps) {
   const cacheRef = useRef<Map<string, TypeCacheEntry>>(new Map());
   const itemPromisesRef = useRef<Map<string, ItemPromiseMap>>(new Map());
+  // Types whose session entry this boot wrote under NO_ORG_SCOPE because the
+  // active organization had not resolved yet (objectui#5243).
+  const unscopedSeedTypesRef = useRef<Set<string>>(new Set<string>());
   const adapterRef = useRef(adapter);
   adapterRef.current = adapter;
 
@@ -645,7 +665,21 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
           }
           // Never let the draft-overlaid world poison the published session
           // cache — preview is ephemeral by design.
-          if (type === 'app' && !preview) saveToSession(type, items);
+          if (type === 'app' && !preview) {
+            const orgScope = activeOrgScope();
+            saveToSession(type, items, orgScope);
+            // objectui#5243 — remember that THIS boot wrote the entry before
+            // the active organization was known, so the org-resolution effect
+            // below can move it onto the key the next boot will look under.
+            // Recorded per write (not per mount) because it is the write that
+            // either did or did not know its scope; a later write that DOES
+            // know it retires the note.
+            if (orgScope === NO_ORG_SCOPE) {
+              unscopedSeedTypesRef.current.add(type);
+            } else {
+              unscopedSeedTypesRef.current.delete(type);
+            }
+          }
           debug(`fetched type=${type} items=${items.length} in ${Date.now() - started}ms`);
           bump();
           return items;
@@ -822,7 +856,47 @@ export function MetadataProvider({ children, adapter, ttlMs = DEFAULT_TTL_MS }: 
     // throw away the eager `app`/`object`/`view` fetches while they are still
     // in flight and make the next render refetch all three — precisely the
     // doubled-request regression objectui#4042 pinned.
-    if (previous === null || previous === activeOrgId) return;
+    if (previous === null || previous === activeOrgId) {
+      // ── The seed written before the org was known (objectui#5243) ────────
+      //
+      // Not a switch, but it IS the moment the scope of this boot's own seed
+      // entry becomes known. On a browser that has never signed in,
+      // `ActiveOrganizationStorage` is empty at mount and the eager `app`
+      // fetch — one round trip — lands long before AuthProvider's
+      // `getSession` → `listOrganizations` → `getActiveOrganization` chain
+      // stamps it. So the entry goes to `…:@none:…`, every later boot computes
+      // the real org id, and the seed misses the boot right after a first
+      // login while the `@none` entry is orphaned until the tab closes.
+      //
+      // Moving the label is sound because the entry is correctly SCOPED and
+      // merely mislabelled: that first request carried no `X-Tenant-ID` (same
+      // empty storage), and the server does not read that header for tenant
+      // scoping — `resolveAuthzContext` takes `tenantId` from
+      // `session.activeOrganizationId` and nothing else, and the environment
+      // chain reads only the hostname and `X-Environment-Id`. The response was
+      // therefore computed for exactly the organization being stamped here.
+      //
+      // Deliberately NOT "wait for the org before seeding": the docblock on
+      // `activeOrgScope` already records why the async context value cannot
+      // gate the seed — it resolves after mount, so gating on it makes EVERY
+      // boot miss its own entry, which is the optimization's whole point.
+      // And deliberately not a refetch: that would trade this card's miss for
+      // the objectui#4042 request-budget regression.
+      if (previous === null && activeOrgId && unscopedSeedTypesRef.current.size > 0) {
+        for (const type of unscopedSeedTypesRef.current) {
+          const entry = cacheRef.current.get(type);
+          if (entry && entry.status === 'ready' && entry.items.length > 0) {
+            // Written from the LIVE entry rather than copied through storage:
+            // the items are already in hand, so no parse, and a cached EMPTY
+            // list stays a miss exactly as objectui#4486 requires.
+            saveToSession(type, entry.items, activeOrgId);
+          }
+          removeNoOrgSeedEntry(type);
+        }
+        unscopedSeedTypesRef.current.clear();
+      }
+      return;
+    }
 
     let cancelled = false;
     cacheRef.current.clear();

--- a/packages/app-shell/src/providers/__tests__/MetadataProvider.firstBootOrgScope.test.tsx
+++ b/packages/app-shell/src/providers/__tests__/MetadataProvider.firstBootOrgScope.test.tsx
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5243 — the seed entry a FIRST-BOOT browser writes must be readable
+ * by the boot that follows it.
+ *
+ * ## The window
+ *
+ * `activeOrgScope()` reads `ActiveOrganizationStorage`, which `AuthProvider`
+ * only stamps after `getSession` → `listOrganizations` → `getActiveOrganization`
+ * resolve. The eager `app` fetch starts at mount and lands first, so on a
+ * browser that has never signed in the entry is written under `@none` while
+ * every LATER boot computes the real org id — the seed misses forever after,
+ * and the `@none` entry is orphaned in `sessionStorage` until the tab closes.
+ *
+ * ## Why the #4486 pins never saw it
+ *
+ * `primeCacheFor` in `MetadataProvider.orgScopedCache.test.tsx` stamps the org
+ * id BEFORE the first render, which models a RETURNING browser — correctly, for
+ * what those pins are about. The window here only exists when storage is empty
+ * AT MOUNT and the org arrives afterwards, so the modelling below is the whole
+ * point: `firstBoot()` renders with both storages empty and stamps the org only
+ * after the app fetch has already landed.
+ *
+ * ## Why re-keying is sound here (the objectui#5243 tenant-header check)
+ *
+ * That first fetch goes out with NO `X-Tenant-ID`, because
+ * `createAuthenticatedFetch` reads the same empty storage. It does not matter:
+ * the server never reads that header for tenant scoping. `resolveAuthzContext`
+ * takes `tenantId` from `session.activeOrganizationId` and nothing else
+ * (framework `packages/core/src/security/resolve-authz-context.ts`, pinned by
+ * `packages/verify/src/harness.org-context.test.ts`: "`session.activeOrganizationId`
+ * is the ONE field `resolveAuthzContext` reads into `tenantId`"), and the
+ * environment chain reads only the hostname and `X-Environment-Id`. So the
+ * response cached under `@none` was computed for exactly the organization
+ * `AuthProvider` is about to stamp — the entry is correctly SCOPED and merely
+ * mislabelled, which is what makes moving the label the right repair rather
+ * than a relabelling of someone else's answer.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+
+/**
+ * Same stubbing posture as the #4486 pins: only `useAuth` is faked, because
+ * `ActiveOrganizationStorage` IS the mechanism under test.
+ */
+const authState: { activeOrganization: { id: string } | null } = {
+  activeOrganization: null,
+};
+vi.mock('@object-ui/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/auth')>();
+  return { ...actual, useAuth: () => authState };
+});
+
+import { ActiveOrganizationStorage, TokenStorage } from '@object-ui/auth';
+import { MetadataProvider, useMetadata } from '../MetadataProvider';
+
+const ORG = 'org_first_login';
+
+interface AppItem {
+  name: string;
+}
+
+function makeAdapter(opts: { apps: AppItem[] | 'pending'; calls?: string[] }) {
+  return {
+    clearCache: vi.fn(),
+    getClient: () => ({
+      meta: {
+        getItems: (type: string) => {
+          opts.calls?.push(type);
+          if (type !== 'app') return Promise.resolve({ type, items: [] });
+          if (opts.apps === 'pending') return new Promise<never>(() => {});
+          return Promise.resolve({ type, items: opts.apps });
+        },
+        getItem: () => Promise.resolve({ item: null }),
+      },
+    }),
+  } as unknown as Parameters<typeof MetadataProvider>[0]['adapter'];
+}
+
+function AppsProbe() {
+  const { apps, loading } = useMetadata();
+  return (
+    <div>
+      <span data-testid="apps">{apps.map((a: AppItem) => a.name).join(',')}</span>
+      <span data-testid="loading">{String(loading)}</span>
+    </div>
+  );
+}
+
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+/** Every `objectui:metadata:app…` entry currently in sessionStorage. */
+function cachedAppKeys(): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < sessionStorage.length; i += 1) {
+    const key = sessionStorage.key(i);
+    if (key?.startsWith('objectui:metadata:app')) keys.push(key);
+  }
+  return keys;
+}
+
+/**
+ * A browser that has NEVER signed in before, driven through one whole boot.
+ *
+ * The ordering is the defect: the app fetch is allowed to land while
+ * `ActiveOrganizationStorage` is still empty (asserted, not assumed — an
+ * accidental pre-stamp would turn this into another returning-browser pin and
+ * it would pass against the bug), and only then does the AuthProvider chain
+ * resolve and stamp the org.
+ */
+async function firstBoot(apps: AppItem[], calls?: string[]): Promise<void> {
+  // Signed in, but the org is not known to the CLIENT yet: the token lands
+  // synchronously at sign-in while the active org costs three more round trips.
+  TokenStorage.set('tok_first_login');
+  // PRECONDITION — this is what makes the test model a first boot at all.
+  expect(ActiveOrganizationStorage.get()).toBeNull();
+  authState.activeOrganization = null;
+
+  const adapter = makeAdapter({ apps, calls });
+  const view = render(
+    <MetadataProvider adapter={adapter}>
+      <AppsProbe />
+    </MetadataProvider>,
+  );
+  // The eager `app` fetch resolves here — still with an empty org storage, so
+  // the request carried no `X-Tenant-ID` and the write happens in the window.
+  await waitFor(() => expect(view.getByTestId('loading').textContent).toBe('false'));
+  expect(ActiveOrganizationStorage.get()).toBeNull();
+
+  // Only NOW does `refreshOrganizations` finish and stamp the real org.
+  ActiveOrganizationStorage.set(ORG);
+  authState.activeOrganization = { id: ORG };
+  view.rerender(
+    <MetadataProvider adapter={adapter}>
+      <AppsProbe />
+    </MetadataProvider>,
+  );
+  await settle();
+  view.unmount();
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+  ActiveOrganizationStorage.clear();
+  authState.activeOrganization = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MetadataProvider first-boot seed scope (objectui#5243)', () => {
+  it('seeds the boot AFTER a first login, instead of missing its own entry', async () => {
+    await firstBoot([{ name: 'setup' }, { name: 'crm' }]);
+
+    // Boot 2. `ActiveOrganizationStorage` persists in localStorage, so the org
+    // is known at mount now — this is the returning browser the seed exists
+    // for. The fetch never lands, so anything rendered came from the seed.
+    authState.activeOrganization = { id: ORG };
+    expect(ActiveOrganizationStorage.get()).toBe(ORG);
+
+    const view = render(
+      <MetadataProvider adapter={makeAdapter({ apps: 'pending' })}>
+        <AppsProbe />
+      </MetadataProvider>,
+    );
+
+    await waitFor(() => expect(view.getByTestId('apps').textContent).toBe('setup,crm'));
+    expect(view.getByTestId('loading').textContent).toBe('false');
+  });
+
+  it('leaves no orphaned no-org entry behind after the org resolves', async () => {
+    await firstBoot([{ name: 'setup' }, { name: 'crm' }]);
+
+    // The whole first boot produced exactly ONE app entry, and it is the one
+    // the next boot will look for. An `@none` entry surviving here is the
+    // orphan the card reports — it is never read again and sits in
+    // `sessionStorage` until the tab closes.
+    const keys = cachedAppKeys();
+    expect(keys.filter((k) => k.includes(':@none:'))).toEqual([]);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toContain(`:${ORG}:`);
+  });
+
+  it('does not re-request the app list to repair the scope', async () => {
+    // The repair must cost a storage move, not a round trip: re-fetching would
+    // trade this card's miss for the objectui#4042 request-budget regression.
+    const calls: string[] = [];
+    await firstBoot([{ name: 'setup' }, { name: 'crm' }], calls);
+
+    expect(calls.filter((c) => c === 'app')).toHaveLength(1);
+  });
+
+  it('still refuses to adopt a no-org entry into a DIFFERENT org (objectui#4486 holds)', async () => {
+    // The counter-pin. Adopting on first resolution must not become "any org
+    // may claim any unlabelled entry": an entry written under a real org id is
+    // that org's, and a later boot resolving a different org must still miss.
+    await firstBoot([{ name: 'setup' }, { name: 'crm' }]);
+
+    ActiveOrganizationStorage.set('org_other');
+    authState.activeOrganization = { id: 'org_other' };
+
+    const view = render(
+      <MetadataProvider adapter={makeAdapter({ apps: 'pending' })}>
+        <AppsProbe />
+      </MetadataProvider>,
+    );
+    await settle();
+
+    expect(view.getByTestId('apps').textContent).toBe('');
+    expect(view.getByTestId('loading').textContent).toBe('true');
+  });
+});


### PR DESCRIPTION
Fixes #5243

The metadata seed cache delivers nothing on the boot right after a first login, and leaves an orphaned no-org entry behind. Verification union below ran on `174f330fa`.

## Re-derivation on current `origin/main` (the card was ~3h old)

The card was filed off a measurement taken during #5198, whose PR #5242 has since merged and touched these very providers. Re-derived at `87d9202b1`; all three readings still hold.

| Reading | Location | Status |
|---|---|---|
| `activeOrgScope()` still reads `ActiveOrganizationStorage.get() \|\| NO_ORG_SCOPE` | `packages/app-shell/src/providers/MetadataProvider.tsx:107-112` | confirmed |
| `AuthProvider` resolves the org only after `getSession` | `packages/auth/src/AuthProvider.tsx:173` sets `user`; the org effect at `:647-651` is gated on `user`; `refreshOrganizations` stamps at `:598` | confirmed |
| The eager `app` fetch still starts at mount | `MetadataProvider.tsx:816` mount effect walks `EAGER_TYPES` (`:51`), deps carry nothing org-derived | confirmed |

**PR #5242 did not close this window.** It appended `:${principalScope()}` to the key and left `activeOrgScope()` untouched — `sessionKeyFor` went from `…:${activeOrgScope()}` to `…:${activeOrgScope()}:${principalScope()}`.

A grep for any pre-existing re-key / adopt / defer mechanism returned zero hits, counter-probed against terms known present in the same file (`sessionKeyFor` 3, `NO_ORG_SCOPE` 4).

One correction to the card's mechanics, which matters for the choice: `saveToSession` is called from the fetch's `.then()` (`:648`), so the key is computed **when the response lands**, not when the request goes out. The defect is therefore precisely "response lands before the org is stamped".

## The `X-Tenant-ID` probe — the check triage folded in

That first-login request does go out with no tenant header (`createAuthenticatedFetch.ts:115-118` omits it entirely when storage is empty). **It changes nothing about the response**, on both paths a tenant could enter:

1. **Tenant scoping** — `resolveAuthzContext` derives `tenantId` from `session.activeOrganizationId` and nothing else (framework `packages/core/src/security/resolve-authz-context.ts:173`). A grep for any tenant-header read in that file returns zero, counter-probed (`tenantId` 20 hits, `headers` 7 hits in the same file). The contract is already pinned: `packages/verify/src/harness.org-context.test.ts:145-148` — *"`session.activeOrganizationId` is the ONE field `resolveAuthzContext` reads into `tenantId`"*.
2. **Environment/kernel routing** — `resolveRequestEnvironmentId` reads the hostname and `X-Environment-Id`; `extractProjectIdHeader` (`rest-server.ts:2640-2647`) reads only `x-environment-id`, never `x-tenant-id`.

Within the framework, `X-Tenant-ID` appears only in the CORS allow-list, and plugin-sharing documents that trusting it as identity was a vulnerability the secure default removed.

**So the entry cached under `@none` is correctly scoped and merely mislabelled** — it holds exactly the data of the organization `AuthProvider` is about to stamp, because the server computed it from the same session. That is what makes moving the label the right repair instead of a relabelling of someone else's answer.

**The stop clause did not fire**: this is a definitive, test-pinned contract answer, not an open contract question — no ambiguity needing a maintainer ruling.

<details>
<summary>Bounding the one sequencing nuance (the ADR-0081 single-membership repair)</summary>

`refreshOrganizations` has a legacy branch (`AuthProvider.tsx:588-596`) that calls `setActiveOrganization(orgs[0].id)`, which *mutates* the session's tenant after the fetch was served. Adoption there would carry an org-less response onto a real org id.

It is not reachable in the window adoption fires: framework #8247/#8245 guarantees a user's first session carries `activeOrganizationId` (membership settles before the session is minted — `first-session-membership-ordering.test.ts`), and that branch is documented as repairing sessions "created before the server-side active-org stamp existed". Reaching it needs an empty `ActiveOrganizationStorage` together with a pre-#8247 token, but both live in the same `localStorage`, so a browser holding the token has already been stamped by an earlier boot. In the residual case the outcome is a same-user, fail-closed-filtered list that self-heals on the next fetch — never cross-tenant.
</details>

## Mechanism chosen, and the measurement that decided it

**Adopt/re-key the entry onto the resolved org scope at the moment the org resolves.**

| Option | Fixes the boot-2 miss | Removes the orphan | Cost |
|---|---|---|---|
| Defer seeding until the org resolves | **No** | Yes | Destroys the optimization on *every* boot |
| **Re-key on org resolution (chosen)** | **Yes** | **Yes** | One storage write + one remove, no request, no render |
| Adopt the no-org entry at read time | Yes | **No** | Widens the read surface permanently |

*Defer* is ruled out by a measurement already recorded in this file — the `activeOrgScope` docblock (`:101-105`) states that the async context value "resolves ASYNCHRONOUSLY … so at seed time — the whole point of this cache — it is still `null` and every boot would miss its own entry". Measured against the round-trip depth: the org costs three sequential trips (`getSession` → `listOrganizations` → `getActiveOrganization`) against the app fetch's one, so a seed gated on it can never beat the fetch it exists to preempt.

*Adopt-at-read* fixes the miss but leaves the orphan the card explicitly names, and makes an unlabelled entry adoptable by whatever org mounts next — weakening the #4486 invariant the counter-pin protects.

**The trade I made:** one `sessionStorage` write plus one remove, executed in an effect that blocks no render, in exchange for keeping the seed's benefit on boot 2 and removing the orphan. I spend neither a request nor a render — the items are taken from the live cache entry rather than re-parsed from storage or refetched, so the #4042 request budget is untouched (pinned by a test).

## Region-level file surface

| File | Region |
|---|---|
| `packages/app-shell/src/providers/MetadataProvider.tsx` | `sessionKeyFor` → split into `sessionKeyForOrg` + `sessionKeyFor`; `saveToSession` gains an optional explicit org scope; new `removeNoOrgSeedEntry`; new `unscopedSeedTypesRef` beside the provider's other refs; the `type === 'app'` write site inside `ensureType`'s `.then()`; the first-resolution branch of the existing `activeOrgId` effect |
| `packages/app-shell/src/providers/__tests__/MetadataProvider.firstBootOrgScope.test.tsx` | new file |
| `.changeset/first-boot-seed-org-scope-5243.md` | new file, `patch` |

No `packages/app-shell/src/views/**` and no `packages/data-objectstack` — #5233's surface, untouched. Serialization disciplines: file surface declared to the region level; `main` merged before opening (`174f330fa`), which also picked up #5233 after it landed as #5272; conflicts go to the merge queue.

## Verification — all on `174f330fa`

- `pnpm exec vitest run packages/app-shell/src/providers/` — **9 files, 57 tests passed**
- `pnpm exec vitest run packages/app-shell/ packages/auth/` — **463 files, 4498 passed, 1 skipped**
- `pnpm --filter '@object-ui/app-shell' type-check` — pass; `lint` — 0 errors
- `pnpm --filter '@object-ui/app-shell^...' build` — pass
- `check-changeset-presence` / `check-changeset-no-major` / `check:control-bytes` / `check:self-import` / `check:esm-specifiers` / `check:phantom-deps` — pass

### Reverse verification (predicted before running)

Restored `MetadataProvider.tsx` to `origin/main`, kept the new tests. No rebuild needed — the test imports `../MetadataProvider` by relative source path, so vitest reads source, not `dist`.

| Test | Predicted | Observed |
|---|---|---|
| seeds the boot after a first login | RED | RED — `expected '' to be 'setup,crm'` |
| leaves no orphaned no-org entry | RED | RED — `expected [ Array(1) ] to deeply equal []`, key `objectui:metadata:app:@none:0cw83dw1k1dblo` |
| does not re-request the app list | GREEN | GREEN — guards a refetch-based mechanism, does not discriminate this bug |
| refuses to adopt into a DIFFERENT org (#4486) | GREEN | GREEN — must hold before and after |

Predicted 2 red / 2 green; observed exactly that. Fix restored byte-identically afterwards.

The new test models a genuinely first-boot browser — `firstBoot()` asserts `ActiveOrganizationStorage.get()` is null both at mount *and* after the app fetch lands, then stamps the org. Written the way the existing `primeCacheFor` pins are written (org stamped before render) it would model a returning browser and pass against the bug.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_