### PR TITLE
fix(ci): bound Chromium provisioning so a stalled apt mirror cannot cancel Build &amp; E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,13 +585,46 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
+      # ── No `apt-get` on this path any more (objectui#5304) ────────────────
+      # `playwright install --with-deps` / `install-deps` shell out to
+      # `apt-get update` as root. On 2026-08-19 that hung this job three times,
+      # each for the full 30-minute ceiling, with a byte-identical last line —
+      # `Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease
+      # [126 kB]` — after the runner's Azure mirror answered `Ign:` for all four
+      # noble indexes and apt fell back to archive.ubuntu.com:
+      #   #5290 job 95986117935  07:05:48 -> cancelled 07:34:39 (30m14s)
+      #   #5290 job 95993643751  07:38:31 -> cancelled 08:07:32 (30m18s, re-run)
+      #   #5294 job 95988703670  07:17:27 -> cancelled 07:46:21 (30m17s)
+      # apt has no timeout covering a mirror that connects and then trickles, so
+      # the only backstop was `timeout-minutes: 30` — which converts a transient
+      # network fault into a CANCELLED check: a gate that reports nothing at all.
+      #
+      # A transient, not a property of the workflow: on #5290 the
+      # `Live E2E (informational)` job (95986118258) ran the same `install-deps`
+      # on the same commit in the same minute and went green in 3m26s. Which is
+      # why the call has to be bounded rather than trusted.
+      #
+      # Browser binaries come from the cache step above, never from apt
+      # (measured on the run that then hung: `Cache hit for:
+      # playwright-Linux-1.62.1`, 269 MB restored). `install` without
+      # `--with-deps` fetches them from Playwright's CDN and touches no mirror,
+      # so the cache-miss path is safe as spelled.
       - name: Install Playwright browsers
         if: steps.relevant.outputs.should_run == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
 
-      - name: Install Playwright system dependencies
-        if: steps.relevant.outputs.should_run == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
+      # The system libraries are on the `ubuntu-latest` image already — it ships
+      # Chrome, Edge and Firefox, whose shared-library closure is the one
+      # `install-deps chromium` asks for. Rather than assume that, this step
+      # PROVES it on every run by launching the same bundled Chromium the suite
+      # launches, and reaches for apt only if the launch fails — bounded, so a
+      # stalled mirror costs seconds instead of the job. It is not a softener:
+      # if no browser can be made to launch the script exits non-zero and this
+      # job goes red. Rationale and the incident log: the script's header;
+      # behaviour pinned by `scripts/__tests__/ensure-chromium-ready.test.ts`.
+      - name: Ensure Chromium can launch
+        if: steps.relevant.outputs.should_run == 'true'
+        run: bash scripts/ensure-chromium-ready.sh
 
       - name: Run E2E tests
         if: steps.relevant.outputs.should_run == 'true'

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -146,13 +146,20 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
+      # Same provisioning shape as `ci.yml`'s `Build & E2E`, and it carries the
+      # same exposure: `--with-deps` / `install-deps` run `apt-get update` with
+      # nothing bounding it. That is what hung `Build & E2E` three times on
+      # 2026-08-19 for the full job ceiling (objectui#5304); this job's ceiling
+      # is 40 minutes, so the same mirror stall would cost even more here. The
+      # browsers come from the cache step above, and the launch probe in the
+      # script is what proves a browser exists. See the script header for the
+      # measured incident log.
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
 
-      - name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
+      - name: Ensure Chromium can launch
+        run: bash scripts/ensure-chromium-ready.sh
 
       - name: Run live E2E allowlist
         run: pnpm test:e2e:live:ci

