### PR TITLE
fix(console): evaluate visibleWhen/visibleOn in FormPage

### DIFF
--- a/.changeset/console-formpage-visible-predicates-5594.md
+++ b/.changeset/console-formpage-visible-predicates-5594.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/console': patch
+---
+
+The console's standalone form renderer now evaluates conditional field visibility.
+
+`apps/console/src/components/FormPage.tsx` is a **second, independent form renderer**
+— its own `buildSections`, its own JSX — and it serves both the public
+`/f/:slug` route and the internal `/forms/:name` route. It read neither spelling of
+the FormView field visibility predicate: a repo-wide grep for a `visibleWhen` /
+`visibleOn` *read* inside that file returned zero. So a field an author conditioned on
+`record.priority == 'urgent'` — legal, spec-strict metadata that `@objectstack/spec`
+normalises to `visibleWhen` (ADR-0089), and that the metadata-admin designer both
+authors and honours — rendered unconditionally on both routes. Fail-open and silent:
+the author saw the field always, with no diagnostic.
+
+objectui#2212 recorded this exact symptom and PR #2214 fixed it — in a **different
+chain**: `ModalForm` → `resolveFormViewLayout` → `@object-ui/plugin-form`
+`sectionFields.ts` → `@object-ui/components` `renderers/form/form.tsx`. `FormPage.tsx`
+is on that chain at no point, and #2212's regression pin lives with the chain it fixed,
+so nothing in the suite could see this copy. One contract, two implementations, each
+only ever checked against itself.
+
+The wiring is **#2212's ruling applied verbatim** rather than a second predicate
+semantics invented for this renderer, because two form renderers disagreeing about what
+`visibleWhen` *means* would be a worse defect than one renderer ignoring it. The
+predicate goes through the canonical engine — `evalFieldPredicate` (`@object-ui/core`,
+`evaluator/fieldRules.ts`) — so the accepted wire shapes (bare CEL string and
+`{ dialect, source }`), the bound scope (`record.*` = the live input values, `previous.*`
+= the stored record an edit form started from), and the fail-open-but-loud behaviour on
+an unevaluable predicate are the shared ones by construction. Resolution is
+canonical-first, `visibleWhen ?? visibleOn`, matching both sibling readers:
+`sectionFields.ts` and app-shell's `readVisibility`.
+
+Two things deliberately did **not** change. A field hidden by its predicate still
+submits its value — conditional visibility is a rendering rule in both renderers, and
+making it a submit-payload rule would be a new contract decided once for both, not
+invented in the second one. And `FormPage` is **not** folded onto the plugin-form chain:
+the second-renderer question is real, but it belongs with the #5596 convergence track,
+not with a predicate that is dead today.
+
+`FormPage.visibleWhen.test.tsx` is the regression pin, and it lives next to *this*
+renderer on purpose — a pin that cannot see the second copy is how the first gap
+survived. With the fix reverted and the pin in place the suite reports
+`11 failed | 1 passed (12)`; the one green is the control that has to be green (a field
+with no predicate still renders), without which every "the field is absent" assertion
+would be equally satisfied by a renderer that draws nothing at all.

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -48,11 +48,30 @@
  * router — a full-page navigation ignores the console mount and drops the
  * submitter at the origin root — while an out-of-contract absolute is refused
  * on screen instead of followed. See `submitRedirect.ts`.
+ *
+ * ## Conditional field visibility (objectui#5594)
+ *
+ * A FormView field may carry a CEL predicate saying WHEN it is visible —
+ * `visibleWhen`, or the deprecated ADR-0089 alias `visibleOn`. This renderer
+ * read neither, so such a field rendered unconditionally on both routes:
+ * fail-open and silent, with no diagnostic for the author.
+ *
+ * It is the SECOND form renderer in this repo, which is why the gap survived.
+ * objectui#2212 recorded this exact symptom and PR #2214 fixed it on the OTHER
+ * chain — `ModalForm` -> `resolveFormViewLayout` -> `@object-ui/plugin-form`
+ * `sectionFields.ts` -> `@object-ui/components` `renderers/form/form.tsx` —
+ * which this file is on at no point, and #2212's regression pin lives with
+ * that chain, so nothing in the suite could see this copy.
+ *
+ * The wiring is #2212's ruling applied verbatim, not a second semantics: see
+ * {@link isFieldVisible} for the engine, the bound scope, and what the fix
+ * deliberately does not change.
  */
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
+import { evalFieldPredicate } from '@object-ui/core';
 import type { FormFieldSpec } from '@object-ui/app-shell';
 import { resolveSubmitRedirect } from './submitRedirect';
 
