### PR TITLE
perf(console): share one in-flight GET instead of racing duplicates on boot

### DIFF
--- a/.changeset/console-boot-request-dedup-5544.md
+++ b/.changeset/console-boot-request-dedup-5544.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/types': patch
+'@object-ui/app-shell': patch
+---
+
+The console's cold load no longer asks `/api/v1/runtime/config` or
+`/auth/me/localization` twice (objectui#5544).
+
+Two pairs of boot callers were racing each other for the same URL, with no shared
+provider between them, so no guard inside either component could see the other:
+
+- `GET /api/v1/runtime/config` — the pre-React branding script inlined in
+  `apps/console/index.html` (it runs during HTML parse so the tab title and
+  favicon are the operator's before the bundle is fetched) and
+  `initRuntimeConfig()`. Measured ×2 on prod and on staging. This is the
+  expensive one: the console `await`s `initRuntimeConfig()` before
+  `createRoot().render()`, so the duplicate sat on the critical path to first
+  paint, and at the control plane's ~0.5–1.4 s for this endpoint it also pushed
+  boot concurrency further past the server's pool knee.
+- `GET /api/v1/auth/me/localization` — `seedTenantLanguage()` on a device's true
+  first visit and `LocalizationFetchProvider` on every boot. The seed keeps
+  running past its 500 ms race by design and the provider mounts the moment that
+  race resolves, so on a first visit the two overlap. Measured ×2 on staging.
+
+`@object-ui/types` gains `sharedGetJson()`: callers that ask for the same GET
+while one is already in flight join that request instead of starting another. It
+shares the in-flight promise and nothing else — the entry is deleted the instant
+the request settles, so there is no cache, no TTL and no stale window, and a
+caller arriving after settle fetches fresh exactly as before. Rejections fan out
+to every sharer with the status intact (`LocalizationFetchProvider`'s retry
+policy still sees its own 503), each caller receives its own copy of the parsed
+body, and only GETs are eligible — a non-GET is refused rather than quietly
+rewritten.
+
+Requests that differ in credentials mode or headers keep separate identities, so
+the console's two deliberate `auth/get-session` calls — one Bearer-only with the
+cookie omitted to detect a stale token, then one through the cookie — stay two
+requests. Collapsing those would have destroyed the signal the first one exists
+to read.
+
+No component receives anything different: same payloads, same errors, one fewer
+round trip.

--- a/.changeset/console-boot-request-dedup-5544.md
+++ b/.changeset/console-boot-request-dedup-5544.md
@@ -1,6 +1,7 @@
 ---
 '@object-ui/types': patch
 '@object-ui/app-shell': patch
+'@object-ui/console': patch
 ---
 
 The console's cold load no longer asks `/api/v1/runtime/config` or

--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -15,19 +15,59 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="manifest" href="./manifest.json" />
     <title></title>
+    <!--
+      Pre-React branding, and the page's ONE `GET /api/v1/runtime/config`
+      (objectui#5544).
+
+      This script runs during parse so the title and favicon are the operator's
+      before the bundle is even fetched. `initRuntimeConfig()` in
+      `@object-ui/app-shell` then needs the same payload — and used to fetch it a
+      second time, which is the `runtime/config ×2` the card measured on both
+      prod and staging. It is the expensive kind of duplicate: the console
+      `await`s that second call before `createRoot().render()`, so it sits on the
+      critical path to first paint.
+
+      The fix is in-flight SHARING, not caching. We publish this request's parsed
+      -body promise into the registry `@object-ui/types` keeps on `globalThis`
+      (`Symbol.for('objectui.inflightGet')`), and delete the entry the moment it
+      settles. `sharedGetJson()` finds it and joins, so app-shell inherits a
+      request that started hundreds of ms earlier instead of starting its own; if
+      it ever arrives after settle it simply fetches, exactly as before.
+
+      Why the key is spelled out by hand here: a classic inline script cannot
+      import, and it must stay classic (see the crypto shim's comment below for
+      the measurement that rules out `type="module"` ordering). The format is
+      owned by `inflightGetKey()` in `packages/types/src/http-inflight.ts`, and
+      `src/__tests__/runtimeConfigBootDedup.test.ts` executes THIS script's text
+      against that function — so a drift between the two spellings fails a test
+      rather than silently restoring the duplicate.
+
+      Falls back gracefully on any error (non-blocking).
+    -->
     <script>
-      // Pre-React branding — fetch runtime config as early as possible so the
-      // browser title and favicon reflect the operator's branding BEFORE React
-      // mounts. Falls back gracefully on any error (non-blocking).
       (async function applyEarlyBranding() {
+        const base = (window.__CONSOLE_SERVER_URL || '').replace(/\/+$/, '');
+        const url = base + '/api/v1/runtime/config';
+        const init = { credentials: 'include', headers: { Accept: 'application/json' } };
+        // Must equal inflightGetKey(url, init) — see the comment above.
+        const key = 'GET\ninclude\n' + url + '\naccept=application/json';
+
+        const registryKey = Symbol.for('objectui.inflightGet');
+        const registry = globalThis[registryKey] || (globalThis[registryKey] = new Map());
+
+        const pending = (async function () {
+          const res = await fetch(url, init);
+          if (!res.ok) throw new Error('runtime/config ' + res.status);
+          return res.json();
+        })();
+        registry.set(key, pending);
+        const drop = function () {
+          if (registry.get(key) === pending) registry.delete(key);
+        };
+        pending.then(drop, drop);
+
         try {
-          const base = (window.__CONSOLE_SERVER_URL || '').replace(/\/+$/, '');
-          const res = await fetch(base + '/api/v1/runtime/config', {
-            credentials: 'include',
-            headers: { Accept: 'application/json' },
-          });
-          if (!res.ok) return;
-          const body = await res.json();
+          const body = await pending;
           if (body?.branding) {
             if (body.branding.productName) {
               document.title = body.branding.productName;

--- a/apps/console/src/LocalizationFetchProvider.tsx
+++ b/apps/console/src/LocalizationFetchProvider.tsx
@@ -31,7 +31,7 @@ import {
   HttpFetchError,
   backoffMs,
   isTransientFailure,
-  retryAfterFrom,
+  sharedGetJson,
   sleep,
 } from '@object-ui/types';
 
@@ -67,13 +67,17 @@ export function LocalizationFetchProvider({
     void (async () => {
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
         try {
-          const res = await fetch(endpoint, {
+          // Shared in flight with `seedTenantLanguage()` (objectui#5544): on a
+          // device's first visit that seed asks this same endpoint, and its
+          // request is still running when this one starts. `sharedGetJson`
+          // rejects with the same `HttpFetchError` a non-2xx produced here
+          // before — including `Retry-After` — so the retry policy below is
+          // untouched, and a shared 503 reaches BOTH callers rather than
+          // resolving one of them empty.
+          const json = await sharedGetJson<MeLocalizationResponse>(endpoint, {
             credentials: 'include',
             headers: { Accept: 'application/json' },
           });
-          if (!res.ok) throw new HttpFetchError(res.status, retryAfterFrom(res));
-
-          const json = (await res.json()) as MeLocalizationResponse;
           // Refresh the UI-language seed cache (objectui#4035) — the
           // "revalidate" half of stale-while-revalidate. This boot has already
           // committed to a language; what this write buys is the NEXT one, so a

--- a/apps/console/src/__tests__/localizationBootDedup.test.tsx
+++ b/apps/console/src/__tests__/localizationBootDedup.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * objectui#5544 — one cold load, one `GET /api/v1/auth/me/localization`.
+ *
+ * On a device's true first visit two callers ask this endpoint at once:
+ * `seedTenantLanguage()` (which keeps running past its 500 ms race, by design)
+ * and `LocalizationFetchProvider` (which mounts as soon as that race resolves).
+ * The card measured the pair as `me/localization ×2` on staging.
+ *
+ * The interesting half is not the request count — it is that the SECOND caller
+ * must still be served. `LocalizationFetchProvider` is the one with a retry
+ * policy, so these pin that a shared answer reaches it, that a shared 503
+ * reaches it as a 503 (not as an empty success), and that once the shared
+ * request has settled a later mount fetches again.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useLocalization, readCachedLanguageSeed } from '@object-ui/i18n';
+import { resetInflightGetsForTesting } from '@object-ui/types';
+import { seedTenantLanguage } from '../languageSeed';
+import { LocalizationFetchProvider } from '../LocalizationFetchProvider';
+
+const ENDPOINT = '/api/v1/auth/me/localization';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => structuredClone(body),
+    headers: { get: () => null },
+  } as unknown as Response;
+}
+
+/** Reads the value the provider publishes, so a starved consumer is visible. */
+function Consumer() {
+  const { currency, locale } = useLocalization();
+  return <span data-testid="value">{`${locale ?? '-'}/${currency ?? '-'}`}</span>;
+}
+
+beforeEach(() => {
+  resetInflightGetsForTesting();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetInflightGetsForTesting();
+  localStorage.clear();
+});
+
+describe('first-visit localization request budget', () => {
+  it('serves the seed and the provider from ONE request', async () => {
+    const gate = deferred<Response>();
+    const fetchStub = vi.fn(() => gate.promise);
+    vi.stubGlobal('fetch', fetchStub);
+
+    // True first visit: no stored choice, no cached seed ⇒ the seed fetches and
+    // races a timeout. A tiny timeout keeps the test fast; the shape is the same
+    // one production has at 500 ms — the race resolves while the fetch runs on.
+    await seedTenantLanguage('', 1);
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+
+    // The provider mounts right after the boot's `Promise.all` resolves — while
+    // the seed's request is still in flight.
+    render(
+      <LocalizationFetchProvider endpoint={ENDPOINT}>
+        <Consumer />
+      </LocalizationFetchProvider>,
+    );
+
+    gate.resolve(jsonResponse({ authenticated: true, locale: 'zh-CN', currency: 'CNY' }));
+
+    // ── the consumer is served, not starved ──
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('zh-CN/CNY'));
+    // ── and the seed got the same answer ──
+    await waitFor(() => expect(readCachedLanguageSeed()).toBe('zh-CN'));
+    // ── from one network call ──
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a shared 503 through to the retry policy rather than resolving it empty', async () => {
+    const gate = deferred<Response>();
+    const fetchStub = vi
+      .fn()
+      .mockImplementationOnce(() => gate.promise)
+      .mockImplementation(async () =>
+        jsonResponse({ authenticated: true, locale: 'ja-JP', currency: 'JPY' }),
+      );
+    vi.stubGlobal('fetch', fetchStub);
+
+    await seedTenantLanguage('', 1);
+    render(
+      <LocalizationFetchProvider endpoint={ENDPOINT}>
+        <Consumer />
+      </LocalizationFetchProvider>,
+    );
+
+    // The shared request fails transiently. Both sharers see the failure; only
+    // the provider has a retry policy, and it must still fire — a dedup that
+    // handed it an empty success would leave the console with no currency and
+    // no way back.
+    gate.resolve(jsonResponse(null, 503));
+
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('ja-JP/JPY'), {
+      timeout: 5000,
+    });
+    expect(fetchStub.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not share once the request has settled', async () => {
+    const fetchStub = vi.fn(async () =>
+      jsonResponse({ authenticated: true, locale: 'en-US', currency: 'USD' }),
+    );
+    vi.stubGlobal('fetch', fetchStub);
+
+    // Let the seed's request settle completely before the provider mounts.
+    await seedTenantLanguage('', 1);
+    await waitFor(() => expect(readCachedLanguageSeed()).toBe('en-US'));
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+
+    render(
+      <LocalizationFetchProvider endpoint={ENDPOINT}>
+        <Consumer />
+      </LocalizationFetchProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('en-US/USD'));
+    // Two waves, two requests: this is in-flight sharing, not a cache.
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/console/src/__tests__/runtimeConfigBootDedup.test.ts
+++ b/apps/console/src/__tests__/runtimeConfigBootDedup.test.ts
@@ -1,0 +1,158 @@
+/**
+ * objectui#5544 — one cold load, one `GET /api/v1/runtime/config`.
+ *
+ * The card measured this endpoint TWICE on prod and twice on staging. The two
+ * callers are the pre-React branding script inlined in `index.html` (it must run
+ * during parse) and `initRuntimeConfig()` in `@object-ui/app-shell` (awaited
+ * before `createRoot().render()`, so it is on the critical path to first paint).
+ * Neither can see the other, which is why no per-component guard closes it.
+ *
+ * These tests grade THE SHIPPED ARTIFACT, the same way
+ * `insecure-origin-crypto.test.ts` does: the inline script's text is extracted
+ * from `index.html` and executed. That is what keeps the request key the script
+ * spells out by hand — a classic script cannot import `inflightGetKey()` — from
+ * drifting away from the function that owns the format. A drift would not break
+ * anything visibly; it would just quietly restore the duplicate, which is
+ * exactly the failure a hand-copied contract produces.
+ */
+
+import indexHtml from '../../index.html?raw';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  initRuntimeConfig,
+  getRuntimeConfig,
+  resetRuntimeConfigForTesting,
+} from '@object-ui/app-shell';
+import { resetInflightGetsForTesting } from '@object-ui/types';
+
+/** The `/api/v1/runtime/config` answer, as the server sends it. */
+const CONFIG_BODY = {
+  cloudUrl: 'https://cloud.example.test',
+  singleEnvironment: false,
+  branding: { productName: 'Acme Ops', productShortName: 'Acme' },
+};
+
+/**
+ * The pre-boot script exactly as it ships. Extraction is by the IIFE's name, so
+ * renaming or deleting it fails here rather than silently testing nothing.
+ */
+function extractEarlyBrandingSource(html: string = indexHtml): string {
+  const scripts = [
+    ...html
+      // Comments first — prose describing a script tag parses as one.
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g),
+  ];
+  const found = scripts.filter((match) => match[1]?.includes('applyEarlyBranding'));
+  if (found.length !== 1) {
+    throw new Error(
+      `expected exactly 1 inline early-branding script in index.html, found ${found.length}`,
+    );
+  }
+  return found[0]?.[1] ?? '';
+}
+
+/** Run the shipped pre-boot script, as the browser would during parse. */
+function runEarlyBranding(): void {
+  new Function(extractEarlyBrandingSource())();
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => structuredClone(body),
+    headers: { get: () => null },
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  resetInflightGetsForTesting();
+  resetRuntimeConfigForTesting();
+  document.title = '';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetInflightGetsForTesting();
+});
+
+describe('the shipped pre-boot script is findable', () => {
+  it('is exactly one inline script in index.html', () => {
+    const source = extractEarlyBrandingSource();
+    expect(source).toContain('/api/v1/runtime/config');
+    expect(source).toContain("Symbol.for('objectui.inflightGet')");
+  });
+
+  it('fails loudly if the script is gone rather than passing vacuously', () => {
+    expect(() => extractEarlyBrandingSource('<html></html>')).toThrow(/found 0/);
+  });
+});
+
+describe('one cold load, one runtime/config request', () => {
+  it('lets app-shell join the pre-boot request instead of issuing a second one', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse(CONFIG_BODY));
+    vi.stubGlobal('fetch', fetchStub);
+
+    // Parse-time script, then the module chunk — the real boot order.
+    runEarlyBranding();
+    await initRuntimeConfig('');
+
+    // ── the duplicate is gone ──
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub.mock.calls[0]![0]).toBe('/api/v1/runtime/config');
+
+    // ── and BOTH consumers still got their data ──
+    // A dedup that starved the second caller would show the same call count.
+    expect(getRuntimeConfig().cloudUrl).toBe('https://cloud.example.test');
+    expect(getRuntimeConfig().branding.productName).toBe('Acme Ops');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(document.title).toBe('Acme Ops');
+  });
+
+  it('still fetches on its own when nothing is in flight — sharing, not caching', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse(CONFIG_BODY));
+    vi.stubGlobal('fetch', fetchStub);
+
+    // No pre-boot script this time (a tenant runtime serving its own HTML).
+    await initRuntimeConfig('');
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(getRuntimeConfig().branding.productName).toBe('Acme Ops');
+  });
+
+  it('re-fetches on a later call, keeping the documented repeat-call contract', async () => {
+    const fetchStub = vi.fn(async () => jsonResponse(CONFIG_BODY));
+    vi.stubGlobal('fetch', fetchStub);
+
+    runEarlyBranding();
+    await initRuntimeConfig('');
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+
+    // `initRuntimeConfig` is documented as safe to call again, and a second call
+    // must re-fetch and re-merge. The registry entry is gone at settle, so it
+    // does — there is no window in which a stale body could be replayed.
+    await initRuntimeConfig('');
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps defaults when the shared request fails, and never leaves the failure cached', async () => {
+    const fetchStub = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(null, 503))
+      .mockResolvedValueOnce(jsonResponse(CONFIG_BODY));
+    vi.stubGlobal('fetch', fetchStub);
+
+    runEarlyBranding();
+    // The rejection reaches app-shell, which absorbs it exactly as it absorbed a
+    // non-2xx before — defaults intact, boot uninterrupted.
+    await initRuntimeConfig('');
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(getRuntimeConfig().branding.productName).toBe('ObjectOS');
+
+    await initRuntimeConfig('');
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+    expect(getRuntimeConfig().branding.productName).toBe('Acme Ops');
+  });
+});

--- a/apps/console/src/__tests__/runtimeConfigBootDedup.test.ts
+++ b/apps/console/src/__tests__/runtimeConfigBootDedup.test.ts
@@ -91,7 +91,7 @@ describe('the shipped pre-boot script is findable', () => {
 
 describe('one cold load, one runtime/config request', () => {
   it('lets app-shell join the pre-boot request instead of issuing a second one', async () => {
-    const fetchStub = vi.fn(async () => jsonResponse(CONFIG_BODY));
+    const fetchStub = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse(CONFIG_BODY));
     vi.stubGlobal('fetch', fetchStub);
 
     // Parse-time script, then the module chunk — the real boot order.

--- a/apps/console/src/languageSeed.ts
+++ b/apps/console/src/languageSeed.ts
@@ -47,6 +47,7 @@
  * The seed lands in the cache instead, and the next boot is correct forever.
  */
 import { cacheLanguageSeed, readCachedLanguageSeed, readStoredLanguage } from '@object-ui/i18n';
+import { sharedGetJson } from '@object-ui/types';
 
 /**
  * How long a true first visit will wait for the tenant's locale before booting
@@ -72,12 +73,17 @@ interface MeLocalizationResponse {
  */
 async function fetchAndCacheSeed(serverBase: string): Promise<void> {
   try {
-    const res = await fetch(`${serverBase}/api/v1/auth/me/localization`, {
-      credentials: 'include',
-      headers: { Accept: 'application/json' },
-    });
-    if (!res.ok) return;
-    const json = (await res.json()) as MeLocalizationResponse;
+    // Shared in flight with `LocalizationFetchProvider` (objectui#5544), which
+    // asks the same endpoint on every boot. The prose above already treats the
+    // two as one request — "without a second request here" — but on a true first
+    // visit both fired, and the card measured them as `me/localization ×2`. They
+    // overlap by construction: this one keeps running past the 500 ms race, and
+    // the provider mounts as soon as the race resolves. Sharing is in-flight
+    // only, so on the boots where they do NOT overlap each still fetches.
+    const json = await sharedGetJson<MeLocalizationResponse>(
+      `${serverBase}/api/v1/auth/me/localization`,
+      { credentials: 'include', headers: { Accept: 'application/json' } },
+    );
     if (json?.authenticated === false) return;
     cacheLanguageSeed(json?.locale);
   } catch {

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -20,6 +20,8 @@
  *   framework/packages/runtime/src/cloud/runtime-config-plugin.ts
  */
 
+import { sharedGetJson } from '@object-ui/types';
+
 export interface RuntimeFeatures {
   /** "Install to this runtime" button is meaningful on this runtime. */
   installLocal: boolean;
@@ -156,16 +158,25 @@ function applyUpdate(patch: Partial<AppShellRuntimeConfig>): void {
  * `baseUrl` lets callers in dev (Vite proxy) override the fetch origin.
  * In production both Console SPA and tenant runtime share an origin so
  * the default (relative `/api/v1/...`) works.
+ *
+ * Goes through {@link sharedGetJson} because this is NOT the page's first ask
+ * for this URL (objectui#5544): the inline branding script in
+ * `apps/console/index.html` starts the identical request during HTML parse, well
+ * before this module chunk is even fetched. Both were measured on prod and
+ * staging, and this one is on the critical path — the console awaits it before
+ * `createRoot().render()`. Joining the earlier request removes a whole
+ * control-plane round trip AND lets this await settle sooner, since it inherits
+ * a request that started first. In-flight only: with nothing in flight this
+ * fetches normally, and the repeat-call contract above is unchanged, because the
+ * registry entry is gone by the time any later call arrives.
  */
 export async function initRuntimeConfig(baseUrl: string = ''): Promise<void> {
   const base = (baseUrl || '').replace(/\/+$/, '');
   try {
-    const res = await fetch(`${base}/api/v1/runtime/config`, {
-      credentials: 'include',
-      headers: { Accept: 'application/json' },
-    });
-    if (!res.ok) return;
-    const body = (await res.json()) as Partial<AppShellRuntimeConfig> | null;
+    const body = await sharedGetJson<Partial<AppShellRuntimeConfig> | null>(
+      `${base}/api/v1/runtime/config`,
+      { credentials: 'include', headers: { Accept: 'application/json' } },
+    );
     if (!body || typeof body !== 'object') return;
     applyUpdate({
       cloudUrl: typeof body.cloudUrl === 'string' ? body.cloudUrl.replace(/\/+$/, '') : current.cloudUrl,

--- a/packages/types/src/__tests__/http-inflight.test.ts
+++ b/packages/types/src/__tests__/http-inflight.test.ts
@@ -1,0 +1,217 @@
+/**
+ * objectui#5544 — one network call for N overlapping identical GETs.
+ *
+ * These pin the four properties the fix stands on. Each one is a way the dedup
+ * could look successful while being wrong, so a request-count assertion alone is
+ * not enough:
+ *
+ *  - N concurrent same-key GETs ⇒ ONE call, and every caller gets the data.
+ *    (Count-only would also pass if late callers resolved `undefined`.)
+ *  - A rejection reaches EVERY sharer, with the status intact, so a caller's
+ *    retry policy still sees its 503.
+ *  - Different keys never share — different URL, different headers, different
+ *    credentials mode. The console asks `get-session` twice on purpose, once
+ *    Bearer-only and once by cookie, and those two must stay two.
+ *  - A wave that starts AFTER the first settled refetches. This is in-flight
+ *    sharing, not a cache: no TTL, no stale window.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  HttpFetchError,
+  inflightGetKey,
+  sharedGetJson,
+  resetInflightGetsForTesting,
+} from '../index.js';
+
+/** A promise plus its settlers, so a test controls exactly when a fetch answers. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** The minimum of `Response` that {@link sharedGetJson} reads. */
+function jsonResponse(body: unknown, status = 200, retryAfter?: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    headers: { get: (name: string) => (name === 'Retry-After' ? (retryAfter ?? null) : null) },
+  } as unknown as Response;
+}
+
+const URL_A = 'https://example.test/api/v1/runtime/config';
+const JSON_GET: RequestInit = { credentials: 'include', headers: { Accept: 'application/json' } };
+
+beforeEach(() => {
+  // The `unit` project runs with `isolate: false`, and the registry lives on
+  // `globalThis` on purpose — so it MUST be cleared between files, not just
+  // between cases.
+  resetInflightGetsForTesting();
+});
+
+describe('inflightGetKey', () => {
+  it('is stable across header spelling and order', () => {
+    const a = inflightGetKey(URL_A, { credentials: 'include', headers: { Accept: 'application/json', 'X-Tenant-ID': 't1' } });
+    const b = inflightGetKey(URL_A, { credentials: 'include', headers: { 'x-tenant-id': 't1', accept: 'application/json' } });
+    expect(a).toBe(b);
+  });
+
+  it('separates requests that differ only in credentials mode or headers', () => {
+    const cookie = inflightGetKey(URL_A, { credentials: 'include' });
+    const bearerOnly = inflightGetKey(URL_A, { credentials: 'omit', headers: { Authorization: 'Bearer x' } });
+    expect(cookie).not.toBe(bearerOnly);
+  });
+
+  it('is the exact string the pre-boot script in index.html builds by hand', () => {
+    // The inline classic script cannot import, so it spells this format out.
+    // If the format here changes, that script stops sharing SILENTLY — this
+    // assertion is the tripwire, and `apps/console` executes the shipped text
+    // against the real function for the end-to-end half.
+    expect(inflightGetKey(URL_A, JSON_GET)).toBe(
+      `GET\ninclude\n${URL_A}\naccept=application/json`,
+    );
+  });
+});
+
+describe('sharedGetJson', () => {
+  it('collapses N concurrent same-key GETs into one call, and answers all of them', async () => {
+    const gate = deferred<Response>();
+    const fetchImpl = vi.fn(() => gate.promise);
+
+    const callers = [1, 2, 3, 4, 5].map(() =>
+      sharedGetJson<{ productName: string }>(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+    );
+    gate.resolve(jsonResponse({ productName: 'ObjectOS' }));
+    const results = await Promise.all(callers);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // Every caller is served — a dedup that starves the late ones would leave
+    // `undefined` here and still show a call count of 1.
+    expect(results).toHaveLength(5);
+    for (const result of results) expect(result).toEqual({ productName: 'ObjectOS' });
+  });
+
+  it('hands each caller its own object, so one caller cannot mutate another', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ branding: { productName: 'ObjectOS' } }));
+    const [first, second] = await Promise.all([
+      sharedGetJson<{ branding: { productName: string } }>(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+      sharedGetJson<{ branding: { productName: string } }>(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+    ]);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(first).not.toBe(second);
+    first!.branding.productName = 'mutated';
+    expect(second!.branding.productName).toBe('ObjectOS');
+  });
+
+  it('fans a rejection out to every sharer, status intact', async () => {
+    const gate = deferred<Response>();
+    const fetchImpl = vi.fn(() => gate.promise);
+
+    const callers = [1, 2, 3].map(() =>
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch).then(
+        () => ({ ok: true }) as const,
+        (err: unknown) => ({ ok: false, err }) as const,
+      ),
+    );
+    gate.resolve(jsonResponse(null, 503, '2'));
+    const settled = await Promise.all(callers);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    for (const outcome of settled) {
+      expect(outcome.ok).toBe(false);
+      const err = (outcome as { err: unknown }).err;
+      // `code`+`status` equivalent for this transport: the error class and the
+      // status a retry policy reads. A bare "it threw" would pass even if the
+      // status were lost, and `LocalizationFetchProvider` decides whether to
+      // retry from exactly this.
+      expect(err).toBeInstanceOf(HttpFetchError);
+      expect((err as HttpFetchError).status).toBe(503);
+      expect((err as HttpFetchError).retryAfterMs).toBe(2000);
+    }
+  });
+
+  it('propagates a thrown fetch (offline) to every sharer', async () => {
+    const boom = new Error('network down');
+    const fetchImpl = vi.fn(async () => {
+      throw boom;
+    });
+    const outcomes = await Promise.allSettled([
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    for (const outcome of outcomes) {
+      expect(outcome.status).toBe('rejected');
+      expect((outcome as PromiseRejectedResult).reason).toBe(boom);
+    }
+  });
+
+  it('does not share across different URLs, headers, or credentials modes', async () => {
+    const gate = deferred<Response>();
+    const fetchImpl = vi.fn(() => gate.promise);
+
+    const all = Promise.all([
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+      sharedGetJson(`${URL_A}?key=ui.recent`, JSON_GET, fetchImpl as unknown as typeof fetch),
+      // Same URL, Bearer-only and no cookie — the stale-token probe. Collapsing
+      // this into the cookie call would destroy the signal it exists to read.
+      sharedGetJson(URL_A, { credentials: 'omit', headers: { Authorization: 'Bearer stale' } }, fetchImpl as unknown as typeof fetch),
+    ]);
+    gate.resolve(jsonResponse({}));
+    await all;
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('refetches on a wave that starts after the first settled — no cache, no TTL', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ n: 1 }));
+
+    await Promise.all([
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    // Second wave, strictly after settle.
+    await Promise.all([
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves nothing behind after a rejected request, so the next caller retries', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(null, 503))
+      .mockResolvedValueOnce(jsonResponse({ n: 2 }));
+
+    await expect(sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch)).rejects.toBeInstanceOf(
+      HttpFetchError,
+    );
+    await expect(sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch)).resolves.toEqual({ n: 2 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses to share a mutation', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}));
+    await expect(
+      sharedGetJson(URL_A, { ...JSON_GET, method: 'POST' }, fetchImpl as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('issues a GET even when the caller passed method: GET explicitly', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}));
+    await sharedGetJson(URL_A, { ...JSON_GET, method: 'get' }, fetchImpl as unknown as typeof fetch);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect((fetchImpl.mock.calls[0]![1] as RequestInit).method).toBe('GET');
+  });
+});

--- a/packages/types/src/__tests__/http-inflight.test.ts
+++ b/packages/types/src/__tests__/http-inflight.test.ts
@@ -200,6 +200,24 @@ describe('sharedGetJson', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it('opts a cancellable request out of sharing, in both directions', async () => {
+    const gate = deferred<Response>();
+    const fetchImpl = vi.fn(() => gate.promise);
+
+    const all = Promise.all([
+      // A caller with its own AbortSignal must neither join…
+      sharedGetJson(URL_A, { ...JSON_GET, signal: new AbortController().signal }, fetchImpl as unknown as typeof fetch),
+      // …nor be joined: aborting one caller must never cancel another's read.
+      sharedGetJson(URL_A, JSON_GET, fetchImpl as unknown as typeof fetch),
+      sharedGetJson(URL_A, { ...JSON_GET, signal: new AbortController().signal }, fetchImpl as unknown as typeof fetch),
+    ]);
+    gate.resolve(jsonResponse({ n: 1 }));
+    const results = await all;
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    for (const result of results) expect(result).toEqual({ n: 1 });
+  });
+
   it('refuses to share a mutation', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({}));
     await expect(
@@ -209,9 +227,9 @@ describe('sharedGetJson', () => {
   });
 
   it('issues a GET even when the caller passed method: GET explicitly', async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({}));
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse({}));
     await sharedGetJson(URL_A, { ...JSON_GET, method: 'get' }, fetchImpl as unknown as typeof fetch);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect((fetchImpl.mock.calls[0]![1] as RequestInit).method).toBe('GET');
+    expect(fetchImpl.mock.calls[0]![1]?.method).toBe('GET');
   });
 });

--- a/packages/types/src/http-inflight.ts
+++ b/packages/types/src/http-inflight.ts
@@ -1,0 +1,202 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Sharing ONE in-flight GET between callers that cannot see each other
+ * (objectui#5544).
+ *
+ * ## The defect this closes
+ *
+ * The console's boot issues several `fetch` calls from modules that have no
+ * shared provider between them, and two pairs of them ask for the *same* URL at
+ * the same time:
+ *
+ *  - `GET /api/v1/runtime/config` — the pre-React branding script inlined in
+ *    `apps/console/index.html` (it runs during parse, so the title and favicon
+ *    are right before the bundle is even fetched) and `initRuntimeConfig()` in
+ *    `@object-ui/app-shell`, which needs the whole payload.
+ *  - `GET /api/v1/auth/me/localization` — `seedTenantLanguage()` on a device's
+ *    true first visit, and `LocalizationFetchProvider` on every boot.
+ *
+ * A guard *inside* either caller cannot see the other one, which is what makes
+ * this a request-layer problem rather than a component one.
+ *
+ * ## What this is, and what it deliberately is not
+ *
+ * It shares the in-flight PROMISE and nothing else. The registry entry is
+ * created when a request starts and deleted the moment it settles — there is no
+ * response cache, no TTL, and no stale window. A caller arriving after settle
+ * issues a fresh request and sees fresh data, exactly as it did before. The only
+ * observable change is that callers *overlapping in time* cost one round trip
+ * instead of N.
+ *
+ * Three consequences worth stating, because a dedup that gets any of them wrong
+ * is worse than the duplicate it removed:
+ *
+ *  1. **A rejection fans out.** Every sharer of a failed request sees the same
+ *     `HttpFetchError`, so a caller with a retry policy (`LocalizationFetchProvider`)
+ *     still gets its 503 and still retries. A dedup that resolved the late
+ *     caller with `undefined` would starve it silently.
+ *  2. **Each caller gets its own object.** The parsed body is cloned per caller,
+ *     so two consumers of one request are as independent as two consumers of two
+ *     requests. Handing out one shared reference would let either caller's
+ *     mutation reach the other.
+ *  3. **GET only.** {@link sharedGetJson} refuses any other method outright
+ *     rather than quietly rewriting it: replaying one POST for two callers, or
+ *     collapsing two POSTs into one, is data loss. Declared = enforced.
+ *
+ * ## Why the registry hangs off `globalThis`
+ *
+ * One of the two callers above is an inline **classic** script in `index.html`.
+ * It cannot import this module — it has to run before any module chunk executes
+ * — so a module-scoped `Map` could never be reached from it, and the most
+ * valuable duplicate (every cold load, on the critical path to first paint)
+ * would survive the fix. `Symbol.for` gives both worlds one registry with no
+ * import and no bundler cooperation. `apps/console/src/__tests__/` executes the
+ * real script text out of the shipped `index.html` against this module, so the
+ * two spellings of {@link inflightGetKey} cannot drift apart unnoticed.
+ *
+ * It lives in `@object-ui/types` for the same reason `http-retry.ts` does: it is
+ * the lowest package every caller can reach.
+ */
+
+import { HttpFetchError, retryAfterFrom } from './http-retry.js';
+
+/**
+ * The registry's slot on `globalThis`.
+ *
+ * `Symbol.for` (not a plain string, and not a module-local symbol) so the inline
+ * classic script in `index.html`, this module, and any duplicate copy of this
+ * module a bundler happens to emit all resolve to the SAME map.
+ */
+export const INFLIGHT_GET_REGISTRY_KEY = Symbol.for('objectui.inflightGet');
+
+/** Registry contents: request key → the in-flight parsed-body promise. */
+type InflightRegistry = Map<string, Promise<unknown>>;
+
+function registry(): InflightRegistry {
+  const holder = globalThis as unknown as Record<symbol, InflightRegistry | undefined>;
+  const existing = holder[INFLIGHT_GET_REGISTRY_KEY];
+  if (existing) return existing;
+  const created: InflightRegistry = new Map();
+  holder[INFLIGHT_GET_REGISTRY_KEY] = created;
+  return created;
+}
+
+/**
+ * Normalise request headers to `name=value` pairs, lowercased and sorted.
+ *
+ * Header names are case-insensitive on the wire, and object literals have no
+ * meaningful order, so two callers spelling the same request differently must
+ * still produce one key.
+ */
+function normalizeHeaders(headers: HeadersInit | undefined): string {
+  if (!headers) return '';
+  const pairs: string[] = [];
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    headers.forEach((value, name) => pairs.push(`${name.toLowerCase()}=${value}`));
+  } else if (Array.isArray(headers)) {
+    for (const [name, value] of headers) pairs.push(`${String(name).toLowerCase()}=${String(value)}`);
+  } else {
+    for (const [name, value] of Object.entries(headers)) {
+      pairs.push(`${name.toLowerCase()}=${String(value)}`);
+    }
+  }
+  return pairs.sort().join(',');
+}
+
+/**
+ * The identity of a GET request, for in-flight sharing.
+ *
+ * Two requests share a promise only when this string matches, which is why the
+ * credentials mode and the headers are part of it and not just the URL. That is
+ * load-bearing, not defensive: the console asks `GET /api/v1/auth/get-session`
+ * twice on purpose — once Bearer-only with `credentials: 'omit'` to detect a
+ * stale token, then again through the cookie — and collapsing those two would
+ * destroy the very signal the first one exists to read. Different headers,
+ * different key, two requests.
+ *
+ * ⚠️ The inline branding script in `apps/console/index.html` builds this string
+ * by hand (it cannot import). Change the format here and that script must change
+ * with it; `runtimeConfigBootDedup.test.ts` executes the shipped script against
+ * this function so a mismatch fails rather than silently un-shares.
+ */
+export function inflightGetKey(url: string, init?: RequestInit): string {
+  const credentials = init?.credentials ?? 'same-origin';
+  return `GET\n${credentials}\n${url}\n${normalizeHeaders(init?.headers)}`;
+}
+
+/**
+ * Hand each caller its own copy of the parsed body.
+ *
+ * The value came off `Response.json()`, so it is JSON-shaped by construction and
+ * both branches are lossless for it.
+ */
+function copy<T>(value: T): T {
+  if (typeof structuredClone === 'function') return structuredClone(value);
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/** The `fetch` this module uses when a caller does not inject one. */
+const defaultFetch: typeof fetch = (input, init) => fetch(input, init);
+
+/**
+ * Issue `GET url`, or join the identical request already in flight, and resolve
+ * the parsed JSON body.
+ *
+ * Rejects with {@link HttpFetchError} carrying the status (and any `Retry-After`)
+ * on a non-2xx, so a caller's existing retry policy keeps working unchanged.
+ *
+ * @param url     Absolute or same-origin URL.
+ * @param init    Standard `fetch` init. `method` may be omitted or `'GET'`;
+ *                anything else throws.
+ * @param fetchImpl Injected transport, for tests and for callers that must go
+ *                through an authenticated wrapper.
+ */
+export async function sharedGetJson<T>(
+  url: string,
+  init?: RequestInit,
+  fetchImpl: typeof fetch = defaultFetch,
+): Promise<T> {
+  const method = init?.method;
+  if (method !== undefined && method.toUpperCase() !== 'GET') {
+    throw new TypeError(
+      `sharedGetJson is GET-only; refusing to share a ${method.toUpperCase()} request`,
+    );
+  }
+
+  const key = inflightGetKey(url, init);
+  const reg = registry();
+
+  const existing = reg.get(key) as Promise<T> | undefined;
+  if (existing) return copy(await existing);
+
+  const started = (async (): Promise<T> => {
+    const res = await fetchImpl(url, { ...init, method: 'GET' });
+    if (!res.ok) throw new HttpFetchError(res.status, retryAfterFrom(res));
+    return (await res.json()) as T;
+  })();
+
+  reg.set(key, started);
+  // `.then(cleanup, cleanup)` rather than `.finally(cleanup)`: `finally`
+  // re-raises the rejection on a NEW chained promise we do not return, which the
+  // runtime then reports as unhandled even though every real caller handled it.
+  const cleanup = () => {
+    // Only drop the entry if it is still ours — a caller that started after we
+    // settled may already have replaced it.
+    if (reg.get(key) === started) reg.delete(key);
+  };
+  started.then(cleanup, cleanup);
+
+  return copy(await started);
+}
+
+/** Drop every registry entry. Tests only — production code never needs this. */
+export function resetInflightGetsForTesting(): void {
+  registry().clear();
+}

--- a/packages/types/src/http-inflight.ts
+++ b/packages/types/src/http-inflight.ts
@@ -170,6 +170,17 @@ export async function sharedGetJson<T>(
     );
   }
 
+  // An `AbortSignal` belongs to ONE caller. Sharing a request behind two signals
+  // would let either caller's abort cancel the other's read — a starvation this
+  // module exists to avoid — and the signal is not part of the key, so it cannot
+  // be separated by one either. A cancellable request simply opts out: it fetches
+  // on its own, and it neither joins nor blocks anyone else's.
+  if (init?.signal) {
+    const res = await fetchImpl(url, { ...init, method: 'GET' });
+    if (!res.ok) throw new HttpFetchError(res.status, retryAfterFrom(res));
+    return (await res.json()) as T;
+  }
+
   const key = inflightGetKey(url, init);
   const reg = registry();
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1274,3 +1274,15 @@ export {
     sleep,
     retryAfterFrom,
 } from './http-retry.js';
+
+// In-flight sharing for identical GETs (objectui#5544). Same argument for the
+// same home: the callers that overlap — the pre-React branding script, app-shell's
+// runtime config, the language seed and the localization provider — have no
+// package in common lower than this one. Shares the PROMISE only; the entry is
+// gone the moment the request settles, so nothing here is a cache.
+export {
+    INFLIGHT_GET_REGISTRY_KEY,
+    inflightGetKey,
+    sharedGetJson,
+    resetInflightGetsForTesting,
+} from './http-inflight.js';


### PR DESCRIPTION
Fixes objectstack-ai/objectui#5544

## What was actually duplicated

I re-derived every row of the card's two tables against `origin/main` before writing
anything. Three of the five endpoints are **not** duplicates, and the earlier round on
this card ([#5593](https://github.com/objectstack-ai/objectui/pull/5593), merged) already
established two of them:

| endpoint | verdict on `main` |
|---|---|
| `data/sys_user_preference` ×3 | **not a duplicate.** `ConsoleShell.tsx:306/311/316` attaches three adapters with three distinct keys (`ui.favorites`, `ui.recent`, `ui.flow.palette.recents`). The card's probe groups by `new URL(r.name).pathname`, which discards the query string the `key` predicate rides in. Pinned by #5593. |
| `meta/object` ×2, `meta/view` ×2 | **already closed** by objectui#4042 and pinned by `MetadataProvider.requestBudget.test.tsx`. |
| `auth/get-session` ×2 | **by design.** `apps/console/src/lib/auth-preflight.ts:52` probes Bearer-only with `credentials: 'omit'`, precisely so the cookie cannot mask a stale token; `AuthProvider` then asks by cookie. Deduping this destroys the signal the first call exists to read. |
| `runtime/config` ×2 | **real, and previously unattributed.** Two callers, both in this repo. |
| `auth/me/localization` ×2 | **real**, on a device's true first visit. |

The two real ones are what this PR closes. Both are the shape the card describes — separate
callers with no shared provider between them, so no per-component guard (the #1477 technique)
can see across them.

**`GET /api/v1/runtime/config`** — the pre-React branding script inlined in
`apps/console/index.html:25` fetches it during HTML parse, and `initRuntimeConfig()`
(`packages/app-shell/src/runtime-config.ts:163`) fetched it again from the module chunk.
This is the expensive one: `apps/console/src/main.tsx:73` **awaits** `initRuntimeConfig()`
inside the `Promise.all` that gates `createRoot().render()`, so the duplicate sat on the
critical path to first paint. Joining the earlier request removes a round trip *and* lets
that await settle sooner, because it inherits a request that started hundreds of ms before
the bundle was even fetched.

**`GET /api/v1/auth/me/localization`** — `seedTenantLanguage()` keeps its request running
past the 500 ms race by design, and `LocalizationFetchProvider` mounts the moment that race
resolves, so on a first visit the two overlap. `languageSeed.ts`'s own docblock already
describes them as one request ("without a second request here"); they were two.

## The mechanism

`@object-ui/types` gains `sharedGetJson()` (sibling to `http-retry.ts`, in the lowest
package every caller can reach). It shares the **in-flight promise and nothing else**:

- the registry entry is deleted the instant the request settles — no cache, no TTL, no
  stale window. A caller arriving after settle fetches fresh, exactly as before;
- a rejection fans out to every sharer with the status intact, so
  `LocalizationFetchProvider`'s retry policy still sees its own `503` + `Retry-After`;
- each caller receives its **own copy** of the parsed body, so two consumers of one request
  are as independent as two consumers of two requests;
- GET only — a non-GET is refused rather than quietly rewritten;
- a request carrying an `AbortSignal` opts out entirely (it neither joins nor is joined):
  a signal belongs to one caller, and sharing behind two would let either caller's abort
  cancel the other's read.

Requests differing in credentials mode or headers keep separate identities, which is what
keeps the deliberate `get-session` pair a pair.

### Why the registry lives on `globalThis`

One of the two `runtime/config` callers is an inline **classic** script — it has to run
before any module chunk executes, so it cannot import. A module-scoped `Map` could never
reach it, and the most valuable duplicate would have survived the fix.
`Symbol.for('objectui.inflightGet')` gives both worlds one registry with no import and no
bundler cooperation. The script spells the request key out by hand; the drift that creates
is closed mechanically, not by comment — `apps/console/src/__tests__/runtimeConfigBootDedup.test.ts`
extracts **the shipped script's text out of `index.html` and executes it** (the pattern
`insecure-origin-crypto.test.ts` already uses), and `http-inflight.test.ts` asserts
`inflightGetKey()` produces the exact string that script builds.

## Verification — all at final head `a6bd4f812`

Exit codes captured before any pipe.

- **New tests, 22 cases** across `packages/types/src/__tests__/http-inflight.test.ts`,
  `apps/console/src/__tests__/runtimeConfigBootDedup.test.ts` and
  `apps/console/src/__tests__/localizationBootDedup.test.tsx`. They pin all four properties
  the card asks for — N concurrent same-key GETs ⇒ one call **and every caller served**;
  rejection fans out; different keys never share; a wave after settle refetches — plus the
  end-to-end boot through the real `index.html`.
- **Test union**: `Test Files 215 passed (215)` / `Tests 1950 passed (1950)`
  (`packages/types/`, `apps/console/`, `packages/app-shell/src/{console,layout,providers}/`,
  `runtime-config.test.ts`, and the i18n / gantt localization consumers).
- **Type-check**, `@object-ui/types` + `@object-ui/app-shell` + `@object-ui/console`: exit 0,
  each script name echoed (so not a zero-match no-op), after building the console's
  dependency closure.
- **Lint**: full-repo `pnpm lint` exit 0 (0 errors repo-wide); `eslint --no-inline-config
  --format json` over the 7 changed files reports `files linted: 7, errors: 0, warnings: 0`.
  `check-lint-coverage`: `46/46 packages linted, 0 with outstanding errors`.
- **`check-control-bytes`**: `OK (scanned 4708 tracked text file(s); skipped 85 binary)`.
- **Changeset gates**: presence `✅ 8 source file(s) of 3 released package(s) changed, and
  this change declares 1 changeset(s)`; `✅ No changeset declares a major bump`;
  `✅ All workspace packages are in the changeset fixed group`.

### Ablation

The join was disabled at its only decision point — `const existing = reg.get(key)` became
`const existing = undefined` in `sharedGetJson`, i.e. the sharing removed while the
registration stays. No rebuild is required and that is proven rather than assumed:
`vitest.config.mts:261` aliases `@object-ui/types` to `packages/types/src`, so the suites
load mutated **source**. The mutation was confirmed on disk by anchored counts in both
directions (original anchor 1 → 0, mutant anchor 0 → 1, `1 file changed, 1 insertion(+),
1 deletion(-)`).

Result: **9 of 21 cases red**, every one of them the duplicate reappearing — `expected
"vi.fn()" to be called 1 times, but got 2 times` (and `3`, and `5`). The negative controls
correctly stayed **green**: different keys still did not share, the key-format assertions
held, and the GET-only refusal held. Restored by a `trap … EXIT INT TERM`; the restore leg
was verified the same way (original anchor back at 1, mutant at 0, `git status --porcelain`
empty).

### What I did not measure

The card's reproduce snippet is a browser probe against prod, and I did not take a local
equivalent, because a faithful one is not available from this repo: the sharing is in-flight
only, so it requires the two calls to *overlap*, and a Vite dev server answers
`/api/v1/runtime/config` with an instant 404 — the pre-boot request settles before the module
chunk runs and both fixed and unfixed builds show ×2. The prod/staging numbers in the card
are its measurement, not mine. What the win depends on is stated plainly: it is proportional
to server latency, and the card's own prod durations (512 / 431 ms for a fetch that starts at
parse time) show the overlap is real there.

## Scope

`out of scope: #5593` — its pin stays exactly as merged. No component receives anything
different: same payloads, same errors, one fewer round trip.

---
_Generated by [Claude Code](https://claude.ai/code/session_30b1d4ba-aaec-4c03-a7b4-d0d9c746cb8a)_
