### PR TITLE
docs(guide): resolve four react-pages.md contradictions toward the framework's sources

### DIFF
--- a/.changeset/react-pages-guide-source-contradictions-5413.md
+++ b/.changeset/react-pages-guide-source-contradictions-5413.md
@@ -1,0 +1,33 @@
+---
+---
+
+Docs only — this publishes nothing, declared explicitly with an empty frontmatter rather
+than left undeclared.
+
+`content/docs/guide/react-pages.md` contradicted the framework's sources on four points.
+The guide is live material (`@object-ui/react-runtime`'s README links it twice), so each
+one was reachable teaching. All four were re-measured against `objectstack@f094214b3` and
+resolved toward the source:
+
+- **Tailwind styling.** The guide taught Tailwind `className` as the react tier's styling
+  primitive, which ADR-0080's 2026-06-30 amendment retracted under ADR-0065 (Accepted): a
+  page's `source` is runtime metadata the console's build-time Tailwind never scans, so an
+  authored utility class silently produces no CSS. Replaced with the per-tier primitive the
+  shipped `page-source-className-tailwind` rule names — inline `style={{ … }}` with
+  `hsl(var(--token))` on the react tier, structured props plus a JSON `style` object on the
+  html tier — and added a Styling section giving the mechanism.
+- **`record:*` scope.** The family was offered as the illustrative in-scope example while
+  `os validate` rejects it (`react-block-needs-record-context`, severity error, matched by
+  type). The tag-derivation rule is kept — it is accurate — and the exclusion, the real
+  error text, and the per-block alternatives are now stated beside it.
+- **`adapter.find` options.** The `Live data` sample passed `filters:`, which is not a
+  `QueryParams` key; `convertQueryParams` reads only `$`-prefixed keys, so the sample
+  returned the object's records unfiltered with no error. Corrected to `$filter`. The same
+  sample also treated the result as an array — `find` resolves to a `QueryResult`, so
+  `.map` on it throws; corrected to `res.data` alongside it.
+- **Block inventory.** The guide conflated the runtime scope (every public non-container
+  block) with the authored contract (`REACT_BLOCKS`: `ObjectForm`, `ListView`,
+  `ObjectChart`, `Block`). Both are now stated as two tiers, with the generated
+  `react-blocks.md` named as the prop authority, and the flat-props example moved off two
+  deprecated `ObjectGrid` spellings (`pageSize`, `fields`) onto the canonical
+  `pagination` / `fields` on `ListView`.

--- a/content/docs/guide/react-pages.md
+++ b/content/docs/guide/react-pages.md
@@ -11,7 +11,7 @@ that are awkward to express as nested JSON:
 
 | `kind` | Source is | Executed? | Author trust |
 |---|---|---|---|
-| `"html"` | Constrained JSX/HTML + Tailwind | **No** — parsed into a schema tree | Untrusted OK |
+| `"html"` | Constrained JSX/HTML | **No** — parsed into a schema tree | Untrusted OK |
 | `"react"` | Real React (hooks, handlers, arbitrary JS) | **Yes** — in the main React tree | Trusted only |
 
 Both set `source` and leave `regions` unused. `"jsx"` is a deprecated alias for
@@ -24,7 +24,9 @@ Both set `source` and leave `regions` unused. `"jsx"` is a deprecated alias for
 
 Reach for **`kind:'html'`** by default. It is parsed, whitelisted against the
 public block manifest, and never executed, so it is safe for AI-generated and
-customer-authored pages. It covers layout, blocks, and Tailwind styling.
+customer-authored pages. It covers layout, blocks, and styling — styling through
+the blocks' own structured props plus a JSON `style` object, **not** Tailwind
+(see *Styling*, below; the rule holds on both tiers).
 
 Reach for **`kind:'react'`** only when you need real behaviour the schema tree
 cannot express — local state, computed lists, event handlers wiring one block to
@@ -37,7 +39,7 @@ another, custom data fetching. It runs **without a sandbox**.
   "type": "home",
   "name": "project_console",
   "kind": "react",
-  "source": "function Page() {\n  const [selected, setSelected] = React.useState(null);\n  return (\n    <div className=\"grid grid-cols-2 gap-4\">\n      <ListView objectName=\"showcase_project\" fields={['name', 'status']} onRowClick={(r) => setSelected(r._id)} />\n      {selected && <ObjectForm objectName=\"showcase_project\" mode=\"edit\" recordId={selected} />}\n    </div>\n  );\n}"
+  "source": "function Page() {\n  const [selected, setSelected] = React.useState(null);\n  return (\n    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>\n      <ListView objectName=\"showcase_project\" fields={['name', 'status']} onRowClick={(r) => setSelected(r._id)} />\n      {selected && <ObjectForm objectName=\"showcase_project\" mode=\"edit\" recordId={selected} />}\n    </div>\n  );\n}"
 }
 ```
 
@@ -47,7 +49,7 @@ Written out, that `source` is:
 function Page() {
   const [selected, setSelected] = React.useState(null);
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
       <ListView
         objectName="showcase_project"
         fields={['name', 'status']}
@@ -78,20 +80,113 @@ Nothing is imported. These identifiers are injected as closure variables:
 | In scope | What it is |
 |---|---|
 | `React` | The host's React — call hooks with it (`React.useState`). |
-| The public data blocks | `<ObjectGrid>`, `<ListView>`, `<ObjectForm>`, `<ObjectKanban>`, `<ObjectChart>`, `<ObjectMetric>`, `<Markdown>`, … |
+| The public data blocks | Every public non-container block, as a PascalCase tag — but *what resolves* and *what you author against* are two different sets, below. |
 | `Block` | Escape hatch for anything not injected. |
 | `useAdapter` | The live data source — query/create/update. |
 | `data`, `variables`, `page` | The page's own data, local variables, and schema. |
 
-The block tags come from the curated **public contract**
-(`PUBLIC_BLOCKS`), converted from kebab-case to PascalCase: `object-grid` →
+#### Two tiers: what resolves, and what you author against
+
+**The runtime scope** is every block in the curated public contract
+(`PUBLIC_BLOCKS`) that is not a layout container. Tags are derived by splitting
+the registry type on `-`, `_` and `:` and PascalCasing each part: `object-grid` →
 `<ObjectGrid>`, `record:details` → `<RecordDetails>`. Blocks registered lazily
 are in scope too — you never wait on a plugin chunk to reference one.
 
-**Layout containers are deliberately not injected.** In react mode you compose
-layout with real HTML and Tailwind, which React is better at than a schema-children
-renderer. `<flex>`, `<grid>`, `<card>` and friends have no injected wrapper — use
-`<div className="flex gap-4">`.
+**The authored contract** is the much smaller set that has *published props* —
+checked by `os validate` and generated into the reference an author, human or AI,
+writes against: **`<ObjectForm>`, `<ListView>`, `<ObjectChart>`, `<Block>`**.
+That set is `REACT_BLOCKS` in `@objectstack/spec`, and the generated per-prop
+table is `skills/objectstack-ui/references/react-blocks.md` in the framework
+repo. **Treat that table as the prop authority, not this page.**
+
+Everything in the runtime scope but outside the contract still resolves and
+renders — its props simply are not part of the react-tier contract. Reach those
+through the contract instead: a kanban / calendar / gantt / timeline / map of an
+object is `<ListView viewType="kanban" …>`, or `<Block type="object-kanban" …>`.
+
+#### The `record:*` family is excluded from this tier
+
+The tag derivation above is real — `<RecordDetails>` and `<RecordHighlights>`
+*are* defined in the scope — but every `record:*` block reads its record from the
+record context a **record page** mounts, and a `kind:'react'` page never mounts
+one. The block renders empty however you bind it: its `objectName`/`recordId` are
+not read by the renderer. `os validate` rejects them at publish time:
+
+```
+  ✗ Author-time rules failed (1 issue)
+  • page "showcase_renewals_pipeline" › RecordHighlights: RecordHighlights renders
+    "record:highlights", which reads its record from the record context a record page
+    mounts — a kind:'react' page never mounts one, so the block renders empty no matter
+    how it is bound (its objectName/recordId are not read by the renderer).
+      rule: react-block-needs-record-context
+```
+
+The rule matches by **type**, so `<Block type="record:details" />` is rejected
+the same way. On a react page, bind the record yourself:
+
+| Instead of | Write |
+|---|---|
+| `<RecordDetails>` | `<ObjectForm objectName="…" mode="view" recordId={…} fields={[…]} />` — it binds by its own props. |
+| `<RecordHighlights>` | `<ObjectForm … mode="view" />`, or read the record with `useAdapter().findOne` and lay the strip out in JSX. |
+| `<RecordRelatedList>` | `<ListView objectName="child_object" filters={['lookup_field', '=', parentId]} />` — the parent binding is an ordinary filter here. |
+| `<RecordPath>` | Read the record with `useAdapter().findOne` and render the stage bar in JSX. |
+
+If you want the whole record-page composition, author the page as `type:'record'`
+instead — that is the page kind that mounts the context these blocks render from.
+
+**Layout containers are deliberately not injected.** The scope builder skips
+every container (`if (!tag || cfg.isContainer) continue;`), so `<flex>`, `<grid>`,
+`<card>` and friends have no injected wrapper. In react mode you compose layout
+with real HTML, which React is better at than a schema-children renderer — styled
+inline, not with Tailwind: `<div style={{ display: 'flex', gap: 16 }}>`.
+
+### Styling — page source is metadata, not build input
+
+**Do not author Tailwind utility classes in page source** — on either tier. A
+page's `source` is *runtime metadata*. The console's Tailwind is compiled at
+**build** time by scanning the console's own `src`, and there is no safelist, so
+it never sees your page. A utility class in page source produces CSS only if that
+exact class happens to already appear in objectui's own source, and otherwise
+produces **nothing, with no error anywhere**.
+
+This is the most expensive mistake on this tier: the page still renders — correct
+structure, correct data, no styling — and nothing reports it. It is recorded as a
+2026-06-30 amendment to ADR-0080 under ADR-0065, after a modal's `bg-black/50`
+backdrop rendered fully transparent in production. `os validate` reports it as
+`page-source-className-tailwind` (a warning, on both tiers).
+
+Each tier has its own styling primitive:
+
+| `kind` | Style with |
+|---|---|
+| `"react"` | Inline `style={{ … }}`, with `hsl(var(--token))` for colour. |
+| `"html"` | The blocks' own structured props (`<flex direction gap>`, `<grid columns>`) plus a JSON `style` object. |
+
+Colours come from the active theme, so the page follows light/dark and whatever
+theme the deployment installs:
+
+```jsx
+<div
+  style={{
+    background: 'hsl(var(--card))',
+    border: '1px solid hsl(var(--border))',
+    borderRadius: 'var(--radius)',
+    padding: 12,
+    color: 'hsl(var(--foreground))',
+  }}
+>
+  …
+</div>
+```
+
+Common tokens: `--background`, `--foreground`, `--card`, `--muted`,
+`--muted-foreground`, `--border`, `--primary`, `--destructive`, plus the
+spacing/radius tokens `--space-*` and `--radius`.
+
+For overlays, do not hand-roll a `position: fixed; inset: 0` backdrop — render
+the form in its built-in Sheet or Dialog, which arrives already styled:
+`<ObjectForm … formType="drawer" drawerSide="right" />`.
 
 ### Blocks take flat props
 
@@ -99,8 +194,14 @@ An injected block folds its JSX props into the block's schema, so you write
 flat props rather than a nested `schema` object:
 
 ```jsx
