### PR TITLE
test(plugin-dashboard): close DashboardGridLayout's object-chart metadata network escape (#5299)

### DIFF
--- a/.changeset/dashboard-grid-object-chart-metadata-probe-network-escape-5299.md
+++ b/.changeset/dashboard-grid-object-chart-metadata-probe-network-escape-5299.md
@@ -1,0 +1,22 @@
+---
+---
+
+Test-only (objectui#5299). `DashboardGridLayout.datasetPath.test.tsx`'s
+'options.data provider widget' negative-control test escaped to the real network:
+1 live TCP connection attempt per run against `http://localhost:3000` (happy-dom's
+default document URL), best-effort-swallowed so all 13 pre-existing tests stayed
+green throughout. `-t` bisected across all 13 cases in isolation to pin the exact
+site — the only escape in the file — refuting the `isLegacyRetiredWidget` sentinel
+candidate a previous round suspected (neither of its two tests escapes alone).
+
+Root cause: the `options.data.provider: 'object'` widget maps to component type
+`object-chart`, whose `ObjectChart.tsx` (`@object-ui/plugin-charts`) still carries
+its own inline `apiFetch ?? fetch` category-color probe — the original objectui#4106
+defect site, never migrated onto the `useDatasetDimensionMeta` hook objectui#4389
+extracted for the dataset-bound path. Same fix shape as objectui#5225's reference PR
+(#5283) and objectui#5280's port (#5300): a recording double answers the metadata
+route, `afterEach` fails on any non-metadata escape instead of swallowing it, and
+`cleanup()` runs before `vi.unstubAllGlobals()` in the same `afterEach` to avoid the
+reverse-registration flake #5280 measured. One new test pins the probe's own request
+shape (exactly one call to `/api/v1/meta/object/invoices`). All 13 pre-existing tests
+still pass; none depended on the swallowed failure. No published behaviour changes.

--- a/packages/plugin-dashboard/src/__tests__/DashboardGridLayout.datasetPath.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardGridLayout.datasetPath.test.tsx
@@ -55,7 +55,7 @@
  * as before AND must never reach the dataset query.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import type { DashboardComponentSchema } from '@object-ui/types';
@@ -63,7 +63,89 @@ import '@object-ui/components';
 import '@object-ui/plugin-charts';
 import { DashboardGridLayout } from '../DashboardGridLayout';
 
-afterEach(cleanup);
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#5299 — this file's own real-network escape (same class as #5225 /
+ * #5280, a DIFFERENT call site).
+ *
+ * `-t` bisected across all 13 cases: isolating each of the 5 negative-control
+ * tests alone reproduces the escape ONLY for 'does NOT take the dataset path
+ * for an options.data provider widget' (3/3). The other two suspects the card
+ * named — both #4613 legacy-retired-widget cases — do NOT escape in isolation
+ * (0/1 each), and neither do the dataset-bound positives, confirming the
+ * card's own re-derived reading: `useDatasetDimensionMeta`'s `!object` guard
+ * is a no-op here (no mocked `queryDataset` result declares `object`), so it
+ * was never the site. There is exactly ONE escape in this file, not several.
+ *
+ * The site: the `options.data.provider: 'object'` widget maps to component
+ * type `object-chart` (`DashboardGridLayout.tsx`'s `getComponentSchema`,
+ * `isObjectProvider` branch) with `objectName: 'invoices'` and a defaulted
+ * `xAxisKey: 'name'` (no `xField` authored). `ObjectChart` — the ORIGINAL
+ * #4106 defect site, still carrying its own inline fetch rather than the
+ * `useDatasetDimensionMeta` hook #4389 later extracted for the dataset path —
+ * runs a category-dimension option-color probe on mount:
+ *
+ *   ObjectChart                        packages/plugin-charts/src/ObjectChart.tsx
+ *     useEffect (~L351-415)
+ *       → `const doFetch = apiFetch ?? fetch`   ← the escape (L355)
+ *         → GET /api/v1/meta/object/invoices    (L376, via loadDimensionFieldMeta)
+ *
+ * With no `SchemaRendererProvider` in this file's render tree, `context` is
+ * undefined, so `apiFetch` is undefined and the probe degrades to the GLOBAL
+ * `fetch` on purpose (#4114 / #4121 — a standalone embed must keep rendering,
+ * not crash). Under happy-dom that global `fetch` is a real HTTP client
+ * resolving the relative URL against the default document origin
+ * (`http://localhost:3000`), hence the ECONNREFUSED-on-port-3000 signature.
+ * The read is wrapped in `try { … } catch { setOptionMeta(null) }`, which is
+ * why the widget renders fine and all 13 tests stay green regardless.
+ *
+ * Answered here from the same RECORDING-double shape #5225's reference fix
+ * (PR #5283) established and #5280 ported (PR #5300): NOT a blanket network
+ * stub — it records every URL it is handed, `afterEach` fails on any URL that
+ * is not the metadata route, and the probe's own request is pinned below.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const META_OBJECT_ROUTE = /^\/api\/v1\/meta\/object\/(.+)$/;
+
+let metaCalls: string[] = [];
+
+/** Serve `/api/v1/meta/object/<name>` with an empty schema doc; record everything. */
+function installMetaObjectDouble() {
+  metaCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      metaCalls.push(url);
+      const m = META_OBJECT_ROUTE.exec(url);
+      if (!m) return { ok: false, status: 404, json: async () => ({}) };
+      const name = decodeURIComponent(m[1]);
+      // No fields declared: `loadDimensionFieldMeta` resolves nothing, so
+      // `optionMeta` stays empty and no pre-existing assertion changes
+      // meaning — this widget's colors were never asserted against the probe.
+      return { ok: true, status: 200, json: async () => ({ item: { name, fields: {} } }) };
+    }),
+  );
+}
+
+beforeEach(() => {
+  installMetaObjectDouble();
+});
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into ObjectChart's best-effort `catch`.
+  expect(metaCalls.filter((url) => !META_OBJECT_ROUTE.test(url))).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks
+  // in reverse registration order, so the light DOM setup's RTL cleanup (its
+  // own `afterEach`, registered before this file loads) runs AFTER this one:
+  // unstubbing first would leave the tree mounted with the real global back
+  // in place, and a metadata effect that settles in that window escapes again
+  // (#5225 / #5280 measured this ordering flake).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 /**
  * `dataset` / `values` / `dimensions` are the ADR-0021 authoring keys; `object`
