### PR TITLE
Approvals Inbox: the raw payload panel is a platform-operator affordance, not the approver's read path

### DIFF
--- a/.changeset/approvals-raw-payload-gate-5553.md
+++ b/.changeset/approvals-raw-payload-gate-5553.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/console': patch
+---
+
+The Approvals Inbox no longer shows a business approver the submitted record's raw
+row JSON.
+
+The detail drawer's "Raw data (JSON)" panel rendered on `payload != null` alone — no
+principal check of any kind — so every approver could expand (and one-click copy) the
+complete raw snapshot: `id`, `created_by`, `updated_by`, `owner_id`,
+`organization_id`, bare lookup ids, and **the fields the object's metadata declares
+`hidden: true`**. Reported from a live EHR deployment on 17.1.0
+(objectstack-ai/objectstack#10734), where that declaration is a patient-data control.
+The app author had no legitimate lever to remove the panel — field `hidden`, view
+columns, app navigation, permission sets and env vars are all ineffective against it —
+so the remedies available in the field were patching the shipped bundle or injecting
+CSS.
+
+The panel is now gated on `holdsStudioAccess`, reused verbatim from the console's
+`studioEntry` module: `studio.access` is a declared platform-scope capability that a
+tenant org owner does not hold by design, and it already reaches the browser in
+`systemPermissions[]` from `/api/v1/auth/me/permissions`. Nothing new is served,
+computed or made authorable — no new config key, no new i18n copy, and the panel is
+byte-for-byte unchanged for the platform operator it was written for. A business
+approver keeps the structured record summary, the approval chain, the activity feed
+and the decision actions; only the raw snapshot is gone.
+
+The gate reads the RAW `systemPermissions` signal and fails **CLOSED**, inverted from
+`usePermissions().hasCapabilities`. That hook fails open on purpose — hiding a
+holder's button while the server still refuses the write is the worse outcome for an
+action. This panel has the opposite stake, since the measured defect is a non-holder
+seeing it, so every not-a-reported-grant answer denies: no provider mounted, a backend
+predating ADR-0066 that omits the field, the resolver's `catch` path that answers `200`
+with no `systemPermissions` at all, and a reported empty array. A deployment whose
+permission layer just failed must not be the one that leaks the snapshot.
+
+`ApprovalsInboxPage.rawPayloadGate.test.tsx` pins all four verdicts. Because the
+acceptance condition is that something does *not* render — which an empty render
+reproduces perfectly — every denial case also asserts the drawer it denies inside, and
+the `studio.access` case drives the same fixture through the same helper and finds the
+panel. `created_by` and `organization_id` are the witnesses: both are in the page's
+`PAYLOAD_SYSTEM_KEYS`, so the summary card already drops them and their values can
+reach the DOM only through the raw panel. Ablating the gate (restoring the bare
+`payload != null` condition) turns the three denial cases red on exactly that
+assertion and leaves the holder case green.
+
+Out of scope, tracked separately: trimming the summary by object metadata, and the
+server-side residual that sends the unfiltered snapshot to the client at all.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.rawPayloadGate.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.rawPayloadGate.test.tsx
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Approvals Inbox — the raw payload snapshot is a platform-operator affordance,
+ * never the business approver's read path (objectui#5553).
+ *
+ * ## The defect
+ *
+ * The detail drawer's "Raw data (JSON)" panel rendered on `payload != null`
+ * alone — no principal check of any kind — so every business approver was
+ * handed the submitted record's complete raw row: internal ids, `created_by` /
+ * `updated_by` / `owner_id` / `organization_id`, bare lookup ids, and the
+ * fields the object's metadata declares `hidden: true`. Reported from a live
+ * EHR deployment on 17.1.0 (objectstack#10734), where that declaration is a
+ * patient-data control. Per the maintainer's ruling the panel does not render
+ * for a business approver by default; holding a platform-admin-only capability
+ * (`studio.access`, via `holdsStudioAccess`) is what restores it.
+ *
+ * ## Why every absence case here carries a counter-probe
+ *
+ * The acceptance condition is that something does NOT render, and a suite that
+ * renders nothing at all reproduces that perfectly. So each denial case also
+ * asserts the drawer it is denying inside — the process label and the business
+ * summary row — and the `studio.access` case renders the SAME fixture through
+ * the SAME helper and finds the panel. An empty render fails the counter-probe;
+ * a gate stuck open fails the denials. Neither can pass alone.
+ *
+ * ## The witnesses
+ *
+ * `created_by` and `organization_id` are in the page's `PAYLOAD_SYSTEM_KEYS`,
+ * so the summary card already drops them: their values can reach the DOM only
+ * through the raw panel. That makes them exact witnesses for "the panel
+ * rendered", not proxies. (Both are also long enough to trip the summary's
+ * opaque-id filter, so neither can slip in by a second route.)
+ *
+ * ## ⛔ What this deliberately does NOT assert
+ *
+ * Nothing here says the summary card is trimmed by object metadata. This card
+ * is the gate only; trimming the payload by `hidden: true` and the server-side
+ * residual (the snapshot reaching the client unfiltered at all) are separate
+ * and are tracked elsewhere. Asserting them here would pin behaviour this
+ * change does not deliver.
+ *
+ * No build artifact sits between the edit and this test: the root Vitest config
+ * aliases every `@object-ui` specifier at that package's source directory, and
+ * the page under test is this app's own source.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MePermissionsProvider, type MePermissionsResponse } from '@object-ui/permissions';
+
+const APP = 'com.objectstack.account';
+
+/** The panel's summary label, as the page spells it through `tr`. */
+const PANEL_LABEL = 'Raw data (JSON)';
+
+/** Values that can only reach the DOM via the raw panel (see header). */
+const AUDIT_WITNESS = 'usr_audit_witness';
+const ORG_WITNESS = 'org_audit_witness';
+
+/** A business field the approver is meant to decide from — the counter-anchor. */
+const BUSINESS_FIELD = 'Q3 clinical supplies';
+
+const { approvalsApiStub, adapterFind, ADAPTER, AUTH, I18N } = vi.hoisted(() => {
+  const row = {
+    id: 'req_1',
+    process_name: 'purchase_approval',
+    process_label: 'Purchase Approval',
+    object_name: 'showcase_purchase',
+    object_label: 'Purchase',
+    record_id: 'po_1',
+    record_title: 'PO-4417',
+    status: 'pending',
+    pending_approvers: ['u_1'],
+    submitter_id: 'u_2',
+    submitter_name: 'Sam Submitter',
+    submitted_at: '2026-08-20T00:00:00.000Z',
+    payload: {
+      subject: 'Q3 clinical supplies',
+      created_by: 'usr_audit_witness',
+      organization_id: 'org_audit_witness',
+    },
+  };
+
+  const adapterFind = vi.fn(async () => ({ data: [{ id: 'po_1' }] }));
+
+  const approvalsApiStub = {
+    listRequests: vi.fn(async () => ({ data: [row], total: 1 })),
+    getRequest: vi.fn(async () => ({ data: row })),
+    listActions: vi.fn(async () => ({ data: [] })),
+    approve: vi.fn(async () => ({ data: row, finalized: true })),
+    reject: vi.fn(async () => ({ data: row, finalized: true })),
+  };
+
+  // STABLE singletons: a mocked hook handing back a fresh object per render
+  // re-runs the page's load effect forever and the drawer never settles.
+  const ADAPTER = { find: adapterFind };
+  const AUTH = { user: { id: 'u_1', email: 'approver@example.com' } };
+  const I18N = {
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  };
+
+  return { approvalsApiStub, adapterFind, ADAPTER, AUTH, I18N };
+});
+
+vi.mock('@object-ui/i18n', () => ({ useObjectTranslation: () => I18N }));
+
+vi.mock('@object-ui/auth', () => {
+  const authFetch = vi.fn(async () => new Response('{}', { status: 200 }));
+  return {
+    useAuth: () => AUTH,
+    createAuthenticatedFetch: () => authFetch,
+    TokenStorage: { get: () => null },
+  };
+});
+
+vi.mock('@object-ui/app-shell', () => ({
+  useAdapter: () => ADAPTER,
+  DeclaredActionsBar: () => null,
+  isViaOverrideRow: () => false,
+}));
+
+vi.mock('../../services/approvalsApi', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  approvalsApi: approvalsApiStub,
+}));
+
+// Imported after the mocks so the page picks them up.
+import { ApprovalsInboxPage } from './ApprovalsInboxPage';
+
+/**
+ * `/me/permissions` as the provider receives it. `systemPermissions` is passed
+ * through EXACTLY as given — `undefined` stays absent from the payload rather
+ * than becoming `[]`, because "never reported" and "reported, holds nothing"
+ * are different facts (objectui#4656) and this gate must deny on both.
+ */
+function permissionsPayload(systemPermissions: string[] | undefined): MePermissionsResponse {
+  const base: MePermissionsResponse = {
+    authenticated: true,
+    userId: 'u_1',
+    tenantId: 't_1',
+    roles: [],
+    permissionSets: [],
+    objects: {},
+    fields: {},
+  };
+  return systemPermissions === undefined ? base : { ...base, systemPermissions };
+}
+
+/**
+ * Render the inbox with the drawer already open on `req_1`, for a principal
+ * holding `systemPermissions`. The `?request=` deep link is the page's own
+ * notification entry point, so the drawer opens the way production opens it.
+ */
+function renderDrawerFor(systemPermissions: string[] | undefined) {
+  return render(
+    <MePermissionsProvider initialPermissions={permissionsPayload(systemPermissions)}>
+      <MemoryRouter initialEntries={[`/apps/${APP}/system/approvals?request=req_1`]}>
+        <Routes>
+          <Route path="/apps/:appName/system/approvals" element={<ApprovalsInboxPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MePermissionsProvider>,
+  );
+}
+
+/** The open drawer, once the deep-linked request has actually loaded into it. */
+async function openedDrawer(): Promise<HTMLElement> {
+  const dialog = await screen.findByRole('dialog');
+  await within(dialog).findByText('Purchase Approval');
+  return dialog;
+}
+
+/**
+ * The counter-probe, as one assertion: this drawer really did render its
+ * business content. Every denial case runs it, so "the panel is absent" can
+ * never be satisfied by an empty render.
+ */
+function expectBusinessDrawerRendered(dialog: HTMLElement): void {
+  expect(within(dialog).getByText('Purchase Approval')).toBeInTheDocument();
+  expect(within(dialog).getByText(BUSINESS_FIELD)).toBeInTheDocument();
+}
+
+beforeEach(() => {
+  adapterFind.mockClear();
+  for (const fn of Object.values(approvalsApiStub)) fn.mockClear();
+});
+afterEach(cleanup);
+
+describe('Approvals Inbox — raw payload panel gating (objectui#5553)', () => {
+  it('does not render the panel for a business approver, whose drawer is otherwise intact', async () => {
+    // `setup.access` is a real, reported grant — an org-level admin holds it —
+    // and it is deliberately NOT one of the platform-admin-only capabilities.
+    renderDrawerFor(['setup.access']);
+    const dialog = await openedDrawer();
+
+    expect(within(dialog).queryByText(PANEL_LABEL)).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(new RegExp(AUDIT_WITNESS))).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(new RegExp(ORG_WITNESS))).not.toBeInTheDocument();
+
+    expectBusinessDrawerRendered(dialog);
+  });
+
+  it('renders the panel, with the raw row, for a holder of studio.access', async () => {
+    renderDrawerFor(['studio.access']);
+    const dialog = await openedDrawer();
+
+    expect(within(dialog).getByText(PANEL_LABEL)).toBeInTheDocument();
+    // The raw row itself, not just its heading: the audit columns the business
+    // approver above could not reach are here, in the panel's JSON.
+    expect(within(dialog).getByText(new RegExp(AUDIT_WITNESS))).toBeInTheDocument();
+    expect(within(dialog).getByText(new RegExp(ORG_WITNESS))).toBeInTheDocument();
+
+    // Same fixture, same helper — so the denial above is a gate, not a fixture
+    // that renders nothing.
+    expectBusinessDrawerRendered(dialog);
+  });
+
+  it('denies on a REPORTED EMPTY capability set — "holds nothing" is a real answer', async () => {
+    renderDrawerFor([]);
+    const dialog = await openedDrawer();
+
+    expect(within(dialog).queryByText(PANEL_LABEL)).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(new RegExp(AUDIT_WITNESS))).not.toBeInTheDocument();
+    expectBusinessDrawerRendered(dialog);
+  });
+
+  it('denies when the backend reports no capability set at all (fail CLOSED)', async () => {
+    // The inverted-stake case: `hasCapabilities` fails OPEN here, and a
+    // deployment whose permission resolution just failed answers 200 with no
+    // `systemPermissions` at all. That deployment must not be the one that
+    // leaks the snapshot, so this gate reads the raw signal and denies.
+    renderDrawerFor(undefined);
+    const dialog = await openedDrawer();
+
+    expect(within(dialog).queryByText(PANEL_LABEL)).not.toBeInTheDocument();
+    expect(within(dialog).queryByText(new RegExp(AUDIT_WITNESS))).not.toBeInTheDocument();
+    expectBusinessDrawerRendered(dialog);
+  });
+});

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -73,6 +73,7 @@ import {
 } from '@object-ui/components';
 import { toast } from 'sonner';
 import { useAuth } from '@object-ui/auth';
