### PR TITLE
fix(components): honour a declared `container.maxWidth: false` as no maximum width

### DIFF
--- a/.changeset/gentle-pugs-smoke.md
+++ b/.changeset/gentle-pugs-smoke.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/components': patch
+---
+
+`container`: honour a declared `maxWidth: false` as "no maximum width"
+
+`ContainerSchema` has always declared `maxWidth?: … | false`, but the renderer
+read it as `schema.maxWidth || 'xl'`, so `false` folded into the default and a
+container asking for **no** constraint rendered `max-w-xl` (`max-width: 36rem`)
+— the opposite of what it declared. The `false` arm of the union had no
+reachable path from the day it was declared.
+
+`maxWidth` is now read with `??` (the spelling `stack` / `grid` always used, and
+the one objectui#4003 gave this file's `padding` and `flex`'s `gap`), and `false`
+emits an explicit **`max-w-none`** rather than simply omitting a class. The two
+are not the same fact: an omitted class leaves an inherited max-width standing —
+`@tailwindcss/typography`'s `.prose` sets `max-width: 65ch` — while `max-w-none`
+cancels it. The registry `inputs` enum for `maxWidth` gains `false` to match the
+type it lagged, so the designer and `sdui-parser`'s manifest gate stop reporting
+a legal value as `invalid-enum`.
+
+No authored node in the repo declared `maxWidth: false`, so nothing that renders
+today changes.

--- a/content/docs/components/layout/container.mdx
+++ b/content/docs/components/layout/container.mdx
@@ -13,6 +13,14 @@ description: "Centered content container with max-width"
 interface ContainerSchema {
   type: 'container';
   children: SchemaNode[];
+  // Max width constraint. `false` means NO maximum width, and it is rendered as
+  // an explicit `max-w-none` — it cancels a max-width inherited from elsewhere
+  // (the typography plugin's `prose`, for instance), which simply omitting the
+  // class would not do.
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl'
+    | '7xl' | 'full' | 'screen' | false;   // default: 'xl'
+  centered?: boolean;                       // default: true
+  padding?: number;                         // 0, 1-8, 10, 12, 16 — default: 4
   className?: string;
 }
 ```

--- a/examples/schema-catalog/src/schemas/components-layout-page/documentation-page.json
+++ b/examples/schema-catalog/src/schemas/components-layout-page/documentation-page.json
@@ -4,8 +4,11 @@
   "description": "Learn how to use the platform",
   "body": [
     {
-      "type": "div",
-      "className": "prose prose-slate max-w-none",
+      "type": "container",
+      "maxWidth": false,
+      "centered": false,
+      "padding": 0,
+      "className": "prose prose-slate",
       "children": [
         {
           "type": "text",

--- a/examples/schema-catalog/test/layout-props-conversion.test.tsx
+++ b/examples/schema-catalog/test/layout-props-conversion.test.tsx
@@ -14,9 +14,10 @@
  * Three different facts get pinned:
  *
  *  1. RATCHET — no `div` anywhere in the catalog carries layout-intent classes,
- *     except three nodes that cannot be converted and say why (below). This is
- *     the "keep the 107th out" guard, and the allowlist is what keeps it honest:
- *     a future conversion that regresses to `div` fails here.
+ *     except two nodes that cannot be converted and say why (below; the third
+ *     was recycled by objectui#4889). This is the "keep the 107th out" guard,
+ *     and the allowlist is what keeps it honest: a future conversion that
+ *     regresses to `div` fails here.
  *  2. NO DEAD SLOT — no `flex` / `stack` / `grid` / `container` node carries a
  *     `body` key. `div` renders `children || body`; all four layout renderers
  *     render `children` ONLY, so a body-keyed node re-typed naively renders
@@ -46,7 +47,7 @@
  * §测试纪律): registering the renderers is an unbounded module load and must not
  * be billed to a bounded hook timeout.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 import '@object-ui/components';
 import { SchemaRenderer } from '@object-ui/react';
@@ -57,7 +58,7 @@ type Node = Record<string, unknown>;
 const LAYOUT_TYPES = new Set(['flex', 'stack', 'grid', 'container']);
 
 /**
- * The three `div` nodes that keep layout-intent classes, each for a reason that
+ * The two `div` nodes that keep layout-intent classes, each for a reason that
  * survives any terminal state of #3965.
  *
  *   `components-basic-div/custom-card` (2 nodes) — rendered by
@@ -65,18 +66,21 @@ const LAYOUT_TYPES = new Set(['flex', 'stack', 'grid', 'container']);
  *   Only)". They exist to SHOW the deprecated spelling; converting them deletes
  *   the thing the page documents.
  *
- *   `components-layout-page/documentation-page` (1 node) — `prose prose-slate
- *   max-w-none`. `max-w-none` REMOVES a max-width (it cancels the typography
- *   plugin's own), the opposite of what `container.maxWidth` constrains, and no
- *   `maxWidth` value renders it: `ContainerSchema` declares `false` for the
- *   no-constraint case, but `container.tsx` reads it as `schema.maxWidth || 'xl'`,
- *   so `false` renders `max-w-xl`. Converting it would change the rendering; it
- *   is tracked separately rather than forced.
+ * RECYCLED (objectui#4889). `components-layout-page/documentation-page` (1 node,
+ * `prose prose-slate max-w-none`) was the third entry, and it was the one
+ * measured victim of a defect rather than a documented intent: `max-w-none`
+ * REMOVES a max-width — it cancels the typography plugin's own — and no
+ * `maxWidth` value rendered it. `ContainerSchema` declared `false` for the
+ * no-constraint case, but `container.tsx` read it as `schema.maxWidth || 'xl'`,
+ * so `false` rendered `max-w-xl`; converting the node would have changed what
+ * it rendered. #4889 made `false` reachable AND made it emit `max-w-none` (an
+ * explicit cancel, not an omitted class — the distinction this very node
+ * depends on), so the node is now authored as a `container` and the exemption
+ * is gone. An exemption outliving its cause is an exemption nobody can audit.
  */
 const DIV_EXEMPTIONS: ReadonlyArray<readonly [string, string]> = [
   ['components-basic-div/custom-card', 'max-w-sm rounded-lg border bg-card text-card-foreground shadow-sm'],
   ['components-basic-div/custom-card', 'p-6 space-y-2'],
-  ['components-layout-page/documentation-page', 'prose prose-slate max-w-none'],
 ];
 
 /** Does this className spell a capability one of the four layout types owns? */
@@ -206,6 +210,16 @@ describe('converted nodes render what their div rendered (#4003)', () => {
       'w-full max-w-4xl p-0 border rounded-lg overflow-hidden',
     ],
     [
+      // The #4889 recycle: this is the node the allowlist used to exempt. Its
+      // `max-w-none` now comes from `maxWidth: false` instead of a hand-written
+      // class, and `prose prose-slate` stays in `className` because that is
+      // typography, not layout.
+      'components-layout-page/documentation-page',
+      'prose prose-slate max-w-none',
+      'container',
+      'w-full max-w-none p-0 prose prose-slate',
+    ],
+    [
       'ecommerce/product-grid',
       'grid sm:grid-cols-2 lg:grid-cols-4 gap-6',
       'grid',
@@ -253,5 +267,55 @@ describe('converted nodes render what their div rendered (#4003)', () => {
     // that a naive re-type of a body-keyed node would fail.
     expect(after.innerHTML).toBe(before.innerHTML);
     expect(after.className).toBe(expectedClass);
+  });
+});
+
+/**
+ * The recycled node, measured on the fact it was exempted FOR (objectui#4889).
+ *
+ * The exemption was never "this node prefers a div" — it was "no `maxWidth`
+ * value can express cancelling an inherited max-width". So the conversion is
+ * only genuinely done if this node, as authored today, still computes
+ * `max-width: none` under the typography plugin's `.prose`. Asserting the class
+ * string alone would not show that: an implementation that merely stopped
+ * emitting a max-width class produces a perfectly reasonable-looking class list
+ * and leaves `.prose`'s 65ch standing.
+ *
+ * happy-dom resolves author stylesheets in `getComputedStyle`, so the cascade
+ * below is real. Values are the shipped ones (`.prose` → `maxWidth: '65ch'`
+ * from the plugin's `DEFAULT`; `--container-xl: 36rem` from Tailwind's theme),
+ * and the utilities are declared after `.prose` because that is the layer order
+ * Tailwind emits — equal specificity, so source order decides, as in the real
+ * CSS. Renderer-level coverage of the same rule lives in
+ * `packages/components/src/__tests__/container-max-width-false.test.tsx`.
+ */
+describe('the recycled documentation-page node still cancels prose\'s max-width (#4889)', () => {
+  let sheet: HTMLStyleElement;
+
+  beforeEach(() => {
+    sheet = document.createElement('style');
+    sheet.textContent = [
+      '.prose { max-width: 65ch; }',
+      '.max-w-none { max-width: none; }',
+      '.max-w-xl { max-width: 36rem; }',
+    ].join('\n');
+    document.head.appendChild(sheet);
+  });
+
+  afterEach(() => {
+    sheet.remove();
+  });
+
+  it('computes max-width: none, not the 65ch it would inherit', () => {
+    const example = allExamples().find((e) => e.id === 'components-layout-page/documentation-page');
+    expect(example, 'documentation-page is missing from the catalog').toBeTruthy();
+
+    const node = collect(example!.schema, (n) => n.type === 'container')[0];
+    expect(node, 'documentation-page no longer authors a container').toBeTruthy();
+    expect(node!.maxWidth, 'the node must author the declared no-constraint value').toBe(false);
+
+    const { container } = render(<SchemaRenderer schema={node as never} />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(getComputedStyle(el).maxWidth).toBe('none');
   });
 });

--- a/packages/components/src/__tests__/container-max-width-false.test.tsx
+++ b/packages/components/src/__tests__/container-max-width-false.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ContainerSchema.maxWidth: false` means "no maximum width", and it must
+ * CANCEL an inherited one rather than merely decline to add its own
+ * (objectui#4889).
+ *
+ * `ContainerSchema` has declared `maxWidth?: ... | false` since the type was
+ * written, but `container.tsx` read it as `schema.maxWidth || 'xl'`. `false ||
+ * 'xl'` is `'xl'`, so the one spelling for "do not constrain me" rendered
+ * `max-w-xl` — `max-width: 36rem`, the exact opposite of what it asked for —
+ * and the `false` arm of the union had no reachable path from the day it was
+ * declared. This is the #4001 failure mode: a declared value the engine
+ * silently swaps for another. `stack.tsx` and `grid.tsx` already read their
+ * scales with `??`, and objectui#4003 converged `flex`'s `gap` and this file's
+ * `padding` onto the same spelling; `maxWidth` was the last `||` in the family.
+ *
+ * WHY `??` ALONE IS NOT THE FIX. `maxWidth` is read as a chain of equality
+ * tests, and `false` equals none of the tokens — so `??` on its own would make
+ * the renderer emit NO max-width class. That is not the same fact as
+ * `max-w-none`:
+ *
+ *   absent  — the element declares nothing, and whatever else applies to it
+ *             wins. Under `@tailwindcss/typography` (a real dependency here,
+ *             loaded by `apps/console/src/index.css` via `@plugin`), `.prose`
+ *             sets `max-width: 65ch`, so the element is still constrained.
+ *   cancel  — `max-w-none` is `max-width: none`, which overrides `.prose` and
+ *             leaves the element genuinely unconstrained.
+ *
+ * The two coincide only when nothing else supplies a max-width, which is why
+ * the emission-only assertion below cannot be the whole pin: the one measured
+ * victim of this bug (the `components-layout-page/documentation-page` catalog
+ * node, `prose prose-slate max-w-none`, a recorded #4003 conversion exemption)
+ * needs the CANCEL. `container-cancels-inherited-max-width` is the assertion
+ * that tells the two apart, and it is the one that reddens if a future change
+ * "simplifies" the fix down to dropping the class.
+ *
+ * ON THE STYLESHEET THIS TEST INJECTS. happy-dom resolves author stylesheets in
+ * `getComputedStyle`, so the cascade is real rather than mocked. The three
+ * rules carry the values the real build produces — `.prose` from the typography
+ * plugin's `DEFAULT` (`maxWidth: '65ch'`), `.max-w-none` and `.max-w-xl` from
+ * Tailwind's own theme (`--container-xl: 36rem`) — and `.max-w-*` is declared
+ * AFTER `.prose` because that is the layer order Tailwind emits (typography
+ * registers `.prose` in `components`, utilities come last). Equal specificity,
+ * so source order is what decides, exactly as it does in the shipped CSS.
+ *
+ * Module-scope import of the renderers, not `beforeAll` (AGENTS.md §测试纪律):
+ * registering them is an unbounded module load and must not be billed to a
+ * bounded hook timeout.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import '../renderers';
+import { SchemaRenderer } from '@object-ui/react';
+
+function renderNode(schema: unknown): HTMLElement {
+  const { container } = render(<SchemaRenderer schema={schema as never} />);
+  return container.firstElementChild as HTMLElement;
+}
+
+const classOf = (schema: unknown): string => renderNode(schema).className;
+
+describe('container honours a declared maxWidth of false (#4889)', () => {
+  it('emits max-w-none, not the max-w-xl default', () => {
+    expect(classOf({ type: 'container', maxWidth: false, padding: 0, centered: false, children: [] }))
+      .toBe('w-full max-w-none p-0');
+  });
+
+  it('still defaults to xl when maxWidth is omitted', () => {
+    // The `false` fix must not turn "unspecified" into "no constraint" — that
+    // is the mirror-image bug, and it is why `??` is correct where `||` was not.
+    expect(classOf({ type: 'container', padding: 0, centered: false, children: [] }))
+      .toBe('w-full max-w-xl p-0');
+  });
+
+  it('leaves every named token rendering the class it always did', () => {
+    for (const token of ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl', 'full'] as const) {
+      expect(classOf({ type: 'container', maxWidth: token, padding: 0, centered: false, children: [] }))
+        .toBe(`w-full max-w-${token} p-0`);
+    }
+    // `screen` is the one token whose class is not `max-w-<token>`.
+    expect(classOf({ type: 'container', maxWidth: 'screen', padding: 0, centered: false, children: [] }))
+      .toBe('w-full max-w-screen-2xl p-0');
+  });
+});
+
+describe('`false` cancels an INHERITED max-width, it does not merely omit one (#4889)', () => {
+  let sheet: HTMLStyleElement;
+
+  beforeEach(() => {
+    sheet = document.createElement('style');
+    // Layer order as shipped: typography's `.prose` (components) first, the
+    // `max-w-*` utilities after it. See the file header.
+    sheet.textContent = [
+      '.prose { max-width: 65ch; }',
+      '.max-w-none { max-width: none; }',
+      '.max-w-xl { max-width: 36rem; }',
+    ].join('\n');
+    document.head.appendChild(sheet);
+  });
+
+  afterEach(() => {
+    sheet.remove();
+  });
+
+  it('harness self-check: the injected cascade tells absent from cancel', () => {
+    // Green on both legs of the reverse-verification by construction — it
+    // exercises no renderer code. It exists so that a failure of the two pins
+    // below cannot be read as "the stylesheet never applied".
+    const absent = renderNode({ type: 'div', className: 'prose' });
+    const cancelled = renderNode({ type: 'div', className: 'prose max-w-none' });
+    expect(getComputedStyle(absent).maxWidth).toBe('65ch');
+    expect(getComputedStyle(cancelled).maxWidth).toBe('none');
+  });
+
+  it('container-cancels-inherited-max-width: prose + maxWidth false computes none', () => {
+    const el = renderNode({
+      type: 'container',
+      maxWidth: false,
+      padding: 0,
+      centered: false,
+      className: 'prose',
+      children: [],
+    });
+    // Before the fix this is `36rem` (576px) — `.prose` would have been the
+    // lesser wrong answer; `||` folded `false` into `xl` and CONSTRAINED it.
+    expect(getComputedStyle(el).maxWidth).toBe('none');
+  });
+
+  it('the same node without the cancel would still inherit 65ch', () => {
+    // The counterfactual, built by hand: identical class list minus
+    // `max-w-none`. It measures what "just stop emitting a class" would have
+    // shipped, and is the reason the branch emits an explicit cancel.
+    const el = renderNode({ type: 'div', className: 'w-full p-0 prose' });
+    expect(getComputedStyle(el).maxWidth).toBe('65ch');
+  });
+});

--- a/packages/components/src/renderers/layout/container.tsx
+++ b/packages/components/src/renderers/layout/container.tsx
@@ -17,7 +17,13 @@ import { forwardRef } from 'react';
 // `__tests__/forwardref-props-annotation.guard.test.ts`.
 const ContainerRenderer = forwardRef<HTMLDivElement, { schema: ContainerSchema; className?: string }>(
   ({ schema, className, ...props }: { schema: ContainerSchema; className?: string; [key: string]: any }, ref) => {
-    const maxWidth = (schema.maxWidth || 'xl') as any;
+    // `??`, not `||`: `maxWidth` declares `false` for the "no maximum width"
+    // case, and `||` folded that legal value into the default — so a container
+    // asking for NO constraint rendered `max-w-xl` (36rem), the exact opposite
+    // of what it declared, and the `false` arm of the union had no reachable
+    // path from the day it was declared (objectui#4889). Same read as `padding`
+    // below, and the one `stack.tsx` / `grid.tsx` have always used.
+    const maxWidth = schema.maxWidth ?? 'xl';
     // `??`, not `||`: `padding` is a declared `number`, and `0` is a legal value
     // that `||` folds into the default — which left the `padding === 0 && 'p-0'`
     // branch below permanently unreachable, so a container asking for no padding
@@ -29,6 +35,14 @@ const ContainerRenderer = forwardRef<HTMLDivElement, { schema: ContainerSchema; 
       // Base container
       'w-full',
       // Max width
+      // `false` emits an EXPLICIT cancel, not merely the absence of a class.
+      // "Absent" and "cancel" coincide only when nothing else supplies a
+      // max-width. Under an INHERITED one they diverge — the typography
+      // plugin's `prose` sets `max-width: 65ch` on the same element — so
+      // dropping the class would leave that constraint standing and the
+      // declared "no maximum width" would still not be what renders
+      // (objectui#4889).
+      maxWidth === false && 'max-w-none',
       maxWidth === 'sm' && 'max-w-sm',
       maxWidth === 'md' && 'max-w-md',
       maxWidth === 'lg' && 'max-w-lg',
@@ -90,7 +104,34 @@ ComponentRegistry.register('container',
       { 
         name: 'maxWidth', 
         type: 'enum', 
-        enum: ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl', 'full', 'screen'],
+        // `false` is a member of the union `ContainerSchema.maxWidth` declares,
+        // and this list lagged it: an author reading the type wrote a value the
+        // published authoring surface called illegal, while the renderer folded
+        // it into `max-w-xl` anyway (objectui#4889). `inputs` is not
+        // documentation — `sdui-parser` serializes it into `sdui.manifest.json`
+        // and `sdui-intrinsics.d.ts`, and `validate.ts` gates authored props
+        // against it — so a value missing here is a value the platform reports
+        // as `invalid-enum`.
+        //
+        // The object form is what carries a non-string member: `enum` is typed
+        // `string[] | { label, value }[]`, not a mixed array, and `enumValues()`
+        // in `sdui-parser/src/validate.ts` flattens BOTH forms, so this stays a
+        // single `enum` arm whose closed list now contains `false`.
+        enum: [
+          { label: 'None (cancel max-width)', value: false },
+          { label: 'sm', value: 'sm' },
+          { label: 'md', value: 'md' },
+          { label: 'lg', value: 'lg' },
+          { label: 'xl', value: 'xl' },
+          { label: '2xl', value: '2xl' },
+          { label: '3xl', value: '3xl' },
+          { label: '4xl', value: '4xl' },
+          { label: '5xl', value: '5xl' },
+          { label: '6xl', value: '6xl' },
+          { label: '7xl', value: '7xl' },
+          { label: 'full', value: 'full' },
+          { label: 'screen', value: 'screen' },
+        ],
         label: 'Max Width',
         defaultValue: 'xl'
       },


### PR DESCRIPTION
Fixes #4889

`ContainerSchema` has declared `maxWidth?: … | false` since the type was written, but `container.tsx` read it as `schema.maxWidth || 'xl'`. `false || 'xl'` is `'xl'`, so the one spelling for "do not constrain me" rendered `max-w-xl` — `max-width: 36rem` — the exact opposite of what it declared. The `false` arm of the union had no reachable path from the day it was declared.

Implements the triage adjudication on the card (`auto-adjudicated`, veto window open — this PR stays draft until reviewed).

## The four deliverables

1. **`??` in place of `||`** — the spelling `stack.tsx` / `grid.tsx` always used, and the one #4003 gave this file's `padding` and `flex.tsx`'s `gap`. `maxWidth` was the last `||` in the family. The `as any` cast on the read is gone too: `schema.maxWidth ?? 'xl'` types precisely, so `maxWidth === false` is a checked comparison rather than a cast.
2. **An explicit `max-w-none`**, not merely an omitted class. See the measurement below — this is the deliverable the ruling flagged as most likely to be shortcut, and shortcutting it leaves the one measured victim unfixed.
3. **The registry `inputs` enum gains `false`.** `enum` is typed `string[] | { label, value }[]` — not a mixed array — so the list moves to the object form, which is what can carry a non-string member. It stays a single `enum` arm: `enumValues()` in `sdui-parser/src/validate.ts` flattens both forms, so the manifest gate now accepts `false` instead of reporting a declared value as `invalid-enum`.
4. **The #4003 allowlist exemption is recycled.**

## Deliverable 4 — the exemption's actual location

The claim deliberately did not state it. Located by reading, it is **not** a data file or a lint allowlist but a constant inside the #4003 guard test:

- `examples/schema-catalog/test/layout-props-conversion.test.tsx` — the `DIV_EXEMPTIONS` array (plus the doc comment above it that justifies each entry, and the "except three nodes" wording in the file header).
- The node it exempted: `examples/schema-catalog/src/schemas/components-layout-page/documentation-page.json`.

Both halves had to move together. The guard's second test asserts every exemption still matches a real `div`, so dropping the entry without converting the node fails there; converting the node without dropping the entry fails the same test the other way. The node is now authored as a `container` with `maxWidth: false`, `centered: false`, `padding: 0` and `className: "prose prose-slate"`, and a new equivalence case pins it in the same table as the other eight #4003 conversions.

## Why "absent" is not "cancel" — measured, not argued

`@tailwindcss/typography` is a real dependency here (0.5.20, loaded by `apps/console/src/index.css` via `@plugin`), and its `DEFAULT` sets `.prose { max-width: 65ch }`. So on the documentation-page node the three candidate behaviours diverge:

| renderer behaviour | class list | computed `max-width` |
| --- | --- | --- |
| `\|\|` (before) | `… max-w-xl …` | `576px` — wrong, and constrained |
| `??` only, no cancel | `w-full p-0 prose prose-slate` | `65ch` — still constrained |
| `??` + `max-w-none` (this PR) | `w-full max-w-none p-0 prose prose-slate` | `none` |

Those numbers are the actual output of the two ablation legs below, not a prediction.

## Verification

Verified at `38e8596e8` (the final commit; the working tree was byte-identical to it for every run — `git diff --exit-code HEAD` clean).

**Re-derived on current `origin/main`** (`a954b4849`), not on any prior description of the file: PR #5298 tightened `readMax`, which lives in `containers.tsx` and is `page:header`-only — a different file from `container.tsx` and unrelated to this key.

**Blast radius re-measured rather than inherited.** Zero authored nodes declare `maxWidth: false` across `packages` / `apps` / `examples` / `content` / `e2e` in `.json`, `.ts`, `.tsx`, `.md`, `.mdx`. Counter-probed with the neighbouring live key so the zero is a reading and not a dead search: the same sweep finds 23 `maxWidth:` declarations (6 of them in catalog JSON). No producer has appeared since the adjudication.

**No build artifact sits between the edit and the thing under test.** The root `vitest.config.mts` aliases `@object-ui/components` → `packages/components/src` (and every sibling package likewise), so both the renderer test and the catalog test — which imports the package specifier — resolve to source. Neither ablation leg needed a rebuild, and neither could have gone falsely green on stale `dist/`.

**Reverse-verification, two legs, predicted before running.**

*Leg A — revert `container.tsx` to `origin/main`, keep tests and the converted JSON.* Predicted 4 red, observed exactly those 4, values included:

| assertion | predicted | observed |
| --- | --- | --- |
| `emits max-w-none, not the max-w-xl default` | `w-full max-w-xl p-0` | same |
| `container-cancels-inherited-max-width` | `576px` | same |
| `components-layout-page/documentation-page (… → container)` | no node matches the pinned class | same |
| `the recycled documentation-page node still cancels prose's max-width` | `576px` | same |

*Leg B — keep `??`, remove only the `max-w-none` branch* (the shortcut the ruling warns about). Same 4 assertions red, but the two inherited-max-width assertions now report **`65ch`**, not `576px` — the node still inherits prose's constraint, i.e. the card would not be fixed. That is what makes deliverable 2 independently pinned rather than a rider on deliverable 1.

**Assertions green on both legs pin nothing about this fix, and are not counted as pins.** Named rather than quietly tallied: `still defaults to xl when maxWidth is omitted` (the mirror-image guard — `undefined` behaves identically under `||` and `??`); `leaves every named token rendering the class it always did` (no-regression sweep over the truthy tokens); `harness self-check: the injected cascade tells absent from cancel` and `the same node without the cancel would still inherit 65ch` (both raw `div`s, exercising no renderer code — they exist so a failure of the real pins cannot be misread as "the stylesheet never applied"); and the pre-existing #4003 assertions, including `no div carries layout-intent classes` (green on both legs because the JSON half of the recycle is renderer-independent).

**Suites and gates run locally** (targeted, per the affected-package rule; the full farm is CI's):

- `pnpm exec vitest run packages/components/ examples/schema-catalog/ packages/sdui-parser/` — **180 files, 3128 tests passed**.
- `pnpm exec vitest run apps/console/src/__tests__/` — **14 files, 202 tests passed**. Run because that is where the registry-`inputs` consumers live: `registry-inputs-spec-parity`, `component-input-union-specimens`, `record-block-record-reach`, `public-block-binding-reach` all read `inputs[].enum` and all handle the object form.
- `turbo run type-check --filter=@object-ui/components --filter=@object-ui/example-schema-catalog` — 30 tasks, 0 failed (`type-check` `dependsOn: ^build`, so the dependency closure was built first).
- `turbo run lint` on the same two packages — **0 errors**. The 890 warnings are pre-existing and live in `src/ui/**` (the no-touch Shadcn zone); the two on `container.tsx` are on the untouched `forwardRef` annotation from #4422. Net `any` count in the file went down by one.
- `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`, `check-doc-links`, `check-doc-component-types` — all pass. `check-doc-snippet-types` first refused to run (`@object-ui/cli` unbuilt in a fresh worktree — a preflight refusal, not a finding, and it names a package this diff does not touch); after running the gate's own `--build-filter` set as the workflow does, it passes.
- Control bytes additionally self-scanned across the changed files with `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` — no hits.

## Contract note

`container` has no entry in `@objectstack/spec`'s `ComponentPropsMap` (checked at the pinned 17.0.0 — 37 blocks, none of them `container`), so `ContainerSchema` in `packages/types` is the contract, and it already declares `false`. This restores declared = enforced without widening the accepted set — bug-repair lane, matching the adjudication's own mechanical boundary test. No lenient consumer-side fallback was added anywhere; the read got stricter, not laxer.

Changeset: `patch`, on `@object-ui/components`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_