### PR TITLE
fix(console): honour section-level and object-level conditional rules in FormPage (#5627)

### DIFF
--- a/.changeset/formpage-conditional-rule-surfaces-5627.md
+++ b/.changeset/formpage-conditional-rule-surfaces-5627.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/console': patch
+---
+
+`FormPage` — the console's own form renderer, serving both the public `/f/:slug`
+route and the internal `/forms/:name` one — now honours the three conditional-rule
+surfaces it still dropped after objectui#5594: section-level `visibleWhen` /
+`visibleOn`, and the object-level field rules `visibleWhen` / `readonlyWhen` /
+`requiredWhen` (objectui#5627).
+
+This is the second form renderer in the repo, and it honoured exactly one of the
+four surfaces the sibling chain does. A section an author conditioned away rendered
+in full — heading and every control — on both routes including the anonymous one.
+The object-level half was worse than fail-open hiding: `readonly` was whatever the
+static flag said, so a field a `readonlyWhen` should have locked stayed editable and
+paired with the server's fail-closed unbound-scope behaviour into "the user edits,
+the save reports success, and the value never lands".
+
+Both halves evaluate through the SHARED machinery rather than a fourth consumer-side
+copy of the rule semantics: `@object-ui/core`'s `resolveFieldRuleState` for the three
+field rules — which brings the settled rulings with it, including the `serverOwnedValue`
+carve-out that keeps a create form from requiring a producer-owned control (#4069 /
+#4085) — and its `evalFieldPredicate` for the section predicate, with the canonical-first
+`visibleWhen ?? visibleOn` read every sibling reader spells.
+
+Visibility stays a RENDERING rule at both granularities: a hidden section's fields
+still submit their values, exactly as a hidden field's have since #5594.

--- a/apps/console/src/components/FormPage.conditionalRules.test.tsx
+++ b/apps/console/src/components/FormPage.conditionalRules.test.tsx
@@ -1,0 +1,698 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5627 — this renderer honours the OTHER THREE conditional-rule
+ * surfaces: section-level `visibleWhen`/`visibleOn`, and the object-level field
+ * rules `visibleWhen`/`readonlyWhen`/`requiredWhen`.
+ *
+ * ## Why a second pin file next to `FormPage.visibleWhen.test.tsx`
+ *
+ * #5594 wired ONE of the four surfaces — the VIEW-level field predicate — and
+ * its pin lives in that file, which is the right shape: a pin belongs next to
+ * the renderer it describes, because a pin that cannot see the second copy is
+ * how the first gap survived (`FormPage.tsx` is the second form renderer in
+ * this repo, and objectui#2212's pin lives with the OTHER chain). These three
+ * surfaces are different keys with different consequences, so they get their
+ * own file rather than being folded into #5594's — the two read as one story
+ * only until one of them fails, and then the failure has to name which
+ * authoring surface stopped working.
+ *
+ * ## Everything here asserts RENDERED OUTPUT, deliberately
+ *
+ * Every failure mode in this card is invisible to `tsc` and to `eslint`: the
+ * types admit the keys either way (the section keys have been *declarable*
+ * since objectui#5596 without being evaluated), and the symptom is a section
+ * that draws in full when it should be gone, or an input that stays editable
+ * when a rule says lock it. So the assertions are on the DOM — presence,
+ * `toBeDisabled`, `toBeRequired`, the required marker inside the `label`
+ * element, and the POST body — never on an intermediate object, except in the
+ * final block, which pins the row-building step the DOM cases depend on.
+ *
+ * ## Reverse verification — MEASURED, not predicted
+ *
+ * See the PR body for the recorded run: `FormPage.tsx` reverted to its
+ * pre-#5627 state with this file left in place fails 19 of its 24 cases, and
+ * every red one fails by NAMING the defect (the conditioned-away section is on
+ * screen, the locked field is editable, the required marker is missing).
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { buildSections, FormPage, isSectionVisible, resolveRowState } from './FormPage';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+/**
+ * The object these forms target. `priority` carries a `defaultValue` so every
+ * predicate below binds its identifier CLEANLY: an unbound identifier is a
+ * predicate FAULT, which fails open, and a case that passed that way would be
+ * proving the fallback rather than the evaluation.
+ *
+ * Per-case rule keys are layered on top of this by {@link withRules}, because
+ * the whole point of the object-level half is that these rules are authored on
+ * the OBJECT's field — not on the form view.
+ */
+const BASE_SCHEMA = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: {
+    title: { type: 'text', label: 'Title' },
+    priority: { type: 'text', label: 'Priority', defaultValue: 'low' },
+    notes: { type: 'text', label: 'Notes' },
+    status: { type: 'text', label: 'Status' },
+    due_at: { type: 'text', label: 'Due at' },
+  } as Record<string, Record<string, unknown>>,
+};
+
+/** `BASE_SCHEMA` with extra keys merged onto named object FIELDS. */
+function withRules(rules: Record<string, Record<string, unknown>>) {
+  const fields: Record<string, Record<string, unknown>> = {};
+  for (const [name, def] of Object.entries(BASE_SCHEMA.fields)) {
+    fields[name] = { ...def, ...(rules[name] ?? {}) };
+  }
+  return { ...BASE_SCHEMA, fields };
+}
+
+/** Wrap sections in the `/meta/view/:name` envelope the internal route reads. */
+function viewEnvelope(sections: unknown[]) {
+  return {
+    name: 'showcase_task.edit',
+    object: 'showcase_task',
+    viewKind: 'form',
+    label: 'Task',
+    config: { type: 'simple', sections },
+  };
+}
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+let calls: Call[] = [];
+
+/** Answers per (method, url-substring); modelled on `FormPage.visibleWhen.test.tsx`. */
+function stubFetch(routes: Array<{ method?: string; match: string; body?: unknown }>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    calls.push({
+      url: String(url),
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    const route = routes.find(
+      (r) => (r.method ?? 'GET').toUpperCase() === method && String(url).includes(r.match),
+    );
+    if (!route) throw new Error(`unstubbed fetch: ${method} ${url}`);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => route.body,
+      text: async () => (route.body === undefined ? '' : JSON.stringify(route.body)),
+    } as unknown as Response;
+  });
+}
+
+const recordPath = (objectName: string, recordId: string) =>
+  `/apps/ai.objectstack.showcase/${objectName}/record/${recordId}`;
+
+interface RenderOpts {
+  objectSchema?: unknown;
+  query?: string;
+  extraRoutes?: Parameters<typeof stubFetch>[0];
+}
+
+/** Render the INTERNAL route (`/forms/:name`) over a given section list. */
+function renderInternal(sections: unknown[], opts: RenderOpts = {}) {
+  vi.stubGlobal(
+    'fetch',
+    stubFetch([
+      { match: '/meta/view/', body: viewEnvelope(sections) },
+      { match: '/meta/object/', body: opts.objectSchema ?? BASE_SCHEMA },
+      ...(opts.extraRoutes ?? []),
+    ]),
+  );
+  return render(
+    <MemoryRouter initialEntries={[`/forms/showcase_task.edit${opts.query ?? ''}`]}>
+      <Routes>
+        <Route path="/forms/:name" element={<FormPage mode="internal" recordPath={recordPath} />} />
+        <Route
+          path="/apps/:appName/:objectName/record/:recordId"
+          element={<div data-testid="record-page">record page</div>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** Render the PUBLIC route (`/f/:slug`) over a given section list. */
+function renderPublic(sections: unknown[], opts: RenderOpts = {}) {
+  vi.stubGlobal(
+    'fetch',
+    stubFetch([
+      {
+        match: '/forms/task-intake',
+        body: {
+          slug: 'task-intake',
+          object: 'showcase_task',
+          label: 'Task intake',
+          form: { type: 'simple', sections },
+          objectSchema: opts.objectSchema ?? BASE_SCHEMA,
+        },
+      },
+    ]),
+  );
+  return render(
+    <MemoryRouter initialEntries={['/f/task-intake']}>
+      <Routes>
+        <Route path="/f/:slug" element={<FormPage mode="public" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** Wait for the form to be on screen — every case needs the load to settle. */
+async function awaitForm() {
+  await waitFor(() => expect(screen.getByLabelText('Priority')).toBeInTheDocument());
+}
+
+/**
+ * The `label` element bound to a control, so the REQUIRED MARKER can be read
+ * off the rendered output. `getByLabelText` cannot serve here: the marker is
+ * inside the label, so a required field's accessible name is `Notes*` and an
+ * exact-string query for `Notes` stops matching the moment the assertion
+ * matters — the query would pass or fail for the wrong reason.
+ */
+function labelFor(container: HTMLElement, name: string): HTMLElement {
+  const el = container.querySelector(`label[for="f_${name}"]`);
+  if (!el) throw new Error(`no label rendered for field '${name}'`);
+  return el as HTMLElement;
+}
+
+/** The control itself, by the id `FieldInput` gives it. */
+function controlFor(container: HTMLElement, name: string): HTMLElement {
+  const el = container.querySelector(`#f_${name}`);
+  if (!el) throw new Error(`no control rendered for field '${name}'`);
+  return el as HTMLElement;
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ─── 1. Section-level visibility (ADR-0089) ──────────────────────────────
+
+describe('objectui#5627 — FormPage evaluates SECTION-level visibility', () => {
+  it('hides a section whose predicate is false, and keeps one whose predicate is true', async () => {
+    renderInternal([
+      { label: 'Basics', fields: ['priority'] },
+      { label: 'Escalation', visibleWhen: "record.priority == 'urgent'", fields: ['notes'] },
+      { label: 'Triage', visibleWhen: "record.priority == 'low'", fields: ['status'] },
+    ]);
+    await awaitForm();
+
+    // `priority` starts at its schema default, 'low'. The section itself is
+    // gone — heading and fields both, which is what distinguishes a section
+    // rule from a field rule applied to each of its members.
+    expect(screen.queryByText('Escalation')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+    expect(screen.getByText('Triage')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+  });
+
+  it('honours the deprecated ADR-0089 alias `visibleOn` on a section', async () => {
+    // The spec normaliser rewrites the alias, so a spec-served view never
+    // carries it — but hand-written layouts and this app's own create schemas
+    // still do, which is why every sibling reader keeps reading it.
+    renderInternal([
+      { label: 'Basics', fields: ['priority'] },
+      { label: 'Escalation', visibleOn: "record.priority == 'urgent'", fields: ['notes'] },
+    ]);
+    await awaitForm();
+    expect(screen.queryByText('Escalation')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+  });
+
+  it('lets the canonical `visibleWhen` win when a section authors both spellings', async () => {
+    // The two predicates disagree on purpose: only the canonical one's verdict
+    // can produce this outcome.
+    renderInternal([
+      { label: 'Basics', fields: ['priority'] },
+      {
+        label: 'Escalation',
+        visibleWhen: "record.priority == 'urgent'", // false -> hidden
+        visibleOn: "record.priority == 'low'", // true -> would show
+        fields: ['notes'],
+      },
+    ]);
+    await awaitForm();
+    expect(screen.queryByText('Escalation')).not.toBeInTheDocument();
+  });
+
+  it('honours the { dialect, source } wire shape on a section', async () => {
+    renderInternal([
+      { label: 'Basics', fields: ['priority'] },
+      {
+        label: 'Escalation',
+        visibleWhen: { dialect: 'cel', source: "record.priority == 'urgent'" },
+        fields: ['notes'],
+      },
+    ]);
+    await awaitForm();
+    expect(screen.queryByText('Escalation')).not.toBeInTheDocument();
+  });
+
+  it('re-evaluates the section predicate against the LIVE values as the user types', async () => {
+    const user = userEvent.setup();
+    renderInternal([
+      { label: 'Basics', fields: ['priority'] },
+      { label: 'Escalation', visibleWhen: "record.priority == 'urgent'", fields: ['notes'] },
+    ]);
+    await awaitForm();
+    expect(screen.queryByText('Escalation')).not.toBeInTheDocument();
+
+    const priority = screen.getByLabelText('Priority');
+    await user.clear(priority);
+    await user.type(priority, 'urgent');
+    await waitFor(() => expect(screen.getByText('Escalation')).toBeInTheDocument());
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+
+    // …and back again, so this pins an evaluation and not a one-way reveal.
+    await user.clear(screen.getByLabelText('Priority'));
+    await user.type(screen.getByLabelText('Priority'), 'low');
+    await waitFor(() => expect(screen.queryByText('Escalation')).not.toBeInTheDocument());
+  });
+
+  it('binds `previous.*` in a section predicate on an edit form', async () => {
+    renderInternal(
+      [
+        { label: 'Basics', fields: ['priority'] },
+        { label: 'Archive', visibleWhen: "previous.status == 'archived'", fields: ['notes'] },
+        { label: 'Open work', visibleWhen: "previous.status == 'open'", fields: ['status'] },
+      ],
+      {
+        query: '?recordId=task-42',
+        extraRoutes: [
+          {
+            match: '/data/showcase_task/task-42',
+            body: {
+              object: 'showcase_task',
+              id: 'task-42',
+              record: { id: 'task-42', priority: 'urgent', status: 'open' },
+            },
+          },
+        ],
+      },
+    );
+    await awaitForm();
+    expect(screen.queryByText('Archive')).not.toBeInTheDocument();
+    expect(screen.getByText('Open work')).toBeInTheDocument();
+  });
+
+  it('honours a section predicate on the PUBLIC /f/:slug route too', async () => {
+    // The user-reachable half of the card: this route is served to anonymous
+    // visitors, so a section an author conditioned away was being shown in full
+    // to strangers.
+    renderPublic([
+      { label: 'Basics', fields: ['priority'] },
+      { label: 'Internal only', visibleWhen: "record.priority == 'urgent'", fields: ['notes'] },
+    ]);
+    await awaitForm();
+    expect(screen.queryByText('Internal only')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+  });
+
+  it('RULING PIN: a section hidden by its predicate still SUBMITS its fields', async () => {
+    // Triage first-touch, 2026-08-22, quoted: "Section-level visibility is a
+    // rendering rule — a hidden section's fields still submit, matching the
+    // field-level answer #5594 deliberately kept and the plugin-form chain."
+    // A positive assertion on the POST body, not an absence: the ruling is that
+    // the value TRAVELS, so only reading it back off the payload can pin it.
+    const user = userEvent.setup();
+    renderInternal(
+      [
+        { label: 'Basics', fields: ['priority'] },
+        { label: 'Escalation', visibleWhen: "record.priority == 'urgent'", fields: ['notes'] },
+      ],
+      {
+        query: '?prefill_notes=carried',
+        extraRoutes: [
+          { method: 'POST', match: '/data/showcase_task', body: { object: 'showcase_task', id: 'new-1' } },
+        ],
+      },
+    );
+    await awaitForm();
+    expect(screen.queryByText('Escalation')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await waitFor(() => expect(calls.some((c) => c.method === 'POST')).toBe(true));
+    const post = calls.find((c) => c.method === 'POST')!;
+    expect((post.body as Record<string, unknown>).notes).toBe('carried');
+  });
+
+  it('CONTROL: a section with no predicate at all still renders', async () => {
+    // Without this, every "not.toBeInTheDocument" above is equally satisfied by
+    // a renderer that draws no sections.
+    renderInternal([
+      { label: 'Basics', fields: ['priority'] },
+      { label: 'Escalation', fields: ['notes'] },
+    ]);
+    await awaitForm();
+    expect(screen.getByText('Escalation')).toBeInTheDocument();
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument();
+  });
+
+  it('CONTROL: a broken section predicate fails OPEN, loudly', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    renderInternal([
+      { label: 'Basics', fields: ['priority'] },
+      { label: 'Escalation', visibleWhen: 'record.priority ===', fields: ['notes'] },
+    ]);
+    await awaitForm();
+
+    // Open: an unevaluable predicate must never hide a section — that is a
+    // whole group of controls the submitter can neither fill in nor see missing.
+    expect(screen.getByText('Escalation')).toBeInTheDocument();
+    // Loud: the shared engine warns once per predicate text, and the locator
+    // names the SECTION, which is what an author can find in their metadata.
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.flat().join(' ')).toContain("visibleWhen of section 'Escalation'");
+  });
+});
+
+// ─── 2. Object-level field rules (ADR-0036) ──────────────────────────────
+
+describe('objectui#5627 — FormPage evaluates OBJECT-level field rules', () => {
+  it('hides a field whose OBJECT-level visibleWhen is false, shows one whose is true', async () => {
+    renderInternal([{ label: 'Basics', fields: ['priority', 'notes', 'status'] }], {
+      objectSchema: withRules({
+        notes: { visibleWhen: "record.priority == 'urgent'" },
+        status: { visibleWhen: "record.priority == 'low'" },
+      }),
+    });
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+  });
+
+  it('LOCKS a field whose readonlyWhen is true, and leaves it editable when false', async () => {
+    // The severity anchor of this card: an un-honoured `readonlyWhen` leaves a
+    // control editable that the server will refuse to write, so "the user
+    // edits, the save reports success, and the value never lands".
+    const { container } = renderInternal([{ label: 'Basics', fields: ['priority', 'notes', 'status'] }], {
+      objectSchema: withRules({
+        notes: { readonlyWhen: "record.priority == 'low'" }, // true  -> locked
+        status: { readonlyWhen: "record.priority == 'urgent'" }, // false -> editable
+      }),
+    });
+    await awaitForm();
+    expect(controlFor(container, 'notes')).toBeDisabled();
+    expect(controlFor(container, 'status')).not.toBeDisabled();
+  });
+
+  it('re-evaluates readonlyWhen against the LIVE values as the user types', async () => {
+    const user = userEvent.setup();
+    const { container } = renderInternal([{ label: 'Basics', fields: ['priority', 'notes'] }], {
+      objectSchema: withRules({ notes: { readonlyWhen: "record.priority == 'urgent'" } }),
+    });
+    await awaitForm();
+    expect(controlFor(container, 'notes')).not.toBeDisabled();
+
+    const priority = screen.getByLabelText('Priority');
+    await user.clear(priority);
+    await user.type(priority, 'urgent');
+    await waitFor(() => expect(controlFor(container, 'notes')).toBeDisabled());
+  });
+
+  it('REQUIRES a field whose requiredWhen is true — marker and control agree', async () => {
+    const { container } = renderInternal([{ label: 'Basics', fields: ['priority', 'notes', 'status'] }], {
+      objectSchema: withRules({
+        notes: { requiredWhen: "record.priority == 'low'" }, // true
+        status: { requiredWhen: "record.priority == 'urgent'" }, // false
+      }),
+    });
+    await awaitForm();
+    // ONE verdict reaches both the control and the marker beside it — the
+    // two-layer disagreement objectui#4201 removed on the sibling chain.
+    expect(controlFor(container, 'notes')).toBeRequired();
+    expect(labelFor(container, 'notes').textContent).toContain('*');
+    expect(controlFor(container, 'status')).not.toBeRequired();
+    expect(labelFor(container, 'status').textContent).not.toContain('*');
+  });
+
+  it('honours the OBJECT-level rules on the PUBLIC /f/:slug route too', async () => {
+    const { container } = renderPublic([{ label: 'Basics', fields: ['priority', 'notes', 'status'] }], {
+      objectSchema: withRules({
+        notes: { readonlyWhen: "record.priority == 'low'" },
+        status: { visibleWhen: "record.priority == 'urgent'" },
+      }),
+    });
+    await awaitForm();
+    expect(controlFor(container, 'notes')).toBeDisabled();
+    expect(screen.queryByLabelText('Status')).not.toBeInTheDocument();
+  });
+
+  it('ANDs the two visibility LAYERS — a view predicate cannot re-show what the object rule hid', async () => {
+    // The layering the sibling chain keeps on purpose (`sectionFields.ts`
+    // routes the view predicate into `visibleOn` "so the object rule is never
+    // clobbered"). Collapsing them with a `??` would make either of these two
+    // rows appear.
+    renderInternal(
+      [
+        {
+          label: 'Basics',
+          fields: [
+            'priority',
+            // view TRUE over object FALSE -> still hidden
+            { field: 'notes', visibleWhen: "record.priority == 'low'" },
+            // view FALSE over object TRUE -> still hidden
+            { field: 'status', visibleWhen: "record.priority == 'urgent'" },
+            // both true -> shown, so this is not a renderer that hides everything
+            { field: 'title', visibleWhen: "record.priority == 'low'" },
+          ],
+        },
+      ],
+      {
+        objectSchema: withRules({
+          notes: { visibleWhen: "record.priority == 'urgent'" },
+          status: { visibleWhen: "record.priority == 'low'" },
+          title: { visibleWhen: "record.priority == 'low'" },
+        }),
+      },
+    );
+    await awaitForm();
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Status')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+  });
+
+  it('CONTROL: a static readonly is not weakened by a readonlyWhen that resolves false', async () => {
+    // `resolveFieldRuleState`'s rule, inherited rather than re-derived: a rule
+    // may only ADD a lock. A renderer that replaced the static flag with the
+    // predicate's verdict would unlock this field.
+    const { container } = renderInternal(
+      [{ label: 'Basics', fields: ['priority', { field: 'notes', readonly: true }] }],
+      { objectSchema: withRules({ notes: { readonlyWhen: "record.priority == 'urgent'" } }) },
+    );
+    await awaitForm();
+    expect(controlFor(container, 'notes')).toBeDisabled();
+  });
+
+  it('CONTROL: a field with no object rules at all renders editable and optional', async () => {
+    const { container } = renderInternal([{ label: 'Basics', fields: ['priority', 'notes'] }]);
+    await awaitForm();
+    expect(controlFor(container, 'notes')).not.toBeDisabled();
+    expect(controlFor(container, 'notes')).not.toBeRequired();
+    expect(labelFor(container, 'notes').textContent).not.toContain('*');
+  });
+});
+
+// ─── 3. The `serverOwnedValue` carve-out (ruled: reuse, do not re-derive) ─
+
+describe('objectui#5627 — requiredWhen takes the serverOwnedValue carve-out', () => {
+  const SERVER_OWNED = withRules({
+    due_at: { defaultValue: 'NOW()', requiredWhen: "record.priority == 'low'" },
+  });
+
+  it('does NOT require a server-owned field on a CREATE form, though requiredWhen is true', async () => {
+    // #4069 / #4085, applied by `resolveFieldRuleState` itself: a create form
+    // leaves a producer-owned control empty so the server resolves the declared
+    // runtime default, and nothing the client evaluates may then declare it
+    // required — there would be nothing the user could type to unblock.
+    const { container } = renderInternal([{ label: 'Basics', fields: ['priority', 'due_at'] }], {
+      objectSchema: SERVER_OWNED,
+    });
+    await awaitForm();
+    expect(controlFor(container, 'due_at')).not.toBeRequired();
+    expect(labelFor(container, 'due_at').textContent).not.toContain('*');
+  });
+
+  it('DOES require the same field on an EDIT form — the carve-out is create-only', async () => {
+    // The control for the case above: without it, "not required" would be
+    // equally satisfied by a renderer that never honours `requiredWhen` at all,
+    // which is precisely the pre-#5627 behaviour.
+    const { container } = renderInternal([{ label: 'Basics', fields: ['priority', 'due_at'] }], {
+      objectSchema: SERVER_OWNED,
+      query: '?recordId=task-42',
+      extraRoutes: [
+        {
+          match: '/data/showcase_task/task-42',
+          body: {
+            object: 'showcase_task',
+            id: 'task-42',
+            record: { id: 'task-42', priority: 'low', due_at: '2026-01-01' },
+          },
+        },
+      ],
+    });
+    await awaitForm();
+    expect(controlFor(container, 'due_at')).toBeRequired();
+    expect(labelFor(container, 'due_at').textContent).toContain('*');
+  });
+});
+
+// ─── 4. The row-building step the DOM cases stand on ─────────────────────
+
+describe('objectui#5627 — the keys reach the rows, in their own slots', () => {
+  it('buildSections carries the SECTION predicate onto the row, canonical first', () => {
+    const sections = buildSections(
+      {
+        sections: [
+          { label: 'a', visibleWhen: 'record.x == 1', fields: ['f'] },
+          { label: 'b', visibleOn: { dialect: 'cel', source: 'record.x == 2' }, fields: ['f'] },
+          { label: 'c', visibleWhen: 'record.x == 3', visibleOn: 'record.x == 4', fields: ['f'] },
+          { label: 'd', fields: ['f'] },
+        ],
+      },
+      null,
+    );
+
+    expect(sections.map((s) => s.visibleWhen)).toEqual([
+      'record.x == 1',
+      { dialect: 'cel', source: 'record.x == 2' },
+      'record.x == 3',
+      undefined,
+    ]);
+  });
+
+  it('buildSections carries the OBJECT rules into `rules`, without collapsing the view slot', () => {
+    const [section] = buildSections(
+      {
+        sections: [
+          {
+            fields: [
+              'a',
+              { field: 'b', visibleWhen: 'view.predicate' },
+              { field: 'c' },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'o',
+        fields: {
+          a: {
+            type: 'text',
+            visibleWhen: 'object.visible',
+            readonlyWhen: 'object.readonly',
+            requiredWhen: 'object.required',
+          },
+          b: { type: 'text', visibleWhen: 'object.visible' },
+          c: { type: 'text' },
+        },
+      },
+    );
+
+    expect(section.fields[0].rules).toEqual({
+      visibleWhen: 'object.visible',
+      readonlyWhen: 'object.readonly',
+      requiredWhen: 'object.required',
+    });
+    // Two slots, two layers: the view predicate stays where #5594 put it and
+    // the object rule keeps its own. A `??` merge would leave one of these two
+    // holding the other's predicate.
+    expect(section.fields[1].visibleWhen).toBe('view.predicate');
+    expect(section.fields[1].rules?.visibleWhen).toBe('object.visible');
+    expect(section.fields[2].visibleWhen).toBeUndefined();
+    expect(section.fields[2].rules).toEqual({
+      visibleWhen: undefined,
+      readonlyWhen: undefined,
+      requiredWhen: undefined,
+    });
+  });
+
+  it('isSectionVisible answers the predicate, and fails open on a broken one', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sections = buildSections(
+      {
+        sections: [
+          { label: 'plain', fields: ['f'] },
+          { label: 'cond', visibleWhen: "record.k == 'y'", fields: ['f'] },
+          { label: 'broken', visibleWhen: 'record.k ===', fields: ['f'] },
+        ],
+      },
+      null,
+    );
+    const [plain, cond, broken] = sections;
+
+    expect(isSectionVisible(plain, {})).toBe(true);
+    expect(isSectionVisible(cond, { k: 'y' })).toBe(true);
+    expect(isSectionVisible(cond, { k: 'n' })).toBe(false);
+    expect(isSectionVisible(broken, { k: 'n' })).toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('resolveRowState folds both visibility layers and both static flags into one verdict', () => {
+    const [section] = buildSections(
+      {
+        sections: [
+          {
+            fields: [
+              { field: 'plain' },
+              { field: 'viewHidden', visibleWhen: "record.k == 'y'" },
+              { field: 'objectHidden' },
+              { field: 'locked' },
+              { field: 'needed' },
+              { field: 'owned' },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'o',
+        fields: {
+          objectHidden: { type: 'text', visibleWhen: "record.k == 'y'" },
+          locked: { type: 'text', readonlyWhen: "record.k == 'n'" },
+          needed: { type: 'text', requiredWhen: "record.k == 'n'" },
+          owned: { type: 'text', defaultValue: 'NOW()', requiredWhen: "record.k == 'n'" },
+        },
+      },
+    );
+    const byName = Object.fromEntries(section.fields.map((f) => [f.name, f]));
+    const values = { k: 'n' };
+    const isCreate = true;
+
+    expect(resolveRowState(byName.plain, values, null, isCreate)).toEqual({
+      visible: true,
+      readonly: false,
+      required: false,
+    });
+    expect(resolveRowState(byName.viewHidden, values, null, isCreate).visible).toBe(false);
+    expect(resolveRowState(byName.objectHidden, values, null, isCreate).visible).toBe(false);
+    expect(resolveRowState(byName.locked, values, null, isCreate).readonly).toBe(true);
+    expect(resolveRowState(byName.needed, values, null, isCreate).required).toBe(true);
+    // Create + runtime default -> the carve-out wins over the true predicate;
+    // the SAME row on an edit form is required.
+    expect(resolveRowState(byName.owned, values, null, true).required).toBe(false);
+    expect(resolveRowState(byName.owned, values, {}, false).required).toBe(true);
+  });
+});

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -66,13 +66,43 @@
  * The wiring is #2212's ruling applied verbatim, not a second semantics: see
  * {@link isFieldVisible} for the engine, the bound scope, and what the fix
  * deliberately does not change.
+ *
+ * ## The other three conditional-rule surfaces (objectui#5627)
+ *
+ * #5594 wired ONE of the four surfaces the sibling chain honours — the
+ * view-level field predicate. The other three were dropped in the same place
+ * and for the same reason: nothing downstream could read a key this file's
+ * payload types did not admit.
+ *
+ *  - SECTION-level `visibleWhen` / `visibleOn` (ADR-0089). The section type is
+ *    no longer this file's to widen — objectui#5596 replaced the hand copy with
+ *    the shared `FormSectionSpec`, which has DECLARED these two keys ever since
+ *    ("declaring a key is not honouring it", as that type's own docstring says
+ *    while naming this card). What was missing here was the evaluation, and the
+ *    render mapped every section unconditionally. See {@link isSectionVisible}.
+ *  - OBJECT-level `visibleWhen` / `readonlyWhen` / `requiredWhen` (ADR-0036),
+ *    authored on the object's field rather than on the form view. This file's
+ *    own `ObjectFieldDef` admitted none of them, so `readonly` and `required`
+ *    were whatever the static flags said. See {@link resolveRowState}, which
+ *    resolves them through the SHARED `resolveFieldRuleState` rather than
+ *    re-deriving what the three rules mean for a fourth time.
+ *
+ * Both halves are RENDERING rules: a hidden section's fields still submit their
+ * values, exactly as a hidden field's do (triage ruling, 2026-08-22, following
+ * #5594 and the plugin-form chain). Nothing in this file makes visibility a
+ * submit-payload rule, at either granularity.
  */
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
-import { evalFieldPredicate } from '@object-ui/core';
-import type { FormFieldSpec, FormViewSpec } from '@object-ui/app-shell';
+import {
+  evalFieldPredicate,
+  isServerOwnedValue,
+  resolveFieldRuleState,
+  type FieldRulePredicate,
+} from '@object-ui/core';
+import type { FormFieldSpec, FormSectionSpec, FormViewSpec } from '@object-ui/app-shell';
 import { resolveSubmitRedirect } from './submitRedirect';
 
 const API_BASE = (import.meta.env.VITE_SERVER_URL || '') + '/api/v1';
@@ -101,6 +131,29 @@ interface ObjectFieldDef {
   options?: Array<{ value: string; label?: string }> | string[];
   placeholder?: string;
   helpText?: string;
+  /**
+   * The OBJECT-level conditional rules (ADR-0036), authored on the object's
+   * field rather than on a form view — a DIFFERENT slot from the view-level
+   * predicate {@link RenderableField.visibleWhen} carries (objectui#5627).
+   *
+   * The sibling chain keeps the two apart on purpose: `@object-ui/plugin-form`
+   * `sectionFields.ts` copies these three straight off the object field and
+   * routes the VIEW predicate into `visibleOn` "so the object rule is never
+   * clobbered", and `@object-ui/components` `renderers/form/form.tsx` then
+   * evaluates the two slots independently and ANDs them. This file admitted
+   * neither of them until #5627, so `buildSections` could not read what it was
+   * never handed: `readonly` was `override.readonly ?? false` and `required`
+   * was `override.required ?? def.required ?? false` — static, never
+   * conditional, on both routes including the anonymous `/f/:slug` one.
+   *
+   * Typed as `@object-ui/core`'s own {@link FieldRulePredicate} rather than
+   * re-spelled, because that is the parameter type of `resolveFieldRuleState`,
+   * the engine every one of these predicates is handed to. (The view-level slot
+   * derives its type from `FormFieldSpec` for the same reason, one layer up.)
+   */
+  visibleWhen?: FieldRulePredicate;
+  readonlyWhen?: FieldRulePredicate;
+  requiredWhen?: FieldRulePredicate;
 }
 
 /** Visualization types the form renderer understands (FormViewSpec.type). */
@@ -320,9 +373,14 @@ interface RenderableField {
   readonly: boolean;
   hidden: boolean;
   /**
-   * Conditional visibility for this row — the predicate {@link isFieldVisible}
-   * evaluates against the LIVE form values, as distinct from the static
-   * `hidden` flag above.
+   * Conditional visibility for this row, as authored on the FORM VIEW's field
+   * — the predicate {@link isFieldVisible} evaluates against the LIVE form
+   * values, as distinct from the static `hidden` flag above.
+   *
+   * The VIEW level, specifically: the object field's own `visibleWhen` is a
+   * separate rule that lives in {@link RenderableField.rules} and is ANDed with
+   * this one by {@link resolveRowState} (objectui#5627). Two layers may both
+   * condition one control, and either one hiding it is enough.
    *
    * Resolved CANONICAL-FIRST when the row is built: `visibleWhen ?? visibleOn`.
    * ADR-0089 renamed the key, and `@objectstack/spec`'s normaliser REWRITES the
@@ -340,6 +398,29 @@ interface RenderableField {
    * in this file.
    */
   visibleWhen?: FormFieldSpec['visibleWhen'];
+  /**
+   * The OBJECT-level rules (ADR-0036) copied off {@link ObjectFieldDef} —
+   * `visibleWhen`, `readonlyWhen`, `requiredWhen` (objectui#5627).
+   *
+   * Carried as a GROUP rather than as three sibling keys because the group IS
+   * `resolveFieldRuleState`'s first parameter: {@link resolveRowState} hands
+   * this object over whole, so there is no per-key re-assembly step for a
+   * fourth consumer-side copy of the rule semantics to hide in. Nesting also
+   * settles the one genuine ambiguity in this row type — `visibleWhen` one
+   * level up is the VIEW's predicate, `rules.visibleWhen` is the OBJECT's, and
+   * the sibling chain's runtime `FormField` happens to spell that same pair the
+   * other way round (`visibleWhen` = object, `visibleOn` = view). A reader of
+   * either file can tell which layer a predicate came from without knowing the
+   * other file's convention.
+   *
+   * Carried, not evaluated, for the reason the view-level slot is: the verdict
+   * depends on the live values, and these rows are memoized on the loaded spec.
+   */
+  rules?: {
+    visibleWhen?: FieldRulePredicate;
+    readonlyWhen?: FieldRulePredicate;
+    requiredWhen?: FieldRulePredicate;
+  };
   placeholder?: string;
   helpText?: string;
   defaultValue?: unknown;
@@ -353,6 +434,26 @@ interface RenderableSection {
   columns: 1 | 2 | 3 | 4;
   collapsible: boolean;
   collapsed: boolean;
+  /**
+   * Conditional visibility for the whole section (ADR-0089), resolved
+   * CANONICAL-FIRST when the row is built: `visibleWhen ?? visibleOn`
+   * (objectui#5627).
+   *
+   * The same key, the same precedence and the same reason as the field row one
+   * type up — the spec's normaliser rewrites the alias, so a spec-served
+   * FormView carries only `visibleWhen`, while hand-written layouts and this
+   * app's own create schemas still produce the deprecated spelling. app-shell's
+   * `SchemaForm` reads its sections through a `readVisibility` helper spelling
+   * exactly this `??`; that helper is module-private there (it is not part of
+   * `@object-ui/app-shell`'s published surface), so the shared machinery this
+   * file can actually import is the ENGINE — `evalFieldPredicate`, via
+   * {@link isSectionVisible} — which is the half that decides anything.
+   *
+   * Type derived from the shared authoring surface (objectui#5596's
+   * {@link FormSectionSpec}) rather than restated, exactly as the field row
+   * derives its own from `FormFieldSpec`.
+   */
+  visibleWhen?: FormSectionSpec['visibleWhen'];
   fields: RenderableField[];
 }
 
@@ -410,6 +511,16 @@ export function buildSections(
         // depends on the live form values, which change per keystroke, while
         // these rows are memoized on the loaded spec.
         visibleWhen: override.visibleWhen ?? override.visibleOn,
+        // The OBJECT's own rules (ADR-0036), off the object field and NOT
+        // merged with the view predicate above: two layers, two slots, ANDed
+        // at render by `resolveRowState` (objectui#5627). A `??` here would be
+        // the collapse the sibling chain avoids on purpose — a view predicate
+        // would then clobber the object's rule instead of narrowing it.
+        rules: {
+          visibleWhen: def.visibleWhen,
+          readonlyWhen: def.readonlyWhen,
+          requiredWhen: def.requiredWhen,
+        },
         placeholder: override.placeholder ?? def.placeholder,
         helpText: override.helpText ?? def.helpText,
         defaultValue: def.defaultValue,
@@ -430,6 +541,9 @@ export function buildSections(
       columns: cols,
       collapsible: !!sec.collapsible,
       collapsed: !!sec.collapsed,
+      // Canonical key wins over the deprecated alias, same precedence as the
+      // field row — see `RenderableSection.visibleWhen` (objectui#5627).
+      visibleWhen: sec.visibleWhen ?? sec.visibleOn,
       fields,
     };
   });
@@ -489,6 +603,120 @@ export function isFieldVisible(
     // name in a warning would be bookkeeping, not an honoured key.
     context: `visibleWhen of field '${field.name}'`,
   });
+}
+
+/**
+ * Is this SECTION on screen, given the form's current state? (objectui#5627)
+ *
+ * The section-granularity twin of {@link isFieldVisible}, and deliberately the
+ * same three things: the canonical-first key read (done once, at build time —
+ * `RenderableSection.visibleWhen`), the canonical ENGINE
+ * (`evalFieldPredicate`), and fail-OPEN with a one-time warning. A section that
+ * cannot be evaluated must not vanish, for the field-level reason multiplied by
+ * however many controls it holds: a section nobody can see is one the submitter
+ * can neither fill in nor notice is missing.
+ *
+ * Scope is the same pair the field predicate binds — live `record.*`, stored
+ * `previous.*` — so an author writes ONE dialect for both granularities, and
+ * `SECTION.visibleWhen` and `FIELD.visibleWhen` cannot disagree about what
+ * `record.status` refers to.
+ *
+ * ## Rendering rule, ruled (triage first-touch, 2026-08-22)
+ *
+ * > Section-level visibility is a rendering rule — a hidden section's fields
+ * > still submit, matching the field-level answer #5594 deliberately kept and
+ * > the plugin-form chain.
+ *
+ * So this decides what is DRAWN and nothing else: `values` still carries what
+ * {@link readPrefill} seeded and `handleSubmit` still submits it, exactly as a
+ * field hidden by its own predicate has done here since #5594.
+ */
+export function isSectionVisible(
+  section: RenderableSection,
+  values: Record<string, unknown>,
+  previous?: Record<string, unknown> | null,
+): boolean {
+  return evalFieldPredicate(section.visibleWhen, values, true, previous ?? undefined, undefined, {
+    // Sections have no `name`, so the locator is the heading an author can
+    // actually find in their own metadata; an unlabelled section says so
+    // rather than printing `undefined`.
+    context: `visibleWhen of section '${section.label ?? '(unlabelled)'}'`,
+  });
+}
+
+/**
+ * The row's EFFECTIVE `{ visible, readonly, required }` — every conditional
+ * rule that bears on one control, resolved in one place (objectui#5627).
+ *
+ * Three of the four inputs are the OBJECT-level rules (`rules.visibleWhen`,
+ * `readonlyWhen`, `requiredWhen`) and they are not evaluated here at all: they
+ * go to `@object-ui/core`'s `resolveFieldRuleState`, the engine the sibling
+ * renderers (`renderers/form/form.tsx`, `WizardForm`, `GridField`,
+ * `plugin-kanban`) already share. That reuse is the point of the card — a
+ * FOURTH consumer-side re-implementation of "what does readonlyWhen mean" is
+ * the defect, not the fix — and it is what carries three settled rulings in
+ * without re-deriving any of them: a static `readonly: true` is never weakened
+ * by a false predicate, a static `required: true` is never weakened by a false
+ * one either, and `serverOwnedValue` outranks both spellings of required.
+ *
+ * ## `isCreateForm` is the CALLER's fact
+ *
+ * `resolveFieldRuleState` must be told whether this submit is an INSERT; it may
+ * not infer it (objectui#4085 — an evaluator guessing from a missing `previous`
+ * would read an edit form that simply passes none as a create). This renderer
+ * knows it exactly, from the URL: {@link readFormRecordTarget} already decided
+ * create / edit / refuse, and `/f/:slug` is create by construction. Passed as a
+ * required parameter rather than defaulted, so a new call site cannot get edit
+ * semantics by omission.
+ *
+ * On a create form a field whose `defaultValue` is a runtime instruction the
+ * server resolves per insert (`NOW()`, `current_user`, a CEL envelope) is
+ * therefore not required — whatever `requiredWhen` evaluates to (#4085) and
+ * whatever the static flag says (#4069). Both halves come from the resolver,
+ * not from a carve-out re-derived here; `isServerOwnedValue` is likewise the
+ * shared classifier, handed the declared default this row already carries.
+ *
+ * ## The two visibility LAYERS are ANDed, never collapsed
+ *
+ * A view-level predicate ({@link isFieldVisible}) and an object-level one
+ * (`rules.visibleWhen`) are different authoring slots with different owners,
+ * and the sibling chain keeps them separate for exactly that reason. Either
+ * one resolving false hides the control; neither can re-show what the other
+ * hid. Both are evaluated on every call even when the first has already
+ * decided, because the warning a broken predicate emits is the author's ONLY
+ * diagnostic — short-circuiting would make a typo in one layer invisible
+ * whenever the other happened to hide the row.
+ */
+export function resolveRowState(
+  field: RenderableField,
+  values: Record<string, unknown>,
+  previous: Record<string, unknown> | null | undefined,
+  isCreateForm: boolean,
+): { visible: boolean; readonly: boolean; required: boolean } {
+  const ruleState = resolveFieldRuleState(
+    field.rules ?? {},
+    values,
+    {
+      required: field.required,
+      readonly: field.readonly,
+      serverOwnedValue: isServerOwnedValue(
+        // The shape that classifier reads — the resolved object-field metadata
+        // and its declared default, which is what `def.defaultValue` already
+        // put on this row in `buildSections`.
+        { field: { defaultValue: field.defaultValue } },
+        isCreateForm,
+      ),
+    },
+    previous ?? undefined,
+    undefined,
+    `field '${field.name}'`,
+  );
+  const viewVisible = isFieldVisible(field, values, previous);
+  return {
+    visible: ruleState.visible && viewVisible,
+    readonly: ruleState.readonly,
+    required: ruleState.required,
+  };
 }
 
 /**
@@ -956,16 +1184,29 @@ const FIELD_CLASS =
 
 interface FieldInputProps {
   field: RenderableField;
+  /**
+   * The row's EFFECTIVE required/readonly verdict for the CURRENT values, from
+   * {@link resolveRowState} — never the static flags on `field` (objectui#5627).
+   *
+   * A prop rather than a read of `field.required` / `field.readonly`, because
+   * those two are now only INPUTS to the verdict: an object-level `readonlyWhen`
+   * can lock a statically-editable field and a `requiredWhen` can require a
+   * statically-optional one. Taking it as a parameter is what makes the control
+   * and the asterisk beside it read ONE verdict — the two-layer disagreement
+   * objectui#4201 removed on the sibling chain, where a field showed no marker
+   * and the submit was refused anyway.
+   */
+  state: { readonly: boolean; required: boolean };
   value: unknown;
   onChange: (v: unknown) => void;
 }
 
-function FieldInput({ field, value, onChange }: FieldInputProps) {
+function FieldInput({ field, state, value, onChange }: FieldInputProps) {
   const common = {
     id: `f_${field.name}`,
     name: field.name,
-    required: field.required,
-    disabled: field.readonly,
+    required: state.required,
+    disabled: state.readonly,
     placeholder: field.placeholder,
     className: FIELD_CLASS,
   };
@@ -1036,7 +1277,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
             id={common.id}
             name={common.name}
             type="checkbox"
-            disabled={field.readonly}
+            disabled={state.readonly}
             checked={Boolean(v)}
             onChange={(e) => onChange(e.target.checked)}
             className="h-4 w-4 rounded border-input"
@@ -1054,7 +1295,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
           value={String(v)}
           onChange={(e) => onChange(e.target.value)}
         >
-          <option value="" disabled={field.required}>
+          <option value="" disabled={state.required}>
             {field.placeholder ?? '— Select —'}
           </option>
           {opts.map((o) => (
@@ -1074,7 +1315,7 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
                 name={field.name}
                 value={o.value}
                 checked={String(v) === o.value}
-                disabled={field.readonly}
+                disabled={state.readonly}
                 onChange={() => onChange(o.value)}
               />
               <span>{o.label}</span>
@@ -1142,6 +1383,14 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
   const editingId = target.kind === 'edit' ? target.recordId : null;
   /** The object the URL claims `editingId` belongs to (#4292), or null. */
   const editingObject = target.kind === 'edit' ? target.recordObject : null;
+  /**
+   * Is the write this form is heading for an INSERT? Read off the same URL
+   * switch as the pair above, because `resolveFieldRuleState` requires the
+   * caller to STATE it rather than infer it (objectui#4085) — see
+   * {@link resolveRowState}. `/f/:slug` is create by construction: public mode
+   * never reads `?recordId=` at all.
+   */
+  const isCreateForm = target.kind !== 'edit';
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -1400,7 +1649,15 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
         )}
       </header>
       <form onSubmit={handleSubmit} className="space-y-6">
-        {sections.map((sec, i) => (
+        {sections.map((sec, i) => {
+          // A section conditioned away is skipped IN PLACE rather than filtered
+          // out of the list first (objectui#5627). The key here is the section's
+          // POSITION, and these predicates re-decide on every keystroke: filtering
+          // would renumber every later section the moment one hid, remounting
+          // their inputs and taking the caret with them. `null` keeps each
+          // surviving section on the key it already had.
+          if (!isSectionVisible(sec, values, loaded.record)) return null;
+          return (
           <section key={i} className="rounded-md border bg-card p-4 sm:p-5">
             {sec.label && (
               <h2 className="mb-3 text-sm font-medium">{sec.label}</h2>
@@ -1416,7 +1673,14 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
                       : 'grid grid-cols-1 gap-4 sm:grid-cols-4'
               }
             >
-              {sec.fields.filter((f) => isFieldVisible(f, values, loaded.record)).map((f) => (
+              {sec.fields.map((f) => {
+                // One resolution per row per render, read by all three of the
+                // things that depend on it below — the row's presence, the
+                // required marker, and the control's own attributes. Computing
+                // it three times would be three chances to disagree.
+                const state = resolveRowState(f, values, loaded.record, isCreateForm);
+                if (!state.visible) return null;
+                return (
                 <div
                   key={f.name}
                   className={
@@ -1431,10 +1695,11 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
                     className="mb-1 block text-xs font-medium text-foreground"
                   >
                     {f.label}
-                    {f.required && <span className="ml-0.5 text-destructive">*</span>}
+                    {state.required && <span className="ml-0.5 text-destructive">*</span>}
                   </label>
                   <FieldInput
                     field={f}
+                    state={state}
                     value={values[f.name]}
                     onChange={(v) => setValues((prev) => ({ ...prev, [f.name]: v }))}
                   />
@@ -1442,10 +1707,12 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
                     <p className="mt-1 text-xs text-muted-foreground">{f.helpText}</p>
                   )}
                 </div>
-              ))}
+                );
+              })}
             </div>
           </section>
-        ))}
+          );
+        })}
         {error && (
           <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
             {error}


### PR DESCRIPTION
Fixes #5627

`FormPage` is the console's own form renderer — its own `buildSections`, its own JSX,
serving the anonymous `/f/:slug` route and the internal `/forms/:name` one. After #5594 it
honoured **one** of the four conditional-rule surfaces the sibling chain honours. This
wires the other three, through the shared machinery rather than a fourth copy of it.

## What was measured before writing anything

The card's behavioural claim held; one of its two type citations did not.

| Card says | On `c7cd2b60b` |
|---|---|
| `interface ObjectFieldDef` admits none of the ADR-0036 rules | Confirmed, `FormPage.tsx:95` |
| the render maps every section unconditionally (`:1398`) | Confirmed, at `:1403` |
| `interface FormSectionSpec { ... }` lives in this file | **It does not.** Zero hits |

The section type is no longer this file's to widen: **#5596 already landed**, replacing the
hand copy with the shared `FormSectionSpec` (`packages/app-shell/src/views/metadata-admin/form-spec.ts`),
imported here through `FormViewSpec`. That type has **declared** `visibleWhen`/`visibleOn`
all along — its own docstring says so while naming this card: *"Declaring a key is not
honouring it: objectui#5627 tracks the console renderer still rendering every section
unconditionally, which this type makes declarable but does not evaluate."* So the
section half of this fix is **evaluation only**; the local type work was the object-field
half alone.

The other measurement worth recording: the two `sections.map` sites are the **builder**
(`buildSections`, `:393`) and the **render** (`:1403`). Only the second one needed a guard.

## The fix

**Sections.** `buildSections` carries `sec.visibleWhen ?? sec.visibleOn` onto the row
(canonical-first, the precedence every sibling reader spells), and the render calls
`isSectionVisible`, which routes the predicate through `evalFieldPredicate` — the same
engine, scope (`record.*` live, `previous.*` stored) and fail-open-but-loud behaviour the
field predicate has used here since #5594.

The ruling asked for `readVisibility` for sections. That helper is **module-private** to
app-shell's `SchemaForm.tsx` and is not part of `@object-ui/app-shell`'s published surface,
so it cannot be imported; what it does is a two-key `??`, which is done once at build time
here exactly as this file already does it for fields. The half that decides anything — the
engine — **is** the shared one.

**Object-level field rules.** `ObjectFieldDef` admits `visibleWhen`/`readonlyWhen`/`requiredWhen`,
`buildSections` carries them onto the row as a group (`RenderableField.rules`), and
`resolveRowState` hands that group **whole** to `@object-ui/core`'s `resolveFieldRuleState`.
No rule semantics are re-derived here. Three settled rulings come along with the resolver
rather than being restated:

- a static `readonly: true` is never weakened by a predicate resolving false;
- likewise a static `required: true`;
- `serverOwnedValue` outranks **both** spellings of required (#4069 / #4085), so a create
  form does not require a producer-owned control. `isCreateForm` is passed as a **required**
  parameter, read off the URL switch `readFormRecordTarget` already owns — the resolver may
  not infer it, and a new call site must not get edit semantics by omission.

**The two visibility layers are ANDed, never collapsed.** A view-level predicate (#5594's
slot) and an object-level `visibleWhen` are different authoring slots with different owners;
`sectionFields.ts` routes the view predicate into `visibleOn` on the sibling chain precisely
so the object rule is never clobbered. Either layer resolving false hides the row, neither
can re-show what the other hid, and both are evaluated even when the first has already
decided — the one-time warning is the author's only diagnostic, and short-circuiting would
make a typo in one layer invisible whenever the other happened to hide the row.

**One verdict per row.** `FieldInput` now takes the resolved `{ readonly, required }` as a
prop instead of reading the static flags, so the control and the asterisk beside it cannot
disagree — the two-layer split objectui#4201 removed on the sibling chain.

**Hidden sections still submit.** Triage's ruling, quoted: *"Section-level visibility is a
rendering rule — a hidden section's fields still submit."* Pinned as a positive assertion on
the POST body. The escape hatch in that clause was checked and did **not** fire: the only
client-side enforcement in this renderer is the DOM `required` attribute, which travels with
the rendered control, so nothing can fire a validation on a value the user could never see.

## Reverse verification — measured

`FormPage.tsx` reverted to `c7cd2b60b` with the new pin file left in place. The mutation was
confirmed on disk before the run (`resolveRowState` 0 hits, `isSectionVisible` 0 hits, the
pre-#5627 render line back at 1 hit) and restored by an `EXIT`/`INT`/`TERM` trap afterwards:

```
Tests  20 failed | 4 passed (24)
```

Every red one fails by naming the defect — the conditioned-away section is on screen, the
locked control is editable, the required marker is missing, the predicate never reached the
row. The **4 green** are the controls that have to be green on both sides, and they are the
whole set:

- `CONTROL: a section with no predicate at all still renders` — without it, every
  `not.toBeInTheDocument` above is equally satisfied by a renderer that draws nothing;
- `CONTROL: a field with no object rules at all renders editable and optional`;
- `CONTROL: a static readonly is not weakened by a readonlyWhen that resolves false`;
- `does NOT require a server-owned field on a CREATE form` — green pre-fix for the *wrong*
  reason (nothing read `requiredWhen` at all), which is exactly why its twin, `DOES require
  the same field on an EDIT form`, is in the file and is red pre-fix.

## Tests — all on rendered output

Every failure mode in this card is invisible to `tsc` and `eslint`, so the 24 new cases
assert the DOM: element presence for the two visibility surfaces, `toBeDisabled()` for
`readonlyWhen`, `toBeRequired()` **plus** the marker read out of the `label` element for
`requiredWhen`, and the POST body for the submit clause. Both routes are covered — the
public `/f/:slug` one included, since that is the user-reachable half.

## Gates run on `2eed0fe2a` (the final commit)

| Gate | Verdict |
|---|---|
| `pnpm --filter @object-ui/console type-check` | `TYPECHECK_EXIT=0` (after building the dependency closure) |
| `pnpm --filter @object-ui/console lint` | `LINT_EXIT=0` — `202 problems (0 errors, 202 warnings)` |
| `pnpm exec vitest run apps/console` | `Test Files 72 passed (72)` / `Tests 782 passed (782)` |
| `check:control-bytes` | `OK (scanned 4776 tracked text file(s))` |
| `check-changeset-presence` / `check-changeset-no-major` / `check-changeset-fixed` | all pass |
| `check:phantom-deps`, `check:self-import`, `check:spec-symbols`, `check:esm-specifiers` | all pass |
| `check:i18n-keys`, `check:i18n-drift` | pass (`No en value changed in this range`) |
| `check:published-dist`, `check:eager-closure`, `check:action-forward-parity` | pass |
| `type-check:coverage`, `lint:coverage` | `46/46 packages linted`, `45/46 via type-check` |

Narrowing declared: `type-check`/`lint`/`test` were run for the **only** package this diff
touches, whole (`eslint .` over `apps/console` is that package's own gate command, not a
file subset). Repo-wide `pnpm lint` / `pnpm type-check` / `pnpm test` are CI's run.

## Out of scope, filed instead

#5727 — `readPrefill` in this same file seeds a **runtime-default** `defaultValue` (`NOW()`,
`current_user`, a CEL envelope) literally into the control, suppressing the server-side
resolution the declaration asks for. Different defect class (seeding, not conditional-rule
evaluation); filed unassigned rather than folded in.

#5596 is adjacent and was **not** folded in — it is already landed for these two container
types, and this PR consumes its result rather than extending it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_