### PR TITLE
docs(console): state the ./urlParams fact directly in the FORM_RECORD_ID_PARAM comment

### DIFF
--- a/.changeset/formpage-record-id-param-comment-4319.md
+++ b/.changeset/formpage-record-id-param-comment-4319.md
@@ -1,0 +1,11 @@
+---
+---
+
+Comment-only repair in `apps/console`'s `FormPage`: the `FORM_RECORD_ID_PARAM`
+docblock no longer borrows `createdRecordPath.ts` as a second witness for
+`@object-ui/app-shell`'s root-barrel unreachability. That sibling case was
+resolved when the host-app resolver was published from the package root, so a
+reader following the cross-reference found the opposite of what it promised.
+The surviving justification is unchanged and still true — the root barrel does
+not re-export `./urlParams` — and now states that fact directly. No published
+behaviour changes.

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -140,10 +140,12 @@ export type FormPageMode = 'public' | 'internal';
  *
  * So this is the registry's name, used as the registry defines it. It is a
  * literal here rather than an import only because `@object-ui/app-shell`
- * exports its package root alone and that root does not re-export
- * `./urlParams` — the same unreachability `createdRecordPath.ts` documents for
- * `resolveHostAppSegment`. `FormPage.test.ts` pins the two spellings equal so
- * they cannot drift apart in silence.
+ * exports its package root alone — its `exports` map publishes `.` and
+ * `./styles.css`, nothing else — and that root does not re-export
+ * `./urlParams`, so `RECORD_DRAWER_PARAM` has no spelling a consumer can
+ * import. Retiring this literal means publishing the registry from that root,
+ * the way objectui#4280 collected `resolveHostAppSegment`. `FormPage.test.ts`
+ * pins the two spellings equal so they cannot drift apart in silence.
  */
 export const FORM_RECORD_ID_PARAM = 'recordId';
 


### PR DESCRIPTION
Fixes #4319

The `FORM_RECORD_ID_PARAM` docblock in `apps/console/src/components/FormPage.tsx`
explained why the param is a literal rather than an import, then closed with a
cross-reference: "the same unreachability `createdRecordPath.ts` documents for
`resolveHostAppSegment`".

Its own claim is still true. What expired is the borrowed second witness — PR
#4318 published the host-app resolver from the package root and deleted the
console's local subset, so `createdRecordPath.ts` imports the resolver today and
documents that unreachability only in the past tense. A reader following the
cross-reference found the opposite of what it promised, which made the surviving
`./urlParams` justification read as though it had also been retired.

## Both halves verified on `origin/main` `6606337e3` before writing

The dispatch made this the load-bearing step: if the first half had moved, the
literal itself would no longer be justified and this would stop being a comment
repair. It has not moved.

**Half 1 — still true, so the literal stands.** `packages/app-shell/package.json`
publishes `"."` and `"./styles.css"` and nothing else (no subpath pattern, so a
deep import is not reachable either). `grep` for `urlParams` and
`RECORD_DRAWER_PARAM` in `packages/app-shell/src/index.ts` exits 1 with zero
hits, while the control probe `resolveHostAppSegment` on the same file hits lines
74 and 79 — the absence is real, not a broken search. `packages/app-shell/src/urlParams.ts`
does exist and defines `RECORD_DRAWER_PARAM = 'recordId'` at line 86; it is
simply unreachable to a consumer.

