### PR TITLE
docs(core): drop the expired formatPercent citation from the percent-route comments

### DIFF
--- a/.changeset/formatpercent-comment-citations-4596.md
+++ b/.changeset/formatpercent-comment-citations-4596.md
@@ -1,0 +1,22 @@
+---
+---
+
+Comments only — this publishes nothing, declared explicitly with an empty frontmatter
+rather than left undeclared. Two `@object-ui/core` files change and every changed line
+sits inside comment syntax; the emitted JavaScript is byte-identical (objectui#4596).
+
+Three comments cited `formatPercent` as the live example of the divide-by-100 percent
+route. Each was accurate when written and stopped being true when objectui#4590 landed:
+`formatPercent` renders through `style: 'percentPoints'` with no division. The comments
+now argue the route on its own merits without the expired citation, and record what
+replaced it — no caller in this repo takes the divide-by-100 route today. `formatPercent`
+was the last one; the two remaining `style: 'percent'` sites hand `Intl` a FRACTION, which
+is that style's own contract, and the route otherwise survives only where a test builds it
+in order to show it disagreeing.
+
+The measured argument underneath is unchanged, and the tie / extreme-magnitude pins that
+keep the percentage-points route honest are untouched. The `27,581 of 1,200,013` figure
+now names the grid it came from — objectui#4576's tie-dense grid, 0.005 steps to 2,000,
+precisions 0/1/2, on `formatMeasure`'s call shape — so it stops reading as a discrepancy
+against objectui#4590's `27,577 of 1,200,003`, which is the same grid re-measured through
+`formatPercent`.

--- a/.changeset/formatpercent-comment-citations-4596.md
+++ b/.changeset/formatpercent-comment-citations-4596.md
@@ -2,8 +2,22 @@
 ---
 
 Comments only — this publishes nothing, declared explicitly with an empty frontmatter
-rather than left undeclared. Two `@object-ui/core` files change and every changed line
-sits inside comment syntax; the emitted JavaScript is byte-identical (objectui#4596).
+rather than left undeclared (objectui#4596).
+
+Why the empty form is the right declaration here: both changed comments are **internal
+reasoning**, not consumer-visible API documentation. One sits inside `formatMeasure`'s
+body; the other is a test-file header. No released behaviour changes, and no declaration
+changes — `dist/utils/dataset-format.d.ts` is byte-identical across this change
+(measured: sha `be5f5938…`, 10,580 bytes on both sides), so nothing a consumer types
+against or reads on hover moves.
+
+Stated honestly, because an earlier draft of this note got it wrong: the shipped
+JavaScript **does** change. `tsconfig.base.json` sets `removeComments: false`
+deliberately and `@object-ui/core` builds with a plain `tsc`, so a body comment is
+emitted — `dist/utils/dataset-format.js` goes from 14,716 to 15,457 bytes, and it is the
+only one of the package's 180 dist files that moves. The test file is excluded from the
+build program (`src/**/__tests__/**`) and never reaches `dist` at all. Bytes moving is
+not the criterion; released behaviour and consumer-visible surface are, and neither does.
 
 Three comments cited `formatPercent` as the live example of the divide-by-100 percent
 route. Each was accurate when written and stopped being true when objectui#4590 landed:

--- a/packages/core/src/utils/__tests__/dataset-format.percent-convention.test.ts
+++ b/packages/core/src/utils/__tests__/dataset-format.percent-convention.test.ts
@@ -37,26 +37,37 @@
  * measured: node v22.22.2, ICU 78.2, machine locale en-US.
  *
  * ⚠️ The en cases are not decoration. The obvious way to adopt the locale's
- * convention is `Intl`'s `style: 'percent'` — the way `formatPercent` does it —
- * but that style wants a FRACTION, so a value already in percentage points must
- * be divided by 100 for `Intl` to multiply it straight back, and that round trip
- * is lossy at rounding TIES. Measured on this runner: 27,581 of 1,200,013
+ * convention is `Intl`'s `style: 'percent'`, but that style wants a FRACTION,
+ * so a value already in percentage points must be divided by 100 for `Intl` to
+ * multiply it straight back, and that round trip is lossy at rounding TIES.
+ * Measured on this runner, on #4576's tie-dense grid (0.005 steps to 2,000,
+ * precisions 0/1/2) and on `formatMeasure`'s call shape: 27,581 of 1,200,013
  * ordinary-magnitude en-US forms move that way (`0.175` at 2 decimals goes from
- * `0.18%` to `0.17%`), plus `MAX_SAFE_INTEGER` and everything from 1e23 up. The
+ * `0.18%` to `0.17%`), plus `MAX_SAFE_INTEGER` and everything from 1e23 up.
+ * (#4590 re-measured the same route through `formatPercent` and reports 27,577
+ * of 1,200,003 — a different form set, not a correction of this one.) The
  * implementation formats the percentage points DIRECTLY with the percent unit
  * instead, which was measured byte-identical on the affix across all 171 locale
- * tags tested and moves none of those 1,200,013 forms. The tie and
- * extreme-magnitude cases below are what keep that route honest: they go red if
+ * tags tested and moves none of those 1,200,013 forms.
+ *
+ * No caller takes the divide-by-100 route today: `formatPercent` used to, and
+ * moved to `style: 'percentPoints'` in #4590, so the route now survives only
+ * where a test builds it in order to show it disagreeing. The tie and
+ * extreme-magnitude cases below are what keep it that way: they go red if
  * anyone "simplifies" this into the divide-by-100 form.
  */
 
 import { describe, it, expect } from 'vitest';
 import { formatMeasure } from '../dataset-format';
 
-// The locale's own percent affix, taken from `Intl` rather than hardcoded —
-// this is the SAME source `formatPercent` renders through, so comparing against
-// it is a structural pin on "both surfaces use the locale's convention" rather
-// than a restatement of today's CLDR data.
+// The locale's own percent affix, taken from `Intl` rather than hardcoded — the
+// same CLDR convention both surfaces render, so comparing against it is a
+// structural pin on "both surfaces use the locale's convention" rather than a
+// restatement of today's CLDR data. Since #4590 the two reach that convention
+// by different `Intl` options — `style: 'percent'` here, `style: 'percentPoints'`
+// in both `formatMeasure` and `formatPercent` — and those were measured to
+// produce a byte-identical affix across all 171 locale tags tested, so this
+// stays a cross-route parity check rather than a tautology.
 function percentAffix(locale: string): { prefix: string; suffix: string } {
   let prefix = '';
   let suffix = '';

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -243,12 +243,24 @@ export function formatMeasure(
   //
   // `style: 'percentPoints'` is what closes it, and the choice of route is
   // measured, not incidental. `display` is already in percentage POINTS, while
-  // `Intl`'s `style: 'percent'` wants a fraction — so routing through that (the
-  // way `formatPercent` does) would mean dividing by 100 for `Intl` to multiply
-  // straight back, and that round trip is lossy at rounding TIES: 27,581 of
-  // 1,200,013 ordinary-magnitude en-US forms move (`0.175` at 2 decimals goes
-  // from `0.18%` to `0.17%`), plus `MAX_SAFE_INTEGER` and everything from 1e23
-  // up. Formatting the points directly with the percent UNIT was measured to
+  // `Intl`'s `style: 'percent'` wants a fraction — so routing through that
+  // would mean dividing by 100 for `Intl` to multiply straight back, and that
+  // round trip is lossy at rounding TIES: 27,581 of 1,200,013
+  // ordinary-magnitude en-US forms move (`0.175` at 2 decimals goes from
+  // `0.18%` to `0.17%`), plus `MAX_SAFE_INTEGER` and everything from 1e23 up.
+  // That count is #4576's tie-dense grid — 0.005 steps to 2,000, precisions
+  // 0/1/2 — measured on THIS formatter's call shape. #4590 re-measured the same
+  // route through `formatPercent` and reports 27,577 of 1,200,003: a different
+  // form set, not a correction of this one.
+  //
+  // No caller in this repo takes the divide-by-100 route today. `formatPercent`
+  // was the last one and moved to `style: 'percentPoints'` in #4590; the two
+  // `style: 'percent'` sites left (`element:number`'s format options and the
+  // report exporter's Excel options) hand `Intl` a FRACTION, which is that
+  // style's own contract and not this trap. The route now survives only where a
+  // test constructs it in order to show it disagreeing.
+  //
+  // Formatting the points directly with the percent UNIT was measured to
   // produce a byte-identical percent affix to `style: 'percent'` across all 171
   // locale tags tested, while moving ZERO of those 1,200,013 en forms — the
   // same convention by a route that does not touch the value.


### PR DESCRIPTION
Fixes #4596

Prose only. Three comments in `packages/core/src/utils` cited `formatPercent` as the live example of the divide-by-100 percent route. Each was accurate when written and stopped being true once objectui#4590 (PR #4595) landed: `formatPercent` renders through `style: 'percentPoints'` with no division, so a reader checking the citation found the opposite of what it claimed.

The surrounding argument is untouched. It is the measured case for the percentage-points route, and the tie / extreme-magnitude pins under it are what keep that route honest. Only the "who does it the other way" example expired.

> ### ⚠️ Retraction, left visible rather than swapped out
>
> An earlier revision of this PR body and of commit `c9ea977a1` claimed the change was **"provably zero emitted JavaScript"** and that the compiled artefact was byte-identical. **That claim was false, and the measurement behind it was invalid.** It came from a hand-run transpile with `removeComments: true` — a flag that overrode the single setting which decides the question. `tsconfig.base.json:22` sets `removeComments: false` **deliberately**, and `@object-ui/core` builds with a plain `tsc`, so a comment inside a function body is emitted into `dist`. Re-measured with the package's real build below. The empty-frontmatter changeset still stands, but on different and better ground — see the changeset section. Commit `6cb62f862` carries the correction.

## The replacement claim, confirmed by grep and not inherited

The card's own replacement sentence is that the repo now has no caller taking the divide-by-100 route. This card exists because a confident comment went stale, so the claim was checked before being written down rather than copied across. **The check changed the sentence**: there are still live `style: 'percent'` call sites, and the honest claim is narrower than the card's.

Probes, run over `packages/ apps/ examples/ e2e/ scripts/ eslint-rules/`, excluding `node_modules/` and `dist/`:

| probe | hits | reading |
|---|---|---|
| a division by 100 paired with `style: 'percent'` on one line | 2 | both are **comment prose**, in `percent-tie-halfup-4590.test.ts` and this card's own test file, describing the route as the one NOT taken |
| files containing both a `/ 100` and a `style: 'percent'` | 4 | all four are the percent-route pin suites plus `fields/src/index.tsx`, whose match is the comment explaining why the division is gone |
| executable (non-comment) lines with `style: 'percent'` | 8 | triaged below |
| other spellings of the same scaling (`* 0.01`, `/ 1e2`, `/ 100.0`) | 0 / 0 / 0 | no alternate route |

Control probes on terms known to be present, so a zero-hit above is a measurement and not a broken search: `percentPoints` **31**, `style: 'percent'` **26**, `formatPercent` **121**, `/ 100` **39**.

Triage of the 8 executable `style: 'percent'` sites:

- **2 production, neither dividing.** `packages/components/src/renderers/basic/elements.tsx:348` (`element:number`'s `FORMAT_OPTS`) and `packages/plugin-report/src/LiveReportExporter.ts:305` (`inferLocaleOptions` for the Excel export) both hand `Intl` the raw value, i.e. a FRACTION. That is `style: 'percent'`'s own contract, not the divide-by-100 trap.
- **6 in tests.** Five are the percent pin suites; `packages/i18n/src/__tests__/spec-formatters.test.ts:111` passes `0.75`, a fraction. The only executable divide-by-100 pairing left in the repo is `packages/core/src/utils/__tests__/number-display.percent-points.test.ts:114-117`, which constructs the route deliberately and asserts `.not.toBe(expected)` — a pin showing it disagreeing, not a caller.

So the sentence written into both comments is that **no caller takes the divide-by-100 route today**, with the two remaining `style: 'percent'` sites named as fraction-holders, and the route recorded as surviving only where a test builds it to show it disagreeing. That is checkable, and it names what would falsify it.

## The two counts now name their grid

`27,581 / 1,200,013` and `27,577 / 1,200,003` are both correct and neither was silently swapped. Naming "the grid" alone does not separate them — both cards describe the same grid (0.005 steps to 2,000, precisions 0/1/2). The disambiguator is the **call shape measured**, so the comments now state both:

- objectui#4576 (PR #4589 body): `27,581 of 1,200,013`, measured on `formatMeasure` / `formatDisplayNumber`'s call shape.
- objectui#4590 (PR #4595, and `packages/fields/CHANGELOG.md`): `27,577 of 1,200,003`, the same grid re-measured through `formatPercent`.

Each site keeps the count that belongs to it and points at the other as a different form set rather than a correction.

## A third site of the same defect, declared

The card named two sites. A sweep of every `formatPercent` mention in the two files turned up a third, eight lines below the header being repaired, in the same file: the `percentAffix` helper's comment claimed `Intl`'s `style: 'percent'` is "the SAME source `formatPercent` renders through". After objectui#4590 the two reach the same CLDR convention by different `Intl` options.

It is corrected in place rather than left: same defect class, same file already open, one clause, and the correct form is pinned by existing measured evidence (the 171-locale affix parity restated in `formatPercent`'s own comment). Leaving a known-stale `formatPercent` citation in the very file whose header is being repaired for stale `formatPercent` citations would reproduce the failure this card exists to stop.

The other four `formatPercent` mentions in these files were checked and are accurate: two are past-tense history, two describe what `formatPercent` still is.

## Diff shape — re-measured with the real build

**No source line outside a comment changed**, and that part was and remains sound: non-comment added lines **0**, non-comment removed lines **0**.

**The shipped bytes DO move.** Built at `HEAD` and at `HEAD~1` with `packages/core/dist` and the tsbuildinfo cleared between runs:

```
                                        before        after         verdict
dist/utils/dataset-format.js            14,716 B      15,457 B      CHANGED
                                        35d28556…     1e00cc5c…
dist/utils/dataset-format.d.ts          10,580 B      10,580 B      byte-identical
                                        be5f5938…     be5f5938…
dist file count                         180           180           unchanged
```

`dist/utils/dataset-format.js` is the **only** one of the package's 180 dist files that moves. The **declaration is byte-identical**, because the edited comment sits inside `formatMeasure`'s body and never reaches the `.d.ts`. The test file is excluded from core's build program (`src/**/__tests__/**`, per that tsconfig's own comment) and never reaches `dist` at all — `grep -c __tests__` over the emitted file list is `0`.

**Restore leg run and verified**, not skipped: after rebuilding the `HEAD~1` revision, the files were restored from `HEAD` and rebuilt, reproducing the AFTER tree hash exactly (`fe020e3764bae607`, 180/180 files) with a clean `git status`. The A/B was confirmed on disk each way — the string `way `formatPercent` does` counted **1** in the before leg and **0** after restore — so neither leg was a no-op edit.

**No new test, and no ablation — stated plainly rather than ritualised.** A prose change has nothing to assert on, and a comment cannot be ablated: removing it changes no observable behaviour, so there is no red leg to run. The existing pins are the relevant evidence and they are unmoved.

## Changeset — empty frontmatter, on the ground that actually decides it

An empty-frontmatter changeset, which the presence gate accepts as a complete answer and prints so explicitly:

```
2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
Every one of them has an EMPTY frontmatter - declared as releasing nothing, which
is the explicit exemption and a complete answer to this gate.
```

**Why it is right here is not byte identity** — the bytes move, as measured above. It is right because both comments are **internal reasoning**, not consumer-visible API documentation: one sits inside `formatMeasure`'s body, the other is a test-file header. No released behaviour changes, and the **declaration is byte-identical**, so nothing a consumer types against or reads on hover moves. That argument holds regardless of what the emitted `.js` does, which is why it is the sounder ground.

AGENTS.md names the empty form as the first-class declaration for a pure-internal change ("要的是『声明一次』,不是强制发版"), and `.changeset/dead-refresh-callback-objectview.md` is direct precedent for a package `src/` change declared empty on "internal only, no released behaviour change". A `patch` would publish the whole 39-package fixed group and, since the platform reads these changesets into its release notes, put a user-facing release note in front of people for a change with no consumer-visible surface.

The contrasting case, for the reader: a JSDoc header on an *exported* function would take a `patch`, because there the comment is the deliverable and consumers reading it on hover is the point.

## Gates

Exit codes captured before any pipe; each gate's own verdict line quoted. Re-run at `6cb62f862`, the final commit.

| gate | exit | its own verdict line |
|---|---|---|
| `pnpm --filter @object-ui/core type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` (clean) |
| `pnpm --filter @object-ui/core lint` | 0 | `513 problems (0 errors, 513 warnings)` |
| `pnpm exec vitest run packages/core/` (repo root) | 0 | `Test Files 93 passed (93)` / `Tests 1945 passed (1945)` |
| `pnpm --filter '@object-ui/core^...' build` | 0 | closure clean; core's own `tsc` build clean on all three legs above |
| `check-control-bytes.mjs` | 0 | `OK (scanned 4654 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence.mjs` | 0 | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | 0 | No changeset declares a "major" bump. |
| `check-changeset-fixed.mjs` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-type-check-coverage.mjs` | 0 | `type-check coverage: 45/46 via type-check ... 1 not compiled` |
| `check-lint-coverage.mjs` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total)` |
| `check-doc-component-types.mjs` | 0 | `Every documented component type is registered.` |
| `check-doc-links.mjs` | 0 | `Links are valid across 13 scan roots.` |
| `check-skills-paths.mjs` | 0 | `OK (95/96 stated path(s) resolve across 18 guide file(s); 1 baselined)` |
| `check-doc-snippet-types.mjs` | 1 | `The snippet program was NOT run: the packages it resolves against are not built` |

**The one non-zero is a broken gauge, not a finding.** That gate needs a full workspace build; it names `@object-ui/react` as unbuilt, a package this diff does not touch. CI builds everything before running it, and its run there is the one that counts.

The gate list was re-derived from the workflow files against this diff rather than taken on trust — `packages/core/src/**` plus `.changeset/**` starts `ci.yml`, `lint.yml`, `control-bytes.yml`, `changeset-presence.yml`, `changeset-guard.yml`, `doc-component-types.yml`, `doc-snippet-types.yml`, `docs-links.yml` and `skills-paths.yml`; `node-esm-load-gate.yml` and `published-dist-gate.yml` are nightly plus self-path-scoped and do not run on this PR.

**vitest ran from the repo root** (`RUN v4.1.10 /home/user/objectui-4596`), not a package cwd, so objectui#3378's silent-false-green is excluded. The 93 files run equal the 93 test files on disk under `packages/core`, and `vitest list` collects all **13** tests from `dataset-format.percent-convention.test.ts`, so the header edit did not disturb collection.

### Lint scope: a narrowing, declared and measured

Repo-wide `pnpm lint` (`turbo run lint`, 46 packages) is CI's run. Locally it was narrowed to `@object-ui/core`, which is the *identical command* CI runs for that package (`eslint .`) and which contains 100% of the changed source files. The three pieces that make this a measurement rather than a gap:

1. **Population from eslint's own config**, not from a guess about which files count: `eslint .` resolved in `packages/core`.
2. **File count from `--format json`: 185 files, 0 errors, 513 warnings.** Both changed files are in that population, each at `errors=0, warnings=0`.
3. **Invariance for untouched files**: the other 45 packages have zero changed files, and this diff changes no declaration in any of them, so no untouched file's verdict can move regardless of whether linting is type-aware.

## Found on the way, filed not folded in

- **#5607** — `plugin-dashboard`'s `recordFields.tsx:189-192` does `(value / 100) * 100` before calling `formatPercent`, re-introducing one call frame upstream the exact artefact objectui#4590 removed. Measured: 19,978 of 199,000 values change bit pattern and **1,108 rendered strings move**, e.g. `1.605` at 2 decimals renders `1.60%` where half-up is `1.61%`. A concrete user-visible rendering defect, kept out of this PR.
- **#5608** — `packages/core/src/utils/number-display.ts:118` and `number-display.percent-points.test.ts:96` carry the bare `27,581 of 1,200,013` figure with no grid or call shape named, so the discrepancy reading this card removes from two sites survives at two others. Prose only, `finding`-labelled, unassigned.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_