### PR TITLE
refactor(types)!: retire `ThemeComponentSchema` — the `type: 'theme'` component kind no renderer implements

### DIFF
--- a/.changeset/retire-theme-component-schema-5489.md
+++ b/.changeset/retire-theme-component-schema-5489.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/types': minor
+---
+
+Retire `ThemeComponentSchema` (`type: 'theme'`) — a component kind no renderer
+implemented (objectui#5489).
+
+`packages/types/src/theme.ts` declared a theme-manager **component** carrying
+`themes[]`, `activeTheme`, `allowSwitching`, `persistPreference` and
+`storageKey`, and `packages/types/src/zod/theme.zod.ts` published the matching
+Zod object as a member of `ThemeUnionSchema` and therefore of
+`AnyComponentSchema`. Nothing rendered it: `'theme'` appears at no
+`ComponentRegistry.register(...)` / `registerLazy(...)` site in `packages/*/src`,
+and in neither `PROTOCOL_COMPONENTS` nor `PALETTE_PLACEHOLDER_BLOCKS`
+(`packages/components/src/renderers/placeholders.tsx`), so it did not even
+resolve to a placeholder — a page declaring one got the registry's "Unknown
+component type" panel (OBJUI-001) instead of a theme manager. Declared-but-
+unenforced, removed under the maintainer ruling of 2026-08-21 on
+objectstack#10485 (option B).
+
+Removed from the published surface: the `ThemeComponentSchema` type
+(`@object-ui/types`), the `ThemeComponentSchema` Zod object
+(`@object-ui/types/zod`), the `ThemeComponentSchemaType` inference alias, and the
+`'theme'` member of `ThemeUnionSchema` / `AnyComponentSchema`. A schema spelling
+`type: 'theme'` is now REFUSED by `AnyComponentSchema.safeParse` rather than
+accepted and then rendered as an error panel, which is pinned by a test.
+
+**The theme system is unchanged.** `Theme` (the spec's authoring theme
+document), `ThemeDefinitionSchema`, `ThemeModeSchema`, `ThemeEngine`
+(`@object-ui/core`) and `ThemeProvider` (`@object-ui/react`) are all retained and
+untouched — the same ruling retains them explicitly. Author a theme as a
+document handed to `ThemeProvider`; that path never went through the removed
+component kind.

--- a/content/docs/guide/schema-overview.md
+++ b/content/docs/guide/schema-overview.md
@@ -47,20 +47,17 @@ const app: AppComponentSchema = {
 #### [Theme Schema](/docs/core/theme-schema)
 Dynamic theming with light/dark modes, color palettes, and typography.
 
-```typescript
-const theme: ThemeComponentSchema = {
-  type: 'theme',
-  mode: 'dark',
-  themes: [{
-    name: 'professional-dark',
-    label: 'Professional (Dark)',
-    mode: 'dark',
-    colors: { primary: '#60a5fa', background: '#0f172a', ... }
-  }]
-};
-```
+Theming is **not** a component you declare in a page. There is no `type: 'theme'`
+node: the `ThemeComponentSchema` wrapper documented here until objectui#5489 was
+retired because no renderer ever implemented it, so a page declaring one got the
+registry's "Unknown component type" panel rather than a theme manager.
 
-**Features:**
+A theme is a **document**, not a node. Author it as the `Theme` shape
+`@object-ui/types` re-exports from `@objectstack/spec/ui`, hand it to
+`ThemeProvider` (`@object-ui/react`), and `ThemeEngine` (`@object-ui/core`)
+turns it into the CSS variables your components already read.
+
+**What the theme document carries:**
 - Light/dark mode switching
 - 20+ semantic colors
 - Typography system
@@ -162,7 +159,6 @@ const block: BlockSchema = {
 | Schema | Purpose | Best For |
 |--------|---------|----------|
 | **AppComponentSchema** | Application structure | Multi-page apps, dashboards |
-| **ThemeComponentSchema** | Visual theming | Brand consistency, white-labeling |
 | **Enhanced Actions** | Complex workflows | API integration, multi-step processes |
 | **ReportComponentSchema** | Data reporting | Analytics, business intelligence |
 | **BlockSchema** | Reusable components | Marketing pages, component libraries |
@@ -204,7 +200,6 @@ Import the type definitions you need:
 ```typescript
 import type { 
   AppComponentSchema, 
-  ThemeComponentSchema, 
   ActionSchema,
   ReportComponentSchema,
   BlockSchema 
@@ -218,7 +213,6 @@ For runtime validation, use the included Zod schemas:
 ```typescript
 import { 
   AppComponentSchema,
-  ThemeComponentSchema,
   ActionSchema,
   ReportComponentSchema,
   BlockSchema
@@ -239,7 +233,7 @@ if (result.success) {
 Here's a complete example showing how to build a simple CRM application using ObjectUI schemas:
 
 ```typescript
-import type { AppComponentSchema, ThemeComponentSchema } from '@object-ui/types';
+import type { AppComponentSchema } from '@object-ui/types';
 
 // Define your application structure
 const app: AppComponentSchema = {
@@ -276,35 +270,15 @@ const app: AppComponentSchema = {
     }
   ]
 };
-
-// Configure your theme
-const theme: ThemeComponentSchema = {
-  type: 'theme',
-  mode: 'auto',
-  themes: [
-    {
-      name: 'professional-light',
-      label: 'Professional (Light)',
-      mode: 'light',
-      colors: { primary: '#3b82f6', background: '#ffffff' }
-    },
-    {
-      name: 'professional-dark',
-      label: 'Professional (Dark)',
-      mode: 'dark',
-      colors: { primary: '#60a5fa', background: '#0f172a' }
-    }
-  ],
-  allowSwitching: true,
-  persistPreference: true
-};
 ```
 
 This creates a professional-looking CRM application with:
 - A sidebar layout with navigation menu
 - Sales section with leads and deals
 - User menu with profile and logout options
-- Professional theme with light/dark mode support
+
+Theming is configured separately, as a theme document handed to `ThemeProvider` —
+see [Theme Schema](/docs/core/theme-schema).
 
 ## Advanced Features
 
@@ -315,7 +289,6 @@ ObjectUI provides advanced schemas and capabilities for enterprise applications:
 ObjectUI includes these top-level schemas:
 
 - **`AppComponentSchema`** - Define your entire application structure
-- **`ThemeComponentSchema`** - Configure themes and color palettes
 - **`ReportComponentSchema`** - Create data reports with aggregation
 - **`BlockSchema`** - Build reusable component blocks
 
@@ -350,7 +323,7 @@ ObjectUI includes enhanced view components:
 
 2. **Configure application** - Define your app structure with AppComponentSchema (optional)
    
-3. **Set up theming** - Add a ThemeComponentSchema for consistent styling (optional)
+3. **Set up theming** - Hand a `Theme` document to `ThemeProvider` for consistent styling (optional)
 
 4. **Implement actions** - Use advanced action features like `confirm` and callbacks
 

--- a/packages/types/src/__tests__/phase2-schemas.test.ts
+++ b/packages/types/src/__tests__/phase2-schemas.test.ts
@@ -1,15 +1,16 @@
 /**
  * Tests for Phase 2 Schema Definitions
- * Testing AppSchema, ThemeComponentSchema, ReportComponentSchema, BlockSchema, and Enhanced ActionSchema
+ * Testing AppSchema, ReportComponentSchema, BlockSchema, and Enhanced ActionSchema
  */
 import { describe, it, expect } from 'vitest';
 import {
   AppComponentSchema,
   AppActionSchema,
   AppMenuItemSchema,
-  ThemeComponentSchema,
   ThemeSwitcherSchema,
   ThemePreviewSchema,
+  ThemeUnionSchema,
+  ThemeDefinitionSchema,
   ReportComponentSchema,
   ReportBuilderSchema,
   ReportViewerSchema,
@@ -112,9 +113,20 @@ describe('Phase 2: AppComponentSchema Zod Validation', () => {
   });
 });
 
-describe('Phase 2: ThemeComponentSchema Zod Validation', () => {
-  it('should validate a complete ThemeComponentSchema', () => {
-    const theme = {
+describe('Phase 2: Theme component kinds — Zod Validation', () => {
+  // `type: 'theme'` (`ThemeComponentSchema`) was RETIRED in objectui#5489 under
+  // the maintainer ruling of 2026-08-21 on objectstack#10485 (option B). It
+  // declared a theme-manager COMPONENT that no renderer ever implemented. This
+  // is the pin that keeps it retired: the shape the old acceptance test proved
+  // VALID is now proven REFUSED, so a re-added union member fails here rather
+  // than reappearing silently in the published `@object-ui/types/zod` surface.
+  //
+  // The theme SYSTEM is untouched — `ThemeDefinitionSchema` (the theme
+  // document the engine and the provider consume) is retained, and this
+  // fixture's `themes[0]` still parses against it, which is what makes the
+  // refusal below attributable to the retired WRAPPER and not to a bad fixture.
+  it('refuses the retired `type: \'theme\'` component kind, while the theme document it carried still parses', () => {
+    const retiredWrapper = {
       type: 'theme',
       mode: 'dark',
       activeTheme: 'professional',
@@ -147,12 +159,14 @@ describe('Phase 2: ThemeComponentSchema Zod Validation', () => {
       storageKey: 'app-theme',
     };
 
-    const result = ThemeComponentSchema.safeParse(theme);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.mode).toBe('dark');
-      expect(result.data.themes).toHaveLength(1);
-    }
+    // The wrapper: gone from every union that used to carry it.
+    expect(ThemeUnionSchema.safeParse(retiredWrapper).success).toBe(false);
+    expect(AnyComponentSchema.safeParse(retiredWrapper).success).toBe(false);
+
+    // The control that makes that refusal mean something: the document the
+    // wrapper carried is retained and still valid on its own. If this leg ever
+    // fails, the fixture broke — not the retirement.
+    expect(ThemeDefinitionSchema.safeParse(retiredWrapper.themes[0]).success).toBe(true);
   });
 
   it('should validate ThemeSwitcherSchema', () => {
@@ -651,7 +665,8 @@ describe('Phase 2: AnyComponentSchema Union Type', () => {
   it('should validate any Phase 2 schema through union type', () => {
     const schemas = [
       { type: 'app', name: 'test-app' },
-      { type: 'theme', mode: 'light' },
+      // `{ type: 'theme' }` removed with the kind itself (objectui#5489); its
+      // refusal is pinned in the theme describe block above.
       { type: 'report', title: 'Test Report' },
       { type: 'block', meta: { name: 'test-block' } },
       { type: 'action', label: 'Test Action' },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -701,7 +701,8 @@ import type { AppComponentSchema } from './app.js';
 export type {
   // Theme System (aligned with @objectstack/spec)
   Theme,
-  ThemeComponentSchema,
+  // `ThemeComponentSchema` RETIRED in objectui#5489 — the `type: 'theme'`
+  // component kind no renderer implemented. See `./theme` for the tombstone.
   ThemeMode,
   ColorPalette,
   Typography,

--- a/packages/types/src/theme.ts
+++ b/packages/types/src/theme.ts
@@ -111,32 +111,33 @@ import type { Theme } from '@objectstack/spec/ui';
 // ObjectUI Component Schemas (UI rendering)
 // ============================================================================
 
-/**
- * Theme Component Schema
- *
- * Used by SchemaRenderer to render a theme manager component.
- */
-export interface ThemeComponentSchema extends BaseSchema {
-  type: 'theme';
-
-  /** Current theme mode */
-  mode?: ThemeMode;
-
-  /** Available themes */
-  themes?: Theme[];
-
-  /** Active theme name */
-  activeTheme?: string;
-
-  /** Allow user theme switching */
-  allowSwitching?: boolean;
-
-  /** Persist theme preference to storage */
-  persistPreference?: boolean;
-
-  /** Storage key for persisting theme */
-  storageKey?: string;
-}
+// `ThemeComponentSchema` (`type: 'theme'`) RETIRED in objectui#5489, under the
+// maintainer ruling of 2026-08-21 on objectstack#10485 (option B, quoted
+// verbatim and untranslated):
+//
+//   「B：退役授权面 —— 收掉 `themes` 载体键与 schema，`app.branding` 留作唯一颜色面；
+//   objectui 引擎代码与单测保留」
+//
+// It declared a COMPONENT kind — a theme-manager node carrying `themes[]`,
+// `activeTheme`, `allowSwitching`, `persistPreference` and `storageKey`. No
+// renderer ever implemented `'theme'`: the literal is absent from every
+// `ComponentRegistry.register(...)` / `registerLazy(...)` site in
+// `packages/*/src`, and from both `PROTOCOL_COMPONENTS` and
+// `PALETTE_PLACEHOLDER_BLOCKS` in
+// `packages/components/src/renderers/placeholders.tsx` — so it did not even
+// resolve to a placeholder. A page declaring one got the registry's "Unknown
+// component type" panel (OBJUI-001), never a theme manager. Declared-but-
+// unenforced, the ADR-0078 class.
+//
+// The theme SYSTEM is untouched and is explicitly RETAINED by the same ruling:
+// `Theme` above is the spec's authoring theme document, `ThemeEngine`
+// (`packages/core/src/theme/ThemeEngine.ts`) turns it into CSS variables, and
+// `ThemeProvider` (`packages/react/src/context/ThemeContext.tsx`) applies it.
+// Retiring the dead component kind is not retiring theming.
+//
+// The two siblings below — `ThemeSwitcherSchema` / `ThemePreviewSchema` — are
+// unregistered in exactly the same way but were NOT named by the ruling; they
+// are recorded as objectui#5647 rather than removed here.
 
 /**
  * Theme Switcher Component Schema

--- a/packages/types/src/zod/index.zod.ts
+++ b/packages/types/src/zod/index.zod.ts
@@ -290,7 +290,7 @@ export {
   ShadowSchema,
   ThemeModeSchema,
   ThemeDefinitionSchema,
-  ThemeComponentSchema,
+  // `ThemeComponentSchema` RETIRED in objectui#5489 — see `./theme.zod`.
   ThemeUnionSchema,
   ThemeSwitcherSchema,
   ThemePreviewSchema,

--- a/packages/types/src/zod/theme.zod.ts
+++ b/packages/types/src/zod/theme.zod.ts
@@ -75,18 +75,11 @@ export const ThemeModeSchema = SpecThemeModeSchema;
  */
 export const ThemeDefinitionSchema = SpecThemeSchema;
 
-/**
- * Theme Component Schema (ObjectUI rendering)
- */
-export const ThemeComponentSchema = BaseSchema.extend({
-  type: z.literal('theme'),
-  mode: ThemeModeSchema.optional().describe('Current theme mode'),
-  themes: z.array(ThemeDefinitionSchema).optional().describe('Available themes'),
-  activeTheme: z.string().optional().describe('Active theme name'),
-  allowSwitching: z.boolean().optional().describe('Allow user theme switching'),
-  persistPreference: z.boolean().optional().describe('Persist theme preference'),
-  storageKey: z.string().optional().describe('Storage key for persisting theme'),
-});
+// `ThemeComponentSchema` (`type: 'theme'`) RETIRED in objectui#5489 — the value
+// side of the interface retired in `../theme.ts`, where the ruling and the
+// unregistered-kind measurement are recorded. `ThemeDefinitionSchema` (the
+// spec's `ThemeSchema`, the theme DOCUMENT) and `ThemeModeSchema` are retained
+// and still exported above: the engine and the provider validate against them.
 
 /**
  * Theme Switcher Schema
@@ -116,7 +109,6 @@ export const ThemePreviewSchema = BaseSchema.extend({
  * Union of all theme component schemas (for AnyComponentSchema union).
  */
 export const ThemeUnionSchema = z.discriminatedUnion('type', [
-  ThemeComponentSchema,
   ThemeSwitcherSchema,
   ThemePreviewSchema,
 ]);
@@ -130,6 +122,5 @@ export type BorderRadiusSchemaType = z.infer<typeof BorderRadiusSchema>;
 export type ShadowSchemaType = z.infer<typeof ShadowSchema>;
 export type ThemeModeSchemaType = z.infer<typeof ThemeModeSchema>;
 export type ThemeDefinitionSchemaType = z.infer<typeof ThemeDefinitionSchema>;
-export type ThemeComponentSchemaType = z.infer<typeof ThemeComponentSchema>;
 export type ThemeSwitcherSchemaType = z.infer<typeof ThemeSwitcherSchema>;
 export type ThemePreviewSchemaType = z.infer<typeof ThemePreviewSchema>;

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -341,8 +341,12 @@ const DOC_TYPE_EXEMPTIONS = {
   },
   'content/docs/core/theme-schema.mdx': {
     theme:
-      'ThemeSchema discriminant — `packages/types/src/theme.ts` declares the theme document\'s own ' +
-      '`type`, validated by zod/theme.zod.ts.',
+      'RETIRED discriminant, kept exempt only until this page is rewritten. `ThemeComponentSchema` ' +
+      '(`type: \'theme\'`) was removed from packages/types in objectui#5489 under the maintainer ' +
+      'ruling of 2026-08-21 — no renderer ever implemented it, so the literal named nothing even ' +
+      'before the removal. This page still teaches it, along with five falsehoods that predate the ' +
+      'retirement; the rewrite around the RETAINED theme document is objectui#5648, and DELETING ' +
+      'this entry is part of it.',
     'theme-preview': 'ThemePreviewSchema discriminant — packages/types/src/theme.ts:167.',
     'theme-switcher': 'ThemeSwitcherSchema discriminant — packages/types/src/theme.ts:145.',
   },
@@ -437,10 +441,6 @@ const DOC_TYPE_EXEMPTIONS = {
     string:
       'BlockVariable.type in the BlockSchema tour\'s `variables[]` — a variable declaration\'s data ' +
       'type, next to `name` / `defaultValue`.',
-    theme:
-      'ThemeSchema discriminant in a `const theme: ThemeComponentSchema = { … }` declaration — ' +
-      'packages/types/src/theme.ts declares the theme document\'s own `type`, validated by ' +
-      'zod/theme.zod.ts. Same vocabulary as core/theme-schema.mdx.',
   },
   'content/docs/guide/schema-playground.md': {
     reset:

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -351,7 +351,10 @@ const UNGATED_DOCS = {
     '`ThemeComponentSchema`, `ReportComponentSchema` at every site including the prose. The ' +
     'annotations that renaming made real then rejected two more falsehoods in the theme example ' +
     '(`mode: \'system\'`, and per-theme `light`/`dark` palettes where the spec `Theme` carries one ' +
-    '`colors` map), fixed in the same pass so the page could not get worse',
+    '`colors` map), fixed in the same pass so the page could not get worse. objectui#5489 then ' +
+    'RETIRED `ThemeComponentSchema` itself — the `type: \'theme\'` component kind no renderer ' +
+    'implemented — so the theme example named above is gone from this page rather than re-spelled ' +
+    'again; the two `AppComponentSchema` / `ReportComponentSchema` re-spellings stand',
   'content/docs/guide/schema-rendering.md':
     '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +


### PR DESCRIPTION
Fixes #5489

Retires `ThemeComponentSchema` (`type: 'theme'`) from `@object-ui/types` — a **component** kind no renderer ever implemented. Under the maintainer ruling of 2026-08-21 on objectstack#10485, option B (verbatim, untranslated):

> 「B：退役授权面 —— 收掉 `themes` 载体键与 schema，`app.branding` 留作唯一颜色面；objectui 引擎代码与单测保留」

**The theme system is untouched.** `ThemeEngine` (`packages/core/src/theme/ThemeEngine.ts`), `ThemeContext` / `ThemeProvider` (`packages/react/src/context/ThemeContext.tsx`) and their unit tests are explicitly retained by that ruling and are not in this diff. `Theme`, `ThemeDefinitionSchema` and `ThemeModeSchema` also stand. Retiring the dead component *kind* is not retiring theming.

## Consumer sweep — the search terms, and the positive control for each

The card records an explicit confidence gap: no in-repo consumer was found, but out-of-repo consumers of the published types package are not measurable from here. A zero-hit sweep is only evidence if the command is proven able to hit, so every term below is paired with a control run through the **identical** pipeline.

| # | Search (`--include='*.ts' --include='*.tsx'` plus `.js/.mjs/.json/.md/.mdx` where noted; `node_modules` and `dist/` excluded) | Result | Positive control, same command |
|---|---|---|---|
| 1 | `grep -rn "ThemeComponentSchema" .` | 15 hits, **all** in `packages/types` (2 declaration sites, 2 export barrels, its own unit test, prose in 1 doc page) + 2 gate-script exemption strings. No consumer. | n/a — non-zero result |
| 2 | `grep -rn "ThemeComponentSchemaType" .` | 1 hit: its own declaration. Not re-exported from `zod/index.zod.ts`; zero consumers. | n/a — non-zero result |
| 3 | `grep -rn "ThemeUnionSchema"` | 3 hits, all `packages/types` | n/a — non-zero result |
| 4 | `grep -rn "AnyComponentSchema" packages/ apps/ examples/ e2e/ scripts/ \| grep -v '^packages/types/'` | **0** | same command for `BaseSchema` → **131** |
| 5 | `grep -rhoE "ComponentRegistry\.(register\|registerLazy)\(\s*'[a-z0-9-]+'" packages/*/src \| sed -E "s/.*'([a-z0-9-]+)'/\1/" \| sort -u \| grep -cx 'theme'` | **0** (659 registered keys enumerated) | same pipeline, `grep -cx 'tooltip'` → **1** |
| 6 | `awk '/PROTOCOL_COMPONENTS = \[/,/^\];/' packages/components/src/renderers/placeholders.tsx \| grep -c "'theme'"` | **0** | same slice, `grep -c "'ai:input'"` → **1** |
| 7 | `grep -rn '"type": *"theme"' .` (JSON/TS/MD fixtures repo-wide) | **0** | same command for `"type": "form"` → **98** |
| 8 | `grep -rn "export \* from '@object-ui/types" packages/ apps/` | **0** — no package re-exports the barrel wholesale, so the removal cannot leak through a star re-export | n/a |
| 9 | `grep -rn "ThemeComponentSchema"` over the sibling `objectstack` checkout | **0** | n/a |

**Conclusion:** `'theme'` is registered by nothing — not by a renderer, and not even by the placeholder registry, so it did not resolve to a placeholder either. A page declaring one got the registry's "Unknown component type" panel (OBJUI-001), never a theme manager. Declared-but-unenforced, the ADR-0078 class. **No in-repo consumer exists**, so stop-and-report condition 1 did not trigger. Out-of-repo consumers of the published `@object-ui/types` remain unmeasurable from this repository — that gap is unchanged by this PR, and is the reason the ruling, not this PR, is the authority for the removal.

## ADR-0087 registry entry: **NO, none is owed**

Checked rather than assumed, in both directions:

- objectui has **no ADR-0087 registry** and no ADR-0087 at all — `docs/adr/` holds the 0001…0059-era ADRs, and `find . -name '*0087*'` outside `.git` returns nothing. The only two mentions of the number in the whole repo are a code comment in `packages/types/src/ui-action.ts:444` naming a spec-side conversion, and one `packages/types/CHANGELOG.md` line.
- The ADR lives in objectstack (`docs/adr/0087-metadata-protocol-upgrade-contract.md`) and its registries are `@objectstack/spec` artefacts: `packages/spec/spec-changes.json`, `packages/spec/src/migrations/`. Its stated Consumers are `@objectstack/spec`, `@objectstack/cli`, the runtime metadata loader, `@objectstack/mcp`, `@objectstack/create-objectstack` and the Release workflow. **objectui is not among them**, and `@object-ui/types` is not the metadata protocol — it is objectui's TypeScript/Zod surface for UI components.
- Cross-check that the two surfaces really are disjoint: the spec's own UI vocabulary declares no `theme` node — `grep -rn "'theme'" packages/spec/src/ui/` in objectstack returns 1 hit, a field *named* `theme` in a view test, while the control `'form'` returns 57. Nothing on the protocol side references the kind being removed.

The changeset is this removal's release-notes input, per the repo's own contract.

## Sequencing / shared artefacts

Independent of the objectstack-side retirement, as the card predicted: different repo, different package, no shared gate and no shared generated artefact. Measured, not assumed — see the spec-vocabulary cross-check above, and `check:spec-symbols` below, which passes with the removal in place.

## What changed

- `packages/types/src/theme.ts` — interface removed, replaced by a tombstone carrying the ruling verbatim and the unregistered-kind measurement.
- `packages/types/src/zod/theme.zod.ts` — the Zod object, its `'theme'` membership in `ThemeUnionSchema`, and `ThemeComponentSchemaType`.
- `packages/types/src/index.ts`, `packages/types/src/zod/index.zod.ts` — both export barrels.
- `packages/types/src/__tests__/phase2-schemas.test.ts` — the acceptance test that pinned the dead shape as **valid** becomes a **retirement pin** proving it **refused** by both `ThemeUnionSchema` and `AnyComponentSchema`, with the theme *document* it carried (`ThemeDefinitionSchema.safeParse`) as the control leg that makes the refusal attributable to the retired wrapper rather than to a broken fixture.
- `.changeset/retire-theme-component-schema-5489.md` — `@object-ui/types: minor` (never `major`; fixed group).

### Bounded in-place fixes, named here with their evidence

Two follow-on edits are the same defect class as the removal (references to the retired kind), mechanically determined by it, and in the same gate family. Naming them is the condition for making them here rather than filing them:

1. **`content/docs/guide/schema-overview.md`** imported and annotated `ThemeComponentSchema` in `typescript`-fenced blocks (an `import type` naming it from `@object-ui/types`, and two `const theme: ThemeComponentSchema = { … }` declarations), plus a comparison-table row and two prose bullets. Left alone it would teach a symbol this PR deletes. The theming section now describes the retained surface — a theme *document* handed to `ThemeProvider` — with no `type:` literal in any fence. The page is in `UNGATED_DOCS`, so it is not compiled; the ledger conditions are re-derived per run and all still hold (document exists; `typescript` fences 8 → 7, still ≥ 1, and `typescript` is in `TS_FENCE_LANGUAGES`; reason string still over the minimum).
2. **`scripts/check-doc-component-types.mjs`** — that page's `theme` exemption would have failed as `stale-exemption` the moment the literal left its code blocks (the gate re-derives every entry and only checks that the *file still spells the value*, confirmed by reading `analyze()`), so it is deleted. The `content/docs/core/theme-schema.mdx` entry stays live — that page still spells the literal — but its reason named `packages/types/src/theme.ts` as the declaration site, which is now false; it is re-pointed at the retirement and at the rewrite card. `scripts/check-doc-snippet-types.mjs`'s ledger prose for schema-overview.md gets one appended clause for the same reason. Gate verdict after both edits: `✅ Every documented component type is registered.`

## Verification — all of it on the final commit `b06fdf397`

```
pnpm --filter '@object-ui/types^...' build   → "No projects matched the filters"
```
Genuine, not the zero-match trap: `packages/types/package.json` declares `@objectstack/spec` and `zod` only — no workspace dependency exists to build.

```
pnpm --filter '@object-ui/types' build       EXIT=0   (tsc)
pnpm --filter '@object-ui/types' type-check  EXIT=0   (tsc --noEmit && tsconfig.examples.json && tsconfig.test.json — script name echoed, so not a zero match)
npx vitest run packages/types --maxWorkers=2 EXIT=0   Test Files 40 passed (40) · Tests 460 passed (460)
```

Gates, each verdict quoted from the gate's own output (exit codes captured before any pipe):

| Gate | Verdict line |
|---|---|
| `check-doc-component-types` | `✅  Every documented component type is registered.` (183 docs, 1053 code blocks, 886 `type` literals, 743 registered / 143 exempted) |
| `check-changeset-presence` | `✅  5 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `✅  No changeset declares a 'major' bump.` |
| `check-changeset-fixed` | `✅  All workspace packages are in the changeset fixed group.` |
| `check-control-bytes` | `✅  check-control-bytes: OK (scanned 4696 tracked text file(s); skipped 85 binary).` |
| `check-spec-symbol-derivation` | `✅  spec symbol derivation: 1290 files scanned against 4912 spec export names` |
| `check-package-self-import` | `✅  No package names itself inside its own src/.` |
| `check-lint-coverage` | `✅  lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `check-type-check-coverage` | `✅  type-check coverage: 45/46 via 'type-check', 0 known-broken` |
| `check-doc-links` | `Links are valid across 13 scan roots.` |

### Ablation — the retirement pin proven able to fail, both legs

The test resolves `'../zod/index.zod'` as a **relative source import**, and the root vitest config additionally aliases `@object-ui/types` → `packages/types/src`; nothing in this path reads `dist/`, so this ablation is source-level and the rebuild-then-re-hash step does not apply here. The script carried a `trap` on `EXIT INT TERM` that ran `git checkout` on both mutated files, so a cap-kill mid-mutation could cost at most one reading and never leave a mutated tree behind. Each leg proved its mutation **on disk** with anchored counts before the run was believed — an editor's exit code is not evidence.

- **Leg A** — re-added a `type: z.literal('theme')` member to `ThemeUnionSchema`. On-disk proof: injected marker → 2, `grep -cxF "  ABLATION_ThemeComponentSchema,"` → 1. Result: `Tests 1 failed | 30 passed`, `AssertionError: expected true to be false` on the refusal assertion. **Predicted red, observed red.**
- **Leg B** — the control leg given its own mutation: put the spec-retired `typography.fontSize` back into the fixture, leaving the union alone. On-disk proof: `grep -cxF "            fontSize: 16,"` → 1. Result: `Tests 1 failed | 30 passed`, `AssertionError: expected false to be true` — the *opposite* direction and the other assertion, which is what shows the control is scoped to the same subject and can fail independently.
- **Restore leg** — both files `git checkout`-ed; markers re-measured at 0 and 0, `git status --porcelain` empty for both, re-run `Tests 31 passed (31)`.

### Declared narrowings — measurement, not omission

Each is a repo-scale run CI performs in full regardless; each is declared with its own evidence rather than silently skipped.

1. **`pnpm lint` (`turbo run lint`, 46 packages).** Narrowed to the 7 changed `.ts`/`.mjs` files. (a) The population comes from eslint's own flat config, not a guess: `eslint.config.js` matches `**/*.{ts,tsx}` with `js.configs.recommended` + `tseslint.configs.recommended`. (b) File count read from `--format json`: **7 files linted, 0 errors, 10 warnings**. (c) Invariance for untouched files: the config declares **no** `parserOptions.project` and no `projectService`, so linting is not type-aware and no edit here can move any untouched file's verdict. The 10 warnings are pre-existing and unchanged — the base revision of that same file, linted through the identical command, also reports **10 warnings, 0 errors**. CI sets no `--max-warnings`.
2. **`check-published-dist-tooling`** was killed by the container's 10-minute foreground cap (`exit 143`) at 9m42s with 15 of 26 turbo builds done and **no finding emitted** — it builds the entire workspace by design (its own header cites the 2026-08-16 ruling on objectui#4846 that assigns exactly this cost to CI). It inspects every package's `dist/` for tooling material and does not read this diff, which adds no test or bench file to any `dist/`. CI owns it.
3. **`check-doc-snippet-types`** is a known-broken gauge (exits 1 on `main`) and compiles a scoped package set. Not run; its ledger conditions were instead re-derived by hand from `analyze()` and all hold — see the bounded-fix note above. CI owns it, as it already does.

## Out-of-scope findings, filed unassigned, not touched here

- **#5647** — `ThemeSwitcherSchema` / `ThemePreviewSchema` are unregistered in exactly the same way (`theme-switcher` → 0, `theme-preview` → 0, same pipeline, control `tooltip` → 1), but the ruling did not name them. After this PR `ThemeUnionSchema` consists of precisely those two unimplemented kinds. Extending the retirement to them would need its own ruling.
- **#5648** — `content/docs/core/theme-schema.mdx` teaches a schema that does not exist: six independent falsehoods, five of them predating this card. It is the reason that page's gate exemption is re-pointed rather than deleted here; deleting the three entries is part of that rewrite.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_