### PR TITLE
docs(esm-load-gate): state the unbundled-Node boundary instead of carrying it as debt

### DIFF
--- a/.changeset/unbundled-node-boundary-5384.md
+++ b/.changeset/unbundled-node-boundary-5384.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/plugin-dashboard': patch
+'@object-ui/plugin-map': patch
+'@object-ui/app-shell': patch
+---
+
+Each package's README now states, up front, that it needs a bundler: importing it from plain Node ESM fails, and that is a supported-configuration boundary rather than a defect.
+
+`@object-ui/plugin-dashboard` imports `react-grid-layout/css/styles.css` at module
+scope and `@object-ui/plugin-map` imports `maplibre-gl/dist/maplibre-gl.css`;
+`@object-ui/app-shell` reaches the first of those through the static
+`@object-ui/plugin-dashboard` imports in `DashboardView` and `ReportView`. Node has
+no loader for `.css` at all, so all three resolve and then die during evaluation:
+
+```
+TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
+  for .../react-grid-layout/css/styles.css
+```
+
+Nothing about how these packages load has changed — every supported host bundles
+them (Vite, webpack, or Next with the package in `transpilePackages`), and that is
+still the only supported way to consume them. What changed is that the boundary is
+now written where a consumer meets it, instead of being learned from a red import.
+
+objectui#5384 ruled unbundled Node consumption **unsupported** for style-carrying
+plugin packages — permanently, over the three packages as a group — rather than
+moving the stylesheet imports out of module scope. No unbundled-Node consumer
+exists, and buying permanent machinery to close a capability gap nobody is pulling
+on was the trade the ruling declined. A real consumer request reopens it as a
+design question, not as a defect: the READMEs say so and name the issue.

--- a/.github/workflows/node-esm-load-gate.yml
+++ b/.github/workflows/node-esm-load-gate.yml
@@ -5,6 +5,14 @@ name: Node ESM Load Gate
 # gate, and why a resolution-only criterion was measured and rejected, are
 # documented at length in scripts/check-node-esm-load.mjs.
 #
+# "Every" has one ruled exception, and it is a product boundary rather than a
+# backlog item: the three style-carrying plugin packages named in
+# UNBUNDLED_NODE_UNSUPPORTED import a `.css` file at module scope, which Node
+# cannot load at all, and objectui#5384 ruled unbundled Node consumption
+# unsupported for them permanently. They are printed on every run, never
+# silently subtracted, and the specifier leg — not this one — is what guards
+# them against a real regression.
+#
 # ── Why this is a scheduled workflow and NOT a pull-request job ──────────────
 #
 # The load leg has to EVALUATE each entry, so it has to build all 39 published

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -788,6 +788,30 @@ is itself a failure, so it cannot outlive the debt it records. Packages that are
 by design — a `bin`-only CLI, or a built web app whose `dist` is `index.html` — are printed on
 every run rather than skipped silently.
 
