### PR TITLE
ci(release): refresh the version PR on a schedule, publish only on a version-PR merge

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -1,9 +1,139 @@
 name: Changeset Release
 
+# ══════════════════════════════════════════════════════════════════════════════
+# TWO LANES, ONE FILE: THE VERSION PR REFRESHES ON A CLOCK, npm PUBLISHES ON A
+# MERGE. (objectstack#10850)
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Maintainer ruling, 2026-08-21 (verbatim, do not translate):
+#
+#   「我每周才发一次版本,changeset 每个pr 都跑有必要吗」
+#   「立卡吧,version 工作流改成发版前手动触发」
+#   「包括 objectui 仓库」
+#
+# The sister half landed first in `../objectstack` as its `release.yml`
+# `version-pr` job (objectstack#11233 / PR #11238, maintainer 2026-08-23): a
+# 6-hourly `schedule` plus an on-demand dispatch input, which is the later and
+# more specific spelling of "手动触发" and the one mirrored here. Per-PR changeset
+# VALIDATION is explicitly untouched by the ruling — `changeset-guard.yml` and
+# `changeset-presence.yml` still run on every pull request.
+#
+# WHY THE REFRESH LEFT THE PUSH TRIGGER
+# -------------------------------------
+# With pending changesets this file's changesets step recomputed and FORCE-PUSHED
+# the standing "chore: release packages" PR (objectui#5400) on every landing, and
+# `main` takes ~18 merges a working day (the same cadence the concurrency note
+# below measures). The PR therefore never held still long enough for its own
+# branch CI to finish. Releases are weekly, so every one of those refreshes was a
+# CI run spent on bookkeeping nobody reads until release day. Between refreshes
+# `changeset-release/main` is now a static branch whose CI can converge.
+#
+# The staleness window is the whole cost, and it is bounded on demand: dispatch
+# with `refresh_version_pr` when you want the PR current NOW (immediately before
+# a release, say). The bookkeeping is not time-critical — the changesets are
+# already committed on `main`; objectui#5400 is only their rendering.
+#
+# WHY THE SPLIT NEEDS A SEPARATE `lane` JOB, AND NOT JUST AN `if:` ON THE STEP
+# ---------------------------------------------------------------------------
+# ⚠️ Unlike objectstack's `release.yml` — which has a version job and a publish
+# job and could simply give each one its own trigger — this repository publishes
+# from THE SAME changesets step that refreshes the PR. Which of the two it does
+# is not ours to choose per invocation: the action decides from repository state.
+# Its v1 source (`changesets/action`, `src/index.ts`) dispatches on exactly two
+# facts, `hasChangesets` and whether a `publish:` input was given:
+#
+#     case !hasChangesets && !hasPublishScript:  -> nothing
+#     case !hasChangesets &&  hasPublishScript:  -> runPublish   (npm + tags)
+#     case  hasChangesets && !hasNonEmptyChangesets: -> nothing
+#     case  hasChangesets:                       -> runVersion   (force-push PR)
+#
+# Two consequences drive everything below, and they are NOT symmetric:
+#
+#   - Omitting `publish:` makes publishing UNREACHABLE BY CONSTRUCTION. There is
+#     no state in which the action publishes without that input.
+#   - Omitting `version:` does NOT make the refresh unreachable. `runVersion`
+#     falls back to plain `changeset version` when the input is absent, so a step
+#     invoked on a push that still carries pending changesets force-pushes
+#     objectui#5400 no matter how it is configured.
+#
+# So the refresh lane is closed by construction, and the publish lane can only be
+# closed by NOT INVOKING THE ACTION on a push that carries pending changesets.
+# That question — "does `main` carry pending changesets?" — has to be answered
+# before the expensive steps, or the saving the ruling asked for is not made: the
+# job would still install and build on all ~18 daily landings just to decide to
+# do nothing. Hence one cheap job that answers it from a sparse checkout, and one
+# job-level `if:` that states the policy. A second workflow FILE was ruled out
+# (no new lanes to maintain, and the publish invariants would be duplicated where
+# they can drift apart).
+#
+# THE LANES
+# ---------
+#   push to main, `.changeset/` empty   -> PUBLISH. The version PR has just been
+#                                          merged; this is the release. Unchanged
+#                                          from before, including the retry on a
+#                                          later push that still finds it empty,
+#                                          which is how @object-ui/*@17.5.0
+#                                          eventually shipped (see the `pnpm test`
+#                                          note further down).
+#   push to main, changesets pending    -> NOTHING. The whole release job is
+#                                          skipped; the refresh is the clock's
+#                                          job now. This is the ruling.
+#   schedule (6-hourly)                 -> REFRESH ONLY. The changesets step is
+#   or a dispatch with                     invoked WITHOUT a `publish:` script
+#   `refresh_version_pr`                   and WITHOUT npm credentials, so the
+#                                          publish branch is unreachable by
+#                                          construction rather than by an `if:`
+#                                          someone can get wrong.
+#   dispatch without the input          -> NOTHING, loudly. See the input's note.
+#
+# ⛔ A refresh lane that could publish would be a NEW capability, not a moved
+# one: this repository's release act is the version-PR MERGE, a human action. A
+# scheduled tick that reached npm would publish with nobody having merged
+# anything. That is why the publish half is denied to it twice over — no
+# `publish:` input and no `NPM_TOKEN`/`NODE_AUTH_TOKEN` in its env — and why the
+# publish half keeps its trigger exactly as it was. This card changed WHEN the
+# version PR refreshes and nothing else: no gate was added, and none removed.
+#
+# ⚠️ Scheduled runs are queued, not guaranteed on the minute — GitHub delays or
+# drops them under load, and disables them entirely after 60 days of repository
+# inactivity. Both are acceptable HERE and would not be on a publishing lane: a
+# refresh that arrives late leaves objectui#5400 stale, which is visible on the
+# PR and fixable with one dispatch. It is a second reason the publish lane must
+# never be reachable from `schedule`.
+
 on:
