### PR TITLE
fix(components): stop the sparse-predicate warning blaming `hidden: true` (#5399)

### DIFF
--- a/.changeset/sparse-predicate-warning-cause-5399.md
+++ b/.changeset/sparse-predicate-warning-cause-5399.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/components': patch
+---
+
+The `[page:header]` sparse-predicate warning no longer blames `hidden: true` — it
+states what it actually measured (objectui#5399).
+
+When an action's `visible` predicate references a `record.<key>` the bound payload
+does not carry, the warner names the missing key and then explained the cause:
+
+> Hidden (hidden: true) fields are stripped from detail payloads server-side, so a
+> predicate gating on one may evaluate to a hide-by-default verdict.
+
+That cause is false, and it names a mechanism this repo does not own. `hidden` is a
+UI concern — the framework spec describes it as "Hidden from default UI"
+(`packages/spec/src/data/field.zod.ts`) — not a projection rule. Confirmed against
+the framework checkout rather than taken on trust: ObjectQL's own strip for the
+`__search` companion documents that the `hidden` / `readonly` / `system` markers are
+"None of them is a PROJECTION rule", which is precisely why a dedicated strip rule
+had to be written for that one column; drivers answer a query with no `fields` using
+`SELECT *`; and `metadata-protocol` enumerates what the read path does drop —
+`internal: true` columns and the `__search` companion, and nothing else. The only two
+read-side uses of `field.hidden` in the framework are auto-view/auto-form column
+generation and companion-source eligibility, neither of which removes a key from a
+record body.
+
+So an author who read this diagnostic went hunting for a `hidden` flag they would
+either not find, or find on a field the payload demonstrably still returns — while
+the real source of the sparseness (a projected or partial read) went unexamined. A
+confidently wrong cause in a diagnostic is worse than no cause, because it is
+actionable in the wrong direction.
+
+The replacement states the fact this surface can actually see and the consequence it
+does own: the page bound a payload without those keys, a projected or partial read
+will not carry them, and the predicate therefore fails closed and hides the action.
+The measured half of the message — action name, missing fields, predicate source —
+is unchanged, and nothing about what triggers the warning changed.
+
+Message text only. The same false claim also sat in this warner's own doc comments
+and in the comments of the test that pins the message; both are corrected here, and
+the docstring now carries an explicit note against re-attributing the cause to
+`hidden: true`. No other call site was swept.

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -824,8 +824,8 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
               },
             ],
           },
-          // Non-empty payload WITHOUT the referenced field — mirrors the
-          // server stripping `hidden: true` fields from detail payloads.
+          // Non-empty payload WITHOUT the referenced field — mirrors a
+          // projected/partial read binding a record that lacks the key.
           { record: { id: '1', status: 'new' } },
         );
         expect(screen.queryByRole('button', { name: /Hidden Field Gate/i })).toBeNull();
@@ -833,8 +833,8 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
           String(c[0]).includes('hidden_field_gate_2358'),
         );
         // TWO diagnostics, one per fact, each once (objectui#3521): this local
