### PR TITLE
fix(plugin-dashboard): let `@object-ui/core` own percent scaling in the record-field branch

### DIFF
--- a/.changeset/olive-pugs-sing.md
+++ b/.changeset/olive-pugs-sing.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+Dashboard record fields: percent columns now render through the one percent
+scaling decision instead of a second, drifted copy of it.
+
+`renderFieldValue`'s `%`-format branch normalised the value itself before
+calling `formatPercent` (`const normalized = value > 1 ? value / 100 : value`,
+then `normalized * 100`). `formatPercent` already applies `percentDisplayValue`,
+which `@object-ui/core` documents as the single source of truth for percent
+display scaling, so the branch was re-deciding what core owns — and its copy had
+drifted from it in three measured ways:
+
+- `(value / 100) * 100` is not value-preserving in binary floating point,
+  re-introducing one call frame upstream the round trip that was removed from
+  inside `formatPercent`. On the 0.001-step grid to 200, 19,978 of 199,000
+  values change bit pattern and 1,108 rendered strings move, every one a
+  last-digit off-by-one: a stored `1.605` rendered `1.60%` where half-up is
+  `1.61%`.
+- A stored fraction below `0.01` was scaled twice — the local `* 100` put it
+  back under 1, so core's fraction arm scaled it again. `0.005` (0.5%) rendered
+  `50.00%`.
+- The local test was `value > 1` rather than core's symmetric `|value| < 1`, so
+  a negative already in percentage points took the fraction arm: `-5` rendered
+  `-500.00%`.
+
+The branch now hands the raw stored value to `formatPercent` — the identical
+call the list-view percent cell already makes for an ordinary percent column —
+so a percent reads the same as a record field, as a grid cell and as a dashboard
+measure. Output moves where it was wrong: values at or above 1 whose round trip
+lost a digit, fractions below `0.01`, negatives at or below `-1`, and exactly
+`1`, which is percentage points by core's convention and now renders `1%`.

--- a/.changeset/olive-pugs-sing.md
+++ b/.changeset/olive-pugs-sing.md
@@ -30,4 +30,6 @@ call the list-view percent cell already makes for an ordinary percent column —
 so a percent reads the same as a record field, as a grid cell and as a dashboard
 measure. Output moves where it was wrong: values at or above 1 whose round trip
 lost a digit, fractions below `0.01`, negatives at or below `-1`, and exactly
-`1`, which is percentage points by core's convention and now renders `1%`.
+`1`, which is one percentage point by core's convention and now renders
+`1.00%` at two decimals, where the local `value > 1` test had made it
+`100.00%`.

