### PR TITLE
fix(components,types): page:header maxVisible honours the contract's value domain

### DIFF
--- a/.changeset/page-header-maxvisible-contract-domain-5006.md
+++ b/.changeset/page-header-maxvisible-contract-domain-5006.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/components': patch
+'@object-ui/types': patch
+---
+
+`page:header`'s `maxVisible` / `mobileMaxVisible` now honour the contract's value domain instead of a laxer renderer tolerance.
+
+Three authorities gave two answers for the same value (objectui#5006). Measured on
+`ComponentPropsMap['page:header']` at `@objectstack/spec@17.0.0` — the member lives
+on the `@objectstack/spec/ui` subpath, not the package root — both keys are a
+POSITIVE SAFE INTEGER (`{format:'safeint'}` plus
+`{check:'greater_than',value:0,inclusive:false}`). Spec rejects `0`, `-1`, `1.5`
+and anything past `Number.MAX_SAFE_INTEGER`. objectui's manifest gate and
+`sdui-parser`'s `checkType` said nothing about any of them, and the renderer's
+`readMax` was looser still: it accepted `0` and floored fractions. So the loosest
+of the three layers decided what shipped on screen, while `os validate` / `os build`
+rejected the very same metadata outright.
+
+`readMax` now accepts only what the contract accepts. `Number.isSafeInteger(v) && v > 0`
+is the exact translation of `safeint`, not an approximation — plain `Number.isInteger`
+would admit `2**53 + 2` and `1e21`, which spec rejects.
+
+Behaviour change, stated because this NARROWS the renderer's accept set rather than
+only fixing a fault: a contract-rejected value no longer takes effect and falls back
+to the documented default (3 desktop / 1 mobile). Concretely, `maxVisible: 0` used to
+render zero inline buttons and sweep every action into the overflow menu, and
+`maxVisible: 1.5` used to be floored to `1`; both now render the default 3-inline
+split. This is a narrowing *toward* an already-published contract — no in-tree
+producer writes a rejected value, so nothing in the repo changes behaviour. Both
+schema-level and `properties.*` spellings go through the one reader. `action:bar`'s
+`maxVisible` is an unrelated reader with no `ComponentPropsMap` entry and is
+deliberately untouched.
+
+`ComponentInput.type`'s doc comment now records the trade the ruling fixed in place
+(maintainer, 2026-08-17): the coarse `number` arm plus `description` is the
+publication face's expression ceiling today, and spec is the sole judge of values.
+Giving `ComponentInput` real constraint slots, and binding `checkType` to spec, were
+both deferred with a named reopen condition — a measured case of an author shipping
+a spec-rejected value that objectui's silence let through.

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -429,6 +429,107 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
   });
 });
 