-        // one names the missing field — a CAUSE only this surface can see, since
-        // the server strips `hidden: true` fields from detail payloads — and the
+        // one names the missing field — a FACT only this surface can see, since
+        // only the page knows which payload it bound (objectui#5399) — and the
         // shared `evalRowPredicate` report states the VERDICT (a CEL fault on an
         // absent key, resolved to the fail-closed default). Before #3521 the
         // legacy JS evaluator returned `undefined` for the absent key without

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -973,18 +973,24 @@ export function cleanupTitleSeparators(s: string): string {
  * warn-once machinery reports a faulting predicate under the label this file
  * passes (`page:header action "…" visible`) — one report per broken predicate,
  * identical in wording to the row kebab and the selection bar. What stays local
- * is the missing-field diagnostic below, which explains a *cause* the engine
- * cannot see (fields stripped from the payload server-side).
+ * is the missing-field diagnostic below, which names a *fact* the engine cannot
+ * see (the payload this page bound does not carry the key at all).
  */
 const _warnedHeaderPredicates = new Set<string>();
 
 /**
  * Warn when a predicate references `record.<field>` keys that are absent from
- * the loaded record payload (#2358 trap 3): the server strips `hidden: true`
- * fields from detail payloads, so such a predicate silently resolves to
+ * the loaded record payload (#2358 trap 3): a projected or partial read binds a
+ * record without those keys, so such a predicate silently resolves to
  * `undefined` and fail-closed hides the action with no error to catch. A key
  * that is present-but-null does NOT trigger this (legitimately empty field).
  * Skipped while the record is empty/loading to avoid false positives.
+ *
+ * ⛔ Do NOT re-attribute this to `hidden: true` (objectui#5399). `hidden` is a
+ * UI concern ("Hidden from default UI"), not a projection rule: the framework's
+ * read path drops `internal: true` columns and the `__search` companion, and
+ * nothing else. This surface knows only WHICH keys the bound payload lacks; it
+ * does not own the read that produced it, so it must not name a cause.
  */
 function warnMissingRecordFields(name: unknown, source: string, record: unknown): void {
   if (!record || typeof record !== 'object' || Object.keys(record as object).length === 0) return;
@@ -1000,8 +1006,10 @@ function warnMissingRecordFields(name: unknown, source: string, record: unknown)
   console.warn(
     `[page:header] action "${String(name)}" predicate references record field(s) ` +
     `not present in the record payload: ${missing.join(', ')}. Predicate: ${source}. ` +
-    `Hidden (hidden: true) fields are stripped from detail payloads server-side, ` +
-    `so a predicate gating on one may evaluate to a hide-by-default verdict.`,
+    `This page bound a record payload that does not carry those key(s) — a projected ` +
+    `or partial read ($select, an embedded card, a custom page passing a projected ` +
+    `record) will not include them — so the predicate fails closed and the action ` +
+    `stays hidden.`,
   );
 }
 


### PR DESCRIPTION
Fixes #5399

## The defect

`packages/components/src/renderers/layout/containers.tsx` — the `[page:header]`
missing-field diagnostic named the action, the missing fields and the predicate
source (all measured, all correct), then closed with a causal sentence:

> Hidden (hidden: true) fields are stripped from detail payloads server-side, so a
> predicate gating on one may evaluate to a hide-by-default verdict.

That cause is false, and it names a mechanism this repo does not own. An author who
read it went looking for a `hidden: true` on the field and found either none, or one
on a field the payload demonstrably still returns — while the real source of the
sparseness (a projected or partial read) went unexamined.

## Premise check — confirmed false, not taken on trust

Verified against the framework checkout at `112a8c6`, four independent ways. Three
of these are my own reading of the running framework, not a restatement of triage:

1. **The spec calls it a UI concern.** `packages/spec/src/data/field.zod.ts:1234` —
   `hidden: z.boolean().default(false).describe('Hidden from default UI')`.
2. **ObjectQL says so in the code that had to work around it.**
   `packages/objectql/src/search-companion.ts:370` and its conformance suite:
   the companion column is declared `hidden` + `readonly` + `system`, and
   "None of them is a PROJECTION rule". A query naming no `fields` reaches the
   driver with `ast.fields` undefined and every driver answers that with `SELECT *`.
   The one column that *is* withheld needed a **purpose-built strip rule** — which is
   only necessary *because* `hidden` does not project.
3. **The framework enumerates what the read path actually drops.**
   `packages/metadata-protocol/src/protocol.ts:8073` names the complete set:
   `omitInternalFields` for `internal: true` columns, and
   `stripSearchCompanionFromRead` for the `__search` companion. `hidden` is not in it.
4. **The only read-side uses of `field.hidden` are something else entirely.**
   `protocol.ts:7020` / `:7053` are auto-view and auto-form column generation (a UI
   concern, exactly as the spec describe says), and `search-companion.ts:136` is an
   eligibility gate for what may be denormalized *into* the companion. Neither removes
   a key from a record body.

Triage's live-server probe (both `hidden: true` business fields present in the payload,
`__search` the only absent key) is consistent with all four and I did not re-run it.

