### PR TITLE
docs(skills): teach the binding `data-table` actually reads, in all three sites

### DIFF
--- a/.changeset/5126-data-table-bind-teaching.md
+++ b/.changeset/5126-data-table-bind-teaching.md
@@ -1,0 +1,6 @@
+---
+---
+
+docs(skills): the `data-table` + `bind` examples in three skill guides now teach the binding the renderer actually reads (objectui#5126, objectui#5337).
+
+No published package source changes: three files under `skills/`, plus one pin test under `packages/components/src/__tests__/` that renders the taught forms through the real `SchemaRenderer`.

--- a/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
+++ b/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
@@ -214,3 +214,62 @@ describe('skill guides — the taught `bind` form renders bound entries (#5126)'
     expect(items).toEqual(['Ada Lovelace', 'Grace Hopper']);
   });
 });
+
+/**
+ * The guides name seven `object-*` widgets as `bind` readers. That list is a
+ * claim about the registry, and a wrong entry there is the same silent failure
+ * this card exists to close — an author writes the type, nothing is registered
+ * under it, and the red "Unknown component type" box is the *good* case.
+ *
+ * Caught one on the way in: the widget file is `ObjectPivotTable.tsx`, but the
+ * key it registers is `object-pivot`.
+ *
+ * Granularity: the key must be registered by exactly one package, and that
+ * package must read `schema.bind` through `useDataScope`. Package-level rather
+ * than file-level on purpose — `object-pivot` and `object-data-table` are
+ * registered in their package's `index.tsx` around a component that lives in a
+ * sibling file, so a same-file assertion would fail on correct code.
+ */
+describe('skill guides — the `object-*` reader list is not stale (#5126)', () => {
+  const pluginRoots = fs
+    .readdirSync(path.join(repoRoot, 'packages'))
+    .filter((name) => name.startsWith('plugin-'))
+    .map((name) => ({ pkg: name, dir: path.join(repoRoot, 'packages', name, 'src') }))
+    .filter(({ dir }) => fs.existsSync(dir));
+
+  function sourceText(dir: string): string {
+    let out = '';
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        out += sourceText(full);
+      } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+        out += fs.readFileSync(full, 'utf8');
+      }
+    }
+    return out;
+  }
+
+  const PACKAGE_TEXT = new Map(pluginRoots.map(({ pkg, dir }) => [pkg, sourceText(dir)]));
+
+  it.each([
+    'skills/objectui/guides/schema-expressions.md',
+    'skills/objectui/guides/data-integration.md',
+  ] as const)('%s names only registered widgets that read `bind`', (rel) => {
+    const md = readGuide(rel);
+    const paragraph = /the plugin packages register \(([^)]*)\)/.exec(md);
+    expect(paragraph, 'the guide must carry the reader list this test judges').toBeTruthy();
+
+    const listed = [...paragraph![1].matchAll(/`(object-[a-z-]+)`/g)].map((m) => m[1]);
+    // Counter-probe: a per-key loop over an empty list passes vacuously.
+    expect(listed.length).toBeGreaterThan(0);
+
+    for (const key of listed) {
+      const registrar = new RegExp(`ComponentRegistry\\.register\\(\\s*'${key}'`);
+      const owners = [...PACKAGE_TEXT.entries()].filter(([, text]) => registrar.test(text));
+      expect(owners.map(([pkg]) => pkg), `\`${key}\` must be registered by exactly one plugin package`).toHaveLength(1);
+      expect(owners[0][1], `\`${key}\`'s package must read schema.bind`).toContain('useDataScope(schema.bind)');
+    }
+  });
+});

