### PR TITLE
docs(plugin-form): state the field-level className rule as contract, not reader count

### DIFF
--- a/.changeset/plugin-form-readme-classname-quantifier-5131.md
+++ b/.changeset/plugin-form-readme-classname-quantifier-5131.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+`README.md`'s "Not a `FormField` key" table said a field-level `className` is
+"read on exactly one pseudo-field, `type: 'section-divider'`". That quantifier
+holds only for the renderer's *explicit* read — `className={fp.className}` on
+the `section-divider` branch of
+`packages/components/src/renderers/form/form.tsx`. The same renderer forwards
+every key it did not destructure, and `className` is not among the names taken
+off the field config, not among the ones `stripRendererOnlyProps` removes, and
+so rides `{...fieldProps}` into `renderFieldComponent`, whose built-in `input`
+branch spreads it onto `<Input>`. A field-level `className` therefore lands
+visibly on ordinary built-in controls, and a reader taking "exactly one"
+literally concludes the opposite of what the code does (objectui#5131).
+
+The cell now describes the contract rather than the reader count: an undeclared
+key still rides the props spread down to whichever component the field resolves
+to, nothing in the contract promises that, and a registered widget honours it
+only if it happens to spread its leftover props — the wording the docs site
+already ships, so the two sources agree again. The advice in the row is
+unchanged and was never wrong (`span` / `colSpan` for width,
+`FormSchema.fieldContainerClass` for the grid), and the explicit
+`section-divider` read is kept, now named as explicit.
+
+This is a documentation fix to a file `plugin-form` publishes to npm, which is
+why it carries a version: the npm landing page only picks up the correction on a
+release. No behaviour, export, type, or `dist` byte changes.

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -224,7 +224,7 @@ here too. Two that a reader might expect, and that are **not** declared:
 | Not a `FormField` key | Write this instead |
 |---|---|
 | `defaultValue` | `FormSchema.defaultValues` at form level. An object-bound form seeds from the object field's own declared `defaultValue` — see [What a create form opens with](#what-a-create-form-opens-with) |
-| `className` | `span` / `colSpan` for width, `FormSchema.fieldContainerClass` for the grid. (A field-level `className` is read on exactly one pseudo-field, `type: 'section-divider'`, where it styles the inline section header.) |
+| `className` | `span` / `colSpan` for width, `FormSchema.fieldContainerClass` for the grid. (An undeclared key still rides the props spread down to whichever component the field resolves to, so a field-level `className` can visibly land on a built-in control — but nothing in the contract promises that, and a registered widget honours it only if it happens to spread its leftover props. The renderer reads it *explicitly* on exactly one pseudo-field, `type: 'section-divider'`, where it styles the inline section header.) |
 
 There is no `ValidationRule` type in this repo, under any spelling.
 


### PR DESCRIPTION
Fixes #5131

`packages/plugin-form/README.md`'s "Not a `FormField` key" table said:

> (A field-level `className` is read on exactly one pseudo-field, `type: 'section-divider'`, where it styles the inline section header.)

The quantifier was checked against the source at the branch base (`6c6cee704`), not taken from the card. It is wrong for anyone who reads "read" literally:

| Step | Where (at `6c6cee704`) | What happens to `className` |
|---|---|---|
| field destructure | `packages/components/src/renderers/form/form.tsx:1848-1867` (`renderFormField`, `...fieldProps` at `:1866`) | not one of the 16 destructured names, so it stays in `fieldProps` |
| renderer-only strip | `form.tsx:348-388` (`stripRendererOnlyProps`) | not in the strip list |
| forward to the control | `form.tsx:2326-2327` — `renderFieldComponent(resolvedType, { ...fieldProps, … })` | forwarded whole |
| built-in `input` branch | `form.tsx:3195-3196`, then the `Input` element at `:3251-3267` | the second destructure and the second strip both keep it; it is spread onto that element via `{...inputProps}` |
| the `Input` component itself | `packages/components/src/ui/input.tsx:14-20` | `cn(baseClasses, className)` — the authored class is appended, not dropped |

So a field-level `className` does visibly land on an ordinary built-in control — the jsdom measurement on the card (`PROBE-CLASS` appended to the input's class list) is the same fact from the other end. The true half of the old sentence, the renderer's *explicit* read at `form.tsx:1942` (`className={fp.className}` on the `section-divider` branch), is kept and now named as explicit.

## The change

One table cell. The advice in the row is unchanged and was never wrong (`span` / `colSpan` for width, `FormSchema.fieldContainerClass` for the grid); only the reader-count claim is replaced by a statement about the contract, in the wording the docs site already ships (`content/docs/plugins/plugin-form.mdx`, from #5130) — the two sources now agree again.

## Scope

Exactly the one quantifier at `README.md:227`, plus the changeset. No other prose in the file, no other README, no source file. No audit of the rest of the file was performed, and none is claimed.

## Verification

The diff is markdown only (`packages/plugin-form/README.md` + one `.changeset/*.md`). `ci.yml` and `lint.yml` skip their expensive steps on such a diff through their own `Decide whether this change needs a full run` step, whose exclusion list carries `**/*.md` and `.changeset/**` — so what actually judges this PR are the gates that carry no path filter. All four were run locally on the final commit `1066b1cdf`, quoting each gate's own verdict line:

```
node scripts/check-control-bytes.mjs       ✅  check-control-bytes: OK (scanned 4754 tracked text file(s); skipped 85 binary).
node scripts/check-changeset-presence.mjs  ✅  No source of a released package changed in this range, so no changeset is owed.
node scripts/check-changeset-no-major.mjs  ✅  No changeset declares a `major` bump.
node scripts/check-doc-links.mjs           Links are valid across 13 scan roots.
```

Plus the author-side control-byte scan over the two touched files: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → no match.

**Declared narrowing.** No build and no test was run, and the shared verify lock was not held. The diff changes no byte that a compiler, bundler or test reads — two markdown files, one of them a changeset — so the provable superset of what it can affect is the markdown gate set above. This is a declared narrowing, not a skipped step; CI still runs the full farm.

The changeset carries a `patch` on `@object-ui/plugin-form` rather than empty frontmatter, following the precedent set for the sibling README correction in `.changeset/calendar-readme-schema-keys-5045.md`: `README.md` is in this package's `files`, so the npm landing page only picks the correction up on a release. No behaviour, export, type or `dist` byte changes.

Neither `content/docs/**` nor `apps/site/**` is touched, so `Build Docs` does not run on this PR.

(Body edited once after creation: the three `Input` JSX fragments in the table above were written in angle-bracket form and the body sanitizer deleted them outright, leaving empty backticks. Rewritten as prose names — no other change.)

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_