### PR TITLE
docs(types): correct the UniquenessValidation deprecation prescription

### DIFF
--- a/.changeset/uniqueness-deprecation-jsdoc-4765.md
+++ b/.changeset/uniqueness-deprecation-jsdoc-4765.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/types': patch
+---
+
+Corrects the `@deprecated` prescription on `UniquenessValidation` in
+`packages/types/src/data-protocol.ts`, which pointed authors at spellings the platform
+no longer accepts (objectui#4765).
+
+Comment-only — no runtime behaviour changes. `patch` rather than an empty frontmatter
+because the JSDoc sits on an **exported** declaration and therefore ships to consumers:
+measured with the package's own build (`tsc`, and `tsconfig.base.json` deliberately sets
+`removeComments: false`), `dist/data-protocol.d.ts` goes 40218 → 41781 bytes and the new
+prose is present in the emitted `.d.ts`. What a consumer reads on hover changes, so it
+is declared. The emitted `dist/data-protocol.js` is byte-identical (sha256
+`a3de34c5…`, 207 bytes both ways) — that file is a types-only module whose entire JS
+output is the license banner plus `export {}`, so a comment on an erased `interface`
+reaches the declaration file and nothing else.
+
+Two of the three spellings it prescribed were wrong, measured against the installed
+`@objectstack/spec@17.0.0` (the report was written against `17.0.0-rc.6`):
+
+- **`indexes[].partial`** was retired in spec 17.0.0 under ADR-0049. It is a tombstone
+  (`z.never()`) that the parse rejects at any value, so "`partial` for a scoped
+  constraint" named a key that cannot be declared. A predicated unique constraint is
+  built at the database layer by a runtime migration issuing
+  `CREATE UNIQUE INDEX … WHERE`; the prescription now says so.
+- **`{ fields, unique: true }`** on `ObjectSchema.indexes` is the deprecated positional
+  spelling of `unique: 'global'` under ADR-0120 — lint `unique/unscoped-declared-index`
+  warns in 17.x and protocol 18 rejects it. The prescription now states the scope:
+  `unique: 'global' | 'organization'`.
+
+The measurement also refined the report, and the refinement is the reason the rewrite is
+not a uniform find-and-replace. The third spelling — **field-level** `unique: true` — is
+NOT deprecated. `unique` is scope vocabulary shared by two surfaces on which the same
+bare `true` means different things: at index level it stays verbatim (`isGlobalUnique`
+and `isOrganizationUnique` both return `false`), which is why it is the positional
+spelling of `'global'` and is being retired; at field level it is the positional spelling
+of `'organization'` and, in the spec's own words, "stays valid indefinitely … no trap".
+Rewriting both occurrences the same way would have replaced one piece of false guidance
+with another, so the comment now names the per-surface difference explicitly.
+
+The interface's own deprecation is untouched and remains correct: `ValidationRuleSchema`
+rejects `type: 'unique'` at the discriminator (accepted discriminants are `script`,
+`state_machine`, `format`, `cross_field`, `json_schema`, `conditional`), so a rule in
+this shape cannot reach the server.
+
+The replacement closes with what would falsify it — `UniqueScopeSchema` and
+`IndexSchema` in `@objectstack/spec` — so the next reader checks the schemas rather than
+trusting the paragraph. This is the fourth piece of false guidance found in this
+campaign (strictness ledger finding 18), and prose that cannot be checked is how the
+first three survived.

--- a/packages/types/src/data-protocol.ts
+++ b/packages/types/src/data-protocol.ts
@@ -1014,12 +1014,38 @@ export type ConditionalValidation = Omit<
  * Uniqueness validation — objectui-local, NOT spec vocabulary.
  *
  * @deprecated The spec removed this deliberately: a SELECT-then-INSERT check is
