### PR TITLE
perf(plugin-chatbot): stop rebuilding the chat transport on every render (#4187)

### DIFF
--- a/.changeset/chat-transport-memo-4187.md
+++ b/.changeset/chat-transport-memo-4187.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/plugin-chatbot': patch
+---
+
+`useObjectChat` no longer rebuilds its `DefaultChatTransport` on every render
+(objectui#4187).
+
+The transport `useMemo` listed the caller's `body` and `headers` in its dep list.
+Both are object props and every caller passes a fresh literal each render — the AI
+page's chat pane builds its `body.context` inline — so the memo never hit and a
+transport was constructed on every render of every chat surface, which during a
+streaming turn is once per token batch.
+
+`body` and `headers` are now read through refs inside
+`prepareSendMessagesRequest`, the idiom this hook already uses for the live model
+(`modelRef`) and the handoff conversation id (`parentConvRef`), and they are gone
+from the dep list. Unlike memoizing at each call site, a future caller cannot
+undo it.
+
+No user-visible behaviour changes: `@ai-sdk/react` keeps the transport in a ref
+and re-keys its `Chat` only on `chat`/`id` (verified against the installed
+4.0.68), which `useObjectChat` passes neither of, so the message thread was never
+at risk — the rebuild was pure waste. The one real difference is *when* the two
+values are sampled: a send now reads them at send time, so it observes the values
+of the most recent render instead of those of the last render that happened to
+rebuild the transport. That is never staler than before, and it is pinned by
+`useObjectChat.transportIdentity.test.tsx`.

--- a/packages/plugin-chatbot/src/__tests__/useObjectChat.transportIdentity.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/useObjectChat.transportIdentity.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#4187 — the transport `useMemo` in `useObjectChat` used to list the
+ * caller's `body`/`headers` as deps. Every caller passes a fresh object literal
+ * each render, so the memo never hit and a `DefaultChatTransport` was built on
+ * every render of every chat surface — once per token batch while streaming.
+ *
+ * These tests pin BOTH halves of the fix:
+ *   1. the transport is built once, however often the caller re-renders;
+ *   2. what a send actually observes afterwards — `body`/`headers` are now read
+ *      through refs at SEND time, so the values are those of the most recent
+ *      render rather than of the last render that happened to rebuild the
+ *      transport. That timing shift is the one real behavioural difference
+ *      between this fix and call-site memoization, and it is not visible by
+ *      reading the diff.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useObjectChat } from '../useObjectChat';
+
+/** Counts `new DefaultChatTransport(...)` across a test. */
+const transportSpy = vi.hoisted(() => ({ constructions: 0 }));
+
+// Count constructions without changing behaviour: a construct-trap Proxy around
+// the real class, so the hook still talks to the genuine transport.
+vi.mock('ai', async (importOriginal) => {
+  const actual = (await importOriginal()) as { [key: string]: unknown };
+  const Real = actual.DefaultChatTransport as new (...args: never[]) => object;
+  const Counting = new Proxy(Real, {
+    construct(target, args) {
+      transportSpy.constructions += 1;
+      return Reflect.construct(target, args);
+    },
+  });
+  return { ...actual, DefaultChatTransport: Counting };
+});
+
+const API = 'https://example.test/api/v1/ai/agents/build/chat';
+
+type AnyRecord = { [key: string]: unknown };
+type FetchMock = { mock: { calls: unknown[][] } };
+
+/** A minimal, well-formed Vercel AI UI-message data stream so a send completes. */
+function dataStreamResponse(): Response {
+  const body =
+    'data: {"type":"start"}\n\n' + 'data: {"type":"finish"}\n\n' + 'data: [DONE]\n\n';
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'x-vercel-ai-ui-message-stream': 'v1',
+    },
+  });
+}
+
+/** The JSON body of a captured chat POST. */
+function bodyOf(fetchMock: FetchMock, callIndex: number): AnyRecord {
+  const init = fetchMock.mock.calls[callIndex]?.[1] as { body?: string } | undefined;
+  return JSON.parse(init?.body ?? '{}') as AnyRecord;
+}
+
+/** One request header off a captured chat POST, however the SDK shaped it. */
+function headerOf(fetchMock: FetchMock, callIndex: number, name: string): string | null {
+  const init = fetchMock.mock.calls[callIndex]?.[1] as { headers?: HeadersInit } | undefined;
+  return new Headers(init?.headers ?? {}).get(name);
+}
+
+beforeEach(() => {
+  transportSpy.constructions = 0;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useObjectChat — transport identity (#4187)', () => {
+  it('builds ONE transport across renders that pass fresh body/headers literals', () => {
+    const { rerender } = renderHook(
+      ({ tick }: { tick: number }) =>
+        useObjectChat({
+          api: API,
+          conversationId: 'build_1',
+          // Fresh identity on every render — the shape every caller uses today
+          // (the AI page's chat pane builds its `body.context` inline).
+          body: { context: { activeApp: 'AI', tick } },
+          headers: { 'x-oui-tick': String(tick) },
+        }),
+      { initialProps: { tick: 0 } },
+    );
+
+    expect(transportSpy.constructions).toBe(1);
+
+    rerender({ tick: 1 });
+    rerender({ tick: 2 });
+    rerender({ tick: 3 });
+
+    // Without the fix this is 4 — one construction per render.
+    expect(transportSpy.constructions).toBe(1);
+  });
+
+  it('still rebuilds the transport when a memoized dep really changes', () => {
+    const { rerender } = renderHook(
+      ({ conversationId }: { conversationId: string }) =>
+        useObjectChat({ api: API, conversationId, body: { context: {} } }),
+      { initialProps: { conversationId: 'build_1' } },
+    );
+
+    expect(transportSpy.constructions).toBe(1);
+    rerender({ conversationId: 'build_2' });
+    expect(transportSpy.constructions).toBe(2);
+  });
+
+  it('a send carries the body/headers of the MOST RECENT render', async () => {
+    const fetchMock = vi.fn(async () => dataStreamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ tick }: { tick: number }) =>
+        useObjectChat({
+          api: API,
+          conversationId: 'build_1',
+          body: { context: { tick } },
+          headers: { 'x-oui-tick': String(tick) },
+        }),
+      { initialProps: { tick: 1 } },
+    );
+
+    rerender({ tick: 2 });
+    rerender({ tick: 3 });
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    expect((bodyOf(fetchMock as unknown as FetchMock, 0).context as AnyRecord).tick).toBe(3);
+    expect(headerOf(fetchMock as unknown as FetchMock, 0, 'x-oui-tick')).toBe('3');
+  });
+
+  it('reads `body` at SEND time, not at transport-construction time', async () => {
+    const fetchMock = vi.fn(async () => dataStreamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    // One STABLE object identity for the whole test. With a stable identity the
+    // memo never re-ran even before this change, so the value a send observes is
+    // decided purely by WHEN it is read: the old code spread `body` into the
+    // transport at CONSTRUCTION time and froze `tick: 1`; the ref is spread at
+    // SEND time. (Mutating a prop is not endorsed here — it is simply the only
+    // externally observable probe of the read timing.)
+    const stableBody: { tick: number } = { tick: 1 };
+
+    const { result } = renderHook(() =>
+      useObjectChat({ api: API, conversationId: 'build_1', body: stableBody }),
+    );
+
+    stableBody.tick = 2;
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    expect(bodyOf(fetchMock as unknown as FetchMock, 0).tick).toBe(2);
+  });
+
+  it('keeps the hook-owned keys winning over the caller body', async () => {
+    const fetchMock = vi.fn(async () => dataStreamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() =>
+      useObjectChat({
+        api: API,
+        conversationId: 'build_1',
+        model: 'claude-sonnet',
+        systemPrompt: 'be brief',
+        // A caller body that tries to shadow every hook-owned key.
+        body: { conversationId: 'spoofed', model: 'spoofed', systemPrompt: 'spoofed', stream: false },
+      }),
+    );
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const sent = bodyOf(fetchMock as unknown as FetchMock, 0);
+    expect(sent.conversationId).toBe('build_1');
+    expect(sent.model).toBe('claude-sonnet');
+    expect(sent.systemPrompt).toBe('be brief');
+    expect(sent.stream).toBe(true);
+  });
+});

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -473,6 +473,12 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
       // `notSent` so the composer can restore the input and show a clear error
       // instead of silently dropping the message (see sendAwareFetch).
       fetch: sendAwareFetch,
