### PR TITLE
fix(console): API Discovery Storage group reads the canonical `storage` slot first

### DIFF
--- a/.changeset/storage-canonical-slot-key-console.md
+++ b/.changeset/storage-canonical-slot-key-console.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/console': patch
+---
+
+API Console's endpoint catalog reads the canonical `storage` service slot
+first, falling back to the deprecated `file-storage` slot while the
+framework's v17 alias lives (objectui#5286, framework#9683).
+
+`useApiDiscovery`'s `SERVICE_ENDPOINT_CATALOG` looks its service names up
+directly in `/discovery`'s `services` map, and that lookup is deliberately
+fail-closed (ADR-0076 D12) — a miss hides the whole endpoint group rather
+than erroring. The framework's #9683 ruling made `storage` the canonical
+`CoreServiceName` slot and kept `file-storage` mirrored, byte-equal,
+alongside it for `@objectstack/spec`'s v17 lifetime. Before this change the
+console only ever read the deprecated key; it now reads the canonical key
+first, so the Storage group correctly reflects the framework's own naming,
+and still renders unchanged against a backend that has not deployed the
+#9683 mirror row yet.

--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts
@@ -1,20 +1,26 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * useApiDiscovery — service-gated endpoint groups (#4240).
+ * useApiDiscovery — service-gated endpoint groups (#4240, #5286).
  *
- * ## The defect this file pins
+ * ## The defect #4240 pinned, and how #9683 reshaped it
  *
- * `SERVICE_ENDPOINT_CATALOG` keys are looked up straight in `/discovery`'s
- * `services` map, which the framework keys by `CoreServiceName`. The storage
- * group was keyed `storage`; the canonical slot is `file-storage`. So the
- * lookup missed on every host, and a miss is indistinguishable from "no such
- * service" — the deliberate fail-closed branch (ADR-0076 D12) then hid all
- * three storage endpoints everywhere, on every deployment, forever.
+ * `SERVICE_ENDPOINT_CATALOG` keys are looked up in `/discovery`'s `services`
+ * map, which the framework keys by `CoreServiceName`. #4240 fixed a mis-key
+ * (the storage group was keyed `storage` when the slot was `file-storage`)
+ * by moving the catalog to `file-storage` — the then-canonical spelling. A
+ * miss here is indistinguishable from "no such service" — the deliberate
+ * fail-closed branch (ADR-0076 D12) then hides the group everywhere, on
+ * every deployment, silently.
  *
- * That is the nastiest shape this page can fail in: fail-closed is *correct*
- * behaviour, so the symptom is silence rather than an error, and a mis-keyed
- * group is indistinguishable from a legitimately absent service.
+ * The framework's #9683 ruling (2026-08-18) inverted the slot's own
+ * canonical spelling: `storage` is now canonical, and `file-storage` is a
+ * deprecated alias both discovery producers mirror byte-equal for the
+ * alias's v17 lifetime. #5286 is the consumer-side follow-up pinned here:
+ * the lookup now reads `services.storage` first and falls back to
+ * `services['file-storage']`, so this page keeps rendering the group
+ * against BOTH an upgraded backend and one that predates the #9683 mirror
+ * row — never regressing to the #4240 failure on either spelling.
  *
  * ## What is asserted, and why the gate is left real
  *
@@ -28,6 +34,16 @@
  * The last block is the tripwire the fix would have needed to be caught: it
  * derives the expected key vocabulary from the spec itself rather than
  * restating it, so a rename on EITHER side goes red instead of going quiet.
+ * It still pins `SERVICE_ENDPOINT_CATALOG` to `file-storage`, not `storage`:
+ * the locally pinned `@objectstack/spec` dependency has not published
+ * `storage` as a `CoreServiceName` member yet (verified 2026-08-19 —
+ * `CoreServiceName.options` from the installed package lists `file-storage`
+ * only), so asserting `storage` membership here would fail against real,
+ * currently-installed types, not against the fix. See
+ * `DEPRECATED_SERVICE_SLOT_ALIASES`'s doc comment in the source file for the
+ * re-key-when-the-dependency-catches-up plan; the last `it` in that block
+ * pins the alias table directly instead, since it needs no spec version to
+ * be true.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -37,6 +53,7 @@ import { CoreServiceName } from '@objectstack/spec/system';
 import {
   useApiDiscovery,
   SERVICE_ENDPOINT_CATALOG,
+  DEPRECATED_SERVICE_SLOT_ALIASES,
   type EndpointGroup,
 } from './useApiDiscovery';
 
@@ -83,17 +100,45 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('useApiDiscovery — the storage group (#4240)', () => {
-  it('renders the Storage group with its 3 endpoints when /discovery reports the `file-storage` slot usable', async () => {
-    const groups = await groupsFor({ 'file-storage': USABLE_STORAGE });
+describe('useApiDiscovery — the storage group (#4240, #5286)', () => {
+  it('renders the Storage group from the canonical `storage` slot (framework #9683)', async () => {
+    const groups = await groupsFor({ storage: USABLE_STORAGE });
 
     const storage = storageGroup(groups);
-    expect(storage, 'Storage group must render when the file-storage slot is filled and usable').toBeDefined();
+    expect(storage, 'Storage group must render when /discovery reports the canonical `storage` slot usable').toBeDefined();
     expect(storage!.endpoints.map(e => `${e.method} ${e.path}`)).toEqual([
       'POST /api/v1/storage/upload',
       'GET /api/v1/storage/:fileId',
       'DELETE /api/v1/storage/:fileId',
     ]);
+  });
+
+  // The v17 alias still resolves — a hard swap to `storage`-only would pass
+  // the case above but fail this one, and would break this console against
+  // any backend that has not deployed the #9683 mirror row yet.
+  it('still renders the Storage group from the deprecated `file-storage` slot while the v17 alias lives', async () => {
+    const groups = await groupsFor({ 'file-storage': USABLE_STORAGE });
+
+    const storage = storageGroup(groups);
+    expect(storage, 'Storage group must keep rendering against a backend that has not deployed the #9683 mirror row yet').toBeDefined();
+    expect(storage!.endpoints.map(e => `${e.method} ${e.path}`)).toEqual([
+      'POST /api/v1/storage/upload',
+      'GET /api/v1/storage/:fileId',
+      'DELETE /api/v1/storage/:fileId',
+    ]);
+  });
+
+  // In production the two rows are byte-equal (the framework mirrors one
+  // into the other), so this scenario cannot occur against a real backend —
+  // it exists only to pin READ ORDER: canonical-first, not an OR/merge of
+  // the two. A `file-storage`-first (or merged) lookup would read the
+  // disabled row here and fail-close.
+  it('reads the canonical `storage` slot before the deprecated one when both are present', async () => {
+    const groups = await groupsFor({
+      storage: USABLE_STORAGE,
+      'file-storage': { enabled: false },
+    });
+    expect(storageGroup(groups), 'canonical `storage` must be read first, not merged with `file-storage`').toBeDefined();
   });
 
   it('honours the route /discovery advertises for the slot, not just the default', async () => {
@@ -106,15 +151,6 @@ describe('useApiDiscovery — the storage group (#4240)', () => {
       '/api/v2/files/:fileId',
       '/api/v2/files/:fileId',
     ]);
-  });
-
-  // The canonical name is the ONLY accepted spelling. A tolerant reader here
-  // (accepting `storage` as well) would be a consumer-side workaround for a
-  // producer-side vocabulary, and would re-hide the real defect the moment the
-  // framework changed anything.
-  it('does not resurrect the group from the legacy `storage` spelling', async () => {
-    const groups = await groupsFor({ storage: USABLE_STORAGE });
-    expect(storageGroup(groups)).toBeUndefined();
   });
 });
 
@@ -178,5 +214,16 @@ describe('SERVICE_ENDPOINT_CATALOG keys are canonical service-slot names', () =>
         + 'and their groups will never render on any host — key them by the canonical slot name, '
         + 'or retire the entry',
     ).toEqual([]);
+  });
+
+  // #5286: the DISCOVERY LOOKUP already prefers the canonical `storage` wire
+  // key (framework #9683) even though the catalog's own key vocabulary above
+  // has not been re-keyed yet (see the comment on the `file-storage` catalog
+  // entry in the source file). Pin the alias table directly rather than
+  // through `CoreServiceName.options`, which does not yet list `storage` in
+  // the locally pinned `@objectstack/spec` dependency — this assertion does
+  // not depend on that dependency catching up.
+  it('maps the deprecated `file-storage` catalog key to the canonical `storage` discovery key', () => {
+    expect(DEPRECATED_SERVICE_SLOT_ALIASES['file-storage']).toBe('storage');
   });
 });

--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
@@ -200,13 +200,28 @@ export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRo
   },
   // The KEY is the canonical service-slot name, because it is looked up
   // straight in `/discovery`'s `services` map (`discoveredServices[serviceName]`
-  // below) — and that map is keyed by `CoreServiceName`. The slot is
+  // below) — and that map is keyed by `CoreServiceName`. The slot WAS
   // `file-storage`; the ROUTE is `/api/v1/storage`. Keying this `storage` (as it
   // was until #4240) missed on every host, and the miss is indistinguishable
   // from "no such service" — so the deliberate fail-closed branch hid all three
   // endpoints everywhere, forever. The group's display name stays `Storage`:
   // that is the route's name and the user-facing one, and it is not derived
   // from the key.
+  //
+  // #5286: the framework's #9683 ruling (2026-08-18) inverted the slot's own
+  // canonical spelling — `storage` is now canonical and `file-storage` is a
+  // deprecated alias both discovery producers mirror byte-equal for the
+  // alias's v17 lifetime. This entry stays keyed `file-storage` rather than
+  // being re-keyed to `storage`: the locally pinned `@objectstack/spec`
+  // dependency has not published `storage` as a `CoreServiceName` member yet
+  // (verified 2026-08-19 against the installed package — see
+  // `DEPRECATED_SERVICE_SLOT_ALIASES` below), so re-keying now would fail the
+  // "every service-gated catalog key is a canonical slot" tripwire in the
+  // test file against the real, currently-installed types. What DOES change
+  // here is the discovery lookup: it reads the canonical `services.storage`
+  // first and falls back to this key, so the group renders from either
+  // spelling. Re-key this entry to `storage` and delete the alias table
+  // once the dependency catches up.
   'file-storage': {
     group: 'Storage',
     defaultRoute: '/api/v1/storage',
@@ -216,6 +231,26 @@ export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRo
       { method: 'DELETE', path: '/:fileId', desc: 'Delete file' },
     ],
   },
