### PR TITLE
fix(auth): useIsWorkspaceAdmin reads the session's published `positions`, restoring platform-admin detection

### DIFF
--- a/.changeset/issue-5389-workspace-admin-positions.md
+++ b/.changeset/issue-5389-workspace-admin-positions.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/auth': patch
+---
+
+Restore platform-admin detection for permission-set-derived administrators.
+
+`useIsWorkspaceAdmin` decides Setup app + Studio visibility, App Marketplace
+gating and the "Build an app" CTAs. Its third source read `user.roles`, a key
+the protocol-17 session face no longer emits (framework ADR-0090 D3 renamed it
+to `positions`). An administrator whose adminship comes from the
+`admin_full_access` permission set — the single-tenant deployment shape, where
+there is no organization member row and the server deliberately no longer
+overwrites `user.role` — matched none of the three sources and read as **not an
+administrator**: Setup and Studio simply disappeared for them.
+
+The hook now reads `user.positions[]`, the one spelling the session publishes.
+Detection is restored for that path and unchanged everywhere else: an active
+member row with an admin role, a stored `user.role` admin scalar, and
+preview/no-auth mode all behave exactly as before, and nobody who was not an
+administrator becomes one — pinned by four negative cases alongside the
+positive one.
+
+Also corrects the now-stale documentation that described the removed spelling:
+the hook's own docblock, the `roles?: string[]` declaration on the client
+`AuthUser` (kept for one remaining compile-time reader; see objectui#5424), and
+two comments in `@object-ui/app-shell`'s Home page. No behaviour change from the
+comment corrections.

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -79,8 +79,11 @@ const AUTHORING_CAPABILITY = 'manage_metadata';
  * objectstack#8270 — on the EE single-database multi-tenant deployment a
  * workspace owner holds `org_owner` + `organization_admin` but NOT
  * `manage_metadata`; that absence is the intended hosted posture (maintainer
- * ruling 2026-08-13), not a missing grant. `useIsWorkspaceAdmin` reads ROLES,
- * so it says `true` for that owner and the builder CTAs rendered — the owner
+ * ruling 2026-08-13), not a missing grant. `useIsWorkspaceAdmin` reads the
+ * session's POSITIONS (spelled `roles` until framework ADR-0090 D3 renamed it;
+ * objectui#5389 moved this hook onto the live spelling, and `org_owner` is in
+ * that array either way), so it says `true` for that owner and the builder CTAs
+ * rendered — the owner
  * followed "Build an app", filled in the new-package dialog, and hit a raw
  * capability refusal at submit. This consumes the answer the server already
  * gives (`GET /api/v1/auth/me/permissions` → `systemPermissions`, surfaced by

--- a/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
@@ -8,8 +8,10 @@
  *
  * On the EE single-database multi-tenant deployment a workspace owner holds
  * `org_owner` + `organization_admin` but NOT `manage_metadata`. `HomePage`
- * gated its builder cover on `useIsWorkspaceAdmin()`, which reads ROLES — so
- * that owner saw "Build an app" as the most prominent thing on their home page,
+ * gated its builder cover on `useIsWorkspaceAdmin()`, which reads the session's
+ * POSITIONS (spelled `roles` until framework ADR-0090 D3 renamed it; see
+ * objectui#5389) and finds `org_owner` there — so that owner saw "Build an app"
+ * as the most prominent thing on their home page,
  * followed it into `/studio`, filled in the new-package dialog, and got a raw
  * English capability refusal at submit.
  *

--- a/packages/auth/src/__tests__/workspaceAdminPositions-5389.test.tsx
+++ b/packages/auth/src/__tests__/workspaceAdminPositions-5389.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5389 — `useIsWorkspaceAdmin` decides platform-admin, and with it
+ * Setup app + Studio visibility, App Marketplace gating and the "Build an app"
+ * CTAs. Its third leg read `user.roles`, a key the protocol-17 session face no
+ * longer emits (framework ADR-0090 D3 renamed it to `positions`). This file is
+ * the measurement, kept as a pin.
+ *
+ * ## The payload these cases are built from is MEASURED, not imagined
+ *
+ * `V17_PERMISSION_SET_ADMIN` below is the verbatim `user` object returned by
+ * `GET /api/v1/auth/get-session` on a real single-tenant server — published
+ * `@objectstack/cli` / `@objectstack/plugin-auth` 17.1.0, `Tenancy: single`,
+ * booted with `objectstack dev --seed-admin --fresh`. The account is the exact
+ * deployment shape the card names: adminship derived from the
+ * `admin_full_access` permission set (a `sys_user_permission_set` row with
+ * `organization_id = NULL`, what `bootstrapPlatformAdmin` seeds), no
+ * `sys_member` row, and `sys_user.role` left at better-auth's default `'user'`
+ * rather than overwritten to `'admin'`.
+ *
+ * What the wire actually carried, and what each leg of the hook made of it:
+ *
+ *   - `session.activeOrganizationId: null`, and `organization/get-active-member`
+ *     answered `400 NO_ACTIVE_ORGANIZATION` -> `activeMember` is null.  LEG 1: no.
+ *   - `user.role: "user"` -> not an admin role.                          LEG 2: no.
+ *   - `user.roles`: THE KEY IS ABSENT (`hasOwnProperty` -> false).       LEG 3: no.
+ *   - `user.positions: ["user", "platform_admin"]` and
+ *     `user.isPlatformAdmin: true` -> read by nothing.
+ *
+ * So the hook returned `false` for a platform administrator. That is the
+ * defect, and `permission-set-derived platform admin` below fails without the
+ * fix.
+ *
+ * ## Why this file also pins the NEGATIVES
+ *
+ * This hook is an authorization-adjacent read. A "fix" that returns `true` more
+ * often makes the positive case green too, so the positive case alone cannot
+ * tell a restored detection from a widened one. The four negative cases exist
+ * to make that substitution fail: an ordinary member must still read as NOT
+ * admin through every leg, an empty `positions` must not admit anyone, a
+ * session predating the key must not either, and the RETIRED `roles` spelling
+ * must not be quietly honoured as a second dialect (framework ADR-0090 D3 bans
+ * resurrecting it; objectui AGENTS.md commandment #0.1 bans the tolerant
+ * consumer-side alias generally).
+ *
+ * The two legs that were never broken get cases of their own for the same
+ * reason: a fix that swaps one dead read for one live read must not be able to
+ * disturb them unnoticed.
+ *
+ * These render the REAL `AuthProvider` against a client double, in the manner
+ * of `singleMembershipActiveOrg-5287.test.tsx`. A mocked `useAuth` could only
+ * restate the fixture; going through the provider measures the path the console
+ * actually takes from wire payload to boolean.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthProvider } from '../AuthProvider';
+import { useAuth } from '../useAuth';
+import { useIsWorkspaceAdmin } from '../useIsWorkspaceAdmin';
+import type { AuthClient, AuthUser } from '../types';
+
+/**
+ * Verbatim from the captured `get-session` payload described in the header.
+ * Kept whole — including the better-auth bookkeeping columns — so that what is
+ * asserted is a real session face and not a hand-picked subset of one. Note
+ * what is NOT here: `roles`.
+ */
+const V17_PERMISSION_SET_ADMIN = {
+  name: 'PermSet Admin',
+  email: 'psadmin@example.com',
+  emailVerified: false,
+  image: null,
+  createdAt: '2026-08-20T16:25:18.056Z',
+  updatedAt: '2026-08-20T16:26:10.016Z',
+  role: 'user',
+  banned: false,
+  banReason: null,
+  banExpires: null,
+  id: 'gwDZFnqdUQGFnOUh3IRWdWqykCw33eVl',
+  positions: ['user', 'platform_admin'],
+  isPlatformAdmin: true,
+} as unknown as AuthUser;
+
+/** The same server, same shape, for an account holding no admin grant at all. */
+const V17_ORDINARY_MEMBER = {
+  name: 'Ordinary Member',
+  email: 'member@example.com',
+  emailVerified: false,
+  image: null,
+  role: 'user',
+  id: 'u_ordinary',
+  positions: ['user', 'org_member'],
+  isPlatformAdmin: false,
+} as unknown as AuthUser;
+
+const ORG = { id: 'org_1', name: 'Acme', slug: 'acme' };
+
+/**
+ * Implements only the methods the provider reaches on these paths, with the
+ * same one-place cast every other double in this package uses.
+ *
+ * The default wiring is the ORG-LESS deployment: `listOrganizations` answers
+ * empty, so `activeOrganization` stays null and the provider never asks for an
+ * active member — which is how the real server behaved above (400
+ * NO_ACTIVE_ORGANIZATION). Cases that need leg 1 pass an org and a member row.
+ */
+function createMockClient(user: AuthUser, overrides: Partial<AuthClient> = {}): AuthClient {
+  return {
+    getSession: vi.fn().mockResolvedValue({ user, session: { token: 'tok-5389' } }),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    listOrganizations: vi.fn().mockResolvedValue([]),
+    getActiveOrganization: vi.fn().mockResolvedValue(null),
+    setActiveOrganization: vi.fn().mockResolvedValue(null),
+    getActiveMember: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  } as unknown as AuthClient;
+}
+
+/**
+ * Renders exactly what every gated console surface renders, plus the two
+ * provider-state markers the waits below need. `user-id` and `member-role` are
+ * not assertions of their own; they exist so a case can wait for the input it
+ * supplies to have ARRIVED before reading the verdict.
+ */
+function AdminProbe() {
+  const isAdmin = useIsWorkspaceAdmin();
+  const { user, activeMember } = useAuth();
+  return (
+    <div>
+      <span data-testid="is-admin">{String(isAdmin)}</span>
+      <span data-testid="user-id">{user?.id ?? 'none'}</span>
+      <span data-testid="member-role">{activeMember?.role ?? 'none'}</span>
+    </div>
+  );
+}
+
+/**
+ * Mount, wait for the session to have LANDED, and return the verdict.
+ *
+ * The wait is on the session's `user` arriving, never on the verdict itself:
+ * waiting for the verdict would make every negative case pass instantly against
+ * the pre-session state, where `user` is null and the answer is `false` for a
+ * reason that has nothing to do with what is being asserted.
+ *
+ * `expectMember` additionally waits for the active-member row, for the cases
+ * that supply one: `activeMember` lands one effect later than `user`, so a leg-1
+ * case read without this would be measuring the moment before its own input
+ * exists.
+ */
+async function mountAndRead(
+  client: AuthClient,
+  opts: { expectMember?: string } = {},
+): Promise<string> {
+  render(
+    <AuthProvider authUrl="/api/v1/auth" client={client}>
+      <AdminProbe />
+    </AuthProvider>,
+  );
+  await waitFor(() => {
+    expect(screen.getByTestId('user-id').textContent).not.toBe('none');
+  });
+  if (opts.expectMember) {
+    await waitFor(() => {
+      expect(screen.getByTestId('member-role').textContent).toBe(opts.expectMember);
+    });
+  }
+  return screen.getByTestId('is-admin').textContent ?? '';
+}
+
+describe('useIsWorkspaceAdmin — the v17 session face publishes `positions` (#5389)', () => {
+  describe('the reported defect', () => {
+    it('detects a permission-set-derived platform admin with no member row and no admin scalar', async () => {
+      const client = createMockClient(V17_PERMISSION_SET_ADMIN);
+
+      expect(await mountAndRead(client)).toBe('true');
+    });
+
+    it('the captured payload really does lack the retired `roles` key', () => {
+      // Guards the fixture itself: if someone "helpfully" adds `roles` back to
+      // the constant above, the case above would start passing through a leg
+      // that no server feeds, and would stop measuring anything.
+      expect(
+        Object.prototype.hasOwnProperty.call(V17_PERMISSION_SET_ADMIN, 'roles'),
+      ).toBe(false);
+      expect((V17_PERMISSION_SET_ADMIN as { positions?: string[] }).positions)
+        .toEqual(['user', 'platform_admin']);
+    });
+  });
+
+  describe('the legs that already worked must keep working', () => {
+    it('leg 1 — an active organization member row with an admin role still detects', async () => {
+      // No `positions` at all on this user: the verdict has to come from the
+      // member row, exactly as it did before this change.
+      const orgAdmin = {
+        id: 'u_orgowner',
+        name: 'Org Owner',
+        email: 'owner@example.com',
+      } as unknown as AuthUser;
+      const client = createMockClient(orgAdmin, {
+        listOrganizations: vi.fn().mockResolvedValue([ORG]),
+        getActiveOrganization: vi.fn().mockResolvedValue(ORG),
+        getActiveMember: vi.fn().mockResolvedValue({
+          id: 'mem_1',
+          organizationId: ORG.id,
+          userId: 'u_orgowner',
+          role: 'owner',
+        }),
+      });
+
+      expect(await mountAndRead(client, { expectMember: 'owner' })).toBe('true');
+    });
+
+    it('leg 2 — a stored `user.role` admin scalar still detects', async () => {
+      const scalarAdmin = {
+        id: 'u_scalar',
+        name: 'Scalar Admin',
+        email: 'scalar@example.com',
+        role: 'admin',
+      } as unknown as AuthUser;
+
+      expect(await mountAndRead(createMockClient(scalarAdmin))).toBe('true');
+    });
+
+    it('preview mode still seeds an admin', async () => {
+      render(
+        <AuthProvider authUrl="/api/v1/auth" previewMode={{ simulatedRole: 'admin' }}>
+          <AdminProbe />
+        </AuthProvider>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('is-admin').textContent).toBe('true');
+      });
+    });
+  });
+
+  describe('nobody new becomes an admin', () => {
+    it('an ordinary member reads as NOT admin through every leg', async () => {
+      const client = createMockClient(V17_ORDINARY_MEMBER, {
+        listOrganizations: vi.fn().mockResolvedValue([ORG]),
+        getActiveOrganization: vi.fn().mockResolvedValue(ORG),
+        getActiveMember: vi.fn().mockResolvedValue({
+          id: 'mem_2',
+          organizationId: ORG.id,
+          userId: 'u_ordinary',
+          role: 'member',
+        }),
+      });
+
+      expect(await mountAndRead(client, { expectMember: 'member' })).toBe('false');
+    });
+
+    it('an empty `positions` array admits nobody', async () => {
+      const noPositions = {
+        id: 'u_empty',
+        name: 'Empty',
+        email: 'empty@example.com',
+        role: 'user',
+        positions: [],
+        isPlatformAdmin: false,
+      } as unknown as AuthUser;
+
+      expect(await mountAndRead(createMockClient(noPositions))).toBe('false');
+    });
+
+    it('a session carrying no `positions` key at all admits nobody', async () => {
+      const preAdr0090 = {
+        id: 'u_old',
+        name: 'Old Server',
+        email: 'old@example.com',
+        role: 'user',
+      } as unknown as AuthUser;
+
+      expect(await mountAndRead(createMockClient(preAdr0090))).toBe('false');
+    });
+
+    it('the retired `roles` spelling alone does NOT confer admin', async () => {
+      // framework ADR-0090 D3 renamed `roles` to `positions` with no
+      // deprecation window, and its declaration bans resurrecting `roles` as a
+      // fallback. `positions` is the one published spelling; a consumer that
+      // honoured both would fossilize a second dialect for one fact and let the
+      // two disagree. If someone ever adds `roles ?? positions`, this fails.
+      const deadSpellingOnly = {
+        id: 'u_dead',
+        name: 'Dead Spelling',
+        email: 'dead@example.com',
+        role: 'user',
+        roles: ['platform_admin', 'org_owner'],
+      } as unknown as AuthUser;
+
+      expect(await mountAndRead(createMockClient(deadSpellingOnly))).toBe('false');
+    });
+  });
+});

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -65,7 +65,23 @@ export interface AuthUser extends SpecAuthUser {
   image?: string;
   /** Primary role */
   role?: string;
-  /** All assigned roles */
+  /**
+   * NOT emitted by the protocol-17 session face. Framework ADR-0090 D3 renamed
+   * this to `positions` with no deprecation window; `GET /auth/get-session`
+   * carries `positions` (inherited here from the spec's `AuthUser`, so it
+   * cannot drift) plus the derived `isPlatformAdmin`, and no `roles` key at
+   * all — measured on a live 17.1.0 server in objectui#5389.
+   *
+   * Kept declared only because one live reader still compiles against it:
+   * `AuthGuard`'s `requiredRoles` check. Deleting the key today fails that file
+   * with TS2339 (the index signature below types the read as `unknown`), so
+   * retiring it is gated on objectui#5424, which owns that decision and the
+   * three other surviving read sites.
+   *
+   * Do NOT reach for this key in new code, and do not pair it with `positions`
+   * as a fallback: `positions` is the one published spelling, and reviving this
+   * one as an alias is what ADR-0090 D3 forbids.
+   */
   roles?: string[];
   /** Email verification status */
   emailVerified?: boolean;

--- a/packages/auth/src/useIsWorkspaceAdmin.ts
+++ b/packages/auth/src/useIsWorkspaceAdmin.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useAuth } from './useAuth.js';
+import { useAuth } from './useAuth';
 
 const ADMIN_ROLES = new Set([
   'owner',
@@ -15,7 +15,7 @@ const ADMIN_ROLES = new Set([
   'superadmin',
   'platform_admin',
   'system_admin',
-  // ADR-0068 canonical role names emitted into `user.roles[]` by the server
+  // ADR-0068 canonical names, emitted into `user.positions[]` by the server's
   // customSession (raw better-auth owner/admin are normalized to org_owner/
   // org_admin). Accept both raw and canonical so admin detection survives the
   // removal of the `user.role = 'admin'` overwrite footgun.
@@ -23,6 +23,13 @@ const ADMIN_ROLES = new Set([
   'org_admin',
 ]);
 
+/**
+ * One name from any of the three sources below — a membership role, the stored
+ * `user.role` scalar, or an entry of `user.positions[]`. The three draw on one
+ * vocabulary by design (ADR-0068 D2 maps a membership `owner`/`admin` onto the
+ * canonical `org_owner`/`org_admin` that `positions[]` carries), so one
+ * predicate serves all three.
+ */
 function isAdminRole(role: unknown): boolean {
   return typeof role === 'string' && ADMIN_ROLES.has(role.toLowerCase());
 }
@@ -32,9 +39,25 @@ function isAdminRole(role: unknown): boolean {
  *
  * Sources considered (any one is sufficient):
  *  - The active organization member row (multi-tenant mode).
- *  - The top-level `user.role` / `user.roles` from the session — this covers
- *    platform / system administrators in single-tenant deployments where
- *    there is no `activeMember` row to read a role from.
+ *  - The top-level `user.role` scalar from the session — legacy deployments
+ *    that still store an admin role on the user row.
+ *  - `user.positions[]` from the session — the canonical identity/position
+ *    names the server derives (ADR-0068 D1/D2, renamed from `roles` by
+ *    ADR-0090 D3). This is the ONLY leg that sees a platform administrator
+ *    whose adminship comes from the `admin_full_access` permission set: on a
+ *    single-tenant deployment there is no member row to read (leg 1), and the
+ *    server deliberately no longer overwrites `user.role` (leg 2), so
+ *    `positions` carrying `platform_admin` is the whole signal. Measured on a
+ *    live protocol-17 server in objectui#5389; pinned by
+ *    `__tests__/workspaceAdminPositions-5389.test.tsx`.
+ *
+ * `positions` is the ONE published spelling. It is deliberately not read
+ * alongside the retired `roles` (ADR-0090 D3 renamed with no deprecation
+ * window and bans resurrecting the old name as a fallback), and not alongside
+ * the derived `user.isPlatformAdmin` either — that flag is computed by the
+ * server as `'platform_admin' in positions` from the same expression, so
+ * reading both would be two spellings for one fact with no way to disagree
+ * usefully and every way to drift.
  *
  * In preview-mode / no-auth-enabled mode the provider seeds an admin user,
  * so this returns `true` for dev/demo setups.
@@ -43,6 +66,7 @@ export function useIsWorkspaceAdmin(): boolean {
   const { activeMember, user } = useAuth();
   if (isAdminRole(activeMember?.role)) return true;
   if (isAdminRole(user?.role)) return true;
-  if (Array.isArray(user?.roles) && user!.roles!.some(isAdminRole)) return true;
+  const positions = user?.positions;
+  if (Array.isArray(positions) && positions.some(isAdminRole)) return true;
   return false;
 }

--- a/packages/auth/src/useIsWorkspaceAdmin.ts
+++ b/packages/auth/src/useIsWorkspaceAdmin.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useAuth } from './useAuth';
+import { useAuth } from './useAuth.js';
 
 const ADMIN_ROLES = new Set([
   'owner',


### PR DESCRIPTION
Fixes #5389

Local gate union re-run on the final commit **`8623e13ea`** — see "Verification" below. Nothing here waits on CI; the PM reads the real gate conclusions after this lands as a draft.

## The card said there was no runtime reproduction. There is one now.

The dispatch order made measuring the first step, so before touching anything I booted a real single-tenant server on the **published** `@objectstack/cli` / `@objectstack/plugin-auth` **17.1.0** (`objectstack dev --seed-admin --fresh`, banner reports `Tenancy: single`, no organizations plugin among the 30 loaded) and built the exact deployment shape the card names: a platform administrator whose adminship comes from the `admin_full_access` permission set (a `sys_user_permission_set` row with `organization_id = NULL`, what `bootstrapPlatformAdmin` seeds), with no `sys_member` row and no admin scalar on the user row.

`GET /api/v1/auth/get-session` answered:

```json
{
  "user": {
    "id": "gwDZFnqdUQGFnOUh3IRWdWqykCw33eVl",
    "email": "psadmin@example.com",
    "role": "user",
    "positions": ["user", "platform_admin"],
    "isPlatformAdmin": true
  },
  "session": { "activeOrganizationId": null }
}
```

`Object.prototype.hasOwnProperty.call(user, 'roles')` on that payload answers **false**, and `organization/get-active-member` answers `400 NO_ACTIVE_ORGANIZATION`. So all three legs of the hook missed:

| leg | reads | value on the wire | verdict |
|---|---|---|---|
| 1 | `activeMember.role` | no member row at all | no |
| 2 | `user.role` | `"user"` | no |
| 3 | `user.roles` | **key absent** (ADR-0090 D3 renamed it) | no |

The hook returned `false` for a platform administrator: Setup and Studio vanish, the marketplace gates shut, the "Build an app" CTAs disappear. **The premise holds and the defect is real.** The captured payload is now the test fixture, verbatim.

The producer half is confirmed at the artifact too, not just at the wire: `@objectstack/plugin-auth@17.1.0`'s bundled `customSession` returns exactly `user: { ...user, positions, isPlatformAdmin: platformAdmin, ...authGate ? { authGate } : {} }`, and no `roles` key appears anywhere in its emission path.

## The fix

Leg 3 now reads `user.positions[]` — the one spelling the session publishes, and one this repository does not hand-copy: it is inherited from the spec's own `AuthUser` through `AuthUser extends SpecAuthUser`, so it cannot drift the way the mirror key did.

Deliberately **not** done, per the card and AGENTS.md commandment #0.1:

- **No `roles ?? positions` dual spelling.** ADR-0090 D3 renamed with no deprecation window and bans reviving the old name as a fallback. A negative case pins this: a session carrying only the retired spelling reads as **not** an administrator. That case failed before the fix (the old leg 3 honoured it) and passes now.
- **`isPlatformAdmin` is not read alongside `positions`.** The server computes it as `'platform_admin' in positions` in the same expression, so the two cannot usefully disagree — reading both would be two spellings for one fact, and `positions` additionally covers the `org_owner` / `org_admin` names that the boolean does not.

## Nobody new becomes an administrator

This is an authorization-adjacent read, and the positive case alone cannot distinguish a restored detection from a widened one — "return `true` more often" also makes it green. Four negative cases exist to make that substitution fail:

- an ordinary member (`positions: ["user", "org_member"]`, member row with role `member`) reads as **not** admin through every leg;
- an empty `positions` array admits nobody;
- a session carrying no `positions` key at all admits nobody;
- the retired `roles` spelling alone confers nothing.

And the two legs that were never broken get cases of their own, so a swap of one dead read for one live read cannot disturb them unnoticed: an active member row with an admin role still detects, a stored `user.role` admin scalar still detects, and preview mode still seeds an admin.

Worth stating because it is the reason nothing widened: `positions` at protocol 17 carries exactly what `roles` carried at 16 — the stored scalar split on commas, the active membership mapped to canonical `org_owner`/`org_admin`/`org_member`, and `platform_admin` when the permission set is held. This is a rename, so restoring the read restores the pre-rename semantics rather than adding to them.

## Reverse verification (predicted before running, both directions)

Written test-first. Predicted **2 failures** on the pre-fix tree: the platform-admin case (`true` expected, `false` observed) and the dead-spelling pin (`false` expected, `true` observed, because leg 3 still honoured `roles`). Observed exactly those two, in exactly those directions, 7 others passing:

```
× detects a permission-set-derived platform admin with no member row and no admin scalar
    AssertionError: expected 'false' to be 'true'
× the retired `roles` spelling alone does NOT confer admin
    AssertionError: expected 'true' to be 'false'
  Tests  2 failed | 7 passed (9)
```

After the fix: `Tests 9 passed (9)`.

**No build artifact sits between the edit and the thing under test, on any leg.** The root `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src/`, and `packages/auth/src` has no runtime workspace import at all — its only cross-package dependency is a type-only import from `@objectstack/spec`, erased before execution. So the red and the green were both read off source, and no ablation needed a rebuild to be trustworthy.

## The one thing the card asked for that could not be done

The card proposed retiring the dead `roles?: string[]` mirror key on the client `AuthUser` in the same pass. **It is not dead.** Removing it fails compilation:

```
src/AuthGuard.tsx(59,60): error TS2339: Property 'includes' does not exist on type '{}'
```

`AuthGuard`'s `requiredRoles` check still reads it, and once the declaration is gone `AuthUser`'s index signature types the read as `unknown`. That is a live reader, not a leftover, so the key keeps its declaration and gains a docblock stating what it actually is — absent from the v17 session face, kept for one compile-time reader, and not to be paired with `positions` as a fallback.

Chasing it further would have meant editing an authorization gate the card explicitly scoped out, and `requiredRoles` is not a mechanical rename anyway (whether it should read `positions`, whether it keeps the scalar fallback, and how it relates to `packages/permissions`' separate `roles` surface are open questions). Filed separately as **#5424** together with three other surviving read sites, which is where that decision belongs. Out of scope for this PR; #5424 stays open.

## Also in this PR, and why each is in scope rather than filed

Both are comment-only, in the same defect class (documentation naming the removed spelling), mechanically determined by the rename, and inside the same gate family — no new verification surface:

- `packages/app-shell/src/console/home/HomePage.tsx` — the "`useIsWorkspaceAdmin` reads ROLES" comment named in the card. The ruling it records is **unchanged**: the EE workspace owner it describes holds `org_owner`, which is in `positions` too, so the sentence needed a spelling correction and not a semantic one.
- `packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx` — carries the same sentence, one file over. Correcting one and leaving the other would have left the card's own stale claim standing in the file that pins the behaviour. Named here because a drive-by fix nobody points at is unreviewable scope creep; this one is pointed at.

Attribution correction for the record: the card locates that comment at `apps/console/.../HomePage.tsx:82`; it actually lives at `packages/app-shell/src/console/home/HomePage.tsx:82`.

## Verification

All re-run against the final commit `8623e13ea` with a clean tree, so these results describe the tree being reviewed:

| gate | result |
|---|---|
| `vitest run packages/auth/ packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx` | 19 files, **196 passed** |
| `pnpm --filter @object-ui/auth type-check` (`tsc --noEmit` + `tsc -p tsconfig.test.json`) | pass |
| `eslint` on all 5 changed files | 0 errors (8 pre-existing `no-explicit-any` warnings on untouched lines) |
| `check-changeset-presence.mjs` | pass |
| `check-changeset-no-major.mjs` | pass — `patch` |
| `check-control-bytes.mjs` | pass (4487 files) |
| `check-node-esm-load.mjs --specifiers-only` | pass |
| `check-package-self-import.mjs` | pass |

Test invocation was from the repository root with repo-relative paths and no `--` separator, per AGENTS.md. Heavy steps ran under the shared `/tmp/os-heavy-verify.lock`.

The full lint/CI farm is left to CI, which runs it exactly once regardless.

## Landing

Draft, and auto-merge is deliberately **not** enabled — the PM lands this. `target:v17`, release-blocking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_