### PR TITLE
fix(app-shell): invert the nav-selection -> AppNavInspector edge

### DIFF
--- a/.changeset/nav-selection-root-keys-edge-5600.md
+++ b/.changeset/nav-selection-root-keys-edge-5600.md
@@ -1,0 +1,25 @@
+---
+---
+
+Internal layering fix, behaviour-unchanged: publishes nothing, declared explicitly
+with an empty frontmatter rather than left undeclared.
+
+Inverts the dependency edge objectui#5600 found: `nav-selection.ts` — otherwise pure
+URL-parsing plumbing (`parseSurfaceParam` / `formatSurfaceParam` / `parseNavSelParam`
+and friends) — statically imported `APP_NAV_ROOT_KEYS` from the 510-line
+`AppNavInspector.tsx`, so every consumer of the URL helpers (including two small
+utilities, `console/ai/artifactStudioPath.ts` and, transitively via
+`useSurfaceDeepLink.ts`, the studio-design surface) pulled a React inspector
+component into their static import graph for one array of root keys.
+
+`APP_NAV_ROOT_KEYS` (`['nav', 'navigation', 'tabs', 'items', 'menu']`) is a plain
+string-literal array — it describes nav SHAPE, not the inspector — so it now lives in
+`nav-selection.ts` instead. `AppNavInspector.tsx` never read the array itself, only
+re-exported it (`export const APP_NAV_ROOT_KEYS = ROOT_KEYS;` as its last line), so
+the fix is a straight move with no back-import needed on that side.
+
+Verified structurally rather than by reading the import line: a BFS over static
+(non-type, non-dynamic) relative imports from `nav-selection.ts` and the other
+non-test importers no longer reaches `AppNavInspector.tsx` (158 files visited, target
+not found), where the same walk over the pre-fix tree found it in 6 files via
+`nav-selection.ts -> AppNavInspector.tsx` directly.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/AppNavInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/AppNavInspector.tsx
@@ -63,8 +63,6 @@ interface NavItem {
   [k: string]: unknown;
 }
 
-const ROOT_KEYS = ['nav', 'navigation', 'tabs', 'items', 'menu'];
-
 type Hop = { key: string; index: number };
 
 /** Parse "nav[0].children[2]" → [{key:'nav', index:0}, {key:'children', index:2}]. */
@@ -506,5 +504,3 @@ export function AppNavInspector({ selection, draft, name, onPatch, onClearSelect
     </InspectorShell>
   );
 }
-
-export const APP_NAV_ROOT_KEYS = ROOT_KEYS;

--- a/packages/app-shell/src/views/metadata-admin/nav-selection.ts
+++ b/packages/app-shell/src/views/metadata-admin/nav-selection.ts
@@ -11,7 +11,16 @@
  * the two at the designer boundary; positions never leave component state.
  */
 
-import { APP_NAV_ROOT_KEYS } from './inspectors/AppNavInspector.js';
+/**
+ * Root keys apps accept nav content under (#5600). This describes nav
+ * SHAPE, not the `AppNavInspector` editor, so it lives here rather than
+ * being re-exported out of that 500+ line React component — this module
+ * is pure string/array plumbing and stays importable without dragging a
+ * Radix/dnd-kit-backed inspector into every URL-parsing consumer's graph.
+ * `AppNavInspector`'s own copy never did anything but re-export this
+ * array, so it was deleted there rather than re-imported.
+ */
+export const APP_NAV_ROOT_KEYS = ['nav', 'navigation', 'tabs', 'items', 'menu'];
 
 /** Search param carrying the designer's selected element. */
 export const DESIGNER_SEL_PARAM = 'sel';


### PR DESCRIPTION
Fixes #5600

## What changed

`nav-selection.ts` (pure URL-parsing plumbing — `parseSurfaceParam` / `formatSurfaceParam`
/ `parseNavSelParam` and friends) statically imported `APP_NAV_ROOT_KEYS` from the
510-line `AppNavInspector.tsx`, so every consumer of the URL helpers pulled a
Radix/dnd-kit-backed React inspector component into its static import graph for one
array of root keys.

