### PR TITLE
Finish the ADR-0080 page-source styling retraction across the remaining 8 prose sites

### DIFF
--- a/.changeset/page-source-tailwind-prose-retraction-5469.md
+++ b/.changeset/page-source-tailwind-prose-retraction-5469.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/react-runtime': patch
+'@object-ui/sdui-parser': patch
+'@object-ui/components': patch
+---
+
+Documentation no longer teaches the "JSX/HTML + Tailwind" framing for a page's
+`source`, which ADR-0080's own 2026-06-30 header amendment (under ADR-0065,
+Accepted) retracted. objectui#5461 corrected three sites; a multiline census
+found eight more, in three spellings a line-oriented grep could not see.
+
+A page's `source` is *runtime metadata*. The console's Tailwind is compiled at
+build time by scanning the console's own `src`, and there is no safelist, so it
+never sees your page: an authored utility class produces CSS only by coincidence
+(when objectui already ships that exact class) and otherwise produces nothing,
+with no error anywhere. That is the ADR-0065 "works only by coincidence" failure
+mode, and it is how a modal's `bg-black/50` backdrop reached production fully
+transparent. `os validate` reports it as `page-source-className-tailwind`, a
+warning on kinds `html`, `react` and `jsx`, shipped in `@objectstack/lint@11.5.0`.
+
+The tiers themselves are unchanged and every load-bearing claim survives —
+parse-never-execute, the untrusted-author safety argument for `html`, and the
+deprecated `'jsx'` alias. Only the styling primitive is corrected, to the wording
+`content/docs/guide/react-pages.md` §Styling already uses:
+
+| `kind` | Style with |
+|---|---|
+| `"html"` | The blocks' own structured props (`` `<flex direction gap>` ``, `` `<grid columns>` ``) plus a JSON `style` object. |
+| `"react"` | Inline `style` objects. |
+
+Colors on both tiers come from the theme as `hsl(var(--token))`.
+
+Why each package has an entry — each was measured against its built artefact, not
+assumed:
+
+- **`@object-ui/react-runtime`**: `README.md` is published to npm (npm includes
+  `README.md` in the tarball regardless of `files`). Its "no sandbox" callout is
+  the paragraph that routes untrusted-author work to the `html` tier, and it
+  carried the retracted framing line-wrapped across `:17-18`. It also gains the
+  §Styling section it was missing — the absence is why the framing survived here.
+- **`@object-ui/sdui-parser`**: the corrected header of `src/types.ts` projects
+  verbatim into the published `dist/types.d.ts`.
+- **`@object-ui/components`**: the corrected header of
+  `src/renderers/basic/html-elements.tsx` projects verbatim into the published
+  `dist/renderers/basic/html-elements.d.ts`. The `kind === 'html'` dispatch-arm
+  comment in `src/renderers/layout/page.tsx` does **not** project (it is inside a
+  function body) and is included here only because the same package already owes
+  an entry.
+
+No behaviour change: this is prose only. `CHANGELOG.md` occurrences are
+deliberately untouched — immutable release history.

--- a/content/docs/components/basic/div.mdx
+++ b/content/docs/components/basic/div.mdx
@@ -17,11 +17,16 @@ description: "Generic container element - use Shadcn components instead"
 The Div component is a generic container element. **It is now deprecated in favor of semantic Shadcn-based components** that provide better accessibility, consistency, and design system integration.
 
 **Scope of this deprecation: JSON-authored pages.** A `kind:'html'` page is written as
-constrained JSX/Tailwind text that the engine compiles (parses, never executes) into
+constrained JSX text that the engine compiles (parses, never executes) into
 nodes, tag name straight through — there, the plain box tag is part of that tier's own
 vocabulary and stays fully supported, because no other spelling of it exists for an
 author to migrate to. The dev-build deprecation notice is therefore reported for
 JSON-authored nodes only, and never for what the html tier compiled from its own source.
+
+Styling on that tier is the blocks' own structured props (`<flex direction gap>`,
+`<grid columns>`) plus a JSON `style` object — **not** Tailwind utility classes, which
+produce no CSS at all when authored in page `source`. `os validate` reports that as
+`page-source-className-tailwind`. See the React Pages guide, §Styling.
 
 ## Migration Guide
 

--- a/content/docs/components/basic/span.mdx
+++ b/content/docs/components/basic/span.mdx
@@ -19,11 +19,16 @@ import { DemoGrid } from '@/app/components/ComponentDemo';
 The Span component is an inline container. **It is now deprecated in favor of semantic Shadcn-based components** that provide better accessibility and design system integration.
 
 **Scope of this deprecation: JSON-authored pages.** A `kind:'html'` page is written as
