### PR TITLE
fix(react): make a node-gate `data.*` predicate the adapter cannot answer loud (#5687)

### DIFF
--- a/.changeset/node-gate-data-predicate-report-5687.md
+++ b/.changeset/node-gate-data-predicate-report-5687.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/react': patch
+---
+
+`SchemaRenderer`'s node visibility gate now emits a dev-only warning when a
+predicate reads `data.*` and the data-source adapter cannot answer that read, so
+an author who wrote `properties: { visible: "data.status == 'draft'" }` sees the
+constant they authored instead of shipping it (objectui#5687).
+
+At the node tier `data` is the data-source **adapter** — the object `${data.total}`
+in a props bag resolves against — and it has never been the row. A predicate
+written with the deprecated `data.*` spelling therefore resolves `undefined ==
+'draft'`, which is a perfectly good `false`: the block is hidden on every row, and
+because it does not throw, the unresolvable-predicate reporter added for
+objectui#5454 never fired. Measured on this base, the same predicate written as a
+`{ dialect: 'cel' }` envelope *does* throw and *was* already reported — so whether
+an author heard about the identical mistake depended on which dialect they happened
+to write it in, which is the arbitrariness objectui#5454 existed to remove.
+
+**No verdict changes and no interpolation changes** (maintainer ruling,
+2026-08-22, option A). The node tier keeps its documented `data` = adapter
+semantics; objectui#5330's row binding does not extend here. The evaluator's answer
+is returned exactly as computed and `${data.*}` interpolation is untouched — only
+the silence moved.
+
+The report fires on a `data.*` read the bound adapter answers with `undefined`, not
+on the spelling. A genuine adapter read stays silent (`data.total > 0` against an
+adapter carrying `total`), a canonical `record.*` predicate stays silent, and a
+correctly-hiding gate stays silent. Dev builds only, `console.warn`, deduped per
+node type + key + predicate source — the same module, Set and lifecycle as the
+objectui#5454 reporter.
+
+This loudness is temporary by design: it dissolves when objectui#5330's deprecation
+window for the `data.*` row spelling closes.

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -30,7 +30,10 @@ import { usePredicateScope } from './hooks/useExpression.js';
 import { usePageVariables } from './hooks/usePageVariables.js';
 import { resolveKeyedI18nLabel } from './utils/i18n.js';
 import { reportUnevaluatedExpressions } from './utils/unevaluatedExpression.js';
-import { reportUnresolvableVisibilityPredicate } from './utils/visibilityDiagnostic.js';
+import {
+  reportUnresolvableVisibilityPredicate,
+  reportAdapterOnlyDataPredicate,
+} from './utils/visibilityDiagnostic.js';
 
 /**
  * Dev-mode schema validation.
@@ -594,7 +597,16 @@ export const SchemaRenderer: ForwardRefExoticComponent<
       // build a message no production build ever prints.
       if (!__DEV__) return evaluator.evaluateCondition(raw);
       try {
-        return evaluator.evaluateCondition(raw, { throwOnError: true });
+        const verdict = evaluator.evaluateCondition(raw, { throwOnError: true });
+        // objectui#5687 — the NON-throwing half of the same silence, and it is
+        // reachable ONLY here, on the branch where the predicate evaluated
+        // cleanly. A `data.*` read the adapter cannot answer is not a fault the
+        // evaluator can raise: `undefined == 'draft'` is a perfectly good
+        // `false`. Verdict untouched — `verdict` is returned exactly as
+        // computed, which is what keeps the ruling's "no verdict changes" true
+        // by construction rather than by review.
+        reportAdapterOnlyDataPredicate(newSchema.type, newSchema.id, key, raw, dataSource);
+        return verdict;
       } catch (err) {
         reportUnresolvableVisibilityPredicate(newSchema.type, newSchema.id, key, raw, err);
         // The historical fail-soft answer, unchanged — and identical to what

--- a/packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx
@@ -1,0 +1,432 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5687 — a node-gate `data.*` predicate the adapter cannot answer is
+ * LOUD, and nothing else moves.
+ *
+ * Maintainer ruling, 2026-08-22, option A: the node tier keeps its documented
+ * `data` = adapter semantics. No verdict changes, no interpolation changes —
+ * objectui#5330's row binding does NOT extend to this tier. Instead the
+ * objectui#5454 reporter posture is extended to this NON-throwing path, so an
+ * author sees the constant-false instead of shipping it.
+ *
+ * ## The pin is a TRIPLE, not a pair
+ *
+ * Two of the three cases here are negatives, and they are the half that keeps
+ * the report honest:
+ *
+ *   1. the card's reproduction shape (`properties: { visible: "data.status ==
+ *      'draft'" }`) reports — and still hides, on every row;
+ *   2. a canonical `record.*` predicate stays SILENT;
+ *   3. a genuine adapter read (`${data.total}` against an adapter that HAS
+ *      `total`) stays SILENT.
+ *
+ * Drop any one and the file is green on an implementation that reports
+ * everything, or nothing.
+ *
+ * ## The control that decides WHICH discriminator is implemented
+ *
+ * "Reports the repro" is satisfied by three mutually incompatible triggers.
+ * `same predicate text, adapter ANSWERS it` (group 2c) is what separates them:
+ * it holds the predicate source and the `false` verdict fixed and moves only
+ * whether the adapter has the key. A "references `data.`" trigger fails it; a
+ * "the predicate is constant-false" trigger fails it; only "a `data.*` read the
+ * bound object does not answer" passes it.
+ *
+ * ## Reverse verification (direction predicted before running)
+ *
+ * Deleting the `reportAdapterOnlyDataPredicate` call in `SchemaRenderer`'s
+ * `evaluateVisibilityPredicate` turns RED exactly the four positive cases in
+ * group 1 and the dedupe case, and leaves every silence case and every verdict
+ * assertion green — that asymmetry IS leg-3-of-#5454's property, restated: the
+ * change moves the silence, not the answer. Removing the `unresolved.length`
+ * guard instead turns RED the silence cases (2a/2b/2c/3a/3b) while group 1 stays
+ * green, which is the false-positive direction the ruling refuses.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+import {
+  __resetVisibilityPredicateWarnings,
+  ADAPTER_ONLY_DATA_PREDICATE_PREFIX,
+  UNRESOLVABLE_VISIBILITY_PREFIX,
+} from '../utils/visibilityDiagnostic';
+import { SchemaRendererContext } from '../context/SchemaRendererContext';
+import { RecordContextProvider } from '../context/RecordContext';
+import { PredicateScopeProvider } from '../hooks/useExpression';
+
+const NAME = 'probe-5687';
+const TYPE = 'element:probe-5687';
+
+const Probe = (props: { content?: unknown }) => (
+  <div data-testid="probe" data-content={props.content === undefined ? 'absent' : String(props.content)} />
+);
+
+/**
+ * The data-source ADAPTER — what `SchemaRendererContext` carries and what
+ * `${data.total}` resolves against. It has `total` and deliberately has NO
+ * `status`: `status` is a ROW field, and the whole card is that the node tier
+ * never bound the row over `data`.
+ */
+const ADAPTER = { total: 99 };
+/** Same adapter, plus the key the predicate asks for. Group 2c's other half. */
+const ADAPTER_WITH_STATUS = { total: 99, status: 'draft' };
+/** …and the polarity that makes group 2c's `false` a verdict, not an absence. */
+const ADAPTER_WITH_OTHER_STATUS = { total: 99, status: 'published' };
+
+const DRAFT = { id: 'r1', status: 'draft' };
+const PUBLISHED = { id: 'r2', status: 'published' };
+
+const cel = (source: string) => ({ dialect: 'cel', source });
+
+/** The ambient scope app-shell's `ExpressionProvider` really mounts. */
+const APP_SCOPE = {
+  current_user: { id: 'u1', email_verified: true },
+  user: { id: 'u1', email_verified: true },
+  app: {},
+  data: {},
+  features: {},
+};
+
+function mount(
+  schema: Record<string, unknown>,
+  record?: Record<string, unknown>,
+  adapter: unknown = ADAPTER,
+  scope: Record<string, unknown> = APP_SCOPE,
+) {
+  const tree = (
+    <PredicateScopeProvider scope={scope}>
+      <SchemaRendererContext.Provider value={{ dataSource: adapter } as never}>
+        <SchemaRenderer schema={{ type: TYPE, ...schema } as never} />
+      </SchemaRendererContext.Provider>
+    </PredicateScopeProvider>
+  );
+  return render(
+    record === undefined
+      ? tree
+      : (
+        <RecordContextProvider objectName="showcase_task" recordId={String(record.id)} data={record}>
+          {tree}
+        </RecordContextProvider>
+      ),
+  );
+}
+
+const shown = () => screen.queryByTestId('probe') !== null;
+
+/**
+ * The structural shape a `console.warn` spy presents, spelled locally.
+ * `ReturnType<typeof vi.spyOn>` erases the argument tuple, so the callbacks
+ * below lose their types under `noImplicitAny`.
+ */
+type WarnSpy = { mock: { calls: unknown[][] } };
+
+/** Lines carrying THIS leg's prefix. */
+const reports = (warn: WarnSpy): string[] =>
+  warn.mock.calls.map(c => String(c[0])).filter(m => m.includes(ADAPTER_ONLY_DATA_PREDICATE_PREFIX));
+/** Lines carrying the objectui#5454 leg's prefix — a different fault. */
+const unresolvableReports = (warn: WarnSpy): string[] =>
+  warn.mock.calls.map(c => String(c[0])).filter(m => m.includes(UNRESOLVABLE_VISIBILITY_PREFIX));
+
+const spyWarn = () => vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+beforeEach(() => {
+  ComponentRegistry.register(NAME, Probe as never, { namespace: 'element', skipFallback: true } as never);
+  __resetVisibilityPredicateWarnings();
+});
+afterEach(() => {
+  cleanup();
+  ComponentRegistry.unregister?.(NAME, 'element');
+  vi.restoreAllMocks();
+});
+
+describe('#5687 group 1 — the card\'s reproduction shape is reported', () => {
+  it('THE acceptance criterion: `properties: { visible: "data.status == \'draft\'" }` warns, and still hides on EVERY row', () => {
+    const warn = spyWarn();
+    // The exact shape the card names. `properties.visible` is hoisted onto the
+    // node by the memo and lands on the `visible` leg of the chain.
+    mount({ properties: { visible: "data.status == 'draft'" } }, DRAFT);
+    // Verdict UNCHANGED — the ruling refuses a verdict change, and this is the
+    // constant-false the author would otherwise have shipped.
+    expect(shown()).toBe(false);
+    const msg = reports(warn)[0];
+    expect(msg).toBeDefined();
+    expect(msg).toContain(TYPE);
+    expect(msg).toContain('visible');
+    expect(msg).toContain("data.status == 'draft'");
+    // The read that could not be answered, named — not just "something is wrong".
+    expect(msg).toContain('data.status');
+    // The two sentences that make it actionable rather than merely noted.
+    expect(msg).toContain('CONSTANT');
+    expect(msg).toContain('record.status');
+  });
+
+  it('… and hides on the OTHER row too, which is what "on every row" means', () => {
+    // The row polarity pair. A gate that depends on the row would differ here;
+    // this one cannot, and that is the defect.
+    const warn = spyWarn();
+    mount({ properties: { visible: "data.status == 'draft'" } }, DRAFT);
+    expect(shown()).toBe(false);
+    cleanup();
+    mount({ properties: { visible: "data.status == 'draft'" } }, PUBLISHED);
+    expect(shown()).toBe(false);
+    expect(reports(warn).length).toBeGreaterThan(0);
+  });
+
+  it('the paired control: the same node with NO gate renders on both rows', () => {
+    // Without this, "hidden" above could be "this node never renders" —
+    // `SchemaRenderer` has several other paths to rendering nothing.
+    const warn = spyWarn();
+    mount({}, DRAFT);
+    expect(shown()).toBe(true);
+    cleanup();
+    mount({}, PUBLISHED);
+    expect(shown()).toBe(true);
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('the `${…}` template dialect reports too — at the tier where it survives to the gate', () => {
+    // A node-level key is NOT pre-evaluated by the memo (only `content`,
+    // `props` and `properties` are), so the template reaches the chain with its
+    // `data.` text intact. This is the spelling `@object-ui/types`' own protocol
+    // comments use (`hidden?: string; // expression: "${data.role != 'admin'}"`).
+    const warn = spyWarn();
+    mount({ visibleWhen: "${data.status == 'draft'}" }, DRAFT);
+    expect(shown()).toBe(false);
+    expect(reports(warn)).toHaveLength(1);
+  });
+
+  it('KNOWN LIMIT, measured and pinned: a `${…}` template INSIDE `properties` is invisible to this leg', () => {
+    // Not a choice — a structural consequence of an ordering this ruling
+    // fences off. The memo evaluates every `properties.*` value BEFORE the
+    // hoist ("Evaluating first is what makes one key mean one thing"), and
+    // measured on `@object-ui/core`'s evaluator:
+    //
+    //   evaluate("data.status == 'draft'")   -> "data.status == 'draft'"  (verbatim)
+    //   evaluate("${data.status == 'draft'}") -> false                    (boolean)
+    //
+    // So the bare string — the card's pinned repro — arrives at the gate with
+    // its `data.` text intact and IS reported, while the template arrives as a
+    // plain `false` with nothing left to detect. Reaching it would mean adding
+    // a diagnostic inside the interpolation loop, and the 2026-08-22 ruling
+    // fences interpolation off ("no interpolation changes").
+    //
+    // The verdict is pinned here anyway: the block is hidden on every row, and
+    // the author gets no signal. That silence is filed separately, not
+    // smuggled in here.
+    const warn = spyWarn();
+    mount({ properties: { visible: "${data.status == 'draft'}" } }, DRAFT);
+    expect(shown()).toBe(false);
+    cleanup();
+    mount({ properties: { visible: "${data.status == 'draft'}" } }, PUBLISHED);
+    expect(shown()).toBe(false); // constant across rows, exactly as in group 1
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('a node-level `visibleWhen` written the deprecated way reports on ITS key', () => {
+    const warn = spyWarn();
+    mount({ visibleWhen: "data.status == 'draft'" }, DRAFT);
+    expect(shown()).toBe(false);
+    expect(reports(warn)[0]).toContain('visibleWhen');
+  });
+
+  it('the NON-negated `hidden` leg reports too, and keeps its own inverted answer', () => {
+    // `hidden` is not negated: a constant-`false` there means the node stays
+    // SHOWN by a gate that was meant to hide it. Equally constant, equally
+    // silent before this change — and the verdict is untouched here as well.
+    const warn = spyWarn();
+    mount({ hidden: "data.status == 'draft'" }, DRAFT);
+    expect(shown()).toBe(true);
+    expect(reports(warn)[0]).toContain('hidden');
+  });
+
+  it('deduped: one line per (node type, key, predicate), not one per render', () => {
+    // Matches objectui#5454's posture exactly — same Set, same key shape.
+    const warn = spyWarn();
+    mount({ properties: { visible: "data.status == 'draft'" } }, DRAFT);
+    cleanup();
+    mount({ properties: { visible: "data.status == 'draft'" } }, PUBLISHED);
+    expect(reports(warn)).toHaveLength(1);
+  });
+});
+
+describe('#5687 group 2 — a genuine adapter read stays SILENT', () => {
+  it('2a: `${data.total}` in a props bag still interpolates, and says nothing', () => {
+    // The docblock's pinned binding, restated: `data` is the adapter, and this
+    // card does not touch it. A props-bag interpolation never reaches the
+    // visibility chain at all — asserted here so the claim is measured, not
+    // inferred from where the call site happens to sit.
+    const warn = spyWarn();
+    mount({ properties: { content: '${data.total}' } }, DRAFT);
+    expect(screen.getByTestId('probe')).toHaveAttribute('data-content', '99');
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('2b: a `data.*` VISIBILITY gate the adapter answers is silent, on both polarities', () => {
+    // The harder half of 2a: this one DOES reach the reporter's call site, and
+    // is silent because the adapter answers the read.
+    const warn = spyWarn();
+    mount({ properties: { visible: 'data.total > 0' } }, DRAFT);
+    expect(shown()).toBe(true);
+    cleanup();
+    mount({ properties: { visible: 'data.total > 100' } }, DRAFT);
+    // A correctly-hiding gate. This is also the case that DISQUALIFIES a
+    // "the predicate is constant-false" trigger: the verdict here is `false`,
+    // exactly as in group 1, and it must stay silent.
+    expect(shown()).toBe(false);
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('2c: SAME predicate text, SAME `false` verdict — silent once the adapter has the key', () => {
+    // The control that picks the discriminator. Only the adapter moves.
+    const warn = spyWarn();
+    mount({ properties: { visible: "data.status == 'draft'" } }, DRAFT, ADAPTER_WITH_STATUS);
+    expect(shown()).toBe(true);
+    cleanup();
+    mount({ properties: { visible: "data.status == 'draft'" } }, DRAFT, ADAPTER_WITH_OTHER_STATUS);
+    expect(shown()).toBe(false); // a real verdict, from a real read
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('2d: a predicate that merely QUOTES `data.status` reads nothing and says nothing', () => {
+    // The scan is lexical, so string literals are stripped before it runs.
+    // Not hypothetical: examples/schema-catalog carries `data.features` inside
+    // a JS snippet in a `content` string.
+    const warn = spyWarn();
+    mount({ properties: { visible: "record.status == 'data.status'" } }, DRAFT);
+    expect(shown()).toBe(false);
+    expect(reports(warn)).toHaveLength(0);
+  });
+});
+
+describe('#5687 group 3 — the `record.*` bucket is NOT this card, and cannot be caught by it', () => {
+  it('3a: a canonical `record.*` predicate reaches opposite verdicts and stays silent', () => {
+    // objectui#5401 → umbrella #5454 bound `record` at this tier. Same
+    // evaluator, different identifier, different correct fix. This leg must be
+    // structurally incapable of firing on it.
+    const warn = spyWarn();
+    mount({ properties: { visible: "record.status == 'draft'" } }, DRAFT);
+    expect(shown()).toBe(true);
+    cleanup();
+    mount({ properties: { visible: "record.status == 'draft'" } }, PUBLISHED);
+    expect(shown()).toBe(false);
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('3b: an UNBOUND `record.*` predicate is still the OTHER reporter\'s case, not this one', () => {
+    // With no row mounted, `record.status` cannot resolve. That is #5454's
+    // fault, reported by #5454's function. This leg must add nothing — two
+    // reports for one predicate would be the "two adjacent reporters" outcome.
+    const warn = spyWarn();
+    mount({ visibleWhen: cel("record.status == 'draft'") }, undefined);
+    expect(shown()).toBe(true);
+    expect(unresolvableReports(warn).length).toBeGreaterThan(0);
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('3c: `metadata.*` is not `data.*` — a longer identifier that merely ENDS in "data"', () => {
+    // The loose-sweep trap, mechanised. `metadata` is not this evaluator's
+    // `data` root, so nothing here is a `data.*` read — even though the raw
+    // source text does contain the substring `data.`.
+    //
+    // `metadata` is BOUND in the scope on purpose, and the ablation is why.
+    // Written without it the predicate THROWS ("metadata is not defined"),
+    // lands in the objectui#5454 catch, and never reaches this leg at all — so
+    // it was green for a reason that had nothing to do with the boundary it
+    // claims to check, and survived the "report on any `data.` mention"
+    // ablation that it exists to kill. Measured, then fixed.
+    const warn = spyWarn();
+    const scopeWithMetadata = { ...APP_SCOPE, metadata: { status: 'published' } };
+    mount(
+      { properties: { visible: "metadata.status == 'draft'" } },
+      DRAFT,
+      ADAPTER,
+      scopeWithMetadata,
+    );
+    expect(shown()).toBe(false); // a real verdict off a real read — not a throw
+    expect(reports(warn)).toHaveLength(0);
+    expect(unresolvableReports(warn)).toHaveLength(0);
+  });
+
+  it('3d: `record.data.*` is the ROW\'s own field, not this evaluator\'s `data` root', () => {
+    const warn = spyWarn();
+    mount({ properties: { visible: "record.data.status == 'draft'" } }, { id: 'r3', data: { status: 'x' } });
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('3e: a CEL envelope reading `data.*` already throws — reported ONCE, by #5454', () => {
+    // Measured on this base: `{ dialect: 'cel' }` routes to `evalFieldPredicate`,
+    // whose bag binds values under `record.`, so `data.status` FAULTS and
+    // `throwOnError` raises. The card's premise ("this path never throws") holds
+    // for the bare-string and template dialects only. This leg runs after a
+    // clean evaluation, so it cannot double-report — pinned here rather than
+    // argued.
+    const warn = spyWarn();
+    mount({ visibleWhen: cel("data.status == 'draft'") }, DRAFT);
+    expect(unresolvableReports(warn).length).toBeGreaterThan(0);
+    expect(reports(warn)).toHaveLength(0);
+  });
+});
+
+describe('#5687 group 4 — production is untouched', () => {
+  it('a PRODUCTION build reaches the SAME verdicts and prints nothing', async () => {
+    // The diagnostic is dev-only by the same `__DEV__` gate objectui#5454 put
+    // in front of the probe. A gate that changed the ANSWER would be a fork.
+    //
+    // The dynamic import lives in the test BODY, not a hook: it has to read
+    // module state that only exists after `resetModules` + `stubEnv`, which is
+    // the case `object-ui/no-dynamic-import-in-test-hook` exempts.
+    vi.resetModules();
+    vi.stubEnv('NODE_ENV', 'production');
+    try {
+      const warn = spyWarn();
+      const [core, prod, ctx, rec, expr] = await Promise.all([
+        import('@object-ui/core'),
+        import('../SchemaRenderer'),
+        import('../context/SchemaRendererContext'),
+        import('../context/RecordContext'),
+        import('../hooks/useExpression'),
+      ]);
+      core.ComponentRegistry.register(NAME, Probe as never, { namespace: 'element', skipFallback: true } as never);
+      const mountProd = (schema: Record<string, unknown>, record: Record<string, unknown>) => render(
+        <expr.PredicateScopeProvider scope={APP_SCOPE}>
+          <ctx.SchemaRendererContext.Provider value={{ dataSource: ADAPTER } as never}>
+            <rec.RecordContextProvider objectName="showcase_task" recordId={String(record.id)} data={record}>
+              <prod.SchemaRenderer schema={{ type: TYPE, ...schema } as never} />
+            </rec.RecordContextProvider>
+          </ctx.SchemaRendererContext.Provider>
+        </expr.PredicateScopeProvider>,
+      );
+
+      // The repro shape: same constant-false, same hidden block.
+      mountProd({ properties: { visible: "data.status == 'draft'" } }, DRAFT);
+      expect(shown()).toBe(false);
+      cleanup();
+      // The genuine adapter read: same interpolation.
+      mountProd({ properties: { content: '${data.total}' } }, DRAFT);
+      expect(screen.getByTestId('probe')).toHaveAttribute('data-content', '99');
+      cleanup();
+      // The canonical spelling: same two verdicts.
+      mountProd({ properties: { visible: "record.status == 'draft'" } }, DRAFT);
+      expect(shown()).toBe(true);
+      cleanup();
+      mountProd({ properties: { visible: "record.status == 'draft'" } }, PUBLISHED);
+      expect(shown()).toBe(false);
+      // …and none of this module's output, on any of them.
+      expect(warn.mock.calls.map(c => String(c[0])).filter(m => m.includes(ADAPTER_ONLY_DATA_PREDICATE_PREFIX))).toHaveLength(0);
+      core.ComponentRegistry.unregister?.(NAME, 'element');
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/react/src/utils/visibilityDiagnostic.ts
+++ b/packages/react/src/utils/visibilityDiagnostic.ts
@@ -118,10 +118,205 @@ export function reportUnresolvableVisibilityPredicate(
 }
 
 /**
- * Test-only reset for the dedupe above. The `Set` is module state: without
- * this, the second test to assert the same warning reads the first test's
- * dedupe entry and sees silence — a green run that checked nothing.
+ * Test-only reset for the dedupe above — for BOTH legs, which is the point of
+ * their sharing one `Set`. The `Set` is module state: without this, the second
+ * test to assert the same warning reads the first test's dedupe entry and sees
+ * silence — a green run that checked nothing.
  */
 export function __resetVisibilityPredicateWarnings(): void {
   _warnedVisibilityPredicates.clear();
+}
+
+/* -------------------------------------------------------------------------- *
+ * objectui#5687 — the NON-throwing half of the same silence
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Prefix for the objectui#5687 leg. A SIBLING of the constant above, not a
+ * reuse of it, and the difference is deliberate.
+ *
+ * The maintainer ruling (2026-08-22, option A) says this path "emits the
+ * dev-only unresolvable-predicate report". What is load-bearing there — and
+ * what the dispatch restated — is the reporter's POSTURE: same module, same
+ * severity (`console.warn`), same dedupe key shape, same dedupe Set, same
+ * dev-only gate at the same call site, same test-only reset. All of that is
+ * shared below. The first LINE is not reused, because on this path it would
+ * state something false: the predicate did not fail to evaluate. It evaluated
+ * perfectly, against the wrong object, and produced a constant. Telling an
+ * author "could not be evaluated" would send them hunting for a syntax error
+ * that is not there.
+ */
+export const ADAPTER_ONLY_DATA_PREDICATE_PREFIX =
+  '[ObjectUI] A visibility predicate resolved `data.*` against the data-source adapter';
+
+/**
+ * Strip string literals before scanning for `data.*` reads.
+ *
+ * The scan below is LEXICAL, not a parse — it reads the predicate's source
+ * text. Without this step a predicate that merely quotes the characters
+ * (`note == 'data.status'`) would be reported for a read it never performs.
+ * That class is not hypothetical in this repo: `examples/schema-catalog`'s
+ * `components-complex-scroll-area/code-preview.json` carries `data.features`
+ * inside a JS snippet in a `content` string.
+ *
+ * Replaced with an EMPTY literal of the same quote style rather than deleted,
+ * so neighbouring tokens cannot be fused into a new false match.
+ */
+function stripStringLiterals(source: string): string {
+  return source.replace(/'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"/g, "''");
+}
+
+/**
+ * `data.<path>` reads, matched only where `data` is a ROOT identifier.
+ *
+ * The leading group is what keeps this from being the loose sweep the card's
+ * own cross-reference warns about: `metadata.status` (a longer identifier that
+ * ends in `data`) and `record.data.status` (`data` as a MEMBER, which is the
+ * row's own field, not this evaluator's root) must not match. Both are pinned.
+ * A capture group is used rather than a lookbehind for target-browser reach.
+ */
+const DATA_ROOT_PATH_RE =
+  /(^|[^A-Za-z0-9_$.])data\.([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*)/g;
+
+/**
+ * The `data.*` reads in `source` that are `undefined` on the object `data` is
+ * actually bound to — i.e. the ones that make the comparison a constant.
+ *
+ * ## Why THIS discriminator, measured against the three alternatives
+ *
+ * The ruling's trigger is not "references `data.`" — a genuine adapter read has
+ * to stay silent, and that half is what makes the loud half mean anything.
+ * Measured on `packages/core`'s built evaluator, against the four candidate
+ * definitions:
+ *
+ *   * "references `data.` at all" — fires on `data.total > 0` against an
+ *     adapter that HAS `total`. Refused by the ruling in as many words.
+ *   * "the whole predicate is constant-false" — measured: `data.total > 100`
+ *     against `{ total: 99 }` returns `false`, and so does a correct
+ *     `record.status == 'draft'` against a row whose status is `open`. The
+ *     definition cannot tell a gate that correctly says NO from a gate that
+ *     never asked. It would report every hiding gate in the repo.
+ *   * "the comparison OPERAND is undefined" — the most precise reading, and it
+ *     needs the expression engine to expose its operands. That is a change to
+ *     `@object-ui/core`'s evaluator for a diagnostic on a card that dissolves
+ *     when objectui#5330's deprecation window closes.
+ *   * "a `data.*` read the bound object does not answer" — this one. On the
+ *     card's repro (`data.status` against the adapter) it fires; on
+ *     `${data.total}` against `{ total: 99 }` it does not; and it is
+ *     STRUCTURALLY incapable of firing on the `record.*` bucket (objectui#5401
+ *     → #5454), which is the adjacent card with a different correct fix.
+ *
+ * Residue, stated rather than hidden: deliberate absence idioms
+ * (`data.status == null`, `!data.status`) are reported. They are not really
+ * false positives at this tier — an adapter that has no `status` makes those
+ * constants too, just constant-TRUE instead of constant-false — but they are
+ * the shapes an author could have meant.
+ *
+ * The walk mirrors `useDataScope`'s own `path.split('.').reduce(…)` resolution
+ * of a `data.*` path, so "undefined here" means what it means everywhere else
+ * this repo resolves against the adapter.
+ */
+function unresolvedDataPaths(source: string, boundData: unknown): string[] {
+  const scannable = stripStringLiterals(source);
+  const out: string[] = [];
+  DATA_ROOT_PATH_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = DATA_ROOT_PATH_RE.exec(scannable)) !== null) {
+    const path = match[2];
+    let cursor: unknown = boundData;
+    try {
+      for (const segment of path.split('.')) {
+        if (cursor === null || cursor === undefined) {
+          cursor = undefined;
+          break;
+        }
+        cursor = (cursor as Record<string, unknown>)[segment];
+      }
+    } catch {
+      // A throwing getter on the adapter is the OTHER reporter's case: the
+      // evaluator would have thrown too. Stay silent rather than guess.
+      return [];
+    }
+    const spelling = 'data.' + path;
+    if (cursor === undefined && out.indexOf(spelling) === -1) out.push(spelling);
+  }
+  return out;
+}
+
+/** Built separately from the emit, for the same reason as the message above. */
+export function formatAdapterOnlyDataMessage(
+  type: unknown,
+  id: unknown,
+  key: string,
+  raw: unknown,
+  unresolved: string[],
+): string {
+  const node = typeof type === 'string' && type ? '"' + type + '"' : '(untyped node)';
+  const where = typeof id === 'string' && id ? ' (id: "' + id + '")' : '';
+  return (
+    ADAPTER_ONLY_DATA_PREDICATE_PREFIX + ' - node ' + node + where + '\n' +
+    '  ' + key + ': ' + JSON.stringify(predicateSourceText(raw)) + '\n' +
+    '  Undefined on the adapter: ' + unresolved.join(', ') + '\n' +
+    'At the node tier `data` is the DATA-SOURCE ADAPTER - the object\n' +
+    '`${data.total}` in a props bag reads - and it is NOT the row. The reads\n' +
+    'above are undefined on it, so this predicate is a CONSTANT: it does not\n' +
+    'depend on the row at all, and on this surface a constant `false` hides the\n' +
+    'node on every row while looking exactly like a gate that said no.\n' +
+    'Write the row as `record.*` (e.g. `record.status`), which page-component\n' +
+    'predicates bind alongside `current_user` and page state as `page.<var>`.\n' +
+    '`data.*` as a spelling for the row is deprecated (objectui#5330) and was\n' +
+    'never bound to the row on this tier.'
+  );
+}
+
+/**
+ * Dev-build diagnostic for a node-gate predicate that reads `data.*` and gets
+ * `undefined` back from the adapter (objectui#5687, maintainer ruling
+ * 2026-08-22 option A).
+ *
+ * ## It changes NO verdict, and it is not allowed to
+ *
+ * The ruling is explicit that the node tier keeps its documented
+ * `data` = adapter semantics: no verdict change, no interpolation change. This
+ * function returns `void`, is called for its console output only, and the
+ * caller passes the evaluator's answer through untouched. The constant-false
+ * still hides the block; the author now hears about it.
+ *
+ * ## Why it lives beside `reportUnresolvableVisibilityPredicate`
+ *
+ * They are two halves of ONE silence. objectui#5454 made the THROWING paths
+ * loud; measured on this base, a `{ dialect: 'cel' }` envelope reading
+ * `data.status` already throws and is already reported by that function. The
+ * bare-string and `${…}` template dialects do not throw for the same
+ * predicate — they resolve `undefined == 'draft'` to a clean `false` — so the
+ * author heard about the identical authoring mistake only if they happened to
+ * write it in the CEL dialect. That is the same dialect-dependent arbitrariness
+ * objectui#5454 existed to remove, one path further along.
+ *
+ * Sharing the module means sharing the LIFECYCLE, which is the part that has to
+ * match: one dedupe Set, one reset, one severity, one dev-only gate. The dedupe
+ * key is tagged with this leg's name so the two diagnostics cannot silence each
+ * other for the same (type, key, source) triple — they are different faults,
+ * and a node that faults one way is not evidence about the other.
+ */
+export function reportAdapterOnlyDataPredicate(
+  type: unknown,
+  id: unknown,
+  key: string,
+  raw: unknown,
+  boundData: unknown,
+): void {
+  const source = predicateSourceText(raw);
+  // Fast reject: the overwhelming majority of predicates never mention `data.`
+  // at all, and this runs for every visibility predicate of every node in dev.
+  if (source.indexOf('data.') === -1) return;
+  const unresolved = unresolvedDataPaths(source, boundData);
+  // Every `data.*` read the adapter answers -> a genuine adapter read.
+  // SILENT. This is the half of the ruling that makes the other half mean
+  // something.
+  if (unresolved.length === 0) return;
+  const dedupeKey = JSON.stringify(['adapter-only-data', type, key, source]);
+  if (_warnedVisibilityPredicates.has(dedupeKey)) return;
+  _warnedVisibilityPredicates.add(dedupeKey);
+  console.warn(formatAdapterOnlyDataMessage(type, id, key, raw, unresolved));
 }


### PR DESCRIPTION
Fixes #5687

Maintainer ruling, 2026-08-22, option A: **the node tier keeps its documented `data` = adapter semantics; the deprecated spelling's constant-false gets loud.** No verdict changes, no interpolation changes — #5330's row binding does not extend here, and the docblock's *"silent interpolation change nobody asked for"* stays refused. What lands instead is the #5454 reporter posture, extended to this non-throwing path.

## The defect, re-measured on this base (not inherited from the card)

The card measured on `3b147a367`; this branch is off `3ece13e33`. All three of its load-bearing facts were re-checked, and one of them has changed:

| card's fact | status on `3ece13e33` |
|---|---|
| `SchemaRenderer` hoists every `properties.*` value onto the node, so `properties.visible` arrives as `schema.visible` | **holds** — the hoist block is intact |
| the node-visibility evaluator is built with `data: dataSource`, the adapter, defaulting to `NO_DATA_SOURCE = {}` | **holds** — `data: dataSource` is still written last, after the ambient spread and after `record` |
| the #5454 reporter keys off a **throw**, which this path never does | **holds only for two of the three dialects** — see below |

Measured directly against `@object-ui/core`'s built evaluator with `data: {}`:

```
bare string   "data.status == 'draft'"                    -> false, NO throw   (silent)
${…} template "${data.status == 'draft'}"                 -> false, NO throw   (silent)
CEL envelope  { dialect:'cel', source:"data.status == …" } -> THROWS under throwOnError
```

So the CEL envelope **already** reports today, through `reportUnresolvableVisibilityPredicate`. The bare-string and template dialects do not. That is precisely the arbitrariness #5454 existed to remove — *"whether an author heard about their own typo depended on which dialect they happened to write it in"* — surviving one path further along. The card's repro shape is the bare string, so the gap is real and this is its narrowest closure.

## What changed

Two files, one call, ~200 lines of which most are the reasoning.

* `packages/react/src/utils/visibilityDiagnostic.ts` — `reportAdapterOnlyDataPredicate()` beside the existing reporter. **Same module, same dedupe `Set`, same `__resetVisibilityPredicateWarnings()`, same `console.warn` severity, same dev-only gate at the same call site.** The dedupe key is tagged with this leg's name so the two diagnostics cannot silence each other for one `(type, key, source)` triple — they are different faults.
* `packages/react/src/SchemaRenderer.tsx` — one call, on the **non-throwing branch only**:

```ts
const verdict = evaluator.evaluateCondition(raw, { throwOnError: true });
reportAdapterOnlyDataPredicate(newSchema.type, newSchema.id, key, raw, dataSource);
return verdict;
```

`verdict` is returned exactly as computed. "No verdict changes" is true **by construction** here, not by review.

## The trigger, and why it is this one

The ruling's trigger is not *references `data.`* — a genuine `${data.total}` adapter read must stay silent, and that half is what makes the loud half mean anything. Four candidate definitions were measured, not argued:

| definition | on the repro | on `data.total > 0` (adapter has `total`) | verdict |
|---|---|---|---|
| references `data.` at all | fires | **fires** | refused by the ruling in as many words |
| the whole predicate is constant-`false` | fires | — but `data.total > 100` against `{total:99}` **fires**, and so does a correct `record.status == 'draft'` against a non-draft row | cannot tell a gate that correctly says NO from one that never asked; would report every hiding gate in the repo |
| the comparison **operand** is `undefined` | fires | silent | most precise, but needs `@object-ui/core`'s evaluator to expose its operands — an engine change for a diagnostic on a card that dissolves |
| **a `data.*` read the bound object does not answer** | **fires** | **silent** | shipped |

The last one is also **structurally incapable** of firing on the `record.*` bucket (#5401 → #5454): a predicate with no `data.` root has nothing for it to look up. The two adjacent cards cannot bleed into each other through this code.

Residue, stated rather than hidden: deliberate absence idioms (`data.status == null`, `!data.status`) are reported. They are not really false positives at this tier — an adapter with no `status` makes those constants too, just constant-**true** — but they are shapes an author could have meant.

The scan is **lexical**, so string literals are stripped before it runs (`record.status == 'data.status'` reads nothing and says nothing). Not hypothetical: `examples/schema-catalog/src/schemas/components-complex-scroll-area/code-preview.json` carries `data.features` inside a JS snippet in a `content` string.

## The pin is a triple

`packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx`, 18 cases. Drop any leg and the file goes green on an implementation that reports everything, or nothing.

1. **the repro reports** — `properties: { visible: "data.status == 'draft'" }` warns, names the node/key/predicate and the unanswered read, and **still hides, on both rows**;
2. **canonical `record.*` stays silent** — opposite verdicts on the two row polarities, zero diagnostics;
3. **a genuine adapter read stays silent** — `${data.total}` still interpolates to `99` in a props bag, and `data.total > 0` as a *visibility gate* is silent on both polarities.

The case that decides **which** discriminator is implemented is 2c: *same predicate text, same `false` verdict, adapter now has the key* → silent. It holds the source and the verdict fixed and moves only the adapter.

Also pinned: the non-negated `hidden` leg keeps its inverted answer; `metadata.*` and `record.data.*` are not `data.*`; a CEL envelope reading `data.*` is reported **once**, by #5454, never twice; production takes the single-evaluation branch, reaches the same four verdicts and prints nothing.

## Ablation — direction predicted before running, both legs restored under `trap … EXIT INT TERM`

Both mutations were confirmed on disk by anchored counts **in both directions** (the deleted text at 0, an injected marker at 1) before any test was read. The mutated subject is imported by the tests via a relative source path (`../SchemaRenderer`), not through a package `exports` → `dist`, so no rebuild is involved and no stale artifact can make a mutation read as green.

**A — delete the reporter call.** Predicted: red exactly the positive cases, green every silence case and every verdict assertion. Observed: **6 red, 32 green**, and the entire #5454 pin file green.

**B — delete the `unresolved.length === 0` silence guard** (i.e. report on any `data.` mention). Predicted: red the silence cases that actually reach the reporter. Observed: **5 red** — 2b, 2c, 2d, 3c, 3d — group 1 and production untouched.

The two brackets are what make the discriminator checkable: A kills a "report nothing" implementation, B kills a "report everything" one.

**Ablation B found a bad control, which is the point of running it.** Case 3c (`metadata.*` is not `data.*`) survived B on the first run. Measured cause: with `metadata` unbound the predicate **throws** (`metadata is not defined`), lands in the #5454 catch, and never reaches this leg at all — so it was green for a reason unrelated to the boundary it claims to check. `metadata` is now bound in that case's scope; it takes the non-throwing path, and it dies under B as it should.

Controls that correctly **survive** both ablations, and why: 3a/3b (`record.*`) — neither mutation touches a path without a `data.` root, which is exactly the evidence the two cards don't bleed; 3e (CEL envelope) — it throws first, so it is #5454's case in both worlds; group 4 (production) — `__DEV__` short-circuits ahead of both mutations.

## Verification

Union run on `06561bde3`, the final commit, after the rebase.

* `pnpm exec vitest run packages/react/` → **52 files, 706 tests, 0 failures**. `pnpm exec vitest list packages/react/` collects 706 cases, 18 of them this file's — the default reporter names no passing file, so inclusion is read from vitest's own collection rather than assumed.
* `pnpm exec vitest run packages/react/ packages/components/ packages/plugin-grid/ packages/types/` → **363 files, 3635 tests, 0 failures**.
* `pnpm --filter @object-ui/react type-check` → exit 0. `pnpm --filter @object-ui/react lint` → `✖ 347 problems (0 errors, 347 warnings)`; all 347 are pre-existing `no-explicit-any`, and none sits in either of this diff's two hunks in `SchemaRenderer.tsx` (warning lines vs. hunk ranges compared).
* `check-control-bytes` `✅ OK (scanned 4801 tracked text file(s))` · `check-changeset-presence` `✅ … declares 1 changeset(s)` · `changeset-fixed` · `changeset-no-major` · `lint-coverage` `✅ 46/46 packages linted, 0 with outstanding errors` · `type-check-coverage` · `phantom-deps` · `self-import` · `esm-specifiers` · `spec-symbols` · `action-forward-parity` — all exit 0, quoting each gate's own verdict line.
* `check-eager-closure` fails with its own *"No eager-closure report … the console was not built … This is a broken gauge, not a passing budget"* — the known worktree gauge. It cannot move here regardless: the module specifiers imported by `SchemaRenderer.tsx` are **byte-identical** before and after (10 before, 10 after, empty diff) — the change widens an existing named import rather than adding an edge.

**Declared narrowing:** `packages/app-shell/` and `apps/console/` exceed the 10-minute foreground cap as whole suites, so the run was narrowed to the actual blast surface — every file carrying a `data.*` visibility predicate — `packages/app-shell/src/views/metadata-admin/` + `apps/console/src/components/FormPage.fieldSpec.test.ts` → **195 files, 1979 passed, 1 skipped**. The residual risk a new `console.warn` poses is a test asserting exact console call counts; the vitest config declares no `onConsoleLog` / `failOnConsole` (grep exit 1, controlled against a term known to be in the file), so an unexpected warn cannot fail a suite by configuration. CI runs the full farm regardless.

## Deprecated-spelling inventory (#5687's open question, answered)

The triage analysis flagged what it could not see: whether node-tier `data.*` predicates exist in real metadata. Controlled sweep of `examples/`, `apps/`, `content/`, `packages/`:

* node-tier `data.*` visibility predicates in non-test source: **zero**.
* The only two real `data.*` visibility predicates in the repo — `packages/app-shell/src/views/metadata-admin/anchors.ts` — are at the **SchemaForm field tier**, where `evaluatePredicate(visibility, { data: value })` binds `data` to the form draft values. A correct, different binding on a different evaluator, which this change cannot reach.

Controls for those zeros, since a zero hit is not a reading: the same shape spelled `record.*` → 246 hits; the visibility keys at all → 1273 hits; `data.` anywhere → 744 hits; and the sweep demonstrably enters `examples/schema-catalog` (5 visibility-key hits there, all `record.*` / `current_user.*`). **Nobody is standing in the blast radius** — useful for whoever owns #5330's deprecation window.

## Filed, not fixed here

**#5756** — a `${…}` predicate written **inside** `properties` is interpolated to a boolean *before* the hoist, so it reaches the chain as a bare `false` and **no** gate-side diagnostic can ever see it (this one or #5454's). It hides the block on every row, silently. Measured, and pinned in this PR as an explicit known limit rather than papered over. Closing it means adding a diagnostic inside the interpolation loop — the surface this ruling fences off — and it carries two real choices, so it belongs to triage, not to this card.

## One deliberate reading of the ruling, flagged for review

The ruling says this path "emits the dev-only unresolvable-predicate report". I read that as the **reporter** — its module, severity, dedupe and lifecycle, all of which are shared verbatim — and gave this leg its own first line (`ADAPTER_ONLY_DATA_PREDICATE_PREFIX`) rather than reusing `'A visibility predicate could not be evaluated'`. On this path that sentence would be false: the predicate evaluated perfectly, against the wrong object, and produced a constant. Telling an author "could not be evaluated" sends them hunting for a syntax error that is not there. Dispatch guidance was that posture matters more than message text, so this is where the flexibility was spent — and if the literal string was meant, it is a one-line change.

## Temporary by design

This is loudness, not a feature. It dissolves when #5330's deprecation window for the `data.*` row spelling closes; the changeset says so.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_