### PR TITLE
fix(plugin-view): a top-level `conditionalFormatting` no longer reaches the kanban view (#5248)

### DIFF
--- a/.changeset/objectview-kanban-conditional-formatting-host-only-5248.md
+++ b/.changeset/objectview-kanban-conditional-formatting-host-only-5248.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/plugin-view': minor
+---
+
+`object-view`: a top-level `conditionalFormatting` no longer reaches the kanban view.
+
+`ObjectView.generateViewSchema`'s kanban branch resolved its rule list from a
+three-link chain: `options.kanban.conditionalFormatting`, then the active view's
+own rule, then `(schema as any).conditionalFormatting` read straight off the
+`object-view` node. The first two links are declared surface. The third was not:
+`ObjectViewSchema` has no such member, the `object-view` registry registration
+does not publish it in `inputs`, and `BaseSchema`'s index signature keeps tsc
+silent — yet it was honoured, because that branch runs exactly when no host
+supplies `renderListView`, which is the path the registered renderer takes.
+
+That one key was the sole counter-example to the objectui#5097 exemption, whose
+stated basis is that its 27 keys are reachable only through the host-supplied
+delegation. Maintainer ruling of 2026-08-19 on objectui#5248 (verbatim
+「全部接受」): Option 2, gated on a liveness check, with Option 1 (declare the key
+on `ObjectViewSchema` and in the registry `inputs`) pre-ruled for the case where
+the check found real authored usage. The check came back empty — no authored
+document in either repo puts `conditionalFormatting` on an `object-view` node
+(objectui docs carry it only on `object-grid`, the authoring skill only on
+`list-view`; objectstack authors no `object-view` node at all) — so the read was
+dropped rather than the key declared.
+
+Behavior change, stated because it is one: an `object-view` node that carried a
+top-level `conditionalFormatting` and rendered a kanban view now renders that
+kanban unformatted. Author the rules where they are declared — under
+`options.kanban.conditionalFormatting`, or on the view — and both keep working
+with the same precedence as before.
+
+Not narrowed: the host `renderListView` delegation still reads the key off the
+`object-view` node and forwards it to the host's list renderer. It remains
+host-composition surface under objectui#5097; only the author-reachable path
+closed. Both halves are pinned in
+`packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx`,
+and `objectViewHostSurface.test.tsx` now asserts that ZERO exempt keys are read
+outside the host-composition fence.

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -378,17 +378,39 @@ type FormMode = 'create' | 'edit' | 'view';
  * `inputs` list at `./index.tsx:71-86` (15 names; the alias `view` declares no
  * `inputs` at all), and none of the 27 appears on either registration.
  *
- * ## The one asymmetry — `conditionalFormatting`
+ * ## The one asymmetry — `conditionalFormatting` — RESOLVED (objectui#5248)
  *
