### PR TITLE
fix(auth): AuthGuard requiredRoles reads positions; retire the roles mirror key

### DIFF
--- a/.changeset/authguard-positions-5424.md
+++ b/.changeset/authguard-positions-5424.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/auth": minor
+---
+
+`AuthGuard`'s `requiredRoles` now matches against `user.positions` — the one published spelling (framework ADR-0090 D3) — keeping the `user.role` scalar fallback only for sessions that carry no `positions` key at all (guest / legacy identities). This restores position-holder admission on protocol-17 deployments (where the retired `roles` key is never emitted) and closes the matching over-admission: a coarse scalar `role` no longer passes a gate whose position the server says the user lacks. Preview mode now emits `positions: [role]` instead of the retired `roles` key — it was the last producer — so preview identities are shaped like protocol-17 sessions for every `positions` consumer. The hand-copied `roles?: string[]` mirror key is removed from the client `AuthUser` type; breaking only for TypeScript consumers that compiled against `AuthUser['roles']` (read `positions` instead — no runtime payload ever carried `roles` at protocol 17). Maintainer ruling 2026-08-22 on objectui#5424.

--- a/packages/auth/src/AuthGuard.tsx
+++ b/packages/auth/src/AuthGuard.tsx
@@ -12,7 +12,14 @@ import { useAuth } from './useAuth.js';
 export interface AuthGuardProps {
   /** Content to render when user is not authenticated */
   fallback?: React.ReactNode;
-  /** Required roles (user must have at least one) */
+  /**
+   * Required position/role names — the user must hold at least one.
+   *
+   * Matched against `user.positions`, the one published spelling (framework
+   * ADR-0090 D3), falling back to the single `user.role` scalar only when the
+   * session carries no `positions` key at all (synthetic guest / legacy
+   * identities). The retired `roles` spelling is not read.
+   */
   requiredRoles?: string[];
   /** Required permissions (user must have all) */
   requiredPermissions?: string[];
@@ -53,9 +60,22 @@ export function AuthGuard({
     return <>{fallback}</>;
   }
 
-  // Check role requirements
+  // Check role requirements.
+  //
+  // `positions` is the ONE published spelling (framework ADR-0090 D3 renamed
+  // `roles` → `positions` with no deprecation window; maintainer ruling on
+  // objectui#5424). When the session carries the key — protocol 17 always
+  // emits it — it is the whole answer, empty included: falling back to the
+  // coarse `user.role` scalar when the server said "no positions" would be
+  // exactly the over-admission this gate used to have (`role: 'admin'`
+  // passing a gate meant for an `admin` position). The scalar fallback exists
+  // for identities that lack the key entirely: the guest user the provider
+  // seeds when auth is disabled, and pre-positions deployments. The retired
+  // `roles` spelling is deliberately NOT read — resurrecting it as a fallback
+  // dialect is what ADR-0090 D3 forbids
+  // (`__tests__/authGuardPositions-5424.test.tsx` pins the refusal).
   if (requiredRoles && requiredRoles.length > 0 && user) {
-    const userRoles = user.roles ?? (user.role ? [user.role] : []);
+    const userRoles = user.positions ?? (user.role ? [user.role] : []);
     const hasRole = requiredRoles.some((role) => userRoles.includes(role));
     if (!hasRole) {
       return <>{fallback}</>;

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -247,7 +247,13 @@ export function AuthProvider({
         email: 'preview@preview.local',
         name,
         role,
-        roles: [role],
+        // `positions` is the published spelling (framework ADR-0090 D3); this
+        // line was the LAST producer of the retired `roles` key
+        // (objectui#5424, maintainer ruling 2026-08-22). Emitting the position
+        // keeps every `positions` consumer — `AuthGuard`'s `requiredRoles`,
+        // the approver-identity derivations, workspace-admin leg 3 — seeing a
+        // preview identity shaped like a protocol-17 session.
+        positions: [role],
       });
       setSession({
         token: 'preview-token',

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -305,10 +305,15 @@ describe('AuthGuard', () => {
     });
   });
 
-  it('allows access when user has one of the required roles', async () => {
+  it('allows access when user holds one of the required positions', async () => {
+    // Until objectui#5424 this fixture spelled the array `roles`, pinning the
+    // retired dialect: it stayed green precisely because the alias branch this
+    // card deletes still read it. `positions` is the published spelling
+    // (framework ADR-0090 D3); the full admission/refusal matrix lives in
+    // `authGuardPositions-5424.test.tsx`.
     const client = createMockClient({
       getSession: vi.fn().mockResolvedValue({
-        user: { id: '1', name: 'Manager', email: 'mgr@test.com', roles: ['manager', 'viewer'] },
+        user: { id: '1', name: 'Manager', email: 'mgr@test.com', positions: ['manager', 'viewer'] },
         session: { token: 'tok' },
       }),
     });
@@ -323,6 +328,32 @@ describe('AuthGuard', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Manager content')).toBeTruthy();
+    });
+  });
+
+  it('does NOT honour the retired `roles` spelling as a second dialect', async () => {
+    // framework ADR-0090 D3 renamed `roles` → `positions` with no deprecation
+    // window and bans resurrecting the old name as a fallback. Before
+    // objectui#5424 this exact fixture was ADMITTED (the gate read
+    // `user.roles` first); a regression that quietly re-reads it turns this
+    // red before it can widen any real gate.
+    const client = createMockClient({
+      getSession: vi.fn().mockResolvedValue({
+        user: { id: '1', name: 'Relic', email: 'relic@test.com', role: 'user', roles: ['admin'] },
+        session: { token: 'tok' },
+      }),
+    });
+
+    render(
+      <AuthProvider authUrl="/api/auth" client={client}>
+        <AuthGuard requiredRoles={['admin']} fallback={<span>Access denied</span>}>
+          <span>Admin content</span>
+        </AuthGuard>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Access denied')).toBeTruthy();
     });
   });
 });

--- a/packages/auth/src/__tests__/authGuardPositions-5424.test.tsx
+++ b/packages/auth/src/__tests__/authGuardPositions-5424.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5424 — `AuthGuard`'s `requiredRoles` gate reads `user.positions`
+ * (maintainer ruling 2026-08-22, Option A), keeping the `user.role` scalar
+ * fallback for identities that lack the key entirely.
+ *
+ * ## What was broken, in both directions at once
+ *
+ * The gate read `user.roles ?? (user.role ? [user.role] : [])`, and the
+ * protocol-17 session face emits NO `roles` key at all (framework ADR-0090 D3
+ * renamed it to `positions` with no deprecation window — measured live in
+ * objectui#5389, whose captured payload this file reuses). So on every real
+ * deployment the left operand was always `undefined` and the gate decided on
+ * the coarse scalar alone:
+ *
+ *  - UNDER-admission: `requiredRoles={['finance_approver']}` refused everyone
+ *    holding `finance_approver` as a position — the only place protocol 17
+ *    puts it.
+ *  - OVER-admission: `role: 'admin'` passed a gate meant for an `admin`
+ *    position the user does not hold.
+ *
+ * ## Why this file pins NEGATIVES, not just the restored admissions
+ *
+ * This is an access-control gate. A "fix" that admits more often makes the
+ * positive cases green too, so positives alone cannot tell a restored
+ * detection from a widened one (same argument as
+ * `workspaceAdminPositions-5389.test.tsx`). Every refusal case below exists to
+ * make a specific over-admission fail loudly:
+ *
+ *  - a user with neither the position nor a matching scalar stays refused;
+ *  - a PRESENT `positions` array is authoritative, empty included — the
+ *    scalar fallback applies only when the key is absent, otherwise
+ *    `role: 'admin'` would re-open the over-admission the ruling closes;
+ *  - the retired `roles` spelling is not honoured as a second dialect
+ *    (ADR-0090 D3 bans resurrecting it; AGENTS.md commandment #0.1 bans the
+ *    tolerant consumer-side alias generally).
+ *
+ * ## Preview mode is half of this card
+ *
+ * `AuthProvider`'s preview mode was the LAST producer of the retired key
+ * (`roles: [role]`, no `positions`). Had the gate moved to `positions` alone
+ * with preview left as it was, every preview user would have been refused at
+ * every `requiredRoles` gate and every demo surface built on preview mode
+ * would go dark. Preview now emits `positions: [role]` (same batch, same
+ * ruling), so a preview identity is shaped like a protocol-17 session for
+ * EVERY `positions` consumer, not just this gate. The cases below pin both the
+ * continuity (preview admin still passes an `admin` gate, preview viewer is
+ * still refused) and the producer retirement itself (`hasOwnProperty('roles')`
+ * is false on the preview identity).
+ *
+ * These render the REAL `AuthProvider` against a client double, in the manner
+ * of `workspaceAdminPositions-5389.test.tsx`: a mocked `useAuth` could only
+ * restate the fixture; going through the provider measures the path a console
+ * actually takes from wire payload (or preview config) to admit/refuse.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthProvider } from '../AuthProvider';
+import { AuthGuard } from '../AuthGuard';
+import { useAuth } from '../useAuth';
+import type { AuthClient, AuthUser } from '../types';
+
+function createClientDouble(user: Record<string, unknown>): AuthClient {
+  return {
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    getSession: vi.fn().mockResolvedValue({ user, session: { token: 'tok' } }),
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+    updateUser: vi.fn(),
+    // `AuthClient` declares ~38 methods; this double implements what the
+    // provider reaches on the session path — the same shape and the same
+    // one-seam assertion as `AuthProvider.test.tsx` in this package.
+  } as unknown as AuthClient;
+}
+
+/** Renders the gate and resolves to which side of it we landed on. */
+async function renderGate(
+  user: Record<string, unknown>,
+  requiredRoles: string[],
+): Promise<'admitted' | 'refused'> {
+  const utils = render(
+    <AuthProvider authUrl="/api/auth" client={createClientDouble(user)}>
+      <AuthGuard requiredRoles={requiredRoles} fallback={<span>REFUSED</span>}>
+        <span>ADMITTED</span>
+      </AuthGuard>
+    </AuthProvider>,
+  );
+  const marker = await waitFor(() => {
+    const found = screen.queryByText('ADMITTED') ?? screen.queryByText('REFUSED');
+    expect(found).toBeTruthy();
+    return found!;
+  });
+  const verdict = marker.textContent === 'ADMITTED' ? 'admitted' : 'refused';
+  utils.unmount();
+  return verdict;
+}
+
+/**
+ * The deployment shape the card measured (objectui#5389's captured
+ * `get-session` payload, business position added): adminship and business
+ * positions live in `positions`, `role` stays at better-auth's default
+ * `'user'`.
+ */
+const V17_POSITION_HOLDER = {
+  id: 'u1',
+  email: 'psadmin@example.com',
+  name: 'PermSet Admin',
+  role: 'user',
+  positions: ['user', 'finance_approver'],
+  isPlatformAdmin: false,
+};
+
+describe('AuthGuard requiredRoles reads positions (objectui#5424)', () => {
+  it('admits a position-holder the retired read refused (the defect)', async () => {
+    // Before the fix: `roles` absent -> scalar ['user'] -> refused, even
+    // though the server says the user holds `finance_approver`.
+    expect(await renderGate(V17_POSITION_HOLDER, ['finance_approver'])).toBe('admitted');
+  });
+
+  it('refuses the coarse scalar when positions is present (over-admission closed)', async () => {
+    // Before the fix: `roles` absent -> scalar ['admin'] -> ADMITTED to a
+    // gate meant for an `admin` position the server says the user lacks.
+    const user = { ...V17_POSITION_HOLDER, role: 'admin', positions: ['user'] };
+    expect(await renderGate(user, ['admin'])).toBe('refused');
+  });
+
+  it('still refuses a user with neither the position nor a matching scalar', async () => {
+    // Green before AND after — a fix that widens admission breaks it.
+    const user = { ...V17_POSITION_HOLDER, positions: ['user'] };
+    expect(await renderGate(user, ['finance_approver'])).toBe('refused');
+  });
+
+  it('treats a PRESENT-but-empty positions array as authoritative', async () => {
+    // Same stance as workspaceAdminPositions-5389: an empty `positions` is
+    // the server's answer, not an invitation to fall back to the scalar.
+    const user = { ...V17_POSITION_HOLDER, role: 'admin', positions: [] as string[] };
+    expect(await renderGate(user, ['admin'])).toBe('refused');
+  });
+
+  it('keeps the scalar fallback for sessions without the positions key', async () => {
+    // The guest identity (`enabled={false}`) and pre-positions deployments
+    // carry only the scalar — the ruling keeps them admitted.
+    const user = { id: 'guest', email: 'guest@local', name: 'Guest', role: 'admin' };
+    expect(await renderGate(user, ['admin'])).toBe('admitted');
+  });
+
+  it('does NOT honour the retired `roles` spelling as a second dialect', async () => {
+    // Before the fix this fixture was ADMITTED (the gate read `user.roles`
+    // first). ADR-0090 D3 bans resurrecting the spelling; if someone ever
+    // adds `roles` back into the chain, this fails before any real gate
+    // widens.
+    const user = { id: 'u2', email: 'relic@example.com', name: 'Relic', role: 'user', roles: ['admin'] };
+    expect(await renderGate(user, ['admin'])).toBe('refused');
+  });
+});
+
+describe('preview mode across the same gate (objectui#5424)', () => {
+  function PreviewProbe() {
+    const { user } = useAuth();
+    if (!user) return <span>NO-USER</span>;
+    return (
+      <div>
+        <span data-testid="positions">{JSON.stringify((user as AuthUser).positions ?? null)}</span>
+        <span data-testid="has-retired-roles">
+          {String(Object.prototype.hasOwnProperty.call(user, 'roles'))}
+        </span>
+      </div>
+    );
+  }
+
+  it('a preview admin passes an admin gate exactly as before the fix', async () => {
+    render(
+      <AuthProvider
+        authUrl="/api/auth"
+        client={createClientDouble({})}
+        previewMode={{ autoLogin: true, simulatedRole: 'admin' }}
+      >
+        <AuthGuard requiredRoles={['admin']} fallback={<span>REFUSED</span>}>
+          <span>ADMITTED</span>
+        </AuthGuard>
+      </AuthProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('ADMITTED')).toBeTruthy();
+    });
+  });
+
+  it('a preview viewer is still refused at an admin gate — nobody new passes', async () => {
+    render(
+      <AuthProvider
+        authUrl="/api/auth"
+        client={createClientDouble({})}
+        previewMode={{ autoLogin: true, simulatedRole: 'viewer' }}
+      >
+        <AuthGuard requiredRoles={['admin']} fallback={<span>REFUSED</span>}>
+          <span>ADMITTED</span>
+        </AuthGuard>
+      </AuthProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('REFUSED')).toBeTruthy();
+    });
+  });
+
+  it('the preview identity emits positions and has retired the roles key', async () => {
+    // The producer half of the card: preview mode was the LAST source still
+    // writing `roles`. `positions: [role]` keeps preview aligned with the
+    // protocol-17 shape for every consumer; `hasOwnProperty('roles')` false
+    // pins that the retired key is gone rather than merely shadowed.
+    render(
+      <AuthProvider
+        authUrl="/api/auth"
+        client={createClientDouble({})}
+        previewMode={{ autoLogin: true, simulatedRole: 'viewer' }}
+      >
+        <PreviewProbe />
+      </AuthProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('positions').textContent).toBe(JSON.stringify(['viewer']));
+      expect(screen.getByTestId('has-retired-roles').textContent).toBe('false');
+    });
+  });
+});

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -65,24 +65,15 @@ export interface AuthUser extends SpecAuthUser {
   image?: string;
   /** Primary role */
   role?: string;
-  /**
-   * NOT emitted by the protocol-17 session face. Framework ADR-0090 D3 renamed
-   * this to `positions` with no deprecation window; `GET /auth/get-session`
-   * carries `positions` (inherited here from the spec's `AuthUser`, so it
-   * cannot drift) plus the derived `isPlatformAdmin`, and no `roles` key at
-   * all — measured on a live 17.1.0 server in objectui#5389.
-   *
-   * Kept declared only because one live reader still compiles against it:
-   * `AuthGuard`'s `requiredRoles` check. Deleting the key today fails that file
-   * with TS2339 (the index signature below types the read as `unknown`), so
-   * retiring it is gated on objectui#5424, which owns that decision and the
-   * three other surviving read sites.
-   *
-   * Do NOT reach for this key in new code, and do not pair it with `positions`
-   * as a fallback: `positions` is the one published spelling, and reviving this
-   * one as an alias is what ADR-0090 D3 forbids.
-   */
-  roles?: string[];
+  // The hand-copied `roles?: string[]` mirror key that used to sit here
+  // RETIRED with objectui#5424 (maintainer ruling 2026-08-22), once its last
+  // reader — `AuthGuard`'s `requiredRoles` check — moved to `positions`.
+  // Framework ADR-0090 D3 renamed `roles` → `positions` with no deprecation
+  // window, and the protocol-17 session face emits no `roles` key at all
+  // (measured live in objectui#5389). With the declaration gone, any future
+  // read of `user.roles` types as `unknown` via the index signature below and
+  // dies at compile time. Do not re-declare it, and do not re-emit it as a
+  // compatibility shadow of `positions` — both are what ADR-0090 D3 forbids.
   /** Email verification status */
   emailVerified?: boolean;
   /** Additional user metadata */


### PR DESCRIPTION
Fixes #5424

The residual of the card after PR #5555 landed sites 2/3/4, implementing the maintainer's 2026-08-22 ruling (同意 / Option A): the gates read `positions`.

## What changed

- **`packages/auth/src/AuthGuard.tsx`** — `requiredRoles` now matches against `user.positions` (framework ADR-0090 D3's one published spelling), keeping the `user.role` scalar fallback **only when the session carries no `positions` key at all** (guest / legacy identities). A present `positions` array is authoritative, empty included — falling back to the scalar on a present-but-empty array would re-open the over-admission this card closes. The retired `roles` spelling is not read.
- **`packages/auth/src/AuthProvider.tsx`** — preview mode emits `positions: [role]` instead of `roles: [role]`. It was the **last producer** of the retired key; a preview identity is now shaped like a protocol-17 session for every `positions` consumer (this gate, the approver-identity derivations, workspace-admin leg 3). Measured before changing it: with the new gate and the old producer, preview users still passed every gate via the scalar fallback — so this half is producer retirement and shape consistency, not what keeps demos alive. The guest identity (`enabled={false}`) is untouched: it never produced `roles` and the scalar fallback covers it, behavior-identical.
- **`packages/auth/src/types.ts`** — the hand-copied `roles?: string[]` mirror key retires now that its last reader is gone. Verified the promised compile-time death: a temporary `user?.roles?.includes('admin')` probe fails `@object-ui/auth` type-check with `src/AuthGuard.tsx(55,21): error TS2339: Property 'includes' does not exist on type '{}'` — the same signature the card measured when the removal was attempted while site 1 still read the key.

Explicitly NOT done, per the ruling: no compatibility shadow key re-emitting `roles`; `packages/permissions`' separate `roles` surface untouched.

## Both directions pinned (`authGuardPositions-5424.test.tsx`)

This is an access-control gate, so the pins cover refusals as much as admissions:

| pin | direction it catches |
|---|---|
| position-holder admitted at their own gate | the under-admission defect (red before fix) |
| coarse scalar refused when `positions` is present | the over-admission defect (red before fix) |
| neither position nor scalar → still refused | a fix that widens admission |
| present-but-empty `positions` → refused | scalar re-opening over-admission |
| no `positions` key → scalar still admits | the ruling's kept fallback |
| retired `roles` spelling → refused | ADR-0090 D3 dialect resurrection (also pinned in `AuthProvider.test.tsx`) |
| preview admin admitted / preview viewer refused | preview continuity — nobody new passes |
| preview identity has `positions: [role]`, `hasOwnProperty('roles')` false | the producer retirement |

Fixture triage: `AuthProvider.test.tsx`'s "one of the required roles" fixture spelled the array `roles` — it stayed green precisely because of the alias branch this PR deletes. Converted to `positions` and given a companion negative pinning the retired spelling refused.

## Verification (all at `cc6e27d7a`, the head of this PR)

- `pnpm exec vitest run packages/auth/` — **20 files, 209 tests passed** (verify-lock verdict: command-exit 0).
- Reverse verification A (committed fix, `AuthGuard.tsx` reverted to `origin/main`, mutation confirmed on disk by grep): **exactly the 4 direction pins fail** (`4 failed | 5 passed`), the widening guard, scalar fallback and preview cases stay green; restored, tree clean.
- Reverse verification B (`AuthProvider.tsx` reverted alone): **only the producer-retirement pin fails** (`1 failed | 8 passed`) — the two preview gate cases staying green is the direct measurement that the scalar fallback alone covers preview at this gate.
- `turbo run type-check --filter=...@object-ui/auth` (auth **and its dependents** — downstream consumer direction): **40/40 tasks successful** (verify-lock verdict: command-exit 0).
- `turbo run lint --filter=@object-ui/auth` (plus root lint): **0 errors** (29 pre-existing warnings, none in this diff; the 4 warnings on touched files pre-date it). Narrowed deliberately: `eslint.config.js` has no type-aware linting (`projectService`/`parserOptions.project` absent) and no custom rule reads other files, so this diff cannot move an untouched package's verdict; CI runs the full farm regardless.
- `check:control-bytes` ✅ (4778 files) · `check:phantom-deps` ✅ · `check:esm-specifiers` ✅ · `changeset:check` ✅ (no `major`) · `check-changeset-presence` ✅ (`.changeset/authguard-positions-5424.md`, `minor`).

Breaking only for TypeScript consumers that compiled against `AuthUser['roles']` — no protocol-17 payload ever carried the key at runtime. Declared in the changeset body; `minor` per this repo's version-alignment policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_