### PR TITLE
fix(core): the pivot preserves category-key ABSENCE, so the framework#4033 guard can fire (#4507)

### DIFF
--- a/.changeset/pivot-preserves-category-key-absence.md
+++ b/.changeset/pivot-preserves-category-key-absence.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/core': patch
+---
+
+`buildChartSeries`' pivot branch preserves key ABSENCE, so a never-projected first dimension still reaches the framework#4033 placeholder.
+
+`hasNoCategoryKey` (plugin-charts' `AdvancedChartImpl`) exists to catch one
+shape: a dimension a dataset query GROUPED BY but never PROJECTED, so no row
+carries the category key. Rather than draw an axis with no marks, the renderer
+names the missing key. Its whole signal is `key in row`, asked of the rows it is
+handed — which for a dataset-bound chart are `buildChartSeries`' output.
+
+The pivot branch wrote `[xKey]` onto every bucket it created, so `key in row`
+was unconditionally true downstream and the guard could not fire for a
+2-dimension/1-measure chart no matter what the query returned. Every row
+collapsed into one unnamed bucket drawing a blank tick — the exact silent shape
+the placeholder was introduced to eliminate. The defence was dead precisely
+where the defect it guards against lands. The single-dimension branch was never
+affected: it passes rows through, so key-absent rows stay key-absent.
+
+An emitted bucket now carries the axis key exactly when some row of it did.
+That is `hasNoCategoryKey`'s own `rows.some(key in row)` lifted through the
+pivot's aggregation, so the guard reads the same fact before and after.
+
+The route rests on a measurement of how a dataset query actually reports an
+unprojected dimension in a 2-dimension grouping: it OMITS the key. The ObjectQL
+strategy writes a dimension key only when the engine returned that column, the
+native-SQL strategy returns driver rows carrying only the selected columns, JSON
+cannot transport `undefined`, and `ObjectStackAdapter.queryDataset` passes rows
+through by reference. An explicit `null` means the opposite — the column WAS
+projected and its value is null — and that case is untouched: it still renders
+under the `(None)` bucket label (objectui#4466 / objectui#4497). Where one
+bucket collects both (an absent value and a stored `null` share the `[null]`
+identity), the bucket keeps its label and draws, because refusing there would
+tell an author their query never projected a dimension that it did.
+
+No change to any chart whose first dimension projected: ordinary, null-valued
+and empty-string categories all emit byte-identical rows, key order included.

--- a/packages/core/src/utils/chart-series.nullCategory.test.ts
+++ b/packages/core/src/utils/chart-series.nullCategory.test.ts
@@ -43,6 +43,15 @@
  * it) while still writing the dropped group's measure into the bucket. The
  * blocks at the bottom of this file are its own.
  *
+ * objectui#4507 is the last of the family, and it is about the DIVISION rather
+ * than the bucket: the pivot wrote the axis key onto every bucket it created,
+ * so a first dimension grouped by but never PROJECTED reached the renderer with
+ * the key present (value `undefined`) and `hasNoCategoryKey` could not fire for
+ * a pivoted chart at all. The pin at the bottom of this file recorded that as a
+ * measured limit; it is now lifted, and the case's own assertion — key-absent
+ * rows are never relabelled `(None)` — is unchanged. `key in row` is the whole
+ * signal, and `toEqual` cannot see it: `chart-series.unprojectedCategory.test.ts`.
+ *
  * objectui#4508 then answers what #4497 filed instead of widening into: that
  * map KEY was the DISPLAY string, so it could not tell a null group from an
  * empty-string one, nor from a record whose stored value spells the bucket
@@ -267,17 +276,25 @@ describe('buildChartSeries — pivot must-not-change (objectui#4497)', () => {
     // defect (a dimension grouped by but never projected) and must not be
     // relabelled "(None)", which would say the records have no value.
     //
-    // MEASURED LIMIT, deliberately pinned: the pivot writes `[xKey]` onto every
-    // bucket it creates, so this shape reaches the renderer WITH the key and
-    // `hasNoCategoryKey` (framework#4033) cannot see it — that was already true
-    // before #4497 and is unchanged by it. Filed separately rather than widened
-    // into this card.
+    // The LIMIT this case pinned is lifted by objectui#4507: the pivot used to
+    // write `[xKey]` onto every bucket it created, so the shape reached the
+    // renderer WITH the key and `hasNoCategoryKey` (framework#4033) could not
+    // see it. It now reaches the renderer key-LESS, and the guard fires. What
+    // this case asserts is unchanged: the row is not bucketed and never wears
+    // the `(None)` label.
+    //
+    // Asserted with `in` / `toStrictEqual` on purpose. `toEqual` DROPS an
+    // undefined-valued key, so the old expectation below read the same against
+    // `{ status: undefined, Low: 3 }` and `{ Low: 3 }` — which is precisely how
+    // the pivot's dead guard stayed invisible while this file pinned the rows
+    // four cards in a row. See `chart-series.unprojectedCategory.test.ts`.
     const r = buildChartSeries(
       [{ priority: 'Low', est_hours: 3 }],
       ['status', 'priority'],
       ['est_hours'],
     );
-    expect(r.data).toEqual([{ status: undefined, Low: 3 }]);
+    expect(r.data).toStrictEqual([{ Low: 3 }]);
+    expect('status' in r.data[0]).toBe(false);
     expect(r.data[0].status).not.toBe(NULL_CATEGORY_LABEL);
   });
 });

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -36,6 +36,13 @@
  * label used to serve as its own key, which conflated two pairs of genuinely
  * different groups; see {@link chartBucketId} for the identity, and
  * {@link CHART_BUCKET_ID_KEY} for how it reaches a click handler.