- * 26 of the 27 are read ONLY inside the host-only branch. `conditionalFormatting`
- * has a SECOND read site, in `generateViewSchema`'s kanban branch (see
- * `kanbanConditionalFormatting`), which IS reachable through the registered
- * renderer. For that one key the ruling's "the authored path cannot reach it"
- * basis is therefore narrower than for its 26 neighbours. Recorded here rather
- * than acted on: the exemption preserves the status quo either way (nothing
- * declared, nothing removed), and whether that second read makes
- * `conditionalFormatting` authored surface on the kanban path is a fresh
- * contract question, filed separately as objectui#5248.
+ * As ruled on 2026-08-18, 26 of the 27 were read ONLY inside the host-only
+ * branch, and `conditionalFormatting` had a SECOND read site in
+ * `generateViewSchema`'s kanban branch — reachable through the REGISTERED
+ * renderer, so for that one key the ruling's "the authored path cannot reach
+ * it" basis was narrower than for its 26 neighbours. objectui#5097 recorded the
+ * gap rather than acting on it and filed the contract question as
+ * objectui#5248.
+ *
+ * That question is now answered, and the gap is closed. Maintainer ruling of
+ * 2026-08-19 (verbatim 「全部接受」, recorded on objectui#5248): a conditional —
+ * Option 2 gated on a liveness check, Option 1 (declare the key) had the check
+ * found real authored usage. The liveness check came back EMPTY:
+ *
+ *   - objectui `content/docs/**`, `skills/**`, `examples/**`, `apps/**`:
+ *     `conditionalFormatting` occurs in exactly two files, on `object-grid`
+ *     (`content/docs/plugins/plugin-grid.mdx`) and on `list-view`
+ *     (`skills/objectui/guides/schema-expressions.md`) — both DECLARED homes,
+ *     neither an object-view node.
+ *   - objectstack: no authored `object-view` node exists at all (two prose
+ *     mentions repo-wide), against 54 files carrying `object-form` and 19
+ *     carrying `object-grid` as the control.
+ *   - No in-repo fixture or catalog schema carries both an object-view node and
+ *     the key: the only files carrying both are this one, its pin test, the
+ *     type declarations, app-shell's host (which reads the key into the
+ *     delegated `list-view` node, not onto the object-view node) and prose.
+ *
+ * So the fallback read was dropped from the kanban branch (see
+ * `kanbanConditionalFormatting`). Every one of the 27 is now read ONLY inside
+ * the `#region` fence, and the exemption's stated basis holds for all of them
+ * without exception. The pin in `objectViewHostSurface.test.tsx` asserts the
+ * resolution directly: ZERO exempt keys are read outside the fence.
  */
 export const OBJECT_VIEW_HOST_COMPOSITION_KEYS = [
   'addDeleteRecordsInline',
@@ -953,24 +975,39 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
             : baseProps.fields) || [];
         const { columns: _kanbanColumns, groupByField: _gbf, groupField: _gf, titleField: _tf, conditionalFormatting: _kanbanCf, ...restKanban } = kanbanCfg;
         // Forward conditional formatting to kanban (issue #1584): nested
-        // `options.kanban.conditionalFormatting` wins, then the view-level, then
-        // the schema-level rule — matching how the grid branch resolves it.
-        // Previously the top-level rule was dropped for kanban entirely.
+        // `options.kanban.conditionalFormatting` wins, then the view-level rule.
+        // Those are the two places the key is DECLARED — `ObjectKanbanSchema`
+        // for the nested block, the named/active view for the other.
         //
-        // ⚠️ objectui#5097 — this is the ONLY read of one of the 27
-        // host-composition keys that sits OUTSIDE the `#region` fence below,
-        // and the only one on a path the REGISTERED renderer can reach:
-        // `generateViewSchema` runs precisely when no host supplied
-        // `renderListView`. So for `conditionalFormatting` alone, the
-        // exemption's "the authored path cannot reach it" basis is narrower
-        // than for its 26 neighbours. Recorded, not acted on — see
-        // `OBJECT_VIEW_HOST_COMPOSITION_KEYS` ("The one asymmetry") and
-        // objectui#5248, which owns the contract question. ⛔ Do not delete
-        // this read, and ⛔ do not move it inside the fence to quiet the pin.
+        // objectui#5248 — a THIRD fallback used to sit at the end of this chain,
+        // `(schema as any).conditionalFormatting`, reading the key off the
+        // object-view node itself. It was the ONLY read of one of the 27
+        // objectui#5097 host-composition keys outside the `#region` fence below,
+        // and the only one on a path the REGISTERED renderer can reach
+        // (`generateViewSchema` runs precisely when no host supplied
+        // `renderListView`). That made the exemption's stated basis — "the
+        // authored path cannot reach these keys" — false for this one key.
+        //
+        // The maintainer ruled on 2026-08-19 (verbatim 「全部接受」, recorded on
+        // objectui#5248): a conditional, Option 2 gated on a liveness check.
+        // The check came back EMPTY — no authored document in either repo puts
+        // `conditionalFormatting` on an object-view node (objectui: it appears
+        // in `content/docs` only on `object-grid`, and in `skills/` only on
+        // `list-view`; objectstack: `object-view` is not authored anywhere, 2
+        // prose mentions and no node, while `object-form` appears in 54 files
+        // and `object-grid` in 19). So the fallback was dropped: the key is now
+        // genuinely host-only, and the objectui#5097 basis holds for all 27.
+        //
+        // ⛔ Do not restore this fallback as a convenience. Authoring
+        // kanban conditional formatting has two declared homes; a top-level key
+        // that nothing declares, nothing publishes in the registry `inputs` and
+        // tsc cannot see (BaseSchema's index signature) is precisely the
+        // "renderer reads it, manifest denies it" condition objectui#4648 /
+        // objectui#5091 exist to close. The host `renderListView` delegation
+        // below still reads and forwards the key — that half is NOT narrowed.
         const kanbanConditionalFormatting =
           kanbanCfg.conditionalFormatting ??
