### PR TITLE
Converge the dev stacks on one origin: empty VITE_SERVER_URL, proxy for the split host

### DIFF
--- a/.changeset/one-origin-dev-configs-5745.md
+++ b/.changeset/one-origin-dev-configs-5745.md
@@ -1,0 +1,36 @@
+---
+---
+
+Dev/build configuration only — this publishes nothing, declared explicitly with an
+empty frontmatter rather than left undeclared. No package `src/` is touched. The
+files changed are `apps/console/.env.development`, `examples/console-starter/.env.*`
+and `examples/console-starter/vite.config.ts`; `.env.development` is not part of
+`@object-ui/console`'s published artifact (`files: ["dist"]`, built from
+`.env.production`, which is untouched), and the example is private and on the
+changeset `ignore` list.
+
+Converge the dev stacks on one origin: empty `VITE_SERVER_URL` and let the Vite
+proxy do the split-host hop.
+
+Both dev env files pointed `VITE_SERVER_URL` at `http://localhost:3000` while the
+page was served from `:5180` (console) and `:5173` (starter). Every client in these
+apps coalesces an unset value to `''` and then builds a relative `/api/...` URL, so
+an empty value routes same-origin through the dev proxy instead. `console-starter`
+had no `server` block at all, so it gets the same one-stanza `/api` proxy
+(`DEV_PROXY_TARGET` or `http://localhost:3000`) that `apps/console` already carries;
+no port is pinned, because its README documents the example on Vite's default 5173.
+
+This is the ruled prerequisite for the `sameOriginOnly` action-runtime default. Under
+that default a non-empty `VITE_SERVER_URL` makes every relative-target `type: 'api'`
+action resolve cross-origin and be fetched bare — no `Authorization`, no
+`X-Tenant-ID`, no `Accept-Language` — i.e. a 401 for the standard `pnpm dev` stack.
+
+`examples/console-starter/.env.production` is emptied too. Its committed
+`https://demo.objectstack.ai` was not a deliberate choice for the example: it is the
+same pre-convergence value the sibling console carried until 2026-05-24, when
+`c351c9604` ("default published SPA to same-origin") cleared it there for CORS-blank
+-page reasons and touched only `apps/console/.env.production`. The starter was left
+behind by that commit, and as a fork-ready scaffold its committed value is the
+production origin every fork inherits. Split-origin deployments inject
+`VITE_SERVER_URL` at build time, the way the console's own `.env.production` already
+documents.

--- a/apps/console/.env.development
+++ b/apps/console/.env.development
@@ -1,5 +1,20 @@
-# Development: connect to a local or remote ObjectStack server.
-# Set VITE_SERVER_URL to your dev server (e.g. http://localhost:3000 or https://demo.objectstack.ai).
-# Leave empty to use same-origin (when Console is served by the server itself).
-VITE_SERVER_URL=http://localhost:3000
+# Development: the Console SPA and the ObjectStack API share ONE origin.
+#
+# Leave VITE_SERVER_URL EMPTY. Every client in this app coalesces an unset
+# value to '' and then builds a RELATIVE `/api/...` URL, which the Vite dev
+# server proxies to the backend (`vite.config.ts` -> server.proxy['/api'],
+# target `DEV_PROXY_TARGET` or http://localhost:3000). So the page at :5180
+# fetches :5180 and the proxy does the split-host hop.
+#
+# Why empty rather than `http://localhost:3000`: a non-empty value makes every
+# relative-target `type: 'api'` action resolve CROSS-origin, and the action
+# runtime does not attach Authorization / X-Tenant-ID / Accept-Language to a
+# cross-origin fetch — a 401 on the standard `pnpm dev` stack. Same-origin is
+# also what `.env.production` already ships, so dev now matches prod.
+#
+# Pointing at a DIFFERENT backend: set DEV_PROXY_TARGET (keeps one origin) —
+#   DEV_PROXY_TARGET=https://demo.objectstack.ai pnpm dev
+# Setting VITE_SERVER_URL to an absolute origin still works, but it opts this
+# app back out of same-origin and into CORS + the 401 above.
+VITE_SERVER_URL=
 VITE_USE_MOCK_SERVER=false

