### PR TITLE
console: read the converged FormFieldSpec instead of a third copy of it

### DIFF
--- a/.changeset/console-form-field-spec-one-declaration-5542.md
+++ b/.changeset/console-form-field-spec-one-declaration-5542.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/console': patch
+---
+
+The form-field authoring contract now has ONE declaration, and the console reads it
+instead of its own copy.
+
+objectui#5040 was not a missing key. It was that **two hand-written descriptions of
+one contract drifted**, and nothing could notice, because each was only ever checked
+against itself. PR #5537 converged the two app-shell descriptions into
+`views/metadata-admin/form-spec.ts`. A **third** survived in `apps/console`:
+`FormPage.tsx` declared its own nine-key `interface FormFieldSpec`, under the same
+name, in a different package — so the same failure mode stayed fully available.
+
+Measured key by key before choosing a route, because the two honest outcomes are
+"same contract, import it" and "genuinely narrower layer, rename it and pin the
+subset". The console's copy was a strict subset — 9 of the shared type's 26 keys,
+every one identical in type, none console-only — and it sat in a position that
+describes an **authored document**: `FormSectionSpec.fields`, read straight off the
+`/meta/view/:name` payload, the same spec `FormView` metadata-admin renders (both
+files even spell the same six-member `type` union and call the element type
+`FormFieldSpec`). The narrow, renderer-honoured shape is a different type that
+already exists in that file, `RenderableField`. So this was one contract described
+twice, and the console's description was wrong about the document: legal metadata —
+`visibleWhen`, `dependsOn`, `type`, `options`, `immutable`, the recursive `fields`,
+and ten more keys — was undeclared there. That is #5040's own symptom, "the type
+rejects the configuration the runtime accepts", which no runtime test can see.
+
+`@object-ui/app-shell` therefore re-exports `FormFieldSpec` from its package root
+(type-only, erased at build — nothing is added to the bundle), and `FormPage.tsx`
+imports it and deletes the local declaration. Reachability is the load-bearing half:
+a type that cannot be imported is a type that gets retyped, and retyped copies drift.
+`form-spec.ts` itself is untouched.
+
+`FormPage.fieldSpec.test.ts` is the pin that makes future drift loud. It reads the
+field-spec type back out of the **exported** `buildSections` signature rather than
+naming it, so re-inlining a local `interface FormFieldSpec` fails `type-check` even
+if the copy agrees on every key on the day it is written — which is exactly what did
+not happen to the copy this change removes. Its liveness controls are what stop it
+being a phantom check: the removed nine-key shape is pinned NOT equal to the shared
+type (so the `Equal` helper is proven to still discriminate), `RenderableField` is
+pinned not equal to it either (so the honoured-row and authored-document types cannot
+be collapsed again), and an undeclared key is still rejected (so the import did not
+smuggle in an index signature). Behaviour is unchanged: the runtime always accepted
+these keys, and the vitest half proves the same rows are built.

