### PR TITLE
fix(plugin-dashboard): PivotTable keeps "no rows" stable so the pivot memo holds

### DIFF
--- a/.changeset/pivot-table-stable-empty-rows-5562.md
+++ b/.changeset/pivot-table-stable-empty-rows-5562.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+`PivotTable` no longer re-runs its cross-tabulation memo on every render when it
+has no rows (objectui#5562).
+
+The component spelled the empty array twice — as the destructuring default for
+`schema.data` and as the `Array.isArray` fallback that keeps a provider-config
+object out of iteration — so a schema declaring no `data` key, or one whose
+`data` is a provider config rather than rows, produced a fresh array identity on
+every render. That value is the first entry of the memo's dependency list, so
+the memo rebuilt its two ordered key sets, its `bucket[row][col]` map, the
+aggregated matrix and the row/column/grand totals on every render, over nothing.
+Both spellings now resolve to one module-scope frozen empty, so "no rows" is a
+stable value and the memo holds.
+
+Wasted work only: the churn feeds a memo rather than a `setState`, and
+`PivotTable` holds no prop-to-state sync, so nothing rendered wrong and no
+render loop was possible. The identical fix landed for `data-table` in
+objectui#4618 and for `ObjectPivotTable` in objectui#4629; this closes the
+direct-use path those two did not cover, where `DashboardRenderer` and
+`DashboardGridLayout` construct pivot schemas without `ObjectPivotTable` in the
+chain.

--- a/packages/plugin-dashboard/src/PivotTable.tsx
+++ b/packages/plugin-dashboard/src/PivotTable.tsx
@@ -98,6 +98,30 @@ function displayKey(key: string, labels?: Record<string, string>): string {
 }
 
 /**
+ * "No rows" as ONE stable value, never a per-render `[]` literal
+ * (objectui#5562).
+ *
+ * `PivotTable` spelled the empty array TWICE — as the destructuring default
+ * for `schema.data` and as the `Array.isArray` fallback — so a schema that
+ * declares no `data` key, or whose `data` is a provider-config object rather
+ * than rows, produced a FRESH array identity on every render. That value is
+ * the first entry of the cross-tabulation memo's dependency list
+ * (`[data, rowField, columnField, valueField, aggregation]`), so the memo
+ * rebuilt its two ordered key sets, its `bucket[row][col]` map, the aggregated
+ * matrix and the row/column/grand totals on every render, over nothing.
+ *
+ * Both spellings now resolve to this one module-scope value, so "no rows" is
+ * stable across renders and the memo holds. Same fix, same reason as
+ * `data-table.tsx`'s EMPTY_COLUMNS/EMPTY_ROWS (objectui#4618) and
+ * `ObjectPivotTable`'s (objectui#4629); this is the direct-use path those two
+ * did not cover.
+ *
+ * Frozen so a consumer that mutates the array it was handed cannot corrupt the
+ * shared instance for every other pivot on the page.
+ */
+const EMPTY_ROWS = Object.freeze([]) as unknown as PivotTableSchema['data'];
+
+/**
  * The aggregations this pivot computes — the renderer half of the spec's
  * `ChartAggregateFunctionSchema` (`ui/chart.zod.ts`), the UI-side subset the
  * spec deliberately carved out of the engine's 8-name `AggregationFunction`.
@@ -143,7 +167,8 @@ export const PivotTable: React.FC<PivotTableProps> = ({ schema, className, rowLa
     columnField,
     valueField,
     aggregation = 'sum',
-    data: rawData = [],
+    // Module-scope empty, never a `[]` literal — see EMPTY_ROWS.
+    data: rawData = EMPTY_ROWS,
     showRowTotals = false,
     showColumnTotals = false,
     format,
@@ -172,8 +197,11 @@ export const PivotTable: React.FC<PivotTableProps> = ({ schema, className, rowLa
     ? 'cursor-pointer hover:bg-accent/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring focus-visible:outline-offset-[-2px]'
     : '';
 
-  // Ensure data is always an array – provider config objects must not reach iteration
-  const data = Array.isArray(rawData) ? rawData : [];
+  // Ensure data is always an array – provider config objects must not reach
+  // iteration. The fallback is the shared empty, not a literal, so a
+  // provider-config schema does not re-key the cross-tabulation memo below
+  // on every render (objectui#5562).
+  const data = Array.isArray(rawData) ? rawData : EMPTY_ROWS;
 
   const { rowKeys, colKeys, matrix, rowTotals, colTotals, grandTotal } = useMemo(() => {
     // Collect unique row/column values preserving insertion order

--- a/packages/plugin-dashboard/src/__tests__/PivotTable.stableEmptyRows.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/PivotTable.stableEmptyRows.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5562 — `PivotTable`'s OWN "no rows" value must be stable.
+ *
+ * `PivotTable` spelled the empty array twice, and both spellings feed the same
+ * memo:
+ *
+ *   :146  data: rawData = [],                          // destructuring default
+ *   :176  const data = Array.isArray(rawData) ? rawData : [];
+ *   :241  }, [data, rowField, columnField, valueField, aggregation]);
+ *
+ * So a schema that declares no `data` key, or one whose `data` is a
+ * provider-config object, handed the memo a FRESH array identity on every
+ * render. The memo is not trivial — two ordered key sets, a
+ * `bucket[row][col] = number[]` map, the aggregated matrix and the
+ * row/column/grand totals — and all of it was rebuilt over nothing.
+ *
+ * ## Why this asserts on the memo and not on the render
+ *
+ * Nothing renders wrong today: the churn feeds a `useMemo`, not a `setState`,
+ * and the wasted matrix is discarded by the `data.length === 0` early return
+ * one line later. A "the pivot renders correctly" assertion is GREEN against
+ * the broken code and proves nothing. The observable that actually moves is
+ * how many times the memo's factory RUNS, so that is what this measures — by
+ * wrapping `useMemo` and counting invocations of the cross-tabulation memo,
+ * identified by its exact five-entry dependency list.
+ *
+ * ## Why both cases, separately
+ *
+ * The two literals are independent churn sources on independent lines. Fixing
+ * only the `Array.isArray` arm leaves a schema with no `data` key still
+ * churning through the destructuring default, and vice versa — and a single
+ * test cannot tell you which half is live. One case per line.
+ *
+ * The object-bound path (`ObjectPivotTable` -> `PivotTable`) was closed by
+ * objectui#4629 and is pinned by `ObjectPivotTable.stableEmptyRows.test.tsx`.
+ * This file covers the DIRECT-USE path — `DashboardRenderer` /
+ * `DashboardGridLayout` construct pivot schemas without `ObjectPivotTable` in
+ * the chain.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+
+/** Fixture field names — also the signature that identifies the memo below. */
+const ROW_FIELD = 'stage';
+const COLUMN_FIELD = 'owner';
+const VALUE_FIELD = 'amount';
+const AGGREGATION = 'sum';
+
+const probe = vi.hoisted(() => ({
+  /** One entry per RENDER that reached the memo's call site. */
+  seenDeps: [] as readonly unknown[][],
+  /** One increment per actual factory execution (i.e. per recompute). */
+  computes: 0,
+  reset() {
+    (this.seenDeps as unknown[][]).length = 0;
+    this.computes = 0;
+  },
+}));
+
+/**
+ * The cross-tabulation memo at PivotTable.tsx:241, matched by its dependency
+ * list `[data, rowField, columnField, valueField, aggregation]`. Anchored to
+ * this file's fixture values so it cannot accidentally match a memo belonging
+ * to some other component in the tree; the "reached once per render"
+ * assertions below fail loudly if it ever stops matching, so a filter that
+ * silently selects nothing cannot read as a pass.
+ */
+function isCrossTabMemo(deps: readonly unknown[] | undefined): boolean {
+  return (
+    Array.isArray(deps) &&
+    deps.length === 5 &&
+    deps[1] === ROW_FIELD &&
+    deps[2] === COLUMN_FIELD &&
+    deps[3] === VALUE_FIELD &&
+    deps[4] === AGGREGATION
+  );
+}
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    useMemo: (factory: () => unknown, deps?: readonly unknown[]) => {
+      if (!isCrossTabMemo(deps)) return actual.useMemo(factory, deps as never);
+      (probe.seenDeps as unknown[][]).push(deps as unknown[]);
+      // Same hook, same position, same deps — only the factory is wrapped, so
+      // hook order and React's own memoization are untouched.
+      return actual.useMemo(() => {
+        probe.computes += 1;
+        return factory();
+      }, deps as never);
+    },
+  };
+});
+
+import React from 'react';
+import { PivotTable } from '../PivotTable';
+
+afterEach(() => {
+  cleanup();
+  probe.reset();
+});
+
+/** A schema with NO `data` key at all — the destructuring default at :146. */
+const NO_DATA_KEY_SCHEMA = {
+  type: 'pivot',
+  rowField: ROW_FIELD,
+  columnField: COLUMN_FIELD,
+  valueField: VALUE_FIELD,
+  aggregation: AGGREGATION,
+} as any;
+
+/**
+ * A schema whose `data` is a PROVIDER CONFIG object rather than rows — the
+ * truthy non-array that selects the `Array.isArray` fallback arm at :176.
+ */
+const PROVIDER_CONFIG_SCHEMA = {
+  ...NO_DATA_KEY_SCHEMA,
+  data: { provider: 'object', object: 'opportunity' },
+} as any;
+
+/**
+ * Render `schema` (a STABLE object, declared once) inside a host that can
+ * re-render on demand. A host re-render is the most ordinary thing on a
+ * dashboard — a filter change, a resize, a parent state update.
+ */
+function renderUnderHostChurn(schema: any) {
+  let bump: (() => void) | null = null;
+  const Host = () => {
+    const [, setTick] = React.useState(0);
+    bump = () => setTick((n) => n + 1);
+    return <PivotTable schema={schema} />;
+  };
+  const utils = render(<Host />);
+  return {
+    ...utils,
+    churn: (times: number) => {
+      for (let i = 0; i < times; i += 1) act(() => { bump!(); });
+    },
+  };
+}
+
+describe('PivotTable keeps "no rows" stable across renders (objectui#5562)', () => {
+  it.each([
+    ['a schema with no `data` key at all (the destructuring default)', NO_DATA_KEY_SCHEMA],
+    ['a schema whose `data` is a provider-config object (the Array.isArray fallback)', PROVIDER_CONFIG_SCHEMA],
+  ])('does not re-run the cross-tabulation memo for %s', (_label, schema) => {
+    renderUnderHostChurn(schema).churn(3);
+
+    // Load-bearing: the memo's call site really was reached, on every render,
+    // and really with "no rows" — otherwise everything below is vacuous.
+    expect(probe.seenDeps.length).toBe(4);
+    expect(probe.seenDeps[0][0]).toEqual([]);
+
+    // The defect and the whole fix. Pre-fix: a fresh `[]` identity per render,
+    // so 4 renders = 4 distinct identities = 4 full recomputes of the key
+    // sets, the bucket map, the matrix and the totals — over nothing.
+    expect(new Set(probe.seenDeps.map((deps) => deps[0])).size).toBe(1);
+    expect(probe.computes).toBe(1);
+
+    // Both spellings resolve to the SAME module-scope value, which is frozen:
+    // a consumer that mutates the array it was handed cannot corrupt every
+    // other pivot on the page.
+    expect(Object.isFrozen(probe.seenDeps[0][0])).toBe(true);
+  });
+
+  it('uses one and the same empty for both spellings', () => {
+    renderUnderHostChurn(NO_DATA_KEY_SCHEMA);
+    const fromDestructuringDefault = probe.seenDeps[0][0];
+    cleanup();
+    probe.reset();
+
+    renderUnderHostChurn(PROVIDER_CONFIG_SCHEMA);
+    const fromIsArrayFallback = probe.seenDeps[0][0];
+
+    expect(fromIsArrayFallback).toBe(fromDestructuringDefault);
+  });
+
+  it('still recomputes when rows actually change — the memo was not disabled', () => {
+    const rows = [{ stage: 'Won', owner: 'ann', amount: 10 }];
+    let setData: ((d: any) => void) | null = null;
+    const Host = () => {
+      const [data, set] = React.useState<any>(undefined);
+      setData = set;
+      return <PivotTable schema={{ ...NO_DATA_KEY_SCHEMA, data } as any} />;
+    };
+    const { container } = render(<Host />);
+
+    expect(probe.computes).toBe(1);
+
+    act(() => { setData!(rows); });
+
+    // Real rows arrive: the memo must recompute and pass them through by
+    // identity, and the matrix must actually render.
+    expect(probe.computes).toBe(2);
+    expect(probe.seenDeps[probe.seenDeps.length - 1][0]).toBe(rows);
+    expect(container.textContent).toContain('Won');
+    expect(container.textContent).toContain('10');
+  });
+});


