### PR TITLE
fix(plugin-detail): bind record:alert predicates through usePredicateRecordContext

### DIFF
--- a/.changeset/record-alert-row-binding-4807.md
+++ b/.changeset/record-alert-row-binding-4807.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`record:alert` binds the row through `usePredicateRecordContext`, so an
+author-declared `properties.visible` is actually consulted.
+
+`renderers/record-alert.tsx` was the last predicate face in the repo still
+handing `useCondition` a root-only `{ record }` bag. Every other row-scoped
+predicate — the four generic action renderers (objectui#4075) and app-shell's
+`DeclaredActionsBar` (objectui#4077) — binds the row through the shared
+`usePredicateRecordContext(record)` helper, which resolves the three spellings
+objectui#5330 ruled on: canonical `record.status`, the deprecated row-action
+shorthand `status`, and deprecated legacy `data.status`.
+
+Under the root-only bag only the canonical spelling worked, and the two others
+failed in **opposite** directions — both of them silently, because this call
+site is fail-soft:
+
+- **row-action shorthand** (`status == 'x'`) resolved nothing, so the evaluator
+  threw. The legacy `${…}` path answers a throw with its own source text, a
+  non-empty and therefore truthy string, so the verdict was **SHOWN on every
+  row**. A banner the author had gated was permanently on screen.
+- **legacy `data.*`** (`data.status == 'x'`) did not throw at all. App-shell's
+  ambient predicate scope (`providers/ExpressionProvider.tsx`) carries
+  `data: {}`, so the predicate read that object instead of the row, compared
+  `undefined`, and the verdict was a constant false — **never shown**.
+
+**Behaviour change, stated plainly:** a shipped `record:alert` whose `visible`
+was written in either deprecated spelling was inert and is now live. A banner
+that was permanently visible may begin to hide, and one that never appeared may
+begin to show — that is the point of the fix, but it is a verdict change rather
+than a no-op. Canonical `record.*` predicates are unaffected in verdict: they
+resolved before and resolve now, pinned on both polarities. An in-tree census
+found no `record:alert` `visible` predicate outside this package's own tests.
+
+A node-level `visibleWhen` is a separate gate one tier up in `SchemaRenderer`,
+with its own deliberate bindings (`data` is the data-source adapter there, not
+the row). This change does not touch it; the two still compose as AND.
+
+The renderer's header comment described the shared-scope behaviour it did not
+have. It now describes what the file does, including the fail-soft policy and
+the two-gate composition.

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.rowBinding.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.rowBinding.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * ══════════════════════════════════════════════════════════════════════════
+ * `record:alert` binds the row the THREE canonical ways (objectui#4807)
+ * ══════════════════════════════════════════════════════════════════════════
+ *
+ * `record:alert` was the last predicate face in the repo still handing
+ * `useCondition` a ROOT-ONLY bag (`{ record }`) instead of the shared
+ * `usePredicateRecordContext(record)` that objectui#4075 / #4077 put under the
+ * four generic action renderers and app-shell's `DeclaredActionsBar`. The
+ * consequence was user-visible, and it is what this file measures:
+ *
+ *   • row-action shorthand (`status == 'x'`) resolved NOTHING, so the
+ *     evaluator threw `status is not defined`. This call site is FAIL-SOFT —
+ *     the legacy `${…}` path answers a throw with its own source text, which is
+ *     a non-empty (truthy) string — so an author-declared gate came out as
+ *     SHOWN on every row. A banner the author gated was permanently on screen,
+ *     with nothing but a console line to say so.
+ *   • legacy `data.*` did not throw at all, which is worse than it sounds: the
+ *     ambient scope app-shell mounts (`providers/ExpressionProvider.tsx`) puts
+ *     `data: {}` in the bag, so `data.status` resolved to `undefined` against
+ *     the wrong object and the comparison was a constant `false` — the banner
+ *     was permanently OFF screen instead. Same defect, opposite polarity.
+ *
+ * objectui#5330 (maintainer, 2026-08-20) ruled **B**: `record.*` is the canon;
+ * the row-action shorthand and legacy `data.*` are DEPRECATED but kept behind a
+ * survey-sized window. So all three must resolve, and the pins below name
+ * `record.*` as the one an author should write today.
+ *
+ * ── Why groups B and C mount different shapes ──────────────────────────────
+ *
+ * There are TWO gates on the way to this banner and they live at different
+ * tiers, each with its own binding:
+ *
+ *   1. `SchemaRenderer`'s node chain. It hoists `properties.visible` onto the
+ *      node and evaluates it on an evaluator that binds `record` (root-only)
+ *      and, deliberately, `data` = the DATA-SOURCE ADAPTER — see the docblock
+ *      on `SchemaRenderer.tsx`'s `evaluatedSchema`, which states that binding
+ *      and why the row must not overwrite it.
+ *   2. `record-alert.tsx`'s own `useCondition`, one layer below. THIS is the
+ *      tier objectui#4075's rule governs and the tier this card fixes.
+ *
+ * The two compose as AND (pinned in `record-alert.visibleWhen.evidence.test.tsx`
+ * group 4). Group B therefore holds gate 1 open with a declared
+ * `visibleWhen: cel('true')` — the node chain tests `visibleWhen` FIRST and
+ * returns without ever consulting `visible` — so that every verdict it records
+ * is gate 2's, i.e. this renderer's. Group C then drops the isolation and mounts
+ * the plain authored shape, so the end-to-end user-visible outcome is pinned too.
+ *
+ * Group C covers the canon and the shorthand only. The legacy `data.*` spelling
+ * is NOT asserted end-to-end, and that is deliberate: through the plain shape
+ * gate 1 decides it on the adapter binding above, one tier up and out of this
+ * card's reach. Fixing this renderer does not (and must not) move that. See the
+ * out-of-scope finding filed alongside this change.
+ *
+ * ── Non-vacuity ────────────────────────────────────────────────────────────
+ *
+ * This renderer has four `return null` paths (dismissed, empty record, the
+ * props gate, and the node gate above it), so "nothing rendered" is not by
+ * itself "the gate said no". Group A is the control: it proves the harness
+ * really mounts and paints the banner, and that this exact channel can hide it.
+ * Every verdict below is asserted on what a USER sees — is the banner's text in
+ * the document — never on computed styles or a predicate's return value.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, type RenderResult } from '@testing-library/react';
+import { RecordContextProvider, SchemaRenderer, PredicateScopeProvider } from '@object-ui/react';
+import '../../index';
+
+/**
+ * The ambient scope app-shell actually mounts on a record page, reproduced from
+ * `packages/app-shell/src/providers/ExpressionProvider.tsx` (`data` defaults to
+ * `{}` and is `{}` at both of its call sites). The absence of `record` here — and
+ * the PRESENCE of an unrelated `data` — are properties of production, not
+ * omissions in the fixture: they are precisely what made the two deprecated
+ * spellings fail in opposite directions.
+ */
+const APP_SCOPE = {
+  current_user: { id: 'u1', name: 'Ada', email_verified: true },
+  user: { id: 'u1', email_verified: true },
+  ctx: { user: { id: 'u1' } },
+  os: { user: { id: 'u1' } },
+  app: {},
+  data: {},
+  features: { multiOrgEnabled: true },
+};
+
+const IN_REVIEW = { id: 'r1', status: 'in_review' };
+const DONE = { id: 'r1', status: 'done' };
+const TITLE = 'Awaiting review';
+
+const cel = (source: string) => ({ dialect: 'cel', source });
+
+/** Holds SchemaRenderer's node gate open so the verdict recorded is this renderer's. */
+const NODE_GATE_OPEN = { visibleWhen: cel('true') };
+
+/**
+ * The three spellings objectui#5330 ruled on, written the way an author writes
+ * them: a BARE expression string, which is the spec spelling and which
+ * `SchemaRenderer`'s per-value `properties` evaluation passes through untouched
+ * (only `${…}` values are interpolated there).
+ */
+const CANON = "record.status == 'in_review'";
+const SHORTHAND = "status == 'in_review'";
+const LEGACY = "data.status == 'in_review'";
+
+function alertNode(visible?: string, extra: Record<string, unknown> = {}) {
+  return {
+    type: 'record:alert',
+    properties: { title: TITLE, ...(visible === undefined ? {} : { visible }) },
+    ...extra,
+  };
+}
+
+function mount(node: unknown, record: Record<string, unknown>): RenderResult {
+  return render(
+    <PredicateScopeProvider scope={APP_SCOPE}>
+      <RecordContextProvider objectName="showcase_task" recordId="r1" data={record}>
+        <SchemaRenderer schema={node as never} />
+      </RecordContextProvider>
+    </PredicateScopeProvider>,
+  );
+}
+
+/** What the user sees: is the banner's own text in the document? */
+const bannerInDocument = (r: RenderResult) => r.queryByText(TITLE) !== null;
+
+/** Mount the same node against both rows and report the pair of verdicts. */
+function verdicts(node: unknown): { onMatchingRow: boolean; onOtherRow: boolean } {
+  const onMatchingRow = bannerInDocument(mount(node, IN_REVIEW));
+  cleanup();
+  const onOtherRow = bannerInDocument(mount(node, DONE));
+  cleanup();
+  return { onMatchingRow, onOtherRow };
+}
+
+afterEach(() => cleanup());
+
+describe('#4807 group A — controls: the harness paints the banner, and this channel can hide it', () => {
+  it('with no predicate declared, the banner is on screen for every row', () => {
+    // If this goes red, nothing below means anything: a `false` verdict there
+    // would be "never rendered", not "the gate said no".
+    expect(bannerInDocument(mount(alertNode(), IN_REVIEW))).toBe(true);
+    cleanup();
+    expect(bannerInDocument(mount(alertNode(), DONE))).toBe(true);
+  });
+
+  it('a constant `properties.visible` decides it in both directions', () => {
+    // The paired control for group B: same key, same tier, same mount — so a
+    // hidden verdict below is this gate's answer and not an inert surface.
+    expect(bannerInDocument(mount(alertNode('false', NODE_GATE_OPEN), DONE))).toBe(false);
+    cleanup();
+    expect(bannerInDocument(mount(alertNode('true', NODE_GATE_OPEN), DONE))).toBe(true);
+  });
+});
+
+describe('#4807 group B — all THREE bindings resolve on this renderer own gate', () => {
+  // The two rows differ ONLY in `status`, so a pair of opposite verdicts IS the
+  // binding: the predicate reached the row. A pair of EQUAL verdicts means the
+  // author's gate was never consulted, whichever way it landed.
+
+  it('canon `record.*` — the spelling objectui#5330 ruled canonical', () => {
+    expect(verdicts(alertNode(CANON, NODE_GATE_OPEN))).toEqual({
+      onMatchingRow: true,
+      onOtherRow: false,
+    });
+  });
+
+  it('row-action shorthand `status` — deprecated by objectui#5330, still resolves', () => {
+    // Before objectui#4807 both mounts were `true`: `status` was unbound, the
+    // evaluator threw, and this fail-soft call site turned the throw into SHOWN.
+    expect(verdicts(alertNode(SHORTHAND, NODE_GATE_OPEN))).toEqual({
+      onMatchingRow: true,
+      onOtherRow: false,
+    });
+  });
+
+  it('legacy `data.*` — deprecated by objectui#5330, still resolves', () => {
+    // Before objectui#4807 both mounts were `false`, not `true`: the ambient
+    // `data: {}` from app-shell answered instead of the row, so the comparison
+    // was constantly false and the banner never appeared at all.
+    expect(verdicts(alertNode(LEGACY, NODE_GATE_OPEN))).toEqual({
+      onMatchingRow: true,
+      onOtherRow: false,
+    });
+  });
+
+  it('the row wins over an ambient `record` / `data` the host also supplied', () => {
+    // `usePredicateRecordContext` writes `record` and `data` AFTER the spread
+    // for this reason; APP_SCOPE carries a `data` of its own, and a host may
+    // carry a `record` too. Pinned on the user-visible verdict so the
+    // precedence cannot regress silently.
+    const hostScope = { ...APP_SCOPE, record: DONE, data: DONE };
+    const withHostScope = (record: Record<string, unknown>) =>
+      render(
+        <PredicateScopeProvider scope={hostScope}>
+          <RecordContextProvider objectName="showcase_task" recordId="r1" data={record}>
+            <SchemaRenderer schema={alertNode(CANON, NODE_GATE_OPEN) as never} />
+          </RecordContextProvider>
+        </PredicateScopeProvider>,
+      );
+    expect(bannerInDocument(withHostScope(IN_REVIEW))).toBe(true);
+    cleanup();
+    expect(bannerInDocument(withHostScope(DONE))).toBe(false);
+  });
+});
+
+describe('#4807 group C — end to end, on the plain authored node', () => {
+  // No `visibleWhen` isolation here: this is the shape an author writes, and
+  // these are the verdicts a user gets.
+
+  it('canon `record.*` gates the banner on the row', () => {
+    expect(verdicts(alertNode(CANON))).toEqual({ onMatchingRow: true, onOtherRow: false });
+  });
+
+  it('row-action shorthand gates the banner on the row', () => {
+    // THE defect of objectui#4807 as a user met it: this pair used to be
+    // `{ true, true }` — an author-declared gate that never once hid the banner.
+    expect(verdicts(alertNode(SHORTHAND))).toEqual({ onMatchingRow: true, onOtherRow: false });
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-alert.tsx
+++ b/packages/plugin-detail/src/renderers/record-alert.tsx
@@ -31,11 +31,34 @@
  *
  * Visibility model
  * ----------------
- *   Reuses `useCondition` + `toPredicateInput` (same pipeline as every
- *   `<ActionButton>` / `<ActionBar>`), so the predicate evaluates against
- *   the same scope: `record`, `user`, `objectName`, `features`, plus
- *   `ctx.*` namespace mirror. Missing predicate → always visible.
+ *   `properties.visible` is normalized by `toPredicateInput` and evaluated by
+ *   `useCondition` against `usePredicateRecordContext(record)` — the repo's one
+ *   row-binding rule (objectui#4075 / #4077), shared with `<ActionButton>` /
+ *   `<ActionMenu>` / `<ActionGroup>` / `<ActionIcon>` and app-shell's
+ *   `DeclaredActionsBar`, so this banner cannot disagree with the buttons it
+ *   pairs with. The row therefore resolves the three ways objectui#5330 ruled
+ *   on (maintainer, 2026-08-20): `record.status` — the CANON, what an author
+ *   should write — plus the deprecated-but-kept row-action shorthand `status`
+ *   and legacy `data.status`.
+ *
+ *   Merged UNDER the row is whatever the host put in the ambient predicate
+ *   scope (`PredicateScopeProvider`; app-shell's `ExpressionProvider` supplies
+ *   `current_user` / `user` / `ctx.user` / `os.user` / `app` / `data` /
+ *   `features`). The row wins, so a host-supplied `record` / `data` cannot
+ *   shadow it. `objectName` is NOT in the predicate scope — it is read from
+ *   `useRecordContext()` for the metadata lookup and the dismiss key only.
+ *
+ *   Missing predicate → always visible. A predicate that cannot be evaluated →
+ *   also visible: this call site is FAIL-SOFT (it does not pass
+ *   `throwOnError`), which is why the unbound spellings above were a
+ *   user-visible defect rather than a console line — objectui#4807.
  *   Empty `record` (loading) → hidden (no flash of stale alert).
+ *
+ *   A node-level `visibleWhen` is a SEPARATE gate one tier up, evaluated by
+ *   `SchemaRenderer` on its own bindings (notably `data` = the data-source
+ *   ADAPTER, not the row). The two compose as AND. Both facts are pinned in
+ *   `__tests__/record-alert.visibleWhen.evidence.test.tsx` (group 4) and
+ *   `__tests__/record-alert.rowBinding.test.tsx`.
  *
  * CTA wiring
  * ----------
@@ -51,6 +74,7 @@ import {
   useMetadataItem,
   useCondition,
   toPredicateInput,
+  usePredicateRecordContext,
   useActionEngine,
 } from '@object-ui/react';
 import { Alert, AlertTitle, AlertDescription, Button, cn, LazyIcon } from '@object-ui/components';
@@ -161,12 +185,16 @@ export const RecordAlertRenderer: React.FC<RecordAlertProps> = ({ schema = {}, c
   const styles = SEVERITY_STYLES[severity];
   const iconName = props.icon || styles.icon;
 
-  // Always-call hooks (Rules of Hooks). Evaluate the visibility predicate
-  // against the record / user / ctx scope using the same canonical helper
-  // every action button uses, so this banner can't disagree with the
-  // Salesforce Lightning-style buttons it commonly pairs with.
+  // Always-call hooks (Rules of Hooks). Bind the row through the shared
+  // helper — NOT a local `{ record }` bag (objectui#4807). A root-only bag
+  // resolves the canonical `record.*` spelling and nothing else, so the two
+  // spellings objectui#5330 kept never reached the row: the shorthand threw
+  // and this fail-soft site answered SHOWN, while `data.*` silently read the
+  // host's ambient `data` and answered a constant false. Either way the
+  // author's gate was never consulted. See `usePredicateRecordContext`.
+  const predicateRecord = usePredicateRecordContext(record);
   const predicateInput = toPredicateInput(props.visible);
-  const passesPredicate = useCondition(predicateInput, { record });
+  const passesPredicate = useCondition(predicateInput, predicateRecord);
 
   // Dismissed-state persistence. Keyed by `<objectName>:<recordId>:<key>`
   // so an admin viewing a different record sees the alert fresh, and so


### PR DESCRIPTION
Fixes #4807

`renderers/record-alert.tsx` was the last predicate face in the repo still handing `useCondition` a root-only `{ record }` bag. Every other row-scoped predicate — the four generic action renderers (#4075) and app-shell's `DeclaredActionsBar` (#4077) — binds the row through the shared `usePredicateRecordContext(record)`, which resolves the three spellings #5330 ruled on: canonical `record.status`, the deprecated row-action shorthand `status`, and deprecated legacy `data.status`.

The card was unblocked by the **B** ruling on #5330 (maintainer, 2026-08-20): canon is `record.*`; the shorthand and `data.*` are deprecated but kept behind a survey-sized window. So all three must resolve, and the pins name `record.*` as the canon.

> Note on spelling in this description, corrected after measuring it: the first revision of this body was posted through the MCP GitHub tool and came back with two angle-bracket fragments gone — the JSX element names and a `<pkg>` path placeholder — even though both sat inside backticks. Re-posting the same text through the raw REST API preserves them, so the stripping is on the MCP tool path rather than GitHub's store. The bare spellings below (`ActionButton`, and `*` for path placeholders) are kept because they survive either path; the renderer's own source comment is unaffected and still carries the angle-bracketed names.

## The defect, measured before it was fixed

Under the root-only bag only the canonical spelling reached the row, and the two others failed in **opposite** directions — both silently, because this call site is fail-soft:

| spelling | what happened | verdict |
|---|---|---|
| `record.status == 'in_review'` | resolved | correct on both rows |
| `status == 'in_review'` | `status` unbound → evaluator throws → the legacy `${…}` path answers a throw with its own source text, a truthy string | **SHOWN on every row** — the author's gate never once hid the banner |
| `data.status == 'in_review'` | no throw at all: app-shell's ambient scope (`providers/ExpressionProvider.tsx`) carries `data: {}`, so the predicate read that object and compared `undefined` | **HIDDEN on every row** |

The issue predicted a fail-soft SHOWN for both deprecated spellings. That held for the shorthand; the `data.*` half is the *opposite* polarity, for the reason in the table, and the changeset and the test header record it that way rather than the way the card guessed.

## The change

Three lines of code:

```
+  usePredicateRecordContext,
+  const predicateRecord = usePredicateRecordContext(record);
+  const passesPredicate = useCondition(predicateInput, predicateRecord);
```

Everything else in `record-alert.tsx` is comment. The header block (the `Visibility model` section the card calls out as untrue) claimed the predicate evaluated "against the same scope … `record`, `user`, `objectName`, `features`" as "every ActionButton / ActionBar". Three things were wrong with that and all three are now stated truthfully: the row binding was **not** the shared one, `objectName` was never in the predicate scope at all (it is read from `useRecordContext()` for the metadata lookup and the dismiss key), and the fail-soft error policy — the reason this was user-visible rather than a console line — went unmentioned. The rewritten block also names the second gate one tier up (`SchemaRenderer`'s node chain, with its own deliberate `data` = adapter binding) and points at the two files that pin the composition.

## Evidence

Red-first, through the real render path (`SchemaRenderer` → registry → `RecordAlertRenderer`), asserting on what a user sees — is the banner's text in the document — never on computed styles or a predicate's return value.

**Unfixed tree — `3 failed | 5 passed (8)`**, and the three failures are exactly the three the fix moves:

```
× group B > row-action shorthand   -   "onOtherRow": false  +   "onOtherRow": true
× group B > legacy `data.*`        -   "onMatchingRow": true  +  "onMatchingRow": false
× group C > row-action shorthand   -   "onOtherRow": false  +   "onOtherRow": true
```

**Fixed tree — `Test Files 2 passed (2)` / `Tests 16 passed (16)`**: the 8 new pins plus the 8 pre-existing pins in `record-alert.visibleWhen.evidence.test.tsx`, which is the acceptance baseline #5454 named. Those 8 are untouched and stay green, which is what makes this additive rather than a migration.

### Non-vacuity

`record:alert` has four `return null` paths (dismissed, empty record, its own props gate, and the node gate above it), so "nothing rendered" is not by itself "the gate said no". Group A is the control: it proves the harness paints the banner, and that this exact channel can hide it in both directions. Both group-A assertions pass on the **unfixed** code, so the three failures above are a defect and not a harness that renders nothing.

### Ablation — two legs, predicted before running

No rebuild leg exists or is needed: the root `vitest.config.mts` aliases every `@object-ui/*` specifier at `packages/*/src`, and the suite imports the registration relatively (`import '../../index'`), so nothing under any `dist/` is on the resolution path. Each leg mutated one line, counted the deleted and the injected text **separately** on disk (`grep -oF … | wc -l` — occurrences, not lines; the mutator aborts unless its anchor matches exactly once), ran the pins, then restored from the committed blob and verified the restore **by hash**. Both legs ran under `trap … EXIT INT TERM`, and the fix was committed first so the restore could not be confused with an uncommitted edit.

| leg | mutation (on disk: deleted 1→0, injected 0→1) | predicted | observed |
|---|---|---|---|
| 1 — revert the fix | `useCondition(predicateInput, predicateRecord)` → `useCondition(predicateInput, { record })` | the 3 defect pins red, every control and canon pin green, the pre-existing evidence suite untouched | `3 failed \| 13 passed (16)` — exactly those 3 |
| 2 — renderer paints nothing | `if (dismissed) return null;` → `if (dismissed \|\| true) return null;` | every assertion expecting the banner ON SCREEN goes red, the pure "hidden" ones survive | `13 failed \| 3 passed (16)` — the 3 survivors are `record:path` assertions, a different renderer |

Leg 2 is the vacuity probe: it shows the group-A controls **can** fail, so their passing in leg 1 is a measurement.

Restore verified both times: worktree blob `950f6969f272f4bce125907235baae62f24b6522` == `HEAD:packages/plugin-detail/src/renderers/record-alert.tsx`. Neither leg was void — both anchors matched exactly once, both mutations were confirmed present on disk before the run and absent after it.

## Verification scope — a derived superset, not a package sweep

All runs below are on the branch head **`02d9d173d`**, with a clean working tree.

The changed module has exactly **one** importer in the repo (`packages/plugin-detail/src/index.tsx`, which registers it as `record:alert` and the `alert` alias) and exactly one changed behaviour: the context bag handed to `useCondition` inside `RecordAlertRenderer`. A test can therefore observe this change only by mounting that renderer, which requires the registry key or a direct import. A repo-wide grep over **all** file types (not just tests, so JSON/TS fixtures are covered) for `record:alert`, `RecordAlertRenderer` and `type: 'alert'` enumerates every file that can do so; the indirect emitters (`synth/buildDefaultPageSchema.ts`, `previews/PagePreview.tsx`) are included through their own test files.

That superset: `Test Files 23 passed (23)` / `Tests 398 passed (398)` in 61s — the `plugin-detail` renderer and synth suites, the four app-shell metadata-admin preview/inspector tests that mention `record:alert`, `PagePreview.test.tsx`, and the four `apps/console` tests that mount record blocks. The whole-package fallback (92 files) was not needed.

- `pnpm --filter @object-ui/plugin-detail type-check` — **exit 0**, after building the dependency closure (`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail^...' build`, exit 0). The run echoes `@object-ui/plugin-detail@17.6.0 type-check`, so it is not a zero-match no-op.
- `check:control-bytes` — `✅ OK (scanned 4736 tracked text file(s); skipped 85 binary)`
- `changeset:check` — `✅ No changeset declares a 'major' bump.` (`minor`, per the fixed-group policy)
- `check:self-import` — `✅ No package names itself inside its own src/.`
- `check:phantom-deps` — `✅ Every in-scope import is declared by the package that publishes it.`
- `check:spec-symbols` — `✅ spec symbol derivation: 1291 files scanned…`
- `check:action-forward-parity` — exit 0
- `check:doc-types` — `✅ Every documented component type is registered.`
- `node scripts/check-changeset-presence.mjs` — `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`

Every exit code above was captured **before** any pipe, and each line quoted is the gate's own verdict line rather than a `$?` this PR wrote.

### Lint: a declared narrowing, with its three pieces of evidence

The repo-wide ESLint scan is CI's run. What is delivered here is a narrowed one that is a *measurement*, not a sample:

1. **Population** — read from ESLint's own config, not guessed: `eslint.config.js` sets no `parserOptions.project` and no `projectService`, so **type-aware linting is not enabled**; and no rule in `eslint-rules/` reads the filesystem (`readdirSync` / `globSync` / `readFileSync`: zero hits). ESLint's verdicts are therefore per-file and independent of the rest of the tree.
2. **File count** — from `--format json`: **2 files linted**, exit 0. `record-alert.rowBinding.test.tsx` 0 errors / 0 warnings; `record-alert.tsx` 0 errors / 8 warnings.
3. **Invariance for untouched files** — with no type-aware rule and no cross-file rule, this diff cannot move any untouched file's verdict.

The 8 warnings are all pre-existing `@typescript-eslint/no-explicit-any` on lines this PR did not touch: the diff adds **zero** lines containing `any` (`git diff origin/main … | grep '^+' | grep -c 'any'` → `0`), and its only non-comment additions are the three lines quoted above.

## Out of scope, filed not fixed

**#5687** — `SchemaRenderer`'s node visibility gate resolves a `data.*` predicate against the data-source **adapter**, so a hoisted `properties.visible` written that way hides the block on every row, without a throw and therefore without the #5454 diagnostic. That is one tier up from this card, on a shared surface, and whether #5330's ruling reaches that tier is a real contract question (binding the row over `data` there would change `${data.*}` interpolation in props bags, which `SchemaRenderer`'s own docblock calls out as deliberate). It is why group C of the new suite covers the canon and the shorthand end-to-end but deliberately does **not** assert `data.*` through the plain authored node — the test header says so in place of a pin, so nobody reads group B as "`data.*` works everywhere". `#5687 is not addressed here`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_

---
_Generated by [Claude Code](https://claude.ai/code)_