### PR TITLE
fix(app-shell): title RecordDetailView's param dialog from `label` alone

### DIFF
--- a/.changeset/record-detail-param-dialog-title-5610.md
+++ b/.changeset/record-detail-param-dialog-title-5610.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`RecordDetailView`'s param-collection dialog now titles itself from `action.label`
+alone — the unreachable `|| action?.title` fallback beside it is removed
+(objectui#5610).
+
+This was the second copy of the limb objectui#4282 removed from
+`useConsoleActionRuntime`. `RecordDetailView` builds its own action runtime rather
+than routing through that hook, so the two near-identical `paramCollectionHandler`s
+have drifted as a pair and the first fix could not reach this one.
+
+`title` is declared on no action surface in the ecosystem: it is absent from
+`@objectstack/spec`'s `ActionSchema` (44 keys walked at spec 17.0.0), from
+`@object-ui/core`'s `ActionDef` and its pinned `ACTION_DEF_KEYS` / `SPEC_ACTION_KEYS`
+inventories, and from `@object-ui/types`' renderer view (`ui-action.ts`) and `crud.ts`
+`ActionSchema` / `BaseSchema`. None of the four action renderers — `action:button`,
+`action:icon`, `action:group`, `action:menu` — forwards it either. So the right-hand
+side of that `||` could not be reached by authored metadata: a fallback that cannot
+fire, which is the "declared is not enforced" shape objectstack#4075 exists to reduce.
+Nothing a user hits changes; the line now reads exactly one key, matching the
+`description` line directly below it.
+
+`RecordDetailView.paramDialogTitle.test.tsx` pins the reader so the alias cannot be
+reinstated silently: an action carrying `title` and no `label` must open an untitled
+dialog rather than a dialog named by a key no producer sets. A pin per reader is the
+only shape that covers both handlers, since the hook's own pin cannot see this site.

--- a/packages/app-shell/src/views/RecordDetailView.paramDialogTitle.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.paramDialogTitle.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RecordDetailView's param-collection dialog titles itself from `label` and
+ * from nothing else (objectui#5610).
+ *
+ * This used to read `action?.label || action?.title`. `title` is declared on no
+ * action surface in the ecosystem — it is absent from `@objectstack/spec`'s
+ * `ActionSchema` (44 keys walked at spec 17.0.0), from `ActionDef` and its
+ * pinned `ACTION_DEF_KEYS` / `SPEC_ACTION_KEYS` inventories, from
+ * `@object-ui/types`' renderer view (`ui-action.ts`) and from its `crud.ts`
+ * `ActionSchema` / `BaseSchema` — and none of the four action renderers
+ * (`action:button`, `action:icon`, `action:group`, `action:menu`) forwards it.
+ * So the right-hand side of that `||` was unreachable from authored metadata:
+ * a fallback that cannot fire, which is precisely the "declared is not
+ * enforced" shape objectstack#4075 exists to reduce.
+ *
+ * ## Why this file exists next to the hook's copy
+ *
+ * This is the SECOND copy of the limb. `useConsoleActionRuntime` carried the
+ * first, removed by objectui#4282 and pinned by
+ * `hooks/__tests__/useConsoleActionRuntime.paramDialogTitle.test.tsx`. This view
+ * does not route through that hook — it builds its own runtime and its own
+ * near-identical `paramCollectionHandler` — so the two have drifted as a pair
+ * and the hook's pin cannot see this site at all. A pin per reader is the only
+ * shape that covers both.
+ *
+ * ## Why this is a pin and not just a deletion
+ *
+ * Removing an alias is cheap; keeping it removed is the expensive half. The
+ * handler's `action` parameter is `any`, so nothing in the compiler stops the
+ * limb being helpfully reinstated by the next reader who sees an untitled
+ * dialog and reaches for a second key. The second test below is red the moment
+ * that happens, and names the rule in its failure.
+ *
+ * Deliberately NOT pinned here: that a host may not carry a `title` at all.
+ * Objects reaching this handler are plain data (objectstack#3903 — stored
+ * `sys_metadata` rows are rehydrated unparsed), so a stray key is not an error,
+ * it is simply not read. The assertion is about the READER, which is the half
+ * this file owns.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => vi.fn(async () =>
+    new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  ),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => [],
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+/**
+ * Capture the state the param dialog is handed — it IS the assertion subject.
+ * The sibling dialogs are orthogonal chrome, stubbed like the other
+ * RecordDetailView suites do.
+ */
+let paramDialogState: any = null;
+vi.mock('./ActionParamDialog', () => ({
+  ActionParamDialog: ({ state }: any) => {
+    if (state?.open) paramDialogState = state;
+    return null;
+  },
+}));
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+// Importing the client modal transport for real drags in <ModalForm> and the
+// whole plugin-form graph — same posture as the modal-dispatch suite.
+vi.mock('../hooks/useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: vi.fn(async () => ({ success: true })),
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: vi.fn(async () => null),
+  }),
+}));
+
+vi.mock('../utils/consoleServerAction', () => ({
+  createConsoleServerActionHandler: () => vi.fn(async () => ({ success: true })),
+}));
+
+/**
+ * Capture every <ActionProvider>'s props while keeping the real provider. The
+ * record page's own provider is the one whose CONTEXT carries this record, so
+ * the selector below picks it even if a nested surface mounts one of its own.
+ * `useObjectLabel` / `useObjectTranslation` are deliberately left REAL: with no
+ * bundle loaded they return the metadata literal, which is exactly the
+ * "authored value reaches the dialog" path under test.
+ */
+const captured: Array<{ onParamCollection: any; context: any }> = [];
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    ActionProvider: (props: any) => {
+      captured.push({ onParamCollection: props.onParamCollection, context: props.context });
+      return React.createElement(actual.ActionProvider as any, props);
+    },
+    SchemaRenderer: () => null,
+  };
+});
+
+import { MetadataCtx } from '@object-ui/react';
+import { RecordDetailView } from './RecordDetailView';
+
+const OBJECT_NAME = 'crm_call';
+const RECORD_ID = 'rec-call-1';
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'Call',
+    fields: {
+      id: { type: 'text', label: 'Id' },
+      name: { type: 'text', label: 'Name' },
+    },
+  },
+];
+
+const METADATA = {
+  objects: OBJECTS,
+  pages: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invalidate: () => {},
+  ensureType: async () => [],
+  getItem: async () => null,
+  getItemsByType: () => [],
+} as any;
+
+const PARAMS = [{ name: 'comment', label: 'Comment', type: 'textarea' }] as any[];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => ({ id: RECORD_ID, name: 'Intro call' })),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+/** The record page's OWN `onParamCollection` — the provider given this record. */
+function recordPageParamCollection() {
+  return [...captured]
+    .reverse()
+    .find((c) => c.onParamCollection && c.context?.record?.id === RECORD_ID)?.onParamCollection;
+}
+
+/**
+ * Mount the view, then drive its `onParamCollection` the way `DeclaredActionsBar`
+ * does and read back the state the dialog received. The promise stays pending —
+ * that is the real shape too: nothing is POSTed until the dialog's own Confirm.
+ */
+async function collectParams(dispatch: Record<string, unknown>) {
+  render(
+    <MemoryRouter initialEntries={[`/app/demo/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={METADATA}>
+        <RecordDetailView
+          dataSource={makeDataSource()}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={RECORD_ID}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(recordPageParamCollection()).toBeTruthy());
+  const collect = recordPageParamCollection()!;
+  paramDialogState = null;
+  await act(async () => {
+    void collect(PARAMS, dispatch as any);
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+  captured.length = 0;
+  paramDialogState = null;
+  // Unrelated chrome on this view (approvals, favourites, …) reaches for the
+  // platform API; in jsdom that is a real socket. Answer it locally so the only
+  // asynchrony left is the record load the capture waits on.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('RecordDetailView — the param dialog titles itself from `label` alone (objectui#5610)', () => {
+  it('titles the dialog with the action label', async () => {
+    await collectParams({
+      name: 'approval_reject',
+      label: 'Reject',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState).toBeTruthy();
+    expect(paramDialogState.title).toBe('Reject');
+  });
+
+  it('does NOT fall back to a `title` key — no producer sets one, so nothing reads one', async () => {
+    // The exact shape the removed limb served: an action with no `label` but
+    // carrying `title`. Before objectui#5610 this dialog came up titled
+    // "Should Not Win"; a key no schema declares and no renderer forwards must
+    // not be the thing naming a dialog.
+    await collectParams({
+      name: 'approval_reject',
+      title: 'Should Not Win',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState).toBeTruthy();
+    expect(paramDialogState.title).toBeUndefined();
+  });
+
+  it('leaves `label` winning when both are present', async () => {
+    // Green before AND after the removal (`||` short-circuits), so it pins no
+    // change — it is here to keep the second test's failure legible: if this one
+    // is green and that one is red, the limb is back.
+    await collectParams({
+      name: 'approval_reject',
+      label: 'Reject',
+      title: 'Should Not Win',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState.title).toBe('Reject');
+  });
+
+  it('titles from `label` independently of the description, which reads one key too', async () => {
+    await collectParams({
+      name: 'approval_reject',
+      label: 'Reject',
+      description: 'A rejection is final for every approver.',
+      objectName: 'sys_approval_request',
+    });
+    expect(paramDialogState.title).toBe('Reject');
+    expect(paramDialogState.description).toBe('A rejection is final for every approver.');
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -535,8 +535,20 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       setParamState({
         open: true,
         params: localized,
-        // Title the dialog as the action rather than the generic "Action parameters".
-        title: action?.label || action?.title,
+        // Title the dialog as the action rather than the generic "Action
+        // parameters" — from `label` alone, the one spelling an action carries
+        // for this. The `|| action?.title` fallback that used to sit here read
+        // a key declared on no action surface at all — not `@objectstack/spec`'s
+        // `ActionSchema` (44 keys walked at spec 17.0.0), not `ActionDef` or its
+        // pinned `ACTION_DEF_KEYS` / `SPEC_ACTION_KEYS`, not `@object-ui/types`'
+        // renderer view (`ui-action.ts`) or `crud.ts` — and forwarded by none of
+        // the four action renderers, so it could not fire from authored
+        // metadata. This was the SECOND copy of the limb objectui#4282 removed
+        // from `useConsoleActionRuntime`: this view builds its own runtime
+        // rather than routing through that hook, so the two param-collection
+        // handlers drift as a pair (objectui#5610). Reads exactly one key, like
+        // `description` below.
+        title: action?.label,
         description: actionDescription(objForI18n, action?.name, action?.description),
         resolve,
       });

--- a/packages/components/src/renderers/action/__tests__/action-forward-parity.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-forward-parity.test.tsx
@@ -18,10 +18,17 @@
  *
  * `label` and `description` are the measured instance. The console's param
  * collection handler titles its dialog from exactly those two —
- * `title: action?.label || action?.title` and
- * `description: actionDescription(…, action?.description)`
- * (useConsoleActionRuntime.tsx:205-207) — so an overflow action opened an
- * untitled dialog while the SAME declaration, rendered inline, named itself.
+ * `title: action?.label` and `description: actionDescription(…,
+ * action?.description)`, in the `setParamState` call of
+ * `useConsoleActionRuntime`'s `paramCollectionHandler` (and of the second copy
+ * that `RecordDetailView` carries) — so an overflow action opened an untitled
+ * dialog while the SAME declaration, rendered inline, named itself.
+ *
+ * The title line used to read `action?.label || action?.title`. That fallback
+ * named a key declared on no action surface and forwarded by no renderer, and
+ * was removed by objectui#4282 and objectui#5610; `label` is now the only key
+ * that titles the dialog, which is what makes this file's `label` assertion the
+ * whole of the title contract rather than half of it.
  *
  * ## Why this file exists alongside `scripts/check-action-forward-parity.mjs`
  *

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -220,9 +220,13 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
             type: action.type,
             name: action.name,
             // See action-button.tsx — the param-collection dialog titles itself
-            // from these two (`title: action?.label || action?.title`,
-            // `description: …action?.description` in
-            // useConsoleActionRuntime.tsx:205-207). Dropped here, an overflow
+            // from these two (`title: action?.label` and
+            // `description: …action?.description`, in the `setParamState` call
+            // of `useConsoleActionRuntime`'s `paramCollectionHandler` and of the
+            // second copy in `RecordDetailView`). The title used to read
+            // `action?.label || action?.title`; that fallback named a key no
+            // action surface declares and no renderer forwards, and was removed
+            // by objectui#4282 and objectui#5610. Dropped here, an overflow
             // action opened an untitled dialog while the SAME declaration
             // rendered inline named itself, so the split that decides which
             // renderer an action gets — `action:bar`'s `maxVisible`, 3 desktop


### PR DESCRIPTION
Fixes #5610

Deletes the `|| action?.title` fallback from `RecordDetailView`'s param-collection
dialog title, leaving `title: action?.label` — one key, matching the `description`
line directly below it.

This is the **second copy** of the limb #5609 removed from
`useConsoleActionRuntime`. `RecordDetailView` builds its own action runtime rather
than routing through that hook, so the two near-identical `paramCollectionHandler`s
drifted as a pair and the first fix could not reach this site.

## Premise re-verified before deleting anything, on current `origin/main`

The card cited `:539` and `:500`. Both are **still accurate** at `6606337e3` — quoted
at the numbers actually found:

- `:500` — `const paramCollectionHandler = useCallback((params: ActionParamDef[], action?: any) => {`
- `:539` — `title: action?.label || action?.title,`

Every zero is paired with a control probe on a term known present, so a zero is a
measurement rather than a broken command.

| Producer surface | probe: `title` | control | verdict |
|---|---|---|---|
| `@objectstack/spec` `ActionSchema` (walked live at spec **17.0.0**, 44 keys) | **absent** | `description` present, `label` present | no producer |
| `@object-ui/core` `actionKeys.ts` (`ACTION_DEF_KEYS` / `SPEC_ACTION_KEYS`) | **0** quoted entries | `'description'` 2, `'label'` 2 | no producer |
| `@object-ui/core` `ActionDef` interface (`ActionRunner.ts:112`) | **0** fields | `description` 1, `label` 1 | no producer |
| `@object-ui/types` `ui-action.ts` | **1** hit, prose only (`titleFormat`, `:273`) | `description` 4, `label` 10 | no producer |
| `@object-ui/types` `crud.ts` `ActionSchema` (body `88..262`) | **0** own fields — only retired-`confirm` prose (`:136`) and the **nested** `dialog.title` (`:161-163`) | `label` 2 | no producer |
| `@object-ui/types` `BaseSchema` (`base.ts` body `69..333`) | **0** | `description` 5, `label` 17 | no producer, and none inherited |
| `base.ts:599` `title?: string` | belongs to `HTMLAttributes` (`:595`), **not** `BaseSchema` | — | the DOM tooltip attribute |
| `action:button` / `action:icon` / `action:group` / `action:menu` | **2 / 1 / 1 / 4** hits, **all prose in comments**; 0 code-level forwards | `label` 13-14 each, `description` 1-3 each | none forwards it |

The spec walk is the pin test's own zod-internals walk, run against the installed
`@objectstack/spec@17.0.0`:

```
total keys        : 44
probe   title     : false
control description: true
control label     : true
```

Two probe corrections worth naming, since they change how the table reads:

- **`crud.ts`'s `ActionSchema` has no `description` either** (0 in the interface
  body). #5609's row used a file-scoped `description` count as its control against
  an interface-scoped probe. Scoped consistently, `label` (2) is the only valid
  in-scope control there — a control that is itself absent cannot falsify anything.
- Two `title` substrings inside `@object-ui/core` (`ActionRunner.ts:129`,
  `actionKeys.ts:103`) are **not** mentions of this key: they are the words
  "sub**title**" and "**title**d itself" in prose about `description`. Both still
  read correctly and are left alone.

**Producer sweep — no new producer has appeared since #5609 landed.** Zero
`.title =` assignments on any action-shaped object; `DeclaredActionsBar` (the live
`overrideNotice` producer) sets **zero** `title:` keys on its dispatch; and
`useActionTextLocalizer` — the one thing that rewrites an action on the way to the
runner — emits `label`, `confirmText` and `successMessage` only. A repo-wide sweep
for reads of the key returns exactly **one live read**, the one this PR removes
(control: 52 `action?.label` reads):

```
packages/app-shell/src/views/RecordDetailView.tsx:539                                    ** this one, removed here
packages/app-shell/src/hooks/useConsoleActionRuntime.tsx:260                             prose (#5609's own comment)
packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.paramDialogTitle.test.tsx:13   prose
packages/components/src/renderers/action/action-menu.tsx:223                             prose - refreshed here
packages/components/src/renderers/action/__tests__/action-forward-parity.test.tsx:21     prose - refreshed here
```

## The two prose mentions: both were stale, both refreshed

Neither still read correctly, so neither was left:

- **`action-menu.tsx:223`** quoted `title: action?.label || action?.title` verbatim as
  a description of live code. No such expression exists anywhere in the repo after
  this PR.
- **`action-forward-parity.test.tsx:21`** quoted the same dead expression *and* cited
  `useConsoleActionRuntime.tsx:205-207`, which was already wrong before this PR — the
  `setParamState` call sits at `:266-269` today.

Both now cite the **symbol** (`useConsoleActionRuntime`'s `paramCollectionHandler`,
and the second copy in `RecordDetailView`) rather than a line number, because a line
cite in a doc comment is a fact with no gate behind it — this is the second time
these numbers have gone stale. The parity test's header also now states why its
`label` assertion is the *whole* of the title contract rather than half of it.

## Evidence: a reachability argument, plus a pin that bites

`RecordDetailView.paramDialogTitle.test.tsx` pins the **reader**, not the deletion —
the handler's `action` parameter is still `any`, so nothing in the compiler stops the
alias being reinstated by the next reader who sees an untitled dialog and reaches for
a second key. A pin per reader is the only shape that covers both handlers: the hook's
existing pin cannot see this site at all, which is precisely why this limb survived
#5609.

Reverse-verified by mutating the fix away on disk, with a `trap ... EXIT INT TERM`
restore. The mutation was proved on disk with anchored counts in **both** directions
before anything was read — the editor's exit code was not used as evidence:

```
sha256 before mutation                          : 19078d2936280e2f
anchor  'title: action?.label,'        before   : 1
mutant  'title: ...label || ...title,' before   : 0
python replace: 1 site rewritten
sha256 after mutation                           : b649b9421c1e52cc   (differs -> not a no-op)
removed 'title: action?.label,'        after    : 0
injected 'title: ...label || ...title,' after   : 1
git diff --stat: 1 file changed, 1 insertion(+), 1 deletion(-)
```

**No rebuild step, stated deliberately:** the ablation condition that forces one does
not hold here. The test imports `./RecordDetailView` **relatively, from inside the same
package's `src/`**, so it reads the mutated file directly — there is no dependency
`exports` hop to a built `dist/` that a stale artifact could hide behind.

Direction observed, as predicted: **red**, on the one test that pins the removal.

```
AssertionError: expected 'Should Not Win' to be undefined
 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
VITEST_EXIT=1
TRAP: restored packages/app-shell/src/views/RecordDetailView.tsx
```

The other three stayed green **by design**, and are not counted as evidence of the
deletion: test 1 and test 4 assert the `label` path, which the mutation does not
touch; test 3 is a legibility control (`label` wins when both are present, green
before *and* after because `||` short-circuits). A lone red on test 2 beside a green
test 3 reads unambiguously as "the limb is back". After the trap: `sha256` back to
`19078d2936280e2f`, `git status --porcelain` empty.

## Gates — all on `861520af9`, the final commit

Exit codes captured **before** any pipe; each gate quoted by its own verdict line.

| Gate | exit | its own verdict |
|---|---|---|
| `@object-ui/app-shell type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` (script body echoed — not a zero-match filter) |
| `@object-ui/components type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` (script body echoed) |
| `@object-ui/app-shell lint` | 0 | `✖ 2549 problems (0 errors, 2549 warnings)` |
| `@object-ui/components lint` | 0 | `✖ 896 problems (0 errors, 896 warnings)` |
| `vitest run` (app-shell observable set, 87 files) | 0 | `Test Files 87 passed (87)` · `Tests 928 passed (928)` |
| `vitest run` (`packages/components/`, whole package) | 0 | `Test Files 174 passed (174)` · `Tests 1576 passed (1576)` |
| `check-control-bytes.mjs` | 0 | `OK (scanned 4667 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence.mjs` | 0 | `4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | 0 | `No changeset declares a 'major' bump.` |
| `check-changeset-fixed.mjs` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-type-check-coverage.mjs` | 0 | `45/46 via type-check … 41/41 packages compile their tests` |
| `check-lint-coverage.mjs` | 0 | `46/46 packages linted, 0 with outstanding errors (0 total)` |
| `check-action-forward-parity.mjs` | 0 | `5 surfaces checked against 39 runtime-read keys from 4 consumers` |
| `check-phantom-dependencies.mjs` | 0 | `Every in-scope import is declared by the package that publishes it.` |
| `check-package-self-import.mjs` | 0 | `No package names itself inside its own src/.` |
| `check-node-esm-load.mjs --specifiers-only` | 0 | `no un-ledgered package emits an extensionless relative specifier` |
| `check-spec-symbol-derivation.mjs` | 0 | `1290 files scanned against 4912 spec export names` |
| `check-i18n-call-site-keys.mjs` | 0 | `Every in-scope call-site key resolves against the en pack (2918 keys)` |
| `check-i18n-en-drift.mjs` | 0 | `No en value changed in this range.` |
| `check-skills-paths.mjs` | 0 | `OK (95/96 stated path(s) resolve across 18 guide file(s); 1 baselined)` |
| `check-doc-component-types.mjs` | 0 | `Every documented component type is registered.` |
| `check-doc-links.mjs` | 0 | (green) |

`check-action-forward-parity` is the one worth naming, and it is **not** presented as
confirmation the deletion was safe: it derives its owed key set *from what the runtime
reads*, so deleting a read shrinks that set and its pass is structurally guaranteed.
The measurement is visible — it reports **39** runtime-read keys where #5609 reported
40. The reachability probes above carry the safety argument, not this gate.

The lint warning delta on `app-shell` (2538 in #5609 to 2549) is entirely the new test
file: 26 `@typescript-eslint/no-explicit-any` warnings, the same rule and same class the
sibling suites already carry (`RecordDetailView.modalDispatch.test.tsx` has 35). They
are unavoidable while the handler's `action` is `any` — see the out-of-scope note below.
Zero errors either way, which is the gate's criterion.

### Two gates NOT run locally, declared

Both are broken-gauge preconditions in this container, not verdicts on this change,
and CI runs both regardless:

- **`check-eager-closure-budget.mjs` (exit 2)** — `No eager-closure report at
  apps/console/dist/eager-closure.json … an absent report means the console was not
  built`. It needs a full `apps/console` vite build. It cannot move here: the diff
  changes **zero import or export lines in production source** (verified by diffing
  the two non-test files for `import`/`require(`/`export` lines — 0 and 0). Every added
  import in this PR lives in the new **test** file, which no app bundle includes.
- **`check-doc-snippet-types.mjs` (exit 1)** — `The snippet program was NOT run: the
  packages it resolves against are not built`, naming `app-shell`, `cli`,
  `plugin-markdown`, `plugin-timeline` as `[unbuilt-package]`. This PR changes **zero**
  docs-site files (the only `.md` it adds is the changeset), so the gate has nothing of
  mine to scan.

### Declared narrowing on the app-shell test run

`packages/app-shell` has **487** test files and the full package suite does not fit the
container's 10-minute foreground cap. `packages/components` was run **whole** (174
files) rather than narrowed, since the change there is comment-only. For app-shell the
run covers a **provable superset** of everything that can observe the change — 87 files,
928 tests, all green:

1. the population was read from the code, not guessed — the union of: every app-shell
   test naming `RecordDetailView` (28); every test naming `AppContent`,
   `InterfaceListPage`, `ObjectDataPage`, `ObjectView` or importing the `views` barrel,
   i.e. the transitive mounters that would not appear in a grep for the view's own name
   (52); every `*ratchet*` test (7); and every test naming `ActionParamDialog`,
   `onParamCollection`, `paramDialogState` or `paramCollection` (26);
2. the counts are vitest's own: `87 passed (87)` / `928 passed (928)`, and
   `174 passed (174)` / `1576 passed (1576)`;
3. invariance: the change alters one expression inside `paramCollectionHandler`, whose
   only value flows into the param dialog's `title` prop. A test outside that set
   neither renders the dialog nor reaches the view by any import path, so no excluded
   file's verdict can move. The other two edited files are **comments only** and can
   move no verdict at all.

CI runs the full farm regardless.

## Not touched, deliberately

The `any` to `ActionDef` narrowing on this handler is **out of scope** and filed as
#5611. It hits the same `overrideNotice` wall #4282 measured — a live producer at
`DeclaredActionsBar.tsx:305` for a key declared on no action surface. It was not
attempted here, and deliberately **not** cast around: a cast would swap a visible `any`
for an invisible one, which is the defect class this card belongs to.

Refs #4282, #4046, #4192, #5178.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_