### PR TITLE
docs(plugin-view): re-teach the canonical table keys now that #5102 landed

### DIFF
--- a/content/docs/plugins/plugin-view.mdx
+++ b/content/docs/plugins/plugin-view.mdx
@@ -119,24 +119,75 @@ object through. Anything else you put in them is ignored:
 
 | Sub-config | Keys `ObjectView` forwards |
 | --- | --- |
-| `table` | `columns`, `fields`, `title`, `description`, `defaultFilters`, `defaultSort`, `pageSize`, `selectable`, `operations`, `className` |
+| `table` | `columns`, `fields`, `title`, `description`, `filter`, `defaultFilters`, `sort`, `defaultSort`, `pagination`, `pageSize`, `selection`, `selectable`, `operations`, `className` |
 | `form` | `fields`, `customFields`, `sections`, `groups`, `layout`, `columns`, `title`, `description`, `subforms`, `buttons`, `defaults`, `initialValues`, `readOnly`, `showSubmit`, `submitText`, `showCancel`, `cancelText`, `showReset`, `className` |
 
-The forwarding is literal, key by key (`ObjectView.tsx:833-848` for `table`,
-`:857-890` for `form`), which is why the list is worth reading: page size is
-`table.pageSize` and **not** `table.pagination` — the latter is a declared
-`ObjectGridSchema` key, but it is not one of the keys `ObjectView` forwards, so
-on an `object-view` node it has no effect.
+The forwarding is literal, key by key, spread across three sites in
+`ObjectView.tsx` — the non-grid data fetch (around `:604-611`), the grid
+schema (around `:1041-1078`), and the schema handed to a host-supplied list
+renderer (around `:1201-1209`) — so the four keys below behave the same on
+every rendering path.
 
-That is one instance of a general point: several of the forwarded `table` keys
-are the ones `ObjectGridSchema` marks legacy — `fields`, `pageSize`,
-`selectable`, `defaultFilters` and `defaultSort` each have a newer counterpart
-there (`columns`, `pagination`, `selection`, `filter`, `sort`). `ObjectView`
-forwards the legacy spellings, so on an `object-view` node those are the ones
-that take effect. `columns` is the exception — it is forwarded alongside
-`fields` and preferred over it. Shapes follow `ObjectGridSchema`:
-`defaultSort` is a single `{ field, order }` object and `defaultFilters` is a
-plain record of field to value.
+#### Canonical keys now take effect (objectui#5102)
+
+Four of the forwarded `table` keys are pairs — a canonical `ObjectGridSchema`
+key and the `@deprecated` legacy spelling it replaced. Both now work; write
+the canonical one:
+
+| write this (canonical) | not this (legacy alias — still works) |
+| --- | --- |
+| `pagination: { pageSize, pageSizeOptions? }` | `pageSize: number` |
+| `selection: { type: 'single' \| 'multiple' \| 'none' }` | `selectable: boolean \| 'single' \| 'multiple'` |
+| `filter: [{ field, operator, value }, …]` (same shape as a named view's `filter`) | `defaultFilters: Record<field, value>` (equality-only) |
+| `sort: 'field direction'` or `SortConfig[]` | `defaultSort: { field, order }` (**no string form** — that arity only exists on `sort`) |
+
+Before objectui#5102, `pagination` / `selection` / `filter` / `sort` had **no
+read point at all** in this file: an author who wrote the canonical shape
+`ObjectGridSchema`'s own JSDoc recommends got a view that compiled, read
+correctly, and silently did nothing. That is fixed — the legacy spellings on
+the right are not going away, they are simply no longer the ones to reach for.
+
+**When a key is written both ways, the canonical spelling wins** — that is
+`ObjectGrid`'s own existing resolution (`schema.pagination?.pageSize ||
+schema.pageSize`; `if (schema.selection?.type) … else if (schema.selectable
+!== undefined)`; `schemaFilter !== undefined ? … : schema.defaultFilters`;
+`schemaSort ?? (schema.defaultSort ? [schema.defaultSort] : undefined)`), and
+`ObjectView` defers to it by forwarding both slots rather than re-resolving
+the pair itself:
+
+```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+const bothSpellingsWritten: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  table: {
+    pagination: { pageSize: 10 }, // wins
+    pageSize: 50, // ignored while `pagination` is present
+  },
+};
+```
+
+⚠️ **`filter` / `sort` have one more tier ahead of `table` entirely**, and it
+predates this change: an **active named view's own** `filter` / `sort`
+(`listViews.<name>.filter` / `.sort`) always outranks anything written on
+`table` — `table.filter` does **not** universally win over the legacy
+`table.defaultFilters`, it wins only when no active named view supplies its
+own filter. In order, highest first: the active named view's `filter`/`sort`,
+then `table.filter`/`table.sort`, then
+`table.defaultFilters`/`table.defaultSort`. If you never write `listViews`,
+that first tier never applies.
+
+`pagination` and `selection` have no such tier, and no effect outside the
+grid: `defaultViewType: 'kanban' | 'gallery' | 'calendar' | 'timeline' |
+'gantt' | 'map'` don't page or multi-select, so `ObjectView` never forwards
+either spelling to those renderers.
+
+`columns` is the one forwarded `table` key that is **not** part of this
+canonical/legacy story, and its gap is still open: it is forwarded on the grid
+path only (the row above, and the section below), so on a non-grid
+`defaultViewType` the field list still comes from `table.fields`
+(objectui#5269).
 
 ## Usage
 
@@ -209,7 +260,7 @@ const userDirectory: ObjectViewSchema = {
   defaultViewType: 'grid',
   table: {
     columns: ['name', 'email', 'role', 'created_at'],
-    defaultSort: { field: 'created_at', order: 'desc' },
+    sort: 'created_at desc', // or [{ field: 'created_at', order: 'desc' }]
   },
 };
 ```
