### PR TITLE
fix(plugin-grid): give a dropped ObjectGrid column an address instead of silence

### DIFF
--- a/.changeset/grid-unresolved-column-diagnostic-5349.md
+++ b/.changeset/grid-unresolved-column-diagnostic-5349.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+`ObjectGrid` says which column it dropped, instead of rendering a header-only grid in silence.
+
+objectui#5068 retired the undeclared `accessorKey` / `header` tolerance branch, so
+`ListColumnSchema`'s `field` / `label` is now the only column spelling the renderer
+reads. That was right — the spec refuses `accessorKey` and `header` by name, and the
+census found zero authored usages. But it relocated a failure mode instead of removing
+it: a column authored in a spelling the renderer does not read contributed nothing, and
+nothing said so. No error, no warning, no empty state — the author got a grid with its
+row-number column and no data columns, which is a success receipt for a disagreement
+between the renderer and the author.
+
+An authored column that can never resolve now emits one `console.warn` naming the
+address rather than the symptom: which block (`object-grid` or the `view:grid` alias),
+which object and label, which `columns[i]`, the keys that entry actually carries, and the
+rewrite that works — for a column authored `{ accessorKey: 'amount', header: 'Amount' }`
+the message spells out `{ field: 'amount', label: 'Amount' }`. It reuses the channel `ObjectGrid` already had for "you declared it, the renderer dropped
+it" (the export-format warning), rather than adding a second differently-shaped one.
+
+Rendering is unchanged in every case: this is additive. The diagnostic reads the
+`columns` input and nothing else — it never asks whether the grid found rows, because
+`object-grid` legitimately draws them from five different places (a bare `data` array,
+`data.provider: 'value'`, legacy `staticData`, `bind`, or a host that owns the fetch and
+passes the window down as a `data` React prop, which is what `plugin-list`'s `ListView`
+does). All five are pinned by test, in both directions. A `hidden: true` column is
+authored intent and is never reported, and so are the arms that legitimately produce no
+columns of their own: no `columns` key, an empty `columns` array, and the `string[]`
+spelling.
+
+A throw was rejected: a grid that renders nothing today would become a page that renders
+nothing.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -48,6 +48,7 @@ import { useRecordCrudVerdicts } from './hooks/useRecordCrudVerdicts';
 import { resolveLegacyRowActions } from './resolveLegacyRowActions';
 import { resolveBulkActions } from './resolveBulkActions';
 import { partitionBulkRows } from './bulkEligibility';
+import { resolvesToDataColumn, describeUnresolvedColumns } from './columnSpellingDiagnostics';
 import { RowActionMenu, formatActionLabel } from './components/RowActionMenu';
 import { BulkActionBar } from './components/BulkActionBar';
 import { BulkActionDialog } from './components/BulkActionDialog';
@@ -1431,6 +1432,41 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   }, [schema.columns]);
   const { summaries, hasSummary } = useColumnSummary(summaryColumns, data, objectSchema?.fields);
 
