### PR TITLE
fix(app-shell): DraftChangesPanel addresses /meta item routes in the singular

### DIFF
--- a/.changeset/draft-changes-meta-singular-5356.md
+++ b/.changeset/draft-changes-meta-singular-5356.md
@@ -12,12 +12,12 @@ pre-#7894 plural spelling made the Console request `/api/v1/meta/objects` and
 singular once, at the boundary where the feed becomes panel entries, and both
 item routes, the grouping and the type heading read that one value.
 
-The fold mirrors `@objectstack/spec/shared`'s `META_URL_TO_SINGULAR` /
-`canonicalMetaUrlType` (the `/meta`-specific contract, not the manifest map),
-with a parity test pinning the mirror against the real export key for key; the
-table is mirrored rather than imported because the import measures +60.1 KB
-gzipped on the console's eager graph, which lazy loading cannot move. It is a
-mapping, never a suffix rule: `capabilities` folds to `capability`.
+The fold is `@objectstack/spec/shared`'s `canonicalMetaUrlType` — the
+`/meta`-specific spelling contract (objectstack#7894, #8424), not the
+manifest-level `pluralToSingular`, which is missing `field`, `seed`,
+`external_catalog` and `translation` entirely. It is a mapping, never a suffix
+rule: `capabilities` folds to `capability`, where a `replace(/s$/, '')` would
+emit `capabilitie`.
 
 Emit-side only. Plural residue already stored on the server is untouched — no
 write path, no migration, and nothing about what the server accepts changes.

--- a/.changeset/draft-changes-meta-singular-5356.md
+++ b/.changeset/draft-changes-meta-singular-5356.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/app-shell': patch
+---
+
+DraftChangesPanel addresses `/meta` item routes in the singular
+
+The pending-changes panel is data-driven: it takes each draft's `type` straight
+from the `/api/v1/meta/_drafts` feed's stored rows, so a row stored under a
+pre-#7894 plural spelling made the Console request `/api/v1/meta/objects` and
+`/api/v1/meta/objects/ticket`. The `/meta` type segment is singular — always
+(objectstack#9180) — so the stored spelling is now folded to its canonical
+singular once, at the boundary where the feed becomes panel entries, and both
+item routes, the grouping and the type heading read that one value.
+
+The fold mirrors `@objectstack/spec/shared`'s `META_URL_TO_SINGULAR` /
+`canonicalMetaUrlType` (the `/meta`-specific contract, not the manifest map),
+with a parity test pinning the mirror against the real export key for key; the
+table is mirrored rather than imported because the import measures +60.1 KB
+gzipped on the console's eager graph, which lazy loading cannot move. It is a
+mapping, never a suffix rule: `capabilities` folds to `capability`.
+
+Emit-side only. Plural residue already stored on the server is untouched — no
+write path, no migration, and nothing about what the server accepts changes.

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -33,6 +33,22 @@ import {
   SheetTitle,
 } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
+// The `/meta` URL-spelling fold (objectstack#7894, #8424), applied once in
+// `listPendingDrafts` below. Measured cost of this import on the console's
+// EAGER graph — the panel is reached statically from ConsoleLayout through
+// DraftPreviewBar — is +213.4 KB minified / +60.1 KB gzipped, on a graph that
+// already holds the spec entries app-shell imports statically (`/ui`,
+// `/kernel`): each published spec subpath is a self-contained bundle and
+// nothing tree-shakes it (`@objectstack/spec` declares no `sideEffects`).
+// Lazy-loading it here would NOT move those bytes — the console's
+// `vendor-objectstack` chunk group claims every `@objectstack/*` module except
+// `@objectstack/lint`, and that group's chunk is a static import of the app
+// entry (objectui#5266). Tracked in objectui#5359.
+//
+// ⛔ Do not "optimize" this into a local copy of the spelling table: a
+// spec-named local declaration is what `scripts/check-spec-symbol-derivation.mjs`
+// refuses, and a faithful copy is exactly the fork that guard exists to prevent.
+import { canonicalMetaUrlType } from '@objectstack/spec/shared';
 import { diffFields } from '../views/metadata-admin/previews/object-fields-io';
 
 export interface DraftChangeEntry {
@@ -48,109 +64,6 @@ export interface DraftChangeEntry {
   packageId: string | null;
   /** `new` = no published version; `update` = overwrites one; undefined = probing. */
   kind?: 'new' | 'update';
-}
-
-/**
- * `/meta/:type` URL spellings the platform accepts → the canonical singular.
- *
- * ## What this mirrors
- *
- * `@objectstack/spec/shared` owns this contract and publishes it as
- * `META_URL_TO_SINGULAR` with the fold `canonicalMetaUrlType`
- * (objectstack#7894, #8424) — the ONE fold for a `/meta` type segment, and
- * deliberately NOT `PLURAL_TO_SINGULAR`: that map's keys are `defineStack()`
- * collection properties, and the four registry types with no stack-level
- * collection (`field`, `seed`, `external_catalog`, `translation`) are absent
- * from it. That absence is the hole #7894 closed, and it is also how the
- * at-rest residue this panel must fold got written: `PUT /meta/fields/...`
- * fell through to the plugin-type path and minted rows under `type='fields'`
- * while `PUT /meta/field/...` was refused. The keys below are therefore
- * exactly the spellings such residue can carry.
- *
- * ## Why it is a mirror and not an import
- *
- * Importing the real fold is the drift-proof spelling and would be the default.
- * Measured with the repo's esbuild on a graph that already holds the
- * `@objectstack/spec` entries app-shell reaches statically (`/ui`, `/kernel`),
- * adding `@objectstack/spec/shared` costs **+213.4 KB minified / +60.1 KB
- * gzipped** (1289.8 → 1503.2 KB min): every published spec subpath is a
- * self-contained bundle, so `/shared` re-ships registry and schema modules the
- * other entries already carry, and nothing tree-shakes them
- * (`@objectstack/spec` declares no `sideEffects`).
- *
- * Those bytes would be EAGER, and laziness cannot move them. This panel is
- * reached statically from `ConsoleLayout` (→ `DraftPreviewBar` → here), and the
- * console's `vendor-objectstack` `advancedChunks` group claims every
- * `@objectstack/*` module except `@objectstack/lint`, with that group's chunk a
- * static import of the app entry — so an `await import()` here would be folded
- * into the eager closure exactly as objectui#5266 documents for the linter.
- * That is the trade `postureHasOrgWall` (`hooks/useTenancyPosture.ts`) already
- * refused at +237 KB: a quarter megabyte on every console page load, for every
- * user, to spell a fold only an admin's pending-changes panel performs.
- *
- * The drift risk that an import would have removed is paid at TEST time
- * instead, the same way: `__tests__/DraftChangesPanel.test.tsx` imports the
- * real `META_URL_TO_SINGULAR` / `canonicalMetaUrlType` and asserts this table
- * equals it key for key, so a metadata type declared, renamed or respelled
- * upstream fails CI here rather than silently emitting a plural route. Tests
- * are not bundled; that assertion is free.
- *
- * ⛔ Never replace this table with a suffix rule. `capabilities` → `capability`
- * is a mapping, not a `replace(/s$/, '')` (which yields `capabilitie`), and
- * upstream refuses to contain such a "spelling GUESSER" at the boundary for
- * that reason. Fold, or leave alone — never guess.
- */
-export const META_URL_TO_SINGULAR: Readonly<Record<string, string>> = Object.freeze({
-  objects: 'object',
-  apps: 'app',
-  pages: 'page',
-  dashboards: 'dashboard',
-  reports: 'report',
-  datasets: 'dataset',
-  actions: 'action',
-  themes: 'theme',
-  flows: 'flow',
-  jobs: 'job',
-  positions: 'position',
-  permissions: 'permission',
-  capabilities: 'capability',
-  sharingRules: 'sharing_rule',
-  apis: 'api',
-  webhooks: 'webhook',
-  agents: 'agent',
-  tools: 'tool',
-  skills: 'skill',
-  ragPipelines: 'rag_pipeline',
-  hooks: 'hook',
-  mappings: 'mapping',
-  analyticsCubes: 'analytics_cube',
-  connectors: 'connector',
-  datasources: 'datasource',
-  views: 'view',
-  emailTemplates: 'email_template',
-  email_templates: 'email_template',
-  docs: 'doc',
-  books: 'book',
-  fields: 'field',
-  seeds: 'seed',
-  external_catalogs: 'external_catalog',
-  externalCatalogs: 'external_catalog',
-  translations: 'translation',
-});
-
-/**
- * Fold a stored metadata type to the spelling `/meta` routes are addressed in.
- * Returns the input unchanged when it is already canonical, or when it is a
- * plugin-registered kind (which has no plural spelling of its own) — mirroring
- * `canonicalMetaUrlType` from `@objectstack/spec/shared`, asserted in the
- * parity test.
- *
- * This is EMIT-side only. Residue stored under a plural type stays exactly as
- * it is on the server: the Console stops addressing it in the plural, and
- * nothing here writes, migrates or re-keys anything.
- */
-export function canonicalMetaUrlType(type: string): string {
-  return META_URL_TO_SINGULAR[type] ?? type;
 }
 
 /** Pending drafts straight from the ADR-0033 `_drafts` endpoint. */
@@ -170,9 +83,23 @@ async function listPendingDrafts(packageId?: string | null): Promise<DraftChange
     .filter((d) => typeof d?.type === 'string' && typeof d?.name === 'string')
     .map((d) => ({
       // The one fold, at the one boundary where a stored spelling enters this
-      // module (objectstack#9180). Everything below — both `/meta` item routes,
-      // the grouping and the heading — reads the folded value, so a route added
-      // later has no raw spelling in scope to interpolate.
+      // module: the `/meta` type segment is singular, always (objectstack#9180).
+      // Everything below — both `/meta` item routes, the grouping and the
+      // heading — reads the folded value, so a route added later has no raw
+      // spelling in scope to interpolate.
+      //
+      // `canonicalMetaUrlType` and not `pluralToSingular`: that map's keys are
+      // `defineStack()` collection properties, and `field`, `seed`,
+      // `external_catalog` and `translation` are absent from it because none is
+      // a stack-level collection. That absence is also how the residue folded
+      // here got written — `PUT /meta/fields/…` fell through to the permissive
+      // plugin-type path and minted rows under `type='fields'` while
+      // `PUT /meta/field/…` was refused (objectstack#7894).
+      //
+      // Fold, never strip: `capabilities` folds to `capability`, where a
+      // `replace(/s$/, '')` emits `capabilitie`. And this is EMIT-side only —
+      // residue stored under a plural type stays exactly as it is on the
+      // server; nothing here writes, migrates or re-keys anything.
       type: canonicalMetaUrlType(d.type as string),
       name: d.name as string,
       packageId: typeof d.packageId === 'string' && d.packageId ? (d.packageId as string) : null,

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -36,11 +36,121 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { diffFields } from '../views/metadata-admin/previews/object-fields-io';
 
 export interface DraftChangeEntry {
+  /**
+   * The CANONICAL SINGULAR metadata type (objectstack#9180). The `_drafts`
+   * feed returns whatever spelling each row was stored under, so the spelling
+   * is folded once — at the boundary that builds these entries — and every
+   * consumer below (both `/meta` item routes, the grouping, the heading) reads
+   * this one value. Nothing downstream ever sees the raw stored spelling.
+   */
   type: string;
   name: string;
   packageId: string | null;
   /** `new` = no published version; `update` = overwrites one; undefined = probing. */
   kind?: 'new' | 'update';
+}
+
+/**
+ * `/meta/:type` URL spellings the platform accepts → the canonical singular.
+ *
+ * ## What this mirrors
+ *
+ * `@objectstack/spec/shared` owns this contract and publishes it as
+ * `META_URL_TO_SINGULAR` with the fold `canonicalMetaUrlType`
+ * (objectstack#7894, #8424) — the ONE fold for a `/meta` type segment, and
+ * deliberately NOT `PLURAL_TO_SINGULAR`: that map's keys are `defineStack()`
+ * collection properties, and the four registry types with no stack-level
+ * collection (`field`, `seed`, `external_catalog`, `translation`) are absent
+ * from it. That absence is the hole #7894 closed, and it is also how the
+ * at-rest residue this panel must fold got written: `PUT /meta/fields/...`
+ * fell through to the plugin-type path and minted rows under `type='fields'`
+ * while `PUT /meta/field/...` was refused. The keys below are therefore
+ * exactly the spellings such residue can carry.
+ *
+ * ## Why it is a mirror and not an import
+ *
+ * Importing the real fold is the drift-proof spelling and would be the default.
+ * Measured with the repo's esbuild on a graph that already holds the
+ * `@objectstack/spec` entries app-shell reaches statically (`/ui`, `/kernel`),
+ * adding `@objectstack/spec/shared` costs **+213.4 KB minified / +60.1 KB
+ * gzipped** (1289.8 → 1503.2 KB min): every published spec subpath is a
+ * self-contained bundle, so `/shared` re-ships registry and schema modules the
+ * other entries already carry, and nothing tree-shakes them
+ * (`@objectstack/spec` declares no `sideEffects`).
+ *
+ * Those bytes would be EAGER, and laziness cannot move them. This panel is
+ * reached statically from `ConsoleLayout` (→ `DraftPreviewBar` → here), and the
+ * console's `vendor-objectstack` `advancedChunks` group claims every
+ * `@objectstack/*` module except `@objectstack/lint`, with that group's chunk a
+ * static import of the app entry — so an `await import()` here would be folded
+ * into the eager closure exactly as objectui#5266 documents for the linter.
+ * That is the trade `postureHasOrgWall` (`hooks/useTenancyPosture.ts`) already
+ * refused at +237 KB: a quarter megabyte on every console page load, for every
+ * user, to spell a fold only an admin's pending-changes panel performs.
+ *
+ * The drift risk that an import would have removed is paid at TEST time
+ * instead, the same way: `__tests__/DraftChangesPanel.test.tsx` imports the
+ * real `META_URL_TO_SINGULAR` / `canonicalMetaUrlType` and asserts this table
+ * equals it key for key, so a metadata type declared, renamed or respelled
+ * upstream fails CI here rather than silently emitting a plural route. Tests
+ * are not bundled; that assertion is free.
+ *
+ * ⛔ Never replace this table with a suffix rule. `capabilities` → `capability`
+ * is a mapping, not a `replace(/s$/, '')` (which yields `capabilitie`), and
+ * upstream refuses to contain such a "spelling GUESSER" at the boundary for
+ * that reason. Fold, or leave alone — never guess.
+ */
+export const META_URL_TO_SINGULAR: Readonly<Record<string, string>> = Object.freeze({
+  objects: 'object',
+  apps: 'app',
+  pages: 'page',
+  dashboards: 'dashboard',
+  reports: 'report',
+  datasets: 'dataset',
+  actions: 'action',
+  themes: 'theme',
+  flows: 'flow',
+  jobs: 'job',
+  positions: 'position',
+  permissions: 'permission',
+  capabilities: 'capability',
+  sharingRules: 'sharing_rule',
+  apis: 'api',
+  webhooks: 'webhook',
+  agents: 'agent',
+  tools: 'tool',
+  skills: 'skill',
+  ragPipelines: 'rag_pipeline',
+  hooks: 'hook',
+  mappings: 'mapping',
+  analyticsCubes: 'analytics_cube',
+  connectors: 'connector',
+  datasources: 'datasource',
+  views: 'view',
+  emailTemplates: 'email_template',
+  email_templates: 'email_template',
+  docs: 'doc',
+  books: 'book',
+  fields: 'field',
+  seeds: 'seed',
+  external_catalogs: 'external_catalog',
+  externalCatalogs: 'external_catalog',
+  translations: 'translation',
+});
+
+/**
+ * Fold a stored metadata type to the spelling `/meta` routes are addressed in.
+ * Returns the input unchanged when it is already canonical, or when it is a
+ * plugin-registered kind (which has no plural spelling of its own) — mirroring
+ * `canonicalMetaUrlType` from `@objectstack/spec/shared`, asserted in the
+ * parity test.
+ *
+ * This is EMIT-side only. Residue stored under a plural type stays exactly as
+ * it is on the server: the Console stops addressing it in the plural, and
+ * nothing here writes, migrates or re-keys anything.
+ */
+export function canonicalMetaUrlType(type: string): string {
+  return META_URL_TO_SINGULAR[type] ?? type;
 }
 
 /** Pending drafts straight from the ADR-0033 `_drafts` endpoint. */
@@ -59,7 +169,11 @@ async function listPendingDrafts(packageId?: string | null): Promise<DraftChange
   return list
     .filter((d) => typeof d?.type === 'string' && typeof d?.name === 'string')
     .map((d) => ({
-      type: d.type as string,
+      // The one fold, at the one boundary where a stored spelling enters this
+      // module (objectstack#9180). Everything below — both `/meta` item routes,
+      // the grouping and the heading — reads the folded value, so a route added
+      // later has no raw spelling in scope to interpolate.
+      type: canonicalMetaUrlType(d.type as string),
       name: d.name as string,
       packageId: typeof d.packageId === 'string' && d.packageId ? (d.packageId as string) : null,
     }));
@@ -73,6 +187,7 @@ async function listPendingDrafts(packageId?: string | null): Promise<DraftChange
  * tree has no such sub-route — the generic :name handler answers anything.)
  */
 async function publishedNamesOf(type: string): Promise<Set<string>> {
+  // `type` is already the canonical singular — folded in `listPendingDrafts`.
   const res = await fetch(`/api/v1/meta/${encodeURIComponent(type)}`, {
     credentials: 'include',
     headers: { Accept: 'application/json' },
@@ -104,6 +219,7 @@ async function fetchItemBody(
   name: string,
   opts: { draft?: boolean; packageId?: string | null } = {},
 ): Promise<Record<string, unknown> | null> {
+  // `type` is already the canonical singular — folded in `listPendingDrafts`.
   const params: string[] = [];
   if (opts.draft) params.push('state=draft');
   if (opts.packageId) params.push(`package=${encodeURIComponent(opts.packageId)}`);

--- a/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
+++ b/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
@@ -17,17 +17,7 @@ vi.mock('@object-ui/i18n', () => ({
   }),
 }));
 
-import {
-  META_URL_TO_SINGULAR as SPEC_META_URL_TO_SINGULAR,
-  canonicalMetaUrlType as specCanonicalMetaUrlType,
-} from '@objectstack/spec/shared';
-
-import {
-  DraftChangesPanel,
-  META_URL_TO_SINGULAR,
-  canonicalMetaUrlType,
-  computeChangeDetail,
-} from '../DraftChangesPanel';
+import { DraftChangesPanel, computeChangeDetail } from '../DraftChangesPanel';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -252,39 +242,5 @@ describe('DraftChangesPanel — /meta routes are addressed in the singular', () 
     renderPanel();
     await waitFor(() => expect(screen.getByText('ticket')).toBeInTheDocument());
     expect(screen.getByRole('heading', { level: 4 }).textContent).toBe('object · 1');
-  });
-});
-
-/**
- * The mirror's drift guard. `@objectstack/spec/shared` owns the `/meta` URL
- * spelling contract; the panel mirrors the table instead of importing it
- * because the import costs +213.4 KB min / +60.1 KB gz on the console's EAGER
- * graph (see the table's doc comment for the measurement and for why lazy
- * loading cannot move those bytes). Tests are not bundled, so the real map is
- * imported HERE and a type declared, renamed or respelled upstream fails CI
- * rather than silently emitting a plural route.
- */
-describe('DraftChangesPanel — the mirrored spelling table tracks @objectstack/spec', () => {
-  it('mirrors META_URL_TO_SINGULAR key for key', () => {
-    expect(META_URL_TO_SINGULAR).toEqual(SPEC_META_URL_TO_SINGULAR);
-  });
-
-  it('folds every spelling the spec folds, and passes the rest through identically', () => {
-    for (const spelling of Object.keys(SPEC_META_URL_TO_SINGULAR)) {
-      expect(canonicalMetaUrlType(spelling)).toBe(specCanonicalMetaUrlType(spelling));
-    }
-    for (const canonical of new Set(Object.values(SPEC_META_URL_TO_SINGULAR))) {
-      expect(canonicalMetaUrlType(canonical)).toBe(specCanonicalMetaUrlType(canonical));
-    }
-    // A plugin-registered kind has no plural spelling of its own — unchanged.
-    expect(canonicalMetaUrlType('my_plugin_kind')).toBe(
-      specCanonicalMetaUrlType('my_plugin_kind'),
-    );
-  });
-
-  it('is a mapping, not a suffix rule', () => {
-    expect(canonicalMetaUrlType('capabilities')).toBe('capability');
-    expect('capabilities'.replace(/s$/, '')).toBe('capabilitie'); // what a rule would emit
-    expect(canonicalMetaUrlType('externalCatalogs')).toBe('external_catalog');
   });
 });

--- a/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
+++ b/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
@@ -17,7 +17,17 @@ vi.mock('@object-ui/i18n', () => ({
   }),
 }));
 
-import { DraftChangesPanel, computeChangeDetail } from '../DraftChangesPanel';
+import {
+  META_URL_TO_SINGULAR as SPEC_META_URL_TO_SINGULAR,
+  canonicalMetaUrlType as specCanonicalMetaUrlType,
+} from '@objectstack/spec/shared';
+
+import {
+  DraftChangesPanel,
+  META_URL_TO_SINGULAR,
+  canonicalMetaUrlType,
+  computeChangeDetail,
+} from '../DraftChangesPanel';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -155,5 +165,126 @@ describe('DraftChangesPanel', () => {
     // status is added in the draft; title unchanged → only the + row shows.
     expect(screen.getByText('+ status')).toBeInTheDocument();
     expect(screen.queryByText(/~ title/)).not.toBeInTheDocument();
+  });
+});
+
+/* ─────────── `/meta` type segment is singular — always (objectstack#9180) ─────────── */
+
+/**
+ * The panel is DATA-DRIVEN, not authored: `type` arrives from the
+ * `/api/v1/meta/_drafts` feed's stored rows with a `typeof` check and nothing
+ * else, so a row stored under a pre-#7894 plural spelling made the Console emit
+ * a plural `/meta` item route. These pins assert the EMITTED addresses, with a
+ * fixture that carries a plural stored `type` — a route-spelling fix passes
+ * vacuously against an already-singular fixture.
+ *
+ * Nothing here asserts anything about the at-rest data: residue stays exactly
+ * as stored, and this change adds no write path.
+ */
+
+/** Record every URL the panel requests, and answer each route shape. */
+function mockRoutesRecording(
+  drafts: Array<{ type: string; name: string; packageId?: string | null }>,
+): string[] {
+  const urls: string[] = [];
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    urls.push(url);
+    const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+    if (url.includes('/_drafts')) {
+      return ok(drafts.map((d) => ({ packageId: 'com.x', ...d })));
+    }
+    const segments = url.split('?')[0].replace('/api/v1/meta/', '').split('/');
+    // `/meta/:type` is the published-name list; `/meta/:type/:name` is an item.
+    if (segments.length === 1) return ok([{ name: 'ticket' }]);
+    return ok(url.includes('state=draft') ? { item: DRAFT_TICKET } : PUBLISHED_TICKET);
+  }) as unknown as typeof fetch;
+  return urls;
+}
+
+/** Every `/meta` request except the `_drafts` feed the values come from. */
+const metaRoutes = (urls: string[]) => urls.filter((u) => !u.includes('/_drafts'));
+
+describe('DraftChangesPanel — /meta routes are addressed in the singular', () => {
+  it('reads the published list of a PLURAL stored type at its singular route', async () => {
+    const urls = mockRoutesRecording([{ type: 'objects', name: 'ticket' }]);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('ticket')).toBeInTheDocument());
+    await waitFor(() => expect(metaRoutes(urls)).toContain('/api/v1/meta/object'));
+    expect(metaRoutes(urls).filter((u) => /\/meta\/objects\b/.test(u))).toEqual([]);
+  });
+
+  it('reads both item bodies of a PLURAL stored type at singular routes', async () => {
+    const urls = mockRoutesRecording([{ type: 'objects', name: 'ticket' }]);
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId('draft-entry-toggle')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('draft-entry-toggle'));
+    await waitFor(() => expect(screen.getByTestId('draft-entry-detail')).toBeInTheDocument());
+    const items = metaRoutes(urls).filter((u) => u.includes('/ticket'));
+    expect(items).toContain('/api/v1/meta/object/ticket?package=com.x');
+    expect(items).toContain('/api/v1/meta/object/ticket?state=draft&package=com.x');
+    expect(items.filter((u) => /\/meta\/objects\b/.test(u))).toEqual([]);
+  });
+
+  it('FOLDS `capabilities`, never strips it — `capabilitie` is what a rule emits', async () => {
+    const urls = mockRoutesRecording([{ type: 'capabilities', name: 'billing_admin' }]);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('billing_admin')).toBeInTheDocument());
+    await waitFor(() => expect(metaRoutes(urls)).toContain('/api/v1/meta/capability'));
+    // `capabilities` and `capabilitie` both contain the stripped stem, so one
+    // assertion covers the unfixed spelling AND the `replace(/s$/, '')` fix.
+    expect(metaRoutes(urls).filter((u) => u.includes('capabilitie'))).toEqual([]);
+  });
+
+  it('leaves an already-canonical type and a plugin-registered kind untouched', async () => {
+    const urls = mockRoutesRecording([
+      { type: 'view', name: 'ticket_list' },
+      { type: 'my_plugin_kind', name: 'thing' },
+    ]);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('ticket_list')).toBeInTheDocument());
+    await waitFor(() => expect(metaRoutes(urls)).toContain('/api/v1/meta/view'));
+    expect(metaRoutes(urls)).toContain('/api/v1/meta/my_plugin_kind');
+  });
+
+  it('groups and labels the drafts under the canonical singular type', async () => {
+    mockRoutesRecording([{ type: 'objects', name: 'ticket' }]);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('ticket')).toBeInTheDocument());
+    expect(screen.getByRole('heading', { level: 4 }).textContent).toBe('object · 1');
+  });
+});
+
+/**
+ * The mirror's drift guard. `@objectstack/spec/shared` owns the `/meta` URL
+ * spelling contract; the panel mirrors the table instead of importing it
+ * because the import costs +213.4 KB min / +60.1 KB gz on the console's EAGER
+ * graph (see the table's doc comment for the measurement and for why lazy
+ * loading cannot move those bytes). Tests are not bundled, so the real map is
+ * imported HERE and a type declared, renamed or respelled upstream fails CI
+ * rather than silently emitting a plural route.
+ */
+describe('DraftChangesPanel — the mirrored spelling table tracks @objectstack/spec', () => {
+  it('mirrors META_URL_TO_SINGULAR key for key', () => {
+    expect(META_URL_TO_SINGULAR).toEqual(SPEC_META_URL_TO_SINGULAR);
+  });
+
+  it('folds every spelling the spec folds, and passes the rest through identically', () => {
+    for (const spelling of Object.keys(SPEC_META_URL_TO_SINGULAR)) {
+      expect(canonicalMetaUrlType(spelling)).toBe(specCanonicalMetaUrlType(spelling));
+    }
+    for (const canonical of new Set(Object.values(SPEC_META_URL_TO_SINGULAR))) {
+      expect(canonicalMetaUrlType(canonical)).toBe(specCanonicalMetaUrlType(canonical));
+    }
+    // A plugin-registered kind has no plural spelling of its own — unchanged.
+    expect(canonicalMetaUrlType('my_plugin_kind')).toBe(
+      specCanonicalMetaUrlType('my_plugin_kind'),
+    );
+  });
+
+  it('is a mapping, not a suffix rule', () => {
+    expect(canonicalMetaUrlType('capabilities')).toBe('capability');
+    expect('capabilities'.replace(/s$/, '')).toBe('capabilitie'); // what a rule would emit
+    expect(canonicalMetaUrlType('externalCatalogs')).toBe('external_catalog');
   });
 });


