### PR TITLE
docs(types): ui-action.ts no longer claims spec 17 narrowed I18nLabel to a plain string

### DIFF
--- a/.changeset/i18nlabel-comment-4611.md
+++ b/.changeset/i18nlabel-comment-4611.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/types': patch
+---
+
+`ActionParam`'s doc block no longer claims that spec 17 narrowed `I18nLabel` to a
+plain string (objectui#4611).
+
+The paragraph explaining why `label` / `options[].label` are inherited rather than
+locally overridden justified itself with a claim about `@objectstack/spec` that was
+never true: "in spec 17 `I18nLabelSchema` is `z.ZodString` — inline per-locale objects
+were dropped in favour of translation files". Measured against the installed GA pin
+`@objectstack/spec@17.0.0` (`dist/ui/index.d.ts:614`), `I18nLabelSchema` is a union of
+a string and a string-to-string record, and the schema's own doc block states two
+authorized forms with "Both are real; neither is deprecated by this schema". Executed
+against `dist/ui/index.mjs`: plain string accepted, inline locale map accepted,
+`{ key, defaultValue }` rejected. A reader who believed the comment would have taken a
+widening to `string | I18nLabel` for a no-op — which is what the finding recorded, one
+seat having nearly done exactly that.
+
+The replacement describes what `I18nLabel` admits and cites the spec's own doc block
+rather than restating a zod expression; where today's spelling is named it is scoped as
+a measurement against 17.0.0 with its file and line, so it ages as a reading rather than
+as a standing fact. The decision itself is unchanged and never depended on the false
+premise — `label` flows in by reference through the spec's schema, and a local
+`string | I18nLabel` collapses to `I18nLabel` whichever forms the union holds.
+
+Documentation only, and the release-visible surface is the declaration file: measured
+with the package's real `tsc` build (`removeComments: false`, per `tsconfig.base.json`),
+108 emitted files on both sides, `dist/ui-action.d.ts` 29,176 → 31,026 bytes, and every
+other file byte-identical — including `dist/ui-action.js` (3,480 bytes, unchanged sha),
+because the comment documents an `interface`, which is erased at emit along with its
+leading comment. No behaviour changes; hover text and the shipped `.d.ts` do.

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -312,15 +312,44 @@ export type ResolvableParamFieldType = ActionParamFieldType | ObjectUiLocalParam
  * regex?) and adding it to `@objectstack/spec`, which is where such a capability
  * would have to start.
  *
