### PR TITLE
ReportView reads only the declared `dataSource.object` key

### DIFF
--- a/.changeset/report-view-datasource-object-key-5116.md
+++ b/.changeset/report-view-datasource-object-key-5116.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/app-shell': minor
+---
+
+`ReportView` reads a report's data binding through the one key the contract declares — `dataSource.object`.
+
+The view accepted `resource` as a second spelling of `object`, in two places, and
+named that spelling in a warning the user could read:
+
+```
+:171  liveReport?.objectName || liveReport?.dataSource?.object
+                             || liveReport?.dataSource?.resource
+:273  dataFetchSource.dataSource.object || dataFetchSource.dataSource.resource
+:275  console.warn('ReportView: dataSource missing object/resource property')
+```
+
+`resource` is not on this binding. `ElementDataSourceConfig` declares `object`,
+`view?`, `filter?`, `sort?` and `limit?`; its `@objectstack/spec` twin
+`ElementDataSourceSchema` is a strict object, so an extra `resource` key is
+*rejected* there rather than ignored; and the binding's own predicate
+`isElementDataSourceConfig` decides on `object`. A `resource`-only binding
+therefore was never a binding on any other renderer in the system — it rendered
+here and silently produced nothing anywhere else, with neither end reporting a
+problem. That divergence is what a consumer-side alias buys: one renderer
+answering a question the contract says has no answer.
+
+`resource` is a real key on other surfaces — `CRUDSchema.resource`, the
+`DataSource` adapter's first parameter, `LiveExportOptions.resource` — and all
+three are untouched. None of them is this one.
+
+Behaviour, measured by rendering each input shape before and after. Only the
+`resource`-only shape moves:
+
+| binding | before | after |
+| --- | --- | --- |
+| `object` only | queries that object | unchanged |
+| `resource` only | queries it as if declared | not queried; named warning, no rows, fallback field list |
+| both | queries `object` | unchanged |
+| neither | not queried; warning | unchanged |
+
+So off-spec report metadata that used to render now fails loudly instead of
+appearing to work. A producer census found nothing that would notice: no site in
+this repository, and none in the `objectstack` framework repository, writes
+`resource` onto a report `dataSource`. The limb was speculative in the commit
+that introduced it, and per AGENTS.md #0.1 an off-spec spelling is corrected at
+the producer, never taught a second dialect by the renderer.
+
+The `:275` wording now names only `object`. A diagnostic that lists a key the
+contract does not declare is not a small thing: it is the system telling an
+author — increasingly, an author's code generator — that the wrong spelling is
+supported.

