### PR TITLE
skills(objectui): record the measured envelope reality instead of contradicting it

### DIFF
--- a/.changeset/skill-provider-envelope-teaching-5372.md
+++ b/.changeset/skill-provider-envelope-teaching-5372.md
@@ -1,0 +1,16 @@
+---
+---
+
+Published-skill teaching only — this publishes nothing, declared explicitly with an
+empty frontmatter rather than left undeclared. No package `src/` is touched: the
+change is confined to `skills/objectui/**` (the published skill package) plus one new
+test under `packages/components/src/__tests__/`, which pins the corrected teaching to
+the real renderer.
+
+The rules told authors that the `properties` / `props` envelope belonged to the
+`element:*` namespace and that every other key "lives on the node". Measured on a real
+`SchemaRenderer` inside a `SchemaRendererProvider`, `properties` is evaluated and then
+hoisted onto the node in *every* namespace — so it was the only spelling that reached a
+`data-table`'s rows from a provider `dataSource`, while the node-level and `props`
+spellings rendered a header over the empty state with nothing thrown and nothing logged.
+The guides now record that measurement instead of contradicting it.

--- a/packages/components/src/__tests__/skill-guide-provider-envelope.test.tsx
+++ b/packages/components/src/__tests__/skill-guide-provider-envelope.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5372 — the published rules told authors the `properties` / `props`
+ * envelope belonged to the `element:*` namespace and nowhere else, and that
+ * every other key "lives on the node". Half of that is right and the half that
+ * is wrong is the half an author hits when wiring a provider to a table.
+ *
+ * Two envelopes, two fates (`packages/react/src/SchemaRenderer.tsx`, the
+ * `evaluatedSchema` memo):
+ *
+ *   - `props.*`      — evaluated, then spread as React props. A `ui:*` /
+ *                      `page:*` renderer reads `schema.*` and never sees it.
+ *   - `properties.*` — evaluated, then HOISTED onto the node by the COMPAT
+ *                      hoist (`type` / `id` excepted). It therefore lands
+ *                      exactly where every renderer reads, in every namespace.
+ *   - a node key     — read, but never expression-evaluated.
+ *
+ * So the one spelling the rules told an author not to reach for was the only
+ * one that reaches a provider's data, and the two the rules endorsed both fail
+ * in this repo's most expensive shape: a correct header over an empty state,
+ * nothing thrown, nothing logged.
+ *
+ * ⛔ This file pins the MEASUREMENT and the corrected teaching. It takes no
+ * position on the two directions the card ruled out of scope — widening
+ * node-level evaluation, and giving `data-table` a `bind` read (declined by the
+ * objectui#5125 ruling). Whether `properties` should be an official `ui:*`
+ * authoring channel is objectui#4795's open question ②; the guides record it
+ * rather than recommend it, and nothing here asserts it should be taught.
+ *
+ * Three halves, same discipline as the sibling `skill-guide-data-table-binding`:
+ * a counter-probe so a zero is a reading, doc-sameness against the real
+ * published bytes, and behaviour through the REAL renderer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+
+// The REAL renderers, at module scope so `data-table` / `card` are registered
+// before the first render (AGENTS.md §测试纪律). Relative, not the bare
+// specifier: this file lives inside `@object-ui/components`
+// (`scripts/check-package-self-import.mjs`).
+import '../renderers';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+const skillsRoot = path.join(repoRoot, 'skills/objectui');
+
+const COLUMNS = [
+  { name: 'name', label: 'Name' },
+  { name: 'email', label: 'Email' },
+];
+const ROWS = [
+  { name: 'Ada Lovelace', email: 'ada@example.com' },
+  { name: 'Grace Hopper', email: 'grace@example.com' },
+];
+const PROVIDER = { customers: ROWS, label: 'Evaluated Title' };
+const EMPTY_STATE = 'No results foundTry adjusting your filters or search query.';
+
+function renderNode(schema: unknown) {
+  return render(
+    <SchemaRendererProvider dataSource={PROVIDER}>
+      <SchemaRenderer schema={schema as never} />
+    </SchemaRendererProvider>,
+  );
+}
+
+/** Every rendered body cell's text, row-major. */
+function bodyCells(): string[] {
+  return Array.from(document.querySelectorAll('tbody td')).map((td) => (td.textContent ?? '').trim());
+}
+
+/** Every published file in the skill package, by repo-relative path. */
+function publishedFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else out.push(path.relative(repoRoot, full));
+    }
+  };
+  walk(skillsRoot);
+  return out.sort();
+}
+
+function readSkillFile(rel: string): string {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+describe('#5372 behaviour — a provider `dataSource` into a `data-table`', () => {
+  it('a node-level `data` expression renders the empty state, silently', () => {
+    renderNode({ type: 'data-table', data: '${data.customers}', columns: COLUMNS });
+
+    // The raw `${…}` string is not an array, so DataTableRenderer falls back to
+    // EMPTY_ROWS. No throw and no console line is the whole defect.
+    expect(bodyCells()).toEqual([EMPTY_STATE]);
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+  });
+
+  it('a `props` envelope renders the empty state — evaluated, then not read', () => {
+    renderNode({ type: 'data-table', props: { data: '${data.customers}' }, columns: COLUMNS });
+
+    expect(bodyCells()).toEqual([EMPTY_STATE]);
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+  });
+
+  it('a `properties` envelope puts the provider rows on screen — evaluated, then hoisted', () => {
+    renderNode({ type: 'data-table', properties: { data: '${data.customers}' }, columns: COLUMNS });
+
+    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+    expect(bodyCells()).toEqual([
+      'Ada Lovelace',
+      'ada@example.com',
+      'Grace Hopper',
+      'grace@example.com',
+    ]);
+  });
+
+  it('the route the guides teach — host-resolved rows on the node — renders', () => {
+    renderNode({ type: 'data-table', data: ROWS, columns: COLUMNS });
+
+    expect(bodyCells()).toEqual([
+      'Ada Lovelace',
+      'ada@example.com',
+      'Grace Hopper',
+      'grace@example.com',
+    ]);
+  });
+});
+
+describe('#5372 behaviour — the hoist is not `element:*`-only', () => {
+  // `card` is a `ui:*` renderer reading `schema.title` (renderers/layout/card.tsx).
+  // If the envelope really were an `element:*` exception, the `properties` leg
+  // here would render no header. It renders one.
+  const header = () => (document.querySelector('[data-obj-type="card"]')?.textContent ?? '').trim();
+  const hasHeaderEl = () => !!document.querySelector('[data-obj-type="card"]')?.firstElementChild;
+
+  it('`props.title` on a `ui:*` card renders no header at all', () => {
+    renderNode({ type: 'card', props: { title: 'Customer Summary' } });
+    expect(hasHeaderEl()).toBe(false);
+    expect(header()).toBe('');
+  });
+
+  it('`properties.title` on the same card renders the header', () => {
+    renderNode({ type: 'card', properties: { title: 'Customer Summary' } });
+    expect(header()).toBe('Customer Summary');
+  });
+
+  it('a node-level `title` is read but never evaluated', () => {
+    renderNode({ type: 'card', title: '${data.label}' });
+    expect(header()).toBe('${data.label}');
+  });
+
+  it('the same expression under `properties` is evaluated AND read', () => {
+    renderNode({ type: 'card', properties: { title: '${data.label}' } });
+    expect(header()).toBe('Evaluated Title');
+  });
+});
+
+describe('#5372 doc-sameness — the published rules record what was measured', () => {
+  const PROTOCOL = 'skills/objectui/rules/protocol.md';
+
+  it('counter-probe: the rules file is readable and still carries the node rule', () => {
+    const md = readSkillFile(PROTOCOL);
+    // A known-present term. The assertions below are only readings because
+    // this one passes: a moved or renamed file would fail here first.
+    expect(md.length).toBeGreaterThan(0);
+    expect(md).toContain('Rule: Keys Live on the Node');
+  });
+
+  it('the retired `element:*`-only claim is gone from the rules', () => {
+    const md = readSkillFile(PROTOCOL);
+    // The exact sentence the measurement rules false, and the instruction that
+    // followed from it.
+    expect(md).not.toMatch(/The one exception is the `element:\*` namespace/);
+    expect(md).not.toMatch(/do not apply either shape everywhere/);
+  });
+
+  it('the rules state the hoist, which is the fact that makes the rest true', () => {
+    // Newline-tolerant: the claim is wrapped prose, not a fixed line.
+    expect(readSkillFile(PROTOCOL)).toMatch(/hoists every key onto\s+the node/);
+  });
+});
+
+describe('#5372 class guard — no published skill prescribes a dead envelope', () => {
+  it('counter-probe: the published tree is enumerable and non-empty', () => {
+    const files = publishedFiles();
+    expect(files.length).toBeGreaterThan(0);
+    expect(files).toContain('skills/objectui/rules/protocol.md');
+  });
+
+  it('no guide tells an author to move an expression "instead of" onto `props`', () => {
+    // The shape the prose carried in two places with none of the searchable
+    // envelope tokens: a Common-Mistakes bullet prescribing the envelope that
+    // renders nothing.
+    for (const rel of publishedFiles().filter((f) => f.endsWith('.md'))) {
+      expect(readSkillFile(rel), `${rel} prescribes the retired \`props.*\` workaround`)
+        .not.toMatch(/instead of\s+`props\./);
+    }
+  });
+
+  it('no published eval REQUIRES a `props.*` spelling in a correct answer', () => {
+    // The graded form of the same false rule. `must_contain` is the assertion
+    // that decides whether an answer passes, so a `props.` entry there marks
+    // the silently-blank spelling as correct.
+    const evals = publishedFiles().filter((f) => f.includes('/evals/') && f.endsWith('.json'));
+    expect(evals.length).toBeGreaterThan(0);
+
+    let graded = 0;
+    for (const rel of evals) {
+      const doc = JSON.parse(readSkillFile(rel)) as {
+        evals?: { assertions?: { must_contain?: string[] } }[];
+      };
+      for (const item of doc.evals ?? []) {
+        const must = item.assertions?.must_contain ?? [];
+        graded += must.length;
+        expect(must.filter((t) => /^props\./.test(t)), `${rel} requires a dead \`props.*\` spelling`)
+          .toEqual([]);
+      }
+    }
+    // Counter-probe: a per-entry loop over empty assertion lists passes
+    // vacuously.
+    expect(graded).toBeGreaterThan(0);
+  });
+});

