### PR TITLE
fix(auth): scope the active-organization key per user, and drop the previous user's client state on a session-user change

### DIFF
--- a/.changeset/per-user-active-org-and-session-user-purge-5664.md
+++ b/.changeset/per-user-active-org-and-session-user-purge-5664.md
@@ -1,0 +1,55 @@
+---
+'@object-ui/auth': patch
+'@object-ui/console': patch
+---
+
+The active organization id is now stored per user, and a change of session user drops the
+previous user's client state wholesale (objectui#5664).
+
+`auth-active-organization-id` was a single un-namespaced `localStorage` key while its
+siblings were already user-scoped (`objectui-recent-items:u:`, `objectui-favorites:u:`,
+`flow-palette-recents:u:`). On a browser handed from one account to another — a shared
+machine, a kiosk, a handover, a support session — the arriving user's console read the
+PREVIOUS user's organization id. The header workspace chip rendered the previous user's
+workspace for a user whose `organization/list` was empty, and the consequence past the
+cosmetics is the one worth stating: the polluted org context suppressed
+`RequireOrganization`'s routing into the guided "Create your workspace" first-run flow, so
+a brand-new user on that browser silently never got the new-user flow at all.
+
+Nothing about row visibility rode on this. With the stale id the server answers
+`403 USER_IS_NOT_A_MEMBER` on `get-full-organization` and `set-active`, and lists zero
+environments; the damage was entirely in what the client believed about itself.
+
+Three changes, and the third is the one that closes the class rather than the instance:
+
+- The key is per-user (`auth-active-organization-id:u:$userId`), matching the convention
+  its siblings already use.
+- It can no longer be written un-namespaced at all. Where no session user is known yet the
+  value lives in memory for that page-load only — a namespacing that kept a bare-key
+  fallback would re-open the defect the first time a write happened before the user id
+  resolved.
+- **A change of session user drops the previous user's client state wholesale.** This is an
+  allowlist sweep of both `localStorage` and `sessionStorage`, not a list of known keys, so
+  the NEXT storage key someone adds without a `:u:` scope is covered before it is written.
+  Only device-scoped entries survive: the arriving session's own bearer token, the pointer
+  recording whose state the browser holds, and the UI theme.
+
+Both properties objectui#5703 established are preserved and still pinned: `get()` prefers a
+non-null `localStorage` read and falls back to the in-memory value, and the memory value is
+nulled BEFORE storage is touched — by `clear()` as before, and now by the user-change purge
+too, so the outgoing user's org id cannot outlive their persisted key on the sign-out-then-
+sign-in path that never reloads the page.
+
+Existing browsers are not migrated. A value sitting under the retired bare key is
+unattributable — nothing recorded whose org id it is — so migrating it is precisely the
+defect it would be migrating away from, and it is deleted instead. A signed-in user loses
+nothing durable: the active organization is a server-owned fact that
+`AuthProvider.refreshOrganizations` re-asks for whenever the list is non-empty and no
+active org is held, including the ADR-0081 single-membership repair. One boot re-supplies
+it; users with no organization land on the guided first-run flow, which is the outcome this
+card is about.
+
+`apps/console`'s pre-render auth preflight purges every spelling of the active-org key —
+the retired bare one and each `:u:` scope — when it finds a dead bearer token, and
+deliberately leaves the session-user pointer in place so the next sign-in can still tell
+that the browser changed hands.

--- a/apps/console/src/lib/auth-preflight.ts
+++ b/apps/console/src/lib/auth-preflight.ts
@@ -23,16 +23,50 @@
  *
  * Run BEFORE React renders. If `auth-session-token` is present, probe
  * `/api/v1/auth/get-session` with that Bearer (and no cookie). If the
- * response is not authenticated, delete the stale token + the stale
- * `auth-active-organization-id` so AuthProvider's first `getSession()`
- * falls back to cookie auth cleanly.
+ * response is not authenticated, delete the stale token + every stale
+ * active-organization id (the bare pre-objectui#5664 key and each
+ * `auth-active-organization-id:u:` scope) so AuthProvider's first
+ * `getSession()` falls back to cookie auth cleanly.
  *
  * Idempotent, runs once per page load, < 50 ms when the token is valid
  * (single round-trip), no UI flicker (happens before render).
  */
 
 const TOKEN_KEY = 'auth-session-token';
