### PR TITLE
fix(hooks): port the two upstream guard-main-checkout-bash fixes — escaped `\"` in a double-quoted word, and shell comments read as commands

### DIFF
--- a/.claude/hooks/guard-main-checkout-bash.selftest.sh
+++ b/.claude/hooks/guard-main-checkout-bash.selftest.sh
@@ -169,6 +169,35 @@ expect allow 'grep -rn "he said \"sed -i\" once" .claude/'
 expect block 'node -e "console.log(\"hi\")" > pkg/out.json'
 expect block 'sed -i "s/\"a\"/\"b\"/" pkg/x.ts'
 
+echo "== a shell COMMENT is text, not a command (objectstack#10570) =="
+CWD="$MAIN"
+# The measured false blocks: prose in a comment put a real `>` in operator position and the
+# next word was named as a write target. Nothing in either command writes anything.
+expect allow "$(printf '# rename foo -> bar\necho hello\n')"
+expect allow "$(printf '# sitting 1 landed; card stays open for sitting 2 -> pm:dispatched goes, pm:queue returns\ncurl -s https://example.com/a\ncurl -s https://example.com/b\n')"
+expect allow 'echo hi   # then; tee pkg/x.ts would write it down'
+expect allow "$(printf '# step one; then a -> b\n# 2> is not a redirect here either\ngit status\n')"
+# Recall is untouched: a real redirect on a LATER line still blocks, and so does one on the
+# SAME line ahead of an inline comment.
+expect block "$(printf '# rename foo -> bar\necho x > pkg/x.ts\n')"
+expect block 'echo x > pkg/x.ts   # write it down'
+expect block "$(printf '# a comment; with a separator\nsed -i s/a/b/ pkg/x.ts\n')"
+# Word start is the whole rule: these `#`s are not comments and must not change a verdict.
+expect block 'touch foo#bar'
+expect block 'rm -rf pkg/x.ts#old'
+expect allow 'curl -s "https://example.com/docs#frag"'
+expect allow "curl -s https://example.com/docs#a-real-redirect-would-be > /dev/null"
+expect allow "grep -n '#' README.md"
+expect allow "sed 's/#//' README.md"
+expect allow 'echo "# not a comment > pkg/x.ts"'
+# `${x#y}` / `${#arr[@]}` — a parameter expansion, not a comment. Swallowing the line here
+# would drop the redirect behind it, so the negative twin is the load-bearing case.
+expect allow 'echo ${x#pkg/} '
+expect block 'echo ${#TOK[@]} > pkg/x.ts'
+expect block 'echo ${x#a} > pkg/x.ts'
+# an escaped `\#` outside quotes is a literal, not a comment opener
+expect allow 'echo \# not a comment'
+
 echo "== shapes this guard deliberately does NOT claim (documented fail-open) =="
 CWD="$MAIN"
 expect allow "bash -c \"sed -i s/a/b/ $MAIN/pkg/x.ts\""

--- a/.claude/hooks/guard-main-checkout-bash.selftest.sh
+++ b/.claude/hooks/guard-main-checkout-bash.selftest.sh
@@ -142,6 +142,33 @@ expect allow "$(printf "cat > /tmp/notes.md <<'EOF'\nsed -i 's/a/b/' %s/pkg/x.ts
 expect block "$(printf 'cat > %s/notes.md <<EOF\nhello\nEOF\n' "$MAIN")"
 expect allow 'grep -q worktree <<<"$AGENTS"'
 
