### PR TITLE
fix(plugin-form): tick EmbeddableForm's thank-you countdown

### DIFF
--- a/.changeset/embeddable-form-thankyou-countdown-tick-5083.md
+++ b/.changeset/embeddable-form-thankyou-countdown-tick-5083.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+A public form's thank-you countdown ("Redirecting in {{seconds}} seconds…") now
+actually counts down, instead of rendering a number once and leaving it frozen
+for the whole wait.
+
+All ten locale packs document `publicForm.redirecting`'s `{{seconds}}` as "the
+remaining seconds", but `EmbeddableForm` computed it exactly once — at the render
+that first shows the thank-you panel — from `pendingRedirect.delayMs`, and never
+touched it again. On the 3 second default delay, a submitter saw a fully static
+"Redirecting in 3 seconds…" for the entire wait (objectui#5083).
+
+The number is now owned by a per-second `setInterval`, on the same ownership
+model PR #5070 established for the redirect wait itself: an effect keyed on the
+accepted destination (`pendingRedirect`), cancelled on unmount and on
+`handleReset`'s `Submit Another Response` — the exact regression surface
+objectui#5049 fixed for the navigation timer, restated here rather than
+reintroduced. The interval also stops itself once it reaches 0, rather than
+ticking indefinitely past a wait that has already ended.
+
+Nothing about WHICH destinations are followed or refused changes
+(`isRedirectUrlSafe` / `allowedRedirectHosts`, objectui#4989), and neither does
+the navigation wait's own ownership (objectui#5049 / PR #5070) — this is the
+display only.

--- a/packages/plugin-form/src/EmbeddableForm.redirectCountdownTick.test.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.redirectCountdownTick.test.tsx
@@ -76,6 +76,17 @@
  *    reverted code — the suite fails at (1) before getting there — so they
  *    are not independently informative in THIS reversion; they are pinned by
  *    the fact that (1) already fails.
+ *
+ * Measured (reverting `EmbeddableForm.tsx` only, to
+ * `de4e29a81` — one commit before this fix, keeping every test in this file
+ * unchanged): all three tests fail, each with the identical
+ * `AssertionError: expected +0 to be 1` at the `armed.length` check inside
+ * `submitAndWaitForCountdown` — exactly (1). The `Redirecting in 4 seconds`
+ * `vi.waitFor` immediately above it did not itself report a failure in any
+ * of the three runs, consistent with (2): it is satisfied by the reverted
+ * code too, so its own green tells you nothing about whether this fix is
+ * present. Restoring the committed `EmbeddableForm.tsx` returns all three
+ * tests to green with no other changes.
  */
 
 import React from 'react';

--- a/packages/plugin-form/src/EmbeddableForm.redirectCountdownTick.test.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.redirectCountdownTick.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5083 — `EmbeddableForm`'s thank-you countdown must actually count
+ * down.
+ *
+ * The panel's "Redirecting in {{seconds}} seconds…" line is documented, in
+ * all ten locale packs (`packages/i18n/src/locales/*.ts`,
+ * `publicForm.redirecting`), as showing "the remaining seconds". Before this
+ * fix the number was computed exactly once — at the render that first shows
+ * the panel — and never touched again: accurate the instant it was drawn,
+ * then a static prop for the rest of the wait (a full, unmoving 3 seconds on
+ * the default delay).
+ *
+ * A test asserting only that render would pass against BOTH the broken and
+ * the fixed behaviour and pin nothing — see the reverse-verification section
+ * below, where that is exactly what happens. This file's job is the half
+ * that only the fixed behaviour can pass: the number genuinely decreasing,
+ * once per second, while `EmbeddableForm` owns the interval driving it.
+ *
+ * ## Why this file fakes the clock, when the #5049 sibling deliberately does
+ * not
+ *
+ * `EmbeddableForm.redirectTimerLifetime.test.tsx` keeps the real clock on
+ * purpose: the submit path is a chain of awaited promises, and faking the
+ * clock around it makes the observation race the promise resolution instead
+ * of the delay. That reasoning is about `@testing-library/react`'s `waitFor`
+ * / `findBy*`, which poll with a plain, timer-blind `setTimeout` — under
+ * `vi.useFakeTimers()` that `setTimeout` never fires because the fake clock
+ * never advances on its own, so those helpers would simply hang.
+ *
+ * `vi.waitFor` (vitest's own, imported as `vi.waitFor`, NOT
+ * `@testing-library`'s `waitFor`) does not have that problem: its polling
+ * loop is backed by the REAL, un-mocked timers (`getSafeTimers()` inside
+ * vitest), and on every poll it checks `vi.isFakeTimers()` and advances the
+ * fake clock itself before re-checking the callback. So the awaited
+ * `dataSource.create(...)` in the submit handler still resolves on its own
+ * microtask — fake timers never touch promises — while every timer this file
+ * cares about (the countdown's `setInterval`, and the sibling navigation
+ * `setTimeout` armed alongside it) is fully virtual and fully controllable
+ * via `vi.advanceTimersByTime`. Every wait below uses `vi.waitFor` for
+ * exactly this reason; `@testing-library`'s `waitFor`/`findBy*` are not used
+ * once fake timers are installed.
+ *
+ * ## What this file deliberately does not touch
+ *
+ * WHETHER a destination is followed (`isRedirectUrlSafe` /
+ * `allowedRedirectHosts`, objectui#4989) and WHETHER the navigation wait
+ * itself is owned correctly (objectui#5049 / PR #5070,
+ * `EmbeddableForm.redirectTimerLifetime.test.tsx`) are unchanged and pinned
+ * elsewhere. Every fixture below uses a same-origin relative destination,
+ * already accepted before this file's subject — the countdown DISPLAY —
+ * begins.
+ *
+ * ## Reverse-verification (predicted BEFORE running, then measured)
+ *
+ * Reverting `EmbeddableForm.tsx` to compute the seconds once from
+ * `pendingRedirect.delayMs` (dropping `useRedirectCountdownSeconds` and its
+ * `setInterval`), with every test below kept as-is:
+ *
+ * 1. **`submitAndWaitForCountdown`'s own `expect(armed.length).toBe(1)`
+ *    check goes red in all three tests** (the reverted code never calls
+ *    `setInterval` at all, so `armed` stays empty forever and the assertion
+ *    fails deterministically — no interval to wait for). This is the
+ *    assertion that PINS the fix; nothing else in this file can even run
+ *    once it fails.
+ * 2. **The `vi.waitFor` immediately above it, asserting
+ *    `Redirecting in 4 seconds`, stays GREEN on the reverted code** — the
+ *    static one-shot text was already correct before this fix, which is
+ *    exactly the "asserts only the initial render" trap the card warns
+ *    about. Recorded here so that green is not miscounted as evidence for
+ *    anything.
+ * 3. Every subsequent decrement assertion (`3 seconds`, `2 seconds`,
+ *    `1 seconds`, `0 seconds` and the self-clear) is unreachable on the
+ *    reverted code — the suite fails at (1) before getting there — so they
+ *    are not independently informative in THIS reversion; they are pinned by
+ *    the fact that (1) already fails.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+
+import { EmbeddableForm, type EmbeddableFormConfig } from './EmbeddableForm';
+import { REDIRECT_COUNTDOWN_TICK_MS } from './thankYouRedirectCountdown';
+
+// ObjectForm resolves field widgets through the global registry.
+registerAllFields();
+
+const DESTINATION = '/thanks-5083';
+/** Long enough to observe four independent per-second decrements (4→0). */
+const DELAY_MS = 4000;
+
+const buildDataSource = () => ({
+  create: vi.fn(async (_obj: string, data: Record<string, unknown>) => ({ id: '1', ...data })),
+  update: vi.fn(),
+  delete: vi.fn(),
+  findOne: vi.fn(),
+  find: vi.fn(async () => ({ data: [], total: 0 })),
+  getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+});
+
+function baseConfig(overrides: Partial<EmbeddableFormConfig> = {}): EmbeddableFormConfig {
+  return {
+    formId: 'f5083',
+    objectName: 'lead',
+    customFields: [{ name: 'email', label: 'Email', type: 'email', required: true } as any],
+    // The anti-bot minimum fill time is a different gate; disable it so
+    // submit reaches the redirect arm without fighting a 1.5s timer.
+    minFillTime: 0,
+    thankYouPage: { redirectUrl: DESTINATION, redirectDelay: DELAY_MS },
+    ...overrides,
+  };
+}
+
+const realHrefDescriptor = Object.getOwnPropertyDescriptor(window.location, 'href');
+
+let hrefSetter: ReturnType<typeof vi.fn<(url: string) => void>>;
+let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+let clearIntervalSpy: ReturnType<typeof vi.spyOn>;
+/** One entry per `setInterval` call the component makes, in arming order. */
+let armed: { ms: number; handle: unknown }[];
+/** Every handle passed to `clearInterval`, by anyone. */
+let cleared: unknown[];
+
+beforeEach(() => {
+  armed = [];
+  cleared = [];
+  hrefSetter = vi.fn<(url: string) => void>();
+
+  // `window.location.href = url` is the sibling navigation hook's call —
+  // shadowed so it never actually navigates jsdom/happy-dom away mid-test;
+  // not this file's subject, but the countdown and the navigation wait are
+  // armed by the same accepted `pendingRedirect`, so this file's setup
+  // mirrors the #5049 sibling's exactly.
+  const realHref = window.location.href;
+  Object.defineProperty(window.location, 'href', {
+    configurable: true,
+    get: () => realHref,
+    set: (value: string) => { hrefSetter(value); },
+  });
+
+  // Fake timers from the very first render — see the file docblock for why
+  // this is safe here (and deliberately different from the #5049 sibling).
+  vi.useFakeTimers();
+
+  // Captured AFTER `useFakeTimers()`, so this is the fake implementation —
+  // the pass-through below still registers with vitest's virtual clock, it
+  // is just observable through this file's spy on the way in.
+  const fakeSetInterval = globalThis.setInterval;
+  const fakeClearInterval = globalThis.clearInterval;
+
+  setIntervalSpy = vi.spyOn(globalThis, 'setInterval').mockImplementation(((
+    cb: any,
+    ms?: number,
+    ...rest: any[]
+  ) => {
+    const handle = (fakeSetInterval as any)(cb, ms, ...rest);
+    if (ms === REDIRECT_COUNTDOWN_TICK_MS) armed.push({ ms, handle });
+    return handle;
+  }) as any);
+
+  clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval').mockImplementation(((handle: any) => {
+    cleared.push(handle);
+    return (fakeClearInterval as any)(handle);
+  }) as any);
+});
+
+afterEach(() => {
+  clearIntervalSpy.mockRestore();
+  setIntervalSpy.mockRestore();
+  vi.useRealTimers();
+  if (realHrefDescriptor) {
+    Object.defineProperty(window.location, 'href', realHrefDescriptor);
+  } else {
+    delete (window.location as any).href;
+  }
+});
+
+/**
+ * Renders the form and drives one successful submit through to `create`.
+ *
+ * Deliberately does NOT additionally wrap these `vi.waitFor` calls in
+ * `act(async () => …)`: `ObjectForm` loads field widgets behind a Suspense
+ * boundary, and nesting an async wait inside `act()` here stalls that
+ * resolution — measured, not theoretical: the form gets stuck on its
+ * "Loading form…" fallback and every subsequent query times out. `vi.waitFor`
+ * on its own is already fake-timer-aware (see the file docblock) and every
+ * assertion in this file is deterministic without the extra wrapping; the
+ * cost is a handful of benign "not wrapped in act(...)" console warnings for
+ * updates this file fully intends and is already asserting on, which is the
+ * lesser problem.
+ */
+async function submitOnce(config: EmbeddableFormConfig, ds: ReturnType<typeof buildDataSource>) {
+  const view = render(
+    <EmbeddableForm
+      config={config}
+      // Prefilled programmatically so react-hook-form's required-field
+      // validation passes without racing a typed value into its state — the
+      // same reason the sibling EmbeddableForm suites prefill.
+      prefillParams={{ email: 'a@b.com' }}
+      dataSource={ds as any}
+    />,
+  );
+  await vi.waitFor(() => {
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+  await vi.waitFor(() => {
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+  return view;
+}
+
+/**
+ * Submits, then waits for BOTH the initial countdown text AND its interval
+ * to be armed. The order matters for the reverse-verification recorded in
+ * the file docblock: the text check alone is satisfied by the pre-fix static
+ * render too, so it is the `armed.length` check that actually pins the fix.
+ */
+async function submitAndWaitForCountdown(
+  config: EmbeddableFormConfig,
+  ds: ReturnType<typeof buildDataSource>,
+  expectedInitialSeconds: number,
+) {
+  const view = await submitOnce(config, ds);
+
+  await vi.waitFor(() => {
+    expect(
+      screen.getByText(new RegExp(`Redirecting in ${expectedInitialSeconds} seconds`, 'i')),
+    ).toBeInTheDocument();
+  });
+
+  // Proves an interval mechanism exists at all, not merely that the number
+  // happened to read right once — the failure mode a render-only assertion
+  // cannot distinguish from the pre-fix behaviour.
+  await vi.waitFor(() => {
+    expect(armed.length).toBe(1);
+  });
+  expect(armed[0].ms).toBe(REDIRECT_COUNTDOWN_TICK_MS);
+
+  return view;
+}
+
+describe('objectui#5083 — EmbeddableForm thank-you countdown ticks', () => {
+  it('decrements the displayed seconds once per second, and self-clears on reaching 0', async () => {
+    const ds = buildDataSource();
+    await submitAndWaitForCountdown(baseConfig(), ds, 4);
+
+    expect(screen.getByText(/Redirecting in 4 seconds/i)).toBeInTheDocument();
+
+    act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS); });
+    expect(screen.getByText(/Redirecting in 3 seconds/i)).toBeInTheDocument();
+    // Counter-probe: the stale reading is gone, paired with the fresh one
+    // above actually being present — an empty query here would also pass on
+    // a panel that stopped rendering the countdown at all.
+    expect(screen.queryByText(/Redirecting in 4 seconds/i)).toBeNull();
+
+    act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS); });
+    expect(screen.getByText(/Redirecting in 2 seconds/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Redirecting in 3 seconds/i)).toBeNull();
+
+    act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS); });
+    expect(screen.getByText(/Redirecting in 1 seconds/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Redirecting in 2 seconds/i)).toBeNull();
+
+    // The 4th tick lands exactly on the declared 4000ms delay — the same
+    // instant the sibling navigation timer (a different file, objectui#5049)
+    // fires. This assertion pins only that the countdown does not run past
+    // 0 and stops itself, regardless of firing order between the two timers.
+    act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS); });
+    expect(screen.getByText(/Redirecting in 0 seconds/i)).toBeInTheDocument();
+    expect(cleared).toContain(armed[0].handle);
+
+    // The write itself already succeeded — a ticking display does not touch it.
+    expect(ds.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the countdown interval when the form unmounts mid-countdown', async () => {
+    const ds = buildDataSource();
+    const view = await submitAndWaitForCountdown(baseConfig(), ds, 4);
+
+    act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS); });
+    expect(screen.getByText(/Redirecting in 3 seconds/i)).toBeInTheDocument();
+
+    // The host page removes the embed, or the route changes under it.
+    view.unmount();
+
+    expect(cleared).toContain(armed[0].handle);
+
+    // Advancing well past the original delay after unmount must not throw —
+    // there is nothing left running to tick.
+    expect(() => {
+      act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS * 10); });
+    }).not.toThrow();
+  });
+
+  it('clears the countdown interval when "Submit Another Response" resets the pending destination', async () => {
+    const ds = buildDataSource();
+    await submitAndWaitForCountdown(baseConfig({ allowMultiple: true }), ds, 4);
+
+    act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS); });
+    expect(screen.getByText(/Redirecting in 3 seconds/i)).toBeInTheDocument();
+
+    const armedHandle = armed[0].handle;
+    fireEvent.click(screen.getByRole('button', { name: /submit another response/i }));
+
+    expect(cleared).toContain(armedHandle);
+
+    // The reset's offer: a fresh form, not a blank screen — the absence of
+    // the countdown line below is earned by the reset, not by the panel
+    // failing to render at all (counter-probe with a known-present term).
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/redirecting/i)).toBeNull();
+
+    // No further ticks after reset — advancing well past the original delay
+    // must not resurrect a countdown for a destination that was dropped.
+    act(() => { vi.advanceTimersByTime(REDIRECT_COUNTDOWN_TICK_MS * 10); });
+    expect(screen.queryByText(/redirecting/i)).toBeNull();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-form/src/EmbeddableForm.tsx
+++ b/packages/plugin-form/src/EmbeddableForm.tsx
@@ -29,6 +29,7 @@ import {
   useThankYouRedirectNavigation,
   type PendingThankYouRedirect,
 } from './thankYouRedirectNavigation';
