### PR TITLE
fix(plugin-grid): harvest row-action predicate fields from the object's userActions only

### DIFF
--- a/.changeset/grid-user-actions-collision-5240.md
+++ b/.changeset/grid-user-actions-collision-5240.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+`object-grid` harvests row-action predicate fields from the OBJECT's `userActions` block only — a view's toolbar policy can no longer shadow it.
+
+`userActions` names two different blocks. On a **view** it is toolbar policy —
+the spec's `UserActionsConfigSchema` (`sort`, `search`, `filter`, `refresh`,
+`rowHeight`, `addRecordForm`, `editInline`, `buttons`), which rejects `edit` by
+name. On an **object** it is the CRUD-predicate block (`edit` / `delete` /
+`create` carrying `visibleWhen` / `disabledWhen`, objectui#2614) — and that is
+the only shape `listViewPredicates` can read, since its loop skips every
+non-object value.
+
+`ObjectGrid` read the key view-first when building the `$select` projection
+(`(schema as any).userActions ?? resolvedSchema.userActions`). A view carrying a
+perfectly legal toolbar block therefore shadowed the object's CRUD predicates,
+the harvest found none, and the predicate's operand left the projection. CEL then
+faults on the absent key, fails closed, and the row Edit/Delete button disappears
+for everyone with nothing pointing at the projection — objectui#3501's failure,
+reached with a success receipt at every step.
+
+The view-level block is not hypothetical: `SpecBridge.transformListView` copies
+it onto the `object-grid` node the renderer receives, and `app-shell`'s
+`ObjectView` builds one unconditionally.
+
+The harvest now reads the resolved object block only. Both `userActions` read
+sites carry a comment naming the collision, and
+`__tests__/gridNonAuthorKeys.test.tsx` pins each clause of it: the two shapes,
+the producer that writes the view one, the harvest's blindness to it, and the
+projection that must keep the object's operand with a toolbar block present.
+
+Toolbar policy itself is untouched — it was never read through this path.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -904,6 +904,18 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
     hasOnEdit: !!onEdit,
     hasOnDelete: !!onDelete,
     managedBy: (objectSchema as any)?.managedBy,
+    // KEY COLLISION — the OBJECT's block, and the only one this can consume.
+    // `userActions` names two different shapes: on a VIEW it is toolbar policy
+    // (`UserActionsConfigSchema` — `sort`/`search`/`filter`/`refresh`/
+    // `rowHeight`/`addRecordForm`/`editInline`/`buttons`, which rejects `edit`
+    // BY NAME), on an OBJECT it is the CRUD-predicate block `edit`/`delete`/
+    // `create` carrying `visibleWhen`/`disabledWhen`. Only the object block
+    // means anything to `resolveRowCrudAffordances` — or to
+    // `listViewPredicates` at the `$select` read below, which carries the full
+    // measurement. So this read stays `objectSchema`-only and must never gain a
+    // `(schema as any).userActions ??` left operand: that is the shadowing this
+    // grid was fixed for (maintainer ruling of 2026-08-20 on objectui#5240,
+    // Q3=B). Pinned by `__tests__/gridNonAuthorKeys.test.tsx`.
     userActions: (objectSchema as any)?.userActions,
     effectiveApiOperations: effectiveApiOps,
     permissionUpdate,
@@ -1115,7 +1127,40 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
                   rowActionDefs: (schema as any).rowActionDefs,
                   bulkActionDefs: (schema as any).bulkActionDefs,
                   objectActions: (resolvedSchema as any)?.actions,
-                  userActions: (schema as any).userActions ?? (resolvedSchema as any)?.userActions,
+                  // KEY COLLISION — `userActions` names TWO different blocks,
+                  // and only the OBJECT's is interpretable here. This read is
+                  // therefore `resolvedSchema`-only; it must never regain a
+                  // `(schema as any).userActions ??` left operand. Maintainer
+                  // ruling of 2026-08-20 on objectui#5240 (Q1=A), on these
+                  // measurements against `@objectstack/spec@17.0.0`:
+                  //
+                  //   - VIEW-level `userActions` is TOOLBAR POLICY —
+                  //     `UserActionsConfigSchema` (`sort`, `search`, `filter`,
+                  //     `refresh`, `rowHeight`, `addRecordForm`, `editInline`,
+                  //     `buttons`), which REJECTS `edit` BY NAME
+                  //     (`unrecognized_keys`). `ListViewSchema` accepts it, so
+                  //     it is spec-legal and really authored: `react/src/
+                  //     spec-bridge/bridges/list-view.ts` copies it onto the
+                  //     `object-grid` node this component receives as `schema`,
+                  //     and `app-shell/src/views/ObjectView.tsx` builds one
+                  //     unconditionally. It is NOT an unwritten key.
+                  //   - OBJECT-level `userActions` is the CRUD-PREDICATE block
+                  //     (`edit` / `delete` / `create` carrying `visibleWhen` /
+                  //     `disabledWhen`, objectui#2614) — what
+                  //     `resolveRowCrudAffordances` consumes above, and the only
+                  //     shape `listViewPredicates` can read: its loop skips
+                  //     every non-object value, so a toolbar block yields ZERO
+                  //     predicates.
+                  //
+                  // Read view-first, a legitimately authored toolbar block
+                  // therefore SHADOWED the object's CRUD predicates and dropped
+                  // their operands from `$select`; CEL then faults `No such
+                  // key`, fails CLOSED, and the row Edit/Delete button vanishes
+                  // for everyone with nothing pointing at the projection
+                  // (objectui#3501 — the whole reason this harvest exists).
+                  // Both halves of the collision, and this read itself, are
+                  // pinned by `__tests__/gridNonAuthorKeys.test.tsx`.
+                  userActions: (resolvedSchema as any)?.userActions,
                 })).filter((f) => isProjectableField(f, declared as Record<string, unknown>))
               : [];
             const withPredicates = (list: any[]): any[] => {

--- a/packages/plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx
+++ b/packages/plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx
@@ -78,17 +78,53 @@
  * The control in 1-3 is `bulkActionDefs`: declared, spec-accepted, clean
  * through the parser. Without it, all three assertions would pass just as
  * happily against a registry that published nothing at all.
+ *
+ * ## The fifth key the census found — and why it is NOT a fifth non-author key
+ *
+ * objectui#5240 filed `userActions` as a sixth cast-read grid key, on the
+ * reading that it was one more "deliberately unlisted" surface with no
+ * producer. Measurement refuted that, twice over, so the maintainer ruled on
+ * 2026-08-20 (Q1=A · Q2=B · Q3=B) that the fix lands with the MEASURED reason
+ * rather than the assumed one. What is actually wrong is a **name collision**:
+ *
+ *   - VIEW-level `userActions` is TOOLBAR POLICY — the spec's
+ *     `UserActionsConfigSchema` (`sort`, `search`, `filter`, `refresh`,
+ *     `rowHeight`, `addRecordForm`, `editInline`, `buttons`), which REJECTS
+ *     `edit` BY NAME. `ListViewSchema` accepts it, so it is spec-legal, and it
+ *     is really written: `SpecBridge.transformListView` copies it onto the
+ *     `object-grid` node `ObjectGrid` renders, and `app-shell`'s `ObjectView`
+ *     builds one unconditionally. "Nobody authors it" was false.
+ *   - OBJECT-level `userActions` is the CRUD-PREDICATE block (`edit` /
+ *     `delete` / `create` carrying `visibleWhen` / `disabledWhen`,
+ *     objectui#2614) — the only shape `listViewPredicates` can read, since its
+ *     loop skips every non-object value.
+ *
+ * `ObjectGrid` used to read the key VIEW-FIRST when harvesting predicate
+ * fields for `$select`, so an authored toolbar block SHADOWED the object's CRUD
+ * predicates and silently dropped their operands from the projection —
+ * objectui#3501's fail-closed CEL fault (`No such key`), reached with a success
+ * receipt. That read is now object-only, and both read sites carry the
+ * collision comment.
+ *
+ * The pin below is therefore shaped differently from the four above: it does
+ * NOT assert "no producer writes this" (two do) and it does not claim the key
+ * is non-author surface. It asserts the four things the comments DO claim —
+ * the two shapes, the producer, and the harvest's blindness to the toolbar
+ * one — plus the renderer behaviour that shadowing broke. The RENDER channel of
+ * the surviving object-block read is already pinned four times over by
+ * `rowCrudEffectiveOps.test.tsx`'s `userActions` opt-out control group, so it
+ * is cited here rather than duplicated.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
-import { ComponentRegistry } from '@object-ui/core';
-import { ComponentPropsMap } from '@objectstack/spec/ui';
+import { ComponentRegistry, collectPredicateFieldRefs, listViewPredicates } from '@object-ui/core';
+import { ComponentPropsMap, ListViewSchema, UserActionsConfigSchema } from '@objectstack/spec/ui';
 import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
 import { registerAllFields } from '@object-ui/fields';
-import { ActionProvider } from '@object-ui/react';
+import { ActionProvider, SpecBridge } from '@object-ui/react';
 
 import { ObjectGrid } from '../ObjectGrid';
 // Module scope, not a hook: this import IS the registration (AGENTS.md's
@@ -398,5 +434,162 @@ describe('the renderer still reads all four (objectui#5091 kept every read site)
     // The harvest ADDS; it never replaces what the columns asked for.
     expect(select).toContain('name');
     expect(select).toContain('id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The FIFTH key the census found — `userActions` — which is a NAME COLLISION,
+// not a fifth non-author key (objectui#5240, maintainer ruling 2026-08-20:
+// Q1=A · Q3=B). See the docblock's last section for the full story; each
+// assertion below pins one clause of the collision comment now carried at both
+// read sites in `ObjectGrid.tsx`.
+// ---------------------------------------------------------------------------
+
+/** What a VIEW author legitimately writes: toolbar policy. */
+const VIEW_TOOLBAR_BLOCK = { sort: true, search: true, filter: false };
+/** What an OBJECT declares under the same name: a CRUD predicate block. */
+const OBJECT_CRUD_BLOCK = { edit: { visibleWhen: 'record.status == "open"' } };
+/** The toolbar vocabulary the comment lists by name. */
+const TOOLBAR_KEYS = [
+  'sort', 'search', 'filter', 'refresh', 'rowHeight', 'addRecordForm', 'editInline', 'buttons',
+];
+
+/** Unrecognized KEYS from a failed parse — a key verdict, never a document one. */
+const unrecognizedKeys = (result: { success: boolean; error?: unknown }): string[] =>
+  ((result as { error: { issues: Array<{ code: string; keys?: string[] }> } }).error?.issues ?? [])
+    .filter((issue) => issue.code === 'unrecognized_keys')
+    .flatMap((issue) => issue.keys ?? []);
+
+describe('`userActions` is two blocks sharing one name — the view one is toolbar policy (objectui#5240)', () => {
+  it.each(['edit', 'delete', 'create'])('the view-level schema refuses the CRUD key `%s` by name', (key) => {
+    const result = UserActionsConfigSchema.safeParse({ [key]: { visibleWhen: 'record.status == "open"' } });
+    expect(
+      result.success,
+      `\`UserActionsConfigSchema\` now ACCEPTS \`${key}\` — the two \`userActions\` blocks no longer`
+        + ' collide, so re-read the collision comments in `ObjectGrid.tsx`: their premise was that a'
+        + ' CRUD predicate block can never legally arrive on a VIEW.',
+    ).toBe(false);
+    expect(unrecognizedKeys(result)).toContain(key);
+  });
+
+  it('…and accepts the toolbar vocabulary, so those refusals are about the KEY', () => {
+    // The control. Without it, "the view schema refuses `edit`" would pass just
+    // as happily against a schema that refuses everything.
+    expect(UserActionsConfigSchema.safeParse(VIEW_TOOLBAR_BLOCK).success).toBe(true);
+    expect(
+      Object.keys((UserActionsConfigSchema as unknown as { shape: Record<string, unknown> }).shape),
+      'the toolbar vocabulary changed — the comments at both read sites spell it out by name.',
+    ).toEqual(expect.arrayContaining(TOOLBAR_KEYS));
+  });
+});
+
+describe('the view-level key is AUTHORED, not an unwritten surface (objectui#5240)', () => {
+  it('a view document carrying the toolbar block is spec-legal', () => {
+    // This is the measurement that killed the original "deliberately unlisted,
+    // zero producers" reading. If it ever goes false, the collision comments
+    // are describing a repo that no longer exists.
+    const result = ListViewSchema.safeParse({
+      name: 'my_view',
+      label: 'My View',
+      columns: [{ field: 'name' }],
+      userActions: VIEW_TOOLBAR_BLOCK,
+    });
+    expect(result.success, JSON.stringify((result as { error?: unknown }).error ?? {})).toBe(true);
+  });
+
+  it('…while the CRUD block is refused on a view, at the userActions path', () => {
+    const result = ListViewSchema.safeParse({
+      name: 'my_view',
+      label: 'My View',
+      columns: [{ field: 'name' }],
+      userActions: OBJECT_CRUD_BLOCK,
+    });
+    expect(result.success).toBe(false);
+    expect(unrecognizedKeys(result)).toContain('edit');
+  });
+
+  it('the PRODUCER writes it onto the very `object-grid` node ObjectGrid renders', () => {
+    // The producer IS the evidence, same as the `NON_AUTHOR_KEYS` table above —
+    // except here it proves the opposite: the key is written, so "nobody
+    // authors it" was never available as a reason.
+    const node = new SpecBridge().transformListView({
+      name: 'accounts',
+      columns: [{ field: 'name', label: 'Name' }],
+      userActions: VIEW_TOOLBAR_BLOCK,
+    } as never) as unknown as Record<string, unknown>;
+    expect(
+      node.type,
+      'the list bridge no longer emits `object-grid` — the collision comments name this producer.',
+    ).toBe('object-grid');
+    expect(
+      node.userActions,
+      'the list bridge stopped copying `userActions` onto the grid node. If that is the'
+        + ' producer-side fix (the spec-coordination card the 2026-08-20 ruling routed through'
+        + ' triage), the collision comments in `ObjectGrid.tsx` are due a re-read — do not just'
+        + ' delete this assertion.',
+    ).toEqual(VIEW_TOOLBAR_BLOCK);
+  });
+});
+
+describe('only the OBJECT block is interpretable by the predicate harvest (objectui#5240)', () => {
+  it('the toolbar block yields ZERO predicate fields', () => {
+    // Every value is a boolean, so `listViewPredicates` skips all of them. This
+    // is why shadowing was silent: not an error, just nothing harvested.
+    expect(collectPredicateFieldRefs(listViewPredicates({ userActions: VIEW_TOOLBAR_BLOCK }))).toEqual([]);
+  });
+
+  it('the object CRUD block yields its operand', () => {
+    expect(collectPredicateFieldRefs(listViewPredicates({ userActions: OBJECT_CRUD_BLOCK }))).toContain('status');
+  });
+});
+
+/**
+ * `$select` for a grid whose OBJECT declares the CRUD predicate block, with
+ * whatever the view carries layered on top.
+ */
+const projectionSelect = async (viewExtra: Record<string, unknown>): Promise<string[]> => {
+  const adapter = makeAdapter({
+    // `status` is deliberately NOT a column: a predicate-only field is the
+    // ordinary case the harvest exists for.
+    fields: { id: { type: 'text' }, name: { type: 'text' }, status: { type: 'select' } },
+    userActions: OBJECT_CRUD_BLOCK,
+  });
+  render(
+    <ActionProvider>
+      <ObjectGrid
+        schema={{
+          type: 'object-grid',
+          objectName: 'test_object',
+          columns: [{ field: 'name', label: 'Name' }],
+          ...viewExtra,
+        } as any}
+        dataSource={adapter as any}
+      />
+    </ActionProvider>,
+  );
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  return (adapter.find.mock.calls.at(-1)?.[1]?.$select ?? []) as string[];
+};
+
+describe('a view-level toolbar block must not shadow the object CRUD predicates (objectui#5240)', () => {
+  it('the object block reaches $select — the surviving read is still there', async () => {
+    // Pins the READ, not the fix: green on both legs of the shadowing change,
+    // red the moment the `userActions` line is dropped from the harvest.
+    expect(
+      await projectionSelect({}),
+      "the object's `userActions.edit.visibleWhen` operand is missing from `$select` — CEL faults"
+        + ' on the absent key and the row Edit button fails closed for everyone (objectui#3501).',
+    ).toContain('status');
+  });
+
+  it('…and a spec-legal toolbar block on the view does not knock it out', async () => {
+    // The regression itself. Read view-first, the `??` took this block, the
+    // harvest found no predicates in it, and `status` left the projection —
+    // with a success receipt at every step.
+    expect(
+      await projectionSelect({ userActions: VIEW_TOOLBAR_BLOCK }),
+      'a view-level toolbar block is shadowing the object CRUD predicates again: the projection'
+        + ' lost `status`. The read at the `$select` harvest must stay object-only.',
+    ).toContain('status');
   });
 });


### PR DESCRIPTION
Fixes #5240

Implements the maintainer ruling of 2026-08-20 (「4 张 同意」): **Q1=A · Q2=B · Q3=B**.

## What was wrong

`userActions` names two different blocks, and the grid's `$select` harvest read them as one.

- **View-level** `userActions` is **toolbar policy** — the spec's `UserActionsConfigSchema`: `sort`, `search`, `filter`, `refresh`, `rowHeight`, `addRecordForm`, `editInline`, `buttons`. It rejects `edit` **by name**.
- **Object-level** `userActions` is the **CRUD-predicate block** — `edit` / `delete` / `create` carrying `visibleWhen` / `disabledWhen` (objectui#2614). It is the only shape `listViewPredicates` can read: its loop skips every non-object value.

The harvest that decides which fields the server is asked for read the key view-first:

```ts
userActions: (schema as any).userActions ?? (resolvedSchema as any)?.userActions,
```

So a perfectly legal toolbar block **shadowed** the object's CRUD predicates. Every value in it is a boolean, the harvest collected zero predicates, the predicate's operand left the projection, CEL faulted on the absent key, failed **closed**, and the row Edit/Delete button disappeared for everyone with nothing pointing at the projection — objectui#3501's failure shape, reached with a success receipt at every step.

The view-level block is not hypothetical. Re-measured on this branch, `@objectstack/spec@17.0.0`:

| probe | result |
| --- | --- |
| `UserActionsConfigSchema.shape` keys | `sort, search, filter, refresh, rowHeight, addRecordForm, editInline, buttons` |
| `UserActionsConfigSchema.safeParse({edit:{visibleWhen}})` | `success: false`, `unrecognized_keys: ["edit"]` |
| `ListViewSchema.safeParse(… userActions:{search:true,sort:true})` | `success: true` |
| `ListViewSchema.safeParse(… userActions:{edit:{visibleWhen}})` | `success: false`, `unrecognized_keys: ["edit"]` at path `userActions` |
| `ComponentPropsMap['object-grid'].safeParse({objectName, userActions})` | `success: false`, `unrecognized_keys: ["userActions"]` |

And two live producers write the toolbar block onto the view: `packages/react/src/spec-bridge/bridges/list-view.ts` (inside `bridgeListView`, which emits a `type: 'object-grid'` node — i.e. straight into the read this PR fixes; pinned by `P1SpecBridge.test.ts`) and `packages/app-shell/src/views/ObjectView.tsx` (built unconditionally as an object literal).

## What changed

1. `packages/plugin-grid/src/ObjectGrid.tsx` — the `$select` harvest reads `resolvedSchema.userActions` **only**. The view-schema-first operand is gone.
2. Both `userActions` read sites carry a comment naming the collision — the surviving object-block read at `resolveRowCrudAffordances` too (Q3=B).
3. `packages/plugin-grid/src/__tests__/gridNonAuthorKeys.test.tsx` — a new section pinning each clause of that comment. 11 new assertions.
4. A `patch` changeset on `@object-ui/plugin-grid`.

## Why the wording is load-bearing

An earlier dispatch of this card stopped without a PR: the original ruling's premises — "zero producers", "an undeclared view-level key", "an ADR-0049 dead override" — were falsified by measurement, one of them in the very file the card cited as proof. The **action** survived; the stated reasons did not. Q1=A exists to keep the falsified claim out of the census artifact, so the comment and the pin state the measured reason instead.

Concretely, the pin does **not** assert "no producer writes this" and does not call the key non-author surface. It asserts:

- the view-level schema refuses `edit` / `delete` / `create` by name, and accepts the toolbar vocabulary (the control that makes those refusals mean something);
- a view document carrying the toolbar block is spec-legal, while the CRUD block is refused on a view;
- `SpecBridge.transformListView` really copies it onto the `object-grid` node — the producer is the evidence, exactly as in the `NON_AUTHOR_KEYS` table above it, except here it proves the opposite;
- `listViewPredicates` harvests **zero** fields from the toolbar block and the operand from the CRUD block;
- and the renderer behaviour: the object's predicate operand reaches `$select`, **with** a toolbar block present on the view.

The render channel of the surviving object-block read is already pinned four times over by `rowCrudEffectiveOps.test.tsx`'s `userActions` opt-out control group, so it is cited in the docblock rather than duplicated.

## Verification — all at `efc95b643`

No build artifact sits between any edit and any measurement here: `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src/`, and this worktree had **no `dist/` at all** while the suites ran (`packages/core/dist`, `packages/react/dist`, `packages/plugin-grid/dist` all absent), so source is provably what executed. `@objectstack/spec` is the published 17.0.0 from `node_modules`; nothing local builds it. The dependency closure was built afterwards, only because `tsc --noEmit` needs the `.d.ts` files.

Run from the repository root, per AGENTS.md:

```
pnpm exec vitest run packages/plugin-grid/          -> 81 files, 737 tests passed
pnpm exec vitest run packages/plugin-list/          -> 42 files, 632 tests passed (downstream consumer)
pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
                                                    -> 65 tests passed
pnpm --filter @object-ui/plugin-grid type-check     -> exit 0 (after building the dep closure)
pnpm --filter @object-ui/plugin-grid lint           -> 0 errors, 641 warnings (pre-existing)
pnpm run check:control-bytes / check:spec-symbols / check:phantom-deps / check:self-import -> all OK
node scripts/check-changeset-presence.mjs / check-changeset-no-major.mjs -> OK
```

### Reverse-verification (two legs, predicted before running, fix committed first)

**Leg 1 — restore the view-first `??`.** Predicted: exactly one red, *"…and a spec-legal toolbar block on the view does not knock it out"*; the sibling case stays green because its fixture carries no view-level key. Observed: `1 failed | 30 passed`, that assertion, `expected [ 'id', 'name' ] to include 'status'`. **Matches.**

**Leg 2 — delete the `userActions` line from the harvest entirely** (the "tidy finish" mutation). Predicted: two red — both projection cases lose `status`. Observed: `2 failed | 29 passed`. **Matches.**

Leg 2 is why the first projection case is counted at all: it is green on both legs of leg 1, so on its own it pins nothing about *this* fix — it pins that the read still exists, and leg 2 is what shows it can go red.

## Scope

`plugin-grid` only, per Q2=B. The identical (and worse — its left operand is always truthy on the app-shell path) instance at `packages/plugin-list/src/ListView.tsx` is #5398, deliberately serial behind this PR so both read sites end up with one shape; out of scope here, and #5398 remains open. The producer-side question — the bridge writing a key `ComponentPropsMap['object-grid']` refuses by name — is routed through triage as its own spec-coordination card and is not addressed here either. Independently re-confirmed while checking downstream impact: `ListView` reads `schema.userActions` as toolbar policy and does **not** forward it into its child grid node, so the app-shell path is unaffected by this change.

Toolbar policy itself is untouched — it was never read through this path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_