### PR TITLE
docs(utilities): teach the real ObjectStack adapter, not a phantom provider

### DIFF
--- a/.changeset/utilities-index-phantom-provider-5360.md
+++ b/.changeset/utilities-index-phantom-provider-5360.md
@@ -1,0 +1,27 @@
+---
+---
+
+Docs and gate ledger only — this publishes nothing, declared explicitly with an empty
+frontmatter rather than left undeclared.
+
+`content/docs/utilities/index.md`'s "Data Integration" section taught
+`import { ObjectStackProvider } from '@object-ui/data-objectstack'`, a React context
+provider on a package that is headless and exports no such thing. Compiled against the
+built `dist/index.d.ts` by the same harness `scripts/check-doc-snippet-types.mjs` uses,
+the block read
+`TS2724: '"@object-ui/data-objectstack"' has no exported member named 'ObjectStackProvider'`,
+so a reader who copied it did not get a runtime bug — they got a compile error. #4124 had
+already established the finding and PR #4129 fixed it on the sibling page
+`content/docs/utilities/data-objectstack.mdx`; the identical phantom survived one file
+over, in the utilities index, outside that card's file surface.
+
+The section now teaches the same shape PR #4129 established: `createObjectStackAdapter`
+returning a plain `DataSource`, injected at the renderer boundary through
+`@object-ui/react`'s `SchemaRendererProvider`. The block is also self-contained — it
+imports every name it uses and types its schema literal as the real `ObjectGridSchema` —
+so it compiles exactly as a reader who copies that one block experiences it.
+
+Because that was the page's only `ts`/`tsx` block and it now produces zero diagnostics,
+`content/docs/utilities/index.md` LEAVES `check-doc-snippet-types.mjs`'s `UNGATED_DOCS`
+ledger instead of getting a re-measured reason: the page is compiled by the gate from
+here on, and no entry on that ledger names a missing export any more.

--- a/content/docs/utilities/index.md
+++ b/content/docs/utilities/index.md
@@ -157,22 +157,43 @@ pnpm publish
 
 ### Data Integration
 
-Connect to ObjectStack backends with the data adapter:
+Connect to ObjectStack backends with the data adapter. `@object-ui/data-objectstack`
+is **headless** — it exports no React components and no hooks. You create a plain
+`DataSource` with `createObjectStackAdapter` and inject it at the renderer boundary
+through `@object-ui/react`'s `SchemaRendererProvider`:
 
-```typescript
-import { ObjectStackProvider } from '@object-ui/data-objectstack'
+```tsx
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import type { ObjectGridSchema } from '@object-ui/types';
 