--- a/apps/console/src/components/FormPage.fieldSpec.test.ts
+++ b/apps/console/src/components/FormPage.fieldSpec.test.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ONE description of the form-field authoring contract — objectui#5542.
+ *
+ * ## The class this pins shut
+ *
+ * objectui#5040 was not a missing key. It was that **two descriptions of one
+ * contract drifted**, and nothing could notice, because each was only ever
+ * checked against itself. PR #5537 converged the two app-shell descriptions
+ * into `packages/app-shell/src/views/metadata-admin/form-spec.ts`. A **third**
+ * survived in this app: `FormPage.tsx` declared its own nine-key
+ * `interface FormFieldSpec`, under the same name, in a different package.
+ *
+ * The measurement that chose the route: the console's copy was a strict subset
+ * — 9 of the shared type's 26 keys, every one of them identical, none of them
+ * console-only — sitting in a position that describes an **authored document**
+ * (`FormSectionSpec.fields`, read straight off `/meta/view/:name`), not a
+ * narrower thing this app authors. The narrow, renderer-honoured shape is a
+ * separate type that already exists here, `RenderableField`. So the two names
+ * were one contract, and the console's copy simply described it wrongly: legal
+ * metadata (`visibleWhen`, `dependsOn`, `type`, `options`, `immutable`, the
+ * recursive `fields`, …) was undeclared, which is #5040's own symptom — "the
+ * type rejects the configuration the runtime accepts".
+ *
+ * ## What is pinned, and by which tool
+ *
+ * Two halves that fail in different places, on purpose:
+ *
+ *   • **`tsc`** — {@link formFieldSpecContractPins}. Type assertions are erased
+ *     at runtime, so vitest proves nothing about them; the app's `type-check`
+ *     script (`tsc --noEmit`, whose `include` is `["src", "dev"]` and therefore
+ *     compiles this file) is what judges them. PIN A is the one that closes the
+ *     class: it reads the field-spec type back out of the **exported**
+ *     `buildSections` signature, so a re-inlined local copy fails here even if
+ *     it agrees on every key on the day it is written. PIN B is its liveness
+ *     control — it asserts that `Equal` still returns `false` for a type that
+ *     really differs, so PIN A can never pass vacuously.
+ *   • **vitest** — the `buildSections` block. It proves the widening is inert
+ *     at runtime: a field spec carrying the previously-undeclarable keys builds
+ *     the same rows, and the keys this renderer does not honour are recorded as
+ *     not honoured rather than assumed.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { FormFieldSpec } from '@object-ui/app-shell';
+import { buildSections } from './FormPage';
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+/**
+ * The console's own view of the field-spec type, read back out of the public
+ * surface rather than re-stated. `buildSections` is exported and takes the
+ * FormView it renders, so this walks spec → sections → fields → the non-string
+ * arm. Deriving it this way is the point: nothing in this file names the type
+ * the way `FormPage.tsx` names it, so the pin follows whatever that file
+ * actually uses in that position.
+ */
+type ConsoleFormViewSpec = Parameters<typeof buildSections>[0];
+type ConsoleSectionSpec = NonNullable<ConsoleFormViewSpec['sections']>[number];
+type ConsoleFieldSpec = Exclude<ConsoleSectionSpec['fields'][number], string>;
+
+/**
+ * These never run. They are the half of this card a runtime test cannot express
+ * — "there is only one declaration of this contract" is a statement about `tsc`.
+ */
+export function formFieldSpecContractPins(): void {
+  // ── PIN A — the class. The element type of the console's authored-field array
+  // IS the app-shell declaration, not a structural twin of it. Re-inlining a
+  // local `interface FormFieldSpec` here turns this line red on the day it is
+  // written, which is exactly what did NOT happen to the copy #5542 removed.
+  //
+  // Spelled as a `const` rather than a bare `type` alias because this app sets
+  // `noUnusedLocals`, which reports an unreferenced alias (TS6196) — a pin that
+  // has to be deleted to compile is no pin. The assertion is unchanged: the
+  // annotation is `Assert<…>`, so a false `Equal` fails the `extends true`
+  // constraint (TS2344) here, and the initializer is erased at runtime.
+  const oneContract: Assert<Equal<ConsoleFieldSpec, FormFieldSpec>> = true;
+  void oneContract;
+
+  // ── PIN B — liveness control for PIN A. `Equal` is a conditional-type trick
+  // and a broken one would answer `true` for everything, which would make PIN A
+  // a phantom check that no drift could ever fail. Pin the negative answer too:
+  // the nine-key shape this file removed is NOT the shared type, and `Equal`
+  // must still say so.
+  type _removedCopy = {
+    field: string;
+    label?: string;
+    placeholder?: string;
+    helpText?: string;
+    required?: boolean;
+    readonly?: boolean;
+    hidden?: boolean;
+    colSpan?: 1 | 2 | 3 | 4;
+    widget?: string;
+  };
+  const equalStillDiscriminates: Assert<Equal<Equal<_removedCopy, FormFieldSpec>, false>> = true;
+  void equalStillDiscriminates;
+
+  // ── PIN C — the measurement, made executable. Every key below was
+  // `TS2353: … does not exist in type 'FormFieldSpec'` in this app before
+  // #5542, while the runtime accepted it and metadata-admin authored it. They
+  // are the difference the key-by-key comparison found.
+  const wasUndeclarableHere: ConsoleFieldSpec = {
+    field: 'stage',
+    type: 'select',
+    options: [{ label: 'New', value: 'new' }],
+    reference: 'showcase_stage',
+    dependsOn: 'objectName',
+    immutable: true,
+    multiple: false,
+    minLength: 1,
+    maxLength: 40,
+    min: 0,
+    max: 10,
+    precision: 2,
+    scale: 1,
+    disclosure: 'popover',
+    language: 'sql',
+    visibleWhen: '${data.kind == "deal"}',
+    visibleOn: { dialect: 'cel', source: 'data.kind == "deal"' },
+    fields: ['nested', { field: 'deeper' }],
+  };
+  void wasUndeclarableHere;
+
+  // ── PIN D — negative control on the KEY. PIN C means "these keys are
+  // declared", not "this position stopped checking". Excess-property checking
+  // is still live, so the import did not smuggle in an index signature or
+  // `any` — the failure mode a widening is most likely to reach for.
+  const undeclaredKey: ConsoleFieldSpec = {
+    field: 'stage',
+    // @ts-expect-error objectui#5542 — an undeclared key is still rejected
+    thisKeyIsNotPartOfTheAuthoringSurface: true,
+  };
+  void undeclaredKey;
+
+  // ── PIN E — the renderer's honoured shape is a DIFFERENT type, and stays
+  // that way. Collapsing the two is how the removed copy came to describe an
+  // authored document with the nine keys this file happens to read.
+  type ConsoleRenderableField = ReturnType<typeof buildSections>[number]['fields'][number];
+  const notTheSameThing: Assert<Equal<Equal<ConsoleRenderableField, FormFieldSpec>, false>> = true;
+  void notTheSameThing;
+}
+
+describe('objectui#5542 — the console renders the shared field spec', () => {
+  it('builds the same rows from a spec carrying the previously-undeclarable keys', () => {
+    // Typed through `buildSections`' own parameter, so this literal is checked
+    // against whatever `FormPage.tsx` declares in that position.
+    const sections = buildSections(
+      {
+        sections: [
+          {
+            label: 'Details',
+            columns: 2,
+            fields: [
+              {
+                field: 'stage',
+                label: 'Stage',
+                colSpan: 2,
+                required: true,
+                // Legal metadata the console could not declare before #5542.
+                type: 'select',
+                options: [{ label: 'New', value: 'new' }],
+                dependsOn: 'objectName',
+                visibleWhen: '${data.kind == "deal"}',
+                immutable: true,
+                maxLength: 40,
+              },
+            ],
+          },
+        ],
+      },
+      null,
+    );
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].columns).toBe(2);
+    expect(sections[0].fields).toHaveLength(1);
+
+    const row = sections[0].fields[0];
+    expect(row.name).toBe('stage');
+    expect(row.label).toBe('Stage');
+    expect(row.colSpan).toBe(2);
+    expect(row.required).toBe(true);
+
+    // Recorded rather than assumed: `RenderableField` is the narrow honoured
+    // shape, and it takes `maxLength` from the OBJECT schema, never from the
+    // field override — so authoring it on the field is declarable-but-inert in
+    // this renderer. That was true before #5542 too; the only thing that
+    // changed is that the type now tells the truth about the document instead
+    // of pretending the key cannot be written at all.
+    expect(row.maxLength).toBeUndefined();
+  });
+
+  it('still accepts the bare string arm, which is most of what authors write', () => {
+    const sections = buildSections({ sections: [{ fields: ['name', 'amount'] }] }, null);
+    expect(sections[0].fields.map((f) => f.name)).toEqual(['name', 'amount']);
+  });
+});

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -53,6 +53,7 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
+import type { FormFieldSpec } from '@object-ui/app-shell';
 import { resolveSubmitRedirect } from './submitRedirect';
 
 const API_BASE = (import.meta.env.VITE_SERVER_URL || '') + '/api/v1';
