### PR TITLE
refactor(app-shell): resolve AiChatPage's share base through the one console-mount resolver

### DIFF
--- a/.changeset/ai-chat-public-share-base-4482.md
+++ b/.changeset/ai-chat-public-share-base-4482.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`AiChatPage`'s public share-link base now resolves through the one console-mount
+resolver instead of a private copy of it (objectui#4482).
+
+The page built `publicShareBase` itself — read the injected `<base href>`, take its
+pathname, trim trailing slashes, concatenate `${origin}${base}/s` — which was the third
+independent implementation of the mount resolution `resolveConsoleUrl` centralizes.
+objectui#4472 had just deleted the other two on that rule; this was the surviving
+sibling. Its output was correct, so nothing a user hits was broken and nothing a user
+hits changes: measured over the base-href matrix, the deleted builder and
+`resolveConsoleUrl('s')` return identical URLs for every shape the console is served in
+— `/_console/` (the only href the framework CLI injects), `/` root mounts, `./` portable
+builds, nested mounts, and no `<base>` at all.
+
+The `/s` resolution now lives beside its three siblings as `resolvePublicShareBase()`,
+which keeps the one thing a bare `resolveConsoleUrl('s')` call would drop: with no DOM
+it returns `undefined` rather than a URL built from an origin that does not exist, so
+`ShareDialog` applies its own fallback. It deliberately takes no `baseURI` argument —
+the mount is only ever carried by the injected `<base href>`, and a resolver with no
+other input cannot be pinned by a test that steers something production never reads.
+
+`resolvePublicShareBase.browser.test.tsx` pins the resolved base against a real injected
+`<base>` element for each deployment shape, plus a structural case asserting no other
+app-shell file reads the `<base>` tag — so a fourth copy fails a test rather than
+waiting for mount semantics to change under it.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -23,6 +23,7 @@ import { useAdapter } from '../../providers/AdapterProvider.js';
 import { useMetadata } from '../../providers/MetadataProvider.js';
 import { formatPublishFailures, type PublishFailure } from '../../views/studio-design/metadataError.js';
 import { resolveKeyedI18nLabel } from '../../utils/index.js';
+import { resolvePublicShareBase } from '../organizations/resolveHomeUrl.js';
 import { ExcelImportBar } from './ExcelImportBar.js';
 import {
   Select,
@@ -980,20 +981,10 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
 
   // Public share-link landing base. SharedRecordPage lives UNDER the console
   // SPA basename (e.g. `/_console/s/:token`), so the ShareDialog default of
-  // `${origin}/s/:token` 404s for recipients. Derive the base from the SPA's
-  // BASE_URL so the copyable link points at the actually-served route.
-  const publicShareBase = useMemo(() => {
-    if (typeof window === 'undefined' || typeof document === 'undefined') return undefined;
-    // Mirror the console's own basename resolution (App.tsx resolveBasename):
-    // the published SPA uses a relative Vite base, so the mount path is carried
-    // by the injected `<base href>` tag, NOT import.meta.env.BASE_URL.
-    let base = '';
-    try {
-      const href = document.querySelector('base')?.getAttribute('href');
-      if (href) base = new URL(href, window.location.origin).pathname.replace(/\/+$/, '');
-    } catch { /* no <base> → root-mounted SPA */ }
-    return `${window.location.origin}${base}/s`;
-  }, []);
+  // `${origin}/s/:token` 404s for recipients. The mount comes from the one
+  // console-mount resolver, which reads the injected `<base href>` — this used
+  // to be a third hand-rolled copy of that resolution (objectui#4482).
+  const publicShareBase = useMemo(() => resolvePublicShareBase(), []);
 
   // New-conversation race guard. On an IN-SPA `/ai?new=1` navigation the
   // URL-mirroring effect below fires in the SAME commit as the hook's effect,

--- a/packages/app-shell/src/console/organizations/__tests__/resolvePublicShareBase.browser.test.tsx
+++ b/packages/app-shell/src/console/organizations/__tests__/resolvePublicShareBase.browser.test.tsx
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+// @vitest-environment happy-dom
+
+/**
+ * The public share-link base resolves through the ONE console-mount resolver
+ * (objectui#4482).
+ *
+ * ## What was wrong, given nothing was broken
+ *
+ * `AiChatPage` built `publicShareBase` itself: read `<base href>`, take its
+ * pathname, trim trailing slashes, concatenate `${origin}${base}/s`. Measured
+ * output was correct for every deployment shape the console is actually served
+ * in — this card is drift risk, not a defect. It was the third independent copy
+ * of a resolution `resolveConsoleUrl` already centralizes; objectui#4472 had
+ * just deleted the other two. A correct-today duplicate is precisely the shape
+ * that rots: the next change to mount semantics updates the helper and misses
+ * the copy.
+ *
+ * So a green suite proves nothing by itself here, and these cases are written
+ * to be discriminating rather than merely passing — see the reverse
+ * verification at the bottom of this header.
+ *
+ * ## Why the pins are driven by an injected `<base>` element
+ *
+ * PR #4480 recorded the trap: `vi.stubEnv('BASE_URL', …)` does nothing against
+ * the `import.meta.env.BASE_URL` spelling, because Vite inlines that at
+ * transform time. A test steering it is permanently green while testing
+ * nothing the production path reads. The mount is carried by the injected
+ * `<base href>` tag and by nothing else, so every case below sets a real
+ * `<base>` element in the document — the same mechanism the framework CLI
+ * writes into the served HTML (`<base href="${CONSOLE_PATH}/">`) and the same
+ * one the router's own basename resolution reads (`apps/console/src/App.tsx`).
+ *
+ * ## Equivalence measured at fix time
+ *
+ * Old builder vs `resolveConsoleUrl('s')` over the base-href matrix: identical
+ * output for every reachable input — `/_console/` (the CLI's only injection,
+ * always trailing-slashed), `/` (root mount), no `<base>` (dev/standalone),
+ * `./` (portable build), and nested mounts. They differ only for inputs
+ * nothing emits: a base href with NO trailing slash, and a cross-origin
+ * absolute base href. In both the shared resolver follows the HTML base-URL
+ * semantics the router and the SPA's relative asset URLs already live by,
+ * while the deleted copy treated the href as a directory prefix and forced the
+ * document origin. Recorded on the issue rather than fixed here — changing
+ * `consoleRoot()` would move `/home` and org-switch navigation too.
+ *
+ * ## Reverse verification (performed when written)
+ *
+ * - Making `consoleRoot()` ignore the `<base>` tag (always the origin root)
+ *   reddens the two mount cases — `/_console/` and the port/scheme one — while
+ *   the root-mount and no-`<base>` cases stay green, because they resolve to
+ *   the same URL either way. That split is the point: it shows the mount cases
+ *   are measuring the mechanism and not a constant. It also reddens the scan
+ *   self-check below, which was NOT predicted and is worth writing down: that
+ *   case asserts the resolver still contains a `<base>` read, and this ablation
+ *   deletes precisely that. The coupling is correct — "the resolver is the one
+ *   place that reads the tag" is false once the resolver stops reading it — but
+ *   it means the self-check is not independent of `consoleRoot()`'s body.
+ * - Deleting the no-DOM guard from `resolvePublicShareBase` reddens the SSR
+ *   case by THROWING (`resolveConsoleUrl` reaches `window.location.origin`
+ *   through an undefined `window`), not by returning a wrong string.
+ * - Re-introducing a hand-rolled `document.querySelector('base')` into
+ *   `AiChatPage` reddens the one-resolver case with that path named.
+ * - Pointing `consoleRoot()`'s no-`<base>` fallback at `document.baseURI`
+ *   reddens only the deep-route case — the regression `resolveHomeUrl`'s
+ *   header already records, here for the share base.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolvePublicShareBase } from '../resolveHomeUrl';
+
+function setBaseHref(href: string | null): void {
+  document.head.querySelectorAll('base').forEach((el) => el.remove());
+  if (href != null) {
+    const base = document.createElement('base');
+    base.setAttribute('href', href);
+    document.head.appendChild(base);
+  }
+}
+
+describe('resolvePublicShareBase (injected <base href> mechanism)', () => {
+  afterEach(() => {
+    setBaseHref(null);
+    vi.unstubAllGlobals();
+    history.pushState({}, '', '/');
+  });
+
+  it('lands under the console mount the framework CLI injects', () => {
+    // `<base href="/_console/">` — packages/cli/src/utils/console.ts writes
+    // exactly this (CONSOLE_PATH + '/'). A recipient opening the copied link
+    // must reach SharedRecordPage at /_console/s/:token, not /s/:token.
+    setBaseHref('/_console/');
+    expect(resolvePublicShareBase()).toBe(`${window.location.origin}/_console/s`);
+  });
+
+  it('is the origin root on a root-mounted deployment', () => {
+    setBaseHref('/');
+    expect(resolvePublicShareBase()).toBe(`${window.location.origin}/s`);
+  });
+
+  it('is the origin root when the host injected no <base> at all', () => {
+    // Standalone / `os dev` runs ship no <base>; the SPA is root-mounted.
+    setBaseHref(null);
+    expect(resolvePublicShareBase()).toBe(`${window.location.origin}/s`);
+  });
+
+  it('ignores the current SPA route when no <base> is present', () => {
+    // The share dialog opens from deep inside the chat surface. Resolving
+    // against the current document URL would produce /ai/agent/s — the same
+    // family of bug as resolveHomeUrl's /home/home/home regression.
+    setBaseHref(null);
+    history.pushState({}, '', '/ai/support_agent/conv_123');
+    expect(resolvePublicShareBase()).toBe(`${window.location.origin}/s`);
+  });
+
+  it('carries a non-default port and scheme through unchanged', () => {
+    setBaseHref('/_console/');
+    const url = new URL(resolvePublicShareBase()!);
+    expect(url.origin).toBe(window.location.origin);
+    // Regression the resolver family exists for: `${origin}${BASE_URL}` with a
+    // relative Vite base produced a trailing-dot host in production.
+    expect(url.hostname.endsWith('.')).toBe(false);
+    expect(url.pathname).toBe('/_console/s');
+  });
+
+  it('returns undefined with no DOM instead of guessing an origin', () => {
+    // ShareDialog then applies its own fallback. A string built here without a
+    // window would be a link to a host that does not exist.
+    setBaseHref('/_console/');
+    vi.stubGlobal('window', undefined);
+    expect(resolvePublicShareBase()).toBeUndefined();
+  });
+});
+
+/**
+ * The structural half. The behavioural cases above cannot tell "routes through
+ * the shared resolver" from "hand-rolls the same answer correctly" — which is
+ * the entire subject of this card, and what the next copy will look like.
+ */
+describe('objectui#4482 — app-shell reads <base href> in exactly one place', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const srcRoot = path.resolve(here, '../../..');
+  const RESOLVER = path.join(srcRoot, 'console/organizations/resolveHomeUrl.ts');
+  const BASE_TAG_READ = /(querySelector|querySelectorAll|getElementsByTagName)\(\s*['"`]base['"`]\s*\)/;
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full, out);
+      // Tests legitimately create and clear <base> elements — including this
+      // file, which must not fence itself out of existence.
+      else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full);
+    }
+    return out;
+  }
+
+  const files = walk(srcRoot);
+
+  it('is reading the real tree, not an empty one', () => {
+    expect(files.length).toBeGreaterThan(200);
+    expect(files).toContain(RESOLVER);
+  });
+
+  it('no app-shell file outside the resolver reads the <base> tag', () => {
+    const offenders = files.filter(
+      (f) => f !== RESOLVER && BASE_TAG_READ.test(readFileSync(f, 'utf8')),
+    );
+    expect(offenders.map((f) => path.relative(srcRoot, f))).toEqual([]);
+  });
+
+  it('the scan can see a hand-rolled read (it is not a regex that never matches)', () => {
+    // Without this the case above would pass just as well spelled wrong. This
+    // is the exact line deleted from AiChatPage.
+    expect(BASE_TAG_READ.test("document.querySelector('base')?.getAttribute('href')")).toBe(true);
+    expect(BASE_TAG_READ.test(readFileSync(RESOLVER, 'utf8'))).toBe(true);
+  });
+});

