### PR TITLE
app-shell: give the pre-publish security block a way to the object it names

### DIFF
--- a/.changeset/surface-deeplink-live-channel-5476.md
+++ b/.changeset/surface-deeplink-live-channel-5476.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Studio's pre-publish security block can now take you to the object it names.
+
+The pending-changes sheet reports what the publish door would refuse — as
+`object/crmext_visit`, with the rule's fix-it hint and "Fix it on the object under
+Settings → Record sharing". Naming it was the half that shipped; reaching it was not.
+The `?surface=<type>:<name>` deep-link that would have carried the author there
+captures the URL exactly ONCE, at mount, and the sheet is opened over an
+already-mounted pillar — so writing the param changed the URL and moved nothing.
+
+That mount-time capture is deliberate and stays exactly as it was: the mirror half
+rewrites the param on every in-pillar selection, so a capture that followed the URL
+would re-trigger its restore on each one. What was missing is a third half — a live
+target delivered BESIDE the URL, which is what a producer already inside the pillar
+needs. `surfaceDeepLinkChannel` adds it: producers ask for a surface by identity
+(`{type, name}`), the host routes cross-pillar requests back through the URL (that
+pillar is unmounted, so its capture is the right mechanism) and vetoes the ones the
+author declines over unsaved edits, and the mounted pillar applies the rest.
+
+Applied AT MOST ONCE, by a monotonic id. A standing request re-resolved on the next
+rail reload would drag the author back off whatever they had since selected — the
+regression the mount-time ref exists to prevent — so `DataPillar.surfaceRequest.test`
+pins a hand-picked object surviving a package switch, and
+`surfaceDeepLinkChannel.test` pins the capture itself as an unchanged control: it
+still ignores every URL change after mount, and a live request never moves it.
+
+The sheet's other home is the Home / draft-preview bar, where the Studio object editor
+is not a reachable destination at all. Reachability is answered structurally — the
+producer hook returns `null` when no host published the channel — so off-Studio the
+item name stays the prose #5418 shipped rather than becoming a link to nowhere. Both
+directions are assertions in `DraftChangesPanel.securityLink.test`, not a comment.
+
+Nothing the other three pillars observe changed: `useSurfaceDeepLink` keeps its
+signature, its return and its behaviour, and only the Data pillar subscribes to the
+new channel. The channel is its own React-only module on purpose — importing the hook
+into the sheet would have pulled `nav-selection` and the App-nav inspector into the
+console's eager graph.

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -51,6 +51,11 @@ import { useObjectTranslation } from '@object-ui/i18n';
 // refuses, and a faithful copy is exactly the fork that guard exists to prevent.
 import { canonicalMetaUrlType } from '@objectstack/spec/shared';
 import { diffFields } from '../views/metadata-admin/previews/object-fields-io.js';
+// The live `?surface=` channel, and NOT `useSurfaceDeepLink` beside it: this
+// import must stay React-only, because that module reaches `nav-selection.js`
+// and through it the App-nav inspector, and this panel sits in the console's
+// EAGER graph (see the `@objectstack/spec` note above for what that costs).
+import { useSurfaceNavigator } from '../views/studio-design/surfaceDeepLinkChannel.js';
 import { lintDraftSecurityPosture, type DraftSecurityProblem } from './securityPostureLint.js';
 
 export interface DraftChangeEntry {
@@ -330,6 +335,12 @@ export function DraftChangesPanel({
    * arrives after the batch has already rolled back.
    */
   const [problems, setProblems] = useState<DraftSecurityProblem[]>([]);
+  /**
+   * Null wherever no host listens for a surface request — the degradation this
+   * panel owes its second home (Home / the draft-preview bar). Never a route
+   * string test: reachability is answered by the tree that mounted us.
+   */
+  const openSurface = useSurfaceNavigator();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   const toggleExpanded = useCallback((key: string) => {
@@ -541,10 +552,28 @@ export function DraftChangesPanel({
                   {/* `type/name`, the way the server's own publish refusal names
                       the item (`object/crmext_visit: …`) — and, unlike a bare
                       name, text that cannot collide with the same draft's row in
-                      the list above. */}
-                  <span className="font-mono">
-                    {p.type}/{p.name}
-                  </span>{' '}
+                      the list above.
+
+                      Clickable ONLY where a host publishes the surface channel,
+                      i.e. inside Studio. This sheet is shared with the Home /
+                      draft-preview bar, where the designer is not a reachable
+                      destination at all: there `openSurface` is null and the
+                      name stays the plain prose it has always been, because a
+                      link that goes nowhere is worse than the sentence below
+                      telling you where to go. */}
+                  {openSurface ? (
+                    <button
+                      type="button"
+                      onClick={() => openSurface({ type: p.type, name: p.name })}
+                      className="font-mono underline decoration-dotted underline-offset-2 hover:text-amber-950 dark:hover:text-amber-100"
+                    >
+                      {p.type}/{p.name}
+                    </button>
+                  ) : (
+                    <span className="font-mono">
+                      {p.type}/{p.name}
+                    </span>
+                  )}{' '}
                   — {p.hint || p.message}
                 </li>
               ))}

--- a/packages/app-shell/src/preview/__tests__/DraftChangesPanel.securityLink.test.tsx
+++ b/packages/app-shell/src/preview/__tests__/DraftChangesPanel.securityLink.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The security block's item name becomes a way IN — objectui#5476.
+ *
+ * objectui#5418 gave the pre-publish block the right words: it names the draft
+ * the publish door would refuse (`object/crmext_visit`), quotes the rule's
+ * fix-it hint, and says "Fix it on the object under Settings → Record
+ * sharing". What it could not do was take you there.
+ *
+ * This suite pins both directions of that, because only one of them is new:
+ *
+ *  - Inside Studio a host publishes the surface channel, so the name is a
+ *    control that asks for that exact object.
+ *  - This sheet's OTHER home is the Home / draft-preview bar, where the Studio
+ *    object editor is not a reachable destination at all. There the name stays
+ *    the prose it has always been. A link that goes nowhere would be strictly
+ *    worse than the sentence telling you where to go, so the degradation is
+ *    asserted here rather than described in a comment.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within, fireEvent, cleanup } from '@testing-library/react';
+
+// Same targeted override as the sibling security suite: `@object-ui/components`
+// pulls `createSafeTranslation` from this module, so a bare object mock breaks
+// at import time rather than at assert time.
+vi.mock('@object-ui/i18n', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/i18n')>();
+  return {
+    ...mod,
+    useObjectTranslation: () => ({
+      t: (_k: string, o?: { defaultValue?: string; count?: number }) =>
+        (o?.defaultValue ?? _k).replace('{{count}}', String(o?.count ?? '')),
+    }),
+  };
+});
+
+import { DraftChangesPanel } from '../DraftChangesPanel';
+import { SurfaceDeepLinkProvider } from '../../views/studio-design/surfaceDeepLinkChannel';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The card's own object: created through `新建对象`, never given an OWD. */
+const OWD_LESS_VISIT = {
+  name: 'crmext_visit',
+  label: '客户拜访',
+  fields: { name: { type: 'text', label: '名称' } },
+};
+
+function mockRoutes() {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+    if (url.includes('/_drafts')) {
+      return ok([{ type: 'object', name: 'crmext_visit', packageId: 'com.test.crmext' }]);
+    }
+    if (url.includes('state=draft')) {
+      return ok({ type: 'object', name: 'crmext_visit', item: OWD_LESS_VISIT });
+    }
+    if (/\/meta\/object(\?|$)/.test(url)) return ok([]);
+    return { ok: false, status: 404, json: async () => ({}) };
+  }) as unknown as typeof fetch;
+}
+
+const panel = <DraftChangesPanel open onOpenChange={() => {}} packageId="com.test.crmext" onPublish={vi.fn()} />;
+
+describe('DraftChangesPanel — reaching the object the publish door refuses (objectui#5476)', () => {
+  it('offers the named item as a control that asks for that surface, inside Studio', async () => {
+    mockRoutes();
+    const onRequest = vi.fn();
+    render(<SurfaceDeepLinkProvider onRequest={onRequest}>{panel}</SurfaceDeepLinkProvider>);
+
+    const block = await screen.findByTestId('draft-security-problems');
+    const link = within(block).getByRole('button', { name: 'object/crmext_visit' });
+    fireEvent.click(link);
+
+    // The surface identity, not a Studio route the sheet had to know how to build.
+    expect(onRequest).toHaveBeenCalledWith({ type: 'object', name: 'crmext_visit' });
+  });
+
+  it('degrades to prose where nothing is listening — the Home / draft-preview bar', async () => {
+    mockRoutes();
+    render(panel);
+
+    const block = await screen.findByTestId('draft-security-problems');
+    // No control at all — not a disabled one, not a dead anchor.
+    expect(within(block).queryByRole('button', { name: 'object/crmext_visit' })).toBeNull();
+    expect(within(block).queryByRole('link')).toBeNull();
+    // And what #5418 shipped is intact: the item is still named, and the
+    // sentence still says where to fix it.
+    expect(block.textContent).toContain('object/crmext_visit');
+    expect(block.textContent).toMatch(/Settings → Record sharing/);
+  });
+});

