### PR TITLE
fix(scripts): doc-snippet gate collects .md under content/docs, and states its scan surface

### DIFF
--- a/content/docs/guide/console-architecture.md
+++ b/content/docs/guide/console-architecture.md
@@ -129,6 +129,8 @@ Navigation items can be conditionally hidden using expressions:
 Actions are typed with `ActionDef` from `@object-ui/core`:
 
 ```ts
+import { useActionRunner } from '@object-ui/react';
+
 const { execute } = useActionRunner({
   context: { objectName: 'contacts' },
 });
@@ -182,6 +184,7 @@ items exist only in `AppSidebar`, which the console no longer mounts (`ConsoleLa
 
 Per-app branding is applied via `AppShell`'s `branding` prop:
 
+<!-- doc-snippet: fragment — a bare JSX opening tag: the section is about the shape of the branding prop, and the element is never closed -->
 ```tsx
 <AppShell branding={{
   primaryColor: '#3B82F6',

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -11,7 +11,7 @@ This keeps the renderer backend-agnostic: ObjectStack, REST, GraphQL, and propri
 The canonical interface lives in `@object-ui/types`:
 
 ```typescript
-import type { QueryParams, QueryResult } from '@object-ui/types';
+import type { BatchTransactionOperation, QueryParams, QueryResult } from '@object-ui/types';
 
 export interface DataSource<T = unknown> {
   find(resource: string, params?: QueryParams): Promise<QueryResult<T>>;
@@ -82,10 +82,13 @@ import '@object-ui/components';
 import '@object-ui/fields';
 import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+import type { BaseSchema } from '@object-ui/types';
 
 const dataSource = createObjectStackAdapter({
   baseUrl: 'https://api.example.com'
 });
+
+const mySchema: BaseSchema = { type: 'table', objectName: 'users' };
 
 function App() {
   return (
@@ -159,6 +162,7 @@ class UserDataSource implements DataSource<User> {
 
 ObjectUI uses OData-style query keys for broad compatibility:
 
+<!-- doc-snippet: fragment — continues the adapter block above: dataSource is the adapter created there, and repeating its construction here would bury the query keys this section is about -->
 ```typescript
 await dataSource.find('users', {
   $select: ['id', 'name', 'email'],

--- a/content/docs/guide/fields.md
+++ b/content/docs/guide/fields.md
@@ -33,7 +33,7 @@ const MyRatingField = ({ value, onChange }: CellRendererProps) => {
       {[1, 2, 3, 4, 5].map(star => (
         <span 
           key={star} 
-          onClick={() => onChange(star)}
+          onClick={() => onChange?.(star)}
           style={{ color: star <= value ? 'gold' : 'grey' }}
         >
           ★
@@ -91,7 +91,7 @@ If you are building your own custom component (like a Kanban board card), you ca
 ```tsx
 import { getCellRenderer } from '@object-ui/fields';
 
-export const KanbanCard = ({ task }) => {
+export const KanbanCard = ({ task }: { task: { name: string; assignee: string } }) => {
   // Get the standard renderer for a 'user' type field
   const UserRenderer = getCellRenderer('user');
   
@@ -101,7 +101,7 @@ export const KanbanCard = ({ task }) => {
       <div className="assignee">
         <UserRenderer 
           value={task.assignee} 
-          field={{ type: 'user' }} 
+          field={{ type: 'user', name: 'assignee' }} 
         />
       </div>
     </div>

--- a/content/docs/guide/metadata-diagnostics.md
+++ b/content/docs/guide/metadata-diagnostics.md
@@ -62,6 +62,8 @@ GET /api/v1/meta/diagnostics?severity=error
 Response:
 
 ```ts
+import type { MetadataDiagnostics } from '@object-ui/data-objectstack';
+
 interface MetadataDiagnosticsSummary {
   entries: Array<{
     type: string;
@@ -196,7 +198,7 @@ A few high-leverage patterns:
 ```ts
 import { MetadataClient } from '@object-ui/data-objectstack';
 
-const client = new MetadataClient(/* config */);
+const client = new MetadataClient({ baseUrl: 'https://api.example.com' });
 const summary = await client.diagnostics({ severity: 'error' });
 console.log(summary.total, 'invalid item(s)');
 ```

--- a/content/docs/guide/quick-start.md
+++ b/content/docs/guide/quick-start.md
@@ -40,6 +40,7 @@ pnpm add -D tailwindcss @tailwindcss/vite
 
 Add Tailwind to your `vite.config.ts`:
 
+<!-- doc-snippet: fragment — a vite.config.ts for the reader's own project: @vitejs/plugin-react and @tailwindcss/vite are the reader's dependencies, not this repository's, so the imports cannot resolve here -->
 ```ts
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';

--- a/content/docs/guide/react-pages.md
+++ b/content/docs/guide/react-pages.md
@@ -177,6 +177,7 @@ only way the new adapter reaches the blocks inside the page. So a host that
 constructs a new adapter on every render resets every react page on every
 render. Provide it from state or a module constant:
 
+<!-- doc-snippet: fragment — a bad/good contrast of two bare JSX opening tags: neither half is a closed element, and showing them closed would hide the difference the section is about -->
 ```tsx
 // ❌ new adapter object every render — every react page below loses its state
 <AdapterCtx.Provider value={new ObjectStackAdapter(config)}>

--- a/content/docs/guide/schema-playground.md
+++ b/content/docs/guide/schema-playground.md
@@ -26,12 +26,11 @@ Add the playground to any React project with ObjectUI installed:
 ```tsx
 import { useState } from 'react';
 import { SchemaRenderer } from '@object-ui/react';
-import { registerDefaultRenderers } from '@object-ui/components';
-import { registerAllFields } from '@object-ui/fields';
-import { Registry } from '@object-ui/core';
+import { initializeComponents } from '@object-ui/components';
+// Side-effect import: loading the package runs its own field registration.
+import '@object-ui/fields';
 
-registerDefaultRenderers();
-registerAllFields(Registry);
+initializeComponents();
 
 function SchemaPlayground() {
   const [schema, setSchema] = useState('{\n  "type": "button",\n  "label": "Click me"\n}');

--- a/content/docs/guide/slotted-pages.md
+++ b/content/docs/guide/slotted-pages.md
@@ -147,6 +147,7 @@ same rules as `action:bar`:
   regardless of how few actions exist (the synthesized Share / Delete
   use this).
 
+<!-- doc-snippet: fragment — a metadata excerpt: the bare slots: key is one fragment of a page schema, shown without the document that would contain it -->
 ```ts
 slots: {
   header: {

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -155,13 +155,31 @@
  *               types, unbuilt tree) turns every document red at once and reads
  *               as "the docs are full of defects".
  *
- * ## Coverage is declared, never assumed
+ * ## Coverage is declared, never assumed — and the scan surface is stated here
  *
  * A document is covered unless it is named in `UNGATED_DOCS` with a reason. The
  * default is therefore COVERED: a new page is compiled from the day it lands,
  * and opting one out is an edit a reviewer can see. Entries are re-derived every
  * run — an entry naming a file that does not exist, or that holds no `ts` / `tsx`
  * block at all, fails as a stale entry, so the list can only shrink.
+ *
+ * That rule is only true of documents the walk actually reaches, so the SCAN
+ * SURFACE is stated in the same breath as the coverage rule rather than left to
+ * be read off the collector:
+ *
+ *     every `.mdx` and `.md` page under `content/docs`, plus every
+ *     `packages/<name>/README.md`.
+ *
+ * Stating it here is objectui#5174's finding, and the finding was not the missing
+ * extension — it was that a reader had to open `listDocuments` to learn that
+ * "covered by default" meant "covered if the filename ends in `.mdx`". The
+ * collector admitted 143 `.mdx` under `content/docs` and silently excluded 40
+ * `.md` guides — the getting-started pages a reader copies from most. None of
+ * them was in the ledger, so they were neither covered NOR declared ungated:
+ * they were invisible to this gate's own accounting, and the summary line below
+ * could not mention them. That is precisely the silent skip the fragment rule
+ * exists to prevent, arriving one level up, at the document instead of the block.
+ * Anything added to the scan surface later belongs in that list, on the same day.
  *
  * ⚠️ The honest limit, stated because a reader of a green run needs it: an
  * ungated document is NOT compiled and NOT counted. Its snippets are unverified,
@@ -187,8 +205,18 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 /** Documentation surfaces read by this gate. Kept identical in spirit to
  *  `check-doc-links.mjs`: the pages a reader lands on, plus every published
  *  package README (which ships to npm inside the package's `files`). */
-const MDX_ROOT = 'content/docs';
+const DOCS_ROOT = 'content/docs';
 const PACKAGES_DIR = 'packages';
+
+/** Page extensions collected under `DOCS_ROOT`. BOTH are collected, and that is
+ *  the whole content of the scan surface: `content/docs` is authored in a mix of
+ *  `.mdx` and `.md` — the same guide tree, the same renderer, the same reader —
+ *  and an extension is not a coverage decision. Collecting only `.mdx` is how
+ *  objectui#5174 happened: 40 `.md` guides sat outside the ledger, so they were
+ *  neither covered nor declared ungated, which is precisely the silent skip the
+ *  fragment rule below exists to prevent. Anything else under the tree (`.json`
+ *  sidecars) holds no prose and is not a page. */
+const DOC_EXTENSIONS = ['.mdx', '.md'];
 
 /** Fence languages treated as compilable TypeScript. `js` / `jsx` are NOT in the
  *  set: they are not type-annotated, so a strict program judges them on rules
@@ -198,6 +226,14 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
 /**
  * Documents whose snippets are NOT compiled, each with the reason. The default
  * is covered; this list is the debt, by name, and it can only shrink.
+ *
+ * ⚠️ 20 of these entries are `.md` pages under `content/docs` that objectui#5174
+ * made visible: the collector now reads `.md`, and an entry with a measured reason
+ * is what a page that cannot pass yet is owed. They are DISCLOSED debt, not new
+ * debt — every one of them was equally unverified before, just unnamed. Their
+ * reasons carry the same measured diagnostic mix as the rest, and several name
+ * the missing export by hand, because a documented symbol a package does not
+ * export is the reader-visible half (objectui#5160).
  *
  * The reasons are deliberately concrete about WHAT would have to change, because
  * "does not compile" is three different jobs: a page whose snippets reference
@@ -210,6 +246,53 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * @type {Record<string, string>}
  */
 const UNGATED_DOCS = {
+  'content/docs/api/schema-reference.md':
+    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; plus TS2305x1 TS2724x1 — candidate real defects, un-triaged. The ' +
+    'missing-export diagnostics name `DashboardSchema` (@object-ui/types), `PageSchema` ' +
+    '(@object-ui/types) — the reader-visible half of this entry',
+  'content/docs/guide/architecture-overview.md':
+    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 5 ' +
+    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS2686x1 — candidate real ' +
+    'defects, un-triaged',
+  'content/docs/guide/architecture.md':
+    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '13 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 3 unresolved-module diagnostic(s); plus TS2322x1 — candidate real ' +
+    'defects, un-triaged',
+  'content/docs/guide/building-crud-app.md':
+    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '20 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 4 unresolved-module diagnostic(s); plus TS2305x2 TS2339x1 TS2345x1 ' +
+    'TS2554x1 TS2724x1 TS2882x1 — candidate real defects, un-triaged. The missing-export ' +
+    'diagnostics name `Field` (@object-ui/types), `ObjectSchema` (@object-ui/types), ' +
+    '`registerAllComponents` (@object-ui/components) — the reader-visible half of this entry',
+  'content/docs/guide/component-registry.md':
+    '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '51 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 6 unresolved-module diagnostic(s); plus TS2305x13 TS2339x1 — candidate ' +
+    'real defects, un-triaged. The missing-export diagnostics name `getComponentRegistry` ' +
+    '(@object-ui/react) x5, `registerDefaultRenderers` (@object-ui/components) x4, `BaseSchema` ' +
+    '(@object-ui/core) x3, `InputRenderer` (@object-ui/components) — the reader-visible half of ' +
+    'this entry',
+  'content/docs/guide/deployment.md':
+    '6 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 — candidate real ' +
+    'defects, un-triaged',
+  'content/docs/guide/expressions.md':
+    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 6 ' +
+    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; plus TS2724x1 TS7006x3 — candidate real defects, un-triaged. The ' +
+    'missing-export diagnostics name `getExpressionEvaluator` (@object-ui/core) — the ' +
+    'reader-visible half of this entry',
+  'content/docs/guide/layout.md':
+    '21 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '20 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 4 unresolved-module diagnostic(s)',
+  'content/docs/guide/notifications.md':
+    '9 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s)',
   'content/docs/guide/objectos-integration.mdx':
     '36 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -221,6 +304,52 @@ const UNGATED_DOCS = {
     'this page still needs the 8 parse-failing blocks re-fenced or declared, the undefined-name ' +
     'blocks made self-contained, and the `@objectstack/*` runtime imports resolvable — none of ' +
     'which this repo can do from here.',
+  'content/docs/guide/plugin-development.md':
+    '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 6 unresolved-module diagnostic(s); plus TS2339x5 TS2882x1 TS7006x3 — ' +
+    'candidate real defects, un-triaged',
+  'content/docs/guide/plugins.md':
+    '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 6 unresolved-module diagnostic(s); plus TS2882x1 TS7006x3 — candidate ' +
+    'real defects, un-triaged',
+  'content/docs/guide/public-forms.md':
+    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 8 ' +
+    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s)',
+  'content/docs/guide/schema-overview.md':
+    '9 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 2 ' +
+    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; plus TS2305x2 TS2724x6 — candidate real defects, un-triaged. The ' +
+    'missing-export diagnostics name `AppSchema` (@object-ui/types) x2, `ThemeSchema` ' +
+    '(@object-ui/types) x2, `AppSchema` (@object-ui/types/zod), `ReportSchema` ' +
+    '(@object-ui/types), `ReportSchema` (@object-ui/types/zod), `ThemeSchema` ' +
+    '(@object-ui/types/zod) — the reader-visible half of this entry',
+  'content/docs/guide/schema-rendering.md':
+    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS2305x4 TS2322x1 TS2451x2 ' +
+    'TS7006x5 — candidate real defects, un-triaged. The missing-export diagnostics name ' +
+    '`FormSchema` (@object-ui/core), `getComponentRegistry` (@object-ui/react), `PageSchema` ' +
+    '(@object-ui/core), `registerDefaultRenderers` (@object-ui/components) — the reader-visible ' +
+    'half of this entry',
+  'content/docs/guide/theming.md':
+    '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '23 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS2339x1 TS2353x1 — candidate ' +
+    'real defects, un-triaged',
+  'content/docs/guide/troubleshooting.md':
+    '8 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 TS2339x2 TS2559x1 ' +
+    'TS2724x1 — candidate real defects, un-triaged. The missing-export diagnostics name ' +
+    '`componentSchema` (@object-ui/types/zod) — the reader-visible half of this entry',
+  'content/docs/guide/user-state-persistence.md':
+    '10 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; plus TS2353x2 TS7031x1 — candidate real defects, un-triaged',
+  'content/docs/plugins/index.md':
+    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS7006x1 — candidate real ' +
+    'defects, un-triaged',
   'content/docs/plugins/plugin-calendar-view.mdx':
     '2 unresolved-module diagnostic(s) — and NOT a defect: the page is a migration guide whose ' +
     '"Before" blocks quote the retired `@object-ui/plugin-calendar-view` import on purpose. Covering ' +
@@ -240,10 +369,19 @@ const UNGATED_DOCS = {
     '43 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'content/docs/plugins/plugin-timeline.mdx':
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
+  'content/docs/rfcs/0001-clipboard-paste.md':
+    '7 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
+    '11 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; plus TS18004x1 TS2391x3 TS7006x1 — candidate real defects, un-triaged',
   'content/docs/utilities/create-plugin.mdx':
     '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
   'content/docs/utilities/data-objectstack.mdx':
     '16 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2391x1 — candidate real defects, un-triaged',
+  'content/docs/utilities/index.md':
+    '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; plus TS2724x1 — candidate real defects, un-triaged. The missing-export ' +
+    'diagnostics name `ObjectStackProvider` (@object-ui/data-objectstack) — the reader-visible ' +
+    'half of this entry',
   'content/docs/utilities/runner.mdx':
     '5 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 3 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 3 unresolved-module diagnostic(s)',
   'packages/app-shell/README.md':
@@ -390,11 +528,12 @@ export function listDocuments(root = repoRoot) {
     for (const entry of readdirSync(dir).sort()) {
       const p = join(dir, entry);
       if (statSync(p).isDirectory()) walk(p);
-      else if (entry.endsWith('.mdx')) out.push(relative(root, p).split(sep).join('/'));
+      else if (DOC_EXTENSIONS.some((ext) => entry.endsWith(ext)))
+        out.push(relative(root, p).split(sep).join('/'));
     }
   };
-  const mdxRoot = join(root, MDX_ROOT);
-  if (existsSync(mdxRoot)) walk(mdxRoot);
+  const docsRoot = join(root, DOCS_ROOT);
+  if (existsSync(docsRoot)) walk(docsRoot);
   const pkgDir = join(root, PACKAGES_DIR);
   if (existsSync(pkgDir)) {
     for (const entry of readdirSync(pkgDir).sort()) {


### PR DESCRIPTION
Part of #5174

`scripts/check-doc-snippet-types.mjs` states its coverage rule in its own docblock — *a document is covered unless it is named in `UNGATED_DOCS` with a reason* — and carries a fragment rule that exists so a snippet is never silently skipped. The collector then picked documents by extension, admitting 143 `.mdx` under `content/docs` and excluding 40 `.md`. None of the 40 was in the ledger, so they were neither covered **nor** declared ungated: invisible to the gate's own accounting, and unmentionable by the summary line it prints.

Both numbers were re-measured on today's `main` before planning: still 143 `.mdx` and 40 `.md`.

This lands the collector change, the docblock half, a complete and measured ledger for everything newly collected, and outright fixes for the eight guides that were cheap and genuinely broken. It is deliberately partial — `Part of`, not `Fixes`. What is left is named below.

## Before / after

Both columns are real runs of the gate against the built `dist`, at the same tree state, with the `origin/main` script used verbatim for the "before" column.

| | before | after | delta |
|---|---|---|---|
| documents scanned | 182 | 222 | +40 |
| **covered** | **138** | **158** | **+20** |
| covered docs holding a ts/tsx block | 13 | 21 | +8 |
| ungated ledger entries | 44 | 64 | +20 |
| blocks compiled | 68 | 87 | +19 |
| declared fragments | 5 | 10 | +5 |
| syntax failures | 0 | 0 | — |
| semantic failures | 0 | 0 | — |

The three constraints this change had to hold, each checked mechanically rather than asserted:

1. **The covered set strictly grows** — 138 to 158.
2. **No previously covered document became ungated.** The ledger key sets were diffed programmatically: `REMOVED entries: []`, and all 20 added keys are newly collected `.md` under `content/docs`. The 44 pre-existing entries are byte-identical — the only deletions in the script's diff are the five lines listed under "What changed" below, none of them inside the ledger. (Rebased on current `main` first, so PR5332's rewrite of the `objectos-integration.mdx` entry and PR5320's reason-string edit are both carried through untouched.)
3. **Nothing about the gate's strictness moved.** No threshold, no diagnostic class, no `FRAGMENT_MARKER` semantics. The regex, `MIN_REASON_LENGTH`, `TS_FENCE_LANGUAGES`, the two-phase split and all three controls are unchanged.

## Where the 40 newly collected documents went

| outcome | count |
|---|---|
| hold no ts/tsx block at all — covered, nothing to judge | 12 |
| **fixed in this PR, now compiling** | **8** |
| ledgered with a measured reason | 20 |

Zero of the 40 passed as collected: every one of the 28 that holds a ts/tsx block failed on first collection. That is the finding, not an accident of this PR.

### The eight fixed

Three are prose fragments, declared with the HTML-comment marker the script already spells out for `.md` (keyword `doc-snippet: fragment`, plus a written reason). Declaring is the gate's own designed mechanism, not a relaxation:

- `guide/quick-start.md` — a `vite.config.ts` for the reader's project; `@vitejs/plugin-react` and `@tailwindcss/vite` are the reader's dependencies, not this repo's.
- `guide/react-pages.md` — a bad/good contrast of two bare JSX opening tags; closing them would erase the difference the section is about.
- `guide/slotted-pages.md` — a bare `slots:` metadata excerpt.

Five carried real defects — documented symbols that do not exist, or literals that do not type-check:

- `guide/schema-playground.md` — `registerDefaultRenderers` is not exported by `@object-ui/components`, and `registerAllFields` takes no arguments. Replaced with the repo's own one registration path: `initializeComponents()` plus the side-effect `@object-ui/fields` import, matching `apps/site/app/components/ObjectUIProvider.tsx`.
- `guide/fields.md` — `onChange` is optional on `CellRendererProps` and was invoked unguarded; a `KanbanCard` prop was untyped; a `field` literal omitted the `name` that `UserFieldMetadata` requires.
- `guide/metadata-diagnostics.md` — `new MetadataClient(...)` was written with its only required argument elided, so the documented line does not compile; and an interface excerpt named `MetadataDiagnostics` without importing it.
- `guide/data-source.md` — an interface excerpt named `BatchTransactionOperation` without importing it, and the injection example rendered a `mySchema` it never defined. One block (the OData query keys) genuinely continues the block above it and is declared as such.
- `guide/console-architecture.md` — `useActionRunner` used with no import (it comes from `@object-ui/react`); the `AppShell branding` block is a bare opening tag and is declared.

### The twenty ledgered

Every entry carries a measured diagnostic mix in the same shape the existing entries use — parse / undefined-name / unresolved-module counts, then the remaining codes as `TSxxxxxN` candidate real defects. No entry says "not triaged yet" and none is a bare filename.

Where the mix included a missing-export diagnostic, the entry **names the symbol**, because that is the reader-visible half (the objectui#5160 class). What that surfaced, aggregated:

| missing symbol | module | occurrences |
|---|---|---|
| `getComponentRegistry` | `@object-ui/react` | 6 |
| `registerDefaultRenderers` | `@object-ui/components` | 5 |
| `AppSchema` / `ThemeSchema` / `ReportSchema` | `@object-ui/types` and `/zod` | 9 |
| `BaseSchema` | `@object-ui/core` | 3 |
| `PageSchema` / `FormSchema` | `@object-ui/core`, `@object-ui/types` | 3 |
| `registerAllComponents` | `@object-ui/components` | 1 |
| `getExpressionEvaluator` | `@object-ui/core` | 1 |
| `ObjectStackProvider` | `@object-ui/data-objectstack` | 1 |
| `ObjectSchema` / `Field` | `@object-ui/types` | 2 |
| `InputRenderer` | `@object-ui/components` | 1 |
| `componentSchema` | `@object-ui/types/zod` | 1 |
| `DashboardSchema` | `@object-ui/types` | 1 |

These are getting-started guides. A reader copying from them today gets code that does not compile. None of it is *caused* by this PR — all of it was equally broken before and simply unnamed, which is the whole point of the card. Working those entries down is per-page documentation work, not a mechanical edit, and it is why #5174 stays open.

## CI cost — this needs a decision under the objectui#4846 ruling

`--build-filter` output **did change**, and the closure grows more than the filter list suggests:

| | filters | turbo build tasks (filters + their dependencies) |
|---|---|---|
| before | 11 | 21 |
| after | 15 | **33** |
| full workspace, for scale | — | 46 |

The four packages added to the filter are `@object-ui/app-shell`, `@object-ui/components`, `@object-ui/fields`, `@object-ui/plugin-detail`. Almost all of the growth is one of them: **`@object-ui/app-shell` is pulled in by exactly one document**, `guide/metadata-diagnostics.md`, and it drags the plugin fan-out with it. Measured: dropping `app-shell` from the filter takes the closure from **33 back to 22** tasks — one more than before.

So the trade is explicit and reversible in one line: covering `guide/metadata-diagnostics.md` costs ~11 extra build tasks per run of this gate. It is fixed and passing here because it was genuinely broken and cheap to fix; if the reviewer would rather not pay that, moving it to the ledger with its measured reason is the one-line alternative and the other seven fixes are unaffected. Flagging rather than deciding, since #4846 makes this a per-PR call.

## Verification

Run from the repo root, at `76a09baef`, against a build of the gate's own filter closure:

- `node scripts/check-doc-snippet-types.mjs` — green. Controls all pass: resolution lands on `packages/types/dist/index.d.ts`, the planted sentinel produces its TS2305, the positive control is clean, no package `src/` leaked into the program.
  ```
  Scanned 222 document(s): 158 covered (21 of them hold a ts/tsx block), 64 ungated
  Covered blocks: 97 — 87 to compile, 10 declared fragment(s).
  Syntax phase:   every block parsed, so every one of them reached the semantic phase.
  Semantic phase: 87 of 87 block(s) judged, 0 failed.
  ```
- `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts` — **20 passed (20)**. Running the script is not running its test; both were run.
- `node scripts/check-doc-component-types.mjs`, `node scripts/check-doc-links.mjs`, `node scripts/check-control-bytes.mjs`, `pnpm run type-check:scripts`, `eslint` on both touched script files — all green.
- `node scripts/check-changeset-presence.mjs` — *"No source of a released package changed in this range, so no changeset is owed."* No changeset added.
- Prettier reports style issues on all nine touched files, and reports the same issues on their `origin/main` versions; no workflow runs `prettier --check`. Left alone rather than mixed in as reformatting churn.

### The markers render as nothing

The three `.md` fragment markers are HTML comments, which the script documents as the `.md` spelling. Verified rather than assumed: fumadocs-mdx 15.2.3 selects the compiler format with `filePath.endsWith(".mdx") ? "mdx" : "md"`, and every edited `.md` file was compiled through `@mdx-js/mdx` in `format: 'md'` — all compile, and the marker text does not appear in the output.

### Reverse-verification of the collector change

Prediction, written before the run: restoring the `.mdx`-only filter drops the 20 newly ledgered `.md` documents out of the scan set, so `analyze` re-derives the ledger against a narrower set and emits a `stale-ungated-entry` finding for each; the test `is green, and the ledger is exact` fails with 20 such findings; the other 19 tests still pass, since 182 documents still clears the plausibility floor and 68 blocks still clears the "has snippets to judge" floor.

Observed: `Tests  1 failed | 19 passed (20)`, the single failure being `is green, and the ledger is exact`, with exactly 20 `stale-ungated-entry` findings in the diff. Predicted and observed match, including the direction — this leg goes red by producing *more* findings, not fewer.

**Build artifact between the edit and the thing under test: none, on either leg.** The suite imports `../check-doc-snippet-types.mjs` directly as source and the gate runs that file directly, so no `dist` sits between the mutation and the verdict and nothing needed rebuilding for either leg. (A build artifact does sit between the *packages* and the gate's verdict — that is the point of the gate — but it is not on the path from this edit to this test.) The restore leg was run and is green: `Tests  20 passed (20)`, with `git status` clean against the commit, so the tree is byte-identical to what is pushed.

## What changed

- `scripts/check-doc-snippet-types.mjs`
  - `MDX_ROOT` becomes `DOCS_ROOT`, and a new `DOC_EXTENSIONS` names both page extensions with the reason they are both collected. The walk tests that list instead of one hard-coded suffix. Five lines removed in total, all of them these.
  - The docblock section that states the coverage rule now states the scan surface in the same breath, with the history of why.
  - 20 ledger entries added, sorted into place; a note above the ledger records that they are disclosed debt rather than new debt.
- `content/docs/guide/{quick-start,react-pages,slotted-pages,schema-playground,fields,metadata-diagnostics,data-source,console-architecture}.md` — the eight fixes above.

No changes to `packages/**`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_