### PR TITLE
fix(console): resolve the pre-boot branding origin from VITE_SERVER_URL

### DIFF
--- a/.changeset/console-preboot-branding-origin-5660.md
+++ b/.changeset/console-preboot-branding-origin-5660.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/console': patch
+---
+
+The console's pre-boot branding script now resolves its server origin from
+`VITE_SERVER_URL` — the same variable every module-side consumer reads — instead of
+`window.__CONSOLE_SERVER_URL`, a global nothing in this repository ever set
+(objectui#5660).
+
+The two callers of `GET /api/v1/runtime/config` share one in-flight request, and
+that sharing keys on the FULL URL. So the origin was half of the contract: the
+inline script in `index.html` read one spelling and `src/main.tsx` read another, and
+whenever they disagreed the two never found each other. A same-origin production
+build hid it completely — both spellings collapse to `''` — so the split surfaced
+only in a dev pointing the console at a separate server, where it cost two requests
+to two different servers and let pre-boot branding paint from the wrong one.
+
+The pre-boot fetch is kept, not deleted: it is the request the module side JOINS.
+`sharedGetJson()` can only hand an earlier request to a later caller, and this
+script is the earlier one by construction — it runs during HTML parse, before the
+bundle is fetched, while `initRuntimeConfig()` is awaited before
+`createRoot().render()`. Deleting it would not remove a request; it would move the
+single remaining one later, onto the critical path to first paint, and leave the
+page's empty `<title>` and favicon unbranded until React mounts.
+
+Vite substitutes its HTML env token only when the variable is set and leaves it
+verbatim otherwise, so the unset case is read as same-origin `''` rather than
+allowed to reach the URL as a path segment.

--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -42,11 +42,33 @@
       against that function — so a drift between the two spellings fails a test
       rather than silently restoring the duplicate.
 
+      The ORIGIN is the other half of that contract (objectui#5660). Sharing
+      keys on the full URL, so the two callers must agree on the server origin
+      or they build two different keys, never find each other, and issue two
+      requests to two different servers. This script used to read
+      `window.__CONSOLE_SERVER_URL` — a global NOTHING in this repository ever
+      set — while every module-side consumer reads
+      `import.meta.env.VITE_SERVER_URL`. A dev pointing the console at a
+      separate server therefore got exactly that split, silently, because both
+      spellings collapse to '' in a same-origin production build, which is the
+      only shape the dedup above was ever measured in. Vite's HTML env
+      substitution resolves the SAME variable the modules read, so one value
+      reaches both callers.
+
       Falls back gracefully on any error (non-blocking).
     -->
     <script>
       (async function applyEarlyBranding() {
-        const base = (window.__CONSOLE_SERVER_URL || '').replace(/\/+$/, '');
+        // Vite's HTML env substitution fills the token below with
+        // `import.meta.env.VITE_SERVER_URL` — the same value `src/main.tsx`
+        // hands `initRuntimeConfig()`. It substitutes only when the variable is
+        // SET and leaves the token verbatim when it is not (`htmlEnvHook`:
+        // `if (key in env) return env[key]; else return text`). Unset is the
+        // ordinary production case — Console SPA and tenant runtime share an
+        // origin — so an unsubstituted token MUST read as same-origin '' and
+        // never as a path segment. No origin can begin with '%'.
+        const injected = '%VITE_SERVER_URL%';
+        const base = (injected.charAt(0) === '%' ? '' : injected).replace(/\/+$/, '');
         const url = base + '/api/v1/runtime/config';
         const init = { credentials: 'include', headers: { Accept: 'application/json' } };
         // Must equal inflightGetKey(url, init) — see the comment above.

--- a/apps/console/src/__tests__/runtimeConfigBootDedup.test.ts
+++ b/apps/console/src/__tests__/runtimeConfigBootDedup.test.ts
@@ -53,8 +53,23 @@ function extractEarlyBrandingSource(html: string = indexHtml): string {
 }
 
 /** Run the shipped pre-boot script, as the browser would during parse. */
-function runEarlyBranding(): void {
-  new Function(extractEarlyBrandingSource())();
+function runEarlyBranding(html: string = indexHtml): void {
+  new Function(extractEarlyBrandingSource(html))();
+}
+
+/**
+ * Vite's `%ENV%` substitution over the HTML, as `htmlEnvHook` performs it:
+ * `html.replace(/%(\S+?)%/g, ...)`, the value when the key is present and the
+ * token VERBATIM when it is not.
+ *
+ * The `?raw` import above deliberately bypasses that hook — it reads the file
+ * off disk — so these tests apply it themselves. That is the only way to grade
+ * BOTH halves of the contract from the shipped artifact: the substituted page a
+ * split-origin dev serves, and the unsubstituted one every same-origin
+ * production build ships.
+ */
+function applyViteHtmlEnv(html: string, env: Record<string, string>): string {
+  return html.replace(/%(\S+?)%/g, (text, key: string) => (key in env ? env[key]! : text));
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -154,5 +169,77 @@ describe('one cold load, one runtime/config request', () => {
     await initRuntimeConfig('');
     expect(fetchStub).toHaveBeenCalledTimes(2);
     expect(getRuntimeConfig().branding.productName).toBe('Acme Ops');
+  });
+});
+
+/**
+ * objectui#5660 — one page, one server origin.
+ *
+ * Sharing keys on the FULL URL (`inflightGetKey`), so the dedup above only ever
+ * fires while both callers agree on the origin. They did not: this script read
+ * `window.__CONSOLE_SERVER_URL`, which nothing in the repository sets, while
+ * `main.tsx` reads `import.meta.env.VITE_SERVER_URL`. Same-origin production
+ * hid it completely — both spellings collapse to '' — so the split only ever
+ * appeared in a dev pointing the console at a separate server, where it cost
+ * two requests to two different servers and pre-boot branding read from the
+ * wrong one.
+ *
+ * These grade the SHIPPED html through Vite's substitution rather than a copy
+ * of the script, so a future edit that reintroduces a second spelling of the
+ * origin fails here.
+ */
+describe('one page, one server origin', () => {
+  const SERVER = 'https://api.example.test';
+
+  it('sends the pre-boot request to VITE_SERVER_URL, so app-shell joins it', async () => {
+    const fetchStub = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse(CONFIG_BODY));
+    vi.stubGlobal('fetch', fetchStub);
+
+    // The page a split-origin dev actually serves.
+    runEarlyBranding(applyViteHtmlEnv(indexHtml, { VITE_SERVER_URL: SERVER }));
+    // `main.tsx:65` hands `initRuntimeConfig` the same env var.
+    await initRuntimeConfig(SERVER);
+
+    // Before the fix this was 2 — '/api/v1/runtime/config' from the inline
+    // script and the SERVER-based one from app-shell, two keys, no sharing.
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub.mock.calls[0]![0]).toBe(`${SERVER}/api/v1/runtime/config`);
+    expect(getRuntimeConfig().branding.productName).toBe('Acme Ops');
+  });
+
+  it('normalises trailing slashes the same way app-shell does', async () => {
+    const fetchStub = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse(CONFIG_BODY));
+    vi.stubGlobal('fetch', fetchStub);
+
+    runEarlyBranding(applyViteHtmlEnv(indexHtml, { VITE_SERVER_URL: `${SERVER}///` }));
+    await initRuntimeConfig(`${SERVER}///`);
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub.mock.calls[0]![0]).toBe(`${SERVER}/api/v1/runtime/config`);
+  });
+
+  it('falls back to same-origin when the variable is unset, never to the raw token', async () => {
+    const fetchStub = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse(CONFIG_BODY));
+    vi.stubGlobal('fetch', fetchStub);
+
+    // Vite leaves its token verbatim when the variable is unset, and that is the
+    // ORDINARY production build. An unsubstituted token must never reach the URL.
+    const productionHtml = applyViteHtmlEnv(indexHtml, {});
+    expect(extractEarlyBrandingSource(productionHtml)).toContain('%VITE_SERVER_URL%');
+
+    runEarlyBranding(productionHtml);
+    await initRuntimeConfig('');
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(fetchStub.mock.calls[0]![0]).toBe('/api/v1/runtime/config');
+    expect(String(fetchStub.mock.calls[0]![0])).not.toContain('%');
+  });
+
+  it('reads the origin from one place only — no second spelling survives', () => {
+    const source = extractEarlyBrandingSource();
+    // The global nothing ever set is gone from the executable text.
+    expect(source).not.toContain('window.__CONSOLE_SERVER_URL');
+    // And the one it does read is the variable the modules read.
+    expect(source).toContain('%VITE_SERVER_URL%');
   });
 });

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -62,6 +62,11 @@ registerPlaceholders();
 // it the SPA would fall back to defaults on first paint and hit 404s.
 // Both kicks are awaited so first paint sees definitive values, but each
 // one absorbs its own failures so a missing endpoint never blocks boot.
