### PR TITLE
fix(app-shell): title the param dialog from `label` alone

### DIFF
--- a/.changeset/param-dialog-title-fallback-4282.md
+++ b/.changeset/param-dialog-title-fallback-4282.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The console's param-collection dialog now titles itself from `action.label` alone —
+the unreachable `|| action?.title` fallback beside it is removed (objectui#4282).
+
+`title` is declared on no action surface in the ecosystem: it is absent from
+`@objectstack/spec`'s `ActionSchema` (44 keys walked at spec 17.0.0), from
+`@object-ui/core`'s `ActionDef` and its pinned `ACTION_DEF_KEYS` / `SPEC_ACTION_KEYS`
+inventories, and from `@object-ui/types`' renderer view (`ui-action.ts`) and `crud.ts`
+`ActionSchema` / `BaseSchema`. None of the four action renderers — `action:button`,
+`action:icon`, `action:group`, `action:menu` — forwards it either. So the right-hand
+side of that `||` could not be reached by authored metadata: a fallback that cannot
+fire, which is the "declared is not enforced" shape objectstack#4075 exists to reduce.
+Nothing a user hits changes; the line now reads exactly one key, matching the
+`description` line directly below it.
+
+`useConsoleActionRuntime.paramDialogTitle.test.tsx` pins the reader so the alias cannot
+be reinstated silently: an action carrying `title` and no `label` must open an untitled
+dialog rather than a dialog named by a key no producer sets.

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.paramDialogTitle.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.paramDialogTitle.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The param-collection dialog titles itself from `label` and from nothing else
+ * (objectui#4282).
+ *
+ * This used to read `action?.label || action?.title`. `title` is declared on no
+ * action surface in the ecosystem — it is absent from `@objectstack/spec`'s
+ * `ActionSchema` (44 keys at spec 17.0.0), from `ActionDef`, from
+ * `@object-ui/types`' renderer view (`ui-action.ts`) and from its `crud.ts`
+ * `ActionSchema` / `BaseSchema` — and none of the four action renderers
+ * (`action:button`, `action:icon`, `action:group`, `action:menu`) forwards it.
+ * So the right-hand side of that `||` was unreachable from authored metadata:
+ * a fallback that cannot fire, which is precisely the "declared is not
+ * enforced" shape objectstack#4075 exists to reduce.
+ *
+ * ## Why this is a pin and not just a deletion
+ *
+ * Removing an alias is cheap; keeping it removed is the expensive half. The
+ * handler's `action` parameter is `any`, so nothing in the compiler stops the
+ * limb being helpfully reinstated by the next reader who sees an untitled
+ * dialog and reaches for a second key. The second test below is red the moment
+ * that happens, and names the rule in its failure.
+ *
+ * Deliberately NOT pinned here: that a host may not carry a `title` at all.
+ * Objects reaching this handler are plain data (objectstack#3903 — stored
+ * `sys_metadata` rows are rehydrated unparsed), so a stray key is not an error,
+ * it is simply not read. The assertion is about the READER, which is the half
+ * this file owns.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'User', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+// Partial mock: `@object-ui/components` reaches for `createSafeTranslation` at
+// import time (`lib/close-label.tsx` -> `ui/dialog.tsx`), so a total double
+// breaks the module graph before a single test runs. Same shape as the sibling
+// override-notice suite.
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@object-ui/i18n')>()),
+  useObjectLabel: () => ({
+    fieldLabel: (_o: any, _n: any, l: any) => l,
+    fieldOptionLabel: (_o: any, _f: any, _v: any, l: any) => l,
+    actionParamText: (_o: any, _a: any, _p: any, _attr: any, fallback: any) => fallback,
+    actionParamOptionLabel: (_o: any, _a: any, _p: any, _v: any, fallback: any) => fallback,
+    actionDescription: (_o: any, _a: any, fallback: any) => fallback,
+  }),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: any) => String(options?.defaultValue ?? key),
+  }),
+}));
+
+vi.mock('../useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: vi.fn(async () => ({ success: true })),
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: vi.fn(async () => null),
+  }),
+}));
+
+/** Capture the state the param dialog is handed — it IS the assertion subject. */
+let paramDialogState: any = null;
+vi.mock('../../views/ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('../../views/ActionParamDialog', () => ({
+  ActionParamDialog: ({ state }: any) => {
+    if (state?.open) paramDialogState = state;
+    return null;
+  },
+}));
+vi.mock('../../views/ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('../../views/FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('sonner', () => {
+  const fn: any = vi.fn();
+  fn.error = vi.fn();
+  fn.success = vi.fn();
+  return { toast: fn };
+});
+
+import { useConsoleActionRuntime } from '../useConsoleActionRuntime';
+
+const PARAMS = [{ name: 'comment', label: 'Comment', type: 'textarea' }] as any[];
+
+/**
+ * Mount the runtime WITH its `dialogs` element — the param dialog reads its
+ * state from there, so a bare `renderHook` would leave the capture above empty.
+ */
+function Harness({ onReady }: { onReady: (fn: any) => void }) {
+  const runtime = useConsoleActionRuntime({ dataSource: {}, objects: [] });
+  const ready = React.useRef(false);
+  if (!ready.current) {
+    ready.current = true;
+    onReady(runtime.actionProviderProps.onParamCollection);
+  }
+  return <>{runtime.dialogs}</>;
+}
+
+/**
+ * Drive `onParamCollection` the way `DeclaredActionsBar` does and read back the
+ * state the dialog received. The promise stays pending — that is the real shape
+ * too: nothing is POSTed until the dialog's own Confirm.
+ */
+async function collectParams(dispatch: Record<string, unknown>) {
+  paramDialogState = null;
+  let collect: any;
+  render(<Harness onReady={(fn) => { collect = fn; }} />);
+  await act(async () => {
+    void collect(PARAMS, dispatch as any);
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => { paramDialogState = null; });
+
+describe('useConsoleActionRuntime — the param dialog titles itself from `label` alone (objectui#4282)', () => {
+  it('titles the dialog with the action label', async () => {
+    await collectParams({
+      name: 'approval_reject',
+      label: 'Reject',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState).toBeTruthy();
+    expect(paramDialogState.title).toBe('Reject');
+  });
+
+  it('does NOT fall back to a `title` key — no producer sets one, so nothing reads one', async () => {
+    // The exact shape the removed limb served: an action with no `label` but
+    // carrying `title`. Before objectui#4282 this dialog came up titled
+    // "Should Not Win"; a key no schema declares and no renderer forwards must
+    // not be the thing naming a dialog.
+    await collectParams({
+      name: 'approval_reject',
+      title: 'Should Not Win',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState).toBeTruthy();
+    expect(paramDialogState.title).toBeUndefined();
+  });
+
+  it('leaves `label` winning when both are present', async () => {
+    // Green before AND after the removal (`||` short-circuits), so it pins no
+    // change — it is here to keep the first test's failure legible: if this one
+    // is green and the second is red, the limb is back.
+    await collectParams({
+      name: 'approval_reject',
+      label: 'Reject',
+      title: 'Should Not Win',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState.title).toBe('Reject');
+  });
+
+  it('titles from `label` independently of the description, which reads one key too', async () => {
+    await collectParams({
+      name: 'approval_reject',
+      label: 'Reject',
+      description: 'A rejection is final for every approver.',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState.title).toBe('Reject');
+    expect(paramDialogState.description).toBe('A rejection is final for every approver.');
+  });
+});

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -256,7 +256,14 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       setParamState({
         open: true,
         params: localized,
-        title: action?.label || action?.title,
+        // Titled from `label` alone — the one spelling an action carries for
+        // this. The `|| action?.title` fallback that used to sit here read a
+        // key declared on no action surface at all — not `@objectstack/spec`'s
+        // `ActionSchema`, not `ActionDef`, not `@object-ui/types`' renderer
+        // view (`ui-action.ts`) or `crud.ts` — and forwarded by none of the
+        // four action renderers, so it could not fire from authored metadata
+        // (objectui#4282). Reads exactly one key, like `description` below.
+        title: action?.label,
         description: overrideNotice
           ? [overrideNotice, declaredDescription].filter(Boolean).join('\n\n')
           : declaredDescription,


### PR DESCRIPTION
Fixes #4282

Deletes the `|| action?.title` fallback from the console param-collection
dialog's title, leaving `title: action?.label` — one key, matching the
`description` line directly below it.

## Premise re-verified before deleting anything

The card was filed against `origin/main` @ `4cb0562b5`; re-audited here against
`7a28e1e3f`. Every zero is paired with a control probe on a term known to be
present, so a zero result is a measurement rather than a broken command.

| Producer surface | probe: `title` | control | verdict |
|---|---|---|---|
| `@objectstack/spec` `ActionSchema` (walked live at spec **17.0.0**, 44 keys) | **absent** | `description` present, `label` present | no producer |
| `@object-ui/core` `SPEC_ACTION_KEYS` | **0** entries | `description` 2, `label` 2 | no producer |
| `@object-ui/core` `ACTION_DEF_KEYS` / the `ActionDef` interface | **0** fields | `description` field present | no producer |
| `@object-ui/types` `ui-action.ts` | **1** hit, prose only (`titleFormat` in a doc comment, `:273`) | `description` 4 | no producer |
| `@object-ui/types` `crud.ts` `ActionSchema` | **2** hits, both non-action: retired-`confirm` prose (`:136`) and the nested `dialog.title` (`:163`) | `description` 3 | no producer |
| `@object-ui/types` `BaseSchema` (`base.ts`) | **1** hit — and it belongs to `HTMLAttributes` (`:599`), not `BaseSchema` | `description` 12 | no producer, and none inherited |
| `action:button` / `action:icon` / `action:group` / `action:menu` | **1 / 1 / 1 / 2** hits, **all prose in comments** | `label` 14-16, `description` 2-4 each | none forwards it |

The spec walk is the pin test's own zod-internals walk, run against the
installed `@objectstack/spec@17.0.0`:

```
total keys        : 44
probe   title     : false
control description: true
control label     : true
```

Sweeping every `ActionDef` construction site in the workspace for a `title:` /
`.title =` assignment found no producer either. **No new producer has appeared
since the card was filed** — the limb was still unreachable, and is now gone.

## The `any` narrowing: attempted, measured, backed out

`ParamCollectionHandler` already types its second parameter as `ActionDef`, and
`ActionDef` is already imported by this file — so the narrowing needed no new
import and no barrel export. It was applied and type-checked. It surfaces real
type debt, in a different package:

```
src/hooks/useConsoleActionRuntime.tsx(253,45): error TS2339: Property 'overrideNotice' does not exist on type 'ActionDef'.
src/hooks/useConsoleActionRuntime.tsx(253,83): error TS2339: Property 'overrideNotice' does not exist on type 'ActionDef'.
src/hooks/useConsoleActionRuntime.tsx(254,18): error TS2339: Property 'overrideNotice' does not exist on type 'ActionDef'.
```

`overrideNotice` is the opposite of `title`: it has a **live producer**
(`DeclaredActionsBar.tsx:305` sets it on the dispatch, then casts to `ActionDef`)
and a live reader (this handler), but is declared on no action surface — exactly
the shape #5178 introduced and #4046 step 3 promoted `description` out of. The
correct fix is to declare it on `ActionDef` in `@object-ui/core` and move
`ACTION_DEF_KEYS` with it, since `actionKeys.pin.test.ts` re-derives that list
from the interface's AST. That is another package plus a pinned inventory and its
pin test, so the narrowing is **backed out here** and filed separately with these
diagnostics. Casting the `overrideNotice` read to make the narrowing compile was
rejected deliberately: it would swap a visible `any` for an invisible cast and
re-hide an undeclared key, which is the thing this card is about.

## Evidence: a reachability argument, plus a pin that bites

`useConsoleActionRuntime.paramDialogTitle.test.tsx` pins the **reader**, not the
deletion — the handler's `action` parameter is still `any`, so nothing in the
compiler stops the alias being reinstated by the next reader who sees an untitled
dialog and reaches for a second key.

Reverse-verified by mutating the fix away on disk, with a
`trap ... EXIT INT TERM` restore. The mutation was proved on disk with anchored
counts in **both** directions before anything was read:

```
anchor 'title: action?.label,' count before  : 1
removed  'title: action?.label,'      after  : 0
injected 'action?.label || action?.title,'   : 1
sha256 before mutation : ba79c42c…3cd212
sha256 after mutation  : 774f6e82…4ddbd0     (differs -> not a no-op)
```

Direction observed, as predicted: **red**, on the one test that pins the removal.

```
AssertionError: expected 'Should Not Win' to be undefined
 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
TRAP: restored packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
```

The other three stayed green by design — the third is a legibility control
(`label` wins when both are present), green before and after, so a lone red on
test 2 reads unambiguously as "the limb is back". After the trap:
`sha256` back to `ba79c42c…3cd212`, `git status --porcelain` empty.

## Gates — all on `87015140a`, the final commit

Exit codes captured **before** any pipe; each gate quoted by its own verdict line.

| Gate | exit | its own verdict |
|---|---|---|
| `@object-ui/app-shell type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` (script name echoed — not a zero-match filter) |
| `@object-ui/app-shell lint` | 0 | `✖ 2538 problems (0 errors, 2538 warnings)` — warnings pre-existing repo-wide |
| `vitest run` (observable set, 57 files) | 0 | `Test Files 57 passed (57)` · `Tests 631 passed (631)` |
| `vitest run` (transitive mounters, 30 files) | 0 | `Test Files 30 passed (30)` · `Tests 271 passed (271)` |
| `check-control-bytes.mjs` | 0 | `OK (scanned 4655 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence.mjs` | 0 | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | 0 | `No changeset declares a 'major' bump.` |
| `check-changeset-fixed.mjs` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-type-check-coverage.mjs` | 0 | `45/46 via type-check … 41/41 packages compile their tests` |
| `check-lint-coverage.mjs` | 0 | `46/46 packages linted, 0 with outstanding errors` |
| `check-action-forward-parity.mjs` | 0 | `5 surfaces checked against 40 runtime-read keys from 4 consumers` |
| `check-i18n-call-site-keys.mjs` | 0 | `Every in-scope call-site key resolves against the en pack (2918 keys)` |
| `check-i18n-en-drift.mjs` | 0 | `No en value changed in this range.` |
| `check-phantom-dependencies.mjs` | 0 | `Every in-scope import is declared by the package that publishes it.` |
| `check-package-self-import.mjs` | 0 | `No package names itself inside its own src/.` |
| `check-spec-symbol-derivation.mjs` | 0 | `1289 files scanned against 4912 spec export names` |
| `check-skills-paths.mjs` | 0 | `OK (95/96 stated path(s) resolve across 18 guide file(s); 1 baselined)` |

`check-action-forward-parity` is the one worth naming: it derives its owed key
set **from what the runtime reads**, so deleting a read shrinks that derived set.
It is green at 40 runtime-read keys across 4 consumers.

### Declared narrowing on the test run

`packages/app-shell` has **483** test files; the full package suite does not fit
inside this environment's 10-minute foreground cap (57 files took 90s, so 483
projects to roughly 12-13 minutes, and one attempt was already killed at the cap).
Instead of the whole package, the run covers a **provable superset of everything
that can observe the change** — 87 files, 902 tests, all green:

1. the population was read from the code, not guessed: every app-shell test that
   names `useConsoleActionRuntime`, every test that names `paramDialogState` or
   `ActionParamDialog`, every `*.ratchet.test.ts`, the whole `hooks/__tests__`
   directory, **plus** every test importing any of the six modules that mount the
   hook (`ConsoleShell`, `AppContent`, `PageView`, `ObjectView`, `FlowRunner`,
   `DeclaredActionsBar`, `RecordDetailView`) — the transitive mounters that would
   not show up in a grep for the hook's name;
2. the counts are vitest's own: `57 passed (57)` and `30 passed (30)`;
3. invariance: the change alters one expression inside `paramCollectionHandler`,
   whose only value flows into the param dialog's `title` prop. A test outside
   that set neither renders the dialog nor reaches the hook by any import path,
   so no excluded file's verdict can move.

CI runs the full farm in 4 shards regardless.

## Not touched, deliberately

Two things in the same defect class sit outside this card's file fence and are
filed separately rather than folded in:

- `RecordDetailView.tsx:539` carries a **second, near-identical**
  `paramCollectionHandler` with the same `title: action?.label || action?.title`
  and the same `action?: any`. Different directory, and another PR in this round
  is touching `views/` — not fixed here.
- the `overrideNotice` declaration that the narrowing needs, above.

A repo-wide sweep confirms those are the only two live reads; the two remaining
hits (`action-menu.tsx:223`, `action-forward-parity.test.tsx:21`) are prose in
comments, and both stay accurate for the `RecordDetailView` site until it is
cleaned up too.

Refs #4046, #4192, #5178.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_