### PR TITLE
fix(form): refuse invented namespaced field widget ids, and cover the remaining secret spellings

### DIFF
--- a/.changeset/secret-widget-spellings-5375.md
+++ b/.changeset/secret-widget-spellings-5375.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/components': minor
+'@object-ui/core': minor
+---
+
+Three more secret-field spellings no longer render a secret in clear text on the form's unregistered-widget branch.
+
+Measured on `main` at `f2e11ae6f`, the real `form` renderer on the built-in path
+(no `registerAllFields()`), before and after objectui#5322's fix:
+
+```
+type            registry hit   rendered type
+ui:password     true           text
+secret          false          text
+field:secret    false          text
+```
+
+Two halves, per the maintainer ruling of 2026-08-20:
+
+- **`@object-ui/core` — an unresolvable namespaced widget id is now an authoring
+  ERROR.** A form field's widget id (`widget`, else `type`) may name the
+  `field:` namespace or a bare name; any other namespace resolves no field
+  widget (objectui#5254) and used to degrade silently to a plain text box.
+  `validateSchema` now reports `UNRESOLVABLE_FIELD_WIDGET_NAMESPACE` and
+  `assertValidSchema` throws. Behaviour change: a schema that previously
+  validated with e.g. `type: 'ui:password'` is now invalid — inventing a
+  plausible-looking widget id fails loudly instead of rendering clear text.
+  `field:` ids stay valid whether or not the widget is registered, since
+  registration is a runtime fact an authoring-time validator cannot see.
+- **`@object-ui/components` — the known secret types cover the remaining
+  spellings.** Bare `secret` and `ui:password` render the native masked input,
+  and `field:secret` is refused outright like `field:password`. Existing authors
+  need no migration.
+
+`ui:password` **is** registered — as an SDUI node renderer for a top-level
+`{ type: 'email' }`-style node — so an author who checked whether it resolved
+got a yes and still got a clear-text box on the field path. No producer emits
+any of the three; all are reachable only through a hand-authored standalone
+form schema, which is exactly the surface where the author is the producer and
+no normalizer sits in between.

--- a/packages/components/src/renderers/form/__tests__/form-secret-widget-spellings.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-secret-widget-spellings.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The three remaining secret-field spellings on the unregistered-widget
+ * `default` branch — objectui#5375, maintainer ruling of 2026-08-20 (C + A).
+ * This file pins **half A**: the defense-in-depth table entries. Half C — the
+ * authoring-time refusal of a namespaced id that is not `field:` — is pinned in
+ * `packages/core/src/validation/__tests__/form-field-widget-namespace.test.ts`.
+ *
+ * ## What was measured on this card's branch point (`main` at f2e11ae6f)
+ *
+ * The real `form` renderer on the built-in path (no `registerAllFields()`),
+ * before AND after objectui#5322's fix:
+ *
+ *   type            registry hit   rendered type
+ *   ui:password     TRUE           text
+ *   secret          false          text
+ *   field:secret    false          text
+ *
+ * All three put the secret on screen in clear text. For contrast, `password`
+ * renders a native masked input and `field:password` is refused outright.
+ *
+ * ## Why each one missed, and what each gets now
+ *
+ *  - **`ui:password`** — `renderFieldComponent` resolves a field's `type` only
+ *    through the `field:` namespace (objectui#5254), so a `ui`-qualified id
+ *    resolves nothing and falls here, where it missed
+ *    `NATIVE_INPUT_FIELD_TYPES` (keyed on the `field:`-stripped type). It is
+ *    the "verifying does not protect you" shape: `ui:password` IS registered —
+ *    as an SDUI node renderer for a top-level `{ type: 'email' }`-style node —
+ *    so an author who checks whether it resolves gets a YES. It now takes the
+ *    native masked input, and half C makes writing it an authoring error.
+ *  - **bare `secret`** — the ObjectQL field type. `mapFieldTypeToFormType` maps
+ *    it to `field:password`, so an OBJECT-derived secret field was always safe;
+ *    a hand-authored `{ name, type: 'secret' }` in a standalone `FormSchema`
+ *    does not go through that mapping. It claims no registered widget, so this
+ *    branch is its intended home: native masked input, same as bare `password`.
+ *  - **`field:secret`** — a REGISTRY KEY naming a widget nothing registers, so
+ *    reaching this branch with it proves the declared widget is absent. Refused
+ *    outright, exactly as `field:password` is.
+ *
+ * ## Severity, stated honestly
+ *
+ * No producer emits any of the three; all are reachable only through a
+ * hand-authored form schema. That is lower severity than objectui#5322 — but a
+ * hand-authored standalone form is exactly the surface where the AUTHOR is the
+ * producer and no normalizer sits in between.
+ *
+ * ## Build artifacts
+ *
+ * None between the edit and the thing under test. The root `vitest.config.mts`
+ * `alias` block maps every `@object-ui/*` specifier to that package's `src/`,
+ * and the renderer under test is imported through a relative path
+ * (`../../../renderers`). No `dist/` is consulted on this leg.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/** Render the built-in branch: no `registerAllFields()`, so nothing resolves under `field:`. */
+function renderForm(fields: any[], extra: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields, ...extra }} />,
+  );
+}
+
+const input = () => document.querySelector('input') as HTMLInputElement | null;
+
+afterEach(cleanup);
+
+describe('secret field spellings on the unregistered-widget default branch (objectui#5375)', () => {
+  describe('the routing premise', () => {
+    it('resolves NOTHING under `field:` on this path', () => {
+      // Counter-probe: without it the whole file would pass on a registry
+      // where the widgets happen to exist — never exercising the branch.
+      expect(ComponentRegistry.get('form')).toBeTruthy();
+      expect(ComponentRegistry.get('field:secret')).toBeUndefined();
+      expect(ComponentRegistry.get('field:password')).toBeUndefined();
+    });
+
+    it('DOES resolve `ui:password` — the "verifying does not protect you" fact', () => {
+      // The whole reason half C is the primary fix: an author who checks
+      // whether this id resolves gets a yes, and still got a clear-text box.
+      // (`./input.tsx` registers `password` with `namespace: 'ui'`.)
+      expect(ComponentRegistry.get('ui:password')).toBeTruthy();
+    });
+  });
+
+  describe('`ui:password` — a registered SDUI node id that is not a field widget', () => {
+    it('renders a native MASKED input, not a clear-text box', () => {
+      // Pre-fix: type="text" — the secret on screen in clear text.
+      const { container } = renderForm([
+        { name: 'pw', label: 'Password', type: 'ui:password' },
+      ]);
+      const el = container.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      expect(el.getAttribute('type')).toBe('password');
+    });
+
+    it('does not resolve the registered `ui` node renderer as the field widget', () => {
+      // objectui#5254's ruling stands: the field path resolves colon-qualified
+      // ids ONLY under `field:`. If the cross-namespace fallback came back, the
+      // `ui` renderer would draw its own <Label> on top of the form's.
+      const { container } = renderForm([
+        { name: 'pw', label: 'Password', type: 'ui:password' },
+      ]);
+      expect(container.querySelectorAll('label').length).toBe(1);
+    });
+
+    it('an explicitly authored `inputType` still wins over the table', () => {
+      const { container } = renderForm([
+        { name: 'pw', label: 'Password', type: 'ui:password', inputType: 'text' },
+      ]);
+      expect((container.querySelector('input') as HTMLInputElement).getAttribute('type')).toBe('text');
+    });
+  });
+
+  describe('bare `secret` — the ObjectQL type, hand-authored', () => {
+    it('renders a native MASKED input, not a clear-text box', () => {
+      // Pre-fix: type="text".
+      const { container } = renderForm([
+        { name: 'apiKey', label: 'API key', type: 'secret' },
+      ]);
+      const el = container.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      expect(el.getAttribute('type')).toBe('password');
+    });
+
+    it('matches what the bare `password` spelling renders', () => {
+      // The two bare spellings name the same kind of value; a fix that gave
+      // them different answers would not be a fix.
+      const { container } = renderForm([{ name: 'a', type: 'password' }]);
+      expect((container.querySelector('input') as HTMLInputElement).getAttribute('type')).toBe('password');
+    });
+  });
+
+  describe('`field:secret` — a registry key nothing registers', () => {
+    it('renders NO input at all', () => {
+      // Pre-fix: <input type="text"> — the secret on screen in clear text.
+      const { container } = renderForm([
+        { name: 's1', label: 'Secret', type: 'field:secret' },
+      ]);
+      expect(container.querySelector('input')).toBeNull();
+    });
+
+    it('renders a visible refusal naming the widget that is missing', () => {
+      const { getByTestId } = renderForm([
+        { name: 's2', label: 'Secret', type: 'field:secret' },
+      ]);
+      const refusal = getByTestId('field-missing-secret-widget');
+      expect(refusal.getAttribute('role')).toBe('alert');
+      expect(refusal.getAttribute('data-missing-field-widget')).toBe('field:secret');
+      expect(refusal.textContent).toContain('field:secret');
+      expect(refusal.textContent).toContain('registerAllFields()');
+    });
+
+    it('keeps a seeded secret out of the DOM entirely', () => {
+      // Not "is it masked" but "is it absent": a type="password" box still
+      // carries the value on the element; this branch must carry it nowhere.
+      const { container } = renderForm(
+        [{ name: 's3', label: 'Secret', type: 'field:secret' }],
+        { defaultValues: { s3: 'hunter2' } },
+      );
+      expect(container.innerHTML).not.toContain('hunter2');
+      expect(input()).toBeNull();
+    });
+  });
+
+  describe('the neighbours this card did NOT move', () => {
+    it('`field:password` still refuses (objectui#5322, unchanged)', () => {
+      const { container, getByTestId } = renderForm([
+        { name: 'pw', label: 'Password', type: 'field:password' },
+      ]);
+      expect(container.querySelector('input')).toBeNull();
+      expect(getByTestId('field-missing-secret-widget').getAttribute('data-missing-field-widget'))
+        .toBe('field:password');
+    });
+
+    it('a non-secret `ui:*` id is untouched — no namespace-stripping rule was added', () => {
+      // The restraint pin. `ui:` did NOT get a prefix-stripping rule of its
+      // own: only the one measured secret spelling is in the table. If someone
+      // later "generalizes" it by stripping `ui:`, this turns red — which is
+      // the point, because that would re-open the cross-namespace resolution
+      // objectui#5254 removed.
+      const { container } = renderForm([{ name: 'e', label: 'Email', type: 'ui:email' }]);
+      const el = container.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      expect(el.getAttribute('type')).toBe('text');
+    });
+
+    it('an ordinary unregistered `field:*` id still renders its text box', () => {
+      // Only the SECRET types are refused — turning the whole class into
+      // refusals would change fields no card has moved or measured.
+      const { container } = renderForm([{ name: 'c', label: 'Cost', type: 'field:currency' }]);
+      const el = container.querySelector('input') as HTMLInputElement;
+      expect(el).toBeTruthy();
+      expect(el.getAttribute('type')).toBe('text');
+    });
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -2817,15 +2817,49 @@ const NATIVE_PICKER_INPUT_TYPES = new Set(['date', 'datetime-local', 'time', 'mo
  * produced, while the leak, the duplicate `<label>` and the dead `max_length`
  * go away. An explicitly authored `inputType` still wins over it.
  *
- * Deliberately just these two. Every other declared field type with a native
- * HTML equivalent (`url`, `phone`, `number`, `color`, `date` …) ALREADY takes
- * this branch as `type="text"` on the built-in path and is untouched by
- * objectui#5254 — widening the table here would change fields this card
- * neither moved nor measured.
+ * Deliberately narrow. Every other declared field type with a native HTML
+ * equivalent (`url`, `phone`, `number`, `color`, `date` …) ALREADY takes this
+ * branch as `type="text"` on the built-in path and is untouched by
+ * objectui#5254 — widening the table beyond a SECRET would change fields no
+ * card has moved or measured.
+ *
+ * ## The two secret spellings added by objectui#5375 (maintainer ruling of
+ * 2026-08-20, half A — defense in depth)
+ *
+ * Measured on `main` at f2e11ae6f, on the built-in path, all three of these
+ * put the value on screen as `type="text"`:
+ *
+ *   ui:password    registry hit = TRUE    rendered type="text"
+ *   secret         registry hit = false   rendered type="text"
+ *   field:secret   registry hit = false   rendered type="text"
+ *
+ *  - **`secret`** is the ObjectQL field type. `mapFieldTypeToFormType` maps it
+ *    to `field:password`, so an OBJECT-derived secret field is already safe —
+ *    it arrives here as `password`. What was not safe is a hand-authored
+ *    `{ name, type: 'secret' }` in a standalone `FormSchema`, which reaches
+ *    this table under its own name and missed it.
+ *  - **`ui:password`** is keyed RAW, not as a declared type, and that is
+ *    deliberate: {@link normalizeFieldType} strips only `field:` (the one
+ *    namespace that means "field widget", objectui#5254), so a `ui:`-qualified
+ *    id arrives here unstripped. It is NOT given a namespace-stripping rule of
+ *    its own — that would re-open the cross-namespace resolution #5254
+ *    deliberately removed, and would silently move `ui:email`, `ui:date` and
+ *    every other `ui:*` id this card never measured.
+ *
+ * `ui:password` is ALSO refused at authoring time as of the same card (half C,
+ * `validateFormSchema` in `@object-ui/core`): a namespaced id that is not
+ * `field:` resolves no field widget and is an authoring error. This entry is
+ * the defense-in-depth half — validation is advisory at render time, so a host
+ * that never validates still must not leak, and an existing author who wrote
+ * the spelling needs no migration to keep a working (masked) field.
  */
 const NATIVE_INPUT_FIELD_TYPES: Record<string, string> = {
   email: 'email',
   password: 'password',
+  // objectui#5375 — see the two paragraphs above. `secret` is a DECLARED type
+  // key (so `field:secret` normalizes into it too); `ui:password` is a RAW key.
+  secret: 'password',
+  'ui:password': 'password',
 };
 
 /**
@@ -2838,11 +2872,26 @@ const NATIVE_INPUT_FIELD_TYPES: Record<string, string> = {
  * least likely to notice (an input, in the right slot, with the right label).
  *
  * Membership is the declared type — the `field:` prefix already stripped by
- * {@link normalizeFieldType} — so the one entry answers both spellings.
- * `secret` (the ObjectQL type `mapFieldTypeToFormType` maps to
- * `field:password`) reaches this set through that mapping, as `password`.
+ * {@link normalizeFieldType} — so each entry answers both its spellings.
+ * An OBJECT-derived secret field reaches this set as `password`, because
+ * `mapFieldTypeToFormType` maps the ObjectQL `secret` type to `field:password`.
+ *
+ * `secret` itself joined the set with objectui#5375 (half A), for the spelling
+ * that mapping never sees: a hand-authored `{ name, type: 'field:secret' }` in
+ * a standalone `FormSchema`. It is a registry key naming a widget nothing
+ * registers, so — exactly like `field:password` — reaching the default branch
+ * with it proves the declared widget is absent, and the value is refused rather
+ * than rendered. The BARE `secret` spelling is not refused: it claims no
+ * registered widget at all, so this branch is its intended home and
+ * `NATIVE_INPUT_FIELD_TYPES` above renders it as the native masked input, the
+ * same answer a bare `password` gets.
+ *
+ * Only members reached with a `field:` prefix are refused — see the gate in
+ * `renderFieldComponent`'s `default` arm — so adding a non-`field:` spelling
+ * here would be a dead entry. `ui:password` is therefore handled by
+ * `NATIVE_INPUT_FIELD_TYPES` alone, and not listed here.
  */
-const SECRET_FIELD_TYPES = new Set(['password']);
+const SECRET_FIELD_TYPES = new Set(['password', 'secret']);
 
 /**
  * `field:<type>` ids already reported missing, keyed by widget id + field name.
@@ -3402,9 +3451,11 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       //
       // The declared type — the prefix stripped — is what the two halves below
       // read. Only `field:` is stripped (`normalizeFieldType`): it is the one
-      // namespace that means "field widget", the one the producer emits, and
-      // the one this card measured. A `ui:`-qualified id keeps rendering
-      // exactly as it does today.
+      // namespace that means "field widget" and the one the producer emits.
+      // A `ui:`-qualified id therefore arrives here UNSTRIPPED and is matched
+      // raw where it is matched at all (`ui:password`, objectui#5375) — no
+      // second namespace gets a stripping rule, because that would re-open the
+      // cross-namespace resolution objectui#5254 deliberately removed.
       const declaredType = normalizeFieldType(type);
 
       // ── Half 1: REFUSE, for a secret ────────────────────────────────────
@@ -3416,11 +3467,14 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       // handling) is absent, and would look like it worked. So the value is
       // not rendered at all, in any form, and the refusal says why.
       //
-      // Deliberately narrow — `password` only, and only under `field:`. Every
-      // other unregistered `field:*` id (`field:currency`, `field:qrcode` …)
-      // still renders the text box it renders today: turning the whole class
-      // into refusals would change fields this card neither moved nor
+      // Deliberately narrow — the SECRET types only, and only under `field:`.
+      // Every other unregistered `field:*` id (`field:currency`,
+      // `field:qrcode` …) still renders the text box it renders today: turning
+      // the whole class into refusals would change fields no card has moved or
       // measured, the same restraint `NATIVE_INPUT_FIELD_TYPES` above states.
+      // `field:secret` joined `SECRET_FIELD_TYPES` with objectui#5375 and so
+      // is refused here too; the BARE `secret` spelling is not — it names no
+      // registry key, so it takes the native masked input below.
       if (type.startsWith('field:') && SECRET_FIELD_TYPES.has(declaredType)) {
         return (
           <MissingSecretFieldWidget
@@ -3483,9 +3537,10 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
           // `@object-ui/types`), and `field:email` declares `email` just as
           // plainly as a bare `email` does. Before this the prefixed spelling
           // missed the table and lost the native keyboard and validation.
-          // `field:password` never reaches here — half 1 above refuses it —
-          // so this line answers `field:email`, and the two bare spellings
-          // exactly as before.
+          // `field:password` / `field:secret` never reach here — half 1 above
+          // refuses them — so this line answers `field:email`, the bare
+          // spellings, and (objectui#5375) the two raw secret spellings
+          // `secret` and `ui:password`, which the table now carries.
           type={inputType || NATIVE_INPUT_FIELD_TYPES[declaredType] || 'text'}
           placeholder={placeholder}
           className={cn(readonlyInputClass)}

--- a/packages/core/src/validation/__tests__/form-field-widget-namespace.test.ts
+++ b/packages/core/src/validation/__tests__/form-field-widget-namespace.test.ts
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Authoring-time refusal of an unresolvable NAMESPACED field widget id —
+ * objectui#5375, maintainer ruling of 2026-08-20 (option C, the primary).
+ * The renderer-side defense-in-depth half (A) is pinned in
+ * `packages/components/src/renderers/form/__tests__/form-secret-widget-spellings.test.tsx`.
+ *
+ * ## The class this closes
+ *
+ * A form field's `type` either names a `field:`-namespaced widget or takes the
+ * renderer's declared `default` input branch (objectui#5254). Any OTHER
+ * namespace resolves nothing on the field path and silently degrades to a plain
+ * text box — which, when the field holds a secret, is the secret on screen in
+ * clear text. Measured on `main` at f2e11ae6f, built-in path:
+ *
+ *   type            registry hit   rendered type
+ *   ui:password     TRUE           text
+ *   secret          false          text
+ *   field:secret    false          text
+ *
+ * `ui:password` resolving in the registry is what makes the class fix primary
+ * rather than another entry in a renderer-side table: an author who VERIFIES
+ * that the id resolves gets a yes, and still gets clear text. A table answers
+ * today's three spellings and leaves the next invented id the same silent
+ * degrade — which is literally how objectui#5375 came to exist after #5322.
+ *
+ * ## Not a warning — deliberately
+ *
+ * The ruling rules a warning out by name: a warning IS the silent degrade this
+ * check exists to kill, in a new spelling. `type: 'error'` is asserted below,
+ * along with `valid === false` and `assertValidSchema` throwing.
+ *
+ * ## Build artifacts
+ *
+ * None. `@object-ui/core` is aliased to `packages/core/src` by the root
+ * `vitest.config.mts`, and this file imports the validator through a relative
+ * path. No `dist/` is consulted on this leg.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateSchema, assertValidSchema } from '../schema-validator.js';
+
+const CODE = 'UNRESOLVABLE_FIELD_WIDGET_NAMESPACE';
+
+const formWith = (field: Record<string, unknown>) => ({
+  type: 'form',
+  fields: [{ name: 'secretValue', ...field }],
+});
+
+const namespaceErrors = (schema: unknown) =>
+  validateSchema(schema as any).errors.filter((e) => e.code === CODE);
+
+describe('unresolvable namespaced field widget id (objectui#5375)', () => {
+  describe('the counter-probe: this validator does see these schemas', () => {
+    it('still reports the pre-existing form-field diagnostics', () => {
+      // Without this, every "no error" assertion below could be passing for
+      // the wrong reason — a validator that never looked at `fields` at all.
+      const result = validateSchema({ type: 'form', fields: [{ type: 'text' }] } as any);
+      expect(result.errors.some((e) => e.code === 'MISSING_FIELD_NAME')).toBe(true);
+    });
+  });
+
+  describe('an invented namespaced id is REFUSED', () => {
+    it('rejects `ui:password` — the spelling that resolves in the registry', () => {
+      const result = validateSchema(formWith({ type: 'ui:password' }) as any);
+      expect(result.valid).toBe(false);
+      const hits = result.errors.filter((e) => e.code === CODE);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].path).toBe('schema.fields[0].type');
+    });
+
+    it('is an ERROR, never a warning', () => {
+      // The load-bearing assertion of half C. A warning would be the same
+      // silent degrade under a new name.
+      const result = validateSchema(formWith({ type: 'ui:password' }) as any);
+      expect(result.errors.map((e) => e.code)).toContain(CODE);
+      expect(result.warnings.map((e) => e.code)).not.toContain(CODE);
+      expect(result.errors.find((e) => e.code === CODE)!.type).toBe('error');
+    });
+
+    it('makes `assertValidSchema` throw', () => {
+      // The publish-time limb: a validating producer stops, it does not render.
+      expect(() => assertValidSchema(formWith({ type: 'ui:password' }) as any))
+        .toThrow(/is not a form field widget/);
+    });
+
+    it('names the id, the rule and the fix in the message', () => {
+      const [err] = namespaceErrors(formWith({ type: 'ui:password' }));
+      expect(err.message).toContain('ui:password');
+      expect(err.message).toContain('field:');
+      // Resolving in the registry is not proof it resolves on the field path —
+      // the message has to say so, because checking is what the author did.
+      expect(err.message).toContain('registered SDUI node renderer');
+    });
+
+    it('rejects an id nobody registered at all, not just the measured one', () => {
+      // The point of closing the CLASS: the next invented spelling is refused
+      // without anyone adding a table entry for it.
+      expect(namespaceErrors(formWith({ type: 'widget:secret-key' }))).toHaveLength(1);
+      expect(namespaceErrors(formWith({ type: 'element:input' }))).toHaveLength(1);
+    });
+
+    it('reads the `widget` key with the same precedence the renderer uses', () => {
+      // `resolvedType` in form.tsx is `widget || field.widget || type`, so an
+      // id written as `widget` reaches exactly the same clear-text box.
+      const hits = namespaceErrors(formWith({ type: 'password', widget: 'ui:password' }));
+      expect(hits).toHaveLength(1);
+      expect(hits[0].path).toBe('schema.fields[0].widget');
+    });
+
+    it('is found on a form nested inside another schema', () => {
+      const nested = {
+        type: 'page',
+        children: [formWith({ type: 'ui:password' })],
+      };
+      const hits = namespaceErrors(nested);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].path).toBe('schema.children[0].fields[0].type');
+    });
+  });
+
+  describe('what stays legal — the set is narrowed, not closed', () => {
+    it('accepts any `field:` id, registered or not', () => {
+      // Registration is a RUNTIME fact (`registerAllFields()`, a lazily loaded
+      // plugin) that an authoring-time validator cannot see. The renderer
+      // already answers an unregistered `field:` secret with a visible refusal
+      // (objectui#5322).
+      expect(namespaceErrors(formWith({ type: 'field:password' }))).toHaveLength(0);
+      expect(namespaceErrors(formWith({ type: 'field:not-registered-anywhere' }))).toHaveLength(0);
+    });
+
+    it('accepts bare names — an open set this validator cannot decide', () => {
+      // Every registered `field:<name>` widget, third-party ones included, is
+      // reachable by its short name.
+      for (const type of ['text', 'input', 'select', 'password', 'secret', 'some-vendor-widget']) {
+        expect(namespaceErrors(formWith({ type }))).toHaveLength(0);
+      }
+    });
+
+    it('ignores a non-string `type`', () => {
+      expect(namespaceErrors(formWith({ type: 42 }))).toHaveLength(0);
+      expect(namespaceErrors(formWith({}))).toHaveLength(0);
+    });
+
+    it('leaves the metadata-admin designer form shape alone', () => {
+      // The one non-`field:` colon-qualified id the census found in this repo:
+      // `{ field: 'source', widget: 'ref:component' }` under `sections[].fields[]`
+      // of a `type: 'simple'` designer form, resolved by app-shell's own
+      // `WIDGETS` table — a different layer that never reaches
+      // `renderFieldComponent`. This check is gated on `type === 'form'`, so it
+      // must not touch it.
+      const designerForm = {
+        type: 'simple',
+        sections: [
+          {
+            label: 'Data Context',
+            fields: [
+              { field: 'variables', type: 'repeater', fields: [{ field: 'source', widget: 'ref:component' }] },
+            ],
+          },
+        ],
+      };
+      expect(namespaceErrors(designerForm)).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/validation/schema-validator.ts
+++ b/packages/core/src/validation/schema-validator.ts
@@ -185,6 +185,124 @@ function validateCRUDSchema(schema: any, path: string = 'schema'): SchemaNodeVal
 }
 
 /**
+ * The ONE namespace a form field's widget id may name — objectui#5254,
+ * maintainer ruling of 2026-08-19.
+ *
+ * A form field's `type` either names a `field:`-namespaced widget or takes the
+ * renderer's declared `default` input branch. It never resolves a plain SDUI
+ * node renderer: `renderFieldComponent` (`@object-ui/components`) resolves a
+ * colon-qualified id ONLY under this prefix, and `resolveFieldLabelling` /
+ * `resolvesToRegisteredFieldWidget` there mirror it exactly.
+ */
+const FIELD_WIDGET_NAMESPACE = 'field:';
+
+/**
+ * The two keys of an AUTHORED form field that can carry a widget id.
+ *
+ * Both are `unknown` rather than `string`: this validator's whole job is to be
+ * handed metadata that may be any shape at all, so the narrowing has to happen
+ * here and not be assumed by the type. (The rest of this file predates that
+ * discipline and reads its input as `any`; new code does not add to it.)
+ */
+interface AuthoredFormField {
+  type?: unknown;
+  widget?: unknown;
+}
+
+/**
+ * The widget id a form field will actually be RENDERED as.
+ *
+ * Mirrors the renderer's own precedence (`resolvedType` in
+ * `packages/components/src/renderers/form/form.tsx`: explicit form-config
+ * `widget`, then the resolved field metadata's widget hint, then the bare
+ * `type`). Only the two keys an AUTHORED schema carries are read here —
+ * `field.field?.widget` is a resolved metadata OBJECT that a hand-authored
+ * standalone `FormSchema` does not have.
+ *
+ * The mirroring is the point, not a convenience: validator and renderer must
+ * not be able to disagree about which component will actually render, which is
+ * the same discipline `resolveFieldLabelling` states on the renderer side.
+ */
+function resolveAuthoredFieldWidgetId(field: AuthoredFormField): string | undefined {
+  const id = field.widget ?? field.type;
+  return typeof id === 'string' ? id : undefined;
+}
+
+/**
+ * A form field's widget id names a namespace that resolves NO field widget —
+ * objectui#5375, maintainer ruling of 2026-08-20 (option C, the primary).
+ *
+ * ## What this refuses, and why it is an error rather than a warning
+ *
+ * Measured on `main` at f2e11ae6f, the real `form` renderer on the built-in
+ * path (no `registerAllFields()`):
+ *
+ *   type            registry hit   rendered type
+ *   ui:password     TRUE           text
+ *   secret          false          text
+ *   field:secret    false          text
+ *
+ * `ui:password` **is** registered — as an SDUI node renderer for a top-level
+ * `{ type: 'email' }`-style node — so an author who checks whether it resolves
+ * gets a YES, and still gets a clear-text box on the field path. That is the
+ * shape where verifying does not protect you, and it is why the class, not
+ * another entry in a renderer-side table, is what gets closed here: the table
+ * fix answers today's spellings and leaves the next invented id to find the
+ * same silent degrade. AI-authored metadata invents plausible-looking widget
+ * ids constantly; this makes inventing one an ERROR at authoring time instead
+ * of a text box that looks like it worked.
+ *
+ * A warning was explicitly ruled out — a warning IS the silent degrade this
+ * check exists to kill, in a new spelling.
+ *
+ * ## Why only the NAMESPACED spelling
+ *
+ * `field:` is allowed whether or not the widget is registered: registration is
+ * a RUNTIME fact (`registerAllFields()`, a lazily loaded plugin) that an
+ * authoring-time validator cannot see, and the renderer already answers an
+ * unregistered `field:` secret with a visible refusal (objectui#5322). A BARE
+ * name is likewise allowed: it is an open set — every registered `field:<name>`
+ * widget, third-party ones included, is reachable by its short name.
+ *
+ * What is decidable statically is the namespace, and it is a CLOSED set of one.
+ * Any other `<ns>:<name>` resolves nothing on the field path by the #5254
+ * ruling and falls to the renderer's plain-text `default` arm.
+ *
+ * ## Census (the ruling made arming this conditional on one)
+ *
+ * 4,397 authored files in this repo, 649 form-field `type`/`widget` literals,
+ * 98 structurally parsed form-field entries in `examples/schema-catalog`:
+ * SEVEN colon-qualified ids on the form-field path, five of them `field:*`.
+ * The two remaining occurrences are one source line naming `ref:component`,
+ * which is a metadata-admin designer `SchemaForm` widget resolved by its own
+ * `WIDGETS` table — a different shape (`{ field, widget }` under
+ * `sections[].fields[]`, node type `simple`) that this function, gated on
+ * `type === 'form'`, never reaches. Zero occurrences of `ui:password`,
+ * `secret` or `field:secret` anywhere on the field path.
+ */
+function validateFieldWidgetNamespace(
+  field: AuthoredFormField,
+  path: string,
+): SchemaNodeValidationError | undefined {
+  const id = resolveAuthoredFieldWidgetId(field);
+  if (!id || !id.includes(':') || id.startsWith(FIELD_WIDGET_NAMESPACE)) return undefined;
+  const key = typeof field.widget === 'string' ? 'widget' : 'type';
+  return {
+    path: `${path}.${key}`,
+    message:
+      `'${id}' is not a form field widget: a namespaced field widget id must name the ` +
+      `\`field:\` namespace (objectui#5254), so this id resolves NOTHING on the field path ` +
+      `and the renderer would fall through to a plain text box — putting a secret on screen ` +
+      `in clear text when the field holds one (objectui#5375). Write the built-in spelling ` +
+      `(e.g. \`password\`), or the field widget id \`field:${id.slice(id.indexOf(':') + 1)}\`. ` +
+      `Resolving in the registry is not proof it resolves HERE — \`ui:password\` is a ` +
+      `registered SDUI node renderer and still renders clear text as a field.`,
+    type: 'error',
+    code: 'UNRESOLVABLE_FIELD_WIDGET_NAMESPACE',
+  };
+}
+
+/**
  * Validate form schema specific properties
  */
 function validateFormSchema(schema: any, path: string = 'schema'): SchemaNodeValidationError[] {
@@ -200,6 +318,16 @@ function validateFormSchema(schema: any, path: string = 'schema'): SchemaNodeVal
             type: 'error',
             code: 'MISSING_FIELD_NAME'
           });
+        }
+
+        // objectui#5375 — an invented namespaced widget id is an ERROR here,
+        // not a silent clear-text box at render time. See the helper's doc.
+        const namespaceError = validateFieldWidgetNamespace(
+          field,
+          `${path}.fields[${index}]`,
+        );
+        if (namespaceError) {
+          errors.push(namespaceError);
         }
 
         // Check for duplicate field names


### PR DESCRIPTION
Fixes #5375

Three field-`type` spellings still put a secret on screen in clear text on the form renderer's unregistered-widget branch. Measured on `main` at `f2e11ae6f`, the real `form` renderer on the built-in path (no `registerAllFields()`), before and after the earlier fix:

```
type            registry hit   rendered type
ui:password     true           text
secret          false          text
field:secret    false          text
```

For contrast, `password` renders a native masked input and `field:password` is refused outright.

Maintainer ruling of 2026-08-20, accepted verbatim (「其他接受你的建议。」): **C + A**, landed together.

## The earlier fix closed this class only halfway — say so plainly

PR #5374 / issue #5322 is titled as if the "a secret shown in clear text" condition were shut. It is shut on the **producer-reachable** path only. `mapFieldTypeToFormType` maps the ObjectQL `secret` type to `field:password`, so every object-derived secret field is answered there. A hand-authored standalone `FormSchema` does not go through that mapping — the author is the producer and no normalizer sits in between — and the three spellings above walked straight past the fix. #5322 remains closed and is not re-opened by this PR; this is the difference, recorded so the next reader is not misled.

## C (the primary) — an invented namespaced widget id is an authoring ERROR

`packages/core/src/validation/schema-validator.ts`

A form field's widget id may name the `field:` namespace or a bare name. Any **other** namespace resolves no field widget on the field path (that is #5254's ruling, and `renderFieldComponent` implements exactly it), so it fell through to the plain-text `default` arm and degraded silently. `validateFormSchema` now reports `UNRESOLVABLE_FIELD_WIDGET_NAMESPACE` as an **error**, so `validateSchema(...).valid` is `false` and `assertValidSchema` throws.

Why the class rather than another table entry: **`ui:password` IS registered** — as an SDUI node renderer for a top-level `{ type: 'email' }`-style node — so an author who checks whether it resolves gets a **yes**, and still gets a clear-text box as a field. That is the shape where verifying does not protect you. A renderer-side table answers today's three spellings and leaves the next invented id the same silent degrade, which is literally how this card came to exist after #5322: that fix keyed on the `field:`-stripped type and `ui:password` walked past it. AI-authored metadata invents plausible-looking widget ids constantly; this makes inventing one fail loudly.

Deliberately **not** a warning — the ruling rules that out by name, because a warning is the same silent degrade under a new spelling.

What stays legal, and why:

- **any `field:` id, registered or not.** Registration is a runtime fact (`registerAllFields()`, a lazily loaded plugin) an authoring-time validator cannot see, and #5322 already answers an unregistered `field:` secret with a visible refusal.
- **bare names.** An open set — every registered `field:name` widget, third-party ones included, is reachable by its short name.

What is decidable statically is the namespace, and it is a closed set of one.

The check reads `widget` then `type`, mirroring the renderer's own `resolvedType` precedence, so validator and renderer cannot disagree about which component will actually render.

### The census — the ruling made arming this conditional on one

Scanned this repo's authored surface two ways: a textual pass over every authored file (bracket-matching each `fields: [ ... ]` region and collecting the `type` / `widget` literals inside it) and a structural pass that parses every JSON/YAML and walks form-field-shaped objects.

| reading | count |
|---|---|
| authored files scanned | 4,397 |
| form-field `type`/`widget` literals (textual) | 649 |
| form-field entries parsed structurally (`examples/schema-catalog`) | 98 |
| colon-qualified ids on the form-field path | **7** |
| — of those, `field:*` (stay legal) | 5 |
| — of those, a **non**-`field:` namespace | **2 occurrences, 1 source line, 1 distinct id** |
| `ui:password` / bare `secret` / `field:secret` on the field path | **0** |

The five `field:*` are `field:text`, `field:select` and two template literals (`field:${type}`). The one non-`field:` id is `ref:component`, at `packages/app-shell/src/views/metadata-admin/RefComponentWidget.test.tsx:174` (counted twice because it sits inside two nested `fields:` arrays). It is **out of the gated shape**: a metadata-admin designer `SchemaForm` spec form-VIEW field (`{ field, widget }` under `sections[].fields[]`, node type `simple`), resolved by app-shell's own `WIDGETS` table, never by `renderFieldComponent`. This check is gated on `type === 'form'` with runtime `fields[].name`, so it never reaches it — pinned as a test.

**Counter-probe, and it caught a real methodology bug.** The first run reported **zero** hits under `examples/`. Probing for form fields I knew were present (`examples/schema-catalog/src/schemas/components-form-form/*.json`) showed the scan's key regex did not accept JSON-quoted keys (`"type":`), only unquoted ones. After the fix `examples/schema-catalog` reports 133 textual and 98 structural hits, including bare `password` three times. So the zero above is a real zero, not a broken probe.

Small count, all hits clearly out of scope ⇒ the refusal is armed, per step 2 of the ruling's gate.

## A (defense in depth, same landing) — the known secret tables

`packages/components/src/renderers/form/form.tsx`

- `NATIVE_INPUT_FIELD_TYPES` gains `secret` and `ui:password`, so both render the **native masked input**.
- `SECRET_FIELD_TYPES` gains `secret`, so `field:secret` is **refused outright** exactly as `field:password` is — no input, no value in the DOM, and a `role="alert"` box naming the missing widget.

Zero migration: an existing author who wrote either spelling keeps a working field, and a host that never validates still does not leak. `ui:password` is keyed **raw**, not as a declared type, and deliberately so — `normalizeFieldType` strips only `field:`, and giving `ui:` a stripping rule of its own would re-open the cross-namespace resolution #5254 removed and would silently move `ui:email`, `ui:date` and every id this card never measured. A test pins `ui:email` still rendering `type="text"` so that widening cannot happen unnoticed.

## Fences honoured

- **Not widened beyond the field path.** #5254 routed these spellings to the `default` arm; that ruling stands. `ui:password` still resolves no widget — it only picks a native input type.
- **Severity stays honest.** No producer emits any of the three; all three are reachable only through a hand-authored form schema. This is **not** a p0 and is not written up as one.
- **Serial constraints.** `packages/react` was **not** touched — the validate path for C lives in `packages/core`, which the dispatch cleared. `packages/react` consumes the changed contract unmodified. PR #5441 landed mid-task; `main` was merged in (`fe76ece3a`) and every gate re-run on the merged head.

## Verification, at `420811271`

Both halves reverse-verified **separately**, direction predicted before running. No build sits between the edits and the tests: the root `vitest.config.mts` `alias` block maps every `@object-ui/*` specifier to that package's `src/`, and both files reach their subject by relative path, so no `dist/` is consulted on any leg. Each ablation was taken from the **committed** fix and restored by `git checkout branch -- path`, proven byte-identical with an empty `git diff --stat HEAD`.

| leg | predicted | observed |
|---|---|---|
| A ablated (`form.tsx` reverted) | 5 RED — `ui:password` and `secret` render `type="text"`, `field:secret` renders an input instead of the refusal | **5 failed / 20 passed**, exactly those |
| C ablated (validator reverted) | 7 RED — the invented id passes validation | **7 failed / 18 passed**, headline `expected true to be false` on `result.valid` |
| both restored | green | **green** |

The A-leg dump is the defect verbatim: `type="text" value="hunter2"` for a `field:secret` field.

Green readings on the merged head:

```
vitest packages/core/ packages/components/src/renderers/form/
  Test Files  142 passed (142)
  Tests       2258 passed (2258)

vitest packages/core/                    92 files / 1929 tests passed
vitest packages/components/             171 files / 1560 tests passed
vitest packages/react/ packages/plugin-form/   104 files / 1225 tests passed   (direct consumers of validateSchema)

type-check  @object-ui/core, @object-ui/components   Done (both echoed `tsc --noEmit`)
eslint      packages/core/src/validation, packages/components/src/renderers/form
            0 errors, 265 warnings (all pre-existing `no-explicit-any`; the count
            dropped from 267 — the new helper adds none)

check:control-bytes PASS   check:phantom-deps PASS   check:self-import PASS
check:esm-specifiers PASS  check:i18n-keys PASS      check:i18n-drift PASS
check-changeset-no-major PASS   check-changeset-presence PASS
plus a direct control-byte scan of every changed file — clean
```

No test was skipped, disabled or quarantined.

A changeset is included (`minor` on both packages; the `@object-ui/core` half is a behaviour change — a schema that previously validated with an invented namespaced id is now invalid).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_