### PR TITLE
fix(docs/gate): check-doc-component-types collects `.md` under content/docs, not `.mdx` only

### DIFF
--- a/.changeset/doc-component-types-md-surface.md
+++ b/.changeset/doc-component-types-md-surface.md
@@ -1,0 +1,7 @@
+---
+---
+
+`scripts/check-doc-component-types.mjs` now collects `.md` pages under `content/docs`
+alongside `.mdx`, converging on the `DOC_EXTENSIONS` spelling
+`scripts/check-doc-snippet-types.mjs` already uses. No published package changes: the
+diff is the gate script, its test, its workflow comments, and six documentation pages.

--- a/.github/workflows/doc-component-types.yml
+++ b/.github/workflows/doc-component-types.yml
@@ -5,8 +5,9 @@ name: Doc Component Types
 # precisely the shape both of those workflows skip. `ci.yml`'s `type-check` job
 # decides whether to run its expensive steps with a `git diff` that excludes
 # `content/**`, `'**/*.md'`, `docs/**` and `apps/site/**` — so a PR that edits
-# only `content/docs/**.mdx` reports the context and runs none of the gates
-# inside it. A gate against a wrong `type` in a teaching snippet, wired there,
+# only `content/docs/**` reports the context and runs none of the gates inside
+# it. Note the `'**/*.md'` term especially: since objectui#5342 this gate reads
+# the `.md` guides too, which is exactly the extension that diff excludes. A gate against a wrong `type` in a teaching snippet, wired there,
 # would be blind to every change that can introduce one.
 #
 # This is the fifth instance of the shape in this repo and the reasoning is
@@ -23,9 +24,9 @@ name: Doc Component Types
 # gate, one home.
 #
 # It needs no install and no build. The script reads the checkout with `node:fs`
-# only: 143 mdx files for the snippets, and the `packages/` + `apps/` sources for
-# the registered-key universe it compares them against. A few seconds. Keep it
-# that way if you add checks to it — the moment this needs `pnpm install` it
+# only: 183 pages for the snippets (143 `.mdx` + 40 `.md`, objectui#5342), and
+# the `packages/` + `apps/` sources for the registered-key universe it compares
+# them against. A few seconds. Keep it that way if you add checks to it — the moment this needs `pnpm install` it
 # stops being cheap enough to run unfiltered, and the filter is the hole.
 
 on:
@@ -65,7 +66,7 @@ jobs:
         with:
           node-version: '22.x'
 
-      # A `type` string in a `content/docs/**.mdx` code block is not rendered,
+      # A `type` string in a `content/docs/**` code block is not rendered,
       # not parsed and not compared against anything, so a snippet can name a
       # component that does not exist and every check in the repo stays green —
       # while a reader who copies it gets the renderer's red "Unknown component

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -680,7 +680,7 @@ A single-record detail view with grouped fields, actions, and tabs.
       "title": "Customer Info",
       "fields": [
         { "name": "customer", "label": "Customer", "type": "text" },
-        { "name": "email", "label": "Email", "type": "link" },
+        { "name": "email", "label": "Email", "type": "email" },
         { "name": "created", "label": "Created", "type": "date", "format": "MMM d, yyyy" }
       ]
     },