+import { useRedirectCountdownSeconds } from './thankYouRedirectCountdown';
 
 export interface EmbeddableFormTexts {
   submit?: string;
@@ -269,6 +270,14 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
   // unconditionally.
   useThankYouRedirectNavigation(pendingRedirect);
 
+  // The ticking half of the same promise: "Redirecting in {{seconds}}
+  // seconds…" is documented, in all ten locale packs, as counting down the
+  // REMAINING wait — not a number frozen at the instant the panel first
+  // paints (objectui#5083). Owned the same way as the wait above: an effect
+  // keyed on `pendingRedirect`, cancelled on unmount and on `handleReset`
+  // dropping the destination (`thankYouRedirectCountdown.ts`).
+  const remainingRedirectSeconds = useRedirectCountdownSeconds(pendingRedirect);
+
   const honeypotName = config.honeypot === false ? null : config.honeypot || DEFAULT_HONEYPOT_NAME;
   const minFillTime = config.minFillTime ?? DEFAULT_MIN_FILL_MS;
 
@@ -423,10 +432,15 @@ export const EmbeddableForm: React.FC<EmbeddableFormProps> = ({
     // in the submit handler): the seconds displayed are the seconds being
     // served, and a host that re-renders with a different `redirectDelay`
     // mid-wait cannot make the two disagree.
-    const redirectingText = pendingRedirect
+    //
+    // The number itself now TICKS (objectui#5083): `remainingRedirectSeconds`
+    // is owned by the effect above, counting down once per second rather than
+    // being computed once from `pendingRedirect.delayMs` and left to go stale
+    // for the whole wait.
+    const redirectingText = pendingRedirect && remainingRedirectSeconds !== null
       ? (texts.redirecting ?? 'Redirecting in {{seconds}} seconds…').replace(
           '{{seconds}}',
-          String(Math.ceil(pendingRedirect.delayMs / 1000)),
+          String(remainingRedirectSeconds),
         )
       : null;
     return (

--- a/packages/plugin-form/src/thankYouRedirectCountdown.ts
+++ b/packages/plugin-form/src/thankYouRedirectCountdown.ts
@@ -1,0 +1,113 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5083 — the thank-you panel's "Redirecting in {{seconds}} seconds…"
+ * copy is a promise made in ALL TEN locale packs
+ * (`packages/i18n/src/locales/*.ts`, key `publicForm.redirecting`, documented
+ * as "the remaining seconds"). The number used to be computed exactly once —
+ * at the render that first shows the panel, as
+ * `Math.ceil(pendingRedirect.delayMs / 1000)` — and never touched again:
+ * accurate the instant it was drawn, then a static prop pretending to be a
+ * countdown for the rest of the wait (3 full seconds, unmoving, on the
+ * default delay).
+ *
+ * This hook owns the ticking half of that promise, on the SAME ownership
+ * model PR #5070 established for the redirect wait itself
+ * (`thankYouRedirectNavigation.ts`) — restated rather than reinvented,
+ * because objectui#5049 already paid for getting that model wrong once on
+ * this exact component:
+ *
+ * - keyed on the ACCEPTED destination (`PendingThankYouRedirect`), not the
+ *   authored one — a destination the guard refused never reaches here with a
+ *   non-null value, same as the navigation wait (objectui#5073);
+ * - an effect owns the interval for exactly as long as `pending` stands, and
+ *   its cleanup — which runs on unmount AND on every change of identity of
+ *   `pending` (a fresh accept, or `handleReset`'s `setPendingRedirect(null)`)
+ *   — is the only thing that ever cancels it. Nothing here reaches for a
+ *   module-level or ref-only handle the way the pre-#5049 code did.
+ *
+ * ## Why the count is *state*, ticked by the interval — not re-derived from
+ * `Date.now()` on every render
+ *
+ * A render-time `Date.now() - startedAt` reading would make the visible
+ * number ride on WHEN React happens to re-render this component for
+ * unrelated reasons, rather than ticking on its own — the same "looks live,
+ * isn't" failure this file exists to fix, just harder to notice in a
+ * short-lived panel. Explicit per-second state, advanced only by the
+ * interval that owns the wait, is the one source both the display and the
+ * wait agree on.
+ *
+ * ## Why the initial value is ALSO assigned during render, not only inside
+ * the effect
+ *
+ * `pending` is a plain object recreated on every accepted submit — a new
+ * identity, not a mutation of the old one — so "the destination changed" is
+ * detected by comparing it against the previously rendered value DURING
+ * render (the React-documented "adjusting state when a prop changes"
+ * pattern: https://react.dev/learn/you-might-not-need-an-effect), rather
+ * than waiting for the commit-then-effect round trip. Without it, the first
+ * paint of the thank-you panel would show the previous render's leftover
+ * count (or nothing) for one frame before the effect below catches up —
+ * which would fail the existing `redirectVerdictCopy` fixture asserting the
+ * exact seconds text is present the instant the panel appears.
+ */
+
+import { useEffect, useState } from 'react';
+import type { PendingThankYouRedirect } from './thankYouRedirectNavigation';
+
+/** One tick per displayed second — matches the `{{seconds}}` unit the copy promises. */
+export const REDIRECT_COUNTDOWN_TICK_MS = 1000;
+
+function secondsFor(pending: PendingThankYouRedirect | null): number | null {
+  return pending ? Math.max(0, Math.ceil(pending.delayMs / 1000)) : null;
+}
+
+/**
+ * The remaining whole seconds of an accepted thank-you redirect wait, ticking
+ * down once per second until it reaches 0. `null` while nothing is pending —
+ * the panel keeps deciding on its own whether a countdown renders at all (a
+ * refused destination, objectui#5073, never reaches this hook with a
+ * non-null `pending`).
+ *
+ * Pass the same `PendingThankYouRedirect | null` value given to
+ * `useThankYouRedirectNavigation`. This hook does not navigate anything and
+ * does not judge the destination — it only counts down the delay that was
+ * captured alongside it.
+ */
+export function useRedirectCountdownSeconds(pending: PendingThankYouRedirect | null): number | null {
+  // Previous-value comparison for the render-time reset described above —
+  // NOT a cache of the count itself.
+  const [committedPending, setCommittedPending] = useState(pending);
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(() => secondsFor(pending));
+
+  if (pending !== committedPending) {
+    setCommittedPending(pending);
+    setRemainingSeconds(secondsFor(pending));
+  }
+
+  useEffect(() => {
+    if (!pending) return;
+    const interval = setInterval(() => {
+      setRemainingSeconds((prev) => {
+        if (prev === null || prev <= 1) {
+          // The wait this counts down is owned elsewhere
+          // (`useThankYouRedirectNavigation`); once the display reaches 0
+          // there is nothing left to report, so the interval stops itself
+          // rather than ticking into negative numbers for a panel that is
+          // about to be replaced.
+          clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, REDIRECT_COUNTDOWN_TICK_MS);
+    // Unmount, or `pending` changing identity — cancels the interval. Same
+    // cleanup shape as `useThankYouRedirectNavigation`, for the same
+    // objectui#5049 reason: an interval nobody owns outlives the component
+    // that armed it.
+    return () => clearInterval(interval);
+  }, [pending]);
+
+  return remainingSeconds;
+}


### PR DESCRIPTION
Fixes #5083

## What was broken

`EmbeddableForm`'s public thank-you panel renders `Redirecting in {{seconds}} seconds…`. All ten locale packs (`packages/i18n/src/locales/*.ts`, key `publicForm.redirecting`) document `{{seconds}}` as "the remaining seconds" — but the number was computed exactly once, at the render that first shows the panel (`Math.ceil(pendingRedirect.delayMs / 1000)`), and never touched again. On the 3 second default delay, a submitter saw a fully static `Redirecting in 3 seconds…` for the whole wait.

## Route taken — route 1 (implement the countdown), not route 2 (reword the copy)

The locale strings already promise decrementing semantics in all ten languages; changing the copy would be retreating from a promise the product already makes. Confirmed by reading `packages/i18n/src/locales/en.ts:3082` and `zh.ts:2898` before choosing — both explicitly document "remaining seconds". No locale pack is touched by this PR.

## The fix

New file `packages/plugin-form/src/thankYouRedirectCountdown.ts` — `useRedirectCountdownSeconds(pending)`, a per-second `setInterval` on the **same ownership model PR #5070 established** for the redirect wait itself (`thankYouRedirectNavigation.ts`):

- keyed on the **accepted** destination (`PendingThankYouRedirect`), not the authored one — a destination the guard refused never reaches this hook with a non-null value (same as #5073's fix);
- an effect owns the interval for exactly as long as `pending` stands; its cleanup runs on **unmount** and on **every change of `pending`'s identity** — a fresh accept, or `handleReset`'s `setPendingRedirect(null)` — which is the exact regression surface #5049 fixed for the navigation timer. Nothing here reaches for a module-level or ref-only handle the way the pre-#5049 code did.
- the interval **self-clears** once it reaches 0, rather than ticking indefinitely past a wait that has already ended.

`EmbeddableForm.tsx` now reads `remainingRedirectSeconds` from this hook instead of re-deriving the seconds from `pendingRedirect.delayMs` on every render.

## Tests

New file `EmbeddableForm.redirectCountdownTick.test.tsx`, three cases:

1. **The number actually decreases over time** — 4s delay, advances a *fake* clock 1s at a time, asserts `4 → 3 → 2 → 1 → 0`, and that the interval self-clears at 0. A test asserting only the initial render would pass against the pre-fix behaviour too (see reverse-verification below) — this is why it isn't enough on its own, and why the suite also asserts an interval was genuinely armed (`setInterval` spy), not just that the text happened to read right once.
2. **Interval cleared on unmount mid-countdown.**
3. **Interval cleared on `handleReset`** (`Submit Another Response`) mid-countdown — the #5049 regression surface — paired with a counter-probe (`getByLabelText(/email/i)`) proving the "no countdown" assertion is earned by the reset, not by the panel failing to render at all.

Fake timers, deliberately different from the sibling `EmbeddableForm.redirectTimerLifetime.test.tsx` (#5049), which keeps the real clock because faking it around the awaited submit chain would race the resolution. That reasoning applies to `@testing-library/react`'s `waitFor`/`findBy*`, which poll with a plain, timer-blind `setTimeout` and would hang under fake timers. `vi.waitFor` (vitest's own) doesn't have that problem — its polling loop is backed by real, unmocked timers and it advances the fake clock itself on every poll, so the awaited `dataSource.create(...)` still resolves on its own microtask while the countdown's `setInterval` stays fully controllable via `vi.advanceTimersByTime`. Every wait in the new file uses `vi.waitFor`, never testing-library's. (One dead end recorded in the file: wrapping those waits in an extra `act(async () => …)` stalls `ObjectForm`'s Suspense-loaded field widgets — measured, not theoretical — so the waits are intentionally left unwrapped, at the cost of some benign "not wrapped in act(...)" console noise.)

### Reverse-verification

Predicted before running, in the test file's own docblock: reverting `EmbeddableForm.tsx` only (to `de4e29a81`, one commit before this fix) with every test kept would fail all three tests at the `expect(armed.length).toBe(1)` check (the reverted code never calls `setInterval`), while the `Redirecting in 4 seconds` initial-render assertion immediately above it would stay green (it was already correct pre-fix).

Measured: exactly that. All three tests failed with the identical `AssertionError: expected +0 to be 1` at that line; nothing failed on the initial-render text. Restoring the committed `EmbeddableForm.tsx` returns all three to green with no other change. (Recorded in the test file's docblock.)

### Commands run (HEAD `6029bdfa8`)

- `pnpm --filter '@object-ui/plugin-form^...' build` — dependency closure, clean.
- `pnpm --filter @object-ui/plugin-form build` — clean, no TS errors.
- `pnpm --filter @object-ui/plugin-form type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`).
- `pnpm --filter @object-ui/plugin-form test` — **574/574 passed** (56 test files), including the 3 new cases.
- `eslint packages/plugin-form/src/EmbeddableForm.tsx packages/plugin-form/src/thankYouRedirectCountdown.ts packages/plugin-form/src/EmbeddableForm.redirectCountdownTick.test.tsx` — 0 errors (17 pre-existing-style `any`/fast-refresh warnings, same pattern as sibling files).
- `node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs` / `check-changeset-fixed.mjs` — ✅ all three.
- `node scripts/check-control-bytes.mjs` — ✅ (plus a manual `grep -naP` self-scan of every changed/new file — clean).
- `node scripts/check-lint-coverage.mjs` / `check-type-check-coverage.mjs` — ✅ both.

## Scope

`packages/plugin-form/src/**` only, per the dispatch's file surface. No locale packs touched (route 1). No public type surface changed — the new hook is an internal module, not exported from `index.tsx`, matching the existing `thankYouRedirectNavigation.ts` precedent. Confirmed no other package imports it.

## Changeset

`patch` on `@object-ui/plugin-form` (`.changeset/embeddable-form-thankyou-countdown-tick-5083.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_