+// `index.html`'s pre-boot branding script resolves this SAME variable through
+// Vite's HTML env substitution, so both callers build one `/api/v1/runtime/config`
+// URL and share one request instead of asking two servers (objectui#5660).
+// Change the spelling here and that script has to change with it;
+// `src/__tests__/runtimeConfigBootDedup.test.ts` fails when the two stop agreeing.
 const SERVER_BASE = (import.meta.env.VITE_SERVER_URL || '').replace(/\/+$/, '');
 // The third entry seeds the UI language from the tenant's server-side locale
 // (objectui#4035). It joins this existing gate rather than adding one of its


### PR DESCRIPTION
Fixes #5660

## The branch this card asked for, and how it was decided

Triage's first-touch was a **check-first**, not a patch: establish whether #5658's
shared in-flight promise makes the inline fetch redundant — if yes, *delete* it; only
if pre-boot timing is load-bearing does the variable-injection repair apply.

**Measured answer: the inline fetch is not redundant, and "redundant" is the wrong
direction entirely.** #5658 shares from the request that started *first* to the one
that started *second*, and the inline script is the first one by construction. It is
the **producer** of the shared promise; `initRuntimeConfig()` is the **joiner**.

Three readings, all reproducible:

1. **`sharedGetJson()` can only flow earlier → later.** It joins an entry that already
   exists (`packages/types/src/http-inflight.ts:187`) and otherwise starts its own
   (`:190`). There is no mechanism by which a later caller serves an earlier one.
