### PR TITLE
Qualify `ADR-0057 D10` as the framework's numbering at seven live citation sites

### DIFF
--- a/.changeset/adr-0057-d10-citation-attribution-5202.md
+++ b/.changeset/adr-0057-d10-citation-attribution-5202.md
@@ -1,0 +1,25 @@
+---
+---
+
+Traceability only — this publishes nothing, declared explicitly with an empty frontmatter
+rather than left undeclared. The change is comment text at seven live source sites; no
+executable line moves, and `git diff -U0` carries zero non-comment added or removed lines.
+
+`server enforces, client is courtesy` was cited at those seven sites as a bare
+**`ADR-0057 D10`**. The substantive claim is correct and is unchanged here; what was missing
+is the **framework qualifier**. In this repository the bare string resolves to
+`docs/adr/0057-console-ai-chat-one-conversation-docked.md` — a document about console AI chat
+docking, which contains no `D10` at all and is the one a reader greps first. The intended
+anchor is the *framework's* ADR-0057, whose D10 decides *"Setup-nav surfacing follows the
+capability (ADR-0029 K2); the object stays open"*.
+
+Each site now carries the disambiguation already shipped by the two authorities in this
+repository — `docs/adr/0036-field-conditional-rules.md:91` and
+`packages/core/src/evaluator/fieldRules.ts:38` — rather than a third phrasing:
+`the framework's ADR-0057 D10 — framework numbering; this repo's own ADR-0057 is an
+unrelated document`.
+
+Three sites are deliberately left byte-untouched, all three already correct:
+`packages/data-objectstack/src/appAccessProbe.test.ts:25` (a verbatim quotation of the
+objectstack#8013 ruling, and about the capability/nav gate — the one family D10 really does
+decide), plus the two authorities above.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1056,7 +1056,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // a record the user may only read: the form opened, the user retyped a
   // field, and the server rejected the save with a 403. Ask the explain
   // engine for the row-level verdict (fail-open; the server stays the