@@ -308,6 +327,27 @@ interface RenderableField {
   required: boolean;
   readonly: boolean;
   hidden: boolean;
+  /**
+   * Conditional visibility for this row — the predicate {@link isFieldVisible}
+   * evaluates against the LIVE form values, as distinct from the static
+   * `hidden` flag above.
+   *
+   * Resolved CANONICAL-FIRST when the row is built: `visibleWhen ?? visibleOn`.
+   * ADR-0089 renamed the key, and `@objectstack/spec`'s normaliser REWRITES the
+   * alias rather than keeping both, so a spec-served FormView carries
+   * `visibleWhen` and no `visibleOn` at all. The deprecated spelling is still
+   * read because it still has live producers — hand-written layouts, and this
+   * app's own create schemas, which never pass through that normaliser. Same
+   * spelling and same precedence as the two sibling readers, deliberately:
+   * `@object-ui/plugin-form` `sectionFields.ts` (`fd.visibleWhen ?? fd.visibleOn`)
+   * and app-shell's metadata-admin `readVisibility`.
+   *
+   * The TYPE is derived from the authoring surface rather than restated:
+   * re-spelling `string | { dialect?, source }` here would be a third
+   * description of one contract, which is the exact class objectui#5542 closed
+   * in this file.
+   */
+  visibleWhen?: FormFieldSpec['visibleWhen'];
   placeholder?: string;
   helpText?: string;
   defaultValue?: unknown;
@@ -373,6 +413,11 @@ export function buildSections(
         required: override.required ?? def.required ?? false,
         readonly: override.readonly ?? false,
         hidden: override.hidden ?? false,
+        // Canonical key wins over the deprecated alias — see
+        // `RenderableField.visibleWhen`. Carried, not evaluated: the verdict
+        // depends on the live form values, which change per keystroke, while
+        // these rows are memoized on the loaded spec.
+        visibleWhen: override.visibleWhen ?? override.visibleOn,
         placeholder: override.placeholder ?? def.placeholder,
         helpText: override.helpText ?? def.helpText,
         defaultValue: def.defaultValue,
@@ -388,6 +433,62 @@ export function buildSections(
       collapsed: !!sec.collapsed,
       fields,
     };
+  });
+}
+
+/**
+ * Is this row on screen, given the form's current state?
+ *
+ * Two independent reasons a field is not rendered, answered in ONE place so
+ * "is this field visible" has a single reader:
+ *
+ *  1. `hidden: true` — the static flag. Unconditional.
+ *  2. `visibleWhen` — the conditional predicate (ADR-0089), evaluated against
+ *     the live form values on every render.
+ *
+ * The predicate is routed through the CANONICAL engine — `evalFieldPredicate`
+ * (`@object-ui/core`, `evaluator/fieldRules.ts`) — which is objectui#2212's
+ * ruling applied verbatim rather than a second predicate semantics invented
+ * for this renderer. Two form renderers disagreeing about what `visibleWhen`
+ * MEANS would be a worse defect than one renderer ignoring it. So the engine,
+ * the accepted wire shapes (bare CEL string and `{ dialect, source }`), the
+ * bound scope and the failure behaviour are the shared ones by construction,
+ * not by agreement.
+ *
+ * Scope: `record.*` is the LIVE values — what the inputs currently hold, not
+ * what was loaded — so a predicate re-decides as the user types, which is the
+ * whole point of a conditional field. `previous.*` is the stored record an
+ * edit form started from (objectui#4278), unbound on a create form. That is
+ * the same pair `form.tsx` binds on the sibling chain.
+ *
+ * Fail-open (`fallback: true`) is deliberate and shared: a predicate that
+ * cannot be evaluated must not HIDE a field, because a hidden field is one the
+ * submitter can neither fill in nor see is missing. Open does not mean silent
+ * — `evalFieldPredicate` warns once per predicate text, naming the field.
+ *
+ * ## What this deliberately does NOT do
+ *
+ * It does not strip the VALUE of a field it hides. `values` still carries
+ * whatever {@link readPrefill} seeded and `handleSubmit` still submits it —
+ * exactly what a statically `hidden: true` field has always done here, and
+ * what the plugin-form chain does (#2212's fix returns `null` at render and
+ * clears stale ERRORS, never values). Conditional visibility is a rendering
+ * rule in both renderers; making it a submit-payload rule would be a new
+ * contract, decided once for both, not invented here in the second one.
+ */
+export function isFieldVisible(
+  field: RenderableField,
+  values: Record<string, unknown>,
+  previous?: Record<string, unknown> | null,
+): boolean {
+  if (field.hidden) return false;
+  return evalFieldPredicate(field.visibleWhen, values, true, previous ?? undefined, undefined, {
+    // Named for the canonical key even when the deprecated alias supplied the
+    // predicate: ADR-0089 is what this predicate is CALLED, and the warning
+    // prints the source text verbatim, which is what finds a hand-written
+    // `visibleOn`. A second stored key whose only job is to spell a deprecated
+    // name in a warning would be bookkeeping, not an honoured key.
+    context: `visibleWhen of field '${field.name}'`,
   });
 }
 
