### PR TITLE
docs(core): qualify both `evaluateExpression` references in the registerFunction JSDoc

### DIFF
--- a/.changeset/evaluateexpression-jsdoc-links-5580.md
+++ b/.changeset/evaluateexpression-jsdoc-links-5580.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/core': patch
+---
+
+Both `evaluateExpression` references in the `ExpressionEvaluator.registerFunction`
+JSDoc are now qualified, so each resolves to the entity it means (objectui#5580).
+
+`ExpressionEvaluator.ts` declares two things spelled `evaluateExpression`: the method
+on `ExpressionEvaluator` (bare expression, throws) and the module-level export
+(context bag, fail-soft, delegating to `evaluate`). The `registerFunction` block
+referred to both under the one spelling, four lines apart.
+
+The prose link was not merely ambiguous, it was bound wrong. Measured with
+`checker.getSymbolAtLocation` on the pre-fix source, `{@link evaluateExpression}`
+resolved to the module-level `FunctionDeclaration` — the fail-soft one — inside the
+sentence that calls it *"the throwing sibling"*. The neighbouring `{@link evaluate}`
+binds to the method, but only because no module-level `evaluate` exists to outrank
+it, so the rule "an unqualified link resolves to the enclosing class's member" does
+not hold here. The link is now `{@link ExpressionEvaluator.evaluateExpression}`,
+which the checker resolves to the `MethodDeclaration`.
+
+The `@example`'s final line is the module-level export — its second parameter is a
+context bag and the `${...}` wrapper only resolves on the `evaluate` path — but it sat
+two lines below calls that establish `evaluator.` as the receiver, and a `.d.ts` hover
+carries no import to disambiguate. It now names the module-level export and shows the
+import it needs.
+
+This is prose only: the diff is confined to a block comment and no declaration moves.
+It is scored `patch` rather than the empty-frontmatter form because the block is
+emitted into what npm ships — measured, this edit moves both
+`dist/evaluator/ExpressionEvaluator.d.ts` and `dist/evaluator/ExpressionEvaluator.js`
+(this package builds with a bare `tsc`, which preserves comments in the JS emit), and
+the ten changed lines in that JS are all comment lines.
+
+`registerFunction-jsdoc-links.test.ts` pins the binding against the checker rather
+than asserting it in prose, since a `{@link}` that binds to the wrong entity is
+indistinguishable in source from one that binds right.

--- a/packages/core/src/evaluator/ExpressionEvaluator.ts
+++ b/packages/core/src/evaluator/ExpressionEvaluator.ts
@@ -367,8 +367,9 @@ export class ExpressionEvaluator {
    *    object, whose identifiers expressions match case-sensitively.
    * 2. A wrong-case call site does not raise. {@link evaluate} catches, warns,
    *    and returns `defaultValue ?? expression`, so the template renders its own
-   *    `${...}` source as literal text. {@link evaluateExpression} is the
-   *    throwing sibling, and reports `'formatCurrency' is not a function`.
+   *    `${...}` source as literal text.
+   *    {@link ExpressionEvaluator.evaluateExpression} is the throwing sibling,
+   *    and reports `'formatCurrency' is not a function`.
    *
    * To keep a name's exact spelling, supply the function as evaluation context
    * data instead: context entries are merged over the formulas and stay verbatim.
@@ -384,7 +385,10 @@ export class ExpressionEvaluator {
    * evaluator.evaluate('${FORMATCURRENCY(price)}'); // '$1,234.50'
    * evaluator.evaluate('${formatCurrency(price)}'); // '${formatCurrency(price)}' — the source, verbatim
    *
-   * // Case-sensitive alternative — the function travels as context data:
+   * // Case-sensitive alternative — the function travels as context data.
+   * // Note the receiver: the call below is the MODULE-LEVEL export (a context
+   * // bag as its second parameter), not the method used above.
+   * import { evaluateExpression } from '@object-ui/core';
    * evaluateExpression('${formatCurrency(price)}', { formatCurrency: fmt, price: 1234.5 }); // '$1,234.50'
    * ```
    */

--- a/packages/core/src/evaluator/__tests__/registerFunction-jsdoc-links.test.ts
+++ b/packages/core/src/evaluator/__tests__/registerFunction-jsdoc-links.test.ts
@@ -1,0 +1,216 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Binding pins for objectui#5580 — the `{@link}` targets in the
+ * `registerFunction` doc block resolve to the entities the prose means.
+ *
+ * `ExpressionEvaluator.ts` declares TWO things spelled `evaluateExpression`:
+ * the METHOD on `ExpressionEvaluator` (bare expression, throws) and the
+ * MODULE-LEVEL export (context bag, fail-soft, delegates to `evaluate`). The
+ * `registerFunction` block refers to both, four lines apart, and calls one of
+ * them "the throwing sibling".
+ *
+ * Why this file drives `tsc` itself: a `{@link}` that binds to the WRONG entity
+ * is indistinguishable in source from one that binds right — both are just
+ * text in a comment. Nothing at runtime observes it, and no lint rule in this
+ * repo resolves link targets. The only thing that actually performs the binding
+ * is the TypeScript checker, which is what an editor hover and the published
+ * `.d.ts` reader both go through, so the checker is what these cases ask.
+ *
+ * The hazard is not hypothetical and it is not symmetric. Measured on the
+ * pre-fix source, the unqualified `{@link evaluateExpression}` resolved to the
+ * module-level `FunctionDeclaration` — the FAIL-SOFT one — while the sentence
+ * containing it calls it the throwing sibling. Sibling `{@link evaluate}` in
+ * the same block binds to the method, but only because no module-level
+ * `evaluate` exists to outrank it. So "an unqualified link in a class member
+ * resolves to that class's member" is FALSE here, and that false reading is
+ * exactly what the card this file closes had assumed.
+ *
+ * NO BUILD ARTIFACT SITS BETWEEN THE EDIT AND THESE ASSERTIONS. The program is
+ * created over the SOURCE file by relative path, so `dist/` is not in the loop
+ * and no rebuild sits between an edit and a result.
+ *
+ * The discrimination proof is built in rather than promised in prose:
+ * `bindingOf(ABLATED)` compiles the same source a SECOND time with the single
+ * qualification removed — everything else byte-identical — and asserts the link
+ * lands back on the module-level function. A pin that cannot fail is not a pin,
+ * so the failing leg is measured here, in-suite, on every run.
+ */
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SUBJECT = join(HERE, '..', 'ExpressionEvaluator.ts');
+
+/** The qualification under test, and the bare spelling it replaced. */
+const QUALIFIED = '{@link ExpressionEvaluator.evaluateExpression}';
+const BARE = '{@link evaluateExpression}';
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2020,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  strict: true,
+  skipLibCheck: true,
+  noEmit: true,
+};
+
+/** Where a resolved symbol actually lives, in terms that survive line drift. */
+interface Binding {
+  readonly kind: string;
+  /** Enclosing class for a method; `'<module>'` for a top-level function. */
+  readonly owner: string;
+  readonly file: string;
+}
+
+/**
+ * Compile `text` as the subject file and report what each `{@link}` in the
+ * `registerFunction` doc block binds to, keyed by the link's literal text.
+ */
+function bindingsIn(text: string): Map<string, Binding> {
+  const host = ts.createCompilerHost(COMPILER_OPTIONS, true);
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreate) => {
+    if (join(fileName) === SUBJECT) {
+      return ts.createSourceFile(fileName, text, languageVersion, true);
+    }
+    return originalGetSourceFile(fileName, languageVersion, onError, shouldCreate);
+  };
+
+  const program = ts.createProgram([SUBJECT], COMPILER_OPTIONS, host);
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(SUBJECT);
+  if (!sourceFile) throw new Error(`subject not loaded: ${SUBJECT}`);
+
+  const method = findRegisterFunction(sourceFile);
+  if (!method) throw new Error('registerFunction declaration not found');
+
+  const out = new Map<string, Binding>();
+  for (const link of linksOf(method)) {
+    const nameNode = (link as ts.JSDocLink).name;
+    if (!nameNode) continue;
+    const literal = `{@link ${nameNode.getText(sourceFile)}}`;
+    const symbol = checker.getSymbolAtLocation(nameNode);
+    const declaration = symbol?.getDeclarations()?.[0];
+    if (!declaration) continue;
+    out.set(literal, {
+      kind: ts.SyntaxKind[declaration.kind],
+      owner: ownerOf(declaration),
+      file: declaration.getSourceFile().fileName.split('/').pop() ?? '',
+    });
+  }
+  return out;
+}
+
+function findRegisterFunction(sourceFile: ts.SourceFile): ts.MethodDeclaration | undefined {
+  let found: ts.MethodDeclaration | undefined;
+  const walk = (node: ts.Node): void => {
+    if (ts.isMethodDeclaration(node) && node.name.getText(sourceFile) === 'registerFunction') {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(sourceFile);
+  return found;
+}
+
+/** Every `{@link}` node inside a declaration's own doc comment. */
+function linksOf(node: ts.Node): ts.Node[] {
+  const links: ts.Node[] = [];
+  const collect = (n: ts.Node): void => {
+    if (
+      n.kind === ts.SyntaxKind.JSDocLink ||
+      n.kind === ts.SyntaxKind.JSDocLinkCode ||
+      n.kind === ts.SyntaxKind.JSDocLinkPlain
+    ) {
+      links.push(n);
+    }
+    ts.forEachChild(n, collect);
+    const comment = (n as ts.JSDoc).comment;
+    if (Array.isArray(comment)) comment.forEach(collect);
+    const tags = (n as ts.JSDoc).tags;
+    if (tags) tags.forEach(collect);
+  };
+  for (const doc of ts.getJSDocCommentsAndTags(node)) collect(doc);
+  return links;
+}
+
+function ownerOf(declaration: ts.Declaration): string {
+  const parent = declaration.parent;
+  if (parent && ts.isClassDeclaration(parent)) {
+    return parent.name?.getText(parent.getSourceFile()) ?? '<anonymous class>';
+  }
+  if (parent && ts.isSourceFile(parent)) return '<module>';
+  return ts.SyntaxKind[parent?.kind ?? ts.SyntaxKind.Unknown];
+}
+
+const PRISTINE = readFileSync(SUBJECT, 'utf8');
+const ABLATED = PRISTINE.replace(QUALIFIED, BARE);
+
+describe('registerFunction JSDoc — {@link} targets bind to the entity the prose means', () => {
+  it('the source carries the qualification, exactly once, and the ablation is a real edit', () => {
+    // Trap #4 in reverse: a zeroed anchor and an absent one look identical, so
+    // the anchors are asserted pristine BEFORE anything is concluded from them.
+    expect(PRISTINE.split(QUALIFIED).length - 1).toBe(1);
+    expect(ABLATED).not.toBe(PRISTINE);
+    expect(ABLATED.split(BARE).length - 1).toBe(1);
+  });
+
+  it('"the throwing sibling" resolves to the METHOD, not the module-level export', () => {
+    const binding = bindingsIn(PRISTINE).get(QUALIFIED);
+    expect(binding).toBeDefined();
+    expect(binding).toEqual({
+      kind: 'MethodDeclaration',
+      owner: 'ExpressionEvaluator',
+      file: 'ExpressionEvaluator.ts',
+    });
+  });
+
+  it('ABLATION — dropping the qualification puts the link back on the fail-soft function', () => {
+    // This is the leg that proves the pin above can fail. If this ever reports a
+    // MethodDeclaration, the qualification has stopped being load-bearing and
+    // the pin above is green for the wrong reason.
+    const binding = bindingsIn(ABLATED).get(BARE);
+    expect(binding).toBeDefined();
+    expect(binding).toEqual({
+      kind: 'FunctionDeclaration',
+      owner: '<module>',
+      file: 'ExpressionEvaluator.ts',
+    });
+  });
+
+  it('the other two links in the block still bind where they read', () => {
+    const bindings = bindingsIn(PRISTINE);
+    // `evaluate` is unqualified and CORRECT — no module-level `evaluate` exists
+    // to outrank it. Pinned so that adding one is a visible break, not a silent
+    // rebinding of this sentence.
+    expect(bindings.get('{@link evaluate}')).toEqual({
+      kind: 'MethodDeclaration',
+      owner: 'ExpressionEvaluator',
+      file: 'ExpressionEvaluator.ts',
+    });
+    expect(bindings.get('{@link FormulaFunctions.register}')).toEqual({
+      kind: 'MethodDeclaration',
+      owner: 'FormulaFunctions',
+      file: 'FormulaFunctions.ts',
+    });
+  });
+
+  it('no link in the block dangles', () => {
+    const bindings = bindingsIn(PRISTINE);
+    expect(bindings.size).toBe(3);
+    for (const [literal, binding] of bindings) {
+      expect(binding.kind, `${literal} resolved nowhere`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #5580

`ExpressionEvaluator.ts` exports two entities spelled `evaluateExpression` — the method on `ExpressionEvaluator` (bare expression, throws) and the module-level export (context bag, fail-soft). The `registerFunction` doc block referred to both under the one spelling, four lines apart. Both references are now qualified.

## Premise re-verified — and one of the card's claims is measured FALSE

The card's `:142` (method) still holds. Its `:368` for the module-level export was **stale**: PR #5578 added ~120 lines of JSDoc above it, so the export now sits at `:405`. Re-derived on `aa3b81062`.

The larger correction is to the card's central claim. It states the prose `{@link evaluateExpression}` *"resolves, per TSDoc, to the **method**. Correct."*, and concludes **"Not a defect — every statement in that block is true."** Asked of the TypeScript checker (`checker.getSymbolAtLocation`) on the pre-fix source:

```
@link line 360: "FormulaFunctions.register" -> FormulaFunctions.ts:38      [MethodDeclaration]
@link line 368: "evaluate"                  -> ExpressionEvaluator.ts:80   [MethodDeclaration]
@link line 370: "evaluateExpression"        -> ExpressionEvaluator.ts:405  [FunctionDeclaration]
```

`:405` is the **module-level export — the fail-soft one** — inside the sentence that calls it *"the throwing sibling, and reports `'formatCurrency' is not a function`."* So the block did contain a false statement; this is a small real defect, not pure imprecision.

Note why the neighbouring link is not evidence of the opposite: `{@link evaluate}` binds to the method only because no module-level `evaluate` exists to outrank it. "An unqualified link in a class member resolves to that class's member" is **false here**, and that is precisely the reading the card relied on.

After the fix:

```
@link line 371: "ExpressionEvaluator.evaluateExpression" -> ExpressionEvaluator.ts:142 [MethodDeclaration]
```

## The fix

- **Prose link** becomes `{@link ExpressionEvaluator.evaluateExpression}`, which the checker resolves to the `MethodDeclaration`.
- **The `@example`'s last line** is the module-level export (context bag as second parameter; the `${...}` wrapper only resolves on the `evaluate` path), but it sat two lines under calls establishing `evaluator.` as the receiver, and a `.d.ts` hover carries no import to disambiguate. It now names the module-level export and shows the import it needs. Both `evaluateExpression` and `ExpressionEvaluator` are exported from the package entry, so that import is true as written (verified against the built entry).

## Checkable, not asserted — and a declared surface expansion

The dispatch asked that the corrected bindings be made checkable, since a `{@link}` that binds to the wrong entity is indistinguishable in source from one that binds right. Nothing in this repo resolves link targets: no lint rule, nothing at runtime. The only thing that performs the binding is the checker — which is what an editor hover and the published `.d.ts` reader both go through.

So this PR adds **one file beyond the dispatched surface**, declared in the same round on the issue before it was committed:

- `packages/core/src/evaluator/__tests__/registerFunction-jsdoc-links.test.ts`

It creates a program over the **source** file by relative path, so no build artifact sits between an edit and a result. It follows the existing house pattern for compiler-driven pins (`packages/core/src/utils/__tests__/freeze-schema.types.test.ts`), including that precedent's built-in discrimination leg. Bindings are asserted as `kind` + owning class rather than line numbers, so the pin does not rot the way the card's `:368` did.

## The pin can fail — measured on its own mutation leg, twice

**In-suite (every run):** one case recompiles the same source with the single qualification removed, via an in-memory host overlay, and asserts the link lands back on the module-level `FunctionDeclaration`.

**External ablation:** the source was reverted to `origin/main` and the suite re-run.

```
ABLATED_VITEST_EXIT=1
  x the source carries the qualification, exactly once, and the ablation is a real edit
  x "the throwing sibling" resolves to the METHOD, not the module-level export
  Tests  2 failed | 3 passed (5)
```

Two red, and the direction was predicted before the run: the in-suite ablation case stays **green** under external ablation, because with the source already bare the mutated copy equals the original and the bare link still resolves to the function. It is stated here rather than counted as evidence.

Mutation was confirmed **on disk** by anchored `grep -cF` on both the removed and injected text, never an editor exit code — anchors asserted pristine (1 / 0) *before* mutating, then inverted (0 / 1) after. The script carried `trap ... EXIT INT TERM`; the tree was verified clean afterwards.

## Shipped bytes — the `.js` prediction is falsified

The prediction under test was: `dist/**/*.d.ts` moves, `dist/**/*.js` byte-identical. Measured over all 90 + 90 emitted files, clean-built both legs (`dist/` **and** `packages/core/tsconfig.tsbuildinfo` cleared — the build info lives **outside** `dist/`, so clearing `dist` alone would have skipped emit).

| artefact | pre-fix sha256 | post-fix sha256 | moved? |
|---|---|---|---|
| `dist/evaluator/ExpressionEvaluator.d.ts` | `8eb97d48…e194d7` | `4948e971…0fa3ba08` | **yes** — as predicted |
| `dist/evaluator/ExpressionEvaluator.js` | `478dcb80…3a4a4f14` | `1fcb9ffa…9cfbd5a1` | **yes — prediction falsified** |

Exactly one file moved on each leg; the other 89 + 89 are unchanged. The `.js` moves because this package builds with a bare `tsc`, which **preserves comments in the JS emit** — so JSDoc reaches *both* published artefacts, not only declarations.

The intent behind the prediction (no program semantics change) still holds, and is proven directly rather than by `--removeComments`, which proves nothing about semantics: the emitted `.js` delta is **10 changed lines, of which 0 are non-comment lines**.

Determinism was cross-checked in both directions: the pre-fix rebuild reproduced the original baseline hashes **exactly**, and the restore rebuild reproduced the post-fix hashes exactly — so the movement is attributable to this edit, not to build noise, and no mutated artefact was left in `dist`.

The new test file does not enter the published emit: dist counts stay 90 / 90, with no `__tests__` directory and no artefact bearing its name.

## Changeset

`check-changeset-presence.mjs` is the authority and was run rather than inferred from the `.d.ts` result — it exits **1** before, **0** after. Scored `patch`, never `major` (fixed group), matching PR #5578's reasoning on this identical surface: the block is emitted into what npm ships, and the measurement above makes that stronger than #5578 knew, since the JSDoc reaches the `.js` as well.

## Verification

All at `3de60fdcd`, the head of this branch. Exit codes captured **before** any pipe; each gate's own verdict line quoted.

| gate | result |
|---|---|
| `pnpm exec vitest run packages/core/` | `CORE_VITEST_EXIT=0` — `Test Files 94 passed (94)` · `Tests 1950 passed (1950)` |
| `pnpm exec vitest run packages/core/src/evaluator/` | `EVALUATOR_VITEST_EXIT=0` — `Test Files 12 passed (12)` · `Tests 364 passed (364)` |
| new pin alone | `VITEST_EXIT=0` — `Tests 5 passed (5)` |
| `pnpm --filter @object-ui/core type-check` | `TYPECHECK_EXIT=0` (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/core lint` | `LINT_EXIT=0` — `✖ 513 problems (0 errors, 513 warnings)` |
| `node scripts/check-changeset-presence.mjs` | `EXIT=0` — `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-fixed.mjs` | `EXIT=0` — `✅ All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | `EXIT=0` — `✅ No changeset declares a `major` bump.` |
| `node scripts/check-control-bytes.mjs` | `EXIT=0` — `✅ OK (scanned 4697 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-package-self-import.mjs` | `EXIT=0` — `✅ No package names itself inside its own src/.` |

`check:self-import` is called out deliberately: the new `@example` line contains `import { evaluateExpression } from '@object-ui/core';` **inside `packages/core` itself**. The gate reports `0 self-import` across `16132 module specifier(s)`, so a specifier in a comment is not counted.

The test suite total moved `93 -> 94` files and `1945 -> 1950` tests against PR #5578's figures — exactly the one file and five cases added here, and nothing else.

**Repo-wide `pnpm lint` / `pnpm test` are left to CI, and the narrowing is declared rather than assumed.** Three pieces, since a narrowing without them is just a skipped run:

1. Population read from **eslint's own resolution**, not from a guess about which files count: **186** files for `packages/core`.
2. That count read from `--format json`, not estimated. Both changed source files are in it; the new test file contributes `0 errors, 0 warnings`, and the totals (`0 errors, 513 warnings`) are the pre-existing baseline unchanged.
3. Root `eslint.config.js` declares no `projectService` and no `parserOptions.project`, so linting is **not type-aware** and this diff cannot move a verdict in any file it does not itself contain.

`check:published-dist` was not run to completion — it hit the container's 10-minute foreground cap. Its concern for this diff is answered directly above (dist counts unchanged at 90 / 90, no `__tests__` in `dist`); the full repo-wide scan belongs to CI. Known-broken gauges left untouched: `check:eager-closure` (exits 2), `check:doc-snippet-types` (exits 1) — the latter's population is `.md` / `.mdx` and package READMEs, so JSDoc `@example` blocks in `.ts` are outside it either way.

## Scope

Exactly the dispatched surface plus the one declared test file. The fence held: `packages/core/src/actions/**` (#5611's open draft) is untouched. No behaviour change, no declaration moves — the source diff is confined to a block comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_