### PR TITLE
fix(app-shell): gate MarketplacePackagePage's listLocalInstalls on marketplaceEnabled + isAdmin (#5620)

### DIFF
--- a/.changeset/gate-listlocalinstalls-marketplace-5620.md
+++ b/.changeset/gate-listlocalinstalls-marketplace-5620.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`MarketplacePackagePage`'s third fetch effect — `listLocalInstalls` — is now gated on
+`marketplaceEnabled` and `isAdmin`, the same two predicates the page's other two fetch
+effects already check, in addition to (not instead of) its existing
+`features.installLocal` check (objectui#5620).
+
+`listLocalInstalls`'s only consumer is `localInstalls.find(...)` in the content branch,
+which is unreachable whenever the page has already returned `MarketplaceDisabled` (no
+marketplace on this runtime) or `MarketplaceAccessDenied` (a refused viewer) — both
+decided ahead of the content branch since objectui#5533 and objectui#5583. Before this
+fix, a runtime with `features.installLocal: true` still fired the request — and
+discarded its answer — on a marketplace-off runtime and for a non-admin, the same
+wasted-round-trip class objectui#5533 established the fix for on this page, on the flag
+that card was not about.
+
+`features.installLocal` remains its own axis: a runtime can mount a local kernel install
+path with no marketplace proxy at all, so the fix adds the two predicates as a
+conjunction rather than replacing the existing check. The request still fires exactly
+when it did before AND the viewer would actually see its answer.

--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -150,14 +150,26 @@ export function MarketplacePackagePage() {
   const [localResult, setLocalResult] = useState<{ ok: boolean; message: string } | null>(null);
 
   useEffect(() => {
+    // `features.installLocal` is a genuinely separate deployment axis from
+    // `features.marketplace` (a runtime can mount a local kernel install path
+    // with no marketplace proxy at all), so it stays its own check rather than
+    // being folded into the other two predicates.
     if (!getRuntimeConfig().features.installLocal) return;
+    // Its only consumer is `localInstalls.find(...)` in the content branch
+    // below, which is unreachable whenever the page has already returned
+    // `MarketplaceDisabled` or (post-objectui#5583) `MarketplaceAccessDenied`.
+    // Firing anyway would be the same discarded-request class objectui#5533
+    // closed for this page, on the flag that card was not about
+    // (objectui#5620).
+    if (!marketplaceEnabled) return;
+    if (!isAdmin) return;
     let cancelled = false;
     (async () => {
       const items = await listLocalInstalls();
       if (!cancelled) setLocalInstalls(items);
     })();
     return () => { cancelled = true; };
-  }, [packageId, localResult]);
+  }, [packageId, localResult, marketplaceEnabled, isAdmin]);
 
   // Seed cloud-install state so the primary CTA renders as "Installed" on
   // first paint instead of inviting another install.

