### PR TITLE
feat(types): retire 'agenda' from CalendarViewMode and the zod enum

### DIFF
--- a/.changeset/calendar-view-mode-agenda-retired-5740.md
+++ b/.changeset/calendar-view-mode-agenda-retired-5740.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/types': minor
+---
+
+`'agenda'` leaves `CalendarViewMode` and the zod `CalendarViewModeSchema`
+(objectui#5740 — the value-level residue of objectui#5667's key-level
+convergence of `CalendarViewSchema` on the registered `calendar-view`
+renderer's measured read set; ADR-0049 enforce-or-remove).
+
+The union declared a value nothing enforced: the registered renderer's `view`
+input declares `enum: ['month','week','day']`, `resolveAuthoredView` resolves
+any off-enum value — `'agenda'` included — to `undefined` (the component's
+`'month'` default), and `CalendarView` renders no agenda view. An author
+writing the type-legal, zod-valid `view: 'agenda'` got a month calendar with
+no error or warning. No in-repo, example, or catalog app authors
+`view: 'agenda'` (measured during objectui#5667's sweep and re-measured for
+this change, including the objectstack tree).
+
+**This narrows the accept set — unlike #5667's key retirements, which created
+no new rejections.** `view` is a declared key, and declared keys are validated
+even under `.passthrough()`, so `view: 'agenda'` is now a **validation error
+that previously parsed green** (an `invalid_value` issue on the `view` path,
+offering `month`/`week`/`day`). Undeclared keys still pass through unchanged.
+Breaking on the published zod surface; ships as `minor` per this repo's
+version-alignment policy (majors track `@objectstack`).
+
+The runtime boundary is unchanged: an off-union `view` in raw metadata still
+falls back to the component's `'month'` default at the renderer, and the
+registry input already declared the three-value enum. Docblocks, the schema
+reference table, and the zod `describe` no longer teach an `'agenda'`
+fallback.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -1076,7 +1076,7 @@ authored `events` is dropped by design, objectui#4433).
 | `endDateField` | `string` | Record field for the event end date/time. Default `"end"`. |
 | `allDayField` | `string` | Record field for the all-day flag. Default `"allDay"`. |
 | `colorField` | `string` | Record field for the event color. Default `"color"`. |
-| `view` | `CalendarViewMode` | View mode: `"month"`, `"week"`, `"day"`. Any other value falls back to `"month"`. |
+| `view` | `CalendarViewMode` | View mode: `"month"`, `"week"`, `"day"` — the full union. `"agenda"` was retired in objectui#5740 and now fails validation. Default `"month"`. |
 | `currentDate` | `string \| Date` | Initial calendar date — an ISO date string when authored as JSON. |
 | `allowCreate` | `boolean` | Show the "New event" affordance; clicking it dispatches a `create` action. Default `false`. |
 | `onEventClick` | `function` | Host-only: forwarded when a React host supplies a function; authored JSON cannot produce one. |

--- a/packages/types/src/__tests__/calendar-view-mode-agenda-retired.test.ts
+++ b/packages/types/src/__tests__/calendar-view-mode-agenda-retired.test.ts
@@ -1,0 +1,117 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — `'agenda'` leaves `CalendarViewMode` and
+ * `CalendarViewModeSchema` (objectui#5740, the value-level residue of
+ * objectui#5667's key-level convergence on the `calendar-view` renderer's
+ * measured read set).
+ *
+ * The declared union named `'agenda'`, but the registered renderer's `view`
+ * input declares `enum: ['month','week','day']`, `resolveAuthoredView`
+ * resolves any off-enum value to `undefined` (the component's `'month'`
+ * default), and `CalendarView` renders no agenda view — so an author writing
+ * the type-legal, zod-valid `view: 'agenda'` got a month calendar with no
+ * error. Declared ≠ enforced, on a published surface (ADR-0049).
+ *
+ * ⚠️ Unlike #5667's key retirements, this one NARROWS the accept set: `view`
+ * is a DECLARED key, and declared keys are validated even under
+ * `.passthrough()`, so `view: 'agenda'` — which parsed green before — is now
+ * a validation error. That is exactly why the zod half is pinned by the
+ * REFUSAL ENVELOPE (a `view`-path `invalid_value` issue naming the surviving
+ * vocabulary) rather than a bare `success === false`, and why the passthrough
+ * control below pins that the rejection is declared-key validation, not a
+ * strictness change. The TS half erases at runtime, so it is pinned with
+ * `@ts-expect-error`, which is real enforcement here because
+ * `packages/types/tsconfig.test.json` is chained from this package's
+ * `type-check` script (#3009).
+ *
+ * The runtime resolver is deliberately NOT changed: an off-union value in raw
+ * metadata still falls back to `'month'` at the renderer boundary
+ * (`calendar-view-renderer.propsContract.test.tsx` pins that branch).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CalendarViewModeSchema, CalendarViewSchema } from '../zod/complex.zod.js';
+import type { CalendarViewMode } from '../complex.js';
+
+/** The retired value, and the survivors the renderer actually renders. */
+const RETIRED = 'agenda';
+const SURVIVORS = ['month', 'week', 'day'] as const;
+
+describe('CalendarViewModeSchema — the shared enum no longer offers the retired value', () => {
+  it('is exactly the rendered set', () => {
+    expect(CalendarViewModeSchema.options).toEqual([...SURVIVORS]);
+  });
+
+  it('rejects the retired value with an invalid_value issue', () => {
+    const result = CalendarViewModeSchema.safeParse(RETIRED);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toHaveLength(1);
+    expect(result.error.issues[0].code).toBe('invalid_value');
+  });
+});
+
+describe('CalendarViewSchema.view — the NEW rejection this retirement creates', () => {
+  it("rejects `view: 'agenda'` on the `view` path, where it previously parsed green", () => {
+    const result = CalendarViewSchema.safeParse({ type: 'calendar-view', view: RETIRED });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    // The envelope, not just the verdict: exactly one issue, on the `view`
+    // path, coded as a closed-vocabulary violation. A bare `success === false`
+    // would also pass if the node had been rejected for an unrelated reason.
+    //
+    // The offending value is deliberately NOT asserted to appear in the
+    // message: measured on zod 4, an `invalid_value` issue carries the ALLOWED
+    // `values` and no echo of the input.
+    const viewIssues = result.error.issues.filter((i) => i.path.join('.') === 'view');
+    expect(viewIssues).toHaveLength(1);
+    expect(viewIssues[0].code).toBe('invalid_value');
+
+    // The shrink, read off the refusal: the retired value is gone from the
+    // offered vocabulary and every survivor is still in it.
+    const offered = (viewIssues[0] as { values?: unknown[] }).values ?? [];
+    expect(offered).not.toContain(RETIRED);
+    for (const survivor of SURVIVORS) expect(offered).toContain(survivor);
+  });
+
+  it('still accepts every rendered view mode in full', () => {
+    // Full green parses, not merely "no `view` issue": a value-level shrink
+    // that quietly invalidated a survivor would otherwise go unseen.
+    for (const survivor of SURVIVORS) {
+      const result = CalendarViewSchema.safeParse({ type: 'calendar-view', view: survivor });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('passthrough control: an UNDECLARED key still parses — the rejection above is declared-key validation, not a strictness change', () => {
+    // `BaseSchema` is `.passthrough()`. This pin keeps the two facts apart:
+    // unknown keys pass (unchanged since #5667), while a declared key's value
+    // is validated (the new rejection above). If this control ever reds, the
+    // schema's strictness changed — a different contract decision than #5740.
+    const result = CalendarViewSchema.safeParse({
+      type: 'calendar-view',
+      someUndeclaredKey: RETIRED,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('the published TS twin no longer offers the retired value', () => {
+  it('`CalendarViewMode` rejects it at compile time and keeps the survivors', () => {
+    // @ts-expect-error — 'agenda' left the union (objectui#5740).
+    const retired: CalendarViewMode = RETIRED;
+    expect(retired).toBe(RETIRED);
+
+    const survivors: CalendarViewMode[] = [...SURVIVORS];
+    expect(survivors).toEqual([...SURVIVORS]);
+  });
+});

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -127,9 +127,14 @@ export interface KanbanSchema extends BaseSchema {
 }
 
 /**
- * Calendar view mode
+ * Calendar view mode — the registered `calendar-view` renderer's rendered set.
+ *
+ * `'agenda'` was retired from this union (objectui#5740): no view ever
+ * rendered it — the renderer resolved it to the `'month'` default — and no
+ * measured app authors it (ADR-0049 enforce-or-remove, the value-level
+ * residue of objectui#5667's key-level convergence).
  */
-export type CalendarViewMode = 'month' | 'week' | 'day' | 'agenda';
+export type CalendarViewMode = 'month' | 'week' | 'day';
 
 /**
  * Calendar event
@@ -225,9 +230,9 @@ export interface CalendarViewSchema extends BaseSchema {
   /**
    * Calendar view mode.
    *
-   * The registered renderer renders `'month' | 'week' | 'day'` and falls back
-   * to `'month'` for any other value — including `'agenda'`, which
-   * {@link CalendarViewMode} still names.
+   * {@link CalendarViewMode} equals the renderer's rendered set since
+   * objectui#5740 retired `'agenda'`; at runtime the renderer still resolves
+   * any off-union value in raw metadata to the `'month'` default.
    * @default 'month'
    */
   view?: CalendarViewMode;

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -66,9 +66,13 @@ export const KanbanSchema = BaseSchema.extend({
 });
 
 /**
- * Calendar View Mode
+ * Calendar View Mode — the registered renderer's rendered set.
+ *
+ * `'agenda'` was retired (objectui#5740): no view ever rendered it, and no
+ * measured app authors it. `view` is a DECLARED key, so this retirement is a
+ * new rejection — see the accept-set note on {@link CalendarViewSchema}.
  */
-export const CalendarViewModeSchema = z.enum(['month', 'week', 'day', 'agenda']);
+export const CalendarViewModeSchema = z.enum(['month', 'week', 'day']);
 
 /**
  * Calendar Event Schema
@@ -97,6 +101,12 @@ export const CalendarEventSchema = z.object({
  * `BaseSchema` is `.passthrough()`, so the retired keys are not REJECTED here
  * — they are simply no longer declared or type-checked. The material accept
  * change is that `events` is no longer required.
+ *
+ * Value-level residue (objectui#5740): `'agenda'` left
+ * `CalendarViewModeSchema`. Unlike the key retirements above, this IS a new
+ * rejection — `view` is a declared key, and declared keys are validated even
+ * under `.passthrough()` — so `view: 'agenda'`, which parsed green before,
+ * now fails with an `invalid_value` issue on the `view` path.
  */
 export const CalendarViewSchema = BaseSchema.extend({
   type: z.literal('calendar-view'),
@@ -118,7 +128,7 @@ export const CalendarViewSchema = BaseSchema.extend({
   allDayField: z.string().optional().describe("Record field for the all-day flag (default 'allDay')"),
   colorField: z.string().optional().describe("Record field for the event color (default 'color')"),
   view: CalendarViewModeSchema.optional().describe(
-    "View mode (the renderer renders 'month' | 'week' | 'day'; other values fall back to 'month')",
+    "View mode — 'month' | 'week' | 'day', the renderer's rendered set ('agenda' was retired: objectui#5740)",
   ),
   currentDate: z
     .union([z.string(), z.date()])


### PR DESCRIPTION
Fixes #5740

## Direction

Option A — narrow the value union — **inherited from the maintainer's 2026-08-22 ruling on #5667** ("the renderer is authoritative; `CalendarViewSchema` converges on the measured read set"), of which this card is the value-level residue on the same renderer. Recorded in the claim comment on #5740 as a veto window; both stop conditions were re-measured and hold (below). Not a fresh adjudication.

## What changed

- `CalendarViewMode` (`packages/types/src/complex.ts`) is now `'month' | 'week' | 'day'`; `CalendarViewModeSchema` (`packages/types/src/zod/complex.zod.ts`) is now `z.enum(['month', 'week', 'day'])`.
- Docblocks on both faces, the zod `describe` on `view`, and the `CalendarViewSchema` table row in `content/docs/api/schema-reference.md` no longer teach an `'agenda'` fallback.
- New pin: `packages/types/src/__tests__/calendar-view-mode-agenda-retired.test.ts` (modeled on `owner-retired-contract-twins.test.ts`) — refusal envelope (`invalid_value` on the `view` path, offered vocabulary asserted), full-green survivors, passthrough control, `@ts-expect-error` TS twin (enforced via `tsconfig.test.json` chained from `type-check`).
- Changeset: `minor` for `@object-ui/types` (majors track `@objectstack`), body states the breaking semantics.
- **Unchanged on purpose:** `resolveAuthoredView` and the registry input (`enum: ['month','week','day']` already declared) — the runtime boundary still resolves any off-union value in raw metadata to the `'month'` default, and `calendar-view-renderer.propsContract.test.tsx`'s off-enum fixture still pins that branch (it authors `view: 'agenda'` through an `as never` cast; after this change that value is simply another off-enum spelling, which is exactly what the fixture represents).

## ⚠️ This narrows the accept set

Unlike #5667's key retirements (no new rejections under `.passthrough()`), `view` is a **declared** key and declared keys are validated even under `.passthrough()`. Measured on this tree before the change: `CalendarViewSchema.safeParse({type:'calendar-view', view:'agenda'})` → `success: true`. After: `success: false`, exactly one `invalid_value` issue on the `view` path offering `month`/`week`/`day`. Undeclared keys still pass (pinned by the passthrough control test). Clause-② dispatch at tier per the claim comment; no compensating label exists in this repo.

## Measurements (stop conditions and reachability)

- **Zero authors of `view: 'agenda'`**: swept objectui (all file types, including `examples/`, catalog, docs) and the full objectstack tree — the only occurrences are the declarations themselves and the props-contract fixture that pins the off-enum drop branch. Stop condition 1 holds.
- **Parent's reason is general, not branch-specific**: the renderer's registered input declares `['month','week','day']` (`calendar-view-renderer.tsx:451`), `resolveAuthoredView` drops off-enum values (`:115`), `CalendarView`'s own prop and switcher are three-valued, `ObjectCalendar` reads `defaultView` as three-valued. Stop condition 2 holds.
- **`CalendarViewMode` reachability**: consumers are `CalendarViewSchema.view` and the HOST-ONLY `onViewChange` parameter — both on this same renderer contract; no other package imports the symbol (narrowing a callback parameter is contravariance-safe for hosts). `CalendarViewModeSchema`'s only consumer is the `view` key. The `defaultView` enums in `objectql.ts` / `objectql.zod.ts` are textually independent inline unions, not consumers — same defect class on a different declaration, filed separately rather than smuggled in here.

## File surface note

The claim's file surface was `packages/types/src/complex.ts`, `packages/types/src/zod/complex.zod.ts`, `packages/plugin-calendar/**`, changeset. This PR additionally touches **one row of `content/docs/api/schema-reference.md`** (line ~1079) — the docs-table copy of the fallback the dispatch explicitly required reconciling ("a retired value still described as 'falls back to month' is a new contradiction"). Declared here as the dispatch-mandated increment; no `packages/plugin-calendar` source needed changing (registry side already correct).

## Verification (union re-run at `e168a0a43`, the PR head)

- `pnpm --filter @object-ui/types type-check` && `pnpm --filter @object-ui/plugin-calendar type-check` — green (scripts echoed).
- `pnpm exec vitest run packages/types/ packages/plugin-calendar/` from repo root — `Test Files 56 passed (56)`, `Tests 590 passed (590)`.
- Ablation (predicted before running): restored the old enum from `origin/main` (mutation anchored on disk — enum-line grep 0→1), reran the new pin — `Tests 3 failed | 3 passed (6)`, exactly the predicted split (rejection legs red, survivors/passthrough green); trap-restored, restore confirmed by grep (1→0) and clean `git status`.
- Rebuilt-`.d.ts` reverse verification: tsc probe against `packages/types/dist` — `error TS2322: Type '"agenda"' is not assignable to type 'CalendarViewMode'`; the `'week'` control compiles clean.
- Gates: `check:control-bytes` ✅, `check:spec-symbols` ✅, `check:doc-types` ✅ ("Every documented component type is registered."), `check-changeset-presence` ✅, `check-changeset-no-major` ✅, `check-changeset-fixed` ✅, `check:esm-specifiers` ✅, `@object-ui/types` lint 0 errors.
- **Declared narrowing:** `check:doc-snippets` was not concluded locally — its preflight red is the known unbuilt-closure gauge ("The snippet program was NOT run"; it kept naming more unbuilt packages after one bounded build round). The edited docs line is a prose table row, not a snippet; CI's built run is the verdict.

## Overlap scan

`packages/types` is serialised: #5494 (`ReferenceRailEntry`) is queued behind this card and not dispatched; this PR does not touch that surface. #5494 remains open and is not addressed here.

_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_