+import { usePermissions } from '@object-ui/permissions';
 import { useObjectTranslation } from '@object-ui/i18n';
 import {
   CheckCircle2,
@@ -104,6 +105,7 @@ import {
   type ApprovalActionAttachment,
 } from '../../services/approvalsApi';
 import { useRecordReadability } from './recordReadability';
+import { holdsStudioAccess } from '../../components/studioEntry';
 
 type TabKey = 'pending' | 'submitted' | 'all';
 
@@ -518,6 +520,59 @@ export function ApprovalsInboxPage() {
   // stripped from the URL so refresh/back doesn't re-open a dismissed drawer.
   const [searchParams, setSearchParams] = useSearchParams();
   const identities = useMemo(() => buildApproverIdentities(user as any), [user]);
+
+  /**
+   * [objectui#5553] May THIS viewer see the drawer's raw payload snapshot?
+   *
+   * ## What this closes
+   *
+   * The drawer's "Raw data (JSON)" panel rendered on `payload != null` alone —
+   * no principal check of any kind — so every business approver was handed the
+   * submitted record's complete raw row: `id`, `created_by`, `updated_by`,
+   * `owner_id`, `organization_id`, bare lookup ids, and **the fields the
+   * object's metadata declares `hidden: true`**. Reported from a live EHR
+   * deployment on 17.1.0, where the app author's `hidden` declaration is a
+   * patient-data control and this path silently bypassed it. The app author had
+   * no legitimate lever to remove the panel — field `hidden`, view columns, nav,
+   * permission sets and env vars are all ineffective against it — so the only
+   * remedies in the field were patching `dist` or injecting CSS.
+   *
+   * ## The signal, and why this one
+   *
+   * `studio.access` is a declared PLATFORM-scope capability that a tenant org
+   * owner does not hold by design (it is one of the framework's
+   * `PLATFORM_ADMIN_ONLY_CAPABILITIES`), and it already reaches the browser in
+   * `systemPermissions[]` from `GET /api/v1/auth/me/permissions` — the payload
+   * `MePermissionsProvider` mounts around every route this page renders under
+   * (`AppContent`). Nothing new is served, computed, or made authorable here:
+   * `holdsStudioAccess` is reused verbatim from `studioEntry`, which is the
+   * console's existing answer to "is this principal a platform operator rather
+   * than a business user", so the two surfaces cannot drift into two spellings
+   * of one fact. Minting an authorable key for this (`approvals.showRawPayload`
+   * or any sibling) would be new public surface and is deliberately NOT done.
+   *
+   * ## ⛔ Fail CLOSED — inverted from `hasCapabilities`
+   *
+   * `usePermissions().hasCapabilities` fails OPEN on an unreported answer, and
+   * that is right for an action button: the server still refuses the write, and
+   * hiding a holder's button is the worse outcome. This panel has the opposite
+   * stake — the measured defect IS a non-holder seeing it — so the RAW signal is
+   * read instead (`systemPermissions`, whose `undefined`-vs-`[]` distinction
+   * objectui#4656 made load-bearing) and every not-a-reported-grant answer
+   * denies: no provider, a backend predating ADR-0066 that omits the field, and
+   * the resolver's `catch` path that answers 200 with no `systemPermissions` at
+   * all. A deployment whose permission layer just failed must not be the one
+   * that leaks the snapshot. A reported empty array is a real answer and denies
+   * too. The cost of denying wrongly is a platform operator losing a debug
+   * affordance, recoverable with a reload; the cost of granting wrongly is the
+   * leak this card exists to close.
+   *
+   * The server-side residual — the payload reaching the client unfiltered in the
+   * first place — is a separate defect tracked in the objectstack repo. This
+   * gate does not depend on it and does not pretend to fix it.
+   */
+  const { systemPermissions } = usePermissions();
+  const maySeeRawPayload = holdsStudioAccess(systemPermissions);
 
   const tr = useCallback(
     (key: string, defaultValue: string, opts?: Record<string, unknown>) =>
@@ -2076,8 +2131,12 @@ export function ApprovalsInboxPage() {
                 )}
               </div>
 
-              {/* Raw snapshot, collapsed by default — for debugging, not the read path */}
-              {selected.payload != null && (
+              {/* Raw snapshot — a platform-operator debug affordance, never the
+                  approver's read path. Gated on `maySeeRawPayload` (see its
+                  definition for the defect, the signal, and the fail-CLOSED
+                  posture); a business approver gets the structured summary,
+                  chain, activity and actions above and nothing else. */}
+              {maySeeRawPayload && selected.payload != null && (
                 <details className="group">
                   <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground select-none">
                     {tr('rawData', 'Raw data (JSON)')}


### PR DESCRIPTION
Fixes #5553

Verified at `d96c3727f` — every gate verdict below was read from a run on that exact tree, after the final commit.

## The defect

The detail drawer's "Raw data (JSON)" panel rendered on `payload != null` alone — no principal check of any kind — so every business approver could expand (and one-click copy) the submitted record's complete raw row: `id`, `created_by`, `updated_by`, `owner_id`, `organization_id`, bare lookup ids, and **the fields the object's metadata declares `hidden: true`**. Reported from a live EHR deployment on 17.1.0 (objectstack-ai/objectstack#10734, @baozhoutao), where that declaration is a patient-data control. The app author had no legitimate lever to remove it — field `hidden`, view columns, app navigation, permission sets and env vars are all ineffective — so the remedies available in the field were patching the shipped bundle or injecting CSS.

Premise re-verified against `origin/main` at `0935a43be` before editing, not relayed: the panel was still live and still unconditional. PR #5509 (`9b9af8d`, the row-remount fix) had already landed in this file and did not touch the panel.

## The fix

The panel is gated on `holdsStudioAccess`, reused verbatim from this app's `studioEntry` module. `studio.access` is a declared platform-scope capability a tenant org owner does not hold by design (one of the framework's `PLATFORM_ADMIN_ONLY_CAPABILITIES`), and it already reaches the browser in `systemPermissions[]` from `/api/v1/auth/me/permissions` — the payload `MePermissionsProvider` mounts around every route this page renders under. Nothing new is served, computed, or made authorable: **no new config key** (the card forbids minting one, and none was needed), no new i18n copy, and the panel is byte-for-byte unchanged for the platform operator it was written for. A business approver keeps the structured record summary, the approval chain, the activity feed and the decision actions; only the raw snapshot is gone.

Reusing `studioEntry`'s predicate rather than mirroring the framework's four-capability platform-admin probe into the renderer is deliberate: one definition of "is this principal a platform operator rather than a business user", so the two surfaces cannot drift into two spellings of one fact (AGENTS.md #0.1). The narrower gate is also the safer one here — `manage_users` is in the server's probe, and a user administrator has no business reading raw clinical payloads.

### Fail CLOSED — inverted from `hasCapabilities`

The gate reads the **raw** `systemPermissions` signal, not `usePermissions().hasCapabilities`. That hook fails *open* on purpose, and that is right for an action button: the server still refuses the write, and hiding a holder's button is the worse outcome. This panel has the opposite stake — the measured defect *is* a non-holder seeing it — so every not-a-reported-grant answer denies: no provider mounted, a backend predating ADR-0066 that omits the field, the resolver's `catch` path that answers `200` with no `systemPermissions` at all, and a reported empty array. A deployment whose permission layer just failed must not be the one that leaks the snapshot. This is the same inversion `studioEntry` already documents for the `/studio/*` route gate, and it is why the `undefined`-vs-`[]` distinction objectui#4656 preserved is load-bearing here.

## Tests, and how the vacuum is guarded

The acceptance condition is that something does *not* render — which an empty render reproduces perfectly. So in `ApprovalsInboxPage.rawPayloadGate.test.tsx` every denial case also asserts the drawer it is denying inside (process label + business summary row), and the `studio.access` case drives the **same fixture through the same helper** and finds the panel. An empty render fails the counter-probe; a gate stuck open fails the denials; neither can pass alone.

`created_by` and `organization_id` are the witnesses rather than proxies: both are in the page's `PAYLOAD_SYSTEM_KEYS`, so the summary card already drops them and their values can reach the DOM only through the raw panel.

**Ablation** (pure source — the root Vitest config aliases every `@object-ui` specifier at that package's source, so no build artifact sits between the edit and the run). The mutation was proven on disk before the measurement, not inferred from an editor exit code: the gated form `maySeeRawPayload && selected.payload != null` went 1 → 0 occurrences and the bare `selected.payload != null && (` went 0 → 1, with `git diff --stat` showing the single-line change. Restoring the bare condition turns **3 of 4 cases red** — the three denial cases, each on the `Raw data (JSON)` assertion, with the failure naming the found summary element it had just found in the DOM — and leaves the `studio.access` case green, which is exactly the predicted direction. The mutation script carried a `trap … EXIT INT TERM` restore, and the tree came back byte-identical (`git status --short` and `git diff --stat` both empty).

## The `rawData` locale key stays

Deliberate, not incidental: the fix **gates** the panel rather than removing it, so `tr('rawData', 'Raw data (JSON)')` remains a live call site and the label still renders for a holder. `check:i18n-dead-keys` is green and **no locale table is touched** — removing the key would have meant editing ~10 locale files, outside this card's file fence, to delete copy that is still reachable.

## Gates run locally at `d96c3727f`

All verdicts quoted from each gate's own output line, with exit codes captured before any pipe.

| Gate | Verdict |
|---|---|
| `apps/console` vitest (whole project) | `Test Files 63 passed (63)` · `Tests 704 passed (704)` |
| `apps/console/src/pages/system/` (final commit) | `Test Files 10 passed (10)` · `Tests 64 passed (64)` |
| `@object-ui/console type-check` | exit 0 (`tsc --noEmit && tsc -b tsconfig.node.json --force` echoed — not a zero-match pass) |
| `@object-ui/console lint` | `✖ 201 problems (0 errors, 201 warnings)` — all pre-existing |
| `check-changeset-fixed` / `-no-major` / `-presence` | exit 0 / 0 / 0 |
| `check-control-bytes` | exit 0 |
| `check:i18n-keys` / `i18n-drift` / `i18n-dead-keys` | exit 0 / 0 / 0 |
| `check:eager-closure` | `✅ Console eager closure is 3784.8 KB gzipped across 52 of 508 chunks (budget: 3867.2 KB, headroom: 82.4 KB)` |
| `check:phantom-deps` / `check:self-import` / `check:esm-specifiers` | exit 0 / 0 / 0 |
| `check-lint-coverage` / `check-type-check-coverage` | exit 0 / 0 |

Lint scope, stated so it is checkable: `eslint .` in `apps/console` linted **165 files** (count read from `--format json`, population from ESLint's own config resolution, not a hand-picked list) with **0 errors** and 201 pre-existing warnings. My new test file reports 0 errors / 0 warnings; `ApprovalsInboxPage.tsx` reports 19 warnings, all on pre-existing lines (the lowest is line 522, the `buildApproverIdentities(user as any)` line that predates this change; the added block starts at 524). Type-aware linting is **not** enabled in the root `eslint.config.js` — no `projectService`, no `parserOptions.project` — so this diff cannot move the verdict of any file it does not touch. The repo-wide `pnpm lint` and `pnpm type-check` farms are CI's run and are not duplicated here.

`check:eager-closure` was first read as a **broken gauge** (`No eager-closure report … the console was not built`), which is the state of any fresh worktree, not a finding about this diff. It was resolved by actually building the console rather than by argument. The structural expectation held: `studioEntry` is already in the eager closure via `App.tsx` → `StudioRoute`, and `ApprovalsInboxPage` stays lazily loaded, so the import adds nothing eager.

## Scope

`apps/console/src/pages/system/ApprovalsInboxPage.tsx`, its new test, and a changeset — the dispatched file fence, not breached.

Out of scope, deliberately and not silently: trimming the summary card by object metadata, and the server-side residual that sends the unfiltered snapshot to the client at all (tracked separately in the objectstack repo). Neither is asserted here, because asserting them would pin behaviour this change does not deliver. objectstack-ai/objectstack#10734 remains open as the originating report.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_