### PR TITLE
chore: drop npm's coverage-v8 security placeholder from root dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,9 +142,6 @@
       "@radix-ui/react-focus-scope": "patches/@radix-ui__react-focus-scope.patch"
     }
   },
-  "dependencies": {
-    "coverage-v8": "0.0.1-security"
-  },
   "msw": {
     "workerDirectory": [
       "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,6 @@ patchedDependencies:
 importers:
 
   .:
-    dependencies:
-      coverage-v8:
-        specifier: 0.0.1-security
-        version: 0.0.1-security
     devDependencies:
       '@changesets/cli':
         specifier: ^3.0.0
@@ -6819,9 +6815,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  coverage-v8@0.0.1-security:
-    resolution: {integrity: sha512-m5c7m+S22CM+YHALYgqJCL9sBbbSkDWP3cxRAkwRMw+/N7cMwqiQ0FDpKe6LXhLY/QJ8zGaDOwYW74M7j1Wrlw==}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -15141,8 +15134,6 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
-
-  coverage-v8@0.0.1-security: {}
 
   crc-32@1.2.2: {}
 


### PR DESCRIPTION
Fixes #5437

## What

Deletes the root `package.json`'s `dependencies` block, which held exactly one
entry: `"coverage-v8": "0.0.1-security"`. That is npm's held-name placeholder
for a name npm removed and now blocks re-registration of — it ships no code,
just a README explaining the hold. It is almost certainly a scope-less typo
for `@vitest/coverage-v8`, which is already declared correctly in
`devDependencies` (`^4.1.10`). Refreshed `pnpm-lock.yaml` via `pnpm install`
(never hand-edited) to match.

## Before / after — root `dependencies` block

Before:
```json
"dependencies": {
  "coverage-v8": "0.0.1-security"
},
```

After: the key is gone entirely — the root declares no `dependencies` block.

## Premise re-measured on current `main`

Re-checked on this branch's base (`3ece13e3`, current `main` at worktree
creation), not inherited from the card's `9f7d786bd` reading: grepped the
whole repo for the bare name `coverage-v8`. Every hit (`scripts/check-package-
self-import.mjs`, its test, `CHANGELOG.md`, `.github/workflows/ci.yml`, one
changeset note) refers to the scoped `@vitest/coverage-v8`, never the bare
name. Nothing in the repo resolves `coverage-v8` unscoped — the "pure residue"
premise holds.

## Verification

- `pnpm install` — the placeholder no longer appears in the install output;
  diff is exactly `package.json` + `pnpm-lock.yaml`.
- Ran `pnpm install` a second time — no further diff (lockfile is stable).
- `pnpm install --frozen-lockfile` — passes.
- `pnpm check:phantom-deps` — ✅ green.
- `pnpm check:self-import` — ✅ green.
- `node scripts/check-changeset-presence.mjs` — ✅ "No source of a released
  package changed in this range, so no changeset is owed." (root is not a
  published package; no changeset added, per the gate's own verdict.)

_Generated by [Claude Code](https://claude.ai/code/session_0124Qg8rLvpXnQDwCmpKUmaJ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_0124Qg8rLvpXnQDwCmpKUmaJ)_