-<ObjectGrid objectName="showcase_project" fields={['name', 'status']} pageSize={25} />
+<ListView objectName="showcase_project" fields={['name', 'status']} pagination={{ pageSize: 25 }} />
 ```
+
+Use the **canonical** spelling of each prop — the one the contract publishes.
+Several blocks still read older flat spellings as back-compat fallbacks but do
+not declare them, so they are not authoring surface: on `<ObjectGrid>`, for
+instance, `pageSize` and `fields` are deprecated aliases of `pagination` and
+`columns`.
 
 Function props (`onRowClick`, `onSelect`) are passed through as real callbacks —
 that is how you wire one block to another.
@@ -126,12 +227,28 @@ function Page() {
   const [rows, setRows] = React.useState([]);
 
   React.useEffect(() => {
-    adapter.find('showcase_project', { filters: [['status', '=', 'open']] }).then(setRows);
+    adapter
+      .find('showcase_project', { $filter: ['status', '=', 'open'] })
+      .then((res) => setRows(res.data ?? []));
   }, [adapter]);
 
   return <ul>{rows.map((r) => <li key={r._id}>{r.name}</li>)}</ul>;
 }
 ```
+
+Two things in that call are easy to get wrong, and neither one errors:
+
+**The `$` prefixes are load-bearing.** Every query key starts with `$` —
+`$select`, `$filter`, `$orderby`, `$skip`, `$top`, `$expand`, `$search`,
+`$searchFields`, `$count`. An unprefixed `filters:` or `top:` is not a query option — the adapter
+reads only the `$`-prefixed keys, so anything else is dropped and the call comes
+back **unfiltered**, or with the default page size, with no error. `$filter`
+takes an ObjectQL filter array — `['field', 'op', value]`, with `and`/`or`
+compounds spelled `['and', [...], [...]]`.
+
+**`find` resolves to a `QueryResult`, not an array.** It is
+`{ data, total, page, pageSize, hasMore }`; the rows are `res.data`. Passing the
+result straight to `setRows` and then calling `.map` on it throws.
 
 ### Source shapes
 
