### PR TITLE
The `I18nLabel` inverted pin now watches the premise it claims to, and `ui-action.ts` drops the unused import

### DIFF
--- a/.changeset/i18nlabel-inverted-pin-5612.md
+++ b/.changeset/i18nlabel-inverted-pin-5612.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/types': patch
+---
+
+The `I18nLabel` "inverted pin" now watches the premise it claims to watch, and
+`ui-action.ts` no longer imports a symbol it never uses (objectui#5612, objectui#5613).
+
+Both are residue of the same removed local `label` / `options[].label` override.
+
+The `it(...)` case in `packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts`
+that called itself an inverted pin on the spec's `I18nLabel` rested on one assertion,
+`const label: SpecI18nLabel = 'Priority'`, under a comment claiming spec 17 had narrowed
+`I18nLabel` to a plain string and that a re-widening would stop it compiling. A plain
+string is assignable under the narrow shape *and* under the wide one, so that assignment
+could only ever fail if the plain-string form were removed — the opposite of the event it
+was written to catch. The widening had already landed: `@objectstack/spec@17.0.0`
+declares `I18nLabelSchema` as a union of a string and a string-to-string record
+(`dist/ui/index.d.ts:614`), and the pin stayed green through it. It reported protection
+it did not provide, and asserted a false premise in its own name.
+
+It is retargeted at what actually holds the decision up — not which single form the spec
+has, but that **both** authorized forms stay assignable, on the spec type and on the
+inherited `ActionParam['label']` and `options[].label`. It now fails when either form is
+withdrawn, and deliberately does not fail on a further widening, since inheriting by
+reference is exactly what stays correct as the authorized set moves. The comment is
+rewritten against the schema's own doc block (two authorized forms, "Both are real;
+neither is deprecated by this schema") instead of the false premise. Verified by
+construction: against a locally built narrow `type I18nLabel = string` the new assertions
+fail with `TS2344` and `TS2322`, where the old assignment compiles clean under both
+shapes.
+
+`ui-action.ts`'s `I18nLabel` type import is deleted — no type position had used it since
+the override was removed, and nothing re-exported it — and the doc paragraph that
+recorded the pin as `NOT guarded` is corrected, since the same change makes it a guard.
+
+No behaviour changes; the release-visible surface is the declaration file. Measured with
+the package's real `tsc` build, both legs building from a cleared `dist/` and cleared
+composite build info: 108 emitted files on both sides, exactly one differing —
+`dist/ui-action.d.ts`, 31,026 → 31,117 bytes, JSDoc prose only, no declaration changed.
+Every other file is byte-identical, including `dist/ui-action.js` (3,480 bytes, unchanged
+sha), because the comment documents an `interface`, which is erased at emit along with
+its leading comment. The deleted type import contributes no emitted delta at all, and the
+rewritten test file is not part of the build.

--- a/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
+++ b/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
@@ -71,6 +71,11 @@ const shapeOf = (s: unknown) => (s as { shape: Record<string, unknown> }).shape;
 /** `true` when `T` is exactly `any` — the case-1/2 probe from the guard header. */
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
+/** Compile-time assertion: `Assert<false>` is a `tsc` error, not a runtime one. */
+type Assert<T extends true> = T;
+/** `true` when a value of type `V` may be written where `T` is expected. */
+type Assignable<V, T> = V extends T ? true : false;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // NavigationAreaSchema — derived (zod)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -347,22 +352,65 @@ describe('ActionParam derives from the spec ActionParamSchema input', () => {
     expect(legacySpelling.type).toBe('datetime-local');
   });
 