**Half 2 — expired.** `apps/console/src/components/createdRecordPath.ts:57` is
`import { resolveHostAppSegment } from '@object-ui/app-shell';`, and its docblock
now records the old unreachability in the past tense ("#4109 could not import the
resolver ... #4280 published the resolver from the package root and deleted the
subset").

## The replacement clause

Before:

    * exports its package root alone and that root does not re-export
    * `./urlParams` — the same unreachability `createdRecordPath.ts` documents for
    * `resolveHostAppSegment`. `FormPage.test.ts` pins the two spellings equal so
    * they cannot drift apart in silence.

After:

    * exports its package root alone — its `exports` map publishes `.` and
    * `./styles.css`, nothing else — and that root does not re-export
    * `./urlParams`, so `RECORD_DRAWER_PARAM` has no spelling a consumer can
    * import. Retiring this literal means publishing the registry from that root,
    * the way objectui#4280 collected `resolveHostAppSegment`. `FormPage.test.ts`
    * pins the two spellings equal so they cannot drift apart in silence.

Two deliberate choices. The `exports` map is named inline so the claim is
checkable without opening a second file — un-checkability by cross-reference is
what failed here. And the resolver's publication is kept as **precedent for
retiring this literal**, not as a live second witness: a merged, historical
publication cannot later turn into the opposite of what it promises, which is
exactly the failure mode being repaired.

The surviving `FormPage.test.ts` sentence was re-verified rather than assumed —
`apps/console/src/components/FormPage.test.ts:260` pins `FORM_RECORD_ID_PARAM` to
`'recordId'`, with a comment at :257 naming `RECORD_DRAWER_PARAM` in
`packages/app-shell/src/urlParams.ts`. It is unchanged.

## The diff is comment-only — verified, not asserted

Every changed line sits inside the `/** ... */` docblock. Rather than leave that
to the eye, both revisions of the file were transpiled with `removeComments: true`
and the emitted programs compared: **byte-identical, 23064 bytes,
sha256 `4fdf391e7cebc470efbf6ff2b75ecffb2be641950e6a68c26c6bf3ee5ac1c36f`**, with
zero diagnostics on either side. A control probe confirms the comparison can
fail — mutating the literal to `'recordIdX'` produces a different emit.

Note on scope of that claim: `tsconfig.base.json` sets `"removeComments": false`,
so comments do ship. The claim is **not** that published bytes are unchanged;
it is that the diff carries zero program semantics.

No test and no ablation is possible on a comment edit, and none was manufactured.
There is no behaviour to assert and nothing to ablate — a mutation of prose
cannot turn any assertion red.

## Gates

Gate set re-derived from `.github/workflows/` against this diff rather than taken
on trust. Exit codes captured before any pipe; each verdict is the gate's own
line. All at `3756e86e9`, the final commit.

| Gate | Exit | Its own verdict |
| --- | --- | --- |
| `@object-ui/console` `type-check` | 0 | clean (dependency closure built first — `dist` was absent, which would have been a false red) |
| `@object-ui/console` `lint` | 0 | `200 problems (0 errors, 200 warnings)` — all pre-existing, all at lines 227+; the edit is lines 141-148 |
| `vitest run apps/console/` (repo root) | 0 | `Test Files 65 passed (65)` / `Tests 710 passed (710)` |
| `check-changeset-presence` | 0 | declares 1 changeset, empty frontmatter accepted as "releases nothing" |
| `check-changeset-no-major` | 0 | `No changeset declares a major bump.` |
| `check-changeset-fixed` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-control-bytes` | 0 | `OK (scanned 4666 tracked text file(s))` |
| `check-type-check-coverage` | 0 | `45/46 via type-check, 0 errors outstanding` |
| `check-lint-coverage` | 0 | `46/46 packages linted, 0 with outstanding errors` |
| `check-phantom-dependencies` | 0 | `Every in-scope import is declared by the package that publishes it.` |
| `check-package-self-import` | 0 | `No package names itself inside its own src/.` |
| `check-spec-symbol-derivation` | 0 | 1290 files scanned against 4912 spec export names |
| `check-action-forward-parity` | 0 | payload excess-property CHECKED |
| `check-i18n-call-site-keys` | 0 | every in-scope call-site key resolves against the en pack |
| `check-i18n-en-drift` | 0 | `No en value changed in this range.` |
| `check-node-esm-load --specifiers-only` | 0 | no un-ledgered extensionless relative specifier |
| `check-skills-paths` | 0 | `95/96 stated path(s) resolve` |
| `check-eager-closure-budget` | **2 then 0** | see below |

`check-eager-closure-budget` first exited **2** — its self-declared broken-gauge
code, because no console build had written `apps/console/dist/eager-closure.json`.
That is not a pass. The console was built and the real number read rather than
arguing the change must be inert: `Console eager closure is 3785.7 KB gzipped
across 52 of 508 chunks (budget: 3867.2 KB, headroom: 81.5 KB)`, exit 0.

**Declared narrowing.** Repo-wide farm runs — `pnpm lint` across all 46 packages,
the full 4-shard `pnpm test`, repo-wide `pnpm type-check`, and the CLI's
`pnpm check` — were left to CI, which runs them once regardless. The narrowing is
sound here for a stronger reason than the usual one: the comment-stripped emit is
byte-identical, so no type information and no lint input anywhere in the workspace
can have moved. `check-lint-coverage` and `check-type-check-coverage` both
independently report full coverage with zero outstanding errors.

## Nothing governed

The diff is exactly two files — this comment and its changeset. It touches no
`docs/adr/**`, no `.claude/**`, no `skills/**`, no `AGENTS.md` or `CLAUDE.md`, and
no `content/docs/releases/**`. Staying draft per the dispatch regardless.

## Changeset

Required — the gate was run rather than guessed, and it demanded one: `apps/console`
is inside the release's fixed group, so a change under its `src/` must declare
itself. Empty frontmatter, the explicit first-class exemption: no consumer-visible
API documentation changes, so this releases nothing.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_