### PR TITLE
perf(console): keep the lazily-imported @objectstack/lint out of the eager chunk

### DIFF
--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -3,7 +3,7 @@
 // `vite`'s own `UserConfigExport` has no `test` property. Importing it from
 // `vite` left that whole block unchecked (objectui#3305).
 import { defineConfig } from 'vitest/config';
-import type { Plugin } from 'vite';
+import type { Plugin, Rollup } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
@@ -45,6 +45,96 @@ function preloadCriticalChunks(): Plugin {
       }
       if (preloadTags.length === 0) return html;
       return html.replace('</head>', `    ${preloadTags.join('\n    ')}\n  </head>`);
+    },
+  };
+}
+
+/**
+ * Build-time guard: `@objectstack/lint` must stay OUT of the eager closure.
+ *
+ * `packages/app-shell/src/preview/capabilityLint.ts` reaches the linter through
+ * a deliberate `await import('@objectstack/lint')` — it runs only when an
+ * author publishes in the metadata designer. That laziness is worth ~89 KiB
+ * gzipped on every console page load, and it is defeated silently: an
+ * `advancedChunks` group whose `test` matches the linter overrides the
+ * module's async-only reachability and folds it in beside the synchronously
+ * reached `@objectstack/spec`, whose chunk the entry imports STATICALLY
+ * (objectui#5266). Nothing about the source changes, no warning is emitted,
+ * and the existing bundle budget cannot see it — that budget weighs the
+ * `index-*.js` entry chunk alone, and these bytes land in a vendor chunk.
+ *
+ * So the invariant is asserted where it is decided, on the emitted graph, in
+ * the spirit of `viteMaplibreWorker` above: a regression must fail the BUILD
+ * rather than ship an extra half-megabyte only a profiler would find.
+ *
+ * The check is deliberately two-part. Asserting "no eager chunk holds the
+ * linter" alone would also pass if the walk found nothing at all — a green
+ * check with no subject. The counter-probe runs first and demands a KNOWN
+ * eager `@objectstack/spec`, so the linter verdict is only ever read after the
+ * closure walk has proven it can see the very chunk the linter used to hide in.
+ */
+function assertLazyLinterStaysLazy(): Plugin {
+  const LINT = /@objectstack[\\/+]lint/;
+  const SPEC = /@objectstack[\\/+]spec/;
+
+  return {
+    name: 'assert-lazy-linter-stays-lazy',
+    generateBundle(_options, bundle) {
+      const chunks = new Map<string, Rollup.OutputChunk>();
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type === 'chunk') chunks.set(fileName, output);
+      }
+
+      // The eager closure: every chunk reachable from an entry chunk through
+      // STATIC imports only. `dynamicImports` is deliberately not followed —
+      // that edge is precisely the boundary the linter is meant to sit behind.
+      const eager = new Set<string>();
+      const queue = [...chunks.values()].filter((c) => c.isEntry).map((c) => c.fileName);
+      while (queue.length > 0) {
+        const fileName = queue.pop() as string;
+        if (eager.has(fileName)) continue;
+        eager.add(fileName);
+        for (const imported of chunks.get(fileName)?.imports ?? []) {
+          if (!eager.has(imported)) queue.push(imported);
+        }
+      }
+
+      const chunksHolding = (test: RegExp): string[] =>
+        [...chunks.values()]
+          .filter((chunk) => Object.keys(chunk.modules).some((id) => test.test(id)))
+          .map((chunk) => chunk.fileName);
+
+      const eagerSpec = chunksHolding(SPEC).filter((fileName) => eager.has(fileName));
+      if (eagerSpec.length === 0) {
+        this.error(
+          `[assert-lazy-linter-stays-lazy] counter-probe failed: no eagerly loaded chunk ` +
+            `contains an \`@objectstack/spec\` module. The spec is reached synchronously ` +
+            `from the app entry, so it must be in the eager closure — its absence means ` +
+            `this walk is reading the graph wrongly, not that the bundle improved. ` +
+            `Fix the walk before trusting the linter assertion below. ` +
+            `(entry chunks: ${[...chunks.values()].filter((c) => c.isEntry).map((c) => c.fileName).join(', ') || 'NONE'}; ` +
+            `eager chunks: ${eager.size}/${chunks.size})`,
+        );
+      }
+
+      const eagerLint = chunksHolding(LINT).filter((fileName) => eager.has(fileName));
+      if (eagerLint.length > 0) {
+        this.error(
+          `[assert-lazy-linter-stays-lazy] \`@objectstack/lint\` is in the EAGER closure ` +
+            `(${eagerLint.join(', ')}), so every console page load pays for it — ~89 KiB ` +
+            `gzipped, measured in objectui#5266.\n\n` +
+            `The linter is imported lazily on purpose (app-shell's capabilityLint.ts). It ` +
+            `becomes eager when an \`advancedChunks\` group claims it, which overrides that ` +
+            `laziness. Check \`VENDOR_OBJECTSTACK_TEST\`: under pnpm the module id is\n` +
+            `  .../node_modules/.pnpm/@objectstack+lint@<v>/node_modules/@objectstack/lint/dist/index.js\n` +
+            `— it matches BOTH of that regex's alternatives, so BOTH need the negative ` +
+            `lookahead. Guarding one alternative alone leaves the other matching and looks ` +
+            `like a fix while changing nothing.\n\n` +
+            `Do NOT "fix" this by switching the import to \`@objectstack/lint/runtime\` — that ` +
+            `subpath reaches 70 of the 72 modules the main entry does, is 93.6% of its size, ` +
+            `and does not export \`validateCapabilityReferences\` at all (objectstack#9772).`,
+        );
+      }
     },
   };
 }
