### PR TITLE
fix(approvals): render the step progress bar as a vertical stepper in both occurrences

### DIFF
--- a/.changeset/approvals-step-progress-vertical-5554.md
+++ b/.changeset/approvals-step-progress-vertical-5554.md
@@ -1,0 +1,61 @@
+---
+'@object-ui/console': patch
+'@object-ui/app-shell': patch
+---
+
+The approval step progress bar is a vertical stepper, so long flows stop
+clipping their tail steps.
+
+Both occurrences were a single non-wrapping flex row whose steps were each
+`shrink-0`. A flex row's min-content width is the sum of its non-shrinkable
+items, so the bar's intrinsic width grew without bound with step count and
+label length. On a live 17.1.0 project a real 6-step flow with ordinary CJK
+step names measured **1070px inside a 527px container** (objectui#5554).
+
+The two hosts failed differently, and neither failure was recoverable by the
+reader:
+
+- **`ApprovalsInboxPage`** (the inbox detail drawer) — the bar itself was not
+  scrollable, so the nearest scroller was the drawer *panel*. Reaching steps
+  4-6 meant dragging the drawer's own horizontal scrollbar, which pushed the
+  record card, the activity timeline and the action buttons off-screen and left
+  a near-blank panel.
+- **`RecordApprovalsPanel`** (the record page's approvals panel) — this one
+  carried `overflow-x-auto`, so it scrolled itself rather than its container.
+  Better, but the tail steps still sat behind a scroll gesture with no visible
+  affordance.
+
+In both, readers took the clipped bar for the end of the data; the reporting
+customer acceptance tester said so verbatim. Widening the window does not help:
+the drawer is fixed-width, and clipping was identical at 1440x900 and 1920x1000.
+
+Both now render as a column: one row per step, a badge-and-rail gutter, and a
+label that may wrap. Width is capped by the container at every step count and
+every label length, which also suits both hosts' tall-and-narrow aspect. The
+rail segment below each step keeps the tint rule the horizontal connector used
+— it is coloured by the step it leads *into*.
+
+**Always vertical, with no step-count or measured-width threshold**, because
+the overflow is driven by intrinsic content width (labels x count), not by
+count alone: three 16-character CJK labels already crowd a 527px drawer, so any
+count threshold picks a cutoff that is wrong for some real flow, and a measured
+one reintroduces a viewport-dependent branch. The card's requirement is a fix
+that cannot break at an untested viewport or flow length, and a layout with no
+breakpoint and no measurement is the form that satisfies it. Horizontal-with-
+scroll was ruled out for both occurrences: it leaves steps behind a gesture.
+
+Pinned in `ApprovalsInboxPage.stepProgressVertical.test.tsx` and
+`RecordApprovalsPanel.stepProgressVertical.test.tsx`. "The stepper renders" is
+green against the broken code too — every step was always in the DOM, and the
+clipping was layout — so the suites assert the property the defect names
+instead: no row is `shrink-0`, every label is `min-w-0` and none is
+`whitespace-nowrap`, nothing in the subtree is an `overflow-x` scroller, and no
+axis, overflow or width-pinning class carries a breakpoint prefix (so there is
+no viewport with untested behaviour). The reported failing regime is exercised
+directly with the reporter's own six CJK labels, and a 2/5/6/12-step sweep pins
+that the layout classes are byte-identical across all four, so no count
+threshold can put some other flow length back on the old path.
+
+The two steppers are kept identical by hand rather than extracted to a shared
+component: they live in different packages, and deduplicating them is a
+refactor with its own surface. Filed separately.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.stepProgressVertical.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.stepProgressVertical.test.tsx
@@ -1,0 +1,342 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Approvals Inbox — the drawer's step progress bar is a VERTICAL stepper
+ * (objectui#5554).
+ *
+ * ## The defect
+ *
+ * The bar was a single non-wrapping flex ROW whose steps were each `shrink-0`,
+ * so its min-content width is the SUM of every step and grows without bound
+ * with step count and label length. On a live 17.1.0 project a real 6-step
+ * flow measured **1070px inside a 527px drawer**, and the bar itself was not
+ * scrollable (`overflow-x: visible`) — the nearest scroller was the drawer
+ * PANEL, so reaching steps 4-6 meant dragging the drawer's own scrollbar,
+ * which pushed the record card, the timeline and the action buttons off-screen
+ * and left a near-blank panel. The customer acceptance tester read the clipped
+ * bar as "there is no data". A wider window does not help: the drawer is
+ * fixed-width, and the reporter confirmed identical clipping at 1440x900 and
+ * 1920x1000.
+ *
+ * ## What is asserted, and why not "it renders"
+ *
+ * "The stepper renders" is green against the broken code too — all six steps
+ * were always in the DOM; the clipping was layout. So the assertions name the
+ * defect's own property: **no element in the stepper may pin intrinsic width,
+ * and no element may be a horizontal scroller** — every step is reachable
+ * without dragging anything sideways. Concretely: the container stacks
+ * (`flex-col`), each step owns a row, no row is `shrink-0`, every label is
+ * `min-w-0` (a flex item defaults to `min-width:auto` = min-content, which is
+ * exactly how a long label pushes a row past its container) and none is
+ * `whitespace-nowrap`, and nothing in the subtree is an `overflow-x` scroller.
+ * The last one also rules out the half-measure the card explicitly rejects —
+ * making the bar scroll itself and calling it fixed.
+ *
+ * ## Viewport and step-count coverage
+ *
+ * There is no CSSOM here, so these read the class contract Tailwind compiles
+ * rather than measured boxes; every token asserted is named for the exact CSS
+ * property whose value caused the reported overflow.
+ *
+ * Rather than sample two viewports, the suite pins the stronger fact that
+ * makes sampling unnecessary: the stepper carries **no breakpoint-prefixed
+ * axis, overflow or width-pinning class and no measurement**, so its layout is
+ * the same at every viewport — there is no width at which an untested branch
+ * takes over. The same argument covers flow length: the reported failing
+ * regime (6 steps, the reporter's own CJK labels, verbatim) is exercised
+ * directly, and a 2/5/6/12-step sweep pins that the layout classes are
+ * byte-identical across all four, so no count threshold can put some other
+ * length back on the old path.
+ *
+ * The `RecordApprovalsPanel` twin in `@object-ui/app-shell` carries the same
+ * suite, by hand rather than by import: the two steppers live in different
+ * packages and are deliberately kept identical, so each side pins the contract
+ * for itself.
+ *
+ * No build artifact sits between the edit and this test: the root Vitest
+ * config aliases every `@object-ui` specifier at that package's source, and
+ * the page under test is this app's own source.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MePermissionsProvider, type MePermissionsResponse } from '@object-ui/permissions';
+
+const APP = 'com.objectstack.account';
+
+/** The bar's accessible name, as the page spells it through `tr`. */
+const STEPPER_LABEL = 'Approval steps';
+
+/** A business field the drawer must show — the counter-anchor for "it loaded". */
+const BUSINESS_FIELD = 'Q3 clinical supplies';
+
+type Step = { id: string; label: string; state: 'done' | 'current' | 'upcoming' };
+
+/**
+ * The reporter's actual 6-step flow, labels verbatim (objectui#5554). They are
+ * CJK on purpose and must not be "translated" to short English: eight to
+ * sixteen CJK characters is an ordinary business step name and is roughly
+ * double the rendered width of an eight-to-sixteen-character English one, so
+ * these labels ARE the reported regime — the 1070px measurement is theirs.
+ * Swapping them for English fixtures would quietly move the fixture out of the
+ * failing regime the card names.
+ */
+const REPORTED_STEPS: Step[] = [
+  { id: 's1', label: '需求部门负责人初审', state: 'done' },
+  { id: 's2', label: '工厂生产工艺负责人审核', state: 'done' },
+  { id: 's3', label: '工厂业财审核（确认单价/派工工时）', state: 'current' },
+  { id: 's4', label: '事业部成本改善经理加审', state: 'upcoming' },
+  { id: 's5', label: '区域总经理+事业部业财运营总监会审', state: 'upcoming' },
+  { id: 's6', label: '工厂厂长审批', state: 'upcoming' },
+];
+
+/** A synthetic flow of `n` steps, for the step-count invariance sweep. */
+function stepsOfLength(n: number): Step[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `syn_${i}`,
+    label: `区域总经理+事业部业财运营总监会审 ${i + 1}`,
+    state: (i === 0 ? 'current' : 'upcoming') as Step['state'],
+  }));
+}
+
+const { approvalsApiStub, setFlowSteps, ADAPTER, AUTH, I18N } = vi.hoisted(() => {
+  const row: Record<string, unknown> = {
+    id: 'req_1',
+    process_name: 'purchase_approval',
+    process_label: 'Purchase Approval',
+    object_name: 'showcase_purchase',
+    object_label: 'Purchase',
+    record_id: 'po_1',
+    record_title: 'PO-4417',
+    status: 'pending',
+    pending_approvers: ['u_1'],
+    submitter_id: 'u_2',
+    submitter_name: 'Sam Submitter',
+    submitted_at: '2026-08-20T00:00:00.000Z',
+    payload: { subject: 'Q3 clinical supplies' },
+    flow_steps: [] as unknown[],
+  };
+
+  const setFlowSteps = (steps: unknown[]) => { row.flow_steps = steps; };
+
+  const approvalsApiStub = {
+    listRequests: vi.fn(async () => ({ data: [row], total: 1 })),
+    getRequest: vi.fn(async () => ({ data: row })),
+    listActions: vi.fn(async () => ({ data: [] })),
+    approve: vi.fn(async () => ({ data: row, finalized: true })),
+    reject: vi.fn(async () => ({ data: row, finalized: true })),
+  };
+
+  // STABLE singletons: a mocked hook handing back a fresh object per render
+  // re-runs the page's load effect forever and the drawer never settles.
+  const ADAPTER = { find: vi.fn(async () => ({ data: [{ id: 'po_1' }] })) };
+  const AUTH = { user: { id: 'u_1', email: 'approver@example.com' } };
+  const I18N = {
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  };
+
+  return { approvalsApiStub, setFlowSteps, ADAPTER, AUTH, I18N };
+});
+
+vi.mock('@object-ui/i18n', () => ({ useObjectTranslation: () => I18N }));
+
+vi.mock('@object-ui/auth', () => {
+  const authFetch = vi.fn(async () => new Response('{}', { status: 200 }));
+  return {
+    useAuth: () => AUTH,
+    createAuthenticatedFetch: () => authFetch,
+    TokenStorage: { get: () => null },
+  };
+});
+
+vi.mock('@object-ui/app-shell', () => ({
+  useAdapter: () => ADAPTER,
+  DeclaredActionsBar: () => null,
+  isViaOverrideRow: () => false,
+}));
+
+vi.mock('../../services/approvalsApi', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  approvalsApi: approvalsApiStub,
+}));
+
+// Imported after the mocks so the page picks them up.
+import { ApprovalsInboxPage } from './ApprovalsInboxPage';
+
+function permissionsPayload(): MePermissionsResponse {
+  return {
+    authenticated: true,
+    userId: 'u_1',
+    tenantId: 't_1',
+    roles: [],
+    permissionSets: [],
+    objects: {},
+    fields: {},
+    // A business approver — deliberately NOT a platform admin. The stepper is
+    // the approver's own read path and is never behind a capability gate.
+    systemPermissions: ['setup.access'],
+  };
+}
+
+/**
+ * Open the drawer on `req_1` for a flow of `steps`, the way production opens
+ * it — the `?request=` deep link is the page's own notification entry point.
+ */
+async function openDrawerWithSteps(steps: Step[]): Promise<HTMLElement> {
+  setFlowSteps(steps);
+  render(
+    <MePermissionsProvider initialPermissions={permissionsPayload()}>
+      <MemoryRouter initialEntries={[`/apps/${APP}/system/approvals?request=req_1`]}>
+        <Routes>
+          <Route path="/apps/:appName/system/approvals" element={<ApprovalsInboxPage />} />
+        </Routes>
+      </MemoryRouter>
+    </MePermissionsProvider>,
+  );
+  const dialog = await screen.findByRole('dialog');
+  await within(dialog).findByText('Purchase Approval');
+  return dialog;
+}
+
+/** Class tokens of an element — `getAttribute` because SVG `className` is not a string. */
+function tokens(el: Element): string[] {
+  return (el.getAttribute('class') ?? '').split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Breakpoint-prefixed tokens in the families that could switch the axis back
+ * to a row, reintroduce a scroller, or re-pin intrinsic width. A hit means
+ * some viewport gets behaviour no test here covers — which is the failure mode
+ * this card exists to end (the reporter measured 1440x900 and 1920x1000 as
+ * identical, and a fix that holds at one width and not another is not a fix).
+ */
+const VIEWPORT_CONDITIONAL_LAYOUT =
+  /^(?:sm|md|lg|xl|2xl|min-\[[^\]]+\]|max-\[[^\]]+\]):(?:flex-row|flex-col|flex|inline-flex|grid|overflow-x-[\w-]+|shrink-0|whitespace-nowrap|w-max|w-screen)$/;
+
+/** Every invariant that makes the steps reachable without a sideways drag. */
+function expectVerticalStepperContract(stepper: HTMLElement, expectedLabels: string[]): void {
+  // 1. Vertical axis — the steps stack; they do not queue across the width.
+  expect(tokens(stepper)).toContain('flex-col');
+
+  // 2. One row per step. Connectors live INSIDE a row, so no connector
+  //    competes with a step for horizontal space (the old bar interleaved
+  //    them as siblings of the step).
+  const rows = within(stepper).getAllByRole('listitem');
+  expect(rows).toHaveLength(expectedLabels.length);
+
+  // 3. Every step is present, in order. Necessary but VACUOUS ALONE — the
+  //    broken bar rendered all of them too. It is here so the width
+  //    assertions below cannot be satisfied by an empty stepper.
+  expectedLabels.forEach((label, i) => {
+    expect(rows[i]).toHaveTextContent(label);
+  });
+
+  // 4. No row pins its own width. `shrink-0` on the step rows is precisely
+  //    what made the old bar's min-content width the sum of every step.
+  for (const row of rows) {
+    expect(tokens(row)).not.toContain('shrink-0');
+  }
+
+  // 5. Every label may shrink below its intrinsic width and wrap.
+  for (const label of expectedLabels) {
+    const el = within(stepper).getByText(label);
+    expect(tokens(el)).toContain('min-w-0');
+    expect(tokens(el)).not.toContain('whitespace-nowrap');
+  }
+
+  // 6. Nothing in the subtree is a horizontal scroller. The fix is that the
+  //    content FITS — not that the reader may drag it into view.
+  for (const el of [stepper, ...Array.from(stepper.querySelectorAll('*'))]) {
+    for (const token of tokens(el)) {
+      expect(token).not.toMatch(/^overflow-x-(auto|scroll)$/);
+    }
+  }
+
+  // 7. No viewport gets its own layout — see the regex's comment.
+  for (const el of [stepper, ...Array.from(stepper.querySelectorAll('*'))]) {
+    for (const token of tokens(el)) {
+      expect(token).not.toMatch(VIEWPORT_CONDITIONAL_LAYOUT);
+    }
+  }
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(approvalsApiStub)) fn.mockClear();
+  ADAPTER.find.mockClear();
+});
+afterEach(cleanup);
+
+describe('Approvals Inbox — vertical step stepper (objectui#5554)', () => {
+  it('lays out the reported 6-step CJK flow so every step is reachable without a sideways drag', async () => {
+    const dialog = await openDrawerWithSteps(REPORTED_STEPS);
+
+    // Counter-probe: this drawer really did load its business content, so the
+    // layout assertions below cannot be satisfied by an empty render.
+    expect(within(dialog).getByText(BUSINESS_FIELD)).toBeInTheDocument();
+
+    expectVerticalStepperContract(
+      within(dialog).getByLabelText(STEPPER_LABEL),
+      REPORTED_STEPS.map((s) => s.label),
+    );
+  });
+
+  it('holds the same contract at the guard boundary (2 steps) and well past the report (12)', async () => {
+    for (const n of [2, 12]) {
+      cleanup();
+      const dialog = await openDrawerWithSteps(stepsOfLength(n));
+      expect(within(dialog).getByText(BUSINESS_FIELD)).toBeInTheDocument();
+      expectVerticalStepperContract(
+        within(dialog).getByLabelText(STEPPER_LABEL),
+        stepsOfLength(n).map((s) => s.label),
+      );
+    }
+  });
+
+  it('has no step-count regime: the layout classes are identical at 2, 5, 6 and 12 steps', async () => {
+    const shapes: Array<{ n: number; rowCount: number; root: string | null; firstRow: string | null; lastRow: string | null }> = [];
+    for (const n of [2, 5, 6, 12]) {
+      cleanup();
+      const dialog = await openDrawerWithSteps(stepsOfLength(n));
+      const stepper = within(dialog).getByLabelText(STEPPER_LABEL);
+      const rows = within(stepper).getAllByRole('listitem');
+      shapes.push({
+        n,
+        rowCount: rows.length,
+        root: stepper.getAttribute('class'),
+        firstRow: rows[0].getAttribute('class'),
+        lastRow: rows[rows.length - 1].getAttribute('class'),
+      });
+    }
+
+    // Every flow length renders one row per step...
+    expect(shapes.map((s) => [s.n, s.rowCount])).toEqual([[2, 2], [5, 5], [6, 6], [12, 12]]);
+    // ...through the SAME layout. A count threshold that put long flows (or
+    // short ones) back on a horizontal row would show up here as a difference,
+    // and that threshold is the "works at one length, breaks at another" shape
+    // this card rules out.
+    expect([...new Set(shapes.map((s) => s.root))]).toHaveLength(1);
+    expect([
+      ...new Set(shapes.map((s) => s.firstRow).concat(shapes.map((s) => s.lastRow))),
+    ]).toHaveLength(1);
+  });
+
+  it('keeps the connector tint keyed to the step it leads INTO, as the horizontal bar did', async () => {
+    const dialog = await openDrawerWithSteps(REPORTED_STEPS);
+    const rows = within(within(dialog).getByLabelText(STEPPER_LABEL)).getAllByRole('listitem');
+
+    // A rail segment hangs below every step but the last.
+    const rail = (row: HTMLElement) =>
+      Array.from(row.querySelectorAll('div')).find((d) => tokens(d).includes('w-px'));
+    expect(rows.slice(0, -1).every((r) => rail(r) !== undefined)).toBe(true);
+    expect(rail(rows[rows.length - 1])).toBeUndefined();
+
+    // s2 (done) and s3 (current) are the steps rows 0 and 1 lead into, so
+    // those segments are green; s4 is upcoming, so row 2's successor is not.
+    expect(tokens(rail(rows[0])!)).toContain('bg-emerald-300');
+    expect(tokens(rail(rows[1])!)).toContain('bg-emerald-300');
+    expect(tokens(rail(rows[2])!)).toContain('bg-border');
+  });
+});

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -22,7 +22,7 @@
  * an input is focused.
  */
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { DeclaredActionsBar, isViaOverrideRow } from '@object-ui/app-shell';
 import { createAuthenticatedFetch } from '@object-ui/auth';
