### PR TITLE
Studio's 新建对象 asks for the record-sharing baseline, and an unauthored one is reported before Publish instead of by it

### DIFF
--- a/.changeset/studio-new-object-asks-for-owd-5418.md
+++ b/.changeset/studio-new-object-asks-for-owd-5418.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/i18n': minor
+---
+
+Studio's `新建对象` asks for the record-sharing baseline, and an unauthored one is reported before Publish rather than by it.
+
+Creating an object through Studio collected exactly two things — display name and
+identifier — and saved a draft that declared no `sharingModel`. The draft saved
+happily, the form designer worked, and the object was then refused at 发布 →
+全部发布 by `security-owd-unset`: a required decision the surface never asked
+for, delivered by failing, as English ADR prose in a toast that then vanished on
+a timer. The one actionable word in it named a control three clicks away that
+nothing routed to.
+
+The publish gate is correct and is unchanged — an org-wide default has to be an
+authored decision, not an accident. What changes is when the console asks and
+when it answers:
+
+- **The create dialog asks.** A third field collects the baseline, pre-selected
+  to `private` and glossed with the Settings tab's own strings, so a new object
+  is publishable by construction. `buildObjectSkeleton` now takes the value as a
+  required parameter — a future create path cannot omit the baseline without
+  failing to type-check. `controlled_by_parent` is deliberately not offered at
+  creation: it derives access from a master relation a brand-new object does not
+  have yet, so offering it would trade one publish refusal for another.
+- **The review sheet reports it.** The pending-changes panel now runs the
+  framework's own `validateSecurityPosture` over the pending object drafts and
+  names any blocking finding, with its fix-it hint, next to the Publish button.
+  It mirrors the producer's rule rather than re-deriving it, and it reports
+  without blocking — the server door stays the authority.
+- **The Settings tab stops calling an unset baseline safe.** It described unset
+  as "defaults to Private", which answers what the runtime does and not whether
+  the object can ship. It now reads as the publish-blocking problem it is,
+  styled like the external-wider warning beside it.

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -22,7 +22,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { ChevronDown, ChevronRight, FilePlus2, FilePen, Loader2, Rocket } from 'lucide-react';
+import { ChevronDown, ChevronRight, FilePlus2, FilePen, Loader2, Rocket, ShieldAlert } from 'lucide-react';
 import {
   Badge,
   Button,
@@ -50,6 +50,7 @@ import { useObjectTranslation } from '@object-ui/i18n';
 // refuses, and a faithful copy is exactly the fork that guard exists to prevent.
 import { canonicalMetaUrlType } from '@objectstack/spec/shared';
 import { diffFields } from '../views/metadata-admin/previews/object-fields-io.js';
+import { lintDraftSecurityPosture, type DraftSecurityProblem } from './securityPostureLint.js';
 
 export interface DraftChangeEntry {
   /**
@@ -321,6 +322,13 @@ export function DraftChangesPanel({
   const { t } = useObjectTranslation();
   const [entries, setEntries] = useState<DraftChangeEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  /**
+   * Author-time security findings that the publish door would REFUSE
+   * (objectui#5418). Surfaced here, next to the button, so the refusal is
+   * something the author reads before committing rather than a toast that
+   * arrives after the batch has already rolled back.
+   */
+  const [problems, setProblems] = useState<DraftSecurityProblem[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   const toggleExpanded = useCallback((key: string) => {
@@ -335,9 +343,24 @@ export function DraftChangesPanel({
   const load = useCallback(async () => {
     setEntries(null);
     setError(null);
+    setProblems([]);
     try {
       const drafts = await listPendingDrafts(packageId);
       setEntries(drafts);
+      // Mirror the publish door's own security-posture rule over these drafts.
+      // Deliberately not awaited with the classification below: a finding is
+      // advisory and must never gate the sheet's ability to render, so its
+      // failure mode is "no findings", exactly like an unavailable lint.
+      void lintDraftSecurityPosture(
+        {
+          getDraft: (type, name, opts) =>
+            fetchItemBody(type, name, {
+              draft: true,
+              packageId: (opts?.packageId as string | undefined) ?? packageId ?? null,
+            }),
+        },
+        drafts,
+      ).then(setProblems, () => setProblems([]));
       // Classify new-vs-update per TYPE: one published-list read covers every
       // draft of that type. A type whose read fails stays unclassified
       // (rendered neutrally) rather than failing the whole panel.
@@ -394,7 +417,10 @@ export function DraftChangesPanel({
             })}
           </SheetDescription>
         </SheetHeader>
-        <div className="mt-4 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 pb-6">
+        <div
+          data-testid="draft-changes-list"
+          className="mt-4 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 pb-6"
+        >
           {error ? (
             <p className="text-sm text-destructive">
               {t('preview.changes.loadFailed', { defaultValue: 'Could not load pending changes:' })}{' '}
@@ -469,6 +495,32 @@ export function DraftChangesPanel({
             ))
           )}
         </div>
+        {problems.length > 0 && !error && (
+          <div
+            data-testid="draft-security-problems"
+            className="mt-auto border-t border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/60 dark:bg-amber-950/30"
+          >
+            <p className="flex items-center gap-1.5 text-xs font-medium text-amber-800 dark:text-amber-300">
+              <ShieldAlert className="h-3.5 w-3.5 shrink-0" />
+              {t('preview.changes.securityBlockTitle', {
+                count: problems.length,
+                defaultValue: 'Publishing will be refused — {{count}} item(s) need a decision first',
+              })}
+            </p>
+            <ul className="mt-1.5 flex flex-col gap-1.5">
+              {problems.map((p) => (
+                <li key={`${p.type}:${p.name}:${p.rule}`} className="text-[11px] leading-5 text-amber-900 dark:text-amber-200">
+                  <span className="font-mono">{p.name}</span> — {p.hint || p.message}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-1.5 text-[11px] text-amber-800/80 dark:text-amber-300/80">
+              {t('preview.changes.securityBlockWhere', {
+                defaultValue: 'Fix it on the object under Settings → Record sharing, then publish again.',
+              })}
+            </p>
+          </div>
+        )}
         {onPublish && (entries?.length ?? 0) > 0 && !error && (
           <div className="mt-auto flex flex-col gap-2 border-t px-4 py-3">
             <p className="text-xs text-muted-foreground">

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -510,7 +510,14 @@ export function DraftChangesPanel({
             <ul className="mt-1.5 flex flex-col gap-1.5">
               {problems.map((p) => (
                 <li key={`${p.type}:${p.name}:${p.rule}`} className="text-[11px] leading-5 text-amber-900 dark:text-amber-200">
-                  <span className="font-mono">{p.name}</span> — {p.hint || p.message}
+                  {/* `type/name`, the way the server's own publish refusal names
+                      the item (`object/crmext_visit: …`) — and, unlike a bare
+                      name, text that cannot collide with the same draft's row in
+                      the list above. */}
+                  <span className="font-mono">
+                    {p.type}/{p.name}
+                  </span>{' '}
+                  — {p.hint || p.message}
                 </li>
               ))}
             </ul>

--- a/packages/app-shell/src/preview/__tests__/DraftChangesPanel.securityProblems.test.tsx
+++ b/packages/app-shell/src/preview/__tests__/DraftChangesPanel.securityProblems.test.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The pending-changes sheet reports what the publish door would refuse —
+ * objectui#5418.
+ *
+ * The card's walk ended at 发布 → 全部发布 with `security-owd-unset`, delivered
+ * as a wall of English ADR prose in a toast that then vanished on a timer. The
+ * finding is correct; the moment was not. This suite pins that the SAME rule is
+ * now answered one click earlier, in the sheet the author is already reading,
+ * and — just as importantly — that it stays silent for a package that is fine
+ * and never takes the Publish button away.
+ *
+ * Driven through the real panel and the real `@objectstack/lint`: a mocked rule
+ * here would pin the wiring and prove nothing about whether the console and the
+ * door agree, which is the whole claim.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Spread the real module and override only the hook: `@object-ui/components`
+// pulls its own `createSafeTranslation` from here for the Dialog close label,
+// so a bare object mock breaks at import time rather than at assert time.
+vi.mock('@object-ui/i18n', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/i18n')>();
+  return {
+    ...mod,
+    useObjectTranslation: () => ({
+      t: (_k: string, o?: { defaultValue?: string; count?: number }) =>
+        (o?.defaultValue ?? _k).replace('{{count}}', String(o?.count ?? '')),
+    }),
+  };
+});
+
+import { DraftChangesPanel } from '../DraftChangesPanel';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** The card's own object: created through `新建对象`, never given an OWD. */
+const OWD_LESS_VISIT = {
+  name: 'crmext_visit',
+  label: '客户拜访',
+  fields: { name: { type: 'text', label: '名称' }, visit_date: { type: 'date', label: '拜访日期' } },
+};
+
+function mockRoutes(draftBody: Record<string, unknown>) {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+    if (url.includes('/_drafts')) {
+      return ok([{ type: 'object', name: 'crmext_visit', packageId: 'com.test.crmext' }]);
+    }
+    if (url.includes('state=draft')) {
+      return ok({ type: 'object', name: 'crmext_visit', item: draftBody });
+    }
+    if (/\/meta\/object(\?|$)/.test(url)) return ok([]); // nothing published yet — a NEW item
+    return { ok: false, status: 404, json: async () => ({}) };
+  }) as unknown as typeof fetch;
+}
+
+const renderPanel = (extra = {}) =>
+  render(<DraftChangesPanel open onOpenChange={() => {}} packageId="com.test.crmext" {...extra} />);
+
+describe('DraftChangesPanel — pre-publish security posture (objectui#5418)', () => {
+  it('names the object whose sharing baseline was never authored', async () => {
+    mockRoutes(OWD_LESS_VISIT);
+    renderPanel({ onPublish: vi.fn() });
+    const block = await screen.findByTestId('draft-security-problems');
+    // The item, addressed the way the server's own refusal addresses it.
+    expect(block.textContent).toContain('object/crmext_visit');
+    // The rule's fix-it HINT, not the ADR paragraph: the actionable half.
+    expect(block.textContent).toMatch(/sharingModel/);
+    // And where to go, which the toast never said.
+    expect(block.textContent).toMatch(/Settings → Record sharing/);
+  });
+
+  it('reports without blocking — the server door stays the authority', async () => {
+    mockRoutes(OWD_LESS_VISIT);
+    const onPublish = vi.fn();
+    renderPanel({ onPublish });
+    await screen.findByTestId('draft-security-problems');
+    // A console that refuses a publish the server would have accepted is the
+    // worse failure: it has no override.
+    expect(screen.getByTestId('draft-changes-publish')).not.toBeDisabled();
+  });
+
+  it('says nothing once the baseline is authored — the shape the create dialog now produces', async () => {
+    mockRoutes({ ...OWD_LESS_VISIT, sharingModel: 'private' });
+    renderPanel({ onPublish: vi.fn() });
+    // Wait on the sheet settling (the entry lands), then assert the absence —
+    // a bare `queryBy` would pass before the async lint had a chance to speak.
+    await waitFor(() => expect(screen.getByTestId('draft-changes-publish')).toBeInTheDocument());
+    await new Promise((r) => setTimeout(r, 150));
+    expect(screen.queryByTestId('draft-security-problems')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
+++ b/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
@@ -9,7 +9,7 @@
 import '@testing-library/jest-dom/vitest';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 vi.mock('@object-ui/i18n', () => ({
   useObjectTranslation: () => ({
@@ -199,7 +199,10 @@ describe('DraftChangesPanel — /meta routes are addressed in the singular', () 
   it('reads the published list of a PLURAL stored type at its singular route', async () => {
     const urls = mockRoutesRecording([{ type: 'objects', name: 'ticket' }]);
     renderPanel();
-    await waitFor(() => expect(screen.getByText('ticket')).toBeInTheDocument());
+    // Scoped to the LIST — see the grouping case below for why.
+    await waitFor(() =>
+      expect(within(screen.getByTestId('draft-changes-list')).getByText('ticket')).toBeInTheDocument(),
+    );
     await waitFor(() => expect(metaRoutes(urls)).toContain('/api/v1/meta/object'));
     expect(metaRoutes(urls).filter((u) => /\/meta\/objects\b/.test(u))).toEqual([]);
   });
@@ -240,7 +243,11 @@ describe('DraftChangesPanel — /meta routes are addressed in the singular', () 
   it('groups and labels the drafts under the canonical singular type', async () => {
     mockRoutesRecording([{ type: 'objects', name: 'ticket' }]);
     renderPanel();
-    await waitFor(() => expect(screen.getByText('ticket')).toBeInTheDocument());
+    // Scoped to the LIST: the sheet's pre-publish problem block (objectui#5418)
+    // names the offending draft too, and this case is about the grouping.
+    await waitFor(() =>
+      expect(within(screen.getByTestId('draft-changes-list')).getByText('ticket')).toBeInTheDocument(),
+    );
     expect(screen.getByRole('heading', { level: 4 }).textContent).toBe('object · 1');
   });
 });

--- a/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
+++ b/packages/app-shell/src/preview/__tests__/DraftChangesPanel.test.tsx
@@ -9,7 +9,7 @@
 import '@testing-library/jest-dom/vitest';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('@object-ui/i18n', () => ({
   useObjectTranslation: () => ({
@@ -199,10 +199,7 @@ describe('DraftChangesPanel — /meta routes are addressed in the singular', () 
   it('reads the published list of a PLURAL stored type at its singular route', async () => {
     const urls = mockRoutesRecording([{ type: 'objects', name: 'ticket' }]);
     renderPanel();
-    // Scoped to the LIST — see the grouping case below for why.
-    await waitFor(() =>
-      expect(within(screen.getByTestId('draft-changes-list')).getByText('ticket')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('ticket')).toBeInTheDocument());
     await waitFor(() => expect(metaRoutes(urls)).toContain('/api/v1/meta/object'));
     expect(metaRoutes(urls).filter((u) => /\/meta\/objects\b/.test(u))).toEqual([]);
   });
@@ -243,11 +240,7 @@ describe('DraftChangesPanel — /meta routes are addressed in the singular', () 
   it('groups and labels the drafts under the canonical singular type', async () => {
     mockRoutesRecording([{ type: 'objects', name: 'ticket' }]);
     renderPanel();
-    // Scoped to the LIST: the sheet's pre-publish problem block (objectui#5418)
-    // names the offending draft too, and this case is about the grouping.
-    await waitFor(() =>
-      expect(within(screen.getByTestId('draft-changes-list')).getByText('ticket')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('ticket')).toBeInTheDocument());
     expect(screen.getByRole('heading', { level: 4 }).textContent).toBe('object · 1');
   });
 });

--- a/packages/app-shell/src/preview/securityPostureLint.test.ts
+++ b/packages/app-shell/src/preview/securityPostureLint.test.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Pre-publish security-posture lint — objectui#5418.
+ *
+ * The card's walk: create an object through Studio's `新建对象`, design its
+ * form, save the draft twice, press 发布 → 全部发布, and only THEN meet
+ * `security-owd-unset`. This module is the half that moves the same rule one
+ * click earlier, into the review sheet.
+ *
+ * Two things need pinning, and they are different claims:
+ *
+ *  1. The pass reports what the door would refuse, and stays silent otherwise
+ *     — driven with an INJECTED rule so the assertions are about this module's
+ *     own plumbing (which drafts it reads, which severities it keeps, how it
+ *     maps a positional finding back to a draft name).
+ *  2. The REAL `@objectstack/lint` behaves as this module assumes when handed
+ *     an objects-only stack. That assumption is load-bearing and invisible:
+ *     the pass deliberately supplies no permissions/positions/apps/books, and
+ *     if some rule read that absence as a violation the sheet would cry wolf
+ *     next to a Publish button. Asserted against the installed package rather
+ *     than reasoned about.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { lintDraftSecurityPosture, type SecurityPostureFinding } from './securityPostureLint';
+
+const draft = (name: string) => ({ type: 'object', name, packageId: 'com.test.crmext' });
+
+/** A client whose `getDraft` serves the given bodies by name. */
+function clientOf(bodies: Record<string, Record<string, unknown>>) {
+  return {
+    getDraft: vi.fn(async (_type: string, name: string) =>
+      // The framework wraps draft reads in `{ type, name, item }`; unwrapping
+      // that envelope is part of what this module is responsible for.
+      name in bodies ? { type: 'object', name, item: bodies[name] } : null,
+    ),
+  };
+}
+
+describe('lintDraftSecurityPosture — plumbing (injected rule)', () => {
+  const owdUnset: SecurityPostureFinding = {
+    severity: 'error',
+    rule: 'security-owd-unset',
+    where: 'object "crmext_visit"',
+    path: 'objects[0].sharingModel',
+    message: 'custom object "crmext_visit" declares no sharingModel (OWD).',
+    hint: "Declare sharingModel explicitly: 'private' (owner + shares; recommended default), …",
+  };
+
+  it('anchors a positional finding back onto the draft that carries it', async () => {
+    const problems = await lintDraftSecurityPosture(
+      clientOf({ crmext_visit: { name: 'crmext_visit', label: '客户拜访' } }),
+      [draft('crmext_visit')],
+      () => [owdUnset],
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0].name).toBe('crmext_visit');
+    expect(problems[0].rule).toBe('security-owd-unset');
+    // The HINT is the actionable half — it is what the sheet renders.
+    expect(problems[0].hint).toContain('sharingModel');
+  });
+
+  it('keeps only blocking findings — advisory severities are not shown beside Publish', async () => {
+    const problems = await lintDraftSecurityPosture(
+      clientOf({ crmext_visit: { name: 'crmext_visit' } }),
+      [draft('crmext_visit')],
+      () => [
+        { ...owdUnset, severity: 'warning', rule: 'security-master-detail-ungranted' },
+        { ...owdUnset, severity: 'info', rule: 'security-private-no-readscope' },
+      ],
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it('passes ONLY object drafts to the rule, in the order it will index them', async () => {
+    const rule = vi.fn((_stack: Record<string, unknown>): SecurityPostureFinding[] => []);
+    await lintDraftSecurityPosture(
+      clientOf({ a: { name: 'a' }, b: { name: 'b' } }),
+      [draft('a'), { type: 'flow', name: 'f', packageId: null }, draft('b')],
+      rule,
+    );
+    expect(rule).toHaveBeenCalledTimes(1);
+    const stack = rule.mock.calls[0][0] as unknown as { objects: Array<{ name: string }> };
+    expect(stack.objects.map((o) => o.name)).toEqual(['a', 'b']);
+  });
+
+  it('skips a draft whose body cannot be read, and still indexes the rest correctly', async () => {
+    // `a` 404s; the surviving object must be `objects[0]`, so a finding on
+    // index 0 must anchor to `b` and never to the draft that was dropped.
+    const problems = await lintDraftSecurityPosture(
+      clientOf({ b: { name: 'b' } }),
+      [draft('a'), draft('b')],
+      () => [{ ...owdUnset, where: 'object "b"', path: 'objects[0].sharingModel' }],
+    );
+    expect(problems.map((p) => p.name)).toEqual(['b']);
+  });
+
+  it('is a no-op when the rule is unavailable — an old lint must not block publish', async () => {
+    const problems = await lintDraftSecurityPosture(
+      clientOf({ crmext_visit: { name: 'crmext_visit' } }),
+      [draft('crmext_visit')],
+      null,
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it('swallows a throwing rule — the lint is advisory and never breaks the sheet', async () => {
+    const problems = await lintDraftSecurityPosture(
+      clientOf({ crmext_visit: { name: 'crmext_visit' } }),
+      [draft('crmext_visit')],
+      () => {
+        throw new Error('rule exploded');
+      },
+    );
+    expect(problems).toEqual([]);
+  });
+});
+
+describe('lintDraftSecurityPosture — against the REAL @objectstack/lint', () => {
+  it('reports the card’s own defect: an object created without an OWD', async () => {
+    const problems = await lintDraftSecurityPosture(
+      clientOf({
+        crmext_visit: {
+          name: 'crmext_visit',
+          label: '客户拜访',
+          fields: { name: { type: 'text', label: '名称' } },
+        },
+      }),
+      [draft('crmext_visit')],
+    );
+    expect(problems.map((p) => p.rule)).toContain('security-owd-unset');
+    expect(problems.find((p) => p.rule === 'security-owd-unset')?.name).toBe('crmext_visit');
+  });
+
+  it('says NOTHING about the same object once the baseline is authored', async () => {
+    // This is the fix the create dialog now performs by construction: the very
+    // same body plus the `sharingModel` the dialog asks for.
+    const problems = await lintDraftSecurityPosture(
+      clientOf({
+        crmext_visit: {
+          name: 'crmext_visit',
+          label: '客户拜访',
+          sharingModel: 'private',
+          fields: { name: { type: 'text', label: '名称' } },
+        },
+      }),
+      [draft('crmext_visit')],
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it('an objects-only stack produces no phantom errors from the collections it omits', async () => {
+    // The counter-probe for this module's central simplification. Every OWD
+    // value the create dialog can produce must come back clean; if handing the
+    // rule a stack with no permissions/positions/apps ever manufactured an
+    // error, the sheet would warn about correct packages.
+    for (const sharingModel of ['private', 'public_read', 'public_read_write']) {
+      const problems = await lintDraftSecurityPosture(
+        clientOf({ ok_obj: { name: 'ok_obj', label: 'Fine', sharingModel, fields: {} } }),
+        [draft('ok_obj')],
+      );
+      expect(problems, `unexpected findings for sharingModel=${sharingModel}`).toEqual([]);
+    }
+  });
+});

--- a/packages/app-shell/src/preview/securityPostureLint.ts
+++ b/packages/app-shell/src/preview/securityPostureLint.ts
@@ -1,0 +1,174 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pre-publish security-posture lint (ADR-0090 D7) — the "fail early, not at
+ * publish" half of objectui#5418.
+ *
+ * The publish door refuses an object whose record-sharing baseline was never
+ * authored (`security-owd-unset`), and it is RIGHT to: the OWD must be a
+ * decision, not an accident. What was wrong was the delivery — nothing between
+ * "create object" and "Publish all" hinted the object was unpublishable, so
+ * the rule was reachable only by failing, as a wall of English ADR prose in a
+ * toast that then disappeared on a timer.
+ *
+ * This module runs the SAME rule the door runs — `validateSecurityPosture`
+ * from `@objectstack/lint`, the framework's own `(stack) => SecurityFinding[]`
+ * function — over the pending drafts, so the review sheet can name the problem
+ * one click BEFORE the publish instead of one click after. It is a mirror of
+ * the producer's rule, never a second implementation of it: a re-derived "is
+ * sharingModel missing" check in the console would be a fork of a security
+ * gate, free to drift from the door it claims to predict.
+ *
+ * ## It reports; it never blocks
+ *
+ * The server door stays the authority. The installed `@objectstack/lint` can
+ * legitimately differ from the version the server enforces, so a finding here
+ * is a warning to act on, not a veto — the Publish button stays live. The
+ * inverse (a console that refuses a publish the server would have accepted) is
+ * the worse failure, because it has no override.
+ *
+ * ## Errors only, and why
+ *
+ * `validateSecurityPosture` spans six collections; this pass hands it only the
+ * object drafts, so rules keyed on permissions/positions/apps/books simply
+ * find nothing to say. Of what remains, only `severity: 'error'` findings are
+ * surfaced: those are the ones that mirror a hard runtime/publish refusal (the
+ * module's own header states this division — `error` rules each mirror an
+ * enforcement point, the rest flag *likely* misconfiguration). A `warning` or
+ * `info` rule decided on a partial stack would be advice computed from
+ * incomplete input, and advice that is sometimes wrong next to a Publish
+ * button is how a real signal gets learned as noise.
+ *
+ * ## Progressive enhancement + dynamic import (both load-bearing)
+ *
+ * Mirrors `capabilityLint.ts`: feature-detect the export, swallow every
+ * failure, no-op against a lint package that lacks it. The `import()` must
+ * stay DYNAMIC — `@objectstack/lint` is the one `@objectstack/*` package the
+ * console's `vendor-objectstack` chunk group does not claim (objectui#5266,
+ * recorded in DraftChangesPanel's own import note), so a static import would
+ * pull the whole lint bundle onto the eager console graph.
+ */
+
+interface PendingDraft {
+  type: string;
+  name: string;
+  packageId: string | null;
+}
+
+/** Shape of `@objectstack/lint`'s `SecurityFinding` (structural, not imported). */
+export interface SecurityPostureFinding {
+  severity: string;
+  /** Diagnostic rule id, e.g. `security-owd-unset`. */
+  rule: string;
+  /** Human-readable location, e.g. `object "crmext_visit"`. */
+  where: string;
+  /** Config path, e.g. `objects[0].sharingModel`. */
+  path: string;
+  message: string;
+  hint?: string;
+}
+
+/** A blocking finding, re-anchored on the draft it belongs to. */
+export interface DraftSecurityProblem {
+  /** Metadata type of the offending draft (always `object` today). */
+  type: string;
+  /** Draft name — what the author clicks in the review sheet. */
+  name: string;
+  rule: string;
+  /** The rule's fix-it hint, which is the actionable half of the finding. */
+  hint: string;
+  message: string;
+}
+
+type SecurityRule = (stack: Record<string, unknown>) => SecurityPostureFinding[];
+
+/** Feature-detect the rule on the installed `@objectstack/lint`. */
+async function loadRule(): Promise<SecurityRule | null> {
+  try {
+    const mod: Record<string, unknown> = await import('@objectstack/lint');
+    return typeof mod?.validateSecurityPosture === 'function'
+      ? (mod.validateSecurityPosture as SecurityRule)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the security-posture rule over the pending OBJECT drafts and return the
+ * blocking problems, keyed back to the draft that carries each one.
+ *
+ * Empty means "clean, or nothing to say" — an unavailable lint, an unreadable
+ * draft and a genuinely clean package are deliberately indistinguishable here,
+ * because all three must leave the publish path untouched.
+ *
+ * @param ruleOverride test seam — inject the rule instead of feature-detecting.
+ */
+export async function lintDraftSecurityPosture(
+  client: {
+    getDraft?: (type: string, name: string, opts?: Record<string, unknown>) => Promise<unknown>;
+  },
+  pending: PendingDraft[],
+  ruleOverride?: SecurityRule | null,
+): Promise<DraftSecurityProblem[]> {
+  try {
+    const rule = ruleOverride !== undefined ? ruleOverride : await loadRule();
+    if (!rule) return [];
+
+    const objects = pending.filter((d) => d.type === 'object');
+    if (objects.length === 0) return [];
+
+    const unwrap = (raw: unknown): Record<string, unknown> | null => {
+      const item = (raw as { item?: unknown })?.item ?? raw;
+      return item && typeof item === 'object' ? (item as Record<string, unknown>) : null;
+    };
+
+    const bodies = await Promise.all(
+      objects.map((d) =>
+        client
+          .getDraft?.(d.type, d.name, d.packageId ? { packageId: d.packageId } : undefined)
+          .then(unwrap)
+          .catch(() => null) ?? Promise.resolve(null),
+      ),
+    );
+
+    // Index-aligned with `bodies`, so a finding's `objects[i]` path maps back
+    // to the draft it came from. The rule reports positionally; carrying the
+    // list is what lets the sheet say WHICH item to go fix.
+    const present: Array<{ draft: PendingDraft; body: Record<string, unknown> }> = [];
+    for (let i = 0; i < bodies.length; i++) {
+      const body = bodies[i];
+      if (body) present.push({ draft: objects[i], body });
+    }
+    if (present.length === 0) return [];
+
+    const findings = rule({ objects: present.map((p) => p.body) });
+    return findings
+      .filter((f) => f && f.severity === 'error')
+      .map((f) => {
+        // Prefer the positional path (`objects[3].sharingModel`); fall back to
+        // matching the rule's `where` against the name when a rule words its
+        // location differently.
+        const idx = Number(/^objects\[(\d+)\]/.exec(f.path ?? '')?.[1] ?? NaN);
+        const hit = Number.isInteger(idx)
+          ? present[idx]
+          : present.find((p) => typeof f.where === 'string' && f.where.includes(String(p.draft.name)));
+        return {
+          type: hit?.draft.type ?? 'object',
+          name: hit?.draft.name ?? '',
+          rule: f.rule,
+          hint: f.hint ?? '',
+          message: f.message ?? '',
+        };
+      })
+      .filter((p) => p.name !== '');
+  } catch {
+    return []; // advisory — never break publish
+  }
+}

--- a/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/createConformance.test.ts
@@ -116,7 +116,7 @@ describe('create-roundtrip conformance: default create output passes spec valida
 // same dead-end family (a minimal shape the spec rejects → create→save 422s).
 describe('Studio inline creators: skeletons pass spec validation', () => {
   const STUDIO_SKELETONS: Array<{ type: string; skeleton: Record<string, unknown> }> = [
-    { type: 'object', skeleton: buildObjectSkeleton('conf_obj', 'Conformance Object', 'Name') },
+    { type: 'object', skeleton: buildObjectSkeleton('conf_obj', 'Conformance Object', 'Name', 'private') },
     { type: 'flow', skeleton: buildFlowSkeleton('conf_flow', 'Conformance Flow', 'Start', 'End') },
     { type: 'app', skeleton: buildAppSkeleton('conf_app', 'Conformance App') },
     {

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -1663,13 +1663,13 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.settings.sharing': 'Record sharing (OWD)',
   'engine.studio.settings.sharingHint': 'Baseline record visibility applied before positions and sharing rules (ADR-0056/0090)',
   'engine.studio.settings.sharingModel': 'Sharing model (sharingModel) — who can see and edit records another user owns',
-  'engine.studio.settings.sharingUnset': '(not set — defaults to Private)',
+  'engine.studio.settings.sharingUnset': '(not set — publishing is refused)',
   'engine.studio.settings.sharingPrivate': 'Private — owner only',
   'engine.studio.settings.sharingPublicRead': 'Public read — everyone reads, only the owner writes',
   'engine.studio.settings.sharingPublicReadWrite': 'Public read/write — everyone reads and writes',
   'engine.studio.settings.sharingControlledByParent': 'Controlled by parent — inherited from the master record',
   'engine.studio.settings.sharingDescUnset':
-    'Not set — the platform defaults to Private (ADR-0090): only the owner can access records. Pick an explicit model to widen visibility.',
+    'Not set — publishing this object is REFUSED (security-owd-unset). The runtime does fall back to Private (ADR-0090 D1), but the baseline has to be an authored decision, not an accident. Pick a model — Private is the same behaviour, chosen on purpose.',
   'engine.studio.settings.sharingDescPrivate':
     'Only the owner (plus users granted via positions or sharing rules) can access a record. Read / Edit permissions then apply to owned records only.',
   'engine.studio.settings.sharingDescPublicRead':
@@ -1757,6 +1757,11 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.data.noObjects': 'No objects yet — create one below to start',
   'engine.studio.data.labelPlaceholder': 'Display name (e.g. Repair Ticket)',
   'engine.studio.data.idPlaceholder': 'Identifier (e.g. repair_ticket)',
+  // [objectui#5418] The create dialog's third field. `新建对象` used to ask for
+  // exactly two things and produce an object the publish door refuses.
+  'engine.studio.data.owdLabel': 'Record sharing (OWD) — who can see records another user owns',
+  'engine.studio.data.owdHint':
+    'Required to publish, and changeable later under Settings → Record sharing. Private matches what the runtime already does when no model is set.',
   'engine.studio.data.newObject': 'New object',
   'engine.studio.data.readOnlyPackage': 'This package is read-only — switch to or create a writable package to add objects',
   'engine.studio.data.firstObjectTitle': 'Start with your first object',
@@ -3462,13 +3467,13 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.settings.sharing': '记录共享模型(OWD)',
   'engine.studio.settings.sharingHint': '在岗位与共享规则之前生效的记录可见性基线(ADR-0056/0090)',
   'engine.studio.settings.sharingModel': '共享模型(sharingModel)—— 谁能查看和编辑他人拥有的记录',
-  'engine.studio.settings.sharingUnset': '(未设置 —— 默认 Private)',
+  'engine.studio.settings.sharingUnset': '(未设置 —— 发布会被拒绝)',
   'engine.studio.settings.sharingPrivate': 'Private 私有 —— 仅记录所有者',
   'engine.studio.settings.sharingPublicRead': 'Public read 公共只读 —— 所有人可读,仅所有者可写',
   'engine.studio.settings.sharingPublicReadWrite': 'Public read/write 公共读写 —— 所有人可读可写',
   'engine.studio.settings.sharingControlledByParent': 'Controlled by parent 受父级控制 —— 继承自主记录',
   'engine.studio.settings.sharingDescUnset':
-    '未设置 —— 平台默认 Private(ADR-0090):仅所有者能访问记录。如需放宽可见性请显式选择模型。',
+    '未设置 —— 该对象无法发布(security-owd-unset)。运行时确实会回落为 Private(ADR-0090 D1),但这条基线必须是显式作出的决定,而不是疏漏。请选择一个模型 —— 选 Private 的行为完全相同,区别在于它是有意选定的。',
   'engine.studio.settings.sharingDescPrivate':
     '只有所有者(以及经岗位或共享规则授予的用户)能访问记录。此时读取 / 编辑权限仅作用于自己拥有的记录。',
   'engine.studio.settings.sharingDescPublicRead':
@@ -3556,6 +3561,10 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.data.noObjects': '还没有对象 — 在下方新建一个开始',
   'engine.studio.data.labelPlaceholder': '显示名(如:报修工单)',
   'engine.studio.data.idPlaceholder': '标识符(如:repair_ticket)',
+  // [objectui#5418] 新建对象对话框的第三项。此前只问两项,产出的对象会被发布门拒绝。
+  'engine.studio.data.owdLabel': '记录共享模型(OWD)—— 谁能看到他人拥有的记录',
+  'engine.studio.data.owdHint':
+    '发布必填,之后可在“设置 → 记录共享模型”中修改。Private 与未设置时运行时的实际行为一致。',
   'engine.studio.data.newObject': '新建对象',
   'engine.studio.data.readOnlyPackage': '此包为只读——请切换到或新建一个可写的包后再添加对象',
   'engine.studio.data.firstObjectTitle': '从第一个对象开始',

--- a/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.test.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.test.tsx
@@ -44,11 +44,32 @@ describe('ObjectSettingsPanel — record sharing (OWD)', () => {
     ).toBeTruthy();
   });
 
-  it('explains that an unset sharing model defaults to private (ADR-0090 D1)', () => {
+  /**
+   * REPLACED, not re-spelled (objectui#5418). This case used to assert the
+   * panel told the author an unset model "defaults to Private" and left it
+   * there — true about the RUNTIME (ADR-0090 D1 fail-closed) and misleading
+   * about the only question being asked at this control, which is whether the
+   * object can ship. It cannot: the publish door refuses an object that
+   * declares no OWD (`security-owd-unset`). The old assertion passed for as
+   * long as the console reassured the author about a state that blocked them.
+   */
+  it('warns that an unset sharing model is REFUSED at publish, not merely defaulted', () => {
     renderPanel(baseDraft);
-    expect(
-      screen.getByText(/defaults to Private \(ADR-0090\)/i),
-    ).toBeTruthy();
+    const desc = screen.getByTestId('owd-internal-desc');
+    expect(desc.textContent).toMatch(/refused/i);
+    expect(desc.textContent).toMatch(/security-owd-unset/);
+    // The runtime fallback is still stated — it is what makes `private` the
+    // safe pick — but as context, not as an all-clear.
+    expect(desc.textContent).toMatch(/Private/);
+    // Styled as a problem, exactly like the D11 external-wider warning.
+    expect(desc.className).toMatch(/amber/);
+  });
+
+  it('drops the warning styling once a baseline is authored', () => {
+    renderPanel({ ...baseDraft, sharingModel: 'private' });
+    const desc = screen.getByTestId('owd-internal-desc');
+    expect(desc.className).not.toMatch(/amber/);
+    expect(desc.textContent).not.toMatch(/refused/i);
   });
 
   it('patches sharingModel when a model is picked', () => {

--- a/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.tsx
@@ -18,8 +18,13 @@
  *     `sharingModel` (private | public_read | public_read_write |
  *     controlled_by_parent). This is the baseline record-level visibility the
  *     runtime applies BEFORE positions and sharing rules. Since ADR-0090 D1
- *     an unset value defaults to `private` (secure default) — the old
- *     fully-public cliff is gone, so leaving it unset is safe.
+ *     an unset value RESOLVES to `private` at runtime (secure default) — the
+ *     old fully-public cliff is gone — but leaving it unset is NOT safe to
+ *     ship: the publish door refuses an object that declares no OWD
+ *     (`security-owd-unset`), because the baseline must be an authored
+ *     decision rather than an accident. Runtime fallback and publishability
+ *     are two different questions, and this comment used to answer only the
+ *     first (objectui#5418).
  *  3. Semantic roles (ADR-0085) — the cross-surface presentation roles:
  *     `nameField`, `stageField` (string | false | unset), `highlightFields`.
  *     These are the ONLY presentation knobs the protocol carries, so the
@@ -180,7 +185,20 @@ export function ObjectSettingsPanel({
               </option>
             </select>
           </label>
-          <p className="text-[11px] text-muted-foreground">
+          {/* An UNSET internal OWD is not a neutral state — the publish door
+              refuses it (`security-owd-unset`). Styled as the problem it is,
+              exactly the way the D11 external-wider violation next to it is
+              (objectui#5418); the two are the same class of "this authoring
+              choice will be rejected at publish" and reading them differently
+              is what let the unset case pass for a safe default. */}
+          <p
+            data-testid="owd-internal-desc"
+            className={
+              sharingModel === ''
+                ? 'text-[11px] text-amber-600 dark:text-amber-500'
+                : 'text-[11px] text-muted-foreground'
+            }
+          >
             {t(sharingDescKey, locale)}
           </p>
           <label className="block">

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.createObjectOwd.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.createObjectOwd.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `新建对象` must ask for the record-sharing baseline — objectui#5418.
+ *
+ * Measured walk on the card: the create dialog collected exactly two fields
+ * (对象名称 / 标识), `buildObjectSkeleton` emitted `{ name, label, fields }`,
+ * and the object was refused at 发布 → 全部发布 by `security-owd-unset`. The
+ * gate is right — an OWD must be an authored decision — so the fix is to ask,
+ * at the one moment the author is thinking about the object.
+ *
+ * This suite drives the REAL `DataPillar` and asserts on the body it hands to
+ * `client.save`, because "the dialog renders a select" is not the claim; the
+ * claim is that the SAVED DRAFT carries an authored baseline.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockClient = {
+  list: vi.fn(async () => []),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async () => ({ effective: null, code: null })),
+  getDraft: vi.fn(async () => null),
+  save: vi.fn(async () => ({})),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({ entries: [] }),
+  };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+import { DataPillar } from './StudioDesignSurface';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(cleanup);
+
+function renderPillar() {
+  return render(
+    <MemoryRouter initialEntries={['/studio/com.test.crmext/data']}>
+      <DataPillar packageId="com.test.crmext" />
+    </MemoryRouter>,
+  );
+}
+
+/** Open the create dialog from the empty-state affordance. */
+async function openCreateDialog() {
+  renderPillar();
+  const opener = await screen.findByTestId('empty-state-new-object');
+  fireEvent.click(opener);
+  return await screen.findByTestId('create-object-owd');
+}
+
+/**
+ * Type a display name and submit. Selected structurally rather than by copy:
+ * this suite is about the saved body, and pinning it to a placeholder string
+ * would make it fail the next time that copy is reworded — in either of the
+ * two locales the Studio catalog carries.
+ */
+function fillAndSubmit(label: string) {
+  const dialog = screen.getByRole('dialog');
+  const inputs = dialog.querySelectorAll('input');
+  // CreateItemDialog renders the display-name field first; the identifier
+  // auto-slugs from it, which is the path a real author walks.
+  fireEvent.change(inputs[0], { target: { value: label } });
+  // By accessible name, NOT by position: DialogContent renders Radix's own
+  // sr-only close button AFTER the footer, so "the last button" is Close and a
+  // positional pick silently dismisses the dialog instead of submitting it.
+  // Matched loosely so the suite survives either of the Studio catalog's two locales.
+  fireEvent.click(within(dialog).getByRole('button', { name: /save as draft|存为草稿/i }));
+}
+
+/** The body `client.save` was called with for the object draft. */
+function savedBody(): Record<string, unknown> {
+  expect(mockClient.save).toHaveBeenCalled();
+  const call = mockClient.save.mock.calls.at(-1) as unknown as [string, string, Record<string, unknown>];
+  return call[2];
+}
+
+describe('新建对象 asks for the OWD (objectui#5418)', () => {
+  it('offers the baseline, defaulted to the platform’s own recommended value', async () => {
+    const select = (await openCreateDialog()) as HTMLSelectElement;
+    expect(select.value).toBe('private');
+  });
+
+  it('offers exactly the three models a brand-new object can author', async () => {
+    // `controlled_by_parent` derives access from a master relation, and a
+    // just-created object has none — offering it would swap the
+    // `security-owd-unset` publish wall for the
+    // `security-controlled-by-parent-no-relation` one. The Settings tab keeps
+    // all four, where the object may since have gained a master-detail field.
+    const select = (await openCreateDialog()) as HTMLSelectElement;
+    const values = [...select.options].map((o) => o.value);
+    expect(values).toEqual(['private', 'public_read', 'public_read_write']);
+    expect(values).not.toContain('controlled_by_parent');
+  });
+
+  it('saves the accepted default as an EXPLICIT baseline on the draft', async () => {
+    await openCreateDialog();
+    fillAndSubmit('Visit');
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled());
+    // The whole point: the key is PRESENT. An absent one is what the publish
+    // door refuses, and "the runtime would have defaulted to private anyway"
+    // is precisely the accident ADR-0090 D1 forbids as a baseline.
+    expect(savedBody()).toHaveProperty('sharingModel', 'private');
+  });
+
+  it('saves a changed choice instead of the default', async () => {
+    const select = await openCreateDialog();
+    fireEvent.change(select, { target: { value: 'public_read' } });
+    fillAndSubmit('Visit');
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled());
+    expect(savedBody()).toHaveProperty('sharingModel', 'public_read');
+  });
+
+  it('saves it as a DRAFT — creation still does not publish anything', async () => {
+    await openCreateDialog();
+    fillAndSubmit('Visit');
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled());
+    const call = mockClient.save.mock.calls.at(-1) as unknown as [string, string, unknown, { mode?: string }];
+    expect(call[3]?.mode).toBe('draft');
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -2010,12 +2010,15 @@ export function DataPillar({
   const [creating, setCreating] = React.useState(false);
   // The OWD the create dialog will author (objectui#5418). Pre-selected to the
   // platform's own recommended baseline; the author sees it and can change it
-  // before the object exists. Reset with each open, mirroring the way
-  // CreateItemDialog resets its own two inputs.
+  // before the object exists. Reset by `openCreateDialog` below rather than by
+  // an effect on `creating` — the effect spelling re-renders the dialog a
+  // second time on every open purely to undo a previous session's pick.
   const [createOwd, setCreateOwd] = React.useState<OwdCreateModel>(OWD_DEFAULT);
-  React.useEffect(() => {
-    if (creating) setCreateOwd(OWD_DEFAULT);
-  }, [creating]);
+  const openCreateDialog = React.useCallback(() => {
+    setError(null);
+    setCreateOwd(OWD_DEFAULT);
+    setCreating(true);
+  }, []);
   const [createBusy, setCreateBusy] = React.useState(false);
   // Whether the selected object exists beyond the draft (published/code baseline).
   // A draft-only object has NO physical table yet (DDL lands at publish), so the
@@ -2451,10 +2454,7 @@ export function DataPillar({
             ) : (
               <button
                 type="button"
-                onClick={() => {
-                  setError(null);
-                  setCreating(true);
-                }}
+                onClick={openCreateDialog}
                 className="inline-flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
               >
                 <Plus className="h-3.5 w-3.5" /> {t('engine.studio.data.newObject', locale)}
@@ -2477,10 +2477,7 @@ export function DataPillar({
                   <button
                     type="button"
                     data-testid="empty-state-new-object"
-                    onClick={() => {
-                      setError(null);
-                      setCreating(true);
-                    }}
+                    onClick={openCreateDialog}
                     className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
                   >
                     <Plus className="h-3.5 w-3.5" /> {t('engine.studio.data.newObject', locale)}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -90,6 +90,7 @@ import { loadPackageSurfaces } from './packageSurfaces.js';
 import { resolveSurface, findSurfaceInTree, type NavNode, type Surface } from './navSurface.js';
 import { useSurfaceDeepLink, resolveSurfaceDeepLink } from './useSurfaceDeepLink.js';
 import { buildObjectSkeleton, buildFlowSkeleton, buildAppSkeleton, buildPermissionSkeleton } from './skeletons.js';
+import { OWD_CREATE_MODELS, OWD_DEFAULT, type OwdCreateModel } from './owd-sharing.js';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n.js';
 import { SuggestedBindingsPanel } from '../../components/SuggestedBindingsPanel.js';
 import { AppNavCanvas } from '../metadata-admin/previews/AppNavCanvas.js';
@@ -122,6 +123,25 @@ import { toast } from 'sonner';
 // threshold (`xl`, not `2xl`) and its matchMedia hook live in ./wideViewport so
 // the rule is testable without mounting this surface; see that module for why
 // 1280 is the right line and what the canvas measures there.
+
+/**
+ * The create dialog's OWD options reuse the SETTINGS tab's own label and gloss
+ * strings verbatim (objectui#5418). The card's complaint was that the Settings
+ * page "is excellent — four options, each with a plain-language gloss" and that
+ * nothing routes the author there; copying the wording rather than writing a
+ * second, shorter one is what keeps the two surfaces from drifting into two
+ * descriptions of one security baseline.
+ */
+const OWD_OPTION_LABEL_KEY: Record<OwdCreateModel, string> = {
+  private: 'engine.studio.settings.sharingPrivate',
+  public_read: 'engine.studio.settings.sharingPublicRead',
+  public_read_write: 'engine.studio.settings.sharingPublicReadWrite',
+};
+const OWD_OPTION_DESC_KEY: Record<OwdCreateModel, string> = {
+  private: 'engine.studio.settings.sharingDescPrivate',
+  public_read: 'engine.studio.settings.sharingDescPublicRead',
+  public_read_write: 'engine.studio.settings.sharingDescPublicReadWrite',
+};
 
 const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> = [
   { key: 'data', label: 'Data', Icon: Database },
@@ -1988,6 +2008,14 @@ export function DataPillar({
   // Left-rail search + inline "new object" creator (design §4: rail = search + New).
   const [query, setQuery] = React.useState('');
   const [creating, setCreating] = React.useState(false);
+  // The OWD the create dialog will author (objectui#5418). Pre-selected to the
+  // platform's own recommended baseline; the author sees it and can change it
+  // before the object exists. Reset with each open, mirroring the way
+  // CreateItemDialog resets its own two inputs.
+  const [createOwd, setCreateOwd] = React.useState<OwdCreateModel>(OWD_DEFAULT);
+  React.useEffect(() => {
+    if (creating) setCreateOwd(OWD_DEFAULT);
+  }, [creating]);
   const [createBusy, setCreateBusy] = React.useState(false);
   // Whether the selected object exists beyond the draft (published/code baseline).
   // A draft-only object has NO physical table yet (DDL lands at publish), so the
@@ -2193,7 +2221,7 @@ export function DataPillar({
   // until the package publish, so we land on 表单·布局 — the metadata-level
   // surface that never fires data SQL.
   const doCreateObject = React.useCallback(
-    async (label: string, rawName: string) => {
+    async (label: string, rawName: string, sharingModel: OwdCreateModel) => {
       if (readOnly) return;
       // Auto-prefix with the package namespace (framework#2694) so a prefix-less
       // object can't be authored; the rule lives in packages-io/spec.
@@ -2205,7 +2233,7 @@ export function DataPillar({
       setCreateBusy(true);
       setError(null);
       try {
-        const body = buildObjectSkeleton(name, label, t('engine.studio.data.nameFieldLabel', locale));
+        const body = buildObjectSkeleton(name, label, t('engine.studio.data.nameFieldLabel', locale), sharingModel);
         await client.save('object', name, body, { mode: 'draft', packageId });
         const surface: Surface = { type: 'object', name, label };
         setObjects((prev) => [...prev, surface]);
@@ -2821,7 +2849,42 @@ export function DataPillar({
         busy={createBusy}
         error={error}
         locale={locale}
-        onSubmit={({ label, name }) => void doCreateObject(label, name)}
+        extra={
+          /* Record sharing (OWD) — the third thing `新建对象` must ask for
+             (objectui#5418). Without it the object saves as a draft happily and
+             is then REFUSED at 发布 → 全部发布 by `security-owd-unset`, a wall
+             the author meets only after building the whole object. The gloss is
+             the SAME string the Settings tab shows for each model, so the two
+             surfaces cannot describe one baseline two ways.
+
+             `controlled_by_parent` is absent on purpose — see OWD_CREATE_MODELS:
+             a just-created object has no master-detail field for it to derive
+             access from. */
+          <label className="block">
+            <span className="mb-1 block text-[11px] text-muted-foreground">
+              {t('engine.studio.data.owdLabel', locale)}
+            </span>
+            <select
+              value={createOwd}
+              data-testid="create-object-owd"
+              onChange={(e) => setCreateOwd(e.target.value as OwdCreateModel)}
+              className="w-full rounded border bg-background px-2 py-1 text-[12px]"
+            >
+              {OWD_CREATE_MODELS.map((m) => (
+                <option key={m} value={m}>
+                  {t(OWD_OPTION_LABEL_KEY[m], locale)}
+                </option>
+              ))}
+            </select>
+            <span className="mt-1 block text-[11px] text-muted-foreground">
+              {t(OWD_OPTION_DESC_KEY[createOwd], locale)}
+            </span>
+            <span className="mt-1 block text-[11px] text-muted-foreground">
+              {t('engine.studio.data.owdHint', locale)}
+            </span>
+          </label>
+        }
+        onSubmit={({ label, name }) => void doCreateObject(label, name, createOwd)}
       />
     </div>
   );

--- a/packages/app-shell/src/views/studio-design/owd-sharing.ts
+++ b/packages/app-shell/src/views/studio-design/owd-sharing.ts
@@ -73,3 +73,37 @@ export function deriveMasterObject(fields: unknown): string | undefined {
   }
   return undefined;
 }
+
+/**
+ * The OWD baseline a BRAND-NEW object starts from, and the models it can
+ * actually choose at creation.
+ *
+ * `OWD_DEFAULT` is `'private'` because that is what the platform itself
+ * treats as the recommended baseline, in two independent places:
+ *   - the framework's own minimal create body seeds `sharingModel: 'private'`
+ *     (`@objectstack/spec` `kernel/metadata-create-seeds.ts`), on the stated
+ *     grounds that the runtime already resolves an absent value to `private`
+ *     (fail-closed, ADR-0090 D1) so making it explicit changes no tenant's
+ *     effective sharing;
+ *   - the `security-owd-unset` rule's own fix-it hint calls `'private'` the
+ *     "recommended default".
+ * It is a PRE-SELECTED, VISIBLE choice on the create form — not a value
+ * written behind the author's back. The ADR's requirement is that the
+ * baseline be authored, and an author who sees the control, reads the gloss
+ * and accepts the default has authored it.
+ *
+ * `OWD_CREATE_MODELS` deliberately OMITS `controlled_by_parent`: it derives
+ * access from a master relation, and a just-created object has no
+ * master-detail field yet, so offering it would trade the `security-owd-unset`
+ * publish wall for the `security-controlled-by-parent-no-relation` one. The
+ * lint's own hint draws the same line — "If the object has no master, its
+ * baseline is its own decision — use sharingModel: 'private' (owner +
+ * shares), 'public_read', or 'public_read_write'." The full four-value set
+ * stays available in the object's Settings tab, where the object may since
+ * have gained the master-detail field that makes the fourth value authorable.
+ */
+export const OWD_DEFAULT: OwdModel = 'private';
+
+/** The OWD values authorable on a just-created object (see `OWD_DEFAULT`). */
+export const OWD_CREATE_MODELS = ['private', 'public_read', 'public_read_write'] as const;
+export type OwdCreateModel = (typeof OWD_CREATE_MODELS)[number];

--- a/packages/app-shell/src/views/studio-design/owd-sharing.ts
+++ b/packages/app-shell/src/views/studio-design/owd-sharing.ts
@@ -102,8 +102,13 @@ export function deriveMasterObject(fields: unknown): string | undefined {
  * stays available in the object's Settings tab, where the object may since
  * have gained the master-detail field that makes the fourth value authorable.
  */
-export const OWD_DEFAULT: OwdModel = 'private';
-
-/** The OWD values authorable on a just-created object (see `OWD_DEFAULT`). */
 export const OWD_CREATE_MODELS = ['private', 'public_read', 'public_read_write'] as const;
 export type OwdCreateModel = (typeof OWD_CREATE_MODELS)[number];
+
+/**
+ * Typed as `OwdCreateModel`, not `OwdModel`: the default has to be a value the
+ * create surface can actually offer. Widening it to the full four-value set
+ * would let a future edit default new objects to `controlled_by_parent`, which
+ * a just-created object has no master relation to derive from.
+ */
+export const OWD_DEFAULT: OwdCreateModel = 'private';

--- a/packages/app-shell/src/views/studio-design/skeletons.ts
+++ b/packages/app-shell/src/views/studio-design/skeletons.ts
@@ -18,10 +18,30 @@
 // Label strings are parameters (the pillars pass localized `t(...)` values); the
 // gate passes any placeholder — the labels don't affect spec validity.
 
-export function buildObjectSkeleton(name: string, label: string, nameFieldLabel: string): Record<string, unknown> {
+import type { OwdCreateModel } from './owd-sharing.js';
+
+/**
+ * A new object's draft body.
+ *
+ * `sharingModel` is a REQUIRED parameter, not an optional one with a default
+ * baked in here. An object with no OWD is refused at the publish door
+ * (`security-owd-unset`, ADR-0090 D1) — the refusal the author used to meet
+ * only after building the whole object — and the spec's own minimal create
+ * body carries the key for exactly that reason. Making it a required
+ * parameter means the value has to come from a create surface that ASKED for
+ * it: a future second create path cannot quietly omit the baseline, because
+ * omitting it does not type-check.
+ */
+export function buildObjectSkeleton(
+  name: string,
+  label: string,
+  nameFieldLabel: string,
+  sharingModel: OwdCreateModel,
+): Record<string, unknown> {
   return {
     name,
     label,
+    sharingModel,
     fields: { name: { type: 'text', label: nameFieldLabel } },
   };
 }

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -3316,6 +3316,11 @@ const ar = {
       detailChangedKeys: 'تغييرات أخرى:',
       confirmNote: 'النشر يُصدر كل المسودات المعلقة ({{count}}) لهذه الحزمة دفعة واحدة.',
       publishConfirm: 'نشر الكل',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: 'سيتم رفض النشر — {{count}} عنصر (عناصر) بحاجة إلى قرار أولاً',
+      securityBlockWhere: 'أصلحه في الكائن ضمن الإعدادات ← مشاركة السجلات، ثم انشر مرة أخرى.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -3309,6 +3309,11 @@ const de = {
       detailChangedKeys: 'Ebenfalls geändert:',
       confirmNote: 'Beim Veröffentlichen werden alle {{count}} ausstehenden Entwürfe dieses Pakets atomar freigegeben.',
       publishConfirm: 'Alle veröffentlichen',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: 'Veröffentlichen wird abgelehnt — {{count}} Element(e) benötigen zuerst eine Entscheidung',
+      securityBlockWhere: 'Korrigieren Sie es am Objekt unter Einstellungen → Datensatzfreigabe und veröffentlichen Sie erneut.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -2781,6 +2781,11 @@ const en = {
       detailChangedKeys: 'Also changed:',
       confirmNote: 'Publishing releases all {{count}} pending drafts of this package atomically.',
       publishConfirm: 'Publish all',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: 'Publishing will be refused — {{count}} item(s) need a decision first',
+      securityBlockWhere: 'Fix it on the object under Settings → Record sharing, then publish again.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -3313,6 +3313,11 @@ const es = {
       detailChangedKeys: 'También cambió:',
       confirmNote: 'Publicar libera atómicamente los {{count}} borradores pendientes de este paquete.',
       publishConfirm: 'Publicar todo',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: 'La publicación será rechazada: {{count}} elemento(s) necesitan una decisión primero',
+      securityBlockWhere: 'Corríjalo en el objeto en Configuración → Uso compartido de registros y vuelva a publicar.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -3311,6 +3311,11 @@ const fr = {
       detailChangedKeys: 'Également modifié :',
       confirmNote: 'La publication libère atomiquement les {{count}} brouillons en attente de ce paquet.',
       publishConfirm: 'Tout publier',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: 'La publication sera refusée — {{count}} élément(s) nécessitent d’abord une décision',
+      securityBlockWhere: 'Corrigez-le sur l’objet dans Paramètres → Partage d’enregistrements, puis publiez à nouveau.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -3309,6 +3309,11 @@ const ja = {
       detailChangedKeys: 'その他の変更：',
       confirmNote: '公開すると、このパッケージの保留中ドラフト {{count}} 件がまとめて（アトミックに）公開されます。',
       publishConfirm: 'すべて公開',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: '公開は拒否されます — {{count}} 件の項目に先に決定が必要です',
+      securityBlockWhere: 'オブジェクトの「設定 → レコード共有」で修正してから、もう一度公開してください。',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -3308,6 +3308,11 @@ const ko = {
       detailChangedKeys: '기타 변경:',
       confirmNote: '게시하면 이 패키지의 대기 중인 초안 {{count}}개가 한 번에(원자적으로) 게시됩니다.',
       publishConfirm: '모두 게시',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: '게시가 거부됩니다 — {{count}}개 항목에 먼저 결정이 필요합니다',
+      securityBlockWhere: '객체의 설정 → 레코드 공유에서 수정한 후 다시 게시하세요.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -3308,6 +3308,11 @@ const pt = {
       detailChangedKeys: 'Também alterado:',
       confirmNote: 'Publicar libera atomicamente todos os {{count}} rascunhos pendentes deste pacote.',
       publishConfirm: 'Publicar tudo',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: 'A publicação será recusada — {{count}} item(ns) precisam de uma decisão primeiro',
+      securityBlockWhere: 'Corrija no objeto em Configurações → Compartilhamento de registros e publique novamente.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -3320,6 +3320,11 @@ const ru = {
       detailChangedKeys: 'Также изменено:',
       confirmNote: 'Публикация атомарно выпускает все {{count}} ожидающих черновиков этого пакета.',
       publishConfirm: 'Опубликовать всё',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: 'Публикация будет отклонена — {{count}} элемент(ов) требуют решения',
+      securityBlockWhere: 'Исправьте это в объекте в разделе «Настройки → Общий доступ к записям» и опубликуйте снова.',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -2615,6 +2615,11 @@ const zh = {
       detailChangedKeys: '其他变更：',
       confirmNote: '发布将一次性（原子地）发布此包全部 {{count}} 个待发布草稿。',
       publishConfirm: '全部发布',
+      // [objectui#5418] Pre-publish security-posture findings, shown next to
+      // the confirm button so a refusal the door would issue is read BEFORE
+      // the click rather than as a toast after the batch rolled back.
+      securityBlockTitle: '发布会被拒绝 —— 有 {{count}} 项需要先做出决定',
+      securityBlockWhere: '请在对象的“设置 → 记录共享模型”中修改后重新发布。',
     },
     // ADR-0045 — the materialized-but-unlisted app banner
     // (UnpublishedAppBar.tsx), sibling of draftBar above.


### PR DESCRIPTION
Fixes #5418

Studio's `新建对象` asked for exactly two things and produced an object the publish
door refuses. The gate is correct and is **unchanged** — an org-wide default has to
be an authored decision. What changes is when the console asks, and when it answers.

## The walk, re-verified on current `main` (9bd753682)

The card was measured on 17.1.0. Every step still reproduces:

| Step | Status on `main` | Evidence |
|---|---|---|
| `新建对象` asks for exactly two fields | reproduces | `CreateItemDialog.tsx` renders two `Input`s plus an unused `extra` slot; the object call site passed no `extra` |
| the saved draft declares no OWD | reproduces | `buildObjectSkeleton` returned `{ name, label, fields }` — zero `sharingModel`, counter-probed against 11 hits in `ObjectSettingsPanel.tsx` |
| publish refuses it | reproduces | `security-owd-unset` still errors for any non-system object with `owd == null` in the framework's `packages/lint/src/validate-security-posture.ts` |
| the refusal is a transient toast | reproduces | `doPublish` → `toast.error(formatPublishFailures(failed))` |
| nothing pre-publish hints at it | reproduces | zero OWD preflight in `app-shell` — the 8 near-hits are the flow simulator, an approval preflight and an i18n column label; counter-probed against 147 `validate` hits in the same tree |

Two things the card did not measure, both of which pin the fix:

- **The framework already does this on its own create path.** `@objectstack/spec`'s
  `kernel/metadata-create-seeds.ts` seeds `sharingModel: 'private'` for `object`,
  reasoning that the runtime already resolves an absent value to `private`
  (fail-closed, ADR-0090 D1) so making it explicit changes no tenant's effective
  sharing. Studio's inline skeleton — which `skeletons.ts` documents as bypassing the
  registry — is the divergence, not the baseline.
- **The Settings tab actively said the opposite of the truth.** Its copy read
  "Not set — the platform defaults to Private (ADR-0090)… Pick an explicit model to
  widen visibility", and its header comment said "leaving it unset is safe". That
  answers what the *runtime* does and not whether the object can *ship*.

## Surface — located by measurement, as instructed

The dispatch warned not to trust `views/metadata-admin/**`. Confirmed: that directory
holds the `engine.studio.*` **i18n table** and nothing else relevant. The create and
publish paths live in the sibling `views/studio-design/`, and the review sheet behind
发布 → 全部发布 is `preview/DraftChangesPanel.tsx`. No package-creation form surface
was touched, so #5416 stays held out.

## The shape chosen, and the ones rejected

The card offered three fixes and said any one closes it. This lands **1 and 2, plus
the wording half of 3**.

**1 — ask in the create dialog.** A third control collects the baseline, pre-selected
to `private`, glossed with the Settings tab's own strings so two surfaces cannot
describe one security baseline two ways. `buildObjectSkeleton` takes the value as a
**required parameter**: a future create path cannot omit the baseline without failing
to type-check.

`controlled_by_parent` is deliberately **not offered at creation** — it derives access
from a master relation a brand-new object does not have, so offering it would trade
the `security-owd-unset` wall for the `security-controlled-by-parent-no-relation` one.
The framework's own hint draws the same line: *"If the object has no master, its
baseline is its own decision — use `sharingModel: 'private'` (owner + shares),
`'public_read'`, or `'public_read_write'`."* The Settings tab keeps all four, where the
object may since have gained the master-detail field.

This is asking, not defaulting around the gate: a visible, labeled, glossed control
pre-set to the value the rule's own hint calls "recommended default". An author who
reads it and accepts it has authored the baseline.

**2 — fail early.** The pending-changes sheet now runs the framework's own
`validateSecurityPosture` over the pending object drafts and names any blocking
finding, with its fix-it hint, beside the Publish button. It **mirrors the producer's
rule rather than re-deriving it** — a console-local "is `sharingModel` missing" check
would be a fork of a security gate, free to drift from the door it predicts. It
**reports without blocking**: the installed lint can legitimately differ from the
version the server enforces, and a console that refuses a publish the server would
accept is the worse failure, because it has no override.

**3 — navigable message: partially.** The block names the item the way the server's own
refusal does (`object/crmext_visit`) and says where the control is. It is **not a live
link**, because `useSurfaceDeepLink` captures its target only at mount, so a
`?surface=` write from an already-mounted pillar moves nothing. Filed as #5476 with the
three candidate routes rather than bolted on here.

**Rejected: shortening the duplicated ADR prose in the toast.** Tempting — the card
names it — but the duplication is producer-side: the failure's `error` string already
contains the text `issues[]` carries. De-duplicating in the consumer is the alias
tolerance Prime Directive #12 forbids. Filed against the producer as
objectstack-ai/objectstack#10524.

**Rejected: seeding `sharingModel` in the skeleton with no UI.** It would make the
error go away and leave the decision unauthored — the manual floor, not this card's.

## Clause ② — yes

This changes what the console **produces**: a `新建对象` draft now carries
`sharingModel`. It does not change what the platform accepts, and no gate was
weakened.

## Reverse-verification

Both legs are source-level within `packages/app-shell` — the tests import the ablated
modules by relative path, not across a package `exports` boundary — so **no `dist`
rebuild is involved**; the only cross-package resolution in play is the unmodified
published `@objectstack/lint`. Direction was predicted before each run.

| Leg | Predicted | Observed |
|---|---|---|
| `buildObjectSkeleton` drops `sharingModel` | 2 failed / 3 passed — only the two body-asserting cases | **exactly that**, asserting on `{ name: 'visit', label: 'Visit', fields }` — the card's original defect shape |
| the sheet stops rendering the problem block | 2 failed / 1 passed, the survivor a **vacuous** pass (it asserts absence) | **exactly that** — which is why the other two exist |

Both restored; `git status` clean at each step.

## Verification

Run on the final commit `f89e0a053`:

- `pnpm exec vitest run packages/app-shell/src/preview/ packages/app-shell/src/views/studio-design/ packages/app-shell/src/views/metadata-admin/ packages/i18n --maxWorkers=2`
  → **273 files, 3056 passed, 1 skipped**. The skip is a pre-existing `it.skipIf`
  version-conditional in `flow-node-config.spec-reconciliation.test.ts`, a file this PR
  does not touch. No test skipped, disabled or quarantined here.
- `type-check` on `@object-ui/app-shell` + `@object-ui/i18n` → both scripts echoed, exit 0.
  It caught a real widening: `OWD_DEFAULT` was typed over all four models while the
  create set has three.
- `lint` → 0 errors. `StudioDesignSurface.tsx` is back at its `origin/main` baseline of
  **16** warnings: the first draft's reset-effect added one
  (`react-hooks/set-state-in-effect`), so the reset moved to an `openCreateDialog`
  callback — better React and no cascading render.
- Gates re-run on the final HEAD: `check:control-bytes`, `check:i18n-keys`,
  `check:i18n-drift`, `check:phantom-deps`, `check:self-import`, `changeset:check` — all pass.
  `check:i18n-keys` confirms both new `defaultValue` strings match their `en` pack
  values and pass exactly the holes those values have; `check:i18n-drift` reports
  "2 keys added, 0 removed, 0 en values changed".

## i18n — a note on "all ten locale packs"

This repo has **two** catalogs, and the dispatch's instruction applies to one of them:

- `preview/DraftChangesPanel.tsx` reads `@object-ui/i18n`, so its two new keys went into
  **all ten packs** (ar, de, en, es, fr, ja, ko, pt, ru, zh).
- The Studio pillars read `views/metadata-admin/i18n.ts`, which is a deliberate
  **two-locale** table (`en-US` | `zh-CN`). `engine.studio.*` appears **0 times** across
  all ten packs — counter-probed, the packs are real and populated — so the
  create-dialog copy follows the existing convention there. Adding it to the ten-pack
  would have been dead weight.

## Not flaky

Adding the block surfaced a latent race: it rendered the bare object name, which
collided with the existing suite's `getByText('ticket')`, resolving on whichever the
async lint won. Fixed **by construction** — the block addresses items as `type/name` —
so the existing `DraftChangesPanel.test.tsx` is byte-for-byte untouched.

## Out-of-scope findings

- objectstack-ai/objectui#5476 — the block cannot navigate to the object's Settings tab (deep-link is mount-time only)
- objectstack-ai/objectui#5477 — `[finding]` `ObjectSettingsPanel` re-declares `OWD_WIDTH` instead of calling `isExternalWider`
- objectstack-ai/objectstack#10524 — the publish failure's `error` string inlines the prose `issues[]` already carries

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_