### PR TITLE
refactor(layout,app-shell,i18n): retire the unreachable id-keyed nav label resolvers

### DIFF
--- a/.changeset/retire-nav-label-resolvers-5197.md
+++ b/.changeset/retire-nav-label-resolvers-5197.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/layout': minor
+'@object-ui/app-shell': minor
+'@object-ui/i18n': minor
+---
+
+**Breaking (published API):** `NavigationRenderer` no longer accepts `resolveGroupLabel` or `resolveItemLabel`. If your build just broke on one of these props, delete the prop — it never did anything.
+
+Both were id-keyed label resolvers on `NavigationRendererProps` (`@object-ui/layout`), typically wired to `useObjectLabel().navGroupLabel` from `@object-ui/i18n` to translate sidebar group and leaf labels from a client translation pack keyed `{ns}.apps.{appName}.navigation.{nodeId}.label`.
+
+**They could never fire.** The renderer guards convention-based resolution with `isCustomized` — a case-insensitive "the authored label differs from this branch's comparison target" test. On the `object` / `dashboard` branches the target is the object or dashboard name, and the test is meaningful: it protects an author's custom label (`Projects`) from being overwritten by an `objects.project.label` translation. On the two id-keyed branches the target was the nav node's own **`id`** — `grp_workspace`, `group_sales` — while the label was its text — `Workspace`, `Sales`. Those never compare equal, so the guard was true for every real navigation entry and the resolver beneath it was unreachable. The only node that could have reached it is one whose label is literally its own id.
+
+Nothing regresses when they go, because nothing was using them to begin with: **app-navigation localization is owned solely by the server-side `/meta` boundary.** `translateApp` (`@objectstack/spec`, `src/system/i18n-resolver.ts`) rewrites every navigation node's `label` by id, and `@objectstack/rest` applies it before the metadata reaches the client — so nav labels arrive already localized and the client-side path was never the one answering. One owner, not two.
+
+**If you wired these hooks to localize navigation, your labels were never being localized by them.** Move the translation to the server side: add it to the app's i18n bundle that `translateApp` reads, keyed by navigation node id. A client-side pack keyed `apps.*.navigation.*.label` changes nothing in the sidebar.
+
+Also in this change:
+
+- `useObjectLabel().navGroupLabel` (`@object-ui/i18n`) is **kept**, but its docstring no longer promises `"Sales" → "销售"` for sidebar groups — that promise was false, and a live docstring describing an unreachable path is how an agent or a developer ends up wiring a translation pack and receiving silent non-localization. It is now documented for what it is: a plain reader for `{ns}.apps.{appName}.navigation.{groupId}.label` with no first-party caller, pointing at the server boundary for anything nav-related.
+- `UnifiedSidebar` (`@object-ui/app-shell`) drops the two prop wirings, including a `studio` carve-out that existed only to stop `resolveItemLabel` from re-translating an already-translated "Package management" label.
+- The `object` / `dashboard` / `viewName` branches — `resolveObjectLabel`, `resolveDashboardLabel`, `resolveViewLabel` — are untouched and keep both their resolvers and the `isCustomized` guard.

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -158,7 +158,7 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
   const { isMobile, setOpenMobile } = useSidebar();
   const location = useLocation();
   const { t, language } = useObjectTranslation();
-  const { objectLabel: resolveNavObjectLabel, dashboardLabel: resolveNavDashboardLabel, navGroupLabel: resolveNavGroupLabel, viewLabel: resolveNavViewLabel } = useObjectLabel();
+  const { objectLabel: resolveNavObjectLabel, dashboardLabel: resolveNavDashboardLabel, viewLabel: resolveNavViewLabel } = useObjectLabel();
   const { context, currentAppName } = useNavigationContext();
   const { user, activeOrganization } = useAuth();
   const isWorkspaceAdmin = useIsWorkspaceAdmin();
@@ -548,12 +548,6 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
              onReorder={handleReorder}
              resolveObjectLabel={(objectName, fallback) => resolveNavObjectLabel({ name: objectName, label: fallback })}
              resolveDashboardLabel={(dashboardName, fallback) => resolveNavDashboardLabel({ name: dashboardName, label: fallback })}
