### PR TITLE
catalog: author layout props as props, and rename `spacing` to `gap` (#4891, #4890)

### DIFF
--- a/.changeset/catalog-layout-props-sweep-4891-4890.md
+++ b/.changeset/catalog-layout-props-sweep-4891-4890.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/components': minor
+---
+
+`stack` now reads its spacing from `gap` and nothing else — the undeclared
+`spacing` key it also accepted is gone (objectui#4890).
+
+`StackSchema extends Omit<FlexSchema, 'type'>`, whose spacing key is `gap`.
+`spacing` was declared by nothing: not the TypeScript interface, not the zod
+mirror, not the renderer's own `inputs` registration. `stack.tsx` read it anyway,
+as `schema.gap ?? (schema as any).spacing ?? 2` — and the `as any` is the whole
+story, since it existed to get past the type system saying the key was not there.
+A lenient consumer leg does not stay in the consumer: it becomes a second
+de-facto contract that producers write to, and 135 nodes across 39 files of the
+shipped schema catalog did exactly that. Every one of them rendered correctly, so
+nothing ever pointed at it, while the examples went on teaching the key to every
+author who copied them.
+
+The trap it was one edit away from springing: `flex` — semantically a `stack`
+with a `direction` — never read `spacing`, so re-typing any of those nodes would
+have dropped the spacing to the default silently. Fixed at the producer
+(AGENTS.md #0.1): those nodes now author `gap`, carrying the same value, and the
+alias is deleted rather than legalised into `StackSchema`, where it would only
+have been a second name for `gap`.
+
+**If you author `spacing` on a `stack`**, rename it to `gap`; the value and the
+rendering are unchanged. A `stack` still carrying `spacing` now renders the
+default gap, exactly as a `flex` always did.
+
+Also in the same sweep, and visible only in the published example catalog rather
+than in any package API: 140 catalog nodes that were already `flex` / `stack` /
+`container` stopped hand-writing their own declared props in `className`
+(`items-center` → `align`, `justify-between` → `justify`, `gap-2` → `gap`,
+`flex-wrap` → `wrap`, `p-4` → a container's `padding`) — 231 tokens in all
+(objectui#4891). Breakpoint-prefixed overrides and everything decorative stay in
+`className`, because the props are not responsive. Both facts are ratcheted in
+`examples/schema-catalog/test/layout-props-conversion.test.tsx`.

--- a/examples/schema-catalog/src/schemas/actions/action-button-variants.json
+++ b/examples/schema-catalog/src/schemas/actions/action-button-variants.json
@@ -1,10 +1,11 @@
 {
   "type": "stack",
-  "spacing": 4,
+  "gap": 4,
   "children": [
     {
       "type": "flex",
-      "className": "gap-2 flex-wrap",
+      "gap": 2,
+      "wrap": true,
       "children": [
         {
           "type": "button",

--- a/examples/schema-catalog/src/schemas/actions/action-toolbar.json
+++ b/examples/schema-catalog/src/schemas/actions/action-toolbar.json
@@ -3,7 +3,9 @@
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between border-b pb-3 mb-4",
+      "align": "center",
+      "justify": "between",
+      "className": "border-b pb-3 mb-4",
       "children": [
         {
           "type": "text",
@@ -19,11 +21,12 @@
     },
     {
       "type": "stack",
-      "spacing": 3,
+      "gap": 3,
       "children": [
         {
           "type": "flex",
-          "className": "gap-2 items-center",
+          "gap": 2,
+          "align": "center",
           "children": [
             {
               "type": "text",
@@ -39,7 +42,8 @@
         },
         {
           "type": "flex",
-          "className": "gap-2 items-center",
+          "gap": 2,
+          "align": "center",
           "children": [
             {
               "type": "text",
@@ -57,7 +61,9 @@
     },
     {
       "type": "flex",
-      "className": "justify-end gap-2 pt-4 border-t mt-4",
+      "justify": "end",
+      "gap": 2,
+      "className": "pt-4 border-t mt-4",
       "children": [
         {
           "type": "button",

--- a/examples/schema-catalog/src/schemas/actions/confirmation-dialog.json
+++ b/examples/schema-catalog/src/schemas/actions/confirmation-dialog.json
@@ -4,7 +4,7 @@
   "header": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "children": [
         {
           "type": "text",
@@ -22,7 +22,9 @@
   "children": [
     {
       "type": "flex",
-      "className": "justify-end gap-2 pt-4",
+      "justify": "end",
+      "gap": 2,
+      "className": "pt-4",
       "children": [
         {
           "type": "button",

--- a/examples/schema-catalog/src/schemas/app/application-header.json
+++ b/examples/schema-catalog/src/schemas/app/application-header.json
@@ -1,10 +1,13 @@
 {
   "type": "flex",
-  "className": "items-center justify-between p-3 border rounded-lg bg-background",
+  "align": "center",
+  "justify": "between",
+  "className": "p-3 border rounded-lg bg-background",
   "children": [
     {
       "type": "flex",
-      "className": "items-center gap-3",
+      "align": "center",
+      "gap": 3,
       "children": [
         {
           "type": "icon",
@@ -20,7 +23,8 @@
     },
     {
       "type": "flex",
-      "className": "items-center gap-2",
+      "align": "center",
+      "gap": 2,
       "children": [
         {
           "type": "button",
@@ -38,7 +42,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2 ml-2 pl-2 border-l",
+          "align": "center",
+          "gap": 2,
+          "className": "ml-2 pl-2 border-l",
           "children": [
             {
               "type": "avatar",
@@ -47,7 +53,7 @@
             },
             {
               "type": "stack",
-              "spacing": 0,
+              "gap": 0,
               "children": [
                 {
                   "type": "text",

--- a/examples/schema-catalog/src/schemas/app/sidebar-navigation.json
+++ b/examples/schema-catalog/src/schemas/app/sidebar-navigation.json
@@ -4,11 +4,13 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 1,
+      "gap": 1,
       "children": [
         {
           "type": "flex",
-          "className": "items-center gap-2 px-3 py-2 rounded-md bg-accent text-accent-foreground",
+          "align": "center",
+          "gap": 2,
+          "className": "px-3 py-2 rounded-md bg-accent text-accent-foreground",
           "children": [
             {
               "type": "icon",
@@ -24,7 +26,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2 px-3 py-2 rounded-md hover:bg-accent/50",
+          "align": "center",
+          "gap": 2,
+          "className": "px-3 py-2 rounded-md hover:bg-accent/50",
           "children": [
             {
               "type": "icon",
@@ -46,7 +50,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2 px-3 py-2 rounded-md hover:bg-accent/50",
+          "align": "center",
+          "gap": 2,
+          "className": "px-3 py-2 rounded-md hover:bg-accent/50",
           "children": [
             {
               "type": "icon",
@@ -71,7 +77,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2 px-3 py-2 rounded-md hover:bg-accent/50",
+          "align": "center",
+          "gap": 2,
+          "className": "px-3 py-2 rounded-md hover:bg-accent/50",
           "children": [
             {
               "type": "icon",
@@ -87,7 +95,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2 px-3 py-2 rounded-md hover:bg-accent/50",
+          "align": "center",
+          "gap": 2,
+          "className": "px-3 py-2 rounded-md hover:bg-accent/50",
           "children": [
             {
               "type": "icon",
@@ -107,7 +117,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2 px-3 py-2 rounded-md hover:bg-accent/50",
+          "align": "center",
+          "gap": 2,
+          "className": "px-3 py-2 rounded-md hover:bg-accent/50",
           "children": [
             {
               "type": "icon",

--- a/examples/schema-catalog/src/schemas/auth/forgot-password.json
+++ b/examples/schema-catalog/src/schemas/auth/forgot-password.json
@@ -4,7 +4,7 @@
   "header": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "className": "text-center",
       "children": [
         { "type": "text", "content": "Reset Password", "className": "text-2xl font-bold tracking-tight" },
@@ -19,11 +19,11 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             { "type": "label", "htmlFor": "email", "label": "Email" },
             {

--- a/examples/schema-catalog/src/schemas/auth/login-simple.json
+++ b/examples/schema-catalog/src/schemas/auth/login-simple.json
@@ -4,7 +4,7 @@
   "header": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "className": "text-center",
       "children": [
         { "type": "text", "content": "Welcome Back", "className": "text-2xl font-bold tracking-tight" },
@@ -15,11 +15,11 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             { "type": "label", "htmlFor": "email", "label": "Email" },
             {
@@ -34,7 +34,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             { "type": "label", "htmlFor": "password", "label": "Password" },
             {
@@ -49,11 +49,13 @@
         },
         {
           "type": "flex",
-          "className": "items-center justify-between",
+          "align": "center",
+          "justify": "between",
           "children": [
             {
               "type": "flex",
-              "className": "items-center space-x-2",
+              "align": "center",
+              "className": "space-x-2",
               "children": [
                 { "type": "checkbox", "id": "remember", "name": "remember" },
                 { "type": "label", "htmlFor": "remember", "label": "Remember me", "className": "text-sm font-normal" }

--- a/examples/schema-catalog/src/schemas/auth/signup.json
+++ b/examples/schema-catalog/src/schemas/auth/signup.json
@@ -4,7 +4,7 @@
   "header": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "className": "text-center",
       "children": [
         { "type": "text", "content": "Create an Account", "className": "text-2xl font-bold tracking-tight" },
@@ -15,7 +15,7 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "grid",
@@ -24,7 +24,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 { "type": "label", "htmlFor": "firstName", "label": "First Name" },
                 { "type": "input", "id": "firstName", "name": "firstName", "placeholder": "John", "required": true }
@@ -32,7 +32,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 { "type": "label", "htmlFor": "lastName", "label": "Last Name" },
                 { "type": "input", "id": "lastName", "name": "lastName", "placeholder": "Doe", "required": true }
@@ -42,7 +42,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             { "type": "label", "htmlFor": "email", "label": "Email" },
             {
@@ -57,7 +57,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             { "type": "label", "htmlFor": "password", "label": "Password" },
             {
@@ -72,7 +72,8 @@
         },
         {
           "type": "flex",
-          "className": "items-start space-x-2",
+          "align": "start",
+          "className": "space-x-2",
           "children": [
             { "type": "checkbox", "id": "terms", "name": "terms", "required": true },
             {

--- a/examples/schema-catalog/src/schemas/auth/two-factor.json
+++ b/examples/schema-catalog/src/schemas/auth/two-factor.json
@@ -4,7 +4,7 @@
   "header": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "className": "text-center",
       "children": [
         { "type": "text", "content": "Two-Factor Authentication", "className": "text-2xl font-bold tracking-tight" },
@@ -19,11 +19,11 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             { "type": "label", "htmlFor": "code", "label": "Verification Code" },
             {

--- a/examples/schema-catalog/src/schemas/block-schema/block-marketplace-listing.json
+++ b/examples/schema-catalog/src/schemas/block-schema/block-marketplace-listing.json
@@ -18,16 +18,17 @@
     },
     {
       "type": "stack",
-      "spacing": 3,
+      "gap": 3,
       "className": "p-4",
       "children": [
         {
           "type": "flex",
-          "className": "items-start justify-between",
+          "align": "start",
+          "justify": "between",
           "children": [
             {
               "type": "stack",
-              "spacing": 1,
+              "gap": 1,
               "children": [
                 {
                   "type": "text",
@@ -55,7 +56,8 @@
         },
         {
           "type": "flex",
-          "className": "gap-2 flex-wrap",
+          "gap": 2,
+          "wrap": true,
           "children": [
             {
               "type": "badge",
@@ -76,7 +78,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center justify-between pt-2 border-t",
+          "align": "center",
+          "justify": "between",
+          "className": "pt-2 border-t",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-analytics-feature.json
+++ b/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-analytics-feature.json
@@ -4,8 +4,9 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 3,
-      "className": "items-center text-center p-4",
+      "gap": 3,
+      "align": "center",
+      "className": "text-center p-4",
       "children": [
         {
           "type": "flex",

--- a/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-security-feature.json
+++ b/examples/schema-catalog/src/schemas/block-schema/block-with-variable-overrides-security-feature.json
@@ -4,8 +4,9 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 3,
-      "className": "items-center text-center p-4",
+      "gap": 3,
+      "align": "center",
+      "className": "text-center p-4",
       "children": [
         {
           "type": "flex",

--- a/examples/schema-catalog/src/schemas/block-schema/feature-card-block.json
+++ b/examples/schema-catalog/src/schemas/block-schema/feature-card-block.json
@@ -4,8 +4,9 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
-      "className": "items-center text-center p-4",
+      "gap": 4,
+      "align": "center",
+      "className": "text-center p-4",
       "children": [
         {
           "type": "flex",

--- a/examples/schema-catalog/src/schemas/blocks-gallery/block-gallery-login-card.json
+++ b/examples/schema-catalog/src/schemas/blocks-gallery/block-gallery-login-card.json
@@ -4,7 +4,7 @@
   "header": [
     {
       "type": "stack",
-      "spacing": 1,
+      "gap": 1,
       "className": "text-center",
       "children": [
         {
@@ -23,11 +23,11 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 3,
+      "gap": 3,
       "children": [
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -42,7 +42,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",

--- a/examples/schema-catalog/src/schemas/blocks-gallery/block-gallery-notification-item.json
+++ b/examples/schema-catalog/src/schemas/blocks-gallery/block-gallery-notification-item.json
@@ -1,6 +1,8 @@
 {
   "type": "flex",
-  "className": "items-start gap-3 p-4 border rounded-lg max-w-md",
+  "align": "start",
+  "gap": 3,
+  "className": "p-4 border rounded-lg max-w-md",
   "children": [
     {
       "type": "avatar",
@@ -9,7 +11,7 @@
     },
     {
       "type": "stack",
-      "spacing": 1,
+      "gap": 1,
       "children": [
         {
           "type": "text",

--- a/examples/schema-catalog/src/schemas/blocks-gallery/block-gallery-stats-card.json
+++ b/examples/schema-catalog/src/schemas/blocks-gallery/block-gallery-stats-card.json
@@ -4,12 +4,13 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "className": "p-4",
       "children": [
         {
           "type": "flex",
-          "className": "items-center justify-between",
+          "align": "center",
+          "justify": "between",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/dashboard/dashboard-overview.json
+++ b/examples/schema-catalog/src/schemas/dashboard/dashboard-overview.json
@@ -1,10 +1,11 @@
 {
   "type": "stack",
-  "spacing": 6,
+  "gap": 6,
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between",
+      "align": "center",
+      "justify": "between",
       "children": [
         {
           "type": "text",
@@ -29,7 +30,7 @@
           "children": [
             {
               "type": "container",
-              "className": "p-4",
+              "padding": 4,
               "children": [
                 {
                   "type": "text",
@@ -50,7 +51,7 @@
           "children": [
             {
               "type": "container",
-              "className": "p-4",
+              "padding": 4,
               "children": [
                 {
                   "type": "text",
@@ -71,7 +72,7 @@
           "children": [
             {
               "type": "container",
-              "className": "p-4",
+              "padding": 4,
               "children": [
                 {
                   "type": "text",
@@ -92,7 +93,7 @@
           "children": [
             {
               "type": "container",
-              "className": "p-4",
+              "padding": 4,
               "children": [
                 {
                   "type": "text",
@@ -121,7 +122,7 @@
           "children": [
             {
               "type": "container",
-              "className": "p-6",
+              "padding": 6,
               "children": [
                 {
                   "type": "text",
@@ -130,7 +131,9 @@
                 },
                 {
                   "type": "flex",
-                  "className": "h-[300px] items-center justify-center text-muted-foreground",
+                  "align": "center",
+                  "justify": "center",
+                  "className": "h-[300px] text-muted-foreground",
                   "children": [
                     {
                       "type": "text",
@@ -148,7 +151,7 @@
           "children": [
             {
               "type": "container",
-              "className": "p-6",
+              "padding": 6,
               "children": [
                 {
                   "type": "text",
@@ -157,11 +160,11 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 4,
+                  "gap": 4,
                   "children": [
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "avatar",
@@ -170,7 +173,7 @@
                         },
                         {
                           "type": "stack",
-                          "spacing": 1,
+                          "gap": 1,
                           "children": [
                             {
                               "type": "text",

--- a/examples/schema-catalog/src/schemas/dashboard/recent-activity-card.json
+++ b/examples/schema-catalog/src/schemas/dashboard/recent-activity-card.json
@@ -4,11 +4,13 @@
   "children": [
     {
       "type": "container",
-      "className": "p-6",
+      "padding": 6,
       "children": [
         {
           "type": "flex",
-          "className": "items-center justify-between mb-4",
+          "align": "center",
+          "justify": "between",
+          "className": "mb-4",
           "children": [
             {
               "type": "text",
@@ -25,15 +27,18 @@
         },
         {
           "type": "stack",
-          "spacing": 4,
+          "gap": 4,
           "children": [
             {
               "type": "flex",
-              "className": "items-center justify-between pb-4 border-b",
+              "align": "center",
+              "justify": "between",
+              "className": "pb-4 border-b",
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center space-x-4",
+                  "align": "center",
+                  "className": "space-x-4",
                   "children": [
                     {
                       "type": "avatar",
@@ -42,7 +47,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",
@@ -67,11 +72,14 @@
             },
             {
               "type": "flex",
-              "className": "items-center justify-between pb-4 border-b",
+              "align": "center",
+              "justify": "between",
+              "className": "pb-4 border-b",
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center space-x-4",
+                  "align": "center",
+                  "className": "space-x-4",
                   "children": [
                     {
                       "type": "avatar",
@@ -80,7 +88,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",
@@ -105,11 +113,14 @@
             },
             {
               "type": "flex",
-              "className": "items-center justify-between pb-4 border-b",
+              "align": "center",
+              "justify": "between",
+              "className": "pb-4 border-b",
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center space-x-4",
+                  "align": "center",
+                  "className": "space-x-4",
                   "children": [
                     {
                       "type": "avatar",
@@ -118,7 +129,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",
@@ -143,11 +154,14 @@
             },
             {
               "type": "flex",
-              "className": "items-center justify-between pb-4 border-b",
+              "align": "center",
+              "justify": "between",
+              "className": "pb-4 border-b",
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center space-x-4",
+                  "align": "center",
+                  "className": "space-x-4",
                   "children": [
                     {
                       "type": "avatar",
@@ -156,7 +170,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",
@@ -181,11 +195,13 @@
             },
             {
               "type": "flex",
-              "className": "items-center justify-between",
+              "align": "center",
+              "justify": "between",
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center space-x-4",
+                  "align": "center",
+                  "className": "space-x-4",
                   "children": [
                     {
                       "type": "avatar",
@@ -194,7 +210,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",

--- a/examples/schema-catalog/src/schemas/ecommerce/order-summary.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/order-summary.json
@@ -1,6 +1,6 @@
 {
   "type": "stack",
-  "spacing": 6,
+  "gap": 6,
   "children": [
     {
       "type": "text",
@@ -20,7 +20,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "text",
@@ -29,7 +29,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 1,
+                  "gap": 1,
                   "children": [
                     {
                       "type": "text",
@@ -69,7 +69,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "text",
@@ -78,7 +78,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-center gap-3",
+                  "align": "center",
+                  "gap": 3,
                   "children": [
                     {
                       "type": "flex",
@@ -129,7 +130,7 @@
       "children": [
         {
           "type": "stack",
-          "spacing": 4,
+          "gap": 4,
           "children": [
             {
               "type": "text",
@@ -138,11 +139,12 @@
             },
             {
               "type": "stack",
-              "spacing": 3,
+              "gap": 3,
               "children": [
                 {
                   "type": "flex",
-                  "className": "justify-between text-sm",
+                  "justify": "between",
+                  "className": "text-sm",
                   "children": [
                     {
                       "type": "text",
@@ -157,7 +159,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "justify-between text-sm",
+                  "justify": "between",
+                  "className": "text-sm",
                   "children": [
                     {
                       "type": "text",
@@ -177,11 +180,12 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "flex",
-                  "className": "justify-between text-sm",
+                  "justify": "between",
+                  "className": "text-sm",
                   "children": [
                     {
                       "type": "text",
@@ -195,7 +199,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "justify-between text-sm",
+                  "justify": "between",
+                  "className": "text-sm",
                   "children": [
                     {
                       "type": "text",
@@ -209,7 +214,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "justify-between text-sm",
+                  "justify": "between",
+                  "className": "text-sm",
                   "children": [
                     {
                       "type": "text",
@@ -226,7 +232,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "justify-between font-bold text-lg",
+                  "justify": "between",
+                  "className": "font-bold text-lg",
                   "children": [
                     {
                       "type": "text",
@@ -246,7 +253,7 @@
     },
     {
       "type": "flex",
-      "className": "gap-3",
+      "gap": 3,
       "children": [
         {
           "type": "button",

--- a/examples/schema-catalog/src/schemas/ecommerce/product-card.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/product-card.json
@@ -18,11 +18,11 @@
     },
     {
       "type": "stack",
-      "spacing": 3,
+      "gap": 3,
       "children": [
         {
           "type": "stack",
-          "spacing": 1,
+          "gap": 1,
           "children": [
             {
               "type": "text",
@@ -38,7 +38,8 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-1",
+          "align": "center",
+          "gap": 1,
           "children": [
             {
               "type": "icon",
@@ -74,7 +75,8 @@
         },
         {
           "type": "flex",
-          "className": "items-baseline gap-2",
+          "align": "baseline",
+          "gap": 2,
           "children": [
             {
               "type": "text",
@@ -96,7 +98,7 @@
         },
         {
           "type": "flex",
-          "className": "gap-2",
+          "gap": 2,
           "children": [
             {
               "type": "button",

--- a/examples/schema-catalog/src/schemas/ecommerce/product-grid.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/product-grid.json
@@ -5,7 +5,9 @@
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between mb-6",
+      "align": "center",
+      "justify": "between",
+      "className": "mb-6",
       "children": [
         {
           "type": "text",
@@ -48,7 +50,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "text",
@@ -91,7 +93,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "text",
@@ -134,7 +136,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "text",
@@ -177,7 +179,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "text",

--- a/examples/schema-catalog/src/schemas/ecommerce/shopping-cart.json
+++ b/examples/schema-catalog/src/schemas/ecommerce/shopping-cart.json
@@ -4,11 +4,12 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 6,
+      "gap": 6,
       "children": [
         {
           "type": "flex",
-          "className": "items-center justify-between",
+          "align": "center",
+          "justify": "between",
           "children": [
             {
               "type": "text",
@@ -27,11 +28,11 @@
         },
         {
           "type": "stack",
-          "spacing": 4,
+          "gap": 4,
           "children": [
             {
               "type": "flex",
-              "className": "gap-4",
+              "gap": 4,
               "children": [
                 {
                   "type": "flex",
@@ -49,7 +50,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 1,
+                  "gap": 1,
                   "children": [
                     {
                       "type": "text",
@@ -63,7 +64,9 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center gap-2 mt-2",
+                      "align": "center",
+                      "gap": 2,
+                      "className": "mt-2",
                       "children": [
                         {
                           "type": "button",
@@ -90,7 +93,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "text",
@@ -113,7 +116,7 @@
             },
             {
               "type": "flex",
-              "className": "gap-4",
+              "gap": 4,
               "children": [
                 {
                   "type": "flex",
@@ -131,7 +134,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 1,
+                  "gap": 1,
                   "children": [
                     {
                       "type": "text",
@@ -145,7 +148,9 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center gap-2 mt-2",
+                      "align": "center",
+                      "gap": 2,
+                      "className": "mt-2",
                       "children": [
                         {
                           "type": "button",
@@ -172,7 +177,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "text",
@@ -197,11 +202,12 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "flex",
-              "className": "justify-between text-sm",
+              "justify": "between",
+              "className": "text-sm",
               "children": [
                 {
                   "type": "text",
@@ -215,7 +221,8 @@
             },
             {
               "type": "flex",
-              "className": "justify-between text-sm",
+              "justify": "between",
+              "className": "text-sm",
               "children": [
                 {
                   "type": "text",
@@ -229,7 +236,8 @@
             },
             {
               "type": "flex",
-              "className": "justify-between text-sm",
+              "justify": "between",
+              "className": "text-sm",
               "children": [
                 {
                   "type": "text",
@@ -246,7 +254,8 @@
             },
             {
               "type": "flex",
-              "className": "justify-between text-lg font-bold",
+              "justify": "between",
+              "className": "text-lg font-bold",
               "children": [
                 {
                   "type": "text",

--- a/examples/schema-catalog/src/schemas/forms/contact-form.json
+++ b/examples/schema-catalog/src/schemas/forms/contact-form.json
@@ -4,7 +4,7 @@
   "header": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "children": [
         {
           "type": "text",
@@ -22,7 +22,7 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "grid",
@@ -31,7 +31,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "label",
@@ -49,7 +49,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "label",
@@ -69,7 +69,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -88,7 +88,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -106,7 +106,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",

--- a/examples/schema-catalog/src/schemas/forms/newsletter-signup.json
+++ b/examples/schema-catalog/src/schemas/forms/newsletter-signup.json
@@ -4,11 +4,11 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "className": "text-center",
           "children": [
             {
@@ -30,7 +30,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -49,7 +49,8 @@
         },
         {
           "type": "flex",
-          "className": "items-start space-x-2",
+          "align": "start",
+          "className": "space-x-2",
           "children": [
             {
               "type": "checkbox",

--- a/examples/schema-catalog/src/schemas/forms/payment-form.json
+++ b/examples/schema-catalog/src/schemas/forms/payment-form.json
@@ -4,11 +4,11 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 6,
+      "gap": 6,
       "children": [
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "text",
@@ -24,11 +24,11 @@
         },
         {
           "type": "stack",
-          "spacing": 4,
+          "gap": 4,
           "children": [
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "label",
@@ -46,7 +46,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "label",
@@ -69,7 +69,7 @@
               "children": [
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "label",
@@ -87,7 +87,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "label",
@@ -110,7 +110,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "text",
@@ -119,11 +119,11 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 4,
+                  "gap": 4,
                   "children": [
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "label",
@@ -157,7 +157,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "label",

--- a/examples/schema-catalog/src/schemas/forms/settings-form.json
+++ b/examples/schema-catalog/src/schemas/forms/settings-form.json
@@ -1,10 +1,10 @@
 {
   "type": "stack",
-  "spacing": 6,
+  "gap": 6,
   "children": [
     {
       "type": "stack",
-      "spacing": 2,
+      "gap": 2,
       "children": [
         {
           "type": "text",
@@ -23,15 +23,15 @@
       "children": [
         {
           "type": "stack",
-          "spacing": 6,
+          "gap": 6,
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "text",
@@ -47,7 +47,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "label",
@@ -65,7 +65,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "label",
@@ -84,7 +84,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "label",
@@ -107,11 +107,11 @@
             },
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "text",
@@ -127,11 +127,12 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-center justify-between",
+                  "align": "center",
+                  "justify": "between",
                   "children": [
                     {
                       "type": "stack",
-                      "spacing": 1,
+                      "gap": 1,
                       "children": [
                         {
                           "type": "text",
@@ -155,11 +156,12 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-center justify-between",
+                  "align": "center",
+                  "justify": "between",
                   "children": [
                     {
                       "type": "stack",
-                      "spacing": 1,
+                      "gap": 1,
                       "children": [
                         {
                           "type": "text",
@@ -182,7 +184,7 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "label",
@@ -219,7 +221,8 @@
             },
             {
               "type": "flex",
-              "className": "justify-end space-x-2",
+              "justify": "end",
+              "className": "space-x-2",
               "children": [
                 {
                   "type": "button",

--- a/examples/schema-catalog/src/schemas/marketing/call-to-action.json
+++ b/examples/schema-catalog/src/schemas/marketing/call-to-action.json
@@ -4,7 +4,7 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 6,
+      "gap": 6,
       "children": [
         {
           "type": "text",
@@ -18,7 +18,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center justify-center gap-4",
+          "align": "center",
+          "justify": "center",
+          "gap": 4,
           "children": [
             {
               "type": "button",
@@ -37,11 +39,15 @@
         },
         {
           "type": "flex",
-          "className": "items-center justify-center gap-8 text-white/80 text-sm",
+          "align": "center",
+          "justify": "center",
+          "gap": 8,
+          "className": "text-white/80 text-sm",
           "children": [
             {
               "type": "flex",
-              "className": "items-center gap-2",
+              "align": "center",
+              "gap": 2,
               "children": [
                 {
                   "type": "icon",
@@ -56,7 +62,8 @@
             },
             {
               "type": "flex",
-              "className": "items-center gap-2",
+              "align": "center",
+              "gap": 2,
               "children": [
                 {
                   "type": "icon",
@@ -71,7 +78,8 @@
             },
             {
               "type": "flex",
-              "className": "items-center gap-2",
+              "align": "center",
+              "gap": 2,
               "children": [
                 {
                   "type": "icon",

--- a/examples/schema-catalog/src/schemas/marketing/features-grid.json
+++ b/examples/schema-catalog/src/schemas/marketing/features-grid.json
@@ -32,7 +32,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 3,
+              "gap": 3,
               "children": [
                 {
                   "type": "flex",
@@ -67,7 +67,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 3,
+              "gap": 3,
               "children": [
                 {
                   "type": "flex",
@@ -102,7 +102,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 3,
+              "gap": 3,
               "children": [
                 {
                   "type": "flex",
@@ -137,7 +137,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 3,
+              "gap": 3,
               "children": [
                 {
                   "type": "flex",
@@ -172,7 +172,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 3,
+              "gap": 3,
               "children": [
                 {
                   "type": "flex",
@@ -207,7 +207,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 3,
+              "gap": 3,
               "children": [
                 {
                   "type": "flex",

--- a/examples/schema-catalog/src/schemas/marketing/pricing-table.json
+++ b/examples/schema-catalog/src/schemas/marketing/pricing-table.json
@@ -33,11 +33,11 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "text",
@@ -53,7 +53,7 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-baseline",
+                  "align": "baseline",
                   "children": [
                     {
                       "type": "text",
@@ -78,11 +78,11 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -98,7 +98,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -114,7 +114,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -140,15 +140,17 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "flex",
-                      "className": "items-center justify-between mb-1",
+                      "align": "center",
+                      "justify": "between",
+                      "className": "mb-1",
                       "children": [
                         {
                           "type": "text",
@@ -171,7 +173,7 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-baseline",
+                  "align": "baseline",
                   "children": [
                     {
                       "type": "text",
@@ -196,11 +198,11 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -216,7 +218,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -232,7 +234,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -248,7 +250,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -274,11 +276,11 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "text",
@@ -294,7 +296,7 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-baseline",
+                  "align": "baseline",
                   "children": [
                     {
                       "type": "text",
@@ -319,11 +321,11 @@
                 },
                 {
                   "type": "stack",
-                  "spacing": 2,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -339,7 +341,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -355,7 +357,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",
@@ -371,7 +373,7 @@
                     },
                     {
                       "type": "flex",
-                      "className": "items-center",
+                      "align": "center",
                       "children": [
                         {
                           "type": "icon",

--- a/examples/schema-catalog/src/schemas/marketing/testimonials.json
+++ b/examples/schema-catalog/src/schemas/marketing/testimonials.json
@@ -32,11 +32,12 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center gap-1",
+                  "align": "center",
+                  "gap": 1,
                   "children": [
                     {
                       "type": "icon",
@@ -72,7 +73,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-center gap-3",
+                  "align": "center",
+                  "gap": 3,
                   "children": [
                     {
                       "type": "avatar",
@@ -81,7 +83,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",
@@ -106,11 +108,12 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center gap-1",
+                  "align": "center",
+                  "gap": 1,
                   "children": [
                     {
                       "type": "icon",
@@ -146,7 +149,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-center gap-3",
+                  "align": "center",
+                  "gap": 3,
                   "children": [
                     {
                       "type": "avatar",
@@ -155,7 +159,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",
@@ -180,11 +184,12 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 4,
+              "gap": 4,
               "children": [
                 {
                   "type": "flex",
-                  "className": "items-center gap-1",
+                  "align": "center",
+                  "gap": 1,
                   "children": [
                     {
                       "type": "icon",
@@ -220,7 +225,8 @@
                 },
                 {
                   "type": "flex",
-                  "className": "items-center gap-3",
+                  "align": "center",
+                  "gap": 3,
                   "children": [
                     {
                       "type": "avatar",
@@ -229,7 +235,7 @@
                     },
                     {
                       "type": "stack",
-                      "spacing": 2,
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",

--- a/examples/schema-catalog/src/schemas/plugin-grid/product-inventory-grid.json
+++ b/examples/schema-catalog/src/schemas/plugin-grid/product-inventory-grid.json
@@ -3,7 +3,9 @@
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between mb-4",
+      "align": "center",
+      "justify": "between",
+      "className": "mb-4",
       "children": [
         {
           "type": "text",
@@ -12,7 +14,7 @@
         },
         {
           "type": "flex",
-          "className": "gap-2",
+          "gap": 2,
           "children": [
             {
               "type": "button",
@@ -34,11 +36,13 @@
     },
     {
       "type": "stack",
-      "spacing": 0,
+      "gap": 0,
       "children": [
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
           "children": [
             {
               "type": "text",
@@ -69,7 +73,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -100,7 +106,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -131,7 +139,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -162,7 +172,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -193,7 +205,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 text-sm",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/plugin-grid/team-members-grid.json
+++ b/examples/schema-catalog/src/schemas/plugin-grid/team-members-grid.json
@@ -3,7 +3,9 @@
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between mb-4",
+      "align": "center",
+      "justify": "between",
+      "className": "mb-4",
       "children": [
         {
           "type": "text",
@@ -21,11 +23,13 @@
     },
     {
       "type": "stack",
-      "spacing": 0,
+      "gap": 0,
       "children": [
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
           "children": [
             {
               "type": "text",
@@ -56,7 +60,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -88,7 +94,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -120,7 +128,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -152,7 +162,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 text-sm",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/plugin-view/detail-view-mode.json
+++ b/examples/schema-catalog/src/schemas/plugin-view/detail-view-mode.json
@@ -4,7 +4,8 @@
   "header": [
     {
       "type": "flex",
-      "className": "items-center gap-3",
+      "align": "center",
+      "gap": 3,
       "children": [
         {
           "type": "avatar",
@@ -13,7 +14,7 @@
         },
         {
           "type": "stack",
-          "spacing": 1,
+          "gap": 1,
           "children": [
             {
               "type": "text",
@@ -33,11 +34,12 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 3,
+      "gap": 3,
       "children": [
         {
           "type": "flex",
-          "className": "items-center gap-2",
+          "align": "center",
+          "gap": 2,
           "children": [
             {
               "type": "text",
@@ -53,7 +55,8 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2",
+          "align": "center",
+          "gap": 2,
           "children": [
             {
               "type": "text",
@@ -69,7 +72,8 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2",
+          "align": "center",
+          "gap": 2,
           "children": [
             {
               "type": "text",
@@ -85,7 +89,8 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-2",
+          "align": "center",
+          "gap": 2,
           "children": [
             {
               "type": "text",
@@ -103,7 +108,9 @@
     },
     {
       "type": "flex",
-      "className": "justify-end gap-2 pt-4 border-t mt-4",
+      "justify": "end",
+      "gap": 2,
+      "className": "pt-4 border-t mt-4",
       "children": [
         {
           "type": "button",

--- a/examples/schema-catalog/src/schemas/plugin-view/form-view-mode.json
+++ b/examples/schema-catalog/src/schemas/plugin-view/form-view-mode.json
@@ -11,7 +11,7 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "grid",
@@ -20,7 +20,7 @@
           "children": [
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "label",
@@ -34,7 +34,7 @@
             },
             {
               "type": "stack",
-              "spacing": 2,
+              "gap": 2,
               "children": [
                 {
                   "type": "label",
@@ -50,7 +50,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -65,7 +65,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -92,7 +92,9 @@
         },
         {
           "type": "flex",
-          "className": "justify-end gap-2 pt-2",
+          "justify": "end",
+          "gap": 2,
+          "className": "pt-2",
           "children": [
             {
               "type": "button",

--- a/examples/schema-catalog/src/schemas/plugin-view/grid-view-mode.json
+++ b/examples/schema-catalog/src/schemas/plugin-view/grid-view-mode.json
@@ -3,7 +3,9 @@
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between mb-4",
+      "align": "center",
+      "justify": "between",
+      "className": "mb-4",
       "children": [
         {
           "type": "text",
@@ -21,11 +23,13 @@
     },
     {
       "type": "stack",
-      "spacing": 0,
+      "gap": 0,
       "children": [
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
           "children": [
             {
               "type": "text",
@@ -51,7 +55,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -77,7 +83,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -103,7 +111,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -129,7 +139,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 text-sm",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/report/report-breakdown-table.json
+++ b/examples/schema-catalog/src/schemas/report/report-breakdown-table.json
@@ -3,7 +3,9 @@
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between mb-4",
+      "align": "center",
+      "justify": "between",
+      "className": "mb-4",
       "children": [
         {
           "type": "text",
@@ -19,11 +21,13 @@
     },
     {
       "type": "stack",
-      "spacing": 0,
+      "gap": 0,
       "children": [
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b",
           "children": [
             {
               "type": "text",
@@ -49,7 +53,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -75,7 +81,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -101,7 +109,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -127,7 +137,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 border-b text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 border-b text-sm",
           "children": [
             {
               "type": "text",
@@ -153,7 +165,9 @@
         },
         {
           "type": "flex",
-          "className": "items-center gap-4 px-4 py-3 text-sm",
+          "align": "center",
+          "gap": 4,
+          "className": "px-4 py-3 text-sm",
           "children": [
             {
               "type": "text",

--- a/examples/schema-catalog/src/schemas/report/report-header-with-kpis.json
+++ b/examples/schema-catalog/src/schemas/report/report-header-with-kpis.json
@@ -1,14 +1,15 @@
 {
   "type": "stack",
-  "spacing": 4,
+  "gap": 4,
   "children": [
     {
       "type": "flex",
-      "className": "items-center justify-between",
+      "align": "center",
+      "justify": "between",
       "children": [
         {
           "type": "stack",
-          "spacing": 1,
+          "gap": 1,
           "children": [
             {
               "type": "text",
@@ -24,7 +25,7 @@
         },
         {
           "type": "flex",
-          "className": "gap-2",
+          "gap": 2,
           "children": [
             {
               "type": "button",

--- a/examples/schema-catalog/src/schemas/report/report-scheduling.json
+++ b/examples/schema-catalog/src/schemas/report/report-scheduling.json
@@ -4,7 +4,8 @@
   "header": [
     {
       "type": "flex",
-      "className": "items-center gap-2",
+      "align": "center",
+      "gap": 2,
       "children": [
         {
           "type": "icon",
@@ -22,11 +23,11 @@
   "children": [
     {
       "type": "stack",
-      "spacing": 4,
+      "gap": 4,
       "children": [
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -54,7 +55,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -70,7 +71,7 @@
         },
         {
           "type": "stack",
-          "spacing": 2,
+          "gap": 2,
           "children": [
             {
               "type": "label",
@@ -84,7 +85,7 @@
         },
         {
           "type": "flex",
-          "className": "gap-2",
+          "gap": 2,
           "children": [
             {
               "type": "checkbox",
@@ -121,7 +122,9 @@
         },
         {
           "type": "flex",
-          "className": "justify-end gap-2 pt-2",
+          "justify": "end",
+          "gap": 2,
+          "className": "pt-2",
           "children": [
             {
               "type": "button",

--- a/examples/schema-catalog/src/schemas/theme/theme-aware-ui-elements.json
+++ b/examples/schema-catalog/src/schemas/theme/theme-aware-ui-elements.json
@@ -1,10 +1,11 @@
 {
   "type": "stack",
-  "spacing": 4,
+  "gap": 4,
   "children": [
     {
       "type": "flex",
-      "className": "gap-2 flex-wrap",
+      "gap": 2,
+      "wrap": true,
       "children": [
         {
           "type": "button",
@@ -35,7 +36,8 @@
     },
     {
       "type": "flex",
-      "className": "gap-2 flex-wrap",
+      "gap": 2,
+      "wrap": true,
       "children": [
         {
           "type": "badge",

--- a/examples/schema-catalog/test/layout-props-conversion.test.tsx
+++ b/examples/schema-catalog/test/layout-props-conversion.test.tsx
@@ -319,3 +319,373 @@ describe('the recycled documentation-page node still cancels prose\'s max-width 
     expect(getComputedStyle(el).maxWidth).toBe('none');
   });
 });
+
+/**
+ * The SECOND sweep over the same catalog surface (objectui#4891 + objectui#4890),
+ * landing here because #4003 already built the ratchet and these are the same
+ * files, the same anti-pattern, and the same "keep the next one out" job.
+ *
+ * #4003 converted nodes whose TYPE was wrong (`div` carrying layout intent).
+ * These two cards are about nodes whose type was already right:
+ *
+ *  - #4891 — 140 nodes across 33 files were already `flex` / `stack` /
+ *    `container`, and still hand-wrote, in `className`, props their own type
+ *    declares: `items-center` for `align`, `justify-between` for `justify`,
+ *    `gap-2` for `gap`, `flex-wrap` for `wrap`, `p-4` for a container's
+ *    `padding`. Re-measured on `origin/main` before the sweep: 231 such tokens,
+ *    distributed `flex` 221 / `container` 7 / `stack` 3 / `grid` 0 — the card's
+ *    own figures, reproduced exactly.
+ *  - #4890 — 135 `stack` nodes across 39 files authored `spacing`, a key NO
+ *    schema declares. `StackSchema extends Omit<FlexSchema, 'type'>`, whose only
+ *    spacing key is `gap`; `stack.tsx` read `spacing` anyway through an `as any`,
+ *    which is what made an undeclared key look authorable for as long as it did.
+ *    Fixed at the producer and the alias deleted, per AGENTS.md #0.1 — NOT by
+ *    legalising `spacing` into `StackSchema`, which would only have added a
+ *    second name for `gap`.
+ *
+ * Why it matters here and not only in a renderer test: `className` wins over the
+ * renderer's own classes (`cn()` is `clsx` + `tailwind-merge`, author string
+ * last), so every one of these 275 nodes RENDERED CORRECTLY. There was no
+ * failure to notice — only 423 shipped examples, read by the docs site and
+ * retrieved as AI few-shot material, teaching authors to reimplement a
+ * component's props in Tailwind and to spell a key the types do not have.
+ *
+ * And the props are not merely a tidier spelling: `gap` / `padding` render a
+ * MOBILE-FIRST LADDER (`gap: 3` → `gap-2 sm:gap-3`), while a hand-written
+ * `gap-3` is one dead value at every width. That is why the equivalence cases
+ * below are split into two kinds instead of asserting one blanket rule.
+ */
+
+const ALIGN_VALUES = new Set(['start', 'end', 'center', 'baseline', 'stretch']);
+const JUSTIFY_VALUES = new Set(['start', 'end', 'center', 'between', 'around', 'evenly']);
+const DIRECTION_TOKENS = new Set(['flex-row', 'flex-col', 'flex-row-reverse', 'flex-col-reverse']);
+/**
+ * The gap steps each renderer actually maps. A step OUTSIDE its ladder is not an
+ * offender: `flex.tsx` has no `gap === 9` arm, so `gap: 9` would emit no gap
+ * class at all and moving `gap-9` out of `className` would DELETE the spacing.
+ * The ratchet must only demand extraction where extraction is lossless.
+ */
+const GAP_LADDER: Record<string, ReadonlySet<number>> = {
+  flex: new Set([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+  stack: new Set([0, 1, 2, 3, 4, 5, 6, 8, 10]),
+  grid: new Set([0, 1, 2, 3, 4, 5, 6, 8, 10, 12]),
+};
+const CONTAINER_PADDING = new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 16]);
+const CONTAINER_MAX_W = new Set([
+  'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl', 'full', 'none', 'screen-2xl',
+]);
+
+/**
+ * The className tokens on this node that spell a prop THIS node's own type
+ * declares — i.e. the ones the node should be authoring as props.
+ *
+ * PREFIXED TOKENS ARE NEVER OFFENDERS. `md:items-start` is a responsive
+ * override and the props are not responsive (`grid.columns` is the one
+ * exception, and it takes an object rather than a class). Stripping a
+ * breakpoint-prefixed class into a flat prop would silently discard the
+ * breakpoint, so they stay in `className` by design — as does everything
+ * decorative (`border-b`, `bg-muted`), and everything belonging to a DIFFERENT
+ * type (`max-w-md` on a `flex`: a flex node has no `maxWidth` prop, so that
+ * class is the only way to say it) or describing this node AS A FLEX ITEM
+ * rather than as a container (`flex-shrink-0`, `space-x-2`).
+ */
+function ownPropTokens(type: string, className: unknown): string[] {
+  if (typeof className !== 'string') return [];
+  const hits: string[] = [];
+  for (const token of className.trim().split(/\s+/).filter(Boolean)) {
+    if (token.includes(':')) continue; // breakpoint / state override — stays
+    let m: RegExpExecArray | null;
+    if (type === 'flex' || type === 'stack') {
+      if ((m = /^items-(.+)$/.exec(token)) && ALIGN_VALUES.has(m[1])) { hits.push(token); continue; }
+      if ((m = /^justify-(.+)$/.exec(token)) && JUSTIFY_VALUES.has(m[1])) { hits.push(token); continue; }
+      if ((m = /^gap-(\d+)$/.exec(token)) && GAP_LADDER[type].has(Number(m[1]))) { hits.push(token); continue; }
+      if (token === 'flex-wrap') { hits.push(token); continue; }
+      if (DIRECTION_TOKENS.has(token)) { hits.push(token); continue; }
+      if (type === 'stack' && (m = /^space-y-(\d+)$/.exec(token)) && GAP_LADDER.stack.has(Number(m[1]))) {
+        hits.push(token); continue;
+      }
+    }
+    if (type === 'container') {
+      if ((m = /^p-(\d+)$/.exec(token)) && CONTAINER_PADDING.has(Number(m[1]))) { hits.push(token); continue; }
+      if ((m = /^max-w-(.+)$/.exec(token)) && CONTAINER_MAX_W.has(m[1])) { hits.push(token); continue; }
+      if (token === 'mx-auto') { hits.push(token); continue; }
+    }
+    if (type === 'grid') {
+      if ((m = /^gap-(\d+)$/.exec(token)) && GAP_LADDER.grid.has(Number(m[1]))) { hits.push(token); continue; }
+      if (/^grid-cols-\d+$/.test(token)) { hits.push(token); continue; }
+    }
+  }
+  return hits;
+}
+
+describe('schema-catalog — a layout node configures itself with props (#4891)', () => {
+  it('no flex/stack/container/grid node hand-writes its own props in className', () => {
+    const offenders = allExamples().flatMap((example) =>
+      collect(
+        example.schema,
+        (n) => typeof n.type === 'string' && LAYOUT_TYPES.has(n.type as string),
+      ).flatMap((n) =>
+        ownPropTokens(String(n.type), n.className).map(
+          (token) => `${example.id} :: ${String(n.type)} :: ${token} (in "${String(n.className)}")`,
+        ),
+      ),
+    );
+    expect(
+      offenders,
+      'a first-class layout node that spells its OWN declared prop in Tailwind ' +
+        'teaches every reader to bypass the props — and `gap`/`padding` props ' +
+        'render a mobile-first ladder that a hand-written single value cannot ' +
+        '(#4891). Author the prop; leave decoration and breakpoint-prefixed ' +
+        'overrides in className.',
+    ).toEqual([]);
+  });
+
+  it('sees enough layout nodes WITH a className for the ratchet to mean something', () => {
+    // The guard is only interesting over nodes that still carry a className at
+    // all — 187 of them after the sweep (252 before; 65 nodes had nothing left
+    // to say once their props were extracted). A floor, so adding examples never
+    // fails this, but a mass deletion of classNames would.
+    const withClassName = allExamples().flatMap((e) =>
+      collect(e.schema, (n) => typeof n.type === 'string' && LAYOUT_TYPES.has(n.type as string))
+        .filter((n) => typeof n.className === 'string' && n.className.trim() !== ''),
+    );
+    expect(withClassName.length).toBeGreaterThanOrEqual(180);
+  });
+});
+
+describe('schema-catalog — `spacing` is not a key (#4890)', () => {
+  it('no node anywhere authors `spacing`, which no schema declares', () => {
+    const offenders = allExamples().flatMap((example) =>
+      collect(example.schema, (n) => 'spacing' in n).map(
+        (n) => `${example.id} (type: ${String(n.type)}, spacing: ${JSON.stringify(n.spacing)})`,
+      ),
+    );
+    expect(
+      offenders,
+      '`spacing` is declared by nothing — `StackSchema` extends `FlexSchema`, ' +
+        'whose spacing key is `gap`. It rendered only because `stack.tsx` read it ' +
+        'behind an `as any`, and that reader is gone (#4890). A `stack` node ' +
+        'authoring `spacing` now renders the DEFAULT gap; re-typing one to `flex` ' +
+        'always did. Author `gap`.',
+    ).toEqual([]);
+  });
+
+  it('the rename landed on every node, carrying every value across', () => {
+    // Measured on `origin/main` before the sweep: 153 stack nodes, of which 18
+    // already authored `gap` and the other 135 authored `spacing` — none had
+    // neither. So "all 153 declare a gap" is the statement that all 135 arrived,
+    // and the per-value counts are the statement that each arrived with the
+    // value it had. The renamed 135 were {0:5, 1:13, 2:68, 3:14, 4:28, 6:7};
+    // adding the 18 that already said `gap` ({2:5, 3:5, 4:7, 6:1}) gives the
+    // census below. A rename that dropped a node, or coerced a value, moves one
+    // of these numbers.
+    const stacks = allExamples().flatMap((e) => collect(e.schema, (n) => n.type === 'stack'));
+    expect(stacks.length, 'catalog stack-node count (a floor, so new examples are free)')
+      .toBeGreaterThanOrEqual(153);
+
+    const declared = stacks.filter((n) => typeof n.gap === 'number');
+    expect(
+      stacks.length - declared.length,
+      'every stack node declares a numeric gap; the 135 that said `spacing` now say `gap`',
+    ).toBe(0);
+
+    const census: Record<string, number> = {};
+    for (const n of declared) census[String(n.gap)] = (census[String(n.gap)] ?? 0) + 1;
+    expect(census).toEqual({ '0': 5, '1': 13, '2': 73, '3': 19, '4': 35, '6': 8 });
+
+    // Every value in that census is a step `stack.tsx` actually maps. An unmapped
+    // step (the ladder skips 7) emits NO gap class at all, so the rename would
+    // have been render-neutral in name only.
+    for (const value of Object.keys(census)) {
+      expect(GAP_LADDER.stack.has(Number(value)), `stack gap ${value} is not on the ladder`).toBe(true);
+    }
+  });
+});
+
+/**
+ * Render-level equivalence for #4891, in the two kinds the conversion actually
+ * produces. Each case carries the pre-sweep node as it shipped on `origin/main`,
+ * rebuilt around the node's own children so the comparison isolates this one
+ * conversion.
+ *
+ * This harness measures the className→props half ONLY. #4890's half cannot be
+ * measured this way and must not appear to be: rendering a pre-sweep `spacing`
+ * node through today's renderer exercises the DELETED leg's absence, not the
+ * rename — see the note on the two stack cases below, and the deleted leg's own
+ * reverse-verification in the PR.
+ *
+ * The comparison is on the class TOKEN SET, not the class string. `cn()` emits
+ * the renderer's own classes first and the author's `className` last, so moving
+ * a token from the author string into a prop moves it earlier in the output;
+ * `tailwind-merge` has already resolved every same-property conflict by then, so
+ * the surviving tokens do not conflict with one another and their order carries
+ * no meaning. Asserting the string would be asserting `cn()`'s argument order.
+ * The post-sweep string is still pinned literally, per case.
+ *
+ * `identical` — the set is unchanged: the author's token and the prop's token are
+ * the same class. Every `align` / `justify` / `wrap` / `direction` extraction is
+ * this kind.
+ *
+ * `ladder` — the set differs, in the gap/padding group ONLY, and deliberately:
+ * `gap: 2` is `gap-1.5 sm:gap-2`, not `gap-2`. Below the `sm` breakpoint that is
+ * genuinely a different rendering, and it is the correct one — the ladder IS what
+ * the prop means (#4891's card says so, and #4003 pinned the same delta). Each
+ * ladder case pins BOTH sides' spacing tokens and asserts everything else is
+ * untouched, so "only the ladder moved" is a measurement rather than a claim.
+ *
+ * `grid` has no case because the sweep converted no grid node: re-measured on
+ * `origin/main`, grid's unprefixed className tokens were `mb-6` and `p-4`, and a
+ * grid declares neither. Zero hits, so there is nothing to sample.
+ */
+describe('the swept nodes render what they rendered before (#4891/#4890)', () => {
+  type SweepCase = {
+    readonly id: string;
+    readonly type: string;
+    /** the node exactly as it shipped before the sweep, minus children */
+    readonly before: Record<string, unknown>;
+    /** the class string the node renders now, pinned literally */
+    readonly after: string;
+    readonly kind: 'identical' | 'ladder';
+  };
+
+  const SWEEP_CASES: readonly SweepCase[] = [
+    // ---- #4891, align/justify: same classes, now declared ----
+    {
+      id: 'actions/action-toolbar',
+      type: 'flex',
+      before: { className: 'items-center justify-between border-b pb-3 mb-4' },
+      after: 'flex flex-row justify-between items-center gap-1.5 sm:gap-2 border-b pb-3 mb-4',
+      kind: 'identical',
+    },
+    {
+      id: 'app/application-header',
+      type: 'flex',
+      before: { className: 'items-center justify-between p-3 border rounded-lg bg-background' },
+      after: 'flex flex-row justify-between items-center gap-1.5 sm:gap-2 p-3 border rounded-lg bg-background',
+      kind: 'identical',
+    },
+    // ---- #4891, gap/wrap: the mobile-first ladder appears ----
+    {
+      id: 'actions/action-button-variants',
+      type: 'flex',
+      before: { className: 'gap-2 flex-wrap' },
+      after: 'flex flex-row justify-start items-start gap-1.5 sm:gap-2 flex-wrap',
+      kind: 'ladder',
+    },
+    {
+      id: 'app/application-header',
+      type: 'flex',
+      before: { className: 'items-center gap-3' },
+      after: 'flex flex-row justify-start items-center gap-2 sm:gap-3',
+      kind: 'ladder',
+    },
+    // ---- #4891, container padding ----
+    {
+      id: 'dashboard/dashboard-overview',
+      type: 'container',
+      before: { className: 'p-4' },
+      after: 'w-full max-w-xl mx-auto p-2 sm:p-3 md:p-4',
+      kind: 'ladder',
+    },
+    {
+      id: 'dashboard/recent-activity-card',
+      type: 'container',
+      before: { className: 'p-6' },
+      after: 'w-full max-w-xl mx-auto p-3 sm:p-4 md:p-6',
+      kind: 'ladder',
+    },
+    // ---- stack, where BOTH cards land on the same node ----
+    // These two shipped as `spacing: N` + `items-center …`. `before` writes the
+    // gap as `gap: N`, NOT as the `spacing: N` actually authored, and that is
+    // deliberate: the leg that resolved `spacing` is deleted, so rendering the
+    // literal pre-sweep node here would render the DEFAULT gap and this harness
+    // would be measuring the alias removal instead of the className extraction.
+    // (It would also pass for the wrong reason wherever the authored value
+    // happened to be the default, 2 — which is how this was caught.) So the
+    // rename is held to its own assertions — `spacing` banned above, the value
+    // census below, and the renderer pin in
+    // `packages/components/src/__tests__/stack-spacing-alias-removed.test.tsx` —
+    // and what these two cases measure is the className half, on the resolved
+    // gap the node had either way.
+    {
+      id: 'block-schema/feature-card-block',
+      type: 'stack',
+      before: { gap: 4, className: 'items-center text-center p-4' }, // shipped as `spacing: 4`
+      after: 'flex flex-col justify-start items-center gap-2 sm:gap-3 md:gap-4 text-center p-4',
+      kind: 'identical',
+    },
+    {
+      id: 'block-schema/block-with-variable-overrides-analytics-feature',
+      type: 'stack',
+      before: { gap: 3, className: 'items-center text-center p-4' }, // shipped as `spacing: 3`
+      after: 'flex flex-col justify-start items-center gap-2 sm:gap-3 text-center p-4',
+      kind: 'identical',
+    },
+  ];
+
+  function renderClass(schema: unknown) {
+    const { container } = render(<SchemaRenderer schema={schema as never} />);
+    const el = container.firstElementChild as HTMLElement;
+    return { className: el.className, innerHTML: el.innerHTML };
+  }
+
+  const isSpacingToken = (t: string) => /(^|:)(gap|p)-/.test(t);
+  const sorted = (s: string) => s.trim().split(/\s+/).filter(Boolean).sort();
+
+  it('covers every converted category and both kinds of delta', () => {
+    expect(SWEEP_CASES.filter((c) => c.kind === 'identical').length).toBeGreaterThanOrEqual(2);
+    expect(SWEEP_CASES.filter((c) => c.kind === 'ladder').length).toBeGreaterThanOrEqual(2);
+    for (const type of ['flex', 'stack', 'container']) {
+      expect(SWEEP_CASES.filter((c) => c.type === type).length, `${type} needs 2+ cases`)
+        .toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it.each(SWEEP_CASES.map((c) => [`${c.id} (${c.type}, ${c.kind})`, c] as const))(
+    '%s',
+    (_label, testCase) => {
+      const example = allExamples().find((e) => e.id === testCase.id);
+      expect(example, `${testCase.id} is missing from the catalog`).toBeTruthy();
+
+      const node = collect(example!.schema, (n) => n.type === testCase.type).find(
+        (n) => renderClass(n).className === testCase.after,
+      );
+      expect(
+        node,
+        `${testCase.id} has no ${testCase.type} node rendering \`${testCase.after}\` — ` +
+          'the pin is stale, or the sweep was undone',
+      ).toBeTruthy();
+
+      // Rebuild the pre-sweep node around the SAME children.
+      const asAuthoredBefore: Node = { type: testCase.type, ...testCase.before };
+      if (node!.children !== undefined) asAuthoredBefore.children = node!.children;
+
+      const after = renderClass(node!);
+      const before = renderClass(asAuthoredBefore);
+
+      expect(after.className).toBe(testCase.after);
+      // Content still reaches the DOM — the failure a naive re-type produces.
+      expect(after.innerHTML).toBe(before.innerHTML);
+
+      if (testCase.kind === 'identical') {
+        expect(
+          sorted(after.className),
+          'this conversion changes no class at all; the props emit exactly the ' +
+            'tokens the author had written by hand',
+        ).toEqual(sorted(before.className));
+      } else {
+        // Everything that is NOT gap/padding is untouched...
+        expect(
+          sorted(after.className).filter((t) => !isSpacingToken(t)),
+          'a ladder conversion must move the gap/padding group and NOTHING else',
+        ).toEqual(sorted(before.className).filter((t) => !isSpacingToken(t)));
+        // ...and the spacing group genuinely differs, which is the upgrade.
+        expect(
+          sorted(after.className).filter(isSpacingToken),
+          'the whole point of the prop: a single hand-written step becomes a ' +
+            'mobile-first ladder',
+        ).not.toEqual(sorted(before.className).filter(isSpacingToken));
+      }
+    },
+  );
+});

--- a/packages/components/src/__tests__/stack-spacing-alias-removed.test.tsx
+++ b/packages/components/src/__tests__/stack-spacing-alias-removed.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `stack` reads `gap`, and ONLY `gap` (objectui#4890).
+ *
+ * `StackSchema extends Omit<FlexSchema, 'type'>`, and `FlexSchema`'s spacing key
+ * is `gap`. `spacing` was declared by nothing — not the TypeScript interface, not
+ * the zod mirror, not the renderer's own `inputs` registration, which has always
+ * listed `gap` alone. `stack.tsx` read it anyway:
+ *
+ *     const gap = schema.gap ?? (schema as any).spacing ?? 2;
+ *
+ * The `as any` is the whole story: it existed to get past the type system saying
+ * the key was not there. A lenient consumer leg like that does not stay in the
+ * consumer — it becomes a second de-facto contract that producers write to. 135
+ * catalog nodes across 39 files did exactly that, and every one of them RENDERED
+ * CORRECTLY, so nothing ever pointed at it. Those examples are the docs site's
+ * reference material and an AI few-shot retrieval source, so the reach of the
+ * alias was "every author who copied a stack".
+ *
+ * The trap it was one edit away from springing: `flex` — semantically a `stack`
+ * with a `direction` — never read `spacing`. Re-typing any of those 135 nodes
+ * would have dropped the spacing to the default with no error, no warning and no
+ * visible cause. That is objectui#4001's failure mode, and #4001's own body
+ * makes the point that the "happens to look right" variant is the worst kind.
+ *
+ * Fixed at the PRODUCER per AGENTS.md #0.1: the 135 nodes author `gap` and this
+ * leg is deleted — NOT by adding `spacing` to `StackSchema`, which would promote
+ * a pure alias to public contract and leave AI authors guessing between two
+ * names for one thing.
+ *
+ * What this file pins is the state AFTER: an undeclared key has no effect, and
+ * `stack` and `flex` now answer identically for it. The catalog-side ban (no node
+ * may author `spacing` at all) lives with the sweep that removed them, in
+ * `examples/schema-catalog/test/layout-props-conversion.test.tsx`.
+ *
+ * Module-scope import of the renderers, not `beforeAll` (AGENTS.md §测试纪律):
+ * registering them is an unbounded module load and must not be billed to a
+ * bounded hook timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '../renderers';
+import { SchemaRenderer } from '@object-ui/react';
+
+const classOf = (schema: unknown): string => {
+  const { container } = render(<SchemaRenderer schema={schema as never} />);
+  return (container.firstElementChild as HTMLElement).className;
+};
+
+/** `stack`'s default gap (2) as the mobile-first ladder renders it. */
+const DEFAULT_STACK_GAP = 'gap-1.5 sm:gap-2';
+
+describe('stack no longer reads the undeclared `spacing` key (#4890)', () => {
+  it('a stack authoring `spacing` renders the DEFAULT gap, not the value', () => {
+    // 6 was a real value in the catalog (`dashboard/dashboard-overview`), and it
+    // is a step the ladder maps — so if the alias were still read this assertion
+    // would see `gap-3 sm:gap-4 md:gap-6` and fail loudly rather than coincide
+    // with the default.
+    const withSpacing = classOf({ type: 'stack', spacing: 6, children: [] });
+    const withNothing = classOf({ type: 'stack', children: [] });
+
+    expect(withSpacing).toContain(DEFAULT_STACK_GAP);
+    expect(withSpacing).not.toContain('md:gap-6');
+    expect(
+      withSpacing,
+      'an undeclared key must be inert — identical to not writing it at all',
+    ).toBe(withNothing);
+  });
+
+  it('`flex` answers the same way, which is the trap that is now closed', () => {
+    // `flex.tsx` never read `spacing`. While `stack.tsx` did, re-typing a stack
+    // to flex silently changed its spacing; the two renderers now agree.
+    expect(classOf({ type: 'flex', spacing: 6, children: [] }))
+      .toBe(classOf({ type: 'flex', children: [] }));
+  });
+
+  it('`gap` — the declared key — still drives the whole ladder', () => {
+    expect(classOf({ type: 'stack', gap: 6, children: [] }))
+      .toBe('flex flex-col justify-start items-stretch gap-3 sm:gap-4 md:gap-6');
+    expect(classOf({ type: 'stack', gap: 3, children: [] }))
+      .toBe('flex flex-col justify-start items-stretch gap-2 sm:gap-3');
+  });
+
+  it('`gap: 0` stays reachable — the read is `??`, never `||`', () => {
+    // The sweep moved five catalog nodes carrying `spacing: 0`. `||` would fold
+    // that legal value into the default; this is the same failure `flex.tsx`'s
+    // gap and `container.tsx`'s padding/maxWidth were fixed for (#4003/#4889).
+    expect(classOf({ type: 'stack', gap: 0, children: [] }))
+      .toBe('flex flex-col justify-start items-stretch gap-0');
+  });
+});

--- a/packages/components/src/renderers/layout/stack.tsx
+++ b/packages/components/src/renderers/layout/stack.tsx
@@ -22,7 +22,19 @@ const StackRenderer = forwardRef<HTMLDivElement, { schema: StackSchema; classNam
     const direction = schema.direction || 'col';
     const justify = schema.justify || 'start';
     const align = schema.align || 'stretch'; // Stack items usually stretch
-    const gap = schema.gap ?? (schema as any).spacing ?? 2;
+    // `gap` ONLY. `stack.tsx` also read an undeclared `spacing` here, through an
+    // `as any` that existed to get past the type system saying it wasn't there —
+    // `StackSchema` extends `FlexSchema`, whose only spacing key is `gap`, and the
+    // registration below has always listed `gap` alone. That second reader made
+    // `spacing` a de-facto contract nothing declared: 135 catalog nodes across 39
+    // files were authored with it, rendered correctly, and taught every copying
+    // author (and every few-shot retrieval over these examples) a key the types do
+    // not have. Re-typing such a node to `flex` — semantically one `direction`
+    // away — would have dropped the spacing silently, because `flex.tsx` never
+    // read `spacing`. Fixed at the PRODUCER (AGENTS.md #0.1): the 135 nodes now
+    // author `gap`, and the alias is gone rather than legalised into the schema,
+    // where it would only have been a second name for `gap` (objectui#4890).
+    const gap = schema.gap ?? 2;
     const wrap = schema.wrap || false;
     
     const stackClass = cn(


### PR DESCRIPTION
Fixes #4891
Fixes #4890

Two cards, one sweep, per triage (comment 5335896302): the same 39 catalog files, the same anti-pattern family, and the same ratchet landing spot.

- **#4891** — 140 nodes across 33 files were **already** `flex` / `stack` / `container` and still hand-wrote, in `className`, props their own type declares. 231 tokens in all.
- **#4890** — 135 `stack` nodes across 39 files authored `spacing`, a key nothing declares. Producer first, then the consumer leg.

Direction was fixed by triage and is followed literally: **producer-side rename first, then delete the `(schema as any).spacing` consumer leg.** `spacing` is not legalised into `StackSchema`; `gap` is already there, and a second name for one thing is what leaves AI authors guessing.

## Re-measured on `origin/main` before touching anything

The counts are inherited from cards written days ago, so they were re-derived rather than trusted. **They reproduced exactly** — this was the byte-identical outcome, not the drifted one:

| card | figure as filed | re-measured at `3b147a367` |
|---|---|---|
| #4891 | 140 nodes, 33 files | 140 nodes, 33 files |
| #4891 | token hits `flex` 221 / `container` 7 / `stack` 3 | `flex` 221 / `container` 7 / `stack` 3 (`grid` 0) — 231 total |
| #4890 | 135 nodes, 39 files | 135 nodes, 39 files |
| triage | "33/39 overlapping files" | all 33 of #4891's files are among #4890's 39; 39 files touched in total |

Measured by parsing all 423 catalog JSON documents and walking the trees, not by grep — the shapes being counted are multi-line object literals and multi-token class strings, which a line-oriented grep mis-reads in both directions. Three secondary readings that shaped the work:

- Every one of the 135 `spacing` values is in `{0, 1, 2, 3, 4, 6}`, all steps `stack.tsx` actually maps, so the rename is render-neutral for every node. `"spacing"` occurs 135 times in the catalog as raw text and 135 times as a parsed node key — the two agreeing is what rules out a `spacing` hiding inside a string value.
- On `origin/main`, of 153 catalog `stack` nodes, **18** already said `gap` and **135** said `spacing`; none said neither. So "all 153 declare a gap" is a complete statement of the rename having landed, and it is asserted.
- No node anywhere carried **both** keys, and no node's existing prop disagreed with the class being extracted — so nothing in this sweep had to choose a winner.

## What is left in `className`, deliberately

Breakpoint- and state-prefixed tokens (`md:items-start`, `hover:bg-accent/50`) stay, because the props are not responsive and flattening one would silently discard the breakpoint. So does everything decorative (`border-b`, `bg-muted`), everything belonging to a *different* type (`max-w-md` on a `flex` — a flex has no `maxWidth` prop, so the class is the only way to say it), and everything describing the node **as a flex item** rather than as a container (`flex-shrink-0`, `space-x-2`).

Gap steps outside a renderer's ladder are also not offenders: `flex.tsx` has no `gap === 9` arm, so moving a `gap-9` out of `className` would delete the spacing rather than declare it. The ratchet only demands extraction where extraction is lossless.

## The one deliberate rendering change

`gap` and `padding` render a **mobile-first ladder** — `gap: 3` is `gap-2 sm:gap-3`, not `gap-3`. Below `sm` that is genuinely different from the hand-written single value, and it is the correct direction: the ladder is what the prop means, and giving it up is half of what these 140 nodes were giving up. #4003 pinned the same delta for the same reason. Every such case is sampled and pinned on both sides (see *Verification*).

`container` padding gets a second, smaller improvement: a container writing `p-4` in `className` rendered `p-4 sm:p-3 md:p-4` — the default ladder with only its base step overridden, so padding *shrank* between 640px and 768px. As `padding: 4` it is the clean `p-2 sm:p-3 md:p-4`.

## Per-node itemisation — #4891, 140 nodes / 33 files / 231 tokens

Grouped by distinct `(type, before, after)` conversion; **44 conversions, every one of the 140 nodes listed exactly once** under the conversion that produced it. `n` is the node count per row and the column sums to 140.

| n | type | before `className` | after | 落点 |
|--:|---|---|---|---|
| 14 | `flex` | `items-center gap-4 px-4 py-3 border-b text-sm` | `align: "center"` `gap: 4` + `className: "px-4 py-3 border-b text-sm"` | `plugin-grid/product-inventory-grid.children[1].children[1]` · `plugin-grid/product-inventory-grid.children[1].children[2]` · `plugin-grid/product-inventory-grid.children[1].children[3]` · `plugin-grid/product-inventory-grid.children[1].children[4]` · `plugin-grid/team-members-grid.children[1].children[1]` · `plugin-grid/team-members-grid.children[1].children[2]` · `plugin-grid/team-members-grid.children[1].children[3]` · `plugin-view/grid-view-mode.children[1].children[1]` · `plugin-view/grid-view-mode.children[1].children[2]` · `plugin-view/grid-view-mode.children[1].children[3]` · `report/report-breakdown-table.children[1].children[1]` · `report/report-breakdown-table.children[1].children[2]` · `report/report-breakdown-table.children[1].children[3]` · `report/report-breakdown-table.children[1].children[4]` |
| 12 | `flex` | `items-center` | `align: "center"` *(className dropped)* | `dashboard/dashboard-overview.children[2].children[1].children[0].children[1].children[0]` · `marketing/pricing-table.children[1].children[0].children[0].children[4].children[0]` · `marketing/pricing-table.children[1].children[0].children[0].children[4].children[1]` · `marketing/pricing-table.children[1].children[0].children[0].children[4].children[2]` · `marketing/pricing-table.children[1].children[1].children[0].children[4].children[0]` · `marketing/pricing-table.children[1].children[1].children[0].children[4].children[1]` · `marketing/pricing-table.children[1].children[1].children[0].children[4].children[2]` · `marketing/pricing-table.children[1].children[1].children[0].children[4].children[3]` · `marketing/pricing-table.children[1].children[2].children[0].children[4].children[0]` · `marketing/pricing-table.children[1].children[2].children[0].children[4].children[1]` · `marketing/pricing-table.children[1].children[2].children[0].children[4].children[2]` · `marketing/pricing-table.children[1].children[2].children[0].children[4].children[3]` |
| 9 | `flex` | `items-center gap-2` | `align: "center"` `gap: 2` *(className dropped)* | `app/application-header.children[1]` · `marketing/call-to-action.children[0].children[3].children[0]` · `marketing/call-to-action.children[0].children[3].children[1]` · `marketing/call-to-action.children[0].children[3].children[2]` · `plugin-view/detail-view-mode.children[0].children[0]` · `plugin-view/detail-view-mode.children[0].children[1]` · `plugin-view/detail-view-mode.children[0].children[2]` · `plugin-view/detail-view-mode.children[0].children[3]` · `report/report-scheduling.header[0]` |
| 8 | `flex` | `items-center justify-between` | `align: "center"` `justify: "between"` *(className dropped)* | `auth/login-simple.children[0].children[2]` · `blocks-gallery/block-gallery-stats-card.children[0].children[0]` · `dashboard/dashboard-overview.children[0]` · `dashboard/recent-activity-card.children[0].children[1].children[4]` · `ecommerce/shopping-cart.children[0].children[0]` · `forms/settings-form.children[1].children[0].children[2].children[1]` · `forms/settings-form.children[1].children[0].children[2].children[2]` · `report/report-header-with-kpis.children[0]` |
| 8 | `flex` | `justify-between text-sm` | `justify: "between"` + `className: "text-sm"` | `ecommerce/order-summary.children[2].children[0].children[1].children[0]` · `ecommerce/order-summary.children[2].children[0].children[1].children[1]` · `ecommerce/order-summary.children[2].children[0].children[3].children[0]` · `ecommerce/order-summary.children[2].children[0].children[3].children[1]` · `ecommerce/order-summary.children[2].children[0].children[3].children[2]` · `ecommerce/shopping-cart.children[0].children[4].children[0]` · `ecommerce/shopping-cart.children[0].children[4].children[1]` · `ecommerce/shopping-cart.children[0].children[4].children[2]` |
| 6 | `flex` | `items-center gap-3` | `align: "center"` `gap: 3` *(className dropped)* | `app/application-header.children[0]` · `ecommerce/order-summary.children[1].children[1].children[0].children[1]` · `marketing/testimonials.children[1].children[0].children[0].children[2]` · `marketing/testimonials.children[1].children[1].children[0].children[2]` · `marketing/testimonials.children[1].children[2].children[0].children[2]` · `plugin-view/detail-view-mode.header[0]` |
| 5 | `flex` | `items-center gap-2 px-3 py-2 rounded-md hover:bg-accent/50` | `align: "center"` `gap: 2` + `className: "px-3 py-2 rounded-md hover:bg-accent/50"` | `app/sidebar-navigation.children[0].children[1]` · `app/sidebar-navigation.children[0].children[2]` · `app/sidebar-navigation.children[0].children[5]` · `app/sidebar-navigation.children[0].children[6]` · `app/sidebar-navigation.children[0].children[8]` |
| 5 | `flex` | `items-center justify-between mb-4` | `align: "center"` `justify: "between"` + `className: "mb-4"` | `dashboard/recent-activity-card.children[0].children[0]` · `plugin-grid/product-inventory-grid.children[0]` · `plugin-grid/team-members-grid.children[0]` · `plugin-view/grid-view-mode.children[0]` · `report/report-breakdown-table.children[0]` |
| 5 | `flex` | `items-center space-x-4` | `align: "center"` + `className: "space-x-4"` | `dashboard/recent-activity-card.children[0].children[1].children[0].children[0]` · `dashboard/recent-activity-card.children[0].children[1].children[1].children[0]` · `dashboard/recent-activity-card.children[0].children[1].children[2].children[0]` · `dashboard/recent-activity-card.children[0].children[1].children[3].children[0]` · `dashboard/recent-activity-card.children[0].children[1].children[4].children[0]` |
| 4 | `flex` | `gap-2 flex-wrap` | `gap: 2` `wrap: true` *(className dropped)* | `actions/action-button-variants.children[0]` · `block-schema/block-marketplace-listing.children[1].children[2]` · `theme/theme-aware-ui-elements.children[0]` · `theme/theme-aware-ui-elements.children[1]` |
| 4 | `container` | `p-4` | `padding: 4` *(className dropped)* | `dashboard/dashboard-overview.children[1].children[0].children[0]` · `dashboard/dashboard-overview.children[1].children[1].children[0]` · `dashboard/dashboard-overview.children[1].children[2].children[0]` · `dashboard/dashboard-overview.children[1].children[3].children[0]` |
| 4 | `flex` | `items-center justify-between pb-4 border-b` | `align: "center"` `justify: "between"` + `className: "pb-4 border-b"` | `dashboard/recent-activity-card.children[0].children[1].children[0]` · `dashboard/recent-activity-card.children[0].children[1].children[1]` · `dashboard/recent-activity-card.children[0].children[1].children[2]` · `dashboard/recent-activity-card.children[0].children[1].children[3]` |
| 4 | `flex` | `items-center gap-1` | `align: "center"` `gap: 1` *(className dropped)* | `ecommerce/product-card.children[1].children[1]` · `marketing/testimonials.children[1].children[0].children[0].children[0]` · `marketing/testimonials.children[1].children[1].children[0].children[0]` · `marketing/testimonials.children[1].children[2].children[0].children[0]` |
| 4 | `flex` | `gap-2` | `gap: 2` *(className dropped)* | `ecommerce/product-card.children[1].children[3]` · `plugin-grid/product-inventory-grid.children[0].children[1]` · `report/report-header-with-kpis.children[0].children[1]` · `report/report-scheduling.children[0].children[3]` |
| 4 | `flex` | `items-center gap-4 px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b` | `align: "center"` `gap: 4` + `className: "px-4 py-2 bg-muted text-xs font-medium text-muted-foreground border-b"` | `plugin-grid/product-inventory-grid.children[1].children[0]` · `plugin-grid/team-members-grid.children[1].children[0]` · `plugin-view/grid-view-mode.children[1].children[0]` · `report/report-breakdown-table.children[1].children[0]` |
| 4 | `flex` | `items-center gap-4 px-4 py-3 text-sm` | `align: "center"` `gap: 4` + `className: "px-4 py-3 text-sm"` | `plugin-grid/product-inventory-grid.children[1].children[5]` · `plugin-grid/team-members-grid.children[1].children[4]` · `plugin-view/grid-view-mode.children[1].children[4]` · `report/report-breakdown-table.children[1].children[5]` |
| 3 | `stack` | `items-center text-center p-4` | `align: "center"` + `className: "text-center p-4"` | `block-schema/block-with-variable-overrides-analytics-feature.children[0]` · `block-schema/block-with-variable-overrides-security-feature.children[0]` · `block-schema/feature-card-block.children[0]` |
| 3 | `container` | `p-6` | `padding: 6` *(className dropped)* | `dashboard/dashboard-overview.children[2].children[0].children[0]` · `dashboard/dashboard-overview.children[2].children[1].children[0]` · `dashboard/recent-activity-card.children[0]` |
| 3 | `flex` | `items-baseline` | `align: "baseline"` *(className dropped)* | `marketing/pricing-table.children[1].children[0].children[0].children[1]` · `marketing/pricing-table.children[1].children[1].children[0].children[1]` · `marketing/pricing-table.children[1].children[2].children[0].children[1]` |
| 2 | `flex` | `gap-2 items-center` | `gap: 2` `align: "center"` *(className dropped)* | `actions/action-toolbar.children[1].children[0]` · `actions/action-toolbar.children[1].children[1]` |
| 2 | `flex` | `justify-end gap-2 pt-4 border-t mt-4` | `justify: "end"` `gap: 2` + `className: "pt-4 border-t mt-4"` | `actions/action-toolbar.children[2]` · `plugin-view/detail-view-mode.children[1]` |
| 2 | `flex` | `items-start space-x-2` | `align: "start"` + `className: "space-x-2"` | `auth/signup.children[0].children[3]` · `forms/newsletter-signup.children[0].children[2]` |
| 2 | `flex` | `gap-4` | `gap: 4` *(className dropped)* | `ecommerce/shopping-cart.children[0].children[2].children[0]` · `ecommerce/shopping-cart.children[0].children[2].children[2]` |
| 2 | `flex` | `items-center gap-2 mt-2` | `align: "center"` `gap: 2` + `className: "mt-2"` | `ecommerce/shopping-cart.children[0].children[2].children[0].children[1].children[2]` · `ecommerce/shopping-cart.children[0].children[2].children[2].children[1].children[2]` |
| 2 | `flex` | `justify-end gap-2 pt-2` | `justify: "end"` `gap: 2` + `className: "pt-2"` | `plugin-view/form-view-mode.children[0].children[3]` · `report/report-scheduling.children[0].children[4]` |
| 1 | `flex` | `items-center justify-between border-b pb-3 mb-4` | `align: "center"` `justify: "between"` + `className: "border-b pb-3 mb-4"` | `actions/action-toolbar.children[0]` |
| 1 | `flex` | `justify-end gap-2 pt-4` | `justify: "end"` `gap: 2` + `className: "pt-4"` | `actions/confirmation-dialog.children[0]` |
| 1 | `flex` | `items-center justify-between p-3 border rounded-lg bg-background` | `align: "center"` `justify: "between"` + `className: "p-3 border rounded-lg bg-background"` | `app/application-header` |
| 1 | `flex` | `items-center gap-2 ml-2 pl-2 border-l` | `align: "center"` `gap: 2` + `className: "ml-2 pl-2 border-l"` | `app/application-header.children[1].children[2]` |
| 1 | `flex` | `items-center gap-2 px-3 py-2 rounded-md bg-accent text-accent-foreground` | `align: "center"` `gap: 2` + `className: "px-3 py-2 rounded-md bg-accent text-accent-foreground"` | `app/sidebar-navigation.children[0].children[0]` |
| 1 | `flex` | `items-center space-x-2` | `align: "center"` + `className: "space-x-2"` | `auth/login-simple.children[0].children[2].children[0]` |
| 1 | `flex` | `items-start justify-between` | `align: "start"` `justify: "between"` *(className dropped)* | `block-schema/block-marketplace-listing.children[1].children[0]` |
| 1 | `flex` | `items-center justify-between pt-2 border-t` | `align: "center"` `justify: "between"` + `className: "pt-2 border-t"` | `block-schema/block-marketplace-listing.children[1].children[3]` |
| 1 | `flex` | `items-start gap-3 p-4 border rounded-lg max-w-md` | `align: "start"` `gap: 3` + `className: "p-4 border rounded-lg max-w-md"` | `blocks-gallery/block-gallery-notification-item` |
| 1 | `flex` | `h-[300px] items-center justify-center text-muted-foreground` | `align: "center"` `justify: "center"` + `className: "h-[300px] text-muted-foreground"` | `dashboard/dashboard-overview.children[2].children[0].children[0].children[1]` |
| 1 | `flex` | `justify-between font-bold text-lg` | `justify: "between"` + `className: "font-bold text-lg"` | `ecommerce/order-summary.children[2].children[0].children[3].children[4]` |
| 1 | `flex` | `gap-3` | `gap: 3` *(className dropped)* | `ecommerce/order-summary.children[3]` |
| 1 | `flex` | `items-baseline gap-2` | `align: "baseline"` `gap: 2` *(className dropped)* | `ecommerce/product-card.children[1].children[2]` |
| 1 | `flex` | `items-center justify-between mb-6` | `align: "center"` `justify: "between"` + `className: "mb-6"` | `ecommerce/product-grid.children[0]` |
| 1 | `flex` | `justify-between text-lg font-bold` | `justify: "between"` + `className: "text-lg font-bold"` | `ecommerce/shopping-cart.children[0].children[4].children[4]` |
| 1 | `flex` | `justify-end space-x-2` | `justify: "end"` + `className: "space-x-2"` | `forms/settings-form.children[1].children[0].children[3]` |
| 1 | `flex` | `items-center justify-center gap-4` | `align: "center"` `justify: "center"` `gap: 4` *(className dropped)* | `marketing/call-to-action.children[0].children[2]` |
| 1 | `flex` | `items-center justify-center gap-8 text-white/80 text-sm` | `align: "center"` `justify: "center"` `gap: 8` + `className: "text-white/80 text-sm"` | `marketing/call-to-action.children[0].children[3]` |
| 1 | `flex` | `items-center justify-between mb-1` | `align: "center"` `justify: "between"` + `className: "mb-1"` | `marketing/pricing-table.children[1].children[1].children[0].children[0].children[0]` |

Distribution of what was written: `align: "center"` ×98, `gap: 2` ×34, `justify: "between"` ×33, `gap: 4` ×25, `gap: 3` ×8, `justify: "end"` ×6, `wrap: true` ×4, `align: "start"` ×4, `padding: 4` ×4, `gap: 1` ×4, `align: "baseline"` ×4, `padding: 6` ×3, `justify: "center"` ×3, `gap: 8` ×1 — 231, the token count.

65 of the 140 nodes had nothing left to say afterwards and lost their `className` key entirely.

## Per-node itemisation — #4890, 135 nodes / 39 files

Uniform conversion: `spacing: N` becomes `gap: N`, same value, on the node itself. Grouped by value; the `n` column sums to 135.

| n | before | after | 落点 |
|--:|---|---|---|
| 5 | `spacing: 0` | `gap: 0` | `app/application-header.children[1].children[2].children[1]` · `plugin-grid/product-inventory-grid.children[1]` · `plugin-grid/team-members-grid.children[1]` · `plugin-view/grid-view-mode.children[1]` · `report/report-breakdown-table.children[1]` |
| 13 | `spacing: 1` | `gap: 1` | `app/sidebar-navigation.children[0]` · `block-schema/block-marketplace-listing.children[1].children[0].children[0]` · `blocks-gallery/block-gallery-login-card.header[0]` · `blocks-gallery/block-gallery-notification-item.children[1]` · `dashboard/dashboard-overview.children[2].children[1].children[0].children[1].children[0].children[1]` · `ecommerce/order-summary.children[1].children[0].children[0].children[1]` · `ecommerce/product-card.children[1].children[0]` · `ecommerce/shopping-cart.children[0].children[2].children[0].children[1]` · `ecommerce/shopping-cart.children[0].children[2].children[2].children[1]` · `forms/settings-form.children[1].children[0].children[2].children[1].children[0]` · `forms/settings-form.children[1].children[0].children[2].children[2].children[0]` · `plugin-view/detail-view-mode.header[0].children[1]` · `report/report-header-with-kpis.children[0].children[0]` |
| 68 | `spacing: 2` | `gap: 2` | `actions/confirmation-dialog.header[0]` · `auth/forgot-password.header[0]` · `auth/forgot-password.children[0].children[0]` · `auth/login-simple.header[0]` · `auth/login-simple.children[0].children[0]` · `auth/login-simple.children[0].children[1]` · `auth/signup.header[0]` · `auth/signup.children[0].children[0].children[0]` · `auth/signup.children[0].children[0].children[1]` · `auth/signup.children[0].children[1]` · `auth/signup.children[0].children[2]` · `auth/two-factor.header[0]` · `auth/two-factor.children[0].children[0]` · `blocks-gallery/block-gallery-login-card.children[0].children[0]` · `blocks-gallery/block-gallery-login-card.children[0].children[1]` · `blocks-gallery/block-gallery-stats-card.children[0]` · `dashboard/recent-activity-card.children[0].children[1].children[0].children[0].children[1]` · `dashboard/recent-activity-card.children[0].children[1].children[1].children[0].children[1]` · `dashboard/recent-activity-card.children[0].children[1].children[2].children[0].children[1]` · `dashboard/recent-activity-card.children[0].children[1].children[3].children[0].children[1]` · `dashboard/recent-activity-card.children[0].children[1].children[4].children[0].children[1]` · `ecommerce/order-summary.children[2].children[0].children[3]` · `ecommerce/product-grid.children[1].children[0].children[1]` · `ecommerce/product-grid.children[1].children[1].children[1]` · `ecommerce/product-grid.children[1].children[2].children[1]` · `ecommerce/product-grid.children[1].children[3].children[1]` · `ecommerce/shopping-cart.children[0].children[2].children[0].children[2]` · `ecommerce/shopping-cart.children[0].children[2].children[2].children[2]` · `ecommerce/shopping-cart.children[0].children[4]` · `forms/contact-form.header[0]` · `forms/contact-form.children[0].children[0].children[0]` · `forms/contact-form.children[0].children[0].children[1]` · `forms/contact-form.children[0].children[1]` · `forms/contact-form.children[0].children[2]` · `forms/contact-form.children[0].children[3]` · `forms/newsletter-signup.children[0].children[0]` · `forms/newsletter-signup.children[0].children[1]` · `forms/payment-form.children[0].children[0]` · `forms/payment-form.children[0].children[1].children[0]` · `forms/payment-form.children[0].children[1].children[1]` · `forms/payment-form.children[0].children[1].children[2].children[0]` · `forms/payment-form.children[0].children[1].children[2].children[1]` · `forms/payment-form.children[0].children[1].children[4]` · `forms/payment-form.children[0].children[1].children[4].children[1].children[0]` · `forms/payment-form.children[0].children[1].children[4].children[1].children[1]` · `forms/settings-form.children[0]` · `forms/settings-form.children[1].children[0].children[0].children[0]` · `forms/settings-form.children[1].children[0].children[0].children[1]` · `forms/settings-form.children[1].children[0].children[0].children[2]` · `forms/settings-form.children[1].children[0].children[0].children[3]` · `forms/settings-form.children[1].children[0].children[2].children[0]` · `forms/settings-form.children[1].children[0].children[2].children[3]` · `marketing/pricing-table.children[1].children[0].children[0].children[0]` · `marketing/pricing-table.children[1].children[0].children[0].children[4]` · `marketing/pricing-table.children[1].children[1].children[0].children[0]` · `marketing/pricing-table.children[1].children[1].children[0].children[4]` · `marketing/pricing-table.children[1].children[2].children[0].children[0]` · `marketing/pricing-table.children[1].children[2].children[0].children[4]` · `marketing/testimonials.children[1].children[0].children[0].children[2].children[1]` · `marketing/testimonials.children[1].children[1].children[0].children[2].children[1]` · `marketing/testimonials.children[1].children[2].children[0].children[2].children[1]` · `plugin-view/form-view-mode.children[0].children[0].children[0]` · `plugin-view/form-view-mode.children[0].children[0].children[1]` · `plugin-view/form-view-mode.children[0].children[1]` · `plugin-view/form-view-mode.children[0].children[2]` · `report/report-scheduling.children[0].children[0]` · `report/report-scheduling.children[0].children[1]` · `report/report-scheduling.children[0].children[2]` |
| 14 | `spacing: 3` | `gap: 3` | `actions/action-toolbar.children[1]` · `block-schema/block-marketplace-listing.children[1]` · `block-schema/block-with-variable-overrides-analytics-feature.children[0]` · `block-schema/block-with-variable-overrides-security-feature.children[0]` · `blocks-gallery/block-gallery-login-card.children[0]` · `ecommerce/order-summary.children[2].children[0].children[1]` · `ecommerce/product-card.children[1]` · `marketing/features-grid.children[1].children[0].children[0]` · `marketing/features-grid.children[1].children[1].children[0]` · `marketing/features-grid.children[1].children[2].children[0]` · `marketing/features-grid.children[1].children[3].children[0]` · `marketing/features-grid.children[1].children[4].children[0]` · `marketing/features-grid.children[1].children[5].children[0]` · `plugin-view/detail-view-mode.children[0]` |
| 28 | `spacing: 4` | `gap: 4` | `actions/action-button-variants` · `auth/forgot-password.children[0]` · `auth/login-simple.children[0]` · `auth/signup.children[0]` · `auth/two-factor.children[0]` · `block-schema/feature-card-block.children[0]` · `dashboard/dashboard-overview.children[2].children[1].children[0].children[1]` · `dashboard/recent-activity-card.children[0].children[1]` · `ecommerce/order-summary.children[1].children[0].children[0]` · `ecommerce/order-summary.children[1].children[1].children[0]` · `ecommerce/order-summary.children[2].children[0]` · `ecommerce/shopping-cart.children[0].children[2]` · `forms/contact-form.children[0]` · `forms/newsletter-signup.children[0]` · `forms/payment-form.children[0].children[1]` · `forms/payment-form.children[0].children[1].children[4].children[1]` · `forms/settings-form.children[1].children[0].children[0]` · `forms/settings-form.children[1].children[0].children[2]` · `marketing/pricing-table.children[1].children[0].children[0]` · `marketing/pricing-table.children[1].children[1].children[0]` · `marketing/pricing-table.children[1].children[2].children[0]` · `marketing/testimonials.children[1].children[0].children[0]` · `marketing/testimonials.children[1].children[1].children[0]` · `marketing/testimonials.children[1].children[2].children[0]` · `plugin-view/form-view-mode.children[0]` · `report/report-header-with-kpis` · `report/report-scheduling.children[0]` · `theme/theme-aware-ui-elements` |
| 7 | `spacing: 6` | `gap: 6` | `dashboard/dashboard-overview` · `ecommerce/order-summary` · `ecommerce/shopping-cart.children[0]` · `forms/payment-form.children[0]` · `forms/settings-form` · `forms/settings-form.children[1].children[0]` · `marketing/call-to-action.children[0]` |

Three nodes appear in **both** tables (`block-schema/feature-card-block.children[0]` and its two `block-with-variable-overrides-*` siblings) — they were carrying `spacing` *and* an `items-center`. 140 + 135 − 3 = **272 distinct nodes changed.**

## How the table and the diff were checked against each other

The risk a sweep actually carries is a node changed but not listed, or listed but not changed. Both directions were measured rather than eyeballed: every one of the 423 catalog documents was parsed at `HEAD` and in the working tree, each object reduced to a signature of its scalar keys, and the two walks compared pointer by pointer.

```
nodes the diff actually changed : 272
nodes the per-node list covers  : 272  (140 + 135, overlap 3)
CHANGED BUT NOT LISTED          : 0
LISTED BUT NOT CHANGED          : 0
nodes added/removed             : 0
```

Set equality, both directions. Two further post-state checks: `"spacing"` now occurs **0** times in the catalog, and each of the 272 rows was re-read from disk and its props and surviving `className` compared against what the table claims.

The edits are applied by offset into the original bytes, never by re-serialising the JSON — 12 catalog files carry hand-compacted single-line objects that a `JSON.stringify(…, null, 2)` round-trip would reflow, which is exactly the "changes outside the listed nodes" this had to avoid. `git diff` on those 12 shows only the intended lines.

## Verification

All commands from the repo root, per AGENTS.md §怎么跑测试. Union re-run **at the final commit `953c58820`** (the `HEAD` printed by the run itself), not at an earlier tree:

```
pnpm exec vitest run examples/schema-catalog/ \
  packages/components/src/__tests__/stack-spacing-alias-removed.test.tsx \
  packages/components/src/__tests__/container-max-width-false.test.tsx \
  packages/components/src/__tests__/div-deprecation-provenance.test.tsx \
  packages/components/src/__tests__/div-deprecation-warn-once.test.tsx \
  packages/plugin-dashboard/src/__tests__/DashboardGridLayout.legacyRetired.test.tsx \
  scripts/__tests__/catalog-index-regenerable-4633.test.ts \
  --reporter=verbose --maxWorkers=2
  -> Test Files  15 passed (15)   Tests  1636 passed (1636)

pnpm exec turbo run type-check --filter=@object-ui/components \
  --filter=@object-ui/example-schema-catalog --concurrency=2
  -> Tasks: 30 successful, 30 total   (both packages' `tsc --noEmit && tsc -p tsconfig.test.json` echoed)

node scripts/check-control-bytes.mjs
  -> check-control-bytes: OK (scanned 4734 tracked text file(s); skipped 85 binary)

node scripts/check-changeset-fixed.mjs      -> All workspace packages are in the changeset fixed group.
node scripts/check-changeset-no-major.mjs   -> No changeset declares a `major` bump.
```

Exit codes were captured **before** any pipe, in a wrapper that propagates them, and each line above quotes the tool's own verdict rather than a `$?` a `tail` would have written. Heavy runs went through `scripts/pm/os-verify-lock.sh`.

**Why this set is a provable superset of what the diff can affect**, rather than a guess:

1. *The catalog JSON* is reachable only through `@object-ui/example-schema-catalog`. Its in-repo dependents are `apps/site` (a `package.json` dependency; excluded from every root vitest project by config, and owned by CI — no `apps/site` or `content/docs` path is touched here) plus four test files, all of which are in the run above alongside the catalog's own nine test files.
2. *The `stack.tsx` change* is one expression: `schema.gap ?? (schema as any).spacing ?? 2` becomes `schema.gap ?? 2`. For any node with `gap` defined the two are identical; with neither key, both give 2. The **only** input whose output moves is a node with `spacing` and no `gap` — and a repo-wide search finds no such node outside the test that authors one deliberately. The observable surface is therefore empty except where it is asserted.

**Lint, narrowed and declared.** `pnpm lint` (the whole-tree `eslint .`) is CI's run, not re-done here. The narrowing is a measurement, with all three legs: the population comes from eslint's own config resolution rather than a guess about which files count; the file count is read from `--format json`; and the invariance claim is that `eslint.config.js` declares **no `parserOptions.project` / `projectService`** and no rule in `eslint-rules/` reads another file (no `readFileSync` / `globSync` anywhere in it), so every rule here is single-file syntactic and this diff cannot move the verdict of a file it did not touch. Reading:

```
pnpm exec eslint --no-inline-config --format json <the 43 changed files>   -> exit 0
files handed to eslint      : 43
files eslint actually linted:  3  (stack.tsx + the two test files)
files outside its population: 40  (the JSON and the changeset — no config block matches them)
errors: 0
```

The two warnings on `stack.tsx` are pre-existing and untouched (`react-refresh/only-export-components`, and the `no-explicit-any` on the `forwardRef` parameter's index signature at line 20 — the objectui#4422 shape). This diff removes one `any` from that file and adds none.

## Reverse-verification

Three legs, each with its direction predicted **before** running. Neither leg needs a build: the root vitest config aliases `@object-ui/components` to `packages/components/src` (`vitest.config.mts:264`) and the catalog test imports `allExamples` from `'../src/index.js'` (line 54), so there is no `dist` anywhere in the resolution path and a source mutation takes effect directly. Every leg mutated, proved the mutation on disk, ran, then restored from the commit under `trap … EXIT INT TERM`; the restore is verified **by sha256**, and all three files came back byte-identical.

| leg | mutation | predicted | observed |
|---|---|---|---|
| A | revert one #4891 conversion (`actions/action-toolbar` `$.children[0]`) to its shipped `className` | RED — the #4891 ratchet (2 offenders) **and** the pinned equivalence case, whose class no longer matches any node | exactly those two: `Tests 2 failed \| 26 passed` |
| B | put `spacing: 2` back on `auth/login-simple` `$.header[0]` | RED — the `spacing` ban (1 offender) **and** the value census (a stack with no numeric `gap`) | exactly those two: `Tests 2 failed \| 26 passed`, reporting `expected 1 to be +0` |
| C | restore `?? (schema as any).spacing` in `stack.tsx` | RED — only "a stack authoring `spacing` renders the DEFAULT gap"; the `flex`, `gap` and `gap: 0` cases unaffected | exactly that one: `Tests 1 failed \| 3 passed` |

**Leg B's first attempt was void and is reported rather than quietly retried.** The mutation landed, but the on-disk confirmation used `grep -F` with a *multi-line* pattern, which grep treats as several patterns and counts matching lines for — so the "this text is gone" probe returned 3 instead of 0 and the guard declared the leg unrun. The reading was discarded and the leg re-run with single-line counting probes (`"gap": 2,` 3 → 2, `"spacing": 2,` 0 → 1). The row above is the second, valid run. The guard firing on a bad probe rather than on a bad mutation is the outcome it exists for; a leg that "looks fine" is the one worth distrusting.

Leg C is what makes the new renderer pin non-phantom: `spacing: 6` was chosen precisely because 6 is a mapped ladder step, so a still-live alias renders `md:gap-6` and fails loudly instead of coinciding with the default.

## What is ratcheted, and where

- `examples/schema-catalog/test/layout-props-conversion.test.tsx` — extended, per the card, from "no `div` carries layout intent" to "no `flex`/`stack`/`container`/`grid` hand-writes its own props". Also carries the `spacing` ban, the value census, and the sampled equivalence (2+ cases each for `flex`, `stack`, `container`; `grid` has none because the sweep converted no grid node — its unprefixed tokens re-measured to `mb-6` and `p-4`, neither of which a grid declares). Equivalence is asserted on the class **token set**, not the string: extraction moves a token from the end of `cn()`'s arguments to the front, `tailwind-merge` has already resolved every same-property conflict by then, and asserting the string would be asserting `cn()`'s argument order. The post-sweep string is still pinned literally per case.
- `packages/components/src/__tests__/stack-spacing-alias-removed.test.tsx` — new; the renderer-side half. An undeclared key is inert, `stack` and `flex` now answer identically for it (the trap #4890 named), `gap` still drives the ladder, and `gap: 0` stays reachable.

## Out of scope, filed separately

- **#5690** (new, `finding`) — nine catalog `flex` nodes still spell horizontal spacing as `space-x-*`. Same reader-facing shape, different mechanism: `space-x-N` is a margin on a sibling selector, not the flexbox gap, so it is not a mechanical rename and a conversion changes rendering in ways worth deciding on deliberately. Excluding it is why this card's 221-token `flex` figure re-measured to the digit.
- **#5574** (existing, already open) — the `flex` / `stack` / `container` renderers spread their schema keys onto the DOM element, the leak PR #5573 closed for `grid` via `toDomProps`. That issue lists these three as "candidates to measure"; the measurement is now posted there as a comment (662 stray attributes across the catalog, `grid` reading clean as the control) instead of duplicating the issue. Worth knowing while reviewing this PR: 231 of those attributes are new here, because declared props are what leak.

Fenced-out paths were not touched: no `content/docs/**`, no `apps/site/**`, and none of the four paths held by concurrent cards this round.


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_