### PR TITLE
refactor(plugin-dashboard): drop the unreachable DatasetWidget arm from DashboardRenderer's self-contained branch

### DIFF
--- a/.changeset/dashboard-self-contained-unreachable-arm-4620.md
+++ b/.changeset/dashboard-self-contained-unreachable-arm-4620.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+`DashboardRenderer` drops the unreachable `DatasetWidget` fork from its self-contained
+(card-less) branch, leaving that branch to render `SchemaRenderer` unconditionally
+(objectui#4620).
+
+`isSelfContained` is defined as `widget.type === 'metric' && !datasetBound`, and the
+`isSelfContained` arm of `renderedNode` then forked on `datasetBound` a second time. The
+`datasetBound` side of that inner fork could never execute: reaching it required
+`isSelfContained` to be true, which requires `!datasetBound`. Behaviour is unchanged —
+the removed arm never ran, and the reachable fork in the Card branch (the one that gives
+a dataset-bound metric its title and border chrome) is untouched.
+
+The cost was to readers, not to users: the shape read as "both branches handle
+dataset-bound widgets" when only one can, and a previous PR mirroring this fork onto
+`DashboardGridLayout` had to pay for the reachability argument before it could decline to
+copy the dead limb. A comment now names the invariant in place so the arm is not re-added.

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -885,9 +885,11 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                 style={innerGridSpanStyle}
                 {...designModeProps}
             >
-                 {datasetBound
-                   ? <div className={cn("h-full w-full", designMode && "pointer-events-none")}><DatasetWidget widget={effectiveWidget} dataSource={dataSource} /></div>
-                   : <SchemaRenderer schema={componentSchema} className={cn("h-full w-full", designMode && "pointer-events-none")} dataSource={dataSource} />}
+                 {/* `isSelfContained` implies `!datasetBound` (see its definition above), so a
+                     dataset-bound widget can never render here — it always takes the Card branch
+                     below for its title + border chrome. Do not re-add a `datasetBound` fork
+                     here: the arm is unreachable by construction (objectui#4620). */}
+                 <SchemaRenderer schema={componentSchema} className={cn("h-full w-full", designMode && "pointer-events-none")} dataSource={dataSource} />
                  {designMode && <div className="absolute inset-0 z-10" aria-hidden="true" data-testid="widget-click-overlay" />}
             </div>
         ) : (


### PR DESCRIPTION
Fixes #4620

Deletion-class change: removes a JSX branch that cannot execute. Behaviour is unchanged.

## Reachability, re-derived on current `origin/main`

Line numbers in the card had drifted; these are the two lines as read at merge-base `7a28e1e3f`, in `packages/plugin-dashboard/src/DashboardRenderer.tsx`:

- **:850** — `const isSelfContained = widget.type === 'metric' && !datasetBound;`
- **:888** — `{datasetBound` opening the inner fork inside the `isSelfContained` arm of `renderedNode` (which begins at **:882**)

`datasetBound` is bound exactly once for this scope, at **:570** (`const datasetBound = !!widget.dataset;`), inside `renderWidget` which opens at **:545**. It is a `const`, never shadowed and never reassigned — its only other reads were :842, :850, :888 and :917. So reaching the truthy side of the :888 fork requires `datasetBound` true, while reaching the enclosing arm at all requires `isSelfContained` true, which requires `datasetBound` false. The arm was unreachable by construction.

The guard on `isSelfContained` still carries its `&& !datasetBound` clause, i.e. the shape has **not** changed since the card was filed, so this stayed a deletion rather than becoming a behaviour question.

## The change

The self-contained arm now renders `SchemaRenderer` unconditionally, with a comment naming the invariant (`isSelfContained` implies `!datasetBound`) so the next person mirroring this shape does not re-add the dead limb — that re-addition is the cost the card documents, already paid once by the PR that mirrored this fork onto `DashboardGridLayout`.

The reachable fork in the Card branch (now at :917) is untouched. It is correct and it is the one giving a dataset-bound metric its title and border chrome.

`DatasetWidget` and `effectiveWidget` both remain referenced by that Card-branch fork, so nothing became unused and the module graph is unchanged.

## Evidence: the Card path is pinned by existing coverage, and the pin bites

The card asserted that existing dataset-bound-metric coverage already pins that such a widget takes the Card path. Verified rather than taken on trust — the test is:

`packages/plugin-dashboard/src/__tests__/DashboardRenderer.filters.test.tsx` at :162, **"injects the merged filter into a dataset widget's runtimeFilter"**. It renders `DashboardRenderer` with `{ id: 'w1', type: 'metric', dataset: 'sales', values: ['revenue'], filter: { stage: 'won' } }` (:171) and asserts `queryDataset` was called with the merged `runtimeFilter`. `isSelfContained` is false for that widget, so the assertion can only pass by way of the Card-branch fork.

Reverse-verification, to show the pin actually bites rather than merely mentioning a dataset metric — the reachable Card-branch fork was forced to its `SchemaRenderer` side on disk and the file restored via `trap ... EXIT INT TERM`:

| leg | result |
| --- | --- |
| baseline | `Test Files 1 passed (1)` · `Tests 5 passed (5)` |
| Card fork mutated | `Test Files 1 failed (1)` · `Tests 5 failed (5)`, the named test among them |
| restored | `git status --porcelain` empty, `git diff --stat` empty |

Both legs were proven on disk with anchored `grep -c` in both directions (injected marker 1 then 0; the removed guard line 0 then 1) plus `git diff --stat`. No rebuild was needed for this ablation: the test reaches the subject through the relative source specifier `../DashboardRenderer`, not through the package's `exports`/`dist`.

No new test is added. A test asserting that deleted code does not run would only re-state the deletion.

## Gates — all at `901f369bc`, exit codes captured before any pipe

| gate | exit | verdict line |
| --- | --- | --- |
| `pnpm --filter @object-ui/plugin-dashboard type-check` | 0 | clean (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/plugin-dashboard lint` | 0 | `365 problems (0 errors, 365 warnings)` — warnings all pre-existing |
| `pnpm exec vitest run packages/plugin-dashboard/` (repo root) | 0 | `Test Files 73 passed (73)` · `Tests 657 passed (657)` |
| `check-control-bytes.mjs` | 0 | `check-control-bytes: OK (scanned 4654 tracked text file(s); skipped 85 binary).` |
| `check-changeset-presence.mjs` | 0 | `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump.` |
| `check-changeset-fixed.mjs` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-type-check-coverage.mjs` | 0 | `type-check coverage: 45/46 via type-check … 0 errors outstanding` |
| `check-lint-coverage.mjs` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |

The dependency closure was built first (`pnpm --filter '@object-ui/plugin-dashboard^...' build`) — the first type-check run in the fresh worktree failed with module-resolution errors that read exactly like breakage but were only unbuilt dependencies.

**Declared narrowing.** Gate set re-derived from `.github/workflows/` against the actual diff rather than from the dispatch list. Left to CI: the repo-wide `pnpm lint` and `pnpm type-check`, `pnpm check` (CLI self-check), the phantom-deps / self-import / esm-specifiers / spec-symbols / action-forward-parity / i18n gates, the two docs type gates (which carry no path filter and so run on every PR), and Bundle Analysis (triggered by `packages/**`). The narrowing cannot hide a failure from this diff: it changes one JSX expression inside one function, adds and removes no import, no export, no string literal and no `t()` call site, so the module graph the bundle and eager-closure gauges measure is byte-for-byte the same set of edges, and the i18n and docs gates read surfaces this diff does not touch. The package's own type-check and full test suite — the two gates that can actually see this edit — were run in full, not narrowed.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_