@@ -1310,7 +1411,7 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
                       : 'grid grid-cols-1 gap-4 sm:grid-cols-4'
               }
             >
-              {sec.fields.filter((f) => !f.hidden).map((f) => (
+              {sec.fields.filter((f) => isFieldVisible(f, values, loaded.record)).map((f) => (
                 <div
                   key={f.name}
                   className={

--- a/apps/console/src/components/FormPage.visibleWhen.test.tsx
+++ b/apps/console/src/components/FormPage.visibleWhen.test.tsx
@@ -1,0 +1,416 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5594 — this renderer evaluates `visibleWhen` / `visibleOn`.
+ *
+ * ## The class this pins shut
+ *
+ * `FormPage.tsx` is the SECOND form renderer in this repo. objectui#2212
+ * recorded exactly this symptom — a FormView field carrying a CEL visibility
+ * predicate renders unconditionally — and PR #2214 fixed it on the OTHER
+ * chain: `ModalForm` -> `resolveFormViewLayout` -> `@object-ui/plugin-form`
+ * `sectionFields.ts` -> `@object-ui/components` `renderers/form/form.tsx`.
+ * This file's renderer is on that chain at no point, so #2212's fix never
+ * reached it and #2212's regression pin — which lives with the chain it fixed
+ * — could not see it. One contract, two implementations, each only ever
+ * checked against itself.
+ *
+ * That is why this pin LIVES HERE, next to the renderer it describes, rather
+ * than being folded into the #2212 suite: a pin that cannot see the second
+ * copy is how the first gap survived.
+ *
+ * ## Reverse verification — MEASURED, not predicted
+ *
+ * `FormPage.tsx` reverted to its pre-#5594 state (`buildSections` not carrying
+ * the predicate, the render filtered by `!f.hidden` alone) with this file left
+ * in place, run from the repo root:
+ *
+ *     Tests  11 failed | 1 passed (12)
+ *
+ * Every red one fails in a way that names the defect — the conditional field
+ * is ON SCREEN when the predicate says it must not be, or the predicate never
+ * reached the row at all:
+ *
+ *   - "hides a field whose predicate is false"            -> field is present
+ *   - "re-evaluates as the user types"                    -> present throughout
+ *   - "honours the { dialect, source } wire shape"        -> field is present
+ *   - "honours the deprecated visibleOn alias"            -> field is present
+ *   - "canonical visibleWhen wins over visibleOn"         -> field is present
+ *   - "the PUBLIC /f/:slug route honours it too"          -> field is present
+ *   - "binds previous.* on an edit form"                  -> field is present
+ *   - "a broken predicate fails OPEN, loudly"             -> no warning at all
+ *   - "a hidden field's value is still submitted"         -> field is present
+ *   - "buildSections carries the predicate onto the row"  -> `undefined`
+ *   - "isFieldVisible answers … in one verdict"           -> no such export
+ *
+ * The ONE that is green on both sides is the control that has to be:
+ *
+ *   - "a field with NO predicate at all still renders" — without it, every
+ *     `not.toBeInTheDocument` above is equally satisfied by a renderer that
+ *     draws nothing at all.
+ *
+ * The two cases named CONTROL are controls on their SECOND assertion and
+ * change-detectors on their first, which is why they are red here rather than
+ * green — worth stating, because "control" usually implies green both sides:
+ *
+ *   - "a broken predicate fails OPEN, loudly" — fail-OPEN is green either way
+ *     (a renderer that never evaluates cannot hide anything), and it is still
+ *     the direction that matters: an unevaluable predicate must never HIDE a
+ *     field, because a hidden field is one the submitter can neither fill in
+ *     nor see is missing. The `loudly` half is what turns red: pre-fix there is
+ *     no evaluation, so there is nothing to warn about.
+ *   - "a field hidden by its predicate still submits its value" — the payload
+ *     assertion is the control (recorded rather than assumed: conditional
+ *     visibility is a RENDERING rule in both renderers, and this card did not
+ *     make it a submit-payload rule). It is red pre-fix only because it first
+ *     has to establish that the field IS hidden.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { buildSections, FormPage, isFieldVisible } from './FormPage';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+/**
+ * The object the forms below target. `priority` carries a `defaultValue` so
+ * the live record binds the key CLEANLY: an unbound identifier is a predicate
+ * FAULT, which fails open, and a test that passed that way would prove the
+ * fallback rather than the evaluation.
+ */
+const OBJECT_SCHEMA = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: {
+    title: { type: 'text', label: 'Title' },
+    priority: { type: 'text', label: 'Priority', defaultValue: 'low' },
+    notes: { type: 'text', label: 'Notes' },
+    status: { type: 'text', label: 'Status' },
+  },
+};
+
+/** Wrap a section's fields in the `/meta/view/:name` envelope this route reads. */
+function viewEnvelope(fields: unknown[]) {
+  return {
+    name: 'showcase_task.edit',
+    object: 'showcase_task',
+    viewKind: 'form',
+    label: 'Task',
+    config: { type: 'simple', sections: [{ label: 'Task', fields }] },
+  };
+}
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+let calls: Call[] = [];
+
+/** Answers per (method, url-substring); modelled on `FormPage.recordId.test.tsx`. */
+function stubFetch(routes: Array<{ method?: string; match: string; body?: unknown }>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    calls.push({
+      url: String(url),
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    const route = routes.find(
+      (r) => (r.method ?? 'GET').toUpperCase() === method && String(url).includes(r.match),
+    );
+    if (!route) throw new Error(`unstubbed fetch: ${method} ${url}`);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => route.body,
+      text: async () => (route.body === undefined ? '' : JSON.stringify(route.body)),
+    } as unknown as Response;
+  });
+}
+
+const recordPath = (objectName: string, recordId: string) =>
+  `/apps/ai.objectstack.showcase/${objectName}/record/${recordId}`;
+
+/** Render the INTERNAL route (`/forms/:name`) over a given field list. */
+function renderInternal(fields: unknown[], query = '', extraRoutes: Parameters<typeof stubFetch>[0] = []) {
+  vi.stubGlobal(
+    'fetch',
+    stubFetch([
+      { match: '/meta/view/', body: viewEnvelope(fields) },
+      { match: '/meta/object/', body: OBJECT_SCHEMA },
+      ...extraRoutes,
+    ]),
+  );
+  return render(
+    <MemoryRouter initialEntries={[`/forms/showcase_task.edit${query}`]}>
+      <Routes>
+        <Route path="/forms/:name" element={<FormPage mode="internal" recordPath={recordPath} />} />
+        <Route
+          path="/apps/:appName/:objectName/record/:recordId"
+          element={<div data-testid="record-page">record page</div>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** Render the PUBLIC route (`/f/:slug`) over a given field list. */
+function renderPublic(fields: unknown[]) {
+  vi.stubGlobal(
+    'fetch',
+    stubFetch([
+      {
+        match: '/forms/task-intake',
+        body: {
+          slug: 'task-intake',
+          object: 'showcase_task',
+          label: 'Task intake',
+          form: { type: 'simple', sections: [{ label: 'Task', fields }] },
+          objectSchema: OBJECT_SCHEMA,
+        },
+      },
+    ]),
+  );
+  return render(
+    <MemoryRouter initialEntries={['/f/task-intake']}>
+      <Routes>
+        <Route path="/f/:slug" element={<FormPage mode="public" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** Wait for the form to be on screen — every case needs the load to settle. */
+async function awaitForm() {
+  await waitFor(() => expect(screen.getByLabelText('Priority')).toBeInTheDocument());
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('objectui#5594 — FormPage evaluates conditional field visibility', () => {
+  it('hides a field whose predicate is false, and shows one whose predicate is true', async () => {
+    renderInternal([
+      'title',
+      'priority',
+      { field: 'notes', visibleWhen: "record.priority == 'urgent'" },
+      { field: 'status', visibleWhen: "record.priority == 'low'" },
+    ]);
+    await awaitForm();
+
+    // `priority` starts at its schema default, 'low'.
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+  });
+
+  it('re-evaluates against the LIVE values as the user types', async () => {
+    const user = userEvent.setup();
+    renderInternal([
+      'title',
+      'priority',
+      { field: 'notes', visibleWhen: "record.priority == 'urgent'" },
+    ]);
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+
+    // The whole point of a conditional field: the predicate re-decides on the
+    // CURRENT input values, not on whatever the form loaded with.
+    const priority = screen.getByLabelText('Priority');
+    await user.clear(priority);
+    await user.type(priority, 'urgent');
+
+    await waitFor(() => expect(screen.getByLabelText('Notes')).toBeInTheDocument());
+
+    // …and back again, so this pins an evaluation and not a one-way reveal.
+    await user.clear(screen.getByLabelText('Priority'));
+    await user.type(screen.getByLabelText('Priority'), 'low');
+    await waitFor(() => expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument());
+  });
+
+  it('honours the { dialect, source } wire shape as well as the bare string', async () => {
+    renderInternal([
+      'priority',
+      { field: 'notes', visibleWhen: { dialect: 'cel', source: "record.priority == 'urgent'" } },
+    ]);
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+  });
+
+  it('honours the deprecated ADR-0089 alias `visibleOn`', async () => {
+    // The spec normaliser rewrites the alias, so a spec-served view never
+    // carries it — but hand-written layouts still do, which is why both
+    // sibling readers keep reading it.
+    renderInternal(['priority', { field: 'notes', visibleOn: "record.priority == 'urgent'" }]);
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+  });
+
+  it('lets the canonical `visibleWhen` win when both spellings are authored', async () => {
+    // `visibleWhen ?? visibleOn` — the same precedence as
+    // `@object-ui/plugin-form` `sectionFields.ts` and app-shell's
+    // `readVisibility`. The two predicates disagree on purpose: only the
+    // canonical one's verdict can produce this outcome.
+    renderInternal([
+      'priority',
+      {
+        field: 'notes',
+        visibleWhen: "record.priority == 'urgent'", // false -> hidden
+        visibleOn: "record.priority == 'low'", // true -> would show
+      },
+    ]);
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+  });
+
+  it('honours the predicate on the PUBLIC /f/:slug route too', async () => {
+    // The user-reachable half of the card: this route is served to anonymous
+    // visitors, so a fail-open predicate here shows strangers a field the
+    // author conditioned away.
+    renderPublic([
+      'priority',
+      { field: 'notes', visibleWhen: "record.priority == 'urgent'" },
+      { field: 'status', visibleWhen: "record.priority == 'low'" },
+    ]);
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+  });
+
+  it('binds `previous.*` to the stored record on an edit form', async () => {
+    // `?recordId=` makes this an EDIT (objectui#4278), and the loaded record is
+    // passed as the predicate's `previous` scope — the same pair the sibling
+    // renderer binds. `record.priority` is the live 'urgent' the record
+    // supplied; `previous.status` is the stored value.
+    renderInternal(
+      [
+        'priority',
+        { field: 'notes', visibleWhen: "previous.status == 'archived'" },
+        { field: 'title', visibleWhen: "previous.status == 'open'" },
+      ],
+      '?recordId=task-42',
+      [
+        {
+          match: '/data/showcase_task/task-42',
+          body: {
+            object: 'showcase_task',
+            id: 'task-42',
+            record: { id: 'task-42', priority: 'urgent', status: 'open' },
+          },
+        },
+      ],
+    );
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+  });
+
+  // ── Controls ───────────────────────────────────────────────────────────
+
+  it('CONTROL: a field with no predicate at all still renders', async () => {
+    // Without this, every "not.toBeInTheDocument" above is equally satisfied
+    // by a renderer that draws no fields.
+    renderInternal(['priority', { field: 'notes' }, 'status']);
+    await awaitForm();
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+  });
+
+  it('CONTROL: a broken predicate fails OPEN, loudly', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    renderInternal(['priority', { field: 'notes', visibleWhen: 'record.priority ===' }]);
+    await awaitForm();
+
+    // Open: an unevaluable predicate must never hide a field.
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+    // Loud: the shared engine warns once per predicate text, naming the field
+    // — without it a broken predicate is indistinguishable from an absent one.
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.flat().join(' ')).toContain("visibleWhen of field 'notes'");
+  });
+
+  it('CONTROL: a field hidden by its predicate still submits its value', async () => {
+    // Recorded, not assumed. Both renderers treat conditional visibility as a
+    // RENDERING rule: the plugin-form fix for #2212 returns `null` at render
+    // and clears stale ERRORS, never values. Turning it into a submit-payload
+    // rule would be a new contract decided once for BOTH renderers — not
+    // invented here, in the second one.
+    const user = userEvent.setup();
+    renderInternal(
+      ['priority', { field: 'notes', visibleWhen: "record.priority == 'urgent'" }],
+      '?prefill_notes=carried',
+      [{ method: 'POST', match: '/data/showcase_task', body: { object: 'showcase_task', id: 'new-1' } }],
+    );
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(calls.some((c) => c.method === 'POST')).toBe(true));
+    const post = calls.find((c) => c.method === 'POST')!;
+    expect((post.body as Record<string, unknown>).notes).toBe('carried');
+  });
+});
+
+describe('objectui#5594 — the predicate reaches the row and the verdict', () => {
+  it('buildSections carries the predicate onto the renderable row, canonical first', () => {
+    const [section] = buildSections(
+      {
+        sections: [
+          {
+            fields: [
+              { field: 'a', visibleWhen: "record.x == 1" },
+              { field: 'b', visibleOn: { dialect: 'cel', source: 'record.x == 2' } },
+              { field: 'c', visibleWhen: "record.x == 3", visibleOn: "record.x == 4" },
+              { field: 'd' },
+              'e',
+            ],
+          },
+        ],
+      },
+      null,
+    );
+
+    expect(section.fields.map((f) => f.visibleWhen)).toEqual([
+      "record.x == 1",
+      { dialect: 'cel', source: 'record.x == 2' },
+      "record.x == 3",
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it('isFieldVisible answers the static flag and the predicate in one verdict', () => {
+    const [section] = buildSections(
+      {
+        sections: [
+          {
+            fields: [
+              { field: 'always' },
+              { field: 'statically_hidden', hidden: true },
+              { field: 'conditional', visibleWhen: "record.priority == 'urgent'" },
+            ],
+          },
+        ],
+      },
+      null,
+    );
+    const [always, staticallyHidden, conditional] = section.fields;
+
+    expect(isFieldVisible(always, { priority: 'low' })).toBe(true);
+    // A static `hidden: true` is unconditional — it is not weakened by a
+    // predicate that would evaluate true.
+    expect(isFieldVisible(staticallyHidden, { priority: 'urgent' })).toBe(false);
+    expect(isFieldVisible(conditional, { priority: 'low' })).toBe(false);
+    expect(isFieldVisible(conditional, { priority: 'urgent' })).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #5594

## Summary

`apps/console/src/components/FormPage.tsx` is a **second, independent form renderer** —
its own `buildSections`, its own JSX — and it serves both the public `/f/:slug` route and
the internal `/forms/:name` route. It read neither spelling of the FormView field
visibility predicate, so a field an author conditioned on `record.priority == 'urgent'`
rendered unconditionally on both routes. Fail-open and silent: the author saw the field
always, with no diagnostic.

This wires the predicate into **this** renderer and pins it with a regression test that
lives with **this** renderer. It does not touch the other one.

## Why the gap survived

Issue #2212 recorded exactly this symptom, and PR #2214 landed the repair on a
**different chain**: `ModalForm` → `resolveFormViewLayout` → `@object-ui/plugin-form`
`sectionFields.ts` → `@object-ui/components` `renderers/form/form.tsx`. `FormPage.tsx` is
on that chain at no point, and that PR's regression pin lives with the chain it repaired,
so nothing in the suite could see this copy. One contract, two implementations, each only
ever checked against itself.

## The ruling applied, verbatim

Per the PM ruling on the card, this inherits #2212's ruling rather than inventing a
second predicate semantics — two form renderers disagreeing about what `visibleWhen`
*means* would be a worse defect than one renderer ignoring it.

**Helper signature verified in the built `dist/*.d.ts` the console's `tsc` actually
reads**, not from memory (`packages/core/dist/evaluator/fieldRules.d.ts:63`):

```ts
export declare function evalFieldPredicate(pred: FieldRulePredicate | undefined | null, record: Record<string, unknown>, fallback: boolean, previous?: Record<string, unknown>, scope?: Record<string, unknown>, diagnostic?: FieldPredicateDiagnostic): boolean;
```

Reachable from the package root via `export * from './evaluator/index.js'` in
`packages/core/dist/index.d.ts:26`.

So, by construction rather than by agreement:

- **Engine** — `evalFieldPredicate` (`@object-ui/core`, `evaluator/fieldRules.ts`).
- **Wire shapes** — bare CEL string and `{ dialect, source }`.
- **Scope** — `record.*` is the LIVE input values (the predicate re-decides as the user
  types), `previous.*` is the stored record an edit form started from (#4278). The same
  pair `form.tsx` binds.
- **Failure** — fail-open, loudly: an unevaluable predicate must never HIDE a field,
  because a hidden field is one the submitter can neither fill in nor see is missing.
- **Precedence** — canonical-first, `visibleWhen ?? visibleOn`, matching both sibling
  readers: `sectionFields.ts` (`fd.visibleWhen ?? fd.visibleOn`) and app-shell's
  `readVisibility`. The deprecated ADR-0089 alias stays honoured because it still has
  live producers that never pass through the spec normaliser.

## What changed

| File | What |
| --- | --- |
| `apps/console/src/components/FormPage.tsx` | `RenderableField` carries the predicate (type **derived** from `FormFieldSpec['visibleWhen']`, not restated); `buildSections` resolves it canonical-first; new exported `isFieldVisible` answers the static flag and the predicate in one verdict; the render filter calls it. |
| `apps/console/src/components/FormPage.visibleWhen.test.tsx` | New. The regression pin, next to the renderer it describes. |
| `.changeset/console-formpage-visible-predicates-5594.md` | `@object-ui/console: patch`. |

Two things deliberately did **not** change, recorded rather than assumed:

- A field hidden by its predicate **still submits its value**. Conditional visibility is a
  rendering rule in both renderers (the plugin-form repair returns `null` at render and
  clears stale *errors*, never values). Making it a submit-payload rule would be a new
  contract decided once for both, not invented here in the second one. Pinned as a control.
- `FormPage` is **not** folded onto the plugin-form chain — the triage scope fence. The
  second-renderer convergence question stays with the #5596 track.

## Evidence

**The defect probe, and a control at identical scope.** A bare `grep -c` for the two key
names in this file returns `1` on today's `main` — but that one hit is a **prose mention
inside a docblock**, not a read. Scoped to a property *read* instead:

```
$ git rev-parse --short HEAD            # origin/main
8c87f0583

# PROBE — predicate reads in this renderer
$ grep -cE '\b(f|field|override|sec)\.(visibleWhen|visibleOn)\b' apps/console/src/components/FormPage.tsx
0

# CONTROL — same file, same regex shape, the static flag this renderer DOES read
$ grep -cE '\b(f|field|override|sec)\.(hidden)\b' apps/console/src/components/FormPage.tsx
2
```

The control returns non-zero at identical scope, so the `0` is a missing read and not a
bad search.

**Reverse verification — measured, not predicted.** `FormPage.tsx` reverted to its pre-fix
state with the new pin left in place (mutation confirmed on disk by anchored greps on the
text being changed, in both legs; the script carries a `trap … EXIT INT TERM` restore, and
the tree was verified clean afterwards). No build leg is involved: the test imports the
subject as a relative source path (`./FormPage`), not through a package `exports` → `dist`.

```
Tests  11 failed | 1 passed (12)
```

The one green is the control that has to be green — *"a field with NO predicate at all
still renders"* — without which every "the field is absent" assertion would be equally
satisfied by a renderer that draws nothing at all. The two cases named CONTROL are red
here because each must first establish that the field IS hidden; their control halves
(fail-open direction, submitted payload) are unaffected. The full per-test breakdown is in
the test file's docblock.

## Gates

All run **after** the final commit, from the repo root (package-cwd `vitest` is refused by
the repo's own guard, #3378), at `93187c334` with a clean worktree:

| Gate | Result |
| --- | --- |
| `npx vitest run apps/console --maxWorkers=2` | `Test Files  66 passed (66)` · `Tests  722 passed (722)` |
| `pnpm --filter @object-ui/console type-check` | exit 0 (`tsc --noEmit && tsc -b tsconfig.node.json --force`, script name echoed — not a zero-match no-op) |
| `pnpm --filter @object-ui/console lint` | exit 0 · `201 problems (0 errors, 201 warnings)`, all pre-existing `no-explicit-any`; the two touched files contribute **0 errors**, and the new test file **0 warnings** |
| `check:control-bytes` | `OK (scanned 4673 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` / `check-changeset-no-major` | `All workspace packages are in the changeset fixed group.` / `No changeset declares a major bump.` |
| `check:phantom-deps` | `Every in-scope import is declared by the package that publishes it.` |
| `check:lint-coverage` | `46/46 packages linted, 0 with outstanding errors` |
| `check:type-check-coverage` | `45/46 via type-check, 0 known-broken` |
| `check:eager-closure` | **exit 2 — broken gauge, not a failure**: `No eager-closure report at apps/console/dist/eager-closure.json … This is a broken gauge, not a passing budget.` It needs a console `vite build` to write the report. Noted, not "repaired". The one new import is `evalFieldPredicate` from `@object-ui/core`, a package already eager in this bundle (55 files under `packages/app-shell/src` import it, and `App.tsx` imports app-shell statically), so no new package enters the eager closure. |

No `packages/**` file is touched, so the "does `dist/*.d.ts` move?" question does not arise
for this change — the whole diff is `apps/console` plus one changeset.

## Follow-up filed, not fixed here — #5627

`FormPage` still drops the *other* conditional-rule surfaces: section-level
`visibleWhen`/`visibleOn`, and the object-level field rules
`visibleWhen`/`readonlyWhen`/`requiredWhen` that the sibling chain copies out of the object
schema. Same class, different keys and different user-visible consequences (disabled state
and submit-blocking, not just hiding), and it raises two semantics questions of its own, so
it is filed rather than smuggled in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_