+echo "== non-ASCII codepoints are never operators; ASCII redirects still are (objectstack#10247) =="
+CWD="$MAIN"
+# A pure-read `node -e` whose string literal carries U+2192. Nothing is redirected: the
+# arrow is a display separator. Every byte of a non-ASCII codepoint is >= 0x80 and `>` is
+# 0x3e, so no arrow can ever reach operator position.
+expect allow "node -e \"console.log(steps.map(st=>st.a).join(' $(printf '\xe2\x86\x92') '))\""
+expect allow "echo 'build $(printf '\xe2\x86\x92') test $(printf '\xe2\x86\x92') ship'"
+expect allow "grep -n '$(printf '\xe2\x86\x92') the URL' AGENTS.md"     # arrows fill this repo's prose
+expect allow "echo 'a $(printf '\xe2\x87\x92') b'"
+# The negative twins: an otherwise-similar command with a REAL ASCII redirect still blocks,
+# so the allow side above is widened for non-ASCII only and not for redirection at large.
+expect block "node -e \"console.log(1)\" > out.log"
+expect block "echo 'build $(printf '\xe2\x86\x92') ship' > steps.txt"
+expect block "echo 'a $(printf '\xe2\x86\x92') b' >> pkg/x.ts"
+
+echo "== \\\" inside a double-quoted word does not end the quote (objectstack#10247 real cause) =="
+CWD="$MAIN"
+# The shape from the card: an escaped \" used to close the string, after which the JS arrow
+# function `st=>` put a real `>` in operator position and the guard named the JS tail that
+# followed it as a write target. Pure read — must be allowed.
+expect allow 'node -e "const j=require(\"./a.json\"); console.log(j.x.map(st=>st.a).join(\" - \"))"'
+expect allow 'node -e "console.log(\"a\", x.map(s=>s.t))"'
+expect allow 'grep -rn "he said \"sed -i\" once" .claude/'
+# Negative twins: a real write is still caught even when an escaped quote precedes it.
+expect block 'node -e "console.log(\"hi\")" > pkg/out.json'
+expect block 'sed -i "s/\"a\"/\"b\"/" pkg/x.ts'
+
 echo "== shapes this guard deliberately does NOT claim (documented fail-open) =="
 CWD="$MAIN"
 expect allow "bash -c \"sed -i s/a/b/ $MAIN/pkg/x.ts\""

--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -54,6 +54,15 @@
 #      in that tail put a REAL ASCII `>` in operator position, so the guard named the
 #      following JS fragment as a write "target" and blocked a pure-read command (objectstack#10247).
 #      Single quotes take no escapes: inside '…' a backslash is literal, as in a real shell.
+#   4. shell COMMENTS are text, not commands — both quote-aware passes stop at an unquoted
+#      `#` that starts a WORD and resume at the next newline (objectstack#10570). A comment cannot
+#      write anything, so reading one as a command is a false BLOCK: prose arrows (`->`,
+#      `=>`) put a real `>` in operator position and the word after it was named as a write
+#      target, while a `;` in the same comment first split it into its own "segment".
+#      The word-start condition is the whole rule — `foo#bar`, `${x#y}`, `curl 'url/#frag'`,
+#      `sed 's/#//'` and `grep '#'` are NOT comments and are left exactly as they were. A
+#      comment never begins inside '…' or "…" (layer 1 owns those) nor inside a heredoc body
+#      (layer 2 has already dropped those lines before this pass runs).
 #
 # Redirection is recognised on ASCII operators ONLY — `>` `>>` `<` `<<` and their fd-prefixed
 # forms. No non-ASCII codepoint is ever an operator or an operator boundary, and this is
@@ -133,10 +142,19 @@ strip_heredocs() {
 
 # --- split the command into shell segments, honouring quotes ---------------------------
 # Verbatim from guard-shared-stash.sh. A separator inside '…' or "…" does NOT split, so
-# writing *about* the ban is never caught by the ban.
+# writing *about* the ban is never caught by the ban. The same goes for a separator inside
+# a COMMENT: `word` tracks whether the next character would open a new WORD, which is the
+# only position where an unquoted `#` begins a comment — the comment then runs to the next
+# newline and never splits, tokenises or contributes a target (objectstack#10570).
+#
+# What resets `word` is exactly what delimits a word in the shell: start of input, blank,
+# and the metacharacters `; | & ( ) newline > <`. `{` and `}` do NOT — they are reserved
+# words rather than metacharacters, so `#` right after one continues the word. That is not
+# cosmetic: this pass splits on `{`/`}` anyway, and treating the `#` of `${#arr[@]}` as a
+# comment would swallow the rest of the line — including a real redirect behind it.
 segments=()
 split_segments() {
-  local s="$1" seg="" q="" ch i n=${#1}
+  local s="$1" seg="" q="" ch i n=${#1} word=0
   for ((i = 0; i < n; i++)); do
     ch="${s:i:1}"
     if [ -n "$q" ]; then
@@ -151,9 +169,20 @@ split_segments() {
       continue
     fi
     case "$ch" in
-      "'" | '"') q="$ch" ; seg+="$ch" ;;
-      ';' | '|' | '&' | '(' | ')' | '{' | '}' | $'\n') segments+=("$seg") ; seg="" ;;
-      *) seg+="$ch" ;;
+      '#')
+        if [ "$word" = 0 ]; then
+          # comment: skip to (not past) the newline, which still separates as usual
+          while [ $((i + 1)) -lt "$n" ] && [ "${s:i+1:1}" != $'\n' ]; do i=$((i + 1)); done
+          continue
+        fi
+        seg+="$ch"                                   # foo#bar, ${x#y}, url/#frag
+        ;;
+      "'" | '"') q="$ch" ; seg+="$ch" ; word=1 ;;
+      ';' | '|' | '&' | '(' | ')' | $'\n') segments+=("$seg") ; seg="" ; word=0 ;;
+      '{' | '}') segments+=("$seg") ; seg="" ; word=1 ;;
+      ' ' | $'\t') seg+="$ch" ; word=0 ;;
+      '>' | '<') seg+="$ch" ; word=0 ;;
+      *) seg+="$ch" ; word=1 ;;
     esac
   done
   segments+=("$seg")
