### PR TITLE
fix(fields): render inline lookup dropdown columns through the cell renderer

### DIFF
--- a/.changeset/lookup-dropdown-cell-renderer-5492.md
+++ b/.changeset/lookup-dropdown-cell-renderer-5492.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/fields': patch
+---
+
+A lookup's inline dropdown renders its columns through the same cell renderer the browse-all picker uses, so one `lookup_columns` declaration cannot produce two answers.
+
+A form's lookup field offers two ways to pick a related record, and both read
+the same declaration: the inline dropdown under the field, and the
+"browse all records" picker behind it. The picker resolved every cell through
+the type-aware cell renderer. The dropdown did not — it printed
+`record[descriptionField]` verbatim into the option subtitle and concatenated
+`label: String(rawValue)` into the row's `title` attribute. Measured on the
+same declaration, on a real 17.1.0 deployment:
+
+```
+column          inline dropdown (before)          browse-all picker
+lookup          T5MsMCuwP4t_yUHq (bare FK id)     the related record's name
+date            2026-08-20T00:00:00.000Z (ISO)    a formatted date
+select          pending (enum code)               the authored option label
+```
+
+Both surfaces now call one shared module — `widgets/lookupColumnDisplay.tsx`,
+which owns column normalisation, the field-descriptor enrichment from the
+referenced object's schema, and the render itself. The picker's own
+`renderCellContent` and `columnFieldDescriptors` are now thin calls into it, so
+there is a single renderer left to drift from. The dropdown's extra columns are
+rendered into the option row itself; the row's `title` keeps the full option
+label, which is what a truncated label needs, instead of a raw-value dump.
+
+No query changed and no contract widened. `lookupColumns` entries stay bare
+field names — no dot paths, no populate/expand semantics — because neither
+surface's request carries populate to begin with: the picker resolves a
+foreign-key id to a name client-side, in the lookup cell renderer, and the
+dropdown now inherits exactly that. An unresolved reference therefore renders
+what the picker renders for it, and keeps its column: a slot is dropped only
+when the record holds no value for the field, decided on the raw value and
+never on what the renderer makes of it, so an unresolved id can never degrade
+into a silently empty column.

