### PR TITLE
docs(fields): tombstone MasterDetailField as a form-unreachable orphan

### DIFF
--- a/.changeset/master-detail-field-tombstone-4811.md
+++ b/.changeset/master-detail-field-tombstone-4811.md
@@ -1,0 +1,9 @@
+---
+---
+
+Comment-only: `MasterDetailField` (`packages/fields/src/widgets/MasterDetailField.tsx`)
+gains a header tombstone recording that it is absent from `fieldWidgetMap`, unreachable
+from any form path (`master_detail` deliberately resolves to `LookupField`), and that its
+only in-repo consumer is its own test — so future `widgets/**` audits (the #3291 / #3318 /
+#4788 class) skip this file instead of re-discovering and re-investigating it each time
+(objectui#4811). No behaviour, export, or public API changes.

--- a/packages/fields/src/widgets/MasterDetailField.tsx
+++ b/packages/fields/src/widgets/MasterDetailField.tsx
@@ -3,6 +3,21 @@ import { Button, Badge, cn } from '@object-ui/components';
 import { Plus, X, ExternalLink } from 'lucide-react';
 import { FieldWidgetComponentProps } from './types';
 
+// TOMBSTONE (objectui#4811): this widget is NOT in `fieldWidgetMap`
+// (packages/fields/src/index.tsx) and is unreachable from any form path —
+// `registerField`/`registerAllFields` only walk `fieldWidgetMap`'s keys, and
+// the `master_detail` key there deliberately resolves to `LookupField`, not
+// this component (see the comment above that map entry: the child-side FK
+// must render as a single-value lookup picker, not the one-to-many list this
+// widget models). Its only in-repo consumer is its own test
+// (complex-widgets.test.tsx), which renders it directly and proves nothing
+// about form reachability. It remains solely because its named export
+// (`export * from './widgets/MasterDetailField'` in index.tsx) is a public
+// API surface, and removing it is a breaking change left to the maintainer
+// (see #4811). Auditors of `widgets/**` (the #3291 / #3318 / #4788 class of
+// sweep): skip this file — it is a known, deliberate orphan, not a gap in
+// your coverage.
+
 /**
  * Master-Detail relationship data structure
  */


### PR DESCRIPTION
Fixes #4811

## What

Adds a tombstone header comment to `packages/fields/src/widgets/MasterDetailField.tsx` recording that the component:

- is **not** in `fieldWidgetMap` (`packages/fields/src/index.tsx`);
- is **unreachable from any form path** (`registerField`/`registerAllFields` only walk `fieldWidgetMap`'s keys);
- has its `master_detail` field-type key deliberately resolving to `LookupField` instead (the child-side FK must render as a single-value picker in create/edit forms, not this widget's one-to-many list model);
- has **its own test as its only in-repo consumer** (`complex-widgets.test.tsx`, which renders it directly and proves nothing about form reachability).

Purpose: every future `widgets/**` sweep (the #3291 DOM-leak sweep / #3318 aria-invalid ledger / #4788 readonly-plumbing scan class — #4788 is where this orphan was originally found) stops paying the false-denominator tax of re-discovering and re-investigating an exported-but-unreachable component.

Scope is **disposition 2 only**, per the triage comment on #4811. **Disposition 1 (deleting the widget and its public export) is explicitly out of scope** — it is a breaking change to a published surface and is left to the maintainer, with the liveness evidence this tombstone documents. Nothing about the component's export, behavior, or registration changed.

## Verification of the tombstone's claims (re-derived on current `origin/main`, not trusted from the issue body)

1. **Absent from `fieldWidgetMap`**: grepped `packages/fields/src/index.tsx` — the `master_detail` entry (line ~2717) resolves to `LookupField`; no map entry anywhere resolves to `MasterDetailField`. Counter-probed the grep methodology against known-present keys (`'text'`, `'number'`, `'select'`) to confirm the search itself works.
2. **Unreachable from any form path**: `registerField()` looks up `fieldWidgetLoaderByKey[fieldType]` (backed by `fieldWidgetMap`) and warns+returns if absent; `registerAllFields()` only iterates `Object.keys(fieldWidgetMap)`. Neither has a special case for `MasterDetailField`. A full-repo grep (all extensions, excluding `node_modules`/`.git`/`dist`) for `MasterDetailField` turns up only: the widget's own definition, its own test, the `index.tsx` barrel export + explanatory comment, an unrelated `MasterDetailFieldMetadata` **type** in `packages/types` (a metadata shape, not a consumer of this component), and a changelog line in an old changeset.
3. **`master_detail` → `LookupField`**: confirmed at the map entry itself, with the adjacent comment explaining why (child-side FK needs a single-value lookup picker, not a one-to-many list).
4. **Only in-repo consumer is its own test**: confirmed by the same full-repo grep — the sole render call is in `complex-widgets.test.tsx`.

All four claims hold; the tombstone was safe to write.

## Verification

- Reverse verification does not meaningfully apply to a comment-only change — no behavior exists to flip and re-flip. Skipped rather than staged as a ceremonial leg.
- `node scripts/check-changeset-presence.mjs` → passes with the added empty-frontmatter changeset (`.changeset/master-detail-field-tombstone-4811.md`); `node scripts/check-changeset-no-major.mjs` → passes (no major declared).
- Manual control-character scan (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) on both changed files → clean (this repo has no `scripts/check-nul-bytes.mjs`, so the manual fallback was used).
- Dependency closure build: `pnpm --filter '@object-ui/fields^...' build` → exit 0.
- `pnpm exec vitest run packages/fields/ --maxWorkers=2` (run from repo root, per the repo's own vitest-invocation guard) → **107 test files / 1802 tests passed**.
- `pnpm --filter '@object-ui/fields' type-check` → exit 0, no errors.
- `pnpm --filter '@object-ui/fields' lint` → exit 0 (839 pre-existing warnings across the package, 0 errors; the one warning on the changed file, line 27's `any`, predates this change and sits outside the added comment block).

All commands run from the repository root; head commit `47c77c03b`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_