@@ -272,19 +273,29 @@ interface FormSectionSpec {
   collapsible?: boolean;
   collapsed?: boolean;
   columns?: 1 | 2 | 3 | 4 | '1' | '2' | '3' | '4';
+  /**
+   * `FormFieldSpec` here is the app-shell declaration, imported — NOT a local
+   * copy of it (objectui#5542).
+   *
+   * This position describes what an AUTHOR wrote: `sec.fields` is read straight
+   * off the `/meta/view/:name` payload, the same `FormView` document
+   * metadata-admin authors and renders. Until #5542 this file declared its own
+   * nine-key `interface FormFieldSpec` in that position — a second description
+   * of one contract, and the description was wrong about the document: the
+   * shared surface has 26 keys, so legal metadata (`visibleWhen`, `dependsOn`,
+   * `type`, `options`, `immutable`, the recursive `fields`, …) was undeclared
+   * here. That is the exact failure mode objectui#5040 recorded — "the type
+   * rejects the configuration the runtime accepts" — and nothing could notice,
+   * because each copy was only ever checked against itself.
+   *
+   * The narrow shape this renderer actually honours is a DIFFERENT type and
+   * already exists: {@link RenderableField}, what {@link buildSections} emits.
+   * Keeping the incoming-document type wide and the honoured-row type narrow is
+   * the distinction the old declaration collapsed. `FormFieldSpec.contract.test.ts`
+   * pins this element type to the app-shell one, so re-inlining a local copy
+   * fails `type-check` even if it agrees on every key on the day it is written.
+   */
   fields: Array<string | FormFieldSpec>;
-}
-
-interface FormFieldSpec {
-  field: string;
-  label?: string;
-  placeholder?: string;
-  helpText?: string;
-  required?: boolean;
-  readonly?: boolean;
-  hidden?: boolean;
-  colSpan?: 1 | 2 | 3 | 4;
-  widget?: string;
 }
 
 /** Normalized field row used by the renderer. */

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -308,6 +308,12 @@ export type {
   MetadataSelection,
   MetadataInspector,
   MetadataInspectorProps,
+  // The form-field authoring surface, in ONE declaration (objectui#5040 /
+  // #5542). `apps/console` renders the same authored `FormView` documents this
+  // package's metadata-admin does; before it could import this name it kept a
+  // third hand-written copy of the shape. See the note on the re-export in
+  // `views/metadata-admin/index.ts`.
+  FormFieldSpec,
 } from './views/metadata-admin/index.js';
 
 // Studio WYSIWYG design surface (ADR-0080) — the open-source design surface.

