### PR TITLE
ComponentRendererProps: re-export the one declaration instead of restating it

### DIFF
--- a/.changeset/componentrendererprops-reexport-4594.md
+++ b/.changeset/componentrendererprops-reexport-4594.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/core': minor
+---
+
+`ComponentRendererProps` is now declared once and re-exported, instead of
+hand-declared a second time in `@object-ui/core` (objectui#4594).
+
+`@object-ui/core`'s `ComponentRendererProps` (`src/types/index.ts`) was a
+non-generic interface typing `schema` as `SchemaNode`, while
+`@object-ui/types`' declaration of the same name is generic —
+`ComponentRendererProps< TSchema extends BaseSchema = BaseSchema >` with
+`schema: TSchema`. Same name, both exported from their package entry, from two
+packages the same consumers import together: which declaration a call site got
+depended on which package it reached for, and the two disagree about whether a
+primitive node is admissible. Core's is now a re-export of types', which is the
+disposition objectui#4580 ruled for `SchemaNode` two lines above it in the same
+file, and objectui#4972 for `ComponentInput` — *a structural copy would
+reproduce the defect the moment either side moved*.
+
+**Published-surface effect, and the reason it is not neutral.** Resolved
+through the TypeScript checker from `core/dist/index.d.ts` over a clean rebuild
+of both legs, `ComponentRendererProps` as reached through `@object-ui/core`
+moves from non-generic with
+`schema: BaseSchema | string | number | boolean | null | undefined` to
+`ComponentRendererProps<TSchema>` with `schema: TSchema`, defaulting to
+`BaseSchema`. `schema` therefore **narrows** back to the object form — core's
+copy had silently widened when objectui#4608 made core's `SchemaNode` a
+re-export of types' union — and the type gains a parameter. **Nothing imported
+it**, on either side, re-verified repo-wide on the merged ref, so no call site
+can observe either move; the narrowing is recorded here because it is a change
+to a published type, not because a consumer is affected.
+
+A compile-time pin now holds the reconciliation from
+`@object-ui/react` — the only position that resolves both packages through
+`node_modules` — alongside the existing `SchemaNode` one. It is a test-only
+addition and emits nothing, so `@object-ui/react` takes no bump of its own.

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -40,17 +40,55 @@
  */
 export type { SchemaNode } from '@object-ui/types';
 
-import type { SchemaNode } from '@object-ui/types';
-
 /**
- * ⛔ Deliberately NOT reconciled with `@object-ui/types`' `ComponentRendererProps`
- * (objectui#4594). The two declarations differ — types' is generic
- * (`< TSchema extends BaseSchema = BaseSchema >`), this one is not — but that
- * card measured **zero consumers** of this declaration, so reconciling it here
- * would be an unmeasured change riding a card that was scoped to `SchemaNode`.
- * It stays dual-declared until #4594 is dispatched on its own evidence.
+ * One `ComponentRendererProps` (objectui#4594).
+ *
+ * This package used to hand-declare `interface ComponentRendererProps
+ * { schema: SchemaNode; [key: string]: any }` here — two lines below `SchemaNode`
+ * and against `@object-ui/types`' generic
+ * `ComponentRendererProps< TSchema extends BaseSchema = BaseSchema >`. Same name,
+ * two packages the same consumers import together: the second such pair in this
+ * one file, and the third across this fault line after `SchemaNode` (#4580) and
+ * `ComponentInput` (#4972).
+ *
+ * **`@object-ui/types`' generic declaration wins**, and is RE-EXPORTED rather
+ * than restated, so there is exactly one declaration left to disagree with — a
+ * structural copy would reproduce the defect the moment either side moved.
+ *
+ * Reconciled now, at **zero consumers** — re-verified on the merged ref rather
+ * than inherited from the card: repo-wide, `ComponentRendererProps` occurred only
+ * at the two declarations, each package's own entry re-export, and one line of
+ * `packages/components/CHANGELOG.md` recording that nothing used it. Zero
+ * consumers is why this is cheap today and would not stay cheap: the day someone
+ * imports it, which declaration they get decides whether a primitive node is
+ * admissible.
+ *
+ * ## What the re-export moves, and how that was measured
+ *
+ * It is NOT surface-neutral, and the gauge that would have said so is vacuous.
+ * `core/src/index.ts` is a 95-line `export *` barrel; `core/dist/index.d.ts` is
+ * therefore byte-identical under ANY change to a re-exported module and cannot
+ * fail for this change class (objectui#5673 — which is also why the sentence
+ * above `SchemaNode` citing that byte-identity is not repeated here).
+ *
+ * Measured instead by resolving the symbol through the TypeScript CHECKER from
+ * `core/dist/index.d.ts`, over a `dist/` + `tsconfig.tsbuildinfo` clean rebuild
+ * on both legs (the build info lives outside `dist/`, so composite `tsc` skips
+ * emit if it survives and two stale trees compare equal for free):
+ *
+ * ```
+ * before   ComponentRendererProps            schema: BaseSchema | string | number | boolean | null | undefined
+ * after    ComponentRendererProps<TSchema>   schema: TSchema  (TSchema extends BaseSchema = BaseSchema)
+ * ```
+ *
+ * So `schema` NARROWS back to the object form — core's copy had silently widened
+ * when #4608 made `SchemaNode` a re-export of types' union, which is the interim
+ * state this card closes — and the type gains a parameter. Nothing downstream
+ * can observe either move, because nothing imports it.
+ *
+ * The collision is only observable from a package that resolves BOTH through
+ * `node_modules`; the pin therefore lives in `@object-ui/react`
+ * (`src/__tests__/ComponentRendererProps.reconciliation.test.ts`), not here —
+ * same position, same reason, as `SchemaNode`'s pin above.
  */
-export interface ComponentRendererProps {
-  schema: SchemaNode;
-  [key: string]: any;
-}
+export type { ComponentRendererProps } from '@object-ui/types';

--- a/packages/react/src/__tests__/ComponentRendererProps.reconciliation.test.ts
+++ b/packages/react/src/__tests__/ComponentRendererProps.reconciliation.test.ts
@@ -1,0 +1,117 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One `ComponentRendererProps` (objectui#4594).
+ *
+ * Two packages published a type of this name and they were not the same type:
+ *
+ *   `@object-ui/core`  `interface ComponentRendererProps { schema: SchemaNode; … }`
+ *   `@object-ui/types` `interface ComponentRendererProps< TSchema extends BaseSchema = BaseSchema > { schema: TSchema; … }`
+ *
+ * The second such pair in one file — it sat two lines below `SchemaNode`, whose
+ * reconciliation #4580/PR #4608 settled — and the third across this fault line
+ * once `ComponentInput` (#4972/PR #5671) is counted. `@object-ui/types`' generic
+ * declaration wins and core's becomes a re-export, so there is exactly one
+ * declaration left to disagree with.
+ *
+ * ## Why this file lives in `@object-ui/react`
+ *
+ * Same reason as `SchemaNode.reconciliation.test.ts` next door: the pin has to
+ * be a CONSUMER of both packages, resolving each through `node_modules`. This
+ * package's `tsconfig.test.json` sets `"paths": {}` precisely so `@object-ui/*`
+ * resolve through the workspace dependency's built `.d.ts` rather than pulling
+ * sibling sources in as program inputs — which is what makes the two `dist`
+ * identities real rather than an artefact of the source tree.
+ *
+ * `ComponentRendererProps` had **zero consumers** when this was written (the
+ * measurement #4594 was dispatched on, re-verified on the merged ref). This
+ * file is therefore the type's first consumer, and deliberately so: a name that
+ * nothing imports is a name nothing can hold still, and the interim state the
+ * card closes — core's `schema` silently widened to types' `SchemaNode` union
+ * when #4608 landed — arrived exactly that way, with no consumer to notice.
+ *
+ * ## Predictions, written before the first run (red-first)
+ *
+ * With core's declaration restored to the hand-written non-generic interface,
+ * `tsc -p packages/react/tsconfig.test.json` must report:
+ *
+ *   1. `assertion1` — `Equal< CoreProps, TypesProps >` resolves `false`
+ *      (core's `schema` is the `SchemaNode` union, types' is `BaseSchema`), so
+ *      `Expect< … >` fails its `extends true` constraint: **TS2344**.
+ *   2. `assertion2` / `narrowedSchemaArmCompiles` — a type argument applied to
+ *      core's name: **TS2315**, `Type 'ComponentRendererProps' is not generic`.
+ *   3. `narrowedSchemaArmCompiles` again, at the read — core's `schema` is the
+ *      union, which is not assignable to a `BaseSchema` sub-interface: **TS2322**.
+ *
+ * After the fix all three compile clean. The equality assertion is deliberately
+ * INVARIANT (`Equal`, not `extends`): the index signature `[key: string]: any`
+ * makes almost anything mutually assignable, so a one-way `extends` — or a bare
+ * `satisfies` — would stay green against a structural copy, which is the whole
+ * defect.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ComponentRendererProps as CoreProps } from '@object-ui/core';
+import type {
+  ComponentRendererProps as TypesProps,
+  BaseSchema,
+} from '@object-ui/types';
+
+/* ── Type-level helpers ──────────────────────────────────────────────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/** A concrete arm, to prove the type parameter is reachable through core's name. */
+interface TextSchema extends BaseSchema {
+  type: 'text';
+  value?: string;
+}
+
+/* ── 1. The two names are now one type ───────────────────────────────────── */
+
+export type assertion1 = Expect< Equal< CoreProps, TypesProps > >;
+
+/* ── 2. Core's name carries the type parameter, with the same default ────── */
+
+export type assertion2 = Expect< Equal< CoreProps< TextSchema >, TypesProps< TextSchema > > >;
+export type assertion3 = Expect< Equal< CoreProps, TypesProps< BaseSchema > > >;
+
+/* ── 3. The parameter actually narrows `schema`, read through core's name ── */
+
+/**
+ * ⚠️ Inside a never-called function on purpose — the sibling `SchemaNode` pin
+ * records why: `declare`d values are type-level fictions, so a top-level
+ * `const` of one throws `ReferenceError` the moment vitest imports the module
+ * and fails the whole suite before a case runs. A function body is checked by
+ * `tsc` just as thoroughly and never executes, which is what lets one file be
+ * read by both tools. Nothing here is `declare`d today, but the constraint is
+ * the file's, not the expression's.
+ */
+export function narrowedSchemaArmCompiles(): void {
+  const props: CoreProps< TextSchema > = { schema: { type: 'text', value: 'Hello' } };
+  // Pre-fix this read is the union, not the arm: TS2322.
+  const node: TextSchema = props.schema;
+  void node;
+}
+
+/* ── Runtime companion ───────────────────────────────────────────────────── */
+
+describe('ComponentRendererProps is declared once (objectui#4594)', () => {
+  it('type-level: core and types name the same type', () => {
+    // The assertions above are erased at runtime — `tsc -p tsconfig.test.json`
+    // is what checks them, and this package chains that from `type-check`.
+    // This case documents that the pin is compile-time, so a reader does not
+    // mistake a green vitest run for the proof.
+    const witness: CoreProps< TextSchema > = { schema: { type: 'text' } };
+    expect(witness.schema.type).toBe('text');
+  });
+});


### PR DESCRIPTION
Fixes #4594

Converges the **second** dual declaration living in the same two files as `SchemaNode` onto the one declaration in `@object-ui/types`, per triage's ruled scope and the #4580 / PR #4608 precedent sitting two lines above it in the same file. The ⛔ *"Deliberately NOT reconciled … stays dual-declared until #4594 is dispatched on its own evidence"* marker comes out in the same diff — `main` was waiting on this card.

- `packages/core/src/types/index.ts` — the local non-generic `interface ComponentRendererProps { schema: SchemaNode; [key: string]: any }` becomes `export type { ComponentRendererProps } from '@object-ui/types'`. The `import type { SchemaNode }` line above it goes with it: the deleted interface was its only reader.
- `packages/react/src/__tests__/ComponentRendererProps.reconciliation.test.ts` — new compile-time pin, beside the `SchemaNode` one, in the only position that resolves both packages through `node_modules`.

Third convergence across this fault line, after `SchemaNode` (#4580) and `ComponentInput` (#4972 / PR #5671).

## Obligation 1 — zero consumers, re-verified on the merged ref

Re-run rather than inherited from the card, repo-wide on `d7573b3f4` (`grep -rn ComponentRendererProps`, excluding `node_modules` / `.git` / `dist`). Five hits, **zero of them a consumer**:

| hit | what it is |
|---|---|
| `packages/types/src/base.ts:341` | the generic declaration |
| `packages/types/src/index.ts:93` | types' own entry re-export |
| `packages/core/src/types/index.ts:46,53` | the ⛔ marker + the non-generic declaration |
| `packages/core/src/index.ts:9` | core's own entry re-export |
| `packages/components/CHANGELOG.md:1725` | prose, recording *"21 occurrences … against zero uses of `ComponentRendererProps`"* |

No import on either side, so the mechanical disposition stands and nothing downstream can observe the shape move measured below.

## Obligation 2 — the surface measurement, and the gauge this PR refuses to use

**`core/dist/index.d.ts` byte-identity is not cited as evidence here.** `packages/core/src/index.ts` is a 95-line `export *` barrel naming neither symbol, so the emitted `core/dist/index.d.ts` is byte-identical under *any* change to a re-exported module and is incapable of failing for this change class — #5673, filed off #5671's control leg. It came out byte-identical again this round (`f6494f80…` on both legs, the same hash #5671 recorded), and that is reported as a **control**, not as a result.

Both legs built from a fully cleaned state: `dist/` removed **and** every `tsconfig.tsbuildinfo` swept repo-wide. The sweep is load-bearing — those files live at `packages/core/tsconfig.tsbuildinfo` and `packages/types/tsconfig.tsbuildinfo`, i.e. *outside* `dist/`, so wiping `dist/` alone leaves composite `tsc` skipping emit and compares two stale trees for free. Measured: the CHANGE leg swept exactly those two. Compared by sha256, never by byte count.

Whole-tree `.d.ts` sha256 manifests over `packages/core/dist` + `packages/types/dist` — **145 files on each leg, exactly one differs**:

| emitted file | BASE | CHANGE | verdict |
|---|---|---|---|
| `core/dist/types/index.d.ts` | `893cb23b…` | `0e64c8c6…` | **changed** |
| `core/dist/index.d.ts` | `f6494f80…` | `f6494f80…` | byte-identical — *the vacuous gauge* |
| the other 143 | — | — | unchanged |

### What the published surface actually does

Reachability and shape resolved through the TypeScript **checker** (`checker.getExportsOfModule` on each package's entry `.d.ts`, then aliases followed to the declaration), never grepped — `export *` propagates a symbol without naming it, so a grep in a barrel proves nothing.

`ComponentRendererProps` as reached through `@object-ui/core`:

| leg | type parameters | `schema` resolves to | declaration home |
|---|---|---|---|
| BASE | none (non-generic) | `BaseSchema \| string \| number \| boolean \| null \| undefined` | `packages/core/dist/types/index.d.ts` |
| CHANGE | `TSchema extends BaseSchema = BaseSchema` | `TSchema` (default `BaseSchema`) | `packages/types/dist/base.d.ts` |

So this change **does** move the resolved shape, in two ways, and the declaration home collapses to the single site shared with `@object-ui/types`:

1. **`schema` narrows** — from the `SchemaNode` union back to the object form. Core's copy had silently *widened* when PR #4608 made core's `SchemaNode` a re-export of types' union; the card predicted that side effect and it happened. This closes the interim state rather than creating one.
2. **The type gains a parameter**, so a call site can pin `schema` to its own `BaseSchema` sub-interface through core's name.

**Can anything downstream see it? No** — Obligation 1: nothing imports the type, on either side. The narrowing is declared in the changeset because it is a change to a published type, not because a consumer is affected.

## Ablation — direction predicted before running

Predicted **RED**: restore core's hand-declared interface, rebuild, and the new pin must fail with (1) TS2344 where `Equal<>` resolves `false`, (2) TS2315 `Type 'ComponentRendererProps' is not generic` wherever a type argument is applied to core's name, (3) TS2322 at `const node: TextSchema = props.schema`. The `tsc --noEmit` half over `src` was predicted to stay **green** (no source consumer).

Observed — `pnpm --filter @object-ui/react type-check` **exit 2**, five errors:

```
ComponentRendererProps.reconciliation.test.ts(81,34): error TS2344: Type 'false' does not satisfy the constraint 'true'.
ComponentRendererProps.reconciliation.test.ts(85,41): error TS2315: Type 'ComponentRendererProps' is not generic.
ComponentRendererProps.reconciliation.test.ts(86,34): error TS2344: Type 'false' does not satisfy the constraint 'true'.
ComponentRendererProps.reconciliation.test.ts(100,16): error TS2315: Type 'ComponentRendererProps' is not generic.
ComponentRendererProps.reconciliation.test.ts(114,20): error TS2315: Type 'ComponentRendererProps' is not generic.
```

(1) and (2) landed as predicted, 2× and 3×. The `src` half stayed green — `&&` short-circuits, so the test project could only have run because it passed.

**(3) did not appear, and the prediction was wrong rather than the leg void.** TS2315 resolves the offending type reference to the error type, so `props` is poisoned to `any` and the assignment underneath it is never checked: the third error is *absorbed* by the second, not additive. Reported as observed.

Both legs rebuilt (`tsconfig.tsbuildinfo` swept, `types` then `core`), and the mutation confirmed **on disk and in `dist/`** on each leg by anchored greps rather than by an editor's exit code — mutation leg: local interface present 1 / re-export absent 0 in both `src` and `dist`; restore leg: the inverse, 1 / 0. The script carried `trap restore EXIT INT TERM` so a killed run could not leave the tree mutated. Restore is provably byte-identical to the commit: `git status --porcelain` empty, and the rebuilt `core/dist/types/index.d.ts` re-hashes to `0e64c8c6…`, the CHANGE-leg value.

## Tests and gates

All against the final commit, `641dcea68`.

- New pin, `pnpm exec vitest run packages/react/src/__tests__/ComponentRendererProps.reconciliation.test.ts` — `Test Files 1 passed (1)` / `Tests 1 passed (1)`, exit 0.
- Affected packages, `pnpm exec vitest run --maxWorkers=2 packages/core/ packages/types/ packages/react/` — `Test Files 187 passed (187)` / `Tests 3110 passed (3110)`, exit 0.
- `pnpm --filter @object-ui/react type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — exit 0, after building react's dependency closure (`--filter '@object-ui/react^...' build`, exit 0).
- Gates, each read from its own printed verdict line, exit code captured before any pipe: `check-changeset-presence` ✅ · `check-changeset-fixed` ✅ · `check-changeset-no-major` ✅ · `check-control-bytes` ✅ (4724 tracked text files) · `check-type-check-coverage` ✅ · `check-lint-coverage` ✅ · `check-package-self-import` ✅ · `check-phantom-dependencies` ✅ · `check-doc-component-types` ✅ · `check-skills-paths` ✅.
- `check:eager-closure`, `check:doc-snippets`, `check:published-dist` not run locally — known-broken/over-cap in this container; CI owns all three.

**Lint was narrowed deliberately, and the narrowing is measured rather than assumed.** ① Population read from eslint's own config, not guessed: `ESLint#isPathIgnored` over `git ls-files` says **3526** of 3528 tracked source files are in scope. ② Files actually linted, read from `--format json`: **2** — exactly the two this diff touches, 0 errors, 0 warnings, exit 0. ③ Invariance for the untouched 3524: `eslint.config.js` declares no `projectService` and no `parserOptions.project` (no type-aware rules), no custom rule in `eslint-rules/` reads any file other than the one being linted (`readFileSync`/`readdirSync`/`globSync`: zero hits), and this diff does not touch the config — so each other file's verdict is a function of its own unchanged text and the unchanged config. CI runs the full farm regardless.

## Scope notes

- No fenced path was touched: `packages/types/src/zod/base.zod.ts`, app-shell's `PageHeader`, `AiChatPage` / console-mount, and `packages/components/**`'s action dialog are all untouched. `packages/types` is untouched entirely — the winning declaration needed no edit.
- No `content/docs/**` or `apps/site/**` file is in this diff (#5668).
- **#5673 is deliberately not addressed here** and remains open — correcting the `SchemaNode` docstring's vacuous justification is that card's job, not a rider on this one. One data point falls out of this PR for free, though: the emitted file that *can* move for a re-export in `core/src/types/index.ts` is `core/dist/types/index.d.ts`, and it did (`893cb23b…` → `0e64c8c6…`), while the barrel did not — a third independent confirmation that the cited gauge cannot discriminate. The new docstring on `ComponentRendererProps` states the checker-resolved measurement instead of repeating the barrel claim.

_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_