### PR TITLE
fix(plugin-dashboard): ObjectMetricWidgetProps speaks the spec's I18nLabel, not the rc.6-retired key-reference form

### DIFF
--- a/.changeset/object-metric-label-i18n-5264.md
+++ b/.changeset/object-metric-label-i18n-5264.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/plugin-dashboard': minor
+---
+
+`ObjectMetricWidgetProps` now speaks `@objectstack/spec`'s `I18nLabel` vocabulary on `label`, `trend.label`, `description` and `title`.
+
+These four members still declared `string | { key?: string; defaultValue?: string }`
+— the key-reference label form `@objectstack/spec` RETIRED at 17.0.0-rc.6
+(objectstack#5055). The sibling `MetricWidgetProps` was migrated to
+`string | I18nLabel` for exactly this reason in objectui#4358; this interface was
+missed in that pass, and it was the last declaration of the retired shape in any
+package's shipped `src` (objectui#5264).
+
+It was not inert. `ObjectMetricWidget` forwards `label` / `description` / `trend`
+straight to `MetricWidget`, which resolves them with `pickLocalized`. The retired
+object matches no locale limb, so resolution fell through to that resolver's last
+resort — the first string property in insertion order — and a metric authored in
+the natural `{ key, defaultValue }` spelling painted the RAW DOTTED TRANSLATION KEY
+onto the KPI card as its visible label. Written the other way round the English
+fell out instead. That property-order dependence is why the defect never read as
+systematic in review.
+
+Breaking semantics, stated per this repo's version policy (objectui's own
+breaking changes ship as `minor` so the fixed group's major stays aligned with
+`@objectstack`; see AGENTS.md §版本号策略):
+
+- **What starts type-checking:** the inline per-locale map — `label={{ en:
+  'Revenue', 'zh-CN': '收入' }}` — which is the ONLY object form the spec admits
+  today. Against the old declaration it was a compile error (TS2322/TS2353,
+  excess property `en`), so a consumer writing the correct vocabulary could not
+  build. This is the substance of the change and it is a WIDENING.
+- **What stops type-checking:** nothing in practice. `I18nLabel`'s object half is
+  `InlineLocaleMap`, which erases to `Record<string, string>` in the emitted
+  `.d.ts` — the BCP-47 key regex is a Zod runtime refinement and does not survive
+  into the type — so `{ key, defaultValue }` remains structurally assignable. The
+  retired form is refused where refusal is expressible: `I18nLabelSchema` rejects
+  it at authoring time, in both property orders. No renderer-side tolerance was
+  added for it (AGENTS.md #0.1).
+- **Behaviour change on the drill-down panel title.** `drawerTitle` read
+  `title?.defaultValue` / `label?.defaultValue` directly. An inline per-locale map
+  has no such limb, so an authored drill title resolved to `''` and the drawer
+  silently fell back to the literal word "Details". It now resolves through the
+  same `pickLocalized` and the same UI language as the tile, so the drawer and the
+  card that opened it can no longer disagree. A metric still passing the retired
+  form (only reachable by cast, or from stored metadata) sees the drawer follow
+  the card instead of diverging from it.

--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -10,8 +10,8 @@ import React, { useState, useEffect, useContext, useCallback, useMemo } from 're
 import { SchemaRendererContext, SchemaRenderer, useFilterScope } from '@object-ui/react';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle } from '@object-ui/components';
 import { isDrillEnabled, resolveDrillTitle } from '@object-ui/core';