--- a/packages/app-shell/src/views/studio-design/DataPillar.surfaceRequest.test.tsx
+++ b/packages/app-shell/src/views/studio-design/DataPillar.surfaceRequest.test.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Data pillar applies a LIVE surface request — objectui#5476.
+ *
+ * Studio's pre-publish security block names `object/crmext_visit` from a sheet
+ * opened over this pillar while it is already mounted, so the `?surface=`
+ * capture (read once, at mount) can never serve it. The pillar subscribes to
+ * the channel instead, and this suite drives that end to end through the
+ * pillar's OWN mirror: the surface param the pillar writes back is the
+ * observable proof that its selection actually moved, not a spy on the wiring.
+ *
+ * The second test is the more important one. The request is applied AT MOST
+ * ONCE by construction, because a standing request re-resolved on the next
+ * rail reload would drag the author off whatever they had since chosen — the
+ * exact regression the mount-time ref was introduced to prevent.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter, useSearchParams } from 'react-router-dom';
+
+const objectDef = {
+  name: 'showcase_project',
+  label: 'Project',
+  fields: [{ name: 'title', label: 'Title', type: 'text' }],
+};
+
+const mockClient = {
+  list: vi.fn(async () => [
+    { name: 'showcase_project', label: 'Project' },
+    { name: 'crmext_visit', label: 'Visit' },
+  ]),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async () => ({ effective: objectDef, code: objectDef })),
+  getDraft: vi.fn(async () => null),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({ entries: [] }),
+  };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+import { DataPillar } from './StudioDesignSurface';
+import { SurfaceDeepLinkProvider, useSurfaceNavigator } from './surfaceDeepLinkChannel';
+import { registerBuiltinInspectors } from '../metadata-admin/inspectors';
+
+registerBuiltinInspectors();
+
+afterEach(cleanup);
+
+/** What the pillar mirrored back to the URL — i.e. what it currently has open. */
+function OpenSurface(): React.ReactElement {
+  const [params] = useSearchParams();
+  return <span data-testid="open-surface">{params.get('surface') ?? 'none'}</span>;
+}
+
+/** Stands in for the pending-changes sheet's security block. */
+function Producer(): React.ReactElement {
+  const openSurface = useSurfaceNavigator();
+  return (
+    <button type="button" onClick={() => openSurface?.({ type: 'object', name: 'crmext_visit' })}>
+      object/crmext_visit
+    </button>
+  );
+}
+
+function renderPillar(packageId = 'com.example.showcase') {
+  return render(
+    <MemoryRouter initialEntries={[`/studio/${packageId}/data`]}>
+      <SurfaceDeepLinkProvider>
+        <OpenSurface />
+        <Producer />
+        <DataPillar packageId={packageId} />
+      </SurfaceDeepLinkProvider>
+    </MemoryRouter>,
+  );
+}
+
+const openSurface = () => screen.getByTestId('open-surface');
+
+describe('DataPillar — a surface requested after mount (objectui#5476)', () => {
+  it('opens the object the request names, with no remount and no URL to capture', async () => {
+    renderPillar();
+    // Nothing deep-linked: the rail opens its first item, as it always has.
+    await waitFor(() => expect(openSurface()).toHaveTextContent('object:showcase_project'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'object/crmext_visit' }));
+
+    await waitFor(() => expect(openSurface()).toHaveTextContent('object:crmext_visit'));
+  });
+
+  it('never re-applies it: a later selection survives the next rail reload', async () => {
+    const { rerender } = renderPillar();
+    await waitFor(() => expect(openSurface()).toHaveTextContent('object:showcase_project'));
+    fireEvent.click(screen.getByRole('button', { name: 'object/crmext_visit' }));
+    await waitFor(() => expect(openSurface()).toHaveTextContent('object:crmext_visit'));
+
+    // The author moves on, by hand, in the rail.
+    fireEvent.click(screen.getByRole('button', { name: 'Project' }));
+    await waitFor(() => expect(openSurface()).toHaveTextContent('object:showcase_project'));
+
+    // Now the rail reloads (here: a package switch — same list, fresh array).
+    // A request that is still standing would yank them back to the object the
+    // sheet named, minutes after they left it.
+    const loadsBefore = mockClient.list.mock.calls.length;
+    rerender(
+      <MemoryRouter initialEntries={['/studio/com.example.other/data']}>
+        <SurfaceDeepLinkProvider>
+          <OpenSurface />
+          <Producer />
+          <DataPillar packageId="com.example.other" />
+        </SurfaceDeepLinkProvider>
+      </MemoryRouter>,
+    );
+    // The reload has to have actually HAPPENED for the rest to mean anything:
+    // an assertion that nothing moved is satisfied perfectly by nothing
+    // running at all.
+    await waitFor(() => expect(mockClient.list.mock.calls.length).toBeGreaterThan(loadsBefore));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(openSurface()).toHaveTextContent('object:showcase_project');
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -79,6 +79,8 @@ import { getMetadataDefaultInspector } from '../metadata-admin/default-inspector
 import { useMetadataClient, useMetadataTypes } from '../metadata-admin/useMetadata.js';
 import {
   DESIGNER_SEL_PARAM,
+  DESIGNER_SURFACE_PARAM,
+  formatSurfaceParam,
   parseNavSelParam,
   formatNavSelParam,
   findNavPositionById,
@@ -88,7 +90,8 @@ import { SourcePageEditor } from '../metadata-admin/previews/SourcePageEditor.js
 import { formatMetadataError, formatPublishFailures, type PublishFailure } from './metadataError.js';
 import { loadPackageSurfaces } from './packageSurfaces.js';
 import { resolveSurface, findSurfaceInTree, type NavNode, type Surface } from './navSurface.js';
-import { useSurfaceDeepLink, resolveSurfaceDeepLink } from './useSurfaceDeepLink.js';
+import { useSurfaceDeepLink, resolveSurfaceDeepLink, type SurfaceTarget } from './useSurfaceDeepLink.js';
+import { SurfaceDeepLinkProvider, useRequestedSurface } from './surfaceDeepLinkChannel.js';
 import { buildObjectSkeleton, buildFlowSkeleton, buildAppSkeleton, buildPermissionSkeleton } from './skeletons.js';
 import { OWD_CREATE_MODELS, OWD_DEFAULT, type OwdCreateModel } from './owd-sharing.js';
 import { t, tFormat, useMetadataLocale } from '../metadata-admin/i18n.js';
@@ -149,6 +152,20 @@ const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> =
   { key: 'interfaces', label: 'Interfaces', Icon: LayoutDashboard },
   { key: 'access', label: 'Access', Icon: Shield },
 ];
+
+/**
+ * Which pillar owns a surface type — the routing half of a live surface
+ * request (see surfaceDeepLinkChannel). Only the types a pillar actually
+ * RESOLVES are listed, mirroring the `resolveSurfaceDeepLink` call sites
+ * below; an unlisted type is delivered in place rather than guessed at,
+ * because navigating to the wrong pillar costs the author their position and
+ * buys nothing.
+ */
+const PILLAR_FOR_SURFACE_TYPE: Readonly<Record<string, string>> = {
+  object: 'data',
+  flow: 'automations',
+  permission: 'access',
+};
 
 const KIND_ICON: Record<string, LucideIcon> = {
   group: Folder,
@@ -614,194 +631,226 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   // — the cloud edition migrates on its own schedule.
   const chatDockMode = !aiSlot;
 
+  /**
+   * Host side of the live `?surface=` channel. Producers below the provider —
+   * today the pending-changes sheet's security block, which names a draft the
+   * publish door would refuse — hand us a surface identity and we put the
+   * author in front of it:
+   *
+   *  - ANOTHER pillar's surface still travels through the URL, because that
+   *    pillar is unmounted and its mount-time capture is the mechanism built
+   *    for exactly this. Vetoed (`false`) when the author declines to abandon
+   *    unsaved edits, so a request never outlives the navigation it needed.
+   *  - THIS pillar's surface is the case the capture cannot serve at all —
+   *    nothing remounts — so the channel carries it and the pillar applies it
+   *    once.
+   *
+   * Either way the sheet closes: a selection nobody can see is not navigation.
+   */
+  const requestSurface = React.useCallback(
+    (target: SurfaceTarget): boolean | void => {
+      const pillar = PILLAR_FOR_SURFACE_TYPE[target.type];
+      if (pillar && pillar !== tab) {
+        if (!confirmLeavePillar()) return false;
+        shellNavigate(
+          `/studio/${packageId}/${pillar}?${DESIGNER_SURFACE_PARAM}=${encodeURIComponent(formatSurfaceParam(target))}`,
+        );
+      }
+      setChangesOpen(false);
+    },
+    [tab, packageId, confirmLeavePillar, shellNavigate],
+  );
+
   return (
-    <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
-      {/* The ADR-0080 `aiSlot` seam — a cloud edition may still inject its own
-        * left copilot panel; the built-in copilot is the RIGHT dock below. */}
-      {aiSlot ? (
-        <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside>
-      ) : null}
+    <SurfaceDeepLinkProvider onRequest={requestSurface}>
+      <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
+        {/* The ADR-0080 `aiSlot` seam — a cloud edition may still inject its own
+          * left copilot panel; the built-in copilot is the RIGHT dock below. */}
+        {aiSlot ? (
+          <aside className="w-64 shrink-0 overflow-auto border-r bg-muted/40">{aiSlot}</aside>
+        ) : null}
 
-      <div className="flex min-w-0 flex-1 flex-col">
-        {/* `overflow-x-auto` — none of Package/pillars/Publish shrink (all
-          * `shrink-0`, and PackageSwitcher's trigger is `whitespace-nowrap`),
-          * so on a narrow viewport this whole strip overflows instead of any
-          * one piece silently clipping off past the screen edge. Scrolling
-          * the header is a worse look than a proper responsive redesign, but
-          * it guarantees every pillar and the Publish button stay reachable. */}
-        <header className="flex items-center gap-3 overflow-x-auto border-b px-3 py-2">
-          {/* Never a dead end: walk back to the platform Home / builder landing. */}
-          <button
-            type="button"
-            onClick={() => {
-              if (!confirmLeavePillar()) return;
-              shellNavigate('/home');
-            }}
-            title={t('engine.studio.home', locale)}
-            className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            <HomeIcon className="h-4 w-4" />
-          </button>
-          <div className="shrink-0">
-            <PackageSwitcher packageId={packageId} tab={tab} beforeNavigate={confirmLeavePillar} />
-          </div>
-          <span className="shrink-0 text-muted-foreground">·</span>
-          <nav className="flex shrink-0 gap-1">
-            {PILLARS.map((p) => (
-              <Link
-                key={p.key}
-                to={`/studio/${packageId}/${p.key}`}
-                onClick={(e) => {
-                  // Re-clicking the open pillar re-navigates to the same URL —
-                  // nothing unmounts. Modified/aux clicks open a new tab and
-                  // leave this one (and its edits) alone; react-router defers
-                  // those to the browser, so don't veto them either.
-                  if (tab === p.key) return;
-                  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-                  if (!confirmLeavePillar()) e.preventDefault();
-                }}
-                className={
-                  'inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-colors ' +
-                  (tab === p.key
-                    ? 'bg-primary/10 font-medium text-primary'
-                    : 'text-muted-foreground hover:bg-muted hover:text-foreground')
-                }
-              >
-                <p.Icon className="h-3.5 w-3.5" />
-                {t(`engine.studio.pillar.${p.key}`, locale)}
-              </Link>
-            ))}
-          </nav>
+        <div className="flex min-w-0 flex-1 flex-col">
+          {/* `overflow-x-auto` — none of Package/pillars/Publish shrink (all
+            * `shrink-0`, and PackageSwitcher's trigger is `whitespace-nowrap`),
+            * so on a narrow viewport this whole strip overflows instead of any
+            * one piece silently clipping off past the screen edge. Scrolling
+            * the header is a worse look than a proper responsive redesign, but
+            * it guarantees every pillar and the Publish button stay reachable. */}
+          <header className="flex items-center gap-3 overflow-x-auto border-b px-3 py-2">
+            {/* Never a dead end: walk back to the platform Home / builder landing. */}
+            <button
+              type="button"
+              onClick={() => {
+                if (!confirmLeavePillar()) return;
+                shellNavigate('/home');
+              }}
+              title={t('engine.studio.home', locale)}
+              className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <HomeIcon className="h-4 w-4" />
+            </button>
+            <div className="shrink-0">
+              <PackageSwitcher packageId={packageId} tab={tab} beforeNavigate={confirmLeavePillar} />
+            </div>
+            <span className="shrink-0 text-muted-foreground">·</span>
+            <nav className="flex shrink-0 gap-1">
+              {PILLARS.map((p) => (
+                <Link
+                  key={p.key}
+                  to={`/studio/${packageId}/${p.key}`}
+                  onClick={(e) => {
+                    // Re-clicking the open pillar re-navigates to the same URL —
+                    // nothing unmounts. Modified/aux clicks open a new tab and
+                    // leave this one (and its edits) alone; react-router defers
+                    // those to the browser, so don't veto them either.
+                    if (tab === p.key) return;
+                    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+                    if (!confirmLeavePillar()) e.preventDefault();
+                  }}
+                  className={
+                    'inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-colors ' +
+                    (tab === p.key
+                      ? 'bg-primary/10 font-medium text-primary'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground')
+                  }
+                >
+                  <p.Icon className="h-3.5 w-3.5" />
+                  {t(`engine.studio.pillar.${p.key}`, locale)}
+                </Link>
+              ))}
+            </nav>
 
-          {/* Package-level draft review + one atomic publish (replaces per-item 发布) */}
-          <div className="ml-auto flex shrink-0 items-center gap-2">
-            {packageApp ? (
+            {/* Package-level draft review + one atomic publish (replaces per-item 发布) */}
+            <div className="ml-auto flex shrink-0 items-center gap-2">
+              {packageApp ? (
+                <button
+                  type="button"
+                  onClick={() => window.open(resolveConsoleUrl(`apps/${encodeURIComponent(packageApp.name)}`), '_blank')}
+                  title={tFormat('engine.studio.app.openTitle', locale, { label: packageApp.label })}
+                  className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                  {t('engine.studio.app.open', locale)}
+                </button>
+              ) : appDraftPending ? (
+                <span
+                  title={t('engine.studio.app.willOpenAfterPublish', locale)}
+                  className="rounded bg-amber-400/15 px-2 py-0.5 text-[11px] text-amber-600 dark:text-amber-300"
+                >
+                  {tFormat('engine.studio.app.pending', locale, { label: appDraftPending })}
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setAppCreating(true)}
+                  disabled={readOnly}
+                  title={readOnly ? t('engine.studio.pkg.readonlyHint', locale) : t('engine.studio.app.noneTitle', locale)}
+                  className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  {t('engine.studio.app.create', locale)}
+                </button>
+              )}
               <button
                 type="button"
-                onClick={() => window.open(resolveConsoleUrl(`apps/${encodeURIComponent(packageApp.name)}`), '_blank')}
-                title={tFormat('engine.studio.app.openTitle', locale, { label: packageApp.label })}
+                onClick={() => setChangesOpen(true)}
                 className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
               >
-                <ExternalLink className="h-3.5 w-3.5" />
-                {t('engine.studio.app.open', locale)}
+                <GitBranch className="h-3.5 w-3.5" />
+                {t('engine.studio.changes', locale)}{hasPending ? ` · ${pendingCount}` : ''}
               </button>
-            ) : appDraftPending ? (
-              <span
-                title={t('engine.studio.app.willOpenAfterPublish', locale)}
-                className="rounded bg-amber-400/15 px-2 py-0.5 text-[11px] text-amber-600 dark:text-amber-300"
-              >
-                {tFormat('engine.studio.app.pending', locale, { label: appDraftPending })}
-              </span>
-            ) : (
               <button
                 type="button"
-                onClick={() => setAppCreating(true)}
-                disabled={readOnly}
-                title={readOnly ? t('engine.studio.pkg.readonlyHint', locale) : t('engine.studio.app.noneTitle', locale)}
-                className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+                // Publish is review-then-confirm: open the pending-changes panel,
+                // whose footer button fires the actual atomic package publish —
+                // never straight from this header click (objectui#2261).
+                onClick={() => setChangesOpen(true)}
+                disabled={publishing || !hasPending || readOnly}
+                title={
+                  readOnly
+                    ? t('engine.studio.pkg.readonlyHint', locale)
+                    : hasPending
+                      ? t('engine.studio.publishTitle', locale)
+                      : t('engine.studio.publishNoneTitle', locale)
+                }
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
               >
-                <Plus className="h-3.5 w-3.5" />
-                {t('engine.studio.app.create', locale)}
+                {publishing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Rocket className="h-3.5 w-3.5" />}
+                {t('engine.studio.publish', locale)}
               </button>
+            </div>
+          </header>
+
+          <div className="min-h-0 flex-1">
+            {tab === 'data' ? (
+              <DataPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} readOnly={readOnly} />
+            ) : tab === 'automations' ? (
+              <AutomationsPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} readOnly={readOnly} />
+            ) : tab === 'access' ? (
+              <AccessPillar
+                packageId={packageId}
+                publishNonce={publishNonce}
+                onDraftSaved={onDraftSaved}
+                readOnly={readOnly}
+                onDirtyChange={setPillarDirty}
+              />
+            ) : (
+              <InterfacesPillar
+                packageId={packageId}
+                publishNonce={publishNonce}
+                draftNonce={draftNonce}
+                onDraftSaved={onDraftSaved}
+                onCreateApp={readOnly ? undefined : () => setAppCreating(true)}
+                readOnly={readOnly}
+                foldInspector={chatDockMode}
+                onDirtyChange={setPillarDirty}
+              />
             )}
-            <button
-              type="button"
-              onClick={() => setChangesOpen(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-            >
-              <GitBranch className="h-3.5 w-3.5" />
-              {t('engine.studio.changes', locale)}{hasPending ? ` · ${pendingCount}` : ''}
-            </button>
-            <button
-              type="button"
-              // Publish is review-then-confirm: open the pending-changes panel,
-              // whose footer button fires the actual atomic package publish —
-              // never straight from this header click (objectui#2261).
-              onClick={() => setChangesOpen(true)}
-              disabled={publishing || !hasPending || readOnly}
-              title={
-                readOnly
-                  ? t('engine.studio.pkg.readonlyHint', locale)
-                  : hasPending
-                    ? t('engine.studio.publishTitle', locale)
-                    : t('engine.studio.publishNoneTitle', locale)
-              }
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
-            >
-              {publishing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Rocket className="h-3.5 w-3.5" />}
-              {t('engine.studio.publish', locale)}
-            </button>
           </div>
-        </header>
-
-        <div className="min-h-0 flex-1">
-          {tab === 'data' ? (
-            <DataPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} readOnly={readOnly} />
-          ) : tab === 'automations' ? (
-            <AutomationsPillar packageId={packageId} publishNonce={publishNonce} onDraftSaved={onDraftSaved} readOnly={readOnly} />
-          ) : tab === 'access' ? (
-            <AccessPillar
-              packageId={packageId}
-              publishNonce={publishNonce}
-              onDraftSaved={onDraftSaved}
-              readOnly={readOnly}
-              onDirtyChange={setPillarDirty}
-            />
-          ) : (
-            <InterfacesPillar
-              packageId={packageId}
-              publishNonce={publishNonce}
-              draftNonce={draftNonce}
-              onDraftSaved={onDraftSaved}
-              onCreateApp={readOnly ? undefined : () => setAppCreating(true)}
-              readOnly={readOnly}
-              foldInspector={chatDockMode}
-              onDirtyChange={setPillarDirty}
-            />
-          )}
         </div>
+
+        {/* ADR-0057 P3c — the copilot as the shared right dock (same package-
+          * scoped build thread as the left panel it replaces; self-gates on the
+          * agent catalog like the copilot always has). */}
+        {chatDockMode && <StudioChatDock packageId={packageId} locale={locale} />}
+
+        <DraftChangesPanel
+          open={changesOpen}
+          onOpenChange={setChangesOpen}
+          packageId={packageId}
+          onPublish={readOnly ? undefined : doPublish}
+          publishing={publishing}
+        />
+
+        <CreateItemDialog
+          open={appCreating}
+          onOpenChange={setAppCreating}
+          title={t('engine.studio.app.create', locale)}
+          labelFieldLabel={t('engine.studio.app.nameLabel', locale)}
+          labelPlaceholder={t('engine.studio.app.namePlaceholder', locale)}
+          idFieldLabel={t('engine.studio.app.idLabel', locale)}
+          idPlaceholder={t('engine.studio.app.idPlaceholder', locale)}
+          submitLabel={t('engine.studio.createDraft', locale)}
+          submittingLabel={t('engine.studio.creating', locale)}
+          busy={appBusy}
+          error={appErr}
+          locale={locale}
+          onSubmit={({ label, name }) => void doCreateApp(label, name)}
+          extra={
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={appAddObjects}
+                onChange={(e) => setAppAddObjects(e.target.checked)}
+                className="h-3.5 w-3.5 accent-primary"
+              />
+              {t('engine.studio.app.scaffoldNav', locale)}
+            </label>
+          }
+        />
       </div>
-
-      {/* ADR-0057 P3c — the copilot as the shared right dock (same package-
-        * scoped build thread as the left panel it replaces; self-gates on the
-        * agent catalog like the copilot always has). */}
-      {chatDockMode && <StudioChatDock packageId={packageId} locale={locale} />}
-
-      <DraftChangesPanel
-        open={changesOpen}
-        onOpenChange={setChangesOpen}
-        packageId={packageId}
-        onPublish={readOnly ? undefined : doPublish}
-        publishing={publishing}
-      />
-
-      <CreateItemDialog
-        open={appCreating}
-        onOpenChange={setAppCreating}
-        title={t('engine.studio.app.create', locale)}
-        labelFieldLabel={t('engine.studio.app.nameLabel', locale)}
-        labelPlaceholder={t('engine.studio.app.namePlaceholder', locale)}
-        idFieldLabel={t('engine.studio.app.idLabel', locale)}
-        idPlaceholder={t('engine.studio.app.idPlaceholder', locale)}
-        submitLabel={t('engine.studio.createDraft', locale)}
-        submittingLabel={t('engine.studio.creating', locale)}
-        busy={appBusy}
-        error={appErr}
-        locale={locale}
-        onSubmit={({ label, name }) => void doCreateApp(label, name)}
-        extra={
-          <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
-            <input
-              type="checkbox"
-              checked={appAddObjects}
-              onChange={(e) => setAppAddObjects(e.target.checked)}
-              className="h-3.5 w-3.5 accent-primary"
-            />
-            {t('engine.studio.app.scaffoldNav', locale)}
-          </label>
-        }
-      />
-    </div>
+    </SurfaceDeepLinkProvider>
   );
 }
 
@@ -1963,6 +2012,25 @@ export function DataPillar({
   // (ADR-0080, `appStudioObjectPath`) lands here with a specific object;
   // shared plumbing (see useSurfaceDeepLink).
   const initialSurface = useSurfaceDeepLink(current);
+  // The LIVE half of the same plumbing (see surfaceDeepLinkChannel): a
+  // producer already inside this mounted pillar — the pending-changes sheet's
+  // security block, naming the object the publish door would refuse — asks for
+  // an object long after the capture ref above was read.
+  //
+  // Applied AT MOST ONCE, by id. A standing request re-resolved on every rail
+  // reload (publish, package switch) would drag the author back off whatever
+  // they had since selected, which is the regression the mount-time ref exists
+  // to prevent — so the id is marked spent as soon as the loaded rail has been
+  // consulted, whether or not it held a match.
+  const requestedSurface = useRequestedSurface();
+  const appliedRequestRef = React.useRef(0);
+  React.useEffect(() => {
+    if (!requestedSurface || !objectsLoaded) return;
+    if (requestedSurface.id === appliedRequestRef.current) return;
+    appliedRequestRef.current = requestedSurface.id;
+    const match = resolveSurfaceDeepLink(objects, requestedSurface.target, 'object');
+    if (match) setCurrent(match);
+  }, [requestedSurface, objects, objectsLoaded]);
   const [objDraft, setObjDraft] = React.useState<Record<string, unknown>>({});
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);

--- a/packages/app-shell/src/views/studio-design/surfaceDeepLinkChannel.test.tsx
+++ b/packages/app-shell/src/views/studio-design/surfaceDeepLinkChannel.test.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The live half of the `?surface=<type>:<name>` plumbing — objectui#5476.
+ *
+ * Studio's pre-publish security block names the draft the publish door would
+ * refuse (`object/crmext_visit`) and could not navigate to it: the block is
+ * rendered from a sheet opened over an ALREADY-MOUNTED pillar, and the
+ * capture half of the deep-link reads the URL exactly once, at mount.
+ *
+ * Two claims are pinned here, and they have to hold TOGETHER — the point of
+ * the card is a capability ADDED, not one swapped for another:
+ *
+ *  - CONTROL: `useSurfaceDeepLink` still captures at mount and nothing after
+ *    it — a later URL change (its own mirror writes one on every selection)
+ *    must not move the captured value. That ref is why in-pillar selections
+ *    don't re-trigger a restore.
+ *  - NEW: a request published on the channel reaches subscribers after mount,
+ *    exactly once per request, and is `null` for producers wherever no host
+ *    is listening (the degradation the Home / draft-preview bar depends on).
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, renderHook, act, cleanup, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useSearchParams } from 'react-router-dom';
+
+import { useSurfaceDeepLink, type SurfaceTarget } from './useSurfaceDeepLink';
+import {
+  SurfaceDeepLinkProvider,
+  useSurfaceNavigator,
+  useRequestedSurface,
+} from './surfaceDeepLinkChannel';
+
+afterEach(cleanup);
+
+describe('useSurfaceDeepLink — the mount-time capture (control)', () => {
+  it('captures the URL target at mount and ignores every later URL change', () => {
+    // The pillar's own mirror rewrites `?surface=` on each selection; a
+    // capture that followed the URL would restore on every one of them.
+    const seen: Array<SurfaceTarget | null> = [];
+    function Probe(): React.ReactElement {
+      const [, setParams] = useSearchParams();
+      const [current, setCurrent] = React.useState<SurfaceTarget | null>(null);
+      seen.push(useSurfaceDeepLink(current));
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            setParams({ surface: 'object:later_pick' }, { replace: true });
+            setCurrent({ type: 'object', name: 'later_pick' });
+          }}
+        >
+          pick
+        </button>
+      );
+    }
+    render(
+      <MemoryRouter initialEntries={['/studio/com.test/data?surface=object:crmext_visit']}>
+        <Probe />
+      </MemoryRouter>,
+    );
+    expect(seen[0]).toEqual({ type: 'object', name: 'crmext_visit' });
+    fireEvent.click(screen.getByRole('button', { name: 'pick' }));
+    // Every render since — still the mount-time value, never `later_pick`.
+    for (const value of seen) expect(value).toEqual({ type: 'object', name: 'crmext_visit' });
+  });
+});
+
+describe('surfaceDeepLinkChannel — the live half (objectui#5476)', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <SurfaceDeepLinkProvider>{children}</SurfaceDeepLinkProvider>
+  );
+
+  it('degrades to null for producers with no host listening', () => {
+    // Rendered by the Home / draft-preview bar, the Studio designer is not a
+    // destination at all. Producers branch on this null and render prose.
+    const { result } = renderHook(() => useSurfaceNavigator());
+    expect(result.current).toBeNull();
+  });
+
+  it('delivers a request to subscribers after mount', () => {
+    const { result } = renderHook(
+      () => ({ open: useSurfaceNavigator(), requested: useRequestedSurface() }),
+      { wrapper },
+    );
+    expect(result.current.requested).toBeNull();
+    act(() => result.current.open!({ type: 'object', name: 'crmext_visit' }));
+    expect(result.current.requested?.target).toEqual({ type: 'object', name: 'crmext_visit' });
+  });
+
+  it('stamps each request with a fresh id, so a repeat of the same target is a new request', () => {
+    // Clicking the same offending object twice has to move the author twice,
+    // even though the target is identical.
+    const { result } = renderHook(
+      () => ({ open: useSurfaceNavigator(), requested: useRequestedSurface() }),
+      { wrapper },
+    );
+    act(() => result.current.open!({ type: 'object', name: 'crmext_visit' }));
+    const first = result.current.requested!.id;
+    act(() => result.current.open!({ type: 'object', name: 'crmext_visit' }));
+    expect(result.current.requested!.id).toBeGreaterThan(first);
+  });
+
+  it('publishes nothing when the host vetoes — a declined navigation leaves no standing request', () => {
+    // The host asks about unsaved pillar edits; the author says no. If the
+    // request were published anyway it would fire later, when that pillar
+    // finally mounts, and move them somewhere they already refused to go.
+    const onRequest = vi.fn(() => false as const);
+    const { result } = renderHook(
+      () => ({ open: useSurfaceNavigator(), requested: useRequestedSurface() }),
+      {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <SurfaceDeepLinkProvider onRequest={onRequest}>{children}</SurfaceDeepLinkProvider>
+        ),
+      },
+    );
+    act(() => result.current.open!({ type: 'object', name: 'crmext_visit' }));
+    expect(onRequest).toHaveBeenCalledWith({ type: 'object', name: 'crmext_visit' });
+    expect(result.current.requested).toBeNull();
+  });
+
+  it('leaves the mount-time capture alone — the two halves are independent', () => {
+    // The regression this card must not author: a live channel that also
+    // moved the captured value would re-arm the restore the ref suppresses.
+    function Probe(): React.ReactElement {
+      const open = useSurfaceNavigator();
+      const captured = useSurfaceDeepLink(null);
+      return (
+        <>
+          <button type="button" onClick={() => open?.({ type: 'object', name: 'other_object' })}>
+            request
+          </button>
+          <span data-testid="captured">{captured ? `${captured.type}:${captured.name}` : 'none'}</span>
+        </>
+      );
+    }
+    render(
+      <MemoryRouter initialEntries={['/studio/com.test/data?surface=object:crmext_visit']}>
+        <SurfaceDeepLinkProvider>
+          <Probe />
+        </SurfaceDeepLinkProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('captured')).toHaveTextContent('object:crmext_visit');
+    fireEvent.click(screen.getByRole('button', { name: 'request' }));
+    expect(screen.getByTestId('captured')).toHaveTextContent('object:crmext_visit');
+  });
+});