@@ -1109,7 +1109,7 @@ An enhanced detail view for a single record with sections, tabs, related records
       "fields": [
         { "name": "firstName", "label": "First Name", "type": "text" },
         { "name": "lastName", "label": "Last Name", "type": "text" },
-        { "name": "email", "label": "Email", "type": "link" },
+        { "name": "email", "label": "Email", "type": "email" },
         { "name": "avatar", "label": "Photo", "type": "image" }
       ]
     }

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -209,7 +209,7 @@ function App() {
     <div className="min-h-screen bg-background p-6">
       <SchemaRenderer
         schema={{
-          type: 'ObjectGrid',
+          type: 'object-grid',
           object: 'task',
           view: 'all',
           data: { objectSchema: TaskSchema },
@@ -238,7 +238,7 @@ Add a "New Task" button and handle row clicks to open the edit form:
 
 ```tsx
 <SchemaRenderer
-  schema={{ type: 'ObjectGrid', object: 'task', view: 'all', data: { objectSchema: TaskSchema } }}
+  schema={{ type: 'object-grid', object: 'task', view: 'all', data: { objectSchema: TaskSchema } }}
   dataSource={dataSource}
   onRowClick={(row: any) => { setEditId(row.id); setShowForm(true); }}
 />
@@ -246,7 +246,7 @@ Add a "New Task" button and handle row clicks to open the edit form:
 {showForm && (
   <SchemaRenderer
     schema={{
-      type: 'ObjectForm',
+      type: 'object-form',
       object: 'task',
       mode: editId ? 'edit' : 'create',
       recordId: editId,
@@ -290,7 +290,7 @@ const [searchQuery, setSearchQuery] = useState('');
 // Grid responds to view and search changes
 <SchemaRenderer
   schema={{
-    type: 'ObjectGrid',
+    type: 'object-grid',
     object: 'task',
     view: activeView,
     data: {
@@ -317,7 +317,7 @@ function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => void }) 
       </button>
       <SchemaRenderer
         schema={{
-          type: 'ObjectDetail',
+          type: 'detail-view',
           object: 'task',
           recordId: taskId,
           data: { objectSchema: TaskSchema },

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -371,7 +371,7 @@ Available: All standard `Math` functions
 
 ```json
 {
-  "type": "empty-state",
+  "type": "empty",
   "visibleOn": "${items.length === 0}",
   "message": "No items to display",
   "description": "Start by adding your first item"

--- a/content/docs/guide/schema-playground.md
+++ b/content/docs/guide/schema-playground.md
@@ -208,7 +208,7 @@ Schemas can be nested to build complex layouts. Here is a dashboard that combine
   "type": "page",
   "title": "Project Dashboard",
   "body": {
-    "type": "grid-layout",
+    "type": "grid",
     "columns": 3,
     "gap": "md",
     "items": [
@@ -280,7 +280,7 @@ const schema = {
 - **Start simple** — Begin with a single `button` or `text` schema and add complexity incrementally.
 - **Use `className`** — Any schema object accepts a `className` property for Tailwind utility classes.
 - **Check the `type`** — If nothing renders, verify the `type` value matches a registered component.
-- **Nest schemas** — Use container types like `stack`, `grid-layout`, and `page` to compose multiple components.
+- **Nest schemas** — Use container types like `stack`, `grid`, and `page` to compose multiple components.
 - **Add expressions** — Use `visibleOn` and `disabledOn` for dynamic behavior: `"visibleOn": "${data.showAdvanced}"`.
 
 ## Related Resources

--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -387,7 +387,7 @@ Always type your schemas for better IDE support and fewer runtime errors.
 
 ```json
 {
-  "type": "empty-state",
+  "type": "empty",
   "visibleOn": "${items.length === 0}",
   "message": "No items found",
   "action": {

--- a/scripts/__tests__/check-doc-component-types.test.ts
+++ b/scripts/__tests__/check-doc-component-types.test.ts
@@ -13,8 +13,8 @@ import { analyze, deriveRegistryKeys, scanDocs } from '../check-doc-component-ty
  * objectui#4823 — the test for `scripts/check-doc-component-types.mjs`.
  *
  * The gate answers one question: does every `type` string literal in a
- * `content/docs/**.mdx` code block name a component this repository actually
- * registers. Nothing rendered or parsed those snippets before it, so the same
+ * `content/docs/**` code block — `.mdx` and `.md` alike — name a component this
+ * repository actually registers. Nothing rendered or parsed those snippets before it, so the same
  * defect landed three times (objectui#4786 `stats-card`, objectui#4796
  * `plugin:grid` and `plugin:map`) and CI was green through all three.
  *
@@ -253,6 +253,31 @@ describe('the docs scan reads code blocks, in both spellings, and only code bloc
     expect(sites).toEqual([]);
   });
 
+  it('collects `.md` pages as well as `.mdx` — the extension is not a coverage decision', () => {
+    // objectui#5342. The collector used to walk `.mdx` only, so 40 `.md` guides
+    // under the SAME tree were neither judged nor declared. This asserts the
+    // walk, not the verdict: revert `DOC_EXTENSIONS` to `['.mdx']` and the
+    // `from-md` site disappears while every other test in this file stays green.
+    const { sites, counters } = withTree((write) => {
+      write('content/docs/a.mdx', ['```json', '{ "type": "from-mdx" }', '```'].join('\n'));
+      write('content/docs/guide/b.md', ['```json', '{ "type": "from-md" }', '```'].join('\n'));
+      // Not a page: the `meta.json` sidecars fumadocs keeps beside the prose.
+      write('content/docs/meta.json', '{ "pages": ["a"] }');
+    }, (dir) => scanDocs(dir));
+    expect(sites.map((s) => s.value).sort()).toEqual(['from-md', 'from-mdx']);
+    expect(counters.files).toBe(2);
+  });
+
+  it('judges a `.md` page by the same rule, so an unregistered type there is a finding', () => {
+    const { findings } = withTree((write) => {
+      write('packages/demo/src/index.tsx', "ComponentRegistry.register('div', C, { namespace: 'ui' });\n");
+      write('content/docs/guide/b.md', ['```json', '{ "type": "not-a-component" }', '```'].join('\n'));
+    }, (dir) => analyze(dir, BARE));
+    const f = findings as Finding[];
+    expect(f.map((x) => x.reason)).toContain('unregistered-doc-type');
+    expect(f.find((x) => x.reason === 'unregistered-doc-type')?.site).toBe('content/docs/guide/b.md:2');
+  });
+
   it('reports an unterminated fence rather than guessing where code stops', () => {
     const { findings } = withTree((write) => {
       write('content/docs/x.mdx', ['```json', '{ "type": "div" }'].join('\n'));
@@ -367,6 +392,18 @@ describe('the scan cannot collapse quietly', () => {
     expect(counters.registered).toBeGreaterThan(400);
   });
 
+  it('really walks the `.md` half of this tree — the objectui#5342 widening, pinned', () => {
+    // A repo-level assertion because the fixture above proves only the
+    // mechanism. `content/docs` holds 143 `.mdx` and 40 `.md`; a revert to
+    // `.mdx`-only drops ~323 `type` literals out of the scan and this repository
+    // stays green while judging none of them.
+    const { sites, counters } = scanDocs(repoRoot);
+    const mdFiles = new Set(sites.filter((s: { file: string }) => s.file.endsWith('.md')).map((s: { file: string }) => s.file));
+    expect(mdFiles.size, 'no `.md` page carries a scanned `type` literal — the collector narrowed').toBeGreaterThan(15);
+    expect(mdFiles.has('content/docs/api/schema-reference.md')).toBe(true);
+    expect(counters.files).toBeGreaterThan(170);
+  });
+
   it('this repository is green', () => {
     const findings = analyze(repoRoot).findings as Finding[];
     expect(findings.map((f) => `${f.reason} :: ${f.site} :: ${f.value ?? ''}`)).toEqual([]);
@@ -408,6 +445,49 @@ describe('the three snippets this gate found on its first run stay fixed', () =>
 
 // ── 6. the wiring ────────────────────────────────────────────────────────────
 
+describe('objectui#5342 — the key errors the widened collector found stay fixed', () => {
+  // Named rather than left to the repo-wide green assertion, for the same reason
+  // the block above names its three: these are the live specimens the extension
+  // widening produced, and a revert would otherwise read as an unrelated
+  // regression somewhere in a 183-file scan. Each one rendered the OBJUI-001
+  // "Unknown component type" panel for a reader who copied it.
+  const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+  it('the CRUD guide spells the registered keys, not the PascalCase component names', () => {
+    const body = read('content/docs/guide/building-crud-app.md');
+    for (const wrong of ['ObjectGrid', 'ObjectForm', 'ObjectDetail']) {
+      expect(body, `${wrong} is a component NAME; the registry key is lower-kebab`).not.toContain(
+        `type: '${wrong}'`,
+      );
+    }
+    expect(body).toContain("type: 'object-grid'");
+    expect(body).toContain("type: 'object-form'");
+    expect(body).toContain("type: 'detail-view'");
+  });
+
+  it('the two empty-state snippets spell `empty`, the key EmptySchema declares', () => {
+    // packages/types/src/feedback.ts declares `type: 'empty'` and
+    // packages/components/src/renderers/feedback/empty.tsx registers it.
+    for (const rel of ['content/docs/guide/expressions.md', 'content/docs/guide/schema-rendering.md']) {
+      expect(read(rel), `${rel} still teaches empty-state`).not.toContain('"type": "empty-state"');
+      expect(read(rel)).toContain('"type": "empty"');
+    }
+  });
+
+  it('the playground teaches `grid`, in the fenced snippet AND in the prose beside it', () => {
+    const body = read('content/docs/guide/schema-playground.md');
+    expect(body, 'nothing registers grid-layout').not.toContain('grid-layout');
+    expect(body).toContain('"type": "grid"');
+  });
+
+  it('the schema reference gives its Email field a field type that exists', () => {
+    // `link` is not in fieldWidgetMap; `email` and `url` are.
+    const body = read('content/docs/api/schema-reference.md');
+    expect(body).not.toContain('"label": "Email", "type": "link"');
+    expect(body).toContain('"label": "Email", "type": "email"');
+  });
+});
+
 describe('wiring — the gate is reachable and a docs-only PR starts it', () => {
   const workflowDir = path.join(repoRoot, '.github/workflows');
   const workflowPath = path.join(workflowDir, 'doc-component-types.yml');
@@ -444,7 +524,7 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
   it('runs it in NO path-filtered workflow — the change that breaks it is docs-only', () => {
     // The whole reason this is its own workflow. `ci.yml`'s type-check job
     // excludes `content/**` from the diff that decides whether its gates run, so
-    // a PR editing only `content/docs/**.mdx` would start this gate nowhere.
+    // a PR editing only `content/docs/**` would start this gate nowhere.
     expect(workflowFiles.length, 'the workflow directory scan returned implausibly few files').toBeGreaterThan(5);
     for (const file of workflowFiles) {
       const yaml = yamlOf(file);

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Every `type` string literal in a `content/docs/**.mdx` code block must name a
- * component the repository actually registers — or be declared, per file, as
- * belonging to some other vocabulary.
+ * Every `type` string literal in a `content/docs/**` code block — `.mdx` and
+ * `.md` alike — must name a component the repository actually registers, or be
+ * declared, per file, as belonging to some other vocabulary.
  *
  * Run:  node scripts/check-doc-component-types.mjs   (also `pnpm check:doc-types`)
  * Exit: 0 = every teaching snippet names a registered type (or a declared
@@ -142,8 +142,28 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 
 // ── Configuration ────────────────────────────────────────────────────────────
 
-/** Where the teaching prose lives. */
+/** Where the teaching prose lives. This gate walks `content/docs` and nothing
+ *  else: not `skills/**`, not the package READMEs (`check-doc-snippet-types.mjs`
+ *  covers those for its own question), not `docs/**`. */
 const DOCS_ROOT = 'content/docs';
+
+/** Page extensions collected under `DOCS_ROOT`. BOTH are collected, and that is
+ *  the whole content of the scan surface: `content/docs` is authored in a mix of
+ *  `.mdx` and `.md` — the same guide tree, the same renderer, the same reader —
+ *  and an extension is not a coverage decision. Deliberately kept identical to
+ *  `check-doc-snippet-types.mjs`'s `DOC_EXTENSIONS`: two collectors walking one
+ *  tree two different ways is a defect one level up from either gate, and it is
+ *  how a page ends up covered by the question it passes and invisible to the one
+ *  it fails.
+ *
+ *  Collecting only `.mdx` is what objectui#5342 measured, and unlike its sibling
+ *  objectui#5174 this file was never lying about it — the sentence above used to
+ *  say `.mdx` and the ledger was keyed by `.mdx` paths throughout. It was a
+ *  stated coverage decision, not a broken promise, and the decision is now the
+ *  other way: 40 `.md` pages sat outside the ledger, so they were neither
+ *  covered nor declared ungated. Anything else under the tree (the `meta.json`
+ *  sidecars) holds no prose and is not a page. */
+const DOC_EXTENSIONS = ['.mdx', '.md'];
 
 /** Where registrations live. Every workspace source root that can register. */
 const SOURCE_ROOTS = ['packages', 'apps', 'examples'];
@@ -211,12 +231,36 @@ const OPEN_REGISTRATION_SITES = {
  * Per-file declarations that a `type` value in that page belongs to a
  * vocabulary other than the SDUI component registry.
  *
- * Keyed `<repo-relative mdx path>` -> `<type value>` -> reason. The reason must
+ * Keyed `<repo-relative doc path>` -> `<type value>` -> reason. The reason must
  * name the vocabulary and, where one exists, where it is declared — an
  * exemption that only says "not a component" teaches the next reader nothing
  * and cannot be re-checked.
  */
 const DOC_TYPE_EXEMPTIONS = {
+  'content/docs/api/schema-reference.md': {
+    action:
+      'ActionSchema discriminant under a CRUD schema\'s ACTION LISTS, never a rendered child — ' +
+      '`toolbar.actions[]`, `rowActions[]`, `batchActions[]` and a detail page\'s `actions[]` are ' +
+      'each typed `ActionSchema[]` (packages/types/src/crud.ts:175, 379, 480, 484, 561, 612), and ' +
+      'that interface declares `type: \'action\'` at crud.ts:89. Same vocabulary as the ' +
+      '`core/enhanced-actions.mdx` entry below.',
+    crud:
+      'CRUDSchema discriminant — packages/types/src/crud.ts:418 declares it, zod/crud.zod.ts:158 ' +
+      'validates it, core/src/validation/schema-validator.ts:135 has a branch for it and ' +
+      'builder/schema-builder.ts:170 constructs it. FOUR declaration faces and NO registered ' +
+      'renderer, and unlike its siblings in this table it IS on the render path (CRUDComponentSchema ' +
+      'is in the node union at types/src/index.ts:852), so a node spelling it paints OBJUI-001. ' +
+      'Ledgered rather than re-spelled because there is no registered spelling to move to: register ' +
+      'a renderer / retire CRUDSchema under ADR-0049 / demote it off the node union are three ' +
+      'different edits to this page, and picking one is a contract decision objectui#5115 left open ' +
+      'after PR objectui#5128 closed only its CLI half. Filed as objectui#5373. DELETE this entry ' +
+      'when that lands — the gate reports a stale exemption, so it cannot be forgotten.',
+    string:
+      'PageNodeSchema variable declaration\'s data type inside `variables[]`, next to `name` / ' +
+      '`defaultValue` — `PageVariable` (packages/types/src/layout.ts:566, re-exported from ' +
+      '@objectstack/spec\'s `PageVariableSchema`). Same vocabulary as blocks/block-schema.mdx\'s ' +
+      '`string`.',
+  },
   'content/docs/blocks/authentication.mdx': {
     submit:
       'ActionSchema discriminant under a button\'s `action` key, not a node type. ' +
@@ -264,6 +308,13 @@ const DOC_TYPE_EXEMPTIONS = {
       'First member of a TypeScript union of view-action ids (`\'share\' | \'settings\' | ' +
       '\'duplicate\' | \'delete\'`) in a Schema API declaration, not a node type.',
   },
+  'content/docs/components/index.md': {
+    'component-name':
+      'Metasyntactic placeholder in the page\'s "Usage Pattern" template — the block shows the SHAPE ' +
+      'every component schema has (`type` / `className` / component-specific props) and the value ' +
+      'stands for whichever key the reader picked from the catalog below it. Nothing registers the ' +
+      'literal string, by design.',
+  },
   'content/docs/core/app-schema.mdx': {
     item: 'AppSchema menu entry kind — a navigation item, sibling of `group`. Not a rendered node.',
     group: 'AppSchema menu entry kind — a navigation group holding `children` items.',
@@ -299,10 +350,128 @@ const DOC_TYPE_EXEMPTIONS = {
     array: 'JSON Schema property type inside a field\'s `schema.properties`, not a node type.',
     string: 'JSON Schema property type inside a field\'s `schema.properties`, not a node type.',
   },
+  'content/docs/guide/architecture.md': {
+    'my-grid':
+      'Deliberate placeholder in the "register your component, then address it by key" contrast — ' +
+      'the snippet\'s own line above spells `ComponentRegistry.register(\'my-grid\', MyGrid)`, so it ' +
+      'is unregistered in this repository by design.',
+    string:
+      '`ComponentInput.type` in a `register(...)` call\'s `inputs[]` — a DESIGNER input\'s coarse ' +
+      'control kind (packages/types/src/base.ts:386), sibling of `number` / `boolean` / `enum`. ' +
+      'Not a node type.',
+  },
+  'content/docs/guide/component-registry.md': {
+    custom:
+      'Placeholder discriminant in a "type your custom component" `interface CustomSchema extends ' +
+      'BaseSchema` declaration — the page is teaching the reader to declare their own schema ' +
+      'interface, so the literal is theirs to register.',
+    'my-component':
+      'Deliberate placeholder in the "register a custom component" walkthrough — the page registers ' +
+      'this key itself (`ComponentRegistry.register(\'my-component\', MyComponent, …)`) and then ' +
+      'shows the JSON that addresses it.',
+    string:
+      '`ComponentInput.type` in a `register(...)` call\'s `inputs[]` — a designer input\'s coarse ' +
+      'control kind (packages/types/src/base.ts:386), not a node type.',
+  },
+  'content/docs/guide/console-architecture.md': {
+    delete:
+      '`ActionDef.type` passed to `useActionRunner().execute(...)` — a RunnableActionType, the ' +
+      'action vocabulary declared at packages/core/src/actions/ActionRunner.ts:112. An action being ' +
+      'run, not a node being rendered.',
+  },
+  'content/docs/guide/dashboard-filters.md': {
+    bar: 'Dashboard widget kind under `widgets[]`, alongside `line` — same vocabulary as the ' +
+      'plugins/plugin-dashboard.mdx entry below. Not a node type.',
+    line: 'Dashboard widget kind under `widgets[]`, alongside `bar` — same vocabulary as the ' +
+      'plugins/plugin-dashboard.mdx entry below. Not a node type.',
+  },
   'content/docs/guide/objectos-integration.mdx': {
     'my-custom-widget':
       'Deliberate placeholder in the "register a lazy custom widget" walkthrough — the reader ' +
       'supplies this key.',
+  },
+  'content/docs/guide/plugin-development.md': {
+    array:
+      '`ComponentInput.type` in this walkthrough\'s own `register(...)` `inputs[]` — a designer ' +
+      'input\'s coarse control kind (packages/types/src/base.ts:386), not a node type.',
+    board:
+      'The walkthrough\'s OWN plugin key. This page builds `@object-ui/plugin-board` end to end, so ' +
+      'every `board` here — the `BoardSchema` interface, the `register(\'board\', BoardRenderer, …)` ' +
+      'call, the test fixture and the final JSON — is the key the READER registers by following the ' +
+      'page. Unregistered in this repository by design.',
+    enum: '`ComponentInput.type` in the walkthrough\'s `inputs[]` — the coarse kind that carries an ' +
+      '`enum` list of allowed values, not a node type.',
+    string:
+      '`ComponentInput.type` in the walkthrough\'s `inputs[]` (packages/types/src/base.ts:386), not ' +
+      'a node type.',
+  },
+  'content/docs/guide/plugins.md': {
+    module:
+      'The `package.json` manifest\'s OWN `"type": "module"` field — Node\'s ESM switch, in a block ' +
+      'showing the plugin package\'s manifest. Not a UI schema at all. objectui#5127 is the same ' +
+      'collision measured on `objectui check`, which read every JSON file\'s root `type` as a ' +
+      'component key and reported `module` as unknown in any Node project.',
+    'my-feature':
+      'Deliberate placeholder for the reader\'s own plugin schema — the page\'s `MyFeatureSchema ' +
+      'extends BaseSchema` declaration in the "author your plugin\'s types" step.',
+  },
+  'content/docs/guide/record-edit-modes.md': {
+    picklist:
+      'ObjectStack object-metadata FIELD type inside a `fields` record, alongside `text` and ' +
+      '`lookup` — the picker/lookup family spelling packages/core/src/utils/record-title.ts:101 ' +
+      'names explicitly. A field\'s data type, not a node type.',
+  },
+  'content/docs/guide/schema-overview.md': {
+    action:
+      'ActionSchema discriminant in a `const action: ActionSchema = { … }` declaration — this page ' +
+      'tours each schema family by declaring one of each, so the literal is the document\'s own ' +
+      'discriminant. Same vocabulary as core/enhanced-actions.mdx.',
+    block:
+      'BlockSchema discriminant in a `const block: BlockSchema = { … }` declaration — ' +
+      'packages/types/src/blocks.ts, validated by zod/blocks.zod.ts. A block definition is not a ' +
+      'rendered node.',
+    group: 'AppSchema menu entry kind — a navigation group holding `children` items, same ' +
+      'vocabulary as core/app-schema.mdx.',
+    item: 'AppSchema menu entry kind — a navigation item, sibling of `group`. Same vocabulary as ' +
+      'core/app-schema.mdx. Not a rendered node.',
+    string:
+      'BlockVariable.type in the BlockSchema tour\'s `variables[]` — a variable declaration\'s data ' +
+      'type, next to `name` / `defaultValue`.',
+    theme:
+      'ThemeSchema discriminant in a `const theme: ThemeComponentSchema = { … }` declaration — ' +
+      'packages/types/src/theme.ts declares the theme document\'s own `type`, validated by ' +
+      'zod/theme.zod.ts. Same vocabulary as core/theme-schema.mdx.',
+  },
+  'content/docs/guide/schema-playground.md': {
+    reset:
+      'ActionSchema discriminant under a form\'s `actions[]`, alongside `submit` — an action ' +
+      'definition in a list, not a rendered child. Same vocabulary as blocks/authentication.mdx.',
+    submit:
+      'ActionSchema discriminant under a form\'s `actions[]`, alongside `reset` — an action ' +
+      'definition in a list, not a rendered child. Same vocabulary as blocks/authentication.mdx.',
+  },
+  'content/docs/guide/schema-rendering.md': {
+    'admin-panel':
+      'Stand-in for one of the READER\'s own registered components in the "move logic to ' +
+      'expressions" pattern block, whose subject is `visibleOn` — the two nodes exist to be shown ' +
+      'and hidden, and nothing about the pattern depends on which components they are. Weaker than ' +
+      'the `my-component` placeholder above it, which the same page registers in its own snippet: ' +
+      'these two are never registered on the page, so the name alone does not announce that they ' +
+      'are the reader\'s. Recorded here as the disclosed cost of leaving the block\'s subject alone.',
+    'my-component':
+      'Deliberate placeholder — the snippet\'s own line above spells ' +
+      '`ComponentRegistry.register(\'my-component\', MyComponent)`, then shows the schema that ' +
+      'addresses it.',
+    'user-panel':
+      'Stand-in for one of the READER\'s own registered components in the `visibleOn` pattern block, ' +
+      'the `${!user.isAdmin}` half of the pair — see the `admin-panel` entry above for the full ' +
+      'reason and its known weakness.',
+  },
+  'content/docs/plugins/index.md': {
+    'plugin-component-name':
+      'Metasyntactic placeholder in the page\'s "Usage Pattern" template — the block shows the shape ' +
+      'every plugin node has and the value stands for whichever plugin key the reader picked from ' +
+      'the table above it. Nothing registers the literal string, by design.',
   },
   'content/docs/plugins/plugin-dashboard.mdx': {
     bar: 'Dashboard widget kind under `widgets[]`, alongside `line`. Not a node type.',
@@ -694,7 +863,7 @@ export function deriveRegistryKeys(root, options = {}) {
  */
 export function scanDocs(root) {
   const docsDir = join(root, DOCS_ROOT);
-  const files = walkFiles(docsDir, (f) => f.endsWith('.mdx')).sort();
+  const files = walkFiles(docsDir, (f) => DOC_EXTENSIONS.some((ext) => f.endsWith(ext))).sort();
   const sites = [];
   const counters = { files: files.length, codeBlocks: 0, typeSites: 0 };
 
@@ -837,7 +1006,7 @@ const HINTS = {
   'stale-indirect-registration':
     'An INDIRECT_REGISTRATIONS entry no longer resolves to keys, so the universe lost them silently.',
   'unterminated-code-fence':
-    'An mdx file has an unclosed ``` fence. The scan cannot separate code from prose past that point.',
+    'A doc file has an unclosed ``` fence. The scan cannot separate code from prose past that point.',
 };
 
 const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
@@ -875,7 +1044,8 @@ if (invokedDirectly) {
   }
 
   console.log(
-    `Scanned ${counters.files} mdx file(s), ${counters.codeBlocks} code block(s), ` +
+    `Scanned ${counters.files} doc file(s) (${DOC_EXTENSIONS.join(' + ')}), ` +
+      `${counters.codeBlocks} code block(s), ` +
       `${counters.typeSites} \`type\` literal(s) against ${counters.registryKeys} registered key(s) ` +
       `derived from ${counters.sourceFiles} source file(s) (${counters.resolved} resolved call site(s), ` +
       `${counters.indirect} indirect, ${counters.open} open): ` +


### PR DESCRIPTION
Fixes #5342
Part of #5106

`scripts/check-doc-component-types.mjs` collected `.mdx` only, so 40 `.md` guides under the same `content/docs` tree were neither judged nor declared. This widens the collector and pays the triage pass it exposes.

**This is a coverage decision, not a broken promise.** Unlike its sibling #5174, this gate's docblock stated the `.mdx` surface in its first sentence and the ledger was keyed by `.mdx` paths throughout. It did not claim to cover what it skipped. The decision is now the other way, and the docblock says so.

## Converged on the pattern that already landed

`scripts/check-doc-snippet-types.mjs` (PR #5341, follow-on PR #5364) did this widening first. This adopts its exact spelling — `DOCS_ROOT`, `DOC_EXTENSIONS = ['.mdx', '.md']`, and a docblock stating the scan surface next to the coverage rule. Two collectors walking one tree two different ways is the defect one level up; there is now one spelling.

## Measured, on `f2e11ae6f`

| | before | after |
|---|---|---|
| doc files scanned | 143 | **183** (+40 `.md`) |
| code blocks | 632 | **1052** |
| `type` literals | 564 | **887** (+323) |
| registered | 476 | **742** |
| exempted | 88 | **145** |
| findings | 0 | 0 |

First collection produced **67 findings across 15 `.md` pages** — 256 of the 323 new literals already named registered keys. The card's earlier estimate was ~26 guides / ~345 literals; the tree has moved, and 323 in 15 pages is what it holds today.

### Scan roots this collector actually walks

`content/docs` and nothing else — `DOCS_ROOT` is a single constant and the walk has one call site. **`skills/**` is NOT in scope**, nor are the package READMEs (`check-doc-snippet-types.mjs` covers those for its own question), nor `docs/**`. So none of `skills/objectui/guides/i18n.md` (claim #5081), `skills/objectui/guides/schema-expressions.md`, `skills/objectui/guides/data-integration.md` or `skills/objectui/rules/protocol.md` is reachable by this gate, and none is touched here. I added that sentence to the `DOCS_ROOT` docblock so the next reader does not have to re-derive it.

## 10 real key errors fixed

Each one paints the renderer's red "Unknown component type" panel (OBJUI-001) for a reader who copies it. Keys taken from the actual `register(...)` calls, never from file or component names:

| page | was | now | pinned by |
|---|---|---|---|
| `guide/building-crud-app.md` x3 | `ObjectGrid` | `object-grid` | `packages/plugin-grid/src/index.tsx:202` |
| `guide/building-crud-app.md` | `ObjectForm` | `object-form` | `packages/plugin-form/src/index.tsx:100` |
| `guide/building-crud-app.md` | `ObjectDetail` | `detail-view` | `packages/plugin-detail/src/index.tsx:133` |
| `guide/expressions.md` | `empty-state` | `empty` | `packages/types/src/feedback.ts:186` declares it, `components/src/renderers/feedback/empty.tsx:15` registers it |
| `guide/schema-rendering.md` | `empty-state` | `empty` | same |
| `guide/schema-playground.md` | `grid-layout` | `grid` | `components/src/renderers/layout/grid.tsx:50`, which reads `columns` as the number the snippet already writes |
| `api/schema-reference.md` x2 | field `"type": "link"` | `"email"` | `link` is not in `fieldWidgetMap`; `email` and `url` are |

Three notes a reviewer should weigh:

1. **`ObjectDetail` to `detail-view` is the one judgment call here.** There is no `object-detail` key. `detail-view` is the record-detail component plugin-detail registers, and `api/schema-reference.md:1091` already teaches that spelling for the same shape. Flagging it rather than burying it.
2. **The PascalCase family is the #5236 / #5247 shape.** Registry lookup is case-sensitive, so `ObjectGrid` was never going to resolve. This spells the registered lower-kebab keys, which is correct whichever way the #5247 decision goes.
3. **Only the `type` key is corrected, not the props beside it.** `object-grid` and `object-form` read `objectName`, and those snippets write `object`. Whether a snippet's OTHER keys are read is this gate's stated non-goal and the sibling gate's ledger already carries `building-crud-app.md` with un-triaged candidate defects. Left alone deliberately; not folded in.

One prose word moved with its snippet: `schema-playground.md:283` listed `grid-layout` among the container types. Same page, same falsehood, one word. **This is not a scan-surface change** — the collector still stops at code fences, which is #5106's first half and stays untouched.

## 31 ledger entries, covering the remaining 57 sites

Every entry is `(file, value)` with a reason naming the vocabulary it really belongs to and where that vocabulary is declared. No entry was widened, none relaxes the gate, and no threshold moved — `FLOORS` is byte-identical.

The vocabularies the `.md` half turned out to speak:

- **ActionSchema discriminants** under action lists (`toolbar.actions[]`, `rowActions[]`, `batchActions[]`, a form's `actions[]`) — `packages/types/src/crud.ts:89`
- **`ComponentInput.type`** in a `register(...)` call's `inputs[]` — a designer input's coarse control kind, `packages/types/src/base.ts:386`. This is the single largest class, and it is why the "write a plugin" walkthroughs lit up.
- **Walkthrough keys the pages register themselves** — `board` (plugin-development.md builds `@object-ui/plugin-board` end to end), `my-component`, `my-grid`, `my-feature`, `custom`
- **Metasyntactic placeholders** in the two "Usage Pattern" templates — `component-name`, `plugin-component-name`
- **Dashboard widget kinds** `bar` / `line`, **AppSchema menu kinds** `item` / `group`, **ThemeSchema / BlockSchema discriminants**, **BlockVariable and PageVariable data types**
- **Object metadata field types** — `picklist`, the picker/lookup family spelling `packages/core/src/utils/record-title.ts:101` names
- **`package.json`'s own `"type": "module"`** in `guide/plugins.md`. Same collision #5127 measured on `objectui check`.
- **`ActionDef.type`** passed to `useActionRunner().execute(...)` — `packages/core/src/actions/ActionRunner.ts:112`

### One entry is disclosed debt, not vocabulary

`api/schema-reference.md` -> `crud`. `CRUDSchema` has four declaration faces (interface, zod mirror, validator branch, builder) and **no registered renderer**, and unlike its siblings it sits on the render path. There is no registered spelling to move it to — register a renderer / retire it under ADR-0049 / demote it off the node union are three different page edits, and that is the contract question #5115 left open after PR #5128 landed only its CLI half. **Filed as #5373**, and the entry says to delete itself when that lands. The gate reports `stale-exemption` the moment the site changes, so it cannot be forgotten.

Two entries are honest about being weaker than their neighbours: `schema-rendering.md` -> `admin-panel` / `user-panel` are stand-ins for the reader's own components in a block whose subject is `visibleOn`, and unlike the `my-component` placeholder above them the page never registers them. The reason string says exactly that rather than pretending they are the same class.

## Verification

**All runs from the repo root.** Heavy runs held `/tmp/os-heavy-verify.lock`.

```
node scripts/check-doc-component-types.mjs
  Scanned 183 doc file(s) (.mdx + .md), 1052 code block(s), 887 `type` literal(s)
  against 659 registered key(s) ... 742 registered, 145 exempted.
  Every documented component type is registered.                          exit 0

npx vitest run scripts/__tests__/check-doc-component-types.test.ts
  Test Files 1 passed (1) | Tests 34 passed (34)                          exit 0
```

The script passing is not its test passing — the test carries hardcoded ledgers the script never touches, so both are reported. 7 tests added: two fixture-level (both extensions collected; a `.md` page judged by the same rule), one repo-level pin that the widened walk really reaches the `.md` tree, and four pinning the key errors above so a revert reads as itself rather than as noise in a 183-file scan.

**Counter-probed the zeros.** A zero from a broken matcher looks exactly like a clean result, so the derived universe was probed with keys known to be registered before any of it was trusted: `object-grid` YES, `object-form` YES, `grid` YES, `form` YES — against `ObjectGrid` no, `object-detail` no, `empty-state` no, `grid-layout` no. The universe is 659 keys taken from the `register(...)` calls themselves.

**Reverse-verification, and the direction is not the one the template predicts.** Reverting only the walk to `.mdx`-only, from the committed state:

```
files scanned: 183 -> 143     type literals: 887 -> 564
.md pages carrying a scanned site: 20 -> 0
gate: exit 1, 31 problem(s) — all `stale-exemption`
test: 5 failed | 29 passed
```

The newly-collected pages do stop being seen, as expected. But the gate does not fall quiet — it goes **red**, because all 31 new ledger entries lose their sites at once. That is the ratchet working in the reverting direction, and it is a better result than a silent green. The restore leg was verified by marker absence (`f.endsWith('.mdx')` gone from the file) before re-reading anything, and re-ran green: 34/34.

**Build artifacts, per leg.** This gate has none between the edit and the result: every import in `check-doc-component-types.mjs` is a `node:` builtin, which its own test asserts (`needs no install, so it can afford to run unfiltered`). So no leg here was rebuilt, and none needed to be — stating that rather than claiming a rebuild that did not happen.

The **sibling** gate does resolve to `dist/`, and my doc edits touch five pages in its ledger, so it was owed a real run. Built its 15 packages (`--build-filter`), proved the artifacts landed in this worktree rather than trusting a turbo cache-hit that replayed logs from another worktree's path, then:

```
Controls: resolution  '@object-ui/types' resolved to
          /home/user/objectui-issue-5342/packages/types/dist/index.d.ts
Semantic phase: 87 of 87 block(s) judged, 0 failed.                        exit 0
```

Its ledger is still exact — the edits were inside `json` fences or were string-literal values, and shifted no diagnostic mix.

Other gates touched by these paths, all green at `0a6cba7b9`: `check:control-bytes` (4761 files), `check-doc-links.mjs` (13 scan roots), `check:skills-paths`. Plus the `check-doc-links` / `check-doc-snippet-types` / `check-doc-component-types` tests together: 141 passed. `scripts/pm/dispatch-gates.mjs` does not exist in this repo — it lives in `objectstack` — so the gate set was derived from the 14 `check:*` scripts against my changed paths instead.

Every number above and the gate union were taken at `0a6cba7b9`, which is this branch's head.

## Changeset: empty frontmatter

`.changeset/doc-component-types-md-surface.md` declares no package. The diff is the gate script, its test, workflow comments and six documentation pages — **no `packages/*/src` file changes and nothing published moves**. A `patch` would version all 39 packages of the fixed group for a change with zero runtime effect, so this uses the repo's declared "no release" form, which `scripts/check-changeset-presence.mjs` documents as a first-class pass. Never `major`. `content/docs/releases/` is untouched.

This repo has no `skip-changeset` label mechanism — the empty-frontmatter changeset is the declaration, and no label was created or applied.

## Serial constraint held

**#5106 is deliberately out of scope and nothing here folds it in.** Its two halves — the scan surface stopping at code fences, and the gate never judging the namespace half — are separate questions from the extension gap. `scanDocs`'s fence loop is byte-identical to `main` except for the one predicate on the walk, and no namespace logic was added. #5106 remains open and undispatched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_