--- a/packages/app-shell/src/views/ReportView.dataSourceObjectKey.test.tsx
+++ b/packages/app-shell/src/views/ReportView.dataSourceObjectKey.test.tsx
@@ -117,7 +117,9 @@ const OTHER_OBJECT = {
  * which field list the config panel was handed.
  */
 async function mountReport(ds: Record<string, unknown>) {
-  const find = vi.fn(async () => ({ data: [{ id: '1' }] }));
+  const find = vi.fn(
+    async (_objectName: string, _params?: Record<string, unknown>) => ({ data: [{ id: '1' }] }),
+  );
   meta.value = {
     apps: [],
     objects: [ACCT_OBJECT, OTHER_OBJECT],
@@ -142,7 +144,7 @@ async function mountReport(ds: Record<string, unknown>) {
 
   return {
     /** First argument of the adapter query, or null when never queried. */
-    queried: find.mock.calls.length ? (find.mock.calls[0][0] as string) : null,
+    queried: find.mock.calls.length ? find.mock.calls[0][0] : null,
     /** Field values the config panel got, e.g. ['industry'] or the fallbacks. */
     fieldValues: (cap.panel.availableFields as any[]).map((f) => f.value),
   };
@@ -161,7 +163,8 @@ afterEach(() => {
 });
 
 /** Every `console.warn` argument the view emitted, flattened to one string. */
-const warnText = () => warn.mock.calls.map((c) => c.join(' ')).join('\n');
+const warnText = () =>
+  warn.mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
 
 describe('ReportView — `dataSource.object` is the only spelling (objectui#5116)', () => {
   it('object only: queries that object, and derives the field list from it', async () => {

--- a/packages/app-shell/src/views/ReportView.dataSourceObjectKey.test.tsx
+++ b/packages/app-shell/src/views/ReportView.dataSourceObjectKey.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ReportView reads `dataSource.object` — and ONLY `object` (objectui#5116).
+ *
+ * The view used to accept `resource` as a second spelling of `object` in two
+ * places, and to NAME that spelling in a user-facing warning:
+ *
+ *   :171  liveReport?.objectName || liveReport?.dataSource?.object
+ *                                || liveReport?.dataSource?.resource
+ *   :273  dataFetchSource.dataSource.object || dataFetchSource.dataSource.resource
+ *   :275  console.warn('ReportView: dataSource missing object/resource property')
+ *
+ * `resource` is not on this contract. `ElementDataSourceConfig`
+ * (`packages/core/src/data-scope/element-data-source.ts`) declares
+ * `object` / `view?` / `filter?` / `sort?` / `limit?`, its spec twin
+ * `ElementDataSourceSchema` is `z.strictObject` (an extra `resource` key is
+ * REJECTED, not ignored), and the binding's own predicate
+ * `isElementDataSourceConfig` decides on `object` — so a `resource`-only
+ * binding was never a binding on any other renderer. `resource` IS a real key
+ * elsewhere (`CRUDSchema.resource`, the `DataSource` adapter's first
+ * parameter, `LiveExportOptions.resource`); none of those is this surface.
+ *
+ * Per AGENTS.md #0.1 the fix belongs at the producer, never as a renderer-side
+ * alias — and the producer census found no producer to fix: nothing in this
+ * repo or in the `objectstack` framework repo writes `resource` onto a report
+ * `dataSource`. The limb was speculative from the commit that introduced it.
+ *
+ * What these pin, per input shape, BY RENDERING (not by reading the source):
+ *
+ *   object only      -> queries that object                (unchanged)
+ *   resource only    -> NOT queried; the view reports it    (behaviour REMOVED)
+ *   object+resource  -> queries `object`; `resource` inert  (unchanged)
+ *   neither          -> NOT queried; the view reports it    (unchanged)
+ *
+ * and, on the second limb, which object the config panel's field list is
+ * derived from. Both limbs are measured in every shape, so a fix applied to
+ * only one of them fails here.
+ *
+ * Non-vacuity: the `resource`-only cases put a REAL object (`acct`, with real
+ * fields) behind the non-contract spelling, so "no query" and "fallback
+ * fields" prove the spelling was not read — not that there was nothing to
+ * read.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+/** Props the (stubbed) report renderer and config panel were handed. */
+const cap = vi.hoisted(() => ({ renderer: null as any, panel: null as any }));
+
+vi.mock('@object-ui/plugin-report', () => ({
+  ReportRenderer: (props: any) => {
+    cap.renderer = props;
+    return null;
+  },
+}));
+vi.mock('@object-ui/plugin-dashboard', () => ({ DrillDownDrawer: () => null }));
+vi.mock('./ReportConfigPanel', () => ({
+  ReportConfigPanel: (props: any) => {
+    cap.panel = props;
+    return null;
+  },
+}));
+
+const meta = vi.hoisted(() => ({ value: null as any }));
+vi.mock('../providers/MetadataProvider', () => ({ useMetadata: () => meta.value }));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ reportName: 'revenue_by_month' }),
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/reports/revenue_by_month', search: '' }),
+}));
+
+vi.mock('./useOpenRecordList', () => ({ useOpenRecordList: () => vi.fn() }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false }),
+}));
+vi.mock('./metadata-admin/useMetadata', () => ({ useMetadataClient: () => ({ get: vi.fn() }) }));
+vi.mock('./runtime-metadata-persistence', () => ({ persistRuntimeMetadata: vi.fn() }));
+vi.mock('../providers/AdapterProvider', () => ({ useAdapter: () => ({}) }));
+vi.mock('../providers/ExpressionProvider', () => ({ useExpressionContext: () => ({ app: undefined }) }));
+vi.mock('@object-ui/auth', () => ({ useIsWorkspaceAdmin: () => true }));
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({ t: (k: string) => k }),
+  createSafeTranslation: (defaults: Record<string, string>) => () => ({
+    t: (k: string) => defaults?.[k] ?? k,
+  }),
+}));
+
+import { ReportView } from './ReportView';
+
+/** A REAL object with REAL fields — what a read of `resource` would find. */
+const ACCT_OBJECT = {
+  name: 'acct',
+  label: 'Account',
+  fields: { industry: { label: 'Industry', type: 'text' } },
+};
+/** A second real object, so "both keys" can show WHICH one was read. */
+const OTHER_OBJECT = {
+  name: 'other',
+  label: 'Other',
+  fields: { misc: { label: 'Misc', type: 'text' } },
+};
+
+/**
+ * Mount the view over a report whose `dataSource` is exactly `ds`, and hand
+ * back the two live measurements: what the adapter was asked to query, and
+ * which field list the config panel was handed.
+ */
+async function mountReport(ds: Record<string, unknown>) {
+  const find = vi.fn(async () => ({ data: [{ id: '1' }] }));
+  meta.value = {
+    apps: [],
+    objects: [ACCT_OBJECT, OTHER_OBJECT],
+    dashboards: [],
+    reports: [{ name: 'revenue_by_month', label: 'Revenue by Month', dataSource: ds }],
+    pages: [],
+    loading: false,
+    error: null,
+    refresh: async () => {},
+    invalidate: () => {},
+    ensureType: async () => [],
+    getItem: vi.fn(async () => null),
+    getItemsByType: () => [],
+    getTypeStatus: () => 'ready',
+  };
+
+  render(<ReportView dataSource={{ find } as any} />);
+  await waitFor(() => expect(cap.panel).not.toBeNull());
+  // The fetch effect is async; let it settle before reading the spy.
+  await waitFor(() => expect(find.mock.calls.length >= 0).toBe(true));
+  await new Promise((r) => setTimeout(r, 0));
+
+  return {
+    /** First argument of the adapter query, or null when never queried. */
+    queried: find.mock.calls.length ? (find.mock.calls[0][0] as string) : null,
+    /** Field values the config panel got, e.g. ['industry'] or the fallbacks. */
+    fieldValues: (cap.panel.availableFields as any[]).map((f) => f.value),
+  };
+}
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  cap.renderer = null;
+  cap.panel = null;
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warn.mockRestore();
+  vi.clearAllMocks();
+});
+
+/** Every `console.warn` argument the view emitted, flattened to one string. */
+const warnText = () => warn.mock.calls.map((c) => c.join(' ')).join('\n');
+
+describe('ReportView — `dataSource.object` is the only spelling (objectui#5116)', () => {
+  it('object only: queries that object, and derives the field list from it', async () => {
+    const { queried, fieldValues } = await mountReport({ object: 'acct' });
+
+    expect(queried).toBe('acct');
+    expect(fieldValues).toEqual(['industry']);
+    expect(warnText()).not.toContain('dataSource missing');
+  });
+
+  it('resource only: NOT queried — the undeclared spelling is not a binding', async () => {
+    const { queried, fieldValues } = await mountReport({ resource: 'acct' });
+
+    // `acct` is a real object with real fields; it stays unread all the same.
+    expect(queried).toBeNull();
+    expect(fieldValues).not.toContain('industry');
+    expect(warnText()).toContain('ReportView: dataSource missing object property');
+  });
+
+  it('object + resource: `object` wins and `resource` is inert', async () => {
+    const { queried, fieldValues } = await mountReport({ object: 'acct', resource: 'other' });
+
+    expect(queried).toBe('acct');
+    expect(fieldValues).toEqual(['industry']);
+    expect(warnText()).not.toContain('dataSource missing');
+  });
+
+  it('neither: NOT queried, and the view reports the missing key', async () => {
+    const { queried } = await mountReport({});
+
+    expect(queried).toBeNull();
+    expect(warnText()).toContain('ReportView: dataSource missing object property');
+  });
+
+  it('the warning names `object` and does NOT teach the non-contract `resource`', async () => {
+    await mountReport({ resource: 'acct' });
+
+    const text = warnText();
+    expect(text).toContain('object');
+    // The old wording was 'missing object/resource property' — a user-facing
+    // diagnostic that promised a key the contract never declared.
+    expect(text).not.toContain('resource');
+    expect(text).not.toContain('object/resource');
+  });
+});