+// objectui#5006 — the `maxVisible` / `mobileMaxVisible` VALUE DOMAIN.
+//
+// Three authorities used to give two answers for the same value. Measured on
+// `ComponentPropsMap['page:header']` at @objectstack/spec 17.0.0 (the member
+// lives on the `@objectstack/spec/ui` subpath, NOT the package root), both keys
+// are a positive safe integer — `{format:'safeint'}` plus
+// `{check:'greater_than',value:0,inclusive:false}`:
+//
+//   value | spec                                  | old readMax
+//   ------+---------------------------------------+---------------------------
+//   3     | OK                                    | 3
+//   0     | REJECT "expected number to be >0"     | 0  (all actions overflowed)
+//   -1    | REJECT "expected number to be >0"     | undefined -> default
+//   1.5   | REJECT "expected int, received number"| 1  (floored)
+//   2^53+2| REJECT "expected int to be <=2^53-1"  | 2^53+2 (nothing overflowed)
+//
+// The renderer was the loosest of the three, so a value `os validate` rejects
+// outright still changed what shipped on screen. `readMax` now enforces the
+// contract and a rejected value falls back to the documented default (3 desktop
+// / 1 mobile) instead of taking effect.
+//
+// ⚠️ Scope note for future readers: `readMax` is `page:header`-only and has
+// exactly two call sites. `action:bar` reads `schema.maxVisible ?? 3` through a
+// wholly separate reader (`renderers/action/action-bar.tsx`) and is NOT in
+// `ComponentPropsMap` at all, so its `maxVisible: 0` fixtures are legitimate and
+// untouched by this suite. The notification stack's `maxVisible` is a third,
+// unrelated reader (provider config).
+describe('PageHeaderRenderer — maxVisible contract domain (objectui#5006)', () => {
+  const fourActions = [
+    { name: 'a', locations: ['record_header'], label: 'Action A' },
+    { name: 'b', locations: ['record_header'], label: 'Action B' },
+    { name: 'c', locations: ['record_header'], label: 'Action C' },
+    { name: 'd', locations: ['record_header'], label: 'Action D' },
+  ];
+
+  // Asserts the DEFAULT-3 split: A/B/C inline, D folded into the overflow menu.
+  // That is what a contract-rejected override must fall back to.
+  function expectDefaultThreeSplit() {
+    expect(screen.getByRole('button', { name: /Action A/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Action B/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Action C/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Action D/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /More actions/i })).toBeTruthy();
+  }
+
+  it('rejects maxVisible: 0 and falls back to the default (spec rejects 0)', () => {
+    // Pre-fix this rendered ZERO inline buttons and swept every action into the
+    // overflow menu — the most visible of the divergences, and the one an author
+    // was most likely to hit by writing "0 means unlimited".
+    renderHeader({ type: 'page:header', maxVisible: 0, actions: fourActions });
+    expectDefaultThreeSplit();
+  });
+
+  it('rejects a fractional maxVisible instead of flooring it (spec rejects 1.5)', () => {
+    // Pre-fix: Math.floor(1.5) === 1, so only Action A stayed inline. Flooring
+    // invented a value the contract never accepted.
+    renderHeader({ type: 'page:header', maxVisible: 1.5, actions: fourActions });
+    expectDefaultThreeSplit();
+  });
+
+  it('rejects a maxVisible past Number.MAX_SAFE_INTEGER (spec format is safeint)', () => {
+    // Pre-fix this was finite and >= 0, so it passed straight through and every
+    // action rendered inline with no overflow button at all. This is the case
+    // that makes Number.isSafeInteger — not Number.isInteger — the correct
+    // predicate: Number.isInteger(2**53 + 2) is true, but spec rejects it.
+    renderHeader({
+      type: 'page:header',
+      maxVisible: Number.MAX_SAFE_INTEGER + 2,
+      actions: fourActions,
+    });
+    expectDefaultThreeSplit();
+  });
+
+  it('applies the same domain to the properties.* spelling (spec bridge variant)', () => {
+    // Both spellings flow through the one `readMax`, so the bridge variant must
+    // not be a way around the contract.
+    renderHeader({
+      type: 'page:header',
+      properties: { maxVisible: 0, actions: fourActions },
+    });
+    expectDefaultThreeSplit();
+  });
+
+  // ⚠️ The two tests below are GREEN BOTH BEFORE AND AFTER the fix — they pin
+  // no part of this change and are recorded as regression guards only. A
+  // negative override already fell back (the old guard was `v >= 0`), and a
+  // positive safe integer was already honoured. They are kept so the accepted
+  // and rejected halves of the domain are both stated in one place.
+  it('regression guard (green pre-fix too): a negative maxVisible falls back', () => {
+    renderHeader({ type: 'page:header', maxVisible: -1, actions: fourActions });
+    expectDefaultThreeSplit();
+  });
+
+  it('regression guard (green pre-fix too): a positive safe integer is honoured', () => {
+    renderHeader({ type: 'page:header', maxVisible: 2, actions: fourActions });
+    expect(screen.getByRole('button', { name: /Action B/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Action C/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /More actions/i })).toBeTruthy();
+  });
+});
+
 // objectui#3391 — record dispatch shape. A `record_header` / `record_more`
 // action must reach the runtime in the SAME shape ObjectGrid row actions and
 // DeclaredActionsBar dispatch: the record stashed under `params._rowRecord`

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -1400,12 +1400,34 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     //      (see the headerActions memo above), so the first `maxVisible`
     //      claim the inline slots.
     // `maxVisible` / `mobileMaxVisible` are overridable on the page:header
