### PR TITLE
fix(ci): scan the repo once in the self-import gate test, not twice

### DIFF
--- a/.changeset/self-import-gate-scan-once-5402.md
+++ b/.changeset/self-import-gate-scan-once-5402.md
@@ -1,0 +1,36 @@
+---
+---
+
+CI tooling only — this publishes nothing, declared explicitly with an empty frontmatter
+rather than left undeclared.
+
+`scripts/check-package-self-import.mjs` now separates the SCAN from the JUDGEMENT:
+`scanRepository(root)` performs the expensive TypeScript parse once, and `judgeScan(scan,
+exemptions)` is a pure filter over its result. `analyze()` keeps its signature and its
+behaviour exactly (differentially verified against the previous implementation over both a
+fixture tree and this repository, across all six exemption-table shapes), and the CLI's
+output is byte-identical.
+
+The reason is `scripts/__tests__/check-package-self-import.test.ts`, which asserts this
+repository is green under the repository's own exemption table AND under no exemptions at
+all. Those were two calls to `analyze(repoRoot)` — the same full parse of ~3,100 files and
+~30 MB of source performed twice — and one of them sat inside a 15-second `it()`. That
+fits uninstrumented (measured 8.8 s) and does not fit under v8 coverage (measured 41.3 s),
+so `ci.yml`'s `Test (coverage)` job failed 100% of the time from 2026-08-16 — 51 completed
+jobs, 0 successes, 50 of them this one file, every one `Test timed out in 15000ms` — and
+Codecov received nothing for four days (objectui#5402).
+
+It is a constant factor, not a race. `@vitest/coverage-v8` arms
+`Profiler.startPreciseCoverage({ callCount, detailed })` in the worker BEFORE test modules
+and their dependencies compile; V8 emits those block counters at compile time and does so
+isolate-wide, so `node_modules/typescript` is instrumented too — `coverage.exclude` filters
+the report, never the instrumentation. Measured here, the identical parse costs 4.1-4.9 s
+uninstrumented and 32-35 s when coverage was armed first, and starting coverage AFTER the
+same code is compiled costs nothing at all.
+
+The test file now scans once at module scope and judges it per assertion: the timeout-prone
+test drops from 41,268 ms to 1 ms under coverage, and the file's total work halves. No
+timeout was raised, nothing is skipped, and coverage is not disabled for anything.
+
+No package `src/` is touched, so no `@object-ui/*` package changes behaviour and there is
+nothing here for a consumer to upgrade to.

--- a/scripts/__tests__/check-package-self-import.test.ts
+++ b/scripts/__tests__/check-package-self-import.test.ts
@@ -10,6 +10,8 @@ import {
   analyze,
   auditExemptions,
   discoverPackages,
+  judgeScan,
+  scanRepository,
 } from '../check-package-self-import.mjs';
 
 /**
@@ -48,6 +50,38 @@ import {
  */
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const GATE = 'scripts/check-package-self-import.mjs';
+
+/**
+ * THE repository scan — computed exactly once, here, and judged many times below.
+ *
+ * Two assertions in this file are about this repository under DIFFERENT exemption
+ * tables (the repository's own, and none at all), and one of them used to call
+ * `analyze(repoRoot)` from inside an `it()`. That is a full TypeScript parse of
+ * every source file of every workspace package — ~3,100 files, ~30 MB, ~15,500
+ * module specifiers — and doing it twice is exactly the same work twice, because
+ * the parse does not depend on the exemption table at all.
+ *
+ * It fits in the 15-second `testTimeout` uninstrumented (measured 8.8 s) and does
+ * NOT fit under coverage (measured 41.3 s), which is why `ci.yml`'s
+ * `Test (coverage)` job failed 100% of the time for four days — 50 of 51 completed
+ * jobs, all on this file, all `Test timed out in 15000ms`. `@vitest/coverage-v8`
+ * arms V8 precise coverage in the worker BEFORE test modules and their
+ * dependencies compile; V8 emits those block counters at compile time and does so
+ * isolate-wide, so `node_modules/typescript` is instrumented too (`coverage.exclude`
+ * filters the report, never the instrumentation). Measured on this repository, the
+ * identical parse costs 4.1-4.9 s uninstrumented and 32-35 s when coverage was
+ * armed first: a 7x constant factor landing squarely on the parser.
+ *
+ * So the rule for anything added to this file: **judge `repoScan`, never rescan.**
+ * `judgeScan()` is pure and costs microseconds; `analyze(repoRoot)` and
+ * `scanRepository(repoRoot)` cost a full parse and must not appear inside an
+ * `it()`. Module scope is deliberate — collection is not bounded by
+ * `testTimeout`, and this scan is the file's one unavoidable cost.
+ *
+ * (objectui#5402. `analyze()` over a throwaway FIXTURE tree stays fine and is used
+ * throughout — those trees hold a handful of tiny files.)
+ */
+const repoScan = scanRepository(repoRoot);
 
 interface Finding {
   reason: string;
@@ -165,7 +199,7 @@ describe('a package name that is not a module edge is not a finding', () => {
       const body = fs.readFileSync(path.join(repoRoot, file), 'utf8');
       expect(body, `${file} no longer carries the literal this pin is about`).toContain(`'${owner}'`);
     }
-    expect((analyze(repoRoot, { exemptions: {} }).findings as Finding[]).map((f) => f.file)).toEqual([]);
+    expect((judgeScan(repoScan, {}).findings as Finding[]).map((f) => f.file)).toEqual([]);
   });
 });
 
