### PR TITLE
fix(data-objectstack): map dataset-query failures by the server's error code, not its status (#5663)

### DIFF
--- a/.changeset/analytics-error-branch-mapping-5663.md
+++ b/.changeset/analytics-error-branch-mapping-5663.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+`ObjectStackAdapter.queryDataset` now maps a failed dataset query by the server's
+ADR-0112 error `code`, not by the HTTP status, so an unknown dataset and an
+unauthenticated session stop being reported as a missing analytics capability
+(objectui#5663).
+
+Two unrelated conditions answer **404** on `POST /api/v1/analytics/dataset/query`:
+the runtime dispatcher's `ROUTE_NOT_FOUND` when the route was never mounted, and
+the route's own `NOT_FOUND` when `body.datasetName` matches no saved dataset. The
+mapping tested `res.status === 501 || res.status === 404` and called all of it
+"the analytics capability is not installed", so every unknown dataset produced a
+banner telling the operator to install `@objectstack/service-analytics` and mount
+`AnalyticsServicePlugin`. Measured live on a prod tenant, that banner was shown on
+four HotCRM Executive Overview widgets while the analytics service was installed
+and answering — the real condition was an installed `app.objectstack.hotcrm` at
+1.3.0 whose datasets ship in 2.2.2, i.e. a package upgrade, the opposite corner of
+the system from the remedy the banner named.
+
+Three conditions now get three answers, each keyed on the code the framework
+declares for it:
+
+- `NOT_IMPLEMENTED` (501, route mounted with no analytics service) and
+  `ROUTE_NOT_FOUND` (404, route not mounted) keep the existing
+  `AnalyticsNotInstalledError` and its copy — one remedy, one message.
+- `NOT_FOUND` (404, unknown `datasetName`) throws the new
+  `AnalyticsDatasetNotFoundError` (`ANALYTICS_DATASET_NOT_FOUND`), naming the
+  dataset and pointing at the installed app's version rather than at the server.
+- `UNAUTHENTICATED` (401, `enforceAuth`) throws the new
+  `AnalyticsUnauthenticatedError` (`ANALYTICS_UNAUTHENTICATED`), which says the
+  request was refused before it ran and therefore says nothing about the
+  capability.
+
+The banner also used to print the server's own message in a parenthetical while
+contradicting it in the headline — it quoted `Dataset "opportunity_metrics" not
+found.` under a headline claiming a missing capability. That is now structurally
+impossible rather than merely fixed: the headline is a pure function of `code` and
+the parenthetical is a verbatim quote of `message`, both read off the same
+response, and a test walks every branch asserting each message carries its own
+headline and none of the others'.
+
+Additive only. `AnalyticsNotInstalledError` keeps its `code`, its copy and its
+constructor signature (it gains an optional third `serverCode` argument and a
+`serverCode` field), so consumers matching `ANALYTICS_NOT_INSTALLED` — including
+the metadata-admin dataset preview — are unaffected. A 404 carrying a code this
+client does not recognise, such as the analytics cube gate's `CUBE_NOT_FOUND`, now
+keeps its server detail instead of being relabelled as a missing capability; a 404
+or 501 carrying no code at all is still read as the capability being absent, since
+the route's own `NOT_FOUND` always ships a code.

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -572,7 +572,18 @@ export class AnalyticsNotInstalledError extends Error {
   readonly code = 'ANALYTICS_NOT_INSTALLED';
   /** The surface that was unavailable, for the message a host renders. */
   readonly surface: string;
-  constructor(surface: string, detail?: string) {
+  /**
+   * The server's own ADR-0112 code — the field this branch was chosen BY, when
+   * a producer named one (`NOT_IMPLEMENTED` from the mounted route with no
+   * service behind it, `ROUTE_NOT_FOUND` from the dispatcher when the route is
+   * not mounted at all). Absent for the no-code residual, where a bare
+   * transport 404/501 is all there was to read.
+   *
+   * Additive (objectui#5663): carried so a reader can audit that the headline
+   * and the quoted `detail` below came off the same answer.
+   */
+  readonly serverCode?: string;
+  constructor(surface: string, detail?: string, serverCode?: string) {
     super(
       `Analytics capability is not installed on this deployment — ${surface} is unavailable. ` +
       'Install @objectstack/service-analytics and mount AnalyticsServicePlugin to enable it.' +
@@ -580,6 +591,7 @@ export class AnalyticsNotInstalledError extends Error {
     );
     this.name = 'AnalyticsNotInstalledError';
     this.surface = surface;
+    this.serverCode = serverCode;
   }
 }
 
@@ -588,6 +600,171 @@ export function isAnalyticsNotInstalledError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   return (error as { code?: unknown }).code === 'ANALYTICS_NOT_INSTALLED';
 }
+
+/**
+ * Thrown when the dataset route ANSWERED and said the dataset this query named
+ * does not exist in this environment — `404` + ADR-0112 `NOT_FOUND`, the
+ * `body.datasetName` lookup miss in `@objectstack/rest`'s
+ * `registerAnalyticsEndpoints` (`Dataset "<name>" not found.`).
+ *
+ * A SIBLING of {@link AnalyticsNotInstalledError}, never a shade of it
+ * (objectui#5663). Both conditions answer **404** — routes-not-mounted through
+ * the runtime dispatcher's `ROUTE_NOT_FOUND`, an unknown dataset through this
+ * route's own `NOT_FOUND` — so a `res.status === 404` test cannot separate
+ * them, and the mapping that could not tell them apart reported EVERY unknown
+ * dataset as a missing server capability.
+ *
+ * Measured live on a prod tenant: four HotCRM Executive Overview widgets told
+ * the operator to install `@objectstack/service-analytics` and mount
+ * `AnalyticsServicePlugin`, while the analytics service was installed and
+ * answering the whole time. The real condition was an installed
+ * `app.objectstack.hotcrm` pinned at 1.3.0 whose datasets ship in 2.2.2. The
+ * remedy the banner named — install a server plugin — is the opposite corner of
+ * the system from the remedy that works: upgrade the installed app. A wrong
+ * diagnosis is not a smaller version of no diagnosis; it spends the operator's
+ * time in the wrong subsystem.
+ *
+ * The `code` is the ONLY field that separates the two, which is why this branch
+ * reads it and nothing else. See {@link readAnalyticsErrorEnvelope}.
+ */
+export class AnalyticsDatasetNotFoundError extends Error {
+  readonly code = 'ANALYTICS_DATASET_NOT_FOUND';
+  /**
+   * The dataset this query asked for, taken from the REQUEST rather than parsed
+   * back out of the server's prose: the request is what we know for certain,
+   * and re-reading the name out of a message would make the headline depend on
+   * that message's WORDING — the coupling framework#5367 spent a whole issue
+   * removing from the producing route.
+   */
+  readonly datasetName?: string;
+  /** The server's own ADR-0112 code — the field this branch was chosen BY. */
+  readonly serverCode?: string;
+  /** The server's own message, quoted verbatim in the parenthetical. */
+  readonly serverMessage?: string;
+  constructor(opts: { datasetName?: string; serverCode?: string; serverMessage?: string }) {
+    const subject = opts.datasetName ? `Dataset "${opts.datasetName}"` : 'The requested dataset';
+    super(
+      `${subject} is not defined in this environment — the app that defines it is missing or out of date. ` +
+      'Analytics itself is installed and answering, so the fix is to upgrade the installed app, not to install a server plugin.' +
+      (opts.serverMessage ? ` (server said: ${opts.serverMessage})` : ''),
+    );
+    this.name = 'AnalyticsDatasetNotFoundError';
+    this.datasetName = opts.datasetName;
+    this.serverCode = opts.serverCode;
+    this.serverMessage = opts.serverMessage;
+  }
+}
+
+/**
+ * Thrown when the dataset query was refused before it ran because the session
+ * is not authenticated — `401` + ADR-0112 `UNAUTHENTICATED`, the REST seam's
+ * `ANONYMOUS_DENY_BODY` (`@objectstack/core`'s `security/anonymous-deny.ts`,
+ * written verbatim by `enforceAuth`).
+ *
+ * The THIRD branch, and the one the reported card under-states (objectui#5663):
+ * it recorded a live `POST /api/v1/analytics/dataset/query -> 401
+ * UNAUTHENTICATED` and read it as evidence for the dataset-unknown branch. It
+ * is neither of the other two. An expired session reported as "the deployment
+ * is missing a capability" is the SAME defect wearing a different mask — an
+ * operator sent to install a server plugin because their token lapsed — so the
+ * separation is the point, not a nicety.
+ *
+ * Deliberately not left to the generic `Dataset query failed: 401 …` either:
+ * that string names a transport status where a person needs an action, and
+ * "sign in again" is an action.
+ */
+export class AnalyticsUnauthenticatedError extends Error {
+  readonly code = 'ANALYTICS_UNAUTHENTICATED';
+  /** The server's own ADR-0112 code — the field this branch was chosen BY. */
+  readonly serverCode?: string;
+  /** The server's own message, quoted verbatim in the parenthetical. */
+  readonly serverMessage?: string;
+  constructor(opts: { serverCode?: string; serverMessage?: string } = {}) {
+    super(
+      'Analytics query refused: this session is not authenticated. Sign in again and retry — ' +
+      'the request was refused before it ran, so it says nothing about whether the analytics ' +
+      'capability is installed.' +
+      (opts.serverMessage ? ` (server said: ${opts.serverMessage})` : ''),
+    );
+    this.name = 'AnalyticsUnauthenticatedError';
+    this.serverCode = opts.serverCode;
+    this.serverMessage = opts.serverMessage;
+  }
+}
+
+/**
+ * The ADR-0112 `code` + `message` an analytics REST error body declares.
+ *
+ * ONE url, TWO declared producers — which is why this reads two SHAPES, and why
+ * it is not the tolerant `body.error?.code ?? body.error` chain that
+ * `@objectstack/core`'s `anonymous-deny.ts` explicitly warns consumers off:
+ *
+ *  - **flat** `{ code, message }` — everything the route writes itself in
+ *    `@objectstack/rest`'s `registerAnalyticsEndpoints` (`501 NOT_IMPLEMENTED`
+ *    when no analytics service provides `queryDataset`, `404 NOT_FOUND` for an
+ *    unknown `datasetName`, `400 VALIDATION_FAILED`, `500
+ *    ANALYTICS_QUERY_FAILED`), plus `enforceAuth`'s `401` `ANONYMOUS_DENY_BODY`
+ *    — `{ error: 'UNAUTHENTICATED', code: 'UNAUTHENTICATED', message: … }`,
+ *    where `error` carries the CODE as a string.
+ *  - **wrapped** `{ success: false, error: { code, message } }` — what answers
+ *    when this route is not mounted at all: `@objectstack/runtime`'s dispatcher
+ *    `404 ROUTE_NOT_FOUND`. The REST auth-gate `403` (`{ error: { code,
+ *    message } }`) is the same shape.
+ *
+ * Both envelopes are live and sanctioned (ADR-0112's 2026-07-30 amendment
+ * records the flat and wrapped families as the two live ones and assigns
+ * converging them to the envelope-convergence line). Reading both here is not a
+ * consumer inventing leniency: this ONE request genuinely has two possible
+ * producers, and which one answered is itself part of the signal — the wrapped
+ * `ROUTE_NOT_FOUND` means the route is absent, and only the route's own flat
+ * envelope can mean the dataset is.
+ *
+ * They are told apart STRUCTURALLY — `typeof body.error === 'object'` — never
+ * by trying one key and falling through to the other. A producer that regresses
+ * its envelope therefore reads as "no code" here, which is the honest answer
+ * and lands in the residual below, instead of being quietly absorbed.
+ *
+ * `message` is DISPLAY ONLY and never feeds classification. That split is what
+ * makes the objectui#5663 contradiction structurally impossible: the headline
+ * is a pure function of `code`, the parenthetical is a verbatim quote of
+ * `message`, and both are read off the SAME response. If they ever disagree the
+ * producer has a bug — whereas under the old mapping the CONSUMER did, because
+ * the headline came from a status two conditions share while the quote came
+ * from the one that had actually happened.
+ */
+function readAnalyticsErrorEnvelope(body: unknown): { code?: string; message?: string } {
+  if (!body || typeof body !== 'object') return {};
+  const flat = body as { code?: unknown; message?: unknown; error?: unknown };
+  const wrapped =
+    flat.error && typeof flat.error === 'object'
+      ? (flat.error as { code?: unknown; message?: unknown })
+      : undefined;
+  const source = wrapped ?? flat;
+  const code = typeof source.code === 'string' && source.code.length > 0 ? source.code : undefined;
+  // Display-only fallback: the flat family's `error` key carries the MESSAGE in
+  // some producers (`{ code: 'ANALYTICS_QUERY_FAILED', error: <text> }`) and the
+  // CODE in others (`ANONYMOUS_DENY_BODY`). Harmless here precisely because
+  // nothing downstream classifies on it — at worst the parenthetical quotes a
+  // code string, which is still the server's own words about its own answer.
+  const message =
+    typeof source.message === 'string' && source.message.length > 0 ? source.message
+    : typeof flat.error === 'string' && flat.error.length > 0 ? flat.error
+    : undefined;
+  return { code, message };
+}
+
+/**
+ * Statuses that identify a condition ON THEIR OWN when the answer carries no
+ * ADR-0112 `code` at all — a bare transport 404/501 from a proxy, a gateway, or
+ * a host that never mounted the API, none of which any ObjectStack route wrote.
+ *
+ * NOT a re-entry for status-mapping (objectui#5663 exists because of it): these
+ * are consulted only AFTER every code branch has declined, i.e. only when there
+ * is no contract field to read at all. `404` is safe HERE and unsafe as a
+ * primary test for exactly the same reason — the route's own `NOT_FOUND` always
+ * ships a `code`, so a 404 WITHOUT one cannot be the unknown-dataset case.
+ */
+const ANALYTICS_ABSENT_STATUSES: readonly number[] = [404, 501];
 
 /**
  * Thrown when the server REJECTED the analytics query body (HTTP 400 —
@@ -4282,21 +4459,99 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     });
 
     if (!res.ok) {
-      let detail = '';
-      try {
-        const errBody = await res.json();
-        detail = errBody?.message || errBody?.error || JSON.stringify(errBody);
-      } catch { /* non-JSON error body */ }
-      // "The capability isn't installed" is not a stack trace to show an
-      // author (framework#3891): the REST dataset route answers 501
-      // NOT_IMPLEMENTED when no analytics service provides `queryDataset`, and
-      // a host that doesn't mount the route at all answers 404. Both mean the
-      // same thing and both get a message a UI can render verbatim; anything
-      // else (a compile error like "relationship not declared in include") is
-      // a real authoring error and keeps its server detail.
-      if (res.status === 501 || res.status === 404) {
-        throw new AnalyticsNotInstalledError('POST /analytics/dataset/query', detail || undefined);
+      let errBody: unknown;
+      try { errBody = await res.json(); } catch { /* non-JSON error body */ }
+      const { code: serverCode, message: serverMessage } = readAnalyticsErrorEnvelope(errBody);
+      // The generic branch's tail, and ONLY the generic branch's: it falls back
+      // to the raw body so an unclassifiable failure still shows an operator
+      // something the server actually sent. Every classified branch below
+      // quotes `serverMessage` instead — a message the producer DECLARED — so a
+      // parenthetical is never a JSON dump dressed up as the server speaking.
+      const detail = serverMessage || (errBody === undefined ? '' : JSON.stringify(errBody));
+      const surface = 'POST /analytics/dataset/query';
+      // The dataset this query asked for, read off OUR request. `queryDataset`
+      // accepts either a saved dataset by name or an inline draft; only the
+      // by-name form can miss, but the inline form still carries `name`, so the
+      // subject of the sentence is known in both.
+      const requestedDatasetName =
+        typeof dataset === 'string' ? dataset
+        : typeof (dataset as { name?: unknown })?.name === 'string' ? String((dataset as { name?: unknown }).name)
+        : undefined;
+
+      /* ── objectui#5663 — branch on the server's ADR-0112 `code`, never on
+       * "the endpoint errored" ────────────────────────────────────────────────
+       *
+       * What stood here tested `res.status === 501 || res.status === 404` and
+       * called all of it "the analytics capability is not installed". TWO
+       * unrelated conditions answer 404 on this url, and the mapping could not
+       * see the difference:
+       *
+       *   route absent      404 `ROUTE_NOT_FOUND` (runtime dispatcher)
+       *   dataset unknown   404 `NOT_FOUND`       (this route's own lookup miss)
+       *
+       * So a HotCRM tenant whose installed app was too old to define
+       * `opportunity_metrics` was told to install a server plugin — while the
+       * server printed `Dataset "opportunity_metrics" not found.` inside the
+       * SAME banner, in the parenthetical the headline was contradicting. The
+       * evidence was in the payload the whole time; the mapping was reading a
+       * different field from the one it quoted.
+       *
+       * The status is not a contract here and never was: it is a transport fact
+       * several conditions share, which is the same reason `isApiAccessDenied`
+       * and `isAppPermissionDeniedError` above discriminate on `code` (see
+       * objectui#4408). The `code` is the contract, it is what ADR-0112 exists
+       * to make readable, and the framework declares a distinct one for every
+       * condition this call can land in. Branch on it.
+       */
+
+      // ① The capability really is absent, from either of its two producers:
+      //    the route is mounted with no analytics service behind it (501
+      //    `NOT_IMPLEMENTED`, `registerAnalyticsEndpoints`), or the route was
+      //    never mounted and the dispatcher answered (404 `ROUTE_NOT_FOUND`).
+      //    One remedy — install and mount the service — so one copy.
+      if (errorCodeIsAnyOf({ code: serverCode }, ['NOT_IMPLEMENTED', 'ROUTE_NOT_FOUND'])) {
+        throw new AnalyticsNotInstalledError(surface, serverMessage, serverCode);
       }
+
+      // ② The route answered; the DATASET is the thing that is missing (404
+      //    `NOT_FOUND`). A package problem in the environment, not a missing
+      //    server capability — the remedy is upgrading the installed app.
+      if (errorCodeIs({ code: serverCode }, 'NOT_FOUND')) {
+        throw new AnalyticsDatasetNotFoundError({
+          datasetName: requestedDatasetName,
+          serverCode,
+          serverMessage,
+        });
+      }
+
+      // ③ The request never ran: the session is anonymous or its token lapsed
+      //    (401 `UNAUTHENTICATED`, `enforceAuth`). Nothing about it is evidence
+      //    for or against the capability being installed.
+      if (errorCodeIs({ code: serverCode }, 'UNAUTHENTICATED')) {
+        throw new AnalyticsUnauthenticatedError({ serverCode, serverMessage });
+      }
+
+      // ④ Residual — the answer declared NO ADR-0112 code, so no ObjectStack
+      //    route wrote it (a proxy, a gateway, a host with no API mounted).
+      //    Only here is the bare status the best signal available, and only
+      //    because every code branch has already declined: this route's own
+      //    `NOT_FOUND` always ships a `code`, so a code-less 404 cannot be the
+      //    unknown-dataset case.
+      if (serverCode === undefined) {
+        if (ANALYTICS_ABSENT_STATUSES.includes(res.status)) {
+          throw new AnalyticsNotInstalledError(surface, detail || undefined);
+        }
+        if (res.status === 401) {
+          throw new AnalyticsUnauthenticatedError({ serverMessage });
+        }
+      }
+
+      // ⑤ Everything that named itself and is none of the above — a compile
+      //    error like "relationship not declared in include" (400
+      //    `DATASET_INVALID`), a `CUBE_NOT_FOUND`, a 5xx — is a real failure
+      //    with a real server detail, and keeps it. Note that a 404
+      //    `CUBE_NOT_FOUND` used to land in the capability-missing branch too,
+      //    by the same status collision; it now reads as what it is.
       throw new Error(`Dataset query failed: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ''}`);
     }
 

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -625,7 +625,8 @@ export function isAnalyticsNotInstalledError(error: unknown): boolean {
  * time in the wrong subsystem.
  *
  * The `code` is the ONLY field that separates the two, which is why this branch
- * reads it and nothing else. See {@link readAnalyticsErrorEnvelope}.
+ * reads it and nothing else. See `readAnalyticsErrorEnvelope` below — the
+ * module-private reader that pulls the code out of either declared envelope.
  */
 export class AnalyticsDatasetNotFoundError extends Error {
   readonly code = 'ANALYTICS_DATASET_NOT_FOUND';

--- a/packages/data-objectstack/src/queryDataset.test.ts
+++ b/packages/data-objectstack/src/queryDataset.test.ts
@@ -143,6 +143,226 @@ describe('ObjectStackAdapter.queryDataset', () => {
 });
 
 /* -------------------------------------------------------------------------- */
+/* objectui#5663 — one branch per SERVER CONDITION, keyed on the ADR-0112       */
+/* `code`, never on "the endpoint errored".                                     */
+/*                                                                             */
+/* Every body below is the wire answer its producer actually writes, copied     */
+/* from the framework rather than imagined here — that is the whole point of    */
+/* the fixtures, since the defect was a client that decided what the server had */
+/* said without reading the field the server said it in:                        */
+/*                                                                             */
+/*   route absent      404 wrapped `ROUTE_NOT_FOUND`  @objectstack/runtime,     */
+/*                                                    dispatcher-plugin.ts      */
+/*   service absent    501 flat    `NOT_IMPLEMENTED`  @objectstack/rest,        */
+/*                                                    registerAnalyticsEndpoints*/
+/*   dataset unknown   404 flat    `NOT_FOUND`        same route, the           */
+/*                                                    `datasetName` lookup miss */
+/*   not signed in     401 flat    `UNAUTHENTICATED`  ANONYMOUS_DENY_BODY,      */
+/*                                                    @objectstack/core         */
+/*                                                                             */
+/* The first two and the third SHARE HTTP 404. That collision is the defect,    */
+/* so the pins below are written to fail if anyone reintroduces a status test.  */
+/* -------------------------------------------------------------------------- */
+describe('ObjectStackAdapter.queryDataset — error branch mapping (objectui#5663)', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  const adapterFor = (fetchImpl: any) =>
+    new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+  /** The dispatcher's 404 for a url no route is registered for. */
+  const ROUTE_NOT_FOUND_BODY = {
+    success: false,
+    error: {
+      code: 'ROUTE_NOT_FOUND',
+      message: 'Not Found',
+      httpStatus: 404,
+      hint: 'No handler matched this request. Check the API discovery endpoint for available routes.',
+    },
+  };
+  /** The REST route's 404 when `body.datasetName` matches no saved dataset. */
+  const DATASET_NOT_FOUND_BODY = {
+    code: 'NOT_FOUND',
+    message: 'Dataset "opportunity_metrics" not found.',
+  };
+  /** `ANONYMOUS_DENY_BODY` — note `error` carries the CODE, not the message. */
+  const UNAUTHENTICATED_BODY = {
+    error: 'UNAUTHENTICATED',
+    code: 'UNAUTHENTICATED',
+    message: 'Authentication is required to access this endpoint.',
+  };
+
+  it('route absent (404 ROUTE_NOT_FOUND, wrapped envelope) → capability not installed', async () => {
+    const { fetchImpl } = makeFetch({ ok: false, status: 404, body: ROUTE_NOT_FOUND_BODY });
+
+    const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+    expect(err.code).toBe('ANALYTICS_NOT_INSTALLED');
+    // Read out of the WRAPPED envelope — a reader that only knew the flat shape
+    // would see no code here and reach the branch by luck of the status.
+    expect(err.serverCode).toBe('ROUTE_NOT_FOUND');
+    expect(err.message).toContain('@objectstack/service-analytics');
+  });
+
+  it('service absent (501 NOT_IMPLEMENTED) → capability not installed', async () => {
+    const { fetchImpl } = makeFetch({
+      ok: false,
+      status: 501,
+      body: {
+        code: 'NOT_IMPLEMENTED',
+        message: 'Analytics dataset query is not available on this deployment (no analytics service with queryDataset).',
+      },
+    });
+
+    const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+    expect(err.code).toBe('ANALYTICS_NOT_INSTALLED');
+    expect(err.serverCode).toBe('NOT_IMPLEMENTED');
+  });
+
+  it('dataset unknown (404 NOT_FOUND) → dataset-not-defined, NOT capability-missing', async () => {
+    const { fetchImpl } = makeFetch({ ok: false, status: 404, body: DATASET_NOT_FOUND_BODY });
+
+    const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+    expect(err.code).toBe('ANALYTICS_DATASET_NOT_FOUND');
+    expect(err.serverCode).toBe('NOT_FOUND');
+    expect(err.datasetName).toBe('opportunity_metrics');
+    // The regression itself: SAME status as the branch above, different answer.
+    expect(isAnalyticsNotInstalledError(err)).toBe(false);
+  });
+
+  it('not signed in (401 UNAUTHENTICATED) → its own branch, neither of the other two', async () => {
+    const { fetchImpl } = makeFetch({ ok: false, status: 401, body: UNAUTHENTICATED_BODY });
+
+    const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+    expect(err.code).toBe('ANALYTICS_UNAUTHENTICATED');
+    expect(err.serverCode).toBe('UNAUTHENTICATED');
+    expect(isAnalyticsNotInstalledError(err)).toBe(false);
+    expect(err.message).toMatch(/not authenticated/i);
+  });
+
+  /* ------------------------------------------------------------------------ */
+  /* The reported incident, replayed byte-for-byte.                            */
+  /* ------------------------------------------------------------------------ */
+  it('replays the reported prod banner: no install-a-plugin advice, and the app upgrade is named', async () => {
+    const { fetchImpl } = makeFetch({ ok: false, status: 404, body: DATASET_NOT_FOUND_BODY });
+
+    const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+    // What the operator on `os-2gv9x5.objectos.ai` was told to do, and must not
+    // be told again: install a server plugin, for an installed-app version skew.
+    expect(err.message).not.toContain('capability is not installed');
+    expect(err.message).not.toContain('AnalyticsServicePlugin');
+    expect(err.message).not.toContain('@objectstack/service-analytics');
+    // What they should have been told.
+    expect(err.message).toContain('Dataset "opportunity_metrics"');
+    expect(err.message).toContain('not defined in this environment');
+    expect(err.message).toContain('upgrade the installed app');
+  });
+
+  /* ------------------------------------------------------------------------ */
+  /* The headline and the parenthetical cannot disagree.                       */
+  /*                                                                           */
+  /* The original banner quoted `Dataset "opportunity_metrics" not found.` in   */
+  /* its own parenthetical while its headline said the capability was missing.  */
+  /* A diagnostic that quotes its subject and then overrides its meaning is     */
+  /* worse than one that says nothing, because it reads as authoritative. The   */
+  /* structural fix is that the headline is now a pure function of `code` and   */
+  /* the parenthetical a verbatim quote of `message` from the SAME response, so */
+  /* the pins below walk every branch and assert both halves at once.          */
+  /* ------------------------------------------------------------------------ */
+  describe('headline and parenthetical are read off the same answer', () => {
+    const branches = [
+      { name: 'route absent', status: 404, body: ROUTE_NOT_FOUND_BODY, quoted: 'Not Found', headline: /capability is not installed/ },
+      { name: 'dataset unknown', status: 404, body: DATASET_NOT_FOUND_BODY, quoted: 'Dataset "opportunity_metrics" not found.', headline: /is not defined in this environment/ },
+      { name: 'not signed in', status: 401, body: UNAUTHENTICATED_BODY, quoted: 'Authentication is required to access this endpoint.', headline: /not authenticated/ },
+    ] as const;
+
+    for (const branch of branches) {
+      it(`${branch.name}: quotes the server verbatim and says the same thing in the headline`, async () => {
+        const { fetchImpl } = makeFetch({ ok: false, status: branch.status, body: branch.body });
+
+        const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+        expect(err.message).toContain(`(server said: ${branch.quoted})`);
+        expect(err.message).toMatch(branch.headline);
+        // …and none of the OTHER branches' headlines. This is the assertion the
+        // old mapping failed: it quoted this branch's message under a different
+        // branch's headline.
+        for (const other of branches) {
+          if (other.name === branch.name) continue;
+          expect(err.message).not.toMatch(other.headline);
+        }
+      });
+    }
+  });
+
+  /* ------------------------------------------------------------------------ */
+  /* The status is consulted ONLY when there is no code to read.               */
+  /* ------------------------------------------------------------------------ */
+  describe('no ADR-0112 code in the answer', () => {
+    it('a bare 404 is still the capability-missing branch — no ObjectStack route wrote it', async () => {
+      const { fetchImpl } = makeFetch({ ok: false, status: 404, body: { error: 'Not found' } });
+
+      const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+      expect(err.code).toBe('ANALYTICS_NOT_INSTALLED');
+      // Nothing named a code, so nothing is claimed about which producer spoke.
+      expect(err.serverCode).toBeUndefined();
+    });
+
+    it('a bare 401 is the unauthenticated branch', async () => {
+      const { fetchImpl } = makeFetch({ ok: false, status: 401, body: {} });
+
+      const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+      expect(err.code).toBe('ANALYTICS_UNAUTHENTICATED');
+      expect(err.serverCode).toBeUndefined();
+    });
+
+    it('a non-JSON error body does not throw the mapping itself', async () => {
+      const fetchImpl = vi.fn(async (url: any) => {
+        const u = String(url);
+        if (u.includes('/api/v1/discovery')) {
+          return { ok: true, status: 200, statusText: 'OK', json: async () => ({ success: true, data: { version: 'v1', routes: {} } }) } as any;
+        }
+        return {
+          ok: false, status: 502, statusText: 'Bad Gateway',
+          json: async () => { throw new SyntaxError('Unexpected token < in JSON'); },
+        } as any;
+      });
+
+      const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+      expect(err.code).toBeUndefined();
+      expect(String(err.message)).toContain('Dataset query failed: 502');
+    });
+  });
+
+  /* ------------------------------------------------------------------------ */
+  /* A 404 this client does not recognise is NOT quietly relabelled.           */
+  /* ------------------------------------------------------------------------ */
+  it('a 404 with an unrecognised code keeps its server detail instead of claiming a capability is missing', async () => {
+    // `CUBE_NOT_FOUND` (404) is a real analytics gate that reaches this route
+    // through the ADR-0112 envelope passthrough. Under the old status test it
+    // was ALSO reported as "install @objectstack/service-analytics"; the point
+    // of branching on `code` is that an unknown condition now reads as unknown
+    // rather than as the one condition the status happened to be tested for.
+    const { fetchImpl } = makeFetch({
+      ok: false, status: 404,
+      body: { code: 'CUBE_NOT_FOUND', message: 'Cube "revenue" is not defined.' },
+    });
+
+    const err = await adapterFor(fetchImpl).queryDataset('opportunity_metrics', selection).catch((e) => e);
+
+    expect(isAnalyticsNotInstalledError(err)).toBe(false);
+    expect(err.code).toBeUndefined();
+    expect(String(err.message)).toContain('Cube "revenue" is not defined.');
+  });
+});
+
+/* -------------------------------------------------------------------------- */
 /* objectui#3613 — the `selection` parameter IS the spec type, not a copy.      */
 /*                                                                             */
 /* Compile-time pins. A violation is a `tsc --noEmit` error, not a runtime      */


### PR DESCRIPTION
Fixes #5663

`POST /api/v1/analytics/dataset/query` answers **404 for two unrelated conditions**. `ObjectStackAdapter.queryDataset` tested the status and could not see the difference:

```ts
if (res.status === 501 || res.status === 404) {
  throw new AnalyticsNotInstalledError('POST /analytics/dataset/query', detail || undefined);
}
```

| condition | status | ADR-0112 `code` | producer |
| --- | --- | --- | --- |
| route never mounted | 404 | `ROUTE_NOT_FOUND` | `@objectstack/runtime` `dispatcher-plugin.ts` (wrapped envelope) |
| route mounted, no analytics service | 501 | `NOT_IMPLEMENTED` | `@objectstack/rest` `registerAnalyticsEndpoints` |
| route answering, **dataset unknown** | 404 | `NOT_FOUND` | same route, the `body.datasetName` lookup miss |
| session not authenticated | 401 | `UNAUTHENTICATED` | `enforceAuth` → `ANONYMOUS_DENY_BODY` (`@objectstack/core`) |

Rows 1 and 3 share a status and nothing else. Every unknown dataset therefore produced the capability-missing banner: on the reported prod tenant, four HotCRM Executive Overview widgets told the operator to install `@objectstack/service-analytics` and mount `AnalyticsServicePlugin`, while the analytics service was installed and answering the whole time. The real condition was an installed `app.objectstack.hotcrm` at 1.3.0 whose datasets ship in 2.2.2 — a package upgrade, the opposite corner of the system from the remedy the banner named.

## What changed

`queryDataset` now branches on the `code` the framework declares for each condition, and consults the status only as a residual when the answer carries no code at all:

- `NOT_IMPLEMENTED` / `ROUTE_NOT_FOUND` → `AnalyticsNotInstalledError`, copy unchanged. One remedy, one message.
- `NOT_FOUND` → new `AnalyticsDatasetNotFoundError` (`ANALYTICS_DATASET_NOT_FOUND`), which names the dataset and points at the installed app's version.
- `UNAUTHENTICATED` → new `AnalyticsUnauthenticatedError` (`ANALYTICS_UNAUTHENTICATED`), which says the request was refused before it ran and therefore says nothing about the capability. Triage ruled this a third branch rather than a shade of either other one; an expired session reported as a missing capability is the same defect wearing a different mask.
- No code at all → a bare 404/501 is still the capability-missing branch (nothing ObjectStack wrote it), a bare 401 is the unauthenticated branch, everything else keeps the generic `Dataset query failed: …` with its server detail.

The status is not a re-entry point here: the residual is reached only after every code branch has declined. A 404 is safe *there* and unsafe as a primary test for exactly the same reason — the route's own `NOT_FOUND` always ships a code, so a code-less 404 cannot be the unknown-dataset case.

## The headline can no longer contradict its own parenthetical

The reported banner printed the server's real message in parentheses — `(server said: Dataset "opportunity_metrics" not found.)` — under a headline claiming a missing capability. A diagnostic that quotes its subject and then overrides its meaning is worse than one that says nothing, because it reads as authoritative.

That is now structurally impossible rather than merely corrected. The headline is a pure function of `code`; the parenthetical is a verbatim quote of `message`; both are read off the same response by the same reader, and `message` never feeds classification. If they ever disagree the *producer* has a bug — whereas before, the consumer did: the headline came from a status two conditions share while the quote came from the one that had actually happened. A parameterised test walks every branch asserting each message carries its own headline **and none of the others'**.

## Reading two envelopes on purpose

One url, two possible producers, so `readAnalyticsErrorEnvelope` reads two shapes: the **flat** `{ code, message }` the route writes itself, and the **wrapped** `{ success: false, error: { code, message } }` the dispatcher writes when the route is not mounted. Both are live and sanctioned by ADR-0112's 2026-07-30 amendment.

This is not the tolerant `body.error?.code ?? body.error` chain `@objectstack/core`'s `anonymous-deny.ts` warns consumers off. The two families are told apart **structurally** (`typeof body.error === 'object'`), never by trying one key and falling through to the other, so a producer that regresses its envelope reads as "no code" — the honest answer, which lands in the residual — instead of being quietly absorbed. And *which* family answered is itself part of the signal: only the wrapped `ROUTE_NOT_FOUND` can mean the route is absent, and only the route's own flat envelope can mean the dataset is.

## Scope notes

- **Additive only.** `AnalyticsNotInstalledError` keeps its `code`, its copy and its constructor arity (it gains an optional third `serverCode` argument plus a `serverCode` field). Consumers matching `ANALYTICS_NOT_INSTALLED` — including `metadata-admin`'s `DatasetPreview`, whose test constructs the capability-missing string as a fixture — are untouched, so nothing under `packages/app-shell/**` needed editing.
- **A 404 with an unrecognised code is no longer relabelled.** The analytics cube gate's `CUBE_NOT_FOUND` (404) used to land in the capability-missing branch by the same status collision; it now keeps its server detail. Pinned.
- **Out of scope here, filed separately:** `classifyAnalyticsFailure` (same file, the `/analytics/query` face) has the same shape — `status === 404` is tested before the code and short-circuits it, so a `CUBE_NOT_FOUND` is *warned as a missing capability and silently degraded to a client-side aggregate*. That is a different route face with a different envelope family, and correcting it moves degradation behaviour rather than copy, so it needs its own measurement: #5721.
- **No i18n keys added.** `@object-ui/data-objectstack` is a transport adapter with no `@object-ui/i18n` dependency and no `t()` call sites; both live renderers (`plugin-dashboard`'s `DatasetWidget`, `app-shell`'s `DatasetPreview`) print `error.message` verbatim. Localising this copy means moving the mapping into a renderer, which is a different change in a different package. Adding pack keys nothing reads would be dead keys on arrival. Called out for the maintainer in the issue report.

## Verification

All at `5c2376387`, the branch head.

- `pnpm exec vitest run --maxWorkers=2 packages/data-objectstack/` → `Test Files 42 passed (42) · Tests 576 passed (576)` (545 before; 31 new)
- `pnpm --filter @object-ui/data-objectstack type-check` → `tsc --noEmit`, exit 0
- `pnpm exec eslint .` in `packages/data-objectstack` → `✖ 368 problems (0 errors, 368 warnings)`, all pre-existing `no-explicit-any`
- `check:control-bytes` → `✅ OK (scanned 4768 tracked text file(s); skipped 85 binary)`
- `check:i18n-keys` → `✅ Every in-scope call-site key resolves against the en pack (2924 keys)…`
- `check:i18n-drift` → `✅ No en value changed in this range.`
- `check:phantom-deps`, `check:self-import`, `check:esm-specifiers` → exit 0
- `check-changeset-presence.mjs` → `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`
- `check-changeset-no-major.mjs` → `✅ No changeset declares a major bump.`

**Ablation.** Restoring the pre-fix `res.status === 501 || res.status === 404` mapping (mutation confirmed on disk by counting both the injected marker, 1, and the deleted branch text, 0) turns **9 of the 31 new tests red**: all four branch pins, the incident replay, the dataset-unknown and not-signed-in halves of the headline/parenthetical sweep, the bare-401 residual, and the unrecognised-404 pin. The route-absent headline pin correctly stays green — the ablation does not change that branch's verdict, only its `serverCode` provenance. No rebuild was needed: the test imports `./index` by relative source path, so `dist` staleness cannot make the ablation falsely green. The restore leg ran under an `EXIT INT TERM` trap and was verified byte-identical to the commit (`git diff --stat HEAD` empty), then re-measured green at 576/576.

**Cross-package type check.** Against the rebuilt `dist/index.d.ts`: a consumer calling the pre-existing two-argument `new AnalyticsNotInstalledError(surface, detail)` still compiles (exit 0), and the reverse leg — passing `datasetName: 404` — fails with `TS2322: Type 'number' is not assignable to type 'string'`, confirming the declarations being read are the rebuilt ones and not a cache.

**Declared narrowing.** Repo-wide `pnpm test` / `pnpm type-check` / `pnpm lint` (all `turbo run …`) are CI's runs and are not duplicated here. The lint narrowing is a measurement, not a skip: the population comes from eslint's own config resolution via `eslint .` in the package — the exact command `turbo run lint` invokes for it — the file count (48) is read from `--format json`, and `eslint.config.js` enables no type-aware linting (`tseslint.configs.recommended`, no `parserOptions.project` / `projectService`), so every file's verdict is a function of its own text plus the shared config and this diff cannot move a verdict in any file it does not edit. The diff touches two files, both inside this one package.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_