### PR TITLE
fix(plugin-detail): record:alert CTA action.label accepts the inline locale map

### DIFF
--- a/.changeset/record-alert-cta-label-i18n-4998.md
+++ b/.changeset/record-alert-cta-label-i18n-4998.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`record:alert`'s renderer-local `RecordAlertProps` CTA slot (`action.label`) is
+widened to `string | I18nLabel` in both copies (`properties.*` and the flat
+compat mirror) in `packages/plugin-detail/src/renderers/record-alert.tsx`.
+
+The renderer already resolves `action.label` through the same inline-locale-map
+`pickLocalized` call as `title` / `body` (`const ctaLabel =
+pickLocalized(props.action?.label, language)`), so a bare `string` declaration
+was narrower than the renderer's own runtime behavior — the same
+declaration-narrower-than-the-renderer contradiction objectui#4970 fixed for
+`title` / `body` one level up in the same interface (objectui#4998).
+
+Type-only: the block's published authoring surface still declares `action` as
+a bare `object` with the member shape in prose only
+(`plugin-detail/src/index.tsx`), so there is no manifest arm to align yet —
+that half stays parked on the `ComponentInput` member-shape question (PR
+#3795) and is out of scope here.

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
@@ -92,6 +92,10 @@ import { RecordAlertRenderer } from '../record-alert';
 // the ambient predicate scope pinned at the bottom of this file is the shipped
 // one, not a stand-in for it.
 import { PredicateScopeProvider } from '@object-ui/react';
+// Real I18nProvider (not mocked) — pins the active language so the locale-map
+// case below (objectui#4998) resolves deterministically instead of riding
+// whatever language another test file left on the global i18next singleton.
+import { I18nProvider } from '@object-ui/i18n';
 
 const RECORD_DEFAULTS = {
   recordCtx: {
@@ -189,6 +193,35 @@ describe('RecordAlertRenderer', () => {
           },
         }}
       />,
+    );
+    expect(screen.getByTestId('alert-cta').textContent).toBe('Send again');
+  });
+
+  // objectui#4998 — `action.label` accepts the inline locale map, not just a
+  // plain string. The renderer already resolved one before this pin existed
+  // (`const ctaLabel = pickLocalized(props.action?.label, language)`), so a
+  // plain-string CTA label is green whether or not the local `RecordAlertProps`
+  // type admits a map — that's the `label: 'Send again'` case just above, and
+  // it cannot tell the widened declaration apart from the narrow one it
+  // replaced. This case can: a bare `label?: string` refused a locale-map
+  // value at the TYPE level even though `pickLocalized` (an `unknown` input)
+  // already resolved it correctly at runtime, exactly the `title` / `body`
+  // contradiction objectui#4970 fixed one level up in the same interface.
+  it('resolves an inline locale-map action.label to the active-language string (objectui#4998)', () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+        <RecordAlertRenderer
+          schema={{
+            properties: {
+              title: 'X',
+              action: {
+                actionName: 'resend_verification_email',
+                label: { en: 'Send again', 'zh-CN': '再次发送' },
+              },
+            },
+          }}
+        />
+      </I18nProvider>,
     );
     expect(screen.getByTestId('alert-cta').textContent).toBe('Send again');
   });

--- a/packages/plugin-detail/src/renderers/record-alert.tsx
+++ b/packages/plugin-detail/src/renderers/record-alert.tsx
@@ -77,10 +77,15 @@ type Severity = 'info' | 'warning' | 'error' | 'success';
  * the renderer and this block's own published surface — the
  * declaration-narrower-than-the-renderer family of objectui#4581.
  *
