### PR TITLE
refactor(app-shell): one `isAiStudioEnabled()` accessor for `features.aiStudio`, replacing two inline spellings

### DIFF
--- a/.changeset/ai-studio-accessor-5577.md
+++ b/.changeset/ai-studio-accessor-5577.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`features.aiStudio` is now read through one `isAiStudioEnabled()` accessor instead
+of being spelled inline at two call sites (objectui#5577).
+
+`features.marketplace` already had a documented accessor whose docblock is where the
+fail-open doctrine is written down — *"Fails OPEN (`!== false`): a runtime predating
+`/api/v1/runtime/config`, or one whose config fetch failed, keeps the default `true`"*,
+plus the "never infer this from the shape of a failure" warning. `features.aiStudio`
+had no such sibling: `ChatDock` read `getRuntimeConfig().features.aiStudio !== false`
+and `HomePage` read `getRuntimeConfig().features?.aiStudio !== false`, so one doctrine
+had two spellings and neither reader could cite it.
+
+The two spellings were not equivalent. `ChatDock`'s omitted the optional chain, and
+against a runtime-config snapshot whose `features` is absent that read is a TypeError
+rather than a fail-open — the exact shape that crashed 29 tests across four suites in
+PR #5575 before it was corrected. Measured here: no live path can currently deliver
+such a snapshot to `ChatDock` (the module's singleton constructs `features` on every
+write and exports no setter, and no suite mounts the dock's default body under a
+partial stand-in), so this closes a reachable-by-construction crash rather than a live
+one — and it closes it at the source by leaving no inline read to get wrong.
+
+`isAiStudioEnabled()` is an internal module export, matching `isMarketplaceEnabled()`:
+neither is re-exported from `src/index.ts`, so the package's published `exports` surface
+is unchanged.

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -39,7 +39,7 @@ import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText, Hammer, Layou
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata.js';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts.js';
 import { resolveAiApiBase } from '../../hooks/useAiSurface.js';
-import { getRuntimeConfig, isMarketplaceEnabled } from '../../runtime-config.js';
+import { isAiStudioEnabled, isMarketplaceEnabled } from '../../runtime-config.js';
 
 /**
  * Which AI home CTAs to surface, driven by the live agent catalog (the single
@@ -386,19 +386,12 @@ export function HomePage() {
   // hosted-SaaS shape it arrives `false` while the ToolRegistry holds zero
   // authoring handlers and `/api/v1/meta/*` answers 403.
   //
-  // Read inline rather than through a new accessor, so this card adds no
-  // export; lifting this and `ChatDock`'s identical read onto an
-  // `isAiStudioEnabled()` sibling of `isMarketplaceEnabled()` is filed as a
-  // follow-up rather than done here, where it would mean editing four
-  // neighbouring suites' module mocks.
-  //
-  // `features?.` and `!== false` are both load-bearing and are copied from
-  // `isMarketplaceEnabled()`'s body rather than invented: hosts (and four
-  // sibling suites) supply a runtime-config snapshot carrying only `branding`,
-  // so `features` is genuinely absent on real code paths — and an absent flag
-  // must fail OPEN. Withholding the product's front door over an unanswered
-  // question is the worse direction; the server refuses the write regardless.
-  const aiStudioEnabled = getRuntimeConfig().features?.aiStudio !== false;
+  // objectui#5577 — read through the accessor, not inline. `features?.` and
+  // `!== false` are both load-bearing, and the reasoning for each now lives in
+  // exactly one place (`isAiStudioEnabled()`'s docblock) instead of being
+  // retyped per call site: that is what the accessor buys. `ChatDock`'s read
+  // was the same doctrine spelled a second, un-chained way.
+  const aiStudioEnabled = isAiStudioEnabled();
   // Shown wherever an authoring entry point is withheld, so the posture is
   // explained on screen instead of surfacing as a refusal after a filled-in
   // dialog. Localized in all ten packs.

--- a/packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx
@@ -107,6 +107,14 @@ vi.mock('../../../runtime-config', () => ({
   // the gate itself is covered by `HomePage.marketplaceDisabled.test.tsx`,
   // which drives the REAL module instead of this stand-in.
   isMarketplaceEnabled: () => true,
+  // objectui#5577 — same treatment for the AI-authoring gate, which Home now
+  // reads through `isAiStudioEnabled()` rather than inline. An explicit factory
+  // replaces the WHOLE module, so an export it does not list is `undefined` at
+  // the call site — i.e. omitting this line is a TypeError here, not a default.
+  // `true` keeps every case in this file on the pre-existing behaviour; the gate
+  // itself is covered by `HomePage.aiStudioDisabled.test.tsx`, which drives the
+  // REAL module instead of this stand-in.
+  isAiStudioEnabled: () => true,
 }));
 
 import { HomePage } from '../HomePage';

--- a/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
@@ -115,6 +115,14 @@ vi.mock('../../../runtime-config', () => ({
   // the gate itself is covered by `HomePage.marketplaceDisabled.test.tsx`,
   // which drives the REAL module instead of this stand-in.
   isMarketplaceEnabled: () => true,
+  // objectui#5577 — same treatment for the AI-authoring gate, which Home now
+  // reads through `isAiStudioEnabled()` rather than inline. An explicit factory
+  // replaces the WHOLE module, so an export it does not list is `undefined` at
+  // the call site — i.e. omitting this line is a TypeError here, not a default.
+  // `true` keeps every case in this file on the pre-existing behaviour; the gate
+  // itself is covered by `HomePage.aiStudioDisabled.test.tsx`, which drives the
+  // REAL module instead of this stand-in.
+  isAiStudioEnabled: () => true,
 }));
 
 import { HomePage } from '../HomePage';

--- a/packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx
@@ -109,6 +109,14 @@ vi.mock('../../../runtime-config', () => ({
   // the gate itself is covered by `HomePage.marketplaceDisabled.test.tsx`,
   // which drives the REAL module instead of this stand-in.
   isMarketplaceEnabled: () => true,
+  // objectui#5577 — same treatment for the AI-authoring gate, which Home now
+  // reads through `isAiStudioEnabled()` rather than inline. An explicit factory
+  // replaces the WHOLE module, so an export it does not list is `undefined` at
+  // the call site — i.e. omitting this line is a TypeError here, not a default.
+  // `true` keeps every case in this file on the pre-existing behaviour; the gate
+  // itself is covered by `HomePage.aiStudioDisabled.test.tsx`, which drives the
+  // REAL module instead of this stand-in.
+  isAiStudioEnabled: () => true,
 }));
 
 import { HomePage } from '../HomePage';

--- a/packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx
@@ -105,6 +105,14 @@ vi.mock('../../../runtime-config', () => ({
   // the gate itself is covered by `HomePage.marketplaceDisabled.test.tsx`,
   // which drives the REAL module instead of this stand-in.
   isMarketplaceEnabled: () => true,
+  // objectui#5577 — same treatment for the AI-authoring gate, which Home now
+  // reads through `isAiStudioEnabled()` rather than inline. An explicit factory
+  // replaces the WHOLE module, so an export it does not list is `undefined` at
+  // the call site — i.e. omitting this line is a TypeError here, not a default.
+  // `true` keeps every case in this file on the pre-existing behaviour; the gate
+  // itself is covered by `HomePage.aiStudioDisabled.test.tsx`, which drives the
+  // REAL module instead of this stand-in.
+  isAiStudioEnabled: () => true,
 }));
 
 import { HomePage } from '../HomePage';

--- a/packages/app-shell/src/layout/ChatDock.tsx
+++ b/packages/app-shell/src/layout/ChatDock.tsx
@@ -34,7 +34,7 @@ import { AiUsageIndicator } from './AiUsageIndicator.js';
 import { useChatConversation } from '../hooks/index.js';
 import { chatConversationScope, chatProductOfAgent } from '../hooks/chatScope.js';
 import { resolveSurfaceAgent } from '../hooks/surfaceAgent.js';
-import { getRuntimeConfig } from '../runtime-config.js';
+import { isAiStudioEnabled } from '../runtime-config.js';
 import {
   clampDockWidth,
   maximizedDockWidth,
@@ -260,7 +260,7 @@ function ChatDockConversation({
       resolveSurfaceAgent('default', {
         agents,
         appDefaultAgent: defaultAgent,
-        aiStudioEnabled: getRuntimeConfig().features.aiStudio !== false,
+        aiStudioEnabled: isAiStudioEnabled(),
       }),
     [agents, defaultAgent],
   );

--- a/packages/app-shell/src/layout/__tests__/ChatDock.partialRuntimeConfig.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ChatDock.partialRuntimeConfig.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5577 — the dock's DEFAULT body under a PARTIAL runtime-config
+ * snapshot.
+ *
+ * `ChatDockConversation` (the body `ChatDockPanel` / `ChatDockMobileSheet` mount
+ * when no `children` override is supplied — i.e. what `ConsoleLayout` renders)
+ * feeds the AI-authoring flag into the ONE surface-agent resolver. It used to
+ * read that flag inline and UN-CHAINED — `getRuntimeConfig().features.aiStudio`
+ * — while `HomePage` read the same flag one file away as `features?.aiStudio`.
+ * One doctrine, two spellings, and only the chained one survives a snapshot
+ * whose `features` is absent: PR #5575 measured the un-chained shape crashing 29
+ * tests across 4 suites before it was corrected.
+ *
+ * These cases pin the corrected shape at the dock. The stand-in is deliberately
+ * NARROW: `importOriginal()` keeps the REAL `isAiStudioEnabled()`, and only
+ * `getRuntimeConfig` is replaced — with the exact partial snapshot four sibling
+ * Home suites already install (`() => ({ branding })`). So a regression to any
+ * inline `getRuntimeConfig().features…` read here turns these red, while the
+ * accessor — which reads the module's own always-complete singleton — stays
+ * green. The assertion is on the VALUE the resolver receives, not merely on
+ * "did not throw": a body that silently stopped mounting would satisfy the
+ * weaker claim while measuring nothing.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ChatDockPanel, ChatDockMobileSheet, type ChatDockState } from '../ChatDock';
+import { resolveSurfaceAgent } from '../../hooks/surfaceAgent';
+
+// PARTIAL — `@object-ui/components`' dialog primitive (which the mobile sheet
+// pulls in) calls `createSafeTranslation` at module scope, so a total stand-in
+// here fails the whole file at import time rather than at any assertion.
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@object-ui/i18n')>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+}));
+
+// The partial snapshot under test — `features` genuinely absent, exactly as the
+// four Home suites' stand-in supplies it. Everything else stays REAL, so
+// `isAiStudioEnabled()` here is the shipped accessor, not a stub of it.
+vi.mock('../runtime-config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../runtime-config')>()),
+  getRuntimeConfig: () => ({ branding: { productName: 'ObjectStack' } }),
+}));
+
+// Spy on the resolver so the flag's VALUE at the seam is observable. The dock
+// computes it in a render-phase `useMemo`, which runs before the empty-catalog
+// early return — so an empty catalog still exercises the read.
+vi.mock('../../hooks/surfaceAgent', () => ({
+  resolveSurfaceAgent: vi.fn(() => undefined),
+}));
+
+// The rest of the chat graph is irrelevant to the flag under test.
+vi.mock('../../console/ai/AiChatPage', () => ({
+  ChatPane: () => null,
+  resolveApiBase: (explicit?: string) => explicit ?? '/api/v1/ai',
+}));
+vi.mock('@object-ui/plugin-chatbot', () => ({
+  useAgents: () => ({ agents: [], isLoading: false, error: undefined }),
+}));
+vi.mock('../../hooks', () => ({
+  useChatConversation: () => ({ conversationId: undefined, initialMessages: [] }),
+}));
+vi.mock('../AiUsageIndicator', () => ({ AiUsageIndicator: () => null }));
+
+const resolverMock = vi.mocked(resolveSurfaceAgent);
+
+function dockState(overrides: Partial<ChatDockState> = {}): ChatDockState {
+  return {
+    expanded: true,
+    width: 420,
+    dragging: false,
+    maximized: false,
+    toggle: vi.fn(),
+    expand: vi.fn(),
+    collapse: vi.fn(),
+    maximize: vi.fn(),
+    restore: vi.fn(),
+    onResizePointerDown: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resolverMock.mockClear();
+});
+
+describe('ChatDock default body on a partial runtime-config snapshot (objectui#5577)', () => {
+  it('mounts the desktop rail and fails OPEN when `features` is absent', () => {
+    render(<ChatDockPanel dock={dockState()} />);
+
+    expect(screen.getByTestId('chat-dock-panel')).toBeInTheDocument();
+    expect(resolverMock).toHaveBeenCalled();
+    expect(resolverMock.mock.calls[0][1]).toMatchObject({ aiStudioEnabled: true });
+  });
+
+  it('mounts the mobile sheet and fails OPEN when `features` is absent', () => {
+    render(<ChatDockMobileSheet open onOpenChange={vi.fn()} />);
+
+    expect(resolverMock).toHaveBeenCalled();
+    expect(resolverMock.mock.calls[0][1]).toMatchObject({ aiStudioEnabled: true });
+  });
+
+  it('still passes the flag through the `default` surface, not a bare call', () => {
+    // The dock is the console's ambient assistant; the flag only means anything
+    // paired with the surface the resolver is bounded on.
+    render(<ChatDockPanel dock={dockState()} />);
+
+    expect(resolverMock.mock.calls[0][0]).toBe('default');
+  });
+});

--- a/packages/app-shell/src/layout/__tests__/ChatDock.partialRuntimeConfig.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ChatDock.partialRuntimeConfig.test.tsx
@@ -41,12 +41,19 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
 }));
 
 // The partial snapshot under test — `features` genuinely absent, exactly as the
-// four Home suites' stand-in supplies it. Everything else stays REAL, so
-// `isAiStudioEnabled()` here is the shipped accessor, not a stub of it.
-vi.mock('../runtime-config', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../runtime-config')>()),
-  getRuntimeConfig: () => ({ branding: { productName: 'ObjectStack' } }),
-}));
+// four Home suites' stand-in supplies it. Everything else stays REAL: the spy
+// below DELEGATES to the shipped `isAiStudioEnabled()`, so the value these cases
+// assert is the accessor's own answer and only the call is observed.
+const aiStudioSpy = vi.hoisted(() => vi.fn<() => boolean>());
+vi.mock('../../runtime-config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../runtime-config')>();
+  aiStudioSpy.mockImplementation(actual.isAiStudioEnabled);
+  return {
+    ...actual,
+    getRuntimeConfig: () => ({ branding: { productName: 'ObjectStack' } }),
+    isAiStudioEnabled: aiStudioSpy,
+  };
+});
 
 // Spy on the resolver so the flag's VALUE at the seam is observable. The dock
 // computes it in a render-phase `useMemo`, which runs before the empty-catalog
@@ -88,6 +95,7 @@ function dockState(overrides: Partial<ChatDockState> = {}): ChatDockState {
 
 beforeEach(() => {
   resolverMock.mockClear();
+  aiStudioSpy.mockClear(); // keeps the delegating implementation
 });
 
 describe('ChatDock default body on a partial runtime-config snapshot (objectui#5577)', () => {
@@ -112,5 +120,17 @@ describe('ChatDock default body on a partial runtime-config snapshot (objectui#5
     render(<ChatDockPanel dock={dockState()} />);
 
     expect(resolverMock.mock.calls[0][0]).toBe('default');
+  });
+
+  it('asks the ACCESSOR rather than re-spelling the read inline', () => {
+    // Scoped deliberately tighter than the two cases above. Those pin the
+    // crash-closure and stay green for ANY optional-chained inline read
+    // (measured: reverting this call site to `features?.aiStudio !== false`
+    // leaves them passing) — so on their own they say nothing about where the
+    // doctrine lives. This one fails for every inline spelling, chained or not,
+    // which is the actual subject of objectui#5577: ONE doctrine, ONE spelling.
+    render(<ChatDockPanel dock={dockState()} />);
+
+    expect(aiStudioSpy).toHaveBeenCalled();
   });
 });

--- a/packages/app-shell/src/runtime-config.test.ts
+++ b/packages/app-shell/src/runtime-config.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { initRuntimeConfig, getRuntimeConfig, getPlatformStage, resetRuntimeConfigForTesting } from './runtime-config.js';
+import { initRuntimeConfig, getRuntimeConfig, getPlatformStage, isAiStudioEnabled, isMarketplaceEnabled, resetRuntimeConfigForTesting } from './runtime-config.js';
 
 function mockConfig(features: Record<string, unknown>) {
     vi.stubGlobal('fetch', vi.fn(async () => ({
@@ -67,6 +67,91 @@ function mockBranding(branding: Record<string, unknown>) {
         json: async () => ({ branding }),
     })) as any);
 }
+
+/**
+ * `isAiStudioEnabled()` — the AI-authoring gate's ONE spelling (objectui#5577).
+ *
+ * `features.aiStudio` used to be read inline at two call sites with two
+ * different spellings (`ChatDock` un-chained, `HomePage` optional-chained), and
+ * the fail-open doctrine was written down only on the `marketplace` sibling. The
+ * accessor is where the doctrine now lives, so these cases pin the doctrine
+ * itself rather than either call site's transcription of it:
+ *
+ *  - fails OPEN on every unanswered question (before init, key absent, fetch
+ *    failed) — withholding a working capability on no answer is the worse
+ *    direction, and the server refuses the write regardless;
+ *  - only the literal `false` closes it;
+ *  - the snapshot the accessor reads always carries `features`, which is why an
+ *    absent flag is a DEFAULT here and never a TypeError.
+ */
+describe('runtime-config isAiStudioEnabled (objectui#5577)', () => {
+    it('fails OPEN before init — a runtime that never answered keeps the capability', () => {
+        resetRuntimeConfigForTesting();
+        expect(isAiStudioEnabled()).toBe(true);
+    });
+
+    it('honours an explicit false from the server', async () => {
+        mockConfig({ aiStudio: false });
+        await initRuntimeConfig();
+        expect(isAiStudioEnabled()).toBe(false);
+    });
+
+    it('stays enabled when the server explicitly says true', async () => {
+        mockConfig({ aiStudio: true });
+        await initRuntimeConfig();
+        expect(isAiStudioEnabled()).toBe(true);
+    });
+
+    it('fails OPEN when the runtime omits the aiStudio key entirely', async () => {
+        mockConfig({ marketplace: true }); // no aiStudio key at all
+        await initRuntimeConfig();
+        expect(isAiStudioEnabled()).toBe(true);
+    });
+
+    it('fails OPEN when the config fetch itself fails', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => {
+            throw new Error('network down');
+        }) as any);
+        await initRuntimeConfig();
+        expect(isAiStudioEnabled()).toBe(true);
+    });
+
+    it('closes only on the literal false, never on a falsy look-alike', async () => {
+        // `!== false` is the doctrine, not `=== true`: a runtime that sends a
+        // string or a 0 has not said "disabled", so the capability stays.
+        mockConfig({ aiStudio: 'false' });
+        await initRuntimeConfig();
+        expect(isAiStudioEnabled()).toBe(true);
+    });
+
+    it('agrees with its marketplace sibling on the fail-open direction', () => {
+        // One doctrine, one spelling. If these two ever diverge, the accessor
+        // that changed has left the doctrine its docblock claims to carry.
+        resetRuntimeConfigForTesting();
+        expect(isAiStudioEnabled()).toBe(isMarketplaceEnabled());
+        expect(isAiStudioEnabled()).toBe(true);
+    });
+
+    /**
+     * The reachability leg of objectui#5577: the accessor reads the module's own
+     * singleton, and EVERY writer of that singleton constructs `features` as an
+     * object (the initial `{...defaults}`, `applyUpdate`'s spread, and the test
+     * reset). There is no exported setter, so no caller can install a partial
+     * snapshot through the module's API — which is what makes an absent flag a
+     * default rather than the TypeError the un-chained inline read would have
+     * produced. Driven through the real fetch path, not asserted from the source.
+     */
+    it('never hands out a snapshot missing `features`, whatever the server sends', async () => {
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            json: async () => ({ branding: { productName: 'Acme' } }), // no `features` key
+        })) as any);
+        await initRuntimeConfig();
+        expect(getRuntimeConfig().features).toBeDefined();
+        expect(getRuntimeConfig().branding.productName).toBe('Acme');
+        expect(isAiStudioEnabled()).toBe(true);
+    });
+});
 
 describe('runtime-config platform stage', () => {
     it('defaults to preview before init (badge shows out of the box)', () => {

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -315,6 +315,48 @@ export function isMarketplaceEnabled(): boolean {
   return current.features?.marketplace !== false;
 }
 
+/**
+ * Is AI-driven metadata authoring ("online development") offered by this
+ * runtime? (objectui#5521 / objectui#5577)
+ *
+ * Reads the server's OWN answer — `features.aiStudio`, which the runtime
+ * derives per request from the same resolution that decides whether the
+ * metadata-authoring agent is mounted at all. On the composed hosted-SaaS shape
+ * it arrives `false` while the ToolRegistry holds zero authoring handlers and
+ * `/api/v1/meta/*` answers 403, so the SPA withholds the authoring entry points
+ * instead of offering a front door the backend refuses.
+ *
+ * Distinct from the PER-PRINCIPAL authoring capability (`useCanAuthorMetadata`):
+ * this is the DEPLOYMENT's answer ("is authoring offered here at all"), that one
+ * is the caller's ("may THIS principal author"). Both gates are real and neither
+ * substitutes for the other.
+ *
+ * ⛔ Never infer this from the SHAPE OF A FAILURE. A 403/404 from `/api/v1/meta/*`
+ * is equally what a permission denial — or a control plane that is merely DOWN —
+ * produces, and a page that concludes "authoring is disabled on this runtime"
+ * from it tells an operator their deployment is the problem while the real one is
+ * their credentials or their upstream. The flag is a property of the runtime's
+ * own capability set; a broken upstream leaves it `true` and the failure stays a
+ * failure.
+ *
+ * Fails OPEN (`!== false`): a runtime predating `/api/v1/runtime/config`, or one
+ * whose config fetch failed, keeps the default `true` and the AI authoring
+ * affordances stay exactly as visible as they were before this gate existed.
+ * Withholding a working capability on an unanswered question is the worse
+ * direction — the server refuses the write regardless.
+ *
+ * `features?.` is load-bearing, not decoration. It is why this doctrine belongs
+ * in ONE place instead of being retyped per call site: a caller reached through a
+ * PARTIAL runtime-config snapshot (a host, or a sibling suite standing the module
+ * in as `getRuntimeConfig: () => ({ branding })`) sees `features` genuinely
+ * absent, and reading `.aiStudio` off `undefined` is a TypeError — a crash, not a
+ * fail-open. PR #5575 measured that exact un-chained shape crashing 29 tests
+ * across 4 suites before it was corrected.
+ */
+export function isAiStudioEnabled(): boolean {
+  return current.features?.aiStudio !== false;
+}
+
 /** Test/dev helper. */
 export function resetRuntimeConfigForTesting(): void {
   current = {


### PR DESCRIPTION
Fixes #5577

`features.marketplace` has a documented accessor whose docblock is where the fail-open
doctrine is written down. `features.aiStudio` had none — it was read inline at two call
sites, in two different spellings, and neither reader could cite the doctrine.

- `packages/app-shell/src/layout/ChatDock.tsx:263` — `getRuntimeConfig().features.aiStudio !== false` (un-chained)
- `packages/app-shell/src/console/home/HomePage.tsx:401` — `getRuntimeConfig().features?.aiStudio !== false` (chained)

Both verified on `origin/main` @ `f1c27f037` before any edit; both line numbers as filed.

## What changed

- `isAiStudioEnabled()` in `runtime-config.ts`, directly after `isMarketplaceEnabled()`,
  carrying the same docblock treatment: what the flag means, the "never infer this from
  the shape of a failure" warning, and the fail-open paragraph.
- Both call sites moved onto it. No inline `features.aiStudio` read remains at any call
  site (`grep` for `getRuntimeConfig().features` in either file returns 0).
- The four Home suites' module mocks taught the new export. An explicit factory replaces
  the **whole** module, so an export it does not list is `undefined` at the call site.
- New coverage, plus a changeset.

## The measurement the card left open: can `ChatDock` actually receive a partial snapshot?

**No — not on any path that exists today. This PR is drift-prevention, not a live bug
fix.** Stated plainly because the answer changes what this PR is, and it was measured
rather than assumed in either direction.

**Production: structurally impossible.** The accessor and both call sites read the
module's own singleton. Every writer of it constructs `features` as an object — the
initial `{ ...defaults }`, `applyUpdate`'s `{ ...current.features, ...(patch.features ?? {}) }`,
and `resetRuntimeConfigForTesting()` — and the module exports **no setter**, so no host
can install a partial snapshot through its API. Driven rather than read off the source:
a new case boots `initRuntimeConfig()` against a server body carrying **no `features` key
at all** and asserts the snapshot still has one. There is also no bundler alias pointing
`runtime-config` anywhere else (checked across every `vite.config.*` / `vitest.config.*`).

**Test harness: no suite reaches it.** `ChatDockConversation` — the only holder of that
read — is module-private and mounts **only** when `ChatDockPanel` / `ChatDockMobileSheet`
get no `children` override. Every construction in the repo was enumerated:
`StudioAiCopilot` passes `children` at both call sites; all 20 renders in `ChatDock.test.tsx`
pass `children` (its own header says so); `ConsoleLayout` is the single consumer that does
not — and it gates the dock behind `useAiSurfaceEnabled()` **and** `dock.expanded`. Of the
six suites in the repo that stand `runtime-config` in with a factory, none mounts
`ConsoleLayout`; of the suites that mount `ConsoleLayout`, none mocks `runtime-config`.

**But the crash shape is real, and it is now measured rather than inferred.** Reverting
this call site to the pre-fix un-chained read, with everything else on this branch intact:

```
TypeError: Cannot read properties of undefined (reading 'aiStudio')
Test Files  1 failed (1)   Tests  4 failed (4)
```

So the asymmetry the card describes was one house-idiom mock away from the failure that
crashed 29 tests across four suites in PR #5575 before it was corrected there. This PR
closes it at the source, by leaving no inline read to get wrong.

## Published-surface reachability (clause ②)

**`isAiStudioEnabled()` is NOT reachable from `@object-ui/app-shell`'s `exports` map** —
which is the opposite of what "a sibling next to an existing published accessor" suggests,
so it is worth stating explicitly rather than assuming.

The `exports` map has exactly one code entry, `"."` → `./dist/index.js`. `src/index.ts`
re-exports twelve symbols from `./runtime-config.js` — and `isMarketplaceEnabled` is **not
among them**. The new accessor follows its sibling's posture exactly and is likewise not
added there, so the package's published surface is unchanged. Adding it would have been an
unrequested widening of the published API with no consumer pulling on it.

Measured, not just read: `dist/index.js` and `dist/index.d.ts` are **byte-identical**
(same sha256) before and after — see the table below.

## Changeset

`.changeset/ai-studio-accessor-5577.md`, `patch` (never `major` — fixed group). The
authority's own verdict line:

```
✅  9 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/ai-studio-accessor-5577.md.
```

Both dist legs measured at the real `dist/` path, `tsconfig.tsbuildinfo` cleared between
builds (this package is `composite: true` and keeps it at `packages/app-shell/tsconfig.tsbuildinfo`,
i.e. **outside** `dist/`, so wiping `dist/` alone would not have forced a re-emit).
Compared by **sha256**, not byte count:

| `dist/` path | before | after | bytes |
|---|---|---|---|
| `runtime-config.js` | `702c3da611469d2c` | `7d421f86372a3fee` | 9125 → 11485 |
| `runtime-config.d.ts` | `b63345d08faa9564` | `7b91fb750487d782` | 8351 → 10676 |
| `layout/ChatDock.js` | `32be92e2c26a1490` | `0b06cac3b2f83b07` | 17432 → 17406 |
| `console/home/HomePage.js` | `221950d741935d82` | `ca74007cbdaeab5a` | 30130 → 29661 |
| `index.js` | `56216a9f70bdce5f` | `56216a9f70bdce5f` | **unchanged** |
| `index.d.ts` | `15cceec868260eee` | `15cceec868260eee` | **unchanged** |

Both legs moved at `runtime-config`, and the entry point did not — the new export exists
in the built artifacts but not on the published entry surface.

## Tests

All runs from the **repo root** (package-cwd `vitest` is refused, objectui#3378), at
`e2d01613a`, the final commit.

**Superset, derived not sampled.** `packages/app-shell` has 488 test files and its full
suite exceeds the container's foreground cap. The behavioural surface here is exactly two
expressions, so the suites that can change verdict are those that mount `HomePage`'s gate
or `ChatDock`'s default body. The run covers every Home-surface suite, every suite that
mounts `ConsoleLayout` or imports `ChatDock`, both remaining `runtime-config` stand-ins
(`PreviewBadge`, `provisionEnvironment` — included to show they are *unaffected*, not
assumed to be), the marketplace suites that build the same `features` fixture, the
`surfaceAgent` consumer of the flag, and the `apps/console` + `i18n` + `permissions`
suites that route through Home. **44 files, 384 tests, all passing.**

```
Test Files  44 passed (44)
      Tests  384 passed (384)
```

`pnpm --filter '@object-ui/app-shell' type-check` — clean, 0 errors, after building the
dependency closure first (`--filter '@object-ui/app-shell^...' build`, 29 projects). The
script name is echoed in the log (`> @object-ui/app-shell@17.6.0 type-check`), so this is
not a zero-match `--filter` reporting green having run nothing. Note this package's
`type-check` is `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file is
type-checked too.

**Lint.** `eslint .` over `packages/app-shell` — **0 errors** across the **920 files
eslint selected from its own config** (count read from `--format json`, not estimated).
All 9 changed files appear in that output with `errorCount: 0`. The repo-wide
`turbo run lint` over the other 46 projects is CI's run: no file outside `packages/app-shell`
changed (the changeset gate independently reports "9 source file(s) of 1 released
package(s)"), and this config is `tseslint.configs.recommended` with no `project` /
`projectService` — linting is per-file and not type-aware, so nothing in this diff can move
an untouched file's verdict.

**Gates**, exit codes captured before any pipe: `check-changeset-presence` 0,
`check-changeset-no-major` 0, `check-control-bytes` 0, `check-package-self-import` 0,
`check-phantom-dependencies` 0, `check-i18n-call-site-keys` 0, `check-node-esm-load --specifiers-only` 0.
The two known-broken gauges reproduce their documented failures and name zero files from
this diff: `check-eager-closure-budget` exits **2** ("No eager-closure report at
`apps/console/dist/eager-closure.json` … This is a broken gauge, not a passing budget"),
`check-doc-snippet-types` exits **1** (unbuilt `packages/cli`, `plugin-markdown`,
`plugin-timeline`). Noted, not touched.

### Reverse verification — five legs, each scoped to one claim and each measured

Every mutation asserted its anchor's pristine count first, then confirmed on disk that the
injected text was present **and** the removed text absent, since `str.replace` returns
happily on zero hits. Restores ran from a `trap … EXIT INT TERM`, so a foreground-cap
SIGTERM mid-mutation could not leave a mutated tree for a later measurement. No `dist/`
preflight was owed: the root `vitest.config.mts` aliases workspace packages to `src/`, and
every file under mutation is imported by relative path within `packages/app-shell/src`, so
no built artifact is in the loop for these runs.

| leg | mutation | result |
|---|---|---|
| A | `ChatDock` → pre-fix **un-chained** inline read | **red**, 4/4, `TypeError: … (reading 'aiStudio')` |
| B | `ChatDock` → **chained** inline read | **red**, 1/4 — only the accessor case |
| C | one Home mock **un-taught** the export | **red**, 5/5 in that suite |
| D | accessor `!== false` → `=== true` | **green** — see below |
| E | parser `!== false` → `=== true` | **red**, 2/16 in `runtime-config.test.ts` |

Leg B is why the probe has three cases and not two. The two crash-closure cases stay green
for *any* optional-chained inline read, so on their own they pin the crash and say nothing
about where the doctrine lives — which is the actual subject of this card. The third case
pins the accessor call itself and fails on a chained re-spelling; leg B is the measurement
that it can.

**Leg D is a negative result worth recording rather than hiding.** Mutating the accessor's
own `!== false` to `=== true` leaves all 16 cases green, so no test here distinguishes
them. That is not a gap in the tests — it is a property of the module: `initRuntimeConfig`
already normalises `aiStudio` to a real boolean on every write (`body.features.aiStudio !== false`),
and every other writer seeds it from `defaults`, so `current.features.aiStudio` is never
`undefined` and the two spellings cannot disagree through the module's public API. Leg E
mutates that normalisation instead and goes red, which is what confirms the unit tests can
fail at all. The accessor keeps `!== false` for parity with its sibling and because it
becomes load-bearing the moment either the parser or the snapshot's provenance changes —
but this PR does not claim a test proves it today.

### A correction found by ablating rather than trusting

The first version of the new probe wrote `vi.mock('../runtime-config', …)`. From
`src/layout/__tests__/` that resolves to `src/layout/runtime-config`, which does not exist,
and **vitest no-ops an unresolvable factory mock instead of erroring** — so the partial
snapshot was never installed and the file passed identically against the un-chained pre-fix
read. Leg A caught it: a probe that cannot fail had been sitting green. Corrected to
`'../../runtime-config'` and re-measured; the leg-A row above is from the corrected probe.


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_