-  it('inherits `label` — spec 17 made `I18nLabel` a plain string', () => {
-    // INVERTED PIN. The local override on `label`/`options[].label` was
-    // justified as a widening to "a string or a per-locale record"; spec 17
-    // dropped inline i18n objects, so `I18nLabelSchema` is `z.ZodString` and
-    // the override had become a restatement claiming to be wider than it was.
-    // If the spec re-widens `I18nLabel`, this stops compiling — which is the
-    // signal to re-decide, rather than inherit the old justification.
-    const label: SpecI18nLabel = 'Priority';
-    expect(label).toBe('Priority');
+  it('inherits `label` — and pins BOTH authorized forms of the spec `I18nLabel`', () => {
+    // INVERTED PIN, retargeted at the premise that actually holds the decision
+    // up — the objectui#3177 lesson applied a second time (objectui#5612).
+    //
+    // What this case used to be: `const label: SpecI18nLabel = 'Priority'`,
+    // under a comment claiming spec 17 had narrowed `I18nLabel` to
+    // `z.ZodString`, and that a re-widening "stops this compiling". Both halves
+    // were wrong. A plain string is assignable under the narrow shape AND under
+    // the wide one, so that assignment could only ever fail if the plain-string
+    // form were REMOVED — the opposite of the event it was written to catch. It
+    // therefore observed nothing when the union arrived, and reported
+    // protection it did not provide while asserting a false premise in its own
+    // name. Measured 2x2 against `@objectstack/spec@17.0.0`: the old assignment
+    // compiles clean under both shapes; the assertions below compile clean
+    // under the union and fail under a locally-constructed `type I18nLabel =
+    // string` with `error TS2322: Type '{ en: string; 'zh-CN': string; }' is
+    // not assignable to type 'string'`.
+    //
+    // What holds the decision up is not which single form the spec has, but
+    // that BOTH forms stay authorized. `label` / `options[].label` flow in by
+    // reference precisely because a local `string | I18nLabel` would collapse
+    // to `I18nLabel` — restating the inherited type while claiming to be wider
+    // than it. The spec says so itself, in its own doc block over
+    // `I18nLabelSchema` (objectstack#5728, maintainer ruling 2026-08-06): a
+    // display label in one of two authorized forms — a plain default-language
+    // string whose translations live in a bundle, or an inline locale map
+    // picked at render time — closing "Both are real; neither is deprecated by
+    // this schema."
+    //
+    // So this pin fails when EITHER form is withdrawn, which is the event that
+    // should send a reader back to the derivation note in `ui-action.ts`. A
+    // further widening (a third authorized form) does NOT fail here, and must
+    // not: inheriting by reference is exactly what stays correct as the
+    // authorized set moves, which is the whole argument for not overriding.
+    type _MapForm = Assert<Assignable<{ en: string; 'zh-CN': string }, SpecI18nLabel>>;
+    type _StringForm = Assert<Assignable<string, SpecI18nLabel>>;
+
+    const plain: SpecI18nLabel = 'Priority';
+    const inline: SpecI18nLabel = { en: 'Priority', 'zh-CN': '优先级' };
+    expect(plain).toBe('Priority');
+    expect(inline).toEqual({ en: 'Priority', 'zh-CN': '优先级' });
+
+    // …and the inheritance really delivers both forms to an author, on the key
+    // and on `options[].label` — the two sites the removed override covered.
+    type ParamOption = NonNullable<ActionParam['options']>[number];
+    type _ParamLabelMap = Assert<Assignable<{ en: string }, NonNullable<ActionParam['label']>>>;
+    type _OptionLabelMap = Assert<Assignable<{ en: string }, ParamOption['label']>>;
 
     const param: ActionParam = {
       name: 'p',
-      label: 'Priority',
-      options: [{ label: 'High', value: 'high' }],
+      label: { en: 'Priority', 'zh-CN': '优先级' },
+      options: [
+        { label: 'High', value: 'high' },
+        { label: { en: 'Low', 'zh-CN': '低' }, value: 'low' },
+      ],
     };
+    expect(param.label).toEqual({ en: 'Priority', 'zh-CN': '优先级' });
     expect(param.options?.[0]?.label).toBe('High');
+    expect(param.options?.[1]?.label).toEqual({ en: 'Low', 'zh-CN': '低' });
   });
 
   it('still expresses the field-backed form (framework#4074)', () => {

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -24,7 +24,6 @@ import type {
   ActionLocation,
   ActionParamSchema as SpecActionParamSchema,
   ActionType as SpecActionType,
-  I18nLabel,
 } from '@objectstack/spec/ui';
 import { FieldType as SpecFieldTypeEnum } from '@objectstack/spec/data';
 import type { FieldType as SpecFieldType } from '@objectstack/spec/data';
@@ -344,12 +343,12 @@ export type ResolvableParamFieldType = ActionParamFieldType | ObjectUiLocalParam
  * a reading of one version, not a standing fact about the schema — which is
  * the distinction the sentence this replaces failed to make.
  *
- * NOT guarded: the `it(...)` case in
+ * Guarded since objectui#5612, and it was not before: the `it(...)` case in
  * `__tests__/page-nav-misc-spec-parity.test.ts` that calls itself an inverted
- * pin on this decision asserts only that a plain string is assignable to
- * `I18nLabel`, which holds under either form — so the widening above went
- * through it green. Filed as objectui#5612; do not read that case as coverage
- * for this paragraph.
+ * pin on this decision used to assert only that a plain string is assignable to
+ * `I18nLabel` — which holds under either form, so the widening above went
+ * through it green. It now asserts BOTH authorized forms are assignable, here
+ * and on `options[].label`, and so fails when either is withdrawn.
  *
  * Drift guard: `__tests__/page-nav-misc-spec-parity.test.ts`.
  */


### PR DESCRIPTION
Fixes #5612
Fixes #5613

Folded per the claim on #5612: both cards are residue of the **same** removed local `label` / `options[].label` override in `packages/types`, each is independently checkable, and one changeset covers both. Precedent: #4559 + #4966 landed as one PR in round 7.

> Generic spellings below are flattened to parentheses to survive GitHub's body sanitizer, which strips tag-shaped `<...>` text — the same convention #5612's own body used. Real syntax is at the cited file and line.

## Part 1 (#5612) — the inverted pin that could not fire

The `it(...)` case in `packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts` called itself an inverted pin on the spec's `I18nLabel` and rested on one assertion:

```ts
const label: SpecI18nLabel = 'Priority';
```

A plain string is assignable under the narrow shape **and** under the wide one, so that assignment could only ever fail if the plain-string form were *removed* — the opposite of the event the comment said it was watching. Re-verified against the installed pin rather than taken from the card: `@objectstack/spec@17.0.0`, `node_modules/@objectstack/spec/dist/ui/index.d.ts:614`

```
declare const I18nLabelSchema: z.ZodUnion( readonly [ z.ZodString, z.ZodRecord( z.ZodString, z.ZodString ) ] );
type I18nLabel = z.input( typeof I18nLabelSchema );   // line 615
```

i.e. the widening had already landed and the pin stayed green through it. Doc block at `dist/ui/index.d.ts:571-613` — both card line numbers confirmed accurate.

**Retargeted at the premise that actually holds the decision up.** Not *which single form* the spec has, but that **both** authorized forms stay assignable — on `SpecI18nLabel` and on the inherited `ActionParam['label']` / `options[].label`. It now fails when either form is withdrawn, and deliberately does *not* fail on a further widening, since inheriting by reference is precisely what stays correct as the authorized set moves. Retitled, and the comment rewritten against the schema's own doc block ("Both are real; neither is deprecated by this schema", objectstack#5728, maintainer ruling 2026-08-06) instead of the false premise.

### Evidence the new pin can fail

⛔ A rewritten pin still green under both shapes would have fixed nothing, so this is shown, not asserted.

**Standalone 2×2 truth table** — the real spec type vs. a locally constructed `type I18nLabel = string`:

| assertion | wide (real `@objectstack/spec@17.0.0`) | narrow (`string`) |
|---|---|---|
| **old** `const label: SpecI18nLabel = 'Priority'` | `tsc` exit 0 | `tsc` exit 0 — **cannot discriminate** |
| **new** map assert + fixture | `tsc` exit 0 | `tsc` exit 2 — **fires** |

```
narrow-new.ts(5,27): error TS2344: Type 'false' does not satisfy the constraint 'true'.
narrow-new.ts(7,14): error TS2322: Type '{ en: string; 'zh-CN': string; }' is not assignable to type 'string'.
```

The wide column carries its own negative control, so it is not vacuously green — assigning a number there resolves the real union and fails, and the error text names the union, proving the leg did not silently fall back to `any`:

```
wide-control.ts(4,14): error TS2322: Type 'number' is not assignable to
                       type 'string | Record( string, string )'.
```

**In-repo reverse verification**, both legs mutation-confirmed on disk and restored to a byte-identical tree (`git diff --quiet HEAD` → 0):

- *Leg A* — narrow `SpecI18nLabel` inside the real test file → `tsc -p tsconfig.test.json` exit 2, `TS2344` + `TS2322`.
- *Leg B* — reintroduce the exact defect the pin guards (a local override narrower than the contract: `label?: string`) → exit 2, **four** errors, including both `ActionParam` legs:

```
page-nav-misc-spec-parity.test.ts(400,34): error TS2344: Type 'false' does not satisfy the constraint 'true'.
page-nav-misc-spec-parity.test.ts(401,35): error TS2344: Type 'false' does not satisfy the constraint 'true'.
page-nav-misc-spec-parity.test.ts(405,7):  error TS2322: Type '{ en: string; 'zh-CN': string; }' is not assignable to type 'string'.
page-nav-misc-spec-parity.test.ts(408,11): error TS2322: Type '{ en: string; 'zh-CN': string; }' is not assignable to type 'string'.
```

### Sibling pins in the same file — probed, none defective

The mechanical test for this defect class: **a pin that cannot fail is one whose asserted value can be flipped without turning the compile red.** Every type-level pin in the file was flipped one at a time, each flip confirmed on disk and restored; baseline green:

| pin | flip | result |
|---|---|---|
| `IsAny( SpecNavigationArea['navigation'][number] ) = false` :251 | to `true` | RED `TS2322` |
| `SpecThemeInput = authored` (mutual assignability) :293 | to a bad literal | RED `TS2353` |
| `ModeOfParsed = 'required'` :309 | to `'optional'` | RED `TS2322` |
| `ModeOfLocal = 'optional'` :313 | to `'required'` | RED `TS2322` |
| `RequiredOf = 'optional'` :346 | to `'required'` | RED `TS2322` |
| new `_MapForm` / `_StringForm` :389-390 | to a narrowed target | RED `TS2344` x2 |
| new `_ParamLabelMap` / `_OptionLabelMap` :400-401 | to a narrowed target | RED `TS2344` x2 |

The file's other 15 compile-time guards are `@ts-expect-error` directives, which cannot be blind *by construction*: a directive suppressing nothing is itself an error. Measured rather than assumed — injecting a directive over an error-free line gives

```
page-nav-misc-spec-parity.test.ts(69,1): error TS2578: Unused '@ts-expect-error' directive.
```

so with the baseline green, all 15 are live. **No sibling pin carries the #5612 defect.**

## Part 2 (#5613) — the unused import

`packages/types/src/ui-action.ts:27` imported the type `I18nLabel` with no type position using it. Re-verified on current `origin/main`: the import line number **:27 is accurate**, but the card's *occurrence count is stale* — it recorded 4 (import + 3 in JSDoc), and the file now holds **6** word-boundary occurrences (import at :27 plus five in JSDoc prose at :317, :323, :335, :336, :350), because #5617 landed the prose rewrite after the card was filed. None is a type position; the symbol is not re-exported. Deleted.

### One bounded in-place fix, named here rather than left silent

The same JSDoc block carried a paragraph opening `NOT guarded:` that recorded this very pin as absent coverage and pointed at #5612. Landing the guard in the same PR would have shipped a published comment asserting the absence of the thing the PR adds, so the paragraph is corrected to say what is now true. Same defect class (stale prose asserting a false premise about this exact pin), same file this card already claims, same gate family, no new verification surface.

## Changeset — `patch`, not empty frontmatter

Let the gate decide and measure `dist/` rather than reasoning from an assumed zero delta — and the delta is **not** zero.

```
$ node scripts/check-changeset-presence.mjs
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/i18nlabel-inverted-pin-5612.md.
$ pnpm changeset:check
✅  All workspace packages are in the changeset fixed group.
✅  No changeset declares a `major` bump.
```

Measured with the package's real `tsc`, **both legs built from a cleared `dist/` and cleared composite build info** (`tsconfig.tsbuildinfo`, so neither leg skipped emit), comparing sha256 per file rather than byte counts:

- 108 emitted files on both sides; **exactly one differs**.
- `dist/ui-action.d.ts` — 31,026 to 31,117 bytes. Content diff is **JSDoc prose only**; no declaration changed.
- `dist/ui-action.js` byte-identical (`1b24e8f5…`, 3,480 bytes) — the comment documents an `interface`, erased at emit with its declaration.
- The deleted type import contributes **no** emitted delta at all, and the rewritten test file is not part of the build (`exclude: **/*.test.ts`).

So the published surface really does move, in the declaration file. That is the same shape and the same scoring as the precedent on this exact block (#5617 used `'@object-ui/types': patch`), which is why the empty-frontmatter "publishes nothing" form would have been wrong here.

## Gates — run at `eca724225`, the final commit

```
$ pnpm --filter @object-ui/types type-check     # tsc --noEmit, tsconfig.examples.json, tsconfig.test.json
os-verify-lock: VERDICT command-exit 0 · held the lock 27s
$ npx vitest run --maxWorkers=2 packages/types/
 Test Files  40 passed (40)
      Tests  460 passed (460)
$ pnpm lint                                     # turbo run lint, repo-wide
 Tasks:    47 successful, 47 total
✅  check-control-bytes: OK (scanned 4679 tracked text file(s); skipped 85 binary).
✅  spec symbol derivation: 1290 files scanned against 4912 spec export names
✅  No package names itself inside its own src/.
✅  lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).
```

The repo-wide `pnpm lint` ran in full — **no narrowing is being declared**. Both changed files lint clean of new findings: the test file reports 0 errors / 0 warnings, and `ui-action.ts`'s 7 `no-explicit-any` warnings are pre-existing, at :600-642, far from either edit.

Not run locally, and left to CI by the standing scope rule: `pnpm check` (the CLI self-check, which needs the CLI build closure). Known-broken gauges noted, not touched: `check-eager-closure-budget` exits 2, `check-doc-snippet-types` exits 1.

## Out-of-scope finding — already filed, no new card

#5613's body also observes that `tsconfig.base.json` sets `noUnusedLocals: true` while `packages/types/tsconfig.json` extends the **root** config, which sets it `false`. Confirmed on current `origin/main`, and extended: nothing under `packages/` or `apps/` extends `tsconfig.base.json` at all — the only consumer is `examples/byo-backend-console/tsconfig.json`, plus `tsconfig.node.json` and `tsconfig.react.json`, which nothing in turn extends.

Searching before filing, per the file-first discipline, this is **already open as #4806**, which states both halves — the `noUnusedLocals` gap and the uncapped `no-unused-vars` warning. No duplicate card was created; today's re-measurement was added there as a comment instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_