--- a/examples/console-starter/.env.development
+++ b/examples/console-starter/.env.development
@@ -1,5 +1,18 @@
-# Development: connect to a local or remote ObjectStack server.
-# Set VITE_SERVER_URL to your dev server (e.g. http://localhost:3000 or https://demo.objectstack.ai).
-# Leave empty to use same-origin (when Console is served by the server itself).
-VITE_SERVER_URL=http://localhost:3000
+# Development: the starter SPA and the ObjectStack API share ONE origin.
+#
+# Leave VITE_SERVER_URL EMPTY. `src/App.tsx`, `src/main.tsx` and everything
+# inside @object-ui/app-shell coalesce an unset value to '' and then build a
+# RELATIVE `/api/...` URL, which the Vite dev server proxies to the backend
+# (`vite.config.ts` -> server.proxy['/api'], target `DEV_PROXY_TARGET` or
+# http://localhost:3000). So the page at :5173 fetches :5173 and the proxy
+# does the split-host hop.
+#
+# Why empty rather than `http://localhost:3000`: a non-empty value makes every
+# relative-target `type: 'api'` action resolve CROSS-origin, and the action
+# runtime does not attach Authorization / X-Tenant-ID / Accept-Language to a
+# cross-origin fetch — a 401 on the standard `pnpm dev` stack.
+#
+# Pointing at a DIFFERENT backend: set DEV_PROXY_TARGET (keeps one origin) —
+#   DEV_PROXY_TARGET=https://demo.objectstack.ai pnpm dev
+VITE_SERVER_URL=
 VITE_USE_MOCK_SERVER=false

--- a/examples/console-starter/.env.production
+++ b/examples/console-starter/.env.production
@@ -1,4 +1,18 @@
 # Production: connect to the ObjectStack server.
-# Set VITE_SERVER_URL to the server origin, or leave empty for same-origin.
-VITE_SERVER_URL=https://demo.objectstack.ai
+#
+# Defaults to same-origin (empty), matching `apps/console/.env.production`.
+# This is a FORK-READY SCAFFOLD: whatever is committed here is the production
+# origin every fork inherits, so it must not name one specific deployment.
+# A committed `https://demo.objectstack.ai` was cleared from the sibling
+# console for exactly that reason — it CORS-blocked the auth / i18n /
+# discovery calls and left a blank page on every host but the demo one.
+#
+# Deployments that genuinely need a split origin inject VITE_SERVER_URL from
+# their own deploy environment at build time, rather than committing it:
+#
+#   VITE_SERVER_URL=https://your-objectstack-host pnpm build
+#
+# A split origin also requires the backend to allow CORS from the SPA origin
+# and to issue auth cookies as `SameSite=None; Secure`.
+VITE_SERVER_URL=
 VITE_USE_MOCK_SERVER=false

