### PR TITLE
perf(console): make the /docs portal genuinely lazy

### DIFF
--- a/.changeset/console-lazy-docs-portal-5467.md
+++ b/.changeset/console-lazy-docs-portal-5467.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/console': patch
+---
+
+The console's `/docs` portal is code-split for real: its four pages leave the eager closure instead of only pretending to.
+
+`AppContent.tsx` lazy-imports `DocsLayout` / `DocsSlug` / `DocPage` for the
+app-scoped `/apps/:packageId/docs` tree (ADR-0048). `App.tsx` imported the same
+three statically for the platform portal at `/docs` (ADR-0046 section 6), so all
+of them sat in the eager graph regardless and the `import()` moved nothing —
+three `INEFFECTIVE_DYNAMIC_IMPORT` warnings on every `vite build`
+(objectui#5467). A static import on either side silently defeats the split for
+both, and the only signal is a build warning that fails nothing.
+
+`App.tsx` now reaches all four docs pages through `lazy()` behind `Suspense`,
+matching the pattern `AppContent.tsx` already uses. `DocsIndex` joins them even
+though it carried no warning: `AppContent` renders `AppDocsIndex` at that slot,
+so nothing imported `DocsIndex` dynamically, but left static it alone would keep
+`DocShell`, `use-book-data` and `book-nav` eager and the portal would only
+half-leave the closure.
+
+Measured on this branch with the `dist/eager-closure.json` gauge added by
+objectui#5324, both builds exiting 0:
+
+| | before | after |
+|---|---|---|
+| `INEFFECTIVE_DYNAMIC_IMPORT` warnings | 46 | 44 |
+| eager closure, gzipped | 3,881,609 B | 3,870,058 B |
+| eager chunks | 58 | 52 |
+
+Six chunks leave the eager closure: `plugin-markdown` (4,212 B gz),
+`CreateViewDialog` (3,617 B), `use-book-data` (1,966 B), `DocShell` (476 B),
+`componentRegistry` (99 B), and `src` (129,555 B), the last of which rolldown
+folds into the entry chunk rather than dropping — which is why the entry chunk
+grows from 25,910 to 154,378 B gzipped while the closure as a whole shrinks by
+11,551 B. The entry stays far under that budget's 350 KB line, and the eager
+closure is the number a page load actually pays.
+
+What does NOT move is `vendor-markdown`, 164,708 B gzipped and the reason this
+looked like a bigger win than it is. Three eager chunks import it statically,
+and only one of them was this portal: `plugin-chatbot` reaches it directly, and
+`packages/fields`' `MarkdownContent` — lazy in source — is folded into the
+eagerly imported `ui-components` chunk by the `advancedChunks` group that claims
+every `packages/fields` module. That is objectui#5325's mechanism, not this
+card's, and it is why the saving here is 0.30% rather than 4%.

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -12,7 +12,7 @@
  * with extra `<Route>` children.
  */
 
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useLocation, Link } from 'react-router-dom';
 import { AuthProvider, useAuth } from '@object-ui/auth';
 import { DevMasterDetail } from './dev/DevMasterDetail';
