### PR TITLE
feat(lint): reject an unpaired getBadgeColorClasses call

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -7,6 +7,7 @@ import noTryCatchAroundHook from './no-try-catch-around-hook.js';
 import noDynamicImportInTestHook from './no-dynamic-import-in-test-hook.js';
 import noQueryParamsUnderOptions from './no-query-params-under-options.js';
 import buttonHasType from './button-has-type.js';
+import noUnpairedBadgeColorClasses from './no-unpaired-badge-color-classes.js';
 
 export default {
   rules: {
@@ -16,5 +17,6 @@ export default {
     'no-dynamic-import-in-test-hook': noDynamicImportInTestHook,
     'no-query-params-under-options': noQueryParamsUnderOptions,
     'button-has-type': buttonHasType,
+    'no-unpaired-badge-color-classes': noUnpairedBadgeColorClasses,
   },
 };

--- a/eslint-rules/no-unpaired-badge-color-classes.js
+++ b/eslint-rules/no-unpaired-badge-color-classes.js
@@ -1,0 +1,154 @@
+/**
+ * ObjectUI ESLint rule: no-unpaired-badge-color-classes
+ *
+ * `@object-ui/fields` answers "what colour is this badge?" in two incompatible
+ * currencies:
+ *
+ *   getBadgeColorClasses(color, value) -> a class string. Complete-looking, and
+ *     structurally unable to carry a runtime colour: an author-declared hex is
+ *     quantized onto one of the nine palette families.
+ *   getBadgeHexAppearance(color) -> `{ className, style }` or `undefined`. The
+ *     correct answer for a declared hex — the className reads CSS custom
+ *     properties that only the `style` half supplies.
+ *
+ * Reaching for the first one alone renders a plausible NEIGHBOURING colour
+ * rather than breaking, so it fails only for authors who declared a hex and it
+ * fails quietly. That is the defect objectui#5141 fixed in the cell renderer
+ * and objectui#5183 fixed at four more sites — twice in two weeks, per-site
+ * both times, because nothing rejected the class-only call at write time
+ * (objectui#5191).
+ *
+ * The paired form, as every live call site writes it:
+ *
+ *     const hexBadge = getBadgeHexAppearance(option?.color);
+ *     const colorClass = hexBadge
+ *       ? hexBadge.className
+ *       : getBadgeColorClasses(option?.color, value);
+ *     // ... and `hexBadge?.style` travels with the class to the element.
+ *
+ * WHAT COUNTS AS PAIRED — lexical visibility, not syntax. A
+ * `getBadgeColorClasses` call is paired when a `getBadgeHexAppearance` call
+ * appears in the SAME function scope or in one ENCLOSING it (module scope
+ * included). Consequences, each pinned in the rule's test:
+ *   - the `if/else` spelling pairs as well as the ternary — the rule reads
+ *     scopes, not conditional shapes, so it cannot be defeated by rewriting the
+ *     branch;
+ *   - hoisting a loop-invariant `getBadgeHexAppearance` above a `.map()` and
+ *     calling the class helper inside the callback stays clean (the consult is
+ *     in an enclosing scope, which is what "visible" means);
+ *   - a consult in a SIBLING function does NOT pair — otherwise one paired site
+ *     in a large file would license every unpaired one added next to it, which
+ *     is precisely the fifth-call-site this rule exists to reject.
+ *
+ * Import aliases are followed (`getBadgeColorClasses as badgeClasses`), and the
+ * namespace form (`fields.getBadgeColorClasses(...)`) is matched on the member
+ * name. Known limit: passing either helper around as a bare function reference
+ * (`const f = getBadgeColorClasses`) is not tracked — no call site in this repo
+ * does that, and adding a reference-flow pass would trade a large false-positive
+ * surface for a case nobody writes.
+ *
+ * Not enforced inside `packages/fields` itself (see eslint.config.js): that
+ * package DEFINES both helpers and unit-tests each half in isolation, so its
+ * deliberate single-helper calls are the helper's own coverage, not a badge
+ * surface.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+
+const CLASS_HELPER = 'getBadgeColorClasses';
+const HEX_HELPER = 'getBadgeHexAppearance';
+const FIELDS_PACKAGE = '@object-ui/fields';
+
+/**
+ * The called name for both spellings a call site can use: a direct identifier
+ * (`getBadgeColorClasses(...)`) and a non-computed member access on a namespace
+ * import (`fields.getBadgeColorClasses(...)`).
+ */
+function calleeName(callee) {
+  if (!callee) return undefined;
+  if (callee.type === 'Identifier') return callee.name;
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property &&
+    callee.property.type === 'Identifier'
+  ) {
+    return callee.property.name;
+  }
+  return undefined;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require a getBadgeHexAppearance consult in scope wherever getBadgeColorClasses is called — the class string alone quantizes an author-declared hex onto a palette family (objectui#5141/#5183/#5191).',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      unpaired:
+        "`{{name}}` alone quantizes an author-declared hex onto one of the nine palette families — the defect fixed per-site in objectui#5141 and objectui#5183. Consult `getBadgeHexAppearance(color)` in this scope (or an enclosing one) first, use its `className` AND carry its `style` through to the element, and fall back to `{{name}}(color, value)` only when it returns `undefined`.",
+    },
+  },
+  create(context) {
+    // Local names each helper is reachable under in this module. The canonical
+    // spelling is always in the set so a re-export or a namespace member is
+    // matched even when no direct import declares it here.
+    const classNames = new Set([CLASS_HELPER]);
+    const hexNames = new Set([HEX_HELPER]);
+
+    // Functions currently open, innermost last. Empty === module scope.
+    const fnStack = [];
+    // The nearest enclosing function of every hex consult seen in this module
+    // (`null` for a consult at module scope, which every scope below can see).
+    const hexScopes = new Set();
+    // Deferred to `Program:exit` so a consult written after the class call —
+    // lexically visible all the same — is not missed by traversal order.
+    const classCalls = [];
+
+    return {
+      ImportDeclaration(node) {
+        if (!node.source || node.source.value !== FIELDS_PACKAGE) return;
+        for (const spec of node.specifiers) {
+          if (spec.type !== 'ImportSpecifier') continue;
+          if (!spec.imported || spec.imported.type !== 'Identifier') continue;
+          if (spec.imported.name === CLASS_HELPER) classNames.add(spec.local.name);
+          if (spec.imported.name === HEX_HELPER) hexNames.add(spec.local.name);
+        }
+      },
+
+      ':function'(node) {
+        fnStack.push(node);
+      },
+      ':function:exit'() {
+        fnStack.pop();
+      },
+
+      CallExpression(node) {
+        const name = calleeName(node.callee);
+        if (!name) return;
+        if (hexNames.has(name)) {
+          hexScopes.add(fnStack.length ? fnStack[fnStack.length - 1] : null);
+          return;
+        }
+        if (classNames.has(name)) {
+          // `null` first: module scope encloses every call in the file.
+          classCalls.push({ node, name, scopes: [null, ...fnStack] });
+        }
+      },
+
+      'Program:exit'() {
+        for (const call of classCalls) {
+          if (call.scopes.some((scope) => hexScopes.has(scope))) continue;
+          context.report({
+            node: call.node,
+            messageId: 'unpaired',
+            data: { name: call.name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/no-unpaired-badge-color-classes.test.js
+++ b/eslint-rules/no-unpaired-badge-color-classes.test.js
@@ -1,0 +1,225 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit test for the local ESLint rule that requires a `getBadgeHexAppearance`
+ * consult in scope wherever `getBadgeColorClasses` is called (objectui#5191).
+ * Plain JS so it needs no package tsconfig.
+ *
+ * The `valid` cases are the shapes that exist on `main` today, transcribed from
+ * the live call sites (plugin-grid ObjectGrid group header + compact card,
+ * plugin-kanban card badges) plus the spellings a correct author may reasonably
+ * reach for next. The `invalid` cases are the historical defect shape
+ * (objectui#5141, objectui#5183) and the ways a fifth site could try to look
+ * paired without being paired.
+ */
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from './no-unpaired-badge-color-classes.js';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run('no-unpaired-badge-color-classes', rule, {
+  valid: [
+    // The canonical pair, as plugin-kanban writes it (ObjectKanban.tsx).
+    `
+      import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+      function KanbanBadge(opt, raw) {
+        const hexBadge = getBadgeHexAppearance(opt?.color);
+        const colorClass = hexBadge ? hexBadge.className : getBadgeColorClasses(opt?.color, raw);
+        return { colorClass, colorStyle: hexBadge?.style };
+      }
+    `,
+    // The nested-ternary shape of ObjectGrid's compact card, where a third
+    // branch falls back to a local pipeline-stage heuristic.
+    `
+      import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+      function CompactCardBadge(optMeta, rawValue) {
+        const hexBadge = getBadgeHexAppearance(optMeta.color);
+        return hexBadge
+          ? hexBadge.className
+          : optMeta.color
+            ? getBadgeColorClasses(optMeta.color, rawValue)
+            : stageBadgeColor(String(rawValue));
+      }
+    `,
+    // Scope-level, not syntax-level: the if/else spelling pairs exactly as well
+    // as the ternary. A rule that read the conditional shape would reject this
+    // correct code, and rewriting the branch would defeat it.
+    `
+      import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+      function resolve(color, value) {
+        const hexBadge = getBadgeHexAppearance(color);
+        let cls;
+        if (hexBadge) {
+          cls = hexBadge.className;
+        } else {
+          cls = getBadgeColorClasses(color, value);
+        }
+        return cls;
+      }
+    `,
+    // An ENCLOSING scope counts: hoisting a loop-invariant consult above the
+    // callback is good code, and the class call inside the callback still sees
+    // it. (Flagging this is how a preventive rule earns itself deleted.)
+    `
+      import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+      function Legend(color, values) {
+        const hexBadge = getBadgeHexAppearance(color);
+        return values.map((v) => (hexBadge ? hexBadge.className : getBadgeColorClasses(color, v)));
+      }
+    `,
+    // Module scope encloses every call in the file.
+    `
+      import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+      const hexBadge = getBadgeHexAppearance(DECLARED_COLOR);
+      function badge(value) {
+        return hexBadge ? hexBadge.className : getBadgeColorClasses(DECLARED_COLOR, value);
+      }
+    `,
+    // Aliased imports are followed on both halves.
+    `
+      import {
+        getBadgeColorClasses as badgeClasses,
+        getBadgeHexAppearance as badgeHex,
+      } from '@object-ui/fields';
+      function resolve(color, value) {
+        const hex = badgeHex(color);
+        return hex ? hex.className : badgeClasses(color, value);
+      }
+    `,
+    // Namespace import: matched on the member name, and paired the same way.
+    `
+      import * as fields from '@object-ui/fields';
+      function resolve(color, value) {
+        const hex = fields.getBadgeHexAppearance(color);
+        return hex ? hex.className : fields.getBadgeColorClasses(color, value);
+      }
+    `,
+    // The consult may be written after the call it guards — the rule resolves
+    // pairing over the whole module, not in traversal order.
+    `
+      import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+      function resolve(color, value) {
+        const cls = hex ? hex.className : getBadgeColorClasses(color, value);
+        const hex = getBadgeHexAppearance(color);
+        return cls;
+      }
+    `,
+    // Nothing to do with badges.
+    `
+      import { formatCurrency } from '@object-ui/fields';
+      const label = formatCurrency(12);
+    `,
+    // A JSX surface that pairs, carrying the style half through to the element.
+    `
+      import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+      function Cell({ option, val }) {
+        const hexBadge = getBadgeHexAppearance(option?.color);
+        const colorClasses = hexBadge ? hexBadge.className : getBadgeColorClasses(option?.color, val);
+        return <Badge className={colorClasses} style={hexBadge?.style} />;
+      }
+    `,
+  ],
+  invalid: [
+    // The historical defect shape: the class helper imported and called alone.
+    // This is what every site fixed by objectui#5141 and objectui#5183 looked
+    // like before the fix.
+    {
+      code: `
+        import { getBadgeColorClasses } from '@object-ui/fields';
+        function StatusBadge({ option, value }) {
+          return <Badge className={getBadgeColorClasses(option?.color, value)} />;
+        }
+      `,
+      errors: [{ messageId: 'unpaired' }],
+    },
+    // Assigned rather than inlined — same defect, no conditional to inspect.
+    {
+      code: `
+        import { getBadgeColorClasses } from '@object-ui/fields';
+        function resolve(color, value) {
+          const cls = getBadgeColorClasses(color, value);
+          return cls;
+        }
+      `,
+      errors: [{ messageId: 'unpaired' }],
+    },
+    // An alias does not hide the call.
+    {
+      code: `
+        import { getBadgeColorClasses as badgeClasses } from '@object-ui/fields';
+        function resolve(color, value) {
+          return badgeClasses(color, value);
+        }
+      `,
+      errors: [{ messageId: 'unpaired' }],
+    },
+    // Nor does the namespace form.
+    {
+      code: `
+        import * as fields from '@object-ui/fields';
+        function resolve(color, value) {
+          return fields.getBadgeColorClasses(color, value);
+        }
+      `,
+      errors: [{ messageId: 'unpaired' }],
+    },
+    // THE HOLE THIS SCOPE RULE CLOSES: a consult in a SIBLING function does not
+    // pair. Otherwise one correct site would license every unpaired site added
+    // beside it in the same file — and the files that already pair (ObjectGrid,
+    // ObjectKanban) are exactly where a fifth badge surface gets written.
+    {
+      code: `
+        import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+        function groupHeader(color, value) {
+          const hexBadge = getBadgeHexAppearance(color);
+          return hexBadge ? hexBadge.className : getBadgeColorClasses(color, value);
+        }
+        function newCardSurface(color, value) {
+          return getBadgeColorClasses(color, value);
+        }
+      `,
+      errors: [{ messageId: 'unpaired' }],
+    },
+    // A consult buried in a NESTED callback is not visible to the outer call
+    // either — direction matters, enclosing only.
+    {
+      code: `
+        import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+        function resolve(color, values) {
+          values.forEach((v) => { getBadgeHexAppearance(v.color); });
+          return getBadgeColorClasses(color, values[0]);
+        }
+      `,
+      errors: [{ messageId: 'unpaired' }],
+    },
+    // The rule counts SITES, not files: two unpaired calls report twice.
+    {
+      code: `
+        import { getBadgeColorClasses } from '@object-ui/fields';
+        function a(c, v) { return getBadgeColorClasses(c, v); }
+        function b(c, v) { return getBadgeColorClasses(c, v); }
+      `,
+      errors: [{ messageId: 'unpaired' }, { messageId: 'unpaired' }],
+    },
+    // Importing the hex helper without ever calling it is not a consult.
+    {
+      code: `
+        import { getBadgeColorClasses, getBadgeHexAppearance } from '@object-ui/fields';
+        function resolve(color, value) {
+          return getBadgeColorClasses(color, value);
+        }
+      `,
+      errors: [{ messageId: 'unpaired' }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -217,4 +217,35 @@ export default tseslint.config({
   rules: {
     'object-ui/no-inline-spec-config': 'error',
   },
+}, {
+  // objectui#5191 ratchet — `getBadgeColorClasses(color, value)` returns a
+  // class string and therefore cannot carry an author-declared hex: it
+  // quantizes the declared colour onto one of nine palette families. The
+  // correct answer is `getBadgeHexAppearance(color)`, whose `className` reads
+  // CSS custom properties that only its `style` half supplies. A class-only
+  // call compiles, renders, and looks right for family-name declarations (the
+  // common case), so it fails only for authors who declared a hex — and it
+  // fails by rendering a plausible NEIGHBOURING colour rather than by breaking.
+  // objectui#5141 fixed that in the cell renderer and objectui#5183 fixed four
+  // more sites; both rounds were per-site, because nothing rejected the
+  // class-only call at write time. Error so the fifth badge surface fails CI
+  // instead of shipping a quietly wrong colour — `.github/workflows/lint.yml`
+  // sets no `--max-warnings`, so a `warn` here could not fail anything. Every
+  // live call site pairs the two helpers already (plugin-grid ObjectGrid group
+  // header + compact card, plugin-kanban card badges), so this lints clean
+  // today with no allowlist.
+  //
+  // `packages/fields` is ignored because it OWNS both helpers: it defines them,
+  // its own badge renderer pairs them anyway, and
+  // `src/__tests__/badge-hex-fidelity-5141.test.tsx` deliberately exercises
+  // each half in isolation — that is the helper's own coverage, not a badge
+  // surface. Everywhere else, including tests, is in scope: outside `fields` a
+  // call to this helper IS a badge surface, and the repo is at zero unpaired
+  // instances today.
+  files: ['**/*.{ts,tsx}'],
+  ignores: ['packages/fields/**'],
+  plugins: { 'object-ui': objectUi },
+  rules: {
+    'object-ui/no-unpaired-badge-color-classes': 'error',
+  },
 });


### PR DESCRIPTION
Fixes #5191

Scoped to the **lint-rule option only**, per the triage comment on the issue. The consolidated-export option is an explicit non-goal and is not touched here: `packages/fields`' published surface is unchanged, and `ObjectGrid.tsx` is not re-entered.

## The class this closes

`@object-ui/fields` answers "what colour is this badge?" in two incompatible currencies:

- `getBadgeColorClasses(color, value)` returns a **class string** — complete-looking, and structurally unable to carry a runtime colour, so an author-declared hex is quantized onto one of nine palette families.
- `getBadgeHexAppearance(color)` returns `{ className, style }` or `undefined` — the correct answer, but only if the caller consults it first **and** carries the `style` through. That className reads CSS custom properties that only the `style` half supplies.

A class-only call compiles, renders, and looks right for family-name declarations (the common case), so it fails only for authors who declared a hex — and it fails by rendering a plausible neighbouring colour rather than by breaking. #5141 fixed that in the cell renderer; #5183 fixed four more sites. Both rounds were per-site, because nothing rejected the class-only call at write time.

## What was verified before writing

Re-derived on `origin/main` @ `12841b6` (still the tip when this branch was cut, matching the triage comment):

- Both exports live: `packages/fields/src/index.tsx:1409` `getBadgeHexAppearance`, `:1440` `getBadgeColorClasses` — located by reading, not by the cited line numbers.
- All four cross-package call sites **pair** them: `plugin-grid/src/ObjectGrid.tsx:3174/3178` (compact card) and `:3394/3397` (group header), `plugin-kanban/src/ObjectKanban.tsx:413/416` and `:471/474`. No live unpaired site exists today, so this rule is preventive.
- `plugin-calendar/src/CalendarView.tsx:34` is a **comment mention only** — confirmed: it is the sole occurrence of the symbol anywhere in that package, there is no import and no call.
- No eslint rule for this already existed (`grep -rni badge eslint-rules/` returns nothing; counter-probed with `context.report`, which hits all six existing rule files).

## The rule

`object-ui/no-unpaired-badge-color-classes` — a `getBadgeColorClasses` call must have a `getBadgeHexAppearance` consult **lexically visible** from it: the same function scope, or one enclosing it (module scope included).

Scope-level rather than syntax-level, which decides three cases the rule's test pins:

- the `if/else` spelling pairs exactly as well as the ternary — the rule reads scopes, not conditional shapes, so it cannot be defeated by rewriting the branch;
- hoisting a loop-invariant consult above a `.map()` and calling the class helper inside the callback stays clean, because an enclosing scope is what "visible" means (a rule that flagged that correct code is a rule someone would delete);
- a consult in a **sibling** function does **not** pair. Otherwise one correct site would license every unpaired site added beside it — and the files that already pair, `ObjectGrid.tsx` and `ObjectKanban.tsx`, are exactly where a fifth badge surface gets written.

Import aliases are followed on both halves, and the namespace form (`fields.getBadgeColorClasses(...)`) is matched on the member name. Known limit, documented in the rule header: passing either helper around as a bare function reference is not tracked — no call site in this repo does that, and a reference-flow pass would trade a large false-positive surface for a case nobody writes.

## Severity: `error`, and why

`error`, matching every other `object-ui/*` ratchet in `eslint.config.js`. **A `warn` would be decoration here**: `.github/workflows/lint.yml` deliberately sets no `--max-warnings` (its own header says so, and the repo carries ten thousand warnings), so a warning cannot fail CI. The lint workflow gates pull requests and every one of the 46 workspace packages runs `eslint .` (`scripts/check-lint-coverage.mjs`: 46/46), so an error here does turn a build red.

The rule lints clean today with no allowlist, so landing it at `error` costs nothing.

## Both halves of the real eslint run

Not just the unit test — an actual `eslint` invocation, at commit `7d1256b32`.

**Half 1 — it fires.** A deliberately-unpaired fixture (temporary, never committed) at `packages/plugin-grid/src/tmp-fixture-5191.tsx`:

```
/home/user/objectui-issue-5191/packages/plugin-grid/src/tmp-fixture-5191.tsx
  7:22  error  `getBadgeColorClasses` alone quantizes an author-declared hex onto one of the nine
  palette families — the defect fixed per-site in objectui#5141 and objectui#5183. Consult
  `getBadgeHexAppearance(color)` in this scope (or an enclosing one) first, use its `className` AND
  carry its `style` through to the element, and fall back to `getBadgeColorClasses(color, value)`
  only when it returns `undefined`  object-ui/no-unpaired-badge-color-classes

✖ 1 problem (1 error, 0 warnings)
exit=1
```

Rewriting that same fixture into the paired form makes it silent: `exit=0`, no findings.

**Half 2 — it is quiet on today's correct code**, which matters as much: a rule that flags correct code gets deleted.

```
pnpm exec eslint .        →  files linted 3357 | errors 0 | no-unpaired-badge-color-classes findings 0
```

Repo-wide, at `7d1256b32`. All four live paired call sites are inside that set.

## Reverse verification

Predicted before running: with the fixture present and the config block removed, the fixture stops being flagged — a straight red-to-green flip on the fixture, exit 0, **not** a count shift elsewhere, since nothing else in the repo emits this diagnostic and no other gate reads its output. No rebuild concern applies: `eslint.config.js` imports `./eslint-rules/index.js` as source, and `eslint-rules/` has no build output, so there is no artifact between the edit and the thing under test.

| leg | state | predicted | observed |
|---|---|---|---|
| 0 | rule wired (committed) | 1 error, exit 1 | 1 error, exit 1 |
| A | config block removed | 0 findings, exit 0 | 0 findings, exit 0 |
| B | restored via `git checkout` | 1 error, exit 1 | 1 error, exit 1 |

Leg B restored the file byte-identically to the commit (`git diff --stat HEAD -- eslint.config.js` empty). The fixture was deleted afterwards; the tree is clean.

## Why `packages/fields` is out of scope

The config block ignores `packages/fields/**`, because that package **owns** both helpers: it defines them, its own badge renderer pairs them anyway (`index.tsx:1559/1560`), and `src/__tests__/badge-hex-fidelity-5141.test.tsx` deliberately exercises each half in isolation. That carve-out is load-bearing and was measured, not assumed — forcing the rule on for that file with `--rule` reports its 7 deliberate single-helper calls.

Everywhere else, including tests, is in scope: outside `fields`, a call to this helper is a badge surface.

## Verification

At commit `7d1256b32`, clean tree:

- `pnpm exec vitest run eslint-rules/no-unpaired-badge-color-classes.test.js` — 18 passed (10 valid shapes, 8 invalid). The valid list is transcribed from the live call sites; the invalid list is the historical defect shape plus the ways a fifth site could look paired without being paired.
- `pnpm exec vitest run eslint-rules/ scripts/` — 62 files, 1394 tests passed. Includes the lint-config meta-tests (`lint-workflow`, `turbo-lint-inputs`, `turbo-task-guard-coverage`).
- `pnpm exec eslint .` — 3357 files, 0 errors.
- `node scripts/check-control-bytes.mjs` — OK, 4684 tracked text files.
- `node scripts/check-lint-coverage.mjs` — 46/46 packages linted, 0 with outstanding errors.
- `node scripts/check-changeset-presence.mjs` — "No source of a released package changed in this range, so no changeset is owed." CI-time only, matching the triage note; checked with the script rather than assumed.

## File surface

`eslint-rules/no-unpaired-badge-color-classes.js`, its test, `eslint-rules/index.js`, `eslint.config.js`. Nothing else — no `packages/fields` export change, no `ObjectGrid.tsx`, no governed surfaces.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_