@@ -301,8 +352,8 @@ opening a drawer, so the host route owns the form.
 
 ### Read/List
 
-Search, filter and sort are toolbar toggles; the column set, default filter,
-default sort and page size live in `table`:
+Search, filter and sort are toolbar toggles; the column set, filter, sort and
+page size live in `table`:
 
 ```typescript
 import type { ObjectViewSchema } from '@object-ui/types';
@@ -316,8 +367,8 @@ const productList: ObjectViewSchema = {
   showSort: true,
   table: {
     columns: ['name', 'price', 'category'],
-    defaultFilters: { category: 'electronics' },
-    pageSize: 25,
+    filter: [{ field: 'category', operator: 'equals', value: 'electronics' }],
+    pagination: { pageSize: 25 },
   },
 };
 ```
@@ -492,7 +543,7 @@ const contactView: ObjectViewSchema = {
   showSort: true,
   table: {
     columns: ['first_name', 'last_name', 'email', 'company'],
-    pageSize: 25,
+    pagination: { pageSize: 25 },
   },
 };
 

--- a/packages/plugin-view/README.md
+++ b/packages/plugin-view/README.md
@@ -202,17 +202,57 @@ object through. Anything else you put in them is ignored:
 
 | Sub-config | Keys `ObjectView` forwards |
 | --- | --- |
-| `table` | `columns`, `fields`, `title`, `description`, `defaultFilters`, `defaultSort`, `pageSize`, `selectable`, `operations`, `className` |
+| `table` | `columns`, `fields`, `title`, `description`, `filter`, `defaultFilters`, `sort`, `defaultSort`, `pagination`, `pageSize`, `selection`, `selectable`, `operations`, `className` |
 | `form` | `fields`, `customFields`, `sections`, `groups`, `layout`, `columns`, `title`, `description`, `subforms`, `buttons`, `defaults`, `initialValues`, `readOnly`, `showSubmit`, `submitText`, `showCancel`, `cancelText`, `showReset`, `className` |
 