--- a/packages/plugin-dashboard/src/__tests__/recordFields.percentScaling-5607.test.ts
+++ b/packages/plugin-dashboard/src/__tests__/recordFields.percentScaling-5607.test.ts
@@ -1,0 +1,144 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5607 — the record-field percent branch stops re-deciding what
+ * `@object-ui/core` owns.
+ *
+ * `renderFieldValue`'s `%`-format branch used to normalise the value itself
+ * before calling `formatPercent`:
+ *
+ *   const normalized = value > 1 ? value / 100 : value;
+ *   return formatPercent(normalized * 100, decimals, displayLocale);
+ *
+ * `formatPercent` already applies `percentDisplayValue`, which its own doc
+ * comment names as the SINGLE source of truth for percent display scaling. So
+ * this was a second, drifted copy of one decision, and it is now deleted: the
+ * raw stored value goes to `formatPercent` — the identical call the list-view
+ * percent cell already makes for an ordinary percent column
+ * (`PercentCellRenderer`, `@object-ui/fields`).
+ *
+ * ── Measured on the current tip BEFORE the repair ────────────────────────
+ * Core already handles BOTH arms, which is why the local branch goes rather
+ * than gets patched: `percentDisplayValue(0.75) === 75` (fraction) and
+ * `percentDisplayValue(1.605) === 1.605` (already points, passed through), so
+ * `formatPercent(1.605, 2, 'en-US')` is `1.61%` with no help from the caller.
+ *
+ * ── Directions, predicted in writing BEFORE the run ──────────────────────
+ * Runner machine locale is irrelevant: every case threads an explicit
+ * `'en-US'`, so these are locale-pinned, not locale-dependent.
+ *   the five movers          RED on the round-trip form, green repaired
+ *   double-scaled fraction   RED on the round-trip form (`50.00%` for 0.005)
+ *   negative already-points  RED on the round-trip form (`-500.00%` for -5)
+ *   the exactly-1 boundary   RED on the round-trip form (`100.00%` for 1)
+ *   CONTROL                  GREEN on BOTH forms — see its own note
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderFieldValue, type FieldMeta } from '../recordFields';
+
+/**
+ * One percent-formatted record field, rendered exactly as the dashboard table
+ * and the record-detail drawer render it. `'0.00%'` is what drives the branch's
+ * own `decimals` extraction to 2 — the precision every value below is quoted at.
+ */
+const pct = (value: number, format = '0.00%'): string =>
+  renderFieldValue(
+    value,
+    { name: 'rate', label: 'Rate', type: 'number', format } satisfies FieldMeta,
+    undefined,
+    'en-US',
+  ) as string;
+
+describe('renderFieldValue percent branch — core owns the scaling (objectui#5607)', () => {
+  /**
+   * The five movers named in the card, each a last-digit off-by-one that the
+   * `(value / 100) * 100` round trip produced. These are the falsification
+   * criterion: on the unrepaired branch every one of them renders the value in
+   * the second column and this case is RED.
+   *
+   *   1.605 -> repaired 1.61%   round trip 1.60%
+   *   1.655 -> repaired 1.66%   round trip 1.65%
+   *   1.705 -> repaired 1.71%   round trip 1.70%
+   *   1.785 -> repaired 1.79%   round trip 1.78%
+   *   1.835 -> repaired 1.84%   round trip 1.83%
+   */
+  it.each([
+    [1.605, '1.61%'],
+    [1.655, '1.66%'],
+    [1.705, '1.71%'],
+    [1.785, '1.79%'],
+    [1.835, '1.84%'],
+  ])('renders %p half-up at 2 decimals as %p, not the round trip\'s last-digit-down', (value, expected) => {
+    expect(pct(value as number)).toBe(expected);
+  });
+
+  /**
+   * CONTROL — same function, same format, same locale, same precision as the
+   * cases above; only the VALUES differ, chosen because the round trip and the
+   * repair were measured to agree on them.
+   *
+   * It is green on the unrepaired code as well as the repaired code, and that
+   * is its whole job: it shows the movers above are a targeted red and not a
+   * branch that stopped rendering percents at all. It can still fail — a wrong
+   * precision, a dropped locale, a lost `%` affix or a broken branch takes it
+   * down with everything else, which is what makes it a control rather than a
+   * tautology.
+   */
+  it.each([
+    [0.75, '75.00%'],
+    [2.5, '2.50%'],
+    [12.25, '12.25%'],
+    [57, '57.00%'],
+  ])('CONTROL: %p renders %p under both the round trip and the repair', (value, expected) => {
+    expect(pct(value as number)).toBe(expected);
+  });
+
+  /**
+   * The same defect's other two faces, both fixed by the same deletion.
+   *
+   * A stored fraction below 0.01 was scaled TWICE — the local `* 100` put it
+   * back under 1, so `percentDisplayValue`'s fraction arm scaled it again. That
+   * is a factor of 100, not a last digit.
+   */
+  it('does not double-scale a stored fraction below 0.01', () => {
+    expect(pct(0.005)).toBe('0.50%');
+    expect(pct(0.0075)).toBe('0.75%');
+  });
+
+  /**
+   * The local test was `value > 1`; core's is the symmetric `|value| < 1`. A
+   * negative already in percentage points therefore took the fraction arm.
+   */
+  it('treats a negative already in percentage points as points, like core does', () => {
+    expect(pct(-5)).toBe('-5.00%');
+    expect(pct(-0.5)).toBe('-50.00%');
+  });
+
+  /**
+   * The boundary itself. `percentDisplayValue` is `value > -1 && value < 1`, so
+   * exactly 1 is percentage points and renders `1%` — the convention
+   * `PercentScale` states in those words (`whole` is `1 => "1%"`). The local
+   * branch's `value > 1` put exactly 1 on the fraction side and rendered
+   * `100.00%`, which is the drift this card removes.
+   */
+  it('puts exactly 1 on core\'s side of the boundary', () => {
+    expect(pct(1)).toBe('1.00%');
+    expect(pct(0.999)).toBe('99.90%');
+  });
+
+  /**
+   * The branch's own `decimals` extraction is untouched by the repair, and this
+   * pins that: `'0.0%'` is 1 decimal, a bare `'%'` matches no `0.(0+)%` group
+   * and is 0.
+   */
+  it('still reads the precision out of the format string', () => {
+    expect(pct(1.605, '0.0%')).toBe('1.6%');
+    expect(pct(1.605, '%')).toBe('2%');
+  });
+});

