### PR TITLE
fix(core): cloneAsOverride returns a mutable type, so an override draft type-checks

### DIFF
--- a/.changeset/clone-as-override-returns-mutable-5257.md
+++ b/.changeset/clone-as-override-returns-mutable-5257.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/core': patch
+---
+
+`cloneAsOverride()` now returns `DeepMutable<T>`, so a Tenant/User override draft type-checks as the mutable value it has always been.
+
+`cloneAsOverride<T>(view: T): T` handed the input type straight back. Cloning a
+`SystemView<S>` — which is `DeepReadonly<S>` plus the marker symbol — therefore
+returned something still typed deep-readonly, even though the implementation has
+always produced a plain mutable object (`structuredClone`, or a JSON round-trip
+fallback) and deliberately drops the marker. The declaration was simply wrong
+about its own value, and the documented override flow was the thing that broke:
+
+```ts
+const draft = cloneAsOverride(userListView)
+draft.columns.push({ name: 'name' })   // TS2339 before this change
+```
+
+That is `packages/core/README.md`'s override example, and it failed to compile
+against the built types — measured by the doc-snippet compile gate, which reads
+`dist/*.d.ts` rather than source. The neighbouring line one block up,
+`userListView.columns.push(...) // ❌ TypeError (strict mode)`, is the opposite
+demonstration and correctly still fails; only the draft line changes colour.
+
+The fix adds `DeepMutable<T>`, the inverse of the `DeepReadonly<T>` that
+`SystemView` is built from, and returns it. Per the maintainer's 2026-08-19
+ruling (option A on objectui#5257), the alternatives were rejected by name:
+teaching a cast in the README is the lenient-consumer pattern the contract rules
+out, and declaring the block a documentation fragment hides a real signature
+defect behind the fragment marker.
+
+Why this is a patch and not a break: the return type relaxes TOWARD what the
+runtime already does, never away from it. A caller gains permission to mutate;
+nobody loses one. `DeepMutable<S>` stays assignable everywhere `DeepReadonly<S>`
+or `SystemView<S>` was expected, so a caller who fed a draft back into a
+deep-readonly position still compiles — both directions are pinned as type-level
+cases in `freeze-schema.types.test.ts`. A repo-wide sweep found no call site at
+all outside the README, so nothing in this workspace needed changing.
+
+Two limits of `DeepMutable`, stated rather than discovered later. It is
+symmetric with `DeepReadonly` arm for arm, which means it inherits the same
+tuple behaviour: a tuple widens to an array, exactly as `DeepReadonly` widens it
+in the other direction. And it does not remove the `SYSTEM_VIEW_MARKER` key —
+the clone never carries the symbol at runtime, but the key is declared optional,
+so keeping it states "may be absent", which is true. Excluding it would require
+a non-homomorphic mapped type that drops the `?` modifier from every other
+property and turns optional keys required — a strictly worse type traded for
+removing a key that already reads as optional.

--- a/packages/core/src/utils/__tests__/freeze-schema.types.test.ts
+++ b/packages/core/src/utils/__tests__/freeze-schema.types.test.ts
@@ -1,0 +1,279 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Type-level pins for objectui#5257 — `cloneAsOverride` returns a type that
+ * tells the truth about the value it produces.
+ *
+ * The defect: `cloneAsOverride<T>(view: T): T` handed the input type straight
+ * back, so cloning a `SystemView<S>` returned something still typed
+ * deep-readonly while the implementation had always produced a plain mutable
+ * object. The documented override flow (`packages/core/README.md`,
+ * `draft.columns.push(...)`) therefore did not compile — TS2339, measured by the
+ * #5138 snippet gate. The fix returns `DeepMutable<T>`, the inverse of the
+ * `DeepReadonly<T>` that `SystemView` is built from.
+ *
+ * Why this file drives `tsc` itself: the property under test is what the
+ * COMPILER accepts. A runtime test cannot observe it — the runtime was never
+ * wrong — and `expectTypeOf` is unavailable here (vitest's `typecheck` mode is
+ * off in `vitest.config.mts`; enabling it is a shared-config change owned by
+ * objectui#3181, not by this card). So the cases are compiled as a virtual
+ * module against the real declarations and the diagnostics are read back. Same
+ * mechanism as `actions/__tests__/actionKeys.types.test.ts`.
+ *
+ * NO BUILD ARTIFACT SITS BETWEEN THE EDIT AND THESE ASSERTIONS. The preamble
+ * imports `../freeze-schema` by relative path, so the program reads the SOURCE
+ * file; every type these cases touch (`DeepReadonly`, `DeepMutable`,
+ * `SystemView`, `cloneAsOverride`) is declared in that one file and resolves
+ * through no workspace package. That is what makes this suite safe from the
+ * staleness `actionKeys.types.test.ts` documents for its `description` pin,
+ * where an indexed access into a WORKSPACE package degraded to `any` whenever
+ * `dist` was unbuilt and turned a `rejected: true` row green for an unrelated
+ * reason. The complementary dist-resolved measurement is the #5138 snippet gate
+ * over `packages/core/README.md`, which compiles against the built
+ * `dist/*.d.ts`; the two legs are deliberately different resolutions.
+ *
+ * The discrimination proof is built in rather than promised in prose: every case
+ * is compiled a SECOND time with one line changed — `cloneAsOverride` redeclared
+ * with its PRE-FIX signature `<T>(view: T) => T`, everything else still the real
+ * module. `EXPECTED_FLIPS` names, by index, exactly which cases that reverts.
+ * A case outside that set is green on BOTH legs and is stated as such, not
+ * quietly counted as evidence.
+ */
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { defineSystemView, cloneAsOverride, isSystemView, SYSTEM_VIEW_MARKER } from '../freeze-schema.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MODULE_IMPORT = join(HERE, '..', 'freeze-schema').replace(/\\/g, '/');
+
+/** One statement, and whether `tsc` is required to reject it. */
+interface Case {
+  readonly what: string;
+  readonly code: string;
+  readonly rejected: boolean;
+}
+
+/** The schema every case clones, written once so the cases stay readable. */
+const VIEW = `defineSystemView({ type: 'list', data: { object: 'User' }, columns: [{ name: 'email' }] })`;
+
+const CASES: readonly Case[] = [
+  // ── The acceptance criterion, in type form ────────────────────────────────
+  // This is `packages/core/README.md`'s override flow. It is the whole card.
+  {
+    what: 'a cloneAsOverride draft accepts .push on a nested array',
+    rejected: false,
+    code: `cloneAsOverride(${VIEW}).columns.push({ name: 'name' });`,
+  },
+  {
+    what: 'a cloneAsOverride draft accepts assignment to a nested property',
+    rejected: false,
+    code: `cloneAsOverride(${VIEW}).data.object = 'Account';`,
+  },
+  {
+    what: 'a cloneAsOverride draft accepts assignment to a top-level property',
+    rejected: false,
+    code: `cloneAsOverride(${VIEW}).type = 'form';`,
+  },
+
+  // ── The opposite, which MUST stay rejected ────────────────────────────────
+  // `defineSystemView` is the immutability contract; relaxing the clone must
+  // not relax the source. Both of these are documented README behaviour.
+  {
+    what: 'the System View itself still refuses .push on a nested array',
+    rejected: true,
+    code: `${VIEW}.columns.push({ name: 'name' });`,
+  },
+  {
+    what: 'the System View itself still refuses assignment to a property',
+    rejected: true,
+    code: `${VIEW}.type = 'form';`,
+  },
+  {
+    what: 'the System View itself still refuses assignment to a NESTED property',
+    rejected: true,
+    code: `${VIEW}.data.object = 'Account';`,
+  },
+
+  // ── The ruling's load-bearing premise: the type RELAXES, so callers keep
+  //    compiling. A caller who fed the clone back into a deep-readonly
+  //    position compiled before the change and must still compile after it.
+  {
+    what: 'a draft is still assignable to the deep-readonly SystemView it came from',
+    rejected: false,
+    code:
+      `const back: SystemView<{ type: string; data: { object: string }; columns: { name: string }[] }> = ` +
+      `cloneAsOverride(${VIEW}); void back;`,
+  },
+  {
+    what: 'a draft is still assignable to a DeepReadonly of the same shape',
+    rejected: false,
+    code:
+      `const ro: DeepReadonly<{ type: string; data: { object: string }; columns: { name: string }[] }> = ` +
+      `cloneAsOverride(${VIEW}); void ro;`,
+  },
+
+  // ── DeepMutable's own shape ───────────────────────────────────────────────
+  // Optionality must survive. A non-homomorphic mapped type (the shape needed
+  // to also strip SYSTEM_VIEW_MARKER) drops the `?` modifier and turns every
+  // optional key required — this case is what would catch that regression:
+  // the literal omits `b`, which is legal only while `b?` is still optional.
+  {
+    what: 'DeepMutable preserves optional (?) property modifiers',
+    rejected: false,
+    code: `const opt: DeepMutable<{ a: number; b?: string }> = { a: 1 }; void opt;`,
+  },
+  {
+    what: 'DeepMutable strips readonly at depth, not just at the top level',
+    rejected: false,
+    code:
+      `const deep: DeepMutable<DeepReadonly<{ a: { b: { c: number[] } } }>> = ` +
+      `{ a: { b: { c: [1] } } }; deep.a.b.c.push(2);`,
+  },
+  {
+    what: 'DeepMutable leaves a primitive alone, so the null/primitive passthrough still types',
+    rejected: false,
+    code: `const prim: number = cloneAsOverride(42); void prim;`,
+  },
+  {
+    what: 'DeepMutable leaves a function alone rather than mapping over its properties',
+    rejected: false,
+    code: `const fn: DeepMutable<(x: number) => string> = (x) => String(x); void fn;`,
+  },
+];
+
+/** Line numbers (case indices) that produced a semantic diagnostic. */
+function erroringLines(preamble: string): Set<number> {
+  const header = `${preamble}\n`;
+  const body = CASES.map((c) => c.code).join('\n');
+  const source = `${header}${body}\nexport {};\n`;
+  const headerLines = header.split('\n').length - 1;
+
+  const VIRTUAL = join(HERE, '__freezeSchemaTypePins.virtual.ts').replace(/\\/g, '/');
+  const options: ts.CompilerOptions = {
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ESNext,
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, languageVersion, ...rest) =>
+    fileName === VIRTUAL
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(fileName, languageVersion, ...rest);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (fileName) => (fileName === VIRTUAL ? true : fileExists(fileName));
+  const readFile = host.readFile.bind(host);
+  host.readFile = (fileName) => (fileName === VIRTUAL ? source : readFile(fileName));
+
+  const program = ts.createProgram([VIRTUAL], options, host);
+  const sf = program.getSourceFile(VIRTUAL);
+  if (!sf) throw new Error('virtual source file was not added to the program');
+
+  const lines = new Set<number>();
+  for (const d of program.getSemanticDiagnostics(sf)) {
+    if (d.start == null) continue;
+    lines.add(sf.getLineAndCharacterOfPosition(d.start).line - headerLines);
+  }
+  return lines;
+}
+
+const REAL_PREAMBLE =
+  `import { defineSystemView, cloneAsOverride } from '${MODULE_IMPORT}';\n` +
+  `import type { DeepReadonly, DeepMutable, SystemView } from '${MODULE_IMPORT}';`;
+
+/**
+ * The same module with ONE line changed: `cloneAsOverride` redeclared with the
+ * signature it carried before this card. Everything else — `DeepMutable`,
+ * `DeepReadonly`, `SystemView`, `defineSystemView` — is still the real thing,
+ * so a flip here can only be caused by the return type.
+ */
+const REVERTED_PREAMBLE =
+  `import { defineSystemView } from '${MODULE_IMPORT}';\n` +
+  `import type { DeepReadonly, DeepMutable, SystemView } from '${MODULE_IMPORT}';\n` +
+  `declare const cloneAsOverride: <T>(view: T) => T;`;
+
+// Module scope on purpose (see the header of actionKeys.types.test.ts): the
+// compiler cost lands in the import phase rather than under a hook timeout.
+const againstReal = erroringLines(REAL_PREAMBLE);
+const againstReverted = erroringLines(REVERTED_PREAMBLE);
+
+describe('cloneAsOverride returns a mutable type (objectui#5257)', () => {
+  for (const [i, c] of CASES.entries()) {
+    it(c.what, () => {
+      expect({ case: c.what, rejected: againstReal.has(i) }).toEqual({ case: c.what, rejected: c.rejected });
+    });
+  }
+});
+
+/**
+ * Indices that the pre-fix signature turns red. Named explicitly so the file
+ * records which assertions actually discriminate — the rest are green on BOTH
+ * legs and prove nothing about this change on their own.
+ *
+ *   0,1,2 — the three mutation cases: the whole defect.
+ *   3,4,5 — rejected on both legs (the System View is untouched by the change).
+ *   6,7   — clean on both legs: the relaxation is assignable back, which is the
+ *           ruling's premise and is exactly what "callers keep compiling" means.
+ *   8-11  — DeepMutable's own shape; it does not exist on the pre-fix leg's
+ *           `cloneAsOverride`, but the type itself is imported either way, so
+ *           these stay clean on both legs by construction.
+ */
+const EXPECTED_FLIPS = [0, 1, 2];
+
+describe('discrimination: the same cases against the pre-fix signature', () => {
+  it('reverting the return type to T is what turns the override flow red', () => {
+    const flipped = CASES.map((c, i) => ({ what: c.what, i }))
+      .filter(({ i }) => againstReverted.has(i) !== againstReal.has(i))
+      .map(({ i }) => i);
+    expect(flipped).toEqual(EXPECTED_FLIPS);
+  });
+
+  it('every flipped case is one that must COMPILE now and did NOT before', () => {
+    for (const i of EXPECTED_FLIPS) {
+      expect({ i, now: againstReal.has(i), before: againstReverted.has(i) }).toEqual({
+        i,
+        now: false,
+        before: true,
+      });
+    }
+  });
+});
+
+/**
+ * The other half of "the type tells the truth about the value": the runtime
+ * behaviour the type now describes. These would have passed before the change
+ * too — the runtime was never the defect — and they are here so a future edit
+ * cannot fix the mismatch by making the RUNTIME readonly instead.
+ */
+describe('cloneAsOverride runtime behaviour the type now describes', () => {
+  it('produces a mutable clone while the source stays frozen', () => {
+    const view = defineSystemView({ type: 'list', columns: [{ name: 'email' }] });
+    const draft = cloneAsOverride(view);
+
+    draft.columns.push({ name: 'name' });
+    expect(draft.columns).toHaveLength(2);
+    expect(Object.isFrozen(view)).toBe(true);
+    expect(view.columns).toHaveLength(1);
+  });
+
+  it('drops the System View marker, so the clone is no longer a System View', () => {
+    const view = defineSystemView({ type: 'list', columns: [{ name: 'email' }] });
+    const draft = cloneAsOverride(view);
+
+    expect(isSystemView(view)).toBe(true);
+    expect(isSystemView(draft)).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(draft, SYSTEM_VIEW_MARKER)).toBe(false);
+  });
+});

--- a/packages/core/src/utils/freeze-schema.ts
+++ b/packages/core/src/utils/freeze-schema.ts
@@ -45,6 +45,38 @@ export type DeepReadonly<T> = T extends (...args: any[]) => any
       : T;
 
 /**
+ * The inverse of `DeepReadonly<T>`: recursively strip `readonly` at every depth.
+ *
+ * Named `DeepMutable` rather than `Mutable` for the same reason the type above
+ * is not called `Readonly` — TS' built-in `Readonly<T>` is SHALLOW, so a bare
+ * `Mutable` would understate what this does by exactly the depth gap that made
+ * `cloneAsOverride` wrong in the first place. A type whose name misreports its
+ * own reach is the defect this pair exists to close, not a naming preference.
+ *
+ * Symmetric with `DeepReadonly` arm for arm, deliberately including its two
+ * limits: a tuple widens to an array (`DeepReadonly` widens it the same way, so
+ * an inverse that preserved tuples would not be an inverse), and `Date`,
+ * `RegExp`, `Map` and `Set` are mapped as plain objects even though
+ * `isFreezableObject` skips them at runtime.
+ *
+ * One thing it deliberately does NOT do: drop the `SYSTEM_VIEW_MARKER` key.
+ * `cloneAsOverride` never copies the symbol, so a clone's marker is always
+ * absent — but the key is declared optional (`?: true`), and carrying it
+ * therefore states "may be absent", which is true. Excluding it needs
+ * `Exclude<keyof T, typeof SYSTEM_VIEW_MARKER>`, a NON-homomorphic mapped type
+ * that drops the `?` modifier from every other property and turns optional keys
+ * required — a strictly worse type, and a real break for callers, traded for
+ * removing a key that already reads as optional.
+ */
+export type DeepMutable<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends ReadonlyArray<infer U>
+    ? DeepMutable<U>[]
+    : T extends object
+      ? { -readonly [K in keyof T]: DeepMutable<T[K]> }
+      : T;
+
+/**
  * A schema that has been frozen by `defineSystemView()`. The marker symbol is
  * non-enumerable and therefore invisible to consumers, but its presence
  * lets us discriminate at runtime.
@@ -159,15 +191,25 @@ export function isSystemView(value: unknown): boolean {
  * Produce a deep, mutable clone of a System View so callers can apply
  * Tenant/User overrides without touching the source schema.
  *
+ * Returns `DeepMutable<T>`, not `T`. The declaration used to hand back the
+ * input type unchanged, which meant cloning a `SystemView<S>` returned
+ * something still typed deep-readonly even though the implementation had always
+ * produced a plain mutable object — so the override flow this function exists
+ * for, `draft.columns.push(...)`, did not type-check (TS2339). The return type
+ * now relaxes TOWARD what the runtime already does, never away from it, which
+ * is why the change adds capability to a caller's type rather than removing it.
+ *
  * Implementation note: uses `structuredClone` when available (Node 17+, all
  * evergreen browsers) and falls back to a JSON round-trip. The marker
  * symbol is intentionally NOT copied — the clone is no longer a System View.
+ * Neither path can copy it by accident: `structuredClone` ignores symbol keys,
+ * and `JSON.stringify` never sees them.
  */
-export function cloneAsOverride<T>(view: T): T {
-  if (view == null || typeof view !== 'object') return view;
+export function cloneAsOverride<T>(view: T): DeepMutable<T> {
+  if (view == null || typeof view !== 'object') return view as DeepMutable<T>;
   const clone =
     typeof structuredClone === 'function'
       ? structuredClone(view)
       : (JSON.parse(JSON.stringify(view)) as T);
-  return clone;
+  return clone as DeepMutable<T>;
 }

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -246,7 +246,15 @@ const UNGATED_DOCS = {
   'packages/components/README.md':
     '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/core/README.md':
-    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 — candidate real defects, un-triaged',
+    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; plus TS2339x1 — TRIAGED, and NOT a defect: the remaining one is ' +
+    '`userListView.columns.push(...) // ❌ TypeError (strict mode)`, the System-View immutability ' +
+    'demonstration, so a readonly rejection there is the documentation working as written. ' +
+    'This entry read TS2339x2 until objectui#5257: the second one, on the `cloneAsOverride` draft ' +
+    'one block below, was a real signature defect — `cloneAsOverride` returned its input type, so ' +
+    'the documented override flow did not compile. It now returns `DeepMutable<T>` and that ' +
+    'diagnostic is gone. Covering this page still needs the 5 undefined-name blocks made ' +
+    'self-contained or declared, plus a way to declare a block whose rejection IS the point.',
   'packages/data-objectstack/README.md':
     '10 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 41 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/fields/README.md':


### PR DESCRIPTION
Fixes #5257

Per the maintainer's 2026-08-19 ruling (verbatim 「全部接受」), **option A**: `cloneAsOverride` returns a type that tells the truth about the value it produces.

## The defect

`cloneAsOverride< T >(view: T): T` handed the input type straight back. Cloning a `SystemView< S >` — which is `DeepReadonly< S >` plus the marker symbol — returned something still typed deep-readonly, even though the implementation has always produced a plain mutable object (`structuredClone`, or a JSON round-trip fallback) and deliberately drops the marker. The declaration was simply wrong about its own value.

## The acceptance criterion, measured

The criterion was concrete: the documented override flow in `packages/core/README.md` must type-check, measured by the snippet compile gate from #5138.

That document sits in the gate's `UNGATED_DOCS` ledger, so a plain `pnpm check:doc-snippets` run does not compile it. The measurement therefore re-runs the gate's **own exported harness** (`analyze` / `compileSnippets` — same compiler options, same dist-resolution control, same planted sentinel) with an `ungated` map covering every document *except* core's README. Nothing about the measurement is re-implemented.

Controls green on every run: resolution landed on `packages/types/dist/index.d.ts` (a built artifact, not source), 0 source-file leaks, the planted sentinel produced its TS2305 (so the program is not resolving everything to `any`), positive control clean.

| | before | after |
|---|---|---|
| `README.md:124` `draft.columns.push(...)` | **TS2339** | **gone** |
| `README.md:119` `userListView.columns.push(...)` | TS2339 | TS2339 — correct, see below |
| total semantic diagnostics on the page | 7 | 6 |

The surviving TS2339 is required. Line 119 is the `userListView.columns.push({ name: 'name' }) // ❌ TypeError (strict mode)` demonstration — the System-View immutability example, where a readonly rejection *is* the documentation working as written. Relaxing the clone must not relax the source, and three type-level cases pin that it does not.

Note on line numbers: the card cites `README.md:121` and `:116`. Those shifted to **`:124`** and **`:119`** between filing and now; the substance is identical and the drift is only the numbering.

## The change

Adds `DeepMutable< T >`, the inverse of the existing `DeepReadonly< T >`, and returns it.

**Naming — a deliberate deviation from the ruling's literal text, flagged for review.** The ruling writes the signature as `Mutable< T >` while also calling for "a `Mutable`/`DeepMutable` inverse". This ships **one** type, named `DeepMutable`, for the same reason the existing type is not called `Readonly`: TS' built-in `Readonly< T >` is *shallow*, so a bare `Mutable` would understate its reach by exactly the depth gap that made `cloneAsOverride` wrong in the first place. Shipping a shallow-sounding name on a deep type would repeat this card's own bug one level up. Two exported names for one type was also rejected — it gives an author two spellings for one thing.

Two limits, stated rather than left to be discovered. `DeepMutable` is symmetric with `DeepReadonly` arm for arm and inherits its tuple behaviour: a tuple widens to an array, exactly as `DeepReadonly` widens it in the other direction (an inverse that preserved tuples would not be an inverse). And it does **not** strip the `SYSTEM_VIEW_MARKER` key — the clone never carries the symbol at runtime, but the key is declared optional, so carrying it states "may be absent", which is true. Excluding it needs `Exclude< keyof T, typeof SYSTEM_VIEW_MARKER >`, a non-homomorphic mapped type that drops the `?` modifier from every other property and turns optional keys required: a strictly worse type traded for removing a key that already reads as optional. One type-level case pins that optionality survives, so that regression cannot land quietly.

## Consumer sweep — the answer is zero, and it is counter-probed

`cloneAsOverride` has **no call site anywhere in the repo** outside `packages/core/README.md`. `DeepReadonly` and `SystemView` have no consumer outside `packages/core` either. The sibling `objectstack` checkout has zero hits.

A zero is only worth as much as the probe that produced it, so the same grep was run over neighbouring core exports: `normalizeListView` and `expandFields` return hits across `plugin-detail`, `plugin-view`, `plugin-list`, `app-shell` and `types`. The sweep spans packages; the zero is real.

So the ruling's load-bearing premise — the return type relaxes toward runtime, existing callers keep compiling — holds trivially here, and is *additionally* pinned rather than assumed: two type-level cases assert a draft is still assignable to the `SystemView< S >` and the `DeepReadonly< S >` it came from. Nobody loses a permission; a caller gains one. Hence **`patch`**.

## Reverse verification — predicted before running, then observed

Reverted `freeze-schema.ts` alone, keeping the new tests and the ledger edit.

**The rebuild question, per leg — and it mattered.** The two legs resolve differently on purpose. The vitest pin file imports `../freeze-schema` by relative path, so it reads **source** and needs no build. The snippet gate resolves `@object-ui/core` through package `exports` to **`dist/*.d.ts`**, so the edit only reaches it through a build. Measured: with the source reverted but `dist` stale, the gate reported **6** diagnostics — the *fixed* state. A false green. After rebuilding core it returned to **7**, with TS2339 at both `:119` and `:124`. Every leg here, mutation and restoration alike, was rebuilt and the marker's presence/absence in `dist/utils/freeze-schema.d.ts` verified before any result was read.

| leg | predicted | observed |
|---|---|---|
| vitest pin file | red, ~8 failures | red, **6** failures |
| `type-check` | red — TS2305/TS2724 on a `DeepMutable` import | red — **TS2339**, different cause |
| snippet gate (after rebuild) | 7 diagnostics, TS2339 at `:119` and `:124` | exactly that |

Both misses are recorded rather than smoothed over:

- **8 vs 6.** Cases 0/1/2 flipped as predicted, and both discrimination tests failed exactly as predicted (`flipped` collapsed to `[]`, and `{ i: 0, now: true, before: true }`). The overcount was cases 8 and 9: an unresolved type name reports at the *import* line, not at the annotation site, where it degrades to `any` and yields no diagnostic. Only case 11 failed at its own line, via an implicit-`any` parameter under `strict`.
- **Wrong diagnostic on `type-check`.** `DeepMutable` is named only inside virtual-module source *strings* in that file, never in a real import, so `tsc` never sees it. What went red instead was the runtime test's own `draft.columns.push(...)` line.

**Green on both legs, stated plainly:** the two runtime tests. They pass reverted and unreverted, because the runtime was never the defect — the type was. They are in the suite so a future edit cannot "fix" the mismatch by making the runtime readonly instead. Note the split they expose: vitest strips types, so those tests *execute* green on the reverted leg, while `type-check` reads their source and goes red. The two legs measure different things.

## Declared file surface

- `packages/core/src/utils/freeze-schema.ts` — `DeepMutable` + the signature
- `packages/core/src/utils/__tests__/freeze-schema.types.test.ts` — new; 12 type-level cases, a revert-proof discrimination control, 2 runtime companions
- `.changeset/clone-as-override-returns-mutable-5257.md` — new, `patch`
- `scripts/check-doc-snippet-types.mjs` — **beyond the claimed surface, named here with evidence.** One ledger string, no behaviour change. The entry for `packages/core/README.md` read `TS2339x2 — candidate real defects, un-triaged`; this PR is what makes that count false. It now reads `TS2339x1`, and the survivor is triaged rather than un-triaged: it is the deliberate immutability demonstration, not a defect. Leaving it would have left the debt list asserting a measurement this PR falsified. The gate's own self-test (20 cases) and a full gate run were both re-run because of this edit.

## Verification

All at head `c548048f3`, run from the repository root (core owns a standalone `vitest.config.ts`, one of the 11 packages objectui#5313 measured the invocation guard as *not* covering).

- `vitest run packages/core scripts/__tests__/check-doc-snippet-types.test.ts` — **92 files, 1937 tests, all pass**
- `pnpm --filter @object-ui/core type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`, both echoed)
- `pnpm --filter @object-ui/core lint` — 0 errors
- `node scripts/check-doc-snippet-types.mjs` — 68/68 blocks judged, 0 failed, all controls green
- `node scripts/check-control-bytes.mjs` — 4716 files scanned, OK
- `check-changeset-presence` / `no-major` / `fixed`, `check-type-check-coverage`, `check-lint-coverage` — all green

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_