### PR DESCRIPTION
Fixes #5562

`PivotTable` spelled the empty array **twice**, and both spellings feed the same cross-tabulation memo:

```
146:    data: rawData = [],                                  // destructuring default
176:  const data = Array.isArray(rawData) ? rawData : [];    // non-array fallback
241:  }, [data, rowField, columnField, valueField, aggregation]);
```

So a schema that declares no `data` key, or one whose `data` is a provider-config object rather than rows, handed the memo a fresh array identity on every render. The memo is not trivial — two ordered key sets, a `bucket[row][col]` number-array map, the aggregated matrix and the row/column/grand totals — and all of it was rebuilt on every render, over nothing. The `data.length === 0` early return sits **after** the memo (hooks must stay unconditional), so the wasted matrix is computed and then discarded.

Both spellings now resolve to one module-scope `Object.freeze([])`. Same fix, same reason as `data-table.tsx`'s `EMPTY_COLUMNS`/`EMPTY_ROWS` (#4618) and `ObjectPivotTable`'s (#4629); this closes the **direct-use** path those two did not cover, where `DashboardRenderer` / `DashboardGridLayout` construct pivot schemas without `ObjectPivotTable` in the chain.

Severity is unchanged from the card: wasted work only. The churn feeds a memo rather than a `setState`, and `PivotTable` holds no prop-to-state sync, so nothing rendered wrong and no render loop was possible.

## The test asserts on the memo, not on the render

Nothing renders wrong today, so a "the pivot renders correctly" assertion is green against the broken code and proves nothing. `PivotTable.stableEmptyRows.test.tsx` wraps `useMemo` and counts how many times the cross-tabulation memo's factory actually **runs**, identifying that memo by its exact five-entry dependency list. It also asserts the identity of the memo's `data` dependency across renders, mirroring `ObjectPivotTable.stableEmptyRows.test.tsx`.

The two literals get **one case each**, because they are independent churn sources on independent lines and a single test cannot tell you which half is live.

## Reverse-verification

Three mutations, each restored by a `trap ... EXIT INT TERM`, each proved on disk with anchored `grep -c` in both directions (real text 1 to 0, mutant 0 to 1) plus `git diff --stat`; `git status --porcelain` empty after every leg. No build step is involved: the root vitest config aliases every `@object-ui/*` specifier to that package's `src/`, and the test imports `../PivotTable` relatively, so the mutated source is what executes.

| mutation | no-`data`-key case | provider-config case | shared-empty case |
| --- | --- | --- | --- |
| both literals reverted | RED | RED | RED |
| only `:146` reverted | **RED** | green | RED |
| only `:176` reverted | green | **RED** | RED |

The two one-sided legs are the load-bearing half: they confirm the card's warning that fixing one literal leaves the other live, and that this test says **which**. The headline failure is `expected 4 to be 1` — four renders, four distinct empty-array identities, four full recomputes.

ESLint tracks the same thing independently. Reverting `:176` alone reproduces the warning the issue quotes verbatim, and it is absent on the fixed file:

```
mutant: 204:9  warning  The 'data' conditional could make the dependencies of useMemo Hook
                        (at line 269) change on every render...   react-hooks/exhaustive-deps
        2 problems (0 errors, 2 warnings)
fixed:  1 problem  (0 errors, 1 warning)
```

The one remaining warning is the pre-existing `react-refresh/only-export-components` on `export const PIVOT_AGGREGATIONS`, shifted from line 109 to 133 by the new doc comment. Not introduced here.

## Gates

All run locally, exit codes captured before any pipe, each gate's own verdict line quoted.

| gate | verdict |
| --- | --- |
| `pnpm --filter @object-ui/plugin-dashboard type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`, both echoed) |
| `pnpm --filter @object-ui/plugin-dashboard lint` | exit 0 — `365 problems (0 errors, 365 warnings)` — every one pre-existing |
| `pnpm exec vitest run packages/plugin-dashboard/` | exit 0 — `Test Files  73 passed (73)` / `Tests  657 passed (657)` |
| `pnpm exec eslint .` (repo-wide, 3486 files) | exit 0 — **0 errors**, 10459 warnings |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 4635 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `node scripts/check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |
| `node scripts/check-lint-coverage.mjs` | `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `node scripts/check-type-check-coverage.mjs` | `45/46 via type-check` / `41/41 packages compile their tests` |
| `node scripts/check-phantom-dependencies.mjs` | `Every in-scope import is declared by the package that publishes it.` |
| `node scripts/check-package-self-import.mjs` | `No package names itself inside its own src/.` |

