### PR TITLE
Remove MetadataClient's inert `options.actor` and its X-Actor header

### DIFF
--- a/.changeset/metadata-client-actor-retired-4834.md
+++ b/.changeset/metadata-client-actor-retired-4834.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/data-objectstack': minor
+---
+
+**Breaking (published surface):** remove `options.actor` from `MetadataClient`'s
+`save`, `reset`, `publish` and `rollback`, and stop emitting the `X-Actor`
+request header.
+
+The server stopped honouring that header. objectstack#7941 ruled that the
+recorded actor is the identity the request was authorized as, and removed the
+header limb from the `/meta` write resolver — attribution cannot drift from
+authorization. The option therefore typed cleanly, sent a header, and could not
+influence the audit or history row it appeared to address: a false affordance
+that promised attribution and silently failed to deliver it.
+
+Three declarations go: `MetadataClientSaveOptions.actor` (inherited by
+`MetadataDeleteOptions` via `extends`, so it served both `save` and `reset`),
+and the inline `{ actor?: string }` on each of `publish` and `rollback`.
+`MetadataAuditEntry.actor` is unaffected — that is the server's read-back of
+who acted, and it remains the way to see attribution.
+
+Marked `minor` rather than `major` per this repo's version-alignment policy
+(the fixed group's major tracks `@objectstack`, and `major` in a changeset
+would drag all 39 packages off that cadence).
+
+No caller in this repo passed `actor`; the census found the only in-repo
+occurrence was the client's own unit test. Callers outside this repo that still
+pass it are unaffected at runtime beyond losing a header the server already
+ignored — the property is dropped rather than forwarded, pinned by
+`metadata-actor-retired-4834.pin.test.ts`.

