### PR TITLE
fix(app-shell): read view-column identity in the canonical spelling only

### DIFF
--- a/.changeset/viewcolumn-identity-canonical-read-5344.md
+++ b/.changeset/viewcolumn-identity-canonical-read-5344.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/app-shell': minor
+---
+
+The metadata designer's View column inspector now reads a column's identity —
+field key and label — in the ObjectStack canonical spelling only: `field` and
+`label`. The legacy TanStack aliases `accessorKey` / `header` are no longer
+consulted (objectui#5344).
+
+Why this is a behaviour change and not a tidy-up: `ListColumn` refuses both
+legacy keys by name (`unrecognized_keys`), so a column carrying them has no
+field key the spec recognises. The inspector nevertheless read them and
+displayed `accessorKey`'s value in the field-key box, presenting a spec-refused
+key as though it were a valid column identity — the same consumer-side
+tolerance alias `ObjectGrid` retired in objectui#5068, surviving one layer up in
+the authoring tool, which is the surface that is supposed to teach the correct
+shape.
+
+**What an author sees:** a stored column shaped `{ accessorKey, header }` now
+shows an EMPTY field key and an empty header, and is re-authored rather than
+silently carried. Canonical `{ field, label }` columns and bare-string columns
+are untouched.
+
+**What is deliberately NOT changed:** the writeback. `patchIdentity` still
+re-emits whichever spelling it was handed, so no stored document is rewritten
+by the act of editing it. Normalising on write was ruled out once the
+maintainer confirmed there is no population of legacy stored documents to
+migrate; such a column stays unsaveable against the spec both before and after
+an edit, exactly as it did before this change. What this removes is the
+invisibility of that state, not the state itself.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.identityRead.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.identityRead.test.tsx
@@ -128,6 +128,11 @@ describe('ViewColumnInspector — identity is read in the canonical spelling onl
 
     fireEvent.change(screen.getByLabelText(FIELD_KEY), { target: { value: 'title' } });
 
+    // Reverse-verified: against the pre-change source this test is red for a
+    // reason that is NOT the writeback — the retired alias seeded a picker
+    // option from `accessorKey`, so the control was a Radix combobox and
+    // `fireEvent.change` was inert (0 calls). The writeback itself is identical
+    // either way; this assertion is a PIN on it, not a red signal.
     expect(onPatch).toHaveBeenCalledTimes(1);
     const written = (onPatch.mock.calls[0][0] as any).list.columns[0];
     // The edit lands on `accessorKey`, NOT on a freshly minted `field` — the
@@ -160,6 +165,11 @@ describe('ViewColumnInspector — identity is read in the canonical spelling onl
     // card's granted surface; filed separately. When that lands, this
     // expectation flips — deliberately, so the boundary is visible rather than
     // silently forgotten.
-    expect(screen.getByText('Name')).toBeInTheDocument();
+    //
+    // Counted, not merely asserted present: post-change EXACTLY ONE element
+    // says `Name`, the list row. Against the pre-change source there were two
+    // (the panel title read `header` as the column's label as well), which is
+    // why this reverse-verifies as a "found multiple elements" failure.
+    expect(screen.getAllByText('Name')).toHaveLength(1);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.identityRead.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.identityRead.test.tsx
@@ -162,7 +162,7 @@ describe('ViewColumnInspector — identity is read in the canonical spelling onl
     // alias retired above (`o.label ?? o.header ?? o.field ?? o.accessorKey`).
     // So the panel's identity controls stop presenting the refused spelling
     // while the list one line above still does. That file is outside this
-    // card's granted surface; filed separately. When that lands, this
+    // card's granted surface; filed as objectui#5725. When that lands, this
     // expectation flips — deliberately, so the boundary is visible rather than
     // silently forgotten.
     //

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.identityRead.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.identityRead.test.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The column inspector reads identity in the CANONICAL spelling only
+ * (objectui#5344, ruled 2026-08-22).
+ *
+ * `ViewColumnInspector` used to read `c.field ?? c.accessorKey` and
+ * `c.label ?? c.header` — the same undeclared-alias read `ObjectGrid` retired
+ * in objectui#5068, surviving one layer up in the authoring tool. `ListColumn`
+ * refuses `accessorKey` / `header` by name, so that read presented a
+ * spec-refused key as though it were a valid column identity: the author saw
+ * `name` in the field-key box for a column the spec says has no field key.
+ *
+ * What the ruling asks for is OBSERVABLE, not type-level — "the inspector
+ * stops presenting a refused spelling as a valid column identity" — so this
+ * suite mounts the real component and reads what it displays.
+ *
+ * Deliberately NOT changed, and pinned here so a later reader does not
+ * "finish the job" by accident:
+ *   - `patchIdentity`'s writeback still re-emits whichever spelling it was
+ *     handed (option A was ruled OUT once the maintainer confirmed there is no
+ *     population of legacy stored documents: 「无」, 2026-08-22). No stored
+ *     document is rewritten.
+ *   - A legacy column therefore stays unsaveable before AND after an edit.
+ *     That closed loop is the RULED OUTCOME, not an oversight; what this change
+ *     removes is its invisibility.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ViewMetadataSchema } from '@objectstack/spec/ui';
+
+// The inspector renders FieldsListEditor, whose `useObjectFields` reaches for
+// the shared metadata client. The variant below binds no object so the hook
+// short-circuits, but the client itself is still constructed — stub it so no
+// test can escape to the network. Same mechanism as
+// ViewVariantInspector.homeGate.test.tsx.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
+import { ViewColumnInspector } from './ViewColumnInspector';
+
+afterEach(cleanup);
+
+const FIELD_KEY = 'Field key'; // engine.inspector.viewColumn.accessorKey
+const HEADER = 'Header'; //     engine.inspector.viewColumn.header
+
+/** A view draft whose `list` variant binds no object → no field catalog. */
+const draftWith = (columns: unknown[]): Record<string, unknown> => ({
+  name: 'invoices',
+  label: 'Invoices',
+  list: { type: 'grid', columns },
+});
+
+function mount(columns: unknown[], onPatch = vi.fn()) {
+  render(
+    <ViewColumnInspector
+      type="view"
+      name="invoices"
+      draft={draftWith(columns)}
+      selection={{ kind: 'column', id: 'list.columns[0]' } as never}
+      onPatch={onPatch}
+      onClearSelection={() => {}}
+      onSelectionChange={() => {}}
+      readOnly={false}
+      locale={'en-US' as never}
+    />,
+  );
+  return onPatch;
+}
+
+/**
+ * What the inspector DISPLAYS as the column's field key.
+ *
+ * The control is a `<Input>` when the field catalog yields no options and a
+ * Radix combobox when it yields some — and which one renders is itself part of
+ * the observable change, since the retired alias is what used to seed an option
+ * from `accessorKey`. Read both shapes rather than assuming one.
+ */
+function shownFieldKey(): { widget: 'input' | 'combobox'; text: string } {
+  const el = screen.getByLabelText(FIELD_KEY);
+  return el instanceof HTMLInputElement
+    ? { widget: 'input', text: el.value }
+    : { widget: 'combobox', text: el.textContent ?? '' };
+}
+
+const shownHeader = () => (screen.getByLabelText(HEADER) as HTMLInputElement).value;
+
+const parses = (columns: unknown[]) => ViewMetadataSchema.safeParse(draftWith(columns)).success;
+
+describe('ViewColumnInspector — identity is read in the canonical spelling only', () => {
+  it('shows an EMPTY field key for a legacy {accessorKey, header} column', () => {
+    mount([{ accessorKey: 'name', header: 'Name' }]);
+
+    // The ruled behaviour: no field key, so the author re-authors it.
+    expect(shownFieldKey()).toEqual({ widget: 'input', text: '' });
+    // `header` is not a label either — both halves of the alias are retired.
+    expect(shownHeader()).toBe('');
+    // The retired read also used to seed a picker option from `accessorKey`,
+    // labelling a spec-refused key as a real (if unknown) field.
+    expect(screen.queryByText('name (not in object)')).not.toBeInTheDocument();
+  });
+
+  it('leaves a canonical {field, label} column exactly as it was', () => {
+    mount([{ field: 'name', label: 'Name', width: 120 }]);
+
+    expect(shownFieldKey().text).toContain('name');
+    expect(shownHeader()).toBe('Name');
+  });
+
+  it('leaves a bare string column exactly as it was', () => {
+    mount(['name']);
+
+    expect(shownFieldKey().text).toContain('name');
+    // A string column has no label of its own; the box stays empty rather
+    // than echoing the field key.
+    expect(shownHeader()).toBe('');
+  });
+
+  it('still writes back the spelling it was handed — option A did not land', () => {
+    const onPatch = mount([{ accessorKey: 'name', header: 'Name' }]);
+
+    fireEvent.change(screen.getByLabelText(FIELD_KEY), { target: { value: 'title' } });
+
+    expect(onPatch).toHaveBeenCalledTimes(1);
+    const written = (onPatch.mock.calls[0][0] as any).list.columns[0];
+    // The edit lands on `accessorKey`, NOT on a freshly minted `field` — the
+    // writeback is out of scope for this card and no document is normalised.
+    expect(written).toEqual({ accessorKey: 'title', header: 'Name' });
+    expect(written).not.toHaveProperty('field');
+  });
+
+  it('pins the closed loop as the ruled outcome: legacy stays refused, controls stay accepted', () => {
+    // Measured against the same gate ResourceEditPage uses on edit
+    // (clientValidation.ts, mode 'edit'). Unchanged by this card in every row —
+    // what changed is only what the inspector SHOWS.
+    expect(parses([{ accessorKey: 'name', header: 'Name' }])).toBe(false);
+    expect(parses([{ accessorKey: 'title', header: 'Name' }])).toBe(false);
+
+    expect(parses([{ field: 'name', label: 'Name', width: 120 }])).toBe(true);
+    expect(parses([{ field: 'title', label: 'Name', width: 120 }])).toBe(true);
+    expect(parses(['name'])).toBe(true);
+    expect(parses(['title'])).toBe(true);
+  });
+
+  it('records the residue this card is fenced out of: the column LIST still shows the legacy name', () => {
+    mount([{ accessorKey: 'name', header: 'Name' }]);
+
+    // `FieldsListEditor` renders inside this same panel and reads its row
+    // labels through `previews/view-column-io.ts`, which still carries the very
+    // alias retired above (`o.label ?? o.header ?? o.field ?? o.accessorKey`).
+    // So the panel's identity controls stop presenting the refused spelling
+    // while the list one line above still does. That file is outside this
+    // card's granted surface; filed separately. When that lands, this
+    // expectation flips — deliberately, so the boundary is visible rather than
+    // silently forgotten.
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewColumnInspector.tsx
@@ -11,10 +11,16 @@
  * list. New ListColumn props in `@objectstack/spec` appear automatically.
  *
  * A thin curated layer stays on top for the column IDENTITY (field key +
- * label) because those round-trip through two shapes: the ObjectStack
- * canonical `{ field, label }` and the legacy TanStack `{ accessorKey,
- * header }`. A column that is a bare string (e.g. a kanban card field) is
- * kept as a string until the author edits a detail prop.
+ * label), and it reads that identity in the ObjectStack canonical spelling
+ * `{ field, label }` ONLY. The legacy TanStack spelling `{ accessorKey,
+ * header }` is not an identity this editor understands: `ListColumn` refuses
+ * both keys by name, so a column carrying them has no field key as far as the
+ * spec is concerned — and the inspector now shows exactly that (an empty field
+ * key) rather than dressing a refused key up as a valid identity. Retiring
+ * that read is objectui#5344; the WRITE path is deliberately untouched, so
+ * editing such a column still re-saves the spelling it was handed and no
+ * stored document is rewritten. A column that is a bare string (e.g. a kanban
+ * card field) is kept as a string until the author edits a detail prop.
  */
 
 import * as React from 'react';
@@ -39,13 +45,29 @@ interface ViewColumn {
   // ObjectStack canonical shape
   field?: string;
   label?: string;
-  // TanStack-style shape (legacy/imported tables)
+  // TanStack-style shape (legacy/imported tables). Preserved on write by
+  // `patchIdentity`, never read as the column's identity — see `colFieldKey`.
   accessorKey?: string;
   header?: string;
   [k: string]: unknown;
 }
 
-/** Identity keys owned by the curated layer — hidden from the spec form. */
+/**
+ * Keys the curated layer owns — hidden from the spec form, and not counted as
+ * detail props by {@link hasDetailProps}.
+ *
+ * `accessorKey` / `header` stay listed even though the identity read below no
+ * longer consults them, because neither reader of this list asks "what is this
+ * column's identity?":
+ *
+ *   - {@link hasDetailProps} asks whether collapsing an object back to a bare
+ *     string would lose anything. Listing the legacy keys keeps that guard
+ *     conservative, and dropping them would change what {@link writeColumns}
+ *     serializes — the write path objectui#5344 rules out of scope.
+ *   - `hiddenFields` asks which SPEC-DECLARED properties the curated layer
+ *     already renders, and `ListColumn` declares neither key, so those two
+ *     entries can never match anything there.
+ */
 const IDENTITY_KEYS = ['field', 'label', 'accessorKey', 'header'];
 
 function parseId(id: string): { variant: string; index: number } | null {
@@ -61,12 +83,25 @@ function readColumn(raw: unknown): ViewColumn {
   return {};
 }
 
+/**
+ * The column's field key, read in the canonical spelling ONLY.
+ *
+ * `c.accessorKey` is deliberately not consulted. `ListColumn` refuses that key
+ * by name (`unrecognized_keys`), so a column carrying it has no field key the
+ * spec recognises; reading it here would present a refused spelling as a valid
+ * identity — the same consumer-side tolerance alias `ObjectGrid` retired in
+ * objectui#5068, surviving one layer up in the authoring tool, which is the
+ * surface that is supposed to teach the correct shape. A legacy column
+ * therefore shows an EMPTY field key and the author re-authors it
+ * (objectui#5344; objectui#5349's renderer diagnostic does the telling).
+ */
 function colFieldKey(c: ViewColumn): string {
-  return c.field ?? c.accessorKey ?? '';
+  return c.field ?? '';
 }
 
+/** The column's display label — canonical `label` only, same rule as above. */
 function colDisplayLabel(c: ViewColumn): string {
-  return c.label ?? c.header ?? colFieldKey(c);
+  return c.label ?? colFieldKey(c);
 }
 
 /** Does the object carry any detail prop beyond its identity keys? */


### PR DESCRIPTION
Fixes #5344

Implements **option D alone**, per the two ruling comments on the card (2026-08-22 02:25Z, completed later the same day when the maintainer answered the outstanding factual question — *is there a known population of pre-#4001 stored view documents carrying `accessorKey` columns?* — with 「无」).

## What changed

`ViewColumnInspector` read a column's identity through both vocabularies:

```
return c.field ?? c.accessorKey ?? '';          // field key
return c.label ?? c.header ?? colFieldKey(c);   // label
```

Both fallbacks are gone; the identity is now read as `field` / `label` only.

That is the same consumer-side tolerance alias `ObjectGrid` retired in #5068, surviving one layer up in the **authoring tool** — the surface that is supposed to teach the correct shape. `ListColumn` refuses both legacy keys by name, so a column carrying them has no field key the spec recognises, yet the inspector displayed `accessorKey`'s value in the field-key box as though it were a valid identity.

**A legacy `{accessorKey, header}` column now shows an empty field key and an empty header, and the author re-authors it.** Canonical `{field, label}` columns and bare-string columns are untouched.

## What is deliberately NOT changed

- **`patchIdentity`'s writeback.** It still re-emits whichever spelling it was handed; no stored document is rewritten by the act of editing it. Option A does not land.
- **`packages/core/src/utils/column-identity.ts`.** Its docblock is not amended — that obligation was attached to option A only, and D *agrees* with it, removing a cross-vocabulary read rather than adding one.
- **The closed loop.** A legacy column stays unsaveable against the spec before *and* after an edit. That is the ruled outcome, not an oversight; what this removes is its **invisibility**. #5349's renderer diagnostic is the surface that does the telling.

## `IDENTITY_KEYS` — measured, and left alone

The dispatch flagged `IDENTITY_KEYS` (which still lists `accessorKey` / `header`) as a possible internal inconsistency. Measured: **it is not one**, because neither of its two readers asks *"what is this column's identity?"*.

| reader | the question it answers | effect of the two legacy entries |
|---|---|---|
| `hasDetailProps` | would collapsing this object back to a bare string lose anything? | **Unreachable.** Its only call site is guarded by `wasString`, and `readColumn` maps a raw string to `{ field }` — nothing can put `accessorKey` on a string-origin column. Removing them would still change what `writeColumns` serializes, i.e. the write path this card fences out. |
| `hiddenFields` | which **spec-declared** properties does the curated layer already render, so the generic form must not double-render them? | **Inert.** `hiddenFields` filters the JSONSchema's own property list, measured as `["field","label","width","align","hidden","sortable","resizable","wrap","type","pinned","summary","prefix","link","action"]` — neither legacy key is in it, so those entries can never match. `hiddenFields` also never affects value preservation (`SchemaForm` spreads unknown keys through on change). |

Neither reader can display or produce an identity, so neither can present a refused spelling as a valid one — the ruling's observable requirement is satisfied by the identity read alone. The constant keeps its members, and its docblock now states why, so the next reader does not "finish the job" by touching the write path.

## Tests

`ViewColumnInspector.identityRead.test.tsx` mounts the **real component** and asserts what it displays, because the requirement is observable rather than type-level:

- legacy `{accessorKey, header}` → the field-key control is an empty text input, the header control is empty, and the phantom picker option the retired alias used to seed (`name (not in object)`) is gone;
- canonical `{field, label, width}` and a bare string `'name'` → unchanged, the controls that prove the instrument can show a value;
- the writeback still emits `{accessorKey: 'title', header: 'Name'}` — pinned so a later reader cannot quietly normalise on write;
- the spec verdicts behind the closed loop: legacy `false` before and after, canonical and bare-string `true` before and after.

**Reverse-verified**, and the direction was not the one predicted. Reverting only the source with the suite in place turns **3** tests red, not 1 — and only one of the three is the intended signal:

| test | pre-change failure | what it means |
|---|---|---|
| legacy shows an empty field key | `expected { widget: 'combobox', … } to deeply equal { widget: 'input', text: '' }` | the real signal — the alias seeded a picker option, so the control was a combobox showing `name (not in object)` |
| writeback pin | `expected "vi.fn()" to be called 1 times, but got 0 times` | an artifact of that same widget switch (`fireEvent.change` is inert on a combobox), **not** a writeback change — the writeback is identical either way |
| residue pin | `Found multiple elements with the text: Name` | pre-change the panel title read `header` as the label too |

Both non-signal rows now carry a comment saying so, so neither is misread as evidence the writeback moved.

## Out of scope, filed

The column **list** rendered inside this same panel still shows the legacy identity: `previews/view-column-io.ts` carries the same alias (`o.label ?? o.header ?? o.field ?? o.accessorKey`), and it feeds `FieldsListEditor`, which `ViewColumnInspector` renders. Outside this card's granted surface, so filed unassigned as #5725 — where it also records that the chain prefers `header` **over** `field`, and that `colFieldName` backs the Add-field picker's used-name set. The suite pins the boundary (`getAllByText('Name')` has length 1) with a comment marking the line to flip when that lands.

## Verification

Run on the final commit `726fed914`:

| gate | verdict |
|---|---|
| `pnpm exec vitest run <18-file superset>` | `Test Files 18 passed (18)` / `Tests 114 passed (114)` |
| `pnpm --filter @object-ui/app-shell type-check` | `TYPECHECK_EXIT=0`, 0 `error TS` (both `tsc --noEmit` and `tsconfig.test.json`) |
| `pnpm --filter @object-ui/app-shell lint` | `LINT_EXIT=0` |
| `check:control-bytes` | `✅ OK (scanned 4778 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `changeset:check` | `✅ No changeset declares a 'major' bump.` |
| `check:i18n-keys` / `check:i18n-drift` | every call-site key resolves; `No en value changed in this range.` |
| `check:spec-symbols`, `check:phantom-deps`, `check:self-import`, `lint:coverage`, `type-check:coverage` | all `✅` |

The 18-file test set is a **derived** superset, not a sample: `colFieldKey` / `colDisplayLabel` are module-private, `ViewColumnInspector` has exactly one importer (`ViewInspector`), and a reverse-import closure over `packages/app-shell/src` yields 17 test files reaching it, plus the new one. No test outside the package drives a column selection (checked across the 51 files importing the `@object-ui/app-shell` barrel), so nothing else can observe the change except through a module-load or type error, which `type-check` covers.

`check:eager-closure` was **not** run: it reads `apps/console/dist/eager-closure.json`, emitted by a full console `vite build`, and reports a broken gauge without one. The source diff adds **zero** module specifiers (verified — the only new imports are in a test file, which the console bundle never includes), so it has no eager-closure surface. CI runs it regardless.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_