-import type { DrillDownConfig } from '@object-ui/types';
-import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
+import type { DrillDownConfig, I18nLabel } from '@object-ui/types';
+import { useLocalization, resolveFieldCurrency, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { MetricWidget } from './MetricWidget';
 import { OpenInListButton } from './OpenInListButton';
 import {
@@ -44,22 +44,40 @@ export interface ObjectMetricWidgetProps {
   aggregate?: { field: string; function: string; groupBy?: string };
   /** Filter conditions */
   filter?: any;
-  /** Static label for the metric */
-  label: string | { key?: string; defaultValue?: string };
+  /**
+   * The KPI's heading, in @objectstack/spec's `I18nLabel` vocabulary — a plain
+   * string or an inline per-locale map (`{ en: 'Revenue', 'zh-CN': '收入' }`).
+   *
+   * Was `string | { key?, defaultValue? }` — the key-reference form
+   * objectstack#5055 RETIRED at rc.6. The sibling `MetricWidgetProps` was
+   * migrated for this reason in objectui#4358; this interface was missed in
+   * that pass, and the omission was not inert (objectui#5264). This component
+   * forwards `label` straight to `MetricWidget`, which resolves it with
+   * `pickLocalized`. The retired object hits no locale limb, so resolution
+   * falls through to the last resort — the FIRST string property in insertion
+   * order — and `{ key, defaultValue }` written in that natural order paints
+   * the raw dotted translation key onto the card as its visible label.
+   *
+   * The producer side already says so: `ObjectMetricPropsSchema.label` in
+   * `@objectstack/spec/ui` is `I18nLabelSchema`, and its inline-map key regex
+   * rejects `key`/`defaultValue` by name. This declaration now agrees with it.
+   */
+  label: string | I18nLabel;
   /** Fallback static value (used when no dataSource or in demo mode) */
   fallbackValue?: string | number;
   /** Trend info */
   trend?: {
     value: number;
-    label?: string | { key?: string; defaultValue?: string };
+    /** Trend caption, same `I18nLabel` vocabulary as {@link ObjectMetricWidgetProps.label}. */
+    label?: string | I18nLabel;
     direction?: 'up' | 'down' | 'neutral';
   };
   /** Icon name or ReactNode */
   icon?: React.ReactNode | string;
   /** Additional CSS class */
   className?: string;
-  /** Description */
-  description?: string | { key?: string; defaultValue?: string };
+  /** Sub-caption under the value, same `I18nLabel` vocabulary as {@link ObjectMetricWidgetProps.label}. */
+  description?: string | I18nLabel;
   /** External data source (overrides context) */
   dataSource?: any;
   /** Visual color variant for the icon container */
@@ -85,8 +103,13 @@ export interface ObjectMetricWidgetProps {
    * to this metric, filtered by the same `filter` used for aggregation.
    */
   drillDown?: DrillDownConfig;
-  /** Title for the drill-down panel; defaults to the metric label. */
-  title?: string | { key?: string; defaultValue?: string };
+  /**
+   * Title for the drill-down panel; defaults to the metric label. Same
+   * `I18nLabel` vocabulary as {@link ObjectMetricWidgetProps.label}, and
+   * resolved through the same `pickLocalized` — see `drawerTitle` below, which
+   * used to read the retired form's `defaultValue` limb directly.
+   */
+  title?: string | I18nLabel;
   /**
    * Period-over-period comparison configuration — the executor's own
    * `{ kind, dimension? }` contract since objectstack#5011. When set, the
@@ -182,6 +205,10 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
   // Tenant default currency (localization.currency, ADR-0053) backstops a
   // currency field that declares no explicit code of its own.
   const { currency: tenantCurrency } = useLocalization();
+  // The UI language — what label TEXT follows (distinct from the tenant's
+  // number/currency locale above). Same source `MetricWidget` resolves its own
+  // heading against, so the drill-down drawer cannot disagree with the tile.
+  const { language } = useObjectTranslation();
   const inferredCurrency = useMemo(() => {
     if (currency) return currency;
     if (valueFieldDef?.type !== 'currency') return undefined;
@@ -347,11 +374,19 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
   // — the whole metric is the slice). Falls back to the metric label as
   // drawer title when no explicit `drillDown.title` template is set.
   const drillEnabled = isDrillEnabled(drillDown) && !!objectName && !!dataSource;
+  //
+  // `title` and `label` are `I18nLabel` (see the interface above), so they are
+  // resolved with `pickLocalized` — the same seam `MetricWidget` uses for the
+  // tile's own heading, so the drawer and the card it opened from agree on one
+  // locale. These two reads previously destructured `defaultValue` off the
+  // RETIRED key-reference form: an inline per-locale map has no such limb, so
+  // an authored `title` resolved to `''` and the drawer silently fell back to
+  // the literal word "Details" (objectui#5264).
   const drawerTitle = useMemo(() => {
-    const labelText = typeof label === 'string' ? label : (label?.defaultValue || '');
-    const titleText = typeof title === 'string' ? title : (title?.defaultValue || '');
+    const labelText = pickLocalized(label, language);
+    const titleText = pickLocalized(title, language);
     return resolveDrillTitle(drillDown, {}, titleText || labelText || 'Details');
-  }, [drillDown, label, title]);
+  }, [drillDown, label, title, language]);
 
   const drillDrawer = useMemo(() => {
     if (!drillEnabled) return null;

--- a/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.i18nLabel.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.i18nLabel.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5264 — `ObjectMetricWidgetProps` was the last interface in
+ * any package's shipped `src` still declaring the `{ key, defaultValue }`
+ * key-reference label form that objectstack#5055 RETIRED at rc.6. The sibling
+ * `MetricWidgetProps` was migrated for exactly this reason in objectui#4358;
+ * this one was missed in that pass.
+ *
+ * WHY IT WAS NOT MERELY INERT. `ObjectMetricWidget` forwards `label` /
+ * `description` / `trend` straight to `MetricWidget`, which resolves them with
+ * `pickLocalized`. The retired object hits no locale limb, so resolution falls
+ * through to the last resort — "first string property in insertion order" — and
+ * the natural `{ key, defaultValue }` spelling therefore paints the raw dotted
+ * translation key onto the KPI card. Write the same two properties the other
+ * way round and the English falls out instead. That PROPERTY-ORDER DEPENDENCE
+ * is why the defect never read as systematic, and it is covered here in both
+ * orders.
+ *
+ * DIRECTIONS, written before the reverse verification was run:
+ *
+ *  - **(a) inline-map `label` / `description` / `trend.label` on the CARD →
+ *    GREEN on both sides.** These three were already forwarded to
+ *    `pickLocalized` by `MetricWidget`, so the migration does not move them.
+ *    They are the non-vacuity floor: they prove the harness renders what it
+ *    claims to, so a red elsewhere is a real red.
+ *  - **(b) inline-map `title` in the DRILL-DOWN DRAWER → RED before.** The
+ *    drawer's `drawerTitle` read `title?.defaultValue` directly. An inline
+ *    per-locale map has no such limb, so an authored drill title resolved to
+ *    `''` and the drawer fell back to the literal word "Details" — a plausible
+ *    heading that silently discards what the author wrote.
+ *  - **(c) inline-map `label` as the drawer's fallback title → RED before**,
+ *    same limb, same substitution.
+ *  - **(d) card/drawer COHERENCE under the retired form, key-first → RED
+ *    before.** This is the order-dependence made executable without
+ *    fossilizing any resolved text. Before the change the two surfaces used
+ *    DIFFERENT resolvers — the card `pickLocalized` (order-dependent), the
+ *    drawer `.defaultValue` (order-independent) — so one KPI tile painted the
+ *    raw dotted key while the drawer it opened painted the English. They now
+ *    share one resolver and cannot disagree.
+ *  - **(e) card/drawer coherence under the retired form, defaultValue-first →
+ *    GREEN on both sides.** The other half of the order pair, and the reason
+ *    (d) is a genuine finding rather than a blanket failure: before the change
+ *    exactly ONE of the two orders diverged.
+ *  - **(f) the accept set — the inline map → RED before, at COMPILE time.**
+ *    This one was predicted the other way round and the prediction was wrong;
+ *    the measurement is recorded here because it changes what this migration
+ *    is. `I18nLabel`'s object half is `InlineLocaleMap`, and that erases to
+ *    `Record<string, string>` in the emitted `.d.ts` — the BCP-47 key regex is
+ *    a Zod RUNTIME refinement and does not survive into the type. So:
+ *
+ *      old `string | { key?: string; defaultValue?: string }`
+ *        accepts `{ key, defaultValue }` (both orders)
+ *        REJECTS `{ en, 'zh-CN' }` with TS2353 — excess property `en`
+ *      new `string | I18nLabel`
+ *        accepts `{ en, 'zh-CN' }`
+ *        still accepts `{ key, defaultValue }` — every string key fits a
+ *        `Record<string, string>` index signature
+ *
+ *    So this migration ADDS the only vocabulary the spec admits (a TS consumer
+ *    writing the correct form previously got a compile error) and REMOVES
+ *    nothing. It is a widening at the type level, not the narrowing it reads
+ *    like. The retired form is refused where refusal is actually expressible —
+ *    `I18nLabelSchema` at authoring time, pinned below in both orders.
+ *
+ *    That is also why there is no `@ts-expect-error` tombstone here: one was
+ *    written first and `tsc` reported both directives UNUSED. Per objectui#4032's
+ *    fixture-triage discipline the same trap applies to a tombstone as to a
+ *    fixture — an assertion that passes for the wrong reason is worse than none.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+// Imported from the package barrel at MODULE scope: the drill drawer renders
+// its body through `SchemaRenderer`, which resolves `object-data-table` from
+// the registry the barrel populates as a side effect. Module scope, never a
+// hook, per AGENTS.md's flaky-test rule (objectui#3010/#3021).
+import { ObjectMetricWidget } from '../index';
+
+afterEach(cleanup);
+
+/** The dotted translation key from the issue's measurement. */
+const KEY = 'crm.dashboards.sales.widgets.revenue.title';
+const ENGLISH = 'Total Revenue';
+
+/** The vocabulary the spec actually admits: an inline per-locale map. */
+const REVENUE = { en: 'Revenue', 'zh-CN': '收入' };
+const RECORDS = { en: 'Revenue records', 'zh-CN': '收入记录' };
+
+const makeSource = () => ({
+  aggregate: vi.fn(async () => [{ amount_sum: 120 }]),
+  find: vi.fn(async () => ({ data: [] })),
+  getObjectSchema: vi.fn(async () => ({ fields: {} })),
+});
+
+function renderIn(language: string, ui: React.ReactElement) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false, resources: {} }}>
+      {ui}
+    </I18nProvider>,
+  );
+}
+
+describe('ObjectMetricWidget — I18nLabel on the card (#5264 (a))', () => {
+  it('resolves a map `label` to the active locale', () => {
+    renderIn('zh', <ObjectMetricWidget objectName="deal" label={REVENUE} fallbackValue={42} />);
+    expect(screen.getByText('收入')).toBeTruthy();
+    expect(screen.queryByText(KEY)).toBeNull();
+  });
+
+  it('resolves a map `description` (the sub-caption slot)', () => {
+    renderIn('zh', (
+      <ObjectMetricWidget objectName="deal" label="Revenue" fallbackValue={42} description={RECORDS} />
+    ));
+    expect(screen.getByText('收入记录')).toBeTruthy();
+  });
+
+  it('resolves a map `trend.label`', () => {
+    renderIn('zh', (
+      <ObjectMetricWidget
+        objectName="deal"
+        label="Revenue"
+        fallbackValue={42}
+        trend={{ value: 12, direction: 'up', label: RECORDS }}
+      />
+    ));
+    expect(screen.getByText('收入记录')).toBeTruthy();
+  });
+
+  it('leaves a plain-string label exactly as authored', () => {
+    renderIn('zh', <ObjectMetricWidget objectName="deal" label="Revenue" fallbackValue={42} />);
+    expect(screen.getByText('Revenue')).toBeTruthy();
+  });
+});
+
+/** Open the KPI tile's drill-down and return the heading text the drawer shows. */
+async function openDrawerTitle(language: string, props: Record<string, unknown>) {
+  const src = makeSource();
+  renderIn(language, (
+    <ObjectMetricWidget
+      objectName="deal"
+      aggregate={{ field: 'amount', function: 'sum' }}
+      dataSource={src as unknown as never}
+      drillDown={{ enabled: true }}
+      {...(props as { label: string })}
+    />
+  ));
+  // The tile becomes `role="button"` only when a drill handler is attached, so
+  // this also asserts the drill is live rather than silently disabled.
+  fireEvent.click(await screen.findByRole('button'));
+  const heading = await screen.findByRole('heading');
+  return heading.textContent ?? '';
+}
+
+describe('ObjectMetricWidget — I18nLabel in the drill-down drawer (#5264 (b)(c))', () => {
+  it('paints an inline-map `title` in the drawer, not the literal "Details"', async () => {
+    const title = await openDrawerTitle('zh', { label: REVENUE, title: RECORDS });
+    expect(title).toBe('收入记录');
+    expect(title).not.toBe('Details');
+  });
+
+  it('falls back to the inline-map `label` when no `title` is authored', async () => {
+    const title = await openDrawerTitle('zh', { label: REVENUE });
+    expect(title).toBe('收入');
+    expect(title).not.toBe('Details');
+  });
+
+  it('still honours a plain-string `title`', async () => {
+    const title = await openDrawerTitle('en', { label: 'Revenue', title: 'Revenue records' });
+    expect(title).toBe('Revenue records');
+  });
+});
+
+/**
+ * The order-dependence, made executable. The retired form can only be reached
+ * through a cast now — which is the fix — so what is asserted here is not the
+ * resolved TEXT (that would fossilize an out-of-contract input) but that the
+ * card and the drawer it opens agree. Before the change they used two different
+ * resolvers and disagreed in exactly one of the two property orders.
+ */
+describe('ObjectMetricWidget — retired {key,defaultValue}: card and drawer agree (#5264 (d)(e))', () => {
+  it('key-first — the tile and its drawer paint the same text', async () => {
+    const retired = { key: KEY, defaultValue: ENGLISH } as unknown as string;
+    const src = makeSource();
+    renderIn('zh', (
+      <ObjectMetricWidget
+        objectName="deal"
+        label={retired}
+        aggregate={{ field: 'amount', function: 'sum' }}
+        dataSource={src as unknown as never}
+        drillDown={{ enabled: true }}
+      />
+    ));
+    const tile = await screen.findByRole('button');
+    const cardText = tile.textContent ?? '';
+    fireEvent.click(tile);
+    const drawerTitle = (await screen.findByRole('heading')).textContent ?? '';
+
+    // Whatever the card resolved to, the drawer resolved to the same thing.
+    expect(cardText).toContain(drawerTitle);
+    expect(drawerTitle).not.toBe('Details');
+  });
+
+  it('defaultValue-first — the tile and its drawer agree here too', async () => {
+    const retired = { defaultValue: ENGLISH, key: KEY } as unknown as string;
+    const src = makeSource();
+    renderIn('zh', (
+      <ObjectMetricWidget
+        objectName="deal"
+        label={retired}
+        aggregate={{ field: 'amount', function: 'sum' }}
+        dataSource={src as unknown as never}
+        drillDown={{ enabled: true }}
+      />
+    ));
+    const tile = await screen.findByRole('button');
+    const cardText = tile.textContent ?? '';
+    fireEvent.click(tile);
+    const drawerTitle = (await screen.findByRole('heading')).textContent ?? '';
+
+    expect(cardText).toContain(drawerTitle);
+    expect(drawerTitle).not.toBe('Details');
+  });
+
+  it('the two orders are NOT interchangeable — this is why the type had to narrow', async () => {
+    // Pure resolver characterization, no component: the same two properties in
+    // the two natural spellings resolve to DIFFERENT strings, one of them the
+    // raw dotted key. Neither spelling is reachable through the props type any
+    // more; this records what made the defect invisible in review.
+    const { pickLocalized } = await import('@object-ui/i18n');
+    expect(pickLocalized({ key: KEY, defaultValue: ENGLISH }, 'zh')).toBe(KEY);
+    expect(pickLocalized({ defaultValue: ENGLISH, key: KEY }, 'zh')).toBe(ENGLISH);
+  });
+});
+
+describe('ObjectMetricWidgetProps — the accept set after the migration (#5264 (f))', () => {
+  it('now accepts the inline per-locale map the spec admits — a COMPILE ERROR before', () => {
+    // The load-bearing assertion is the compiler's: `tsconfig.test.json` type-
+    // checks this file (chained from the package's `type-check` script), and
+    // against the retired declaration these three props were TS2353 — excess
+    // property `en` does not exist in `{ key?, defaultValue? }`. A consumer
+    // writing the ONLY vocabulary @objectstack/spec accepts could not compile.
+    const ok = (
+      <ObjectMetricWidget
+        objectName="deal"
+        label={REVENUE}
+        description={RECORDS}
+        title={RECORDS}
+        trend={{ value: 1, direction: 'up', label: RECORDS }}
+        fallbackValue={42}
+      />
+    );
+    expect(ok).toBeTruthy();
+  });
+
+  it('leaves the retired form refused where refusal is expressible — the spec, at authoring time', async () => {
+    // TypeScript cannot express this rejection: `I18nLabel`'s object half is
+    // `Record<string, string>`, so `key` and `defaultValue` are two ordinary
+    // string entries as far as the compiler is concerned. The refusal lives in
+    // the spec's runtime schema, whose own message names both properties.
+    // Contract-first (AGENTS.md #0.1): the producer is rejected at publish
+    // time rather than tolerated by a renderer-side fallback here.
+    const { I18nLabelSchema } = await import('@objectstack/spec/ui');
+    expect(I18nLabelSchema.safeParse({ key: KEY, defaultValue: ENGLISH }).success).toBe(false);
+    expect(I18nLabelSchema.safeParse({ defaultValue: ENGLISH, key: KEY }).success).toBe(false);
+    // Non-vacuity: the same schema accepts both admitted forms.
+    expect(I18nLabelSchema.safeParse(REVENUE).success).toBe(true);
+    expect(I18nLabelSchema.safeParse('Revenue').success).toBe(true);
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.i18nLabel.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.i18nLabel.test.tsx
@@ -77,7 +77,7 @@
 
 import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { I18nProvider } from '@object-ui/i18n';
 // Imported from the package barrel at MODULE scope: the drill drawer renders
 // its body through `SchemaRenderer`, which resolves `object-data-table` from


### PR DESCRIPTION
Fixes #5264

`ObjectMetricWidgetProps` was the last interface in any package's shipped `src` still declaring the `{ key, defaultValue }` key-reference label form that `@objectstack/spec` RETIRED at 17.0.0-rc.6 (objectstack#5055). The sibling `MetricWidgetProps` was migrated to `string | I18nLabel` for exactly this reason in #4358; this interface was missed in that pass. The four members — `label`, `trend.label`, `description`, `title` — now match the sibling verbatim.

Re-derived on current `origin/main` after #5207 landed: that PR re-keyed `dashboardComponents`, a different map, and did **not** touch any of these four members. `main` is merged into this branch.

## Clause-② — yes, and the card's framing was wrong; here is the measurement

This edits a published props interface's accept set, so it is declared rather than argued away. But the direction is the opposite of what the card and the triage comment assumed, and the difference is load-bearing enough that the changeset spells it out too.

`I18nLabel`'s object half is `InlineLocaleMap`, and that erases to `Record< string, string >` in the emitted `.d.ts` — the BCP-47 key regex is a Zod **runtime** refinement and does not survive into the type. Measured with `tsc` on this tree (both declarations, same six literals):

| assigned literal | old `string \| { key?: string; defaultValue?: string }` | new `string \| I18nLabel` |
|---|---|---|
| `{ key, defaultValue }` | accepts | **still accepts** |
| `{ defaultValue, key }` | accepts | **still accepts** |
| `{ en: 'Revenue', 'zh-CN': ... }` | **TS2353 — excess property `en`** | accepts |

**What stops type-checking for a downstream TS consumer: nothing.** Every string key fits a `Record< string, string >` index signature, so the retired shape stays structurally assignable.

**What starts type-checking: the inline per-locale map** — the only object form the spec admits today. Against the old declaration, a consumer writing the *correct* vocabulary got a compile error. That is the substance of this change, and it is a **widening**.

So the retired form is not removed by the type, because TypeScript cannot express that rejection here. It is refused where refusal *is* expressible — `I18nLabelSchema` at authoring time, in both property orders, verified in this PR's tests. No renderer-side tolerance was added for it (AGENTS.md #0.1).

A first draft of the tests did carry a `@ts-expect-error` tombstone asserting the retired branch was gone. `tsc` reported **both directives unused** (TS2578). That measurement is what produced the table above; the tombstone was replaced rather than weakened, because per #4032's discipline an assertion that passes for the wrong reason is worse than none.

## The runtime half — this is where the user-visible fix is

`drawerTitle` read `title?.defaultValue` and `label?.defaultValue` directly. An inline per-locale map has no such limb, so an authored drill-down title resolved to `''` and the panel silently fell back to the literal word **"Details"**. Both reads now go through `pickLocalized` against the same UI language the tile uses, so the drawer and the card that opened it cannot disagree.

## The order-dependence, made executable

This is what made the defect invisible in review, and covering only one property order proves half of it. The test does not assert the resolved *text* for the retired form — that would fossilize an out-of-contract input — it asserts that the tile and the drawer it opens **agree**:

```tsx
it('key-first — the tile and its drawer paint the same text', async () => {
  const retired = { key: KEY, defaultValue: ENGLISH } as unknown as string;
  // ... render, click the tile, read the drawer heading
  expect(cardText).toContain(drawerTitle);
  expect(drawerTitle).not.toBe('Details');
});
```

Before this change the two surfaces used **different** resolvers — the card `pickLocalized` (order-dependent), the drawer `.defaultValue` (order-independent) — so exactly one of the two orders diverged. That asymmetry is the order-dependence:

- **key-first → RED before.** Observed: `expected 'crm.dashboards.sales.widgets.revenue.…' to contain 'Total Revenue'` — the card painted the raw dotted key while the drawer painted the English. That is the issue's measurement, reproduced as a failure.
- **defaultValue-first → GREEN on both sides.** The other half of the pair, and the reason the first is a genuine finding rather than a blanket failure.

A third case pins the pure-resolver characterization in both orders, so the divergence is recorded independently of the components.

## Reverse verification

Original source restored from this branch's parent, new tests kept, directions predicted **before** running (they are written into the test file's header).

| leg | predicted | observed |
|---|---|---|
| card: map `label` / `description` / `trend.label` / plain-string control | 4 GREEN | 4 GREEN |
| drawer: map `title`; map `label` fallback | 2 RED | 2 RED — both got `'Details'` |
| drawer: plain-string `title` | GREEN | GREEN |
| coherence key-first / defaultValue-first | 1 RED / 1 GREEN | 1 RED / 1 GREEN |
| resolver characterization; `I18nLabelSchema` rejection; accept-set render | 3 GREEN | 3 GREEN |
| **vitest total** | **3 RED / 9 GREEN** | **3 failed / 9 passed** |
| `type-check` | RED on the inline-map props | RED — 7 errors |

One prediction missed: I wrote TS2353 and observed **TS2322**. Same meaning (the map is not assignable to the retired union) — the code differs because the failures land in JSX attribute position rather than a fresh literal binding. Recorded rather than smoothed over.

Restore leg: source restored byte-identically (`git diff --stat HEAD` empty), then 12/12 and `type-check` green again.

**Is a rebuild in the ablation's resolution path?** For the vitest leg, no — and it cannot hide a stale result, because nothing reads `dist` at all: the repo's `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src/`, and the ablated file is reached by a *relative* import (`../index` → `../ObjectMetricWidget`), which is always source. For the `type-check` leg, `tsconfig.test.json` sets `"paths": {}`, so `@object-ui/types` — where `I18nLabel` comes from — resolves through its built `.d.ts`; that artifact **is** in the path, so the dependency closure was built before any measurement was read, and it is unchanged by the ablation either way. The ablated file itself is pulled in as source by the relative import.

## The fixture sweep — result: zero conversions, and the zero is a reading

Per #4032's discipline, a fixture pinning the retired branch keeps passing precisely because nothing produces that shape any more. Every search below was counter-probed with a term known to be present in the same scope.

**Searches.** (1) Declaration grep for the retired form across every package's `src`: 4 hits, all four being the members migrated here. (2) Construction grep repo-wide over `.ts`/`.tsx`/`.json`, both property orders: 16 hits. (3) Object-form `label`/`title`/`description` in `examples/` and `apps/` JSON metadata: 0 hits (counter-probe: 4 plain `"label"` entries in the same dashboard file). (4) `plugin-dashboard`'s own test fixtures: every metric fixture uses a plain string.

**Verdicts.** All 16 construction hits are the *other*, live vocabulary — `KeyedI18nLabel` (`{ key, defaultValue?, params? }`), objectui's own reference-into-a-bundle type, resolved by `resolveKeyedI18nLabel` and explicitly distinguished from the spec's `I18nLabel` in `packages/types/src/base.ts`. None is a metric-widget label.

| fixture / source | verdict |
|---|---|
| `app-shell/src/views/__tests__/SearchResultsPage.records.test.tsx` (2) | **Leave** — `KeyedI18nLabel` object labels, live vocabulary |
| `app-shell/src/views/metadata-admin/issuePath.test.ts` | **Leave** — same |
| `apps/console/src/pages/system/__tests__/AppManagementPage.search.test.tsx` (2) | **Leave** — same |
| `apps/console/src/pages/system/__tests__/AppManagementPage.i18n.test.tsx` | **Leave** — same |
| `types/src/__tests__/base-schema-label-vocabulary.test.ts` (2) | **Leave** — pins `KeyedI18nLabel` *as* the distinct type; converting it would erase the distinction |
| `components/src/__tests__/toggle-aria-label-keyed.test.tsx` (2) | **Leave** — `ariaLabel` is `KeyedI18nLabel` by ADR, not `I18nLabel` |
| `react/src/__tests__/SchemaRenderer.aria.test.tsx` | **Leave** — same |
| `auth/src/org-roles.ts` (3), `app-shell/src/console/ai/AiChatPage.tsx` (2) | **Leave** — production `KeyedI18nLabel` constants, not fixtures |
| **any fixture constructing the retired form for a metric label surface** | **none exist** |

So there was nothing to convert and no existing fixture to turn into a tombstone. The tombstone had to be **authored**, which is what the accept-set tests are — and authoring it is what exposed that the `@ts-expect-error` spelling would have been the failure mode this discipline warns about.

## Out of scope, filed

- **#5301** — `WidgetConfigPanel`'s private `resolveLabel` is the fourth copy of the resolver #4032 swept, and it is inverted: it returns `""` for the spec's inline locale map and resolves only the retired form. Because its result seeds the editable draft, a map-titled widget opens the config panel EMPTY and a save writes `''` over the author's map. Not addressed here: it is a different member surface, and unlike these four the fix is not mechanical — the function has no locale in scope, so it needs a decision about which locale an authoring panel shows and what a save writes back.

## Verification

All run at `2c64c75f2` (the merge commit, and this branch's head).

- `pnpm exec vitest run packages/plugin-dashboard` from the repo root (per #3378) — **65 files, 590 tests, all passing**, including the 12 new ones.
- `pnpm --filter @object-ui/plugin-dashboard run type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`; the hyphenated script name is echoed in the output, so it really ran rather than matching zero scripts).
- `pnpm --filter @object-ui/plugin-dashboard run lint` — 0 errors, 317 warnings, all pre-existing `no-explicit-any`; the new files contribute none.
- Dependency closure built first (`--filter '@object-ui/plugin-dashboard^...' build`), then the package; the emitted `dist/ObjectMetricWidget.d.ts` carries `string | I18nLabel`, so the contract change reaches consumers.
- Gates derived from the changed paths rather than from a carried list: `check:control-bytes`, `check:phantom-deps`, `check:self-import`, `check:spec-symbols`, `check:doc-types`, `check:i18n-keys`, `check:i18n-drift`, `check:i18n-dead-keys`, `changeset:check`, `check-changeset-presence`, `type-check:coverage`, `lint:coverage` — all green. `check:phantom-deps` in particular because the new test imports `@objectstack/spec/ui`.

## Changeset

`minor`, never `major` — per AGENTS.md §版本号策略, objectui's major is pinned to `@objectstack`'s so "same major ⇒ compatible" holds, and objectui's own breaking changes ship as `minor` with the breaking semantics written into the changeset body. This card is a contract-surface edit, so the body spells out all three consequences: what starts type-checking, what does not stop, and the drill-down title behaviour change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_