-constrained JSX/Tailwind text that the engine compiles (parses, never executes) into
+constrained JSX text that the engine compiles (parses, never executes) into
 nodes, tag name straight through — there, the plain inline tag is part of that tier's own
 vocabulary and stays fully supported, because no other spelling of it exists for an
 author to migrate to. The dev-build deprecation notice is therefore reported for
 JSON-authored nodes only, and never for what the html tier compiled from its own source.
+
+Styling on that tier is the blocks' own structured props (`<flex direction gap>`,
+`<grid columns>`) plus a JSON `style` object — **not** Tailwind utility classes, which
+produce no CSS at all when authored in page `source`. `os validate` reports that as
+`page-source-className-tailwind`. See the React Pages guide, §Styling.
 
 ## Migration Guide
 

--- a/packages/components/src/__tests__/div-deprecation-provenance.test.tsx
+++ b/packages/components/src/__tests__/div-deprecation-provenance.test.tsx
@@ -9,7 +9,7 @@
 /**
  * The `div` deprecation notice is scoped BY PROVENANCE (objectui#4000).
  *
- * A `kind:'html'` page is authored as constrained JSX/Tailwind text that our own
+ * A `kind:'html'` page is authored as constrained JSX text that our own
  * parser compiles (never executes) into SDUI nodes, tag name straight through.
  * So an author writing the plain box tag in that tier gets a node the DEPRECATED
  * renderer serves — and the notice fired at them, recommending replacements that

--- a/packages/components/src/__tests__/span-deprecation-provenance.test.tsx
+++ b/packages/components/src/__tests__/span-deprecation-provenance.test.tsx
@@ -10,7 +10,7 @@
  * The `span` deprecation notice is scoped BY PROVENANCE (objectui#4917,
  * applying the ruling made for `div` in objectui#4000).
  *
- * A `kind:'html'` page is authored as constrained JSX/Tailwind text that our own
+ * A `kind:'html'` page is authored as constrained JSX text that our own
  * parser compiles (never executes) into SDUI nodes, tag name straight through.
  * So an author writing the plain inline tag in that tier gets a node the
  * DEPRECATED renderer serves — and the notice fired at them, recommending

--- a/packages/components/src/renderers/basic/html-elements.tsx
+++ b/packages/components/src/renderers/basic/html-elements.tsx
@@ -7,7 +7,7 @@
  *
  * Safe native HTML element passthrough renderers (ADR: kind:'html').
  *
- * A `kind:'html'` page is authored as a constrained JSX/Tailwind string that is
+ * A `kind:'html'` page is authored as a constrained JSX string that is
  * PARSED (never executed) into the SDUI tree. For that tier to live up to its
  * name, the everyday HTML tags an author reaches for — headings, paragraphs,
  * lists, links, images, emphasis — must each resolve to a renderer (otherwise

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -538,9 +538,15 @@ export const PageRenderer: React.FC<{
     if (kind === 'react') {
       return <ReactKindPage schema={schema} />;
     }
-    // `kind:'html'` (formerly 'jsx') — author-written constrained JSX/HTML+Tailwind
-    // compiled (parsed, never executed) to a SchemaNode tree and rendered. The
-    // legacy 'jsx' value is still accepted as a deprecated alias.
+    // `kind:'html'` (formerly 'jsx') — author-written constrained JSX compiled
+    // (parsed, never executed) to a SchemaNode tree and rendered. The legacy
+    // 'jsx' value is still accepted as a deprecated alias.
+    // Styling on this tier is the blocks' own structured props
+    // (`<flex direction gap>`, `<grid columns>`) plus a JSON `style` object —
+    // NOT Tailwind utility classes. `source` is runtime metadata, so the build's
+    // Tailwind scan never sees it and an authored class produces no CSS and no
+    // error anywhere; `os validate` reports `page-source-className-tailwind`.
+    // (ADR-0065; ADR-0080's 2026-06-30 amendment.)
     if (kind === 'html' || kind === 'jsx') {
       const src = (schema as { source?: string }).source ?? '';
       const { tree, diagnostics } = compile(src, getJsxManifest());

--- a/packages/react-runtime/README.md
+++ b/packages/react-runtime/README.md
@@ -14,8 +14,8 @@ lazy-load it behind a capability flag.
 > and everything in scope. It is not isolated, not restricted, and not
 > validated. Only run source you would run as first-party code.
 >
-> For untrusted authors use **`kind:'html'`** instead: constrained JSX/HTML +
-> Tailwind, parsed into a schema tree and never executed. See
+> For untrusted authors use **`kind:'html'`** instead: constrained JSX, parsed
+> into a schema tree and never executed. See
 > [React pages](../../content/docs/guide/react-pages.md).
 
 ## Installation
@@ -85,6 +85,23 @@ that reads `scope.import`:
 ```
 
 Anything not provided there throws `Module not found`.
+
+## Styling
+
+**Do not author Tailwind utility classes in page `source`** — on either tier. A
+page's `source` is *runtime metadata*: the console's Tailwind is compiled at
+build time by scanning the console's own `src`, and there is no safelist, so it
+never sees your page. An authored utility class produces CSS only by coincidence
+(when objectui already ships that exact class) and otherwise produces nothing,
+with no error anywhere. `os validate` reports it as
+`page-source-className-tailwind`, a warning on both tiers. (ADR-0065; ADR-0080's
+2026-06-30 amendment.)
+
+Style a `kind:'react'` page with inline `style` objects, and a `kind:'html'` page
+with the blocks' own structured props (`<flex direction gap>`, `<grid columns>`)
+plus a JSON `style` object. Colors on both tiers come from the theme as
+`hsl(var(--token))`, so a page follows light/dark and whatever theme the
+deployment installs.
 
 ## Stable scope identity matters
 

--- a/packages/sdui-parser/src/types.ts
+++ b/packages/sdui-parser/src/types.ts
@@ -2,7 +2,7 @@
  * ObjectUI — SDUI JSX-source parser (ADR-0080)
  *
  * Types shared by the constrained JSX-source compiler. The parser turns a
- * constrained JSX/HTML+Tailwind *text* into the existing SDUI `SchemaNode`
+ * constrained JSX *text* into the existing SDUI `SchemaNode`
  * tree. It PARSES — it never executes. No `import`, no `eval`, no JS.
  */
 


