### PR TITLE
fix(components): record_picker `label` / `placeholder` resolve the inline locale map their contract admits (#5637)

### DIFF
--- a/.changeset/record-picker-label-placeholder-i18n-5637.md
+++ b/.changeset/record-picker-label-placeholder-i18n-5637.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/components': patch
+---
+
+`element:record_picker`'s `label` and `placeholder` now resolve the inline
+per-locale map their contract admits, and their published declarations say so
+(objectui#5637).
+
+These are the two remaining keys of the trio objectui#5590 fixed one of. All
+three members of `ElementRecordPickerPropsSchema` are the `I18nLabel` union
+(`string | Record< string, string >`) — measured on the installed
+`@objectstack/spec` 17.1.0 pin, where each resolves to
+`optional -> union -> string | record` and
+`safeParse({ object: 'account', <key>: { en, 'zh-CN' } })` succeeds. The
+renderer honoured only the string arm on both, and the two keys failed in two
+different ways:
+
+- `placeholder` was read raw and handed to `SelectValue`. React refuses a plain
+  object in that position rather than stringifying it, so the whole picker
+  subtree threw
+  `Objects are not valid as a React child (found: object with keys {en, zh-CN})`
+  — the same harm objectui#5590 removed from `emptyText`.
+- `label` went through the file's local `toText`, whose object branch ends
+  `String(o.label ?? o.name ?? o.title ?? o.en ?? '')`. Reaching `o.en`
+  unconditionally is an English pick wearing locale resolution's clothes, so a
+  `zh-CN` viewer was shown the English entry — and a map that simply omits `en`
+  resolved to `''`, which the `{label && …}` render site drops, making the
+  picker's label element DISAPPEAR with nothing thrown and nothing logged.
+
+Both keys now resolve at their own read site through `pickLocalized`, the same
+helper the settled `emptyText` shape uses. `toText` is deliberately unchanged:
+it is shared with the row values (`toText(row?.[labelField])`), which are record
+field values rather than `I18nLabel`, so teaching it locale resolution would
+have changed a second, unrelated call site. The `placeholder` default is applied
+before resolution, so an absent key still means "Select a record…" and an
+authored empty string still renders empty.
+
+The two `ComponentMeta` entries, which held a single `'string'` arm precisely
+because the renderer dropped the other one, now declare `['string', 'object']`
+— declared in the change that makes the arm render, never before, which is the
+order `ComponentInput.type` prescribes and the order `emptyText` set.
+
+KNOWN GAP, unchanged by this release: the sibling `label` read sites in
+`renderers/layout/containers.tsx` compose
+`translateLabel(pickLocalized(…), language)`, and that second helper is not
+applied here — `translateLabel` and its `KNOWN_LABEL_DICT` are module-private to
+that file. Only the locale-map resolution lands in this change; a plain-English
+string `label` is still rendered verbatim in every language, exactly as before.

--- a/packages/components/src/renderers/basic/__tests__/record-picker-label-placeholder-i18n.test.tsx
+++ b/packages/components/src/renderers/basic/__tests__/record-picker-label-placeholder-i18n.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `element:record_picker`'s `label` and `placeholder` resolve the inline locale
+ * map their contract admits (objectui#5637) — the two keys objectui#5590 left
+ * behind when it fixed the third key of this same block.
+ *
+ * Measured on the installed pin (`@objectstack/spec` 17.1.0), all three members
+ * of `ElementRecordPickerPropsSchema` resolve to
+ * `optional -> union -> string | record`, and
+ * `safeParse({ object: 'account', <key>: { en, 'zh-CN' } })` succeeds for each.
+ *
+ * ## Red-first — the three measured failure modes, and they are NOT one mode
+ *
+ * Run against the unfixed renderer, viewer language `zh-CN`:
+ *
+ * ```
+ * placeholder={ en, 'zh-CN' }        -> THREW  Objects are not valid as a React child
+ *                                              (found: object with keys {en, zh-CN})
+ * label={ en: 'Owner', 'zh-CN': … }  -> RENDERED "Owner"            (English to a zh-CN viewer)
+ * label={ 'zh-CN': …, ja: … }        -> label element ABSENT        (nothing thrown, nothing logged)
+ * ```
+ *
+ * The second and third come from this file's local `toText()`, whose object
+ * branch ends `String(o.label ?? o.name ?? o.title ?? o.en ?? '')`. Reaching
+ * `o.en` unconditionally is an ENGLISH PICK wearing locale resolution's
+ * clothes, and its `?? ''` miss meets a `{label && …}` render site — so a map
+ * that simply omits English deletes the label element. A fix that only stops
+ * the throw is half a fix, which is why all three are pinned here.
+ *
+ * ## `toText` is deliberately NOT the fix site
+ *
+ * `toText` is SHARED: it also renders ROW VALUES (`toText(row?.[labelField])`).
+ * Those are record field values, not `I18nLabel`, so a locale-aware `toText`
+ * would change a second, unrelated call site. Both keys resolve at their own
+ * read site instead, and the last case below is the control that proves the row
+ * path still runs through the untouched helper.
+ *
+ * No adapter is provided: with none, the fetch effect parks and `rows` stays
+ * empty — the same disposition `record-picker-empty-text-i18n.test.tsx` and
+ * `page-variables.test.tsx` already rely on for this block. The one case that
+ * needs rows drives its own stub adapter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers `element:record_picker` at module scope, not in a hook
+// (object-ui/no-dynamic-import-in-test-hook, objectui#3010).
+import '../../../renderers';
+
+/** The inline locale map an author writes; `zh-CN` exists so a switch is observable. */
+const INLINE_MAP = { en: 'Owner', 'zh-CN': '负责人' } as const;
+
+/** The same shape with NO `en` entry — legal under the contract, and the case that vanished. */
+const NO_EN_MAP = { 'zh-CN': '负责人', ja: '担当' } as const;
+
+function renderPicker(properties: Record<string, unknown>, language = 'en') {
+  const C = ComponentRegistry.get('element:record_picker') as React.ComponentType<any>;
+  if (!C) throw new Error('element:record_picker is not registered');
+  return render(
+    <I18nProvider
+      persistLanguage={false}
+      config={{ defaultLanguage: language, detectBrowserLanguage: false }}
+    >
+      {/* eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns the registered component (stable), not one created during render */}
+      <C schema={{ type: 'element:record_picker', id: 'picker', properties }} />
+    </I18nProvider>,
+  );
+}
+
+/** The rendered `<label>` element, or `null` when the render site dropped it. */
+const labelEl = (container: HTMLElement) => container.querySelector('label');
+/** The trigger's rendered text — where `SelectValue`'s placeholder lands. */
+const triggerText = (container: HTMLElement) =>
+  container.querySelector('[data-testid="record-picker-trigger"]')?.textContent ?? '';
+
+describe('element:record_picker — label/placeholder accept the inline locale map (objectui#5637)', () => {
+  it('renders the picker, its label and its placeholder at all (reachability before absence)', () => {
+    // Without this, every "the text is X" / "the element is gone" assertion
+    // below would be satisfied just as well by a picker that rendered neither.
+    const { container } = renderPicker({
+      object: 'account',
+      label: 'Owner',
+      placeholder: 'Select a record…',
+    });
+    expect(screen.getByTestId('record-picker')).toBeInTheDocument();
+    expect(labelEl(container)?.textContent).toBe('Owner');
+    expect(triggerText(container)).toContain('Select a record…');
+  });
+
+  // ── 1. placeholder: the arm that THREW ────────────────────────────────────
+  it('resolves a `placeholder` map to the active language — the case that THREW', () => {
+    const { container } = renderPicker({ object: 'account', placeholder: INLINE_MAP }, 'zh-CN');
+    expect(triggerText(container)).toContain('负责人');
+  });
+
+  it('resolves the SAME `placeholder` map differently for a different language', () => {
+    // Paired with the case above: an `.en` pick would satisfy this one alone.
+    const { container } = renderPicker({ object: 'account', placeholder: INLINE_MAP }, 'en');
+    expect(triggerText(container)).toContain('Owner');
+  });
+
+  it('falls back from a region tag to the base language the author wrote (`placeholder`)', () => {
+    // Author wrote `zh`; viewer is `zh-CN`. Pins a limb past "exact match", so a
+    // resolver that only ever hit the exact key could not satisfy this file.
+    const { container } = renderPicker(
+      { object: 'account', placeholder: { en: 'Owner', zh: '负责人' } },
+      'zh-CN',
+    );
+    expect(triggerText(container)).toContain('负责人');
+  });
+
+  // ── 2. label: rendered ENGLISH to a zh-CN viewer ──────────────────────────
+  it('resolves a `label` map to the active language, not to its `en` entry', () => {
+    // THE ASSERTION THAT SEPARATES THE TWO CANDIDATE FIXES. `toText` already
+    // reaches `o.en`, so the English half of this map renders green either way;
+    // only the zh-CN viewer distinguishes real locale resolution from an
+    // English pick.
+    const { container } = renderPicker({ object: 'account', label: INLINE_MAP }, 'zh-CN');
+    expect(labelEl(container)?.textContent).toBe('负责人');
+  });
+
+  it('resolves the SAME `label` map differently for a different language', () => {
+    const { container } = renderPicker({ object: 'account', label: INLINE_MAP }, 'en');
+    expect(labelEl(container)?.textContent).toBe('Owner');
+  });
+
+  // ── 3. label: the element that DISAPPEARED ────────────────────────────────
+  it('keeps the label ELEMENT for a map that omits `en` — the silent case', () => {
+    // The quiet one. `toText` returned `''` for a map with no `en`, and the
+    // render site is `{label && …}`, so a correctly authored map that simply
+    // omits English deleted the label element with nothing thrown and nothing
+    // logged. Asserted as presence FIRST, then text: a fix that resolved the
+    // string but left the element gone must fail here.
+    const { container } = renderPicker({ object: 'account', label: NO_EN_MAP }, 'zh-CN');
+    expect(labelEl(container)).not.toBeNull();
+    expect(labelEl(container)?.textContent).toBe('负责人');
+  });
+
+  it('resolves a no-`en` map for a viewer whose language it does carry (`ja`)', () => {
+    // Same map, a different one of its entries: the vanishing was a property of
+    // the MAP (no `en`), not of `zh-CN`.
+    const { container } = renderPicker({ object: 'account', label: NO_EN_MAP }, 'ja');
+    expect(labelEl(container)?.textContent).toBe('担当');
+  });
+
+  // ── Controls ──────────────────────────────────────────────────────────────
+  it('passes a plain string `label` and `placeholder` through unchanged, in any language', () => {
+    // CONTROL, same keys and same read sites as the probes: capable of failing
+    // — a resolution that mangled the string arm turns this red.
+    const { container } = renderPicker(
+      { object: 'account', label: 'Owner', placeholder: 'Pick one' },
+      'zh-CN',
+    );
+    expect(labelEl(container)?.textContent).toBe('Owner');
+    expect(triggerText(container)).toContain('Pick one');
+  });
+
+  it('keeps the "Select a record…" placeholder default for an ABSENT key', () => {
+    // CONTROL for the ordering choice at the read site: the default is applied
+    // before resolution, so an absent key still means the default.
+    const { container } = renderPicker({ object: 'account' }, 'zh-CN');
+    expect(triggerText(container)).toContain('Select a record…');
+  });
+
+  it('renders NO label element when `label` is absent', () => {
+    // CONTROL for the other direction of the `{label && …}` site: absent must
+    // still mean absent, so the vanishing-map fix cannot be "always render a
+    // label".
+    const { container } = renderPicker({ object: 'account' }, 'zh-CN');
+    expect(labelEl(container)).toBeNull();
+  });
+});

--- a/packages/components/src/renderers/basic/record-picker.tsx
+++ b/packages/components/src/renderers/basic/record-picker.tsx
@@ -75,12 +75,15 @@ function ElementRecordPickerRenderer({ schema }: { schema: any }) {
     object?: string;
     labelField?: string;
     valueField?: string;
-    label?: unknown;
-    placeholder?: string;
-    // `string | I18nLabel` because that is what the contract says: rc.6 widened
-    // this key to the same inline-locale-map union it widened `label` and
-    // `placeholder` to, and the render site below now RESOLVES the map arm, so
-    // the declaration and the renderer finally agree (objectui#5590).
+    // All three are `string | I18nLabel` because that is what the contract says:
+    // rc.6 widened the whole trio to the same inline-locale-map union, and the
+    // read sites below now RESOLVE the map arm on each, so the declarations and
+    // the renderer finally agree (objectui#5590 for `emptyText`, objectui#5637
+    // for these two). `label` was `unknown` for as long as it went through
+    // `toText`, which accepts anything; it is the contract's union now that it
+    // resolves like one.
+    label?: string | I18nLabel;
+    placeholder?: string | I18nLabel;
     emptyText?: string | I18nLabel;
     filter?: unknown;
     sort?: any;
@@ -169,8 +172,44 @@ function ElementRecordPickerRenderer({ schema }: { schema: any }) {
     [binding],
   );
 
-  const label = toText(props.label);
-  const placeholder = props.placeholder ?? 'Select a record…';
+  // `label` and `placeholder` are `string | I18nLabel` and both land in a
+  // position React refuses to stringify, so both resolve HERE, at their own read
+  // site, through the same `pickLocalized` the settled `emptyText` shape below
+  // uses (objectui#5637). They failed in two different ways, and only pinning
+  // both explains why this is one change:
+  //
+  //   placeholder={ en, 'zh-CN' }  THREW `Objects are not valid as a React child`
+  //   label={ en, 'zh-CN' }        rendered "Owner" — ENGLISH, to a zh-CN viewer
+  //   label={ 'zh-CN', ja }        rendered NOTHING — the label element vanished
+  //
+  // The last two came from `toText`, whose object branch ends
+  // `String(o.label ?? o.name ?? o.title ?? o.en ?? '')`. Reaching `o.en`
+  // unconditionally is an ENGLISH PICK wearing locale resolution's clothes, and
+  // its `?? ''` miss meets the `{label && …}` render site below — so a map that
+  // simply omits English DELETED the label element, with nothing thrown and
+  // nothing logged.
+  //
+  // ⛔ `toText` is deliberately not the fix site and is UNCHANGED. It is SHARED
+  // with the row values (`toText(row?.[labelField])` below), which are record
+  // FIELD VALUES, not `I18nLabel` — teaching it locale resolution would change
+  // a second, unrelated call site whose contract is not this one.
+  //
+  // The placeholder default is applied BEFORE resolution, matching `emptyText`:
+  // an absent key still means "Select a record…", and an authored `''` still
+  // renders empty because `pickLocalized` passes either string through
+  // untouched. `label` takes no default — absent resolves to `''`, which the
+  // `{label && …}` site drops exactly as it always did.
+  //
+  // KNOWN GAP — the `translateLabel` half of this card's ruling is NOT applied
+  // here. The sibling `label` read sites compose
+  // `translateLabel(pickLocalized(…), language)`, but `translateLabel` and its
+  // `KNOWN_LABEL_DICT` are module-private to
+  // `renderers/layout/containers.tsx`, which this change's fence marks
+  // out-of-scope; reaching them needs either an export from that file or a hoist
+  // into a shared module, and `basic/ -> layout/` would be a new dependency
+  // between renderer families. Tracked separately (objectui#5637 report).
+  const label = pickLocalized(props.label, language);
+  const placeholder = pickLocalized(props.placeholder ?? 'Select a record…', language);
   // `emptyText` is `string | I18nLabel`, and its destination is a TEXT NODE, so
   // it resolves through `pickLocalized` — the objectui-side helper the sibling
   // text-node sites read through (`element:text.content`,
@@ -289,8 +328,37 @@ ComponentRegistry.register('record_picker', ElementRecordPickerRenderer, {
     },
     { name: 'labelField', type: 'string', label: 'Label Field' },
     { name: 'valueField', type: 'string', label: 'Value Field' },
-    { name: 'placeholder', type: 'string', label: 'Placeholder' },
-    { name: 'label', type: 'string', label: 'Label' },
+    {
+      name: 'placeholder',
+      // TWO arms, declared in the change that makes the second one render — the
+      // order `emptyText` below established and `packages/types`'
+      // `ComponentInput.type` doc prescribes. The contract has been
+      // `string | Record< string, string >` since rc.6 widened this key to the
+      // same `I18nLabel` union it widened the rest of the trio to; this entry
+      // held one arm only because the renderer handed the map straight to
+      // `SelectValue`, where React REFUSED it rather than stringifying it. The
+      // read site resolves it now (`pickLocalized`, above), so withholding the
+      // object arm would be the opposite defect — `type-mismatch` reported on a
+      // legal write this input's own description teaches (objectui#5637).
+      type: ['string', 'object'],
+      label: 'Placeholder',
+      description:
+        'Prompt shown in the closed control while no record is selected (renderer default "Select a record…"). Display-only — it never reaches the query. Accepts either a plain string or an inline per-locale map (`{ en: "Owner", "zh-CN": "负责人" }`), the `I18nLabel` union rc.6 widened this key to; the renderer resolves the map against the active language at the read site, falling back through base language, a region-qualified sibling, `default`, then `en`. It is REPLACED while the picker is busy: "Loading…" during the fetch and "Failed to load" after an error both win over this key. An authored empty string stays empty; the default applies only when the key is absent.',
+    },
+    {
+      name: 'label',
+      // TWO arms, same reason and same ordering rule as `placeholder` above.
+      // This key's pre-fix failure was the quieter one: it went through the
+      // file's local `toText`, whose `o.en` fallback rendered ENGLISH to every
+      // viewer and whose `?? ''` miss made a map without an `en` entry delete
+      // the label element outright. Declaring the object arm while that was true
+      // would have advertised a shape that reached the screen wrong or not at
+      // all; the read site resolves it now (objectui#5637).
+      type: ['string', 'object'],
+      label: 'Label',
+      description:
+        'Caption rendered above the picker, in a `<label>` element. Display-only — it never reaches the query, and it is OMITTED entirely when the key is absent or resolves to an empty string. Accepts either a plain string or an inline per-locale map (`{ en: "Owner", "zh-CN": "负责人" }`), the `I18nLabel` union rc.6 widened this key to; the renderer resolves the map against the active language at the read site, with the same fallback chain as `placeholder`. Distinct from `labelField`, which names the RECORD field each offered row is titled by.',
+    },
     // ── sort / limit / emptyText — declared on the rc.6 bump (objectui#4167) ──
     // `@objectstack/spec` 17.0.0-rc.6 lands objectstack#5775's other half: these
     // three arrive as newly DECLARED keys on `ElementRecordPickerProps`, and the


### PR DESCRIPTION
Part of #5637

⚠️ **Deliberately `Part of`, not the closing keyword the dispatch asked for.** The
card's measured defect — all three fixtures — is fixed here, but one clause of
triage's binding ruling is **not** implemented and could not be, inside this
change's fence. Merging this should therefore not close the card. Flip the first
line if PM rules the remaining clause is a separate card. Details in
[the gap](#the-one-ruling-clause-this-change-does-not-carry) below.

---

## What was broken

`packages/components/src/renderers/basic/record-picker.tsx` has three props whose
contract is the `I18nLabel` union. #5590 fixed one (`emptyText`). The other two
were still unresolved, and they failed in **two different ways** — which is why a
fix that only stops the throw would be half a fix.

Measured on the installed pin, `@objectstack/spec` **17.1.0** (the card and #5590
both say 17.0.0 GA; the pin has moved and the union is unchanged):

```
top-level keys: object, labelField, valueField, label, filter, sort, limit,
                targetVariable, placeholder, emptyText, displayField,
                searchFields, multiple, aria
label        optional -> union -> [string | record]
placeholder  optional -> union -> [string | record]
emptyText    optional -> union -> [string | record]
safeParse map on label       => OK
safeParse map on placeholder => OK
safeParse label:42           => REJECTED
```

Red-first, run against the unfixed tree with the test file added in this PR,
viewer language `zh-CN` (verbatim):

```
× resolves a `placeholder` map to the active language — the case that THREW
    Error: Objects are not valid as a React child (found: object with keys {en, zh-CN}).
× falls back from a region tag to the base language the author wrote (`placeholder`)
    Error: Objects are not valid as a React child (found: object with keys {en, zh}).
× resolves a `label` map to the active language, not to its `en` entry
    AssertionError: expected 'Owner' to be '负责人'   // English, to a zh-CN viewer
× keeps the label ELEMENT for a map that omits `en` — the silent case
    AssertionError: expected null not to be null      // the label element vanished

 Test Files  1 failed (1)
      Tests  6 failed | 5 passed (11)
```

- **`placeholder` THREW.** It was read raw and handed to `SelectValue`. React
  refuses a plain object in a child position rather than stringifying it, so the
  whole picker subtree failed — identical harm to the one #5590 removed from
  `emptyText`.
- **`label` rendered English.** It went through this file's local `toText`, whose
  object branch ends `String(o.label ?? o.name ?? o.title ?? o.en ?? '')`.
  Reaching `o.en` unconditionally is an English pick wearing locale resolution's
  clothes.
- **`label` DISAPPEARED.** With no `en` entry `toText` returns `''`, and the
  render site is `{label && …}` — so a correctly authored map that simply omits
  English deleted the label element, with nothing thrown and nothing logged. This
  is the one no static check can see: lint and type-check are green over all
  three modes both before and after.

The five passing cases in that red run are the controls and the reachability
case; they are what make the six reds mean something.

## What changed

Both keys resolve at their **own read site** through `pickLocalized` — the same
helper, and the same shape, #5590 settled for `emptyText` one key over:

```ts
const label = pickLocalized(props.label, language);
const placeholder = pickLocalized(props.placeholder ?? 'Select a record…', language);
```

The placeholder default is applied **before** resolution, matching `emptyText`:
an absent key still means "Select a record…", and an authored `''` still renders
empty. `label` takes no default, so absent still resolves to `''` and the
`{label && …}` site drops it exactly as before.

⛔ **`toText` is unchanged.** It is shared with the row values
(`toText(row?.[labelField])`), which are record **field values**, not
`I18nLabel` — teaching it locale resolution would change a second, unrelated call
site. That is the card's own analysis, adopted by triage as the fence, and
verified rather than assumed: the sharing is real, and the diff on this file
touches no line of that function's body.

The two `ComponentMeta` entries, which held a single `'string'` arm precisely
because the renderer dropped the other one, now declare `['string', 'object']` —
**in this same change and not before**, which is the order `ComponentInput.type`
prescribes in `@object-ui/types` and the order `emptyText` set. Both descriptions
were rewritten from what the renderer now does, including the two things an
author cannot read off the spec: that "Loading…" / "Failed to load" replace
`placeholder` while the picker is busy, and that `label` is omitted entirely when
it resolves empty.

## The one ruling clause this change does not carry

Triage ruled that `label` takes the sibling pairing — `pickLocalized` **+
`translateLabel`**, matching `containers.tsx:569` / `:831`. Only the
`pickLocalized` half is here.

`translateLabel` and its `KNOWN_LABEL_DICT` are **module-private** to
`packages/components/src/renderers/layout/containers.tsx`, which this change's
fence marks hard out-of-scope. Reaching them needs one of:

1. export the symbol from `containers.tsx` and import it here — an edit to a
   fenced file, plus a new `basic/ → layout/` static import between renderer
   families, in a repo that weighs the eager import closure with a byte budget
   (`scripts/check-eager-closure-budget.mjs`); or
2. hoist `translateLabel` + the dictionary into a shared module — a larger change
   across more out-of-fence files.

Neither is mechanical, so this PR stops at the fence rather than crossing it. A
plain-English string `label` is rendered verbatim in every language here, exactly
as before this change — no regression, just the pairing not yet applied.

Worth weighing when that call is made: `translateLabel` is a hardcoded
English→Chinese dictionary of well-known **tab** tokens (`Details`, `Related`,
`Notes`, …), and its two live call sites translate labels that `buildDefaultTabs`
**generated**. A record picker's `label` is author-supplied, so the pairing would
mean the platform silently rewrites an author's literal string. That is an
observation for the decision, not a re-litigation of the ruling.

## Verification

Every command below was run at `907ec3e64`, the tree of this PR's only commit.

| Gate | Verdict line |
| --- | --- |
| new render test + neighbours (`record-picker-empty-text-i18n`, `page-variables`, `inline-locale-label-read-sites`) | `Test Files  4 passed (4)` · `Tests  38 passed (38)` |
| `vitest run packages/components` | `Test Files  182 passed (182)` · `Tests  1638 passed (1638)` |
| `pnpm --filter @object-ui/components type-check` | `tsc --noEmit && tsc -p tsconfig.test.json`, exit 0 |
| `eslint .` in `packages/components` | `✖ 909 problems (0 errors, 909 warnings)` over 396 files |
| console declaration-parity tests (4 files, run not edited) | `Test Files  4 passed (4)` · `Tests  100 passed (100)` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 4767 tracked text file(s); skipped 85 binary).` |
| `pnpm check:i18n-keys` | `Every in-scope call-site key resolves against the en pack (2924 keys) …` |
| `pnpm check:i18n-drift` | `No en value changed in this range.` |
| `pnpm check:i18n-dead-keys` | report-only, exit 0 |
| `pnpm check:doc-types` | `✅ Every documented component type is registered.` |
| `pnpm check:spec-symbols` | `✅ spec symbol derivation: 1294 files scanned …` |
| `pnpm changeset:check` | `✅ No changeset declares a 'major' bump.` |

**The declaration widening needed no out-of-fence edit** — unlike #5590, which had
to flip an `apps/console` specimen. Those four console parity files were *run* and
are green as-is: none of them pins `record_picker.label` / `.placeholder` to a
single arm.

**Declared narrowing.** `pnpm lint` is `turbo run lint` over 42 packages with a
lint script; this run covered `@object-ui/components` only. The narrowing is a
measurement, not a skip: the population comes from that package's own `eslint .`
(396 files, its entire file set, not a diff-derived subset); `eslint.config.js`
declares no `project` / `projectService`, so no type information crosses package
boundaries; and no rule in `eslint-rules/` reads a file other than the one it is
linting. A change confined to `packages/components` therefore cannot move a
verdict in another package's lint run. CI runs the full farm regardless.

## Test mechanism

`packages/components/src/renderers/basic/__tests__/record-picker-label-placeholder-i18n.test.tsx`
asserts on **rendered output**, because nothing static can see this defect. The
registered renderer is invoked directly through `ComponentRegistry.get` (the
component the registry really renders) inside an `I18nProvider` pinned to a
language, and the three modes are read off the DOM:

- the throw — the case simply renders, and the trigger's text contains the
  resolved string;
- the language a viewer sees — `container.querySelector('label')?.textContent`,
  asserted for `zh-CN` **and** `en` on the same map, since an `.en` pick passes
  the English half alone;
- presence/absence of the element — `expect(labelEl(container)).not.toBeNull()`
  before its text, so a fix that resolved the string but left the element gone
  still fails, paired with a control asserting the element stays **absent** when
  `label` is absent.

The file lives under `renderers/basic/__tests__/` (a new directory, matching the
existing `renderers/action|complex|form/__tests__/`) because that is the test
surface this change's fence names; #5590 put its sibling file in
`packages/components/src/__tests__/`. Both are collected by the `dom` project's
`packages/**/*.test.tsx` glob.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_