### PR TITLE
fix(app-shell): Studio Data pillar form preview keeps `fields` identity stable (#4574)

### DIFF
--- a/.changeset/studio-form-preview-fields-stable-identity.md
+++ b/.changeset/studio-form-preview-fields-stable-identity.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The Studio Data pillar's form preview no longer rebuilds `ObjectForm`'s `fields` array on every render (#4574).
+
+The pillar built the real runtime `ObjectForm`'s `fields` array inline, in the same shape #4567 fixed for the grid. `ObjectForm` lists `schema.fields` in its field-generation effect's dependency array by identity, so a fresh array on every render of the pillar (which re-renders at keystroke rate) re-ran that effect on every keystroke — redundant recomputation plus one extra `setFormFields` render pass, not a duplicate query: the effect is a pure derivation, and the object-schema fetch and record load are separate effects that never depended on `schema.fields`.
+
+The array is now memoized on the draft's `fields`, as a second memo alongside the grid's existing `gridColumns` memo — not a reuse of it, since the form's filter differs (it does not drop a field named `actions`, unlike the grid). The dependency stays live: adding, removing or reordering a field still produces a new array.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.formFields.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.formFields.test.tsx
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Data pillar's form-preview must not rebuild `ObjectForm`'s `fields`
+ * array on every render — objectui#4574.
+ *
+ * Re-derived on current `origin/main` (2026-08-19, after objectui#5272 /
+ * objectui#5278 both touched `packages/app-shell`): `DataPillar`'s form
+ * preview (`viewMode === 'form'`, `formMode === 'preview'`) still built the
+ * real runtime `ObjectForm`'s schema inline —
+ *
+ *   fields: readFields(objDraft.fields).entries.map((e) => e.name)
+ *     .filter((n) => !STUDIO_SYSTEM_FIELD_NAMES.has(n)),
+ *
+ * — allocating a fresh array on every render of the pillar. `ObjectForm`
+ * lists `schema.fields` in its field-generation effect's dependency array BY
+ * IDENTITY (plugin-form/src/ObjectForm.tsx, the effect ending in
+ * `setFormFields(generatedFields)`), so a fresh array re-runs that effect on
+ * every keystroke-level re-render of the pillar.
+ *
+ * ## Why this is a SECOND memo, not a reuse of the grid's `gridColumns`
+ *
+ * `DataPillar` already memoizes an analogous array for the grid
+ * (objectui#4567's `gridColumns`, keyed on `objDraft.fields`), but its filter
+ * ALSO drops a field literally named `actions` (the grid pins its own
+ * row-actions column). The form has no such column, so a data field named
+ * `actions` must stay editable there. Sharing `gridColumns` would silently
+ * change which fields the form renders — exactly what this card's scope
+ * forbids. The fix is a second memo, `formFields`, with the grid's filter
+ * minus the `actions` exclusion.
+ *
+ * ## Why this is NOT a #4567 — and what that means for the test
+ *
+ * Traced `ObjectForm`'s effects on current `main`
+ * (plugin-form/src/ObjectForm.tsx): the field-generation effect
+ * (`schema.fields` in its deps) is a pure derivation ending in
+ * `setFormFields(generatedFields)` — it makes no `dataSource` call. The
+ * object-schema fetch (`dataSource.getObjectSchema`, deps: `schema.objectName,
+ * dataSource, hasInlineFields`) and the record load (`dataSource.findOne`,
+ * gated on `schema.recordId && mode !== 'create'`) are SEPARATE effects, and
+ * neither lists `schema.fields` in its dependency array. So the cost fixed
+ * here is redundant recomputation (plus one extra `setFormFields` render
+ * pass) — never a duplicate query. Unlike the #4567 suite
+ * (`StudioDesignSurface.gridColumns.test.tsx`), this suite does NOT assert a
+ * find()-count delta as its primary claim — that would prove something false,
+ * since there was never a duplicate query to eliminate. It asserts IDENTITY
+ * STABILITY of the `fields` array `ObjectForm` receives, plus (as a real,
+ * exercised invariant rather than a vacuous one — the wrapper below still
+ * renders the REAL `ObjectForm`) that no new fetch appears across re-renders
+ * that don't change `objDraft.fields`. That is also the card's own "why this
+ * is NOT a #4567" section, read as its test brief.
+ *
+ * This suite drives the REAL producer (`DataPillar`), not a reconstruction of
+ * it — the defect is a property of how that component builds its schema.
+ * Only the leaf consumer (`ObjectForm`) is wrapped, and only to observe the
+ * `schema.fields` reference it is called with; the wrapper still renders the
+ * real `ObjectForm` via `React.createElement`, so the suite still exercises
+ * the real field-generation effect end to end.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const objectDef = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: [
+    { name: 'name', label: 'Name', type: 'text' },
+    { name: 'status', label: 'Status', type: 'text' },
+  ],
+};
+
+const mockClient = {
+  list: vi.fn(async () => [{ name: 'showcase_task', label: 'Task' }]),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async () => ({ effective: objectDef, code: objectDef })),
+  getDraft: vi.fn(async () => null),
+  save: vi.fn(async () => ({})),
+};
+
+/** find/findOne/getObjectSchema are the "no new fetch" measurement. */
+function createDataSource() {
+  return {
+    find: vi.fn(async () => []),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+    getObjectSchema: vi.fn(async () => objectDef),
+  };
+}
+
+/**
+ * Module-scope so the `useAdapter` mock factory (hoisted) closes over the
+ * binding rather than a value, and so the reference handed to the pillar is
+ * STABLE across renders — an adapter that changed identity per render would
+ * manufacture the very churn these tests measure. Same convention as
+ * StudioDesignSurface.gridColumns.test.tsx (objectui#4567).
+ */
+let dataSource = createDataSource();
+
+/**
+ * Every `schema.fields` reference `ObjectForm` is called with, in render
+ * order. The wrapper below still renders the REAL `ObjectForm` (via
+ * `React.createElement`) — this array only records the identity of the prop
+ * it was handed, it does not replace the component's own behaviour.
+ */
+let fieldsSnapshots: unknown[] = [];
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({ entries: [] }),
+  };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => dataSource };
+});
+
+vi.mock('@object-ui/plugin-form', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/plugin-form')>();
+  return {
+    ...actual,
+    ObjectForm: (props: { schema?: { fields?: unknown } }) => {
+      fieldsSnapshots.push(props.schema?.fields);
+      return React.createElement(actual.ObjectForm, props as never);
+    },
+  };
+});
+
+import { DataPillar } from './StudioDesignSurface';
+
+beforeEach(() => {
+  dataSource = createDataSource();
+  fieldsSnapshots = [];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/** Long enough for the mount's own fetch to settle before a measurement. */
+const SETTLE_MS = 300;
+const settle = () => new Promise((r) => setTimeout(r, SETTLE_MS));
+
+/**
+ * Renders the real pillar under a parent that can force a no-op re-render.
+ * `DataPillar` is not memoized, so a parent render re-renders it — which is
+ * exactly the Studio steady state the card describes (its whole schema is a
+ * fresh object literal each time).
+ */
+function Harness(): React.ReactElement {
+  const [, force] = React.useState(0);
+  return (
+    <MemoryRouter initialEntries={['/studio/com.example.showcase/data']}>
+      <button type="button" data-testid="rerender" onClick={() => force((n) => n + 1)}>
+        rerender
+      </button>
+      <DataPillar packageId="com.example.showcase" />
+    </MemoryRouter>
+  );
+}
+
+/**
+ * Mount, land on the auto-selected object's grid (the default tab — its
+ * mount settling first mirrors the #4567 suite's `mountSettledGrid`), then
+ * switch to Form ⇄ Preview, which is the ONLY place `DataPillar` renders the
+ * real runtime `ObjectForm` (Form ⇄ Layout renders `ObjectFormDesigner`
+ * instead, which does not consume this array).
+ */
+async function mountSettledFormPreview(): Promise<void> {
+  render(<Harness />);
+  await waitFor(() => expect(dataSource.find).toHaveBeenCalled(), { timeout: 4000 });
+  fireEvent.click(screen.getByRole('button', { name: 'Form' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+  await waitFor(() => expect(dataSource.getObjectSchema).toHaveBeenCalled(), { timeout: 4000 });
+  await settle();
+}
+
+describe('Studio Data pillar form preview — `fields` keeps a stable identity (#4574)', () => {
+  it('three no-op re-renders leave `schema.fields` at the SAME identity, and issue no new fetch', async () => {
+    await mountSettledFormPreview();
+    expect(fieldsSnapshots.length).toBeGreaterThan(0);
+    const stable = fieldsSnapshots[fieldsSnapshots.length - 1];
+
+    const findBefore = dataSource.find.mock.calls.length;
+    const findOneBefore = dataSource.findOne.mock.calls.length;
+    const schemaBefore = dataSource.getObjectSchema.mock.calls.length;
+
+    // Nothing changes: same object, same fields. Before the fix each of these
+    // rebuilt the inline `fields` array, handing ObjectForm a fresh reference
+    // (and re-running its field-generation effect) every time.
+    fireEvent.click(screen.getByTestId('rerender'));
+    fireEvent.click(screen.getByTestId('rerender'));
+    fireEvent.click(screen.getByTestId('rerender'));
+    await settle();
+
+    // Identity stability — the card's actual claim. Every render since the
+    // settled preview mount handed ObjectForm the SAME `fields` array
+    // reference, not merely an equal-by-value one.
+    expect(fieldsSnapshots.length).toBeGreaterThan(1);
+    for (const snap of fieldsSnapshots) {
+      expect(snap).toBe(stable);
+    }
+
+    // No new fetch appears. There never was a duplicate query here — asserted
+    // against the REAL ObjectForm (rendered through the wrapper above), not a
+    // stub, so this is an exercised invariant: the field-generation effect
+    // that used to re-run on every render is a pure derivation, and the
+    // schema fetch / record load are separate effects that never depended on
+    // `schema.fields`. A passing find()-count-drop assertion here would prove
+    // something false; this suite deliberately asserts flatness instead.
+    expect(dataSource.find.mock.calls.length).toBe(findBefore);
+    expect(dataSource.findOne.mock.calls.length).toBe(findOneBefore);
+    expect(dataSource.getObjectSchema.mock.calls.length).toBe(schemaBefore);
+  });
+
+  /**
+   * The dependency must stay LIVE, not be defeated. Mirrors the
+   * must-not-change pin in StudioDesignSurface.gridColumns.test.tsx
+   * (objectui#4567): "+ Add field" mutates `objDraft.fields` via `onPatch`,
+   * which does NOT remount the form preview — its key is
+   * `${current.name}:${gridVer}:form` and neither part changes — so a NEW
+   * `fields` identity can only have arrived through the memo's live
+   * dependency. A memo that froze the array (or returned a constant) would
+   * turn this red.
+   */
+  it('a REAL field change still produces a NEW `fields` identity', async () => {
+    await mountSettledFormPreview();
+    const before = fieldsSnapshots[fieldsSnapshots.length - 1];
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Add field/i })[0]);
+
+    await waitFor(
+      () => {
+        const after = fieldsSnapshots[fieldsSnapshots.length - 1];
+        expect(after).not.toBe(before);
+      },
+      { timeout: 4000 },
+    );
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -2132,6 +2132,43 @@ export function DataPillar({
     [objDraft.fields],
   );
 
+  /**
+   * The design-mode FORM's fields: the object's own fields, dropping
+   * framework-managed/audit fields — the same base set `gridColumns` above
+   * uses, but WITHOUT its `actions` exclusion. The grid drops a field named
+   * `actions` because the grid always pins its own row-actions column headed
+   * "Actions"; the form has no such column, so a data field literally named
+   * `actions` stays editable here. That filter difference is why this is a
+   * SECOND memo rather than a reuse of `gridColumns` — sharing it would
+   * silently drop an `actions` field from the rendered form.
+   *
+   * Memoized for an IDENTITY reason, not a fetch reason (objectui#4574,
+   * ruled to the objectui#4567 producer-side pattern above). `ObjectForm`
+   * lists `schema.fields` in its field-generation effect's dependency array
+   * BY IDENTITY (plugin-form/src/ObjectForm.tsx). Built inline, this
+   * allocated a fresh array on every render of the pillar, so that effect
+   * (ending in `setFormFields(generatedFields)`) re-ran on every keystroke —
+   * redundant recomputation, NOT a duplicate query: the effect is a pure
+   * derivation, and the object-schema fetch and the record load are separate
+   * effects, neither of which depends on `schema.fields`. Unlike #4567,
+   * there is no `dataSource` call in this effect's dependency chain today —
+   * but there is a latent hazard: if one is ever added there, this becomes a
+   * #4567 with no producer-side change needed, because the identity is
+   * already stable.
+   *
+   * Keyed on `objDraft.fields` rather than `objDraft`, same reasoning as
+   * `gridColumns`: `onPatch` replaces the draft object while keeping
+   * `fields` identical, so the looser key would churn (and re-run the form's
+   * field-generation effect) on every unrelated draft edit (icon, label).
+   */
+  const formFields = React.useMemo(
+    () =>
+      readFields(objDraft.fields)
+        .entries.map((e) => e.name)
+        .filter((n) => !STUDIO_SYSTEM_FIELD_NAMES.has(n)),
+    [objDraft.fields],
+  );
+
   const onPatch = React.useCallback((patch: Record<string, unknown>) => {
     setObjDraft((d) => ({ ...d, ...patch }));
     setDirty(true);
@@ -2701,9 +2738,11 @@ export function DataPillar({
                           type: 'object-form',
                           objectName: current.name,
                           mode: 'create',
-                          fields: readFields(objDraft.fields)
-                            .entries.map((e) => e.name)
-                            .filter((n) => !STUDIO_SYSTEM_FIELD_NAMES.has(n)),
+                          // Memoized above at the top of the component: this array's
+                          // IDENTITY is a dependency of ObjectForm's field-generation
+                          // effect, so rebuilding it inline here re-ran that effect on
+                          // every keystroke-level render of the pillar (objectui#4574).
+                          fields: formFields,
                         } as never
                       }
                       dataSource={adapter as never}


### PR DESCRIPTION
Fixes #4574

## Re-derived on current `main` before editing

Filed 2026-08-13; `packages/app-shell` took #5272 and #5278 today. Re-read the code fresh (no line numbers carried from the card):

- `DataPillar` (`packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx`) still builds the form-preview's `ObjectForm` schema with `fields: readFields(objDraft.fields).entries.map((e) => e.name).filter((n) => !STUDIO_SYSTEM_FIELD_NAMES.has(n))` **inline**, at the `<ObjectForm>` JSX in the `formMode === 'preview'` branch. Not memoized — the defect is still live.
- `ObjectForm` (`packages/plugin-form/src/ObjectForm.tsx`, now at line 758) still lists `schema.fields` in its field-generation effect's dependency array by identity.
- Traced that effect's body: it is a pure derivation ending in `setFormFields(generatedFields)`. It makes no `dataSource` call. The object-schema fetch (`dataSource.getObjectSchema`, deps: `schema.objectName, dataSource, hasInlineFields`) and the record load (`dataSource.findOne`, gated on `recordId && mode !== 'create'`) are separate effects, and **neither depends on `schema.fields`** — confirmed on current `main`, matching the card's own "why this is NOT a #4567" claim.

## Fix

Second `React.useMemo`, `formFields`, keyed on `objDraft.fields` — module-local to `DataPillar`, alongside the existing `gridColumns` memo from #4567/#4573. **Not a reuse of `gridColumns`**: the grid's filter also drops a field literally named `actions` (to avoid colliding with the grid's own row-actions column); the form has no such column, so a data field named `actions` must stay editable there. Sharing the memo would silently change which fields the form renders — out of this card's scope. `formFields` replaces the inline array at the `<ObjectForm>` call site; nothing else changed.

## Why this is a second memo, not the grid's (again, for the record)

| | `gridColumns` (#4567) | `formFields` (#4574) |
|---|---|---|
| Filter | drops `STUDIO_SYSTEM_FIELD_NAMES` **and** `actions` | drops `STUDIO_SYSTEM_FIELD_NAMES` only |
| Consumer | `ListView` — identity feeds a **fetch** effect's deps | `ObjectForm` — identity feeds a **pure-derivation** effect's deps |
| Stakes before fix | duplicate `find()` per render | wasted recomputation only |

## Test — asserts identity stability, NOT fetch elimination

`StudioDesignSurface.formFields.test.tsx` drives the real `DataPillar` (mounts, switches to the Form tab, then Preview — the only place the real `ObjectForm` renders; Layout renders `ObjectFormDesigner` instead). A wrapper around `@object-ui/plugin-form`'s `ObjectForm` records the identity of the `schema.fields` reference it's called with on each render, while still rendering the real component via `React.createElement` (so the real field-generation effect runs).

- **Test 1** — three no-op re-renders: asserts every recorded `fields` reference is the **same object** (`toBe`, not `toStrictEqual`) since the settled mount, *and* that `dataSource.find` / `findOne` / `getObjectSchema` call counts don't increase. There is no duplicate query on this path and never was — a test proving a fetch disappeared would be proving something false; this asserts the stable *invariant* instead, exercised against the real component rather than a stub.
- **Test 2** (must-not-regress pin, green in both states, mirroring `gridColumns.test.tsx`'s own live-dependency pin) — "+ Add field" still produces a **new** `fields` identity, proving the memo's dependency stays live rather than freezing.

### Reverse verification

Committed the fix + test, then `git checkout <fix-commit> -- ` reverted only `StudioDesignSurface.tsx` to `origin/main`'s (pre-fix) version, keeping the new test.

**Predicted before running:** the identity-stability loop (`expect(snap).toBe(stable)`) goes red — every render (including several during the async settle window) allocates a fresh inline array, so no two snapshots share identity. The three fetch-count assertions stay green regardless of the fix (none of those effects ever depended on `schema.fields`). Test 2 stays green in both states (it's an invariant, not red-first).

**Observed:** exactly that.
```
✕ three no-op re-renders leave `schema.fields` at the SAME identity, and issue no new fetch
  AssertionError: expected [ 'name', 'status' ] to be [ 'name', 'status' ] // Object.is equality
  (content-equal, reference-different — confirms the assertion targets IDENTITY, not content)
✓ a REAL field change still produces a NEW `fields` identity
Test Files  1 failed (1)
     Tests  1 failed | 1 passed (2)
```
Restored the fix (`git checkout <branch> -- <path>`) — working tree is clean against the fix commit. No rebuild is in this ablation's resolution path: vitest transforms/imports the `.tsx` source directly for this package's own tests (no `dist/` step between edit and test run), so nothing could hide a stale result here.

## Verification (final HEAD `a4ba2ff85`)

- `pnpm --filter '@object-ui/app-shell^...' build` — dependency closure, clean.
- `pnpm --filter '@object-ui/app-shell' type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — clean.
- `pnpm --filter '@object-ui/app-shell' build` (`tsc`) — clean.
- `pnpm --filter '@object-ui/app-shell' lint` — 0 errors (2475 pre-existing warnings, none touching this change).
- `node scripts/check-control-bytes.mjs` — OK.
- `node scripts/check-changeset-presence.mjs` — OK, `.changeset/studio-form-preview-fields-stable-identity.md` (`patch`).
- `node scripts/check-changeset-no-major.mjs` — OK.
- `pnpm exec vitest run packages/app-shell/src/views/studio-design/ --maxWorkers=2` — **29 test files, 157 tests, all pass** (includes the 2 new tests + the existing #4567 `gridColumns`/`gridRefresh` suites, `DataPillar.*` gates, `ObjectFormDesigner`, etc.).

**Narrowing declared explicitly, per the shared-lock contention this run hit:** the full `packages/app-shell/` suite (281 files) was attempted first but the shared `/tmp/os-heavy-verify.lock` was contended by other concurrent dev agents for long enough that the run couldn't be observed to completion in this session. Per PM direction, narrowed to the `studio-design/` directory (the pillar this PR touches) plus the package-level build/type-check/lint, all run to completion in the foreground and reported above. `packages/plugin-form/` (the consumer, unmodified by this PR) was **not** run locally — out of the narrowed scope since no line in it changed. CI runs the full farm on this PR and is authoritative for the rest.

## Scope

Touched only `packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx` + its new test file + one changeset. No `docs/adr/**`, `.claude/**`, `skills/**`, `AGENTS.md`, or `CLAUDE.md` touched. Does not change which fields the form renders in any case (same filter, same input) — only the array's identity.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_