### PR TITLE
fix(components): the static `table` renderer reads only the declared `TableColumn` contract, and §TableSchema is corrected to match

### DIFF
--- a/.changeset/table-renderer-declared-column-contract-5350.md
+++ b/.changeset/table-renderer-declared-column-contract-5350.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/components': minor
+---
+
+The static `table` renderer reads only the declared `TableColumn` contract, and its published reference page teaches that spelling.
+
+`renderers/complex/table.tsx` resolved a heading as `col.header || col.label` and a
+cell as `row[col.accessorKey || col.name]`. Neither `label` nor `name` is declared
+on `TableColumn`, which declares `header` and `accessorKey` — both required
+(`packages/types/src/data-display.ts`). This was the fourth site of the
+column-alias family, after `data-table`, `ObjectDataTable` and `ObjectGrid`
+(objectui#5350).
+
+Both aliases are retired. The ruling recorded on objectui#5120 (2026-08-20) is the
+family direction — *retire the consumer-side alias; unify the producers* — and it
+names this site: the declared `header`/`accessorKey` contract wins.
+
+What makes this site different from its three siblings is that the alias was not
+merely tolerated, it was **published**. `content/docs/api/schema-reference.md`
+§TableSchema shipped a copyable `{ "name": "id", "label": "#" }` example and a
+property row reading *"Column definitions with `name`, `label`, …"*, while
+`packages/types` declared the opposite pair. Docs and type disagreed about one
+type they both call `TableColumn`, each internally consistent. Retiring the alias
+without correcting the page would have turned a documented, working example into a
+silently broken one, so both halves land together: the page now authors
+`accessorKey`/`header`. The same row also advertised a `render` property that
+`TableColumn` has never declared — the renderer's hook is `cell` — and that claim
+is dropped rather than re-spelled.
+
+The failure mode of a now-unresolvable column is worth stating, because it is
+quiet: the column keeps its slot and its neighbours are unaffected, the header or
+the cells simply render empty, and nothing throws. This renderer keys its cells by
+index rather than by accessor, so unlike `data-table` it does not even produce
+React's generic missing-key warning — a retired-spelling column is fully silent.
+Whether that silence should become an authoring diagnostic is objectui#5349's
+question; no diagnostic is added here.
+
+The two `columns.map` callbacks are typed `TableColumn` instead of `any`, so
+re-introducing an undeclared alias on this renderer is now a type error rather
+than a reviewer's catch.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -400,10 +400,10 @@ A data table with columns, optional striping, and hover effects.
   "hoverable": true,
   "striped": true,
   "columns": [
-    { "name": "id", "label": "#", "width": 60 },
-    { "name": "customer", "label": "Customer" },
-    { "name": "amount", "label": "Amount", "align": "right" },
-    { "name": "status", "label": "Status" }
+    { "accessorKey": "id", "header": "#", "width": 60 },
+    { "accessorKey": "customer", "header": "Customer" },
+    { "accessorKey": "amount", "header": "Amount" },
+    { "accessorKey": "status", "header": "Status" }
   ],
   "data": [
     { "id": 1, "customer": "Acme Corp", "amount": "$1,200", "status": "Paid" },
@@ -416,7 +416,7 @@ A data table with columns, optional striping, and hover effects.
 | Property | Type | Description |
 |----------|------|-------------|
 | `caption` | `string` | Table caption / title text. |
-| `columns` | `TableColumn[]` | Column definitions with `name`, `label`, `width`, `align`, `sortable`, `render`. |
+| `columns` | `TableColumn[]` | Column definitions. `accessorKey` (the row key to read) and `header` (heading text) are required; `width`, `className`, and `cellClassName` are honoured by this renderer. |
 | `data` | `any[]` | Array of row data objects. |
 | `footer` | `SchemaNode \| string` | Footer content below the table. |
 | `hoverable` | `boolean` | Highlight rows on hover. |

--- a/packages/components/src/renderers/complex/__tests__/table-column-contract.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/table-column-contract.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5350 — the static `table` renderer reads ONLY the declared
+ * `TableColumn` contract (`header` + `accessorKey`).
+ *
+ * This is the fourth site of the column-alias family ruled on #5120
+ * (2026-08-20): "retire the consumer-side alias; unify the producers ...
+ * declared `header`/`accessorKey` contract wins". Before that ruling this
+ * renderer resolved a header as `col.header || col.label` and a cell as
+ * `row[col.accessorKey || col.name]` — two undeclared aliases that
+ * `packages/types/src/data-display.ts` never declared.
+ *
+ * The `name`/`label` assertions below are the ones that must FAIL before the
+ * retirement and pass after it; the `header`/`accessorKey` assertions pin the
+ * behaviour the retirement must NOT move.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Module-scope side-effect import, not a `beforeAll` — see
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../../index';
+
+const ROWS = [{ name: 'Ada', role: 'Engineer' }];
+
+const renderTable = (columns: unknown[]) =>
+  render(<SchemaRenderer schema={{ type: 'table', columns, data: ROWS } as never} />);
+
+describe('`table` resolves columns through the declared TableColumn contract only', () => {
+  it('renders a column authored the declared way (header + accessorKey)', () => {
+    const { container } = renderTable([
+      { header: 'Name', accessorKey: 'name' },
+      { header: 'Role', accessorKey: 'role' },
+    ]);
+
+    expect([...container.querySelectorAll('thead th')].map((e) => e.textContent)).toEqual([
+      'Name',
+      'Role',
+    ]);
+    expect([...container.querySelectorAll('tbody td')].map((e) => e.textContent)).toEqual([
+      'Ada',
+      'Engineer',
+    ]);
+  });
+
+  it('does NOT resolve a cell through the retired `name` alias', () => {
+    const { container } = renderTable([{ header: 'Name', name: 'name' }]);
+
+    // The header is declared, so it still renders...
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    // ...but `name` is not an accessor: the cell resolves to nothing.
+    expect([...container.querySelectorAll('tbody td')].map((e) => e.textContent)).toEqual(['']);
+    expect(screen.queryByText('Ada')).not.toBeInTheDocument();
+  });
+
+  it('does NOT resolve a header through the retired `label` alias', () => {
+    const { container } = renderTable([{ label: 'Name', accessorKey: 'name' }]);
+
+    // `accessorKey` is declared, so the cell still renders...
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    // ...but `label` is not a header: the heading resolves to nothing.
+    expect([...container.querySelectorAll('thead th')].map((e) => e.textContent)).toEqual(['']);
+    expect(screen.queryByText('Name')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for a fully alias-spelled column (the retired docs spelling)', () => {
+    // Exactly the shape `content/docs/api/schema-reference.md` §TableSchema
+    // published before this change: `{ name, label }`.
+    const { container } = renderTable([{ name: 'name', label: 'Name' }]);
+
+    expect([...container.querySelectorAll('thead th')].map((e) => e.textContent)).toEqual(['']);
+    expect([...container.querySelectorAll('tbody td')].map((e) => e.textContent)).toEqual(['']);
+  });
+
+  it('legibility: an unresolvable column is kept, not dropped, and does not throw', () => {
+    // Pinned as measured behaviour, NOT endorsed: the column keeps its slot and
+    // its neighbour is unaffected. Unlike `data-table` (which keys cells by
+    // `accessorKey` and so emits React's generic missing-key warning), this
+    // renderer keys by index, so a retired-spelling column is fully SILENT.
+    // Whether that silence should become a diagnostic is #5349's question, not
+    // this card's — no diagnostic is implemented here.
+    const { container } = renderTable([
+      { name: 'name', label: 'Name' },
+      { header: 'Role', accessorKey: 'role' },
+    ]);
+
+    expect(container.querySelectorAll('thead th')).toHaveLength(2);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(2);
+    expect(screen.getByText('Role')).toBeInTheDocument();
+    expect(screen.getByText('Engineer')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/complex/table.tsx
+++ b/packages/components/src/renderers/complex/table.tsx
@@ -8,7 +8,7 @@
 
 // table.tsx implementation
 import { ComponentRegistry } from '@object-ui/core';
-import type { TableSchema } from '@object-ui/types';
+import type { TableColumn, TableSchema } from '@object-ui/types';
 import { renderChildren } from '../../lib/utils';
 import { 
   Table, 
@@ -28,9 +28,9 @@ ComponentRegistry.register('table',
       {schema.caption && <TableCaption>{schema.caption}</TableCaption>}
       <TableHeader>
         <TableRow>
-          {schema.columns?.map((col: any, index: number) => (
+          {schema.columns?.map((col: TableColumn, index: number) => (
             <TableHead key={index} className={col.className} style={{ width: col.width }}>
-                {col.header || col.label}
+                {col.header}
             </TableHead>
           ))}
         </TableRow>
@@ -38,9 +38,9 @@ ComponentRegistry.register('table',
       <TableBody>
         {schema.data?.map((row: any, rowIndex: number) => (
           <TableRow key={rowIndex}>
-            {schema.columns?.map((col: any, colIndex: number) => (
+            {schema.columns?.map((col: TableColumn, colIndex: number) => (
                 <TableCell key={colIndex} className={col.cellClassName}>
-                    {row[col.accessorKey || col.name]}
+                    {row[col.accessorKey]}
                 </TableCell>
             ))}
           </TableRow>


### PR DESCRIPTION
Fixes #5350

The static `table` renderer was the **fourth site** of the undeclared column-alias family. It resolved a heading as `col.header || col.label` and a cell as `row[col.accessorKey || col.name]`, while `packages/types/src/data-display.ts` declares `TableColumn` with required `header` and `accessorKey` and neither alias. Both aliases are retired here, and the published reference page that contradicted the type is corrected in the same PR.

## The ruling this applies, verbatim

Recorded on #5120, 2026-08-20 — maintainer accepted the batch verbatim: 「其他接受你的建议。」

> **Ruled: retire the consumer-side alias; unify the producers** — the #3951 direction for the whole family.
>
> 3. This ruling is the **family direction** for the satellites: **#5350** (fourth site, static `table` renderer — its docs-vs-types contradiction resolves the same way: the declared `header`/`accessorKey` contract wins, `schema-reference.md` §TableSchema corrects to match) and **#5351** (`label`→`header`: the producer maps the spec's `ListColumnSchema.label` to `header` at delivery — metadata vocabulary stays out of the adapter).

Triage's unlock note on #5350 applies the same words to this card: *"`packages/types`' declared contract stands; `schema-reference.md` §TableSchema corrects to match."*

## Both halves, one PR

This site is not a mechanical follow-on of its three siblings, and that is the whole point: the alias here was not merely tolerated, it was **published**. §TableSchema shipped a copyable `{ "name": "id", "label": "#" }` example plus a property row reading *"Column definitions with `name`, `label`, …"*. Retiring the alias without correcting the page would have converted a documented, working example into a silently broken one.

- `packages/components/src/renderers/complex/table.tsx` — `col.header || col.label` becomes `col.header`; `row[col.accessorKey || col.name]` becomes `row[col.accessorKey]`.
- `content/docs/api/schema-reference.md` §TableSchema — the example authors `accessorKey`/`header`; the property row states the declared contract.

## Per-shape before/after, measured by rendering

Measured with a temporary probe that renders each shape through `SchemaRenderer` and reads back the actual `thead`/`tbody` text, run on both legs. Row data is `{ name: 'Ada', role: 'Engineer' }`. The probe was removed before commit; the same shapes are pinned permanently in `table-column-contract.test.tsx`.

| authored column | headers BEFORE | cells BEFORE | headers AFTER | cells AFTER | moved |
|---|---|---|---|---|---|
| `{ accessorKey }` | `""` | `Ada` | `""` | `Ada` | no |
| `{ name }` | `""` | `Ada` | `""` | `""` | **cells** |
| `{ header, accessorKey }` | `Name` | `Ada` | `Name` | `Ada` | no |
| `{ label, accessorKey }` | `Name` | `Ada` | `""` | `Ada` | **headers** |
| `{ name, label }` — the retired docs spelling | `Name` | `Ada` | `""` | `""` | **both** |
| `{ label, accessorKey }` — the skills-guide spelling | `Name` | `Ada` | `""` | `Ada` | **headers** |

The two shapes that move nothing are exactly the two spelled the declared way. Legibility of a now-unresolvable column, pinned as measured behaviour rather than endorsed: the column keeps its slot, neighbours are unaffected, nothing throws, and because this renderer keys cells by **index** rather than by accessor it does not even emit React's generic missing-key warning that `data-table` produces. It is fully silent. Whether that should become a diagnostic is #5349's question; none is implemented here.

## Census, with its counter-probe

**Question**: every authored `type: "table"` column using the `name`/`label` spelling, across docs, skills, examples, fixtures, catalogs, apps, e2e and package READMEs.

Two independent methods over the same corpus (4174 files: `content/docs`, `skills`, `examples`, `apps`, `e2e`, `packages`):

1. Locate all 70 `type: "table"` occurrences repo-wide, then read each one's `columns`.
2. Bracket-match every `columns:` array in the corpus (194 found), classify each by spelling and by the nearest enclosing `type`.

Both agree. Exactly **four** `columns` arrays sit on a `type: "table"` node and carry `name` or `label`:

| site | verdict |
|---|---|
| `content/docs/api/schema-reference.md:402` §TableSchema | **the defect — corrected in this PR** |
| `skills/objectui/guides/schema-expressions.md:500` | **real blast radius — reported, not migrated** (below) |
| `content/docs/api/schema-reference.md:1131` §DetailViewSchema `related[]` | **excluded**: not this renderer |
| `content/docs/core/report-schema.mdx:327` | **excluded**: not this renderer |

The two exclusions are textual near-misses on a different declared contract, and both were checked by reading the render path rather than the spelling:

- §DetailViewSchema `related[]` is a related-list descriptor (`api`-backed). `DetailView.tsx:1526-1533` forwards `related.columns` into a RelatedList component, never the component-registry `table` key. `packages/plugin-detail/README.md` authors the same array as bare strings.
- `report-schema.mdx:327` is a report **section**, rendered by `ReportViewer.tsx:345`, which emits its own markup reading `col.label || col.name` against `ReportField` — and `packages/types/src/reports.ts:57-66` **declares** `name` and `label` on `ReportField`. It is correctly spelled for its own contract. This refines the premise in #5350's body, which cited it as evidence of the same defect; it is not.

**Counter-probe.** The zero-beyond-the-known-docs claim is only meaningful if the same method can see the spelling that is present, so the run reports both buckets. Method 2 found **39** column arrays spelled the declared `header`/`accessorKey` way in the same pass, **six of them on `type: "table"` nodes**: `apps/site/app/playground/page.tsx:751`, `examples/schema-catalog/src/schemas/components-complex-table/basic-table.json:3`, `packages/plugin-dashboard/README.md:496`, `packages/types/examples/data-display-examples.json:70`, `packages/plugin-dashboard/src/__tests__/StaticTableWidget.test.tsx:131`, and this renderer's own `defaultProps`. So the method demonstrably finds `table`-enclosed column arrays and reads their spelling correctly, and the alias bucket was non-empty in the same run. `e2e/` holds no `type: "table"` node at all; the catalog holds exactly one, already declared-spelled.

### Blast radius — reported, not migrated

`skills/objectui/guides/schema-expressions.md` depends on both retired aliases: its prose at L493 documents the accessor fallback as contract (*"`accessorKey`, falling back to `name`"*), and its worked example at L500 authors `{ "label": "Name", "accessorKey": "name" }`, which renders an empty heading after this change. `skills/**` is a governed, customer-published surface outside this card's declared file surface, so it is **filed as #5473** rather than silently migrated. Sequencing is triage's call.

## Scope fences held

- ⛔ Untouched: `data-table.tsx`, `ObjectDataTable.tsx`, `ObjectGrid.tsx` and the `object-grid` doc examples — **#5120+#5351 is in flight** on those.
- ⛔ The `type: "crud"` examples in the same file spell `name`/`label` too and are **not** touched. Checked against **#5373** before deciding, as instructed: its maintainer ruling (2026-08-20) is *"retire `CRUDSchema` under ADR-0049 enforce-or-remove … delete all four declaration faces, rewrite `api/schema-reference.md` around shapes that render"*. That section is scheduled for **deletion**, not re-spelling, and `crud` has no renderer at all — so re-spelling its columns would be work that gets deleted and a collision in the one file both cards edit. Left alone deliberately.

## One bounded in-place fix, named rather than slipped in

The §TableSchema property row also advertised a **`render`** property. `TableColumn` has never declared one — the renderer hook is `cell` (`data-display.ts:277`). Correcting `name`/`label` in that sentence while leaving `render` standing would have republished a false claim in a line already being rewritten, so the row now states only what is both declared and honoured here: `accessorKey`, `header`, `width`, `className`, `cellClassName`. For the same reason `"align": "right"` is dropped from the example — `align` **is** declared on `TableColumn`, but this renderer never reads it, so keeping it would have contradicted the corrected sentence one line below.

`align` is not alone in that, and the broader gap is **not** fixed here: 11 of the 20 keys `TableSchema`/`TableColumn` declare are inert on this renderer, including `hoverable` and `striped`, which the page documents as working and which the example still sets. That is an ADR-0049 enforce-or-remove decision rather than a re-spelling, so it is **filed as #5474** and the example keeps them.

Finally, the two `columns.map` callbacks are typed `TableColumn` instead of `any`, so reintroducing an undeclared alias on this renderer is now a type error rather than a reviewer's catch.

## Verification

All at final commit `455bbec9c`, the tree this PR ships.

- **New**: `packages/components/src/renderers/complex/__tests__/table-column-contract.test.tsx` — 5 tests, all passing.
- **Package suite**, from the repo root (a package-scoped run uses a different config than CI): `pnpm exec vitest run packages/components --maxWorkers=2` -> `Test Files 172 passed (172) / Tests 1565 passed (1565)`.
- **Pinning**: the pre-existing `shadowed-renderer-behaviour.test.tsx` authors its columns the declared way and stays green — behaviour the retirement must not move, and does not.
- **Typecheck**: `pnpm --filter @object-ui/components type-check` -> exit 0, after `pnpm build` (43/43 tasks). The run echoes `tsc --noEmit && tsc -p tsconfig.test.json`, so this is a real pass and not a zero-match filter exiting 0.
- **Gates derived from the diff**: `check-control-bytes` OK (4526 files), `check-doc-component-types` OK, `check-doc-links` OK, `check-changeset-presence` / `check-changeset-no-major` / `check-changeset-fixed` OK, and `check-doc-snippet-types` OK — *"Semantic phase: 88 of 88 block(s) judged, 0 failed"* (it hard-fails on an unbuilt workspace, so the build above is a precondition, not an optimisation).

### Reverse verification

Prediction was recorded before the run. **No build artifact sits between the edit and the test**: `vitest.config.mts:264` aliases `@object-ui/components` to `packages/components/src`, so both legs transform source and neither leg needs a rebuild — checked, not assumed.

Ablating the fix (`git checkout origin/main -- table.tsx`, tests kept) was predicted to flip `name`-only cells back to `Ada`, `label`-bearing headers back to `Name`, and to turn exactly **3** of the 5 new tests red — the three alias assertions — leaving the declared-spelling test and the legibility test green, since the latter asserts only slot counts and its neighbour column.

Observed: `Tests 3 failed | 3 passed (6)` (6 = 5 contract tests + the probe), the three failures being precisely `does NOT resolve a cell through the retired name alias`, `does NOT resolve a header through the retired label alias`, and `renders nothing for a fully alias-spelled column`. Every shape in the matrix flipped as predicted. **Predicted and observed match exactly.**

The tree was then restored with `git checkout HEAD -- table.tsx` and proven clean: `git status --short` empty, `git diff --stat HEAD` empty, and both retired lines confirmed back to their post-fix bytes.

## Changeset

`.changeset/table-renderer-declared-column-contract-5350.md`, `@object-ui/components: minor` — declared as the behaviour change it is, including the silent failure mode of a retired-spelling column.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_