### PR TITLE
fix(scripts): read the ESM gate's specifiers from the parser, not a comment mask

### DIFF
--- a/.changeset/esm-load-comment-mask-5382.md
+++ b/.changeset/esm-load-comment-mask-5382.md
@@ -1,0 +1,41 @@
+---
+---
+
+CI tooling only — this publishes nothing, declared explicitly with an empty frontmatter
+rather than left undeclared. No package `src/` is touched.
+
+Fixes the comment mask in `scripts/check-node-esm-load.mjs` (objectui#5382). Leg 1 of
+the gate blanked comments out of every source with two ordered regexes and then matched
+specifiers in the result. The block-comment pass ran first and had no notion of already
+being inside a `//` line, so a slash-star sequence occurring in ordinary line-comment
+prose — a package glob, a path pattern, a wildcard import, all of them ordinary here —
+opened a comment that ran to the next closing delimiter anywhere in the file and blanked
+every line between, live code included.
+
+Re-measured on `main` at 478ec54ce over the 805 emitted sources of the 13
+specifier-preserving packages: the mask found 2132 relative specifiers and the TypeScript
+parser found 2133. The one it could not see is a real `import` in
+`packages/app-shell/src/preview/DraftChangesPanel.tsx`, hidden by a line comment naming
+the `@objectstack` chunk group by glob two lines above it.
+
+That direction is the bad one. Since `SPECIFIER_DEBT` emptied, leg 1 is a hard
+requirement rather than a ratchet, so a blind spot in it is somewhere a regression can
+sit permanently while the run reports clean and only the nightly load leg can see the
+consequence.
+
+Leg 1 now reads each file exactly as written and takes its module edges from
+`check-phantom-dependencies.mjs`'s shared TypeScript scanner — the same one
+`check-package-self-import.mjs` uses, so three gates cannot drift apart on what a module
+edge is. Comments, strings, template literals and regex literals stop being questions
+this gate has an opinion about. Reported line numbers stay the compiler's: the specifier
+literal is located inside the statement the parser already identified, which matters
+because `tsc` reports this class at the specifier and the statement opens on a different
+line for 255 of 2066 relative specifiers here.
+
+The gate's verdict is unchanged — 0 findings before, 0 findings after — because the
+newly visible import already carries its `.js` extension. What changed is that it is now
+visible. The whole cheap leg went from 0.71s to 2.43s.
+
+`readTsconfig()` in the same script strips comments with the same kind of
+context-unaware regex and is a separate live instance of this class. It is deliberately
+untouched here and remains open as objectui#5367.

--- a/scripts/__tests__/check-node-esm-load.test.ts
+++ b/scripts/__tests__/check-node-esm-load.test.ts
@@ -4,10 +4,10 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {
+  ESM_MODULE_EDGE,
   EXPLICIT_EXTENSION,
   MIN_LOADED,
   MIN_PACKAGES,
-  RELATIVE_SPECIFIER,
   SPECIFIER_DEBT,
   UNBUNDLED_NODE_UNSUPPORTED,
   attributeMissingModule,
@@ -16,9 +16,9 @@ import {
   emittedSources,
   esmEntryOf,
   importEntry,
+  relativeSpecifiers,
   resolvesToModule,
   scanSpecifiers,
-  withoutCommentedCode,
 } from '../check-node-esm-load.mjs';
 
 /**
@@ -47,6 +47,13 @@ import {
  *  5. **Line numbers must address the real file.** Stripping comments outright
  *     moved every finding in `react/src/index.ts` up by six lines, so the gate
  *     pointed at line 3 for what `tsc` reported at line 9.
+ *  6. **The gate must not MUTATE the text it grades** (objectui#5382). Leg 1
+ *     used to blank comments with two ordered regexes and match specifiers in
+ *     the result; the block-comment pass did not know it was already inside a
+ *     `//` line, so prose naming a package glob opened a comment that ran to
+ *     the next closing delimiter anywhere in the file and blanked the live code
+ *     between. The last `describe` below pins both halves of that: the hidden
+ *     import is found, and the prose that must stay invisible still is.
  */
 
 const tmpdir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'esm-load-gate-'));
