### PR TITLE
docs(react): toRenderableSchema's header says the bridge is permanent (#4622)

### DIFF
--- a/.changeset/schema-input-bridge-permanent-4622.md
+++ b/.changeset/schema-input-bridge-permanent-4622.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/react': patch
+---
+
+`toRenderableSchema`'s header now says the bridge is permanent, instead of instructing
+callers to remove it (objectui#4622).
+
+Comment-only — the emitted JavaScript is byte-identical. The paragraph nonetheless ships:
+this package builds with plain `tsc`, so the JSDoc is carried into
+`dist/schema-input.d.ts` and is what an editor shows on hover at every call site.
+
+The old closing paragraph said the two competing repo-wide `SchemaNode` spellings "have
+not been reconciled" and that "when it lands, the call sites using this can go back to
+forwarding directly". Both halves went false when PR #4608 merged, and the second half is
+the harmful one: it is an instruction whose trigger condition has now fired, sitting
+directly above the function a future author is about to call.
+
+The reconciliation (objectui#4580 / PR #4608) resolved the collision in favour of
+`@object-ui/types`' union — `@object-ui/core` now re-exports it rather than hand-declaring
+an interface — while `SchemaRenderer`'s prop stays deliberately narrow per objectui#4548
+ruling Q2 (`schema: BaseSchema | string | null | undefined`, no `number` / `boolean`). So
+a `SchemaNode` became *less* assignable to that prop, not more, and the bridge is a
+permanent crossing between two intentionally different types rather than scaffolding
+awaiting a merge.
+
+Following the old instruction has a measured cost: five `apps/site` call sites were
+forwarding directly when PR #4608 landed, and `Build Docs` was red on `main` for roughly
+five hours until PR #4621 routed all five through this function (objectui#4617).

--- a/.changeset/schema-input-bridge-permanent-4622.md
+++ b/.changeset/schema-input-bridge-permanent-4622.md
@@ -5,9 +5,19 @@
 `toRenderableSchema`'s header now says the bridge is permanent, instead of instructing
 callers to remove it (objectui#4622).
 
-Comment-only — the emitted JavaScript is byte-identical. The paragraph nonetheless ships:
-this package builds with plain `tsc`, so the JSDoc is carried into
-`dist/schema-input.d.ts` and is what an editor shows on hover at every call site.
+No executable line changes — but the artifact is **not** unchanged, and that is worth
+stating plainly rather than rounding to "comment-only". This package builds with plain
+`tsc`, and `tsconfig.base.json` sets `"removeComments": false` deliberately, so the JSDoc
+is emitted into `dist/schema-input.js` as well as `dist/schema-input.d.ts` — it is both
+what an editor shows on hover at every call site and bytes that ship.
+
+Measured by building the package the way the repo builds it, at both revisions:
+`dist/schema-input.js` grows from 1,486 to 2,316 bytes (1.45 KB to 2.26 KB), and from 850
+to 1,246 bytes gzipped (0.83 KB to 1.22 KB) — **+830 bytes raw, +396 gzipped**. All 18
+differing lines in the emitted file are JSDoc continuations and the three executable lines
+are byte-identical, so the growth is the paragraph and nothing else. The trade is
+deliberate: roughly 0.4 KB gzipped, against the five-hour `Build Docs` outage the old
+paragraph's instruction produced once already.
 
 The old closing paragraph said the two competing repo-wide `SchemaNode` spellings "have
 not been reconciled" and that "when it lands, the call sites using this can go back to

--- a/.changeset/schema-input-bridge-permanent-4622.md
+++ b/.changeset/schema-input-bridge-permanent-4622.md
@@ -12,8 +12,8 @@ is emitted into `dist/schema-input.js` as well as `dist/schema-input.d.ts` — i
 what an editor shows on hover at every call site and bytes that ship.
 
 Measured by building the package the way the repo builds it, at both revisions:
-`dist/schema-input.js` grows from 1,486 to 2,316 bytes (1.45 KB to 2.26 KB), and from 850
-to 1,246 bytes gzipped (0.83 KB to 1.22 KB) — **+830 bytes raw, +396 gzipped**. All 18
+`dist/schema-input.js` grows from 1,486 to 2,377 bytes (1.45 KB to 2.32 KB), and from 850
+to 1,266 bytes gzipped (0.83 KB to 1.24 KB) — **+891 bytes raw, +416 gzipped**. All 19
 differing lines in the emitted file are JSDoc continuations and the three executable lines
 are byte-identical, so the growth is the paragraph and nothing else. The trade is
 deliberate: roughly 0.4 KB gzipped, against the five-hour `Build Docs` outage the old

--- a/packages/react/src/schema-input.ts
+++ b/packages/react/src/schema-input.ts
@@ -36,9 +36,10 @@ import type { SchemaRendererProps } from './SchemaRenderer.js';
  * and it stays. ⛔ Do not "tidy" a call site back into a direct forward: the
  * five `apps/site` sites that were forwarding directly when PR #4608 landed are
  * what kept `Build Docs` red on `main` for ~5 hours — each one a TS2322 naming
- * `number` against this function's return type — until PR #4621 routed all five
- * through here (objectui#4617). An earlier revision of this paragraph said the
- * reconciliation was still pending and invited exactly that edit.
+ * `number` against this function's return type, spelled
+ * `string | BaseSchema | null | undefined` in objectui#4617's logs — until
+ * PR #4621 routed all five through here. An earlier revision of this paragraph
+ * said the reconciliation was still pending and invited exactly that edit.
  */
 export function toRenderableSchema(
   node: BaseSchema | string | number | boolean | null | undefined,

--- a/packages/react/src/schema-input.ts
+++ b/packages/react/src/schema-input.ts
@@ -25,10 +25,20 @@ import type { SchemaRendererProps } from './SchemaRenderer.js';
  * tells no lie — the value a caller forwards renders identically whether or not
  * it passes through here.
  *
- * It exists because the two competing repo-wide `SchemaNode` spellings
- * (`@object-ui/core`'s interface vs `@object-ui/types`' union) have not been
- * reconciled; that reconciliation is tracked separately. When it lands, the
- * call sites using this can go back to forwarding directly.
+ * The bridge is PERMANENT — not scaffolding awaiting a merge. The two competing
+ * repo-wide `SchemaNode` spellings ARE reconciled (objectui#4580, PR #4608):
+ * `@object-ui/core` stopped hand-declaring its own interface and now re-exports
+ * `@object-ui/types`' union, so one declaration is left to disagree with. That
+ * reconciliation resolved in favour of the UNION, while `SchemaRenderer`'s prop
+ * stays deliberately narrow (objectui#4548 ruling Q2 — it declares no `number`
+ * or `boolean`), so a `SchemaNode` is now LESS assignable to that prop than it
+ * was, not more. This step therefore bridges two intentionally different types,
+ * and it stays. ⛔ Do not "tidy" a call site back into a direct forward: the
+ * five `apps/site` sites that were forwarding directly when PR #4608 landed are
+ * what kept `Build Docs` red on `main` for ~5 hours — each one a TS2322 naming
+ * `number` against this function's return type — until PR #4621 routed all five
+ * through here (objectui#4617). An earlier revision of this paragraph said the
+ * reconciliation was still pending and invited exactly that edit.
  */
 export function toRenderableSchema(
   node: BaseSchema | string | number | boolean | null | undefined,


### PR DESCRIPTION
Fixes #4622.

One paragraph of prose, at the bottom of `toRenderableSchema`'s JSDoc in `packages/react/src/schema-input.ts`. The first two paragraphs are accurate and are untouched.

> **Correction, kept in place rather than quietly edited away.** The first revision of this PR and its changeset both claimed *"the emitted JavaScript is byte-identical"*. **That was false.** The measurement behind it is retracted and re-done below, against the build this repo actually performs. The correction is recorded here because a claim that does not survive being checked is the exact defect this card exists to fix, and silently swapping the sentence would leave the reviewer no way to see it happened.

## What was wrong

The closing paragraph said the two competing repo-wide `SchemaNode` spellings *"have not been reconciled"* and that *"when it lands, the call sites using this can go back to forwarding directly"*. That is not a stale fact — it is an **instruction whose trigger condition has already fired**, sitting directly above the function every future author calls. Acting on it reproduces objectui#4617 exactly.

## Every claim in the replacement, verified against `origin/main` rather than taken from the card

The card exists because a header made a confident claim that later went false, so each new claim was read out of the code on `7a28e1e3f` before it was written down.

**1. The reconciliation landed, and core re-exports the union** — `packages/core/src/types/index.ts:41`:

```ts
export type { SchemaNode } from '@object-ui/types';
```

and the declaration it now points at, `packages/types/src/base.ts:334`:

```ts
export type SchemaNode = BaseSchema | string | number | boolean | null | undefined;
```

**2. `SchemaRenderer`'s prop is still deliberately narrow, and still excludes `number` / `boolean`** — `packages/react/src/SchemaRenderer.tsx`, the interface and the sentence above it:

```ts
 * handles: an object schema, a bare string (rendered as text), or nothing at
 * all. `number` / `boolean` are deliberately excluded — the runtime tolerates
 * them defensively (see the primitive guard in the evaluation memo) but no
 * author should be invited to pass them.
export interface SchemaRendererProps {
  schema: BaseSchema | string | null | undefined;
}
```

So the two types are intentionally different, in the direction that makes the bridge permanent: a value typed `SchemaNode` is now **less** assignable to that prop than it was, not more.

**3. The ruling and PR #4608 agree with the code** — from #4608's own must-not-change section: *"`toRenderableSchema` in `packages/react` remains. SchemaRenderer's component-level union deliberately excludes `number`/`boolean` (#4548 ruling Q2), so the bridge still normalizes those after reconciliation."*

**4. The measured cost of the old reading** — objectui#4617: five `apps/site` call sites (`InteractiveDemo.tsx` twice, `LiveSplitDemo.tsx`, `SchemaThumbnail.tsx`, `playground/page.tsx`) were forwarding directly when #4608 landed, each reported as `error TS2322: Type 'SchemaNode' is not assignable to type 'string | BaseSchema | null | undefined'`. Merge timestamps bound the red window: #4608 merged `2026-08-13T20:24:13Z`, #4621 merged `2026-08-14T01:55:18Z` — 5h31m, i.e. the "roughly five hours" the new paragraph states. All five sites route through this function today (`grep` for `toRenderableSchema` in `apps/site`).

Nothing had moved, so there was nothing to stop for.

## The replacement paragraph

```
 * The bridge is PERMANENT — not scaffolding awaiting a merge. The two competing
 * repo-wide `SchemaNode` spellings ARE reconciled (objectui#4580, PR #4608):
 * `@object-ui/core` stopped hand-declaring its own interface and now re-exports
 * `@object-ui/types`' union, so one declaration is left to disagree with. That
 * reconciliation resolved in favour of the UNION, while `SchemaRenderer`'s prop
 * stays deliberately narrow (objectui#4548 ruling Q2 — it declares no `number`
 * or `boolean`), so a `SchemaNode` is now LESS assignable to that prop than it
 * was, not more. This step therefore bridges two intentionally different types,
 * and it stays. ⛔ Do not "tidy" a call site back into a direct forward: the
 * five `apps/site` sites that were forwarding directly when PR #4608 landed are
 * what kept `Build Docs` red on `main` for ~5 hours — each one a TS2322 naming
 * `number` against this function's return type, spelled
 * `string | BaseSchema | null | undefined` in objectui#4617's logs — until
 * PR #4621 routed all five through here. An earlier revision of this paragraph
 * said the reconciliation was still pending and invited exactly that edit.
```

### Why the TS2322 clause is worded in two halves

A paragraph whose subject is a claim that rotted should not introduce a new way to rot. Naming the type by its **role** ("this function's return type") is self-updating: if `SchemaRendererProps['schema']` gains or loses a member, that clause stays true with no edit. Naming today's spelling as a present-tense fact would not be — it would hardcode a type into prose, which is the defect this card exists to fix.

So the literal spelling is scoped as a **historical quotation of what #4617's logs said**, which is a fixed fact that cannot go stale however the union evolves, and which hands a reader with the log open the exact string to match in one hop. The role-based half and the quoted half do different jobs; keeping both costs about twenty bytes.

The equivalence behind the role-based half is not folklore either: the function is annotated `: SchemaRendererProps['schema']`, and `SchemaRenderer.propsResolution.test.ts` pins `Equal<ReturnType<typeof toRenderableSchema>, SchemaRendererProps['schema']>`, so a future edit that breaks the correspondence fails a type assertion rather than quietly falsifying this sentence.

## The source change is comment-only; the emitted artifact is NOT unchanged

Two different questions, and the first revision of this PR ran the second one wrong.

### Retracted: the `--removeComments` experiment

It transpiled both revisions with `tsc --ignoreConfig --removeComments --noResolve --skipLibCheck`, got matching sha256s, and concluded the emitted JS was byte-identical. **That measured a build this repo does not perform.** `tsconfig.base.json:22` sets `"removeComments": false` deliberately, and this package's build script is plain `tsc`, so comments are emitted into `dist/*.js`. Passing `--removeComments` overrode the exact setting that decides the answer — it measured away the thing being measured. What that experiment does still establish is narrow and not what was claimed: the two revisions are identical *once comments are stripped*, i.e. no executable statement changed.

### The real measurement

The package built the way the repo builds it (`pnpm --filter @object-ui/react build`, `dist/` cleared between runs), at both revisions, at the current head `21d9d4726`:

| `packages/react/dist/schema-input.js` | before (`7a28e1e3f`) | after | delta |
|---|---|---|---|
| raw | 1,486 B (1.45 KB) | 2,377 B (2.32 KB) | **+891 B** |
| gzipped | 850 B (0.83 KB) | 1,266 B (1.24 KB) | **+416 B** |

**Cross-checked against CI's own bot.** The bundle-size row is `wc -c` and `gzip -c | wc -c` of this very file (`performance-budget.yml`, "Generate package size report"), so it and this table measure the same artifact. At head `012c57cb8` the bot reported **2.26 KB / 1.22 KB** for `react (schema-input.js)` against **1.45 KB / 0.83 KB** on two sibling PRs cut from the same merge-base that do not touch this file — and building that same tree locally reproduced 2.26 KB / 1.22 KB exactly. The current head is slightly larger (2.32 KB / 1.24 KB) because the paragraph gained the quoted spelling above; the before figure is unchanged and re-measured at 1,486 B / 850 B on this round.

*(One trap worth naming, since it moved a number: `gzip` stores the source filename in its header, so gzipping a renamed copy of the same bytes gives a different size — 862 B for `dist-before-schema-input.js` versus 850 B for `schema-input.js`. Every gzip figure above is measured at the real `dist/` path, which is what CI measures.)*

**What did not change.** All 19 differing lines in the emitted file are JSDoc continuations, and the three executable lines are byte-identical on both sides:

```
$ diff dist-before/schema-input.js dist-after/schema-input.js \
    | grep -E '^[<>]' | grep -vE '^[<>]  \* '
(no output)

export function toRenderableSchema(node) {
    return typeof node === 'number' || typeof node === 'boolean' ? String(node) : node;
}
```

**Structural check on the source, unaffected by the above and still sound** — every added and removed line is a JSDoc continuation:

```
$ git diff -U0 -- packages/react/src/schema-input.ts \
    | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-] \* '
(no output)
```

**The size is not being chased.** Roughly 0.4 KB gzipped is the deliberate price of not repeating a 5h31m `Build Docs` outage on `main`; shrinking the paragraph to win those bytes back would trade the thing of value for the thing of no value.

**No test and no ablation is possible here, and none is manufactured.** There is no executable behaviour to pin, and mutating a doc comment cannot turn any suite red — a "reverse verification" of this diff would be a ritual that proves nothing. The measurements above stand in its place.

## Why a changeset, and why patch

The gate said so first, red before the changeset was written:

```
Compared the working tree with 7a28e1e3f (merge-base with origin/main): 1 file(s) changed,
1 of them under the src/ of a package the release covers, 0 under a package changesets
ignores, 0 changeset(s) added.
❌  1 source file(s) of 1 released package(s) changed, and this change adds no changeset:
      @object-ui/react
          packages/react/src/schema-input.ts
```

Patch rather than the empty frontmatter, because the paragraph genuinely ships — in `dist/schema-input.d.ts`, where it is what an editor shows on hover at each call site, and in `dist/schema-input.js` as the bytes measured above. The changeset carries the corrected, re-measured numbers, not the retracted claim. Documentation of a published API changed; behaviour did not.

**No `skip-changeset` label**, deliberately — that label does not exist in this repo; PR #4621 recorded that it was one of the phantom workflows objectui#3724 deleted. `content/docs/releases/**` untouched.

## Gates

Re-derived from `.github/workflows/` against this diff (`packages/react/src/**` plus `.changeset/**`), not taken from a list. Exit codes captured before any pipe, and each line below is the gate's own verdict.

Re-run at the current head **21d9d4726**, working tree clean:

| Gate | Exit | Its own verdict line |
|---|---|---|
| `pnpm --filter @object-ui/react type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` — no diagnostics |
| `pnpm --filter @object-ui/react lint` | 0 | `✖ 347 problems (0 errors, 347 warnings)` — all pre-existing; **0 attributable to the touched file** (`grep -c schema-input.ts` on the log = 0) |
| `pnpm exec vitest run packages/react/ --maxWorkers=2` (repo root) | 0 | `Test Files 49 passed (49)` · `Tests 680 passed (680)` |
| `check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 4654 tracked text file(s); skipped 85 binary).` |
| `check-changeset-presence.mjs` | 0 | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | 0 | `✅ No changeset declares a 'major' bump.` |
| `check-changeset-fixed.mjs` | 0 | `✅ All workspace packages are in the changeset fixed group.` |

From head **012c57cb8**, whose tree differs from the current one only in prose inside these same two files — no gate below reads that prose:

| Gate | Exit | Its own verdict line |
|---|---|---|
| `check-type-check-coverage.mjs` | 0 | `✅ type-check coverage: 45/46 via 'type-check', 0 via their own build, 0 known-broken, 1 not compiled.` |
| `check-lint-coverage.mjs` | 0 | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `check-doc-links.mjs` | 0 | `Links are valid across 13 scan roots.` |
| `check-doc-component-types.mjs` | 0 | `✅ Every documented component type is registered.` |
| `check-doc-snippet-types.mjs` | 0 | `Semantic phase: 88 of 88 block(s) judged, 0 failed.` (needed the workspace built first — the unbuilt run reports a precondition, not a finding) |
| `check-skills-paths.mjs` | 0 | `✅ check-skills-paths: OK (95/96 stated path(s) resolve across 18 guide file(s); 1 baselined).` |
| `check-package-self-import.mjs` | 0 | `✅ No package names itself inside its own src/.` |
| `check-phantom-dependencies.mjs` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check-node-esm-load.mjs --specifiers-only` | 0 | `Specifier leg: no un-ledgered package emits an extensionless relative specifier.` |
| `check-spec-symbol-derivation.mjs` | 0 | `✅ spec symbol derivation: 1289 files scanned against 4912 spec export names` |
| `check-action-forward-parity.mjs` | 0 | every action row `payload excess-property CHECKED` |
| `check-i18n-call-site-keys.mjs` | 0 | `Every in-scope call-site key resolves against the en pack (2918 keys)` |
| `check-i18n-en-drift.mjs` | 0 | `No en value changed in this range.` |

**`Build Docs` specifically**, given this card's history — `apps/site` is the consumer that went red last time:

```
$ pnpm --filter @object-ui/site type-check
> fumadocs-mdx && next typegen && tsc --noEmit
✓ Types generated successfully
### exit: 0 ###
```

The full workspace build the snippet gate needed also passed: `Tasks: 43 successful, 43 total`.

### Declared narrowing

Repo-wide `pnpm lint` was **not** run; the package-scoped run above was, and it covers this diff completely. Three pieces of evidence, so this reads as a measurement rather than a gap:

1. **Population from eslint's own config, not from a guess** — `eslint.config.js:28` selects `files: ['**/*.{ts,tsx}']`. The changeset `.md` is outside eslint's universe entirely, so `packages/react/src/schema-input.ts` is the only lintable file in the diff.
2. **Count from `--format json`** — `eslint --format json packages/react/src/schema-input.ts` reports `files linted: 1`, `errors 0`, `warnings 0`.
3. **Invariance for untouched files** — the config extends `tseslint.configs.recommended` (not `recommendedTypeChecked`) and sets no `parserOptions.project`, so linting is not type-aware and this diff cannot move a verdict on any file it does not contain.

Repo-wide `pnpm type-check` and the full `pnpm test` farm were likewise left to CI, which runs both in full on this PR.

## Scope

`packages/react/src/schema-input.ts` (one paragraph) and one changeset. No other package, no `apps/site`, no `content/docs/releases/**`, no governed surface (`docs/adr/**`, `.claude/**`, `skills/**`, `AGENTS.md`, `CLAUDE.md`). No `git stash` at any point — the worktree is dedicated to this issue, and every before/after build comparison used a committed revision plus `git checkout <rev> -- <path>` (or a patch file for an in-flight edit), restored and verified byte-identical by sha256 afterwards.

Draft on purpose: the PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_