-    // schema and default to 3 / 1 — the same contract as action:bar. This
-    // still keeps the header from drowning in 4–5 buttons on every record
-    // page, while letting multi-action objects surface several primary
-    // buttons at once.
+    // schema and default to 3 / 1. This still keeps the header from drowning
+    // in 4–5 buttons on every record page, while letting multi-action objects
+    // surface several primary buttons at once.
+    //
+    // `readMax` enforces the SPEC's value domain rather than a laxer renderer
+    // tolerance (objectui#5006). Measured on `ComponentPropsMap['page:header']`
+    // at @objectstack/spec 17.0.0, both keys are a POSITIVE SAFE INTEGER
+    // (`{format:'safeint'}` + `{check:'greater_than',value:0,inclusive:false}`),
+    // so `0`, `-1`, `1.5` and anything past `Number.MAX_SAFE_INTEGER` are all
+    // rejected by the contract. This reader used to be the loosest of the three
+    // authorities — it accepted `0` and floored fractions — so a value that
+    // `os validate` / `os build` rejects outright still changed what rendered
+    // here, and the loosest layer decided behaviour. A contract-rejected value
+    // now falls back to the default instead of taking effect.
+    //
+    // `Number.isSafeInteger` is the exact translation of `safeint`, not an
+    // approximation: plain `Number.isInteger` would admit `2**53 + 2` and
+    // `1e21`, both of which spec rejects (`Too big: expected int to be
+    // <= 9007199254740991`). It also subsumes the old `Number.isFinite` guard,
+    // since Infinity and NaN are not safe integers.
+    //
+    // ⛔ Do NOT re-lax this into a tolerant read. objectui's authoring-time
+    // gates stay coarse by ruling (maintainer, 2026-08-17): `ComponentInput`
+    // keeps its single `number` arm and `checkType` is not bound to spec, so
+    // SPEC IS THE SOLE JUDGE OF VALUES — which makes agreeing with it this
+    // renderer's job. Rejections are pinned in `page-header-actions.test.tsx`.
     const readMax = (v: any): number | undefined =>
-      typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : undefined;
+      typeof v === 'number' && Number.isSafeInteger(v) && v > 0 ? v : undefined;
     const maxVisible = isMobile
       ? (readMax(schema?.mobileMaxVisible ?? schema?.properties?.mobileMaxVisible) ?? 1)
       : (readMax(schema?.maxVisible ?? schema?.properties?.maxVisible) ?? 3);
