### PR TITLE
fix(fields,auth,mobile,collaboration,permissions,providers): publish explicit .js extensions so plain Node ESM can load these entries

### DIFF
--- a/.changeset/issue-5214-esm-specifiers-six-packages.md
+++ b/.changeset/issue-5214-esm-specifiers-six-packages.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/collaboration': patch
+'@object-ui/permissions': patch
+'@object-ui/providers': patch
+'@object-ui/fields': patch
+'@object-ui/mobile': patch
+'@object-ui/auth': patch
+---
+
+Publish relative import specifiers with explicit `.js` extensions so these six packages load under plain Node ESM.
+
+Node's ESM resolver does not extension-search relative specifiers and `tsc` never rewrites them, so an extensionless `./Foo` in the source shipped as an extensionless `./Foo` in `dist` and importing the package entry outside a bundler failed with `ERR_MODULE_NOT_FOUND`. Bundled consumers were unaffected. Unbundled consumers — plain Node ESM, an SSR host importing the package directly, anyone running the published tarball without a build step — can now import these entries, and so can the downstream `@object-ui/plugin-*` packages that evaluate through `mobile`, `permissions` and `providers`.

--- a/packages/auth/src/AuthContext.ts
+++ b/packages/auth/src/AuthContext.ts
@@ -7,7 +7,7 @@
  */
 
 import { createContext } from 'react';