@@ -164,6 +193,9 @@ split_segments() {
 # enough there. Here the whole argument list matters, and `read -r -a` would promote a
 # QUOTED ">" or "sed -i" to a real operator/command — exactly the false positive that makes
 # a guard get disabled. So: quotes are stripped and their contents are inert.
+# A comment is inert here too: `have` is already the "a word is open" flag, so an unquoted
+# `#` with have=0 is at word start and begins a comment (objectstack#10570). `foo#bar` and
+# `${x#y}` reach this point with have=1 and stay part of the token.
 # TOK[] = token values (unquoted); TOP[] = "op" for an unquoted redirection operator.
 TOK=(); TOP=()
 tokenize() {
@@ -183,6 +215,14 @@ tokenize() {
       continue
     fi
     case "$ch" in
+      '#')
+        if [ "$have" = 0 ]; then
+          # word-start `#`: comment, inert to the next newline
+          while [ $((i + 1)) -lt "$n" ] && [ "${s:i+1:1}" != $'\n' ]; do i=$((i + 1)); done
+          continue
+        fi
+        tok+="$ch"
+        ;;
       "'" | '"') q="$ch" ; have=1 ;;
       '\')
         i=$((i + 1))

--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -41,12 +41,28 @@
 # for anyone who means to write there, and the target of this guard is the reflexive
 # `sed -i` an agent reaches for mid-task, not a determined evader.
 #
-# Writing ABOUT the ban must never trip the ban (objectstack#4890's lesson). Two layers:
+# Writing ABOUT the ban must never trip the ban (objectstack#4890's lesson). Three layers:
 #   1. quote-aware segmentation + tokenisation — a `>` or a `sed -i` inside '…' or "…" is
 #      literal text, so `grep -n "sed -i" .claude/` and `echo "never sed -i in main"` pass;
 #   2. heredoc bodies are stripped before analysis — the LINES of a `cat > /tmp/notes <<EOF`
 #      body are documentation, not commands, and segmentation alone (which splits on
-#      newlines) would happily read them as such.
+#      newlines) would happily read them as such;
+#   3. a backslash-escaped `\"` inside a double-quoted word does NOT end the quote — POSIX
+#      says `\` keeps its meaning before `"`, `\`, `$` and a backtick there, and nowhere else.
+#      Layer 1 used to end the string at the `\"`, and everything after it — the rest of a
+#      `node -e "…"` program — was then read as bare shell. A JS arrow function `st=>st.x`
+#      in that tail put a REAL ASCII `>` in operator position, so the guard named the
+#      following JS fragment as a write "target" and blocked a pure-read command (objectstack#10247).
+#      Single quotes take no escapes: inside '…' a backslash is literal, as in a real shell.
+#
+# Redirection is recognised on ASCII operators ONLY — `>` `>>` `<` `<<` and their fd-prefixed
+# forms. No non-ASCII codepoint is ever an operator or an operator boundary, and this is
+# structural rather than a list to maintain: every byte of a non-ASCII UTF-8 codepoint is
+# >= 0x80, while `>` is 0x3e and `<` is 0x3c, so `→` (e2 86 92), `⇒` (e2 87 92) and `➜`
+# (e2 9e 9c) cannot collide with an operator byte-wise or character-wise. That matters
+# because `→` runs all through this repo's own AGENTS.md — one per Prime Directive clause,
+# and again in the state-classification rules — so echoing or grepping that prose must stay
+# allowed. The self-test pins both directions.
 #
 # Exit-code contract, mirroring both sibling hooks: 0 = allow, 2 = block with the reason on
 # stderr.
@@ -124,6 +140,12 @@ split_segments() {
   for ((i = 0; i < n; i++)); do
     ch="${s:i:1}"
     if [ -n "$q" ]; then
+      if [ "$q" = '"' ] && [ "$ch" = '\' ] && [ $((i + 1)) -lt "$n" ]; then
+        case "${s:i+1:1}" in
+          '"' | '\' | '$' | '`')
+            seg+="$ch" ; i=$((i + 1)) ; seg+="${s:i:1}" ; continue ;;
+        esac
+      fi
       seg+="$ch"
       [ "$ch" = "$q" ] && q=""
       continue
@@ -150,6 +172,12 @@ tokenize() {
   for ((i = 0; i < n; i++)); do
     ch="${s:i:1}"
     if [ -n "$q" ]; then
+      if [ "$q" = '"' ] && [ "$ch" = '\' ] && [ $((i + 1)) -lt "$n" ]; then
+        case "${s:i+1:1}" in
+          '"' | '\' | '$' | '`')
+            i=$((i + 1)) ; tok+="${s:i:1}" ; have=1 ; continue ;;
+        esac
+      fi
       if [ "$ch" = "$q" ]; then q=""; else tok+="$ch"; fi
       have=1
       continue


### PR DESCRIPTION
Fixes #5459
Fixes #5712

Ports the two upstream fixes that this repo's copy of `guard-main-checkout-bash.sh` had
drifted from. The file's own header declares the two repos' copies "deliberately kept
case-for-case identical … so the two repos' guards cannot drift"; two independent fixes had
landed upstream since, and neither was here.

One commit per member card, in upstream's own order.

## Commit 1 — `\"` inside a double-quoted word does not end the quote (#5459, upstream objectstack PR #10406)

POSIX: inside `"…"` a backslash keeps its meaning only before `"`, `\`, `$` and a backtick.
Both quote-aware passes (`split_segments()` and `tokenize()`) ended the string at the `\"`,
after which the rest of a `node -e "…"` program was read as bare shell.

Measured against this repo's pre-fix copy, from a cwd inside the shared primary checkout —
the desync failed in **both** directions:

| command | pre-fix verdict |
|:--|:--|
| `node -e "const j=require(\"./a.json\"); console.log(j.x.map(st=>st.a)…)"` | **BLOCK**, `target: st.a).join("` — a pure read |
| `sed -i "s/\"a\"/\"b\"/" pkg/x.ts` | **ALLOW** — a real write, missed |

The second is the reflexive `sed -i` this guard exists to catch, so the shared checkout was
unguarded against that shape until this PR.

## Commit 2 — a shell COMMENT is text, not a command (#5712, upstream objectstack PR #11129)

Both passes now apply the shell's comment rule: outside quotes and heredoc bodies, an
unquoted `#` that starts a WORD begins a comment running to the next newline.

Measured against this repo's pre-fix copy:

```
# rename foo -> bar
echo hello          -> BLOCK, target: bar    (a pure read)
echo hello          -> allow                 (control: same command, no comment)
```

Fail-CLOSED, so nothing unguarded slipped through — but it is the false-positive direction
that trains an operator onto `OS_ALLOW_MAIN_EDITS=1`, which switches the guard off for the
whole command.

The word-start condition is the whole rule: `foo#bar`, `${x#y}`, `curl 'url/#frag'`,
`sed 's/#//'` and `grep '#'` are not comments and keep every verdict they had. `{`/`}` do
not reset word state (reserved words, not metacharacters), so the `#` of `${#arr[@]}` cannot
swallow a real redirect behind it.

## Verification

Self-test: **70 → 82 → 100 cases**, matching upstream's own counts at each step (upstream
PR #11129's message records `82 -> 100`), which is independent evidence the two ports were
split at the right line.

**Ablation — each member's assertions are independently load-bearing.** Two fixes in one PR
is exactly where one shared assertion can hide a missing half, so each fix was reverted
alone, with the mutation confirmed on disk by marker count before reading any result:

| run | on-disk proof | result |
|:--|:--|:--|
| both present | — | 100 passed, 0 failed |
| escaped-quote fix ablated | escape-block markers 2 → 0 | 96 passed, **4 failed — all in the `\"` section**; comment-rule section green |
| comment-rule fix ablated | word-tracking markers 3 → 0 | 96 passed, **4 failed — all in the COMMENT section**; `\"` section green |
| restored | markers back to 2 / 3 | 100 passed, 0 failed, tree clean |

No other section failed in either ablation.

Gates run at `db9d0fd0` (the final commit), derived from the actual diff against this
repo's own scripts — `scripts/pm/dispatch-gates.mjs` is objectstack-only and does not exist
here:

- `.claude/hooks/guard-main-checkout-bash.selftest.sh` → `100 passed, 0 failed`
- `node scripts/check-control-bytes.mjs` → `✅  check-control-bytes: OK (scanned 4797 tracked text file(s); skipped 85 binary).`
- `node scripts/check-changeset-presence.mjs` → `✅  No source of a released package changed in this range, so no changeset is owed.`
- `bash -n` on both files → clean

ESLint owes nothing on this diff, and that is a measurement rather than a skip: every block
in `eslint.config.js` is scoped to `**/*.{ts,tsx}` (no `.sh` glob anywhere in the config),
this diff contributes **0** files to that population, and since no shell file is in any
config block's `files` — nor importable by TypeScript — the diff cannot move a verdict on
any untouched file.

## Localisation

Per the header's own convention. The residual diff against objectstack's copy is now
**localisation only** — every logic line is byte-identical:

- issue refs carry the `objectstack#` prefix (`objectstack#10247`, `objectstack#10570`),
  matching the existing `objectstack#4890` precedent — upstream's bare `#10247` / `#10570`
  are not copied in verbatim;
- the non-ASCII paragraph and its self-test probe cite **this repo's own AGENTS.md** prose
  arrows instead of objectstack's CLI boot banner (`➜  API:`), which does not exist here —
  measured: 0 occurrences of that glyph in objectui source, 14 `→` in `AGENTS.md`;
- this copy's own cross-references to `guard-shared-stash.sh`, its `packages/fields/src/x.tsx`
  example path, its `@object-ui/app-shell` filter example and the `objectui#3435` / `#3430`
  refs are left untouched.

### One deliberate non-divergence, flagged for review

Upstream's header says **"Three layers:"** and then lists **four** — PR #11129 added layer 4
without bumping the count. It is ported **verbatim, miscount included**, because
case-for-case identity is this file pair's whole invariant and correcting it here would be
inventing a fix ahead of the source repo — the same principle as the exclusion list below.
Filed upstream instead: objectstack-ai/objectstack#11234. Once that lands, the correction
ports here like any other drift item.

## Explicitly NOT in this PR

- `guard-main-checkout.sh` — the Edit/Write guard parses no shell text;
- `guard-shared-stash.sh` and its self-test — a different guard; neither card claims drift there;
- **objectstack's copy** — this port runs one direction only;
- upstream objectstack#11131 (backslash-desync) and objectstack#11133 (heredoc-in-comment) —
  the two fail-open siblings recorded in #11129's out-of-scope note, both unadjudicated
  upstream; porting them would be inventing fixes ahead of the source repo;
- **the case-for-case identity gate itself.** Noted as a follow-up candidate per the triage
  decision, not built here. Both cards raise it and this PR is the third data point: a gate
  that diffs the two copies modulo the localised lines would have caught both drifts when
  they were introduced. Two things a future gate would need, learned here: the localised set
  is small and enumerable (issue refs, example paths, the package name, the sibling-hook
  cross-references, and the downstream-only "Ported from …" provenance paragraph), and the
  file pair's self-tests keep matching case counts, which is a cheaper second signal.

## Related finding

CI in **neither** repo runs these hook self-tests — `grep -rn selftest .github/workflows/`
returns nothing in objectui or objectstack — so a broken guard lands green. Filed separately
as objectstack-ai/objectui#5754; not fixed here.

Governed surface (`.claude/**`): left as a **draft**, not enqueued, no auto-merge. The
maintainer's manual merge is the review record.

⚠️ **The review request could not be set.** Requesting `os-zhuang` returned
`Review cannot be requested from pull request author` — all agents share the `os-zhuang`
identity, so the reviewer the governed-surface rule names is also this PR's author, and
GitHub rejects that pairing. Not worked around: nothing was flipped, relabelled, or
reassigned to force it through. @os-zhuang — this needs your review; the request has to
come from outside the shared identity, or the convention needs a different reviewer.

---
_Generated by [Claude Code](https://claude.ai/code/session_0124Qg8rLvpXnQDwCmpKUmaJ)_


---
_Generated by [Claude Code](https://claude.ai/code)_