--- a/packages/data-objectstack/src/metadata-actor-retired-4834.pin.test.ts
+++ b/packages/data-objectstack/src/metadata-actor-retired-4834.pin.test.ts
@@ -1,0 +1,131 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `MetadataClient` no longer offers actor attribution — negative pin
+ * (objectui#4834, inheriting objectstack#7941).
+ *
+ * ## What was removed
+ *
+ * Four methods took an `actor` option and turned it into an `X-Actor` request
+ * header: `save` (PUT), `reset` (DELETE), `publish` (POST), `rollback` (POST).
+ * Three declarations carried it — `MetadataClientSaveOptions.actor` (which
+ * `MetadataDeleteOptions` inherits via `extends`, so it served both `save` and
+ * `reset`), plus an inline `{ actor?: string }` on each of `publish` and
+ * `rollback`.
+ *
+ * ## Why it went, rather than being documented or deprecated
+ *
+ * Maintainer ruling objectstack#7941 settled that the recorded actor is the
+ * identity the request was authorized as, and removed the header limb from the
+ * server's resolver outright — `resolveMetaWriteActor` now states that
+ * `X-Actor` "is ignored outright ... there is no shape in which a caller can
+ * choose the name the audit row records". The server's own pin
+ * (`packages/rest/src/meta-write-actor-identity.test.ts`, cases 3 and 4) fixes
+ * that in both directions: an explicit `X-Actor` does not outrank the
+ * authenticated identity, and it is inert on the machine-write path too.
+ *
+ * So the option could not affect the outcome. It typed cleanly and sent a
+ * header the server discards, which is worse than absent: it promises
+ * attribution and silently fails to deliver it. That is the false affordance
+ * the ruling's reasoning excludes, so the knob goes rather than acquiring a
+ * doc-comment apologising for itself.
+ *
+ * ## Why a runtime pin, and why it smuggles the property in through a cast
+ *
+ * Removing the declaration stops *TypeScript* callers. It does nothing to
+ * JavaScript ones, and this is published surface — `@object-ui/data-objectstack`
+ * ships to consumers this repo cannot enumerate. A stale external caller still
+ * passing `{ actor }` must have it dropped on the floor, not forwarded, so the
+ * assertion has to run against the real request rather than against the type.
+ * The cast reproduces exactly that caller.
+ *
+ * The header check is case-insensitive on purpose: `X-Actor`, `x-actor` and
+ * any other casing are the same header, and a reintroduction that changed the
+ * spelling would otherwise slip past a literal key lookup.
+ *
+ * ## If per-request attribution is ever wanted again
+ *
+ * It cannot be re-added here alone — the server would still ignore it. It
+ * starts as a producer change in `objectstack`, which means revisiting #7941's
+ * ruling that attribution may not drift from authorization. This pin is what
+ * you delete in that PR, deliberately.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MetadataClient } from './metadata-client';
+
+describe('MetadataClient actor attribution is retired (objectui#4834)', () => {
+  let sent: (RequestInit | undefined)[];
+
+  function client() {
+    return new MetadataClient({
+      baseUrl: 'http://localhost:3000',
+      fetch: vi.fn(async (_url: string, init?: RequestInit) => {
+        sent.push(init);
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch,
+    });
+  }
+
+  /** Every header key on the recorded request, lowercased. */
+  function headerKeys(init: RequestInit | undefined): string[] {
+    return Object.keys((init?.headers ?? {}) as Record<string, string>).map((k) =>
+      k.toLowerCase(),
+    );
+  }
+
+  beforeEach(() => {
+    sent = [];
+  });
+
+  // Without this, every assertion below would also pass against a client that
+  // sent no headers at all — or against a capture that recorded nothing.
+  describe('the probe itself works', () => {
+    it('captures a request whose headers this instrument can read', async () => {
+      await client().save('object', 'account', { foo: 1 }, { ifMatch: 'sha256:abc' });
+      expect(sent).toHaveLength(1);
+      const keys = headerKeys(sent[0]);
+      // A header the client DOES still send, proving the capture is live.
+      expect(keys).toContain('if-match');
+      expect(keys.length).toBeGreaterThan(1);
+    });
+  });
+
+  const CALLS: ReadonlyArray<
+    readonly [name: string, run: (c: MetadataClient, opts: object) => Promise<unknown>]
+  > = [
+    ['save', (c, opts) => c.save('object', 'account', { foo: 1 }, opts)],
+    ['reset', (c, opts) => c.reset('object', 'account', opts)],
+    ['publish', (c, opts) => c.publish('object', 'account', opts)],
+    ['rollback', (c, opts) => c.rollback('object', 'account', 2, opts)],
+  ] as const;
+
+  it.each(CALLS)(
+    '`%s` sends no X-Actor header even when a stale caller still passes `actor`',
+    async (_name, run) => {
+      // The cast is the point: a JS consumer of the published package can still
+      // pass this, and it must not reach the wire.
+      await run(client(), { actor: 'user_1' } as object);
+      expect(sent).toHaveLength(1);
+      expect(headerKeys(sent[0])).not.toContain('x-actor');
+    },
+  );
+
+  it('no method spells the header at all', async () => {
+    for (const [, run] of CALLS) {
+      await run(client(), { actor: 'user_1' } as object);
+    }
+    const everyHeaderKey = sent.flatMap(headerKeys);
+    expect(everyHeaderKey.length).toBeGreaterThan(0);
+    expect(everyHeaderKey.filter((k) => k.includes('actor'))).toEqual([]);
+  });
+});

--- a/packages/data-objectstack/src/metadata-client.test.ts
+++ b/packages/data-objectstack/src/metadata-client.test.ts
@@ -91,15 +91,17 @@ describe('MetadataClient', () => {
     expect(items).toEqual([{ name: 'wrapped' }]);
   });
 
-  it('sends If-Match and X-Actor headers on save when provided', async () => {
+  // objectui#4834 removed the `actor` option and its `X-Actor` emission; the
+  // If-Match half of this case is untouched optimistic-concurrency coverage and
+  // stays. That the header is NOT emitted is pinned in
+  // `metadata-actor-retired-4834.pin.test.ts`.
+  it('sends the If-Match header on save when provided', async () => {
     await client('http://localhost:3000').save('object', 'account', { foo: 1 }, {
       ifMatch: 'sha256:abc',
-      actor: 'user_1',
     });
     expect(inits[0]?.method).toBe('PUT');
     const headers = inits[0]?.headers as Record<string, string>;
     expect(headers['If-Match']).toBe('sha256:abc');
-    expect(headers['X-Actor']).toBe('user_1');
     expect(headers['Content-Type']).toBe('application/json');
     expect(inits[0]?.body).toBe(JSON.stringify({ foo: 1 }));
   });

--- a/packages/data-objectstack/src/metadata-client.ts
+++ b/packages/data-objectstack/src/metadata-client.ts
@@ -182,9 +182,9 @@ export interface MetadataDraftHeader {
  * metadata item to a FILE — `format: json|yaml|ts`, `path`, `indent`,
  * `prettify`, `sortKeys`, `backup`, `atomic`, `loader`. Not one of those keys
  * exists here, and not one of these exists there: this is the REST client's
- * request envelope — optimistic concurrency (`ifMatch` → `If-Match`), actor
- * attribution, the destructive-change override, the ADR-0033 draft/publish
- * mode, and the owning package. Same words, different layer.
+ * request envelope — optimistic concurrency (`ifMatch` → `If-Match`), the
+ * destructive-change override, the ADR-0033 draft/publish mode, and the
+ * owning package. Same words, different layer.
  */
 export interface MetadataClientSaveOptions {
   /**
@@ -193,8 +193,6 @@ export interface MetadataClientSaveOptions {
    * edits get a 409 instead of overwriting each other.
    */
   ifMatch?: string;
-  /** Optional actor id, sent as `X-Actor` for history attribution. */
-  actor?: string;
   /**
    * Bypass destructive-change protection (Phase 3a). The server returns
    * `409 destructive_change` with `issues[]` if a write would drop or
@@ -355,7 +353,10 @@ export interface MetadataAuditEntry {
   id: unknown;
   /** ISO timestamp when the attempt happened. */
   occurredAt: string;
-  /** Who attempted the operation (`x-actor` header or `'system'`). */
+  /**
+   * Who attempted the operation — the identity the request was authorized
+   * as, or `'system'` for internal machine writes (objectstack#7941).
+   */
   actor: string;
   /** Code path that recorded the row (e.g. `protocol.saveMetaItem`). */
   source: string | null;
@@ -804,7 +805,6 @@ export class MetadataClient {
       'Content-Type': 'application/json',
     };
     if (options.ifMatch) headers['If-Match'] = options.ifMatch;
-    if (options.actor) headers['X-Actor'] = options.actor;
     const res = await this.fetchImpl(url, {
       method: 'PUT',
       headers,
@@ -1019,7 +1019,6 @@ export class MetadataClient {
     const url = `${this.base}/${encodeURIComponent(type)}/${encodeURIComponent(name)}${qs}`;
     const headers: Record<string, string> = { ...this.headers };
     if (options.ifMatch) headers['If-Match'] = options.ifMatch;
-    if (options.actor) headers['X-Actor'] = options.actor;
     const res = await this.fetchImpl(url, { method: 'DELETE', headers });
     if (!res.ok) throw await parseError(res);
     return (await res.json()) as T;
@@ -1035,14 +1034,13 @@ export class MetadataClient {
   async publish<T = unknown>(
     type: string,
     name: string,
-    options: { actor?: string; message?: string } = {},
+    options: { message?: string } = {},
   ): Promise<T> {
     const url = `${this.base}/${encodeURIComponent(type)}/${encodeURIComponent(name)}/publish`;
     const headers: Record<string, string> = {
       ...this.headers,
       'Content-Type': 'application/json',
     };
-    if (options.actor) headers['X-Actor'] = options.actor;
     const res = await this.fetchImpl(url, {
       method: 'POST',
       headers,
@@ -1064,14 +1062,13 @@ export class MetadataClient {
     type: string,
     name: string,
     toVersion: number,
-    options: { actor?: string; message?: string } = {},
+    options: { message?: string } = {},
   ): Promise<T> {
     const url = `${this.base}/${encodeURIComponent(type)}/${encodeURIComponent(name)}/rollback`;
     const headers: Record<string, string> = {
       ...this.headers,
       'Content-Type': 'application/json',
     };
-    if (options.actor) headers['X-Actor'] = options.actor;
     const res = await this.fetchImpl(url, {
       method: 'POST',
       headers,


### PR DESCRIPTION
Fixes #4834

Triage route **option 1** (comment 5332236515): remove `options.actor` from the four methods and drop the `X-Actor` emission. This is ruling inheritance from objectstack#7941, not a new decision.

## The premise, re-measured before deleting

Triage flagged the premise as falsifiable. It was verified at **both** ends on `3b147a367`.

**Producer side** — the header is not merely unused, it is structurally ignored. `objectstack`'s `resolveMetaWriteActor` states: *"No header limb, by ruling. `X-Actor` on the request is ignored outright — it is not consulted for user principals, and not as a fallback for unauthenticated ones either."* Its pin (`packages/rest/src/meta-write-actor-identity.test.ts`, cases 3–4) fixes both directions: an explicit `X-Actor` does not outrank the authenticated identity, and it is inert on the machine-write path too. Every remaining `X-Actor` mention in `rest-server.ts` is a comment documenting the removal, not a live read.

**Consumer side** — census re-run on the current ref, in a tree with no `node_modules` and no `dist` (nothing to inflate counts):

| probe | result |
|---|---|
| `X-Actor` (any case), all file types | only `metadata-client.ts` + its own test; 2 CHANGELOG entries |
| `actor:` property form, all TS/JS | only `metadata-client.test.ts:97` on the request side |
| shorthand `{ actor }` (colon-less) | **0** |
| `.actor` member access (catches `opts.actor = x`) | every hit outside the client reads a **server response** |
| four methods' call sites, multi-line `rg -U --hidden` | none passes `actor` |

Two hygiene notes, because both would have corrupted the count: a bare `grep -oi actor` reports **972** occurrences, inflated by `f-actor-y`/`ref-actor`; word-boundary matching gives **153**. The app-shell file that appears to mention `actor` 14 times is `metadata-client-auth.ratchet.test.ts`, where all 14 are substrings of `FACTORY`.

**Scope of the claim:** this establishes *no caller **in this repo***. `@object-ui/data-objectstack` is published, so external callers cannot be enumerated from here — which is why the removal is backed by a runtime pin rather than by the type alone.

## What moves in the published surface

Measured by rebuilding after cleaning `dist/` **and** every `tsconfig.tsbuildinfo`, then diffing whole-tree `.d.ts` sha256 manifests. Exactly **1 of 153** `.d.ts` files changed hash (`data-objectstack/dist/index.d.ts`, 119.63 → 119.56 KB).

Reachability was resolved **through the TypeScript checker**, not by grepping the barrel — and that mattered: `MetadataClient` is re-exported as an *alias* (symbol flags 2097152, not `Class`), so a naive `getDeclaredTypeOfSymbol` reads the static side and sees no methods at all.

| declaration | serves | disposition |
|---|---|---|
| `MetadataClientSaveOptions.actor` | `save`, and `reset` via `extends` | removed |
| inline `{ actor?: string }` on `publish` | `publish` | removed |
| inline `{ actor?: string }` on `rollback` | `rollback` | removed |
| `MetadataAuditEntry.actor` (required) | server's read-back of who acted | **kept** |

Checker totals: exported symbols **75 → 75** (no export dropped, only properties), reachable `actor` **3 → 1**, `MetadataClient` methods carrying an `actor` param **4 → 0**.

## Test triage — the existing case was narrowed, not deleted

`'sends If-Match and X-Actor headers on save when provided'` asserted **both** headers plus method, content-type and body. Deleting it wholesale — the literal reading of "drop its unit test" — would have silently dropped optimistic-concurrency coverage, and nothing would have gone red. It is narrowed to the `If-Match` half.

A new negative pin (`metadata-actor-retired-4834.pin.test.ts`) asserts the header is not emitted across all four methods **even when a stale caller still passes `actor` through a cast**. Removing the declaration stops TypeScript callers; it does nothing to the JavaScript consumers of a published package, so the assertion runs against the real request. The header check is case-insensitive so a re-introduction under different spelling cannot slip past.

## Bounded in-place fix (named, per policy)

`MetadataAuditEntry.actor`'s doc comment read *"(`x-actor` header or `'system'`)"* — naming a source the same ruling made false. Corrected to the authorized identity, or `'system'` for machine writes. Same defect class, mechanical, form pinned by the server's own cases 1–2; no new verification surface.

## Verification — all against `4136e98fd`, on a clean tree

- `vitest run packages/data-objectstack/` → **42 files, 564 tests passed**
- `type-check` for `@object-ui/data-objectstack` + `@object-ui/app-shell` (incl. `tsconfig.test.json`) → both `Done`, script name echoed twice so this is not a zero-match silent green
- Gates green by their own verdict lines: `check:control-bytes` (4736 files), `check:self-import`, `check:phantom-deps`, `check:spec-symbols`, `check:esm-specifiers`, `check-changeset-presence` (3 source files, 1 changeset), `check-changeset-no-major`
- Full-tree `eslint . --no-inline-config` ran over its own resolved population of **3532 files**. My three changed files: **0 errors**; the pin test **0 warnings**. The 11 warnings on `metadata-client.ts` are pre-existing `no-explicit-any` at lines 497/638-641/866-867, none inside any diff hunk. None of the 73 error-bearing files repo-wide is a file this PR touches.

**Ablation** (committed first; direction predicted before running). Re-inserting the `save` emission turned the pin **partially** red — `save` and "no method spells the header" failed, `reset`/`publish`/`rollback` stayed green (only `save` was mutated), and the probe self-check stayed green, proving the instrument was live rather than blind. Mutation confirmed on disk by injected-token count (0 → 1) *and* hash change, not by the editor's exit code. It bit with **no rebuild**, which empirically proves vitest ran `src` via the relative intra-package import rather than `dist`. Restored under `trap … EXIT INT TERM` and verified byte-identical by sha256.

**Reverse verification.** Adding `actor` to a real consumer call site in `EmbeddedItemEditor.tsx` produced `error TS2353: Object literal may only specify known properties, and 'actor' does not exist in type 'MetadataClientSaveOptions'` — proving the narrowing is enforced downstream *and* that app-shell reads the rebuilt declaration; a stale `.d.ts` would have stayed green. Restored under trap.

**One void leg, reported rather than silently retried:** the first reverse-verification attempt had `$SP` undefined inside a quoted heredoc, so its `TYPECHECK_EXIT=1` was a failed shell redirect, not a tsc verdict. No typecheck ran. Re-run correctly above.

## Changeset tier

`minor`, not `major`, despite being a published-API removal: this repo's version-alignment policy fixes the group's major to `@objectstack`'s, and `check-changeset-no-major.mjs` mechanically rejects `major` — a breaking change is declared `minor` with the semantics spelled out in the body. Gate confirms.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_