### PR TITLE
docs(core): state the registerFunction case-fold on the method itself

### DIFF
--- a/.changeset/registerfunction-casefold-doc-5363.md
+++ b/.changeset/registerfunction-casefold-doc-5363.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/core': patch
+---
+
+`ExpressionEvaluator.registerFunction` now documents the case-fold it has always
+performed: the name is stored — and must be called — in UPPER CASE
+(objectui#5363).
+
+`registerFunction('formatCurrency', fn)` registers `FORMATCURRENCY`, because the
+method delegates to `FormulaFunctions.register`, which stores under
+`name.toUpperCase()`. That fold is correct for the spreadsheet-style built-in
+vocabulary (`SUM`, `IF`, `UPPER`) and is unchanged here — but nothing declared
+it on the public method, and two things keep it from being self-evident at the
+call site. The registry API stays case-insensitive, so `getFormulas().has()` and
+`.get()` both answer to the original spelling and never reveal the fold; only
+expressions see the stored key, because the evaluation scope is built from
+`FormulaFunctions.toObject()`, a plain object whose identifiers are matched
+case-sensitively. And a wrong-case call site does not raise: `evaluate()`
+catches, warns, and returns `defaultValue ?? expression`, so the template
+renders its own `${...}` source as literal text on screen rather than erroring.
+
+Behavior is untouched — this is the declaration catching up with what the code
+enforces. It ships as a patch rather than as an empty changeset because the
+JSDoc is emitted into the published `dist/evaluator/ExpressionEvaluator.d.ts`,
+so it is what consumers see on hover.
+
+`ExpressionEvaluator.test.ts` gains three cases pinning the half that was
+uncovered — that the given spelling does *not* resolve in an expression, that
+the failure renders the raw template source instead of throwing, and that the
+registry API stays case-insensitive underneath — so making registration
+case-preserving fails a test instead of silently invalidating the new JSDoc.

--- a/packages/core/src/evaluator/ExpressionEvaluator.ts
+++ b/packages/core/src/evaluator/ExpressionEvaluator.ts
@@ -349,7 +349,44 @@ export class ExpressionEvaluator {
   }
 
   /**
-   * Register a custom formula function
+   * Register a custom formula function.
+   *
+   * **The name is case-folded: it is stored — and must be called — in UPPER
+   * CASE.** `registerFunction('formatCurrency', fn)` registers
+   * `FORMATCURRENCY`, and an expression has to spell it that way:
+   * `${FORMATCURRENCY(price)}` resolves, `${formatCurrency(price)}` does not.
+   * The fold is deliberate — formula names are spreadsheet-style vocabulary
+   * (`SUM`, `IF`, `UPPER`) and the built-ins go through the very same
+   * {@link FormulaFunctions.register} — but two things keep it from being
+   * self-evident at the call site:
+   *
+   * 1. The registry API stays case-insensitive, so it never surfaces the fold:
+   *    `getFormulas().has('formatCurrency')` is `true` and `.get()` returns the
+   *    function. Only expressions see the stored spelling, because the
+   *    evaluation scope is built from `FormulaFunctions.toObject()` — a plain
+   *    object, whose identifiers expressions match case-sensitively.
+   * 2. A wrong-case call site does not raise. {@link evaluate} catches, warns,
+   *    and returns `defaultValue ?? expression`, so the template renders its own
+   *    `${...}` source as literal text. {@link evaluateExpression} is the
+   *    throwing sibling, and reports `'formatCurrency' is not a function`.
+   *
+   * To keep a name's exact spelling, supply the function as evaluation context
+   * data instead: context entries are merged over the formulas and stay verbatim.
+   *
+   * @param name Function name; folded to upper case for both storage and lookup.
+   * @param fn Implementation, invoked with the evaluated call arguments.
+   *
+   * @example
+   * ```ts
+   * const evaluator = new ExpressionEvaluator({ price: 1234.5 });
+   * evaluator.registerFunction('formatCurrency', fmt);
+   *
+   * evaluator.evaluate('${FORMATCURRENCY(price)}'); // '$1,234.50'
+   * evaluator.evaluate('${formatCurrency(price)}'); // '${formatCurrency(price)}' — the source, verbatim
+   *
+   * // Case-sensitive alternative — the function travels as context data:
+   * evaluateExpression('${formatCurrency(price)}', { formatCurrency: fmt, price: 1234.5 }); // '$1,234.50'
+   * ```
    */
   registerFunction(name: string, fn: (...args: any[]) => any): void {
     this.formulas.register(name, fn);

--- a/packages/core/src/evaluator/__tests__/ExpressionEvaluator.test.ts
+++ b/packages/core/src/evaluator/__tests__/ExpressionEvaluator.test.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ExpressionEvaluator, evaluateExpression, evaluateCondition, evaluatePlainCondition } from '../ExpressionEvaluator';
 import { ExpressionContext } from '../ExpressionContext';
 import { SafeExpressionParser } from '../SafeExpressionParser';
@@ -616,5 +616,55 @@ describe('ExpressionEvaluator — CSP safety integration', () => {
       globalThis.eval = originalEval;
       (globalThis as any).Function = originalFunction;
     }
+  });
+});
+
+/**
+ * The case-fold contract stated in `ExpressionEvaluator.registerFunction`'s
+ * JSDoc. These pin the half that is NOT self-evident: the spelling handed to
+ * `registerFunction` is not the spelling an expression can call, and getting it
+ * wrong is silent rather than loud. Registering `'DOUBLE'` and then calling
+ * `DOUBLE(...)` would prove none of that — every assertion below is one that a
+ * case-preserving `registerFunction` (objectui#5363 direction 2) would turn
+ * red, which is precisely the wanted signal if that behaviour is ever changed:
+ * the JSDoc on the method would have silently become wrong.
+ */
+describe('ExpressionEvaluator.registerFunction - documented case-fold', () => {
+  const evaluatorWithDouble = () => {
+    const evaluator = new ExpressionEvaluator({ x: 5 });
+    evaluator.registerFunction('double', (n: number) => n * 2);
+    return evaluator;
+  };
+
+  it('stores under the upper-cased name, so only that spelling resolves in an expression', () => {
+    const evaluator = evaluatorWithDouble();
+
+    expect(evaluator.evaluateExpression('DOUBLE(x)')).toBe(10);
+    expect(() => evaluator.evaluateExpression('double(x)')).toThrow(/"double" is not a function/);
+  });
+
+  it('renders the raw template source, not an error, when the call site uses the registered spelling', () => {
+    const evaluator = evaluatorWithDouble();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      expect(evaluator.evaluate('${DOUBLE(x)}')).toBe(10);
+      // Not a throw, not an empty string: the template's own source, verbatim.
+      // This soft-fail is what makes the fold easy to miss on screen.
+      expect(evaluator.evaluate('${double(x)}')).toBe('${double(x)}');
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps the registry API case-insensitive, which is why the fold stays invisible until an expression runs', () => {
+    const evaluator = evaluatorWithDouble();
+
+    expect(evaluator.getFormulas().has('double')).toBe(true);
+    expect(typeof evaluator.getFormulas().get('double')).toBe('function');
+    // ...but the key the expression scope is built from is the folded one.
+    expect(evaluator.getFormulas().getNames()).toContain('DOUBLE');
+    expect(evaluator.getFormulas().getNames()).not.toContain('double');
   });
 });


