### PR TITLE
fix(auth): stop sweepStore aborting the sign-in purge on one throwing removeItem (#5763)

### DIFF
--- a/.changeset/sweep-store-per-key-try-5763.md
+++ b/.changeset/sweep-store-per-key-try-5763.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/auth': patch
+---
+
+`sweepStore()` — the walk that drops the previous user's `localStorage`/`sessionStorage`
+state on a change of session user (objectui#5664 part 3) — now costs one key when a
+single `removeItem` throws, instead of aborting the rest of the sweep (objectui#5763).
+
+The `try` wrapped the WHOLE loop, not each removal. A `removeItem` that threw on key
+`n` aborted the walk, so keys `n+1..end` were never swept, and the failure was
+swallowed — `purgePreviousUserClientState()` returned normally and `SessionUserScope.adopt`
+believed the sign-in purge had completed. This is an ALLOWLIST sweep precisely so the
+next un-namespaced key — one nobody has written yet — cannot re-open the cross-user
+pollution class #5664 fixed; a partial sweep is a partial allowlist, and which keys
+survived depended on `Object.keys` iteration order rather than on anything bounded. The
+previous user's org id, recents, favourites, or a `sessionStorage` metadata seed (their
+permission-filtered app list, a cross-principal disclosure per objectui#5198) could all
+land on the wrong side of the abort.
+
+`Object.keys(store)` — the reason a guard exists here at all — stays guarded on its
+own; only the per-key guard is new, so one uncooperative key now costs exactly that key.
+
+Unlike `ActiveOrganizationStorage.clear()` (objectui#5731), a failed removal here is
+NOT verified by read-back and NOT quarantined: `clear()` owns every future read of its
+one key through `ActiveOrganizationStorage.get()`, so a "still readable" verdict and a
+quarantine are what keep a failed `clear()` from handing the value straight back.
+`sweepStore` walks keys it does not own reads for — another package's recents cache, a
+metadata seed — so there is no `get()` here to guard and nothing to quarantine; adding
+read-back verification for keys this function does not otherwise touch would be a
+general storage-error-handling refactor of the module, which this card is scoped away
+from. What IS mirrored is the reporting channel: a key whose `removeItem` throws is
+named in a `console.warn`, the same channel `clear()` uses, so a partial sweep is
+discoverable instead of silent. The caller (`SessionUserScope.adopt`, on the sign-in
+path, inside an `AuthProvider` effect) still cannot act on the failure and must not
+throw either.
+
+A working `localStorage`/`sessionStorage` behaves exactly as before: every
+non-device-scoped key is removed, nothing is reported, and the device-scoped allowlist
+(`auth-session-token`, `auth-session-user-id`, `vite-ui-theme`) is unaffected.

--- a/packages/auth/src/ActiveOrganizationStorage.ts
+++ b/packages/auth/src/ActiveOrganizationStorage.ts
@@ -183,16 +183,57 @@ function removePersisted(key: string): boolean {
  * Snapshot the keys first (`Object.keys`) — removing entries during a live
  * index walk shifts the ones behind it and skips half of them. Same idiom as
  * `AuthProvider`'s sign-out purge loop.
+ *
+ * ## The `try` guards the SNAPSHOT, not the walk (objectui#5763)
+ *
+ * `Object.keys(store)` can itself throw — partitioned iframes, some privacy
+ * modes — and that is the reason a guard exists here at all, so it stays.
+ * What it must NOT do is wrap the loop: a `removeItem` that throws on key `n`
+ * would abort the walk, leaving keys `n+1..end` unswept, with the failure
+ * swallowed so the caller believes the purge completed. This is an ALLOWLIST
+ * sweep (see the module doc, part 3) precisely so the next un-namespaced key
+ * cannot re-open the cross-user pollution class — a partial sweep is a
+ * partial allowlist. So each `removeItem` gets its own `try`: one
+ * uncooperative key costs exactly that key.
+ *
+ * ## Reported, not quarantined — unlike {@link ActiveOrganizationStorage.clear}
+ *
+ * `clear()` (objectui#5731) judges a removal by READ-BACK and quarantines a
+ * key that fails, because it owns every future read of that one key through
+ * {@link ActiveOrganizationStorage.get} — the quarantine is what keeps a
+ * failed `clear()` from handing the value straight back. `sweepStore` walks
+ * keys it does not own reads for (another package's recents cache, a
+ * metadata seed) — there is no `get()` here to guard, so there is nothing to
+ * quarantine, and adding a read-back verdict for keys this function does not
+ * otherwise touch would be exactly the "general storage-error-handling
+ * refactor" the card scopes this fix away from. What IS mirrored is the
+ * reporting channel: a key whose `removeItem` throws is named in a
+ * `console.warn`, same as `clear()`, so a partial sweep is discoverable
+ * instead of silent — the caller (`SessionUserScope.adopt`, on the sign-in
+ * path) still cannot act on it and must not throw either.
  */
 function sweepStore(store: Storage | undefined): void {
   if (!store) return;
+  let keys: string[];
   try {
-    for (const key of Object.keys(store)) {
-      if (DEVICE_SCOPED_KEYS.has(key)) continue;
-      store.removeItem(key);
-    }
+    keys = Object.keys(store);
   } catch {
-    /* storage unavailable */
+    return; /* storage unavailable */
+  }
+  const unswept: string[] = [];
+  for (const key of keys) {
+    if (DEVICE_SCOPED_KEYS.has(key)) continue;
+    try {
+      store.removeItem(key);
+    } catch {
+      unswept.push(key);
+    }
+  }
+  if (unswept.length > 0) {
+    console.warn(
+      `[purgePreviousUserClientState] could not remove ${unswept.length} key(s) from storage: ` +
+        `${unswept.join(', ')}. The previous user's state may still be readable under these keys.`,
+    );
   }
 }
 

--- a/packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx
+++ b/packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx
@@ -304,6 +304,78 @@ describe('a change of session user drops the previous user’s state wholesale (
 
     vi.unstubAllGlobals();
   });
+
+  // -------------------------------------------------------------------------
+  // objectui#5763 — a throwing `removeItem` must cost exactly that key
+  // -------------------------------------------------------------------------
+
+  it('sweeps every other non-device-scoped key when one removeItem throws (#5763)', () => {
+    SessionUserScope.adopt(USER_A);
+    ActiveOrganizationStorage.set('org_a');
+    // Keys on BOTH SIDES of the poisoned one in insertion order, so a green
+    // run proves the walk continues past the throw rather than stopping at
+    // the first non-poisoned key it happens to reach.
+    localStorage.setItem(`objectui-recent-items:u:${USER_A}`, '[{"id":"acct_1"}]');
+    const POISON_KEY = 'objectui-nav-order-crm';
+    localStorage.setItem(POISON_KEY, '["accounts"]');
+    localStorage.setItem('objectui-favorites', '["acct_2"]');
+    sessionStorage.setItem('objectui:metadata:app:org_a:@anon', '[{"name":"crm"}]');
+    // Device-scoped, written for the INCOMING user the same way the passing
+    // sibling case above does it.
+    TokenStorage.set('tok-bob');
+    localStorage.setItem('vite-ui-theme', 'dark');
+
+    const realRemoveItem = localStorage.removeItem.bind(localStorage);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const removeItemSpy = vi.spyOn(localStorage, 'removeItem').mockImplementation((key: string) => {
+      if (key === POISON_KEY) throw new Error('simulated removeItem failure');
+      realRemoveItem(key);
+    });
+
+    try {
+      expect(() => SessionUserScope.adopt(USER_B)).not.toThrow();
+
+      // The poisoned key is the residue the card is about — it survives.
+      expect(localStorage.getItem(POISON_KEY)).toBe('["accounts"]');
+
+      // Everything else non-device-scoped is still swept, in BOTH stores —
+      // this is the pin: one uncooperative key costs one key, not the rest.
+      expect(localStorage.getItem(scopedOrgKey(USER_A))).toBeNull();
+      expect(localStorage.getItem(`objectui-recent-items:u:${USER_A}`)).toBeNull();
+      expect(localStorage.getItem('objectui-favorites')).toBeNull();
+      expect(sessionStorage.getItem('objectui:metadata:app:org_a:@anon')).toBeNull();
+
+      // The device-scoped allowlist is still respected around the failure.
+      expect(TokenStorage.get()).toBe('tok-bob');
+      expect(localStorage.getItem('vite-ui-theme')).toBe('dark');
+      expect(localStorage.getItem('auth-session-user-id')).toBe(USER_B);
+
+      // Discoverable, not silent — the failure is named, not swallowed whole.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(POISON_KEY);
+    } finally {
+      // Explicit, not left to `afterEach`'s `restoreAllMocks()`: a spy
+      // installed on a jsdom `Storage` instance (rather than a plain object)
+      // has been observed to survive `restoreAllMocks()` across tests — the
+      // NEXT test in this file measured the mock still active on entry. Left
+      // to the shared teardown, this poisoned `removeItem` for every later
+      // case in the file that happens to touch the same key name.
+      removeItemSpy.mockRestore();
+    }
+  });
+
+  it('reports nothing when every removal sticks', () => {
+    // Control on the case above: the warning is a measurement of an actual
+    // failure, not a constant emitted on every purge.
+    SessionUserScope.adopt(USER_A);
+    localStorage.setItem('objectui-nav-order-crm', '["accounts"]');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    SessionUserScope.adopt(USER_B);
+
+    expect(localStorage.getItem('objectui-nav-order-crm')).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #5763

## The shape

`packages/auth/src/ActiveOrganizationStorage.ts`, `sweepStore()`:

```ts
function sweepStore(store: Storage | undefined): void {
  if (!store) return;
  try {
    for (const key of Object.keys(store)) {
      if (DEVICE_SCOPED_KEYS.has(key)) continue;
      store.removeItem(key);
    }
  } catch {
    /* storage unavailable */
  }
}
```

The `try` wrapped the WHOLE loop, not each removal. A `removeItem` that threw on key
`n` aborted the walk, so keys `n+1..end` were never swept, and the failure was
swallowed — `purgePreviousUserClientState()` returned normally and `SessionUserScope.adopt`
believed the sign-in purge had completed. This is the #5664 allowlist sweep (part 3 of
that fix) precisely so the next un-namespaced key — one nobody has written yet — cannot
re-open the cross-user pollution class; a partial sweep is a partial allowlist, and
which keys survived depended on `Object.keys` iteration order rather than on anything
bounded.

## What changed

`Object.keys(store)` — the reason a guard exists here at all — stays guarded on its
own; only the per-key guard is new, so one uncooperative key now costs exactly that
key, not the rest of the purge (the invariant triage named).

```ts
function sweepStore(store: Storage | undefined): void {
  if (!store) return;
  let keys: string[];
  try {
    keys = Object.keys(store);
  } catch {
    return; /* storage unavailable */
  }
  const unswept: string[] = [];
  for (const key of keys) {
    if (DEVICE_SCOPED_KEYS.has(key)) continue;
    try {
      store.removeItem(key);
    } catch {
      unswept.push(key);
    }
  }
  if (unswept.length > 0) {
    console.warn(`[purgePreviousUserClientState] could not remove ${unswept.length} key(s) …`);
  }
}
```

## The "should a failed sweep report" question — measured, and where it diverges from #5731

Triage directed following whatever #5731's landed answer (PR #5764, merged before this
branch was cut) was for `clear()`, and saying so explicitly if it doesn't transfer. Read
on `origin/main` at 286dd8daa:

- **`clear()`'s verdict is a READ-BACK** (`removePersisted` returns whether the key is
  still readable after the attempt), not "did `removeItem` throw" — because a wrapped or
  proxied `localStorage` whose `removeItem` is a silent no-op never throws and leaves
  identical residue.
- **`clear()` quarantines** a key whose removal it cannot verify, in `_unremovedKeys`,
  so `get()` skips the persisted branch for it and answers from `_memoryValue` instead —
  the quarantine is what turns the verdict into an outcome.
- **`clear()` reports** via `console.warn`, because none of its five callers (including
  `purgePreviousUserClientState` itself) can act on a storage failure.

**Reporting transfers; read-back-verdict and quarantine do not, and here is why.**
`clear()` can quarantine because it owns every future read of its ONE key, through
`ActiveOrganizationStorage.get()` — the quarantine is meaningless without a `get()` to
consult it. `sweepStore` walks an open-ended set of keys it does **not** own reads for
(another package's recents cache, a metadata seed written by `MetadataProvider`) — there
is no `get()` here to guard, so there is nothing to quarantine, and building a
generalized read-back-plus-quarantine mechanism for keys this function doesn't otherwise
touch would be the "general storage-error-handling refactor of the module" the card
scopes this fix away from. What **is** mirrored is the channel: a key whose `removeItem`
throws is named in a `console.warn`, same as `clear()`, so the failure the card's title
is about — a *silent* partial purge — is now discoverable. The caller
(`SessionUserScope.adopt`, on the sign-in path, inside an `AuthProvider` effect) still
cannot act on it and must not throw either, same reasoning #5731 laid out for the
sign-out callers.

One consequence worth naming: because the verdict here is "did `removeItem` throw" and
not a read-back, a wrapped/proxied `localStorage` whose `removeItem` is a silent no-op
(the "too narrow" case #5731's own docblock names) would sweep silently and unreported
through this function — narrower coverage than `clear()`'s. That gap is accepted as
in-scope-for-#5731-only, not closed here; closing it would mean the same generalization
just ruled out.

## Tests

`packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx`, two new cases (14
total in the file, up from 12; 23 total across it and `activeOrgStorageFallback-5703.test.tsx`):

- **`sweeps every other non-device-scoped key when one removeItem throws (#5763)`** — a
  `localStorage.removeItem` spy throws for one poisoned key, with keys seeded on BOTH
  sides of it in insertion order. Asserts every other key — including the one seeded
  *after* the poison — is swept in both stores, the device-scoped allowlist survives,
  and the failure is named once in a `console.warn` containing the poisoned key.
- **`reports nothing when every removal sticks`** — control on the case above: no
  `console.warn` call on a healthy sweep, so the warning is a measurement of an actual
  failure and not a constant.

**Reverse verification** (fix committed first, so the restore below is a real
checkpoint, not the working tree as the only copy):

```
git checkout origin/main -- packages/auth/src/ActiveOrganizationStorage.ts
pnpm exec vitest run packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx -t "removeItem throws"
```

```
FAIL  … > sweeps every other non-device-scoped key when one removeItem throws (#5763)
AssertionError: expected '["acct_2"]' to be null
  345|       expect(localStorage.getItem('objectui-favorites')).toBeNull();
```

`objectui-favorites` — seeded *after* the poisoned key — survives on pre-fix code
exactly as the card describes: the whole-loop `try` aborts the walk at the throw. Fix
restored with `git checkout claude/issue-5763-sweepstore-per-key-try -- packages/auth/src/ActiveOrganizationStorage.ts`;
tree byte-identical to the committed fix (`git status` clean), full suite re-run green
afterward.

**A real-jsdom `Storage` gotcha found while writing the case, noted for the next
person:** `vi.spyOn(localStorage, 'removeItem').mockImplementation(...)` was observed to
survive this file's shared `afterEach(() => vi.restoreAllMocks())` — the very next test
measured the mock still installed on entry (`(localStorage.removeItem as any).mock !==
undefined` was `true`). Fixed by capturing the spy and calling `.mockRestore()`
explicitly in a `finally` inside the test that installs it, rather than relying on the
shared teardown for this particular spy target.

## Verification — union run at `8e1409881` (final commit, clean tree)

| check | result |
|---|---|
| `vitest run packages/auth/src/__tests__/sessionUserChangePurge-5664.test.tsx packages/auth/src/__tests__/activeOrgStorageFallback-5703.test.tsx` | exit 0 — 23 tests passed |
| `vitest run packages/auth/` | exit 0 — **24 files, 248 tests passed** (was 246 at #5764's baseline; +2 new here) |
| `pnpm --filter @object-ui/auth type-check` | exit 0 (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/auth lint` | exit 0 — `✖ 29 problems (0 errors, 29 warnings)`, same count as #5764's baseline, none in the changed files |
| `check-control-bytes` | exit 0 — `OK (scanned 4814 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | exit 0 — `2 source file(s) of 1 released package(s) changed … declares 1 changeset(s)` |
| `check-changeset-no-major` · `check-changeset-fixed` | exit 0 |

`@object-ui/auth` is vitest-aliased to `packages/auth/src`, so every run above exercises
the edited source directly — no `dist/` in the resolution path.

## Serial-note discharge (triage's note)

Triage's serial note said this shares `ActiveOrganizationStorage.ts` with #5731's
then-in-flight PR and to land after it or rebase. #5731's PR #5764 merged to `main` at
`0610ca74b` (2026-08-23, before this branch was cut from `origin/main` at `286dd8daa`),
so this branch already contains that fix — confirmed by reading the file on this base:
`removePersisted`'s read-back verdict and `ActiveOrganizationStorage._unremovedKeys` are
already present. Nothing to serialise behind.

## Out of scope

`AuthProvider.tsx`'s `purgeSignedOutClientCaches()` — the sign-out counterpart, which
purges `sessionStorage` metadata-seed-cache keys — has the identical shape: a `try`
wrapping the whole loop instead of each `removeItem`. Same defect class, different file,
different caller, and this card's own scope note rules out widening into a general
refactor of the module. Filed separately, unassigned: #5777.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_
