### PR TITLE
docs(types,components): name the real per-tier page-source styling primitive

### DIFF
--- a/.changeset/page-source-tailwind-framing-5461.md
+++ b/.changeset/page-source-tailwind-framing-5461.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/types': patch
+---
+
+`PageSchema.kind`'s TSDoc names the real per-tier styling primitive for source-authored pages instead of the "HTML + Tailwind" framing ADR-0080's own amendment retracted.
+
+This is a published type surface: the TSDoc ships in `@object-ui/types`'s built
+`.d.ts` and is what an author reads on hover over `kind`. It said a `kind:'html'`
+page is "constrained JSX/HTML + Tailwind" — and it links
+`content/docs/guide/react-pages.md`, which objectui#5413 has already corrected to
+say the opposite. Shipped type documentation was contradicting the guide it points
+readers to.
+
+ADR-0080's header amendment (2026-06-30, under ADR-0065, Accepted) supersedes that
+framing on styling: a page's `source` is *runtime metadata*, the console's Tailwind
+is compiled at build time by scanning the console's own `src`, and there is no
+safelist — so an authored utility class produces CSS only by coincidence, when
+objectui already ships that exact class, and otherwise produces nothing with no
+error anywhere. That is the ADR-0065 failure mode verbatim ("works only by
+coincidence"), and it is how a modal's `bg-black/50` backdrop reached production
+fully transparent.
+
+The tiers themselves are unchanged, and every load-bearing claim in the TSDoc
+survives verbatim — parse-never-execute and untrusted-author safety for `html`,
+the deprecated `'jsx'` alias, EVALUATED-in-the-main-tree with no sandbox behind the
+`react-pages` host capability for `react`, the ADR-0080 citation and the guide
+link. Only the styling conclusion changes, to the primitive each tier actually has:
+
+| `kind` | Style with |
+|---|---|
+| `"html"` | The blocks' own structured props (`` `<flex direction gap>` ``, `` `<grid columns>` ``) plus a JSON `style` object. |
+| `"react"` | Inline `style` objects. |
+
+Colors on both tiers come from the theme as `hsl(var(--token))`, so a page follows
+light/dark and whatever theme the deployment installs. The TSDoc now also names the
+rule that reports a violation — `page-source-className-tailwind`, shipped in
+`@objectstack/lint@11.5.0` as `validatePageSourceStyling` and reported by
+`os validate` as a warning on both tiers.
+
+No behaviour change, and the accepted `kind` set is untouched.
+
+`packages/components/src/renderers/layout/react-page.tsx` carries the same
+correction on its two source comments (the injected-scope note and
+`buildComponentScope`), and gains the styling note the file was missing. Those are
+internal comments — they do not project into any `.d.ts` and change no export — so
+they get no entry of their own; there is nothing an `@object-ui/components`
+consumer could read in a CHANGELOG and act on.

--- a/packages/components/src/renderers/layout/react-page.tsx
+++ b/packages/components/src/renderers/layout/react-page.tsx
@@ -21,11 +21,21 @@
  *   - `React`                — so authors can call hooks.
  *   - the PUBLIC data blocks — `<ObjectGrid>`, `<ObjectForm>`, charts, metrics…
  *     each as a prop-driven wrapper that renders via SchemaRenderer. Layout is
- *     left to plain HTML + Tailwind (React's strength); only the data blocks
- *     that can't be expressed in HTML are injected.
+ *     left to plain HTML (React's strength); only the data blocks that can't be
+ *     expressed in HTML are injected.
  *   - `Block`                — escape hatch: `<Block type="object-grid" .../>`.
  *   - `useAdapter`            — live data hook: query/create/update objects.
  *   - `data` / `variables`   — page data + local variables, for convenience.
+ *
+ * Styling — page source is metadata, not build input. A react page styles with
+ * inline `style` objects using `hsl(var(--token))` theme colors; overlays render
+ * through `<ObjectForm formType="drawer"|"modal">` rather than a hand-rolled
+ * `fixed inset-0` backdrop. Do NOT author Tailwind utility classes in page
+ * `source`: `source` is runtime metadata, the console's Tailwind is compiled at
+ * build time by scanning the console's own `src`, and there is no safelist — an
+ * authored utility class silently produces no CSS. `os validate` reports it as
+ * `page-source-className-tailwind`. (ADR-0065; ADR-0080's 2026-06-30 amendment;
+ * see `content/docs/guide/react-pages.md`.)
  */
 
 import * as React from 'react';
@@ -46,7 +56,8 @@ function toPascal(tag: string): string {
 // Build the component scope from the curated PUBLIC contract. We inject the
 // data/leaf blocks (non-containers) as prop-driven wrappers; layout containers
 // are intentionally left out — in react mode the author composes layout with
-// real HTML + Tailwind, not our schema-children renderers.
+// real HTML and inline `style` objects, not our schema-children renderers (and
+// not Tailwind classes — see the styling note in this file's header).
 //
 // Lazily-registered blocks (`object-kanban`, `object-map`, `markdown`, … — see
 // apps/console/src/main.tsx) are in here too: `getPublicConfigs()` resolves

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -613,11 +613,25 @@ export interface PageNodeSchema extends BaseSchema {
    *
    * Source-authored (`source` carries the body; `regions` is unused) —
    * ADR-0080, see `content/docs/guide/react-pages.md`:
-   * - `"html"`: constrained JSX/HTML + Tailwind, PARSED into a SchemaNode
-   *   tree and rendered. Never executed — safe for untrusted authors.
-   *   `"jsx"` is a deprecated alias, still accepted.
+   * - `"html"`: constrained JSX, PARSED into a SchemaNode tree and
+   *   rendered. Never executed — safe for untrusted authors. Styled with
+   *   the blocks' own structured props (`<flex direction gap>`,
+   *   `<grid columns>`) plus a JSON `style` object. `"jsx"` is a
+   *   deprecated alias, still accepted.
    * - `"react"`: real React, transpiled and EVALUATED in the main tree.
-   *   No sandbox; gated behind the `react-pages` host capability.
+   *   No sandbox; gated behind the `react-pages` host capability. Styled
+   *   with inline `style` objects.
+   *
+   * Colors on both tiers come from the theme as `hsl(var(--token))`.
+   *
+   * Do NOT author Tailwind utility classes in page `source`, on either
+   * tier. `source` is *runtime metadata*: the console's Tailwind is
+   * compiled at build time by scanning the console's own `src`, and there
+   * is no safelist, so it never sees your page — an authored utility class
+   * produces CSS only by coincidence (when objectui already ships that
+   * exact class) and otherwise produces nothing, with no error anywhere.
+   * `os validate` reports it as `page-source-className-tailwind`.
+   * (ADR-0065; ADR-0080's 2026-06-30 amendment.)
    *
    * @default 'full'
    */


### PR DESCRIPTION
Fixes #5461

Three sources still taught the "constrained JSX/HTML + Tailwind" framing that ADR-0080's
2026-06-30 header amendment retracted on styling. One of them ships in a published `.d.ts`
and links the very guide that now says the opposite.

## The authority I matched against — not this PR's own phrasing

Two **landed** sources, cross-checked against each other before a word was written:

1. `content/docs/guide/react-pages.md` §"Styling — page source is metadata, not build
   input", corrected by #5413 / PR #5462 and on `main` as of `688cb93ad`. It carries the
   per-tier table verbatim:

   | `kind` | Style with |
   |---|---|
   | `"react"` | Inline `style={{ … }}`, with `hsl(var(--token))` for colour. |
   | `"html"` | The blocks' own structured props (flex `direction`/`gap`, grid `columns`) plus a JSON `style` object. |

2. `packages/lint/src/validate-page-source-styling.ts` in the framework —
   `validatePageSourceStyling`, rule id `page-source-className-tailwind`, released in
   `@objectstack/lint@11.5.0`. Read directly, not from the card's summary. It gates on
   `kind !== 'html' && kind !== 'react' && kind !== 'jsx' → continue`, emits
   `severity: 'warning'`, and its two hints are the same split as the guide's table:
   react → inline `style={{}}` with `hsl(var(--token))` theme colors; html → the
   components' structured props plus a JSON `style` object.

Both trace to ADR-0080's header amendment (2026-06-30, under **ADR-0065, Accepted**),
which I read at source: *"The tiers themselves stand; only the styling **primitive**
changes ... **Do not author Tailwind classes in page source.**"*

**Citation hygiene, per the card's own warning.** The card flagged that this family's
citation trail had a bad link elsewhere — `validate-responsive-styles.ts` does not read
page `source` at all. Verified: that rule walks `regions[].components[]`, so it is not
cited here. Two further corrections to the trail:

- **objectstack PR #10436 is still an open draft, not landed.** The card and its dependency
  note both say the spec-side `PageSchema` describes "has just" been fixed. As of
  `objectstack@7679f8b54` (2026-08-21 00:13) `packages/spec/src/ui/page.zod.ts:520/560/566`
  still carry `constrained JSX/HTML+Tailwind`. This changes nothing about the defect here —
  the ADR amendment, the released lint rule and the corrected guide are all landed and all
  agree — but the wording in this PR is aligned with that pending PR's shape, so the two
  trees converge rather than diverge when it merges.
- The three-site count is wrong. See the sweep.

## The change

Comment/TSDoc prose only. No behaviour change, no export change, the accepted `kind` set
untouched.

**`packages/types/src/layout.ts`** — the TSDoc on `PageSchema.kind`. This is the
consumer-facing one: it ships in the built `.d.ts` and is what shows on hover. Verified,
not assumed — after `pnpm --filter @object-ui/types build`, the new prose is at
`packages/types/dist/layout.d.ts:582-604`. It now states the per-tier primitive, that
colors on both tiers come from the theme as `hsl(var(--token))`, and the do-not-author
rule with its mechanism and the rule id that reports it.

**`packages/components/src/renderers/layout/react-page.tsx`** — the injected-scope note
(`:24`) and the `buildComponentScope` comment (`:49`), plus the styling note the file
header was missing (inline `style` objects with token colours; overlays through
`ObjectForm` with `formType="drawer"|"modal"` rather than a hand-rolled `fixed inset-0`).

**Every load-bearing claim survives**, which was the card's explicit constraint:

| Claim | Survives |
|---|---|
| `html` is PARSED into a SchemaNode tree, never executed | ✅ verbatim |
| `html` is safe for untrusted authors | ✅ verbatim |
| `'jsx'` is a deprecated alias, still accepted | ✅ verbatim |
| `react` is EVALUATED in the main tree, no sandbox | ✅ verbatim |
| `react` gated behind the `react-pages` host capability | ✅ verbatim |
| ADR-0080 citation + the link to `react-pages.md` | ✅ verbatim |
| **"layout containers are deliberately not injected"** | ✅ verbatim — only the "so use Tailwind" conclusion is replaced |

`content/docs/guide/react-pages.md` is **not** touched: it is already correct as of PR #5462.

## Sweep — the card's "three" is not the complete set

The card measured with `grep -rn "HTML + Tailwind" packages/ apps/ content/` → 3 hits. That
single-line, single-spelling probe misses three classes: the no-space spelling
`HTML+Tailwind`, the `JSX/Tailwind` spelling that drops "HTML", and any occurrence wrapped
across a line boundary. A multiline-tolerant sweep for every compound spelling, run at the
merge base `9bd753682`:

```
grep -rnP -U -z -o --include='*.ts' --include='*.tsx' --include='*.md' --include='*.mdx' \
  --include='*.json' --include='*.js' --include='*.mjs' --include='*.css' \
  '(JSX|HTML|html|jsx)\s*[/+]\s*(\*|>|//|\n|\r|\s)*\s*Tailwind' .
```

**11 live sites, not 3** (plus 5 in `CHANGELOG.md` files — immutable release history, left
alone). Three are this PR's; the other 8 are outside the declared file surface, so per the
dispatch's stop-on-breach clause they are filed, not fixed:

- **Filed as #5469** — the 8 remaining prose sites. Two are high-reach:
  `packages/components/src/renderers/layout/page.tsx:541` sits on the `kind === 'html'`
  dispatch arm itself, and `packages/react-runtime/README.md:17-18` is a **published npm
  README** — and it is the one the card's grep could never have seen, because the exact
  phrase wraps across a blockquote line boundary.
- **Filed as #5470** — a different and worse class: the three console SDUI preview
  harnesses do not merely *describe* the retracted framing, they *demonstrate* it. 79
  Tailwind `className` attributes inside real page `source` strings, working only because
  each file's own header arranges for the console's build-time Tailwind to scan it — the
  ADR-0065 "works only by coincidence" failure, stated as the mechanism. All three would
  trip `page-source-className-tailwind`.

### Counter-probe

The sweep's zeros are real zeros, not a broken search — each probed with the identical
grep invocation:

| Claimed zero | Control phrase, same `grep -rnP -U -z -o` | Hits |
|---|---|---|
| no compound framing in `scripts/` | `Tailwind` | 19 |
| no compound framing in `skills/` | `Tailwind` | 39 |
| no compound framing in `docs/` | `Tailwind` | 2 |
| no compound framing in `examples/` | `Tailwind` | 10 |
| no compound framing in `e2e/` | `Tailwind` returns 0 there too, so probed with `expect` | 290 |
| **post-fix**: no compound framing left in this PR's two files | `Tailwind` in those same two files | 7 |

The last row is the one that matters for this PR: the compound spelling is gone from both
files (0 hits) while the same command still finds 7 bare `Tailwind` mentions in them, so
the zero is the edit's, not the probe's.

## Verification

All commands below on the final commit `7d2391fde`, exit codes captured before any pipe.

```
pnpm --filter @object-ui/types build                        BUILD_EXIT=0
pnpm --filter '@object-ui/components^...' build             DEPBUILD_EXIT=0   (dependency closure first)
pnpm exec vitest run packages/components/                   TEST_EXIT=0
    Test Files  171 passed (171)
    Tests       1560 passed (1560)
pnpm --filter @object-ui/types --filter @object-ui/components type-check
    packages/types type-check: Done      (tsc --noEmit && tsconfig.examples.json && tsconfig.test.json)
    packages/components type-check: Done (tsc --noEmit && tsconfig.test.json)
    TC_EXIT=0
```

The test run is from the repo root with no `--`, per this repo's vitest guard (objectui#3288 /
#3378) — the package-scoped `pnpm --filter … test -- --maxWorkers=2` form is refused here,
and the refusal is correct.

Gates re-derived from the actual diff and re-run on the final commit:

```
check-control-bytes.mjs        EXIT=0
check-changeset-presence.mjs   EXIT=0
check-changeset-no-major.mjs   EXIT=0
check-changeset-fixed.mjs      EXIT=0
eslint packages/types/src/layout.ts                                     EXIT=0
eslint packages/components/src/renderers/layout/react-page.tsx          EXIT=0  (6 pre-existing `any` warnings, all on untouched lines)
```

Control-byte self-scan beyond the gate, on all three changed files:
`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → no match.

## Changeset

One entry, `@object-ui/types` **patch** — consumer-visible, and evidenced rather than
asserted: the new TSDoc is present in the built `packages/types/dist/layout.d.ts`, which is
what a consumer's editor reads on hover. Scored `patch`, never `major` (AGENTS.md §版本号策略).

The `react-page.tsx` half gets **no entry of its own**: file-header and internal function
comments project into no `.d.ts` and change no export, so there is nothing an
`@object-ui/components` consumer could read in a CHANGELOG and act on. It is named in the
changeset body rather than left silent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_