--- a/packages/fields/src/widgets/LookupField.pickerAgreement.test.tsx
+++ b/packages/fields/src/widgets/LookupField.pickerAgreement.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One `lookup_columns` declaration, two surfaces, one answer — objectui#5492.
+ *
+ * Reported from a real 17.1.0 deployment. A form's lookup field offers two
+ * ways to pick a related record:
+ *
+ *   the inline dropdown  — the quick-select popover under the field, and
+ *   the browse-all picker — the RecordPickerDialog table behind "show all".
+ *
+ * Both read the SAME `lookup_columns` declaration, and they disagreed. The
+ * picker resolved every cell through the type-aware cell renderer; the
+ * dropdown printed the raw stored value into its option subtitle and
+ * concatenated `label: String(rawValue)` into the row's `title` attribute. So
+ * one declaration produced, side by side:
+ *
+ *   | column | dropdown (before)              | picker                |
+ *   |--------|--------------------------------|-----------------------|
+ *   | lookup | T5MsMCuwP4t_yUHq (bare FK id)  | the related record name |
+ *   | date   | 2026-08-20T00:00:00.000Z (ISO) | a formatted date      |
+ *   | select | pending (enum code)            | the authored option label |
+ *
+ * These tests pin the DISAGREEMENT rather than either surface alone: the same
+ * declaration is driven through both, and the rendered values must match
+ * column for column.
+ *
+ * They also pin the fallback. Neither surface's query carries populate/expand
+ * — that is unchanged, and widening `lookupColumns` with dot-path/populate
+ * semantics is explicitly NOT what fixes this — so a lookup value can
+ * legitimately arrive as an unresolved foreign-key id. The rule is that the
+ * dropdown adopts whatever the picker shows for it, and that the column is
+ * never silently dropped: a held value keeps its slot and renders the lookup
+ * cell renderer's own placeholder, because a blank column is worse than a
+ * bare id (the field report records a dot-path attempt producing exactly that
+ * silent-empty outcome).
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, act, fireEvent } from '@testing-library/react';
+import { SchemaRendererContext } from '@object-ui/react';
+import { LookupField } from './LookupField';
+import { RecordPickerDialog } from './RecordPickerDialog';
+import { getCellRenderer } from '../index';
+
+/** The reporter's shape: a schedule row referencing a work step by bare id. */
+const RESOLVABLE_STEP_ID = 'T5MsMCuwP4t_yUHq';
+/** A second id nothing resolves — the unresolved-reference fallback pin. */
+const UNRESOLVED_STEP_ID = 'Zz9QwErTyUiOpAsD';
+
+const PLANNED_ISO = '2026-08-20T00:00:00.000Z';
+
+const WORK_STEPS: Record<string, any> = {
+  [RESOLVABLE_STEP_ID]: { id: RESOLVABLE_STEP_ID, name: 'Fitting, Line A' },
+};
+
+/**
+ * The referenced object's schema. `lookup_columns` names four of its fields;
+ * three of them are exactly the types the report calls out.
+ */
+const SCHEDULE_FIELDS: Record<string, any> = {
+  name: { type: 'text', label: 'Name' },
+  work_step: { type: 'lookup', label: 'Work Step', reference_to: 'work_steps' },
+  planned_on: { type: 'date', label: 'Planned On', format: 'medium' },
+  status: {
+    type: 'select',
+    label: 'Status',
+    options: [
+      { value: 'pending', label: 'Pending approval' },
+      { value: 'done', label: 'Completed' },
+    ],
+  },
+};
+
+const LOOKUP_COLUMNS = ['name', 'work_step', 'planned_on', 'status'];
+
+/** The non-display columns — the ones both surfaces must agree about. */
+const COMPARED = ['work_step', 'planned_on', 'status'];
+
+function makeSchedule(stepId: string) {
+  return {
+    id: 'sch_1',
+    name: 'Line A retooling',
+    work_step: stepId,
+    planned_on: PLANNED_ISO,
+    status: 'pending',
+  };
+}
+
+function makeDataSource(rows: any[]) {
+  return {
+    find: vi.fn(async (objectName: string) => {
+      if (objectName === 'work_steps') {
+        return { data: Object.values(WORK_STEPS), total: Object.keys(WORK_STEPS).length };
+      }
+      return { data: rows, total: rows.length };
+    }),
+    findOne: vi.fn(async (objectName: string, id: any) => {
+      if (objectName === 'work_steps') return WORK_STEPS[String(id)] ?? null;
+      return rows.find((r) => r.id === id) ?? null;
+    }),
+    getObjectSchema: vi.fn(async (objectName: string) => {
+      if (objectName === 'work_schedules') return { name: objectName, fields: SCHEDULE_FIELDS };
+      if (objectName === 'work_steps') {
+        return { name: objectName, fields: { name: { type: 'text', label: 'Name' } } };
+      }
+      return undefined;
+    }),
+  } as any;
+}
+
+/**
+ * Flush the client-side id resolution both surfaces depend on: the referenced
+ * object's schema fetch, then the lookup cell renderer's `findOne`, then the
+ * re-render that carries the resolved name into the DOM. Macrotask flushes
+ * rather than a `waitFor` predicate on purpose — the predicate would have to
+ * encode the very answer under test, and a timeout would replace a readable
+ * value diff with a timeout message.
+ */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 6; i++) {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+}
+
+/**
+ * What one surface shows for one column: the rendered text, plus whether that
+ * text came from the shared empty-value slot. Both matter — an unresolved
+ * reference and an absent value can print the same glyph, and only one of them
+ * is correct for a record that HOLDS a foreign key.
+ */
+type ColumnReading = { text: string; emptySlot: boolean; present: boolean };
+
+function readColumns(selector: (field: string) => string): Record<string, ColumnReading> {
+  const out: Record<string, ColumnReading> = {};
+  for (const field of COMPARED) {
+    const el = document.querySelector(selector(field));
+    out[field] = {
+      present: !!el,
+      text: el ? (el.textContent ?? '') : '',
+      emptySlot: !!el?.querySelector('[data-slot="empty-value"]'),
+    };
+  }
+  return out;
+}
+
+/** Render the inline dropdown, open it, and read its rendered column values. */
+async function readInlineDropdown(stepId: string): Promise<Record<string, ColumnReading>> {
+  const rows = [makeSchedule(stepId)];
+  const dataSource = makeDataSource(rows);
+  render(
+    <SchemaRendererContext.Provider value={{ dataSource } as any}>
+      <LookupField
+        value={undefined}
+        onChange={() => {}}
+        dataSource={dataSource}
+        field={{
+          reference_to: 'work_schedules',
+          display_field: 'name',
+          lookup_columns: LOOKUP_COLUMNS,
+        } as never}
+      />
+    </SchemaRendererContext.Provider>,
+  );
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('lookup-trigger'));
+  });
+  await waitFor(() => expect(screen.getByText('Line A retooling')).toBeInTheDocument());
+  await settle();
+  const values = readColumns((f) => `[data-lookup-preview="${f}"]`);
+  cleanup();
+  return values;
+}
+
+/** Render the browse-all picker over the same declaration and read its cells. */
+async function readBrowseAllPicker(stepId: string): Promise<Record<string, ColumnReading>> {
+  const rows = [makeSchedule(stepId)];
+  const dataSource = makeDataSource(rows);
+  render(
+    <SchemaRendererContext.Provider value={{ dataSource } as any}>
+      <RecordPickerDialog
+        open
+        onOpenChange={() => {}}
+        dataSource={dataSource}
+        objectName="work_schedules"
+        displayField="name"
+        columns={LOOKUP_COLUMNS}
+        onSelect={() => {}}
+        cellRenderer={getCellRenderer}
+        fieldsMeta={SCHEDULE_FIELDS}
+      />
+    </SchemaRendererContext.Provider>,
+  );
+  await waitFor(() => expect(screen.getByText('Line A retooling')).toBeInTheDocument());
+  await settle();
+  const values = readColumns((f) => `[data-lookup-cell="${f}"]`);
+  cleanup();
+  return values;
+}
+
+afterEach(cleanup);
+
+describe('LookupField — inline dropdown agrees with the browse-all picker (objectui#5492)', () => {
+  it('renders lookup, date and select columns identically on both surfaces', async () => {
+    const dropdown = await readInlineDropdown(RESOLVABLE_STEP_ID);
+    const picker = await readBrowseAllPicker(RESOLVABLE_STEP_ID);
+
+    // The whole card: one declaration must not produce two answers.
+    expect(dropdown).toEqual(picker);
+
+    // …and the answer both give is the RENDERED one, not the stored one.
+    expect(dropdown.work_step.text).toBe('Fitting, Line A');
+    expect(dropdown.work_step.text).not.toBe(RESOLVABLE_STEP_ID);
+
+    expect(dropdown.planned_on.text).not.toBe(PLANNED_ISO);
+    expect(dropdown.planned_on.text).not.toContain('T00:00:00');
+    expect(dropdown.planned_on.text.trim()).not.toBe('');
+
+    expect(dropdown.status.text).toBe('Pending approval');
+    expect(dropdown.status.text).not.toBe('pending');
+  });
+
+  it('keeps an unresolved reference visible, and shows what the picker shows', async () => {
+    const dropdown = await readInlineDropdown(UNRESOLVED_STEP_ID);
+    const picker = await readBrowseAllPicker(UNRESOLVED_STEP_ID);
+
+    // The dropdown's query carries no populate/expand, so an id that resolves
+    // to nothing is a legitimate state. Whatever it renders, it renders the
+    // picker's answer — the two surfaces do not get to disagree here either.
+    expect(dropdown).toEqual(picker);
+
+    // The column must still be THERE, and it must not have degraded into the
+    // shared empty-value slot. A dot-path declaration produces an undefined
+    // read and a silently empty column; that outcome is worse than showing the
+    // bare id, and these three lines are what keep the fix away from it. What
+    // renders instead is the lookup cell renderer's own placeholder for a
+    // reference that is present but not nameable — the picker's long-standing
+    // answer, which the dropdown now adopts rather than re-deciding.
+    expect(dropdown.work_step.present).toBe(true);
+    expect(dropdown.work_step.emptySlot).toBe(false);
+    expect(dropdown.work_step.text.trim()).not.toBe('');
+
+    // The sibling columns are unaffected by the unresolved reference.
+    expect(dropdown.status.text).toBe('Pending approval');
+    expect(dropdown.planned_on.text).not.toBe(PLANNED_ISO);
+  });
+});

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -22,6 +22,16 @@ import { getRecordDisplayName, mergeFilterNodes } from '@object-ui/core';
 import { getRecentLookupIds, pushRecentLookupId } from './recentLookups.js';
 import { getPersonInitials } from './personDisplay.js';
 import { getCellRendererResolver } from './_cell-renderer-bridge.js';
