### PR TITLE
fix(app-shell): drop the dead `theme:` clientValidation entry pointing at a retired spec symbol

### DIFF
--- a/.changeset/theme-clientvalidation-dead-entry-5715.md
+++ b/.changeset/theme-clientvalidation-dead-entry-5715.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Removed the dead `theme:` entry from `clientValidation.ts`'s `LOADERS` table, which
+read `ThemeSchema` off `@objectstack/spec/ui` — a symbol the spec retired upstream
+(objectstack#10485 / PR objectstack#10695, which deleted the whole `ui/theme.zod.ts`
+module). `theme` was never a registered metadata type, so metadata-admin never asked
+for it (objectui#5715).
+
+This is dead-code hygiene, not a bug fix, and it changes nothing an author can
+observe. Two measurements say why, and both cut against the more dramatic reading:
+
+- The entry is not broken *today*. objectui's own `@objectstack/spec` pin (17.1.0)
+  still publishes `ThemeSchema` as a working strict Zod schema — measured by
+  importing the `ui` subpath and by ablation, where restoring the entry made
+  `validateMetadataDraft('theme', ...)` actively reject a draft. The skew is with
+  objectstack's `main`, not with what objectui installs, which is exactly why no
+  gate here ever went red.
+- It could never have crashed. `getSchemaForType` duck-checks the loader's result
+  (`typeof schema.safeParse === 'function'`) and wraps the call in `try/catch`, so an
+  `undefined` export degrades to a silent no-op validator, never a throw. After a
+  future spec bump past the retirement that is the branch it would have taken.
+
+The one thing that was genuinely off: `hasClientValidator` answers from key presence
+alone, so it returned `true` for `theme` while the validator behind it would have
+judged nothing. Per its own docblock that combination makes `ResourceEditPage` treat
+live client issues as the error source and suppress the server's `_diagnostics` — a
+stored item rendering as clean. Unreachable in practice, but it is the reason the
+entry is worth removing rather than leaving inert.
+
+The line is replaced by an absence note in the shape the file already uses for
+`workflow` and `approval`, because re-adding this entry from the spec would
+type-check and go green against the current pin. A metadata-admin theme editing
+surface remains a separate capability decision.

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.themeRetired.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.themeRetired.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `theme` — the retired `clientValidation.ts` LOADERS entry, and the pin that
+ * keeps it retired (objectui#5715).
+ *
+ * The entry read `ThemeSchema` off `@objectstack/spec/ui`. The spec retired
+ * that whole module upstream (objectstack#10485 / PR objectstack#10695), and
+ * `theme` was never a registered metadata type, so nothing ever asked for it.
+ *
+ * Why this needs a pin rather than just a comment: objectui's own
+ * `@objectstack/spec` pin STILL publishes `ThemeSchema` as a working Zod
+ * schema, so re-adding the entry would type-check, resolve, and go green —
+ * exactly the "finish the job by wiring it back up" regression this file
+ * exists to stop. It is also the wrong-schema class `clientValidation.ts` has
+ * already paid for twice (`email_template`, then the objectui#3561 three).
+ *
+ * NOTE: this deliberately does NOT pin "the spec no longer exports
+ * ThemeSchema" — that assertion would be red today and would flip for reasons
+ * unrelated to this module. What is pinned is this module's own behaviour.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateMetadataDraft, hasClientValidator } from './clientValidation';
+
+describe('`theme` is not a client-validated metadata type — objectui#5715', () => {
+  it('reports NO client validator on either door', async () => {
+    // CONTROL: a live table-mate on the same subpath must still gate, so a
+    // `false` on `theme` is a measurement and not a broken import.
+    expect(hasClientValidator('page', 'create')).toBe(true);
+    expect(hasClientValidator('page', 'edit')).toBe(true);
+
+    expect(hasClientValidator('theme', 'create')).toBe(false);
+    expect(hasClientValidator('theme', 'edit')).toBe(false);
+  });
+
+  it('falls through to server-side validation instead of judging the draft', async () => {
+    // Load-bearing, per the `hasClientValidator` docblock: a type that answers
+    // `true` makes `ResourceEditPage` treat live client issues as the error
+    // source and suppress the server's `_diagnostics`. While the entry existed,
+    // `theme` answered `true` — so had it ever been reached, a stored item
+    // would have rendered as clean with the server's errors suppressed.
+    const res = await validateMetadataDraft('theme', { nonsense: true });
+    expect(res.ok).toBe(true);
+    expect(res.issues).toEqual([]);
+
+    // CONTROL: the same shape IS judged for a wired type, proving the
+    // pass-through above is `theme`-specific and not a dead test.
+    const control = await validateMetadataDraft('page', { nonsense: true });
+    expect(control.ok).toBe(false);
+    expect(control.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -587,7 +587,16 @@ const LOADERS: Record<string, SchemaLoader> = {
   dashboard: async () => (await import('@objectstack/spec/ui')).DashboardSchema as unknown as ZodLikeSchema,
   report: async () => (await import('@objectstack/spec/ui')).ReportSchema as unknown as ZodLikeSchema,
   action: async () => (await import('@objectstack/spec/ui')).ActionSchema as unknown as ZodLikeSchema,
-  theme: async () => (await import('@objectstack/spec/ui')).ThemeSchema as unknown as ZodLikeSchema,
+  // `theme` is intentionally absent. It was never a registered metadata type,
+  // so metadata-admin never asks for it — and the spec retired the whole
+  // `ui/theme.zod.ts` module (objectstack#10485 / PR objectstack#10695), so the
+  // `ThemeSchema` the old entry read off this subpath is gone upstream. Nothing
+  // here ever went red because objectui's own `@objectstack/spec` pin (17.1.0)
+  // still publishes that symbol: the entry type-checked and resolved, and would
+  // simply have degraded to a silent no-op validator (`getSchemaForType`'s
+  // `safeParse` duck-check) on the first bump past the retirement. Do not
+  // re-add it from the spec — a metadata-admin theme editing surface is a
+  // capability decision of its own (objectui#5715).
 
   // automation
   flow: async () => (await import('@objectstack/spec/automation')).FlowSchema as unknown as ZodLikeSchema,


### PR DESCRIPTION
Fixes #5715

Removes the dead `theme:` entry from the `LOADERS` table in
`packages/app-shell/src/views/metadata-admin/clientValidation.ts`, which read
`ThemeSchema` off `@objectstack/spec/ui` — a symbol the spec retired upstream
(objectstack#10485 / PR objectstack#10695, which deleted the whole
`ui/theme.zod.ts` module). `theme` was never a registered metadata type.

Per the triage ruling, the line is replaced by an absence note in the shape the
file already uses for `workflow` and `approval` a few lines below, rather than
left as a bare hole. The five live table-mates above it (`page`, `app`,
`dashboard`, `report`, `action`) are untouched.

## Measurements

Three claims in the card were checked rather than assumed. Two hold; one is
falsified and one is materially sharpened.

**1. The installed spec pin still publishes the symbol — CONFIRMED.** The card's
central claim (no gate can catch this) rests on a fact it could not measure.
Measured by importing the resolved `ui` subpath and reading the namespace:

```
ThemeSchema        present=true   type=function safeParse=function
PageSchema         present=true   type=function safeParse=function
FormViewSchema     present=true   type=function safeParse=function
AppSchema          present=true   type=function safeParse=function
total exports: 231
exports matching /theme/i: ["ThemeMode","ThemeModeSchema","ThemeSchema","defineTheme"]
```

Installed `@objectstack/spec` is **17.1.0** (app-shell declares `^17.0.0`).
Controls are live on the same command, so this is a measurement. The premise does
**not** invert: the symbol is present here, tsc compiles clean, and the skew is
with objectstack's `main` rather than with what objectui installs. That is exactly
why nothing here ever went red.

**2. "A crash, or a silent no-op" — the crash branch is FALSIFIED.** The caller
cannot crash on a missing export. `getSchemaForType` duck-checks the loader result
and additionally wraps the call in `try/catch`:

```ts
const value = (schema && typeof schema.safeParse === 'function') ? schema : null;
```

An `undefined` export therefore degrades to `null`, and `validateMetadataDraft`
returns `{ok: true, issues: []}`. It is the silent-no-op branch, guarded twice.

The sharpening: that branch is **not what happens today**. Because 17.1.0 still
ships a working strict `ThemeSchema`, the entry currently resolves and would
actively judge a draft — demonstrated by the ablation below, where restoring the
entry made `validateMetadataDraft('theme', ...)` *reject* a draft. The no-op is the
branch it would have taken on the first spec bump past the retirement. So this is
dead-code hygiene, not a latent-crash fix, and the changeset says so.

**3. "Unreachable" — TRUE in practice, but not structurally guaranteed here.**
`ResourceEditPage.tsx:283` keys the lookup from a route param:

```ts
const type = typeProp ?? params.type ?? '';
```

`resolveResourceConfig` is total (it falls back to a bare config for an unknown
type), and the route itself is defined by the consuming app, so this package
cannot close the key set. What makes `theme` unreachable is the upstream fact that
no server registers it as a metadata type, not a guard in this code. Controlled
greps: zero `'theme'` string literals in `app-shell/src` other than
`ConsoleToaster.tsx:22` (the next-themes UI theme, unrelated), and zero `theme`
references in the metadata-admin tests against controls `sharing_rule` (15) and
`translation` (22).

One thing was genuinely off: `hasClientValidator` answers from key presence alone,
so it returned `true` for `theme` while the validator behind it would judge
nothing. Per its own docblock that combination makes `ResourceEditPage` treat live
client issues as the error source and suppress the server's `_diagnostics`.
Unreachable in practice, but it is why the entry is worth removing rather than
leaving inert.

## Tests

`clientValidation.themeRetired.test.ts` pins this module's behaviour, each negative
paired with a live control so a `false` is a measurement and not a broken import:
`hasClientValidator('theme')` is false on both doors, and
`validateMetadataDraft('theme', ...)` falls through, while `page` still gates and
still rejects the same shape.

It deliberately does **not** pin "the spec no longer exports ThemeSchema" — that
would be red today and would flip for reasons unrelated to this module.

**Ablation** (re-adding the entry), mutation confirmed on disk by anchored
occurrence counts in both directions, restored under `trap ... EXIT INT TERM`:

```
MUTATION ON DISK: injected-line count 0 -> 1
ABLATION_TEST_EXIT=1
  x reports NO client validator on either door
  x falls through to server-side validation instead of judging the draft
  AssertionError: expected true to be false
  AssertionError: expected false to be true
restore leg: injected-line count now = 0, note-anchor count now = 1, Tests 2 passed
```

Both legs bite. No rebuild leg was required: the test imports `./clientValidation`
by relative path from source, so vitest transforms the mutated file directly — and
the behaviour change itself proves the mutated source is what ran.

## Verification

Green union re-run at final HEAD `280668a82`:

- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/` — Test Files 194 passed, Tests 1977 passed / 1 skipped (run at `6b8f330d6`; source tree identical, only the changeset markdown was added after)
- targeted re-run at `280668a82` — Test Files 3 passed, Tests 36 passed
- `pnpm --filter @object-ui/app-shell type-check` — exit 0
- `check:spec-symbols` — `spec symbol derivation: 1296 files scanned against 4966 spec export names`
- `check:control-bytes` — `check-control-bytes: OK (scanned 4792 tracked text file(s))`
- `check:self-import`, `check:phantom-deps`, `check:esm-specifiers`, `check:action-forward-parity` — exit 0
- changeset presence / no-major / fixed — exit 0

Note on the vitest invocation: package-level `pnpm --filter ... test` is refused by
this repo's guard (objectui#3378 false-green trap); all runs above were driven from
the repo root as that guard instructs.

**Declared narrowing:** lint was run as the affected package's own
`pnpm --filter @object-ui/app-shell lint` (exit 0; 0 errors, 2553 pre-existing
warnings), not the repo-wide `turbo run lint`. Safe here because eslint in this
repo is not type-aware (no `projectService` or `project` in `eslint.config.js`), so
this diff cannot move the verdict on any file it does not touch. CI runs the full
farm regardless.

Base note: branched off `origin/main` at `d1ab06f0f`; the dispatch cited
`8689166f6`, which had already moved.

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_