### PR TITLE
Record `tree` and `chart` as host-composition-only view types, and give `tree` its icon (#5321)

### DIFF
--- a/.changeset/host-only-viewtypes-tree-icon-5321.md
+++ b/.changeset/host-only-viewtypes-tree-icon-5321.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/plugin-view': patch
+---
+
+A host-composed `tree` view is now labelled with the tree icon in `ObjectView`'s
+view switcher instead of the grid one, and the `tree` / `chart` view types are
+recorded as host-composition-only surfaces (objectui#5321).
+
+`viewSwitcherSchema`'s `iconMap` carried an entry for every view type except
+`tree`, so a tree view fell through to the `|| 'table'` fallback and was drawn
+with the grid glyph. objectui#2916 fixed exactly this once, for `chart`, by
+adding a single key — nothing recorded that the map had to be COMPLETE, so the
+next missing member went unnoticed. The map is now typed
+`Record<ViewType, string>`, which is how `ViewSwitcher`'s own
+`DEFAULT_VIEW_ICONS` (the consumer of these strings) has always been declared:
+a future `ViewType` member fails `type-check` rather than silently rendering as
+a grid. The `tree` value is `'list-tree'`, the same `ListTree` glyph
+`DEFAULT_VIEW_ICONS` already names for this view type, and the runtime fallback
+stays for host props that carry an unrecognised type. Reached in practice by
+the console, whose `CreateViewDialog` offers `tree` among the view types a user
+can create.
+
+No authoring surface changes. `generateViewSchema` renders eight view types
+while `ObjectViewSchema.defaultViewType` and `NamedListView.type` admit six of
+them, so `tree` and `chart` are selectable only through the component's `views`
+prop. The maintainer ruled on 2026-08-20 that both stay recorded as
+host-composition-only rather than being added to those unions, following the
+objectui#5097 precedent; the record now lives beside that one, with the branch
+set derived from a source fence, the authored unions pinned at the type level,
+and host reachability measured.

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -458,6 +458,68 @@ export const OBJECT_VIEW_DECLARED_FORWARDED_KEYS = [
 ] as const;
 
 /**
+ * HOST-COMPOSITION VIEW TYPES on the `object-view` node — the two
+ * `generateViewSchema` branches an author cannot select, deliberately NOT
+ * added to the authored view-type unions, and ⛔ not to be taught as
+ * authorable `defaultViewType` / `NamedListView.type` values anywhere in the
+ * docs (objectui#5321).
+ *
+ * ## The verdict
+ *
+ * `generateViewSchema` below switches on eight view types. The type an AUTHOR
+ * uses to select one admits six of them: `ObjectViewSchema.defaultViewType`
+ * and `NamedListView.type` (both `@object-ui/types`) are the same seven-value
+ * union `'grid' | 'kanban' | 'gallery' | 'calendar' | 'timeline' | 'gantt' |
+ * 'map'`, and neither spells `tree` or `chart`. The one segment that can is
+ * the `views` PROP on this component, which is typed `ViewType` — and
+ * `ViewType` carries both. So `currentViewType` is `tree` or `chart` only when
+ * a HOST composes `ObjectView` with a `views` prop; from authored metadata
+ * those two branches are unreachable, including the tree branch's own
+ * `viewOptions.tree.*` config surface and the ADR-0021 dataset-bound chart
+ * shape.
+ *
+ * ## The ruling that made it deliberate
+ *
+ * Maintainer, 2026-08-20, on objectui#5321, verbatim 「其他接受你的建议。」:
+ * option B — `tree` and `chart` are RECORDED as host-composition-only
+ * surfaces, following the objectui#5097 precedent above, rather than added to
+ * the authored unions. Declaring two more authored members is a permanent
+ * authoring-surface obligation with no measured pull; the exemption gets
+ * revisited the day a real metadata-authoring need for tree or chart views
+ * arrives.
+ *
+ * ## Host-only is not dead — the path is live
+ *
+ * Measured, not assumed: `@object-ui/app-shell`'s console passes stored view
+ * records to this component as `views`, and its `CreateViewDialog` offers
+ * `tree` and `chart` among the nine types a console user can create. That is
+ * the path these branches serve, and it is why the icon map beside them is
+ * total over `ViewType` rather than over the authored union.
+ *
+ * ## What holds the record honest
+ *
+ * The exemption is a claim about REACHABILITY, so both halves are pinned:
+ *
+ *   - `src/__tests__/objectViewHostSurface.test.tsx` — the record. The branch
+ *     set is re-derived from the `#region` fence around the switch below, so a
+ *     ninth branch (or a deleted one) fails BY NAME instead of quietly
+ *     changing what this list describes; and type-level pins fail
+ *     `pnpm type-check` the day either authored union grows a `tree` or
+ *     `chart` member, because that is the day this record goes stale.
+ *   - `src/__tests__/ObjectView.hostOnlyViewTypes.test.tsx` — the basis,
+ *     measured: a host `views` prop still reaches both branches. An exemption
+ *     whose reachability stops being proved is a record about nothing.
+ *
+ * ⛔ Do not "finish" this by deleting the branches as unreachable code. They
+ * are unreachable from AUTHORED metadata only; host composition is a supported
+ * path with a live consumer.
+ */
+export const OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES = [
+  'chart',
+  'tree',
+] as const;
+
+/**
  * ObjectView Component
  *
  * Renders a complete object management interface with multi-view rendering
@@ -848,7 +910,22 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
       defaultView: (activeView?.type || 'grid') as ViewType,
       activeView: (activeView?.type || 'grid') as ViewType,
       views: viewsPropResolved.map(v => {
-        const iconMap: Record<string, string> = {
+        // objectui#5321 — TOTAL over `ViewType`, so no member can land without
+        // an icon. This was `Record<string, string>`, and a member with no key
+        // falls through to the `'table'` fallback below: a host-supplied
+        // `tree` view was labelled with the GRID icon. objectui#2916 fixed
+        // exactly that for `chart` by adding one key, and nothing recorded
+        // that the set has to be COMPLETE, so `tree` stayed missing. The
+        // annotation is the guard for the whole class: `ViewSwitcher`'s own
+        // `DEFAULT_VIEW_ICONS` — the consumer of these strings — is already
+        // `Record<ViewType, LucideIcon>`, and only this producer was partial.
+        //
+        // The values are the spellings `ViewSwitcher.resolveIcon` PascalCases
+        // back into lucide icons, so `tree: 'list-tree'` resolves to the same
+        // `ListTree` that file's `DEFAULT_VIEW_ICONS.tree` already names for
+        // this view type. The `|| 'table'` fallback stays: `v.type` arrives
+        // from a host prop and nothing validates it at runtime.
+        const iconMap: Record<ViewType, string> = {
           kanban: 'kanban',
           calendar: 'calendar',
           map: 'map',
@@ -859,6 +936,7 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           list: 'list',
           detail: 'file-text',
           chart: 'bar-chart-3',
+          tree: 'list-tree',
         };
         return {
           type: v.type as ViewType,
@@ -949,6 +1027,14 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
         }
     }
 
+    // #region object-view VIEW-TYPE BRANCHES (objectui#5321)
+    //
+    // Every view type this component can render, and the two of them
+    // (`chart`, `tree`) that no authored document can select — see
+    // {@link OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES} at the top of this file.
+    // The fence is load-bearing, not decoration: `objectViewHostSurface.test`
+    // re-derives the branch set from it, so a ninth branch fails BY NAME
+    // rather than quietly changing what that record describes.
     switch (viewType) {
       case 'kanban': {
         // Per @objectstack/spec, kanban-specific config lives under view.kanban.*
@@ -1064,6 +1150,14 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           ...pickFlatMapConfig(viewOptions.map),
         };
       case 'tree':
+        // ⛔ HOST-COMPOSITION ONLY (objectui#5321) — see
+        // {@link OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES}. `tree` is a member
+        // of neither `ObjectViewSchema.defaultViewType` nor
+        // `NamedListView.type`, so no authored document reaches this branch;
+        // it runs only when a host passes a `views` prop. Ruled RECORDED, not
+        // declared, 2026-08-20. The `viewOptions.tree.*` surface below is
+        // therefore HOST config — maintained, read, and ⛔ not authoring
+        // surface to teach in the docs.
         return {
           type: 'object-tree',
           ...baseProps,
@@ -1077,6 +1171,11 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           ...(viewOptions.tree || {}),
         };
       case 'chart': {
+        // ⛔ HOST-COMPOSITION ONLY (objectui#5321) — the same record as
+        // `tree` above: `chart` is in neither authored union, so the ADR-0021
+        // shape below is reachable only through a host `views` prop. Ruled
+        // RECORDED, not declared, 2026-08-20.
+        //
         // Aggregated chart of the object's records, delegating to the same
         // object-chart component the dashboard uses.
         const chartCfg = viewOptions.chart || {};
@@ -1116,6 +1215,7 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
       default:
         return null;
     }
+    // #endregion object-view VIEW-TYPE BRANCHES (objectui#5321)
     // `schema.table?.columns` joins the list with the read added for
     // objectui#5269: a memo that reads a key but does not depend on it keeps
     // serving the field list the author has already replaced.

--- a/packages/plugin-view/src/__tests__/ObjectView.hostOnlyViewTypes.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.hostOnlyViewTypes.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The BASIS of the objectui#5321 exemption, measured — plus the one behaviour
+ * the card changed.
+ *
+ * ## What this file is for
+ *
+ * The maintainer ruled on 2026-08-20 that `tree` and `chart` stay
+ * HOST-COMPOSITION-ONLY view types: recorded, not added to
+ * `ObjectViewSchema.defaultViewType` / `NamedListView.type`. That record lives
+ * in `OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES` (ObjectView.tsx) and is pinned
+ * by `objectViewHostSurface.test.tsx`.
+ *
+ * An exemption of that shape is a claim about REACHABILITY — "an author cannot
+ * select these, a host still can" — so the second half has to keep being
+ * measured or the record quietly becomes a statement about nothing. That is
+ * this file: a host `views` prop still drives `generateViewSchema` into both
+ * branches, and both still emit their renderer schema.
+ *
+ * ## Why the other half is NOT tested here
+ *
+ * There is deliberately no "an author cannot reach it" runtime test. Types are
+ * erased before this suite runs, so a schema with `defaultViewType: 'tree'`
+ * force-cast past the compiler WOULD reach the branch at runtime — a test
+ * asserting otherwise could only pass by testing something else. The authored
+ * half is a compile-time claim and is pinned where it can actually fail: the
+ * type-level assertions in `objectViewHostSurface.test.tsx`, which go red under
+ * `pnpm --filter @object-ui/plugin-view type-check` the day either union grows
+ * a `tree` or `chart` member.
+ *
+ * ## The behaviour the card changed
+ *
+ * `viewSwitcherSchema`'s `iconMap` had a `chart` key (added by objectui#2916)
+ * and no `tree` one, so a host-supplied tree view fell through to the
+ * `'table'` fallback and was labelled with the GRID icon. The console reaches
+ * this: `CreateViewDialog` offers `tree` among the view types a user can
+ * create, and those records arrive here as the `views` prop.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { icons } from 'lucide-react';
+import type { ObjectViewSchema, ViewType } from '@object-ui/types';
+import { ObjectView, OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES } from '../ObjectView';
+
+/** Every schema handed to SchemaRenderer, in order. */
+const rendered: any[] = [];
+/** Every schema handed to the ViewSwitcher, in order. */
+const switcherSchemas: any[] = [];
+
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
+  return {
+    SchemaRenderer: ({ schema }: any) => {
+      rendered.push(schema);
+      return <div data-testid="schema-renderer">{schema?.type}</div>;
+    },
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+vi.mock('@object-ui/plugin-grid', () => ({ ObjectGrid: () => <div data-testid="object-grid" /> }));
+vi.mock('@object-ui/plugin-form', () => ({ ObjectForm: () => <div data-testid="object-form" /> }));
+// The switcher is captured rather than rendered: the claim is about the icon
+// NAME this component computes, and reading it off the props is the only way to
+// see it without going through lucide's rendering.
+vi.mock('../ViewSwitcher', () => ({
+  ViewSwitcher: ({ schema }: any) => {
+    switcherSchemas.push(schema);
+    return <div data-testid="view-switcher" />;
+  },
+}));
+
+const dataSource = () => ({
+  find: vi.fn().mockResolvedValue({ data: [], total: 0 }),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn().mockResolvedValue({ name: 'task', fields: {} }),
+});
+
+/** Compose the component the way a HOST does — the only path to these types. */
+async function renderWithViews(
+  views: Array<Record<string, unknown>>,
+  schemaExtra: Record<string, unknown> = {},
+) {
+  rendered.length = 0;
+  switcherSchemas.length = 0;
+  render(
+    <ObjectView
+      schema={{ type: 'object-view', objectName: 'task', ...schemaExtra } as ObjectViewSchema}
+      views={views as never}
+      dataSource={dataSource() as never}
+    />,
+  );
+  await waitFor(() => expect(rendered.length + switcherSchemas.length).toBeGreaterThan(0));
+}
+
+// ---------------------------------------------------------------------------
+// 1. The exemption's basis: a host `views` prop still reaches both branches.
+// ---------------------------------------------------------------------------
+
+describe('the host-only view types stay reachable from a `views` prop (objectui#5321)', () => {
+  it('`tree` reaches the object-tree branch, with its `viewOptions.tree.*` surface', async () => {
+    await renderWithViews([
+      { id: 't', label: 'Tree', type: 'tree', tree: { parentField: 'parent_id', defaultExpandedDepth: 2 } },
+    ]);
+    const schema = rendered[rendered.length - 1];
+
+    expect(
+      schema?.type,
+      'A host `views` prop no longer reaches `generateViewSchema`\'s `tree` branch. That branch being\n'
+        + 'host-reachable IS the objectui#5321 exemption: the maintainer ruled `tree` recorded rather\n'
+        + 'than declared BECAUSE hosts can still select it. With the reachability gone the record\n'
+        + 'describes nothing, and the question goes back to the maintainer — it is not fixed by\n'
+        + 'deleting this test.',
+    ).toBe('object-tree');
+    // The config surface the exemption specifically covers: host config, not
+    // authoring surface, but read and forwarded all the same.
+    expect(schema.parentField).toBe('parent_id');
+    expect(schema.defaultExpandedDepth).toBe(2);
+  });
+
+  it('`chart` reaches the object-chart branch, in the ADR-0021 dataset shape', async () => {
+    await renderWithViews([
+      { id: 'c', label: 'Chart', type: 'chart', chart: { dataset: 'tasks_by_stage', dimensions: ['stage'], values: ['amount'] } },
+    ]);
+    const schema = rendered[rendered.length - 1];
+
+    expect(
+      schema?.type,
+      'A host `views` prop no longer reaches `generateViewSchema`\'s `chart` branch — the same\n'
+        + 'objectui#5321 reachability claim as `tree` above.',
+    ).toBe('object-chart');
+    expect(schema.dataset).toBe('tasks_by_stage');
+    expect(schema.dimensions).toEqual(['stage']);
+    expect(schema.xAxisKey).toBe('stage');
+  });
+
+  it('both recorded host-only types are covered by the two tests above', () => {
+    // Guards the pair, not the prose: a third name joining the record without a
+    // reachability test would leave the exemption half-measured.
+    expect([...OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES].sort()).toEqual(['chart', 'tree']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The behaviour objectui#5321 changed: the missing `tree` icon.
+// ---------------------------------------------------------------------------
+
+const switcherIcons = (): Record<string, string> =>
+  Object.fromEntries(
+    (switcherSchemas[switcherSchemas.length - 1]?.views ?? []).map(
+      (v: { type: string; icon: string }) => [v.type, v.icon],
+    ),
+  );
+
+/** Two views and the toggle on — the switcher's own preconditions. */
+const renderSwitcherWith = (type: string) =>
+  renderWithViews(
+    [
+      { id: 'g', label: 'Grid', type: 'grid' },
+      { id: 'x', label: 'Other', type },
+    ],
+    { showViewSwitcher: true },
+  );
+
+describe('the view switcher labels every composed view type (objectui#5321)', () => {
+  it('a host `tree` view gets the tree icon, not the `table` fallback', async () => {
+    await renderSwitcherWith('tree');
+
+    expect(
+      switcherIcons().tree,
+      'The `tree` entry is gone from `iconMap` again. Without it `tree` falls through to the\n'
+        + "`|| 'table'` fallback and a tree view is labelled with the GRID icon — the objectui#5321\n"
+        + 'gap, and the exact shape objectui#2916 already fixed once for `chart`.',
+    ).toBe('list-tree');
+    expect(switcherIcons().tree).not.toBe('table');
+  });
+
+  it('that name resolves to a real lucide icon', () => {
+    // Load-bearing, and NOT implied by the assertion above: `ViewSwitcher`
+    // renders `icons[toPascalCase(name)]` and draws NOTHING when the lookup
+    // misses, so an icon name can be present, spelled plausibly, and still
+    // produce no icon at all. Measured on lucide-react 1.31: `list-tree` is
+    // `ListTree` and resolves.
+    //
+    // Asserted for `tree` only, deliberately. Two SIBLING entries in the same
+    // map — `chart: 'bar-chart-3'` and `gantt: 'gantt-chart'` — do NOT resolve
+    // on this version (lucide dropped both from its `icons` record while
+    // keeping them as deprecated named exports), so they render icon-less
+    // today. That is a different defect from the missing key this card fixes,
+    // it needs new icon names chosen rather than a key added, and it is filed
+    // as objectui#5586. ⛔ Do not widen this assertion over the whole map
+    // expecting green — that widening belongs to objectui#5586, with the fix.
+    expect(icons.ListTree, '`list-tree` no longer resolves in lucide-react.').toBeTruthy();
+  });
+
+  it('agrees with the icon ViewSwitcher itself already names for `tree`', () => {
+    // Why `list-tree` and not some other plausible glyph: the consumer of these
+    // strings already answers that. Read from source rather than imported —
+    // `DEFAULT_VIEW_ICONS` is module-private, and the point is that the two
+    // sides of the same package do not drift apart silently.
+    const path = [
+      resolve(process.cwd(), 'src/ViewSwitcher.tsx'),
+      resolve(process.cwd(), 'packages/plugin-view/src/ViewSwitcher.tsx'),
+    ].find((candidate) => existsSync(candidate));
+    expect(path, 'cannot locate plugin-view/src/ViewSwitcher.tsx').toBeTruthy();
+    expect(
+      readFileSync(path as string, 'utf8'),
+      "`ViewSwitcher.DEFAULT_VIEW_ICONS` no longer maps `tree` to `ListTree`, so `iconMap`'s\n"
+        + "`tree: 'list-tree'` has stopped agreeing with the default for the same view type. Move both\n"
+        + 'or neither.',
+    ).toContain('tree: ListTree');
+  });
+
+  it('an unrecognised type still falls back to `table` — the control', async () => {
+    // Without this, "tree is not `table`" would also pass against a build where
+    // the fallback had been deleted, and the fallback is what keeps an
+    // unvalidated host prop from rendering a broken switcher.
+    await renderSwitcherWith('not-a-view-type' as ViewType);
+    expect(switcherIcons()['not-a-view-type']).toBe('table');
+  });
+});

--- a/packages/plugin-view/src/__tests__/objectViewHostSurface.test.tsx
+++ b/packages/plugin-view/src/__tests__/objectViewHostSurface.test.tsx
@@ -5,8 +5,21 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * `object-view` — the 27 keys ruled HOST-COMPOSITION SURFACE stay undeclared,
- * and stay read (objectui#5097).
+ * `object-view` — the HOST-COMPOSITION SURFACE ledger.
+ *
+ * TWO records live here, in the same shape and for the same reason: a
+ * maintainer ruled that something this component reads or renders stays HOST
+ * surface rather than becoming authored surface, and a census has to be able
+ * to read that ruling somewhere other than a closed issue.
+ *
+ *   1. objectui#5097 — the 27 `renderListView` keys stay undeclared, and stay
+ *      read. Sections 1-3 below.
+ *   2. objectui#5321 — the `tree` and `chart` view-type branches stay
+ *      unauthored, and stay reachable from a host `views` prop. Section 4.
+ *
+ * =========================================================================
+ * RECORD 1 — the 27 keys ruled HOST-COMPOSITION SURFACE (objectui#5097)
+ * =========================================================================
  *
  * ## The card, and the ruling
  *
@@ -66,12 +79,13 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { ComponentRegistry } from '@object-ui/core';
 import { ComponentPropsMap } from '@objectstack/spec/ui';
-import type { ObjectViewSchema } from '@object-ui/types';
+import type { NamedListView, ObjectViewSchema, ViewType } from '@object-ui/types';
 
 import {
   ObjectView,
   OBJECT_VIEW_HOST_COMPOSITION_KEYS,
   OBJECT_VIEW_DECLARED_FORWARDED_KEYS,
+  OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES,
 } from '../ObjectView';
 // Module scope, not a hook: this import IS the registration.
 import '../index';
@@ -351,5 +365,149 @@ describe('every forwarded key still reaches the host renderer (objectui#5097)', 
         + 'licence to stop reading it. A dropped read silently blanks that setting in every stored\n'
         + 'app-shell document that carries it.',
     ).toEqual(want);
+  });
+});
+
+// ===========================================================================
+// RECORD 2 — the `tree` and `chart` view-type branches (objectui#5321)
+// ===========================================================================
+//
+// ## The card, and the ruling
+//
+// `generateViewSchema` switches on eight view types and returns a renderer
+// schema for each. The type an AUTHOR uses to select one admits six of them:
+// `ObjectViewSchema.defaultViewType` and `NamedListView.type` are the same
+// seven-value union and neither spells `tree` or `chart`. The one segment that
+// can is the `views` PROP, typed `ViewType`, which carries both. So those two
+// branches — the tree branch's `viewOptions.tree.*` config surface and the
+// ADR-0021 dataset-bound chart shape included — are reachable only when a HOST
+// composes this component.
+//
+// Maintainer ruling, 2026-08-20, verbatim 「其他接受你的建议。」: option B —
+// RECORD the host-only exemption, following record 1's precedent, rather than
+// declare two more authored members. Two more members is a permanent
+// authoring-surface obligation with no measured pull; the exemption gets
+// revisited the day a real metadata-authoring need arrives.
+//
+// ## Where each half of the claim is pinned, and why it splits
+//
+// The exemption asserts two things, and they fail in different tools:
+//
+//   - "an author cannot select these" is a COMPILE-TIME claim. It is pinned by
+//     the type-level assertions below, which fail `pnpm type-check` (the
+//     package's script runs `tsc -p tsconfig.test.json` over this file). It
+//     cannot be pinned at runtime: types are erased before vitest runs, so a
+//     force-cast `defaultViewType: 'tree'` WOULD reach the branch, and a
+//     runtime test claiming otherwise could only pass by testing something
+//     else.
+//   - "a host still can" is a RUNTIME claim, and it is the basis the ruling
+//     rests on, so it is measured rather than asserted in prose:
+//     `ObjectView.hostOnlyViewTypes.test.tsx` drives both branches through a
+//     `views` prop.
+//
+// What is pinned HERE is the record itself: that the branch set is what this
+// record says it is, and that the two names still describe real branches.
+
+const VIEW_TYPE_REGION_OPEN = '// #region object-view VIEW-TYPE BRANCHES (objectui#5321)';
+const VIEW_TYPE_REGION_CLOSE = '// #endregion object-view VIEW-TYPE BRANCHES (objectui#5321)';
+
+/** The `generateViewSchema` switch, sliced out of the source by its fence. */
+const branchSlice = (): string => {
+  const start = SOURCE.indexOf(VIEW_TYPE_REGION_OPEN);
+  const end = SOURCE.indexOf(VIEW_TYPE_REGION_CLOSE);
+  expect(
+    start >= 0 && end > start,
+    'The `#region object-view VIEW-TYPE BRANCHES` fence in ObjectView.tsx is gone or reordered.\n'
+      + 'It is load-bearing, not decoration: it is how this record knows which view-type branches\n'
+      + 'exist. Restore it rather than deleting this test.',
+  ).toBe(true);
+  return SOURCE.slice(start, end);
+};
+
+/** Every `case '…':` label in a slice of CODE, distinct, sorted. */
+const caseLabelsIn = (slice: string): string[] =>
+  [...new Set([...stripComments(slice).matchAll(/case '([a-z-]+)':/g)].map((m) => m[1]))].sort();
+
+/** The eight branches the card was measured on. */
+const MEASURED_BRANCHES = [
+  'calendar', 'chart', 'gallery', 'gantt', 'kanban', 'map', 'timeline', 'tree',
+];
+
+// ---------------------------------------------------------------------------
+// 4. The record is what the source says it is.
+// ---------------------------------------------------------------------------
+
+describe('the host-only view-type record matches the branches (objectui#5321)', () => {
+  const recorded: string[] = [...OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES].sort();
+
+  it('the fenced switch carries exactly the eight branches the card measured', () => {
+    expect(
+      caseLabelsIn(branchSlice()),
+      'A view-type branch was added to or removed from `generateViewSchema`. That is a contract\n'
+        + 'question, not a refactor: a NEW branch is authorable only if an author can spell it, so\n'
+        + 'check it against `ObjectViewSchema.defaultViewType` / `NamedListView.type` and either\n'
+        + 'declare it there or add it to OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES with a ruling.\n'
+        + 'objectui#5321 is the precedent for the second route.',
+    ).toEqual(MEASURED_BRANCHES);
+  });
+
+  it('every recorded host-only type is a real branch — no stale name', () => {
+    expect(recorded.filter((t) => !caseLabelsIn(branchSlice()).includes(t))).toEqual([]);
+  });
+
+  it('the record names the two the ruling was made on', () => {
+    // Hand-written on purpose: this is the RECORD, and the ruling is what puts
+    // a name on it. A name appearing here without one is how an exemption stops
+    // describing anything — the failure this expectation exists to cause.
+    expect(
+      recorded,
+      'OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES changed. The maintainer ruled on exactly two names\n'
+        + '(2026-08-20, objectui#5321). Adding a third — or dropping one — is a new ruling, not an\n'
+        + 'edit to this list.',
+    ).toEqual(['chart', 'tree']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4b. The compile-time half: the authored unions still exclude both.
+// ---------------------------------------------------------------------------
+//
+// These fail `tsc`, not vitest, and that is the point — the claim they carry
+// ("no authored document can select these") is a claim about what the compiler
+// accepts. If one of them stops compiling, the exemption is STALE: someone
+// widened an authored union, which is exactly the option the 2026-08-20 ruling
+// rejected. Re-open objectui#5321 rather than deleting the assertion; the two
+// branches and their config surfaces become authoring surface the moment the
+// union admits them, with docs and migration owed.
+
+/** The view-type union an AUTHOR writes on an object-view node. */
+type AuthoredViewType = NonNullable<ObjectViewSchema['defaultViewType']>;
+/** The same union on a named list view. */
+type NamedViewType = NonNullable<NamedListView['type']>;
+
+type Assert<T extends true> = T;
+/** `true` only when member `M` is NOT part of union `U`. */
+type NotIn<M extends string, U extends string> = M extends U ? false : true;
+/** `true` only when member `M` IS part of union `U`. */
+type IsIn<M extends string, U extends string> = M extends U ? true : false;
+
+// The exemption: neither authored union admits either name.
+type _TreeIsNotAuthored = Assert<NotIn<'tree', AuthoredViewType>>;
+type _ChartIsNotAuthored = Assert<NotIn<'chart', AuthoredViewType>>;
+type _TreeIsNotANamedView = Assert<NotIn<'tree', NamedViewType>>;
+type _ChartIsNotANamedView = Assert<NotIn<'chart', NamedViewType>>;
+
+// The other side of it: the HOST union must still carry both, or the exemption
+// describes a path that no longer exists and the branches really are dead.
+type _TreeIsHostSelectable = Assert<IsIn<'tree', ViewType>>;
+type _ChartIsHostSelectable = Assert<IsIn<'chart', ViewType>>;
+
+describe('the type-level half of the record (objectui#5321)', () => {
+  it('is carried by the compiler, not by this suite', () => {
+    // A placeholder with a purpose: the assertions above are type aliases, so
+    // this file would otherwise report nothing about them and a reader could
+    // reasonably think the vitest run had checked the unions. It has not —
+    // `pnpm --filter @object-ui/plugin-view type-check` has.
+    expect([...OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES]).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Fixes #5321

Verified at `d5895ecaf`.

## The ruling this implements

`ObjectView.generateViewSchema` switches on eight view types. The unions an **author** writes admit six of them — `ObjectViewSchema.defaultViewType` and `NamedListView.type` are the same seven-value union, and neither spells `tree` or `chart`. The only segment that can is the component's `views` **prop**, typed `ViewType`, which carries both.

The maintainer ruled on 2026-08-20 (verbatim 「其他接受你的建议。」): **option B — record the host-composition-only exemption**, following the objectui#5097 precedent, rather than adding two members to the authored unions. Two more authored members is a permanent authoring-surface obligation with no measured pull; the exemption gets revisited the day a real metadata-authoring need arrives. Option A (widening the unions) was considered and rejected, so **`packages/types` is untouched and this PR widens no authoring surface**.

## What landed

**1. The record** — `OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES` in `packages/plugin-view/src/ObjectView.tsx`, in the shape of the objectui#5097 constant beside it: the verdict, the ruling with its provenance, the live host path, and where each half of the claim is pinned.

**2. Noted at the branches** — the `tree` and `chart` cases carry a note saying they are host-only and that the `viewOptions.tree.*` surface is host config rather than authoring surface. Without it the next reader sees a maintained config surface and reasonably concludes it is authorable, which is how this card was filed in the first place. The switch is fenced with a `#region` marker so the branch set can be re-derived from source.

**3. The pins** — `objectViewHostSurface.test.tsx` becomes a two-record ledger. The new record 2 asserts the fenced branch set is the eight the card measured, that no recorded name is stale, and that the record still names exactly the two the ruling was made on. The compile-time half is pinned as type-level assertions, because "an author cannot select these" is a claim about what the compiler accepts and cannot be tested at runtime — types are erased before vitest runs, so a force-cast `defaultViewType: 'tree'` **would** reach the branch. A new suite, `ObjectView.hostOnlyViewTypes.test.tsx`, measures the other half: a host `views` prop still drives both branches. That reachability is the exemption's whole basis, so it has to keep being measured rather than asserted in prose.

**4. The one behaviour change** — `viewSwitcherSchema`'s `iconMap` gains `tree: 'list-tree'`. It had an entry for every view type except `tree`, so a tree view fell through to the `|| 'table'` fallback and was drawn with the **grid** glyph. This is live, not hypothetical: the console's `CreateViewDialog` offers `tree` among the view types a user can create, and those records arrive here as the `views` prop.

## One bounded widening, declared

The `iconMap` annotation moved from `Record< string, string >` to `Record< ViewType, string >`, which is more than adding the one missing key. Naming it explicitly because it is the kind of change that should not arrive unannounced:

- **Same defect class.** objectui#2916 already fixed this exact gap once, for `chart`, by adding a single key. Nothing recorded that the map had to be *complete*, so the next missing member went unnoticed. One more key closes one more instance; the annotation closes the class — a future `ViewType` member now fails `type-check` instead of silently rendering as a grid.
- **The shape is pinned by existing evidence, not chosen.** `ViewSwitcher`'s own `DEFAULT_VIEW_ICONS` — the consumer of these strings, in the same package — has always been declared `Record< ViewType, LucideIcon >`. The duty already existed on the consumer side; only the producer was partial, and that asymmetry is the defect.
- **The value is derived, not invented.** `tree: 'list-tree'` PascalCases to `ListTree`, the same glyph `DEFAULT_VIEW_ICONS.tree` already names for this view type. A test asserts the two sides keep agreeing.
- **No new verification surface.** Same gate family; `type-check` already ran on this package.

The runtime `|| 'table'` fallback stays: `v.type` arrives from a host prop and nothing validates it, so the compiler's totality is not a runtime guarantee. A test pins the fallback as the control.

## Verification

All at `d5895ecaf`, each exit code captured before any pipe, each quoted from the gate's own verdict line.

| gate | exit | verdict line |
| --- | --- | --- |
| `pnpm --filter @object-ui/plugin-view type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` (silent on success) |
| `pnpm --filter @object-ui/plugin-view lint` | 0 | `229 problems (0 errors, 229 warnings)` |
| `pnpm exec vitest run packages/plugin-view/` | 0 | `Test Files 19 passed (19)` · `Tests 194 passed (194)` |
| `node scripts/check-control-bytes.mjs` | 0 | `check-control-bytes: OK (scanned 4638 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | 0 | `3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump` |
| `node scripts/check-changeset-fixed.mjs` | 0 | `All workspace packages are in the changeset fixed group` |
| `node scripts/check-type-check-coverage.mjs` | 0 | `test type-check coverage: 41/41 packages compile their tests` |
| `node scripts/check-lint-coverage.mjs` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |

Two more gates were re-derived from the diff rather than taken from the dispatch list. `check-eager-closure-budget.mjs` exits 2 here for a reason unrelated to this change — it reads `apps/console/dist/eager-closure.json`, which only exists after a console build, and reports itself as *a broken gauge, not a passing budget*. It is left to CI, which builds the console. `published-dist-gate` likewise needs a full build; the new test file is excluded from `dist` twice over by `tsconfig.json` (by the `__tests__` directory rule and by the `*.test.tsx` name rule), which is the same path every sibling test file in this package takes.

**Ablation of the behaviour change.** The `tree: 'list-tree'` line was deleted and the suites re-run. Mutation proven on disk in both directions before reading any result — the anchored code line went `1` to `0`, the sibling `chart: 'bar-chart-3'` line stayed at `1`, and `git diff --stat` showed exactly `1 file changed, 1 deletion(-)`. Result: **1 test failed, 20 passed** — only the icon assertion, so the pin is specific rather than a blanket. It failed with `expected 'table' to be 'list-tree'`, i.e. the exact pre-fix behaviour the card describes. Restore ran from a `trap ... EXIT INT TERM` and the tree came back byte-identical (`git status --porcelain` empty, `git diff --stat` zero lines).

**Pin-liveness probe for the type-level assertions.** A type-level pin that no project compiles is a phantom check, so it was proven to bite: flipping one assertion to claim `tree` **is** authored turned `type-check` red with `error TS2344: Type 'false' does not satisfy the constraint 'true'` (exit 2) at that line. Mutation proven on disk both directions, restored by trap.

**No ablation for the record and the branch notes.** They are documentation. There is nothing to mutate that would produce a meaningful red, and manufacturing one would be theatre.

**Declared narrowing.** The repo-wide `pnpm lint` was not run; the package-scoped `eslint .` was. Three pieces of evidence that this cannot hide a failure in the diff: (a) the population comes from eslint's own config resolution — the repo has exactly one `eslint.config.js` and no package-level config, so the package run resolves the same rule set as the repo-wide run; (b) `--format json` reports **34 files linted, 0 errors, 229 warnings**, and all three changed source files are in that population by path; (c) that config enables no type-aware linting — no `projectService`, no `parserOptions.project`, no `project:` — so no rule reads type information and this diff cannot move the verdict on any file it did not touch. The four warnings the new suite adds are `no-explicit-any` on its test doubles, matching every sibling suite in the directory.

## Found while measuring, filed separately

Two **other** entries in the same `iconMap` supply names that no longer resolve: `chart: 'bar-chart-3'` and `gantt: 'gantt-chart'` are absent from lucide 1.31's `icons` record — lucide keeps them as deprecated named exports while dropping them from the by-name lookup, so the compiler cannot see it. `getViewIcon` does not fall back to a default once an explicit icon is set, so those two view types render with **no icon at all** today. Different defect, different remedy (new names chosen, not a key added), out of this card's fence: filed as #5586. The new suite's resolvability assertion is deliberately scoped to `tree` alone, with a comment saying why, so widening it lands with that card instead of as a surprise red.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_