### PR TITLE
fix(fields): required file grid cells announce their state — FileCell gains the published error slot

### DIFF
--- a/.changeset/filecell-error-slot-5431.md
+++ b/.changeset/filecell-error-slot-5431.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/fields': minor
+---
+
+**API addition (public-surface widening):** `FileCell` — the compact upload
+control `@object-ui/fields` exports for line-item grid cells — gains the
+published optional `error?: string` slot, mirroring `LookupField` and
+`FileField`: the same validation slot `@objectstack/spec/ui`'s
+`FieldWidgetPropsSchema` declares and `FieldWidgetComponentProps` names
+(objectui#3222). When set, `FileCell` puts `aria-invalid` on its own focusable
+picker button; the message text stays with the host (objectui#5431).
+
+`GridField` now passes that slot for a required-but-empty `file` cell — the one
+cell type objectui#3318's per-cell `aria-invalid` delivery left out. Before
+this, a required `file` cell flagged only the visual ring and `title` on the
+`td`; no element in the cell subtree announced the state, so assistive tech was
+told nothing (a wrapper-only mark is exactly what objectui#5223 forbids). Text,
+number, select, and lookup cells were wired in PR #5429; `file` cells now
+behave identically.

--- a/packages/fields/src/complex-widgets.test.tsx
+++ b/packages/fields/src/complex-widgets.test.tsx
@@ -5,7 +5,7 @@ import { ActionProvider } from '@object-ui/react';
 import { FieldEditWidget } from './FieldEditWidget';
 import { MasterDetailField } from './widgets/MasterDetailField';
 import { GridField } from './widgets/GridField';
-import { FileField } from './widgets/FileField';
+import { FileField, FileCell } from './widgets/FileField';
 import type { FieldWidgetComponentProps } from './widgets/types';
 
 // ------------- Mocks & Setup -------------
@@ -864,6 +864,20 @@ describe('Complex & Relationship Widgets', () => {
              // edit mode renders inputs whose values are the row data
              expect(screen.getByDisplayValue('Alice')).toBeInTheDocument();
              expect(screen.getByDisplayValue('30')).toBeInTheDocument();
+        });
+    });
+
+    describe('FileCell (grid cell helper)', () => {
+        it('drives aria-invalid on its picker button from the published error slot (#5431)', () => {
+            render(<FileCell value={null} onChange={() => {}} aria-label="Receipt" error="Receipt is required" />);
+            // The carrier is the focusable picker control, mirroring
+            // LookupField's trigger and FileField's dropzone (#3222 / #5223).
+            expect(screen.getByRole('button', { name: 'Receipt' }).getAttribute('aria-invalid')).toBe('true');
+        });
+
+        it('reports aria-invalid="false" when the slot is empty', () => {
+            render(<FileCell value={null} onChange={() => {}} aria-label="Receipt" />);
+            expect(screen.getByRole('button', { name: 'Receipt' }).getAttribute('aria-invalid')).toBe('false');
         });
     });
 

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -408,6 +408,7 @@ export function FileCell({
   multiple,
   accept,
   maxSize,
+  error,
   'aria-label': ariaLabel,
   'data-cell': dataCell,
 }: {
@@ -419,6 +420,22 @@ export function FileCell({
   accept?: string;
   /** Max file size in bytes (oversize picks are rejected with an inline error). */
   maxSize?: number;
+  /**
+   * The active validation message for this cell, named as
+   * `@objectstack/spec/ui`'s `FieldWidgetPropsSchema` names it — the same
+   * published slot `FieldWidgetComponentProps` declares and `LookupField` /
+   * `FileField` above already consume (objectui#5431, completing #3318's
+   * per-cell delivery). NOT the per-pick upload `errors` this component
+   * computes itself — this is the HOST's verdict on the cell's value.
+   *
+   * **Producer**: `GridField`, for a required-but-empty `file` cell.
+   * **Consumer**: drives `aria-invalid` on the picker button — the focusable
+   * control assistive tech reads a control state from (objectui#5223; a mark
+   * on the non-focusable wrapper is exactly what the registry sweep forbids).
+   * The message TEXT stays with the cell's `title` in `GridField`; rendering
+   * it here would double-display it.
+   */
+  error?: string;
   'aria-label'?: string;
   /** Focus-grid coordinate (see GridField keyboard navigation). */
   'data-cell'?: string;
@@ -499,6 +516,10 @@ export function FileCell({
           aria-label={ariaLabel}
           data-cell={dataCell}
           disabled={disabled}
+          // The published `error` slot lands here, on the focusable control a
+          // keyboard user edits — same computation as FileField's dropzone and
+          // LookupField's trigger (#3222 / #5431).
+          aria-invalid={!!error}
         >
           <Upload className="size-3.5" />
           {files.length === 0 && t('fields.file.upload', { defaultValue: 'Upload' })}

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -544,6 +544,47 @@ describe('GridField / LineItemsField — editable line items', () => {
       expect(onChange).toHaveBeenCalledWith([{ description: 'Taxi', receipt: null }]);
     });
 
+    it('announces a required, empty file cell on the focusable picker control (#5431)', () => {
+      const reqFileField = {
+        columns: [{ name: 'receipt', label: 'Receipt', type: 'file' as const, required: true }],
+      } as any;
+      render(<GridField value={[{ receipt: null }]} onChange={() => {}} field={reqFileField} />);
+      // The VISUAL ring + testid predate #5431 and are not the assertion —
+      // the announced state is. The carrier must be the focusable picker
+      // button inside the cell, never the td wrapper (#3318 / #5223).
+      const cell = screen.getByTestId('line-items-invalid-0-receipt');
+      const carrier = cell.querySelector('[aria-invalid="true"]');
+      expect(carrier).toBeTruthy();
+      expect(carrier!.tagName).toBe('BUTTON');
+      expect(cell.getAttribute('aria-invalid')).toBeNull();
+    });
+
+    it('does not announce invalid on an optional empty file cell or on the ghost row', () => {
+      const optFileField = {
+        columns: [{ name: 'receipt', label: 'Receipt', type: 'file' as const }],
+      } as any;
+      const { container } = render(
+        <GridField value={[{ receipt: null }]} onChange={() => {}} field={optFileField} />,
+      );
+      // Data row and ghost row each render a picker; none may announce invalid.
+      expect(container.querySelector('[aria-invalid="true"]')).toBeNull();
+    });
+
+    it('stops announcing once the required file cell holds a file', () => {
+      const reqFileField = {
+        columns: [{ name: 'receipt', label: 'Receipt', type: 'file' as const, required: true }],
+      } as any;
+      const { container } = render(
+        <GridField
+          value={[{ receipt: { name: 'receipt.png', mime_type: 'image/png' } }]}
+          onChange={() => {}}
+          field={reqFileField}
+        />,
+      );
+      expect(screen.queryByTestId('line-items-invalid-0-receipt')).toBeNull();
+      expect(container.querySelector('[aria-invalid="true"]')).toBeNull();
+    });
+
     it('passes the column accept list to the native picker', () => {
       const withAccept = {
         columns: [{ name: 'receipt', label: 'Receipt', type: 'file' as const, accept: ['image/*', '.pdf'] }],

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -892,10 +892,6 @@ export function GridField({
     // not a text input: chips for uploaded files + a compact picker button.
     if (c.type === 'file') {
       return (
-        // Not marked by `invalid`: `FileCell`'s prop set is closed and its
-        // control is its own (objectui#3318 kept the scope to the controls this
-        // file renders directly). A required FILE column therefore still marks
-        // only the cell's visual ring — tracked, not silently accepted.
         <FileCell
           value={val}
           onChange={(v: any) => setCellValue(rowIdx, c.name, v)}
@@ -904,6 +900,11 @@ export function GridField({
           disabled={locked}
           aria-label={c.label || c.name}
           data-cell={`${rowIdx}-${colIdx}`}
+          // The published `error` slot, not a hand-rolled attribute — same
+          // wiring as the lookup branch above: FileCell puts `aria-invalid` on
+          // its own focusable picker button from it (objectui#5431, closing
+          // the one cell type #3318 left out).
+          error={invalid ? `${c.label || c.name} is required` : undefined}
         />
       );
     }


### PR DESCRIPTION
Fixes #5431

## What

A required-but-empty `file` cell in `GridField` flagged only the visual ring and `title` on the `td` — no element in the cell subtree carried `aria-invalid`, so assistive tech was told nothing. #3318 / PR #5429 wired every other cell type (text/number/currency/date/datetime/time, select, lookup); `file` was left out because `FileCell`'s prop set was closed.

Per the dispatch ruling (option 1, triage-concurred): `FileCell` gains the published `error` slot mirroring `LookupField`, and the grid passes it.

## Public-surface widening (stated explicitly, per the contract-review dispatch)

`FileCell` is exported from `@object-ui/fields`'s barrel (`export * from './widgets/FileField.js'`), so the new **optional `error?: string` prop is an API addition** to a published package. It is the same validation slot `@objectstack/spec/ui`'s `FieldWidgetPropsSchema` declares (verified: `error: z.ZodOptional<z.ZodString>` in the installed spec typings) and `FieldWidgetComponentProps` names (objectui#3222) — no second spelling is minted. The changeset declares `minor` and describes the addition.

## How

- `packages/fields/src/widgets/FileField.tsx` — `FileCell` takes `error?: string` (doc comment states producer/consumer and distinguishes it from the component's own per-pick upload `errors`). The carrier is the **focusable picker button** (`aria-invalid={!!error}`), the same computation as `FileField`'s dropzone and `LookupField`'s trigger — never the wrapper (#5223).
- `packages/fields/src/widgets/GridField.tsx` — the `file` branch passes `error={invalid ? `…is required` : undefined}` exactly as the lookup branch does; the "not marked — tracked, not silently accepted" comment is replaced.

## Tests

- `GridField.test.tsx`: required-empty file cell → the `aria-invalid="true"` carrier inside the flagged cell is a BUTTON and the `td` is not the carrier; optional-empty and required-filled cells announce nothing; ghost row stays unmarked.
- `complex-widgets.test.tsx`: `FileCell` unit pins — `error` set → picker button `aria-invalid="true"`; slot empty → `"false"`.
- **Reverse verification** (fix committed first, sources reverted to `origin/main`, mutation confirmed on disk by anchored grep counts 2→1 for both `aria-invalid={!!error}` and `error={invalid`): exactly the 3 positive pins went red (`Tests 3 failed | 85 passed`), the 2 negative guards stayed green as predicted; restore leg confirmed markers back (counts 2/2) and 88/88 green. No dist rebuild involved — both suites import the widgets by relative src path.
- The registry sweep (`widget-aria-invalid-registry-e2e.test.tsx`) legitimately does not see this per-column-type gap (text/number grid config) and stays green before and after — not cited as evidence.

## Verification (all at head `818107d`)

- `pnpm exec vitest run packages/fields/ packages/plugin-detail/src/__tests__/RelatedList.filecolumns.test.tsx packages/plugin-form/src/deriveMasterDetail.test.ts packages/plugin-form/src/deriveMasterDetail.declaredSpelling.test.tsx --maxWorkers=2` → `Test Files 113 passed (113)`, `Tests 1882 passed (1882)` (includes the two FileCell-consumer suites outside the package)
- `pnpm --filter @object-ui/fields type-check` → exit 0 (script echoed; deps built first via `pnpm --workspace-concurrency=2 --filter '@object-ui/fields^...' build`)
- `pnpm exec turbo run lint --filter=@object-ui/fields --concurrency=2` → `0 errors` (857 pre-existing warnings, package `no-explicit-any` baseline). Narrowed lint declared: root lint is per-package `turbo run lint`; no per-package eslint config exists, root flat config has no type-aware (`projectService`/`project`) settings and no markdown plugin, so the fields package is the entire lint population this diff can move; changesets sit in no eslint population.
- `node scripts/check-control-bytes.mjs`, `check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-changeset-fixed.mjs` → all ✅

Note: the dispatch's gate list named objectstack-side gates (`check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, plugin-teardown/docs-audit/ADR-0087 scripts) that do not exist in this repo; re-derived against objectui's actual gate set as above.

## Scope

File surface as dispatched: the two widget sources, their tests, and a changeset. `packages/fields/README.md` mentions `FileCell` only for upload mechanics (no prop list documented), so no doc file is touched; the changeset carries the API-addition record.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_