### PR TITLE
fix(app-shell): action runtime builds sameOriginOnly authenticated fetch

### DIFF
--- a/.changeset/action-runtime-same-origin-only-5702.md
+++ b/.changeset/action-runtime-same-origin-only-5702.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/app-shell': patch
+---
+
+**Behaviour change:** the console action runtime (`useConsoleActionRuntime`) now
+builds its authenticated fetch with `sameOriginOnly: true`, matching the
+`provider: 'api'` data-source lane (`ConsoleShell`). A metadata `type: 'api'`
+action whose resolved target is a different origin than the page is fetched
+through the bare global fetch: the platform Bearer token, `X-Tenant-ID`, and
+`Accept-Language` are no longer attached (objectui#5702, maintainer ruling
+2026-08-22). Previously the Bearer rode to any off-origin target whose URL
+contained `/api/`, and `X-Tenant-ID` rode to every off-origin target
+unconditionally.
+
+Same-origin actions — including every relative target in a same-origin
+deployment — are unchanged, and off-origin requests still execute (pass-through,
+not a refusal). An off-origin integration that legitimately needs the platform
+bearer declares itself explicitly or proxies same-origin.
+
+Note for split-host setups: `apiHandler` prefixes relative action targets with
+`VITE_SERVER_URL`. When that is set to an origin different from the page's,
+those action requests are off-origin and no longer carry credentials. The
+committed dev and starter configurations are unaffected: since objectui#5745
+they ship `VITE_SERVER_URL` empty and reach a split-host backend through the
+Vite `/api` dev proxy, so their action requests are same-origin.

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.sameOriginOnly-5702.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.sameOriginOnly-5702.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * #5702 regression pin — the console action runtime builds its authenticated
+ * fetch with `sameOriginOnly: true` (the #2725 mitigation, ruled onto this
+ * lane: a metadata `type: 'api'` action's `target` is author-supplied and may
+ * name an off-origin host that must never see the platform bearer or the
+ * tenant header).
+ *
+ * The pin is deliberately a PAIR, exercised through `apiHandler` with the
+ * REAL `createAuthenticatedFetch` (not the whole-module auth mock the sibling
+ * test file uses — that mock never sees the option, so it cannot pin this):
+ *
+ *   1. a same-origin action target still carries Authorization AND
+ *      X-Tenant-ID — the ruled change must leave same-origin actions
+ *      untouched;
+ *   2. an absolute off-origin target carries NEITHER — and the request still
+ *      goes out (pass-through to the bare fetch, not a refusal).
+ *
+ * Either half alone proves nothing: the off-origin half is green on a wrapper
+ * that attaches no headers at all, and the same-origin half is green on the
+ * bare wrapper this call site built before #5702.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+
+// PARTIAL auth mock: `useAuth` is stubbed (renderHook mounts no AuthProvider),
+// but `createAuthenticatedFetch`, `TokenStorage` and `ActiveOrganizationStorage`
+// stay real — the point of this file is to observe which headers the wrapper
+// the hook builds actually attaches.
+vi.mock('@object-ui/auth', async (importOriginal) => {
+  const real = await importOriginal<typeof import('@object-ui/auth')>();
+  return {
+    ...real,
+    useAuth: () => ({
+      user: { id: 'u1', name: 'User', image: null },
+      activeOrganization: null,
+    }),
+  };
+});
+
+// Partial as well — the light-dom import graph reaches other @object-ui/i18n
+// exports (e.g. `createSafeTranslation` via @object-ui/components); only the
+// two hooks the runtime reads are stubbed.
+vi.mock('@object-ui/i18n', async (importOriginal) => {
+  const real = await importOriginal<typeof import('@object-ui/i18n')>();
+  return {
+    ...real,
+    useObjectLabel: () => ({
+      fieldLabel: (_o: any, _n: any, l: any) => l,
+      fieldOptionLabel: (_o: any, _f: any, _v: any, l: any) => l,
+      actionParamText: (_o: any, _a: any, _p: any, _attr: any, fallback: any) => fallback,
+      actionParamOptionLabel: (_o: any, _a: any, _p: any, _v: any, fallback: any) => fallback,
+      actionDescription: (_o: any, _a: any, fallback: any) => fallback,
+    }),
+    useObjectTranslation: () => ({
+      t: (key: string, options?: any) => String(options?.defaultValue ?? key),
+    }),
+  };
+});
+
+vi.mock('../useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: vi.fn(async () => ({ success: true })),
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: vi.fn(async () => null),
+  }),
+}));
+
+vi.mock('../../views/ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('../../views/ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('../../views/ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('../../views/FlowRunner', () => ({ FlowRunner: () => null }));
+
+vi.mock('sonner', () => {
+  const fn: any = vi.fn();
+  fn.error = vi.fn();
+  fn.success = vi.fn();
+  return { toast: fn };
+});
+
+import { TokenStorage, ActiveOrganizationStorage } from '@object-ui/auth';
+import { useConsoleActionRuntime } from '../useConsoleActionRuntime';
+
+/** Stub the global fetch and capture each call's URL + resolved Headers. */
+function stubFetch() {
+  const calls: Array<{ url: string; headers: Headers }> = [];
+  const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+    calls.push({ url, headers: new Headers(init?.headers) });
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+  vi.stubGlobal('fetch', mock);
+  return calls;
+}
+
+describe('useConsoleActionRuntime — sameOriginOnly on the action lane (#5702)', () => {
+  beforeEach(() => {
+    ActiveOrganizationStorage.clear();
+    ActiveOrganizationStorage.set('org-5702');
+    vi.spyOn(TokenStorage, 'get').mockReturnValue('tok-5702');
+  });
+
+  afterEach(() => {
+    ActiveOrganizationStorage.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('same-origin action target still carries Authorization and X-Tenant-ID', async () => {
+    const calls = stubFetch();
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [] }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.apiHandler({
+        type: 'api',
+        name: 'sameOriginAction',
+        target: '/api/v1/env-5702',
+        params: { name: 'x' },
+      } as any);
+    });
+
+    expect(res).toMatchObject({ success: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('/api/v1/env-5702');
+    expect(calls[0].headers.get('Authorization')).toBe('Bearer tok-5702');
+    expect(calls[0].headers.get('X-Tenant-ID')).toBe('org-5702');
+  });
+
+  it('absolute off-origin target carries neither header — and the request still goes out', async () => {
+    const calls = stubFetch();
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [] }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.apiHandler({
+        type: 'api',
+        name: 'offOriginAction',
+        target: 'https://third-party.example.com/api/hook',
+        params: { name: 'x' },
+      } as any);
+    });
+
+    // Pass-through, not a refusal: the request executes against the bare fetch.
+    expect(res).toMatchObject({ success: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://third-party.example.com/api/hook');
+    expect(calls[0].headers.get('Authorization')).toBeNull();
+    expect(calls[0].headers.get('X-Tenant-ID')).toBeNull();
+    expect(calls[0].headers.get('Accept-Language')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -305,7 +305,15 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
   }, [navigate]);
 
   // Authenticated fetch for direct backend calls. Declared before apiHandler.
-  const authFetch = useMemo(() => createAuthenticatedFetch(), []);
+  //
+  // `sameOriginOnly` (#2725 mitigation, applied to this lane per the #5702
+  // ruling): an action's `target` comes from author-supplied metadata and may
+  // name an off-origin host. Cross-origin requests pass through to the bare
+  // global fetch — no Authorization, X-Tenant-ID, or Accept-Language — matching
+  // the `provider: 'api'` data-source lane (ConsoleShell). Same-origin actions
+  // are unaffected. An off-origin integration that legitimately needs the
+  // platform bearer declares itself explicitly or proxies same-origin.
+  const authFetch = useMemo(() => createAuthenticatedFetch({ sameOriginOnly: true }), []);
 
   const openEntitlementDialog = useCallback((spec: EntitlementDialogSpec) => {
     setEntitlementDialog({ open: true, spec });
@@ -317,9 +325,12 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
       const params = action.params || {};
 
       // Absolute HTTP target — bypass dataSource and call the API directly
-      // through the authenticated fetch wrapper (Bearer + X-Tenant-ID +
-      // same-origin cookies). The canonical path for schema actions on
-      // managed-by tables and global page actions.
+      // through the authenticated fetch wrapper. Same-origin targets get
+      // Bearer + X-Tenant-ID + same-origin cookies; an off-origin target
+      // (the metadata may name a third-party host) goes out through the bare
+      // global fetch with none of them (`sameOriginOnly`, #5702). The
+      // canonical path for schema actions on managed-by tables and global
+      // page actions.
       const targetStr = typeof target === 'string' ? target : '';
       const isAbsolute = targetStr.startsWith('/') || /^https?:\/\//i.test(targetStr);
       if (isAbsolute) {


### PR DESCRIPTION
Fixes #5702

Maintainer ruling 2026-08-22 (「同意所有」, item 17), re-affirmed 2026-08-23 as **A, sequenced**: `useConsoleActionRuntime` builds `createAuthenticatedFetch({ sameOriginOnly: true })`, matching the `provider: 'api'` data-source lane (`ConsoleShell`). A metadata `type: 'api'` action whose resolved target is off-origin now goes out through the bare global fetch — no `Authorization`, no `X-Tenant-ID`, no `Accept-Language`. Same-origin actions are unchanged. Quiet fix, no advisory, per the ruling.

The sequencing prerequisite has landed: #5745 (merged as PR #5765) converged the dev stacks on one origin — verified on `origin/main` `bc21c704b` that all four committed env files ship `VITE_SERVER_URL` empty and `examples/console-starter/vite.config.ts:80` carries the `/api` dev proxy — so this change no longer de-authenticates the standard dev stack. `Blocked-by: objectui#5745` is discharged (#5745 is itself already closed, completed by PR #5765).

## What changed

- `packages/app-shell/src/hooks/useConsoleActionRuntime.tsx` — the one ruled line at `:316` plus lane comments stating the off-origin behaviour (the old `apiHandler` comment described the wrapper as unconditional "Bearer + X-Tenant-ID + same-origin cookies").
- `packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.sameOriginOnly-5702.test.tsx` — the regression pin, deliberately a PAIR through `apiHandler` with the real `createAuthenticatedFetch` (partial auth mock; the wrapper, `TokenStorage`, `ActiveOrganizationStorage` stay real): a same-origin target still carries `Authorization` and `X-Tenant-ID`; an absolute off-origin target carries neither and the request still executes (pass-through, not a refusal). Either half alone proves nothing — the off-origin half is green on a wrapper that attaches nothing, the same-origin half on the bare wrapper this site built before.
- `.changeset/action-runtime-same-origin-only-5702.md` — patch, states the behaviour change plainly, including the split-host note and the #5745 convergence.

This is a re-derivation of the earlier pushed branch `claude/issue-5702-action-runtime-same-origin` (head `074121474`, pre-#5744/#5765) onto current main; that branch is left untouched.

## Re-measurements on `bc21c704b` (all line numbers re-derived)

- `sameOriginOnly` short-circuits at `createAuthenticatedFetch.ts:81` — **before** `isApiCall` (`:84`), `Authorization` (`:87`), `X-Tenant-ID` (`:128`) and `Accept-Language` (`:141`). The post-#5744 rewrite (188 lines) preserves this ordering; the option stops all three headers.
- The switch is shared: construction at `useConsoleActionRuntime.tsx:308` (pre-change), consumed at `:399` (`apiHandler`), `:534`, `:592` (server-action env), `:695` (child prop) and returned from the hook at `:721` — five lanes, four building URLs from `VITE_SERVER_URL` (`:326`, `:509`, `:593`, `:696`). The change at the construction covers all of them; nothing is scoped to `apiHandler` alone.
- **Shipped-reliance sweep re-run (the ruling's conditional stop): clean, controlled.** Absolute `http(s)` action targets in ts/tsx across `packages/ apps/ examples/`: 5 hits, every one a `type: 'url'` navigation action in core ActionRunner tests (no fetch, no headers). Controls: 108 relative `/api/` targets by the same pattern family; JSON/YAML lane 0 files with an api-typed action (control: 268 `type: 'api'` occurrences in TS). The first pass's split-host reliance is repaired on main by #5745, verified above. **The stop does not re-fire.**
- `withSettleSignal` (the extra wrapper at `ConsoleShell.tsx`'s site) is orthogonal here: it manages request settling for the data-source provider lane; the action runtime never had it and adding it is not part of the ruling.
- Out of scope, per the original dispatch: the other bare `createAuthenticatedFetch()` construction sites take code-supplied first-party URLs, not author metadata — the axis this card turns on. The `X-Tenant-ID` gating question is #5279-side follow-up evidence, not this PR.

## Verification (union at `17a273779`, clean tree, sha echoed by the run itself)

- Targeted suite (canonical root invocation): new pin + 3 sibling `useConsoleActionRuntime` files + `packages/auth` `createAuthenticatedFetch.test.tsx` (the legacy-behaviour pin "without sameOriginOnly, cross-origin /api/ URLs keep the legacy attach behaviour" — stays green, fence not crossed): `Test Files 5 passed (5) / Tests 72 passed (72)`, `UNION-VITEST-EXIT=0`, lock `VERDICT command-exit 0`.
- `pnpm --filter @object-ui/app-shell type-check` after building the dependency closure: script name echoed (`@object-ui/app-shell@17.6.0 type-check`), `TYPECHECK-EXIT=0`.
- **Ablation** (committed first; mutation script with `trap restore EXIT INT TERM`): reverted the one line, disk-confirmed by anchored counts both directions (pre: option-call 1 / bare-call 0 → mutated: 0 / 1 → restored: 1 / 0). No build leg exists on this path and none is needed: vitest aliases `@object-ui/auth` to `packages/auth/src` and the pin imports the hook relatively from source, so both legs execute on-disk source. Observed direction as predicted: off-origin pin RED (`AssertionError: expected 'Bearer tok-5702' to be null`), same-origin pin **survived** — correctly, same-origin attach is identical with and without the option — and the legacy wrapper file stayed green (it pins the wrapper, which the ablation never touches).
- Targeted eslint (`--no-inline-config --format json`) on the two touched lintable files: `ESLINT-EXIT=0`, 2 files linted, 0 errors, 63 warnings all `@typescript-eslint/no-explicit-any` + pre-existing hook warnings — the lint gate is errors-only by the workflow's own header. Narrowing declared: population is the root flat `eslint.config.js` (`files: ['**/*.{ts,tsx}']`), file count from the JSON formatter, and the config enables no type-aware linting (no `projectService` / `parserOptions.project`), so this diff cannot move untouched files' verdicts. The repo-wide farm is CI's run.
- `node scripts/check-changeset-presence.mjs`: "2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)", exit 0.

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_