-             resolveGroupLabel={activeApp ? (groupId, fallback) => resolveNavGroupLabel(activeApp.name, groupId, fallback) : undefined}
-             resolveItemLabel={activeApp ? (itemId, fallback) => (
-               activeApp.name === 'studio' && fallback === t('sidebar.packageManagement', { defaultValue: 'Package management' })
-                 ? fallback
-                 : resolveNavGroupLabel(activeApp.name, itemId, fallback)
-             ) : undefined}
              resolveViewLabel={(objectName, viewName, fallback) => resolveNavViewLabel(objectName, viewName, fallback)}
              onAction={dispatchNavAction}
              t={t}
@@ -668,10 +662,10 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
                  order. A pinned section would also land directly above this
                  arm's own "Starred" group. Separate product decisions, not part
                  of unflattening a group.
-               - `resolveGroupLabel` / `resolveItemLabel` — keyed on
-                 `activeApp.name`, which does not denote this context. Home
-                 labels are already resolved through `t()` where the items are
-                 constructed. */}
+               (Until objectui#5197 this list also named `resolveGroupLabel` /
+               `resolveItemLabel`. Those props are gone from the renderer
+               entirely — they were unreachable for every real nav entry, and
+               app-nav localization belongs to the server `/meta` boundary.) */}
            <NavigationRenderer
              items={homeNavigation}
              basePath=""

--- a/packages/app-shell/src/layout/__tests__/AppSidebar.derivedAreaVisibility.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/AppSidebar.derivedAreaVisibility.test.tsx
@@ -40,7 +40,6 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
     objectLabel: ({ label }: { label?: string }) => label,
     viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
     dashboardLabel: ({ label }: { label?: string }) => label,
-    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
   }),
 }));
 

--- a/packages/app-shell/src/layout/__tests__/UnifiedSidebar.derivedAreaVisibility.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/UnifiedSidebar.derivedAreaVisibility.test.tsx
@@ -40,7 +40,6 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
     objectLabel: ({ label }: { label?: string }) => label,
     viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
     dashboardLabel: ({ label }: { label?: string }) => label,
-    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
   }),
 }));
 

--- a/packages/app-shell/src/layout/__tests__/appSidebarSettingsTargets.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/appSidebarSettingsTargets.test.tsx
@@ -93,7 +93,6 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
     objectLabel: ({ label }: { label?: string }) => label,
     viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
     dashboardLabel: ({ label }: { label?: string }) => label,
-    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
   }),
 }));
 

--- a/packages/app-shell/src/layout/__tests__/systemNavDatasourcesHop.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/systemNavDatasourcesHop.test.tsx
@@ -71,7 +71,6 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
     objectLabel: ({ label }: { label?: string }) => label,
     viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
     dashboardLabel: ({ label }: { label?: string }) => label,
-    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
   }),
 }));
 

--- a/packages/app-shell/src/layout/__tests__/systemNavObjectsHop.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/systemNavObjectsHop.test.tsx
@@ -87,7 +87,6 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
     objectLabel: ({ label }: { label?: string }) => label,
     viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
     dashboardLabel: ({ label }: { label?: string }) => label,
-    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
   }),
 }));
 

--- a/packages/app-shell/src/layout/__tests__/systemNavSettingsTarget.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/systemNavSettingsTarget.test.tsx
@@ -96,7 +96,6 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
     objectLabel: ({ label }: { label?: string }) => label,
     viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
     dashboardLabel: ({ label }: { label?: string }) => label,
