### PR TITLE
fix(plugin-dashboard): one header spelling across the table widget family; pin dashboard dimension-member labels

### DIFF
--- a/.changeset/dashboard-table-header-one-spelling-5425.md
+++ b/.changeset/dashboard-table-header-one-spelling-5425.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+A dashboard table's auto-derived column headers spell a field key the same way every other path in the `table` widget family does.
+
+`ObjectDataTable` derives headers on two paths — from the author's declared
+`columns`, and from the object schema when no columns were declared. The
+declared path (and the static `data-table` half of the same widget family)
+already used `humanizeFieldKey`, whose docstring names it "the single home for
+the convention, because both halves of the `table` widget family need it and
+they must agree". The auto-derived path carried a third, inline spelling that
+split camelCase but never turned `_` into a space, so it left a raw underscore
+on screen. Measured over the same object's columns:
+
+```
+path                                     close_date    needs_analysis
+object-bound, AUTO-DERIVED   (before)    Close_date    Needs_analysis
+object-bound, AUTO-DERIVED   (after)     Close Date    Needs Analysis
+object-bound, DECLARED columns           Close Date    Needs Analysis
+static `data-table`, no columns          Close Date    Needs Analysis
+```
+
+One dashboard can hold all three widgets over one object, so a single field key
+rendered under two spellings — the defect class objectui#5425 rules out. The odd
+path adopts the shared convention rather than the convention gaining a fourth
+dialect. camelCase keys are unaffected (`unitPrice` read `Unit Price` before and
+after — the coincidence that kept the snake_case divergence unnoticed), and a
+translated header still wins: only the fallback handed to `fieldLabel` changed.
+
+Dimension MEMBER labels are untouched by this. The same card reported dashboard
+members rendering a prettified enum instead of the picklist's translated label,
+measured on 17.1.0; re-measured on this branch it no longer reproduces — the
+analytics label net shipped in 17.5.0 routes every non-metric dataset dimension
+through the field's declared options and the locale bundle. That behaviour had
+no test stated in the card's terms and now has one, over the four dashboards the
+card measured, including the property that a bar axis and a pivot header cannot
+disagree about one stored value.

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -311,8 +311,28 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
       }
     }
 