+      // No `headers` here (objectui#4187): the caller's headers are applied
+      // per-send in prepareSendMessagesRequest below. `reconnectToStream` does
+      // NOT run that hook — it reads this constructor's `headers` — so the first
+      // consumer to wire up stream resumption must merge `headersRef.current`
+      // into `prepareReconnectToStreamRequest` too, or it will resume without
+      // them. Nothing in this repo resumes a stream today.
       body: {
         ...(conversationId ? { conversationId } : {}),
         ...(model ? { model } : {}),

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -441,6 +441,26 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
     if (parentConversationId && !prev) parentConvRef.current = parentConversationId;
   }, [parentConversationId]);
 
+  // objectui#4187 - the caller's `body`/`headers` are read through refs at SEND
+  // time instead of being closed over by the transport, so they are NOT memo
+  // deps below. Every caller passes a fresh object literal each render (the AI
+  // page's chat pane rebuilds `body.context` inline), so listing them rebuilt
+  // `DefaultChatTransport` on every render of every chat surface - once per
+  // token batch during a streaming turn. Same idiom as `modelRef` above, and
+  // the only one of the two candidate fixes a future caller cannot silently
+  // undo by forgetting its own `useMemo`.
+  //
+  // SAMPLING CONTRACT (the one real behavioural change): a send serializes
+  // whatever these refs hold when `prepareSendMessagesRequest` runs, i.e. the
+  // values from the most recent render, spread at SEND time. Before, the values
+  // were spread into the transport at CONSTRUCTION time, so a send observed the
+  // last render that happened to rebuild it. The ref read is never staler than
+  // that and is now unconditional - see `useObjectChat.transportIdentity.test`.
+  const bodyRef = useRef(body);
+  bodyRef.current = body;
+  const headersRef = useRef(headers);
+  headersRef.current = headers;
+
   // Build a transport for API mode that posts to the configured endpoint and
   // forwards conversation/system/model metadata in the request body.
   // Note: conversationId is sent in the body (not a header) to avoid CORS