--- a/packages/app-shell/src/views/studio-design/surfaceDeepLinkChannel.ts
+++ b/packages/app-shell/src/views/studio-design/surfaceDeepLinkChannel.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The LIVE half of the `?surface=<type>:<name>` deep-link plumbing — the half
+ * {@link file://./useSurfaceDeepLink.ts} describes and never had.
+ *
+ * That module captures the URL target ONCE, at mount, and that is deliberate:
+ * a pillar that re-read the param would re-trigger its restore on every
+ * in-pillar selection, because the MIRROR half writes the param back on each
+ * one. The consequence is that a producer already inside a mounted pillar —
+ * the pending-changes sheet's pre-publish security block, which names the
+ * draft the publish door would refuse as `object/crmext_visit` — can write the
+ * param and move nothing at all.
+ *
+ * So the live target travels BESIDE the URL rather than through it, which is
+ * what keeps the mount-time ref intact instead of replacing it:
+ *
+ *  - PRODUCERS call {@link useSurfaceNavigator}. It returns `null` wherever no
+ *    host is listening, and that null IS the degradation contract: the sheet
+ *    is shared with the Home / draft-preview bar, where the Studio object
+ *    editor is not a reachable destination at all, and a dead link there is
+ *    worse than the prose it would replace. `null` means "render the prose".
+ *  - SUBSCRIBERS (the pillars) read {@link useRequestedSurface}. Every request
+ *    carries a monotonic `id` and must be applied AT MOST ONCE: a pillar that
+ *    kept re-resolving a standing request would yank the author off their own
+ *    selection on the next rail reload — precisely the regression the
+ *    mount-time ref exists to prevent.
+ *
+ * Deliberately its own module rather than more of `useSurfaceDeepLink.ts`: a
+ * producer subscribes with React alone, while that module pulls in
+ * `nav-selection.js` (and through it the App-nav inspector) for its
+ * parse/format pair. The sheet reaches this file from the console's eager
+ * graph, so the import it does not make is the point.
+ */
+
+import * as React from 'react';
+import type { SurfaceTarget } from './useSurfaceDeepLink.js';
+
+/** A surface asked for AFTER mount, stamped so subscribers apply it once. */
+export interface SurfaceRequest {
+  target: SurfaceTarget;
+  /** Monotonic within one provider. Compare against the last id you applied. */
+  id: number;
+}
+
+interface SurfaceDeepLinkChannel {
+  requested: SurfaceRequest | null;
+  request: (target: SurfaceTarget) => void;
+}
+
+const SurfaceDeepLinkContext = React.createContext<SurfaceDeepLinkChannel | null>(null);
+
+/**
+ * Publishes the channel to a host's subtree — mounting this is what makes
+ * {@link useSurfaceNavigator} non-null for every producer below it, so the
+ * decision "is this destination reachable here?" is answered structurally,
+ * by the tree, and never by sniffing a route string.
+ */
+export function SurfaceDeepLinkProvider({
+  onRequest,
+  children,
+}: {
+  /**
+   * Host-side effects of a request — switching pillars, closing the surface
+   * the producer lives in. Return `false` to VETO it (the host asked about
+   * unsaved edits and the author declined): the request is then never
+   * published, so no pillar can act on it later either.
+   */
+  onRequest?: (target: SurfaceTarget) => boolean | void;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const [requested, setRequested] = React.useState<SurfaceRequest | null>(null);
+  const idRef = React.useRef(0);
+  // Held in a ref so a host that rebuilds its handler each render does not
+  // churn `request`'s identity — producers pass it straight into effect deps.
+  const onRequestRef = React.useRef(onRequest);
+  React.useEffect(() => {
+    onRequestRef.current = onRequest;
+  });
+  const request = React.useCallback((target: SurfaceTarget) => {
+    if (onRequestRef.current?.(target) === false) return;
+    idRef.current += 1;
+    setRequested({ target, id: idRef.current });
+  }, []);
+  const value = React.useMemo(() => ({ requested, request }), [requested, request]);
+  // `createElement` rather than JSX so this stays a `.ts` module alongside the
+  // hook it completes, instead of forcing a rename of a file four pillars and
+  // their tests import.
+  return React.createElement(SurfaceDeepLinkContext.Provider, { value }, children);
+}
+
+/**
+ * Producer side: ask the host to open a surface, or `null` when nothing is
+ * listening. Callers MUST branch on the null and render prose instead of a
+ * link — the null is the documented degradation, not a failure.
+ */
+export function useSurfaceNavigator(): ((target: SurfaceTarget) => void) | null {
+  return React.useContext(SurfaceDeepLinkContext)?.request ?? null;
+}
+
+/** Subscriber side: the standing request, or `null` outside a provider. */
+export function useRequestedSurface(): SurfaceRequest | null {
+  return React.useContext(SurfaceDeepLinkContext)?.requested ?? null;
+}

--- a/packages/app-shell/src/views/studio-design/useSurfaceDeepLink.ts
+++ b/packages/app-shell/src/views/studio-design/useSurfaceDeepLink.ts
@@ -21,6 +21,14 @@
  * pillar grew the capture half for the app→Studio object bridge (#2446);
  * Automations/Access had neither, so their deep-links snapped back to the
  * first item. This hook is the single canonical implementation.
+ *
+ * Both halves above are URL-shaped, which is exactly why a producer that is
+ * ALREADY INSIDE a mounted pillar cannot use them: writing `?surface=` moves
+ * nothing (capture is over) and the mirror overwrites it on the next
+ * selection. The third half — a live target delivered beside the URL, applied
+ * once — lives in {@link file://./surfaceDeepLinkChannel.ts}. It is additive:
+ * nothing here observes it, so the mount-time ref keeps meaning exactly what
+ * it meant.
  */
 
 import * as React from 'react';


### PR DESCRIPTION
Fixes #5476

Route **A** as ruled — a live target channel beside the mount-time capture. The
measurement asked for before landing is at the bottom, along with one scope
deviation I could not avoid and am flagging rather than burying.

## The defect

The pending-changes sheet names the drafts the publish door would refuse —
`object/crmext_visit`, with the rule's fix-it hint and "Fix it on the object
under Settings → Record sharing". Naming it shipped in #5418; reaching it did
not. `useSurfaceDeepLink` reads `?surface=TYPE:NAME` exactly once, at mount,
and the sheet opens over an already-mounted `DataPillar` — so writing the param
changed the URL and moved nothing.

## What route A actually is

The mount-time `useRef` is not a bug to route around: the MIRROR half rewrites
the param on every in-pillar selection, so a capture that followed the URL would
re-trigger its restore on each one. Both existing halves are URL-shaped, which
is exactly why a producer already inside the pillar cannot use either. The
missing half is a live target carried **beside** the URL.

`surfaceDeepLinkChannel.ts` (new, in `studio-design/`) is that half:

- **Producers** call `useSurfaceNavigator()` and ask by surface identity
  (`{type, name}`) — never by a Studio route the sheet would have to know how to
  build.
- **The host** (`StudioDesignSurface`) routes a request for ANOTHER pillar's
  surface back through the URL, because that pillar is unmounted and its
  mount-time capture is the mechanism built for precisely that; it vetoes what
  the author declines over unsaved edits, and closes the sheet.
- **Subscribers** (today only `DataPillar`) apply a request AT MOST ONCE, by a
  monotonic id.

That one-shot rule is the whole regression guard. A standing request re-resolved
on the next rail reload would drag the author back off whatever they had since
selected — the exact behaviour the mount-time ref exists to prevent.

## Off-Studio degradation

The sheet's other home is the Home / draft-preview bar, where the Studio object
editor is not a reachable destination at all. `useSurfaceNavigator()` returns
`null` wherever no host published the channel, so reachability is answered
**structurally, by the tree** — never by sniffing a route string, which would
also have crashed the existing suites that render this panel with no router at
all. Off-Studio the item name stays the exact prose #5418 shipped.

Both directions are assertions in `DraftChangesPanel.securityLink.test.tsx`:
the in-Studio case clicks the control and expects the surface identity; the
off-Studio case asserts no button and no link — not a disabled one, not a dead
anchor — and that the item name and the "Settings → Record sharing" sentence are
still there.

## The measurement you asked for: does A change what the other three pillars observe?

**No.** `useSurfaceDeepLink` is untouched apart from its doc comment — same
signature, same return, same behaviour. The Interfaces / Automations / Access
call sites are byte-identical, and none of them subscribes to the channel.
`git diff` on the hook is comment-only; the three other `useSurfaceDeepLink(...)`
call sites do not appear in the diff at all.

## Reverse-verification

Two ablations, each mutated with an anchored `grep -c` in both directions plus
`git diff --stat`, restored through a `trap ... EXIT INT TERM`, tree verified
byte-identical afterwards (`git status --porcelain` empty). Both suites reach the
mutated module by relative same-package path, so no `dist/` is in the resolution
path and there is nothing to rebuild — the import specifiers are printed in the
ablation log.

**Ablation 1 — delete the live half's delivery** (`setRequested(...)`, 1 -> 0
occurrences, marker 0 -> 1):

```
mutated: Test Files 2 failed | 2 passed (4) · Tests 4 failed | 11 passed (15)
  x delivers a request to subscribers after mount
  x stamps each request with a fresh id
  x opens the object the request names, with no remount and no URL to capture
  x never re-applies it: a later selection survives the next rail reload
restored: 15 passed
```

The mount-time CONTROL stayed green throughout — `useSurfaceDeepLink.test.ts`
(the pre-existing pins) and the two new capture pins: the capture ignores every
URL change after mount, and a live request never moves it. Capability added,
not swapped.

**Ablation 2 — delete the one-shot guard** (`if (requestedSurface.id === ...)
return;`, 1 -> 0): exactly one test red — "never re-applies it" — while "opens
the object the request names" stayed green.

Ablation 2 is why this PR has a stronger test than it started with. On its first
run it came back **all green**: my one-shot pin was asserting an absence in a
window where the rail reload had not yet happened, so nothing had had a chance to
violate it. The pin now waits on `client.list` actually being called again before
asserting nothing moved. A phantom assertion that the ablation caught, not a
tuning tweak.

## Gates (exit codes captured before any pipe; each gate's own verdict quoted)

All at `a506dff0d`, the final commit.

| gate | verdict |
| --- | --- |
| `pnpm --filter '@object-ui/app-shell^...' build` | `VERDICT command-exit 0 · held the lock 140s` |
| `pnpm --filter @object-ui/app-shell type-check` | `EXIT=0` — `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/app-shell lint` | `EXIT=0` — `2510 problems (0 errors, 2510 warnings)` |
| `vitest run` (narrowed, see below) | `Test Files 48 passed (48) · Tests 298 passed (298)` |
| `check-control-bytes` | `OK (scanned 4650 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | `7 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `No changeset declares a major bump.` |
| `check-changeset-fixed` | `All workspace packages are in the changeset fixed group.` |
| `check-eager-closure-budget` | `3785.3 KB gzipped across 52 of 508 chunks (budget: 3867.2 KB, headroom: 81.9 KB)` |
| `check-lint-coverage` | `46/46 packages linted, 0 with outstanding errors` |
| `check-type-check-coverage` | `45/46 via type-check` · `41/41 packages compile their tests` |
| `check-i18n-call-site-keys` | every in-scope call-site key resolves; no new keys added |

`check-eager-closure-budget` first exited **2** — its documented "no trustworthy
measurement" code, because no console build had written the report. This diff
puts a module into the console's EAGER graph, so a broken gauge was not good
enough: `apps/console` was built and the gate re-run for the number above. The
new module imports `react` and nothing else — `useSurfaceDeepLink` was
deliberately NOT imported into the sheet, since it reaches `nav-selection` and
through it the App-nav inspector.

**Declared narrowing of the vitest run.** Not the whole package: the run covers
`views/studio-design/`, `preview/`, and the three `metadata-admin` suites that
name anything this diff touches. Containment is measured, not assumed — grepping
the whole package for every identifier changed here (`surfaceDeepLinkChannel`,
`useSurfaceDeepLink`, `DraftChangesPanel`, `StudioDesignSurface`, `DataPillar`)
returns 26 suites, and all 26 are inside that run. Across the rest of
`packages/`, zero files outside `app-shell` reference any of them. CI runs the
full farm regardless.

## Scope deviation — please rule

The dispatch fenced this to `packages/app-shell/src/views/studio-design/**` plus
a changeset, on the stated grounds that "the only other consumer of the hook is
`StudioDesignSurface.tsx`, in the same directory". That is true of the *hook*,
but the sheet that has to render the link is
`packages/app-shell/src/preview/DraftChangesPanel.tsx` — a sibling directory —
and the binding requirement ("the link must degrade to prose off-Studio, and
that degradation is a **test assertion**") has no subject without it.

So two files sit outside the fence, and I did not take them silently:

```
packages/app-shell/src/preview/DraftChangesPanel.tsx                  the link / prose branch
packages/app-shell/src/preview/__tests__/DraftChangesPanel.securityLink.test.tsx
```

Same package, no change to the package's public exports (`src/index.ts`
untouched), no overlap with #5544's `src/chrome/**`, and the import direction
`preview/ -> views/` is the one already established there
(`views/metadata-admin/previews/object-fields-io.js`). The alternative was
shipping an unconsumed channel and a degradation requirement with nothing to
degrade. Happy to split the sheet half into its own PR if you would rather rule
the other way.

## Deliberate non-goals

- The request carries a surface identity only, so the pillar lands on the object
  — not on its **Settings** tab. Adding a tab axis would widen the identity four
  pillars share; the sheet's sentence still says where to go once the object is
  open.
- `PILLAR_FOR_SURFACE_TYPE` lists only the types a pillar actually resolves.
  An unlisted type is delivered in place rather than guessed at: navigating to
  the wrong pillar costs the author their position and buys nothing.


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_