### PR TITLE
fix(i18n,app-shell): pending-drafts bar keys land in the locale packs (#5696 follow-up, main is red)

### DIFF
--- a/.changeset/pending-drafts-i18n-keys.md
+++ b/.changeset/pending-drafts-i18n-keys.md
@@ -1,0 +1,6 @@
+---
+'@object-ui/i18n': patch
+'@object-ui/app-shell': patch
+---
+
+Follow-up to #5696: the pending-drafts bar's strings live at `console.ai.pendingDrafts.*` with en+zh locale entries — the i18n call-site key gate and ratchet flagged the original root-level keys that existed nowhere.

--- a/packages/app-shell/src/console/ai/PendingDraftsBar.tsx
+++ b/packages/app-shell/src/console/ai/PendingDraftsBar.tsx
@@ -99,7 +99,7 @@ export function PendingDraftsBar({ packageId, idle }: PendingDraftsBarProps) {
       if (!res.ok) {
         const message =
           (body as { error?: { message?: string } } | undefined)?.error?.message ??
-          t('ai.pendingDrafts.failed', { defaultValue: 'Publish failed.' });
+          t('console.ai.pendingDrafts.failed', { defaultValue: 'Publish failed.' });
         toast.error(message);
         return;
       }
@@ -107,13 +107,13 @@ export function PendingDraftsBar({ packageId, idle }: PendingDraftsBarProps) {
       const problems = (health?.issues ?? []).filter((i) => i.severity === 'error');
       if (health?.seedError || problems.length > 0) {
         toast.warning(
-          t('ai.pendingDrafts.publishedWithFindings', {
+          t('console.ai.pendingDrafts.publishedWithFindings', {
             defaultValue: 'Published, but the runtime probes reported problems: {{detail}}',
             detail: [health?.seedError, ...problems.map((p) => p.message)].filter(Boolean).join('; '),
           }),
         );
       } else {
-        toast.success(t('ai.pendingDrafts.published', { defaultValue: 'All pending changes are live.' }));
+        toast.success(t('console.ai.pendingDrafts.published', { defaultValue: 'All pending changes are live.' }));
       }
       // The launcher/nav may have just gained entries — refresh the shared
       // metadata so the user's next click finds them.
@@ -136,14 +136,14 @@ export function PendingDraftsBar({ packageId, idle }: PendingDraftsBarProps) {
       className="pointer-events-auto flex w-full max-w-3xl items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm shadow-sm backdrop-blur"
     >
       <span className="min-w-0 truncate">
-        {t('ai.pendingDrafts.count', {
+        {t('console.ai.pendingDrafts.count', {
           defaultValue: '{{count}} change(s) are not published yet — users cannot see them.',
           count,
         })}
       </span>
       <Button size="sm" onClick={() => void publish()} disabled={publishing} className="shrink-0">
         {publishing ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <CloudUpload className="mr-1 h-3.5 w-3.5" />}
-        {t('ai.pendingDrafts.publish', { defaultValue: 'Publish' })}
+        {t('console.ai.pendingDrafts.publish', { defaultValue: 'Publish' })}
       </Button>
     </div>
   );

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1687,6 +1687,13 @@ const en = {
       createApp: 'Create New App',
     },
     ai: {
+      pendingDrafts: {
+        count: '{{count}} change(s) are not published yet — users cannot see them.',
+        publish: 'Publish',
+        published: 'All pending changes are live.',
+        failed: 'Publish failed.',
+        publishedWithFindings: 'Published, but the runtime probes reported problems: {{detail}}',
+      },
       usage: {
         title: 'AI usage',
         meterBuild: 'Build',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1558,6 +1558,13 @@ const zh = {
       createApp: '创建新应用',
     },
     ai: {
+      pendingDrafts: {
+        count: '有 {{count}} 项改动尚未发布——用户还看不到。',
+        publish: '发布',
+        published: '全部待发布改动已生效。',
+        failed: '发布失败。',
+        publishedWithFindings: '已发布，但运行时探针发现问题：{{detail}}',
+      },
       usage: {
         title: 'AI 用量',
         meterBuild: 'AI 搭建',


### PR DESCRIPTION
## What

#5696 shipped `PendingDraftsBar` with root-level `ai.pendingDrafts.*` t() keys that exist in no locale pack — the en call-site key gate and the i18n ratchet test are both red on main (my miss: I ran the component tests but not the key gate before merging). Keys move to `console.ai.pendingDrafts.*` — the surface's real namespace (`console.ai` block) — with **en + zh** entries; other locales fall back to en per the pack's normal behavior.

Verified: `check-i18n-call-site-keys` ratchet + bar tests — 68 passed; `i18n` and `app-shell` tsc builds green.

Fix-forward for main; please expedite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)