### PR TITLE
docs(plugin-form): Phase 0 of the row-predicate deprecation — stop teaching the bare shorthand (#5738)

### DIFF
--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -306,7 +306,7 @@ at insert regardless of state, so the producer's guarantee covers the
 conditional claim exactly as it covers the unconditional one:
 
 ```ts
-remind_at: Field.datetime({ requiredWhen: 'status == "scheduled"', defaultValue: 'NOW()' }),
+remind_at: Field.datetime({ requiredWhen: 'record.status == "scheduled"', defaultValue: 'NOW()' }),
 ```
 
 | Mode | Declared | Left empty | Effect |


### PR DESCRIPTION
Fixes #5738

Phase 0 of the row-predicate deprecation ruled on #5330 (2026-08-20, option B): stop **teaching** a spelling that the Phase-1 warning (PR #5737) now flags in the dev console. The card's own sizing note said this was plausibly zero-diff and that nobody had measured it — so the measurement is the deliverable, and it is reported in full below.

## Result

**One defect found and fixed**, in `packages/plugin-form/README.md`:

```diff
-remind_at: Field.datetime({ requiredWhen: 'status == "scheduled"', defaultValue: 'NOW()' }),
+remind_at: Field.datetime({ requiredWhen: 'record.status == "scheduled"', defaultValue: 'NOW()' }),
```

This one is the bad arm, not merely the non-canonical one. The same README's own table says these rules are "CEL predicates over the live record, evaluated by `@objectstack/formula` — the same engine and dialect the server enforces", and on that engine `buildScope({ record })` mounts exactly `['record']`, so the bare root faults there with `Unknown variable: status`. `requiredWhen` is one of the two rules enforced **client and server**, so the README was handing authors the spelling the server refuses outright.

## How the sweep was controlled

Driven by the shipped oracle, not by a regex: `detectNonCanonicalRowSpelling`, exported from `@object-ui/core`, is the same detector behind the live warning, so this cannot disagree with what authors see in their console. It reports `bare-shorthand` on the old text and nothing on the new.

Discovery was **key-agnostic** rather than a guess at which keys carry predicates — every string literal in the corpus containing a comparison or boolean operator, then classified by root identifier. Roots scanned, with the literal counts that prove the scanner reached them:

| root | files | string literals parsed |
|---|---|---|
| `content/docs` | 202 | 18,755 |
| `examples` (incl. schema-catalog, 427 JSON) | 465 | 21,787 |
| `apps` | 226 | 22,202 |
| `packages/*/README.md` | 39 | 6,738 |
| `skills` | 29 | 4,664 |
| `docs` | 15 | 2,474 |

That yielded 441 predicate-shaped strings (top roots: `record` 98, `data` 56). Positive control: the neighbouring terms `record.`, `data.`, `${`, `columns` and `objectql` all return hits across the corpus, so a zero in any class is a measured zero rather than a scanner that never arrived. Negative control: the canonical examples and the host-scope roots (`current_user.*`, `previous.*`) are run through the detector too and it reports nothing on them.

The schema-catalog corpus is **clean**: every predicate across its 427 JSON files is a static boolean, a canonical `record.*`, or a host-scope `current_user.*`.

## The three stand-downs, each verified rather than assumed

The layer rule is the whole difficulty here, and a blanket rewrite of either `data.` or the bare root would have broken a working tier. Three classes were deliberately left alone:

1. **Legacy `${…}`-dialect predicates** — in that dialect `data.*` is the correct spelling, and `evalRowPredicate` routes those strings to the legacy engine *before* the warning, so they cannot be what an author is being warned about. All `data.*` hits in `content/docs` are of this class.
2. **The schema/widget tier** (`visibleOn` / `hiddenOn` / `disabledOn` in the published skills guides) — a different engine (`SafeExpressionParser`), where `data` is the widget data scope rather than a row. Verified against the detector both ways: with `dataNamesRow: false` it reports nothing, and the counterfactual with `dataNamesRow: true` shows what it *would* say on a record surface. The stand-down rests on the tier, and that is stated rather than hidden.
3. **The flow tier** in `apps/console/src/preview-samples.ts` — `visibleWhen: 'discount > 0'` on a flow **screen** node reads as a bare-shorthand row predicate and is not one. Confirmed in code: `isFieldVisibleWhen` (`previews/screen-spec.ts`) evaluates it with `evalCondition(normalized, variables)` against **flow variables**, never `evalRowPredicate` — so the Phase-1 warning cannot fire there, and `discount` correctly names a sibling screen field. `FlowRunner.visibleWhen.test.tsx` pins the same shape from HotCRM's real lead-conversion screen. The neighbouring flow trigger, decision-edge and validation-rule conditions in that file are the same story.

## Verification

Gate union run **after** the final commit, on `f7074a8`, each exit code captured before any pipe:

| gate | exit | its own verdict line |
|---|---|---|
| `check:control-bytes` | 0 | `OK (scanned 4799 tracked text file(s); skipped 85 binary)` |
| `docs:check-links` | 0 | `Links are valid across 13 scan roots.` |
| `check:skills-paths` | 0 | `OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined)` |
| `check:doc-types` | 0 | `Every documented component type is registered.` |
| `check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| `check:changeset-presence` | 0 | `No source of a released package changed in this range, so no changeset is owed.` |
| `pnpm build` | 0 | `43 successful, 43 total` |

`check:doc-snippets` needed the build to run at all (it refuses on unbuilt packages) and its self-checks fired — resolution, a `ThisNameIsDefinitelyNotExported` sentinel producing TS2305, and a positive import producing zero. **One honest limit:** `packages/plugin-form/README.md` sits in that gate's *ungated* ledger (63 documents "declared in this script, NOT verified by it"), so the green above is not coverage of the file this PR edits.

**Declared narrowing.** Repo-wide `pnpm lint` was not run. The diff is a single `.md` file, and eslint's own configuration is the authority on whether that can matter: `npx eslint packages/plugin-form/README.md --format json` returns `File ignored because no matching configuration was supplied`. No eslint configuration matches `.md` at all, so this diff can move neither its own verdict nor any untouched file's. CI runs the full farm regardless.

**No changeset**, on the repo's own rule rather than an assumption: `check-changeset-presence.mjs` guards a released package's `src` tree only, and a README sits outside it — the gate says so itself in the table above.

## Out of scope, filed separately

The published skills guide `skills/objectui/guides/schema-expressions.md` still presents the three-way row binding without noting that two of the three now warn and are slated for retirement. That is stale post-#5737, but `skills/**` is outside this card's declared file surface and carries its own net-increase budget, so it is filed rather than edited here. See the linked finding.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_