@@ -453,9 +473,7 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
       // `notSent` so the composer can restore the input and show a clear error
       // instead of silently dropping the message (see sendAwareFetch).
       fetch: sendAwareFetch,
-      headers: { ...headers },
       body: {
-        ...body,
         ...(conversationId ? { conversationId } : {}),
         ...(model ? { model } : {}),
         ...(systemPrompt ? { systemPrompt } : {}),
@@ -463,8 +481,25 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
       },
       // Stamp a stable per-turn idempotency key (ADR-0013 D1). See withTurnId —
       // it reconstructs the full default body (incl. messages) + adds turnId.
-      prepareSendMessagesRequest: ({ id, body: reqBody, messages, trigger, messageId }) => {
-        const req = withTurnId({ id, body: reqBody, messages, trigger, messageId });
+      prepareSendMessagesRequest: ({
+        id,
+        body: reqBody,
+        messages,
+        trigger,
+        messageId,
+        headers: reqHeaders,
+      }) => {
+        // #4187: the caller's live `body` goes in FIRST, so the fixed keys above
+        // (conversationId/model/systemPrompt/stream) and any per-send body still
+        // win - the same precedence as when it was spread into the transport's
+        // own `body` option.
+        const req = withTurnId({
+          id,
+          body: { ...bodyRef.current, ...reqBody },
+          messages,
+          trigger,
+          messageId,
+        });
         // ADR-0028: always send the CURRENTLY selected model (see modelRef above)
         // so a mid-session picker switch routes, despite the cached transport.
         if (modelRef.current) (req.body as Record<string, unknown>).model = modelRef.current;
@@ -476,10 +511,16 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
           req.body = withHandoffContext(req.body as Record<string, unknown>, parentConvRef.current);
           parentConvRef.current = undefined;
         }
-        return req;
+        // #4187: the SDK hands us its merged base headers and REPLACES them with
+        // whatever we return here, so re-merge instead of replacing. The caller's
+        // live headers go in first so a per-send header still overrides them,
+        // exactly as the transport's own `headers` option behaved.
+        const sendHeaders = new Headers(headersRef.current ?? {});
+        new Headers(reqHeaders ?? {}).forEach((value, key) => sendHeaders.set(key, value));
+        return { ...req, headers: sendHeaders };
       },
     });