@@ -99,10 +106,6 @@ describe('objectui#4538 — the defect the gate exists for', () => {
     expect(scanSpecifiers({ name: 'p', dir: 'p', srcDir: path.join(dir, 'src') })).toEqual([]);
   });
 
-  it('preserves line count when blanking comments', () => {
-    expect(withoutCommentedCode('/*\n\n*/\nkeep').split('\n')).toHaveLength(4);
-  });
-
   it('catches every specifier form the repo writes', () => {
     const forms = [
       "export * from './a';",
@@ -111,7 +114,7 @@ describe('objectui#4538 — the defect the gate exists for', () => {
       "import x from './d';",
       "export { y } from './e';",
     ].join('\n');
-    const specs = [...forms.matchAll(RELATIVE_SPECIFIER)].map((m) => m[3]);
+    const specs = relativeSpecifiers(forms, 'forms.ts').map((use) => use.specifier);
     expect(specs).toEqual(['./a', './b', './c', './d', './e']);
   });
 
@@ -273,6 +276,153 @@ describe('the gate cannot be green about nothing', () => {
     expect(resolvesToModule(from, './file')).toBe(true);
     expect(resolvesToModule(from, './sub')).toBe(true);
     expect(resolvesToModule(from, './nope')).toBe(false);
+  });
+});
+
+describe('objectui#5382 — the comment mask that hid live code', () => {
+  /**
+   * The measured shape, kept as close to the real file as a fixture can be.
+   *
+   * `packages/app-shell/src/preview/DraftChangesPanel.tsx` carries a line
+   * comment naming the `@objectstack` chunk group by glob. Under the retired
+   * mask the slash-star inside that prose opened a block comment, and the mask
+   * ran to the closing delimiter of the next doc comment — blanking the live
+   * `import` in between. Re-measured on `main` at 478ec54ce over the 805 files
+   * of the 13 specifier-preserving packages: the mask found 2132 relative
+   * specifiers, the TypeScript parser 2133, and the single difference was that
+   * import.
+   *
+   * Verified to be a real repro rather than a fixture that happens to pass:
+   * handed to the retired implementation this source yields ZERO specifiers.
+   */
+  const GLOB_PROSE_FIXTURE = [
+    '// The `vendor-objectstack` chunk group claims every `@objectstack/*` module',
+    '// except `@objectstack/lint`, and that group is a static import of the entry.',
+    "import { diffFields } from './object-fields-io';",
+    '',
+    'export interface DraftChangeEntry {',
+    '  /** The canonical singular metadata type. */',
+    '  type: string;',
+    '}',
+    '',
+  ].join('\n');
+
+  it('finds an import that a package glob in line-comment prose used to hide', () => {
+    expect(relativeSpecifiers(GLOB_PROSE_FIXTURE, 'DraftChangesPanel.tsx')).toEqual([
+      { specifier: './object-fields-io', kind: 'import', line: 3 },
+    ]);
+  });
+
+  it('flags it as a FINDING when it is extensionless, which is the point', () => {
+    // The mask did not merely mislabel this import, it removed it from the leg
+    // entirely — and since SPECIFIER_DEBT emptied, that leg is a hard
+    // requirement. A blind spot in a hard requirement is where a regression
+    // sits permanently, so the pin goes all the way to the verdict.
+    const dir = tmpdir();
+    fs.mkdirSync(path.join(dir, 'src'));
+    fs.writeFileSync(path.join(dir, 'src/object-fields-io.ts'), 'export const diffFields = 1;\n');
+    fs.writeFileSync(path.join(dir, 'src/DraftChangesPanel.tsx'), GLOB_PROSE_FIXTURE);
+
+    const findings = scanSpecifiers({ name: 'p', dir: 'p', srcDir: path.join(dir, 'src') });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].spec).toBe('./object-fields-io');
+    expect(findings[0].line).toBe(3);
+  });
+
+  it('is not fooled by the same glob inside an ordinary string literal', () => {
+    // The other half of the class the parser removes. The retired mask had no
+    // notion of a string either, so a const holding the glob opened exactly the
+    // same fake comment. Also a zero-specifier source under the old code.
+    const source = [
+      "export const CHUNK_GLOB = '@objectstack/*';",
+      "import { diffFields } from './object-fields-io';",
+      '/** Doc. */',
+      'export const used = diffFields;',
+      '',
+    ].join('\n');
+
+    expect(relativeSpecifiers(source, 'chunks.ts')).toEqual([
+      { specifier: './object-fields-io', kind: 'import', line: 2 },
+    ]);
+  });
+
+  it('reads JSX, so a `.tsx` file is not silently half-parsed', () => {
+    const source = [
+      "import { Panel } from './Panel';",
+      '',
+      'export const View = () => <Panel title="a > b" />;',
+      '',
+    ].join('\n');
+
+    expect(relativeSpecifiers(source, 'View.tsx').map((use) => use.specifier)).toEqual(['./Panel']);
+  });
+
+  it('reports the SPECIFIER line, not the line the statement opens on', () => {
+    // `tsc` reports this class at the specifier. Measured, for a fixture whose
+    // statement opens on line 1 and whose specifier sits on line 4:
+    //
+    //   src/index.ts(8,8): error TS2835: Relative import paths need explicit
+    //     file extensions ... Did you mean './a.js'?
+    //
+    // The two disagree for 255 of this repository's 2066 relative specifiers,
+    // by up to 7 lines, so this is not a hypothetical distinction. The retired
+    // regex matched at `from`, which shares the specifier's line; that accuracy
+    // is preserved rather than traded away for the parser's statement position.
+    const source = ['import {', '  a,', '  b,', "} from './wide';", ''].join('\n');
+    expect(relativeSpecifiers(source, 'wide.ts')).toEqual([
+      { specifier: './wide', kind: 'import', line: 4 },
+    ]);
+  });
+
+  describe('the counter-probe — a zero is only worth what the same method still finds', () => {
+    // "No hidden specifiers" means nothing unless the method that reports it is
+    // still capable of seeing the real ones AND of ignoring the prose. Both
+    // buckets are asserted, because a scanner that returned nothing at all
+    // would satisfy the first half of this file's promise and none of the
+    // second. Measured over the repository at 478ec54ce: 2139 textual
+    // occurrences of the specifier grammar, 2133 real module edges reported, 6
+    // prose-only occurrences correctly not reported.
+    const PROSE_ONLY = [
+      '/**',
+      ' * Usage:',
+      " *   import { translateMetadataType } from './i18n';",
+      ' */',
+      "// export { ObjectStackAdapter } from './objectstack-adapter';",
+      "import { real } from './real-module';",
+      "export * from './another-real-module';",
+      '',
+    ].join('\n');
+
+    it('still reports every specifier that is genuinely present', () => {
+      expect(relativeSpecifiers(PROSE_ONLY, 'probe.ts').map((use) => use.specifier)).toEqual([
+        './real-module',
+        './another-real-module',
+      ]);
+    });
+
+    it('still reports none of the ones that are only prose', () => {
+      const reported = relativeSpecifiers(PROSE_ONLY, 'probe.ts').map((use) => use.specifier);
+      expect(reported).not.toContain('./i18n');
+      expect(reported).not.toContain('./objectstack-adapter');
+    });
+  });
+
+  it('grades the ESM forms only, and says which those are', () => {
+    // The shared scanner reads all five forms that make a module edge. The two
+    // CommonJS ones are not resolved by Node's ESM resolver at all, so grading
+    // them here would answer a different question with this gate's message.
+    // Measured before excluding them: ZERO relative `require()` or
+    // `import =` edges exist in any specifier-preserving package, so the
+    // exclusion narrows nothing today — it is pinned so that stays deliberate.
+    expect([...ESM_MODULE_EDGE].sort()).toEqual(['dynamic import()', 'export', 'import', 'import()-type']);
+
+    const commonjs = ["const a = require('./cjs-dep');", "import b = require('./cjs-equals');", ''].join('\n');
+    expect(relativeSpecifiers(commonjs, 'cjs.ts')).toEqual([]);
+  });
+
+  it('never reports a bare package name, however relative it looks', () => {
+    const source = ["import { canonicalMetaUrlType } from '@objectstack/spec/shared';", ''].join('\n');
+    expect(relativeSpecifiers(source, 'a.ts')).toEqual([]);
   });
 });
 

