### PR TITLE
fix(app-shell,i18n): name the pending approver, not a truncated raw id

### DIFF
--- a/.changeset/approver-display-name-5414.md
+++ b/.changeset/approver-display-name-5414.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/i18n': minor
+---
+
+The approval panel identifies the pending approver by name, not by a truncated raw id.
+
+A record waiting on a position rendered its approver as `positi…ager` — the
+engine reference `position:sales_manager`, 22 characters, past the identity
+formatter's 14-character truncation arm and middle-truncated to fit its chip. The
+step names beside it were human prose; the one line answering *who is holding
+this record* was an internal identifier, and not even a complete one. The same
+reference reached the admin-override confirm dialog un-truncated, so a paragraph
+of plain governance prose ended `— position:sales_manager` (objectui#5414).
+
+Both surfaces now resolve the reference before rendering, in three tiers, most
+authoritative first. The server's own `pending_approver_names` wins whenever it
+answers, and a backend that resolves its own slate costs the record page no extra
+request. Otherwise the console reads the directory row the spec's approver
+binding names — `sys_position.label` gives `Sales Manager` / `销售经理` — and,
+for a position, who fills the seat (`Sales Manager · Zhang Wei, Li Na`). With no
+adapter and no row, the machine name still prettifies into prose rather than
+truncating. The raw reference stays on hover, which is where an internal
+identifier belongs.
+
+An unstaffed position is surfaced rather than hidden: `销售经理（暂无在岗人员）`
+is actionable where `positi…ager` is not, and it is the motivating rescue case
+for the admin-override path. Staffing is deliberately tri-state — a
+`sys_user_position` read the viewer is not permitted to make leaves the seat's
+staffing UNKNOWN and says nothing, because "I could not look" is a different
+claim from "nobody holds it" and only one of them is safe to print on a
+governance surface.
+
+Two locale keys are added across all ten packs: `approvalsInbox.approverUnstaffed`
+and `approvalsInbox.approverNameSeparator`. The separator is a translated
+punctuation key rather than `Intl.ListFormat`, which was measured on this tree
+joining `['张伟','李娜']` into `张伟李娜` for `zh` — two names run together with
+no separator, reading as one person's name.
+
+The directory-backed kinds and their value columns are read from
+`@objectstack/spec`'s `APPROVER_VALUE_SOURCES` rather than restated, so a new
+approver type is covered the day the spec publishes it. Id-valued kinds
+(`user` / `team` / `department`) keep the existing middle-truncation: a row id
+has no prose to recover, and that arm is objectui#3461's answer, not this card's
+defect.

--- a/packages/app-shell/src/hooks/useApproverDirectory.ts
+++ b/packages/app-shell/src/hooks/useApproverDirectory.ts
@@ -1,0 +1,241 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * useApproverDirectory — resolve `<kind>:<value>` approver references against
+ * the system directory objects, for the surfaces that must NAME an approver
+ * (objectui#5414).
+ *
+ * ## Server-first, and inert by default
+ *
+ * The producer's own `pending_approver_names` is authoritative and this hook
+ * never competes with it: callers pass only the references the server left
+ * unresolved. On a backend that resolves everything the ref list is empty, the
+ * effect returns before touching the adapter, and the record page issues not one
+ * extra request. That gate is why a display fix can afford directory reads at
+ * all.
+ *
+ * ## What it reads, and why the staffing leg is separate
+ *
+ *   - one `find` per distinct directory OBJECT (`sys_position`, `sys_team`,
+ *     `sys_business_unit`, `sys_user`), batched with `$in` over that object's
+ *     values — the label leg;
+ *   - for `position` refs only, `sys_user_position` -> `sys_user` — the staffing
+ *     leg, which answers "who actually sits in this seat" and, when it comes
+ *     back empty, the unstaffed state objectui#5414 asks to surface.
+ *
+ * The two legs fail INDEPENDENTLY. A business-app reader may hold list access to
+ * `sys_position` and none to `sys_user_position`; `find` rejects that with
+ * `OBJECT_API_DISABLED` rather than an empty page. Folding the legs together
+ * would let a permission error render as `销售经理(暂无在岗人员)` — a fabricated
+ * fact on a governance surface. A failed staffing leg therefore leaves `holders`
+ * `undefined` (unknown), which `approverDisplay` renders as silence, while the
+ * label it did resolve still lands.
+ *
+ * ## The module-level cache
+ *
+ * `DeclaredActionsBar` mounts one component PER declared action, each asking
+ * about the same slate; the panel asks again. Without dedupe an override on a
+ * three-action request would fan one answer into a dozen requests. The cache is
+ * keyed by the reference string and lives for the page session — a display
+ * label, not a decision input, so a position renamed mid-session reading stale
+ * until reload is the correct trade. `resetApproverDirectoryCache()` exists for
+ * tests, which must not inherit each other's answers.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAdapter } from '@object-ui/react';
+import {
+  APPROVER_DIRECTORY_BINDINGS,
+  PERSON_DISPLAY_FIELDS,
+  parseApproverRef,
+  rowLabel,
+  type ResolvedApprover,
+} from '../utils/approverIdentity.js';
+
+/** The directory answers for a slate of references, keyed by the raw reference. */
+export type ApproverDirectory = Record<string, ResolvedApprover>;
+
+/** Junction carrying "user U holds position P" (ADR-0090 D3). */
+const USER_POSITION_OBJECT = 'sys_user_position';
+/** `sys_user_position.position` stores the position MACHINE NAME, not its id. */
+const USER_POSITION_NAME_FIELD = 'position';
+const USER_POSITION_USER_FIELD = 'user_id';
+const PERSON_OBJECT = 'sys_user';
+
+const CACHE = new Map<string, ResolvedApprover>();
+const INFLIGHT = new Map<string, Promise<void>>();
+
+/** Drop every memoized answer — tests only; see this module's docstring. */
+export function resetApproverDirectoryCache(): void {
+  CACHE.clear();
+  INFLIGHT.clear();
+}
+
+/** `find()` answers as a bare array or under one of several envelope keys. */
+const asArray = (res: any): any[] =>
+  Array.isArray(res) ? res : res?.records ?? res?.items ?? res?.data ?? [];
+
+/**
+ * Resolve the label leg for every reference of one directory kind.
+ * Rejects propagate to {@link loadSlate}, which isolates each kind.
+ */
+async function resolveLabels(
+  adapter: any,
+  kind: string,
+  values: string[],
+  into: Map<string, ResolvedApprover>,
+): Promise<void> {
+  const binding = APPROVER_DIRECTORY_BINDINGS[kind];
+  if (!binding) return;
+  const rows = asArray(
+    await adapter.find(binding.object, {
+      $filter: { [binding.valueField]: { $in: values } },
+      $top: 200,
+    }),
+  );
+  for (const row of rows) {
+    const key = row?.[binding.valueField];
+    if (key == null) continue;
+    const label = rowLabel(row, binding.displayFields);
+    if (!label) continue;
+    const ref = `${kind}:${String(key)}`;
+    into.set(ref, { ...into.get(ref), label });
+  }
+}
+
+/**
+ * Resolve the staffing leg for `position:` references — who sits in each seat.
+ * A seat that the junction never mentions is recorded as `[]` (probed, empty),
+ * which is what makes the unstaffed state sayable; a REJECTION leaves every
+ * seat's `holders` untouched, i.e. unknown.
+ */
+async function resolveStaffing(
+  adapter: any,
+  positionNames: string[],
+  into: Map<string, ResolvedApprover>,
+): Promise<void> {
+  const assignments = asArray(
+    await adapter.find(USER_POSITION_OBJECT, {
+      $filter: { [USER_POSITION_NAME_FIELD]: { $in: positionNames } },
+      $top: 500,
+    }),
+  );
+  const userIdsByPosition = new Map<string, string[]>();
+  for (const name of positionNames) userIdsByPosition.set(name, []);
+  for (const a of assignments) {
+    const name = a?.[USER_POSITION_NAME_FIELD];
+    const uid = a?.[USER_POSITION_USER_FIELD];
+    if (name == null || uid == null) continue;
+    const bucket = userIdsByPosition.get(String(name));
+    if (bucket && !bucket.includes(String(uid))) bucket.push(String(uid));
+  }
+
+  const allIds = [...new Set([...userIdsByPosition.values()].flat())];
+  const nameById = new Map<string, string>();
+  if (allIds.length > 0) {
+    const people = asArray(
+      await adapter.find(PERSON_OBJECT, { $filter: { id: { $in: allIds } }, $top: 500 }),
+    );
+    for (const p of people) {
+      if (p?.id == null) continue;
+      nameById.set(String(p.id), rowLabel(p, PERSON_DISPLAY_FIELDS) || String(p.id));
+    }
+  }
+
+  for (const [name, ids] of userIdsByPosition) {
+    const ref = `position:${name}`;
+    into.set(ref, { ...into.get(ref), holders: ids.map((id) => nameById.get(id) ?? id) });
+  }
+}
+
+/**
+ * Resolve one slate of references, writing every answer into the shared cache.
+ *
+ * Each leg is isolated: a kind whose object the viewer cannot list must not cost
+ * the other kinds their labels, and a failed staffing leg must not cost the
+ * position its label. Every reference asked about is written back even when
+ * nothing resolved, so a second mount does not re-ask a question the directory
+ * has already declined to answer.
+ */
+async function loadSlate(adapter: any, refs: string[]): Promise<void> {
+  const answers = new Map<string, ResolvedApprover>();
+  const valuesByKind = new Map<string, string[]>();
+  for (const raw of refs) {
+    const ref = parseApproverRef(raw);
+    if (!ref || !APPROVER_DIRECTORY_BINDINGS[ref.kind]) continue;
+    const bucket = valuesByKind.get(ref.kind) ?? [];
+    if (!bucket.includes(ref.value)) bucket.push(ref.value);
+    valuesByKind.set(ref.kind, bucket);
+  }
+
+  await Promise.all(
+    [...valuesByKind].map(([kind, values]) =>
+      resolveLabels(adapter, kind, values, answers).catch(() => {
+        /* label leg unavailable — the prettified machine name still reads */
+      }),
+    ),
+  );
+
+  const positions = valuesByKind.get('position');
+  if (positions && positions.length > 0) {
+    await resolveStaffing(adapter, positions, answers).catch(() => {
+      /* staffing unknown — NOT the same claim as "the seat is empty" */
+    });
+  }
+
+  for (const raw of refs) CACHE.set(raw, answers.get(raw) ?? {});
+}
+
+/**
+ * Directory answers for `refs`, resolved once per page session.
+ *
+ * Pass `[]` (or only server-unresolved references) to keep the hook inert.
+ */
+export function useApproverDirectory(refs: readonly string[]): ApproverDirectory {
+  const adapter = useAdapter() as any;
+  // Sorted + de-duplicated so a re-render that reorders the slate does not
+  // re-run the effect, and so the in-flight key is stable across callers.
+  const wanted = useMemo(() => [...new Set(refs)].filter(Boolean).sort(), [refs]);
+  const key = wanted.join('|');
+  const [tick, bump] = useState(0);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    return () => { alive.current = false; };
+  }, []);
+
+  useEffect(() => {
+    if (!adapter || wanted.length === 0) return;
+    const missing = wanted.filter((r) => !CACHE.has(r));
+    if (missing.length === 0) return;
+    const batch = missing.join('|');
+    let pending = INFLIGHT.get(batch);
+    if (!pending) {
+      pending = loadSlate(adapter, missing).finally(() => INFLIGHT.delete(batch));
+      INFLIGHT.set(batch, pending);
+    }
+    void pending.then(() => { if (alive.current) bump((n) => n + 1); });
+    // `key` is the stable identity of `wanted`; listing the array itself would
+    // re-run on every render that rebuilds it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [adapter, key]);
+
+  return useMemo(() => {
+    const out: ApproverDirectory = {};
+    for (const r of wanted) {
+      const hit = CACHE.get(r);
+      if (hit) out[r] = hit;
+    }
+    return out;
+    // `tick` is bumped when a load settles; `key` identifies the slate. The
+    // cache itself is module state and cannot be a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, tick]);
+}

--- a/packages/app-shell/src/utils/approverIdentity.test.ts
+++ b/packages/app-shell/src/utils/approverIdentity.test.ts
@@ -1,0 +1,236 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * approverIdentity — an approver REFERENCE becomes something a person can read
+ * (objectui#5414).
+ *
+ * The reported defect, measured on this tree before the fix:
+ *
+ *     approverChips(request)  ->  [{ label: 'positi…ager', title: 'position:sales_manager' }]
+ *     bypassedApproverNames(request)  ->  ['position:sales_manager']
+ *
+ * `positi…ager` is `formatIdentity('position:sales_manager')`: 22 characters,
+ * past the 14-char truncation arm, middle-truncated to fit a chip. These pin the
+ * three tiers that replace it (server name > directory row > prettified machine
+ * name), the tri-state staffing rule, and the two arms that must NOT change —
+ * a UUID still truncates, an email is still shown whole.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  APPROVER_DIRECTORY_BINDINGS,
+  DEFAULT_APPROVER_COPY,
+  approverCopyFrom,
+  approverDisplay,
+  formatIdentity,
+  parseApproverRef,
+  prettifyMachineName,
+  rowLabel,
+  unresolvedApproverRefs,
+} from './approverIdentity';
+
+/** The exact string the card reports, kept as a literal so it cannot come back. */
+const REPORTED_TRUNCATION = 'positi…ager';
+
+describe('formatIdentity', () => {
+  it('no longer truncates the reported reference — that string was the defect', () => {
+    // Pin the OLD output as a literal: `position:sales_manager` is 22 chars, so
+    // the generic `> 14` arm produced exactly this.
+    expect(`${'position:sales_manager'.slice(0, 6)}…${'position:sales_manager'.slice(-4)}`)
+      .toBe(REPORTED_TRUNCATION);
+    expect(formatIdentity('position:sales_manager')).toBe('Sales Manager');
+    expect(formatIdentity('position:sales_manager')).not.toBe(REPORTED_TRUNCATION);
+  });
+
+  it('keeps middle-truncation for the ID-valued kinds — a UUID has no prose to recover', () => {
+    // `user` / `team` / `department` commit a row id, not a machine name.
+    // Prettifying one yields nonsense; truncating it is what objectui#3461
+    // asked for and is not what #5414 reports.
+    expect(APPROVER_DIRECTORY_BINDINGS.user.valueField).toBe('id');
+    expect(formatIdentity('9f8c2b41-77de-4a0e-9a11-0c6d2f3e5a10')).toContain('…');
+    expect(formatIdentity('u_qa_head')).toBe('u_qa_head');
+  });
+
+  it('leaves the two pre-existing arms exactly as they were', () => {
+    expect(formatIdentity('zhang.wei@example.com')).toBe('zhang.wei@example.com');
+    expect(formatIdentity('role:admin')).toBe('Role: admin');
+    expect(formatIdentity(null)).toBe('—');
+  });
+});
+
+describe('parseApproverRef', () => {
+  it('accepts only the kinds the SPEC declares', () => {
+    expect(parseApproverRef('position:sales_manager'))
+      .toEqual({ raw: 'position:sales_manager', kind: 'position', value: 'sales_manager' });
+    // Not an approver vocabulary word — must fall through to plain formatting
+    // rather than being re-read as a seat.
+    expect(parseApproverRef('flow:qif_review')).toBeNull();
+    expect(parseApproverRef('zhang.wei@example.com')).toBeNull();
+    expect(parseApproverRef('u_qa_head')).toBeNull();
+    expect(parseApproverRef(':orphan')).toBeNull();
+    expect(parseApproverRef('position:')).toBeNull();
+  });
+
+  it('keeps a colon inside the value', () => {
+    expect(parseApproverRef('user:urn:x:1')?.value).toBe('urn:x:1');
+  });
+});
+
+describe('APPROVER_DIRECTORY_BINDINGS is derived from the spec, not restated', () => {
+  it('binds position to sys_position by machine name — framework#3508 territory', () => {
+    expect(APPROVER_DIRECTORY_BINDINGS.position)
+      .toMatchObject({ object: 'sys_position', valueField: 'name' });
+    expect(APPROVER_DIRECTORY_BINDINGS.position.displayFields[0]).toBe('label');
+  });
+
+  it('skips the kinds whose source is not data rather than throwing', () => {
+    // `manager` (auto), `queue` (unsupported), `role` (enum) have no directory
+    // rows. A module-level throw over a vocabulary change would white-screen
+    // the record page.
+    for (const kind of ['manager', 'queue', 'role', 'field', 'expression']) {
+      expect(APPROVER_DIRECTORY_BINDINGS[kind]).toBeUndefined();
+    }
+    expect(Object.keys(APPROVER_DIRECTORY_BINDINGS).sort())
+      .toEqual(['department', 'position', 'team', 'user']);
+  });
+});
+
+describe('approverDisplay — the three tiers, most authoritative first', () => {
+  const copy = DEFAULT_APPROVER_COPY;
+
+  it('never second-guesses the server name', () => {
+    const out = approverDisplay('position:sales_manager', {
+      serverName: 'Sales Manager Desk',
+      resolved: { label: 'Sales Manager', holders: ['Zhang Wei'] },
+      copy,
+    });
+    expect(out.label).toBe('Sales Manager Desk');
+  });
+
+  it('uses the directory row label when the server had none', () => {
+    const out = approverDisplay('position:sales_manager', {
+      resolved: { label: '销售经理' },
+      copy,
+    });
+    expect(out.label).toBe('销售经理');
+    expect(out.raw).toBe('position:sales_manager');
+  });
+
+  it('falls back to the prettified machine name — still not a truncated id', () => {
+    expect(approverDisplay('position:sales_manager', { copy }).label).toBe('Sales Manager');
+  });
+
+  it('names the people when the seat resolves to people', () => {
+    const out = approverDisplay('position:sales_manager', {
+      resolved: { label: 'Sales Manager', holders: ['Zhang Wei', 'Li Na'] },
+      copy,
+    });
+    expect(out.label).toBe('Sales Manager');
+    expect(out.detail).toBe('Zhang Wei, Li Na');
+    expect(out.unstaffed).toBe(false);
+  });
+
+  it('collapses a long slate to the first three plus a counter', () => {
+    const out = approverDisplay('position:sales_manager', {
+      resolved: { label: 'Sales Manager', holders: ['A', 'B', 'C', 'D', 'E'] },
+      copy,
+    });
+    expect(out.detail).toBe('A, B, C +2');
+  });
+
+  it('surfaces the unstaffed seat — a real state, and the actionable one', () => {
+    const out = approverDisplay('position:sales_manager', {
+      resolved: { label: 'Sales Manager', holders: [] },
+      copy,
+    });
+    expect(out.label).toBe('Sales Manager (no current holder)');
+    expect(out.unstaffed).toBe(true);
+  });
+
+  it('says NOTHING about staffing when the probe never answered', () => {
+    // The asymmetry that matters: `undefined` holders mean "unknown", and
+    // rendering unknown as "nobody holds this" would write a fabricated fact
+    // onto a governance surface. A denied `sys_user_position` read lands here.
+    const out = approverDisplay('position:sales_manager', {
+      resolved: { label: 'Sales Manager' },
+      copy,
+    });
+    expect(out.unstaffed).toBe(false);
+    expect(out.detail).toBe('');
+    expect(out.label).toBe('Sales Manager');
+  });
+});
+
+describe('unresolvedApproverRefs — the gate that keeps the lookup free', () => {
+  it('drops every reference the server already named', () => {
+    expect(unresolvedApproverRefs({
+      pending_approvers: ['position:sales_manager', 'position:qc_director'],
+      pending_approver_names: { 'position:qc_director': 'QC Director' },
+    })).toEqual(['position:sales_manager']);
+  });
+
+  it('drops what this console cannot look up, and de-duplicates', () => {
+    expect(unresolvedApproverRefs({
+      pending_approvers: [
+        'position:sales_manager',
+        'position:sales_manager',
+        'u_bare_id',
+        'manager:',
+        'queue:q1',
+        '',
+        null,
+      ],
+    })).toEqual(['position:sales_manager']);
+  });
+
+  it('is empty for a row with nothing pending, and for a non-row', () => {
+    expect(unresolvedApproverRefs({ pending_approvers: [] })).toEqual([]);
+    expect(unresolvedApproverRefs(null)).toEqual([]);
+  });
+});
+
+describe('approverCopyFrom', () => {
+  const t = (key: string, opts?: any) =>
+    String(opts?.defaultValue ?? key).replace(/\{\{(\w+)\}\}/g, (_m, n) => String(opts?.[n] ?? ''));
+
+  it('renders the en defaults through a real interpolating translator', () => {
+    const copy = approverCopyFrom(t);
+    expect(copy.joinNames(['Zhang Wei', 'Li Na'])).toBe('Zhang Wei, Li Na');
+    expect(copy.unstaffed('Sales Manager')).toBe('Sales Manager (no current holder)');
+  });
+
+  it('renders the zh pack values — the strings the card asks for', () => {
+    // Read from the shipped pack rather than restated, so a translation edit
+    // cannot leave this assertion describing copy that no longer ships.
+    const zhPack: Record<string, string> = {
+      'approvalsInbox.approverNameSeparator': '、',
+      'approvalsInbox.approverUnstaffed': '{{seat}}（暂无在岗人员）',
+    };
+    const zh = approverCopyFrom((key: string, opts?: any) =>
+      (zhPack[key] ?? String(opts?.defaultValue ?? key))
+        .replace(/\{\{(\w+)\}\}/g, (_m, n) => String(opts?.[n] ?? '')));
+    expect(zh.joinNames(['张伟', '李娜'])).toBe('张伟、李娜');
+    expect(zh.unstaffed('销售经理')).toBe('销售经理（暂无在岗人员）');
+  });
+
+  it('yields to English rather than printing "undefined" with no provider mounted', () => {
+    const copy = approverCopyFrom(() => undefined);
+    expect(copy.joinNames(['A', 'B'])).toBe('A, B');
+    expect(copy.unstaffed('Sales Manager')).toBe('Sales Manager (no current holder)');
+  });
+});
+
+describe('rowLabel / prettifyMachineName', () => {
+  it('takes the first non-empty display column', () => {
+    expect(rowLabel({ label: '', name: 'sales_manager' }, ['label', 'name'])).toBe('sales_manager');
+    expect(rowLabel({ label: '  Sales Manager  ' }, ['label', 'name'])).toBe('Sales Manager');
+    expect(rowLabel(null, ['label'])).toBe('');
+  });
+
+  it('still strips the flow: prefix it always did', () => {
+    expect(prettifyMachineName('flow:qif_review')).toBe('Qif Review');
+    expect(prettifyMachineName('manager_review')).toBe('Manager Review');
+    expect(prettifyMachineName(null)).toBe('—');
+  });
+});

--- a/packages/app-shell/src/utils/approverIdentity.ts
+++ b/packages/app-shell/src/utils/approverIdentity.ts
@@ -1,0 +1,380 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * approverIdentity — the ONE place the console turns an approver REFERENCE
+ * into something a person can read (objectui#5414).
+ *
+ * ## The defect this closes
+ *
+ * `sys_approval_request.pending_approvers` carries the engine's own vocabulary:
+ * `<kind>:<value>` references (`position:sales_manager`, `department:<id>`, …),
+ * the portable indirect bindings ADR-0090 D3 leads with. The record page's
+ * approval panel ran every entry through `formatIdentity`, which knew `role:`
+ * and email addresses and otherwise MIDDLE-TRUNCATED anything over 14
+ * characters. `position:sales_manager` is 22, so the one line answering *who is
+ * holding this record* rendered as
+ *
+ *     positi…ager
+ *
+ * — an internal identifier, and not even a complete one. The same string
+ * reached the admin-override confirm dialog un-truncated (`bypassedApproverNames`
+ * defaults its formatter to identity), so a dialog that explains a subtle
+ * governance concept in plain prose named the bypassed party as
+ * `position:sales_manager`.
+ *
+ * ## What replaces it
+ *
+ * Three tiers, most authoritative first — the first that answers wins:
+ *
+ *   1. **The server's own resolution.** `pending_approver_names[ref]` is the
+ *      producer's id -> name mapping. When it answers, nothing here fires and no
+ *      request is made. This module never overrides it.
+ *   2. **The directory record.** A ref whose kind the spec declares as
+ *      `source: 'data'` names a row in a system directory object
+ *      ({@link APPROVER_DIRECTORY_BINDINGS}); its display column is the label a
+ *      person recognizes (`sys_position.label` -> `Sales Manager` / `销售经理`).
+ *      `useApproverDirectory` fetches those; this module only composes them.
+ *   3. **The machine name, prettified.** With no adapter and no directory row,
+ *      `sales_manager` -> `Sales Manager` still beats `positi…ager`, and it is
+ *      derived rather than guessed.
+ *
+ * The raw reference is never lost — every caller keeps it as the element's
+ * `title`, which is where the card says an internal identifier belongs.
+ *
+ * ## Why staffing is tri-state, and why that is load-bearing
+ *
+ * "Nobody currently holds this position" is a REAL state and the motivating
+ * rescue case for the admin-override path (framework#3424) — a request routed
+ * to an unstaffed seat. `销售经理(暂无在岗人员)` is actionable; `positi…ager` is
+ * not. But "the staffing query failed / was never run" is a different claim
+ * from "the seat is empty", and rendering the first as the second would put a
+ * fabricated fact on a governance surface. So {@link ResolvedApprover.holders}
+ * is `undefined` (unknown — say nothing) / `[]` (probed, confirmed empty) /
+ * a non-empty list, and {@link approverDisplay} only ever reports an empty seat
+ * for the middle case. Same asymmetry, same reason, as `isViaOverrideRow` in
+ * `approvalOverride.ts`.
+ */
+
+import { APPROVER_VALUE_SOURCES } from '@objectstack/spec/automation';
+
+/** A parsed `<kind>:<value>` approver reference. */
+export interface ApproverRef {
+  /** The reference exactly as the server sent it. */
+  raw: string;
+  /** Approver type (`position` / `team` / `department` / `user` / …). */
+  kind: string;
+  /** The value the kind's binding commits — a machine name or a row id. */
+  value: string;
+}
+
+/** Where a directory-backed approver kind's row lives, and what to show for it. */
+export interface ApproverDirectoryBinding {
+  /** Directory object holding the row — from the spec's published binding. */
+  object: string;
+  /** Column the reference's value matches — from the spec's binding. */
+  valueField: string;
+  /**
+   * Columns tried in order for the row's human label. PRESENTATION, and
+   * deliberately local: `@objectstack/spec` publishes the data contract only
+   * and says so (see `APPROVER_VALUE_SOURCES`'s own docstring), exactly as
+   * `FlowReferenceField`'s `RECORD_LOOKUP_PRESENTATION` composes on top of the
+   * same source. A list rather than one column because these rows come from
+   * four different objects whose label column is not uniformly named, and a
+   * missing label must degrade to the machine name rather than to blank.
+   */
+  displayFields: string[];
+}
+
+/**
+ * PRESENTATION per directory object — see {@link ApproverDirectoryBinding.displayFields}.
+ * Keyed by object so a kind whose spec binding moves objects picks the right
+ * columns without a second edit here.
+ */
+const DISPLAY_FIELDS_BY_OBJECT: Record<string, string[]> = {
+  sys_position: ['label', 'name'],
+  sys_team: ['label', 'name'],
+  sys_business_unit: ['label', 'name'],
+  sys_user: ['full_name', 'name', 'display_name', 'email'],
+};
+
+/** Columns tried for a person's name (`sys_user` rows only). */
+export const PERSON_DISPLAY_FIELDS: readonly string[] = DISPLAY_FIELDS_BY_OBJECT.sys_user;
+
+/**
+ * The approver kinds backed by DATA records, DERIVED from the spec.
+ *
+ * Never hand-written: framework#3508 is the measured cost of a local mirror of
+ * this contract (every directory kind wired to the metadata registry, which
+ * holds no `sys_position` ROWS — candidates came back empty and the control
+ * degraded to free text). Reading `APPROVER_VALUE_SOURCES` means a new approver
+ * type is covered here the day the spec publishes it, and a kind whose source
+ * is `enum` / `auto` / `unsupported` is skipped rather than thrown on — a
+ * module-level throw over a vocabulary change would white-screen the record page.
+ */
+export const APPROVER_DIRECTORY_BINDINGS: Record<string, ApproverDirectoryBinding> =
+  Object.fromEntries(
+    Object.entries(APPROVER_VALUE_SOURCES).flatMap(([kind, source]) => {
+      if (!source || source.source !== 'data') return [];
+      const object = String(source.object);
+      return [[
+        kind,
+        {
+          object,
+          valueField: String(source.valueField),
+          displayFields: DISPLAY_FIELDS_BY_OBJECT[object] ?? ['label', 'name'],
+        },
+      ]];
+    }),
+  );
+
+/** Every approver kind the spec declares — directory-backed or not. */
+const KNOWN_APPROVER_KINDS = new Set(Object.keys(APPROVER_VALUE_SOURCES));
+
+/**
+ * Split `<kind>:<value>` into its parts, or `null` when the string is not an
+ * approver reference at all.
+ *
+ * Strict on the kind: only a prefix the SPEC declares counts. A bare user id, a
+ * UUID, an email address (`a@b.com` has no colon) and a namespaced value from
+ * some other subsystem must all fall through to the caller's existing
+ * formatting rather than being re-read as an approver seat.
+ */
+export function parseApproverRef(raw: string | null | undefined): ApproverRef | null {
+  if (!raw || typeof raw !== 'string') return null;
+  const at = raw.indexOf(':');
+  if (at <= 0 || at === raw.length - 1) return null;
+  const kind = raw.slice(0, at);
+  if (!KNOWN_APPROVER_KINDS.has(kind)) return null;
+  return { raw, kind, value: raw.slice(at + 1) };
+}
+
+/**
+ * `manager_review` -> "Manager Review"; `flow:qif_review` -> "QIF Review".
+ *
+ * Moved here from `RecordApprovalsPanel` so the panel, the override dialog and
+ * the directory resolver cannot prettify a machine name three different ways.
+ */
+export function prettifyMachineName(raw: string | null | undefined): string {
+  if (!raw) return '—';
+  const base = String(raw).replace(/^flow:/, '').trim();
+  return base.split(/[_\-\s]+/).filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') || '—';
+}
+
+/**
+ * Render an actor/approver identifier in a friendly form (mirrors the Approval
+ * Center): emails as-is, `role:<name>` labeled, a directory reference whose
+ * binding commits a machine NAME prettified, and opaque 16+ char ids
+ * middle-truncated.
+ *
+ * Moved here from `RecordApprovalsPanel` in objectui#5414 so the panel, the
+ * timeline and the admin-override dialog cannot format one identifier three
+ * ways. The truncation arm is deliberately kept for the id-valued kinds: a raw
+ * UUID wall is what objectui#3461 complained about, and a UUID has no prose to
+ * recover. What #5414 adds is the arm above it — `position:sales_manager`
+ * carries a machine name, so it never had to be truncated in the first place.
+ */
+export function formatIdentity(id: string | null | undefined): string {
+  if (!id) return '—';
+  if (id.includes('@')) return id;
+  if (id.startsWith('role:')) return `Role: ${id.slice(5)}`;
+  const ref = parseApproverRef(id);
+  if (ref && APPROVER_DIRECTORY_BINDINGS[ref.kind]?.valueField === 'name') {
+    return prettifyMachineName(ref.value);
+  }
+  if (id.length > 14) return `${id.slice(0, 6)}…${id.slice(-4)}`;
+  return id;
+}
+
+/**
+ * The pending-approver references on `record` that the SERVER left unresolved
+ * and that this console can look up itself.
+ *
+ * The gate that keeps `useApproverDirectory` inert on a backend that resolves
+ * everything: an entry with a `pending_approver_names` answer is dropped here,
+ * so it costs no request. Takes `unknown` because the two callers hold the row
+ * at different types — the panel has an `ApprovalRequestLite`, the override
+ * dialog the same untyped `record` `bypassedApproverNames` reads.
+ */
+export function unresolvedApproverRefs(record: unknown): string[] {
+  if (!record || typeof record !== 'object') return [];
+  const row = record as { pending_approvers?: unknown; pending_approver_names?: unknown };
+  const pending = Array.isArray(row.pending_approvers) ? row.pending_approvers : [];
+  const names =
+    row.pending_approver_names && typeof row.pending_approver_names === 'object'
+      ? (row.pending_approver_names as Record<string, unknown>)
+      : {};
+  const out: string[] = [];
+  for (const raw of pending) {
+    if (typeof raw !== 'string' || !raw) continue;
+    const served = names[raw];
+    if (typeof served === 'string' && served) continue;
+    const ref = parseApproverRef(raw);
+    if (!ref || !APPROVER_DIRECTORY_BINDINGS[ref.kind]) continue;
+    if (!out.includes(raw)) out.push(raw);
+  }
+  return out;
+}
+
+/** What the directory could tell us about ONE approver reference. */
+export interface ResolvedApprover {
+  /** The row's display label, absent when no row answered. */
+  label?: string;
+  /**
+   * People filling the seat. TRI-STATE, and the distinction is the point:
+   * `undefined` = never probed or the probe failed (say nothing), `[]` = probed
+   * and the seat is genuinely empty, non-empty = the people. See this module's
+   * docstring.
+   */
+  holders?: string[];
+}
+
+/** How one approver reference should read on screen. */
+export interface ApproverDisplay {
+  /** Primary identification — never a truncated raw id once the ref parses. */
+  label: string;
+  /** Secondary line: the people filling the seat. Empty when there is none. */
+  detail: string;
+  /** The reference verbatim, for `title` / debug surfaces. */
+  raw: string;
+  /** Probed AND empty — the actionable state, never an unknown rendered as one. */
+  unstaffed: boolean;
+}
+
+/** The localized fragments {@link approverDisplay} needs, injected by the caller. */
+export interface ApproverDisplayCopy {
+  /** The surface's existing identity formatter, for refs that do not parse. */
+  fallback: (id: string) => string;
+  /** Joins holder names with the locale's list separator (`, ` / `、`). */
+  joinNames: (names: string[]) => string;
+  /** Wraps a seat that nobody currently holds (`销售经理(暂无在岗人员)`). */
+  unstaffed: (seat: string) => string;
+}
+
+/** Holder names beyond this many collapse into a `+N` counter on the chip. */
+export const MAX_INLINE_HOLDERS = 3;
+
+/**
+ * Compose the one string a person reads for one pending approver.
+ *
+ * `serverName` first (the producer resolved it — never second-guess that),
+ * then the directory row's label, then the prettified machine name. Prettifying
+ * is restricted to references whose binding commits a NAME: `position` stores
+ * `sys_position.name` because the engine routes by machine name, so
+ * `sales_manager` prettifies into real prose. The id-valued kinds
+ * (`user`/`team`/`department`) carry opaque row ids that prettify into
+ * nonsense — those keep the caller's existing formatting, which is the right
+ * treatment for an id and is not what objectui#5414 reports.
+ */
+export function approverDisplay(
+  raw: string,
+  opts: {
+    serverName?: string | null;
+    resolved?: ResolvedApprover;
+    copy: ApproverDisplayCopy;
+  },
+): ApproverDisplay {
+  const { serverName, resolved, copy } = opts;
+  const ref = parseApproverRef(raw);
+  const binding = ref ? APPROVER_DIRECTORY_BINDINGS[ref.kind] : undefined;
+
+  const resolvedLabel = resolved?.label?.trim() || '';
+  const serverLabel = typeof serverName === 'string' ? serverName.trim() : '';
+  const derived = ref && binding?.valueField === 'name'
+    ? prettifyMachineName(ref.value)
+    : '';
+
+  let label = serverLabel || resolvedLabel || derived || copy.fallback(raw);
+
+  const holders = resolved?.holders;
+  let detail = '';
+  let unstaffed = false;
+  if (Array.isArray(holders)) {
+    if (holders.length === 0) {
+      unstaffed = true;
+      label = copy.unstaffed(label);
+    } else {
+      const shown = holders.slice(0, MAX_INLINE_HOLDERS);
+      detail = copy.joinNames(shown);
+      if (holders.length > shown.length) detail += ` +${holders.length - shown.length}`;
+    }
+  }
+
+  return { label, detail, raw, unstaffed };
+}
+
+/** First non-empty display column of a directory row, or `''`. */
+export function rowLabel(row: unknown, displayFields: readonly string[]): string {
+  if (!row || typeof row !== 'object') return '';
+  const r = row as Record<string, unknown>;
+  for (const f of displayFields) {
+    const v = r[f];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+    if (typeof v === 'number') return String(v);
+  }
+  return '';
+}
+
+/**
+ * The English copy, for a surface with no translator mounted — provider-less
+ * embeds and unit tests. Mirrors the `en` pack values used as the inline
+ * `defaultValue`s in {@link approverCopyFrom}; the two must be edited together.
+ */
+export const DEFAULT_NAME_SEPARATOR = ', ';
+
+export const DEFAULT_APPROVER_COPY: ApproverDisplayCopy = {
+  fallback: formatIdentity,
+  joinNames: (names) => names.join(DEFAULT_NAME_SEPARATOR),
+  unstaffed: (seat) => `${seat} (no current holder)`,
+};
+
+/** Minimal shape of i18next's `t` — injected so this module stays pure. */
+export type ApproverTranslate = (key: string, opts?: Record<string, unknown>) => unknown;
+
+/**
+ * Build {@link ApproverDisplayCopy} from a translator.
+ *
+ * The two keys live here, spelled in FULL, rather than at each surface: the
+ * panel and the override dialog must name an empty seat with the same sentence,
+ * and a second copy of a string is how two surfaces drift. Both inline
+ * `defaultValue`s mirror the `en` pack exactly — `check:i18n-keys` fails on a
+ * call site whose default contradicts the pack (objectui#3810).
+ *
+ * `approverNameSeparator` is a translated PUNCTUATION key rather than
+ * `Intl.ListFormat` on purpose. Measured on this tree: `Intl.ListFormat('zh',
+ * { style: 'short', type: 'unit' }).format(['张伟','李娜'])` yields `张伟李娜` —
+ * two names run together with no separator, which reads as ONE person's name.
+ * A list of approvers is exactly where that failure is least acceptable.
+ */
+export function approverCopyFrom(
+  t: ApproverTranslate,
+  fallback: (id: string) => string = formatIdentity,
+): ApproverDisplayCopy {
+  // A translator that answers with anything but a non-empty string (no
+  // provider mounted, a pack still loading) yields to the English default
+  // rather than to the literal `"undefined"` a bare `String()` would print.
+  const str = (out: unknown, fallbackText: string): string =>
+    typeof out === 'string' && out ? out : fallbackText;
+  const separator = str(
+    t('approvalsInbox.approverNameSeparator', { defaultValue: DEFAULT_NAME_SEPARATOR }),
+    DEFAULT_NAME_SEPARATOR,
+  );
+  return {
+    fallback,
+    joinNames: (names) => names.join(separator),
+    unstaffed: (seat) =>
+      str(
+        t('approvalsInbox.approverUnstaffed', {
+          defaultValue: '{{seat}} (no current holder)',
+          seat,
+        }),
+        DEFAULT_APPROVER_COPY.unstaffed(seat),
+      ),
+  };
+}

--- a/packages/app-shell/src/views/DeclaredActionsBar.tsx
+++ b/packages/app-shell/src/views/DeclaredActionsBar.tsx
@@ -58,6 +58,12 @@ import { useMetadataItem } from '@object-ui/react';
 import { decisionOutputDefs, decisionOutputParams } from '../utils/decisionOutputParams.js';
 import { getIcon } from '../utils/getIcon.js';
 import { isOverrideDecision, bypassedApproverNames } from '../utils/approvalOverride.js';
+import {
+  approverCopyFrom,
+  approverDisplay,
+  unresolvedApproverRefs,
+} from '../utils/approverIdentity.js';
+import { useApproverDirectory } from '../hooks/useApproverDirectory.js';
 
 export interface DeclaredActionsBarProps {
   /** Object whose declared actions to render (e.g. `sys_approval_request`). */
@@ -190,8 +196,27 @@ const DeclaredActionButton: React.FC<{
    * naming *who* was about to be bypassed would have stopped, so the empty case
    * (the unstaffed-position rescue the override path exists for) gets its own
    * wording rather than an empty list.
+   *
+   * objectui#5414 — and those names must be NAMES. `bypassedApproverNames`
+   * defaults its formatter to identity, so an engine reference reached this
+   * dialog raw: a paragraph of plain governance prose ending
+   * `—— position:sales_manager`. Resolution is gated on `isOverride`, so an
+   * ordinary record page asks the directory nothing, and the shared cache in
+   * `useApproverDirectory` means the panel and every button on the same request
+   * resolve one slate once.
    */
-  const bypassed = useMemo(() => bypassedApproverNames(record), [record]);
+  const bypassedRefs = useMemo(
+    () => (isOverride ? unresolvedApproverRefs(record) : []),
+    [isOverride, record],
+  );
+  const approverDirectory = useApproverDirectory(bypassedRefs);
+  const bypassed = useMemo(() => {
+    const copy = approverCopyFrom(t as unknown as Parameters<typeof approverCopyFrom>[0]);
+    return bypassedApproverNames(record, (id) => {
+      const shown = approverDisplay(id, { resolved: approverDirectory[id], copy });
+      return shown.detail ? `${shown.label} · ${shown.detail}` : shown.label;
+    });
+  }, [record, approverDirectory, t]);
   // The declared label, localized — resolved ONCE here so the button text, the
   // param dialog's title and the override framing below can never come from
   // different bundle reads (objectui#4265).

--- a/packages/app-shell/src/views/RecordApprovalsPanel.approverIdentity.test.tsx
+++ b/packages/app-shell/src/views/RecordApprovalsPanel.approverIdentity.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * RecordApprovalsPanel — the pending approver is a NAME, not a truncated raw id
+ * (objectui#5414).
+ *
+ * Measured on this tree before the fix, HotCRM opportunity with a pending
+ * `approval` node routed to `position:sales_manager`:
+ *
+ *     Waiting on
+ *       positi…ager          <- the whole answer to "who is holding this record"
+ *
+ * The step names beside it were human prose. These render the same panel and
+ * read the chip back, in `en` and in `zh`, for every state the seat can be in:
+ * resolved with people, resolved and unstaffed, resolved but unprobeable, and
+ * unresolvable with no adapter at all. The raw reference stays reachable on
+ * hover throughout — that is where the card says an internal identifier belongs.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { AdapterCtx } from '@object-ui/react';
+import type { ApprovalRequestLite } from '../hooks/useRecordApprovals';
+
+vi.mock('@object-ui/auth', () => ({ createAuthenticatedFetch: () => vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+import { RecordApprovalsPanel } from './RecordApprovalsPanel';
+import { resetApproverDirectoryCache } from '../hooks/useApproverDirectory';
+
+/** The exact string the card reports — pinned so it cannot come back. */
+const REPORTED = 'positi…ager';
+
+const request = (over: Partial<ApprovalRequestLite> = {}): ApprovalRequestLite => ({
+  id: 'req_1',
+  process_name: 'flow:large_deal_approval',
+  process_label: 'Large Deal Approval (on create)',
+  object_name: 'crm_opportunity',
+  record_id: 'opp_1',
+  status: 'pending',
+  current_step: 'sales_manager_review',
+  step_label: 'Sales Manager Review',
+  submitter_id: 'u_sub',
+  pending_approvers: ['position:sales_manager'],
+  viewer: { can_act: false, is_submitter: false, can_override: true },
+  ...over,
+});
+
+/**
+ * A directory the panel can read. `sys_position` answers the label leg,
+ * `sys_user_position` -> `sys_user` the staffing leg; `failStaffing` makes the
+ * second leg reject the way a denied object API does (`OBJECT_API_DISABLED`),
+ * which must read as UNKNOWN staffing rather than as an empty seat.
+ */
+function directory(opts: {
+  label?: string;
+  holders?: Array<{ id: string; name: string }>;
+  failStaffing?: boolean;
+}) {
+  return {
+    find: vi.fn(async (object: string) => {
+      if (object === 'sys_position') {
+        return opts.label === undefined
+          ? { data: [] }
+          : { data: [{ name: 'sales_manager', label: opts.label }] };
+      }
+      if (object === 'sys_user_position') {
+        if (opts.failStaffing) {
+          throw Object.assign(new Error('denied'), { code: 'OBJECT_API_DISABLED' });
+        }
+        return {
+          data: (opts.holders ?? []).map((h, i) => ({
+            id: `up_${i}`, position: 'sales_manager', user_id: h.id,
+          })),
+        };
+      }
+      if (object === 'sys_user') {
+        return { data: (opts.holders ?? []).map((h) => ({ id: h.id, name: h.name })) };
+      }
+      return { data: [] };
+    }),
+  };
+}
+
+function renderPanel(req: ApprovalRequestLite, adapter: unknown, language = 'en') {
+  render(
+    <I18nProvider
+      config={{ defaultLanguage: language, detectBrowserLanguage: false }}
+      persistLanguage={false}
+    >
+      <AdapterCtx.Provider value={adapter as never}>
+        <RecordApprovalsPanel
+          approvals={{ available: true, requests: [req], pendingRequest: req }}
+          currentUserId="u_sub"
+        />
+      </AdapterCtx.Provider>
+    </I18nProvider>,
+  );
+}
+
+const chip = () => document.querySelector('[data-testid="approver-chip"]');
+const chipText = () => chip()?.textContent ?? '';
+
+beforeEach(() => {
+  resetApproverDirectoryCache();
+  // The panel's own action-thread fetch — inert here; the approver identity is
+  // what is under test.
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) }) as never));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('RecordApprovalsPanel — pending approver identity (objectui#5414)', () => {
+  it('names the position and its people, and keeps the raw reference on hover', async () => {
+    renderPanel(
+      request(),
+      directory({
+        label: 'Sales Manager',
+        holders: [{ id: 'u1', name: 'Zhang Wei' }, { id: 'u2', name: 'Li Na' }],
+      }),
+    );
+    await waitFor(() => expect(chipText()).toContain('Zhang Wei'));
+    expect(chipText()).toBe('Sales Manager· Zhang Wei, Li Na');
+    expect(chipText()).not.toContain(REPORTED);
+    expect(chipText()).not.toContain('position:sales_manager');
+    // Where the internal identifier DOES belong.
+    expect(chip()?.getAttribute('title')).toBe('position:sales_manager');
+  });
+
+  it('renders the same seat in zh — the strings the card asks for', async () => {
+    renderPanel(
+      request(),
+      directory({
+        label: '销售经理',
+        holders: [{ id: 'u1', name: '张伟' }, { id: 'u2', name: '李娜' }],
+      }),
+      'zh',
+    );
+    await waitFor(() => expect(chipText()).toContain('张伟'));
+    expect(chipText()).toBe('销售经理· 张伟、李娜');
+  });
+
+  it('surfaces the unstaffed seat rather than an unexplained label', async () => {
+    renderPanel(request(), directory({ label: 'Sales Manager', holders: [] }));
+    await waitFor(() => expect(chip()?.getAttribute('data-unstaffed')).toBe('true'));
+    expect(chipText()).toBe('Sales Manager (no current holder)');
+  });
+
+  it('says the unstaffed seat in zh too', async () => {
+    renderPanel(request(), directory({ label: '销售经理', holders: [] }), 'zh');
+    await waitFor(() => expect(chip()?.getAttribute('data-unstaffed')).toBe('true'));
+    expect(chipText()).toBe('销售经理（暂无在岗人员）');
+  });
+
+  it('does NOT claim an empty seat when the staffing read was refused', async () => {
+    // A business-app reader may list `sys_position` and not `sys_user_position`.
+    // "I could not look" is a different claim from "nobody holds it", and only
+    // one of them is safe to print on a governance surface.
+    renderPanel(request(), directory({ label: 'Sales Manager', failStaffing: true }));
+    await waitFor(() => expect(chipText()).toBe('Sales Manager'));
+    expect(chip()?.getAttribute('data-unstaffed')).toBeNull();
+  });
+
+  it('still reads as prose with no adapter at all — the truncation is gone either way', async () => {
+    renderPanel(request(), null);
+    await waitFor(() => expect(chip()).toBeTruthy());
+    expect(chipText()).toBe('Sales Manager');
+    expect(chipText()).not.toContain(REPORTED);
+  });
+
+  it('leaves a server-resolved name alone, and asks the directory nothing', async () => {
+    // Server-first: `pending_approver_names` is the producer's own resolution,
+    // and a backend that sends it must cost the record page no extra request.
+    const adapter = directory({ label: 'Sales Manager' });
+    renderPanel(
+      request({ pending_approver_names: { 'position:sales_manager': 'Sales Manager Desk' } }),
+      adapter,
+    );
+    await waitFor(() => expect(chipText()).toBe('Sales Manager Desk'));
+    expect(adapter.find).not.toHaveBeenCalled();
+  });
+
+  it('leaves a plain user slate exactly as it rendered before', async () => {
+    // The regression direction: #5414 must not restyle the ordinary case that
+    // objectui#3461 already got right.
+    renderPanel(
+      request({
+        pending_approvers: ['u_qa_head', 'u_prod_head'],
+        pending_approver_names: { u_qa_head: 'Qian Hua', u_prod_head: 'Li Lei' },
+      }),
+      null,
+    );
+    await waitFor(() => expect(chip()).toBeTruthy());
+    const labels = Array.from(document.querySelectorAll('[data-testid="approver-chip"]'))
+      .map((n) => n.textContent);
+    expect(labels).toEqual(['Qian Hua', 'Li Lei']);
+  });
+});

--- a/packages/app-shell/src/views/RecordApprovalsPanel.tsx
+++ b/packages/app-shell/src/views/RecordApprovalsPanel.tsx
@@ -20,6 +20,19 @@ import {
   type ApprovalRequestLite,
 } from '../hooks/useRecordApprovals.js';
 import { isViaOverrideRow } from '../utils/approvalOverride.js';
+import {
+  approverCopyFrom,
+  approverDisplay,
+  formatIdentity,
+  prettifyMachineName,
+  unresolvedApproverRefs,
+  DEFAULT_APPROVER_COPY,
+  type ApproverDisplayCopy,
+} from '../utils/approverIdentity.js';
+import {
+  useApproverDirectory,
+  type ApproverDirectory,
+} from '../hooks/useApproverDirectory.js';
 
 /**
  * RecordApprovalsPanel — the record page's read-only approval surface
@@ -98,25 +111,11 @@ const ACTION_DOT: Record<string, string> = {
 };
 
 /**
- * Render an actor/approver identifier in a friendly form (mirrors the
- * Approval Center): emails as-is, `role:<name>` labeled, opaque 16+ char ids
- * middle-truncated — a raw UUID wall is exactly what #3461 complains about.
+ * Identity formatting moved to `utils/approverIdentity` in objectui#5414 — the
+ * panel, the merged timeline and the admin-override dialog must not each own a
+ * copy. Re-exported here because this module is where it was published.
  */
-export function formatIdentity(id: string | null | undefined): string {
-  if (!id) return '—';
-  if (id.includes('@')) return id;
-  if (id.startsWith('role:')) return `Role: ${id.slice(5)}`;
-  if (id.length > 14) return `${id.slice(0, 6)}…${id.slice(-4)}`;
-  return id;
-}
-
-/** `manager_review` → "Manager Review" (display fallback for legacy rows). */
-function prettifyMachineName(raw: string | null | undefined): string {
-  if (!raw) return '—';
-  const base = String(raw).replace(/^flow:/, '').trim();
-  return base.split(/[_\-\s]+/).filter(Boolean)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ') || '—';
-}
+export { formatIdentity };
 
 /**
  * Collapse the pending-approver chips, keyed by (name, group) so 会签
@@ -125,22 +124,54 @@ function prettifyMachineName(raw: string | null | undefined): string {
  * with a count. Mirrors the Approval Center's `approverChips` (#2762 P1-2 /
  * objectui#2807); the tooltip keeps the underlying ids inspectable.
  */
+export interface ApproverChip {
+  label: string;
+  group?: string;
+  count: number;
+  title: string;
+  /**
+   * The people filling the seat, already joined for display. Absent (rather
+   * than empty) when there is nothing to add, so a caller comparing chips with
+   * `toEqual` sees the same shape it always did.
+   */
+  detail?: string;
+  /** Probed AND empty — set only when the seat is genuinely unstaffed. */
+  unstaffed?: boolean;
+}
+
 export function approverChips(
   r: ApprovalRequestLite,
-): Array<{ label: string; group?: string; count: number; title: string }> {
+  opts?: { directory?: ApproverDirectory; copy?: ApproverDisplayCopy },
+): ApproverChip[] {
+  const copy = opts?.copy ?? DEFAULT_APPROVER_COPY;
+  const directory = opts?.directory ?? {};
   const order: string[] = [];
-  const byKey = new Map<string, { label: string; group?: string; count: number; title: string }>();
+  const byKey = new Map<string, ApproverChip>();
   for (const a of r.pending_approvers || []) {
-    const label = r.pending_approver_names?.[a] || formatIdentity(a);
+    const shown = approverDisplay(a, {
+      serverName: r.pending_approver_names?.[a],
+      resolved: directory[a],
+      copy,
+    });
+    const label = shown.label;
     const gs = r.pending_approver_groups?.[a];
     const group = gs && gs.length ? gs.join(' / ') : undefined;
-    const key = group ? `${label} ${group}` : label;
+    // The seat's people are part of its identity: two positions can share a
+    // label, and collapsing them would merge two different slates into one chip.
+    const key = [label, shown.detail, group].filter(Boolean).join(' ');
     const seen = byKey.get(key);
     if (seen) {
       seen.count += 1;
       if (a && !seen.title.split(', ').includes(a)) seen.title += `, ${a}`;
     } else {
-      byKey.set(key, { label, group, count: 1, title: a || label });
+      byKey.set(key, {
+        label,
+        group,
+        count: 1,
+        title: a || label,
+        ...(shown.detail ? { detail: shown.detail } : {}),
+        ...(shown.unstaffed ? { unstaffed: true } : {}),
+      });
       order.push(key);
     }
   }
@@ -182,6 +213,25 @@ export const RecordApprovalsPanel: React.FC<RecordApprovalsPanelProps> = ({
   const [actions, setActions] = React.useState<ApprovalActionLite[]>([]);
   const [actionsLoading, setActionsLoading] = React.useState(false);
   const [reminding, setReminding] = React.useState(false);
+
+  /**
+   * Resolve the pending approvers the SERVER could not name (objectui#5414).
+   *
+   * `positi…ager` was `formatIdentity('position:sales_manager')` — the raw
+   * engine reference, middle-truncated to fit its chip. The gate below keeps
+   * this free on a backend that resolves its own slate: a request whose
+   * `pending_approver_names` covers every id yields an empty list, and the
+   * hook never touches the adapter.
+   */
+  const approverRefs = React.useMemo(
+    () => unresolvedApproverRefs(pendingRequest),
+    [pendingRequest],
+  );
+  const approverDirectory = useApproverDirectory(approverRefs);
+  const approverCopy = React.useMemo<ApproverDisplayCopy>(
+    () => approverCopyFrom(t as unknown as Parameters<typeof approverCopyFrom>[0]),
+    [t],
+  );
 
   // Reload key: the id set plus each request's decision state, as a stable
   // string — so the timeline refetches when a decision lands (the host's
@@ -430,9 +480,19 @@ export const RecordApprovalsPanel: React.FC<RecordApprovalsPanelProps> = ({
               {tr('waitingOn', 'Waiting on')}
             </div>
             <div className="flex flex-wrap gap-1">
-              {approverChips(pendingRequest).map((chip, i) => (
-                <Badge key={`${chip.label}-${chip.group ?? ''}-${i}`} variant="outline" className="text-[11px]" title={chip.title}>
+              {approverChips(pendingRequest, { directory: approverDirectory, copy: approverCopy }).map((chip, i) => (
+                <Badge
+                  key={`${chip.label}-${chip.group ?? ''}-${i}`}
+                  variant="outline"
+                  className="text-[11px]"
+                  /* The raw `position:…` reference belongs on hover, not as the
+                     primary identification — objectui#5414. */
+                  title={chip.title}
+                  data-testid="approver-chip"
+                  data-unstaffed={chip.unstaffed ? 'true' : undefined}
+                >
                   {chip.label}
+                  {chip.detail && <span className="ml-1 text-muted-foreground">· {chip.detail}</span>}
                   {chip.group && <span className="ml-1 text-muted-foreground">· {chip.group}</span>}
                   {chip.count > 1 && <span className="ml-1 text-muted-foreground">×{chip.count}</span>}
                 </Badge>

--- a/packages/app-shell/src/views/__tests__/DeclaredActionsBar.overrideAffordance.test.tsx
+++ b/packages/app-shell/src/views/__tests__/DeclaredActionsBar.overrideAffordance.test.tsx
@@ -101,7 +101,9 @@ vi.mock('@object-ui/components', async () => {
   };
 });
 
+import { AdapterCtx } from '@object-ui/react';
 import { DeclaredActionsBar } from '../DeclaredActionsBar';
+import { resetApproverDirectoryCache } from '../../hooks/useApproverDirectory';
 
 /**
  * The declared gates, in the spelling this suite's evaluator can evaluate.
@@ -171,15 +173,73 @@ const STAFFED_REQUEST = {
   pending_approver_names: { u_qa_head: 'Qian Hua', u_prod_head: 'Li Lei' },
 };
 
-function renderBar(viewer: Record<string, unknown>, record: Record<string, unknown> = STAFFED_REQUEST) {
+function renderBar(
+  viewer: Record<string, unknown>,
+  record: Record<string, unknown> = STAFFED_REQUEST,
+  adapter: unknown = null,
+) {
   return render(
-    <DeclaredActionsBar
-      objectName="sys_approval_request"
-      record={{ ...record, viewer }}
-      location="record_section"
-      actions={ACTIONS}
-    />,
+    <AdapterCtx.Provider value={adapter as never}>
+      <DeclaredActionsBar
+        objectName="sys_approval_request"
+        record={{ ...record, viewer }}
+        location="record_section"
+        actions={ACTIONS}
+      />
+    </AdapterCtx.Provider>,
   );
+}
+
+/**
+ * A request routed to a POSITION the server did not resolve — objectui#5414's
+ * second surface. Before that card this dialog printed the reference verbatim:
+ * a paragraph of plain governance prose ending `— position:sales_manager`.
+ */
+const POSITION_REQUEST = {
+  id: 'req_3',
+  status: 'pending',
+  record_id: 'opp_1',
+  pending_approvers: ['position:sales_manager'],
+};
+
+/** The directory legs `useApproverDirectory` reads, doubled. */
+function positionDirectory(opts: { label: string; holders?: Array<{ id: string; name: string }> }) {
+  return {
+    find: vi.fn(async (object: string) => {
+      if (object === 'sys_position') return { data: [{ name: 'sales_manager', label: opts.label }] };
+      if (object === 'sys_user_position') {
+        return {
+          data: (opts.holders ?? []).map((h, i) => ({
+            id: `up_${i}`, position: 'sales_manager', user_id: h.id,
+          })),
+        };
+      }
+      if (object === 'sys_user') {
+        return { data: (opts.holders ?? []).map((h) => ({ id: h.id, name: h.name })) };
+      }
+      return { data: [] };
+    }),
+  };
+}
+
+/**
+ * The composed warning, polled until the directory lookup has landed.
+ *
+ * The bar surfaces its resolved slate ONLY through the dispatch, so the click
+ * sits inside the poll rather than in front of it. That is cheap and safe here:
+ * `execute` is called synchronously by `handleClick`, `executeSpy` is inert, and
+ * a retry that arrives while the previous click is still in flight is dropped by
+ * the component's own `loading` guard.
+ */
+async function noticeMatching(expected: RegExp): Promise<string> {
+  let notice = '';
+  await waitFor(() => {
+    executeSpy.mockClear();
+    fireEvent.click(screen.getByTestId('declared-action-approval_approve'));
+    notice = String(executeSpy.mock.calls[0]?.[0]?.overrideNotice ?? '');
+    expect(notice).toMatch(expected);
+  });
+  return notice;
 }
 
 const OVERRIDE_ONLY = { can_act: false, is_submitter: false, can_override: true };
@@ -187,6 +247,7 @@ const DESIGNATED_APPROVER = { can_act: true, is_submitter: false, can_override: 
 
 beforeEach(() => {
   executeSpy.mockClear();
+  resetApproverDirectoryCache();
 });
 
 describe('DeclaredActionsBar — override-only viewer (objectui#5178)', () => {
@@ -325,5 +386,50 @@ describe('DeclaredActionsBar — the ordinary path is untouched (objectui#5178)'
     const finalise = screen.getByTestId('declared-action-approval_finalise_now');
     expect(finalise.getAttribute('data-override-decision')).toBe('true');
     expect(finalise.textContent).toContain('Override Finalise');
+  });
+});
+
+describe('DeclaredActionsBar — the bypassed party is NAMED, not referenced (objectui#5414)', () => {
+  it('never prints the raw engine reference, even with no directory to read', async () => {
+    renderBar(OVERRIDE_ONLY, POSITION_REQUEST);
+    const notice = await noticeMatching(/Sales Manager/);
+    expect(notice).not.toContain('position:sales_manager');
+    // …and the sentence around it is still the whole warning.
+    expect(notice).toContain('finalises the step immediately');
+    expect(notice).toContain('recorded as an admin override');
+  });
+
+  it('names the people filling the seat when the directory can answer', async () => {
+    renderBar(
+      OVERRIDE_ONLY,
+      POSITION_REQUEST,
+      positionDirectory({
+        label: 'Sales Manager',
+        holders: [{ id: 'u1', name: 'Zhang Wei' }, { id: 'u2', name: 'Li Na' }],
+      }),
+    );
+    const notice = await noticeMatching(/Zhang Wei/);
+    expect(notice).toContain('Sales Manager · Zhang Wei, Li Na');
+    expect(notice).not.toContain('position:sales_manager');
+  });
+
+  it('says the seat is unstaffed — the rescue case this path exists for', async () => {
+    renderBar(
+      OVERRIDE_ONLY,
+      POSITION_REQUEST,
+      positionDirectory({ label: 'Sales Manager', holders: [] }),
+    );
+    const notice = await noticeMatching(/no current holder/);
+    expect(notice).toContain('Sales Manager (no current holder)');
+  });
+
+  it('asks the directory nothing on the ordinary, non-override path', async () => {
+    // The cost gate: this bar renders on every record page, and a viewer who is
+    // not overriding must not pay for a lookup they will never see.
+    const adapter = positionDirectory({ label: 'Sales Manager' });
+    renderBar(DESIGNATED_APPROVER, POSITION_REQUEST, adapter);
+    await waitFor(() =>
+      expect(screen.getByTestId('declared-action-approval_approve')).toBeTruthy());
+    expect(adapter.find).not.toHaveBeenCalled();
   });
 });

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -3217,6 +3217,8 @@ const ar = {
     submittedAgo: 'قُدِّم {{when}}',
     completedAt: 'اكتمل {{when}}',
     waitingOn: 'بانتظار',
+    approverNameSeparator: '، ',
+    approverUnstaffed: '{{seat}} (لا يشغلها أحد حاليًا)',
     history: 'النشاط',
     noActions: 'لا إجراءات بعد.',
     actSubmit: 'تقديم',

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -3210,6 +3210,8 @@ const de = {
     submittedAgo: 'Eingereicht {{when}}',
     completedAt: 'Abgeschlossen {{when}}',
     waitingOn: 'Wartet auf',
+    approverNameSeparator: ', ',
+    approverUnstaffed: '{{seat}} (derzeit unbesetzt)',
     history: 'Aktivität',
     noActions: 'Noch keine Aktionen.',
     actSubmit: 'Eingereicht',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -3523,6 +3523,8 @@ const en = {
     submittedAgo: 'Submitted {{when}}',
     completedAt: 'Completed {{when}}',
     waitingOn: 'Waiting on',
+    approverNameSeparator: ', ',
+    approverUnstaffed: '{{seat}} (no current holder)',
     history: 'Activity',
     noActions: 'No actions yet.',
     actSubmit: 'Submitted',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -3214,6 +3214,8 @@ const es = {
     submittedAgo: 'Enviada {{when}}',
     completedAt: 'Completada {{when}}',
     waitingOn: 'A la espera de',
+    approverNameSeparator: ', ',
+    approverUnstaffed: '{{seat}} (actualmente sin titular)',
     history: 'Actividad',
     noActions: 'Aún no hay acciones.',
     actSubmit: 'Enviada',

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -3212,6 +3212,8 @@ const fr = {
     submittedAgo: 'Soumise {{when}}',
     completedAt: 'Terminée {{when}}',
     waitingOn: 'En attente de',
+    approverNameSeparator: ', ',
+    approverUnstaffed: '{{seat}} (poste actuellement vacant)',
     history: 'Activité',
     noActions: 'Aucune action pour le moment.',
     actSubmit: 'Soumise',

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -3210,6 +3210,8 @@ const ja = {
     submittedAgo: '{{when}}に申請',
     completedAt: '{{when}}に完了',
     waitingOn: '承認待ちの担当者',
+    approverNameSeparator: '、',
+    approverUnstaffed: '{{seat}}（現在の担当者なし）',
     history: '承認履歴',
     noActions: 'まだ操作はありません。',
     actSubmit: '申請',

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -3209,6 +3209,8 @@ const ko = {
     submittedAgo: '{{when}} 제출됨',
     completedAt: '{{when}} 완료됨',
     waitingOn: '대기 중인 승인자',
+    approverNameSeparator: ', ',
+    approverUnstaffed: '{{seat}}(현재 담당자 없음)',
     history: '승인 활동',
     noActions: '아직 작업이 없습니다.',
     actSubmit: '제출',

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -3209,6 +3209,8 @@ const pt = {
     submittedAgo: 'Enviada {{when}}',
     completedAt: 'Concluída {{when}}',
     waitingOn: 'Aguardando',
+    approverNameSeparator: ', ',
+    approverUnstaffed: '{{seat}} (atualmente sem titular)',
     history: 'Atividade',
     noActions: 'Nenhuma ação ainda.',
     actSubmit: 'Enviada',

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -3221,6 +3221,8 @@ const ru = {
     submittedAgo: 'Отправлен {{when}}',
     completedAt: 'Завершён {{when}}',
     waitingOn: 'Ожидает решения',
+    approverNameSeparator: ', ',
+    approverUnstaffed: '{{seat}} (сейчас не занята)',
     history: 'История',
     noActions: 'Действий пока нет.',
     actSubmit: 'Отправлен',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -3334,6 +3334,8 @@ const zh = {
     submittedAgo: '提交于{{when}}',
     completedAt: '完成于{{when}}',
     waitingOn: '等待以下审批人',
+    approverNameSeparator: '、',
+    approverUnstaffed: '{{seat}}（暂无在岗人员）',
     history: '审批动态',
     noActions: '暂无操作记录。',
     actSubmit: '提交',


### PR DESCRIPTION
Fixes #5414

The approval panel rendered the pending approver as `positi…ager`. That is `formatIdentity('position:sales_manager')`: the engine reference is 22 characters, past the identity formatter's 14-character truncation arm, middle-truncated to fit its chip. The step names beside it were human prose; the one line answering *who is holding this record* was an internal identifier, and not even a complete one. The same reference reached the admin-override confirm dialog un-truncated — `bypassedApproverNames` defaults its formatter to identity — so a paragraph of plain governance prose ended `— position:sales_manager`.

## Measured before / after

Rendered, not reasoned about: the panel was mounted with a pending request routed to `position:sales_manager` and the chip read back out of the DOM, in `en` and `zh`, once per state the seat can be in. Every string below is copied from a run.

| surface / state | before | after |
| --- | --- | --- |
| chip, position staffed (en) | `positi…ager` | `Sales Manager· Zhang Wei, Li Na` |
| chip, position staffed (zh) | `positi…ager` | `销售经理· 张伟、李娜` |
| chip, position unstaffed (en) | `positi…ager` | `Sales Manager (no current holder)` |
| chip, position unstaffed (zh) | `positi…ager` | `销售经理（暂无在岗人员）` |
| chip, staffing read refused | `positi…ager` | `Sales Manager` — and no unstaffed claim |
| chip, no adapter at all | `positi…ager` | `Sales Manager` |
| chip, server already named the seat | `Sales Manager Desk` | `Sales Manager Desk`, `adapter.find` calls: **0** |
| chip `title` (hover) | `position:sales_manager` | `position:sales_manager` — unchanged, on purpose |
| override dialog `{{who}}`, staffed | `position:sales_manager` | `Sales Manager · Zhang Wei, Li Na` |
| override dialog `{{who}}`, unstaffed | `position:sales_manager` | `Sales Manager (no current holder)` |
| override dialog `{{who}}`, no directory | `position:sales_manager` | `Sales Manager` |

The gap between label and detail is the `ml-1` margin the panel already uses for its 会签 group chip, so `textContent` concatenates without a space while the rendered chip has one.

## What changed

`packages/app-shell/src/utils/approverIdentity.ts` is the one place an approver reference becomes readable text, in three tiers, most authoritative first:

1. **The server's own `pending_approver_names`.** It wins whenever it answers, and a backend that resolves its own slate costs the record page **no extra request** — `unresolvedApproverRefs` drops every already-named entry, so the hook below stays inert.
2. **The directory row.** A reference whose kind the spec declares as `source: 'data'` names a row in a system directory object; `sys_position.label` is `Sales Manager` / `销售经理`. `packages/app-shell/src/hooks/useApproverDirectory.ts` reads it, plus — for a position — `sys_user_position` to `sys_user` for who fills the seat.
3. **The prettified machine name.** With no adapter and no row, `sales_manager` still reads as `Sales Manager`, which is derived rather than guessed.

The object and value column per kind come from `@objectstack/spec`'s `APPROVER_VALUE_SOURCES` rather than being restated here, so a new approver type is covered the day the spec publishes it — framework#3508 is the measured cost of a local mirror of that contract. Only presentation (which column to show) is local, which is the same division `FlowReferenceField` already documents.

**Id-valued kinds keep the existing middle-truncation.** `user` / `team` / `department` commit a row id; a UUID has no prose to recover, and that arm is objectui#3461's answer, not this card's defect. Prettifying is restricted to bindings whose `valueField` is `name` — today that is `position`, which is exactly the reported case.

**Staffing is tri-state, and that is load-bearing.** `undefined` = never probed or the probe failed, `[]` = probed and genuinely empty, non-empty = the people. A business-app reader may list `sys_position` and not `sys_user_position`; that read rejects with `OBJECT_API_DISABLED` rather than returning an empty page, and folding the two legs together would let a permission error render as `销售经理（暂无在岗人员）` — a fabricated fact on a surface people audit. Same asymmetry, same reason, as `isViaOverrideRow`.

## i18n

Two keys, added to **all ten** packs: `approvalsInbox.approverUnstaffed` and `approvalsInbox.approverNameSeparator`.

The separator is a translated punctuation key rather than `Intl.ListFormat`, and that was measured rather than assumed: on this tree `Intl.ListFormat('zh', { style: 'short', type: 'unit' }).format(['张伟','李娜'])` returns `张伟李娜` — two names run together with no separator, which reads as one person's name. A list of approvers is where that failure is least acceptable.

## Reverse verification

Three legs, each ablated from the **committed** state, predicted before running, then restored with `git checkout` and the tree proved clean (`git status --porcelain` and `git diff HEAD` both empty).

**Leg 1 — drop the directory-name arm from `formatIdentity`.**
Predicted: red, but only partially — the unit assertion reverts to the reported string, while adapter-backed panel tests stay green because they resolve through the directory tier.
Observed: `1 failed | 29 passed`, `AssertionError: expected 'positi…ager' to be 'Sales Manager'` — the reported string came straight back.
**Divergence, reported rather than smoothed over:** I also predicted the panel's *no adapter at all* case would fail. It passed. `approverDisplay` reaches `prettifyMachineName` on its own tier, before `formatIdentity` is ever consulted as the fallback, so the chip path does not depend on that arm. The arm is still load-bearing for the callers that use `formatIdentity` directly — the merged timeline's actor and the reassign from/to line. The two paths are independent, which the prediction had merged.

**Leg 2 — make a refused staffing read record `holders: []` instead of leaving it undefined.**
Predicted: exactly one failure, in the panel test, with the pure composer test staying green because the ablation is in the hook.
Observed: exactly that. `1 failed | 29 passed`, `AssertionError: expected 'true' to be null` on the `data-unstaffed` attribute. The asymmetry is the finding: the tri-state needs both the composer assertion and the hook assertion to be covered.

**Leg 3 — restore `bypassedApproverNames(record)` with no formatter.**
Predicted: three failures, all in the new #5414 block; the pre-existing #5178 case naming `Qian Hua` / `Li Lei` stays green because server-resolved names are handled inside `bypassedApproverNames` before the formatter is consulted.
Observed: exactly that. `3 failed | 11 passed`.

## Gates run locally

At `4633ea9fe`, on a tree proved byte-identical to that commit:

- `pnpm exec vitest run packages/app-shell packages/i18n` — **507 files, 5323 passed, 1 skipped**. The one skip is pre-existing, in files this PR does not touch; nothing was skipped, disabled or quarantined here.
- targeted union at HEAD, real exit code (no pipe): **55 files, 972 passed**, exit 0.
- `type-check` for `@object-ui/app-shell` and `@object-ui/i18n` — clean.
- `check:i18n-keys`, `check:i18n-drift`, `check:i18n-dead-keys`, `check:control-bytes`, `check:phantom-deps`, `check:self-import`, `check:esm-specifiers`, `check-changeset-no-major`, `check-changeset-fixed`, `check-changeset-presence`, `check-type-check-coverage`, `check-lint-coverage` — all green.
- `lint` on both packages — 0 errors.

`check:i18n-keys` was counter-probed rather than trusted: flipping one inline `defaultValue` to a deliberate wrong value made it fail and name `packages/app-shell/src/utils/approverIdentity.ts:373`, so its green is a reading of these call sites and not a green that never saw them. The file was then restored and confirmed byte-identical.

## Not addressed here

That the server leaves a `position:` reference unresolved in `pending_approver_names` is a framework-side observation, out of scope: #5414 is scoped to the console surfaces, the resolution here is server-first and never overrides a name the producer does send.

_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_
