### PR TITLE
refactor(plugin-grid,core): the bulk dialog's data-source rule derives from core, not a fourth private copy

### DIFF
--- a/.changeset/bulk-param-data-source-rule-derives-from-core-4815.md
+++ b/.changeset/bulk-param-data-source-rule-derives-from-core-4815.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-grid': patch
+'@object-ui/core': patch
+---
+
+The bulk-action dialog's "this widget needs a DataSource" rule now derives from the shared reference-field family instead of a fourth private copy.
+
+`packages/plugin-grid/src/components/bulkParamToField.ts` held its own
+`DATA_SOURCE_WIDGET_TYPES` — the fourth hand-maintained answer to one question
+("which widget has to query records, so it must be handed a DataSource and a
+`reference_to`"), and the only one whose member set matched none of the other
+three: `lookup` / `master_detail` / `user`, against `@object-ui/core`'s
+`EXPANDABLE_FIELD_TYPES` (which also holds `tree`) and the object form's rule
+(which adds three widget-hint pickers). Nothing anywhere could detect the drift;
+the same shape objectui#4770 and objectui#4790 each closed on another surface.
+
+It now reads core's set through one predicate, so all three consumers of the rule
+— the label prefetch / option source (`isLookupishParam`), the `dataSource` prop
+the dialog threads into the widget (`fieldNeedsDataSource`), and the
+`reference_to` / `display_field` branch of `bulkParamToField` — cannot drift apart
+from each other or from the form again.
+
+No behaviour change on any reachable path, which is why this is a patch. The one
+member the two tables differed on, `tree`, can never be a widget key on this
+surface: it is absent from the fields widget map and `mapFieldTypeToFormType`
+sends it to `field:lookup`, so a `tree` param arrives at the rule as `lookup`
+(pinned). The divergence in the other direction is deliberately preserved: the
+form additionally wires `object-ref` / `filter-condition` / `recipient-picker`,
+widget hints no object schema can declare and no bulk param produces — absorbing
+them would change which widgets receive a DataSource here, which is a behaviour
+change and not a convergence.
+
+The pin is an identity pin, not a membership one: it spies on the `has` of the
+Set object core exports, so a member-identical private copy fails it. A
+value-equality assertion would have passed against exactly the defect this
+change removes.

--- a/packages/core/src/utils/expand-fields.ts
+++ b/packages/core/src/utils/expand-fields.ts
@@ -23,17 +23,21 @@ import { columnIdentity } from './column-identity.js';
  * belongs in this set; whether the backend materialises the expanded object
  * for it is a server concern — requesting it is harmless and forward-compatible.
  *
- * ## One family, three consumers
+ * ## One family, four consumers
  *
  * This is the reference-bearing FAMILY, not the `$expand` builder's private
- * list, and three concerns already read it under three different words:
+ * list, and four concerns already read it under three different words:
  *
  *  - `$expand` construction — `buildExpandFields` below ("expandable");
  *  - predicate-record projection — `predicate-record.ts` ("relational");
  *  - the object form's data-source wiring — `needsDataSourceWiring` in
  *    `packages/components/src/renderers/form/form.tsx`, which decides which
  *    registered widget gets `dataSource` / `dependentValues` /
- *    `dependsOnLabels` threaded to it.
+ *    `dependsOnLabels` threaded to it;
+ *  - the grid's bulk-action dialog — `widgetNeedsDataSource` in
+ *    `packages/plugin-grid/src/components/bulkParamToField.ts`, which decides
+ *    which param widget is handed the grid's `DataSource` and which param field
+ *    shape carries `reference_to` / `display_field`.
  *
  * The third one used to be a second hand-maintained copy, and this comment used
  * to claim the set "mirrors the form layer's `DATA_SOURCE_FIELD_TYPES`
@@ -52,6 +56,18 @@ import { columnIdentity } from './column-identity.js';
  * declarable field types (`widgetHintOnly: true` in
  * `app-shell/src/utils/paramValueShape.ts`), so no object schema can produce a
  * field whose `type` is one of them.
+ *
+ * The fourth was a hand-maintained copy too, one member set removed from BOTH
+ * of the above (`lookup` / `master_detail` / `user` — no `tree`, no pickers, and
+ * for a while a fifth spelling, `owner`, that objectui#4814 retired). It now
+ * derives from this set with NO extension, because the bulk dialog's params
+ * cannot produce the three widget-hint names (objectui#4815):
+ *
+ *     bulk dialog's data-source rule  ==  EXPANDABLE_FIELD_TYPES
+ *
+ * Neither consumer copies the set — both call `.has()` on THIS object, and both
+ * carry an identity pin (a spy on this `has`) so a member-identical private copy
+ * fails rather than quietly re-forking the table.
  *
  * Stated so it reads as a decision rather than a surprise: **adding a member
  * here also grants that type the form's data-source wiring.** That is the

--- a/packages/plugin-grid/src/__tests__/bulkParamToField.test.ts
+++ b/packages/plugin-grid/src/__tests__/bulkParamToField.test.ts
@@ -13,6 +13,7 @@
  * threading, and the option-value stringification the confirm step relies on.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EXPANDABLE_FIELD_TYPES } from '@object-ui/core';
 
 import {
   bulkParamToField,
@@ -119,5 +120,92 @@ describe('lookup helpers', () => {
     expect(fieldNeedsDataSource({ type: 'user' })).toBe(true);
     expect(fieldNeedsDataSource({ type: 'lookup' })).toBe(true);
     expect(fieldNeedsDataSource({ type: 'date' })).toBe(false);
+  });
+});
+
+describe('the data-source rule is core\'s object, not a copy (objectui#4815)', () => {
+  it('asks `@object-ui/core` EXPANDABLE_FIELD_TYPES which params need a DataSource', () => {
+    // IDENTITY, not membership — the pin shape objectui#4770 / #4790 established
+    // (`cascadeOptionWidgetTypes.reexport.test.tsx`,
+    // `form-data-source-wiring.test.tsx`). Every membership assertion in this
+    // file is satisfied by a private `new Set(['lookup', 'master_detail',
+    // 'user'])` holding the same strings, which is exactly the state
+    // objectui#4815 closed — a value-equality check would pass ON the defect and
+    // report a convergence that isn't there. The spy is installed on the Set
+    // object exported by core; it records a call only if this module consulted
+    // THAT object, so a member-identical copy leaves it empty and this fails.
+    const spy = vi.spyOn(EXPANDABLE_FIELD_TYPES, 'has');
+    try {
+      expect(isLookupishParam({ name: 'q', type: 'lookup', object: 'queues' })).toBe(true);
+      expect(spy.mock.calls.map(([k]) => k)).toContain('lookup');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('routes all THREE consumers of the rule through that same object', () => {
+    // The private copy had three readers, and a convergence that reconnected
+    // only the one under test would leave the others forked. `isLookupishParam`
+    // (label prefetch + option source in BulkActionDialog), `fieldNeedsDataSource`
+    // (the `dataSource` prop the dialog threads into the widget) and
+    // `bulkParamToField`'s `reference_to` / `display_field` branch must each
+    // reach core.
+    const consumers: [string, string, () => unknown][] = [
+      ['isLookupishParam', 'user', () => isLookupishParam({ name: 'u', type: 'user' })],
+      ['fieldNeedsDataSource', 'user', () => fieldNeedsDataSource({ type: 'user' })],
+      // The `reference_to` / `display_field` branch, reached with the widget key
+      // this param resolves to.
+      ['bulkParamToField', 'lookup', () => bulkParamToField({ name: 'q', type: 'lookup', object: 'queues' }, false)],
+    ];
+    for (const [label, key, exercise] of consumers) {
+      const spy = vi.spyOn(EXPANDABLE_FIELD_TYPES, 'has');
+      try {
+        exercise();
+        expect(spy.mock.calls.map(([k]) => k), `${label} never consulted the shared set`).toContain(key);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it('holds every core member under this surface\'s normalization', () => {
+    // The shared set is defined over SCHEMA types; this surface tests WIDGET
+    // keys (`resolveBulkParamWidgetType` output). Reading one with the other is
+    // only safe while the family is closed under that resolution — every member
+    // resolves to a member. A future core member that resolved to `text` here
+    // would be a schema-declared reference field silently rendered as a plain
+    // input with no DataSource, so it fails loudly instead.
+    for (const type of EXPANDABLE_FIELD_TYPES) {
+      const widgetKey = resolveBulkParamWidgetType(type);
+      expect(
+        EXPANDABLE_FIELD_TYPES.has(widgetKey),
+        `core member '${type}' resolves to '${widgetKey}', which is outside the family`,
+      ).toBe(true);
+    }
+  });
+
+  it('keeps `tree` unreachable here — the one cell where the two tables differed', () => {
+    // Why converging cost no behaviour change: `tree` is a core member that can
+    // never BE a widget key on this path (absent from the fields widget map,
+    // and `mapFieldTypeToFormType` sends it to `field:lookup`). If someone
+    // registers a real `tree` widget, this flips and `tree` starts matching the
+    // rule here — a behaviour change that would otherwise arrive silently.
+    expect(EXPANDABLE_FIELD_TYPES.has('tree')).toBe(true);
+    expect(resolveBulkParamWidgetType('tree')).toBe('lookup');
+    expect(fieldNeedsDataSource({ type: 'lookup' })).toBe(true);
+  });
+
+  it('does NOT absorb the form-only widget-hint pickers', () => {
+    // The other measured divergence, left exactly as objectui#4815 measured it.
+    // The object form ALSO wires `object-ref` / `filter-condition` /
+    // `recipient-picker` — widget hints no object schema can declare, and which
+    // a bulk param does not produce. Pulling them in would change which widgets
+    // get a DataSource on this surface: a behaviour change, not a convergence.
+    // (Green before and after the convergence by design — it pins the boundary,
+    // not the convergence.)
+    for (const hint of ['object-ref', 'filter-condition', 'recipient-picker']) {
+      expect(fieldNeedsDataSource({ type: hint }), `${hint} must stay out`).toBe(false);
+      expect(isLookupishParam({ name: 'p', type: hint }), `${hint} must stay out`).toBe(false);
+    }
   });
 });

--- a/packages/plugin-grid/src/components/bulkParamToField.ts
+++ b/packages/plugin-grid/src/components/bulkParamToField.ts
@@ -21,6 +21,7 @@
  * unit-testable without the dialog render tree (mirrors app-shell's
  * `paramToField`).
  */
+import { EXPANDABLE_FIELD_TYPES } from '@object-ui/core';
 import { resolveFormWidgetType } from '@object-ui/fields';
 import type { BulkActionParam } from '@object-ui/types';
 
@@ -50,8 +51,43 @@ const LOOKUP_WIDGET_TYPES = new Set(['lookup', 'master_detail']);
  */
 const USER_WIDGET_TYPES = new Set(['user']);
 
-/** Widget keys whose widget must be handed the grid's DataSource explicitly. */
-const DATA_SOURCE_WIDGET_TYPES = new Set([...LOOKUP_WIDGET_TYPES, ...USER_WIDGET_TYPES]);
+/**
+ * Whether the widget rendered for this key has to QUERY records to do its job —
+ * so it must be handed the grid's `DataSource`, and its field shape needs the
+ * `reference_to` / `display_field` the picker queries with.
+ *
+ * The reference-bearing half is NOT restated here: it is `EXPANDABLE_FIELD_TYPES`
+ * from `@object-ui/core`, the one relational-field family the `$expand` builder
+ * and the predicate-record projection already read, and the same seam the object
+ * form derives `needsDataSourceWiring` from (objectui#4790). This module held a
+ * private copy of it (`DATA_SOURCE_WIDGET_TYPES = LOOKUP_WIDGET_TYPES ∪
+ * USER_WIDGET_TYPES`) until objectui#4815 — the FOURTH hand-maintained answer to
+ * one question, with a member set that matched neither of the other three and no
+ * gate anywhere that could say so.
+ *
+ * Converging on the shared set costs this surface nothing, because the one cell
+ * where the two tables differ is unreachable here: `tree` is a core member but
+ * never a widget key on this path — it is absent from `fields`' widget map and
+ * `mapFieldTypeToFormType` sends it to `field:lookup`, so every key tested here
+ * (always `resolveBulkParamWidgetType` output) arrives as `lookup`. The form's
+ * copy carries the same inert `tree` member for the same reason.
+ *
+ * The other direction is deliberately NOT converged: the form additionally wires
+ * `object-ref` / `filter-condition` / `recipient-picker`, which are widget HINTS
+ * that no object schema can declare (`widgetHintOnly: true`) and that a bulk
+ * param does not produce. Pulling them in would CHANGE which widgets receive a
+ * DataSource on this surface — a behaviour change, not a convergence — so
+ * objectui#4815 left that cell measured and empty on purpose.
+ *
+ * Extending this surface later: OR in a second, surface-local set, the way
+ * `needsDataSourceWiring` does — `EXPANDABLE_FIELD_TYPES.has(t) || SURFACE_ONLY.has(t)`.
+ * Never `new Set([...EXPANDABLE_FIELD_TYPES, …])`: a copy silently re-forks the
+ * table, which is the defect objectui#4815 removed, and the identity pin in
+ * `__tests__/bulkParamToField.test.ts` fails on it by design.
+ */
+function widgetNeedsDataSource(widgetType: string): boolean {
+  return EXPANDABLE_FIELD_TYPES.has(widgetType);
+}
 
 /** Resolve a param `type` to the form widget key that renders it. */
 export function resolveBulkParamWidgetType(paramType: string): string {
@@ -61,7 +97,7 @@ export function resolveBulkParamWidgetType(paramType: string): string {
 /** True when the resolved widget is a record/person picker (id-valued). */
 export function isLookupishParam(param: BulkActionParam): boolean {
   const type = resolveBulkParamWidgetType(param.type);
-  return DATA_SOURCE_WIDGET_TYPES.has(type);
+  return widgetNeedsDataSource(type);
 }
 
 /**
@@ -140,7 +176,7 @@ export function bulkParamToField(
     multiple,
   };
 
-  if (DATA_SOURCE_WIDGET_TYPES.has(type)) {
+  if (widgetNeedsDataSource(type)) {
     field.reference_to = object;
     if (typeof labelField === 'string') field.display_field = labelField;
   }
@@ -150,5 +186,5 @@ export function bulkParamToField(
 
 /** Whether the widget for this field shape needs the DataSource threaded in. */
 export function fieldNeedsDataSource(field: Record<string, any>): boolean {
-  return DATA_SOURCE_WIDGET_TYPES.has(field.type);
+  return widgetNeedsDataSource(field.type);
 }


### PR DESCRIPTION
Fixes #4815

`packages/plugin-grid/src/components/bulkParamToField.ts` held its own `DATA_SOURCE_WIDGET_TYPES` — the fourth hand-maintained answer to one question ("which widget has to query records, so it must be handed a DataSource and a reference target"), and the only one whose member set matched none of the other three. Nothing anywhere could detect the drift. Same shape as the convergences #4770 and #4790 each landed on another surface.

Verified on current `origin/main` (de4e29a81) rather than taken from the card: the `owner` cell is already gone (#4814 / PR #4915 — `USER_WIDGET_TYPES` reads `new Set(['user'])` with a tombstone above it), so the remaining ask was exactly the convergence.

## What changed

**One definition.** The reference half is no longer restated here: `widgetNeedsDataSource()` reads `EXPANDABLE_FIELD_TYPES` from `@object-ui/core` — the same object the `$expand` builder, the predicate-record projection and the object form's `needsDataSourceWiring` already read. All three consumers of the rule now go through that one predicate:

| consumer | what it decides |
|---|---|
| `isLookupishParam` | label prefetch + option source in `BulkActionDialog` |
| `fieldNeedsDataSource` | the `dataSource` prop threaded into the widget (`BulkActionDialog.tsx:600`) |
| `bulkParamToField` | the `reference_to` / `display_field` branch of the field shape |

`packages/core/src/utils/expand-fields.ts` gains the fourth consumer in its "one family, N consumers" TSDoc, so the shared table names every surface that reads it.

**No reachable behaviour change** — which is why the changeset is `patch`, and it is the roll-back clause taken seriously rather than assumed:

- `tree` is the one cell where the two tables differed, and it can never be a widget key on this path: it is absent from the fields widget map and `mapFieldTypeToFormType` sends it to `field:lookup`, so a `tree` param reaches the rule as `lookup`. Counter-probed (0 hits for `tree` in `fieldWidgetMap` while `lookup` / `master_detail` / `user` give 3 from the same extraction) and pinned by a test, so if someone ever registers a real `tree` widget this flips loudly instead of silently.
- The divergence in the other direction is deliberately preserved. The object form also wires `object-ref` / `filter-condition` / `recipient-picker` — widget hints no object schema can declare and no bulk param produces. Absorbing them would change which widgets receive a DataSource here: a behaviour change, not a convergence. #4815's own analysis is the spec for that cell, and a test pins it shut.

## The pin is an identity pin

`expect(...).toEqual([...])` on the members would have passed against **exactly** the defect this PR removes — four copies that happen to agree today — so it would have been worse than no test. The pin instead spies on the `has` of the Set object core exports and asserts this module called **that** object.

Proved to discriminate, not assumed. Reverse verification ran two legs, each predicted before running and matched exactly:

| leg | predicted | observed |
|---|---|---|
| A — revert the source, keep the tests | the 2 identity assertions red, 13 green | `Tests 2 failed \| 13 passed` — `expected [] to include 'lookup'` |
| B — substitute a **member-identical** copy (`new Set([...EXPANDABLE_FIELD_TYPES])`, members equal by construction) | the same 2 red | `Tests 2 failed \| 13 passed` — same two |

Leg B is the one that matters: every membership-shaped assertion in the file stayed **green** against that copy, which is the empirical version of "a value-equality assertion reports a convergence that isn't there".

Stated rather than counted: the other 3 new assertions are green on both legs by design. They pin the normalization contract (every core member is closed under `resolveBulkParamWidgetType`) and the two deliberate boundaries above — they guard a future widening, not this convergence.

**Rebuild question, per leg:** no build artifact sits between any edit and the runner. The canonical invocation (`pnpm exec vitest run ...` from the repo root, which is what CI shards) loads the root `vitest.config.mts`, whose `resolve.alias` maps `@object-ui/core` to `packages/core/src`; the test imports `bulkParamToField` by a relative specifier. Proved directly rather than read off the config: with `packages/core/dist` moved aside entirely the run is still 15/15 green. Both red legs above are therefore self-proving — they could not have gone red unless the edit reached the runner. The pin also holds under the other resolution regime (a package-cwd run, where `@object-ui/core` resolves through package exports to `dist`): 15/15.

## Verification

All at `455a274f6`, after the final commit:

- `pnpm exec vitest run` over the 8 affected files (bulk param + dialog params/record/multiple/fanout, core expand-fields + unmaterialized-fields, the form's data-source wiring): **8 files / 80 tests passed**
- `pnpm --filter @object-ui/plugin-grid --filter @object-ui/core type-check`: both `Done` (script name echoed, so it is not a zero-match silent pass)
- `eslint` on the three changed files: 0 errors (5 pre-existing `no-explicit-any` warnings on untouched lines)
- `check:control-bytes`, `check:phantom-deps`, `check:self-import`, `check:esm-specifiers`: pass; plus a direct control-byte scan of the changed files

## Out of scope, filed not fixed

- #5312 — `app-shell`'s `paramToField` is now the **last** private copy of this rule, and its "moves in lockstep with plugin-grid's twin" comment stopped being mechanically true the moment this PR landed the twin on core. Asymptomatic today, same reason as here. Outside this PR's file surface.
- #5313 — `assertCanonicalVitestInvocation` does not cover the 11 packages that own a `vitest.config.ts`; measured, a package-cwd run in `plugin-grid` is not refused, contradicting the guard's own coverage claim.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_