+  # The PUBLISH lane (and only it — see the header). Kept exactly as it was: the
+  # merge of the version PR is the release act in this repository.
   push:
     branches:
       - main
+  # The REFRESH lane. GitHub runs `schedule` on the DEFAULT BRANCH exclusively,
+  # which is the only ref this workflow may regenerate the version PR from, so
+  # the trigger cannot reach a ref the lane is not meant to touch.
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      # The on-demand half of the schedule. Its ONLY effect is to select the
+      # refresh lane; it can start nothing the 6-hourly tick does not start, so
+      # it cannot widen anything.
+      #
+      # ⚠️ It defaults to FALSE to match objectstack's spelling of the same
+      # input, which leaves "Run workflow" with default inputs doing NOTHING in
+      # this repository — objectstack's bare dispatch is its publish REPAIR lane,
+      # and this repository has no such lane (publishing here is not gated on an
+      # environment approval, so there is nothing to re-approve). Rather than
+      # invent one under this card, the `lane` job below prints a `::notice::`
+      # saying why nothing ran, so a bare dispatch reports instead of vanishing.
+      refresh_version_pr:
+        description: >-
+          Regenerate the "chore: release packages" PR (objectui#5400) now instead
+          of waiting for the next 6-hourly refresh. Runs the bookkeeping lane
+          ONLY: nothing is published to npm. Leave unchecked and this workflow
+          does nothing at all.
+        required: false
+        default: false
+        type: boolean
 
 # One concurrency group per COMMIT — never one shared by every push to `main`.
 #
@@ -15,10 +145,27 @@ on:
 # 106 that did execute held the group for a median of 33m22s. Median wait for a run
 # that survived: 5m16s (objectui#5404, method and figures from objectui#5395).
 #
-# The last step of this workflow publishes to npm, so a discarded run is a discarded
+# A push run of this workflow can publish to npm, so a discarded run is a discarded
 # publish. `cancel-in-progress: true` is NOT the fix: it keeps one pending slot by
 # killing the run that may be mid-`changeset publish`, which is strictly worse than
 # any wait.
+#
+# ⚠️ "A push run" is where that sentence used to say "this workflow", and the
+# distinction is new with objectstack#10850: since the refresh lane arrived, `push`
+# is no longer the only event here, and `github.sha` is no longer unique per run.
+# A `schedule` tick and a `workflow_dispatch` both read the head of `main`, so two
+# of them between merges land in the SAME group and the older pending one is
+# evicted. That is harmless, and provably so rather than by luck:
+#
+#   - Only refresh runs can be evicted. A push run at `<sha>` is always the FIRST
+#     run in its group — the sha did not exist before that push — so it is never
+#     the pending one, and `cancel-in-progress: false` means it is never cancelled
+#     once started. The publish lane keeps exactly the protection this key was
+#     added for.
+#   - An evicted refresh is nothing lost. The refresh regenerates objectui#5400
+#     from scratch, so the newest run's result is the one that was wanted anyway —
+#     the same reasoning `../objectstack`'s `version-pr` job records for its own
+#     concurrency group.
 #
 # Keyed by `github.sha` the group holds exactly one run, so nothing is ever discarded.
 # Serialisation is not given up — it moves into the "Wait for older release runs" step
@@ -37,8 +184,124 @@ permissions:
   id-token: write
 
 jobs:
+  # ══════════════════════════════════════════════════════════════════════════
+  # Which lane is this run in? (objectstack#10850)
+  # ══════════════════════════════════════════════════════════════════════════
+  # The header explains why this cannot be an `if:` on the changesets step: the
+  # publish lane is only safe on a commit where `.changeset/` is empty, and that
+  # fact has to be known BEFORE install and build, or every one of `main`'s ~18
+  # daily landings still pays for a job that will decide to do nothing.
+  #
+  # This job answers the FACT ("does this commit carry pending changesets?") and
+  # nothing else. The POLICY lives in the release job's `if:` below, in workflow
+  # expression language where it can be read in one place — a shell script that
+  # emitted "the lane" would move the split somewhere no reviewer looks.
+  lane:
+    name: Decide lane
+    runs-on: ubuntu-latest
+    # Narrower than the workflow-level block deliberately: this job reads files
+    # and writes nothing. Declaring any `permissions:` sets every unlisted scope
+    # to `none`, which is the point — a new job on a workflow that can publish
+    # should not inherit the publish credentials' scopes.
+    permissions:
+      contents: read
+    outputs:
+      pending_changesets: ${{ steps.detect.outputs.pending_changesets }}
+    steps:
+      # `.changeset/` only — the whole question is answered by that directory, and
+      # a full checkout of this repository is ~15s that every landing would pay.
+      - name: Check out .changeset
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .changeset
+
+      # ⛔ This must stay a faithful mirror of `readChangesetState` in
+      # `changesets/action`'s `src/index.ts` (it re-exports `@changesets/read`),
+      # because the release job's guard is only correct while the two agree:
+      #
+      #   - every `.changeset/*.md` counts EXCEPT `README.md`;
+      #   - an EMPTY changeset still counts (this repository declares "nothing to
+      #     release" with empty frontmatter — see `changeset-presence.yml` — and
+      #     the action's `hasChangesets` counts those too, which is why a commit
+      #     carrying only empty changesets skips this job's release half. The
+      #     action would have taken its `!hasNonEmptyChangesets` branch and done
+      #     nothing anyway, so the observable behaviour is unchanged);
+      #   - in pre mode ONLY, the ids already listed in `pre.json.changesets` are
+      #     filtered out, because the action filters them and would therefore
+      #     publish where a naive file count says "pending". This repository is
+      #     not in pre mode and has no `pre.json`, so that branch is dormant — it
+      #     is written because the failure it prevents (a pre-mode release that
+      #     silently never publishes) is invisible until release day.
+      #
+      # It fails LOUDLY rather than guessing a lane: this is deterministic file
+      # I/O, so an error here means something is wrong that a default would hide.
+      - name: Detect pending changesets
+        id: detect
+        env:
+          REFRESH_VERSION_PR: ${{ inputs.refresh_version_pr }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          in_pre_mode=false
+          consumed=''
+          if [ -f .changeset/pre.json ]; then
+            if [ "$(jq -r '.mode // ""' .changeset/pre.json)" = 'pre' ]; then
+              in_pre_mode=true
+              consumed=$(jq -r '.changesets[]? // empty' .changeset/pre.json)
+            fi
+          fi
+
+          pending=false
+          for file in .changeset/*.md; do
+            name="${file##*/}"
+            if [ "$name" = 'README.md' ]; then
+              continue
+            fi
+            if [ "$in_pre_mode" = true ] && printf '%s\n' "$consumed" | grep -qxF -- "${name%.md}"; then
+              continue
+            fi
+            echo "pending changeset: ${name}"
+            pending=true
+          done
+
+          echo "pending_changesets=${pending}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo '### Changeset Release lane'
+            echo
+            echo "- event: \`${GITHUB_EVENT_NAME}\`"
+            echo "- commit: \`${GITHUB_SHA}\`"
+            echo "- pending changesets: \`${pending}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # A bare "Run workflow" reports instead of vanishing — see the input's
+          # note in the `on:` block above.
+          if [ "${GITHUB_EVENT_NAME}" = 'workflow_dispatch' ] && [ "${REFRESH_VERSION_PR}" != 'true' ]; then
+            echo "::notice::Nothing to do. Check 'refresh_version_pr' to regenerate the version PR; publishing to npm happens when that PR is merged, not from a dispatch."
+          fi
+
   release:
     name: Changeset Release
+    needs: lane
+    # The whole lane split, in one place (objectstack#10850). Each half names its
+    # own event rather than leaning on the complement of the other:
+    #
+    #   push + no pending changesets  -> the version PR was merged: PUBLISH.
+    #   push + pending changesets     -> skipped; the clock refreshes the PR now.
+    #   schedule                      -> REFRESH.
+    #   dispatch WITH the input       -> the same refresh, on demand.
+    #   dispatch WITHOUT it           -> skipped; the `lane` job says why.
+    #
+    # `inputs.refresh_version_pr` is guarded by its event test rather than read
+    # bare: the `inputs` context exists only on `workflow_dispatch`, so on a
+    # `schedule` run it is null — falsy, and therefore the right answer by
+    # accident. Say which event we are on, so the guard states the lane split
+    # instead of leaning on a context's emptiness.
+    if: >-
+      (github.event_name == 'push' && needs.lane.outputs.pending_changesets == 'false') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.refresh_version_pr)
     runs-on: ubuntu-latest
     steps:
       # The queue the `concurrency:` key above cannot provide. GitHub offers exactly two