--- a/packages/app-shell/src/console/organizations/resolveHomeUrl.ts
+++ b/packages/app-shell/src/console/organizations/resolveHomeUrl.ts
@@ -58,3 +58,35 @@ export function resolveRootUrl(baseURI?: string): string {
 export function resolveConsoleUrl(path: string, baseURI?: string): string {
   return new URL(path.replace(/^\//, ''), resolveRootUrl(baseURI)).toString();
 }
+
+/**
+ * Resolve the public share-link landing base — the console-mounted `/s` route
+ * that `SharedRecordPage` serves (`/_console/s/:token` on a CLI-served
+ * deployment). `ShareDialog` appends `/:token` to it for the link a user
+ * copies and hands to a recipient.
+ *
+ * `ShareDialog`'s own default is `${origin}/s/:token`, which 404s wherever the
+ * console is not root-mounted. The link is a full-page destination pasted into
+ * another browser, so it needs exactly the deployment-mount resolution the
+ * navigations above already do — and it takes it from {@link resolveConsoleUrl}
+ * rather than a private copy. This helper replaced the third hand-rolled
+ * base-href reader in the console (objectui#4482); objectui#4472 removed the
+ * other two. One resolver, so the next change to mount semantics cannot reach
+ * some call sites and miss others.
+ *
+ * Returns `undefined` — not a guessed URL — with no DOM, so `ShareDialog`
+ * applies its own fallback instead of rendering a link built from an origin
+ * that does not exist. That guard is the one thing this adds over a bare
+ * `resolveConsoleUrl('s')` call.
+ *
+ * Deliberately takes no `baseURI` argument, unlike its three siblings: the
+ * mount is only ever carried by the injected `<base href>`, and a resolver
+ * with no other input cannot be pinned by a test that steers something the
+ * production path never reads (the `vi.stubEnv('BASE_URL', …)` trap recorded
+ * in objectui#4482 — Vite inlines `import.meta.env` at transform time, so such
+ * a test is permanently green).
+ */
+export function resolvePublicShareBase(): string | undefined {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return undefined;
+  return resolveConsoleUrl('s');
+}


### PR DESCRIPTION
Fixes #4482

`AiChatPage` built `publicShareBase` itself — read the injected `<base href>`, take its pathname, trim trailing slashes, concatenate `${origin}${base}/s`. That was the third independent implementation of the console-mount resolution `resolveConsoleUrl` centralizes; #4472 had just deleted the other two on the one-resolver rule, and this was the surviving sibling.

The `/s` resolution now lives beside its three siblings in `resolveHomeUrl.ts` as `resolvePublicShareBase()`, which delegates to `resolveConsoleUrl('s')` and keeps the one thing a bare call would drop: with no DOM it returns `undefined` rather than a URL built from an origin that does not exist, so `ShareDialog` applies its own fallback.

## Parameter shape, measured at fix time (the card asked for this, not assumed)

Old builder vs `resolveConsoleUrl('s')` over the base-href matrix:

| injected `<base href>` | old builder | `resolveConsoleUrl('s')` | |
|---|---|---|---|
| `/_console/` | `https://host/_console/s` | `https://host/_console/s` | same |
| `/` | `https://host/s` | `https://host/s` | same |
| no `<base>` tag | `https://host/s` | `https://host/s` | same |
| `./` | `https://host/s` | `https://host/s` | same |
| `/a/b/` | `https://host/a/b/s` | `https://host/a/b/s` | same |
| `/_console` (no trailing slash) | `https://host/_console/s` | `https://host/s` | **differs** |
| `https://cdn.example/_console/` | `https://host/_console/s` | `https://cdn.example/_console/s` | **differs** |

**No currently-reachable input changes.** The only injector in the platform is `packages/cli/src/utils/console.ts`, which writes `` `<base href="${CONSOLE_PATH}/">` `` — always trailing-slashed — and objectui ships no `<base>` tag in any HTML of its own (`grep` over `apps/**`, `packages/**`). The remaining reachable shapes are "no `<base>` tag" (standalone / `os dev`) and `/` (root mount), both identical either way.

The two divergent shapes are unreachable, and in both the shared resolver follows the HTML base-URL semantics the router basename and the SPA's own relative asset URLs already live by, while the deleted copy treated the href as a directory prefix and forced the document origin. A third, same-family difference: at origin `"null"` (a `file://` or sandboxed-iframe document) the shared resolver throws where the copy produced the garbage string `null/s` — the console's other full-page navigation helpers (`resolveRootUrl` in `WorkspaceSwitcher` / `OrganizationsPage`) already throw there, so this aligns rather than regresses. Nothing here is changed in `consoleRoot()`: that would move `/home` and org-switch navigation too, which is outside this card. Filed as #5678 instead.

## Tests

`resolvePublicShareBase.browser.test.tsx` — six behavioural cases driven by a **real injected `<base>` element**, never `vi.stubEnv('BASE_URL', …)`. That trap is recorded on the card: Vite inlines `import.meta.env` at transform time, so a test steering it is permanently green while testing nothing the production path reads. Plus three structural cases: no app-shell file outside the resolver reads the `<base>` tag, the scan is reading a real tree (over 200 files), and the scan's regex actually matches a hand-rolled read.

Since the card is explicitly "correct today", a green suite proves nothing on its own — the discriminating evidence is the ablation. Each leg's direction was predicted before running; each mutation was confirmed on disk (anchor gone, injected text present, counted with `grep -o | wc -l`) by a helper that **raises on a zero match**, restored under a `trap … EXIT INT TERM`, and the restore verified by sha256.

| leg | mutation | predicted | observed |
|---|---|---|---|
| A | `consoleRoot()` ignores the `<base>` tag | 2 failed / 7 passed | **3 failed / 6 passed** |
| B | delete the no-DOM guard | 1 failed / 8 passed, by throwing | 1 failed / 8 passed — `TypeError: Cannot read properties of undefined (reading 'location')` |
| C | re-introduce the hand-rolled read in `AiChatPage` | 1 failed / 8 passed, offender named | 1 failed / 8 passed — `expected [ 'console/ai/AiChatPage.tsx' ] to deeply equal []` |
| D | no-`<base>` fallback → `document.baseURI` | 1 failed / 8 passed | 1 failed / 8 passed — `expected 'http://localhost:3000/ai/support_agen…' to be 'http://localhost:3000/s'` |

**Leg A missed its prediction and the miss is recorded in the test header rather than papered over.** The two mount cases reddened as predicted (`/_console/s` → `/s`) and the root-mount, no-`<base>`, deep-route and SSR cases stayed green — that split is the point, since it shows the mount cases measure the mechanism and not a constant. The unpredicted third failure is the scan self-check, which asserts the resolver still contains a `<base>` read; leg A deletes exactly that. The coupling is correct but real, so the header now says so.

**One void leg, disclosed:** leg B's first run was voided by my own confirmation step, not by the mutation. `grep -o -F` with a *multi-line* anchor matches each line separately, and the injected line still contained the second anchor line as a substring, so "anchor occurrences after" read 1 instead of 0. The mutation had in fact been applied and was restored unread; the leg was re-run with a single-line anchor and the count then meant what it said.

No rebuild leg was needed and that is measured, not assumed: the pin imports the subject through a relative source specifier (`from '../resolveHomeUrl'`), and `packages/app-shell/dist` does not exist in this worktree at all, so the green run cannot have been reading a stale build.

## Local gates — all at `867124423`, the final commit

| command | verdict line |
|---|---|
| `pnpm --filter '@object-ui/app-shell^...' build` (upstream closure) | `BUILD_EXIT=0` |
| `pnpm --filter '@object-ui/app-shell' type-check` | `TYPECHECK_EXIT=0` (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm exec vitest run packages/app-shell/` | `Test Files 493 passed (493)` · `Tests 4843 passed, 1 skipped (4844)` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 4724 tracked text file(s); skipped 85 binary)` |
| `check:esm-specifiers` | `no un-ledgered package emits an extensionless relative specifier` |
| `check:self-import` | `✅ No package names itself inside its own src/` |

**ESLint was narrowed to the changed files, and the narrowing is a measurement:** the population comes from eslint's own config (`files: ['**/*.{ts,tsx}']`, `eslint.config.js:28`), which excludes the `.md` changeset; `--format json` reported **3** file entries for the 3 lintable changed files, none of them ignored; and `eslint.config.js` sets no `parserOptions.project` / `projectService`, so linting is not type-aware and this diff cannot move the verdict of any file it does not touch. Result: **0 errors**, exit 0.

Worth flagging in the other direction: the warning count on `AiChatPage.tsx` goes **26 → 28**. The two extra diagnostics are `react-hooks/refs` at line 1004 (the `staleNewTargetRef` render-phase write, deliberate and documented in place) and `react-hooks/set-state-in-effect` at line 1082 (an existing title-hint effect) — both pre-existing code I did not author, of rule classes already firing 9× and 2× in this file. Shrinking the `useMemo` body changed what the compiler-based rules could analyse before bailing out, surfacing two more instances of the same patterns. `.github/workflows/lint.yml` deliberately sets no `--max-warnings`, so nothing fails on it.

## Note for the next holder of the verify lock

The app-shell suite alone runs 686s; this PR's heavy leg held the shared lock 927s with three sibling agents queued behind it. Saying so on the card as the lock's own advice asks: for a change this narrow, the resolver directory would have been the honest scope, and the full package suite was wider than the diff warranted.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_


---
_Generated by [Claude Code](https://claude.ai/code)_