### PR TITLE
Marketplace catalog page answers "no marketplace here" before "not an admin" (#5557)

### DIFF
--- a/.changeset/marketplace-catalog-runtime-before-admin-5557.md
+++ b/.changeset/marketplace-catalog-runtime-before-admin-5557.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The marketplace **catalog** page now tells a non-admin that the runtime has no
+marketplace, instead of telling them they lack permission (objectui#5557).
+
+`MarketplacePage` ordered its two early returns admin-first, so on a runtime that
+mounts no marketplace at all (`features.marketplace: false` — an `OS_CLOUD_URL=off`
+deployment, the EE deploy template's factory default) an unprivileged member got
+"access denied" for a surface that exists for nobody. That answer sends them to
+ask an administrator for a grant that would not help them, and it left the
+informational disabled state built in objectui#5504 unreachable for every
+non-admin. The runtime check now answers first, because "this deployment has no
+marketplace" is true regardless of who is asking.
+
+This restores the sibling-page invariant for the one class of viewer it still
+failed for: `MarketplacePackagePage` was reordered the same way in objectui#5533,
+so on a marketplace-off runtime the catalog page and the package detail page now
+give a non-admin the same kind of answer.
+
+Scope, deliberately narrow:
+
+- **Admin-first ordering stays correct where a marketplace exists.** On a runtime
+  with `features.marketplace: true`, a non-admin still gets `MarketplaceAccessDenied`
+  — the catalog is an install surface, and a member who cannot install has nothing
+  to do with it. That boundary is pinned by an explicit test, not left to prose:
+  without it, a change that simply dropped the admin check would look correct.
+- Nothing an admin sees changes, on either kind of runtime.
+- No new i18n keys, and no change to `MarketplaceAccessDenied` or
+  `MarketplaceDisabled` themselves — only which of the two the page reaches for,
+  and in which order it decides.
+- The disabled state is still the server's own answer (`features.marketplace`),
+  never inferred from a failed request, and it still fails open.

--- a/packages/app-shell/src/console/marketplace/MarketplacePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePage.tsx
@@ -197,10 +197,21 @@ export function MarketplacePage() {
     });
   }, [items, query, category, language]);
 
-  if (!isAdmin) return <MarketplaceAccessDenied />;
-  // Ordered after the access guard on purpose: a non-admin has no business
-  // reading this runtime's marketplace posture either way.
+  // Ahead of the `!isAdmin` guard below deliberately (objectui#5557): on a
+  // runtime that mounts no marketplace, "there is no marketplace here" is true
+  // of every viewer, and `features.marketplace` is public runtime config every
+  // client already reads -- so the retired ordering withheld nothing, it only
+  // misdirected. Telling an unprivileged member they lack PERMISSION for a
+  // surface that exists for nobody sends them to ask an administrator for a
+  // grant that would not help them. This is the ordering
+  // `MarketplacePackagePage` landed under objectui#5533; the sibling pages now
+  // answer one runtime the same way.
   if (!marketplaceEnabled) return <MarketplaceDisabled />;
