### PR TITLE
fix(i18n): `console.ai.pendingDrafts` lands in the eight remaining locale packs (#5705)

### DIFF
--- a/.changeset/pending-drafts-bar-locale-parity-5705.md
+++ b/.changeset/pending-drafts-bar-locale-parity-5705.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/i18n': patch
+---
+
+`console.ai.pendingDrafts` — the standing unpublished-changes bar's five strings —
+now exists in all ten locale packs. It previously existed only in `en` and `zh`, so
+`ar`, `ru`, `pt`, `es`, `fr`, `de`, `ko` and `ja` rendered the English defaults and
+`all-locales-key-parity` failed on `main` (objectui#5705).
+
+The feature landed `en`-only in objectui#5696; the follow-up in objectui#5697 was
+titled for the locale packs but reached only `zh`, so eight packs × five keys stayed
+missing and the parity assertion — which carries no allowlist — was red on `main` and
+on every PR whose diff touched source. Source-free diffs skip the shard that runs it,
+which is why the breakage survived several merges.
+
+Each pack keeps its own conventions rather than `en`'s: the eight all quote with `"`,
+`ru` puts the number last (`…: {{count}}`) as it already does for the sibling
+`home.pendingDrafts` counts, and `ja` uses the full-width `：` before `{{detail}}`
+because that value is a runtime message rather than a single token — both choices
+carry an in-pack note. Terminology is taken from each pack's existing publish-bar
+vocabulary (`home.pendingDrafts`, `console.ai.seedWarn`) so the two banners read
+alike.
+
+Both interpolations survive verbatim in every pack — `{{count}}` in `count` and
+`{{detail}}` in `publishedWithFindings` — asserted mechanically against the evaluated
+packs, not by eye. The unrelated `home.pendingDrafts` block (`message` / `cta`) is a
+different node and is untouched.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1420,6 +1420,13 @@ const ar = {
       passwordsDownload: "تنزيل ملف CSV",
     },
     ai: {
+      pendingDrafts: {
+        count: "هناك {{count}} من التغييرات لم تُنشر بعد — لا يمكن للمستخدمين رؤيتها.",
+        publish: "نشر",
+        published: "جميع التغييرات المعلّقة فعّالة الآن.",
+        failed: "فشل النشر.",
+        publishedWithFindings: "تم النشر، لكن مجسّات وقت التشغيل أبلغت عن مشكلات: {{detail}}",
+      },
       usage: {
         title: "استخدام الذكاء الاصطناعي",
         meterBuild: "الإنشاء",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1413,6 +1413,13 @@ const de = {
       passwordsDownload: "CSV herunterladen",
     },
     ai: {
+      pendingDrafts: {
+        count: "{{count}} Änderung(en) sind noch nicht veröffentlicht — Benutzer können sie nicht sehen.",
+        publish: "Veröffentlichen",
+        published: "Alle ausstehenden Änderungen sind live.",
+        failed: "Veröffentlichen fehlgeschlagen.",
+        publishedWithFindings: "Veröffentlicht, aber die Laufzeitprüfungen haben Probleme gemeldet: {{detail}}",
+      },
       usage: {
         title: "KI-Nutzung",
         meterBuild: "Erstellen",

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1417,6 +1417,13 @@ const es = {
       passwordsDownload: "Descargar CSV",
     },
     ai: {
+      pendingDrafts: {
+        count: "{{count}} cambio(s) aún no se han publicado — los usuarios no pueden verlos.",
+        publish: "Publicar",
+        published: "Todos los cambios pendientes están activos.",
+        failed: "Error al publicar.",
+        publishedWithFindings: "Publicado, pero las comprobaciones en tiempo de ejecución detectaron problemas: {{detail}}",
+      },
       usage: {
         title: "Uso de IA",
         meterBuild: "Crear",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1415,6 +1415,13 @@ const fr = {
       passwordsDownload: "Télécharger le CSV",
     },
     ai: {
+      pendingDrafts: {
+        count: "{{count}} modification(s) ne sont pas encore publiée(s) — les utilisateurs ne peuvent pas les voir.",
+        publish: "Publier",
+        published: "Toutes les modifications en attente sont actives.",
+        failed: "Échec de la publication.",
+        publishedWithFindings: "Publié, mais les contrôles d'exécution ont signalé des problèmes : {{detail}}",
+      },
       usage: {
         title: "Utilisation de l'IA",
         meterBuild: "Créer",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1413,6 +1413,15 @@ const ja = {
       passwordsDownload: "CSV をダウンロード",
     },
     ai: {
+      pendingDrafts: {
+        // {{detail}} はランタイムが返すメッセージ列なので、中間コロンは全角
+        // (exportFailed などと同じ。単一トークンの値なら半角)。
+        count: "未公開の変更が {{count}} 件あります — ユーザーには表示されません。",
+        publish: "公開",
+        published: "保留中の変更はすべて反映されています。",
+        failed: "公開に失敗しました。",
+        publishedWithFindings: "公開しましたが、ランタイムプローブが問題を報告しました：{{detail}}",
+      },
       usage: {
         title: "AI 使用状況",
         meterBuild: "ビルド",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1413,6 +1413,13 @@ const ko = {
       passwordsDownload: "CSV 다운로드",
     },
     ai: {
+      pendingDrafts: {
+        count: "게시되지 않은 변경이 {{count}}건 있습니다 — 사용자에게는 보이지 않습니다.",
+        publish: "게시",
+        published: "대기 중인 변경 사항이 모두 반영되었습니다.",
+        failed: "게시에 실패했습니다.",
+        publishedWithFindings: "게시했지만 런타임 프로브에서 문제가 보고되었습니다: {{detail}}",
+      },
       usage: {
         title: "AI 사용량",
         meterBuild: "빌드",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1412,6 +1412,13 @@ const pt = {
       passwordsDownload: "Baixar CSV",
     },
     ai: {
+      pendingDrafts: {
+        count: "{{count}} alteração(ões) ainda não publicada(s) — os usuários não conseguem vê-las.",
+        publish: "Publicar",
+        published: "Todas as alterações pendentes estão ativas.",
+        failed: "Falha ao publicar.",
+        publishedWithFindings: "Publicado, mas as verificações de tempo de execução relataram problemas: {{detail}}",
+      },
       usage: {
         title: "Uso de IA",
         meterBuild: "Criar",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1423,6 +1423,15 @@ const ru = {
       passwordsDownload: "Скачать CSV",
     },
     ai: {
+      pendingDrafts: {
+        // Число вынесено в конец («…: {{count}}») — так этот пак пишет
+        // количества, как в home.pendingDrafts.publishedVerified.
+        count: "Ещё не опубликовано изменений: {{count}} — пользователи их не видят.",
+        publish: "Опубликовать",
+        published: "Все ожидающие изменения вступили в силу.",
+        failed: "Не удалось опубликовать.",
+        publishedWithFindings: "Опубликовано, но проверки среды выполнения выявили проблемы: {{detail}}",
+      },
       usage: {
         title: "Использование ИИ",
         meterBuild: "Сборка",


### PR DESCRIPTION
Fixes #5705

`main` is red on `packages/i18n/src/__tests__/all-locales-key-parity.test.ts`: the
standing unpublished-changes bar's `console.ai.pendingDrafts` block existed only in
`en` and `zh`. The other eight packs — `ar`, `ru`, `pt`, `es`, `fr`, `de`, `ko`, `ja`
— had no such block at all. Eight packs x five keys.

#5696 landed the feature `en`-only; #5697, titled for the locale packs, reached `zh`
only. Source-free diffs skip the shard that runs this test, which is why it survived
several merges.

## What changed

The five keys — `count`, `publish`, `published`, `failed`, `publishedWithFindings` —
added to the eight packs, translated, at `en`'s position: first key inside
`console.ai`, immediately before `usage`. Insertion was anchored on the parsed
`    ai: {` line, never on a grep for `pendingDrafts` — there are **two** unrelated
blocks by that name and an occurrence count answers wrongly in both directions.

Nothing else: 60 insertions, 0 deletions, 8 locale files plus the changeset. No
reordering, no other parity gaps touched.

Each pack keeps its own conventions rather than `en`'s:

- All eight quote with `"` (`en` uses `'`).
- `ru` puts the number last (`...: {{count}}`), the convention that pack already
  documents for the sibling `home.pendingDrafts` counts.
- `ja` uses the full-width `：` before `{{detail}}`, because that pack's documented
  rule is full-width when the interpolation carries a message and half-width when it
  carries a single token — `{{detail}}` is a joined list of runtime probe messages.
- Both deviations carry a short in-pack note, in the pack's own language, matching
  how these files already annotate translation choices.

Terminology is lifted from each pack's existing publish-bar vocabulary
(`home.pendingDrafts`, `console.ai.seedWarn`, `console.ai.publishFailed`) so the two
banners read alike.

## Verification

All results below are at the final commit, `739dd78b6`.

**Red leg, captured before the fix** (`origin/main` @ `83ec61881`):

```
Test Files  1 failed (1)
     Tests  8 failed | 24 passed (32)
AssertionError: ja is missing 5 key(s)
+ [ "console.ai.pendingDrafts.count", "console.ai.pendingDrafts.failed",
+   "console.ai.pendingDrafts.publish", "console.ai.pendingDrafts.published",
+   "console.ai.pendingDrafts.publishedWithFindings" ]
```

...identically for `ko`, `de`, `fr`, `es`, `pt`, `ru`, `ar`. Exactly the five keys,
nothing else.

**Green leg** — same file, `--reporter=verbose`, so the assertions are named rather
than aggregated:

```
Test Files  1 passed (1)
     Tests  32 passed (32)
```

That includes all nine `%s defines every en key` cases, all nine of the sibling
`%s defines no key that en lacks` (the other direction — a mis-nested key would fail
here), `placeholders match en in every pack`, and both non-vacuity guards.

**Placeholders, checked mechanically** against the *evaluated* packs rather than the
file text — for all ten packs, `console.ai.pendingDrafts` has exactly `en`'s five
keys, `{{count}}` is present in `count`, `{{detail}}` in `publishedWithFindings`, the
per-key placeholder shape equals `en`'s, and the unrelated `home.pendingDrafts` block
still has its `message` / `cta` and gained nothing:

```
locales: en zh ja ko de fr es pt ru ar (10)
  ok ar keys=5 count[{{count}}]=yes findings[{{detail}}]=yes home.pendingDrafts=intact
  ... (all ten)
VERIFY OK — 0 failures
```

**Scoped suite** — the edited package plus the one provable consumer of these keys
(`packages/app-shell/src/console/ai/PendingDraftsBar.tsx`, found by grepping every
call site of `console.ai.pendingDrafts`; it is the only one):

```
pnpm exec vitest run --maxWorkers=2 packages/i18n/ \
  packages/app-shell/src/console/ai/__tests__/PendingDraftsBar.test.tsx
Test Files  52 passed (52)
     Tests  883 passed (883)
```

This is a provable superset for an i18n-data change, not app-shell's full 493-file
suite.

**Gates:**

| Gate | Result |
|---|---|
| `check-i18n-en-drift.mjs` | exit 0 — no `en` value changed |
| `check-i18n-call-site-keys.mjs` | exit 0 |
| `check-i18n-dead-keys.mjs` | exit 0 (a report, not a gate) |
| `check-control-bytes.mjs` | `OK (scanned 4756 tracked text file(s); skipped 85 binary)` |
| `pnpm --filter @object-ui/i18n type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/i18n lint` | `34 problems (0 errors, 34 warnings)` — all pre-existing, none in a locale file |

Lint narrowing, stated as a measurement: `eslint --no-inline-config --format json` on
the diff reports **8 files, 0 errors, 0 warnings**. The full repo population eslint
itself resolves is **3544 files**; that run also reports **0 findings in any
`packages/i18n/src/locales/` file**. The config sets no `projectService` /
`project:`, so linting is not type-aware and this diff cannot move the verdict of any
untouched file.

## Not in scope

`main` is separately red on `Build Docs` (#5668) and `Test (coverage)` (#5402). Those
are not addressed here and remain open.

The card also raises whether the parity test should run in a cheap, unskippable job
rather than only inside a shard that a source-free diff skips — that is a real gap
(it is why this survived several merges) but it is a CI-topology decision, left for
the maintainer rather than ridden along on a blocker fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_012u2pRjcqAYtoEjgr3wwhnK)_