@@ -25,6 +25,7 @@ import {
   RequireAiSurface,
   SystemRedirect,
   ConsoleToaster,
+  LoadingScreen,
   DefaultHomeLayout,
   DefaultHomePage,
   DefaultOrganizationsLayout,
@@ -49,10 +50,6 @@ import { FormPage } from './components/FormPage';
 import { InternalFormRoute } from './components/InternalFormRoute';
 import { MetadataHmrReloader } from './components/MetadataHmrReloader';
 import SharedRecordPage from './pages/SharedRecordPage';
-import DocPage from './pages/DocPage';
-import DocsIndex from './pages/DocsIndex';
-import DocsSlug from './pages/DocsSlug';
-import DocsLayout from './pages/DocsLayout';
 import { LoginPage } from './pages/auth/LoginPage';
 import { RegisterPage } from './pages/auth/RegisterPage';
 import { ForgotPasswordPage } from './pages/auth/ForgotPasswordPage';
@@ -62,6 +59,32 @@ import { VerifyEmailPage } from './pages/auth/VerifyEmailPage';
 import { VerifyEmailPromptPage } from './pages/auth/VerifyEmailPromptPage';
 import { OAuthConsentPage } from './pages/auth/OAuthConsentPage';
 import { DeviceAuthPage } from './pages/auth/DeviceAuthPage';
+
+/*
+ * Package documentation portal (ADR-0046 section 6), lazy on purpose.
+ *
+ * Nothing on a normal console page load visits /docs, and `DocPage` is the
+ * only console-owned module that reaches `@object-ui/plugin-markdown`. These
+ * four therefore belong behind a lazy boundary.
+ *
+ * `AppContent.tsx` already lazy-imports `DocsLayout` / `DocsSlug` / `DocPage`
+ * for the app-scoped `/apps/:packageId/docs` tree (ADR-0048). Importing the
+ * same three STATICALLY here put them in the eager graph anyway, so that
+ * `import()` moved nothing -- three `INEFFECTIVE_DYNAMIC_IMPORT` warnings on
+ * every build (objectui#5467). Both sides must stay lazy: a static import on
+ * either one silently re-defeats the split for BOTH, and the only signal is a
+ * build warning that fails nothing.
+ *
+ * `DocsIndex` is lazy here for the same reason even though it carried no
+ * warning (`AppContent` renders `AppDocsIndex` at that slot, so nothing
+ * imported it dynamically). Left static it would keep `DocShell`,
+ * `use-book-data` and `book-nav` eager on its own and the portal would only
+ * half-leave the closure.
+ */
+const DocsLayout = lazy(() => import('./pages/DocsLayout'));
+const DocsIndex = lazy(() => import('./pages/DocsIndex'));
+const DocsSlug = lazy(() => import('./pages/DocsSlug'));
+const DocPage = lazy(() => import('./pages/DocPage'));
 
 const AUTH_URL = `${import.meta.env.VITE_SERVER_URL || ''}/api/v1/auth`;
 
@@ -240,12 +263,12 @@ export function App() {
               *                  coordinate; the book segment is derived nav). */}
             <Route path="/docs" element={
               <ProtectedRoute>
-                <DocsLayout />
+                <Suspense fallback={<LoadingScreen />}><DocsLayout /></Suspense>
               </ProtectedRoute>
             }>