--- a/scripts/__tests__/ensure-chromium-ready.test.ts
+++ b/scripts/__tests__/ensure-chromium-ready.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#5304 — `Build & E2E` hung inside `apt-get update` and was cancelled
+ * at the 30-minute job ceiling, three times, with a byte-identical last line:
+ *
+ *   Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+ *
+ *   PR #5290 job 95986117935  07:05:48 -> cancelled 07:34:39 (30m14s)
+ *   PR #5290 job 95993643751  07:38:31 -> cancelled 08:07:32 (30m18s)  (re-run)
+ *   PR #5294 job 95988703670  07:17:27 -> cancelled 07:46:21 (30m17s)
+ *
+ * The apt call was not in the workflow — it is what `playwright install-deps`
+ * shells out to. Nothing bounded it, so a mirror that accepts the connection
+ * and then never finishes the transfer consumed the entire job and left the
+ * check `cancelled`: a gate that reports NOTHING, which is the worst of the
+ * three possible outcomes.
+ *
+ * `scripts/ensure-chromium-ready.sh` replaces the unconditional apt call with
+ * "prove the browser launches; reach for apt only if it does not, and bound it
+ * when you do". The four cases below are the whole contract, and the third is
+ * the direct regression pin: with apt stubbed to hang forever, the script must
+ * still terminate.
+ *
+ * These run without a browser and without a network — both the launch probe and
+ * the dependency install are substituted through the documented env seams. That
+ * is deliberate: GitHub Actions cannot be run locally, so the logic that has to
+ * survive a stalled mirror is pinned here, where it CAN be measured, rather
+ * than only in a workflow nobody can execute outside CI.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const script = path.join(repoRoot, 'scripts/ensure-chromium-ready.sh');
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  elapsedMs: number;
+}
+
+function run(env: Record<string, string>): RunResult {
+  const startedAt = Date.now();
+  const result = spawnSync('bash', [script], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    elapsedMs: Date.now() - startedAt,
+  };
+}
+
+/** A fresh marker path that no test shares with another. */
+function marker(name: string): string {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), `os-5304-${name}-`)), 'deps-ran');
+}
+
+describe('ensure-chromium-ready.sh — apt is off the happy path', () => {
+  it('never invokes the dependency install when Chromium already launches', () => {
+    const ran = marker('happy');
+
+    const result = run({
+      OS_CHROMIUM_PROBE_CMD: 'true',
+      OS_CHROMIUM_DEPS_CMD: `touch ${ran}`,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(
+      fs.existsSync(ran),
+      'The dependency install ran even though Chromium launched. That is the objectui#5304 ' +
+        'exposure back again: an unconditional apt-get on the critical path of the gate.',
+    ).toBe(false);
+    expect(result.stdout).toMatch(/No apt-get on this path/);
+  });
+});
+
+describe('ensure-chromium-ready.sh — recovery when a library really is missing', () => {
+  it('installs the system libraries and succeeds once Chromium launches', () => {
+    const ran = marker('recover');
+
+    // The probe fails until the install has run, then succeeds — the shape of a
+    // runner image that genuinely lost a shared library.
+    const result = run({
+      OS_CHROMIUM_PROBE_CMD: `test -f ${ran}`,
+      OS_CHROMIUM_DEPS_CMD: `touch ${ran}`,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(fs.existsSync(ran)).toBe(true);
+    expect(result.stdout).toMatch(/Chromium launches after installing its system libraries/);
+  });
+});
+
+describe('ensure-chromium-ready.sh — a hanging apt cannot hang the job (the #5304 pin)', () => {
+  it('terminates well inside the job ceiling when the dependency install never returns', () => {
+    const result = run({
+      OS_CHROMIUM_PROBE_CMD: 'false',
+      // Stands in for `apt-get update` against the stalled mirror: it accepts
+      // the call and never comes back.
+      OS_CHROMIUM_DEPS_CMD: 'sleep 600',
+      OS_CHROMIUM_DEPS_TIMEOUT: '2',
+    });
+
+    // The defect was unbounded waiting, so the assertion is on the clock. 600s
+    // is what the stub would take unbounded; the real incident took 1_800s.
+    expect(
+      result.elapsedMs,
+      `The script ran for ${result.elapsedMs}ms against a dependency install that never ` +
+        'returns. Unbounded again — this is exactly what cancelled three jobs in objectui#5304.',
+    ).toBeLessThan(60_000);
+    expect(result.status, 'a browser that never became usable must still fail the job').not.toBe(0);
+    expect(result.stderr).toMatch(/objectui#5304 signature/);
+  }, 120_000);
+});
+
+describe('ensure-chromium-ready.sh — the gate still reports', () => {
+  it('fails the job when Chromium cannot launch even after the install', () => {
+    const result = run({
+      OS_CHROMIUM_PROBE_CMD: 'false',
+      OS_CHROMIUM_DEPS_CMD: 'true',
+    });
+
+    expect(
+      result.status,
+      'Exiting 0 with no usable browser would let the E2E suite report on a browser it never ' +
+        'had. The point of #5304 is to RESTORE the signal, so this path must be red.',
+    ).toBe(1);
+    expect(result.stderr).toMatch(/must not report green/);
+  });
+});
+
+describe('the workflows actually use it', () => {
+  const workflows = ['.github/workflows/ci.yml', '.github/workflows/live-e2e.yml'];
+
+  /**
+   * Whole-line comments removed. Required, not cosmetic: both workflows now
+   * explain the incident in prose and name the very spellings asserted against
+   * below, so a scan that counted the prose would report an unbounded apt call
+   * that no step makes.
+   */
+  const withoutComments = (yaml: string): string =>
+    yaml
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n');
+
+  it.each(workflows)('%s calls the script instead of shelling straight to apt', (file) => {
+    const yaml = withoutComments(fs.readFileSync(path.join(repoRoot, file), 'utf8'));
+
+    expect(
+      yaml,
+      `${file} must drive Chromium provisioning through scripts/ensure-chromium-ready.sh — ` +
+        'that is the only place the apt call is bounded.',
+    ).toMatch(/ensure-chromium-ready\.sh/);
+
+    // The two spellings that reintroduce the unbounded `apt-get update`.
+    // `playwright install chromium` (no `--with-deps`) is deliberately still
+    // allowed and is what the cache-miss step runs: it downloads browser
+    // binaries from Playwright's CDN and touches no apt mirror.
+    expect(
+      yaml,
+      `${file} reintroduces an unbounded apt-get: 'playwright install --with-deps' and ` +
+        "'playwright install-deps' both run 'apt-get update' with no timeout, which is the " +
+        'objectui#5304 defect. Let scripts/ensure-chromium-ready.sh decide, and bound, that call.',
+    ).not.toMatch(/playwright\s+install(-deps|\s+--with-deps)/);
+  });
+});

--- a/scripts/ensure-chromium-ready.sh
+++ b/scripts/ensure-chromium-ready.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Make the Playwright jobs independent of Ubuntu's apt mirrors (objectui#5304).
+#
+# ── What went wrong ───────────────────────────────────────────────────────────
+# `playwright install --with-deps` / `playwright install-deps` shell out to
+# `apt-get update` as root. On 2026-08-19 that hung `Build & E2E` three times,
+# each for the full 30-minute job ceiling, with a byte-identical last line:
+#
+#   Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+#
+#   PR #5290 job 95986117935  07:05:48 -> cancelled 07:34:39 (30m14s)
+#   PR #5290 job 95993643751  07:38:31 -> cancelled 08:07:32 (30m18s)  (re-run)
+#   PR #5294 job 95988703670  07:17:27 -> cancelled 07:46:21 (30m17s)
+#
+# In each run the runner's `azure.archive.ubuntu.com` mirror answered `Ign:` for
+# all four noble indexes, apt fell back to `archive.ubuntu.com`, started three
+# InRelease fetches and never returned. apt applies no timeout that covers a
+# mirror which accepts the connection and then trickles, so the only backstop
+# was the job's `timeout-minutes` — which turns a transient mirror fault into a
+# cancelled gate that reports nothing.
+#
+# It is a transient rather than a property of the workflow: on #5290 the
+# `Live E2E (informational)` job (95986118258) ran the SAME `install-deps` step
+# on the SAME commit in the SAME minute and finished green in 3m26s. That is
+# precisely why the call has to be bounded rather than trusted.
+#
+# ── Why the happy path needs no apt at all ────────────────────────────────────
+# The browser binaries come from the `actions/cache` step, not from apt
+# (measured on the very run that then hung: `Cache hit for:
+# playwright-Linux-1.62.1`, 269 MB restored). The system libraries come from the
+# runner image, which ships Google Chrome, Microsoft Edge and Firefox — their
+# shared-library closure is the one `install-deps chromium` asks for.
+#
+# So: probe first, and only reach for apt if the probe says a library really is
+# missing. The probe is the honest test — it launches the same bundled Chromium
+# the suite launches, in the same environment, on every run. Nothing here is
+# assumed about the image; if the assumption above ever stops holding, the
+# recovery path below runs and says so in the log.
+#
+# ── Why this does not make the gate quieter ───────────────────────────────────
+# Every exit is a verdict. If Chromium cannot launch and apt cannot fix it, this
+# script exits non-zero and the job goes RED — it is never skipped, never
+# `continue-on-error`, and the E2E suite still has to pass afterwards. What
+# changes is only that a stalled mirror costs seconds instead of consuming the
+# whole job ceiling and cancelling the check.
+set -uo pipefail
+
+# Bounds the apt recovery path. Deliberately far below any job `timeout-minutes`
+# so this script can never be the thing that consumes the ceiling.
+DEPS_TIMEOUT=${OS_CHROMIUM_DEPS_TIMEOUT:-240}
+
+# Test seams. `scripts/__tests__/ensure-chromium-ready.test.ts` substitutes both
+# so the four branches below can be exercised without a browser or a network —
+# in particular the one that matters, "a hanging apt cannot hang the job".
+DEPS_CMD=${OS_CHROMIUM_DEPS_CMD:-"pnpm exec playwright install-deps chromium"}
+PROBE_CMD=${OS_CHROMIUM_PROBE_CMD:-}
+
+# Launches the bundled Chromium exactly as `playwright.config.ts` does — its
+# `chromium` project is `devices['Desktop Chrome']` with no `channel`, so the
+# default launch is the representative one.
+probe() {
+  if [ -n "$PROBE_CMD" ]; then
+    bash -c "$PROBE_CMD"
+    return $?
+  fi
+  node --input-type=module -e '
+    import { chromium } from "@playwright/test";
+    const browser = await chromium.launch();
+    await browser.close();
+  '
+}
+
+if probe; then
+  echo "Chromium launches with the libraries already present on this image."
+  echo "No apt-get on this path (objectui#5304)."
+  exit 0
+fi
+
+echo "---"
+echo "Chromium did not launch, so a system library is genuinely missing."
+echo "Falling back to 'playwright install-deps', bounded at ${DEPS_TIMEOUT}s so a"
+echo "stalled Ubuntu mirror cannot hang this job the way it did in objectui#5304."
+
+# `-k` escalates to KILL if apt ignores the TERM: a process blocked in a socket
+# read is exactly the shape that does. 124 is timeout's own "deadline expired".
+timeout -k 15s "${DEPS_TIMEOUT}s" bash -c "$DEPS_CMD"
+deps_status=$?
+
+if [ "$deps_status" -eq 124 ] || [ "$deps_status" -eq 137 ]; then
+  echo "install-deps exceeded ${DEPS_TIMEOUT}s and was killed (exit ${deps_status})." >&2
+  echo "This is the objectui#5304 signature: an apt mirror that accepts the" >&2
+  echo "connection and then never completes the transfer." >&2
+elif [ "$deps_status" -ne 0 ]; then
+  echo "install-deps failed with exit ${deps_status}." >&2
+else
+  echo "install-deps completed."
+fi
+
+# Whatever apt did or did not manage, the question is unchanged and is settled
+# the same way: can Chromium launch? Only the probe may answer it.
+if probe; then
+  echo "Chromium launches after installing its system libraries."
+  exit 0
+fi
+
+echo "---" >&2
+echo "Chromium still cannot launch after the recovery attempt above." >&2
+echo "Failing the job: the E2E suite cannot produce a verdict without a browser," >&2
+echo "and a gate that cannot produce a verdict must not report green." >&2
+exit 1


### PR DESCRIPTION
Fixes #5304

`Build & E2E` hung inside `apt-get update` and was cancelled at the 30-minute
ceiling. This makes the job independent of Ubuntu's apt mirrors, without making
the gate quieter: every path here still ends in a verdict.

## What is measured, and what is reasoned

Everything in this section is **measured from real job logs**, not read off the
YAML. Job ids are given so each line can be re-checked.

### The hang is in `Install Playwright system dependencies`, not in the build

The issue body says the job "never reaches the build or the E2E run". That is
**not what the logs show**, and the correction matters because it names the
step to fix. In job `95986117935` (PR #5290) the console build *completed*:

```
07:05:05.7607105Z  built in 6.69s
07:05:05.8579595Z Console build artifact is ready
07:05:06.5843307Z Cache hit for: playwright-Linux-1.62.1
07:05:09.7439407Z ##[group]Run pnpm exec playwright install-deps chromium
07:05:10.5408963Z Switching to root user to install dependencies...
```

The browser cache **hit** (269 MB restored), so the step that ran was
`Install Playwright system dependencies`, i.e. `playwright install-deps
chromium`, which shells out to `apt-get update` as root. That is where it
stopped. (The "~4.8 KB total log" in the card is the log's **line** count,
4853 lines, not its size.)

### Three occurrences, one signature

The runner's Azure mirror answered `Ign:` for all four noble indexes, apt fell
back to `archive.ubuntu.com`, began three InRelease fetches, and never returned:

| PR | job | last line | cancelled |
|---|---|---|---|
| #5290 | `95986117935` | `Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]` 07:05:48 | 07:34:39 (30m14s) |
| #5290 (re-run) | `95993643751` | same line, 07:38:31 | 08:07:32 (30m18s) |
| #5294 | `95988703670` | same line, 07:17:27 | 07:46:21 (30m17s) |

The third row is new here — PR #5290's job was re-run and hung a second time
with the identical signature.

### It is a transient, which is exactly why it must be bounded

On PR #5290, the `Live E2E (informational)` job `95986118258` ran the **same**
`install-deps` step, on the **same** commit, starting in the **same minute**
(07:04:25), and finished green in 3m26s while `Build & E2E` hung. So the mirror
stall is per-runner luck, not a property of the workflow — and a call whose
success depends on luck must not be able to consume the job ceiling.

### Correction: PR #5292 did not short-circuit

The card treats #5292's sub-2-minute pass as evidence of a path-filtered
short-circuit on which "a green proves nothing". Its job log (`95987067483`)
shows it took the **full** leg — it ran the E2E suite:

```
07:10:42.5293894Z   23 skipped
07:10:42.5294151Z   10 passed (17.1s)
```

Reading the filter confirms it: `should_run` is false only when **every**
changed file matches `**/*.md`, `content/**`, `docs/**`, `apps/site/**` or
`.changeset/**`. #5292 changed `eslint-rules/**` and `eslint.config.js`, which
match none of them. The job is simply about two minutes long when apt behaves.
So the fault is not "the full leg is always broken" — it is a transient that,
when it lands, costs the entire 30 minutes.

## The fix

Two changes, both of which follow from "the browsers do not come from apt".

**1. Take apt off the happy path.** The cache-miss step drops `--with-deps`:

```
- run: pnpm exec playwright install --with-deps chromium
+ run: pnpm exec playwright install chromium
```

Browser binaries come from Playwright's CDN (and, in practice, from the
`actions/cache` step, which was measured hitting on the very run that hung).
Neither touches an Ubuntu mirror.

**2. Replace the unconditional `install-deps` with a probe that proves a browser
exists, and bound the apt call to the case where it does not.**
`scripts/ensure-chromium-ready.sh` launches the same bundled Chromium the suite
launches (`playwright.config.ts`'s `chromium` project is
`devices['Desktop Chrome']` with no `channel`, so the default launch is the
representative one). If it launches, the job proceeds and no apt runs at all. If
it does not, the script runs `install-deps` under `timeout -k 15s 240s`, then
**re-probes** — and if a browser still cannot be launched it exits non-zero and
the job goes red.

The claim "the `ubuntu-latest` image already carries these libraries" is
**reasoned, not measured** — the image ships Chrome, Edge and Firefox, whose
shared-library closure is the one `install-deps chromium` requests. The design
does not depend on that reasoning being right: the probe measures it on every
run, and the bounded recovery path is what handles it being wrong.

### Why this does not weaken the gate

- The job is never skipped, never `continue-on-error`, and the timeout is not
  raised. The E2E suite still runs and still decides the check.
- The one new failure mode — no browser can be made to launch — is a **red**
  job with a named reason, not a green one and not a cancelled one.
- The previous behaviour produced `cancelled`, which reports *nothing*. Turning
  that into either green or red is a strict increase in signal.

## Tests

CI cannot be run locally, so the logic that has to survive a stalled mirror is
pinned where it *can* be measured: `scripts/__tests__/ensure-chromium-ready.test.ts`
drives the script with the launch probe and the dependency install substituted
through documented env seams. Six tests:

1. Chromium already launches, so the dependency install is **never invoked**.
2. Probe fails, install fixes it, probe passes, exit 0.
3. **The regression pin** — the install is stubbed as `sleep 600` and the probe
   always fails: the script must still terminate. Asserts on the clock.
4. Probe never passes, so the job **fails** (the gate still reports).
5-6. Both workflows call the script and neither reintroduces
   `playwright install --with-deps` or `playwright install-deps` (comments
   stripped first, since both files now discuss those spellings in prose).

Verified at `fde19d0c8` (the final commit; working tree byte-identical to HEAD):
`pnpm exec vitest run scripts/` -> **56 files, 1278 tests passed**, plus
`node scripts/check-control-bytes.mjs` and `node scripts/check-changeset-presence.mjs`
both exit 0.

**Reverse verification.** With `timeout -k 15s "${DEPS_TIMEOUT}s"` removed from the
script and nothing else changed, test 3 fails as predicted — and fails on the
clock, having waited the full stub:

```
AssertionError: The script ran for 600014ms against a dependency install that
never returns. ... expected 600014 to be less than 60000
```

That run also reproduces the shape of the CI defect locally: vitest's own
120s per-test timeout could not interrupt it, because the wait is synchronous —
just as `timeout-minutes` could only cancel the job, never recover it. Restored,
the same file runs in 2.72s.

No build artifacts are involved: the test executes the script from the working
tree via `bash` and reads the workflow YAML from disk, so there is no `dist/`
that could make an ablation falsely green.

## Which leg this PR takes

**The full leg.** The filter is the `Decide whether this change needs a full
run` step in the `e2e` job; `should_run=false` requires every changed file to
match `**/*.md`, `content/**`, `docs/**`, `apps/site/**` or `.changeset/**`.
This PR changes `.github/workflows/ci.yml`, `.github/workflows/live-e2e.yml`,
`scripts/ensure-chromium-ready.sh` and
`scripts/__tests__/ensure-chromium-ready.test.ts` — none matches any of the
five, so `should_run` is `true`. It is also the strongest possible case: the
diff edits the `e2e` job itself, so the run exercises the new steps directly.

## File surface

Declared surface, as the claim comment asks:

- `.github/workflows/ci.yml` — the `e2e` job's two Playwright steps
- `.github/workflows/live-e2e.yml` — the same two steps, same defect
- `scripts/ensure-chromium-ready.sh` (new)
- `scripts/__tests__/ensure-chromium-ready.test.ts` (new)

`live-e2e.yml` is included deliberately: it is the identical two-step shape with
the identical unbounded apt call, under a **40**-minute ceiling, so the same
stall costs more there. It is the same defect class, the correct form is pinned
by the fix landing here, no other open PR holds the file, and it adds no new
verification surface. Leaving it would have left the next stall a live hazard.

**Serial constraint respected.** PR #5295 holds
`.github/workflows/cross-repo-issue-closer.yml`, `.github/workflows/lint.yml`,
root `package.json` and `pnpm-lock.yaml`. This PR touches none of those four.

No changeset: `node scripts/check-changeset-presence.mjs` reports `0 of them
under the src/ of a package the release covers` and exits 0.

## Not done here, deliberately

The card rules `required_status_checks` on the `main` ruleset out of scope, and
that is untouched. So a cancelled or red `Build & E2E` is still invisible to the
merge machinery — this PR restores the *signal*, not its enforcement. #5304
records that gap and it remains the maintainer's call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_