+  // An authored column the renderer cannot read now says so, instead of just
+  // not being there (objectui#5349 — the Q2 objectui#5068 deferred).
+  //
+  // #5068 made `ListColumnSchema`'s `field` / `label` the only spelling read
+  // here, which is right; what it left behind was the receipt. A column
+  // authored `{ accessorKey, header }` (or with no `field` at all) is dropped
+  // by `resolvesToDataColumn` above, and until this effect landed the author
+  // saw no error, no warning and no empty header — just a grid with its
+  // row-number column and no data columns. Same defect shape #5068 exists to
+  // fix, one level down: renderer and author disagree, author gets a success
+  // receipt.
+  //
+  // Scope, deliberately narrow: this reads the `columns` INPUT and nothing
+  // else. It never asks whether the grid found ROWS, because a grid legitimately
+  // draws them from five different places (inline `data` array, `data.provider:
+  // 'value'`, legacy `staticData`, `bind`, or a host that owns the fetch and
+  // passes the window down as a `data` React prop). A predicate that consulted
+  // those would eventually paint a configuration error over a working grid.
+  // `hidden: true` is authored intent and is never reported.
+  //
+  // Channel: the same one `ObjectGrid` already uses for "you declared it, the
+  // renderer dropped it" — a `useEffect` keyed on the schema slice and one
+  // `console.warn` prefixed `[ObjectUI] ObjectGrid <topic>:` (see the export
+  // format warning below) — rather than a second, differently-shaped one.
+  const columnDiagnosticBlockType = (schema as { type?: unknown }).type;
+  const columnDiagnosticLabel = schema.label ?? (schema as { title?: unknown }).title;
+  useEffect(() => {
+    const message = describeUnresolvedColumns(schema.columns, {
+      blockType: columnDiagnosticBlockType,
+      objectName: schema.objectName,
+      label: columnDiagnosticLabel,
+    });
+    if (message) console.warn(message);
+  }, [schema.columns, columnDiagnosticBlockType, schema.objectName, columnDiagnosticLabel]);
+
   const generateColumns = useCallback(() => {
     // Map field type to column header icon (Airtable-style)
     const getTypeIcon = (fieldType: string | null): React.ReactNode => {
@@ -1559,8 +1595,13 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
       // component still writes below. Metadata vocabulary in, adapter
       // vocabulary out, one translation.
       if (cols.length > 0 && typeof cols[0] === 'object' && cols[0] !== null) {
+        // The drop decision lives in `resolvesToDataColumn`
+        // (`columnSpellingDiagnostics.ts`) so the diagnostic that reports a
+        // dropped column cannot drift from the filter that drops it — one
+        // predicate, two readers (objectui#5349). Semantics unchanged:
+        // `col?.field && typeof col.field === 'string' && !col.hidden`.
         return (cols as ListColumn[])
-          .filter((col) => col?.field && typeof col.field === 'string' && !col.hidden)
+          .filter((col) => resolvesToDataColumn(col))
           .map((col, colIndex) => {
             // Fall back to the SCHEMA FIELD's label before prettifying the machine
             // name — otherwise a column declared as bare { field } shows an English

--- a/packages/plugin-grid/src/__tests__/columnDeclaredSpellingOnly.test.tsx
+++ b/packages/plugin-grid/src/__tests__/columnDeclaredSpellingOnly.test.tsx
@@ -31,13 +31,20 @@
  * `TABLE_ADAPTER_COLUMN_KEY`). This card is about the way IN.
  *
  * LEGIBILITY (pinned below, deliberately, rather than left as folklore): an
- * undeclared column does not throw, does not render an empty header, and
- * produces no console line — it is simply DROPPED, so a grid whose columns are
- * all mis-spelled renders as the row-number column alone. Whether that silence
- * deserves a dev-time diagnostic is its own decision (objectui#5068 Q2) and is
- * deliberately NOT implemented here.
+ * undeclared column does not throw and does not render an empty header — it is
+ * simply DROPPED, so a grid whose columns are all mis-spelled renders as the
+ * row-number column alone. That the RENDERING is unchanged is what this file
+ * pins, and objectui#5349 left every reading below exactly as it was.
+ *
+ * What #5349 DID change is the receipt: the drop is no longer silent. It emits
+ * one `console.warn` naming the block, the object, the column index, the keys
+ * it found and the spelling that works. The message itself and the
+ * configurations that must stay quiet are pinned in
+ * `columnSpellingDiagnostics.test.ts` and `columnSpellingDiagnosticRender.test.tsx`;
+ * this file pins only that the diagnostic is a console line and NOT a thrown
+ * error or an `alert` role — the blast radius #5349 deliberately did not take.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
@@ -119,15 +126,27 @@ describe('ObjectGrid columns — the declared spelling is the only one read (#50
     expect(screen.getByText('Grace')).toBeInTheDocument();
   });
 
-  it('leaves the grid standing — and silent — when every column is undeclared', () => {
-    // The legibility pin. Not an error, not an empty header cell, not a
-    // console line: the columns are simply gone. Recorded as behaviour so the
-    // follow-up diagnostics decision (Q2) has something to measure against.
+  it('leaves the grid standing when every column is undeclared — loudly, not silently (#5349)', () => {
+    // The legibility pin, updated by objectui#5349. Still not an error and not
+    // an empty header cell: the columns are gone and the grid stands. What is
+    // no longer true is the third clause — the drop used to produce no console
+    // line either, which is exactly the failure mode #5349 removed.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { container } = renderGrid([{ accessorKey: 'name', header: 'Name' }]);
+    const diagnostics = warn.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.startsWith('[ObjectUI] ObjectGrid columns:'));
+    warn.mockRestore();
 
     expect(headers()).toEqual(['#']);
     expect(container.querySelector('table')).toBeInTheDocument();
+    // The rejected escalation: a diagnostic, not a throw and not an in-page
+    // alert. A grid that renders nothing must not become a page that renders
+    // nothing.
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toContain('columns[0]');
+    expect(diagnostics[0]).toContain("Write `{ field: 'name', label: 'Name' }` instead.");
   });
 
   it('still renders a plain string[] column list', () => {

--- a/packages/plugin-grid/src/__tests__/columnSpellingDiagnosticRender.test.tsx
+++ b/packages/plugin-grid/src/__tests__/columnSpellingDiagnosticRender.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A dropped column now leaves a receipt (objectui#5349) — measured through a
+ * real render, not through the pure helper.
+ *
+ * `columnSpellingDiagnostics.test.ts` pins the message. This file pins the two
+ * things only a render can answer: that the DIAGNOSTIC fires where the grid
+ * actually drops a column, and — the half that matters more — that it stays
+ * quiet on every configuration that legitimately renders. `object-grid` draws
+ * its rows from five different places, and a diagnostic that painted a
+ * configuration error over one of them would be worse than the silence it
+ * replaces, so each is pinned here with BOTH legs: clean columns → no
+ * diagnostic and rows on screen, then the same configuration with one
+ * mis-spelled column → exactly one diagnostic naming it.
+ *
+ * That second leg is also the counter-probe for every zero asserted here: the
+ * capture that reports "no diagnostics" is the same capture that reports one a
+ * moment later, in the same configuration.
+ *
+ * The rendering itself is UNCHANGED by this card — the header/cell readings
+ * below are byte-identical to the ones objectui#5349 measured on `main` before
+ * it. The diagnostic is additive.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+
+registerAllFields();
+
+const ROWS = [
+  { id: '1', name: 'Ada', amount: 100 },
+  { id: '2', name: 'Grace', amount: 200 },
+];
+
+/** The one channel this card adds — matched by its prefix, so unrelated console noise cannot pass for it. */
+const DIAGNOSTIC_PREFIX = '[ObjectUI] ObjectGrid columns:';
+
+/**
+ * Render a grid and capture the diagnostics it emits.
+ *
+ * `props` carries the host-side halves — the `data` React prop a host like
+ * `plugin-list`'s `ListView` passes down — so the same helper covers a
+ * schema-driven grid and a host-driven one.
+ */
+function renderGrid(
+  schema: Record<string, unknown>,
+  options: { props?: Record<string, unknown>; scopeData?: unknown } = {},
+): { diagnostics: string[]; headers: string[] } {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const grid = <ObjectGrid schema={{ type: 'object-grid', ...schema } as any} {...(options.props ?? {})} />;
+  render(
+    <ActionProvider>
+      {options.scopeData !== undefined
+        ? <SchemaRendererProvider dataSource={options.scopeData as any}>{grid}</SchemaRendererProvider>
+        : grid}
+    </ActionProvider>,
+  );
+  const diagnostics = warn.mock.calls
+    .map((call) => String(call[0]))
+    .filter((line) => line.startsWith(DIAGNOSTIC_PREFIX));
+  warn.mockRestore();
+  return {
+    diagnostics,
+    headers: screen.getAllByRole('columnheader').map((h) => (h.textContent ?? '').trim()),
+  };
+}
+
+afterEach(() => cleanup());
+
+describe('objectui#5349 — the four-way matrix, rendering and diagnostic together', () => {
+  it('field-only: renders both columns, says nothing', () => {
+    const { headers, diagnostics } = renderGrid({
+      objectName: 'opportunities',
+      data: ROWS,
+      columns: [{ field: 'name', label: 'Name' }, { field: 'amount', label: 'Amount' }],
+    });
+    expect(headers).toEqual(['#', 'Name', 'Amount']);
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('accessorKey-only: header-only grid — and now a diagnostic that says which columns and why', () => {
+    // THE card. Before this landed the reading below was identical except for
+    // an empty `diagnostics` array: a grid with its row-number column, no data
+    // columns, and no error, no warning, no empty state.
+    const { headers, diagnostics } = renderGrid({
+      objectName: 'opportunities',
+      data: ROWS,
+      columns: [{ accessorKey: 'name', header: 'Name' }, { accessorKey: 'amount', header: 'Amount' }],
+    });
+    expect(headers).toEqual(['#']);
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument();
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toContain("object-grid (objectName: 'opportunities')");
+    expect(diagnostics[0]).toContain('2 of 2 authored columns resolve to nothing');
+    expect(diagnostics[0]).toContain('row-number column and NO data columns');
+    expect(diagnostics[0]).toContain("columns[0]: keys seen: `accessorKey`, `header`");
+    expect(diagnostics[0]).toContain("Write `{ field: 'name', label: 'Name' }` instead.");
+    expect(diagnostics[0]).toContain("Write `{ field: 'amount', label: 'Amount' }` instead.");
+  });
+
+  it('mixed, declared first: drops the second — and names the second', () => {
+    const { headers, diagnostics } = renderGrid({
+      objectName: 'opportunities',
+      data: ROWS,
+      columns: [{ field: 'name', label: 'Name' }, { accessorKey: 'amount', header: 'Amount' }],
+    });
+    expect(headers).toEqual(['#', 'Name']);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toContain('1 of 2 authored columns resolve to nothing');
+    expect(diagnostics[0]).toContain('columns[1]');
+    expect(diagnostics[0]).not.toContain('columns[0]');
+  });
+
+  it('mixed, undeclared first: same drop, same address — order does not change the answer', () => {
+    // The retired tolerance branch sniffed `columns[0]` alone, so this ordering
+    // used to THROW mid-render while the other silently dropped a column. The
+    // diagnostic inherits the per-column judgement, not the sniff.
+    const { headers, diagnostics } = renderGrid({
+      objectName: 'opportunities',
+      data: ROWS,
+      columns: [{ accessorKey: 'amount', header: 'Amount' }, { field: 'name', label: 'Name' }],
+    });
+    expect(headers).toEqual(['#', 'Name']);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toContain('columns[0]');
+    expect(diagnostics[0]).not.toContain('columns[1]');
+  });
+});
+
+describe('objectui#5349 — the column-side fallbacks that keep their silence', () => {
+  it('a `string[]` column list is the other declared spelling: renders, says nothing', () => {
+    const { headers, diagnostics } = renderGrid({
+      objectName: 'opportunities',
+      data: ROWS,
+      columns: ['name', 'amount'],
+    });
+    expect(headers).toEqual(['#', 'Name', 'Amount']);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('no `columns` at all: the grid auto-derives them and is not scolded for it', () => {
+    const { headers, diagnostics } = renderGrid({ objectName: 'opportunities', data: ROWS });
+    expect(headers).toEqual(['#', 'Id', 'Name', 'Amount']);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('an empty `columns` array: same auto-derivation, same silence', () => {
+    const { headers, diagnostics } = renderGrid({ objectName: 'opportunities', data: ROWS, columns: [] });
+    expect(headers).toEqual(['#', 'Id', 'Name', 'Amount']);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('`hidden: true` on every column: authored intent, not a defect', () => {
+    // Renders exactly like the accessorKey-only case above — header-only — and
+    // is the reason the diagnostic cannot be "the grid ended up with no
+    // columns". The author asked for this one.
+    const { headers, diagnostics } = renderGrid({
+      objectName: 'opportunities',
+      data: ROWS,
+      columns: [{ field: 'name', label: 'Name', hidden: true }],
+    });
+    expect(headers).toEqual(['#']);
+    expect(diagnostics).toEqual([]);
+
+    // Counter-probe: the same grid, one column mis-spelled instead of hidden.
+    cleanup();
+    const probe = renderGrid({
+      objectName: 'opportunities',
+      data: ROWS,
+      columns: [{ accessorKey: 'name', header: 'Name' }],
+    });
+    expect(probe.headers).toEqual(['#']);
+    expect(probe.diagnostics).toHaveLength(1);
+  });
+});
+
+describe('objectui#5349 — the row-side fallbacks a `needs columns` predicate would have broken', () => {
+  /**
+   * Each of the five places `object-grid` gets rows from, twice: clean columns
+   * must render and stay silent, and the same configuration with one bad
+   * column must produce exactly one diagnostic. The second leg is what makes
+   * the first leg's zero mean something.
+   */
+  const GOOD = [{ field: 'name', label: 'Name' }];
+  const BAD = [{ accessorKey: 'name', header: 'Name' }];
+
+  it('inline rows as a bare `data` array', () => {
+    const ok = renderGrid({ objectName: 'opportunities', data: ROWS, columns: GOOD });
+    expect(ok.headers).toEqual(['#', 'Name']);
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(ok.diagnostics).toEqual([]);
+
+    cleanup();
+    expect(renderGrid({ objectName: 'opportunities', data: ROWS, columns: BAD }).diagnostics).toHaveLength(1);
+  });
+
+  it("inline rows as `data: { provider: 'value', items }` — the declared shape", () => {
+    const schema = { objectName: 'opportunities', data: { provider: 'value', items: ROWS } };
+    const ok = renderGrid({ ...schema, columns: GOOD });
+    expect(ok.headers).toEqual(['#', 'Name']);
+    expect(screen.getByText('Grace')).toBeInTheDocument();
+    expect(ok.diagnostics).toEqual([]);
+
+    cleanup();
+    expect(renderGrid({ ...schema, columns: BAD }).diagnostics).toHaveLength(1);
+  });
+
+  it('legacy `staticData`', () => {
+    const ok = renderGrid({ objectName: 'opportunities', staticData: ROWS, columns: GOOD });
+    expect(ok.headers).toEqual(['#', 'Name']);
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(ok.diagnostics).toEqual([]);
+
+    cleanup();
+    expect(renderGrid({ objectName: 'opportunities', staticData: ROWS, columns: BAD }).diagnostics).toHaveLength(1);
+  });
+
+  it('`bind` — rows resolved from the surrounding data scope', () => {
+    const scopeData = { rows: ROWS };
+    const ok = renderGrid({ bind: 'rows', columns: GOOD }, { scopeData });
+    expect(ok.headers).toEqual(['#', 'Name']);
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(ok.diagnostics).toEqual([]);
+
+    cleanup();
+    expect(renderGrid({ bind: 'rows', columns: BAD }, { scopeData }).diagnostics).toHaveLength(1);
+  });
+
+  it('a HOST that owns the fetch and passes the window down as a `data` React prop', () => {
+    // What `plugin-list`'s `ListView` does. Note the schema carries NO data key
+    // at all here — the rows arrive as a prop, which is why a predicate built
+    // on `'data' in props` would have been wrong in both directions.
+    const ok = renderGrid({ objectName: 'opportunities', columns: GOOD }, { props: { data: ROWS } });
+    expect(ok.headers).toEqual(['#', 'Name']);
+    expect(screen.getByText('Grace')).toBeInTheDocument();
+    expect(ok.diagnostics).toEqual([]);
+
+    cleanup();
+    expect(
+      renderGrid({ objectName: 'opportunities', columns: BAD }, { props: { data: ROWS } }).diagnostics,
+    ).toHaveLength(1);
+  });
+});

--- a/packages/plugin-grid/src/__tests__/columnSpellingDiagnostics.test.ts
+++ b/packages/plugin-grid/src/__tests__/columnSpellingDiagnostics.test.ts
@@ -1,0 +1,203 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The diagnostic that gives a dropped column an ADDRESS (objectui#5349).
+ *
+ * objectui#5068 made `ListColumnSchema`'s `field` / `label` the only column
+ * spelling `ObjectGrid` reads. Right call — but a column authored the other way
+ * then contributed nothing and NOTHING SAID SO. This file pins the two halves
+ * of the answer as pure functions, so the message's wording is testable without
+ * a DOM: `resolvesToDataColumn` (the renderer's own drop decision, shared so it
+ * cannot drift from the reporter) and `describeUnresolvedColumns` (what the
+ * author is told).
+ *
+ * Every "no diagnostic" case below is COUNTER-PROBED: the same input, mutated
+ * by one key, must produce one — otherwise a silent predicate would read as a
+ * clean bill of health, which is the exact failure mode this card exists to
+ * remove.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolvesToDataColumn,
+  partitionAuthoredColumns,
+  describeUnresolvedColumns,
+} from '../columnSpellingDiagnostics';
+
+const ADDRESS = { blockType: 'object-grid', objectName: 'opportunities' };
+
+describe('resolvesToDataColumn — the renderer drop decision, extracted (#5349)', () => {
+  /**
+   * Parity with the inline filter it replaced, case for case:
+   * `col?.field && typeof col.field === 'string' && !col.hidden`.
+   */
+  const CASES: Array<[string, unknown, boolean]> = [
+    ['declared column', { field: 'name', label: 'Name' }, true],
+    ['declared column, bare', { field: 'name' }, true],
+    ['hidden declared column', { field: 'name', hidden: true }, false],
+    ['undeclared spelling', { accessorKey: 'name', header: 'Name' }, false],
+    ['no field key', { label: 'Name' }, false],
+    ['empty field', { field: '' }, false],
+    ['non-string field', { field: 42 }, false],
+    ['null field', { field: null }, false],
+    ['null entry', null, false],
+    ['undefined entry', undefined, false],
+    ['string entry', 'name', false],
+  ];
+
+  it.each(CASES)('%s', (_label, col, expected) => {
+    expect(resolvesToDataColumn(col)).toBe(expected);
+  });
+
+  it('matches the predicate ObjectGrid used inline before the extraction', () => {
+    // The ratchet on "semantics unchanged": if someone widens one side, this
+    // table disagrees with the other.
+    const legacy = (col: any) => !!(col?.field && typeof col.field === 'string' && !col.hidden);
+    for (const [, col] of CASES) {
+      expect(resolvesToDataColumn(col)).toBe(legacy(col));
+    }
+  });
+});
+
+describe('partitionAuthoredColumns — hidden is intent, not a defect (#5349)', () => {
+  it('counts resolved, hidden and unresolved apart', () => {
+    const partition = partitionAuthoredColumns([
+      { field: 'name', label: 'Name' },
+      { field: 'secret', hidden: true },
+      { accessorKey: 'amount', header: 'Amount' },
+    ]);
+    expect(partition).toEqual({
+      resolved: 1,
+      hidden: 1,
+      unresolved: [{ index: 2, detail: expect.stringContaining('accessorKey') }],
+    });
+  });
+
+  it('counts a hidden column as hidden even when it also mis-spells its identity', () => {
+    // It contributes nothing either way, and the author asked for nothing.
+    // Reporting it would be noise on top of a deliberate choice.
+    const partition = partitionAuthoredColumns([{ accessorKey: 'amount', hidden: true }]);
+    expect(partition).toEqual({ resolved: 0, hidden: 1, unresolved: [] });
+  });
+
+  it('abstains on the inputs it does not judge', () => {
+    expect(partitionAuthoredColumns(undefined)).toBeNull();
+    expect(partitionAuthoredColumns([])).toBeNull();
+    expect(partitionAuthoredColumns(['name', 'amount'])).toBeNull(); // the string[] arm
+    expect(partitionAuthoredColumns('name')).toBeNull();
+  });
+});
+
+describe('describeUnresolvedColumns — silence, and the fallbacks that earn it (#5349)', () => {
+  /**
+   * The abstentions, each COUNTER-PROBED one key later. A predicate that
+   * returned `null` for everything would pass the left column alone.
+   */
+  it('says nothing when there is no authored `columns` array', () => {
+    expect(describeUnresolvedColumns(undefined, ADDRESS)).toBeNull();
+    // counter-probe
+    expect(describeUnresolvedColumns([{ accessorKey: 'a' }], ADDRESS)).not.toBeNull();
+  });
+
+  it('says nothing for an empty `columns` array — the grid auto-derives', () => {
+    expect(describeUnresolvedColumns([], ADDRESS)).toBeNull();
+    // counter-probe
+    expect(describeUnresolvedColumns([{}], ADDRESS)).not.toBeNull();
+  });
+
+  it('says nothing for the `string[]` spelling — the other declared one', () => {
+    expect(describeUnresolvedColumns(['name', 'amount'], ADDRESS)).toBeNull();
+    // counter-probe: the same names as objects with no `field`
+    expect(describeUnresolvedColumns([{ name: 'name' }], ADDRESS)).not.toBeNull();
+  });
+
+  it('says nothing when every column resolves', () => {
+    expect(describeUnresolvedColumns([{ field: 'name' }, { field: 'amount' }], ADDRESS)).toBeNull();
+    // counter-probe: one key renamed to the retired spelling
+    expect(
+      describeUnresolvedColumns([{ field: 'name' }, { accessorKey: 'amount' }], ADDRESS),
+    ).not.toBeNull();
+  });
+
+  it('says nothing when the only non-resolving columns are `hidden`', () => {
+    expect(
+      describeUnresolvedColumns([{ field: 'name' }, { field: 'amount', hidden: true }], ADDRESS),
+    ).toBeNull();
+    // counter-probe: drop `hidden` and mis-spell the same entry
+    expect(
+      describeUnresolvedColumns([{ field: 'name' }, { accessorKey: 'amount' }], ADDRESS),
+    ).not.toBeNull();
+  });
+});
+
+describe('describeUnresolvedColumns — the message names the address (#5349)', () => {
+  it('names block, object, index, the keys seen, and the rewrite that works', () => {
+    const message = describeUnresolvedColumns(
+      [{ accessorKey: 'name', header: 'Full Name' }, { accessorKey: 'amount', header: 'Amount' }],
+      { blockType: 'object-grid', objectName: 'opportunities', label: 'Open Deals' },
+    );
+    expect(message).toContain('[ObjectUI] ObjectGrid columns:');
+    expect(message).toContain("object-grid (objectName: 'opportunities', label: 'Open Deals')");
+    expect(message).toContain('2 of 2 authored columns resolve to nothing');
+    expect(message).toContain('row-number column and NO data columns');
+    expect(message).toContain('columns[0]');
+    expect(message).toContain('columns[1]');
+    expect(message).toContain('`accessorKey`, `header`');
+    // The rewrite, per column, built from what was actually authored.
+    expect(message).toContain("Write `{ field: 'name', label: 'Full Name' }` instead.");
+    expect(message).toContain("Write `{ field: 'amount', label: 'Amount' }` instead.");
+    expect(message).toContain('`ListColumnSchema` (@objectstack/spec/ui)');
+    expect(message).toContain('(objectui#5349)');
+  });
+
+  it('reports the partial case as partial — it does not claim the grid is empty', () => {
+    const message = describeUnresolvedColumns(
+      [{ field: 'name', label: 'Name' }, { accessorKey: 'amount', header: 'Amount' }],
+      ADDRESS,
+    )!;
+    expect(message).toContain('1 of 2 authored columns resolve to nothing');
+    expect(message).toContain('(1 still render)');
+    expect(message).not.toContain('NO data columns');
+    // Addressed by index — the surviving column is not named as a suspect.
+    expect(message).toContain('columns[1]');
+    expect(message).not.toContain('columns[0]');
+  });
+
+  it('names the block alias when the node was authored as `view:grid`', () => {
+    const message = describeUnresolvedColumns([{ accessorKey: 'a' }], {
+      blockType: 'view:grid',
+      objectName: 'deals',
+    })!;
+    expect(message).toContain("view:grid (objectName: 'deals')");
+  });
+
+  it('says so when the grid names no object, instead of printing `undefined`', () => {
+    const message = describeUnresolvedColumns([{ accessorKey: 'a' }], {})!;
+    expect(message).toContain('object-grid (no objectName)');
+    expect(message).not.toContain('undefined');
+  });
+
+  it('distinguishes the ways a column can fail to name a field', () => {
+    const message = describeUnresolvedColumns(
+      [{ label: 'Name' }, { field: '' }, { field: 42 }, {}, 'name', null],
+      ADDRESS,
+    )!;
+    expect(message).toContain('columns[0]: keys seen: `label` — no `field` key');
+    expect(message).toContain('columns[1]: keys seen: `field` — `field` is an empty string');
+    expect(message).toContain('columns[2]: keys seen: `field` — `field` is a number (42)');
+    expect(message).toContain('columns[3]: the entry is empty `{}`');
+    expect(message).toContain("columns[4]: the entry is a string ('name'), not a column object");
+    expect(message).toContain('columns[5]: the entry is null, not a column object');
+  });
+
+  it('omits the rewrite hint when the retired key carries nothing to rewrite', () => {
+    const message = describeUnresolvedColumns([{ accessorKey: 42, header: 'Amount' }], ADDRESS)!;
+    expect(message).toContain('`accessorKey` / `header`');
+    expect(message).not.toContain('Write `{ field:');
+  });
+});

--- a/packages/plugin-grid/src/columnSpellingDiagnostics.ts
+++ b/packages/plugin-grid/src/columnSpellingDiagnostics.ts
@@ -1,0 +1,223 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The ONE place that decides whether an authored `columns[i]` becomes a data
+ * column — and the diagnostic that says so out loud when it does not
+ * (objectui#5349, the Q2 objectui#5068 deferred).
+ *
+ * ## Why this file exists
+ *
+ * objectui#5068 retired `ObjectGrid`'s undeclared `accessorKey` / `header`
+ * tolerance branch, so `ListColumnSchema`'s `field` / `label` is now the only
+ * spelling the renderer reads. That is right — `ListColumnSchema`
+ * (`@objectstack/spec/ui`) is a STRICT object that refuses `accessorKey` and
+ * `header` BY NAME, and the census behind #5068 found zero authored
+ * `accessorKey`-shaped `object-grid` columns.
+ *
+ * But it RELOCATED a failure mode instead of removing it: a column authored in
+ * a spelling the renderer does not read now contributes nothing, and nothing
+ * said so — no error, no warning, no empty header. The author got a grid with
+ * its row-number column and no data columns, i.e. a success receipt for a
+ * disagreement between the renderer and the author. That is the same shape
+ * #5068 exists to fix, one level down.
+ *
+ * ## What is diagnosed — and what deliberately is not
+ *
+ * The predicate here is about the `columns` INPUT only. It never asks whether
+ * the grid found rows, because "this grid has no columns" is a question with
+ * legitimate answers: a grid with no `columns` at all auto-derives them from
+ * the object schema or the first inline row, and a grid can draw its rows from
+ * five different places (`data` array, `data.provider: 'value'`, legacy
+ * `staticData`, `bind`, or a HOST that owns the fetch and passes the window
+ * down as a `data` React prop — `plugin-list`'s `ListView` does exactly that).
+ * A "needs columns" predicate that consulted any of those would paint a
+ * configuration error over a working grid, which is worse than the silence it
+ * replaces. So the question asked here is strictly the local one:
+ *
+ *   the author WROTE this column entry, and it can never resolve — say which
+ *   one, what it spells, and what the declared spelling is.
+ *
+ * `hidden: true` is authored intent, not a defect, so a hidden column is
+ * counted apart and never reported — including a hidden column that also
+ * mis-spells its identity, which contributes nothing either way.
+ *
+ * ## Why a console warning, and only a console warning
+ *
+ * `ObjectGrid` already has exactly one channel for "you declared something and
+ * the renderer dropped it": the export-format warning in `ObjectGrid.tsx`
+ * (`[ObjectUI] ObjectGrid export: unsupported format(s) hidden from the
+ * menu…`) — a `useEffect` keyed on the schema slice, one `console.warn`, no
+ * NODE_ENV branch. This diagnostic is deliberately the SAME shape rather than
+ * a second, differently-shaped one next to it (objectui#5349's own warning
+ * about that). Rendering a visible in-grid message instead would be
+ * user-facing copy, which needs all ten locale packs in `@object-ui/i18n` —
+ * outside this card's file surface — and a throw would take the whole
+ * surrounding page down for a defect that today costs one grid.
+ */
+
+/** The declared column-identity key — `ListColumnSchema.field`. */
+export const DECLARED_COLUMN_FIELD_KEY = 'field';
+/** The declared column-header key — `ListColumnSchema.label`. */
+export const DECLARED_COLUMN_LABEL_KEY = 'label';
+
+/**
+ * Keys the spec refuses BY NAME and this renderer no longer reads. `accessorKey`
+ * is not a typo — it is the data-table ADAPTER's key on the way OUT (see
+ * `TABLE_ADAPTER_COLUMN_KEY` in `@object-ui/core`), which is exactly why it
+ * reads as plausible authoring vocabulary on the way IN.
+ */
+const RETIRED_COLUMN_KEYS = ['accessorKey', 'header'] as const;
+
+/**
+ * Does this authored entry become a data column?
+ *
+ * This is the renderer's own filter, extracted so the diagnostic below and
+ * `ObjectGrid`'s `generateColumns` cannot drift apart: one predicate, two
+ * readers. Semantics are unchanged from the inline filter it replaces —
+ * `col?.field && typeof col.field === 'string' && !col.hidden`.
+ */
+export function resolvesToDataColumn(col: unknown): boolean {
+  if (!col || typeof col !== 'object') return false;
+  const entry = col as Record<string, unknown>;
+  if (entry.hidden) return false;
+  return typeof entry.field === 'string' && entry.field.length > 0;
+}
+
+/** Is this entry suppressed on purpose rather than broken? */
+function isDeliberatelyHidden(col: unknown): boolean {
+  return !!col && typeof col === 'object' && !!(col as Record<string, unknown>).hidden;
+}
+
+/** One authored entry that can never resolve, and why. */
+export interface UnresolvedAuthoredColumn {
+  /** Index in the authored `columns` array — the address. */
+  index: number;
+  /** What the entry spells, and the rewrite that would work. */
+  detail: string;
+}
+
+export interface AuthoredColumnPartition {
+  /** Entries that become data columns. */
+  resolved: number;
+  /** Entries suppressed by `hidden: true` — authored intent, never reported. */
+  hidden: number;
+  /** Entries that can never resolve, each with its address. */
+  unresolved: UnresolvedAuthoredColumn[];
+}
+
+function quote(value: unknown): string {
+  return typeof value === 'string' ? `'${value}'` : String(value);
+}
+
+/** Describe ONE unresolved entry: what it spells, and what to write instead. */
+function describeEntry(col: unknown): string {
+  if (col === null || col === undefined) {
+    return `the entry is ${String(col)}, not a column object`;
+  }
+  if (typeof col !== 'object') {
+    return `the entry is a ${typeof col} (${quote(col)}), not a column object — a `
+      + `bare field name only works when EVERY entry is a string (\`columns: ['name', 'amount']\`)`;
+  }
+  const entry = col as Record<string, unknown>;
+  const keys = Object.keys(entry);
+  const retired = RETIRED_COLUMN_KEYS.filter((k) => k in entry);
+  const seen = keys.length > 0 ? `keys seen: ${keys.map((k) => `\`${k}\``).join(', ')}` : 'the entry is empty `{}`';
+
+  if (retired.length > 0) {
+    const accessor = entry.accessorKey;
+    const header = entry.header;
+    const rewrite = typeof accessor === 'string' && accessor.length > 0
+      ? ` Write \`{ ${DECLARED_COLUMN_FIELD_KEY}: '${accessor}'`
+        + `${typeof header === 'string' && header.length > 0 ? `, ${DECLARED_COLUMN_LABEL_KEY}: '${header}'` : ''} }\` instead.`
+      : '';
+    return `${seen} — ${retired.map((k) => `\`${k}\``).join(' / ')} `
+      + `${retired.length > 1 ? 'are' : 'is'} refused by name and not read here.${rewrite}`;
+  }
+  if (!(DECLARED_COLUMN_FIELD_KEY in entry)) {
+    return `${seen} — no \`${DECLARED_COLUMN_FIELD_KEY}\` key, so the column names no field.`;
+  }
+  const field = entry[DECLARED_COLUMN_FIELD_KEY];
+  if (typeof field !== 'string') {
+    return `${seen} — \`${DECLARED_COLUMN_FIELD_KEY}\` is a ${field === null ? 'null' : typeof field} `
+      + `(${quote(field)}), and only a non-empty string names a field.`;
+  }
+  return `${seen} — \`${DECLARED_COLUMN_FIELD_KEY}\` is an empty string, so the column names no field.`;
+}
+
+/**
+ * Split an authored `columns` array into resolved / hidden / unresolved.
+ *
+ * Returns `null` when there is nothing to judge — no `columns`, an empty
+ * `columns`, or the `string[]` spelling (whose own arm in `generateColumns`
+ * filters non-strings and is not this card's failure mode).
+ */
+export function partitionAuthoredColumns(columns: unknown): AuthoredColumnPartition | null {
+  if (!Array.isArray(columns) || columns.length === 0) return null;
+  // `normalizeColumns` dispatches the whole array on its first entry, so a
+  // `string[]` list is the string arm — judged there, not here.
+  if (typeof columns[0] !== 'object' || columns[0] === null) return null;
+
+  const partition: AuthoredColumnPartition = { resolved: 0, hidden: 0, unresolved: [] };
+  columns.forEach((col, index) => {
+    if (resolvesToDataColumn(col)) partition.resolved += 1;
+    else if (isDeliberatelyHidden(col)) partition.hidden += 1;
+    else partition.unresolved.push({ index, detail: describeEntry(col) });
+  });
+  return partition;
+}
+
+/** Where the offending block lives, for the first line of the message. */
+export interface GridColumnAddress {
+  /** The schema node's `type` — `object-grid`, or the `view:grid` alias. */
+  blockType?: unknown;
+  /** The object the grid queries, when it names one. */
+  objectName?: unknown;
+  /** The grid's authored label, when it has one — often the only human name. */
+  label?: unknown;
+}
+
+function describeAddress({ blockType, objectName, label }: GridColumnAddress): string {
+  const block = typeof blockType === 'string' && blockType.length > 0 ? blockType : 'object-grid';
+  const parts: string[] = [];
+  if (typeof objectName === 'string' && objectName.length > 0) parts.push(`objectName: '${objectName}'`);
+  else parts.push('no objectName');
+  if (typeof label === 'string' && label.length > 0) parts.push(`label: '${label}'`);
+  return `${block} (${parts.join(', ')})`;
+}
+
+/**
+ * The message for a `columns` array whose entries cannot all resolve, or
+ * `null` when every authored entry is fine.
+ *
+ * Naming the ADDRESS is the whole point: which block, which object, which
+ * index, which spelling was seen, and which spelling to write instead. A
+ * message that only said something went wrong would leave the author exactly
+ * where the silence did.
+ */
+export function describeUnresolvedColumns(columns: unknown, address: GridColumnAddress): string | null {
+  const partition = partitionAuthoredColumns(columns);
+  if (!partition || partition.unresolved.length === 0) return null;
+
+  const authored = Array.isArray(columns) ? columns.length : 0;
+  const count = partition.unresolved.length;
+  const headline = partition.resolved === 0
+    ? `${count} of ${authored} authored columns resolve to nothing, so this grid renders its `
+      + 'row-number column and NO data columns'
+    : `${count} of ${authored} authored columns resolve to nothing and are dropped `
+      + `(${partition.resolved} still render)`;
+
+  const lines = partition.unresolved.map((u) => `  • columns[${u.index}]: ${u.detail}`);
+
+  return `[ObjectUI] ObjectGrid columns: ${describeAddress(address)} — ${headline}.\n`
+    + `${lines.join('\n')}\n`
+    + `  \`ListColumnSchema\` (@objectstack/spec/ui) declares ONE column spelling: `
+    + `\`${DECLARED_COLUMN_FIELD_KEY}\` (required — the field name) and `
+    + `\`${DECLARED_COLUMN_LABEL_KEY}\` (the header). A plain \`string[]\` of field names `
+    + `works too. (objectui#5349)`;
+}

--- a/packages/plugin-grid/src/columnSpellingDiagnostics.ts
+++ b/packages/plugin-grid/src/columnSpellingDiagnostics.ts
@@ -147,7 +147,17 @@ function describeEntry(col: unknown): string {
     return `${seen} — \`${DECLARED_COLUMN_FIELD_KEY}\` is a ${field === null ? 'null' : typeof field} `
       + `(${quote(field)}), and only a non-empty string names a field.`;
   }
-  return `${seen} — \`${DECLARED_COLUMN_FIELD_KEY}\` is an empty string, so the column names no field.`;
+  if (field.length === 0) {
+    return `${seen} — \`${DECLARED_COLUMN_FIELD_KEY}\` is an empty string, so the column names no field.`;
+  }
+  // Unreachable while `hidden` is judged before this function is called (it is,
+  // in `partitionAuthoredColumns`) — a non-empty string `field` is exactly what
+  // `resolvesToDataColumn` accepts. Kept explicit anyway: this line used to be
+  // the `field.length === 0` message with no length check under it, so removing
+  // the `hidden` carve-out made the diagnostic tell a well-formed column that
+  // its `field` was "an empty string". A message must never assert something it
+  // did not check. (Found by the objectui#5349 reverse-verification.)
+  return `${seen} — \`${DECLARED_COLUMN_FIELD_KEY}\` is '${field}', and the column still did not resolve.`;
 }
 
 /**


### PR DESCRIPTION
Fixes #5349

#5068 retired `ObjectGrid`'s undeclared `accessorKey` / `header` tolerance branch, so
`ListColumnSchema`'s `field` / `label` is now the only column spelling the renderer
reads. That was right. What it left behind was the receipt: a column authored in a
spelling the renderer does not read contributed **nothing**, and nothing said so — no
error, no warning, no empty state. The author got a grid with its row-number column and
no data columns, i.e. a success receipt for a disagreement between renderer and author.
The same shape #5068 exists to fix, one level down.

An authored column that can never resolve now emits **one** `console.warn` naming the
address rather than the symptom.

## The diagnostic

Verbatim, from the `accessorKey`-only leg of the test suite:

```
[ObjectUI] ObjectGrid columns: object-grid (objectName: 'opportunities') — 2 of 2 authored columns resolve to nothing, so this grid renders its row-number column and NO data columns.
  • columns[0]: keys seen: `accessorKey`, `header` — `accessorKey` / `header` are refused by name and not read here. Write `{ field: 'name', label: 'Name' }` instead.
  • columns[1]: keys seen: `accessorKey`, `header` — `accessorKey` / `header` are refused by name and not read here. Write `{ field: 'amount', label: 'Amount' }` instead.
  `ListColumnSchema` (@objectstack/spec/ui) declares ONE column spelling: `field` (required — the field name) and `label` (the header). A plain `string[]` of field names works too. (objectui#5349)
```

Which block (the `view:grid` alias is named as `view:grid`), which object and label,
which `columns[i]`, the keys that entry actually carries, and the rewrite that works —
built from what was authored, not from a template.

**Channel.** `ObjectGrid` already had exactly one channel for "you declared it, the
renderer dropped it": the export-format warning (`[ObjectUI] ObjectGrid export:
unsupported format(s) hidden from the menu…`) — a `useEffect` keyed on the schema slice,
one `console.warn`, no `NODE_ENV` branch. This is deliberately the **same** shape rather
than a second, differently-shaped one next to it, which the card explicitly warned
against. A visible in-grid message would be user-facing copy needing all ten locale packs
in `@object-ui/i18n` — outside this card's file surface — and a throw was rejected on the
card's own reasoning: a grid that renders nothing today would become a page that renders
nothing.

## Measured matrix, before and after

Rendering is **unchanged in every leg** — the diagnostic is additive. Readings are the
literal `getAllByRole('columnheader')` / `getAllByRole('cell')` output over two inline
rows (`#` is the built-in row-number column, `Open` the row affordance):

| input | headers, before | headers, after | diagnostics, before | diagnostics, after |
| --- | --- | --- | --- | --- |
| `[{field:'name'},{field:'amount'}]` | `["#","Name","Amount"]` | same | 0 | 0 |
| `[{accessorKey:'name'},{accessorKey:'amount'}]` | `["#"]`, no data cells | same | **0** | **1** — names `columns[0]` and `columns[1]` |
| `[{field:'name'},{accessorKey:'amount'}]` | `["#","Name"]` | same | **0** | **1** — names `columns[1]` only |
| `[{accessorKey:'amount'},{field:'name'}]` | `["#","Name"]` | same | **0** | **1** — names `columns[0]` only |
| `['name','amount']` | `["#","Name","Amount"]` | same | 0 | 0 |
| `[{field:'name',hidden:true}]` | `["#"]` | same | 0 | **0** — authored intent |
| no `columns` key | `["#","Id","Name","Amount"]` | same | 0 | 0 |
| `columns: []` | `["#","Id","Name","Amount"]` | same | 0 | 0 |

The `hidden` row is the one that decides the design. It renders **identically** to the
`accessorKey`-only row — header-only — and it is correct. So the predicate cannot be
"the grid ended up with no columns".

## What the predicate asks, and what it refuses to ask

It reads the `columns` **input** and nothing else: *the author wrote this entry and it
can never resolve — say which one*. It never asks whether the grid found **rows**,
because `object-grid` legitimately draws them from five different places, and a
"needs columns" predicate consulting any of them would eventually paint a configuration
error over a working grid.

All five are pinned by test, in **both** directions — clean columns must render and stay
silent, then the same configuration with one mis-spelled column must produce exactly one
diagnostic (that second leg is the counter-probe that makes the first leg's zero mean
something):

| fallback honoured | pinned by |
| --- | --- |
| inline rows as a bare `data` array | `columnSpellingDiagnosticRender.test.tsx` |
| `data: { provider: 'value', items }` | same |
| legacy `staticData` | same |
| `bind` — rows from the surrounding data scope | same |
| a host that owns the fetch and passes the window as a `data` React prop (`plugin-list`'s `ListView`) | same |

The host-prop case is why the tests pass the rows as a **React prop** with no `data` key
on the schema at all: `SchemaRenderer` spreads every unstripped schema key as a prop, so
a bare `'data' in props` would be true of the schema's own `data` object too. Nothing
here tests `data` presence in either form; the predicate never looks.

Column-side fallbacks that keep their silence, each also counter-probed: the `string[]`
spelling, an absent `columns`, an empty `columns`, and `hidden: true` (including a hidden
column that *also* mis-spells its identity — it contributes nothing either way and the
author asked for nothing).

**One predicate, two readers.** The drop decision moved out of the inline filter into
`resolvesToDataColumn`, which `generateColumns` and the reporter now share, so the
diagnostic cannot drift from the filter that drops the column. A test pins the extracted
predicate against the inline expression it replaced, case for case.

## Reverse verification

Two legs, direction predicted before running. Both ablations are directly effective: the
tests import `../ObjectGrid` and `../columnSpellingDiagnostics` as source, and vitest
aliases every `@object-ui/*` specifier to `packages/*/src` — no `dist` is involved on
either leg, and each ablation flipped results, which is itself the proof it reached the
code under test. Both were restored and the tree proved clean (`git status --porcelain`
empty).

**Leg 1 — remove the emitter** (`console.warn(message)` in the effect).
*Predicted*: the pure-module file stays fully green (it never renders); the render files
go red only where a diagnostic is asserted — 3 of 4 matrix legs, the `hidden`
counter-probe, all 5 row-side counter-probes (9 of 13), plus 1 of 6 in the baseline file.
*Observed*: `Tests 10 failed | 35 passed (45)` — exactly those ten, test for test.

**Leg 2 — remove the `hidden` carve-out** (hidden columns counted as unresolved).
*Predicted*: this direction is not "goes quiet" but **more diagnostics** — a false
positive over authored intent. 3 red in the unit file, 1 in the render file, baseline
untouched.
*Observed*: `Tests 4 failed | 41 passed (45)`, exactly those four, and the render failure
is the predicted direction:

```
AssertionError: expected [ Array(1) ] to deeply equal []
- []
+ [ "[ObjectUI] ObjectGrid columns: … 1 of 1 authored columns resolve to nothing …" ]
```

**Leg 2 found a real defect in this PR's own message** and it is fixed in the second
commit: `describeEntry`'s tail was the "`field` is an empty string" message with no
length check under it, so with the carve-out gone it told a well-formed column that its
non-empty `field` was empty. The check is now explicit and the branch below states only
what it verified. Unreachable today; a message must never assert something it did not
check.

## Verification

Run on `57cda96a8` (the final commit):

- `pnpm exec vitest run packages/plugin-grid/` — **84 files, 786 tests, all passing**
- `pnpm exec vitest run packages/plugin-list/` — 43 files, 644 tests, all passing (the host that passes rows down as a prop)
- `pnpm --filter @object-ui/plugin-grid type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`)
- `pnpm --filter @object-ui/plugin-grid lint` — 0 errors (655 pre-existing warnings, the repo baseline; the gate is errors-only by design)
- `check:control-bytes`, `check:spec-symbols`, `check:phantom-deps`, `check:self-import`, `check:i18n-keys`, `check:i18n-drift`, `check:i18n-dead-keys`, `changeset:check`, `check-changeset-presence.mjs` — all pass
- No test skipped, disabled or quarantined. 39 tests added, 1 existing test updated.

File surface held: every source change is under `packages/plugin-grid/src/**`, plus the
required changeset. No new user-facing copy, so no locale pack changes — the diagnostic
is developer-facing English on the console, which is also what commandment #-1 requires
of console messages.

## The one updated test

`columnDeclaredSpellingOnly.test.tsx` is the baseline the card said to measure against,
and its docblock claimed the drop "produces no console line". That is the sentence this
PR makes false, so it is rewritten rather than left as a stale claim. Its last case now
asserts the diagnostic **and** keeps pinning the escalation that was rejected: still no
throw, still no `alert` role. Every rendering assertion in that file is byte-identical.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_