@@ -150,15 +413,59 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
+      # ══════════════════════════════════════════════════════════════════════
+      # One changesets step per lane, and each one CANNOT do the other's job.
+      # ══════════════════════════════════════════════════════════════════════
+      # These were a single step carrying both `version:` and `publish:`, which
+      # let repository state pick the behaviour (the algorithm is quoted in this
+      # file's header). Splitting them is what makes each lane's limit structural
+      # instead of conditional: the refresh step has no `publish:` input, so no
+      # state — not even a `.changeset/` that has just been emptied by a merge
+      # racing the tick — can make a scheduled run publish. An `if:` cannot say
+      # that; an absent input can.
+      #
+      # The `id:`s are for the log, nothing reads them.
+
+      # PUBLISH. Reachable only from `push`, and the job guard above has already
+      # established that this commit carries no pending changesets — so the
+      # action takes its `!hasChangesets && hasPublishScript` branch, which is
+      # `runPublish`. No `version:` here: it would be dead configuration, and a
+      # reader is better served by a step that carries only what it can use.
+      #
+      # ⚠️ Do not mistake that for a guarantee. Omitting `version:` does NOT
+      # disable the refresh branch — the action falls back to plain
+      # `changeset version` — so what keeps THIS step from force-pushing the
+      # version PR is the job's `needs.lane` guard, and only that. If you ever
+      # relax that guard, this step starts refreshing the PR again.
+      - name: Publish to npm
+        id: changesets-publish
+        if: github.event_name == 'push'
         uses: changesets/action@v1
         with:
-          version: pnpm changeset:version
           publish: pnpm changeset:publish
-          title: 'chore: release packages'
-          commit: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # REFRESH. No `publish:` input, so `runPublish` is unreachable; no npm
+      # credentials in `env:`, so it is unreachable a second time over. Both are
+      # deliberate — this lane runs unattended on a clock, and the release act in
+      # this repository is a human merging the PR it regenerates.
+      #
+      # `version:` must stay `pnpm changeset:version` rather than bare
+      # `changeset version`: the npm script also runs
+      # `scripts/sync-quick-reference-release.mjs`, which is the only thing that
+      # keeps `QUICK_REFERENCE.md` from fossilising at release time
+      # (objectui#5394). `scripts/__tests__/sync-quick-reference-release.test.ts`
+      # reads this very line and fails if it changes.
+      - name: Refresh the version PR
+        id: changesets-version
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset:version
+          title: 'chore: release packages'
+          commit: 'chore: release packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -37,7 +37,7 @@ one has its own section below.
 | `labeler.yml` | Auto Label PRs | PR `opened`, `synchronize`, `reopened` | No |
 | `dependabot-auto-merge.yml` | Dependabot Auto-merge | PR to `main`/`develop` authored by `dependabot[bot]` | No — but it gates *its own* merge, and goes red instead of merging when the check set is not green |
 | `cross-repo-issue-closer.yml` | Cross-repo Issue Closer | PR `closed` (acts only when merged) | No — runs after merge |
