### PR TITLE
refactor(charts): drop ObjectChart's fieldOptionLabel ref workaround

### DIFF
--- a/.changeset/objectchart-fieldoptionlabel-ref-5587.md
+++ b/.changeset/objectchart-fieldoptionlabel-ref-5587.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+`ObjectChart` now depends on the `fieldOptionLabel` resolver directly instead of
+holding it behind a ref, so a chart re-resolves its groupBy option labels when
+the resolver genuinely changes (objectui#5587).
+
+The ref existed for a reason that no longer holds. `useSafeFieldLabel()` returned
+a fresh object on every render outside an i18next provider, so a direct
+dependency made `fetchData`'s `useCallback` identity fresh on every render, and
+the effect that depends on `fetchData` refetched on every render — an unbounded
+loop. `ObjectChart` worked around that locally with `fieldOptionLabelRef` plus a
+`useEffect` keeping it current. `useObjectLabel`'s memo now holds with or without
+an i18next instance bound (objectui#5564), so the resolver's identity is stable
+on both paths and the indirection buys nothing.
+
+It did cost something, and that is the user-visible half: a ref-hidden dependency
+meant `fetchData` did NOT re-run when the resolver changed. A chart mounted
+before its `I18nProvider`, or rendered across a language switch, kept serving
+groupBy labels resolved by the old resolver until some unrelated dependency
+(object name, filter, aggregate) happened to move. It now refetches once on that
+transition and shows labels in the active language.
+
+Pinned by `ObjectChart.fieldOptionLabelRefetch.test.tsx`, which counts fetches
+across forced re-renders both outside and inside a provider. Reverting
+`useObjectLabel.ts` to its pre-objectui#5564 state turns the no-provider case red
+(2 fetches instead of 1, alongside React's "Maximum update depth exceeded"), so
+the removal is pinned to the fix that unlocked it rather than to a comment.

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useContext, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useContext, useCallback, useMemo } from 'react';
 import { useDataScope, SchemaRendererContext, SchemaRenderer, useDrillNavigation, useFilterScope, ElementDataSourceGate, type ElementDataSourceMapping } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
 import { ComponentRegistry, humanizeLabel, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, deriveDimensionLabelMaps, dimensionOptionTranslator, loadDimensionFieldMeta, relabelDimensions, localizeFieldOptions, type DimensionFieldMeta, type CompareToConfig, type DrillEvent, type ChartResultField, type ChartSegmentClickEvent } from '@object-ui/core';
@@ -266,14 +266,7 @@ export const ObjectChart = (props: any) => {
   const apiFetch = context?.apiFetch;
   const boundData = useDataScope(schema.bind);
   const { fieldOptionLabel } = useSafeFieldLabel();
-  // Keep a stable ref to fieldOptionLabel — the i18n hook returns a fresh
-  // function reference on every render, which would otherwise invalidate
-  // fetchData's useCallback identity and trigger an infinite refetch loop.
-  const fieldOptionLabelRef = useRef(fieldOptionLabel);
-  useEffect(() => {
-    fieldOptionLabelRef.current = fieldOptionLabel;
-  }, [fieldOptionLabel]);
-  
+
   const [fetchedData, setFetchedData] = useState<any[]>([]);
   // Measure/dimension label metadata from a dataset-bound queryDataset()
   // response (e.g. { name: 'task_count', label: 'Tasks' }) — captured so
@@ -647,7 +640,7 @@ export const ObjectChart = (props: any) => {
                     groupByField,
                     objectSchema,
                     ds,
-                    (value, fallback) => fieldOptionLabelRef.current(schema.objectName, groupByField, value, fallback),
+                    (value, fallback) => fieldOptionLabel(schema.objectName, groupByField, value, fallback),
                   );
               } catch {
                   // Schema fetch failed — continue with raw values
@@ -665,8 +658,20 @@ export const ObjectChart = (props: any) => {
       } finally {
           if (mounted.current) setLoading(false);
       }
+      // `fieldOptionLabel` is a REAL dependency, not a lint concession: the
+      // groupBy label resolution above calls it, so a fetch that ran with a
+      // stale resolver would render stale option labels. It used to be hidden
+      // behind a ref because `useSafeFieldLabel()` returned a fresh object on
+      // every render outside an i18next provider, which made this callback --
+      // and therefore the effect below that depends on it -- fresh every
+      // render too, i.e. an unbounded refetch loop. `useObjectLabel`'s memo now
+      // holds on both paths (objectui#5564), so the identity changes only when
+      // the resolver genuinely changes: once, when a provider mounts or the
+      // language switches. The disable below stays for the OTHER omissions on
+      // this list (`schema.aggregate`, `schema.dataset`, ...), which predate
+      // this change.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schema.objectName, datasetKey, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate, filterScope]);
+  }, [schema.objectName, datasetKey, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate, filterScope, fieldOptionLabel]);
 
   useEffect(() => {
     const mounted = { current: true };

--- a/packages/plugin-charts/src/__tests__/ObjectChart.fieldOptionLabelRefetch.test.tsx
+++ b/packages/plugin-charts/src/__tests__/ObjectChart.fieldOptionLabelRefetch.test.tsx
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5587 — `ObjectChart` reads `fieldOptionLabel` DIRECTLY and still
+ * fetches exactly once.
+ *
+ * `fetchData` used to hide that resolver behind a ref, because
+ * `useSafeFieldLabel()` handed back a fresh object on every render outside an
+ * i18next provider (objectui#5564). A direct dependency therefore made
+ * `fetchData` fresh on every render, and the effect that depends on `fetchData`
+ * refetched on every render — an unbounded loop, which is what the ref was
+ * written to stop.
+ *
+ * `useObjectLabel`'s memo now holds on BOTH paths, so the ref is dead weight
+ * and the dependency can be honest. This file is what pins that: it asserts a
+ * FETCH COUNT across forced re-renders, not rendered output. Nothing renders
+ * wrong when the loop is present — the chart just refetches forever — so an
+ * output assertion is green against the defect.
+ *
+ * Ablation, run while writing this file: revert `packages/i18n/src/useObjectLabel.ts`
+ * to its pre-#5585 state and both cases below go red with a fetch count in the
+ * dozens instead of 1.
+ *
+ * NOTE ON ORDER: `createI18n` registers its instance as react-i18next's
+ * process-global, and `useTranslation` falls back to that global when no
+ * context supplies one. The no-provider case therefore runs FIRST, and asserts
+ * the raw option label rather than the localized one — if an instance ever
+ * leaked into it, that assertion fails instead of the case quietly becoming a
+ * second test of the with-provider path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+
+let lastSchema: any = null;
+
+vi.mock('../ChartRenderer', () => ({
+  ChartRenderer: (props: any) => {
+    lastSchema = props.schema;
+    return null;
+  },
+}));
+
+import { I18nProvider, createI18n } from '@object-ui/i18n';
+import { ObjectChart } from '../ObjectChart';
+
+/** The option-color probe ObjectChart fires on the GLOBAL fetch, answered from a double. */
+function installMetaFetchDouble() {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      calls.push(url);
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+  return calls;
+}
+
+let metaCalls: string[] = [];
+
+beforeEach(() => {
+  metaCalls = installMetaFetchDouble();
+});
+
+afterEach(() => {
+  expect(metaCalls.filter((u) => u !== '/api/v1/meta/object/deal')).toEqual([]);
+  vi.unstubAllGlobals();
+  lastSchema = null;
+});
+
+/** Stable module-level schema — a fresh object per render would move `fetchData`'s OTHER deps. */
+const SCHEMA = {
+  objectName: 'deal',
+  chartType: 'bar',
+  aggregate: { field: 'amount', function: 'sum', groupBy: 'stage' },
+  xAxisKey: 'stage',
+};
+
+/**
+ * A `select` groupBy field, so `resolveGroupByLabels` takes the branch that
+ * calls the resolver under test with the option's own label as the fallback.
+ */
+const OBJECT_SCHEMA = {
+  fields: {
+    stage: { type: 'select', options: [{ value: 'won', label: 'Won' }] },
+  },
+};
+
+const RAW_OPTION_LABEL = 'Won';
+const LOCALIZED_OPTION_LABEL = 'Won (localized)';
+
+/** Both fetching entry points ObjectChart drives per data load, counted. */
+const makeSource = () => ({
+  aggregate: vi.fn(async () => [{ stage: 'won', amount: 120 }]),
+  getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+});
+
+/**
+ * Let anything the render just scheduled actually run.
+ *
+ * Deliberately a plain timer rather than `act(async …)`: a refetch loop
+ * regenerates work as fast as act drains it, so an exhaustive drain would hang
+ * instead of failing. A fixed window lets the count be READ — under the loop it
+ * is in the dozens, and the assertion reports that number.
+ */
+const settle = (ms = 40) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Mount, wait for the first load, force three more renders of the same tree,
+ * and report how many times the data source was asked.
+ */
+async function countFetchesAcrossRerenders(wrap: (chart: React.ReactElement) => React.ReactElement) {
+  const src = makeSource();
+  const tree = (tick: number) => wrap(<ObjectChart key="chart" schema={SCHEMA} dataSource={src} tick={tick} />);
+
+  const { rerender } = render(tree(0));
+  await waitFor(() => expect(lastSchema?.data?.length).toBe(1));
+  const afterFirstLoad = src.aggregate.mock.calls.length;
+
+  for (const tick of [1, 2, 3]) {
+    rerender(tree(tick));
+    await settle();
+  }
+  await settle();
+
+  return {
+    afterFirstLoad,
+    aggregateCalls: src.aggregate.mock.calls.length,
+    schemaCalls: src.getObjectSchema.mock.calls.length,
+    resolvedLabel: lastSchema?.data?.[0]?.stage,
+  };
+}
+
+describe('ObjectChart — fieldOptionLabel is a direct dependency (objectui#5587)', () => {
+  it('fetches once across re-renders with NO i18next provider', async () => {
+    const seen = await countFetchesAcrossRerenders((chart) => chart);
+
+    expect(seen.afterFirstLoad).toBe(1);
+    expect(seen.aggregateCalls).toBe(1);
+    expect(seen.schemaCalls).toBe(1);
+    // Precondition, asserted rather than assumed: a leaked global instance
+    // would localize this and turn the case into a duplicate of the next one.
+    expect(seen.resolvedLabel).toBe(RAW_OPTION_LABEL);
+  });
+
+  it('fetches once across re-renders INSIDE an i18next provider', async () => {
+    const instance = createI18n({ defaultLanguage: 'en', detectBrowserLanguage: false });
+    // `getAppNamespaces()` only discovers a namespace carrying one of its
+    // marker sub-keys, so `objects` is present to make `crm` discoverable at
+    // all; `fieldOptions` is the entry the resolver actually reads.
+    instance.addResourceBundle(
+      'en',
+      'translation',
+      {
+        crm: {
+          objects: { deal: { label: 'Deal' } },
+          fieldOptions: { deal: { stage: { won: LOCALIZED_OPTION_LABEL } } },
+        },
+      },
+      true,
+      true,
+    );
+
+    const seen = await countFetchesAcrossRerenders((chart) => (
+      <I18nProvider instance={instance} persistLanguage={false}>
+        {chart}
+      </I18nProvider>
+    ));
+
+    expect(seen.afterFirstLoad).toBe(1);
+    expect(seen.aggregateCalls).toBe(1);
+    expect(seen.schemaCalls).toBe(1);
+    // The resolver really ran through the bound instance — so the case above
+    // and this one exercise the two different identity paths, not one twice.
+    expect(seen.resolvedLabel).toBe(LOCALIZED_OPTION_LABEL);
+  });
+});


### PR DESCRIPTION
Fixes #5587

All measurements below were taken at `337f55d8`, the head of this branch.

## What changed

`packages/plugin-charts/src/ObjectChart.tsx` held its `fieldOptionLabel` resolver behind a ref. That ref is gone; `fetchData` now depends on the resolver directly.

- deleted the comment + `fieldOptionLabelRef` + the `useEffect` keeping it current
- line 650's `fieldOptionLabelRef.current(...)` → `fieldOptionLabel(...)`
- added `fieldOptionLabel` to `fetchData`'s `useCallback` dep array (the pre-existing `exhaustive-deps` disable stays — it covers other, older omissions on that list, which this PR does not touch)
- dropped `useRef` from the React import; it was there for this ref alone
- new pin test + changeset

The block that came out, verbatim (`ObjectChart.tsx:269-275`; line 268, the hook call, stays):

```tsx
  const { fieldOptionLabel } = useSafeFieldLabel();
  // Keep a stable ref to fieldOptionLabel — the i18n hook returns a fresh
  // function reference on every render, which would otherwise invalidate
  // fetchData's useCallback identity and trigger an infinite refetch loop.
  const fieldOptionLabelRef = useRef(fieldOptionLabel);
  useEffect(() => {
    fieldOptionLabelRef.current = fieldOptionLabel;
  }, [fieldOptionLabel]);
```

Its one read, at line 650, and what replaced it:

```tsx
-                    (value, fallback) => fieldOptionLabelRef.current(schema.objectName, groupByField, value, fallback),
+                    (value, fallback) => fieldOptionLabel(schema.objectName, groupByField, value, fallback),
```

and the dependency that was hidden behind it is now declared:

```tsx
-  }, [schema.objectName, datasetKey, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate, filterScope]);
+  }, [schema.objectName, datasetKey, aggregateKey, filterKey, compareToKey, schema.xAxisKey, schema.chartType, runAggregate, filterScope, fieldOptionLabel]);
```

## Verified line numbers

The card cited `ObjectChart.tsx:268-271`. Located by code against `origin/main` at `8c87f0583`, the workaround is **lines 269-275**:

| line | content |
|---|---|
| 268 | `const { fieldOptionLabel } = useSafeFieldLabel();` — the hook call, **kept** |
| 269-271 | the three-line "Keep a stable ref…" comment |
| 272 | `const fieldOptionLabelRef = useRef(fieldOptionLabel);` |
| 273-275 | the `useEffect` writing `.current` |
| 650 | the single read: `fieldOptionLabelRef.current(schema.objectName, groupByField, value, fallback)` |

So the card's range starts one line early (it includes the hook call, which stays) and stops four lines short of the `useEffect` it describes.

## Why the precondition is gone — from PR #5585's diff, not from #5564 being closed

The workaround's own comment states the precondition: *"the i18n hook returns a fresh function reference on every render"*. That is a claim about one memo, and PR #5585 (`38a956877`, an ancestor of this branch — confirmed with `git merge-base --is-ancestor`) is what falsified it.

`useSafeFieldLabel()` is `useObjectLabel() ?? SAFE_FIELD_LABEL_FALLBACK`, and `useObjectLabel` returns `useMemo(() => {…}, [t, i18n])` (`useObjectLabel.ts:116` … `:675`). `fieldOptionLabel` is a closure built inside that memo, so its identity is exactly the memo's identity.

**Before #5585**, `useObjectLabel` opened with `const { t, i18n } = useObjectTranslation()` and passed those straight into the dep list. `useObjectTranslation` delegates to react-i18next's `useTranslation`, which with no bound instance rebuilds its return value from a fresh `{}` every render. So `i18n` arrived with a new identity each render, the memo never held, and every closure on it — `fieldOptionLabel` included — was fresh each render. That is precisely the condition ObjectChart's comment describes.

**After #5585**, the same function reads (`useObjectLabel.ts:108-110`):

```ts
const bound = hasUsableI18nInstance(boundI18n);
const t = bound ? boundT : NO_INSTANCE_T;
const i18n = bound ? boundI18n : NO_INSTANCE_I18N;
```

`NO_INSTANCE_T` (`:72`) and `NO_INSTANCE_I18N` (`:77`) are **module-level** constants, so while nothing is bound both memo dependencies carry one identity for the life of the process and the memo holds. When an instance is bound they are the live values, which were already stable. Both paths, one identity — the precondition is gone.

This is asserted empirically rather than only read off the diff; see the ablation below.

## The test that pins it

`packages/plugin-charts/src/__tests__/ObjectChart.fieldOptionLabelRefetch.test.tsx` counts **fetches across forced re-renders**, not rendered output — nothing renders wrong when the loop is present, the chart just refetches forever, so an output assertion would be green against the defect.

Two cases, one per identity path. Each mounts, waits for the first load, forces three more renders of the same tree, and asserts `ds.aggregate` and `ds.getObjectSchema` were each called exactly once. The only difference between them is the wrapper:

```tsx
// no provider — the path objectui#5564 fixed
const seen = await countFetchesAcrossRerenders((chart) => chart);

// inside a provider — the path that already worked, kept as a regression guard
const seen = await countFetchesAcrossRerenders((chart) => (
  <I18nProvider instance={instance} persistLanguage={false}>
    {chart}
  </I18nProvider>
));
```

The no-provider case runs **first** and asserts the **raw** option label (`Won`), because `createI18n` registers its instance as react-i18next's process-global; if one ever leaked into that case, the assertion fails rather than the case quietly becoming a second test of the bound path. The provider case asserts the **localized** label, so the two cases demonstrably exercise different paths.

### Ablation — the test fails against the pre-#5585 code

With this PR's `ObjectChart.tsx` in place, `packages/i18n/src/useObjectLabel.ts` was reverted to `38a9568~1` and the same command re-run.

Mutation confirmed **on disk** before measuring, anchored on the text #5585 added and removed (an editor's exit code proves nothing):

```
hasUsableI18nInstance (added by #5585, expect 0): 0
NO_INSTANCE_T         (added by #5585, expect 0): 0
pre-#5585 guard line  (removed by #5585, expect 1): 1
```

Result:

```
× fetches once across re-renders with NO i18next provider
  AssertionError: expected 2 to be 1
Test Files  1 failed (1)
     Tests  1 failed | 1 passed (2)
```

alongside 4 × React `Maximum update depth exceeded` in the same log — the refetch loop, caught by React's own guard, which is why the count reads 2 rather than climbing without bound.

**Direction, as observed rather than as predicted:** only the **no-provider** case goes red. The with-provider case stays green, and that is correct — #5585 only changed the unbound path; the bound path's memo was already holding. So one case is the unlock pin and the other is a regression guard on the path that already worked.

No rebuild was needed for this ablation and none was skipped: `vitest.config.mts` aliases `@object-ui/i18n` to `packages/i18n/src`, so a root-launched run reads that source file directly rather than `dist/`. The ablation flipping red is itself the proof of that — a run reading `dist/` would have stayed green. The restore leg ran from an `EXIT INT TERM` trap and is verified: `git status` clean, marker back (5 hits), and `git diff --quiet origin/main -- packages/i18n/src/useObjectLabel.ts` reports identical.

## Over-delete sweep, with a same-scope control

`check-action-forward-parity` and gates like it derive their owed set from what the runtime reads, so deleting a read shrinks the set instead of failing. They cannot catch an over-delete, so the sweep is the evidence.

One `sweep()` function; probe and control differ **only** in the search pattern — same root, same `--exclude-dir` set, same flags:

- **probe** `fieldOptionLabelRef` → **6 hits**: 3 in `ObjectChart.tsx` (all three deleted or rewritten here) and 3 in `packages/plugin-dashboard/src/ObjectPivotTable.tsx`, which is a **separate module-local symbol of the same name**, not a reader of ObjectChart's. `grep -c` on the edited file after the change: **0**. Nothing else in the repo read what was deleted.
- **control** `fieldOptionLabel`, identical scope and flags → **102 hits**, exit 0.

The control is what makes the probe's small result readable: the same command over the same tree does find things, so 6 is a measurement and not a silently-empty search.

`useRef` was also checked before removing it from the import — it appeared only on the import line and on line 272.

## Changeset

`.changeset/objectchart-fieldoptionlabel-ref-5587.md`, patch to `@object-ui/plugin-charts`. The authority agrees:

```
✅  2 source file(s) of 1 released package(s) changed, and this change
    declares 1 changeset(s): .changeset/objectchart-fieldoptionlabel-ref-5587.md.
```

Both legs built and diffed at the **real** `packages/plugin-charts/dist/` path:

| file | with change | without | delta | |
|---|---|---|---|---|
| `dist/index.js` | 66,201 | 66,269 | **−68 B** | DIFFERENT |
| `dist/index.umd.cjs` | 49,549 | 49,613 | **−64 B** | DIFFERENT |
| `dist/index.d.ts` | 559 | 559 | 0 | IDENTICAL (same sha256) |

The emitted JS shrinks, which is what a deletion of reachable runtime code should do — had it not shrunk, the deleted code would have been unreachable or already bundled away and this PR would be claiming something different. The `.d.ts` is byte-identical, as expected: an internal ref changes no exported type.

The changeset is owed on the source-of-a-released-package rule and is independently earned by behaviour: a ref-hidden dependency meant `fetchData` did **not** re-run when the resolver changed. A chart mounted before its `I18nProvider`, or rendered across a language switch, kept serving groupBy labels resolved by the old resolver until some unrelated dependency happened to move. It now refetches once on that transition.

## Verification

| check | result |
|---|---|
| `pnpm exec vitest run packages/plugin-charts/` (repo root) | `Test Files 34 passed (34)` / `Tests 239 passed (239)` |
| `pnpm --filter @object-ui/plugin-charts type-check` | `tsc --noEmit`, exit 0 |
| `check:control-bytes` | `✅ OK (scanned 4673 tracked text file(s); skipped 85 binary)` |
| `check:phantom-deps` | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:self-import` | `✅ No package names itself inside its own src/.` |
| `check:action-forward-parity` | exit 0 |
| `check:i18n-keys` | `Every in-scope call-site key resolves against the en pack (2918 keys)…` |
| `check:i18n-drift` | `No en value changed in this range.` |
| `check:spec-symbols` | `✅ spec symbol derivation: 1290 files scanned…` |
| `check:doc-types` | `✅ Every documented component type is registered.` |
| `check:esm-specifiers` | `no un-ledgered package emits an extensionless relative specifier` |
| `check:skills-paths` | `✅ OK (95/96 stated path(s) resolve…)` — untouched, governed surface |
| `check:published-dist` | `✅ No published package's build output carries tooling material.` |
| `check-changeset-presence` | quoted above |

Vitest ran from the **repo root** throughout; a package-cwd run is refused by the repo's own guard.

**Broken gauges, unrelated to this diff** — both report the documented "I did not run" state rather than a verdict:

- `check:eager-closure` exits **2**: `❌ No eager-closure report at apps/console/dist/eager-closure.json … This is a broken gauge, not a passing budget.` (needs a console build)
- `check:doc-snippets` exits **1**: `The snippet program was NOT run: the packages it resolves against are not built…`

**Declared narrowing — lint.** CI's `pnpm lint` is `turbo run lint`, a per-package fan-out of `eslint .`; the package task covering this diff was run in full rather than the whole farm. Three pieces of evidence, so this reads as a measurement and not as "skipped":

1. *Population from ESLint's own config*, not from a guess about which files count: the repo has a single root `eslint.config.js` whose `files` glob is `**/*.{ts,tsx}`.
2. *File count from `--format json`*: **47 files linted, 0 errors, 273 warnings** in `packages/plugin-charts`. The warnings are pre-existing `no-explicit-any`; the 2 in the new test file are `let lastSchema: any` and the `ChartRenderer` mock's `(props: any)`, the same two the sibling `ObjectChart.compareTo.test.tsx` carries.
3. *Invariance for untouched files*: `eslint.config.js` declares no `parserOptions.project` / `projectService` (grep empty) → **no type-aware linting**; and no rule in `eslint-rules/*.js` reads the filesystem or holds cross-file state (grep for `readFileSync|globSync|process.cwd()` empty) → each file's verdict is a function of its own text plus the shared config. This diff touches two `.tsx` files, both inside `packages/plugin-charts`, plus one `.changeset/*.md` that falls outside the `files` glob entirely. No file outside that package can change verdict.

## Scope

`ObjectTimeline` was **not** touched — per triage it wants its own card, filed as **#5623** (third hand-rolled `useSafeFieldLabel`, 3-member fallback where the shared one has 5).

The over-delete sweep additionally turned up **#5625**: `ObjectPivotTable` carries the same class of ref workaround with the same now-gone precondition. Deliberately not folded in — different package, different suite, and the ref there hides the resolvers from a metadata-derivation effect rather than from a fetch callback, so it changes different behaviour and wants its own before/after test.

Both are filed unassigned and labelled `finding` only.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code)_