### PR TITLE
fix(plugin-dashboard,i18n): the widget config panel reads AND writes an inline-locale-map label (#5301)

### DIFF
--- a/.changeset/widget-config-panel-locale-map-5301.md
+++ b/.changeset/widget-config-panel-locale-map-5301.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-dashboard': patch
+'@object-ui/i18n': minor
+---
+
+`WidgetConfigPanel` reads an inline-locale-map title, and a save no longer destroys the other locales.
+
+The dashboard widget config panel carried a private `resolveLabel` documented as
+resolving an `I18nLabel` while reading `defaultValue || key` — the key-reference
+form `@objectstack/spec` retired at 17.0.0-rc.6 (objectstack#5055). The inline
+per-locale map `I18nLabelSchema` actually admits has neither limb, so
+`{ en: 'Revenue', zh: '收入' }` resolved to `''`. It was the fourth private copy
+of that resolver; objectui#4032 swept the other three out of `DashboardRenderer`,
+`MetricWidget` and `MetricCard`.
+
+This was not a display bug. The resolved value seeds the panel's editable draft,
+so a widget whose stored title was a map opened with an **empty** Title field and
+the next save wrote `''` over the author's map — on the ordinary path, not an
+exotic one: open the widget, change anything, save.
+
+Both halves are fixed, per the maintainer's 2026-08-20 ruling on objectui#5301:
+
+- **Reading** goes through `pickLocalized(value, language)`, so the panel shows
+  the active locale like every sibling surface post-objectui#4032.
+- **Writing** replaces only the active locale's entry and carries every other
+  locale across. A title the author never touched round-trips the stored object
+  itself through an unrelated config edit; an edited one merges into the entry
+  that was displayed. The live-update callback (`onFieldChange`) forwards the
+  merged map for the same reason — hosts feed it back into the widget the panel
+  re-opens from, so a bare string there dropped the map before a save ever ran.
+
+`@object-ui/i18n` gains `setLocalized(value, language, next)`, the write-side
+inverse of `pickLocalized`, so the rule is stated once instead of re-derived per
+panel. It follows `pickLocalized`'s first three limbs — exact tag, base language,
+region-qualified sibling — and deliberately stops there: the `default` / `en` /
+first-value limbs are display fallbacks that hand back *another* locale's string,
+and writing to one would let an author editing in `fr` overwrite English. With no
+entry for the active locale the edit adds one. The pairing
+`pickLocalized(setLocalized(map, lang, s), lang) === s` is pinned, because a
+write that lands where the read does not look is how a "saved" string disappears.
+
+A full multi-locale editing UI remains out of scope (objectui#4163).

--- a/packages/i18n/src/__tests__/setLocalized.test.ts
+++ b/packages/i18n/src/__tests__/setLocalized.test.ts
@@ -1,0 +1,193 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `setLocalized` — the write-side inverse of `pickLocalized` (objectui#5301).
+ *
+ * A single-line authoring input can hold exactly one locale's string. Writing
+ * that string back as the WHOLE value is the data-loss shape this function
+ * exists to remove: `{ en: 'Revenue', 'zh-CN': '收入' }` becomes `'Revenue'` and
+ * the Chinese title is gone, silently, with no failure signal anywhere.
+ *
+ * Two properties carry the whole contract, and both are pinned below:
+ *
+ *  1. **Every other locale survives.** The result differs from the input in at
+ *     most one entry.
+ *  2. **The entry written is the entry displayed** — for any map and any
+ *     language, `pickLocalized(setLocalized(map, lang, s), lang) === s`. This is
+ *     the pairing that stops the two functions drifting apart: if a write ever
+ *     lands somewhere `pickLocalized` does not read, the author's "saved" string
+ *     disappears on the next open while a stale one shows in its place.
+ *
+ * The one place the two deliberately DISAGREE is the tail of the chain, and
+ * that asymmetry is the point rather than an oversight: `pickLocalized` falls
+ * back through `default` -> `en` -> first value to find something to SHOW, and
+ * none of those may be a write target. An author editing in `fr` a map with no
+ * French entry is looking at the English string; writing there would overwrite
+ * English with French. The write adds an `fr` entry instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pickLocalized, setLocalized } from '../pickLocalized';
+
+describe('setLocalized — values with no map to preserve', () => {
+  it('returns the new string for a plain-string label', () => {
+    expect(setLocalized('Revenue', 'en', 'Turnover')).toBe('Turnover');
+  });
+
+  it('returns the new string for a null/undefined label', () => {
+    expect(setLocalized(null, 'en', 'Turnover')).toBe('Turnover');
+    expect(setLocalized(undefined, 'zh-CN', '营收')).toBe('营收');
+  });
+
+  it('returns the new string for an array (not an inline locale map)', () => {
+    expect(setLocalized(['Revenue'], 'en', 'Turnover')).toBe('Turnover');
+  });
+});
+
+describe('setLocalized — the edited entry, and only the edited entry', () => {
+  it('replaces the exact language tag and preserves the rest', () => {
+    const stored = { en: 'Revenue', 'zh-CN': '收入', ja: '収益' };
+    expect(setLocalized(stored, 'zh-CN', '营收')).toEqual({
+      en: 'Revenue',
+      'zh-CN': '营收',
+      ja: '収益',
+    });
+  });
+
+  it('never mutates the stored map', () => {
+    const stored = { en: 'Revenue', 'zh-CN': '收入' };
+    setLocalized(stored, 'zh-CN', '营收');
+    expect(stored).toEqual({ en: 'Revenue', 'zh-CN': '收入' });
+  });
+
+  it('writes the BASE entry when that is the one displayed (zh-CN -> zh)', () => {
+    // `pickLocalized({ en, zh }, 'zh-CN')` shows the `zh` entry, so that is the
+    // entry the author edited.
+    expect(setLocalized({ en: 'Revenue', zh: '收入' }, 'zh-CN', '营收')).toEqual({
+      en: 'Revenue',
+      zh: '营收',
+    });
+  });
+
+  it('writes the REGIONAL entry when that is the one displayed (zh -> zh-CN)', () => {
+    // The alternative — adding a bare `zh` key — would leave the edited-away
+    // `zh-CN: '收入'` in the stored map: invisible in the panel that just
+    // changed it, still live for any consumer asking for `zh-CN`.
+    expect(setLocalized({ en: 'Revenue', 'zh-CN': '收入' }, 'zh', '营收')).toEqual({
+      en: 'Revenue',
+      'zh-CN': '营收',
+    });
+  });
+
+  it('prefers the exact tag over the base and the regional sibling', () => {
+    expect(setLocalized({ zh: '基础', 'zh-CN': '区域' }, 'zh', 'X')).toEqual({
+      zh: 'X',
+      'zh-CN': '区域',
+    });
+  });
+
+  it('treats a non-string entry as no entry and overwrites it', () => {
+    // `pickLocalized` skips a non-string entry, so nothing readable is lost.
+    expect(setLocalized({ en: 42, fr: 'Revenu' }, 'en', 'Revenue')).toEqual({
+      en: 'Revenue',
+      fr: 'Revenu',
+    });
+  });
+});
+
+describe('setLocalized — a locale the map does not carry ADDS an entry', () => {
+  it('never overwrites the `en` entry the display fell back to', () => {
+    expect(setLocalized({ en: 'Revenue' }, 'fr', 'Revenu')).toEqual({
+      en: 'Revenue',
+      fr: 'Revenu',
+    });
+  });
+
+  it('never overwrites the `default` entry the display fell back to', () => {
+    expect(setLocalized({ default: 'Revenue', ja: '収益' }, 'fr', 'Revenu')).toEqual({
+      default: 'Revenue',
+      ja: '収益',
+      fr: 'Revenu',
+    });
+  });
+
+  it('never overwrites the first-value entry the display fell back to', () => {
+    expect(setLocalized({ ja: '収益' }, 'fr', 'Revenu')).toEqual({
+      ja: '収益',
+      fr: 'Revenu',
+    });
+  });
+
+  it('treats an absent language as `en`, matching pickLocalized', () => {
+    expect(setLocalized({ ja: '収益' }, undefined, 'Revenue')).toEqual({
+      ja: '収益',
+      en: 'Revenue',
+    });
+  });
+});
+
+/**
+ * objectui#3907 narrowed every `pickLocalized` limb to OWN properties and
+ * `string` values. The write-key resolution follows, for the same reason: a tag
+ * naming an `Object.prototype` member is not an entry, so it cannot be the
+ * entry the author edited — the write adds a real own property instead of
+ * appearing to overwrite an inherited one.
+ */
+describe('setLocalized — own properties only (objectui#3907 parity)', () => {
+  const PROTOTYPE_MEMBERS = ['constructor', 'toString', 'valueOf', 'hasOwnProperty'];
+
+  for (const member of PROTOTYPE_MEMBERS) {
+    it(`adds an own \`${member}\` entry rather than resolving against the prototype`, () => {
+      const out = setLocalized({ en: 'Revenue' }, member, 'X') as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(out, member)).toBe(true);
+      expect(out[member]).toBe('X');
+      expect(out.en).toBe('Revenue');
+      // And the pairing still holds for the odd tag.
+      expect(pickLocalized(out, member)).toBe('X');
+    });
+  }
+});
+
+/**
+ * The invariant that makes the pair safe to co-locate: whatever `setLocalized`
+ * writes for a language, `pickLocalized` reads back for that same language.
+ * Any future edit to either function's limb order that breaks the pairing fails
+ * here rather than in a user's stored metadata.
+ */
+describe('setLocalized ∘ pickLocalized — what you write is what you read', () => {
+  const CASES: Array<[string, unknown, string | undefined]> = [
+    ['exact tag', { en: 'Revenue', 'zh-CN': '收入' }, 'zh-CN'],
+    ['base fallback', { en: 'Revenue', zh: '收入' }, 'zh-CN'],
+    ['regional upgrade', { en: 'Revenue', 'zh-CN': '收入' }, 'zh'],
+    ['exact over base', { zh: '基础', 'zh-CN': '区域' }, 'zh'],
+    ['no entry, en present', { en: 'Revenue' }, 'fr'],
+    ['no entry, default present', { default: 'Revenue' }, 'fr'],
+    ['no entry, single foreign entry', { ja: '収益' }, 'fr'],
+    ['empty map', {}, 'de'],
+    ['absent language', { ja: '収益' }, undefined],
+    ['plain string', 'Revenue', 'zh-CN'],
+    ['nullish', undefined, 'zh-CN'],
+  ];
+
+  for (const [name, stored, language] of CASES) {
+    it(`round-trips the written string for: ${name}`, () => {
+      const written = setLocalized(stored, language, 'WRITTEN');
+      expect(pickLocalized(written, language)).toBe('WRITTEN');
+    });
+  }
+
+  it('keeps every untouched entry byte-identical across a write', () => {
+    const stored = { en: 'Revenue', 'zh-CN': '收入', ja: '収益', default: 'Revenue' };
+    const written = setLocalized(stored, 'ja', '売上') as Record<string, unknown>;
+    for (const key of ['en', 'zh-CN', 'default'] as const) {
+      expect(written[key]).toBe(stored[key]);
+    }
+    expect(Object.keys(written)).toEqual(Object.keys(stored));
+  });
+});

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -105,7 +105,7 @@ export {
   type SpecTranslationData,
 } from './utils/index.js';
 
-export { pickLocalized } from './pickLocalized.js';
+export { pickLocalized, setLocalized } from './pickLocalized.js';
 export { LocalizationProvider, useLocalization, type LocalizationValue } from './LocalizationContext.js';
 export { resolveFieldCurrency } from './currency.js';
 

--- a/packages/i18n/src/pickLocalized.ts
+++ b/packages/i18n/src/pickLocalized.ts
@@ -66,3 +66,78 @@ export function pickLocalized(value: unknown, language: string | undefined | nul
   }
   return String(value);
 }
+
+/**
+ * The map key an edit made in `language` must be WRITTEN to — the write-side
+ * twin of {@link pickLocalized}'s read limbs.
+ *
+ * It deliberately implements only the first three limbs (exact tag, base
+ * language, region-qualified sibling) and then STOPS. `pickLocalized` continues
+ * into `default` -> `en` -> first value, and those last three limbs must never
+ * be write targets: they are DISPLAY fallbacks that hand back *another*
+ * locale's string. Following them would mean an author editing in `fr`, shown
+ * the `en` entry because the map has no French, saves and overwrites English.
+ * When no entry for the active locale exists the edit ADDS one under the active
+ * tag and every stored entry survives untouched.
+ *
+ * The first three limbs are followed exactly because they identify the entry
+ * the author was actually looking at. Writing `zh` when the map stores `zh-CN`
+ * would leave the edited-away `zh-CN` string in place — invisible in the panel
+ * that just "changed" it, still live for any consumer that asks for `zh-CN`.
+ *
+ * Own properties only, `string` values only, for the same reason every
+ * `pickLocalized` limb narrowed that way in objectui#3907: a locale tag that
+ * names an `Object.prototype` member is not an entry, so it cannot be the entry
+ * the author edited.
+ */
+function localeWriteKey(
+  o: Record<string, unknown>,
+  language: string | undefined | null,
+): string {
+  const lang = (language || 'en').trim() || 'en';
+  const base = lang.split('-')[0];
+  const has = (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(o, key) && typeof o[key] === 'string';
+  if (has(lang)) return lang;
+  if (has(base)) return base;
+  return Object.keys(o).find((k) => k.split('-')[0] === base && has(k)) ?? lang;
+}
+
+/**
+ * Write `next` back into a possibly-localized value as the `language` entry,
+ * preserving every other locale — the write-side inverse of
+ * {@link pickLocalized}.
+ *
+ * An authoring surface that shows one locale in one text input has to answer
+ * two questions, and they are not the same question: which entry to DISPLAY
+ * (`pickLocalized`) and which entry a save REPLACES. Answering the second with
+ * "the whole value" is the data-loss shape this function exists to remove —
+ * `onChange(e.target.value)` straight back over `{ en, zh-CN }` destroys every
+ * locale the author was not looking at, silently, on the first keystroke.
+ *
+ * - Plain string / `null` / `undefined` / array input: there is no map to
+ *   preserve, so the result is `next` itself. A string-valued label keeps
+ *   behaving exactly as it always has.
+ * - Inline locale map: the result is the same map with exactly one entry
+ *   replaced (or added — see {@link localeWriteKey}). Non-string entries and
+ *   unrelated locales are carried across untouched.
+ *
+ * The pairing with `pickLocalized` is the invariant that matters and it is
+ * pinned in `__tests__/setLocalized.test.ts`: for any map and any language,
+ * `pickLocalized(setLocalized(map, lang, s), lang) === s`. If the two functions
+ * ever drift apart, an edit lands in an entry the panel does not display and
+ * the "saved" string vanishes — which is why they live in one file.
+ *
+ * ⚠️ This is the minimal non-destructive write for a SINGLE-locale editor. It
+ * is not a multi-locale authoring UI (objectui#4163) and does not pretend to
+ * be: an author can only ever reach the entry for the locale they are in.
+ */
+export function setLocalized(
+  value: unknown,
+  language: string | undefined | null,
+  next: string,
+): string | Record<string, unknown> {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return next;
+  const o = value as Record<string, unknown>;
+  return { ...o, [localeWriteKey(o, language)]: next };
+}

--- a/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
+++ b/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from '@object-ui/components';
 import { ConfigRow } from '@object-ui/components';
 import { X } from 'lucide-react';
+import { pickLocalized, setLocalized } from '@object-ui/i18n';
 import type { ConfigPanelSchema, ConfigField } from '@object-ui/components';
 import type { WidgetDatasetCatalogEntry } from './dataset-catalog';
 import {
@@ -491,15 +492,88 @@ export interface WidgetConfigPanelProps {
 // Component
 // ---------------------------------------------------------------------------
 
-/** Resolve an I18nLabel (string or {key, defaultValue}) to a plain string. */
-function resolveLabel(v: unknown): string {
-  if (v === undefined || v === null) return '';
-  if (typeof v === 'string') return v;
-  if (typeof v === 'object') {
-    const obj = v as Record<string, any>;
-    return obj.defaultValue || obj.key || '';
+// ---------------------------------------------------------------------------
+// `I18nLabel` display and write-back (objectui#5301)
+//
+// A private `resolveLabel(v)` used to sit here, documented as resolving an
+// `I18nLabel` while reading `obj.defaultValue || obj.key` — the key-reference
+// form `@objectstack/spec` RETIRED at 17.0.0-rc.6 (objectstack#5055). The
+// inline per-locale map `I18nLabelSchema` actually admits has neither limb, so
+// it resolved `{ en: 'Revenue', 'zh-CN': '收入' }` to `''`. That was not a
+// display bug: the resolved value seeds the editable draft below, so a widget
+// whose stored title is a map opened with an EMPTY Title field and the next
+// save wrote `''` over the author's map. It was the fourth private copy of that
+// resolver; objectui#4032 swept the other three out of `DashboardRenderer`,
+// `MetricWidget` and `MetricCard`.
+//
+// Both halves now come from `@object-ui/i18n`, which is where the read rule and
+// the write rule are stated once (they have to agree — see `setLocalized`):
+//
+//   READ  `pickLocalized(value, language)` — show the active locale, like every
+//         sibling surface post-#4032.
+//   WRITE `setLocalized(stored, language, edited)` — replace ONLY the active
+//         locale's entry and carry every other locale across untouched.
+//
+// A full multi-locale editor (authoring every locale in the panel) is
+// objectui#4163's territory, not this one.
+// ---------------------------------------------------------------------------
+
+/**
+ * The config keys this panel edits as plain single-line text while the spec
+ * types them `I18nLabel` — i.e. the keys whose stored value may be an inline
+ * locale map that one `<input >` cannot represent.
+ */
+const I18N_LABEL_KEYS = ['title', 'description'] as const;
+
+/** Is this stored value an inline locale map (rather than a plain string)? */
+function isLocaleMap(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Put the `I18nLabel` keys of a draft back into the shape they were stored in.
+ *
+ * The draft carries ONE string per label key — the active locale's, which is
+ * what the text input can hold. Persisting that string as the whole value is
+ * the data loss this card is about, so before a save each label key is mapped
+ * back against the value the panel was handed:
+ *
+ * - stored value is a plain string (or absent): nothing was ever collapsed, so
+ *   the draft's string is already the correct whole value — passed through.
+ * - stored value is a map and the draft's string still equals what the panel
+ *   DISPLAYED: the author never touched this field, so the **original object is
+ *   returned by reference**. An untouched title survives an unrelated config
+ *   edit byte-identically — the round trip the ruling requires, and the reason
+ *   this is an identity restore rather than a rebuild that would happen to
+ *   produce an equal object (a rebuild would add an entry for the active locale
+ *   to a map that never had one).
+ * - stored value is a map and the string differs: the edit lands in the active
+ *   locale's entry via `setLocalized`, every other locale preserved.
+ *
+ * Exported for direct unit testing — the panel path reaches it only through
+ * `useConfigDraft`, so a component test alone would be asserting that hook's
+ * behaviour as much as this rule.
+ */
+export function restoreI18nLabels(
+  draft: Record<string, any>,
+  source: Record<string, any>,
+  language: string | undefined,
+): Record<string, any> {
+  let out = draft;
+  for (const key of I18N_LABEL_KEYS) {
+    const stored = source?.[key];
+    if (!isLocaleMap(stored)) continue;
+    const edited = draft[key];
+    // Not a string ⇒ the draft still holds the stored value itself; there is
+    // nothing to merge back and nothing to lose.
+    if (typeof edited !== 'string') continue;
+    if (out === draft) out = { ...draft };
+    out[key] =
+      edited === pickLocalized(stored, language)
+        ? stored
+        : setLocalized(stored, language, edited);
   }
-  return String(v);
+  return out;
 }
 
 /**
@@ -547,17 +621,48 @@ export function WidgetConfigPanel({
   datasets,
   datasetsLoading: _datasetsLoading,
 }: WidgetConfigPanelProps) {
-  const { t } = useConfigPanelTranslation();
+  const { t, language } = useConfigPanelTranslation();
 
   // Pre-process config to resolve any I18nLabel values for title/description
+  // down to the ONE string a single-line text input can hold. `language` is a
+  // dependency and has to be: it is the locale the draft was seeded from, and
+  // `restoreI18nLabels` compares the draft against `pickLocalized(stored,
+  // language)` to tell "untouched" from "edited". Leaving it out would let a
+  // language switch mid-session leave a draft seeded from the OLD locale being
+  // compared against the NEW one — every untouched label would read as edited
+  // and get merged into the wrong entry. Re-seeding costs an in-progress edit
+  // on a language switch, which is the cheap half of that trade.
   const normalizedConfig: Record<string, any> = React.useMemo(() => ({
     ...config,
-    title: typeof config.title === 'object' ? resolveLabel(config.title) : config.title,
-    description: typeof config.description === 'object' ? resolveLabel(config.description) : config.description,
-  }), [config]);
+    title: typeof config.title === 'object' ? pickLocalized(config.title, language) : config.title,
+    description:
+      typeof config.description === 'object'
+        ? pickLocalized(config.description, language)
+        : config.description,
+  }), [config, language]);
+
+  // The live-update callback is the panel's OTHER way out, and it is a
+  // data-loss path of its own: hosts feed it straight back into the widget they
+  // re-open the panel from (`DashboardWithConfig` writes it into `liveSchema`,
+  // which is exactly where the next `config` prop comes from), and some persist
+  // it. Forwarding the bare editor string would put a plain string where the
+  // map was — the map then gone before a save ever ran. Same rule as the save
+  // path, applied per field.
+  const handleFieldChange = React.useCallback(
+    (field: string, value: any) => {
+      if (!onFieldChange) return;
+      const stored = config?.[field];
+      const localized =
+        (I18N_LABEL_KEYS as readonly string[]).includes(field) &&
+        isLocaleMap(stored) &&
+        typeof value === 'string';
+      onFieldChange(field, localized ? setLocalized(stored, language, value) : value);
+    },
+    [onFieldChange, config, language],
+  );
 
   const { draft, isDirty, updateField, discard } = useConfigDraft(normalizedConfig, {
-    onUpdate: onFieldChange,
+    onUpdate: handleFieldChange,
   });
 
   const schema = React.useMemo(
@@ -573,7 +678,9 @@ export function WidgetConfigPanel({
       draft={draft}
       isDirty={isDirty}
       onFieldChange={updateField}
-      onSave={() => onSave(sanitizeDraftForType(draft))}
+      onSave={() =>
+        onSave(sanitizeDraftForType(restoreI18nLabels(draft, config, language)))
+      }
       onDiscard={discard}
       headerExtra={headerExtra}
     />

--- a/packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.inlineLocaleMap.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.inlineLocaleMap.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `WidgetConfigPanel` reads AND writes an inline-locale-map title
+ * (objectui#5301).
+ *
+ * The panel carried a private `resolveLabel` reading `defaultValue || key` —
+ * the key-reference form `@objectstack/spec` RETIRED at 17.0.0-rc.6
+ * (objectstack#5055). The inline per-locale map `I18nLabelSchema` admits has
+ * neither limb, so it resolved to `''`.
+ *
+ * ## Red-first — measured against the unfixed source, verbatim
+ *
+ * With `config.title = { en: 'Revenue', zh: '收入' }` the Title input rendered
+ * with `value=""`:
+ *
+ * ```
+ * AssertionError: expected '' to be '收入'
+ * ```
+ *
+ * and the save that followed an unrelated edit emitted `title: ''` — the
+ * author's map replaced by an empty string. That is why this file asserts the
+ * SAVE payload and not only the rendered value: an empty input is cosmetic, an
+ * empty input that seeds the draft is data loss on the ordinary path (open
+ * widget -> change anything -> save).
+ *
+ * ## What the ruling pins (maintainer, 2026-08-20)
+ *
+ * - read through `pickLocalized(value, language)`, like every sibling surface
+ *   post-objectui#4032;
+ * - a save writes back ONLY the active locale's entry and preserves the others;
+ * - an untouched map survives an unrelated edit **byte-identically** — asserted
+ *   with `toBe`, i.e. the same object, because an equal-but-rebuilt object is
+ *   a different guarantee (a rebuild would add an entry for the active locale
+ *   to a map that never carried one).
+ *
+ * A full multi-locale editor is objectui#4163's territory and is deliberately
+ * NOT asserted here.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+import { WidgetConfigPanel, restoreI18nLabels } from '../WidgetConfigPanel';
+
+afterEach(cleanup);
+
+/**
+ * `zh` is spelled as a bare base tag on BOTH sides — the provider's language and
+ * the map's key — so the write target is the same entry whether the active
+ * language arrives as `zh` or `zh-CN` (exact hit, or base hit). The point under
+ * test is which entries survive, not which spelling of Chinese wins; that is
+ * `pickLocalized`'s own suite.
+ */
+const MAP_TITLE = { en: 'Revenue', zh: '收入' } as const;
+const MAP_DESCRIPTION = { en: 'Monthly total', zh: '每月总额' } as const;
+
+function renderPanel(
+  config: Record<string, any>,
+  handlers: { onSave?: (c: Record<string, any>) => void; onFieldChange?: (f: string, v: any) => void } = {},
+  language = 'zh',
+) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <WidgetConfigPanel
+        open
+        onClose={vi.fn()}
+        config={config}
+        onSave={handlers.onSave ?? vi.fn()}
+        onFieldChange={handlers.onFieldChange}
+      />
+    </I18nProvider>,
+  );
+}
+
+const titleInput = () => screen.getByTestId('config-field-title') as HTMLInputElement;
+const descriptionInput = () =>
+  screen.getByTestId('config-field-description') as HTMLInputElement;
+
+/** An edit that has nothing to do with the label keys — the ordinary path. */
+function makeUnrelatedEdit() {
+  fireEvent.change(screen.getByTestId('config-field-dataset'), {
+    target: { value: 'sales_pipeline' },
+  });
+}
+
+const save = () => fireEvent.click(screen.getByTestId('config-panel-save'));
+
+describe('WidgetConfigPanel — reading an inline locale map', () => {
+  it('shows the active locale in the Title field', () => {
+    renderPanel({ id: 'w1', type: 'bar', title: MAP_TITLE });
+    expect(titleInput().value).toBe('收入');
+  });
+
+  it('shows the same map differently for another language', () => {
+    renderPanel({ id: 'w1', type: 'bar', title: MAP_TITLE }, {}, 'en');
+    expect(titleInput().value).toBe('Revenue');
+  });
+
+  it('shows the active locale in the Description field', () => {
+    renderPanel({ id: 'w1', type: 'bar', description: MAP_DESCRIPTION });
+    expect(descriptionInput().value).toBe('每月总额');
+  });
+
+  it('leaves a plain-string title exactly as authored', () => {
+    renderPanel({ id: 'w1', type: 'bar', title: 'Revenue' });
+    expect(titleInput().value).toBe('Revenue');
+  });
+});
+
+describe('WidgetConfigPanel — an untouched map survives an unrelated edit', () => {
+  it('saves the stored title object itself, not a rebuilt equal one', () => {
+    const onSave = vi.fn();
+    const config = { id: 'w1', type: 'bar', title: MAP_TITLE, description: MAP_DESCRIPTION };
+    renderPanel(config, { onSave });
+
+    makeUnrelatedEdit();
+    save();
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.dataset).toBe('sales_pipeline');
+    // The byte-identical round trip the ruling requires.
+    expect(saved.title).toBe(config.title);
+    expect(saved.description).toBe(config.description);
+  });
+
+  it('still saves a plain-string title as a plain string', () => {
+    const onSave = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar', title: 'Revenue' }, { onSave });
+
+    makeUnrelatedEdit();
+    save();
+
+    expect(onSave.mock.calls[0][0].title).toBe('Revenue');
+  });
+
+  it('does not invent a title for a widget that never had one', () => {
+    const onSave = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar' }, { onSave });
+
+    makeUnrelatedEdit();
+    save();
+
+    expect(onSave.mock.calls[0][0].title).toBeUndefined();
+  });
+});
+
+describe('WidgetConfigPanel — editing writes ONE locale entry', () => {
+  it('merges the edit into the active locale and keeps the others', () => {
+    const onSave = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar', title: MAP_TITLE }, { onSave });
+
+    fireEvent.change(titleInput(), { target: { value: '营收' } });
+    save();
+
+    expect(onSave.mock.calls[0][0].title).toEqual({ en: 'Revenue', zh: '营收' });
+  });
+
+  it('edits the description independently of the title', () => {
+    const onSave = vi.fn();
+    const config = { id: 'w1', type: 'bar', title: MAP_TITLE, description: MAP_DESCRIPTION };
+    renderPanel(config, { onSave });
+
+    fireEvent.change(descriptionInput(), { target: { value: '季度总额' } });
+    save();
+
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.description).toEqual({ en: 'Monthly total', zh: '季度总额' });
+    expect(saved.title).toBe(config.title);
+  });
+
+  it('adds an entry for a locale the map does not carry, overwriting nothing', () => {
+    const onSave = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar', title: MAP_TITLE }, { onSave }, 'de');
+
+    // The panel showed the `en` entry (display fallback); the edit must NOT
+    // land there.
+    expect(titleInput().value).toBe('Revenue');
+    fireEvent.change(titleInput(), { target: { value: 'Umsatz' } });
+    save();
+
+    expect(onSave.mock.calls[0][0].title).toEqual({
+      en: 'Revenue',
+      zh: '收入',
+      de: 'Umsatz',
+    });
+  });
+
+  it('restores the stored map when an edit is typed back to what was shown', () => {
+    const onSave = vi.fn();
+    const config = { id: 'w1', type: 'bar', title: MAP_TITLE };
+    renderPanel(config, { onSave });
+
+    fireEvent.change(titleInput(), { target: { value: '营收' } });
+    fireEvent.change(titleInput(), { target: { value: '收入' } });
+    save();
+
+    expect(onSave.mock.calls[0][0].title).toBe(config.title);
+  });
+
+  it('writes an emptied field into the active locale rather than over the map', () => {
+    const onSave = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar', title: MAP_TITLE }, { onSave });
+
+    fireEvent.change(titleInput(), { target: { value: '' } });
+    save();
+
+    // Clearing the title in this locale is an authoring act; clearing every
+    // other locale with it is not. `InlineLocaleMapSchema` is
+    // `z.record(<tag >, z.string())`, so `''` is an admissible entry.
+    expect(onSave.mock.calls[0][0].title).toEqual({ en: 'Revenue', zh: '' });
+  });
+});
+
+/**
+ * The live-update callback is the panel's other way out, and hosts feed it
+ * straight back into the widget the panel re-opens from — `DashboardWithConfig`
+ * writes it into `liveSchema`, which is where the next `config` prop is derived
+ * from. Forwarding the bare editor string would drop the map before a save ever
+ * ran: open, type, close without saving, re-open, and the other locales are
+ * already gone.
+ */
+describe('WidgetConfigPanel — onFieldChange preserves the map too', () => {
+  it('forwards the merged map, not the bare string', () => {
+    const onFieldChange = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar', title: MAP_TITLE }, { onFieldChange });
+
+    fireEvent.change(titleInput(), { target: { value: '营收' } });
+
+    expect(onFieldChange).toHaveBeenCalledWith('title', { en: 'Revenue', zh: '营收' });
+  });
+
+  it('forwards a plain string unchanged for a string-valued title', () => {
+    const onFieldChange = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar', title: 'Revenue' }, { onFieldChange });
+
+    fireEvent.change(titleInput(), { target: { value: 'Turnover' } });
+
+    expect(onFieldChange).toHaveBeenCalledWith('title', 'Turnover');
+  });
+
+  it('forwards non-label fields untouched', () => {
+    const onFieldChange = vi.fn();
+    renderPanel({ id: 'w1', type: 'bar', title: MAP_TITLE }, { onFieldChange });
+
+    makeUnrelatedEdit();
+
+    expect(onFieldChange).toHaveBeenCalledWith('dataset', 'sales_pipeline');
+  });
+});
+
+/**
+ * The pure rule, tested directly. The panel reaches it only through
+ * `useConfigDraft`, so the component cases above are also asserting that hook's
+ * behaviour; these are not.
+ */
+describe('restoreI18nLabels — the pure write-back rule', () => {
+  const language = 'zh';
+
+  it('returns the draft untouched when no label key was stored as a map', () => {
+    const draft = { id: 'w1', title: 'Revenue', description: 'x' };
+    expect(restoreI18nLabels(draft, { id: 'w1', title: 'Revenue' }, language)).toBe(draft);
+  });
+
+  it('restores the stored object by reference for an untouched label', () => {
+    const source = { title: MAP_TITLE };
+    const out = restoreI18nLabels({ title: '收入' }, source, language);
+    expect(out.title).toBe(source.title);
+  });
+
+  it('merges an edited label into the active locale', () => {
+    const out = restoreI18nLabels({ title: '营收' }, { title: MAP_TITLE }, language);
+    expect(out.title).toEqual({ en: 'Revenue', zh: '营收' });
+  });
+
+  it('never mutates the draft it was given', () => {
+    const draft = { title: '营收' };
+    restoreI18nLabels(draft, { title: MAP_TITLE }, language);
+    expect(draft.title).toBe('营收');
+  });
+
+  it('leaves a draft value that is not a string alone', () => {
+    // Nothing was collapsed into an input, so there is nothing to merge back.
+    const out = restoreI18nLabels({ title: MAP_TITLE }, { title: MAP_TITLE }, language);
+    expect(out.title).toBe(MAP_TITLE);
+  });
+
+  it('tolerates a missing source', () => {
+    const draft = { title: 'Revenue' };
+    expect(restoreI18nLabels(draft, undefined as any, language)).toBe(draft);
+  });
+});


### PR DESCRIPTION
Fixes #5301

`WidgetConfigPanel` carried a private `resolveLabel` documented as resolving an
`I18nLabel` while reading `defaultValue || key` — the key-reference form
`@objectstack/spec` retired at 17.0.0-rc.6 (objectstack#5055). The inline
per-locale map `I18nLabelSchema` actually admits has neither limb, so
`{ en: 'Revenue', zh: '收入' }` resolved to `''`. Fourth private copy of that
resolver; objectui#4032 swept the other three out of `DashboardRenderer`,
`MetricWidget` and `MetricCard`.

Not a display bug: the resolved value seeds the editable draft, so a map-titled
widget opened with an **empty** Title field and the next save wrote `''` over the
author's map — on the ordinary path (open widget, change anything, save).

## The measurement the dispatch asked for FIRST

Triage flagged an unchecked assumption: nobody had verified what the dashboard
save path persists for other object-valued config keys. **Measured — the panel
already round-trips untouched keys; it does not rebuild the config from the
draft.** No diff mechanism is needed and the card is the small shape. The chain,
end to end:

1. `useConfigDraft(source)` seeds `useState({ ...source })` — a shallow copy of
   the whole config object, not a projection over the schema's field list.
2. `updateField` returns `{ ...prev, [field]: value }` — only the named key moves.
3. `sanitizeDraftForType(draft)` spreads the draft and deletes a fixed deny-list
   (legacy analytics keys, retired action keys, `dimensions` for metric-likes).
4. `DashboardWithConfig.handleWidgetSave` forwards that object verbatim.

Object-valued keys therefore already survive — `dimensions` / `values` are arrays
carried across untouched, pinned by the existing `sanitizeDraftForType` tests.
The normalization of `title` / `description` was the **single** lossy step in the
path, which is exactly where the fix lands.

## The fix (maintainer ruling, 2026-08-20)

- **Reading** — `pickLocalized(value, language)`, matching every sibling surface
  post-objectui#4032.
- **Writing** — a save replaces only the active locale's entry. An untouched
  label round-trips **the stored object itself** (asserted with `toBe`, not
  `toEqual`: an equal-but-rebuilt object is a weaker guarantee, since a rebuild
  would add an entry for the active locale to a map that never carried one). An
  edited label merges into the entry that was displayed.
- **`onFieldChange` too.** The live-update callback is the panel's other way out
  and a data-loss path of its own: `DashboardWithConfig` writes it into
  `liveSchema`, which is where the next `config` prop is derived from. Forwarding
  the bare editor string dropped the map before a save ever ran — open, type,
  close without saving, re-open, and the other locales were already gone.
- A full multi-locale editor stays out of scope (objectui#4163).

`@object-ui/i18n` gains `setLocalized(value, language, next)`, the write-side
inverse of `pickLocalized`, **co-located in the same file** because the entry
written must be the entry read. It follows `pickLocalized`'s first three limbs —
exact tag, base language, region-qualified sibling — and deliberately stops
there: `default` / `en` / first-value are DISPLAY fallbacks handing back another
locale's string, so writing to one would let an author editing in `fr` overwrite
English. With no entry for the active locale the edit adds one. The pairing
`pickLocalized(setLocalized(map, lang, s), lang) === s` is pinned as a property
over 11 cases.

`language` is a dependency of the normalization memo and has to be: it is the
locale the draft was seeded from, and the write-back compares the draft against
`pickLocalized(stored, language)` to tell untouched from edited. Omitting it
would let a mid-session language switch compare an old-locale draft against the
new locale — every untouched label reading as edited, merged into the wrong entry.

## Verification (tree `369e6a073`)

Run from the repo root. Vitest resolves `@object-ui/i18n` to `packages/i18n/src`
via the root config's alias, so **no build artifact sits between the edit and the
thing under test** on any test leg. (The type-check leg is different — `tsc` has
no `paths` entry for `@object-ui/i18n` and resolves it to `dist`, so the
dependency closure was built first.)

| leg | result |
|---|---|
| `vitest run packages/plugin-dashboard packages/i18n` | 115 files, **1496 passed** |
| `pnpm --filter @object-ui/plugin-dashboard --filter @object-ui/i18n type-check` | Done, both echoed |
| `pnpm --filter ... lint` | 0 errors (329 pre-existing `any` / fast-refresh warnings) |
| `check:control-bytes` | OK, 4485 files |
| `check:self-import` | 0 self-imports |
| `check:phantom-deps` | every in-scope import declared |
| `check:i18n-keys` / `check:i18n-drift` | 2904 keys resolve; 0 en values changed |
| `check-changeset-{presence,no-major,fixed}` | all OK |

New coverage: 29 cases in `packages/i18n/src/__tests__/setLocalized.test.ts`,
21 in `packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.inlineLocaleMap.test.tsx`.

### Reverse verification — two legs, predicted before running

**Leg A — read half reverted to the retired-form resolver.** Predicted 6 red
(3 display cases, 2 untouched-round-trip cases, the `de` case's display
assertion). **Observed 7.** The extra one is honest and worth recording: *"writes
an emptied field into the active locale"* types `''` into a field the ablated
read had already rendered as `''`, so React dispatches no change event, the panel
never goes dirty, and the Save button — which only renders when dirty — is never
found. It fails for a mechanical reason rather than the assertion, which is why
the prediction missed it. Assertion messages on the other six were the defect
verbatim: `expected '' to be '收入'`, and
`expected { en: 'Revenue', zh: '' } to be { en: 'Revenue', zh: '收入' }` — the
draft seeded empty, then merged back as an empty entry.

**Leg B — write-back removed from the save path, read intact.** Predicted 6 red,
every save-payload case, with display and `onFieldChange` staying green.
**Observed exactly 6**, messages showing the data-loss shape directly:
`expected '收入' to be { en: 'Revenue', zh: '收入' }`,
`expected 'Umsatz' to deeply equal { en: 'Revenue', zh: '收入', …(1) }`.

Both legs were restored with `git checkout HEAD -- ...` from the committed fix
and the marker's absence verified before re-running green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_