-| `changeset-release.yml` | Changeset Release | Push to `main` | n/a |
+| `changeset-release.yml` | Changeset Release | Push to `main` (publish half); 6-hourly cron `0 */6 * * *`; manual (version-PR refresh half) | n/a |
 | `changelog.yml` | Auto Changelog | GitHub Release published; manual | n/a |
 | `stale.yml` | Stale Issues & PRs | Daily cron `0 0 * * *`; manual | n/a |
 | `shadcn-check.yml` | Check Shadcn Components | Weekly cron `0 9 * * 1`; manual | n/a |
@@ -709,19 +709,37 @@ Uses [Lychee](https://github.com/lycheeverse/lychee) with configuration from `ly
 
 ### Changeset Release (`changeset-release.yml`)
 
-**Trigger:** Push to `main`.
+**Trigger:** Push to `main` — the **publish** half. Cron `0 */6 * * *` and manual dispatch with
+`refresh_version_pr` — the **version-PR refresh** half.
 
-Uses [Changesets](https://github.com/changesets/changesets) for automated versioning and npm publishing:
-1. Detects pending changesets.
-2. Bumps package versions.
-3. Publishes to npm.
-4. Configures a pnpm-lock.yaml merge driver to prevent lock file conflicts.
+Uses [Changesets](https://github.com/changesets/changesets) for automated versioning and npm
+publishing, in **two lanes that cannot do each other's job**:
 
-Step 3 runs `pnpm changeset:publish`, and that script is
+| Event | `.changeset/` | What runs |
+|---|---|---|
+| Push to `main` | empty | **Publish to npm.** The version PR has just been merged; that merge is the release act. |
+| Push to `main` | changesets pending | **Nothing.** The whole release job is skipped. |
+| Cron `0 */6 * * *` | either | **Refresh the version PR** ([#5400](https://github.com/objectstack-ai/objectui/pull/5400)) — never publishes. |
+| Manual, `refresh_version_pr` checked | either | The same refresh, on demand. |
+| Manual, unchecked | either | Nothing; the run says so with a `::notice::`. |
+
+The refresh used to run on **every** push to `main`, which force-pushed the version PR ~18 times
+a working day while releases are weekly — so its branch CI never converged, and every refresh
+was a CI run spent on bookkeeping nobody reads until release day
+([objectstack#10850](https://github.com/objectstack-ai/objectstack/issues/10850)). A `lane` job
+answers "does this commit carry pending changesets?" from a sparse checkout of `.changeset/`
+before anything installs or builds, so a landing that owes no publish costs one cheap job.
+
+The refresh lane is invoked **without** a `publish:` script and **without** npm credentials, so
+it cannot publish by construction rather than by a condition — the release act in this
+repository stays the human merge of the version PR. Step 3 of the publish lane runs
+`pnpm changeset:publish`, and that script is
 `node scripts/check-published-dist-tooling.mjs && changeset publish` — the **blocking** copy of
 the Published Dist Gate above. A published package whose `dist/` carries tooling material stops
 the publish before a single tarball reaches npm, which is where that defect actually costs
 anything ([#4846](https://github.com/objectstack-ai/objectui/issues/4846)).
+
+Both lanes configure a pnpm-lock.yaml merge driver to prevent lock file conflicts.
 
 ### Published Dist Gate (`published-dist-gate.yml`)
 

--- a/scripts/check-changeset-fixed.mjs
+++ b/scripts/check-changeset-fixed.mjs
@@ -36,7 +36,13 @@
  * bumping the CLI without declaring the key exited 1 on `changeset status` AND
  * on `changeset version` — the release lane stops, and nothing in PR CI would
  * have said so, because no PR workflow runs either command (the only invocation
- * is inside `.github/workflows/changeset-release.yml`, on push to `main`).
+ * is inside `.github/workflows/changeset-release.yml`). Since objectstack#10850
+ * that invocation is later still: `changeset version` runs on that workflow's
+ * REFRESH lane — the 6-hourly cron or a manual `refresh_version_pr` dispatch —
+ * not on push to `main`, so a mixed changeset that would stop the release lane
+ * now surfaces at the next refresh rather than at the next landing. Which only
+ * sharpens the point: this gate is still the only thing that can say so on a
+ * pull request.
  *
  * Hence rule 2: silence about `privatePackages` is no longer a safe default,
  * because its meaning inverted. And hence rule 3: `fixed` membership and


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#10850

Sister card in this repository: objectstack-ai/objectui#5571 (same maintainer ruling, this
repo's own workflow). It is left open for the PM to close or retarget — this PR carries the
closing keyword for the dispatched card only.

The objectstack half of the ruling landed as objectstack-ai/objectstack#11238; this is the
`objectui` half, mirroring its reasoning where the two files are analogous and diverging where
they are not.

## The problem

`changeset-release.yml` ran its changesets step on **every** push to `main`. With pending
changesets that step's version path is `git reset --hard HEAD-of-the-push` → re-version →
`git push --force origin HEAD:changeset-release/main`, so the standing
"chore: release packages" PR (#5400) was force-refreshed on each of `main`'s ~18 daily
landings while releases are weekly. The PR never held still long enough for its own branch CI
to finish, and every refresh was a CI run spent on bookkeeping nobody reads until release day.

Measured on this branch's merge base: **157** pending changesets in `.changeset/` — every one
of those ~18 daily runs was re-rendering all 157.

## Trigger truth table

| Event | `.changeset/` state | Lane | Publishes? |
|---|---|---|---|
| `push` to `main` | empty | **Publish to npm** (unchanged) | Yes — this is the version-PR merge, i.e. the release act |
| `push` to `main` | changesets pending | **Nothing** — release job skipped | No |
| `push` to `main` | only *empty* changesets | **Nothing** — release job skipped | No (the action would have done nothing anyway) |
| `schedule` `0 */6 * * *` | any | **Refresh the version PR** | No — unreachable by construction |
| `workflow_dispatch` **with** `refresh_version_pr` | any | **Refresh the version PR** | No — unreachable by construction |
| `workflow_dispatch` **without** the input | any | **Nothing**, with a `::notice::` saying why | No |

## The split shape, and why this one

⚠️ This repository is **structurally different** from objectstack's `release.yml`. There, a
`version-pr` job and a `publish` job already existed and each could simply take its own
trigger. Here there is **one** changesets step carrying both `version:` and `publish:`, and
*which* of the two it performs is not ours to choose per invocation — the action decides from
repository state. Its v1 source (`changesets/action`, `src/index.ts`) dispatches on exactly two
facts:

```
case !hasChangesets && !hasPublishScript:        -> nothing
case !hasChangesets &&  hasPublishScript:        -> runPublish   (npm + tags)
case  hasChangesets && !hasNonEmptyChangesets:   -> nothing
case  hasChangesets:                             -> runVersion   (force-push the PR)
```

The two consequences are **not symmetric**, and this asymmetry is the whole design:

- Omitting `publish:` makes publishing **unreachable by construction**. No repository state
  makes the action publish without that input.
- Omitting `version:` does **not** make the refresh unreachable — `runVersion` falls back to
  plain `changeset version`. A step invoked on a push that still carries pending changesets
  force-pushes #5400 no matter how it is configured.

So the refresh lane can be closed by construction, but the publish lane can only be closed by
**not invoking the action at all** on a push that carries pending changesets. That question has
to be answered *before* install and build, or the saving the ruling asked for is not made: the
job would still install and build on all ~18 daily landings just to decide to do nothing.

**Chosen shape — a second job in the same file** (a second workflow *file* was ruled out):

1. A cheap `lane` job: sparse checkout of `.changeset/` only, `permissions: contents: read`,
   emits one fact — `pending_changesets`. It answers the *fact*; the *policy* stays in the
   release job's `if:`, in workflow expression language where one reader can see the whole
   split.
2. The `release` job gains `needs: lane` and one job-level `if:` carrying the truth table.
3. The single changesets step becomes **two mutually exclusive steps**, so each lane's limit is
   structural rather than conditional: the refresh step has **no `publish:` input** and **no
   `NPM_TOKEN`/`NODE_AUTH_TOKEN` in its env**.

### Failure modes this shape excludes

- **A scheduled tick publishing to npm.** Denied twice over — no `publish:` input and no npm
  credentials. Even a `.changeset/` emptied by a merge racing the tick cannot make it publish.
  This matters because a publish from a tick would be a *new* capability: the release act here
  is a human merging #5400, and a tick reaching npm would publish with nobody having merged.
- **A push force-pushing #5400.** The whole release job is skipped when changesets are pending,
  so the version path is never entered from `push`.
- **The version-PR merge failing to publish.** Preserved exactly, including the retry on a
  later push that still finds `.changeset/` empty — the path by which `@object-ui/*@17.5.0`
  eventually shipped.
- **A wrong lane chosen silently.** The detection fails loudly rather than defaulting; it is
  deterministic file I/O, so an error means something a default would hide.
- **Detection drifting from the action.** The `lane` script is a deliberate mirror of the
  action's `readChangesetState`, and it is cross-checked against the real reader below —
  including the pre-mode branch, which is dormant here but whose failure (a pre-mode release
  that silently never publishes) would only surface on release day.
- **A bare "Run workflow" vanishing.** objectstack's bare dispatch is its publish *repair*
  lane; this repository has none (publishing here is not gated on an environment approval, so
  there is nothing to re-approve). Rather than invent one under this card, the default-`false`
  input is kept for spelling parity and a bare dispatch emits a `::notice::` explaining that
  nothing ran.

### Preserved verbatim

- The **"Wait for older release runs" step** — byte-identical to `origin/main` (2031 bytes,
  verified mechanically), fail-open design and all. It now serialises across *both* lanes,
  which is wanted: a refresh force-pushing `changeset-release/main` while a publish is in
  flight is exactly the race it exists to prevent.
- The **per-commit concurrency group** (`${{ github.workflow }}-${{ github.sha }}`,
  `cancel-in-progress: false`) — unchanged. Only its header comment gained a qualifier, because
  the trigger change falsifies one sentence in it: `github.sha` is no longer unique per run
  (a tick and a dispatch both read `main`'s head), so same-sha collisions are now reachable.
  They are provably harmless: a push run at a given sha is always the *first* run in its group —
  the sha did not exist before that push — so a publish run is never the pending one and never
  evicted; only refreshes can be evicted, and a refresh regenerates the PR from scratch.

### Not done, deliberately

No gate added or removed; `pnpm build` still runs on both lanes (the refresh arguably does not
need it, but that is an optimisation this card does not authorise). Per-PR changeset
*validation* — `changeset-guard.yml`, `changeset-presence.yml` — is untouched, as the ruling
requires.

## Prose sites updated (only what the trigger change falsifies)

| Site | Was | Now |
|---|---|---|
| `changeset-release.yml` concurrency header | "The last step of this workflow publishes to npm, so a discarded run is a discarded publish" | "A push run … can publish", plus the same-sha collision analysis |
| `content/docs/guide/ci-cd-pipeline.md` workflow inventory table | "Push to `main`" | both halves named |
| `content/docs/guide/ci-cd-pipeline.md` §Changeset Release | "**Trigger:** Push to `main`" + a 4-step list implying one run does all of it | two-lane trigger + a lane table |
| `scripts/check-changeset-fixed.mjs` header | "the only invocation is inside `changeset-release.yml`, on push to `main`" | names the refresh lane; the gate's point (only *it* can say so on a PR) is sharpened, not weakened |

Left alone because they are **not** falsified: `sync-quick-reference-release.mjs` and its test
(they say `changeset version` runs "with no human present" — still true on the refresh lane),
the pnpm-lock merge-driver table, and the `NPM_TOKEN` secrets row.

## Verification

All at `b38e47f68` (the final commit), run as one union after committing.

**The detection script is the load-bearing new logic, so it was tested rather than assumed.**
The script under test was *extracted from the shipped YAML*, so what ran is what ships.

Oracle = the real `@changesets/read@1.0.0` plus the action's own `readChangesetState` filtering
rule, transcribed from its fetched source:

| Fixture | Oracle | Shipped mirror | Agree |
|---|---|---|---|
| `.changeset/` as it stands on `main` (157 changesets) | `true` | `true` | yes |
| version PR just merged (README only) | `false` | `false` | yes |
| pre mode, all ids consumed | `false` | `false` | yes |
| pre **exited**, same files | `true` | `true` | yes |
| only an *empty* changeset (docs-only declaration) | `true` | `true` | yes |

**The comparison was proven able to fail.** Ablation on the extracted copy (scratchpad only,
never the repo file, with a restore trap): removing the `README.md` exclusion was confirmed on
disk by an anchored observation (`README.md` mentions 1 → 0, 1189 → 1134 bytes), after which
the "version PR just merged" fixture **diverged** (mirror `true` vs oracle `false`). The
restore leg was confirmed the same way (mentions back to 1) and agreement returned. A first
attempt at this mutation did **not** land — the `perl` anchor missed the extracted script's
indentation and exited 0 — so that reading was discarded as void rather than reported.

Gate verdicts, each quoting the gate's own line:

| Check | Verdict |
|---|---|
| `vitest run` on the 4 test files that read this workflow | `Test Files  4 passed (4)` / `Tests  72 passed (72)` |
| `pnpm changeset:check` | `✅  All workspace packages are in the changeset fixed group.` / `✅  No changeset declares a major bump.` |
| `pnpm check:control-bytes` | `✅  check-control-bytes: OK (scanned 4803 tracked text file(s); skipped 85 binary).` |
| `pnpm docs:check-links` | `Links are valid across 13 scan roots.` |
| `node scripts/check-changeset-presence.mjs` | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| YAML validity, via the workspace's own `yaml@2.9.0` | `parse errors: 0 warnings: 0`; `on:` parses as the string key, not YAML-1.1 `true` |

The pin test that reads this file specifically — `changeset-release.yml` must still hand the
action `version: pnpm changeset:version` — passes: the regex it uses
(`/^\s*version:\s*(.+)$/m`) resolves to `pnpm changeset:version` on the new file, which is why
that input stays on the refresh step verbatim.

**Lint** was narrowed to the changed files rather than the repo-wide run, and the narrowing is
a measurement, not a skip: eslint's *own* config reports the `.yml` and `.md` files as "File
ignored because no matching configuration was supplied", leaving exactly one lintable changed
file; `--format json` counts 3 files reported, 0 errors; and `eslint.config.js` enables no
type-aware linting (no `projectService`/`project:`), so this diff cannot move the verdict on
any untouched file.

**Changeset:** none owed. The presence gate decided that itself from the diff (line quoted
above); this repository has no `skip-changeset` label, and the diff touches no released
package's `src/`.

**Landing class:** this diff touches `.github/workflows/`, `content/docs/` and `scripts/` —
**not** on this repository's governed surface (`AGENTS.md`, `CLAUDE.md`, `.claude/**`,
`docs/adr/**` per AGENTS.md §受管面), so the ordinary path would apply. Held as **draft**
anyway pending PM review, as dispatched; no ready/queue/auto-merge action taken.

**Not verified locally, by design:** the acceptance criterion ("a test merge to `main` starts
zero Version-Packages refresh runs") is observable only in the Actions run list after this
lands. The trigger truth table above is what stands in for it until then.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsbKEG4LtERSLaDrbehM3e)_
