### PR TITLE
fix(plugin-view): give `chart` and `gantt` views an icon that resolves, and pin every name both icon maps supply

### DIFF
--- a/.changeset/view-switcher-chart-gantt-icons-5586.md
+++ b/.changeset/view-switcher-chart-gantt-icons-5586.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/plugin-view': patch
+---
+
+`ViewSwitcher` draws an icon for `chart` and `gantt` views again, and both
+icon maps in the package now name only spellings lucide still resolves
+(objectui#5586).
+
+`ViewSwitcher.resolveIcon` turns an icon NAME into a component by looking it up
+in lucide's runtime `icons` record. lucide retires a spelling by dropping it
+from that record while KEEPING it as a deprecated named export, so a retired
+name still imports, still type-checks and still renders as a component — and
+silently resolves to nothing as a string. `ObjectView` composes the switcher
+from names, and two of them had been retired on lucide-react 1.31.0:
+`chart: 'bar-chart-3'` and `gantt: 'gantt-chart'`. Both view types rendered as a
+label with no icon at all while every sibling type had one, and nothing went red
+because no lucide symbol appears in that map for the compiler to check. Measured
+against the installed package: `BarChart3` and `GanttChart` are absent from
+`icons`, while `ChartColumn` and `ChartGantt` are present.
+
+- `ObjectView`'s `iconMap`: `bar-chart-3` → `chart-column`,
+  `gantt-chart` → `chart-gantt`.
+- `ViewSwitcher`'s `DEFAULT_VIEW_ICONS`: the adjacent entries that named
+  deprecated aliases move to the names the record carries —
+  `BarChart3` → `ChartColumn`, `GanttChartSquare` → `ChartGantt`,
+  `Grid` → `Grid3x3`. `ChartColumn`/`Grid3x3` are the same components the
+  aliases already pointed at, so those two glyphs are unchanged; the `gantt`
+  default picks up the plain gantt glyph, which is what `iconMap` now supplies
+  for that view type.
+
+The regression pin widens from `tree` alone to EVERY name both maps supply: a
+pin scoped to the two names that broke would not have caught this and would not
+catch the next lucide bump.

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -925,17 +925,28 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
         // `ListTree` that file's `DEFAULT_VIEW_ICONS.tree` already names for
         // this view type. The `|| 'table'` fallback stays: `v.type` arrives
         // from a host prop and nothing validates it at runtime.
+        //
+        // objectui#5586 — the VALUES have to be names lucide still carries in
+        // its runtime `icons` record, which is what `ViewSwitcher.resolveIcon`
+        // reads. `chart: 'bar-chart-3'` and `gantt: 'gantt-chart'` were dropped
+        // from that record while surviving as deprecated NAMED EXPORTS, so both
+        // types rendered with NO icon at all while every sibling had one. The
+        // compiler sees none of it: nothing in this map is a lucide symbol.
+        // Measured on lucide-react 1.31.0, `chart-column` → `ChartColumn` and
+        // `chart-gantt` → `ChartGantt` both resolve, and both agree with the
+        // components `ViewSwitcher.DEFAULT_VIEW_ICONS` names for the same view
+        // types. Every value here is pinned by `ViewSwitcher.test.tsx`.
         const iconMap: Record<ViewType, string> = {
           kanban: 'kanban',
           calendar: 'calendar',
           map: 'map',
           gallery: 'layout-grid',
           timeline: 'activity',
-          gantt: 'gantt-chart',
+          gantt: 'chart-gantt',
           grid: 'table',
           list: 'list',
           detail: 'file-text',
-          chart: 'bar-chart-3',
+          chart: 'chart-column',
           tree: 'list-tree',
         };
         return {

--- a/packages/plugin-view/src/ViewSwitcher.tsx
+++ b/packages/plugin-view/src/ViewSwitcher.tsx
@@ -24,11 +24,11 @@ import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
 import type { ViewSwitcherSchema, ViewType } from '@object-ui/types';
 import {
   Activity,
-  BarChart3,
   Calendar,
+  ChartColumn,
+  ChartGantt,
   FileText,
-  GanttChartSquare,
-  Grid,
+  Grid3x3,
   Images,
   LayoutGrid,
   List,
@@ -69,17 +69,28 @@ const DEFAULT_VIEW_LABELS: Record<ViewType, string> = {
   tree: 'Tree',
 };
 
+// objectui#5586 — every value here is a name lucide still carries in its
+// runtime `icons` record, deliberately NOT one of the deprecated ALIASES it
+// keeps only as a named export. The compiler cannot tell the two apart:
+// `BarChart3`, `GanttChartSquare` and `Grid` all import and all render, and all
+// three were absent from `icons` on lucide-react 1.31.0. That distinction is
+// load-bearing here because the sibling producer — `ObjectView`'s `iconMap` —
+// supplies the SAME glyphs as STRINGS, which `resolveIcon` below looks up in
+// exactly that record: there a deprecated spelling resolves to nothing and the
+// view renders with no icon at all. Keeping this map on record-live names keeps
+// the two halves comparable and keeps a dead spelling from being copied back
+// into the string map. Both maps are pinned in `ViewSwitcher.test.tsx`.
 const DEFAULT_VIEW_ICONS: Record<ViewType, LucideIcon> = {
   list: List,
   detail: FileText,
-  grid: Grid,
+  grid: Grid3x3,
   kanban: LayoutGrid,
   calendar: Calendar,
   timeline: Activity,
   map: Map,
   gallery: Images,
-  gantt: GanttChartSquare,
-  chart: BarChart3,
+  gantt: ChartGantt,
+  chart: ChartColumn,
   tree: ListTree,
 };
 

--- a/packages/plugin-view/src/__tests__/ObjectView.hostOnlyViewTypes.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.hostOnlyViewTypes.test.tsx
@@ -196,14 +196,15 @@ describe('the view switcher labels every composed view type (objectui#5321)', ()
     // produce no icon at all. Measured on lucide-react 1.31: `list-tree` is
     // `ListTree` and resolves.
     //
-    // Asserted for `tree` only, deliberately. Two SIBLING entries in the same
-    // map — `chart: 'bar-chart-3'` and `gantt: 'gantt-chart'` — do NOT resolve
-    // on this version (lucide dropped both from its `icons` record while
-    // keeping them as deprecated named exports), so they render icon-less
-    // today. That is a different defect from the missing key this card fixes,
-    // it needs new icon names chosen rather than a key added, and it is filed
-    // as objectui#5586. ⛔ Do not widen this assertion over the whole map
-    // expecting green — that widening belongs to objectui#5586, with the fix.
+    // Scoped to `tree` here because this file is about the objectui#5321
+    // exemption. The widening this comment used to forbid HAS LANDED: the two
+    // sibling entries that did not resolve — `chart: 'bar-chart-3'` and
+    // `gantt: 'gantt-chart'`, dropped from lucide's `icons` record while
+    // surviving as deprecated named exports — are fixed by objectui#5586,
+    // which pins EVERY name both maps supply in `ViewSwitcher.test.tsx`. The
+    // pin lives there because the real component renders the names there, so
+    // no hand-copied PascalCase mirror of `resolveIcon` can drift out from
+    // under it (this file mocks `../ViewSwitcher` away).
     expect(icons.ListTree, '`list-tree` no longer resolves in lucide-react.').toBeTruthy();
   });
 

--- a/packages/plugin-view/src/__tests__/ViewSwitcher.test.tsx
+++ b/packages/plugin-view/src/__tests__/ViewSwitcher.test.tsx
@@ -8,6 +8,9 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { icons } from 'lucide-react';
 import { ViewSwitcher } from '../ViewSwitcher';
 import type { ViewSwitcherSchema, ViewType } from '@object-ui/types';
 
@@ -54,6 +57,59 @@ function schemaFor(types: ViewType[]): ViewSwitcherSchema {
   };
 }
 
+function schemaForNamed(entries: Array<[string, string]>): ViewSwitcherSchema {
+  return {
+    type: 'view-switcher',
+    variant: 'buttons',
+    views: entries.map(([type, icon]) => ({ type: type as ViewType, icon })),
+  };
+}
+
+/** Buttons of ONE render, scoped to its own container so probe and control cannot see each other. */
+const buttonsIn = (container: HTMLElement): HTMLButtonElement[] =>
+  Array.from(container.querySelectorAll('button'));
+
+/**
+ * Read a sibling source file, from the repo root or from the package directory.
+ *
+ * NOT `new URL('../x', import.meta.url)`: Vite rewrites `import.meta.url` to a
+ * SERVER-ROOT-relative path, so that form resolved to `/packages/plugin-view/
+ * src/ObjectView.tsx` — an absolute path missing the repo root, ENOENT for the
+ * whole suite. The two candidates below mirror the pair
+ * `ObjectView.hostOnlyViewTypes.test.tsx` already uses for the same reason; the
+ * first is the canonical repo-root invocation (objectui#3378).
+ */
+const readSibling = (file: string): string => {
+  const candidates = [
+    resolve(process.cwd(), 'packages/plugin-view/src', file),
+    resolve(process.cwd(), 'src', file),
+  ];
+  const found = candidates.find(candidate => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `cannot locate plugin-view/src/${file} from ${process.cwd()} — tried:\n  ${candidates.join('\n  ')}`,
+    );
+  }
+  return readFileSync(found, 'utf8');
+};
+
+/**
+ * The `key: value` pairs of one named const object literal, read out of source:
+ * a quoted string for the icon-NAME map, a bare identifier for the
+ * icon-COMPONENT map. Read from source because both maps are module-private and
+ * stay that way — exporting them would widen the package's surface for the sake
+ * of a test. A parse that finds nothing is caught by the precondition test.
+ */
+function parseMapEntries(source: string, declaration: string): Array<[string, string]> {
+  const start = source.indexOf(declaration);
+  if (start === -1) return [];
+  const open = start + declaration.length;
+  const close = source.indexOf('};', open);
+  if (close === -1) return [];
+  return [...source.slice(open, close).matchAll(/^\s*(\w+)\s*:\s*(?:'([\w-]+)'|(\w+))\s*,\s*$/gm)]
+    .map(m => [m[1], (m[2] ?? m[3]) as string] as [string, string]);
+}
+
 describe('ViewSwitcher default view labels and icons', () => {
   it('renders a non-empty label and an icon for every ViewType', () => {
     render(<ViewSwitcher schema={schemaFor(ALL_VIEW_TYPES)} />);
@@ -78,17 +134,136 @@ describe('ViewSwitcher default view labels and icons', () => {
   });
 
   it('still lets an explicit label and icon override the defaults', () => {
-    render(
+    const { container } = render(
       <ViewSwitcher
         schema={{
           type: 'view-switcher',
           variant: 'buttons',
-          views: [{ type: 'chart', label: 'Revenue', icon: 'pie-chart' }],
+          views: [{ type: 'chart', label: 'Revenue', icon: 'chart-pie' }],
         }}
       />
     );
 
     expect(screen.getByText('Revenue')).toBeInTheDocument();
     expect(screen.queryByText('Chart')).toBeNull();
+    // The icon half of the same override, asserted rather than assumed. This
+    // fixture read `pie-chart` until objectui#5586: a deprecated lucide alias
+    // that is absent from the runtime `icons` record, so the override rendered
+    // a label and NO icon — and the test stayed green because it only ever
+    // looked at the label. `chart-pie` is the spelling the record carries.
+    expect(
+      container.querySelector('button svg'),
+      'the explicit `icon` override rendered no icon at all',
+    ).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// objectui#5586 — a name that stopped resolving renders NOTHING at all.
+//
+// `ViewSwitcher` turns an icon NAME into a component by looking it up in
+// lucide's runtime `icons` record, and draws nothing when the lookup misses.
+// lucide retires a spelling by dropping it from that record while KEEPING it as
+// a deprecated named export, so a retired name still imports, still
+// type-checks, and still renders when used as a COMPONENT — and silently
+// resolves to nothing when used as a STRING. That is how a major lucide bump
+// took the `chart` and `gantt` icons out of the switcher with nothing going
+// red: `packages/plugin-view` names the same glyphs both ways.
+//
+// So the pin is over EVERY name the two maps supply, not over the two that
+// happened to break — a pin scoped to those two would not have caught this bug
+// and would not catch the next bump. Both maps are annotated
+// `Record<ViewType, …>`, so their key set IS the union and this coverage widens
+// by itself when a view type is added.
+// ---------------------------------------------------------------------------
+
+/** `ObjectView`'s producer map: view type → icon NAME, resolved at render time. */
+const HOST_ICON_NAMES = parseMapEntries(
+  readSibling('ObjectView.tsx'),
+  'const iconMap: Record<ViewType, string> = {',
+);
+
+/** `ViewSwitcher`'s own fallback map: view type → icon COMPONENT, imported by name. */
+const DEFAULT_ICON_COMPONENTS = parseMapEntries(
+  readSibling('ViewSwitcher.tsx'),
+  'const DEFAULT_VIEW_ICONS: Record<ViewType, LucideIcon> = {',
+);
+
+describe('every icon name plugin-view supplies still resolves (objectui#5586)', () => {
+  it('both source reads found a real, TOTAL map — the precondition for "every"', () => {
+    // A parse that quietly found nothing would leave every assertion below
+    // vacuously green, which is the failure mode a widened pin invites. The
+    // key-set comparison carries the totality claim too: both maps are
+    // `Record<ViewType, …>`, so the compiler will not let a view type land
+    // without an entry. Re-annotated to `Record<string, …>`, "every name"
+    // would quietly shrink to "every name someone remembered".
+    expect(
+      HOST_ICON_NAMES.map(([type]) => type).sort(),
+      'cannot read `iconMap` out of ObjectView.tsx — the declaration moved, was re-annotated, or\n'
+        + 'no longer covers every ViewType. Fix the reader or the map; do not delete the pin.',
+    ).toEqual([...ALL_VIEW_TYPES].sort());
+    expect(
+      DEFAULT_ICON_COMPONENTS.map(([type]) => type).sort(),
+      'cannot read `DEFAULT_VIEW_ICONS` out of ViewSwitcher.tsx — same reading.',
+    ).toEqual([...ALL_VIEW_TYPES].sort());
+  });
+
+  it('renders an icon for every name `ObjectView` supplies', () => {
+    const { container } = render(<ViewSwitcher schema={schemaForNamed(HOST_ICON_NAMES)} />);
+
+    for (const [type, icon] of HOST_ICON_NAMES) {
+      const button = buttonsIn(container).find(b => b.textContent?.trim().toLowerCase() === type);
+      expect(button, `no button rendered for view type "${type}"`).toBeDefined();
+      expect(
+        button!.querySelector('svg'),
+        `\`${type}: '${icon}'\` renders NO icon. The name is resolved through lucide's runtime\n`
+          + '`icons` record, and a spelling lucide keeps only as a DEPRECATED NAMED EXPORT is absent\n'
+          + 'from that record — that it imports and type-checks elsewhere says nothing about this\n'
+          + 'path. Replace it with a spelling the record carries (objectui#5586).',
+      ).not.toBeNull();
+    }
+  });
+
+  it('renders NO icon for a name that does not resolve — the control', () => {
+    // Same component, same schema shape, same container-scoped query as the
+    // assertion above, so it fails on exactly what that one passes on. Without
+    // it, "every button has an svg" would hold just as well against a build
+    // whose icon slot always rendered something — and an always-filled slot is
+    // not what `{Icon ? <Icon /> : null}` does. This is also the precise shape
+    // the two broken names had on screen: a label, and nothing beside it.
+    const { container } = render(
+      <ViewSwitcher schema={schemaForNamed([['grid', 'no-such-lucide-icon']])} />,
+    );
+
+    const button = buttonsIn(container).find(b => b.textContent?.trim() === 'Grid');
+    expect(button, 'no button rendered for the control view').toBeDefined();
+    expect(button!.querySelector('svg')).toBeNull();
+  });
+
+  it('names only live `icons` keys in `DEFAULT_VIEW_ICONS`', () => {
+    // The other half of the same class, and NOT implied by the render test
+    // above: these entries are imported components, so a retired alias goes on
+    // rendering here while the string beside it in `iconMap` renders nothing.
+    // Record membership is what keeps the two halves from drifting — a
+    // spelling that is dead for the lookup does not get to look alive in the
+    // defaults and be copied back into the string map, which is how
+    // `bar-chart-3` and `gantt-chart` got there.
+    const retired = DEFAULT_ICON_COMPONENTS.filter(
+      ([, ident]) => !Object.prototype.hasOwnProperty.call(icons, ident),
+    );
+
+    expect(
+      retired,
+      'These `DEFAULT_VIEW_ICONS` entries name lucide exports that are NOT keys of the runtime\n'
+        + '`icons` record — i.e. deprecated aliases. They keep rendering, so nothing else goes red.\n'
+        + 'Replace each with the name the record carries (objectui#5586).',
+    ).toEqual([]);
+  });
+
+  it('rejects an identifier the record does not carry — the control', () => {
+    // Same record, same membership predicate as the assertion above: without
+    // it, "no entry is missing from `icons`" would also pass if the predicate
+    // said yes to everything.
+    expect(Object.prototype.hasOwnProperty.call(icons, 'NoSuchLucideIcon')).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #5586

## What was wrong

`ViewSwitcher.resolveIcon` turns an icon NAME into a component by PascalCasing it and looking it up in lucide's runtime `icons` record. lucide retires a spelling by dropping it from that record while KEEPING it as a deprecated named export, so a retired name still imports, still type-checks and still renders as a component — and silently resolves to nothing as a string. `ObjectView`'s `iconMap` supplies names, and two of them had been retired: `chart: 'bar-chart-3'` and `gantt: 'gantt-chart'`. Both types drew a label with no icon while every sibling had one, and nothing went red because no lucide symbol appears in that map for the compiler to look at.

## Evidence — the record the code reads, not the module's export list

Installed version, read from the resolved package:

```
$ node -p "require('lucide-react/package.json').version"
1.31.0
$ node -p "require.resolve('lucide-react/package.json')"
/home/…/node_modules/.pnpm/lucide-react@1.31.0_react@19.2.8/node_modules/lucide-react/package.json
```

Probed against that install (`icons` has 1767 keys):

```
== iconMap (ObjectView) name -> icons record, BEFORE ==
kanban    kanban         -> Kanban           RESOLVES
calendar  calendar       -> Calendar         RESOLVES
map       map            -> Map              RESOLVES
gallery   layout-grid    -> LayoutGrid       RESOLVES
timeline  activity       -> Activity         RESOLVES
gantt     gantt-chart    -> GanttChart       *** MISSING ***
grid      table          -> Table            RESOLVES
list      list           -> List             RESOLVES
detail    file-text      -> FileText         RESOLVES
chart     bar-chart-3    -> BarChart3        *** MISSING ***
tree      list-tree      -> ListTree         RESOLVES

== the replacements, re-verified ==
chart-column         -> ChartColumn          inIcons=true  namedExport=true
chart-gantt          -> ChartGantt           inIcons=true  namedExport=true

== DEFAULT_VIEW_ICONS named imports: in the icons record? ==
BarChart3            namedExport=true  inIcons=false  displayName=ChartColumn
GanttChartSquare     namedExport=true  inIcons=false  displayName=SquareChartGantt
Grid                 namedExport=true  inIcons=false  displayName=Grid3x3
Activity/Calendar/FileText/Images/LayoutGrid/List/Map/ListTree/Plus/Share2/Settings/Copy/Trash2   all inIcons=true

== alias identity ==
BarChart3 === ChartColumn      : true
Grid      === Grid3x3          : true
GanttChartSquare === ChartGantt: false
```

## What changed

- `ObjectView`'s `iconMap`: `bar-chart-3` → `chart-column`, `gantt-chart` → `chart-gantt`.
- `ViewSwitcher`'s `DEFAULT_VIEW_ICONS` — the adjacent entries that named deprecated aliases, in scope per the card: `BarChart3` → `ChartColumn`, `Grid` → `Grid3x3`, `GanttChartSquare` → `ChartGantt`. The first two are the SAME component under a live name (`===` above), so those glyphs are unchanged. `gantt` is the one visual change: from the square-framed `SquareChartGantt` glyph to the plain `ChartGantt`, chosen so the default agrees with the string `iconMap` now supplies for the same view type — the agreement the `tree` pin already asserts for its pair.
- The resolvability pin widens from `tree` alone to **every** name both maps supply.

## The pin, and where it lives

The widened pin is in `packages/plugin-view/src/__tests__/ViewSwitcher.test.tsx` rather than at the `⛔ do not widen` marker in `ObjectView.hostOnlyViewTypes.test.tsx` (whose comment is updated to point at it). The reason is mechanical: that file mocks `../ViewSwitcher` away, so a pin there could only re-implement `toPascalCase` + the record lookup by hand — a mirror that can drift out from under the assertion while staying green. In `ViewSwitcher.test.tsx` the real component renders the names, so the pin measures the production path itself.

Both halves are covered, because they fail differently:

| pin | subject | why it is not implied by the other |
| --- | --- | --- |
| renders an icon for every name `ObjectView` supplies | the STRING map, through a real render | a retired string resolves to `null` and draws nothing |
| names only live `icons` keys in `DEFAULT_VIEW_ICONS` | the COMPONENT map, by record membership | a retired alias keeps rendering here, so nothing else goes red — but it is how a dead spelling gets copied into the string map |

Coverage widens by itself: both maps are annotated as a total `Record` keyed by `ViewType`, so their key set IS the union, and a precondition test asserts the source read found exactly that union's members (a silent parse miss would make the rest vacuously green).

<sub>(Prose note: this paragraph and the out-of-scope one below were first written with angle-bracket generics and read back as though GitHub had stripped them. Measured afterwards against the REST payload: GitHub stored them intact — the elision was in the API client used to verify. The angle-bracket-free wording is kept because it reads the same; nothing about the code or the measurements changed.)</sub>

Each probe has a control at **identical scope**: the render probe's control renders an unresolvable name through the same component, same schema shape, same container-scoped `querySelector('svg')`, and asserts NO icon; the record-membership probe's control applies the same `hasOwnProperty(icons, …)` predicate to a name the record does not carry.

## Ablation — the pin has teeth

Reverting ONLY the two source files to `origin/main` (tests untouched), with the mutation confirmed on disk by anchored grep counts before the run, and restored by a `trap … EXIT INT TERM`:

```
MUTATION ON DISK: base values back=2 fixed values gone=0 | base idents back=3 fixed idents gone=0
 × renders an icon for every name `ObjectView` supplies
 × names only live `icons` keys in `DEFAULT_VIEW_ICONS`
 Test Files  1 failed (1)
      Tests  2 failed | 6 passed (8)
ABLATION_VITEST_EXIT=1
RESTORED (trap)
```

with the failures naming the defects exactly:

```
AssertionError: `gantt: 'gantt-chart'` renders NO icon. …
AssertionError: expected [ [ 'grid', 'Grid' ], [ 'gantt', 'GanttChartSquare' ], [ 'chart', 'BarChart3' ] ] to deeply equal []
```

No build is involved: this suite imports `../ObjectView` / `../ViewSwitcher` as source and the root Vitest config aliases `@object-ui/*` to sibling `src/`, so nothing resolves through `dist/`. Restored leg re-measured green (15/15 across both files).

## Shipped bytes — both legs built at the real `dist/` path

`pnpm --filter @object-ui/plugin-view build` on each leg, sizes read at `packages/plugin-view/dist` (no copies, no gzip):

```
./index.js            base=86530   fix=86528   delta=-2
./index.umd.cjs       base=68095   fix=68095   delta=0    (same length, differs at char 2083)
./index.d.ts          base=1402    fix=1402    delta=0    (byte-identical, diff -u empty)
./ObjectView.d.ts     base=16503   fix=16503   delta=0
./ViewSwitcher.d.ts   base=641     fix=641     delta=0
…every other .d.ts: delta=0
```

Content reached both emitted formats: `bar-chart-3` 1→0 and `chart-column` 0→1 in `index.js` and in `index.umd.cjs`. So the type surface is unchanged and the runtime values shipped are not — which is the expected shape for a values-only fix, and a changeset is still owed. The authority agrees:

```
$ node scripts/check-changeset-presence.mjs
✅  4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s):
    .changeset/view-switcher-chart-gantt-icons-5586.md.
```

## One bounded in-place fix, declared

`ViewSwitcher.test.tsx`'s "explicit label and icon override" fixture read `icon: 'pie-chart'` — `PieChart` is a retired alias (canonical `ChartPie`, `inIcons=false`), so that fixture rendered a label and no icon, and stayed green because it only ever asserted the label. Same defect class, same file, mechanically determined by the same probe: it now reads `chart-pie` and asserts the icon actually renders.

## Out of scope — filed, not fixed here

A repo-wide scan of every kebab-case icon-name string literal on an `icon:` key (53 distinct names, 109 sites across `packages/` and `apps/`) against the same record found two more live sites outside this card's fence — `icon: 'edit'` in `plugin-detail`'s mobile Edit action and `icon: 'smile'` as the `icon` renderer's own registry default — plus the same three stale component aliases in `plugin-list`'s `VIEW_ICONS`, and the fact that four copies of this resolver exist and only `plugin-view` now has a pin. Filed unassigned as #5622; deliberately untouched here.

## Verification

All at `550f4c902`, each exit code captured before any pipe:

| gate | verdict |
| --- | --- |
| `pnpm exec vitest run …/ViewSwitcher.test.tsx …/ObjectView.hostOnlyViewTypes.test.tsx` | `Test Files 2 passed (2)` · `Tests 15 passed (15)` |
| `pnpm exec vitest run packages/plugin-view` (whole package) | `Test Files 19 passed (19)` · `Tests 199 passed (199)` |
| `pnpm --filter @object-ui/plugin-view type-check` (`tsc --noEmit` then `tsc -p tsconfig.test.json`) | exit 0 |
| `pnpm --filter @object-ui/plugin-view lint` | `✖ 229 problems (0 errors, 229 warnings)`, exit 0 — warnings are the package's existing debt, unchanged |
| `node scripts/check-changeset-presence.mjs` | `✅ 4 source file(s) of 1 released package(s) changed…` |
| `pnpm changeset:check` | `✅ All workspace packages are in the changeset fixed group.` · `✅ No changeset declares a major bump.` |
| `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 4672 tracked text file(s); skipped 85 binary).` |

Vitest was run from the repo root throughout (the package-cwd invocation is refused by the repo's own guard). The lint run is a declared narrowing of the repo-wide `pnpm lint`: the universe is eslint's own resolution of `.` from the package directory — exactly what the per-package `lint` task runs — 34 files, read from `--format json` output, 0 errors; and `eslint.config.js` declares no type-aware parser options (`projectService` / `project:` / `parserOptions` / `tsconfigRootDir` all absent, `recommendedTypeChecked` count 0), so this diff cannot move the verdict on any file it does not touch. `check-eager-closure-budget` and `check-doc-snippet-types` were not run: both are the known-broken gauges that exit non-zero until a console build / workspace build writes their inputs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code)_