- * `label` and `options[].label` are NOT pinned, though the comment above used
- * to justify them as a widening: "labels take the spec's `I18nLabel` (a string
- * or a per-locale record)". In spec 17 `I18nLabelSchema` is `z.ZodString` —
- * inline per-locale objects were dropped in favour of translation files — so
- * the local override had become an exact restatement of the spec's own type
- * while still claiming to be wider than it. Both keys are now inherited.
- * (`__tests__/page-nav-misc-spec-parity.test.ts` pins that reading, so the day
- * the spec re-widens `I18nLabel` this decision gets re-made rather than
- * inherited.)
+ * `label` and `options[].label` are NOT pinned: both flow in by reference with
+ * the rest of the spec's keys. The comment here used to justify a local
+ * override as a widening — "labels take the spec's `I18nLabel` (a string or a
+ * per-locale record)" — and then justified deleting that override with a claim
+ * about the spec that was never true: "in spec 17 `I18nLabelSchema` is
+ * `z.ZodString`, inline per-locale objects were dropped in favour of
+ * translation files". The spec never narrowed that way (objectui#4611).
+ *
+ * What `I18nLabel` admits, stated in as many words by its own doc block in
+ * `@objectstack/spec/ui` (objectstack#5728, maintainer ruling 2026-08-06): a
+ * display label in one of TWO authorized forms — a plain default-language
+ * string, whose translations live in a translation bundle addressed by
+ * convention, or an inline locale map keyed by locale tag (`en`, `zh-CN`, ...)
+ * picked at render time — closing with "Both are real; neither is deprecated
+ * by this schema." The map form is live here, not theoretical: this repo's
+ * renderers resolve it through `pickLocalized` (e.g. `schema.title` in
+ * `packages/components/src/renderers/layout/containers.tsx`), and the spec
+ * ships `resolveI18nLabel` as the matching resolver on its own side.
+ *
+ * Deleting the override was still right, for a reason that does not depend on
+ * which forms the union holds: a plain string is one of the forms `I18nLabel`
+ * admits, so a local `string | I18nLabel` collapses to `I18nLabel` — an exact
+ * restatement of the inherited type while claiming to be wider than it.
+ * Inheriting by reference is what keeps these keys correct as the spec's set of
+ * authorized forms moves; an override is what cannot.
+ *
+ * If you need today's spelling rather than the authorized forms, measure it:
+ * against `@objectstack/spec@17.0.0` it is `z.ZodUnion([z.ZodString,
+ * z.ZodRecord(z.ZodString, z.ZodString)])` (`dist/ui/index.d.ts:614`). That is
+ * a reading of one version, not a standing fact about the schema — which is
+ * the distinction the sentence this replaces failed to make.
+ *
+ * NOT guarded: the `it(...)` case in
+ * `__tests__/page-nav-misc-spec-parity.test.ts` that calls itself an inverted
+ * pin on this decision asserts only that a plain string is assignable to
+ * `I18nLabel`, which holds under either form — so the widening above went
+ * through it green. Filed as objectui#5612; do not read that case as coverage
+ * for this paragraph.
  *
  * Drift guard: `__tests__/page-nav-misc-spec-parity.test.ts`.
  */


### PR DESCRIPTION
Fixes #4611

One paragraph of `packages/types/src/ui-action.ts`'s `ActionParam` doc block asserted something about `@objectstack/spec` that was never true, sitting on the exact symbol the label vocabulary turns on. A seat reading it while implementing the `label` / `description` widening would have taken that work for a no-op.

## The measurement, taken fresh against the installed GA

The card was filed against `17.0.0-rc.6`; the pin has since moved to GA. Resolved from `packages/types`: `@objectstack/spec@17.0.0`, `node_modules/.pnpm/@objectstack+spec@17.0.0_.../dist/ui/index.d.ts:614`, quoted with the generic brackets flattened so GitHub's body sanitizer cannot eat them (the file holds real syntax):

```
declare const I18nLabelSchema: z.ZodUnion( readonly ( z.ZodString, z.ZodRecord( z.ZodString, z.ZodString ) ) );
type I18nLabel = z.input( typeof I18nLabelSchema );
```

Still a union; the comment is false against GA as it was against rc.6. Corroborated three ways:

- **The schema's own doc block** (`:571-613`) says it in as many words: a display label in one of *two* authorized forms (objectstack#5728, maintainer ruling 2026-08-06), a plain default-language string or an inline locale map, closing with *"Both are real; neither is deprecated by this schema."*
- **Executed** against `dist/ui/index.mjs`: plain string ACCEPTED, inline locale map ACCEPTED, `{ key, defaultValue }` REJECTED.
- **The keys this paragraph is about carry that union**: `ActionParamSchema.label` and `options( ).label` are both `string | Record( string, string )` in the shipped declaration.

Live rather than theoretical, measured in this tree: 26 files under `packages/` contain a `pickLocalized(` call site (19 of them non-test), e.g. `packages/components/src/renderers/layout/containers.tsx:739` resolving `schema.title`.

## What the replacement says, and why it should not rot the same way

It leads with what `I18nLabel` **admits** and cites the spec's own doc block, rather than restating a zod expression a spec bump can falsify. Today's spelling is still recorded — a reader needs it — but scoped as *"against `@objectstack/spec@17.0.0` it is ... (`dist/ui/index.d.ts:614`)"*, a reading of one named version with its file and line, and it says so: that is the distinction the replaced sentence failed to make.

**The decision is unchanged, and never structurally depended on the false premise.** `label` flows in by reference through `Omit( z.input( typeof ActionParamSchema ), 'type' )`, so it is whatever the spec declares. Deleting the local override was right for a reason the union's contents do not affect: a plain string is one of the admitted forms, so a local `string | I18nLabel` collapses to `I18nLabel` either way — an exact restatement claiming to be wider than it is. The old text reached the right conclusion through a false premise; the correction keeps the conclusion and replaces the reasoning.

## Diff shape: comment-only, proven rather than asserted

- Source: one hunk, `@@ -315,9 +315,38 @@`, 47 changed lines, **every one** matching `^[+-] \*( |$)` — JSDoc continuation lines, all inside the block spanning 226-355 that documents `export interface ActionParam`.
- Emitted, using the package's **real** `tsc` build (`removeComments: false` per `tsconfig.base.json`, so comments *are* emitted), dist cleared and tsbuildinfo removed between legs, restore leg guarded by an EXIT trap: **108 files both sides, exactly one differs** — `dist/ui-action.d.ts`, 29,176 to 31,026 bytes, and its diff is likewise one hunk of 47 lines all matching `^[+-] \*( |$)`.
- `dist/ui-action.js` is **byte-identical** (3,480 bytes, sha256 `1b24e8f5`). Not because comments were stripped — they were not — but because this block documents an `interface`, which tsc erases along with its leading comment. No fragment of the block appears in the emitted JS on either side. Flagging this because the dispatch expected shipped JS to move: it does not *here*, and the reason is structural rather than a measurement artifact.

**Changeset form follows that measurement**: `patch` for `@object-ui/types`, not empty frontmatter. The JSDoc is on an exported declaration, so it ships in `dist/*.d.ts` and in consumers' hover text — consumer-visible API documentation, which is the criterion. No behaviour changes.

**No test and no ablation is possible on this change** — there is no executable behaviour to pin and nothing to ablate; a mutation of comment text cannot turn any assertion red. Stating that plainly rather than manufacturing a test that would only pin prose.

## Gates — exit code captured before any pipe, each gate's own verdict quoted

All run at `ec10aa217` (the final commit) with a clean tree, from the repo root:

| gate | exit | verdict |
|---|---|---|
| `pnpm --filter @object-ui/types type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json` (script name echoed, so not a zero-match) |
| `pnpm --filter @object-ui/types lint` | 0 | `✖ 255 problems (0 errors, 255 warnings)` |
| `pnpm exec vitest run packages/types/` | 0 | `Test Files 40 passed (40)` · `Tests 460 passed (460)` |
| `check-control-bytes` | 0 | `check-control-bytes: OK (scanned 4666 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | 0 | `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-changeset-no-major` | 0 | `No changeset declares a major bump.` |
| `check-type-check-coverage` | 0 | `45/46 via type-check, 0 known-broken (0 errors outstanding)` |
| `check-lint-coverage` | 0 | `46/46 packages linted, 0 with outstanding errors (0 total)` |
| `check-spec-symbol-derivation` | 0 | `1290 files scanned against 4912 spec export names` |
| `check-action-forward-parity` | 0 | `5 surfaces checked against 40 runtime-read keys from 4 consumers` |

`vitest` was run from the repo root with a path filter, never `pnpm --filter ... test` (objectui#3378). Heavy runs went through the container's shared verify lock.

**Declared narrowing.** Repo-wide `pnpm lint` / `pnpm type-check` (turbo, 46 packages), the four test shards, and the import-shape gates (`check:phantom-deps`, `check:self-import`, `check:esm-specifiers`, `check:i18n-keys`, `check:i18n-drift`) were left to CI. Why the narrowing cannot hide a failure: ESLint here is **not type-aware** — `eslint.config.js` declares no `parserOptions.project` and no `projectService` — so every file's lint verdict is a function of that file's own source, and the only source file this PR touches was linted green. For everything type- or behaviour-shaped, the emitted-artifact measurement above is the argument: the sole changed byte range in the whole build output is JSDoc text inside one `.d.ts`, so no declaration, no type, and no runtime value that any other package compiles or executes against has moved. Imports are untouched, no locale strings or `t()` call sites are involved.

## Two findings filed rather than fixed here

- **objectui#5612** — the parity test's self-described `INVERTED PIN` on this very decision **cannot detect a re-widening**. `packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts:350-366` asserts `const label: SpecI18nLabel = 'Priority'`, which type-checks under both the narrow and the wide shape. The spec has already re-widened and the pin stayed green — the event it promised to catch happened and it observed nothing. Out of this card's scope (different file), so it is filed, not touched. Its `it(...)` title is now the last copy of the false belief in this package.
- **objectui#5613** — `ui-action.ts:27` imports `I18nLabel` and never uses it (residue of the removed override). Confirmed by this PR's own lint run: `27:3 warning 'I18nLabel' is defined but never used`. Nothing fails on it: `packages/types/tsconfig.json` extends the **root** `tsconfig.json`, which sets `noUnusedLocals: false` (`tsconfig.base.json`'s `true` never reaches the package), and the ESLint rule is a warning with no `--max-warnings` cap. Left in place to keep this diff prose-only.

`skills/objectui/guides/i18n.md` carries the same false belief as a *rule* — that is #5081, `needs-user-decision`, on a governed human-merge-only surface. **Not touched here.** Notes for whoever picks it up are in the report to the dispatching seat.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_