- * The CTA's `action.label` below is the same slot one level down and is
- * deliberately NOT widened here (objectui#4998): its published surface declares
- * `action` as a bare `object` with the member shape in prose only, so the arms it
- * would be aligned against do not exist yet.
+ * The CTA's `action.label` below is the same slot one level down, widened here
+ * (objectui#4998) to match: it is read through the same `pickLocalized` call as
+ * `title` / `body` (`const ctaLabel = pickLocalized(props.action?.label, language)`
+ * further down), so a declaration of bare `string` was narrower than the
+ * renderer's own runtime behaviour, exactly as `title` / `body` were before
+ * objectui#4970. This widening is TYPE-only: the block's published surface still
+ * declares `action` as a bare `object` with the member shape in prose
+ * (`plugin-detail/src/index.tsx`), so there is no manifest arm to align — that
+ * half stays parked on the `ComponentInput` member-shape question (PR #3795).
  */
 interface RecordAlertProps {
   schema?: {
@@ -90,7 +95,7 @@ interface RecordAlertProps {
       body?: string | I18nLabel;
       visible?: any;
       icon?: string;
-      action?: { actionName: string; label?: string; variant?: string };
+      action?: { actionName: string; label?: string | I18nLabel; variant?: string };
       dismissible?: boolean;
       dismissKey?: string;
     };
@@ -100,7 +105,7 @@ interface RecordAlertProps {
     body?: string | I18nLabel;
     visible?: any;
     icon?: string;
-    action?: { actionName: string; label?: string; variant?: string };
+    action?: { actionName: string; label?: string | I18nLabel; variant?: string };
     dismissible?: boolean;
     dismissKey?: string;
     className?: string;


### PR DESCRIPTION
Fixes #4998

## What

`record:alert`'s renderer-local, unexported `RecordAlertProps` CTA slot
(`action.label`) is widened from `label?: string` to `label?: string | I18nLabel`
in **both copies** in `packages/plugin-detail/src/renderers/record-alert.tsx`:

- `schema.properties.action.label` — line 98
- `schema.action.label` (flat-compat mirror) — line 108

This is the same move objectui#4970 already landed for `title` / `body` in the
same interface: the renderer resolves `action.label` through the identical
inline-locale-map `pickLocalized(props.action?.label, language)` call used for
`title` / `body` two lines above it, so the bare-`string` declaration was
narrower than the renderer's own runtime behavior. #4970 deliberately left this
slot narrow and filed it as this issue (see the doc comment it added, now
updated in this PR to say the widening landed).

## Out of scope (per the issue + triage ruling)

The publish-surface half — declaring the `action` member shape in the manifest
— stays out. `plugin-detail/src/index.tsx` still declares `action` as a bare
`object` with the member shape in prose only, so there is no manifest arm to
align the type against yet; that's parked on the `ComponentInput` member-shape
question in #3795. Not touched here.

## Test

Added a case to `record-alert.test.tsx` asserting the case the *type* previously
refused: a CTA whose `action.label` is an inline locale map
(`{ en: 'Send again', 'zh-CN': '再次发送' }`), rendered to the resolved string
for the active language, via a real `I18nProvider` pinning the language so the
resolution is deterministic. The existing "CTA label override" test (plain
string label) stays green before and after this change and cannot distinguish
the widened declaration from the narrow one it replaces — this new case can,
because it is a *type-check* discriminator, not a runtime one: `pickLocalized`'s
own parameter is `unknown`, so it never errors either way; only the call
site's literal (assigning an object to a `string`-typed prop) trips `tsc`.

Reverse-verified: with only the type declaration reverted to the pre-fix
`label?: string` (source only, no other edits), `pnpm --filter
@object-ui/plugin-detail type-check` fails exactly at the new test's locale-map
literal:

```
src/renderers/__tests__/record-alert.test.tsx(219,17): error TS2322: Type '{ en: string; 'zh-CN': string; }' is not assignable to type 'string'.
```

Restoring the fix returns `type-check` to exit 0. This confirms the new case —
not the pre-existing plain-string CTA test — is what the narrow declaration
refused.

## Gates (all at `dc14b6488`)

| Gate | Command | Verdict |
|---|---|---|
| type-check | `pnpm --filter @object-ui/plugin-detail type-check` | ✅ exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`, no errors) |
| tests | `pnpm exec vitest run packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx` | ✅ 21/21 passed |
| full package tests | `pnpm exec vitest run packages/plugin-detail/` | ✅ 90 files / 848 tests passed |
| lint | `pnpm --filter @object-ui/plugin-detail lint` | ✅ exit 0, 0 errors (809 pre-existing `no-explicit-any` / hook warnings, none on touched lines) |
| `check:control-bytes` | `node scripts/check-control-bytes.mjs` | ✅ OK (4629 tracked text files scanned) |
| `check-changeset-presence.mjs` | — | ✅ 2 source files changed, 1 changeset declared |
| `check-changeset-no-major.mjs` | — | ✅ no major bump declared |
| `check-changeset-fixed.mjs` | — | ✅ all workspace packages in fixed group |

Changeset: `.changeset/record-alert-cta-label-i18n-4998.md` (`@object-ui/plugin-detail`: patch).

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_