### PR TITLE
docs(plugin-list): correct the stale sort advice and the misattributed docblock (#4559) (#4966)

### DIFF
--- a/.changeset/listview-comment-pair-4559.md
+++ b/.changeset/listview-comment-pair-4559.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-list': patch
+---
+
+Two comment corrections in `ListView.tsx` (objectui#4559, objectui#4966). No runtime
+behaviour changes and the emitted bundle is byte-identical; the published `.d.ts` does
+change, which is why this is a `patch` rather than an empty frontmatter.
+
+**objectui#4559 — the sort rationale stopped prescribing a formula field.** The comment
+block above the `sortFields` memo still called a formula field "the supported
+alternative (… which sorts like any text column)". Since objectui#4294 the
+`list.sortRelationalHint` string in this same file says the opposite ("Not a formula
+field: it is virtual, so no column is stored for it and the server refuses to sort by
+one"), the memo underneath filters formula out via `UNMATERIALIZED_FIELD_TYPES`, and the
+server answers such a sort with `400 INVALID_SORT` (objectstack#6994). The parenthetical
+now names the remedy the hint, the server's refusal and the README already share — a
+stored field that denormalizes the name onto this object, written when the source
+changes. This was the last copy of the retired advice in the repo.
+
+**objectui#4966 — `formatActionLabel`'s docblock now sits above `formatActionLabel`.**
+It had drifted two declarations up, so the exported `parseSortConfig` carried two
+stacked leading comments and the helper carried none. This one was not cosmetic: because
+`parseSortConfig` is exported, `vite-plugin-dts` copied the misattributed block into
+`dist/ListView.d.ts`, so every consumer's editor hover and TypeDoc introduced the sort
+parser with a sentence about action labels. Moving the block removes it from the `.d.ts`;
+`formatActionLabel` is module-private, so its now-correct docblock does not appear there.
+It also matters to `scripts/check-spec-symbol-derivation.mjs`, whose rule 2 reads the
+comment block *attached* to a declaration — a misattributed docblock is the mechanism by
+which a claim gets scored against the wrong symbol. This block carries no spec-alignment
+phrase, so nothing fired today.
+
+No tests accompany this change and none could: both edits are comment-only, and there is
+no runtime behaviour to pin. The `.d.ts` delta was measured with the package's real
+`vite build` before and after, not asserted.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -276,10 +276,6 @@ export function normalizeFilterCondition(condition: any[]): any[] {
 }
 
 /**
- * Format an action identifier string into a human-readable label.
- * e.g., 'send_email' → 'Send Email'
- */
-/**
  * Normalize a view's `sort` declaration to SortItem[]. @objectstack/spec
  * ListViewSchema.sort is `string | Array<{ field, order }>` — the TOP-LEVEL
  * value may be a bare string ("name desc"); array entries may be strings
@@ -310,6 +306,10 @@ export function parseSortConfig(sort: unknown): SortItem[] {
   return items;
 }
 
+/**
+ * Format an action identifier string into a human-readable label.
+ * e.g., 'send_email' → 'Send Email'
+ */
 function formatActionLabel(action: string): string {
   return action.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
@@ -2306,8 +2306,8 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // server cannot sort by the related record's name without a join
   // (objectstack#4256 settled that it won't), so the honest move is to stop
   // offering the illusion: relational fields leave the picker, and the hint
-  // below points at the supported alternative (a formula field that
-  // denormalizes the name onto this object, which sorts like any text column).
+  // below points at the supported alternative (a stored field that
+  // denormalizes the name onto this object, written when the source changes).
   //
   // Second rule — `UNMATERIALIZED_FIELD_TYPES` (`@object-ui/core`, bound to the
   // spec's own storage fact): a `formula` field has no materialised column, so


### PR DESCRIPTION
Fixes #4559
Fixes #4966

A triage-designated pair: two comment corrections in the same file, same class, shipped
in one PR. Prose only — zero non-comment lines change.

All coordinates were re-anchored on the declarations rather than the line numbers in the
cards, because #4965 (#3950) moved this region and moved `UNSORTABLE_FIELD_TYPES` out of
the file entirely (it now lives in `@object-ui/core` as `UNMATERIALIZED_FIELD_TYPES`).
Line numbers below are the ones actually found on `main` at `6606337e3`.

## Edit 1 — #4559: the sort rationale stopped prescribing a formula field

`packages/plugin-list/src/ListView.tsx`, in the comment block above the
`sortHasRelationalField` / `sortFields` memo, **lines 2309-2310**.

Before:

```
  // below points at the supported alternative (a formula field that
  // denormalizes the name onto this object, which sorts like any text column).
```

After:

```
  // below points at the supported alternative (a stored field that
  // denormalizes the name onto this object, written when the source changes).
```

### Both claims verified at source before writing, as the card required

**The hint string, quoted as it reads today** (`ListView.tsx:608-609`, the provider-less
fallback table):

> Columns that link to another record are not listed: they can only be sorted by the
> stored ID, not by the name shown in the cell. To sort by that name, denormalize it onto
> this object as a stored field, written when the source changes, and sort by that. **Not
> a formula field**: it is virtual, so no column is stored for it and the server refuses
> to sort by one.

**The filtering predicate, quoted as it reads today** (`ListView.tsx:2338`):

```ts
      if (!relational && !UNMATERIALIZED_FIELD_TYPES.has(field.type)) {
```

`UNMATERIALIZED_FIELD_TYPES` (`packages/core/src/utils/unmaterialized-fields.ts`) is
bound to `SEARCH_VIRTUAL_TYPES` from `@objectstack/spec/data`, which is
`new Set(['formula'])` (`packages/spec/src/data/search-fields.ts:77`, pinned by that
package's own test). So the memo does withhold formula, the string does refuse it, and
the parenthetical was still recommending it. Neither had changed in a way that would
make the parenthetical correct, so the edit proceeded.

The new wording is the one the hint and `packages/plugin-list/README.md:229-232` already
share ("a **stored field, written when the source changes**"), and
"which sorts like any text column" is dropped, as the card asked.

## Edit 2 — #4966: `formatActionLabel`'s docblock now sits above `formatActionLabel`

Same file. The block moved from **lines 278-281** (where it stacked above
`parseSortConfig`'s own docblock) down to **lines 309-312**, directly above
`formatActionLabel` at line 313.

Before:

```ts
/**
 * Format an action identifier string into a human-readable label.
 * e.g., 'send_email' → 'Send Email'
 */
/**
 * Normalize a view's `sort` declaration to SortItem[]. …
 */
export function parseSortConfig(sort: unknown): SortItem[] { … }

function formatActionLabel(action: string): string { … }
```

After:

```ts
/**
 * Normalize a view's `sort` declaration to SortItem[]. …
 */
export function parseSortConfig(sort: unknown): SortItem[] { … }

/**
 * Format an action identifier string into a human-readable label.
 * e.g., 'send_email' → 'Send Email'
 */
function formatActionLabel(action: string): string { … }
```

**This one turned out to be more than tidiness, and the measurement below is why.**
Because `parseSortConfig` is exported, `vite-plugin-dts` copied the misattributed block
straight into `dist/ListView.d.ts` — so every consumer's editor hover and TypeDoc
introduced the sort parser with a sentence about action labels. The card predicted the
adjacency cost to the next reader; it also shipped.

## The diff is comment-only, verified rather than asserted

`git diff --numstat` is `6 6 packages/plugin-list/src/ListView.tsx` (plus the changeset).
Every added and removed line, with the `+`/`-` stripped, filtered for anything that is
not comment syntax:

```
git diff -U0 -- packages/plugin-list/src/ListView.tsx \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | sed -E 's/^[+-]//' \
  | grep -vE '^[[:space:]]*(//|/\*\*|\*/|\*([[:space:]]|$))'
```

returns **0 lines**. No strings, no code, no tests — and no test or ablation is possible
on a comment edit, so none is offered rather than manufactured.

## Changeset form: a real `patch`, decided by measurement

The dispatch note's stated mechanism does not hold for this package, and the measurement
says so. `packages/plugin-list` is not built by plain `tsc` — its `build` is `vite build`
(rolldown for the bundle, `vite-plugin-dts` for the types); `tsc` appears only as
`--noEmit` in `type-check`, so `tsconfig.base.json`'s `removeComments: false` never
governs this package's emitted JS.

Measured with the package's real build, before and after the edit:

| artifact | result |
| --- | --- |
| `dist/index.js` | **byte-identical**, sha256 `639a0310d7ab0b88…` both sides |
| `dist/index.umd.cjs` | **byte-identical**, sha256 `d9db44da63c753a5…` both sides |
| `dist/ListView.d.ts` | **changes** — the misattributed block is removed |
| `dist/ListView.d.ts.map` | changes (follows the above) |

The bundler strips these comments entirely: `grep -c "Format an action identifier"` over
both emitted bundles returns `0`. The `.d.ts` delta is exactly:

```diff
 export declare function normalizeFilterCondition(condition: any[]): any[];
 /**
- * Format an action identifier string into a human-readable label.
- * e.g., 'send_email' → 'Send Email'
- */
-/**
  * Normalize a view's `sort` declaration to SortItem[]. @objectstack/spec
```

Consumer-visible API documentation changes, so this gets a real `patch` changeset rather
than an empty frontmatter. Edit 1 lives inside a function body and reaches no `.d.ts`;
`formatActionLabel` is module-private, so its now-correct docblock does not appear there
either — the whole `.d.ts` delta is the removal above.

## Gates

Re-derived from `.github/workflows/` against the actual diff rather than taken from the
dispatch list. Every exit code was captured before any pipe; each verdict line is the
gate's own.

| gate | exit | its own verdict line |
| --- | --- | --- |
| `pnpm --filter @object-ui/plugin-list type-check` | 0 | ran `tsc --noEmit && tsc -p tsconfig.test.json`, no diagnostics |
| `pnpm --filter @object-ui/plugin-list lint` | 0 | `✖ 388 problems (0 errors, 388 warnings)` — all pre-existing |
| `pnpm exec vitest run packages/plugin-list/` (repo root) | 0 | `Test Files 44 passed (44)` · `Tests 652 passed (652)` |
| `check-control-bytes` | 0 | `OK (scanned 4665 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | 0 | `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | 0 | `No changeset declares a major bump.` |
| `check-changeset-fixed` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-type-check-coverage` | 0 | `45/46 via type-check, 0 known-broken, 1 not compiled` |
| `check-lint-coverage` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `check-spec-symbol-derivation` | 0 | `1290 files scanned against 4912 spec export names` |
| `check-i18n-call-site-keys` | 0 | every in-scope call-site key resolves against the en pack |
| `check-i18n-en-drift` | 0 | `0 en value(s) changed` — independent confirmation no string moved |
| `check-action-forward-parity` | 0 | `action:menu owes 24, forwards 18` |
| `check-package-self-import` | 0 | `No package names itself inside its own src/.` |
| `check-phantom-dependencies` | 0 | `Every in-scope import is declared by the package that publishes it.` |

The last twelve were re-run on the final commit `d05c0f2b8` with a clean tree, so the
three heavy gates above them ran on a byte-identical tree.

**Narrowing, declared.** The repo-wide `pnpm lint` and `pnpm check` were not run whole;
`eslint .` was run scoped to this package, which is the only package whose files changed.
That cannot hide a failure here: the diff adds zero non-comment lines, so no rule with a
code-shaped target can newly fire, and this repo does not enable type-aware linting
across package boundaries, so a comment in `plugin-list` cannot move any verdict on an
untouched file. `performance-budget.yml` triggers on `packages/**` and so will run — it
cannot move, because both emitted bundles are byte-identical by sha256.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_