### PR DESCRIPTION
Fixes #5356
Part of objectstack-ai/objectstack#9180

The `/meta` type segment is singular — always (objectstack#9180, maintainer 2026-08-16; step ③ scoped to internal spelling correction by the 2026-08-17 re-weigh). This is the objectui half.

## The defect

`packages/app-shell/src/preview/DraftChangesPanel.tsx` is **data-driven, not authored**: each entry's `type` comes straight from the `/api/v1/meta/_drafts` feed's stored rows, guarded by a `typeof` check and nothing else (`:62` on the branch point, `bdf8cf76e`). It is then interpolated into two `/meta` item routes — the published-name list at `:76` and the item body read at `:112` — so a row stored under a pre-#7894 plural spelling made the Console request `/api/v1/meta/objects` and `/api/v1/meta/objects/ticket`.

Re-verified at the branch point: all four measured sites present as stated, and these two remain the only variable-typed `/meta` route emitters in objectui — every other site interpolates a name into a literal singular type (`meta/object/…`, `meta/dataset/…`, `meta/app/…`).

## The fix

One fold, at the one boundary where a stored spelling enters the module — where feed rows become `DraftChangeEntry`. Everything below (both item routes, the grouping, the type heading) reads the folded value, so a route added later has no raw spelling in scope to interpolate. That is the durable shape `rest-server.ts` argues for after its own per-gate normalization came back as the same hole eight days later (objectstack#6241).

**Which helper, and why that one.** objectui has no singular-folding helper of its own — this is the first place that needs one. The ecosystem's is `canonicalMetaUrlType` from `@objectstack/spec/shared` (a declared dependency of `@object-ui/app-shell`), the published fold for exactly a `/meta/:type` path segment (objectstack#7894, #8424), and the same one `RestServer` folds incoming requests with.

Deliberately **not** `pluralToSingular`: that map's keys are `defineStack()` collection properties, and `field`, `seed`, `external_catalog` and `translation` are absent from it because none of them is a stack-level collection. That absence is also how the residue being folded here got written — `PUT /meta/fields/…` fell through to the permissive plugin-type path and minted rows under `type='fields'` while `PUT /meta/field/…` was refused. The spellings this fold accepts are exactly the ones such residue can carry.

**Fold, never strip.** `capabilities` maps to `capability`; a `replace(/s$/, '')` emits `capabilitie`. The pin below asserts against that specific wrong answer.

**No laundering.** Emit-side only: residue stored under a plural type stays exactly as it is on the server. No write path, no migration, no server-side tolerance, and nothing about what the server accepts changes.

## A local copy of the table was tried first, and is refused mechanically

The first implementation mirrored the 35-entry spelling table locally with a parity test pinning it against the real export, to avoid the weight below. `node scripts/check-spec-symbol-derivation.mjs` rejects that: a spec-named symbol must be derived from `@objectstack/spec`, and the guard's own header explains that a faithful copy is precisely the fork it exists to prevent — reference identity is the only thing distinguishing a re-export from one, and its `ALLOW` map governs deliberate *divergence*, which a mirror is not. So the import is the sanctioned spelling, and the gate is green on this branch.

**The price, measured, so it is not invisible:** +213.4 KB minified / +60.1 KB gzipped on the console's **eager** graph (esbuild, on a graph already holding the `/ui` + `/kernel` entries app-shell imports statically). The panel is reached through static imports from `ConsoleLayout`, and lazy-loading cannot move those bytes — the console's `vendor-objectstack` chunk group claims every `@objectstack/*` module except the linter, and that group's chunk is a static import of the app entry (objectui#5266). Recorded at the import site and filed as #5359; both levers for paying it down live in `apps/console/vite.config.ts`, outside this card's file surface.

## Verification

`2efc90d19`, all from the repo root (17 packages own a standalone `vitest.config.ts`, so a package-scoped run would use a different config than CI does):

- `pnpm exec vitest run packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx` — **13 passed**, 5 of them new route pins driven by a fixture that carries a **plural** stored `type` (a route-spelling fix passes vacuously against an already-singular fixture).
- `pnpm --filter @object-ui/app-shell type-check` — green (`tsc --noEmit` + `tsconfig.test.json`), after building the dependency closure.
- `eslint` on both changed files — 0 errors (2 pre-existing warnings on untouched lines).
- Gates at this sha: `check-spec-symbol-derivation`, `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`, `check-phantom-dependencies`, `check-package-self-import` — all exit 0.

**Reverse verification.** Reverting the fold to `type: d.type as string` turns 4 of the 5 pins red, with the plural addresses in the failure text:

```
AssertionError: expected [ '/api/v1/meta/objects' ] to include '/api/v1/meta/object'
AssertionError: expected [ '/api/v1/meta/capabilities' ] to include '/api/v1/meta/capability'
AssertionError: expected 'objects · 1' to be 'object · 1'
```

The fifth pin — an already-canonical type and a plugin-registered kind pass through unchanged — stays green in both legs by design; it is the passthrough control. Restoring the fold returns 13/13.

Per leg: **no build artifact sits between the edit and the thing under test.** The test imports `../DraftChangesPanel` by relative path and vitest transforms it from source, so neither leg needed a rebuild. The only prebuilt artifact in play is the installed `@objectstack/spec` dist providing the fold, which the ablation does not touch.

Changeset: `patch` for `@object-ui/app-shell`.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_