### PR TITLE
fix(react,plugin-detail,plugin-grid,plugin-form,docs): one data-source resolution rule for the object-bound family, and a loud report when none resolves

### DIFF
--- a/.changeset/loud-lamps-shake.md
+++ b/.changeset/loud-lamps-shake.md
@@ -1,0 +1,33 @@
+---
+"@object-ui/react": minor
+"@object-ui/plugin-detail": minor
+"@object-ui/plugin-grid": minor
+"@object-ui/plugin-form": minor
+---
+
+`object-grid` / `object-form` / `detail-view` resolve their data source the same way, and a block that resolves none says so
+
+The three object-bound blocks disagreed about how the data-source adapter reached
+them. `object-grid` and `object-form` were registered through wrappers that read
+it from `SchemaRendererProvider` context; `detail-view` was registered as the raw
+component, which reads a React `dataSource` prop. `SchemaRenderer` itself reads
+only context, so the two wirings were mutually exclusive: measured with correct
+keys in every cell, provider wiring gave the grid `find` 1 and the detail view
+`findOne` 0, and prop wiring gave exactly the reverse. Neither reported anything.
+
+All three now resolve the adapter through one rule — an explicit `dataSource`
+prop first, the provider context second. This is additive: `detail-view` keeps
+its prop form (and direct `<DetailView dataSource={…} />` callers are untouched),
+`object-form` gains a prop form it did not have, and `object-grid` no longer
+throws `useSchemaContext must be used within a SchemaRendererProvider` when a
+page has no provider.
+
+And the silence is over. A block in this family that resolves no adapter renders
+a **No data source resolved** panel naming the block, the object it was about to
+read, and the ancestor that injects the adapter — instead of a header-only grid,
+a field-less form card, or nothing at all. The check is opt-in per block, so a
+placement with inline rows, inline `customFields`, an inline record or an `api`
+endpoint is untouched.
+
+New from `@object-ui/react`: `useResolvedDataSource`, `NoDataSourcePanel`,
+`noDataSourceMessage`, and a `requiresDataSource` prop on `ElementDataSourceGate`.

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -25,7 +25,7 @@ Install ObjectUI core packages and the plugins you need:
 
 ```bash
 pnpm add @object-ui/react @object-ui/core @object-ui/types @object-ui/components @object-ui/fields
-pnpm add @object-ui/plugin-grid @object-ui/plugin-form
+pnpm add @object-ui/plugin-grid @object-ui/plugin-form @object-ui/plugin-detail
 ```
 
 Install Tailwind CSS:
@@ -58,16 +58,26 @@ Create `src/setup.ts` to register the built-in component and field renderers:
 
 ```ts
 import { initializeComponents } from '@object-ui/components';
-// Side-effect import: loading the package runs its own field registration.
+// Side-effect imports: loading each package runs its own registration.
 import '@object-ui/fields';
+import '@object-ui/plugin-grid';
+import '@object-ui/plugin-form';
+import '@object-ui/plugin-detail';
 
 initializeComponents();
 ```
 
-Loading each package registers what it owns — the components and the field
-widgets go into the one `ComponentRegistry` that `@object-ui/core` exports.
-`initializeComponents()` takes no arguments; it exists so a bundler cannot
-tree-shake the side-effect import away.
+Loading each package registers what it owns — the components, the field widgets
+and each plugin's blocks all go into the one `ComponentRegistry` that
+`@object-ui/core` exports. `initializeComponents()` takes no arguments; it exists
+so a bundler cannot tree-shake the side-effect import away.
+
+**Every block this tutorial renders comes from a plugin**, so the three plugin
+imports are not optional extras: `object-grid` lives in `@object-ui/plugin-grid`,
+`object-form` in `@object-ui/plugin-form` and `detail-view` in
+`@object-ui/plugin-detail`. Leave one out and `SchemaRenderer` has nothing to
+resolve that `type` to — it renders the red **Unknown component type** panel
+instead of the block.
 
 Import this file once at the top of your app entry point (`src/main.tsx` or `src/App.tsx`).
 