+    // The AUTO-DERIVED half of this widget's headers. It spells the convention
+    // with `humanizeFieldKey` — the same function `normalizeColumns` (the
+    // DECLARED half, above) and `deriveStaticTableColumns` (the static half of
+    // the same `table` widget family) already use, whose docstring names itself
+    // the single home for this convention "because both halves of the `table`
+    // widget family need it and they must agree".
+    //
+    // This line used to carry a THIRD, inline spelling that split camelCase but
+    // never turned `_` into a space, so one field key rendered under two
+    // spellings on one dashboard — measured, as headers over the same
+    // `crm_opportunity` columns (objectui#5425):
+    //
+    //   auto-derived (here)                 Close_date · Needs_analysis
+    //   declared `columns: ['close_date']`  Close Date · Needs Analysis
+    //   static `data-table`, no columns     Close Date · Needs Analysis
+    //
+    // That is the defect class objectui#5425 rules out — "a value cannot appear
+    // twice under two spellings" — so the odd one out adopts the convention
+    // rather than the convention gaining a fourth dialect. The i18n wrapper is
+    // unchanged: a bundle entry still wins, and this is only its fallback.
     const buildHeader = (k: string) => {
-      const humanized = k.charAt(0).toUpperCase() + k.slice(1).replace(/([A-Z])/g, ' $1');
+      const humanized = humanizeFieldKey(k);
       return objectName ? fieldLabel(objectName, k, humanized) : humanized;
     };
 

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.dimensionMemberLabels.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.dimensionMemberLabels.test.tsx
@@ -1,0 +1,408 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5425 (rendering half of objectstack#10292, maintainer ruling
+ * 2026-08-20) — a dashboard's dimension MEMBERS must resolve through the
+ * backing picklist field's declared options, and therefore through that
+ * field's translations; the prettified enum stays a fallback for genuinely
+ * free-form columns only. And one stored value must not appear under two
+ * spellings on one dashboard.
+ *
+ * ## What this file is, and why it is a pin rather than a fix
+ *
+ * The card was measured on **17.1.0**. Re-measured on `main` (17.6.0) the
+ * reported rendering no longer reproduces: the analytics label net shipped in
+ * **17.5.0** (objectui#4030 / PR #4324 for charts and dotted dimensions,
+ * objectui#4330 for local selects on table/pivot, objectui#4389 lifting the
+ * shared glue) already routes every non-metric dataset dimension through
+ * `resolveDimensionFieldMeta` → `buildDimensionLabelMap` → `relabelDimensions`
+ * with the locale bundle applied. Both of the card's defects are consequences
+ * of that net being absent, so both went with it.
+ *
+ * What did NOT exist was a test stated in the card's own terms — the four
+ * measured widgets, their measured member values, in a zh-CN session — so
+ * nothing would have failed if the net regressed. That is what this file adds.
+ * It is a characterization pin, and its ablation is recorded below.
+ *
+ * ## Provenance of the two spellings the card measured
+ *
+ * The card reports `NeedsAnalysis` on the bar axis and `Needs Analysis` in the
+ * pivot row label and calls them "two prettifiers". Run over the card's own
+ * stored value, that is exactly what the two functions `git grep` finds do:
+ *
+ *   humanizeLabel     ('NeedsAnalysis') → 'NeedsAnalysis'   ← plugin-charts/ObjectChart.tsx
+ *   humanizeFieldKey  ('NeedsAnalysis') → 'Needs Analysis'  ← plugin-dashboard/utils.ts
+ *
+ * `humanizeLabel` maps `[_-]` to spaces and title-cases word boundaries, so a
+ * PascalCase stored value passes through untouched; `humanizeFieldKey` also
+ * splits camelCase, so the same value gains a space. Neither is reachable from
+ * a dataset dimension member today — the dataset path prettifies nothing, it
+ * relabels through the option map and otherwise renders the value as stored —
+ * which is why the two spellings cannot recur on this surface. The residual
+ * disagreement between those functions is a HEADER-family concern and is
+ * pinned separately in `ObjectDataTable.headerSpelling.test.tsx`.
+ *
+ * ## DIRECTIONS, written before the ablation was run
+ *
+ * These assertions pin behaviour that already exists, so they are GREEN on
+ * unmodified `main` — that is the finding, not a defect in the pins. To show
+ * they are load-bearing rather than phantom, the ablation removes the locale
+ * seam at its single wiring point in `DatasetWidget` (passing `undefined` for
+ * `fieldOptionLabel` into `deriveDimensionLabelMaps`). Predicted: every zh-CN
+ * member assertion turns RED and reads the object's authored English label —
+ * the exact 17.1.0 symptom — while the free-form fallback pin and the
+ * bar/pivot agreement pin stay GREEN, because neither depends on the bundle.
+ * Measured result recorded in the PR body.
+ *
+ * No `dist/` is involved: the root `vitest.config.mts` aliases every
+ * `@object-ui/*` specifier to that package's `src/`, and this file imports
+ * `../DatasetWidget` relatively, so both ablation legs read source directly.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { DatasetWidget } from '../DatasetWidget';
+
+/** Capture what the widget hands the chart renderer (jsdom lays out no SVG). */
+let capturedChartProps: any = null;
+beforeAll(() => {
+  ComponentRegistry.register('chart', (props: any) => {
+    capturedChartProps = props;
+    return null;
+  });
+});
+
+vi.mock('../DrillDownDrawer', () => ({ DrillDownDrawer: () => null }));
+
+afterEach(() => {
+  cleanup();
+  capturedChartProps = null;
+  vi.restoreAllMocks();
+});
+
+/**
+ * The card's object, carrying the four dimensions its four widgets group by.
+ *
+ * Two storage conventions are represented deliberately, because the card's
+ * measurement contains both: `stage` / `forecast_category` store an opaque
+ * PascalCase code whose authored label differs from it, while `lead_source` /
+ * `loss_reason` store the display string itself. `buildDimensionLabelMap` keys
+ * the map by BOTH the stored value and the authored label, so the same net has
+ * to serve both — and a regression that only handled one would slip past a
+ * fixture that only contained one.
+ */
+const OPPORTUNITY = {
+  name: 'crm_opportunity',
+  fields: {
+    stage: {
+      type: 'select',
+      options: [
+        { value: 'NeedsAnalysis', label: 'Needs Analysis' },
+        { value: 'Negotiation', label: 'Negotiation' },
+        { value: 'Proposal', label: 'Proposal' },
+      ],
+    },
+    forecast_category: {
+      type: 'select',
+      options: [
+        { value: 'BestCase', label: 'Best Case' },
+        { value: 'Commit', label: 'Commit' },
+      ],
+    },
+    lead_source: {
+      type: 'select',
+      options: [
+        { value: 'Content / Blog', label: 'Content / Blog' },
+        { value: 'Email Campaign', label: 'Email Campaign' },
+        { value: 'Event / Trade Show', label: 'Event / Trade Show' },
+        { value: 'Partner', label: 'Partner' },
+        { value: 'Referral', label: 'Referral' },
+        { value: 'Web', label: 'Web' },
+      ],
+    },
+    loss_reason: {
+      type: 'select',
+      options: [
+        { value: 'Bad Timing', label: 'Bad Timing' },
+        { value: 'Lost to Competitor', label: 'Lost to Competitor' },
+        { value: 'Missing Features', label: 'Missing Features' },
+        { value: 'No Budget', label: 'No Budget' },
+        { value: 'Price Too High', label: 'Price Too High' },
+      ],
+    },
+    /** A genuinely free-form column: no options, so nothing to resolve through. */
+    owner_note: { type: 'text' },
+    owner: { type: 'text' },
+  },
+};
+
+/**
+ * The zh-CN bundle, on the one channel list, form and kanban surfaces already
+ * read select options through: `{ns}.fieldOptions.<object>.<field>.<value>`.
+ * `fields` sits beside it because that is what makes `crm` discoverable as an
+ * app namespace.
+ */
+const ZH_BUNDLE = {
+  zh: {
+    crm: {
+      fields: {
+        crm_opportunity: {
+          stage: '阶段',
+          forecast_category: '预测类别',
+          lead_source: '线索来源',
+          loss_reason: '丢单原因',
+        },
+      },
+      fieldOptions: {
+        crm_opportunity: {
+          stage: { NeedsAnalysis: '需求分析', Negotiation: '谈判', Proposal: '提案' },
+          forecast_category: { BestCase: '最佳情况', Commit: '承诺' },
+          lead_source: {
+            'Content / Blog': '内容 / 博客',
+            'Email Campaign': '邮件营销',
+            'Event / Trade Show': '活动 / 展会',
+            Partner: '合作伙伴',
+            Referral: '推荐',
+            Web: '网站',
+          },
+          loss_reason: {
+            'Bad Timing': '时机不合适',
+            'Lost to Competitor': '输给竞争对手',
+            'Missing Features': '功能缺失',
+            'No Budget': '预算不足',
+            'Price Too High': '价格过高',
+          },
+        },
+      },
+    },
+  },
+};
+
+function installMetaRouter(docs: Record<string, unknown>) {
+  const requested: string[] = [];
+  global.fetch = vi.fn(async (input: unknown) => {
+    const m = /\/api\/v1\/meta\/object\/(.+)$/.exec(String(input));
+    const name = m ? decodeURIComponent(m[1]) : '';
+    requested.push(name);
+    const doc = docs[name];
+    if (!doc) return { ok: false, json: async () => ({}) };
+    return { ok: true, json: async () => ({ item: doc }) };
+  }) as any;
+  return { requested };
+}
+
+const sourceOf = (result: unknown) => ({ queryDataset: vi.fn(async () => result) });
+
+function renderIn(language: string, ui: React.ReactElement) {
+  return render(
+    <I18nProvider
+      config={{ defaultLanguage: language, detectBrowserLanguage: false, resources: ZH_BUNDLE }}
+    >
+      {ui}
+    </I18nProvider>,
+  );
+}
+
+/** A one-dimension bar widget over `dim`, with rows keyed by `values`. */
+function barOver(dim: string, values: string[]) {
+  return {
+    widget: { type: 'bar', dataset: 'sales', dimensions: [dim], values: ['opp_count'] },
+    dataSource: sourceOf({
+      rows: values.map((v, i) => ({ [dim]: v, opp_count: i + 1 })),
+      fields: [
+        // `type: 'string'` deliberately: that is what a select dimension is on
+        // the wire — `AnalyticsResult.fields[]` has no `select` member.
+        { name: dim, type: 'string', label: dim },
+        { name: 'opp_count', type: 'number', label: 'Opportunities' },
+      ],
+      object: 'crm_opportunity',
+      dimensionFields: { [dim]: dim },
+    }),
+  };
+}
+
+/** The categories the widget handed the chart renderer, in order. */
+const categories = (dim: string): string[] =>
+  (capturedChartProps?.schema?.data ?? []).map((r: any) => r[dim]);
+
+describe('objectui#5425 — the four measured dashboards render translated picklist labels', () => {
+  it('阶段管道分布 — an opaque stored code resolves through the option label', async () => {
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('stage', ['NeedsAnalysis', 'Negotiation', 'Proposal']);
+    renderIn('zh', <DatasetWidget widget={widget} dataSource={dataSource} />);
+
+    await waitFor(() => expect(categories('stage')).toEqual(['需求分析', '谈判', '提案']));
+    // The card's measured spelling must not survive beside the translation.
+    expect(categories('stage')).not.toContain('NeedsAnalysis');
+  });
+
+  it('预测类别管道分布 — same, on the second opaque-code dimension', async () => {
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('forecast_category', ['BestCase', 'Commit']);
+    renderIn('zh', <DatasetWidget widget={widget} dataSource={dataSource} />);
+
+    await waitFor(() => expect(categories('forecast_category')).toEqual(['最佳情况', '承诺']));
+    expect(categories('forecast_category')).not.toContain('BestCase');
+  });
+
+  it('线索来源分布 — a value stored AS its display string still translates', async () => {
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('lead_source', [
+      'Content / Blog',
+      'Email Campaign',
+      'Event / Trade Show',
+      'Partner',
+      'Referral',
+      'Web',
+    ]);
+    renderIn('zh', <DatasetWidget widget={widget} dataSource={dataSource} />);
+
+    await waitFor(() =>
+      expect(categories('lead_source')).toEqual([
+        '内容 / 博客',
+        '邮件营销',
+        '活动 / 展会',
+        '合作伙伴',
+        '推荐',
+        '网站',
+      ]),
+    );
+  });
+
+  it('丢单原因分析 — same, on the fourth measured dimension', async () => {
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('loss_reason', [
+      'Bad Timing',
+      'Lost to Competitor',
+      'Missing Features',
+      'No Budget',
+      'Price Too High',
+    ]);
+    renderIn('zh', <DatasetWidget widget={widget} dataSource={dataSource} />);
+
+    await waitFor(() =>
+      expect(categories('loss_reason')).toEqual([
+        '时机不合适',
+        '输给竞争对手',
+        '功能缺失',
+        '预算不足',
+        '价格过高',
+      ]),
+    );
+    expect(document.body.textContent).not.toContain('Lost to Competitor');
+  });
+
+  it('BOUNDARY — a genuinely free-form column keeps the value as stored', async () => {
+    // The card's own carve-out: the fallback survives for columns with no
+    // declared options. Green in both ablation legs — it never consults the
+    // bundle — which is what makes it a boundary rather than a restatement.
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('owner_note', ['renewal risk', 'needs_analysis']);
+    renderIn('zh', <DatasetWidget widget={widget} dataSource={dataSource} />);
+
+    await waitFor(() =>
+      expect(categories('owner_note')).toEqual(['renewal risk', 'needs_analysis']),
+    );
+  });
+
+  it('BOUNDARY — an `en` session keeps the object`s authored labels', async () => {
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('stage', ['NeedsAnalysis', 'Negotiation']);
+    renderIn('en', <DatasetWidget widget={widget} dataSource={dataSource} />);
+
+    await waitFor(() => expect(categories('stage')).toEqual(['Needs Analysis', 'Negotiation']));
+    expect(document.body.textContent).not.toContain('需求分析');
+  });
+});
+
+describe('objectui#5425 — one stored value, ONE spelling across bar axis and pivot header', () => {
+  /**
+   * The card's second defect, stated as the property it asks for. The two
+   * surfaces are fed the value in the two shapes they really receive it in:
+   * the chart query returns the dimension UNRESOLVED (the stored code), while
+   * a table/pivot query returns it SERVER-RESOLVED to the object's authored
+   * English label (ADR-0021). Those are the two inputs that produced the card's
+   * two spellings; they must now produce one.
+   */
+  const STORED = 'NeedsAnalysis';
+  const SERVER_RESOLVED = 'Needs Analysis';
+
+  it('the bar axis and the pivot header agree on the same stored value', async () => {
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('stage', [STORED]);
+    renderIn('zh', <DatasetWidget widget={widget} dataSource={dataSource} />);
+    await waitFor(() => expect(categories('stage')).toEqual(['需求分析']));
+    const axisSpelling = categories('stage')[0];
+    cleanup();
+
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    renderIn(
+      'zh',
+      <DatasetWidget
+        widget={{
+          type: 'pivot',
+          dataset: 'sales',
+          dimensions: ['owner', 'stage'],
+          values: ['opp_count'],
+        }}
+        dataSource={sourceOf({
+          rows: [{ owner: 'Dev Admin', stage: SERVER_RESOLVED, opp_count: 5 }],
+          fields: [
+            { name: 'owner', type: 'string', label: 'Owner' },
+            { name: 'stage', type: 'string', label: 'Stage' },
+            { name: 'opp_count', type: 'number', label: 'Opportunities' },
+          ],
+          object: 'crm_opportunity',
+          dimensionFields: { owner: 'owner', stage: 'stage' },
+        })}
+      />,
+    );
+
+    await waitFor(() => expect(document.body.textContent).toContain(axisSpelling));
+    // Neither of the card's two measured spellings may reach the screen.
+    expect(document.body.textContent).not.toContain(SERVER_RESOLVED);
+    expect(document.body.textContent).not.toContain(STORED);
+  });
+
+  it('BOUNDARY — a free-form value also gets ONE spelling on both surfaces', async () => {
+    // Green in both ablation legs. The point is that the agreement does not
+    // depend on a bundle entry existing: with no options to resolve through,
+    // BOTH surfaces render the value as stored — neither prettifies it, which
+    // is why `NeedsAnalysis` vs `Needs Analysis` cannot recur here.
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    const { widget, dataSource } = barOver('owner_note', ['needs_analysis']);
+    renderIn('zh', <DatasetWidget widget={widget} dataSource={dataSource} />);
+    await waitFor(() => expect(categories('owner_note')).toEqual(['needs_analysis']));
+    cleanup();
+
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    renderIn(
+      'zh',
+      <DatasetWidget
+        widget={{
+          type: 'pivot',
+          dataset: 'sales',
+          dimensions: ['owner', 'owner_note'],
+          values: ['opp_count'],
+        }}
+        dataSource={sourceOf({
+          rows: [{ owner: 'Dev Admin', owner_note: 'needs_analysis', opp_count: 5 }],
+          fields: [
+            { name: 'owner', type: 'string', label: 'Owner' },
+            { name: 'owner_note', type: 'string', label: 'Note' },
+            { name: 'opp_count', type: 'number', label: 'Opportunities' },
+          ],
+          object: 'crm_opportunity',
+          dimensionFields: { owner: 'owner', owner_note: 'owner_note' },
+        })}
+      />,
+    );
+
+    await waitFor(() => expect(document.body.textContent).toContain('needs_analysis'));
+    // The prettified spellings the card measured must not appear on either side.
+    expect(document.body.textContent).not.toContain('Needs Analysis');
+    expect(document.body.textContent).not.toContain('NeedsAnalysis');
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.dimensionMemberLabels.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.dimensionMemberLabels.test.tsx
@@ -52,7 +52,17 @@
  * member assertion turns RED and reads the object's authored English label —
  * the exact 17.1.0 symptom — while the free-form fallback pin and the
  * bar/pivot agreement pin stay GREEN, because neither depends on the bundle.
- * Measured result recorded in the PR body.
+ *
+ * Measured: the four zh-CN member pins went RED as predicted, and so did the
+ * bar/pivot agreement pin — a SEQUENCING dependency, not an assertion one, and
+ * this line is the correction rather than a re-run to fit the sentence. That
+ * pin captures the axis spelling by first waiting for the translated category,
+ * so it needs the bundle to get past its `waitFor` even though the property it
+ * asserts (the two surfaces agree) is direction-independent. The pin below it
+ * is the direction-independent twin: it agrees over a FREE-FORM value, waits on
+ * no translation, and stayed GREEN in both legs — which is what shows the
+ * agreement itself does not rest on a bundle entry existing. The two remaining
+ * boundaries (free-form fallback, `en` session) stayed GREEN as predicted.
  *
  * No `dist/` is involved: the root `vitest.config.mts` aliases every
  * `@object-ui/*` specifier to that package's `src/`, and this file imports

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.headerSpelling.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.headerSpelling.test.tsx
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5425, second defect — "a value cannot appear twice under two
+ * spellings on one dashboard", applied to the surviving instance of that class
+ * in the widget the card names.
+ *
+ * ## What was measured
+ *
+ * The `table` widget family derives a column header from a field key on three
+ * paths. Two of them called `humanizeFieldKey`, whose own docstring names it
+ * "the single home for the convention, because both halves of the `table`
+ * widget family need it and they must agree". The third — the AUTO-DERIVED
+ * columns of the object-bound half, in `ObjectDataTable` — carried an inline
+ * third spelling that split camelCase but never turned `_` into a space, so it
+ * left a raw underscore in a user-visible header:
+ *
+ *   path                                    close_date     needs_analysis
+ *   ─────────────────────────────────────── ────────────── ────────────────
+ *   object-bound, AUTO-DERIVED (before)     Close_date     Needs_analysis
+ *   object-bound, DECLARED `columns: [...]` Close Date     Needs Analysis
+ *   static `data-table`, no columns         Close Date     Needs Analysis
+ *
+ * One dashboard can hold all three widgets over the same object, so one field
+ * key rendered under two spellings — the card's defect, one step across from
+ * where it was reported. The fix adopts the convention on the odd path out
+ * rather than adding a fourth dialect.
+ *
+ * ## Why the header family and not the member family
+ *
+ * The card's own measurement (`NeedsAnalysis` vs `Needs Analysis` for a
+ * dimension MEMBER) no longer reproduces: dataset dimension members resolve
+ * through the picklist's translated options and reach no prettifier at all —
+ * pinned in `DatasetWidget.dimensionMemberLabels.test.tsx`. The prettifier
+ * family the card pointed at survives only over field KEYS, which is what this
+ * file covers. `humanizeLabel` in `plugin-charts` is deliberately NOT changed
+ * here: it is a byte-identical copy of `@object-ui/fields`' export that
+ * `plugin-grid` / `plugin-gantt` / `plugin-detail` also read, so aligning it
+ * alone would trade one disagreement for another across a package this card
+ * does not own. Recorded as a separate finding.
+ *
+ * ## DIRECTIONS, written before the reverse verification was run
+ *
+ * Predicted RED on `origin/main` for the two auto-derived assertions (they read
+ * `Close_date` / `Needs_analysis`), and GREEN on both sides for the declared,
+ * static and i18n-override assertions — the fix must not move those. The
+ * camelCase row (`unitPrice` → `Unit Price`) is green on both sides too: the
+ * old spelling already agreed there, which is precisely why the disagreement
+ * went unnoticed. Measured result recorded in the PR body.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { ObjectDataTable, normalizeColumns } from '../ObjectDataTable';
+import { deriveStaticTableColumns, humanizeFieldKey } from '../utils';
+
+/** Capture the columns the widget hands the data-table renderer. */
+let captured: any = null;
+beforeAll(() => {
+  ComponentRegistry.register('data-table', (props: any) => {
+    captured = props;
+    return null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  captured = null;
+  vi.restoreAllMocks();
+});
+
+const KEYS = ['close_date', 'needs_analysis', 'unitPrice'];
+const ROW = { close_date: '2026-01-01', needs_analysis: 'x', unitPrice: 3 };
+
+const OPPORTUNITY = {
+  name: 'crm_opportunity',
+  fields: {
+    close_date: { type: 'date' },
+    needs_analysis: { type: 'text' },
+    unitPrice: { type: 'number' },
+  },
+};
+
+const dataSource = {
+  getObjectSchema: async () => OPPORTUNITY,
+  find: async () => [ROW],
+};
+
+const headers = (): string[] => (captured?.schema?.columns ?? []).map((c: any) => c.header);
+
+async function renderTable(schema: Record<string, unknown>, ui?: (node: React.ReactElement) => React.ReactElement) {
+  const node = <ObjectDataTable schema={schema as any} dataSource={dataSource} />;
+  render(ui ? ui(node) : node);
+  await waitFor(() => expect((captured?.schema?.columns ?? []).length).toBeGreaterThan(0));
+}
+
+describe('objectui#5425 — one field key, ONE header spelling across the table family', () => {
+  it('AUTO-DERIVED columns spell the header with the shared convention', async () => {
+    await renderTable({ type: 'object-data-table', objectName: 'crm_opportunity' });
+    expect(headers()).toEqual(['Close Date', 'Needs Analysis', 'Unit Price']);
+    // The pre-fix spelling left a raw underscore on screen.
+    expect(headers()).not.toContain('Close_date');
+    expect(headers()).not.toContain('Needs_analysis');
+  });
+
+  it('AUTO-DERIVED, DECLARED and STATIC paths all agree, key for key', async () => {
+    // The property the card asks for, stated over all three producers at once
+    // rather than as three separate expected strings — a future fourth path
+    // that reintroduces a dialect fails here without anyone updating a literal.
+    await renderTable({ type: 'object-data-table', objectName: 'crm_opportunity' });
+    const auto = headers();
+    cleanup();
+    captured = null;
+
+    await renderTable({ type: 'object-data-table', objectName: 'crm_opportunity', columns: KEYS });
+    const declared = headers();
+
+    const staticHeaders = deriveStaticTableColumns([ROW]).map((c) => c.header);
+    const shorthand = normalizeColumns(KEYS).map((c) => c.header);
+    const convention = KEYS.map(humanizeFieldKey);
+
+    expect(auto).toEqual(convention);
+    expect(declared).toEqual(convention);
+    expect(staticHeaders).toEqual(convention);
+    expect(shorthand).toEqual(convention);
+  });
+
+  it('BOUNDARY — a bundle entry still wins over the derived spelling', async () => {
+    // Green on both sides. The fix touches only the fallback handed to
+    // `fieldLabel`; a translated header must keep overriding it.
+    const resources = {
+      zh: { crm: { fields: { crm_opportunity: { close_date: '结单日期' } } } },
+    };
+    await renderTable({ type: 'object-data-table', objectName: 'crm_opportunity' }, (node) => (
+      <I18nProvider
+        config={{ defaultLanguage: 'zh', detectBrowserLanguage: false, resources }}
+      >
+        {node}
+      </I18nProvider>
+    ));
+    expect(headers()[0]).toBe('结单日期');
+    expect(headers()).not.toContain('Close Date');
+  });
+
+  it('BOUNDARY — camelCase already agreed, and still does', async () => {
+    // Green on both sides: `unitPrice` is where the old inline spelling and the
+    // convention happened to coincide, which is why the divergence on
+    // snake_case keys went unnoticed. Pinned so the fix is not misread as
+    // having changed camelCase behaviour.
+    expect(humanizeFieldKey('unitPrice')).toBe('Unit Price');
+    await renderTable({ type: 'object-data-table', objectName: 'crm_opportunity' });
+    expect(headers()[2]).toBe('Unit Price');
+  });
+});


### PR DESCRIPTION
Part of #5425. **Read the first section before reviewing the diff** — the card's primary premise did not survive re-measurement, and this PR deliberately does not implement what the card asks for.

Verification below was run on `231698b96`, the branch head.

## The fork: defect 1 no longer reproduces

The card was measured on **17.1.0**. Re-measured on `main` (**17.6.0**), dashboard dimension members already resolve through the backing picklist field's declared options and therefore through its translations. The analytics label net that does this shipped in **17.5.0** — objectui#4030 / PR #4324 (charts and dotted dimensions), objectui#4330 (local selects on table and pivot), objectui#4389 (the shared React glue). Every non-metric dataset dimension is routed `resolveDimensionFieldMeta` to `buildDimensionLabelMap` to `relabelDimensions` with the locale bundle applied.

Measured as rendering, which is what the card asks for — a zh-CN session, the card's four widgets, the card's own member values:

| widget | stored values | 17.1.0 (card) | this branch |
|---|---|---|---|
| 阶段管道分布 | `NeedsAnalysis` `Negotiation` `Proposal` | `NeedsAnalysis · Negotiation · Proposal` | 需求分析 · 谈判 · 提案 |
| 预测类别管道分布 | `BestCase` `Commit` | `BestCase · Commit` | 最佳情况 · 承诺 |
| 线索来源分布 | `Content / Blog` … `Web` | `Content / Blog · … · Web` | 内容 / 博客 · … · 网站 |
| 丢单原因分析 | `Bad Timing` … `Price Too High` | `Bad Timing · … · Price Too High` | 时机不合适 · … · 价格过高 |

The "this branch" column is the same on `origin/main` — nothing here produces it. What was missing was a test stated in the card's terms, so a regression would have been silent. That is what this PR adds.

Defect 2 goes with it on that surface. The card reads `NeedsAnalysis` on the bar axis against `Needs Analysis` in the pivot row label; today both surfaces consume the **same** `dimensionLabels` map and fall back to the **same** stored value, so one value cannot carry two spellings there. Pinned explicitly, including the free-form case where no bundle entry exists.

## Provenance of the two measured spellings

The card asked which function each spelling comes from. Run over the card's own stored value, the two functions `git grep` surfaces reproduce the reported pair exactly:

```
humanizeLabel    ('NeedsAnalysis') -> 'NeedsAnalysis'    packages/plugin-charts/src/ObjectChart.tsx
humanizeFieldKey ('NeedsAnalysis') -> 'Needs Analysis'   packages/plugin-dashboard/src/utils.ts
```

`humanizeLabel` maps `[_-]` to spaces and title-cases word boundaries, so a PascalCase value passes through untouched; `humanizeFieldKey` also splits camelCase. The card's diagnosis was right for 17.1.0. Neither is reachable from a dataset dimension member today.

## What this PR does change

The prettifier family the card pointed at survives over field **keys**, and there it still carried the card's defect class. `ObjectDataTable` derives column headers on two paths; the declared path and the static `data-table` half both used `humanizeFieldKey`, while the auto-derived path carried a third inline spelling that split camelCase but never turned `_` into a space. Measured, rendered, over the same object's columns:

| path | `close_date` | `needs_analysis` | `unitPrice` |
|---|---|---|---|
| object-bound, auto-derived (before) | `Close_date` | `Needs_analysis` | `Unit Price` |
| object-bound, auto-derived (after) | `Close Date` | `Needs Analysis` | `Unit Price` |
| object-bound, declared `columns` | `Close Date` | `Needs Analysis` | `Unit Price` |
| static `data-table`, no columns | `Close Date` | `Needs Analysis` | `Unit Price` |

One dashboard can hold all three widgets over one object, so a single field key rendered under two spellings, one of them leaving a raw underscore on screen. The odd path adopts the convention `humanizeFieldKey`'s own docstring already declares itself the single home of, rather than the convention gaining a fourth dialect. A bundle entry still wins — only the fallback handed to `fieldLabel` changed. The camelCase column is where the old spelling and the convention coincided, which is why the snake_case divergence went unnoticed; it is pinned so this is not misread as a camelCase change.

Zero contract additions, as the ruling requires. No translation-schema key is added, and measure/dimension labels are untouched — that half stays deferred.

## Reverse verification

Directions written before each leg ran; both legs read source directly (the root `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src/`, and the tests import `../DatasetWidget` / `../ObjectDataTable` relatively), so no `dist/` is involved in either the mutated or the restored leg. Restoration was confirmed by grepping the marker back out of each file.

**Leg 1 — revert the `ObjectDataTable` fix.** Predicted: the two auto-derived assertions RED, every boundary GREEN. Measured exactly that.

```
× AUTO-DERIVED columns spell the header with the shared convention
× AUTO-DERIVED, DECLARED and STATIC paths all agree, key for key
Test Files  1 failed | 1 passed (2)
     Tests  2 failed | 10 passed (12)
```

**Leg 2 — remove the locale seam** (pass `undefined` for `fieldOptionLabel` into `deriveDimensionLabelMaps`), to show the new member pins are load-bearing rather than phantom. Predicted: the four zh-CN member pins RED, the bar/pivot agreement pin and both boundaries GREEN. Measured **five** red — the agreement pin went red too:

```
× 阶段管道分布 — an opaque stored code resolves through the option label
× 预测类别管道分布 — same, on the second opaque-code dimension
× 线索来源分布 — a value stored AS its display string still translates
× 丢单原因分析 — same, on the fourth measured dimension
× the bar axis and the pivot header agree on the same stored value
Test Files  1 failed | 1 passed (2)
     Tests  5 failed | 7 passed (12)
```

That fifth failure is a **sequencing** dependency, not an assertion one: the pin captures the axis spelling by first waiting for the translated category, so it needs the bundle to clear its `waitFor` even though the property it asserts is direction-independent. The prediction is corrected in the test file's header rather than the run being repeated to fit it, and the free-form twin below it — which agrees over a value with no options, waits on no translation, and stayed GREEN in both legs — is what shows the agreement does not rest on a bundle entry existing.

## Gates

`scripts/pm/dispatch-gates.mjs` does not exist in this repository (it is an objectstack-repo tool), so the family was derived from the changed paths: two `plugin-dashboard` test files, one `plugin-dashboard` source file, one changeset.

```
pnpm exec vitest run packages/plugin-dashboard/ packages/plugin-charts/
  -> Test Files 100 passed (100) | Tests 870 passed (870)

pnpm --filter '@object-ui/plugin-dashboard^...' build   -> exit 0   (deps first; without it type-check
pnpm --filter @object-ui/plugin-dashboard type-check    -> exit 0    reports phantom TS2307s)

pnpm exec eslint <the 3 changed source/test files>      -> 0 errors, 41 warnings (no-explicit-any,
                                                            matching the files' existing style;
                                                            lint.yml deliberately sets no --max-warnings)
pnpm check:control-bytes   -> OK (4498 tracked text files scanned)
pnpm check:phantom-deps    -> OK
pnpm check:self-import     -> OK
pnpm check:esm-specifiers  -> OK
node scripts/check-changeset-presence.mjs -> OK (3 source files of 1 released package, 1 changeset)
node scripts/check-changeset-no-major.mjs -> OK
```

Plus a manual control-byte scan over the changed files: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` returned no matches.

No test was skipped, disabled or quarantined.

## Out of scope

Filed unassigned as #5444: the value-fallback prettifier `humanizeLabel` has two byte-identical copies (`packages/fields`, `packages/plugin-charts`) and disagrees with the key-fallback convention on camelCase input. It is deliberately not touched here — aligning only the `plugin-charts` copy would trade a latent disagreement for a live one against `plugin-grid` / `plugin-gantt` / `plugin-detail`, and `packages/fields` sits outside this card's file surface and was held by PR #5441 at the time.

## For the PM

This is titled `Part of #5425` rather than a closing keyword on purpose: the card's own two asks are satisfied by code that already shipped, so #5425 needs re-triage rather than being closed by this merge. #5444 is a new finding and is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_