### PR TITLE
plugin-view: drop the unreferenced handleRefresh from ObjectView

### DIFF
--- a/.changeset/dead-refresh-callback-objectview.md
+++ b/.changeset/dead-refresh-callback-objectview.md
@@ -1,0 +1,12 @@
+---
+---
+
+Internal only, no released behaviour change: `plugin-view`'s `ObjectView` no
+longer declares a `handleRefresh` callback that nothing referenced.
+
+The callback bumped `refreshKey` but was never passed to the toolbar, exposed on
+a handle, or wired to any control — it advertised a refresh entry point the
+component does not have, which cost objectui#4549 a detour to rule out. The
+reachable refresh paths are unchanged (`onMutation` auto-subscribe, delete, bulk
+delete, form success), and the real toolbar Refresh button continues to live in
+`plugin-list`'s `ListView`, reached through `renderListView`.

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -836,11 +836,6 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
     setSelectedRecord(null);
   }, []);
 
-  // Handle refresh
-  const handleRefresh = useCallback(() => {
-    setRefreshKey(prev => prev + 1);
-  }, []);
-
   // --- ViewSwitcher schema (for multi-view prop views) ---
   const viewSwitcherSchema: ViewSwitcherSchema | null = useMemo(() => {
     if (!hasMultiView || !viewsPropResolved || viewsPropResolved.length <= 1) return null;

--- a/packages/plugin-view/src/__tests__/ObjectView.refreshSignal.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.refreshSignal.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ObjectView's refresh signal has exactly the entry points that are reachable
+ * (objectui#4568).
+ *
+ * ## Why this file exists
+ *
+ * `ObjectView` kept a `handleRefresh` callback that bumped `refreshKey` and was
+ * referenced by nothing — not passed to the toolbar, not exposed on a handle,
+ * not wired to any control. It read as "ObjectView has a refresh entry point"
+ * to anyone scanning for one, which cost objectui#4549 a detour to rule out.
+ * Triage ruled deletion rather than wiring it to a new toolbar button: the
+ * button is a feature with no recorded pull, and the affordance already exists
+ * downstream (see below). objectui#4568 removed the callback.
+ *
+ * A dead-code deletion is only safe once the surviving paths are pinned, so
+ * this file asserts the ones that remain rather than asserting the absence of
+ * the one that went. `refreshKey` itself stays — it is read by the non-grid
+ * fetch effect, by the child-view remount key, and is forwarded to a host list
+ * view as `refreshKey` / `refreshTrigger`.
+ *
+ * ## Where the real refresh button lives
+ *
+ * Not here. `packages/plugin-list/src/ListView.tsx` renders a toolbar Refresh
+ * button gated on `toolbarFlags.showRefresh` (derived from
+ * `userActions.refresh`) driving ListView's OWN refresh counter. ObjectView
+ * reaches it by delegating through `renderListView` — and deliberately does not
+ * auto-subscribe in that mode, which is the third test below. That delegation
+ * is why the deleted callback had no toolbar to attach to in the first place.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import { ObjectView } from '../ObjectView';
+import type { ObjectViewSchema, DataSourceMutationEvent } from '@object-ui/types';
+
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
+  return {
+    SchemaRenderer: ({ schema }: any) => (
+      <div data-testid="schema-renderer">{schema?.type}</div>
+    ),
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+vi.mock('@object-ui/plugin-grid', () => ({ ObjectGrid: () => <div data-testid="object-grid" /> }));
+vi.mock('@object-ui/plugin-form', () => ({ ObjectForm: () => <div data-testid="object-form" /> }));
+
+/**
+ * A DataSource whose `onMutation` hands the registered callback back to the
+ * test, so a mutation can be emitted the way a real adapter would.
+ */
+function makeDataSource() {
+  const subscribers: ((event: DataSourceMutationEvent) => void)[] = [];
+  const unsubscribe = vi.fn();
+  const onMutation = vi.fn((cb: (event: DataSourceMutationEvent) => void) => {
+    subscribers.push(cb);
+    return unsubscribe;
+  });
+  const find = vi.fn().mockResolvedValue({ data: [], total: 0 });
+  const ds: any = {
+    find,
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({ name: 'task', fields: {} }),
+    onMutation,
+  };
+  return {
+    ds,
+    find,
+    onMutation,
+    unsubscribe,
+    emit: async (event: DataSourceMutationEvent) => {
+      await act(async () => {
+        subscribers.forEach(cb => cb(event));
+      });
+    },
+  };
+}
+
+/** A non-grid view type, because the grid branch fetches its own data. */
+const KANBAN_SCHEMA = {
+  type: 'object-view',
+  objectName: 'task',
+  defaultViewType: 'kanban',
+} as unknown as ObjectViewSchema;
+
+describe('ObjectView refresh signal (objectui#4568)', () => {
+  it('re-fetches when the DataSource reports a mutation on the same object', async () => {
+    const { ds, find, emit } = makeDataSource();
+    render(<ObjectView schema={KANBAN_SCHEMA} dataSource={ds} />);
+
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
+
+    await emit({ type: 'create', resource: 'task', id: '1' });
+
+    await waitFor(
+      () => expect(find).toHaveBeenCalledTimes(2),
+      { timeout: 2000 },
+    );
+  });
+
+  it('ignores a mutation reported for a different object', async () => {
+    const { ds, find, emit } = makeDataSource();
+    render(<ObjectView schema={KANBAN_SCHEMA} dataSource={ds} />);
+
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
+
+    await emit({ type: 'create', resource: 'not_task', id: '1' });
+
+    // Nothing should re-run the fetch. Give the effect a turn to misbehave
+    // before asserting it did not.
+    await act(async () => { await Promise.resolve(); });
+    expect(
+      find,
+      'A mutation on an unrelated object re-queried this view. The auto-subscribe\n'
+        + 'is gated on `event.resource === schema.objectName`; losing that gate turns\n'
+        + 'every mutation anywhere into a refetch storm.',
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not auto-subscribe when a host list view is supplied', async () => {
+    const { ds, onMutation } = makeDataSource();
+    render(
+      <ObjectView
+        schema={KANBAN_SCHEMA}
+        dataSource={ds}
+        renderListView={({ refreshKey }) => (
+          <div data-testid="host-list" data-refresh-key={refreshKey} />
+        )}
+      />,
+    );
+
+    await waitFor(() => expect(ds.getObjectSchema).toHaveBeenCalled());
+
+    expect(
+      onMutation,
+      'ObjectView auto-subscribed to mutations while a host list view was supplied.\n'
+        + 'The host (e.g. plugin-list ListView) owns its own fetching AND its own\n'
+        + 'toolbar Refresh button; subscribing here double-fetches. This delegation is\n'
+        + 'also why ObjectView never had a refresh control of its own for the\n'
+        + 'objectui#4568 callback to attach to.',
+    ).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #4568

`ObjectView` declared a `handleRefresh` callback that bumped `refreshKey` and was referenced by nothing — not passed to the toolbar, not exposed on a handle, not wired to any control. It advertised a refresh entry point the component does not have, which cost #4549 a detour to rule out.

Triage ruled **deletion** rather than wiring it to a new toolbar Refresh button: the button is a feature with no recorded pull, and the affordance already exists downstream. That ruling is not re-litigated here.

## The reference surface, proven empty before deleting

A dead-code deletion is mechanical only *after* the reference surface is proven empty, so every zero-hit below is paired with a control probe on a term known to be present in the same scope — a bare zero-hit proves nothing about the search itself. All measured on the merged ref at claim time (`f24195aeb`).

**1. Whole repo, all tracked files.** `git grep -n "handleRefresh" -- .` returns 17 hits across 7 files. Six of those files (`app-shell/.../ExternalDatasourcePanel.tsx`, `plugin-ai/AIFormAssist.tsx`, `plugin-dashboard/DashboardGridLayout.tsx`, `plugin-dashboard/DashboardRenderer.tsx`, `plugin-report/ReportViewer.tsx`, `plugin-timeline/ObjectTimeline.tsx`) declare their **own** module-local `handleRefresh` and each wires it to something; none of them can see this one. In `packages/plugin-view` the identifier appears **exactly once** — the declaration.

*Control:* the same command shape for `handleDelete` returns hits across `apps/`, `packages/`, tests and CHANGELOGs, so the scope is live and repo-wide. The sharpest contrast is in this very file: `handleDelete` shows a declaration (`:817`) **and a use** (`:1501`); `handleRefresh` showed a declaration and nothing.

**2. Untracked files too.** A filesystem `grep -rn` excluding `node_modules`/`.git`/`dist`/`.turbo` gives the same 17 hits, 1 in plugin-view. *Control:* `setRefreshKey` in the identical scope returns 6 hits inside the same file, so the scope reaches the file's interior rather than stopping at its name.

**3. Case-insensitive.** `git grep -in "handlerefresh" -- packages/plugin-view/` returns only the declaration. *Control:* `git grep -in "HANDLEREFRESH"` matches that same mixed-case line, proving `-i` was actually in effect.

**4. Not exported — the public-surface flip condition does not trigger.** `handleRefresh` was a `const` inside the `ObjectView` component body (component opens at `:509`), so it is lexically unreachable from outside. The package's only entry point is `.` &rarr; `dist/index.*`, built from `src/index.tsx`, and that barrel re-exports `ObjectView`, `ViewSwitcher`, `FilterUI`, `SortUI`, `SharedViewLink`, `ViewTabBar`, `ManageViewsDialog`, the `recordSurface` helpers and the `view-config-utils` helpers — no `handleRefresh`. This is an internal cleanup, not a public-surface removal.

## Where the deletion stopped, and what did not fall out

Nothing was orphaned. `useCallback` still has 13 uses in the file, `setRefreshKey` still has 5, and `refreshKey` itself keeps four live readers (the non-grid fetch effect's dep array `:709`, the child-view remount key `:1356`, and the `refreshTrigger` / `refreshKey` props forwarded to a host list view). No import became unused; no helper became unreferenced. The diff is exactly the five deleted lines plus a test and a changeset.

## Where the real refresh button lives

Not in this component. `packages/plugin-list/src/ListView.tsx` renders a toolbar Refresh button gated on `toolbarFlags.showRefresh` (derived from `userActions.refresh`, `:796`) driving ListView's own counter (`:3080`). `ObjectView` reaches it by delegating through `renderListView`, and deliberately skips its own mutation auto-subscribe in that mode. That delegation is *why* the deleted callback never had a toolbar to attach to.

## Test

`packages/plugin-view/src/__tests__/ObjectView.refreshSignal.test.tsx` is new. It pins the paths that **survive** rather than asserting the absence of the one that went — the package previously had zero coverage of refresh or `onMutation` at all:

- a mutation reported on the same object re-fetches;
- a mutation on a different object does not (the `event.resource === schema.objectName` gate);
- a host-supplied `renderListView` suppresses the auto-subscribe entirely.

**Reverse-verified.** Direction predicted before running: test 1 only should go red. Ablating the `setRefreshKey` call inside the `onMutation` handler (mutation confirmed on disk by grepping the injected marker — 1 — and the anchor text, `setRefreshKey` 5&rarr;4) gave `Tests 1 failed | 2 passed`, exit 1 — exactly the predicted direction. The restore leg is proven byte-identical to the commit (marker absent, `setRefreshKey` back to 5, empty `git diff` against `HEAD`). The mutation and restore legs needed no rebuild: the test imports `../ObjectView` by relative path, so it resolves to source and never reads `dist/`.

## Gates

All run on the final commit `f882f07a9`, working tree byte-identical to it; each verdict quoted from the gate's own output, with exit codes captured before any pipe.

| Gate | Result |
|---|---|
| `vitest run packages/plugin-view/` | `Test Files 18 passed (18)` / `Tests 183 passed (183)` |
| `turbo run type-check --filter @object-ui/plugin-view` | `16 successful, 16 total` (includes `tsconfig.test.json`) |
| `turbo run lint --filter @object-ui/plugin-view` | `2 successful, 2 total`; `224 problems (0 errors, 224 warnings)` — all warnings pre-existing except 2 `no-explicit-any` in the new test, matching the sibling `ObjectView.kanbanConditionalFormatting.test.tsx` convention for test doubles |
| `check:control-bytes` | `OK (scanned 4625 tracked text file(s))` |
| `check-changeset-presence` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `No changeset declares a major bump.` |
| `check-changeset-fixed` | `All workspace packages are in the changeset fixed group.` |
| `check:self-import` | `No package names itself inside its own src/.` |
| `check:phantom-deps` | `Every in-scope import is declared by the package that publishes it.` |
| `check:published-dist` | `No published package's build output carries tooling material.` (full 39-package build, 221s — independently proves plugin-view builds clean after the deletion) |

The changeset has **empty frontmatter**: this is a purely internal deletion with no released behaviour change, and the gate confirms that form is "the explicit exemption and a complete answer to this gate."

**Declared narrowing.** Repo-wide `pnpm lint` (`turbo run lint` across all 44 packages) was not run locally; CI runs the farm regardless. The narrowing is a measurement, not a gap: (1) the changed-file population is the complete `git diff --name-only` against the merge-base — three files, all in `packages/plugin-view/src/` and `.changeset/`; (2) the file count comes from eslint's own `--format json` output, 33 files linted in `@object-ui/plugin-view`, 0 errors; (3) `eslint.config.js` has **zero** matches for `projectService`/`parserOptions`, so type-aware linting is not enabled and this diff cannot move a verdict in any file it does not itself contain.

## Out of scope

While proving the reference surface I measured a second, adjacent dead declaration and filed it separately as #5567 rather than fixing it here: the `object-view` registry declares `showRefresh` as a designer input, defaults it to `true`, and the docs describe it as a working toolbar toggle — but `ObjectView` never reads it and does not forward it. That key lives in `index.tsx` (outside this card's file surface) and is authorable surface, so its disposition is a decision rather than a cleanup. Not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_