### PR TITLE
refactor(layout): remove the unread `logo` key from AppShellBranding

### DIFF
--- a/.changeset/appshellbranding-logo-removed.md
+++ b/.changeset/appshellbranding-logo-removed.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/layout': minor
+'@object-ui/app-shell': minor
+'@object-ui/console': minor
+---
+
+Remove the published optional key `logo` from `AppShellBranding` (`@object-ui/layout`).
+
+The key was declared but never read. `useAppShellBranding` applies only
+`primaryColor`, `accentColor`, `favicon` and `title`, and `AppShell` installs no
+context provider at all — so its doc comment, "Logo URL — passed to sidebar/navbar
+via context", described a mechanism that did not exist. Three call sites were
+feeding the key a real value that was silently discarded, and all three are removed
+with it: `AppSchemaRenderer`, `ConsoleLayout` and the console's `useBranding` hook.
+
+The real logo entry point is unchanged and is where it always was: the app schema's
+own `branding.logo`, read directly by `AppSidebar` in `@object-ui/app-shell`, plus
+the app schema's top-level `logo`, rendered directly by `AppSchemaRenderer`'s
+default sidebar header. Neither path went through `AppShellBranding`, so nothing
+rendering-visible changes.
+
+Migration: a consumer that passes `logo` inside an `AppShellBranding` object literal
+now gets a compile error. Delete the key — it never reached a renderer. To show a
+logo, set it on the app schema's `branding.logo` instead.