@@ -245,6 +327,33 @@ describe('DashboardGridLayout dataset-bound widgets (#4614)', () => {
     const src = makeSource(async () => ({ rows: [{ x: 1 }] }));
     renderOne({ id: 'w1', type: 'metric', object: 'invoices', aggregate: 'count' }, src);
     expect(screen.getByText(/retired data format/i)).toBeInTheDocument();
+    expect(src.queryDataset).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * objectui#5299 — the `options.data.provider: 'object'` widget's own
+ * category-color metadata probe, pinned so a future widening of the read (or
+ * a regression back onto the real network) shows up as a red test here
+ * instead of a silent extra request to whatever owns port 3000.
+ */
+describe('DashboardGridLayout — object-chart metadata probe (objectui#5299)', () => {
+  it('probes exactly the widget-declared object, once, over the metadata route', async () => {
+    const src = { queryDataset: vi.fn(async () => ({ rows: [] })) };
+    render(
+      <DashboardGridLayout
+        schema={dash({
+          id: 'w1',
+          type: 'bar',
+          options: { data: { provider: 'object', object: 'invoices', aggregate: { field: 'amount', function: 'sum' } } },
+        })}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(metaCalls).toEqual(['/api/v1/meta/object/invoices']));
+    // Bisected as the ONLY escape site in this file (see the block comment
+    // above): the rows never touch this channel, which is why the sibling
+    // `dataSource` double in the test above it could not intercept it either.
     expect(src.queryDataset).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #5299

## The escape, bisected

`DashboardGridLayout.datasetPath.test.tsx` made a real network call — same ECONNREFUSED-on-port-3000 signature as #5225 / #5280, a different file. Reproduced 3/3 in isolation pre-fix (1 attempt; all 13 tests still passed, which is exactly why nothing caught it).

Per the card, the actual work item was the `-t` bisect. Running each of the 5 negative-control tests alone:

| test | ECONNREFUSED alone |
|---|---|
| `does NOT take the dataset path for a static-data widget` | 0/1 |
| `does NOT take the dataset path for an options.data provider widget` | **3/3** |
| `does NOT take the dataset path for a static-data pivot widget` | 0/1 |
| `still shows the #4613 retired-format placeholder for a legacy widget…` | 0/1 |
| `renders a legacy widget's placeholder even when a dataSource IS supplied…` | 0/1 |

There is exactly **one** escape site in this file, not several. This refutes the card's `isLegacyRetiredWidget` sentinel candidate — neither of its two tests escapes alone, confirming the card's own re-derived reading that `useDatasetDimensionMeta`'s `!object` guard was never the site (no mocked `queryDataset` result here declares `object`).

## Root cause

The `options.data.provider: 'object'` widget maps to component type `object-chart` (`DashboardGridLayout.tsx`'s `getComponentSchema`, `isObjectProvider` branch) with `objectName: 'invoices'` and a defaulted `xAxisKey: 'name'`. `ObjectChart.tsx` (`@object-ui/plugin-charts`) — the original #4106 defect site, never migrated onto the `useDatasetDimensionMeta` hook #4389 extracted for the dataset-bound path — still carries its own inline fetch for a category-dimension option-color probe:

```
ObjectChart                        packages/plugin-charts/src/ObjectChart.tsx
  useEffect (~L351-415)
    → const doFetch = apiFetch ?? fetch   ← the escape (L355)
      → GET /api/v1/meta/object/invoices  (L376, via loadDimensionFieldMeta)
```

With no `SchemaRendererProvider` in this file's render tree, `apiFetch` is undefined and the probe degrades to the global `fetch` on purpose (#4114 / #4121 — a standalone embed must keep rendering, not crash). Under happy-dom that resolves the relative URL against the default document origin (`http://localhost:3000`), hence the signature. The read is wrapped in `try { … } catch { setOptionMeta(null) }`, which is why the widget renders fine regardless.

**This is a test-harness gap, not a product bug** — no fork to report; the "suggested fix shape" branch of the card applies.

## The fix — ports the established shape (#5283 → #5280/#5300)

- A **recording double** answers `/api/v1/meta/object/{name}`.
- `afterEach` **fails on any non-metadata escape** instead of swallowing it.
- `cleanup()` runs **before** `vi.unstubAllGlobals()` in the same `afterEach` — #5280 measured the LIFO reverse-registration order as a real flake source here.
- One new pin test asserts the probe's own request shape (exactly one call to `/api/v1/meta/object/invoices`), proving the double is actually exercised.

Test-only. File surface: the one test file + an empty-frontmatter changeset (judged via `node scripts/check-changeset-presence.mjs`).

## Verification

- Isolated file, pre-fix: 3/3 runs, 1 ECONNREFUSED attempt each (`grep -c ECONNREFUSED` = 2, matching the card's own count).
- Isolated file, post-fix: 3/3 runs, 0 ECONNREFUSED, 14/14 tests passing (13 original + 1 new pin).
- Full package (`pnpm exec vitest run packages/plugin-dashboard`, from repo root): 65 files / 594 tests passed, 0 ECONNREFUSED — no residual escape.
- **Reverse-verification** (fix committed first, then the double-install call was disabled while the new pin test was kept, per AGENTS.md's revert-with-pin discipline): predicted the pin test goes red (times out — nothing populates its recording array) and the 13 pre-existing tests stay green (the swallowed-escape signature is exactly why this bug survived). Observed: 1 failed (the pin, `Timeout … expected [] to equal ['/api/v1/meta/object/invoices']`), 13 passed — predicted-vs-observed match. ECONNREFUSED count rose to 4 in this leg (2 attempts: the original site plus the new pin test's own render, both hitting the real network with the double off) — diagnostics increased, not decreased, as expected for an added-test revert. Restored the file to the just-committed fix with a branch-and-path-scoped `git checkout` (`git diff HEAD` confirmed clean afterward).
- `pnpm --filter @object-ui/plugin-dashboard type-check`: clean (script is `type-check`, not `typecheck`).
- `pnpm --filter @object-ui/plugin-dashboard lint`: 0 errors, 0 new warnings (317 pre-existing warnings elsewhere, none in the touched file).
- `node scripts/check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-control-bytes.mjs`: all green.

Ran from the repository root throughout, per AGENTS.md. Final commit: `9e2578265`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_
