### PR TITLE
fix(auth): make the ActiveOrganizationStorage memory fallback reachable when localStorage rejects writes

### DIFF
--- a/.changeset/active-org-storage-memory-fallback-5703.md
+++ b/.changeset/active-org-storage-memory-fallback-5703.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/auth': patch
+---
+
+`ActiveOrganizationStorage.get()` now prefers a non-null `localStorage` read and falls
+back to the in-memory value otherwise, instead of returning the `localStorage` read
+unconditionally — so the fallback is reachable in the browser state it was written for
+(objectui#5703).
+
+`set()` already swallowed a failed `localStorage.setItem` into `_memoryValue`, but
+`get()` only consulted `_memoryValue` when the READ itself threw. There is a real
+browser state where the read does not throw and the fallback is nonetheless the only
+copy: `localStorage` present and readable but rejecting writes — Safari private
+browsing, and any quota-exhausted origin, where `setItem` throws `QuotaExceededError`.
+In that state the active org was stored and could not be read back, measured as
+`_memoryValue = org-42` alongside `get() = null`.
+
+The cost was silent and lasted the whole session rather than the documented first-boot
+window: `createAuthenticatedFetch` reads `get()`, so `X-Tenant-ID` was never stamped on
+any request. Per the edge contract documented on objectui#5279 that header is a routing
+hint a reader falls through on — the framework scopes from the session — so no row
+visibility rode on this; what was missing is the tenant-routing input, on every request.
+`switchOrganization` also appeared to succeed while the client-side stamp never
+followed.
+
+Sign-out is unaffected, and that is the half worth stating: the new fallback fires
+exactly when the `localStorage` read is null, which is the state `clear()` leaves
+behind. It answers `null` there because `clear()` nulls `_memoryValue` too. That
+property is now pinned by test rather than relied upon, so a future `clear()` that only
+removed the persisted key fails a test instead of quietly re-stamping a cleared org.
+
+A non-null persisted read still wins over the memory value, so a working `localStorage`
+behaves exactly as before.

--- a/packages/auth/src/__tests__/activeOrgStorageFallback-5703.test.tsx
+++ b/packages/auth/src/__tests__/activeOrgStorageFallback-5703.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * `ActiveOrganizationStorage`: the in-memory fallback must be REACHABLE in the
+ * browser state it was written for — `localStorage` present, reads fine,
+ * rejects writes (objectui#5703).
+ *
+ * Safari private browsing and any quota-exhausted origin present exactly that
+ * shape: `getItem` works, `setItem` throws `QuotaExceededError`. `set()`
+ * already swallows the write failure into `_memoryValue`; before this fix
+ * `get()` returned the `localStorage` read UNCONDITIONALLY, so it answered
+ * `null` and the value that had just been stored could never be read back. The
+ * cost was silent and lasted the whole session: `createAuthenticatedFetch`
+ * reads `get()`, so `X-Tenant-ID` was never stamped on any request.
+ *
+ * ## The constraint these cases exist to PIN
+ *
+ * The repair is "prefer a non-null `localStorage` read, else fall back to
+ * `_memoryValue`" — and the half that matters is the one that must NOT happen:
+ * **sign-out's `clear()` must not be resurrected by that fallback.** A fallback
+ * keyed on "the read came back null" is, on its own, exactly the shape that
+ * re-stamps a cleared org — after `clear()` the `localStorage` read is null by
+ * construction, so the fallback fires, and whatever `_memoryValue` still held
+ * goes back on the wire. What makes it safe here is a property of `clear()`,
+ * not of `get()`: `clear()` nulls `_memoryValue` BEFORE it touches
+ * `localStorage`. That property is load-bearing for a security-relevant path,
+ * so these cases pin it directly (`_memoryValue` asserted null after `clear()`,
+ * not merely `get()`), rather than reading it off the current source and
+ * trusting it to stay. If someone later makes `clear()` only remove the
+ * persisted key, `clear-then-get` below goes red instead of silently
+ * resurrecting the org.
+ *
+ * Lives as `.test.tsx` so it runs under happy-dom alongside
+ * `createAuthenticatedFetch.test.tsx` — the wire-level cases need `fetch`,
+ * `Headers` and a `window.location` for the same-origin check.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createAuthenticatedFetch, ActiveOrganizationStorage } from '../createAuthenticatedFetch';
+import { TokenStorage } from '../createAuthClient';
+
+const ACTIVE_ORG_STORAGE_KEY = 'auth-active-organization-id';
+const API_URL = 'http://localhost/api/v1/meta/object/account';
+
+/**
+ * Install a `localStorage` double and return the Map backing it, so a case can
+ * assert what did (or did not) reach the persisted layer.
+ *
+ * `reject` names which operations throw. The card's probe is
+ * `{ setItem: true }`: present, readable, unwritable.
+ */
+function installLocalStorage(reject: { getItem?: boolean; setItem?: boolean } = {}) {
+  const store = new Map<string, string>();
+  const quota = () => {
+    // The card's probe threw exactly this.
+    throw new Error('QuotaExceededError');
+  };
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (reject.getItem ? quota() : store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      if (reject.setItem) quota();
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+  });
+  return store;
+}
+
+/** Stub the global fetch and capture the Headers it was called with. */
+function stubFetch() {
+  const calls: Array<{ url: string; headers: Headers }> = [];
+  const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+    calls.push({ url, headers: new Headers(init?.headers) });
+    return new Response('{}', { status: 200 });
+  });
+  vi.stubGlobal('fetch', mock);
+  return calls;
+}
+
+describe('ActiveOrganizationStorage — the in-memory fallback (#5703)', () => {
+  beforeEach(() => {
+    ActiveOrganizationStorage.clear();
+    vi.spyOn(TokenStorage, 'get').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    ActiveOrganizationStorage.clear();
+  });
+
+  // ── (a) read-succeeds / write-fails: the card's probe ──────────────────
+
+  it('reads back a value it could not persist, when localStorage rejects writes', () => {
+    const persisted = installLocalStorage({ setItem: true });
+
+    ActiveOrganizationStorage.set('org-42');
+
+    // The premise of the case, asserted rather than assumed: the write really
+    // did fail, so this is the read-succeeds/write-fails state and not a
+    // working localStorage wearing a costume.
+    expect(persisted.has(ACTIVE_ORG_STORAGE_KEY)).toBe(false);
+    expect(localStorage.getItem(ACTIVE_ORG_STORAGE_KEY)).toBeNull();
+    expect(ActiveOrganizationStorage._memoryValue).toBe('org-42');
+
+    // The defect: measured as `null` before the fix.
+    expect(ActiveOrganizationStorage.get()).toBe('org-42');
+  });
+
+  it('stamps X-Tenant-ID for the whole session when localStorage rejects writes', async () => {
+    installLocalStorage({ setItem: true });
+    ActiveOrganizationStorage.set('org-42');
+
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(API_URL);
+    await createAuthenticatedFetch()(API_URL);
+
+    // Before the fix both requests left unstamped — not just the early ones.
+    expect(calls[0].headers.get('X-Tenant-ID')).toBe('org-42');
+    expect(calls[1].headers.get('X-Tenant-ID')).toBe('org-42');
+  });
+
+  // ── (b) clear-then-get stays null: the security-relevant half ──────────
+
+  it('does NOT resurrect a cleared org through the fallback', () => {
+    installLocalStorage({ setItem: true });
+    ActiveOrganizationStorage.set('org-42');
+    // Precondition: the fallback is live and holding the org, so the case
+    // below is a real test of `clear()` and not a vacuous one.
+    expect(ActiveOrganizationStorage.get()).toBe('org-42');
+
+    ActiveOrganizationStorage.clear();
+
+    // The property that makes "fall back when the read is null" safe. Pinned
+    // directly: a `clear()` that only removed the persisted key would leave
+    // `_memoryValue` set, the null read would fall through to it, and the
+    // cleared org would go straight back on the wire.
+    expect(ActiveOrganizationStorage._memoryValue).toBeNull();
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  it('sends NO tenant header after sign-out clears the org, in the same browser', async () => {
+    // The same statement one level out, on the wire — the header must be
+    // ABSENT, not present-and-empty, per the edge contract this package's
+    // README documents (objectui#5279).
+    installLocalStorage({ setItem: true });
+    ActiveOrganizationStorage.set('org-42');
+    ActiveOrganizationStorage.clear();
+
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(API_URL);
+
+    expect(calls[0].headers.has('X-Tenant-ID')).toBe(false);
+  });
+
+  it('does not resurrect a cleared org when localStorage works normally either', () => {
+    const persisted = installLocalStorage();
+    ActiveOrganizationStorage.set('org-42');
+    expect(persisted.get(ACTIVE_ORG_STORAGE_KEY)).toBe('org-42');
+
+    ActiveOrganizationStorage.clear();
+
+    expect(persisted.has(ACTIVE_ORG_STORAGE_KEY)).toBe(false);
+    expect(ActiveOrganizationStorage._memoryValue).toBeNull();
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  // ── (c) plain working localStorage: unchanged ──────────────────────────
+
+  it('keeps the persisted value authoritative when localStorage works', () => {
+    const persisted = installLocalStorage();
+
+    ActiveOrganizationStorage.set('org-42');
+
+    expect(persisted.get(ACTIVE_ORG_STORAGE_KEY)).toBe('org-42');
+    expect(ActiveOrganizationStorage.get()).toBe('org-42');
+  });
+
+  it('prefers what localStorage holds over a stale memory value', () => {
+    // The ordering the repair keeps: a non-null persisted read WINS. Another
+    // tab (or a page that outlived a memory value) is the authority, so the
+    // fallback must never override a value that is actually there.
+    installLocalStorage();
+    ActiveOrganizationStorage.set('org-stale');
+    // Simulate the persisted layer moving on underneath this tab.
+    localStorage.setItem(ACTIVE_ORG_STORAGE_KEY, 'org-fresh');
+
+    expect(ActiveOrganizationStorage._memoryValue).toBe('org-stale');
+    expect(ActiveOrganizationStorage.get()).toBe('org-fresh');
+  });
+
+  it('reads null when nothing was ever set and localStorage works', () => {
+    installLocalStorage();
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  // ── (d) the path the fallback was originally written for ───────────────
+
+  it('still falls back to memory when the localStorage READ itself throws', () => {
+    // The `catch` branch, which was the only way `_memoryValue` was ever
+    // reachable before this fix. Pinned so the repair does not quietly cost
+    // the case it already handled.
+    installLocalStorage({ getItem: true, setItem: true });
+
+    ActiveOrganizationStorage.set('org-42');
+
+    expect(ActiveOrganizationStorage.get()).toBe('org-42');
+  });
+});

--- a/packages/auth/src/createAuthenticatedFetch.ts
+++ b/packages/auth/src/createAuthenticatedFetch.ts
@@ -41,10 +41,36 @@ const ACTIVE_ORG_STORAGE_KEY = 'auth-active-organization-id';
 export const ActiveOrganizationStorage = {
   _memoryValue: null as string | null,
 
+  /**
+   * The active org id, or `null`.
+   *
+   * READ ORDER — a non-null `localStorage` read wins; anything else falls
+   * through to `_memoryValue`. Returning the `localStorage` read
+   * UNCONDITIONALLY (what this did before objectui#5703) left the fallback
+   * reachable only when the read THREW, and there is a real browser state
+   * where the read does not throw and the fallback is still the only copy:
+   * `localStorage` present and readable but REJECTING WRITES — Safari private
+   * browsing, and any quota-exhausted origin, where `setItem` throws
+   * `QuotaExceededError`. `set()` swallows that failure into `_memoryValue`
+   * (correctly — the fallback is right there), and `get()` then never
+   * consulted it: the value was stored and could not be read back, so
+   * `X-Tenant-ID` went unstamped for the whole session, not just the early
+   * requests.
+   *
+   * WHY FALLING BACK ON `null` DOES NOT RESURRECT A CLEARED ORG. After
+   * `clear()` the `localStorage` read is null by construction, so this
+   * fallback fires — and it must answer `null`, because sign-out is one of
+   * `clear()`'s callers. It does, because `clear()` nulls `_memoryValue` too.
+   * That property is what makes this read order safe rather than an
+   * incidental detail of `clear()`'s body, so it is pinned by test
+   * (`__tests__/activeOrgStorageFallback-5703.test.tsx`) instead of being
+   * re-derived by whoever edits `clear()` next.
+   */
   get(): string | null {
     try {
       if (typeof localStorage !== 'undefined') {
-        return localStorage.getItem(ACTIVE_ORG_STORAGE_KEY);
+        const persisted = localStorage.getItem(ACTIVE_ORG_STORAGE_KEY);
+        if (persisted !== null) return persisted;
       }
     } catch { /* SSR / test */ }
     return this._memoryValue;
@@ -60,6 +86,12 @@ export const ActiveOrganizationStorage = {
   },
 
   clear(): void {
+    // Nulling the fallback is SECURITY-RELEVANT, not bookkeeping: `get()`
+    // falls through to `_memoryValue` whenever the `localStorage` read comes
+    // back null, which is exactly the state this method leaves behind. Drop
+    // this line and sign-out's clear stops sticking — the removed key reads
+    // null, the fallback fires, and the cleared org goes back on the wire as
+    // `X-Tenant-ID`. Pinned by `__tests__/activeOrgStorageFallback-5703.test.tsx`.
     this._memoryValue = null;
     try {
       if (typeof localStorage !== 'undefined') {


### PR DESCRIPTION
Fixes #5703

`ActiveOrganizationStorage.get()` returned the `localStorage` read unconditionally, so the module-level `_memoryValue` fallback was reachable **only when the read itself threw**. There is a real browser state where the read does not throw and the fallback is nonetheless the only copy of the value: `localStorage` present and readable but **rejecting writes** — Safari private browsing, and any quota-exhausted origin, where `setItem` throws `QuotaExceededError`.

In that state `set()` correctly swallowed the write failure into `_memoryValue`, and `get()` then never consulted it. The active org was stored and could not be read back.

## The repair

`get()` now prefers a **non-null** `localStorage` read and falls back to `_memoryValue` otherwise:

```ts
const persisted = localStorage.getItem(ACTIVE_ORG_STORAGE_KEY);
if (persisted !== null) return persisted;
```

A working `localStorage` is untouched, and a non-null persisted read still wins over the memory value — so another tab (or a page that outlived a memory value) remains the authority.

## The half that had to be pinned, not assumed

The new fallback fires exactly when the `localStorage` read is null — **which is also the state `clear()` leaves behind**. Sign-out calls `clear()`, so "fall back whenever the read is null" is, on its own, the precise shape that would re-stamp a cleared org.

It answers `null` here because `clear()` nulls `_memoryValue` *before* it touches `localStorage`. That is a property of `clear()`'s body, not a guarantee of `get()`, so this PR pins it directly rather than reading it off the current source and trusting it to stay:

- `_memoryValue` itself is asserted null after `clear()`, not merely `get()`. A future `clear()` that only removed the persisted key fails a test instead of silently resurrecting the org.
- The same statement is pinned one level out, on the wire: after `clear()`, `createAuthenticatedFetch` sends **no** `X-Tenant-ID` at all — absent, not present-and-empty.
- `clear()` carries a comment naming the line as security-relevant, since that is where a future editor would break it.

## Tests

`packages/auth/src/__tests__/activeOrgStorageFallback-5703.test.tsx` — 9 cases covering triage's matrix: (a) read-succeeds/write-fails, (b) clear-then-get stays null, (c) plain working `localStorage` unchanged, plus (d) the read-throws path the fallback was originally written for, so the repair does not cost the case it already handled.

The card's probe is reproduced as a committed test against **source** (the repo's vitest aliases `@object-ui/auth` to `packages/auth/src`), not the built `dist/` the one-off probe used.

Measured red before the fix, on the same tree:

```
× reads back a value it could not persist, when localStorage rejects writes
× stamps X-Tenant-ID for the whole session when localStorage rejects writes
× does NOT resurrect a cleared org through the fallback
AssertionError: expected null to be 'org-42' // Object.is equality
Tests  3 failed | 6 passed (9)
```

Worth noting which three went red: the clear-case failed at its own **precondition** (`get()` must return the org before `clear()` can be tested), because the fallback was not live. That case was vacuous before this fix — which is exactly why it needed pinning rather than relying on the current behaviour.

Green after, on `4cae3d6a8`:

```
Test Files  21 passed (21)
     Tests  218 passed (218)      # whole packages/auth
Test Files  3 passed (3)
     Tests  13 passed (13)        # the MetadataProvider consumers
```

## Blast radius — noted, deliberately not fixed here

Two consequences disappear on their own once `get()` is repaired; neither is touched by this PR:

- **`X-Tenant-ID` was never stamped for the whole session**, not just the documented first-boot window. Per the edge contract documented on #5279 the header is a routing hint a reader falls through on — the framework scopes from the session — so **this is not a data-scoping bug**; what was missing is the tenant-routing input, on every request.
- `activeOrgScope()` in `packages/app-shell/src/providers/MetadataProvider.tsx` reads the same storage, so its org-scoped session cache stayed permanently keyed `@none` and the first-boot relabel never fired. `packages/app-shell/**` is out of scope for this PR; its three `MetadataProvider` consumer tests are run above and stay green.

Cross-references #5279, which documented this window's observable consequence without repairing it.

## Verification

| Gate | Verdict |
| --- | --- |
| `pnpm exec vitest run packages/auth` | `Test Files 21 passed (21)` / `Tests 218 passed (218)` |
| `pnpm exec vitest run` (3 MetadataProvider consumers) | `Test Files 3 passed (3)` / `Tests 13 passed (13)` |
| `pnpm --filter @object-ui/auth type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `eslint .` in `packages/auth` | 42 files, **0 errors**, 29 warnings (all in files this PR does not touch) |
| `check-control-bytes.mjs` | `OK (scanned 4782 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence.mjs` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |
| `check-phantom-dependencies.mjs` | `Every in-scope import is declared by the package that publishes it.` |
| `check-package-self-import.mjs` | `No package names itself inside its own src/.` |

The repo-wide `pnpm test` and `pnpm lint` runs are left to CI, which runs the farm exactly once regardless. The local lint above is a **declared narrowing**: the population is ESLint's own selection (42 files), the count is read from `--format json`, and no type-aware linting is configured (`eslint.config.js` sets no `projectService`, `project:`, or `parserOptions`), so this diff cannot move the verdict on any file it does not itself contain.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_