### PR TITLE
finding(timeline): dedup ObjectTimeline's useSafeObjectLabel onto the shared useSafeFieldLabel

### DIFF
--- a/.changeset/timeline-shared-safe-field-label-5623.md
+++ b/.changeset/timeline-shared-safe-field-label-5623.md
@@ -1,0 +1,8 @@
+---
+---
+
+Internal dedup: `ObjectTimeline` now uses the shared `useSafeFieldLabel` from
+`@object-ui/react` instead of its own local `useSafeObjectLabel` wrapper /
+`OBJECT_LABEL_FALLBACK` (objectui#5623). No exported symbol changed and the
+timeline's `fieldOptionLabel` call site behaves identically on both the
+bound and unbound i18n paths — no published behaviour changes.

--- a/packages/plugin-timeline/src/ObjectTimeline.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.test.tsx
@@ -23,7 +23,14 @@ vi.mock('@object-ui/react', async () => {
     // around the hook inside ObjectTimeline — which meant this mock's gap was
     // silently absorbed by production code that had a rules-of-hooks bug
     // (objectui#2879). With that removed, the mock has to be complete.
-    useObjectLabel: () => ({
+    //
+    // objectui#5623: ObjectTimeline now calls the SHARED `useSafeFieldLabel`
+    // (from `@object-ui/react`, re-exported from `@object-ui/i18n`) instead of
+    // a local `useObjectLabel`-based wrapper, so this mock has to cover that
+    // name instead — a mock without it would leave `useSafeFieldLabel`
+    // `undefined` (this `vi.mock` factory replaces the whole module, no
+    // `...actual` spread) and throw on the destructure.
+    useSafeFieldLabel: () => ({
       fieldOptionLabel: (_o: string, _f: string, _v: string, fallback: string) => fallback,
       translateOptions: (_o: string, _f: string, opts: unknown[]) => opts,
       fieldLabel: (_o: string, _f: string, fallback: string) => fallback,

--- a/packages/plugin-timeline/src/ObjectTimeline.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.tsx
@@ -8,34 +8,13 @@
 
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { DataSource, TimelineSchema, ListViewTimelineConfig } from '@object-ui/types';
-import { useDataScope, useNavigationOverlay, useObjectLabel } from '@object-ui/react';
+import { useDataScope, useNavigationOverlay, useSafeFieldLabel } from '@object-ui/react';
 import { NavigationOverlay } from '@object-ui/components';
 import { extractRecords, buildExpandFields, convertSortToQueryParams } from '@object-ui/core';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { z } from 'zod';
 import { TimelineRenderer } from './renderer';
 import { useTimelineTranslation } from './useTimelineTranslation';
-
-/**
- * Wrap `useObjectLabel` so the timeline keeps rendering when no
- * I18nProvider is mounted (standalone usage / unit tests).
- *
- * No try/catch: `useObjectLabel` delegates to the provider-safe
- * `useObjectTranslation` and never throws, and wrapping a hook call in
- * try/catch violates rules-of-hooks — a throw after other hooks ran would
- * desync hook order on the next render (objectui#2879, same class as
- * #2595/#2596). The nullish guard is the defensive default, mirroring
- * `useSafeFieldLabel` in `@object-ui/i18n`.
- */
-const OBJECT_LABEL_FALLBACK = {
-  fieldOptionLabel: (_o: string, _f: string, _v: string, fallback: string) => fallback,
-  translateOptions: <T extends { value: string; label: string }>(_o: string, _f: string, opts: T[]) => opts,
-  fieldLabel: (_o: string, _f: string, fallback: string) => fallback,
-} as any;
-
-function useSafeObjectLabel() {
-  return useObjectLabel() ?? OBJECT_LABEL_FALLBACK;
-}
 
 /**
  * Rows fetched when the author declared no `limit`.
@@ -230,7 +209,7 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
 
   const rawData = (props as any).data || boundData || fetchedData;
   const { t } = useTimelineTranslation();
-  const { fieldOptionLabel } = useSafeObjectLabel();
+  const { fieldOptionLabel } = useSafeFieldLabel();
 
   // Resolve TimelineConfig with backwards-compatible fallbacks (computed
   // outside the items-derivation block so we can also use them for

--- a/packages/plugin-timeline/src/__tests__/timeline-shared-safe-field-label-5623.test.tsx
+++ b/packages/plugin-timeline/src/__tests__/timeline-shared-safe-field-label-5623.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5623 — `ObjectTimeline` no longer hand-rolls its own
+ * `useSafeObjectLabel` / `OBJECT_LABEL_FALLBACK` (a 3-member fallback cast
+ * `as any`); it now calls the SHARED `useSafeFieldLabel` from `@object-ui/react`
+ * (re-exported from `@object-ui/i18n`), which carries a 5-member fallback.
+ *
+ * The acceptance check triage named for this dedup: the timeline's one call
+ * site (`fieldOptionLabel`, used to resolve the `status`/`priority` meta-chip
+ * labels) must behave IDENTICALLY on the bound and unbound paths. This file
+ * pins that directly against the REAL `@object-ui/react` / `@object-ui/i18n`
+ * exports — no `useObjectLabel`/`useSafeFieldLabel` mock — so a future
+ * regression in the shared hook's fallback shape would be caught here, not
+ * just in `packages/i18n`'s own tests.
+ *
+ * `./renderer` is deliberately NOT mocked either: the meta-chip text is read
+ * off the real `TimelineRenderer` output, the same surface an end user sees.
+ *
+ * NOTE ON ORDER (mirrors `ObjectChart.fieldOptionLabelRefetch.test.tsx`,
+ * objectui#5587): `createI18n` registers its instance as react-i18next's
+ * process-global (via `initReactI18next`), and `useTranslation` falls back to
+ * that global whenever no context supplies one. `react-i18next` itself is not
+ * a direct dependency of `@object-ui/plugin-timeline` (only transitively, via
+ * `@object-ui/i18n`), so this file cannot import `setI18n` to detach it
+ * itself — the UNBOUND case therefore runs FIRST, before any test in this
+ * file has created a bound instance. A leaked instance would make it a
+ * second, silent run of the bound case instead of failing.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { I18nProvider, createI18n } from '@object-ui/i18n';
+import { ObjectTimeline } from '../ObjectTimeline';
+
+// Only `useDataScope` / `useNavigationOverlay` are stubbed — everything else
+// (crucially `useSafeFieldLabel`) passes through to the real `@object-ui/react`
+// module, which re-exports it straight from `@object-ui/i18n`.
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await (importOriginal() as Promise<Record<string, unknown>>);
+  return {
+    ...actual,
+    useDataScope: () => undefined,
+    useNavigationOverlay: () => ({
+      isOverlay: false,
+      handleClick: vi.fn(),
+      selectedRecord: null,
+      isOpen: false,
+      close: vi.fn(),
+      setIsOpen: vi.fn(),
+      mode: 'overlay',
+      view: undefined,
+    }),
+  };
+});
+
+// `@object-ui/components` is deliberately left UNMOCKED: `./renderer` needs
+// its real `cva`-built primitives (`TimelineItem`, `TimelineMarker`, …) to
+// render the meta chip this file reads, and `NavigationOverlay` (the one
+// piece `ObjectTimeline` itself imports from this package) is never invoked
+// — the mocked `useNavigationOverlay` above returns `isOverlay: false`, and
+// `ObjectTimeline` only renders `<NavigationOverlay>` when that flag is true.
+
+const RAW_LABEL = 'Open';
+const LOCALIZED_LABEL = 'Open (localized)';
+
+const OBJECT_DEF = {
+  fields: {
+    status: { type: 'select', options: [{ value: 'open', label: RAW_LABEL }] },
+  },
+};
+
+const ROWS = [{ id: '1', name: 'Item 1', date: '2024-01-01', status: 'open' }];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => OBJECT_DEF),
+  };
+}
+
+const SCHEMA = { type: 'object-timeline', objectName: 'lead', titleField: 'name', dateField: 'date' };
+
+/** The status meta-chip renders as a `<span>` whose text is the resolved label. */
+async function renderTimelineAndReadChip(wrap: (el: React.ReactElement) => React.ReactElement) {
+  const props = { schema: SCHEMA, data: ROWS, dataSource: makeDataSource() } as unknown as React.ComponentProps<
+    typeof ObjectTimeline
+  >;
+  render(wrap(<ObjectTimeline {...props} />));
+  // The status chip only appears once `objectDef` has resolved asynchronously
+  // (fetched from `dataSource.getObjectSchema`) and the field-options memo has
+  // re-run — wait for its own text rather than `Item 1`, which is present from
+  // the very first render.
+  await waitFor(() => expect(screen.queryByText(RAW_LABEL) || screen.queryByText(LOCALIZED_LABEL)).not.toBeNull());
+  return (screen.queryByText(RAW_LABEL) ?? screen.queryByText(LOCALIZED_LABEL))!.textContent;
+}
+
+describe('ObjectTimeline — fieldOptionLabel via the shared useSafeFieldLabel (objectui#5623)', () => {
+  it('resolves to the raw metadata label with NO I18nProvider mounted (unbound path)', async () => {
+    const label = await renderTimelineAndReadChip((el) => el);
+    expect(label).toBe(RAW_LABEL);
+  });
+
+  it('resolves to the SAME raw metadata label with an I18nProvider mounted but no matching translation (bound path)', async () => {
+    // A real, bound i18next instance — but its bundle has nothing under
+    // `fieldOptions.lead.status.open`, so `resolve()` still falls through to
+    // the fallback exactly as the unbound path does. This is the case the
+    // acceptance check names: bound and unbound must be IDENTICAL for this
+    // call site when there is nothing for the bound path to find either.
+    const instance = createI18n({ defaultLanguage: 'en', detectBrowserLanguage: false });
+    instance.addResourceBundle('en', 'translation', { crm: { objects: { lead: { label: 'Lead' } } } }, true, true);
+
+    const label = await renderTimelineAndReadChip((el) => (
+      <I18nProvider instance={instance} persistLanguage={false}>
+        {el}
+      </I18nProvider>
+    ));
+    expect(label).toBe(RAW_LABEL);
+  });
+
+  it('still resolves a REAL translation when one is bound — proving the shared hook is genuinely wired, not just harmlessly inert', async () => {
+    const instance = createI18n({ defaultLanguage: 'en', detectBrowserLanguage: false });
+    instance.addResourceBundle(
+      'en',
+      'translation',
+      {
+        crm: {
+          objects: { lead: { label: 'Lead' } },
+          fieldOptions: { lead: { status: { open: LOCALIZED_LABEL } } },
+        },
+      },
+      true,
+      true,
+    );
+
+    const label = await renderTimelineAndReadChip((el) => (
+      <I18nProvider instance={instance} persistLanguage={false}>
+        {el}
+      </I18nProvider>
+    ));
+    expect(label).toBe(LOCALIZED_LABEL);
+  });
+});


### PR DESCRIPTION
Fixes #5623

## What

`ObjectTimeline.tsx` hand-rolled its own `useSafeObjectLabel` wrapper: a
docstring near-verbatim from the shared hook, a 3-member `OBJECT_LABEL_FALLBACK`
cast `as any`, and `useSafeObjectLabel() { return useObjectLabel() ?? OBJECT_LABEL_FALLBACK; }`.
Its single consumer (`const { fieldOptionLabel } = useSafeObjectLabel();`) is
replaced with the shared `useSafeFieldLabel` from `@object-ui/react`
(re-exported from `@object-ui/i18n`), and the local docstring/const/function
(21 lines) are deleted.

- `packages/plugin-timeline/src/ObjectTimeline.tsx` — swap the import
  (`useObjectLabel` → `useSafeFieldLabel`), delete the local wrapper, update
  the call site.
- `packages/plugin-timeline/src/ObjectTimeline.test.tsx` — its `@object-ui/react`
  mock replaces the whole module (no `...actual` spread), so it needed
  `useSafeFieldLabel` added in place of the now-unused `useObjectLabel` entry
  or the destructure would throw on `undefined`.
- New test:
  `packages/plugin-timeline/src/__tests__/timeline-shared-safe-field-label-5623.test.tsx` —
  pins the triage-named acceptance check directly against the REAL
  `@object-ui/react` / `@object-ui/i18n` exports (no `useSafeFieldLabel` mock):
  the timeline's one call site (`fieldOptionLabel`, used to resolve the
  `status`/`priority` meta-chip labels) resolves to the **same** raw metadata
  label with no `I18nProvider` mounted (unbound) and with one mounted but
  carrying no matching translation (bound) — and a third case confirms a real
  translation resolves when one *is* bound, so the equivalence isn't just
  because the resolver is inert.

## Why this is safe (the `as any` cast erased a real disagreement)

The local fallback was 3 members (`fieldOptionLabel`, `translateOptions`,
`fieldLabel`); the shared `SAFE_FIELD_LABEL_FALLBACK` in
`packages/i18n/src/useObjectLabel.ts` is 5 (adds `sectionLabel`,
`actionLabel`). Per PR #5585, `useObjectLabel()` never actually returns
nullish any more (its memo holds on both the bound and no-instance paths), so
in both the old and new code the `?? FALLBACK` branch is dead in practice —
which is exactly why swapping the fallback SHAPE underneath it is safe for
this one call site. Confirmed directly (see Testing) rather than asserted.

## Testing

Reverse-verification, run while writing this: restored `ObjectTimeline.tsx`
to its pre-fix state (`git checkout HEAD~1 -- packages/plugin-timeline/src/ObjectTimeline.tsx`,
i.e. the local `useSafeObjectLabel`/`OBJECT_LABEL_FALLBACK`) with the NEW test
file in place, and re-ran it — **same 3/3 pass**, which is the direct proof of
the equivalence claim (not merely "didn't regress"): the call site behaves
identically whether reached through the local 3-member fallback or the shared
5-member one. Then restored the fix by checking out
`claude/issue-5623-timeline-shared-safe-field-label`'s version of the file
(`git status` clean afterward).

```
pnpm exec vitest run packages/plugin-timeline/ --maxWorkers=2
 Test Files  9 passed (9)
      Tests  68 passed (68)

pnpm --filter @object-ui/plugin-timeline type-check   # tsc --noEmit && tsc -p tsconfig.test.json
EXIT=0

pnpm --filter @object-ui/plugin-timeline build        # vite build
EXIT=0
```

Targeted `eslint --no-inline-config` on the touched files: 0 errors, 41
warnings — all pre-existing (`@typescript-eslint/no-explicit-any` on
long-standing `any` props typing, `react-hooks/exhaustive-deps`), confirmed
by linting the pre-fix `ObjectTimeline.tsx` for comparison: 32 warnings there
vs 31 on the fixed file — one FEWER, the `as any` cast this PR removes.

Dependency closure built first (`pnpm --filter '@object-ui/plugin-timeline^...' build`),
exit 0.

`node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs` /
`check-control-bytes.mjs`: all pass; changeset has empty frontmatter per
`.changeset/README.md`'s own "DON'T create a changeset for internal
refactoring with no API changes" — the removed symbols
(`useSafeObjectLabel`, `OBJECT_LABEL_FALLBACK`) were never exported.

Neither `useSafeObjectLabel` nor `OBJECT_LABEL_FALLBACK` had any other
reference anywhere in the repo (grepped `packages/`).

## Scope

Per triage (2026-08-22) and the claim comment: mechanical dedup only. #5625
(the pivot-table ref workaround) shares the #5587 lineage but has its own
behaviour surface and stays a separate card, out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_