### PR TITLE
fix(app-shell,i18n): surface a screen flow's resume result, on both outcomes

### DIFF
--- a/.changeset/flow-resume-result-5417.md
+++ b/.changeset/flow-resume-result-5417.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/i18n': minor
+---
+
+A screen flow's resume result reaches the user — on both outcomes (objectui#5417).
+
+A dogfood walkthrough reported that a refused `resume` and a successful one
+"render identically: the dialog closes and the page is unchanged", leaving no
+gesture that distinguishes "created" from "rejected". Re-measured against `main`
+before any change, one half of that was already fixed — `interpretFlowResponse`
+reads the ADR-0112 envelope, and `FlowRunner`'s `toast.error` has carried its
+prose since the `400 FLOW_FAILED` classification landed in `17.6.0`, five minors
+after the version the report was measured on. There was no interpreter bug and
+no un-consolidated fourth call site. Three gaps in the RUNNER's disposition were
+real, and they are what changed:
+
+- **A terminal failure no longer closes the dialog.** The reason it closed is
+  unchanged and is not reversed: on a `FLOW_FAILED` the engine has already
+  consumed the suspension, so a resubmit can only reach "No suspended run" and
+  must not be offered. Closing was one way to withhold that dead retry and the
+  expensive one — the user had just typed a form they could no longer see, and
+  the engine's sentence names a value that left the screen with it. The dialog
+  now stays open with the submit affordance withdrawn: the flat footer swaps
+  Submit for Close, and an `object-form` step drops its Save (which also stops a
+  second click from duplicating the record it had already persisted).
+- **The refusal has a second, non-expiring carrier.** The toast stays — it is
+  viewport-fixed, so it still reaches a user scrolled past a tall step's header
+  — and an inline destructive `Alert` (`role="alert"`) now holds the same
+  sentence inside the dialog, beside the values that produced it. A retryable
+  refusal (`INVALID_SCREEN_INPUT`, transport, 5xx) keeps Submit live as before,
+  and its banner clears as soon as the user starts editing.
+- **A successful run invalidates what the flow WROTE, not just what the user is
+  looking at.** Both hosts answered `onComplete` with
+  `notifyDataChanged({ objectName: <this page's object> })`, so a flow that
+  created a quote from an Opportunity page never told the related list that
+  would now contain it — the record did not appear until a manual reload. The
+  runner cannot know which objects a flow touched, so it emits
+  `{ objectName: '*' }`: the same scope, for the same stated reason, that the
+  record page's manual ⟳ already uses. Everything mounted refetches in place
+  over the invalidation bus, with no remount.
+
+The runner's copy now goes through `@object-ui/i18n` instead of being hardcoded
+English: a new `flowRunner` namespace (`title`, `submitting`, `saveAndContinue`,
+`nextStep`, `completed`) in all ten packs, plus reuse of
+`common.{loading,cancel,close,submit}` and `wizard.missingRequired`. The
+server's own refusal sentence is still passed through untranslated — it is prose
+the automation engine composed for a human, not copy with a key.