`APP_NAV_ROOT_KEYS` (`['nav', 'navigation', 'tabs', 'items', 'menu']`) is a plain
string-literal array — it describes nav SHAPE, not the editor — so it now lives in
`nav-selection.ts`. Checked whether `AppNavInspector.tsx` needed to import it back:
grepping the file for any use of `ROOT_KEYS` beyond its declaration and the trailing
`export const APP_NAV_ROOT_KEYS = ROOT_KEYS;` found none — the component never reads
the array, it only re-exported it. So the fix is a straight move, no back-import: the
declaration + export are deleted from `AppNavInspector.tsx` entirely, and nothing
outside this repo depends on the old path (no barrel/index re-export surfaces it, and
`@object-ui/app-shell`'s package `exports` field never touched it).

## Re-measuring the card's importer list

The card lists five non-test importers of `nav-selection`, including `utils/appRoute.ts`.
Re-checking against current `main`: `appRoute.ts` has **no import statements at all** —
its one `nav-selection` hit is a doc-comment mention (`` `?surface=` restore honors (see
`nav-selection.ts`) ``), not an import. The actual non-test importer set today is four
files: `views/studio-design/useSurfaceDeepLink.ts`, `views/studio-design/StudioDesignSurface.tsx`,
`views/metadata-admin/ResourceEditPage.tsx`, `console/ai/artifactStudioPath.ts`. The
small-utility case the card makes still holds — `artifactStudioPath.ts` is exactly that —
just naming one file, not two.

## Proving the edge is gone (not by reading the import line)

A `grep` can't see a transitive edge, so this is verified structurally: a small BFS
script (`trace-static-imports.mjs`, not part of this PR — a throwaway verification tool)
walks STATIC (non-`import type`, non-dynamic-`import()`) relative imports from the four
importers above, confined to `packages/app-shell/src`, and checks whether it ever
reaches `AppNavInspector.tsx`.

- **Pre-fix** (`origin/main`, in a scratch comparison worktree): reached in 6 files
  visited — `nav-selection.ts -> AppNavInspector.tsx` directly.
- **Post-fix** (this branch): 158 files visited, target never reached.

Bare package specifiers (workspace packages, npm deps) aren't traversed — they're
separate, already-built chunk boundaries, which is the right cut here since
`AppNavInspector.tsx` lives in-package and was only reachable via the one relative
import this PR removes.

## Eager-closure budget (bonus, not the bar per triage)

Built `apps/console` and ran `scripts/check-eager-closure-budget.mjs` before and after,
using `git checkout HEAD~1 -- <2 files>` / `git checkout HEAD -- <2 files>` to swap
between pre- and post-fix content in place (same install, same dependency closure, so
the only variable is these two files) rather than a second full `pnpm install`:

| | gzipped | headroom (budget 3990.2 KB) |
|---|---|---|
| pre-fix | 3918.5 KB | 71.7 KB |
| post-fix | 3918.4 KB | 71.8 KB |

`metadata-admin-*.js` shrank 175.8 KB -> 175.6 KB. A ~100-byte-gzipped reclaim — the
array itself is tiny and this is well within measurement noise. Reported as asked;
matches the triage note that a reclaim here is a bonus, not the acceptance bar. The bar
is the edge being gone, shown above.

## Tests

All run via `pnpm exec vitest run <paths>` from the repo root (this repo's
`vitest-invocation-guard` requires it):

- Directly-affected: `nav-selection.surface.test.ts`, `useSurfaceDeepLink.test.ts`,
  `appRoute.test.ts`, `artifactStudioPath.test.ts`, `nav-target.test.ts`,
  `StudioDesignSurface.navItemInspector.test.tsx` — **77 passed (6 files)**.
- `ResourceEditPage.*.test.tsx` (6 files covering the fifth importer) — passed as part
  of an earlier 8-file/40-test run alongside `StudioDesignSurface.navItemInspector.test.tsx`.
- `pnpm --filter '@object-ui/app-shell^...' build` (dependency closure) and
  `pnpm --filter '@object-ui/app-shell' build` (`tsc`) both exit 0.
- `pnpm exec eslint packages/app-shell/src/views/metadata-admin/nav-selection.ts
  packages/app-shell/src/views/metadata-admin/inspectors/AppNavInspector.tsx
  --no-inline-config` — 0 errors (18 pre-existing `any`/hooks warnings, unrelated to
  this diff, all on lines this PR doesn't touch).
- `node scripts/check-changeset-presence.mjs` — passes; empty-frontmatter changeset
  declares this behaviour-unchanged (no release).

No behaviour change — `AppNavInspector`'s root-key handling and `nav-selection`'s
parsing/formatting functions are byte-identical in logic, only the constant's home
module moved.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_