### PR TITLE
Retire the inert register-meta key `defaultChildren` (#5051)

### DIFF
--- a/.changeset/default-children-retired-5051.md
+++ b/.changeset/default-children-retired-5051.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/types': minor
+'@object-ui/core': minor
+'@object-ui/components': minor
+---
+
+The register-meta key `defaultChildren` is retired (objectui#5051).
+
+It was declared in four places, produced in eleven, and read in **none**. The designer's
+drop path builds a new node from its twin key only — `PageDesigner.tsx`,
+`props: paletteItem?.defaultProps ?? {}` — with no `children:` line, so a palette item
+that declared `defaultChildren` dropped an **empty** node and the declared children never
+materialised. Nothing rendered the wrong thing; an entire declaration surface was simply
+inert, which is the declared-but-unenforced shape ADR-0049 targets. Per the maintainer
+ruling of 2026-08-19, the key is removed rather than wired up; if designer
+default-children UX is ever product-wanted it returns as its own designed card.
+
+**If you author plugins against the published register-meta table, drop the key.** It is
+gone from `skills/objectui/guides/plugin-development.md`, which had been teaching it. A
+meta that still declares it stays *valid*: `ComponentMetaSchema` is a plain `z.object`,
+and measured on zod 4.4.3 that STRIPS unknown keys rather than rejecting them — so the
+key is silently dropped from the parse output instead of failing validation. TypeScript
+authors get the loud signal instead: all three `ComponentMeta` declarations
+(`@object-ui/types` `base.ts` and `plugin-scope.ts`, `@object-ui/core` `Registry.ts`) no
+longer offer it, so re-declaring it is now a compile error.
+
+**No runtime behaviour changes in either direction.** No code path read the key before
+this change, and the eleven producers that set it (`sidebar.tsx` x10, `span.tsx`) were
+feeding a reader that did not exist. Dropping a `span` or any of the ten sidebar types
+into the designer produces exactly the node it produced yesterday.
+
+Two suites keep it retired, one per package: `packages/types` pins the zod twin (the key
+is absent from the parse output, with a surviving sibling asserted present through the
+same parse as the control) plus the two TS twins with `@ts-expect-error`, and
+`packages/core` pins the registration surface the eleven producers were written against.
+Both are compile-time-enforced through each package's chained `tsconfig.test.json`.

--- a/packages/components/src/renderers/basic/span.tsx
+++ b/packages/components/src/renderers/basic/span.tsx
@@ -156,9 +156,6 @@ ComponentRegistry.register('span',
     ],
     defaultProps: {
       className: 'px-1.5 py-0.5 sm:px-2 sm:py-1'
-    },
-    defaultChildren: [
-      { type: 'text', content: 'Inline text' }
-    ]
+    }
   }
 );

--- a/packages/components/src/renderers/navigation/sidebar.tsx
+++ b/packages/components/src/renderers/navigation/sidebar.tsx
@@ -49,11 +49,7 @@ ComponentRegistry.register('sidebar-provider',
     ],
     defaultProps: {
       defaultOpen: true
-    },
-    defaultChildren: [
-      { type: 'sidebar' },
-      { type: 'sidebar-inset' }
-    ]
+    }
   }
 );
 
@@ -73,12 +69,7 @@ ComponentRegistry.register('sidebar',
       collapsible: 'icon',
       side: 'left',
       variant: 'sidebar'
-    },
-    defaultChildren: [
-      { type: 'sidebar-header' },
-      { type: 'sidebar-content' },
-      { type: 'sidebar-footer' }
-    ]
+    }
   }
 );
 
@@ -88,10 +79,7 @@ ComponentRegistry.register('sidebar-header',
   ),
   { 
     namespace: 'ui',
-    label: 'Sidebar Header',
-    defaultChildren: [
-      { type: 'text', content: 'Sidebar Header' }
-    ]
+    label: 'Sidebar Header'
   }
 );
 