+};
+
+/**
+ * Deprecated → canonical `CoreServiceName` slot aliases (framework #9683,
+ * maintainer ruling 2026-08-18: `storage` is now the canonical slot; the
+ * compound `file-storage` spelling is a deprecated alias kept for
+ * `@objectstack/spec`'s v17 lifetime). `/discovery`'s `services` map reports
+ * BOTH keys — byte-equal — for as long as the alias lives, so
+ * {@link useApiDiscovery}'s lookup below reads the canonical key first and
+ * falls back to the deprecated one only when the canonical key is entirely
+ * absent (a backend that predates the #9683 mirror row). Both spellings are
+ * pinned in `useApiDiscovery.test.ts`.
+ *
+ * This table is keyed by the CATALOG's key (still `file-storage`, see the
+ * comment on that entry above), not by every `CoreServiceName` value — add
+ * an entry here only when a catalog key itself has a deprecated spelling to
+ * bridge.
+ */
+export const DEPRECATED_SERVICE_SLOT_ALIASES: Record<string, string> = {
+  'file-storage': 'storage',
 };
 
 export function buildServiceEndpoints(serviceName: string, routePrefix: string): EndpointDef[] {
@@ -270,9 +305,13 @@ export function useApiDiscovery() {
 
       const serviceEndpoints: EndpointDef[] = [];
       for (const [serviceName, catalog] of Object.entries(SERVICE_ENDPOINT_CATALOG)) {
-        const serviceInfo = discoveredServices[serviceName] as
-          | (DiscoveryServiceStatus & { route?: string })
-          | undefined;
+        // #5286: read the canonical slot name first (framework #9683) and
+        // fall back to the catalog's own (possibly deprecated) key — see
+        // `DEPRECATED_SERVICE_SLOT_ALIASES`'s doc comment above.
+        const canonicalSlot = DEPRECATED_SERVICE_SLOT_ALIASES[serviceName];
+        const serviceInfo = (
+          (canonicalSlot ? discoveredServices[canonicalSlot] : undefined) ?? discoveredServices[serviceName]
+        ) as (DiscoveryServiceStatus & { route?: string }) | undefined;
         // ADR-0076 D12 (framework#2462): gate on the shared honest-capability
         // check — `stub`/`unavailable`/`handlerReady:false` entries must not
         // render endpoint groups (`degraded` still serves and stays visible).


### PR DESCRIPTION
Fixes #5286

## What

`apps/console/src/pages/developer/hooks/useApiDiscovery.ts` looked the Storage
service slot up in `/discovery`'s `services` map by the deprecated
`file-storage` key only. The framework's #9683 ruling
(objectstack-ai/objectstack#9683, merged as objectstack-ai/objectstack#9820)
made `storage` the canonical `CoreServiceName` slot and kept `file-storage`
mirrored, byte-equal, alongside it for `@objectstack/spec`'s v17 lifetime.

This is the consumer-side rename follow-up: the lookup now reads
`services.storage` first and falls back to `services['file-storage']`, so the
Storage group renders from either spelling — the canonical one when the
backend has deployed the #9683 mirror row, and the deprecated one for a
backend that has not.

## Why the catalog key itself did not move

`SERVICE_ENDPOINT_CATALOG` stays keyed by `file-storage`, not re-keyed to
`storage`. Verified directly against the installed dependency (not assumed):
the locally pinned `@objectstack/spec@17.0.0` has not published `storage` as
a `CoreServiceName` member yet —

```
$ node -e "console.log(require('@objectstack/spec/system').CoreServiceName.options)"
[ 'metadata', 'data', 'auth', 'file-storage', 'search', 'cache', 'queue',
  'automation', 'analytics', 'realtime', 'job', 'notification', 'ai', 'i18n', 'ui' ]
```

Re-keying the catalog to `storage` now would fail the existing
`SERVICE_ENDPOINT_CATALOG keys are canonical service-slot names` tripwire
(objectui#4240) against these real, currently-installed types — not because
the framework's rename is wrong, but because this repository's dependency has
not caught up to it yet. A new `DEPRECATED_SERVICE_SLOT_ALIASES` table bridges
the gap: it is keyed by the catalog's own (still-deprecated) key and maps it to
the canonical discovery key to read first. Re-key the catalog entry to
`storage` and delete that table once `@objectstack/spec` publishes the new
enum member and this repo's lockfile picks it up.

## Tests

`useApiDiscovery.test.ts` now pins both spellings:
- the canonical `storage` slot resolves the Storage group (new — this is what
  a hard swap to `storage`-only would also pass);
- the deprecated `file-storage` slot still resolves it while the v17 alias
  lives (this is what a hard swap would FAIL — the case the fix shape rules
  out);
- canonical is read before the deprecated key when both are present (read
  order, not a merge/OR of the two);
- the route-override and fail-closed (ADR-0076 D12) coverage from #4240 is
  otherwise unchanged;
- the deprecated-to-canonical alias table itself is pinned directly, so that
  assertion does not depend on the `@objectstack/spec` dependency bump noted
  above.

Reverse verification (restore the pre-fix hook, keep the new tests): predicted
3 of 14 would go red — the two new canonical-slot assertions (nothing to
resolve against the old file-storage-only lookup) and the new alias-table pin
(the export does not exist pre-fix) — with the rest staying green. Observed
exactly that (`14 tests | 3 failed`, the 3 named above), then restored the
fix and re-ran clean (`14 passed`).

Also run at the same HEAD (`47cc35bfc`): `pnpm --filter '@object-ui/console'
type-check` (exit 0), `pnpm --filter '@object-ui/console' lint` (0 errors,
200 pre-existing warnings unrelated to this diff), `node
scripts/check-control-bytes.mjs` (OK), `node
scripts/check-changeset-presence.mjs` (declares
`.changeset/storage-canonical-slot-key-console.md`). All commands run from
the repo root per AGENTS.md's vitest-invocation guard.

## Cross-repo

Named reader in the framework's retirement ledger:
objectstack-ai/objectstack#9819 — landing this un-blocks one line of that
ledger (not a closing reference; the ledger line lives in that repo).

## Scope

No accept-set change: `SERVICE_ENDPOINT_CATALOG`'s key vocabulary is
unchanged, only the discovery lookup for the one aliased slot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_