### PR TITLE
fix(console): drop the dead `workflow` and `feed` catalog keys (#4303)

### DIFF
--- a/.changeset/api-console-drop-dead-catalog-keys-4303.md
+++ b/.changeset/api-console-drop-dead-catalog-keys-4303.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/console': patch
+---
+
+API Console's endpoint catalog drops the `workflow` and `feed` entries — 7 endpoint declarations that could never render on any host
+
+`SERVICE_ENDPOINT_CATALOG` keys are looked up directly in `/discovery`'s `services` map, which the framework keys by `CoreServiceName`. Neither `workflow` (5 endpoints under `/api/v1/workflow/*`) nor `feed` (2 endpoints under `/api/v1/feed/*`) names a `CoreServiceName` slot: the `workflow` slot was retired upstream (objectstack#4451) and `feed` never was one. Both were unconditionally hidden by the fail-closed lookup (ADR-0076 D12) — a miss is indistinguishable from "no such service" — so this changes no rendered output; it only removes two catalog entries that could never surface an endpoint.
+
+Counter-probed against current objectstack `origin/main` before removal: no `registerService('workflow')`, no mounted `/api/v1/workflow` route, and no `/api/v1/feed` route anywhere in source — both are confirmed dead, not merely unused. Per objectui#4303's ruling, this is dead-code removal, not a rename: neither key has a correctly-spelled slot to move to.
+
+#4240's tripwire test — which pins `SERVICE_ENDPOINT_CATALOG` keys against `CoreServiceName` and had carried `workflow`/`feed` as a documented exception set — is trimmed alongside the catalog: the exception set and its `#4303` reference are removed now that both keys are gone, so the assertion goes back to a plain "every catalog key is a canonical slot" with no carve-outs.

--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts
@@ -158,18 +158,6 @@ describe('useApiDiscovery — fail-closed posture is preserved (ADR-0076 D12)', 
 describe('SERVICE_ENDPOINT_CATALOG keys are canonical service-slot names', () => {
   const SLOTS = new Set<string>(CoreServiceName.options);
 
-  /**
-   * Catalog keys that are NOT slots and are known-dead, with the finding that
-   * tracks them: objectui#4303. `workflow`'s slot was retired in
-   * objectstack#4451 and `feed` never was one, so neither can ever appear in
-   * `/discovery` — there is no correctly-spelled name to rename them to, which
-   * is why they are excepted here instead of fixed in #4240.
-   *
-   * This is a subset check, so REMOVING either key keeps this green; only
-   * adding a new non-slot key goes red.
-   */
-  const KNOWN_DEAD_NON_SLOT_KEYS = new Set(['workflow', 'feed']);
-
   it('the spec exports a usable slot vocabulary (guards the derivation itself)', () => {
     expect(SLOTS.size).toBeGreaterThan(5);
     expect(SLOTS.has('file-storage'), 'file-storage must be a declared CoreServiceName slot').toBe(true);
@@ -181,15 +169,14 @@ describe('SERVICE_ENDPOINT_CATALOG keys are canonical service-slot names', () =>
     expect(SERVICE_ENDPOINT_CATALOG['file-storage'].defaultRoute).toBe('/api/v1/storage');
   });
 
-  it('every service-gated catalog key is a canonical slot, except the documented dead ones (#4303)', () => {
+  it('every service-gated catalog key is a canonical slot', () => {
     const nonSlot = Object.keys(SERVICE_ENDPOINT_CATALOG).filter(k => !SLOTS.has(k));
-    const undocumented = nonSlot.filter(k => !KNOWN_DEAD_NON_SLOT_KEYS.has(k));
 
     expect(
-      undocumented,
+      nonSlot,
       'these catalog keys name no CoreServiceName slot, so /discovery can never report them '
         + 'and their groups will never render on any host — key them by the canonical slot name, '
-        + 'or retire the entry (see objectui#4303)',
+        + 'or retire the entry',
     ).toEqual([]);
   });
 });

--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
@@ -138,17 +138,6 @@ export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRo
       { method: 'GET', path: '/usage', desc: 'AI quota headroom per meter (console usage indicator)' },
     ],
   },
-  workflow: {
-    group: 'Workflow',
-    defaultRoute: '/api/v1/workflow',
-    endpoints: [
-      { method: 'GET', path: '/:object/config', desc: 'Get workflow configuration' },
-      { method: 'GET', path: '/:object/:recordId/state', desc: 'Get workflow state' },
-      { method: 'POST', path: '/:object/:recordId/transition', desc: 'Execute workflow transition', bodyTemplate: { targetState: '' } },
-      { method: 'POST', path: '/:object/:recordId/approve', desc: 'Approve workflow step', bodyTemplate: { comment: '' } },
-      { method: 'POST', path: '/:object/:recordId/reject', desc: 'Reject workflow step', bodyTemplate: { comment: '' } },
-    ],
-  },
   realtime: {
     group: 'Realtime',
     defaultRoute: '/api/v1/realtime',
@@ -207,14 +196,6 @@ export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRo
       { method: 'POST', path: '/views', desc: 'Create view', bodyTemplate: { name: '', object: '', type: 'list' } },
       { method: 'PATCH', path: '/views/:id', desc: 'Update view', bodyTemplate: { name: '' } },
       { method: 'DELETE', path: '/views/:id', desc: 'Delete view' },
-    ],
-  },
-  feed: {
-    group: 'Feed',
-    defaultRoute: '/api/v1/feed',
-    endpoints: [
-      { method: 'GET', path: '/:object/:recordId', desc: 'Get feed items' },
-      { method: 'POST', path: '/:object/:recordId', desc: 'Post feed item', bodyTemplate: { body: '' } },
     ],
   },
   // The KEY is the canonical service-slot name, because it is looked up


### PR DESCRIPTION
Fixes #4303

## What

`SERVICE_ENDPOINT_CATALOG` in `apps/console/src/pages/developer/hooks/useApiDiscovery.ts` carried two catalog keys that name no `CoreServiceName` slot and therefore could never render on any host — `workflow` (retired upstream in objectstack#4451) and `feed` (never existed as a slot). Per triage's ruling (issue comment), this is dead-code removal, not a rename: both entries are deleted.

- Removed `workflow` (5 endpoint declarations under `/api/v1/workflow/*`)
- Removed `feed` (2 endpoint declarations under `/api/v1/feed/*`)
- **7 endpoint declarations removed in total**, matching the card's count.

No rendered behaviour changes: both groups were already unconditionally hidden by the fail-closed `discoveredServices` lookup (ADR-0076 D12) on every host, since neither key was ever present in `/discovery`'s `services` map.

## Premise re-check (objectui side, current `origin/main`)

Confirmed before editing: `SERVICE_ENDPOINT_CATALOG` still carried both `workflow` (5 endpoints) and `feed` (2 endpoints) — 7 total, matching the ruled count exactly. (The objectstack-side counter-probes were already re-run by the PM at claim time — both keys are dead there too: no `registerService('workflow')`, no mounted `/api/v1/workflow` route, no `/api/v1/feed` route in source.)

No server routes, discovery entries, or slot members were added — removal only, per triage's explicit prohibition on widening.

## #4240 pin test — trimmed, not just left passing

#4240's tripwire test asserts every `SERVICE_ENDPOINT_CATALOG` key against `CoreServiceName`, with `workflow`/`feed` carried as a documented, exhaustive exception set citing #4303. As the card predicted, removing the two keys keeps the pin green on its own (it's a subset check) — that would have been the trap. This PR also trims the now-stale `KNOWN_DEAD_NON_SLOT_KEYS` exception set and its `#4303` reference, so the assertion goes back to a plain "every catalog key is a canonical slot" with no carve-outs. The pin itself is untouched/still enforcing.

Verified green at three points — before the catalog edit, after the catalog edit but before the trim, and after the trim — all three runs `Test Files 1 passed (1)` / `Tests 12 passed (12)` on `apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts`. Final confirmation re-run at this PR's head commit `23dfa0a5e`:

```
 Test Files  4 passed (4)
      Tests  35 passed (35)
```
(`useApiDiscovery.test.ts` + the other 3 developer-page suites — the 12 pin-test cases are included in the 35.)

## Tests

All run from the repo root per objectui#3378 (`pnpm --filter` silently runs the wrong package's suite).

- `pnpm exec vitest run apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts` — 12/12 green, checked before the catalog edit, after the catalog edit, and after the exception-set trim.
- `pnpm exec vitest run apps/console/src/pages/developer/` — full developer-page suite, 35/35 green (re-confirmed at head `23dfa0a5e`).
- `apps/console` type-check (`tsc --noEmit && tsc -b tsconfig.node.json --force`) — green, after building the full workspace dependency closure (`pnpm exec turbo run build --filter='@object-ui/console^...'`).
- `apps/console` lint (`eslint .`) — 0 errors, 200 pre-existing warnings (none in the touched files beyond one pre-existing warning at an unrelated line in `useApiDiscovery.ts`, unchanged by this diff).
- `node scripts/check-control-bytes.mjs`, `node scripts/check-changeset-presence.mjs`, `node scripts/check-changeset-no-major.mjs` — all green.

## Changeset

`.changeset/api-console-drop-dead-catalog-keys-4303.md` (patch, `@object-ui/console`) — no rendered behaviour changes, but the catalog source changed so a changeset is owed per `check-changeset-presence.mjs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_