@@ -101,10 +89,7 @@ ComponentRegistry.register('sidebar-content',
   ),
   { 
     namespace: 'ui',
-    label: 'Sidebar Content',
-    defaultChildren: [
-      { type: 'sidebar-group' }
-    ]
+    label: 'Sidebar Content'
   }
 );
 
@@ -136,10 +121,7 @@ ComponentRegistry.register('sidebar-group',
     ],
     defaultProps: {
       label: 'Menu'
-    },
-    defaultChildren: [
-      { type: 'sidebar-menu' }
-    ]
+    }
   }
 );
 
@@ -149,11 +131,7 @@ ComponentRegistry.register('sidebar-menu',
   ),
   { 
     namespace: 'ui',
-    label: 'Sidebar Menu',
-    defaultChildren: [
-      { type: 'sidebar-menu-item' },
-      { type: 'sidebar-menu-item' }
-    ]
+    label: 'Sidebar Menu'
   }
 );
 
@@ -163,10 +141,7 @@ ComponentRegistry.register('sidebar-menu-item',
   ),
   { 
     namespace: 'ui',
-    label: 'Sidebar Menu Item',
-    defaultChildren: [
-      { type: 'sidebar-menu-button' }
-    ]
+    label: 'Sidebar Menu Item'
   }
 );
 
@@ -186,10 +161,7 @@ ComponentRegistry.register('sidebar-menu-button',
     ],
     defaultProps: {
       size: 'default'
-    },
-    defaultChildren: [
-      { type: 'text', content: 'Menu Item' }
-    ]
+    }
   }
 );
 
@@ -199,10 +171,7 @@ ComponentRegistry.register('sidebar-footer',
   ),
   { 
     namespace: 'ui',
-    label: 'Sidebar Footer',
-    defaultChildren: [
-      { type: 'text', content: 'Footer' }
-    ]
+    label: 'Sidebar Footer'
   }
 );
 
@@ -212,10 +181,7 @@ ComponentRegistry.register('sidebar-inset',
   ),
   { 
     namespace: 'ui',
-    label: 'Sidebar Inset',
-    defaultChildren: [
-      { type: 'div', className: 'p-4', body: [{ type: 'text', content: 'Main content area' }] }
-    ]
+    label: 'Sidebar Inset'
   }
 );
 

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -7,7 +7,6 @@
  */
 
 import type { ComponentInputControlType } from '@object-ui/types';
-import type { SchemaNode } from '../types/index.js';
 import { PUBLIC_BLOCKS } from './public-blocks.js';
 
 export type ComponentRenderer<T = any> = T;