### PR DESCRIPTION
Fixes #5469

ADR-0080's 2026-06-30 header amendment (under ADR-0065, **Accepted**) retracted the
"JSX/HTML + Tailwind" framing for a page's `source`. #5461 corrected 3 sites and
asserted that was the complete set; it was 11. This lands the remaining 8.

## The census, re-derived (not trusted)

The card's own multiline instrument was re-derived rather than taken on faith, and
cross-checked against two independent instruments. All numbers below are occurrence
counts (NUL records / match counts), **never** `grep -c`, which counts lines.

```
grep -rnP -U -z -o --include='*.ts' --include='*.tsx' --include='*.md' --include='*.mdx' \
  --include='*.json' --include='*.js' --include='*.mjs' --include='*.css' \
  --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git \
  '(JSX|HTML|html|jsx)\s*[/+]\s*(\*|>|//|\n|\r|\s)*\s*Tailwind' .
```

**Before: 17 occurrences. After: 10, all of them deliberately preserved.** Verified
identically by `rg -U --pcre2 --hidden` and by a `git ls-files`-driven sweep.

Two corrections to the instrument as published on the card, both of which silently
change the answer:

- **It needs `--exclude-dir=node_modules --exclude-dir=dist`.** Run in a *built*
  tree it returned **51**, because the emitted `.d.ts`/`.js` copies of the very
  files being fixed are matched too. The card's clean census only held because it
  was taken in an unbuilt tree.
- **`rg` skips dot-directories by default**, so it silently misses
  `.changeset/**` unless `--hidden` is passed. That is a two-occurrence blind spot
  on this exact pattern.

## The 8 sites

Consumer-facing sites name the real primitive; the four source/test docstrings
just drop the Tailwind half of the compound.

| Site | Spelling | Treatment |
|---|---|---|
| `packages/react-runtime/README.md:17-18` | `JSX/HTML +` ⏎ `Tailwind` (line-wrapped) | names the primitive; gains the §Styling section it was missing |
| `packages/components/src/renderers/layout/page.tsx:541` | `JSX/HTML+Tailwind` | names the primitive on the `kind === 'html'` dispatch arm |
| `content/docs/components/basic/div.mdx:20` | `JSX/Tailwind` | names the primitive |
| `content/docs/components/basic/span.mdx:22` | `JSX/Tailwind` | names the primitive |
| `packages/sdui-parser/src/types.ts:5` | `JSX/HTML+Tailwind` | drops `+ Tailwind` |
| `packages/components/src/renderers/basic/html-elements.tsx:10` | `JSX/Tailwind` | drops `+ Tailwind` |
| `packages/components/src/__tests__/div-deprecation-provenance.test.tsx:12` | `JSX/Tailwind` | drops `+ Tailwind` |
| `packages/components/src/__tests__/span-deprecation-provenance.test.tsx:13` | `JSX/Tailwind` | drops `+ Tailwind` |