### PR DESCRIPTION
Fixes #5363

## What this is — and what it deliberately is not

The card reads like a bug: `ExpressionEvaluator.registerFunction('formatCurrency', fn)`
registers `FORMATCURRENCY`, so `${formatCurrency(price)}` renders its own `${...}` source
on screen. **This PR changes no behavior.** It states the case-fold on the method that
performs it, so the declaration matches what the code enforces, and pins the half of that
contract nothing covered.

I re-derived the fork rather than taking it on trust, and **agreed with triage: direction 1.**
Reasoning is in the report comment on #5363; the short form is that the fold is the
*registry's* contract, not an accident of this method — `FormulaFunctions.register` folds,
and every built-in (`SUM`, `IF`, `UPPER`) is registered through the same call. Making only
`registerFunction` case-preserving would put two dialects in one registry, which is exactly
what commandment #0.1 exists to stop, and it is a **breaking** change rather than an
unobserved one: `ActionRunner.scriptAwait.test.ts` already registers `'doWrite'` and calls
`DOWRITE()`. That is a Feature card through the decision inbox, not a drive-by, so I did not
write it.

## Premise re-verified on today's `main`

The issue measured against `bdf8cf76e`; `origin/main` is now `ac73c24b0`. Re-measured against
a fresh `packages/core/dist/` build — the premise holds, and one detail is sharper than the
card states:

| probe | result |
|---|---|
| `evaluate('${formatCurrency(price)}')` after registering `'formatCurrency'` | `'${formatCurrency(price)}'` — the source, verbatim |
| `evaluate('${FORMATCURRENCY(price)}')` | `'$1,234.50'` |
| `getFormulas().has('formatCurrency')` / `.get(...)` | `true` / `function` — **case-insensitive** |
| `getFormulas().toObject()` key | `FORMATCURRENCY` |
| `evaluateExpression('formatCurrency(price)')` | throws `"formatCurrency" is not a function` |