-const ACTIVE_ORG_KEY = 'auth-active-organization-id';
+/**
+ * Base name of the active-organization key. Since objectui#5664 the live key
+ * is per-user (`auth-active-organization-id:u:<userId>`) and the bare name is
+ * the retired pre-#5664 spelling, so the purge below matches BOTH by prefix.
+ *
+ * Spelled out rather than imported from `@object-ui/auth`: this module runs
+ * BEFORE React renders, and pulling the auth barrel in here would drag its
+ * component closure into the eager entry chunk.
+ */
+const ACTIVE_ORG_KEY_BASE = 'auth-active-organization-id';
+
+/**
+ * Remove the stale active-organization id under every spelling — the bare
+ * pre-#5664 key and each `:u:<userId>` scope.
+ *
+ * Every scope goes, not just the current user's: a dead Bearer means this
+ * browser cannot say whose ids these are, and the value is a client-side cache
+ * of a SERVER-owned fact (`AuthProvider.refreshOrganizations` re-asks on the
+ * next boot), so deleting one that turns out to still be wanted costs a
+ * re-fetch and nothing else.
+ *
+ * `auth-session-user-id` is deliberately NOT removed. It is the pointer that
+ * lets the next sign-in notice it belongs to a DIFFERENT user and drop the
+ * previous user's state wholesale (objectui#5664); clearing it here would make
+ * that transition look like a first-ever sign-in and skip the purge.
+ */
+function purgeActiveOrgKeys(): void {
+  // Snapshot first — removing during a live index walk skips entries.
+  for (const key of Object.keys(localStorage)) {
+    if (key === ACTIVE_ORG_KEY_BASE || key.startsWith(`${ACTIVE_ORG_KEY_BASE}:u:`)) {
+      localStorage.removeItem(key);
+    }
+  }
+}
 
 export async function preflightAuth(authBaseUrl: string): Promise<void> {
   if (typeof window === 'undefined') return;
@@ -69,7 +103,7 @@ export async function preflightAuth(authBaseUrl: string): Promise<void> {
 
     // 401, 4xx, or 200-with-null — token is stale. Purge.
     localStorage.removeItem(TOKEN_KEY);
-    localStorage.removeItem(ACTIVE_ORG_KEY);
+    purgeActiveOrgKeys();
   } catch {
     // Network error: assume token might still be good; don't punish the
     // user by clearing it. Worst case AuthProvider will detect it next.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -167,7 +167,7 @@ authorization input, and **not** what scopes rows.
 | | |
 | --- | --- |
 | Stamped by | `createAuthenticatedFetch` ([`src/createAuthenticatedFetch.ts`](src/createAuthenticatedFetch.ts)) |
-| Value read from | `ActiveOrganizationStorage` — `localStorage`, key `auth-active-organization-id` |
+| Value read from | `ActiveOrganizationStorage` ([`src/ActiveOrganizationStorage.ts`](src/ActiveOrganizationStorage.ts)) — `localStorage`, key `auth-active-organization-id:u:$userId` (per-user since objectui#5664; the bare key is the retired pre-#5664 spelling) |
 | Condition | that storage holds a non-empty value |
 | *Not* conditioned on | the URL being an `/api/` call. `Authorization` and `Accept-Language` are; this is not |
 | Suppressed by | `createAuthenticatedFetch({ sameOriginOnly: true })` for cross-origin URLs — it returns before any header work |

--- a/packages/auth/src/ActiveOrganizationStorage.ts
+++ b/packages/auth/src/ActiveOrganizationStorage.ts
@@ -1,0 +1,354 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Per-user client state: WHOSE state this browser currently holds
+ * ({@link SessionUserScope}), and the active organization id scoped to that
+ * user ({@link ActiveOrganizationStorage}).
+ *
+ * # objectui#5664 — why this file exists
+ *
+ * `auth-active-organization-id` was a single un-namespaced `localStorage` key,
+ * while its siblings in `@object-ui/app-shell` were already user-scoped
+ * (`objectui-recent-items:u:<id>`, `objectui-favorites:u:<id>`,
+ * `flow-palette-recents:u:<id>`). On a browser handed from one account to
+ * another the new session read the PREVIOUS user's organization id: the header
+ * workspace chip rendered the previous user's workspace, and — the consequence
+ * that is not cosmetic — the polluted org context suppressed
+ * `RequireOrganization`'s routing into the guided "Create your workspace"
+ * first-run flow. A brand-new user on a shared browser silently never got the
+ * new-user flow.
+ *
+ * The server side was verified clean while the card was written: with the
+ * stale id, `get-full-organization` and `set-active` both answer
+ * `403 USER_IS_NOT_A_MEMBER` and `sys_environment` lists zero rows. Nothing
+ * about row visibility rode on this; the damage was entirely in what the
+ * client believed about itself.
+ *
+ * # The three parts, and which one closes the class
+ *
+ *  1. The key is namespaced per user (below).
+ *  2. `set()` can no longer write the un-namespaced key at all — see
+ *     {@link scopedActiveOrgKey}. Namespacing that keeps a bare-key fallback
+ *     re-opens the defect the first time a write happens before the user id is
+ *     known.
+ *  3. {@link SessionUserScope.adopt} drops the previous user's UI state
+ *     WHOLESALE when the session user changes. That is the load-bearing part:
+ *     (1) and (2) fix one key, while (3) is what keeps the NEXT un-namespaced
+ *     key — one nobody has written yet — from re-opening the same class. It is
+ *     an allowlist sweep for exactly that reason: a denylist of the keys we
+ *     know about today would not cover a key added tomorrow.
+ *
+ * # Resolving the scope with no `await`
+ *
+ * The user id is NOT known from React state at the moment this storage is
+ * first read. `createAuthenticatedFetch` reads it on every request including
+ * the very first `get-session`, and `MetadataProvider` reads it synchronously
+ * at mount to scope its seed cache — both before `AuthProvider`'s async
+ * session chain has resolved anything. So the scope is resolved from
+ * {@link SESSION_USER_STORAGE_KEY}, an ordinary `localStorage` pointer the
+ * PREVIOUS page-load wrote: one synchronous read, no await, and correct for
+ * every boot of a browser that has held a session before.
+ *
+ * The window where that pointer is stale — a boot whose cookie session belongs
+ * to someone other than the pointer — is bounded by `adopt()` firing as soon
+ * as `get-session` answers, and it is the same window the `X-Tenant-ID` edge
+ * contract already documents as "the header may be absent or not yet
+ * authoritative" (objectui#5279, this package's README). Requests that leave
+ * inside it are scoped by the SESSION server-side, not by the header.
+ */
+
+/**
+ * Pointer to the user whose client state this browser holds. Deliberately NOT
+ * user-scoped itself — it is the thing that makes user scoping resolvable, and
+ * it is overwritten rather than accumulated, so there is never more than one.
+ */
+const SESSION_USER_STORAGE_KEY = 'auth-session-user-id';
+
+/** Base name the per-user active-org key is derived from. */
+const ACTIVE_ORG_BASE_KEY = 'auth-active-organization-id';
+
+/**
+ * The pre-#5664 spelling — the same string, un-suffixed. Every browser that
+ * has run an older build still has a value under it, and that value is
+ * UNATTRIBUTABLE: nothing recorded whose org id it is. It is therefore deleted
+ * rather than migrated. Migrating it is precisely the defect (on a handed-over
+ * browser it would hand the previous user's org id to the new one), and
+ * keeping it would leave a live bare key for a future reader to find.
+ *
+ * Dropping it costs a signed-in user nothing durable: `AuthProvider`'s
+ * `refreshOrganizations` asks the SERVER for the active organization whenever
+ * the list is non-empty and no active org is held, including the ADR-0081
+ * single-membership repair. The server is the authority for this value; the
+ * client copy is a routing-header cache. One boot re-supplies it.
+ */
+const LEGACY_ACTIVE_ORG_KEY = ACTIVE_ORG_BASE_KEY;
+
+/**
+ * Keys that survive a change of session user, because they describe the DEVICE
+ * or the INCOMING session rather than the outgoing user's state.
+ *
+ * `auth-session-token` is spelled out rather than imported from
+ * `createAuthClient.ts` (where it is a module-private constant). The two ends
+ * are held together by BEHAVIOUR instead of by a shared symbol — the pin in
+ * `__tests__/sessionUserChangePurge-5664.test.tsx` fills it through the real
+ * `TokenStorage` and reads it back through `TokenStorage` after a purge, so a
+ * spelling that drifts on either side fails there rather than silently signing
+ * the incoming user out.
+ *
+ * `vite-ui-theme` is `@object-ui/app-shell`'s `ThemeProvider` default. An app
+ * that passes a custom `storageKey` loses its theme once on a user change and
+ * re-picks it on the next toggle — cosmetic and self-healing, which is the
+ * right side of an allowlist to err on.
+ */
+const DEVICE_SCOPED_KEYS: ReadonlySet<string> = new Set([
+  'auth-session-token',
+  SESSION_USER_STORAGE_KEY,
+  'vite-ui-theme',
+]);
+
+/**
+ * `localStorage` / `sessionStorage`, or `undefined` where they are absent or
+ * blocked. Accessing the global itself can throw (partitioned iframes, some
+ * privacy modes), so the guard has to be a try/catch and not a `typeof` test
+ * alone.
+ */
+function safeStore(kind: 'local' | 'session'): Storage | undefined {
+  try {
+    if (kind === 'local') {
+      return typeof localStorage !== 'undefined' ? localStorage : undefined;
+    }
+    return typeof sessionStorage !== 'undefined' ? sessionStorage : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readPersisted(key: string): string | null {
+  try {
+    return safeStore('local')?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writePersisted(key: string, value: string): void {
+  try {
+    safeStore('local')?.setItem(key, value);
+  } catch {
+    /* SSR / quota / private browsing — the caller keeps a memory copy */
+  }
+}
+
+function removePersisted(key: string): void {
+  try {
+    safeStore('local')?.removeItem(key);
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+/**
+ * Delete every entry in `store` that is not device-scoped.
+ *
+ * Snapshot the keys first (`Object.keys`) — removing entries during a live
+ * index walk shifts the ones behind it and skips half of them. Same idiom as
+ * `AuthProvider`'s sign-out purge loop.
+ */
+function sweepStore(store: Storage | undefined): void {
+  if (!store) return;
+  try {
+    for (const key of Object.keys(store)) {
+      if (DEVICE_SCOPED_KEYS.has(key)) continue;
+      store.removeItem(key);
+    }
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+/**
+ * Drop the outgoing user's client state wholesale — part 3 of the fix.
+ *
+ * Order is load-bearing and mirrors `clear()`'s: the in-memory active org goes
+ * FIRST, because `ActiveOrganizationStorage.get()` falls through to
+ * `_memoryValue` whenever the persisted read is null, which is exactly the
+ * state this function leaves behind (objectui#5703). Sweeping storage first
+ * would leave the outgoing user's org id live in memory for the rest of the
+ * page-load — the SPA sign-out-then-sign-in path never reloads.
+ *
+ * Both stores are swept. `sessionStorage` is per-TAB, not per-session, so the
+ * previous user's `objectui:metadata:*` seed (their PERMISSION-FILTERED app
+ * list) and their `objectui-ctx-*` scope picks survive into whoever signs in
+ * next in that tab unless something removes them.
+ */
+export function purgePreviousUserClientState(): void {
+  ActiveOrganizationStorage.clear();
+  sweepStore(safeStore('local'));
+  sweepStore(safeStore('session'));
+}
+
+/**
+ * Which user's client state this browser holds, and the transition that drops
+ * the previous user's state.
+ */
+export const SessionUserScope = {
+  /**
+   * Memory copy of the pointer. Read FIRST by {@link current}: once this
+   * page-load has adopted a user, that answer is authoritative for this tab
+   * even if another tab has since written a different id, and it is the only
+   * copy in a browser whose `localStorage` rejects writes.
+   */
+  _userId: null as string | null,
+
+  /** The user whose state this browser holds, or `null` if it has never held one. */
+  current(): string | null {
+    if (this._userId !== null) return this._userId;
+    return readPersisted(SESSION_USER_STORAGE_KEY);
+  },
+
+  /**
+   * Record `userId` as the owner of this browser's client state, dropping the
+   * previous owner's state wholesale when it changes.
+   *
+   * Idempotent: re-adopting the same user purges nothing. Called from
+   * `AuthProvider` for real sessions only — the synthetic `preview-user` /
+   * `guest` identities never reach it, so a preview mount cannot purge a real
+   * user's state.
+   */
+  adopt(userId: string): void {
+    if (!userId) return;
+    const previous = this.current();
+    if (previous !== null && previous !== userId) {
+      purgePreviousUserClientState();
+    }
+    this._userId = userId;
+    writePersisted(SESSION_USER_STORAGE_KEY, userId);
+    // Unattributable legacy state, cleaned up on any adopt rather than only on
+    // a change — see LEGACY_ACTIVE_ORG_KEY.
+    removePersisted(LEGACY_ACTIVE_ORG_KEY);
+  },
+
+  /**
+   * Forget the in-memory pointer. Test seam only — production has no reason to
+   * un-know who is signed in, and sign-out deliberately KEEPS the persisted
+   * pointer so that the next sign-in by a DIFFERENT user still sees a previous
+   * owner to purge.
+   */
+  _resetForTests(): void {
+    this._userId = null;
+  },
+};
+
+/**
+ * The `localStorage` key holding the active org id for the current user, or
+ * `null` when no user is known yet.
+ *
+ * `null` — not the bare base key — is the whole point. `@object-ui/app-shell`'s
+ * `scopedKey(base, userId)` falls back to the un-namespaced key for
+ * "no user id yet", and that is correct THERE: its callers persist recents and
+ * favourites, where a signed-out bucket leaking is cosmetic. Here the bare key
+ * IS the defect, so "no user id yet" means "there is no key to persist under"
+ * and the value lives in memory for this page-load only. The convention for
+ * the scoped half is copied exactly (`${base}:u:${userId}`) — the symbol
+ * cannot travel, because `@object-ui/app-shell` depends on `@object-ui/auth`
+ * and not the other way round.
+ */
+function scopedActiveOrgKey(): string | null {
+  const userId = SessionUserScope.current();
+  return userId ? `${ACTIVE_ORG_BASE_KEY}:u:${userId}` : null;
+}
+
+/**
+ * Get/set the active organization id that {@link createAuthenticatedFetch}
+ * stamps as `X-Tenant-ID`.
+ *
+ * `AuthProvider` is the only writer, at four moments: `refreshOrganizations`
+ * sets it once the `getSession` -> `listOrganizations` ->
+ * `getActiveOrganization` chain resolves (including the ADR-0081
+ * single-membership repair), `switchOrganization` sets or clears it,
+ * `deleteOrganization` / `leaveOrganization` clear it when the active org is
+ * the one going away, and sign-out clears it.
+ *
+ * Because the first of those is asynchronous, this reads EMPTY for the first
+ * stretch of a boot, and every request that leaves in that window carries no
+ * tenant header at all. That window is a documented part of the header's
+ * contract, not an accident to paper over — see the "unstamped-first-request
+ * gap" section of this package's README (objectui#5279).
+ */
+export const ActiveOrganizationStorage = {
+  _memoryValue: null as string | null,
+
+  /**
+   * The active org id for the CURRENT user, or `null`.
+   *
+   * READ ORDER — a non-null `localStorage` read wins; anything else falls
+   * through to `_memoryValue`. Returning the `localStorage` read
+   * UNCONDITIONALLY (what this did before objectui#5703) left the fallback
+   * reachable only when the read THREW, and there is a real browser state
+   * where the read does not throw and the fallback is still the only copy:
+   * `localStorage` present and readable but REJECTING WRITES — Safari private
+   * browsing, and any quota-exhausted origin, where `setItem` throws
+   * `QuotaExceededError`. `set()` swallows that failure into `_memoryValue`
+   * (correctly — the fallback is right there), and `get()` then never
+   * consulted it: the value was stored and could not be read back, so
+   * `X-Tenant-ID` went unstamped for the whole session, not just the early
+   * requests.
+   *
+   * WHY FALLING BACK ON `null` DOES NOT RESURRECT A CLEARED ORG. After
+   * `clear()` the `localStorage` read is null by construction, so this
+   * fallback fires — and it must answer `null`, because sign-out is one of
+   * `clear()`'s callers. It does, because `clear()` nulls `_memoryValue` too.
+   * That property is what makes this read order safe rather than an
+   * incidental detail of `clear()`'s body, so it is pinned by test
+   * (`__tests__/activeOrgStorageFallback-5703.test.tsx`) instead of being
+   * re-derived by whoever edits `clear()` next.
+   *
+   * The same reasoning is why a change of session user purges through
+   * {@link purgePreviousUserClientState} rather than by removing keys: the
+   * outgoing user's id in `_memoryValue` would otherwise outlive their
+   * persisted key on the SPA sign-out-then-sign-in path (objectui#5664).
+   */
+  get(): string | null {
+    const key = scopedActiveOrgKey();
+    if (key) {
+      try {
+        const persisted = safeStore('local')?.getItem(key) ?? null;
+        if (persisted !== null) return persisted;
+      } catch { /* SSR / test */ }
+    }
+    return this._memoryValue;
+  },
+
+  /**
+   * With no session user known this writes to memory ONLY. That is not a
+   * degraded path to apologise for — it is the fix: a persisted write with no
+   * owner is the un-namespaced key this card retired.
+   */
+  set(orgId: string): void {
+    this._memoryValue = orgId;
+    const key = scopedActiveOrgKey();
+    if (!key) return;
+    writePersisted(key, orgId);
+  },
+
+  clear(): void {
+    // Nulling the fallback is SECURITY-RELEVANT, not bookkeeping: `get()`
+    // falls through to `_memoryValue` whenever the `localStorage` read comes
+    // back null, which is exactly the state this method leaves behind. Drop
+    // this line and sign-out's clear stops sticking — the removed key reads
+    // null, the fallback fires, and the cleared org goes back on the wire as
+    // `X-Tenant-ID`. Pinned by `__tests__/activeOrgStorageFallback-5703.test.tsx`.
+    this._memoryValue = null;
+    const key = scopedActiveOrgKey();
+    if (key) removePersisted(key);
+    // Also drop the pre-#5664 bare key, so a `clear()` on a browser upgrading
+    // from an older build leaves nothing behind under the retired spelling.
+    removePersisted(LEGACY_ACTIVE_ORG_KEY);
+  },
+};

--- a/packages/auth/src/ActiveOrganizationStorage.ts
+++ b/packages/auth/src/ActiveOrganizationStorage.ts
@@ -220,11 +220,31 @@ export const SessionUserScope = {
    * `AuthProvider` for real sessions only — the synthetic `preview-user` /
    * `guest` identities never reach it, so a preview mount cannot purge a real
    * user's state.
+   *
+   * Because the decision reads the PERSISTED pointer, anything that deletes
+   * that pointer without deleting the state it describes would silently retire
+   * this invariant. `apps/console/src/lib/auth-preflight.ts` is the one place
+   * that sweeps auth keys before render, and it says so in its own comment:
+   * it removes every active-org spelling and leaves `auth-session-user-id`
+   * alone on purpose.
    */
   adopt(userId: string): void {
     if (!userId) return;
-    const previous = this.current();
-    if (previous !== null && previous !== userId) {
+    // Already this page-load's owner. Short-circuits before the storage read
+    // below, which matters in a browser that REJECTS WRITES: there the pointer
+    // write further down silently fails, so every later call would re-read a
+    // stale persisted owner and purge again.
+    if (this._userId === userId) return;
+    // WHOSE RESIDUE IS IN THIS STORE — read from storage, deliberately not
+    // from {@link current}. The two questions are different and take different
+    // authorities. `current()` answers "which key do I use right now", and
+    // memory is this tab's truth for that. This answers "is there another
+    // user's state PERSISTED here", and the persisted pointer is the only
+    // witness to that: a browser that never persisted anything has no residue
+    // to drop, and purging on the strength of an in-memory id would delete
+    // state that was written for the arriving user.
+    const persistedPrevious = readPersisted(SESSION_USER_STORAGE_KEY);
+    if (persistedPrevious !== null && persistedPrevious !== userId) {
       purgePreviousUserClientState();
     }
     this._userId = userId;

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -11,7 +11,7 @@ import { authGateEvents } from './auth-gate-events.js';
 import type { AuthUser, AuthClient, AuthProviderOptions, PreviewModeOptions, AuthOrganization, AuthOrganizationMember, AuthInvitation, AuthPublicConfig, SignInWithProviderOptions } from './types.js';
 import { AuthCtx, type AuthContextValue } from './AuthContext.js';
 import { createAuthClient, TokenStorage } from './createAuthClient.js';
-import { ActiveOrganizationStorage } from './createAuthenticatedFetch.js';
+import { ActiveOrganizationStorage, SessionUserScope } from './ActiveOrganizationStorage.js';
 
 /**
  * Prefix of every `MetadataProvider` seed entry in `sessionStorage`
@@ -669,6 +669,37 @@ export function AuthProvider({
       setActiveMemberResolved(true);
     }
   }, [client, enabled, isPreviewMode, previewMode, activeOrganization]);
+
+  /**
+   * objectui#5664 — the session-user-change invariant.
+   *
+   * Declared BEFORE the two effects below on purpose: effects run in the order
+   * their hooks were called, so this settles "whose browser is this" before
+   * `refreshActiveMember` and `refreshOrganizations` read or write anything
+   * org-scoped. `refreshOrganizations` in particular calls
+   * `ActiveOrganizationStorage.set()`, which resolves its key through the
+   * pointer this establishes.
+   *
+   * Keyed on the session user ID rather than wired into each of the five
+   * places that set `user` (mount / `refreshSession` / rotation, sign-in,
+   * sign-up, and the two provider flows). One implementation, and a sign-in
+   * path added later is covered without being told to be.
+   *
+   * Preview and auth-disabled mounts are excluded because their identities are
+   * SYNTHETIC — a fixed `preview-user` / `guest` id. Adopting one would read as
+   * a user change and purge a real user's state on any browser that opened a
+   * marketplace demo.
+   *
+   * What "purge" means, and why it is wholesale rather than key-by-key, is in
+   * `ActiveOrganizationStorage.ts`: it is an allowlist sweep, so the NEXT
+   * un-namespaced key is covered before anyone writes it.
+   */
+  useEffect(() => {
+    if (!enabled || isPreviewMode) return;
+    const sessionUserId = user?.id;
+    if (!sessionUserId) return;
+    SessionUserScope.adopt(sessionUserId);
+  }, [user?.id, enabled, isPreviewMode]);
 
   useEffect(() => {
     refreshActiveMember();

--- a/packages/auth/src/__tests__/activeOrgStorageFallback-5703.test.tsx
+++ b/packages/auth/src/__tests__/activeOrgStorageFallback-5703.test.tsx
@@ -31,13 +31,28 @@
  * Lives as `.test.tsx` so it runs under happy-dom alongside
  * `createAuthenticatedFetch.test.tsx` — the wire-level cases need `fetch`,
  * `Headers` and a `window.location` for the same-origin check.
+ *
+ * ## What objectui#5664 changed here, and what it did NOT
+ *
+ * The persisted key is now per-user (`...:u:<userId>`), so these cases adopt a
+ * session user before they touch storage and assert against the scoped
+ * spelling. That is a SPELLING change: every property this file exists to pin
+ * — a non-null persisted read wins, the memory fallback is reachable when
+ * `localStorage` rejects writes, `clear()` nulls `_memoryValue` before it
+ * touches storage, and a cleared org never goes back on the wire — is asserted
+ * unchanged. Without the adopt the cases would still be green and would mean
+ * nothing: with no session user `set()` writes to memory only, so every
+ * "reached the persisted layer" assertion below would be vacuously testing an
+ * empty store.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createAuthenticatedFetch, ActiveOrganizationStorage } from '../createAuthenticatedFetch';
+import { SessionUserScope } from '../ActiveOrganizationStorage';
 import { TokenStorage } from '../createAuthClient';
 
-const ACTIVE_ORG_STORAGE_KEY = 'auth-active-organization-id';
+const SESSION_USER_ID = 'u_5703';
+const ACTIVE_ORG_STORAGE_KEY = `auth-active-organization-id:u:${SESSION_USER_ID}`;
 const API_URL = 'http://localhost/api/v1/meta/object/account';
 
 /**
@@ -81,6 +96,11 @@ function stubFetch() {
 describe('ActiveOrganizationStorage — the in-memory fallback (#5703)', () => {
   beforeEach(() => {
     ActiveOrganizationStorage.clear();
+    // objectui#5664 — the persisted key is per-user. `current()` reads the
+    // in-memory pointer first, so this survives the `localStorage` doubles the
+    // cases install below and the scope is the same in every case.
+    SessionUserScope._resetForTests();
+    SessionUserScope.adopt(SESSION_USER_ID);
     vi.spyOn(TokenStorage, 'get').mockReturnValue(null);
   });
 
@@ -88,6 +108,7 @@ describe('ActiveOrganizationStorage — the in-memory fallback (#5703)', () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     ActiveOrganizationStorage.clear();
+    SessionUserScope._resetForTests();
   });
 
   // ── (a) read-succeeds / write-fails: the card's probe ──────────────────

--- a/packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx
+++ b/packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx
@@ -246,6 +246,29 @@ describe('a change of session user drops the previous user’s state wholesale (
     expect(localStorage.getItem('objectui-nav-order-crm')).toBe('["accounts"]');
   });
 
+  it('does not purge when the previous owner was never PERSISTED', () => {
+    // The asymmetry `adopt()` is built on, pinned so it is not "tidied" back
+    // into a `current()` call. `current()` is memory-first because it answers
+    // "which key do I use in this tab". The purge decision is storage-only
+    // because it answers "is another user's state sitting in this store" — and
+    // a browser that persisted nothing (Safari private browsing, a quota-
+    // exhausted origin, a store cleared out from under us) has no residue to
+    // drop. Purging on an in-memory id there deletes state written FOR the
+    // arriving user, not by the previous one.
+    SessionUserScope.adopt(USER_A);
+    localStorage.clear();
+    localStorage.setItem('objectui-nav-order-crm', '["accounts"]');
+    // Precondition: memory still names A, so a `current()`-based decision
+    // would read this as a change. This case is not vacuous.
+    expect(SessionUserScope.current()).toBe(USER_A);
+    expect(localStorage.getItem('auth-session-user-id')).toBeNull();
+
+    SessionUserScope.adopt(USER_B);
+
+    expect(localStorage.getItem('objectui-nav-order-crm')).toBe('["accounts"]');
+    expect(SessionUserScope.current()).toBe(USER_B);
+  });
+
   it('nulls the in-memory org BEFORE it touches storage', () => {
     // The ordering property #5703 made load-bearing, restated for this path.
     // `get()` falls through to `_memoryValue` whenever the persisted read is

--- a/packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx
+++ b/packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx
@@ -1,0 +1,381 @@
+/**
+ * objectui#5664 — cross-user client-state pollution.
+ *
+ * ## The defect
+ *
+ * `auth-active-organization-id` was one un-namespaced `localStorage` key while
+ * its siblings were already `:u:<userId>`-scoped. A brand-new user signing in
+ * on a browser that had held someone else's session read the PREVIOUS user's
+ * organization id: the header workspace chip rendered the previous user's
+ * workspace, and the polluted org context suppressed `RequireOrganization`'s
+ * routing into the guided "Create your workspace" first-run flow — on a
+ * shared or handed-over browser the new-user flow silently never happened.
+ *
+ * ## What is pinned here
+ *
+ * Three parts, and the third is the one that closes the CLASS:
+ *
+ *  1. the key is per-user, and
+ *  2. it can no longer be written un-namespaced at all, and
+ *  3. **a change of session user drops the previous user's UI state
+ *     wholesale** — so the next un-namespaced key, one nobody has written yet,
+ *     cannot re-open this.
+ *
+ * The headline case is deliberately shaped as ZERO A-SCOPED READS rather than
+ * "B reads the right thing". Asserting only that B's own reads are correct is
+ * green on the buggy code too — B reading `null` for a key nobody wrote proves
+ * nothing about A's residue. So the storage layer is instrumented and the
+ * assertion is over what the reads ANSWERED while B's session booted, with the
+ * instrument's own liveness asserted alongside (a zero hit is a reading only
+ * once the instrument is shown to record something).
+ *
+ * The controls that must SURVIVE the purge carry as much weight as the ones
+ * that must die: `auth-session-token` is the INCOMING user's credential, so a
+ * purge that took it would sign B out on arrival, and the theme is a device
+ * preference belonging to nobody.
+ */
+
+import React, { useEffect } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { AuthProvider } from '../AuthProvider';
+import { useAuth } from '../useAuth';
+import { TokenStorage } from '../createAuthClient';
+import {
+  ActiveOrganizationStorage,
+  SessionUserScope,
+  purgePreviousUserClientState,
+} from '../ActiveOrganizationStorage';
+import type { AuthClient } from '../types';
+import type { AuthContextValue } from '../AuthContext';
+
+const USER_A = 'u_alice';
+const USER_B = 'u_bob';
+const ORG_A = { id: 'org_a', name: "Alice's Workspace", slug: 'alice-ws' };
+
+const LEGACY_ACTIVE_ORG_KEY = 'auth-active-organization-id';
+const scopedOrgKey = (userId: string) => `${LEGACY_ACTIVE_ORG_KEY}:u:${userId}`;
+
+// ---------------------------------------------------------------------------
+// Doubles
+// ---------------------------------------------------------------------------
+
+/**
+ * The handful of methods the provider reaches on these paths — same shape and
+ * same one-place cast as every other double in this package.
+ */
+function createClientFor(
+  userId: string,
+  name: string,
+  orgs: Array<{ id: string; name: string; slug: string }>,
+): AuthClient {
+  const active = orgs[0] ?? null;
+  return {
+    signIn: vi.fn(),
+    signOut: vi.fn().mockImplementation(async () => { TokenStorage.clear(); }),
+    getSession: vi.fn().mockResolvedValue({
+      user: { id: userId, name, email: `${userId}@test.com` },
+      session: { token: `tok-${userId}` },
+    }),
+    listOrganizations: vi.fn().mockResolvedValue(orgs),
+    getActiveOrganization: vi.fn().mockResolvedValue(active),
+    setActiveOrganization: vi.fn().mockResolvedValue(active),
+    getActiveMember: vi.fn().mockResolvedValue(
+      active ? { id: 'mem_1', organizationId: active.id, userId, role: 'owner' } : null,
+    ),
+  } as unknown as AuthClient;
+}
+
+const authRef: { current: AuthContextValue | null } = { current: null };
+
+function Probe() {
+  const auth = useAuth();
+  useEffect(() => { authRef.current = auth; }, [auth]);
+  return (
+    <div>
+      <span data-testid="user">{auth.user?.name ?? 'none'}</span>
+      <span data-testid="active-org">{auth.activeOrganization?.name ?? 'none'}</span>
+    </div>
+  );
+}
+
+/**
+ * Record every `getItem` a store answers, keeping the real store underneath so
+ * the code under test still behaves normally. Returns the log.
+ */
+function recordReads(store: Storage): Array<{ key: string; value: string | null }> {
+  const reads: Array<{ key: string; value: string | null }> = [];
+  const real = store.getItem.bind(store);
+  vi.spyOn(store, 'getItem').mockImplementation((key: string) => {
+    const value = real(key);
+    reads.push({ key, value });
+    return value;
+  });
+  return reads;
+}
+
+beforeEach(() => {
+  authRef.current = null;
+  localStorage.clear();
+  sessionStorage.clear();
+  TokenStorage.clear();
+  ActiveOrganizationStorage.clear();
+  SessionUserScope._resetForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  SessionUserScope._resetForTests();
+});
+
+// ---------------------------------------------------------------------------
+// (1) the key is per-user, and cannot be written un-namespaced
+// ---------------------------------------------------------------------------
+
+describe('the active-org key is per-user (#5664)', () => {
+  it('persists under `:u:<userId>` and not under the bare key', () => {
+    SessionUserScope.adopt(USER_A);
+
+    ActiveOrganizationStorage.set('org_a');
+
+    expect(localStorage.getItem(scopedOrgKey(USER_A))).toBe('org_a');
+    expect(localStorage.getItem(LEGACY_ACTIVE_ORG_KEY)).toBeNull();
+    expect(ActiveOrganizationStorage.get()).toBe('org_a');
+  });
+
+  it('does not read another user’s scope', () => {
+    SessionUserScope.adopt(USER_A);
+    ActiveOrganizationStorage.set('org_a');
+
+    // Straight to the pointer: the same browser, now owned by B, with A's
+    // entry still physically present (the purge is exercised separately —
+    // this case isolates the READ).
+    SessionUserScope._resetForTests();
+    localStorage.setItem('auth-session-user-id', USER_B);
+    ActiveOrganizationStorage._memoryValue = null;
+
+    expect(localStorage.getItem(scopedOrgKey(USER_A))).toBe('org_a');
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  it('writes NOTHING persisted when no session user is known', () => {
+    // The un-namespaced fallback `@object-ui/app-shell`'s `scopedKey` uses for
+    // "no user id yet" is exactly the defect here, so this path is memory-only.
+    ActiveOrganizationStorage.set('org_orphan');
+
+    expect(localStorage.getItem(LEGACY_ACTIVE_ORG_KEY)).toBeNull();
+    expect(Object.keys(localStorage).filter((k) => k.startsWith(LEGACY_ACTIVE_ORG_KEY))).toEqual([]);
+    // Control on the same instrument: with a user adopted the very same call
+    // DOES reach the persisted layer, so the emptiness above is a measurement
+    // and not a broken store.
+    SessionUserScope.adopt(USER_A);
+    ActiveOrganizationStorage.set('org_a');
+    expect(Object.keys(localStorage).filter((k) => k.startsWith(LEGACY_ACTIVE_ORG_KEY)))
+      .toEqual([scopedOrgKey(USER_A)]);
+  });
+
+  it('never resurrects a value sitting under the retired bare key', () => {
+    // The state every existing browser is in on the day this ships.
+    localStorage.setItem(LEGACY_ACTIVE_ORG_KEY, 'org_a');
+
+    SessionUserScope.adopt(USER_B);
+
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+    // Deleted rather than migrated: nothing recorded whose org id it was, and
+    // migrating it is the defect (it would hand A's org to B).
+    expect(localStorage.getItem(LEGACY_ACTIVE_ORG_KEY)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3) the invariant: a change of session user drops the previous user's state
+// ---------------------------------------------------------------------------
+
+describe('a change of session user drops the previous user’s state wholesale (#5664)', () => {
+  it('purges both stores, allowlisting only device-scoped keys', () => {
+    SessionUserScope.adopt(USER_A);
+    ActiveOrganizationStorage.set('org_a');
+    // A's state, in both the namespaced and the un-namespaced shape. The
+    // second is the one that matters: it stands in for the NEXT key someone
+    // adds without a `:u:` scope, which this invariant has to cover without
+    // being told about it.
+    localStorage.setItem(`objectui-recent-items:u:${USER_A}`, '[{"id":"acct_1"}]');
+    localStorage.setItem('objectui-nav-order-crm', '["accounts"]');
+    sessionStorage.setItem('objectui:metadata:app:org_a:@anon', '[{"name":"crm"}]');
+    sessionStorage.setItem('objectui-ctx-studio-active_package', 'pkg_alice');
+    // Device-scoped: the INCOMING session's credential and a preference that
+    // belongs to nobody.
+    TokenStorage.set('tok-bob');
+    localStorage.setItem('vite-ui-theme', 'dark');
+
+    SessionUserScope.adopt(USER_B);
+
+    expect(localStorage.getItem(scopedOrgKey(USER_A))).toBeNull();
+    expect(localStorage.getItem(`objectui-recent-items:u:${USER_A}`)).toBeNull();
+    expect(localStorage.getItem('objectui-nav-order-crm')).toBeNull();
+    expect(sessionStorage.getItem('objectui:metadata:app:org_a:@anon')).toBeNull();
+    expect(sessionStorage.getItem('objectui-ctx-studio-active_package')).toBeNull();
+
+    // The controls that must SURVIVE. A purge that took the token would sign
+    // the arriving user out at the moment they arrive.
+    expect(TokenStorage.get()).toBe('tok-bob');
+    expect(localStorage.getItem('vite-ui-theme')).toBe('dark');
+    expect(localStorage.getItem('auth-session-user-id')).toBe(USER_B);
+  });
+
+  it('purges nothing when the same user is re-adopted', () => {
+    SessionUserScope.adopt(USER_A);
+    ActiveOrganizationStorage.set('org_a');
+    localStorage.setItem('objectui-nav-order-crm', '["accounts"]');
+
+    SessionUserScope.adopt(USER_A);
+
+    expect(ActiveOrganizationStorage.get()).toBe('org_a');
+    expect(localStorage.getItem('objectui-nav-order-crm')).toBe('["accounts"]');
+  });
+
+  it('purges nothing on the first sign-in a browser has ever seen', () => {
+    localStorage.setItem('vite-ui-theme', 'dark');
+    localStorage.setItem('objectui-nav-order-crm', '["accounts"]');
+
+    SessionUserScope.adopt(USER_A);
+
+    // No previous owner recorded, so there is no previous owner's state to
+    // drop — this must not read as a change.
+    expect(localStorage.getItem('objectui-nav-order-crm')).toBe('["accounts"]');
+  });
+
+  it('nulls the in-memory org BEFORE it touches storage', () => {
+    // The ordering property #5703 made load-bearing, restated for this path.
+    // `get()` falls through to `_memoryValue` whenever the persisted read is
+    // null — which is exactly the state a purge leaves behind — so an
+    // implementation that swept storage first would leave A's org id live in
+    // memory for the rest of a page-load, and the SPA sign-out-then-sign-in
+    // path never reloads.
+    const observed: Array<string | null> = [];
+    const realClear = ActiveOrganizationStorage.clear.bind(ActiveOrganizationStorage);
+    vi.spyOn(ActiveOrganizationStorage, 'clear').mockImplementation(() => {
+      realClear();
+      observed.push(ActiveOrganizationStorage._memoryValue);
+    });
+
+    SessionUserScope.adopt(USER_A);
+    ActiveOrganizationStorage.set('org_a');
+    expect(ActiveOrganizationStorage._memoryValue).toBe('org_a');
+
+    SessionUserScope.adopt(USER_B);
+
+    expect(observed).toEqual([null]);
+    expect(ActiveOrganizationStorage._memoryValue).toBeNull();
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  it('survives a storage layer that is entirely unavailable', () => {
+    // SSR / partitioned iframe: the purge must be a no-op, not a throw on the
+    // sign-in path.
+    vi.stubGlobal('localStorage', undefined);
+    vi.stubGlobal('sessionStorage', undefined);
+
+    expect(() => purgePreviousUserClientState()).not.toThrow();
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The end-to-end shape: user B signs in after user A, through AuthProvider
+// ---------------------------------------------------------------------------
+
+describe('user B signing in after user A reads none of A’s state (#5664)', () => {
+  it('answers ZERO A-scoped reads, and lands B without an organization', async () => {
+    // --- user A's session, through the real provider -----------------------
+    const view = render(
+      <AuthProvider authUrl="/api/auth" client={createClientFor(USER_A, 'Alice', [ORG_A])}>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(view.getByTestId('user').textContent).toBe('Alice'));
+    await waitFor(() =>
+      expect(view.getByTestId('active-org').textContent).toBe("Alice's Workspace"),
+    );
+    expect(localStorage.getItem(scopedOrgKey(USER_A))).toBe(ORG_A.id);
+
+    // The rest of A's UI state, as the browser holds it when it is handed over.
+    localStorage.setItem(`objectui-recent-items:u:${USER_A}`, '[{"id":"acct_1"}]');
+    localStorage.setItem('objectui-nav-order-crm', '["accounts"]');
+    sessionStorage.setItem('objectui:metadata:app:org_a:@anon', '[{"name":"crm"}]');
+    const A_VALUES = new Set([
+      ORG_A.id,
+      '[{"id":"acct_1"}]',
+      '["accounts"]',
+      '[{"name":"crm"}]',
+    ]);
+
+    cleanup();
+    // B arrives with their own credential and a device preference that is
+    // nobody's state.
+    TokenStorage.set('tok-bob');
+    localStorage.setItem('vite-ui-theme', 'dark');
+    // A page reload drops the in-memory pointer; the persisted one (A) is what
+    // the next boot resolves the scope from, exactly as in the browser.
+    SessionUserScope._resetForTests();
+
+    // --- instrument, then boot B ------------------------------------------
+    const localReads = recordReads(localStorage);
+    const sessionReads = recordReads(sessionStorage);
+
+    const viewB = render(
+      <AuthProvider authUrl="/api/auth" client={createClientFor(USER_B, 'Bob', [])}>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(viewB.getByTestId('user').textContent).toBe('Bob'));
+    await waitFor(() => expect(authRef.current?.isOrganizationsLoading).toBe(false));
+
+    const reads = [...localReads, ...sessionReads];
+    // The instrument is live — a zero hit below is a measurement, not a
+    // silent no-op. (`auth-session-token` alone guarantees traffic.)
+    expect(reads.length).toBeGreaterThan(0);
+
+    // THE PIN: nothing B's session read answered with a value of A's.
+    const aScopedReads = reads.filter((r) => r.value !== null && A_VALUES.has(r.value));
+    expect(aScopedReads).toEqual([]);
+
+    // ... and nothing keyed to A is left to be read later either.
+    const survivingAKeys = [...Object.keys(localStorage), ...Object.keys(sessionStorage)]
+      .filter((k) => k.includes(USER_A) || k.includes(ORG_A.id));
+    expect(survivingAKeys).toEqual([]);
+
+    // The consequence the card is actually about: B has no organization
+    // context, so `RequireOrganization` routes them into the guided first-run
+    // flow instead of a Welcome page furnished for A.
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+    expect(authRef.current?.activeOrganization).toBeNull();
+    expect(authRef.current?.organizations).toEqual([]);
+    expect(viewB.getByTestId('active-org').textContent).toBe('none');
+
+    // B is still signed in: the purge took state, not credentials.
+    expect(TokenStorage.get()).toBe('tok-bob');
+    expect(localStorage.getItem('vite-ui-theme')).toBe('dark');
+  });
+
+  it('does not adopt — or purge for — a synthetic preview identity', async () => {
+    SessionUserScope.adopt(USER_A);
+    ActiveOrganizationStorage.set('org_a');
+    localStorage.setItem('objectui-nav-order-crm', '["accounts"]');
+
+    const view = render(
+      <AuthProvider authUrl="/api/auth" previewMode={{ simulatedRole: 'admin' }}>
+        <Probe />
+      </AuthProvider>,
+    );
+    await waitFor(() => expect(view.getByTestId('user').textContent).not.toBe('none'));
+
+    // A marketplace demo mounts with a fixed `preview-user` id. Treating that
+    // as a user change would purge a real signed-in user's state.
+    expect(SessionUserScope.current()).toBe(USER_A);
+    expect(localStorage.getItem('objectui-nav-order-crm')).toBe('["accounts"]');
+    expect(localStorage.getItem(scopedOrgKey(USER_A))).toBe('org_a');
+  });
+});

--- a/packages/auth/src/createAuthenticatedFetch.ts
+++ b/packages/auth/src/createAuthenticatedFetch.ts
@@ -8,6 +8,7 @@
 
 import { TokenStorage } from './createAuthClient.js';
 import { authGateEvents, detectAuthGate } from './auth-gate-events.js';
+import { ActiveOrganizationStorage } from './ActiveOrganizationStorage.js';
 
 /**
  * Options for creating an authenticated adapter.
@@ -19,87 +20,14 @@ export interface AuthenticatedAdapterOptions {
   [key: string]: unknown;
 }
 
-const ACTIVE_ORG_STORAGE_KEY = 'auth-active-organization-id';
-
 /**
- * Get/set the active organization id that {@link createAuthenticatedFetch}
- * stamps as `X-Tenant-ID`.
- *
- * `AuthProvider` is the only writer, at four moments: `refreshOrganizations`
- * sets it once the `getSession` -> `listOrganizations` ->
- * `getActiveOrganization` chain resolves (including the ADR-0081
- * single-membership repair), `switchOrganization` sets or clears it,
- * `deleteOrganization` / `leaveOrganization` clear it when the active org is
- * the one going away, and sign-out clears it.
- *
- * Because the first of those is asynchronous, this reads EMPTY for the first
- * stretch of a boot, and every request that leaves in that window carries no
- * tenant header at all. That window is a documented part of the header's
- * contract, not an accident to paper over — see the "unstamped-first-request
- * gap" section of this package's README (objectui#5279).
+ * Re-exported from its own module so this file stays the WIRE lane and the
+ * storage lane has one home. `ActiveOrganizationStorage` moved out when it
+ * gained per-user scoping (objectui#5664); the export identity is unchanged,
+ * so `@object-ui/auth`'s barrel, this package's tests and every consumer
+ * import the same symbol from the same place they did before.
  */
-export const ActiveOrganizationStorage = {
-  _memoryValue: null as string | null,
-
-  /**
-   * The active org id, or `null`.
-   *
-   * READ ORDER — a non-null `localStorage` read wins; anything else falls
-   * through to `_memoryValue`. Returning the `localStorage` read
-   * UNCONDITIONALLY (what this did before objectui#5703) left the fallback
-   * reachable only when the read THREW, and there is a real browser state
-   * where the read does not throw and the fallback is still the only copy:
-   * `localStorage` present and readable but REJECTING WRITES — Safari private
-   * browsing, and any quota-exhausted origin, where `setItem` throws
-   * `QuotaExceededError`. `set()` swallows that failure into `_memoryValue`
-   * (correctly — the fallback is right there), and `get()` then never
-   * consulted it: the value was stored and could not be read back, so
-   * `X-Tenant-ID` went unstamped for the whole session, not just the early
-   * requests.
-   *
-   * WHY FALLING BACK ON `null` DOES NOT RESURRECT A CLEARED ORG. After
-   * `clear()` the `localStorage` read is null by construction, so this
-   * fallback fires — and it must answer `null`, because sign-out is one of
-   * `clear()`'s callers. It does, because `clear()` nulls `_memoryValue` too.
-   * That property is what makes this read order safe rather than an
-   * incidental detail of `clear()`'s body, so it is pinned by test
-   * (`__tests__/activeOrgStorageFallback-5703.test.tsx`) instead of being
-   * re-derived by whoever edits `clear()` next.
-   */
-  get(): string | null {
-    try {
-      if (typeof localStorage !== 'undefined') {
-        const persisted = localStorage.getItem(ACTIVE_ORG_STORAGE_KEY);
-        if (persisted !== null) return persisted;
-      }
-    } catch { /* SSR / test */ }
-    return this._memoryValue;
-  },
-
-  set(orgId: string): void {
-    this._memoryValue = orgId;
-    try {
-      if (typeof localStorage !== 'undefined') {
-        localStorage.setItem(ACTIVE_ORG_STORAGE_KEY, orgId);
-      }
-    } catch { /* SSR / test */ }
-  },
-
-  clear(): void {
-    // Nulling the fallback is SECURITY-RELEVANT, not bookkeeping: `get()`
-    // falls through to `_memoryValue` whenever the `localStorage` read comes
-    // back null, which is exactly the state this method leaves behind. Drop
-    // this line and sign-out's clear stops sticking — the removed key reads
-    // null, the fallback fires, and the cleared org goes back on the wire as
-    // `X-Tenant-ID`. Pinned by `__tests__/activeOrgStorageFallback-5703.test.tsx`.
-    this._memoryValue = null;
-    try {
-      if (typeof localStorage !== 'undefined') {
-        localStorage.removeItem(ACTIVE_ORG_STORAGE_KEY);
-      }
-    } catch { /* SSR / test */ }
-  },
-};
+export { ActiveOrganizationStorage, SessionUserScope, purgePreviousUserClientState } from './ActiveOrganizationStorage.js';
 
 export interface CreateAuthenticatedFetchOptions {
   /**


### PR DESCRIPTION
Fixes #5664

Verified on `a92b9902c` (the final commit; every result below was measured on that tree).

## What was wrong

`auth-active-organization-id` was one un-namespaced `localStorage` key while its siblings
were already user-scoped (`objectui-recent-items:u:`, `objectui-favorites:u:`,
`flow-palette-recents:u:`). On a browser handed from one account to another the arriving
user's console read the previous user's organization id — and the consequence past the
cosmetics is the one that matters: the polluted org context suppressed
`RequireOrganization`'s routing into the guided "Create your workspace" first-run flow, so
a brand-new user on a shared browser silently never got the new-user flow.

Server side is unchanged and was already clean (403 `USER_IS_NOT_A_MEMBER` on the stale
org id). This is purely client state.

## What changed

1. **The key is per-user** — `auth-active-organization-id:u:$userId`, the convention
   `@object-ui/app-shell`'s `scopedKey` already uses.
2. **It can no longer be written un-namespaced at all.** Where no session user is known
   yet the value lives in memory for that page-load only. `scopedKey`'s un-namespaced
   fallback is right for recents and favourites; here the bare key *is* the defect, so
   this file deliberately inverts that branch and says so at the call site.
3. **A change of session user drops the previous user's client state wholesale**
   (`SessionUserScope.adopt`). This is an **allowlist** sweep of both `localStorage` and
   `sessionStorage` — not a list of known keys — because that is the only shape that
   covers the *next* key someone adds without a `:u:` scope. Only device-scoped entries
   survive: the arriving session's bearer token, the pointer recording whose state the
   browser holds, and the UI theme.

`ActiveOrganizationStorage` moved into its own file, `packages/auth/src/ActiveOrganizationStorage.ts`.
Its export identity is unchanged — `createAuthenticatedFetch.ts` re-exports it — so the
barrel, the existing tests and every consumer import the same symbol from the same place.

### Resolving the user scope with no `await`

The user id is not known from React state when this storage is first read:
`createAuthenticatedFetch` reads it on every request including the first `get-session`,
and `MetadataProvider` reads it synchronously at mount to scope its seed cache. The scope
is therefore resolved from a plain `localStorage` pointer (`auth-session-user-id`) that
the *previous* page-load wrote — one synchronous read, no await.

### The #5730 properties are preserved

Both are still pinned and still green:

- `get()` prefers a non-null `localStorage` read and falls back to `_memoryValue`.
- the memory value is nulled **before** storage is touched — by `clear()` as before, and
  now by the user-change purge too, so the outgoing user's org id cannot outlive their
  persisted key on the sign-out-then-sign-in path that never reloads.

`packages/auth/src/__tests__/activeOrgStorageFallback-5703.test.tsx` needed two edits — the
key literal, and adopting a session user in `beforeEach`. That is a **spelling** change:
every property the file exists to pin is asserted unchanged. Without the adopt the cases
would still be green and would mean nothing, because with no session user `set()` writes
to memory only and every "reached the persisted layer" assertion would be vacuous.

### Migration decision (stated, not silent)

**No migration. The bare key is deleted.** A value under the retired key is
*unattributable* — nothing recorded whose org id it is — so migrating it is precisely the
defect it would be migrating away from: on a handed-over browser it hands A's org to B. A
signed-in user loses nothing durable; the active organization is a server-owned fact that
`refreshOrganizations` re-asks for whenever the list is non-empty and no active org is
held (including the ADR-0081 single-membership repair). One boot re-supplies it. Users
with no organization land on the guided first-run flow, which is the outcome this card is
about.

### Why the purge decision reads storage, not memory

`SessionUserScope.current()` is memory-first (it answers "which key do I use in this
tab"). `adopt()` deliberately reads the **persisted** pointer instead, because it answers
a different question — "is another user's state sitting in this store" — and the persisted
pointer is the only witness to that. Deciding from memory made the purge fire on a browser
with nothing persisted to purge, deleting state written *for* the arriving user. That was
measured, not reasoned: it turned
`packages/app-shell/src/providers/__tests__/MetadataProvider.crossPrincipalSeed.test.tsx`
red. Pinned in both directions (case `does not purge when the previous owner was never
PERSISTED`, plus ablation A5 below).

## Tests

New: `packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx`, 12 cases.

The headline case is shaped as **zero A-scoped reads**, not "B reads the right thing" —
the latter is green on the buggy code too. Both stores' `getItem` are instrumented, the
assertion is over what the reads *answered* while B's session booted, and the
instrument's own liveness is asserted alongside so the zero hit is a measurement rather
than a silent no-op. The controls that must **survive** are asserted too:
`auth-session-token` is the arriving user's credential, so a purge that took it would
sign B out on arrival.

```
pnpm exec vitest run packages/auth/ packages/app-shell/src/providers/__tests__/ --maxWorkers=2
  Test Files  26 passed (26)      Tests  246 passed (246)

pnpm exec vitest run packages/auth/ packages/app-shell/src/providers/ packages/app-shell/src/layout/ \
                     packages/app-shell/src/console/ apps/console/src --maxWorkers=2
  Test Files  201 passed (201)    Tests  1747 passed (1747)
```

### Ablations — each mutation confirmed on disk in both directions, restored under `trap ... EXIT INT TERM`

Every leg printed `orig=1 injected=0` before and `orig=0 injected=1` after, and the run was
voided if either check failed. No rebuild is involved: these tests import the module by
relative source path, so `dist/` is not on the resolution path.

| # | Mutation | Red |
| --- | --- | --- |
| A1 | `scopedActiveOrgKey()` returns the bare key (the naive port) | 5 of 12 |
| A2 | `adopt()` no longer purges | 3 of 12 |
| A3 | `auth-session-token` dropped from the device allowlist | 2 of 12 |
| A4 | the invariant unwired from `AuthProvider` | 1 of 12 |
| A5 | purge decided from `current()` (memory-first) | 1 of 12 |

The headline case dies under A1–A4. Three readings worth stating rather than smoothing over:

- Under **A2** the headline case is caught by the *surviving-keys* assertion, not by the
  read log — with the key still namespaced nothing in this package *reads* A's residue.
  Both halves of that case are load-bearing; neither alone covers A2.
- Under **A1** the case `never resurrects a value sitting under the retired bare key`
  correctly stays **green**: it pins the *deletion* of the legacy value, which A1 does not
  touch. A control that survives an ablation it has no business failing is a feature.
- Under **A4** the case fails at its own setup assertion (A's org id never reaches
  storage, because nothing adopts a user). That is a real signal about the wiring, and it
  is narrower than the others — worth knowing when reading the table.

## Gates run locally

| Gate | Verdict line |
| --- | --- |
| `pnpm lint` (repo-wide, `eslint . --no-inline-config`) | `Tasks: 47 successful, 47 total` — exit 0, no narrowing |
| `check-lint-coverage` | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `type-check` — auth, app-shell, console | all `Done`, exit 0 (against a rebuilt dependency closure) |
| `check-type-check-coverage` | `45/46 via type-check, 0 known-broken` |
| `check-control-bytes` | `OK (scanned 4790 tracked text file(s); skipped 85 binary)` |
| `check-package-self-import` | `No package names itself inside its own src/` |
| `check-node-esm-load --specifiers-only` | `no un-ledgered package emits an extensionless relative specifier` |
| `check-phantom-dependencies` | `Every in-scope import is declared by the package that publishes it` |
| `check-changeset-presence` | `6 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |

`check-eager-closure-budget`, `check-doc-snippet-types` and `check-published-dist-tooling`
are the known worktree-broken gauges and were left to CI. On the budget specifically: this
change adds **no** static import anywhere — `auth-preflight.ts` deliberately spells the key
prefix out rather than importing `@object-ui/auth`, precisely so the pre-render entry chunk
does not gain that closure.

## Notes for the batch

- **`createAuthenticatedFetch.ts` (read-only for #5702):** its runtime behaviour is
  unchanged — same `ActiveOrganizationStorage.get()` call, same header logic, same
  exports. The only change is that the storage object is now *defined* in a sibling module
  and re-exported from here. No signature moved.
- **One file outside the dispatched fence was touched, deliberately and loudly:**
  `packages/auth/README.md`, one table row that named the storage key. The change renames
  that key, so leaving the row would leave the package documenting a spelling that no
  longer exists — to a cloud-repo audience that reads this table for the `X-Tenant-ID`
  contract. One line, same defect class, no other claimant. Drop it if the seat would
  rather it went in a separate PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_