- * racy (TOCTOU) where a DB constraint is not. Declare a unique **index**
- * (`ObjectSchema.indexes`, `{ fields, unique: true }`, `partial` for a scoped
- * constraint) or field-level `unique: true` instead. `ValidationRuleSchema`
- * rejects `type: 'unique'`, so a rule in this shape cannot reach the server —
- * `ObjectValidationEngine` only evaluates it for callers that build rules by
- * hand.
+ * racy (TOCTOU) where a DB constraint is not. Enforce it in the database
+ * instead — and note that `unique` is scoped vocabulary (ADR-0120), so the
+ * replacement has to state a scope rather than a bare boolean:
+ *
+ * - A unique **index**: an `ObjectSchema.indexes` entry
+ *   `{ fields, unique: 'global' | 'organization' }`. `'organization'` is one
+ *   holder per organization (the driver prepends the NULL-safe organization
+ *   key part); `'global'` is one holder across the installation. On THIS
+ *   surface bare `unique: true` is the deprecated positional spelling of
+ *   `'global'` — lint `unique/unscoped-declared-index` warns in 17.x and
+ *   protocol 18 rejects it.
+ * - Field-level `unique` for a single-field constraint. The same token does
+ *   NOT mean the same thing on both surfaces: at field level bare `true` is
+ *   the positional spelling of `'organization'` and stays valid, though new
+ *   code spells `'organization'` so the scope is legible without knowing the
+ *   default.
+ * - A **partial** (predicated) constraint is not declarable at all. It is
+ *   built at the database layer by a runtime migration issuing
+ *   `CREATE UNIQUE INDEX … WHERE`. `indexes[].partial` was retired in
+ *   `@objectstack/spec` 17.0.0 (ADR-0049) and is now a tombstone the parse
+ *   rejects at any value — no driver ever emitted the `WHERE` clause, so a
+ *   declared partial index had been materializing as a FULL one.
+ *
+ * What would falsify the above: `UniqueScopeSchema` and `IndexSchema` in
+ * `@objectstack/spec` are what decide it. If the scope union gains a member,
+ * the `partial` tombstone is lifted, or protocol 18 lands its rejection, this
+ * paragraph is the thing that goes stale — re-read those two schemas, not this
+ * comment.
+ *
+ * `ValidationRuleSchema` rejects `type: 'unique'`, so a rule in this shape
+ * cannot reach the server — `ObjectValidationEngine` only evaluates it for
+ * callers that build rules by hand.
  */
 export interface UniquenessValidation extends BaseValidation {
   type: 'unique';


### PR DESCRIPTION
Fixes #4765

Corrects the `@deprecated` prescription on `UniquenessValidation` in `packages/types/src/data-protocol.ts`. Comment-only; no runtime behaviour.

## Re-measured against the installed spec, not the rc

The card was written against `@objectstack/spec@17.0.0-rc.6`; GA `17.0.0` is pinned now, so every claim below was re-run against the installed package. Each probe is paired with a control, because a probe that can only come out one way is not a measurement.

**`indexes[].partial` — retired, rejected at any value.** Confirmed:

```
IndexSchema.safeParse({ fields: ['a'], partial: "s = 'open'" })
  success = false
  issue.code = invalid_type   issue.path = ["partial"]
  "`indexes[].partial` was removed in @objectstack/spec 17.0.0 (#5248, #4943,
   ADR-0049) — no driver ever emitted the `WHERE` clause, so a declared partial
   index was materialized as a FULL index and the predicate silently did
   nothing. Delete the key. Partial indexes are built at the database layer,
   not the declaration surface: issue CREATE [UNIQUE] INDEX ... WHERE (the
   predicate placeholder is elided here — GitHub's write path destroys
   angle-bracketed text) from a runtime migration"
```

Same rejection at `partial: true`, so it is a tombstone rather than a type error on one value. Control: `{ fields: ['a'], zzz_not_a_key: 1 }` parses **green** — the shape is `.strip()`, not strict, so the rejection is a targeted tombstone (`partial` is typed `z.never()` in the emitted shape) and not generic unknown-key behaviour.

**`unique: true` — deprecated on the index surface.** Confirmed from the schema's own description text:

```
'global' = materialized over exactly `fields`, no organization column injected
'organization' = the driver prepends the NULL-safe organization key part
bare true = deprecated positional spelling of 'global' (warned in 17.x by lint
            unique/unscoped-declared-index, rejected at protocol 18, #5082)
            — state the scope
```

Controls: `unique: 'global'` and `unique: 'organization'` both parse green; `unique: 'nonsense_scope'` is rejected, so the union is genuinely discriminating.

## The measurement refined the card, and that changed the fix

The report treats `unique: true` as one uniform defect. It is not — **`unique` is scope vocabulary shared by two surfaces on which the same bare `true` means different things**, and the original sentence prescribed it on both in a single breath:

| surface | bare `true` means | status |
| --- | --- | --- |
| `indexes[].unique` | stays verbatim over `fields` — same materialization as `'global'` | **deprecated**; lint warns in 17.x, protocol 18 rejects |
| field-level `unique` | per-organization (the positional default) | **valid**; spec says it "stays valid indefinitely … no trap" |

Measured via the spec's own driver-facing helpers, which are the single source of truth the drivers read:

```
unique=true            isUniqueDeclared=true  isGlobalUnique=false  isOrganizationUnique=false
unique="global"        isUniqueDeclared=true  isGlobalUnique=true   isOrganizationUnique=false
unique="organization"  isUniqueDeclared=true  isGlobalUnique=false  isOrganizationUnique=true
```

`true` is neither flag, i.e. no organization key part is prepended — which is exactly why it is the positional spelling of `'global'` on the index surface. At field level the same value resolves through `isUniqueDeclared && !isGlobalUnique`, i.e. per-organization. `FieldSchema.safeParse({ type: 'text', unique: true })` parses green.

So **two** of the three prescribed spellings were wrong, and the third — field-level `unique: true` — was correct all along. Rewriting both `unique: true` occurrences the same way would have swapped one piece of false guidance for another. The replacement names the per-surface difference instead.

## The replacement

Prescribes `{ fields, unique: 'global' | 'organization' }` for the index, keeps field-level `unique` valid while flagging that the token is surface-dependent, and sends predicated constraints to the database layer (a runtime migration issuing `CREATE UNIQUE INDEX … WHERE`) rather than at a declarable key. It closes by naming what would falsify it — `UniqueScopeSchema` and `IndexSchema` in `@objectstack/spec` — so the next reader checks the schemas rather than trusting the paragraph. This is the fourth piece of false guidance found in this campaign (strictness ledger finding 18); prose that cannot be checked is how the first three survived.

The interface's own deprecation is untouched and still correct. Verified: `ValidationRuleSchema` rejects `type: 'unique'` at the discriminator (accepted: `script`, `state_machine`, `format`, `cross_field`, `json_schema`, `conditional`). Control — a fully green parse, so the probe was capable of passing: `{ type: 'format', field: 'email', format: 'email', message: 'bad', name: 'r1' }` parses `success = true`.

## Comment-only, verified rather than asserted

Every one of the 38 changed lines in the `.ts` file was classified; lines not inside the block comment: **0**.

```
git diff -U0 | classify each +/- line as comment vs code
  comment lines: 38     non-comment lines: 0
```

## Changeset form: `patch`, decided by the `.d.ts`

Measured with the package's real build (`tsc`; `tsconfig.base.json` sets `removeComments: false` deliberately), building both sides from committed states:

| artifact | before | after | verdict |
| --- | --- | --- | --- |
| `dist/data-protocol.d.ts` | 40218 bytes | 41781 bytes | **differs** — new prose present, stale prose gone |
| `dist/data-protocol.js` | 207 bytes | 207 bytes | identical, sha256 `a3de34c5…` |

The JSDoc sits on an exported declaration and reaches the declaration file, so consumer-visible API documentation changes and it is declared as `patch`.

Worth recording, since it cuts against the usual reasoning about `removeComments: false`: the emitted **JS** is byte-identical here. `data-protocol.ts` is a types-only module whose entire JS output is the license banner plus `export {}` — a comment attached to an erased `interface` reaches the `.d.ts` and nothing else. The `.d.ts` is what decided the bump; the `.js` is reported as measured, not as the general rule.

## Gates

Union re-run after the final commit, at `531561746`. Exit codes captured before any pipe; each line is the gate's own verdict.

| gate | exit | verdict |
| --- | --- | --- |
| `check-control-bytes` | 0 | OK, scanned 4666 tracked text files, skipped 85 binary |
| `check-changeset-presence` | 0 | 1 source file of 1 released package changed, 1 changeset declares it |
| `check-changeset-no-major` | 0 | No changeset declares a `major` bump |
| `check-changeset-fixed` | 0 | All workspace packages are in the changeset fixed group |
| `check-type-check-coverage` | 0 | 45/46 via `type-check`, 0 errors outstanding |
| `check-lint-coverage` | 0 | 46/46 packages linted, 0 with outstanding errors |
| `check-spec-symbol-derivation` | 0 | 1290 files scanned against 4912 spec export names |
| `pnpm --filter @object-ui/types type-check` | 0 | `tsc --noEmit` plus the examples and test projects |
| `pnpm --filter @object-ui/types lint` | 0 | 255 problems, **0 errors**, all pre-existing `no-explicit-any` |
| `pnpm exec vitest run packages/types/` (repo root) | 0 | 40 files, 460 tests, all passed |
| `check-phantom-dependencies` | 0 | Every in-scope import is declared by its publishing package |
| `check-package-self-import` | 0 | No package names itself inside its own `src/` |
| `check-skills-paths` | 0 | 95/96 stated paths resolve, 1 baselined |

The control-bytes gate was deliberately re-run **after** the changeset was committed: it scans *tracked* files, and on the first run the changeset was still untracked, so that run had not seen it. The count moves 4665 to 4666 across the two runs.

**No test and no ablation is possible on this change.** The diff is a comment; nothing executes it, so there is no assertion that could distinguish the old prose from the new one, and mutating it could not turn any suite red. The 460 passing tests are context, not evidence for this change. What stands in for a test is the parse measurement above — run against the installed spec, each probe paired with a control.

**Declared narrowing.** Repo-wide `pnpm lint` (`turbo run lint`, 46 packages) was not run locally; `@object-ui/types` was linted in full instead. Why that cannot hide a failure: the population is read from eslint's own JSON output — 99 files, 0 errors, 255 warnings, with the changed file present in it and contributing 44 pre-existing `no-explicit-any` warnings on `any` types, none of which a comment can create. The only channel by which this diff could reach another package's lint verdict is the emitted `.d.ts`, and type-aware linting is off: `eslint.config.js` has zero hits for `projectService`, `project:`, or `parserOptions` (controls on that same file: `rules` 10 hits, `files` 10 hits, so the search works). With no type information consulted, no untouched file's verdict can move. CI runs the full farm regardless.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_