### PR TITLE
test(scripts): the #3944 alias-target gate now covers the 24 package-level vite.config.ts tables

### DIFF
--- a/.changeset/5168-package-vite-alias-target-existence.md
+++ b/.changeset/5168-package-vite-alias-target-existence.md
@@ -1,0 +1,38 @@
+---
+---
+
+Test-only gate extension, no behaviour and no authoring-surface change (objectui#5168).
+
+`scripts/__tests__/vitest-config-alias-targets-3944.test.ts` enforced "every declared
+alias target exists on disk" for two tables — the root `vitest.config.mts` alias table
+(objectui#3944) and the root `tsconfig.json` `compilerOptions.paths` table, folded in by
+objectui#4804. The package-level `vite.config.ts` alias tables were covered by nothing:
+24 configs, 227 entries, 200 of them `@object-ui/*`.
+
+The one other gate that reads those tables — `side-effects-declaration-consistency.test.ts` —
+does not go red on a dead entry, and that is correct for its own question: an unresolvable
+target contributes no entry form, so no `sideEffects` declaration can conflict with it. Target
+existence and `sideEffects` declaration consistency are two different contracts, so this lands
+in the file whose contract already is the former rather than being folded into that gate.
+
+The parse is borrowed from that gate's AST reader rather than written a fifth time, because
+across 24 files the table is spelled four ways (bare `resolve(`, `path.resolve(`, the array
+`{ find, replacement }` form, and double-quoted keys) and a regex reader that understood one
+of them had 15 configs contributing zero entries while staying green. A spelling-coverage case
+asserts each of the four is demonstrably reachable, so a parser that stopped reading one goes
+red instead of quietly shrinking the surface.
+
+Two adjustments the root tables did not need: existence probes Vite's `resolve.extensions`
+after the alias substitution (an extension-less target naming a file, such as `packages/runner`'s
+`@/lib/utils` pointing at `utils.tsx`, is live), and the root half's "an extension-less target
+must be a directory" case is deliberately not ported, because down here landing on a file is
+the intended spelling.
+
+One live dead entry was found by the new gate on its first run and is carved out as a
+shrink-only ratchet rather than fixed here: `packages/runner`'s `"@app"` points at
+`packages/runner/src/app-data`, which does not exist in any form, and nothing in the repo
+imports `@app`. Whether the fix is to drop the line or restore the DX symlink its comment
+names is a maintainer call — filed as objectui#5380.
+
+No package is declared because nothing published changed: the diff is one file under
+`scripts/__tests__/`.

--- a/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
+++ b/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 /**
  * objectui#3944 — every `resolve.alias` target in the root `vitest.config.mts`
@@ -355,6 +356,543 @@ describe('objectui#4804 — root tsconfig.json compilerOptions.paths table', () 
       nowResolving.map((e) => e.specifier),
       'A carved-out target now exists, so the objectui#4820 carve-out is obsolete for it — drop ' +
         'it from KNOWN_MISSING_TARGETS so the entry is guarded like every other one.'
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// objectui#5168 — the THIRD table set: the package-level `vite.config.ts`
+// alias tables.
+// ---------------------------------------------------------------------------
+
+/**
+ * objectui#5168 — every `resolve.alias` target in every PACKAGE-level
+ * `vite.config.ts` must resolve to something a bundler can reach.
+ *
+ * ## The hole
+ *
+ * The two halves above cover the two ROOT tables. The package-level tables were
+ * covered by nothing. Measured on this tree: **24 configs declare a
+ * `resolve.alias` table**, contributing **227 entries** — 200 of them
+ * `@object-ui/*`, spread over 20 of those configs.
+ *
+ * The only other gate that reads these tables is
+ * `side-effects-declaration-consistency.test.ts`, and it does NOT go red on a
+ * dead entry — `resolveAliasModule()` returns undefined and
+ * `resolvableEntryPaths()` `continue`s. That is correct behaviour for its own
+ * question (a dead alias contributes no entry form, so no `sideEffects`
+ * declaration can conflict with it), not an oversight. Target existence and
+ * `sideEffects` declaration consistency are two different contracts; folding
+ * this one into that gate would have it health-check alias tables it only reads
+ * incidentally. So it lands here, in the file whose contract already IS "a
+ * declared alias target must exist" — the same absorption #4804 did.
+ *
+ * ## Why an AST read here, when the two halves above read TEXT
+ *
+ * The halves above each read ONE table in ONE file whose spelling is fixed and
+ * visible. These are 24 files written four different ways, and #5158 measured
+ * what a regex costs across them: a reader requiring `path.resolve(` after a
+ * SINGLE-quoted key saw 70 of 196 entries, with 15 configs contributing zero —
+ * not checked-and-passed, never looked at. The four spellings in the tree:
+ *
+ *   - bare `resolve(__dirname, …)` from `import { resolve } from 'path'`;
+ *   - `path.resolve(__dirname, …)`;
+ *   - the ARRAY table form, `alias: [{ find, replacement }]`;
+ *   - DOUBLE-quoted keys.
+ *
+ * The parser below is BORROWED from `side-effects-declaration-consistency.ts`
+ * (`:397-502`, `resolveAliasModule` at `:524`) rather than written a fifth
+ * time — it already reads the structure instead of the spelling. Borrowed, not
+ * moved: that file is another gate's, and its copy answers its own question.
+ * The spelling-coverage case below is what keeps the borrow honest — a parser
+ * that silently skipped one spelling would produce a green meaning "did not
+ * look", which is the exact failure this file exists to end.
+ *
+ * ## Two things that do NOT transfer from the halves above
+ *
+ * 1. **Existence is not `existsSync` alone here.** A root-table target is
+ *    always a directory or an explicit file. A package table legitimately
+ *    aliases an EXTENSION-LESS file: `packages/runner`'s `"@/lib/utils"` points
+ *    at `packages/components/src/lib/utils`, which is `utils.tsx` on disk and
+ *    resolves fine — Vite probes `resolve.extensions` after substituting an
+ *    alias. `existsSync` on the written target is false for it. So the
+ *    predicate is "exists, or exists with one of Vite's extensions appended".
+ *
+ * 2. **The "extension-less target must be a directory" case does not apply.**
+ *    Up there it is right: every root entry but one is a package `src/` root, so
+ *    a file where a directory is meant breaks every deep import. Down here an
+ *    extension-less target landing on a FILE is the intended, common spelling
+ *    (`@/lib/utils` again). Porting that case would have made a correct config
+ *    red. Named rather than silently dropped.
+ *
+ * ## What is still out of reach, named
+ *
+ * `apps/console` mutates its table at runtime under `OBJECTSTACK_SPEC_DIST`
+ * (`Object.assign(workspaceAliases, specDistInjection.aliases)`). A static read
+ * sees the baseline literal, which is the table every ordinary build uses.
+ * Scoped to `resolve.alias`: a `test.alias` would be a Vitest-only surface, and
+ * no package config declares one today.
+ *
+ * ## Reverse verification (predicted before running; observed in PR body)
+ *
+ * Direction predicted: plain RED, and +1 CASE as well as +1 failure — the alias
+ * tables are the sole input, an added entry can only add one `it.each` row and
+ * that row can only add a finding. The case count is the load-bearing half: a
+ * spelling the parser skipped would add ZERO cases and stay green, which is the
+ * "did not look" green this gate exists to make impossible. Four probes, one
+ * per spelling, each in the config that natively uses it, plus a fifth for the
+ * no-silent-skip case:
+ *
+ *   A. `packages/plugin-editor` — `'@object-ui/ghost-5158': resolve(__dirname,
+ *      '../ghost-5158/src')` (single-quoted key, bare `resolve`) — the probe
+ *      objectui#5168 was filed with, which BOTH pre-existing gates pass.
+ *   B. `packages/fields` — same shape with `path.resolve(`.
+ *   C. `packages/runner` — same shape with a DOUBLE-quoted key.
+ *   D. `packages/components` — the ARRAY form, `{ find, replacement }`.
+ *   E. a value the parser cannot read at all — predicted to differ from A–D:
+ *      NO new case, the coverage case red instead.
+ *
+ * No build artifact sits between any of these edits and the thing under test:
+ * this file reads `node:fs` and parses source text, so nothing is compiled,
+ * bundled or emitted in between. Nothing was rebuilt, and nothing needed to be.
+ */
+
+/** Bundler configs, by strict basename — see the borrowed parser's note on why
+ * a `vite.config.*` GLOB is wrong: it also matches the
+ * `vite.config.ts.timestamp-*.mjs` temp file Vite writes while loading a
+ * config, and reading one would feed this gate a stale snapshot of a table. */
+const BUNDLER_CONFIG_RE = /^vite\.config\.(ts|mts|cts|js|mjs|cjs)$/;
+
+/** How an alias key is written. The spelling-coverage case reads this. */
+type AliasKeyForm = 'single-quoted' | 'double-quoted' | 'identifier' | 'array-string' | 'array-regexp';
+
+interface PackageAliasEntry {
+  /** Repo-relative config declaring it, e.g. `packages/runner/vite.config.ts`. */
+  config: string;
+  /** The alias key: a specifier, or a RegExp matcher's source text. */
+  specifier: string;
+  /** The target exactly as written in the second `resolve()` argument. */
+  target: string;
+  /** Absolute path the target names, resolved from the config's own directory. */
+  abs: string;
+  keyForm: AliasKeyForm;
+  /** `resolve(…)` vs `path.resolve(…)`. */
+  calleeForm: 'bare-resolve' | 'member-resolve';
+}
+
+/**
+ * An alias table entry the parser could not turn into a (key, target) pair.
+ * Never a silent skip: the failure mode this whole file exists to end is a
+ * surface that shrinks without saying so.
+ */
+interface PackageAliasParseGap {
+  config: string;
+  /** The key, or a description of the table when the table itself is unreadable. */
+  what: string;
+  /** The source text that was not understood, first line, clipped. */
+  text: string;
+}
+
+const packageAliasParseGaps: PackageAliasParseGap[] = [];
+
+/**
+ * The `packages:` globs from `pnpm-workspace.yaml`, read rather than hardcoded
+ * so a new workspace root is covered the day it is added. Understands only the
+ * two shapes the file uses (`dir/*` and a bare `dir`); anything else throws
+ * rather than being skipped, because a guard that silently stops looking at
+ * part of the workspace goes on reporting success over a shrinking surface.
+ */
+function workspaceGlobs(): string[] {
+  const yaml = fs.readFileSync(path.join(repoRoot, 'pnpm-workspace.yaml'), 'utf8');
+  const lines = yaml.split('\n');
+  const start = lines.findIndex((l) => /^packages:\s*$/.test(l));
+  if (start === -1) throw new Error('pnpm-workspace.yaml no longer declares a top-level `packages:` key');
+
+  const globs: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    if (!/^\s/.test(line)) break;
+    const match = line.match(/^\s*-\s*['"]?([^'"#\s]+)['"]?\s*(#.*)?$/);
+    if (!match) {
+      throw new Error(
+        `Unparsed entry in pnpm-workspace.yaml \`packages:\`: ${JSON.stringify(line)} — teach this guard the new syntax.`
+      );
+    }
+    globs.push(match[1]);
+  }
+  return globs;
+}
+
+function workspacePackageDirs(): string[] {
+  const dirs: string[] = [];
+  for (const glob of workspaceGlobs()) {
+    if (glob.endsWith('/*')) {
+      const parent = path.join(repoRoot, glob.slice(0, -2));
+      if (!fs.existsSync(parent)) continue;
+      for (const d of fs.readdirSync(parent)) {
+        const full = path.join(parent, d);
+        if (fs.statSync(full).isDirectory()) dirs.push(full);
+      }
+    } else if (!glob.includes('*')) {
+      dirs.push(path.join(repoRoot, glob));
+    } else {
+      throw new Error(`Unsupported workspace glob ${JSON.stringify(glob)} — teach this guard how to expand it.`);
+    }
+  }
+  return dirs;
+}
+
+/** `x as T`, `x satisfies T`, `(x)` — spellings that wrap the node we want. */
+function unwrapExpression(node: ts.Expression): ts.Expression {
+  let current = node;
+  while (
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isParenthesizedExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** A property's name as text, for the spellings a config uses (`k`, `'k'`, `"k"`). */
+function propertyKey(prop: ts.PropertyAssignment): string | undefined {
+  const name = prop.name;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) {
+    return name.text;
+  }
+  return undefined;
+}
+
+/** Quote style of a key as written — two of the four spellings differ only here. */
+function keyFormOf(node: ts.Node, source: ts.SourceFile): AliasKeyForm {
+  const raw = node.getText(source);
+  if (raw.startsWith('"')) return 'double-quoted';
+  if (raw.startsWith("'")) return 'single-quoted';
+  return 'identifier';
+}
+
+/**
+ * A `resolve()`-shaped call, whatever the callee is spelled as: bare `resolve`
+ * from `import { resolve } from 'path'`, `path.resolve`, or a renamed import
+ * like `nodePath.resolve`. The ARGUMENTS are what make it an alias target —
+ * `(__dirname | import.meta.dirname, '<relative>')` — so the callee only has to
+ * be the right function name, not the right import style.
+ */
+function resolveCallTarget(
+  value: ts.Expression
+): { relative: string; calleeForm: 'bare-resolve' | 'member-resolve' } | undefined {
+  const call = unwrapExpression(value);
+  if (!ts.isCallExpression(call)) return undefined;
+
+  const callee = call.expression;
+  const bare = ts.isIdentifier(callee) && callee.text === 'resolve';
+  const member = ts.isPropertyAccessExpression(callee) && callee.name.text === 'resolve';
+  if (!bare && !member) return undefined;
+
+  if (call.arguments.length !== 2) return undefined;
+  const base = call.arguments[0];
+  const isDirname =
+    (ts.isIdentifier(base) && base.text === '__dirname') ||
+    (ts.isPropertyAccessExpression(base) && base.name.text === 'dirname' && ts.isMetaProperty(base.expression));
+  if (!isDirname) return undefined;
+
+  const relative = call.arguments[1];
+  if (!ts.isStringLiteral(relative) && !ts.isNoSubstitutionTemplateLiteral(relative)) return undefined;
+  return { relative: relative.text, calleeForm: bare ? 'bare-resolve' : 'member-resolve' };
+}
+
+/**
+ * The `resolve.alias` tables of one config, as expressions.
+ *
+ * Scoped to `alias` under a `resolve` property: a blind search for any `alias:`
+ * would also pick up a `test.alias` (a Vitest-only surface) and a
+ * `dts({ aliasesExclude })` option. One hop of identifier indirection is
+ * followed — `apps/console` and `examples/console-starter` both declare
+ * `const workspaceAliases = { … }` and then write `alias: workspaceAliases`,
+ * which is 65 of the entries here.
+ */
+function aliasTableExpressions(source: ts.SourceFile, config: string): ts.Expression[] {
+  const declarations = new Map<string, ts.Expression>();
+  const tables: ts.Expression[] = [];
+
+  const collectDeclarations = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      declarations.set(node.name.text, unwrapExpression(node.initializer));
+    }
+    ts.forEachChild(node, collectDeclarations);
+  };
+  collectDeclarations(source);
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAssignment(node) && propertyKey(node) === 'alias') {
+      const owner = node.parent.parent;
+      if (ts.isPropertyAssignment(owner) && propertyKey(owner) === 'resolve') {
+        let table = unwrapExpression(node.initializer);
+        if (ts.isIdentifier(table)) {
+          const declared = declarations.get(table.text);
+          if (declared === undefined) {
+            packageAliasParseGaps.push({
+              config,
+              what: `resolve.alias -> \`${table.text}\``,
+              text: 'alias table is an identifier this file does not declare',
+            });
+            ts.forEachChild(node, visit);
+            return;
+          }
+          table = declared;
+        }
+        tables.push(table);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return tables;
+}
+
+/** Configs that declare at least one `resolve.alias` table, repo-relative. */
+const configsWithAliasTable = new Set<string>();
+
+/**
+ * Every alias entry in every package-level bundler config.
+ *
+ * Read as source rather than imported, for the same reason the two halves above
+ * read text: these configs pull in the whole Vite plugin surface at module
+ * scope, and a guard that only needs a list of strings should not boot that.
+ *
+ * Unlike the borrowed copy, this one keeps entries whose key is a RegExp
+ * matcher. There it is right to drop them — a RegExp names no single specifier,
+ * so it can yield no entry form. Here the QUESTION is about the replacement,
+ * and a RegExp-keyed replacement is a path like any other:
+ * `packages/components` has three, all pointing at real shim files.
+ */
+function readPackageAliasEntries(): PackageAliasEntry[] {
+  const entries: PackageAliasEntry[] = [];
+
+  for (const dir of workspacePackageDirs()) {
+    if (!fs.existsSync(dir)) continue;
+    for (const name of fs.readdirSync(dir).sort()) {
+      if (!BUNDLER_CONFIG_RE.test(name)) continue;
+      const configPath = path.join(dir, name);
+      const config = path.relative(repoRoot, configPath).split(path.sep).join('/');
+      const source = ts.createSourceFile(
+        configPath,
+        fs.readFileSync(configPath, 'utf8'),
+        ts.ScriptTarget.Latest,
+        true
+      );
+      const clip = (node: ts.Node): string => node.getText(source).split('\n')[0].trim().slice(0, 120);
+
+      const tables = aliasTableExpressions(source, config);
+      if (tables.length > 0) configsWithAliasTable.add(config);
+
+      for (const table of tables) {
+        /** `[key, key form, value node, node to quote in a gap report]` */
+        const pairs: [string, AliasKeyForm, ts.Expression, ts.Node][] = [];
+
+        if (ts.isObjectLiteralExpression(table)) {
+          for (const prop of table.properties) {
+            if (!ts.isPropertyAssignment(prop)) {
+              packageAliasParseGaps.push({ config, what: 'a non-assignment table member', text: clip(prop) });
+              continue;
+            }
+            const key = propertyKey(prop);
+            if (key === undefined) {
+              packageAliasParseGaps.push({ config, what: 'a computed alias key', text: clip(prop) });
+              continue;
+            }
+            pairs.push([key, keyFormOf(prop.name, source), prop.initializer, prop]);
+          }
+        } else if (ts.isArrayLiteralExpression(table)) {
+          for (const element of table.elements) {
+            const entry = unwrapExpression(element);
+            if (!ts.isObjectLiteralExpression(entry)) {
+              packageAliasParseGaps.push({ config, what: 'a non-object array table entry', text: clip(entry) });
+              continue;
+            }
+            let find: ts.Expression | undefined;
+            let replacement: ts.Expression | undefined;
+            for (const prop of entry.properties) {
+              if (!ts.isPropertyAssignment(prop)) continue;
+              if (propertyKey(prop) === 'find') find = unwrapExpression(prop.initializer);
+              if (propertyKey(prop) === 'replacement') replacement = prop.initializer;
+            }
+            if (find === undefined || replacement === undefined) {
+              packageAliasParseGaps.push({ config, what: 'an array table entry missing find/replacement', text: clip(entry) });
+              continue;
+            }
+            if (ts.isStringLiteral(find) || ts.isNoSubstitutionTemplateLiteral(find)) {
+              pairs.push([find.text, 'array-string', replacement, entry]);
+            } else if (ts.isRegularExpressionLiteral(find)) {
+              pairs.push([find.getText(source), 'array-regexp', replacement, entry]);
+            } else {
+              packageAliasParseGaps.push({ config, what: 'an array table entry with an unreadable find', text: clip(entry) });
+            }
+          }
+        } else {
+          packageAliasParseGaps.push({
+            config,
+            what: `resolve.alias (${ts.SyntaxKind[table.kind]})`,
+            text: clip(table),
+          });
+          continue;
+        }
+
+        for (const [specifier, keyForm, value, node] of pairs) {
+          const resolved = resolveCallTarget(value);
+          if (resolved === undefined) {
+            packageAliasParseGaps.push({ config, what: specifier, text: clip(node) });
+            continue;
+          }
+          entries.push({
+            config,
+            specifier,
+            target: resolved.relative,
+            abs: path.resolve(dir, resolved.relative),
+            keyForm,
+            calleeForm: resolved.calleeForm,
+          });
+        }
+      }
+    }
+  }
+
+  return entries;
+}
+
+const packageAliasEntries = readPackageAliasEntries();
+
+/**
+ * Vite's own `resolve.extensions`, in its own order. An alias substitution is
+ * followed by ordinary resolution, so an extension-less target that names a
+ * file is live — see note 1 in the header.
+ */
+const VITE_RESOLVE_EXTENSIONS = ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'];
+
+/** True when a bundler can reach the target: a file, a directory, or a file one extension away. */
+function packageAliasTargetExists(abs: string): boolean {
+  if (fs.existsSync(abs)) return true;
+  return VITE_RESOLVE_EXTENSIONS.some((ext) => fs.existsSync(`${abs}${ext}`));
+}
+
+/**
+ * objectui#5380 — one entry whose target does not exist and which this PR
+ * deliberately does NOT delete, for the same reason objectui#4820 was carved
+ * out of the `paths` half rather than fixed in it.
+ *
+ * `packages/runner`'s `"@app"` points at `packages/runner/src/app-data`, which
+ * is absent in every form (no directory, no `app-data.<ext>`). Its comment reads
+ * `DX: App Data Symlink`, and nothing in the repo imports `@app` — the
+ * declaration is the only occurrence. So the fix is either "drop the line" or
+ * "restore the symlink this DX affordance was written for", and which one is a
+ * maintainer call, not a rider on a gate that is only supposed to start looking.
+ * Filed as objectui#5380; this file's job here is to stop it being invisible.
+ *
+ * Note it is NOT an `@object-ui/*` key. The finding that opened objectui#5168
+ * counted 196 `@object-ui/*` entries, and a gate scoped to that prefix would
+ * have shipped green over this. That is the second time this exact config has
+ * outlived a target: its own comment records objectui#3593, where a
+ * `2>/dev/null` kept a dead `data-objectql` entry quiet.
+ *
+ * A shrink-only ratchet, not an exemption. The list may not grow — a NEW dead
+ * target is still red — and the pin below asserts the listed entry is still
+ * declared AND still missing, so resolving it either way turns this file red
+ * until the list is emptied with it.
+ */
+const KNOWN_MISSING_PACKAGE_ALIAS_TARGETS: readonly { config: string; specifier: string }[] = [
+  { config: 'packages/runner/vite.config.ts', specifier: '@app' },
+];
+
+const isCarvedOut = (entry: PackageAliasEntry): boolean =>
+  KNOWN_MISSING_PACKAGE_ALIAS_TARGETS.some(
+    (known) => known.config === entry.config && known.specifier === entry.specifier
+  );
+
+describe('objectui#5168 — package-level vite.config.ts alias tables', () => {
+  it('parses a plausible set of tables (a zero-hit parse would make every case below vacuous)', () => {
+    // The failure mode this guards: a config is reformatted or the walk stops
+    // finding files, `packageAliasEntries` shrinks toward [] and the existence
+    // check passes while checking less and less — the empty-fixture trap, which
+    // across 24 files can also happen to a SUBSET without the total hitting 0.
+    expect(configsWithAliasTable.size).toBeGreaterThanOrEqual(20);
+    expect(packageAliasEntries.length).toBeGreaterThanOrEqual(180);
+    expect(packageAliasEntries.map((e) => e.config)).toContain('apps/console/vite.config.ts');
+    expect(packageAliasEntries.map((e) => e.specifier)).toContain('@object-ui/core');
+  });
+
+  it('every config that declares a resolve.alias table contributes at least one parsed entry', () => {
+    // The subset form of the trap above: one config whose table stops parsing
+    // is invisible in a 227-entry total, and a config contributing zero is
+    // exactly what objectui#5158 measured for 15 configs at once.
+    const contributing = new Set(packageAliasEntries.map((e) => e.config));
+
+    expect(
+      [...configsWithAliasTable].filter((config) => !contributing.has(config)).sort(),
+      'These configs declare a `resolve.alias` table that yielded no entry at all, so the ' +
+        'existence check below never sees them. That is a parser gap, not an empty table.'
+    ).toEqual([]);
+  });
+
+  it('parses EVERY entry in every table, so none can dodge the existence check', () => {
+    // Coverage, not style — the same case both halves above carry. An entry
+    // written in some form the parser does not read would be skipped and
+    // silently escape; here it is recorded and fails instead.
+    expect(
+      packageAliasParseGaps,
+      'These `resolve.alias` entries could not be read as `resolve(__dirname, "<relative path>")`, ' +
+        'so the target-exists check below never sees them. Use that form, or teach this test the new one.'
+    ).toEqual([]);
+  });
+
+  it('covers all four spellings the package configs are written in', () => {
+    // The load-bearing case. objectui#5158 measured what happens when a reader
+    // understands one spelling: 15 configs contributed zero and the gate stayed
+    // green — a green that meant "did not look". Each spelling must be
+    // demonstrably reachable, so dropping support for one goes red HERE rather
+    // than quietly shrinking the surface everything below rests on.
+    const keyForms = new Set(packageAliasEntries.map((e) => e.keyForm));
+    const calleeForms = new Set(packageAliasEntries.map((e) => e.calleeForm));
+
+    expect(calleeForms, 'no entry is written as bare `resolve(__dirname, …)`').toContain('bare-resolve');
+    expect(calleeForms, 'no entry is written as `path.resolve(__dirname, …)`').toContain('member-resolve');
+    expect(keyForms, 'no entry is written with a double-quoted key').toContain('double-quoted');
+    expect(keyForms, 'no entry is written in the array `{ find, replacement }` form').toContain('array-string');
+  });
+
+  it.each(packageAliasEntries.filter((entry) => !isCarvedOut(entry)))(
+    '$config: $specifier resolves to a path that exists ($target)',
+    ({ config, specifier, target, abs }) => {
+      expect(
+        packageAliasTargetExists(abs),
+        `${config}: alias '${specifier}' points at ${target}, which does not exist in the workspace ` +
+          '(not as a file, not as a directory, and not with any extension Vite probes). A ' +
+          'dead alias never fails a test — nothing resolves through it — it just reads as if the ' +
+          'package were wired up (objectui#3944, objectui#5168). Drop the entry, or add the target.'
+      ).toBe(true);
+    }
+  );
+
+  it('the objectui#5168 carve-out still describes exactly the entries it was written for', () => {
+    const declared = KNOWN_MISSING_PACKAGE_ALIAS_TARGETS.filter((known) =>
+      packageAliasEntries.some((e) => e.config === known.config && e.specifier === known.specifier)
+    );
+
+    expect(
+      declared,
+      'KNOWN_MISSING_PACKAGE_ALIAS_TARGETS names an entry that is no longer declared in its config. ' +
+        'If it was resolved by deleting the line, delete it from the carve-out too.'
+    ).toEqual([...KNOWN_MISSING_PACKAGE_ALIAS_TARGETS]);
+
+    const nowResolving = packageAliasEntries.filter(
+      (entry) => isCarvedOut(entry) && packageAliasTargetExists(entry.abs)
+    );
+
+    expect(
+      nowResolving.map((e) => `${e.config}: ${e.specifier}`),
+      'A carved-out target now exists, so the carve-out is obsolete for it — drop it from ' +
+        'KNOWN_MISSING_PACKAGE_ALIAS_TARGETS so the entry is guarded like every other one.'
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #5168

## What was missing

`scripts/__tests__/vitest-config-alias-targets-3944.test.ts` enforces "a declared alias target must exist on disk" — for two **root** tables: `vitest.config.mts`'s `resolve.alias` (#3944) and `tsconfig.json`'s `compilerOptions.paths`, folded into the same file by #4804. The **package-level** `vite.config.ts` tables were covered by nothing.

The only other gate that reads those tables, `side-effects-declaration-consistency.test.ts`, does not go red on a dead entry — `resolveAliasModule()` returns undefined and `resolvableEntryPaths()` `continue`s. That is correct behaviour for its own question (a dead alias contributes no entry form, so no `sideEffects` declaration can conflict with it), not an oversight. Target existence and `sideEffects` consistency are two contracts, so this lands in the file whose contract already **is** the former — the same absorption #4804 performed — rather than making that gate health-check tables it only reads incidentally.

## Counts — measured here, not adopted

Three prior methods gave three numbers (card: 24 files / 196 entries; triage: 24 of 26; a crude `git grep -l`: 26 files). Measured by this PR's own parse on `main@aff10e283`:

| | measured |
|---|---|
| configs walked with a `vite.config.*` basename | 26 |
| configs declaring a `resolve.alias` table | **24** |
| total entries in those tables | **227** |
| of those, `@object-ui/*` | **200**, across 20 configs |
| dead `@object-ui/*` targets | **0** |
| dead targets overall | **1** (see the carve-out) |

24 matches the card and triage. 200 is not 196: the card measured `main@cdac3cc20`, and `apps/console` (34 to 35), `examples/console-starter` (29 to 30) and `packages/runner` (14 to 15) have each gained an entry since, plus one more elsewhere. The 26-vs-24 spread is the looser predicate — two of the 26 configs match on `aliasesExclude` / `Object.assign`, not on a `resolve.alias` table.

## Why an AST read, and why borrowed

Across 24 files the table is spelled four ways: bare `resolve(`, `path.resolve(`, the array `alias: [{ find, replacement }]` form, and double-quoted keys. #5158 measured the cost of a regex here — a reader requiring `path.resolve(` after a single-quoted key saw 70 of 196 entries, **15 configs contributing zero**: not checked-and-passed, never looked at. The parser is **borrowed** from `side-effects-declaration-consistency.test.ts` (`:397-502`, `resolveAliasModule` at `:524`) rather than written a fifth time. Borrowed, not moved or edited — that file is another gate's, and its copy answers its own question.

One deliberate divergence from the borrowed copy: entries whose key is a **RegExp** matcher are kept. There it is right to drop them (a RegExp names no single specifier, so it yields no entry form); here the question is about the *replacement*, and a RegExp-keyed replacement is a path like any other — `packages/components` has three, all pointing at real shim files.

## Two things that do not transfer from the root halves

1. **Existence is not `existsSync` alone.** A package table legitimately aliases an extension-less **file**: `packages/runner`'s `"@/lib/utils"` points at `packages/components/src/lib/utils`, which is `utils.tsx` on disk and resolves fine, because Vite probes `resolve.extensions` after substituting an alias. The predicate is "exists, or exists with one of those extensions appended".
2. **The "extension-less target must be a directory" case is deliberately not ported.** Up there it is right — every root entry but one is a package `src/` root. Down here, landing on a file is the intended spelling, and porting the case would have reddened a correct config. Named in the header rather than silently dropped.

## The gate found one live dead entry

`packages/runner/vite.config.ts:25` — `"@app": path.resolve(__dirname, "./src/app-data")`. `packages/runner/src/app-data` does not exist in any form, and the declaration is the **only** occurrence of `@app` in the repo. Its comment reads `DX: App Data Symlink`, so the fix is either "drop the line" or "restore the symlink it was written for" — a maintainer call, not a rider on a gate that is only supposed to start looking. It is carved out as a **shrink-only ratchet** (`KNOWN_MISSING_PACKAGE_ALIAS_TARGETS`), the same shape #4820 has in the `paths` half: the list may not grow, and a pin asserts the entry is still declared **and** still missing, so resolving it either way turns this file red until the list is emptied with it. Filed unassigned as #5380 — that issue remains open and is not addressed here.

Worth noting for scope: `"@app"` is **not** an `@object-ui/*` key. A gate scoped to the 196-entry `@object-ui/*` framing would have shipped green over it. That is why the range is "every entry in the table", matching both root halves, which also check every key regardless of prefix. This is also the second time this one config has outlived a target — its own comment records #3593, where a `2>/dev/null` kept a dead `data-objectql` entry quiet.

## Reverse verification — the whole difficulty, since the gate lands green

There are zero dead `@object-ui/*` entries today, so passing proves nothing. **Direction predicted before running: plain RED, and +1 *case* as well as +1 failure.** The case count is the load-bearing half — a spelling the parser skipped would add **zero** cases and stay green, which is exactly the "did not look" green this card exists to close.

No build artifact sits between any edit below and the thing under test: the gate reads `node:fs` and parses source text, so nothing is compiled, bundled or emitted in between. **Nothing was rebuilt, and nothing needed to be.** All runs from the repo root (`pnpm exec vitest run scripts/…`), never `pnpm --filter`.

| leg | probe | predicted | observed |
|---|---|---|---|
| baseline | none | 289 pass / 0 fail | **289 pass / 0 fail** |
| **A** | the card's exact probe — `'@object-ui/ghost-5158': resolve(__dirname, '../ghost-5158/src')` in `packages/plugin-editor` (single-quoted key, bare `resolve`) | 290 total, 1 fail | **290 total, 1 fail** |
| **B** | same shape with `path.resolve(` in `packages/fields` | 290 total, 1 fail | **290 total, 1 fail** |
| **C** | same shape with a double-quoted key in `packages/runner` | 290 total, 1 fail | **290 total, 1 fail** |
| **D** | the array form, `{ find, replacement }`, in `packages/components` | 290 total, 1 fail | **290 total, 1 fail** |
| **E** | a value the parser cannot read (`ghostHelper('…')`) | differs from A–D: **no** new case, coverage case red | **289 total, 1 fail** — `parses EVERY entry in every table` |
| **F** | ablation: parser blinded to `path.resolve` | at least 2 fail; total **decreases** | **195 total, 5 fail** — 94 rows vanished |
| **G** | `mkdir packages/runner/src/app-data` | carve-out pin red, it.each count unchanged | **289 total, 1 fail** — `A carved-out target now exists…` |

Legs A–D confirm all four spellings are reachable, one probe each, in the config that natively uses that spelling. Leg E confirms the different shape the no-silent-skip case has. Leg G confirms the ratchet's obsolescence half.

**Prediction vs observation differed on leg F, and the gap is the finding.** I predicted at least two red cases (the spelling-coverage case and the parse-gap case). Observed **five**: the plausibility floor, the per-config coverage case and the carve-out pin catch the shrink too, because 94 of the 227 entries are written with `path.resolve` and their disappearance drops the total under the floor, empties three configs entirely, and takes `@app` out of the parsed set. Five independent cases stand between a silently-narrowed parser and a green run — stronger than designed for, not weaker.

**The contrast that shows the hole was real, on probe A:** with the dead entry in place, the two pre-existing gates were run against the gate file **as it stands on `origin/main`** — `Tests 88 passed (88)`, i.e. #3944 at 58/58 and side-effects at 30/30, reproducing exactly what #5168 measured. The same tree with this PR's gate goes red.

## Verification

Gate union re-derived against the actual diff (one file under `scripts/__tests__/`, one changeset) and run on the final commit **`deb273f91`**:

- `pnpm exec vitest run scripts/` — **57 files, 1522 tests, all passing** (the gate file itself contributes 289).
- `pnpm run type-check:scripts` (`tsc -p tsconfig.scripts.json`) — clean.
- `pnpm exec eslint scripts/__tests__/vitest-config-alias-targets-3944.test.ts` — clean.
- `node scripts/check-control-bytes.mjs` — OK, 4762 tracked text files scanned.
- `node scripts/check-changeset-presence.mjs` — "No source of a released package changed in this range, so no changeset is owed"; `check-changeset-no-major.mjs` — no `major` declared.

`objectui` has no `skip-changeset` label, so the declaration form is an **empty-frontmatter** changeset — added, and correct here because the diff is one file under `scripts/__tests__/` with no package `src/` touched, which is precisely what the presence check reports.

## Not in scope

- **#4925** is the opposite failure direction on these same tables: completeness (are entries *missing*) versus this card's existence (are entries *dead*). Untouched, and the line is not blurred.
- `side-effects-declaration-consistency.test.ts` is read but not modified.
- No package `src/`, no `content/docs/releases/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_