--- a/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
+++ b/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5126 / objectui#5337 — three published skill guides taught a
+ * `data-table` bound with `bind`, and `data-table` reads no such key.
+ *
+ * `DataTableRenderer` takes its rows from `data: rawData = EMPTY_ROWS` off the
+ * node (`renderers/complex/data-table.tsx`); the file contains neither `bind`
+ * nor `useDataScope`. Copying the old example therefore produced no error and
+ * no warning — a table with a correct-looking header over the "No results
+ * found" empty state, which is the hardest failure shape for an AI author to
+ * self-check. The guides also asserted a mechanism that belongs to a different
+ * component: "the table component calls `useDataScope("customers")`".
+ *
+ * Direction was settled by objectui#5125 (merged PR #5338): the only
+ * bind-reading table renderer was DELETED under enforce-or-remove rather than
+ * promoted, so `data-table` does not gain `bind` — the teaching is what
+ * changes. Today `useDataScope` is called by `list` and `tree-view` in this
+ * package, plus the `object-*` widgets in the plugin packages.
+ *
+ * Three halves, and the first two are what make the third mean anything:
+ *
+ *   - COUNTER-PROBE. Each guide is asserted to still contain a `bind` key in a
+ *     JSON block at all. Without it, "no `data-table` block carries `bind`"
+ *     would also pass against a file whose fences this extractor cannot see,
+ *     or one that stopped teaching `bind` altogether. A zero is not a reading
+ *     until a known-present term proves the method works.
+ *   - DOC-SAMENESS. The pin is on the guide bytes, not on a copy: the blocks
+ *     are lifted out of the real files at run time, so re-introducing the
+ *     defect in any of the three sites fails here.
+ *   - BEHAVIOUR. The blocks the guides now teach are fed to the REAL
+ *     `SchemaRenderer` and asserted to put rows on screen, and the retired
+ *     `bind` form is fed to the same renderer and asserted to produce the
+ *     empty state. The correction is verified against the renderer rather
+ *     than against a reading of it.
+ *
+ * The `columns` entries in these examples are deliberately untouched: their
+ * `{ name, label }` spelling is the separate open question on objectui#5120
+ * (the undeclared `col.name` / `col.label` alias at `data-table.tsx:776-777`),
+ * parked with the maintainer. This file pins the BINDING only, and stays true
+ * whichever way that one lands — nothing below asserts a column key spelling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+
+// The REAL renderers, imported at module scope so `data-table` / `list` are in
+// the registry before the first render (AGENTS.md §测试纪律 — never behind a
+// lazy boundary inside a bounded window).
+import '@object-ui/components';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+
+const GUIDES = {
+  'skills/objectui/guides/schema-expressions.md': 'schema-expressions',
+  'skills/objectui/rules/protocol.md': 'protocol',
+  'skills/objectui/guides/data-integration.md': 'data-integration',
+} as const;
+
+const GUIDE_PATHS = Object.keys(GUIDES) as (keyof typeof GUIDES)[];
+
+function readGuide(rel: string): string {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+/** Every fenced ```json block body in a markdown file, in document order. */
+function jsonBlocks(md: string): string[] {
+  const out: string[] = [];
+  const fence = /```json\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = fence.exec(md)) !== null) out.push(m[1]);
+  return out;
+}
+
+/**
+ * Parse a doc block that may carry `//` comments (the guides annotate their
+ * examples inline). Only `//` at line start or after whitespace is stripped,
+ * so a `https://` inside a string value is safe. Returns undefined for blocks
+ * that are illustrative rather than complete (e.g. `"columns": [...]`).
+ */
+function parseBlock(body: string): any | undefined {
+  const stripped = body.replace(/(^|\s)\/\/[^\n]*/g, '$1');
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    return undefined;
+  }
+}
+
+function blocksOfType(md: string, type: string): any[] {
+  return jsonBlocks(md)
+    .map(parseBlock)
+    .filter((node): node is Record<string, unknown> => !!node && node.type === type);
+}
+
+/** Every rendered body cell's text, row-major. */
+function bodyCells(): string[] {
+  return Array.from(document.querySelectorAll('tbody td')).map((td) => (td.textContent ?? '').trim());
+}
+
+function renderNode(schema: unknown, dataSource: unknown) {
+  return render(
+    <SchemaRendererProvider dataSource={dataSource}>
+      <SchemaRenderer schema={schema as never} />
+    </SchemaRendererProvider>,
+  );
+}
+
+describe('skill guides — counter-probe before the zero (#5126)', () => {
+  it.each(GUIDE_PATHS)('%s still teaches `bind` in a JSON block', (rel) => {
+    const md = readGuide(rel);
+    const blocks = jsonBlocks(md);
+
+    // The extractor sees this file at all...
+    expect(blocks.length).toBeGreaterThan(0);
+    // ...and a `bind` key is present in one of the blocks it sees. This is the
+    // known-present term: the "no `data-table` block binds" assertion below is
+    // only a reading because this one passes.
+    expect(blocks.some((b) => /"bind"\s*:/.test(b))).toBe(true);
+  });
+});
+
+describe('skill guides — no `data-table` example is bound with `bind` (#5126, #5337)', () => {
+  it.each(GUIDE_PATHS)('%s', (rel) => {
+    const md = readGuide(rel);
+    const offenders = jsonBlocks(md).filter(
+      (b) => /"type"\s*:\s*"data-table"/.test(b) && /"bind"\s*:/.test(b),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('no guide claims a table component calls useDataScope', () => {
+    for (const rel of GUIDE_PATHS) {
+      const md = readGuide(rel);
+      // The exact retired sentence and its shape: a `data-table` cannot be the
+      // subject of a useDataScope claim, because it never calls it.
+      expect(md).not.toMatch(/table component calls\s+`?useDataScope/i);
+    }
+  });
+});
+
+describe('skill guides — the taught `data-table` form renders rows (#5126)', () => {
+  // A decoy dataSource: it holds exactly the path the retired example bound to.
+  // Rows appearing while this is in scope proves they came from the node's
+  // inline `data`, not from the provider.
+  const DECOY = { customers: [{ name: 'Should Not Appear', email: 'decoy@example.com' }] };
+
+  it.each(['skills/objectui/guides/schema-expressions.md', 'skills/objectui/guides/data-integration.md'] as const)(
+    '%s: the inline-`data` table puts its rows on screen',
+    (rel) => {
+      const [node, ...extra] = blocksOfType(readGuide(rel), 'data-table');
+      expect(node, 'the guide must carry a parseable data-table example').toBeTruthy();
+      expect(extra).toEqual([]);
+
+      renderNode(node, DECOY);
+
+      expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+      expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
+      expect(bodyCells()).toEqual([
+        'Ada Lovelace',
+        'ada@example.com',
+        'Grace Hopper',
+        'grace@example.com',
+      ]);
+    },
+  );
+
+  it('the retired `bind` form renders the empty state — the defect this card closes', () => {
+    // Same node, `data` swapped for the `bind` the guides used to teach, and a
+    // provider that really does hold the array. This is the measurement that
+    // rules the old teaching false; it is not a claim about the docs.
+    const [taught] = blocksOfType(readGuide('skills/objectui/guides/schema-expressions.md'), 'data-table');
+    const { data: _rows, ...withoutData } = taught as Record<string, unknown>;
+    const bound = { ...withoutData, bind: 'customers' };
+
+    renderNode(bound, { customers: _rows });
+
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+    // One body row, and it is the empty state spanning the table — measured,
+    // not assumed: the bound array never reaches the renderer at all.
+    expect(document.querySelectorAll('tbody tr')).toHaveLength(1);
+    expect(bodyCells()).toEqual(['No results foundTry adjusting your filters or search query.']);
+  });
+});
+
+describe('skill guides — the taught `bind` form renders bound entries (#5126)', () => {
+  it.each(GUIDE_PATHS)('%s: its `list` example renders one entry per bound item', (rel) => {
+    // Selected by its bound path, not by document order: these guides carry
+    // several `list` examples (the data-as-nodes section adds more).
+    const node = blocksOfType(readGuide(rel), 'list').find((n) => n.bind === 'customerNames');
+    expect(node, 'the guide must carry a parseable list example bound with `bind`').toBeTruthy();
+
+    renderNode(node, { customerNames: ['Ada Lovelace', 'Grace Hopper'] });
+
+    const items = Array.from(document.querySelectorAll('li')).map((li) => (li.textContent ?? '').trim());
+    expect(items).toEqual(['Ada Lovelace', 'Grace Hopper']);
+  });
+});

--- a/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
+++ b/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
@@ -57,8 +57,10 @@ import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 
 // The REAL renderers, imported at module scope so `data-table` / `list` are in
 // the registry before the first render (AGENTS.md §测试纪律 — never behind a
-// lazy boundary inside a bounded window).
-import '@object-ui/components';
+// lazy boundary inside a bounded window). The relative path is required: this
+// file lives INSIDE `@object-ui/components`, and the bare specifier would be a
+// package self-import (`scripts/check-package-self-import.mjs`).
+import '../renderers';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, '../../../..');
@@ -90,19 +92,22 @@ function jsonBlocks(md: string): string[] {
  * so a `https://` inside a string value is safe. Returns undefined for blocks
  * that are illustrative rather than complete (e.g. `"columns": [...]`).
  */
-function parseBlock(body: string): any | undefined {
+function parseBlock(body: string): unknown {
   const stripped = body.replace(/(^|\s)\/\/[^\n]*/g, '$1');
   try {
-    return JSON.parse(stripped);
+    return JSON.parse(stripped) as unknown;
   } catch {
     return undefined;
   }
 }
 
-function blocksOfType(md: string, type: string): any[] {
+function blocksOfType(md: string, type: string): Record<string, unknown>[] {
   return jsonBlocks(md)
     .map(parseBlock)
-    .filter((node): node is Record<string, unknown> => !!node && node.type === type);
+    .filter(
+      (node): node is Record<string, unknown> =>
+        !!node && typeof node === 'object' && (node as Record<string, unknown>).type === type,
+    );
 }
 
 /** Every rendered body cell's text, row-major. */
@@ -182,7 +187,7 @@ describe('skill guides — the taught `data-table` form renders rows (#5126)', (
     // provider that really does hold the array. This is the measurement that
     // rules the old teaching false; it is not a claim about the docs.
     const [taught] = blocksOfType(readGuide('skills/objectui/guides/schema-expressions.md'), 'data-table');
-    const { data: _rows, ...withoutData } = taught as Record<string, unknown>;
+    const { data: _rows, ...withoutData } = taught;
     const bound = { ...withoutData, bind: 'customers' };
 
     renderNode(bound, { customers: _rows });

--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -193,7 +193,7 @@ the `customerNames` array from the dataSource.
 `useDataScope` is called by `list` and `tree-view` in `@object-ui/components`,
 and by the `object-*` widgets the plugin packages register (`object-grid`,
 `object-kanban`, `object-chart`, `object-data-table`, `object-gallery`,
-`object-timeline`, `object-pivot-table`). Every other component ignores `bind`
+`object-timeline`, `object-pivot`). Every other component ignores `bind`
 completely — no error, no warning, nothing in the console.
 
 `data-table` is not among them, which is the trap worth knowing by name: it

--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -178,20 +178,42 @@ adapter.onBatchProgress((event) => {
 
 ### Via `bind` + `useDataScope`
 
-Data-driven components (grids, tables, kanbans, charts) use the `bind` field:
+A component reads the `bind` field only if it calls `useDataScope`:
+
+```json
+{
+  "type": "list",
+  "bind": "customerNames"
+}
+```
+
+Inside the component: `const data = useDataScope("customerNames")` resolves to
+the `customerNames` array from the dataSource.
+
+`useDataScope` is called by `list` and `tree-view` in `@object-ui/components`,
+and by the `object-*` widgets the plugin packages register (`object-grid`,
+`object-kanban`, `object-chart`, `object-data-table`, `object-gallery`,
+`object-timeline`, `object-pivot-table`). Every other component ignores `bind`
+completely — no error, no warning, nothing in the console.
+
+`data-table` is not among them, which is the trap worth knowing by name: it
+takes its rows from an inline `data` array on the node, so a bound `data-table`
+renders a correct-looking header over an empty body, with nothing thrown and
+nothing logged.
 
 ```json
 {
   "type": "data-table",
-  "bind": "customers",
+  "data": [
+    { "name": "Ada Lovelace", "email": "ada@example.com" },
+    { "name": "Grace Hopper", "email": "grace@example.com" }
+  ],
   "columns": [
     { "name": "name", "label": "Name" },
     { "name": "email", "label": "Email" }
   ]
 }
 ```
-
-Inside the component: `const data = useDataScope("customers")` resolves to the `customers` array from the dataSource.
 
 ### Via expressions on the node
 

--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -140,7 +140,8 @@ const staticData = {
 </SchemaRendererProvider>
 ```
 
-Components with `bind: "customers"` will then access `staticData.customers`.
+Components that read `bind` (see "Via `bind` + `useDataScope`" below) will then
+access `staticData.customers` when given `bind: "customers"`.
 
 ## ObjectStackAdapter
 

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -391,7 +391,7 @@ When `SchemaRendererProvider` receives
 `useDataScope` is called by `list` and `tree-view` in `@object-ui/components`,
 and by the `object-*` widgets the plugin packages register (`object-grid`,
 `object-kanban`, `object-chart`, `object-data-table`, `object-gallery`,
-`object-timeline`, `object-pivot-table`). Every other component ignores `bind`
+`object-timeline`, `object-pivot`). Every other component ignores `bind`
 completely — no error, no warning, nothing in the console.
 
 `data-table` is the one that catches authors out. It takes its rows from an

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -370,12 +370,43 @@ in `dependsOn`.
 
 ## Data binding with `bind`
 
-The `bind` field is NOT expression-evaluated. It's a path string resolved by `useDataScope()`:
+The `bind` field is NOT expression-evaluated. It's a path string resolved by
+`useDataScope()` — and **only a component that calls that hook reads it**.
+
+```json
+{
+  "type": "list",
+  "bind": "customerNames"
+}
+```
+
+When `SchemaRendererProvider` receives
+`dataSource = { customerNames: ["Ada Lovelace", "Grace Hopper"] }`, `list` calls
+`useDataScope("customerNames")` and renders one entry per array element.
+
+**Nested paths work:** `"bind": "app.settings.users"` resolves `dataSource.app.settings.users`.
+
+### Which components read `bind`
+
+`useDataScope` is called by `list` and `tree-view` in `@object-ui/components`,
+and by the `object-*` widgets the plugin packages register (`object-grid`,
+`object-kanban`, `object-chart`, `object-data-table`, `object-gallery`,
+`object-timeline`, `object-pivot-table`). Every other component ignores `bind`
+completely — no error, no warning, nothing in the console.
+
+`data-table` is the one that catches authors out. It takes its rows from an
+inline `data` array on the node and never calls `useDataScope`, so a `bind` on
+it resolves nothing: the table renders its header over the "No results found"
+empty state. Nothing is thrown and nothing is logged — a table that looks built
+and is blank is the whole failure.
 
 ```json
 {
   "type": "data-table",
-  "bind": "customers",
+  "data": [
+    { "name": "Ada Lovelace", "email": "ada@example.com" },
+    { "name": "Grace Hopper", "email": "grace@example.com" }
+  ],
   "columns": [
     { "name": "name", "label": "Name" },
     { "name": "email", "label": "Email" }
@@ -383,9 +414,9 @@ The `bind` field is NOT expression-evaluated. It's a path string resolved by `us
 }
 ```
 
-When `SchemaRendererProvider` receives `dataSource = { customers: [...] }`, the table component calls `useDataScope("customers")` and gets the array.
-
-**Nested paths work:** `"bind": "app.settings.users"` resolves `dataSource.app.settings.users`.
+To show *provider* data in a `data-table`, resolve the array in the host and put
+it on the node — the same "expand in the host" route the next section describes
+for per-record nodes.
 
 ## No per-item template iteration (`list` is data-as-nodes)
 

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -123,17 +123,18 @@ When the entire string is a single `${expression}`, the result preserves its typ
 
 ## Rule: Data Binding Path Resolution
 
-The `bind` field is NOT expression-evaluated. It's a path string resolved by `useDataScope()`:
+The `bind` field is NOT expression-evaluated. It's a path string resolved by `useDataScope()`, and only a component that calls that hook reads it:
 
 ```json
 {
-  "type": "data-table",
-  "bind": "customers",  // Resolved as dataSource.customers
-  "columns": [...]
+  "type": "list",
+  "bind": "customerNames"  // Resolved as dataSource.customerNames
 }
 ```
 
 **Nested paths work:** `"bind": "app.settings.users"` resolves `dataSource.app.settings.users`.
+
+**Readers only.** `list` and `tree-view` (`@object-ui/components`) and the `object-*` plugin widgets call `useDataScope`. `data-table` does NOT: it reads its rows from an inline `data` array on the node, so a `bind` on it is ignored and the table renders its header over an empty body — no error, no warning.
 
 ## Rule: Action Event Structure
 


### PR DESCRIPTION
Fixes #5126
Fixes #5337

## The defect

Three published skill guides taught `{ "type": "data-table", "bind": "customers" }`, and two of them added a mechanism sentence: *"the table component calls `useDataScope("customers")` and gets the array."*

`DataTableRenderer` takes its rows from `data: rawData = EMPTY_ROWS` off the node, and `packages/components/src/renderers/complex/data-table.tsx` matches neither `bind` nor `useDataScope` (grep, zero hits, re-measured on this branch). Copying the example threw nothing and logged nothing — a header over the "No results found" empty state, which is the hardest shape for an AI author to self-check.

Measured here through the real `SchemaRenderer`, with a provider that really does hold the array:

```
retired bind form : 1 tbody row  -> ["No results foundTry adjusting your filters or search query."]
taught data form  : 2 tbody rows -> ["Ada Lovelace","ada@example.com","Grace Hopper","grace@example.com"]
```

## Direction — inherited, not re-opened

#5125 was adjudicated as enforce-or-remove **deletion** of the only bind-reading table renderer (landed in PR #5338), so `data-table` does not gain `bind` here: the teaching is what changes. Making it read `bind` would widen the authorable key surface that sibling ruling declined to widen; that would be a new Feature card through the decision inbox, and is out of scope here.

## Site census — measured on `origin/main` `bdf8cf76e`, and repo-wide

| file | `data-table` blocks | which carried `bind` | verdict |
|---|---|---|---|
| `skills/objectui/guides/schema-expressions.md` | `:377` | `:377` | corrected |
| `skills/objectui/guides/data-integration.md` | `:185` | `:185` | corrected |
| `skills/objectui/rules/protocol.md` | `:100`, `:109`, `:130` | `:130` only | `:130` corrected; `:100` / `:109` left alone |

`protocol.md:100` and `:109` are the "No Schema Property Invention" pair — a violation example spelling `fields`, and its `columns` counterpart. Neither carries `bind`; both are about the property-invention rule and are correct as they stand.

**The zeros are counter-probed, not assumed.** Grepping each whole file on `origin/main` for the known-present terms: `schema-expressions.md` has 13 `bind` lines and 3 `useDataScope` lines; `protocol.md` has 5 and 2; `data-integration.md` has 5 and 3. So the extractor does see these files, and "only one block in `protocol.md` binds" is a reading rather than a silent miss.

Widened past the three cards named: across all 307 markdown/MDX files tracked under `content/docs`, `skills`, `packages`, `apps` and `examples`, exactly **3** fenced `json` blocks paired `data-table` with a `bind` key — the three above — and **0** remain on this branch. Counter-probe on the same scan: 8 json blocks carry a `bind` key on both refs, so the zero is the finding and not a broken matcher. (The first version of that scan made the language tag optional in the fence pattern, mis-paired opening and closing fences, and reported **zero on `origin/main` too**. The counter-probe is what caught it.)

## What changed

- All three sites now demonstrate `bind` with `list`, which does call `useDataScope`, bound to a **string** array. Binding `list` to ordinary records renders the right number of *empty* entries — the sibling trap #4797 recorded — so the example data is node-shaped on purpose.
- Each site now names the real readers and says plainly that `data-table` is not one of them.
- The `useDataScope` mechanism sentence, which described a different component, is gone.
- `schema-expressions.md` and `data-integration.md` keep a `data-table` example, now in its real inline-`data` form.
- `data-integration.md:143` carried the same over-broad claim in miniature ("Components with `bind: "customers"` will then access ...", unqualified). One clause, same defect class, same file, named here because a fix nobody names is scope creep.

The reader list is `list` and `tree-view` in `@object-ui/components`, plus `object-grid`, `object-kanban`, `object-chart`, `object-data-table`, `object-gallery`, `object-timeline` and `object-pivot` from the plugin packages. That list is itself pinned (below) — the first draft said `object-pivot-table`, which is the component **file** (`ObjectPivotTable.tsx`); the key it registers is `object-pivot`, and a copied type nothing is registered under is the same class of silent failure.

## The `columns` pin is intact

The `columns` entries in `schema-expressions.md` and `data-integration.md` are **byte-identical** to `origin/main` — they do not appear in the diff at all, git matched them as context. Their `{ name, label }` spelling is the separate open question on #5120, parked at `needs-user-decision` with the maintainer to be taken with #5350; nothing here decides it, and both examples stay true whichever way it lands. That question is not addressed by this PR and #5120 remains open.

One `columns` line did go: `protocol.md:130`'s `"columns": [...]` placeholder, which left with the `data-table` node it belonged to. It carried no column-key spelling at all, and `protocol.md` is not one of the two files the #5120 census fork names, so it pre-empts nothing — flagged here rather than buried.

## Verification — against the renderer, not against a reading of it

New pin: `packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx`. It lifts the JSON blocks out of the **real guide files** at run time and feeds them to the real `SchemaRenderer`, so it pins the shipped bytes rather than a copy. Three halves: counter-probe (each guide must still carry a `bind` key in some block, so the "no `data-table` binds" assertion is a reading), doc-sameness, and behaviour.

**Build artifacts between the edit and the thing under test: none, on every leg.** The root `vitest.config.mts` aliases every workspace package to its `src/`, so `@object-ui/react` and the renderers resolve to source; the guides are read from disk at run time. No `dist/` sits in the path, so no rebuild is needed for a leg to be honest.

All runs from the repo root (`pnpm exec vitest run PATH`), per the invocation guard — never `pnpm --filter PKG test`.

Green on `99d8721a3`:

```
vitest run packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
  Test Files  1 passed (1)        Tests  15 passed (15)          exit 0

vitest run scripts/__tests__/doc-version-claims.test.ts \
           scripts/__tests__/check-skills-paths.test.ts \
           packages/plugin-dashboard/src/__tests__/ObjectDataTable.columnIdentity.test.tsx
  Test Files  3 passed (3)        Tests  61 passed (61)          exit 0

pnpm --filter @object-ui/components run type-check                exit 0
eslint packages/components/src/__tests__/skill-guide-...test.tsx  exit 0 (0 errors, 0 warnings)
node scripts/check-skills-paths.mjs                               exit 0 (94/95 paths resolve, 1 baselined)
node scripts/check-control-bytes.mjs                              exit 0 (4758 files)
node scripts/check-package-self-import.mjs                        exit 0
node scripts/check-changeset-presence.mjs                         exit 0 (empty-frontmatter exemption)
node scripts/check-changeset-fixed.mjs / -no-major.mjs            exit 0
```

**Reverse verification, both legs run and both stated.** With the three guides reverted to `origin/main` and the test unchanged, the pin goes **red**: 9 failed / 4 passed, exit 1 — the three `no data-table example is bound` cases, the `useDataScope` sentence case, both inline-`data` render cases, and the three `list` cases. Restoring the guides returns 15/15, exit 0. The four that pass under the mutation are the three counter-probes (main teaches `bind` too, correctly, so they must pass) and the empty-state measurement, which is true on both refs — that is the point of it.

Second ablation, on the reader-list guard specifically: putting `object-pivot-table` back into `schema-expressions.md` fails it with `` `object-pivot-table` must be registered by exactly one plugin package: expected [] to have a length of 1 ``. Restored, 15/15.

## Governed surface — do not merge

`skills/**` is maintainer-merge-only. This is a **draft** on purpose: please **do not enable auto-merge and do not merge it** from a passing seat. It waits for a maintainer.

## Changeset

`.changeset/5126-data-table-bind-teaching.md`, empty frontmatter. Nothing published changes: three files under `skills/`, one new test, and no package source. The empty frontmatter is the gate's explicit exemption, and the only reason a declaration is owed at all is that the new test lives under `packages/components/src/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_