@@ -1974,27 +1974,48 @@ export function ApprovalsInboxPage() {
               })()}
 
               {(selected.flow_steps?.length ?? 0) > 1 && (
-                <div className="flex items-center px-1" aria-label={tr('stepProgress', 'Approval steps')}>
-                  {selected.flow_steps!.map((s, i) => (
-                    <Fragment key={s.id}>
-                      {i > 0 && <div className={cn('h-px flex-1 mx-2', s.state === 'done' || s.state === 'current' ? 'bg-emerald-300 dark:bg-emerald-700' : 'bg-border')} />}
-                      <div className="flex items-center gap-1.5 shrink-0">
+                // objectui#5554 — the step strip is a VERTICAL stepper, at
+                // every step count. A horizontal row's intrinsic width grows
+                // without bound with step count and label length, so a real
+                // 6-step flow with ordinary CJK labels measured 1070px inside
+                // a 527px drawer: steps 4-6 were reachable only by dragging
+                // the drawer's own scrollbar, which pushed the rest of the
+                // drawer off-screen. A column caps width at the container at
+                // any step count and any label length, so there is no flow
+                // length or viewport at which it silently regresses — which
+                // is exactly what a count- or measurement-triggered switch
+                // would reintroduce. Nothing here may pin intrinsic width:
+                // no `shrink-0` on the rows, no `whitespace-nowrap` on the
+                // labels, and no horizontal scroller.
+                <ol className="flex flex-col px-1" aria-label={tr('stepProgress', 'Approval steps')}>
+                  {selected.flow_steps!.map((s, i, steps) => {
+                    const next = steps[i + 1];
+                    return (
+                      <li key={s.id} className="flex items-start gap-2">
+                        <div className="flex flex-col items-center self-stretch">
+                          <span className={cn(
+                            'flex items-center justify-center h-5 w-5 shrink-0 rounded-full text-[10px] font-semibold',
+                            s.state === 'done' && 'bg-emerald-500 text-white',
+                            s.state === 'current' && 'bg-amber-500 text-white ring-2 ring-amber-200 dark:ring-amber-500/30',
+                            s.state === 'upcoming' && 'bg-muted text-muted-foreground border',
+                          )}>
+                            {s.state === 'done' ? <Check className="h-3 w-3" /> : i + 1}
+                          </span>
+                          {next && (
+                            // Tinted by the step it leads INTO — the same rule
+                            // the horizontal connector used, now running down
+                            // the rail instead of across it.
+                            <div className={cn('w-px flex-1 min-h-3 my-1', next.state === 'done' || next.state === 'current' ? 'bg-emerald-300 dark:bg-emerald-700' : 'bg-border')} />
+                          )}
+                        </div>
                         <span className={cn(
-                          'flex items-center justify-center h-5 w-5 rounded-full text-[10px] font-semibold',
-                          s.state === 'done' && 'bg-emerald-500 text-white',
-                          s.state === 'current' && 'bg-amber-500 text-white ring-2 ring-amber-200 dark:ring-amber-500/30',
-                          s.state === 'upcoming' && 'bg-muted text-muted-foreground border',
-                        )}>
-                          {s.state === 'done' ? <Check className="h-3 w-3" /> : i + 1}
-                        </span>
-                        <span className={cn(
-                          'text-xs',
+                          'min-w-0 flex-1 pt-0.5 text-xs break-words',
                           s.state === 'current' ? 'font-medium' : 'text-muted-foreground',
                         )}>{s.label}</span>
-                      </div>
-                    </Fragment>
-                  ))}
-                </div>
+                      </li>
+                    );
+                  })}
+                </ol>
               )}
 
               <div>