--- a/packages/app-shell/src/console/marketplace/__tests__/MarketplacePackagePage-5620.test.tsx
+++ b/packages/app-shell/src/console/marketplace/__tests__/MarketplacePackagePage-5620.test.tsx
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `MarketplacePackagePage`'s third fetch effect — `listLocalInstalls` — is
+ * gated on the same predicates that make its only consumer reachable
+ * (objectui#5620).
+ *
+ * ## The defect
+ *
+ * objectui#5533 and objectui#5583 gated `getMarketplacePackage` and
+ * `getCloudInstallationInfo` on `marketplaceEnabled` and `isAdmin`, but the
+ * page's third effect was left checking only `features.installLocal`:
+ *
+ *     useEffect(() => {
+ *       if (!getRuntimeConfig().features.installLocal) return;
+ *       ...listLocalInstalls()...
+ *     }, [packageId, localResult]);
+ *
+ * `listLocalInstalls`'s only consumer is `localInstalls.find(...)` in the
+ * CONTENT branch, reached only after both `!marketplaceEnabled` and
+ * `!isAdmin` have already returned early. So on any runtime with
+ * `features.installLocal: true`, the request still fired — and its answer
+ * was discarded — on a marketplace-off runtime and for a refused viewer.
+ *
+ * ## What is NOT claimed
+ *
+ * That `features.installLocal` stops mattering. It is a genuinely separate
+ * deployment axis from `features.marketplace` (a runtime can mount a local
+ * kernel install path with no marketplace proxy at all), so the fix ADDS the
+ * two predicates as a conjunction rather than replacing the existing check —
+ * the negative controls below pin that `installLocal: false` still skips the
+ * request even when marketplace is on and the viewer is an admin.
+ *
+ * ## Why these cases boot the REAL runtime-config module
+ *
+ * Same argument the sibling suites make (`*.guardOrder`, `*.disabledState`):
+ * `features.marketplace` and `features.installLocal` are both server-derived
+ * runtime config, never inferred from the shape of a failure, so every case
+ * boots the genuine `initRuntimeConfig()` over a stubbed
+ * `GET /api/v1/runtime/config` and lets the real merge run.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/** The viewer's privilege, varied per case — one of the two axes this suite exists for. */
+const viewer = vi.hoisted(() => ({ isAdmin: false }));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ packageId: 'com.acme.crm' }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useWorkspaceAdminStatus: () => ({ isAdmin: viewer.isAdmin, isResolved: true }),
+}));
+
+// `t` echoes the KEY, for the reason the sibling suites give: a `t` echoing
+// `defaultValue` renders identical text whether or not the key is wired, and
+// the claim under test is WHICH state — and so which string — the page reaches.
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      typeof opts?.url === 'string' ? `«${key}:${opts.url}»` : `«${key}»`,
+    language: 'en',
+  }),
+}));
+
+const getMarketplacePackage = vi.fn();
+const getCloudInstallationInfo = vi.fn();
+const listLocalInstalls = vi.fn();
+
+vi.mock('../marketplaceApi', () => ({
+  getMarketplacePackage: (...a: unknown[]) => getMarketplacePackage(...a),
+  getCloudInstallationInfo: (...a: unknown[]) => getCloudInstallationInfo(...a),
+  listLocalInstalls: (...a: unknown[]) => listLocalInstalls(...a),
+  listMarketplacePackages: async () => ({ items: [] }),
+  listOrgPackages: async () => ({ items: [] }),
+  listInstalledPackages: async () => ({ items: [] }),
+  installPackage: async () => ({}),
+  installLocal: async () => ({}),
+  uninstallLocal: async () => ({}),
+  listCloudEnvironments: async () => [],
+  listInstallableOrgIds: async () => [],
+  cloudInstallDeepLink: () => '',
+  reseedSampleData: async () => ({ ok: true }),
+  purgeSampleData: async () => ({ ok: true }),
+  reseedLocalSampleData: async () => ({ ok: true }),
+  purgeLocalSampleData: async () => ({ ok: true }),
+}));
+
+vi.mock('../../../assistant/assistantBus', () => ({ emitMetadataRefresh: () => {} }));
+vi.mock('../../../providers/MetadataProvider', () => ({ useMetadata: () => ({ refresh: () => {} }) }));
+// Renders nothing here: it fetches its own suggestions on mount, which is a
+// second network surface this suite is not about.
+vi.mock('../../../components/SuggestedBindingsPanel', () => ({ SuggestedBindingsPanel: () => null }));
+
+import { initRuntimeConfig, resetRuntimeConfigForTesting } from '../../../runtime-config';
+import { MarketplacePackagePage } from '../MarketplacePackagePage';
+
+/** A `GET /api/v1/runtime/config` answer, as the server sends it. */
+type ConfigBody = Record<string, unknown>;
+
+const serverConfig = (marketplace: boolean, installLocal: boolean): ConfigBody => ({
+  cloudUrl: marketplace ? 'https://cloud.objectos.ai' : '',
+  singleEnvironment: true,
+  features: { installLocal, marketplace, aiStudio: true, autoPublishAiBuilds: true },
+  branding: { productName: 'ObjectOS', productShortName: 'ObjectOS' },
+});
+
+/** Boot the SPA against a runtime that answers with `body`. */
+async function bootOn(body: ConfigBody) {
+  resetRuntimeConfigForTesting();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, status: 200, json: async () => body })),
+  );
+  await initRuntimeConfig();
+}
+
+const PACKAGE = {
+  package: {
+    id: 'pkg_1',
+    manifest_id: 'com.acme.crm',
+    display_name: 'Acme CRM',
+    description: 'A CRM.',
+    latest_version: null,
+  },
+  versions: [],
+};
+
+beforeEach(() => {
+  viewer.isAdmin = false;
+  getMarketplacePackage.mockReset();
+  getCloudInstallationInfo.mockReset();
+  listLocalInstalls.mockReset();
+  getMarketplacePackage.mockResolvedValue(PACKAGE);
+  getCloudInstallationInfo.mockResolvedValue(null);
+  listLocalInstalls.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetRuntimeConfigForTesting();
+});
+
+describe('listLocalInstalls on a marketplace-OFF runtime', () => {
+  it('never fires, even with installLocal on and the viewer an admin', async () => {
+    viewer.isAdmin = true;
+    await bootOn(serverConfig(false, true));
+
+    render(<MarketplacePackagePage />);
+
+    await waitFor(() => expect(screen.getByTestId('marketplace-disabled')).toBeInTheDocument());
+    expect(listLocalInstalls).not.toHaveBeenCalled();
+  });
+});
+
+describe('listLocalInstalls for a REFUSED (non-admin) viewer', () => {
+  it('never fires on a runtime that does mount a marketplace', async () => {
+    viewer.isAdmin = false;
+    await bootOn(serverConfig(true, true));
+
+    render(<MarketplacePackagePage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('«marketplace.accessDenied.title»')).toBeInTheDocument(),
+    );
+    expect(listLocalInstalls).not.toHaveBeenCalled();
+  });
+});
+
+describe('POSITIVE CONTROL — admin + marketplace on + installLocal on', () => {
+  it('fires the request and renders the local-install badge from its answer', async () => {
+    viewer.isAdmin = true;
+    await bootOn(serverConfig(true, true));
+    listLocalInstalls.mockResolvedValue([
+      { manifestId: 'com.acme.crm', version: '1.2.0', withSampleData: false },
+    ]);
+
+    render(<MarketplacePackagePage />);
+
+    await screen.findByText('Acme CRM');
+    expect(listLocalInstalls).toHaveBeenCalled();
+    expect(await screen.findByText('«marketplace.detail.installedV»')).toBeInTheDocument();
+  });
+});
+
+describe('NEGATIVE CONTROL — features.installLocal itself is untouched', () => {
+  it('still skips the request when installLocal is off, even for an admin on a marketplace-on runtime', async () => {
+    viewer.isAdmin = true;
+    await bootOn(serverConfig(true, false));
+
+    render(<MarketplacePackagePage />);
+
+    await screen.findByText('Acme CRM');
+    expect(listLocalInstalls).not.toHaveBeenCalled();
+  });
+});
+
+describe('an admin whose adminship resolves AFTER first paint', () => {
+  it('fetches local installs once the flag flips, instead of staying gated forever', async () => {
+    await bootOn(serverConfig(true, true));
+
+    const { rerender } = render(<MarketplacePackagePage />);
+
+    expect(screen.getByText('«marketplace.accessDenied.title»')).toBeInTheDocument();
+    expect(listLocalInstalls).not.toHaveBeenCalled();
+
+    viewer.isAdmin = true;
+    rerender(<MarketplacePackagePage />);
+
+    await waitFor(() => expect(listLocalInstalls).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
Fixes #5620

## What

`MarketplacePackagePage`'s third fetch effect — `listLocalInstalls` — now checks
`marketplaceEnabled` and `isAdmin` in addition to (not instead of) its existing
`features.installLocal` check, matching the two predicates the page's other two fetch
effects (`getMarketplacePackage`, `getCloudInstallationInfo`) already check since
#5533/#5583.

```ts
useEffect(() => {
  if (!getRuntimeConfig().features.installLocal) return;
  if (!marketplaceEnabled) return;
  if (!isAdmin) return;
  ...
}, [packageId, localResult, marketplaceEnabled, isAdmin]);
```

## Why

`listLocalInstalls`'s only consumer is `localInstalls.find(...)` in the content branch
(line ~604), which is unreachable whenever the page has already returned
`MarketplaceDisabled` (`!marketplaceEnabled`, line 539) or `MarketplaceAccessDenied`
(`!isAdmin`, line 571) — both decided ahead of the content branch. Confirmed by reading:
`localInstalls` state has exactly one consumer in the file, at line 604, after all three
early returns.

Before this fix, a runtime with `features.installLocal: true` still fired the request —
and discarded its answer — on a marketplace-off runtime and for a refused (non-admin)
viewer. Same discipline #5533 established on this page ("a request the page knows it
will not use should be skipped rather than fired and discarded"), applied to the flag
that card wasn't about, per triage's shape.

`features.installLocal` stays its own axis — a genuinely separate deployment dimension —
so the fix is a conjunction, not a replacement.

## Premise check (per triage's premise-first clause)

Verified before editing: `localInstalls` (the state `listLocalInstalls`'s answer feeds)
has no consumer outside the content branch. No recorded ruling or external consumer
found that would pin the "fire unconditionally" reading. Proceeding with the gate as
specified.

## Tests

Added `packages/app-shell/src/console/marketplace/__tests__/MarketplacePackagePage-5620.test.tsx`,
following the mocking convention `MarketplacePackagePage.guardOrder.test.tsx` /
`*.disabledState.test.tsx` established (real `initRuntimeConfig()` over a stubbed
`GET /api/v1/runtime/config`, `t` echoing keys, `../marketplaceApi` module mock):

- marketplace off ⇒ `listLocalInstalls` never fires, even with `installLocal: true` and
  an admin viewer
- non-admin (refused) viewer on a marketplace-on runtime ⇒ never fires
- **positive control**: admin + marketplace on + `installLocal` on ⇒ fires, and its
  answer renders the local-install badge
- **negative control**: `installLocal: false` ⇒ still skips the request even for an
  admin on a marketplace-on runtime (pins that this axis is untouched)
- admin whose adminship resolves after first paint ⇒ fetches once the flag flips

19/19 tests pass across the new suite plus the two sibling suites it shares a page with
(no regression). `pnpm --filter '@object-ui/app-shell' type-check` — exit 0.
`pnpm --filter '@object-ui/app-shell^...' build` — all dependency packages build clean.
Directed `eslint` on both touched files — 0 errors (pre-existing `no-explicit-any`
warnings at unrelated lines, untouched by this diff). Changeset gates
(`check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`) — all
pass.

head: `ddc9ac406`

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_