### PR TITLE
fix(auth): stop `ActiveOrganizationStorage.clear()` swallowing a failed removal

### DIFF
--- a/.changeset/active-org-clear-removal-failure-5731.md
+++ b/.changeset/active-org-clear-removal-failure-5731.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/auth': patch
+---
+
+`ActiveOrganizationStorage.clear()` now verifies that the persisted key is actually
+gone and, when it is not, both reports the failure and stops `get()` answering from
+the surviving value — instead of swallowing the failed removal (objectui#5731).
+
+`clear()` nulled `_memoryValue` and then removed the persisted key inside a
+`try`/`catch` that discarded any failure. Since objectui#5703 `get()` prefers a
+NON-NULL `localStorage` read and only falls through to `_memoryValue`, so the two
+halves of `clear()` were not equally strong: nulling memory always sticks, while a
+removal that did not stick left the key readable and the read order preferred it.
+Sign-out is one of `clear()`'s five callers, so the failure mode was "sign-out does
+not stick", and it was silent — the cleared organization went back on the wire as
+`X-Tenant-ID` on every subsequent request.
+
+The removal is now judged by a READ-BACK rather than by catching the throw, which is
+both narrower and wider in the right directions. Wider: a wrapped or proxied
+`localStorage` whose `removeItem` is a silent no-op never throws and leaves identical
+residue, and is now covered. Narrower: SSR and the partitioned-iframe browser where
+every operation throws have nothing readable to resurrect, were already safe, and are
+not reported as failures.
+
+A key whose removal could not be verified is quarantined in memory for the rest of the
+page-load: `get()` skips the persisted branch for it and answers from `_memoryValue`,
+which `clear()` has just nulled and which a later `set()` refills with the value that
+write was meant to persist. The quarantine is released as soon as a removal on that key
+sticks. An unstamped `X-Tenant-ID` is a documented state of the edge contract
+(objectui#5279); a re-stamped signed-out organization is not.
+
+The failure is not thrown and not returned. All five call sites — sign-out's
+`purgeSignedOutClientCaches`, `switchOrganization`, `deleteOrganization`,
+`leaveOrganization`, and the session-user purge that runs on the SIGN-IN path — arrive
+after the transition they follow up on has already happened, and none can act on a
+storage failure; a `boolean` every caller ignores would read as handled when it is not.
+So the invariant is restored inside `clear()` and the failure is reported to the
+console.
+
+A working `localStorage` behaves exactly as before: the removal sticks, nothing is
+quarantined, nothing is reported, and a non-null persisted read is still authoritative.
+`set()`'s swallowed write failure is deliberately untouched — that swallow is
+objectui#5703's memory fallback, and it is the correct kind, because the memory copy
+upholds `set()`'s postcondition where nulling memory could not uphold `clear()`'s.

--- a/packages/auth/src/ActiveOrganizationStorage.ts
+++ b/packages/auth/src/ActiveOrganizationStorage.ts
@@ -145,12 +145,36 @@ function writePersisted(key: string, value: string): void {
   }
 }
 
-function removePersisted(key: string): void {
+/**
+ * Remove `key`, and report whether it is gone — `true` when a read-back can no
+ * longer produce a value for it.
+ *
+ * ## Why the verdict is a READ-BACK and not "did `removeItem` throw"
+ * (objectui#5731)
+ *
+ * `get()` can only answer with what `getItem` hands back, so "did this removal
+ * stick" is exactly the question "is the key still readable". Deciding it from
+ * the throw instead would be both too narrow and too wide:
+ *
+ *  - TOO NARROW. A wrapped or proxied `localStorage` — an extension, a
+ *    polyfill — whose `removeItem` is a silent no-op never throws, and leaves
+ *    exactly the residue this guards against. objectui#5731 named the throwing
+ *    variant; the no-op variant is the same defect, and a read-back catches
+ *    both without having to enumerate them.
+ *  - TOO WIDE. In SSR, and in a partitioned iframe where every operation
+ *    throws, there is nothing readable to resurrect and the paths are already
+ *    safe. A throw-based verdict would report those two states as failures,
+ *    which is how a report earns a reputation for crying wolf.
+ *
+ * The throw is therefore still swallowed here: it is not the verdict.
+ */
+function removePersisted(key: string): boolean {
   try {
     safeStore('local')?.removeItem(key);
   } catch {
-    /* storage unavailable */
+    /* not the verdict — the read-back below is */
   }
+  return readPersisted(key) === null;
 }
 
 /**
@@ -305,6 +329,17 @@ export const ActiveOrganizationStorage = {
   _memoryValue: null as string | null,
 
   /**
+   * Keys whose removal by {@link clear} did not stick — the value was still
+   * readable afterwards (objectui#5731).
+   *
+   * {@link get} refuses to answer from the persisted layer for a key in here,
+   * which is the mechanism that keeps a cleared organization cleared. Held in
+   * memory, so it lasts exactly one page-load: a browser that starts fresh
+   * re-measures rather than inheriting a verdict.
+   */
+  _unremovedKeys: new Set<string>(),
+
+  /**
    * The active org id for the CURRENT user, or `null`.
    *
    * READ ORDER — a non-null `localStorage` read wins; anything else falls
@@ -336,7 +371,18 @@ export const ActiveOrganizationStorage = {
    */
   get(): string | null {
     const key = scopedActiveOrgKey();
-    if (key) {
+    // A key {@link clear} could not remove is QUARANTINED for the rest of this
+    // page-load, and skipping the persisted branch is what stops the cleared
+    // org from being handed straight back (objectui#5731). `_memoryValue` then
+    // answers, and for that key it is the only copy this page-load can trust:
+    // `clear()` nulled it, and a later `set()` refills it with the value that
+    // write was meant to persist — so this stays correct in both directions
+    // with no release step of its own. What it gives up is cross-tab freshness
+    // for one key, in a browser that has just demonstrated it cannot delete
+    // from storage. An unstamped `X-Tenant-ID` is a documented state of the
+    // edge contract (see `createAuthenticatedFetch`); a re-stamped signed-out
+    // org is not.
+    if (key && !this._unremovedKeys.has(key)) {
       try {
         const persisted = safeStore('local')?.getItem(key) ?? null;
         if (persisted !== null) return persisted;
@@ -357,6 +403,43 @@ export const ActiveOrganizationStorage = {
     writePersisted(key, orgId);
   },
 
+  /**
+   * Drop the active organization, from memory and from the persisted key.
+   *
+   * POSTCONDITION: {@link get} answers `null` afterwards. Sign-out is one of
+   * the callers, so that is a security-relevant guarantee rather than a
+   * convenience — and before objectui#5731 it was not one, because a
+   * `removeItem` that failed was swallowed and the surviving key won `get()`'s
+   * read order.
+   *
+   * ## Why a failed removal is neither thrown nor returned (objectui#5731)
+   *
+   * Every caller arrives here AFTER the transition it is following up on has
+   * already happened, and not one of them can act on a storage failure:
+   *
+   *  - `AuthProvider`'s `purgeSignedOutClientCaches` — the session is already
+   *    ended. Sign-out cannot be refused because a key would not delete.
+   *  - `switchOrganization` — the server already switched or cleared the
+   *    active org; a throw would report a successful switch as a failure and
+   *    route the caller into its error branch.
+   *  - `deleteOrganization` / `leaveOrganization` — the org is already deleted
+   *    or already left.
+   *  - {@link purgePreviousUserClientState}, via {@link SessionUserScope.adopt}
+   *    — runs on the SIGN-IN path inside an `AuthProvider` effect, where a
+   *    throw breaks the boot of the ARRIVING user.
+   *
+   * A `boolean` return only moves the problem one step: all five call sites
+   * would have nothing to write in the failure branch, and a return value that
+   * every caller ignores reads as handled when it is not. So the invariant is
+   * restored HERE, where it can be, and the failure is reported to the console,
+   * where a human can find it.
+   *
+   * The third shape considered and rejected was re-writing the key with an
+   * empty value. That relocates the fix into every consumer's truthiness test
+   * (`createAuthenticatedFetch` does `if (activeOrgId)`), which is the lenient
+   * consumer AGENTS.md #0.1 forbids, and it leaves a signed-out browser holding
+   * a live key.
+   */
   clear(): void {
     // Nulling the fallback is SECURITY-RELEVANT, not bookkeeping: `get()`
     // falls through to `_memoryValue` whenever the `localStorage` read comes
@@ -366,9 +449,36 @@ export const ActiveOrganizationStorage = {
     // `X-Tenant-ID`. Pinned by `__tests__/activeOrgStorageFallback-5703.test.tsx`.
     this._memoryValue = null;
     const key = scopedActiveOrgKey();
-    if (key) removePersisted(key);
+    if (key) {
+      if (removePersisted(key)) {
+        // Confirmed gone. Recomputed on every call rather than left alone, so
+        // a key quarantined by an earlier failure is RELEASED the moment a
+        // removal sticks: the quarantine describes the last attempt, not a
+        // permanent verdict on the browser.
+        this._unremovedKeys.delete(key);
+      } else {
+        // The removal did not stick and the value is still readable, so
+        // `get()` would hand the signed-out org straight back. Two things
+        // happen here and they are deliberately separable: the stale read is
+        // SUPPRESSED, which restores the postcondition without any caller's
+        // help, and the failure is REPORTED, because "sign-out did not fully
+        // stick" is something whoever is reading a console has to be able to
+        // find. Neither half substitutes for the other — a report alone leaves
+        // the org on the wire, and suppression alone is the same silence this
+        // card was filed about, just with a better outcome.
+        this._unremovedKeys.add(key);
+        console.warn(
+          `[ActiveOrganizationStorage] clear() could not remove "${key}" from localStorage — ` +
+            'it is still readable. Reads for it are answered from memory for the rest of this ' +
+            'page-load, so the cleared organization is not re-stamped as X-Tenant-ID.',
+        );
+      }
+    }
     // Also drop the pre-#5664 bare key, so a `clear()` on a browser upgrading
     // from an older build leaves nothing behind under the retired spelling.
+    // Its verdict is deliberately ignored: `scopedActiveOrgKey()` never returns
+    // the bare spelling, so nothing reads it and a survival here cannot
+    // resurrect an org through `get()`.
     removePersisted(LEGACY_ACTIVE_ORG_KEY);
   },
 };

--- a/packages/auth/src/__tests__/activeOrgClearRemovalFailure-5731.test.tsx
+++ b/packages/auth/src/__tests__/activeOrgClearRemovalFailure-5731.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * objectui#5731 — `ActiveOrganizationStorage.clear()` must not swallow a failed
+ * removal, because `get()` would then hand the cleared organization back.
+ *
+ * ## The asymmetry, re-derived on the post-#5664 code
+ *
+ * `clear()` nulls `_memoryValue` and then removes the persisted key. `get()`
+ * prefers a NON-NULL persisted read and only falls through to `_memoryValue`
+ * (the objectui#5703 read order). So the two halves of `clear()` are not
+ * equally strong: nulling memory is unconditional and always sticks, while the
+ * removal was best-effort and its failure was swallowed. A removal that does
+ * not stick leaves the key readable, the read order prefers it, and sign-out —
+ * one of `clear()`'s five callers — silently does not stick. The org goes back
+ * on the wire as `X-Tenant-ID`.
+ *
+ * ## Why there is no browser repro here, on purpose
+ *
+ * The filer refused to claim a defect they had not reproduced, and triage
+ * graded the card anyway with the reason recorded: *"Acceptance must NOT
+ * require reproducing a browser state ... the deliverable is that the failure
+ * stops being silent, plus a unit-level pin that a throwing `localStorage` no
+ * longer leaves `get()` returning the cleared org."* A `localStorage` double is
+ * the instrument, and it is the RIGHT instrument: the invariant under test is a
+ * property of this module, not of any particular browser's storage quirk.
+ *
+ * Two shapes of failing removal are driven, because the fix verifies by
+ * READ-BACK rather than by catching the throw and therefore covers both:
+ *
+ *  - `removeItem` THROWS — the shape the card describes.
+ *  - `removeItem` is a SILENT NO-OP — a wrapped or proxied `localStorage`, the
+ *    only candidate the filer could name. It never throws, so a throw-based
+ *    guard would miss it entirely while leaving identical residue.
+ *
+ * ## What must NOT be weakened
+ *
+ * `activeOrgStorageFallback-5703.test.tsx` pins that `clear()` nulls
+ * `_memoryValue` BEFORE touching storage and that a non-null persisted read
+ * wins; `sessionUserChangePurge-5664.test.tsx` pins the session-user purge.
+ * Suppression here is scoped to a key whose removal was MEASURED to have
+ * failed, so neither of those properties moves: on every store that can
+ * actually delete, the persisted read is still preferred and still authoritative.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createAuthenticatedFetch } from '../createAuthenticatedFetch';
+import { ActiveOrganizationStorage, SessionUserScope } from '../ActiveOrganizationStorage';
+import { TokenStorage } from '../createAuthClient';
+
+const SESSION_USER_ID = 'u_5731';
+const SCOPED_ORG_KEY = `auth-active-organization-id:u:${SESSION_USER_ID}`;
+const API_URL = 'http://localhost/api/v1/meta/object/account';
+
+/**
+ * A `localStorage` double whose `removeItem` fails in a chosen way, keeping the
+ * backing Map visible so a case can assert what actually survived.
+ *
+ * `removal: 'throws'` is the card's shape; `'noop'` is the wrapped-storage
+ * shape. `'works'` is the control — the same double with a removal that sticks,
+ * so a green case cannot be explained by "the double is broken".
+ */
+function installLocalStorage(removal: 'works' | 'throws' | 'noop' = 'works') {
+  const store = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => {
+      if (removal === 'throws') throw new Error('SecurityError: removeItem is not allowed');
+      if (removal === 'noop') return;
+      store.delete(k);
+    },
+  });
+  return store;
+}
+
+/** Stub the global fetch and capture the Headers it was called with. */
+function stubFetch() {
+  const calls: Array<{ url: string; headers: Headers }> = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+    calls.push({ url, headers: new Headers(init?.headers) });
+    return new Response('{}', { status: 200 });
+  }));
+  return calls;
+}
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // Resolve the scope from the in-memory pointer, so it survives every double
+  // the cases install below. Without a session user `set()` writes to memory
+  // only and every "reached the persisted layer" assertion would be vacuous.
+  SessionUserScope._resetForTests();
+  SessionUserScope.adopt(SESSION_USER_ID);
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(TokenStorage, 'get').mockReturnValue(null);
+});
+
+afterEach(() => {
+  // Order matters: unstub FIRST so this `clear()` runs against a working store
+  // and releases any quarantine the case left on the scoped key, and reset the
+  // scope LAST so that `clear()` still resolves the same key.
+  vi.unstubAllGlobals();
+  ActiveOrganizationStorage.clear();
+  vi.restoreAllMocks();
+  SessionUserScope._resetForTests();
+});
+
+// ---------------------------------------------------------------------------
+// (a) the pin triage asked for: an outcome, not a "did it warn"
+// ---------------------------------------------------------------------------
+
+describe('a clear() whose removal fails no longer leaves the org readable (#5731)', () => {
+  it('answers null after clear(), when removeItem THROWS', () => {
+    const persisted = installLocalStorage('throws');
+    ActiveOrganizationStorage.set('org-42');
+    // Preconditions, asserted rather than assumed: the value really reached
+    // the persisted layer, and `get()` really was answering from it.
+    expect(persisted.get(SCOPED_ORG_KEY)).toBe('org-42');
+    expect(ActiveOrganizationStorage.get()).toBe('org-42');
+
+    ActiveOrganizationStorage.clear();
+
+    // The premise of the case: the removal did NOT stick. Without this the
+    // case would pass against a store that quietly deleted the key, and would
+    // be testing nothing.
+    expect(persisted.get(SCOPED_ORG_KEY)).toBe('org-42');
+    expect(localStorage.getItem(SCOPED_ORG_KEY)).toBe('org-42');
+
+    // THE PIN. Measured as 'org-42' before the fix.
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  it('answers null after clear(), when removeItem is a SILENT NO-OP', () => {
+    // The wrapped/proxied `localStorage` the filer named as the only candidate
+    // they could point at. It never throws, so a fix that only caught the
+    // throw would leave this one exactly as broken as before.
+    const persisted = installLocalStorage('noop');
+    ActiveOrganizationStorage.set('org-42');
+    expect(ActiveOrganizationStorage.get()).toBe('org-42');
+
+    ActiveOrganizationStorage.clear();
+
+    expect(persisted.get(SCOPED_ORG_KEY)).toBe('org-42');
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+
+  it('sends NO tenant header after a clear() whose removal failed', async () => {
+    // The same statement one level out, where the consequence actually lands:
+    // the header must be ABSENT, per the `X-Tenant-ID` edge contract this
+    // package's README documents (objectui#5279).
+    installLocalStorage('throws');
+    ActiveOrganizationStorage.set('org-42');
+    ActiveOrganizationStorage.clear();
+
+    const calls = stubFetch();
+    await createAuthenticatedFetch()(API_URL);
+
+    expect(calls[0].headers.has('X-Tenant-ID')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) the mechanism, pinned directly — the effect is one line from accidental
+// ---------------------------------------------------------------------------
+
+describe('the suppression mechanism, not just its effect (#5731)', () => {
+  it('quarantines the key whose removal could not be verified', () => {
+    installLocalStorage('throws');
+    ActiveOrganizationStorage.set('org-42');
+    expect(ActiveOrganizationStorage._unremovedKeys.has(SCOPED_ORG_KEY)).toBe(false);
+
+    ActiveOrganizationStorage.clear();
+
+    // `get()` returning null is achievable by accident — by never reading
+    // storage, by returning null unconditionally. This asserts WHICH mechanism
+    // produced it, so a later refactor that keeps the outcome by some other
+    // means has to say so here.
+    expect(ActiveOrganizationStorage._unremovedKeys.has(SCOPED_ORG_KEY)).toBe(true);
+  });
+
+  it('RELEASES the quarantine as soon as a removal sticks', () => {
+    // The quarantine describes the last attempt, not a permanent verdict on
+    // the browser: a store that recovers gets its persisted read back.
+    installLocalStorage('throws');
+    ActiveOrganizationStorage.set('org-42');
+    ActiveOrganizationStorage.clear();
+    expect(ActiveOrganizationStorage._unremovedKeys.has(SCOPED_ORG_KEY)).toBe(true);
+
+    vi.unstubAllGlobals();
+    const persisted = installLocalStorage('works');
+    ActiveOrganizationStorage.clear();
+
+    expect(ActiveOrganizationStorage._unremovedKeys.has(SCOPED_ORG_KEY)).toBe(false);
+    // ... and the persisted layer is authoritative again for that key.
+    persisted.set(SCOPED_ORG_KEY, 'org-fresh');
+    expect(ActiveOrganizationStorage.get()).toBe('org-fresh');
+  });
+
+  it('does not go blind: a set() after a failed clear() is readable again', () => {
+    // The case that dies if "suppress the stale read" is ever implemented as
+    // "answer null forever". A quarantined key is answered from `_memoryValue`,
+    // which is the copy this page-load can trust — so the NEW value comes back
+    // whether or not the write reached a store that cannot delete.
+    installLocalStorage('throws');
+    ActiveOrganizationStorage.set('org-42');
+    ActiveOrganizationStorage.clear();
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+
+    ActiveOrganizationStorage.set('org-99');
+
+    expect(ActiveOrganizationStorage.get()).toBe('org-99');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) the failure stops being SILENT — the other half of the deliverable
+// ---------------------------------------------------------------------------
+
+describe('a failed clear() is reported (#5731)', () => {
+  it('warns once, naming the key it could not remove', () => {
+    installLocalStorage('throws');
+    ActiveOrganizationStorage.set('org-42');
+
+    ActiveOrganizationStorage.clear();
+
+    // Exactly once: `clear()` also removes the retired bare key, whose removal
+    // fails on this same double. That one is deliberately NOT reported —
+    // `scopedActiveOrgKey()` never returns the bare spelling, so nothing reads
+    // it and its survival cannot resurrect an org through `get()`. A report per
+    // failed removeItem would be two lines of noise for one real failure.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain(SCOPED_ORG_KEY);
+  });
+
+  it('stays quiet when the removal sticks', () => {
+    const persisted = installLocalStorage('works');
+    ActiveOrganizationStorage.set('org-42');
+
+    ActiveOrganizationStorage.clear();
+
+    expect(persisted.has(SCOPED_ORG_KEY)).toBe(false);
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when there is no storage at all', () => {
+    // SSR, and the partitioned-iframe browser where every operation throws.
+    // Nothing is readable in either, so nothing can be resurrected and both
+    // were already safe. A report that fired here would be crying wolf on the
+    // two states the card explicitly ruled OUT as the defect.
+    vi.stubGlobal('localStorage', undefined);
+
+    expect(() => ActiveOrganizationStorage.clear()).not.toThrow();
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(ActiveOrganizationStorage._unremovedKeys.has(SCOPED_ORG_KEY)).toBe(false);
+    expect(ActiveOrganizationStorage.get()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) the neighbouring swallow that is DELIBERATE and must survive
+// ---------------------------------------------------------------------------
+
+describe('set()’s swallowed write failure is left alone (#5703 design)', () => {
+  it('still keeps the value in memory when localStorage rejects writes', () => {
+    // `set()` swallows a failing `setItem` too, and that one is correct: the
+    // memory copy upholds the postcondition ("what was set reads back"), and
+    // `get()`'s fallback is built to consult it. `clear()`'s swallow was the
+    // accidental one because nulling memory does NOT uphold ITS postcondition
+    // — the surviving persisted value SHADOWS it. That is the test for telling
+    // the two apart, and this case pins that the deliberate one is untouched.
+    const store = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: () => { throw new Error('QuotaExceededError'); },
+      removeItem: (k: string) => { store.delete(k); },
+    });
+
+    ActiveOrganizationStorage.set('org-42');
+
+    expect(store.has(SCOPED_ORG_KEY)).toBe(false);
+    expect(ActiveOrganizationStorage.get()).toBe('org-42');
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #5731

## The file the card names is not the file the code is in

Both the card and its triage line say `packages/auth/src/createAuthenticatedFetch.ts`. That was true when they were written. #5664 / PR #5744 moved `ActiveOrganizationStorage` into its own module at 03:56Z the same day; `createAuthenticatedFetch.ts` now only re-exports it, and that re-export is untouched here. The asymmetry was **re-derived on the post-#5664 code** rather than taken from the card's quote, and it survives the move intact.

## The asymmetry, on `origin/main` at 9850c6e4e

```ts
clear(): void {
  this._memoryValue = null;               // unconditional — always sticks
  const key = scopedActiveOrgKey();
  if (key) removePersisted(key);          // best-effort — failure swallowed
  removePersisted(LEGACY_ACTIVE_ORG_KEY);
}
```

`get()` prefers a **non-null** persisted read and only falls through to `_memoryValue` (the #5703 read order). So `clear()`'s two halves are not equally strong: nulling memory always sticks, while a removal that does not stick leaves the key readable — and the read order prefers it. The memory null is **shadowed** by the surviving persisted value. Sign-out is one of five callers, so the failure mode is "sign-out does not stick", silently, with the cleared org back on the wire as `X-Tenant-ID`.

## Distinguishing the accidental swallow from the deliberate one

`set()`/`writePersisted` swallows a failing `setItem` one function away. That is #5703's memory-fallback design and it is **not** touched here. The test that tells them apart is not "which one catches" but **does the swallow leave a path that still upholds the method's postcondition**:

| | postcondition | on failure | verdict |
|---|---|---|---|
| `set()` | `get()` reads back what was set | `_memoryValue` holds it, and `get()`'s fallback is built to consult it | upheld — deliberate |
| `clear()` | `get()` answers `null` | `_memoryValue` is null but the surviving persisted value **outranks** it | not upheld — accidental |

A case in the new file pins that the deliberate one still behaves as #5703 designed it.

## What changed

**1. The verdict is a read-back, not a caught throw.** `removePersisted` now returns whether the key is still readable. `get()` can only answer with what `getItem` hands back, so "did this removal stick" *is* "is the key still readable". Deciding it from the throw would be wrong in both directions:

- **too narrow** — a wrapped or proxied `localStorage` whose `removeItem` is a silent **no-op** never throws and leaves identical residue. That was the only candidate the filer could name, and it is now covered; a throw-based guard would have missed it entirely.
- **too wide** — SSR, and the partitioned-iframe browser where every operation throws, have nothing readable to resurrect. The card explicitly ruled both out as the defect. Reporting them as failures is how a report earns a reputation for crying wolf.

**2. The invariant is restored inside `clear()`.** A key whose removal cannot be verified is quarantined in memory for the rest of the page-load; `get()` skips the persisted branch for it and answers from `_memoryValue` — which `clear()` just nulled, and which a later `set()` refills with the value that write was meant to persist. Correct in both directions with no release step of its own. The quarantine *is* released as soon as a removal on that key sticks, so it describes the last attempt rather than a permanent verdict on the browser. What it gives up is cross-tab freshness for one key in a browser that has just proved it cannot delete from storage: an unstamped `X-Tenant-ID` is a documented state of the edge contract (#5279), a re-stamped signed-out org is not.

**3. The failure is reported, not thrown and not returned.** `clear()`'s callers were enumerated first, and the shape follows from what they can do:

| caller | state when it calls | can it act on a failure? |
|---|---|---|
| `purgeSignedOutClientCaches` (sign-out) | session already ended | no — sign-out cannot be refused |
| `switchOrganization` | server already switched/cleared | no — a throw reports a successful switch as failed |
| `deleteOrganization` / `leaveOrganization` | org already deleted / left | no |
| `purgePreviousUserClientState` via `SessionUserScope.adopt` | **sign-in** path, inside an effect | no — a throw breaks the arriving user's boot |

Not one of them can act on it, so a `boolean` return only moves the problem: five call sites with nothing to write in the failure branch, and a return value every caller ignores reads as *handled* when it is not. `console.warn` is the channel this package already uses for intentional diagnostics (`[AuthProvider] Failed to load organizations:`) and eslint's `no-console` allows it.

**Rejected third shape:** re-writing the key with an empty value. It relocates the fix into every consumer's truthiness test (`createAuthenticatedFetch` does `if (activeOrgId)`) — the lenient consumer AGENTS.md #0.1 forbids — and leaves a signed-out browser holding a live key.

## Tests

`packages/auth/src/__tests__/activeOrgClearRemovalFailure-5731.test.tsx`, 10 cases. Per triage, **no browser state is reproduced**: a `localStorage` double is the instrument, and the headline assertions are **outcomes** (`get()` is null; the header is absent from the wire), not "did it warn".

Both failing-removal shapes are driven — `removeItem` **throws** and `removeItem` is a **silent no-op** — and each case asserts its own premise (the value really reached the persisted layer; the removal really did not stick), so a green case cannot be explained by a double that quietly deleted the key.

Controls, without which the pins would pass on an implementation that always returns null: a working store where the removal sticks and the key is gone; a `set()` after a failed `clear()` that must be readable again; and the release-on-recovery case.

## Ablation

Committed first, mutated, confirmed on disk by single-line anchored counts **in both directions**, restored under `trap ... EXIT INT TERM`, restored tree re-run green.

| leg | mutation | anchored counts (baseline → mutated → restored) | result |
|---|---|---|---|
| A | delete the `get()` quarantine guard | `_unremovedKeys.has(key)` 1 → **0** → 1 | **4 failed / 6 passed** |
| B | `removePersisted` stops verifying (`return true`) | `readPersisted(key) === null` 1 → **0** → 1; bare `return true;` 0 → **1** → 0 | **7 failed / 3 passed** |
| — | restored tree | counts back to baseline, `git status` clean | **10 passed** |

The two legs separate the mechanism from its input, which is why both are pinned. Under **A** the three outcome pins die while the mechanism pins **survive** — `clear()` still populates the quarantine correctly, and the bookkeeping alone does nothing; the `get()` guard is what turns it into the outcome. Under **B** the mechanism pins die too, because verification is upstream of everything.

**Three cases survive both legs, and that is the point of them:** "stays quiet when the removal sticks", "stays quiet when there is no storage at all", and the `set()`-swallow case. They assert behaviour on stores where nothing fails and on the swallow this card deliberately leaves alone. Had any of them died, the change would have been over-reaching — reporting on a healthy store, crying wolf on SSR, or breaking #5703's memory fallback. Their survival is the evidence that the change is scoped to *measured* failures.

## Verification — union run at `0610ca74b` (final commit, clean tree)

| check | result |
|---|---|
| `vitest run packages/auth/` | exit 0 — **24 files, 246 tests passed** |
| `vitest run` app-shell `MetadataProvider.{firstBootOrgScope,orgScopedCache,crossPrincipalSeed}` | exit 0 — 3 files, 13 tests passed |
| `pnpm --filter @object-ui/auth type-check` | exit 0 (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/auth lint` | exit 0 — `✖ 29 problems (0 errors, 29 warnings)`, all pre-existing and none in the changed files |
| `check-control-bytes` | exit 0 — `OK (scanned 4805 tracked text file(s))` |
| `check-changeset-presence` | exit 0 — `2 source file(s) of 1 released package(s) changed ... declares 1 changeset(s)` |
| `check-changeset-no-major` · `check-changeset-fixed` | exit 0 |
| `check-lint-coverage` · `check-type-check-coverage` | exit 0 — `46/46 packages linted`; `41/41 packages compile their tests` |
| `check-package-self-import` · `check-phantom-dependencies` | exit 0 |

Both load-bearing pins in the blast radius are green and unmodified: `activeOrgStorageFallback-5703.test.tsx` (9 cases) and `sessionUserChangePurge-5664.test.tsx` (12 cases).

**Narrowed lint, declared.** `pnpm lint` is `turbo run lint` (per-package `eslint .`); the run above is the whole `@object-ui/auth` package — a superset of the diff — measured at **46 files** from `--format json`, with the population decided by eslint's own config rather than by a guess. The invariance that makes the narrowing a measurement: `eslint.config.js` extends `tseslint.configs.recommended`, **not** the type-checked preset, and carries no `projectService` / `parserOptions` / `project:` (each grepped with the exit code captured before any pipe: `grep_exit=1`, 0 hits, against control terms in the same file that hit — `languageOptions` 1, `rules` 10, `files:` 6). With no type-aware linting, a diff confined to `packages/auth` cannot move the verdict on any untouched file. The rest of the farm is CI's run.

`@object-ui/auth` is vitest-aliased to `packages/auth/src`, so every run above — the consumer tests and both ablation legs included — exercises the edited source directly. No `dist/` is in the resolution path, and no stale-artifact false green is possible.

## Out of scope

`createAuthenticatedFetch.ts` is untouched — the re-export still resolves, and no signature moved. One neighbouring finding is filed separately and stays out of this PR: #5763 (open, unassigned) — `sweepStore`'s `try` wraps the whole loop, so one throwing `removeItem` silently cancels the rest of the session-user purge. Same class, different function and different callers, and it needs a partial-failure test of its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_