--- a/skills/objectui/SKILL.md
+++ b/skills/objectui/SKILL.md
@@ -135,7 +135,7 @@ See `rules/no-touch-zones.md` for the full list and rationale.
 - Introducing package coupling (e.g. a UI package depending on business logic).
 - Registering components without a namespace in plugin-heavy projects.
 - Skipping docs updates for newly introduced schema patterns.
-- Putting expression values in top-level `value` / `label` fields instead of `props.*`.
+- Expecting a `${...}` on a top-level `value` / `label` to evaluate, or "fixing" it by moving it under `props` — the first renders the literal, the second renders nothing at all. Resolve the value in the host, or carry it on a `text` node's `content` ([`rules/protocol.md`](./rules/protocol.md)).
 - Missing the published stylesheet imports — `@object-ui/components/style.css` then `@object-ui/fields/style.css`, in that order — components render but look completely unstyled. The components sheet carries the theme tokens and the `:root` / `.dark` defaults; the fields sheet is a subtracted supplement that resolves against them.
 - Pointing Tailwind at the installed ObjectUI packages instead of importing those two sheets: the published tarballs carry `dist` only, so the theme block the themed utilities are built on is not there to scan. Inside the ObjectUI workspace the reverse holds — packages are linked to their sources, an app scans them and declares the theme itself. See [`rules/styling.md`](./rules/styling.md) for both cases; do not keep a second copy of the answer here.
 

