### PR TITLE
plugin-dashboard: hoist the "no rows yet" empty to module scope in ObjectDataTable and ObjectPivotTable

### DIFF
--- a/.changeset/dashboard-stable-empty-rows-4629.md
+++ b/.changeset/dashboard-stable-empty-rows-4629.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+`ObjectDataTable` and `ObjectPivotTable` now use a module-scope frozen empty for
+"no rows yet" instead of a fresh array literal per render (objectui#4629).
+
+Both spelled the resolved row list as `Array.isArray(rawData) ? rawData : []`, so
+whenever `rawData` was a truthy non-array — a provider-config `data`, or a `bind`
+path that resolves to an object — the fallback produced a NEW array identity on
+every render. In `ObjectDataTable` that value keys the `derivedColumns` memo, so
+every column was re-derived (`buildFieldMeta`, a fresh `cell` closure, the
+`isSystemField` pass, the `fieldLabel` lookups) and then discarded by the
+`finalData.length === 0` early return. In `ObjectPivotTable` the value is handed
+straight to `PivotTable`, where it keys the cross-tabulation memo, so the pivot
+rebuilt its row/column sets, bucket map and totals on every render over no rows
+at all.
+
+Nothing rendered wrong before or after; this is wasted work in the empty window,
+plus the live `react-hooks/exhaustive-deps` warning the conditional raised. It is
+the same module-scope frozen empty `data-table.tsx` adopted for its own
+`EMPTY_ROWS` (objectui#4618), applied to the `provider: 'object'` siblings.

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -47,6 +47,29 @@ interface NormalizedColumn {
 }
 
 /**
+ * Shared empty fallback for the resolved row list (objectui#4629).
+ *
+ * `Array.isArray(rawData) ? rawData : []` evaluates a FRESH array on every
+ * render, and that value is a dependency of the `derivedColumns` memo below.
+ * So for as long as `rawData` is a non-array — a provider-config `data`, or a
+ * `bind` path that resolves to an object — the memo's key changes on every
+ * render and every column is re-derived (`buildFieldMeta`, a fresh `cell`
+ * closure per column, the `isSystemField` pass, the `fieldLabel` lookups) only
+ * to be discarded: `finalData.length === 0` is exactly the case in which the
+ * component returns its empty state without ever rendering the table.
+ * Hoisting the empty to module scope makes "no rows yet" a stable value, so
+ * the memo sees what is actually true — nothing changed.
+ *
+ * The same move `data-table.tsx` made for its own `EMPTY_ROWS` (objectui#4618,
+ * PR #4623). This file is the `provider: 'object'` sibling of that one, so it
+ * takes the same shape rather than a second remedy for one defect class.
+ *
+ * Frozen so a consumer that mutates the array it was handed cannot corrupt the
+ * shared instance for every other table on the page.
+ */
+const EMPTY_ROWS = Object.freeze([]) as unknown as any[];
+
+/**
  * Normalize columns to support both string[] shorthand and object[] formats.
  *
  * - `string[]` entries are converted to `{ header, accessorKey }` objects,
@@ -307,7 +330,7 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
 
   // Resolve data: bound data > static schema data > fetched data
   const rawData = boundData || schema.data || fetchedData;
-  const finalData = Array.isArray(rawData) ? rawData : [];
+  const finalData = Array.isArray(rawData) ? rawData : EMPTY_ROWS;
 
   // Auto-derive columns from data keys when none are provided. When `objectName`
   // is set, prefer translated field labels via the convention-based hook so that

--- a/packages/plugin-dashboard/src/ObjectPivotTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectPivotTable.tsx
@@ -16,6 +16,28 @@ import { DrillDownDrawer } from './DrillDownDrawer';
 import { resolveFilterPlaceholders } from './utils';
 import type { PivotTableSchema } from '@object-ui/types';
 
+/**
+ * Shared empty fallback for the resolved row list (objectui#4629).
+ *
+ * `Array.isArray(rawData) ? rawData : []` evaluates a FRESH array on every
+ * render, and this component hands the result straight to `PivotTable` as
+ * `finalSchema.data`, where it is the identity key of the cross-tabulation
+ * memo (`PivotTable.tsx`, `[data, rowField, columnField, valueField,
+ * aggregation]`). So while `rawData` is a non-array — a provider-config
+ * `data`, or a `bind` path that resolves to an object — that memo rebuilds its
+ * row/column sets, bucket map and totals on every render over nothing at all.
+ * A module-scope empty makes "no rows yet" a stable value, and the
+ * `Array.isArray` arm downstream passes it through unchanged, so the memo
+ * holds.
+ *
+ * The same move `data-table.tsx` made for its own `EMPTY_ROWS` (objectui#4618,
+ * PR #4623) and `ObjectDataTable.tsx` makes for the identical expression.
+ *
+ * Frozen so a consumer that mutates the array it was handed cannot corrupt the
+ * shared instance for every other pivot on the page.
+ */
+const EMPTY_ROWS = Object.freeze([]) as unknown as any[];
+
 export interface ObjectPivotTableProps {
   schema: PivotTableSchema & {
     objectName?: string;
@@ -151,7 +173,7 @@ export const ObjectPivotTable: React.FC<ObjectPivotTableProps> = ({ schema, data
 
   // Resolve data: bound data > static schema data > fetched data
   const rawData = boundData || schema.data || fetchedData;
-  const finalData = Array.isArray(rawData) ? rawData : [];
+  const finalData = Array.isArray(rawData) ? rawData : EMPTY_ROWS;
 
   // Loading skeleton
   if (loading && finalData.length === 0) {

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.stableEmptyRows.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.stableEmptyRows.test.tsx
@@ -103,8 +103,9 @@ const I18N_CONFIG = { defaultLanguage: 'en', detectBrowserLanguage: false } as c
  * `finalData` is the only churning dependency and this test measures exactly
  * it. OUTSIDE any provider react-i18next has no instance to bind to and hands
  * back a fresh `t` every render, so the memo re-keys regardless of this fix —
- * measured on this branch (8 calls, unchanged by the fix) and filed separately;
- * it is a defect in a different package and is not what #4629 is about.
+ * measured on this branch (8 calls, unchanged by the fix) and filed as
+ * objectui#5564; it is a defect in a different package and is not what #4629
+ * is about.
  */
 function renderUnderHostChurn(schema: any) {
   let bump: (() => void) | null = null;

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.stableEmptyRows.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.stableEmptyRows.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4629 — "no rows yet" must be a STABLE value in `ObjectDataTable`.
+ *
+ * `const finalData = Array.isArray(rawData) ? rawData : []` evaluated a FRESH
+ * array literal on every render, and `finalData` is a dependency of the
+ * `derivedColumns` memo. So while `rawData` is a non-array the memo's key
+ * changed on every render and every column was re-derived — `buildFieldMeta`,
+ * a fresh `cell` closure, the `isSystemField` pass, the `fieldLabel` lookups —
+ * and then discarded, because `finalData.length === 0` is exactly the case in
+ * which the component returns its empty state without rendering the table.
+ *
+ * Nothing renders WRONG either before or after, so a "the table renders
+ * correctly" assertion is green against the broken code and proves nothing.
+ * The observable that separates the two is the RECOMPUTE COUNT: one
+ * `buildFieldMeta` call per declared column per memo evaluation. An
+ * `eslint-disable` suppression of the `react-hooks/exhaustive-deps` warning
+ * would silence the warning and leave this count growing, so this test
+ * discriminates the real fix from a suppression.
+ *
+ * WHICH rawData is a non-array, measured rather than assumed: `rawData` is
+ * `boundData || schema.data || fetchedData`, and `fetchedData` is
+ * `useState<any[]>([])` — an array with a STABLE identity from the first
+ * render. So the plain pre-fetch window was never the churning case; the
+ * churn needs a truthy non-array, i.e. a provider-config `data` (below) or a
+ * `bind` path that resolves to an object.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import React from 'react';
+
+const counters = vi.hoisted(() => ({ buildFieldMeta: 0 }));
+
+// Count memo evaluations at the per-column work the memo does. `importActual`
+// keeps the real enrichment running, so the component still behaves normally.
+vi.mock('../recordFields', async () => {
+  const actual: any = await vi.importActual('../recordFields');
+  return {
+    ...actual,
+    buildFieldMeta: (...args: any[]) => {
+      counters.buildFieldMeta += 1;
+      return actual.buildFieldMeta(...args);
+    },
+  };
+});
+
+// The underlying `data-table` renderer is stubbed so the test does not depend
+// on the component registry — the same shape the sibling suites in this
+// directory use.
+vi.mock('@object-ui/react', async () => {
+  const actual: any = await vi.importActual('@object-ui/react');
+  return {
+    ...actual,
+    SchemaRenderer: ({ schema }: any) => (
+      <div data-testid="table">
+        {(schema.data ?? []).map((row: any, i: number) => (
+          <span key={i}>{String(row.name)}</span>
+        ))}
+      </div>
+    ),
+  };
+});
+
+import { ObjectDataTable } from '../ObjectDataTable';
+
+afterEach(() => {
+  cleanup();
+  counters.buildFieldMeta = 0;
+});
+
+/**
+ * A schema whose `data` is a PROVIDER CONFIG object rather than rows — the
+ * same case `data-table.tsx`'s own `EMPTY_ROWS` docstring names. `columns` is
+ * declared so the memo takes its full enrichment branch: this is the window
+ * where the work is done and thrown away.
+ */
+const PROVIDER_CONFIG_SCHEMA = {
+  type: 'object-table',
+  data: { provider: 'object', object: 'account' },
+  columns: ['name', 'amount'],
+} as any;
+
+/**
+ * Declared at module scope, not inline: `I18nProvider` memoizes its i18next
+ * bootstrap on the `config` IDENTITY, so an inline literal would rebuild the
+ * instance every render — the very class of bug under test, one level up.
+ */
+const I18N_CONFIG = { defaultLanguage: 'en', detectBrowserLanguage: false } as const;
+
+/**
+ * The widget is rendered inside a real `I18nProvider`, which is load-bearing
+ * rather than decoration. `derivedColumns` also depends on `fieldLabel` /
+ * `fieldOptionLabel` from `useSafeFieldLabel`, which memoize on react-i18next's
+ * `[t, i18n]`. With a real instance those are stable between renders, so
+ * `finalData` is the only churning dependency and this test measures exactly
+ * it. OUTSIDE any provider react-i18next has no instance to bind to and hands
+ * back a fresh `t` every render, so the memo re-keys regardless of this fix —
+ * measured on this branch (8 calls, unchanged by the fix) and filed separately;
+ * it is a defect in a different package and is not what #4629 is about.
+ */
+function renderUnderHostChurn(schema: any) {
+  let bump: (() => void) | null = null;
+  const Host = () => {
+    const [, setTick] = React.useState(0);
+    bump = () => setTick((n) => n + 1);
+    return <ObjectDataTable schema={schema} />;
+  };
+  const utils = render(<I18nProvider config={I18N_CONFIG}><Host /></I18nProvider>);
+  return {
+    ...utils,
+    churn: (times: number) => {
+      for (let i = 0; i < times; i += 1) act(() => { bump!(); });
+    },
+  };
+}
+
+describe('ObjectDataTable keeps "no rows yet" stable (#4629)', () => {
+  it('derives each column once, however often the host re-renders', () => {
+    const tile = renderUnderHostChurn(PROVIDER_CONFIG_SCHEMA);
+
+    // Load-bearing: proves the memo really ran its enrichment branch (two
+    // declared columns → two calls). Without it the assertion below would be
+    // vacuously green if `buildFieldMeta` were never reached at all.
+    const afterMount = counters.buildFieldMeta;
+    expect(afterMount).toBe(2);
+    // And that this is the discarding window — the table is not rendered.
+    expect(tile.queryByTestId('table')).toBeNull();
+    expect(tile.getByTestId('table-empty-state')).toBeTruthy();
+
+    tile.churn(3);
+
+    // Pre-fix this was 8: a fresh `[]` re-keyed `derivedColumns` on each of
+    // the three host renders, re-deriving both columns every time.
+    expect(counters.buildFieldMeta).toBe(afterMount);
+  });
+
+  it('still re-derives when rows actually arrive — the memo was stabilized, not frozen', () => {
+    let setData: ((d: any) => void) | null = null;
+    const Host = () => {
+      const [data, set] = React.useState<any>({ provider: 'object', object: 'account' });
+      setData = set;
+      return (
+        <ObjectDataTable
+          schema={{ type: 'object-table', data, columns: ['name', 'amount'] } as any}
+        />
+      );
+    };
+    const { getByTestId, queryByTestId } = render(
+      <I18nProvider config={I18N_CONFIG}><Host /></I18nProvider>,
+    );
+    expect(queryByTestId('table')).toBeNull();
+    const beforeRows = counters.buildFieldMeta;
+
+    act(() => { setData!([{ name: 'INV-1', amount: 100 }]); });
+
+    expect(counters.buildFieldMeta).toBeGreaterThan(beforeRows);
+    expect(getByTestId('table').textContent).toContain('INV-1');
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.stableEmptyRows.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.stableEmptyRows.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4629 (package sweep) — the identical expression in
+ * `ObjectPivotTable`.
+ *
+ * `const finalData = Array.isArray(rawData) ? rawData : []` evaluated a FRESH
+ * array literal on every render, and unlike `ObjectDataTable` this component
+ * has no unconditional empty-state early return: it hands the value straight
+ * to `PivotTable` as `finalSchema.data`, where it is the identity key of the
+ * cross-tabulation memo (`[data, rowField, columnField, valueField,
+ * aggregation]`). So the churn ESCAPED the component here and rebuilt the
+ * row/column sets, the bucket map and the totals on every render over nothing.
+ *
+ * This is the direct identity assertion: the same array object must reach
+ * `PivotTable` on every render. An `eslint-disable` suppression would not move
+ * it, and it is not satisfiable by "the pivot renders correctly" (which is
+ * green against the broken code too).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import React from 'react';
+
+const captured = vi.hoisted(() => ({ data: [] as any[] }));
+
+vi.mock('../PivotTable', () => ({
+  PivotTable: ({ schema }: any) => {
+    captured.data.push(schema.data);
+    return <div data-testid="pivot">{(schema.data ?? []).map((r: any, i: number) => <span key={i}>{String(r.stage)}</span>)}</div>;
+  },
+}));
+
+import { ObjectPivotTable } from '../ObjectPivotTable';
+
+afterEach(() => {
+  cleanup();
+  captured.data.length = 0;
+});
+
+/**
+ * `data` is a PROVIDER CONFIG object rather than rows — the truthy non-array
+ * that selects the fallback arm. No `objectName`, so no fetch and no
+ * "no data source" early return: the component reaches `PivotTable`.
+ */
+const PROVIDER_CONFIG_SCHEMA = {
+  type: 'pivot-table',
+  rowField: 'stage',
+  columnField: 'owner',
+  valueField: 'amount',
+  data: { provider: 'object', object: 'opportunity' },
+} as any;
+
+function renderUnderHostChurn(schema: any) {
+  let bump: (() => void) | null = null;
+  const Host = () => {
+    const [, setTick] = React.useState(0);
+    bump = () => setTick((n) => n + 1);
+    return <ObjectPivotTable schema={schema} />;
+  };
+  const utils = render(<Host />);
+  return {
+    ...utils,
+    churn: (times: number) => {
+      for (let i = 0; i < times; i += 1) act(() => { bump!(); });
+    },
+  };
+}
+
+describe('ObjectPivotTable keeps "no rows yet" stable (#4629)', () => {
+  it('hands PivotTable one and the same empty array across host re-renders', () => {
+    const tile = renderUnderHostChurn(PROVIDER_CONFIG_SCHEMA);
+
+    // Load-bearing: the component really reached `PivotTable`, and with "no
+    // rows" — otherwise the identity assertion below would be vacuous.
+    expect(captured.data.length).toBe(1);
+    expect(captured.data[0]).toEqual([]);
+
+    tile.churn(3);
+
+    expect(captured.data.length).toBeGreaterThanOrEqual(4);
+    // Pre-fix: one distinct identity per render (4). The whole fix is that
+    // this is 1.
+    expect(new Set(captured.data).size).toBe(1);
+    // The module-scope empty is frozen, so a consumer that mutates the array
+    // it was handed cannot corrupt every other pivot on the page.
+    expect(Object.isFrozen(captured.data[0])).toBe(true);
+  });
+
+  it('still forwards rows when they arrive — the pass-through was not removed', () => {
+    let setData: ((d: any) => void) | null = null;
+    const Host = () => {
+      const [data, set] = React.useState<any>({ provider: 'object', object: 'opportunity' });
+      setData = set;
+      return (
+        <ObjectPivotTable
+          schema={{ ...PROVIDER_CONFIG_SCHEMA, data } as any}
+        />
+      );
+    };
+    const { getByTestId } = render(<Host />);
+    const rows = [{ stage: 'Won', owner: 'ann', amount: 10 }];
+
+    act(() => { setData!(rows); });
+
+    expect(captured.data[captured.data.length - 1]).toBe(rows);
+    expect(getByTestId('pivot').textContent).toContain('Won');
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.stableEmptyRows.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.stableEmptyRows.test.tsx
@@ -18,6 +18,11 @@
  * aggregation]`). So the churn ESCAPED the component here and rebuilt the
  * row/column sets, the bucket map and the totals on every render over nothing.
  *
+ * This closes the OBJECT-BOUND path only: the stable empty passes through
+ * `PivotTable`'s own `Array.isArray` arm unchanged. `PivotTable` still spells
+ * two per-render literals of its own for callers that reach it directly — out
+ * of this card's file surface, filed as objectui#5562.
+ *
  * This is the direct identity assertion: the same array object must reach
  * `PivotTable` on every render. An `eslint-disable` suppression would not move
  * it, and it is not satisfiable by "the pivot renders correctly" (which is


### PR DESCRIPTION
Fixes #4629

`ObjectDataTable` and `ObjectPivotTable` both spelled the resolved row list as
`Array.isArray(rawData) ? rawData : []`, evaluating a fresh array literal on every
render. Both now fall back to a module-scope `Object.freeze([])` — the same shape
`data-table.tsx` adopted for its own `EMPTY_ROWS` under #4618 / PR #4623, applied to
the `provider: 'object'` siblings. No second remedy was invented: no `useMemo` wrapper
around the conditional, no change to any memo's dependency list.

## Verification

Gate union run at HEAD `c8fd1be97` (the final commit), all green:

| gate | verdict line it printed |
|---|---|
| `pnpm exec turbo run lint --filter=@object-ui/plugin-dashboard` | `Tasks: 2 successful, 2 total` · `0 errors, 360 warnings` |
| `pnpm exec turbo run type-check --filter=@object-ui/plugin-dashboard` | `Tasks: 13 successful, 13 total` (incl. `tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm exec vitest run packages/plugin-dashboard/` | `Test Files 72 passed (72)` · `Tests 653 passed (653)` |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 4620 tracked text file(s))` |
| `node scripts/check-changeset-presence.mjs` | `4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `node scripts/check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |
| `node scripts/check-lint-coverage.mjs` | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `node scripts/check-type-check-coverage.mjs` | `test type-check coverage: 41/41 packages compile their tests, 0 declared debt` |
| `pnpm check:self-import` | `No package names itself inside its own src/.` |
| `pnpm check:phantom-deps` | `Every in-scope import is declared by the package that publishes it.` |

**Declared narrowing of `pnpm lint`.** Repo-wide `pnpm lint` (turbo across 46 packages)
was narrowed to this package's own declared `lint` task. Three pieces of evidence, not
an assertion: (1) the population is eslint's own config resolution — the package script
is literally `eslint .`, no hand-picked file list; (2) **102 files linted**, read from
`--format json` output length, `0 errors / 360 warnings`; (3) the narrowing can exclude
nothing, because `eslint.config.js` enables no type-aware linting (no
`parserOptions.project`, no `projectService`, no `*TypeChecked` preset) and none of the
seven rules in `eslint-rules/` reads any file other than the one under lint (no
`readFileSync` / `globSync` / `readdirSync`), so this diff cannot move the verdict on any
file outside the 102. `check-lint-coverage.mjs` independently reports 46/46 packages
linted with 0 outstanding errors repo-wide.

## The ESLint warning, and why clearing it is not the evidence

On `origin/main`, `ObjectDataTable.tsx:310:9` reported exactly what the card quoted:

```
warning  The 'finalData' conditional could make the dependencies of useMemo Hook
         (at line 417) change on every render...   react-hooks/exhaustive-deps
```

It is gone on this branch (measured both states in one trap-guarded run; the mutation
was confirmed on disk by anchored `grep -c` on the reverted text, not by an editor's
exit code). But a suppression would clear it too, so the identity is pinned directly.

`ObjectPivotTable` had **no** such warning on `origin/main` — its `finalData` reaches no
hook in that file, it flows to `PivotTable` through props. The sweep therefore found a
site the linter could not have flagged.

## Tests: what they assert, and the reverse verification

Nothing renders wrong before or after, so a "the table renders correctly" assertion is
green against the broken code. The two new suites assert the two forms the churn takes:

- `ObjectDataTable.stableEmptyRows.test.tsx` — **recompute count**. One `buildFieldMeta`
  call per declared column per memo evaluation, counted through a partial mock of
  `../recordFields`. A load-bearing pre-assertion (`toBe(2)` at mount) keeps it from
  passing vacuously, and it also asserts the table is *not* rendered in that window.
- `ObjectPivotTable.stableEmptyRows.test.tsx` — **direct identity**. The array handed to
  `PivotTable` must be one and the same object across host re-renders, and frozen.

Reverse verification, directions written before the run and both matched:

| leg | predicted | measured |
|---|---|---|
| `ObjectDataTable` recompute count | RED | RED — `expected 8 to be 2` |
| `ObjectPivotTable` identity | RED | RED — `expected 4 to be 1` |
| both negative controls (rows arriving still re-derive / still forward) | GREEN both sides | GREEN both sides |

The fix was committed first so the revert had a restore point; the tree was restored
byte-identically afterwards (`git diff --exit-code HEAD` clean). The script carried a
`trap … EXIT INT TERM` restore, so a foreground-cap `SIGTERM` mid-mutation could not
have left the tree mutated for later measurements.

## Sweep disposition — every site measured, none silently skipped

| site | disposition | measurement |
|---|---|---|
| `ObjectDataTable.tsx:310` `finalData` | **FIXED** | keys `derivedColumns` (dep list `:417`); ESLint-reported |
| `ObjectPivotTable.tsx:154` `finalData` | **FIXED** | reaches `PivotTable` as `schema.data`, keys its cross-tab memo |
| `ObjectDataTable.tsx:162` `cols` | **SKIPPED — not the defect shape** (see below) | inside `computeLookupExpand`, a module-scope pure function, not a component body; `cols` never escapes the call |
| `PivotTable.tsx:176` + the `data: rawData = []` destructuring default | **SKIPPED — out of declared file surface**, filed as #5562 | ESLint on `origin/main`: *"The 'data' conditional could make the dependencies of useMemo Hook (at line 241) change on every render"* |
| `DashboardFilterBar.tsx:300` | skipped | inside a `.then()` callback; feeds `setDynamicOptions(pairOptionRows(...))`, not a per-render literal |
| `DashboardWithConfig.tsx:111-112` | skipped | inside `selectedWidgetConfig = React.useMemo(...)` (deps `[selectedWidgetId, configVersion]`) |
| `DatasetWidget.tsx:400-401` | skipped | each already wrapped in its own `useMemo` |
| `DatasetWidget.tsx:529` | skipped | inside a `.then()`; a `setState` payload |
| `ObjectMetricWidget.tsx:253` | skipped | inside an async `useCallback` body; local to the call |

**`ObjectDataTable.tsx:162` — the dispatch listed this as in-surface "same defect shape";
measured otherwise and left alone.** It sits inside `export function computeLookupExpand`,
which is not a component body. `cols` is consumed only within that call (`.length`,
`.map`) and never returned; the function's own result is a fresh `Array.from(out)` on
every call regardless, and its single call site (`:263`) is a fetch-effect body, not a
dependency list. By the card's own criterion — "only ever safe when nothing memoizes or
synchronizes on the result" — nothing does. Hoisting a shared empty there would imply a
render-identity concern that does not exist.

## Two premise corrections, both measured

**1. "The whole pre-fetch window" is too wide.** `rawData` is
`boundData || schema.data || fetchedData`, and `fetchedData` is a `useState` seeded with `[]` —
an array with a *stable* identity from the first render. So the plain pre-fetch window
was never the churning case. The churn needs a truthy **non-array**: a provider-config
`data`, or a `bind` path that resolves to an object. This narrows the exposure; it does
not change the fix, since the identity bug and the ESLint warning are unconditional.

**2. The render-loop question — confirmed impossible, by a stronger argument than the
card's.** In `ObjectDataTable` the fallback fires **iff** `finalData.length === 0`, and
that is exactly the condition under which the component takes an early return (loading /
error / no-datasource / empty state) and never renders `SchemaRenderer` at all. So the
churn does not merely fail to feed a `setState` — it never reaches `data-table` in the
first place. Observation-class grading stands. `ObjectPivotTable` has no unconditional
empty-state early return, so there the churn *did* escape into `PivotTable`'s memo, which
is why it is the site with the direct identity assertion.

## Filed out of scope (unassigned, not fixed here)

- #5562 — `PivotTable`'s own two per-render literals. #5562 remains open; the object-bound
  path through `ObjectPivotTable` is handled by this PR, the direct-use path is not.
- #5564 — outside an i18next instance, `useSafeFieldLabel` returns a fresh object every
  render (measured: 4 distinct identities in 4 renders, 1 with an instance). It re-keys
  `derivedColumns` independently of this fix, which is why the `ObjectDataTable` suite
  renders inside a real `I18nProvider` and says so. #5564 is untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_