@@ -191,7 +281,28 @@ const OPTIMIZE_DEPS_INCLUDE = [
 // Baseline `vendor-objectstack` grouping: the installed spec/client, reached
 // either through `node_modules/@objectstack/` or through pnpm's flattened
 // `@objectstack+<pkg>` store path.
-const VENDOR_OBJECTSTACK_TEST = /([\\/]node_modules[\\/]@objectstack[\\/]|[\\/]@objectstack\+)/;
+//
+// `@objectstack/lint` is excluded. It is reached from exactly one place —
+// `packages/app-shell/src/preview/capabilityLint.ts`, through a deliberate
+// `await import('@objectstack/lint')` that runs only when an author publishes
+// in the metadata designer. Without the exclusion this group overrides that
+// async-only reachability and folds the linter in beside `@objectstack/spec`
+// and `@objectstack/client`, which the app entry reaches synchronously — so
+// the group's chunk is a STATIC import of the entry and every console page
+// load downloads and parses the whole linter (objectui#5266).
+//
+// BOTH alternatives need the guard, and that is not redundancy: under pnpm a
+// dependency resolves through the store, so the module's id is
+//   .../node_modules/.pnpm/@objectstack+lint@<v>/node_modules/@objectstack/lint/dist/index.js
+// — one path containing BOTH `/@objectstack+` and `/node_modules/@objectstack/`.
+// Guarding either alternative alone leaves the other one matching, and the
+// linter stays in the eager chunk with no visible symptom.
+//
+// The lookaheads are deliberately tight: `lint[\\/]` and `lint@` match the
+// `lint` package only, so a future `@objectstack/lint-*` sibling still groups
+// here rather than silently scattering into its importers' chunks.
+const VENDOR_OBJECTSTACK_TEST =
+  /([\\/]node_modules[\\/]@objectstack[\\/](?!lint[\\/])|[\\/]@objectstack\+(?!lint@))/;
 
 // Opt-in override of the installed `@objectstack/spec` — the spec twin of
 // OBJECTSTACK_CLIENT_DIST above, so a framework build can bundle the console
@@ -249,6 +360,10 @@ export default defineConfig({
     react(),
     // Inject <link rel="modulepreload"> for critical chunks
     preloadCriticalChunks(),
+    // Fails the build if the lazily-imported linter is folded back into an
+    // eagerly-loaded chunk. Runs on CI/Vercel too — it costs microseconds and
+    // the regression it catches is invisible in every other signal.
+    assertLazyLinterStaysLazy(),
     // maplibre-gl loads its worker as a sibling of its own chunk URL — an
     // edge no bundler can see — so the worker (and the shared module it
     // imports) must be copied into assets/ or every map page 404s

--- a/scripts/__tests__/vite-objectstack-spec-dist.test.ts
+++ b/scripts/__tests__/vite-objectstack-spec-dist.test.ts
@@ -60,8 +60,26 @@ import {
 const require_ = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
-/** The baseline `vendor-objectstack` group test, as the console config spells it. */
-const BASE_VENDOR_TEST = /([\\/]node_modules[\\/]@objectstack[\\/]|[\\/]@objectstack\+)/;
+/**
+ * The baseline `vendor-objectstack` group test, as the console config spells it.
+ *
+ * Mirror of `VENDOR_OBJECTSTACK_TEST` in `apps/console/vite.config.ts`. When
+ * that constant changes this one must change with it — but do NOT treat the two
+ * assertions below as a string to re-paste. They pin two different things:
+ * `.source` equality pins that the spec-dist override left the baseline INERT,
+ * and `startsWith` pins that the override WIDENED the baseline instead of
+ * replacing it. The semantic assertions beside them say which modules the
+ * grouping is supposed to catch, so a future edit that keeps the shape while
+ * changing the membership still fails.
+ *
+ * The negative lookaheads exclude `@objectstack/lint` from the group: it is
+ * imported lazily (app-shell's `capabilityLint.ts`) and a group that claims it
+ * overrides that laziness, putting ~89 KiB gzipped on every console page load
+ * (objectui#5266). Both alternatives need the guard — under pnpm the module id
+ * contains both `/@objectstack+` and `/node_modules/@objectstack/`.
+ */
+const BASE_VENDOR_TEST =
+  /([\\/]node_modules[\\/]@objectstack[\\/](?!lint[\\/])|[\\/]@objectstack\+(?!lint@))/;
 
 /** The installed spec package — a real, fully built override target. */
 const installedSpecDir = path.dirname(require_.resolve('@objectstack/spec/package.json'));
@@ -206,6 +224,12 @@ describe('objectui#4854: OBJECTSTACK_SPEC_DIST is subpath-aware', () => {
     expect(outOfTreeInjection.vendorChunkTest.test('/repo/node_modules/.pnpm/@objectstack+spec@1/x.mjs')).toBe(true);
     // And it stays a spec-shaped test, not a catch-all.
     expect(injection.vendorChunkTest.test('/repo/packages/core/src/index.ts')).toBe(false);
+    // The baseline arms' `@objectstack/lint` exclusion survives the widening.
+    expect(
+      outOfTreeInjection.vendorChunkTest.test(
+        '/repo/node_modules/.pnpm/@objectstack+lint@17.0.0/node_modules/@objectstack/lint/dist/index.js'
+      )
+    ).toBe(false);
   });
 
   it('accepts a `dist/` or entry-file spelling of the same package', () => {
@@ -307,6 +331,20 @@ describe('objectui#4854: the four flagged surfaces in the console config', () =>
     const vendor = groups.find((g) => g.name === 'vendor-objectstack');
     expect(vendor).toBeDefined();
     expect(vendor!.test.source).toBe(BASE_VENDOR_TEST.source);
+    // …and what that literal MEANS, so a future rewrite that keeps the shape
+    // but changes the membership cannot pass by pasting a new string in.
+    // Reads off the live config's own regex, never the mirror above.
+    const LINT_ID =
+      '/repo/node_modules/.pnpm/@objectstack+lint@17.0.0/node_modules/@objectstack/lint/dist/index.js';
+    expect(vendor!.test.test(LINT_ID)).toBe(false);
+    // Counter-probe: the packages that DO belong in the group still match, via
+    // both spellings — otherwise the line above would also pass if the group
+    // test had been broken into matching nothing at all.
+    expect(vendor!.test.test('/repo/node_modules/@objectstack/spec/dist/index.js')).toBe(true);
+    expect(vendor!.test.test('/repo/node_modules/.pnpm/@objectstack+spec@17.0.0/x.js')).toBe(true);
+    expect(vendor!.test.test('/repo/node_modules/@objectstack/client/dist/index.js')).toBe(true);
+    // The exclusion is scoped to the `lint` package, not a `lint*` prefix.
+    expect(vendor!.test.test('/repo/node_modules/@objectstack/lint-utils/dist/index.js')).toBe(true);
 
     // 4. server.fs — absent, so Vite keeps its own default allow-list.
     expect(config.server.fs).toBeUndefined();
@@ -350,6 +388,14 @@ describe('objectui#4854: the four flagged surfaces in the console config', () =>
       )!.test;
     expect(vendorOf(injected).source.startsWith(BASE_VENDOR_TEST.source)).toBe(true);
     expect(vendorOf(injected).test(`${fs.realpathSync(installedSpecDir)}/dist/ui/index.mjs`)).toBe(true);
+    // Widening appends an arm; it must not resurrect the lint exclusion the
+    // baseline arms carry, or a spec-dist build would silently re-eagerize the
+    // linter while a released build stayed lazy (objectui#5266).
+    expect(
+      vendorOf(injected).test(
+        '/repo/node_modules/.pnpm/@objectstack+lint@17.0.0/node_modules/@objectstack/lint/dist/index.js'
+      )
+    ).toBe(false);
 
     // 4. server.fs.allow — the workspace root plus the injected package.
     expect(injected.server.fs.allow).toEqual([repoRoot, fs.realpathSync(installedSpecDir)]);


### PR DESCRIPTION
Fixes #5266

The `vendor-objectstack` `advancedChunks` group matched every `@objectstack/*` package, so `@objectstack/lint` was folded in beside `@objectstack/spec` and `@objectstack/client`. Those two are reached synchronously from the app entry, so the group's chunk is a **static** import of `index-*.js` — and the group overrides the linter's async-only reachability. Every console page load downloaded and parsed the whole linter.

The linter has exactly one runtime reference in this repo: `packages/app-shell/src/preview/capabilityLint.ts`, behind a deliberate `await import('@objectstack/lint')` that runs only when an author publishes in the metadata designer.

Two commits: the config fix, and the pin in `scripts/__tests__/` that mirrors the config constant.

## Premise re-derived on current `main` before implementing

The card measured at pin `82a94170c405` / framework `6f40ed736`; `main` has taken **120 commits** since. Re-checked:

- `pnpm-lock.yaml` diff over that range: 1,138 lines changed, **0** of them mentioning `@objectstack` (counter-probe: 134 `resolution:` lines in the same diff, so the zero is real, not an empty diff). The dependency pin has not moved.
- `@objectstack/lint@17.0.0` `dist/index.js` is **532,262 bytes** — byte-identical to the card's figure.
- `VENDOR_OBJECTSTACK_TEST` is unchanged between the pin and current `main`; the only `vite.config.ts` commit in between (`578e02516`) added an unrelated `@object-ui/types/zod` alias.

**One card figure did move:** the eager closure is **58** chunks on `main`, not 59. The parity check below is therefore 58/58. Everything else reproduced.

## Both lookahead alternatives are load-bearing

Under pnpm the linter resolves through the store, so its module id — read out of the build's own module map, not assumed — is:

```
.../node_modules/.pnpm/@objectstack+lint@17.0.0_.../node_modules/@objectstack/lint/dist/index.js
```

That single path contains **both** `/@objectstack+` and `/node_modules/@objectstack/`. Tested against the real path rather than picked by inspection:

| variant | lint | spec | client | a hypothetical `lint-utils` sibling |
|---|---|---|---|---|
| baseline (no lookahead) | matches | matches | matches | matches |
| lookahead on alternative A only | **matches** | matches | matches | matches |
| lookahead on alternative B only | **matches** | matches | matches | matches |
| both (this PR) | **no match** | matches | matches | matches |

Guarding one alternative alone leaves the other matching and looks like a fix while changing nothing. The lookaheads are tight (`lint[\\/]`, `lint@`) so a future `@objectstack/lint-*` sibling still groups here rather than scattering into its importers' chunks.

## Measured — baseline beside result

Eager closure = every chunk reachable from `index.html` through **static** imports only, walked with `es-module-lexer`; gzip read from the build's own emitted `.gz`. Both builds at `eb503920f`'s tree, `vite build`, compression + visualizer active.

| | baseline | this PR | delta |
|---|---|---|---|
| eager closure, gzipped | 3,957,301 | 3,866,123 | **−91,178 (−89.0 KiB)** |
| eager closure, raw | 13,626,583 | 13,330,253 | −296,330 |
| eager chunk count | 58 | 58 | **0** |
| emitted JS chunks | 506 | 507 | +1 |

The eager chunk **name sets are identical** — nothing entered or left the closure; only the linter's bytes did. The +1 emitted chunk is the linter's new home, `assets/dist-*.js` (294,864 raw / 91,271 gzipped), which is **not** in the eager closure; it is fetched only when an author publishes in the metadata designer, which is what the `await import` was always asking for. `vendor-objectstack` itself drops 5,352,089 to 5,055,720 raw.

## The linter's placement is verified directly, not inferred from the delta

Two independent reads, each with a counter-probe:

- **Path-based** (visualizer module map): `@objectstack/lint/dist/index.js` moves from `assets/vendor-objectstack-BM4dkOHC.js` (eager) to `assets/dist-LXdey3OB.js` (not eager). Counter-probe: `@objectstack/spec` is still in `vendor-objectstack`, so the exclusion is not over-broad.
- **Content-based**: three lint rule-id markers (`widget-legacy-analytics-unrenderable`, `visibility-root-mislayered`, `view-ref-form-target-missing`) hit **0** eager chunks after the change, all three in `assets/dist-LXdey3OB.js`. Counter-probe: the substring `objectstack` still hits 27 chunks (19 eager), so the scan is live and the zero is a real zero.

## Regression checks

### 1. A build-output assertion, stated plainly

This part is **not** a unit test. The invariant is a property of the emitted chunk graph, so it is asserted where it is decided: a new `assert-lazy-linter-stays-lazy` plugin in `apps/console/vite.config.ts` walks the bundle at `generateBundle`, computes the eager closure from `chunk.imports` (never `dynamicImports`), and fails the build if any eager chunk holds an `@objectstack/lint` module. It follows `viteMaplibreWorker`'s existing precedent in this file: an invisible bundling edge must fail the BUILD, loudly.

It is **two-part on purpose**. Asserting "no eager chunk holds the linter" alone would also pass if the walk found nothing at all — a green check with no subject. A counter-probe runs first and demands a known-eager `@objectstack/spec`, so the linter verdict is only ever read after the walk has proven it can see the very chunk the linter used to hide in.

This costs no new CI job: the console is already built by `ci.yml` (Build & E2E), `live-e2e.yml`, and `performance-budget.yml`. Worth noting why the existing bundle budget never caught this — it weighs the `index-*.js` entry chunk alone against 350 KB, and these bytes were sitting in a vendor chunk. Filed separately as #5324.

### 2. The existing pin in `scripts/__tests__/`, re-pinned and strengthened

`scripts/__tests__/vite-objectstack-spec-dist.test.ts` mirrors the config's `VENDOR_OBJECTSTACK_TEST` as a literal `BASE_VENDOR_TEST` and asserts on it twice. The lookahead turned both red. **Neither assertion was relaxed** — I worked out what each was protecting first, and both hold verbatim once the mirror is current:

- `.source` equality lives in *"leaves all four flagged surfaces at their baseline values"*. Its intent is **"an unset `OBJECTSTACK_SPEC_DIST` leaves the group test inert"**, not "the regex is this string". Kept as exact equality.
- `startsWith` lives in the override-set case. Its intent is **"the derivation WIDENS the baseline (appends an arm) rather than replacing it"** — `resolveSpecDistInjection` builds `` `${base.source}|${dir}${SEP}` ``. My change does not touch the derivation, so this holds unchanged. Kept as-is.

**Strengthened**, because string equality alone would let a future edit keep the shape while changing membership. Added, reading the *live config's* regex rather than the mirror: the real pnpm lint id must **not** match; spec (both spellings) and client **must** match, so that rejection cannot pass by matching nothing; `@objectstack/lint-utils` **must** match, pinning the exclusion to the `lint` package rather than a `lint*` prefix. The same exclusion is also asserted on the **widened** regex in both the live-config case and the `resolveSpecDistInjection` unit — otherwise a spec-dist build could silently re-eagerize the linter while a released build stayed lazy.

### Reverse-verification — predicted before running, then observed

**Ablation A — the guard.** Reverted the regex only, kept the build assertion. *Predicted:* non-zero exit at `generateBundle`; the *second* assertion fires naming the vendor-objectstack chunk; the counter-probe does *not* fire (spec is eager either way); plain red. *Observed:* all four. `BUILD_EXIT=1`, stack in `PluginContextImpl.generateBundle`, `counter-probe failed` count 0 / `is in the EAGER closure` count 1, error naming `assets/vendor-objectstack-BM4dkOHC.js` — the baseline chunk hash exactly, so reverting reproduces the original bundle rather than some third state.

**Ablation B — the pin catches a config revert.** Reverted `vite.config.ts` only, kept the updated pin. *Predicted:* red in exactly the 2 cases that read the live config; the helper-level cases stay green because they feed `BASE_VENDOR_TEST` into `resolveSpecDistInjection` directly and never read the config. *Observed:* exactly that — `Tests 2 failed | 16 passed (18)`.

**Ablation C — the strengthening is load-bearing.** Ablation B fails on `.source` first, so it does not by itself exercise the new semantic assertions. Reverted the config **and** the mirror in lockstep, so string equality and `startsWith` both pass and only semantics can catch it. *Observed:* **3** failed / 15 passed — one *more* than Ablation B, all `expected true to be false`, and it reaches the helper-level case that a config-only revert cannot. Direction here is "diagnostics increase", not the plain red of A and B.

The fix was committed before each ablation; restoration was proven byte-identical by `sha256sum -c`, tree clean.

## Not taken: the documented trap

Switching the import to `@objectstack/lint/runtime` is **not** a fix and was not attempted — that subpath reaches 70 of the 72 modules the main entry reaches, is 93.6% of its size, and does not export `validateCapabilityReferences` at all. Recorded in objectstack#9772; the reasoning is now also inline in the guard's failure message, where the next person reaching for it will actually read it.

## Verification run at `6db2fa648`

All from the repository root unless noted:

- `pnpm exec vitest run scripts/__tests__/vite-objectstack-spec-dist.test.ts` — **18/18 passed**.
- `pnpm exec vitest run scripts/__tests__/` — **57 files, 1,291 tests, all passed**. Widened deliberately, to check whether any other pin in that directory encodes the same pattern. None does: a repo-wide grep for the pattern finds exactly two sites, this test and the config (counter-probed — the same grep finds both known sites).
- `pnpm exec vitest run apps/console/ --maxWorkers=2` — **55 files, 658 tests, all passed** (vitest root echoed as the repo root, so not the package-cwd phantom run).
- `tsc --noEmit` (console app program) — **0**, after `pnpm --filter '@object-ui/console^...' build`. The first run's 20 `TS2307`/`TS2882` were unbuilt `@object-ui/*` dists, none involving this change.
- `tsc -b tsconfig.node.json --force` — **0**. That is the program that actually contains `vite.config.ts`; the app program does not (`include: ["src", "dev"]`).
- `eslint` on both changed files — **0 errors**. 3 pre-existing `no-explicit-any` warnings in untouched regions of the test file; this diff adds none.
- `check:control-bytes` (4,714 files), `check:phantom-deps`, `check:self-import`, `check:esm-specifiers` — all **0**.
- `vite build` with the guard active — **exit 0**, byte-for-byte the same output as the pre-guard fixed build.

Changeset: none owed — `node scripts/check-changeset-presence.mjs` reports `0 of them under the src/ of a package the release covers`. No label applied (this repo has no `skip-changeset` mechanism).

Scope check: in-flight #5254's file surface is `packages/components/src/renderers/form/**` — no overlap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_