Repo-wide lint was **not** narrowed — the full `eslint .` farm ran green. The dependency closure had to be built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-dashboard^...' build`); without it `tsc` resolves workspace packages through `dist/` and reports `Cannot find module '@object-ui/components'` on files this PR never touches.

One gate is declared **not run**: `node scripts/check-eager-closure-budget.mjs` refuses without `apps/console/dist/eager-closure.json`, which only a console `vite build` emits — its own verdict line calls that "a broken gauge, not a passing budget", so it reports nothing about this change either way. It cannot be implicated regardless: that gate measures which modules land in the eager closure, and `git diff` shows this PR adds and removes **zero** import statements in `src/`.

The 6 `@typescript-eslint/no-explicit-any` warnings on the new test are `as any` casts on SDUI schema fixtures — the established pattern in this package's tests (the sibling `ObjectPivotTable.stableEmptyRows.test.tsx` carries 8 of the same, `PivotTable.drill.test.tsx` 1).

Gate union was run against the final commit, `34db0672`.

## Scope

`packages/plugin-dashboard/src/PivotTable.tsx`, its new test, and one changeset. `ObjectPivotTable.tsx` and `ObjectDataTable.tsx` were **not** touched — both already fixed by #4629. No drive-by tidying, and no out-of-scope findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_