@@ -393,7 +427,9 @@ describe('an empty scan is a failure, not a pass', () => {
 // ── 5. this repository ───────────────────────────────────────────────────────
 
 describe('objectui itself', () => {
-  const result = analyze(repoRoot);
+  // The repository's OWN exemption table, over the same single scan the
+  // no-exemptions assertion above judges.
+  const result = judgeScan(repoScan, SELF_IMPORT_EXEMPTIONS);
 
   it('scans a real surface (a guard that found nothing would pass everything)', () => {
     expect(result.counters.packages).toBeGreaterThan(30);
@@ -447,6 +483,93 @@ describe('objectui itself', () => {
     const config = fs.readFileSync(path.join(repoRoot, 'packages/components/tsconfig.test.json'), 'utf8');
     expect(config).toContain('"paths": {}');
     expect(config).not.toContain('"@object-ui/components": ["src/index.ts"]');
+  });
+});
+
+// ── 5b. scan once, judge many ────────────────────────────────────────────────
+
+describe('the judgement is separate from the scan, and pure', () => {
+  // This is the property that lets the whole file share ONE `repoScan`. If
+  // judging ever re-read the repository or consumed the scan, sharing it would
+  // be wrong and the cost this file was cut down from would come straight back
+  // (objectui#5402 — see the note on `repoScan`).
+
+  it('judges the same scan under two tables without re-reading anything', () => {
+    // A scan whose site names a file that does not exist: a judgement that went
+    // back to the filesystem could not produce this finding.
+    const scan = {
+      packages: [{ name: '@fixture/self' }],
+      sites: [
+        {
+          reason: 'package-self-import',
+          pkg: '@fixture/self',
+          file: 'packages/self/src/vanished.ts',
+          line: 1,
+          column: 1,
+          kind: 'import',
+          typeOnly: false,
+          specifier: '@fixture/self',
+        },
+      ],
+      counters: { packages: 1, files: 1, specifiers: 1, relative: 0, alias: 0, builtin: 0, external: 0, selfImport: 1 },
+    };
+    const frozen = structuredClone(scan);
+
+    const strict = judgeScan(scan, {});
+    expect((strict.findings as Finding[]).map((f) => `${f.file} :: ${f.specifier}`)).toEqual([
+      'packages/self/src/vanished.ts :: @fixture/self',
+    ]);
+    expect(strict.counters.exempted).toBe(0);
+
+    const lenient = judgeScan(scan, {
+      'packages/self/src/vanished.ts': { specifiers: ['@fixture/self'], reason: 'pins what a consumer resolves' },
+    });
+    expect(lenient.findings).toEqual([]);
+    expect(lenient.counters.exempted).toBe(1);
+
+    // …and neither call consumed or edited the scan it was handed, so the next
+    // judgement sees the same input.
+    expect(scan).toEqual(frozen);
+    expect((judgeScan(scan, {}).findings as Finding[]).map((f) => f.file)).toEqual([
+      'packages/self/src/vanished.ts',
+    ]);
+  });
+
+  it('hands out findings the caller cannot use to corrupt the scan', () => {
+    const scan = scanRepository(
+      fixtureRepo('purity', [
+        {
+          manifest: { name: '@fixture/self' },
+          files: { 'a.ts': "import { a } from '@fixture/self';\nexport { a };\n" },
+        },
+      ]),
+    );
+    const [finding] = judgeScan(scan, {}).findings as Finding[];
+    finding.file = 'rewritten-by-the-caller.ts';
+    expect((judgeScan(scan, {}).findings as Finding[]).map((f) => f.file)).toEqual(['packages/self/src/a.ts']);
+  });
+
+  it('analyze() is exactly scanRepository() followed by judgeScan()', () => {
+    const root = fixtureRepo('composition', [
+      {
+        manifest: { name: '@fixture/self' },
+        files: {
+          'a.ts': "import { a } from '@fixture/self';\nexport { a };\n",
+          'b.ts': "export { b } from '@fixture/self/deep';\n",
+        },
+      },
+    ]);
+    const exemptions: Exemptions = {
+      'packages/self/src/a.ts': { specifiers: ['@fixture/self'], reason: 'pins what a consumer resolves' },
+    };
+    expect(analyze(root, { exemptions })).toEqual(judgeScan(scanRepository(root), exemptions));
+  });
+
+  it('the scan carries no verdict of its own — counters.exempted belongs to the judgement', () => {
+    // A scan that already knew what was exempt would be a scan tied to one
+    // table, which is the thing this split exists to undo.
+    expect(Object.keys(repoScan.counters as Record<string, number>)).not.toContain('exempted');
+    expect(judgeScan(repoScan, {}).counters.exempted).toBe(0);
   });
 });
 

--- a/scripts/check-package-self-import.mjs
+++ b/scripts/check-package-self-import.mjs
@@ -204,17 +204,18 @@ export function discoverPackages(root) {
 // ── the judgement ────────────────────────────────────────────────────────────
 
 /**
- * One package's self-imports.
+ * One package's self-imports, WITHOUT judging them.
  *
- * `sites` lists EVERY self-import found, exempted or not; the exemption audit
- * reads it so a stale entry is caught in the same single parse.
+ * `sites` lists EVERY self-import found, carrying the full detail a finding
+ * needs. Nothing here consults the exemption table, and that is the point: the
+ * parse is what costs, and it does not depend on which entries are exempt. See
+ * `scanRepository` for why the split exists (objectui#5402).
  *
  * @param {{ name: string, dir: string, srcDir: string, manifest: any }} pkg
- * @param {{ root: string, exemptions?: Record<string, SelfImportExemption> }} options
- * @returns {{ findings: any[], sites: { file: string, specifier: string }[], counters: Record<string, number> }}
+ * @param {{ root: string }} options
+ * @returns {{ sites: any[], counters: Record<string, number> }}
  */
-export function auditPackage(pkg, { root, exemptions = SELF_IMPORT_EXEMPTIONS } = {}) {
-  const findings = [];
+export function auditPackage(pkg, { root } = {}) {
   const sites = [];
   const counters = {
     files: 0,
@@ -224,7 +225,6 @@ export function auditPackage(pkg, { root, exemptions = SELF_IMPORT_EXEMPTIONS } 
     builtin: 0,
     external: 0,
     selfImport: 0,
-    exempted: 0,
   };
 
   for (const file of listSourceFiles(pkg.srcDir)) {
@@ -260,13 +260,7 @@ export function auditPackage(pkg, { root, exemptions = SELF_IMPORT_EXEMPTIONS } 
       }
 
       counters.selfImport += 1;
-      sites.push({ file: relPath, specifier: use.specifier });
-
-      if (exemptions[relPath]?.specifiers?.includes(use.specifier)) {
-        counters.exempted += 1;
-        continue;
-      }
-      findings.push({
+      sites.push({
         reason: 'package-self-import',
         pkg: pkg.name,
         file: relPath,
@@ -279,7 +273,7 @@ export function auditPackage(pkg, { root, exemptions = SELF_IMPORT_EXEMPTIONS } 
     }
   }
 
-  return { findings, sites, counters };
+  return { sites, counters };
 }
 
 /**
@@ -328,17 +322,43 @@ export function auditExemptions(exemptions, sites) {
 }
 
 /**
- * The whole judgement for one repository root.
+ * Every self-import in a repository, WITHOUT judging any of them.
  *
- * `exemptions` is injectable because the default table describes THIS
- * repository: a test about the mechanism supplies its own rather than editing
- * the repository's.
+ * This is the expensive half and the whole reason the API is split in two: it
+ * full-parses every source file of every workspace package with TypeScript
+ * (~3,100 files / ~30 MB in this repository today), and NONE of that work
+ * depends on the exemption table. Judging is a filter over the result and costs
+ * microseconds.
+ *
+ * ## Why the split exists (objectui#5402)
+ *
+ * `scripts/__tests__/check-package-self-import.test.ts` asserts two different
+ * things about this repository — that it is green under the repository's own
+ * exemption table, and that it is green under NO exemptions at all. Before the
+ * split those were two calls to `analyze(repoRoot)`, i.e. the same 30 MB parse
+ * performed twice, and the second one sat inside a 15-second `it()`.
+ *
+ * That is affordable uninstrumented and not affordable under coverage. V8's
+ * precise coverage (`Profiler.startPreciseCoverage({ callCount, detailed })`,
+ * which `@vitest/coverage-v8` arms in the worker BEFORE test modules and their
+ * dependencies are compiled) emits block counters at compile time and is
+ * isolate-wide — `coverage.exclude` filters the REPORT, never the
+ * instrumentation, so `node_modules/typescript` is instrumented too. Measured
+ * on this repository: the identical parse takes 4.1-4.9 s uninstrumented and
+ * 32-35 s when coverage was armed first — a 7x constant factor landing squarely
+ * on the parser. Two scans, one of them inside a bounded window, is what made
+ * `ci.yml`'s `Test (coverage)` job fail 100% of the time for four days.
+ *
+ * So: scan once, judge as often as you like.
+ *
+ * Deliberately NOT memoised. A cache keyed by root would return stale verdicts
+ * for a tree that changed under it, and the callers that need one scan can hold
+ * one scan.
  *
  * @param {string} root
- * @param {{ exemptions?: Record<string, SelfImportExemption> }} [options]
- * @returns {{ findings: any[], counters: Record<string, number>, packages: any[] }}
+ * @returns {{ packages: any[], sites: any[], counters: Record<string, number> }}
  */
-export function analyze(root, { exemptions = SELF_IMPORT_EXEMPTIONS } = {}) {
+export function scanRepository(root) {
   const packages = discoverPackages(root);
   const counters = {
     packages: packages.length,
@@ -349,20 +369,60 @@ export function analyze(root, { exemptions = SELF_IMPORT_EXEMPTIONS } = {}) {
     builtin: 0,
     external: 0,
     selfImport: 0,
-    exempted: 0,
   };
 
-  const findings = [];
   const sites = [];
   for (const pkg of packages) {
-    const result = auditPackage(pkg, { root, exemptions });
-    findings.push(...result.findings);
+    const result = auditPackage(pkg, { root });
     sites.push(...result.sites);
     for (const key of Object.keys(result.counters)) counters[key] += result.counters[key];
   }
-  findings.push(...auditExemptions(exemptions, sites));
 
-  return { findings, counters, packages };
+  return { packages, sites, counters };
+}
+
+/**
+ * The verdict a given exemption table reaches about an already-completed scan.
+ *
+ * Pure: it reads `scan` and never re-reads the repository, never mutates what it
+ * was handed. Everything expensive already happened in `scanRepository`.
+ *
+ * @param {{ packages: any[], sites: any[], counters: Record<string, number> }} scan
+ * @param {Record<string, SelfImportExemption>} [exemptions]
+ * @returns {{ findings: any[], counters: Record<string, number>, packages: any[] }}
+ */
+export function judgeScan(scan, exemptions = SELF_IMPORT_EXEMPTIONS) {
+  const findings = [];
+  let exempted = 0;
+  for (const site of scan.sites) {
+    if (exemptions[site.file]?.specifiers?.includes(site.specifier)) {
+      exempted += 1;
+      continue;
+    }
+    findings.push({ ...site });
+  }
+  findings.push(...auditExemptions(exemptions, scan.sites));
+
+  return { findings, counters: { ...scan.counters, exempted }, packages: scan.packages };
+}
+
+/**
+ * The whole judgement for one repository root: scan, then judge.
+ *
+ * `exemptions` is injectable because the default table describes THIS
+ * repository: a test about the mechanism supplies its own rather than editing
+ * the repository's.
+ *
+ * Every call re-scans. A caller that judges the SAME root under more than one
+ * exemption table should call `scanRepository` once and `judgeScan` per table
+ * instead — see the note on `scanRepository`.
+ *
+ * @param {string} root
+ * @param {{ exemptions?: Record<string, SelfImportExemption> }} [options]
+ * @returns {{ findings: any[], counters: Record<string, number>, packages: any[] }}
+ */
+export function analyze(root, { exemptions = SELF_IMPORT_EXEMPTIONS } = {}) {
+  return judgeScan(scanRepository(root), exemptions);
 }
 
 // ── CLI ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #5402

`ci.yml`'s `Test (coverage)` job has failed 100% of the time since 2026-08-16T12:48Z — 51 completed jobs, 0 successes, 50 of them on `scripts/__tests__/check-package-self-import.test.ts` with `Test timed out in 15000ms`. Codecov has received nothing for four days.

## It is not a race — it is one full repo parse done twice, times a 7x coverage constant

The test asserts two things about this repository: that it is green under the repository's own exemption table, **and** that it is green under no exemptions at all. Those were two calls to `analyze(repoRoot)` — the same full TypeScript parse of every source file of every workspace package, performed twice — and one of them sat inside a 15-second `it()`.

Measured here: 44 packages, 3,094 files, 30.3 MB of source, 15,550 module specifiers. `moduleSpecifiers()` full-parses each with `ts.createSourceFile(..., setParentNodes, ScriptKind.TSX)`. Per-test timings for the file, from `--reporter=verbose`:

| | without coverage | under coverage |
|---|---|---|
| `the two live specimens in this repository stay unflagged` | **8,782 ms** (59% of the 15 s budget) | **41,268 ms** — FAIL |
| every other test in the file | under 10 ms | under 10 ms |
| file duration | 20.05 s | 84.81 s |

So the whole cost is that one test, and it was already at 59% of budget green.

**The constant factor is compile-order, not the counters.** `@vitest/coverage-v8` arms `Profiler.startPreciseCoverage({ callCount: true, detailed: true })` in the worker *before* test modules and their dependencies compile. V8 emits block counters at compile time and does so isolate-wide, so `node_modules/typescript` is instrumented too — `coverage.exclude` filters the **report**, never the instrumentation. Two controlled runs of the identical parse over the identical corpus:

```
coverage armed AFTER typescript is compiled and warmed
  before precise coverage : 4254 ms      under precise coverage : 4184 ms   (no cost)

coverage armed BEFORE typescript is compiled  (the order vitest uses)
  COV=0  pass1 4919 ms  pass2 4105 ms
  COV=1  pass1 34941 ms pass2 32230 ms   (7.1x - 7.9x)
```

That is the whole mechanism, and it answers the question the issue asked: the test does real work proportional to repo size, and v8 coverage multiplies it by ~7 on the TypeScript parser specifically. Not a race, nothing nondeterministic — every one of the 51 jobs failed.

## The fix: scan once, judge many

The parse does not depend on the exemption table at all — only the verdict does. So `scripts/check-package-self-import.mjs` now separates them:

- `scanRepository(root)` — the expensive, exemption-independent parse, returning `sites` (every self-import found, with full finding detail) plus the counters.
- `judgeScan(scan, exemptions)` — pure: a filter over `sites` plus the stale-exemption audit. Microseconds.
- `analyze(root, { exemptions })` is now exactly `judgeScan(scanRepository(root), exemptions)` — same signature, same behaviour.

The test scans once at module scope and judges that one scan per assertion.

| under `--coverage` | before | after |
|---|---|---|
| `the two live specimens...` | 41,268 ms → FAIL | **1 ms** → pass |
| total test time for the file | 41.31 s | **0.077 s** |
| file duration | 84.81 s | **45.16 s** |
| result | 1 failed / 23 passed | **28 passed** |

The file's total work halves, because the second identical 30 MB parse is gone. No timeout was raised, nothing is skipped, quarantined or deleted, and coverage is not disabled for anything.

### `analyze()` is unchanged — verified, not asserted

- **CLI output byte-identical** to `origin/main`'s version, both run with `--root` over this repository (`diff` clean, same exit code).
- **Differential over 14 cases**: old vs new `analyze()` compared on `findings`, `counters` and `packages`, over a fixture tree *and* this repository, across all six exemption-table shapes (empty, covering, stale-file, stale-specifier, no-reason, no-specifiers) plus the default-table path. All identical.

Four new tests pin the property that makes sharing one scan safe: judging re-reads nothing (it judges a scan whose site names a file that does not exist), does not mutate or consume the scan, hands out findings the caller cannot use to corrupt it, and `analyze()` still equals the composition.

## Reverse verification

Predicted before running, then run. The test imports `../check-package-self-import.mjs` by relative path — a plain ESM source file transformed in-memory by vitest, never through a package `exports` map or a `dist/` — so **no build artifact sits between the edit and the thing under test on either leg**, and no rebuild is possible or needed.

Ablating only the test-file half (`git checkout origin/main -- scripts/__tests__/check-package-self-import.test.ts`, keeping the gate split):

| | predicted | observed |
|---|---|---|
| failed tests | 1 | 1 |
| which one | `the two live specimens...`, `Test timed out in 15000ms` at `:140:3` | verbatim |
| totals | 24 tests, 23 passed | 24 tests, 23 passed |
| file duration | ~85 s | 86.05 s |
| `coverage/` directory | absent | absent |

Restore leg: 28 passed, 44.87 s, `coverage/` present. Both predictions exact.

## Second symptom: no `coverage/` directory — a consequence, not a second defect

The issue reports the live unsharded recipe leaving no `coverage/` directory at all on a failing suite (2 of 2), while the blob-report path produced a complete report every time. Mechanism found, and it is not mysterious:

```
vitest/dist/chunks/coverage.DM_a_rWm.js:791
  if (!this.options.reportOnFailure) await this.cleanAfterRun();

vitest/dist/chunks/defaults.9aQKnqFk.js:22
  reportOnFailure: false,
```

`coverage.reportOnFailure` defaults to `false` and `vitest.config.mts` does not set it, so the v8 provider **deletes the reports directory** whenever the run is red. The blob-report path escapes it because merge-reports is a separate, green vitest invocation.

Demonstrated on the two legs above — same command, same tree, same configured reporters:

- red run (ablated) → **no `coverage/` directory**
- green run (fixed) → `coverage/` with `coverage-final.json`

So this needed no separate fix: it is downstream of the red suite, and it clears when the suite goes green. Whether red runs should still emit partial coverage (`reportOnFailure: true`) is a policy call for the coverage lane rather than a defect — noted for #5403, and `.github/workflows/ci.yml` is untouched here as that file is #5403's.

## Verification

Run from the repo root. Gate union re-derived from the actual changed paths and run at the final commit **`f1f0da7c3`**:

```
scripts/check-package-self-import.mjs
scripts/__tests__/check-package-self-import.test.ts
.changeset/self-import-gate-scan-once-5402.md

check:self-import PASS   check:phantom-deps PASS   check:control-bytes PASS
check:esm-specifiers PASS  type-check:coverage PASS  lint:coverage PASS
type-check:scripts PASS  changeset no-major/fixed/presence PASS  eslint PASS

pnpm exec vitest run scripts/__tests__/       58 files, 1553 tests, all passed
pnpm exec vitest run scripts/__tests__/check-package-self-import.test.ts --coverage   28 passed, largest test 15 ms
```

`origin/main` was merged in (fast-forward, `fd227eae1`) — my branch point predated the #5394 fix, which is why `quick-reference-current-release-4143.test.ts` was red before the merge and is green after. That failure was never mine.

Changeset: empty frontmatter — this is CI tooling and publishes nothing, declared explicitly rather than left undeclared, matching the house form.

## Not addressed here

While measuring I found that `ts.createSourceFile`'s `setParentNodes` argument is passed `true` in `scripts/check-phantom-dependencies.mjs`'s shared `moduleSpecifiers()`, and nothing needs it — `node.getStart(source)` takes the source file explicitly and `ts.forEachChild` does not walk parents. Measured 3,600 ms vs 4,800 ms over the same 3,094 files with byte-identical output on every one. That is a further ~25% off the dominant cost of two gates, but it changes a parser shared with `check:phantom-deps` and so widens the verification surface beyond this card. Filed as #5410 (unassigned, `finding`); out of scope here, and this card is closed without it.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_