### PR TITLE
fix(components): a form field resolves a field widget or the default input — never a ui-namespace SDUI node renderer

### DIFF
--- a/.changeset/form-field-crossnamespace-fallback-5254.md
+++ b/.changeset/form-field-crossnamespace-fallback-5254.md
@@ -1,0 +1,56 @@
+---
+'@object-ui/components': minor
+---
+
+Form-field type resolution no longer falls back to `ui`-namespace SDUI node renderers.
+
+A `FormSchema` field's `type` now resolves a `field:`-namespaced widget or takes
+the builtin `default` input branch. It no longer falls back to
+`ComponentRegistry.get(type)` — the bare name in whatever namespace happened to
+hold it. (Maintainer ruling of 2026-08-19 on objectui#5254, option B.)
+
+**This is a behaviour change, and it is the point of the change, not a side
+effect.** A spelling that resolved yesterday stops resolving: a form field whose
+`type` names a non-field component renders the default input instead of that
+component. Measured on the built-in (no-`registerAllFields()`) path, the removed
+fallback answered **126** bare names — `div`, `h1`, `card`, `button`, `form`,
+`alert`, `badge`, the display `text` widget — and 116 of them with the fields
+package registered as well. Marked `minor` for that reason. It is released as a
+behaviour change rather than a fix because callers cannot tell from their own
+metadata which of the two rules answered them; anyone who deliberately pointed a
+form field at an SDUI component was relying on a rule no contract stated, and
+that reliance now needs a `field:`-namespaced widget instead.
+
+Nothing changes for the two paths that carry real traffic. With
+`registerAllFields()` — the production configuration — every affected field type
+already resolved its own `field:` widget (`email` to `field:email`, `password`
+to `field:password`, `text` to `field:text`), and object-derived forms go
+through `mapFieldTypeToFormType`, which has always emitted the `field:`-prefixed
+id. Rendering one of these components as a top-level SDUI **node** is untouched:
+this rule governs field resolution only.
+
+What the fallback was producing on the built-in path, for
+`{ name: 'contact', type: 'email', max_length: 50 }`:
+
+```
+attrs=["class","id","max_length","field","aria-describedby",
+       "aria-invalid","type","value","name"]   maxlength=null
+```
+
+`email` and `password` are registered as `ui`-namespace node renderers for
+top-level `{ type: 'email' }` nodes, so reached as a *field* they received the
+field-widget prop bundle they do not implement and spread it onto the element:
+the raw metadata object landed as `field="[object Object]"`, `max_length`
+landed as an inert attribute with no cap in effect (`maxlength` null), and the
+node renderer's own `<Label>` gave the control a second `<label>` on top of the
+form's. All three are gone; the declared ceiling now actually caps
+(`maxlength="50"`).
+
+`email` and `password` keep rendering the native input they always rendered.
+The default branch derives `<input type>` from those two declared field types
+(`EmailFieldMetadata` / `PasswordFieldMetadata`), because `inputType` there is
+whatever the author wrote and a plain `{ name, type: 'password' }` authors none
+— without it that field would have rendered `type="text"` and shown a secret in
+clear text. An explicitly authored `inputType` still wins. Other declared types
+with a native HTML equivalent (`url`, `phone`, `number`, `color`, `date`)
+already took this branch as `type="text"` and are unchanged.

--- a/packages/components/src/renderers/form/__tests__/form-field-carrier.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-field-carrier.test.tsx
@@ -163,27 +163,40 @@ describe('form renderer — `field` is the single metadata carrier (objectui#323
   });
 });
 