+A separate list, `UNBUNDLED_NODE_UNSUPPORTED`, names the packages plain Node is **not expected
+to load at all**. Three style-carrying plugin packages sit there: `@object-ui/plugin-dashboard`
+and `@object-ui/plugin-map` import `react-grid-layout`'s and `maplibre-gl`'s stylesheets at
+module scope, and `@object-ui/app-shell` reaches the first of those through static imports. All
+three resolve fine and then die on `ERR_UNKNOWN_FILE_EXTENSION`, because Node has no loader for
+`.css`. That is **a stated product boundary, not debt** — unbundled Node consumption is not
+supported for style-carrying plugin packages, ruled on
+[#5384](https://github.com/objectstack-ai/objectui/issues/5384) after measuring that no
+unbundled-Node consumer exists: every consumer reaches these packages through a bundler (`vite`
+in the console and the examples, Next's `transpilePackages` in `apps/site`). The load leg's count
+therefore stops short of the total on purpose, and the run prints those three names on every run
+rather than quietly subtracting them. Each package says the same thing in its own README, so a
+consumer meets the boundary before a red import rather than after one.
+
+The boundary has a price, and the list states it rather than leaving it to be found later: it
+matches by **package name**, not by error code, so the load leg cannot speak for those three at
+all — a genuine extensionless-specifier regression in one of them would print as a boundary line
+instead of failing the run. What guards them instead is the specifier leg, which is a hard
+requirement now that `SPECIFIER_DEBT` is empty; [#5357](https://github.com/objectstack-ai/objectui/issues/5357)'s
+ablation reverted app-shell's specifiers and watched the specifier leg redden while the load leg
+went on printing its ledger line. The ratchet is kept in the other direction too: a named package
+whose entry starts loading is itself a failure, because from that moment the exemption costs
+coverage and buys nothing.
+
 ### Changeset Guard (`changeset-guard.yml`)
 
 **Trigger:** PR to `main`/`develop`, and push to `main`, **when `.changeset/**` changes** — the

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -19,6 +19,31 @@ This package provides the essential building blocks for rendering ObjectUI schem
 pnpm add @object-ui/app-shell
 ```
 
+## Requires a bundler — plain Node cannot import this package
+
+This package's own artifact is clean, but `DashboardView` and `ReportView` import
+`@object-ui/plugin-dashboard` **statically**, and that package imports `react-grid-layout`'s
+stylesheet at module scope. Node has no loader for `.css`, so importing the published entry
+from plain Node ESM — no bundler, no loader hooks — resolves and then fails during evaluation:
+
+```text
+TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
+  for .../react-grid-layout/css/styles.css
+```
+
+**This is a supported-configuration statement, not a bug to report.** Unbundled Node
+consumption is not supported for style-carrying plugin packages, and app-shell inherits the
+boundary through the import above. It was ruled that way on
+[objectui#5384](https://github.com/objectstack-ai/objectui/issues/5384), over the alternative
+of moving those stylesheet imports out of module scope, because no unbundled-Node consumer
+exists to serve.
+
+Consume it through a host that handles CSS imports, which every supported host does: Vite,
+webpack, or Next with the package listed in `transpilePackages`. If you have a real need to
+import it under plain Node — SSR with no bundler, a Node-side script — please open an issue.
+That reopens the question as a design decision rather than a defect, and the shape of your
+consumer is the missing input.
+
 ## Usage
 
 ### Basic Setup

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -16,6 +16,30 @@ Dashboard plugin for Object UI - Create beautiful dashboards with metrics, chart
 pnpm add @object-ui/plugin-dashboard
 ```
 
+## Requires a bundler — plain Node cannot import this package
+
+`DashboardGridLayout` imports `react-grid-layout`'s stylesheet at module scope
+(`import 'react-grid-layout/css/styles.css'`), and Node has no loader for `.css` at all.
+Importing the published entry from plain Node ESM — no bundler, no loader hooks — therefore
+resolves and then fails during evaluation:
+
+```text
+TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
+  for .../react-grid-layout/css/styles.css
+```
+
+**This is a supported-configuration statement, not a bug to report.** Unbundled Node
+consumption is not supported for style-carrying plugin packages. It was ruled that way on
+[objectui#5384](https://github.com/objectstack-ai/objectui/issues/5384) — deliberately, over
+the alternative of moving the stylesheet out of module scope — because the grid's layout rules
+are not optional and no unbundled-Node consumer exists to serve.
+
+Consume it through a host that handles CSS imports, which every supported host does: Vite,
+webpack, or Next with the package listed in `transpilePackages`. If you have a real need to
+import it under plain Node — SSR with no bundler, a Node-side script — please open an issue.
+That reopens the question as a design decision rather than a defect, and the shape of your
+consumer is the missing input.
+
 ## Usage
 
 ### Automatic Registration (Side-Effect Import)

--- a/packages/plugin-map/README.md
+++ b/packages/plugin-map/README.md
@@ -21,6 +21,30 @@ both resolving to the same renderer:
 pnpm add @object-ui/plugin-map
 ```
 
+## Requires a bundler — plain Node cannot import this package
+
+`ObjectMap` imports MapLibre's stylesheet at module scope
+(`import 'maplibre-gl/dist/maplibre-gl.css'`), and Node has no loader for `.css` at all.
+Importing the published entry from plain Node ESM — no bundler, no loader hooks — therefore
+resolves and then fails during evaluation:
+
+```text
+TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
+  for .../maplibre-gl/dist/maplibre-gl.css
+```
+
+**This is a supported-configuration statement, not a bug to report.** Unbundled Node
+consumption is not supported for style-carrying plugin packages. It was ruled that way on
+[objectui#5384](https://github.com/objectstack-ai/objectui/issues/5384) — deliberately, over
+the alternative of moving the stylesheet out of module scope — because a MapLibre canvas
+without its stylesheet is not a map, and no unbundled-Node consumer exists to serve.
+
+Consume it through a host that handles CSS imports, which every supported host does: Vite,
+webpack, or Next with the package listed in `transpilePackages`. If you have a real need to
+import it under plain Node — SSR with no bundler, a Node-side script — please open an issue.
+That reopens the question as a design decision rather than a defect, and the shape of your
+consumer is the missing input.
+
 ## Usage
 
 Registration is a side effect of the import. There is no manual-registration

--- a/scripts/__tests__/check-node-esm-load.test.ts
+++ b/scripts/__tests__/check-node-esm-load.test.ts
@@ -5,11 +5,11 @@ import path from 'node:path';
 
 import {
   EXPLICIT_EXTENSION,
-  LOAD_DEBT,
   MIN_LOADED,
   MIN_PACKAGES,
   RELATIVE_SPECIFIER,
   SPECIFIER_DEBT,
+  UNBUNDLED_NODE_UNSUPPORTED,
   attributeMissingModule,
   buildPreservesSpecifiers,
   effectiveNoEmit,
@@ -282,17 +282,43 @@ describe('the ledger is a ratchet', () => {
       expect(name).toMatch(/^@object-ui\//);
       expect(reason.length).toBeGreaterThan(10);
     }
-    for (const [name, reason] of LOAD_DEBT) {
+    for (const [name, reason] of UNBUNDLED_NODE_UNSUPPORTED) {
       expect(name).toMatch(/^@object-ui\//);
       expect(reason.length).toBeGreaterThan(10);
     }
   });
 
+  it('cites a ruling on every boundary entry, so no exemption is a bare name', () => {
+    // objectui#5384 turned these three from debt into a permanent statement:
+    // unbundled Node consumption is not supported for style-carrying plugin
+    // packages. A permanent exemption a reader cannot trace is how it becomes a
+    // mystery three months later — the reason and the ruling have to come from
+    // the ENTRY, not from the fact that a name sits in a map. This is the pin
+    // that makes adding a bare name fail.
+    for (const reason of UNBUNDLED_NODE_UNSUPPORTED.values()) {
+      expect(reason).toMatch(/objectui#\d+/);
+      expect(reason).toMatch(/unbundled Node is not supported/);
+    }
+  });
+
+  it('holds exactly the group the ruling covered, so it cannot widen quietly', () => {
+    // The ruling was taken over the style-carrying packages as a GROUP rather
+    // than one at a time, which is also what keeps the boundary describable in
+    // one sentence. A fourth name is a new product decision, not a spelling
+    // change, so it has to come here and say so.
+    expect([...UNBUNDLED_NODE_UNSUPPORTED.keys()].sort()).toEqual([
+      '@object-ui/app-shell',
+      '@object-ui/plugin-dashboard',
+      '@object-ui/plugin-map',
+    ]);
+  });
+
   it('keeps the two ledgers disjoint — they answer different questions', () => {
-    // SPECIFIER_DEBT is this defect class. LOAD_DEBT is "can an unbundled
-    // consumer load this at all", which is a product question. Merging them
-    // would let the defect stop being visible inside a grab-bag.
-    for (const name of LOAD_DEBT.keys()) expect(SPECIFIER_DEBT.has(name)).toBe(false);
+    // SPECIFIER_DEBT is this defect class. UNBUNDLED_NODE_UNSUPPORTED is "can an
+    // unbundled consumer load this at all", which is a product question that has
+    // been answered and closed. Merging them would let the defect stop being
+    // visible inside a grab-bag.
+    for (const name of UNBUNDLED_NODE_UNSUPPORTED.keys()) expect(SPECIFIER_DEBT.has(name)).toBe(false);
   });
 
   it('does not ledger the packages objectui#4538 fixed', () => {
@@ -303,7 +329,7 @@ describe('the ledger is a ratchet', () => {
       '@object-ui/i18n',
     ]) {
       expect(SPECIFIER_DEBT.has(fixed)).toBe(false);
-      expect(LOAD_DEBT.has(fixed)).toBe(false);
+      expect(UNBUNDLED_NODE_UNSUPPORTED.has(fixed)).toBe(false);
     }
   });
 });

--- a/scripts/check-node-esm-load.mjs
+++ b/scripts/check-node-esm-load.mjs
@@ -5,7 +5,8 @@
  * Run:  node scripts/check-node-esm-load.mjs --specifiers-only  (`pnpm check:esm-specifiers`)
  *       node scripts/check-node-esm-load.mjs                    (`pnpm check:node-esm-load`)
  * Exit: 0 = no un-ledgered package emits an unresolvable relative specifier,
- *           and (full mode) every entry the gate imported evaluated,
+ *           and (full mode) every entry the gate imported either evaluated or
+ *           is named as a stated boundary (UNBUNDLED_NODE_UNSUPPORTED),
  *       1 = a finding, OR the gate could not build, OR it inspected too little
  *           to be asserting anything.
  *
@@ -58,6 +59,12 @@
  * defect that reaches a package through a dependency; leg 2 cannot see a
  * defect on a code path evaluation does not take. Leg 1 is the ratchet; leg 2
  * is the proof that the ratchet guards the right property.
+ *
+ * Leg 2 also carries this repository's one PRODUCT boundary: three
+ * style-carrying plugin packages that plain Node is not expected to load, ruled
+ * permanent rather than owed. It is stated at length on
+ * UNBUNDLED_NODE_UNSUPPORTED below — including what the boundary costs this
+ * gate, and which leg guards those packages instead.
  *
  * ## The vacuous forms this gate must never take
  *
@@ -218,33 +225,111 @@ export function buildPreservesSpecifiers(buildScript, pkgDir) {
 export const SPECIFIER_DEBT = new Map();
 
 /**
- * Packages whose published entry cannot evaluate under plain Node for a reason
- * that is NOT this defect class, with the reason each one shows.
+ * Packages whose published entry cannot evaluate under plain Node, and for which
+ * that is a STATED PRODUCT BOUNDARY rather than a debt anyone intends to pay.
  *
- * Kept separate from SPECIFIER_DEBT on purpose: an entry here is a statement
- * about a DIFFERENT question (is an unbundled consumer supported at all?),
- * and merging the two would let this gate become a grab-bag in which the
- * defect it exists for stops being visible.
+ * Kept separate from SPECIFIER_DEBT on purpose: an entry here answers a
+ * DIFFERENT question (is an unbundled consumer supported at all?), and merging
+ * the two would let this gate become a grab-bag in which the defect it exists
+ * for stops being visible.
+ *
+ * Formerly `LOAD_DEBT`, renamed by the ruling below. A map whose name says
+ * "debt" reads as a promise to fix, and these three entries are not one — the
+ * old name is what made the ledger aspirational rather than honest. The
+ * previous spelling survives in `packages/app-shell/CHANGELOG.md`, which
+ * records the day that entry was added; this is the map it names.
+ *
+ * ## The boundary, and who ruled it
+ *
+ * **Unbundled Node consumption is NOT supported for style-carrying plugin
+ * packages.** Ruled on objectui#5384 (2026-08-20), taken over the three
+ * packages as a group rather than one at a time, exactly as the card asked.
+ * The maintainer accepted the triage batch verbatim: 「其他接受你的建议。」
+ *
+ * The card put three directions on the table — move the stylesheet import off
+ * module scope so the entry loads, declare the boundary, or something
+ * upstream-shaped for `react-grid-layout` / `maplibre-gl` — and the ruling took
+ * the second, with its reason recorded: *"No known unbundled-Node consumer
+ * exists; converting a zero-pull capability gap into permanent maintained
+ * machinery is the shape the startup rule rejects."*
+ *
+ * That premise was re-measured when this ledger was reworded, not inherited.
+ * Every consumer of these three packages in this repository reaches them
+ * through a bundler: `vite` in `apps/console`, `examples/console-starter` and
+ * `examples/byo-backend-console`, and Next's `transpilePackages` in `apps/site`
+ * — which is the key that makes the stylesheet work there. Nothing declares
+ * them under `serverExternalPackages`, so Next's Node side never loads these
+ * entries itself either, and the sibling `objectstack` repository names them
+ * only in comments and changeset fixtures. Zero unbundled-Node consumers, and
+ * the searches that returned zero were counter-probed with terms known to be
+ * present.
+ *
+ * Revisit ONLY on a real consumer request, which reopens objectui#5384 as a
+ * DESIGN card rather than a debt payment: the question to re-answer is whether
+ * these packages should carry their stylesheet at module scope at all, and it
+ * needs the consumer's shape to answer.
+ *
+ * ## What each entry excuses, measured rather than assumed
+ *
+ * All three die on the same code, and it is not this gate's defect class:
+ * `ERR_UNKNOWN_FILE_EXTENSION`. Resolution SUCCEEDS — both stylesheets are
+ * exported by their own packages — and evaluation fails, because Node has no
+ * loader for `.css` at all. Measured directly under Node 22.22.2:
+ *
+ *     TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
+ *       for …/react-grid-layout/css/styles.css
+ *     TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
+ *       for …/maplibre-gl/dist/maplibre-gl.css
+ *
+ * ## What the boundary costs, stated here rather than discovered later
+ *
+ * This map matches by PACKAGE NAME, not by error code, so the load leg cannot
+ * speak for these three AT ALL: a genuine extensionless-specifier regression in
+ * any of them would print as a boundary line here instead of failing the run.
+ * That was true while they were debt and it is true now — permanence just makes
+ * it permanent, so it is written down instead of remembered.
+ *
+ * What carries the guard instead is the SPECIFIER leg, which became a hard
+ * requirement the moment SPECIFIER_DEBT emptied, and the ruling keeps it there
+ * deliberately. It is measured, not hoped: objectui#5357's ablation reverted
+ * app-shell's specifiers and watched the specifier leg redden while the load
+ * leg went on printing a ledger line.
+ *
+ * An entry here is therefore never a way to turn a red run green. It owes what
+ * these three pay: the boundary in words, the ruling that made it permanent,
+ * and the consumer question it answers — a bare name would be a mystery to
+ * whoever reads it next. `check-node-esm-load.test.ts` pins that every entry
+ * cites a ruling, so an unexplained one fails the suite.
+ *
+ * The ratchet in the other direction is kept exactly as it was: a package named
+ * here whose entry DOES load is a finding, because from that moment the
+ * exemption costs coverage and buys nothing.
+ *
+ * @type {Map<string, string>}
  */
-export const LOAD_DEBT = new Map([
+export const UNBUNDLED_NODE_UNSUPPORTED = new Map([
   [
     '@object-ui/app-shell',
-    "reaches react-grid-layout's stylesheet through the STATIC `@object-ui/plugin-dashboard` imports in " +
-      'DashboardView and ReportView, so it fails for the same reason that package does. Uncovered by ' +
-      'objectui#5357: while app-shell emitted extensionless specifiers its first error was ' +
-      'ERR_MODULE_NOT_FOUND on its own file, which masked this one entirely — the first-failure shape ' +
-      'objectui#5214 measured (5 predicted red, 10 observed). Its specifier debt is paid and its own ' +
-      'artifact is clean; what is left is the `.css` question, and it clears the moment ' +
-      '@object-ui/plugin-dashboard does',
+    'unbundled Node is not supported for this package, by ruling objectui#5384 — a stated boundary, ' +
+      "not debt. It reaches react-grid-layout's stylesheet through the STATIC " +
+      '`@object-ui/plugin-dashboard` imports in DashboardView and ReportView, so Node stops on the same ' +
+      'ERR_UNKNOWN_FILE_EXTENSION that package does. Its own specifier debt is paid and its own artifact ' +
+      'is clean — uncovered by objectui#5357, because while app-shell emitted extensionless specifiers ' +
+      'its first error was ERR_MODULE_NOT_FOUND on its own file, which masked the stylesheet entirely ' +
+      '(the first-failure shape objectui#5214 measured: 5 predicted red, 10 observed)',
   ],
   [
     '@object-ui/plugin-dashboard',
-    "imports react-grid-layout's stylesheet; Node cannot load `.css` at all, which is a question " +
-      'about whether unbundled consumers are supported, not about this defect',
+    'unbundled Node is not supported for this package, by ruling objectui#5384 — a stated boundary, ' +
+      "not debt. DashboardGridLayout imports react-grid-layout's stylesheet " +
+      '(`react-grid-layout/css/styles.css`) at module scope, and Node has no loader for `.css`, so the ' +
+      'entry resolves and then dies with ERR_UNKNOWN_FILE_EXTENSION. Every supported consumer bundles it',
   ],
   [
     '@object-ui/plugin-map',
-    "imports maplibre-gl's stylesheet; same question as @object-ui/plugin-dashboard",
+    'unbundled Node is not supported for this package, by ruling objectui#5384 — a stated boundary, ' +
+      "not debt. ObjectMap imports maplibre-gl's stylesheet (`maplibre-gl/dist/maplibre-gl.css`) at " +
+      'module scope; same ERR_UNKNOWN_FILE_EXTENSION and same ruling as @object-ui/plugin-dashboard',
   ],
 ]);
 
@@ -514,9 +599,13 @@ function main(argv) {
     const outcome = importEntry(entryPath);
     if (outcome.ok) {
       loaded++;
-      if (LOAD_DEBT.has(pkg.name)) {
+      if (UNBUNDLED_NODE_UNSUPPORTED.has(pkg.name)) {
         failed = true;
-        console.error(`\n✗ ${pkg.name} is in LOAD_DEBT but now loads. Delete its entry.`);
+        console.error(
+          `\n✗ ${pkg.name} is named as unsupported under unbundled Node, but its entry now loads.\n` +
+            '  Delete its entry in the commit that made it loadable: the boundary no longer describes ' +
+            'this package, and while the name sits here the load leg cannot speak for it at all.',
+        );
       }
       continue;
     }
@@ -531,6 +620,17 @@ function main(argv) {
   if (notImportable.length > 0) {
     console.log(`  not importable by design: ${notImportable.join(', ')}`);
   }
+  // Named on every run for the same reason the line above is: the packages this
+  // gate is not allowed to speak for are the ones a reader most needs to see. A
+  // count that never reaches the total is honest only while the shortfall is
+  // legible from the run itself.
+  const boundary = esmPackages.filter((p) => UNBUNDLED_NODE_UNSUPPORTED.has(p.name)).map((p) => p.name);
+  if (boundary.length > 0) {
+    console.log(
+      '  unbundled Node unsupported, by ruling rather than by debt (each entry names its ruling in ' +
+        `UNBUNDLED_NODE_UNSUPPORTED): ${boundary.join(', ')}`,
+    );
+  }
   if (loaded < MIN_LOADED) {
     console.error(
       `✗ only ${loaded} entries evaluated (expected at least ${MIN_LOADED}). This run proved nothing — ` +
@@ -540,12 +640,17 @@ function main(argv) {
   }
 
   for (const f of loadFindings) {
-    const ledgered =
-      LOAD_DEBT.has(f.name) || (f.code === 'ERR_MODULE_NOT_FOUND' && SPECIFIER_DEBT.has(f.owner));
+    // Two different verdicts, printed as two different words. `ledgered` means
+    // a debt someone still owes; `by design` means a boundary that was ruled,
+    // and reading the second as the first is how a permanent statement gets
+    // mistaken for a worklist item.
+    const byDesign = UNBUNDLED_NODE_UNSUPPORTED.has(f.name);
+    const ledgered = byDesign || (f.code === 'ERR_MODULE_NOT_FOUND' && SPECIFIER_DEBT.has(f.owner));
     const via = f.owner !== f.name ? ` (via ${f.owner})` : '';
     if (!ledgered) failed = true;
     const line = `${f.name}${via}: ${f.code} — ${f.message}`;
-    if (ledgered) console.log(`  ledgered ${line}`);
+    if (byDesign) console.log(`  by design ${line}`);
+    else if (ledgered) console.log(`  ledgered ${line}`);
     else console.error(`✗ ${line}`);
   }
 


### PR DESCRIPTION
Fixes #5384

The card's title argues for moving the CSS import out of module scope. That is **not** what was ruled, and this PR does not do it — no package's import statements are touched. What changed is the ledger, its gate, and the docs, so that all three say the true thing.

## The ruling, verbatim

> **Ruled: the second direction — unbundled Node consumption is NOT supported for style-carrying plugin packages, as a permanent statement rather than debt.** Provenance: maintainer accepted the batch, verbatim: 「其他接受你的建议。」 Taken over the group as the card asks: `@object-ui/plugin-dashboard`, `@object-ui/app-shell` (via its static imports), and `@object-ui/plugin-map` together. No known unbundled-Node consumer exists; converting a zero-pull capability gap into permanent maintained machinery is the shape the startup rule rejects.
>
> Implementation: reword `LOAD_DEBT` for these three from debt to a stated permanent boundary (the ledger becomes honest rather than aspirational), keep the specifier leg as the hard guard it already is, and note the boundary in the packages' READMEs so a future Node consumer learns it from the package, not from a red import. Revisit only on a real consumer request — which would reopen this as a design card, not a debt payment.

All three implementation clauses are done below, in that order.

## Before / after — the number does not move, and that is the point

Measured against **one build** of every published package (43 turbo tasks), running the `origin/main` gate and this branch's gate over the **same artifacts**, both with `--no-build`:

| | before (`origin/main`) | after (this branch) |
|---|---|---|
| Load leg | `34 of 39 published ESM entries imported and evaluated` | `34 of 39 published ESM entries imported and evaluated` |
| exit code | 0 | 0 |
| the three packages | `ledgered @object-ui/app-shell: ERR_UNKNOWN_FILE_EXTENSION …` ×3 | `by design @object-ui/app-shell: ERR_UNKNOWN_FILE_EXTENSION …` ×3, plus a named summary line |

Nothing about which entries load changed, because nothing about how they load changed. The card was never worth a bigger number — it was worth a ledger that stops describing a permanent boundary as an unpaid debt.

The run now also names the exempt packages in the summary block, next to the existing `not importable by design` line:

```text
Load leg: 34 of 39 published ESM entries imported and evaluated.
  not importable by design: @object-ui/create-plugin (bin-only CLI), @object-ui/runner (no importable entry declared)
  unbundled Node unsupported, by ruling rather than by debt (each entry names its ruling in UNBUNDLED_NODE_UNSUPPORTED): @object-ui/app-shell, @object-ui/plugin-dashboard, @object-ui/plugin-map
```

## What changed

**1. `LOAD_DEBT` is now `UNBUNDLED_NODE_UNSUPPORTED`** (`scripts/check-node-esm-load.mjs`). A map whose name says "debt" reads as a promise to fix; these three entries are not one, and that name is what made the ledger aspirational rather than honest. Its docblock now carries the ruling, the date, the verbatim provenance, the re-measured premise, and what would reopen it. The former name is called out in the docblock so the reference in `packages/app-shell/CHANGELOG.md` stays traceable.

**2. Each entry states its own boundary and cites the ruling.** The failure is recorded as measured rather than described loosely — all three die on the same code, and it is not this gate's defect class:

```text
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
  for .../react-grid-layout/css/styles.css
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css"
  for .../maplibre-gl/dist/maplibre-gl.css
```

Resolution *succeeds* — both stylesheets are exported by their own packages — and evaluation fails, because Node has no loader for `.css`.

**3. The cost is stated, not left to be discovered.** The map matches by package **name**, not by error code, so the load leg cannot speak for these three at all. That was true while they were debt; permanence just makes it permanent, so it is written down. The specifier leg is what guards them, exactly as the ruling directs, and that leg is untouched here — it is a hard requirement while `SPECIFIER_DEBT` is empty, and #5357's ablation measured it reddening on a reverted app-shell while the load leg went on printing its ledger line.

**4. The verdicts print as two different words.** `ledgered` (a debt someone owes) and `by design` (a boundary that was ruled) are no longer the same word, because reading the second as the first is how a permanent statement gets mistaken for a worklist item. The reverse ratchet is kept: a named package whose entry starts loading is still a failure, with a message that now says why.

**5. READMEs — the ruling's third clause.** `@object-ui/plugin-dashboard`, `@object-ui/plugin-map` and `@object-ui/app-shell` each carry a "Requires a bundler" section after Installation: the real error text, the statement that this is a supported-configuration boundary rather than a bug, the ruling link, and the invitation to open an issue if a real unbundled-Node use case exists. READMEs ship inside the published tarball, so this reaches an npm consumer.

**6. Docs and workflow.** `content/docs/guide/ci-cd-pipeline.md` describes the second list beside `SPECIFIER_DEBT`, including why the load leg's count stops short of the total on purpose. The workflow header no longer claims an unqualified "every published ESM package".

**7. A pin so the exemption can never become a bare allowlist.** `check-node-esm-load.test.ts` now requires every entry to cite a ruling (`objectui#NNNN`) and state the boundary, and pins the membership to exactly the three packages the ruling covered — a fourth name is a new product decision, not a spelling change.

## The ruling's premise, re-measured rather than inherited

The ruling rests on "no known unbundled-Node consumer exists", so it was probed rather than assumed. Every consumer of these packages reaches them through a bundler: `vite` in `apps/console`, `examples/console-starter` and `examples/byo-backend-console`, and Next's `transpilePackages` in `apps/site` — nothing is declared under `serverExternalPackages` (zero hits repo-wide), so Next's Node side never loads these entries either. `examples/schema-catalog` builds with a bare `tsc` and looked like a candidate, but it imports only JSON schema files out of directories named after the plugins, never the packages. In the sibling `objectstack` repository all four hits are string literals in comments and changeset fixtures.

Every zero above was counter-probed with a term known to be present, so none of them is a broken search reading as an empty one. **Premise holds.**

## Verification

Run at `77d894b76`, the head of this branch, tree clean:

```text
PASS  pnpm check:esm-specifiers          Specifier leg: no un-ledgered package emits an extensionless relative specifier.
PASS  pnpm check:control-bytes           scanned 4510 tracked text file(s)
PASS  pnpm changeset:check
PASS  pnpm docs:check-links              Links are valid across 13 scan roots.
PASS  pnpm type-check:scripts
PASS  pnpm check:doc-snippets            87 of 87 block(s) judged, 0 failed
PASS  vitest check-node-esm-load + ci-cd-pipeline-doc      Tests  62 passed (62)
PASS  pnpm check:node-esm-load --no-build                  Load leg: 34 of 39
```

**Reverse verification of the new pin.** Predicted direction: reddens. Stripping `by ruling objectui#5384` from the `plugin-map` entry produced `Tests  1 failed | 29 passed (30)`, failing on `expect(reason).toMatch(/objectui#\d+/)` at the un-cited entry; restoring gave `30 passed (30)`. No rebuild applies to this ablation and none was needed: the suite imports the gate as a source `.mjs` by relative path, not through a package's `exports` map, so no `dist/` sits between the edit and the assertion. The fix was committed before the mutation, and the restore was a `git checkout` of the committed file, verified byte-identical by a clean `git status`.

## Not done, deliberately

The stylesheet imports in `DashboardGridLayout`, `ObjectMap`, `DashboardView` and `ReportView` are untouched. That is option A, and it was ruled against.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_