### PR TITLE
app-shell PageHeader: one key for the secondary line, `subtitle` (#4761)

### DIFF
--- a/.changeset/app-shell-page-header-subtitle-4761.md
+++ b/.changeset/app-shell-page-header-subtitle-4761.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The console's `<PageHeader>` spells its secondary line `subtitle`, the same key the other `PageHeader` in this repo uses (objectui#4761).
+
+This repository has two components named `PageHeader`. `@object-ui/layout`'s is
+the renderer for the authored `page:header` / `page-header` node and converged
+on `subtitle` in objectui#3789, because `subtitle` is the key
+`@objectstack/spec/ui`'s `PageHeaderProps` declares. `@object-ui/app-shell`'s —
+the console's own title row, drawn by `ObjectView` and `ObjectDataPage` —
+spelled the very same concept `description` and had no `subtitle` at all. Both
+rendered correctly; the defect was one concept carrying two key names one
+package apart, the objectstack#4115 shape moved up a layer. An author reading
+one component to learn the other was being taught a key the contract does not
+have.
+
+**Not a breaking change, measured rather than assumed.** The convergence is a
+plain rename with no alias, because this component is not on the published
+surface:
+
+| gauge | result |
+|---|---|
+| exports of `dist/index.d.ts`, through the TypeScript checker | 226 symbols; `PageHeader` and `PageHeaderComponentProps` are not among them (controls: `AppShell` reachable, a nonsense name not) |
+| `exports` map | declares exactly `.` and `./styles.css` |
+| Node resolving `@object-ui/app-shell/layout`, `…/dist/layout/PageHeader.js`, `…/src/layout/PageHeader.js` | `ERR_PACKAGE_PATH_NOT_EXPORTED` for all three, while the declared entry resolves |
+| in-repo call sites | 2, both inside this package (`ObjectView.tsx`, `ObjectDataPage.tsx`) |
+| emitted declarations that change | `dist/layout/PageHeader.d.ts` only — `dist/index.d.ts` and `dist/layout/index.d.ts` are byte-identical across the change (`8c886251…`, `f9f4862b…`, both legs) |
+
+No supported specifier reaches the prop, so there was nothing to keep
+compatible, and a renderer-side `description` alias would have been exactly the
+second dialect AGENTS.md #0.1 forbids — the layout side had just finished
+retiring one. Out-of-repo consumers cannot be enumerated from this repository;
+what can be, and is, is the set of import paths through which one could have
+reached this component, which is empty.
+
+Rendered output is unchanged: same element, same classes, same position. The
+patch tier is a declaration that the tarball moved, not a claim that a consumer
+must act.
+
+`packages/app-shell/src/layout/__tests__/PageHeader.subtitle.test.tsx` is the
+pin the card asked for. It asserts the subtitle on the DOM a reader gets (a
+`<p>`, in the title block, after the `<h1>`), that `description` now draws
+nothing and is rejected by the compiler, and — the assertion that actually goes
+red if either side drifts again — that both packages' `PageHeaderComponentProps`
+declare `subtitle`.

--- a/packages/app-shell/src/layout/PageHeader.tsx
+++ b/packages/app-shell/src/layout/PageHeader.tsx
@@ -16,7 +16,7 @@
  * Layout:
  *   [accent hairline]
  *   [icon]  Title             [actions...]
- *           description
+ *           subtitle
  */
 
 import * as React from 'react';
@@ -37,14 +37,31 @@ import { cn } from '@object-ui/components';
  * objectstack#4115 defect. `__tests__/spec-symbol-parity.test.ts` pins that the spec
  * does not own this name.
  *
- * `@object-ui/layout` carries the same collision (objectui#3161, batch 7); it
- * should adopt this same name so the two packages do not invent two dialects.
+ * `@object-ui/layout` carries the same collision (objectui#3161, batch 7) and
+ * adopted this same name, so the two packages do not invent two dialects.
  */
 export interface PageHeaderComponentProps {
   /** Page title (required, becomes <h1>). */
   title: React.ReactNode;
-  /** Optional secondary description shown beneath the title. */
-  description?: React.ReactNode;
+  /**
+   * Optional secondary line shown beneath the title. `subtitle` is the only
+   * spelling this component accepts.
+   *
+   * It used to be `description`, which made one concept carry two key names
+   * one package apart: `@objectstack/spec/ui`'s `PageHeaderProps` declares
+   * `subtitle` for the authored `page:header` node, and `@object-ui/layout`'s
+   * `<PageHeader>` converged on `subtitle` in objectui#3789. This component is
+   * the console's rendered layer of that same element, so it now spells the
+   * secondary line the way the contract does (objectui#4761).
+   *
+   * The old spelling was NOT kept as an alias. It was never reachable outside
+   * this package — `src/index.ts` does not re-export `PageHeader`, and the
+   * `exports` map declares no subpath that could reach it — so nothing had to
+   * be tolerated, and a renderer-side alias is exactly the second dialect
+   * AGENTS.md #0.1 exists to prevent. `__tests__/PageHeader.subtitle.test.tsx`
+   * pins both halves.
+   */
+  subtitle?: React.ReactNode;
   /**
    * Optional leading icon (already-instantiated React element).
    * The icon is auto-sized via CSS — pass it with whatever default sizing,
@@ -90,7 +107,7 @@ export interface PageHeaderComponentProps {
  */
 export function PageHeader({
   title,
-  description,
+  subtitle,
   icon,
   actions,
   accentColor,
@@ -152,9 +169,9 @@ export function PageHeader({
             <h1 className="text-base sm:text-lg lg:text-xl font-semibold tracking-tight text-foreground truncate leading-tight">
               {title}
             </h1>
-            {description && (
+            {subtitle && (
               <p className="text-xs sm:text-sm text-muted-foreground truncate hidden sm:block max-w-xl mt-0.5">
-                {description}
+                {subtitle}
               </p>
             )}
           </div>

--- a/packages/app-shell/src/layout/__tests__/PageHeader.subtitle.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/PageHeader.subtitle.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One concept, one key: the console `<PageHeader>`'s secondary line is
+ * `subtitle` (objectui#4761).
+ *
+ * WHAT DIVERGED. This repo has two components named `PageHeader`.
+ * `@object-ui/layout`'s is the renderer for the authored `page:header` /
+ * `page-header` node and converged on `subtitle` in objectui#3789, because
+ * `subtitle` is the key `@objectstack/spec/ui`'s `PageHeaderProps` declares.
+ * This one — the console's own title row, used by `ObjectView` and
+ * `ObjectDataPage` — spelled the very same concept `description` and had no
+ * `subtitle` at all. Two dialects for one idea, one package apart, which is the
+ * objectstack#4115 shape moved up a layer. Nothing rendered wrong on either
+ * side; the defect was the divergence itself, and an author (especially an AI
+ * one) reading one component to learn the other was being taught the wrong key.
+ *
+ * WHY A PLAIN RENAME AND NOT AN ALIAS. The alias route the layout side needed
+ * was not needed here: this component is not part of `@object-ui/app-shell`'s
+ * published API. Measured, not assumed — `src/index.ts` names 226 exports and
+ * `PageHeader` is not among them (the package has no `export *` to propagate it
+ * silently), and the `exports` map declares exactly `.` and `./styles.css`, so
+ * Node refuses every deep subpath that could reach it with
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED`. With no supported import path there was
+ * nothing to keep compatible, and a renderer-side alias would have been exactly
+ * the second dialect AGENTS.md #0.1 forbids.
+ *
+ * WHAT THIS FILE PINS. Both directions of the convergence, so the next agent
+ * finds an answer instead of re-opening the drift:
+ *   1. `subtitle` renders, as the secondary line beneath the title, inside the
+ *      header — asserted on the DOM a user gets, not on the props object.
+ *   2. `description` is an ordinary unknown prop: rejected by the compiler and
+ *      drawing nothing at runtime.
+ *   3. This component and `@object-ui/layout`'s agree on the key, at compile
+ *      time — the assertion that actually goes red if either side drifts again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { PageHeader } from '../PageHeader';
+import type { PageHeaderComponentProps } from '../PageHeader';
+// The sibling component this card exists to agree with. A type-only import:
+// nothing from `@object-ui/layout` is rendered here.
+import type { PageHeaderComponentProps as LayoutPageHeaderProps } from '@object-ui/layout';
+
+describe('the secondary line renders from `subtitle`', () => {
+  it('draws it beneath the title, inside the header', () => {
+    render(<PageHeader title="Accounts" subtitle="Everything your team owns" />);
+
+    const header = screen.getByTestId('page-header');
+    const h1 = header.querySelector('h1');
+    const line = screen.getByText('Everything your team owns');
+
+    expect(h1?.textContent).toBe('Accounts');
+    // A `<p>`, in the same title block as the `<h1>`, positioned after it —
+    // i.e. the line a reader sees UNDER the title, not a stray node parked
+    // elsewhere in the header that happens to carry the text.
+    expect(line.tagName).toBe('P');
+    expect(header.contains(line)).toBe(true);
+    expect(line.parentElement).toBe(h1?.parentElement);
+    expect(
+      Boolean(h1!.compareDocumentPosition(line) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true);
+  });
+
+  it('renders no secondary line at all when `subtitle` is omitted', () => {
+    const { container } = render(<PageHeader title="Accounts" />);
+    expect(screen.getByText('Accounts')).toBeTruthy();
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('keeps the line reachable from the `sm` breakpoint up', () => {
+    // The class contract, pinned as a string because happy-dom evaluates no
+    // Tailwind: `hidden sm:block` is "hidden on phones, shown from 640px up",
+    // and both call sites already hide the whole header below `sm`. Dropping
+    // the `sm:block` half would leave a bare `hidden` — an element that passes
+    // every DOM assertion above while being invisible at every width. That is
+    // the failure this case exists to catch; it is not a claim about computed
+    // style, which nothing in this environment can measure.
+    render(<PageHeader title="Accounts" subtitle="Everything your team owns" />);
+    const line = screen.getByText('Everything your team owns');
+    expect(line.className).toContain('hidden');
+    expect(line.className).toContain('sm:block');
+  });
+});
+
+describe('`description` is not a second spelling of it', () => {
+  it('draws nothing for the retired key', () => {
+    render(
+      // @ts-expect-error — `description` is not a prop of this component. Unlike
+      // `@object-ui/layout`'s header, this one does not extend `HTMLAttributes`,
+      // so the compiler rejects the key outright; the runtime assertion below
+      // covers the JS caller the compiler never sees.
+      <PageHeader title="Accounts" description="Everything your team owns" />,
+    );
+    expect(screen.getByText('Accounts')).toBeTruthy();
+    expect(screen.queryByText('Everything your team owns')).toBeNull();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins — compiled by tsconfig.test.json, chained off type-check. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type HasKey<T, K extends string> = K extends keyof T ? true : false;
+
+describe('both `PageHeader`s spell the secondary line the same way', () => {
+  it('is pinned at compile time', () => {
+    type _ConsoleHasSubtitle = Assert<HasKey<PageHeaderComponentProps, 'subtitle'>>;
+    type _LayoutHasSubtitle = Assert<HasKey<LayoutPageHeaderProps, 'subtitle'>>;
+
+    // Only this side can be pinned negatively. `@object-ui/layout`'s props
+    // extend `React.HTMLAttributes<HTMLDivElement>`, which declares `about`,
+    // `color` and friends — so `keyof` over it is open enough that a
+    // "`description` is absent" assertion there would be about the DOM
+    // attribute surface, not about this component's contract. The layout side's
+    // half of the retirement is pinned where it belongs, on rendered output, in
+    // `packages/layout/src/__tests__/page-header-authorable-keys.test.tsx`.
+    type _ConsoleHasNoDescription = Assert<
+      HasKey<PageHeaderComponentProps, 'description'> extends true ? false : true
+    >;
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -511,7 +511,7 @@ export function ObjectDataPage({ dataSource, objects }: any) {
               </span>
             </span>
           }
-          description={t('console.objectData.description', {
+          subtitle={t('console.objectData.description', {
             defaultValue: 'URL-defined data slice — not bound to any saved view.',
           })}
           icon={React.createElement(getIcon((objectDef as any)?.icon), { className: 'h-4 w-4' })}

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -2266,7 +2266,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                      <ManagedByBadge managedBy={(objectDef as any)?.managedBy} />
                    </span>
                  }
-                 description={objectDef.description ? objectDesc(objectDef) : undefined}
+                 subtitle={objectDef.description ? objectDesc(objectDef) : undefined}
                  icon={(() => { const I = getIcon((objectDef as any)?.icon); return <I className="h-4 w-4" />; })()}
                  actions={
                    <>


### PR DESCRIPTION
Fixes #4761

This repository has two components named `PageHeader`. `@object-ui/layout`'s renders the authored `page:header` / `page-header` node and converged on `subtitle` in #3789 (PR #4759), because `subtitle` is the key `@objectstack/spec/ui`'s `PageHeaderProps` declares. `@object-ui/app-shell`'s — the console's own title row, drawn by `ObjectView` and `ObjectDataPage` — spelled the very same concept `description` and had no `subtitle` at all. Both rendered correctly; the defect was one concept carrying two key names one package apart, the objectstack#4115 shape moved up a layer.

The card was measurement-first, so the measurement comes first.

## The consumer surface of app-shell's `PageHeader`

| gauge | how it was measured | result |
|---|---|---|
| in-repo import sites | `rg` over the tree, dot-directories included, `node_modules`/`dist` excluded | **2** — `views/ObjectView.tsx:56`, `views/ObjectDataPage.tsx:62`, both `from '../layout/PageHeader.js'` |
| in-repo JSX call sites | occurrence count, not line count | **2** — `ObjectView.tsx:2262`, `ObjectDataPage.tsx:505`; both passed `description` |
| reachable from the package entry? | **TypeScript checker** (`getExportsOfModule`) on `src/index.ts` *and* on the built `dist/index.d.ts` — never grep, since `export *` propagates a symbol without naming it | **No.** 226 exports either way; `PageHeader` and `PageHeaderComponentProps` are not among them. Controls: `AppShell` / `ConsoleLayout` / `PreviewBadge` reachable, a nonsense name not |
| deep subpath reachable? | Node's own resolver, from `apps/console` (a real dependent) | `@object-ui/app-shell/layout`, `…/dist/layout/PageHeader.js`, `…/src/layout/PageHeader.js` → **`ERR_PACKAGE_PATH_NOT_EXPORTED`** for all three, while the declared entry resolves. The `exports` map declares exactly `.` and `./styles.css` |
| sibling repos | `rg "from '@object-ui/app-shell'"` in `../objectstack` | no import sites |
| public docs | `content/docs/**` | every `PageHeader` page documents `@object-ui/layout`'s component / the SDUI block. app-shell's is undocumented, consistent with it not being exported — **so no docs edit was needed** |

The same probe run against `@object-ui/layout`'s entry is the contrast that makes the call: **33 exports, `PageHeader` REACHABLE** — through an `export *` that a text search of the barrel would have missed. That side's convergence really was a breaking prop removal on a published surface, which is why #3789 shipped it as a `minor` with a migration table. This side has no such surface.

**Out-of-repo consumers cannot be enumerated from this repository, and this PR does not claim they were.** What can be enumerated, and is, is the set of import paths through which one could reach this component — and that set is empty. (`files` ships `dist`, so the bytes are in the tarball; a consumer that patches the `exports` map or uses a resolver that ignores it could reach them. That is outside the supported contract.)

## The change

Convergence to `subtitle`, as triage's first branch ruled — a plain rename, **no deprecation alias**. With no supported specifier reaching the prop there was nothing to keep compatible, and a renderer-side `description` read would have been exactly the second dialect AGENTS.md #0.1 forbids, one card after the layout side finished retiring one.

Rendered output is unchanged: same element, same classes, same position. Emitted declarations confirm the blast radius — `dist/index.d.ts` (`8c886251…`) and `dist/layout/index.d.ts` (`f9f4862b…`) are **byte-identical** across the change; only `dist/layout/PageHeader.d.ts` moves (`8535dd1e…` → `603c6702…`), the one file no supported specifier can reach.

Untouched on purpose: `objectDef.description` (a metadata key) and the i18n key `console.objectData.description` are different things that happen to share the word; only the JSX prop was renamed.

## The pin

`packages/app-shell/src/layout/__tests__/PageHeader.subtitle.test.tsx`, five cases:

1. `subtitle` draws as the secondary line — asserted on the DOM a reader gets: a `<p>`, inside `data-testid="page-header"`, in the **same block as the `<h1>` and positioned after it** (`compareDocumentPosition`), not merely "the text is somewhere on the page".
2. No `subtitle` → no secondary line at all.
3. The class contract `hidden sm:block` survives. happy-dom evaluates no Tailwind, so this is pinned as a string and says so in the file: dropping the `sm:block` half would leave a bare `hidden` — an element that passes every DOM assertion above while being invisible at every width. It is not a claim about computed style, which nothing in this environment can measure.
4. `description` draws nothing and is rejected by the compiler (`@ts-expect-error` — unlike layout's, these props do not extend `HTMLAttributes`, so the key is a real type error rather than a silently-spread DOM attribute).
5. Compile-time: **both** packages' `PageHeaderComponentProps` declare `subtitle`. This is the assertion that goes red if either side drifts again.

## Ablation

Directions predicted before running; mutations confirmed on disk by counting the injected **and** the removed text (an editor's exit code proves nothing — `sed`/`perl -i`/`str.replace` all exit 0 on zero matches); restores under `trap … EXIT INT TERM` and **verified by hash** against the committed blobs.

No rebuild is required and none was performed, which is a claim about resolution rather than an omission: the pin imports `../PageHeader`, a **relative** specifier that no `exports` map can intercept, so vitest transforms the mutated source directly and both `tsc` projects compile that same source. The only dist-resolved import in the file is `import type … from '@object-ui/layout'`, and no leg mutates that package.

| leg | mutation | predicted | observed |
|---|---|---|---|
| A | undo the convergence in `PageHeader.tsx` | vitest RED (3 of 4 render cases), tsc RED | **3 failed / 2 passed**; tsc exit 2, `TS2322` at *both* call sites |
| B | drop `sm:block` from the subtitle class | vitest RED, exactly 1 case; tsc GREEN | **1 failed / 4 passed**; tsc exit 0 |
| C | flip the compile-time `subtitle` assert | vitest GREEN (type assertions are erased); tsc RED | **5 passed**; tsc exit 2, `TS2344: Type 'false' does not satisfy the constraint 'true'` |

Leg C is the asymmetry worth recording: vitest proves nothing about case 5's assertions, and `tsc -p tsconfig.test.json` is the only thing that can. Leg A came in slightly *narrower* than predicted — `type-check` is `tsc --noEmit && tsc -p tsconfig.test.json`, so the source project went red first and short-circuited before the test project could report its own errors. Reported as observed rather than as predicted.

## Verification

All at `0c37726`, after the final commit:

```
BUILD_EXIT=0      turbo run build --filter=@object-ui/app-shell   (29/29 tasks)
TEST_EXIT=0       vitest run packages/app-shell/src/layout/ + every ObjectView.*/ObjectDataPage.* suite
                  Test Files  40 passed (40)
                       Tests  338 passed (338)
TC_EXIT=0         pnpm --filter @object-ui/app-shell type-check
                  > tsc --noEmit && tsc -p tsconfig.test.json
PKG_LINT_EXIT=0   pnpm --filter @object-ui/app-shell lint  →  0 errors, 2551 pre-existing warnings
```

Gates: `check:control-bytes` ✅ · `changeset:check` ✅ · `check:changeset-presence` ✅ · `check:spec-symbols` ✅ · `check:self-import` ✅ · `check:phantom-deps` ✅.

Repo-wide `turbo run lint` was **not** run locally, and that narrowing is declared rather than implied: this diff touches four files, all in `@object-ui/app-shell`, whose whole package was linted above; and `eslint.config.js` enables **no** type-aware linting (`tseslint.configs.recommended`, no `parserOptions.project`, no `projectService`), so a verdict on an untouched file is computed from that file alone and cannot move because of this diff. CI runs the full farm regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_