+
+  // On a runtime that DOES have a marketplace, admin-first stays correct: the
+  // catalog is an install surface, and a member who cannot install has nothing
+  // to do with it. objectui#5557 did not claim otherwise.
+  if (!isAdmin) return <MarketplaceAccessDenied />;
 
   return (
     <div className="flex flex-col gap-6 p-4 sm:p-6">

--- a/packages/app-shell/src/console/marketplace/__tests__/MarketplacePage.guardOrder.test.tsx
+++ b/packages/app-shell/src/console/marketplace/__tests__/MarketplacePage.guardOrder.test.tsx
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The catalog page answers "this runtime has no marketplace" BEFORE it answers
+ * "you are not an admin" (objectui#5557).
+ *
+ * ## The defect
+ *
+ * `MarketplacePage` ordered its early returns admin-first:
+ *
+ *     if (!isAdmin) return (MarketplaceAccessDenied)
+ *     if (!marketplaceEnabled) return (MarketplaceDisabled)
+ *
+ * so on an `OS_CLOUD_URL=off` deployment — the EE deploy template's factory
+ * default — an unprivileged member was told they lack PERMISSION for a surface
+ * that exists for nobody. That answer sends them to ask an administrator for a
+ * grant that would not help them, and it left the disabled state objectui#5504
+ * built unreachable for every non-admin. `MarketplacePackagePage` had already
+ * been reordered under objectui#5533, so the two sibling pages disagreed about
+ * one runtime for exactly one class of viewer.
+ *
+ * ## Why a separate suite from `MarketplacePage.disabledState.test.tsx`
+ *
+ * That suite pins WHERE the disabled state comes from, and hard-mocks
+ * `useIsWorkspaceAdmin: () => true` at module scope — every case in it is an
+ * admin, so none of them can see this defect. The admin flag has to vary per
+ * case here, which is a different module mock and therefore a different file.
+ *
+ * ## Why these cases boot the REAL runtime-config module
+ *
+ * Same argument the sibling suites make: the disabled state's correctness is
+ * *where it comes from*. It comes from `features.marketplace`, which the server
+ * derives per request from its own route table (objectstack#8356) — never from
+ * the shape of a failure. So every case boots the genuine `initRuntimeConfig()`
+ * over a stubbed `GET /api/v1/runtime/config` and lets the real merge run.
+ *
+ * ## The control that makes the rest load-bearing
+ *
+ * objectui#5557 explicitly does NOT claim admin-first ordering is wrong in
+ * general. On a runtime that DOES mount a marketplace, a non-admin must still
+ * get access-denied — the catalog is an install surface. Without that boundary
+ * case, a "fix" that simply deleted the admin check would satisfy every other
+ * assertion in this file while handing an install surface to every member.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+
+/** The viewer's privilege, varied per case — the axis this suite exists for. */
+const viewer = vi.hoisted(() => ({ isAdmin: false }));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  // `packageId` serves the detail page in the sibling-consistency case; the
+  // catalog page reads only `appName`, so one mock drives both.
+  useParams: () => ({ packageId: 'com.acme.crm' }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useIsWorkspaceAdmin: () => viewer.isAdmin,
+}));
+
+// `t` echoes the KEY, for the reason the sibling suites give: a `t` echoing
+// `defaultValue` renders identical text whether or not the key is wired, and
+// the claim under test is WHICH state — and so which string — the page reaches.
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      typeof opts?.url === 'string' ? `«${key}:${opts.url}»` : `«${key}»`,
+    language: 'en',
+  }),
+}));
+
+const listMarketplacePackages = vi.fn();
+const getMarketplacePackage = vi.fn();
+const getCloudInstallationInfo = vi.fn();
+
+vi.mock('../marketplaceApi', () => ({
+  listMarketplacePackages: (...a: unknown[]) => listMarketplacePackages(...a),
+  getMarketplacePackage: (...a: unknown[]) => getMarketplacePackage(...a),
+  getCloudInstallationInfo: (...a: unknown[]) => getCloudInstallationInfo(...a),
+  listLocalInstalls: async () => [],
+  listOrgPackages: async () => ({ items: [] }),
+  listInstalledPackages: async () => ({ items: [] }),
+  installPackage: async () => ({}),
+  installLocal: async () => ({}),
+  uninstallLocal: async () => ({}),
+  listCloudEnvironments: async () => [],
+  listInstallableOrgIds: async () => [],
+  cloudInstallDeepLink: () => '',
+  reseedSampleData: async () => ({ ok: true }),
+  purgeSampleData: async () => ({ ok: true }),
+  reseedLocalSampleData: async () => ({ ok: true }),
+  purgeLocalSampleData: async () => ({ ok: true }),
+}));
+
+vi.mock('../../../assistant/assistantBus', () => ({ emitMetadataRefresh: () => {} }));
+vi.mock('../../../providers/MetadataProvider', () => ({ useMetadata: () => ({ refresh: () => {} }) }));
+
+import { initRuntimeConfig, resetRuntimeConfigForTesting } from '../../../runtime-config';
+import { MarketplacePage } from '../MarketplacePage';
+// Read-only here: the already-fixed sibling, mounted to prove the two pages
+// agree. objectui#5557 changes nothing in it.
+import { MarketplacePackagePage } from '../MarketplacePackagePage';
+
+/** A `GET /api/v1/runtime/config` answer, as the server sends it. */
+type ConfigBody = Record<string, unknown>;
+
+const serverConfig = (cloudUrl: string, marketplace: boolean): ConfigBody => ({
+  cloudUrl,
+  singleEnvironment: true,
+  features: { installLocal: true, marketplace, aiStudio: true, autoPublishAiBuilds: true },
+  branding: { productName: 'ObjectOS', productShortName: 'ObjectOS' },
+});
+
+/** Boot the SPA against a runtime that answers with `body`. */
+async function bootOn(body: ConfigBody) {
+  resetRuntimeConfigForTesting();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, status: 200, json: async () => body })),
+  );
+  await initRuntimeConfig();
+}
+
+/** What a runtime with no marketplace proxy actually returns for these routes. */
+const NOT_FOUND = () => Promise.reject(new Error('HTTP 404: Not found'));
+
+/**
+ * Which KIND of answer a page gave this viewer — the unit the
+ * sibling-consistency case compares. Deliberately not "did some element
+ * render": two pages both rendering `other` would otherwise read as agreement.
+ */
+type Answer = 'runtime-off' | 'access-denied' | 'neither';
+
+function classify(): Answer {
+  return screen.queryByTestId('marketplace-disabled')
+    ? 'runtime-off'
+    : screen.queryByText('«marketplace.accessDenied.title»')
+      ? 'access-denied'
+      : 'neither';
+}
+
+/** The answer a page gives with no request settled — i.e. from config alone. */
+function answerOf(ui: ReactElement): Answer {
+  const { unmount } = render(ui);
+  const answer = classify();
+  unmount();
+  return answer;
+}
+
+/**
+ * The answer a page gives once it has settled.
+ *
+ * Needed only on a marketplace-ON runtime, and only for the detail page: its
+ * `!isAdmin` guard sits AFTER its `loading` and `error || !data` branches
+ * (`MarketplacePackagePage.tsx`), so it reaches a refusal only once a package
+ * has loaded. A page that settles on neither refusal times out here, which is
+ * the correct direction of failure — "did not refuse" is what this pins.
+ */
+async function settledAnswerOf(ui: ReactElement): Promise<Answer> {
+  const { unmount } = render(ui);
+  let answer: Answer = 'neither';
+  try {
+    await waitFor(() => {
+      answer = classify();
+      expect(answer).not.toBe('neither');
+    });
+  } finally {
+    unmount();
+  }
+  return answer;
+}
+
+beforeEach(() => {
+  viewer.isAdmin = false;
+  listMarketplacePackages.mockReset();
+  getMarketplacePackage.mockReset();
+  getCloudInstallationInfo.mockReset();
+  listMarketplacePackages.mockResolvedValue({ items: [] });
+  getMarketplacePackage.mockImplementation(NOT_FOUND);
+  getCloudInstallationInfo.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetRuntimeConfigForTesting();
+});
+
+describe('a NON-ADMIN on a runtime deployed with OS_CLOUD_URL=off', () => {
+  beforeEach(async () => {
+    // What the EE template's factory default produces: no browse mount, so the
+    // server's own derived flag is false.
+    await bootOn(serverConfig('', false));
+    listMarketplacePackages.mockImplementation(NOT_FOUND);
+  });
+
+  it('is told the runtime has no marketplace, never that they lack permission', () => {
+    render(<MarketplacePage />);
+
+    expect(screen.getByTestId('marketplace-disabled')).toBeInTheDocument();
+    expect(screen.getByText('«marketplace.disabled.title»')).toBeInTheDocument();
+    // The retired answer. It invited this viewer to go ask an administrator for
+    // a grant that would not help them — there is nothing behind the door on
+    // this deployment.
+    expect(screen.queryByText('«marketplace.accessDenied.title»')).toBeNull();
+    expect(screen.queryByText('«marketplace.accessDenied.description»')).toBeNull();
+  });
+
+  it('gets the SAME KIND of answer from the catalog page and the package detail page', () => {
+    // The invariant objectui#5504 and objectui#5533 were closing, restored for
+    // the one class of viewer it still failed for. Compared as kinds, so this
+    // cannot pass by both pages rendering something unrelated.
+    const catalog = answerOf(<MarketplacePage />);
+    const detail = answerOf(<MarketplacePackagePage />);
+
+    expect(catalog).toBe(detail);
+    expect(catalog).toBe('runtime-off');
+  });
+
+  it('issues no catalog request it already knows will 404', async () => {
+    render(<MarketplacePage />);
+
+    await waitFor(() => expect(screen.getByTestId('marketplace-disabled')).toBeInTheDocument());
+    expect(listMarketplacePackages).not.toHaveBeenCalled();
+  });
+
+  it('leaves the admin answer on this runtime exactly as it was', () => {
+    // The reorder must be invisible to admins: they already reached the
+    // disabled state, and objectui#5504's pins on it still hold.
+    viewer.isAdmin = true;
+
+    render(<MarketplacePage />);
+
+    expect(screen.getByTestId('marketplace-disabled')).toBeInTheDocument();
+    expect(screen.getByTestId('marketplace-disabled-hint')).toHaveTextContent(
+      '«marketplace.disabled.hint»',
+    );
+  });
+});
+
+describe('the "Not claimed" boundary — a runtime that DOES have a marketplace', () => {
+  beforeEach(async () => {
+    await bootOn(serverConfig('https://cloud.objectos.ai', true));
+  });
+
+  it('still refuses a NON-ADMIN with access-denied, not with the disabled state', async () => {
+    // THE CONTROL for this whole card. objectui#5557 does not claim admin-first
+    // ordering is wrong in general: where a marketplace exists, the catalog is
+    // an install surface and a member who cannot install has nothing to do with
+    // it. A "fix" that deleted the admin check passes every other case in this
+    // file and fails here.
+    render(<MarketplacePage />);
+
+    expect(await screen.findByText('«marketplace.accessDenied.title»')).toBeInTheDocument();
+    expect(screen.getByText('«marketplace.accessDenied.description»')).toBeInTheDocument();
+    expect(screen.queryByTestId('marketplace-disabled')).toBeNull();
+    // Not merely "some heading is missing": the catalog itself never rendered.
+    expect(screen.queryByText('«marketplace.title»')).toBeNull();
+  });
+
+  it('and the detail page refuses that same non-admin the same way', async () => {
+    // The sibling invariant, stated in the other direction: agreement must hold
+    // on a marketplace-ON runtime too, or "the pages agree" would only mean
+    // "both pages are off".
+    //
+    // The detail page needs a package that LOADS to get there: its admin guard
+    // runs after `loading` and `error || !data`, so a 404 sends it to the
+    // destructive card and it never reaches a refusal at all.
+    getMarketplacePackage.mockResolvedValue({
+      package: {
+        id: 'pkg_1',
+        manifest_id: 'com.acme.crm',
+        display_name: 'Acme CRM',
+        description: 'A CRM.',
+        latest_version: null,
+      },
+      versions: [],
+    });
+
+    const catalog = answerOf(<MarketplacePage />);
+    const detail = await settledAnswerOf(<MarketplacePackagePage />);
+
+    expect(catalog).toBe(detail);
+    expect(catalog).toBe('access-denied');
+  });
+
+  it('lets an admin through to the catalog, as before', async () => {
+    viewer.isAdmin = true;
+
+    render(<MarketplacePage />);
+
+    expect(await screen.findByText('«marketplace.title»')).toBeInTheDocument();
+    expect(screen.queryByTestId('marketplace-disabled')).toBeNull();
+    expect(screen.queryByText('«marketplace.accessDenied.title»')).toBeNull();
+    expect(listMarketplacePackages).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #5557

## The defect

`MarketplacePage` — the marketplace **catalog** page — ordered its two early returns admin-first:

```
if (!isAdmin) return ( MarketplaceAccessDenied )       // was line 200
if (!marketplaceEnabled) return ( MarketplaceDisabled ) // was line 203
```

So on a runtime that mounts no marketplace at all (`features.marketplace: false` — an `OS_CLOUD_URL=off` deployment, the EE deploy template's factory default) an unprivileged member was told they lack **permission** for a surface that exists for nobody. That answer sends them to ask an administrator for a grant that would not help them, and it left the informational disabled state built in #5504 unreachable for every non-admin.

## The fix

The runtime check answers first, because "this deployment has no marketplace" is true regardless of who is asking. That is the ordering `MarketplacePackagePage` landed under #5533, so the two sibling pages stop disagreeing about one runtime for the one class of viewer they still disagreed for.

The retired code comment claimed the old order was deliberate — "a non-admin has no business reading this runtime's marketplace posture either way". The merged sibling rebuts it on the record, and this PR carries that rationale over: `features.marketplace` is **public runtime config every client already reads**, so the old order withheld nothing. It only misdirected.

## Boundary — what this PR does not claim

Admin-first ordering stays correct where a marketplace exists. On `features.marketplace: true` a non-admin still gets `MarketplaceAccessDenied`; the catalog is an install surface. That boundary is a test assertion, not prose — **it is the control for the whole change**: without it, a "fix" that simply deleted the admin check would satisfy every other case in the file while handing an install surface to every member.

## Reverse-verification (ablation)

The pre-fix ordering was restored on disk and the suite re-run. No rebuild is involved: the tests import the subject as a relative **source** path (`from '../MarketplacePage'`), so nothing resolves through `dist/`.

| | result |
| --- | --- |
| mutation proven on disk | admin guard moved to line 209, runtime guard to 214; `git diff --stat` 2 insertions/2 deletions; sha256 `fc7e9405…` → `60753dec…` |
| under the mutation | **3 failed / 29 passed** — the three non-admin marketplace-off cases went red |
| the boundary control | **stayed green**, as required |
| restore | via `trap ... EXIT INT TERM`; sha256 back to `fc7e9405…`, `git status` clean |

## Gates — all at `880929160`

| gate | verdict |
| --- | --- |
| `pnpm --filter '@object-ui/app-shell^...' build` | `command-exit 0` (run first; without it type-check reports TS2307 on every sibling) |
| `pnpm --filter @object-ui/app-shell type-check` | `TYPECHECK_EXIT=0` — `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/app-shell lint` | `LINT_EXIT=0` — `2509 problems (0 errors, 2509 warnings)` |
| `vitest run packages/app-shell/src/console/marketplace/` | `Test Files 5 passed (5)` · `Tests 32 passed (32)` |
| `check-control-bytes` | `OK (scanned 4638 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `No changeset declares a major bump.` |
| `check-changeset-fixed` | `All workspace packages are in the changeset fixed group.` |
| `check-i18n-call-site-keys` | exit 0 — no new keys; every call-site key resolves |
| `check-lint-coverage` · `check-type-check-coverage` | `46/46 packages linted` · `41/41 packages compile their tests` |

**Declared narrowing** — vitest was run over `console/marketplace/` rather than all of `packages/app-shell`, and here is why that cannot hide a failure. The changed function body can only execute where the real component is imported. Measured across every test file in the repo: exactly **3** import it for real, and all three are in the directory that was run. The only two others that reach the marketplace route replace it with a stub (`vi.mock('../marketplace/MarketplacePage', …)`), so the changed code cannot run in them. Invariance for untouched files: the change is a statement reorder inside one function body and alters no export signature, and `type-check` compiled the **whole** package (both tsconfigs) green.

## Scope

`MarketplacePage.tsx`, one new test file, one changeset. `MarketplacePackagePage.tsx` is read-only here — it is the already-fixed sibling, mounted by the new tests only to prove the two pages agree. `MarketplaceAccessDenied.tsx` and `MarketplaceDisabled.tsx` are untouched: only *which* of the two the page reaches for changes, and in *which order* it decides.

Why a new test file rather than growing `MarketplacePage.disabledState.test.tsx`: that suite hard-mocks `useIsWorkspaceAdmin: () => true` at module scope, so every case in it is an admin and none of them can see this defect. The admin flag has to vary per case here, which is a different module mock and therefore a different file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_