-  // authority per ADR-0057 D10) and fold it into the same affordance gates.
+  // authority per the framework's ADR-0057 D10 — framework numbering; this
+  // repo's own ADR-0057 is an unrelated document) and fold it into the same
+  // affordance gates.
   const recordWriteAllowed = useRecordEditable(
     objectDef?.name,
     pureRecordId,

--- a/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
@@ -85,7 +85,11 @@ export interface PackageOwdOverviewPanelProps {
   publishNonce?: number;
   /** Notify the surface so its pending-changes counter refreshes after a save. */
   onDraftSaved?: () => void;
-  /** Courtesy gate: read-only packages render badges only (ADR-0057 D10). */
+  /**
+   * Courtesy gate: read-only packages render badges only (the framework's
+   * ADR-0057 D10 — framework numbering; this repo's own ADR-0057 is an
+   * unrelated document).
+   */
   readOnly?: boolean;
   locale: SupportedLocale;
   /** Object to scroll to / highlight (deep-link from the permission matrix badge). */

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -423,11 +423,12 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   const tab = params.tab ?? 'interfaces';
   const locale = useMetadataLocale();
 
-  // Courtesy gate (ADR-0057 D10): a read-only code/installed package refuses
-  // authoring server-side (ADR-0070), so don't let the user build up doomed
-  // local edits first — disable the authoring affordances up front. Unknown
-  // writability (fetch failed / still loading) stays ungated; the server gate
-  // remains the authority either way.
+  // Courtesy gate (the framework's ADR-0057 D10 — framework numbering; this
+  // repo's own ADR-0057 is an unrelated document): a read-only code/installed
+  // package refuses authoring server-side (ADR-0070), so don't let the user
+  // build up doomed local edits first — disable the authoring affordances up
+  // front. Unknown writability (fetch failed / still loading) stays ungated;
+  // the server gate remains the authority either way.
   const [pkgWritable, setPkgWritable] = React.useState<boolean | null>(null);
   React.useEffect(() => {
     let cancelled = false;

--- a/packages/plugin-detail/src/useRecordEditable.test.tsx
+++ b/packages/plugin-detail/src/useRecordEditable.test.tsx
@@ -16,7 +16,9 @@
  * the row-level verdict instead.
  *
  * Every uncertainty must fail OPEN — a courtesy hint may never be the reason a
- * permitted user cannot act. The server is the authority (ADR-0057 D10).
+ * permitted user cannot act. The server is the authority (the framework's
+ * ADR-0057 D10 — framework numbering; this repo's own ADR-0057 is an
+ * unrelated document).
  */
 import * as React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/packages/plugin-detail/src/useRecordEditable.ts
+++ b/packages/plugin-detail/src/useRecordEditable.ts
@@ -13,8 +13,9 @@
  * sharing rule sits inside an object the user may otherwise create and edit
  * freely — so the header offered a primary "Edit" CTA that opened the form, let
  * the user retype a field, and only then bounced with a 403. The server is the
- * authority (ADR-0057 D10) and stays so; this is the courtesy check that stops
- * the UI from inviting a write it knows will fail.
+ * authority (the framework's ADR-0057 D10 — framework numbering; this repo's
+ * own ADR-0057 is an unrelated document) and stays so; this is the courtesy
+ * check that stops the UI from inviting a write it knows will fail.
  *
  * The answer comes from the explain engine's record-grained verdict
  * (`POST /api/v1/security/explain` with a `recordId`, ADR-0090 D6 / ADR-0095

--- a/packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts
+++ b/packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts
@@ -41,9 +41,10 @@
  * SPA origin where the cookie doesn't reach the API: the row's verdict is
  * `undefined` and the caller keeps the OBJECT-level answer, i.e. exactly what
  * this list rendered before this hook existed. The server is the authority
- * (ADR-0057 D10) and stays so; hiding a capability on missing data would be a
- * worse defect than the wasted click this fixes, and it is the same posture
- * `useRecordEditable` takes for the detail header.
+ * (the framework's ADR-0057 D10 — framework numbering; this repo's own
+ * ADR-0057 is an unrelated document) and stays so; hiding a capability on
+ * missing data would be a worse defect than the wasted click this fixes, and
+ * it is the same posture `useRecordEditable` takes for the detail header.
  *
  * The probe rides the host's AUTHENTICATED fetch (`SchemaRendererProvider`'s
  * `apiFetch`) rather than the bare global one: a bearer-token session carries

--- a/packages/react/src/hooks/useCapabilityGate.ts
+++ b/packages/react/src/hooks/useCapabilityGate.ts
@@ -24,8 +24,10 @@
  *
  * **Fail-OPEN when unknown.** No runner, no user, no `systemPermissions` array:
  * the action shows. Unknown is not denied, the server is the authority
- * (ADR-0057 D10), and hiding a permitted user's button on missing client data
- * is the worse failure. An EMPTY array is not unknown — it means "holds
+ * (the framework's ADR-0057 D10 — framework numbering; this repo's own
+ * ADR-0057 is an unrelated document), and hiding a permitted user's button on
+ * missing client data is the worse failure. An EMPTY array is not unknown —
+ * it means "holds
  * nothing" and gates normally.
  */
 


### PR DESCRIPTION
Fixes #5202

Comment text only. `git diff -U0` carries **zero non-comment added or removed lines** — verified mechanically, not asserted.

## ⚠️ Read this first: `ADR-0057 D10` is NOT the final anchor

This PR fixes the **qualifier**, not the number. Do not read the landed comments as settling where the rule is decided:

- **The framework's `ADR-0124` D1 decides the rule generally** — *"The server is the enforcement point; client-side gating is a usability courtesy"* (`docs/adr/0124-server-enforces-client-is-courtesy.md:61`, Status: Accepted 2026-08-18 on the maintainer ruling on objectstack#9628, on framework `main` since 9dd192d).
- **Framework ADR-0057 says so itself**, at `0057-erp-authorization-core-business-units-and-scope-depth.md:518`:

  > ⚠️ **The general rule lives in [ADR-0124](./0124-server-enforces-client-is-courtesy.md), not here.** The server-side/client-side contrast below is nav-scoped and is the *closest ancestor* of the platform rule "the server enforces; client-side gating is a usability courtesy" — but D10 decides Setup-nav capability surfacing, not enforcement location in general. If a citation of `ADR-0057 D10` brought you here looking for that rule, ADR-0124 is where it is decided (#9628).

- **Retargeting these sites to ADR-0124 D1 is the pre-registered follow-up** that #5202's triage comment assigns to whichever seat accepts this PR. It is deliberately *not* done here.

What this PR changes is the reader's destination, and that change is monotonic with the retarget rather than in tension with it:

| | where a reader lands |
|---|---|
| before | objectui's own `docs/adr/0057-console-ai-chat-one-conversation-docked.md` — console AI chat docking, **no `D10` in it at all**. A dead end with no signpost. |
| after | the framework's ADR-0057, whose PS-2 note at line 518 redirects to ADR-0124. Correct repo, working signpost. |
| after the retarget | the framework's ADR-0124 D1 directly. |

The qualifier landed here **survives the retarget** — even pointed at ADR-0124 a citation must still say *whose* numbering, because this repository owns a different ADR-0057 and would own a different 0124. Only the number changes.

## The defect this PR fixes

`server enforces, client is courtesy` was cited at seven live source sites as a bare `ADR-0057 D10`, with no repo qualifier. The substantive claim is correct and survives unchanged; the intended anchor was always the *framework's* ADR-0057, whose D10 decides *"Setup-nav surfacing follows the capability (ADR-0029 K2); the object stays open"* — nav-scoped, and the closest ancestor of the rule rather than the rule.

## Wording is derived, not invented

Two authorities in this repository already ship the disambiguation, and the seven sites now match them rather than introducing a third phrasing:

- `docs/adr/0036-field-conditional-rules.md:91` — the model wording
- `packages/core/src/evaluator/fieldRules.ts:38` — the same, in source

Landed form: `the framework's ADR-0057 D10 — framework numbering; this repo's own ADR-0057 is an unrelated document`.

## Site count: I landed SEVEN, and I say so because the brief said eight

My dispatch brief said "8 of 9 assertive sites". Measured independently at `origin/main` before editing, **that count is wrong and the corrected count is seven** — the PM reached the same conclusion independently and sent a correction mid-task; the two measurements agree.

| Site | Disposition |
|---|---|
| `packages/app-shell/src/views/RecordDetailView.tsx:1059` | swept |
| `packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx:88` | swept |
| `packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx:426` | swept |
| `packages/plugin-detail/src/useRecordEditable.ts:16` | swept |
| `packages/plugin-detail/src/useRecordEditable.test.tsx:19` | swept |
| `packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts:44` | swept |
| `packages/react/src/hooks/useCapabilityGate.ts:27` | swept |
| `packages/data-objectstack/src/appAccessProbe.test.ts:25` | **untouched** — verbatim quotation of the objectstack#8013 ruling, and about the capability/service gate D10 really does decide (*"an app gated by an absent optional service"*) |
| `packages/core/src/evaluator/fieldRules.ts:38` | **untouched** — already carries the qualifier |
| `docs/adr/0036-field-conditional-rules.md:91` | **untouched, and deliberately so — `docs/adr/**` is a governed surface** (AGENTS.md §受管面). It carries the same not-final-anchor issue as the source sites and is being filed separately rather than ridden along in a code PR. |

The brief's line numbers had also drifted (`StudioDesignSurface` is at 426, not 389; `RecordDetailView` at 1059, not 1047). No `docs/adr/**`, `content/docs/**` or `apps/site/**` path is touched, so no governed surface and no `Build Docs` exposure.

## Verification

Scoped to a **provable superset**, not to app-shell's full suite. The diff is comment-only (mechanically proved), so only two things can be affected: the changed files' own parse/lint, and any test that reads those files' **source text**.

- **Comment-only proof** — every added/removed line matches a comment prefix; the diff contains no `@ts-*`, `@type`, `eslint-disable`, `@param` or `@returns` directive, so nothing type-significant moved.
- **ESLint**, the 7 changed files, repo config: `ESLINT_EXIT=0`, `files linted: 7  errors: 0  warnings: 137`. File count read from `--format json`; all 7 were linted rather than ignored. Type-aware linting is not configured in `eslint.config.js` (no `project` / `projectService`), so this diff cannot move any untouched file's verdict. `--max-warnings` is deliberately unset repo-wide, so the warnings (pre-existing `no-explicit-any` / `react-hooks`) are not a gate reading.
- **Source-reading tests** — enumerated repo-wide rather than guessed: every test file matching `readFileSync|readFile(` that also names any changed file. Four hits, all run, plus the changed test file itself: `Test Files 5 passed (5)`, `Tests 60 passed (60)`, `VITEST_EXIT=0`.
- **Gates**: `check-changeset-presence` → *"7 source file(s) of 4 released package(s) changed … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate."* · `check-control-bytes` → *"OK (scanned 4754 tracked text file(s); skipped 85 binary)"* · `check-changeset-no-major` → *"No changeset declares a `major` bump."* All three exit 0.

All of the above ran on the tree at **`8faa2fea0`**, which is this branch's head; `git status --porcelain` was empty at that commit, so the verified tree is exactly the pushed tree.

The changeset has an empty frontmatter on purpose: this publishes nothing. Note that its prose predates the section at the top of this body — where the changeset speaks of D10 as the anchor for *"server enforces, client is courtesy"*, this body is the correction: D10 is the **inherited citation being qualified**, and ADR-0124 D1 is where the rule is decided.

Staying in draft for the accepting seat to land.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_