### PR TITLE
test(plugin-report): serve the dimension-metadata probe from a double, not the network (#5225)

### DIFF
--- a/.changeset/report-metadata-probe-double.md
+++ b/.changeset/report-metadata-probe-double.md
@@ -1,0 +1,10 @@
+---
+---
+
+Test-only change to `@object-ui/plugin-report`'s `DatasetReportRenderer` suite
+(objectui#5225): the dimension-metadata probe — `useDatasetDimensionMeta`'s
+`GET /api/v1/meta/object/:object`, which falls back to the global `fetch` when no
+`SchemaRendererProvider` is mounted — is now answered by a recording test double
+instead of escaping to the real network on `127.0.0.1:3000`, and its
+previously-unasserted request shape is pinned. Product code is untouched and no
+published behaviour changes.

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -15,8 +15,8 @@
  *  - ordering (framework#3916): `report.order` / `blocks[].order` lowered onto
  *    the selection, scoped per sub-selection, and part of the refetch key
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { I18nProvider } from '@object-ui/i18n';
 import { DatasetReportRenderer, isDatasetReport } from '../DatasetReportRenderer';
@@ -53,6 +53,99 @@ function makeSource(byDataset: Record<string, MockRows | MockResult>) {
     }),
   };
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#5225 — the metadata probe this file used to send to the REAL network
+ *
+ * Nothing in `packages/plugin-report/src` calls `fetch`, yet this file made 8
+ * live TCP connections per run to `http://localhost:3000` (16 stderr lines —
+ * two per attempt). The path, traced with a `net.Socket.prototype.connect`
+ * probe:
+ *
+ *   DatasetReportRenderer  (tabular / matrix / chart branches)
+ *     → useDatasetDimensionLabels        (re-export of @object-ui/react's hook)
+ *       → useDatasetDimensionMeta        packages/react/src/hooks/useDatasetDimensionLabels.ts
+ *         → `const doFetch = apiFetch ?? fetch`  ← the escape
+ *           → loadDimensionFieldMeta     packages/core/src/utils/chart-series.ts
+ *             GET /api/v1/meta/object/<object>
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off `SchemaRendererContext`
+ * and, with no `SchemaRendererProvider` in the tree, degrades to the GLOBAL
+ * `fetch` on purpose (objectui#4121 property 1 — a standalone embed must keep
+ * rendering, not crash). Under happy-dom that global `fetch` is a real HTTP
+ * client, and vitest's happy-dom environment defaults the document URL to
+ * `http://localhost:3000`, so the relative `/api/v1/...` resolved to a live
+ * request to whatever happens to own port 3000 in a shared container.
+ *
+ * Why the tests' own mock never intercepted it: this read is a SECOND data
+ * channel. `dataSource.queryDataset` (the prop double below) serves the report
+ * ROWS; the dimension-label metadata never goes through `dataSource` at all.
+ * Only the ~8 cases whose mock result carries `object` reach it — that field is
+ * what the hook keys on.
+ *
+ * The read is best-effort (`catch {}` leaves rows exactly as the server sent
+ * them), which is why 42 tests stayed green while the request always failed.
+ *
+ * Answer it from a RECORDING double, the shape objectui#3339 / #4106 settled on
+ * and this package's own `DatasetReportRenderer.localSelectI18n.test.tsx`
+ * already uses. It is deliberately NOT a blanket network stub: it records every
+ * URL it is handed, `afterEach` fails on any URL that is not the metadata route,
+ * and the probe's shape — previously asserted by nobody — is pinned below.
+ *
+ * The default document declares no option-bearing fields, so
+ * `deriveDimensionLabelMaps` resolves nothing and `relabelDimensions` returns
+ * the rows by identity: byte-identical to what the failing request produced.
+ * No pre-existing assertion changes meaning.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const META_OBJECT_ROUTE = /^\/api\/v1\/meta\/object\/(.+)$/;
+
+type MetaFieldDoc = { type?: string; options?: Array<{ value: string; label?: string }> };
+type MetaObjectDoc = { name: string; fields?: Record<string, MetaFieldDoc> };
+
+let metaCalls: Array<{ url: string; init?: { headers?: Record<string, string>; credentials?: string } }> = [];
+let metaDocs: Record<string, MetaObjectDoc> = {};
+
+/** Serve `/api/v1/meta/object/<name>` from `metaDocs`; record everything. */
+function installMetaObjectDouble() {
+  metaCalls = [];
+  metaDocs = {};
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      metaCalls.push({ url, init: init as { headers?: Record<string, string>; credentials?: string } });
+      const m = META_OBJECT_ROUTE.exec(url);
+      if (!m) return { ok: false, status: 404, json: async () => ({}) };
+      const name = decodeURIComponent(m[1]);
+      const doc = metaDocs[name] ?? { name, fields: {} };
+      return { ok: true, status: 200, json: async () => ({ item: doc }) };
+    }),
+  );
+}
+
+/** The object names this render probed, in request order. */
+const probedObjects = () =>
+  metaCalls.map((c) => META_OBJECT_ROUTE.exec(c.url)?.[1]).filter((n): n is string => Boolean(n)).map(decodeURIComponent);
+
+beforeEach(() => {
+  installMetaObjectDouble();
+});
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(metaCalls.filter((c) => !META_OBJECT_ROUTE.test(c.url)).map((c) => c.url)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so the setup file's RTL cleanup runs after this
+  // one: unstubbing first leaves the tree mounted with the real global back in
+  // place, and a metadata effect that settles in that window escapes again.
+  // Measured — one run in six leaked a single attempt that way.
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('isDatasetReport', () => {
   it('matches a report bound to a dataset', () => {
@@ -1005,5 +1098,81 @@ describe('DatasetReportRenderer — matrix bucket encoding (objectstack#5665)', 
     await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
     expect(screen.getAllByTestId('matrix-row-total').map((el) => el.textContent)).toEqual(['1', '2']);
     expect(screen.getByTestId('matrix-grand-total')).toHaveTextContent('3');
+  });
+});
+
+/**
+ * objectui#5225 — the dimension-metadata probe's own shape.
+ *
+ * Before this file answered the probe from the double above, the request went
+ * to the real network and always failed, so nothing here had ever asserted it
+ * and its SUCCESS path had never once executed in this suite. These three pins
+ * state what the renderer's own wiring asks for — which object, how many times,
+ * and that a resolved document actually reaches the rendered cells — so a
+ * future widening of the read shows up as a red test rather than as a silent
+ * extra request to whatever owns port 3000.
+ *
+ * (The label-resolution RULES are `@object-ui/core`'s and are unit-tested
+ * there; the locale half is pinned in `DatasetReportRenderer.localSelectI18n.test.tsx`.
+ * What is new here is only this renderer's request wiring.)
+ */
+describe('DatasetReportRenderer — dimension metadata probe (objectui#5225)', () => {
+  it('probes exactly the result-declared object, once, over the metadata route', async () => {
+    const src = makeSource({
+      task_metrics: {
+        rows: [{ status: 'Backlog', est_hours: 30 }],
+        object: 'task',
+        dimensionFields: { status: 'status' },
+      },
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    await waitFor(() => expect(probedObjects()).toEqual(['task']));
+    // The rows come from `dataSource`; the metadata is a separate channel that
+    // never touches it, which is why the prop double could not intercept this.
+    expect(metaCalls.map((c) => c.url)).toEqual(['/api/v1/meta/object/task']);
+    expect(metaCalls[0].init?.headers).toMatchObject({ accept: 'application/json' });
+  });
+
+  it('issues no metadata probe when the result declares no object', async () => {
+    const src = makeSource({ task_metrics: [{ status: 'Backlog', est_hours: 30 }] });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Backlog')).toBeInTheDocument());
+    expect(metaCalls).toEqual([]);
+  });
+
+  it('applies the probed document: a select dimension renders its option label', async () => {
+    metaDocs.task = {
+      name: 'task',
+      fields: { status: { type: 'select', options: [{ value: 'in_progress', label: 'In Progress' }] } },
+    };
+    const src = makeSource({
+      task_metrics: {
+        // The server sent the STORED value here; the probe is what turns it
+        // into the authored label — the path that never ran while the request
+        // was failing.
+        rows: [{ status: 'in_progress', est_hours: 30 }],
+        object: 'task',
+        dimensionFields: { status: 'status' },
+      },
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'r', type: 'summary', dataset: 'task_metrics', rows: ['status'], values: ['est_hours'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('In Progress')).toBeInTheDocument());
+    expect(screen.queryByText('in_progress')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #5225

Test-only. Product code is untouched.

## Premise re-checked on current `main` first

The card measured on a feature branch that has since merged (PR #5224), so the recheck was re-run on `origin/main` @ `41f498bcb` before anything else:

```
pnpm exec vitest run packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx 2>&1 | grep -c ECONNREFUSED
-> 16          Tests  42 passed (42)
```

Still there. The per-file bisect was re-run too — over **all 13** files in the package, not the 5 the card listed (the package has grown since): the escape is still confined to `DatasetReportRenderer.test.tsx`, every other file is 0.

```
DatasetReportRenderer.test.tsx                  -> ECONNREFUSED x16 | 42 passed
DatasetReportRenderer.chartChrome.test.tsx      -> x0 | 19 passed
DatasetReportRenderer.chartMeasureLabel.test.tsx-> x0 | 10 passed
DatasetReportRenderer.chartNullCategory.test.tsx-> x0 | 10 passed
DatasetReportRenderer.localSelectI18n.test.tsx  -> x0 |  7 passed
DatasetReportRenderer.measureLocale.test.tsx    -> x0 | 10 passed
DatasetReportRenderer.rejectedFilterAlias.test.tsx -> x0 | 9 passed
ReportRenderer.test.tsx                         -> x0 |  3 passed
ReportRendererDispatcher.test.tsx               -> x0 |  7 passed
ReportViewer.cells.test.tsx                     -> x0 |  7 passed
ReportViewer.printButtonSemantics.test.tsx      -> x0 |  5 passed
report-aggregation-coverage.test.ts             -> x0 |  7 passed
report-spec-parity.test.tsx                     -> x0 | 13 passed
```

16 is the grep line count; the real figure is **8 connection attempts** — each failure prints two matching lines (`Error: connect ECONNREFUSED …` and `code: 'ECONNREFUSED',`).

## Which module opens the connection

The card's three negative claims were re-verified here, each with a counter-probe so the zero is a reading rather than a typo:

| claim | hits | counter-probe |
|---|---|---|
| no `fetch(` in `packages/plugin-report/src` | 0 | `DatasetReportRenderer` → 111 |
| no literal `3000` in `packages/plugin-report/src` | 0 | `dataset` → 13 files |
| neither in the three root setup files | 0 | `import` → 4 / 7 / 10 |

The caller was then located with a `net.Socket.prototype.connect` preload probe, which prints the JS stack under the TCP connect:

```
at loadObjectSchema        packages/react/src/hooks/useDatasetDimensionLabels.ts:144
at loadDimensionFieldMeta  packages/core/src/utils/chart-series.ts:1178
at GlobalWindow.fetch      happy-dom/lib/window/BrowserWindow.js:2203
GET http://localhost:3000/api/v1/meta/object/task
```

So the path is:

```
DatasetReportRenderer  (tabular / matrix / chart branches)
  -> useDatasetDimensionLabels        packages/plugin-report/src/useDatasetDimensionLabels.ts (a re-export)
    -> useDatasetDimensionMeta        packages/react/src/hooks/useDatasetDimensionLabels.ts
       `const doFetch = apiFetch ?? fetch`          <-- the escape
      -> loadDimensionFieldMeta       packages/core/src/utils/chart-series.ts
         GET /api/v1/meta/object/:object
```

`useDatasetDimensionMeta` reads the host's authenticated `apiFetch` off `SchemaRendererContext` and, with no `SchemaRendererProvider` in the tree, degrades to the **global** `fetch` on purpose — objectui#4121 property 1, so a standalone embed keeps rendering instead of crashing. Under happy-dom that global `fetch` is a real HTTP client, and **vitest's happy-dom environment defaults the document URL to `http://localhost:3000`** (`vitest/dist/chunks/index.DC7d2Pf8.js`: `url: happyDOM.url || "http://localhost:3000"`), so the relative `/api/v1/...` resolves to a live request. That is where the `3000` comes from — no repo file names it.

Because the aliases in `vitest.config.mts` resolve `@object-ui/react` and `@object-ui/core` to their `src`, the stack above is source, not `dist` — nothing here can be a stale-build artefact.

## Why the test's mock did not intercept it

The metadata read is a **second data channel**. `dataSource.queryDataset` — the prop double this file passes — serves the report ROWS; the dimension-label metadata never goes through `dataSource` at all. Only the cases whose mocked result carries `object` reach it, since that field is what the hook keys on: 8 of the file's renders (`task` x4, `deal` x2, `opportunity` x2), which is exactly the 8 attempts.

The read is best-effort — a failure leaves the rows exactly as the server sent them — which is why 42 tests were green while the request never once succeeded.

## The fix

A **recording** double, the shape objectui#3339 and #4106 settled on and the one this package's own `DatasetReportRenderer.localSelectI18n.test.tsx` already uses. Explicitly not a blanket network stub, not a global error sink:

- it records every URL it is handed and answers only `/api/v1/meta/object/:name`;
- `afterEach` asserts the recorded set contains **no** non-metadata URL, so an escape to some other endpoint becomes a red test in this file instead of vanishing into the hook's `catch {}`;
- the default document declares no option-bearing fields, so `deriveDimensionLabelMaps` resolves nothing and `relabelDimensions` returns the rows by identity — byte-identical to what the failing request produced. No pre-existing assertion changes meaning;
- the probe's shape, previously asserted by nobody, is pinned by three new tests: which object is probed (once, over the metadata route, with `accept: application/json`), that a result declaring no `object` probes nothing at all, and that a resolved document actually reaches the rendered cells — the success path that had never executed in this suite.

One ordering detail worth keeping: the hook unmounts (`cleanup()`) **before** `vi.unstubAllGlobals()`. Vitest runs `afterEach` in reverse registration order, so the setup file's RTL cleanup runs *after* this file's hook; unstubbing first left the tree mounted with the real global back in place and a settling metadata effect escaped again — measured, one run in six leaked a single attempt.

## Post-fix status of all 42 tests

**All 42 pre-existing tests still pass, unchanged** — none of them depended on the swallowed failure. Plus the 3 new pins: `Tests 45 passed (45)`, `ECONNREFUSED 0`, stable across 8 consecutive runs. Package-wide: `Test Files 13 passed (13) · Tests 152 passed (152) · ECONNREFUSED 0`.

## Reverse verification

Predicted **before** running, with the pre-fix file restored (`git checkout origin/main -- …`): 16 ECONNREFUSED lines, 42 passed, **0 failed** — the direction here is *not* red/green, because the defect is a swallowed side effect rather than a wrong assertion; the observable is the connection count and the missing pins.

Observed: `16` / `Tests 42 passed (42)` / `0` occurrences of the new describe block. Predicted == observed on all three. The fix was then restored from the branch and proved byte-identical (`git hash-object` == `git rev-parse HEAD:…` == `4e522c49e`).

## Family: same root cause as #4106, not a fourth one

- **#3339** (plugin-detail) — different call site: `useRecordEditable`'s `POST /api/v1/security/explain`.
- **#4106** (plugin-charts / plugin-dashboard) — **this one.** ObjectChart's category option-colour effect reading `/api/v1/meta/object/:object` off the global `fetch`. Its fix (`ce4b9e8af`) landed in five `packages/plugin-charts/**` files only; #4389 later extracted that exact call site into the shared `useDatasetDimensionMeta` hook, which is what `plugin-report` reaches today. So this is #4106's root cause at a consumer the sweep did not cover, not a new one.
- **#4688** (plugin-view / app-shell / plugin-designer) — again the grid's record-level explain probe.

The shared mechanism across all three is the same and worth stating once: a hook that degrades to the global `fetch` outside a host provider, plus happy-dom's real fetch on a `localhost:3000` default origin, plus a best-effort `catch`.

## Why it is not merely noise

In this repo's shared containers a dev server on port 3000 is routine. If one is up, those 8 attempts **connect** — to whatever another agent happens to be running — and the tests' rendered labels change without a line of them changing (the double's third pin shows exactly how: a resolved document rewrites dimension cells). That is the argument for locating and answering the request rather than muting it.

## Out of scope, filed

`packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx` still escapes through the same hook — 10 ECONNREFUSED lines (5 attempts) for `showcase_task` x3, `showcase_deal` x2, `invoices` x1, with 52 tests green. Different package, outside this card's write surface: filed as **#5280**, unassigned, not touched here.

## Verification

At `be8cbe607`:

- `pnpm exec vitest run packages/plugin-report` — 13 files / 152 tests passed, 0 ECONNREFUSED
- `pnpm --filter '@object-ui/plugin-report^...' build` — dependency closure, exit 0
- `pnpm --filter @object-ui/plugin-report type-check` — `tsc --noEmit && tsc -p tsconfig.test.json`, exit 0
- `pnpm --filter @object-ui/plugin-report lint` — 0 errors (85 pre-existing warnings; the two in the edited file are the pre-existing `makeSource` `any`s at lines 37/41)
- `node scripts/check-control-bytes.mjs` — OK (4664 files), plus a direct control-byte grep over the two changed files
- `node scripts/check-changeset-presence.mjs` — satisfied by an empty-frontmatter changeset (the change is under a guarded `src/`, and the gate's own documented answer for a `src/__tests__/**`-only change)
- `node scripts/check-changeset-no-major.mjs` — no `major`

Docs untouched, so #5136's `content/docs/core/report-schema.mdx` is unaffected: this PR changes nothing about what the renderer reads.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_