--- a/scripts/check-node-esm-load.mjs
+++ b/scripts/check-node-esm-load.mjs
@@ -78,6 +78,17 @@
  *   - "Import it and count the successes." A run where every package failed for
  *     an unrelated reason would report no findings of the gated class. So both
  *     legs assert their own SIZE — see MIN_PACKAGES / MIN_LOADED.
+ *   - "Scan a text the gate MUTATED first." Leg 1 used to blank comments out of
+ *     each source with two ordered regexes before matching specifiers in it,
+ *     and the block-comment pass had no notion of already being inside a `//`
+ *     line: a slash-star sequence in ordinary line-comment prose opened a
+ *     comment that ran to the next star-slash anywhere in the file and blanked
+ *     the live code between them. Measured on `main` at 478ec54ce — 2132
+ *     specifiers seen by the mask, 2133 by the parser, the missing one a real
+ *     `import`. Leg 1 now reads the file as written and asks the shared
+ *     TypeScript scanner what the module edges are (objectui#5382); see
+ *     `relativeSpecifiers`. `readTsconfig` below is the same class, still open
+ *     as objectui#5367.
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -85,7 +96,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { SKIP_DIRS, TOOLING_FILE, discoverPackages } from './check-phantom-dependencies.mjs';
+import { SKIP_DIRS, TOOLING_FILE, discoverPackages, moduleSpecifiers } from './check-phantom-dependencies.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -336,12 +347,6 @@ export const UNBUNDLED_NODE_UNSUPPORTED = new Map([
 // ── leg 1: the specifiers ────────────────────────────────────────────────────
 
 /**
- * Relative import/export specifiers, in every form this repository writes them:
- * `from '...'`, a bare side-effect `import '...'`, and dynamic `import('...')`.
- */
-export const RELATIVE_SPECIFIER = /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(['"])(\.\.?(?:\/[^'"]*)?)\2/g;
-
-/**
  * Extensions Node's ESM resolver accepts as written, so the specifier is done.
  *
  * `.json` needs an import attribute to actually load and `.css` never loads at
@@ -351,21 +356,120 @@ export const RELATIVE_SPECIFIER = /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(['"]
 export const EXPLICIT_EXTENSION = /\.(js|jsx|mjs|cjs|json|css|svg|png|woff2?)$/;
 
 /**
- * Blank out comments that could carry a retired `import` line, PRESERVING every
- * newline so reported line numbers still address the real file.
+ * The `moduleSpecifiers()` kinds Node's ESM resolver actually has to resolve.
  *
- * The newline preservation is not tidiness. Stripping a block comment outright
- * moved every finding in `packages/react/src/index.ts` up by six lines — the
- * license header — so the gate pointed at line 3 for a defect `tsc` reported at
- * line 9. A gate whose line numbers do not match the compiler's teaches the
- * reader to stop trusting them.
+ * The shared scanner reads all five forms that make a module edge. Two of them
+ * are CommonJS — `require('…')` and `import x = require('…')` — and the ESM
+ * resolver never sees either, so grading them here would answer a different
+ * question with this gate's error message. Measured on this repository before
+ * excluding them: ZERO relative edges of either kind exist in any
+ * specifier-preserving package, so the exclusion narrows nothing today and is
+ * written down rather than left to be discovered if one ever appears.
+ *
+ * The four kept forms are exactly what the retired regex matched, so the scope
+ * of the leg is unchanged by the parser swap. `import()-type` is erased from the
+ * JavaScript emit and survives only in the `.d.ts`, which is graded for the same
+ * conservative reason `buildPreservesSpecifiers` grades a tsc-plus-bundler
+ * pipeline: a false positive lands in a ledger with a reason, a false negative
+ * ships.
  */
-export function withoutCommentedCode(source) {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' '))
-    // Only a line whose first non-space character opens a comment. A `//` in
-    // the middle of a line is far more likely to be inside a URL string.
-    .replace(/^([ \t]*)\/\/.*$/gm, '$1');
+export const ESM_MODULE_EDGE = new Set(['import', 'export', 'dynamic import()', 'import()-type']);
+
+/**
+ * Every relative module specifier a source file names, read from the PARSER.
+ *
+ * ## Why this is not a regex any more (objectui#5382)
+ *
+ * It used to be one, over a source that a `withoutCommentedCode()` helper had
+ * blanked comments out of. That helper blanked BLOCK comments first, with a
+ * pattern that had no notion of already being inside a `//` line, so any slash-
+ * star sequence occurring in ordinary line-comment prose opened a comment that
+ * ran to the next star-slash anywhere in the file — blanking every line in
+ * between, live code included.
+ *
+ * That is not exotic prose. A line comment naming a package glob, a path
+ * pattern or a wildcard import is ordinary here, and one such comment in
+ * `packages/app-shell/src/preview/DraftChangesPanel.tsx` hid the real `import`
+ * eight lines below it. Re-measured on `main` at 478ec54ce, over the 805 files
+ * of the 13 specifier-preserving packages: the regex found 2132 relative
+ * specifiers and the TypeScript parser found 2133 — one live import invisible
+ * to a leg that has been a HARD REQUIREMENT since SPECIFIER_DEBT emptied, which
+ * is the direction that ships a broken artifact behind a green run.
+ *
+ * The fix is not a cleverer pattern. A pattern cannot answer "am I inside a
+ * comment", and the two `replace` calls whose ORDER decided the answer were the
+ * defect. Asking the parser removes the whole class at once: comments, strings,
+ * template literals and regex literals stop being questions this gate has an
+ * opinion about. `readTsconfig()` above still strips comments with regexes and
+ * is a SEPARATE live instance of the same class — objectui#5367, deliberately
+ * not touched here.
+ *
+ * ## Why the sibling gate's scanner rather than a second parser
+ *
+ * `moduleSpecifiers()` is `check-phantom-dependencies.mjs`'s TypeScript-backed
+ * scanner, already shared with `check-package-self-import.mjs` for the reason
+ * that applies here too: three gates that each decide for themselves what a
+ * module edge IS will eventually disagree, and the one that drifts stops
+ * covering a form without anybody noticing.
+ *
+ * ## The line number is the SPECIFIER's, not the statement's
+ *
+ * `moduleSpecifiers()` reports where the STATEMENT starts, which is the right
+ * answer for a gate asking "which package does this file name". This one prints
+ * a line a reader is expected to jump to and check against `tsc`, and `tsc`
+ * reports the error at the specifier — measured, for an import whose statement
+ * opens on line 6 and whose specifier sits on line 8:
+ *
+ *     src/index.ts(8,8): error TS2835: Relative import paths need explicit file
+ *       extensions in ECMAScript imports when '--moduleResolution' is 'node16'
+ *       or 'nodenext'. Did you mean './a.js'?
+ *
+ * The two disagree for 255 of this repository's 2066 relative import/export
+ * specifiers — 12.3%, by up to 7 lines. The retired regex matched at `from`,
+ * which shares the specifier's line, so it was accurate and this must not
+ * regress: a gate whose line numbers do not match the compiler's teaches the
+ * reader to stop trusting them. (That lesson was paid for once already, by a
+ * block-comment strip that moved every finding in `packages/react/src/index.ts`
+ * six lines up — the license header.) Verified by construction: over all 2132
+ * specifiers the old method could see, the new one reports the identical
+ * specifier-and-line pair for every single entry.
+ *
+ * The literal is LOCATED, never re-parsed. The AST has already decided that
+ * this statement carries this specifier, and an import or export declaration
+ * holds no other string literal, so the first occurrence of the quoted text at
+ * or after the statement's own start IS that literal. Nothing here decides what
+ * is code — the parser did. If the text cannot be found (a specifier written
+ * with an escape), the statement's own line is used rather than a guess.
+ *
+ * @param {string} source the file's text, unmodified
+ * @param {string} fileName only for the parser's diagnostics
+ * @returns {{ specifier: string, kind: string, line: number }[]} in source order
+ */
+export function relativeSpecifiers(source, fileName) {
+  const lineStarts = [0];
+  for (let i = 0; i < source.length; i += 1) {
+    if (source[i] === '\n') lineStarts.push(i + 1);
+  }
+
+  const found = [];
+  for (const use of moduleSpecifiers(source, fileName)) {
+    if (!ESM_MODULE_EDGE.has(use.kind)) continue;
+    if (!/^\.\.?(?:\/|$)/.test(use.specifier)) continue;
+
+    const statementStart = lineStarts[use.line - 1] + (use.column - 1);
+    let literalAt = -1;
+    for (const quote of ['"', "'"]) {
+      const at = source.indexOf(quote + use.specifier + quote, statementStart);
+      if (at !== -1 && (literalAt === -1 || at < literalAt)) literalAt = at;
+    }
+    const line =
+      literalAt === -1
+        ? use.line
+        : use.line + source.slice(statementStart, literalAt).split('\n').length - 1;
+
+    found.push({ specifier: use.specifier, kind: use.kind, line });
+  }
+  return found;
 }
 
 /** Every source file a specifier-preserving build emits from `srcDir`. */
@@ -407,18 +511,22 @@ export function resolvesToModule(fromFile, spec) {
   return false;
 }
 
-/** Findings for one package's sources. */
+/**
+ * Findings for one package's sources.
+ *
+ * The file's text is handed to the parser UNMODIFIED. Nothing masks, strips or
+ * blanks it first — that step is what objectui#5382 was: a comment mask hid a
+ * live import from a leg that is a hard requirement.
+ */
 export function scanSpecifiers(pkg) {
   const findings = [];
   if (!existsSync(pkg.srcDir)) return findings;
   for (const file of emittedSources(pkg.srcDir)) {
-    const source = withoutCommentedCode(readFileSync(file, 'utf8'));
-    for (const match of source.matchAll(RELATIVE_SPECIFIER)) {
-      const spec = match[3];
-      if (EXPLICIT_EXTENSION.test(spec)) continue;
-      if (!resolvesToModule(file, spec)) continue;
-      const line = source.slice(0, match.index).split('\n').length;
-      findings.push({ file, line, spec });
+    const source = readFileSync(file, 'utf8');
+    for (const { specifier, line } of relativeSpecifiers(source, file)) {
+      if (EXPLICIT_EXTENSION.test(specifier)) continue;
+      if (!resolvesToModule(file, specifier)) continue;
+      findings.push({ file, line, spec: specifier });
     }
   }
   return findings;


### PR DESCRIPTION
Fixes #5382

Leg 1 of the ESM-load gate blanked comments out of every source with two ordered regexes and then matched specifiers in the result. The block-comment pass ran first and had no notion of already being inside a `//` line, so a slash-star sequence in ordinary line-comment prose opened a comment that ran to the next closing delimiter anywhere in the file, blanking every line between — live code included.

## Re-measured on `main` at 478ec54ce

Not the card's numbers; the repository moved since it was written (805 files now, 424 in app-shell then vs 426 now).

| method | relative specifiers |
|---|---|
| the retired mask + `RELATIVE_SPECIFIER` | 2132 |
| the TypeScript parser | 2133 |

Set difference, one entry, one direction — the parser sees it and the gate did not:

```
packages/app-shell/src/preview/DraftChangesPanel.tsx:52  '../views/metadata-admin/previews/object-fields-io.js'
```

Hidden by the line comment eight lines above it, which names the `@objectstack` chunk group by glob. Restricted to `@object-ui/app-shell` alone the same measurement is 1275 vs 1276, which is the card's 1270 vs 1271 plus the five specifiers the package has grown since.

The direction is the bad one. Since `SPECIFIER_DEBT` emptied, leg 1 is a hard requirement rather than a ratchet, so a blind spot in it is somewhere a regression can sit permanently behind a green run.

## The fix is not a cleverer pattern

A pattern cannot answer "am I inside a comment", and the two `replace` calls whose ORDER decided the answer were the defect. Leg 1 now reads each file exactly as written and takes its module edges from `check-phantom-dependencies.mjs`'s TypeScript-backed `moduleSpecifiers()` — the same scanner `check-package-self-import.mjs` already shares, so three gates cannot drift apart on what a module edge is. Comments, strings, template literals and regex literals stop being questions this gate has an opinion about.

`RELATIVE_SPECIFIER` and `withoutCommentedCode()` are deleted rather than left unused.

Two details that are load-bearing rather than tidy:

- **Line numbers stay the compiler's.** `moduleSpecifiers()` reports where the STATEMENT starts; `tsc` reports this class at the SPECIFIER, and the two differ for 255 of 2066 relative specifiers here (12.3%), by up to 7 lines. Measured directly: `src/index.ts(8,8): error TS2835` for an import whose statement opens on line 6. So the specifier literal is LOCATED inside the statement the parser already identified — nothing here decides what is code. Verified by construction: over all 2132 specifiers the old method could see, the new one reports the identical specifier-and-line pair for every single entry.
- **Only the four ESM forms are graded.** `moduleSpecifiers()` also reads `require()` and `import x = require()`, which Node's ESM resolver never sees. `ESM_MODULE_EDGE` names the four kept forms — exactly what the retired regex matched, so the leg's scope is unchanged by the swap. Measured before excluding them: zero relative edges of either CommonJS kind exist in any specifier-preserving package.

## Before / after, and the blast radius

| | specifiers seen | findings | cheap leg wall time |
|---|---|---|---|
| 478ec54ce (`origin/main`) | 2132 | **0** | 0.71s |
| 906bccbe0 (this branch) | 2133 | **0** | 2.43s |

**The gate does not go red.** The newly visible import already carries its `.js` extension — it was cleared by #5357 while still invisible to the gate that was supposed to be watching it. Nothing was exempted, nothing was ledgered, `SPECIFIER_DEBT` is still empty. The whole blast radius is +1 visible specifier and +1.7s.

## Counter-probe — the zero is only worth what the same method still finds

"No hidden specifiers" is meaningless from a scanner that finds nothing, so both buckets are reported. Over the same 805 files:

| bucket | count |
|---|---|
| textual occurrences of the specifier grammar in the raw sources | 2139 |
| real module edges the parser reports | 2133 |
| prose-only, correctly NOT reported | 6 |

All six were read and confirmed prose — JSDoc usage examples, a retired commented-out `export`, and a doc comment quoting a public export. Zero false positives in either direction, and pinned as a test pair rather than only measured.

## Reverse-verification

`relativeSpecifiers`'s body was replaced with the retired mask-and-regex mechanism, keeping the export and signature so the signal is about the mechanism rather than a missing import.

*Predicted before running:* 3 red / 35 green — the two glob fixtures and the finding-level assertion; the counter-probe, line-number, JSX and form-scope pins unaffected because the retired regex handles those cases identically.

*Observed:* `Tests 3 failed | 35 passed (38)`, on exactly those three.

```
× finds an import that a package glob in line-comment prose used to hide
× flags it as a FINDING when it is extensionless, which is the point
× is not fooled by the same glob inside an ordinary string literal
```

No build sits between the edit and the run: the test imports `'../check-node-esm-load.mjs'` by relative path, and no vitest alias redirects it — there is no `dist/` for a mutation to fail to reach. Both legs were proved to reach the code under test (the ablated build returned `[]` for the fixture, the restored one returns the import again). Restored with `git checkout`; tree clean, ablation marker count 0, suite back to 38 passed.

## On #5367 — NOT subsumed, deliberately untouched

`readTsconfig()` in this same script still strips comments with `.replace(/\/\*[\s\S]*?\*\//g, '')` plus a line-comment pass, and still destroys any tsconfig whose JSON strings contain a slash-star. That is the same defect CLASS and a separate live instance, in a different function, on a different input. Nothing in this PR touches it — it was out of the dispatched file surface, and it is left open.

What this PR does change for whoever picks it up: `typescript` is now reachable from this script through the shared scanner, so #5367's own suggested shape (`ts.parseConfigFileTextToJson`) no longer costs a new dependency edge, and after this lands `readTsconfig()` is the LAST context-unaware comment stripper in the file.

## Verification at 906bccbe0

```
pnpm vitest run scripts/__tests__/check-node-esm-load.test.ts   38 passed (38)
pnpm vitest run --project unit scripts/__tests__                60 files, 1624 passed
pnpm type-check:scripts                                         exit 0
pnpm exec eslint on the two changed files                       exit 0
check:esm-specifiers / control-bytes / changeset-presence
  / changeset-no-major / changeset-fixed / self-import
  / phantom-deps / lint-coverage                                all exit 0
```

Changeset: empty frontmatter — CI tooling only, no package `src/` touched, so this publishes nothing and says so explicitly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_