### PR TITLE
docs: fix two stale-symbol doc/comment strings (GanttViewMode JSDoc, ReportInput exemption reasons)

### DIFF
--- a/.changeset/stale-gantt-viewmode-doc.md
+++ b/.changeset/stale-gantt-viewmode-doc.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/plugin-gantt': patch
+---
+
+Fix the `GanttViewMode` JSDoc to name all five granularities (objectui#5132).
+
+The comment above `export type GanttViewMode` said "one column per day, week,
+month, or quarter" while the type itself, `VIEW_MODES`, `NOMINAL_DAYS`
+(`year: 365.25`), the column builder, the toolbar and the header-band logic
+have honored a fifth member, `'year'`, all along — `'year'` was fully live,
+just undocumented. Doc-only change, no behavior difference.

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -193,7 +193,7 @@ export interface GanttTask {
   hasOwnDates?: boolean
 }
 
-/** Timeline granularity — one column per day, week, month, or quarter. */
+/** Timeline granularity — one column per day, week, month, quarter, or year. */
 export type GanttViewMode = 'day' | 'week' | 'month' | 'quarter' | 'year';
 
 const VIEW_MODES: GanttViewMode[] = ['day', 'week', 'month', 'quarter', 'year'];

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -326,8 +326,8 @@ const DOC_TYPE_EXEMPTIONS = {
       'vocabulary (`SelectionConfigSchema`, @objectstack/spec/ui), not a node type.',
   },
   'content/docs/plugins/plugin-report.mdx': {
-    matrix: 'ReportInput kind — a report definition\'s shape, sibling of `joined` / `summary`.',
-    joined: 'ReportInput kind — a report definition\'s shape, sibling of `matrix` / `summary`.',
+    matrix: 'ReportSchema.type kind — a report definition\'s shape, sibling of `joined` / `summary`.',
+    joined: 'ReportSchema.type kind — a report definition\'s shape, sibling of `matrix` / `summary`.',
   },
   'content/docs/utilities/runner.mdx': {
     'my-component':


### PR DESCRIPTION
Fixes #5132
Fixes #5139

Sweep pack: two one-line stale-doc-text fixes, unrelated files, no behavior change either card.

## Before / after

| Issue | File | Before | After |
|---|---|---|---|
| #5132 | `packages/plugin-gantt/src/GanttView.tsx:195` | `/** Timeline granularity — one column per day, week, month, or quarter. */` | `/** Timeline granularity — one column per day, week, month, quarter, or year. */` |
| #5139 | `scripts/check-doc-component-types.mjs:329` | `matrix: 'ReportInput kind — a report definition\'s shape, sibling of \`joined\` / \`summary\`.',` | `matrix: 'ReportSchema.type kind — a report definition\'s shape, sibling of \`joined\` / \`summary\`.',` |
| #5139 | `scripts/check-doc-component-types.mjs:330` | `joined: 'ReportInput kind — a report definition\'s shape, sibling of \`matrix\` / \`summary\`.',` | `joined: 'ReportSchema.type kind — a report definition\'s shape, sibling of \`matrix\` / \`summary\`.',` |

## #5132 — GanttViewMode JSDoc undercounted granularities

The JSDoc above `export type GanttViewMode` named four granularities while the type itself (`'day' | 'week' | 'month' | 'quarter' | 'year'`), `VIEW_MODES`, `NOMINAL_DAYS` (`year: 365.25`), the column builder, the toolbar (`VIEW_MODES.map`) and the header-band logic (`viewMode === 'year' ? 'decade' : …`) all honor a fifth member, `'year'`. `'year'` is fully live, not vestigial. The upstream spec agrees: `GanttConfigSchema.viewMode` on `@objectstack/spec@17.0.0` is `z.enum(['day','week','month','quarter','year'])`. One-word fix, comment only.

## #5139 — DOC_TYPE_EXEMPTIONS reason cites a retired symbol

Both `DOC_TYPE_EXEMPTIONS['content/docs/plugins/plugin-report.mdx']` reason strings opened with `'ReportInput kind — …'`. `ReportInput` is not on `@objectstack/spec@17.0.0`'s export surface — the `…Input` aliases were retired at rc.6 (`packages/types/src/spec-report.ts` records the rename). The exemptions themselves stay exactly as they are: `matrix` and `joined` really are report-type discriminants, not component types. Only the reason text changes.

Chose to name the real member, `ReportSchema.type`, over the more generic `Report kind` — verified against the current `@objectstack/spec@17.0.0` `.d.ts`: `ReportSchema` declares its `type` field as a defaulted Zod enum over `summary` / `tabular` / `matrix` / `joined`, and the exported `ReportType` enum carries the same four members. Naming the concrete field is more defensible and re-checkable than the generic phrase.

## Verification

- `node scripts/check-doc-component-types.mjs` — passes on the edited file (`Scanned 143 mdx file(s) … Every documented component type is registered.`).
- `node scripts/check-changeset-presence.mjs` — `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` (`@object-ui/plugin-gantt` patch changeset added; `scripts/` is not a released package so #5139's file needs none).
- `node scripts/check-changeset-no-major.mjs` — no `major` bump declared.
- Vitest run from repo root, `pnpm exec vitest run scripts/__tests__/check-doc-component-types.test.ts` — `Test Files 1 passed (1)`, `Tests 27 passed (27)` (this is the gate's own test, not just the gate script — a prior PR, #5244, went red for skipping this distinction).
- Dependency closure built first (`pnpm --filter "@object-ui/plugin-gantt^..." build`, 13 packages), then `pnpm --filter "@object-ui/plugin-gantt" type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — green, zero errors. Ran it and it was green; a JSDoc-only edit cannot break typecheck but this is measured, not assumed.
- `packages/plugin-gantt` owns a standalone `vitest.config.ts` (confirmed — `assertCanonicalVitestInvocation` does not cover it), so its real invocation is the package-scoped one: `pnpm --filter "@object-ui/plugin-gantt" test` — `Test Files 44 passed (44)`, `Tests 386 passed (386)`. Cross-checked the file count against `find packages/plugin-gantt/src -iname '*.test.*' | wc -l` (44) to rule out a silent zero/partial match.
- Reverse-verification: **degenerate here, stated plainly rather than filled into the template.** Both changes are comment/string-literal text with no reachable behavior difference to revert-and-observe: the JSDoc line is never read by any code path (TypeScript doesn't type-check comment prose), and the exemption *reason* string is dead data as far as `check-doc-component-types.mjs`'s accept/reject logic goes — the gate keys off `matrix`/`joined` (untouched) and only ever prints the reason string in a pass-report, never branches on its content. There is no artifact-vs-source distinction to report per leg because there is no behavior boundary to cross in either direction.

All verification above ran against commit `3fefe5fde` (this branch's current head).

## Scope note

Nothing else rides along. Sweep-pack rules followed: only the two lines named in the dispatch order changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_