@@ -103,7 +102,6 @@ export type ComponentMeta = {
   labelling?: 'control' | 'group' | 'display';
   inputs?: ComponentInput[];
   defaultProps?: Record<string, any>; // Default props when dropped
-  defaultChildren?: SchemaNode[]; // Default children when dropped
   examples?: Record<string, any>; // Example configurations
   isContainer?: boolean; // Whether the component can have children
   resizable?: boolean; // Whether the component can be resized in the designer

--- a/packages/core/src/registry/__tests__/default-children-retired.test.ts
+++ b/packages/core/src/registry/__tests__/default-children-retired.test.ts
@@ -1,0 +1,59 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — the fourth declaration twin of the register-meta key
+ * `defaultChildren` (objectui#5051, ADR-0049 enforce-or-remove; maintainer
+ * ruling of 2026-08-19 adopted option B, "retire the key everywhere").
+ *
+ * `ComponentMeta` here is the registration surface every `ComponentRegistry.register`
+ * call is checked against, so it is the twin a producer would re-grow the key
+ * through: the eleven producers retired alongside it (`sidebar.tsx` x10,
+ * `span.tsx`) were all written against THIS type. Its three siblings — the two
+ * `ComponentMeta` interfaces and the `ComponentMetaSchema` validator in
+ * `@object-ui/types` — are pinned in that package.
+ *
+ * This is a COMPILE-TIME pin only, and deliberately claims nothing at runtime.
+ * The registry does not validate meta: it stores what a caller hands it, so a
+ * caller casting through `any` could still park the key on a config object at
+ * runtime and no assertion here could see it. `@ts-expect-error` is real
+ * enforcement because `packages/core/tsconfig.test.json` is chained from this
+ * package's `type-check` script (objectui#3009), which is what CI's Type Check
+ * job runs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ComponentMeta } from '../Registry';
+
+describe('ComponentMeta (core registry) — the retired key is gone from the registration surface', () => {
+  it('rejects `defaultChildren` at compile time', () => {
+    const retired: ComponentMeta = {
+      label: 'Inline Container',
+      // @ts-expect-error `defaultChildren` was retired by objectui#5051 — the
+      // designer's drop path reads `defaultProps` only, so the declared default
+      // children never materialised. Re-declaring it here re-opens the
+      // declared-but-unenforced gap ADR-0049 targets.
+      defaultChildren: [{ type: 'text', content: 'Inline text' }],
+    };
+    // Referenced so the binding is not merely unused — the `@ts-expect-error`
+    // above is the actual assertion.
+    expect(retired.label).toBe('Inline Container');
+  });
+
+  it('still offers the twin the designer actually reads', () => {
+    // Positive control: the surface is not simply refusing everything. This is
+    // the key `PageDesigner` consumes on drop, and it is untouched by #5051.
+    const legal: ComponentMeta = {
+      label: 'Inline Container',
+      defaultProps: { className: 'px-1.5 py-0.5' },
+      isContainer: true,
+    };
+    expect(legal.defaultProps).toEqual({ className: 'px-1.5 py-0.5' });
+    expect(legal.isContainer).toBe(true);
+  });
+});