-          activeView?.conditionalFormatting ??
-          (schema as any).conditionalFormatting;
+          activeView?.conditionalFormatting;
         return {
           type: 'object-kanban',
           ...baseProps,
@@ -1333,11 +1370,13 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
     // deleted read silently blanks a stored app-shell document.
     //
     // The list, the two supplier `file:line`s, the contract's (non-)verdict and
-    // the `conditionalFormatting` asymmetry live with
-    // `OBJECT_VIEW_HOST_COMPOSITION_KEYS` at the top of this file. The `#region`
-    // fence is load-bearing: `src/__tests__/objectViewHostSurface.test.tsx`
+    // the now-resolved `conditionalFormatting` asymmetry (objectui#5248) live
+    // with `OBJECT_VIEW_HOST_COMPOSITION_KEYS` at the top of this file. The
+    // `#region` fence is load-bearing: `src/__tests__/objectViewHostSurface.test.tsx`
     // re-derives the read set from between these two markers, so adding or
-    // removing a read here fails that pin BY NAME.
+    // removing a read here fails that pin BY NAME — and since objectui#5248 it
+    // also fails if any exempt key is read OUTSIDE the fence, which is where
+    // the author-reachable paths live.
     if (renderListView) {
       return renderListView({
         schema: {

--- a/packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Kanban `conditionalFormatting` is authored where it is DECLARED, and nowhere
+ * else (objectui#5248).
+ *
+ * ## What this pins, and why it is a contract test rather than a refactor test
+ *
+ * `generateViewSchema`'s kanban branch resolves the rule list from a chain. Two
+ * links are declared surface:
+ *
+ *   - `options.kanban.conditionalFormatting` — `ObjectKanbanSchema` declares it
+ *     (`packages/types/src/objectql.ts`, zod contract pinned in
+ *     `packages/types/src/__tests__/kanban-conditional-formatting.test.ts`).
+ *   - the active/named view's own `conditionalFormatting` — the view definition
+ *     declares it, and it is what Studio's CEL editor writes.
+ *
+ * A third link used to sit at the end: `(schema as any).conditionalFormatting`,
+ * read straight off the `object-view` node. Nothing declared it —
+ * `ObjectViewSchema` has no such member, the `object-view` registry
+ * registration does not publish it in `inputs`, and `BaseSchema`'s index
+ * signature means tsc says nothing either. It was honoured anyway, because this
+ * branch runs exactly when no host supplied `renderListView` — the path the
+ * REGISTERED renderer takes.
+ *
+ * That made it the one counter-example to the objectui#5097 exemption, whose
+ * stated basis is that its 27 keys are reachable only through the host-supplied
+ * delegation. Maintainer ruling 2026-08-19 (verbatim 「全部接受」, recorded on
+ * objectui#5248): Option 2, gated on a liveness check — Option 1 (declare the
+ * key on `ObjectViewSchema` + registry `inputs`) had the check found real
+ * authored usage. The check came back empty, so the read was dropped.
+ *
+ * ## The half that must NOT move
+ *
+ * The key stays HOST surface. The `renderListView` delegation still reads it
+ * off the object-view node and forwards it to the host's list renderer — a
+ * stored app-shell document that carries it must keep working. The last
+ * describe below is that half, asserted from the same file so the two cannot
+ * drift apart: narrowing one is a ruling, narrowing both is a bug.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ObjectView } from '../ObjectView';
+import type { ObjectViewSchema } from '@object-ui/types';
+
+/** Every schema the view hands to SchemaRenderer, in order. */
+const rendered: any[] = [];
+
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
+  return {
+    SchemaRenderer: ({ schema }: any) => {
+      rendered.push(schema);
+      return <div data-testid="schema-renderer">{schema?.type}</div>;
+    },
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+vi.mock('@object-ui/plugin-grid', () => ({ ObjectGrid: () => <div data-testid="object-grid" /> }));
+vi.mock('@object-ui/plugin-form', () => ({ ObjectForm: () => <div data-testid="object-form" /> }));
+
+const dataSource = (): any => ({
+  find: vi.fn().mockResolvedValue({ data: [], total: 0 }),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn().mockResolvedValue({ name: 'task', fields: {} }),
+});
+
+/** The two authoring shapes, distinct enough that a mix-up is visible. */
+const TOP_LEVEL_RULE = [{ condition: "record.stage == 'won'", style: { backgroundColor: '#top' } }];
+const VIEW_LEVEL_RULE = [{ condition: "record.stage == 'won'", style: { backgroundColor: '#view' } }];
+const NESTED_RULE = [{ condition: "record.stage == 'won'", style: { backgroundColor: '#nested' } }];
+
+/**
+ * Renders a kanban view through the REGISTERED renderer's path — i.e. with no
+ * `renderListView` — and returns the `object-kanban` node the branch emits.
+ */
+async function renderKanbanView(opts: {
+  schemaExtras?: Record<string, unknown>;
+  view?: Record<string, unknown>;
+}): Promise<any> {
+  rendered.length = 0;
+  render(
+    <ObjectView
+      schema={{ type: 'object-view', objectName: 'task', ...(opts.schemaExtras ?? {}) } as unknown as ObjectViewSchema}
+      views={[{ id: 'k', label: 'Board', type: 'kanban' as any, kanban: { groupByField: 'stage' }, ...(opts.view ?? {}) }] as any}
+      dataSource={dataSource()}
+    />,
+  );
+  await waitFor(() => expect(rendered.length).toBeGreaterThan(0));
+  const node = rendered[rendered.length - 1];
+  expect(node.type).toBe('object-kanban');
+  return node;
+}
+
+describe('the kanban branch reads `conditionalFormatting` only where it is declared (objectui#5248)', () => {
+  it('a TOP-LEVEL rule on the object-view node does not reach the kanban node', async () => {
+    const node = await renderKanbanView({ schemaExtras: { conditionalFormatting: TOP_LEVEL_RULE } });
+
+    expect(
+      Object.prototype.hasOwnProperty.call(node, 'conditionalFormatting'),
+      'A `conditionalFormatting` written at the TOP LEVEL of an object-view node reached the kanban\n'
+        + 'node again. Nothing declares that key there: it is not a member of ObjectViewSchema, the\n'
+        + '`object-view` registration does not publish it in `inputs`, and BaseSchema\'s index\n'
+        + 'signature keeps tsc silent — so honouring it is the "renderer reads it, manifest denies\n'
+        + 'it" condition. Ruled out on objectui#5248 (2026-08-19). Author it under\n'
+        + '`options.kanban.conditionalFormatting` or on the view.',
+    ).toBe(false);
+    expect(node.conditionalFormatting).toBeUndefined();
+  });
+
+  it('the VIEW-level rule still reaches the kanban node', async () => {
+    const node = await renderKanbanView({ view: { conditionalFormatting: VIEW_LEVEL_RULE } });
+    expect(node.conditionalFormatting).toEqual(VIEW_LEVEL_RULE);
+  });
+
+  it('the NESTED `options.kanban` rule still reaches the kanban node', async () => {
+    const node = await renderKanbanView({
+      view: { kanban: { groupByField: 'stage', conditionalFormatting: NESTED_RULE } },
+    });
+    expect(node.conditionalFormatting).toEqual(NESTED_RULE);
+  });
+
+  it('nested wins over view-level, and neither is displaced by a top-level key', async () => {
+    const node = await renderKanbanView({
+      schemaExtras: { conditionalFormatting: TOP_LEVEL_RULE },
+      view: {
+        conditionalFormatting: VIEW_LEVEL_RULE,
+        kanban: { groupByField: 'stage', conditionalFormatting: NESTED_RULE },
+      },
+    });
+    expect(node.conditionalFormatting).toEqual(NESTED_RULE);
+  });
+
+  it('a top-level key does not fill in for a view that declares none', async () => {
+    // The precedence chain is nested → view. With both of those absent the
+    // answer is "no conditional formatting", not "fall back to the undeclared
+    // top-level key" — this is the case the dropped read used to serve, and the
+    // only one whose behaviour objectui#5248 changes.
+    const withTop = await renderKanbanView({ schemaExtras: { conditionalFormatting: TOP_LEVEL_RULE } });
+    const withoutTop = await renderKanbanView({});
+    expect(withTop.conditionalFormatting).toEqual(withoutTop.conditionalFormatting);
+    expect(withoutTop.conditionalFormatting).toBeUndefined();
+  });
+
+  it('the other kanban resolution is untouched — groupBy and card fields still flow', async () => {
+    // The control. Without it, every assertion above would pass just as happily
+    // against a kanban branch that had stopped emitting anything at all.
+    const node = await renderKanbanView({
+      view: { kanban: { groupByField: 'stage', columns: ['name', 'amount'], titleField: 'name' } },
+    });
+    expect(node.groupBy).toBe('stage');
+    expect(node.groupField).toBe('stage');
+    expect(node.titleField).toBe('name');
+    expect(node.cardFields).toEqual(['name', 'amount']);
+  });
+});
+
+describe('the HOST delegation still carries the top-level key — not narrowed (objectui#5097)', () => {
+  it('`renderListView` receives `conditionalFormatting` read off the object-view node', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    render(
+      <ObjectView
+        schema={{
+          type: 'object-view',
+          objectName: 'task',
+          conditionalFormatting: TOP_LEVEL_RULE,
+        } as unknown as ObjectViewSchema}
+        dataSource={dataSource()}
+        renderListView={({ schema: s }: { schema: Record<string, unknown> }) => {
+          seen.push(s);
+          return <div data-testid="delegated" />;
+        }}
+      />,
+    );
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+
+    expect(
+      seen[0].conditionalFormatting,
+      'The host `renderListView` delegation stopped forwarding `conditionalFormatting`. objectui#5248\n'
+        + 'narrowed the AUTHOR-reachable kanban read only; the key remains host-composition surface\n'
+        + '(objectui#5097) and a stored app-shell document that carries it must keep rendering. ⛔ Do\n'
+        + 'not narrow this half to match the other.',
+    ).toEqual(TOP_LEVEL_RULE);
+    expect(seen[0].type).toBe('list-view');
+  });
+});

--- a/packages/plugin-view/src/__tests__/objectViewHostSurface.test.tsx
+++ b/packages/plugin-view/src/__tests__/objectViewHostSurface.test.tsx
@@ -158,20 +158,45 @@ describe('the forwarded key set equals the documented exemption (objectui#5097)'
     expect(exempt.filter((k) => declared.includes(k))).toEqual([]);
   });
 
-  it('`conditionalFormatting` is the ONLY exempt key also read outside the fence', () => {
-    // The measured asymmetry recorded on objectui#5248: `generateViewSchema`'s
-    // kanban branch reads it too, and that branch runs exactly when no host
-    // supplied `renderListView` — i.e. on the path the registered renderer
-    // takes. For this one key the ruling's "the authored path cannot reach it"
-    // basis is narrower than for its 26 neighbours. Pinned so the exception
-    // cannot be lost, and so a SECOND such read cannot appear unnoticed.
+  it('NO exempt key is read outside the fence — the objectui#5248 resolution', () => {
+    // This assertion used to read `.toEqual(['conditionalFormatting'])`.
+    //
+    // objectui#5097 measured one asymmetry: `generateViewSchema`'s kanban
+    // branch read `conditionalFormatting` off the object-view node too, and
+    // that branch runs exactly when no host supplied `renderListView` — i.e. on
+    // the path the REGISTERED renderer takes. For that one key the ruling's
+    // "the authored path cannot reach it" basis was narrower than for its 26
+    // neighbours, and objectui#5248 was filed to settle it.
+    //
+    // Maintainer ruling 2026-08-19 (verbatim 「全部接受」): Option 2, gated on a
+    // liveness check — which came back empty (no authored document in either
+    // repo puts the key on an object-view node), so the fallback read was
+    // dropped rather than the key declared. The set of exempt keys read outside
+    // the fence is therefore EMPTY, and the exemption's basis now holds for all
+    // 27 without exception. That is what this pins.
+    //
+    // ⛔ Do not "fix" a failure here by re-listing a key. A key read out here is
+    // author-reachable; putting it back on this list is how the exemption stops
+    // describing anything.
     const outside = castReadsIn(SOURCE.replace(regionSlice(), ''));
     expect(
       outside,
-      'A host-composition key is now read outside the objectui#5097 fence. Reads out there are on\n'
+      'A host-composition key is read outside the objectui#5097 fence again. Reads out there are on\n'
         + 'the AUTHOR-reachable path, which is the basis the exemption rests on — so this is a\n'
-        + 'contract change, not a refactor. See objectui#5248 before widening this list.',
-    ).toEqual(['conditionalFormatting']);
+        + 'contract change, not a refactor. objectui#5248 closed the one asymmetry that existed\n'
+        + '(the kanban branch\'s `conditionalFormatting` fallback); re-opening one needs a ruling,\n'
+        + 'not an edit to this expectation.',
+    ).toEqual([]);
+  });
+
+  it('`conditionalFormatting` in particular is no longer read outside the fence (objectui#5248)', () => {
+    // Named separately from the property above: the property would also pass if
+    // the whole file stopped using the cast form, and this key is the one the
+    // ruling is about. Its read inside the fence is asserted by the tests above
+    // and by the delegation test at the bottom of this file — the key stays
+    // host surface, it just stopped being author-reachable.
+    expect(castReadsIn(SOURCE.replace(regionSlice(), ''))).not.toContain('conditionalFormatting');
+    expect(castReadsIn(regionSlice())).toContain('conditionalFormatting');
   });
 });
 


### PR DESCRIPTION
Fixes #5248

**Branch fired: Option 2.** The liveness check that gates the 2026-08-19 ruling came back **empty** — no authored document in either repo puts `conditionalFormatting` on an `object-view` node — so the `(schema as any).conditionalFormatting` fallback in `generateViewSchema`'s kanban branch is dropped rather than the key declared. The `object-view` node's 27 host-composition keys (objectui#5097) are now read **only** inside the `#region` fence, so that exemption's stated basis — "reachable only via the host-supplied `renderListView` delegation" — is true for all 27 without exception. Option 1 (declare the key on `ObjectViewSchema` + registry `inputs`) was pre-ruled for the other outcome and did not fire; Option 3 was explicitly rejected by the ruling and is not implemented.

**Clause-②: `no`.** This branch *narrows* — a key stops being honoured on the author path, restoring `declared = enforced`. It does not widen the accepted set. (Option 1 would have been `yes`; it did not fire.)

## The liveness check — commands and output

The ruling's "(expected)" about an empty result is a prediction, so it was treated as something to falsify. Every zero below is paired with a counter-probe run **through the same method on the same corpus** with a term known to be present.

**objectui — authored corpora (`content/docs`, `skills`, `examples`, `apps`):**

```
$ grep -rn "conditionalFormatting" content/docs skills examples apps | grep -v node_modules
content/docs/plugins/plugin-grid.mdx:73:| `rowHeight`, …, `conditionalFormatting`, … | | The rest of the declared surface. |
skills/objectui/guides/schema-expressions.md:283:> typed as CEL (`ListViewSchema.conditionalFormatting[].condition` and
skills/objectui/guides/schema-expressions.md:291:  "conditionalFormatting": [
```

Two files, and neither is the case that fires the fallback: the first documents `object-grid`'s **declared** key, the second authors it on a `list-view` node (`{ "type": "list-view", "objectName": "invoice", "conditionalFormatting": [...] }`) — also declared. Zero top-level occurrences on an `object-view` node.

Controls, same method, same corpora: `object-view` → 5 files (docs 3, examples 1, apps 1); `groupByField` → 1 file. Non-zero, so the probe reaches these trees.

**objectui — remaining dirs (`e2e`, `scripts`, `public`, `docs`):** one hit, `docs/audits/2026-07-objectview-detailview-schema.md:92`, prose listing the forwarded keys. Control `objectName` in the same dirs → 13 files.

**objectstack (the sibling repo where the real metadata apps live):**

```
$ grep -rn "conditionalFormatting" content/docs skills examples | grep -v node_modules
content/docs/references/ui/view.mdx:520 / :609      (declared surface tables)
content/docs/references/ui/component.mdx:287 / :329 (declared surface tables)
examples/app-showcase/src/ui/views/field-zoo.view.ts:61: conditionalFormatting: [
```

The one real authored use, `field-zoo.view.ts:61`, sits inside `defineView({ list: { type: 'grid', … } })` — a **view-level** rule on a grid view. That is the `activeView?.conditionalFormatting` link, which this PR keeps.

More decisively, an `object-view` node is not authored in objectstack at all:

```
$ grep -rl "object-view" --include='*.ts' --include='*.tsx' --include='*.json' --include='*.yml' \
    --include='*.md' --include='*.mdx' . | grep -v node_modules | grep -v /dist/ | grep -v CHANGELOG
./packages/spec/liveness/view.json      (prose in a ledger note)
./docs/adr/0080-ai-authored-ui-jsx-source.md   (prose)
```

Controls in that same corpus: `object-form` → 54 files, `object-grid` → 19 files. So the zero is a reading, not an artefact of the method.

**Structural cross-check** — every file in either repo containing *both* an `object-view` mention and `conditionalFormatting`: `packages/types/src/objectql.ts` and `.../zod/objectql.zod.ts` (declarations), `plugin-view/src/ObjectView.tsx` + its pin test (the code under change), `app-shell/src/views/ObjectView.tsx`, `ROADMAP.md` and one audit doc (prose), plus objectstack's `packages/spec/liveness/view.json`. The app-shell one is the host: it builds its `object-view` node at `ObjectView.tsx:2154` **without** the key, and reads `conditionalFormatting` at `:1962` into the delegated `list-view` node inside its `renderListView` callback. Nothing authored relies on the top-level read.

Supporting facts re-measured on this base: `conditionalFormatting` is not a member of `ObjectViewSchema` (0 hits inside the interface in `packages/types/src/objectql.ts`), and it is not among the 15 names in the `object-view` registry `inputs` (`packages/plugin-view/src/index.tsx`).

## What changed

- `packages/plugin-view/src/ObjectView.tsx` — the kanban branch's chain loses its third link. It is now `kanbanCfg.conditionalFormatting ?? activeView?.conditionalFormatting`; the comment records the ruling, the liveness evidence and why the fallback must not come back.
- Same file — the `OBJECT_VIEW_HOST_COMPOSITION_KEYS` block's "The one asymmetry" section is rewritten as "RESOLVED (objectui#5248)", carrying the liveness evidence, and the `#region` banner is updated to match.
- `packages/plugin-view/src/__tests__/objectViewHostSurface.test.tsx` — the pin that read `.toEqual(['conditionalFormatting'])` now asserts `.toEqual([])`: **zero** exempt keys read outside the fence. A second, named test pins the same fact for this key specifically, plus its continued read *inside* the fence.
- `packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx` — new; 7 tests.
- Changeset: `@object-ui/plugin-view` `minor` (behaviour change, described as one; never `major` per the repo's version-alignment rule).

**Not narrowed:** the host `renderListView` delegation still reads the key off the `object-view` node and forwards it to the host's list renderer. It stays host-composition surface; a stored app-shell document that carries it keeps rendering. That half is asserted in the new test file so the two cannot drift apart.

## Tests — measured at `6325ef257`

```
$ pnpm exec vitest run packages/plugin-view/                       # repo root, CI's config
  Test Files  17 passed (17)
       Tests  180 passed (180)
$ pnpm exec turbo run type-check --filter=@object-ui/plugin-view --concurrency=2
  Tasks:    16 successful, 16 total
$ pnpm exec eslint [the 3 changed source files]   # 0 errors, 65 pre-existing-style warnings
$ pnpm run check:control-bytes                    # OK (4726 tracked text files)
$ node scripts/check-changeset-presence.mjs       # OK, 1 changeset
$ node scripts/check-changeset-no-major.mjs       # OK
```

New behaviour pinned (all 7 green): a top-level rule does **not** reach the emitted `object-kanban` node (no own property, `undefined`); the view-level rule still does; the nested `options.kanban` rule still does and still wins; a top-level key neither displaces the declared links nor fills in for a view that declares none; a control that `groupBy`/`groupField`/`titleField`/`cardFields` still flow (without it, "emits nothing" would pass too); and the host `renderListView` delegation still receives the top-level key on a `list-view` node.

## Reverse verification — predicted before running, then observed

Legs: restore `ObjectView.tsx` to `origin/main`, keep both test files; then restore to the commit.

**Build artifact between the edit and the thing under test: none, on either leg.** The repo-root vitest config aliases every `@object-ui/*` specifier straight at `packages/*/src` (`vitest.config.mts` lines 244-285, including `@object-ui/core`, `@object-ui/types`, `@object-ui/react`), no package in this worktree has a `dist/` at test time, and the edited file lives in the package under test and is imported relatively. The pin test additionally reads `ObjectView.tsx` from disk at import. So no rebuild is owed on either leg — and the red leg landing exactly where predicted is itself the proof that the mutation reached the tests rather than a stale artefact.

Predicted red (4): the new file's "a TOP-LEVEL rule … does not reach the kanban node" and "a top-level key does not fill in for a view that declares none"; the pin's "NO exempt key is read outside the fence" and "`conditionalFormatting` in particular is no longer read outside the fence". Predicted green: the other 13.

Observed — identical, no surprises:

```
 × a TOP-LEVEL rule on the object-view node does not reach the kanban node
 × a top-level key does not fill in for a view that declares none
 × NO exempt key is read outside the fence — the objectui#5248 resolution
 × `conditionalFormatting` in particular is no longer read outside the fence (objectui#5248)
 Test Files  2 failed (2)
      Tests  4 failed | 13 passed (17)
```

Restoration leg (source back at the commit, tests untouched): `Test Files 2 passed (2) / Tests 17 passed (17)`.

---

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_