### PR TITLE
fix(components): a `field:`-prefixed secret field fails closed instead of rendering clear text (#5322)

### DIFF
--- a/.changeset/prefixed-secret-field-fails-closed.md
+++ b/.changeset/prefixed-secret-field-fails-closed.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/components': patch
+---
+
+A `field:`-prefixed `password` no longer renders as clear text when its widget is not registered
+
+On the built-in path (`@object-ui/fields` not registered) a form field spelled with the
+`field:`-prefixed widget id resolved nothing and took the form renderer's `default` input
+branch. That branch's native-input table was keyed on the raw `type`, so the prefixed
+spelling missed it and rendered `type="text"` — and `mapFieldTypeToFormType` emits the
+prefixed id for **every** object-derived form, so this was the normal path, not an edge
+case. An object-derived `password` field therefore put the secret on screen in clear text,
+and an object-derived `email` field lost its native keyboard and validation.
+
+The two spellings now get the answer each deserves:
+
+- **`field:password` refuses.** Reaching the unregistered default with a registry key
+  proves the app shipped without the widget it declares, so the value is not rendered at
+  all — no input, nothing carrying the secret in the DOM. In its place is an inline
+  `role="alert"` refusal naming the missing widget, plus a `console.error` that doubles as
+  the fix instruction. Masking alone would still invite a user to type a secret into a form
+  whose password widget is absent.
+- **`field:email` renders the native email input**, because the native-input table is now
+  keyed on the declared type with the `field:` prefix stripped.
+- **The bare `password` / `email` spellings are unchanged.** They claim no registered
+  widget, the default branch is their intended home, and their native input stays exactly
+  as it was.
+
+Deliberately narrow: only `password` refuses, and only under the `field:` namespace. Every
+other unregistered `field:*` id renders the same text box it rendered before, and a
+registered `field:password` widget still wins.

--- a/packages/components/src/renderers/form/__tests__/form-prefixed-field-native-input.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-prefixed-field-native-input.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The unregistered-widget `default` branch, answered per spelling —
+ * objectui#5322, triage ruling of 2026-08-19.
+ *
+ * ## What was measured on this card's branch point (`main` at f2e11ae6f)
+ *
+ * On the built-in path (no `registerAllFields()`), with nothing registered
+ * under the `field:` namespace:
+ *
+ *   field:password  registryGet=false  type="text"
+ *                   attrs=["class","id","aria-describedby","aria-invalid","type","name"]
+ *   field:email     registryGet=false  type="text"
+ *   password        registryGet=true   type="password"    (objectui#5254 / PR5326)
+ *   email           registryGet=true   type="email"       (objectui#5254 / PR5326)
+ *
+ * `mapFieldTypeToFormType` (`@object-ui/fields`) emits the `field:`-prefixed id
+ * for EVERY object-derived form, so the first two lines are the normal path:
+ * an object-derived `password` field rendered a plain text box with the secret
+ * on screen in clear text, and an object-derived `email` field lost its native
+ * keyboard and validation.
+ *
+ * PRE-EXISTING, not a regression from objectui#5254: `NATIVE_INPUT_FIELD_TYPES`
+ * is keyed on the raw `type`, so the prefixed spelling always missed it. The
+ * same reading was taken on `origin/main` before that change.
+ *
+ * ## The two halves, and why the spellings differ
+ *
+ * The ruling: *"the unregistered-widget default must respect the declared input
+ * type, or refuse to render the value rather than degrade to clear text"*, with
+ * *"for `password` specifically, prefer masking/refusal over best-effort
+ * rendering"*. Both limbs are used, on the spellings where each is correct:
+ *
+ *  - A **bare** `password` / `email` claims no registered widget. This branch is
+ *    its intended home and its native input is the CORRECT rendering, not a
+ *    degrade. Unchanged — the behaviour PR5326 gave it is pinned below, because
+ *    a fix that traded one spelling for the other would not be a fix.
+ *  - A **`field:`-prefixed** id is a registry key, so reaching this branch with
+ *    one PROVES the app shipped without the widget it declares. For `email`
+ *    that is answered by respecting the declared type (`type="email"`). For
+ *    `password` masking is not enough: the user would be typing a secret into a
+ *    form whose password widget is absent, in a box that looks like it worked.
+ *    It refuses — no input, no value in the DOM — and says why.
+ *
+ * ## Build artifacts
+ *
+ * None between the edit and the thing under test. Every `@object-ui/*`
+ * specifier is aliased to that package's `src/` by the root `vitest.config.mts`
+ * (`alias` block), and the renderer under test is imported through a relative
+ * path (`../../../renderers`). No `dist/` is consulted on this leg.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/** Render the built-in branch: no `registerAllFields()`, so nothing resolves under `field:`. */
+function renderForm(fields: any[], extra: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields, ...extra }} />,
+  );
+}
+
+const input = () => document.querySelector('input') as HTMLInputElement | null;
+
+afterEach(cleanup);
+
+describe('the unregistered-widget default branch, per spelling (objectui#5322)', () => {
+  describe('the routing premise', () => {
+    it('resolves NOTHING for either `field:`-prefixed id on this path', () => {
+      // Without this the whole file would pass on a registry where the widgets
+      // happen to exist — i.e. never exercising the branch under test.
+      expect(ComponentRegistry.get('form')).toBeTruthy(); // counter-probe: registry populated
+      expect(ComponentRegistry.get('field:password')).toBeUndefined();
+      expect(ComponentRegistry.get('field:email')).toBeUndefined();
+    });
+  });
+
+  describe('`field:password` — refuses, rather than degrading to clear text', () => {
+    it('renders NO input at all', () => {
+      // Pre-fix: <input type="text"> — the secret on screen in clear text.
+      const { container } = renderForm([
+        { name: 'pw1', label: 'Password', type: 'field:password' },
+      ]);
+      expect(container.querySelector('input')).toBeNull();
+    });
+
+    it('renders a visible refusal naming the widget that is missing', () => {
+      const { getByTestId } = renderForm([
+        { name: 'pw2', label: 'Password', type: 'field:password' },
+      ]);
+      const refusal = getByTestId('field-missing-secret-widget');
+      // `role="alert"` so the refusal is announced, not merely painted.
+      expect(refusal.getAttribute('role')).toBe('alert');
+      expect(refusal.getAttribute('data-missing-field-widget')).toBe('field:password');
+      // The text names the offending id AND the fix — it is what an agent
+      // iterating on the host bootstrap reads.
+      expect(refusal.textContent).toContain('field:password');
+      expect(refusal.textContent).toContain('registerAllFields()');
+    });
+
+    it('keeps a seeded secret out of the DOM entirely', () => {
+      // The load-bearing assertion of this card: not "is it masked" but "is it
+      // absent". A `type="password"` box still carries the value on the
+      // element; this branch must carry it nowhere.
+      const { container } = renderForm(
+        [{ name: 'pw3', label: 'Password', type: 'field:password' }],
+        { defaultValues: { pw3: 'hunter2' } },
+      );
+      expect(container.innerHTML).not.toContain('hunter2');
+      expect(container.querySelector('input')).toBeNull();
+    });
+
+    it('writes the fix instruction to the console', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        renderForm([{ name: 'pw4', label: 'Password', type: 'field:password' }]);
+        const said = spy.mock.calls.map((c) => String(c[0])).join('\n');
+        expect(said).toContain("form field 'pw4'");
+        expect(said).toContain('field:password');
+        expect(said).toContain('registerAllFields()');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('does not take the rest of the form down with it', () => {
+      // One unrenderable field must not cost the other fields — the reason the
+      // refusal is a rendered alert and not a throw.
+      const { container, getByTestId } = renderForm([
+        { name: 'pw5', label: 'Password', type: 'field:password' },
+        { name: 'contact', label: 'Contact', type: 'field:email' },
+      ]);
+      expect(getByTestId('field-missing-secret-widget')).toBeTruthy();
+      const email = container.querySelector('input[name="contact"]') as HTMLInputElement;
+      expect(email).toBeTruthy();
+      expect(email.getAttribute('type')).toBe('email');
+    });
+
+    it('yields to a REGISTERED `field:password` widget', () => {
+      // The refusal answers a missing widget. It must never preempt a present
+      // one — otherwise every app that DOES register its fields would lose its
+      // password widget. Registered here rather than via `registerAllFields()`
+      // so the assertion is hermetic.
+      const Widget = (props: any) => (
+        <output data-testid="zzpw">{String(props.field?.name)}</output>
+      );
+      ComponentRegistry.register('password', Widget as any, { namespace: 'field' });
+      try {
+        const { getByTestId, queryByTestId } = renderForm([
+          { name: 'pw6', label: 'Password', type: 'field:password' },
+        ]);
+        expect(getByTestId('zzpw').textContent).toBe('pw6');
+        expect(queryByTestId('field-missing-secret-widget')).toBeNull();
+      } finally {
+        ComponentRegistry.unregister('password', 'field');
+      }
+    });
+  });
+
+  describe('`field:email` — respects the declared input type', () => {
+    it('renders the native email input, still named and labelled', () => {
+      // Pre-fix: type="text" — the native keyboard and validation lost.
+      const { container } = renderForm([
+        { name: 'contact', label: 'Contact', type: 'field:email' },
+      ]);
+      const el = input()!;
+      expect(el.tagName).toBe('INPUT');
+      expect(el.getAttribute('type')).toBe('email');
+      expect(el.getAttribute('name')).toBe('contact');
+      // Label names THIS control (the `for`/`id` pair), so the input is
+      // reachable by its accessible name rather than merely present.
+      const label = container.querySelector('label')!;
+      expect(label.getAttribute('for')).toBe(el.getAttribute('id'));
+      expect(el.getAttribute('id')).toBeTruthy();
+    });
+
+    it('accepts typed input and reports it to the form — usable, not just present', () => {
+      const seen: any[] = [];
+      renderForm([{ name: 'contact', label: 'Contact', type: 'field:email' }], {
+        onChange: (values: unknown) => {
+          seen.push(values);
+        },
+      });
+      fireEvent.change(input()!, { target: { value: 'a@b.com' } });
+      expect(input()!.value).toBe('a@b.com');
+      expect(seen.at(-1)).toMatchObject({ contact: 'a@b.com' });
+    });
+
+    it('lets an explicitly authored inputType win over the type-derived one', () => {
+      renderForm([
+        { name: 'contact', label: 'Contact', type: 'field:email', inputType: 'tel' },
+      ]);
+      expect(input()!.getAttribute('type')).toBe('tel');
+    });
+  });
+
+  describe('the BARE spellings keep exactly what PR5326 gave them', () => {
+    // A fix that traded one spelling for the other would not be a fix, and a
+    // file that only covered the prefixed form would not catch that.
+    it('renders bare `password` MASKED', () => {
+      renderForm([{ name: 'secret', label: 'Secret', type: 'password' }]);
+      const el = input()!;
+      expect(el.getAttribute('type')).toBe('password');
+      expect(el.getAttribute('name')).toBe('secret');
+    });
+
+    it('does NOT refuse a bare `password` — it claims no registered widget', () => {
+      // The asymmetry, stated as a test: the refusal keys on the `field:`
+      // prefix (a registry key that resolved nothing), never on the type alone.
+      const { queryByTestId } = renderForm([
+        { name: 'secret', label: 'Secret', type: 'password' },
+      ]);
+      expect(queryByTestId('field-missing-secret-widget')).toBeNull();
+    });
+
+    it('renders bare `email` as a native email input', () => {
+      renderForm([{ name: 'contact', label: 'Contact', type: 'email' }]);
+      expect(input()!.getAttribute('type')).toBe('email');
+    });
+  });
+
+  describe('nothing else on this branch moved', () => {
+    it('leaves another unregistered `field:*` id rendering its text box', () => {
+      // Deliberately narrow: only `password` refuses, and only the two table
+      // members get a native type. Turning the whole unregistered-`field:*`
+      // class into refusals would change fields this card neither moved nor
+      // measured.
+      expect(ComponentRegistry.get('field:currency')).toBeUndefined(); // counter-probe
+      const { queryByTestId } = renderForm([
+        { name: 'amount', label: 'Amount', type: 'field:currency' },
+      ]);
+      expect(input()!.getAttribute('type')).toBe('text');
+      expect(queryByTestId('field-missing-secret-widget')).toBeNull();
+    });
+
+    it('leaves a builtin type on its own branch', () => {
+      // `input` is a BUILTIN_FIELD_TYPES member — the registry is never
+      // consulted for it, and the prefix logic never runs.
+      renderForm([{ name: 'plain', label: 'Plain', type: 'input' }]);
+      expect(input()!.getAttribute('type')).toBe('text');
+    });
+
+    it('still caps a prefixed field by its declared ceiling', () => {
+      // The `maxLength ?? max_length` resolution this branch does (#5253) is
+      // untouched by the type-key change above.
+      renderForm([
+        { name: 'contact', label: 'Contact', type: 'field:email', max_length: 50 },
+      ]);
+      expect(input()!.getAttribute('maxlength')).toBe('50');
+      expect(input()!.getAttributeNames()).not.toContain('max_length');
+    });
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -2828,6 +2828,113 @@ const NATIVE_INPUT_FIELD_TYPES: Record<string, string> = {
   password: 'password',
 };
 
+/**
+ * Declared field types whose VALUE is a SECRET — objectui#5322.
+ *
+ * The one type family where "render something plausible" is the wrong answer.
+ * Every other type in this branch degrades to a text box that is merely LESS
+ * capable than the widget the author declared; a `password` degrades to a text
+ * box that PUTS THE SECRET ON SCREEN, and does it in the shape the author is
+ * least likely to notice (an input, in the right slot, with the right label).
+ *
+ * Membership is the declared type — the `field:` prefix already stripped by
+ * {@link normalizeFieldType} — so the one entry answers both spellings.
+ * `secret` (the ObjectQL type `mapFieldTypeToFormType` maps to
+ * `field:password`) reaches this set through that mapping, as `password`.
+ */
+const SECRET_FIELD_TYPES = new Set(['password']);
+
+/**
+ * `field:<type>` ids already reported missing, keyed by widget id + field name.
+ *
+ * Module-level and de-duplicated for the reason `_reportedUnrecognizedRules`
+ * above is: a schema-driven caller re-renders this field on every keystroke
+ * elsewhere on the form, and a diagnostic that repeats forever gets muted by
+ * the very reader it is written for (objectui#3965).
+ */
+const _reportedMissingSecretWidgets = new Set<string>();
+
+/**
+ * Report a missing SECRET field widget — loudly, once per widget id + field.
+ *
+ * NOT dev-gated, unlike {@link reportUnrecognizedRulesOnce}. That one is a
+ * metadata lint whose audience is the author at their desk; this one is a
+ * REGISTRATION failure on a security-relevant field, and an app that reaches
+ * production in this state is exactly the one whose console should say so.
+ * Same call this file's spec-vocabulary boundary (#3090) and
+ * `RetiredFieldTombstone` (`packages/fields`, objectui#4814) already made for
+ * the same class of entry — one this renderer cannot honour.
+ */
+function reportMissingSecretWidget(widgetType: string, fieldName: string): void {
+  const memo = `${widgetType}::${fieldName}`;
+  if (_reportedMissingSecretWidgets.has(memo)) return;
+  _reportedMissingSecretWidgets.add(memo);
+  // The message doubles as the fix instruction — it is what an agent
+  // iterating on the metadata (or on the host bootstrap) will read and follow.
+  console.error(
+    `[object-ui] form field '${fieldName}': widget '${widgetType}' is NOT registered, so this ` +
+      `form has no widget for a SECRET value. The field renders a refusal instead of an input — ` +
+      `the default input branch would render it as \`type="text"\` and put the secret on screen ` +
+      `in clear text (objectui#5322). Register the field widgets — \`registerAllFields()\` from ` +
+      `\`@object-ui/fields\` — so '${widgetType}' resolves. In a hand-authored standalone form, ` +
+      `write the built-in spelling \`{ type: 'password' }\` instead, which renders the native ` +
+      `masked input on this branch.`,
+  );
+}
+
+/**
+ * The refusal a `field:`-namespaced SECRET field renders when its widget is not
+ * registered — objectui#5322.
+ *
+ * Shape borrowed from `RetiredFieldTombstone` (`packages/fields`) and this
+ * file's own spec-vocabulary boundary (#3090), this repo's settled answer to
+ * "an authored entry this renderer cannot honour": an inline alert that NAMES
+ * the offending entry, plus a `console.error` whose text doubles as the fix
+ * instruction. Nothing is thrown — one unrenderable field must not take down
+ * the rest of the record form — and nothing is silently substituted, which is
+ * the whole point.
+ *
+ * A COMPONENT, not inline JSX, for the same reason `BuiltinSelectEmptyState`
+ * above is one: `renderFieldComponent` is a plain helper that early-returns, so
+ * a hook called there would run conditionally (rules-of-hooks).
+ *
+ * `...rest` is forwarded because `<FormControl>` is a Radix `Slot`: it hands the
+ * control its `id` / `aria-describedby` / `aria-invalid`, so dropping the rest
+ * props here would unlink the field's own label and error message. What is
+ * deliberately NOT forwarded is the field's `value`/`onChange` bundle — the
+ * point of the refusal is that the secret reaches no element at all, so this
+ * component is handed the two identifying strings and nothing else.
+ */
+function MissingSecretFieldWidget({
+  widgetType,
+  fieldName,
+  className,
+  ...rest
+}: {
+  widgetType: string;
+  fieldName: string;
+} & React.HTMLAttributes<HTMLDivElement>) {
+  React.useEffect(() => {
+    reportMissingSecretWidget(widgetType, fieldName);
+  }, [widgetType, fieldName]);
+  return (
+    <div
+      role="alert"
+      data-testid="field-missing-secret-widget"
+      data-missing-field-widget={widgetType}
+      className={cn(
+        'rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive',
+        className,
+      )}
+      {...rest}
+    >
+      {`This field was not rendered: its widget \`${widgetType}\` is not registered. ` +
+        `Register the field widgets (\`registerAllFields()\` from \`@object-ui/fields\`). ` +
+        `A secret is never rendered in a plain text box.`}
+    </div>
+  );
+}
+
 function openNativePickerOnClick(inputType: string | undefined) {
   if (!inputType || !NATIVE_PICKER_INPUT_TYPES.has(inputType)) return undefined;
   return (e: React.MouseEvent<HTMLInputElement>) => {
@@ -3256,6 +3363,73 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
     }
 
     default: {
+      // ── The unregistered-widget default, objectui#5322 ──────────────────
+      //
+      // Two spellings reach this branch and they do NOT mean the same thing,
+      // so the ruling of 2026-08-19 is answered on each in its own terms
+      // ("the unregistered-widget default must respect the declared input
+      // type, OR refuse to render the value rather than degrade to clear
+      // text", with "for `password` specifically, prefer masking/refusal over
+      // best-effort rendering"):
+      //
+      //  - A BARE `password` / `email` is a declared input type on the
+      //    built-in path. It claims no registered widget, this branch IS its
+      //    intended home, and `NATIVE_INPUT_FIELD_TYPES` renders it natively
+      //    (objectui#5254). Nothing below changes that — a fix that traded one
+      //    spelling for the other would not be a fix.
+      //
+      //  - A `field:`-prefixed id is a REGISTRY KEY. Reaching this branch with
+      //    one is proof of an unmet contract: the app declares a widget that
+      //    is not registered (no `registerAllFields()`, or no
+      //    `@object-ui/fields` at all). `mapFieldTypeToFormType` emits the
+      //    prefixed id for EVERY object-derived form, so this is the normal
+      //    path and not an edge case.
+      //
+      // Measured on this branch point (f2e11ae6f), before the change, with
+      // nothing registered under `field:`:
+      //
+      //   field:password → type="text"   attrs=["class","id",
+      //                    "aria-describedby","aria-invalid","type","name"]
+      //   field:email    → type="text"
+      //   password       → type="password"      (PR5326, unchanged)
+      //   email          → type="email"         (PR5326, unchanged)
+      //
+      // i.e. the object-derived spelling of a password field put the secret on
+      // screen in clear text. PRE-EXISTING: `NATIVE_INPUT_FIELD_TYPES` is keyed
+      // on the raw type, so the prefixed spelling always missed it — this is
+      // not a regression from objectui#5254, which was measured on
+      // `origin/main` before that change too.
+      //
+      // The declared type — the prefix stripped — is what the two halves below
+      // read. Only `field:` is stripped (`normalizeFieldType`): it is the one
+      // namespace that means "field widget", the one the producer emits, and
+      // the one this card measured. A `ui:`-qualified id keeps rendering
+      // exactly as it does today.
+      const declaredType = normalizeFieldType(type);
+
+      // ── Half 1: REFUSE, for a secret ────────────────────────────────────
+      // Masking the value would already close the leak the card names, and it
+      // is what the bare spelling does. It is not enough HERE, because here we
+      // additionally KNOW the app shipped without the widget it declares: a
+      // masked box would let the user type a secret into a form whose password
+      // widget (its own strength meter, confirm pair, reveal toggle, submit
+      // handling) is absent, and would look like it worked. So the value is
+      // not rendered at all, in any form, and the refusal says why.
+      //
+      // Deliberately narrow — `password` only, and only under `field:`. Every
+      // other unregistered `field:*` id (`field:currency`, `field:qrcode` …)
+      // still renders the text box it renders today: turning the whole class
+      // into refusals would change fields this card neither moved nor
+      // measured, the same restraint `NATIVE_INPUT_FIELD_TYPES` above states.
+      if (type.startsWith('field:') && SECRET_FIELD_TYPES.has(declaredType)) {
+        return (
+          <MissingSecretFieldWidget
+            widgetType={type}
+            fieldName={String(fieldProps.name ?? '')}
+          />
+        );
+      }
+
       // The declared ceiling is resolved HERE, in BOTH authored spellings,
       // rather than left to ride the pass-through onto the DOM
       // (objectui#5253). Identical mechanism, identical reasons and identical
@@ -3295,13 +3469,24 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       const maxLength = (fieldProps as any).maxLength ?? (fieldProps as any).max_length;
       return (
         <Input
+          // ── Half 2: RESPECT the declared input type ───────────────────
           // An authored `inputType` first, then the native type this field's
           // own declared `type` names (objectui#5254 — `email` / `password`
           // reach this branch since the cross-namespace fallback was removed,
           // and must keep rendering the native input they always rendered:
           // without this a `type: 'password'` field would show the secret as
           // clear text). `'text'` for everything else, exactly as before.
-          type={inputType || NATIVE_INPUT_FIELD_TYPES[type] || 'text'}
+          //
+          // Keyed on `declaredType`, not the raw `type` (objectui#5322): the
+          // table's two members are DECLARED FIELD TYPES
+          // (`EmailFieldMetadata` / `PasswordFieldMetadata` in
+          // `@object-ui/types`), and `field:email` declares `email` just as
+          // plainly as a bare `email` does. Before this the prefixed spelling
+          // missed the table and lost the native keyboard and validation.
+          // `field:password` never reaches here — half 1 above refuses it —
+          // so this line answers `field:email`, and the two bare spellings
+          // exactly as before.
+          type={inputType || NATIVE_INPUT_FIELD_TYPES[declaredType] || 'text'}
           placeholder={placeholder}
           className={cn(readonlyInputClass)}
           {...fallbackProps}


### PR DESCRIPTION
Fixes #5322

## The defect, re-measured at this branch point

`main` at `f2e11ae6f`. On the built-in path (`@object-ui/fields` not registered), rendered through the real `form` renderer:

```
type            registry hit   rendered type   attrs
field:password  false          text            ["class","id","aria-describedby","aria-invalid","type","name"]
field:email     false          text            (same)
password        true           password        (PR5326 behaviour)
email           true           email           (PR5326 behaviour)
```

A `field:`-prefixed id resolves nothing, takes `renderFieldComponent`'s `default` arm, and misses `NATIVE_INPUT_FIELD_TYPES` because that table is keyed on the raw `type`. `mapFieldTypeToFormType` emits the prefixed id for **every** object-derived form, so this is the normal path: an object-derived `password` field put the secret on screen in clear text, and an object-derived `email` field lost its native keyboard and validation.

**Pre-existing.** The table is keyed on the raw type, so the prefixed spelling never matched it — the same reading was taken on `origin/main` before #5254 landed. #5254 / PR5326 neither introduced nor fixed this.

## The shape chosen, and why

Triage ruled: *"the unregistered-widget default must respect the declared input type, or refuse to render the value rather than degrade to clear text"*, with *"for `password` specifically, prefer masking/refusal over best-effort rendering"*. Both limbs are used — on the spelling where each is correct, because **the two spellings do not mean the same thing**:

- A **bare** `password` / `email` is a declared input type on the built-in path. It claims no registered widget; this branch is its intended home and its native input is the *correct* rendering, not a degrade. Untouched.
- A **`field:`-prefixed** id is a registry key. Reaching the default arm with one *proves* an unmet contract: the app declares a widget that is not registered.

So:

| spelling | before | after |
|---|---|---|
| `field:password` | `type="text"` — secret in clear text | **refusal** — no input, no value in the DOM |
| `field:email` | `type="text"` | `type="email"` |
| `password` | `type="password"` | `type="password"` (unchanged) |
| `email` | `type="email"` | `type="email"` (unchanged) |

**Why refusal and not masking for `field:password`.** Masking alone closes the leak, and it is exactly what the bare spelling does. It is not enough here, because here we additionally know the app shipped **without the widget it declares**: a masked box would invite the user to type a secret into a form whose password widget — strength meter, confirm pair, reveal toggle, submit handling — is absent, in a control that looks like it worked. The refusal is an inline `role="alert"` naming the missing widget id, plus a `console.error` whose text doubles as the fix instruction (`registerAllFields()`), mirroring `RetiredFieldTombstone` in `packages/fields` and this file's own spec-vocabulary boundary (#3090). Nothing is thrown — one unrenderable field must not take down the rest of a record form.

**Why `field:email` gets the other limb.** No leak, and the ruling's first limb applies directly: respect the declared type. Turning every unregistered `field:*` id into a refusal would change `field:currency`, `field:qrcode` and every other type this card neither moved nor measured, and would break every app that renders forms without registering fields.

Deliberately narrow: only `password` refuses, only under the `field:` namespace, and a registered `field:password` widget still wins. A `ui:`-qualified id renders exactly as it does today.

## No new authorable key

The accept set is unchanged — no metadata key is declared, read, or widened. `NATIVE_INPUT_FIELD_TYPES` is now keyed on the declared type (`normalizeFieldType`, already in this file) instead of the raw one; the refusal keys on the `field:` prefix plus a two-line `SECRET_FIELD_TYPES` set. This narrows what renders; it accepts nothing new.

## Verification

Pinned on the **rendered output**, not the resolver — the whole defect is that a resolver returning nothing still produced a plausible-looking control.

New file: `packages/components/src/renderers/form/__tests__/form-prefixed-field-native-input.test.tsx`, 16 tests, covering both spellings and both types plus the no-collateral cases (a registered `field:password` widget wins; `field:currency` still renders its text box; builtin `input` untouched; the declared ceiling still caps).

Verified at `6a668d777`:

```
pnpm exec vitest run packages/components/src/renderers/form/__tests__/form-prefixed-field-native-input.test.tsx
  Test Files  1 passed (1)        Tests  16 passed (16)

pnpm exec vitest run packages/components/src/renderers/form packages/components/src/__tests__/form-renderers.test.tsx
  Test Files  50 passed (50)      Tests  352 passed (352)

pnpm exec vitest run packages/plugin-form packages/plugin-detail packages/fields
  Test Files  250 passed (250)    Tests  3200 passed (3200)

pnpm --filter @object-ui/components type-check     exit 0
pnpm exec eslint (the two changed files)           0 errors
node scripts/check-control-bytes.mjs               OK
check:i18n-keys / i18n-drift / doc-types / phantom-deps / self-import   all rc=0
```

Run from the **repo root** with no `--` before the paths, per `scripts/vitest-invocation-guard.mjs`.

### Reverse verification

`form.tsx` reverted to `origin/main` with the new test file kept, then re-run:

```
Test Files  1 failed (1)      Tests  6 failed | 10 passed (16)

× renders NO input at all
    AssertionError: expected an input element to be null
× renders a visible refusal naming the widget that is missing
× keeps a seeded secret out of the DOM entirely
    Received: "… type="text" value="hunter2" name="pw3" …"
× writes the fix instruction to the console
× does not take the rest of the form down with it
× renders the native email input, still named and labelled
    AssertionError: expected 'text' to be 'email'
```

`type="text"` appears in the failure text on the `field:password` legs, and the seeded-secret leg prints the pre-fix DOM carrying `value="hunter2"` in clear text. The 10 that stay green are the bare-spelling pins and the no-collateral cases — i.e. the file would also catch a fix that traded one spelling for the other. `form.tsx` was restored from the commit afterwards (`git checkout HEAD -- …`), verified byte-identical by an empty `git diff HEAD`.

### Build artifacts

**None on any leg.** The root `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src/`, and the renderer under test is imported through a relative path, so no `dist/` sits between the edit and the thing under test. The dependency closure (`pnpm --filter '@object-ui/components^...' build`) was built only because `type-check` resolves `@object-ui/core` and `@object-ui/types` through their published `.d.ts` — without it that leg fails with `TS2307 Cannot find module`, which reads like a source error and is not one.

`check:doc-snippets` was not run locally: it refuses to start until every package it resolves against has a built `dist/`, unrelated to this change. CI builds first and runs it there.

## Notes

- The visible refusal is developer copy, not end-user copy (an app in this state is misconfigured), so it is plain English with no i18n key — the same call `RetiredFieldTombstone` makes.
- `+1` eslint warning on `form.tsx` (`react-refresh/only-export-components`, for the new component), the same warning the two neighbouring built-in-branch components already carry. `--max-warnings` is deliberately unset in `lint.yml`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_