-  }, [isApiMode, api, headers, body, model, systemPrompt, streamingEnabled, conversationId]);
+  }, [isApiMode, api, model, systemPrompt, streamingEnabled, conversationId]);
 
   // --- @ai-sdk/react useChat (always called to satisfy Rules of Hooks, but only active in API mode) ---
   // Ref so `onError` (fired later, async) can reach the live setMessages/messages


### PR DESCRIPTION
Fixes #4187

## 1. Premise re-measured against the installed 4.0.68 — still dormant, severity unchanged

The card's whole "waste-only" framing was written against `@ai-sdk/react@4.0.59`; the package now carries `^4.0.68`, which is what fired the hold's restart condition. I read the installed build rather than inheriting the analysis: `node_modules/.pnpm/@ai-sdk+react@4.0.68_react@19.2.8_zod@4.4.3/node_modules/@ai-sdk/react/dist/index.js`, version field `4.0.68`.

**Q: does `useChat` still store the transport in a ref and delegate through a `getTransport()` indirection?** Yes, verbatim (`dist/index.js:301-322`):

```js
const latestRef = useRef2({});
if (!("chat" in options)) {
  latestRef.current = { onToolCall: ..., onData: ..., onFinish: ..., onError: ..., sendAutomaticallyWhen: ..., transport: options.transport };
}
let defaultTransport;
const getTransport = () => { ... return latestRef.current.transport != null ? latestRef.current.transport : ... };
const chatOptions = { ...options, transport: {
  sendMessages: (sendOptions) => getTransport().sendMessages(sendOptions),
  reconnectToStream: (reconnectOptions) => getTransport().reconnectToStream(reconnectOptions)
}, ... };
```

`latestRef.current` is reassigned during every render and `getTransport()` is called at send time, so the transport is late-bound.

**Q: is `Chat` recreation still keyed only on `chat` / `id`, or does transport identity now participate?** Still only `chat` / `id` — transport identity does not participate (`dist/index.js:347`):

```js
const shouldRecreateChat = "chat" in options && options.chat !== chatRef.current || "id" in options && options.id != null && chatRef.current.id !== options.id;
```

`useObjectChat` passes `transport`, `messages` and `onError` and neither `chat` nor `id`, so the `Chat` object — and the message list with it — survives every transport rebuild.

**Conclusion: this is NOT a live per-render thread reset.** 4.0.68 behaves exactly as the card described 4.0.59, so the severity is unchanged: construction waste only, nothing a user hits. The restart condition fired on the version string, not on a behaviour change. What the bump does confirm is the card's own argument for fixing it anyway — the safety is a property of the SDK's internals that a future release can withdraw silently, and the memo gives a reviewer no warning because it is already written as though it works.

## 2. The fix

`packages/plugin-chatbot/src/useObjectChat.ts`. The caller's `body` and `headers` move out of the transport `useMemo` dep list and are read through refs at send time, the idiom the hook already uses two dozen lines above for the live model (`modelRef`) and the handoff conversation id (`parentConvRef`):

- `bodyRef` / `headersRef` are assigned on every render, beside the existing refs;
- the transport constructor keeps only the hook-owned keys (`conversationId`, `model`, `systemPrompt`, `stream`) and no longer takes `headers`;
- `prepareSendMessagesRequest` spreads `bodyRef.current` under the request body and returns the caller's headers merged into the SDK's base headers;
- the dep list drops to `[isApiMode, api, model, systemPrompt, streamingEnabled, conversationId]`.

Call-site memoization was considered and rejected upstream of this PR as unenforceable; this is the only one of the two a future caller cannot silently undo by forgetting a `useMemo` of its own.

**Merge order is preserved in both directions**, which is the part of the diff most able to regress quietly:

- body — the SDK hands `prepareSendMessagesRequest` its own `body` already merged as constructor-body over per-send body, so spreading the caller's live body *underneath* it reproduces the old precedence exactly: caller body loses to the hook-owned keys, which lose to a per-send body. Pinned by the "hook-owned keys winning over the caller body" test.
- headers — returning headers from `prepareSendMessagesRequest` REPLACES the SDK's base headers rather than merging with them, so the caller's headers are re-merged underneath the base set. A per-send header still wins, as it did when the caller's headers were the transport's own `headers` option.

**One consequence, and it is recorded in the file rather than only here:** `headers` leaving the constructor also takes them off `reconnectToStream`, which reads the constructor's `headers` through `prepareReconnectToStreamRequest` and never runs `prepareSendMessagesRequest`. That path has no consumer in this repo — `grep -rn "resumeStream\|reconnectToStream"` over `packages/` and `apps/` returns nothing outside `node_modules` — so nothing regresses today. Because a PR body is not what the next person reads, the invariant now sits as a comment on the exact line the `headers` option used to occupy, naming what a future `resumeStream` consumer has to merge and where.

## 3. The sampling-timing answer (the one real behavioural difference)

**Which values does a send observe after the change?** Those of the most recent completed render, read at send time. `bodyRef.current` / `headersRef.current` are assigned during every render; `prepareSendMessagesRequest` runs synchronously at the top of `HttpChatTransport.sendMessages`, which is itself reached through `getTransport()` at that instant. So the pair a send serializes is always the last-rendered pair, spread at send time.

**What did it observe before?** The transport spread `body`/`headers` into itself at CONSTRUCTION time, so a send serialized the values of the last render that rebuilt the transport. With both in the dep list and every caller passing a fresh literal, that was in practice also the last render — which is exactly why nothing changes for any caller that exists today. But the guarantee was incidental: it held only because the memo never hit. A caller with a stable `body` identity got a value frozen at the first construction.

**Net:** the new read is never staler than the old one and is now unconditional rather than a side effect of the memo missing. It is pinned by `useObjectChat.transportIdentity.test.tsx`, whose fourth case holds one object identity across the whole test — with a stable identity the memo never re-ran even before this change, so the value a send observes is decided purely by when it is read. That case fails on `main` with `expected 1 to be 2` and passes here.

## 4. Tests

New: `packages/plugin-chatbot/src/__tests__/useObjectChat.transportIdentity.test.tsx`, five cases, counting `new DefaultChatTransport(...)` with a construct-trap Proxy around the real class so the hook still talks to the genuine transport.

1. builds ONE transport across renders that pass fresh body/headers literals — the fix itself;
2. still rebuilds the transport when a memoized dep really changes — the memo is not simply disarmed;
3. a send carries the body/headers of the MOST RECENT render — contract pin; green before and after, stated as such rather than passed off as a regression guard;
4. reads `body` at SEND time, not at transport-construction time — the sampling change;
5. keeps the hook-owned keys winning over the caller body — the merge order above.

### Reverse-verification

Both ablations restored through `trap ... EXIT INT TERM`, each mutation proved on disk with an anchored `grep -c` in both directions before reading any result.

**A — the deps put back on the memo list** (`}, [isApiMode, api, headers, body, model, ...]);`): fixed-form count 1 then 0, ablated-form count 0 then 1, `git diff --stat` `1 file changed, 1 insertion(+), 1 deletion(-)`. Case 1 fails with `AssertionError: expected 4 to be 1` — four renders, four constructions — and 4 of 5 still pass. Restored, `git status --porcelain` empty.

**B — the whole hook reverted to `origin/main`** (`git checkout origin/main -- packages/plugin-chatbot/src/useObjectChat.ts`): fix marker `bodyRef.current = body;` count 1 then 0, pre-fix marker `headers: { ...headers },` count 0 then 1. Cases 1 and 4 fail (`expected 4 to be 1`, `expected 1 to be 2` — the frozen construction-time body), cases 2, 3 and 5 pass, which is the predicted split. `git diff --stat` printed nothing for this leg because `git checkout ref -- path` writes the index too, so that diff was staged; the two-directional grep is the load-bearing proof. Restored, and the tree verified byte-identical to HEAD afterwards: `git status --porcelain` and `git diff HEAD --name-only` both empty.

No ablation for the invariant comment in section 2 — a comment has nothing executable to pin.

