### PR TITLE
fix(app-shell): overlay recovery strips a half-filled `between` (#5025)

### DIFF
--- a/.changeset/objectview-overlay-pair-completeness-5025.md
+++ b/.changeset/objectview-overlay-pair-completeness-5025.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`sanitizeViewOverride` now strips a half-filled `between` from a stored view
+overlay, instead of handing it back to the merge (objectui#5025,
+objectstack#8815).
+
+The overlay recovery pass asked "is this filter row filled in?" with the
+shape-blind predicate objectstack#8815 retired — `value == null || value === ''
+|| (Array.isArray(value) && value.length === 0)`. That is correct for `scalar`
+and `list` and blind to `pair`: a `between` carrying one bound is
+`['2024-01-01', '']`, an array of length 2, so the pass read it as a real
+condition and kept it. The two write paths (`plugin-list`'s `ListView` and
+app-shell's `viewFilterFold`) were converted to the builder's arity-aware
+`isFilterValueComplete`; this read path was the third verbatim copy, and the one
+whose job was to clean up exactly the rows the other two used to write. Until
+now a stored half-range survived the pass, reached the query, and the server
+refused the whole view (`400 INVALID_FILTER`) for every user on every later
+read.
+
+The pass now delegates to the same `isFilterValueComplete` the write paths use,
+on both of the at-rest shapes it handles (the spec `ViewFilterRule` object and
+the legacy runtime triple). A complete range — bounds of `0` and `false`
+included — is untouched, and the `scalar` and `list` families read exactly as
+before, since the retired predicate was already right for them. One shape is
+newly stripped beyond the half-filled array: a `between` whose value is a bare
+scalar, which `ViewFilterRuleSchema` itself refuses.
+
+Which operators want no value at all is unchanged and still answered by
+app-shell's `VALUELESS_FILTER_OPERATORS` — that set is already derived from the
+builder's `VALUELESS_FILTER_BUILDER_OPERATORS` rather than being a private copy,
+and its parity is pinned.

--- a/packages/app-shell/src/views/ObjectView.overlayPairValue.test.ts
+++ b/packages/app-shell/src/views/ObjectView.overlayPairValue.test.ts
@@ -1,0 +1,205 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5025 — the overlay RECOVERY pass must strip a half-filled `between`.
+ *
+ * The third site of objectstack#8815, and the one that matters most, because it
+ * is the pass that exists to CLEAN UP the shape the other two used to write.
+ * All three asked "is this filter row filled in?" with one shape-blind
+ * predicate:
+ *
+ * ```ts
+ * value == null || value === '' || (Array.isArray(value) && value.length === 0)
+ * ```
+ *
+ * Right for `scalar` and `list`, blind to `pair`. A `between` row with one bound
+ * typed is `['2024-01-01', '']` — an array of length 2 — so it read as a real
+ * condition. The two WRITE paths were converted (`plugin-list/src/ListView.tsx`,
+ * `views/viewFilterFold.ts`); `sanitizeViewOverride` kept the verbatim copy, so
+ * the read path handed the half-range straight back to the merge and the view
+ * went on being refused (`400 INVALID_FILTER`) for every user on every load.
+ *
+ * WHY THIS IS REACHABLE, not dead-but-misleading code — the question the card
+ * asked to measure first. Two independent producers, neither of them the
+ * converted builder:
+ *
+ *   1. Installs that ran a pre-conversion build. `foldFilterGroupToSpecRules`
+ *      persisted half-filled ranges into stored view bodies, and this pass is
+ *      documented as the recovery half for exactly that class of row — "an
+ *      install already carrying a poisoned row self-heals on the next load".
+ *      It self-healed every arity except the one the sibling issue was about.
+ *   2. Any producer that is not the builder — hand-authored view JSON, an
+ *      AI-authored metadata app, an import, a migration — because the SPEC
+ *      accepts the shape. Measured below rather than asserted from the
+ *      docstring: `ViewFilterRuleSchema` counts the two slots and does not ask
+ *      what is in them, so authoring validation is green on a half-filled range
+ *      and it only dies at query time. That makes this read-path pass the last
+ *      guard standing, not a tidy-up.
+ *
+ * SUITE DIRECTION — stated before running.
+ *
+ *   RED under the mutation leg that restores the old predicate at both branches
+ *   of `sanitizeViewOverride`: every case in the two `between` blocks below.
+ *   Those are the discriminating ones; each quotes a VALUE in its failure, not
+ *   an import.
+ *
+ *   GREEN under that same leg, by design: the whole `arities this change must
+ *   not touch` block (the old predicate is CORRECT for `scalar` and `list`, so
+ *   an assertion that passes on it there proves the change stayed scoped), plus
+ *   the spec-acceptance case, which is a fact about `@objectstack/spec` and
+ *   would pass in any world. It is recorded because it is the reason the pair
+ *   cases matter, and it is labelled non-discriminating so nobody later reads
+ *   it as a pin on OUR code.
+ *
+ *   Those controls are shown capable of failing by a SECOND leg (see the PR
+ *   body): making the sanitizer's predicate answer `false` unconditionally
+ *   turns the control block red while leaving the pair block green — the two
+ *   legs fail in disjoint directions, which is what makes each of them a
+ *   measurement rather than a decoration.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ViewFilterRuleSchema } from '@objectstack/spec/ui';
+import { sanitizeViewOverride } from './ObjectView';
+
+/** The source-declared body an overlay must not be able to poison or erase. */
+const SOURCE_VIEW = {
+    label: 'All work orders',
+    columns: ['name', 'declare_date'],
+    filter: [{ field: 'status', operator: 'not_in', value: ['archived', 'deleted'] }],
+};
+
+const overlay = (filter: unknown[]) => ({ name: 'wo.all', object: 'work_order', filter });
+
+describe('sanitizeViewOverride — a `between` needs both bounds (#5025)', () => {
+    it.each([
+        ['upper bound missing', ['2024-01-01', '']],
+        ['lower bound missing', ['', '2024-03-01']],
+        ['both bounds missing', ['', '']],
+        // Not an array at all. The spec REFUSES a scalar under `between`
+        // (measured in the block below), so the server would refuse it too —
+        // stripping it is the same judgement, one layer earlier.
+        ['a scalar where a range belongs', '2024-01-01'],
+    ])('drops the whole `filter` key when the only rule has %s', (_name, value) => {
+        const sanitized = sanitizeViewOverride(
+            overlay([{ field: 'declare_date', operator: 'between', value }]),
+        );
+        // The KEY, not an empty array: `{ ...source, ...override }` is key-wise,
+        // so `filter: []` would still blank the source declaration.
+        expect('filter' in sanitized).toBe(false);
+        expect({ ...SOURCE_VIEW, ...sanitized }.filter).toEqual(SOURCE_VIEW.filter);
+    });
+
+    it('drops it in the legacy runtime triple shape too', () => {
+        const sanitized = sanitizeViewOverride(
+            overlay([['declare_date', 'between', ['2024-01-01', '']]]),
+        );
+        expect('filter' in sanitized).toBe(false);
+    });
+
+    it('drops only the half-filled range, keeping the complete rules beside it', () => {
+        expect(
+            sanitizeViewOverride(
+                overlay([
+                    { field: 'stage', operator: 'equals', value: 'won' },
+                    { field: 'declare_date', operator: 'between', value: ['2024-01-01', ''] },
+                ]),
+            ).filter,
+        ).toEqual([{ field: 'stage', operator: 'equals', value: 'won' }]);
+    });
+});
+
+describe('sanitizeViewOverride — a complete `between` survives untouched (#5025)', () => {
+    it('keeps a range with both bounds, and returns the row by identity', () => {
+        const row = overlay([
+            { field: 'declare_date', operator: 'between', value: ['2024-01-01', '2024-03-01'] },
+        ]);
+        expect(sanitizeViewOverride(row)).toBe(row);
+    });
+
+    it('keeps a bound of 0 — a real bound on a number column (objectui#4873)', () => {
+        const row = overlay([{ field: 'amount', operator: 'between', value: [0, 100] }]);
+        expect(sanitizeViewOverride(row)).toBe(row);
+    });
+
+    it('keeps a bound of `false`, which `!bound` would have read as unfilled', () => {
+        const row = overlay([{ field: 'flag', operator: 'between', value: [false, true] }]);
+        expect(sanitizeViewOverride(row)).toBe(row);
+    });
+
+    it('keeps a complete range in the legacy runtime triple shape', () => {
+        const row = overlay([['declare_date', 'between', ['2024-01-01', '2024-03-01']]]);
+        expect(sanitizeViewOverride(row)).toBe(row);
+    });
+});
+
+describe('the arities this change must not touch (#5025)', () => {
+    // The retired predicate is CORRECT for `scalar` and `list`. These cases read
+    // identically before and after, and that is the point: a red here means the
+    // conversion reached past `pair`.
+    it('still drops an empty scalar and an empty list', () => {
+        expect(
+            sanitizeViewOverride(
+                overlay([
+                    { field: 'name', operator: 'equals', value: '' },
+                    { field: 'kind', operator: 'in', value: [] },
+                    { field: 'owner', operator: 'equals', value: null },
+                ]),
+            ).filter,
+        ).toBeUndefined();
+    });
+
+    it('still keeps a filled scalar and a non-empty list', () => {
+        const row = overlay([
+            { field: 'name', operator: 'equals', value: 'acme' },
+            { field: 'kind', operator: 'in', value: ['a'] },
+        ]);
+        expect(sanitizeViewOverride(row)).toBe(row);
+    });
+
+    it('still keeps a value-less operator whose value slot is empty', () => {
+        // Both dialects: the builder id and the canonical spec spelling this
+        // layer additionally sees.
+        const row = overlay([
+            { field: 'closed_at', operator: 'isEmpty', value: '' },
+            { field: 'owner', operator: 'is_null', value: '' },
+        ]);
+        expect(sanitizeViewOverride(row)).toBe(row);
+    });
+});
+
+describe('why the read path is the last guard (#5025)', () => {
+    // NON-DISCRIMINATING by construction: this asserts a fact about
+    // `@objectstack/spec`, not about `sanitizeViewOverride`, so it is green in
+    // every world. It is here because it is the reason the cases above are a
+    // bug fix rather than a tidy-up — authoring validation cannot catch this
+    // shape, so nothing upstream of the recovery pass will.
+    it('the spec ACCEPTS a half-filled range, so authoring validation lets it through', () => {
+        expect(
+            ViewFilterRuleSchema.safeParse({
+                field: 'declare_date',
+                operator: 'between',
+                value: ['2024-01-01', ''],
+            }).success,
+        ).toBe(true);
+    });
+
+    it('…while refusing the shapes that are merely malformed', () => {
+        for (const value of ['2024-01-01', ['2024-01-01']]) {
+            expect(
+                ViewFilterRuleSchema.safeParse({
+                    field: 'declare_date',
+                    operator: 'between',
+                    value,
+                }).success,
+                JSON.stringify(value),
+            ).toBe(false);
+        }
+    });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -35,6 +35,7 @@ import {
   EmptyTitle,
   EmptyDescription,
   NavigationOverlay,
+  isFilterValueComplete,
 } from '@object-ui/components';
 import { Plus, Upload, Star, StarOff, Table as TableIcon, KanbanSquare, Calendar, LayoutGrid, Activity, GanttChart, MapPin, BarChart3 } from 'lucide-react';
 import { useFavorites } from '../hooks/useFavorites.js';
@@ -325,6 +326,30 @@ export function defaultListColumnsFromObject(
  * objects (`{ field, operator, value }`, what the fold writes) and the legacy
  * runtime triple `[field, operator, value]` a source view may declare and which
  * `persistViewPatch` copies into the overlay along with the rest of the view.
+ *
+ * Whether a matched entry's VALUE counts as supplied is asked of the builder's
+ * own {@link isFilterValueComplete}, not of a local predicate (objectstack#8815,
+ * objectui#5025). This pass used to spell the question out here:
+ *
+ * ```ts
+ * value == null || value === '' || (Array.isArray(value) && value.length === 0)
+ * ```
+ *
+ * — right for `scalar` and `list`, blind to `pair`. A `between` carrying one
+ * bound is `['2024-01-01', '']`, an array of length 2, so the recovery pass read
+ * it as a real condition and handed it back. That is the one shape this pass
+ * most needs to strip: `ViewFilterRuleSchema` ACCEPTS a half-filled range
+ * (measured on `@objectstack/spec` 17.1.0 — it counts the two slots, not what is
+ * in them), so authoring validation is green on it and it only dies at query
+ * time, where the server refuses the WHOLE view (`400 INVALID_FILTER`) for every
+ * user on every later read. The builder's two write paths were converted to the
+ * arity-aware reading; this is the read-path half, and it was the third verbatim
+ * copy of a predicate that had already been indicted twice.
+ *
+ * The split of duties is the helper's own: it answers the VALUE question only,
+ * while which operators want no value at all stays with
+ * {@link VALUELESS_FILTER_OPERATORS} above — this layer additionally sees the
+ * canonical spec spellings (`is_null`) that never reach the dropdown.
  */
 export function sanitizeViewOverride(override: any): any {
     if (!override || typeof override !== 'object') return override;
@@ -348,13 +373,13 @@ export function sanitizeViewOverride(override: any): any {
             if (entry.length < 2) return false;
             const [, operator, value] = entry;
             if (VALUELESS_FILTER_OPERATORS.has(String(operator))) return true;
-            return !(value == null || value === '' || (Array.isArray(value) && value.length === 0));
+            return isFilterValueComplete(String(operator), value);
         }
         if (!entry || typeof entry !== 'object') return false;
         if (typeof entry.field !== 'string' || entry.field === '') return false;
         if (VALUELESS_FILTER_OPERATORS.has(String(entry.operator))) return true;
         const value = entry.value;
-        return !(value == null || value === '' || (Array.isArray(value) && value.length === 0));
+        return isFilterValueComplete(String(entry.operator), value);
     });
 
     // The empty-array case is checked FIRST: `filter: []` (Clear all's write)


### PR DESCRIPTION
Fixes #5025

`sanitizeViewOverride` in `packages/app-shell/src/views/ObjectView.tsx` carried the shape-blind emptiness predicate that objectstack#8815 / PR #4962 retired on the two builder write paths:

```ts
value == null || value === '' || (Array.isArray(value) && value.length === 0)
```

Correct for `scalar` and `list`, blind to `pair`. Both branches now delegate to the builder's arity-aware `isFilterValueComplete`.

## Reachability of the reuse target — the card's first question

**Verdict: reachable as a plain import, no widening. Nothing was exported to make this work.**

The chain, verified on the *built* type surface rather than on source (an unbuilt or stale `dist` lies in both directions):

| step | evidence |
|---|---|
| declared | `packages/components/src/custom/filter-builder.tsx:840` — `export function isFilterValueComplete` |
| barrel | `packages/components/src/custom/index.ts:10` → `packages/components/src/index.ts:75` (`export * from './custom'`) |
| built `.d.ts` | `packages/components/dist/custom/filter-builder.d.ts:399` — `export declare function isFilterValueComplete(...)`, reached from `dist/index.d.ts` via `custom/index.d.ts:10` |
| dependency edge | `@object-ui/components` is already `workspace:*` in `packages/app-shell/package.json` |
| precedent | `packages/app-shell/src/views/viewFilterFold.ts:34` — a sibling file **in the same directory** already imports the same symbol from the same entry |

So the import costs nothing new: no export added to a published entry, no new dependency edge, no local re-implementation. The added binding rides on the `@object-ui/components` import block ObjectView.tsx already had.

## Reachability of the defect shape — the issue's own open question

The issue asked to measure this first, and explicitly refused to call it a live bug until someone did. **Measured: live, not dead-but-misleading code.** Two producers, neither of them the converted builder:

1. **This pass is the recovery half for exactly this class of row.** Its own docstring says so: *"an install already carrying a poisoned row self-heals on the next load rather than needing a `sys_metadata` delete plus a service restart."* Pre-conversion builds persisted half-filled ranges through `foldFilterGroupToSpecRules`; the recovery pass self-healed every arity **except the one the sibling issue was about**.
2. **The spec accepts the shape**, so any non-builder producer — hand-authored view JSON, an AI-authored metadata app, an import, a migration — can mint it and pass authoring validation. Measured against `ViewFilterRuleSchema` from `@objectstack/spec` **17.1.0** (the version this tip resolves; the sibling docstrings still say 17.0.0):

   ```
   true   between ['2024-01-01', '']       half-filled: ACCEPTED
   true   between ['', '']
   true   between ['2024-01-01', '2024-03-01']
   false  between '2024-01-01'             scalar: refused
   false  between ['2024-01-01']           one element: refused
   ```

   It counts the two slots and does not ask what is in them. Authoring validation is green on precisely the shape that dies at query time, which leaves this read-path pass as the last guard standing.

Both branches of the pass are converted, because both at-rest shapes reach it: the spec `ViewFilterRule` object and the legacy runtime triple `[field, operator, value]` that `persistViewPatch` copies into an overlay along with the rest of the view.

## The cited line numbers, re-verified on the current tip

`main` @ `7e811687a`. #4962's two sites are **still converted**; one of the issue's three citations had drifted:

| site | issue says | actually | state |
|---|---|---|---|
| `packages/plugin-list/src/ListView.tsx` | `:414` | **`:477`** | converted ✅ |
| `packages/app-shell/src/views/viewFilterFold.ts` | `:109` | `:109` | converted ✅ |
| `packages/app-shell/src/views/ObjectView.tsx` | `:330–342` | **`:351` and `:357`** (pre-patch) | this PR |

After this change the only occurrence of the retired expression in those three files is the one quoted inside the new doc comment.

## One premise of the card corrected

The issue's ⭐ note — *"it also uses `VALUELESS_FILTER_OPERATORS`, **not** the builder's `VALUELESS_FILTER_BUILDER_OPERATORS` … so this surface already keeps its own copy of the operator vocabulary"* — **is stale, and no reconciliation was needed.** `viewFilterFold.ts:84` builds that set **from** the shared import (`...VALUELESS_FILTER_BUILDER_OPERATORS`) plus the canonical spec spellings (`is_null`) that only this layer sees, and `viewFilterFold.emptyValue.test.ts:143` already pins the parity. That is exactly the split `isFilterValueComplete`'s own docstring prescribes — the helper answers the VALUE question, each caller keeps its own operator vocabulary — so the operator half is left untouched deliberately, not overlooked.

## One shape newly stripped beyond the half-filled array

A `between` whose value is a bare scalar (`'2024-01-01'`) used to survive the pass and now does not. That is the same judgement one layer earlier: `ViewFilterRuleSchema` refuses it outright (measured above), so the server would too. Pinned as its own case.

## Measurement — four mutation legs, each restored by a `trap`

Every leg is `mutate → assert the mutation landed on disk (injected text AND removed text counted, with pristine counts asserted first) → run → restore`. The restore is armed **before** the mutation, as

```bash
trap 'git checkout HEAD -- "$FILE"' EXIT INT TERM
```

so a SIGTERM at the foreground cap cannot leave a mutated tree behind for later measurements to silently read. `git status --porcelain` was empty after each leg.

(Written that way on purpose: an earlier revision of this body spelled the trap's payload inside angle brackets and GitHub's body sanitizer ate the fragment **even inside backticks**, leaving a line that read as an empty trap.)

No rebuild step participates: `vitest.config.mts:264` aliases `@object-ui/components` to `packages/components/src`, and the mutated file is app-shell source, so every leg measures source directly.

**Predicted before running**, then measured — the two agreed:

| leg | mutation | result | reds |
|---|---|---|---|
| **A** | restore the retired predicate verbatim, both branches | **6 failed / 9 passed** | exactly the `pair` block |
| **B1** | value predicate always `false` | 6 failed / 9 passed | the four "complete range survives" controls, "keeps a filled scalar and a non-empty list", the mixed case |
| **B2** | value predicate always `true` | 7 failed / 8 passed | the `pair`-drop block **and** "still drops an empty scalar and an empty list" |
| **C** | remove the two `VALUELESS_FILTER_OPERATORS` early returns | 1 failed / 14 passed | exactly "still keeps a value-less operator whose value slot is empty" |

**Leg A is the one the card asked for.** Its six reds are the discriminating cases, and they fail on a VALUE rather than on an import — e.g.

```
AssertionError: expected [ { field: 'stage', …(2) }, …(1) ] to deeply equal [ { field: 'stage', …(2) } ]
```

Its **nine greens are the point**: the retired predicate is *correct* for `scalar` and `list`, so the whole `arities this change must not touch` block passing under leg A is what proves the conversion stayed scoped to `pair`. An assertion that discriminated there would mean the change had reached further.

Legs B1/B2/C exist because a control that passes in every world proves nothing. Each is scoped to the same function and turns a **different** control red, so every one of the 13 assertions about our code is measured capable of failing under at least one leg — and legs A and B1 fail in disjoint directions, which is what separates the pair pin from the controls. The two remaining assertions are facts about `@objectstack/spec`, green in every world; they are labelled non-discriminating **in the test file itself** so nobody later reads them as a pin on our code.

## Verification

All Vitest runs from the repo **root** (#3378).

- **New pin** — `packages/app-shell/src/views/ObjectView.overlayPairValue.test.ts`: **15 passed (15)**.
- **Provable superset, 58 files, 587 tests, both runs exit 0.** *Principle*: the diff changes exactly one runtime decision, inside `sanitizeViewOverride` in `ObjectView.tsx`; a test can observe it only if that **module** is in its graph. So a reverse-import BFS from that file over all 3,328 first-party sources (relative specifiers resolved to files, `@object-ui/*` to the package's `src` barrel) yields a 109-module closure containing **58 test files** — 19 in `packages/app-shell`, 39 in `apps/console` reached through the barrel. Anything outside cannot load the changed module.
  - `packages/…` half: `Test Files 19 passed (19) · Tests 222 passed (222)`
  - `apps/console` half: `Test Files 39 passed (39) · Tests 365 passed (365)`
  - **Each file confirmed executed**, by diffing reporter file names against the derived list: `comm` in both directions is empty for both halves. Worth noting for the next person: the `apps/console` project does report paths relative to **its own root** (`src/…`, not `apps/console/src/…`), so the comparison normalizes that before diffing.
- **Type-check** — `pnpm --filter @object-ui/app-shell type-check` → exit 0, script echoed (`tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file is type-checked too). The dependency closure was built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`, exit 0) — a fresh-tree type-check without it fails on the unbuilt closure, not on the diff.
- **Lint** — `pnpm --filter @object-ui/app-shell lint` (`eslint .` over the whole affected package): **0 errors**, exit 0 (2,551 pre-existing warnings, unchanged baseline). No narrowing was applied here; the repo-wide `turbo run lint` across 46 packages is CI's run.
- **Targeted gates**, each quoting its own verdict line, exit codes captured before any pipe:
  - `check-control-bytes` → `✅ OK (scanned 4705 tracked text file(s); skipped 85 binary)`
  - `check-changeset-presence` → `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`
  - `check-changeset-no-major` → `✅ No changeset declares a 'major' bump.`
  - `check-phantom-dependencies` → exit 0 (the added import is on an already-declared dependency)
  - `check-package-self-import` → exit 0
  - `check-lint-coverage` → `✅ 46/46 packages linted, 0 with outstanding errors` (a coverage gate — it validates that every package is reached by `turbo run lint`, it does not itself run ESLint repo-wide)
  - `check-type-check-coverage` → `✅ 45/46 via type-check, 0 errors outstanding`
  - Independent self-scan for raw control bytes over the changed files: no matches.
- **Not run locally, by design**: the repo-wide `pnpm check` farm and `pnpm lint`, which CI runs exactly once either way. Noted, untouched: `check-eager-closure-budget` (exits 2 locally), `check-doc-snippet-types` (exits 1), `check-published-dist-tooling` (belongs to CI).

Changeset: `patch` for `@object-ui/app-shell`.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_