--- a/packages/app-shell/src/utils/__tests__/flowResponse.test.ts
+++ b/packages/app-shell/src/utils/__tests__/flowResponse.test.ts
@@ -100,8 +100,10 @@ describe('interpretFlowResponse — a 400 FLOW_FAILED on resume is TERMINAL (obj
     // objectstack#8684 moves this exact event off `200 {data:{success:false}}`
     // onto a real status code. It must land in the same class as the inner
     // envelope failure, NOT in the transport class: the engine consumed the
-    // suspension (resume-once), so the wizard must close rather than offer a
-    // retry that can only reach "No suspended run".
+    // suspension (resume-once), so the wizard must not offer a retry that can
+    // only reach "No suspended run". (How the runner withholds it is the
+    // runner's business — since objectui#5417 it withdraws Submit and keeps the
+    // dialog up, rather than closing and taking the user's input with it.)
     it('classifies it NON-retryable — keyed on the code, not on the status alone', () => {
         const out = interpretFlowResponse(
             { ok: false, status: 400 },

--- a/packages/app-shell/src/utils/flowResponse.ts
+++ b/packages/app-shell/src/utils/flowResponse.ts
@@ -128,7 +128,13 @@ export type FlowResponseOutcome<S = unknown> =
          * a retry of the same run is meaningful. False for a flow failure:
          * the engine consumed the suspension before running downstream nodes
          * (resume-once), so retrying only reaches "No suspended run", and a
-         * runner should close rather than leave a dead form open.
+         * runner must not offer one.
+         *
+         * What a runner DOES with that is the runner's own decision, and it is
+         * not "close" (objectui#5417): `FlowRunner` keeps the dialog up so the
+         * refusal stays beside the input that caused it, and withdraws the
+         * submit affordance instead. This flag says the run is gone, nothing
+         * more.
          */
         retryable: boolean;
     }

--- a/packages/app-shell/src/views/FlowRunner.tsx
+++ b/packages/app-shell/src/views/FlowRunner.tsx
@@ -13,9 +13,58 @@
  * The screen BODY (flat fields / object-form) is rendered by the shared
  * {@link ScreenView} — the same renderer the Studio design preview reuses, so
  * the two can never drift (cf. #1927).
+ *
+ * ## The resume RESULT has to reach the user (objectui#5417)
+ *
+ * A dogfood walkthrough reported that a `400 FLOW_FAILED` and a successful run
+ * "render identically: the dialog closes and the page is unchanged". Half of
+ * that was already fixed by the time it was triaged — `interpretFlowResponse`
+ * reads the ADR-0112 envelope and the `toast.error` below has carried its prose
+ * since #4899 — but three gaps survived, and they are what this component now
+ * answers:
+ *
+ * 1. **A terminal failure closed the dialog, taking the user's input with it.**
+ *    The reason it closed is still sound and is NOT reversed here: on a
+ *    `FLOW_FAILED` the engine has already consumed the suspension
+ *    (resume-once), so a retry can only reach "No suspended run", and offering
+ *    one is a lie. What #4899 concluded from that — *close* — is one way to
+ *    withhold the dead retry, and it is the expensive one: the user has just
+ *    typed a form they can no longer see, and the sentence explaining the
+ *    refusal names a value that is now gone from the screen. So the dialog
+ *    stays OPEN and the run's disposition is expressed the narrow way instead:
+ *    `retryable === false` withdraws the submit affordance (the flat footer
+ *    swaps Submit for a single Close; an `object-form` step drops `showSubmit`,
+ *    which also stops a second Save from creating a DUPLICATE record — its
+ *    first one was already persisted before the resume failed). Nothing offers
+ *    a retry that cannot work; the input and the reason stay on screen
+ *    together.
+ * 2. **The message had one carrier, and it was the transient one.** The toast
+ *    is kept — it is the console's failure idiom and it is viewport-fixed, so
+ *    it survives a tall `object-form` step scrolled past its own header — and
+ *    an inline destructive `Alert` (`role="alert"`) now carries the same
+ *    sentence inside the dialog, next to the values that produced it.
+ * 3. **Success invalidated the wrong thing.** Both hosts answer `onComplete`
+ *    with `notifyDataChanged({ objectName: <this page's object> })`, which is
+ *    the record the user is LOOKING at — never the record the flow WROTE. The
+ *    reported run created a `crm_quote` from an Opportunity page, so the
+ *    related list that would now contain it was never told, and the quote did
+ *    not appear until a manual reload. This component cannot know which objects
+ *    a flow touched (reading that out of the flow's output is a contract
+ *    question, deliberately not answered here), so it invalidates `'*'` — the
+ *    same scope, for the same stated reason, that `RecordDetailView`'s manual ⟳
+ *    uses: everything mounted refetches in place over the #2269 bus, with no
+ *    remount, so tab / scroll / inline-edit state all survive (AGENTS.md §5 #8).
+ *
+ * Copy goes through `@object-ui/i18n` (via the `@object-ui/react` re-export)
+ * like its neighbours; the only English left in this file is the inline
+ * `defaultValue` each key carries, which `check:i18n-keys` pins to its `en`
+ * value. The server's own refusal sentence is passed through untranslated by
+ * design — it is prose the backend composed, not a string with a key.
  */
 import { Suspense, useEffect, useState } from 'react';
 import {
+  Alert,
+  AlertDescription,
   Dialog,
   DialogContent,
   DialogHeader,
@@ -24,6 +73,7 @@ import {
   DialogDescription,
   Button,
 } from '@object-ui/components';
+import { notifyDataChanged, useObjectTranslation } from '@object-ui/react';
 import { toast } from 'sonner';
 import { ScreenView, isObjectFormScreen, initialScreenValues, visibleScreenFields, type ScreenSpec } from './ScreenView.js';
 import { interpretFlowResponse } from '../utils/flowResponse.js';
@@ -34,6 +84,17 @@ export interface ScreenFlowState {
   flowName: string;
   runId: string;
   screen: ScreenSpec;
+}
+
+/**
+ * A refused resume, held so the dialog can show it beside the input that
+ * produced it. `retryable` is `interpretFlowResponse`'s verdict, forwarded
+ * unchanged: `false` means the suspension is gone and no resubmit of this run
+ * can succeed, so the submit affordance is withdrawn (see the header note).
+ */
+interface ResumeError {
+  message: string;
+  retryable: boolean;
 }
 
 export interface FlowRunnerProps {
@@ -61,11 +122,13 @@ export interface FlowRunnerProps {
 }
 
 export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dataSource, objects }: FlowRunnerProps) {
+  const { t } = useObjectTranslation();
   const [screen, setScreen] = useState<ScreenSpec | null>(null);
   const [runId, setRunId] = useState('');
   const [flowName, setFlowName] = useState('');
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [submitting, setSubmitting] = useState(false);
+  const [resumeError, setResumeError] = useState<ResumeError | null>(null);
 
   useEffect(() => {
     if (state) {
@@ -73,12 +136,20 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
       setRunId(state.runId);
       setFlowName(state.flowName);
       setValues(initialScreenValues(state.screen));
+      // A fresh run must not open under the previous run's refusal.
+      setResumeError(null);
     }
   }, [state]);
 
   if (!state || !screen) return null;
 
-  const setVal = (name: string, v: unknown) => setValues((p) => ({ ...p, [name]: v }));
+  const setVal = (name: string, v: unknown) => {
+    setValues((p) => ({ ...p, [name]: v }));
+    // Editing is the start of a retry, so the banner it answers goes — but only
+    // where a retry exists. A terminal refusal must stay on screen: its whole
+    // job is to explain why the (now absent) Submit is not coming back.
+    setResumeError((e) => (e && e.retryable ? null : e));
+  };
 
   // Resume the paused run with `inputs` (applied as bare flow variables) and
   // advance: render the next screen (multi-step wizard) or finish + refresh.
@@ -98,23 +169,29 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
     // #31). See utils/flowResponse.
     const outcome = interpretFlowResponse<ScreenSpec>(res, json, 'Resume');
     if (outcome.kind === 'failed') {
+      // Two carriers on purpose (#5417): the toast is fixed to the viewport and
+      // reaches a user scrolled to the bottom of a tall object-form step; the
+      // inline Alert stays with the values that caused it.
       toast.error(outcome.error);
-      // A transport / envelope failure may be transient (network, 5xx) and did
-      // not consume the suspension — keep the dialog open so the user can retry
-      // the same run. A flow failure is TERMINAL: the engine consumes the
-      // suspension before running downstream nodes (resume-once), so a retry
-      // would only hit "No suspended run". Close instead of leaving a dead form.
-      if (!outcome.retryable) onClose();
+      setResumeError({ message: outcome.error, retryable: outcome.retryable });
       return;
     }
+    setResumeError(null);
     if (outcome.kind === 'paused') {
       setScreen(outcome.screen);
       setRunId(outcome.runId || runId);
       setValues(initialScreenValues(outcome.screen));
-      toast.success('Saved — next step');
+      toast.success(t('flowRunner.nextStep', { defaultValue: 'Saved — next step' }));
     } else {
       // Terminal success — show the flow's declared completion message.
-      toast.success(outcome.successMessage || 'Done');
+      toast.success(
+        outcome.successMessage
+          || t('flowRunner.completed', { flow: flowName, defaultValue: 'Flow "{{flow}}" completed' }),
+      );
+      // The flow may have written ANY object — a quote created from an
+      // Opportunity page lands in a related list this component cannot name.
+      // See the header note on why the scope is `'*'` and not the host record.
+      notifyDataChanged({ objectName: '*' });
       onComplete();
     }
   };
@@ -132,14 +209,23 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
       (f) => f.required && (values[f.name] === undefined || values[f.name] === '' || values[f.name] === null),
     );
     if (missing.length) {
-      toast.error(`Please fill: ${missing.map((f) => f.label || f.name).join(', ')}`);
+      toast.error(
+        t('wizard.missingRequired', {
+          fields: missing.map((f) => f.label || f.name).join(', '),
+          defaultValue: 'Please complete the required fields: {{fields}}',
+        }),
+      );
       return;
     }
     setSubmitting(true);
     try {
       await resumeWith(values);
     } catch (err) {
-      toast.error((err as Error).message);
+      // The request never produced a response (network / abort), so the
+      // suspension was not consumed — this one IS retryable.
+      const message = (err as Error).message;
+      toast.error(message);
+      setResumeError({ message, retryable: true });
     } finally {
       setSubmitting(false);
     }
@@ -156,21 +242,36 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
     try {
       await resumeWith(inputs);
     } catch (err) {
-      toast.error((err as Error).message);
+      const message = (err as Error).message;
+      toast.error(message);
+      setResumeError({ message, retryable: true });
     } finally {
       setSubmitting(false);
     }
   };
 
   const isObjectForm = isObjectFormScreen(screen);
+  // The run is gone: this dialog can still be read and copied from, but nothing
+  // in it may offer to resubmit. See the header note.
+  const terminal = resumeError !== null && !resumeError.retryable;
 
   return (
     <Dialog open onOpenChange={(o) => { if (!o && !submitting) onClose(); }}>
       <DialogContent className={isObjectForm ? 'sm:max-w-3xl max-h-[90vh] overflow-y-auto' : 'sm:max-w-md'}>
         <DialogHeader>
-          <DialogTitle>{screen.title || 'Input'}</DialogTitle>
+          <DialogTitle>{screen.title || t('flowRunner.title', { defaultValue: 'Input' })}</DialogTitle>
           {screen.description && <DialogDescription>{screen.description}</DialogDescription>}
         </DialogHeader>
+
+        {resumeError && (
+          <Alert variant="destructive">
+            {/* The server composed this sentence for a human — ADR-0112
+                `error.message` is already user-grade prose ("Node 'create_quote'
+                failed: … at most 2 decimal places"). It is passed through
+                verbatim and untranslated: it is data, not copy with a key. */}
+            <AlertDescription>{resumeError.message}</AlertDescription>
+          </Alert>
+        )}
 
         {/* The screen body pulls in lazily-loaded chunks (an `object-form` step
             mounts ObjectForm, whose field widgets are lazy). Without a boundary
@@ -178,7 +279,7 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
             route-level one on some surfaces — which swaps the whole page for a
             fallback and destroys the host's state, taking this dialog (and the
             run it is driving) with it. */}
-        <Suspense fallback={<div className="py-6 text-sm text-muted-foreground">Loading…</div>}>
+        <Suspense fallback={<div className="py-6 text-sm text-muted-foreground">{t('common.loading', { defaultValue: 'Loading…' })}</div>}>
           <ScreenView
             screen={screen}
             values={values}
@@ -188,18 +289,33 @@ export function FlowRunner({ state, authFetch, baseUrl, onClose, onComplete, dat
             objectForm={{
               onSuccess: onObjectFormSaved,
               onCancel: onClose,
-              showSubmit: true,
+              // Withdrawn once the run is gone: the record this step created was
+              // already persisted, so a second Save would duplicate it AND still
+              // have no suspension to resume.
+              showSubmit: !terminal,
               showCancel: true,
-              submitText: 'Save & Continue',
-              cancelText: 'Cancel',
+              submitText: t('flowRunner.saveAndContinue', { defaultValue: 'Save & Continue' }),
+              cancelText: terminal
+                ? t('common.close', { defaultValue: 'Close' })
+                : t('common.cancel', { defaultValue: 'Cancel' }),
             }}
           />
         </Suspense>
 
         {!isObjectForm && (
           <DialogFooter>
-            <Button variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
-            <Button onClick={submit} disabled={submitting}>{submitting ? 'Submitting…' : 'Submit'}</Button>
+            {terminal ? (
+              <Button variant="outline" onClick={onClose}>{t('common.close', { defaultValue: 'Close' })}</Button>
+            ) : (
+              <>
+                <Button variant="outline" onClick={onClose} disabled={submitting}>{t('common.cancel', { defaultValue: 'Cancel' })}</Button>
+                <Button onClick={submit} disabled={submitting}>
+                  {submitting
+                    ? t('flowRunner.submitting', { defaultValue: 'Submitting…' })
+                    : t('common.submit', { defaultValue: 'Submit' })}
+                </Button>
+              </>
+            )}
           </DialogFooter>
         )}
       </DialogContent>

--- a/packages/app-shell/src/views/__tests__/FlowRunner.resumeResult.test.tsx
+++ b/packages/app-shell/src/views/__tests__/FlowRunner.resumeResult.test.tsx
@@ -176,8 +176,13 @@ describe('#5417 — a refused resume is readable, and keeps the input', () => {
     setup(authFetch);
     await fillAndSubmit();
 
-    // Inline: the sentence lives in the dialog, beside the values that caused it.
-    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(FLOW_FAILED_MESSAGE));
+    // Queried by TEXT first, on purpose. `getByRole('alert')` would fail with
+    // "unable to find role alert", which reads the same whether the sentence was
+    // dropped or the markup moved; querying the sentence makes the reverse
+    // verification NAME what went missing. The role is then asserted on the node
+    // that was found, so the announcement is still pinned.
+    await waitFor(() => expect(screen.getByText(FLOW_FAILED_MESSAGE)).toBeInTheDocument());
+    expect(screen.getByText(FLOW_FAILED_MESSAGE).closest('[role="alert"]')).not.toBeNull();
     // Toast: the carrier that survives a scrolled-away dialog header.
     expect(toastError).toHaveBeenCalledWith(FLOW_FAILED_MESSAGE);
   });

--- a/packages/app-shell/src/views/__tests__/FlowRunner.resumeResult.test.tsx
+++ b/packages/app-shell/src/views/__tests__/FlowRunner.resumeResult.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The resume RESULT reaches the user — objectui#5417.
+ *
+ * ## What was measured, and what of it survived triage
+ *
+ * The card reports that on `17.1.0` a `400 FLOW_FAILED` and a successful run
+ * "render identically: the dialog closes and the page is unchanged". Re-measured
+ * against `main` before writing a line (probe run, 2026-08-20), one half of that
+ * was already gone: `interpretFlowResponse` reads the ADR-0112 envelope, and the
+ * `toast.error` in `resumeWith` has carried its prose since #4899 — which shipped
+ * in `17.6.0`, five minors AFTER the version the card was measured on. So the
+ * premise "all of it is discarded at the client" is no longer true, and there is
+ * no interpreter bug and no fourth un-consolidated call site to fix.
+ *
+ * Three things the card asks for were still missing, and this file pins them.
+ * Every one is a fact about the RUNNER's disposition, which is why none of them
+ * belongs in `flowResponse.ts` — that module's verdict was already correct.
+ *
+ * ## 1. A terminal failure took the user's input with it
+ *
+ * `retryable === false` used to mean `onClose()`. The reasoning behind it holds
+ * and is not reversed here: the engine consumes the suspension before running
+ * downstream nodes, so a resubmit of that run can only reach "No suspended run".
+ * But *closing* is not the only way to withhold a dead retry, and it is the one
+ * that costs the most: the user has just typed a form they can no longer see,
+ * and the engine's sentence names a value that left the screen with it. The
+ * dialog now stays open with Submit withdrawn — no dead retry is offered, and
+ * the input and the reason stay on screen together.
+ *
+ * ## 2. The message had exactly one carrier, and it was the transient one
+ *
+ * A toast is viewport-fixed (so it survives a tall `object-form` step scrolled
+ * past its own header) but it also expires. Both carriers are asserted here,
+ * because dropping either one re-opens a reported failure mode.
+ *
+ * ## 3. Success invalidated the object the user was LOOKING at, never the one
+ *    the flow WROTE
+ *
+ * Both hosts answer `onComplete` with
+ * `notifyDataChanged({ objectName: <this page's object> })`. The reported run
+ * created a `crm_quote` from an Opportunity page, so the related list that would
+ * now hold it was never told and the quote did not appear until a manual reload.
+ * The runner cannot know which objects a flow touched, so it emits `'*'` —
+ * `dataChangeMatches` short-circuits true for it, which is precisely "treat
+ * everything mounted as stale". Asserted over the REAL bus
+ * (`subscribeDataChanges`) rather than a module mock, so the assertion is about
+ * what readers receive and not about which function was called.
+ *
+ * ## Reverse verification, direction predicted before running
+ *
+ * Reverting `FlowRunner.tsx` to its committed parent must turn these RED, and
+ * the RED must NAME the swallowed sentence — an assertion that fails with a
+ * generic "element not found" would not distinguish "the message is missing"
+ * from "the dialog moved". Recorded in the PR body with the real output.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider, subscribeDataChanges, type DataChange } from '@object-ui/react';
+
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+vi.mock('sonner', () => ({ toast: { error: toastError, success: toastSuccess } }));
+
+const { FlowRunner } = await import('../FlowRunner');
+type ScreenFlowState = import('../FlowRunner').ScreenFlowState;
+
+const STATE: ScreenFlowState = {
+  flowName: 'quote_generation',
+  runId: 'run_0b47',
+  screen: {
+    nodeId: 'screen_1',
+    title: 'Quote inputs',
+    fields: [{ name: 'discount', label: 'Discount', type: 'text', required: true }],
+  },
+};
+
+/**
+ * The card's wire payload, transcribed rather than paraphrased: this is the
+ * exact envelope the dogfood run captured, down to the per-node summary that
+ * `errorEnvelopeDetails` has to walk past without finding an `errorMessage`.
+ */
+const FLOW_FAILED_MESSAGE =
+  "Node 'create_quote' failed: create_record(crm_quote) failed: Total Price must have at most 2 decimal places (got 11)";
+const FLOW_FAILED_400 = {
+  success: false,
+  error: {
+    code: 'FLOW_FAILED',
+    message: FLOW_FAILED_MESSAGE,
+    httpStatus: 400,
+    details: {
+      summary: {
+        selected: 1,
+        acted: 0,
+        skipped: 0,
+        nodes: [
+          { nodeId: 'start', nodeType: 'start', status: 'success', runs: 1 },
+          { nodeId: 'screen_1', nodeType: 'screen', status: 'success', runs: 1 },
+          { nodeId: 'get_opportunity', nodeType: 'get_record', status: 'success', runs: 1 },
+          { nodeId: 'create_quote', nodeType: 'create_record', status: 'failure', runs: 1, failures: 1 },
+        ],
+      },
+    },
+  },
+};
+
+/**
+ * Radix's `DialogContent` renders its OWN dismiss `X`, and its accessible name
+ * is also "Close" (an `sr-only` span). So a bare `getByRole('button', { name:
+ * 'Close' })` finds two and throws. The footer's button is the one whose label
+ * is VISIBLE — that is the affordance a sighted user reaches for, and the one
+ * these tests are about.
+ */
+function footerCloseButton(): HTMLElement | undefined {
+  return screen
+    .getAllByRole('button', { name: 'Close' })
+    .find((b) => b.querySelector('.sr-only') === null);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+function setup(authFetch: (url: string, init?: RequestInit) => Promise<Response>) {
+  const onClose = vi.fn();
+  const onComplete = vi.fn();
+  render(<FlowRunner state={STATE} authFetch={authFetch} baseUrl="" onClose={onClose} onComplete={onComplete} />);
+  return { onClose, onComplete };
+}
+
+async function fillAndSubmit(value = '0.115', submitLabel = 'Submit') {
+  const user = userEvent.setup();
+  await user.type(screen.getAllByRole('textbox')[0], value);
+  await user.click(screen.getByRole('button', { name: submitLabel }));
+  return user;
+}
+
+/** Same render, wrapped in the real i18next instance for a given locale. */
+function renderWithLocale(
+  authFetch: (url: string, init?: RequestInit) => Promise<Response>,
+  defaultLanguage: string,
+) {
+  const onClose = vi.fn();
+  const onComplete = vi.fn();
+  render(
+    <I18nProvider config={{ defaultLanguage, detectBrowserLanguage: false }} persistLanguage={false}>
+      <FlowRunner state={STATE} authFetch={authFetch} baseUrl="" onClose={onClose} onComplete={onComplete} />
+    </I18nProvider>,
+  );
+  return { onClose, onComplete };
+}
+
+let changes: DataChange[] = [];
+let unsubscribe: (() => void) | undefined;
+
+beforeEach(() => {
+  toastError.mockClear();
+  toastSuccess.mockClear();
+  changes = [];
+  unsubscribe = subscribeDataChanges((c) => { changes.push(c); });
+});
+afterEach(() => { unsubscribe?.(); });
+
+describe('#5417 — a refused resume is readable, and keeps the input', () => {
+  it('shows the engine sentence inline AND as a toast', async () => {
+    const authFetch = vi.fn(async () => jsonResponse(FLOW_FAILED_400, 400));
+    setup(authFetch);
+    await fillAndSubmit();
+
+    // Inline: the sentence lives in the dialog, beside the values that caused it.
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(FLOW_FAILED_MESSAGE));
+    // Toast: the carrier that survives a scrolled-away dialog header.
+    expect(toastError).toHaveBeenCalledWith(FLOW_FAILED_MESSAGE);
+  });
+
+  it('keeps the dialog open with the typed input intact', async () => {
+    const authFetch = vi.fn(async () => jsonResponse(FLOW_FAILED_400, 400));
+    const { onClose, onComplete } = setup(authFetch);
+    await fillAndSubmit();
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText('Quote inputs')).toBeInTheDocument();
+    expect(screen.getAllByRole('textbox')[0]).toHaveValue('0.115');
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('withdraws Submit, because the suspension is already consumed', async () => {
+    const authFetch = vi.fn(async () => jsonResponse(FLOW_FAILED_400, 400));
+    setup(authFetch);
+    await fillAndSubmit();
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    // No dead retry is on offer…
+    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+    // …and the one request that was made is still the only one.
+    expect(authFetch).toHaveBeenCalledTimes(1);
+    // The way out is explicit rather than implied.
+    expect(footerCloseButton()).toBeInTheDocument();
+  });
+
+  it('keeps the terminal banner up while the user edits — there is nothing to re-submit', async () => {
+    const authFetch = vi.fn(async () => jsonResponse(FLOW_FAILED_400, 400));
+    setup(authFetch);
+    const user = await fillAndSubmit();
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    await user.type(screen.getAllByRole('textbox')[0], '2');
+    // Clearing it here would remove the only explanation for the missing Submit.
+    expect(screen.getByRole('alert')).toHaveTextContent(FLOW_FAILED_MESSAGE);
+    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+  });
+});
+
+describe('#5417 — a RETRYABLE refusal still offers the retry', () => {
+  // `INVALID_SCREEN_INPUT` is refused before the signal reaches the variable
+  // map, so the suspension survives and a corrected resubmit is meaningful.
+  // This is the arm the terminal disposition must not swallow.
+  const RETRYABLE_400 = {
+    success: false,
+    error: { code: 'INVALID_SCREEN_INPUT', message: 'discount must be a number', httpStatus: 400 },
+  };
+
+  it('surfaces the message and leaves Submit live', async () => {
+    const authFetch = vi.fn(async () => jsonResponse(RETRYABLE_400, 400));
+    const { onClose } = setup(authFetch);
+    await fillAndSubmit();
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('discount must be a number'));
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('clears the banner once the user starts fixing the input', async () => {
+    const authFetch = vi.fn(async () => jsonResponse(RETRYABLE_400, 400));
+    setup(authFetch);
+    const user = await fillAndSubmit();
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    await user.type(screen.getAllByRole('textbox')[0], '9');
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+});
+
+describe('#5417 — a successful run is visible on the page it wrote to', () => {
+  it('invalidates every mounted reader, not just the host record', async () => {
+    const authFetch = vi.fn(async () => jsonResponse({ success: true, data: { success: true, status: 'completed' } }));
+    const { onComplete } = setup(authFetch);
+    await fillAndSubmit('0.10');
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    // `'*'` is the scope, and it is load-bearing: a related list showing the
+    // `crm_quote` this flow just created subscribes to `crm_quote`, an object
+    // this component has no way to name.
+    expect(changes).toEqual([{ objectName: '*', recordId: undefined }]);
+  });
+
+  it('announces completion with the flow-declared message when there is one', async () => {
+    const authFetch = vi.fn(async () =>
+      jsonResponse({ success: true, data: { success: true, successMessage: 'Quote QTE-0006 created' } }),
+    );
+    setup(authFetch);
+    await fillAndSubmit('0.10');
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Quote QTE-0006 created'));
+  });
+
+  // These two mount the REAL provider on purpose. Provider-less, react-i18next
+  // hands back the call site's `defaultValue` verbatim and never interpolates —
+  // so a provider-less assertion here would pass on a component carrying no
+  // `flowRunner.completed` key at all, and would read a literal `{{flow}}` as
+  // success. With the provider the key has to resolve out of the pack and the
+  // hole has to be filled; the `zh` case then shows the copy is genuinely
+  // localized rather than English hiding behind a key — objectui#5417 asks it
+  // to match the console's `服务案例创建成功` / `对象「…」已存为草稿` idiom.
+  it('falls back to the en pack value, with the flow name filled in', async () => {
+    const authFetch = vi.fn(async () => jsonResponse({ success: true, data: { success: true } }));
+    renderWithLocale(authFetch, 'en');
+    await fillAndSubmit('0.10', 'Submit');
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    expect(toastSuccess.mock.calls).toEqual([['Flow "quote_generation" completed']]);
+  });
+
+  it('renders that fallback in the display locale, not in English', async () => {
+    const authFetch = vi.fn(async () => jsonResponse({ success: true, data: { success: true } }));
+    renderWithLocale(authFetch, 'zh');
+    await fillAndSubmit('0.10', '提交');
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    expect(toastSuccess.mock.calls).toEqual([['流程「quote_generation」已完成']]);
+  });
+});

--- a/packages/app-shell/src/views/__tests__/FlowRunner.test.tsx
+++ b/packages/app-shell/src/views/__tests__/FlowRunner.test.tsx
@@ -39,13 +39,27 @@ async function fillAndSubmit() {
 beforeEach(() => vi.restoreAllMocks());
 
 describe('FlowRunner resume outcomes', () => {
-  it('closes the runner on a TERMINAL flow failure (suspension already consumed)', async () => {
+  it('withdraws Submit on a TERMINAL flow failure (suspension already consumed)', async () => {
+    // The runner used to call `onClose` here. It no longer does (objectui#5417):
+    // closing threw away the input the user had just typed AND the screen the
+    // engine's sentence refers to. The reason it closed — never offer a retry
+    // that can only reach "No suspended run" — is unchanged and is now expressed
+    // by withdrawing Submit instead of by unmounting. See FlowRunner's header.
     const authFetch = vi.fn(async () =>
       jsonResponse({ success: true, data: { success: false, error: "Node 'apply' failed: Update requires an ID" } }),
     );
     const { onClose, onComplete } = setup(authFetch);
     await fillAndSubmit();
-    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByText("Node 'apply' failed: Update requires an ID")).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+    // Radix's own dismiss `X` shares the accessible name "Close"; the footer's
+    // is the one with a visible label.
+    expect(
+      screen.getAllByRole('button', { name: 'Close' }).filter((b) => b.querySelector('.sr-only') === null),
+    ).toHaveLength(1);
+    expect(onClose).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
   });
 

--- a/packages/i18n/src/__tests__/de-quote-pairing-3876.test.ts
+++ b/packages/i18n/src/__tests__/de-quote-pairing-3876.test.ts
@@ -254,8 +254,11 @@ describe('objectui#3876 — de pack closes „ with “ and not with a straight 
     // `grid.import.savedMappingHint` / `savedMappingPreviewNote` German quotes,
     // 50 once objectui#3919 germanised the three `approvalsInbox` values,
     // 51 once objectstack#8270 added `home.build.noCapability`, which names the
-    // withheld „Metadaten verwalten“ permission in the gate's reason line.
-    expect(okSpans, 'correctly paired spans').toBe(51);
+    // withheld „Metadaten verwalten“ permission in the gate's reason line,
+    // 52 once objectui#5417 added `flowRunner.completed`, which names the flow
+    // it just finished — „{{flow}}“, an interpolated span, so the pairing is
+    // asserted around a hole rather than around literal prose.
+    expect(okSpans, 'correctly paired spans').toBe(52);
   });
 
   it('keeps the count identity that replaces the card’s count(„) === count(“)', () => {
@@ -267,11 +270,12 @@ describe('objectui#3876 — de pack closes „ with “ and not with a straight 
     // 45 / 47 / 2 at objectui#3876's landing; 47 / 47 / 0 after objectui#3920
     // translated the two English values; 50 / 50 / 0 after objectui#3919 gave the
     // three `approvalsInbox` values German quotes; 51 / 51 / 0 after
-    // objectstack#8270 added `home.build.noCapability`. See the header for why the
+    // objectstack#8270 added `home.build.noCapability`; 52 / 52 / 0 after
+    // objectui#5417 added `flowRunner.completed`. See the header for why the
     // naive equality was false on the file #3876 left behind — and note that it is
     // now true for a *different* reason (rdq went to zero), which is why the
     // identity below is asserted as arithmetic rather than as `close === open`.
-    expect({ open, close, rdq }).toEqual({ open: 51, close: 51, rdq: 0 });
+    expect({ open, close, rdq }).toEqual({ open: 52, close: 52, rdq: 0 });
     // The durable shape: every „ closed by a “, every surplus “ an English
     // opener answered by a ”. Survived translating the two English values.
     expect(close).toBe(open + rdq);

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -3437,6 +3437,13 @@ const ar = {
   wizard: {
     missingRequired: "يرجى إكمال الحقول المطلوبة: {{fields}}",
   },
+  flowRunner: {
+    title: 'إدخال',
+    submitting: 'جارٍ الإرسال…',
+    saveAndContinue: 'حفظ ومتابعة',
+    nextStep: 'تم الحفظ — الخطوة التالية',
+    completed: 'اكتمل التدفق «{{flow}}»',
+  },
   appManagement: {
     title: "التطبيقات",
     subtitle: "إدارة جميع التطبيقات المُعدّة",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -3430,6 +3430,13 @@ const de = {
   wizard: {
     missingRequired: "Bitte füllen Sie die Pflichtfelder aus: {{fields}}",
   },
+  flowRunner: {
+    title: 'Eingabe',
+    submitting: 'Wird gesendet…',
+    saveAndContinue: 'Speichern und fortfahren',
+    nextStep: 'Gespeichert — nächster Schritt',
+    completed: 'Flow „{{flow}}“ abgeschlossen',
+  },
   appManagement: {
     title: "Anwendungen",
     subtitle: "Alle konfigurierten Anwendungen verwalten",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -3722,6 +3722,30 @@ const en = {
   wizard: {
     missingRequired: 'Please complete the required fields: {{fields}}',
   },
+  // The screen-flow runner dialog (`app-shell/views/FlowRunner`) — the modal a
+  // `type: 'flow'` action opens when its run pauses at a `screen` node.
+  //
+  // What is deliberately NOT here: the sentence a refused resume shows. That is
+  // the ADR-0112 envelope's own `error.message`, prose the automation engine
+  // composed for a human ("Node 'create_quote' failed: … at most 2 decimal
+  // places"), so it has no fixed catalogue to key against and is passed through
+  // untranslated — the same division `appManagement` states above. The runner
+  // borrows `common.{loading,cancel,close,submit}` for its chrome and
+  // `wizard.missingRequired` for the pre-submit check, which is the same
+  // sentence `plugin-form`'s WizardForm raises.
+  flowRunner: {
+    // Fallback dialog title, used only when the `screen` node declares none.
+    title: 'Input',
+    submitting: 'Submitting…',
+    // The submit label of an `object-form` step: it saves a record AND advances
+    // the run, so it is not the plain `common.submit`.
+    saveAndContinue: 'Save & Continue',
+    // A multi-screen wizard advanced to the next step (not the end of the run).
+    nextStep: 'Saved — next step',
+    // Terminal success, used only when the flow declares no `successMessage`
+    // of its own.
+    completed: 'Flow "{{flow}}" completed',
+  },
   // Console › System › Applications (objectui#4307). The page's OWN chrome —
   // headings, controls, badges and the frames of its toasts.
   //

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -3434,6 +3434,13 @@ const es = {
   wizard: {
     missingRequired: "Complete los campos obligatorios: {{fields}}",
   },
+  flowRunner: {
+    title: 'Entrada',
+    submitting: 'Enviando…',
+    saveAndContinue: 'Guardar y continuar',
+    nextStep: 'Guardado — paso siguiente',
+    completed: 'Flujo «{{flow}}» completado',
+  },
   appManagement: {
     title: "Aplicaciones",
     subtitle: "Gestione todas las aplicaciones configuradas",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -3432,6 +3432,13 @@ const fr = {
   wizard: {
     missingRequired: "Veuillez renseigner les champs obligatoires : {{fields}}",
   },
+  flowRunner: {
+    title: 'Saisie',
+    submitting: 'Envoi…',
+    saveAndContinue: 'Enregistrer et continuer',
+    nextStep: 'Enregistré — étape suivante',
+    completed: 'Flux « {{flow}} » terminé',
+  },
   appManagement: {
     title: "Applications",
     subtitle: "Gérer toutes les applications configurées",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -3430,6 +3430,13 @@ const ja = {
   wizard: {
     missingRequired: "必須項目を入力してください: {{fields}}",
   },
+  flowRunner: {
+    title: '入力',
+    submitting: '送信中…',
+    saveAndContinue: '保存して続行',
+    nextStep: '保存しました — 次のステップ',
+    completed: 'フロー「{{flow}}」が完了しました',
+  },
   appManagement: {
     title: "アプリケーション",
     subtitle: "設定済みのアプリケーションをすべて管理します",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -3429,6 +3429,13 @@ const ko = {
   wizard: {
     missingRequired: "필수 항목을 입력하세요: {{fields}}",
   },
+  flowRunner: {
+    title: '입력',
+    submitting: '제출 중…',
+    saveAndContinue: '저장 후 계속',
+    nextStep: '저장됨 — 다음 단계',
+    completed: '플로우 「{{flow}}」이(가) 완료되었습니다',
+  },
   appManagement: {
     title: "애플리케이션",
     subtitle: "구성된 모든 애플리케이션을 관리합니다",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -3429,6 +3429,13 @@ const pt = {
   wizard: {
     missingRequired: "Preencha os campos obrigatórios: {{fields}}",
   },
+  flowRunner: {
+    title: 'Entrada',
+    submitting: 'Enviando…',
+    saveAndContinue: 'Salvar e continuar',
+    nextStep: 'Salvo — próxima etapa',
+    completed: 'Fluxo "{{flow}}" concluído',
+  },
   appManagement: {
     title: "Aplicativos",
     subtitle: "Gerencie todos os aplicativos configurados",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -3441,6 +3441,13 @@ const ru = {
   wizard: {
     missingRequired: "Заполните обязательные поля: {{fields}}",
   },
+  flowRunner: {
+    title: 'Ввод',
+    submitting: 'Отправка…',
+    saveAndContinue: 'Сохранить и продолжить',
+    nextStep: 'Сохранено — следующий шаг',
+    completed: 'Поток «{{flow}}» завершён',
+  },
   appManagement: {
     title: "Приложения",
     subtitle: "Управление всеми настроенными приложениями",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -3488,6 +3488,13 @@ const zh = {
   wizard: {
     missingRequired: '请填写以下必填字段：{{fields}}',
   },
+  flowRunner: {
+    title: '输入',
+    submitting: '提交中…',
+    saveAndContinue: '保存并继续',
+    nextStep: '已保存 — 下一步',
+    completed: '流程「{{flow}}」已完成',
+  },
   appManagement: {
     title: '应用',
     subtitle: '管理所有已配置的应用',


### PR DESCRIPTION
Fixes #5417

Gate union and test readings below were taken at `ddb7a5fe7`, which is this branch's head.

## Diagnosis first — and one premise of the card did not survive it

The dispatch asked which of three things this was. Measured against `origin/main` at `15236e055` with the card's exact wire payload, before writing a line: **none of them.** `packages/app-shell/src/utils/flowResponse.ts` parses the `400 FLOW_FAILED` envelope correctly, `FlowRunner.tsx:99` already routes the resume through it, and `FlowRunner.tsx:101` already hands the prose to `toast.error`. There is no interpreter bug, no discarded verdict, and no fourth un-consolidated call site — so `flowResponse.ts` needed no behaviour change and got none.

The probe pinned all three observations as hard assertions and they all passed on `main`:

- `toast.error` received `Node 'create_quote' failed: create_record(crm_quote) failed: Total Price must have at most 2 decimal places (got 11)` — verbatim.
- `onClose` was called once.
- Nothing rendered the sentence inside the dialog.

So the card's `no toast` is **false at HEAD**. The card was measured on `17.1.0`; the `400 FLOW_FAILED` classification landed later and shipped in `17.6.0` (`packages/app-shell/CHANGELOG.md` line 832, commit `833c900`), five minors after. Reporting this rather than quietly building around it, per the standing rule that the card body is a clue and not a spec.

What was still true at HEAD is the **disposition**, and that is what this PR changes.

## 1. A terminal failure no longer closes the dialog

The reason it closed is sound and is **not reversed**: on a `FLOW_FAILED` the engine has already consumed the suspension (resume-once), so a resubmit can only reach `No suspended run`, and offering one is a lie. But *closing* is only one way to withhold that dead retry, and it is the expensive one — the user has just typed a form they can no longer see, and the engine's sentence names a value that left the screen with it.

The dialog now stays open with the **submit affordance withdrawn** instead: the flat footer swaps Submit for a single Close, and an `object-form` step drops `showSubmit` — which also stops a second Save from **duplicating the record it had already persisted** before the resume failed. Nothing offers a retry that cannot work; the input and the reason stay on screen together.

`retryable` keeps doing exactly the job it documents. The doc comment that said a runner *should close* now says the runner must not offer a retry, and names where the disposition actually lives. The retryable arm (`INVALID_SCREEN_INPUT`, transport, 5xx) is unchanged: Submit stays live, and its banner clears the moment the user starts editing.

## 2. The refusal gets a second, non-expiring carrier

The toast stays — it is viewport-fixed, so it still reaches a user scrolled past a tall step's own header — and an inline destructive `Alert` with `role="alert"` now holds the same sentence beside the values that produced it. Both, because dropping either one re-opens a reported failure mode.

The server's sentence is passed through **untranslated** by design: it is prose the automation engine composed for a human, not copy with a key. Same division `appManagement` already states in the `en` pack.

## 3. Success invalidated what the user was looking at, never what the flow wrote

Both hosts answer `onComplete` with `notifyDataChanged` scoped to **this page's own object and record id**. The reported run created a `crm_quote` from an Opportunity page, so the related list that would now contain it was never told — hence "does not appear until a manual reload".

`FlowRunner` cannot know which objects a flow touched (reading that out of the flow output is the contract question the dispatch fenced off), so it emits `{ objectName: '*' }` before `onComplete()`. Same scope, for the same stated reason, that `RecordDetailView`'s manual refresh already uses; `dataChangeMatches` short-circuits true for it, and `data-invalidation.ts` names **flow completions** as one of the writes that still need a manual call. Refetch in place over the #2269 bus, no remount — AGENTS.md section 5 #8.

## Copy goes through `packages/i18n`

New `flowRunner` namespace (`title`, `submitting`, `saveAndContinue`, `nextStep`, `completed`) in all ten packs, plus reuse of `common.{loading,cancel,close,submit}` and `wizard.missingRequired` — the same sentence `plugin-form`'s WizardForm already raises.

**File surface widened beyond the dispatched two files, and it is forced rather than chosen** (declared in a claim amendment on the issue). `scripts/check-i18n-call-site-keys.mjs` requires every `t()` key to exist in the `en` pack and `all-locales-key-parity` requires all ten to carry it, so "use i18n" and "edit the packs" are one action. Measured, not assumed: provider-less, react-i18next returns the inline `defaultValue` **verbatim and uninterpolated**, so without the pack entry a user reads a literal `Flow "{{flow}}" completed`. That is also why the two completion-copy tests mount the real `I18nProvider` — a provider-less assertion there would pass on a component carrying no key at all.

The German quote-pairing ratchet moves 51 to 52 because the `de` value quotes the flow name as a properly paired German span. Its invariants are untouched (`open === close`, `rdq === 0`, zero mismatches); the count is bumped with a history line, following the four increments already recorded in that file.

## Reverse verification — direction predicted before running

Predicted: reverting `FlowRunner.tsx` to `origin/main` turns the new pins RED, the first RED **names the swallowed sentence**, and `announces completion with the flow-declared message` stays GREEN because `main` already honours `successMessage`.

Observed, exactly that — 10 RED, 6 green:

```
FAIL  shows the engine sentence inline AND as a toast
TestingLibraryElementError: Unable to find an element with the text: Node 'create_quote'
failed: create_record(crm_quote) failed: Total Price must have at most 2 decimal places (got 11).

FAIL  invalidates every mounted reader, not just the host record
AssertionError: expected [] to deeply equal [ { objectName: '*', ...(1) } ]

FAIL  falls back to the en pack value, with the flow name filled in
AssertionError: expected [ [ 'Done' ] ] to deeply equal [ Array(1) ]
```

The sentence is queried **by text** rather than by the alert role on purpose: the role query fails with "unable to find role alert", which reads the same whether the sentence was dropped or the markup moved. Querying the text makes the RED name what went missing.

Mutation and restore legs were both proved to land by a marker grep (`notifyDataChanged` absent on the mutated leg, present on the restore, tree clean afterwards). **No rebuild leg applies here and none is claimed**: the root `vitest.config.mts` aliases `@object-ui/*` to `packages/*/src`, so neither leg resolves through a `dist`.

## Readings, all at `ddb7a5fe7`

| check | result |
|---|---|
| `vitest run packages/app-shell/` | **457 files / 4420 passed**, 1 skipped, 0 failed |
| `vitest run packages/i18n/` | **48 files / 869 passed** |
| restore leg (5 FlowRunner + flowResponse files, incl. the #2958 consolidation ratchet) | **6 files / 48 passed** |
| `type-check` (app-shell, i18n) | Done, Done — after building the dependency closure (`TS6305` without it) |
| `lint` (app-shell, i18n) | 0 errors. `FlowRunner.tsx` is **4 warnings before and after** — no new ones |
| `check:i18n-keys` | every in-scope key resolves, every inline default matches its `en` value, interpolation parity 0 findings |
| `check:i18n-drift` | 0 `en` values changed, 5 keys added |
| `check:control-bytes` | OK, 4497 tracked files |
| `check:phantom-deps` / `check:self-import` / `check:esm-specifiers` | all clean |
| `changeset-presence` / `changeset-no-major` | 1 changeset, no `major` |

## Deliberately not done

Navigation to the newly created record. The card calls it "would close the loop", i.e. a suggestion; it needs the flow output to name a record, which is a contract question. The output shape does not answer it today — the terminal `data` is `AutomationResult`, which carries no record identity — so nothing was built and no follow-up card was filed on it. The card's note that `16.1.0` sent zero requests on Submit is context, not work, and was not re-litigated.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_