### Gates, all at `72bd9df02` with a clean tree

Exit codes captured before any pipe; each line is the gate's own verdict. The three gates that can see a comment change were re-run on the new head after the review addition: `type-check`, `lint` and the package's vitest suite, all reported below at `72bd9df02`. The remaining rows were measured at `0cd066a7c`, whose only difference from this head is six lines of comment in one file.

| Gate | Exit | Verdict |
| --- | --- | --- |
| `pnpm exec vitest run packages/plugin-chatbot/` | 0 | `Test Files  23 passed (23)` / `Tests  326 passed (326)` |
| the new file alone, `--reporter=verbose` | 0 | `packages/plugin-chatbot/src/__tests__/useObjectChat.transportIdentity.test.tsx` named on all 5 lines, `Tests  5 passed (5)` |
| consumer tests (app-shell chat/AI hooks, ChatDock, studio dock, components palette) | 0 | `Test Files  7 passed (7)` / `Tests  75 passed (75)` |
| `pnpm --filter @object-ui/plugin-chatbot type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` clean |
| `pnpm --filter @object-ui/plugin-chatbot lint` | 0 | `86 problems (0 errors, 86 warnings)` |
| `node scripts/check-control-bytes.mjs` | 0 | `check-control-bytes: OK (scanned 4655 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | 0 | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump.` |
| `node scripts/check-changeset-fixed.mjs` | 0 | `All workspace packages are in the changeset fixed group.` |
| `node scripts/check-type-check-coverage.mjs` | 0 | `type-check coverage: 45/46 ... 41/41 packages compile their tests` |
| `node scripts/check-lint-coverage.mjs` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `node scripts/check-phantom-dependencies.mjs` | 0 | `Every in-scope import is declared by the package that publishes it.` |
| `node scripts/check-package-self-import.mjs` | 0 | `No package names itself inside its own src/.` |
| `node scripts/check-spec-symbol-derivation.mjs` | 0 | `1289 files scanned against 4912 spec export names` |
| `node scripts/check-i18n-call-site-keys.mjs` | 0 | `Every in-scope call-site key resolves against the en pack (2918 keys)` |
| `node scripts/check-i18n-en-drift.mjs` | 0 | `No en value changed in this range.` |
| `node scripts/check-skills-paths.mjs` | 0 | `95/96 stated path(s) resolve across 18 guide file(s); 1 baselined` |
| `node scripts/check-node-esm-load.mjs --specifiers-only` | 0 | `no un-ledgered package emits an extensionless relative specifier` |

Derived from the workflows against this diff rather than from a handed-down list; `check-changeset-fixed`, `check-phantom-dependencies`, `check-package-self-import`, `check-node-esm-load --specifiers-only`, `check-spec-symbol-derivation`, both i18n gates and `check-skills-paths` are additions the dispatch list did not name.

The 86 lint warnings are the package's pre-existing count plus two of a class this very file already emits four times: `react-hooks/refs` "Cannot access refs during render" at `useObjectChat.ts:460` and `:462`, the same warning the sibling idiom `modelRef.current = model` draws at `:423`. Left unsuppressed for consistency with the refs beside them, and lint still exits 0. `eslint . --format json` inside the package: 55 files, 0 errors, 86 warnings; the new test file contributes 0 of each.

**Narrowing declared.** Two repo-wide runs were left to CI. `pnpm lint` is `turbo run lint`, which fans the same `eslint .` out to each of 46 packages; I ran the one package whose files changed, and the flat config extends `tseslint.configs.recommended` with no `project` or `projectService`, so type-aware linting is off and this diff cannot move the verdict on a file it does not contain. `pnpm test` is sharded repo-wide in CI; I ran the changed package in full plus every test file outside it that names `plugin-chatbot` or `useObjectChat`. `check-eager-closure-budget` exits 2 here for a reason unrelated to this change — it reads `apps/console/dist/eager-closure.json`, written by a console `vite build`, and reports itself as `a broken gauge, not a passing budget` when absent; it belongs to the performance-budget job. The doc-snippet and doc-component gates were not run: no exported signature, option or type changed, so no documented snippet can compile differently.

One changeset, patch, `@object-ui/plugin-chatbot`. No release notes touched.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_