@@ -1748,10 +1770,13 @@ ComponentRegistry.register('header', PageHeaderRenderer, {
     // `ComponentPropsMap['page:header']` on the installed GA pin, both are
     // `z.number()` constrained to a POSITIVE SAFE INTEGER — `0`, `-1` and `2.5`
     // are all rejected by value, which is why the descriptions say so instead
-    // of leaving an author to discover it from a parse error. (`readMax` here is
-    // laxer than that — it accepts `0` and floors fractions — but a renderer
-    // tolerance is not an authoring surface, and the contract is what `inputs`
-    // publishes.)
+    // of leaving an author to discover it from a parse error. (`readMax` at the
+    // inline/overflow split above now enforces exactly that domain — objectui#5006
+    // closed the gap where this renderer accepted `0` and floored fractions while
+    // the contract rejected both. The coarse `number` arm here still cannot
+    // express the domain: `ComponentInput.type` has no integer/min/max slot, so
+    // `description` stays the only authoring-time expression of it, and spec
+    // stays the sole judge of values.)
     { name: 'maxVisible', type: 'number', label: 'Max Inline Actions', defaultValue: 3, description: 'How many header actions render as inline buttons on desktop before the rest fold into the overflow menu. A positive integer — the contract rejects 0 and fractional values. Two kinds of action are routed to the overflow menu regardless of this budget and never occupy an inline slot: an action whose locations declare record_more without record_header, and any action with component action:menu.' },
     { name: 'mobileMaxVisible', type: 'number', label: 'Max Inline Actions (Mobile)', defaultValue: 1, description: 'The same inline-button budget on mobile viewports, where horizontal room is scarce. A positive integer, defaulting to 1; the desktop half is Max Inline Actions, and the overflow routing rules stated there apply unchanged.' },
   ],

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -410,6 +410,35 @@ export interface ComponentInput {
    * one-element array back to the bare string, so the published
    * `sdui.manifest.json` gains arrays only where a union was really declared.
    *
+   * ## The arms are COARSE KINDS — and that is the ceiling (objectui#5006)
+   *
+   * An arm names a value's *kind*, never its *domain*. `'number'` is the only
+   * numeric arm and `ComponentInput` has no `integer` / `min` / `max` slot to
+   * pair with it, so a key whose contract is narrower than "some number" has
+   * no way to say so here. Worked example — `page:header.maxVisible`, whose
+   * spec type is a POSITIVE SAFE INTEGER: `@objectstack/spec` rejects `0`,
+   * `-1` and `1.5`, while this declaration's `'number'` arm admits all three
+   * and `checkType` raises no diagnostic on any of them.
+   *
+   * **Ruled (maintainer, 2026-08-17): the coarse arm plus `description` IS the
+   * publication face's expression ceiling today, and SPEC IS THE SOLE JUDGE OF
+   * VALUES.** So spell the domain out in `description`, in the author's own
+   * terms ("A positive integer — the contract rejects 0 and fractional
+   * values"), and let `os validate` / `os build` be the gate that enforces it.
+   * `description` documents, it does not check: objectui deliberately raises
+   * no authoring-time diagnostic on an out-of-domain value. A *renderer*
+   * reading such a key should therefore agree with spec rather than tolerate
+   * what spec rejects — `page:header`'s `readMax` was tightened to exactly the
+   * contract for this reason, so the loosest layer stops deciding behaviour.
+   *
+   * Two directions were **deferred**, not rejected on merit: giving
+   * `ComponentInput` real constraint slots (two sources of truth, free to
+   * drift), and binding `checkType` to spec's Zod member when a
+   * `ComponentPropsMap` entry exists (one truth, but couples `sdui-parser` to
+   * spec). The ruling names the reopen condition: **a measured case of an
+   * author — human or agent — shipping a spec-rejected value that objectui's
+   * silence let through.** Until that is measured, do not widen this field.
+   *
    * @example 'string'
    * @example ['string', 'object']   // a string or an inline translation map
    * @example ['string', 'number']   // element:text_input.defaultValue


### PR DESCRIPTION
Fixes #5006

Implements the maintainer's 2026-08-17 ruling (「同意」): **disposition 3 now, plus disposition 4's record. Dispositions 1 and 2 stay deferred** — see "Deliberately not taken" below.

## The defect: three authorities, two answers

Re-derived on `origin/main` @ `95cf24168` with `@objectstack/spec@17.0.0` installed. All three authorities still disagreed exactly as filed:

| authority | verdict on `page:header.maxVisible` |
|---|---|
| **spec** (`ComponentPropsMap['page:header']`) | `1`/`3`/`100` OK; `0` and `-1` → *"Too small: expected number to be greater than 0"*; `1.5` → *"Invalid input: expected int, received number"*; past `Number.MAX_SAFE_INTEGER` → *"Too big"* |
| **`checkType`** (`packages/sdui-parser/src/validate.ts`) | `case 'number': return typeof value === 'number';` — admits all of them, no diagnostic |
| **`readMax`** (the renderer) | accepted `0`, floored fractions, passed huge values straight through |

So the **loosest** of the three layers decided what shipped on screen, while `os validate` / `os build` rejected the very same metadata outright. An author writing `maxVisible: 0` got a green local render (0 inline buttons, everything swept into the overflow menu) and a rejection only at publish time.

> ⚠️ **Probe note for anyone re-measuring:** `ComponentPropsMap` is **not** on the `@objectstack/spec` package root. The root exports 125 names and this is not among them — it lives on the `@objectstack/spec/ui` subpath (`dist/ui/index.js`). Reading the root returns `undefined`, which would "measure" that spec imposes no constraint at all: the exact inverse of the truth. Every zero here was counter-probed against a known-present neighbour before being believed.

## Deliverable 1 — `readMax` tightens to the contract

`packages/components/src/renderers/layout/containers.tsx`

```
- typeof v === 'number' && Number.isFinite(v) && v >= 0 ? Math.floor(v) : undefined
+ typeof v === 'number' && Number.isSafeInteger(v) && v > 0 ? v : undefined
```

`Number.isSafeInteger` is the **exact** translation of spec's `{format:'safeint'}`, not an approximation. Measured against spec on every edge:

| value | spec | `Number.isInteger` | `Number.isSafeInteger` |
|---|---|---|---|
| `Number.MAX_SAFE_INTEGER` | OK | true | true |
| `MAX_SAFE_INTEGER + 2` | REJECT | true ❌ | false ✅ |
| `1e21` | REJECT | true ❌ | false ✅ |
| `Infinity` / `NaN` | REJECT | false | false |

Plain `Number.isInteger` would have disagreed with the contract on two of those. `isSafeInteger` also subsumes the old `Number.isFinite` guard.

## Deliverable 2 — the trade is recorded where authors look

`packages/types/src/base.ts` — `ComponentInput.type`'s doc comment, alongside the existing objectui#3832 note, now states that the coarse `number` arm plus `description` **is** the publication face's expression ceiling today, and that **spec is the sole judge of values**. It carries the worked `maxVisible` example, the reason `description` documents rather than checks, and the deferral with its reopen condition.

I also corrected a claim in the `inputs` block of `containers.tsx` that this PR falsifies — it read "`readMax` here is laxer than that — it accepts `0` and floors fractions", which stops being true as of this change.

## Clause-② — declared, not argued away

**Yes, this narrows the renderer's accept set.** A fraction that used to be floored is now rejected, and `0` no longer takes effect. A contract-rejected value falls back to the documented default (3 desktop / 1 mobile) instead of rendering.

It is a narrowing *toward* an already-published contract — spec has always rejected these values — but it changes the accept set, so it is declared rather than reasoned away. Producer sweep over `packages/`, `apps/`, `examples/`: **no `page:header` producer writes a rejected value**, so nothing in the tree changes behaviour.

## Scope: three other `maxVisible` readers, all untouched

`readMax` is `page:header`-only with exactly two call sites. Deliberately **not** swept in:

- **`action:bar`** reads `schema.maxVisible ?? 3` through a wholly separate reader and is **not in `ComponentPropsMap` at all**, so its constraint simply does not exist. Its `maxVisible: 0` fixture is legitimate and still passes. (Round 12's sweep reported only positive literals; there is in fact one `0`, and it belongs here — not to `readMax`.)
- **The notification stack** (`NotificationInline` / `NotificationBanners`) takes `maxVisible` from provider config.
- **`PresenceAvatars`** in `RecordDetailView` takes it as a React prop.

## Reverse verification — predicted before running, then observed

Reverted only the `readMax` expression, keeping all six new tests. **No build artifact sits between the edit and the thing under test**: the root vitest config aliases `@object-ui/components` to `packages/components/src`, so resolution never reaches the package `exports` → `dist`. No rebuild is required for the ablation to be real, and the restore leg was re-run and re-verified byte-identical to the committed fix (`git diff HEAD` empty).

| test | predicted | observed |
|---|---|---|
| rejects `maxVisible: 0` | RED at `getByRole(/Action A/)` | RED — *Unable to find ... `/Action A/i`* ✅ |
| rejects fractional `1.5` | RED at `getByRole(/Action B/)` | RED — *Unable to find ... `/Action B/i`* ✅ |
| rejects past `MAX_SAFE_INTEGER` | RED at `queryByRole(/Action D/).toBeNull()` | RED — *expected button to be null* ✅ |
| same domain on `properties.*` | RED at `getByRole(/Action A/)` | RED — *Unable to find ... `/Action A/i`* ✅ |
| guard: negative falls back | **GREEN both legs** | GREEN both legs |
| guard: positive safe int honoured | **GREEN both legs** | GREEN both legs |

Predicted 4 failed / 39 passed of 43 — **observed exactly that**. Direction was the ordinary reddening one.

**The last two assertions pin nothing about this change and are not counted as evidence for it.** A negative value already fell back (the old guard was `v >= 0`) and a positive safe integer was already honoured. They are labelled in the test file as regression guards only, kept so both halves of the domain are stated in one place.

## Gates, all run at final commit `616499ba7` (clean tree)

- `pnpm exec vitest run packages/components packages/types` — **202 files / 1932 tests passed**
- `pnpm exec vitest run apps/console/.../registry-inputs-spec-parity.test.ts .../ga-honoured-inputs-author-reach.test.ts` — **69 passed** (the parity gates that read this renderer's `inputs`)
- `pnpm --filter @object-ui/types --filter @object-ui/components type-check` — pass (note: this repo spells it `type-check`, hyphenated)
- `pnpm --filter ... lint` — **0 errors**
- `check:control-bytes` — OK (4685 files) · `check:doc-types` — OK · `check-changeset-no-major` — OK

Changeset: **`patch`** for `@object-ui/components` and `@object-ui/types`, with the narrowing spelled out as breaking semantics in the body.

## Deliberately not taken

Disposition 1 (giving `ComponentInput` `integer?`/`min?`/`max?` slots) and disposition 2 (binding `checkType` to spec's Zod member) were **deferred by the ruling**, not left undone by oversight. Both carry structural costs — two sources of truth free to drift, or coupling `sdui-parser` to spec — that need real pull to justify. The reopen condition is named in the ruling and recorded in the doc comment: *a measured case of an author, human or agent, shipping a spec-rejected value that objectui's silence let through.* objectui still raises **no** authoring-time diagnostic on an out-of-domain numeric value; that is the ruled state, not a gap this PR forgot.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_