### PR TITLE
feat(types,layout,app-shell): consume the declared nav runAction slot; retire the private ?runAction= convention

### DIFF
--- a/.changeset/5216-nav-run-action-slot.md
+++ b/.changeset/5216-nav-run-action-slot.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/types': minor
+'@object-ui/layout': minor
+'@object-ui/app-shell': minor
+---
+
+Consume the declared nav `runAction` slot; retire the private `?runAction=` string convention
+
+An `object` navigation item can now declare `runAction: '<actionName>'` and the shell will run that action once on arrival at the object's list surface, through the ordinary execute path — so param dialogs, confirms and entitlement gates all still apply. The slot is `@objectstack/spec`'s `ObjectNavItemSchema.runAction`; objectui now reads it instead of a private convention.
+
+- `NavigationItem` declares `runAction` (derived from the spec's object-nav variant), and objectui's own nav schema stops stripping it — `objectui validate` previously discarded the key, so an entry carrying a deep link validated clean with the deep link thrown away.
+- `resolveHref` encodes it onto the list href as the reserved `?runAction=` param, on the list landings only. A `recordId` entry resolves to a record page, which has no list toolbar to answer it, so the slot is not encoded there.
+- The deep link is honoured on **every** object list, not just the environments list. The action is armed only when it is actually present at `list_toolbar`; a name no action answers to runs nothing and deliberately leaves the URL untouched, so a later mount with fresher metadata can still honour it. Undefined references are rejected upstream at authoring time by `defineStack`.
+- The param name now has exactly one definition (`NAV_RUN_ACTION_PARAM`, exported from `@object-ui/layout`) and is registered in the console's reserved-param collision check. It was previously a bare literal hand-written at both the producing and consuming ends, declared by no schema and listed in no registry.
+- `CloudOnboardingNext` takes an optional `properties.createAction` (defaulting to `create_environment`) instead of hand-concatenating its deep link.

--- a/packages/app-shell/src/__tests__/navRunAction.privateConventionRetired.test.ts
+++ b/packages/app-shell/src/__tests__/navRunAction.privateConventionRetired.test.ts
@@ -1,0 +1,129 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5216 — the private `?runAction=` string convention is RETIRED, and
+ * cannot come back by accident.
+ *
+ * ## What the convention was
+ *
+ * `?runAction=<name>` was a deep link with **two hand-written definitions and
+ * no declaration**: `CloudOnboardingNext` built the query by string
+ * concatenation (`` `${envsRoute}?runAction=create_environment` ``), and
+ * `EnvironmentListToolbar` matched it by reading a bare `'runAction'` literal
+ * off `window.location.search` and comparing it to a hard-coded action name.
+ *
+ * Nothing declared it. `objectui validate` could not see it (the nav schema
+ * strips unknown keys). `RESERVED_URL_PARAMS` did not list it, so a page could
+ * have repurposed the name with no collision check to catch it. And because the
+ * consumer compared against ONE hard-coded action, the "convention" was really
+ * a single-value private protocol between two files — a second de-facto
+ * contract of exactly the shape AGENTS.md #0.1 exists to prevent.
+ *
+ * `@objectstack/spec` now publishes the real one: `ObjectNavItemSchema.runAction`
+ * (objectstack#7253). So the convention is not a contract that needs migrating;
+ * it is pure debt, and this file is what keeps it deleted.
+ *
+ * ## ⚠ WHAT THIS FILE CANNOT ASSERT — read before adding a case here
+ *
+ * This is a SOURCE SCAN, not a behavioural test. It proves the literal is gone
+ * from the source, not that the runtime honours the declared slot — that is
+ * `resolveHref.runAction.test.ts` (producer) and `useNavRunAction.test.tsx`
+ * (consumer), and neither is replaceable by this one. A scan also cannot see a
+ * literal assembled at runtime (`'run' + 'Action'`); it catches the failure
+ * mode that actually recurs — someone re-typing the string because importing
+ * the constant was one keystroke more.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { NAV_RUN_ACTION_PARAM } from '@object-ui/layout';
+import { RESERVED_URL_PARAMS } from '../urlParams';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+/**
+ * Drop block and line comments before scanning. Doc comments legitimately NAME
+ * the retired param while explaining the mechanism that replaced it — without
+ * this, the rule would forbid documenting its own subject, and the pressure
+ * would be to delete the explanation rather than the debt.
+ */
+const stripComments = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+/**
+ * Every file that used to hand-write the param name, plus the two that consume
+ * it today. If a future file needs the name, it imports the constant — so this
+ * list is allowed to grow only with files that DON'T contain the literal.
+ */
+const SOURCES_THAT_MUST_NOT_SPELL_IT = [
+  'packages/app-shell/src/environment/EnvironmentListToolbar.tsx',
+  'packages/app-shell/src/console/home/CloudOnboardingNext.tsx',
+  'packages/app-shell/src/views/ObjectView.tsx',
+  'packages/app-shell/src/hooks/useNavRunAction.ts',
+];
+
+describe('the private `?runAction=` convention is gone from the source (#5216)', () => {
+  it.each(SOURCES_THAT_MUST_NOT_SPELL_IT)('%s spells the param name nowhere', (rel) => {
+    const src = read(rel);
+
+    // The quoted literal in code — see `stripComments` on why documentation
+    // that names the retired string is not itself the debt.
+    const code = stripComments(src);
+
+    expect(code).not.toMatch(/['"`]runAction['"`]/);
+    // The hand-concatenated query, in any quoting.
+    expect(code).not.toMatch(/\?runAction=/);
+  });
+
+  it('the toolbar no longer reads the raw search string for it', () => {
+    const src = read('packages/app-shell/src/environment/EnvironmentListToolbar.tsx');
+
+    // Before #5216: `new URLSearchParams(window.location.search).get('runAction')`.
+    // Read-once/consume-once now lives in one shared hook; a second copy here
+    // would be a second set of #4123 semantics waiting to drift.
+    expect(src).not.toContain('URLSearchParams');
+    expect(src).toContain('useNavRunAction');
+  });
+
+  it('the welcome CTA no longer concatenates its own deep link', () => {
+    const src = read('packages/app-shell/src/console/home/CloudOnboardingNext.tsx');
+
+    expect(src).toContain('navRunActionHref');
+    // The exact template that used to build it. Comments are stripped for the
+    // same reason as above: the comment there NAMES the retired string while
+    // explaining what replaced it, which is documentation, not a producer.
+    expect(stripComments(src)).not.toContain('?runAction=create_environment');
+  });
+});
+
+describe('the param name now has exactly one definition (#5216)', () => {
+  it('is owned by @object-ui/layout, next to its only writer', () => {
+    expect(NAV_RUN_ACTION_PARAM).toBe('runAction');
+  });
+
+  it('is registered in the console reserved-param collision check', () => {
+    // The half the private convention never had: a page that tried to claim
+    // `runAction` for its own purposes now collides visibly.
+    expect(RESERVED_URL_PARAMS).toContain(NAV_RUN_ACTION_PARAM);
+  });
+
+  it('urlParams re-exports the constant rather than restating the string', () => {
+    const src = read('packages/app-shell/src/urlParams.ts');
+
+    // Every other reserved param is `export const X = '<literal>'` here; this
+    // one must NOT be, or there would be two spellings to drift apart.
+    expect(src).not.toMatch(/NAV_RUN_ACTION_PARAM\s*=\s*['"]/);
+    expect(src).toContain("from '@object-ui/layout'");
+  });
+});

--- a/packages/app-shell/src/console/home/CloudOnboardingNext.tsx
+++ b/packages/app-shell/src/console/home/CloudOnboardingNext.tsx
@@ -33,6 +33,7 @@ import { useAuth } from '@object-ui/auth';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import { ComponentRegistry } from '@object-ui/core';
 import { useObjectTranslation } from '@object-ui/i18n';
+import { navRunActionHref } from '../../hooks/useNavRunAction';
 
 interface CloudOnboardingNextProps {
   properties?: {
@@ -40,6 +41,14 @@ interface CloudOnboardingNextProps {
     openProductionUrl?: string;
     /** SPA route to the environments list (create / open / manage). */
     environmentsRoute?: string;
+    /**
+     * Name of the action the "Create your environment" CTA deep-links into on
+     * that list — the same slot an object nav entry declares as `runAction`.
+     * Defaults to `create_environment`, which is the name the Cloud app's
+     * transitional pin test guards, so this is safe to ship ahead of the page
+     * metadata that will supply it (#5216).
+     */
+    createAction?: string;
     /**
      * Optional backend pre-warm endpoint. When set and the caller already has
      * a production env, the widget fires a best-effort GET the moment it knows
@@ -59,6 +68,13 @@ type Resolved =
 
 const DEFAULT_OPEN_PRODUCTION_URL = '/api/v1/cloud/environments/production/sso-open';
 const DEFAULT_ENVIRONMENTS_ROUTE = '/apps/cloud_control/sys_environment';
+
+/**
+ * The environment list's create action. Cloud-owned name, guarded by cloud's
+ * transitional pin test (cloud#1048) — kept as the default so page metadata
+ * that predates `properties.createAction` still deep-links correctly.
+ */
+const DEFAULT_CREATE_ACTION = 'create_environment';
 
 /** Resolve the active locale's string (cheap; the page uses {en,zh} pairs). */
 /**
@@ -132,6 +148,7 @@ export function CloudOnboardingNext({ properties }: CloudOnboardingNextProps) {
   const state = useProductionEnvState(properties?.warmUrl);
   const openUrl = properties?.openProductionUrl || DEFAULT_OPEN_PRODUCTION_URL;
   const envsRoute = properties?.environmentsRoute || DEFAULT_ENVIRONMENTS_ROUTE;
+  const createAction = properties?.createAction || DEFAULT_CREATE_ACTION;
 
   // Loading — a neutral skeleton sized like the button row, so the hero doesn't
   // jump when the real CTA lands.
@@ -157,11 +174,20 @@ export function CloudOnboardingNext({ properties }: CloudOnboardingNextProps) {
       <div className="flex flex-wrap items-center justify-center gap-3">
         {showCreatePrimary ? (
           // Deep-link straight INTO the create dialog (#844): the environments
-          // list consumes `runAction=create_environment` and auto-opens its
-          // create action once entitlements resolve — "Create your environment"
-          // used to be a plain navigation that left the user hunting for a
-          // second create button on the list page.
-          <Button size="lg" onClick={() => navigate(`${envsRoute}?runAction=create_environment`)}>
+          // list consumes the declared `runAction` slot and auto-opens the named
+          // action once entitlements resolve — "Create your environment" used to
+          // be a plain navigation that left the user hunting for a second create
+          // button on the list page.
+          //
+          // [#5216] Both halves are declared now. The action NAME comes from page
+          // metadata (`properties.createAction`, same bag that already owns
+          // `environmentsRoute` — the Cloud app owns its URLs and now its deep
+          // link too), and the ENCODING comes from `navRunActionHref`, which
+          // spells the param through `NAV_RUN_ACTION_PARAM`. What this retires is
+          // the hand-concatenated `?runAction=create_environment` literal: a
+          // private convention whose only definition was this template string
+          // and a matching literal in the toolbar.
+          <Button size="lg" onClick={() => navigate(navRunActionHref(envsRoute, createAction))}>
             <Plus className="mr-2 h-4 w-4" />
             {t('cloudOnboarding.createEnvironment')}
           </Button>

--- a/packages/app-shell/src/environment/EnvironmentListToolbar.tsx
+++ b/packages/app-shell/src/environment/EnvironmentListToolbar.tsx
@@ -58,12 +58,13 @@
  *     (reported back on cloud#1049 for the cloud seat).
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { SchemaRenderer, useCapabilityGate } from '@object-ui/react';
 import { actionRendersAt } from '@object-ui/types';
 import { Button, Skeleton } from '@object-ui/components';
 import { Plus } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
+import { useNavRunAction } from '../hooks/useNavRunAction';
 import {
   decideEnvironmentCta,
   upgradeDialogSpec,
@@ -74,52 +75,42 @@ import {
 const CREATE_ACTION = 'create_environment';
 
 /**
- * Deep-link support (#844): `?runAction=create_environment` on the
- * environments route auto-opens the create dialog once entitlements have
- * resolved — the welcome page's "Create your environment" CTA uses it so the
- * user doesn't land on the list and have to find the create button again.
- * The param is consumed exactly once (stripped from the URL on consumption)
- * so refresh / back don't re-open the dialog.
+ * Deep-link support (#844, re-based onto the DECLARED slot by objectui#5216):
+ * an object nav entry declaring `runAction: 'create_environment'` resolves to
+ * an environments href carrying `?runAction=`, and landing on it auto-opens the
+ * create dialog once entitlements have resolved — so the welcome page's "Create
+ * your environment" CTA lands the user IN the dialog instead of on the list,
+ * hunting for a second create button.
+ *
+ * Read-once / consume-once now lives in {@link useNavRunAction}, shared with the
+ * generic object list; this wrapper contributes only the environment-specific
+ * arming condition. What it retires: the bare `'runAction'` literal read off
+ * `window.location.search` and compared to a hard-coded action name — a private
+ * convention with a second copy at the producing end and no schema behind
+ * either.
  *
  * ## Arming is destructive — only arm when there is something to trigger (#4123)
  *
  * Consumption is modelled as "strip the param", so arming SPENDS a one-shot
  * user intent. Arm it when nothing can act on it and the intent is not merely
  * lost, it is unrecoverable: the URL no longer carries it, so a reload cannot
- * retry. That is why the caller passes a non-null `ctaKind` only once the
- * create action is actually on the bar — see `hasCreateAction` below. When it
- * is not, the honest degradation is to leave the URL alone: the next mount
- * that CAN act on the deep link still does (a reload, or the action arriving
- * with fresh metadata).
+ * retry. Hence both conjuncts below: the create action must actually be on the
+ * bar (`hasCreateAction`), AND entitlements must have resolved — `upgrade_...`
+ * routes to the upgrade dialog instead, and while loading we must not trigger
+ * an action whose meaning (prod vs dev create) isn't known yet. When either
+ * fails, the honest degradation is to leave the URL alone: the next mount that
+ * CAN act on the deep link still does.
+ *
+ * A requested name this toolbar does not answer to is the same "leave it alone"
+ * case — see `useNavRunAction` on why the client degrades quietly while the
+ * AUTHORING tier rejects the undefined reference loudly.
  */
-function useAutoRunCreate(ctaKind: string | null): boolean {
-  // Deliberately router-free (window.location + history.replaceState): the
-  // toolbar also renders in tests/hosts without a Router, and the param is a
-  // one-shot signal, not navigation state.
-  const [requested] = useState<boolean>(() => {
-    try {
-      return new URLSearchParams(window.location.search).get('runAction') === CREATE_ACTION;
-    } catch {
-      return false;
-    }
-  });
-  const consumed = useRef(false);
-  // Only meaningful once the entitlement state has resolved: `upgrade_...`
-  // routes to the upgrade dialog instead, and while loading we must not
-  // trigger an action whose meaning (prod vs dev create) isn't known yet.
-  const shouldRun = requested && !consumed.current && ctaKind != null;
-  useEffect(() => {
-    if (!shouldRun) return;
-    consumed.current = true;
-    try {
-      const url = new URL(window.location.href);
-      url.searchParams.delete('runAction');
-      window.history.replaceState(window.history.state, '', url);
-    } catch {
-      /* URL cleanup is cosmetic — never fail the trigger over it */
-    }
-  }, [shouldRun]);
-  return shouldRun;
+function useAutoRunCreate(hasCreateAction: boolean, ctaKind: string | null): boolean {
+  return (
+    useNavRunAction(
+      (requested) => requested === CREATE_ACTION && hasCreateAction && ctaKind != null,
+    ) !== null
+  );
 }
 
 /** Non-create toolbar actions, rendered through the normal bar in every state. */
@@ -174,7 +165,7 @@ export function EnvironmentListToolbar({ actions, entitlements, onUpgrade }: Pro
   // has actions" (#4123). The old predicate armed on `toolbarActions.length > 0`,
   // so a toolbar carrying any other action consumed `?runAction=create_environment`
   // and triggered nothing (measured: `urlParam=null execute=0`), unrecoverably.
-  const autoRunCreate = useAutoRunCreate(hasCreateAction ? ctaKind : null);
+  const autoRunCreate = useAutoRunCreate(hasCreateAction, ctaKind);
 
   // Deep-linked "create" while in the upgrade state opens the SAME upgrade
   // prompt — the honest answer to "create" here. In an effect, not render:

--- a/packages/app-shell/src/hooks/__tests__/useNavRunAction.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useNavRunAction.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `useNavRunAction` — the console-side consumer of the declared nav `runAction`
+ * slot (objectui#5216), and the ONE place the read-once / consume-once
+ * semantics live now that `EnvironmentListToolbar` and the generic object list
+ * both depend on them.
+ *
+ * The two behaviours worth pinning are the two that are destructive to get
+ * wrong: consuming SPENDS the intent (the param is stripped, so a reload cannot
+ * retry), and NOT consuming keeps it recoverable. #4123 is the record of what
+ * the first failure mode costs — `urlParam=null execute=0`, unrecoverable.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { NAV_RUN_ACTION_PARAM } from '@object-ui/layout';
+import { useNavRunAction, navRunActionHref } from '../useNavRunAction';
+
+const ROUTE = '/apps/cloud_control/sys_environment';
+
+function land(search: string): void {
+  window.history.replaceState({}, '', `${ROUTE}${search}`);
+}
+
+/** The param as the URL currently holds it — null once consumed. */
+function paramNow(): string | null {
+  return new URL(window.location.href).searchParams.get(NAV_RUN_ACTION_PARAM);
+}
+
+/** Render a probe that reports what the hook returned on each commit. */
+function probe(armed: (requested: string) => boolean) {
+  const seen: (string | null)[] = [];
+  function Probe() {
+    seen.push(useNavRunAction(armed));
+    return null;
+  }
+  const view = render(<Probe />);
+  return { seen, view };
+}
+
+beforeEach(() => {
+  window.history.replaceState({}, '', ROUTE);
+});
+
+describe('useNavRunAction — armed', () => {
+  it('returns the requested action name and consumes the param', async () => {
+    land(`?${NAV_RUN_ACTION_PARAM}=create_environment`);
+
+    const { seen } = probe(() => true);
+
+    expect(seen[0]).toBe('create_environment');
+    await waitFor(() => expect(paramNow()).toBeNull());
+  });
+
+  it('leaves the rest of the query string alone when it strips its own param', async () => {
+    land(`?tab=details&${NAV_RUN_ACTION_PARAM}=create_environment&q=prod`);
+
+    probe(() => true);
+
+    await waitFor(() => expect(paramNow()).toBeNull());
+    const q = new URL(window.location.href).searchParams;
+    expect(q.get('tab')).toBe('details');
+    expect(q.get('q')).toBe('prod');
+  });
+
+  it('re-renders do not re-fire it — the name survives the strip it caused', async () => {
+    land(`?${NAV_RUN_ACTION_PARAM}=create_environment`);
+
+    const { seen, view } = probe(() => true);
+    await waitFor(() => expect(paramNow()).toBeNull());
+    view.rerender(<div />);
+
+    // Every commit that saw it saw the SAME name: reading the name from state
+    // captured at mount is what keeps the post-strip render from losing it.
+    expect(seen.every((s) => s === 'create_environment')).toBe(true);
+  });
+
+  it('percent-encoded names arrive decoded, matching what resolveHref encoded', () => {
+    land(`?${NAV_RUN_ACTION_PARAM}=create%20environment`);
+
+    const { seen } = probe(() => true);
+
+    expect(seen[0]).toBe('create environment');
+  });
+});
+
+describe('useNavRunAction — not armed (arming is destructive, #4123)', () => {
+  it('an action name nothing on this surface answers to runs nothing AND keeps the URL', async () => {
+    // The client's half of the undefined-reference contract. `defineStack`
+    // rejects a `runAction` naming an undefined action at AUTHORING time
+    // ("deep-link references action '…' (via runAction)"), which is where the
+    // author can act on it. A client that arrives holding such a name must not
+    // spend the one-shot intent on nothing: it degrades quietly and leaves the
+    // param, so a later mount with fresher metadata can still honour it.
+    land(`?${NAV_RUN_ACTION_PARAM}=no_such_action`);
+
+    const { seen } = probe((requested) => requested === 'create_environment');
+
+    expect(seen.every((s) => s === null)).toBe(true);
+    // Not merely "did not run" — still RECOVERABLE.
+    await waitFor(() => expect(paramNow()).toBe('no_such_action'));
+  });
+
+  it('arms later when the predicate flips true, and only then consumes', async () => {
+    land(`?${NAV_RUN_ACTION_PARAM}=create_environment`);
+    let ready = false;
+
+    function Probe() {
+      const got = useNavRunAction(() => ready);
+      return <span data-testid="got">{got ?? 'none'}</span>;
+    }
+    const view = render(<Probe />);
+
+    expect(view.getByTestId('got').textContent).toBe('none');
+    expect(paramNow()).toBe('create_environment');
+
+    ready = true;
+    view.rerender(<Probe />);
+
+    expect(view.getByTestId('got').textContent).toBe('create_environment');
+    await waitFor(() => expect(paramNow()).toBeNull());
+  });
+
+  it('no param at all → null, and the predicate is never consulted', () => {
+    land('');
+    const armed = vi.fn(() => true);
+
+    const { seen } = probe(armed);
+
+    expect(seen.every((s) => s === null)).toBe(true);
+    expect(armed).not.toHaveBeenCalled();
+  });
+
+  it('an empty param value is not a request', () => {
+    land(`?${NAV_RUN_ACTION_PARAM}=`);
+
+    const { seen } = probe(() => true);
+
+    expect(seen.every((s) => s === null)).toBe(true);
+  });
+});
+
+describe('navRunActionHref — the non-nav producer uses the same wire format', () => {
+  it('appends the declared param to a bare route', () => {
+    expect(navRunActionHref(ROUTE, 'create_environment')).toBe(
+      `${ROUTE}?${NAV_RUN_ACTION_PARAM}=create_environment`,
+    );
+  });
+
+  it('joins with & when the route already carries a query', () => {
+    expect(navRunActionHref(`${ROUTE}?tab=all`, 'create_environment')).toBe(
+      `${ROUTE}?tab=all&${NAV_RUN_ACTION_PARAM}=create_environment`,
+    );
+  });
+
+  it('encodes the name', () => {
+    expect(navRunActionHref(ROUTE, 'a b')).toBe(`${ROUTE}?${NAV_RUN_ACTION_PARAM}=a%20b`);
+  });
+
+  it('round-trips into the hook — producer and consumer agree by construction', () => {
+    const href = navRunActionHref(ROUTE, 'create_environment');
+    window.history.replaceState({}, '', href);
+
+    const { seen } = probe(() => true);
+
+    expect(seen[0]).toBe('create_environment');
+  });
+});

--- a/packages/app-shell/src/hooks/useNavRunAction.ts
+++ b/packages/app-shell/src/hooks/useNavRunAction.ts
@@ -1,0 +1,105 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `useNavRunAction` — the console-side consumer of the DECLARED nav
+ * `runAction` slot (`ObjectNavItemSchema.runAction`, objectstack#7253).
+ *
+ * ## What it consumes
+ *
+ * `NavigationRenderer.resolveHref` encodes an object nav entry's declared
+ * `runAction` as {@link NAV_RUN_ACTION_PARAM} on the list href. When the shell
+ * lands on that list, this hook reads the name back through the SAME constant
+ * and hands it to the toolbar, which marks the matching action `autoTrigger` so
+ * it runs through the ordinary execute path — param dialogs, confirms and
+ * entitlement gates all still apply.
+ *
+ * ## Why this is a hook and not two `window.location` reads (#5216)
+ *
+ * It replaces a private convention: `EnvironmentListToolbar` used to read a
+ * bare `'runAction'` literal off `window.location.search` and compare it to a
+ * hard-coded `'create_environment'`, while `CloudOnboardingNext` hand-built the
+ * matching query string at the other end. Two literals, no schema, no registry
+ * — a second de-facto contract that `objectui validate` could not see and no
+ * gate could check. The name now has one definition and the VALUE comes from
+ * declared metadata, so the deep link is authored, validated and rendered
+ * through one contract.
+ *
+ * ## Arming is destructive — the #4123 rule, kept
+ *
+ * Consumption is modelled as "strip the param", so arming SPENDS a one-shot
+ * user intent: once stripped, a reload cannot retry it. So the caller passes an
+ * `armed` predicate and the hook consumes only when it answers true — i.e. only
+ * when there is genuinely something to run. This is also the client's answer to
+ * a name no action declares: `defineStack`'s cross-reference walk rejects those
+ * at AUTHORING time ("deep-link references action '…' (via runAction)"), and a
+ * client that somehow arrives holding one runs nothing AND leaves the URL
+ * alone, so a later mount with fresher metadata can still honour it. Degrading
+ * quietly is right here precisely because the loud rejection already happened
+ * upstream, where the author could act on it.
+ *
+ * Router-free on purpose (`window.location` + `history.replaceState`): the
+ * toolbars that call this also render in tests and hosts without a Router, and
+ * the param is a one-shot signal rather than navigation state.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { NAV_RUN_ACTION_PARAM } from '@object-ui/layout';
+
+/**
+ * Read the declared deep link once, and consume it once `armed` says something
+ * can act on it.
+ *
+ * @param armed Called with the requested action name; return `true` only when
+ *   that action is actually present and runnable on this surface. Returning
+ *   `false` leaves the URL untouched — the intent stays recoverable.
+ * @returns The requested action name while it is armed and unconsumed, else
+ *   `null`. Callers use it to mark exactly that action `autoTrigger: true`.
+ */
+export function useNavRunAction(armed: (requested: string) => boolean): string | null {
+  // Read at mount, from the URL as it was on arrival. `useState`'s initializer
+  // (not a ref assignment) so a re-render caused by the strip below cannot
+  // re-read an already-emptied search string and lose the name mid-flight.
+  const [requested] = useState<string | null>(() => {
+    try {
+      const raw = new URLSearchParams(window.location.search).get(NAV_RUN_ACTION_PARAM);
+      return raw && raw !== '' ? raw : null;
+    } catch {
+      return null;
+    }
+  });
+  const consumed = useRef(false);
+  const shouldRun = requested !== null && !consumed.current && armed(requested);
+  useEffect(() => {
+    if (!shouldRun) return;
+    consumed.current = true;
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.delete(NAV_RUN_ACTION_PARAM);
+      window.history.replaceState(window.history.state, '', url);
+    } catch {
+      /* URL cleanup is cosmetic — never fail the trigger over it */
+    }
+  }, [shouldRun]);
+  return shouldRun ? requested : null;
+}
+
+/**
+ * Build a list-surface deep link that runs `actionName` on arrival.
+ *
+ * For the one producer that is NOT a nav item: a page widget whose target route
+ * came from page metadata rather than from a `NavigationItem` (see
+ * `CloudOnboardingNext`). It still goes through {@link NAV_RUN_ACTION_PARAM},
+ * so there is no second spelling of the wire format — only a second, equally
+ * declared, source for the action NAME.
+ */
+export function navRunActionHref(route: string, actionName: string): string {
+  if (!actionName) return route;
+  const sep = route.includes('?') ? '&' : '?';
+  return `${route}${sep}${NAV_RUN_ACTION_PARAM}=${encodeURIComponent(actionName)}`;
+}

--- a/packages/app-shell/src/urlParams.ts
+++ b/packages/app-shell/src/urlParams.ts
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { NAV_RUN_ACTION_PARAM } from '@object-ui/layout';
+
 /**
  * urlParams — the single registry of RESERVED console URL query params
  * (objectui#2269 P3; ADR-0054 C3 "URL-addressable state").
@@ -61,6 +63,14 @@
  * Page-scoped params (`q`, `limit`, `offset`, `view`, `type`, `review`,
  * `package`, …) belong to their page's own contract and are NOT reserved
  * here — but they must not collide with the names above.
+ *
+ * One reserved param is DEFINED ELSEWHERE and only re-exported here:
+ * `runAction` (see {@link NAV_RUN_ACTION_PARAM}). It is the wire encoding of a
+ * spec-declared nav slot, written by `@object-ui/layout`'s `resolveHref`, which
+ * sits below this package — so the constant lives there and this registry
+ * references it rather than restating it. Restating would give the console's
+ * hottest collision check a second spelling to drift from, which is the exact
+ * failure this file exists to prevent.
  */
 
 /**
@@ -107,6 +117,18 @@ export const KEYBOARD_SHORTCUTS_PARAM = 'shortcuts';
 export const RECORD_TRAIL_PARAM = 'from';
 
 /**
+ * Auto-run deep link on an object list (`?runAction=<actionName>`) — the wire
+ * encoding of the spec-declared `ObjectNavItemSchema.runAction` nav slot.
+ *
+ * Re-exported, not restated: `@object-ui/layout`'s `resolveHref` is the only
+ * writer and owns the definition. Listed in {@link RESERVED_URL_PARAMS} below
+ * so the collision check is complete — before objectui#5216 it was a bare
+ * literal at both ends and this registry did not know the name existed.
+ * Consume it with `useNavRunAction`, never by reading the raw string.
+ */
+export { NAV_RUN_ACTION_PARAM };
+
+/**
  * All reserved params, for collision checks (e.g. a lint or a dev-time
  * assertion that a page-scoped param doesn't shadow the console contract).
  */
@@ -119,6 +141,7 @@ export const RESERVED_URL_PARAMS: readonly string[] = [
   COMMAND_PALETTE_PARAM,
   KEYBOARD_SHORTCUTS_PARAM,
   RECORD_TRAIL_PARAM,
+  NAV_RUN_ACTION_PARAM,
 ];
 
 /**

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -75,6 +75,8 @@ import { ActionProvider, useNavigationOverlay, SchemaRenderer, useActionTextLoca
 import type { RelatedRecordActionsValue, RelatedRecordHandlers } from '@object-ui/react';
 import { toast } from 'sonner';
 import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
+import { useNavRunAction } from '../hooks/useNavRunAction';
+import { actionRendersAt } from '@object-ui/types';
 import { useEnvironmentEntitlements } from '../environment/useEnvironmentEntitlements';
 import { EnvironmentListToolbar } from '../environment/EnvironmentListToolbar';
 
@@ -926,6 +928,35 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const localizedToolbarActions = useMemo(
         () => (objectDef.actions || []).map((a: any) => localizeActionTexts(objectDef.name, a)),
         [objectDef, localizeActionTexts],
+    );
+
+    // [#5216] The DECLARED nav `runAction` slot, consumed generically.
+    // An object nav entry declaring `runAction: '<name>'` resolves (via
+    // `resolveHref`) to this list's href carrying `?runAction=`; landing here
+    // runs that action once, through the ordinary execute path.
+    //
+    // Arm only on an action THIS toolbar actually renders — `list_toolbar` is
+    // the slot's surface, so a name that only exists at `record_header` cannot
+    // be triggered from here and must not spend the one-shot intent (#4123).
+    // `sys_environment` is excluded because `EnvironmentListToolbar` owns the
+    // arming there: it must additionally wait for entitlements to resolve, and
+    // two consumers of one param would race to strip it.
+    const navRunAction = useNavRunAction((requested) =>
+        !isEnvironmentList &&
+        localizedToolbarActions.some(
+            (a: any) => a?.name === requested && actionRendersAt(a, 'list_toolbar'),
+        ),
+    );
+    // Mark exactly the requested action `autoTrigger`, leaving every other
+    // action's identity untouched so the bar's ordering/overflow is unchanged.
+    const toolbarActionsWithDeepLink = useMemo(
+        () =>
+            navRunAction === null
+                ? localizedToolbarActions
+                : localizedToolbarActions.map((a: any) =>
+                      a?.name === navRunAction ? { ...a, autoTrigger: true } : a,
+                  ),
+        [localizedToolbarActions, navRunAction],
     );
 
     // Resolve which generic CRUD affordances belong in the toolbar for
@@ -2291,7 +2322,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                       <SchemaRenderer schema={{
                         type: 'action:bar',
                         location: 'list_toolbar',
-                        actions: localizedToolbarActions,
+                        actions: toolbarActionsWithDeepLink,
                         size: 'sm',
                         variant: 'outline',
                         // On mobile, collapse all schema-driven toolbar actions

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -467,6 +467,51 @@ function applyNavTemplate(
 }
 
 /**
+ * The wire encoding of the declared `runAction` nav slot — ONE definition,
+ * sited with `resolveHref` because that is the only thing that writes it.
+ *
+ * `ObjectNavItemSchema.runAction` (objectstack#7253) declares WHICH action an
+ * object nav entry auto-runs on arrival; the URL is how that declaration
+ * survives the navigation, because the list surface mounts in a fresh render
+ * tree with nothing but the location to read. Naming the param after the slot
+ * is deliberate: the slot owns the name, so producer and consumer cannot drift.
+ *
+ * Before this constant existed, the name was a bare `'runAction'` literal
+ * hand-written at both ends — a private convention no schema declared, so
+ * `objectui validate` could not see it, `RESERVED_URL_PARAMS` did not list it,
+ * and a page could have repurposed the name with nothing to catch the
+ * collision. Import this; never re-spell it. `@object-ui/app-shell`'s
+ * `urlParams` re-exports it into the reserved registry rather than restating
+ * it, so there is still exactly one definition.
+ */
+export const NAV_RUN_ACTION_PARAM = 'runAction';
+
+/**
+ * Encode a declared `runAction` onto a LIST-surface href.
+ *
+ * Applied to the two list landings (`filters` slice and bare/named view) and
+ * deliberately NOT to the record deep-link above it: the spec defines the slot
+ * as running "on arrival at the object's list surface", and a `recordId` entry
+ * arrives at a record detail page, which has no list toolbar to answer to it.
+ * Encoding it there would put an unanswerable param on the URL that the
+ * consumer would then have to decide whether to strip — a one-shot intent spent
+ * on a surface that never had the action. The installed `@objectstack/spec@17.0.0`
+ * still ACCEPTS `runAction` + `recordId` together (measured — the parse-level
+ * exclusivity the card describes is not in this pin), so this precedence is
+ * load-bearing rather than merely defensive.
+ *
+ * An empty string is treated as absent: the spec's `z.string()` accepts `''`
+ * (measured), and no action can be named it, so encoding it would produce a
+ * param that arms nothing.
+ */
+function withRunAction(href: string, item: NavigationItem): string {
+  const name = (item as { runAction?: unknown }).runAction;
+  if (typeof name !== 'string' || name === '') return href;
+  const sep = href.includes('?') ? '&' : '?';
+  return `${href}${sep}${NAV_RUN_ACTION_PARAM}=${encodeURIComponent(name)}`;
+}
+
+/**
  * Resolve a NavigationItem to an absolute href (relative to `basePath`).
  *
  * Single source of truth for nav → URL mapping across the shell. Other
@@ -514,9 +559,18 @@ export function resolveHref(
           if (resolved !== null) usp.set(`filter[${field}]`, resolved);
         }
         const qs = usp.toString();
-        return { href: qs ? `${objectPath}/data?${qs}` : `${objectPath}/data`, external: false };
+        return {
+          href: withRunAction(qs ? `${objectPath}/data?${qs}` : `${objectPath}/data`, item),
+          external: false,
+        };
       }
-      return { href: item.viewName ? `${objectPath}/view/${item.viewName}` : objectPath, external: false };
+      return {
+        href: withRunAction(
+          item.viewName ? `${objectPath}/view/${item.viewName}` : objectPath,
+          item,
+        ),
+        external: false,
+      };
     }
     case 'dashboard':
       return { href: item.dashboardName ? `${basePath}/dashboard/${item.dashboardName}` : '#', external: false };

--- a/packages/layout/src/__tests__/resolveHref.runAction.test.ts
+++ b/packages/layout/src/__tests__/resolveHref.runAction.test.ts
@@ -1,0 +1,161 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The DECLARED nav `runAction` slot → URL (objectui#5216).
+ *
+ * `ObjectNavItemSchema.runAction` (objectstack#7253, merged pre-GA and present
+ * in the installed `@objectstack/spec@17.0.0` — see the PR body's Zone 0 probe)
+ * declares which action an object nav entry auto-runs on arrival at its list
+ * surface. `resolveHref` is the only writer of that intent onto the URL, and
+ * {@link NAV_RUN_ACTION_PARAM} is the only spelling of the param name.
+ *
+ * This replaces a private `?runAction=` string convention: a bare literal
+ * hand-written in `CloudOnboardingNext` and matched by another bare literal in
+ * `EnvironmentListToolbar`, declared by no schema, listed in no registry, and
+ * therefore invisible to `objectui validate` and to the reserved-param
+ * collision check. The retirement is pinned in
+ * `packages/app-shell/src/__tests__/navRunAction.privateConventionRetired.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { NavigationItem } from '@object-ui/types';
+import { resolveHref, resolveActiveNavItem, NAV_RUN_ACTION_PARAM } from '../NavigationRenderer';
+
+const BASE = '/apps/cloud_control';
+
+function objectItem(extra: Partial<NavigationItem> = {}): NavigationItem {
+  return { id: 'nav_env', type: 'object', label: 'Environments', objectName: 'sys_environment', ...extra };
+}
+
+/** The declared deep link as it appears on the resolved href, or null. */
+function runActionOf(href: string): string | null {
+  const i = href.indexOf('?');
+  return new URLSearchParams(i >= 0 ? href.slice(i + 1) : '').get(NAV_RUN_ACTION_PARAM);
+}
+
+describe('resolveHref — declared `runAction` slot (#5216)', () => {
+  it('the param name is the slot name, so producer and consumer cannot drift', () => {
+    expect(NAV_RUN_ACTION_PARAM).toBe('runAction');
+  });
+
+  // ── The positive case: a declared slot reaches the URL ────────────────────
+  it('a bare object item declaring runAction lands on the list carrying the deep link', () => {
+    const { href, external } = resolveHref(objectItem({ runAction: 'create_environment' }), BASE);
+
+    expect(href).toBe(`${BASE}/sys_environment?${NAV_RUN_ACTION_PARAM}=create_environment`);
+    expect(external).toBe(false);
+  });
+
+  it('a named view still lands on that view, carrying the deep link', () => {
+    const { href } = resolveHref(
+      objectItem({ viewName: 'active', runAction: 'create_environment' }),
+      BASE,
+    );
+
+    expect(href.split('?')[0]).toBe(`${BASE}/sys_environment/view/active`);
+    expect(runActionOf(href)).toBe('create_environment');
+  });
+
+  it('a filters slice keeps its filter params AND carries the deep link', () => {
+    const { href } = resolveHref(
+      objectItem({ filters: { status: 'active' }, runAction: 'create_environment' }),
+      BASE,
+    );
+
+    expect(href.split('?')[0]).toBe(`${BASE}/sys_environment/data`);
+    const q = new URLSearchParams(href.slice(href.indexOf('?') + 1));
+    // The `&` join, not a second `?` — the filters branch already opened the
+    // query string, so a naive append would produce an unparseable href.
+    expect(q.get('filter[status]')).toBe('active');
+    expect(q.get(NAV_RUN_ACTION_PARAM)).toBe('create_environment');
+  });
+
+  it('an action name needing escaping is encoded, not concatenated raw', () => {
+    const { href } = resolveHref(objectItem({ runAction: 'a b&c=d' }), BASE);
+
+    expect(href).toContain(`${NAV_RUN_ACTION_PARAM}=a%20b%26c%3Dd`);
+    // Round-trips through a real parser — the point of encoding it.
+    expect(runActionOf(href)).toBe('a b&c=d');
+  });
+
+  // ── The list-surface boundary ─────────────────────────────────────────────
+  it('a recordId entry resolves to the RECORD page and carries no deep link', () => {
+    // The spec defines the slot as running on arrival at the object's LIST
+    // surface; a record detail page has no list toolbar to answer to it, so
+    // encoding it there would put a one-shot intent on a surface that can only
+    // spend it for nothing. Load-bearing rather than defensive: the installed
+    // 17.0.0 pin still ACCEPTS `runAction` + `recordId` together, so nothing
+    // upstream stops this pair from being authored.
+    const { href } = resolveHref(
+      objectItem({ recordId: 'env_1', runAction: 'create_environment' }),
+      BASE,
+    );
+
+    expect(href).toBe(`${BASE}/sys_environment/record/env_1`);
+    expect(runActionOf(href)).toBeNull();
+  });
+
+  it('an UNRESOLVED recordId template falls back to the list — and the deep link comes back with it', () => {
+    // The existing fallback: an unresolvable template yields the list view
+    // rather than a dead link. That IS the list surface, so the slot applies.
+    const { href } = resolveHref(
+      objectItem({ recordId: '{current_user_id}', runAction: 'create_environment' }),
+      BASE,
+      {},
+    );
+
+    expect(href.split('?')[0]).toBe(`${BASE}/sys_environment`);
+    expect(runActionOf(href)).toBe('create_environment');
+  });
+
+  // ── Absence ──────────────────────────────────────────────────────────────
+  it('an item declaring no runAction is byte-identical to before', () => {
+    expect(resolveHref(objectItem(), BASE).href).toBe(`${BASE}/sys_environment`);
+    expect(resolveHref(objectItem({ viewName: 'active' }), BASE).href).toBe(
+      `${BASE}/sys_environment/view/active`,
+    );
+  });
+
+  it('an empty runAction is treated as absent, not encoded as an empty param', () => {
+    // `z.string()` accepts `''` (measured against the installed pin), and no
+    // action can be named it — an empty param would arm nothing while looking
+    // like a deep link.
+    expect(resolveHref(objectItem({ runAction: '' }), BASE).href).toBe(`${BASE}/sys_environment`);
+  });
+
+  it('non-object nav types never grow the param', () => {
+    const dash = resolveHref(
+      { id: 'd', type: 'dashboard', label: 'D', dashboardName: 'sales', runAction: 'x' } as NavigationItem,
+      BASE,
+    );
+    expect(dash.href).toBe(`${BASE}/dashboard/sales`);
+  });
+});
+
+describe('the deep link does not disturb sidebar active-state (#2272 inverse)', () => {
+  // `itemMatchScore`'s object branch scores against the PATHNAME and the
+  // `filter[...]` params only, so a query param it does not read cannot change
+  // the election. Pinned because `resolveHref` and `resolveActiveNavItem` are
+  // documented as round-trip inverses — a writer that broke the reader would
+  // light up the wrong sidebar row, or none.
+  const plain = objectItem({ id: 'nav_plain' });
+  const deepLinked = objectItem({ id: 'nav_deep', runAction: 'create_environment' });
+
+  it('a deep-linked item still wins its own list route', () => {
+    const active = resolveActiveNavItem([deepLinked], `${BASE}/sys_environment`, '', BASE);
+    expect(active?.id).toBe('nav_deep');
+  });
+
+  it('and scores identically to the same item without the slot', () => {
+    const a = resolveActiveNavItem([plain], `${BASE}/sys_environment`, '', BASE);
+    const b = resolveActiveNavItem([deepLinked], `${BASE}/sys_environment`, '', BASE);
+    expect(a?.id).toBe('nav_plain');
+    expect(b?.id).toBe('nav_deep');
+  });
+});

--- a/packages/types/src/app.ts
+++ b/packages/types/src/app.ts
@@ -146,6 +146,33 @@ export interface NavigationItem {
    */
   filters?: SpecObjectNavItem['filters'];
 
+  /**
+   * Auto-run deep link (for type: 'object') — the name of an action on the
+   * target object that the list surface runs ONCE on arrival, through the same
+   * execute path as a click (so param dialogs, confirms and entitlement gates
+   * all still apply). Use for "take me straight into create" entries: a
+   * welcome-page CTA that should land the user IN the create dialog rather than
+   * on the list, hunting for a second button.
+   *
+   * Landing surface only: `runAction` describes the LIST surface, so it is
+   * ignored when `recordId` wins the precedence chain and the entry resolves to
+   * a record detail page instead. `NavigationRenderer.resolveHref` encodes it
+   * as the reserved `?runAction=` search param — {@link NAV_RUN_ACTION_PARAM}
+   * in `@object-ui/layout` is that param name's ONE definition, and the list
+   * toolbar reads it back through the same constant.
+   *
+   * The reference is validated at AUTHORING time, not here: `defineStack`'s
+   * cross-reference walk rejects a name no action declares ("deep-link
+   * references action '…' (via runAction)"). A client that arrives holding a
+   * name no action on the toolbar answers to runs nothing and — deliberately —
+   * does not consume the param, so a reload with fresher metadata can still
+   * honour it (the #4123 "arming is destructive" rule).
+   *
+   * Shape derived from the spec's object-nav variant (#3177); declared by
+   * `ObjectNavItemSchema.runAction` since objectstack#7253.
+   */
+  runAction?: SpecObjectNavItem['runAction'];
+
   /** Target dashboard name (for type: 'dashboard') */
   dashboardName?: string;
 

--- a/packages/types/src/zod/app.zod.ts
+++ b/packages/types/src/zod/app.zod.ts
@@ -55,6 +55,11 @@ export const NavigationItemSchema: z.ZodType<any> = z.lazy(() => z.object({
   recordId: z.string().optional().describe('Target record id (type: object) — opens a single record. Supports template variables {current_user_id}, {current_org_id}.'),
   recordMode: z.enum(['view', 'edit']).optional().describe('Record opening mode when recordId is set (default: view)'),
   filters: z.record(z.string(), z.string()).optional().describe('URL filter conditions (type: object) — targets the /:objectName/data bare surface via filter[<field>]=<value> params instead of a saved view. Values support {current_user_id}/{current_org_id}. Precedence: recordId → filters → viewName.'),
+  // Declared here for the same reason `requiresObject` / `actionDef` are: this
+  // schema STRIPS unknown keys, so an entry deep-linking into an action would
+  // have validated clean through `objectui validate` with the deep link thrown
+  // away (the objectstack#4115 failure class). Spec: `ObjectNavItemSchema.runAction`.
+  runAction: z.string().optional().describe('Auto-run deep link (type: object) — name of an action on the target object that the list surface runs once on arrival. Ignored when recordId wins precedence (that resolves to a record page, not the list). Encoded as the reserved ?runAction= search param.'),
   dashboardName: z.string().optional().describe('Target dashboard name (type: dashboard)'),
   pageName: z.string().optional().describe('Target page name (type: page)'),
   reportName: z.string().optional().describe('Target report name (type: report)'),


### PR DESCRIPTION
Fixes #5216

## Zone 0 — the premise gate, measured

The blocker objectstack#7253 merged 2026-08-10, pre-GA, so the declared slot was *expected* in the `17.0.0` pin. Measured against the **installed** package, with counter-probes through the same import:

```
@objectstack/spec (installed) : 17.0.0
import path                   : @objectstack/spec/ui -> ObjectNavItemSchema

PROBE     runAction  present  : true
CONTROL+  recordId   present  : true
CONTROL+  objectName present  : true
CONTROL-  zzNotAKey  present  : false
```

The counter-probes discriminate: a known-present key reads `true`, a known-absent key reads `false`, so the `true` on `runAction` is a reading and not an artefact of a wrong import path. **Premise valid — proceeded.**

Two further measurements against the same pin, both of which changed the implementation:

- `ObjectNavItemSchema` **accepts** `runAction` together with `recordId`. The card's description of a parse-level exclusivity rule is **not true of this pin**, so the list-surface-only precedence below is load-bearing rather than merely defensive.
- A misspelling is rejected with did-you-mean (`runActionn` produces `unrecognized_keys` ... "Did you mean ... runAction?"), and `runAction: ''` is accepted — hence the empty-string-is-absent handling.

## What the private convention could express that the declared slot cannot

**Nothing, on the nav path.** Measured: the string was produced in exactly one place (`CloudOnboardingNext.tsx`, hand-concatenating onto a route from page metadata) and consumed in exactly one (`EnvironmentListToolbar.tsx`, comparing a bare `'runAction'` literal against a hard-coded `create_environment`). It was a **single-value private protocol between two files** — strictly less expressive than the declared slot, which carries any action name on any object.

The one genuine gap is that the welcome CTA is **not a nav item**: it is a page widget whose target route arrives as page metadata, so no `NavigationItem` exists to hang a slot on. That is not a fork, because the slot's contribution is the **param name and encoding**, and the widget now takes both from it while sourcing the action *name* from its own declared page metadata (`properties.createAction`). One contract, two declared producers — not two contracts. **No spec change is needed and none is made (Clause-2: no).**

**No compatibility shim.** No producer outside this repo emits the string: cloud supplies the bare `environmentsRoute` property and the query was concatenated here, so producer and consumer both moved in this PR.

## Changes

- **`packages/types`** — `NavigationItem.runAction`, derived from the spec's object-nav variant per the #3177 burn-down. Also declared in objectui's own nav Zod schema: that schema strips unknown keys, so before this an entry carrying a deep link validated clean through `objectui validate` **with the deep link discarded** (the objectstack#4115 failure class).
- **`packages/layout`** — `NAV_RUN_ACTION_PARAM` is the param name's one definition, sited with `resolveHref`, its only writer. `resolveHref` encodes the slot onto the **list** landings only (bare / named view / filters slice, joining with `&` where a query already exists). A `recordId` entry resolves to a record page, which has no list toolbar to answer it, so encoding there would spend a one-shot intent on a surface that never had the action.
- **`packages/app-shell`** — `useNavRunAction` is the single implementation of read-once / consume-once. The deep link is now honoured on **every** object list, not just the environments list. `urlParams` registers the name by **re-export**, so the reserved-param collision check is complete without a second spelling.

Arming stays destructive-aware (#4123): the action must actually be present at `list_toolbar`. **A name no action answers to runs nothing and deliberately leaves the URL intact**, so a later mount with fresher metadata can still honour it — the loud rejection of an undefined reference already happened upstream at authoring time, where the author can act on it (`defineStack`: "deep-link references action '...' (via runAction)").

## Tests and reverse-verification

Run from the repo root, at `f1eb6dafe`.

`vitest run packages/layout/ packages/types/ packages/app-shell/... packages/core/src/actions/` — **407 files, 4299 passed, 1 skipped, exit 0**. `type-check` on all three packages green; `eslint` on the diff: 0 errors. `check:control-bytes`, `check:self-import`, `check:esm-specifiers`, `check:phantom-deps`, `check:spec-symbols`, `check-changeset-presence`, `check-changeset-no-major`: all green.

**No build artifact sits between the edit and any vitest leg** — `vitest.config.mts` aliases `@object-ui/layout` / `types` / `app-shell` to `src`, so an ablation cannot go falsely green through a stale `dist`. The `type-check` leg *does* read `dist/*.d.ts`; the dependency closure was built first and the artifact was confirmed to carry the new export (`packages/layout/dist/NavigationRenderer.d.ts` declares `NAV_RUN_ACTION_PARAM`).

Two legs, predicted before running:

| Leg | Predicted | Observed |
|---|---|---|
| Revert the `withRunAction` application in `resolveHref` (constant kept, so failures are assertion-level) | 5 red in `resolveHref.runAction.test.ts` — the four positive encodings plus the unresolved-template fallback; absence cases stay green; other two files green | **exactly those 5 red, 28 green** |
| Restore `EnvironmentListToolbar` + `CloudOnboardingNext` to `origin/main` | 4 red in the retirement pin (2 of 4 `it.each` file cases + 2 named cases); ObjectView/hook cases and all "one definition" cases green; existing deep-link suites green | **exactly those 4 red, 134 green** |

Leg 2's second half is the point of the retirement pin: the *existing* deep-link suites pass happily against the restored private convention, so they cannot be what retires it.

## Cross-repo follow-up (not in this PR)

Step 4 of the card — flipping the framework liveness-ledger row `apps.navigation.children.runAction` from `planned`/`authorWarn` to `live` — lands in `objectstack`. The evidence pointer that row needs is `packages/layout/src/NavigationRenderer.tsx` (`resolveHref` / `NAV_RUN_ACTION_PARAM`) for the producer and `packages/app-shell/src/hooks/useNavRunAction.ts` for the consumer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_