-    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
   }),
 }));
 

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -300,13 +300,27 @@ export function useObjectLabel() {
     },
 
     /**
-     * Resolve translated label for a navigation group within an app.
-     * Convention: `{ns}.apps.{appName}.navigation.{groupId}.label`.
+     * Read `{ns}.apps.{appName}.navigation.{groupId}.label` out of the loaded
+     * CLIENT translation resources, falling back to `fallback`.
      *
-     * Mirrors `objectLabel`/`dashboardLabel` so app metadata can keep
-     * English fallbacks while translation packs supply localised
-     * sidebar group labels (e.g. "Sales" → "销售") without explicit
-     * I18nLabel `{ key, defaultValue }` annotations.
+     * ⚠️ This does NOT localize the sidebar, and adding a translation pack
+     * keyed this way will not change a single rendered nav label.
+     * **App-navigation localization is owned solely by the server-side
+     * `/meta` boundary**: `translateApp` in `@objectstack/spec`
+     * (`src/system/i18n-resolver.ts`) rewrites every navigation node's
+     * `label` by id, and `@objectstack/rest` applies it before the metadata
+     * reaches this client — so nav labels arrive already localized. One
+     * owner, not two. To translate a sidebar group, translate it there.
+     *
+     * History (objectui#5197): until then this docstring promised
+     * `"Sales" → "销售"` for sidebar groups, and `NavigationRenderer`
+     * accepted `resolveGroupLabel`/`resolveItemLabel` to wire it up. Those
+     * props could never fire — the renderer's `isCustomized` guard compared a
+     * node's authored label against its own `id` (`Workspace` vs
+     * `grp_workspace`), which never match, so the guard was true for every
+     * real entry. The props are gone; the promise was false, not merely
+     * unused. This helper is kept as a plain key reader for a consumer that
+     * renders navigation itself — it has no first-party caller.
      */
     navGroupLabel: (appName: string, groupId: string, fallback: string) =>
       resolve(`apps.${appName}.navigation.${groupId}.label`, fallback),

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -197,23 +197,11 @@ export interface NavigationRendererProps {
    */
   resolveViewLabel?: (objectName: string, viewName: string, fallbackLabel: string) => string;
 
-  /**
-   * Optional label resolver for navigation group items.
-   * Called with `(groupId, fallbackLabel)` for items where
-   * `item.type === 'group'` and `item.label` is a plain string.
-   * Enables convention-based i18n via
-   * `{ns}.apps.{appName}.navigation.{groupId}.label`.
-   */
-  resolveGroupLabel?: (groupId: string, fallbackLabel: string) => string;
-
-  /**
-   * Optional label resolver for non-object/non-dashboard/non-group nav
-   * items (url, page, report, custom). Called with `(itemId, fallbackLabel)`
-   * for items that have a plain-string label and a stable `id`.
-   * Convention: `{ns}.apps.{appName}.navigation.{itemId}.label` — same
-   * key shape as `resolveGroupLabel` so a single i18n helper covers both.
-   */
-  resolveItemLabel?: (itemId: string, fallbackLabel: string) => string;
+  // RETIRED (objectui#5197): `resolveGroupLabel` / `resolveItemLabel`, the two
+  // id-keyed label resolvers. They were unreachable by construction — see the
+  // note on `resolveNavItemLabel` below — and app-navigation localization is
+  // owned solely by the server-side `/meta` boundary. Do not re-add them; a
+  // sidebar label that needs translating is translated there.
 
   /**
    * Optional i18n translation function for resolving I18nLabel objects
@@ -287,15 +275,28 @@ export function resolveLabel(
  * 3. Otherwise, the schema-authored explicit label always wins — an app
  *    author who wrote a custom label (e.g. a plural 'Projects') must never
  *    have it silently overridden by an `objects.<name>.label` translation.
+ *
+ * Deliberately NOT here: id-keyed resolution for `group` items and for
+ * url/page/report/custom leaves. Those two hooks existed until objectui#5197
+ * and could never fire: the `isCustomized` guard below compares the authored
+ * label against the branch's comparison target, and on an id-keyed branch
+ * that target is the node's own `id` (`grp_workspace`) while the label is its
+ * text (`Workspace`). Those never compare equal, so the guard was true for
+ * every real entry and the resolver under it was dead code with a live
+ * docstring promising localization.
+ *
+ * App-navigation localization is owned solely by the server-side `/meta`
+ * boundary: `translateApp` in `@objectstack/spec`
+ * (`src/system/i18n-resolver.ts`) rewrites every navigation node's `label` by
+ * id before the metadata reaches this renderer, so `base` is already
+ * localized when it arrives. One owner, not two — localize nav labels there.
  */
 function resolveNavItemLabel(
   item: NavigationItem,
   resolver?: (objectName: string, fallbackLabel: string) => string,
   t?: (key: string, options?: any) => string,
   dashboardResolver?: (dashboardName: string, fallbackLabel: string) => string,
-  groupResolver?: (groupId: string, fallbackLabel: string) => string,
   viewResolver?: (objectName: string, viewName: string, fallbackLabel: string) => string,
-  itemResolver?: (itemId: string, fallbackLabel: string) => string,
 ): string {
   const base = resolveLabel(item.label, t);
   // Only apply convention-based resolution for items with plain string labels.
@@ -325,15 +326,9 @@ function resolveNavItemLabel(
     if (isCustomized((item as any).dashboardName)) return base;
     if (dashboardResolver) return dashboardResolver((item as any).dashboardName, base);
   }
-  if (item.type === 'group' && item.id) {
-    if (isCustomized(item.id)) return base;
-    if (groupResolver) return groupResolver(item.id, base);
-  }
-  // Fallback for non-object/non-dashboard/non-group items (url, page, report,
-  // custom) with a stable id — translate via the per-app navigation namespace.
-  if (itemResolver && item.id && !isCustomized(item.id)) {
-    return itemResolver(item.id, base);
-  }
+  // `group` items and non-object/non-dashboard leaves (url, page, report,
+  // custom) return the authored label untouched — their localization already
+  // happened at the server `/meta` boundary (see the note above).
   return base;
 }
 
@@ -838,9 +833,7 @@ function SortableNavigationItem({
   enableReorder,
   resolveObjectLabel,
   resolveDashboardLabel,
-  resolveGroupLabel,
   resolveViewLabel,
-  resolveItemLabel,
   t: tProp,
   templateContext,
 }: {
@@ -855,9 +848,7 @@ function SortableNavigationItem({
   enableReorder?: boolean;
   resolveObjectLabel?: (objectName: string, fallbackLabel: string) => string;
   resolveDashboardLabel?: (dashboardName: string, fallbackLabel: string) => string;
-  resolveGroupLabel?: (groupId: string, fallbackLabel: string) => string;
   resolveViewLabel?: (objectName: string, viewName: string, fallbackLabel: string) => string;
-  resolveItemLabel?: (itemId: string, fallbackLabel: string) => string;
   t?: (key: string, options?: any) => string;
   templateContext?: NavTemplateContext;
 }) {
@@ -891,9 +882,7 @@ function SortableNavigationItem({
         dragListeners={enableReorder ? listeners : undefined}
         resolveObjectLabel={resolveObjectLabel}
         resolveDashboardLabel={resolveDashboardLabel}
-        resolveGroupLabel={resolveGroupLabel}
         resolveViewLabel={resolveViewLabel}
-        resolveItemLabel={resolveItemLabel}
         t={tProp}
         templateContext={templateContext}
       />
@@ -917,9 +906,7 @@ function NavigationItemRenderer({
   dragListeners,
   resolveObjectLabel,
   resolveDashboardLabel,
-  resolveGroupLabel,
   resolveViewLabel,
-  resolveItemLabel,
   t: tProp,
   templateContext,
 }: {
@@ -934,9 +921,7 @@ function NavigationItemRenderer({
   dragListeners?: Record<string, any>;
   resolveObjectLabel?: (objectName: string, fallbackLabel: string) => string;
   resolveDashboardLabel?: (dashboardName: string, fallbackLabel: string) => string;
-  resolveGroupLabel?: (groupId: string, fallbackLabel: string) => string;
   resolveViewLabel?: (objectName: string, viewName: string, fallbackLabel: string) => string;
-  resolveItemLabel?: (itemId: string, fallbackLabel: string) => string;
   t?: (key: string, options?: any) => string;
   templateContext?: NavTemplateContext;
 }) {
@@ -1006,7 +991,7 @@ function NavigationItemRenderer({
       .slice()
       .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 
-    const groupLabel = resolveNavItemLabel(item, resolveObjectLabel, tProp, resolveDashboardLabel, resolveGroupLabel, resolveViewLabel, resolveItemLabel);
+    const groupLabel = resolveNavItemLabel(item, resolveObjectLabel, tProp, resolveDashboardLabel, resolveViewLabel);
 
     return (
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -1035,9 +1020,7 @@ function NavigationItemRenderer({
                     onPinToggle={onPinToggle}
                     resolveObjectLabel={resolveObjectLabel}
                     resolveDashboardLabel={resolveDashboardLabel}
-                    resolveGroupLabel={resolveGroupLabel}
                     resolveViewLabel={resolveViewLabel}
-                    resolveItemLabel={resolveItemLabel}
                     t={tProp}
                     templateContext={templateContext}
                   />
@@ -1114,7 +1097,7 @@ function NavigationItemRenderer({
   const Icon = resolveIcon(item.icon);
   const { href, external } = resolveHref(item, basePath, templateContext);
   const isActive = activeNavId !== null && item.id === activeNavId;
-  const itemLabel = resolveNavItemLabel(item, resolveObjectLabel, tProp, resolveDashboardLabel, resolveGroupLabel, resolveViewLabel, resolveItemLabel);
+  const itemLabel = resolveNavItemLabel(item, resolveObjectLabel, tProp, resolveDashboardLabel, resolveViewLabel);
 
   const content = (
     <>
@@ -1222,9 +1205,7 @@ export function NavigationRenderer({
   onReorder,
   resolveObjectLabel,
   resolveDashboardLabel,
-  resolveGroupLabel,
   resolveViewLabel,
-  resolveItemLabel,
   t: tProp,
   templateContext,
 }: NavigationRendererProps) {
@@ -1286,9 +1267,7 @@ export function NavigationRenderer({
     onPinToggle,
     resolveObjectLabel,
     resolveDashboardLabel,
-    resolveGroupLabel,
     resolveViewLabel,
-    resolveItemLabel,
     t: tProp,
     templateContext,
   };

--- a/packages/layout/src/__tests__/NavigationRenderer.navLabelOwnership.test.tsx
+++ b/packages/layout/src/__tests__/NavigationRenderer.navLabelOwnership.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Who owns app-navigation label localization (objectui#5197).
+ *
+ * The answer is: the server-side `/meta` boundary, alone. `translateApp` in
+ * `@objectstack/spec` rewrites each navigation node's `label` by id before the
+ * metadata reaches this renderer, so what arrives here is already localized
+ * and must be rendered verbatim.
+ *
+ * Until #5197 the renderer also accepted two id-keyed client-side resolvers
+ * (`resolveGroupLabel` / `resolveItemLabel`). They could never fire — the
+ * `isCustomized` guard compares the authored label against the branch's
+ * comparison target, and on those branches the target was the node's own `id`
+ * (`grp_workspace`) while the label was its text (`Workspace`), which never
+ * match. They are gone; these tests pin what is left:
+ *
+ *  - a normal tree renders exactly the labels it was given (the removal is not
+ *    user-visible, because the server path was the one answering all along);
+ *  - the `object` / `dashboard` branches keep their resolvers AND their guard;
+ *  - id-keyed client-side resolution stays absent — the last test fails if
+ *    anyone re-introduces it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { NavigationItem } from '@object-ui/types';
+import { SidebarProvider } from '@object-ui/components';
+import { NavigationRenderer } from '../NavigationRenderer';
+
+/** A conventionally-id'd tree: ids are slugs, labels are human text. */
+const workspaceTree: NavigationItem[] = [
+  {
+    id: 'grp_workspace',
+    type: 'group',
+    label: 'Workspace',
+    children: [
+      { id: 'nav_users', type: 'url', label: 'Users', url: '/users' },
+      { id: 'nav_pipeline', type: 'report', label: 'Pipeline report' },
+    ],
+  },
+  { id: 'group_sales', type: 'group', label: 'Sales', children: [
+    { id: 'nav_leads', type: 'url', label: 'Leads', url: '/leads' },
+  ] },
+];
+
+function renderNav(items: NavigationItem[], props: Record<string, unknown> = {}) {
+  return render(
+    <MemoryRouter initialEntries={['/apps/crm']}>
+      <SidebarProvider defaultOpen>
+        <NavigationRenderer items={items} basePath="/apps/crm" {...props} />
+      </SidebarProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('NavigationRenderer — nav label ownership', () => {
+  it('renders a normal tree with the labels exactly as authored', () => {
+    renderNav(workspaceTree);
+
+    expect(screen.getByText('Workspace')).toBeTruthy();
+    expect(screen.getByText('Sales')).toBeTruthy();
+    expect(screen.getByText('Users')).toBeTruthy();
+    expect(screen.getByText('Pipeline report')).toBeTruthy();
+    expect(screen.getByText('Leads')).toBeTruthy();
+    // No id ever leaks into the rail as a label.
+    expect(screen.queryByText('grp_workspace')).toBeNull();
+    expect(screen.queryByText('nav_users')).toBeNull();
+  });
+
+  it('renders server-localized labels verbatim — the /meta boundary already ran', () => {
+    // Exactly what `translateApp` hands the shell for a zh-CN session: ids
+    // untouched, labels rewritten. The renderer must not second-guess them.
+    renderNav([
+      {
+        id: 'grp_workspace',
+        type: 'group',
+        label: '工作区',
+        children: [{ id: 'nav_users', type: 'url', label: '用户', url: '/users' }],
+      },
+    ]);
+
+    expect(screen.getByText('工作区')).toBeTruthy();
+    expect(screen.getByText('用户')).toBeTruthy();
+  });
+
+  it('still resolves an un-customized object label through resolveObjectLabel', () => {
+    const resolveObjectLabel = vi.fn((_objectName: string, _fallback: string) => 'Accounts');
+    renderNav(
+      [{ id: 'nav_accounts', type: 'object', label: 'account', objectName: 'account' }],
+      { resolveObjectLabel },
+    );
+
+    expect(resolveObjectLabel).toHaveBeenCalledWith('account', 'account');
+    expect(screen.getByText('Accounts')).toBeTruthy();
+  });
+
+  it('still lets an authored object label win over resolveObjectLabel', () => {
+    const resolveObjectLabel = vi.fn((_objectName: string, _fallback: string) => 'Projects (translated)');
+    renderNav(
+      [{ id: 'nav_projects', type: 'object', label: 'Projects', objectName: 'project' }],
+      { resolveObjectLabel },
+    );
+
+    // The `isCustomized` guard survives on this branch: an author who wrote a
+    // custom label must never have it overridden by an object translation.
+    expect(resolveObjectLabel).not.toHaveBeenCalled();
+    expect(screen.getByText('Projects')).toBeTruthy();
+  });
+
+  it('keeps the same guard on the dashboard branch', () => {
+    const resolveDashboardLabel = vi.fn((_dashboardName: string, _fallback: string) => 'Sales overview (translated)');
+    renderNav(
+      [
+        { id: 'nav_so', type: 'dashboard', label: 'sales_overview', dashboardName: 'sales_overview' },
+        { id: 'nav_custom', type: 'dashboard', label: 'Executive summary', dashboardName: 'exec' },
+      ],
+      { resolveDashboardLabel },
+    );
+
+    // Assert on WHICH names reached the resolver, not on a call count — the
+    // tree re-renders (useIsMobile settles) and the count is not the contract.
+    expect(resolveDashboardLabel).toHaveBeenCalledWith('sales_overview', 'sales_overview');
+    expect(resolveDashboardLabel.mock.calls.every(([name]) => name === 'sales_overview')).toBe(true);
+    expect(screen.getByText('Sales overview (translated)')).toBeTruthy();
+    expect(screen.getByText('Executive summary')).toBeTruthy();
+  });
+
+  it('does not accept id-keyed client-side label resolvers', () => {
+    // The ruling on #5197: nav localization has ONE owner, the server `/meta`
+    // boundary. This renders with the retired prop names still supplied — a
+    // consumer that never updated, or a future re-introduction. Nothing may
+    // consume them.
+    //
+    // Note this assertion also held BEFORE the removal, because the guard made
+    // those hooks unreachable; that degeneracy is the finding, not a gap. Its
+    // job is forward-looking: re-adding id-keyed resolution (the rejected
+    // option A) turns this red.
+    const resolveGroupLabel = vi.fn((_groupId: string, _fallback: string) => 'GROUP FROM CLIENT PACK');
+    const resolveItemLabel = vi.fn((_itemId: string, _fallback: string) => 'ITEM FROM CLIENT PACK');
+
+    renderNav(workspaceTree, { resolveGroupLabel, resolveItemLabel });
+
+    expect(resolveGroupLabel).not.toHaveBeenCalled();
+    expect(resolveItemLabel).not.toHaveBeenCalled();
+    expect(screen.queryByText('GROUP FROM CLIENT PACK')).toBeNull();
+    expect(screen.queryByText('ITEM FROM CLIENT PACK')).toBeNull();
+    expect(screen.getByText('Workspace')).toBeTruthy();
+    expect(screen.getByText('Users')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #5197

Implements the maintainer ruling of 2026-08-19 (Option B): keep the `isCustomized` guard, delete the two id-keyed resolver hooks, and correct the `navGroupLabel` docstring so it names the path that actually localizes navigation.

**Clause-②: yes.** This removes a **published** surface. Removed exports:

| Package | Removed | Kind |
| --- | --- | --- |
| `@object-ui/layout` | `NavigationRendererProps.resolveGroupLabel` | optional prop |
| `@object-ui/layout` | `NavigationRendererProps.resolveItemLabel` | optional prop |

`useObjectLabel().navGroupLabel` on `@object-ui/i18n` is **retained** — the ruling says "correct the `navGroupLabel` docstring", not delete it — but it now has no first-party caller (see Open question below).

## Premise, re-verified on today's `main`

Triage read this at `12841b6`; re-read at `b8ce7dcd2` and the line numbers had not moved. `NavigationRenderer.tsx:307-308` defines the guard, the group branch sits at `:329-331`, the trailing `itemResolver` branch at `:334-336`.

`isCustomized` is a case-insensitive "authored label differs from this branch's comparison target" test. On the `object` / `dashboard` branches the target is the object or dashboard name and the test is meaningful — it protects an author's custom `Projects` from an `objects.project.label` translation. On the two id-keyed branches the target was the nav node's own **`id`** (`grp_workspace`, `group_sales`) while the label was its text (`Workspace`, `Sales`). Those never compare equal, so the guard was true for every real entry and the resolver beneath it was unreachable. The only node that reaches it is one whose label is literally its own id — demonstrated mechanically below.

Nothing is user-visible here because **app-nav localization is owned solely by the server-side `/meta` boundary**: `translateApp` in the framework's `packages/spec/src/system/i18n-resolver.ts` rewrites every navigation node's `label` by id, and `@objectstack/rest` applies it before the metadata reaches the client. The client-side path was never the one answering. One owner, not two.

## The tombstone

The reason this was worth doing is that a live docstring promised `"Sales"` to `"销售"` and the code could not deliver it — a planted false premise that gets the next reader to wire a translation pack and receive silent non-localization. So the correction does not merely delete:

- `packages/i18n/src/useObjectLabel.ts` — `navGroupLabel`'s docstring now states plainly that this does **not** localize the sidebar, names `translateApp` at the `/meta` boundary as the sole owner, and records why the old promise was false.
- `packages/layout/src/NavigationRenderer.tsx` — `resolveNavItemLabel`'s docstring carries the same note, and a `RETIRED` marker sits where the two props were so nobody re-adds them.
- `packages/app-shell/src/layout/UnifiedSidebar.tsx` — the home arm's "deliberately not forwarded" list can no longer cite props that do not exist; it now records why.

No deprecated stub and no re-export shim: the props are gone from the type, not neutered in place.

## Measured file surface

The triage estimate was "`UnifiedSidebar.tsx` + 6 test files + `packages/i18n` + `packages/layout`". Measured radius, 11 files:

- `packages/layout/src/NavigationRenderer.tsx` — both props, both `resolveNavItemLabel` parameters, both id-keyed branches, and the plumbing through `SortableNavigationItem` / `NavigationItemRenderer` / `NavigationRenderer` (3 destructures, 2 type members, 2 forwards, `itemProps`, 2 call sites).
- `packages/app-shell/src/layout/UnifiedSidebar.tsx` — the two prop wirings, the `navGroupLabel` destructure, and the home-arm note. This also removes a `studio` carve-out that existed **only** to stop `resolveItemLabel` from re-translating an already-translated "Package management" label — dead code guarding dead code. Its `t('sidebar.packageManagement')` call site is not the last one (`UnifiedSidebar.tsx:402` still constructs the label), so no i18n key is orphaned; `check:i18n-keys` and `check:i18n-dead-keys` confirm.
- `packages/i18n/src/useObjectLabel.ts` — docstring only.
- 6 test files under `packages/app-shell/src/layout/__tests__/` — see below.
- `packages/layout/src/__tests__/NavigationRenderer.navLabelOwnership.test.tsx` — new.

The 6 test files were **not** resolver tests. They are `AppSidebar.derivedAreaVisibility`, `UnifiedSidebar.derivedAreaVisibility`, `appSidebarSettingsTargets`, `systemNavDatasourcesHop`, `systemNavObjectsHop`, `systemNavSettingsTarget`, and each carried one line of mock scaffolding — `navGroupLabel: (_a, _g, fallback) => fallback` inside a `useObjectLabel` mock — present only because `UnifiedSidebar` destructured that field. **Nothing was deleted or rewritten: no assertion in any of them touched the resolvers, and each pins something else (nav hops, settings targets, derived area visibility), so all of them keep every test they had.** Only the now-unconsumed mock key is dropped, because a mock that says "the sidebar localizes groups through `navGroupLabel`" is the same false premise one level down.

Worth recording: **zero tests exercised `resolveGroupLabel` / `resolveItemLabel` anywhere in the repo.** Nothing pinned the behaviour, which is consistent with it never having run.

## Tests

New: `packages/layout/src/__tests__/NavigationRenderer.navLabelOwnership.test.tsx`, 6 tests.

- A normal tree (`grp_workspace`/`Workspace`, `group_sales`/`Sales`, `nav_users`/`Users`, `nav_pipeline`/`Pipeline report`) renders every label exactly as authored, and no id leaks into the rail — this is the "no user-visible change" claim as a test rather than an assertion.
- A server-localized tree (ids untouched, labels `工作区` / `用户`, i.e. what `translateApp` hands the shell) renders verbatim.
- `object` branch keeps both halves of its guard: `resolveObjectLabel` **is** called for an un-customized label, and is **not** called when the author wrote `Projects`.
- `dashboard` branch, same.
- Id-keyed client-side resolvers stay unconsumed: passing the retired prop names changes nothing. This one is green on both sides of this PR by construction — its job is forward-looking, and it turns red if the rejected option A is ever implemented.

## Reverse-verification

**Leg A — cross-package type narrowing (`resolveGroupLabel` re-added to `UnifiedSidebar`).** A build artifact **does** sit between the edit and the check: `packages/app-shell/tsconfig.json` resolves `@object-ui/layout` through its built `dist/index.d.ts`, and `turbo run type-check` rebuilds it via `dependsOn: ["^build"]`. Predicted before running: red with an excess-property error naming the prop. Observed:

```
src/layout/UnifiedSidebar.tsx(551,14): error TS2322: ...
  Property 'resolveGroupLabel' does not exist on type 'IntrinsicAttributes & NavigationRendererProps'.
```

Predicted red, observed red — which also proves the check read the rebuilt `.d.ts` rather than a cached one.

**Leg B — restore the deleted hooks, keep the tests. Degenerate, as predicted.** No build artifact on this leg: vitest aliases `@object-ui/layout` to `packages/layout/src`, and the test imports `../NavigationRenderer` relatively — nothing reads `dist/`. Predicted before running: **nothing goes red**, because restoring code that could never execute cannot change an observable. Observed: 6/6 kept tests green with the hooks restored. Filling in a red/green table here would be fiction; the degeneracy is the finding, and it is precisely why this code was safe to delete.

To make the leg say something, a throwaway probe ran against the restored hooks with a resolver wired:

| Node | Resolver reached? |
| --- | --- |
| `id: grp_workspace`, `label: Workspace` (conventional group) | **no** — renders `Workspace` |
| `id: nav_users`, `label: Users` (conventional leaf) | **no** — renders `Users` |
| `id: grp_workspace`, `label: grp_workspace` (degenerate) | **yes** — renders the resolver's output |

That is the premise, mechanically: reachable only for a node whose label is literally its own id. The probe was deleted and the tree restored byte-identically (`git diff HEAD` empty) before the verification union below.

## Gates — run on `c642a5261`, after the final commit

Derived from the diff (`scripts/pm/dispatch-gates.mjs` is objectstack-only). vitest run from the repo root per AGENTS.md.

```
pnpm exec vitest run packages/layout/ packages/app-shell/src/layout/ packages/i18n/
  → Test Files 94 passed (94) | Tests 1223 passed (1223)

turbo run type-check lint --filter=@object-ui/layout --filter=@object-ui/app-shell --filter=@object-ui/i18n
  → Tasks: 36 successful, 36 total   (lint: 0 errors; warnings pre-existing)

check:control-bytes PASS   check:i18n-keys PASS   check:i18n-drift PASS
check:self-import   PASS   check:esm-specifiers PASS   check:phantom-deps PASS
changeset:check     PASS   (check:i18n-dead-keys is a report, not a gate — no new hit)
```

## Changeset

`.changeset/retire-nav-label-resolvers-5197.md`, **`minor`** on `@object-ui/layout` / `@object-ui/app-shell` / `@object-ui/i18n`. Never `major` — objectui's major follows `@objectstack`'s and would move all 39 packages.

The confidence gap is on the record: external consumers who wired these hooks outside this monorepo are unmeasurable (in-repo and in the framework repo, there are none). Per the ruling the changeset is the loud signal, so its body is written for someone whose build just broke — it names the removed exports, explains why they could never have worked, and points at the server boundary with the concrete migration.

## Open question for the maintainer (not decided here)

`useObjectLabel().navGroupLabel` is kept per the ruling's literal wording, but after this change it has **zero callers** in this repo and zero in the framework repo. The dispatch's clause-② note lists it among the removed surface, while the ruling text says to correct its docstring — those two readings differ, and deleting a published export that the ruling did not explicitly name for deletion is a one-way door. Kept, documented, and flagged rather than guessed. If it should also go, that is a one-line follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_