@@ -194,11 +204,13 @@ export class RestDataSource implements DataSource {
 
 ## Step 5: Render a CRUD Grid View
 
-Wire everything together in `src/App.tsx`. The `SchemaRenderer` takes your schema and data source and renders the appropriate view:
+Wire everything together in `src/App.tsx`. `SchemaRendererProvider` injects the
+data source once, and every `SchemaRenderer` beneath it renders its schema
+against that one adapter:
 
 ```tsx
 import './setup';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 import { TaskSchema } from './schemas/task';
 import { RestDataSource } from './data/rest-data-source';
 
@@ -206,17 +218,18 @@ const dataSource = new RestDataSource('https://api.example.com/v1');
 
 function App() {
   return (
-    <div className="min-h-screen bg-background p-6">
-      <SchemaRenderer
-        schema={{
-          type: 'object-grid',
-          object: 'task',
-          view: 'all',
-          data: { objectSchema: TaskSchema },
-        }}
-        dataSource={dataSource}
-      />
-    </div>
+    <SchemaRendererProvider dataSource={dataSource}>
+      <div className="min-h-screen bg-background p-6">
+        <SchemaRenderer
+          schema={{
+            type: 'object-grid',
+            objectName: 'task',
+            view: 'all',
+            data: { objectSchema: TaskSchema },
+          }}
+        />
+      </div>
+    </SchemaRendererProvider>
   );
 }
 
@@ -224,6 +237,22 @@ export default App;
 ```
 
 This renders a fully interactive data grid with sortable columns, pagination, and row actions — all driven by the `TaskSchema` you defined.
+
+Two details in that snippet are load-bearing, and getting either wrong produces
+a grid that draws its header and nothing else:
+
+- **The data source is injected by an ancestor, not passed to the block.**
+  `object-grid`, `object-form` and `detail-view` all read the adapter from
+  `SchemaRendererProvider`, so it has to be *above* them in the tree. A
+  `dataSource` written on the block itself reaches that one block and never
+  becomes context for anything under it.
+- **The object is named by `objectName`.** That is the key each of these blocks
+  declares as required; a differently-spelled key (`object`) is not read, so the
+  block has no object to query.
+
+Neither mistake used to say anything — the block simply rendered empty. Both now
+report themselves: a block that resolves no adapter renders a **No data source
+resolved** panel naming itself and the object it was about to read.
 
 ## Step 6: Add Create and Edit Forms
 
@@ -236,10 +265,12 @@ const [editId, setEditId] = useState<string | null>(null);
 
 Add a "New Task" button and handle row clicks to open the edit form:
 
+Both of these render inside the `SchemaRendererProvider` from Step 5, so neither
+carries a data source of its own:
+
 ```tsx
 <SchemaRenderer
-  schema={{ type: 'object-grid', object: 'task', view: 'all', data: { objectSchema: TaskSchema } }}
-  dataSource={dataSource}
+  schema={{ type: 'object-grid', objectName: 'task', view: 'all', data: { objectSchema: TaskSchema } }}
   onRowClick={(row: any) => { setEditId(row.id); setShowForm(true); }}
 />
 
@@ -247,17 +278,20 @@ Add a "New Task" button and handle row clicks to open the edit form:
   <SchemaRenderer
     schema={{
       type: 'object-form',
-      object: 'task',
+      objectName: 'task',
       mode: editId ? 'edit' : 'create',
       recordId: editId,
       data: { objectSchema: TaskSchema },
     }}
-    dataSource={dataSource}
     onSubmit={() => setShowForm(false)}
     onCancel={() => setShowForm(false)}
   />
 )}
 ```
+
+`recordId` is the key `object-form` reads to load the record it is editing — it
+is the form's own spelling and is not shared with `detail-view`, which uses
+`resourceId` (Step 8).
 
 The form automatically renders the correct field widgets (text inputs, select dropdowns, date pickers) based on your `FieldMetadata` definitions. Validation rules like `required` are enforced out of the box.
 
@@ -291,14 +325,13 @@ const [searchQuery, setSearchQuery] = useState('');
 <SchemaRenderer
   schema={{
     type: 'object-grid',
-    object: 'task',
+    objectName: 'task',
     view: activeView,
     data: {
       objectSchema: TaskSchema,
       queryParams: searchQuery ? { $search: searchQuery } : undefined,
     },
   }}
-  dataSource={dataSource}
 />
 ```
 
@@ -318,16 +351,28 @@ function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => void }) 
       <SchemaRenderer
         schema={{
           type: 'detail-view',
-          object: 'task',
-          recordId: taskId,
-          data: { objectSchema: TaskSchema },
+          objectName: 'task',
+          resourceId: taskId,
         }}
-        dataSource={dataSource}
       />
     </div>
   );
 }
 ```
+
+Render `TaskDetail` inside the same `SchemaRendererProvider` as the grid — it
+reads the injected data source from context, exactly as `object-grid` and
+`object-form` do.
+
+Two keys differ from the form above, and both matter:
+
+- **`resourceId`, not `recordId`.** `detail-view` sources the record id from
+  `resourceId`; `recordId` is `object-form`'s spelling. The two blocks are not
+  interchangeable here.
+- **No `data`.** On `detail-view`, `data` means *"here is the record already,
+  do not fetch"* — so handing it anything (including the object's metadata)
+  makes the block skip `findOne` entirely and render that value as if it were
+  the record. Omit it and the block loads the record for itself.
 
 Use this component in your main app with simple routing state, or integrate with a router like React Router or TanStack Router for URL-based navigation.
 

--- a/packages/plugin-detail/README.md
+++ b/packages/plugin-detail/README.md
@@ -22,6 +22,36 @@ pnpm add @object-ui/plugin-detail
 
 ## Usage
 
+### Two ways to reach a data source
+
+`detail-view` needs a data source to load a record, and there are two ways to
+give it one. They are equivalent, and an explicit prop wins when both are
+present:
+
+```tsx
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+
+// 1. Injected by an ancestor — the pattern the rest of the family uses, and the
+//    one to reach for when a page renders several data-bound blocks.
+<SchemaRendererProvider dataSource={dataSource}>
+  <SchemaRenderer schema={{ type: 'detail-view', objectName: 'account', resourceId: '42' }} />
+</SchemaRendererProvider>
+
+// 2. Handed to one placement — what `<DetailView dataSource={…} />` has always
+//    taken, and what the examples below use.
+<DetailView schema={{ type: 'detail-view', objectName: 'account', resourceId: '42' }} dataSource={dataSource} />
+```
+
+Route 1 is new as of objectui#5378: this block used to read the adapter from its
+prop ONLY, while its siblings `object-grid` and `object-form` read it from
+context only, so a page could satisfy one of them or the other and never both.
+Nothing that worked before changed — route 2 is unaffected — and a block that
+resolves neither now renders a **No data source resolved** panel naming itself
+and the object it was about to read, instead of an empty shell.
+
+Note the record id is `resourceId` here. `object-form`'s is `recordId`; the two
+blocks do not share that key.
+
 ### Basic Example
 
 ```tsx

--- a/packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx
+++ b/packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#5378 item 1 — `detail-view` resolves its adapter the way its siblings
+ * do, and the getting-started guide's own `detail-view` snippet is RENDERED here.
+ *
+ * ## The split this closes
+ *
+ * `object-grid` and `object-form` are registered through wrappers that read the
+ * adapter from `SchemaRendererContext`. `detail-view` was registered as the RAW
+ * `DetailView`, which reads a React `dataSource` PROP. `SchemaRenderer` itself
+ * reads only context, so the two wirings were mutually exclusive and a page
+ * could satisfy exactly one of them. Measured on `origin/main`, keys held
+ * correct in every cell:
+ *
+ * | wiring                                  | `object-grid` | `detail-view` |
+ * |-----------------------------------------|---------------|---------------|
+ * | `SchemaRendererProvider dataSource={…}`  | `find` 1      | `findOne` 0   |
+ * | `SchemaRenderer dataSource={…}` (prop)   | `find` 0      | `findOne` 1   |
+ *
+ * Neither cell reported anything. The whole page could therefore be wired
+ * "correctly" and still render half of itself as an empty shell.
+ *
+ * ## What is pinned below
+ *
+ * The maintainer ruling of 2026-08-20 made the wrapper ADDITIVE — the
+ * `dataSource`-prop form stays accepted, no prop is removed — so all three
+ * wirings are asserted: context alone (the new one), prop alone (the one that
+ * must not break), and both at once, where the explicit prop wins because it is
+ * the more specific signal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Module-scope side-effect imports: the registry must hold `detail-view` and the
+// field widgets it renders into before the first render (AGENTS.md §测试纪律).
+import '@object-ui/components';
+import '@object-ui/fields';
+import '../index';
+
+const GUIDE = path.resolve(__dirname, '../../../../content/docs/guide/building-crud-app.md');
+
+const TASK_SCHEMA = {
+  name: 'task',
+  label: 'Task',
+  fields: {
+    title: { name: 'title', type: 'text', label: 'Title' },
+    status: { name: 'status', type: 'text', label: 'Status' },
+  },
+};
+
+const RECORD = { id: '42', title: 'Write the guide', status: 'Todo' };
+
+/** See the twin helper in `plugin-grid`'s probe — same rule, same reason. */
+function guideSchemas(key: string): any[] {
+  const src = fs.readFileSync(GUIDE, 'utf8');
+  const needle = `type: '${key}'`;
+  const out: any[] = [];
+  for (let at = src.indexOf(needle); at !== -1; at = src.indexOf(needle, at + 1)) {
+    const start = src.lastIndexOf('{', at);
+    let depth = 0;
+    let end = start;
+    for (; end < src.length; end++) {
+      if (src[end] === '{') depth++;
+      else if (src[end] === '}' && --depth === 0) break;
+    }
+    out.push(
+      new Function(
+        'TaskSchema', 'editId', 'taskId', 'activeView', 'searchQuery',
+        `return (${src.slice(start, end + 1)});`,
+      )(TASK_SCHEMA, '42', '42', 'all', ''),
+    );
+  }
+  return out;
+}
+
+function makeAdapter() {
+  return {
+    find: vi.fn().mockResolvedValue({ data: [RECORD], total: 1 }),
+    findOne: vi.fn().mockResolvedValue(RECORD),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(TASK_SCHEMA),
+  };
+}
+
+const DETAIL_SNIPPETS = guideSchemas('detail-view');
+const SNIPPET = DETAIL_SNIPPETS[0];
+
+beforeEach(() => cleanup());
+
+describe('guide/building-crud-app.md — the `detail-view` snippet actually renders', () => {
+  it('publishes exactly one detail snippet', () => {
+    expect(DETAIL_SNIPPETS).toHaveLength(1);
+  });
+
+  it('loads the record under the PROVIDER wiring — the convergence', async () => {
+    // This is the cell that was `findOne` 0 before the wrapper existed.
+    const adapter = makeAdapter();
+    const { container } = render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={SNIPPET} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(adapter.findOne).toHaveBeenCalledTimes(1));
+    expect(adapter.findOne.mock.calls[0].slice(0, 2)).toEqual(['task', '42']);
+    await waitFor(() => expect(container.textContent).toContain('Write the guide'));
+  });
+
+  it('still loads it under the PROP wiring — the ruling kept that form accepted', async () => {
+    const adapter = makeAdapter();
+    const { container } = render(<SchemaRenderer schema={SNIPPET} dataSource={adapter as any} />);
+
+    await waitFor(() => expect(adapter.findOne).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(container.textContent).toContain('Write the guide'));
+  });
+
+  it('lets the explicit prop win when both are present', async () => {
+    const ambient = makeAdapter();
+    const explicit = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={ambient as any}>
+        <SchemaRenderer schema={SNIPPET} dataSource={explicit as any} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(explicit.findOne).toHaveBeenCalledTimes(1));
+    expect(ambient.findOne).not.toHaveBeenCalled();
+  });
+
+  it('sources the record id from `resourceId` — `recordId` loads nothing here', async () => {
+    // objectui#5377's correction, pinned so it cannot be lost again: the
+    // `recordId` → `resourceId` rename is right ONLY for this block.
+    // `object-form` genuinely reads `recordId`, and a blanket rename across the
+    // guide's five snippets would have broken the form instead.
+    const asItWas = { ...SNIPPET, recordId: SNIPPET.resourceId };
+    delete asItWas.resourceId;
+
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={asItWas} />
+      </SchemaRendererProvider>,
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(adapter.findOne).not.toHaveBeenCalled();
+  });
+
+  it('names the object with `objectName` — `object` loads nothing', async () => {
+    const asItWas = { ...SNIPPET, object: SNIPPET.objectName };
+    delete asItWas.objectName;
+
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={asItWas} />
+      </SchemaRendererProvider>,
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(adapter.findOne).not.toHaveBeenCalled();
+  });
+
+  it('carries no `data` — on this block `data` MEANS "already loaded, do not fetch"', async () => {
+    // Why the guide's `data: { objectSchema: TaskSchema }` had to go from this
+    // snippet and not merely be re-spelled: `DetailView` returns early on any
+    // `schema.data`, so the object's METADATA was being installed as the record
+    // and `findOne` never ran. Inert on `object-grid`, load-bearing here — which
+    // is why each snippet was judged on its own rather than swept.
+    expect(SNIPPET.data).toBeUndefined();
+
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={{ ...SNIPPET, data: { objectSchema: TASK_SCHEMA } }} />
+      </SchemaRendererProvider>,
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(adapter.findOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('detail-view — a block that resolves no adapter says so (objectui#5378 item 2)', () => {
+  it('reports "No data source resolved" instead of rendering nothing at all', async () => {
+    const { findByTestId } = render(<SchemaRenderer schema={SNIPPET} />);
+    const panel = await findByTestId('detail-view-no-data-source');
+    expect(panel).toHaveAttribute('role', 'alert');
+    expect(panel.textContent).toContain('detail-view');
+    expect(panel.textContent).toContain('task');
+    expect(panel.textContent).toContain('SchemaRendererProvider');
+  });
+
+  it('stays silent for an inline record, which needs no adapter', async () => {
+    const { queryByTestId, container } = render(
+      <SchemaRenderer
+        schema={{ type: 'detail-view', objectName: 'task', resourceId: '42', data: RECORD } as any}
+      />,
+    );
+    await waitFor(() => expect(container.textContent).toContain('Write the guide'));
+    expect(queryByTestId('detail-view-no-data-source')).toBeNull();
+  });
+
+  it('stays silent for an `api`-sourced record, which fetches without an adapter', async () => {
+    const { queryByTestId } = render(
+      <SchemaRenderer
+        schema={{ type: 'detail-view', objectName: 'task', resourceId: '42', api: '/api/task' } as any}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(queryByTestId('detail-view-no-data-source')).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -6,7 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as React from 'react';
 import { ComponentRegistry, type ComponentInput } from '@object-ui/core';
+import {
+  ElementDataSourceGate,
+  noDataSourceMessage,
+  useResolvedDataSource,
+} from '@object-ui/react';
 import { withFieldCarrier } from '@object-ui/fields';
 import { DetailView } from './DetailView';
 import { DetailSection } from './DetailSection';
@@ -23,7 +29,7 @@ import { RecordHistoryRenderer } from './renderers/record-history';
 import { RecordReferenceRailRenderer } from './renderers/record-reference-rail';
 import { RecordAlertRenderer } from './renderers/record-alert';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
-import type { DetailViewSchema } from '@object-ui/types';
+import type { DataSource, DetailViewSchema } from '@object-ui/types';
 import { ACTION_LOCATIONS } from '@object-ui/types';
 
 export { DetailView, DetailSection, DetailTabs, RelatedList };
@@ -129,8 +135,103 @@ export type {
   BuildPageOptions,
 } from './synth/buildDefaultPageSchema';
 
-// Register DetailView component
-ComponentRegistry.register('detail-view', DetailView, {
+/**
+ * The registry face of `detail-view` — objectui#5378 item 1.
+ *
+ * ## What was wrong
+ *
+ * `detail-view` was registered as the RAW `DetailView` component, which reads
+ * its adapter from its own React `dataSource` PROP. Its two siblings in the
+ * family are registered through wrappers that read the adapter from
+ * `SchemaRendererContext` (`ObjectGridRenderer`, `ObjectFormRenderer`), and
+ * `SchemaRenderer` itself reads only context — an explicit `dataSource` PROP
+ * arrives through `...props` and never becomes context for anything below.
+ *
+ * So the two wirings were mutually exclusive, and a page could satisfy only one
+ * of them. Measured on the published getting-started guide's own snippets,
+ * keys held correct in every cell:
+ *
+ * | wiring                                    | `object-grid` | `detail-view` |
+ * |-------------------------------------------|---------------|---------------|
+ * | `SchemaRendererProvider dataSource={…}`    | `find` 1      | `findOne` 0   |
+ * | `SchemaRenderer dataSource={…}` (prop)     | `find` 0      | `findOne` 1   |
+ *
+ * Neither cell reported anything: one half of the page fetched, the other half
+ * rendered an empty shell in silence. The registry gave the author no signal
+ * about which wiring they were holding.
+ *
+ * ## What this is
+ *
+ * The same context-reading wrapper the siblings have, so every block in the
+ * family resolves the adapter the same way — maintainer ruling of 2026-08-20 on
+ * objectui#5378, item 1 (「其他接受你的建议。」), which also settled the
+ * compatibility question: this is ADDITIVE. The `dataSource`-PROP form stays
+ * accepted, and no prop is removed this pass.
+ *
+ * ## Precedence, when both are present
+ *
+ * The explicit prop WINS. It is the more specific signal — written on this one
+ * placement, by someone who can see it — while the context adapter is ambient
+ * and applies to every descendant of the provider. That is also the only
+ * precedence under which the ruling's \"stays accepted\" is true of the case that
+ * matters: a prop-form caller mounted somewhere inside an app that has a
+ * provider would otherwise have had its explicit choice silently overruled by
+ * an ancestor it never wrote.
+ *
+ * Measured caller population behind that judgement (objectui#5378's stated
+ * confidence gap): in this repo, every `dataSource`-prop consumer of
+ * `DetailView` — `renderers/record-details.tsx`, `RecordDetailDrawer.tsx`, and
+ * the published README's documented usage — renders the COMPONENT directly and
+ * never passes through the registry, so this wrapper does not sit between any
+ * of them and `DetailView`. Registry-routed `detail-view` nodes carrying a
+ * `dataSource` prop: zero, the getting-started guide being the one that tried.
+ * The additive shape therefore changes no measured caller's behaviour, and the
+ * precedence above is pinned by test rather than left to be discovered.
+ */
+export const DetailViewRenderer: React.FC<{
+  schema: any;
+  dataSource?: unknown;
+  [key: string]: any;
+}> = ({ schema, dataSource: dataSourceProp, ...props }) => {
+  // The family's ONE resolution rule (`@object-ui/react`): explicit adapter
+  // first, `SchemaRendererProvider` context second, and the spec BINDING never
+  // mistaken for an adapter. Sharing the hook is what keeps the three blocks
+  // from drifting back apart — the drift IS the defect this card closes.
+  const dataSource = useResolvedDataSource<DataSource>(dataSourceProp);
+  return (
+    <ElementDataSourceGate
+      schema={schema}
+      // `object` → `objectName` is the whole mapping: a detail view shows ONE
+      // record, so it has no collection query for the binding's `filter` /
+      // `sort` / `limit` to narrow and no field projection for its `columns`.
+      // Mapping them anywhere would write keys this block does not read, which
+      // is the defect the gate exists to remove.
+      dataSource={dataSource}
+      testId="detail-view"
+      errorTitle="This detail view’s data source could not be resolved"
+      // `DetailView` returns early on inline `schema.data` and fetches over
+      // `schema.api` without an adapter; either one is a legitimate placement
+      // with nothing to resolve. Everything else reaches the branch that needs
+      // `dataSource && objectName && resourceId` and, without it, renders
+      // nothing at all — the silence objectui#5378 item 2 ends.
+      requiresDataSource={
+        schema?.data == null
+        && schema?.api == null
+        && typeof schema?.objectName === 'string'
+        && schema.objectName.length > 0
+      }
+      noDataSourceMessage={noDataSourceMessage('detail-view', schema?.objectName)}
+    >
+      {(bound) => <DetailView schema={bound as DetailViewSchema} dataSource={dataSource} {...props} />}
+    </ElementDataSourceGate>
+  );
+};
+
+// Register detail-view through the wrapper above, NOT the raw component: the
+// registry entry is what a `SchemaRenderer` reaches, and the wrapper is what
+// makes context wiring work there. `DetailView` stays exported unchanged for
+// the direct React callers (`record-details`, `RecordDetailDrawer`, the README).
+ComponentRegistry.register('detail-view', DetailViewRenderer, {
   namespace: 'plugin-detail',
   label: 'Detail View',
   category: 'Views',

--- a/packages/plugin-form/src/__tests__/guideCrudAppRenders.test.tsx
+++ b/packages/plugin-form/src/__tests__/guideCrudAppRenders.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#5378 + objectui#5377 — the getting-started guide's own `object-form`
+ * snippet is RENDERED here, not read.
+ *
+ * This block was already context-wired, so the guide's `dataSource` PROP reached
+ * it as a React prop and never as context: measured `getObjectSchema` **0**,
+ * `findOne` **0**, a card with no fields and no error. The key axis compounded
+ * it — the page named the object with `object`, and this block declares
+ * `objectName` as required.
+ *
+ * ## The correction this file exists to keep
+ *
+ * `recordId` → `resourceId` is right ONLY for `detail-view`. `object-form`
+ * genuinely reads `recordId` (`ObjectForm.tsx`, `findOne(schema.objectName,
+ * schema.recordId)`), so a blanket rename across the guide's five snippets —
+ * which is what "fix the keys" reads like from a distance — would have taken
+ * this block from working to broken while the PR reported success. The rename
+ * is asserted to BREAK this block below, so nobody has to remember.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Module-scope side-effect imports: the registry must hold `object-form` and the
+// field widgets it renders into before the first render (AGENTS.md §测试纪律).
+import '@object-ui/components';
+import '@object-ui/fields';
+import '../index';
+
+const GUIDE = path.resolve(__dirname, '../../../../content/docs/guide/building-crud-app.md');
+
+const TASK_SCHEMA = {
+  name: 'task',
+  label: 'Task',
+  fields: {
+    title: { name: 'title', type: 'text', label: 'Title' },
+    status: { name: 'status', type: 'text', label: 'Status' },
+  },
+};
+
+const RECORD = { id: '42', title: 'Write the guide', status: 'Todo' };
+
+/** See the twin helper in `plugin-grid`'s probe — same rule, same reason. */
+function guideSchemas(key: string): any[] {
+  const src = fs.readFileSync(GUIDE, 'utf8');
+  const needle = `type: '${key}'`;
+  const out: any[] = [];
+  for (let at = src.indexOf(needle); at !== -1; at = src.indexOf(needle, at + 1)) {
+    const start = src.lastIndexOf('{', at);
+    let depth = 0;
+    let end = start;
+    for (; end < src.length; end++) {
+      if (src[end] === '{') depth++;
+      else if (src[end] === '}' && --depth === 0) break;
+    }
+    out.push(
+      new Function(
+        'TaskSchema', 'editId', 'taskId', 'activeView', 'searchQuery',
+        `return (${src.slice(start, end + 1)});`,
+      )(TASK_SCHEMA, '42', '42', 'all', ''),
+    );
+  }
+  return out;
+}
+
+function makeAdapter() {
+  return {
+    find: vi.fn().mockResolvedValue({ data: [RECORD], total: 1 }),
+    findOne: vi.fn().mockResolvedValue(RECORD),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(TASK_SCHEMA),
+  };
+}
+
+const FORM_SNIPPETS = guideSchemas('object-form');
+const SNIPPET = FORM_SNIPPETS[0];
+
+beforeEach(() => cleanup());
+
+describe('guide/building-crud-app.md — the `object-form` snippet actually renders', () => {
+  it('publishes exactly one form snippet', () => {
+    expect(FORM_SNIPPETS).toHaveLength(1);
+  });
+
+  it('fetches the object schema and the edited record under the provider wiring', async () => {
+    const adapter = makeAdapter();
+    const { container } = render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={SNIPPET} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(adapter.getObjectSchema).toHaveBeenCalledWith('task'));
+    await waitFor(() => expect(adapter.findOne).toHaveBeenCalledTimes(1));
+    expect(adapter.findOne.mock.calls[0].slice(0, 2)).toEqual(['task', '42']);
+    // A form that resolved its object renders the object's fields; the
+    // field-less card was the whole silent failure.
+    await waitFor(() => expect(container.textContent).toContain('Title'));
+  });
+
+  it('names the object with `objectName` — `object` fetches nothing', async () => {
+    const asItWas = { ...SNIPPET, object: SNIPPET.objectName };
+    delete asItWas.objectName;
+
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={asItWas} />
+      </SchemaRendererProvider>,
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(adapter.getObjectSchema).not.toHaveBeenCalled();
+    expect(adapter.findOne).not.toHaveBeenCalled();
+  });
+
+  it('keeps `recordId` — the `resourceId` spelling loads no record HERE', async () => {
+    // The correction, pinned. `detail-view` wants `resourceId`; this block does
+    // not, and a sweep across the guide would have swapped a working key for a
+    // dead one.
+    expect(SNIPPET.recordId).toBe('42');
+
+    const swept = { ...SNIPPET, resourceId: SNIPPET.recordId };
+    delete swept.recordId;
+
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={swept} />
+      </SchemaRendererProvider>,
+    );
+
+    // The object schema still resolves — the form still knows WHICH object —
+    // but there is no record to load, which is the shape of the damage: a form
+    // that looks configured and silently edits nothing.
+    await waitFor(() => expect(adapter.getObjectSchema).toHaveBeenCalledWith('task'));
+    expect(adapter.findOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('object-form — a block that resolves no adapter says so (objectui#5378 item 2)', () => {
+  it('reports "No data source resolved" instead of a field-less card', async () => {
+    const { findByTestId } = render(<SchemaRenderer schema={SNIPPET} />);
+    const panel = await findByTestId('object-form-no-data-source');
+    expect(panel).toHaveAttribute('role', 'alert');
+    expect(panel.textContent).toContain('object-form');
+    expect(panel.textContent).toContain('task');
+    expect(panel.textContent).toContain('SchemaRendererProvider');
+  });
+
+  it('stays silent for inline `customFields`, which need no adapter', async () => {
+    const { queryByTestId } = render(
+      <SchemaRenderer
+        schema={{
+          type: 'object-form',
+          objectName: 'task',
+          customFields: [{ name: 'title', type: 'text', label: 'Title' }],
+        } as any}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(queryByTestId('object-form-no-data-source')).toBeNull();
+  });
+});

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -11,8 +11,11 @@ import { ComponentRegistry } from '@object-ui/core';
 import {
   ElementDataSourceGate,
   SchemaRendererContext,
+  noDataSourceMessage,
+  useResolvedDataSource,
   type ElementDataSourceMapping,
 } from '@object-ui/react';
+import type { DataSource } from '@object-ui/types';
 import { ObjectForm } from './ObjectForm';
 
 export { ObjectForm };
@@ -66,13 +69,22 @@ export { deriveDetail, deriveColumns, deriveFormFields, findRelationshipField, r
 export type { DerivedDetail, InlineMode } from './deriveMasterDetail';
 
 // Register object-form component
-const ObjectFormRenderer: React.FC<{ schema: any }> = ({ schema }) => {
-  // Resolve dataSource from the SchemaRendererProvider context (same as
-  // object-view): ObjectForm needs a dataSource to fetch the object schema and
-  // auto-generate its fields. Without this, an `object-form` rendered straight
-  // through SchemaRenderer (e.g. the Studio view preview) has no fields.
-  const ctx = useContext(SchemaRendererContext as React.Context<any>);
-  const dataSource = ctx?.dataSource ?? undefined;
+const ObjectFormRenderer: React.FC<{ schema: any; dataSource?: unknown }> = ({
+  schema,
+  dataSource: dataSourceProp,
+}) => {
+  // ObjectForm needs a dataSource to fetch the object schema and auto-generate
+  // its fields. Without one, an `object-form` rendered straight through
+  // SchemaRenderer (e.g. the Studio view preview) has no fields.
+  //
+  // Resolved through the family's shared rule (objectui#5378): an explicit
+  // adapter first, the `SchemaRendererProvider` context second. The explicit
+  // half is additive — this block used to read context ONLY, so nothing that
+  // worked before resolves differently now; what changes is that the three
+  // blocks in the family no longer answer "where does the adapter come from?"
+  // three different ways, which is the split that made the getting-started
+  // guide satisfiable by neither wiring.
+  const dataSource = useResolvedDataSource<DataSource>(dataSourceProp);
   // The spec's `PageComponentSchema.dataSource` binding (objectstack#6953). A
   // page that declared `dataSource: { object }` and no `objectName` rendered a
   // field-less shell: `ObjectForm` gates its whole schema fetch on `objectName`.
@@ -91,6 +103,19 @@ const ObjectFormRenderer: React.FC<{ schema: any }> = ({ schema }) => {
       dataSource={dataSource}
       testId="object-form"
       errorTitle="This form’s data source could not be resolved"
+      // `ObjectForm` builds its fields from the object's metadata, which only an
+      // adapter can serve — its own effect calls the branch it comments as
+      // "cannot proceed" and then renders a field-less card in silence
+      // (objectui#5378 item 2). The one escape hatch is inline `customFields`,
+      // which is exactly what `hasInlineFields` gates on inside the component,
+      // so the two stay in step. A form with no `objectName` is a different
+      // defect and is left to report itself.
+      requiresDataSource={
+        !(schema?.customFields?.length > 0)
+        && typeof schema?.objectName === 'string'
+        && schema.objectName.length > 0
+      }
+      noDataSourceMessage={noDataSourceMessage('object-form', schema?.objectName)}
     >
       {(bound) => <ObjectForm schema={bound} dataSource={dataSource} />}
     </ElementDataSourceGate>

--- a/packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx
+++ b/packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#5378 + objectui#5377 — the getting-started guide's own `object-grid`
+ * snippets are RENDERED here, not read.
+ *
+ * `content/docs/guide/building-crud-app.md` is the first-run CRUD walkthrough,
+ * and three independent axes each took it from "works" to "renders nothing":
+ *
+ *  1. **registration** — its `setup.ts` loaded `@object-ui/components` and
+ *     `@object-ui/fields` only, so `object-grid` resolved to the registry's
+ *     "Unknown component type" panel.
+ *  2. **wiring** (#5378) — it passed `dataSource` as a PROP on `SchemaRenderer`,
+ *     which never becomes context; this block reads the adapter from
+ *     `SchemaRendererProvider`. Measured `find` **0**.
+ *  3. **keys** (#5377) — it named the object with `object`, and this block
+ *     declares `objectName` (`GRID_QUERY_INPUTS`, `required: true`). Measured
+ *     `find` **0** even under the right wiring.
+ *
+ * Every intermediate state passes a diff review and renders nothing, which is
+ * why this file evaluates the guide's literals instead of asserting about their
+ * text: the schema objects below are the ones the published page hands a reader.
+ * The `find` **0 → 1** contrast for each axis is pinned so a future edit that
+ * reintroduces one fails here rather than on a reader's screen.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Module-scope side-effect imports: the registry must hold every key the
+// guide's snippets name before the first render (AGENTS.md §测试纪律 — a
+// `beforeAll` import is bounded by `hookTimeout` and would race the loader).
+import '@object-ui/components';
+import '@object-ui/fields';
+import '../index';
+
+const GUIDE = path.resolve(__dirname, '../../../../content/docs/guide/building-crud-app.md');
+
+const TASK_SCHEMA = {
+  name: 'task',
+  label: 'Task',
+  fields: {
+    title: { name: 'title', type: 'text', label: 'Title' },
+    status: { name: 'status', type: 'text', label: 'Status' },
+    priority: { name: 'priority', type: 'text', label: 'Priority' },
+    assignee: { name: 'assignee', type: 'text', label: 'Assignee' },
+    due_date: { name: 'due_date', type: 'date', label: 'Due Date' },
+  },
+};
+
+const ROW = { id: '42', title: 'Write the guide', status: 'Todo', priority: 'High' };
+
+/**
+ * Every schema literal the guide publishes for `type: '<key>'`, evaluated.
+ *
+ * Reading the literals out of the page is the point: a transcription kept in
+ * this file would drift from the page silently, and the whole failure mode here
+ * is that nothing tells you when the page stops working.
+ *
+ * The guide's literals close over exactly the identifiers bound below (its
+ * `TaskSchema` import and the `useState` values of Steps 6 and 7), and carry no
+ * TypeScript syntax inside the object, so `Function` is enough to evaluate one.
+ */
+function guideSchemas(key: string): any[] {
+  const src = fs.readFileSync(GUIDE, 'utf8');
+  const needle = `type: '${key}'`;
+  const out: any[] = [];
+  for (let at = src.indexOf(needle); at !== -1; at = src.indexOf(needle, at + 1)) {
+    const start = src.lastIndexOf('{', at);
+    let depth = 0;
+    let end = start;
+    for (; end < src.length; end++) {
+      if (src[end] === '{') depth++;
+      else if (src[end] === '}' && --depth === 0) break;
+    }
+    const literal = src.slice(start, end + 1);
+    out.push(
+      new Function(
+        'TaskSchema', 'editId', 'taskId', 'activeView', 'searchQuery',
+        `return (${literal});`,
+      )(TASK_SCHEMA, '42', '42', 'all', ''),
+    );
+  }
+  return out;
+}
+
+function makeAdapter() {
+  return {
+    find: vi.fn().mockResolvedValue({ data: [ROW], total: 1 }),
+    findOne: vi.fn().mockResolvedValue(ROW),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(TASK_SCHEMA),
+  };
+}
+
+const GRID_SNIPPETS = guideSchemas('object-grid');
+
+beforeEach(() => cleanup());
+
+describe('guide/building-crud-app.md — every `object-grid` snippet actually renders', () => {
+  it('publishes the three snippets this file is about', () => {
+    // A guide that lost a snippet would otherwise make this whole file vacuous:
+    // zero snippets means zero assertions and a green run.
+    expect(GRID_SNIPPETS).toHaveLength(3);
+  });
+
+  it.each(GRID_SNIPPETS.map((schema, i) => [i + 1, schema] as const))(
+    'snippet %i queries `task` under the provider wiring and paints the row',
+    async (_i, schema) => {
+      const adapter = makeAdapter();
+      const { container } = render(
+        <SchemaRendererProvider dataSource={adapter as any}>
+          <SchemaRenderer schema={schema} />
+        </SchemaRendererProvider>,
+      );
+
+      await waitFor(() => expect(adapter.find).toHaveBeenCalledTimes(1));
+      expect(adapter.find.mock.calls[0][0]).toBe('task');
+      await waitFor(() => expect(container.textContent).toContain('Write the guide'));
+    },
+  );
+
+  it('names the object with the key this block declares — `object` fetches nothing', async () => {
+    // The #5377 axis, pinned as a contrast rather than described. Same snippet,
+    // same wiring, one key re-spelled the way the page used to spell it.
+    const [first] = GRID_SNIPPETS;
+    const asItWas = { ...first, object: first.objectName };
+    delete asItWas.objectName;
+
+    const adapter = makeAdapter();
+    const { container } = render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={asItWas} />
+      </SchemaRendererProvider>,
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(adapter.find).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain('Write the guide');
+  });
+
+  it('resolves the adapter from EITHER wiring now, and the prop wins over context', async () => {
+    // The #5378 axis, as it stands AFTER the convergence. It used to be a hard
+    // split: `SchemaRenderer` reads only context, and this block's
+    // `useSchemaContext()` THREW without a provider, so the guide's prop wiring
+    // painted «Component "object-grid" failed to render» and `find` was 0.
+    //
+    // Both wirings resolve now. The prop wins because it is the more specific
+    // signal — written on this one placement, against a provider that applies to
+    // every descendant. That precedence is not new (the adapter already reached
+    // `ObjectGrid` through `{...props}`, spread last, whenever a provider
+    // existed); it is now stated instead of being an accident of spread order.
+    const [first] = GRID_SNIPPETS;
+
+    const propOnly = makeAdapter();
+    const { unmount } = render(<SchemaRenderer schema={first} dataSource={propOnly as any} />);
+    await waitFor(() => expect(propOnly.find).toHaveBeenCalledTimes(1));
+    unmount();
+
+    const ambient = makeAdapter();
+    const explicit = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={ambient as any}>
+        <SchemaRenderer schema={first} dataSource={explicit as any} />
+      </SchemaRendererProvider>,
+    );
+    await waitFor(() => expect(explicit.find).toHaveBeenCalledTimes(1));
+    expect(ambient.find).not.toHaveBeenCalled();
+  });
+
+  it('the page injects the adapter once, above the blocks, and on no block itself', () => {
+    const src = fs.readFileSync(GUIDE, 'utf8');
+    expect(src).toContain('<SchemaRendererProvider dataSource={dataSource}>');
+    // AGENTS.md commandment #1 is the injection pattern; a `dataSource` written
+    // on a `SchemaRenderer` in this page is the wiring #5378 measured as dead.
+    // `\s` after the name is what keeps `<SchemaRendererProvider …>` out of the set.
+    const calls = src.match(/<SchemaRenderer\s[\s\S]*?\/>/g) ?? [];
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.filter((c) => /\bdataSource=/.test(c))).toEqual([]);
+  });
+});
+
+describe('object-grid — a block that resolves no adapter says so (objectui#5378 item 2)', () => {
+  it('reports "No data source resolved" instead of an empty grid', async () => {
+    const { findByTestId } = render(
+      <SchemaRenderer schema={{ type: 'object-grid', objectName: 'task' } as any} />,
+    );
+    const panel = await findByTestId('object-grid-no-data-source');
+    expect(panel).toHaveAttribute('role', 'alert');
+    // The message has to be an ADDRESS, not a symptom: it names the block, the
+    // object it was about to read, and the ancestor that injects the adapter.
+    expect(panel.textContent).toContain('object-grid');
+    expect(panel.textContent).toContain('task');
+    expect(panel.textContent).toContain('SchemaRendererProvider');
+  });
+
+  it('stays silent for inline rows, which need no adapter', async () => {
+    const { queryByTestId, container } = render(
+      <SchemaRenderer
+        schema={{
+          type: 'object-grid',
+          objectName: 'task',
+          data: { provider: 'value', items: [ROW] },
+        } as any}
+      />,
+    );
+    await waitFor(() => expect(container.textContent).toContain('Write the guide'));
+    expect(queryByTestId('object-grid-no-data-source')).toBeNull();
+  });
+
+  it('stays silent when a HOST owns the fetch and hands the window down as a prop', async () => {
+    // `plugin-list`'s ListView renders this block through `SchemaRenderer` with
+    // `data` as a REACT prop. An empty first window is a host still fetching —
+    // presence of the prop is the signal, never its truthiness.
+    const { queryByTestId } = render(
+      <SchemaRenderer schema={{ type: 'object-grid', objectName: 'task' } as any} data={[]} />,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(queryByTestId('object-grid-no-data-source')).toBeNull();
+  });
+});

--- a/packages/plugin-grid/src/index.tsx
+++ b/packages/plugin-grid/src/index.tsx
@@ -10,9 +10,12 @@ import React from 'react';
 import { ComponentRegistry, type ComponentInput } from '@object-ui/core';
 import {
   ElementDataSourceGate,
+  noDataSourceMessage,
+  useResolvedDataSource,
   useSchemaContext,
   type ElementDataSourceMapping,
 } from '@object-ui/react';
+import type { DataSource } from '@object-ui/types';
 import { ObjectGrid } from './ObjectGrid';
 import { VirtualGrid } from './VirtualGrid';
 import { ImportWizard } from './ImportWizard';
@@ -75,9 +78,53 @@ const OBJECT_GRID_DATA_SOURCE: ElementDataSourceMapping = {
   limit: 'pagination.pageSize',
 };
 
+/**
+ * Whether THIS grid placement can only draw rows by querying — i.e. whether a
+ * missing adapter is a defect rather than a legitimate configuration
+ * (objectui#5378 item 2, the `requiresDataSource` contract).
+ *
+ * Every escape hatch `ObjectGrid` itself honours is enumerated here, and the
+ * list is the reason this predicate lives at the call site rather than in the
+ * gate. `getDataConfig` folds an array `data`, a `ViewData` with
+ * `provider: 'value'` and the legacy `staticData` into inline rows and never
+ * reaches the fetch effect; `bind` resolves rows from the surrounding data
+ * scope; and a HOST that owns the fetch — `plugin-list`'s `ListView` is the one
+ * in this repo — hands the window down as a `data` REACT PROP, which is why the
+ * prop is read here too. It is tested with `Array.isArray` because that is the
+ * exact test `ObjectGrid` applies to it (`passedData && Array.isArray(…)`) —
+ * and because `SchemaRenderer` spreads EVERY unstripped schema key as a React
+ * prop, so a mere `'data' in props` would also be true of the schema's own
+ * `data` object and would wave through a grid that really has nowhere to look.
+ *
+ * `objectName` is required last: a grid with no object named it is a different
+ * defect with a different answer, and "no data source" would be the wrong
+ * address for it.
+ */
+const gridNeedsDataSource = (schema: any, hostRows: unknown): boolean => {
+  if (Array.isArray(hostRows)) return false;
+  if (schema?.bind != null) return false;
+  if (Array.isArray(schema?.data)) return false;
+  if (schema?.data?.provider === 'value') return false;
+  if (schema?.staticData != null) return false;
+  return typeof schema?.objectName === 'string' && schema.objectName.length > 0;
+};
+
 // Register object-grid component
 export const ObjectGridRenderer: React.FC<{ schema: any; [key: string]: any }> = ({ schema, ...props }) => {
-  const { dataSource } = useSchemaContext() || {};
+  // ONE resolution rule for the whole family (objectui#5378): an explicit
+  // adapter first, the `SchemaRendererProvider` context second.
+  //
+  // This used to be `useSchemaContext() || {}`, and that hook THROWS without a
+  // provider — the `|| {}` could never catch it. So the exact case this card is
+  // about, an author who never wired a provider, surfaced as `SchemaRenderer`'s
+  // error boundary saying «Component "object-grid" failed to render» over a
+  // React hook message that names neither the data source nor the fix. The
+  // adapter was ALSO already reaching `ObjectGrid` as a prop whenever a provider
+  // happened to exist, because `{...props}` is spread last; pulling it out here
+  // makes that precedence explicit and identical to `detail-view`'s, instead of
+  // an accident of spread order that a reordering could silently reverse.
+  const { dataSource: dataSourceProp, ...rest } = props;
+  const dataSource = useResolvedDataSource<DataSource>(dataSourceProp);
   // The spec's `PageComponentSchema.dataSource` binding (objectstack#6953).
   // Nothing here used to map `dataSource.object` onto the `objectName` this
   // block requires, so a page that declared the binding the spec documents —
@@ -91,8 +138,10 @@ export const ObjectGridRenderer: React.FC<{ schema: any; [key: string]: any }> =
       dataSource={dataSource}
       testId="object-grid"
       errorTitle="This grid’s data source could not be resolved"
+      requiresDataSource={gridNeedsDataSource(schema, (rest as { data?: unknown }).data)}
+      noDataSourceMessage={noDataSourceMessage('object-grid', schema?.objectName)}
     >
-      {(bound) => <ObjectGrid schema={bound} dataSource={dataSource} {...props} />}
+      {(bound) => <ObjectGrid schema={bound} {...rest} dataSource={dataSource} />}
     </ElementDataSourceGate>
   );
 };

--- a/packages/react/src/element-data-source/ElementDataSourceGate.tsx
+++ b/packages/react/src/element-data-source/ElementDataSourceGate.tsx
@@ -59,6 +59,17 @@
  * therefore leaves `limit` unmapped rather than parking it somewhere plausible,
  * and the gap is recorded at the call site instead of being papered over here.
  *
+ * ## A block with no ADAPTER fails loudly too (objectui#5378)
+ *
+ * The section below is about an unresolvable view NAME. The coarser failure —
+ * no runtime adapter reached the block at all — used to render an empty shell
+ * in exactly the same silence, and that is what `requiresDataSource` +
+ * {@link NoDataSourcePanel} now report. Measured on the published
+ * getting-started guide: all five of its blocks resolved no adapter, fetched
+ * nothing, and said nothing. The two panels are deliberately the same shape;
+ * they answer "which view?" and "which data source?", and an author who sees
+ * either one is being told where to look.
+ *
  * ## An unresolvable `view` fails loudly
  *
  * When the named view does not exist the gate renders a configuration error
@@ -78,6 +89,7 @@ import {
   useElementDataSource,
   type ElementDataSourceStatus,
 } from '../hooks/useElementDataSource.js';
+import { SchemaRendererContext } from '../context/SchemaRendererContext.js';
 
 /**
  * Where a block's row cap lives. Three spellings are real in this repo and each
@@ -301,6 +313,83 @@ export function ElementDataSourceLoadingPanel({
   );
 }
 
+/**
+ * The adapter this block would use, resolved the one way every block in the
+ * family resolves it: an explicit value first, the `SchemaRendererProvider`
+ * context second.
+ *
+ * The `isElementDataSourceConfig` guard is the same one
+ * {@link useElementDataSourceSchema} applies — a host handing us the spec
+ * BINDING under this name is handing us metadata, not an adapter, and counting
+ * it as one is how "no data source" reads as "resolved".
+ *
+ * `T` is what the CALLER expects to have been injected, and the assertion is
+ * the caller's, not this hook's: an adapter arrives here as a `dataSource` prop
+ * or a context value that nothing in this package can narrow, so the type has
+ * to be declared by whoever knows which interface their block consumes. Leave
+ * it off and you get `unknown`, which is the honest default.
+ */
+export function useResolvedDataSource<T = unknown>(explicit?: unknown): T | undefined {
+  const context = React.useContext(SchemaRendererContext as React.Context<any>);
+  const named = isElementDataSourceConfig(explicit) ? undefined : explicit;
+  return (named ?? context?.dataSource ?? undefined) as T | undefined;
+}
+
+/**
+ * The author-facing sentence a block with no adapter says out loud.
+ *
+ * One wording for the whole object-bound family, because the reader's mistake
+ * is the same one every time and the fix is the same one every time: the
+ * adapter is injected by an ANCESTOR (`SchemaRendererProvider`), so nothing
+ * written on the block itself can supply it. Naming the block and the object
+ * it was about to read is what turns "nothing happened" into an address.
+ */
+export function noDataSourceMessage(blockKey: string, objectName?: unknown): string {
+  const target =
+    typeof objectName === 'string' && objectName.trim().length > 0
+      ? `“${objectName}”`
+      : 'its object';
+  return (
+    `“${blockKey}” has no data source, so it cannot read ${target}. ` +
+    `Inject one from an ancestor — <SchemaRendererProvider dataSource={…}> from ` +
+    `@object-ui/react — or hand this block a dataSource of its own.`
+  );
+}
+
+/**
+ * The "this block resolved no adapter" panel — objectui#5378 item 2, and the
+ * #5349 shape it belongs to.
+ *
+ * Until this existed, a block that resolved no adapter rendered an EMPTY SHELL:
+ * `object-grid` painted a header-only table, `object-form` a field-less card,
+ * `detail-view` nothing at all — no error, no warning, no empty state that
+ * explained itself. Measured on the published getting-started guide
+ * (`content/docs/guide/building-crud-app.md`), every one of its five blocks was
+ * in that state and the page reported success while fetching nothing.
+ *
+ * The empty shell is the defect, not a side effect of it: it is indistinguishable
+ * from "the query ran and matched no rows", which is the reading an author (very
+ * often an AI author) takes, and it points at the DATA when the fault is in the
+ * WIRING one level up. Same posture as {@link ElementDataSourceErrorPanel}: the
+ * metadata is answerable, so the answer is rendered where the author can see it.
+ */
+export function NoDataSourcePanel({
+  testId,
+  title = 'No data source resolved',
+  message,
+}: ElementDataSourceStatusPanelProps): React.ReactElement {
+  return (
+    <div
+      className="p-4 border border-red-500 rounded text-red-500 bg-red-50 my-2"
+      role="alert"
+      data-testid={`${testId}-no-data-source`}
+    >
+      <p className="font-medium">{title}</p>
+      {message ? <p className="text-sm mt-1">{message}</p> : null}
+    </div>
+  );
+}
+
 export interface ElementDataSourceGateProps<S> {
   /** The block's schema node. */
   schema: S;
@@ -312,6 +401,23 @@ export interface ElementDataSourceGateProps<S> {
   testId: string;
   /** Heading for the unresolvable-view panel. */
   errorTitle?: string;
+  /**
+   * Whether THIS placement cannot do its job without a runtime adapter — when
+   * true and none resolves, the gate renders {@link NoDataSourcePanel} instead
+   * of the block (objectui#5378 item 2).
+   *
+   * The gate cannot compute this and does not try. "Needs an adapter" is a
+   * statement about the block's own fallbacks, and every block in the family
+   * has different ones: an `object-grid` carrying inline `data` rows needs no
+   * adapter, an `object-form` with inline `customFields` needs none, a
+   * `detail-view` handed a `data` record needs none. A predicate guessed HERE
+   * would paint a configuration error over a block that is working, which is a
+   * worse failure than the silence this replaces — so the call site, which
+   * knows its own fallbacks, states it.
+   */
+  requiresDataSource?: boolean;
+  /** Explanation for the no-adapter panel; see {@link noDataSourceMessage}. */
+  noDataSourceMessage?: string;
   /**
    * Renders the block with the bound schema. Called during the gate's own
    * render, so it must RETURN AN ELEMENT and never call hooks itself — the
@@ -335,9 +441,21 @@ export function ElementDataSourceGate<S>({
   dataSource,
   testId,
   errorTitle,
+  requiresDataSource,
+  noDataSourceMessage: noDataSourceText,
   children,
 }: ElementDataSourceGateProps<S>): React.ReactElement | null {
   const bound = useElementDataSourceSchema(schema, mapping, dataSource);
+  const adapter = useResolvedDataSource(dataSource);
+
+  // Reported BEFORE the view state, because with no adapter every downstream
+  // answer is a symptom of this one: `useElementDataSource` cannot list the
+  // object's saved views either, so a block carrying a `view` would otherwise
+  // report "this data source cannot list the saved views" — true, and pointing
+  // at the view name instead of at the missing injection.
+  if (requiresDataSource && adapter == null) {
+    return <NoDataSourcePanel testId={testId} message={noDataSourceText} />;
+  }
 
   if (bound.status === 'missing') {
     return <ElementDataSourceErrorPanel testId={testId} title={errorTitle} message={bound.error} />;

--- a/packages/react/src/element-data-source/__tests__/ElementDataSourceGate.test.tsx
+++ b/packages/react/src/element-data-source/__tests__/ElementDataSourceGate.test.tsx
@@ -30,9 +30,12 @@ import { render, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import {
   ElementDataSourceGate,
+  noDataSourceMessage,
   useElementDataSourceSchema,
+  useResolvedDataSource,
   type ElementDataSourceMapping,
 } from '../ElementDataSourceGate';
+import { SchemaRendererProvider } from '../../context/SchemaRendererContext';
 
 const HOT_VIEW = {
   name: 'hot',
@@ -333,5 +336,117 @@ describe('ElementDataSourceGate — resolution states', () => {
       </ElementDataSourceGate>,
     );
     expect(getByTestId('block').textContent).toBe('task');
+  });
+});
+
+describe('ElementDataSourceGate — no adapter resolved (objectui#5378 item 2)', () => {
+  const Block = ({ schema }: { schema: any }) => (
+    <div data-testid="block">{String(schema?.objectName)}</div>
+  );
+
+  const gate = (props: Record<string, unknown>) => (
+    <ElementDataSourceGate
+      schema={{ objectName: 'account' }}
+      testId="probe"
+      requiresDataSource
+      noDataSourceMessage={noDataSourceMessage('probe-block', 'account')}
+      {...props}
+    >
+      {(bound) => <Block schema={bound} />}
+    </ElementDataSourceGate>
+  );
+
+  it('renders the panel instead of the block when no adapter resolves', () => {
+    const { getByTestId, queryByTestId } = render(gate({}));
+    const panel = getByTestId('probe-no-data-source');
+    expect(panel).toHaveAttribute('role', 'alert');
+    expect(queryByTestId('block')).toBeNull();
+  });
+
+  it('names the block, the object and the ancestor that injects the adapter', () => {
+    // The message has to be an ADDRESS. "Nothing rendered" is what the author
+    // already had; what they did not have is where to look.
+    const { getByTestId } = render(gate({}));
+    const text = getByTestId('probe-no-data-source').textContent ?? '';
+    expect(text).toContain('probe-block');
+    expect(text).toContain('account');
+    expect(text).toContain('SchemaRendererProvider');
+  });
+
+  it('is satisfied by the provider context, not only by an explicit adapter', () => {
+    const { getByTestId, queryByTestId } = render(
+      <SchemaRendererProvider dataSource={makeAdapter() as any}>
+        {gate({})}
+      </SchemaRendererProvider>,
+    );
+    expect(queryByTestId('probe-no-data-source')).toBeNull();
+    expect(getByTestId('block').textContent).toBe('account');
+  });
+
+  it('never fires when the call site did not opt in', () => {
+    // Every other block that uses this gate is untouched: the check is opt-IN
+    // because "needs an adapter" is a statement about the block's own
+    // fallbacks, and a wrong guess paints a configuration error over a
+    // component that is working.
+    const { getByTestId, queryByTestId } = render(
+      <ElementDataSourceGate schema={{ objectName: 'account' }} testId="probe">
+        {(bound) => <Block schema={bound} />}
+      </ElementDataSourceGate>,
+    );
+    expect(queryByTestId('probe-no-data-source')).toBeNull();
+    expect(getByTestId('block').textContent).toBe('account');
+  });
+
+  it('answers "which data source?" before "which view?"', async () => {
+    // With no adapter, the view cannot resolve EITHER — so the view panel would
+    // fire too, reporting "this data source cannot list the saved views", which
+    // is true and points at the view name instead of at the missing injection.
+    const { findByTestId, queryByTestId } = render(
+      <ElementDataSourceGate
+        schema={{ objectName: 'account', dataSource: { object: 'account', view: 'hot' } }}
+        testId="probe"
+        requiresDataSource
+        noDataSourceMessage={noDataSourceMessage('probe-block', 'account')}
+      >
+        {(bound) => <Block schema={bound} />}
+      </ElementDataSourceGate>,
+    );
+    await findByTestId('probe-no-data-source');
+    expect(queryByTestId('probe-datasource-error')).toBeNull();
+  });
+});
+
+describe('useResolvedDataSource — one resolution rule for the family', () => {
+  const read = (explicit: unknown, ambient?: unknown) => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      ambient === undefined
+        ? <>{children}</>
+        : <SchemaRendererProvider dataSource={ambient as any}>{children}</SchemaRendererProvider>;
+    return renderHook(() => useResolvedDataSource(explicit), { wrapper }).result.current;
+  };
+
+  it('prefers the explicit adapter over the ambient one', () => {
+    const explicit = makeAdapter();
+    const ambient = makeAdapter();
+    expect(read(explicit, ambient)).toBe(explicit);
+  });
+
+  it('falls back to the provider context', () => {
+    const ambient = makeAdapter();
+    expect(read(undefined, ambient)).toBe(ambient);
+  });
+
+  it('is undefined — not a throw — when there is no provider at all', () => {
+    // `useSchemaContext()` throws here, which is how "this page never wired a
+    // data source" used to surface as an error boundary over a React hook
+    // message instead of as the panel above.
+    expect(read(undefined)).toBeUndefined();
+  });
+
+  it('never mistakes the spec BINDING for an adapter', () => {
+    // Same guard `useElementDataSourceSchema` applies: counting the binding as
+    // an adapter is how "no data source" reads as "resolved".
+    const ambient = makeAdapter();
+    expect(read({ object: 'account', view: 'hot' }, ambient)).toBe(ambient);
   });
 });


### PR DESCRIPTION
Fixes #5378
Fixes #5377

Two independent axes broke the same five snippets in `content/docs/guide/building-crud-app.md`, and a third turned up while measuring. Landing any one of them alone leaves the page rendering nothing while the PR reports success — which is exactly what #5378 was split out to prevent — so they are folded into one branch.

## What was measured first (baseline, `origin/main` @ `32ef595f4`)

Every snippet rendered through the real registry with a fake adapter. `find` / `findOne` call counts, and whether the row text appears:

| snippet, **as the guide publishes it** | provider wiring | prop wiring |
|---|---|---|
| Step 5 / 6 / 7 `object-grid` | `find` **0**, nothing | `find` **0**, nothing |
| Step 6 `object-form` | `findOne` **0**, nothing | `findOne` **0**, nothing |
| Step 8 `detail-view` | `findOne` **0**, nothing | `findOne` **0**, nothing |

All five dead in both directions. With the keys corrected, the split #5378 reports appears:

| keys corrected, `data` dropped | provider wiring | prop wiring |
|---|---|---|
| `object-grid` | `find` **1**, row renders | `find` **0** |
| `detail-view` | `findOne` **0** | `findOne` **1**, row renders |

Two mutually exclusive wirings. Neither reported anything: no error, no warning, no empty state that explained itself.

## 1. Converge the wiring (ruling item 1)

`detail-view` was registered as the raw `DetailView`, which reads a React `dataSource` **prop**. Its siblings are registered through wrappers that read `SchemaRendererContext`. `SchemaRenderer` itself reads only context, so a prop never becomes context for anything below it.

All three blocks now resolve the adapter through one shared hook, `useResolvedDataSource` (new, `@object-ui/react`): **an explicit `dataSource` prop first, the provider context second.**

**Precedence, stated and pinned:** the explicit prop wins. It is the more specific signal — written on one placement, by someone who can see it — while the context adapter is ambient over every descendant. It is also the only precedence under which the ruling's "the prop form stays accepted" is true of the case that matters: a prop-form caller mounted inside an app that happens to have a provider would otherwise have its explicit choice silently overruled by an ancestor it never wrote.

**Additive, as ruled — no prop removed this pass.** Three wirings are asserted for `detail-view`: context alone (new), prop alone (must not break), and both at once (prop wins).

### The compatibility surface, measured (the triage confidence gap)

Triage flagged that nobody had sized the existing `detail-view` prop-form caller population. Measured in this repo:

- `packages/plugin-detail/src/renderers/record-details.tsx` and `packages/plugin-detail/src/RecordDetailDrawer.tsx` both render the **component** directly, never through the registry. The published README documents the same direct form. The new wrapper does not sit between any of them and `DetailView`.
- Registry-routed `detail-view` nodes carrying a `dataSource` prop: **zero**, the getting-started guide being the one that tried.

So the additive wrapper changes no measured caller's behaviour and creates no ambiguous precedence. **No fork to report** — but the precedence is pinned by test rather than left to be discovered.

Two side effects of the convergence, both strictly widening:

- `object-grid` used to call `useSchemaContext()`, which **throws** without a provider — the `|| {}` beside it could never catch it. So the exact case this card is about surfaced as the error boundary saying `Component "object-grid" failed to render` over a React hook message naming neither the data source nor the fix. It now reads the context.
- `object-form` gains a `dataSource` prop it did not have. It read context only, so nothing that worked before resolves differently.

## 2. The silence dies with it (ruling item 2)

A block in the family that resolves no adapter now renders a **No data source resolved** panel — `role="alert"`, same shape as the existing unresolvable-view panel — naming the block, the object it was about to read, and the ancestor that injects the adapter. An address, not a symptom.

The check is **opt-in per block** (`requiresDataSource` on `ElementDataSourceGate`). The gate cannot compute "needs an adapter" and does not try: every block has different escape hatches, and a predicate guessed in the shared gate would paint a configuration error over a block that is working — a worse failure than the silence it replaces. Each call site states it, enumerating its own fallbacks:

- `object-grid`: inline rows (`data` array, `provider: 'value'`, legacy `staticData`), `bind`, or a host that owns the fetch and passes the window as a `data` React prop (`plugin-list`'s ListView). Tested with `Array.isArray`, which is the exact test `ObjectGrid` applies — a bare `'data' in props` would also be true of the schema's own `data` object, because `SchemaRenderer` spreads every unstripped schema key as a prop.
- `object-form`: inline `customFields`, which is what `hasInlineFields` gates on inside the component.
- `detail-view`: an inline `data` record, or an `api` endpoint it fetches without an adapter.

The no-adapter answer comes **before** the unresolvable-view answer: with no adapter the view cannot resolve either, so the block would otherwise report "this data source cannot list the saved views" — true, and pointing at the view name instead of at the missing injection.

The other eight blocks using this gate are untouched; the flag defaults off.

## 3. The guide (ruling item 3, plus #5377's key axis)

- **Wiring** — one `SchemaRendererProvider` at the top of the App, per AGENTS.md commandment #1. No `SchemaRenderer` in the page carries a `dataSource` prop any more; a test asserts that over the file's text.
- **Keys** — `object` becomes `objectName` in all five snippets.
- **`recordId` becomes `resourceId` on `detail-view` ONLY.** `object-form` genuinely reads `recordId` (`ObjectForm.tsx` calls `findOne(schema.objectName, schema.recordId)`), so the blanket rename that "fix the keys" reads like from a distance would have taken a working block to broken. Both directions are pinned: the form probe asserts the `resourceId` spelling loads **no** record there, the detail probe asserts `recordId` loads none there.
- **`data` removed from the `detail-view` snippet only.** Per-snippet triage, not a sweep: on `detail-view`, `data` means *"here is the record already, do not fetch"* — `DetailView` returns early on any `schema.data`, so the object's metadata was being installed as the record and `findOne` never ran (measured `findOne` **0** with it, **1** without). On `object-grid` and `object-form` the same key is measured **inert** (`find` 1 either way), so it stays and is filed instead.

### A third axis, found while measuring — and fixed here with evidence

The guide's `setup.ts` loaded `@object-ui/components` and `@object-ui/fields` only. `initializeComponents()` registers neither the plugins nor anything else beyond its own package, and Step 1 never installed `@object-ui/plugin-detail` at all. Measured by rendering the three keys against exactly the guide's registration set:

```
REG|object-grid|text="Unknown component type: object-grid…"
REG|object-form|text="Unknown component type: object-form…"
REG|detail-view|text="Unknown component type: detail-view…"
```

All five snippets resolved to the OBJUI-001 panel for anyone who followed the page literally, so no amount of wiring or key fixing could have made it render. Fixed in place rather than filed because the correct form is pinned by the page's own idiom — Step 2 already writes `import '@object-ui/fields';` and explains why — and because a render probe over "the guide's snippets" that registered the plugins itself while the guide did not would have been measuring something the reader cannot reproduce.

## Acceptance: a render probe, not a diff review

Three probe files (`packages/plugin-{grid,form,detail}/src/__tests__/guideCrudAppRenders.test.tsx`) **evaluate the guide's own schema literals off disk** — balanced-brace extraction plus `Function`, with the identifiers the page closes over bound — and render them through the real registry. A transcription kept in the tests would drift from the page silently, which is this defect's whole failure mode. Each file asserts its snippet count first, so a lost snippet cannot make the file vacuous.

Per snippet, after both axes: adapter call count **0 → 1** and the row text appears.

| snippet | before | after |
|---|---|---|
| Step 5 `object-grid` | `find` 0 | `find` 1, `["task", …]`, row painted |
| Step 6 `object-grid` | `find` 0 | `find` 1, row painted |
| Step 7 `object-grid` | `find` 0 | `find` 1, row painted |
| Step 6 `object-form` | `getObjectSchema` 0 / `findOne` 0 | `getObjectSchema('task')`, `findOne('task','42')`, fields painted |
| Step 8 `detail-view` | `findOne` 0 | `findOne('task','42')`, record painted |

Each axis is also pinned as a standing contrast, so reintroducing one fails here rather than on a reader's screen: re-spell `objectName` back to `object` and the block fetches nothing; put `recordId` on the detail view and it loads nothing; hand the detail view a `data` and `findOne` never runs.

## Reverse verification — predicted, then observed

No build artifact sits between any edit and the thing under test: the root vitest config aliases every `@object-ui/*` specifier to `packages/*/src`, and each probe imports its own plugin as `../index`. Leg A proves it rather than asserting it — it edits a registration that a *different* file's assertions depend on, and a stale `dist/` in the path would have left it green.

| leg | predicted | observed |
|---|---|---|
| A — register the raw `DetailView` again | 4 red | **2 red**: the provider-wiring test and the panel-presence test |
| B — drop `requiresDataSource` from the grid | 1 red | **1 red**, exactly the panel test |
| C — put `object:` back in the guide's Step 5 | 1 red | **2 red** |

Leg A is the interesting miss, and it is about my own tests rather than the code: two of the three no-adapter tests are *absence* assertions (a placement with inline rows must NOT get the panel), and a build with no wrapper satisfies those trivially. They are false-positive guards, not feature proofs, and only the presence assertion can fail when the feature is removed. Leg C under-counted for the same kind of reason — the both-wirings test reads the same snippet, so it dies with it.

A cross-package type check was reverse-verified too: `requiresDataSource="yes-please"` in `packages/plugin-grid` draws `TS2322: Type 'string' is not assignable to type 'boolean | undefined'`, which proves the new prop reached `packages/react/dist/index.d.ts` and that plugin-grid's `tsc` is reading the rebuilt declarations, not a cached copy. (It first failed for the opposite reason — a stale `dist` gave `TS2558: Expected 0 type arguments` after `useResolvedDataSource` became generic.)

## Out of scope, filed

Filed as #5446: Step 7 documents a view switcher and a search box that `object-grid` never reads — top-level `view` has zero read points, and `data: { objectSchema, queryParams }` is none of `ViewData`'s four `provider` arms. Measured inert (identical `find` params with and without both keys). Left alone here because two legitimate correct forms exist — move it into the spec `dataSource: { object, view }` binding, or spell the view's declared `filter` / `sort` on the block — and choosing between them changes what the page teaches and, for the first option, what a reader sees when their backend has no such saved view. That is a decision, not a mechanical fix.

## Verification

Gate union re-derived from the actual three-dot changed paths after the final commit, and run at `55c49cbb1`:

- `pnpm exec vitest run packages/plugin-detail/ packages/plugin-form/ packages/react/` — 193 files, **2074 passed**
- `pnpm exec vitest run packages/plugin-grid/ packages/plugin-list/` — 124 files, **1379 passed** (plugin-list included deliberately: it is the host that passes the grid's rows as a React prop)
- `pnpm exec vitest run packages/app-shell/` — 456 files, **4410 passed**, 1 skipped (the heaviest in-repo consumer of all three blocks)
- `turbo run type-check` across the workspace — **81/81**, the downstream-consumer direction for the new `@object-ui/react` exports
- `turbo run lint` on the four changed packages — **0 errors**
- `check:doc-types`, `check:doc-snippets` (with the packages its `--build-filter` names built), `check-doc-links`, `check:control-bytes`, `check:phantom-deps`, `check:self-import`, `check-lint-coverage`, `check-type-check-coverage`, `check:skills-paths`, `check:spec-symbols`, `check:action-forward-parity`, `check:i18n-keys`, `check:i18n-drift`, `check-changeset-no-major`, `check-changeset-fixed`, `check-changeset-presence` — all green

Changeset: `minor` on the four packages (never `major`, per AGENTS.md §版本号策略).

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_