+ *
+ * Key ABSENCE survives the pivot as of objectui#4507: an emitted bucket carries
+ * the x-axis key exactly when some row of it did. A first dimension that was
+ * grouped by but never PROJECTED therefore still reaches the renderer key-less,
+ * where `hasNoCategoryKey` (framework#4033) names it instead of drawing an axis
+ * with no marks. "Known to be empty" draws under the bucket label, "cannot
+ * know" refuses — one doctrine, and now BOTH branches state it.
  */
 import { pivotBucketId, pivotDimensionValue } from './dataset-pivot.js';
 
@@ -463,11 +470,54 @@ export function buildChartSeries(
       // defect, one branch below). Key and display value are two different
       // things here, and now they are two different KINDS of thing.
       //
-      // The bucket takes its label from the row that CREATED it, exactly as it
-      // took its raw value before.
+      // The bucket takes its label from the first row that CARRIES the key,
+      // exactly as it took the CREATING row's raw value before — the same row
+      // in every bucket a projected dimension produces, because a row whose
+      // `xKey` is absent reads `xRaw === undefined` and therefore lands in the
+      // `[null]` bucket and nowhere else.
+      //
+      // A bucket carries `xKey` exactly when SOME row of it did, and that is
+      // objectui#4507: the write used to be unconditional, so a first dimension
+      // GROUPED BY BUT NEVER PROJECTED (framework#4033 — no row carries the key
+      // at all) reached the renderer as `{ [xKey]: undefined }`, `key in row`
+      // answered true, and `hasNoCategoryKey` could not fire for a pivoted
+      // chart. The defence was dead exactly where the defect it guards against
+      // lands: every row collapsed into one bucket painting a blank tick, which
+      // is the silent shape the placeholder exists to replace. The single-
+      // dimension branch never had the problem — it passes rows through, so
+      // key-absent rows stay key-absent — and this is that same answer here.
+      //
+      // MEASURED end to end before it was written (objectui#4507): the strategy
+      // that maps engine rows to result rows writes a dimension key only when
+      // the engine actually returned that column (`if (shortName in row)`), the
+      // native-SQL strategy returns driver rows that carry only the columns the
+      // statement selected, and JSON cannot transport `undefined` in the first
+      // place — so an unprojected dimension arrives as an ABSENT key, while an
+      // explicit `null` means the column WAS projected and its value is null.
+      // Those are the two shapes, they are cleanly separated at the source, and
+      // this branch now keeps them apart instead of merging them.
+      //
+      // Why the bug was invisible to every pin that "saw" the emitted row: both
+      // `JSON.stringify` and `toEqual` DROP an undefined-valued key, so the
+      // pivot's output read as key-absent everywhere except in the one test
+      // that decides the placeholder — `key in row`.
+      //
+      // The upgrade in the second clause is not cosmetic. `chartBucketId`
+      // encodes an absent value and a stored `null` identically (`[null]`, by
+      // ADR-0021's normalization), so ONE bucket can collect both key-absent
+      // rows and rows whose category is genuinely null. If any of its rows
+      // carried the key, the bucket is "known to be empty" and draws under the
+      // label; refusing there would tell the author their query never projected
+      // a dimension that it did project — a false sentence, and the mirror of
+      // the false sentence objectui#4497 refused to print by NOT relabelling a
+      // key-absent row `(None)`. Both halves of that doctrine are now live in
+      // this branch: key absent everywhere → the framework#4033 placeholder;
+      // key present with a null value → the bucket label.
       const xId = chartBucketId(xRaw);
-      if (!byX.has(xId)) {
-        byX.set(xId, { [xKey]: isNullCategory(row, xKey) ? nullLabel : xRaw });
+      let bucket = byX.get(xId);
+      if (!bucket) byX.set(xId, (bucket = {}));
+      if (carriesKey(row, xKey) && !carriesKey(bucket, xKey)) {
+        bucket[xKey] = isNullCategory(row, xKey) ? nullLabel : xRaw;
       }
       // The group's own column, or nothing at all when the row carries no
       // second dimension to be grouped BY. Nothing at all is the point: the
@@ -477,7 +527,7 @@ export function buildChartSeries(
       const column = carriesKey(row, groupKey)
         ? columnById.get(chartBucketId(row[groupKey]))
         : undefined;
-      if (column !== undefined) byX.get(xId)![column] = row[measure];
+      if (column !== undefined) bucket[column] = row[measure];
     }
 
     // Two DISTINCT buckets can still render the same axis text — the null

--- a/packages/core/src/utils/chart-series.unprojectedCategory.test.ts
+++ b/packages/core/src/utils/chart-series.unprojectedCategory.test.ts
@@ -1,0 +1,217 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4507 — key ABSENCE must survive the pivot, or the framework#4033
+ * guard is dead exactly where the defect it guards against lands.
+ *
+ * `hasNoCategoryKey` (plugin-charts' `AdvancedChartImpl`) catches a first
+ * dimension that a dataset query GROUPED BY but never PROJECTED: no row carries
+ * the category key, so instead of drawing an axis with no marks the renderer
+ * names the missing key. Its whole signal is one expression over the rows it is
+ * handed — and for a dataset-bound chart those rows are `buildChartSeries`'
+ * OUTPUT:
+ *
+ *     !rows.some((row) => row != null && typeof row === 'object' && key in row)
+ *
+ * The pivot branch wrote `[xKey]` onto every bucket it created, so `key in row`
+ * was unconditionally true downstream and the guard could not fire for a
+ * 2-dimension/1-measure chart no matter what the query returned. Every row
+ * collapsed into one unnamed bucket painting a blank tick — the silent shape
+ * the placeholder exists to replace.
+ *
+ * ## The measurement the fix rests on (taken before it was written)
+ *
+ * How a dataset query actually reports an unprojected dimension in a 2-dim
+ * grouping — the card's own binding precondition, because omitting `[xKey]`
+ * only helps if key-ABSENCE is genuinely the shape that arrives:
+ *
+ *  - the ObjectQL strategy builds each result row from scratch and writes a
+ *    dimension key ONLY when the engine returned that column
+ *    (`if (shortName in row) mapped[dim] = row[shortName]`), so an unprojected
+ *    dimension is OMITTED, never `null`-filled — pinned framework-side by
+ *    `objectql-timedimension-projection.test.ts`
+ *    (`expect(row).not.toHaveProperty('due_date')`) and measured live in
+ *    framework#4033, where the rows read `[{ count: 2 }, { count: 8 }]`;
+ *  - the native-SQL strategy returns driver rows, which carry only the columns
+ *    the statement selected — same shape, different path;
+ *  - JSON cannot transport `undefined` at all, so nothing between the server and
+ *    a chart can turn "no column" into a present-but-undefined key;
+ *  - `ObjectStackAdapter.queryDataset` hands `rows` through by reference.
+ *
+ * Measured end to end through that adapter with the server answering the
+ * #4033 payload for `dimensions: ['status','priority']`: `'status' in rows[0]`
+ * was `false`, and after `buildChartSeries` it was `true` with the value
+ * `undefined`. An explicit `null` means something DIFFERENT and arrives only
+ * when the column WAS projected — that is the `(None)` bucket's case
+ * (objectui#4466 / objectui#4497), which this file must leave intact.
+ *
+ * ## Why `toEqual` cannot be the assertion here
+ *
+ * Both `JSON.stringify` and `toEqual` DROP an undefined-valued key, so
+ * `{ status: undefined, Low: 3 }` and `{ Low: 3 }` read as identical
+ * everywhere except in the one test that decides the placeholder — `key in
+ * row`. That is why this defect survived four cards' worth of pins over the
+ * same rows, and why the assertions below say `in` / `Object.keys` /
+ * `toStrictEqual` out loud.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildChartSeries, NULL_CATEGORY_LABEL } from './chart-series.js';
+
+/**
+ * `hasNoCategoryKey`'s predicate, verbatim (plugin-charts'
+ * `AdvancedChartImpl.tsx`), minus the chart-type gate it shares with nothing
+ * here. Spelled rather than imported because `@object-ui/core` must not depend
+ * on a plugin; the DOM half — key-absent rows render the explanatory
+ * placeholder — is pinned in `AdvancedChartImpl.missingCategoryKey.test.tsx`,
+ * and this file is what finally lets a PIVOTED chart reach it.
+ */
+const guardWouldFire = (rows: Array<Record<string, unknown>>, key: string): boolean =>
+  rows.length > 0 && !rows.some((row) => row != null && typeof row === 'object' && key in row);
+
+/** The framework#4033 shape in a 2-dim grouping: `status` never projected. */
+const UNPROJECTED_X = [
+  { priority: 'High', est_hours: 5 },
+  { priority: 'Low', est_hours: 3 },
+];
+
+describe('buildChartSeries — an unprojected first dimension survives the pivot (objectui#4507)', () => {
+  it('emits a bucket that does NOT carry the category key', () => {
+    const r = buildChartSeries(UNPROJECTED_X, ['status', 'priority'], ['est_hours']);
+
+    expect(r.data).toHaveLength(1);
+    expect('status' in r.data[0]).toBe(false);
+    expect(Object.keys(r.data[0])).toEqual(['High', 'Low']);
+    // The measures still land — the numbers were never the broken part.
+    expect(r.data[0]).toStrictEqual({ High: 5, Low: 3 });
+  });
+
+  it('reaches the framework#4033 guard, which the pivot used to defeat', () => {
+    const r = buildChartSeries(UNPROJECTED_X, ['status', 'priority'], ['est_hours']);
+
+    // Same question, asked of the raw rows and of the pivot's output. Before
+    // this card the two answers disagreed, and the renderer only ever sees the
+    // second one.
+    expect(guardWouldFire(UNPROJECTED_X, 'status')).toBe(true);
+    expect(guardWouldFire(r.data, r.xAxisKey!)).toBe(true);
+  });
+
+  it('does NOT relabel the key-absent bucket "(None)" — that would state something false', () => {
+    // The other half of the doctrine, unchanged (objectui#4497): "this
+    // dimension was never projected" and "these records have no value" are
+    // different sentences, and only the second one is the bucket's.
+    const r = buildChartSeries(UNPROJECTED_X, ['status', 'priority'], ['est_hours']);
+
+    expect(Object.values(r.data[0])).not.toContain(NULL_CATEGORY_LABEL);
+    expect(r.data[0].status).not.toBe(NULL_CATEGORY_LABEL);
+  });
+
+  it('still names the second dimension\'s series — only the axis key is withheld', () => {
+    const r = buildChartSeries(UNPROJECTED_X, ['status', 'priority'], ['est_hours']);
+
+    expect(r.xAxisKey).toBe('status');
+    expect(r.series).toEqual([
+      { dataKey: 'High', label: 'High' },
+      { dataKey: 'Low', label: 'Low' },
+    ]);
+  });
+});
+
+describe('buildChartSeries — a bucket carries the key exactly when some row did (objectui#4507)', () => {
+  it('a genuinely NULL category beside a key-absent row keeps its "(None)" label', () => {
+    // `chartBucketId` encodes an absent value and a stored `null` identically
+    // (`[null]`), so ONE bucket collects both. If ANY of its rows carried the
+    // key, the bucket is "known to be empty" — it draws under the label, and
+    // the guard must stay silent. Refusing here would tell the author their
+    // query never projected a dimension that it demonstrably did.
+    const rows = [
+      { priority: 'High', est_hours: 5 },          // key absent
+      { status: null, priority: 'Low', est_hours: 3 }, // key present, value null
+    ];
+    const r = buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+
+    expect(r.data).toHaveLength(1);
+    expect('status' in r.data[0]).toBe(true);
+    expect(r.data[0].status).toBe(NULL_CATEGORY_LABEL);
+    expect(guardWouldFire(r.data, r.xAxisKey!)).toBe(false);
+  });
+
+  it('order does not decide it — the null row first gives the same bucket', () => {
+    const rows = [
+      { status: null, priority: 'Low', est_hours: 3 },
+      { priority: 'High', est_hours: 5 },
+    ];
+    const r = buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+
+    expect(r.data).toStrictEqual([{ status: NULL_CATEGORY_LABEL, Low: 3, High: 5 }]);
+  });
+
+  it('a PARTIALLY projected first dimension draws what projected', () => {
+    // The mirror of `hasNoCategoryKey`'s own `!rows.some(…)`: it refuses only
+    // when NOT ONE row carries the key. Some rows carrying it means there is a
+    // real axis to draw, so the guard stays silent and the key-less rows keep
+    // their (blank-ticked) bucket — the shape they always had.
+    const rows = [
+      { status: 'Backlog', priority: 'High', est_hours: 5 },
+      { priority: 'Low', est_hours: 3 },
+    ];
+    const r = buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+
+    expect(r.data).toHaveLength(2);
+    expect(r.data[0]).toStrictEqual({ status: 'Backlog', High: 5 });
+    expect('status' in r.data[1]).toBe(false);
+    expect(guardWouldFire(r.data, r.xAxisKey!)).toBe(false);
+  });
+});
+
+describe('buildChartSeries — must-not-change (objectui#4507)', () => {
+  it('an ordinary pivot is byte-identical, key ORDER included', () => {
+    const rows = [
+      { status: 'Backlog', priority: 'High', est_hours: 5 },
+      { status: 'Backlog', priority: 'Low', est_hours: 3 },
+      { status: 'Done', priority: 'High', est_hours: 24 },
+    ];
+    const r = buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+
+    expect(r.data).toStrictEqual([
+      { status: 'Backlog', High: 5, Low: 3 },
+      { status: 'Done', High: 24 },
+    ]);
+    // The axis key is still written FIRST: a bucket's creating row carries it
+    // whenever the dimension projected at all.
+    expect(Object.keys(r.data[0])).toEqual(['status', 'High', 'Low']);
+  });
+
+  it('a null-valued category still becomes the bucket label (objectui#4497)', () => {
+    const r = buildChartSeries(
+      [{ status: null, priority: 'High', est_hours: 5 }],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+
+    expect(r.data).toStrictEqual([{ status: NULL_CATEGORY_LABEL, High: 5 }]);
+  });
+
+  it('an empty-string category is a VALUE and keeps it (objectui#4508)', () => {
+    const r = buildChartSeries(
+      [{ status: '', priority: 'High', est_hours: 5 }],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+
+    expect(r.data).toStrictEqual([{ status: '', High: 5 }]);
+    expect(guardWouldFire(r.data, r.xAxisKey!)).toBe(false);
+  });
+
+  it('never mutates the caller rows', () => {
+    const rows = [{ priority: 'High', est_hours: 5 }];
+    buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+
+    expect(rows).toStrictEqual([{ priority: 'High', est_hours: 5 }]);
+  });
+});


### PR DESCRIPTION
Fixes #4507

Verified at `02779e625` (the commit this body's gate list was run against).

## The measurement the route rests on (taken FIRST, before any edit)

The card's own precondition is binding: omitting `[xKey]` from a bucket only helps if key-**absence** is genuinely the shape a dataset query produces for a dimension it grouped by but never projected. So that was measured before anything was written.

**Producer half — the key is OMITTED, never null-filled.**

- `service-analytics`' ObjectQL strategy builds each result row from scratch and writes a dimension key only when the engine actually returned that column — `if (shortName in row) mapped[dim] = row[shortName]`. A dimension that did not project simply never becomes a property.
- The native-SQL strategy returns driver rows (`ctx.executeRawSql`) verbatim; a column the statement never selected is not a property of the row object either. Same shape, different path.
- Pinned framework-side already: `objectql-timedimension-projection.test.ts`, case "keeps a non-granular timeDimension OUT of the projection", asserts `expect(row).not.toHaveProperty('due_date')`. And framework#4033 itself was measured on a live showcase app, where the rows read `[{ count: 2 }, { count: 8 }]` — the bucket key entirely gone while the numbers were right.
- JSON cannot transport `undefined` at all, so no layer between the server and a chart can turn "no column" into a present-but-undefined key — even the executor paths that spell `out[dim] = row[dim]` emit a key `JSON.stringify` then drops.
- `ObjectStackAdapter.queryDataset` passes `rows` through by reference (no per-row normalization).

**Consumer half — executed end to end through the real adapter** with the server answering the framework#4033 payload for `dimensions: ['status','priority'], measures: ['est_hours']` (`status` never projected):

```
[1] adapter rows            : [{"priority":"High","est_hours":5},{"priority":"Low","est_hours":3}]
[1] "status" in rows[0]     : false
[1] Object.keys(rows[0])    : [ 'priority', 'est_hours' ]
[2] emitted data            : [{"High":5,"Low":3}]          <- JSON hides it
[2] Object.keys(data[0])    : [ 'status', 'High', 'Low' ]   <- the key IS there
[2] "status" in data[0]     : true
[2] data[0].status          : undefined
[3] guard fires on RAW rows : true
[3] guard fires on PIVOTED  : false
```

So: **the row omits the key**, the rows are still returned (they are grouped by the dimension that did project), and the pivot is exactly where the signal dies. An explicit `null` means the opposite — the column WAS projected and its value is null — which is the `(None)` bucket's case (objectui#4466 / #4497) and is untouched here. The two shapes are cleanly separated at the source, which is what makes route 1 coherent.

The measurement **confirms** route 1. No fork to report.

## The route taken, and why

**Route 1 — the pivot preserves key-absence, so the existing guard sees it.** One guard, one meaning; nothing of the pivot's internals leaks into the renderer, and `packages/plugin-charts` is not touched at all (route 2 would have widened the file surface, and the dispatch ruled that a fork to report rather than a widening to take).

An emitted bucket now carries the axis key **exactly when some row of it did**:

```ts
const xId = chartBucketId(xRaw);
let bucket = byX.get(xId);
if (!bucket) byX.set(xId, (bucket = {}));
if (carriesKey(row, xKey) && !carriesKey(bucket, xKey)) {
  bucket[xKey] = isNullCategory(row, xKey) ? nullLabel : xRaw;
}
```

That is `hasNoCategoryKey`'s own `rows.some(key in row)` lifted through the pivot's aggregation, so the guard reads the same fact before and after the pivot instead of the opposite one.

The second clause is not cosmetic. `chartBucketId` encodes an absent value and a stored `null` identically (`[null]`, by ADR-0021's normalization), so **one** bucket can collect both key-absent rows and rows whose category is genuinely null. If any of its rows carried the key, the bucket is "known to be empty": it keeps its `(None)` label and draws. Refusing there would tell an author their query never projected a dimension that it demonstrably did — the mirror of the false sentence #4497 refused to print by not relabelling a key-absent row `(None)`.

## Why this survived four cards' worth of pins over the same rows

Both `JSON.stringify` and `toEqual` **drop an undefined-valued key**, so `{ status: undefined, Low: 3 }` and `{ Low: 3 }` read as identical everywhere — except in the one test that decides the placeholder, `key in row`. The new assertions say `in` / `Object.keys` / `toStrictEqual` out loud for that reason.

## The pinned limit keeps its meaning

`chart-series.nullCategory.test.ts`, case "does NOT bucket a row that lacks the category key ENTIRELY", is **not** rewritten to match the change and does not fail: `(None)`-relabel stays refused for key-absent rows, which is what the case asserts. What changed is the stale *limit* recorded in its comment ("the pivot writes `[xKey]` onto every bucket … the guard cannot see it") — that limit is what this card exists to lift, so the note now says so, and the expectation is tightened from `toEqual([{ status: undefined, Low: 3 }])` (blind in both directions) to `toStrictEqual([{ Low: 3 }])` plus an explicit `'status' in` assertion. Same meaning, now falsifiable.

## Reverse verification — predicted before running, then run

Ablation: restore the pre-fix `chart-series.ts` from `origin/main`, keep the new tests. **No rebuild is involved in the resolution path**: the tests import `./chart-series.js`, which vitest resolves to `packages/core/src/utils/chart-series.ts` (source), and `vitest.config.mts` additionally aliases `@object-ui/core` to `packages/core/src`. There is no `dist` and no package-`exports` hop anywhere in the path, so a stale build cannot hold a result — and the ablation going red is itself the proof that the source edit is what the run reads. The restore leg was confirmed by `git status` / `git diff HEAD` both empty (tree byte-identical to the commit) and the suites returning to green.

Predicted **5 red**, named individually; observed **5 red, exactly those five**:

| test | predicted | observed |
|---|---|---|
| emits a bucket that does NOT carry the category key | RED | RED |
| reaches the framework#4033 guard, which the pivot used to defeat | RED | RED |
| does NOT relabel the key-absent bucket "(None)" | GREEN (already true) | GREEN |
| still names the second dimension's series | GREEN | GREEN |
| a genuinely NULL category beside a key-absent row keeps its "(None)" label | RED | RED |
| order does not decide it — the null row first | GREEN (old code was right this way round) | GREEN |
| a PARTIALLY projected first dimension draws what projected | RED | RED |
| ordinary pivot byte-identical, key ORDER included | GREEN | GREEN |
| null-valued category still becomes the bucket label | GREEN | GREEN |
| empty-string category is a VALUE and keeps it | GREEN | GREEN |
| never mutates the caller rows | GREEN | GREEN |
| nullCategory: does NOT bucket a row that lacks the category key ENTIRELY | RED | RED |

```
Tests  5 failed | 73 passed (78)
AssertionError: expected false to be true   <- guard on the pivoted rows
```

After restore: `Test Files 3 passed (3) · Tests 88 passed (88)`.

## Gates run locally (at `02779e625`)

- `pnpm --filter '@object-ui/core^...' build` — dependency closure, green
- `pnpm exec vitest run packages/core/ packages/plugin-charts/` — 121 files, 2132 tests, green
- `pnpm exec vitest run packages/plugin-dashboard/ packages/plugin-report/ packages/data-objectstack/` — 117 files, 1280 tests, green (every `buildChartSeries` consumer)
- `pnpm --filter @object-ui/core type-check` — green
- `pnpm exec eslint` on the three changed source files — green
- `node scripts/check-control-bytes.mjs`, `check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-changeset-fixed.mjs`, `check-type-check-coverage.mjs` — green
- `pnpm check:esm-specifiers`, `check:self-import`, `check:phantom-deps` — green

The DOM half is already pinned and untouched: `AdvancedChartImpl.missingCategoryKey.test.tsx` renders the explanatory placeholder for key-absent rows. This PR is what finally lets a pivoted chart reach it.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_