### PR TITLE
ComponentInput: re-export the one declaration instead of restating it three times

### DIFF
--- a/.changeset/componentinput-reexport-4972.md
+++ b/.changeset/componentinput-reexport-4972.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/core': minor
+'@object-ui/types': minor
+---
+
+`ComponentInput` is now declared once and re-exported, instead of restated in three
+places (objectui#4972).
+
+`@object-ui/core`'s `ComponentInput` (`registry/Registry.ts`) and `@object-ui/types`'
+plugin-scoped `ComponentInput` (`plugin-scope.ts`, published as `PluginComponentInput`)
+were structural copies of the interface in `@object-ui/types`' `base.ts`. Both are now
+re-exports of that one declaration, which is the disposition objectui#4580 ruled for the
+identical shape — *a structural copy would reproduce the defect the moment either side
+moved* — and the way `core/src/types/index.ts` already handles `SchemaNode`.
+
+Either side had already moved. `base.ts` declared thirteen keys; both copies declared
+nine, so `min` / `max` / `step` / `placeholder` were missing from **the copy every
+component registration actually imports**. Those four keys were unwritable at any real
+registration — a plain TypeScript error at the call site — while `ComponentInputSchema`
+(the zod schema) and `ComponentMeta.inputs` both accepted them. The publication face
+advertised four keys the authoring face rejected. Measured over the repository, no
+registration had tried to write one yet, so nothing a user hits was broken today; what
+changes is that the four keys become writable, and there is no longer a second
+declaration for the next widening to miss.
+
+`ComponentInput`'s arm vocabulary (`ComponentInputControlType`) was already a single
+declaration imported by all three sites (objectui#3832); this converges the rest of the
+interface.
+
+Measured, not assumed: `@object-ui/core`'s published entry `dist/index.d.ts` is
+byte-identical across the change (sha256 `f6494f80…`, both legs). That gauge is reported
+here only with its control — a probe that added a *required* key to `ComponentInput` left
+the same file byte-identical, because `dist/index.d.ts` is a 63-line barrel of
+`export *` lines that names `ComponentInput` zero times. The gauge that can actually fail
+is the emitted declaration file: `dist/registry/Registry.d.ts` changes, as does
+`@object-ui/types`' `dist/plugin-scope.d.ts`, and those two files are the *only* emitted
+declarations that change in either package.
+
+`WidgetInput`'s union-arm capability is deliberately untouched — a different gate path
+and a separate judgment.

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { ComponentInputControlType } from '@object-ui/types';
+import type { ComponentInput } from '@object-ui/types';
 import { PUBLIC_BLOCKS } from './public-blocks.js';
 
 export type ComponentRenderer<T = any> = T;
@@ -15,29 +15,24 @@ export type ComponentRenderer<T = any> = T;
  * What a registration DECLARES about one authorable prop.
  *
  * This is the declaration the component registrations themselves import, so it
- * is the one an author's manifest is ultimately built from. It is structurally
- * the third copy of `ComponentInput` (the others live in the types package's
- * `base.ts` and `plugin-scope.ts`); the arm vocabulary of `type` is imported
- * from there rather than re-spelled, so the union widening of objectui#3832
- * cannot land on two of the three and drift.
+ * is the one an author's manifest is ultimately built from — and it is now
+ * RE-EXPORTED from `@object-ui/types` rather than restated here
+ * (objectui#4972), the disposition objectui#4580 ruled for the identical
+ * shape: *a structural copy would reproduce the defect the moment either side
+ * moved.* This package already depends on `@object-ui/types`, so the edge
+ * exists and adds no cycle, and `src/types/index.ts` re-exports `SchemaNode`
+ * from there the same way.
+ *
+ * The copy this replaces had ALREADY moved, which is why the card is not
+ * hypothetical: it carried nine keys while `base.ts` carried thirteen, so
+ * `min` / `max` / `step` / `placeholder` were missing from *the copy every
+ * registration actually imports*. Those four keys were therefore unwritable at
+ * any real registration — a plain TS error — while `ComponentInputSchema` (the
+ * zod schema) and `ComponentMeta.inputs` both accepted them. The publication
+ * face advertised four keys the authoring face rejected; the divergence was
+ * dormant only because no registration had tried to write one yet.
  */
-export type ComponentInput = {
-  name: string;
-  /**
-   * Input control type — one coarse kind, or an array of them when the key's
-   * contract is a union (objectui#3832). A value passes the manifest gate when
-   * ANY declared arm accepts it; a value matching none is still reported. Full
-   * semantics: `ComponentInput.type` in the types package's `base.ts`.
-   */
-  type: ComponentInputControlType | ComponentInputControlType[];
-  label?: string;
-  defaultValue?: any;
-  required?: boolean;
-  enum?: string[] | { label: string; value: any }[];
-  description?: string;
-  advanced?: boolean;
-  inputType?: string;
-};
+export type { ComponentInput } from '@object-ui/types';
 
 export type ComponentMeta = {
   label?: string; // Display name in designer

--- a/packages/types/src/plugin-scope.ts
+++ b/packages/types/src/plugin-scope.ts
@@ -16,7 +16,7 @@
  * @packageDocumentation
  */
 
-import type { ComponentInputControlType } from './base.js';
+import type { ComponentInput } from './base.js';
 
 /**
  * Plugin Scope Interface
@@ -168,28 +168,15 @@ export interface ComponentMeta {
 /**
  * Component input definition
  *
- * The plugin-scoped twin of `base.ts`' {@link ComponentInput}. The arm
- * vocabulary is IMPORTED from there rather than re-spelled (objectui#3832):
- * the two interfaces already have to move together, and a second copy of the
- * eleven literals is the copy that drifts — the hazard objectui#4580's ruling
- * settled by re-exporting one declaration instead of restating it.
+ * The plugin-scoped twin of `base.ts`' {@link ComponentInput} is no longer a
+ * twin: it is the SAME declaration, RE-EXPORTED rather than restated
+ * (objectui#4972). Only the arm vocabulary was shared before (objectui#3832);
+ * this finishes the job for the rest of the interface, per objectui#4580's
+ * ruling — *a structural copy would reproduce the defect the moment either
+ * side moved.* Re-exported under this name so that `index.ts`' public
+ * `ComponentInput as PluginComponentInput` alias keeps naming a real export.
  */
-export interface ComponentInput {
-  name: string;
-  /**
-   * Input control type — one coarse kind, or an array of them for a union key.
-   * Semantics, the array form's rules and why it exists: see
-   * `ComponentInput.type` in `base.ts`.
-   */
-  type: ComponentInputControlType | ComponentInputControlType[];
-  label?: string;
-  defaultValue?: any;
-  required?: boolean;
-  enum?: string[] | { label: string; value: any }[];
-  description?: string;
-  advanced?: boolean;
-  inputType?: string;
-}
+export type { ComponentInput } from './base.js';
 
 /**
  * Event handler type


### PR DESCRIPTION
Part of #4972

> ⚠️ **Deliberately `Part of`, not `Fixes` — this PR carries an open governance question** (see *The gate conflict* below). Flip the closer to `Fixes #4972` once the widening is confirmed as the adjudicated one.

Converges the three structural copies of `ComponentInput` onto the one declaration in `@object-ui/types`' `base.ts`, per #4580's ruling for the identical shape — *"a structural copy would reproduce the defect the moment either side moved"* — and the way `core/src/types/index.ts` already handles `SchemaNode`.

- `packages/core/src/registry/Registry.ts` — the copy **every component registration actually imports** — becomes `export type { ComponentInput } from '@object-ui/types'`.
- `packages/types/src/plugin-scope.ts` (published as `PluginComponentInput`) becomes `export type { ComponentInput } from './base.js'`.

`ComponentInputControlType` (the arm vocabulary) was already single-declared by #3832; this converges the rest of the interface.

## The divergence was real, and three-way

`base.ts` declared 13 keys; both copies declared 9. `min` / `max` / `step` / `placeholder` were missing from the copy registration imports, so those four keys were unwritable at any real registration — a plain TS error — while **both** other authorities accepted them: `ComponentInputSchema` in `zod/base.zod.ts` declares all four (verified at lines 235-238), and `ComponentMeta.inputs` is typed from `base.ts`. The publication face advertised four keys the authoring face rejected. No registration had tried to write one yet, so nothing a user hits was broken today.

## Obligation 1 — the dist measurement, and why the named gauge is reported with a control

Both legs built from a **fully cleaned** state: `dist/` removed **and** every `tsconfig.tsbuildinfo` swept repo-wide. That sweep matters — the build info for these two packages lives at `packages/core/tsconfig.tsbuildinfo` and `packages/types/tsconfig.tsbuildinfo`, i.e. **outside `dist/`**, so wiping `dist/` alone would have left composite `tsc` skipping emit and compared two stale trees. Compared by sha256, never by byte count.

| emitted file | BASE | CHANGE | verdict |
|---|---|---|---|
| `core/dist/index.d.ts` | `f6494f80…` | `f6494f80…` | **byte-identical** |
| `core/dist/registry/Registry.d.ts` | `839bb311…` | `6d6679c6…` | changed |
| `types/dist/plugin-scope.d.ts` | `973093ca…` | `b73108c6…` | changed |

Those are the **only** two emitted declarations that change in either package (whole-tree `.d.ts` hash manifests diffed on both legs).

**The byte-identical result on `core/dist/index.d.ts` certifies nothing, and is reported only with the control that proves it.** A control leg added a *required* key (`__controlProbe__: number`) to core's `ComponentInput` — an indisputable published-surface change — rebuilt, and measured `core/dist/index.d.ts` at `f6494f80…`, **unchanged**, while `Registry.d.ts` moved. The reason: `core/dist/index.d.ts` is a 63-line barrel of `export *` lines that names `ComponentInput` **zero times**. It is byte-identical under *any* change to a re-exported module, so it is incapable of failing for this change class. The mutation was confirmed on disk before the build and the marker confirmed absent from `dist/` after restore, under a `trap`.

### What the published surface actually does

Reachability measured through the TypeScript checker rather than grepped (`export *` propagates a symbol without naming it, so a grep in a barrel proves nothing). A probe resolving `ComponentInput` from `packages/core/dist/index.d.ts`:

| leg | resolved properties | declaration home |
|---|---|---|
| BASE | 9 | `packages/core/dist/registry/Registry.d.ts` |
| CHANGE | **13** | `packages/types/dist/base.d.ts` |

Delta is exactly `min?: number`, `max?: number`, `step?: number`, `placeholder?: string` — **the four keys the ruling adjudicated, and nothing else** — and the declaration home collapses to the single site. Both legs ran the same probe against a fully rebuilt tree; the BASE leg restored under a `trap`.

### The gate conflict — the open question

Route (a) *prescribes* that the four keys enter the registration surface, so a byte-identical **meaningful** dist was never achievable for this card. Clause ② says a non-byte-identical delta is a published-surface change to stop and report rather than land. Both are satisfied only on the vacuous gauge, so the disposition is a judgment call and not mine to make silently:

- The measured widening is **exactly** the adjudicated four keys, no more.
- Recommendation: **land it.** Clause ②'s purpose — catching *unadjudicated* widening — is discharged by the itemized measurement above.

## Obligation 2 — registrations that newly type-error: **zero**

`turbo run type-check` across **all 40** type-checkable packages, run in three batches to stay under the runner cap and each package confirmed to have actually executed (40/40, none missing): **all green, exit 0**. The superset is the whole workspace rather than the three packages that name `ComponentInput`, because `ComponentMeta.inputs` reaches every component registration structurally, without naming the type.

This includes `packages/components` — inside another card's fence this round — so **no fenced file needed an edit**.

## Tests

- 3 suites naming `ComponentInput`: **30 passed**.
- `@object-ui/core` + `@object-ui/types`: **137 files, 2429 tests passed**.
- Gates, each read from its own verdict line: `check-changeset-presence` ✅, `check-changeset-fixed` ✅, `check-changeset-no-major` ✅, `check-doc-component-types` ✅, `check-control-bytes` ✅, `check-package-self-import` ✅, `check-phantom-dependencies` ✅, `check-type-check-coverage` ✅.

All of the above ran against the final commit, `b2b3d1ec1`.

`WidgetInput`'s union-arm capability is deliberately untouched — different gate path, separate judgment.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_