### PR TITLE
docs(guide): objectstack.config.ts belongs to the server project — link it, do not re-type it (#5160)

### DIFF
--- a/content/docs/guide/objectos-integration.mdx
+++ b/content/docs/guide/objectos-integration.mdx
@@ -75,72 +75,19 @@ export async function createKernel() {
 
 ### 3. Create ObjectStack Configuration
 
-```typescript
-// objectstack.config.ts
-import type { AppManifest } from '@objectstack/spec';
+`objectstack.config.ts` belongs to the **ObjectStack server project**, not to an
+ObjectUI app. It is authored with `defineStack()` and compiled by the `os` CLI;
+the packages it imports (`@objectstack/spec`, `@objectstack/runtime`, plugins)
+are dependencies of that project, not of this one. ObjectUI is a pure consumer
+of whatever the server publishes over the metadata API, so the authoritative
+reference for this file lives on the ObjectStack side:
 
-export const manifest: AppManifest = {
-  name: 'my-app',
-  version: '1.0.0',
-  description: 'My ObjectUI + ObjectOS Application',
-  
-  // Define your data objects
-  objects: {
-    contact: {
-      name: 'contact',
-      label: 'Contact',
-      fields: {
-        name: { name: 'name', label: 'Name', type: 'text', required: true },
-        email: { name: 'email', label: 'Email', type: 'email', required: true },
-        phone: { name: 'phone', label: 'Phone', type: 'phone' },
-        company: { name: 'company', label: 'Company', type: 'text' },
-        status: {
-          name: 'status',
-          label: 'Status',
-          type: 'select',
-          options: [
-            { label: 'Active', value: 'active' },
-            { label: 'Inactive', value: 'inactive' }
-          ]
-        }
-      }
-    }
-  },
+- [Your First Project](https://objectstack.ai/docs/getting-started/your-first-project) — the generated `objectstack.config.ts` walked through key by key: `manifest`, `plugins`, `objects`
+- [Command Line Interface](https://objectstack.ai/docs/deployment/cli) — how the file is discovered, validated against `ObjectStackDefinitionSchema`, and compiled to a deployable `dist/objectstack.json`
+- [Data Flow Diagrams](https://objectstack.ai/docs/api/data-flow) — how `defineStack()` becomes a running application
 
-  // Define UI pages
-  pages: [
-    {
-      name: 'contacts',
-      label: 'Contacts',
-      path: '/contacts',
-      icon: 'users',
-      component: {
-        type: 'object-view',
-        objectName: 'contact',
-        viewTypes: ['grid', 'kanban', 'calendar']
-      }
-    }
-  ],
-
-  // Define app navigation
-  navigation: {
-    items: [
-      {
-        label: 'Dashboard',
-        path: '/',
-        icon: 'home'
-      },
-      {
-        label: 'Contacts',
-        path: '/contacts',
-        icon: 'users'
-      }
-    ]
-  }
-};
-
-export default manifest;
-```
+The rest of this guide is ObjectUI's half of the integration: rendering the
+objects, views and apps that the server exposes.
 
 ### 4. Set Up Frontend with Console
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -211,7 +211,16 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  */
 const UNGATED_DOCS = {
   'content/docs/guide/objectos-integration.mdx':
-    '36 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 7 unresolved-module diagnostic(s); plus TS2305x1 TS2339x1 — candidate real defects, un-triaged',
+    '36 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 7 unresolved-module diagnostic(s); plus TS2339x1 — candidate real defects, ' +
+    'un-triaged. This entry read TS2305x1 until objectui#5160, whose last name was the ' +
+    '`AppManifest` annotation on an `objectstack.config.ts` literal. That block is gone rather ' +
+    'than re-typed: the file is a server-project config this repo neither owns nor builds, so the ' +
+    'section links to the ObjectStack documentation instead of restating its shape here. Covering ' +
+    'this page still needs the 8 parse-failing blocks re-fenced or declared, the undefined-name ' +
+    'blocks made self-contained, and the `@objectstack/*` runtime imports resolvable — none of ' +
+    'which this repo can do from here.',
   'content/docs/plugins/plugin-calendar-view.mdx':
     '2 unresolved-module diagnostic(s) — and NOT a defect: the page is a migration guide whose ' +
     '"Before" blocks quote the retired `@object-ui/plugin-calendar-view` import on purpose. Covering ' +


### PR DESCRIPTION
Fixes #5160

The last of the 15 non-exported-symbol imports measured across this repo's published pages. The other 14 landed in #5260; this is the `AppManifest` block at `content/docs/guide/objectos-integration.mdx:80`.

## The measurement that selected the branch

The maintainer ruling of 2026-08-19 is **Option C — delete the block and link to the framework repo's own `objectstack.config.ts` documentation**, with a pre-ruled fallback to Option A (rewrite to `defineStack`) **if the framework repo has no such page**. So the branch turns on one cross-repo reading:

Searched `objectstack-ai/objectstack` at `origin/main` (`43cd348a2`), over `content/docs/**` — 429 files — by filename and by content:

| probe | result |
| --- | --- |
| filenames matching `config` | 7 files, none of them the authoring page (`config-resolution`, `*-node-config`, `auth/email/registry-config`) |
| content `objectstack\.config` | **34 files**, 60+ hits |
| content `defineStack` (counter-probe, known present) | **58 files** |
| content `ObjectStackDefinitionSchema` (counter-probe, known present) | 6 files |
| content `zzqqxxnotapage` (negative control) | 0 files |

Not a zero, and the apparatus discriminates: a term known present returns 58 of 429, a nonsense term returns 0. **The framework repo does document this file**, so **Option C** it is; Option A was not taken.

Three pages carry it, and all three are linked from the rewritten section:

- `content/docs/getting-started/your-first-project.mdx` — the generated `objectstack.config.ts` walked through key by key, in a fence titled with that exact filename
- `content/docs/deployment/cli.mdx` — discovery order, validation against `ObjectStackDefinitionSchema`, compilation to `dist/objectstack.json`
- `content/docs/api/data-flow.mdx` — how `defineStack()` becomes a running application

**URL construction, stated because I could not fetch it:** every probe of `objectstack.ai` / `docs.objectstack.ai` returned `000` through this container's proxy, which is a proxy reading and not a site reading. The URLs are therefore built from the framework repo's own convention rather than from a fetch: its `README.md` links `https://objectstack.ai/docs/getting-started/build-with-claude-code` and `https://objectstack.ai/docs/deployment/self-hosting`, and both of those map onto files that exist at the same path under `content/docs/` with an `.mdx` extension. `https://objectstack.ai/docs` is the dominant form in that repo (61 occurrences). Each of the three files linked here was confirmed present at `origin/main`.

## Why the block is gone rather than re-typed

Option B — correcting only the import path to `@objectstack/spec/system` — stays rejected, and the diff does not drift toward it. The name is real there, but `AppManifestSchema` is `{name, label, version, description?, objects: string[], views: string[], flows: string[], dependencies: string[]}` while the literal beneath the annotation has no `label` and its `objects` is a map of full object definitions. A path-only fix trades `TS2305` for a fresh `TS2739`/`TS2322` on the same lines: the page keeps teaching something that does not compile while the ledger reads as improved.

The section keeps its heading and its place in the numbered walkthrough — `content/docs/guide/console.md:72` and `console-architecture.md:75` both point readers here for the server-side shape, and they still land on an answer. It now says the file belongs to the ObjectStack server project, that it is authored with `defineStack()` and compiled by the `os` CLI, and where the authoritative reference lives.

## The ledger, in the same PR

Re-measured after the edit and restated. Nothing added, nothing widened, no entry deleted.

| | before | after |
| --- | --- | --- |
| ts/tsx blocks compiled | 22 | 21 |
| parse | 36 | 36 |
| undefined-name | 10 | 10 |
| unresolved-module | 7 | 7 |
| **TS2305** | **1** (`:80`, `AppManifest`) | **0** |
| TS2339 | 1 | 1 |

The page does not reach zero, so **the entry stays** — it is the mix that changed. The mechanical half of the new reason string is generated, not hand-counted: the generator was first validated by reproducing the **current** entry **byte-for-byte** from the pre-edit tree, then re-run against the tree as committed, where the committed entry is a prefix match on the freshly measured mix plus triage prose.

## Verification — all at `57aef7f3e`, working tree clean

Whether a build artifact sits between each edit and the thing under test, per leg:

- **doc edit to measurement** — no artifact between them. The gate reads the `.mdx` from the working tree at run time. Artifacts do sit under the *packages* the snippets are judged against, so those were built first: `pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter)` -> `Tasks: 20 successful`, plus four measurement-only packages (`components`, `fields`, `plugin-form`, `plugin-kanban`) that un-gating this page for measurement pulls in -> `14 successful`.
- **ledger edit to gate** — no artifact between them either. `check-doc-snippet-types.mjs` runs from source as an `.mjs` script.
- **reverse-verification of the ledger edit** — mutated the committed entry to a one-character reason: gate goes **exit 1** with `content/docs/guide/objectos-integration.mdx [unexplained-ungated-entry] an entry with no written reason is not a declaration`. Restored with `git checkout` of the branch path for `scripts/check-doc-snippet-types.mjs` (never `git stash`); gate returns to **exit 0** and `git status` is clean. Predicted direction was red-on-mutation and that is what happened.

Runs:

- `node scripts/check-doc-snippet-types.mjs` -> exit 0. `Semantic phase: 68 of 68 block(s) judged, 0 failed.` All three controls proven in the same run: resolution landed on `packages/types/dist/index.d.ts`, sentinel produced `TS2305`, positive produced 0.
- `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts` from the repo root -> `Test Files 1 passed (1), Tests 20 passed (20)`. Running the script is not running its test; both were run.
- `--build-filter` output is **byte-identical** before and after (`diff` clean). Expected: the page stays ungated, and the deleted block imported `@objectstack/spec`, an external package that never entered the filter. Gate CI cost does not move.
- `node scripts/check-doc-links.mjs` -> `Links are valid across 13 scan roots.`
- `pnpm turbo run build --filter='@object-ui/site'` -> `Tasks: 29 successful, 29 total` (the diff touches `content/`, so Build Docs will run in CI).
- `node scripts/check-control-bytes.mjs` -> OK, 4721 tracked text files; plus a direct `grep -naP` over the two changed files -> clean.
- `pnpm type-check:scripts` -> exit 0. `pnpm lint:root` -> 0 errors, 24 pre-existing warnings, none in either changed file.
- `node scripts/check-changeset-presence.mjs` -> `No source of a released package changed in this range, so no changeset is owed.` Followed the verdict rather than assuming; no changeset added.

Heavy runs were serialized on the shared `/tmp/os-heavy-verify.lock`. CI convergence is not awaited here, per the 2026-08-10 ruling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_