### PR TITLE
fix(components): announce `element:text_input`'s `description` with the field

### DIFF
--- a/.changeset/text-input-description-aria-describedby-5735.md
+++ b/.changeset/text-input-description-aria-describedby-5735.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/components': patch
+---
+
+`element:text_input` now ties its authored `description` to the field with
+`aria-describedby`, so assistive tech announces the helper text as the input's
+accessible description instead of leaving it as an unassociated paragraph
+beside the field (objectui#5735).
+
+Before this the paragraph and the input were siblings with no programmatic
+relationship: a screen reader moving to the field announced the label and the
+value and never the helper text. The `label` half of the same block was already
+wired (`htmlFor` against the input's `id`), which is what made the gap specific
+to `description` rather than a general absence of a11y wiring — and the
+identical key authored on a field INSIDE `renderers/form/form.tsx` has been
+announced all along, so one authoring key behaved two ways depending on which
+container the author reached for. It no longer does.
+
+The paragraph's id is minted per instance with `React.useId()` — the same source
+`FormItem` mints the form renderer's description id from — and deliberately not
+derived from `schema.id`. The two associations in this block need ids on
+opposite ends: `htmlFor` names the INPUT, whose id only the author can supply,
+so that wiring still holds only when they gave the node an `id`; `aria-describedby`
+names the PARAGRAPH, which the renderer owns, so the description association
+holds unconditionally and cannot collide when two nodes share an authored id.
+The attribute is emitted only when a paragraph is actually rendered — an absent
+or empty `description` leaves the input with no `aria-describedby` rather than a
+dangling reference.
+
+The key's published `ComponentInput` description, which documented this gap in
+so many words, is rewritten in the same change. Its closing advice — prefer
+`label` for an instruction a user must not miss — is kept rather than deleted,
+on a new basis: a description is announced after the field's name and screen
+readers gate description text behind verbosity settings a user can turn down, so
+it remains the half of the announcement most likely to go unheard.

--- a/packages/components/src/__tests__/text-input-description-association.test.tsx
+++ b/packages/components/src/__tests__/text-input-description-association.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `element:text_input` — the authored `description` is the field's accessible
+ * DESCRIPTION, not an unassociated paragraph beside it (objectui#5735).
+ *
+ * ## What these tests pin, and what they deliberately do NOT
+ *
+ * The defect was never "the paragraph has no id". It was that the paragraph and
+ * the input had no programmatic RELATIONSHIP: a screen reader moving to the
+ * field announced the label and the value and never the helper text. So every
+ * case below asserts the relationship end to end — read the control's
+ * `aria-describedby`, look each id up in the document, and compare the resolved
+ * element's text — via the `describedElements` helper. Two assertions that
+ * checked the attributes separately ("the p has an id", "the input has an
+ * aria-describedby") both pass on a build where the two point at DIFFERENT
+ * things, which is the build this file has to be able to fail on.
+ *
+ * ## What the instrument can and cannot discriminate
+ *
+ * `toHaveAccessibleDescription` runs `dom-accessibility-api` over happy-dom. It
+ * can prove the description is COMPUTED — that the reference resolves and the
+ * resolved text is what an AT would be handed. It cannot prove any screen
+ * reader SPEAKS it: description text is announced after the accessible name and
+ * is gated by AT verbosity settings (NVDA's "Report object descriptions",
+ * VoiceOver hint verbosity), and nothing in this repo can measure that. This is
+ * why the renderer's own `description` prose keeps the "prefer `label` for
+ * instructions a user must not miss" advice after the wiring landed — the
+ * advice now rests on announcement order and verbosity, which is cited, rather
+ * than on the text being unreachable, which was measured and is now false.
+ *
+ * Second limit, worth stating because it is the one that could mislead: CSS
+ * generated content does not exist in happy-dom, so the `required` asterisk
+ * (`after:content-['*']` on the `Label`) is invisible to every name/description
+ * computation here. It IS part of the accessible name in a real browser. No
+ * case below depends on that either way.
+ *
+ * ## Why the renderer is driven through the registry, not `SchemaRenderer`
+ *
+ * Same reason `text-input-i18n-label-arms.test.tsx` next door states:
+ * `SchemaRenderer` injects its own props around a renderer, so a case driven
+ * through it can be green for a reason that is not the renderer's. The last
+ * case re-runs the primary relationship through `SchemaRenderer` on purpose —
+ * that is the path an authored page actually takes, and it is worth one
+ * assertion that the wrapper does not strip the wiring.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers `element:text_input` at module scope, not in a hook
+// (object-ui/no-dynamic-import-in-test-hook, objectui#3010).
+import '../renderers';
+
+afterEach(cleanup);
+
+const HELP = 'Lowercase letters and dashes only.';
+
+/**
+ * The relationship, resolved the way assistive tech resolves it: read
+ * `aria-describedby`, split it, and look every id up in the document.
+ *
+ * A dangling id THROWS rather than being skipped. That is the point — an
+ * `aria-describedby` naming an element that does not exist is worse than no
+ * attribute, and a helper that quietly dropped the miss would let exactly that
+ * build pass.
+ */
+function describedElements(control: Element): HTMLElement[] {
+  const ref = control.getAttribute('aria-describedby');
+  if (ref == null) return [];
+  return ref
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((id) => {
+      const el = document.getElementById(id);
+      if (!el) {
+        throw new Error(`aria-describedby names "${id}", but no element in the document has that id`);
+      }
+      return el;
+    });
+}
+
+function renderInput(properties: Record<string, unknown>, schemaExtra: Record<string, unknown> = {}) {
+  const C = ComponentRegistry.get('element:text_input') as React.ComponentType<any>;
+  if (!C) throw new Error('element:text_input is not registered');
+  return render(<C schema={{ type: 'element:text_input', id: 'ws_input', properties, ...schemaExtra }} />);
+}
+
+describe('element:text_input — description is the field\'s accessible description (objectui#5735)', () => {
+  it('resolves the input aria-describedby to the paragraph carrying the resolved description', () => {
+    renderInput({ label: 'Workspace', description: HELP });
+
+    const input = screen.getByRole('textbox');
+    const described = describedElements(input);
+
+    // ONE description carrier, and it is the rendered paragraph — asserted as a
+    // resolution, not as two independent attributes.
+    expect(described).toHaveLength(1);
+    expect(described[0].tagName).toBe('P');
+    expect(described[0].textContent).toBe(HELP);
+    expect(described[0]).toBe(screen.getByText(HELP));
+
+    // And the computed description an AT would be handed.
+    expect(input).toHaveAccessibleDescription(HELP);
+  });
+
+  it('emits NO aria-describedby when no description is authored', () => {
+    renderInput({ label: 'Workspace' });
+
+    const input = screen.getByRole('textbox');
+    // The control that keeps the fix honest: a renderer that ALWAYS emitted an
+    // `aria-describedby` would satisfy every other case in this file while
+    // publishing a dangling reference on every description-less field.
+    expect(input).not.toHaveAttribute('aria-describedby');
+    expect(describedElements(input)).toHaveLength(0);
+    expect(input).toHaveAccessibleDescription('');
+    expect(document.querySelector('p')).toBeNull();
+  });
+
+  it('emits no aria-describedby for a description that resolves to an empty string', () => {
+    // The paragraph is dropped by the same `{description && …}` truthiness the
+    // id is minted under, so the two cannot drift apart into an attribute
+    // pointing at a paragraph that was never rendered.
+    renderInput({ label: 'Workspace', description: '' });
+
+    const input = screen.getByRole('textbox');
+    expect(input).not.toHaveAttribute('aria-describedby');
+    expect(document.querySelector('p')).toBeNull();
+  });
+
+  it('keeps the label association working — it shares the id most likely to break', () => {
+    renderInput({ label: 'Workspace', description: HELP });
+
+    const input = screen.getByRole('textbox');
+    expect(screen.getByLabelText('Workspace')).toBe(input);
+    expect(input).toHaveAccessibleName('Workspace');
+    // Name and description are separate channels: the helper text must not have
+    // leaked into the name.
+    expect(input).toHaveAccessibleDescription(HELP);
+    expect(document.querySelector('label')).toHaveAttribute('for', 'ws_input');
+    expect(input).toHaveAttribute('id', 'ws_input');
+  });
+
+  it('associates the description even when the node carries NO id — while the label degrades exactly as before', () => {
+    // The deliberate half of the fix. `htmlFor` needs an id on the INPUT, which
+    // only the author can supply, so the label wiring can only hold when they
+    // did — unchanged here. `aria-describedby` needs an id on the PARAGRAPH,
+    // which the renderer mints, so the description association never depended
+    // on the author at all.
+    const C = ComponentRegistry.get('element:text_input') as React.ComponentType<any>;
+    render(<C schema={{ type: 'element:text_input', properties: { label: 'Workspace', description: HELP } }} />);
+
+    const input = screen.getByRole('textbox');
+
+    // Pre-existing behaviour, pinned so a later "fix" cannot change it silently.
+    expect(input).not.toHaveAttribute('id');
+    expect(document.querySelector('label')).not.toHaveAttribute('for');
+    expect(input).toHaveAccessibleName('');
+
+    // …and the description is associated anyway.
+    const described = describedElements(input);
+    expect(described).toHaveLength(1);
+    expect(described[0].textContent).toBe(HELP);
+    expect(input).toHaveAccessibleDescription(HELP);
+  });
+
+  it('gives each input its OWN paragraph even when two nodes share an authored id', () => {
+    // The case that discriminates the chosen mechanism from the obvious
+    // alternative. Deriving the paragraph id from `schema.id` would publish two
+    // paragraphs with the same id here, and BOTH fields would resolve to
+    // whichever came first in the document — the wrong helper text announced on
+    // one of them, which is worse than none. A per-instance `React.useId()`
+    // cannot collide. This pins the property, not an endorsement of duplicate
+    // authored ids.
+    const C = ComponentRegistry.get('element:text_input') as React.ComponentType<any>;
+    render(
+      <>
+        <C schema={{ type: 'element:text_input', id: 'dup', properties: { label: 'First', description: 'First help.' } }} />
+        <C schema={{ type: 'element:text_input', id: 'dup', properties: { label: 'Second', description: 'Second help.' } }} />
+      </>,
+    );
+
+    const [first, second] = screen.getAllByRole('textbox');
+    expect(first.getAttribute('aria-describedby')).not.toBe(second.getAttribute('aria-describedby'));
+    expect(describedElements(first)[0].textContent).toBe('First help.');
+    expect(describedElements(second)[0].textContent).toBe('Second help.');
+    expect(first).toHaveAccessibleDescription('First help.');
+    expect(second).toHaveAccessibleDescription('Second help.');
+  });
+
+  it('describes the field from the description, not from the placeholder', () => {
+    renderInput({ label: 'Workspace', placeholder: 'acme', description: HELP });
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('placeholder', 'acme');
+    expect(input).toHaveAccessibleDescription(HELP);
+    expect(describedElements(input)[0].textContent).toBe(HELP);
+  });
+
+  it('associates the RESOLVED locale value, not the raw map', () => {
+    // `description` accepts an inline per-locale map (objectui#5717). What must
+    // reach `aria-describedby` is the value `pickLocalized` resolved for the
+    // active language — a build that associated the paragraph but rendered the
+    // map, or resolved the map but associated something else, is red here.
+    const C = ComponentRegistry.get('element:text_input') as React.ComponentType<any>;
+    render(
+      <I18nProvider persistLanguage={false} config={{ defaultLanguage: 'zh-CN', detectBrowserLanguage: false }}>
+        <C
+          schema={{
+            type: 'element:text_input',
+            id: 'ws_input',
+            properties: { label: 'Workspace', description: { en: 'Owner', 'zh-CN': '负责人' } },
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(describedElements(input)[0].textContent).toBe('负责人');
+    expect(input).toHaveAccessibleDescription('负责人');
+  });
+
+  it('survives the real render path through SchemaRenderer', () => {
+    render(
+      <SchemaRenderer
+        schema={{ type: 'element:text_input', id: 'ws_input', properties: { label: 'Workspace', description: HELP } }}
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(describedElements(input)[0].textContent).toBe(HELP);
+    expect(input).toHaveAccessibleDescription(HELP);
+  });
+});

--- a/packages/components/src/renderers/basic/text-input.tsx
+++ b/packages/components/src/renderers/basic/text-input.tsx
@@ -97,6 +97,33 @@ function ElementTextInputRenderer({ schema }: { schema: any }) {
   const placeholder = pickLocalized(props.placeholder, language);
   const description = pickLocalized(props.description, language);
 
+  // The description paragraph's id is MINTED HERE, and deliberately NOT derived
+  // from `schema.id` — the two associations in this block need ids on opposite
+  // ends and therefore do not share a dependency:
+  //
+  //  - `label`'s `htmlFor` must name the INPUT, whose id is the author's
+  //    `schema.id` (the same key `usePageVariableBinding` binds on). Only the
+  //    author can supply it, so that wiring can only hold when they did.
+  //  - `aria-describedby` names the PARAGRAPH, an element this renderer wholly
+  //    owns and that no author ever addresses. Nothing about it depends on the
+  //    node carrying an `id`, so the association holds unconditionally.
+  //
+  // Reusing `schema.id` would have imported the label's dependency for no gain
+  // and added a failure the label wiring cannot have: two inputs sharing an id
+  // would publish two paragraphs sharing an id, and both fields'
+  // `aria-describedby` would resolve to whichever came first in the document —
+  // the WRONG helper text announced, which is worse than none. `React.useId()`
+  // is per instance and SSR-stable, and it is the same source `<FormItem>`
+  // mints the form renderer's `…-form-item-description` from (`ui/form.tsx`),
+  // so the standalone element and the form container now reach the same shape
+  // by the same route.
+  const instanceId = React.useId();
+  // Emitted ONLY when a paragraph is actually rendered. An `aria-describedby`
+  // that outlives an absent description is a DANGLING reference — worse than
+  // no attribute, because assistive tech reports the broken id rather than
+  // falling through to whatever else could describe the field.
+  const descriptionId = description ? `${instanceId}-description` : undefined;
+
   return (
     <div
       className={cn('grid w-full max-w-sm items-center gap-1.5', schema?.className)}
@@ -119,9 +146,14 @@ function ElementTextInputRenderer({ schema }: { schema: any }) {
         defaultValue={value === undefined ? (props.defaultValue as any) : undefined}
         required={props.required}
         disabled={props.disabled}
+        aria-describedby={descriptionId}
         onChange={handleChange}
       />
-      {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      {description && (
+        <p id={descriptionId} className="text-sm text-muted-foreground">
+          {description}
+        </p>
+      )}
     </div>
   );
 }
@@ -246,10 +278,23 @@ ComponentRegistry.register('text_input', ElementTextInputRenderer, {
       // destination-based split would have declared an arm on one key and
       // withheld it on another for a difference neither the gate nor the
       // contract can see.
+      //
+      // The a11y sentence at the END of this description is PAIRED with the
+      // render site above and must move with it. It previously documented the
+      // gap ("does not tie it to the field with `aria-describedby`") because
+      // that was true; the wiring landed with objectui#5735 and the sentence
+      // was rewritten in the same change. The trailing "prefer `label`" advice
+      // was kept, not deleted: it was ORIGINALLY true because the text was not
+      // exposed at all, and it is STILL true for a different and weaker reason
+      // — a description is announced after the accessible name and is gated by
+      // AT verbosity settings a user can turn down. That reason is CITED, not
+      // measured here: the tests can prove the accessible description is
+      // computed and non-empty, and no test in this repo can prove what any
+      // screen reader speaks in any given verbosity mode.
       type: ['string', 'object'],
       label: 'Description',
       description:
-        'Helper text rendered BELOW the input, in its own `<p>` — a different destination from `label` (above, in a `<label>`) and `placeholder` (inside the field), reached by the same read path. Display-only, and OMITTED entirely when the key is absent or resolves to an empty string. Accepts either a plain string or an inline per-locale map (`{ en: "Owner", "zh-CN": "负责人" }`), resolved against the active language with the same fallback chain as `label`. Presentational only: the renderer renders it as a sibling paragraph and does not tie it to the field with `aria-describedby`, so a screen reader does not announce it together with the input — instructions a user must not miss belong in `label`.',
+        'Helper text rendered BELOW the input, in its own `<p>` — a different destination from `label` (above, in a `<label>`) and `placeholder` (inside the field), reached by the same read path. Display-only, and OMITTED entirely when the key is absent or resolves to an empty string. Accepts either a plain string or an inline per-locale map (`{ en: "Owner", "zh-CN": "负责人" }`), resolved against the active language with the same fallback chain as `label`. The paragraph IS tied to the field with `aria-describedby`, so the resolved text is the input’s accessible DESCRIPTION and assistive tech announces it with the field rather than leaving it as unreachable decoration. That association does not depend on the node carrying an `id` (`label`’s `htmlFor` does): the id `aria-describedby` needs sits on the paragraph, which the renderer mints per instance, and it is emitted only when a paragraph is actually rendered — an absent or empty `description` leaves the input with no `aria-describedby` at all. Prefer `label` anyway for an instruction a user MUST NOT miss: a description is announced after the field’s name, and screen readers gate description text behind verbosity settings a user can turn down (NVDA’s “Report object descriptions”, VoiceOver hint verbosity), so it is the half of the announcement most likely to go unheard — the same advice as before, now resting on announcement order and verbosity rather than on the text being unwired.',
     },
   ],
 });


### PR DESCRIPTION
Fixes #5735

`element:text_input` rendered its resolved `description` as a bare sibling paragraph: no `id` on the paragraph, no `aria-describedby` on the `Input`. The two elements had no programmatic relationship, so a screen reader moving to the field announced the label and the value and never the helper text.

## The three facts the card rests on — verified on this worktree, not taken from the card

| Claim | Verdict |
|---|---|
| `text-input.tsx` renders the description with no `id`, and the `Input` gets no `aria-describedby` | **Holds.** `{description && ...}` rendered a `text-sm text-muted-foreground` paragraph; the `Input` prop list carried `id` / `type` / `placeholder` / `value` / `defaultValue` / `required` / `disabled` / `onChange` and no aria attribute. |
| The `label` half **is** wired: `Label htmlFor={schema?.id}` against `Input id={schema?.id}` | **Holds**, and is now pinned by a test so it cannot regress behind this change. |
| `packages/components/src/ui/input.tsx` adds no aria attributes of its own | **Holds** — and it needs no change. It is a `forwardRef` over a native `input` that spreads `...props`, so an `aria-describedby` handed down by a caller reaches the element unaltered. The primitive is named by triage as the thing that does not *supply* the attribute, and that stays true: it is not the thing that should. **No edit to that file, as instructed.** |

## The mechanism, and why it is the platform's rather than a local invention

`renderers/form/form.tsx` has wired this correctly all along, via `ui/form.tsx`: `FormItem` mints an id with `React.useId()`, `useFormField` derives `formDescriptionId` from it, `FormDescription` publishes that id, and `FormControl` (a Radix `Slot`) injects `aria-describedby` into the control. So one authoring key behaved two ways depending on which container the author reached for.

This change converges on the **id source and the suffix derivation**, not on the injection plumbing — there is no `Slot` here and no context to hang one on, and adding either to a nine-line render body would be the locally clever fix, not the converged one. The paragraph id is minted with `React.useId()` and the attribute is set directly.

It deliberately does **not** converge on one property of the form path: `FormControl` emits `aria-describedby` unconditionally, so a form field with no description publishes a reference to an element that was never rendered. This renderer emits the attribute only when a paragraph is actually rendered. (That divergence is stated here rather than filed — the form path's version is a Slot-level behaviour shared with `FormMessage`, and untangling it is a different card.)

## The absent-`schema.id` path — the decision the card asked for

The card framed this as a choice between "generate a fallback id so the association always holds" and "stay consistent with `label` and wire only when the author gave the node an id", warning that the block should not end up with two conventions.

The two are not the same situation, and that is what decides it: **the two associations need ids on opposite ends.**

- `htmlFor` must name the **input**, whose id is the author's `schema.id` — the same key `usePageVariableBinding` binds on. Only the author can supply it, so that wiring can only hold when they did. **Unchanged.**
- `aria-describedby` must name the **paragraph**, an element this renderer wholly owns and that no author ever addresses. Nothing about it depends on the node carrying an `id`.

So there is one convention — *associate where we can* — applied to a case where we always can. Deriving the paragraph id from `schema.id` would have imported the label's dependency for no gain and added a failure the label wiring cannot have: two nodes sharing an authored id would publish two paragraphs sharing an id, and both fields' `aria-describedby` would resolve to whichever came first in the document. That is the **wrong** helper text announced, which is worse than none. A per-instance `useId` cannot collide, and there is a test for exactly that case.

Measured id shape under React 19.2.8: `_r_1_-description`.

## The published prose, and the trailing clause

#5717 rewrote this key's `ComponentInput.description` to document the gap. That sentence is now false, so it is rewritten in the same change. A repo-wide search found exactly one copy of it (controlled against a neighbouring "Presentational only" occurrence in `AiUsageIndicator.tsx`, which the same search did return, so the single hit is a reading and not a broken instrument). The published skills corpus does not document this key at all — `grep` for `text_input`, `record_picker` and `aria-describedby` under `skills/` returns zero, controlled against "ObjectUI", which returns three files. **No diff under `skills/`, so the published-skills line-count ruling does not apply here.**

The trailing clause — *"instructions a user must not miss belong in `label`"* — is **kept, not deleted**, and its basis is restated.

It was originally true because the text was not exposed at all. That reason is now gone. The reason it is still true is different and weaker: a description is announced **after** the accessible name (it is the last element of the name/role/state/value/description order), and screen readers expose description text through verbosity settings the user can turn down — NVDA's *Report object descriptions* under Object Presentation, VoiceOver's hint verbosity, JAWS' verbosity levels. So it remains the half of the announcement most likely to go unheard.

**This half is cited, not measured, and the code says so.** The tests here run `dom-accessibility-api` over happy-dom: that can prove the description is *computed* and that the reference resolves, and it cannot prove what any screen reader *speaks* in any given verbosity mode. Deleting the clause would have told authors that a critical instruction placed in `description` is now guaranteed to be heard, which nothing in this repo can support.

## Tests — the relationship, not its halves

`packages/components/src/__tests__/text-input-description-association.test.tsx`, 9 cases. Every one resolves the link the way assistive tech does (read `aria-describedby`, look each id up in the document, compare the resolved element's text) through a helper that **throws** on a dangling id rather than skipping it. Asserting the two attributes separately would pass on a build where they point at different things.

Alongside the primary case: the two absence controls (no description, and a description resolving to an empty string, both emitting **no** attribute), the label association it shares an id with, the absent-`schema.id` path, the duplicate-authored-id case, description-beats-placeholder, the resolved-locale-value case, and one run through `SchemaRenderer` so the real render path is covered too.

### Ablation — both directions, committed first, restored under a trap

Tests resolve **source**, not `dist`: `vitest.config.mts:264` aliases `@object-ui/components` to `packages/components/src`, and no `dist/` exists anywhere in this worktree (`test -d packages/components/dist` exits 1; so does `packages/core/dist`) while all 9 cases pass. **No rebuild leg is possible or needed** — there is no build artifact a stale copy could hide in.

Each mutation was confirmed on disk by anchored counts in **both** directions before any run, and restored by `trap '...' EXIT INT TERM`.

**A — remove `aria-describedby={descriptionId}` from the `Input`.** Injected-text count 0, paragraph-`id` count still 1, `git diff --stat` 1 deletion.

```
Tests  7 failed | 2 passed (9)
```

The 2 survivors are the two absence controls, and they **survive correctly**: they assert the attribute is *absent*, which removing the attribute cannot break. That is the point of having them — they are the half that mutation A structurally cannot reach.

**B — drop the conditional, so the id (and therefore the attribute) is always emitted.** Conditional form gone (0), unconditional form landed (1).

```
Tests  2 failed | 7 passed (9)

expect(element).not.toHaveAttribute("aria-describedby")
Received: aria-describedby="_r_1_-description"
```

Exactly the complement: the two absence controls, and only those, go red. Between them the two ablations account for all 9 cases, and neither leaves a case that no mutation can kill. Both restore legs confirmed on disk (anchored count back to 1; `git status` clean, i.e. byte-identical to the commit).

## Verification — all at `f448261f7`, on a clean tree

| Run | Result |
|---|---|
| `pnpm exec vitest run packages/components --maxWorkers=4` | **184 files, 1663 tests, all passed**, exit 0 (3m46s). Includes both snapshot suites. |
| `pnpm --filter @object-ui/components type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`, both echoed) after `pnpm --workspace-concurrency=2 --filter '@object-ui/components^...' build` |
| `pnpm lint` (`turbo run lint`, the whole repo) | **47 successful, 47 total**, exit 0. Not narrowed — the full task graph ran (4m00s). My two files carry only pre-existing-idiom `no-explicit-any` warnings, 0 errors repo-wide. |
| `check:control-bytes` | `check-control-bytes: OK (scanned 4810 tracked text file(s); skipped 85 binary)` |
| `check:doc-types` | `Every documented component type is registered.` |
| `check:self-import` | `No package names itself inside its own src/.` |
| `check:phantom-deps` | `Every in-scope import is declared by the package that publishes it.` |
| `check:spec-symbols` | `spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages.` (exit 0) |
| `check:skills-paths` | `OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined)` |
| `check:i18n-keys` / `check:i18n-drift` | exit 0, both verdict lines clean |
| `check:i18n-dead-keys` | exit 0 — and it prints that it is a **report, not a gate** |

Every exit code above was captured **before** any pipe (`cmd > file 2>&1; EXIT=$?`), and each row quotes the gate's own verdict line rather than a bare `$?`.

Changeset: `.changeset/text-input-description-aria-describedby-5735.md` (`@object-ui/components: patch`).

## Out-of-scope finding — reported, not widened

Swept per the card's ask. Within this renderer nothing else is in the same position: `required` reaches the native `required` attribute (announced), the asterisk is CSS generated content on the `Label` (invisible to happy-dom, part of the accessible name in a real browser, and not depended on either way by any test here), `placeholder` reaches the native attribute, and this renderer emits no error message at all, so there is no error relationship to wire.

One sibling block **is**, and it is filed rather than fixed: `element:record_picker` renders a `label` element with **no** `htmlFor` while its `SelectTrigger` carries no `id` — so its label is unassociated in both directions, which is a step worse than the gap this card closes. Its own registration prose advertises the caption as rendered "in a `label` element". This is the same defect class #3341 ruled on and fixed for the ActionParamDialog select branch, one surface over.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_