Note: the card and its dispatch both say "the **three** test/source docstrings".
There are **four** — `sdui-parser/src/types.ts` is the one the count misses. All
four are handled.

Wording is taken from `content/docs/guide/react-pages.md` §Styling and from the
sibling TSDoc #5461 landed in `packages/types/src/layout.ts`, so no fourth phrasing
enters the tree. The rule named is `page-source-className-tailwind`
(`@objectstack/lint@11.5.0`), a **warning** on kinds `html`/`react`/`jsx` — not
`validate-responsive-styles.ts`, which never reads page `source`. The tiers,
parse-never-execute, the untrusted-author safety argument and the deprecated `jsx`
alias are all unchanged; only the styling primitive moves.

## What was deliberately NOT touched (the 10 remaining)

- **6 occurrences in 4 `CHANGELOG.md` files** — immutable release history.
  `git diff origin/main...HEAD -- '*CHANGELOG.md'` is **empty**: zero CHANGELOG
  bytes changed. (The card says "5"; the sixth is `packages/react/CHANGELOG.md:2363`
  `raw-HTML/Tailwind`, which is a different construct — a degraded-variant note, not
  the page-source framing. Either reading leaves it untouched.)
- **2 occurrences in `.changeset/page-source-tailwind-framing-5461.md`** — #5461's
  own changeset, *quoting* the retracted framing in the course of describing its
  retraction. A mention, not a use, and another PR's pending changeset besides.
- **1 occurrence in `apps/console/src/sdui-jsx-preview.tsx:36`** — this is
  #5470 / PR #5662's **declared ADR-0080 exception**: a renderer-plumbing preview
  that keeps its Tailwind and says so in its header, pinned by
  `apps/console/src/__tests__/sdui-preview-page-source-styling.test.ts` as an
  EXPECTED finding. Touching it would break a landed pin. Not on the card's list of 8.
- (One further occurrence is added by this PR's own changeset, for the same
  mention-not-use reason.)

## #5461 overlap verdict: **landed, zero overlap**

#5461 merged as PR #5471 (`a691c0bee`), before this branch's base. Its declared
surface — `packages/types/src/layout.ts` and
`packages/components/src/renderers/layout/react-page.tsx` — is measured clean of the
pattern, and neither file is touched here. The two file sets are disjoint.

## Verification

All at `4060df523`, exit codes captured **before** any pipe.

| Gate | Verdict line |
|---|---|
| `check-changeset-presence.mjs` | `✅  5 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | `✅  No changeset declares a 'major' bump.` |
| `check-changeset-fixed.mjs` | `✅  All workspace packages are in the changeset fixed group.` |
| `check-control-bytes.mjs` | `✅  check-control-bytes: OK (scanned 4717 tracked text file(s))` |
| `check-doc-links.mjs` | `Links are valid across 13 scan roots.` |
| `check-doc-component-types.mjs` | `✅  Every documented component type is registered.` |
| `type-check` × 3 pkgs | all `Done`, 3 of 3 scripts echoed (guards the zero-match silent pass) |
| `lint` × 3 pkgs | `0 errors` (898 pre-existing warnings, none in the touched files) |
| the 2 touched test files | `Test Files 2 passed (2) / Tests 8 passed (8)` |

**Control probe.** Predicted: the census detects a re-injected *line-wrapped*
occurrence (9 → 10) while a line-oriented grep misses it. Measured exactly that —
the census went 9 → 10 and `grep -rnP 'JSX/HTML \+\s*Tailwind'` returned no match on
the same mutated file. Mutation was confirmed on disk by anchored counts in both
directions, never by an editor exit code. ⚠️ The restore leg used
`git checkout -- <path>` against an **uncommitted** edit and therefore reverted this
PR's own README changes rather than only the mutation; that was detected by the
follow-up census (back to 10), re-applied, re-verified, and the work was committed
before any further verification. Reported rather than silently retried.

## Changeset

Three packages, each justified against its **built** artefact rather than assumed:

- `@object-ui/react-runtime` — `README.md` ships to npm (npm includes `README.md`
  regardless of `files`).
- `@object-ui/sdui-parser` — the corrected header projects verbatim into
  `dist/types.d.ts`.
- `@object-ui/components` — the corrected header projects verbatim into
  `dist/renderers/basic/html-elements.d.ts`. The `page.tsx` dispatch-arm comment
  does **not** project (it is inside a function body).

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_