--- a/packages/types/src/__tests__/default-children-retired-contract-twins.test.ts
+++ b/packages/types/src/__tests__/default-children-retired-contract-twins.test.ts
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — the register-meta key `defaultChildren` (objectui#5051,
+ * ADR-0049 enforce-or-remove; maintainer ruling of 2026-08-19 adopted option B,
+ * "retire the key everywhere").
+ *
+ * The key was declared in four places, produced in eleven, and read in NONE.
+ * The designer drag-and-drop path builds a dropped node from its twin key only
+ * (`PageDesigner.tsx`, `props: paletteItem?.defaultProps ?? {}`), with no
+ * `children:` line — so a palette item that declared `defaultChildren` dropped
+ * an empty node and the declaration never materialised. This package holds two
+ * of the four declaration twins plus the runtime one:
+ *
+ *  1. `ComponentMetaSchema` (`zod/base.zod.ts`) — the runtime validator.
+ *  2. `ComponentMeta` (`base.ts`) — the published `.d.ts` autocomplete surface,
+ *     i.e. what a plugin author (or an AI author) copies from.
+ *  3. `ComponentMeta` (`plugin-scope.ts`) — its plugin-facing twin, which spelt
+ *     the same key `any[]`.
+ *
+ * The Registry twin (`@object-ui/core`) is pinned in that package instead, so
+ * this suite does not have to import its own dependent.
+ *
+ * Two kinds of assertion, deliberately different because the surfaces differ:
+ *
+ * The Zod half is NOT a refusal. Measured on zod 4.4.3, a `z.object` STRIPS
+ * unknown keys rather than rejecting them, and `ComponentMetaSchema` is a plain
+ * `z.object` with no `.strict()`. So the honest pin is that the key is silently
+ * DROPPED from the parse output — which is precisely the behaviour the ruling's
+ * confidence-gap note called out for external authors who already declare it.
+ * Asserting a rejection here would pin a verdict this validator never emits.
+ *
+ * That "absent from the output" assertion is worthless on its own — a schema
+ * that stripped EVERYTHING would satisfy it — so each case carries its own
+ * positive control: a surviving sibling key asserted PRESENT in the same parse
+ * output, through the same call.
+ *
+ * The two TS halves erase at runtime, so they are pinned with
+ * `@ts-expect-error`, which is real enforcement only because
+ * `packages/types/tsconfig.test.json` is chained from this package's
+ * `type-check` script (#3009).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentMetaSchema } from '../zod/base.zod.js';
+import type { ComponentMeta } from '../base.js';
+import type { ComponentMeta as PluginScopeComponentMeta } from '../plugin-scope.js';
+
+/** The retired key, and the twin the designer actually reads. */
+const RETIRED = 'defaultChildren';
+const SURVIVOR = 'defaultProps';
+
+describe('ComponentMetaSchema — the runtime twin no longer carries the retired key', () => {
+  it('drops an authored `defaultChildren` from the parse output, while carrying its surviving twin through the same parse', () => {
+    const result = ComponentMetaSchema.safeParse({
+      label: 'Inline Container',
+      defaultProps: { className: 'px-1.5' },
+      defaultChildren: [{ type: 'text', content: 'Inline text' }],
+    });
+
+    // Not a refusal: the schema strips, so an author who still declares the key
+    // keeps a VALID meta. The retirement is that the key stops travelling.
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data).not.toHaveProperty(RETIRED);
+
+    // Positive control, same parse, same call: the schema is still capable of
+    // carrying a key through. Without this, a schema that dropped every key
+    // would pass the assertion above.
+    expect(result.data).toHaveProperty(SURVIVOR);
+    expect(result.data.defaultProps).toEqual({ className: 'px-1.5' });
+  });
+
+  it('shrank by exactly one member — the sibling meta vocabulary still round-trips', () => {
+    // Guards the removal from over-reaching: a hand-edited schema that dropped
+    // a neighbour would otherwise pass every assertion above.
+    const result = ComponentMetaSchema.safeParse({
+      label: 'Sidebar',
+      icon: 'panel-left',
+      category: 'Navigation',
+      defaultProps: { collapsible: 'icon' },
+      examples: { basic: {} },
+      isContainer: true,
+      resizable: true,
+      tags: ['navigation'],
+      description: 'A sidebar',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    for (const key of [
+      'label',
+      'icon',
+      'category',
+      'defaultProps',
+      'examples',
+      'isContainer',
+      'resizable',
+      'tags',
+      'description',
+    ]) {
+      expect(result.data).toHaveProperty(key);
+    }
+  });
+});
+
+describe('the published TS twins no longer offer the retired key', () => {
+  it('`ComponentMeta` (base.ts) rejects it at compile time', () => {
+    const legal: ComponentMeta = { label: 'Span', defaultProps: { className: 'px-1' } };
+    expect(legal.defaultProps).toEqual({ className: 'px-1' });
+
+    const retired: ComponentMeta = {
+      label: 'Span',
+      // @ts-expect-error `defaultChildren` was retired by objectui#5051 — it had
+      // no consumer, so the declared default children never materialised on drop.
+      defaultChildren: [{ type: 'text', content: 'Inline text' }],
+    };
+    // Referenced so the binding is not merely unused — the `@ts-expect-error`
+    // above is the actual assertion, enforced by `tsconfig.test.json`.
+    expect(retired.label).toBe('Span');
+  });
+
+  it('`ComponentMeta` (plugin-scope.ts) rejects it at compile time', () => {
+    const legal: PluginScopeComponentMeta = { label: 'Span', defaultProps: { className: 'px-1' } };
+    expect(legal.defaultProps).toEqual({ className: 'px-1' });
+
+    const retired: PluginScopeComponentMeta = {
+      label: 'Span',
+      // @ts-expect-error `defaultChildren` was retired by objectui#5051; the
+      // plugin-facing twin spelt it `any[]` and is retired in lockstep.
+      defaultChildren: [{ type: 'text', content: 'Inline text' }],
+    };
+    expect(retired.label).toBe('Span');
+  });
+});

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -535,11 +535,6 @@ export interface ComponentMeta {
   defaultProps?: Record<string, any>;
 
   /**
-   * Default children for container components
-   */
-  defaultChildren?: SchemaNode[];
-
-  /**
    * Example configurations for documentation
    */
   examples?: Record<string, any>;

--- a/packages/types/src/plugin-scope.ts
+++ b/packages/types/src/plugin-scope.ts
@@ -152,7 +152,6 @@ export interface ComponentMeta {
   category?: string;
   inputs?: ComponentInput[];
   defaultProps?: Record<string, any>;
-  defaultChildren?: any[];
   examples?: Record<string, any>;
   isContainer?: boolean;
   resizable?: boolean;

--- a/packages/types/src/zod/base.zod.ts
+++ b/packages/types/src/zod/base.zod.ts
@@ -247,7 +247,6 @@ export const ComponentMetaSchema = z.object({
   category: z.string().optional().describe('Component category'),
   inputs: z.array(ComponentInputSchema).optional().describe('Configurable properties'),
   defaultProps: z.record(z.string(), z.any()).optional().describe('Default property values'),
-  defaultChildren: z.array(SchemaNodeSchema).optional().describe('Default children'),
   examples: z.record(z.string(), z.any()).optional().describe('Example configurations'),
   isContainer: z.boolean().optional().describe('Can have children'),
   resizable: z.boolean().optional().describe('Can be resized'),

--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -77,7 +77,6 @@ ComponentRegistry.register('my-widget', MyWidgetRenderer, {
 | `skipFallback` | `boolean` | Don't register non-namespaced fallback (prevents overwrites) |
 | `inputs` | `ComponentInput[]` | Schema inputs for designer |
 | `defaultProps` | `Record<string, any>` | Default properties |
-| `defaultChildren` | `SchemaNode[]` | Default child schema |
 | `isContainer` | `boolean` | Accepts child components |
 | `resizable` | `boolean` | Designer allows resizing |
 | `resizeConstraints` | `object` | Min/max width/height |


### PR DESCRIPTION
Fixes #5051

Retires the register-meta key `defaultChildren`, which was declared in four places, produced in eleven, and read in **none**.

## The fork was already decided — this PR executes the ruling

The card is explicitly a fork (retire the key vs. implement the consumer), and it is not a dev's to pick. It does not need picking: the maintainer ruled on it on 2026-08-19 (recorded in the issue thread, verbatim reply 「全部接受」), adopting **option B — retire the key everywhere**, including the row in the published plugin-author guide, per ADR-0049 enforce-or-remove. Option A (wiring `children: paletteItem?.defaultChildren ?? []` into the designer) was rejected "for now; if designer default-children UX is ever product-wanted it returns as its own designed card."

That ruling is also what clears the contract-change clause: removing a declared key from `@object-ui/types` / `@object-ui/core` is a contract decision, and an authority had already made it.

## Counts re-measured on the current tip, each with a positive control

A zero count is only evidence if the command is proven able to hit, so every sweep below was run through the identical pipeline as a control term known to resolve.

| Surface | At filing | Re-measured on `7e811687a` | Control |
| --- | --- | --- | --- |
| Declarations | 4 | **4** | `grep -cxF` on the literal `Registry.ts:106` line returns 1 |
| Producers | 11 | **11** (`sidebar.tsx` x10, `span.tsx` x1) | same pipeline hits all 11 |
| Consumers | 0 | **0** | identical pipeline finds 183 `defaultProps` hits, **including the consumer** `PageDesigner.tsx:173` |

The control is the load-bearing part: the same command that returns zero for `defaultChildren` returns the twin key's consumer, so the zero is absence, not a silently-zeroed pattern. Line numbers had drifted since filing (`types/base.ts` 508 to 540, `span.tsx` 138 to 160); the counts had not.

Consumption was checked beyond the literal spelling: no bracket access (`['defaultChildren']`), no case-variant spelling, and the drop path destructures `paletteItem` field by field (`defaultSize`, `defaultProps`) with no wholesale spread that could have carried the key into a node without naming it.

## What changed

- 4 declarations: `core/registry/Registry.ts`, `types/base.ts`, `types/plugin-scope.ts`, `types/zod/base.zod.ts` — plus the `SchemaNode` type import in `Registry.ts`, which the removed line was its only remaining user.
- 11 producers: `renderers/navigation/sidebar.tsx` x10, `renderers/basic/span.tsx` x1.
- The published guide row in `skills/objectui/guides/plugin-development.md`, in this same PR as the ruling requires.
- Two retirement pins plus a changeset.

**No runtime behaviour changes in either direction.** Nothing read the key before this change, so dropping a `span` or any of the ten sidebar types into the designer produces exactly the node it produced yesterday.

## Retirement pins

One per package, both compile-time-enforced through each package's chained `tsconfig.test.json`:

- `packages/types` — pins the zod twin and both TS twins.
- `packages/core` — pins the registration surface the eleven producers were written against.

The zod half asserts a **strip, not a refusal**. Measured on zod 4.4.3, a plain `z.object` strips unknown keys rather than rejecting them, and `ComponentMetaSchema` has no `.strict()`; so an external author who still declares the key keeps a valid meta and the key is silently dropped. Asserting a rejection would have pinned a verdict this validator never emits. That "absent from output" assertion carries its own in-test control — a surviving sibling key asserted **present** in the same parse output through the same call, since a schema that dropped everything would otherwise satisfy it.

## Verification, all on `de05aed4c`

Control probe on the pins, because a pin is only enforcement if it can turn red. Each leg re-declared the key, confirmed the mutation on disk **by re-reading the file anchored on the injected text** (not by trusting an editor exit code), then restored — with a restore trap, and the restore proven byte-identical to pristine:

```
=== LEG: @object-ui/types ===   post: injected-text=1 (re-read from disk)
  type-check EXIT=2   error TS2578: Unused '@ts-expect-error' directive.
  restored: byte-identical to pristine = true
=== LEG: @object-ui/core ===    post: injected-text=1 (re-read from disk)
  type-check EXIT=2   error TS2578: Unused '@ts-expect-error' directive.
  restored: byte-identical to pristine = true
```

An earlier attempt at this probe produced two void legs and is reported rather than buried: one wrote its log to a path containing a `/` from the package name, so the redirect failed and the non-zero status read back was bash's, not the type-checker's; the other used a `perl` replacement containing `//`, which terminated the regex and changed nothing. The on-disk anchor check caught the second as a no-op. Both were rerun as above.

Shipped bytes, with the type-only question settled rather than assumed: the `.d.ts` removals erase at runtime, and the one runtime-bearing removal in these packages is the zod mirror — `dist/zod/base.zod.js` now carries `defaultChildren` 0 times and `defaultProps` 1 time. Zero occurrences of the retired key across `types/dist` and `core/dist`, while the same grep still finds `defaultProps` in 8 dist files, so the sweep was capable of hitting.

- Builds: `@object-ui/core...` and `@object-ui/components^...` closures, exit 0.
- Type-check: `types`, `core`, `components` — all exit 0, script names echoed so a zero-match silent pass is ruled out.
- Tests: the two new suites 6/6; the affected components superset 12 files / 157 tests, the executed file count matching the derived set.
- Gates: `check-skills-paths`, `check-changeset-presence`, `check-changeset-no-major`, `check-type-check-coverage`, `check-doc-links`, `check-lint-coverage`, `check-package-self-import`, `check-control-bytes` — all exit 0, each captured before any pipe.
- Lint: a full-repo `eslint . --no-inline-config` covered 3516 files and my 8 changed source files carry **0 errors**. That run also reports 89 errors across 73 files, and those are **not** repo breakage: they are inline-suppressed and surface only because of `--no-inline-config`. The repo's actual lint is `turbo run lint` (per-package `eslint .`), which honours the suppressions — measured on one of them, `RouteFader.tsx` reports 1 error with the flag and 0 without. Zero overlap with this diff either way, and type-aware linting is not enabled (`tseslint.configs.recommended`, no `project`/`projectService`), so this diff cannot move an untouched file's verdict.

## Published `skills/` readings

A deletion, so both readings move down by one line.

- Changed file `plugin-development.md`: 427 to 426 lines.
- Whole published package (18 `.md` files under `skills/`): 5674 to 5673 lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_