## The fix

Message text only. The measured half is untouched; the causal sentence is replaced with
the fact this surface can actually see plus the consequence it does own:

> This page bound a record payload that does not carry those key(s) — a projected or
> partial read ($select, an embedded card, a custom page passing a projected record)
> will not include them — so the predicate fails closed and the action stays hidden.

**No behaviour change.** What triggers the warning is byte-identical; the only changed
executable line in the diff is the string literal inside `console.warn`.

## The two things the card asked me to check

**1. Does a test assert this message?** Yes — `page-header-actions.test.tsx:842` asserts
`/not present in the record payload/` and `toContain('secret_level_2358')`. Both sit in the
**measured** half of the message, which is unchanged, so **no assertion went red**. Confirmed
by the suite passing, not by inspection alone.

**2. Is the same claim repeated elsewhere?** Yes, in four places, all of them annotations of
**this same call site** — not other warners, not prose docs. Because they document the exact
function being corrected, leaving them would ship the fix underneath a comment restating the
falsehood, and the next reader would revert the message to match. All four are inside the two
files this card's scope already names, and each is called out here rather than swept silently:

- `containers.tsx:977` — the paragraph introducing the warner ("fields stripped from the
  payload server-side")
- `containers.tsx:983` — the docstring of `warnMissingRecordFields` itself ("the server strips
  `hidden: true` fields from detail payloads"); it now also carries an explicit note against
  re-attributing the cause, so this cannot quietly regress
- `page-header-actions.test.tsx:828` and `:837` — the comments of the test that pins the message

**Nothing outside those two files was touched.** The sweep found no other site carrying this
claim: every other "server strips" hit in the repo is about **write** stripping (readonly
fields dropped from a save), which is a different and real mechanism. One adjacent site worth
recording but *not* a duplicate:
`apps/console/src/pages/system/ApprovalsInboxPage.rawPayloadGate.test.tsx:39` explicitly says
trimming a payload by `hidden: true` is **not** asserted there and is tracked elsewhere — which
is consistent with this finding rather than a repeat of it. No new issue filed; nothing found
that needs one.

## Verification

There is no meaningful ablation for a message-text change and I did not manufacture one —
mutating a string literal to watch an assertion flip would be theatre, and the assertion that
matters deliberately does not cover the changed sentence.

All gates run at the tree now committed as `059cb503d` (working tree was clean at commit),
exit codes captured before any pipe, each gate's own verdict line quoted:

| Gate | Verdict |
| --- | --- |
| `pnpm --filter @object-ui/components type-check` | `VERDICT command-exit 0` (script echoed `tsc --noEmit && tsc -p tsconfig.test.json`, so not a zero-match) |
| `pnpm --filter @object-ui/components lint` | `896 problems (0 errors, 896 warnings)` — all pre-existing warnings |
| `pnpm exec vitest run packages/components/` (repo root) | `Test Files 174 passed (174)` · `Tests 1576 passed (1576)` |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 4645 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `node scripts/check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |

Re-derived from the actual changed paths rather than trusting the dispatch list, and ran the
additional gates that could plausibly be implicated: `check-i18n-call-site-keys`,
`check-i18n-en-drift`, `check-i18n-dead-keys`, `check-action-forward-parity`,
`check-lint-coverage`, `check-type-check-coverage`, `check-doc-links` — all exit 0.

**Declared narrowing:** lint was run package-scoped rather than repo-wide. It cannot hide a
failure for this diff — `pnpm --filter @object-ui/components lint` runs `eslint .` across the
whole package, and both changed files are inside `packages/components` and appear by name in
its output. The dependency closure was built first
(`pnpm --workspace-concurrency=2 --filter "@object-ui/components^..." build`, exit 0), so the
type-check read fresh `.d.ts` rather than stale or absent output. CI runs the full farm.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_