### PR TITLE
refactor(app-shell): paramToField's reference-bearing rule derives from core, not the last private copy

### DIFF
--- a/.changeset/paramtofield-reference-rule-derives-from-core-5312.md
+++ b/.changeset/paramtofield-reference-rule-derives-from-core-5312.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`ActionParamDialog`'s "this param carries a reference target" rule now derives from the shared reference-field family instead of the last private copy of it.
+
+`packages/app-shell/src/utils/paramToField.ts` restated the rule inline as
+`LOOKUP_WIDGET_TYPES.has(type) || type === 'user'` — the fourth and last
+hand-maintained answer to one question ("does this widget resolve a foreign key,
+so hand it `reference_to` / `display_field` / the rest of the picker config").
+The other three converged on `@object-ui/core`'s `EXPANDABLE_FIELD_TYPES` in
+objectui#4770 / #4790 / #4815; this face is now the fourth.
+
+No reachable behaviour change. The shared set is one member wider (`tree`), and
+that member can never be a widget key on this surface: it is absent from
+`fields`' widget map and `mapFieldTypeToFormType` sends it to `field:lookup`, so
+every key the rule tests arrives as `lookup`. Both halves are pinned, so
+registering a real `tree` widget surfaces the change instead of shipping it
+silently.
+
+The module's second rule — which widget keys degrade to a text input for want of
+a declared `referenceTo` — is a different set over overlapping types (`user`
+defaults its target to `sys_user` and must never degrade) and was deliberately
+left un-merged, matching the same split the plugin-grid twin keeps.
+
+Also retires a comment that claimed the disjunction "moves in lockstep with
+plugin-grid's `bulkParamToField` twin — the two param faces are never split".
+Measured on the tip before this change, that was false in both senses: the twin
+had read core's Set since objectui#4815 while this line read a private literal,
+so the two shared nothing and no gate could report a split; and the two member
+sets already differed, by `tree`. Lockstep now holds mechanically — the pin is
+on object identity (a spy on core's `has`), so a member-identical private copy
+fails where a value check would pass.

--- a/packages/app-shell/src/utils/paramToField.test.ts
+++ b/packages/app-shell/src/utils/paramToField.test.ts
@@ -15,9 +15,9 @@
  * `FORM_FIELD_TYPES` + this drift test makes that class of bug impossible to
  * reintroduce silently.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { FORM_FIELD_TYPES } from '@object-ui/fields';
-import type { ActionParamDef } from '@object-ui/core';
+import { EXPANDABLE_FIELD_TYPES, type ActionParamDef } from '@object-ui/core';
 import { paramToField, resolveParamWidgetType } from './paramToField';
 
 const p = (over: Partial<ActionParamDef>): ActionParamDef => ({
@@ -25,6 +25,13 @@ const p = (over: Partial<ActionParamDef>): ActionParamDef => ({
   label: 'X',
   type: 'text',
   ...over,
+});
+
+afterEach(() => {
+  // The identity pins below install a spy on the Set object EXPORTED by core —
+  // a shared, module-level object. A leaked spy would follow every later file
+  // in the worker, so restoring is not optional here.
+  vi.restoreAllMocks();
 });
 
 describe('param widget support ⊇ form widget support (drift guard)', () => {
@@ -151,5 +158,105 @@ describe('paramToField', () => {
 
   it('user params keep their picker without needing referenceTo (implicit sys_user)', () => {
     expect(paramToField(p({ type: 'user' }))).toMatchObject({ type: 'user' });
+  });
+});
+/**
+ * The reference-bearing rule is core's object, not a copy (objectui#5312).
+ *
+ * This module held the FOURTH and last hand-maintained answer to one question —
+ * "does this widget resolve a foreign key, so hand it the reference target?" —
+ * as the inline disjunction `LOOKUP_WIDGET_TYPES.has(type) || type === 'user'`.
+ * The other three converged on `@object-ui/core`'s `EXPANDABLE_FIELD_TYPES` in
+ * objectui#4770 / #4790 / #4815.
+ *
+ * Every membership assertion in this file is satisfied by a private
+ * `new Set(['lookup', 'master_detail', 'user', 'tree'])` holding the same
+ * strings — i.e. by the exact state this change removed. So the load-bearing
+ * pin below is on OBJECT IDENTITY (a spy on core's `has`), not on members.
+ */
+describe("the reference-bearing rule is core's object, not a copy (objectui#5312)", () => {
+  it('asks `@object-ui/core` EXPANDABLE_FIELD_TYPES which params carry a reference target', () => {
+    // The spy is installed on the Set exported by core and records a call only
+    // if THIS module consulted THAT object. A member-identical private copy
+    // leaves it empty, so this fails where a value check would pass.
+    const spy = vi.spyOn(EXPANDABLE_FIELD_TYPES, 'has');
+    try {
+      expect(paramToField(p({ type: 'user' }))).toMatchObject({ type: 'user' });
+      expect(spy.mock.calls.map(([k]) => k)).toContain('user');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('reaches that object on the lookup path too, not just the person path', () => {
+    // `user` and `lookup` enter the branch by different routes (the degrade
+    // rule above runs first and only for `lookup` / `master_detail`), so a
+    // convergence that reconnected one route would leave the other forked.
+    const spy = vi.spyOn(EXPANDABLE_FIELD_TYPES, 'has');
+    try {
+      paramToField(p({ type: 'lookup', referenceTo: 'accounts' }));
+      expect(spy.mock.calls.map(([k]) => k)).toContain('lookup');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // Behaviour equivalence with the literal this replaced, stated as the literal
+  // itself rather than as prose: the retired inline rule matched exactly these
+  // three widget keys.
+  const RETIRED_INLINE_MEMBERS = ['lookup', 'master_detail', 'user'];
+
+  it('still hands the reference config to every member of the literal it replaced', () => {
+    for (const type of RETIRED_INLINE_MEMBERS) {
+      expect(
+        paramToField(p({ type, referenceTo: 'accounts', displayField: 'name' })),
+        `'${type}' lost its reference config in the convergence`,
+      ).toMatchObject({ type, reference_to: 'accounts', display_field: 'name' });
+    }
+    expect(RETIRED_INLINE_MEMBERS.filter((t) => !EXPANDABLE_FIELD_TYPES.has(t))).toEqual([]);
+  });
+
+  it('adds exactly one member, and that member is unreachable on this surface', () => {
+    // Why converging cost no behaviour change: the shared set is one member
+    // wider, and that member can never BE a widget key here — `tree` is absent
+    // from `fields`' widget map and `mapFieldTypeToFormType` sends it to
+    // `field:lookup`, so every key tested by the rule (always
+    // `resolveParamWidgetType` output) arrives as `lookup`. If someone
+    // registers a real `tree` widget this flips and `tree` starts matching the
+    // rule here — a behaviour change that would otherwise arrive silently.
+    const added = [...EXPANDABLE_FIELD_TYPES].filter((t) => !RETIRED_INLINE_MEMBERS.includes(t));
+    expect(added).toEqual(['tree']);
+    expect(resolveParamWidgetType('tree')).toBe('lookup');
+  });
+
+  it('holds every core member under the normalization this surface applies', () => {
+    // The shared set is defined over SCHEMA types; this surface tests WIDGET
+    // keys (`resolveParamWidgetType` output). Reading one with the other is
+    // only safe while the family is closed under that resolution — every member
+    // resolves to a member. A future core member resolving to `text` here would
+    // be a schema-declared reference field silently rendered as a plain input
+    // with no target, so it fails loudly instead.
+    for (const type of EXPANDABLE_FIELD_TYPES) {
+      const widgetKey = resolveParamWidgetType(type);
+      expect(
+        EXPANDABLE_FIELD_TYPES.has(widgetKey),
+        `core member '${type}' resolves to '${widgetKey}', which is outside the family`,
+      ).toBe(true);
+    }
+  });
+
+  it('keeps the target-required rule SEPARATE from the reference-bearing rule', () => {
+    // The two rules are different sets over overlapping types and must not be
+    // folded together: `user` is reference-bearing but defaults its target to
+    // `sys_user`, so it must never degrade for want of `referenceTo`; `lookup`
+    // and `master_detail` must. Merging them would either strip the person
+    // picker or stop degrading targetless record pickers.
+    expect(paramToField(p({ type: 'user' }))).toMatchObject({ type: 'user' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(paramToField(p({ type: 'master_detail' }))).toMatchObject({ type: 'text' });
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/app-shell/src/utils/paramToField.ts
+++ b/packages/app-shell/src/utils/paramToField.ts
@@ -12,7 +12,7 @@
  * render tree (mirrors `filterVisibleParams`' style), with a drift test
  * asserting param support ⊇ form support.
  */
-import type { ActionParamDef } from '@object-ui/core';
+import { EXPANDABLE_FIELD_TYPES, type ActionParamDef } from '@object-ui/core';
 import { resolveFormWidgetType } from '@object-ui/fields';
 
 /**
@@ -40,7 +40,17 @@ export function resolveParamWidgetType(paramType: string): string {
   return resolveFormWidgetType(PARAM_TYPE_ALIASES[paramType] ?? paramType);
 }
 
-/** Widget keys that render the record-picker family and need a reference target. */
+/**
+ * Widget keys whose picker cannot query without an explicitly DECLARED target,
+ * so a param of that type with no `referenceTo` degrades to a plain text input.
+ *
+ * Deliberately NOT the reference-bearing family (`EXPANDABLE_FIELD_TYPES`, read
+ * below): `user` belongs to that family but defaults its target to `sys_user`,
+ * so it must never degrade. Two rules over overlapping types, kept separate —
+ * the same split the twin keeps between its own `LOOKUP_WIDGET_TYPES` and
+ * `widgetNeedsDataSource` (plugin-grid's `bulkParamToField`). objectui#5312
+ * converged the second rule only, on purpose.
+ */
 const LOOKUP_WIDGET_TYPES = new Set(['lookup', 'master_detail']);
 
 /**
@@ -91,10 +101,35 @@ export function paramToField(param: ActionParamDef): Record<string, any> {
     field.widget = 'checkbox';
   }
 
-  // `|| type === 'owner'` stood here until objectui#4814 retired that spelling
-  // (ruling A′). It moves in lockstep with plugin-grid's `bulkParamToField`
-  // twin — the two param faces are never split.
-  if (LOOKUP_WIDGET_TYPES.has(type) || type === 'user') {
+  // Which widgets carry a reference target is NOT restated here: it is
+  // `EXPANDABLE_FIELD_TYPES` from `@object-ui/core`, the one relational-field
+  // family that `buildExpandFields`, the predicate-record projection, the object
+  // form's `needsDataSourceWiring` and the grid's `bulkParamToField` already
+  // read (objectui#4770 / #4790 / #4815). This face held the fourth and last
+  // private copy of it — `LOOKUP_WIDGET_TYPES.has(type) || type === 'user'`,
+  // once with a fifth spelling `owner` that objectui#4814 retired (ruling A′).
+  //
+  // The comment that stood here claimed the disjunction "moves in lockstep with
+  // plugin-grid's `bulkParamToField` twin — the two param faces are never
+  // split". Measured on the tip before this change, that was false in BOTH
+  // senses: mechanically, the twin had read core's Set since objectui#4815 while
+  // this line read a private literal, so the two faces shared nothing and no
+  // gate could report a split; and by membership they already differed, by
+  // `tree`. Lockstep is true again — and for the first time it is mechanical,
+  // not hand-kept: the identity pin in `paramToField.test.ts` fails on a
+  // member-identical private copy, which is what a value check would not.
+  //
+  // `tree` is the member this face gains, and it is unreachable here: it is
+  // absent from `fields`' widget map and `mapFieldTypeToFormType` sends it to
+  // `field:lookup`, so every key tested here — always `resolveParamWidgetType`
+  // output — arrives as `lookup`. Pinned, so registering a real `tree` widget
+  // surfaces that behaviour change instead of shipping it silently.
+  //
+  // Extending this surface later: OR in a second, surface-local set, the way
+  // `needsDataSourceWiring` does. Never `new Set([...EXPANDABLE_FIELD_TYPES, …])`
+  // — a copy re-forks the table, which is the defect this change removed, and
+  // the identity pin fails on it by design.
+  if (EXPANDABLE_FIELD_TYPES.has(type)) {
     Object.assign(field, {
       reference_to: param.referenceTo,
       display_field: param.displayField,


### PR DESCRIPTION
Fixes #5312

`packages/app-shell/src/utils/paramToField.ts` restated the reference-bearing rule inline as `LOOKUP_WIDGET_TYPES.has(type) || type === 'user'` — the **fourth and last** hand-maintained answer to one question: *does this widget resolve a foreign key, so hand it `reference_to` / `display_field` / the rest of the picker config?* The other three converged on `@object-ui/core`'s `EXPANDABLE_FIELD_TYPES` in #4770 / #4790 / #4815. This face now does too.

## The comment was a claim to test, not a fact to inherit — and it was false

The disjunction carried this in-source comment:

> It moves in lockstep with plugin-grid's `bulkParamToField` twin — the two param faces are never split.

**Measured on the tip (`aa3b81062`) before touching anything. It was false in both senses:**

| | `paramToField` (this file, before) | `bulkParamToField` (the twin) |
|---|---|---|
| what the rule reads | private literal `new Set(['lookup','master_detail'])` `\|\|` `type === 'user'` | `EXPANDABLE_FIELD_TYPES.has(t)` — core's exported object, since #4815 |
| member set | `{lookup, master_detail, user}` | `{lookup, master_detail, tree, user}` |
| gate that could report a split | none | identity pin (`bulkParamToField.test.ts:137`) |

1. **Mechanically split.** The twin has read core's `Set` since #4815; this line read a private literal. The two faces shared no object, so "lockstep" was hand-kept — and nothing anywhere could report a divergence.
2. **Already split by membership**, by exactly one member: `tree`.

So the comment described a guarantee that had stopped existing. It is replaced with what was measured, and lockstep now holds *mechanically* rather than by assertion.

## What changed

- The rule is now `EXPANDABLE_FIELD_TYPES.has(type)` — core's object, read, never copied.
- The comment is replaced with the measurement above, plus the reachability argument and the "OR in a surface-local set, never `new Set([...EXPANDABLE_FIELD_TYPES, …])`" extension note the twin carries.
- **The module's *second* rule is deliberately left un-merged.** `LOOKUP_WIDGET_TYPES` still answers a different question — *which keys degrade to a text input for want of a declared `referenceTo`* — over an overlapping but different set: `user` is reference-bearing yet defaults its target to `sys_user`, so it must never degrade. Its docblock now says so explicitly. Same split the twin keeps between its own `LOOKUP_WIDGET_TYPES` and `widgetNeedsDataSource`.

## No reachable behaviour change

The derived set is one member wider (`tree`), and that member can never *be* a widget key here: it is absent from `fields`' widget map and `mapFieldTypeToFormType` sends it to `field:lookup`, so every key the rule tests — always `resolveParamWidgetType` output — arrives as `lookup`. Both halves are pinned, so registering a real `tree` widget surfaces the change instead of shipping it silently.

## Pins, and the ablation legs that prove each can fail

Pinned by **identity**, not membership: every membership assertion in the file is satisfied by a member-identical private copy — i.e. by the exact state this PR removes — so a value check would have passed *on the defect*.

Each control got its own mutation leg. Every leg asserted its anchor count non-zero **before** mutating, then proved the mutation reached disk in both directions (removed-text count **and** injected-text count **and** the file's `git hash-object`), and restored under an `EXIT`/`INT`/`TERM` trap. No rebuild was needed and none was skipped: the test imports `./paramToField` relatively and `@object-ui/core` through the repo-root vitest alias to `packages/core/src`, so both legs read source, never a `dist/` artefact. (The green identity pin is itself the proof that test and module resolve to one `@object-ui/core` instance — a split resolution would leave the spy empty.)

| leg | mutation | expected | measured |
|---|---|---|---|
| A | rule → member-identical private copy `new Set(['lookup','master_detail','tree','user'])` | identity pins red, membership green | **2 failed / 15 passed** — exactly the two identity pins |
| B | rule → `EXPANDABLE_FIELD_TYPES.has(type) && type !== 'user'` | equivalence-with-the-retired-literal probe red | **1 failed / 16 passed** — that probe alone |
| C | alias `tree: 'user'`, so `resolveParamWidgetType('tree') !== 'lookup'` | `tree`-unreachability probe red | **2 failed / 15 passed** — that probe + the pre-existing `:51` assertion of the same fact |
| D | merge the two rules (degrade rule → `EXPANDABLE_FIELD_TYPES`) | separation probe red | **3 failed / 14 passed** — the separation probe, the pre-existing implicit-`sys_user` test, and the identity pin (merging degrades `user` to text before the branch is reached, so the spy never sees `'user'`) |

Leg A is the load-bearing one: it is the defect this PR removes, and only the identity pins notice it.

Leg C mutated by **insertion**, not replacement, so its removed-text anchor stayed at 1 by construction; the injected-text count went 1 → 2 and the file hash changed. Recorded as measured rather than smoothed into the table's shape.

All four legs restored to the pristine blob `b3e8a51a`, verified by hash after each leg and once more by the trap.

## Verification — all at `7784e137e`

**Test scope is a derived superset, not a sample.** `packages/app-shell` has ~488 test files and its full suite exceeds the container's foreground cap. Both changed files are side-effect-free ES modules and vitest isolates the module graph per test file, so a test whose **static import graph never reaches a changed file cannot observe this change** — there is no other channel (no global written, no registry mutated, no generated artefact). The reverse import closure of the two changed files is therefore a superset of "tests this change can affect". It was over-approximated three further ways so the answer only ever grows: specifiers resolved extension- and index-agnostically, every existing candidate path counted as an edge, and bare `@object-ui/*` specifiers resolved through the vitest alias table (which is what pulls the whole `apps/console` project in, via the `app-shell` barrel).

**105 test files — 67 in `packages/app-shell`, 38 in `apps/console`. 1127 tests, 0 failures.** Run from the repo root (package-cwd vitest is refused by the repo's own guard), paced into nine batches because a single 67-file invocation was SIGTERM'd at the cap with a buffered reporter that had written *nothing* — the batches use a streaming reporter so a cap kill can never again cost the findings. Each superset file was confirmed to have actually executed by diffing the TAP file names against the derived list (the `apps/console` project reports paths relative to its own root, so the two lists only reconcile after normalising that prefix — the first comparison "found" 38 missing files that had all run).

| gate | result |
|---|---|
| 105-file derived superset | `Tests 1127 passed, 0 failed` |
| `pnpm --filter @object-ui/app-shell type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`, both echoed — not a zero-match no-op) |
| `pnpm --filter @object-ui/app-shell lint` | exit 0 |
| `check-changeset-presence` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` / `check-changeset-no-major` | `✅ All workspace packages are in the changeset fixed group.` / `✅ No changeset declares a major bump.` |
| `check-control-bytes` | `✅ OK (scanned 4695 tracked text file(s); skipped 85 binary)` |
| `check-package-self-import` | `✅ No package names itself inside its own src/.` |
| `check-phantom-dependencies` | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check-spec-symbol-derivation` | `✅ 1290 files scanned against 4912 spec export names` |
| `check-lint-coverage` | `✅ 46/46 packages linted, 0 with outstanding errors (0 total)` |
| `check-type-check-coverage` | `✅ 45/46 via type-check … ✅ 41/41 packages compile their tests` |

Recorded because it looks like a discrepancy and is not: an ad-hoc `eslint packages/app-shell --no-inline-config` from the repo root reports 15 errors across 920 files, while the gate (`turbo run lint` → per-package `eslint .`) reports 0. The difference is `--no-inline-config` stripping pre-existing `eslint-disable` comments in 13 files this PR does not touch (12 × `react-hooks/static-components`, plus one `no-unused-expressions` and one `no-console`). None are in the changed files, and `check-lint-coverage` independently reports 0 outstanding errors repo-wide.

The two `@typescript-eslint/no-explicit-any` warnings on the changed file are pre-existing: linting the base blob through stdin reproduces both at the pre-shift line numbers (`63`/`76` → `73`/`86`).

## Scope

The root barrel was **not** needed and is untouched (`packages/app-shell/src/index.ts` does not re-export this module, the rule is read inline rather than through a new export, and the pin test imports `./paramToField` relatively) — so no serialisation against #5596 is required. `packages/app-shell/src/views/metadata-admin/**` is untouched; its tests were only *run*, as part of the derived superset.

One out-of-scope finding filed, not fixed here: **#5654** — `ActionParamDialog`'s `isLookupParam` restates the picker family over *raw* param spellings (`{lookup, reference}`) while the module that performs the degradation tests *resolved widget keys* (`{lookup, master_detail}`). The two sets are not in a subset relation either way, and the measured consequence is that a targetless `master_detail` param degrades to a text input but gets neither the placeholder nor the help text #3405 added for that state. It is a different rule with no authority to derive from, and repairing it changes behaviour — so it is a separate card, not a rider.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_