2. **Deleting the inline fetch removes no request.** The existing suite already pins
   one request both with the pre-boot script (`runtimeConfigBootDedup.test.ts`, "lets
   app-shell join the pre-boot request") and without it ("still fetches on its own when
   nothing is in flight"). The count is 1 either way — so the axis on which "redundant"
   would live shows no gain. What deletion changes is *when*: the single remaining
   request moves from HTML-parse time to module-evaluation time, and `main.tsx` awaits
   it before `createRoot().render()`. That is precisely the head start #5658 landed to
   buy.
3. **The branding regression would be visible, not subtle.** `index.html` ships a title
   element with no text and a favicon link whose href is the empty string. The pre-boot
   script is the only thing that fills either before React mounts, so deletion means a
   blank tab title and no favicon until the bundle boots.

Either reading alone rules deletion out. So: **variable injection**, per the ruling's
conditional.

## The defect, stated more precisely than the card could

The card frames the cost as "the inline fetch 404s against the Vite dev origin". The
mismatch is real, but the failure mode is worse than a 404: `apps/console/vite.config.ts:709`
proxies `/api` to `DEV_PROXY_TARGET || 'http://localhost:3000'`, so the inline request is
generally *served* — by whichever server the proxy points at, which need not be the one
`VITE_SERVER_URL` names.

The load-bearing consequence is the one the sharing makes: `inflightGetKey()` keys on the
**full URL**, so the origin is half of that hand-copied contract. Two spellings meant two
keys, so the callers never found each other. Measured on `origin/main` `d8afbe519` by
executing the shipped script:

```
inline script requested  : "/api/v1/runtime/config"
module path would request: "https://api.example.test/api/v1/runtime/config"
SAME URL (=> one shared request)? false
```

Same-origin production hides it completely — both spellings collapse to `''` — which is
why #5658's dedup was measured working there.

## The change

`index.html`'s branding script now resolves its origin from Vite's HTML env substitution
of `VITE_SERVER_URL`, the same variable `src/main.tsx:65` hands `initRuntimeConfig()`.
`window.__CONSOLE_SERVER_URL` — a global nothing in this repository ever set — is gone
from the executable text, so there is exactly one spelling of the origin in the page.

**The unset case is handled deliberately, because it is the ordinary production build.**
Vite's `htmlEnvHook` substitutes only when the variable is present and otherwise leaves
the token **verbatim**:

```js
if (key in env) return env[key];
else { /* warn if VITE_-prefixed */ return text; }
```

An unsubstituted token must therefore read as same-origin `''` and must never reach the
URL as a path segment. No origin can begin with `%`, so the leading character decides it.

A note on failure fan-out, since the two requests are now shared where they were not:
this cannot starve the module path. The two are now byte-identical requests, so any
origin that rejects the inline fetch would reject `initRuntimeConfig()`'s own fetch
identically — there is no case where the old split would have succeeded and the shared
one fails.

## Tests

Four cases added to the file that already grades the shipped artifact. They run the real
`index.html` through Vite's substitution rather than a copy of the script, so a future
edit reintroducing a second spelling of the origin fails here.

**Reverse verification** (revert only the `index.html` read site, keep the tests; mutation
confirmed on disk by grepping both the removed and injected text; restore proven
byte-identical to HEAD afterwards):

```
× one page, one server origin > sends the pre-boot request to VITE_SERVER_URL
  → expected "vi.fn()" to be called 1 times, but got 2 times
× one page, one server origin > normalises trailing slashes the same way app-shell does
  → expected "vi.fn()" to be called 1 times, but got 2 times
× one page, one server origin > falls back to same-origin when the variable is unset
× one page, one server origin > reads the origin from one place only
 Tests  4 failed | 6 passed (10)
```

The `1 times, but got 2 times` is the defect itself: two requests to two servers.
The six pre-existing #5544 cases stay green under the ablation, so this change does not
disturb what that card pinned.

**Gates, all green on `c62ceff90`** (the union was run after the final commit):

| gate | verdict |
| --- | --- |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 4783 tracked text file(s))` |
| `check-changeset-presence` | `✅ 2 source file(s) of 1 released package(s) changed … declares 1 changeset(s)` |
| `check-changeset-no-major` | ``✅ No changeset declares a `major` bump.`` |
| `check-changeset-fixed` | `✅ All workspace packages are in the changeset fixed group.` |
| ESLint (changed `.ts`/`.tsx`) | 2 files, 0 errors, 0 warnings |
| `@object-ui/console` `type-check` | `tsc --noEmit && tsc -b tsconfig.node.json --force`, exit 0 |
| `apps/console` vitest | `Test Files 72 passed (72) · Tests 786 passed (786)` |

`index.html` is an unusual gate surface here, so the coverage was derived rather than
assumed: ESLint's population is `**/*.{ts,tsx}` (`eslint.config.js:28`, `:245`) and
matches no `.html`, so the file is covered by `check:control-bytes` — which carries no
path filter by design — and by the vitest suite that extracts and executes its text.
That suite is the real gate on this file, which is why the fix is pinned there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_