-function App() {
+const dataSource = createObjectStackAdapter({
+  baseUrl: 'https://api.example.com',
+  token: 'your-api-token', // optional when auth is handled elsewhere
+});
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'account',
+  columns: ['name', 'owner', 'created'],
+};
+
+export function App() {
   return (
-    <ObjectStackProvider
-      apiUrl="https://api.example.com"
-      apiKey="your-api-key"
-    >
+    <SchemaRendererProvider dataSource={dataSource}>
       <SchemaRenderer schema={schema} />
-    </ObjectStackProvider>
-  )
+    </SchemaRendererProvider>
+  );
 }
 ```
+
+`new ObjectStackAdapter(config)` is the class form of the same factory, and
+`SchemaRenderer` also takes an explicit `dataSource` prop when you would rather
+inject per render than through context. See
+[ObjectStack Data Adapter](/docs/utilities/data-objectstack) for the full config,
+the API reference, and how a schema node's own `dataSource` key (the spec's
+per-element binding — *what* to query, not *how* to reach the backend) differs
+from the adapter above.
 
 ## Features
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -227,7 +227,7 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * Documents whose snippets are NOT compiled, each with the reason. The default
  * is covered; this list is the debt, by name, and it can only shrink.
  *
- * ⚠️ 20 of these entries are `.md` pages under `content/docs` that objectui#5174
+ * ⚠️ 19 of these entries are `.md` pages under `content/docs` that objectui#5174
  * made visible: the collector now reads `.md`, and an entry with a measured reason
  * is what a page that cannot pass yet is owed. They are DISCLOSED debt, not new
  * debt — every one of them was equally unverified before, just unnamed. Their
@@ -239,9 +239,16 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * pages: no entry for `content/docs/guide/**` or for
  * `content/docs/api/schema-reference.md` names a missing export any more. Every
  * symbol those pages documented now exists on the built `dist/index.d.ts`, so
- * their reasons record what each fabricated name BECAME instead. Exactly one
- * entry still names a missing export — `content/docs/utilities/index.md`
- * (`ObjectStackProvider`), a different directory and a different card.
+ * their reasons record what each fabricated name BECAME instead. objectui#5360
+ * then closed out the last one. `content/docs/utilities/index.md` named
+ * `ObjectStackProvider` (@object-ui/data-objectstack) — a React context provider
+ * on a package that is headless — and that page LEFT this ledger rather than
+ * getting a re-measured reason: it holds exactly ONE ts/tsx block, so rewriting
+ * that block against the real surface (`createObjectStackAdapter` injected
+ * through `@object-ui/react`'s `SchemaRendererProvider`, the shape PR #4129 had
+ * already established on the sibling `content/docs/utilities/data-objectstack.mdx`)
+ * retired the two undefined-name diagnostics in the same stroke and took the page
+ * to zero. No entry on this list names a missing export any more.
  *
  * The reasons are deliberately concrete about WHAT would have to change, because
  * "does not compile" is three different jobs: a page whose snippets reference
@@ -402,11 +409,6 @@ const UNGATED_DOCS = {
     '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
   'content/docs/utilities/data-objectstack.mdx':
     '16 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2391x1 — candidate real defects, un-triaged',
-  'content/docs/utilities/index.md':
-    '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; plus TS2724x1 — candidate real defects, un-triaged. The missing-export ' +
-    'diagnostics name `ObjectStackProvider` (@object-ui/data-objectstack) — the reader-visible ' +
-    'half of this entry',
   'content/docs/utilities/runner.mdx':
     '5 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 3 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 3 unresolved-module diagnostic(s)',
   'packages/app-shell/README.md':


### PR DESCRIPTION
Fixes #5360

Docs + gate ledger only. Rewrites the "Data Integration" section of
`content/docs/utilities/index.md` against the surface `@object-ui/data-objectstack`
actually exports, and takes the page off `check-doc-snippet-types.mjs`'s `UNGATED_DOCS`
ledger because it now compiles clean.

## Premise re-verified on the branch tip

The phantom is genuinely absent from the built package, and the real names are present —
each grep counter-probed with a term known to be there, so a zero is a measured zero and
not a mistyped path:

| probe over `packages/data-objectstack/dist/index.d.ts` | count |
|---|---|
| `ObjectStackProvider` | **0** (grep exit 1) |
| `ObjectStackAdapter` (counter-probe, known present) | 16 |

`createObjectStackAdapter` is declared at `dist/index.d.ts:2418` and named in the export
list at `:2431`. `SchemaRendererProvider` is declared in
`packages/react/dist/context/SchemaRendererContext.d.ts:18` and re-exported through
`packages/react/dist/index.d.ts`. `ObjectGridSchema` is declared in
`packages/types/dist/objectql.d.ts:484` (`type: 'object-grid'`, `objectName: string`) and
exported from that package's index.

## Before / after, compiled — not eyeballed

Both readings come from the SAME harness the gate uses: `analyze()` + `compileSnippets()`
imported from `scripts/check-doc-snippet-types.mjs`, with every other document declared
ungated so the program compiles exactly this page's blocks. Its three controls were green
on every run below — resolution landed on
`/home/user/objectui-issue-5360/packages/types/dist/index.d.ts` (a built artifact, never a
package's `src/`), the planted sentinel produced its TS2305, the positive control produced
zero, and zero source files under any `packages/*/src/` entered the program.

**Before** (`origin/main` content, against the built `dist/*.d.ts`):

```
[semantic]  content/docs/utilities/index.md:163:10  TS2724: '"@object-ui/data-objectstack"' has no exported member named 'ObjectStackProvider'. Did you mean 'ObjectStackError'?
[semantic]  content/docs/utilities/index.md:171:8   TS2304: Cannot find name 'SchemaRenderer'.
[semantic]  content/docs/utilities/index.md:171:31  TS2304: Cannot find name 'schema'.

Semantic phase: 1 of 1 block(s) judged, 1 failed.
Total diagnostics on content/docs/utilities/index.md: 3
```

That is exactly the mix the ledger entry recorded by hand — `TS2724x1` plus
"2 undefined-name diagnostic(s)".

**After**:

```
Blocks: 1 to compile, 0 declared fragment(s).

Syntax phase:   0 block(s) failed to parse.
Semantic phase: 1 of 1 block(s) judged, 0 failed.
Total diagnostics on content/docs/utilities/index.md: 0
```

**Counter-probe on that zero.** A green run whose harness silently stopped reading the
page looks identical to a green run whose page is correct, so the zero was probed rather
than trusted: re-planting `ObjectStackProvider` beside the real import turned BOTH the
targeted probe and the full gate red, on this file, by name —

```
[semantic]  content/docs/utilities/index.md:166:36  TS2724: '"@object-ui/data-objectstack"' has no exported member named 'ObjectStackProvider'. Did you mean 'ObjectStackError'?
Semantic phase: 88 of 88 block(s) judged, 1 failed.
```

— and reverting it restored the green. The mutation was made and reverted on top of the
commit, so the restored file is byte-identical to what is pushed (`git status` clean, and
`ObjectStackProvider` greps 0 while `createObjectStackAdapter` greps 3).

## The PR #4129 precedent this follows

#4124 established the finding and PR #4129 fixed it — on
`content/docs/utilities/data-objectstack.mdx` only. Reading that PR rather than inventing
a shape, its precedent was:

1. **Delete the phantom React API; do not add the export.** `@object-ui/data-objectstack`
   is headless — no `react` in any dependency field, no React import in `src/` — so
   `ObjectStackProvider` has no home there. PR #4129's reverse verification recorded the
   same TS2724 / TS2305 pair this card's `TS2724` is one half of.
2. **Teach `createObjectStackAdapter` returning a plain `DataSource`**, with
   `new ObjectStackAdapter(config)` named as the class form of the same thing.
3. **Inject it at the renderer boundary through `@object-ui/react`'s
   `SchemaRendererProvider`**, since React wiring lives in `@object-ui/react`, not in the
   adapter package — and note that `SchemaRenderer` also takes an explicit `dataSource`
   prop for per-render injection.
4. **Drop the invented props with it.** `apiUrl` / `apiKey` became `baseUrl` / `token`,
   which is what `createObjectStackAdapter`'s config declares.
5. **Keep the schema node's own `dataSource` key distinct from the adapter** — the former
   is the spec's per-element binding (*what* to query), the latter is *how* to reach the
   backend. The rewritten section says so and links to the sibling page for the full table.

The rewritten snippet is also **self-contained**: it imports every name it uses and types
its schema literal as the real `ObjectGridSchema`, so it is judged exactly as a reader who
copies that one block experiences it. That is what retires the two `TS2304` undefined-name
diagnostics the same ledger entry carried — the sibling page still carries 16 of them and
stays ungated for that reason.

## The page LEAVES the ledger, with the measurement

`content/docs/utilities/index.md` holds exactly ONE `ts`/`tsx` fenced block (verified
against the fence scan: one ```typescript fence at `:162`, now ```tsx, and six ```bash
fences). With that block at zero diagnostics the page needs no entry, so the entry is
removed rather than re-measured — the ledger's own rule is that it can only shrink.

Full gate, whole corpus, real exit code captured (not read through a pipe):

```
Scanned 222 document(s): 159 covered (22 of them hold a ts/tsx block), 63 ungated
Covered blocks: 98 — 88 to compile, 10 declared fragment(s).
Syntax phase:   every block parsed, so every one of them reached the semantic phase.
Semantic phase: 88 of 88 block(s) judged, 0 failed.
Every covered documentation snippet compiles against the built types.
GATE_EXIT=0
```

Covered went 158 -> **159**, ungated 64 -> **63**. Two header claims in the same script
were true only while the entry existed and are corrected in the same commit: the
"20 of these entries are `.md` pages" count is now 19, and "Exactly one entry still names a
missing export" — that one — now records what became of it. No entry on the ledger names a
missing export any more.

## Verification

All of the below on `7b289c91b`, the branch head and the final commit. Heavy runs were
serialised through the shared `/tmp/os-heavy-verify.lock`.

| gate | result |
|---|---|
| `pnpm turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2` | `32 successful, 32 total` |
| `node scripts/check-doc-snippet-types.mjs` | **exit 0** — 88/88 judged, 0 failed |
| the same gate with the phantom re-planted (counter-probe) | **red**, naming this file |
| `npx vitest run scripts/__tests__/check-doc-snippet-types.test.ts` | `1 passed (1)`, `20 passed (20)`, exit 0 |
| `node scripts/check-doc-component-types.mjs` | `Every documented component type is registered.` (`object-grid` is a registered key) |
| `node scripts/check-doc-links.mjs` | `Links are valid across 13 scan roots.` |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 4520 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | `1 changeset(s) added`, exit 0 |
| `node scripts/check-changeset-fixed.mjs` / `check-changeset-no-major.mjs` | both exit 0 |
| `pnpm type-check:scripts` | exit 0 |
| `npx eslint scripts/check-doc-snippet-types.mjs` | exit 0 |
| control-byte self-scan over the three changed files | no matches (grep exit 1) |

Changeset: `.changeset/utilities-index-phantom-provider-5360.md`, **empty frontmatter** —
this publishes nothing, declared explicitly rather than left undeclared. No package `src/`
is touched.

## File surface

Exactly three files, `origin/main...HEAD` (three-dot, against merge base `77f846a8b`):

```
 .changeset/utilities-index-phantom-provider-5360.md | 27 +++++++++++++
 content/docs/utilities/index.md                     | 45 ++++++++++++++------
 scripts/check-doc-snippet-types.mjs                 | 20 +++++-----
```

`content/docs/guide/react-pages.md` is not addressed here — sibling card #5413 is in
flight on that page and it is deliberately untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_