--- a/packages/plugin-dashboard/src/recordFields.tsx
+++ b/packages/plugin-dashboard/src/recordFields.tsx
@@ -187,8 +187,36 @@ export function renderFieldValue(
   }
   if (typeof fmt === 'string' && /%/.test(fmt) && typeof value === 'number') {
     const decimals = (fmt.match(/0\.(0+)%/) || [undefined, ''] as any)[1].length;
-    const normalized = value > 1 ? value / 100 : value;
-    return formatPercent(normalized * 100, decimals, displayLocale);
+    // The RAW stored value goes to `formatPercent`, which applies
+    // `percentDisplayValue` — the single source of truth for percent display
+    // scaling (`@object-ui/core`), whose doc comment says so in those words.
+    // This is the same call the list-view percent cell makes for an ordinary
+    // percent column (`PercentCellRenderer` in `@object-ui/fields`), so a
+    // percent now reads identically as a record field, as a grid cell and as a
+    // dashboard measure.
+    //
+    // ⚠️ This call site used to make the fraction/points decision AGAIN, with a
+    // local copy that had drifted from the one it duplicated (objectui#5607):
+    //
+    //   const normalized = value > 1 ? value / 100 : value;
+    //   return formatPercent(normalized * 100, decimals, displayLocale);
+    //
+    // Three measured divergences, all of them the one defect — a caller
+    // re-deciding what core owns:
+    //  - `(value / 100) * 100` is NOT value-preserving in binary floating
+    //    point. It re-introduced, one call frame upstream, exactly the round
+    //    trip objectui#4590 removed from inside `formatPercent`: 19,978 of
+    //    199,000 values on the 0.001-step grid to 200 change bit pattern and
+    //    1,108 rendered strings move, every one a last-digit off-by-one —
+    //    a stored `1.605` rendered `1.60%` where half-up is `1.61%`.
+    //  - A stored fraction below 0.01 was scaled TWICE: the local `* 100` put
+    //    it below 1, so core's fraction arm scaled it again — `0.005` (0.5%)
+    //    rendered `50.00%`, a factor of 100.
+    //  - The local test was `value > 1`, not core's symmetric `|value| < 1`,
+    //    so a negative already in points was treated as a fraction: `-5`
+    //    rendered `-500.00%`.
+    // Deleting the branch fixes all three, because they were never three bugs.
+    return formatPercent(value, decimals, displayLocale);
   }
   if (typeof fmt === 'string' && /[YMDHms]/.test(fmt)) {
     return formatDate(value, fmt);


### PR DESCRIPTION
Fixes #5607

`renderFieldValue`'s `%`-format branch normalised the value itself before calling
`formatPercent`. `formatPercent` already applies `percentDisplayValue`, which
`@object-ui/core` documents as the SINGLE source of truth for percent display
scaling — so the call site was re-deciding what core owns, with a copy that had
drifted from it.

**The branch is deleted rather than repaired**, and the measurement below is why.

## Verified line numbers (re-derived by code on `origin/main`)

The card cites `packages/plugin-dashboard/src/recordFields.tsx:189-192`. Derived
on `cdda37ae3` with `git show origin/main:… | grep -n`:

```
188:  if (typeof fmt === 'string' && /%/.test(fmt) && typeof value === 'number') {
189:    const decimals = (fmt.match(/0\.(0+)%/) || [undefined, ''] as any)[1].length;
190:    const normalized = value > 1 ? value / 100 : value;
191:    return formatPercent(normalized * 100, decimals, displayLocale);
```

**No drift.** The two defect lines are 190-191; the branch opens at 188. The file
is byte-identical between `f52d36c96` (when the card was filed) and current
`origin/main` — `git diff --stat f52d36c96 origin/main -- <file>` is empty.

## What core already does (the measurement that chose the shape)

Triage asked for this to be measured before choosing between repairing the local
normalisation and deleting it. Executed against the built `dist`:

```
percentDisplayValue(0.75)  = 75        percentDisplayValue(1.605) = 1.605
percentDisplayValue(0.005) = 0.5       percentDisplayValue(57)    = 57
percentDisplayValue(-0.5)  = -50       percentDisplayValue(-5)    = -5
percentDisplayValue(1)     = 1
```

`percentDisplayValue` is `value > -1 && value < 1 ? value * 100 : value` —
**both arms, and a symmetric test**. Core needs no help from the caller, so the
condition triage named for "the branch should go rather than be fixed" is met by
measurement. The raw stored value now goes to `formatPercent`: the identical call
the list-view percent cell already makes for an ordinary percent column.

Note this also rules out the shape the issue body floated
(`formatPercent(value > 1 ? value : value * 100, …)`): it keeps the asymmetric
`> 1` test and double-scales small fractions, i.e. it preserves two of the three
divergences below.

## `Intl` option spellings, re-read on the current tip

Triage's second note. The body's measurement was taken through
`style: 'unit'` / `unit: 'percent'` / `unitDisplay: 'narrow'` quoted from
`formatPercent`. **Those spellings have moved.** On the current tip
`formatPercent` renders through `formatDisplayNumber(displayValue, { locale,
style: 'percentPoints', … })` — the raw `Intl` triple is now an internal detail
of the `'percentPoints'` style token. This PR therefore pins **no** `Intl`
options: every assertion goes through `renderFieldValue`, so nothing here can
become a second drift when that token's internals move again.

## The three divergences, all one defect

| stored | before | after |
| --- | --- | --- |
| `1.605` | `1.60%` | `1.61%` |
| `0.005` | `50.00%` | `0.50%` |
| `-5` | `-500.00%` | `-5.00%` |
| `1` | `100.00%` | `1.00%` |

1. `(value / 100) * 100` is not value-preserving in binary floating point. Grid
   `v = i/1000`, `i` in `1001..200000`, re-measured through the **current** call
   shape: **19,978 of 199,000** values change bit pattern and **1,108 rendered
   strings move** — reproducing the card's numbers and its five first movers
   exactly.
2. A stored fraction below `0.01` was scaled twice — the local `* 100` put it
   back under 1, so core's fraction arm scaled it again.
3. The local test was `value > 1`, not core's symmetric `|value| < 1`, so a
   negative already in percentage points took the fraction arm.

## Evidence — the repair is what turns the test green

Ablation by mutating the fix away on disk. Each leg proves the mutation on disk
with **anchored whole-line counts in both directions** before measuring, and a
`trap … EXIT INT TERM` restores the file. No rebuild is needed for the mutation
to take effect: the test reaches the subject by a **relative source import**
(`../recordFields`), not through the package's `exports`→`dist`.

**Leg A — restore the round-trip form.** `8 failed | 5 passed (13)`, and all five
named movers are red with exactly the card's values:

```
AssertionError: expected '1.60%' to be '1.61%'
AssertionError: expected '1.65%' to be '1.66%'
AssertionError: expected '1.70%' to be '1.71%'
AssertionError: expected '1.78%' to be '1.79%'
AssertionError: expected '1.83%' to be '1.84%'
```

The 5 that stay green are the 4 controls plus the precision pin — so the red is
targeted, not a branch that stopped rendering percents.

**Leg B — the controls' own mutation leg.** A control that cannot fail is a
tautology, so this measures rather than argues it: same branch, same call, same
locale, only `decimals` → `decimals + 1`. Result `13 failed (13)` — **all four
controls red**, e.g. `expected '1.000%' to be '1.00%'`.

An earlier revision of the ablation used `grep -E`, where `(` is a grouping
metacharacter, so the literal parens matched nothing and every anchor read 0. The
pristine assertion aborted with `ablation NOT RUN` rather than reporting a
no-op as a result; anchors are now `grep -cxF`. Recorded because the guard
firing is the reason the reading is trustworthy.

## Runs

All at `348c1330f`, from the repo root (package-cwd `vitest` is refused by the
repo's own guard, objectui#3378).

| run | verdict |
| --- | --- |
| new test file | `Test Files 1 passed (1)` · `Tests 13 passed (13)` |
| full `plugin-dashboard` suite | `Test Files 74 passed (74)` · `Tests 670 passed (670)` |
| `type-check` | `VERDICT command-exit 0` (`tsc --noEmit && tsc -p tsconfig.test.json` echoed) |
| `lint` | `✖ 365 problems (0 errors, 365 warnings)` — exit 0 |
| `check-control-bytes` | `✅ OK (scanned 4684 tracked text file(s); skipped 85 binary)` |

The heavier runs were measured at `4e98151ea`; the only commit since touches
`.changeset/*.md`, so the code tree is byte-identical and they apply unchanged.

No existing fixture pinned the old behaviour — notably
`ObjectDataTable.percentLocale.test.tsx`, which drives this same branch with
`1234.5` (`'0%'`) and `33.33` (`'0.00%'`), is green unchanged.

### Lint narrowing — declared, and measured

The repo-wide `eslint .` is CI's run. This narrowing is a measurement, not a skip:

1. Population read from ESLint's **own** config via `isPathIgnored`: **3,506**
   lintable tracked files, of which **104** under `packages/plugin-dashboard/`.
2. Files actually linted here, counted from `--format json`: **104** — the whole
   changed package, 0 errors.
3. Type-aware linting is **not** enabled (no `projectService` / `parserOptions` /
   `project:` in `eslint.config.js`), so no untouched file's verdict can depend
   on this diff. The 3,402 excluded files are provably unmovable by it.

`src/recordFields.tsx` carries 14 `no-explicit-any` warnings, all at lines 47-126
— upstream of the percent branch and untouched here.

## Changeset

`check-changeset-presence.mjs` is the authority:

```
✅  2 source file(s) of 1 released package(s) changed, and this change declares
    1 changeset(s): .changeset/olive-pugs-sing.md.
```

Dist deltas, measured at the real `dist/` path with `dist/` (which contains
`tsconfig.tsbuildinfo`) removed on **every** leg, compared by **hash**:

| artifact | fixed | unfixed |
| --- | --- | --- |
| `dist/index.js` | `77df7ba4d50ceb43` (131,405 B) | `a2db53c8a5fae48a` (131,436 B) |
| all 26 `*.d.ts` | `061342ba4c1f1e5b` | `061342ba4c1f1e5b` |

The behaviour-card signature exactly: **JS moves, `.d.ts` does not** — which is
why a zero `.d.ts` delta would have been the wrong reason to skip a changeset.
`dist/` was rebuilt from the restored source afterwards and re-hashed to
`77df7ba4d50ceb43`, with the mutation marker absent, so no mutated build was left
behind. (`plugin-dashboard` emits no `index.cjs`; ESM only.)

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_