@@ -200,6 +317,11 @@ each block's declared inputs, and unknown tags are a hard error at save time.
 Use it for anything author- or AI-generated. Expressions are limited to what the
 schema supports (`${data.x}`), and there is no local state or event handling
 beyond the action system.
+
+Styling works the same way as on the react tier — *page source is never scanned
+by the build* — but with this tier's own primitive: lay out with the blocks'
+structured props (`<flex direction gap>`, `<grid columns>`) and add CSS as a JSON
+`style` object. See *Styling*, above.
 
 ## Related
 


### PR DESCRIPTION
Fixes #5413

The guide is live material — `@object-ui/react-runtime`'s README links it twice
(`README.md:19` and `:127`) — so each contradiction was reachable teaching.

**Every claim was re-measured, not inherited.** The card measured against
`objectstack@502dc6fe7`; that pin had moved **65 commits** by the time this ran. All four
were re-measured against `objectstack@f094214b3` and objectui `77f846a8b`. Nothing had
been fixed upstream in the meantime, so no axis is moot — but three of the card's
citations had drifted, noted below.

## Per-axis verdict

All four came out **settled**, each by a live shipped mechanism rather than by an ADR
whose status could be argued. Nothing goes to the decision inbox.

| # | Axis | Verdict | What changed in the guide | Source read |
|---|---|---|---|---|
| 1 | Tailwind styling | **settled** | Dropped "+ Tailwind" from the `kind` table and the html-tier blurb; restyled the headline example to an inline `style` object; replaced the "so use Tailwind" conclusion on the layout-containers paragraph; added a **Styling** section giving the mechanism and the per-tier primitive | `packages/lint/src/validate-page-source-styling.ts` — rule `page-source-className-tailwind`, fires on `kind` `html`/`react`/`jsx`, hint names inline `style` + `hsl(var(--token))` for react and structured props + JSON `style` for html. Registered in `authoring-rules.ts:741` (`tier: 'advisory'`), exported from `lint/src/index.ts:152`, **released** in `@objectstack/lint@11.5.0` (changelog `ec7175d`, which states it "corrects … ADR-0080/0081 away from the 'HTML + Tailwind' framing"). Backed by ADR-0065 (**Accepted** 2026-06-22) and ADR-0080's 2026-06-30 header amendment |
| 2 | `record:*` scope | **settled** | Kept the tag-derivation rule (it is accurate); added the exclusion, the real `os validate` error text, the per-block alternatives table, and the note that the rule matches by **type** so `Block type="record:…"` is caught too | `packages/spec/src/ui/react-blocks.ts` — the `REACT_RECORD_BLOCK_ALTERNATIVES` ledger and the withdrawal rationale (#4413); `packages/lint/src/validate-react-page-props.ts:913` — `REACT_BLOCK_NEEDS_RECORD_CONTEXT`, **severity `error`**, matched by type not by tag list |
| 3 | `adapter.find` options | **settled** | `filters:` → `$filter`; added the load-bearing-`$` note with the exact key list | objectui `packages/types/src/data.ts:42` — `QueryParams` declares only `$`-prefixed keys; `packages/data-objectstack/src/index.ts:2976` `convertQueryParams` builds a **fresh** options object from `$`-prefixed reads only, so an unprefixed key reaches no branch. The framework's own react page uses `$filter` (`renewals-pipeline.page.ts:67`) |
| 4 | Block inventory | **settled** | Split the single tag list into **runtime scope** vs **authored contract**, named `react-blocks.md` as the prop authority, and moved the flat-props example off two deprecated `ObjectGrid` spellings | `REACT_BLOCKS` in `packages/spec/src/ui/react-blocks.ts` is exactly `ObjectForm`, `ListView`, `ObjectChart`, `Block`; objectui `packages/core/src/registry/public-blocks.ts` `PUBLIC_BLOCKS` plus `buildComponentScope` (`renderers/layout/react-page.tsx:66`, `if (!tag || cfg.isContainer) continue;`) is the runtime scope |

### Why axis 1 is settled rather than escalated

This is the one the card framed as an ADR-amendment question, so it got the most scrutiny.
The amendment lives in ADR-0080, whose own Status line still reads "Proposed" — but the
amendment is a *correction pointing back to* **ADR-0065, which is Accepted**, and it has
since been implemented and released: a dedicated lint rule ships and is wired into
`os validate`/`os build`, the generated react contract carries it, and objectstack#10286 /
PR #10436 has just carried the same correction into `PageSchema`'s own describes. That
card's `needs:contract-review` label is a path-limb process gate on `packages/spec/src/**`,
and its reviewer graded the content limb "no" — it is not a dispute about direction.
Nothing anywhere in either tree argues the other way.

### Three of the card's citations had drifted — corrected here

- The card cites `packages/lint/src/validate-responsive-styles.ts` (`style-classname-tailwind`)
  as the Tailwind corroborator. **Counter-probed: that rule never reads page `source`** —
  it walks `regions[].components[]` only, and the file contains no occurrence of `source`
  at all. The rule that actually governs the source tier is the separate
  `validate-page-source-styling.ts` cited above. Same conclusion, stronger and correct
  authority.
- The card locates `QueryParams` at `packages/types/src/data.ts` in the framework repo.
  That path does not exist at `objectstack@f094214b3`; the file is **objectui's own**.
- The card says the `record:*` gate applies to the four withdrawn tags. It matches by
  **type prefix**, so all `record:*` blocks are covered — including the six never in the
  contract — and `Block type="record:…"` with the type spelled out.

## One bounded in-place fix, declared

The `Live data` sample had a **second** defect in the same call, same class (the sample
contradicts `ObjectStackAdapter`'s real contract): it passed the result straight to
`setRows` and then called `.map` on it. `find` resolves to a `QueryResult`
(`{ data, total, page, pageSize, hasMore }`), never a bare array — `normalizeQueryResult`
(`data-objectstack/src/index.ts`) returns that shape on every branch, and `find` is
declared as returning a promise of `QueryResult` (generic elided here — GitHub's sanitizer
eats angle brackets). As written the sample throws. Corrected to `res.data` alongside the
`$filter` fix and called out in the prose, rather than left as a silent rider. Same file,
same defect class, same gate family, no new verification surface.

## Verification

All results below are on the final commit **`42a1d7359`**, re-run after committing; exit
codes captured per gate, never through a pipe.

```
EXIT=0 :: check-doc-component-types.mjs :: Every documented component type is registered.
             (183 doc files, 1054 code blocks, 887 `type` literals, 742 registered / 145 exempted)
EXIT=0 :: check-doc-links.mjs           :: Links are valid across 13 scan roots.
EXIT=0 :: check-control-bytes.mjs       :: OK (scanned 4521 tracked text files; skipped 85 binary)
EXIT=0 :: check-changeset-presence.mjs  :: No source of a released package changed in this range
EXIT=0 :: check-changeset-no-major.mjs  :: No changeset declares a `major` bump
```

Plus the standing control-byte self-scan on the changed files
(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) — clean.

**One gate narrowed, declared not skipped.** `check:doc-snippets` compiles every `ts`/`tsx`
fence in a covered document against built `dist/*.d.ts`, and `react-pages.md` is covered
(not in `UNGATED_DOCS`). Its only input from this file is one `tsx` fence, and that fence is
**byte-identical** before and after — extracted and compared programmatically, 1 fence
before, 1 after, `IDENTICAL: True` — with its `doc-snippet: fragment` marker still
immediately above it. The gate's verdict on this file therefore cannot move, and CI runs it
on a built tree regardless. No ablation was run: nothing here is a gate-can-fail claim.

No test was skipped, disabled, or quarantined. `content/docs/utilities/index.md` was **not**
touched (sibling card #5360 is in flight there); `content/docs/releases/` untouched; no
force-push.

## Changeset

Empty frontmatter — docs-only, so this publishes nothing, declared explicitly rather than
left undeclared (objectui does not use a `skip-changeset` label). `check-changeset-presence`
confirms none is owed.

## Out-of-scope findings, filed not fixed

- **#5461** (objectui, unassigned) — three objectui sources still carry the same retracted
  "HTML + Tailwind" framing, one of them the published TSDoc on `PageSchema.kind`
  (`packages/types/src/layout.ts:616`), which links *this* guide and so will contradict it
  once this lands. Outside this card's declared file surface.
- **objectstack#10479** (unassigned, filed as a sub-issue of objectstack#10288) — the
  showcase CRM workbench react page passes `limit: 200` to `adapter.find`, the same
  dropped-option class, in a second file that #10288's stated one-file change does not
  reach.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_