--- a/packages/app-shell/src/views/RecordApprovalsPanel.stepProgressVertical.test.tsx
+++ b/packages/app-shell/src/views/RecordApprovalsPanel.stepProgressVertical.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * RecordApprovalsPanel — the flow step strip is a VERTICAL stepper
+ * (objectui#5554).
+ *
+ * ## The defect
+ *
+ * The strip was a single non-wrapping flex ROW whose steps were each
+ * `shrink-0` and whose labels were `whitespace-nowrap`. Its min-content width
+ * is therefore the SUM of every step, so intrinsic width grows without bound
+ * with step count and label length. On a live 17.1.0 project a real 6-step
+ * flow measured 1070px inside a 527px container. The console drawer's twin
+ * had no scroller of its own and dragged the whole drawer sideways; THIS one
+ * carried `overflow-x-auto`, so it scrolled itself — better, but the tail
+ * steps still sat behind a scroll gesture with no visible affordance, and the
+ * customer acceptance tester read the clipped strip as "there is no data".
+ *
+ * ## What is asserted, and why not "it renders"
+ *
+ * "The stepper renders" is green against the broken code too — every step was
+ * always in the DOM; the clipping was layout. So the assertions below name the
+ * defect's own property: **no element in the stepper may pin intrinsic width,
+ * and no element may be a horizontal scroller** — i.e. every step is reachable
+ * without dragging anything sideways. Concretely: the container stacks
+ * (`flex-col`), each step owns a row, no row is `shrink-0`, every label is
+ * `min-w-0` (a flex item defaults to `min-width:auto` = min-content, which is
+ * exactly how a long label pushes a row past its container) and none is
+ * `whitespace-nowrap`, and nothing in the subtree is an `overflow-x` scroller.
+ *
+ * ## Viewport and step-count coverage
+ *
+ * There is no CSSOM in this environment, so these read the class contract
+ * Tailwind compiles rather than measured boxes. Every token asserted is named
+ * for the exact CSS property whose value caused the reported overflow.
+ *
+ * Rather than sample two viewports, the suite pins the stronger fact that
+ * makes sampling unnecessary: the stepper carries **no breakpoint-prefixed
+ * axis, overflow or width-pinning class and no measurement**, so it has the
+ * same layout at every viewport — there is no width at which an untested
+ * branch takes over. The same argument is made for flow length by rendering
+ * 2, 5, 6 and 12 steps and pinning that the layout classes are byte-identical
+ * across all four: the reported failure regime (6 steps, the reporter's own
+ * CJK labels, verbatim) is exercised directly, and the invariance test rules
+ * out a count threshold that could put some other length back on the old path.
+ *
+ * No build artifact sits between the edit and this test — the root Vitest
+ * config aliases every `@object-ui` specifier at that package's source.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import type { ApprovalRequestLite } from '../hooks/useRecordApprovals';
+
+vi.mock('@object-ui/auth', () => ({ createAuthenticatedFetch: () => vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+import { RecordApprovalsPanel } from './RecordApprovalsPanel';
+
+/** The strip's accessible name, as the panel spells it through `tr`. */
+const STEPPER_LABEL = 'Approval steps';
+
+type Step = NonNullable<ApprovalRequestLite['flow_steps']>[number];
+
+/**
+ * The reporter's actual 6-step flow, labels verbatim (objectui#5554). They are
+ * CJK on purpose and must not be "translated" to short English: eight to
+ * sixteen CJK characters is an ordinary business step name and is roughly
+ * double the rendered width of an eight-to-sixteen-character English one, so
+ * these labels ARE the reported regime. Swapping them for English fixtures
+ * would quietly move the fixture out of the failing regime.
+ */
+const REPORTED_STEPS: Step[] = [
+  { id: 's1', label: '需求部门负责人初审', state: 'done' },
+  { id: 's2', label: '工厂生产工艺负责人审核', state: 'done' },
+  { id: 's3', label: '工厂业财审核（确认单价/派工工时）', state: 'current' },
+  { id: 's4', label: '事业部成本改善经理加审', state: 'upcoming' },
+  { id: 's5', label: '区域总经理+事业部业财运营总监会审', state: 'upcoming' },
+  { id: 's6', label: '工厂厂长审批', state: 'upcoming' },
+];
+
+/** A synthetic flow of `n` steps, for the step-count invariance sweep. */
+function stepsOfLength(n: number): Step[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `syn_${i}`,
+    label: `区域总经理+事业部业财运营总监会审 ${i + 1}`,
+    state: i === 0 ? 'current' : 'upcoming',
+  })) as Step[];
+}
+
+function pendingWith(flow_steps: Step[]): ApprovalRequestLite {
+  return {
+    id: 'req_pending',
+    process_name: 'flow:purchase',
+    process_label: 'Purchase Approval',
+    object_name: 'purchase_order',
+    record_id: 'rec_1',
+    status: 'pending',
+    submitter_id: 'u_submitter',
+    submitter_name: 'Zhou Ming',
+    submitted_at: '2026-08-20T08:00:00Z',
+    viewer: { can_act: false, is_submitter: false },
+    flow_steps,
+  };
+}
+
+function renderWithSteps(flow_steps: Step[]) {
+  const pending = pendingWith(flow_steps);
+  return render(
+    <RecordApprovalsPanel
+      approvals={{ available: true, requests: [pending], pendingRequest: pending }}
+      currentUserId="u_viewer"
+    />,
+  );
+}
+
+/** Class tokens of an element — `getAttribute` because SVG `className` is not a string. */
+function tokens(el: Element): string[] {
+  return (el.getAttribute('class') ?? '').split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Breakpoint-prefixed tokens in the families that could switch the axis back
+ * to a row, reintroduce a scroller, or re-pin intrinsic width. A hit means
+ * some viewport gets behaviour no test here covers — which is the failure mode
+ * this card exists to end.
+ */
+const VIEWPORT_CONDITIONAL_LAYOUT =
+  /^(?:sm|md|lg|xl|2xl|min-\[[^\]]+\]|max-\[[^\]]+\]):(?:flex-row|flex-col|flex|inline-flex|grid|overflow-x-[\w-]+|shrink-0|whitespace-nowrap|w-max|w-screen)$/;
+
+/**
+ * Every invariant that makes the steps reachable without a sideways drag.
+ * Shared by the console drawer's twin suite by hand rather than by import:
+ * the two steppers live in different packages and are deliberately kept
+ * identical, so each side pins the contract for itself.
+ */
+function expectVerticalStepperContract(stepper: HTMLElement, expectedLabels: string[]): void {
+  // 1. Vertical axis — the steps stack; they do not queue across the width.
+  expect(tokens(stepper)).toContain('flex-col');
+
+  // 2. One row per step. Connectors live INSIDE a row, so no connector
+  //    competes with a step for horizontal space (the old strip interleaved
+  //    them as siblings of the row).
+  const rows = within(stepper).getAllByRole('listitem');
+  expect(rows).toHaveLength(expectedLabels.length);
+
+  // 3. Every step is present, in order. Necessary but VACUOUS ALONE — the
+  //    broken row rendered all of them too. It is here so the width
+  //    assertions below cannot be satisfied by an empty stepper.
+  expectedLabels.forEach((label, i) => {
+    expect(rows[i]).toHaveTextContent(label);
+  });
+
+  // 4. No row pins its own width. `shrink-0` on the step rows is precisely
+  //    what made the old strip's min-content width the sum of every step.
+  for (const row of rows) {
+    expect(tokens(row)).not.toContain('shrink-0');
+  }
+
+  // 5. Every label may shrink below its intrinsic width and wrap.
+  for (const label of expectedLabels) {
+    const el = within(stepper).getByText(label);
+    expect(tokens(el)).toContain('min-w-0');
+    expect(tokens(el)).not.toContain('whitespace-nowrap');
+  }
+
+  // 6. Nothing in the subtree is a horizontal scroller. The fix is that the
+  //    content FITS — not that the reader may drag it into view, which is the
+  //    half-measure the card explicitly rules out.
+  for (const el of [stepper, ...Array.from(stepper.querySelectorAll('*'))]) {
+    for (const token of tokens(el)) {
+      expect(token).not.toMatch(/^overflow-x-(auto|scroll)$/);
+    }
+  }
+
+  // 7. No viewport gets its own layout — see the regex's comment.
+  for (const el of [stepper, ...Array.from(stepper.querySelectorAll('*'))]) {
+    for (const token of tokens(el)) {
+      expect(token).not.toMatch(VIEWPORT_CONDITIONAL_LAYOUT);
+    }
+  }
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  // The panel loads each request's action thread; an empty thread keeps this
+  // suite about layout only.
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) }) as any));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('RecordApprovalsPanel — vertical step stepper (objectui#5554)', () => {
+  it('lays out the reported 6-step CJK flow so every step is reachable without a sideways drag', () => {
+    renderWithSteps(REPORTED_STEPS);
+    const stepper = screen.getByLabelText(STEPPER_LABEL);
+    expectVerticalStepperContract(stepper, REPORTED_STEPS.map((s) => s.label));
+  });
+
+  it('holds the same contract at the guard boundary (2 steps) and well past the report (12)', () => {
+    for (const n of [2, 12]) {
+      cleanup();
+      renderWithSteps(stepsOfLength(n));
+      const stepper = screen.getByLabelText(STEPPER_LABEL);
+      expectVerticalStepperContract(stepper, stepsOfLength(n).map((s) => s.label));
+    }
+  });
+
+  it('has no step-count regime: the layout classes are identical at 2, 5, 6 and 12 steps', () => {
+    const shapes = [2, 5, 6, 12].map((n) => {
+      cleanup();
+      renderWithSteps(stepsOfLength(n));
+      const stepper = screen.getByLabelText(STEPPER_LABEL);
+      const rows = within(stepper).getAllByRole('listitem');
+      return {
+        n,
+        rowCount: rows.length,
+        root: stepper.getAttribute('class'),
+        firstRow: rows[0].getAttribute('class'),
+        lastRow: rows[rows.length - 1].getAttribute('class'),
+      };
+    });
+
+    // Every flow length renders one row per step...
+    expect(shapes.map((s) => [s.n, s.rowCount])).toEqual([[2, 2], [5, 5], [6, 6], [12, 12]]);
+    // ...through the SAME layout. A count threshold that put long flows (or
+    // short ones) back on a horizontal row would show up here as a difference,
+    // and that threshold is the "works at one length, breaks at another" shape
+    // this card rules out.
+    const distinctRoots = new Set(shapes.map((s) => s.root));
+    const distinctRows = new Set(shapes.map((s) => s.firstRow).concat(shapes.map((s) => s.lastRow)));
+    expect([...distinctRoots]).toHaveLength(1);
+    expect([...distinctRows]).toHaveLength(1);
+  });
+
+  it('keeps the connector tint keyed to the step it leads INTO, as the horizontal strip did', () => {
+    renderWithSteps(REPORTED_STEPS);
+    const rows = within(screen.getByLabelText(STEPPER_LABEL)).getAllByRole('listitem');
+
+    // A rail segment hangs below every step but the last.
+    const rail = (row: HTMLElement) =>
+      Array.from(row.querySelectorAll('div')).find((d) => tokens(d).includes('w-px'));
+    expect(rows.slice(0, -1).every((r) => rail(r) !== undefined)).toBe(true);
+    expect(rail(rows[rows.length - 1])).toBeUndefined();
+
+    // s2 (done) and s3 (current) are the steps rows 1 and 2 lead into, so
+    // those segments are green; s4 is upcoming, so row 2's successor is not.
+    expect(tokens(rail(rows[0])!)).toContain('bg-emerald-300');
+    expect(tokens(rail(rows[1])!)).toContain('bg-emerald-300');
+    expect(tokens(rail(rows[2])!)).toContain('bg-border');
+  });
+});

