### PR TITLE
docs(guide,api): one disposition per fabricated export, applied at every site (#5343)

### DIFF
--- a/.changeset/guide-fabricated-exports-5343.md
+++ b/.changeset/guide-fabricated-exports-5343.md
@@ -1,0 +1,24 @@
+---
+---
+
+Docs + gate-ledger only (objectui#5343). The getting-started guides under
+`content/docs/guide/**` and `content/docs/api/schema-reference.md` documented 14 symbols
+the packages do not export; a reader who copied one of those imports got a compile error,
+not a degraded render. Each symbol got ONE disposition, taken from the packages' built
+`dist/index.d.ts` and applied at every site:
+
+- renamed — `PageSchema` → `PageNodeSchema`, `DashboardSchema` → `DashboardComponentSchema`,
+  `AppSchema` / `ThemeSchema` / `ReportSchema` → `AppComponentSchema` /
+  `ThemeComponentSchema` / `ReportComponentSchema` (type and zod entries both),
+  `componentSchema` → `ComponentSchema`, `registerDefaultRenderers` /
+  `registerAllComponents` → `initializeComponents()` plus the side-effect
+  `@object-ui/fields` import, `getComponentRegistry()` → the `ComponentRegistry` singleton;
+- wrong package — `BaseSchema`, `PageSchema` and `FormSchema` were claimed from
+  `@object-ui/core` while they live in `@object-ui/types`;
+- removed with nothing replacing it — `InputRenderer`, the `ObjectSchema` / `Field`
+  builder pair and `getExpressionEvaluator`: those examples are gone and the pages teach
+  the real surface instead.
+
+No published behaviour changes: no package's runtime source was touched. The
+`UNGATED_DOCS` entries in `scripts/check-doc-snippet-types.mjs` are rewritten to the
+diagnostic mix each page now measures — every bucket equal or lower, nothing added.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -10,7 +10,7 @@ This reference documents every ObjectUI schema type with annotated JSON examples
 > **Import:** All types are available from `@object-ui/types`.
 >
 > ```typescript
-> import type { PageSchema, FormSchema, TableSchema, /* ... */ } from '@object-ui/types';
+> import type { PageNodeSchema, FormSchema, TableSchema, /* ... */ } from '@object-ui/types';
 > ```
 
 ---
@@ -68,7 +68,7 @@ All schema types extend `BaseSchema`. These shared properties are available on e
 
 ## Layout Schemas
 
-### PageSchema
+### PageNodeSchema
 
 Top-level page container. Defines a full page with optional regions (header, sidebar, footer).
 
@@ -196,7 +196,7 @@ A responsive grid layout. Columns can be a fixed number or responsive breakpoint
 | `gap` | `number` | Gap between grid items (Tailwind spacing scale). |
 | `children` | `SchemaNode \| SchemaNode[]` | Grid items. |
 
-**Related:** [DivSchema](#divschema), [CardSchema](#cardschema), [DashboardSchema](#dashboardschema)
+**Related:** [DivSchema](#divschema), [CardSchema](#cardschema), [DashboardComponentSchema](#dashboardcomponentschema)
 
 ---
 
@@ -233,7 +233,7 @@ A tabbed interface for organizing content into switchable panels.
 | `orientation` | `"horizontal" \| "vertical"` | Tab bar orientation. |
 | `items` | `TabItem[]` | Tab definitions, each with `value`, `label`, `icon`, `content`, and optional `disabled`. |
 
-**Related:** [CardSchema](#cardschema), [PageSchema](#pageschema)
+**Related:** [CardSchema](#cardschema), [PageNodeSchema](#pagenodeschema)
 
 ---
 
@@ -469,7 +469,7 @@ A chart visualization supporting multiple chart types.
 | `animate` | `boolean` | Enable entry animations. |
 | `config` | `Record<string, any>` | Additional chart library configuration. |
 
-**Related:** [DashboardSchema](#dashboardschema), [CardSchema](#cardschema)
+**Related:** [DashboardComponentSchema](#dashboardcomponentschema), [CardSchema](#cardschema)
 
 ---
 
@@ -971,7 +971,7 @@ A drag-and-drop Kanban board with columns and cards.
 
 ---
 
-### DashboardSchema
+### DashboardComponentSchema
 
 A widget-based dashboard with configurable grid layout and auto-refresh.
 
@@ -1076,7 +1076,7 @@ A multi-view calendar for displaying and managing events.
 | `onEventUpdate` | `function` | Callback when an event is modified. |
 | `onDateChange` | `function` | Callback when the visible date range changes. |
 
-**Related:** [ObjectViewSchema](#objectviewschema), [DashboardSchema](#dashboardschema)
+**Related:** [ObjectViewSchema](#objectviewschema), [DashboardComponentSchema](#dashboardcomponentschema)
 
 ---
 
@@ -1281,7 +1281,7 @@ Import only the types you need:
 
 ```typescript
 // Layout
-import type { PageSchema, DivSchema, CardSchema, GridSchema, TabsSchema } from '@object-ui/types';
+import type { PageNodeSchema, DivSchema, CardSchema, GridSchema, TabsSchema } from '@object-ui/types';
 
 // Forms
 import type { FormSchema, InputSchema, SelectSchema, ButtonSchema } from '@object-ui/types';
@@ -1296,7 +1296,7 @@ import type { CRUDSchema, ActionSchema, DetailSchema } from '@object-ui/types';
 import type { ObjectGridSchema, ObjectFormSchema, ObjectViewSchema } from '@object-ui/types';
 
 // Complex
-import type { KanbanSchema, DashboardSchema, CalendarViewSchema } from '@object-ui/types';
+import type { KanbanSchema, DashboardComponentSchema, CalendarViewSchema } from '@object-ui/types';
 
 // Views
 import type { DetailViewSchema, ViewSwitcherSchema } from '@object-ui/types';

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -57,13 +57,17 @@ Add to your `src/index.css`:
 Create `src/setup.ts` to register the built-in component and field renderers:
 
 ```ts
-import { Registry } from '@object-ui/core';
-import { registerAllComponents } from '@object-ui/components';
-import { registerAllFields } from '@object-ui/fields';
+import { initializeComponents } from '@object-ui/components';
+// Side-effect import: loading the package runs its own field registration.
+import '@object-ui/fields';
 
-registerAllComponents(Registry);
-registerAllFields(Registry);
+initializeComponents();
 ```
+
+Loading each package registers what it owns — the components and the field
+widgets go into the one `ComponentRegistry` that `@object-ui/core` exports.
+`initializeComponents()` takes no arguments; it exists so a bundler cannot
+tree-shake the side-effect import away.
 
 Import this file once at the top of your app entry point (`src/main.tsx` or `src/App.tsx`).
 
@@ -72,31 +76,46 @@ Import this file once at the top of your app entry point (`src/main.tsx` or `src
 Create `src/schemas/task.ts`. This is the metadata that drives the entire UI — grid columns, form fields, validation, and views are all derived from this schema:
 
 ```ts
-import { ObjectSchema, Field } from '@object-ui/types';
+import type { FieldMetadata } from '@object-ui/types';
 
-export const TaskSchema = ObjectSchema.create({
+const fields: Record<string, FieldMetadata> = {
+  title: { name: 'title', type: 'text', label: 'Title', required: true },
+  status: {
+    name: 'status',
+    type: 'select',
+    label: 'Status',
+    defaultValue: 'Todo',
+    options: [
+      { label: 'Backlog', value: 'Backlog' },
+      { label: 'Todo', value: 'Todo' },
+      { label: 'In Progress', value: 'In Progress' },
+      { label: 'Review', value: 'Review' },
+      { label: 'Done', value: 'Done' },
+    ],
+  },
+  priority: {
+    name: 'priority',
+    type: 'select',
+    label: 'Priority',
+    defaultValue: 'Medium',
+    options: [
+      { label: 'Critical', value: 'Critical' },
+      { label: 'High', value: 'High' },
+      { label: 'Medium', value: 'Medium' },
+      { label: 'Low', value: 'Low' },
+    ],
+  },
+  assignee: { name: 'assignee', type: 'text', label: 'Assignee' },
+  due_date: { name: 'due_date', type: 'date', label: 'Due Date' },
+  description: { name: 'description', type: 'textarea', label: 'Description' },
+};
+
+export const TaskSchema = {
   name: 'task',
   label: 'Task',
   icon: 'check-circle-2',
   titleFormat: '{title}',
-  fields: {
-    title: Field.text({
-      label: 'Title',
-      required: true,
-      searchable: true,
-    }),
-    status: Field.select(
-      ['Backlog', 'Todo', 'In Progress', 'Review', 'Done'],
-      { label: 'Status', defaultValue: 'Todo' }
-    ),
-    priority: Field.select(
-      ['Critical', 'High', 'Medium', 'Low'],
-      { label: 'Priority', defaultValue: 'Medium' }
-    ),
-    assignee: Field.text({ label: 'Assignee' }),
-    due_date: Field.date({ label: 'Due Date' }),
-    description: Field.textarea({ label: 'Description' }),
-  },
+  fields,
   list_views: {
     all: {
       label: 'All Tasks',
@@ -109,10 +128,16 @@ export const TaskSchema = ObjectSchema.create({
       sort: [['priority', 'asc']],
     },
   },
-});
+};
 ```
 
-Each `Field.*()` call produces a `FieldMetadata` entry that ObjectUI uses to choose the correct renderer, apply validation, and generate form controls automatically.
+An object's metadata is a plain document — the same shape a backend serves from
+`DataSource.getObjectSchema()` — so it is written as a literal rather than built
+by a helper. `FieldMetadata` is the union every field entry belongs to (`text`,
+`select`, `date`, `textarea`, …), and typing the `fields` record against it is
+what makes a wrong `type` or a misspelled key fail at compile time. ObjectUI
+reads those entries to choose the renderer, apply validation, and generate form
+controls automatically.
 
 ## Step 4: Create a Data Source
 

--- a/content/docs/guide/component-registry.md
+++ b/content/docs/guide/component-registry.md
@@ -14,10 +14,11 @@ Schema Type → Component Registry → React Component
 
 ## Getting the Registry
 
-```tsx
-import { getComponentRegistry } from '@object-ui/react'
+`ComponentRegistry` is a process-level singleton exported by `@object-ui/core`.
+Import it directly — there is no accessor function and nothing to construct:
 
-const registry = getComponentRegistry()
+```tsx
+import { ComponentRegistry } from '@object-ui/core'
 ```
 
 ## Registering Components
@@ -27,11 +28,19 @@ const registry = getComponentRegistry()
 The easiest way to get started is to register all default components:
 
 ```tsx
-import { registerDefaultRenderers } from '@object-ui/components'
+import { initializeComponents } from '@object-ui/components'
+// Side-effect import: loading the package runs its own field registration.
+import '@object-ui/fields'
 
 // Call once at app initialization
-registerDefaultRenderers()
+initializeComponents()
 ```
+
+Loading each package registers what it owns — the components and the field
+widgets both land in the one `ComponentRegistry`; `initializeComponents()` exists
+so a bundler cannot tree-shake the side-effect import away. The individual
+renderers are not exported for hand-registration: registration is what loading
+the package does.
 
 This registers all built-in components like:
 - Forms: `input`, `textarea`, `select`, `checkbox`, etc.
@@ -39,26 +48,13 @@ This registers all built-in components like:
 - Layout: `page`, `grid`, `flex`, `container`, etc.
 - Feedback: `alert`, `dialog`, `toast`, etc.
 
-### Registering Individual Components
-
-Register specific components one at a time:
-
-```tsx
-import { getComponentRegistry } from '@object-ui/react'
-import { InputRenderer } from '@object-ui/components'
-
-const registry = getComponentRegistry()
-
-registry.register('input', InputRenderer)
-```
-
 ### Registering Custom Components
 
 Create and register your own components:
 
 ```tsx
-import { getComponentRegistry } from '@object-ui/react'
-import type { BaseSchema } from '@object-ui/core'
+import { ComponentRegistry } from '@object-ui/core'
+import type { BaseSchema } from '@object-ui/types'
 
 interface MyComponentSchema extends BaseSchema {
   type: 'my-component'
@@ -75,8 +71,7 @@ function MyComponent(props: MyComponentSchema) {
   )
 }
 
-const registry = getComponentRegistry()
-registry.register('my-component', MyComponent)
+ComponentRegistry.register('my-component', MyComponent)
 ```
 
 Now you can use it in schemas:
@@ -125,18 +120,14 @@ function MyRenderer(props: ComponentProps<MyComponentSchema>) {
 Register components with additional metadata:
 
 ```tsx
-registry.register('my-component', MyComponent, {
-  displayName: 'My Custom Component',
+ComponentRegistry.register('my-component', MyComponent, {
+  label: 'My Custom Component',
   category: 'Custom',
   icon: 'component-icon',
-  description: 'A custom component for special use cases',
-  schema: {
-    type: 'object',
-    properties: {
-      title: { type: 'string' },
-      content: { type: 'string' }
-    }
-  }
+  inputs: [
+    { name: 'title', type: 'string', label: 'Title' },
+    { name: 'content', type: 'string', label: 'Content' }
+  ]
 })
 ```
 
@@ -147,13 +138,8 @@ This metadata is used by the Visual Designer to provide better editing experienc
 Register components that load on demand:
 
 ```tsx
-import { lazy } from 'react'
-
-const HeavyComponent = lazy(() => import('./HeavyComponent'))
-
-registry.register('heavy-component', HeavyComponent, {
-  lazy: true
-})
+// The loader runs the first time a schema asks for `heavy-component`.
+ComponentRegistry.registerLazy('heavy-component', () => import('./HeavyComponent'))
 ```
 
 ### Overriding Built-in Components
@@ -161,13 +147,15 @@ registry.register('heavy-component', HeavyComponent, {
 Override default components with your own:
 
 ```tsx
-import { registerDefaultRenderers } from '@object-ui/components'
+import { ComponentRegistry } from '@object-ui/core'
+import { initializeComponents } from '@object-ui/components'
+import '@object-ui/fields'
 
 // Register defaults first
-registerDefaultRenderers()
+initializeComponents()
 
 // Override specific component
-registry.register('button', MyCustomButton)
+ComponentRegistry.register('button', MyCustomButton)
 ```
 
 ## Component Categories
@@ -250,14 +238,14 @@ Default components are organized by category:
 ### Get All Registered Types
 
 ```tsx
-const types = registry.getRegisteredTypes()
+const types = ComponentRegistry.getAllTypes()
 console.log(types) // ['input', 'button', 'form', ...]
 ```
 
 ### Check if Type is Registered
 
 ```tsx
-if (registry.has('my-component')) {
+if (ComponentRegistry.has('my-component')) {
   console.log('Component is registered')
 }
 ```
@@ -265,10 +253,10 @@ if (registry.has('my-component')) {
 ### Get Component Metadata
 
 ```tsx
-const metadata = registry.getMetadata('input')
+const metadata = ComponentRegistry.getMeta('input')
 console.log(metadata)
 // {
-//   displayName: 'Input',
+//   label: 'Input',
 //   category: 'Form',
 //   icon: 'input-icon',
 //   ...
@@ -281,9 +269,10 @@ console.log(metadata)
 
 ```tsx
 // main.tsx or App.tsx
-import { registerDefaultRenderers } from '@object-ui/components'
+import { initializeComponents } from '@object-ui/components'
+import '@object-ui/fields'
 
-registerDefaultRenderers()
+initializeComponents()
 
 function App() {
   // Your app code
@@ -293,7 +282,7 @@ function App() {
 ### 2. Use TypeScript for Custom Components
 
 ```tsx
-import type { BaseSchema } from '@object-ui/core'
+import type { BaseSchema } from '@object-ui/types'
 
 interface CustomSchema extends BaseSchema {
   type: 'custom'
@@ -314,12 +303,11 @@ Use kebab-case for component types:
 ### 4. Provide Meaningful Metadata
 
 ```tsx
-registry.register('rating', RatingComponent, {
-  displayName: 'Star Rating',
+ComponentRegistry.register('rating', RatingComponent, {
+  label: 'Star Rating',
   category: 'Form',
   icon: 'star',
-  description: 'A 5-star rating input component',
-  tags: ['form', 'input', 'rating']
+  labelling: 'group'
 })
 ```
 
@@ -346,27 +334,26 @@ Group related components into plugin packages:
 
 ```tsx
 // @my-org/objectui-plugin-charts
-import { getComponentRegistry } from '@object-ui/react'
+import { ComponentRegistry } from '@object-ui/core'
 import { BarChart } from './BarChart'
 import { LineChart } from './LineChart'
 import { PieChart } from './PieChart'
 
 export function registerChartComponents() {
-  const registry = getComponentRegistry()
-  
-  registry.register('bar-chart', BarChart)
-  registry.register('line-chart', LineChart)
-  registry.register('pie-chart', PieChart)
+  ComponentRegistry.register('bar-chart', BarChart)
+  ComponentRegistry.register('line-chart', LineChart)
+  ComponentRegistry.register('pie-chart', PieChart)
 }
 ```
 
 Usage:
 
 ```tsx
-import { registerDefaultRenderers } from '@object-ui/components'
+import { initializeComponents } from '@object-ui/components'
+import '@object-ui/fields'
 import { registerChartComponents } from '@my-org/objectui-plugin-charts'
 
-registerDefaultRenderers()
+initializeComponents()
 registerChartComponents()
 ```
 
@@ -376,8 +363,8 @@ Here's a complete example of a custom form component:
 
 ```tsx
 import { forwardRef } from 'react'
-import { getComponentRegistry } from '@object-ui/react'
-import type { BaseSchema } from '@object-ui/core'
+import { ComponentRegistry } from '@object-ui/core'
+import type { BaseSchema } from '@object-ui/types'
 import { cn } from '@/lib/utils'
 
 interface RatingSchema extends BaseSchema {
@@ -434,22 +421,17 @@ const RatingComponent = forwardRef<HTMLDivElement, { schema: RatingSchema }>(
 RatingComponent.displayName = 'Rating'
 
 // Register the component
-const registry = getComponentRegistry()
-registry.register('rating', RatingComponent, {
-  displayName: 'Star Rating',
+ComponentRegistry.register('rating', RatingComponent, {
+  label: 'Star Rating',
   category: 'Form',
-  description: 'A star rating input component',
-  schema: {
-    type: 'object',
-    properties: {
-      name: { type: 'string' },
-      label: { type: 'string' },
-      maxStars: { type: 'number', default: 5 },
-      required: { type: 'boolean' },
-      disabled: { type: 'boolean' }
-    },
-    required: ['name']
-  }
+  labelling: 'group',
+  inputs: [
+    { name: 'name', type: 'string', label: 'Name', required: true },
+    { name: 'label', type: 'string', label: 'Label' },
+    { name: 'maxStars', type: 'number', label: 'Max stars', defaultValue: 5 },
+    { name: 'required', type: 'boolean', label: 'Required' },
+    { name: 'disabled', type: 'boolean', label: 'Disabled' }
+  ]
 })
 
 export { RatingComponent }

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -530,44 +530,48 @@ This logs all expression evaluations to the console.
 
 ### Custom Functions
 
-Extend the expression context with custom functions:
+There is no global evaluator to extend: `SchemaRenderer` builds a fresh
+`ExpressionEvaluator` for each evaluation, so a function has to reach it through
+the evaluation context. Anything callable you put in the context is callable in
+an expression, under exactly the name you gave it:
 
 ```tsx
-import { getExpressionEvaluator } from '@object-ui/core'
+import { evaluateExpression } from '@object-ui/core'
 
-const evaluator = getExpressionEvaluator()
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value)
 
-evaluator.registerFunction('formatCurrency', (value: number) => {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD'
-  }).format(value)
-})
+// => '$1,234.50'
+evaluateExpression('${formatCurrency(price)}', { formatCurrency, price: 1234.5 })
 ```
 
-Use in schemas:
+That is the direct-evaluation path. A component expression rendered by
+`SchemaRenderer` resolves against the scope the renderer itself builds — the
+provider's data source (as `data`), the host scope (`user` / `current_user`) and
+page variables — so a function you registered elsewhere is not reachable from a
+schema expression. Compute the value before it reaches the schema, and bind the
+result.
 
-```json
-{
-  "type": "text",
-  "value": "${formatCurrency(price)}"
-}
+Hold an evaluator when you want one context reused — construct it, then call
+`evaluate`:
+
+```tsx
+import { ExpressionEvaluator } from '@object-ui/core'
+
+const evaluator = new ExpressionEvaluator({ user: { role: 'admin' } })
+
+evaluator.evaluate('${user.role === "admin"}')
 ```
 
 ### Custom Operators
 
-Register custom operators for domain-specific logic:
-
-```tsx
-evaluator.registerOperator('contains', (array, item) => {
-  return array.includes(item)
-})
-```
+Expressions are JavaScript, evaluated against the context — operators are the
+language's own. A membership test is written with the array method:
 
 ```json
 {
   "type": "button",
-  "visibleOn": "${user.permissions contains 'admin'}"
+  "visibleOn": "${user.permissions.includes('admin')}"
 }
 ```
 

--- a/content/docs/guide/schema-overview.md
+++ b/content/docs/guide/schema-overview.md
@@ -25,7 +25,7 @@ ObjectUI includes enterprise-grade capabilities to build production-ready applic
 Define your entire application structure with navigation, branding, and global settings.
 
 ```typescript
-const app: AppSchema = {
+const app: AppComponentSchema = {
   type: 'app',
   title: 'My Application',
   layout: 'sidebar',
@@ -48,13 +48,14 @@ const app: AppSchema = {
 Dynamic theming with light/dark modes, color palettes, and typography.
 
 ```typescript
-const theme: ThemeSchema = {
+const theme: ThemeComponentSchema = {
   type: 'theme',
   mode: 'dark',
   themes: [{
-    name: 'professional',
-    light: { primary: '#3b82f6', ... },
-    dark: { primary: '#60a5fa', ... }
+    name: 'professional-dark',
+    label: 'Professional (Dark)',
+    mode: 'dark',
+    colors: { primary: '#60a5fa', background: '#0f172a', ... }
   }]
 };
 ```
@@ -105,7 +106,7 @@ const action: ActionSchema = {
 Enterprise reports with aggregation, export, and scheduling.
 
 ```typescript
-const report: ReportSchema = {
+const report: ReportComponentSchema = {
   type: 'report',
   title: 'Sales Report',
   fields: [
@@ -160,10 +161,10 @@ const block: BlockSchema = {
 
 | Schema | Purpose | Best For |
 |--------|---------|----------|
-| **AppSchema** | Application structure | Multi-page apps, dashboards |
-| **ThemeSchema** | Visual theming | Brand consistency, white-labeling |
+| **AppComponentSchema** | Application structure | Multi-page apps, dashboards |
+| **ThemeComponentSchema** | Visual theming | Brand consistency, white-labeling |
 | **Enhanced Actions** | Complex workflows | API integration, multi-step processes |
-| **ReportSchema** | Data reporting | Analytics, business intelligence |
+| **ReportComponentSchema** | Data reporting | Analytics, business intelligence |
 | **BlockSchema** | Reusable components | Marketing pages, component libraries |
 
 ## View Components
@@ -202,10 +203,10 @@ Import the type definitions you need:
 
 ```typescript
 import type { 
-  AppSchema, 
-  ThemeSchema, 
+  AppComponentSchema, 
+  ThemeComponentSchema, 
   ActionSchema,
-  ReportSchema,
+  ReportComponentSchema,
   BlockSchema 
 } from '@object-ui/types';
 ```
@@ -216,14 +217,14 @@ For runtime validation, use the included Zod schemas:
 
 ```typescript
 import { 
-  AppSchema,
-  ThemeSchema,
+  AppComponentSchema,
+  ThemeComponentSchema,
   ActionSchema,
-  ReportSchema,
+  ReportComponentSchema,
   BlockSchema
 } from '@object-ui/types/zod';
 
-const result = AppSchema.safeParse(myConfig);
+const result = AppComponentSchema.safeParse(myConfig);
 if (result.success) {
   // Valid configuration
   const app = result.data;
@@ -238,10 +239,10 @@ if (result.success) {
 Here's a complete example showing how to build a simple CRM application using ObjectUI schemas:
 
 ```typescript
-import type { AppSchema, ThemeSchema } from '@object-ui/types';
+import type { AppComponentSchema, ThemeComponentSchema } from '@object-ui/types';
 
 // Define your application structure
-const app: AppSchema = {
+const app: AppComponentSchema = {
   type: 'app',
   name: 'enterprise-crm',
   title: 'Enterprise CRM',
@@ -277,14 +278,23 @@ const app: AppSchema = {
 };
 
 // Configure your theme
-const theme: ThemeSchema = {
+const theme: ThemeComponentSchema = {
   type: 'theme',
-  mode: 'system',
-  themes: [{
-    name: 'professional',
-    light: { primary: '#3b82f6', background: '#fff' },
-    dark: { primary: '#60a5fa', background: '#0f172a' }
-  }],
+  mode: 'auto',
+  themes: [
+    {
+      name: 'professional-light',
+      label: 'Professional (Light)',
+      mode: 'light',
+      colors: { primary: '#3b82f6', background: '#ffffff' }
+    },
+    {
+      name: 'professional-dark',
+      label: 'Professional (Dark)',
+      mode: 'dark',
+      colors: { primary: '#60a5fa', background: '#0f172a' }
+    }
+  ],
   allowSwitching: true,
   persistPreference: true
 };
@@ -304,9 +314,9 @@ ObjectUI provides advanced schemas and capabilities for enterprise applications:
 
 ObjectUI includes these top-level schemas:
 
-- **`AppSchema`** - Define your entire application structure
-- **`ThemeSchema`** - Configure themes and color palettes
-- **`ReportSchema`** - Create data reports with aggregation
+- **`AppComponentSchema`** - Define your entire application structure
+- **`ThemeComponentSchema`** - Configure themes and color palettes
+- **`ReportComponentSchema`** - Create data reports with aggregation
 - **`BlockSchema`** - Build reusable component blocks
 
 ### Enhanced ActionSchema
@@ -338,9 +348,9 @@ ObjectUI includes enhanced view components:
    npm install @object-ui/types@latest
    ```
 
-2. **Configure application** - Define your app structure with AppSchema (optional)
+2. **Configure application** - Define your app structure with AppComponentSchema (optional)
    
-3. **Set up theming** - Add a ThemeSchema for consistent styling (optional)
+3. **Set up theming** - Add a ThemeComponentSchema for consistent styling (optional)
 
 4. **Implement actions** - Use advanced action features like `confirm` and callbacks
 

--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -20,10 +20,12 @@ The `SchemaRenderer` is the primary component that interprets your JSON schemas:
 
 ```tsx
 import { SchemaRenderer } from '@object-ui/react'
-import { registerDefaultRenderers } from '@object-ui/components'
+import { initializeComponents } from '@object-ui/components'
+// Side-effect import: loading the package runs its own field registration.
+import '@object-ui/fields'
 
 // Register components once at app initialization
-registerDefaultRenderers()
+initializeComponents()
 
 function App() {
   const schema = {
@@ -97,12 +99,11 @@ Use expression syntax `${}` to reference data:
 The schema renderer uses a component registry to map schema types to React components:
 
 ```tsx
-import { getComponentRegistry } from '@object-ui/react'
+import { ComponentRegistry } from '@object-ui/core'
 
-const registry = getComponentRegistry()
-
+// `ComponentRegistry` is a process-level singleton — import it, do not construct one.
 // Register a custom component
-registry.register('my-component', MyComponent)
+ComponentRegistry.register('my-component', MyComponent)
 
 // Now you can use it in schemas
 const schema = {
@@ -289,18 +290,18 @@ The renderer includes built-in error boundaries:
 Full type safety for your schemas:
 
 ```tsx
-import type { PageSchema, FormSchema } from '@object-ui/core'
+import type { PageNodeSchema, FormSchema } from '@object-ui/types'
 
-const schema: PageSchema = {
+const form: FormSchema = {
+  type: "form",
+  // TypeScript will validate this entire structure
+  fields: []
+}
+
+const schema: PageNodeSchema = {
   type: "page",
   title: "Typed Page",
-  body: {
-    type: "form",
-    // TypeScript will validate this entire structure
-    body: [
-      // ...
-    ]
-  }
+  body: [form]
 }
 ```
 

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -154,8 +154,9 @@ import type { FormSchema } from '@object-ui/types/form';
 import type { LayoutSchema } from '@object-ui/types/layout';
 import type { DataDisplaySchema } from '@object-ui/types/data-display';
 
-// Zod validation schemas
-import { componentSchema } from '@object-ui/types/zod';
+// Zod validation schemas — same PascalCase names as the types, so alias one of
+// the two when a module imports both.
+import { ComponentSchema as ComponentSchemaValidator } from '@object-ui/types/zod';
 ```
 
 The `@object-ui/types` package exports multiple entry points (`base`, `layout`, `form`, `data-display`, `feedback`, `overlay`, `navigation`, `complex`, `data`, `zod`). Check `packages/types/package.json` for the full list.

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -231,9 +231,17 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * made visible: the collector now reads `.md`, and an entry with a measured reason
  * is what a page that cannot pass yet is owed. They are DISCLOSED debt, not new
  * debt — every one of them was equally unverified before, just unnamed. Their
- * reasons carry the same measured diagnostic mix as the rest, and several name
- * the missing export by hand, because a documented symbol a package does not
- * export is the reader-visible half (objectui#5160).
+ * reasons carry the same measured diagnostic mix as the rest, and a symbol a
+ * package does not export is called out by name, because that is the
+ * reader-visible half (objectui#5160).
+ *
+ * objectui#5343 then read that list back and cleared it for the getting-started
+ * pages: no entry for `content/docs/guide/**` or for
+ * `content/docs/api/schema-reference.md` names a missing export any more. Every
+ * symbol those pages documented now exists on the built `dist/index.d.ts`, so
+ * their reasons record what each fabricated name BECAME instead. Exactly one
+ * entry still names a missing export — `content/docs/utilities/index.md`
+ * (`ObjectStackProvider`), a different directory and a different card.
  *
  * The reasons are deliberately concrete about WHAT would have to change, because
  * "does not compile" is three different jobs: a page whose snippets reference
@@ -248,9 +256,10 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
 const UNGATED_DOCS = {
   'content/docs/api/schema-reference.md':
     '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; plus TS2305x1 TS2724x1 — candidate real defects, un-triaged. The ' +
-    'missing-export diagnostics name `DashboardSchema` (@object-ui/types), `PageSchema` ' +
-    '(@object-ui/types) — the reader-visible half of this entry',
+    'page never defines. This entry read TS2305x1 TS2724x1 until objectui#5343: both were ' +
+    'fabricated exports of @object-ui/types, re-spelled to the names the built `dist/index.d.ts` ' +
+    'declares — `PageSchema` → `PageNodeSchema` (renamed by objectui#3074, which split the ' +
+    'renderer NODE off the spec document type) and `DashboardSchema` → `DashboardComponentSchema`',
   'content/docs/guide/architecture-overview.md':
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 5 ' +
     'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -264,28 +273,38 @@ const UNGATED_DOCS = {
   'content/docs/guide/building-crud-app.md':
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '20 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 4 unresolved-module diagnostic(s); plus TS2305x2 TS2339x1 TS2345x1 ' +
-    'TS2554x1 TS2724x1 TS2882x1 — candidate real defects, un-triaged. The missing-export ' +
-    'diagnostics name `Field` (@object-ui/types), `ObjectSchema` (@object-ui/types), ' +
-    '`registerAllComponents` (@object-ui/components) — the reader-visible half of this entry',
+    'page never defines; 4 unresolved-module diagnostic(s); plus TS2339x1 TS2345x1 TS2882x1 — ' +
+    'candidate real defects, un-triaged. This entry read TS2305x2 TS2554x1 TS2724x1 until ' +
+    'objectui#5343: `registerAllComponents` (@object-ui/components) and the `ObjectSchema` / ' +
+    '`Field` builder pair (@object-ui/types) were fabricated. Registration is now what LOADING ' +
+    'the packages does (`initializeComponents()` plus the side-effect `@object-ui/fields` ' +
+    'import), which also retired the `registerAllFields(Registry)` arity error, and the object ' +
+    'metadata is the plain document a data source serves, with its `fields` record typed ' +
+    '`Record<string, FieldMetadata>`',
   'content/docs/guide/component-registry.md':
     '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
-    '51 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 6 unresolved-module diagnostic(s); plus TS2305x13 TS2339x1 — candidate ' +
-    'real defects, un-triaged. The missing-export diagnostics name `getComponentRegistry` ' +
-    '(@object-ui/react) x5, `registerDefaultRenderers` (@object-ui/components) x4, `BaseSchema` ' +
-    '(@object-ui/core) x3, `InputRenderer` (@object-ui/components) — the reader-visible half of ' +
-    'this entry',
+    '50 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
+    'page never defines; 6 unresolved-module diagnostic(s). This entry read TS2305x13 TS2339x1 ' +
+    'until objectui#5343, which cleared the page of fabricated exports: `getComponentRegistry` ' +
+    '(@object-ui/react) x5 → the `ComponentRegistry` singleton @object-ui/core exports, ' +
+    '`registerDefaultRenderers` (@object-ui/components) x4 → `initializeComponents()` plus the ' +
+    'side-effect `@object-ui/fields` import, `BaseSchema` (@object-ui/core) x3 → @object-ui/types ' +
+    '(which is also what retired the TS2339, since the real `BaseSchema` declares `className`), ' +
+    'and `InputRenderer` (@object-ui/components), which nothing replaces — the built-in renderers ' +
+    'are registered by loading their package, never handed out one by one',
   'content/docs/guide/deployment.md':
     '6 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
     'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 — candidate real ' +
     'defects, un-triaged',
   'content/docs/guide/expressions.md':
-    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 6 ' +
+    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 5 ' +
     'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; plus TS2724x1 TS7006x3 — candidate real defects, un-triaged. The ' +
-    'missing-export diagnostics name `getExpressionEvaluator` (@object-ui/core) — the ' +
-    'reader-visible half of this entry',
+    'page never defines; plus TS7006x1 — a candidate real defect, un-triaged. This entry read ' +
+    'TS2724x1 TS7006x3 until objectui#5343: `getExpressionEvaluator` (@object-ui/core) was ' +
+    'fabricated and nothing replaces it — there is no process-level evaluator, `SchemaRenderer` ' +
+    'constructs a fresh `ExpressionEvaluator` per evaluation, so the section now teaches the real ' +
+    'surface (`evaluateExpression(expr, context)` / `new ExpressionEvaluator(context)`) and the ' +
+    'two implicit-any parameters went with the `registerOperator` example it rooted',
   'content/docs/guide/layout.md':
     '21 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '20 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -317,21 +336,25 @@ const UNGATED_DOCS = {
     'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
     'page never defines; 1 unresolved-module diagnostic(s)',
   'content/docs/guide/schema-overview.md':
-    '9 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 2 ' +
+    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 2 ' +
     'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; plus TS2305x2 TS2724x6 — candidate real defects, un-triaged. The ' +
-    'missing-export diagnostics name `AppSchema` (@object-ui/types) x2, `ThemeSchema` ' +
-    '(@object-ui/types) x2, `AppSchema` (@object-ui/types/zod), `ReportSchema` ' +
-    '(@object-ui/types), `ReportSchema` (@object-ui/types/zod), `ThemeSchema` ' +
-    '(@object-ui/types/zod) — the reader-visible half of this entry',
+    'page never defines. This entry read TS2305x2 TS2724x6 until objectui#5343: `AppSchema`, ' +
+    '`ThemeSchema` and `ReportSchema` were fabricated in BOTH the type and the ' +
+    '`@object-ui/types/zod` entry, and are re-spelled `AppComponentSchema`, ' +
+    '`ThemeComponentSchema`, `ReportComponentSchema` at every site including the prose. The ' +
+    'annotations that renaming made real then rejected two more falsehoods in the theme example ' +
+    '(`mode: \'system\'`, and per-theme `light`/`dark` palettes where the spec `Theme` carries one ' +
+    '`colors` map), fixed in the same pass so the page could not get worse',
   'content/docs/guide/schema-rendering.md':
     '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s); plus TS2305x4 TS2322x1 TS2451x2 ' +
-    'TS7006x5 — candidate real defects, un-triaged. The missing-export diagnostics name ' +
-    '`FormSchema` (@object-ui/core), `getComponentRegistry` (@object-ui/react), `PageSchema` ' +
-    '(@object-ui/core), `registerDefaultRenderers` (@object-ui/components) — the reader-visible ' +
-    'half of this entry',
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 TS2451x2 TS7006x5 — ' +
+    'candidate real defects, un-triaged. This entry read TS2305x4 until objectui#5343: ' +
+    '`registerDefaultRenderers` (@object-ui/components) → `initializeComponents()` plus the ' +
+    'side-effect `@object-ui/fields` import, `getComponentRegistry` (@object-ui/react) → the ' +
+    '`ComponentRegistry` singleton @object-ui/core exports, and `PageSchema` / `FormSchema` were ' +
+    'claimed from @object-ui/core while they live in @object-ui/types (`PageNodeSchema` there, ' +
+    'whose `body` is `SchemaNode[]` — the typed example is written as an array now)',
   'content/docs/guide/theming.md':
     '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '23 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -339,9 +362,11 @@ const UNGATED_DOCS = {
     'real defects, un-triaged',
   'content/docs/guide/troubleshooting.md':
     '8 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 TS2339x2 TS2559x1 ' +
-    'TS2724x1 — candidate real defects, un-triaged. The missing-export diagnostics name ' +
-    '`componentSchema` (@object-ui/types/zod) — the reader-visible half of this entry',
+    'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 TS2339x2 TS2559x1 — ' +
+    'candidate real defects, un-triaged. This entry read TS2724x1 until objectui#5343: the zod ' +
+    'entry exports `ComponentSchema`, not `componentSchema` — and because the same block imports ' +
+    'the TYPE of that name from @object-ui/types, the validator is imported under an alias rather ' +
+    'than colliding with it',
   'content/docs/guide/user-state-persistence.md':
     '10 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +


### PR DESCRIPTION
Fixes #5343
Part of #5174

The getting-started guides taught 14 symbols the packages do not export. A reader who copied one of those imports did not get a degraded render — they got a compile error. Same class as #5160 (five published READMEs), one directory over, on the pages people copy from most.

Every name set comes from each package's **built `dist/index.d.ts`**, resolved exactly as `check-doc-snippet-types.mjs` resolves it (each package's `exports.types`), never from a grep of `src/` — the #5053 rule. The measurement harness reuses that script's own `analyze()` / `compileSnippets()`, so the numbers below are produced by the same pipeline that writes the ledger, over the **whole corpus in one program** (637 blocks, 541 semantically judged). Build artifacts sit between every edit and the thing under test, so the packages were built first (`turbo run build`, 43 tasks) and every measurement ran against that `dist/`.

## Re-measured before working — and it agrees with the card

The card said its symbol table came from PR5341's run and the tree had moved. Re-derived here, the **baseline reproduced the ledger's recorded mix exactly, for all seven entries** — so this tree had not moved on these pages. One number disagrees with the card's body table: `AppSchema` / `ThemeSchema` / `ReportSchema` are **8** occurrences, not 9 (TS2305x2 + TS2724x6 in `schema-overview.md`). The card's `ObjectStackProvider` row lives at `content/docs/utilities/index.md:163`, **outside this card's file surface**; it is untouched, still on the ledger, and now filed on its own (see Findings).

## One disposition per symbol, applied at every site

| symbol | claimed from | disposition | resolves to | sites |
| --- | --- | --- | --- | --- |
| `getComponentRegistry` | `@object-ui/react` | renamed + wrong package | `ComponentRegistry`, the process-level singleton `@object-ui/core` exports (`Registry.d.ts:341`; the spelling PR5260 landed in the core/react/components READMEs) | component-registry ×5, schema-rendering ×1 |
| `registerDefaultRenderers` | `@object-ui/components` | renamed — **settled by PR5341, not re-decided** | `initializeComponents()` plus the side-effect `import '@object-ui/fields'` (`apps/site/app/components/ObjectUIProvider.tsx`) | component-registry ×4, schema-rendering ×1 |
| `registerAllComponents` | `@object-ui/components` | same disposition, same evidence | as above (which also retired the `registerAllFields(Registry)` arity error — the real one takes no arguments and the module calls it itself at load) | building-crud-app ×1 |
| `BaseSchema` | `@object-ui/core` | wrong package | `@object-ui/types` (`base.d.ts:65`, and it declares `className` — which is what retired the page's TS2339) | component-registry ×3 |
| `PageSchema` | `@object-ui/types` / `@object-ui/core` | renamed + wrong package | `PageNodeSchema` in `@object-ui/types` — renamed by objectui#3074, which split the renderer NODE off the spec's `Page` document | schema-reference ×1, schema-rendering ×1 |
| `FormSchema` | `@object-ui/core` | wrong package | `@object-ui/types` (`form.d.ts:1073`) | schema-rendering ×1 |
| `DashboardSchema` | `@object-ui/types` | renamed | `DashboardComponentSchema` (`complex.d.ts:657`) | schema-reference ×1 |
| `AppSchema` | `@object-ui/types`, `/zod` | renamed | `AppComponentSchema` (`app.d.ts:283`, zod `app.zod`) | schema-overview ×3 |
| `ThemeSchema` | `@object-ui/types`, `/zod` | renamed | `ThemeComponentSchema` (`theme.d.ts:79`, zod `theme.zod`) | schema-overview ×3 |
| `ReportSchema` | `@object-ui/types`, `/zod` | renamed | `ReportComponentSchema` — the presentation layer; `Spec*` is the definition layer (`spec-report.d.ts` header) | schema-overview ×2 |
| `componentSchema` | `@object-ui/types/zod` | renamed (case) | `ComponentSchema` (`zod/blocks.zod.d.ts:482`) — aliased at the site, because the same block already imports the TYPE of that name | troubleshooting ×1 |
| `InputRenderer` | `@object-ui/components` | **removed, nothing replaces it** | built-in renderers are registered by loading their package; they are not handed out one by one. The "Registering Individual Components" section is gone | component-registry ×1 |
| `ObjectSchema` / `Field` | `@object-ui/types` | **removed, nothing replaces it** | no builder API exists. Object metadata is the plain document a data source serves (`DataSource.getObjectSchema()` returns `Promise&lt;any&gt;`); the example now writes it as a literal whose `fields` record is typed against the real `FieldMetadata` union | building-crud-app ×1 (two names) |
| `getExpressionEvaluator` | `@object-ui/core` | **removed, nothing replaces it** | there is no process-level evaluator — `SchemaRenderer.tsx:420` constructs a fresh `ExpressionEvaluator` per evaluation, and each one builds its own `FormulaFunctions`. The section now teaches `evaluateExpression(expr, context)` and `new ExpressionEvaluator(context)` | expressions ×1 |

Two same-spelling names were checked and deliberately **not** touched, because their source is real: `layout.md`'s prose "an `AppSchema` JSON document" and `dashboard-filters.md`'s "`DashboardSchema.dateRange` … are part of `@objectstack/spec`" both name **spec** exports (`@objectstack/spec/ui` does export `AppSchema`). The defect was always the claimed source, never the spelling in the abstract.

The two replacement claims in `expressions.md` were verified by running them against the built `dist/`, not by reading: a context-supplied function is callable under its exact name (`evaluateExpression('${formatCurrency(price)}', { formatCurrency, price: 1234.5 })` → `'$1,234.50'`), and `${user.permissions.includes('admin')}` returns `true` / `false` against the two obvious contexts.

## Adjacent falsehoods the renames exposed — fixed here, and why that is not scope creep

Re-pointing an import at the real type turns a previously-unchecked literal into a checked one. Three blocks would have gained a **new** diagnostic class, which the ratchet forbids, so they were corrected in the same pass, each pinned by the same built `d.ts` the disposition came from:

- `schema-overview.md` theme example — `mode: 'system'` (the vocabulary is `auto` / `light` / `dark`) and per-theme `light` / `dark` palettes (the spec `Theme` carries one `colors` map). Measured: TS2322x1 + TS2353x1 appeared, then went.
- `schema-rendering.md` typed page — `PageNodeSchema.body` is `SchemaNode[]`, so the nested form is an array element. Measured: TS2353x1 appeared, then went.
- `component-registry.md` `register(…)` metadata — `displayName` / `description` / `tags` / `schema` / `lazy: true` are not `ComponentMeta` keys; the real ones (`label`, `category`, `icon`, `inputs`, `labelling`) are used, and lazy registration is `registerLazy(type, loader)`. In the same page `getRegisteredTypes()` / `getMetadata()` became `getAllTypes()` / `getMeta()`, the names the `Registry` class declares.

## Ledger — rewritten to the new measured mix, never widened

Every entry stays: none of the seven pages reaches zero, because #5174's fragment / self-containment half is a separate job.

| entry | before (= what the ledger recorded) | after |
| --- | --- | --- |
| `api/schema-reference.md` | 1 undef; **TS2305x1 TS2724x1** | 1 undef |
| `guide/building-crud-app.md` | 1 parse; 20 undef; 4 unres; **TS2305x2** TS2339x1 TS2345x1 **TS2554x1 TS2724x1** TS2882x1 | 1 parse; 20 undef; 4 unres; TS2339x1 TS2345x1 TS2882x1 |
| `guide/component-registry.md` | 3 parse; 51 undef; 6 unres; **TS2305x13 TS2339x1** | 3 parse; 50 undef; 6 unres |
| `guide/expressions.md` | 8 parse; 6 undef; **TS2724x1** TS7006x3 | 8 parse; 5 undef; TS7006x1 |
| `guide/schema-overview.md` | 9 parse; 2 undef; **TS2305x2 TS2724x6** | 8 parse; 2 undef |
| `guide/schema-rendering.md` | 8 parse; 10 undef; 1 unres; **TS2305x4** TS2322x1 TS2451x2 TS7006x5 | 8 parse; 10 undef; 1 unres; TS2322x1 TS2451x2 TS7006x5 |
| `guide/troubleshooting.md` | 8 undef; 1 unres; TS2322x1 TS2339x2 TS2559x1 **TS2724x1** | 8 undef; 1 unres; TS2322x1 TS2339x2 TS2559x1 |

Every bucket is equal or lower and no new class appears. Nothing was added to the ledger, no threshold moved, and **no export was added to any package** — the accept set is untouched.

The ledger's header note is updated with it: after this change, exactly one entry in the whole file still names a missing export (`content/docs/utilities/index.md`, `ObjectStackProvider`), and it says so by name.

## Verification (at `d975803fb`, the final commit)

```
node scripts/check-doc-snippet-types.mjs      → 87/87 blocks judged, 0 failed; ledger exact; controls green
node scripts/check-doc-component-types.mjs    → 564 type literals, 0 unregistered
node scripts/check-doc-links.mjs              → links valid across 13 scan roots
node scripts/check-control-bytes.mjs          → OK (4757 tracked text files)
node scripts/check-changeset-{no-major,fixed,presence}.mjs → green; no changeset owed
pnpm exec eslint scripts/check-doc-snippet-types.mjs       → clean
pnpm exec vitest run scripts/__tests__/check-doc-{snippet,component}-types.test.ts → 47 passed
```

Corpus re-derivation at the same commit: over **all 35 guide pages plus `schema-reference.md`**, and again over the whole 637-block corpus, **zero** TS2305 / TS2724 / TS2614 remain anywhere under this card's file surface. The only missing-export diagnostic left in the corpus is `ObjectStackProvider` at `content/docs/utilities/index.md:163`.

Changeset: **empty frontmatter** (`.changeset/guide-fabricated-exports-5343.md`) — docs and gate ledger only, no package `src/` touched, so nothing publishes. That is this repo's declared "no release" form (AGENTS.md §9; precedent `.changeset/app-shell-docs-nav-examples.md`) and it is what `check-changeset-presence.mjs` confirms is owed. The dispatch suggested `patch`; a patch would move all 39 packages of the fixed group for a change with no runtime effect, so the empty declaration is used instead and flagged here.

## Findings, filed not fixed

- **#5360** — `content/docs/utilities/index.md` still documents the `ObjectStackProvider` phantom React API that #4124 / PR4129 removed from the sibling page one file over. Outside this card's file surface.
- **#5362** — `ObjectSchemaMetadata` declares neither `titleFormat` nor `list_views` / `listViews` nor `icon`, all of which the runtime reads. Adding them is a contract change and a different card; this PR left the guide's metadata document a plain literal and typed only the `fields` record.
- **#5363** — `ExpressionEvaluator.registerFunction(name, fn)` upper-cases the name, so `${formatCurrency(x)}` never resolves to a function registered as `formatCurrency` and renders its own source instead. Measured, not inferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_