-import type { AuthUser, AuthClientSession, PreviewModeOptions, AuthOrganization, AuthOrganizationMember, AuthInvitation, AuthPublicConfig, SignInWithProviderOptions, DelegableScope } from './types';
+import type { AuthUser, AuthClientSession, PreviewModeOptions, AuthOrganization, AuthOrganizationMember, AuthInvitation, AuthPublicConfig, SignInWithProviderOptions, DelegableScope } from './types.js';
 
 export interface AuthContextValue {
   /** Current authenticated user */

--- a/packages/auth/src/AuthGuard.tsx
+++ b/packages/auth/src/AuthGuard.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { useAuth } from './useAuth';
+import { useAuth } from './useAuth.js';
 
 export interface AuthGuardProps {
   /** Content to render when user is not authenticated */

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -7,11 +7,11 @@
  */
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { authGateEvents } from './auth-gate-events';
-import type { AuthUser, AuthClient, AuthProviderOptions, PreviewModeOptions, AuthOrganization, AuthOrganizationMember, AuthInvitation, AuthPublicConfig, SignInWithProviderOptions } from './types';
-import { AuthCtx, type AuthContextValue } from './AuthContext';
-import { createAuthClient, TokenStorage } from './createAuthClient';
-import { ActiveOrganizationStorage } from './createAuthenticatedFetch';
+import { authGateEvents } from './auth-gate-events.js';
+import type { AuthUser, AuthClient, AuthProviderOptions, PreviewModeOptions, AuthOrganization, AuthOrganizationMember, AuthInvitation, AuthPublicConfig, SignInWithProviderOptions } from './types.js';
+import { AuthCtx, type AuthContextValue } from './AuthContext.js';
+import { createAuthClient, TokenStorage } from './createAuthClient.js';
+import { ActiveOrganizationStorage } from './createAuthenticatedFetch.js';
 
 /**
  * Prefix of every `MetadataProvider` seed entry in `sessionStorage`

--- a/packages/auth/src/ForgotPasswordForm.tsx
+++ b/packages/auth/src/ForgotPasswordForm.tsx
@@ -7,8 +7,8 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { useAuth } from './useAuth';
-import type { AuthLinkComponentProps } from './types';
+import { useAuth } from './useAuth.js';
+import type { AuthLinkComponentProps } from './types.js';
 import {
   AUTH_FIELD_LABEL_CLASS,
   AUTH_INPUT_CLASS,
@@ -18,7 +18,7 @@ import {
   AuthFormHeader,
   AuthMailIcon,
   AuthSpinner,
-} from './authStyles';
+} from './authStyles.js';
 
 /** Translatable labels for the ForgotPasswordForm */
 export interface ForgotPasswordFormLabels {

--- a/packages/auth/src/LoginForm.tsx
+++ b/packages/auth/src/LoginForm.tsx
@@ -7,10 +7,10 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { useAuth } from './useAuth';
-import { SocialSignInButtons } from './SocialSignInButtons';
-import { looksLikePhoneIdentifier, normalizePhoneIdentifier } from './phone-identifier';
-import type { AuthLinkComponentProps } from './types';
+import { useAuth } from './useAuth.js';
+import { SocialSignInButtons } from './SocialSignInButtons.js';
+import { looksLikePhoneIdentifier, normalizePhoneIdentifier } from './phone-identifier.js';
+import type { AuthLinkComponentProps } from './types.js';
 import {
   AUTH_FIELD_LABEL_CLASS,
   AUTH_INPUT_CLASS,
@@ -20,7 +20,7 @@ import {
   AuthErrorBanner,
   AuthFormHeader,
   AuthSpinner,
-} from './authStyles';
+} from './authStyles.js';
 
 /** Translatable labels for the LoginForm */
 export interface LoginFormLabels {

--- a/packages/auth/src/PreviewBanner.tsx
+++ b/packages/auth/src/PreviewBanner.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { useAuth } from './useAuth';
+import { useAuth } from './useAuth.js';
 
 export interface PreviewBannerProps {
   /** Custom class name for the banner */

--- a/packages/auth/src/RegisterForm.tsx
+++ b/packages/auth/src/RegisterForm.tsx
@@ -7,9 +7,9 @@
  */
 
 import React, { useState } from 'react';
-import { useAuth } from './useAuth';
-import { SocialSignInButtons } from './SocialSignInButtons';
-import type { AuthLinkComponentProps } from './types';
+import { useAuth } from './useAuth.js';
+import { SocialSignInButtons } from './SocialSignInButtons.js';
+import type { AuthLinkComponentProps } from './types.js';
 import {
   AUTH_FIELD_LABEL_CLASS,
   AUTH_INPUT_CLASS,
@@ -18,7 +18,7 @@ import {
   AuthErrorBanner,
   AuthFormHeader,
   AuthSpinner,
-} from './authStyles';
+} from './authStyles.js';
 
 /** Translatable labels for the RegisterForm */
 export interface RegisterFormLabels {

--- a/packages/auth/src/SocialSignInButtons.tsx
+++ b/packages/auth/src/SocialSignInButtons.tsx
@@ -7,9 +7,9 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { useAuth } from './useAuth';
-import { AuthSpinner } from './authStyles';
-import type { AuthSocialProvider } from './types';
+import { useAuth } from './useAuth.js';
+import { AuthSpinner } from './authStyles.js';
+import type { AuthSocialProvider } from './types.js';
 
 // Brand name overrides for providers whose `name` from the server may be unset
 // or where we want to canonicalize casing.

--- a/packages/auth/src/UserMenu.tsx
+++ b/packages/auth/src/UserMenu.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { useAuth } from './useAuth';
-import { getUserInitials } from './types';
+import { useAuth } from './useAuth.js';
+import { getUserInitials } from './types.js';
 
 export interface UserMenuProps {
   /** Custom avatar URL override */

--- a/packages/auth/src/createAuthClient.ts
+++ b/packages/auth/src/createAuthClient.ts
@@ -11,8 +11,8 @@ import { organizationClient, twoFactorClient } from 'better-auth/client/plugins'
 import type {
   AuthClient, AuthClientConfig, AuthUser, AuthClientSession, SignInCredentials, SignUpData,
   AuthOrganization, AuthOrganizationMember, AuthInvitation, AuthPublicConfig, SignInWithProviderOptions,
-} from './types';
-import { AUTH_INVITATION_STATUSES, isAuthInvitationStatus } from './invitation-status';
+} from './types.js';
+import { AUTH_INVITATION_STATUSES, isAuthInvitationStatus } from './invitation-status.js';
 
 const TOKEN_STORAGE_KEY = 'auth-session-token';
 
@@ -710,7 +710,7 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
      * `null` so the caller HIDES placement instead of offering a form the
      * server would refuse.
      */
-    async describeDelegableScope(): Promise<import('./types').DelegableScope | null> {
+    async describeDelegableScope(): Promise<import('./types.js').DelegableScope | null> {
       try {
         const securityBase = basePath.replace(/\/auth$/, '/security');
         const response = await bearerFetch(`${origin}${securityBase}/my-delegable-scope`, {
@@ -722,7 +722,7 @@ export function createAuthClient(config: AuthClientConfig): AuthClient {
         // The server wraps some payloads as `{ success, data }`; tolerate both.
         const scope = body && typeof body === 'object' && 'data' in body ? body.data : body;
         return scope && typeof scope === 'object' && Array.isArray(scope.placeableBusinessUnitIds)
-          ? (scope as import('./types').DelegableScope)
+          ? (scope as import('./types.js').DelegableScope)
           : null;
       } catch {
         return null;

--- a/packages/auth/src/createAuthenticatedFetch.ts
+++ b/packages/auth/src/createAuthenticatedFetch.ts
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { TokenStorage } from './createAuthClient';
-import { authGateEvents, detectAuthGate } from './auth-gate-events';
+import { TokenStorage } from './createAuthClient.js';
+import { authGateEvents, detectAuthGate } from './auth-gate-events.js';
 
 /**
  * Options for creating an authenticated adapter.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -21,21 +21,21 @@
  * @packageDocumentation
  */
 
-export { AuthProvider, type AuthProviderProps } from './AuthProvider';
-export { useAuth } from './useAuth';
-export { useIsWorkspaceAdmin } from './useIsWorkspaceAdmin';
-export { AuthGuard, type AuthGuardProps } from './AuthGuard';
-export { AuthShell, type AuthShellProps, type AuthShellBrandPanel } from './AuthShell';
-export { LoginForm, type LoginFormProps, type LoginFormLabels } from './LoginForm';
-export { RegisterForm, type RegisterFormProps, type RegisterFormLabels } from './RegisterForm';
-export { ForgotPasswordForm, type ForgotPasswordFormProps, type ForgotPasswordFormLabels } from './ForgotPasswordForm';
-export { SocialSignInButtons, type SocialSignInButtonsProps } from './SocialSignInButtons';
-export { UserMenu, type UserMenuProps } from './UserMenu';
-export { PreviewBanner, type PreviewBannerProps } from './PreviewBanner';
-export { createAuthClient, TokenStorage } from './createAuthClient';
-export { normalizePhoneIdentifier, looksLikePhoneIdentifier } from './phone-identifier';
-export { createAuthenticatedFetch, ActiveOrganizationStorage, type AuthenticatedAdapterOptions } from './createAuthenticatedFetch';
-export { getUserInitials } from './types';
+export { AuthProvider, type AuthProviderProps } from './AuthProvider.js';
+export { useAuth } from './useAuth.js';
+export { useIsWorkspaceAdmin } from './useIsWorkspaceAdmin.js';
+export { AuthGuard, type AuthGuardProps } from './AuthGuard.js';
+export { AuthShell, type AuthShellProps, type AuthShellBrandPanel } from './AuthShell.js';
+export { LoginForm, type LoginFormProps, type LoginFormLabels } from './LoginForm.js';
+export { RegisterForm, type RegisterFormProps, type RegisterFormLabels } from './RegisterForm.js';
+export { ForgotPasswordForm, type ForgotPasswordFormProps, type ForgotPasswordFormLabels } from './ForgotPasswordForm.js';
+export { SocialSignInButtons, type SocialSignInButtonsProps } from './SocialSignInButtons.js';
+export { UserMenu, type UserMenuProps } from './UserMenu.js';
+export { PreviewBanner, type PreviewBannerProps } from './PreviewBanner.js';
+export { createAuthClient, TokenStorage } from './createAuthClient.js';
+export { normalizePhoneIdentifier, looksLikePhoneIdentifier } from './phone-identifier.js';
+export { createAuthenticatedFetch, ActiveOrganizationStorage, type AuthenticatedAdapterOptions } from './createAuthenticatedFetch.js';
+export { getUserInitials } from './types.js';
 
 // Organization membership-role vocabulary — a CLOSED, framework-owned list of
 // four (framework ADR-0108), re-exported from `@objectstack/spec`'s
@@ -53,7 +53,7 @@ export {
   invitableOrgRoles,
   assignableOrgRoles,
   type OrgRole,
-} from './org-roles';
+} from './org-roles.js';
 
 // Invitation lifecycle vocabulary — a CLOSED set of four, bound to better-auth's
 // own `InvitationStatus` so it cannot drift, plus the narrowing guard the wire
@@ -63,7 +63,7 @@ export {
   AUTH_INVITATION_STATUSES,
   isAuthInvitationStatus,
   type AuthInvitationStatus,
-} from './invitation-status';
+} from './invitation-status.js';
 
 // Shared auth form primitives — exposed so consumers can build custom forms
 // that match the look of LoginForm / RegisterForm / ForgotPasswordForm.
@@ -79,7 +79,7 @@ export {
   AuthFormHeader,
   AuthMailIcon,
   AuthSpinner,
-} from './authStyles';
+} from './authStyles.js';
 
 // Re-export types for convenience
 export type {
@@ -101,6 +101,6 @@ export type {
   SignInWithProviderOptions,
   TenancyPosture,
   DelegableScope,
-} from './types';
+} from './types.js';
 
-export type { AuthContextValue } from './AuthContext';
+export type { AuthContextValue } from './AuthContext.js';

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -13,7 +13,7 @@ import type {
   DelegableAdminScope,
 } from '@objectstack/spec/contracts';
 import type { TenancyPosture } from '@objectstack/spec/security';
-import type { AuthInvitationStatus } from './invitation-status';
+import type { AuthInvitationStatus } from './invitation-status.js';
 
 /**
  * Authentication types for @object-ui/auth

--- a/packages/auth/src/useAuth.ts
+++ b/packages/auth/src/useAuth.ts
@@ -7,7 +7,7 @@
  */
 
 import { useContext } from 'react';
-import { AuthCtx, type AuthContextValue } from './AuthContext';
+import { AuthCtx, type AuthContextValue } from './AuthContext.js';
 
 /**
  * Hook to access authentication state and methods.

--- a/packages/auth/src/useIsWorkspaceAdmin.ts
+++ b/packages/auth/src/useIsWorkspaceAdmin.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useAuth } from './useAuth';
+import { useAuth } from './useAuth.js';
 
 const ADMIN_ROLES = new Set([
   'owner',

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -8,6 +8,25 @@
     "paths": {
       "@/*": ["src/*"]
     },
+
+    // Node's ESM resolver does NOT extension-search relative specifiers, so an
+    // extensionless `./Foo` in the emitted dist is unloadable under plain Node
+    // (`ERR_MODULE_NOT_FOUND`) — objectui#5214, same defect and same remedy as
+    // objectui#4538. `tsc` never rewrites specifiers, so what the source writes
+    // is what dist ships; the only way to KEEP the extensions is to have the
+    // compiler reject a missing one (TS2835, and TS2834 for a bare directory
+    // import) instead of leaving it to review.
+    //
+    // These override the ROOT tsconfig's `"module": "ESNext"` /
+    // `"moduleResolution": "bundler"` for THIS package only — the root is
+    // shared by 38 packages and flipping it there is a different, much larger
+    // change. Emit is unchanged: package.json is `"type": "module"`, so
+    // `nodenext` emits the same ESM `ESNext` did.
+    //
+    // Runtime loadability is pinned separately by `pnpm check:node-esm-load`,
+    // which actually imports the built entry under plain Node.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
     "composite": true,

--- a/packages/collaboration/src/CommentThread.tsx
+++ b/packages/collaboration/src/CommentThread.tsx
@@ -10,7 +10,7 @@ import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import {
   useCollaborationTranslation,
   type CollaborationTranslate,
-} from './useCollaborationTranslation';
+} from './useCollaborationTranslation.js';
 
 export interface Comment {
   id: string;

--- a/packages/collaboration/src/LiveCursors.tsx
+++ b/packages/collaboration/src/LiveCursors.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useMemo } from 'react';
-import type { PresenceUser } from './usePresence';
+import type { PresenceUser } from './usePresence.js';
 
 export interface LiveCursorsProps {
   /** Other users' presence data */

--- a/packages/collaboration/src/PresenceAvatars.tsx
+++ b/packages/collaboration/src/PresenceAvatars.tsx
@@ -7,11 +7,11 @@
  */
 
 import React, { useMemo } from 'react';
-import type { PresenceUser } from './usePresence';
+import type { PresenceUser } from './usePresence.js';
 import {
   useCollaborationTranslation,
   type CollaborationTranslate,
-} from './useCollaborationTranslation';
+} from './useCollaborationTranslation.js';
 
 export interface PresenceAvatarsProps {
   /** Present users */

--- a/packages/collaboration/src/PresenceProvider.tsx
+++ b/packages/collaboration/src/PresenceProvider.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from 'react';
-import type { PresenceUser } from './usePresence';
+import type { PresenceUser } from './usePresence.js';
 
 /**
  * Scope key for record-level presence ("who else is viewing this record").

--- a/packages/collaboration/src/index.ts
+++ b/packages/collaboration/src/index.ts
@@ -26,7 +26,7 @@ export {
   type ConnectionState,
   type RealtimeMessage,
   type RealtimeResult,
-} from './useRealtimeSubscription';
+} from './useRealtimeSubscription.js';
 
 export {
   usePresence,
@@ -34,20 +34,20 @@ export {
   type PresenceUser,
   type PresenceConfig,
   type PresenceResult,
-} from './usePresence';
+} from './usePresence.js';
 
 export {
   useConflictResolution,
   type VersionEntry,
   type ConflictInfo,
   type ConflictResolutionResult,
-} from './useConflictResolution';
+} from './useConflictResolution.js';
 
 export {
   CommentThread,
   type Comment,
   type CommentThreadProps,
-} from './CommentThread';
+} from './CommentThread.js';
 
 // This package's i18n seam. Exported like `plugin-detail`'s
 // `useDetailTranslation` / `DETAIL_DEFAULT_TRANSLATIONS` so a host can read the
@@ -57,29 +57,29 @@ export {
   useCollaborationTranslation,
   COLLAB_DEFAULT_TRANSLATIONS,
   type CollaborationTranslate,
-} from './useCollaborationTranslation';
+} from './useCollaborationTranslation.js';
 
 export {
   useMentionNotifications,
   type MentionNotificationsConfig,
   type MentionNotificationsResult,
-} from './useMentionNotifications';
+} from './useMentionNotifications.js';
 
 export {
   useCommentSearch,
   type CommentSearchConfig,
   type CommentSearchReturn,
-} from './useCommentSearch';
+} from './useCommentSearch.js';
 
 export {
   LiveCursors,
   type LiveCursorsProps,
-} from './LiveCursors';
+} from './LiveCursors.js';
 
 export {
   PresenceAvatars,
   type PresenceAvatarsProps,
-} from './PresenceAvatars';
+} from './PresenceAvatars.js';
 
 export {
   PresenceProvider,
@@ -88,7 +88,7 @@ export {
   type PresenceSource,
   type PresenceProviderProps,
   type RecordPresenceScope,
-} from './PresenceProvider';
+} from './PresenceProvider.js';
 
 // Re-export types from @object-ui/types for convenience
 export type {

--- a/packages/collaboration/tsconfig.json
+++ b/packages/collaboration/tsconfig.json
@@ -8,6 +8,25 @@
     "paths": {
       "@/*": ["src/*"]
     },
+
+    // Node's ESM resolver does NOT extension-search relative specifiers, so an
+    // extensionless `./Foo` in the emitted dist is unloadable under plain Node
+    // (`ERR_MODULE_NOT_FOUND`) — objectui#5214, same defect and same remedy as
+    // objectui#4538. `tsc` never rewrites specifiers, so what the source writes
+    // is what dist ships; the only way to KEEP the extensions is to have the
+    // compiler reject a missing one (TS2835, and TS2834 for a bare directory
+    // import) instead of leaving it to review.
+    //
+    // These override the ROOT tsconfig's `"module": "ESNext"` /
+    // `"moduleResolution": "bundler"` for THIS package only — the root is
+    // shared by 38 packages and flipping it there is a different, much larger
+    // change. Emit is unchanged: package.json is `"type": "module"`, so
+    // `nodenext` emits the same ESM `ESNext` did.
+    //
+    // Runtime loadability is pinned separately by `pnpm check:node-esm-load`,
+    // which actually imports the built entry under plain Node.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
     "composite": true,

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -7,43 +7,43 @@
  */
 
 import React from 'react';
-import type { FieldWidgetComponentProps } from './widgets/types';
+import type { FieldWidgetComponentProps } from './widgets/types.js';
 
 // The SAME dedicated widgets the form renders — reused for in-place editing
 // (e.g. the data grid's inline cell editor) so a select edits as a dropdown, a
 // boolean as a checkbox, a date as a date picker, etc. — never a bare text box.
-import { TextField } from './widgets/TextField';
-import { TextAreaField } from './widgets/TextAreaField';
-import { NumberField } from './widgets/NumberField';
-import { CurrencyField } from './widgets/CurrencyField';
-import { PercentField } from './widgets/PercentField';
-import { SliderField } from './widgets/SliderField';
-import { RatingField } from './widgets/RatingField';
-import { BooleanField } from './widgets/BooleanField';
-import { SelectField } from './widgets/SelectField';
-import { MultiSelectField } from './widgets/MultiSelectField';
-import { RadioField } from './widgets/RadioField';
-import { CheckboxesField } from './widgets/CheckboxesField';
-import { TagsField } from './widgets/TagsField';
-import { DateField } from './widgets/DateField';
-import { DateTimeField } from './widgets/DateTimeField';
-import { TimeField } from './widgets/TimeField';
-import { EmailField } from './widgets/EmailField';
-import { PhoneField } from './widgets/PhoneField';
-import { UrlField } from './widgets/UrlField';
+import { TextField } from './widgets/TextField.js';
+import { TextAreaField } from './widgets/TextAreaField.js';
+import { NumberField } from './widgets/NumberField.js';
+import { CurrencyField } from './widgets/CurrencyField.js';
+import { PercentField } from './widgets/PercentField.js';
+import { SliderField } from './widgets/SliderField.js';
+import { RatingField } from './widgets/RatingField.js';
+import { BooleanField } from './widgets/BooleanField.js';
+import { SelectField } from './widgets/SelectField.js';
+import { MultiSelectField } from './widgets/MultiSelectField.js';
+import { RadioField } from './widgets/RadioField.js';
+import { CheckboxesField } from './widgets/CheckboxesField.js';
+import { TagsField } from './widgets/TagsField.js';
+import { DateField } from './widgets/DateField.js';
+import { DateTimeField } from './widgets/DateTimeField.js';
+import { TimeField } from './widgets/TimeField.js';
+import { EmailField } from './widgets/EmailField.js';
+import { PhoneField } from './widgets/PhoneField.js';
+import { UrlField } from './widgets/UrlField.js';
 // Relational pickers — the SAME standard widgets the form uses. They read the
 // related-object dataSource from SchemaRendererContext (which the grid already
 // provides), so they drop straight into an inline cell.
-import { LookupField } from './widgets/LookupField';
-import { UserField } from './widgets/UserField';
+import { LookupField } from './widgets/LookupField.js';
+import { UserField } from './widgets/UserField.js';
 // Structured-value editors — lightweight (no map/code-editor deps), same
 // widgets the form uses. Drop into a cell like the rest.
-import { ColorField } from './widgets/ColorField';
-import { AddressField } from './widgets/AddressField';
-import { LocationField } from './widgets/LocationField';
-import { GeolocationField } from './widgets/GeolocationField';
-import { CodeField } from './widgets/CodeField';
-import { QRCodeField } from './widgets/QRCodeField';
+import { ColorField } from './widgets/ColorField.js';
+import { AddressField } from './widgets/AddressField.js';
+import { LocationField } from './widgets/LocationField.js';
+import { GeolocationField } from './widgets/GeolocationField.js';
+import { CodeField } from './widgets/CodeField.js';
+import { QRCodeField } from './widgets/QRCodeField.js';
 // The FORM's spec-alias table (`json` → `field:code`, `tree` → `field:lookup`,
 // …) — inline resolution reuses it so spec spellings get the form's decision.
 // `RETIRED_FIELD_TYPES` / `reportRetiredFieldType` come from the same module on
@@ -55,7 +55,7 @@ import {
   mapFieldTypeToFormType,
   RETIRED_FIELD_TYPES,
   reportRetiredFieldType,
-} from './field-type-alias';
+} from './field-type-alias.js';
 
 /**
  * True when a spelling has been RETIRED by this renderer (objectui#4814's

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -15,10 +15,10 @@ import { Check, X, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import { SchemaRendererContext as _SchemaRendererContext } from '@object-ui/react';
 import { useRelatedRecordActions } from '@object-ui/react';
-import { withFieldCarrier } from './withFieldCarrier';
+import { withFieldCarrier } from './withFieldCarrier.js';
 // Pure formatting rule shared with `AddressField`'s readonly branch — no React,
 // so this does not pull the widget out of its lazy chunk (objectui#4037).
-import { formatAddress, type AddressValue } from './widgets/address-format';
+import { formatAddress, type AddressValue } from './widgets/address-format.js';
 
 // Module-level cache so multiple renderers fetching the same lookup ID
 // only trigger one network call. Keyed by `${objectName}:${id}`.
@@ -302,8 +302,8 @@ function useFieldTranslate(): ((key: string, params?: Record<string, unknown>) =
 // through the lazy loaders in `fieldWidgetMap` below, so nothing here needs a
 // static reference; the widgets stay publicly available via the `export * from
 // './widgets/…'` block at the end of this file.
-import { ImageLightbox } from './widgets/ImageLightbox';
-import { readFileValues } from './widgets/file-value';
+import { ImageLightbox } from './widgets/ImageLightbox.js';
+import { readFileValues } from './widgets/file-value.js';
 
 /**
  * Cell renderer props
@@ -371,7 +371,7 @@ export function coerceToSafeValue(value: unknown): string | number | boolean | n
  * value of `.50` renders `.50`, not `.5`, and a yen amount renders `¥1,235`
  * rather than cents the yen does not have.
  */
-import { resolveFieldCurrency, currencyFractionDigits } from './currency';
+import { resolveFieldCurrency, currencyFractionDigits } from './currency.js';
 export { resolveFieldCurrency };
 
 export function formatCurrency(value: number, currency?: string, locale?: string): string {
@@ -2266,7 +2266,7 @@ export function ColorSwatchCellRenderer({ value }: CellRendererProps): React.Rea
   );
 }
 
-const LazyMarkdownContent = React.lazy(() => import('./widgets/MarkdownContent'));
+const LazyMarkdownContent = React.lazy(() => import('./widgets/MarkdownContent.js'));
 
 /**
  * Renders `markdown` / `richtext` values as formatted GFM markdown (lazy-loaded,
@@ -2481,17 +2481,17 @@ registerFieldRenderer('user', UserCellRenderer);
 
 // Register getCellRenderer in the bridge so RecordPickerDialog can access it
 // via LookupField without circular imports.
-import { setCellRendererResolver } from './widgets/_cell-renderer-bridge';
+import { setCellRendererResolver } from './widgets/_cell-renderer-bridge.js';
 setCellRendererResolver(getCellRenderer);
 
 
 
 // `mapFieldTypeToFormType` moved to './field-type-alias' (re-exported below) so
 // FieldEditWidget can resolve spec aliases without importing this barrel.
-export { mapFieldTypeToFormType } from './field-type-alias';
-import { mapFieldTypeToFormType } from './field-type-alias';
-export { RETIRED_FIELD_TYPES, reportRetiredFieldType, resetRetiredFieldTypeReports } from './field-type-alias';
-import { RETIRED_FIELD_TYPES, reportRetiredFieldType } from './field-type-alias';
+export { mapFieldTypeToFormType } from './field-type-alias.js';
+import { mapFieldTypeToFormType } from './field-type-alias.js';
+export { RETIRED_FIELD_TYPES, reportRetiredFieldType, resetRetiredFieldTypeReports } from './field-type-alias.js';
+import { RETIRED_FIELD_TYPES, reportRetiredFieldType } from './field-type-alias.js';
 
 /**
  * Formats file size in bytes to human-readable string
@@ -2682,73 +2682,73 @@ type FieldWidgetLoader = () => Promise<{ default: React.ComponentType<any> }>;
 // labelling is a compile error, not a silent fallback (objectui#4857).
 const fieldWidgetMap = {
   // Basic fields
-  'text': () => import('./widgets/TextField').then(m => ({ default: m.TextField })),
-  'textarea': () => import('./widgets/TextAreaField').then(m => ({ default: m.TextAreaField })),
-  'number': () => import('./widgets/NumberField').then(m => ({ default: m.NumberField })),
-  'boolean': () => import('./widgets/BooleanField').then(m => ({ default: m.BooleanField })),
-  'select': () => import('./widgets/SelectField').then(m => ({ default: m.SelectField })),
-  'date': () => import('./widgets/DateField').then(m => ({ default: m.DateField })),
-  'datetime': () => import('./widgets/DateTimeField').then(m => ({ default: m.DateTimeField })),
-  'time': () => import('./widgets/TimeField').then(m => ({ default: m.TimeField })),
+  'text': () => import('./widgets/TextField.js').then(m => ({ default: m.TextField })),
+  'textarea': () => import('./widgets/TextAreaField.js').then(m => ({ default: m.TextAreaField })),
+  'number': () => import('./widgets/NumberField.js').then(m => ({ default: m.NumberField })),
+  'boolean': () => import('./widgets/BooleanField.js').then(m => ({ default: m.BooleanField })),
+  'select': () => import('./widgets/SelectField.js').then(m => ({ default: m.SelectField })),
+  'date': () => import('./widgets/DateField.js').then(m => ({ default: m.DateField })),
+  'datetime': () => import('./widgets/DateTimeField.js').then(m => ({ default: m.DateTimeField })),
+  'time': () => import('./widgets/TimeField.js').then(m => ({ default: m.TimeField })),
   
   // Contact fields
-  'email': () => import('./widgets/EmailField').then(m => ({ default: m.EmailField })),
-  'phone': () => import('./widgets/PhoneField').then(m => ({ default: m.PhoneField })),
-  'url': () => import('./widgets/UrlField').then(m => ({ default: m.UrlField })),
+  'email': () => import('./widgets/EmailField.js').then(m => ({ default: m.EmailField })),
+  'phone': () => import('./widgets/PhoneField.js').then(m => ({ default: m.PhoneField })),
+  'url': () => import('./widgets/UrlField.js').then(m => ({ default: m.UrlField })),
   
   // Selection fields (multi-value / option groups)
-  'multiselect': () => import('./widgets/MultiSelectField').then(m => ({ default: m.MultiSelectField })),
-  'radio': () => import('./widgets/RadioField').then(m => ({ default: m.RadioField })),
-  'checkboxes': () => import('./widgets/CheckboxesField').then(m => ({ default: m.CheckboxesField })),
-  'tags': () => import('./widgets/TagsField').then(m => ({ default: m.TagsField })),
+  'multiselect': () => import('./widgets/MultiSelectField.js').then(m => ({ default: m.MultiSelectField })),
+  'radio': () => import('./widgets/RadioField.js').then(m => ({ default: m.RadioField })),
+  'checkboxes': () => import('./widgets/CheckboxesField.js').then(m => ({ default: m.CheckboxesField })),
+  'tags': () => import('./widgets/TagsField.js').then(m => ({ default: m.TagsField })),
 
   // Specialized fields
-  'currency': () => import('./widgets/CurrencyField').then(m => ({ default: m.CurrencyField })),
-  'percent': () => import('./widgets/PercentField').then(m => ({ default: m.PercentField })),
-  'password': () => import('./widgets/PasswordField').then(m => ({ default: m.PasswordField })),
-  'markdown': () => import('./widgets/RichTextField').then(m => ({ default: m.RichTextField })),
-  'html': () => import('./widgets/RichTextField').then(m => ({ default: m.RichTextField })),
-  'richtext': () => import('./widgets/RichTextField').then(m => ({ default: m.RichTextField })),
-  'lookup': () => import('./widgets/LookupField').then(m => ({ default: m.LookupField })),
+  'currency': () => import('./widgets/CurrencyField.js').then(m => ({ default: m.CurrencyField })),
+  'percent': () => import('./widgets/PercentField.js').then(m => ({ default: m.PercentField })),
+  'password': () => import('./widgets/PasswordField.js').then(m => ({ default: m.PasswordField })),
+  'markdown': () => import('./widgets/RichTextField.js').then(m => ({ default: m.RichTextField })),
+  'html': () => import('./widgets/RichTextField.js').then(m => ({ default: m.RichTextField })),
+  'richtext': () => import('./widgets/RichTextField.js').then(m => ({ default: m.RichTextField })),
+  'lookup': () => import('./widgets/LookupField.js').then(m => ({ default: m.LookupField })),
   // master_detail represents the child-side FK to its parent. In create/edit forms it
   // must render as a single-value lookup picker (it is typically NOT NULL). The legacy
   // MasterDetailField widget modelled this as a one-to-many list, which is incorrect
   // for the child-side and prevented users from filling the required parent reference.
-  'master_detail': () => import('./widgets/LookupField').then(m => ({ default: m.LookupField })),
+  'master_detail': () => import('./widgets/LookupField.js').then(m => ({ default: m.LookupField })),
   
   // File fields
-  'file': () => import('./widgets/FileField').then(m => ({ default: m.FileField })),
-  'image': () => import('./widgets/ImageField').then(m => ({ default: m.ImageField })),
+  'file': () => import('./widgets/FileField.js').then(m => ({ default: m.FileField })),
+  'image': () => import('./widgets/ImageField.js').then(m => ({ default: m.ImageField })),
   
   // Location field
-  'location': () => import('./widgets/LocationField').then(m => ({ default: m.LocationField })),
+  'location': () => import('./widgets/LocationField.js').then(m => ({ default: m.LocationField })),
   
   // Computed/Read-only fields
-  'formula': () => import('./widgets/FormulaField').then(m => ({ default: m.FormulaField })),
-  'summary': () => import('./widgets/SummaryField').then(m => ({ default: m.SummaryField })),
-  'auto_number': () => import('./widgets/AutoNumberField').then(m => ({ default: m.AutoNumberField })),
+  'formula': () => import('./widgets/FormulaField.js').then(m => ({ default: m.FormulaField })),
+  'summary': () => import('./widgets/SummaryField.js').then(m => ({ default: m.SummaryField })),
+  'auto_number': () => import('./widgets/AutoNumberField.js').then(m => ({ default: m.AutoNumberField })),
   
   // User fields. `owner` pointed at this same UserField until objectui#4814
   // retired it (see the TOMBSTONE near `registerAllFields`) — do not re-add it
   // here: membership in this map is what makes a name a renderable field type
   // (`FORM_FIELD_TYPES` is its key set).
-  'user': () => import('./widgets/UserField').then(m => ({ default: m.UserField })),
+  'user': () => import('./widgets/UserField.js').then(m => ({ default: m.UserField })),
 
   // Complex data types
-  'object': () => import('./widgets/ObjectField').then(m => ({ default: m.ObjectField })),
-  'vector': () => import('./widgets/VectorField').then(m => ({ default: m.VectorField })),
-  'grid': () => import('./widgets/GridField').then(m => ({ default: m.GridField })),
+  'object': () => import('./widgets/ObjectField.js').then(m => ({ default: m.ObjectField })),
+  'vector': () => import('./widgets/VectorField.js').then(m => ({ default: m.VectorField })),
+  'grid': () => import('./widgets/GridField.js').then(m => ({ default: m.GridField })),
   
   // Additional field types from @objectstack/spec
-  'color': () => import('./widgets/ColorField').then(m => ({ default: m.ColorField })),
-  'slider': () => import('./widgets/SliderField').then(m => ({ default: m.SliderField })),
-  'rating': () => import('./widgets/RatingField').then(m => ({ default: m.RatingField })),
-  'code': () => import('./widgets/CodeField').then(m => ({ default: m.CodeField })),
-  'avatar': () => import('./widgets/AvatarField').then(m => ({ default: m.AvatarField })),
-  'address': () => import('./widgets/AddressField').then(m => ({ default: m.AddressField })),
-  'geolocation': () => import('./widgets/GeolocationField').then(m => ({ default: m.GeolocationField })),
-  'signature': () => import('./widgets/SignatureField').then(m => ({ default: m.SignatureField })),
-  'qrcode': () => import('./widgets/QRCodeField').then(m => ({ default: m.QRCodeField })),
+  'color': () => import('./widgets/ColorField.js').then(m => ({ default: m.ColorField })),
+  'slider': () => import('./widgets/SliderField.js').then(m => ({ default: m.SliderField })),
+  'rating': () => import('./widgets/RatingField.js').then(m => ({ default: m.RatingField })),
+  'code': () => import('./widgets/CodeField.js').then(m => ({ default: m.CodeField })),
+  'avatar': () => import('./widgets/AvatarField.js').then(m => ({ default: m.AvatarField })),
+  'address': () => import('./widgets/AddressField.js').then(m => ({ default: m.AddressField })),
+  'geolocation': () => import('./widgets/GeolocationField.js').then(m => ({ default: m.GeolocationField })),
+  'signature': () => import('./widgets/SignatureField.js').then(m => ({ default: m.SignatureField })),
+  'qrcode': () => import('./widgets/QRCodeField.js').then(m => ({ default: m.QRCodeField })),
 
   // Widget-hint-only pickers (reached via a field `widget:` override, never a
   // bare field `type`). They render a *picker* over machine data an admin would
@@ -2756,9 +2756,9 @@ const fieldWidgetMap = {
   //   object-ref       → choose a registered object by name
   //   filter-condition → visual criteria builder scoped to the chosen object
   //   recipient-picker → record picker whose target follows a sibling type
-  'object-ref': () => import('./widgets/ObjectRefField').then(m => ({ default: m.ObjectRefField })),
-  'filter-condition': () => import('./widgets/FilterConditionField').then(m => ({ default: m.FilterConditionField })),
-  'recipient-picker': () => import('./widgets/RecipientPickerField').then(m => ({ default: m.RecipientPickerField })),
+  'object-ref': () => import('./widgets/ObjectRefField.js').then(m => ({ default: m.ObjectRefField })),
+  'filter-condition': () => import('./widgets/FilterConditionField.js').then(m => ({ default: m.FilterConditionField })),
+  'recipient-picker': () => import('./widgets/RecipientPickerField.js').then(m => ({ default: m.RecipientPickerField })),
 } satisfies Record<string, FieldWidgetLoader>;
 
 /** The registered field widget keys, as a literal union (objectui#4857). */
@@ -3135,79 +3135,79 @@ export function registerAllFields(): void {
 // field NAME carries ownership meaning, the type carries the widget.
 // `UserField` and `UserCellRenderer` are untouched; only the synonym is gone.
 
-export * from './widgets/types';
+export * from './widgets/types.js';
 // File field value shapes (ObjectStack ADR-0104 D3 wave 2) — the single
 // arbiter of reference vs expanded vs legacy-blob form, shared by the upload
 // widgets and by action-param serialization.
-export * from './widgets/file-value';
-export * from './FieldEditWidget';
-export * from './widgets/TextField';
-export * from './widgets/NumberField';
-export * from './widgets/BooleanField';
-export * from './widgets/SelectField';
-export * from './widgets/DateField';
-export * from './widgets/DateTimeField';
-export * from './widgets/TimeField';
-export * from './widgets/EmailField';
-export * from './widgets/PhoneField';
-export * from './widgets/UrlField';
-export * from './widgets/CurrencyField';
-export * from './widgets/PercentField';
-export * from './widgets/PasswordField';
-export * from './widgets/TextAreaField';
-export * from './widgets/RichTextField';
-export * from './widgets/LookupField';
-export * from './widgets/CapabilityMultiSelectField';
-export * from './widgets/ObjectRefField';
-export * from './widgets/FilterConditionField';
-export * from './widgets/RecipientPickerField';
-export * from './widgets/RecordPickerDialog';
+export * from './widgets/file-value.js';
+export * from './FieldEditWidget.js';
+export * from './widgets/TextField.js';
+export * from './widgets/NumberField.js';
+export * from './widgets/BooleanField.js';
+export * from './widgets/SelectField.js';
+export * from './widgets/DateField.js';
+export * from './widgets/DateTimeField.js';
+export * from './widgets/TimeField.js';
+export * from './widgets/EmailField.js';
+export * from './widgets/PhoneField.js';
+export * from './widgets/UrlField.js';
+export * from './widgets/CurrencyField.js';
+export * from './widgets/PercentField.js';
+export * from './widgets/PasswordField.js';
+export * from './widgets/TextAreaField.js';
+export * from './widgets/RichTextField.js';
+export * from './widgets/LookupField.js';
+export * from './widgets/CapabilityMultiSelectField.js';
+export * from './widgets/ObjectRefField.js';
+export * from './widgets/FilterConditionField.js';
+export * from './widgets/RecipientPickerField.js';
+export * from './widgets/RecordPickerDialog.js';
 // Shared picker-column derivation (ADR-0085 highlightFields → displayFields →
 // schema walk) — consumed by LookupField AND by RelatedList's Add-picker so a
 // lookup picker and a related-list Add dialog of the same object agree on
 // columns (#3365).
-export * from './widgets/deriveLookupColumns';
-export * from './widgets/FileField';
-export * from './widgets/ImageField';
-export { ImageCropperDialog } from './widgets/ImageCropperDialog';
-export type { ImageCropperDialogProps } from './widgets/ImageCropperDialog';
-export * from './widgets/LocationField';
-export * from './widgets/FormulaField';
-export * from './widgets/SummaryField';
-export * from './widgets/AutoNumberField';
-export * from './widgets/UserField';
-export * from './widgets/ObjectField';
-export * from './widgets/VectorField';
-export * from './widgets/GridField';
+export * from './widgets/deriveLookupColumns.js';
+export * from './widgets/FileField.js';
+export * from './widgets/ImageField.js';
+export { ImageCropperDialog } from './widgets/ImageCropperDialog.js';
+export type { ImageCropperDialogProps } from './widgets/ImageCropperDialog.js';
+export * from './widgets/LocationField.js';
+export * from './widgets/FormulaField.js';
+export * from './widgets/SummaryField.js';
+export * from './widgets/AutoNumberField.js';
+export * from './widgets/UserField.js';
+export * from './widgets/ObjectField.js';
+export * from './widgets/VectorField.js';
+export * from './widgets/GridField.js';
 // New widgets according to @objectstack/spec
-export * from './widgets/ColorField';
-export * from './widgets/SliderField';
-export * from './widgets/RatingField';
-export * from './widgets/CodeField';
-export * from './widgets/AvatarField';
-export * from './widgets/AddressField';
-export * from './widgets/GeolocationField';
-export * from './widgets/SignatureField';
-export * from './widgets/QRCodeField';
-export * from './widgets/MasterDetailField';
-export * from './widgets/MultiSelectField';
-export * from './widgets/RadioField';
-export * from './widgets/CheckboxesField';
-export * from './widgets/TagsField';
+export * from './widgets/ColorField.js';
+export * from './widgets/SliderField.js';
+export * from './widgets/RatingField.js';
+export * from './widgets/CodeField.js';
+export * from './widgets/AvatarField.js';
+export * from './widgets/AddressField.js';
+export * from './widgets/GeolocationField.js';
+export * from './widgets/SignatureField.js';
+export * from './widgets/QRCodeField.js';
+export * from './widgets/MasterDetailField.js';
+export * from './widgets/MultiSelectField.js';
+export * from './widgets/RadioField.js';
+export * from './widgets/CheckboxesField.js';
+export * from './widgets/TagsField.js';
 
 // The SDUI-node → `field` adapter every registration here goes through
 // (objectui#3233). Exported so a widget registered OUTSIDE this repo can reach
 // the same single-carrier guarantee instead of re-growing a `field || schema`
 // read of its own.
-export { withFieldCarrier } from './withFieldCarrier';
+export { withFieldCarrier } from './withFieldCarrier.js';
 
 // The whitelist that decides what a widget's `...props` spread may put on a
 // DOM element (objectui#3291) — the runtime executor of the "DOM pass-through"
 // block of `FieldWidgetComponentProps`. Exported for the same reason as
 // `withFieldCarrier` above: a widget authored outside this repo needs to reach
 // it, or it re-grows the bare spread this closed.
-export { toDomProps } from './widgets/toDomProps';
-export type { DomProps } from './widgets/toDomProps';
+export { toDomProps } from './widgets/toDomProps.js';
+export type { DomProps } from './widgets/toDomProps.js';
 
 // The native date/time control value adapters (objectui#3127). `DateTimeField`
 // is ISO-canonical on BOTH sides — it takes the record's ISO instant and hands
@@ -3223,7 +3223,7 @@ export {
   toDateInputValue,
   toDateTimeInputValue,
   fromDateTimeInputValue,
-} from './widgets/nativeDateValue';
+} from './widgets/nativeDateValue.js';
 
 // Initialize registry
 registerAllFields();

--- a/packages/fields/src/widgets/AddressField.tsx
+++ b/packages/fields/src/widgets/AddressField.tsx
@@ -1,10 +1,10 @@
 import React, { useId } from 'react';
 import { Input, Label, EmptyValue } from '@object-ui/components';
 import { useDisplayLocale } from '@object-ui/i18n';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
-import { useFieldTranslation } from './useFieldTranslation';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
+import { useFieldTranslation } from './useFieldTranslation.js';
 // The value shape and the single-line formatting rule now live in a pure module
 // so the display (read) cell renderer formats a stored address exactly the way
 // this widget's readonly branch does — one rule, not two copies that drift
@@ -14,14 +14,14 @@ import {
   readPostalCode,
   type AddressValue,
   type LegacyAddressValue,
-} from './address-format';
+} from './address-format.js';
 
 // Re-exported through its declaring module rather than bare, so the spec-symbol
 // guard resolves the name to where it is actually defined: `address-format`
 // imports `AddressValue` from `@objectstack/spec/data` (objectui#4167), and a
 // bare `export type { AddressValue }` here would read to that guard as a second,
 // local declaration of a name the spec owns.
-export type { AddressValue } from './address-format';
+export type { AddressValue } from './address-format.js';
 
 /**
  * Address field widget - provides a structured address input

--- a/packages/fields/src/widgets/AutoNumberField.tsx
+++ b/packages/fields/src/widgets/AutoNumberField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
+import { FieldWidgetComponentProps } from './types.js';
 
 /**
  * AutoNumberField - Read-only auto-generated field

--- a/packages/fields/src/widgets/AvatarField.tsx
+++ b/packages/fields/src/widgets/AvatarField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Avatar, AvatarFallback, AvatarImage, Button } from '@object-ui/components';
 import { Upload, X } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * Avatar field widget - provides an avatar/profile picture uploader

--- a/packages/fields/src/widgets/BooleanField.tsx
+++ b/packages/fields/src/widgets/BooleanField.tsx
@@ -1,7 +1,7 @@
 import React, { useId } from 'react';
 import { Switch, Checkbox, Label } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * BooleanField - Toggle input supporting switch and checkbox variants

--- a/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
+++ b/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Badge, EmptyValue, cn } from '@object-ui/components';
 import { SchemaRendererContext } from '@object-ui/react';
 import type { DataSource, QueryParams } from '@object-ui/types';
-import { FieldWidgetComponentProps } from './types';
-import { useFieldTranslation } from './useFieldTranslation';
+import { FieldWidgetComponentProps } from './types.js';
+import { useFieldTranslation } from './useFieldTranslation.js';
 
 /**
  * CapabilityMultiSelectField — structured picker for a permission set's

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -1,11 +1,11 @@
 import React, { useId, useEffect } from 'react';
 import { Checkbox, Label, EmptyValue, Badge } from '@object-ui/components';
 import type { OptionLike } from '@object-ui/core';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
-import { OptionsEmptyState } from './OptionsEmptyState';
-import { useCascadingOptions } from './useCascadingOptions';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
+import { OptionsEmptyState } from './OptionsEmptyState.js';
+import { useCascadingOptions } from './useCascadingOptions.js';
 
 type Option = OptionLike;
 

--- a/packages/fields/src/widgets/CodeField.tsx
+++ b/packages/fields/src/widgets/CodeField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Textarea, cn, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * Code field widget - provides a code editor with syntax highlighting

--- a/packages/fields/src/widgets/ColorField.tsx
+++ b/packages/fields/src/widgets/ColorField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * Color field widget - provides a color picker input

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 import { useLocalization, useDisplayLocale, formatDisplayNumber } from '@object-ui/i18n';
-import { resolveFieldCurrency, currencyFractionDigits, currencySymbol } from '../currency';
+import { resolveFieldCurrency, currencyFractionDigits, currencySymbol } from '../currency.js';
 
 /**
  * Format currency value for display. When `currency` is undefined the value

--- a/packages/fields/src/widgets/DateField.tsx
+++ b/packages/fields/src/widgets/DateField.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { useDisplayLocale } from '@object-ui/i18n';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { openNativePicker } from './openNativePicker';
-import { toDateInputValue } from './nativeDateValue';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { openNativePicker } from './openNativePicker.js';
+import { toDateInputValue } from './nativeDateValue.js';
 
 /**
  * DateField - Date picker input widget

--- a/packages/fields/src/widgets/DateTimeField.tsx
+++ b/packages/fields/src/widgets/DateTimeField.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { useDisplayLocale } from '@object-ui/i18n';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { openNativePicker } from './openNativePicker';
-import { toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { openNativePicker } from './openNativePicker.js';
+import { toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue.js';
 
 /**
  * DateTimeField - Combined date and time picker widget

--- a/packages/fields/src/widgets/EmailField.tsx
+++ b/packages/fields/src/widgets/EmailField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * EmailField - Email address input with mailto link in readonly mode

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -3,11 +3,11 @@ import { Button, EmptyValue } from '@object-ui/components';
 import { useUpload } from '@object-ui/providers';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Upload, X, File as FileIcon, ImageIcon, Camera, Loader2 } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
-import { useUploadingSignal } from './useUploadingSignal';
-import { maxSizeError, type TranslateFn } from './file-size-guard';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
+import { useUploadingSignal } from './useUploadingSignal.js';
+import { maxSizeError, type TranslateFn } from './file-size-guard.js';
 import {
   fileValueForSubmit,
   readFileValues,
@@ -15,7 +15,7 @@ import {
   withRecentUploads,
   isImageValue,
   type FileValueView,
-} from './file-value';
+} from './file-value.js';
 
 /**
  * Shared upload pipeline for the file widgets: validates size, uploads through

--- a/packages/fields/src/widgets/FilterConditionField.tsx
+++ b/packages/fields/src/widgets/FilterConditionField.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { FilterBuilder, cn } from '@object-ui/components';
 import { SchemaRendererContext } from '@object-ui/react';
-import type { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { useFieldTranslation } from './useFieldTranslation';
+import type { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { useFieldTranslation } from './useFieldTranslation.js';
 
 /**
  * FilterConditionField — visual criteria builder for a stored FilterCondition

--- a/packages/fields/src/widgets/FormulaField.tsx
+++ b/packages/fields/src/widgets/FormulaField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EmptyValue } from '@object-ui/components';
 import { useDisplayLocale } from '@object-ui/i18n';
-import { FieldWidgetComponentProps } from './types';
+import { FieldWidgetComponentProps } from './types.js';
 
 /**
  * FormulaField - Read-only computed field

--- a/packages/fields/src/widgets/GeolocationField.tsx
+++ b/packages/fields/src/widgets/GeolocationField.tsx
@@ -1,9 +1,9 @@
 import React, { useId } from 'react';
 import { Input, Button, Label, EmptyValue } from '@object-ui/components';
 import { MapPin, Crosshair } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
 
 /**
  * Geolocation data structure

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { FieldWidgetComponentProps } from './types';
+import { FieldWidgetComponentProps } from './types.js';
 import {
   cn,
   Button,
@@ -18,11 +18,11 @@ import {
 import { Plus, Trash2, SlidersHorizontal, Maximize2, Copy, GripVertical } from 'lucide-react';
 import { resolveFieldRuleState } from '@object-ui/core';
 import { useDisplayLocale } from '@object-ui/i18n';
-import { LookupField } from './LookupField';
-import { FileCell } from './FileField';
-import { toDateInputValue, toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
+import { LookupField } from './LookupField.js';
+import { FileCell } from './FileField.js';
+import { toDateInputValue, toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
 
 /**
  * GridField / LineItemsField — editable child-grid ("line items") widget.

--- a/packages/fields/src/widgets/ImageField.tsx
+++ b/packages/fields/src/widgets/ImageField.tsx
@@ -3,23 +3,23 @@ import { Button, EmptyValue } from '@object-ui/components';
 import { useUpload } from '@object-ui/providers';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { X, Image as ImageIcon, Crop as CropIcon, Loader2 } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { ImageLightbox } from './ImageLightbox';
-import { useUploadingSignal } from './useUploadingSignal';
-import { maxSizeError, type TranslateFn } from './file-size-guard';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { ImageLightbox } from './ImageLightbox.js';
+import { useUploadingSignal } from './useUploadingSignal.js';
+import { maxSizeError, type TranslateFn } from './file-size-guard.js';
 import {
   fileValueForSubmit,
   readFileValues,
   uploadResultView,
   withRecentUploads,
   type FileValueView,
-} from './file-value';
+} from './file-value.js';
 
 // Lazy-load the cropper so the dialog (canvas + crop logic) is not in the initial
 // ImageField bundle. Consumers that never crop pay zero cost.
 const ImageCropperDialog = lazy(() =>
-  import('./ImageCropperDialog').then((m) => ({ default: m.ImageCropperDialog })),
+  import('./ImageCropperDialog.js').then((m) => ({ default: m.ImageCropperDialog })),
 );
 
 /**

--- a/packages/fields/src/widgets/LocationField.tsx
+++ b/packages/fields/src/widgets/LocationField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * LocationField - Geographic coordinate input for latitude and longitude

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -10,20 +10,20 @@ import { cn,
   PopoverTrigger,
   PopoverContent, EmptyValue } from '@object-ui/components';
 import { Search, X, Loader2, AlertCircle, Plus, TableProperties } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 import type { DataSource, QueryParams, LookupColumnDef } from '@object-ui/types';
-import { RecordPickerDialog, lookupFiltersToRecord } from './RecordPickerDialog';
-import type { RecordPickerFilterColumn } from './RecordPickerDialog';
-import { PeoplePicker } from './PeoplePicker';
-import { useRecordQuery } from './useRecordQuery';
-import { deriveLookupColumns } from './deriveLookupColumns';
+import { RecordPickerDialog, lookupFiltersToRecord } from './RecordPickerDialog.js';
+import type { RecordPickerFilterColumn } from './RecordPickerDialog.js';
+import { PeoplePicker } from './PeoplePicker.js';
+import { useRecordQuery } from './useRecordQuery.js';
+import { deriveLookupColumns } from './deriveLookupColumns.js';
 import { getRecordDisplayName, mergeFilterNodes } from '@object-ui/core';
-import { getRecentLookupIds, pushRecentLookupId } from './recentLookups';
-import { getPersonInitials } from './personDisplay';
-import { getCellRendererResolver } from './_cell-renderer-bridge';
+import { getRecentLookupIds, pushRecentLookupId } from './recentLookups.js';
+import { getPersonInitials } from './personDisplay.js';
+import { getCellRendererResolver } from './_cell-renderer-bridge.js';
 import { SchemaRendererContext as ImportedSchemaRendererContext, useAction, useHasActionProvider } from '@object-ui/react';
-import { useFieldTranslation } from './useFieldTranslation';
+import { useFieldTranslation } from './useFieldTranslation.js';
 
 export interface LookupOption {
   value: string | number;

--- a/packages/fields/src/widgets/MasterDetailField.tsx
+++ b/packages/fields/src/widgets/MasterDetailField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Badge, cn } from '@object-ui/components';
 import { Plus, X, ExternalLink } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
+import { FieldWidgetComponentProps } from './types.js';
 
 // TOMBSTONE (objectui#4811): this widget is NOT in `fieldWidgetMap`
 // (packages/fields/src/index.tsx) and is unreachable from any form path —

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { Badge, EmptyValue, cn } from '@object-ui/components';
 import type { OptionLike } from '@object-ui/core';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
-import { OptionsEmptyState } from './OptionsEmptyState';
-import { useCascadingOptions } from './useCascadingOptions';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
+import { OptionsEmptyState } from './OptionsEmptyState.js';
+import { useCascadingOptions } from './useCascadingOptions.js';
 
 interface Option extends OptionLike { color?: string }
 

--- a/packages/fields/src/widgets/NumberField.tsx
+++ b/packages/fields/src/widgets/NumberField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { NumberFieldMetadata } from '@object-ui/types';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * NumberField - Numeric input with optional decimal precision

--- a/packages/fields/src/widgets/ObjectField.tsx
+++ b/packages/fields/src/widgets/ObjectField.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Textarea, cn, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * ObjectField - JSON object editor

--- a/packages/fields/src/widgets/ObjectRefField.tsx
+++ b/packages/fields/src/widgets/ObjectRefField.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Combobox, EmptyValue, cn } from '@object-ui/components';
 import { SchemaRendererContext } from '@object-ui/react';
-import type { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { useFieldTranslation } from './useFieldTranslation';
+import type { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { useFieldTranslation } from './useFieldTranslation.js';
 
 /**
  * ObjectRefField — object-name picker for form fields that store the machine

--- a/packages/fields/src/widgets/OptionsEmptyState.tsx
+++ b/packages/fields/src/widgets/OptionsEmptyState.tsx
@@ -8,8 +8,8 @@
 
 import React from 'react';
 import { cn } from '@object-ui/components';
-import { useFieldTranslation } from './useFieldTranslation';
-import type { HostGroupProps } from './toHostGroupProps';
+import { useFieldTranslation } from './useFieldTranslation.js';
+import type { HostGroupProps } from './toHostGroupProps.js';
 
 /**
  * The "this option list cannot be filled" state shared by every fixed-option

--- a/packages/fields/src/widgets/PasswordField.tsx
+++ b/packages/fields/src/widgets/PasswordField.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { Input } from '@object-ui/components';
 import { Button } from '@object-ui/components';
 import { Eye, EyeOff } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * PasswordField - Secure password input with visibility toggle

--- a/packages/fields/src/widgets/PeoplePicker.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.tsx
@@ -29,17 +29,17 @@ import {
 } from '@object-ui/components';
 import { Search, Loader2, AlertCircle } from 'lucide-react';
 import type { DataSource, LookupFilterDef } from '@object-ui/types';
-import { useRecordQuery } from './useRecordQuery';
+import { useRecordQuery } from './useRecordQuery.js';
 // The repo's single filter sink — conjoins filter sources under one `and`
 // instead of spreading them, so an id restriction can never overwrite a
 // declared filter on the same field (#5195).
 import { mergeFilterNodes } from '@object-ui/core';
-import { lookupFiltersToRecord } from './RecordPickerDialog';
-import { getPersonId } from './personDisplay';
-import { PersonRow } from './PersonRow';
-import { SelectionTray } from './SelectionTray';
-import { getRecentLookupIds, pushRecentLookupId } from './recentLookups';
-import { useFieldTranslation } from './useFieldTranslation';
+import { lookupFiltersToRecord } from './RecordPickerDialog.js';
+import { getPersonId } from './personDisplay.js';
+import { PersonRow } from './PersonRow.js';
+import { SelectionTray } from './SelectionTray.js';
+import { getRecentLookupIds, pushRecentLookupId } from './recentLookups.js';
+import { useFieldTranslation } from './useFieldTranslation.js';
 
 /**
  * PeoplePicker — the Tier 0, search-first user picker (issue #2112).

--- a/packages/fields/src/widgets/PercentField.tsx
+++ b/packages/fields/src/widgets/PercentField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, Slider, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * PercentField - Percentage input with configurable decimal precision

--- a/packages/fields/src/widgets/PersonRow.tsx
+++ b/packages/fields/src/widgets/PersonRow.tsx
@@ -15,7 +15,7 @@ import {
   getPersonSubtitle,
   getPersonAvatarUrl,
   matchRanges,
-} from './personDisplay';
+} from './personDisplay.js';
 
 /**
  * A rich, single-line candidate row for the search-first PeoplePicker:

--- a/packages/fields/src/widgets/PhoneField.tsx
+++ b/packages/fields/src/widgets/PhoneField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * PhoneField - Telephone number input with tel link in readonly mode

--- a/packages/fields/src/widgets/QRCodeField.tsx
+++ b/packages/fields/src/widgets/QRCodeField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Input, Button, EmptyValue } from '@object-ui/components';
 import { QrCode, Copy } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * QR Code field widget - generates QR codes from text

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -1,11 +1,11 @@
 import React, { useId, useEffect } from 'react';
 import { RadioGroup, RadioGroupItem, Label, EmptyValue } from '@object-ui/components';
 import { isValueStillOffered, type OptionLike } from '@object-ui/core';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
-import { OptionsEmptyState } from './OptionsEmptyState';
-import { useCascadingOptions } from './useCascadingOptions';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
+import { OptionsEmptyState } from './OptionsEmptyState.js';
+import { useCascadingOptions } from './useCascadingOptions.js';
 
 type Option = OptionLike;
 

--- a/packages/fields/src/widgets/RatingField.tsx
+++ b/packages/fields/src/widgets/RatingField.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Star } from 'lucide-react';
 import { cn } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
 
 /**
  * Rating field widget - provides a star rating input

--- a/packages/fields/src/widgets/RecipientPickerField.tsx
+++ b/packages/fields/src/widgets/RecipientPickerField.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Combobox, EmptyValue, cn } from '@object-ui/components';
 import { SchemaRendererContext } from '@object-ui/react';
-import type { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { useFieldTranslation } from './useFieldTranslation';
+import type { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { useFieldTranslation } from './useFieldTranslation.js';
 
 /**
  * RecipientPickerField — dependent record picker for a polymorphic recipient

--- a/packages/fields/src/widgets/RecordPickerDialog.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.tsx
@@ -43,8 +43,8 @@ import type { DataSource, LookupColumnDef, LookupFilterDef } from '@object-ui/ty
 // ObjectView, so a spec `ViewFilterRule[]` lowers in exactly one place.
 import { mergeFilterNodes } from '@object-ui/core';
 import { useSafeFieldLabel, useDisplayLocale } from '@object-ui/i18n';
-import { useFieldTranslation } from './useFieldTranslation';
-import { useRecordQuery } from './useRecordQuery';
+import { useFieldTranslation } from './useFieldTranslation.js';
+import { useRecordQuery } from './useRecordQuery.js';
 
 /** Default page size for the Record Picker dialog */
 const DEFAULT_PAGE_SIZE = 10;

--- a/packages/fields/src/widgets/RichTextField.tsx
+++ b/packages/fields/src/widgets/RichTextField.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { cn, Textarea, EmptyValue, type FullscreenEditorAria } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/react';
-import { FullscreenFieldEditor } from './FullscreenFieldEditor';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps, type DomProps } from './toDomProps';
+import { FullscreenFieldEditor } from './FullscreenFieldEditor.js';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps, type DomProps } from './toDomProps.js';
 
 /**
  * The rich-text editing surface, rendered by `RichTextField` in BOTH positions:

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -9,12 +9,12 @@ import {
 } from '@object-ui/components';
 import { isValueStillOffered } from '@object-ui/core';
 import { SelectFieldMetadata } from '@object-ui/types';
-import { useFieldTranslation } from './useFieldTranslation';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { MultiSelectField } from './MultiSelectField';
-import { OptionsEmptyState } from './OptionsEmptyState';
-import { useCascadingOptions } from './useCascadingOptions';
+import { useFieldTranslation } from './useFieldTranslation.js';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { MultiSelectField } from './MultiSelectField.js';
+import { OptionsEmptyState } from './OptionsEmptyState.js';
+import { useCascadingOptions } from './useCascadingOptions.js';
 
 /**
  * SelectField - dropdown selection widget.

--- a/packages/fields/src/widgets/SelectionTray.tsx
+++ b/packages/fields/src/widgets/SelectionTray.tsx
@@ -14,7 +14,7 @@ import {
   getPersonInitials,
   getPersonAvatarUrl,
   getPersonId,
-} from './personDisplay';
+} from './personDisplay.js';
 
 /**
  * "Selected" transfer-box area (穿梭框式已选区): live echo of the current

--- a/packages/fields/src/widgets/SignatureField.tsx
+++ b/packages/fields/src/widgets/SignatureField.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect } from 'react';
 import { Button } from '@object-ui/components';
 import { Eraser } from 'lucide-react';
-import { FieldWidgetComponentProps } from './types';
-import { toHostGroupProps } from './toHostGroupProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
 
 /**
  * Signature field widget - provides a signature pad for capturing signatures

--- a/packages/fields/src/widgets/SliderField.tsx
+++ b/packages/fields/src/widgets/SliderField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Slider } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { toHostGroupProps } from './toHostGroupProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { toHostGroupProps } from './toHostGroupProps.js';
 
 /**
  * Slider field widget - provides a range slider input

--- a/packages/fields/src/widgets/SummaryField.tsx
+++ b/packages/fields/src/widgets/SummaryField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
+import { FieldWidgetComponentProps } from './types.js';
 
 /**
  * SummaryField - Read-only aggregation field

--- a/packages/fields/src/widgets/TagsField.tsx
+++ b/packages/fields/src/widgets/TagsField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Badge, Input, EmptyValue, cn } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { useFieldTranslation } from './useFieldTranslation';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { useFieldTranslation } from './useFieldTranslation.js';
 
 /**
  * TagsField - free-form list of string tags. Type a value and press Enter (or

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -1,8 +1,8 @@
 import React, { useId } from 'react';
 import { Textarea, EmptyValue, CharacterCount } from '@object-ui/components';
-import { FullscreenFieldEditor } from './FullscreenFieldEditor';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FullscreenFieldEditor } from './FullscreenFieldEditor.js';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * TextAreaField - Multi-line text input widget

--- a/packages/fields/src/widgets/TextField.tsx
+++ b/packages/fields/src/widgets/TextField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Input, Textarea, EmptyValue } from '@object-ui/components';
 import { TextareaFieldMetadata } from '@object-ui/types';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * TextField - Standard single-line or multi-line text input

--- a/packages/fields/src/widgets/TimeField.tsx
+++ b/packages/fields/src/widgets/TimeField.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
-import { openNativePicker } from './openNativePicker';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
+import { openNativePicker } from './openNativePicker.js';
 
 /**
  * TimeField - Time picker input widget

--- a/packages/fields/src/widgets/UrlField.tsx
+++ b/packages/fields/src/widgets/UrlField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
-import { toDomProps } from './toDomProps';
+import { FieldWidgetComponentProps } from './types.js';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * UrlField - URL input with clickable link in readonly mode

--- a/packages/fields/src/widgets/UserField.tsx
+++ b/packages/fields/src/widgets/UserField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { FieldWidgetComponentProps } from './types';
-import { LookupField } from './LookupField';
+import { FieldWidgetComponentProps } from './types.js';
+import { LookupField } from './LookupField.js';
 
 /**
  * UserField — person picker for the `user` field type.

--- a/packages/fields/src/widgets/VectorField.tsx
+++ b/packages/fields/src/widgets/VectorField.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EmptyValue } from '@object-ui/components';
-import { FieldWidgetComponentProps } from './types';
+import { FieldWidgetComponentProps } from './types.js';
 
 /**
  * VectorField - Vector/embedding data display

--- a/packages/fields/src/widgets/_cell-renderer-bridge.ts
+++ b/packages/fields/src/widgets/_cell-renderer-bridge.ts
@@ -6,7 +6,7 @@
  * index.tsx registers the resolver via setCellRendererResolver().
  * LookupField reads it via getCellRendererResolver() to pass as a prop.
  */
-import type { CellRendererResolver } from './RecordPickerDialog';
+import type { CellRendererResolver } from './RecordPickerDialog.js';
 
 let _resolver: CellRendererResolver | undefined;
 

--- a/packages/fields/src/widgets/toDomProps.ts
+++ b/packages/fields/src/widgets/toDomProps.ts
@@ -11,7 +11,7 @@ import {
   type SduiDomPassThroughKey,
   type DomProps as CoreDomProps,
 } from '@object-ui/core';
-import type { FieldWidgetComponentProps, FieldWidgetDomProps } from './types';
+import type { FieldWidgetComponentProps, FieldWidgetDomProps } from './types.js';
 
 /**
  * The RUNTIME EXECUTOR of the "DOM pass-through" section of

--- a/packages/fields/src/widgets/toHostGroupProps.ts
+++ b/packages/fields/src/widgets/toHostGroupProps.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { toDomProps } from './toDomProps';
+import { toDomProps } from './toDomProps.js';
 
 /**
  * The props that make a group-labelled widget's rendered surface the thing its

--- a/packages/mobile/src/MobileProvider.tsx
+++ b/packages/mobile/src/MobileProvider.tsx
@@ -8,7 +8,7 @@
 
 import React, { createContext, useContext, useMemo } from 'react';
 import type { PWAConfig, PWAOfflineConfig } from '@object-ui/types';
-import { useBreakpoint, type BreakpointState } from './useBreakpoint';
+import { useBreakpoint, type BreakpointState } from './useBreakpoint.js';
 
 export interface MobileContextValue extends BreakpointState {
   /** PWA configuration */

--- a/packages/mobile/src/ResponsiveContainer.tsx
+++ b/packages/mobile/src/ResponsiveContainer.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import type { BreakpointName } from '@object-ui/types';
-import { useBreakpoint } from './useBreakpoint';
+import { useBreakpoint } from './useBreakpoint.js';
 
 export interface ResponsiveContainerProps {
   /** Minimum breakpoint to show content */

--- a/packages/mobile/src/createOfflineDataSource.ts
+++ b/packages/mobile/src/createOfflineDataSource.ts
@@ -11,7 +11,7 @@
  * lets callers opt into local caching but is not built in here.
  */
 
-import { type OfflineQueueBackend, type OfflineOperation, generateOpId } from './offlineQueue';
+import { type OfflineQueueBackend, type OfflineOperation, generateOpId } from './offlineQueue.js';
 
 /** Minimal DataSource shape we care about. */
 export interface QueueableDataSource {

--- a/packages/mobile/src/index.ts
+++ b/packages/mobile/src/index.ts
@@ -19,17 +19,17 @@
  * @packageDocumentation
  */
 
-export { useBreakpoint, type BreakpointState } from './useBreakpoint';
-export { useResponsive } from './useResponsive';
-export { useResponsiveConfig, type SpecResponsiveConfig, type ResolvedResponsiveState } from './useResponsiveConfig';
-export { useGesture, type UseGestureOptions } from './useGesture';
-export { useSpecGesture, type UseSpecGestureOptions } from './useSpecGesture';
-export { useTouchTarget, type UseTouchTargetOptions, type TouchTargetResult } from './useTouchTarget';
-export { usePullToRefresh, type PullToRefreshOptions } from './usePullToRefresh';
-export { MobileProvider, type MobileProviderProps } from './MobileProvider';
-export { ResponsiveContainer, type ResponsiveContainerProps } from './ResponsiveContainer';
-export { generatePWAManifest } from './pwa';
-export { registerServiceWorker, type ServiceWorkerConfig } from './serviceWorker';
+export { useBreakpoint, type BreakpointState } from './useBreakpoint.js';
+export { useResponsive } from './useResponsive.js';
+export { useResponsiveConfig, type SpecResponsiveConfig, type ResolvedResponsiveState } from './useResponsiveConfig.js';
+export { useGesture, type UseGestureOptions } from './useGesture.js';
+export { useSpecGesture, type UseSpecGestureOptions } from './useSpecGesture.js';
+export { useTouchTarget, type UseTouchTargetOptions, type TouchTargetResult } from './useTouchTarget.js';
+export { usePullToRefresh, type PullToRefreshOptions } from './usePullToRefresh.js';
+export { MobileProvider, type MobileProviderProps } from './MobileProvider.js';
+export { ResponsiveContainer, type ResponsiveContainerProps } from './ResponsiveContainer.js';
+export { generatePWAManifest } from './pwa.js';
+export { registerServiceWorker, type ServiceWorkerConfig } from './serviceWorker.js';
 export {
   createOfflineQueue,
   IndexedDbOfflineQueue,
@@ -37,20 +37,20 @@ export {
   generateOpId,
   type OfflineOperation,
   type OfflineQueueBackend,
-} from './offlineQueue';
+} from './offlineQueue.js';
 export {
   createOfflineDataSource,
   type OfflineDataSource,
   type OfflineDataSourceOptions,
   type QueueableDataSource,
-} from './createOfflineDataSource';
-export { useOfflineSync, type OfflineSyncState } from './useOfflineSync';
+} from './createOfflineDataSource.js';
+export { useOfflineSync, type OfflineSyncState } from './useOfflineSync.js';
 export {
   getServiceWorkerSource,
   requestBackgroundSync,
   type ServiceWorkerSourceOptions,
-} from './serviceWorkerSource';
-export { BREAKPOINTS, resolveResponsiveValue } from './breakpoints';
+} from './serviceWorkerSource.js';
+export { BREAKPOINTS, resolveResponsiveValue } from './breakpoints.js';
 
 // Re-export types for convenience
 export type {

--- a/packages/mobile/src/useBreakpoint.ts
+++ b/packages/mobile/src/useBreakpoint.ts
@@ -8,7 +8,7 @@
 
 import { useState, useEffect } from 'react';
 import type { BreakpointName } from '@object-ui/types';
-import { BREAKPOINTS, BREAKPOINT_ORDER, getCurrentBreakpoint } from './breakpoints';
+import { BREAKPOINTS, BREAKPOINT_ORDER, getCurrentBreakpoint } from './breakpoints.js';
 
 export interface BreakpointState {
   /** Current breakpoint name */

--- a/packages/mobile/src/useOfflineSync.ts
+++ b/packages/mobile/src/useOfflineSync.ts
@@ -7,8 +7,8 @@
  */
 
 import { useEffect, useState, useCallback } from 'react';
-import type { OfflineDataSource } from './createOfflineDataSource';
-import type { OfflineOperation } from './offlineQueue';
+import type { OfflineDataSource } from './createOfflineDataSource.js';
+import type { OfflineOperation } from './offlineQueue.js';
 
 export interface OfflineSyncState {
   /** True if the browser reports `navigator.onLine`. */

--- a/packages/mobile/src/useResponsive.ts
+++ b/packages/mobile/src/useResponsive.ts
@@ -8,8 +8,8 @@
 
 import { useMemo } from 'react';
 import type { ResponsiveValue } from '@object-ui/types';
-import { useBreakpoint } from './useBreakpoint';
-import { resolveResponsiveValue } from './breakpoints';
+import { useBreakpoint } from './useBreakpoint.js';
+import { resolveResponsiveValue } from './breakpoints.js';
 
 /**
  * Hook that resolves a responsive value based on the current breakpoint.

--- a/packages/mobile/src/useResponsiveConfig.ts
+++ b/packages/mobile/src/useResponsiveConfig.ts
@@ -7,8 +7,8 @@
  */
 
 import { useMemo } from 'react';
-import { useBreakpoint } from './useBreakpoint';
-import { resolveResponsiveValue } from './breakpoints';
+import { useBreakpoint } from './useBreakpoint.js';
+import { resolveResponsiveValue } from './breakpoints.js';
 import type { BreakpointName, SpecResponsiveConfig } from '@object-ui/types';
 
 /**

--- a/packages/mobile/src/useSpecGesture.ts
+++ b/packages/mobile/src/useSpecGesture.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useGesture } from './useGesture';
+import { useGesture } from './useGesture.js';
 import type { GestureType, SpecGestureConfig } from '@object-ui/types';
 
 export interface UseSpecGestureOptions {

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -8,6 +8,25 @@
     "paths": {
       "@/*": ["src/*"]
     },
+
+    // Node's ESM resolver does NOT extension-search relative specifiers, so an
+    // extensionless `./Foo` in the emitted dist is unloadable under plain Node
+    // (`ERR_MODULE_NOT_FOUND`) — objectui#5214, same defect and same remedy as
+    // objectui#4538. `tsc` never rewrites specifiers, so what the source writes
+    // is what dist ships; the only way to KEEP the extensions is to have the
+    // compiler reject a missing one (TS2835, and TS2834 for a bare directory
+    // import) instead of leaving it to review.
+    //
+    // These override the ROOT tsconfig's `"module": "ESNext"` /
+    // `"moduleResolution": "bundler"` for THIS package only — the root is
+    // shared by 38 packages and flipping it there is a different, much larger
+    // change. Emit is unchanged: package.json is `"type": "module"`, so
+    // `nodenext` emits the same ESM `ESNext` did.
+    //
+    // Runtime loadability is pinned separately by `pnpm check:node-esm-load`,
+    // which actually imports the built entry under plain Node.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
     "composite": true,

--- a/packages/permissions/src/MePermissionsProvider.tsx
+++ b/packages/permissions/src/MePermissionsProvider.tsx
@@ -19,7 +19,7 @@ import type {
   PermissionCheckResult,
   FieldLevelPermission,
 } from '@object-ui/types';
-import { PermCtx, type PermissionContextValue } from './PermissionContext';
+import { PermCtx, type PermissionContextValue } from './PermissionContext.js';
 
 /**
  * Shape of the upstream `/api/v1/auth/me/permissions` response.

--- a/packages/permissions/src/PermissionGuard.tsx
+++ b/packages/permissions/src/PermissionGuard.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import type { PermissionAction } from '@object-ui/types';
-import { usePermissions } from './usePermissions';
+import { usePermissions } from './usePermissions.js';
 
 export interface PermissionGuardProps {
   /** Target object name */

--- a/packages/permissions/src/PermissionProvider.tsx
+++ b/packages/permissions/src/PermissionProvider.tsx
@@ -14,8 +14,8 @@ import type {
   PermissionCheckResult,
   FieldLevelPermission,
 } from '@object-ui/types';
-import { PermCtx, type PermissionContextValue } from './PermissionContext';
-import { evaluatePermission } from './evaluator';
+import { PermCtx, type PermissionContextValue } from './PermissionContext.js';
+import { evaluatePermission } from './evaluator.js';
 
 export interface PermissionProviderProps {
   /** Role definitions */

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -19,13 +19,13 @@
  * @packageDocumentation
  */
 
-export { PermissionProvider, type PermissionProviderProps } from './PermissionProvider';
-export { MePermissionsProvider, type MePermissionsProviderProps, type MePermissionsResponse } from './MePermissionsProvider';
-export { usePermissions } from './usePermissions';
-export { useFieldPermissions } from './useFieldPermissions';
-export { PermissionGuard, type PermissionGuardProps } from './PermissionGuard';
-export { evaluatePermission } from './evaluator';
-export { createPermissionStore, type PermissionStore } from './store';
+export { PermissionProvider, type PermissionProviderProps } from './PermissionProvider.js';
+export { MePermissionsProvider, type MePermissionsProviderProps, type MePermissionsResponse } from './MePermissionsProvider.js';
+export { usePermissions } from './usePermissions.js';
+export { useFieldPermissions } from './useFieldPermissions.js';
+export { PermissionGuard, type PermissionGuardProps } from './PermissionGuard.js';
+export { evaluatePermission } from './evaluator.js';
+export { createPermissionStore, type PermissionStore } from './store.js';
 
 // Re-export types for convenience
 export type {

--- a/packages/permissions/src/store.ts
+++ b/packages/permissions/src/store.ts
@@ -12,7 +12,7 @@ import type {
   PermissionAction,
   PermissionCheckResult,
 } from '@object-ui/types';
-import { evaluatePermission } from './evaluator';
+import { evaluatePermission } from './evaluator.js';
 
 /**
  * Permission store for non-React contexts (e.g., API handlers, middleware).

--- a/packages/permissions/src/useFieldPermissions.ts
+++ b/packages/permissions/src/useFieldPermissions.ts
@@ -7,7 +7,7 @@
  */
 
 import { useMemo } from 'react';
-import { usePermissions } from './usePermissions';
+import { usePermissions } from './usePermissions.js';
 
 /**
  * Hook to get field-level permissions for a specific object.

--- a/packages/permissions/src/usePermissions.ts
+++ b/packages/permissions/src/usePermissions.ts
@@ -8,7 +8,7 @@
 
 import { useContext, useMemo } from 'react';
 import type { PermissionAction, PermissionCheckResult } from '@object-ui/types';
-import { PermCtx, type PermissionContextValue } from './PermissionContext';
+import { PermCtx, type PermissionContextValue } from './PermissionContext.js';
 
 /**
  * Hook to access the permission system.

--- a/packages/permissions/tsconfig.json
+++ b/packages/permissions/tsconfig.json
@@ -8,6 +8,25 @@
     "paths": {
       "@/*": ["src/*"]
     },
+
+    // Node's ESM resolver does NOT extension-search relative specifiers, so an
+    // extensionless `./Foo` in the emitted dist is unloadable under plain Node
+    // (`ERR_MODULE_NOT_FOUND`) — objectui#5214, same defect and same remedy as
+    // objectui#4538. `tsc` never rewrites specifiers, so what the source writes
+    // is what dist ships; the only way to KEEP the extensions is to have the
+    // compiler reject a missing one (TS2835, and TS2834 for a bare directory
+    // import) instead of leaving it to review.
+    //
+    // These override the ROOT tsconfig's `"module": "ESNext"` /
+    // `"moduleResolution": "bundler"` for THIS package only — the root is
+    // shared by 38 packages and flipping it there is a different, much larger
+    // change. Emit is unchanged: package.json is `"type": "module"`, so
+    // `nodenext` emits the same ESM `ESNext` did.
+    //
+    // Runtime loadability is pinned separately by `pnpm check:node-esm-load`,
+    // which actually imports the built entry under plain Node.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
     "composite": true,

--- a/packages/providers/src/DataSourceProvider.tsx
+++ b/packages/providers/src/DataSourceProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type { DataSourceProviderProps } from './types';
+import type { DataSourceProviderProps } from './types.js';
 
 const DataSourceContext = createContext<any>(null);
 

--- a/packages/providers/src/MetadataProvider.tsx
+++ b/packages/providers/src/MetadataProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react';
-import type { MetadataProviderProps } from './types';
+import type { MetadataProviderProps } from './types.js';
 
 interface MetadataContextValue {
   metadata: any;

--- a/packages/providers/src/ThemeProvider.tsx
+++ b/packages/providers/src/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react';
-import type { ThemePreference, ThemeProviderProps } from './types';
+import type { ThemePreference, ThemeProviderProps } from './types.js';
 
 interface ThemeContextValue {
   theme: ThemePreference;

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -4,9 +4,9 @@
  * Reusable context providers for ObjectUI applications
  */
 
-export { DataSourceProvider, useDataSource } from './DataSourceProvider';
-export { MetadataProvider, useMetadata } from './MetadataProvider';
-export { ThemeProvider, useTheme } from './ThemeProvider';
+export { DataSourceProvider, useDataSource } from './DataSourceProvider.js';
+export { MetadataProvider, useMetadata } from './MetadataProvider.js';
+export { ThemeProvider, useTheme } from './ThemeProvider.js';
 export {
   UploadProvider,
   useUpload,
@@ -14,14 +14,14 @@ export {
   createS3Adapter,
   createAzureBlobAdapter,
   createObjectStackUploadAdapter,
-} from './UploadProvider';
+} from './UploadProvider.js';
 
 export type {
   DataSourceProviderProps,
   MetadataProviderProps,
   ThemeProviderProps,
   ThemePreference,
-} from './types';
+} from './types.js';
 
 export type {
   UploadAdapter,
@@ -31,4 +31,4 @@ export type {
   S3AdapterOptions,
   AzureBlobAdapterOptions,
   ObjectStackUploadAdapterOptions,
-} from './UploadProvider';
+} from './UploadProvider.js';

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -5,6 +5,25 @@
     "rootDir": "src",
     "jsx": "react-jsx",
     "lib": ["ES2020", "DOM"],
+
+    // Node's ESM resolver does NOT extension-search relative specifiers, so an
+    // extensionless `./Foo` in the emitted dist is unloadable under plain Node
+    // (`ERR_MODULE_NOT_FOUND`) — objectui#5214, same defect and same remedy as
+    // objectui#4538. `tsc` never rewrites specifiers, so what the source writes
+    // is what dist ships; the only way to KEEP the extensions is to have the
+    // compiler reject a missing one (TS2835, and TS2834 for a bare directory
+    // import) instead of leaving it to review.
+    //
+    // These override the ROOT tsconfig's `"module": "ESNext"` /
+    // `"moduleResolution": "bundler"` for THIS package only — the root is
+    // shared by 38 packages and flipping it there is a different, much larger
+    // change. Emit is unchanged: package.json is `"type": "module"`, so
+    // `nodenext` emits the same ESM `ESNext` did.
+    //
+    // Runtime loadability is pinned separately by `pnpm check:node-esm-load`,
+    // which actually imports the built entry under plain Node.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
     "composite": true

--- a/scripts/check-node-esm-load.mjs
+++ b/scripts/check-node-esm-load.mjs
@@ -187,9 +187,11 @@ export function buildPreservesSpecifiers(buildScript, pkgDir) {
  * objectui#4538's own scope was `@object-ui/react` plus the dependency closure
  * its entry evaluates through (`types`, `core`, `i18n`) — without those three
  * the card's own package stayed unloadable, so they were in scope by necessity
- * rather than by choice. The packages below carry the identical defect and are
- * left for their own cards: two of them (`app-shell`, `fields`) were held by
- * other sessions when this landed and could not have been touched.
+ * rather than by choice. Seven more packages carried the identical defect and
+ * were left for their own cards; six of them (`auth`, `collaboration`,
+ * `fields`, `mobile`, `permissions`, `providers`) were cleared, and only
+ * `app-shell` — an order of magnitude larger than any of them, and split off
+ * for its own card — is still owed.
  *
  * This is a RATCHET, not a mute button. A package named here that is now clean
  * is a FINDING — the entry must be deleted in the commit that fixes it, so the
@@ -205,12 +207,6 @@ export function buildPreservesSpecifiers(buildScript, pkgDir) {
  */
 export const SPECIFIER_DEBT = new Map([
   ['@object-ui/app-shell', 'objectui#5214; 1259 specifiers, large enough to deserve its own card'],
-  ['@object-ui/auth', 'objectui#5214'],
-  ['@object-ui/collaboration', 'objectui#5214'],
-  ['@object-ui/fields', 'objectui#5214; held by another session when objectui#4538 landed'],
-  ['@object-ui/mobile', 'objectui#5214; blocks 6 plugin packages that fail on its dist'],
-  ['@object-ui/permissions', 'objectui#5214; blocks 4 plugin packages that fail on its dist'],
-  ['@object-ui/providers', 'objectui#5214; blocks 2 packages that fail on its dist'],
 ]);
 
 /**


### PR DESCRIPTION
Part of #5214

Clears the **six small packages**. `@object-ui/app-shell` (1271 specifiers) is deliberately left, split off to #5357 with the triage seat's authorisation — which is why this is `Part of` and not `Fixes`: #5214 must not close on merge.

## The payload: 17 -> 34 of 39 loadable entries

Both numbers measured in this worktree, on a full build, with `node scripts/check-node-esm-load.mjs`. The card predicted 17 -> 35 for all seven packages; app-shell is the missing +1.

| | before | after |
|---|---|---|
| published ESM entries that import and evaluate under plain Node | **17 of 39** | **34 of 39** |

The +17 is 6 packages fixed here plus **all 11 downstream packages that were failing on somebody else's file** — which is the card's real payload:

- on `mobile/dist/useBreakpoint`: `plugin-calendar`, `plugin-designer`, `plugin-grid`, `plugin-list`, `plugin-timeline`, `plugin-view`
- on `permissions/dist/PermissionProvider`: `plugin-detail`, `plugin-form`, `plugin-gantt`, `plugin-kanban`
- on `providers/dist/DataSourceProvider`: `plugin-report`

The 5 that still do not load are all accounted for and none is a regression: `app-shell` (#5357), `plugin-dashboard` + `plugin-map` (`LOAD_DEBT`, third-party `.css`), and `create-plugin` + `runner` (not importable by design).

## What changed

**412 relative specifiers across 94 files**, each **resolved against the filesystem** rather than pattern-matched. The diff was then verified mechanically to be nothing but extension appends: 412 changed line pairs, **0** that are not a pure specifier-extension append, histogram `{ '.js': 412 }`. All 412 name a real sibling module inside their own package `src/` (0 escape the package, 0 target a test/tooling file), and all 412 take `.js` — there are no directory imports among them.

A regex sweep would have been wrong. Two specifiers parse as imports but live in **prose comments** and are deliberately untouched:

- `packages/fields/src/widgets/MasterDetailField.tsx:15` — a line comment quoting the barrel's re-export
- `packages/fields/src/withFieldCarrier.tsx:14` — a JSDoc `{@link import('./widgets/types').FieldWidgetComponentProps}`

**The ledger shrank in the same commit**, per the ratchet: all six entries deleted from `SPECIFIER_DEBT`, leaving only `@object-ui/app-shell`. The doc comment above the map was updated so it no longer claims `fields` is still owed. Nothing was added to either ledger.

**Step 2 (`nodenext` pin) on five of the six**, in each package's own tsconfig, never the root. Verified to bite rather than decorate: removing the extension from the `./PermissionProvider.js` re-export makes `tsc` fail with `TS2835 ... Did you mean './PermissionProvider.js'?`. `packages/fields` deliberately does **not** get the pin — see below.

## Two corrections to the card's model

**1. `fields` was never failing on its own file.** Measured on the before-build: `fields/dist` carries **0** extensionless relative specifiers, even unfixed. Its `tsc` step inherits the root's `noEmit: true` and only type-checks; `dist` comes from vite, which resolves the specifiers away. The before-run attributes it `@object-ui/fields (via @object-ui/providers)`. So the card's "the 7 above, each failing on its own file" is wrong for `fields`, and what made `fields` loadable was fixing `providers`. Its 293 source specifiers were real **ratchet** debt (leg 1 reads sources) and are still worth clearing, but they were not a live `dist` defect. Related gate quirk filed as #5367.

**2. The "11 that fail on somebody else's file" table is a first-failure snapshot, not a dependency map.** This fell out of the reverse-verification below and is the single most useful thing this PR learned.

## Reverse-verification

Reverted `packages/permissions` to `origin/main` (both `src` and `tsconfig.json` — `src` alone fails `tsc` on the new pin and emits no `dist` at all, leaving the gate nothing to grade), kept everything else fixed, kept `permissions` deleted from `SPECIFIER_DEBT`.

**Artifact between the edit and the thing under test: yes, certainly** — the load gate reads `dist/`. So both legs got `pnpm --filter @object-ui/permissions build`, and each was confirmed by reading the emitted specifier out of `packages/permissions/dist/index.js` *before* running the gate: mutation leg showed `from './PermissionProvider'`, restore leg showed `from './PermissionProvider.js'` and 0 extensionless left. That check earned its keep — a typo (`flock -E 500`, out of range) made one restore-leg rebuild silently not run, and the marker was what caught the stale artifact.

**Predicted before running: 34 -> 29, five entries red** (`permissions` + `plugin-detail`, `plugin-form`, `plugin-gantt`, `plugin-kanban`), all `X` rather than `ledgered`.

**Observed: 34 -> 24, ten entries red.** Direction right, number wrong, and the miss is the finding: `plugin-calendar`, `plugin-designer`, `plugin-grid`, `plugin-list` and `plugin-view` flipped too. They depend on **both** `mobile` and `permissions`; the card's table recorded only whichever missing module each package hit **first**, and with `mobile` fixed the second dependency surfaced. `plugin-timeline` did not flip, so it really does depend on `mobile` alone. Leg 1 also went red as predicted, un-ledgered: `X @object-ui/permissions: 14 relative specifier(s) without an explicit extension`, exit 1.

Restore leg: rebuilt, marker absent, gate back to **34 of 39**, exit 0.

## Why `packages/fields` does not get the `nodenext` pin

Applying it there reports a flood of TS2305 against `@object-ui/components` — `Module '"@object-ui/components"' has no exported member 'Badge' / 'Input' / 'Switch' / ...` — because that package's emitted `dist/index.d.ts` re-exports through 21 extensionless relative specifiers of its own, which TypeScript under `nodenext` cannot follow either. Same defect class, different artifact (`.d.ts`, not `.js`), different package, outside this card's declared surface, and no gate covers it. Filed as #5365 rather than fixed here. `fields` is still fully covered by the `check:esm-specifiers` ratchet, which is the enforcement that matters.

## Verification

Union re-derived from the actual diff and run at final HEAD `7513c879`:

| check | result |
|---|---|
| `pnpm check:esm-specifiers` | **0 findings** for each of the six; 13/39 preserving census unchanged; each of the six individually confirmed still in ratchet scope. Exit 0 |
| `pnpm check:node-esm-load` | **34 of 39** loaded. Exit 0 |
| `pnpm exec vitest run packages/{fields,auth,mobile,collaboration,permissions,providers}/` (repo root) | **141 files, 2157 tests passed** |
| `lint` for the six | **0 errors**, 839 pre-existing warnings. Exit 0 |
| `check-published-dist-tooling` | 39 packages, 5760 tarball files, 0 tooling artifacts. Exit 0 |
| `check-package-self-import`, `check-phantom-dependencies`, `check-type-check-coverage`, `check-lint-coverage`, `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed` | all pass |

Changeset: one, `patch` across the six, never `major`.

## Note for #5357

The surviving `SPECIFIER_DEBT` entry still reads `objectui#5214`, not `#5357`. Left alone on purpose — #5214 stays open until app-shell lands, so the pointer is still accurate, and #5357's PR deletes that exact line. Repointing it here would only hand that PR a conflict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_