--- a/examples/console-starter/vite.config.ts
+++ b/examples/console-starter/vite.config.ts
@@ -60,4 +60,24 @@ const workspaceAliases: Record<string, string> = {
 export default defineConfig({
   plugins: [react()],
   resolve: { alias: workspaceAliases },
+  // ONE ORIGIN in dev, proxy for the split host. `.env.development` leaves
+  // VITE_SERVER_URL empty, so every client here builds a RELATIVE `/api/...`
+  // URL and this stanza forwards it to the backend. Without it an empty
+  // VITE_SERVER_URL would make those fetches hit the Vite dev server, which
+  // has no `/api` route and answers with the SPA's index.html fallback.
+  //
+  // Why not just point VITE_SERVER_URL at the backend: a cross-origin value
+  // makes every relative-target `type: 'api'` action resolve off-origin, and
+  // the action runtime does not attach Authorization / X-Tenant-ID /
+  // Accept-Language across origins — a 401 on the standard `pnpm dev` stack.
+  //
+  // `DEV_PROXY_TARGET` and the `/api` prefix mirror `apps/console/vite.config.ts`
+  // deliberately: the two dev stacks are meant to be configured the same way.
+  // No `port` is set — the README documents this example on Vite's default
+  // 5173, and pinning one would only collide with a real fork's choice.
+  server: {
+    proxy: {
+      '/api': { target: process.env.DEV_PROXY_TARGET || 'http://localhost:3000', changeOrigin: true },
+    },
+  },
 });


### PR DESCRIPTION
Fixes #5745

The ruled prerequisite for #5702. Landing this alone is harmless; landing #5702 without it breaks the standard `pnpm dev` stack.

## What changed

| file | before | after |
| --- | --- | --- |
| `apps/console/.env.development` | `VITE_SERVER_URL=http://localhost:3000` | empty |
| `examples/console-starter/.env.development` | `VITE_SERVER_URL=http://localhost:3000` | empty |
| `examples/console-starter/.env.production` | `VITE_SERVER_URL=https://demo.objectstack.ai` | empty |
| `examples/console-starter/vite.config.ts` | no `server` block at all | one `/api` proxy stanza, no port pinned |

`apps/console/.env.production` and `apps/console/vite.config.ts` are untouched.

## The enumeration (this was the substance, not the three-line edit)

Full-repo scan, no `node_modules` present at scan time: **114 mentions of `VITE_SERVER_URL`**, of which **~50 are executable read sites**. Every one was traced to the path it actually builds — through prop-passing consumers (`FlowRunner`, `createConsoleServerActionHandler`, `createObjectStackUploadAdapter`, `useEnvironmentEntitlements`, `createIdentityImportDataSource`, `MetadataClient`, `ObjectStackAdapter`) and into `@objectstack/client@17.1.0`'s own route table.

**Class 1 — statically under `/api` (the overwhelming majority).** Every `fetch`-building site: `/api/v1/...`, `/api/data/...`, `/api/settings`. The existing `/api` proxy covers all of them, because a Vite proxy key matches by prefix.

**Class 2 — suffix supplied by metadata or by server data.** `${baseUrl}${resolvedTarget}` (`useConsoleActionRuntime.tsx:346`, `RecordDetailView.tsx:640`), `${apiBase}${resolved}` (`MetadataTypeActions.tsx:151`), storage download URLs (`RecordApprovalsPanel.tsx:312`, `ApprovalsInboxPage.tsx:723`, `RecordAttachmentsPanel.tsx:363`), `${apiBase}${url}` / `${apiBase}${warmUrl}` (`CloudAiModelStatus.tsx:99`, `CloudOnboardingNext.tsx:125`). Not statically bounded — this is exactly the class #5702 exists for. Every first-party default in it is `/api/...`.

**Class 3 — server-supplied route table.** `@objectstack/client`'s `getRoute()` prefers `discoveryInfo.routes[key]` over its built-in map. That built-in map is 100% `/api/v1/*` and its own comment says both discovery producers emit the conventional paths — but a server *could* advertise a route outside `/api`, and the proxy would not cover it. Named, not solved.

## The counterexamples — reported, not worked around

The card's premise was that convergence is clean. It is, for every `fetch`. It is **not** universally clean, and both exceptions are **navigations**, not fetches:

1. **`packages/core/src/actions/ActionRunner.ts:1343`** promotes `/api/`, **`/_auth/`** and **`/_account/`** to `${apiBase}${url}` and then does a full-page `window.location.href`. `/_auth/` and `/_account/` are not under `/api` and are covered by neither proxy. Reachability measured: 7 repo-wide hits, all CHANGELOG / test / doc prose — **no first-party producer of such an action target exists**. `/_account/*` is a sibling *SPA mount* (`apps/console/src/utils/consoleBase.ts:37`), and `apps/console/src/App.tsx:7` records that it is being retired into the console SPA itself, so a same-origin `/_account/...` landing on the console is arguably the intended end state.

2. **`packages/app-shell/src/environment/entitlements.ts:48`** — `DEFAULT_UPGRADE_URL = '/settings/billing'`, rendered by `resolveCtaHref` as `${apiBase}/settings/billing`. Non-`/api`, and an anchor `href` that no proxy could help. Emptying **improves** this site: today it opens `http://localhost:3000/settings/billing` in a new tab (`external: Boolean(base)`); empty makes it a same-origin in-app route — which is already the shipped production behaviour, since `apps/console/.env.production` has been empty since 2026-05-24.

**I did not widen `apps/console/vite.config.ts`** (read-only under this card's fence). Reason it is not needed: the `/api` proxy already covers every fetch site, and the two non-`/api` paths are navigations with no first-party producer. If the maintainer wants `/_auth` + `/_account` proxied for symmetry, that is a one-stanza follow-up — flagged rather than taken.

## `.env.production` — established, not guessed

The ruling said *revisit*, not change. What was established:

- `examples/console-starter` is `private: true`, on the changeset `ignore` list, and **referenced by no workflow, no vercel config, no deploy** (controlled grep: `apps/console` hits 3+ workflows, `console-starter` hits none).
- Git history (clone deepened from 70 to 4598 commits to make this a measurement rather than a boundary artifact): `apps/console/.env.production` carried the identical `https://demo.objectstack.ai` until **`c351c9604`, 2026-05-24, "fix(console): default published SPA to same-origin (clear VITE_SERVER_URL)"** — whose changeset reads *"CORS-blocked auth/i18n/discovery calls were preventing the SPA from rendering when embedded in any host other than the demo deployment."* That commit touched **only** `apps/console/.env.production` plus its changeset. The starter was left behind by it.
- `10d2a5119` (the starter's apparent origin commit) is a pure rename with 0-byte diffs, so the value predates it as a shared sibling default.

Conclusion: **not deliberate — it is the pre-convergence value that the 2026-05-24 same-origin fix did not reach.** As a fork-ready scaffold its committed value is the production origin every fork inherits.

## Port

`console-starter` stays on Vite's default 5173, deliberately: its README already documents `pnpm dev  # Vite; no server.port is set, so the default 5173`, and pinning one would only collide with a real fork's choice. `apps/console` keeps 5180.

## Evidence

Union re-run at final commit **`645b024cb`**, tree clean.

**Measured before/after of a relative action target**, computed off the real env files (before read from git at the merge-base, after from the working tree) using the resolution rule copied verbatim from `useConsoleActionRuntime.tsx:326`+`:346`:

```
=== apps/console  (page origin http://localhost:5180) ===
  action target                : /api/v1/data/lead/query
  BEFORE resolves to           : http://localhost:3000/api/v1/data/lead/query
  BEFORE same-origin as page?  : false
  AFTER  resolves to           : /api/v1/data/lead/query
  AFTER  same-origin as page?  : true
  AFTER  path covered by proxy?: true

=== examples/console-starter  (page origin http://localhost:5173, Vite default) ===
  BEFORE resolves to           : http://localhost:3000/api/v1/data/lead/query   same-origin: false
  AFTER  resolves to           : /api/v1/data/lead/query                        same-origin: true
  AFTER  proxy keys in config  : ["/api"]                                       covered: true
```

**End-to-end, real dev server against a recording stub backend** — the starter's new stanza actually forwards:

```
curl http://localhost:39312/api/v1/data/lead/query   =>  HTTP=200
body:  {"ok":true,"sawPath":"/api/v1/data/lead/query"}
stub:  HITS=[{"method":"GET","url":"/api/v1/data/lead/query","host":"localhost:39311"}]
```

**Ablation** (stanza removed by taking `origin/main`'s config; mutation proved on disk by marker count — `DEV_PROXY_TARGET` 0 occurrences, control `workspaceAliases` still 2; vite reads `vite.config.ts` directly at startup so no build step is involved; restore leg proved by `git status --porcelain` empty). Predicted direction stated before running — hits go to zero while HTTP stays 200:

```
HTTP=200                                 <- unchanged, so status is a FALSE-GREEN signal
body:  an HTML doctype line, i.e. the    <- the SPA index.html fallback, not JSON
       SPA index.html fallback page
stub:  HITS=[]                           <- the discriminating signal
```

That is also the hazard in miniature: without the proxy, an empty `VITE_SERVER_URL` would return HTML with a 200 rather than failing loudly.

**Gates**, exit codes captured before any pipe, each line quoted from the gate's own verdict:

```
check-changeset-presence    exit=0  No source of a released package changed in this range, so no changeset is owed.
check-changeset-no-major    exit=0  No changeset declares a `major` bump.
check-control-bytes         exit=0  OK (scanned 4804 tracked text file(s); skipped 85 binary).
check-doc-links             exit=0  Links are valid across 13 scan roots.
check-lint-coverage         exit=0  lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).
check-type-check-coverage   exit=0  45/46 via `type-check`, 0 known-broken; tests 41/41.
vitest (3 affected files)   exit=0  Test Files 3 passed (3) / Tests 26 passed (26)
```

Tests chosen because they are the ones that actually read the changed files: `committed-telemetry-endpoint.test.ts` (enumerates every committed `.env*` via `git ls-files` and parses it from disk), `vite-alias-closure.test.ts` (reads `console-starter/vite.config.ts`), `runtimeConfigBootDedup.test.ts` (pins the `%VITE_SERVER_URL%` HTML substitution, including the empty case).

**Lint narrowing is a measurement, not a skip:** eslint itself was asked which of the 5 changed files it considers — 4 report as ignored, 1 is linted; `--format json` reports `files linted: 1, errors: 0, warnings: 0`; and `eslint.config.js` declares no `projectService` / `parserOptions.project` (grep exit 1, controlled by `rules` hitting 10x in the same file), so type-aware linting is off and this diff cannot move the verdict on any untouched file. Independently, `check-lint-coverage` reports 46/46 packages clean.

`process.env` in the starter's vite config is safe: `tsc --showConfig` reports its program as 2 files (`src/App.tsx`, `src/main.tsx`) and `includes vite.config.ts: false`, matching the `__dirname` already in that file; eslint does lint it and is clean.

Not run and not claimed: the repo-wide `pnpm lint` / `pnpm test` farms, which CI runs exactly once regardless; and the three gauges known to be broken in a worktree (`check-eager-closure-budget`, `check-doc-snippet-types`, `check-published-dist-tooling`). `Build Docs` should report a ~10s skip, since this diff touches neither `apps/site/` nor `content/` — that skip is not evidence the docs site builds.

## Known gap this PR does not close

Doc drift, outside this card's write fence, filed as #5766 — `examples/console-starter/README.md` still tabulates the two old env values, `apps/console/README.md:36` still says "defaults to `http://localhost:3000`", and `apps/console/README.md:54` claims Vite proxies `/api/*` **and** `/_account/*` when `vite.config.ts:709-711` proxies only `/api` (that last one is pre-existing). Say the word and I will fold the doc half in here.

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_