--- a/skills/objectui/evals/schema-expressions.json
+++ b/skills/objectui/evals/schema-expressions.json
@@ -4,32 +4,34 @@
     {
       "id": 1,
       "prompt": "I have a statistic card in my Object UI schema but the value shows literally as ${data.revenue} instead of the actual number. Here's my schema: { \"type\": \"statistic\", \"value\": \"${data.revenue}\", \"label\": \"Revenue\" }. What's wrong?",
-      "expected_output": "Identifies that top-level 'value' and 'label' are not expression-evaluated, and provides the corrected schema using props.value and props.label.",
+      "expected_output": "Identifies that top-level 'value' and 'label' are not expression-evaluated, and does NOT offer props.value / props.label as the fix — that envelope is evaluated and then discarded, rendering nothing. Corrects it by resolving the value in the host before rendering, or by carrying it on a text node's content.",
       "files": [],
       "assertions": {
         "must_contain": [
-          "props.value",
-          "props.label",
+          "content",
           "${data."
         ],
         "must_not_contain": [
-          "top-level value works"
+          "top-level value works",
+          "props.value",
+          "props.label"
         ]
       }
     },
     {
       "id": 2,
       "prompt": "I need to make a button visible only to admin users AND only when the record status is 'active'. Also, the button should show the record owner's name. Show me the correct schema.",
-      "expected_output": "Produces a schema with combined visible/hidden expression using && operator, and uses props.label with template expression for the owner name.",
+      "expected_output": "Produces a schema with combined visible/hidden expression using && operator, and does not put the owner name in props.label — that envelope is evaluated and then discarded. The name is resolved in the host, or carried on a text node's content.",
       "files": [],
       "assertions": {
         "must_contain": [
           "visible",
           "&&",
-          "props.label",
           "${"
         ],
-        "must_not_contain": []
+        "must_not_contain": [
+          "props.label"
+        ]
       }
     },
     {

--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -200,7 +200,12 @@ completely — no error, no warning, nothing in the console.
 `data-table` is not among them, which is the trap worth knowing by name: it
 takes its rows from an inline `data` array on the node, so a bound `data-table`
 renders a correct-looking header over an empty body, with nothing thrown and
-nothing logged.
+nothing logged. Pointing the node's own `data` key at an expression
+(`"data": "${data.customers}"`) fails the same silent way — node keys are not
+expression-evaluated — so **the host resolves the array and puts it on the
+node**, as below. The one spelling that does carry a provider expression
+through is measured, with its open-question caveat, in
+[`../rules/protocol.md`](../rules/protocol.md).
 
 ```json
 {
@@ -247,7 +252,9 @@ A `statistic`'s `label` / `value` / `description` are read off the node but are
 
 Do not reach for a `props` envelope to get an expression evaluated — values
 inside it are evaluated and then handed over as React props, which these
-renderers never read, so the component paints an empty frame.
+renderers never read, so the component paints an empty frame. (`properties` is a
+different envelope and behaves differently; see
+[`../rules/protocol.md`](../rules/protocol.md).)
 
 ### Via DataSource methods (in plugin code)
 

--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -89,9 +89,16 @@ renderers read `schema.title` / `schema.content` / `schema.columns` directly;
 `SchemaRenderer` spreads `schema.props` as React props instead of merging it
 into the node, so a key parked under `props` is never read and the component
 paints an empty frame (the envelope itself also lands in the DOM as
-`props="[object Object]"`). Namespaced `element:*` components are the one
-deliberate exception — they read their config out of `properties` / `props`
-by design (`readProps` in `packages/components/src/renderers/basic/elements.tsx`).
+`props="[object Object]"`). Namespaced `element:*` components are where `props`
+is read by design (`readProps` in
+`packages/components/src/renderers/basic/elements.tsx`).
+
+`properties` is a different envelope with a different fate: `SchemaRenderer`
+evaluates it and then **hoists its keys onto the node**, so unlike `props` it
+does reach every renderer. That is why it is the only spelling that gets a
+provider expression into a `data-table` today — measured, with the failing legs
+and the reason it is recorded rather than recommended, in
+[`rules/protocol.md`](../rules/protocol.md).
 
 Prefer expression-based behavior (`hidden`, `disabled`) over imperative
 branching in component code.
@@ -180,6 +187,7 @@ clear the first gate; only the short list below clears the second.
 | `visible` / `visibleOn` | Boolean expression. `visible` takes priority over `hidden`. |
 | `disabled` / `disabledOn` | Boolean expression. Passed as prop to component. |
 | `props.*` | Template-evaluated, but handed to the component as React props — a `ui:*` / `page:*` renderer never reads the result back, so the evaluated value is discarded. Only `element:*` components consume it. Do not use it as an expression carrier. |
+| `properties.*` | Template-evaluated **and hoisted onto the node**, so unlike `props` the result is read — by every namespace. Its status as an authoring channel is open (objectui#4795); see [`rules/protocol.md`](../rules/protocol.md) before reaching for it. |
 
 **NOT evaluated (raw strings passed through):**
 
@@ -478,7 +486,7 @@ It exposes `ObjectRenderer`, `PageRenderer`, `DashboardRenderer` and matching pr
 - Introducing package coupling (for example, UI package depending on business logic package).
 - Registering components without namespace in plugin-heavy projects.
 - Skipping docs updates for newly introduced schema patterns.
-- Putting expression values in top-level `value`/`label` fields instead of `props.*`.
+- Expecting a `${...}` on top-level `value` / `label` to evaluate — it does not, and moving it under `props` renders nothing at all. Resolve it in the host, or carry it on a `text` node's `content`.
 - Missing Shadcn CSS variables — components render but look completely unstyled.
 - Forgetting the `@object-ui/components/style.css` and `@object-ui/fields/style.css` imports, or importing them in the wrong order — ObjectUI's utilities never reach the page.
 

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -83,8 +83,17 @@ literal `${...}` on screen for nothing on screen. Put keys on the node.
 ] }
 ```
 
-The `element:*` namespace is the deliberate exception: those components read
-their config out of `properties` / `props`, so the envelope is required there.
+The `element:*` namespace is where `props` is read: those components take their
+config out of `properties` / `props`, so the envelope is required there.
+
+`properties` is not the same envelope as `props`. `SchemaRenderer` evaluates it
+and then **hoists its keys onto the node**, so it is read by every namespace —
+measured, `{ "type": "card", "properties": { "title": "${data.customer.name}" } }`
+does render the evaluated name. Whether that is an authoring channel for
+`ui:*` / `page:*` is an open contract question (objectui#4795); the measurement
+and the failing legs beside it are in
+[`rules/protocol.md`](../rules/protocol.md). Until it is ruled, the route this
+guide teaches is unchanged: `content`, or resolve the value in the host.
 
 ## Template expression syntax (`${}`)
 
@@ -604,7 +613,7 @@ Expressions don't throw on missing variables — they return `undefined`. Use fa
 
 When an expression isn't working:
 
-1. Is it `content` (or a predicate key)? Those are the fields that are both evaluated and read. A `${...}` on `title` / `label` / `value` / `description` is never evaluated, and one inside a `props` envelope is evaluated and then discarded.
+1. Is it `content` (or a predicate key)? Those are the fields that are both evaluated and read. A `${...}` on `title` / `label` / `value` / `description` is never evaluated, and one inside a `props` envelope is evaluated and then discarded. (A `properties` envelope is the one that is evaluated *and* hoisted onto the node — see [`rules/protocol.md`](../rules/protocol.md) for why that is recorded, not recommended.)
 2. Is the `${}` syntax correct? Check for unmatched braces.
 3. Is the data actually available in scope? Check `SchemaRendererProvider dataSource`.
 4. For conditions: are you using `On` suffix correctly? (`hiddenOn` takes raw expression, `hidden` needs `${}` if it's a string).

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -19,6 +19,7 @@ value must clear before it reaches the screen.
 | `visibleOn` | Condition | boolean | `"visibleOn": "data.permissions.canView"` |
 | `disabled` | Condition | boolean | `"disabled": "${form.isSubmitting}"` |
 | `disabledOn` | Condition | boolean | `"disabledOn": "!data.hasPermission"` |
+| `properties.*` | Template (`${}`) | Preserves original type | Evaluated, then **hoisted onto the node** (`type` / `id` excepted), so the result lands where every renderer reads. See "Rule: Keys Live on the Node" below. |
 | `props.*` | Template (`${}`) | Preserves original type | Evaluated, then spread as **React props** — a `ui:*` / `page:*` renderer reads `schema.*` and never sees the result. Consumed only by `element:*` components. |
 
 **Precedence rule:** `visible` takes priority over `hidden`.
@@ -46,6 +47,8 @@ Every UI component node MUST follow this shape:
 interface UIComponent {
   type: string;              // Required: component type identifier
   id?: string;               // Optional: unique identifier
+  properties?: Record<string, any>; // Optional: spec config bag, hoisted onto
+                                    // the node. See "Rule: Keys Live on the Node".
   props?: Record<string, any>; // Optional: element:* config envelope — NOT a
                                // general bag. See "Rule: Keys Live on the Node".
   bind?: string;             // Optional: data binding path
@@ -83,12 +86,34 @@ attribute `props="[object Object]"`.
 }
 ```
 
-**The one exception is the `element:*` namespace.** Those components read their
-config out of `properties` / `props` by design (`readProps` in
+**`props` and `properties` are two different envelopes, and only one of them is
+dropped.** The rule above is about `props`. `properties` is the spec spelling of
+the same bag, and `SchemaRenderer` evaluates it and then **hoists every key onto
+the node** (`type` / `id` excepted) before the renderer runs — so it is read by
+every namespace, not just `element:*`. Measured on `origin/main` `f1c27f037`
+with `dataSource = { label: "Evaluated Title" }`:
+
+| node | rendered card header |
+|---|---|
+| `{ "type": "card", "title": "Customer Summary" }` | `Customer Summary` |
+| `{ "type": "card", "props": { "title": "Customer Summary" } }` | *no header element at all* |
+| `{ "type": "card", "properties": { "title": "Customer Summary" } }` | `Customer Summary` |
+| `{ "type": "card", "title": "${data.label}" }` | `${data.label}` — read, never evaluated |
+| `{ "type": "card", "properties": { "title": "${data.label}" } }` | `Evaluated Title` |
+
+The `element:*` namespace is where `props` is *also* read: those components take
+their config from `properties` / `props` by design (`readProps` in
 `packages/components/src/renderers/basic/elements.tsx`), so
-`{ "type": "element:text", "properties": { "content": "Hi" } }` is correct and
-the same keys on the node would be ignored. Match the envelope to the
-namespace; do not apply either shape everywhere.
+`{ "type": "element:text", "properties": { "content": "Hi" } }` is correct there.
+
+**What to write.** Keep keys on the node and let the host resolve values before
+it hands the schema to `SchemaRenderer` — that is the supported route and the
+one this skill teaches. The last row above is real and is the only spelling that
+carries an expression into a key a `ui:*` / `page:*` renderer reads, but whether
+`properties` is an official authoring channel for those namespaces is an open
+contract question (objectui#4795), so it is recorded here rather than
+recommended. What is *not* open: a `${...}` on the node is never evaluated, and a
+key under `props` never reaches a `ui:*` / `page:*` renderer at all.
 
 ## Rule: No Schema Property Invention
 
@@ -135,6 +160,25 @@ The `bind` field is NOT expression-evaluated. It's a path string resolved by `us
 **Nested paths work:** `"bind": "app.settings.users"` resolves `dataSource.app.settings.users`.
 
 **Readers only.** `list` and `tree-view` (`@object-ui/components`) and the `object-*` plugin widgets call `useDataScope`. `data-table` does NOT: it reads its rows from an inline `data` array on the node, so a `bind` on it is ignored and the table renders its header over an empty body — no error, no warning.
+
+**Provider rows into a `data-table`.** Measured on `origin/main` `f1c27f037`,
+real `SchemaRenderer` inside a `SchemaRendererProvider` holding
+`{ customers: [ 2 records ] }`, identical `columns` in every leg, reading
+`tbody td`:
+
+| node | rendered body cells |
+|---|---|
+| `{ "type": "data-table", "data": "${data.customers}", "columns": [...] }` | `No results found` |
+| `{ "type": "data-table", "props": { "data": "${data.customers}" }, ... }` | `No results found` |
+| `{ "type": "data-table", "properties": { "data": "${data.customers}" }, ... }` | the two rows |
+| `{ "type": "data-table", "data": [ 2 literal records ], ... }` | the two rows |
+
+Both failing legs fail the same way this file keeps warning about: a correct
+header over the empty state, nothing thrown, nothing logged. **Do not read that
+empty table as "the provider has no data."** The route this skill teaches is the
+last row — the host resolves the array and puts it on the node — for the reason
+given under "Rule: Keys Live on the Node": the third row works today, but its
+channel is objectui#4795's open question, not a taught surface.
 
 ## Rule: Action Event Structure
 


### PR DESCRIPTION
Fixes #5372

The published rules told authors that the `properties` / `props` envelope belonged to the `element:*` namespace and that every other key "lives on the node". Measured against the real renderer, only half of that is true — and the wrong half is the half an author hits when wiring provider data into a `data-table`. The guides now record the measurement instead of contradicting it.

⛔ **Draft on purpose, and it should stay one.** The seat dispatched this as a governed surface: human merge only, no ready flip, no auto-merge, no queue. See the one conflict note at the bottom before acting on that.

## Re-measured first — the card's claim is a runtime statement, and the tip had moved

The card was filed against `99d8721a3`; triage annotated it at 2026-08-21T10:33Z. Re-measured on **`origin/main` `f1c27f037`**, real `SchemaRenderer` inside a `SchemaRendererProvider` holding `{ customers: [ 2 records ] }`, identical `columns` in every leg, reading `tbody td`:

| leg | node | rendered body cells |
|---|---|---|
| A | `{ "type": "data-table", "data": "${data.customers}", "columns": [...] }` | `["No results foundTry adjusting your filters or search query."]` |
| B | `{ "type": "data-table", "properties": { "data": "${data.customers}" }, ... }` | `["Ada Lovelace","ada@example.com","Grace Hopper","grace@example.com"]` |
| C | `{ "type": "data-table", "props": { "data": "${data.customers}" }, ... }` | `["No results foundTry adjusting your filters or search query."]` |
| D | `{ "type": "data-table", "data": [ 2 literal records ], ... }` | `["Ada Lovelace","ada@example.com","Grace Hopper","grace@example.com"]` |
| F | `{ "type": "data-table", "bind": "customers", ... }` | `["No results foundTry adjusting your filters or search query."]` |

**The card's claim holds on the current tip, unchanged.** Exactly one of the three spellings reaches the provider's data, and it is the one the rules told authors not to reach for.

## What the measurement actually shows — the rule was wrong about the namespace, not just about `data-table`

The card explains the `data-table` case. Probing a `ui:*` `card` shows the same mechanism is not namespace-scoped, which is what makes the published sentence false rather than merely incomplete (same tip, `dataSource = { label: "Evaluated Title" }`):

| node | rendered card header |
|---|---|
| `{ "type": "card", "title": "Customer Summary" }` | `Customer Summary` |
| `{ "type": "card", "props": { "title": "Customer Summary" } }` | **no header element at all** |
| `{ "type": "card", "properties": { "title": "Customer Summary" } }` | `Customer Summary` |
| `{ "type": "card", "title": "${data.label}" }` | `${data.label}` — read, never evaluated |
| `{ "type": "card", "properties": { "title": "${data.label}" } }` | `Evaluated Title` |

So there are two envelopes with two different fates, and the rules had merged them into one:

- `props.*` — evaluated, then spread as **React props**. A `ui:*` / `page:*` renderer reads `schema.*` and never sees it. `element:*`'s `readProps()` does. The old rule is right about this one.
- `properties.*` — the spec spelling; evaluated, then **hoisted onto the node** by the COMPAT hoist (`type` / `id` excepted), so it lands where *every* renderer reads, in every namespace. The old rule was wrong about this one.
- a node key — read, but never expression-evaluated.

## Recorded, not recommended — and why that line is where it is

The taught route is unchanged: keys on the node, values resolved in the host before the schema reaches `SchemaRenderer`. Whether `properties` is an official `ui:*` authoring channel is **#4795's open sub-question ②**, still awaiting the maintainer's one-liner (comment 5328302083: *"Still awaiting the maintainer's one-liner on the two parked sub-questions: ② whether the diagnostic copy names the `properties` channel"*). Promoting it to a taught spelling here would settle that from a guide edit, so the guides state the measurement and name the open question instead.

What is **not** open, and is now stated plainly: a `${...}` on the node is never evaluated, a key under `props` never reaches a `ui:*` / `page:*` renderer, and neither failure says anything about whether the provider has data.

## ⛔ Out of scope, and neither was prepared for

- **Node-level evaluation is not widened.** No renderer, no `SchemaRenderer`, no types file is touched — the diff contains zero package `src/` changes outside one new test.
- **`data-table` does not gain a `bind` read** — declined by the #5125 ruling for its sibling renderer. `#5125 remains open on its own terms` and is not addressed here.

## Swept by claim, not by phrase — two sites had none of the searchable tokens

Grepping for the envelope wording finds `protocol.md`, `page-builder.md` and `schema-expressions.md`. Sweeping for the *claim* found two more that a phrase grep misses, both prescribing the workaround #4786 retired from the prose:

1. **`SKILL.md:138`** and its twin **`page-builder.md:481`** — a Common Mistakes bullet reading *"Putting expression values in top-level `value` / `label` fields instead of `props.*`."* It names the envelope as the **fix**. `page-builder.md` therefore contradicted itself: line 188 of the same file already said "Moving it under `props` does not help." Measured false above — `props.title` renders no header at all.
2. **`skills/objectui/evals/schema-expressions.json`** — the *graded* form of the same false rule, and the one with no prose tokens at all. Evals 1 and 2 listed `props.value` / `props.label` in `must_contain`, so an assistant answering with the spelling that renders blank was scored **correct**, and one answering correctly was scored wrong. Both now require the working answer and list the dead spelling under `must_not_contain`.

Fixing (2) is the in-place bounded exemption, declared: same defect class as this card, mechanical with the correct shape already pinned by the sibling prose and the 2026-08-17 ruling ("Direction 2 permanently rejected"; working channels are `content` or host pre-resolution), no other claim on the file (no open PR touches `skills/`, no open issue names the evals), and the same gate family. Full file surface: `skills/objectui/{SKILL.md, rules/protocol.md, guides/page-builder.md, guides/schema-expressions.md, guides/data-integration.md, evals/schema-expressions.json}` plus one new test and one changeset.

## Published-skill net-addition budget

Preference honoured: the false teaching is **replaced in place**, not appended to. `SKILL.md` is +0 — a same-length swap.

| file | before → after (lines) | delta |
|---|---|---|
| `skills/objectui/SKILL.md` | 155 → 155 | **+0** |
| `skills/objectui/rules/protocol.md` | 231 → 275 | +44 |
| `skills/objectui/guides/schema-expressions.md` | 612 → 621 | +9 |
| `skills/objectui/guides/page-builder.md` | 502 → 510 | +8 |
| `skills/objectui/guides/data-integration.md` | 430 → 437 | +7 |
| `skills/objectui/evals/schema-expressions.json` | 51 → 53 | +2 |
| **whole package, published `.md`** | **5608 → 5676** | **+68 (+1.2%)** |
| whole `skills/` tree incl. eval JSON | 6216 → 6286 | +70 |

The +44 is concentrated in the one file whose central rule was false, and is mostly two measured tables standing in for prose that was wrong. The other four sites are pointers into it rather than restatements, which is what keeps the package delta at +1.2%. No sibling gate defines a token count for `skills/` (`scripts/` carries only `check-skills-paths.mjs` and its baseline), so lines are the reading.

## The pin

`packages/components/src/__tests__/skill-guide-provider-envelope.test.tsx` renders all five legs through the **real** `SchemaRenderer` and guards the class, in the same three-part shape as its sibling `skill-guide-data-table-binding.test.tsx`:

- **counter-probe** — the rules file is readable and still carries a known-present term, so the "the retired sentence is gone" assertions below it are readings rather than vacuous passes; the eval sweep counts graded assertions and fails on zero.
- **doc-sameness** — lifted from the real published bytes at run time, so re-introducing the claim fails here.
- **behaviour** — the corrected teaching is verified against the renderer, not against a reading of it.
- **class guard** — no published guide may prescribe the envelope (`instead of \`props.\``), and **no published eval may require a `props.*` spelling in a correct answer**.

## Verification — all at the final commit `2c03db447`

```
check:skills-paths   ✅  check-skills-paths: OK (95/96 stated path(s) resolve across 18 guide file(s); 1 baselined).
check:control-bytes  ✅  check-control-bytes: OK (scanned 4690 tracked text file(s); skipped 85 binary).
docs:check-links     Links are valid across 13 scan roots.
check:doc-types      ✅  Every documented component type is registered.
changeset:check      ✅  All workspace packages are in the changeset fixed group.
                     ✅  No changeset declares a `major` bump.
quick-reference      ✅  QUICK_REFERENCE.md's "Current Release" block already states every anchor.
```

Changeset gate, quoted rather than assumed — it rules that none is owed, and an explicit empty-frontmatter declaration is added anyway (objectui's first-class "publishes nothing" form; this repo has no `skip-changeset` label):

```
Compared the working tree with f1c27f037 (merge-base with origin/main): 6 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
1 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

Build, type-check and tests, exit codes captured before any pipe:

```
BUILD_EXIT=0       pnpm --workspace-concurrency=2 --filter '@object-ui/components^...' build
TYPECHECK_EXIT=0   > @object-ui/components@17.6.0 type-check
                   > tsc --noEmit && tsc -p tsconfig.test.json
TEST_EXIT=0        Test Files  2 passed (2)
                   Tests  29 passed (29)
```

The type-check line is quoted because a `pnpm --filter` that matches no script exits 0 having run nothing; the echoed script name shows this one really ran (objectui spells it `type-check`, hyphenated).

**Reverse verification.** Both retired sites were re-introduced on the committed tree and the mutation was confirmed *on disk* by anchored greps before the run — `instead of \`props.*\`` present (1), `renders nothing at all` absent (0), and eval 1's `must_contain` re-parsed from JSON as `['props.value', 'props.label', '${data.']`. Predicted direction was **red on exactly the two class-guard cases**, and that is what happened:

```
× no guide tells an author to move an expression "instead of" onto `props`
× no published eval REQUIRES a `props.*` spelling in a correct answer
Tests  2 failed | 12 passed (14)
```

The mutation script carried a `trap … EXIT INT TERM` restore; the restore leg is proven by `git status --porcelain` returning empty, i.e. byte-identical to the commit that ran 29/29 green. No rebuild leg is claimed because none applies here: the pin reads the guides through `fs.readFileSync` on source paths, and the renderer legs resolve through vitest's workspace `alias` map to `packages/*/src`, never `dist`.

**Lint — a measured narrowing, not a skipped run.** ESLint's own config is the population: it refuses `skills/` outright ("all of the files matching the glob pattern `skills/` are ignored") and reports markdown as "File ignored because no matching configuration was supplied", with `files: ['**/*.{ts,tsx}']` as its only source glob. So exactly one of the eight changed files is in its population, and `--format json` reports `files eslint linted: 1 | errors: 0 | warnings: 0`. `grep -c 'projectService\|project:' eslint.config.js` is **0** — no type-aware linting is configured, so nothing in this diff can move a verdict on a file it does not touch. CI runs the farm regardless.

`check:doc-snippets` is not quoted: it exits 1 as a broken gauge until the workspace is built, and its scan surface does not include `skills/` (#5465).

## One conflict to relay, not to act on

The dispatch flagged `skills/**` as a governed surface. `AGENTS.md` §受管面 says the opposite in as many words: `.claude/skills/**` is governed, while **`skills/**` at the repo root — the published tree, e.g. `skills/objectui/` — is explicitly *not*, and it warns that misjudging conservatively is still misjudging, because it leaves work parked. This PR is left as a draft either way, because a draft is where a dev seat's PR ends. Flagging it so the seat can reconcile the two before this sits waiting for a merge nobody is obliged to perform.

## Out-of-scope finding

- **#5640** — `SKILL.md:81` still teaches `cols: { sm: … }` for layout responsiveness, the spelling `rules/protocol.md:252` and `guides/mobile.md:100` both retire citing #4001. Different defect class (layout key, already ruled), so filed unassigned rather than ridden in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_