--- a/apps/console/src/hooks/useBranding.ts
+++ b/apps/console/src/hooks/useBranding.ts
@@ -14,7 +14,6 @@ interface AppBranding {
   primaryColor?: string;
   accentColor?: string;
   favicon?: string;
-  logo?: string;
 }
 
 export function useBranding(app: { branding?: AppBranding; label?: string } | undefined) {
@@ -24,7 +23,6 @@ export function useBranding(app: { branding?: AppBranding; label?: string } | un
           primaryColor: app.branding.primaryColor,
           accentColor: app.branding.accentColor,
           favicon: app.branding.favicon,
-          logo: app.branding.logo,
         }
       : undefined,
     app?.label ? `${app.label} — ${getProductName()}` : undefined,

--- a/packages/app-shell/src/layout/ConsoleLayout.tsx
+++ b/packages/app-shell/src/layout/ConsoleLayout.tsx
@@ -171,7 +171,6 @@ export function ConsoleLayout({
               primaryColor: activeApp.branding.primaryColor,
               accentColor: activeApp.branding.accentColor,
               favicon: activeApp.branding.favicon,
-              logo: activeApp.branding.logo,
               title: activeApp.label
                 ? `${resolveKeyedI18nLabel(activeApp.label)} — ${getProductName()}`
                 : undefined,

--- a/packages/layout/src/AppSchemaRenderer.tsx
+++ b/packages/layout/src/AppSchemaRenderer.tsx
@@ -579,7 +579,6 @@ export function AppSchemaRenderer({
   const branding: AppShellBranding = {
     title: schema.title,
     favicon: schema.favicon,
-    logo: schema.logo,
   };
 
   // --- Build sidebar element ---

--- a/packages/layout/src/AppShell.tsx
+++ b/packages/layout/src/AppShell.tsx
@@ -16,8 +16,6 @@ export interface AppShellBranding {
   accentColor?: string;
   /** Favicon URL — replaces the <link rel="icon"> href */
   favicon?: string;
-  /** Logo URL — passed to sidebar/navbar via context */
-  logo?: string;
   /** Page title suffix (sets document.title) */
   title?: string;
 }


### PR DESCRIPTION
Fixes #4818

Maintainer ruling, 2026-08-19, over the 27-card objectui decision-inbox review (comment 5339695386), verbatim: 「全部接受」 — **option 1, remove**. Option 2 (build a real branding context) was rejected as a permanent provider obligation with zero demand.

## What was removed

`AppShellBranding.logo` was declared but never read.

- `useAppShellBranding` (`packages/layout/src/AppShell.tsx`) applies only `primaryColor`, `accentColor`, `favicon` and `title`; its effect dependency array does not list `logo` at all.
- `AppShell` installs no context provider, so the key's doc comment — "Logo URL — passed to sidebar/navbar via context" — named a mechanism that does not exist in the code. That comment is deleted with the key.

Six deleted lines, no additions, across four files plus a changeset.

## Three feed lines, not one

The card named one feeder. There are three, and each one was handing the key a real value that was silently discarded:

| Feed line | Named by |
| --- | --- |
| `apps/console/src/hooks/useBranding.ts:27` — `logo: app.branding.logo` | the card |
| `packages/layout/src/AppSchemaRenderer.tsx:582` — `logo: schema.logo` | the dispatch's correction |
| `packages/app-shell/src/layout/ConsoleLayout.tsx:174` — `logo: activeApp.branding.logo` | **nobody** |

The third is the only reason this diff reaches `packages/app-shell`, which is outside the file surface the card and the dispatch drew. It is not optional: deleting the key makes that line a hard `tsc` error (evidence below), so leaving it would ship a red typecheck. It is the same defect class, the same mechanical one-line deletion as its two siblings, in a file no in-flight worktree or open PR touches, and it adds no new gate. `apps/console/src/hooks/useBranding.ts` also loses the matching `logo?: string` from its local `AppBranding` interface — that hook has zero callers today.

## The premise check the dispatch asked for — measured, and it holds

The dispatch flagged one thing to verify rather than assume: `AppSchemaRenderer` forwarded `schema.logo`, a **top-level** app-schema key, while `AppSidebar.tsx:194` reads `activeApp?.branding?.logo`, a **nested** one — so was the forward actually dead?

Measured on `origin/main` `bdf8cf76e`: they are **not** the same key and **not** the same place — but that turns out not to matter, because **neither logo render site goes through `AppShellBranding` at all**. Both are untouched by this PR:

- `packages/layout/src/AppSchemaRenderer.tsx:385` — `resolveIcon(schema.logo)` — and `:397-399`, an `img` whose `src` is `schema.logo`, in the default sidebar header. This renders the top-level key **directly**, in the very same file that built the branding object. The forward at `:582` was a second, parallel, dead route for a value the file was already rendering itself.
- `packages/app-shell/src/layout/AppSidebar.tsx:194` — `activeApp?.branding?.logo`, read directly off the app schema.

So the ruling's premise — "the logo already renders correctly today via the real path" — is true for both halves. The roll-back clause does not trigger.

## Reverse verification

Stated per leg, because a deletion PR is exactly the shape that passes vacuously. **`tsc` has a build artifact between the edit and the result** for the two cross-package legs: the root `tsconfig.json` has no `paths` entry for `@object-ui/layout`, so consumers resolve it through `node_modules` to `packages/layout/dist/AppShell.d.ts`. Every leg below rebuilt that artifact first and proved the marker's presence or absence in it. Vitest is the opposite: `vitest.config.mts:263` aliases `@object-ui/layout` to `packages/layout/src`, so **no artifact sits between the edit and the tests**.

**Leg 1 — baseline, `logo` present in the built `.d.ts`.** After building the dependency closure, `packages/layout/dist/AppShell.d.ts:14` carried `logo?: string;`. All three consumer packages type-checked clean, i.e. writing `logo` compiled:

```
packages/layout type-check: Done
packages/app-shell type-check: Done
apps/console type-check: Done
EXIT=0
```

**Leg 2 — key deleted, feed lines still in place; rebuild proved the marker gone** (`grep -c logo packages/layout/dist/AppShell.d.ts` → `0`). Each of the three consumers then failed, naming exactly one site:

```
packages/layout   src/AppSchemaRenderer.tsx(582,5): error TS2353: Object literal may only
                  specify known properties, and 'logo' does not exist in type 'AppShellBranding'.
packages/app-shell src/layout/ConsoleLayout.tsx(174,15): error TS2322: ... Object literal may
                  only specify known properties, and 'logo' does not exist in type 'AppShellBranding'.
apps/console      src/hooks/useBranding.ts(27,11): error TS2345: ... Object literal may only
                  specify known properties, and 'logo' does not exist in type 'AppShellBranding'.
```

That is the answer to "show that a consumer writing `logo` is now a compile error" — demonstrated by three real consumers, two of them resolving through the published `.d.ts` exactly as an external consumer would.

**Leg 3 — feed lines deleted, artifacts rebuilt, marker re-confirmed absent.** All three green again (`EXIT=0`).

**Nothing rendering-visible changed.** The removed key had no reader: no branch of `useAppShellBranding` touched it, and `AppShell` exposes no context for anything downstream to read it from. The two live render sites listed above still sit at the same lines.

## Tests

Run from the **repo root** with path filters, never `pnpm --filter pkg test` — 17 packages here own a standalone `vitest.config.ts` that does not re-export the root config, so a package-scoped run executes a different config than CI.

```
pnpm exec vitest run packages/layout/ apps/console/ --maxWorkers=2
  Test Files  76 passed (76)
       Tests  874 passed (874)

pnpm exec vitest run packages/app-shell/src/layout/ packages/app-shell/src/console/ \
                     packages/app-shell/src/runtime-config.test.ts packages/app-shell/src/hooks/ --maxWorkers=2
  Test Files  110 passed (110)
       Tests  835 passed (835)
```

186 files, 1709 tests, zero failures. The second command's paths cover every `packages/app-shell` test that mentions `ConsoleLayout`, `AppShellBranding` or `branding`, plus the `AppSidebar` suites that guard the real logo path. The remainder of that package's 456 files is left to CI, which runs the whole farm once anyway.

## Gates

Union re-run **after** the final commit, at `49dee42ad`:

```
check-changeset-presence   4 source file(s) of 3 released package(s) changed, 1 changeset declared
check:changeset (fixed)    All workspace packages are in the changeset fixed group
check:changeset (no-major) No changeset declares a `major` bump
check:control-bytes        OK (4757 tracked text files)
check:doc-types            Every documented component type is registered
check:doc-snippets         87 of 87 blocks judged, 0 failed — compiled against the BUILT types
check:phantom-deps         Every in-scope import is declared by the package that publishes it
check:self-import          No package names itself inside its own src/
lint                       0 errors (201 pre-existing warnings, unchanged from main)
```

`check:doc-snippets` is the load-bearing one for a published-type deletion: it compiles documentation snippets against the built types and found no snippet writing `logo` on an `AppShellBranding` literal.

## Docs

- `packages/layout/README.md:82` — re-read, **unchanged**. Its `branding` row already lists exactly the four keys really read, so it gains no stale mention.
- `content/docs/guide/layout.md:82` — same row, same four keys, likewise needs nothing.
- `content/docs/layout/app-shell.mdx` — **deliberately not touched**. Its only `AppShellBranding` mention is a "see AppShellBranding" pointer, and its logo prose is about the `navbar` slot, an unrelated `ReactNode`. The app-shell.mdx prose is #4830's job and remains open; writing it here would be a file-surface breach.

## Versioning

`minor` for `@object-ui/layout`, `@object-ui/app-shell` and `@object-ui/console` — never `major`. Maintainer, 2026-08-19, verbatim: 「objectui ui 的 major 是要跟着 objectstack 走的,不可以自己发 major」. The changeset body names the removed published optional key and the real replacement path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_