-describe('form renderer — retiring the carrier did NOT touch the SDUI `schema` contract', () => {
-  it('still passes `schema` to a plain component reached by the bare-name fallback', () => {
-    // The load-bearing distinction, and the one a "just delete `schema`"
-    // refactor gets wrong: `renderFieldComponent`'s registry lookup can answer
-    // with two different KINDS of component.
+describe('form renderer — a form field no longer reaches a plain SDUI component at all', () => {
+  it('does not render a bare-name component in the field slot (objectui#5254)', () => {
+    // This block used to assert the INVERSE of the tests above: that a form
+    // field resolving through the BARE-NAME fallback was handed the universal
+    // `schema` node, because such a component's contract is `schema` and not
+    // `FieldWidgetComponentProps`. That was a correct reading of a resolution
+    // rule that no longer exists — objectui#5254's ruling (maintainer,
+    // 2026-08-19) removed the fallback itself, so a form field's type resolves
+    // a `field:` widget or takes the builtin `default` input branch.
     //
-    //  - a `field:<type>` entry is a field widget — `field` only, since v17;
-    //  - the bare-name fallback is an ordinary SDUI component (the display
-    //    `text` widget, `alert`, `badge` …), whose contract is the universal
-    //    `schema` node. That key is NOT retired, and dropping it here rendered
-    //    `undefined.className` for every form field that resolves this way
-    //    (caught by `form-write-error-message.test.tsx`, whose fields are
-    //    `type: 'text'` with `@object-ui/fields` not loaded).
-    //
-    // So this asserts the INVERSE of the tests above, on purpose.
+    // The `schema` contract is untouched where it actually applies: rendering
+    // one of these components as an SDUI NODE. What changed is only that a
+    // FORM FIELD is no longer one of the ways to get there.
     ComponentRegistry.register('plaindisplay', CarrierProbe);
 
     renderForm([{ name: 'note', label: 'Note', type: 'plaindisplay' }], { note: '' });
 
-    expect(captured.props).not.toBeNull();
-    expect(captured.props!.schema).toBeTruthy();
-    expect(captured.props!.schema.name).toBe('note');
+    // Counter-probe for the two negatives below: the component IS registered
+    // and IS resolvable — it is simply not resolvable as a FIELD.
+    expect(ComponentRegistry.get('plaindisplay')).toBeTruthy();
+    expect(captured.props).toBeNull();
+    expect(screen.queryByTestId('probe-note')).toBeNull();
+  });
+
+  it('renders the builtin default input for that field instead', () => {
+    ComponentRegistry.register('plaindisplay2', CarrierProbe);
+
+    const { container } = renderForm([{ name: 'note', label: 'Note', type: 'plaindisplay2' }], { note: '' });
+
+    const el = container.querySelector('input')!;
+    expect(el).toBeTruthy();
+    expect(el.getAttribute('name')).toBe('note');
+    // And none of the field-widget prop bundle rides onto it.
+    expect(el.getAttributeNames()).not.toContain('field');
+    expect(el.getAttributeNames()).not.toContain('schema');
   });
 });

--- a/packages/components/src/renderers/form/__tests__/form-field-crossnamespace-fallback.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-field-crossnamespace-fallback.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * A form field's `type` resolves a FIELD WIDGET or nothing — objectui#5254,
+ * maintainer ruling of 2026-08-19 (option B of the measured option set).
+ *
+ * ## What was measured on `origin/main` at 3fbbea1f3
+ *
+ * `renderFieldComponent` resolved `field:<type>` first and then fell back to
+ * `ComponentRegistry.get(type)` — the BARE name, in whatever namespace happened
+ * to hold it. `./input.tsx` registers `email` and `password` as `ui`-namespace
+ * SDUI NODE renderers (for a top-level `{ type: 'email' }` node), so a
+ * hand-authored form field landed in one of them and got the field-widget prop
+ * bundle it does not implement, spread straight onto the element:
+ *
+ *   type:'email' + max_length: 50
+ *     attrs=["class","id","max_length","field","aria-describedby",
+ *            "aria-invalid","type","value","name"]
+ *     maxlength=null      field="[object Object]"
+ *
+ * Three defects in one render:
+ *
+ *   1. `field` — the raw metadata OBJECT — became a stray DOM attribute,
+ *      stringified to `[object Object]`. The field-widget strip deliberately
+ *      KEEPS `field` (it is the widget metadata carrier, objectui#3233), which
+ *      is correct for a field widget and wrong for a component that is not one.
+ *   2. `max_length` reached the element as an inert attribute and the field had
+ *      NO cap: `maxlength` was `null`.
+ *   3. That renderer draws its own `<Label>`, so the control got a SECOND
+ *      `<label>` on top of the form's own `<FormLabel>` — two labels naming one
+ *      control.
+ *
+ * The fallback was not narrow: it answered **126** bare names on this built-in
+ * path (`div`, `h1`, `card`, `button`, `form` …) and 116 with the fields
+ * package registered as well.
+ *
+ * ## The behaviour change, stated
+ *
+ * A spelling that resolved yesterday stops resolving: a form field whose `type`
+ * names a non-field component now takes the `default` input branch instead of
+ * rendering that component. That is the ruling's substance, not a side effect.
+ *
+ * ## Why `email`/`password` still render a native input
+ *
+ * The ruling put one verification on the implementer: "the default branch
+ * renders a usable input for these types". Measured — it does NOT on its own.
+ * `inputType` on the default branch is whatever the AUTHOR wrote, and a plain
+ * `{ name, type: 'password' }` authors none, so the branch would have rendered
+ * `type="text"` and put a secret on screen in clear text. `NATIVE_INPUT_FIELD_TYPES`
+ * in form.tsx is what closes that: these two declared field types
+ * (`EmailFieldMetadata` / `PasswordFieldMetadata` in `@object-ui/types`) keep
+ * the native input they always had. The VISIBLE rendering of an `email` /
+ * `password` field is therefore unchanged — only the leak, the duplicate label
+ * and the dead ceiling go away.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/** Render the built-in branch: no `registerAllFields()`, so nothing resolves under `field:`. */
+function renderForm(fields: any[], extra: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields, ...extra }} />,
+  );
+}
+
+const input = () => document.querySelector('input') as HTMLInputElement;
+
+afterEach(cleanup);
+
+describe('form field type resolution — no cross-namespace fallback (objectui#5254)', () => {
+  describe('the fallback the ruling removed', () => {
+    it('still has a bare `email` entry to fall back TO — the routing premise', () => {
+      // Without this the whole file would pass on an empty registry. `email`
+      // and `password` ARE registered (as `ui` SDUI nodes) and there is NO
+      // `field:` entry for them on this path — exactly the shape that used to
+      // route a form field into a non-field component.
+      expect(ComponentRegistry.get('form')).toBeTruthy(); // counter-probe: registry populated
+      expect(ComponentRegistry.get('email')).toBeTruthy();
+      expect(ComponentRegistry.get('password')).toBeTruthy();
+      expect(ComponentRegistry.get('field:email')).toBeUndefined();
+      expect(ComponentRegistry.get('field:password')).toBeUndefined();
+    });
+
+    it('never leaks the `field` metadata object onto the DOM', () => {
+      renderForm([{ name: 'contact', label: 'Contact', type: 'email' }]);
+      // Pre-fix: field="[object Object]".
+      expect(input().getAttributeNames()).not.toContain('field');
+    });
+
+    it('never leaks `max_length`, and the declared ceiling now actually caps', () => {
+      renderForm([{ name: 'contact', label: 'Contact', type: 'email', max_length: 50 }]);
+      // Pre-fix: a stray `max_length="50"` attribute AND `maxlength` null —
+      // two independent halves, so both are asserted.
+      expect(input().getAttributeNames()).not.toContain('max_length');
+      expect(input().getAttribute('maxlength')).toBe('50');
+    });
+
+    it('gives the control exactly ONE label', () => {
+      // Pre-fix the `ui` renderer drew its own <Label> on top of <FormLabel>.
+      const { container } = renderForm([{ name: 'contact', label: 'Contact', type: 'email' }]);
+      expect(container.querySelectorAll('label')).toHaveLength(1);
+    });
+
+    it('stops routing a form field into an arbitrary non-field component', () => {
+      // The CLASS, not just the two spellings the card measured: `card` is a
+      // plain SDUI component that no `field:` entry claims. Pre-fix this
+      // rendered the Card component in the field slot and no input at all.
+      expect(ComponentRegistry.get('card')).toBeTruthy(); // counter-probe
+      renderForm([{ name: 'note', label: 'Note', type: 'card' }]);
+      expect(input()).toBeTruthy();
+    });
+  });
+
+  describe('the ruling’s required check — the default branch is a USABLE input', () => {
+    it('renders `email` as a native email input, still named and labelled', () => {
+      const { container } = renderForm([{ name: 'contact', label: 'Contact', type: 'email' }]);
+      const el = input();
+      expect(el.tagName).toBe('INPUT');
+      expect(el.getAttribute('type')).toBe('email');
+      expect(el.getAttribute('name')).toBe('contact');
+      expect(el.hasAttribute('disabled')).toBe(false);
+      expect(el.hasAttribute('readonly')).toBe(false);
+      // Label names THIS control (the `for`/`id` pair), so the input is
+      // reachable by its accessible name rather than merely present.
+      const label = container.querySelector('label')!;
+      expect(label.getAttribute('for')).toBe(el.getAttribute('id'));
+      expect(el.getAttribute('id')).toBeTruthy();
+    });
+
+    it('renders `password` MASKED — the half that would be worse than the leak', () => {
+      // Without form.tsx's `NATIVE_INPUT_FIELD_TYPES` this branch renders
+      // `type="text"` and the secret is on screen in clear text.
+      renderForm([{ name: 'secret', label: 'Secret', type: 'password' }]);
+      expect(input().getAttribute('type')).toBe('password');
+      expect(input().getAttribute('name')).toBe('secret');
+    });
+
+    it('accepts typed input and reports it to the form — usable, not just present', () => {
+      const seen: any[] = [];
+      renderForm([{ name: 'contact', label: 'Contact', type: 'email' }], {
+        onChange: (values: unknown) => { seen.push(values); },
+      });
+      fireEvent.change(input(), { target: { value: 'a@b.com' } });
+      expect(input().value).toBe('a@b.com');
+      // The value reaches the form state under the field's own name — this is
+      // what makes it a working FIELD and not merely a text box on screen.
+      expect(seen.at(-1)).toMatchObject({ contact: 'a@b.com' });
+    });
+
+    it('lets an explicitly authored inputType win over the type-derived one', () => {
+      renderForm([{ name: 'contact', label: 'Contact', type: 'email', inputType: 'text' }]);
+      expect(input().getAttribute('type')).toBe('text');
+    });
+  });
+
+  describe('what did NOT change', () => {
+    it('still resolves a `field:`-namespaced widget', () => {
+      // The other side of the rule: removing the bare-name tail must not touch
+      // field-widget resolution. Registered here rather than via
+      // `registerAllFields()` so the assertion is hermetic.
+      const Widget = (props: any) =>
+        <output data-testid="zzwidget">{String(props.field?.name)}</output>;
+      ComponentRegistry.register('zzcross', Widget as any, { namespace: 'field' });
+      try {
+        const { getByTestId } = renderForm([{ name: 'w', label: 'W', type: 'zzcross' }]);
+        expect(getByTestId('zzwidget').textContent).toBe('w');
+      } finally {
+        ComponentRegistry.unregister('zzcross', 'field');
+      }
+    });
+
+    it('leaves the `ui` SDUI node renderers reachable as NODES', () => {
+      // `email`/`password` are legitimate top-level SDUI node types. This card
+      // removes them from FIELD resolution only — rendering one as a node is
+      // untouched (and is what packages/components/src/__tests__/
+      // form-renderers.test.tsx covers).
+      const Email = ComponentRegistry.get('email')!;
+      const { container } = render(<Email schema={{ type: 'email', label: 'Email' }} />);
+      expect(container.querySelector('input[type="email"]')).toBeTruthy();
+    });
+
+    it('leaves a builtin type on its own branch', () => {
+      // `input` is a BUILTIN_FIELD_TYPES member — the registry is never
+      // consulted for it, before or after.
+      renderForm([{ name: 'plain', label: 'Plain', type: 'input' }]);
+      expect(input().getAttribute('type')).toBe('text');
+      expect(input().getAttributeNames()).not.toContain('field');
+    });
+  });
+});

--- a/packages/components/src/renderers/form/__tests__/form-readonly-host-group.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-readonly-host-group.test.tsx
@@ -349,13 +349,23 @@ describe('nothing else changed shape (the paths this issue does not touch)', () 
     expect(document.querySelector('[role="group"]')).toBeNull();
   });
 
-  it('a bare-name SDUI component is not a field widget and is left alone', () => {
+  it('a bare-name SDUI component is not a field widget and gets no group', () => {
     renderForm([FIELD('barenameprobe', { readonly: true })], { f_barenameprobe: 'Hello' });
 
-    // Its contract is `schema`, not `FieldWidgetComponentProps`; the ruling
-    // scoped the wrapper to registered FIELD widgets.
+    // #4788's assertion, unchanged: the wrapper is scoped to registered FIELD
+    // widgets, and this type is not one.
     expect(group('f_barenameprobe')).toBeNull();
-    expect(screen.getByTestId('bare-name')).toBeInTheDocument();
+
+    // The SECOND half of this test used to be `getByTestId('bare-name')` — it
+    // asserted that a form field REACHED the bare-name component, which was
+    // true only because of the cross-namespace fallback objectui#5254's ruling
+    // removed. A form field's type now resolves a `field:` widget or nothing,
+    // so this type takes the builtin `default` input branch instead. The probe
+    // is still registered (bare, no namespace) and still resolvable as an SDUI
+    // NODE — it is simply no longer reachable as a FIELD.
+    expect(ComponentRegistry.get('barenameprobe')).toBeTruthy(); // counter-probe
+    expect(screen.queryByTestId('bare-name')).toBeNull();
+    expect(item('f_barenameprobe').querySelector('input')).toBeTruthy();
   });
 });
 

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -2798,6 +2798,36 @@ interface RenderFieldProps {
 // box so they behave like the other field widgets (click-anywhere-to-edit).
 const NATIVE_PICKER_INPUT_TYPES = new Set(['date', 'datetime-local', 'time', 'month', 'week']);
 
+/**
+ * Field types whose native `<input type>` the `default` branch must resolve
+ * from the field's own declared `type` (objectui#5254).
+ *
+ * Both are declared field types in `@object-ui/types`
+ * (`EmailFieldMetadata` / `PasswordFieldMetadata`), and both used to reach a
+ * native input only by ACCIDENT: the bare-name fallback handed the field to
+ * the `ui`-namespace SDUI node renderer registered under the same short name
+ * (./input.tsx), which hard-codes `inputType`. With that fallback gone
+ * (see `renderFieldComponent`) they take this branch, where `inputType` is
+ * whatever the AUTHOR wrote — `undefined` for a plain
+ * `{ name, type: 'password' }`, which would render `type="text"` and put a
+ * secret on screen in clear text.
+ *
+ * So this table is not a new tolerance (AGENTS.md #0.1): it is what keeps the
+ * VISIBLE rendering of these two types byte-identical to what the fallback
+ * produced, while the leak, the duplicate `<label>` and the dead `max_length`
+ * go away. An explicitly authored `inputType` still wins over it.
+ *
+ * Deliberately just these two. Every other declared field type with a native
+ * HTML equivalent (`url`, `phone`, `number`, `color`, `date` …) ALREADY takes
+ * this branch as `type="text"` on the built-in path and is untouched by
+ * objectui#5254 — widening the table here would change fields this card
+ * neither moved nor measured.
+ */
+const NATIVE_INPUT_FIELD_TYPES: Record<string, string> = {
+  email: 'email',
+  password: 'password',
+};
+
 function openNativePickerOnClick(inputType: string | undefined) {
   if (!inputType || !NATIVE_PICKER_INPUT_TYPES.has(inputType)) return undefined;
   return (e: React.MouseEvent<HTMLInputElement>) => {
@@ -2943,57 +2973,67 @@ const BuiltinSelectControl = React.forwardRef<HTMLButtonElement, BuiltinSelectCo
 );
 
 function renderFieldComponent(type: string, props: RenderFieldProps) {
-  // 1. Try to resolve specialized field widget from registry first.
-  //    Form fields should always prefer the `field:<type>` namespace when
-  //    available (e.g. so { type: 'text' } in a form schema resolves to the
-  //    text input field, not the display text widget that shares the same
-  //    short name in the global registry).
+  // 1. Resolve the specialized FIELD WIDGET — and only a field widget.
+  //    A form field's type either names a `field:`-namespaced widget or takes
+  //    the declared `default` input branch below; it never resolves a plain
+  //    SDUI node renderer (objectui#5254, maintainer ruling of 2026-08-19 —
+  //    option B of the measured option set).
   //
-  //    Which entry answered decides which CONTRACT the resolved component
-  //    implements, so the lookups are kept apart rather than folded into one
-  //    `||` chain (objectui#3233):
+  //    The bare `field:<type>` preference was always the point (so { type:
+  //    'text' } in a form schema resolves to the text INPUT, not the display
+  //    `text` widget sharing that short name in the global registry). What is
+  //    gone is the `|| ComponentRegistry.get(type)` tail behind it: a form
+  //    field that missed the `field:` namespace fell through to whatever
+  //    happened to hold the bare name in ANY namespace, which is a
+  //    cross-namespace fallback no contract states.
   //
-  //      - a `field:` entry is a FIELD WIDGET — `FieldWidgetComponentProps`,
-  //        whose metadata carrier is `field` and nothing else since v17;
-  //      - the bare-name fallback is a plain SDUI COMPONENT (the display
-  //        `text` widget, `alert`, `badge` …). Its contract is the universal
-  //        `schema` node every registered component receives from
-  //        `SchemaRenderer`. That key is NOT retired and must still be passed,
-  //        or such a field renders `undefined.className`.
+  //    Measured on `origin/main` at 3fbbea1f3, that tail answered 126 bare
+  //    names on the built-in (no-`registerAllFields()`) path — `div`, `h1`,
+  //    `card`, `button`, even `form` — and 116 of them with the fields package
+  //    registered too. The two that mattered in practice were `email` and
+  //    `password`, registered as `ui`-namespace SDUI node renderers for
+  //    top-level `{ type: 'email' }` nodes (see ./input.tsx). Reached as a
+  //    FIELD they got the field-widget prop bundle they do not implement and
+  //    spread it straight onto the element, so a hand-authored
+  //    `{ name, type: 'email', max_length: 50 }` rendered:
+  //
+  //      attrs=["class","id","max_length","field","aria-describedby",
+  //             "aria-invalid","type","value","name"]   maxlength=null
+  //
+  //    i.e. the raw metadata OBJECT as `field="[object Object]"`, an inert
+  //    `max_length` that capped nothing, and — because that renderer draws its
+  //    own `<Label>` on top of the form's `<FormLabel>` — a SECOND `<label>`
+  //    naming the same control.
+  //
+  //    A `field:` entry is a FIELD WIDGET (`FieldWidgetComponentProps`, whose
+  //    metadata carrier is `field` and nothing else since v17), which is now
+  //    the only contract this function dispatches to. `resolveFieldLabelling`
+  //    and `resolvesToRegisteredFieldWidget` above mirror this resolution and
+  //    already spelled the rule this way; they now agree with it exactly.
   const namespacedWidget = !BUILTIN_FIELD_TYPES.has(type) && !type.includes(':')
     ? ComponentRegistry.get(`field:${type}`)
     : undefined;
+  // A colon-qualified type resolves directly, and only when it names the
+  // `field` namespace (`type: 'field:textarea'`). `ui:email` is not a field
+  // widget any more than the bare `email` was.
   const RegisteredComponent = !BUILTIN_FIELD_TYPES.has(type)
-    ? (namespacedWidget || ComponentRegistry.get(type))
+    ? (namespacedWidget || (type.startsWith('field:') ? ComponentRegistry.get(type) : undefined))
     : undefined;
-  // A colon-qualified type resolves directly, and is a field widget only when
-  // it names the `field` namespace (`type: 'field:textarea'`).
-  const isFieldWidget = !!namespacedWidget || type.startsWith('field:');
 
   if (RegisteredComponent) {
-    const registeredProps = stripRegisteredFieldProps(type, props);
-
-    if (isFieldWidget) {
-      // `field` is the single metadata carrier (objectui#3233). It rides in
-      // `registeredProps` untouched — the caller always sets it (`field.field
-      // || field`, i.e. the raw metadata object, never undefined) and
-      // `stripRegisteredFieldProps` keeps it.
-      //
-      // This used to ALSO pass `schema={props.field || props.schema || props}`,
-      // a second key carrying the *same* object: `props.field` is truthy at the
-      // only call site, so the two chain terms after it were unreachable and
-      // `schema` was always `=== props.field`. Widgets therefore resolved
-      // `field || schema` to `field` on this path every time — which is why
-      // dropping the key here changes no payload, only the number of spellings
-      // a widget author has to know.
-      return <RegisteredComponent {...registeredProps} />;
-    }
-
-    // Non-field component reached through the bare-name fallback: `schema` is
-    // ITS contract, not the retired field-widget carrier, so the original
-    // resolution is preserved verbatim.
-    const nodeSchema = props.field || props.schema || props;
-    return <RegisteredComponent schema={nodeSchema} {...registeredProps} />;
+    // `field` is the single metadata carrier (objectui#3233). It rides in
+    // `registeredProps` untouched — the caller always sets it (`field.field
+    // || field`, i.e. the raw metadata object, never undefined) and
+    // `stripRegisteredFieldProps` keeps it.
+    //
+    // This used to ALSO pass `schema={props.field || props.schema || props}`,
+    // a second key carrying the *same* object: `props.field` is truthy at the
+    // only call site, so the two chain terms after it were unreachable and
+    // `schema` was always `=== props.field`. Widgets therefore resolved
+    // `field || schema` to `field` on this path every time — which is why
+    // dropping the key here changes no payload, only the number of spellings
+    // a widget author has to know.
+    return <RegisteredComponent {...stripRegisteredFieldProps(type, props)} />;
   }
 
   const { inputType, options = [], placeholder, readonly, emptyHint, ...fieldProps } = props;
@@ -3255,7 +3295,13 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       const maxLength = (fieldProps as any).maxLength ?? (fieldProps as any).max_length;
       return (
         <Input
-          type={inputType || 'text'}
+          // An authored `inputType` first, then the native type this field's
+          // own declared `type` names (objectui#5254 — `email` / `password`
+          // reach this branch since the cross-namespace fallback was removed,
+          // and must keep rendering the native input they always rendered:
+          // without this a `type: 'password'` field would show the secret as
+          // clear text). `'text'` for everything else, exactly as before.
+          type={inputType || NATIVE_INPUT_FIELD_TYPES[type] || 'text'}
           placeholder={placeholder}
           className={cn(readonlyInputClass)}
           {...fallbackProps}


### PR DESCRIPTION
Fixes #5254

Implements the maintainer ruling of 2026-08-19 (verbatim 「全部接受」), **option B**: form-field type resolution stops falling back to `ui`-namespace SDUI node renderers.

## The located surface

The claim deliberately left the file surface unstated. Located by reading, it is **one function in one file**:

- `packages/components/src/renderers/form/form.tsx` — `renderFieldComponent`, plus the `default` arm of its field switch.

That is the only site in the repo doing this resolution: a `ComponentRegistry.get` on a `field:`-prefixed key appears exactly twice across `packages/**`, both in this file (the other is `resolvesToRegisteredFieldWidget`, which only mirrors the rule and already spelled it the way the ruling prescribes). No overlap with the in-flight #5269 (`packages/plugin-view`), #5299 (`packages/plugin-dashboard`) or #5257 (`packages/core`).

## Re-derived on current `origin/main` first

The fallback still existed and still had the shape the card recorded. Measured at `3fbbea1f3`, built-in path (no `registerAllFields()`), field `{ name: 'contact', type: 'email', max_length: 50 }`:

```
ComponentRegistry.get('email') = true    ComponentRegistry.get('field:email') = false
attrs=["class","id","max_length","field","aria-describedby","aria-invalid","type","value","name"]
maxlength=null      field="[object Object]"
```

Two things the card recorded, and **a third it did not**: because the `ui` node renderer draws its own label, the control got a **second `label` element** on top of the form's own — two labels naming one control.

I also measured how wide the fallback actually was. It answered **126** bare names on the built-in path (`div`, `h1`, `card`, `button`, `form`, `alert`, `badge`, the display `text` widget …), and **116** with the fields package registered too.

## The change

A form field's `type` now resolves a `field:`-namespaced widget or takes the builtin `default` input branch. The `|| ComponentRegistry.get(type)` tail is gone, and with it the whole "non-field component reached through the bare-name fallback" branch — so `renderFieldComponent` now dispatches to exactly one contract (`FieldWidgetComponentProps`). A colon-qualified type resolves only when it names the `field` namespace, closing the same hole for `ui:email` rather than only the bare spelling.

## ⚠️ Clause-② — this IS a behaviour change, stated plainly

A spelling that resolved yesterday stops resolving. A form field whose `type` names a non-field component renders the default input instead of that component. That is the substance of the ruling, not a side effect of it, and the changeset is **`minor`** for that reason (never `major` — objectui's major is pinned to `@objectstack`'s).

Not softening it, but scoping it honestly: with `registerAllFields()` — the production configuration — every affected type already resolved its own `field:` widget, and object-derived forms go through `mapFieldTypeToFormType`, which has always emitted the `field:`-prefixed id. Rendering these components as top-level SDUI **nodes** is untouched; this rule governs field resolution only.

## The verification the ruling put on the implementer

> "Implementer must verify the default branch renders a usable input for these types."

**Measured answer: on its own, it does not.** `inputType` on that branch is whatever the author wrote, and a plain `{ name, type: 'password' }` authors none — so the branch rendered `type="text"` and put a secret on screen in clear text. That is the "worse than the leak" outcome, and it is why this PR also adds `NATIVE_INPUT_FIELD_TYPES` to the default branch: `email` and `password` are declared field types in `@object-ui/types` (`EmailFieldMetadata` / `PasswordFieldMetadata`) and keep the native input they always rendered. An explicitly authored `inputType` still wins.

So the visible rendering of an `email` / `password` field is **unchanged**; what goes away is the leak, the duplicate label and the dead ceiling. After the fix, same field as above:

```
attrs=["class","maxlength","id","aria-describedby","aria-invalid","type","name"]
type=email   maxlength=50   (no `field`, no `max_length`, one label)
```

The table is deliberately those two only. Other declared types with a native HTML equivalent (`url`, `phone`, `number`, `color`, `date`) already took this branch as `type="text"` and are untouched — widening it would change fields this card neither moved nor measured.

## Reverse verification — predicted before running, both legs

Fix committed first, then reverted, so both legs ran from a known state.

**Leg 1 — restore the bare-name fallback, keep all tests.** Predicted 8 red, named in advance; **observed exactly those 8**, no others:

| assertion | predicted | observed |
|---|---|---|
| never leaks the `field` metadata object | RED | RED |
| never leaks `max_length`, ceiling caps | RED | RED |
| exactly ONE label | RED | RED |
| stops routing a field into a non-field component (`card`) | RED | RED |
| authored `inputType` wins | RED | RED |
| carrier: no bare-name component in the field slot | RED | RED |
| carrier: renders the builtin default input instead | RED | RED |
| host-group: bare-name gets no group | RED | RED |

**Leg 2 — revert only `NATIVE_INPUT_FIELD_TYPES`.** Predicted 2 red; observed exactly 2, with the failure text that is the ruling's answer in one line:

```
AssertionError: expected 'text' to be 'password'
AssertionError: expected 'text' to be 'email'
```

**Assertions green on BOTH legs — pinning nothing on their own, said rather than counted:** the registry-reading premise test, `still resolves a field: widget`, `ui node renderers still reachable as NODES`, `builtin type on its own branch`, and (leg 1 only) the three "usable input" assertions, since the old fallback also produced a native email/password input. They are counter-probes and routing guards, not evidence of the fix.

Every zero is counter-probed with a known-present neighbouring term — `ComponentRegistry.get('form')` / `get('card')` / `get('barenameprobe')` / `get('plaindisplay')` are asserted truthy next to each `toBeUndefined()` / `toBeNull()`, so no assertion can pass on an empty registry.

## Build artifact between the edit and the thing under test

**None for the tests.** The root `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src/`, so vitest reads the edited source directly; no `dist/` sits in between. A build **is** required for `type-check` (it reads dependencies' `.d.ts`), and the first run in this fresh worktree failed with `TS2307: Cannot find module '@object-ui/core'` for that reason alone. After `pnpm --filter '@object-ui/components^...' build` it passes.

## Fixture triage

Two existing tests pinned the removed branch and were rewritten rather than re-spelled, because their assertions passed *precisely because* the fallback existed:

- `form-field-carrier.test.tsx` — the block asserting a bare-name component receives the universal `schema` node. Correct about a rule that no longer exists; now asserts the field is not routed there at all, and takes the builtin input.
- `form-readonly-host-group.test.tsx` — kept #4788's own assertion (no group wrapper for a non-field-widget) and replaced only the half that asserted the field *reached* the bare-name probe.

Both keep a counter-probe showing the component is still registered and still resolvable — it is simply no longer reachable as a **field**.

## Tests (all from repo root, canonical `pnpm exec vitest run` + the file path; no `--`)

Run on the final commit `e20ea0d22`:

| scope | result |
|---|---|
| `packages/components/src/renderers/form` + the two form-renderer suites | 50 files, **340 passed** |
| `packages/components` (full) | 166 files, **1508 passed** |
| `packages/plugin-form` + `packages/plugin-detail` | 143 files, **1398 passed** |
| `packages/plugin-view` `plugin-list` `react` `layout` `fields` | 230 files, **3445 passed** |
| `packages/app-shell` | 449 files, **4332 passed**, 1 skipped |
| `pnpm --filter @object-ui/components type-check` | pass (after building the dep closure) |
| `check:control-bytes` / `check:self-import` / `check:esm-specifiers` | pass |
| `eslint` on the changed files | 0 errors (77 pre-existing warnings; `any`-count unchanged at 45) |

Vitest was run from the repository root every time — `packages/components` owns a standalone `vitest.config.ts` and is one of the 11 packages objectui#5313 measured `assertCanonicalVitestInvocation` as NOT covering, so the guard was not relied on.

## Filed separately, not fixed here

**#5322** — a `field:`-prefixed `password` / `email` field (what `mapFieldTypeToFormType` emits) renders `type="text"` when its widget is not registered, showing a secret in clear text. Measured as pre-existing and **unchanged by this PR** on both sides of the change. Left to its own card exactly as the ruling directs, rather than widened into this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_