--- a/packages/app-shell/src/views/ReportView.tsx
+++ b/packages/app-shell/src/views/ReportView.tsx
@@ -168,7 +168,7 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
   // Uses live editSchema when available to respond to objectName changes
   const availableFields = useMemo(() => {
     const liveReport = editSchema || reportData;
-    const objName = liveReport?.objectName || liveReport?.dataSource?.object || liveReport?.dataSource?.resource;
+    const objName = liveReport?.objectName || liveReport?.dataSource?.object;
     return getFieldsForObject(objName) ?? FALLBACK_FIELDS;
   }, [editSchema, reportData, getFieldsForObject]);
 
@@ -269,15 +269,18 @@ export function ReportView({ dataSource }: { dataSource?: DataSource }) {
     if (dataFetchSource.dataSource) {
       const fetchDataFromSource = async () => {
         try {
-          // Use the dataSource configuration to fetch data
-          const resource = dataFetchSource.dataSource.object || dataFetchSource.dataSource.resource;
-          if (!resource) {
-            console.warn('ReportView: dataSource missing object/resource property');
+          // Use the dataSource configuration to fetch data. `object` is the
+          // ONLY spelling this binding declares (ElementDataSourceConfig /
+          // the spec's strict ElementDataSourceSchema); the adapter just
+          // happens to call its first parameter `resource` (objectui#5116).
+          const objectName = dataFetchSource.dataSource.object;
+          if (!objectName) {
+            console.warn('ReportView: dataSource missing object property');
             setReportRuntimeData([]);
             return;
           }
 
-          const result = await dataSource.find(resource, {
+          const result = await dataSource.find(objectName, {
             $filter: dataFetchSource.dataSource.filter,
             $orderby: dataFetchSource.dataSource.sort,
             $top: dataFetchSource.dataSource.limit,


### PR DESCRIPTION
Fixes #5116

`ReportView` accepted `resource` as a second spelling of `object` on a report's `dataSource` binding, in two places, and **named that spelling in a warning the user could read**:

```
:171  liveReport?.objectName || liveReport?.dataSource?.object
                             || liveReport?.dataSource?.resource
:273  dataFetchSource.dataSource.object || dataFetchSource.dataSource.resource
:275  console.warn('ReportView: dataSource missing object/resource property')
```

`resource` is not on this contract. `ElementDataSourceConfig` declares `object` / `view?` / `filter?` / `sort?` / `limit?`; its spec twin `ElementDataSourceSchema` is a **strict** object, so an extra `resource` key is *rejected* there rather than ignored; and the binding's predicate `isElementDataSourceConfig` decides on `object`. A `resource`-only binding was therefore never a binding on any other renderer — it rendered here and silently produced nothing everywhere else, with neither end reporting a problem.

`resource` is a real key on **other** surfaces — `CRUDSchema.resource`, the `DataSource` adapter's first parameter, `LiveExportOptions.resource` — all three untouched. None of them is this one.

Per AGENTS.md #0.1 an off-spec spelling is corrected at the producer, never taught a second dialect by the renderer.

## Producer census (premise-first), with counter-probe

Triage asked this be re-verified on current `main` before deleting: **if any producer or authored site supplies `resource` on this binding, the card becomes a migration, not a tolerance deletion.** Result: **zero producers.**

| probe | objectui | objectstack (framework) |
| --- | --- | --- |
| `dataSource` block containing `resource` | **0** real hits | **0** hits |
| **counter-probe** — same regex, `object` instead | **182** hits | **15** hits |

The counter-probe is what makes the zero a *reading* rather than a broken search: the identical multiline pattern finds 182 + 15 sites for the key that *is* produced.

Authored corpora were searched too, not just source — docs (`content/docs/**`), `skills/**`, examples, fixtures, and every `.json` / `.yaml` / `.md` / `.mdx`. Every authored `resource:` key found resolves to a **different surface**, individually inspected:

- `packages/plugin-report/README.md:412` — `LiveExportOptions.resource`, an argument to `exportWithLiveData`, beside the runtime **adapter**
- `content/docs/api/schema-reference.md:532` — `CRUDSchema.resource` (`type: 'crud'`)
- `content/docs/guide/objectos-integration.mdx:284` — `useViewData({ resource })` hook options
- `packages/core/src/adapters/README.md:33` — a **sibling** key of `dataSource` on a `data-table` schema, not `dataSource.resource`
- `packages/permissions/README.md:108` — `evaluatePermission({ resource })`
- the remaining ~770 tokens are `DataSource` method parameters, plugin-gantt's resource-workload feature, etc.

The two multiline hits inside a `dataSource` block are both the adapter interface declaring `create(resource: string, ...)` / `update(resource: string, ...)` — method parameters, not a metadata key.

**History**: `git log -S` traced the limb to the commit that first added data loading to this view. It was speculative *in that commit* — no producer preceded it, and none appeared since. The three report fixtures in `examples/schema-catalog` carry no `dataSource` at all.

The premise holds, so the deletion proceeds rather than escalating.

## Behaviour, measured by rendering

Each input shape was rendered through the real component before and after, reading the actual adapter query, the rows handed to the renderer, the config panel's field list, and the warning. The `resource`-only cases put a **real** object (`acct`, with real fields) behind the non-contract spelling, so "not queried" proves the spelling was not read, not that there was nothing to read.

| binding | before | after |
| --- | --- | --- |
| `{ object: 'acct' }` | queries `acct`, 1 row, fields `industry` | **unchanged** |
| `{ resource: 'acct' }` | queries `acct`, 1 row, fields `industry`, no warning | **not queried**, 0 rows, fallback fields, warns `ReportView: dataSource missing object property` |
| `{ object: 'acct', resource: 'other' }` | queries `acct`, fields `industry` | **unchanged** — `resource` was already inert |
| `{}` | not queried, 0 rows, fallback fields, warns `missing object/resource property` | not queried, 0 rows, fallback fields, warns `missing object property` |

**The behaviour being removed, stated plainly**: a `resource`-only report binding used to render as if declared. It now fails **loudly** — a named warning, zero rows, and the fallback field list — instead of appearing to work while every other renderer in the system disagreed with it. Only that one shape moves; the other three are byte-identical readings.

The `:275` wording now names only `object`. A diagnostic listing a key the contract does not declare is not cosmetic: it is the system telling an author — increasingly, an author's code generator — that the wrong spelling is supported.

## Reverse-verification

Both legs were run **from the committed state**, direction predicted before running.

| leg | ablation | predicted | observed |
| --- | --- | --- | --- |
| 1 | restore `origin/main` `ReportView.tsx` (both limbs + old wording) | RED, **3 failed / 2 passed**; `resource only`, `neither`, `warning names object` | **exact match** — `expected 'acct' to be null`, `missing object/resource property`, `expected '' to contain 'object'` |
| 2 | restore **only** the two `||` limbs, keep the reworded warning | RED, **2 failed / 3 passed** — `neither` now PASSES, since only the wording half pins it | **exact match** |

Leg 2 is what separates the two halves of the fix: it shows each assertion is load-bearing for a specific limb, and that `neither` is the assertion pinning the `:275` reword.

Ablation validity: this package's tests resolve the component through a **relative source import** (`./ReportView`) and the root vitest alias table maps every `@object-ui/*` specifier to `src/` — so the mutation is read straight from source with no `dist/` in the path. Demonstrated rather than assumed: the source-only edit moved the suite red and back green with no rebuild between.

Restored afterwards and proven clean by blob hash, not by eyeball — worktree `13466eff4fc346c70267b5c2f44a3a9c910062b1` equals the committed blob, `git status` empty.

## Verification at `d8a61a5ce`

The gate union below was run **after** the final commit, on that sha.

- `pnpm exec vitest run packages/app-shell/src/views/` — **285 files, 2817 passed, 1 skipped** (the skip is a pre-existing spec-version `skipIf` in `flow-node-config.spec-reconciliation.test.ts`, untouched)
- `pnpm exec vitest run packages/app-shell/src/console/ packages/app-shell/src/__tests__/` — **59 files, 500 passed** (the route + barrel that consume `ReportView`)
- new pin `ReportView.dataSourceObjectKey.test.tsx` — **5/5**
- `pnpm --filter @object-ui/app-shell type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`, script name echoed; 3 real type errors in the new test were found and fixed here, not suppressed)
- `eslint` on both changed files — 0 errors. `ReportView.tsx` warning count is **24 before and 24 after**, measured against an `origin/main` copy — zero introduced
- `check:control-bytes`, `check:esm-specifiers`, `check:self-import`, `check:phantom-deps`, `check:doc-types` — pass
- `check:doc-snippets` — pass, **after building the packages it resolves against**; its own sentinel/positive controls are green, so this is a real reading rather than a skipped one
- `check:eager-closure` (ratchet) — pass: **3792.5 KB gzipped, budget 3867.2 KB, 74.7 KB headroom**. Required building `apps/console` and its closure; `ReportView` stays lazily routed, and no import statement changed
- `check-changeset-presence`, `check-changeset-no-major` — pass

No test skipped, disabled, or quarantined.

## Notes

- **Changeset**: `minor`, declaring the removal honestly with the per-shape table. Not `major` — per AGENTS.md that would drag the whole 39-package fixed group off the `@objectstack` major it tracks.
- **Small rename in the same hunk**: the local `resource` variable at the fetch site is now `objectName`. It was the last in-code echo of the non-contract spelling *on the very line being fixed*, and an open invitation to re-add the alias. The adapter's own parameter is still called `resource`; a comment records where the two vocabularies meet.
- **Scope**: three files. `#5203` is in flight in this same package but confined to `layout/` and `hooks/` — **neither directory is touched**, verified against the merge base. No governed surface (`AGENTS.md`, `CLAUDE.md`, `.claude/**`, `docs/adr/**`, `skills/**`) is touched.
- No out-of-scope findings surfaced; nothing was filed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV6yuVCxymHYE16PL9vQkE)_