### PR TITLE
The SDUI authoring preview stops teaching Tailwind in page source; the two plumbing previews declare the exception

### DIFF
--- a/.changeset/sdui-preview-page-source-tailwind-5470.md
+++ b/.changeset/sdui-preview-page-source-tailwind-5470.md
@@ -1,0 +1,26 @@
+---
+---
+
+Publishes nothing — declared with an empty frontmatter rather than left undeclared.
+
+The changed files are `apps/console`'s three ADR-0080 browser preview harnesses
+(`src/sdui-*-preview.tsx`) plus a test. They are dev-server-only: `apps/console`'s
+vite config declares no `build.rollupOptions.input`, so the build's only entry is
+`index.html` (resolved config, measured: `input` unset) — the three
+`sdui-*-preview.html` entries and the modules behind them never enter `dist/`.
+`@object-ui/console`'s `files` omits `src`, and its `exports` map has exactly one
+entry (`.` → `./plugin.js`, built from `tsconfig.plugin.json` including
+`plugin.ts` alone, which imports nothing from `src/`). Nothing here reaches a
+consumer.
+
+Behind the change: page `source` is runtime metadata, and the console's Tailwind
+is compiled at build time by scanning the console's own `src` with no safelist, so
+a utility class authored in real page metadata produces no CSS and no error
+(ADR-0065; ADR-0080's 2026-06-30 amendment). `sdui-tiers-preview.tsx` — the
+harness making an explicit authoring claim — now styles with each tier's real
+primitive (the html tier with `<flex>`'s structured props plus JSON `style`
+objects, the react tier with inline `style` objects, colours as
+`hsl(var(--token))`), so it demonstrates what authors are told to write and now
+follows the theme in light and dark. The two renderer-plumbing harnesses keep
+their Tailwind and declare the exception in their headers; a test pins both
+halves against the shipped `page-source-className-tailwind` rule.

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -91,6 +91,7 @@
     "@object-ui/test-support": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/client": "^17.0.0",
+    "@objectstack/lint": "^17.0.0",
     "@objectstack/spec": "^17.0.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/typography": "^0.5.20",

--- a/apps/console/src/__tests__/sdui-preview-page-source-styling.test.ts
+++ b/apps/console/src/__tests__/sdui-preview-page-source-styling.test.ts
@@ -25,13 +25,23 @@
  *     cannot quietly inherit the exception.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { validatePageSourceStyling, PAGE_SOURCE_CLASSNAME } from '@objectstack/lint';
 import { parseJsx } from '@object-ui/sdui-parser';
 
-const srcDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+/**
+ * The harness files as TEXT, enumerated by Vite rather than `node:fs`: this
+ * app's tsconfig is browser-only (`lib: ES2020, DOM`, `types` without `node`),
+ * so a `node:fs` import passes under Vitest and fails the console's `tsc` —
+ * the trap `insecure-origin-crypto.placement.test.ts` records. The glob is also
+ * the enumeration the last test needs: Vite expands it against the real
+ * directory at transform time, so a NEW harness appears here without anyone
+ * remembering to add it.
+ */
+const harnesses = import.meta.glob('../*-preview.tsx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
 
 /** The header line every harness that keeps its Tailwind must carry. */
 const EXCEPTION_ANCHOR = ' * ADR-0080 EXCEPTION — Tailwind in page source';
@@ -88,7 +98,16 @@ function findingsFor(pages: HarnessPage[]) {
   return validatePageSourceStyling({ pages: pages as unknown as Record<string, unknown>[] });
 }
 
-const read = (file: string) => readFileSync(path.join(srcDir, file), 'utf8');
+function read(file: string): string {
+  const text = harnesses[`../${file}`];
+  // A missing key means the file was renamed or the glob stopped matching —
+  // fail loudly rather than assert over an empty string, which reads exactly
+  // like a clean file.
+  if (typeof text !== 'string') {
+    throw new Error(`${file} is not in the preview-harness glob (found: ${Object.keys(harnesses).join(', ')})`);
+  }
+  return text;
+}
 
 describe('ADR-0080 preview harnesses — page-source styling', () => {
   // ---- the instrument, before anything is asserted with it ----------------
@@ -164,10 +183,17 @@ describe('ADR-0080 preview harnesses — page-source styling', () => {
 
   // ---- no silent third path ----------------------------------------------
   it('every preview harness in src/ is one of the two declared shapes', () => {
-    const harnesses = readdirSync(srcDir).filter((f) => /-preview\.tsx$/.test(f));
-    expect(harnesses.length).toBeGreaterThanOrEqual(3);
+    const files = Object.keys(harnesses).map((k) => k.replace('../', ''));
+    expect(files.length).toBeGreaterThanOrEqual(3);
+    expect(files).toEqual(
+      expect.arrayContaining([
+        'sdui-jsx-preview.tsx',
+        'sdui-tiers-preview.tsx',
+        'sdui-workbench-preview.tsx',
+      ]),
+    );
 
-    for (const file of harnesses) {
+    for (const file of files) {
       const text = read(file);
       const pages = pagesOf(text);
       if (pages.length === 0) continue; // not a source-tier harness
@@ -177,7 +203,7 @@ describe('ADR-0080 preview harnesses — page-source styling', () => {
         dirty === declared,
         dirty
           ? `${file} authors Tailwind in page source without the "${EXCEPTION_ANCHOR.trim()}" header note. ` +
-            'Style with the tier primitive (see sdui-tiers-preview.tsx), or declare the exception.'
+            'Style with the tier primitive (content/docs/guide/react-pages.md §Styling), or declare the exception.'
           : `${file} carries the exception note but authors no Tailwind in page source — drop the note.`,
       ).toBe(true);
     }

--- a/apps/console/src/__tests__/sdui-preview-page-source-styling.test.ts
+++ b/apps/console/src/__tests__/sdui-preview-page-source-styling.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The three ADR-0080 browser preview harnesses, held to the page-source styling
+ * rule BY THAT RULE — `validatePageSourceStyling` from `@objectstack/lint`, the
+ * same `page-source-className-tailwind` an author gets from `os validate`. Not a
+ * local re-implementation: a copy of a rule cannot disagree with itself.
+ *
+ * WHY THIS FILE EXISTS (objectui#5470). A page's `source` is RUNTIME metadata.
+ * The console's Tailwind is compiled at BUILD time by scanning the console's own
+ * `src` (`@source '../src/**'` in `apps/console/src/index.css`) with no
+ * safelist, so a utility class authored in real page metadata produces no CSS
+ * and no error anywhere — the ADR-0065 "works only by coincidence" failure,
+ * recorded as ADR-0080's 2026-06-30 amendment. These three harnesses are the one
+ * place in the repo where the rule is violated AND STILL LOOKS RIGHT, because
+ * each harness file is itself inside the scanned `src`. Lift one of their source
+ * strings into a real page and every class evaporates silently.
+ *
+ * So the harnesses are split, and both halves are pinned here:
+ *   - `sdui-tiers-preview.tsx` makes an explicit AUTHORING claim ("Browser
+ *     preview for the two AI-authoring tiers"), so it was rewritten to each
+ *     tier's real primitive and must stay at ZERO findings.
+ *   - the other two are renderer-PLUMBING previews that keep their Tailwind and
+ *     declare the exception in their headers. They are pinned as EXPECTED
+ *     findings carrying that note — so the note cannot be deleted while the
+ *     classNames stand, a cleanup cannot land unnoticed, and a NEW harness
+ *     cannot quietly inherit the exception.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validatePageSourceStyling, PAGE_SOURCE_CLASSNAME } from '@objectstack/lint';
+import { parseJsx } from '@object-ui/sdui-parser';
+
+const srcDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** The header line every harness that keeps its Tailwind must carry. */
+const EXCEPTION_ANCHOR = ' * ADR-0080 EXCEPTION — Tailwind in page source';
+
+interface HarnessPage {
+  kind: string;
+  name: string;
+  source: string;
+}
+
+/**
+ * Pull the page objects out of a harness file: every `kind: '<k>'` inside an
+ * object literal that also carries a `source`, with the source resolved from
+ * the template literal it names (or the ES-shorthand `source` const).
+ *
+ * Deliberately fails loudly rather than returning nothing: an extractor that
+ * silently finds zero pages is indistinguishable from a clean file, which is
+ * the exact way a count-based guard rots (objectui#5470 — the card's own 79 was
+ * a whole-file `grep -c`, i.e. LINES, harness JSX included; the rule's own count
+ * over the source strings is 95).
+ */
+function pagesOf(text: string): HarnessPage[] {
+  const pages: HarnessPage[] = [];
+  for (const m of text.matchAll(/\bkind:\s*'([a-z]+)'/g)) {
+    // widen from the `kind:` match to the enclosing object literal
+    const open = text.lastIndexOf('{', m.index);
+    if (open < 0) continue;
+    let depth = 0;
+    let close = open;
+    for (; close < text.length; close++) {
+      if (text[close] === '{') depth++;
+      else if (text[close] === '}' && --depth === 0) break;
+    }
+    const objText = text.slice(open, close + 1);
+    const bound = objText.match(/\bsource:\s*([A-Za-z_$][\w$]*)/);
+    const ident = bound ? bound[1] : /\bsource\s*[,}]/.test(objText) ? 'source' : null;
+    if (!ident) continue;
+    const decl = new RegExp(String.raw`^const\s+${ident}\s*=\s*\``, 'm').exec(text);
+    if (!decl) continue;
+    const start = decl.index + decl[0].length;
+    let i = start;
+    while (i < text.length) {
+      if (text[i] === '\\') { i += 2; continue; }
+      if (text[i] === '`') break;
+      i++;
+    }
+    const name = objText.match(/\bname:\s*'([^']+)'/)?.[1] ?? ident;
+    pages.push({ kind: m[1], name, source: text.slice(start, i) });
+  }
+  return pages;
+}
+
+function findingsFor(pages: HarnessPage[]) {
+  return validatePageSourceStyling({ pages: pages as unknown as Record<string, unknown>[] });
+}
+
+const read = (file: string) => readFileSync(path.join(srcDir, file), 'utf8');
+
+describe('ADR-0080 preview harnesses — page-source styling', () => {
+  // ---- the instrument, before anything is asserted with it ----------------
+  it('the rule fires on an authored className (control)', () => {
+    const dirty = findingsFor([
+      { kind: 'html', name: 'control', source: '<section className="p-4">x</section>' },
+    ]);
+    expect(dirty.map((f) => f.rule)).toEqual([PAGE_SOURCE_CLASSNAME]);
+    expect(dirty[0].message).toContain('1 `className` attribute');
+
+    // …and is silent on the same markup styled the prescribed way, so a green
+    // result below means "clean", not "rule inert".
+    const clean = findingsFor([
+      { kind: 'html', name: 'control', source: '<section style={{"padding":"var(--space-4)"}}>x</section>' },
+    ]);
+    expect(clean).toEqual([]);
+  });
+
+  // ---- (a) the authoring example: zero findings ---------------------------
+  it('sdui-tiers-preview.tsx authors no Tailwind in either page source', () => {
+    const pages = pagesOf(read('sdui-tiers-preview.tsx'));
+    expect(pages.map((p) => `${p.name}:${p.kind}`)).toEqual([
+      'release_notes:html',
+      'pipeline_react:react',
+    ]);
+    expect(findingsFor(pages)).toEqual([]);
+  });
+
+  it("the html-tier source's JSON style objects materialize (not deferred expressions)", () => {
+    const [html] = pagesOf(read('sdui-tiers-preview.tsx'));
+    const parsed = parseJsx(html.source);
+    expect(parsed.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    // A braced attribute is materialized by JSON.parse and kept as `{ $expr }`
+    // otherwise, so JS-object syntax (`style={{ padding: 4 }}`) would parse
+    // without complaint and render NOTHING. Every style here must be a real
+    // object, and there must be some.
+    const styles: unknown[] = [];
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) return node.forEach(walk);
+      const rec = node as Record<string, unknown>;
+      if ('style' in rec) styles.push(rec.style);
+      if (Array.isArray(rec.children)) rec.children.forEach(walk);
+    };
+    walk(parsed.tree);
+    expect(styles.length).toBeGreaterThan(8);
+    for (const s of styles) {
+      expect(s).toBeTypeOf('object');
+      expect(s).not.toHaveProperty('$expr');
+    }
+  });
+
+  // ---- (b) the plumbing previews: exception kept, and declared ------------
+  it.each([
+    ['sdui-jsx-preview.tsx', 48],
+    ['sdui-workbench-preview.tsx', 21],
+  ])('%s keeps its Tailwind AND declares the exception', (file, expected) => {
+    const text = read(file);
+    const pages = pagesOf(text);
+    expect(pages).toHaveLength(1);
+
+    const findings = findingsFor(pages);
+    expect(findings.map((f) => f.rule)).toEqual([PAGE_SOURCE_CLASSNAME]);
+    // The rule counts `className=` inside the source string; pinning the number
+    // means a class added or removed here is a deliberate, reviewed edit.
+    expect(findings[0].message).toContain(`${expected} \`className\` attributes`);
+
+    // The note is what makes the exception legible to the next reader. If the
+    // classNames ever go, this assertion is the reminder to drop the note too.
+    expect(text.split('\n')).toContain(EXCEPTION_ANCHOR);
+  });
+
+  // ---- no silent third path ----------------------------------------------
+  it('every preview harness in src/ is one of the two declared shapes', () => {
+    const harnesses = readdirSync(srcDir).filter((f) => /-preview\.tsx$/.test(f));
+    expect(harnesses.length).toBeGreaterThanOrEqual(3);
+
+    for (const file of harnesses) {
+      const text = read(file);
+      const pages = pagesOf(text);
+      if (pages.length === 0) continue; // not a source-tier harness
+      const dirty = findingsFor(pages).length > 0;
+      const declared = text.split('\n').includes(EXCEPTION_ANCHOR);
+      expect(
+        dirty === declared,
+        dirty
+          ? `${file} authors Tailwind in page source without the "${EXCEPTION_ANCHOR.trim()}" header note. ` +
+            'Style with the tier primitive (see sdui-tiers-preview.tsx), or declare the exception.'
+          : `${file} carries the exception note but authors no Tailwind in page source — drop the note.`,
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/console/src/sdui-jsx-preview.tsx
+++ b/apps/console/src/sdui-jsx-preview.tsx
@@ -1,6 +1,26 @@
 /* ADR-0080 browser preview: a kind:'jsx' page rendered through the real
- * PageRenderer (compile -> SchemaRenderer). Tailwind v4 scans this file's text
- * for class candidates, so the runtime source string is fully styled. */
+ * PageRenderer (compile -> SchemaRenderer).
+ *
+ * ADR-0080 EXCEPTION — Tailwind in page source
+ * The page source below authors Tailwind classNames. The rule forbids that in
+ * real page metadata: `source` is RUNTIME metadata, the console's Tailwind is
+ * compiled at BUILD time by scanning the console's own `src` (`@source
+ * '../src/**'` in index.css) with no safelist, so a utility class authored in a
+ * real page produces no CSS and no error anywhere. `os validate` reports it as
+ * `page-source-className-tailwind` (ADR-0065; ADR-0080's 2026-06-30 amendment;
+ * `content/docs/guide/react-pages.md` §Styling).
+ *
+ * It renders fully styled HERE only because this harness file is itself inside
+ * the scanned `src` — precisely the "works only by coincidence" failure mode
+ * ADR-0065 names. This file is a renderer-PLUMBING preview (does the jsx tier
+ * compile and mount the registered blocks), not an authoring example: DO NOT
+ * copy its source string into a page. The authoring example is
+ * `sdui-tiers-preview.tsx`, whose sources carry no className at all and style
+ * with each tier's real primitive.
+ *
+ * `__tests__/sdui-preview-page-source-styling.test.ts` pins this exception:
+ * the note cannot be dropped while the classNames stand, and a NEW harness
+ * cannot inherit the exception unnoticed. */
 import './index.css';
 import '@object-ui/components';
 import React from 'react';

--- a/apps/console/src/sdui-tiers-preview.tsx
+++ b/apps/console/src/sdui-tiers-preview.tsx
@@ -37,13 +37,13 @@ enableCapability(CAP_REACT_PAGES);
 // deferred expression.
 const htmlSource = `
 <section style={{"maxWidth":"48rem","margin":"0 auto","padding":"var(--space-10)","color":"hsl(var(--foreground))"}}>
-  <flex direction="col" gap={6}>
-    <flex direction="col" gap={3}>
+  <flex direction="col" align="stretch" gap={6}>
+    <flex direction="col" align="stretch" gap={3}>
       <h1 style={{"fontSize":"2.25rem","fontWeight":"700","letterSpacing":"-0.02em","lineHeight":"1.15"}}>Release Notes</h1>
       <p style={{"fontSize":"1rem","lineHeight":"1.7","color":"hsl(var(--muted-foreground))"}}>A <strong style={{"fontWeight":"600","color":"hsl(var(--foreground))"}}>kind:'html'</strong> page — native HTML tags and the blocks' structured props, parsed (never executed), styled from theme tokens.</p>
     </flex>
     <hr style={{"border":"0","borderTop":"1px solid hsl(var(--border))"}} />
-    <flex direction="col" gap={3}>
+    <flex direction="col" align="stretch" gap={3}>
       <h2 style={{"fontSize":"1.5rem","fontWeight":"600"}}>What shipped</h2>
       <ul style={{"paddingLeft":"var(--space-6)","listStyleType":"disc","lineHeight":"1.9","color":"hsl(var(--muted-foreground))"}}>
         <li>Full HTML tag set in the <em style={{"fontStyle":"italic"}}>html</em> tier.</li>

--- a/apps/console/src/sdui-tiers-preview.tsx
+++ b/apps/console/src/sdui-tiers-preview.tsx
@@ -1,12 +1,25 @@
 /* Browser preview for the two AI-authoring tiers, each rendered through the
  * REAL PageRenderer (not a private harness):
  *   - kind:'html'  — constrained JSX with the full native HTML tag set (h1/p/
- *     a/ul/li/img/strong/blockquote), parsed, never executed.
+ *     a/ul/li/img/strong/blockquote) plus the blocks' own structured props
+ *     (<flex direction gap>), parsed, never executed.
  *   - kind:'react' — real React (useState/map/onClick) + an injected data block,
  *     executed by @object-ui/react-runtime. Gated by CAP_REACT_PAGES, enabled
  *     here to exercise the trusted tier.
- * Tailwind v4 scans this file's text for class candidates, so the runtime
- * source strings below are fully styled. */
+ *
+ * STYLING — the two page sources below carry NO Tailwind classes, and must not
+ * acquire any. A page's `source` is runtime metadata: the console's Tailwind is
+ * compiled at build time by scanning the console's own `src` (`@source
+ * '../src/**'` in index.css) with no safelist, so a utility class authored in
+ * real page metadata produces no CSS and no error anywhere. (ADR-0065; ADR-0080's
+ * 2026-06-30 amendment; `content/docs/guide/react-pages.md` §Styling; `os
+ * validate` reports it as `page-source-className-tailwind`.) This file makes an
+ * explicit authoring claim, so its sources style the way authors are told to:
+ * the html tier with the blocks' structured props plus a JSON `style` object,
+ * the react tier with inline `style` objects — colours from the theme as
+ * `hsl(var(--token))`, so both tiers follow light/dark and whatever theme the
+ * deployment installs. `__tests__/sdui-preview-page-source-styling.test.ts`
+ * holds this file to zero authored classNames. */
 import './index.css';
 import '@object-ui/components';
 import React from 'react';
@@ -17,60 +30,92 @@ import { enableCapability, CAP_REACT_PAGES } from '@object-ui/core';
 // Trusted tier on (a host would do this; never authored metadata).
 enableCapability(CAP_REACT_PAGES);
 
+// Layout comes from <flex>'s structured props (the renderer emits the classes
+// from its OWN source, which the build does scan); everything else is a JSON
+// `style` object — quoted keys and quoted values, because the html tier
+// materializes a braced attribute with JSON.parse and keeps anything else as a
+// deferred expression.
 const htmlSource = `
-<section className="mx-auto max-w-3xl p-10">
-  <h1 className="text-4xl font-bold tracking-tight text-slate-900">Release Notes</h1>
-  <p className="mt-3 text-base leading-relaxed text-slate-500">A <strong className="font-semibold text-slate-700">kind:'html'</strong> page — plain native HTML tags, Tailwind classes, parsed (never executed).</p>
-  <hr className="my-6 border-slate-200" />
-  <h2 className="text-2xl font-semibold text-slate-800">What shipped</h2>
-  <ul className="mt-3 list-disc space-y-2 pl-6 text-slate-600">
-    <li>Full HTML tag set in the <em className="italic">html</em> tier.</li>
-    <li>A trusted <a href="https://objectui.org" className="font-medium text-indigo-600 underline">react tier</a> behind a flag.</li>
-    <li>Author writes markup; the platform renders it.</li>
-  </ul>
-  <blockquote className="mt-6 border-l-4 border-indigo-300 bg-indigo-50 p-4 text-slate-700">
-    <p>“The best custom page is one the AI can write and the platform can render safely.”</p>
-  </blockquote>
-  <img src="https://placehold.co/600x160/4f46e5/ffffff?text=kind:html" alt="banner" className="mt-6 w-full rounded-xl" />
+<section style={{"maxWidth":"48rem","margin":"0 auto","padding":"var(--space-10)","color":"hsl(var(--foreground))"}}>
+  <flex direction="col" gap={6}>
+    <flex direction="col" gap={3}>
+      <h1 style={{"fontSize":"2.25rem","fontWeight":"700","letterSpacing":"-0.02em","lineHeight":"1.15"}}>Release Notes</h1>
+      <p style={{"fontSize":"1rem","lineHeight":"1.7","color":"hsl(var(--muted-foreground))"}}>A <strong style={{"fontWeight":"600","color":"hsl(var(--foreground))"}}>kind:'html'</strong> page — native HTML tags and the blocks' structured props, parsed (never executed), styled from theme tokens.</p>
+    </flex>
+    <hr style={{"border":"0","borderTop":"1px solid hsl(var(--border))"}} />
+    <flex direction="col" gap={3}>
+      <h2 style={{"fontSize":"1.5rem","fontWeight":"600"}}>What shipped</h2>
+      <ul style={{"paddingLeft":"var(--space-6)","listStyleType":"disc","lineHeight":"1.9","color":"hsl(var(--muted-foreground))"}}>
+        <li>Full HTML tag set in the <em style={{"fontStyle":"italic"}}>html</em> tier.</li>
+        <li>A trusted <a href="https://objectui.org" style={{"fontWeight":"500","color":"hsl(var(--primary))","textDecoration":"underline"}}>react tier</a> behind a flag.</li>
+        <li>Author writes markup; the platform renders it.</li>
+      </ul>
+    </flex>
+    <blockquote style={{"borderLeft":"4px solid hsl(var(--primary))","background":"hsl(var(--muted))","borderRadius":"var(--radius)","padding":"var(--space-4)","margin":"0","color":"hsl(var(--foreground))"}}>
+      <p style={{"margin":"0"}}>“The best custom page is one the AI can write and the platform can render safely.”</p>
+    </blockquote>
+    <img src="https://placehold.co/600x160/4f46e5/ffffff?text=kind:html" alt="banner" style={{"width":"100%","borderRadius":"var(--radius-xl)"}} />
+  </flex>
 </section>`;
 
 const htmlPage = { type: 'home', kind: 'html', name: 'release_notes', label: 'Release Notes', source: htmlSource };
 
+// The react tier's styling primitive: inline `style` objects, colours as
+// `hsl(var(--token))`. Real JS, so shared style objects are just consts.
 const reactSource = `
 function Page() {
   const [sortKey, setSortKey] = React.useState('amount');
   const [count, setCount] = React.useState(0);
   const rows = [...data].sort((a, b) => (sortKey === 'amount' ? b.amount - a.amount : a.name.localeCompare(b.name)));
   const total = data.reduce((s, r) => s + r.amount, 0);
+  const cell = { padding: 'var(--space-2) 0', borderBottom: '1px solid hsl(var(--border))' };
+  const head = { padding: 'var(--space-2) 0', fontWeight: 500, color: 'hsl(var(--muted-foreground))' };
   return (
-    <div className="mx-auto max-w-3xl p-10">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold text-slate-900">Pipeline (real React)</h1>
+    <div style={{ maxWidth: '48rem', margin: '0 auto', padding: 'var(--space-10)', color: 'hsl(var(--foreground))' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--space-4)' }}>
+        <h1 style={{ fontSize: '1.875rem', fontWeight: 700, letterSpacing: '-0.02em' }}>Pipeline (real React)</h1>
         <button
           onClick={() => setCount((c) => c + 1)}
-          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+          style={{
+            borderRadius: 'var(--radius)',
+            background: 'hsl(var(--primary))',
+            color: 'hsl(var(--primary-foreground))',
+            padding: 'var(--space-2) var(--space-4)',
+            fontSize: '0.875rem',
+            fontWeight: 600,
+            border: 'none',
+            cursor: 'pointer',
+          }}
         >Clicked {count} times</button>
       </div>
-      <p className="mt-2 text-sm text-slate-500">useState · map · reduce · sort · onClick — executed by the runtime.</p>
-      <div className="mt-4 flex gap-2 text-xs">
+      <p style={{ marginTop: 'var(--space-2)', fontSize: '0.875rem', color: 'hsl(var(--muted-foreground))' }}>useState · map · reduce · sort · onClick — executed by the runtime.</p>
+      <div style={{ marginTop: 'var(--space-4)', display: 'flex', gap: 'var(--space-2)', fontSize: '0.75rem' }}>
         {['amount', 'name'].map((k) => (
           <button key={k} onClick={() => setSortKey(k)}
-            className={'rounded-full px-3 py-1 font-semibold ' + (sortKey === k ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-600')}
+            style={{
+              borderRadius: '9999px',
+              padding: 'var(--space-1) var(--space-3)',
+              fontWeight: 600,
+              border: '1px solid hsl(var(--border))',
+              cursor: 'pointer',
+              background: sortKey === k ? 'hsl(var(--foreground))' : 'hsl(var(--muted))',
+              color: sortKey === k ? 'hsl(var(--background))' : 'hsl(var(--muted-foreground))',
+            }}
           >sort by {k}</button>
         ))}
       </div>
-      <table className="mt-4 w-full text-left text-sm">
-        <thead><tr className="border-b text-slate-400"><th className="py-2">Account</th><th className="py-2 text-right">Amount</th></tr></thead>
+      <table style={{ marginTop: 'var(--space-4)', width: '100%', textAlign: 'left', fontSize: '0.875rem', borderCollapse: 'collapse' }}>
+        <thead><tr style={{ borderBottom: '1px solid hsl(var(--border))' }}><th style={head}>Account</th><th style={{ ...head, textAlign: 'right' }}>Amount</th></tr></thead>
         <tbody>
           {rows.map((r) => (
-            <tr key={r.name} className="border-b border-slate-100">
-              <td className="py-2 font-medium text-slate-700">{r.name}</td>
-              <td className="py-2 text-right tabular-nums text-slate-600">{'$' + r.amount.toLocaleString()}</td>
+            <tr key={r.name}>
+              <td style={{ ...cell, fontWeight: 500 }}>{r.name}</td>
+              <td style={{ ...cell, textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: 'hsl(var(--muted-foreground))' }}>{'$' + r.amount.toLocaleString()}</td>
             </tr>
           ))}
         </tbody>
       </table>
-      <div className="mt-3 text-right text-sm font-semibold text-slate-900">Total: {'$' + total.toLocaleString()}</div>
+      <div style={{ marginTop: 'var(--space-3)', textAlign: 'right', fontSize: '0.875rem', fontWeight: 600 }}>Total: {'$' + total.toLocaleString()}</div>
     </div>
   );
 }`;
@@ -92,9 +137,9 @@ const reactPage = {
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <div className="space-y-10 bg-slate-50">
+    <div className="space-y-10 bg-background text-foreground">
       <div data-tier="html"><SchemaRenderer schema={htmlPage as any} /></div>
-      <div className="border-t-4 border-dashed border-slate-300" />
+      <div className="border-t-4 border-dashed border-border" />
       <div data-tier="react"><SchemaRenderer schema={reactPage as any} /></div>
     </div>
   </React.StrictMode>,

--- a/apps/console/src/sdui-workbench-preview.tsx
+++ b/apps/console/src/sdui-workbench-preview.tsx
@@ -2,7 +2,28 @@
  * (<ListView> + <ObjectForm>) with React state — a master/detail workbench,
  * the exact pattern of examples/app-showcase crm-workbench.page.ts. Rendered
  * through the real PageRenderer; a tiny in-memory adapter stands in for the
- * backend so the real plugins mount and the interaction is genuinely exercised. */
+ * backend so the real plugins mount and the interaction is genuinely exercised.
+ *
+ * ADR-0080 EXCEPTION — Tailwind in page source
+ * The page source below authors Tailwind classNames. The rule forbids that in
+ * real page metadata: `source` is RUNTIME metadata, the console's Tailwind is
+ * compiled at BUILD time by scanning the console's own `src` (`@source
+ * '../src/**'` in index.css) with no safelist, so a utility class authored in a
+ * real page produces no CSS and no error anywhere. `os validate` reports it as
+ * `page-source-className-tailwind` (ADR-0065; ADR-0080's 2026-06-30 amendment;
+ * `content/docs/guide/react-pages.md` §Styling).
+ *
+ * It renders fully styled HERE only because this harness file is itself inside
+ * the scanned `src` — precisely the "works only by coincidence" failure mode
+ * ADR-0065 names. This file is a renderer-PLUMBING preview (do the real
+ * <ListView>/<ObjectForm> blocks mount and interact inside an executed react
+ * page), not an authoring example: DO NOT copy its source string into a page.
+ * The authoring example is `sdui-tiers-preview.tsx`, whose sources carry no
+ * className at all and style with each tier's real primitive.
+ *
+ * `__tests__/sdui-preview-page-source-styling.test.ts` pins this exception:
+ * the note cannot be dropped while the classNames stand, and a NEW harness
+ * cannot inherit the exception unnoticed. */
 import './index.css';
 import '@object-ui/components';
 import '@object-ui/plugin-grid';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       '@objectstack/client':
         specifier: ^17.0.0
         version: 17.1.0(ai@7.0.65(zod@4.4.3))
+      '@objectstack/lint':
+        specifier: ^17.0.0
+        version: 17.1.0(ai@7.0.65(zod@4.4.3))
       '@objectstack/spec':
         specifier: ^17.0.0
         version: 17.1.0(ai@7.0.65(zod@4.4.3))


### PR DESCRIPTION
Part of #5470

Triage settled the remedy fork on the card itself (2026-08-21): **(a)** for
`sdui-tiers-preview.tsx`, **(b)** for the other two. This implements that split. The one
judgement triage left open — whether the rewrite costs visual fidelity the manual dogfood
loop uses — is answered below with a measured before/after, not an opinion: **it costs
none, and it gains dark mode.** `Part of`, not `Fixes`, because the card's headline number
is wrong (see *The counts*) and the maintainer may want the corrected figure recorded
before it closes.

> Note for readers: GitHub's body sanitizer strips bare angle-bracket fragments even inside
> backticks (it ate seven of them on the first revision of this description), so every JSX
> tag below is written inside a fenced block or without its brackets.

## The defect

A page's `source` is **runtime metadata**. The console's Tailwind is compiled at **build**
time by scanning the console's own `src` — `apps/console/src/index.css` line 12:

```css
@source '../src/**/*.{ts,tsx}';
```

— with no safelist. So a utility class authored in *real* page metadata produces no CSS and
no error anywhere. That is the ADR-0065 "works only by coincidence" failure, recorded as
ADR-0080's 2026-06-30 amendment, and `os validate` reports it as
`page-source-className-tailwind`.

The three harnesses are the one place in the repo where the rule is violated **and still
looks right**, because each harness file is itself inside that scanned `src` — their own
headers said as much. Lift one of their source strings into a real page and every class
evaporates silently.

## The counts — the card's `79` is a whole-file `grep -c`

Re-measured on the current tip. The three files are **byte-identical** to the card's
measurement commit (blob hashes at `9bd753682` and at branch point `7e811687a` match, and
no commit touched them in between), so the difference is method, not drift:

| file | card | `className=` **inside** page `source` | rule's own count |
|---|---|---|---|
| `sdui-jsx-preview.tsx` | 40 | **48** | 48 |
| `sdui-tiers-preview.tsx` | 25 | **26** | 26 |
| `sdui-workbench-preview.tsx` | 14 | **21** | 21 |
| total | **79** | **95** | **95** |

The card's numbers reproduce exactly as:

```
grep -c 'className=' apps/console/src/sdui-jsx-preview.tsx        # 40
grep -c 'className=' apps/console/src/sdui-tiers-preview.tsx      # 25
grep -c 'className=' apps/console/src/sdui-workbench-preview.tsx  # 14
```

— which counts **matching lines**, not occurrences, and reads the **whole file**, so it
includes the harnesses' own console JSX (legitimate Tailwind, outside any page source). The
middle column counts occurrences strictly inside the page-`source` template literals; the
right column is what `validatePageSourceStyling` itself reports, and it agrees. The card
*undercounts* the violation.

## What changed

**(a) `sdui-tiers-preview.tsx` — rewritten to each tier's real primitive.** It is the file
that labels itself *"Browser preview for the two AI-authoring tiers"*, so it is the one
making an authoring claim. Its two sources now carry **zero** `className`:

- `kind:'html'` — layout from the blocks' own structured props, everything else a JSON
  `style` object:

  ```jsx
  <flex direction="col" align="stretch" gap={6}>
    <hr style={{"border":"0","borderTop":"1px solid hsl(var(--border))"}} />
    <ul style={{"paddingLeft":"var(--space-6)","listStyleType":"disc"}}>…</ul>
  </flex>
  ```

  Quoted keys and quoted values are load-bearing: the html tier materializes a braced
  attribute with `JSON.parse` and keeps anything else as a deferred `{ $expr }`, so
  JS-object syntax parses without complaint and renders **nothing**. A test covers exactly
  that.
- `kind:'react'` — inline `style` objects, real JS so shared style objects are just consts.
- Colours on both tiers as `hsl(var(--token))`.

**(b) `sdui-jsx-preview.tsx` and `sdui-workbench-preview.tsx` — kept, and declared.** They
are renderer-plumbing previews (does the tier compile and mount the registered blocks; do
the real `ListView` / `ObjectForm` blocks interact inside an executed react page). Each
header now carries an `ADR-0080 EXCEPTION` note naming the build-scan coincidence, saying
the source is not a pattern to copy, and pointing at the authoring example.

**A gate that can see the exception.** `__tests__/sdui-preview-page-source-styling.test.ts`
runs the **shipped rule** — `validatePageSourceStyling` from `@objectstack/lint`, the same
finding an author gets from `os validate` — not a local re-implementation, because a copy
of a rule cannot disagree with itself. It pins: zero findings for the authoring harness;
expected findings **with** the header note for the other two; and no third path, over an
`import.meta.glob('../*-preview.tsx')` enumeration so a **new** harness is judged without
anyone remembering to list it.

## Verification

**The gate is measured capable of failing.** Three mutation legs, each confirmed on disk
(anchor counts before/after — an editor's exit code proves nothing) and each restored under
a `trap`, restoration verified by blob hash:

| leg | mutation | on disk | result |
|---|---|---|---|
| 1 | re-add `className="p-4"` to the rewritten html source | target 1→0, injected 0→1 | **2 failed** — "authors no Tailwind", "declared shapes" |
| 2 | delete the `ADR-0080 EXCEPTION` line from `sdui-jsx-preview.tsx` | anchor lines 1→0 | **2 failed** — "declares the exception", "declared shapes" |
| 3 | JS-object style instead of JSON in the html source | json-form 1→0, js-form 0→1 | **1 failed** — "style objects materialize" |

Leg 3's message is the trap stated by the tool itself:

```
→ expected { Object ($expr) } to not have property "$expr"
```

Each leg was re-measured against the final tree after the test's read path changed. The
in-test control specimen is committed too: the rule must fire on a dirty specimen and stay
silent on a clean one, so a green run means *clean*, not *rule inert*.

**Rendered in a real browser** — Chromium (Playwright) against `vite dev` serving
`sdui-tiers-preview.html`, not merely asserted:

- structured props produce real CSS: the flex column reports `display: flex`,
  `flex-direction: column`, `gap: 24px`
- JSON `style` materializes: 12 styled nodes; the list → `list-style-type: disc;
  padding-left: 24px`; the blockquote → token background, 4px left border, 16px padding
- react tier interaction still works: click → `Clicked 1 times`; *sort by name* → first row
  `Acme` (was `Umbrella` by amount); 5 rows, `Total: $465,000`
- zero page errors on both harnesses; the untouched jsx preview still renders its 6 cards
- **theme follow-through, which is the fidelity gain:** every colour flips under `.dark` —
  h1 `rgb(2,8,23)` → `rgb(248,250,252)`, body `rgb(246,246,249)` → `rgb(14,14,16)`,
  blockquote `rgb(237,237,242)` → `rgb(39,39,43)`. The old sources hard-coded slate/indigo
  and did not move.

**One real regression, caught only by the browser and fixed.** The `flex` block's `align`
defaults to `start` (`items-start`), so the horizontal rule — no intrinsic width —
collapsed. Playwright reported:

```
123 × locator resolved to hidden <hr data-obj-type="hr"/>
```

…while its *computed border was correct all along*, so nothing static could have caught it.
`align="stretch"` is the canonical structured prop for it; re-measured, the rule, the
blockquote and the image all report 688px in a 688px column, matching the pre-change page.

**Fidelity, measured against the base.** The pre-change file was checked out at
`7e811687a` (26 `className`s — the pristine count re-asserted), re-rendered, and compared.
Same structure, same content, same richness; every difference is the palette moving from
fixed slate/indigo to theme tokens. Two things that look like losses are **not** from this
change and are identical in both renders: the `placehold.co` banner fails to load (the
sandbox proxy blocks outbound; `ERR_TUNNEL_CONNECTION_FAILED`, one occurrence in each
version), and the space between a text run and an adjacent inline element is dropped —
`A <strong>x</strong> page` renders as `Axpage` — filed as #5661, a `sdui-parser` defect
with its own fork. The other console error is a `/favicon.ico` 404.

## Gates

Run at the final commit `70fc8b9a6`, clean tree, each exit code captured **before** any
pipe and each verdict quoted from the gate's own output:

```
check-changeset-presence    EXIT=0  ✅ 4 source file(s) … declares 1 changeset(s) … EMPTY frontmatter … complete answer to this gate
check-changeset-no-major    EXIT=0  ✅ No changeset declares a `major` bump.
check-changeset-fixed       EXIT=0  ✅ All workspace packages are in the changeset fixed group.
check-control-bytes         EXIT=0  ✅ scanned 4705 tracked text file(s); skipped 85 binary
check-phantom-dependencies  EXIT=0  ✅ Every in-scope import is declared by the package that publishes it.
check-lint-coverage         EXIT=0  ✅ 46/46 packages linted, 0 with outstanding errors
check-type-check-coverage   EXIT=0  ✅ 45/46 via `type-check`, 0 errors outstanding
check-package-self-import   EXIT=0  ✅ No package names itself inside its own src/.
turbo type-check --filter=@object-ui/console  EXIT=0  (36 tasks successful; "tsc --noEmit && tsc -b tsconfig.node.json --force" echoed)
vitest --project @object-ui/console           EXIT=0  Test Files 69 passed (69) · Tests 749 passed (749)
```

**ESLint — a declared narrowing, not a skipped run.** `eslint apps/console` was run rather
than the repo-wide `eslint .`: 168 files enumerated **by ESLint itself**, count read from
`--format json`, **0 errors** (200 warnings, all pre-existing
`@typescript-eslint/no-explicit-any` on the harnesses' `as any` schema casts — same count
and kind as before). The narrowing is sound because the repo's `eslint.config.js` declares
**no** `parserOptions.project` and no `projectService`, i.e. no type-aware linting, so no
rule's verdict on a file can depend on another file's contents — and every file this branch
touches is under `apps/console` (plus a changeset `.md` and the lockfile, neither of which
`files: ['**/*.{ts,tsx}']` matches). CI runs the full farm regardless.

## Notes

- The changeset has an **empty frontmatter**: this publishes nothing. `apps/console`'s vite
  config declares no `build.rollupOptions.input` — resolved config, measured: `input` unset
  → vite's default single `index.html` entry — so the three `sdui-*-preview.html` entries
  and the modules behind them are dev-server-only and never enter `dist/`.
  `@object-ui/console`'s `files` omits `src`, and its `exports` map has exactly one entry
  (`.` → `./plugin.js`, built from `tsconfig.plugin.json` including `plugin.ts` alone,
  which imports nothing from `src/`). Re-verified this round; the shape has not moved.
- `@objectstack/lint` is added to `apps/console`'s `devDependencies` (`^17.0.0`, matching
  `@object-ui/app-shell`) because the test imports the real rule. It is not in the workspace
  root's devDependencies, so `check-phantom-dependencies` would have called it a phantom.
- Out of the fence for this round and untouched: `packages/components/src/renderers/**` and
  the `packages/types` declaration sites. Noted while reading, not fixed:
  `packages/components/src/renderers/layout/page.tsx:541` still carries the retracted
  "HTML+Tailwind" framing in a comment — that is #5469's surface, not this one's.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_