--- a/packages/app-shell/src/views/RecordApprovalsPanel.tsx
+++ b/packages/app-shell/src/views/RecordApprovalsPanel.tsx
@@ -383,29 +383,49 @@ export const RecordApprovalsPanel: React.FC<RecordApprovalsPanelProps> = ({
 
       <div className="px-4 py-3 space-y-3">
         {/* Flow-level step strip — where in the multi-level flow this record
-            sits; present on the enriched pending row only (single reads). */}
+            sits; present on the enriched pending row only (single reads).
+
+            objectui#5554 — VERTICAL, at every step count. This panel's strip
+            used to scroll itself horizontally, which is better than the
+            console drawer's (that one dragged its whole container), but it
+            still parked the tail steps behind a scroll gesture with no
+            affordance, and readers took the clipped strip for "no more data".
+            A column caps width at the container at any step count and any
+            label length, so there is no flow length or viewport at which it
+            regresses — which is what a count- or measurement-triggered switch
+            back to a row would reintroduce. Kept identical to the console
+            drawer's stepper on purpose: same family, same treatment. Nothing
+            here may pin intrinsic width — no `shrink-0` on the rows, no
+            `whitespace-nowrap` on the labels, no horizontal scroller. */}
         {(pendingRequest?.flow_steps?.length ?? 0) > 1 && (
-          <div className="flex items-center overflow-x-auto" aria-label={tr('stepProgress', 'Approval steps')}>
-            {pendingRequest!.flow_steps!.map((s, i) => (
-              <React.Fragment key={s.id}>
-                {i > 0 && <div className={cn('h-px flex-1 min-w-4 mx-2', s.state === 'done' || s.state === 'current' ? 'bg-emerald-300 dark:bg-emerald-700' : 'bg-border')} />}
-                <div className="flex items-center gap-1.5 shrink-0">
+          <ol className="flex flex-col" aria-label={tr('stepProgress', 'Approval steps')}>
+            {pendingRequest!.flow_steps!.map((s, i, steps) => {
+              const next = steps[i + 1];
+              return (
+                <li key={s.id} className="flex items-start gap-2">
+                  <div className="flex flex-col items-center self-stretch">
+                    <span className={cn(
+                      'flex items-center justify-center h-5 w-5 shrink-0 rounded-full text-[10px] font-semibold',
+                      s.state === 'done' && 'bg-emerald-500 text-white',
+                      s.state === 'current' && 'bg-amber-500 text-white ring-2 ring-amber-200 dark:ring-amber-500/30',
+                      s.state === 'upcoming' && 'bg-muted text-muted-foreground border',
+                    )}>
+                      {s.state === 'done' ? <Check className="h-3 w-3" /> : i + 1}
+                    </span>
+                    {next && (
+                      // Tinted by the step it leads INTO — the same rule the
+                      // horizontal connector used, now running down the rail.
+                      <div className={cn('w-px flex-1 min-h-3 my-1', next.state === 'done' || next.state === 'current' ? 'bg-emerald-300 dark:bg-emerald-700' : 'bg-border')} />
+                    )}
+                  </div>
                   <span className={cn(
-                    'flex items-center justify-center h-5 w-5 rounded-full text-[10px] font-semibold',
-                    s.state === 'done' && 'bg-emerald-500 text-white',
-                    s.state === 'current' && 'bg-amber-500 text-white ring-2 ring-amber-200 dark:ring-amber-500/30',
-                    s.state === 'upcoming' && 'bg-muted text-muted-foreground border',
-                  )}>
-                    {s.state === 'done' ? <Check className="h-3 w-3" /> : i + 1}
-                  </span>
-                  <span className={cn(
-                    'text-xs whitespace-nowrap',
+                    'min-w-0 flex-1 pt-0.5 text-xs break-words',
                     s.state === 'current' ? 'font-medium' : 'text-muted-foreground',
                   )}>{s.label}</span>
-                </div>
-              </React.Fragment>
-            ))}
-          </div>
+                </li>
+              );
+            })}
+          </ol>
         )}
 
         {/* Aggregation progress — server-computed tally (quorum/unanimous


### PR DESCRIPTION
Fixes #5554

## What was wrong

Both occurrences laid the approval step strip out as a single non-wrapping flex row whose steps were each `shrink-0`. A flex row's min-content width is the sum of its non-shrinkable items, so the strip's intrinsic width grew without bound with **step count x label length**. On a live 17.1.0 project a real 6-step flow with ordinary CJK step names measured **1070px inside a 527px container**.

The two hosts failed differently, and neither failure was recoverable by the reader:

| | scroller | what the reader had to do |
|---|---|---|
| `ApprovalsInboxPage` (inbox drawer) | none on the strip; nearest was the **drawer panel** | drag the drawer's own scrollbar, which pushed the record card, activity timeline and action buttons off-screen and left a near-blank panel |
| `RecordApprovalsPanel` (record page) | `overflow-x-auto` on the strip | scroll the strip — better, but the tail steps still sat behind a gesture with **no visible affordance** |

In both, readers took the clipped strip for the end of the data; the reporting customer acceptance tester said so verbatim. Widening the window does not help — the drawer is fixed-width, and clipping was identical at 1440x900 and 1920x1000.

## The fix, and why *always* vertical

Both now render as a column: one row per step, a badge-and-rail gutter, a wrapping label. Width is capped by the container at every step count and every label length, which also suits both hosts' tall-and-narrow aspect ratio.

The card left the layout choice open between always-vertical and vertical-past-a-threshold. **Always vertical, with no step-count and no measured-width threshold**, because:

- The overflow is driven by **intrinsic content width**, not by count. Three 16-character CJK labels already crowd a 527px drawer, so any count threshold picks a cutoff that is wrong for some real flow — the guard is `flow_steps.length > 1`, and label length is unbounded and unowned by us.
- A **measured** threshold reintroduces exactly the failure class the card rules out: a branch whose behaviour depends on a width nobody tested, plus a `ResizeObserver`/layout-effect that no unit test in this repo can exercise.
- A layout with **no breakpoint and no measurement** is viewport-invariant by construction, which is strictly stronger than passing at two sampled viewports.

Horizontal-with-scroll was rejected for both occurrences per the card: it leaves steps behind a gesture.

The rail segment below each step keeps the tint rule the horizontal connector used — it is coloured by the step it leads *into* — so the "how far has this flow got" reading is unchanged.

## Verification

`pnpm exec vitest run` from the repo root (per AGENTS.md; never `--filter`, never paths after `--`).

**"The stepper renders" is green against the broken code**, so that is not what is asserted — and this was *measured*, not assumed. A throwaway presence-only probe (finds the stepper by its accessible name, finds all six labels) run against the reverted `RecordApprovalsPanel` passed **1/1**. The committed suites, run against the same reverted components, failed **8/8**.

The suites assert the property the defect names — no element may pin intrinsic width and none may be a horizontal scroller:

- the container stacks (`flex-col`), and each step owns a row (`listitem`);
- no row is `shrink-0` — the class that made min-content width the *sum* of every step;
- every label is `min-w-0` (a flex item defaults to `min-width:auto` = min-content, which is how a long label pushes a row past its container) and none is `whitespace-nowrap`;
- nothing in the subtree is an `overflow-x-auto`/`-scroll` scroller;
- no axis, overflow or width-pinning class carries a breakpoint prefix, so there is no viewport with untested behaviour.

**Regimes exercised.** The reported failing regime directly — 6 steps, the reporter's own CJK labels verbatim (they are the regime: 8-16 CJK characters is an ordinary business step name and roughly double the width of the same character count in English, so English fixtures would quietly leave the failing regime). Plus the guard boundary (2 steps) and well past the report (12). A 2/5/6/12 sweep pins that the root and row layout classes are **byte-identical** across all four, so no count threshold can put some other flow length back on the old path.

**Viewports.** No browser is available in this container (`chromium` is not installed), so there is no real-layout measurement here and none is claimed. Instead of sampling widths, the suites pin the fact that makes sampling unnecessary: the stepper carries no breakpoint-prefixed axis/overflow/width class and no measurement, so its layout is the same at every viewport by construction.

### Gates run — all against `cc07ae9af`, this PR's head

| gate | verdict line |
|---|---|
| targeted vitest (new suites) | `Test Files 2 passed (2)` / `Tests 8 passed (8)` |
| regression vitest — the whole `apps/console` project plus every approvals-surface suite in `app-shell` and `plugin-detail` | `Test Files 71 passed (71)` / `Tests 772 passed (772)` |
| `turbo run type-check` (`@object-ui/console`, `@object-ui/app-shell`, incl. `tsconfig.test.json`) | `Tasks: 37 successful, 37 total` |
| `pnpm lint` — **full farm, uncached** | `Tasks: 47 successful, 47 total` · `Cached: 0 cached, 47 total` · 0 errors repo-wide |
| `pnpm check:control-bytes` | `OK (scanned 4626 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence.mjs` | `4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |
| `pnpm check:i18n-keys` | `Every in-scope call-site key resolves against the en pack (2918 keys)` |
| `pnpm check:i18n-drift` | `No en value changed in this range.` |
| `pnpm check:i18n-dead-keys` | exit 0 (report, not a gate) |
| `pnpm check:skills-paths` | `OK (95/96 stated path(s) resolve across 18 guide file(s); 1 baselined)` |
| `pnpm check:doc-types` | `Every documented component type is registered.` |
| `pnpm check:doc-snippets` | `Every covered documentation snippet compiles against the built types.` |

Exit codes were captured before any pipe (`cmd > log 2>&1; EXIT=$?`), and each row quotes the gate's own verdict line rather than `$?`.

`check:doc-snippets` first refused to run with `@object-ui/cli declares types at packages/cli/dist/index.d.ts and it is not on disk` — an unbuilt-workspace precondition, unrelated to this diff. Building that one package turned it green; recorded so the red is not mistaken for a finding.

No new i18n keys: both steppers keep the existing `approvalsInbox.stepProgress` call site, which is already present in all ten locale packs.

**Not run locally, left to CI:** Test shards 1-4/4 (the console project and the entire approvals surface were run; the rest of the farm is CI's), Build & E2E (`@object-ui/app-shell:build` did run and pass, as a turbo dependency of type-check), and Bundle Analysis. This is a declared narrowing, not a skip.

## Scope

Exactly the declared file surface — the two components, their tests, and a changeset. No breach.

`packages/app-shell/src/hooks/useRecordApprovals.ts` was read (it owns the `flow_steps` type) and **not** modified; the fix needs no data-shape change.

The two steppers are kept identical **by hand** rather than extracted to a shared component: they live in different packages and deduplicating them is a refactor with its own surface, outside this fence. Filed separately as #5569.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_