### PR TITLE
fix(console): suppress the Approvals Inbox record link when the viewer cannot read the target

### DIFF
--- a/.changeset/lucky-buttons-clap.md
+++ b/.changeset/lucky-buttons-clap.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/console': patch
+---
+
+Approvals Inbox: stop offering a record link that dead-ends for the viewer it is
+offered to. Approver routing goes by position while record visibility is a
+separate gate, so an approver can be routed a request about a record they cannot
+read — the row's record chip then landed on the record page's "Record not found".
+The row (and the drawer's record title) now suppress the link for exactly those
+targets, decided by one batched readability read per distinct object. Nothing
+else changes: the title still shows, the approval decision path is untouched, and
+the server's access semantics are neither read nor reported on.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.recordLink.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.recordLink.test.tsx
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Approvals Inbox — the record link is offered only to a viewer who can open it
+ * (objectui#5211).
+ *
+ * ## The defect
+ *
+ * Approver routing goes by position; record visibility is a separate gate, and
+ * nothing reconciles the two. An approver routed a request about a record they
+ * cannot read was still offered the row's record chip, which landed on the
+ * record page's "Record not found — … does not exist or may have been deleted".
+ * Per the maintainer's ruling (2026-08-19) the link is suppressed for exactly
+ * those rows.
+ *
+ * ## What each case is measuring
+ *
+ * - the unreadable row renders **no link** (and still renders the title, which
+ *   comes from the request's payload snapshot);
+ * - the readable row is untouched — link, and the same href as before;
+ * - the whole page costs **one** readability read for two rows of one object —
+ *   the batching the ruling made the deciding criterion;
+ * - the **decision path is untouched**: one case pins inline approve WITHOUT
+ *   involving the probe (so it holds on the pre-change tree too — that is what
+ *   makes it a pin), and one shows that a row whose link was suppressed is still
+ *   decidable, which is the thing that already worked and must keep working.
+ *
+ * ⛔ Nothing here asserts anything about the server answering `404` rather than
+ * `403` for the by-id read. That is the server's deliberate choice and is out of
+ * scope in both directions; the probe issues a list read, never a by-id one.
+ *
+ * No build artifact sits between the edit and this test: the root Vitest config
+ * aliases every `@object-ui` specifier at that package's `src` directory, and
+ * the page and probe under test are this app's own source. (Writing that path
+ * with a glob segment would close this comment — the sequence is a block-comment
+ * terminator, and the parse error it produces points at a line far below.)
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+const APP = 'com.objectstack.account';
+
+const { adapterFind, approvalsApiStub, rows, ADAPTER, AUTH, I18N } = vi.hoisted(() => {
+  const rows = [
+    {
+      id: 'req_readable',
+      process_name: 'invoice_approval',
+      process_label: 'Invoice Approval',
+      object_name: 'showcase_invoice',
+      object_label: 'Invoice',
+      record_id: 'inv_readable',
+      record_title: 'Readable Invoice',
+      status: 'pending',
+      pending_approvers: ['u_1'],
+      submitter_id: 'u_2',
+      submitter_name: 'Sam Submitter',
+      submitted_at: '2026-08-19T00:00:00.000Z',
+    },
+    {
+      id: 'req_hidden',
+      process_name: 'invoice_approval',
+      process_label: 'Invoice Approval',
+      object_name: 'showcase_invoice',
+      object_label: 'Invoice',
+      record_id: 'inv_hidden',
+      record_title: 'Hidden Invoice',
+      status: 'pending',
+      pending_approvers: ['u_1'],
+      submitter_id: 'u_2',
+      submitter_name: 'Sam Submitter',
+      submitted_at: '2026-08-19T00:00:00.000Z',
+    },
+  ];
+
+  /**
+   * The server's own behaviour, reduced: a record the principal's grant filters
+   * out never appears in the row set, so an `id in (…)` read simply comes back
+   * without it. `inv_hidden` is that record.
+   */
+  const adapterFind = vi.fn(async (_object: string, params?: Record<string, unknown>) => {
+    const ids = (params?.$filter as { id?: { $in?: string[] } } | undefined)?.id?.$in ?? [];
+    return { data: ids.filter((id) => id !== 'inv_hidden').map((id) => ({ id })) };
+  });
+
+  const approvalsApiStub = {
+    listRequests: vi.fn(async () => ({ data: rows })),
+    getRequest: vi.fn(async (id: string) => ({ data: rows.find((r) => r.id === id) })),
+    listActions: vi.fn(async () => ({ data: [] })),
+    approve: vi.fn(async () => ({ data: rows[0], finalized: true })),
+    reject: vi.fn(async () => ({ data: rows[0], finalized: true })),
+  };
+
+  // STABLE singletons. A mocked hook that returns a fresh object per render
+  // gives every render a new `user` / `adapter` identity, which re-runs the
+  // page's load effect (and the probe's) forever — the page never leaves its
+  // loading skeleton and every query below times out on an empty table.
+  const ADAPTER = { find: adapterFind };
+  const AUTH = { user: { id: 'u_1', email: 'approver@example.com' } };
+  const I18N = {
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  };
+
+  return { adapterFind, approvalsApiStub, rows, ADAPTER, AUTH, I18N };
+});
+
+vi.mock('@object-ui/i18n', () => ({ useObjectTranslation: () => I18N }));
+
+vi.mock('@object-ui/auth', () => {
+  const authFetch = vi.fn(async () => new Response('{}', { status: 200 }));
+  return {
+    useAuth: () => AUTH,
+    createAuthenticatedFetch: () => authFetch,
+    TokenStorage: { get: () => null },
+  };
+});
+
+vi.mock('@object-ui/app-shell', () => ({
+  useAdapter: () => ADAPTER,
+  DeclaredActionsBar: () => null,
+  isViaOverrideRow: () => false,
+}));
+
+// `buildApproverIdentities` stays REAL — the "can this approver act" pin is only
+// worth anything if the identity resolution under it is the shipped one.
+vi.mock('../../services/approvalsApi', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  approvalsApi: approvalsApiStub,
+}));
+
+// Imported after the mocks so the page picks them up.
+import { ApprovalsInboxPage } from './ApprovalsInboxPage';
+
+function renderInbox() {
+  return render(
+    <MemoryRouter initialEntries={[`/apps/${APP}/system/approvals`]}>
+      <Routes>
+        <Route path="/apps/:appName/system/approvals" element={<ApprovalsInboxPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** The desktop table row holding `title` (the mobile card renders no links). */
+function rowFor(title: string): HTMLElement {
+  const found = screen.getAllByRole('row').find((r) => within(r).queryByText(title));
+  if (!found) throw new Error(`no row for ${title}`);
+  return found;
+}
+
+/**
+ * Approve the row holding `title`, through the row button and its confirmation.
+ *
+ * Query and click in ONE synchronous step, with `fireEvent`: the page declares
+ * `RecordCell` / `InlineActions` INSIDE its component body, so every re-render
+ * is a fresh component type and React replaces those DOM nodes. A multi-tick
+ * `userEvent` interaction lets a re-render land between its pointerdown and its
+ * click, and the rest of the sequence goes to a detached node — the click then
+ * silently does nothing and the confirmation never opens.
+ */
+async function approveFromRow(title: string): Promise<void> {
+  fireEvent.click(within(rowFor(title)).getByRole('button', { name: 'Approve' }));
+  const dialog = await screen.findByRole('alertdialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Approve' }));
+}
+
+beforeEach(() => {
+  adapterFind.mockClear();
+  for (const fn of Object.values(approvalsApiStub)) fn.mockClear();
+});
+afterEach(cleanup);
+
+describe('Approvals Inbox — record link readability (objectui#5211)', () => {
+  it('suppresses the record link on a row whose target this viewer cannot read', async () => {
+    renderInbox();
+
+    // The readable row is untouched: still a link, still the same href.
+    const link = await screen.findByRole('link', { name: /Readable Invoice/ });
+    expect(link).toHaveAttribute('href', `/apps/${APP}/showcase_invoice/record/inv_readable`);
+
+    // The unreadable one loses the link once the probe has answered…
+    await waitFor(() =>
+      expect(screen.queryByRole('link', { name: /Hidden Invoice/ })).not.toBeInTheDocument(),
+    );
+    // …and only the link. The title still shows — it comes from the request's
+    // payload snapshot, which is what the approver decides from.
+    expect(screen.getAllByText('Hidden Invoice').length).toBeGreaterThan(0);
+    expect(within(rowFor('Hidden Invoice')).queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('costs ONE readability read for a page of rows sharing an object', async () => {
+    renderInbox();
+    await screen.findByRole('link', { name: /Readable Invoice/ });
+    await waitFor(() => expect(adapterFind).toHaveBeenCalled());
+
+    // Two rows, one object => one batched list read. Not one per row.
+    expect(adapterFind).toHaveBeenCalledTimes(1);
+    expect(adapterFind).toHaveBeenCalledWith('showcase_invoice', {
+      $filter: { id: { $in: ['inv_readable', 'inv_hidden'] } },
+      $select: ['id'],
+      $top: 2,
+    });
+  });
+
+  /**
+   * A PIN, deliberately independent of the readability probe: it must pass on
+   * the tree BEFORE this change as well as after, which is what makes it
+   * evidence that the decision path was left alone rather than evidence that
+   * the change works. (It is stated separately from the case below because a
+   * pin coupled to the new behaviour proves nothing about the old.)
+   */
+  it('pins the inline decision path — approve still fires for the row it is clicked on', async () => {
+    renderInbox();
+    // Rows are up (desktop table + mobile card each render one per request).
+    await screen.findAllByRole('button', { name: 'Approve' });
+
+    await approveFromRow('Readable Invoice');
+
+    await waitFor(() =>
+      expect(approvalsApiStub.approve).toHaveBeenCalledWith('req_readable', { actor_id: 'u_1' }),
+    );
+  });
+
+  it('still lets the approver decide a row whose link was suppressed', async () => {
+    renderInbox();
+    // Wait for the rows FIRST. Waiting only for the link's absence passes
+    // vacuously while the page is still a loading skeleton — measured: on the
+    // pre-change tree this case went green for that reason alone.
+    await screen.findByRole('link', { name: /Readable Invoice/ });
+    await waitFor(() =>
+      expect(screen.queryByRole('link', { name: /Hidden Invoice/ })).not.toBeInTheDocument(),
+    );
+
+    await approveFromRow('Hidden Invoice');
+
+    await waitFor(() =>
+      expect(approvalsApiStub.approve).toHaveBeenCalledWith('req_hidden', { actor_id: 'u_1' }),
+    );
+  });
+
+  it('keeps every link when the probe cannot answer (fail open)', async () => {
+    adapterFind.mockImplementationOnce(async () => { throw new Error('NETWORK'); });
+    renderInbox();
+
+    await screen.findByRole('link', { name: /Readable Invoice/ });
+    await waitFor(() => expect(adapterFind).toHaveBeenCalled());
+    // Unknown is not "unreadable": a failed probe must never withhold a link
+    // from someone who could have used it.
+    expect(await screen.findByRole('link', { name: /Hidden Invoice/ })).toBeInTheDocument();
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -103,6 +103,7 @@ import {
   type ApprovalActionRow,
   type ApprovalActionAttachment,
 } from '../../services/approvalsApi';
+import { useRecordReadability } from './recordReadability';
 
 type TabKey = 'pending' | 'submitted' | 'all';
 
@@ -478,6 +479,25 @@ export function ApprovalsInboxPage() {
   const [selected, setSelected] = useState<ApprovalRequestRow | null>(null);
   const [actions, setActions] = useState<ApprovalActionRow[]>([]);
   const [drawerLoading, setDrawerLoading] = useState(false);
+
+  /**
+   * objectui#5211 — an approver can be routed a request about a record they
+   * cannot read (approver routing goes by position; record visibility is a
+   * separate gate). The link below then dead-ends on the record page's
+   * "may have been deleted", so it is suppressed for exactly those rows.
+   *
+   * One batched list read per distinct object covers the whole page — see
+   * `recordReadability.ts` for the cost model, the fail-open rule, and why
+   * nothing here says anything about WHY a target is unreadable.
+   *
+   * `selected` joins the loaded rows because the drawer can be deep-linked
+   * (`?request=<id>`) to a request that is not in the current row set.
+   */
+  const readabilityTargets = useMemo(
+    () => (selected ? [...rows, selected] : rows),
+    [rows, selected],
+  );
+  const readability = useRecordReadability(readabilityTargets);
   // Approve/reject/reassign/send-back/… are server-declared actions rendered by
   // DeclaredActionsBar (objectui#2697 + framework#3300); their param dialog
   // collects the comment and — since the shared upload-widget renderer (#2700/
@@ -1080,17 +1100,25 @@ export function ApprovalsInboxPage() {
     // Surface the decision-relevant amount inline so a reviewer can triage the
     // queue without opening each request (#2762 P1-3).
     const amount = decisionAmountEntry(r);
+    // objectui#5211: no link into a record this viewer cannot open. The title
+    // still shows — it comes from the request's own payload snapshot, which the
+    // approver was already given — it just stops being an anchor.
+    const title = r.record_title || formatIdentity(r.record_id);
     return (
       <div className="min-w-0">
+        {readability.isUnreadable(r) ? (
+          <div className="text-sm truncate max-w-full" title={r.record_id}>{title}</div>
+        ) : (
         <Link
           to={recordHref(r)}
           onClick={(e) => e.stopPropagation()}
           className="inline-flex items-center gap-1 text-sm hover:underline truncate max-w-full"
           title={r.record_id}
         >
-          <span className="truncate">{r.record_title || formatIdentity(r.record_id)}</span>
+          <span className="truncate">{title}</span>
           <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
         </Link>
+        )}
         <div className="text-xs text-muted-foreground truncate">
           {objectDisplay(r)}
           {amount && (
@@ -1680,6 +1708,15 @@ export function ApprovalsInboxPage() {
                 <CardContent className="p-4 space-y-3">
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0">
+                      {/* Same suppression as the row (objectui#5211) — the drawer
+                          offers the same link to the same record for the same
+                          viewer, so fixing only the row would move the dead end
+                          one click deeper instead of removing it. */}
+                      {readability.isUnreadable(selected) ? (
+                        <div className="text-base font-semibold truncate">
+                          {selected.record_title || formatIdentity(selected.record_id)}
+                        </div>
+                      ) : (
                       <Link
                         to={recordHref(selected)}
                         className="text-base font-semibold hover:underline inline-flex items-center gap-1.5"
@@ -1687,6 +1724,7 @@ export function ApprovalsInboxPage() {
                         <span className="truncate">{selected.record_title || formatIdentity(selected.record_id)}</span>
                         <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       </Link>
+                      )}
                       <div className="text-xs text-muted-foreground">{objectDisplay(selected)}</div>
                     </div>
                     <div className="text-right text-xs text-muted-foreground shrink-0">
@@ -2064,6 +2102,12 @@ export function ApprovalsInboxPage() {
                       {tr('returnedHint', 'An approver sent this back to you. The record is unlocked — fix the data, then resubmit to start a new approval round.')}
                     </div>
                     <div className="flex gap-2 flex-wrap items-center">
+                      {/* NOT readability-suppressed (objectui#5211), deliberately:
+                          this branch renders only for the SUBMITTER of a returned
+                          request, whose whole job here is to edit that record —
+                          a different persona from the approver the suppression is
+                          for, and one who demonstrably reached the record to
+                          submit it. */}
                       <Button asChild size="sm" variant="outline">
                         <Link to={recordHref(selected)}>
                           <ExternalLink className="h-4 w-4 mr-1" />

--- a/apps/console/src/pages/system/recordReadability.test.ts
+++ b/apps/console/src/pages/system/recordReadability.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Approvals Inbox readability probe (objectui#5211) — cost model and
+ * answer semantics.
+ *
+ * ## Why the cost is asserted rather than described
+ *
+ * The maintainer's ruling makes the probe's cost the thing that selects the
+ * disposition: a probe that batches (no per-row round trip) suppresses the
+ * dead-end link; a probe that costs a request per row does not ship at all.
+ * `planReadabilityProbe` returns exactly the list reads a render performs, so
+ * `groups.length` IS the call count — the number in the PR body is read off
+ * these assertions, not estimated.
+ *
+ * ## What is deliberately NOT asserted here
+ *
+ * Nothing about the server's `404 RECORD_NOT_FOUND` vs `403`. That semantics
+ * is the server's deliberate choice and is out of scope in both directions —
+ * the probe never sees a by-id read, only a list read whose row set the server
+ * has already filtered for this principal.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  planReadabilityProbe,
+  probeRecordReadability,
+  readabilityKey,
+  READABILITY_PROBE_CHUNK,
+  type ReadabilityProbeSource,
+} from './recordReadability';
+
+/** N rows of `object`, ids `<object>_0 … <object>_{n-1}`. */
+function rowsFor(object: string, n: number) {
+  return Array.from({ length: n }, (_, i) => ({ object_name: object, record_id: `${object}_${i}` }));
+}
+
+/**
+ * A data source that records every call and answers with the rows whose ids
+ * are in `readable` — which is precisely what the server does for a principal
+ * whose grant filters the record out of the row set.
+ */
+function countingSource(readable: ReadonlySet<string>) {
+  const calls: Array<{ object: string; ids: unknown }> = [];
+  const source: ReadabilityProbeSource = {
+    find: vi.fn(async (object: string, params?: Record<string, unknown>) => {
+      const filter = params?.$filter as { id?: { $in?: string[] } } | undefined;
+      const ids = filter?.id?.$in ?? [];
+      calls.push({ object, ids });
+      return { data: ids.filter((id) => readable.has(id)).map((id) => ({ id })) };
+    }),
+  };
+  return { source, calls };
+}
+
+describe('planReadabilityProbe — the cost model', () => {
+  it('costs one list read per distinct object, not one per row', () => {
+    const groups = planReadabilityProbe([...rowsFor('showcase_invoice', 30), ...rowsFor('showcase_project', 20)]);
+
+    // 50 rows, 2 objects => 2 calls. The measurement the ruling asked for.
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.objectName)).toEqual(['showcase_invoice', 'showcase_project']);
+    expect(groups[0].ids).toHaveLength(30);
+    expect(groups[1].ids).toHaveLength(20);
+  });
+
+  it('costs exactly one read for a page that names a single object', () => {
+    expect(planReadabilityProbe(rowsFor('showcase_invoice', 50))).toHaveLength(1);
+  });
+
+  it('dedupes repeated targets — several requests about one record probe it once', () => {
+    const target = { object_name: 'showcase_invoice', record_id: 'inv_1' };
+    const groups = planReadabilityProbe([target, { ...target }, { ...target }]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].ids).toEqual(['inv_1']);
+  });
+
+  it('skips targets it cannot address, and costs nothing for an empty page', () => {
+    expect(planReadabilityProbe([])).toEqual([]);
+    expect(planReadabilityProbe([
+      { object_name: '', record_id: 'x' },
+      { object_name: 'showcase_invoice', record_id: '' },
+      { object_name: null, record_id: null },
+    ])).toEqual([]);
+  });
+
+  it('splits only past the batch cap, so the call count stays O(objects)', () => {
+    const groups = planReadabilityProbe(rowsFor('showcase_invoice', READABILITY_PROBE_CHUNK + 1));
+    expect(groups).toHaveLength(2);
+    expect(groups[0].ids).toHaveLength(READABILITY_PROBE_CHUNK);
+    expect(groups[1].ids).toHaveLength(1);
+  });
+});
+
+describe('probeRecordReadability — the answer', () => {
+  it('answers every id from one batched read per object', async () => {
+    const { source, calls } = countingSource(new Set(['showcase_invoice_0', 'showcase_project_1']));
+    const map = await probeRecordReadability(source, [
+      ...rowsFor('showcase_invoice', 2),
+      ...rowsFor('showcase_project', 2),
+    ]);
+
+    expect(calls).toHaveLength(2);
+    expect(source.find).toHaveBeenCalledTimes(2);
+    expect(map.get(readabilityKey('showcase_invoice', 'showcase_invoice_0'))).toBe(true);
+    expect(map.get(readabilityKey('showcase_invoice', 'showcase_invoice_1'))).toBe(false);
+    expect(map.get(readabilityKey('showcase_project', 'showcase_project_1'))).toBe(true);
+    expect(map.get(readabilityKey('showcase_project', 'showcase_project_0'))).toBe(false);
+  });
+
+  it('pins `$top` to the batch size so a default page size cannot forge an unreadable', async () => {
+    const findCalls: Array<Record<string, unknown> | undefined> = [];
+    const source: ReadabilityProbeSource = {
+      find: async (_object: string, params?: Record<string, unknown>) => {
+        findCalls.push(params);
+        return { data: [] };
+      },
+    };
+    await probeRecordReadability(source, rowsFor('showcase_invoice', 60));
+    expect(findCalls).toHaveLength(1);
+    expect(findCalls[0]?.$top).toBe(60);
+    // Projected to the id column — the probe reads existence, never content.
+    expect(findCalls[0]?.$select).toEqual(['id']);
+  });
+
+  it('leaves a failed group UNKNOWN (absent), never guessed, and keeps the others', async () => {
+    const source: ReadabilityProbeSource = {
+      find: async (object: string, params?: Record<string, unknown>) => {
+        if (object === 'showcase_invoice') throw new Error('NETWORK');
+        const ids = (params?.$filter as { id?: { $in?: string[] } })?.id?.$in ?? [];
+        return { data: ids.map((id) => ({ id })) };
+      },
+    };
+    const map = await probeRecordReadability(source, [
+      ...rowsFor('showcase_invoice', 2),
+      ...rowsFor('showcase_project', 1),
+    ]);
+
+    // Absent, not `false`: an unknown target keeps its link (fail open).
+    expect(map.has(readabilityKey('showcase_invoice', 'showcase_invoice_0'))).toBe(false);
+    // The healthy object still answered.
+    expect(map.get(readabilityKey('showcase_project', 'showcase_project_0'))).toBe(true);
+  });
+
+  it('accepts a bare-array result as well as the `{ data }` envelope', async () => {
+    const source: ReadabilityProbeSource = {
+      find: async () => [{ id: 'showcase_invoice_0' }],
+    };
+    const map = await probeRecordReadability(source, rowsFor('showcase_invoice', 2));
+    expect(map.get(readabilityKey('showcase_invoice', 'showcase_invoice_0'))).toBe(true);
+    expect(map.get(readabilityKey('showcase_invoice', 'showcase_invoice_1'))).toBe(false);
+  });
+});

--- a/apps/console/src/pages/system/recordReadability.ts
+++ b/apps/console/src/pages/system/recordReadability.ts
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Per-row record readability for the Approvals Inbox (objectui#5211).
+ *
+ * ## The affordance this exists to remove
+ *
+ * Approver resolution routes on positions; record visibility is a separate
+ * gate, and nothing reconciles the two. So an approver can be routed a request
+ * about a record they cannot read — the inbox then offers a record link that,
+ * for the person it is offered to, lands on "Record not found — the record you
+ * are looking for does not exist or may have been deleted". The approval
+ * itself is fine (the drawer carries the request's payload snapshot and the
+ * decision path never touches the record read); what is broken is the link.
+ *
+ * The maintainer's ruling (2026-08-19, recorded on objectui#5211) is to
+ * **suppress the link when the viewer cannot read the target**, decided per row
+ * by this probe.
+ *
+ * ## ⛔ What this deliberately does NOT do
+ *
+ * It does not change, soften, or report on the server's answer. The server
+ * replies `404 RECORD_NOT_FOUND` — not `403` — to a by-id read of a record
+ * filtered out of the principal's row set, **on purpose**: 404 is how it
+ * declines to confirm that a record exists to someone not permitted to see it.
+ * Telling the viewer "you do not have access to this record" would confirm
+ * exactly that, so no copy here says it, and nothing here asserts anything
+ * about 404-vs-403. A suppressed link is silent: the row still shows the
+ * record's title from the request's own payload snapshot (which the approver
+ * was already given), just not as a link into a page they cannot open.
+ *
+ * The probe cannot widen access either. It is an ordinary list read issued as
+ * the signed-in viewer, under the viewer's own grants — the same read the
+ * record page would perform one click later. It only moves the answer earlier.
+ *
+ * ## Cost — why this is batchable
+ *
+ * The probe is **per distinct object, not per row**: every row's `record_id` for
+ * one `object_name` goes into a single `id in (…)` list read, projected down to
+ * the id column. A page of N rows spanning K objects costs `K` calls (K ≈ 1–2 in
+ * practice), not N — and rows already probed are never re-probed, so paging in
+ * more rows costs only the new ids. See `planReadabilityProbe`, which IS the
+ * cost model and is pinned by `recordReadability.test.ts`.
+ *
+ * ## Fail-open, always
+ *
+ * An unanswered or failed probe leaves the target **unknown**, and an unknown
+ * target keeps its link. This is an affordance, not an access control — the
+ * server stays the only authority — so the failure mode of the probe must be
+ * today's behaviour (a link that may dead-end), never a link withheld from
+ * someone who could have used it.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAdapter } from '@object-ui/app-shell';
+import type { QueryParams } from '@object-ui/types';
+
+/** The two fields of an approval request that address its target record. */
+export interface ReadabilityTarget {
+  object_name?: string | null;
+  record_id?: string | null;
+}
+
+/**
+ * Minimal structural view of the data source the probe needs. Declared here
+ * rather than importing the adapter type so the probe is testable with a
+ * counting stub — and so it can never reach for anything but a list read.
+ */
+export interface ReadabilityProbeSource {
+  find(objectName: string, params?: QueryParams): Promise<unknown>;
+}
+
+/**
+ * Ids per list read. One call per object is the shape that matters; the cap
+ * only keeps a very long queue from building a single unbounded `$in` (and an
+ * over-long URL) — at PAGE_SIZE = 50 rows per page it is never reached.
+ */
+export const READABILITY_PROBE_CHUNK = 100;
+
+/**
+ * Key for one target in the readability map.
+ *
+ * `::` is unambiguous here because object names are metadata identifiers
+ * (`[a-z0-9_]`), so the first `::` always separates object from record id.
+ * (A control byte as separator would be unsearchable and trips
+ * `check:control-bytes` — see `scripts/check-control-bytes.mjs`.)
+ */
+export function readabilityKey(objectName: string, recordId: string): string {
+  return `${objectName}::${recordId}`;
+}
+
+/** A target the probe can actually ask about. */
+function probeable(t: ReadabilityTarget): t is { object_name: string; record_id: string } {
+  return typeof t.object_name === 'string' && t.object_name !== ''
+    && typeof t.record_id === 'string' && t.record_id !== '';
+}
+
+/** One batched list read: every id below belongs to `objectName`. */
+export interface ReadabilityProbeGroup {
+  objectName: string;
+  ids: string[];
+}
+
+/**
+ * Group targets into the list reads that answer them — **the cost model**.
+ *
+ * `groups.length` is exactly the number of network calls a render adds, so a
+ * test can assert the cost directly instead of describing it. Ids are deduped
+ * per object and kept in first-seen order (stable output for stable input).
+ */
+export function planReadabilityProbe(
+  targets: readonly ReadabilityTarget[],
+): ReadabilityProbeGroup[] {
+  const byObject = new Map<string, string[]>();
+  const seen = new Set<string>();
+  for (const t of targets) {
+    if (!probeable(t)) continue;
+    const key = readabilityKey(t.object_name, t.record_id);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const ids = byObject.get(t.object_name);
+    if (ids) ids.push(t.record_id);
+    else byObject.set(t.object_name, [t.record_id]);
+  }
+  const groups: ReadabilityProbeGroup[] = [];
+  for (const [objectName, ids] of byObject) {
+    for (let i = 0; i < ids.length; i += READABILITY_PROBE_CHUNK) {
+      groups.push({ objectName, ids: ids.slice(i, i + READABILITY_PROBE_CHUNK) });
+    }
+  }
+  return groups;
+}
+
+/** Rows come back as a bare array from some adapters and `{ data }` from others. */
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const data = (result as { data?: unknown } | null | undefined)?.data;
+  return Array.isArray(data) ? (data as Array<Record<string, unknown>>) : [];
+}
+
+/**
+ * Ask the data source which of `targets` this viewer can read.
+ *
+ * Returns a map of {@link readabilityKey} → readable. A key is **absent** when
+ * its group's read failed — unknown, never guessed — because callers must
+ * fail open (see the module header).
+ *
+ * Never rejects: a per-group failure drops that group's answers and leaves the
+ * rest intact, so one denied object cannot blank the whole inbox.
+ */
+export async function probeRecordReadability(
+  source: ReadabilityProbeSource,
+  targets: readonly ReadabilityTarget[],
+): Promise<Map<string, boolean>> {
+  const out = new Map<string, boolean>();
+  const groups = planReadabilityProbe(targets);
+  await Promise.all(groups.map(async ({ objectName, ids }) => {
+    let readable: Set<string>;
+    try {
+      // `$top` is pinned to the batch size: a server-side default page size
+      // smaller than the batch would truncate the answer and read as "these
+      // ids are unreadable" — a link withheld from someone who could use it.
+      const result = await source.find(objectName, {
+        $filter: { id: { $in: ids } },
+        $select: ['id'],
+        $top: ids.length,
+      });
+      readable = new Set(
+        rowsOf(result)
+          .map((row) => row?.id)
+          .filter((id): id is string => typeof id === 'string' && id !== ''),
+      );
+    } catch {
+      // Unknown, so the caller keeps the link. Deliberately silent: a viewer
+      // without access to an object hits this on every load, and a console
+      // error per row would be noise, not a signal.
+      return;
+    }
+    for (const id of ids) out.set(readabilityKey(objectName, id), readable.has(id));
+  }));
+  return out;
+}
+
+/** What a row asks the probe at render time. */
+export interface RecordReadability {
+  /**
+   * `true` only when the probe has answered and the answer is "cannot read".
+   * Unknown (not yet probed, probe failed, no data source) reads as `false`,
+   * which keeps the link — see the module header on failing open.
+   */
+  isUnreadable(target: ReadabilityTarget): boolean;
+}
+
+/**
+ * Probe the targets a render needs and keep the answers.
+ *
+ * Each (object, id) is probed at most once per mount: newly loaded rows cost
+ * only their own ids, and re-renders (search typing, the minute clock, a
+ * drawer opening) cost nothing. The trade is that an access grant made while
+ * the page is open is not picked up until it is reloaded — acceptable for an
+ * affordance, and it fails in the direction that keeps a link rather than
+ * hiding one.
+ */
+export function useRecordReadability(targets: readonly ReadabilityTarget[]): RecordReadability {
+  const adapter = useAdapter();
+  const [known, setKnown] = useState<ReadonlyMap<string, boolean>>(() => new Map());
+  /** Keys already handed to a probe — the "probe once" ledger. */
+  const attempted = useRef<Set<string>>(new Set());
+  /** Latest targets without making them an effect dependency (see `signature`). */
+  const latest = useRef<readonly ReadabilityTarget[]>(targets);
+  latest.current = targets;
+
+  // `targets` is a fresh array every render, so the effect keys off the SET of
+  // targets rather than the array's identity.
+  const signature = useMemo(
+    () => targets
+      .filter(probeable)
+      .map((t) => readabilityKey(t.object_name, t.record_id))
+      .join('|'),
+    [targets],
+  );
+
+  useEffect(() => {
+    if (!adapter) return;
+    const fresh = latest.current.filter(
+      (t) => probeable(t) && !attempted.current.has(readabilityKey(t.object_name, t.record_id)),
+    );
+    if (fresh.length === 0) return;
+    for (const t of fresh) {
+      if (probeable(t)) attempted.current.add(readabilityKey(t.object_name, t.record_id));
+    }
+    let cancelled = false;
+    void probeRecordReadability(adapter, fresh).then((result) => {
+      if (cancelled || result.size === 0) return;
+      setKnown((prev) => {
+        const next = new Map(prev);
+        for (const [key, value] of result) next.set(key, value);
+        return next;
+      });
+    });
+    return () => { cancelled = true; };
+  }, [adapter, signature]);
+
+  return useMemo<RecordReadability>(() => ({
+    isUnreadable: (target) =>
+      probeable(target)
+      && known.get(readabilityKey(target.object_name, target.record_id)) === false,
+  }), [known]);
+}


### PR DESCRIPTION
Fixes #5211

**Shipped: Option 2** (suppress the link), not the pre-ruled Option 1 fallback. **The measurement that chose it:** the readability probe is **one batched list read per distinct object per load, and zero per-row round trips** — asserted, not estimated. In the render test, a page of 2 rows sharing one object issues exactly **1** `find` call (`expect(adapterFind).toHaveBeenCalledTimes(1)`); at the plan level, 50 rows across 2 objects cost **2** calls, 50 rows of one object cost **1**, ids are deduped, and a single object only splits past 100 ids. Each (object, id) is probed at most once per mount, so paging in another 50 rows costs only the new ids, and the drawer costs 0 extra for a row already in the list (at most 1 for a deep-linked request naming an object the page has not already covered). For scale: the inbox already spends 1 `listRequests` per load, plus 1 badge refresh on the non-pending tabs — the probe is the same order of traffic, not a multiple of the row count.

One thing I want visible rather than decided silently: the ruling's "expensive" clause also names *"a call the inbox does not otherwise make"*, and this **is** a new call type — the inbox otherwise talks only to `/approvals/*`. I read that clause as describing per-row cost rather than as a separate disqualifier, because on the strict reading no probe could ever qualify (a probe the inbox already made would not be a probe), which would make Option 2 unreachable by construction while the ruling names it primary and calls it "batchable". The number above is the trade; if the maintainer reads the clause the other way, Option 1 is a small revert of the two render sites.

## What changed

An approver is routed a request by position, but record visibility is a separate gate and nothing reconciles the two — so the row offered a record chip that, for the person it was offered to, landed on "Record not found — the record you are looking for does not exist or may have been deleted". Two render sites now show the record title as plain text instead of a link when the probe says this viewer cannot read the target:

- `apps/console/src/pages/system/ApprovalsInboxPage.tsx` — `RecordCell` (the row chip: the reported surface), and the drawer's record-title link. The drawer is included because it offers **the same link to the same record for the same viewer**; fixing only the row would move the dead end one click deeper rather than remove it.
- **Deliberately not suppressed**, with a comment saying so: the "Edit record" button on a *returned* request. That branch renders only for the **submitter**, whose job there is to edit that record — a different persona from the approver this is for.

The title itself still renders: it comes from the request's own payload snapshot, which is what the approver decides from. The mobile card never rendered a link and is untouched.

New: `apps/console/src/pages/system/recordReadability.ts` — `planReadabilityProbe` (the cost model, so a test can assert the call count directly), `probeRecordReadability`, and the `useRecordReadability` hook. The probe is an ordinary `id in (…)` list read issued as the signed-in viewer under the viewer's own grants, projected to the id column, with `$top` pinned to the batch size so a server-side default page size cannot truncate the answer into a forged "unreadable".

**Fail-open, always.** Unknown, unanswered, failed, or no data source leaves the link exactly as it is today. This is an affordance, not an access control — the server stays the only authority — so the probe's failure mode must never withhold a link from someone who could have used it. One denied object cannot blank the others: failures are per group.

## ⛔ What this does not touch

The server's access semantics, in either direction. It answers `404 RECORD_NOT_FOUND` rather than `403` **deliberately** — the record is filtered out of the row set before the by-id read, so declining to confirm its existence is the point. Nothing here says *why* a target is unreadable, **no user-visible copy is added at all** (hence no i18n keys, no locale packs, and `check:i18n-keys` / `check:i18n-drift` / `check:i18n-dead-keys` stay green), and no test asserts anything about 404-vs-403. Option 3 and Option 4 are not touched.

## Verification — all at `d8927ba1a`

`pnpm exec vitest run apps/console/` (repo root, the config CI uses): **57 files / 672 tests passed**, including the 14 new ones. `apps/console` `type-check` and `lint` green (0 errors; the surviving warnings are pre-existing). Gates run and green: `check:control-bytes`, `check:i18n-keys`, `check:i18n-drift`, `check:i18n-dead-keys`, `check:phantom-deps`, `check:self-import`, `check-changeset-presence`, `check-changeset-no-major`. The workspace dependency closure was built before `type-check` — without it every `@object-ui` import reads as an unresolved module and the run is a false red.

### Reverse verification — predicted before running, then observed

Restored only the page render change (probe module and all tests kept). Predicted: probe unit file all green; suppression RED; cost RED; the pure decision-path pin **GREEN**; suppressed-row-decidable RED; fail-open RED. **Observed: exactly that — 4 failed / 10 passed.** Direction was straight red, not a diagnostic-count change and not a reversal. The restore leg is byte-identical to `HEAD` (`git status --porcelain` empty) and back to 14/14.

No build artifact sits between the edit and the thing under test on either leg: the root Vitest config aliases every `@object-ui` specifier at that package's `src`, and the page and probe are `apps/console` source that Vite transforms directly. (The `tsc` type-check is the one tool here that *does* read the packages' built `dist` declarations — a different tool, not this test path.)

**A first attempt at the pin was wrong and is worth recording.** It opened by waiting for the suppressed link to be *absent*, which passes vacuously while the page is still a loading skeleton — so it went **green on the pre-change tree**, proving nothing. It is now split in two: one case pins inline approve without involving the probe at all (green on both trees, which is what makes it a pin), and one waits for the rows first and then for the link to vanish before deciding the suppressed row.

Changeset: `patch` (`.changeset/lucky-buttons-clap.md`) — user-visible, and never `major`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_