+// The one place a lookup column's display value is decided — shared with the
+// "browse all records" picker (RecordPickerDialog) so a single `lookup_columns`
+// declaration cannot render two different ways (objectui#5492).
+import {
+  normalizeColumn,
+  fieldToLabel,
+  buildLookupColumnDescriptors,
+  renderLookupColumnValue,
+} from './lookupColumnDisplay.js';
+import { useSafeFieldLabel, useDisplayLocale } from '@object-ui/i18n';
 import { SchemaRendererContext as ImportedSchemaRendererContext, useAction, useHasActionProvider } from '@object-ui/react';
 import { useFieldTranslation } from './useFieldTranslation.js';
 
@@ -195,6 +205,11 @@ function mapFieldTypeToFilterType(
 export function LookupField({ value, onChange, field, readonly, error: fieldError, ...props }: FieldWidgetComponentProps<any>) {
   const [isOpen, setIsOpen] = useState(false);
   const { t } = useFieldTranslation();
+  // Same two i18n channels RecordPickerDialog reads, so the inline dropdown
+  // resolves option labels and formats dates exactly as the picker does
+  // (objectui#5492). Both are provider-safe.
+  const { translateOptions } = useSafeFieldLabel();
+  const displayLocale = useDisplayLocale();
   const listboxId = React.useId();
 
   // Create-new error is local; the popover's fetch state (search/loading/error/
@@ -387,6 +402,49 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
     if (!extra) return undefined;
     return typeof extra === 'string' ? extra : extra.field;
   }, [descriptionField, pickerColumns, displayField]);