-Note that several of the forwarded `table` keys are the ones `ObjectGridSchema`
-marks legacy — `fields`, `pageSize`, `selectable`, `defaultFilters` and
-`defaultSort` each have a newer counterpart there (`columns`, `pagination`,
-`selection`, `filter`, `sort`). `ObjectView` forwards the legacy spellings, so
-on an `object-view` node those are the ones that take effect; `columns` is the
-exception, forwarded alongside `fields` and preferred here. Shapes follow
-`ObjectGridSchema`: `defaultSort` is a single `{ field, order }` object and
-`defaultFilters` is a plain `Record` of field to value.
+Four of the forwarded `table` keys are pairs — a canonical `ObjectGridSchema`
+key and the `@deprecated` legacy spelling it replaced. As of objectui#5102 the
+canonical spelling **takes effect** on every rendering path (the grid, and the
+non-grid `kanban` / `gallery` / `calendar` / `timeline` / `gantt` / `map`
+renderers); the legacy spelling on the right keeps working as an alias, it is
+just no longer the one to reach for:
+
+| write this (canonical) | not this (legacy alias — still works) |
+| --- | --- |
+| `pagination: { pageSize, pageSizeOptions? }` | `pageSize: number` |
+| `selection: { type: 'single' \| 'multiple' \| 'none' }` | `selectable: boolean \| 'single' \| 'multiple'` |
+| `filter: [{ field, operator, value }, …]` (same shape as a named view's `filter`) | `defaultFilters: Record<field, value>` (equality-only) |
+| `sort: 'field direction'` or `SortConfig[]` | `defaultSort: { field, order }` (**no string form** — that arity only exists on `sort`) |
+
+**Precedence when a key is written both ways** — `table: { pagination: {
+pageSize: 10 }, pageSize: 50 }`, say — the canonical spelling wins. That is
+`ObjectGrid`'s own existing resolution (`schema.pagination?.pageSize ||
+schema.pageSize`; `if (schema.selection?.type) … else if (schema.selectable
+!== undefined)`; `schemaFilter !== undefined ? … : schema.defaultFilters`;
+`schemaSort ?? (schema.defaultSort ? [schema.defaultSort] : undefined)`), and
+`ObjectView` defers to it by forwarding both slots rather than re-resolving
+the pair itself:
+
+```typescript
+const schema: ObjectViewSchema = {
+  type: 'object-view',
+  objectName: 'products',
+  table: {
+    pagination: { pageSize: 10 }, // wins
+    pageSize: 50, // ignored while `pagination` is present
+  },
+};
+```
+
+`filter` / `sort` have one more tier ahead of `table` entirely, and it
+predates this change: an **active named view's own** `filter` / `sort`
+(`listViews.<name>.filter` / `.sort`) always outranks anything written on
+`table`. In order, highest first: the active named view's `filter`/`sort`,
+then `table.filter`/`table.sort`, then `table.defaultFilters`/
+`table.defaultSort`. (If you never write `listViews`, that first tier never
+applies.) `pagination` and `selection` have no such tier, and no effect
+outside the grid — the non-grid renderers don't page or multi-select, so
+`ObjectView` never forwards either spelling to them.
+
+`columns` is the one forwarded `table` key that is **not** part of this
+canonical/legacy story, and it has an unrelated gap: it is forwarded on the
+grid path only, so on a non-grid `defaultViewType` the field list still comes
+from `table.fields` (objectui#5269, open).
 
 ### ViewSwitcher
 
@@ -285,7 +325,7 @@ const schema: ObjectViewSchema = {
   defaultViewType: 'grid',
   table: {
     columns: ['name', 'email', 'role', 'created_at'],
-    defaultSort: { field: 'created_at', order: 'desc' },
+    sort: 'created_at desc', // or [{ field: 'created_at', order: 'desc' }]
   },
 };
 ```
@@ -367,8 +407,8 @@ opening a drawer, so the host route owns the form.
 
 ### Read/List
 
-Search, filter and sort are toolbar toggles; column set, default filter,
-default sort and page size live in `table`:
+Search, filter and sort are toolbar toggles; column set, filter, sort and page
+size live in `table`:
 
 ```typescript
 const schema: ObjectViewSchema = {
@@ -380,8 +420,8 @@ const schema: ObjectViewSchema = {
   showSort: true,
   table: {
     columns: ['name', 'price', 'category'],
-    defaultFilters: { category: 'electronics' },
-    pageSize: 25,
+    filter: [{ field: 'category', operator: 'equals', value: 'electronics' }],
+    pagination: { pageSize: 25 },
   },
 };
 ```
@@ -459,7 +499,7 @@ const schema: ObjectViewSchema = {
   showSort: true,
   table: {
     columns: ['first_name', 'last_name', 'email', 'company'],
-    pageSize: 25,
+    pagination: { pageSize: 25 },
   },
 };
 


### PR DESCRIPTION
Fixes #5271

## Which pages, and how I found them

The card and the dispatch order both say "the pages PR #5101 wrote." I read PR #5101's actual diff (`changed_files: 2`) rather than trusting that description: it touched only `packages/plugin-view/README.md` + a changeset — **not** anything under `content/docs/**`. The dispatch order's Hard Limits line ("File surface: the `content/docs/**` pages PR #5101 touched") is therefore not literally true of any file; it conflated PR #5101 with its docs-site sibling.

That sibling exists and has the identical defect: `content/docs/plugins/plugin-view.mdx` was written by **PR #5109** (issue #5088, "文档站页面整片示例按 ObjectView 真读的键面重写") as the docs-site mirror of PR #5101's README rewrite, same key-face investigation, same era, same legacy-only teaching + the same now-stale caveat ("page size is `table.pageSize` and **not** `table.pagination`"). Leaving it untouched while fixing the README would have left the two pages disagreeing.

**Fixed both**, under one bounded scope — same defect class (docs teaching the deprecated spelling exclusively, now stale since #5102 landed), same evidence (the landed `ObjectView.tsx` / `ObjectGrid.tsx`), same gate family, no new verification surface:

- `packages/plugin-view/README.md` — PR #5101's actual output.
- `content/docs/plugins/plugin-view.mdx` — PR #5109's actual output, the docs-site mirror.

Confirmed via `git log --oneline -- content/docs/plugins/plugin-view.mdx` that no OTHER PR has touched it since #5109, and via `search_pull_requests` that no open PR currently touches either file.

## What changed

Both pages taught only `table.pageSize` / `.selectable` / `.defaultFilters` / `.defaultSort` and stated that the canonical `.pagination` / `.selection` / `.filter` / `.sort` had no effect. As of #5102 (PR #5274, merged) all four canonical keys take effect on every forwarding path; the legacy spellings stay working aliases. Both pages now teach the canonical spelling as the recommended form, **without** stating or implying the legacy ones stopped working — the forwarding table and every explanatory paragraph list both, and three rewritten examples show the canonical spelling in place (grid sort, read/list filter+pagination, ObjectQL-integration pagination), one of them (`sort: 'created_at desc'`) deliberately using the string arity `defaultSort` cannot reach.

## Precedence, quoted from the landed code (not guessed)

**When a key is written both ways**, canonical wins — `ObjectGrid.tsx`'s own pre-existing resolution, which `ObjectView` defers to by forwarding both slots rather than re-resolving:

```
schema.pagination?.pageSize || schema.pageSize                          ObjectGrid.tsx:2647
if (schema.selection?.type) … else if (schema.selectable !== undefined) ObjectGrid.tsx:2354
schemaFilter !== undefined ? … : schema.defaultFilters                 ObjectGrid.tsx:1098
schemaSort ?? (schema.defaultSort ? [schema.defaultSort] : undefined)  ObjectGrid.tsx:2701
```

**One caveat I did not overclaim** (the precision note in the dispatch): on the grid path the canonical `filter`/`sort` slots forwarded from `table` carry the `table` segment only —

```ts
filter: viewFilter ? undefined : schema.table?.filter,
sort: viewSort ? undefined : schema.table?.sort,
```

(`ObjectView.tsx`, `gridSchema`, around `:1041-1078`) — so an active named/saved list view's own `filter`/`sort` keeps outranking `table.filter`/`table.sort`, exactly as it already outranked `table.defaultFilters`/`table.defaultSort`. Both pages state the full three-tier order (active named view, then `table.filter`/`.sort`, then `table.defaultFilters`/`.defaultSort`) rather than the wrong "`table.filter` always wins" simplification the card explicitly warned against. `pagination`/`selection` have no such tier (no view-level pagination/selection to defer to) and no effect outside the grid — verified by reading `ObjectView.tsx`'s non-grid `baseProps` builder (around `:840-843`), which forwards `fields` only, never `pagination`/`selection`.

`table.columns` is untouched and **not** taught as working on non-grid views: the forwarding-table row still marks it as the one non-canonical/legacy key with its own open gap (#5269, grid-path only), per the card's explicit ⛔.

## Gate awareness — measured, not carried from another card (per the PM's follow-up message)

| file | ` ```typescript ` fence count | in `UNGATED_DOCS` (`scripts/check-doc-snippet-types.mjs`)? | gate live for this file? |
| --- | --- | --- | --- |
| `packages/plugin-view/README.md` | 20 (`grep -c '^```typescript'`) | **yes**, line 294 — reason on file: "14 parse diagnostic(s) … 14 undefined-name diagnostic(s)" | declared, **not verified** by this gate |
| `content/docs/plugins/plugin-view.mdx` | 14 | **no** — absent from the table | **yes**, compiled against built `dist/*.d.ts` |

Because the `.mdx` page is gated, I built the gate's own `--build-filter` package set (`cli`, `core`, `data-objectstack`, `plugin-charts`, `plugin-editor`, `plugin-grid`, `plugin-markdown`, `plugin-timeline`, `plugin-view`, `react`, `types` — via `pnpm exec turbo run build --concurrency=2` under the shared `/tmp/os-heavy-verify.lock`) and then ran the gate for real, in the foreground, and watched it finish (it does not read the README's snippets at all — they are declared-ungated, not silently passing):

```
Controls:
  resolution   Module name '@object-ui/types' was successfully resolved to '.../packages/types/dist/index.d.ts'
  sentinel     importing 'ThisNameIsDefinitelyNotExported' produced 1 diagnostic(s) (TS2305)
  positive     importing 'ComponentSchema' produced 0 diagnostic(s)

Scanned 182 document(s): 138 covered (13 of them hold a ts/tsx block), 44 ungated
Covered blocks: 73 — 68 to compile, 5 declared fragment(s)
Semantic phase: 68 of 68 block(s) judged, 0 failed
Every covered documentation snippet compiles against the built types.
```

(An earlier attempt at this same build auto-backgrounded past the tool's 120s foreground window and I stopped the turn waiting on a Monitor notification that, per the PM's follow-up, was not going to arrive in this container. Resumed in the foreground per that message; the build had in fact already finished, exit 0, 20/20 tasks — reported here rather than claimed sight-unseen.)

## Verification, on final commit `ce711b6ff`

- `node scripts/check-doc-snippet-types.mjs` → ran to completion above, 68/68 semantic pass — this is the one that needed the build, and I watched it finish.
- `node scripts/check-doc-component-types.mjs` → `Scanned 143 mdx file(s) … ✅ Every documented component type is registered.` (no build needed; unaffected by this change — I add no new `type:` literals).
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4682 tracked text file(s))`; manual self-scan of both changed files with `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` — no hits.
- `node scripts/check-changeset-presence.mjs` → `0 file(s) … under the src/ of a package the release covers … No source of a released package changed in this range, so no changeset is owed.` Both changed files are docs (a package README and a `content/docs/**` page), neither under a package's `src/**`. This repo has no `skip-changeset` label mechanism (unlike `objectstack`), so nothing to apply.

All five gates in the verification bar ran and finished; none skipped, none guessed.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_