### PR TITLE
fix(types): drop dead require condition from @object-ui/types exports

### DIFF
--- a/.changeset/types-drop-dead-require-condition.md
+++ b/.changeset/types-drop-dead-require-condition.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/types': patch
+---
+
+Removed the dead `require` condition from `exports["."]` in `@object-ui/types`'s `package.json`. It pointed at `dist/index.cjs`, a file the package's `"build": "tsc"` script (bare `tsc`, no bundler) structurally never emits — verified on a clean rebuild (`rm -rf dist tsconfig.tsbuildinfo && tsc`): zero `.cjs` files under `dist/`.
+
+**Judged non-breaking (`patch`), because the condition never resolved to anything a consumer could depend on** — measured both ways from a real `require()` call through the package's own resolved workspace symlink (not asserted):
+
+- **Before this change**: `require('@object-ui/types')` → `MODULE_NOT_FOUND: Cannot find module '.../dist/index.cjs'` (the condition existed but its target was never written by the build).
+- **After this change**: `require('@object-ui/types')` → `ERR_PACKAGE_PATH_NOT_EXPORTED: No "exports" main defined ...` (no matching condition).
+
+Both throw. No working `require()` call is turned into a failing one — there was no working one to begin with, in this repo or in any published version, since the build has never emitted `dist/index.cjs`. The `import` condition (`./dist/index.js`, real and always present) and the `types` condition are unchanged.
+
+The package declares `"type": "module"` and ships no bundler, so ESM-only is the contract-honest shape going forward; adding a second build format to satisfy a condition nothing used was the alternative and was not taken.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,8 +10,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     },
     "./base": {
       "types": "./dist/base.d.ts",

--- a/packages/types/src/__tests__/package-exports-manifest.test.ts
+++ b/packages/types/src/__tests__/package-exports-manifest.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pins `@object-ui/types`' `package.json` `exports` map to the shape its
+ * bare-`tsc` build can actually produce (objectui#4896).
+ *
+ * ## The defect this guards against
+ *
+ * The shipped `exports["."].require` condition used to point at
+ * `dist/index.cjs` — a file the package's `"build": "tsc"` script structurally
+ * never emits (`tsc` alone writes `.js` + `.d.ts`, never `.cjs`; a second
+ * output format needs a bundler or an explicit dual-emit step, and this
+ * package has neither). Any CJS consumer resolving the `require` condition
+ * therefore hit `MODULE_NOT_FOUND` against a published tarball that declared
+ * an entry point it never shipped.
+ *
+ * Measured directly against a clean rebuild before this fix (`rm -rf dist
+ * tsconfig.tsbuildinfo && tsc`): zero `.cjs` files under `dist/`, and
+ * `require.resolve('.../packages/types/dist/index.cjs')` throws
+ * `MODULE_NOT_FOUND`. The package declares `"type": "module"` and is
+ * types-first (no bundler in its build), so ESM-only — dropping the dead
+ * `require` condition rather than adding a second build format — is the
+ * contract-honest fix; see the PR body for the full premise verification
+ * (nothing in-repo `require()`s this package, and the one in-repo CJS-format
+ * bundle consumer, `packages/vscode-extension` via `tsup --format cjs` with
+ * `noExternal: ['@object-ui/types', ...]`, builds byte-identically with the
+ * condition present or absent — it resolves the value imports it re-exports
+ * via the `import` condition regardless of its own output format).
+ *
+ * ## What this test is, and is not
+ *
+ * This is a MANIFEST-level pin — it reads `package.json` as text and asserts
+ * on its shape. It does NOT build the package or inspect `dist/`: this
+ * repo's per-PR `test` job (`ci.yml`) runs `pnpm test` with no build step
+ * ahead of it (turbo's `test` task only `dependsOn: ["^build"]` — the
+ * DEPENDENCY closure, never the package's own build — see
+ * `scripts/check-package-self-import.mjs`'s header for the same trap hitting
+ * a different gate), so a test that required a fresh `dist/` to exist would
+ * be vacuously absent-or-red on a cold CI cache, not a meaningful signal.
+ * The artifact-level claim (a clean `tsc` build never emits `.cjs`) was
+ * verified by hand for this fix and is not expected to regress silently: the
+ * package's `"build": "tsc"` script and lack of any bundler/dual-emit step
+ * are exactly the two other things this test pins, so a future edit that
+ * reintroduces a `require` condition without ALSO reintroducing the emit step
+ * would still need to touch this file's expectations to pass CI.
+ */
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { describe, it, expect } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const pkg = JSON.parse(
+  readFileSync(require.resolve('../../package.json'), 'utf8'),
+) as {
+  type?: string;
+  scripts?: Record<string, string>;
+  exports?: Record<string, Record<string, string> | string>;
+};
+
+describe('@object-ui/types package.json exports map (objectui#4896)', () => {
+  it('declares "type": "module" — the premise for an ESM-only exports map', () => {
+    expect(pkg.type).toBe('module');
+  });
+
+  it('builds with bare tsc — no bundler that could emit a second (CJS) format', () => {
+    // If this ever changes to a bundler/dual-emit build, the `require`-less
+    // exports map below should be revisited rather than assumed to still be
+    // correct.
+    expect(pkg.scripts?.build).toBe('tsc');
+  });
+
+  it('the root "." export carries exactly {types, import} — no "require" condition', () => {
+    const rootExport = pkg.exports?.['.'];
+    expect(rootExport).toEqual({
+      types: './dist/index.d.ts',
+      import: './dist/index.js',
+    });
+  });
+
+  it('no export condition anywhere in the map points at a bare-tsc build never emits (*.cjs)', () => {
+    const offenders: string[] = [];
+    for (const [subpath, conditions] of Object.entries(pkg.exports ?? {})) {
+      if (typeof conditions === 'string') continue;
+      for (const [condition, target] of Object.entries(conditions)) {
+        if (typeof target === 'string' && target.endsWith('.cjs')) {
+          offenders.push(`${subpath} -> ${condition}: ${target}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #4896

## The defect

`packages/types/package.json`'s `exports["."]` map declared a `require` condition pointing at `dist/index.cjs` — a file the package's `"build": "tsc"` script (bare `tsc`, no bundler, no dual-format step) structurally never emits. Verified on a clean rebuild (`rm -rf dist tsconfig.tsbuildinfo && tsc` inside `packages/types`): zero `.cjs` files under `dist/`, and `require.resolve('.../dist/index.cjs')` throws `MODULE_NOT_FOUND`.

## Route taken — drop the condition, verified rather than assumed

The triage comment suggested dropping the `require` condition (ESM-only is the contract-honest shape, given `"type": "module"` and no bundler) rather than adding a second build format. Both premises behind that route were verified directly, not taken on faith:

- **`"type": "module"` is declared** — `packages/types/package.json:5`.
- **Nothing in-repo consumes this package via `require()`** — `grep -rn "require(['\"]@object-ui/types"` across the whole repo (excluding `node_modules`) returns zero hits. Counter-probed with a known-present neighbouring term (`require('@object-ui/types` broadly, and CJS `package.json`s repo-wide) to make sure the zero was a real zero and not a grep miss: exactly two workspace packages default to CommonJS (`packages/vscode-extension`, `apps/site`); `apps/site` declares `@object-ui/types` as a dependency but has zero source references to it (phantom/unused); `packages/vscode-extension` is the one real case — it builds via `tsup --format cjs` with `noExternal: ['@object-ui/types', '@object-ui/core']`, forcing both to be bundled into its CJS output, and `@object-ui/core` does value-import runtime exports from `@object-ui/types` (`ACTION_LOCATIONS`, `errorCodeIs`, `actionRendersAt`, etc. — not just types). I built it both ways to settle whether esbuild's bundler actually needs the `require` condition for this path:

  ```
  # baseline (require condition present, pointing at nonexistent dist/index.cjs)
  CJS dist/extension.js     32.87 KB
  CJS ⚡️ Build success in 25ms

  # after removing the require condition
  CJS dist/extension.js     32.87 KB
  CJS ⚡️ Build success in 26ms
  ```

  Byte-identical output either way — esbuild resolves the `import` statements it's bundling via the `import` condition regardless of its own output format, so the `require` condition was dead weight even for the one real CJS-bundling consumer in this repo.

## The changeset call

Judged **non-breaking → `patch`**, and here is why, measured rather than asserted. I ran a real `require('@object-ui/types')` through the package's actual workspace symlink (`packages/core/node_modules/@object-ui/types`, which resolves to `../../../types`) in both states:

- **Before this fix**: `MODULE_NOT_FOUND: Cannot find module '.../dist/index.cjs'` (the condition existed but pointed nowhere real).
- **After this fix**: `ERR_PACKAGE_PATH_NOT_EXPORTED: No "exports" main defined ...` (no matching condition).

Both throw. No working `require()` call is turned into a failing one, because there was never a working one — the build has never emitted `dist/index.cjs`, in this repo or in any published version. Stays `patch` on `@object-ui/types` only — never `major`, well inside objectui's fixed-group minor/patch lane.

## The pin — manifest-level, not artifact-level, and why

Added `packages/types/src/__tests__/package-exports-manifest.test.ts`: pins the `.` export to exactly `{types, import}`, pins `"type": "module"`, pins `"build": "tsc"` (the premise that makes a `require` condition suspect at all — no bundler, no dual-emit), and asserts no export condition anywhere in the map targets a `.cjs` file.

This is deliberately a **manifest-level** pin, not a build-artifact-level gate, for a repo-specific reason: `turbo.json`'s `test` task only `dependsOn: ["^build"]` (the dependency closure, never the package's own build), and `ci.yml`'s per-PR `Test` job runs `pnpm test` with no build step ahead of it at all. A test that required a fresh `dist/` to exist would be vacuously absent-or-red on a cold CI cache — exactly the trap `scripts/check-package-self-import.mjs`'s header documents for a different gate, and the same reason this repo's own artifact-level gates (`check:published-dist`, `check:node-esm-load`'s full/LOAD leg) are deliberately release-time/nightly workflows, never per-PR (`published-dist-gate.yml`, `node-esm-load-gate.yml`).

**Reverse-verified**, with the fix committed first so the revert is a real restore point:
1. Reverted just `packages/types/package.json` to `origin/main`'s content (test file kept).
2. Predicted: the "root export exactly `{types, import}`" and "no `.cjs` target" tests go red; the "`type: module`" and "`build: tsc`" tests stay green.
3. Observed: **exactly that** — `Tests 2 failed | 2 passed (4)`, both failures naming the reintroduced `require: ./dist/index.cjs`.
4. Restored the fix from the branch's own committed state; all 4 green again.

The artifact-level claim (a clean `tsc` build never emits `.cjs`) is the one manual proof above, run once for this fix — it doesn't need a repeating gate, because what the pin protects going forward is the *manifest* staying internally consistent with the *build config* (`"build": "tsc"`), and any future change to either would need to touch this test.

## Out of scope, filed separately if warranted

Per the card: the 22-package exports-vs-dist sweep the original finding (#4896) mentioned is explicitly out of scope for this PR. This fix doesn't establish that the wider pattern is a live problem elsewhere (the two other spot-checked packages in the finding, `data-objectstack` and `fields`, both have build configs that plausibly back their `require` conditions), so I have **not** filed a follow-up sweep issue — filing one on top of an unconfirmed pattern would be speculative, not evidence-based.

## Verification

- `pnpm exec vitest run packages/types/` → **39 files / 447 tests passed** (includes the new pin, in both states above).
- `pnpm --filter '@object-ui/types' type-check` → passed (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`).
- `node scripts/check-changeset-no-major.mjs` → passed.
- `node scripts/check-changeset-presence.mjs` → passed (1 changeset for 1 released package touched).
- `node scripts/check-phantom-dependencies.mjs` → passed (40 packages, 14925 specifiers scanned).
- `node scripts/check-node-esm-load.mjs --specifiers-only` → passed (cheap/source leg; the build-dependent LOAD leg is the dedicated nightly workflow noted above, not a per-PR gate in this repo).
- `node scripts/check-control-bytes.mjs` → passed.
- All of the above re-run at the final commit, `0097d2752`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_