+
+  /**
+   * Columns previewed under each quick-select option (objectui#5492).
+   *
+   * This is the inline dropdown's half of the one-declaration/two-surfaces
+   * contract. It used to be two separate ad-hoc reads of the raw record — the
+   * subtitle printed `record[descriptionField]` verbatim and the row's `title`
+   * attribute concatenated `label: String(rawValue)` for every other column —
+   * so the same `lookup_columns` that the picker rendered as resolved names,
+   * formatted dates and option labels came out here as bare foreign-key ids,
+   * ISO timestamps and enum codes.
+   *
+   * Now one list feeds one renderer: an explicitly authored `description_field`
+   * still leads (the author picked that column to be the subtitle), followed by
+   * every non-display picker column. Both halves render through
+   * `renderLookupColumnValue`, the picker's own renderer.
+   */
+  const previewColumns = useMemo<LookupColumnDef[]>(() => {
+    const cols: LookupColumnDef[] = [];
+    const seen = new Set<string>([displayField]);
+    if (descriptionField) {
+      cols.push({ field: descriptionField });
+      seen.add(descriptionField);
+    }
+    for (const c of pickerColumns ?? []) {
+      const col = normalizeColumn(c);
+      if (seen.has(col.field)) continue;
+      seen.add(col.field);
+      cols.push(col);
+    }
+    return cols;
+  }, [descriptionField, pickerColumns, displayField]);
+
+  /**
+   * Field descriptors for the previewed columns — the SAME builder the picker
+   * calls, fed the same referenced-object schema, so a `select` column resolves
+   * its authored option label and a `lookup` column carries its `reference`
+   * through to the cell renderer that resolves the id to a name.
+   */
+  const previewDescriptors = useMemo(
+    () => buildLookupColumnDescriptors(previewColumns, refObjectSchema?.fields, referenceTo ?? '', translateOptions),
+    [previewColumns, refObjectSchema, referenceTo, translateOptions],
+  );
 
   // Derive filter-bar columns from any typed picker columns.
   const filterColumns = useMemo<RecordPickerFilterColumn[] | undefined>(() => {
@@ -904,24 +962,44 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
     [onCreateNew, allowCreate, referenceTo, hasActionProvider, execute, dataSource, displayField, idField, effectiveDescriptionField, refTitleFormat, refObjectSchema, handleSelect],
   );
 
-  // Compact one-line preview of an option's extra (non-display) columns —
-  // shown as a native tooltip so users can disambiguate without opening it.
+  /**
+   * Compact one-line preview of an option's extra (non-display) columns.
+   *
+   * Every value goes through `renderLookupColumnValue` — the picker's renderer
+   * — so this line and the picker's table agree on one `lookup_columns`
+   * declaration (objectui#5492). It replaces a `label: String(rawValue)`
+   * concatenation that produced bare ids, raw ISO timestamps and enum codes.
+   *
+   * A column is previewed when the record HOLDS a value for it, decided on the
+   * raw value, never on what the renderer makes of it. An unresolved foreign
+   * key is a held value, so it keeps its column and shows whatever the lookup
+   * cell renderer shows for it — never a silently empty slot, which the field
+   * report behind this issue calls out as worse than showing the bare id.
+   */
   const previewOf = useCallback(
-    (option: LookupOption): string | undefined => {
-      if (!pickerColumns || pickerColumns.length === 0) return undefined;
-      const parts: string[] = [];
-      for (const c of pickerColumns) {
-        const f = typeof c === 'string' ? c : c.field;
-        if (f === displayField) continue;
-        const v = (option as any)[f];
-        if (v === null || v === undefined || v === '') continue;
-        const lbl = typeof c === 'string' ? f : (c.label || f);
-        const text = typeof v === 'object' ? (v.name ?? v.label ?? JSON.stringify(v)) : v;
-        parts.push(`${lbl}: ${text}`);
-      }
-      return parts.length ? parts.join(' · ') : undefined;
+    (option: LookupOption): React.ReactNode => {
+      const cols = previewColumns.filter((c) => {
+        const v = (option as any)[c.field];
+        return v !== null && v !== undefined && v !== '';
+      });
+      if (cols.length === 0) return null;
+      return cols.map((col, i) => (
+        <React.Fragment key={col.field}>
+          {i > 0 && <span aria-hidden="true" className="shrink-0 opacity-60">·</span>}
+          <span className="flex min-w-0 items-center gap-1 truncate">
+            <span className="shrink-0 opacity-70">{`${col.label || fieldToLabel(col.field)}:`}</span>
+            <span className="min-w-0 truncate" data-lookup-preview={col.field}>
+              {renderLookupColumnValue(option, col, {
+                descriptors: previewDescriptors,
+                cellRenderer: getCellRendererResolver(),
+                displayLocale,
+              })}
+            </span>
+          </span>
+        </React.Fragment>
+      ));
     },
-    [pickerColumns, displayField],
+    [previewColumns, previewDescriptors, displayLocale],
   );
 
   // Keyboard handler for the search input — arrow keys + Enter
@@ -1239,7 +1317,11 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
                           data-lookup-index={idx}
                           role="option"
                           aria-selected={isSelected}
-                          title={previewOf(option)}
+                          // The full label stays reachable on hover now that the
+                          // extra columns are rendered into the row itself
+                          // instead of concatenated raw into this attribute
+                          // (objectui#5492).
+                          title={String(option.label ?? '')}
                           onClick={() => handleSelect(option)}
                           className={`w-full text-left px-3 py-2 rounded-md text-sm hover:bg-accent flex items-center justify-between ${
                             isActive
@@ -1252,11 +1334,18 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
                         >
                           <div className="min-w-0 flex-1">
                             <span className="block truncate">{option.label}</span>
-                            {option.description && (
-                              <span className="block truncate text-xs text-muted-foreground">
-                                {option.description}
-                              </span>
-                            )}
+                            {(() => {
+                              const preview = previewOf(option);
+                              if (!preview) return null;
+                              return (
+                                <span
+                                  className="flex min-w-0 items-center gap-1 overflow-hidden text-xs text-muted-foreground"
+                                  data-testid="lookup-option-preview"
+                                >
+                                  {preview}
+                                </span>
+                              );
+                            })()}
                           </div>
                           {isSelected && (
                             <Badge variant="default" className="ml-2 shrink-0">{t('lookup.selectedBadge')}</Badge>

--- a/packages/fields/src/widgets/RecordPickerDialog.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.tsx
@@ -45,6 +45,18 @@ import { mergeFilterNodes } from '@object-ui/core';
 import { useSafeFieldLabel, useDisplayLocale } from '@object-ui/i18n';
 import { useFieldTranslation } from './useFieldTranslation.js';
 import { useRecordQuery } from './useRecordQuery.js';
+// The one place a lookup column's display value is decided — shared with the
+// inline dropdown in LookupField so a single `lookup_columns` declaration
+// cannot render two different ways (objectui#5492).
+import {
+  normalizeColumn,
+  fieldToLabel,
+  resolveSchemaOptions,
+  buildLookupColumnDescriptors,
+  renderLookupColumnValue,
+  type SchemaOption,
+  type LookupCellRendererResolver,
+} from './lookupColumnDisplay.js';
 
 /** Default page size for the Record Picker dialog */
 const DEFAULT_PAGE_SIZE = 10;
@@ -59,7 +71,7 @@ const SKELETON_ROW_COUNT = 5;
  * Cell renderer function signature — matches getCellRenderer from @object-ui/fields.
  * Accepts a field type and returns a React component that renders a formatted cell.
  */
-export type CellRendererResolver = (fieldType: string) => React.FC<{ value: any; field: any }>;
+export type CellRendererResolver = LookupCellRendererResolver;
 
 /**
  * Filter column definition used by the inline filter bar.
@@ -128,25 +140,6 @@ export interface RecordPickerGridSlotProps {
 }
 
 /**
- * Normalise a lookup_columns entry (string | LookupColumnDef) into a
- * concrete LookupColumnDef object.
- */
-function normalizeColumn(col: string | LookupColumnDef): LookupColumnDef {
-  return typeof col === 'string' ? { field: col } : col;
-}
-
-/**
- * Pretty-print a field name as a column header label.
- * Converts snake_case / camelCase to Title Case.
- */
-function fieldToLabel(field: string): string {
-  return field
-    .replace(/_/g, ' ')
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/\b\w/g, c => c.toUpperCase());
-}
-
-/**
  * Convert LookupFilterDef[] to a Record<string, any> compatible with
  * QueryParams.$filter.  Supports operator mapping for eq/ne/gt/lt/gte/lte/
  * contains/in/notIn.
@@ -187,41 +180,6 @@ export function lookupFiltersToRecord(
     }
   }
   return result;
-}
-
-/**
- * A select option as the object schema declares it — `{ value, label }` plus
- * whatever the renderer also reads (`color`, …), which the i18n translation
- * carries through untouched.
- */
-type SchemaOption = { value: any; label: string; [key: string]: any };
-
-/**
- * Resolve a field's select options from the referenced object's schema field
- * definition (`fieldsMeta[field]`), translated through the shared i18n option
- * path.
- *
- * This is the SINGLE source for both surfaces that need option labels: the
- * table cells (#3333) and the filter panel's select inputs (#3336) — so a
- * picker column and the filter input for that same column can never disagree
- * about what an option is called.
- *
- * Returns `undefined` when the schema field declares no options: a select
- * field with no authored options genuinely has nothing to offer, and
- * synthesising entries from the loaded page's raw stored values would paper
- * over the metadata gap with a list that changes per page.
- */
-function resolveSchemaOptions(
-  meta: { options?: unknown } | undefined,
-  objectName: string,
-  fieldName: string,
-  translateOptions: (o: string, f: string, opts: SchemaOption[]) => SchemaOption[],
-): SchemaOption[] | undefined {
-  const raw = meta?.options;
-  if (!Array.isArray(raw) || raw.length === 0) return undefined;
-  const options = raw as SchemaOption[];
-  if (!objectName) return options;
-  return translateOptions(objectName, fieldName, options);
 }
 
 /**
@@ -535,27 +493,13 @@ export function RecordPickerDialog({
     return [{ field: displayField, label: fieldToLabel(displayField) }];
   }, [columnsProp, displayField]);
 
-  // Field descriptors handed to the type-aware cell renderers, enriched from
-  // the referenced object's schema (`fieldsMeta`) the same way the list view
-  // enriches its columns. This is what lets a `select` column resolve its
-  // option label (options + i18n) instead of title-casing the raw value
-  // (#3333). Columns whose def carries no `type` inherit the schema field's
-  // type so authored string `lookup_columns` format identically.
-  const columnFieldDescriptors = useMemo<Record<string, any>>(() => {
-    const map: Record<string, any> = {};
-    for (const col of resolvedColumns) {
-      const meta = fieldsMeta?.[col.field];
-      const type = col.type ?? meta?.type;
-      if (!type) continue;
-      const descriptor: any = meta
-        ? { ...meta, name: col.field, type }
-        : { name: col.field, type };
-      const options = resolveSchemaOptions(meta, objectName, col.field, translateOptions);
-      if (options) descriptor.options = options;
-      map[col.field] = descriptor;
-    }
-    return map;
-  }, [resolvedColumns, fieldsMeta, objectName, translateOptions]);
+  // Field descriptors handed to the type-aware cell renderers — built by the
+  // SHARED helper, the same call the inline dropdown makes, so both surfaces
+  // enrich one `lookup_columns` declaration identically (objectui#5492).
+  const columnFieldDescriptors = useMemo<Record<string, any>>(
+    () => buildLookupColumnDescriptors(resolvedColumns, fieldsMeta, objectName, translateOptions),
+    [resolvedColumns, fieldsMeta, objectName, translateOptions],
+  );
 
   // Auto-generate filter columns from lookupFilters when no explicit filterColumns given.
   // Each LookupFilterDef becomes a filterable field with inferred type.
@@ -816,60 +760,21 @@ export function RecordPickerDialog({
     }
   }, [focusedRow]);
 
-  // Get display value for a cell — type-aware rendering when cellRenderer is provided
-  const renderCellContent = useCallback((record: any, col: LookupColumnDef): React.ReactNode => {
-    // When the column is the auto-inferred displayField column and the
-    // referenced object declares a `titleFormat`, render via the template so
-    // users see human-readable names instead of a raw id when the displayField
-    // (commonly defaulted to `name`) doesn't exist on the record.
-    if (titleFormat && col.field === displayField) {
-      const EMPTY = '\u0000';
-      const SEP = '[-\\u2013\\u2014|/·,:]';
-      let any = false;
-      const raw = titleFormat.replace(/\{([^{}]+)\}/g, (_m, key) => {
-        const v = (record as any)[key.trim()];
-        if (v !== null && v !== undefined && v !== '') {
-          any = true;
-          return String(v);
-        }
-        return EMPTY;
-      });
-      if (any) {
-        const out = raw
-          .replace(new RegExp(`\\s*${SEP}\\s*${EMPTY}`, 'g'), '')
-          .replace(new RegExp(`${EMPTY}\\s*${SEP}\\s*`, 'g'), '')
-          .replace(new RegExp(EMPTY, 'g'), '')
-          .replace(/\s+/g, ' ')
-          .trim();
-        if (out) return out;
-      }
-    }
-
-    const val = record[col.field];
-
-    // Use type-aware renderer when a field descriptor (column `type`, or the
-    // schema field's type via `fieldsMeta`) and a resolver are available.
-    const descriptor = columnFieldDescriptors[col.field];
-    if (descriptor && cellRenderer) {
-      const Renderer = cellRenderer(descriptor.type);
-      if (Renderer) {
-        return <Renderer value={val} field={descriptor} />;
-      }
-    }
-
-    // Fallback: plain text formatting
-    if (val === null || val === undefined) return '';
-    if (typeof val === 'object') {
-      // Handle MongoDB types / expanded references
-      if (val.$numberDecimal) return String(Number(val.$numberDecimal));
-      if (val.$oid) return String(val.$oid);
-      if (val.$date) return new Date(val.$date).toLocaleDateString(displayLocale);
-      if (val.name || val.label) return String(val.name || val.label);
-      return JSON.stringify(val);
-    }
-    if (typeof val === 'boolean') return val ? 'Yes' : 'No';
-    return String(val);
-  }, [cellRenderer, titleFormat, displayField, columnFieldDescriptors, displayLocale]);
+  // Get display value for a cell. Delegated to the SHARED lookup-column
+  // renderer (objectui#5492) — the inline dropdown in LookupField calls the
+  // very same function, so this table and that popover cannot answer one
+  // `lookup_columns` declaration two different ways.
+  const renderCellContent = useCallback(
+    (record: any, col: LookupColumnDef): React.ReactNode =>
+      renderLookupColumnValue(record, col, {
+        descriptors: columnFieldDescriptors,
+        cellRenderer,
+        titleFormat,
+        displayField,
+        displayLocale,
+      }),
+    [cellRenderer, titleFormat, displayField, columnFieldDescriptors, displayLocale],
+  );
 
   // Render sort indicator for a column
   const renderSortIcon = useCallback((field: string) => {
@@ -1279,7 +1184,12 @@ export function RecordPickerDialog({
                             </TableCell>
                           )}
                           {resolvedColumns.map(col => (
-                            <TableCell key={col.field} className="py-2.5">
+                            // `data-lookup-cell` names the column this cell
+                            // renders, so the two-surface agreement pin can
+                            // compare it against the inline dropdown's
+                            // `data-lookup-preview` for the same column
+                            // (objectui#5492).
+                            <TableCell key={col.field} className="py-2.5" data-lookup-cell={col.field}>
                               {renderCellContent(record, col)}
                             </TableCell>
                           ))}

--- a/packages/fields/src/widgets/lookupColumnDisplay.tsx
+++ b/packages/fields/src/widgets/lookupColumnDisplay.tsx
@@ -1,0 +1,232 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The ONE place that answers "what does column C of a candidate record
+ * display?" for a lookup field (objectui#5492).
+ *
+ * A lookup declares its columns once (`lookup_columns` / `lookupColumns`) and
+ * two surfaces consume that one declaration:
+ *
+ *   1. the inline dropdown under the form field (LookupField's popover), and
+ *   2. the "browse all records" picker (RecordPickerDialog's table).
+ *
+ * They used to answer differently. The picker resolved each cell through the
+ * type-aware cell renderer, while the dropdown built its option subtitle and
+ * its hover tooltip by plain string concatenation of the RAW stored value — so
+ * one declaration produced a resolved name in the picker and a bare foreign-key
+ * id in the dropdown, a formatted date beside a raw ISO timestamp, an option
+ * label beside an enum code. Both surfaces now call into this module, so the
+ * two cannot drift again: there is only one renderer left.
+ *
+ * Note what this module deliberately does NOT do: it does not widen the
+ * `lookupColumns` contract. Column entries stay bare field names — no dot
+ * paths, no populate/expand semantics. A lookup column whose value arrives as
+ * an unresolved foreign-key id is resolved the same way the picker has always
+ * resolved it — client-side, by the lookup cell renderer — so the two surfaces
+ * agree without either query changing.
+ */
+
+import React from 'react';
+import type { LookupColumnDef } from '@object-ui/types';
+
+/**
+ * Cell renderer function signature — matches `getCellRenderer` from
+ * `@object-ui/fields`. Re-declared here (rather than imported from
+ * RecordPickerDialog) so this module sits BELOW both consumers in the import
+ * graph and neither surface can pull the other in.
+ */
+export type LookupCellRendererResolver = (
+  fieldType: string,
+) => React.FC<{ value: any; field: any }>;
+
+/**
+ * A select option as the object schema declares it — `{ value, label }` plus
+ * whatever the renderer also reads (`color`, …), which the i18n translation
+ * carries through untouched.
+ */
+export type SchemaOption = { value: any; label: string; [key: string]: any };
+
+/** Translate a schema field's options through the shared i18n option path. */
+export type OptionTranslator = (
+  objectName: string,
+  fieldName: string,
+  options: SchemaOption[],
+) => SchemaOption[];
+
+/**
+ * Normalise a lookup_columns entry (string | LookupColumnDef) into a
+ * concrete LookupColumnDef object.
+ */
+export function normalizeColumn(col: string | LookupColumnDef): LookupColumnDef {
+  return typeof col === 'string' ? { field: col } : col;
+}
+
+/**
+ * Pretty-print a field name as a column header label.
+ * Converts snake_case / camelCase to Title Case.
+ */
+export function fieldToLabel(field: string): string {
+  return field
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/**
+ * Resolve a field's select options from the referenced object's schema field
+ * definition (`fieldsMeta[field]`), translated through the shared i18n option
+ * path.
+ *
+ * This is the SINGLE source for every surface that needs option labels: the
+ * picker table cells (#3333), the picker's filter panel select inputs (#3336)
+ * and the inline dropdown's option preview (#5492) — so a picker column, the
+ * filter input for that same column and the dropdown row can never disagree
+ * about what an option is called.
+ *
+ * Returns `undefined` when the schema field declares no options: a select
+ * field with no authored options genuinely has nothing to offer, and
+ * synthesising entries from the loaded page's raw stored values would paper
+ * over the metadata gap with a list that changes per page.
+ */
+export function resolveSchemaOptions(
+  meta: { options?: unknown } | undefined,
+  objectName: string,
+  fieldName: string,
+  translateOptions: OptionTranslator,
+): SchemaOption[] | undefined {
+  const raw = meta?.options;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const options = raw as SchemaOption[];
+  if (!objectName) return options;
+  return translateOptions(objectName, fieldName, options);
+}
+
+/**
+ * Field descriptors handed to the type-aware cell renderers, enriched from the
+ * referenced object's schema (`fieldsMeta`) the same way the list view enriches
+ * its columns. This is what lets a `select` column resolve its option label
+ * (options + i18n) instead of title-casing the raw value (#3333), and what
+ * carries `reference` / `reference_to` through to the lookup cell renderer so
+ * an unresolved foreign-key id resolves to a name (#5492).
+ *
+ * Columns whose def carries no `type` inherit the schema field's type, so
+ * string-authored `lookup_columns` format identically to object-authored ones.
+ */
+export function buildLookupColumnDescriptors(
+  columns: LookupColumnDef[],
+  fieldsMeta: Record<string, any> | undefined,
+  objectName: string,
+  translateOptions: OptionTranslator,
+): Record<string, any> {
+  const map: Record<string, any> = {};
+  for (const col of columns) {
+    const meta = fieldsMeta?.[col.field];
+    const type = col.type ?? meta?.type;
+    if (!type) continue;
+    const descriptor: any = meta ? { ...meta, name: col.field, type } : { name: col.field, type };
+    const options = resolveSchemaOptions(meta, objectName, col.field, translateOptions);
+    if (options) descriptor.options = options;
+    map[col.field] = descriptor;
+  }
+  return map;
+}
+
+export interface LookupColumnRenderContext {
+  /** Field descriptors from {@link buildLookupColumnDescriptors}. */
+  descriptors: Record<string, any>;
+  /** Type-aware renderer resolver; when absent every cell degrades to text. */
+  cellRenderer?: LookupCellRendererResolver;
+  /** The referenced object's `titleFormat`, applied to the display column. */
+  titleFormat?: string | null;
+  /** The lookup's display field — the column the title template stands in for. */
+  displayField?: string;
+  /** Locale for the plain-text `$date` fallback. */
+  displayLocale?: string;
+}
+
+/**
+ * Sentinel marking a template slot that resolved to nothing, so the separator
+ * around it can be stripped. Built with `fromCharCode` rather than written as
+ * a literal so no control byte — raw or escaped — ever lands in this source
+ * file (`scripts/check-control-bytes.mjs`).
+ */
+const EMPTY_SLOT = String.fromCharCode(0);
+
+/**
+ * Render one column of one candidate record.
+ *
+ * Order:
+ *   1. `titleFormat` template, for the display column only — so users see a
+ *      human-readable name instead of a raw id when the display field
+ *      (commonly defaulted to `name`) does not exist on the record.
+ *   2. the type-aware cell renderer for the column's field descriptor.
+ *   3. a plain-text fallback for columns with no descriptor / no resolver.
+ *
+ * Step 3 never blanks a populated value: an object with no recognised shape
+ * keeps its JSON and a primitive keeps its `String()` form. That floor is
+ * deliberate — an unresolved reference showing its bare id is strictly better
+ * than a silently empty column (objectui#5492).
+ */
+export function renderLookupColumnValue(
+  record: any,
+  col: LookupColumnDef,
+  ctx: LookupColumnRenderContext,
+): React.ReactNode {
+  const { descriptors, cellRenderer, titleFormat, displayField, displayLocale } = ctx;
+
+  // When the column is the auto-inferred displayField column and the
+  // referenced object declares a `titleFormat`, render via the template so
+  // users see a human-readable name instead of a raw id.
+  if (titleFormat && col.field === displayField) {
+    const SEP = '[-\\u2013\\u2014|/·,:]';
+    let any = false;
+    const raw = titleFormat.replace(/\{([^{}]+)\}/g, (_m, key) => {
+      const v = (record as any)?.[key.trim()];
+      if (v !== null && v !== undefined && v !== '') {
+        any = true;
+        return String(v);
+      }
+      return EMPTY_SLOT;
+    });
+    if (any) {
+      const out = raw
+        .replace(new RegExp(`\\s*${SEP}\\s*${EMPTY_SLOT}`, 'g'), '')
+        .replace(new RegExp(`${EMPTY_SLOT}\\s*${SEP}\\s*`, 'g'), '')
+        .replace(new RegExp(EMPTY_SLOT, 'g'), '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (out) return out;
+    }
+  }
+
+  const val = record?.[col.field];
+
+  // Use the type-aware renderer when a field descriptor (column `type`, or the
+  // schema field's type via `fieldsMeta`) and a resolver are available.
+  const descriptor = descriptors[col.field];
+  if (descriptor && cellRenderer) {
+    const Renderer = cellRenderer(descriptor.type);
+    if (Renderer) {
+      return <Renderer value={val} field={descriptor} />;
+    }
+  }
+
+  // Fallback: plain text formatting.
+  if (val === null || val === undefined) return '';
+  if (typeof val === 'object') {
+    // Handle MongoDB types / expanded references
+    if (val.$numberDecimal) return String(Number(val.$numberDecimal));
+    if (val.$oid) return String(val.$oid);
+    if (val.$date) return new Date(val.$date).toLocaleDateString(displayLocale);
+    if (val.name || val.label) return String(val.name || val.label);
+    return JSON.stringify(val);
+  }
+  if (typeof val === 'boolean') return val ? 'Yes' : 'No';
+  return String(val);
+}


### PR DESCRIPTION
Fixes #5492

## The disagreement

A lookup field offers two ways to pick a related record, and both read **one**
`lookup_columns` declaration:

| surface | where it lives | how it rendered a column |
|---|---|---|
| inline dropdown | the quick-select popover under the form field | raw stored value |
| browse-all picker | `RecordPickerDialog`'s table behind "show all results" | the type-aware cell renderer |

Both code paths, re-derived on `origin/main` at `cad512fe1` and named as the
card asks:

- **the concatenation site (dropdown, defective)** — two of them, in
  `packages/fields/src/widgets/LookupField.tsx`:
  - the option **subtitle** came from `recordToOption`, which set
    `description = record[descriptionField]` and printed it verbatim;
  - the option **tooltip** came from `previewOf`, which built
    `` `${lbl}: ${text}` `` per column, `text` being the raw value, and dropped
    the result into the row's `title` attribute.
- **the cell-renderer path (picker, correct)** —
  `RecordPickerDialog.renderCellContent`, which looked each column up in
  `columnFieldDescriptors` (enriched from the referenced object's schema) and
  rendered it through the resolver `LookupField` hands it as
  `cellRenderer={getCellRendererResolver()}`.

Measured on the branch, driving the same declaration through both surfaces
(this is the ablation output, quoted verbatim below):

```
column       inline dropdown (before)          browse-all picker
work_step    Zz9QwErTyUiOpAsD  (bare FK id)    —
planned_on   2026-08-20T00:00:00.000Z (ISO)    Aug 20
status       pending           (enum code)     Pending approval
```

## The fix

A new shared module, `packages/fields/src/widgets/lookupColumnDisplay.tsx`,
becomes the one place that answers "what does column C of this candidate
record display?". It owns column normalisation, the field-descriptor
enrichment from the referenced object's schema, and the render itself.

- `RecordPickerDialog` now builds `columnFieldDescriptors` with
  `buildLookupColumnDescriptors` and implements `renderCellContent` as a call
  to `renderLookupColumnValue`. Its behaviour is unchanged — the logic moved,
  it was not rewritten.
- `LookupField` builds the **same** descriptors from the same
  `refObjectSchema.fields` and renders its option preview through the **same**
  `renderLookupColumnValue`. The subtitle and the old tooltip merge into one
  rendered preview line in the option row; the row's `title` now carries the
  full option label, which is what a truncated label actually needs, instead of
  a raw-value dump.

There is one renderer left, so the two surfaces cannot drift apart again.

### The cost this accepts, stated plainly

Resolving a foreign key to a name is a client-side fetch, so a dropdown page
that previously rendered ids now mounts one lookup cell renderer per lookup
column per option, up to the popover's page size of 50. Those resolutions are
deduplicated by the module-level name cache the picker already fills, and only
`lookup`-typed columns fetch at all — a date or a select column is pure
formatting. It is the same work the picker has always done over its (smaller,
10-row) page, and it is the work the reporter is asking for: the alternative to
the fetch is the bare id. Flagging it because it is a real change in request
volume on popover open, not because it is believed to be a problem.

## What is deliberately NOT here

No query changed and no contract widened. `lookupColumns` entries stay bare
field names — no dot-path, no populate/expand semantics — and this fix does not
need them: **neither** surface's request carries populate. Re-derived on the
branch, `LookupField` and `RecordPickerDialog` both call `useRecordQuery`
without an `expand` argument. The picker resolved foreign-key ids to names
purely client-side all along, in `LookupCellRenderer` via its fetch-on-demand
`useLookupName` plus a module-level name cache. The dropdown now inherits
exactly that resolution. So the spec-widening ask on the card is not a
prerequisite for the primary defect, and is not attempted here.

## The unresolved-id decision

Because no populate is involved, a lookup column's value can legitimately be an
id that resolves to nothing. The decision: **the dropdown adopts whatever the
picker shows, and the column is never dropped.**

- A column is previewed when the record **holds** a value for it. That is
  decided on the **raw** value, never on what the renderer makes of it — so an
  unresolved id keeps its slot.
- What renders in that slot is the lookup cell renderer's own placeholder for a
  present-but-unnamed reference (a muted en dash, still wrapped in the
  referenced-record link so the reference stays openable), not the shared
  empty-value slot that means "this record has nothing here". The test asserts
  that distinction structurally, not by glyph.
- This is strictly above the floor the card sets. The silent-empty outcome it
  reports for a dot-path attempt is the case where the column disappears; that
  is what the raw-value presence rule rules out.

## Tests

`packages/fields/src/widgets/LookupField.pickerAgreement.test.tsx` pins the
**disagreement**, not either surface alone: it drives one `lookup_columns`
declaration through the inline dropdown and through the browse-all picker and
compares them column for column, for a lookup, a date and a select field, in
two states — a reference that resolves and one that does not.

Reverse-verification, both mutations proved on disk with anchored `grep -c` in
both directions plus `git diff --stat`, restored by a `trap ... EXIT INT TERM`,
tree confirmed byte-identical afterwards (`git status --porcelain` empty, marker
sweep 0/0). No rebuild leg is needed and that is a property of the resolution
path, not an assumption: the test reaches every mutated file through a
**relative** specifier inside `packages/fields/src`, so nothing resolves through
a sibling package's `exports` to a `dist` tree.

- **Ablation A** — the dropdown stops calling the shared renderer and prints the
  raw value again (the pre-fix behaviour). Anchor count 1 to 0, marker 0 to 1,
  `1 insertion(+), 5 deletions(-)`. Predicted red, observed red: **2 of 2 tests
  failed**, and the failure diff reproduces the card's table exactly (the block
  quoted above is that diff). The fallback assertions behaved as predicted —
  `present`, `emptySlot === false` and non-empty still **passed** under the
  ablation, because the bare id is also non-empty. They are a floor the fix must
  not fall below, not a detector for this mutation; the agreement assertion is
  what turns red.
- **Ablation B** — the shared module stops using the cell renderer at all.
  Anchor count 1 to 0, marker 0 to 1, `1 insertion(+), 1 deletion(-)`. Predicted
  and observed: both surfaces degrade **together**, so the agreement assertion
  keeps passing while the concrete renderings go red
  (`expected 'T5MsMCuwP4t_yUHq' to be 'Fitting, Line A'`,
  `expected 'pending' to be 'Pending approval'`). That is the proof that the
  shared module is the live renderer for **both** surfaces and not just for one.

## Gates

Exit codes captured before any pipe; each verdict is the gate's own line.

| gate | verdict |
|---|---|
| `pnpm --filter @object-ui/fields type-check` | `os-verify-lock: VERDICT command-exit 0` (`tsc --noEmit && tsc -p tsconfig.test.json`, no diagnostics) |
| `pnpm --filter @object-ui/fields lint` | `os-verify-lock: VERDICT command-exit 0` — `✖ 869 problems (0 errors, 869 warnings)` over 190 files |
| `pnpm exec vitest run packages/fields/` (repo root) | `Test Files 111 passed (111)` / `Tests 1839 passed (1839)` |
| `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 4645 tracked text file(s))` |
| `node scripts/check-changeset-presence.mjs` | `✅ 4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |
| `node scripts/check-changeset-fixed.mjs` | `✅ All workspace packages are in the changeset fixed group.` |
| `pnpm check:i18n-keys` | `✅ every in-scope call-site key resolves against the en pack` (no `t()` call site changed) |
| `pnpm check:phantom-deps` | `✅ Every in-scope import is declared by the package that publishes it.` |
| `pnpm check:self-import` | `✅ No package names itself inside its own src/.` |
| `pnpm check:esm-specifiers` | `Specifier leg: no un-ledgered package emits an extensionless relative specifier.` |
| `pnpm check:spec-symbols` | `✅ spec symbol derivation: 1289 files scanned` |
| `pnpm check:action-forward-parity` | exit 0 |
| `pnpm check:i18n-drift` | `No en value changed in this range.` |
| `node scripts/check-type-check-coverage.mjs` | `✅ type-check coverage: 45/46 ... ✅ test type-check coverage: 41/41` |
| `node scripts/check-lint-coverage.mjs` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors` |

All of the above ran on the final commit's tree, `6582f0d2b`, with
`git status --porcelain` empty. `type-check` and `lint` were re-run on that
exact tree after the last edit, so no verdict here reports a tree that is no
longer HEAD.

**Declared narrowing.** Lint ran over `packages/fields` (190 files, from
eslint's `--format json` output) rather than the repo-wide `eslint .`. It cannot
hide a failure elsewhere: `eslint.config.js` declares no `project` /
`projectService`, so type-aware linting is off and every file's verdict is a
function of its own text — this diff touches five files, four of them under
`packages/fields/src` and one changeset, so no untouched file's verdict can
move. The population is read from eslint's own configuration by
`check-lint-coverage.mjs`, which reports 46/46 packages in scope at 0 outstanding
errors. Type-check was likewise narrowed to `@object-ui/fields`: the only
publicly visible type change is `CellRendererResolver`, which becomes an alias
of a structurally identical type, and the new module is not re-exported from the
package barrel. `pnpm check:eager-closure` was not run — it reads
`apps/console/dist/eager-closure.json` and reports itself a broken gauge without
a console build; that build is CI's, and this diff does not touch the console.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_
