### PR TITLE
fix(i18n): hold useObjectLabel's memo when no i18next instance is bound

### DIFF
--- a/.changeset/safe-field-label-identity-5564.md
+++ b/.changeset/safe-field-label-identity-5564.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/i18n': patch
+---
+
+`useObjectLabel` now keeps a stable identity when no i18next instance is bound,
+so the memoization it advertises holds on the no-provider path too
+(objectui#5564).
+
+react-i18next's `useTranslation` builds its return value out of a fresh `{}` on
+every render when it has nothing to bind to (`const finalI18n = i18n || {}`,
+which then feeds that hook's own `useMemo` deps), so the `i18n` object arrived
+with a new identity each render. `useObjectLabel` keyed its memo on `[t, i18n]`,
+so the memo never held: measured 4 distinct returned objects across 4 renders
+with no instance, against 1 with one. That is the wrong way round — the memo
+exists to stop downstream `useMemo`/`useCallback` deps from being re-keyed in
+heavy consumers, and `useSafeFieldLabel`'s docstring names the no-provider case
+as the one it exists to serve.
+
+Both memo dependencies are now pinned to module-level constants while no
+instance is bound. The substitution is unobservable rather than merely
+convenient: every `t()` call in the module sits inside a
+`for (… of getAppNamespaces())` loop, and `getAppNamespaces()` returns `[]`
+under exactly the same "is there a usable instance" predicate — so while the
+substitution is in effect, the closures cannot read either value. When an
+instance appears the dependencies become the live values again, so a provider
+mounting after first render recomputes the object exactly once and resolves
+real translations from then on.
+
+No API change: no new exports, no signature changes, and the returned surface is
+identical on both paths. Direct `useObjectLabel()` consumers are fixed alongside
+`useSafeFieldLabel()` ones, including `ListView.filterFields` — the consumer the
+memo's own docstring names.

--- a/packages/i18n/src/__tests__/useObjectLabel-identity-5564.test.tsx
+++ b/packages/i18n/src/__tests__/useObjectLabel-identity-5564.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * objectui#5564 — `useObjectLabel`'s memo must hold whether or not an i18next
+ * instance is bound.
+ *
+ * Every assertion here is on IDENTITY / recompute counts rather than on
+ * rendered output, deliberately: nothing renders wrong today, so a rendering
+ * assertion is green against the broken code. The defect is that the object
+ * feeding every downstream `useMemo`/`useCallback` dependency list was rebuilt
+ * on each render outside a provider — the very configuration
+ * `useSafeFieldLabel` advertises — because react-i18next hands back a fresh
+ * `i18n` object every render when it has no instance to bind to.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { I18nextProvider, getI18n, setI18n } from 'react-i18next';
+import type { i18n as I18nInstance } from 'i18next';
+import { createI18n } from '../i18n';
+import { useObjectLabel, useSafeFieldLabel } from '../useObjectLabel';
+
+type Labels = ReturnType<typeof useObjectLabel>;
+
+/**
+ * `createI18n` registers its instance as react-i18next's process-global (via
+ * `initReactI18next`), and `useTranslation` falls back to that global whenever
+ * no context supplies one. Detaching it is what makes "no instance" actually
+ * mean no instance in this file: without it, a probe meant to run unbound would
+ * silently bind to an instance built by an earlier test and assert nothing.
+ */
+function detachGlobalI18n(): void {
+  setI18n(undefined as unknown as I18nInstance);
+}
+
+/** An i18next instance carrying one app-namespaced field translation. */
+function createBoundInstance(): I18nInstance {
+  const instance = createI18n({ defaultLanguage: 'en', detectBrowserLanguage: false });
+  instance.addResourceBundle(
+    'en',
+    'translation',
+    { crm: { fields: { lead: { status: 'Localized Status' } } } },
+    true,
+    true,
+  );
+  detachGlobalI18n();
+  return instance;
+}
+
+/** A component recording the hook's return value once per render, in order. */
+function makeProbe(hook: () => Labels) {
+  const seen: Labels[] = [];
+  const Component: React.FC<{ tick: number }> = () => {
+    seen.push(hook());
+    return null;
+  };
+  return { seen, Component };
+}
+
+describe('useObjectLabel identity (objectui#5564)', () => {
+  beforeEach(() => {
+    detachGlobalI18n();
+  });
+
+  it('holds one identity across renders with no i18next instance bound', () => {
+    // Precondition, asserted rather than assumed: a leaked global instance
+    // would turn this into a test of the path that already worked.
+    expect(getI18n()).toBeFalsy();
+
+    const { seen, Component } = makeProbe(useObjectLabel);
+    const { rerender } = render(<Component tick={0} />);
+    rerender(<Component tick={1} />);
+    rerender(<Component tick={2} />);
+    rerender(<Component tick={3} />);
+
+    // The card measured { renders: 4, distinctObject: 4, distinctFieldLabel: 4 }.
+    expect(seen.length).toBeGreaterThanOrEqual(4);
+    expect(new Set(seen).size).toBe(1);
+    expect(new Set(seen.map((labels) => labels.fieldLabel)).size).toBe(1);
+  });
+
+  it('holds one identity across renders through useSafeFieldLabel with no instance', () => {
+    expect(getI18n()).toBeFalsy();
+
+    const { seen, Component } = makeProbe(() => useSafeFieldLabel() as unknown as Labels);
+    const { rerender } = render(<Component tick={0} />);
+    rerender(<Component tick={1} />);
+    rerender(<Component tick={2} />);
+    rerender(<Component tick={3} />);
+
+    expect(new Set(seen).size).toBe(1);
+    expect(new Set(seen.map((labels) => labels.fieldLabel)).size).toBe(1);
+  });
+
+  it('still holds one identity across renders with an instance bound', () => {
+    // Regression guard on the path that already worked — the fix must not cost
+    // stability where the memo was already holding.
+    const instance = createBoundInstance();
+    const { seen, Component } = makeProbe(useObjectLabel);
+    const tree = (tick: number) => (
+      <I18nextProvider i18n={instance}>
+        <Component tick={tick} />
+      </I18nextProvider>
+    );
+
+    const { rerender } = render(tree(0));
+    rerender(tree(1));
+    rerender(tree(2));
+    rerender(tree(3));
+
+    expect(new Set(seen).size).toBe(1);
+    expect(seen[0].fieldLabel('lead', 'status', 'Status')).toBe('Localized Status');
+  });
+
+  it('recomputes exactly once when an instance appears after first render', () => {
+    // Triage's dispatch clause: the late-instance transition is pinned, not
+    // left as a surprise.
+    const instance = createBoundInstance();
+    expect(getI18n()).toBeFalsy();
+
+    const { seen, Component } = makeProbe(useObjectLabel);
+    // The provider element sits at the same position in every tree below, so
+    // the probe is UPDATED rather than remounted when the instance arrives. A
+    // remount would reset the memo and prove nothing about the transition.
+    const tree = (i18n: I18nInstance | undefined, tick: number) => (
+      <I18nextProvider i18n={i18n as I18nInstance}>
+        <Component tick={tick} />
+      </I18nextProvider>
+    );
+
+    const { rerender } = render(tree(undefined, 0));
+    rerender(tree(undefined, 1));
+    rerender(tree(undefined, 2));
+    expect(new Set(seen).size).toBe(1);
+
+    rerender(tree(instance, 3));
+    rerender(tree(instance, 4));
+    rerender(tree(instance, 5));
+
+    // Exactly two identities over the whole run: one before the instance, one
+    // after — i.e. the transition recomputed once and then held again. Asserted
+    // as a distinct-count so an extra render scheduled by react-i18next's own
+    // readiness effect cannot make this pass or fail for the wrong reason.
+    const distinct = [...new Set(seen)];
+    expect(distinct).toHaveLength(2);
+
+    // And the recompute is real rather than cosmetic: the second object
+    // resolves translations, the first one never does.
+    expect(distinct[0].fieldLabel('lead', 'status', 'Status')).toBe('Status');
+    expect(distinct[1].fieldLabel('lead', 'status', 'Status')).toBe('Localized Status');
+  });
+
+  it('offers the same member set with and without an instance', () => {
+    // Guards `record:reference-rail`, which calls `useSafeFieldLabel().objectLabel(...)`
+    // and may render outside a provider: narrowing the no-instance path to the
+    // 5-member SAFE_FIELD_LABEL_FALLBACK would make that
+    // `i18n.objectLabel is not a function`.
+    const unbound = makeProbe(() => useSafeFieldLabel() as unknown as Labels);
+    render(<unbound.Component tick={0} />);
+
+    const instance = createBoundInstance();
+    const bound = makeProbe(useObjectLabel);
+    render(
+      <I18nextProvider i18n={instance}>
+        <bound.Component tick={0} />
+      </I18nextProvider>,
+    );
+
+    expect(Object.keys(unbound.seen[0]).sort()).toEqual(Object.keys(bound.seen[0]).sort());
+    // 27 is the surface measured on the card; a new resolver must land on both
+    // paths at once, because there is only one path.
+    expect(Object.keys(unbound.seen[0])).toHaveLength(27);
+    expect(typeof unbound.seen[0].objectLabel).toBe('function');
+    expect(unbound.seen[0].objectLabel({ name: 'lead', label: 'Lead' })).toBe('Lead');
+  });
+});

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -33,6 +33,49 @@ const BUILTIN_KEYS = new Set([
   'appDesigner', 'console', 'errors', 'detail',
 ]);
 
+/** The translation surface this module binds to, as `useObjectTranslation` hands it over. */
+type ObjectTranslation = ReturnType<typeof useObjectTranslation>;
+
+/**
+ * Whether `i18n` is a real i18next instance rather than react-i18next's
+ * no-instance placeholder.
+ *
+ * With nothing to bind to, `useTranslation` warns `NO_I18NEXT_INSTANCE` and
+ * builds its return value out of a fresh `{}` on every render (`const
+ * finalI18n = i18n || {}`, which then feeds that hook's own `useMemo` deps), so
+ * the `i18n` we receive has a new identity each render even though nothing
+ * about it can have changed.
+ *
+ * `getResourceBundle` is the probe because it is the only instance member the
+ * resolvers below ever touch — via `getAppNamespaces`, the single gate every
+ * `t()` call in this module sits behind.
+ */
+function hasUsableI18nInstance(i18n: ObjectTranslation['i18n'] | undefined): boolean {
+  return Boolean(i18n) && typeof i18n?.getResourceBundle === 'function';
+}
+
+/**
+ * Stand-ins pinned into the memo dependency list while no i18next instance is
+ * bound, so the memo in {@link useObjectLabel} actually holds on the
+ * no-provider path (objectui#5564). Module-level, so they carry one identity
+ * for the lifetime of the process instead of one per render.
+ *
+ * Substituting them is unobservable rather than merely convenient: every `t()`
+ * call in this module sits inside a `for (… of getAppNamespaces())` loop, and
+ * `getAppNamespaces()` returns `[]` under exactly {@link hasUsableI18nInstance}
+ * — so for as long as the substitution is in effect, the closures cannot read
+ * either value at all. `NO_INSTANCE_T` still mirrors react-i18next's own
+ * not-ready `t` (honour a string `defaultValue`, otherwise echo the key) so
+ * that if that reachability argument ever stops holding, behaviour does not
+ * change silently.
+ */
+const NO_INSTANCE_T = ((key: unknown, options?: { defaultValue?: unknown }) =>
+  typeof options?.defaultValue === 'string' ? options.defaultValue : key
+) as unknown as ObjectTranslation['t'];
+
+/** @see NO_INSTANCE_T */
+const NO_INSTANCE_I18N = Object.freeze({}) as unknown as ObjectTranslation['i18n'];
+
 /**
  * Hook for convention-based auto-resolution of object and field labels.
  *
@@ -49,7 +92,22 @@ const BUILTIN_KEYS = new Set([
  * ```
  */
 export function useObjectLabel() {
-  const { t, i18n } = useObjectTranslation();
+  const { t: boundT, i18n: boundI18n } = useObjectTranslation();
+
+  // Pin both memo dependencies to module constants while there is no i18next
+  // instance to bind to. Without this the memo below never held on exactly the
+  // no-provider path `useSafeFieldLabel` advertises: react-i18next rebuilds its
+  // return value from a fresh `{}` each render, so `i18n` arrived with a new
+  // identity every time and re-keyed every consumer memo this hook feeds
+  // (objectui#5564 measured 4 distinct identities across 4 renders). See
+  // `hasUsableI18nInstance` for why the substitution cannot be observed.
+  //
+  // When an instance does appear these become the live values again, so a
+  // provider mounting after first render recomputes the object exactly once and
+  // resolves real translations from then on.
+  const bound = hasUsableI18nInstance(boundI18n);
+  const t = bound ? boundT : NO_INSTANCE_T;
+  const i18n = bound ? boundI18n : NO_INSTANCE_I18N;
 
   // Memoize the entire returned object — all closures below reference `t`/`i18n`
   // and stay valid until the language changes. Returning a fresh object on every
@@ -69,7 +127,7 @@ export function useObjectLabel() {
    * (objectui#3372).
    */
   const getAppNamespaces = (): string[] => {
-    if (!i18n || typeof i18n.getResourceBundle !== 'function') return [];
+    if (!hasUsableI18nInstance(i18n)) return [];
     const lang = i18n.language || 'en';
     const bundle = i18n.getResourceBundle(lang, 'translation') as Record<string, any> | undefined;
     if (!bundle) return [];
@@ -643,8 +701,11 @@ const SAFE_FIELD_LABEL_FALLBACK = {
 export function useSafeFieldLabel() {
   // useObjectLabel delegates to the provider-safe useObjectTranslation (react-
   // i18next falls back to the global instance and never throws), so it needs no
-  // try/catch — wrapping the hook call would violate rules-of-hooks. It already
-  // returns a stable memoized object; the module-level fallback stays as a
-  // defensive default, reached only if it ever returns nullish.
+  // try/catch — wrapping the hook call would violate rules-of-hooks. Its memo
+  // now holds with or without an i18next instance, so the object below is
+  // stable on both paths — it was NOT before objectui#5564, which measured a
+  // fresh object every render outside a provider, i.e. the opposite of what
+  // this wrapper advertises. The module-level fallback stays as a defensive
+  // default, reached only if it ever returns nullish.
   return useObjectLabel() ?? SAFE_FIELD_LABEL_FALLBACK;
 }


### PR DESCRIPTION
Fixes #5564

Verified at `b492c9796` (the final commit on this branch; every gate below ran on that tree).

## The defect

`useSafeFieldLabel()` delegates to `useObjectLabel()`, which memoizes its whole returned object on react-i18next's `[t, i18n]`. With no i18next instance bound, `useTranslation` warns `NO_I18NEXT_INSTANCE` and rebuilds its return value out of a fresh empty object every render (`const finalI18n = i18n || {}`, which then feeds that hook's own `useMemo` deps) — so `i18n` arrives with a new identity each render and the memo never holds.

Re-measured here by ablation: **4 distinct returned objects across 4 renders** with no instance, **1** with one. The protection is present exactly where it is not needed and absent exactly where `useSafeFieldLabel`'s docstring says it exists to serve.

One refinement to the card's account: only `i18n` churns. `t` is already stable when unbound — react-i18next returns a module-level `notReadyT` from a module-level `notReadySnapshot`. The single churning dependency is `i18n`.

## Option 2 was chosen, and why not option 1

**Option 1 does not fix the consumer the memo's own docstring names as its reason to exist.** `ListView.filterFields` reaches the hook through `useListFieldLabel`, which calls **`useObjectLabel()` directly** (`packages/plugin-list/src/ListView.tsx:683`), not `useSafeFieldLabel()`. Option 1 only changes the wrapper, so `ListView` keeps the defect — along with 20+ other direct `useObjectLabel()` call sites across `app-shell`, `plugin-dashboard`, `components` and `react`. `packages/plugin-timeline/src/ObjectTimeline.tsx:37` even carries its own hand-rolled `useObjectLabel() ?? OBJECT_LABEL_FALLBACK` wrapper, which option 1 would miss too.

The 27-vs-5 counts from the dispatch were re-verified independently and are exact: the memo returns 27 members, `SAFE_FIELD_LABEL_FALLBACK` has 5. Option 1 would therefore also cost a hand-maintained 27-member parallel shape plus a pin test to stop it drifting. Option 2 needs no parallel shape at all, because there is only one code path.

Option 2 also preserves today's return **values** exactly and changes only identity, which is precisely the defect.

## The change

Both memo dependencies are pinned to module-level constants while no instance is bound. The substitution is unobservable rather than merely convenient, and that is the correctness argument:

- every `t()` call in the module sits inside a `for (... of getAppNamespaces())` loop;
- `getAppNamespaces()` returns the empty array under **exactly** the same "is there a usable instance" predicate;
- so while the substitution is in effect, the closures cannot read `t` or `i18n` at all.

The predicate now has one definition (`hasUsableI18nInstance`) used by both the memo key and `getAppNamespaces`, so the two cannot drift. `NO_INSTANCE_T` still mirrors react-i18next's own not-ready `t` so behaviour would not change silently if that reachability argument ever stopped holding.

When an instance appears the dependencies become the live values again, so a provider mounting after first render recomputes exactly once. On the bound path the dependency list is literally `[t, i18n]` as before — no behaviour change where the memo already held.

The now-false comment on `useSafeFieldLabel` ("It already returns a stable memoized object") is corrected.

**No API change:** no new exports, no signature changes, identical returned surface on both paths.

## Tests

`packages/i18n/src/__tests__/useObjectLabel-identity-5564.test.tsx`, 5 cases, all asserting on **identity / recompute counts** rather than rendered output — nothing renders wrong today, so a rendering assertion is green against the broken code.

1. no instance, 4 renders, one identity (and one `fieldLabel` identity)
2. same through `useSafeFieldLabel`
3. **with** an instance, one identity — regression guard on the path that already worked
4. **the late-instance transition** (triage's dispatch clause): the provider element sits at the same tree position for every render, so the probe is *updated* rather than remounted when the instance arrives; asserts exactly two identities over six renders, that the first resolves no translations and the second does
5. the member set is the same with and without an instance, pinned at 27, and `objectLabel` is callable unbound — this guards `record:reference-rail`, which does `useSafeFieldLabel().objectLabel(...)` and would get "objectLabel is not a function" if the no-instance path were ever narrowed to the 5-member fallback

The tests deliberately detach react-i18next's process-global instance and **assert that precondition**, because `createI18n` registers itself globally via `initReactI18next`; without that, a probe meant to run unbound would silently bind to an instance from an earlier test and assert nothing.

## Reverse-verification

Fix committed first, then reverted (source only) under a `trap ... EXIT INT TERM` restore. Mutation confirmed on disk with anchored counts in both directions (fix markers 0, pre-fix gate and destructure 1 each) plus `git diff --stat`.

Ablated result — `VERDICT command-exit 1`, 3 failed / 2 passed:

```
expected 4 to be 1   (no instance, 4 renders)
expected 4 to be 1   (useSafeFieldLabel, 4 renders)
expected 3 to be 1   (late-instance test, unbound phase)
```

The first two reproduce the card's measurement exactly. The two that stayed green are the right two — the with-instance guard and the shape pin — which is what makes this an ablation rather than a blanket break. Restored and re-run green; `git status --porcelain` empty, so the tree is byte-identical.

No dist is in the loop: the test imports the ablation target by relative path from source, so there is no build step whose staleness could fake the result.

## Gates

All at `b492c9796`, exit codes captured before any pipe:

| gate | verdict |
|---|---|
| `pnpm --filter '@object-ui/i18n^...' build` | exit 0 (`packages/core build: Done`) |
| `pnpm --filter @object-ui/i18n type-check` | exit 0, script echoed `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/i18n lint` | `34 problems (0 errors, 34 warnings)` — all warnings pre-existing `any` usages outside this diff; the new test file contributes none |
| `pnpm exec vitest run packages/i18n/` | `Test Files 50 passed (50)` / `Tests 878 passed (878)` |
| `pnpm exec vitest run packages/plugin-detail/` | `Test Files 90 passed (90)` / `Tests 848 passed (848)` |
| `pnpm exec vitest run packages/plugin-dashboard/` | `Test Files 72 passed (72)` / `Tests 653 passed (653)` |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 4638 tracked text file(s))` |
| `node scripts/check-changeset-presence.mjs` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `node scripts/check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |

**Both consumer packages were run deliberately:** `plugin-detail` holds the two whole-object `useSafeFieldLabel()` consumers the dispatch flagged (`record-reference-rail` calling `i18n.objectLabel(...)`, and `record-related-list`), so it is the package a shape change would break first; `plugin-dashboard` holds `ObjectDataTable`, the consumer whose `derivedColumns` recomputation the card measured.

### Declared narrowing

- **Repo-wide `pnpm lint` was not run;** `pnpm --filter @object-ui/i18n lint` was. This cannot hide a failure: the diff touches only `packages/i18n`, and `eslint.config.js` enables **no type-aware linting** (no `projectService`, no `parserOptions.project`), so this change cannot move the verdict on any file it does not contain.
- **2 of roughly 15 consumer packages were tested locally.** This one *is* a real narrowing — the hook is consumed broadly and a behaviour change could in principle surface in `plugin-list`, `plugin-grid`, `plugin-form`, `app-shell`, `plugin-charts`, `plugin-timeline`, `components`, `react`, `fields`, `plugin-report`, `plugin-kanban` or `plugin-tree`. CI runs the full farm.

## Notes

- `packages/plugin-charts/src/ObjectChart.tsx:268-271` carries a hand-rolled ref workaround for this exact defect ("the i18n hook returns a fresh function reference on every render ... trigger an infinite refetch loop"). **This fix makes that workaround removable** — `fieldOptionLabel` is now identity-stable with or without a provider. Not removed here; it is outside this surface and wants its own card. The same applies to `plugin-timeline`'s `useSafeObjectLabel`.
- Scope held to `packages/i18n/src/useObjectLabel.ts`, its tests, and one changeset. No consumer package was modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_