### PR TITLE
fix(components): whitelist ui:grid's DOM passthrough so schema keys stop leaking as attributes

### DIFF
--- a/.changeset/grid-dom-attribute-whitelist-4787.md
+++ b/.changeset/grid-dom-attribute-whitelist-4787.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/components': patch
+---
+
+The `ui:grid` renderer now forwards to the DOM by whitelist, so schema keys no longer
+land on the rendered `<div>` as invalid HTML attributes (objectui#4787).
+
+`grid.tsx` ended in a bare `{...gridProps}` spread that removed only `data-obj-*` and
+`style`, so everything else `SchemaRenderer` hands a registered component reached the
+element. Measured on a canary node, eight attributes leaked:
+`columns="4"`, `gap="4"`, `mdcolumns="2"`, `smcolumns="2"`, `name="grid_node"`,
+`props="[object Object]"`, `colorvariant="x"` (the flattened `props` container) and an
+unknown authored `zzcanary="leak"`. A responsive `columns` object rendered as
+`columns="[object Object]"`. Layout was unaffected, so every catalog grid example
+rendered with them — the reason this went unnoticed.
+
+The spread now goes through `toDomProps` from `@object-ui/core`, the same whitelist
+objectui#3291 established in `packages/fields` and objectui#4425 phase 2 promoted to the
+SDUI widget contract. Keys that are *declared* DOM-safe survive — `id`, `className`,
+`role`, `tabIndex`, plus the open `data-*` and `aria-*` families, which is how the
+designer's `data-obj-id` / `data-obj-type` still arrive — and `style` continues to be
+forwarded by name. Nothing an author can add to a grid node reaches the DOM implicitly
+any more, including keys `GridSchema` does not have yet; enumerating today's keys to
+strip would have re-rotted on the next schema addition.
+
+No authored input changes and no layout changes: the grid's own vocabulary was always
+read off `schema`, never off these props.

--- a/packages/components/src/__tests__/grid-dom-attribute-whitelist.test.tsx
+++ b/packages/components/src/__tests__/grid-dom-attribute-whitelist.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ui:grid` forwards to the DOM by WHITELIST (objectui#4787).
+ *
+ * ## What is being observed, and why the obvious test is worthless here
+ *
+ * The observable is the RENDERED DOM, not the React tree. `SchemaRenderer` spreads
+ * the authored node onto the registered component, and `grid.tsx` used to end in a
+ * bare `{...gridProps}` spread onto its `<div>`, so the node's own vocabulary landed
+ * as invalid HTML attributes. Measured on `origin/main` with the canary node below:
+ *
+ * ```
+ * <div class="grid grid-cols-4 …" columns="4" gap="4" mdcolumns="2" smcolumns="2"
+ *      id="grid-node" name="grid_node" props="[object Object]" zzcanary="leak"
+ *      data-testid="g" aria-label="A grid" role="region" colorvariant="x"
+ *      data-obj-id="grid-node" data-obj-type="grid"></div>
+ * ```
+ *
+ * Every one of those renders. "The grid renders" is GREEN against the broken code —
+ * every catalog grid example rendered today, wrong attributes and all. So the
+ * assertion has to be that the offending attributes are ABSENT from the element.
+ *
+ * ## Why case 1 sweeps every attribute instead of naming the bad ones
+ *
+ * Naming `columns` / `gap` / `mdcolumns` would pass just as well against a renderer
+ * that strips those four and keeps leaking the rest, and it would re-rot the moment
+ * `GridSchema` grows a key — the exact staleness this defect IS. It also could never
+ * reach the OPEN TAIL: `zzcanary` and the flattened `props` container are
+ * author-supplied, so no finite list of schema keys names them. Case 1 therefore
+ * asserts the whole attribute set against what the contract DECLARES as DOM-safe, so
+ * a key added to `GridSchema` tomorrow is covered without editing this file.
+ *
+ * ## The positive control is load-bearing
+ *
+ * A renderer that stripped EVERYTHING would satisfy the absence assertions on its
+ * own. Case 2 pins what must still arrive — the computed grid classes, the authored
+ * `className` merged with them, `id`, `role`, the `data-*` / `aria-*` families
+ * (including the designer's `data-obj-id` / `data-obj-type`), the forwarded `style`,
+ * and the children — so "strips everything" fails here even while case 1 passes.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Registered at module scope, NOT in a `beforeAll` — there the cold transform is
+// billed to the narrower `hookTimeout` (AGENTS.md 测试纪律, objectui#3010/#3021).
+import '../renderers';
+
+/**
+ * Attribute names legal on the `<div>` this renderer produces: the exact keys
+ * `@object-ui/core`'s SDUI pass-through set declares (lowercased, as the DOM stores
+ * them — `className` becomes `class`, `tabIndex` becomes `tabindex`), plus `style`,
+ * which `grid.tsx` forwards by name as its designer sizing channel.
+ */
+const ALLOWED_EXACT = new Set(['class', 'id', 'role', 'tabindex', 'autofocus', 'style']);
+
+/** `data-*` and `aria-*` are open families in HTML and in the widget contract. */
+const isAllowedAttribute = (name: string): boolean =>
+  ALLOWED_EXACT.has(name) || name.startsWith('data-') || name.startsWith('aria-');
+
+/**
+ * A grid node carrying, deliberately, one of every category the leak drew from:
+ * the renderer's own vocabulary in both `columns` spellings, SDUI node metadata,
+ * the `props` container, an unknown authored key, and the legitimately forwarded
+ * DOM channels.
+ */
+const CANARY_NODE = {
+  type: 'grid',
+  // Renderer vocabulary — CONSUMED off `schema`, never forwarded.
+  columns: 4,
+  gap: 4,
+  smColumns: 2,
+  mdColumns: 2,
+  lgColumns: 3,
+  xlColumns: 6,
+  // SDUI node metadata `SchemaRenderer` hands down.
+  name: 'grid_node',
+  // The `props` container, whose contents get flattened onto the component.
+  props: { colorVariant: 'x' },
+  // The open tail: an authored key nothing declares.
+  zzcanary: 'leak',
+  // Legitimate DOM channels — the positive control.
+  id: 'grid-node',
+  className: 'authored-class',
+  role: 'region',
+  'aria-label': 'A grid',
+  'data-testid': 'grid-el',
+  children: [],
+} as const;
+
+function renderCanary(overrides: Record<string, unknown> = {}) {
+  const { container } = render(
+    <SchemaRenderer schema={{ ...CANARY_NODE, ...overrides } as never} />,
+  );
+  const el = container.firstElementChild as HTMLElement;
+  expect(el, 'the canary grid must render at all').not.toBeNull();
+  return el;
+}
+
+const attributeNames = (el: HTMLElement) => Array.from(el.attributes).map((a) => a.name);
+
+describe('ui:grid — schema keys never reach the DOM (objectui#4787)', () => {
+  it('case 1: no attribute outside the declared DOM-safe set survives', () => {
+    const el = renderCanary();
+
+    // The whole set, judged against the contract rather than against a list of
+    // today's bad keys. The failure message carries the leaked names.
+    expect(attributeNames(el).filter((n) => !isAllowedAttribute(n))).toEqual([]);
+
+    // The named regressions from the card, spelled out so a future failure reads as
+    // this defect rather than as an anonymous set difference. `mdColumns` reaches the
+    // DOM lowercased (HTML attribute names are case-insensitive), which is why the
+    // card records it as `mdcolumns`.
+    for (const leaked of [
+      'columns', 'gap', 'smcolumns', 'mdcolumns', 'lgcolumns', 'xlcolumns',
+      'name', 'props', 'zzcanary', 'colorvariant',
+    ]) {
+      expect(el.hasAttribute(leaked), `"${leaked}" must not reach the DOM`).toBe(false);
+    }
+
+    // The headline symptom: an object stringified onto an attribute. Assert on the
+    // serialized element so this cannot pass by the attribute merely being renamed.
+    expect(el.outerHTML).not.toContain('[object Object]');
+  });
+
+  it('case 1b: a responsive `columns` OBJECT does not become columns="[object Object]"', () => {
+    // The flat `smColumns`/`mdColumns`/… keys deliberately OVERRIDE the object form
+    // in this renderer, so they are cleared here to exercise the object path itself.
+    const el = renderCanary({
+      columns: { xs: 1, md: 3 },
+      smColumns: undefined, mdColumns: undefined, lgColumns: undefined, xlColumns: undefined,
+    });
+
+    expect(el.hasAttribute('columns')).toBe(false);
+    expect(el.outerHTML).not.toContain('[object Object]');
+    expect(attributeNames(el).filter((n) => !isAllowedAttribute(n))).toEqual([]);
+    // Still CONSUMED: the object form drives the classes it always did.
+    expect(el.className).toContain('grid-cols-1');
+    expect(el.className).toContain('md:grid-cols-3');
+  });
+
+  it('case 2: positive control — everything legitimately forwarded still arrives', () => {
+    const el = renderCanary({
+      style: { minHeight: '10px' },
+      children: [{ type: 'text', content: 'child-marker' }],
+    });
+
+    // Computed layout classes — the renderer's real output, merged with the
+    // authored className. A filter that dropped `className` would fail here.
+    expect(el.className).toContain('grid');
+    expect(el.className).toContain('sm:grid-cols-2');
+    expect(el.className).toContain('md:grid-cols-2');
+    expect(el.className).toContain('gap-4');
+    expect(el.className).toContain('authored-class');
+
+    // Declared global attributes.
+    expect(el.getAttribute('id')).toBe('grid-node');
+    expect(el.getAttribute('role')).toBe('region');
+
+    // The two open families, including the designer channel that used to be
+    // hand-forwarded and now arrives through the `data-*` prefix rule.
+    expect(el.getAttribute('aria-label')).toBe('A grid');
+    expect(el.getAttribute('data-testid')).toBe('grid-el');
+    expect(el.getAttribute('data-obj-id')).toBe('grid-node');
+    expect(el.getAttribute('data-obj-type')).toBe('grid');
+
+    // `style`, forwarded by name.
+    expect(el.style.minHeight).toBe('10px');
+
+    // And the container still contains things.
+    expect(el.textContent).toContain('child-marker');
+  });
+
+  /**
+   * The card's side-question, pinned as far as it can honestly be pinned.
+   *
+   * React DOES warn here — but only for the CAMEL-CASE keys (`mdColumns`,
+   * `smColumns`, `colorVariant`): "React does not recognize the `%s` prop on a DOM
+   * element. If you intentionally want it to appear in the DOM as a custom
+   * attribute, spell it as lowercase `%s` instead." Measured on `origin/main`: eight
+   * attributes leaked, three `console.error` calls. The all-lowercase ones —
+   * `columns`, `gap`, `name`, `props`, `zzcanary`, and both attributes the card's
+   * title names — produce NO warning at all, because React passes unknown lowercase
+   * attributes through by design and stringifies object values silently.
+   *
+   * So this case is the WEAKER half and is kept only as a noise-floor ratchet on this
+   * renderer: it can catch a camelCase key being reopened, and it is blind to the
+   * majority of the very defect it accompanies. Case 1 is what actually closes the
+   * class, because it reads the DOM instead of the console. Do not let this case's
+   * green be read as coverage.
+   *
+   * Note it must SPY rather than rely on the run's output: Vitest 4's reporter
+   * defaults to `silent: 'passed-only'`, so console output from a passing test is
+   * discarded — which is the third reason this warning could never have turned a
+   * test red on its own. See the PR body for the full answer.
+   */
+  it('case 3: React emits no unknown-prop warning for this renderer any more', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      renderCanary();
+      const unknownPropWarnings = errSpy.mock.calls.filter((args) =>
+        /does not recognize the .* prop on a DOM element/.test(String(args[0])),
+      );
+      expect(unknownPropWarnings).toEqual([]);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});

--- a/packages/components/src/__tests__/grid-dom-attribute-whitelist.test.tsx
+++ b/packages/components/src/__tests__/grid-dom-attribute-whitelist.test.tsx
@@ -198,13 +198,23 @@ describe('ui:grid — schema keys never reach the DOM (objectui#4787)', () => {
    *
    * Note it must SPY rather than rely on the run's output: Vitest 4's reporter
    * defaults to `silent: 'passed-only'`, so console output from a passing test is
-   * discarded — which is the third reason this warning could never have turned a
-   * test red on its own. See the PR body for the full answer.
+   * discarded — the third reason this warning could never have turned a test red on
+   * its own.
+   *
+   * And it must use a camelCase canary key of its OWN (`zzCanaryCamel`, authored
+   * nowhere else in this file). React latches the unknown-prop warning per prop NAME
+   * per module instance, so it fires only on the FIRST render that carries a given
+   * key. Written against the shared canary this case PASSED against the broken
+   * renderer — cases 1 and 1b render first and consume the latch for every key they
+   * carry, leaving nothing for the spy to see. That is measured, not theorized: it is
+   * how this case was first written, and reverse-verification caught it green on code
+   * that leaked ten attributes. A unique key makes the case independent of order.
+   * The latch is also the fourth reason the warning is useless as a gate.
    */
   it('case 3: React emits no unknown-prop warning for this renderer any more', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
-      renderCanary();
+      renderCanary({ zzCanaryCamel: 'leak' });
       const unknownPropWarnings = errSpy.mock.calls.filter((args) =>
         /does not recognize the .* prop on a DOM element/.test(String(args[0])),
       );

--- a/packages/components/src/renderers/layout/grid.tsx
+++ b/packages/components/src/renderers/layout/grid.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ComponentRegistry } from '@object-ui/core';
+import { ComponentRegistry, toDomProps } from '@object-ui/core';
 import type { GridSchema } from '@object-ui/types';
 import { renderChildren } from '../../lib/utils';
 import { cn } from '../../lib/utils';
@@ -102,21 +102,36 @@ ComponentRegistry.register('grid',
       className
     );
 
-    // Extract designer-related props
-    const { 
-        'data-obj-id': dataObjId, 
-        'data-obj-type': dataObjType,
-        style, 
-        ...gridProps 
-    } = props;
+    // DOM pass-through is a WHITELIST, never a list of keys to strip — objectui#3291's
+    // discipline, promoted out of `packages/fields` to `@object-ui/core` by
+    // objectui#4425 phase 2 and executed here by {@link toDomProps}.
+    //
+    // `SchemaRenderer` hands this renderer the authored node's own keys, the contents
+    // of its `props` container, and any extra key the author wrote. The bare
+    // `{...gridProps}` spread this replaces put all of it on the div as invalid HTML
+    // attributes — measured on a canary node: `columns="4"`, `gap="4"`, `mdcolumns="2"`,
+    // `smcolumns="2"`, `name="grid_node"`, `props="[object Object]"`,
+    // `colorvariant="x"` and an unknown authored `zzcanary="leak"`, eight in all
+    // (objectui#4787). Only `data-obj-*`/`style` were ever removed.
+    //
+    // Enumerating today's GridSchema keys instead would re-rot the moment the schema
+    // grows one, and could never name the OPEN TAIL — `zzcanary` and the flattened
+    // `props` container are author-supplied, so no finite list reaches them. The
+    // whitelist keeps what is DECLARED DOM-safe (`id`, `className`, `role`, `tabIndex`,
+    // … plus the open `data-*` / `aria-*` families, which is how `data-obj-id` and
+    // `data-obj-type` still arrive) and drops everything else by construction.
+    //
+    // `style` is forwarded BY NAME rather than reopened in the shared whitelist (the
+    // objectui#4435 route): it is this container's designer sizing channel, but the
+    // shared set is deliberately element-agnostic and nothing element-specific belongs
+    // in it. Grid's own keys (`columns`, `gap`, `smColumns`…) are CONSUMED off `schema`
+    // above and must never be forwarded.
+    const { style, ...hostProps } = props;
 
     return (
-      <div 
-        className={gridClass} 
-        {...gridProps}
-        // Apply designer props
-        data-obj-id={dataObjId}
-        data-obj-type={dataObjType}
+      <div
+        {...toDomProps(hostProps)}
+        className={gridClass}
         style={style}
       >
         {schema.children && renderChildren(schema.children)}


### PR DESCRIPTION
Fixes #4787

> Note on spelling: element tags below are written with a space after `<` and before `>` (`< div … >`), the same workaround #3291's body uses. GitHub's body sanitizer eats angle-bracket-delimited runs even inside fenced code blocks — the first revision of this description lost the entire DOM measurement to it.

## The defect, measured

`grid.tsx` ended in a bare `{...gridProps}` spread onto its `< div >`, removing only `data-obj-*` and `style`. Everything else `SchemaRenderer` hands a registered component — the authored node's own keys, the contents of its `props` container, and any extra key the author wrote — landed on the element as invalid HTML attributes. Measured on `origin/main` with the canary node the new test uses:

```
< div class="grid grid-cols-4 sm:grid-cols-2 md:grid-cols-2 gap-4 authored-class"
      columns="4" gap="4" mdcolumns="2" smcolumns="2" id="grid-node" name="grid_node"
      props="[object Object]" zzcanary="leak" data-testid="g" aria-label="A grid"
      role="region" colorvariant="x" data-obj-id="grid-node" data-obj-type="grid" >
```

Eight illegitimate attributes: `columns`, `gap`, `mdcolumns`, `smcolumns`, `name`, `props`, `zzcanary`, and `colorvariant` (the flattened `props` container). A responsive `columns` object renders as `columns="[object Object]"`. Layout is unaffected, which is why every catalog grid example has been rendering with them.

## The fix — whitelist, per triage's ruling

The spread now goes through `toDomProps` from `@object-ui/core`: the whitelist #3291 established in `packages/fields` and #4425 phase 2 promoted to the SDUI widget contract. This is the existing mechanism, not a second spelling of it — `grid.tsx` is now one more caller of the same executor that `plugin-chatbot` and `DashboardRenderer` already use.

Keys that are *declared* DOM-safe survive (`id`, `className`, `role`, `tabIndex`, `autoFocus`, the React synthetic handlers) plus the open `data-*` / `aria-*` families — which is how the designer's `data-obj-id` / `data-obj-type` still arrive, so the two hand-forwarded lines they used to need are gone. `style` continues to be forwarded **by name** (the #4435 route): it is this container's designer sizing channel, but the shared set is deliberately element-agnostic and nothing element-specific belongs in it.

Enumerating today's `GridSchema` keys to strip would have re-rotted on the next schema addition, and could never have reached the open tail — `zzcanary` and the `props` container are author-supplied, so no finite list names them.

Grid's own vocabulary was always read off `schema`, never off these props, so no authored input and no rendered layout changes.

## Why React's unknown-attribute warning never turned a test red

Triage asked for this, and it has **four independent answers, each sufficient on its own**. The card's premise — that there is an "unknown-lowercase-attribute warning" being swallowed — turns out to be the least of it.

**1. For most of the leak, including both attributes the card's title names, React emits no warning at all.** Since React 16, unknown **all-lowercase** attributes are passed straight to the DOM by design, silently, with object values stringified. So `columns`, `gap`, `name`, `props`, `zzcanary` produce *zero* console output. Measured: eight leaked attributes, three `console.error` calls. There is no lowercase warning to swallow — React does not have one.

**2. The warning that does fire is the camelCase one**, for `mdColumns` / `smColumns` / `lgColumns` / `xlColumns` / `colorVariant`:

> React does not recognize the `mdColumns` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `mdcolumns` instead.

Note the trap in React's own remedy: spelling it lowercase silences the warning **while keeping the leak** — it converts case 2 into case 1.

**3. Vitest 4's reporter defaults to `silent: 'passed-only'`, so console output from a passing test is discarded.** Measured directly — two tests in one file, identical `console.error`, only the failing one's output survives:

```
stderr | zz-sink.test.ts  >  sink probe  >  FAILING test logs
MARKER-FROM-FAILING-TEST
```

`MARKER-FROM-PASSING-TEST` appears nowhere in the run output. This makes the warning *structurally* incapable of turning a test red: to be seen at all, something else must have already failed. A grid that renders fine while leaking attributes is precisely the passing case.

**4. React latches the warning per prop name per module instance**, so it fires only on the first render carrying a given key. This is not theory — it bit this PR. Case 3 of the new test, written against the shared canary, **passed against the leaking renderer**, because cases 1 and 1b render first and consume the latch. Reverse-verification caught it green on code leaking ten attributes; it now authors its own `zzCanaryCamel` key, used nowhere else in the file, and goes red as it should.

There is also no `console.error`-as-failure pin anywhere in `vitest.setup.base.ts` / `vitest.setup.dom-light.tsx` / `vitest.setup.dom.tsx`, so even a printed warning would only be log noise.

### Recommendation: a warning-as-error pin is **not** the right guard here

I recommend against it as the answer to this class, for one decisive reason: **it is blind to the majority of this very defect.** It can only ever catch case 2 — five of the ten leaked attributes here, and neither of the two the card's title names. A green warning-as-error pin would read as "this class is closed" while `columns="[object Object]"` sailed past it untouched. That is a phantom check, and reasons 3 and 4 above mean it would also be order- and reporter-sensitive.

The mechanism that actually closes the class is the one this repo already built: **read the DOM, not the console.** `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx` checks every rendered attribute against what HTML defines, and catches lowercase and camelCase alike. Case 1 of the new test applies that technique to this renderer.

The real gap is that the sweep's targets are four plugin packages and it **does not reach the `packages/components` renderers at all** — which is why `ui:grid` leaked unobserved through #4008's ratchet and #4011's implementation. Extending it there is the pin worth having, it would have caught this, and it lands outside this card's file surface, so it is filed rather than built: **#5574** (sub-issue of #4425), which also records that `flex.tsx`, `stack.tsx`, `container.tsx` and `text.tsx` carry the identical unfixed spread.

## Tests

`packages/components/src/__tests__/grid-dom-attribute-whitelist.test.tsx`, four cases.

Case 1 sweeps **every** attribute on the element against the declared DOM-safe set rather than naming today's bad keys — so a key added to `GridSchema` tomorrow is covered without editing the test, and the open tail is covered at all. Case 1b covers the responsive `columns` object. Case 2 is a **positive control**: the computed grid classes, the authored `className` merged with them, `id`, `role`, `aria-*`, `data-*` including `data-obj-id`/`data-obj-type`, the forwarded `style`, and the children. Case 3 is the React-warning ratchet described above, kept explicitly labelled as the weaker half.

**Reverse-verification** (fix reverted to `origin/main`, mutation confirmed on disk by `grep -c toDomProps` = 0 / `gridProps` = 2, restored via an `EXIT` trap):

```
× case 1  — expected [ 'columns', 'gap', 'smcolumns', …(7) ] to deeply equal []
× case 1b — expected true to be false   (columns="[object Object]")
× case 3  — React unknown-prop warnings present
✓ case 2  — positive control PASSES against the broken code
Tests  3 failed | 1 passed (4)
```

Case 2 staying green against the leaking renderer is the point: it proves it is a control, not the detector — a fix that stripped everything would fail it while cases 1/1b passed.

## Gates

All run at `020140073` (the final commit), from the worktree root:

| gate | result |
|---|---|
| `pnpm --filter @object-ui/components type-check` | exit 0 — `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/components lint` | exit 0 — `896 problems (0 errors, 896 warnings)`, all pre-existing `react-refresh/only-export-components` |
| `pnpm exec vitest run packages/components/` | exit 0 — `Test Files 174 passed (174)`, `Tests 1576 passed (1576)` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 4630 tracked text file(s); skipped 85 binary)` |
| `check:doc-types` | `✅ Every documented component type is registered.` |
| `check-changeset-presence` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `✅ No changeset declares a major bump.` |
| `check-changeset-fixed` | `✅ All workspace packages are in the changeset fixed group.` |

**Declared narrowing, two items — read these as narrowing, not as passes:**

- **`check:doc-snippets` was NOT run.** It refuses to run on this worktree: `@object-ui/plugin-view … is not on disk — run the build first`, 11 packages unbuilt, and it says so explicitly (`The snippet program was NOT run`). Building their full closures is effectively a whole-workspace build, which CI does anyway. It cannot observe this diff regardless: it is a type-level gate over doc snippets compiled against built package types, and `grid.tsx` has **zero** `export` statements — it is a pure side-effect registration module (`import './grid'`), contributing nothing to any package's `.d.ts`. `check:doc-types`, the gate that actually checks documented component types against the registry, did run and is green.
- **Repo-wide `pnpm lint` / `pnpm type-check` (`turbo run …`) were scoped to `@object-ui/components`.** The package's own lint ran over the *whole* package, so there is no file-level narrowing within it; the narrowing is at package level, and it is sound because the diff touches only the `packages/components` tree plus `.changeset/`, and `eslint.config.js` enables **no type-aware linting** (no `parserOptions.project`, no `projectService`), so this diff cannot move any untouched package's verdict.

Also swept: no snapshot or fixture anywhere in the repo pinned the leaked spellings (`grep -rn "mdcolumns|smcolumns|lgcolumns|xlcolumns"` outside the changed files returns nothing), so no fixture triage was needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_