The sharper detail: the **registry API is case-insensitive** (`has`/`get` answer to the
original spelling). Only *expressions* are case-sensitive, because the evaluation scope is
built from `toObject()` — a plain object whose identifiers match exactly. That is why the
fold is invisible right up until someone writes an expression, and it is the part the new
JSDoc leads with.

## The pin can fail — measured, not asserted

The dispatch asked for a pin that proves something about the *documented* contract, or none
at all. Registering `'DOUBLE'` and calling `DOUBLE(...)` proves nothing, so the three new
cases pin the uncovered half: that the **given** spelling does not resolve, that the failure
renders raw template source instead of raising, and that the registry API stays
case-insensitive underneath.

Reverse-verified by ablation — `FormulaFunctions.register` mutated to `set(name, fn)`, i.e.
direction 2 simulated:

```
Tests  3 failed | 79 passed (82)
```

**All three** new cases go red; the 79 pre-existing ones stay green — so nothing previously
covered this fold at all, and the pin is a real tripwire on the behavior change this card
declined. Mutation was confirmed on disk by anchored `grep -c` on both the removed and the
injected text (1→0 and 0→1) plus `git diff --stat`, never an editor exit code; the script
carried a `trap ... EXIT INT TERM` restore, and the tree was verified byte-identical to HEAD
afterwards (`git status --porcelain` empty). The suite resolves its subject by **relative
source path**, so no `dist` is in the loop and no rebuild sits between mutation and result.

## Changeset: a real `patch`, not the empty-frontmatter exemption

`.changeset/README.md` says not to write changesets for documentation updates. That rule is
about documentation *files*; this is source in a released package, and the JSDoc is emitted
into the published artifact — measured:

```
packages/core/dist/evaluator/ExpressionEvaluator.d.ts:134:  * **The name is case-folded: it is stored — and must be called — in UPPER
```

So it is what consumers see on hover, which is a user-visible change to what npm ships.
Cheap to overrule: swap the frontmatter for the empty form.

## Verification

Exit codes captured before any pipe; each gate's own verdict line quoted.

| gate | result |
|---|---|
| `pnpm --filter @object-ui/core lint` | `LINT_EXIT=0` — `✖ 513 problems (0 errors, 513 warnings)`, all pre-existing `no-explicit-any` |
| `pnpm --filter @object-ui/core type-check` | `TYPECHECK_EXIT=0` (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm exec vitest run packages/core/src/evaluator/__tests__/ExpressionEvaluator.test.ts` | `Test Files 1 passed (1)` · `Tests 82 passed (82)` |
| `pnpm exec vitest run packages/core/` (whole package) | `Test Files 93 passed (93)` · `Tests 1945 passed (1945)` |
| `node scripts/check-control-bytes.mjs` | `EXIT=0` — `✅ OK (scanned 4629 tracked text file(s))` |
| `node scripts/check-changeset-presence.mjs` | `EXIT=0` — `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `EXIT=0` — `✅ No changeset declares a major bump` |
| `node scripts/check-changeset-fixed.mjs` | `EXIT=0` — `✅ All workspace packages are in the changeset fixed group` |

All run at `29d23acc0`, which is the head of this branch.

**Repo-wide `pnpm lint` / `pnpm type-check` are left to CI, and the narrowing is declared
rather than assumed.** Evidence, since a narrowing without it is just a skipped run:
eslint's own population for `packages/core` is **185 files** (count read from `--format json`,
not guessed), both touched files are in it; and root `eslint.config.js` declares no
`projectService` / `parserOptions.project`, so linting is **not type-aware** and this diff
cannot move a verdict in any file it does not itself contain. For `type-check` the invariance
is stronger still: the `ExpressionEvaluator.ts` diff contains **zero non-comment lines**
(single hunk at line 349; lines 1–200 byte-identical to `origin/main`), so the emitted type
signature is unchanged and no consumer package can be affected.

One measurement worth flagging: `eslint . --no-inline-config` reports 5 errors in
`packages/core`, but that flag is **not** what this repo's gate runs (`pnpm lint` is
`turbo run lint` → per-package `eslint .`). All 5 sit at deliberate `eslint-disable`
comments in code this PR does not touch — including the ES2020 `preserve-caught-error`
waiver at `ExpressionEvaluator.ts:176`, proven pre-existing above.

## Scope

Exactly the dispatched surface, no breach: `ExpressionEvaluator.ts`, one test file, one
changeset. `FormulaFunctions.ts` carries the same fold undocumented on its own `register`,
but it is outside the declared surface and its `toUpperCase()` is visible in its one-line
body — noted in the report rather than filed or fixed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_