--- a/packages/app-shell/src/views/metadata-admin/index.ts
+++ b/packages/app-shell/src/views/metadata-admin/index.ts
@@ -27,6 +27,19 @@ export { MetadataDiagnosticsPage } from './DiagnosticsPage.js';
 export { MetadataQuickFind } from './QuickFind.js';
 export { PageShell as MetadataPageShell } from './PageShell.js';
 export { SchemaForm } from './SchemaForm.js';
+/**
+ * The ONE declaration of the metadata-admin form-field authoring surface
+ * (objectui#5040, converged by PR #5537 into the `./form-spec.js` leaf).
+ *
+ * Re-exported through the package root because it has an out-of-package
+ * consumer: `apps/console`'s `FormPage.tsx` reads the same authored `FormView`
+ * documents and, until objectui#5542, held a THIRD hand-written description of
+ * this shape under the same name. A type that cannot be imported is a type
+ * that gets retyped, and retyped copies drift — which is the defect #5040
+ * recorded. Reachability is what makes the convergence hold outside this
+ * directory. Type-only: erased at build, so nothing is added to the bundle.
+ */
+export type { FormFieldSpec } from './form-spec.js';
 export { LayeredDiff } from './LayeredDiff.js';
 export { PermissionMatrixEditPage } from './PermissionMatrixEditor.js';
 export {


### PR DESCRIPTION
Fixes #5542

## The comparison, key by key — the route is a measurement

Triage ruled that both outcomes close the class and that which one applies is a
measurement, not a preference. Here is the measurement.

The console's declaration (`FormPage.tsx:278` on `cad512fe1`) had **9 keys**. The
converged app-shell declaration (`form-spec.ts:26`) has **26**. Every one of the
console's 9 is present in the shared type with an **identical** type, and the console
had **zero** keys of its own:

| key | console | app-shell `form-spec.ts` | verdict |
| --- | --- | --- | --- |
| `field` | `string` (required) | `string` (required) | identical |
| `label` | `string?` | `string?` | identical |
| `placeholder` | `string?` | `string?` | identical |
| `helpText` | `string?` | `string?` | identical |
| `required` | `boolean?` | `boolean?` | identical |
| `readonly` | `boolean?` | `boolean?` | identical |
| `hidden` | `boolean?` | `boolean?` | identical |
| `colSpan` | `1 \| 2 \| 3 \| 4` optional | `1 \| 2 \| 3 \| 4` optional | identical |
| `widget` | `string?` | `string?` | identical |
| `type`, `options`, `reference`, `dependsOn`, `maxLength`, `minLength`, `min`, `max`, `precision`, `scale`, `multiple`, `immutable`, `disclosure`, `language`, `visibleWhen`, `visibleOn`, `fields` | absent | declared | **17 keys the console did not admit** |

Zero disagreements, zero console-only keys, strict 9-of-26 subset.

## Which route the comparison supports, and why

**Same contract — import it.** A subset relation alone does not settle it; a narrower
authoring layer would also look like a subset. Three further facts do settle it:

1. **The position describes an authored document, not something the console authors.**
   The type sits on `FormSectionSpec.fields`, and `sec.fields` is read straight off the
   `/meta/view/:name` payload (`resolveInternalForm` casts the response into
   `FormViewSpec`). That is the same spec `FormView` metadata-admin renders — app-shell's
   own container says so in as many words, "Lightweight shape of the spec `FormView` we
   consume". Both files even spell the same character-identical six-member `type` union
   and both call the element type `FormFieldSpec`.
2. **The narrower renderer type already exists, under a different name.** `FormPage.tsx`
   declares `RenderableField` — the normalized row `buildSections` emits, which really is
   "what this renderer honours". The narrowing role was already filled, so the local
   `FormFieldSpec` was not filling it.
3. **So the console's copy was not a narrower layer, it was a wrong description.** Legal
   metadata the spec accepts and the runtime passes through — `visibleWhen`, `dependsOn`,
   `type`, `options`, `immutable`, the recursive `fields`, 17 keys in all — was
   undeclared here. That is objectui#5040's own symptom, "the type rejects the
   configuration the runtime accepts", which no runtime test can see.

A rename would have declared a narrowing that the code does not perform, so it was not
the honest route even though it is the smaller diff.

## The change

- `@object-ui/app-shell` re-exports `FormFieldSpec` from its package root. **Type-only**
  — erased at build, nothing added to the bundle (the eager-closure gate confirms it
  below). Reachability is the load-bearing half of the fix: the type was previously
  unnameable outside `views/metadata-admin/`, and a type that cannot be imported is a
  type that gets retyped. `FormPage.tsx` already documents this exact unreachability for
  a sibling case (`urlParams`), which is how the third copy came to exist.
- `FormPage.tsx` imports it and deletes the local declaration.
- `FormPage.fieldSpec.test.ts` is the pin.
- One changeset.

⚠️ **Scope note for review.** The card fenced
`packages/app-shell/src/views/metadata-admin/form-spec.ts` as a read-only reuse target
and it is **untouched** — confirmed, it is not in this diff. But reuse needed
reachability, so this PR does add two additive `export type` lines to app-shell's
barrels (`views/metadata-admin/index.ts` and `src/index.ts`). That is beyond the letter
of the declared file surface. Flagging rather than burying it: if the reviewer would
rather not widen app-shell's public type surface, the alternative is a subpath export or
moving the type to a shared package, both larger than this card.

## The pin, and proof that it bites

The pin does not name the console's type — it reads it **back out of the exported
`buildSections` signature**, walking spec → sections → fields → the non-string arm. So it
follows whatever `FormPage.tsx` actually uses in that position and cannot be satisfied by
a decoy:

```ts
type ConsoleFormViewSpec = Parameters( typeof buildSections )[0];
type ConsoleSectionSpec = NonNullable( ConsoleFormViewSpec['sections'] )[number];
type ConsoleFieldSpec = Exclude( ConsoleSectionSpec['fields'][number], string );

const oneContract: Assert( Equal( ConsoleFieldSpec, FormFieldSpec ) ) = true;
```

(Written with parens above because the write path eats angle brackets; the file uses real
generics.)

**Liveness probe — a type assertion no project compiles is a phantom check.** Rather than
flip the assertion to a trivially false thing, I simulated the actual regression: dropped
the shared import and re-inlined the nine-key local `interface FormFieldSpec`, exactly as
a future agent would. `FormPage.tsx` still compiles on its own, so the redness is the pin
and nothing else:

```
BEFORE  import-line count : 1     local-decl count : 0
MUTATE
AFTER   import-line count : 0     local-decl count : 1
        apps/console/src/components/FormPage.tsx | 13 ++++++++++++-
        1 file changed, 12 insertions(+), 1 deletion(-)

src/components/FormPage.fieldSpec.test.ts(81,29): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/components/FormPage.fieldSpec.test.ts(81,9):  error TS2322: Type 'true' is not assignable to type 'false'.
src/components/FormPage.fieldSpec.test.ts(109,5): error TS2353: Object literal may only specify known properties, and 'type' does not exist in type 'FormFieldSpec'.
src/components/FormPage.fieldSpec.test.ts(165,17): error TS2353: Object literal may only specify known properties, and 'type' does not exist in type 'FormFieldSpec'.
Exit status 2
```

Line 81 is the pin. Note the TS2353 pair: a re-inlined copy immediately re-creates
#5040's exact symptom, and the pin reports it in #5040's own words. Restored via
`trap ... EXIT INT TERM`; `git status --porcelain` empty afterwards and both anchored
counts back to 1 / 0.

Three further controls stop the pin being vacuous, and they compile on **every** run
rather than being a one-time ritual:

- the removed nine-key shape is pinned **not** equal to the shared type, so the `Equal`
  helper is proven to still discriminate;
- `RenderableField` is pinned **not** equal to it either, so the honoured-row and
  authored-document types cannot be quietly collapsed again;
- an undeclared key is still rejected (`@ts-expect-error`), so the import did not smuggle
  in an index signature or `any` — the failure mode a widening reaches for first.

`check-type-check-coverage` independently confirms a project really compiles this file:
`41/41 packages compile their tests, 0 with a narrow type-assertion project`.

## Gate verdicts — exit codes captured before any pipe, each gate's own verdict line quoted

All run at `5536bd387`, the final commit; the probe restored the tree to that exact sha
before this list was taken.

| gate | verdict line | exit |
| --- | --- | --- |
| `@object-ui/console` `type-check` | `os-verify-lock: VERDICT command-exit 0 · held the lock 21s` | 0 |
| `@object-ui/app-shell` `type-check` | (`tsc --noEmit` then `tsc -p tsconfig.test.json`, no output) | 0 |
| `@object-ui/app-shell` `build` | (`tsc`, no output) | 0 |
| `@object-ui/console` `lint` | `✖ 200 problems (0 errors, 200 warnings)` | 0 |
| `@object-ui/app-shell` `lint` | `✖ 2509 problems (0 errors, 2509 warnings)` | 0 |
| `vitest run` (repo root cwd) | `Test Files  202 passed (202)` / `Tests  2191 passed \| 1 skipped (2192)` | 0 |
| `vitest` — the new pin file, verbose | `Test Files  1 passed (1)` / `Tests  2 passed (2)` | 0 |
| `check-control-bytes` | `✅ check-control-bytes: OK (scanned 4647 tracked text file(s); skipped 85 binary).` | 0 |
| `check-changeset-presence` | `✅ 3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` | 0 |
| `check-changeset-no-major` | `✅ No changeset declares a 'major' bump.` | 0 |
| `check-changeset-fixed` | `✅ All workspace packages are in the changeset fixed group.` | 0 |
| `check-type-check-coverage` | `✅ type-check coverage: 45/46 via 'type-check' … 41/41 packages compile their tests` | 0 |
| `check-lint-coverage` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` | 0 |
| `@object-ui/console` `build` | (`tsc`, `vite build`, `tsc -p tsconfig.plugin.json`) | 0 |
| `check-eager-closure-budget` | `✅ Console eager closure is 3784.9 KB gzipped across 52 of 508 chunks (budget: 3867.2 KB, headroom: 82.3 KB).` | 0 |

Two notes on how that list was built rather than taken on trust:

- **The dispatched gate list was treated as a clue, not a spec.** I re-derived it from
  the CI workflows against my actual diff, which added four gates the dispatch did not
  name: `check-type-check-coverage`, `check-lint-coverage`, `check-eager-closure-budget`,
  and the console `build` the last of those needs. `check-eager-closure-budget` was **red
  before the build** — `No eager-closure report … This is a broken gauge, not a passing
  budget` — so rather than argue that a type-only import must be erased, I built the
  console and read the real number.
- **The root `vitest` reporter names only failing files**, so a green run is not by
  itself evidence that the new pin file ran at all — the same shape as a `--filter` that
  matches nothing. Re-run alone with `--reporter=verbose`, which names it under the
  `@object-ui/console` project with both tests passing.

Declared narrowing: `vitest` was scoped to `apps/console/src/components/` and
`packages/app-shell/src/views/metadata-admin/` rather than the whole repo. Evidence it
cannot hide a failure: the app-shell half of this diff is two `export type` lines, which
emit no JavaScript at all, so no module outside those two paths can observe a runtime
difference; the console half is an `import type` plus a deleted `interface`, both fully
erased. CI runs the full farm regardless.

## Out of scope, filed separately

Three findings from the same read, all unassigned, none fixed here:

- #5594 — this same console renderer never evaluates `visibleWhen`/`visibleOn` at all.
  objectui#2212 recorded that symptom and PR #2214 fixed it in the **other** form chain
  (`plugin-form` `sectionFields.ts` plus `components` `renderers/form/form.tsx`);
  `FormPage.tsx` is not on that chain, so the fix never reached it. User-reachable.
- #5595 — `buildSections` drops the field-level `maxLength` override while its own
  docstring promises overrides win. Pre-existing and unchanged by this PR, but newly
  *expressible* because the shared type declares the key. The new test records the
  current answer explicitly rather than assuming it.
- #5596 — the same drift class one level up: `FormViewSpec` and `FormSectionSpec` are each
  hand-declared twice, and unlike the field spec those two have **already** drifted in
  both directions. `finding`, not queued: converging the containers is a real
  architectural call, not a mechanical one.