### PR TITLE
docs(auth): write down the X-Tenant-ID edge contract and its unstamped-first-request gap

### DIFF
--- a/.changeset/tenant-header-edge-contract-5279.md
+++ b/.changeset/tenant-header-edge-contract-5279.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/auth': patch
+---
+
+Document the `X-Tenant-ID` edge contract that `createAuthenticatedFetch` stamps, and the
+unstamped-first-request window in which it is not sent (objectui#5279). Documentation
+only — no behaviour changes.
+
+The header had no written contract anywhere, and the shape of the missing information was
+actively misleading: its only non-CORS consumer lives in the **cloud** repository, so a
+search confined to this repo and the framework (`objectstack`) returns zero readers and
+reads as "nothing consumes this stamp". #5279 was filed on exactly that reading, and was
+held until a cloud-side reading came back non-empty. Without the contract written down,
+the next person to grep reaches the same false conclusion and deletes a live routing
+input.
+
+`packages/auth/README.md` gains "The `X-Tenant-ID` edge contract": what the header means
+(a routing hint carrying the better-auth `activeOrganizationId` — not an identity claim,
+not an authorization input, not what scopes rows), who stamps it and under exactly which
+condition, who reads it, and what a reader may and may not assume. The framework half is
+stated as a negative with its pin — `resolveAuthzContext` takes `tenantId` from the
+API-key principal or `session.activeOrganizationId` and from no header — alongside
+`plugin-sharing`'s record that trusting `x-tenant-id` as identity *was* a vulnerability.
+The configuration half is quoted from the contract this package can actually resolve,
+`TenantRoutingConfigSchema` in `@objectstack/spec/cloud`, where `X-Tenant-ID` is the
+default of a configurable `tenantHeaderName` and `header` ranks second of six
+identification sources behind `subdomain`.
+
+The unstamped-first-request gap gets its own section: `ActiveOrganizationStorage` is
+filled only after `AuthProvider`'s async `getSession` -> `listOrganizations` ->
+`getActiveOrganization` chain resolves, so early-boot requests carry no tenant header at
+all. What a reader observes is documented as **absent, never present-and-empty**, with the
+five situations that open the window and the instruction to fall through to the next
+identification source rather than fail closed. The gap is recorded, deliberately not
+closed: the cloud readers observe today's behaviour, so changing when the header first
+appears is its own decision.
+
+Three cases in `createAuthenticatedFetch.test.tsx` pin the statements the prose makes
+about the wire — no active organization means no header at all, the stamp is not gated on
+`/api/` the way `Authorization` is, and the active organization overwrites a caller-set
+`X-Tenant-ID` — so the documentation cannot drift away from the behaviour unnoticed.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -137,6 +137,154 @@ const authedFetch = createAuthenticatedFetch();
 const apiProviderFetch = createAuthenticatedFetch({ sameOriginOnly: true });
 ```
 
+## The `X-Tenant-ID` edge contract
+
+`createAuthenticatedFetch` stamps `X-Tenant-ID` on the requests it wraps. This section is
+that header's contract: what it means, who stamps it, who reads it, what a reader may
+assume, and the one window in which it is not sent at all.
+
+It is written down because **a grep cannot answer any of those questions from this
+repository.** The header's only non-CORS consumer lives in the **cloud** repository, so a
+search confined to this repo and the framework (`objectstack`) finds zero readers and
+reads as *"nothing consumes this stamp"*. That reading is what
+[objectui#5279](https://github.com/objectstack-ai/objectui/issues/5279) was filed on, and
+it is false. Do not act on it.
+
+### What it means
+
+A **routing hint** for the hosting edge — *this request belongs to tenant `<id>`*:
+
+```http
+X-Tenant-ID: <better-auth activeOrganizationId>
+```
+
+The value is the active **organization** id, the same id the session carries as
+`session.activeOrganizationId`. The header is **not** an identity claim, **not** an
+authorization input, and **not** what scopes rows.
+
+### Who stamps it
+
+| | |
+| --- | --- |
+| Stamped by | `createAuthenticatedFetch` ([`src/createAuthenticatedFetch.ts`](src/createAuthenticatedFetch.ts)) |
+| Value read from | `ActiveOrganizationStorage` — `localStorage`, key `auth-active-organization-id` |
+| Condition | that storage holds a non-empty value |
+| *Not* conditioned on | the URL being an `/api/` call. `Authorization` and `Accept-Language` are; this is not |
+| Suppressed by | `createAuthenticatedFetch({ sameOriginOnly: true })` for cross-origin URLs — it returns before any header work |
+| Precedence | overwrites an `X-Tenant-ID` the caller passed in `init.headers` |
+
+`ActiveOrganizationStorage` has exactly one writer, [`AuthProvider`](src/AuthProvider.tsx):
+
+| Event | Effect |
+| --- | --- |
+| `refreshOrganizations` — after `getSession` &rarr; `listOrganizations` &rarr; `getActiveOrganization` resolves (including the ADR-0081 single-membership repair) | set |
+| `switchOrganization` — the org switcher | set, or clear when the server returns no org |
+| `deleteOrganization` / `leaveOrganization`, when the active org is the one going away | clear |
+| sign-out | clear |
+
+### Who reads it
+
+**The cloud edge — yes.** The non-test readers are recorded on objectui#5279:
+`packages/service-tenant/src/tenant-context.ts` (header resolution) and
+`packages/tenant-router/src/spec/turso-multi-tenant.zod.ts`, both in the `cloud`
+repository. That repository is not readable from this one, so those paths are cited as the
+recorded reading rather than re-derived here.
+
+**Its configuration contract, though, IS readable from here**, because this package
+depends on `@objectstack/spec`. `TenantRoutingConfigSchema` (`@objectstack/spec/cloud`) is
+what configures a tenant resolver; parsing an empty config on the version this package
+resolves today (17.1.0) yields:
+
+```text
+enabled:               false
+identificationSources: ["subdomain", "header", "jwt_claim"]
+tenantHeaderName:      "X-Tenant-ID"
+jwtOrganizationClaim:  "organizationId"
+```
+
+Two consequences matter to a client author:
+
+- **The header name is configurable.** `X-Tenant-ID` is its default, not a constant.
+- **The header is one of six identification sources** (`subdomain`, `custom_domain`,
+  `header`, `jwt_claim`, `session`, `default`), and in the default precedence it ranks
+  **second, behind `subdomain`**. On a subdomain-routed deployment it is not the thing
+  that picks the tenant, and a deployment may leave it out of `identificationSources`
+  entirely.
+
+**The framework (`objectstack`) — no.** `resolveAuthzContext`
+(`packages/core/src/security/resolve-authz-context.ts`) derives `tenantId` from the
+API-key principal or from `session.activeOrganizationId`, and from no header;
+`packages/verify/src/harness.org-context.test.ts` pins it — *"`session.activeOrganizationId`
+is the ONE field `resolveAuthzContext` reads into `tenantId`"*. Environment and kernel
+routing read the hostname and `X-Environment-Id`. The framework's only other mentions are
+the CORS preflight allow-list (`DEFAULT_CORS_ALLOW_HEADERS`, whose comment describes
+`X-Tenant-ID` / `X-Environment-Id` as what routes "a request to its environment") and
+`plugin-sharing`, which records that trusting `x-tenant-id` as identity **was a
+vulnerability**: its secure default stopped reading identity from headers because doing so
+let a client forge attribution and enumerate or revoke other users' links.
+
+### What a reader may assume
+
+A reader **may**:
+
+- use it to select the tenant database or environment to route to, subject to its own
+  `identificationSources` precedence;
+- treat it as a hint that may be absent, stale, or contradicted by the session.
+
+A reader **may not**:
+
+- treat it as authenticated identity, or as an authorization decision. It is
+  client-controlled — any caller can send any value, and `plugin-sharing` is the recorded
+  precedent for what happens to a server that trusts it;
+- assume the row scoping it sees downstream came from this header. It did not: the
+  framework scopes from the session;
+- assume the header is present. See below.
+
+### The unstamped-first-request gap
+
+The stamp reads storage that `AuthProvider` fills only **after** `getSession` &rarr;
+`listOrganizations` &rarr; `getActiveOrganization` resolves. Every request that leaves
+before that chain completes carries **no** `X-Tenant-ID` at all.
+
+The window opens in five situations:
+
+1. a browser that has never signed in, or whose site data was cleared, including a private
+   window;
+2. the page load in which the user signs in — from the sign-in response until the
+   organization chain resolves;
+3. after sign-out, which clears the storage, until a new organization resolves;
+4. outside a browser (SSR, tests, a worker), where `localStorage` is unavailable and the
+   storage falls back to a per-process in-memory value that starts empty on every cold
+   start;
+5. a browser where `localStorage` exists but **rejects writes** (Safari private browsing,
+   quota exhaustion). There the window never closes — the in-memory fallback is written
+   but never read back, because `get()` only falls back when reading itself *throws*, and
+   a rejected write leaves reads working and returning `null`. Reported on objectui#5279
+   as a separate defect; it is not fixed here.
+
+Case 1 is not theoretical in this codebase: `app-shell`'s `MetadataProvider` issues its
+eager `app` metadata fetch inside exactly this window, which is why its first-boot cache
+scope needed its own reasoning
+([`packages/app-shell/src/providers/MetadataProvider.tsx`](../app-shell/src/providers/MetadataProvider.tsx),
+pinned by `MetadataProvider.firstBootOrgScope.test.tsx`).
+
+**What a reader observes in the window:** the header is **absent**, never
+present-and-empty. A resolver must fall through to its next configured identification
+source — `subdomain` already outranks it by default, with `jwt_claim`, `session` and
+`defaultTenantId` behind it — rather than fail closed on the absence. It must also not
+cache a routing decision taken inside the window as *the* tenant for the session: the very
+next request will normally carry the header.
+
+**Why the gap does not corrupt data scoping.** A response computed inside the window is
+still computed for the right tenant, because the framework takes `tenantId` from the
+session rather than from the header. The gap is a *routing-input* gap, not a scoping gap.
+This is the same reasoning objectui#5243 relied on when it relabelled a metadata cache
+entry that had been written in the window.
+
+**Closing the gap is a separate decision, not an omission.** The cloud readers observe the
+current behaviour, so changing when the header first appears changes what they see. If it
+should be closed, it needs its own card.
+
 ## Server Feature Flags (`GET /auth/config`)
 
 `createAuthClient().getConfig()` fetches the server's public auth configuration. The

--- a/packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx
+++ b/packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx
@@ -111,4 +111,51 @@ describe('createAuthenticatedFetch', () => {
     await createAuthenticatedFetch()('https://third-party.example.com/api/x');
     expect(calls[0].headers.get('Authorization')).toBe('Bearer tok123');
   });
+
+  // ── X-Tenant-ID: the edge contract, pinned (#5279) ────────────────────
+  //
+  // The header IS consumed — by the cloud edge, in a repository this one
+  // cannot see. These cases pin the three statements the README's "The
+  // `X-Tenant-ID` edge contract" section makes about what leaves the browser,
+  // so the prose cannot drift away from the wire without a red test.
+
+  it('sends NO tenant header at all when no organization is active (the unstamped-first-request gap)', async () => {
+    // The gap itself, on the wire. `AuthProvider` fills
+    // `ActiveOrganizationStorage` only after its async organization chain
+    // resolves, so every request before that looks like this one. The
+    // distinction a cloud-side resolver depends on is ABSENT vs
+    // present-and-empty: an empty-string header would make the resolver see a
+    // tenant id of "" instead of falling through to its next identification
+    // source.
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(API_URL);
+    expect(calls[0].headers.get('X-Tenant-ID')).toBeNull();
+    expect(calls[0].headers.has('X-Tenant-ID')).toBe(false);
+  });
+
+  it('stamps the tenant header on non-API URLs too — recorded, not endorsed (#5279)', async () => {
+    // Unlike `Authorization` and `Accept-Language`, the tenant stamp is not
+    // gated on `isApiCall`. This case exists so that asymmetry is VISIBLE:
+    // it records what ships today, it does not bless it, and the question of
+    // whether the stamp should be gated is reported on #5279 for triage. If
+    // that is answered by gating the stamp, this expectation changes with the
+    // fix — deliberately, rather than silently.
+    ActiveOrganizationStorage.set('org-42');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()('http://localhost/static/logo.png');
+    expect(calls[0].headers.get('X-Tenant-ID')).toBe('org-42');
+    // The contrast that makes the asymmetry the point of this case:
+    expect(calls[0].headers.get('Authorization')).toBeNull();
+  });
+
+  it('the active organization wins over an X-Tenant-ID the caller supplied', async () => {
+    // `headers.set` overwrites. Stated in the README as the header's
+    // precedence rule, because a caller reading its own value back off the
+    // request would otherwise be surprised.
+    ActiveOrganizationStorage.set('org-42');
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(API_URL, { headers: { 'X-Tenant-ID': 'org-caller' } });
+    expect(calls[0].headers.get('X-Tenant-ID')).toBe('org-42');
+  });
 });

--- a/packages/auth/src/createAuthenticatedFetch.ts
+++ b/packages/auth/src/createAuthenticatedFetch.ts
@@ -22,8 +22,21 @@ export interface AuthenticatedAdapterOptions {
 const ACTIVE_ORG_STORAGE_KEY = 'auth-active-organization-id';
 
 /**
- * Get/set the active organization ID for tenant-scoped API requests.
- * Used by createAuthenticatedFetch to inject X-Tenant-ID header.
+ * Get/set the active organization id that {@link createAuthenticatedFetch}
+ * stamps as `X-Tenant-ID`.
+ *
+ * `AuthProvider` is the only writer, at four moments: `refreshOrganizations`
+ * sets it once the `getSession` -> `listOrganizations` ->
+ * `getActiveOrganization` chain resolves (including the ADR-0081
+ * single-membership repair), `switchOrganization` sets or clears it,
+ * `deleteOrganization` / `leaveOrganization` clear it when the active org is
+ * the one going away, and sign-out clears it.
+ *
+ * Because the first of those is asynchronous, this reads EMPTY for the first
+ * stretch of a boot, and every request that leaves in that window carries no
+ * tenant header at all. That window is a documented part of the header's
+ * contract, not an accident to paper over — see the "unstamped-first-request
+ * gap" section of this package's README (objectui#5279).
  */
 export const ActiveOrganizationStorage = {
   _memoryValue: null as string | null,
@@ -82,7 +95,9 @@ function isCrossOrigin(url: string): boolean {
 /**
  * Creates an authenticated fetch wrapper that injects the Bearer token
  * from localStorage into every request to the ObjectStack API.
- * Also injects X-Tenant-ID header when an active organization is set.
+ * Also injects X-Tenant-ID header when an active organization is set — see the
+ * "The `X-Tenant-ID` edge contract" section of this package's README for what
+ * that header means, who reads it, and the window in which it is not sent.
  *
  * @example
  * ```ts
@@ -111,7 +126,43 @@ export function createAuthenticatedFetch(
     if (token && isApiCall) {
       headers.set('Authorization', `Bearer ${token}`);
     }
-    // Inject tenant header for multi-tenant routing
+    // ── `X-Tenant-ID` — the edge routing contract (objectui#5279) ────────
+    //
+    // WHAT IT MEANS. A routing hint for the hosting edge: "this request belongs
+    // to tenant <id>". The value is the better-auth `activeOrganizationId` the
+    // session already carries. It is NOT an identity claim, NOT an
+    // authorization input, and NOT what scopes rows.
+    //
+    // DO NOT DELETE THIS ON THE STRENGTH OF A GREP. The framework
+    // (`objectstack`) does not read it: `resolveAuthzContext` takes `tenantId`
+    // from the API-key principal or `session.activeOrganizationId` and never
+    // from a header, and environment routing reads the hostname and
+    // `X-Environment-Id`. So a search confined to this repo plus the framework
+    // finds zero consumers and reads as "dead stamp" — which is the false
+    // premise objectui#5279 was filed on. The consumer is in the CLOUD repo,
+    // which neither checkout contains: `service-tenant`'s `tenant-context.ts`
+    // resolves the header, and `tenant-router`'s `turso-multi-tenant.zod.ts`
+    // configures that resolution. The configuration contract IS readable from
+    // here — `TenantRoutingConfigSchema` in `@objectstack/spec/cloud` defaults
+    // `tenantHeaderName` to `X-Tenant-ID` and ranks `header` SECOND of six
+    // identification sources, behind `subdomain`.
+    //
+    // THE UNSTAMPED-FIRST-REQUEST GAP. `ActiveOrganizationStorage` is filled
+    // only after AuthProvider's async organization chain resolves, so early
+    // requests go out with the header ABSENT — never present-and-empty. A
+    // reader must fall through to its next identification source rather than
+    // fail closed. Nothing about row visibility rides on this: the framework
+    // scopes from the session, so a response computed inside the window is
+    // still computed for the right tenant.
+    //
+    // Not gated on `isApiCall`, unlike `Authorization` and `Accept-Language`
+    // above — recorded as the behaviour that ships, not endorsed; the
+    // asymmetry is reported on objectui#5279 for triage to route. A wrapper
+    // built with `sameOriginOnly` short-circuits every cross-origin request
+    // before this line.
+    //
+    // Full contract, including what a reader may and may not assume: this
+    // package's README, "The `X-Tenant-ID` edge contract".
     const activeOrgId = ActiveOrganizationStorage.get();
     if (activeOrgId) {
       headers.set('X-Tenant-ID', activeOrgId);


### PR DESCRIPTION
Fixes #5279

Documentation only. The header `createAuthenticatedFetch` stamps had no written contract, and the shape of the missing information was actively misleading.

## Why this card existed at all

`X-Tenant-ID`'s only non-CORS consumer lives in the **cloud** repository. A search confined to this repo and the framework (`objectstack`) finds zero readers and reads as *"nothing consumes this stamp"*. #5279 was filed on exactly that reading, held on it, and was only discharged when a cloud-side reading came back non-empty (`packages/service-tenant/src/tenant-context.ts`, `packages/tenant-router/src/spec/turso-multi-tenant.zod.ts`).

That makes the missing documentation an active hazard rather than a gap: the next person to grep reaches the same false conclusion and deletes a live routing input. So the decisive facts go where a grep-then-delete reader looks first — the stamping site itself — and the full contract goes in the package README, which ships to npm.

## What is documented

`packages/auth/README.md` gains **"The `X-Tenant-ID` edge contract"**:

| Question | Answer written down |
| --- | --- |
| What it means | A routing hint carrying the better-auth `activeOrganizationId`. **Not** an identity claim, **not** an authorization input, **not** what scopes rows |
| Who stamps it | `createAuthenticatedFetch`, from `ActiveOrganizationStorage`, whenever that holds a value — not gated on the URL being an `/api/` call, suppressed by `sameOriginOnly` for cross-origin URLs, overwrites a caller-supplied value |
| Who writes the storage | `AuthProvider` only, at four moments (organization load, org switch, delete/leave, sign-out) |
| Who reads the header | The cloud edge — cited from #5279, since that repo is not readable from here. Its configuration contract *is* readable here and is quoted from it |
| Who does **not** read it | The framework. `resolveAuthzContext` takes `tenantId` from the API-key principal or `session.activeOrganizationId` and from no header, pinned by `packages/verify/src/harness.org-context.test.ts` |
| What a reader may assume | May route on it; may not treat it as identity, may not assume the row scoping came from it, may not assume it is present |

The configuration half is not paraphrased from the cloud repo — it is measured from the contract this package actually resolves. `TenantRoutingConfigSchema` from `@objectstack/spec/cloud` (17.1.0, the version `@object-ui/auth` resolves), parsed on an empty config:

```
enabled:               false
identificationSources: ["subdomain", "header", "jwt_claim"]
tenantHeaderName:      "X-Tenant-ID"
jwtOrganizationClaim:  "organizationId"
```

Two things a client author needs from that: the header **name is configurable** (`X-Tenant-ID` is a default, not a constant), and the header is **one of six** identification sources ranked **second, behind `subdomain`** — on a subdomain-routed deployment it is not what picks the tenant.

The negative half is stated with its own evidence, because "the framework ignores it" is the half that reads as "nobody uses it": the CORS allow-list comment (`X-Tenant-ID` / `X-Environment-Id` route "a request to its environment") and `plugin-sharing`'s record that trusting `x-tenant-id` as identity **was** a vulnerability.

## The unstamped-first-request gap

Its own section. `ActiveOrganizationStorage` is filled only after `AuthProvider`'s async `getSession` -> `listOrganizations` -> `getActiveOrganization` chain resolves, so early-boot requests carry no tenant header at all. Documented:

- **What a reader observes: absent, never present-and-empty.** That distinction is the whole operational content — an empty-string header would make a resolver see a tenant id of `""` instead of falling through to its next identification source.
- The **five** situations that open the window, including the one that never closes (a browser whose `localStorage` rejects writes — filed separately as #5703).
- That the window is already load-bearing here: `MetadataProvider`'s eager `app` fetch lands inside it, which is what #5243 had to reason about.
- **Why it does not corrupt data scoping**: the framework scopes from the session, so a response computed inside the window is still computed for the right tenant. It is a routing-input gap.
- That **closing it is a separate decision**, deliberately not taken here: the cloud readers observe today's behaviour, so changing when the header first appears changes what they see.

## Three pins, so the prose cannot drift

`packages/auth/src/__tests__/createAuthenticatedFetch.test.tsx` gains one case per wire-level statement the README makes: no active organization means **no header at all** (`.has()` false, not empty-string); the stamp is **not** gated on `/api/` the way `Authorization` is; the active organization **overwrites** a caller-supplied `X-Tenant-ID`.

The middle one is labelled in the test body as recorded, **not endorsed** — it makes today's asymmetry visible so that gating the stamp becomes a deliberate, red-test change rather than a silent one, and the question is filed for triage rather than answered here.

## Scope

Deliberately **not** in this PR, per the card:

- Removing or deprecating the header. Off the table on this evidence — it has readers.
- Closing the first-request gap. Different card; it would change what the cloud readers see.
- `content/docs/**` and `apps/site/**`. Untouched — the contract lives with the code.
- `skills/objectui/guides/auth-permissions.md`, whose multi-tenancy paragraph implies the header is what enforces row isolation. Outside the fence; filed as #5704.

## Verification

Run at `f3e0d6313`, the head of this branch.

Scope is narrowed to `@object-ui/auth`, and the narrowing is **proven rather than asserted**: every `.ts` edit is comment-only, so the change can have no runtime effect. Demonstrated by compiling both revisions of `createAuthenticatedFetch.ts` with `removeComments` and diffing — byte-identical, 2750 bytes each — and by the package's other 20 emitted `dist/*.js` files being hash-identical across the rebuild. The instrument was self-checked: re-spelling one header literal in a scratchpad copy makes the same comparison go red, so a green reading is a measurement, not a no-op.

| Gate | Result |
| --- | --- |
| `pnpm --filter @object-ui/auth build` | pass |
| `pnpm --filter @object-ui/auth type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | pass |
| `pnpm --filter @object-ui/auth lint` | pass — `29 problems (0 errors, 29 warnings)`, every warning pre-existing in `AuthProvider.tsx` |
| `pnpm exec vitest run packages/auth/` | `Test Files 18 passed (18)` / `Tests 190 passed (190)`. The three new cases were confirmed to actually execute by a `--reporter=verbose` run of the edited file (`Tests 13 passed (13)`, each new title printed), not inferred from the file-level count |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 4754 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `node scripts/check-doc-snippet-types.mjs` | **narrowed, declared** — see below |

`check-doc-snippet-types` is the gate this diff most obviously reaches: its declared scan surface is every page under `content/docs` **plus every `packages/<name>/README.md`**. It refuses to run against an unbuilt tree (`The snippet program was NOT run: the packages it resolves against are not built`) and wants 14 packages built first, so it was **not** run in full here — CI runs it on a built tree.

What replaces it is a measurement rather than a hope, because the narrowing is provable. The gate compiles only the fence languages in its own exported `TS_FENCE_LANGUAGES` — `ts`, `tsx`, `typescript` — so the population was read from the gate itself and applied to both revisions of the file:

| Revision | fenced blocks | in the compiled population |
| --- | --- | --- |
| before | 11 | 10 |
| after | 13 | 10, byte-lengths identical and in the same order |

The two blocks this PR adds are `http` and `text` — the header example and the parsed-config dump are not compilable programs, and marking them as fragments would have been a worse answer than writing them as TypeScript. The set of blocks the gate compiles is therefore unchanged by this diff, so its verdict on this file is unchanged. The extractor was self-checked: planting one `ts` block in a scratchpad copy takes the population from 10 to 11, so the zero-delta reading is a measurement and not a broken probe.

The rest of the farm is CI's run, as always.

---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_