-              <Route index element={<DocsIndex />} />
-              <Route path=":slug" element={<DocsSlug />} />
-              <Route path=":slug/:name" element={<DocPage />} />
+              <Route index element={<Suspense fallback={<LoadingScreen />}><DocsIndex /></Suspense>} />
+              <Route path=":slug" element={<Suspense fallback={<LoadingScreen />}><DocsSlug /></Suspense>} />
+              <Route path=":slug/:name" element={<Suspense fallback={<LoadingScreen />}><DocPage /></Suspense>} />
             </Route>
             <Route path="/home" element={
               <ProtectedRoute>

--- a/apps/console/src/__tests__/App.docsPortalLazy.test.tsx
+++ b/apps/console/src/__tests__/App.docsPortalLazy.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5467 — the console's `/docs` portal must stay OUT of the eager
+ * module graph.
+ *
+ * ## What this measures, and why it is not a source-text check
+ *
+ * `AppContent.tsx` lazy-imports `DocsLayout` / `DocsSlug` / `DocPage` for the
+ * app-scoped `/apps/:packageId/docs` tree (ADR-0048). `App.tsx` used to import
+ * the same three STATICALLY for the platform portal at `/docs` (ADR-0046
+ * section 6), which put them in the eager graph anyway and made that
+ * `import()` decoration — three `INEFFECTIVE_DYNAMIC_IMPORT` warnings on every
+ * `vite build`, and a build warning fails nothing.
+ *
+ * So the regression this file exists to catch is a static import re-appearing
+ * in `App.tsx`, and it is asserted as the PROPERTY rather than the spelling: a
+ * `vi.mock` factory runs the first time its module is imported, so the flags
+ * below record *when* each page entered the graph. A static import makes the
+ * page load while `App.tsx` itself is evaluated — before any test body runs —
+ * and this file goes red. A regex over `App.tsx` would pin one spelling of the
+ * mistake; this pins the mistake.
+ *
+ * ## Counter-probes
+ *
+ * Two, because "the page never loaded" is exactly what a flag that can never
+ * be set looks like.
+ *
+ *   1. `SharedRecordPage` is a LIVE positive control: `App.tsx` still imports
+ *      it statically, so its flag must already be set before the first render.
+ *      If the observer stopped seeing static imports, that assertion fails
+ *      instead of the lazy ones passing vacuously.
+ *   2. Visiting `/docs` must FLIP the layout's flag and render it. A flag that
+ *      is merely stuck at unset cannot satisfy both halves.
+ *
+ * `DocsSlug` and `DocPage` sit on deeper routes that `/docs` does not match,
+ * so they must still be unloaded after the render — the portal is split per
+ * page, not into one docs bundle.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { Outlet } from 'react-router-dom';
+import type { ReactNode } from 'react';
+
+// `vi.hoisted`, not plain consts: every `vi.mock` factory below is hoisted to
+// the top of the file, so a factory closing over an ordinary `const` reads it
+// before initialization.
+const { loaded, passthrough, stub, tracked } = vi.hoisted(() => {
+  const loaded: Record<string, boolean> = {};
+  const passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>;
+  const stub = (testid: string) => () => <div data-testid={testid} />;
+  /** A default-export page module that records the moment it is imported. */
+  const tracked = (name: string, testid: string) => () => {
+    loaded[name] = true;
+    return { default: stub(testid) };
+  };
+  return { loaded, passthrough, stub, tracked };
+});
+
+// ── The four docs pages, plus the statically imported positive control ────
+// The layout renders its `Outlet` so the index child actually mounts —
+// otherwise `DocsIndex` would read as "still lazy" for the wrong reason
+// (nothing ever asked for it) and the assertion on it would be vacuous.
+vi.mock('../pages/DocsLayout', () => {
+  loaded.DocsLayout = true;
+  return {
+    default: () => (
+      <div data-testid="docs-layout">
+        <Outlet />
+      </div>
+    ),
+  };
+});
+vi.mock('../pages/DocsIndex', tracked('DocsIndex', 'docs-index'));
+vi.mock('../pages/DocsSlug', tracked('DocsSlug', 'docs-slug'));
+vi.mock('../pages/DocPage', tracked('DocPage', 'doc-page'));
+vi.mock('../pages/SharedRecordPage', tracked('SharedRecordPage', 'shared-record-page'));
+
+// ── Everything else App.tsx imports but this card does not touch ──────────
+vi.mock('@object-ui/app-shell', () => ({
+  ConsoleShell: passthrough,
+  ConsoleToaster: () => null,
+  LoadingScreen: stub('loading-screen'),
+  RequireAiSurface: passthrough,
+  SystemRedirect: () => null,
+  DefaultHomeLayout: passthrough,
+  DefaultHomePage: stub('home-page'),
+  DefaultOrganizationsLayout: passthrough,
+  DefaultOrganizationsPage: stub('organizations-page'),
+  DefaultOrganizationLayout: stub('organization-layout'),
+  DefaultMembersPage: stub('members-page'),
+  DefaultInvitationsPage: stub('invitations-page'),
+  DefaultSettingsPage: stub('settings-page'),
+  DefaultAcceptInvitationPage: stub('accept-invitation-page'),
+  DefaultAiChatPage: stub('ai-chat-page'),
+  StudioDesignSurface: stub('studio-design-surface'),
+  BuilderLanding: stub('builder-landing'),
+  getProductName: () => 'ObjectOS',
+  getFaviconUrl: () => '',
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  AuthProvider: passthrough,
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+vi.mock('../AppContent', () => ({ AppContent: stub('app-content') }));
+vi.mock('../components/ProtectedRoute', () => ({ ProtectedRoute: passthrough }));
+vi.mock('../components/RootLandingRedirect', () => ({ RootLandingRedirect: stub('root-landing') }));
+vi.mock('../components/SetupRoute', () => ({ SetupRoute: stub('setup-route') }));
+vi.mock('../components/FormPage', () => ({ FormPage: stub('form-page') }));
+vi.mock('../components/InternalFormRoute', () => ({ InternalFormRoute: stub('internal-form-route') }));
+vi.mock('../components/MetadataHmrReloader', () => ({ MetadataHmrReloader: () => null }));
+vi.mock('../pages/auth/LoginPage', () => ({ LoginPage: stub('login-page') }));
+vi.mock('../pages/auth/RegisterPage', () => ({ RegisterPage: stub('register-page') }));
+vi.mock('../pages/auth/ForgotPasswordPage', () => ({ ForgotPasswordPage: stub('forgot-page') }));
+vi.mock('../pages/auth/ResetPasswordPage', () => ({ ResetPasswordPage: stub('reset-page') }));
+vi.mock('../pages/auth/SetPasswordPage', () => ({ SetPasswordPage: stub('set-password-page') }));
+vi.mock('../pages/auth/VerifyEmailPage', () => ({ VerifyEmailPage: stub('verify-email-page') }));
+vi.mock('../pages/auth/VerifyEmailPromptPage', () => ({ VerifyEmailPromptPage: stub('verify-prompt-page') }));
+vi.mock('../pages/auth/OAuthConsentPage', () => ({ OAuthConsentPage: stub('oauth-consent-page') }));
+vi.mock('../pages/auth/DeviceAuthPage', () => ({ DeviceAuthPage: stub('device-auth-page') }));
+vi.mock('../dev/DevMasterDetail', () => ({ DevMasterDetail: stub('dev-master-detail') }));
+vi.mock('../dev/DevLists', () => ({ DevLists: stub('dev-lists') }));
+vi.mock('../dev/DevModal', () => ({ DevModal: stub('dev-modal') }));
+vi.mock('../dev/DevLookup', () => ({ DevLookup: stub('dev-lookup') }));
+vi.mock('../dev/DevRowActions', () => ({ DevRowActions: stub('dev-row-actions') }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { App } from '../App';
+
+afterEach(() => {
+  cleanup();
+  window.history.pushState({}, '', '/');
+});
+
+describe('the /docs portal is genuinely lazy (objectui#5467)', () => {
+  it('leaves the docs pages out of the graph until a /docs route matches', async () => {
+    // Counter-probe 1 — a page App.tsx still imports statically. Importing
+    // `../App` above was enough to load it, which is what "eager" means and
+    // what the four assertions below deny for the docs portal.
+    expect(loaded.SharedRecordPage).toBe(true);
+
+    expect(loaded.DocsLayout).toBeUndefined();
+    expect(loaded.DocsIndex).toBeUndefined();
+    expect(loaded.DocsSlug).toBeUndefined();
+    expect(loaded.DocPage).toBeUndefined();
+
+    window.history.pushState({}, '', '/docs');
+    render(<App />);
+
+    // Counter-probe 2 — the flags can be set, and the Suspense boundary the
+    // lazy elements sit behind actually resolves them. Without it React would
+    // throw here rather than render the layout.
+    expect(await screen.findByTestId('docs-layout')).toBeInTheDocument();
+    expect(loaded.DocsLayout).toBe(true);
+    expect(loaded.DocsIndex).toBe(true);
+
+    // Split per page, not into one docs bundle: `/docs` matches neither of
+    // these deeper routes, so neither may have been pulled in.
+    expect(loaded.DocsSlug).toBeUndefined();
+    expect(loaded.DocPage).toBeUndefined();
+  });
+});

--- a/apps/console/src/__tests__/internalFormShell.test.tsx
+++ b/apps/console/src/__tests__/internalFormShell.test.tsx
@@ -56,6 +56,10 @@ const { passthrough, stub } = vi.hoisted(() => ({
 vi.mock('@object-ui/app-shell', () => ({
   ConsoleShell: passthrough,
   ConsoleToaster: () => null,
+  // Suspense fallback for App.tsx's lazy /docs routes (objectui#5467).
+  // The route elements are built when App renders, so this export is
+  // read even by a test that never visits /docs.
+  LoadingScreen: stub('loading-screen'),
   RequireAiSurface: passthrough,
   SystemRedirect: () => null,
   DefaultHomeLayout: ({ children }: { children?: ReactNode }) => (


### PR DESCRIPTION
Fixes #5467

`AppContent.tsx` lazy-imports `DocsLayout` / `DocsSlug` / `DocPage` for the app-scoped `/apps/:packageId/docs` tree (ADR-0048). `App.tsx` imported the same three **statically** for the platform portal at `/docs` (ADR-0046 section 6), so all three sat in the eager graph regardless and the `import()` moved nothing — three `INEFFECTIVE_DYNAMIC_IMPORT` warnings on every `vite build`.

## Which side was fixed, and why

Both route trees are live, so neither set of imports is dead code:

- `App.tsx` — the platform docs portal at `/docs` (ADR-0046 section 6): `DocsLayout` with `DocsIndex`, `DocsSlug`, `DocPage`.
- `AppContent.tsx` — the app-scoped package docs at `/apps/:packageId/docs` (ADR-0048): the same `DocsLayout` / `DocsSlug` / `DocPage`, with `AppDocsIndex` at the index slot.

Deleting the lazy imports in `AppContent.tsx` would make the intent honest and change nothing: the pages are already eager, so that route is the one paying, not the one deciding. The laziness was written on purpose and `AppContent` applies it uniformly to all thirteen of its pages — nothing on a normal console page load visits docs, and `DocPage` is the only console-owned module that reaches `@object-ui/plugin-markdown`. So `App.tsx` is the side that was wrong, and it now reaches all four docs pages through `lazy()` behind `Suspense`, in exactly the shape `AppContent.tsx` already uses.

`DocsIndex` joins them even though it carried no warning — `AppContent` renders `AppDocsIndex` at that slot, so nothing imported `DocsIndex` dynamically. Left static it alone would keep `DocShell`, `use-book-data` and `book-nav` eager, and the portal would only half-leave the closure.

## Measured

Gauge: `apps/console/dist/eager-closure.json`, added by #5324 / PR #5466. Both legs exited **0** — the warning count was never read from a build that died. Final numbers taken from the build on `f9bbd4144`, the branch HEAD.

| metric | before | after | delta |
|---|---|---|---|
| `INEFFECTIVE_DYNAMIC_IMPORT` warnings | 46 | 44 | −2 |
| eager closure, gzipped bytes | 3,881,609 | 3,870,058 | −11,551 (−0.30%) |
| eager chunks | 58 / 507 | 52 / 508 | −6 |

Warning composition, which is the counter-probe on the zero: the three console-page warnings go 3 to **0**, while the 43 `packages/fields` warnings of #5325 stay at 43 in both legs. A grep that had stopped matching, or a build that had died, would have taken those 43 with it.

Six chunks leave the eager closure:

| chunk | gzipped |
|---|---|
| `src` | 129,555 |
| `plugin-markdown` | 4,212 |
| `CreateViewDialog` | 3,617 |
| `use-book-data` | 1,966 |
| `DocShell` | 476 |
| `componentRegistry` | 99 |

`src` is not a saving: rolldown folds it into the entry chunk instead of dropping it, which is why the entry chunk grows from 25,910 to 154,378 gzipped bytes while the closure as a whole shrinks. The entry stays far under that budget's 350 KB line, and `scripts/check-eager-closure-budget.mjs` passes with headroom up from 78.4 KB to 87.8 KB. Worth knowing before reading the Bundle Analysis comment, where the entry-chunk number jumps six-fold and the closure number is the one that matters.

## The saving is 0.30%, not 4% — and the reason is #5325

`vendor-markdown` does **not** move: 164,708 gzipped bytes, still eager. Three eager chunks import it statically and only one of them was this portal:

- `plugin-chatbot`, which reaches it directly and is itself eager;
- `ui-components`, because `packages/fields`' `MarkdownContent` — `React.lazy` in source — is folded into that eagerly imported chunk by the `advancedChunks` group claiming every `packages/fields` module.

That second one is exactly the mechanism #5325 measured, arriving from a different direction. This card's hypothesis — that `apps/console/src` is claimed by no group and so a genuinely lazy page can get its own chunk — held: the console's own modules did cleave. What did not follow is the markdown vendor payload, because the console pages were never its only eager owner. Non-zero, but an order of magnitude below what the file list suggests.

## Reverse verification

Ablation: `git checkout origin/main -- apps/console/src/App.tsx`, both legs re-run, direction predicted before running.

| leg | predicted | observed |
|---|---|---|
| `App.docsPortalLazy.test.tsx` | red at `expect(loaded.DocsLayout).toBeUndefined()`, positive control still green | red, exactly there: `expected true to be undefined` at line 151; the `SharedRecordPage` control on line 149 passed first |
| `vite build` | warnings back to 46 with the three docs ones returning; closure back to 3,881,609 B / 58 chunks | 46 warnings, the three docs ones back, 3,881,609 B / 58 chunks, exit 0 |

Restored with `git checkout HEAD -- apps/console/src/App.tsx`; `git status --porcelain` empty and `git hash-object` of the working file equals the committed blob `68d115b3`, so the restore is byte-identical rather than merely clean-looking.

## A warning appears that was not there before, and it is not a regression

The build now reports one warning it did not report before:

> `packages/app-shell/src/index.ts` is dynamically imported by `src/registerStudioComponents.tsx` but also statically imported by `src/App.tsx`, `src/AppContent.tsx`, ...

That file is byte-identical to `main` in this branch (`git diff origin/main...HEAD` touches it not at all), and its laziness was already dead there: it statically imports `registerAppComponent` from the same barrel on line 19 while `lazy()`-importing the barrel on line 22, and `App.tsx` on `main` already imports `BuilderLanding` statically from it. The ablation confirms the direction — with the fix removed the warning goes away again, so what changed is reportability, not the defect: once the docs pages leave, `src` folds into the entry chunk and rolldown can see that this `import()` cannot move anything. Filed separately rather than folded in; the correct shape there is a decision (drop the `lazy()`, or stop importing `BuilderLanding` statically in `App.tsx`), not a mechanical edit.

## Tests

`apps/console/src/__tests__/App.docsPortalLazy.test.tsx` pins laziness as a **runtime property**, not as a spelling. A `vi.mock` factory runs the first time its module is imported, so the flags it sets record *when* each page entered the graph: a static import in `App.tsx` sets the flag while `App.tsx` is evaluated, before any test body runs. A regex over the source would pin one spelling of the mistake; this pins the mistake.

Two counter-probes, because "never loaded" is what a flag that can never be set also looks like: `SharedRecordPage` is a live positive control (still statically imported, so its flag must already be set), and visiting `/docs` must flip the layout's flag and render it through the Suspense boundary. `DocsSlug` and `DocPage` must still be unloaded afterwards, since `/docs` matches neither.

`internalFormShell.test.tsx`'s `@object-ui/app-shell` mock gains `LoadingScreen`. This is required, not optional: `App.tsx`'s route elements are constructed when `App` renders, so the Suspense fallback's export is read even by a test that never visits `/docs`, and without it both of its tests died on the vitest mock proxy. That failure was observed before it was fixed.

**Surface note:** the card's declared file surface was `apps/console/src/{App,AppContent}.tsx` plus `src/pages/**`. The two test files above sit in `src/__tests__/` — the new one is a new path that cannot collide, and the mock repair is mandated by this change rather than chosen.

## Verification run on `f9bbd4144`

| | |
|---|---|
| `pnpm exec vitest run apps/console/` | 58 files, 673 tests, 0 failed, 0 skipped |
| `pnpm --filter @object-ui/console type-check` | pass |
| `pnpm --filter @object-ui/console lint` | 0 errors (202 pre-existing warnings, none in changed files) |
| `check:eager-closure` | pass, 3779.4 KB against a 3867.2 KB budget |
| `check:control-bytes` | pass, 4531 files scanned |
| `check:self-import`, `check:esm-specifiers`, `check:phantom-deps` | pass |
| `check-changeset-presence`, `check-changeset-no-major` | pass |

Changeset: `.changeset/console-lazy-docs-portal-5467.md` (`@object-ui/console: patch`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_