### PR TITLE
docs(i18n,plugin-dashboard): state the single-locale write rule instead of deferring to a closed card

### DIFF
--- a/.changeset/stale-4163-pointers-5591.md
+++ b/.changeset/stale-4163-pointers-5591.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/i18n': patch
+---
+
+`setLocalized`'s published docblock states the single-locale write rule that is
+actually in force, instead of deferring the multi-locale-authoring question to a
+closed card (objectui#5591).
+
+The docblock read "is not a multi-locale authoring UI (objectui#4163)". objectui#4163
+closed as completed on 2026-08-15 with that product question still unanswered, so the
+parenthetical pointed at nothing — and it read as though the question had been settled
+somewhere a reader could go and check. This is the failure mode objectui#5428
+demonstrated is not harmless: there, a dangling deferral of exactly this shape let an
+expired justification sit unread for a release cycle at two surfaces.
+
+The remedy is objectui#5428's, not a re-pointing at a successor card: state the rule in
+force (`setLocalized` reaches only the entry for the locale the author is in), keep the
+open product question open **in place**, and record why there is deliberately no tracker
+reference — so the next reader cannot restore one. Re-pointing is how the class
+regenerates, because the next card closes too. The same wording form already landed in
+`plugin-designer`'s `writeWidgetTitle` and `DashboardWidgetInspector`.
+
+Prose only. No behaviour, no signature, no test changes — `setLocalized`'s pairing with
+`pickLocalized` is unchanged and still pinned by `src/__tests__/setLocalized.test.ts`.
+
+Declared as a `patch` for `@object-ui/i18n` alone because the emit was measured per
+package rather than assumed, and the two packages this change touches differ:
+
+- `@object-ui/i18n` — the docblock sits on the **exported** `setLocalized`, so it reaches
+  the published artifacts. Rebuilt with `tsconfig.tsbuildinfo` cleared first (the build is
+  `composite`, which otherwise skips emit), and compared by SHA-256 rather than byte count:
+  `dist/pickLocalized.d.ts` `1e2170ad…` -> `124a1c07…` and `dist/pickLocalized.js`
+  `06eb88bd…` -> `568cb703…`. A consumer reads this text on hover and in the API docs, so
+  it publishes something.
+- `@object-ui/plugin-dashboard` — the two comments changed there are a `//` banner between
+  declarations and a test docblock, neither attached to an exported declaration.
+  `dist/WidgetConfigPanel.d.ts` is **byte-identical** across the rebuild
+  (`93252e8cdf5a6faa…` both sides). The only artifact that moved is
+  `dist/WidgetConfigPanel.d.ts.map`, whose mappings shift because lines were added above
+  the declarations; no declaration text changed. Nothing user-visible publishes from that
+  package, so it is not named here.

--- a/packages/i18n/src/pickLocalized.ts
+++ b/packages/i18n/src/pickLocalized.ts
@@ -129,8 +129,15 @@ function localeWriteKey(
  * the "saved" string vanishes — which is why they live in one file.
  *
  * ⚠️ This is the minimal non-destructive write for a SINGLE-locale editor. It
- * is not a multi-locale authoring UI (objectui#4163) and does not pretend to
- * be: an author can only ever reach the entry for the locale they are in.
+ * is not a multi-locale authoring UI and does not pretend to be: an author can
+ * only ever reach the entry for the locale they are in.
+ *
+ * Authoring every locale from one surface remains an OPEN product question, and
+ * is deliberately not deferred to a tracker here: the deferral this replaced
+ * named objectui#4163, which closed as completed on 2026-08-15 with the question
+ * still unanswered. A comment pointing at a closed card reads as though the
+ * question were settled somewhere, which is how the previous stale premise in
+ * this area survived unread.
  */
 export function setLocalized(
   value: unknown,

--- a/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
+++ b/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
@@ -514,8 +514,11 @@ export interface WidgetConfigPanelProps {
 //   WRITE `setLocalized(stored, language, edited)` — replace ONLY the active
 //         locale's entry and carry every other locale across untouched.
 //
-// A full multi-locale editor (authoring every locale in the panel) is
-// objectui#4163's territory, not this one.
+// A full multi-locale editor — authoring every locale from this panel — is NOT
+// what this panel offers; it edits the active locale only. That remains an OPEN
+// product question and is deliberately not deferred to a tracker here: the
+// deferral this replaced named objectui#4163, which closed as completed on
+// 2026-08-15 with the question still unanswered.
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.inlineLocaleMap.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.inlineLocaleMap.test.tsx
@@ -40,8 +40,11 @@
  *   a different guarantee (a rebuild would add an entry for the active locale
  *   to a map that never carried one).
  *
- * A full multi-locale editor is objectui#4163's territory and is deliberately
- * NOT asserted here.
+ * A full multi-locale editor is deliberately NOT asserted here — this suite pins
+ * the single-locale write rule above and nothing wider. Authoring every locale
+ * from one panel remains an OPEN product question, not deferred to a tracker
+ * here: the deferral this replaced named objectui#4163, which closed as
+ * completed on 2026-08-15 with the question still unanswered.
  */
 
 import * as React from 'react';


### PR DESCRIPTION
Fixes #5591

Three comments deferred the multi-locale-authoring product question to
objectui#4163. That card is closed (completed, 2026-08-15) with the product
question still unanswered, so each deferral pointed at nothing — while reading
as though the question had been settled somewhere a reader could go and check.

## Premise re-derived by code on `origin/main`

Both cited sites were verified at the line numbers the card gives, on
`f1c27f037` (merge-base):

| Site | Card says | Found |
|---|---|---|
| `packages/i18n/src/pickLocalized.ts` | :132 | :132, verbatim |
| `packages/plugin-dashboard/src/WidgetConfigPanel.tsx` | :518 | :518, verbatim |
| `packages/components/src/renderers/basic/record-picker.tsx` | swept by #5590 | `grep -c '4163'` = **0**, confirmed |

## The class sweep found a third site the card did not name

Grepping `4163` alone under-reports — the #5590 precedent. Sweeping for the
*claim* (`multi-locale`, `authoring UI`, `territory`, `deferred`, `tracked in`,
`pending`, `part 2`, …) as well as the number turned up:

- `packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.inlineLocaleMap.test.tsx:43`
  — "A full multi-locale editor is objectui#4163's territory and is deliberately
  NOT asserted here." This is the pin test for the *same* panel's *same*
  deliberate non-behaviour, carrying the identical forward-looking claim.

It is included deliberately, and named here rather than fixed quietly. Leaving
it would have shipped a PR whose source comment states the rule in force while
its own pin test one file away still defers to a closed card — the exact drift
that regenerates this class. It is the same defect class, a mechanical prose
fix whose correct form is already pinned by the landed precedents, in a file no
other in-flight claim holds (checked against the three sibling worktrees), and
in the same gate family with no new verification surface.

Within the two cited files themselves, the sweep found **no** further same-class
site: the other issue references there (`#3907`, `objectstack#6765`, `#4748`,
`objectstack#5010`, `objectstack#7129`, `#5301`, `objectstack#5055`, `#4032`)
are all historical attribution, and `WidgetConfigPanel.tsx:487`'s "reserved for
future UX" is a different claim that names no card.

## Remedy — #5428's, not a re-pointing

⛔ No successor card is referenced, because re-pointing is how this class
regenerates: the next card closes too and the pointer dangles again. Each site
now states the rule actually in force (`setLocalized` reaches only the entry for
the locale the author is in), keeps the open product question open **in place**,
and records why there is deliberately no tracker reference — so the next reader
cannot restore one. This matches the wording form already landed in
`plugin-designer`'s `writeWidgetTitle` and in `DashboardWidgetInspector`.

**Historical attribution is untouched**, per the card's own discrimination and
the #4319 precedent: citing a closed card for work it actually did is correct,
and a merged historical fact cannot invert the way a live pointer does. The
retained "the deferral this replaced named objectui#4163" clauses are themselves
historical — they convert a live pointer into a record of why no pointer is
there.

## Changeset — the `dist/*.d.ts` criterion, measured per package

This is a prose-only change, so the question is whether the comment reaches a
published `.d.ts`. Measured at the **real `dist/` path for each package**, not
generalised — and the two packages genuinely differ. Compared by **SHA-256**,
not byte count, with `packages/i18n/tsconfig.tsbuildinfo` deleted before the
rebuild because that build is `composite` and would otherwise skip emit.

**`@object-ui/i18n` — the published artifacts DO move.** The docblock sits on
the **exported** `setLocalized`, so `tsc` carries it into both emitted files:

```
dist/pickLocalized.d.ts   1e2170ad…  ->  124a1c07…
dist/pickLocalized.js     06eb88bd…  ->  568cb703…
```

**`@object-ui/plugin-dashboard` — the published `.d.ts` does NOT move.** Its two
comments are a `//` banner between declarations and a test docblock, neither
attached to an exported declaration; the vite/`vite-plugin-dts` build strips
them (`grep -rc '4163' dist/` = 0 matches, and `multi-locale` likewise):

```
dist/WidgetConfigPanel.d.ts       93252e8cdf5a6faa…  ->  93252e8cdf5a6faa…  (identical)
dist/WidgetConfigPanel.d.ts.map   b24aea04…          ->  91fea81d…          (line offsets only)
```

The only artifact that moved there is the declaration **source map**, whose
mappings shift because lines were added above the declarations — no declaration
text changed. So the changeset names `@object-ui/i18n` as `patch` and does not
name `plugin-dashboard`.

Two incidental corrections to the dispatch's framing, both measured rather than
assumed: `plugin-dashboard` is **not** ESM-only — it publishes
`dist/index.umd.cjs` under `exports['.'].require` (there is indeed no
`index.cjs`, which is presumably what the note meant); and its `tsbuildinfo`
does not live inside `dist/` — `i18n`'s sits at `packages/i18n/tsconfig.tsbuildinfo`,
and `plugin-dashboard` has none at all, since it builds with vite.

The gate decides, and its verdict line:

```
✅  3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s): .changeset/stale-4163-pointers-5591.md.
```

## Verification — all at `049806cab`, the final commit

| Check | Verdict |
|---|---|
| `vitest run packages/i18n packages/plugin-dashboard` (repo root, `--maxWorkers=2`) | `Test Files 124 passed (124)` · `Tests 1548 passed (1548)` |
| `type-check` (both packages) | `packages/i18n type-check: Done` · `packages/plugin-dashboard type-check: Done` |
| `check-changeset-presence` | `✅  … declares 1 changeset(s)` |
| `check-changeset-no-major` | ``✅  No changeset declares a `major` bump.`` |
| `check-changeset-fixed` | `✅  All workspace packages are in the changeset fixed group.` |
| `check-control-bytes` | `✅  check-control-bytes: OK (scanned 4691 tracked text file(s); skipped 85 binary).` |
| `check-published-dist-tooling` | `✅  No published package's build output carries tooling material.` |
| `check-package-self-import` | `✅  No package names itself inside its own src/.` |
| `check-phantom-dependencies` | `✅  Every in-scope import is declared by the package that publishes it.` |
| `check-i18n-call-site-keys` | `Every in-scope call-site key resolves against the en pack (2918 keys)…` |
| `check-i18n-en-drift` | `No en value changed in this range.` |

Tests were run from the **repo root** (package-cwd `vitest` is refused,
objectui#3378), and the dependency closure was built first so the `type-check`
verdict is a real one. Both pin suites are in the matched set — `vitest list`
enumerates 124 files including `setLocalized.test.ts`, `pickLocalized.test.ts`
and `WidgetConfigPanel.inlineLocaleMap.test.tsx` — so the run is not a
zero-match silent pass; likewise both `type-check` scripts are echoed in the
build log.

**Declared narrowing:** repo-wide `pnpm lint` (turbo, 47 projects) was not run
locally — CI runs the farm exactly once regardless. In its place, `eslint
--no-inline-config --format json` was run on the three changed files: **3 files
linted, 0 errors, 27 warnings**, every warning a pre-existing
`no-explicit-any` / `react-refresh/only-export-components` on lines this diff
does not touch. The narrowing excludes nothing, because `eslint.config.js`
configures **no type-aware linting** (no `projectService`, no
`parserOptions.project`) — lint verdicts are per-file and syntactic, so a
comment-only diff cannot move any untouched file's result.

**Known-broken gauges, noted not fixed:** `check-eager-closure-budget` (exits 2)
and `check-doc-snippet-types` (exits 1) are broken independently of this change;
a comment-only diff cannot affect either, and neither was run.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_