### PR TITLE
Refresh the lockfile to @objectstack/* 17.2.0 — fs stops reaching the browser bundle

### DIFF
--- a/.changeset/spec-refresh-17-2-0-5668.md
+++ b/.changeset/spec-refresh-17-2-0-5668.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/console': patch
+---
+
+Refreshes the lockfile so every `@objectstack/*` package resolves at `17.2.0` — `spec`, `client`, `core`, `formula`, `lint` and `sdui-parser` move in lockstep (a split resolution is what produced the dual-version spec graph that reddened `check:spec-symbols` in this repo's history), and no `17.1.0` resolution remains.
+
+**The docs-site and console builds stop pulling a Postgres connection-string parser toward the browser bundle.** `@objectstack/spec@17.1.0` imported `pg-connection-string` at the top level of `dist/index.mjs` with no `browser` export condition, so `apps/site`'s production build failed with `Module not found: Can't resolve 'fs'` on every route that reaches `@object-ui/components` from a client component — red on `main` since 2026-08-22 (objectui#5668). `17.2.0` ships the objectstack#11072 fix: `.`, `./data`, `./system`, `./kernel` and `./cloud` now carry `browser` conditions pointing at schema-free `dist/browser/**` bundles, and the site build is back to `Tasks: 29 successful, 29 total`.
+
+The refresh is lockfile-only — every manifest already declared `^17.0.0`, which admits `17.2.0`, so no dependency range changed. No shipped source moves: the two in-repo adaptations are a drift-guard test and a CI gate, both forced by `17.2.0` retiring the spec's theme module (objectstack#10485) exactly as the objectui#5716 localization predicted — its `Theme`/`ThemeMode`/`ColorPalette` ALLOW entries in `check:spec-symbols` went stale and were deleted, and the parity test now pins the vacancy (the spec re-publishing a theme name is a loud collision) instead of a spec leg that no longer exists.

--- a/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
+++ b/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
@@ -15,9 +15,14 @@
  *
  *  - **Derived** (`ActionParam`, `CreateExportJobRequest`,
  *    `CreateExportJobResult`, `ImportRowResult`, `NavigationArea`,
- *    `NavigationAreaSchema`, `Theme`): the spec now supplies the keys, so the
+ *    `NavigationAreaSchema`): the spec now supplies the keys, so the
  *    risk is no longer drift but a divergence outliving its reason, or a local
  *    key quietly reclaiming a name the spec owns. Asserted in both directions.
+ *    (`Theme` was in this list until `@objectstack/spec` 17.2.0 retired its
+ *    whole theme module — objectstack#10485 / PR objectstack#10695. Under the
+ *    objectui#5716 ruling, option A, this package now OWNS the vocabulary, so
+ *    `Theme`/`ThemeMode`/`ColorPalette` moved to the vacancy-pinned rows
+ *    below, the same road `GestureType`/`GestureConfig` travelled.)
  *  - **Renamed** (`FileMetadata`, `GestureConfig`, `GestureType`,
  *    `OfflineConfig`, `PageRegion`, `PageRegionSchema`, `ResponsiveConfig`,
  *    `WidgetManifest`, `WidgetSource`): nine genuine coincidences — same word,
@@ -50,15 +55,6 @@ import type {
   ActionParamSchema as SpecActionParamSchema,
   I18nLabel as SpecI18nLabel,
   NavigationArea as SpecNavigationArea,
-  // Re-pointed BY SIDE on the rc.6 bump (objectui#4167), not by name.
-  // Up to rc.5 the spec published `Theme` (= `z.infer`) alongside `ThemeInput`
-  // (= `z.input`); rc.6 retired every `…Input` alias and moved the bare name
-  // onto the INPUT side, so `Theme` is now `z.input` and `ThemeParsed` is the
-  // `z.infer` side. Following the old NAMES here would have swapped both pins
-  // silently — which is why `ThemeInput` became `Theme` and `Theme` became
-  // `ThemeParsed`, rather than either binding staying where it was written.
-  Theme as SpecThemeInput,
-  ThemeParsed as SpecThemeParsed,
 } from '@objectstack/spec/ui';
 import { NavigationAreaSchema } from '../zod/app.zod.js';
 import type { NavigationArea, NavigationItem } from '../app.js';
@@ -280,34 +276,23 @@ describe('NavigationArea derives from the spec', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Theme — derived (re-export of the spec's AUTHORING shape)
+// Theme — owned locally since the spec's theme retirement (objectui#5716)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Theme is the spec AUTHORING theme, not the parsed one', () => {
+describe('Theme is the AUTHORING theme document, owned by this package (objectui#5716)', () => {
+  // Until `@objectstack/spec` 17.2.0 this block pinned mutual assignability
+  // with the spec's `Theme` (its `z.input` side) and pinned `ThemeParsed.mode`
+  // required — the two spec legs `theme.ts`'s header predicted would retire on
+  // the pin refresh. 17.2.0 shipped the retirement (objectstack#10485 / PR
+  // objectstack#10695): the spec no longer exports any theme name, so there is
+  // nothing upstream to pin against and the shapes are documented, not pinned
+  // (objectui#5716 ruling, option A — localize). The vacancy itself is pinned
+  // in the renamed-dialects block below. What stays executable here is the
+  // AUTHORING reading the engine depends on: `mode` optional, because
+  // `ThemeEngine` receives stored/authored themes, not parsed ones.
   it('accepts a theme with no `mode` (the authoring side)', () => {
     const authored: Theme = { name: 'acme', label: 'Acme', colors: { primary: '#0af' } };
     expect(authored.mode).toBeUndefined();
-
-    // Mutual assignability with the spec's authoring type: this is what makes
-    // the re-export a re-export rather than a coincidence.
-    const asSpecInput: SpecThemeInput = authored;
-    const back: Theme = asSpecInput;
-    expect(back.name).toBe('acme');
-  });
-
-  it('is NOT the spec parsed theme, whose `mode` is required', () => {
-    // `.default('auto')` has already run in `z.infer`, so the parsed type would
-    // make `mode` mandatory and every stored objectui theme unrepresentable.
-    // If the spec ever drops that default the two collapse and this pin fails,
-    // which is the moment to re-read the derivation comment in `theme.ts`.
-    //
-    // rc.6 spells the `z.infer` side `ThemeParsed`. The pin reads the same fact
-    // it always did — following the NAME `Theme` here instead would have made
-    // this assertion compare the authoring side against itself and go green on
-    // nothing, which is exactly the swap the import comment warns about.
-    type ModeOfParsed = undefined extends SpecThemeParsed['mode'] ? 'optional' : 'required';
-    const parsedModeIs: ModeOfParsed = 'required';
-    expect(parsedModeIs).toBe('required');
 
     type ModeOfLocal = undefined extends Theme['mode'] ? 'optional' : 'required';
     const localModeIs: ModeOfLocal = 'optional';
@@ -691,6 +676,32 @@ describe('renamed local dialects do not collide with a spec export (objectui#307
           `exact name — this is a live collision, not a latent one. Re-triage ` +
           `(objectstack#4115): derive from the spec, or rename the local dialect back.`,
       ).not.toContain(reclaimed);
+    },
+  );
+
+  /**
+   * THE TRIPWIRE'S THIRD FIRING, on the `@objectstack/spec` 17.2.0 refresh
+   * (objectui#5668). 17.2.0 retired the spec's whole theme module
+   * (objectstack#10485 / PR objectstack#10695) while objectui retained the
+   * theme SYSTEM, so under the objectui#5716 ruling (option A — localize)
+   * `@object-ui/types` now OWNS `Theme`, `ThemeMode` and `ColorPalette`,
+   * hand-written in `theme.ts` from the last-published 17.1.0 shapes.
+   *
+   * Unlike the Gesture pair these were never renamed — the local names were
+   * derived from the spec until the retirement — but the pin they need now is
+   * the same one: the names are exported from this package, so the spec
+   * re-publishing any of them is a live collision, not a latent one.
+   */
+  it.each([['Theme'], ['ThemeMode'], ['ColorPalette']])(
+    'the spec no longer owns `%s`, localized under the objectui#5716 ruling',
+    (localized) => {
+      expect(
+        names,
+        `spec owns '${localized}' again — the objectstack#10485 theme retirement has ` +
+          `been undone upstream while @object-ui/types exports that exact name ` +
+          `(theme.ts, objectui#5716). This is a live collision: re-triage against ` +
+          `objectstack#4115 — derive from the spec again, or arbitrate the name.`,
+      ).not.toContain(localized);
     },
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 10.0.1(eslint@10.8.1(jiti@2.7.0))
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
@@ -270,13 +270,13 @@ importers:
         version: link:../../packages/types
       '@objectstack/client':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@objectstack/lint':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -411,7 +411,7 @@ importers:
         version: link:../../packages/types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       fumadocs-core:
         specifier: 16.14.4
         version: 16.14.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3)
@@ -760,13 +760,13 @@ importers:
         version: link:../types
       '@objectstack/formula':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@objectstack/lint':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@sentry/react':
         specifier: ^10.70.0
         version: 10.70.0(react@19.2.8)
@@ -860,7 +860,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       better-auth:
         specifier: ^1.6.28
         version: 1.6.28(@opentelemetry/api@1.9.1)(better-sqlite3@12.9.0)(mongodb@7.2.0(socks@2.8.9))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -956,7 +956,7 @@ importers:
     devDependencies:
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
@@ -992,7 +992,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@radix-ui/react-accordion':
         specifier: ^1.2.20
         version: 1.2.20(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1176,10 +1176,10 @@ importers:
         version: link:../types
       '@objectstack/formula':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1238,10 +1238,10 @@ importers:
         version: link:../types
       '@objectstack/client':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -1275,7 +1275,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1382,7 +1382,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1429,7 +1429,7 @@ importers:
     devDependencies:
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
@@ -1604,7 +1604,7 @@ importers:
     devDependencies:
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
@@ -1646,7 +1646,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@radix-ui/react-slot':
         specifier: ^1.3.3
         version: 1.3.3(@types/react@19.2.18)(react@19.2.8)
@@ -1765,7 +1765,7 @@ importers:
         version: link:../plugin-charts
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@types/react-grid-layout':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1874,7 +1874,7 @@ importers:
         version: link:../i18n
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -1996,7 +1996,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -2051,7 +2051,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -2112,7 +2112,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2256,7 +2256,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
@@ -2295,7 +2295,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -2445,7 +2445,7 @@ importers:
     devDependencies:
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -2490,7 +2490,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2545,7 +2545,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
@@ -2609,7 +2609,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2643,7 +2643,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2677,7 +2677,7 @@ importers:
         version: link:../types
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2751,7 +2751,7 @@ importers:
     devDependencies:
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -2790,13 +2790,13 @@ importers:
         version: link:../react
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
 
   packages/test-support:
     devDependencies:
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2808,7 +2808,7 @@ importers:
     dependencies:
       '@objectstack/spec':
         specifier: ^17.0.0
-        version: 17.1.0(ai@7.0.65(zod@4.4.3))
+        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4165,26 +4165,26 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@objectstack/client@17.1.0':
-    resolution: {integrity: sha512-pgd7JTIxN0TBDKs0bYuYWCJrPS8+H1sDby7vdvdYPBr4uaNBcwXQD3BWvSpaNyU11S8EtwWK5RQnqVYZARZEpA==}
+  '@objectstack/client@17.2.0':
+    resolution: {integrity: sha512-bVRrWyqpn71U6HxQ2IuOuI5sg6b/xp0ZGaKms41+y1a/22bv1Q9cdTd3nY71jGvKmVZ/TJMEd8+D1poAPQQrKQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/core@17.1.0':
-    resolution: {integrity: sha512-4R+rmaNWNmW6K2hMK2GihCAYwLPJr9csqpq0Rmegs79ElXPRy93JNoVy5LG3WotVnIvUdPlGCWogdRhc4lRhqw==}
+  '@objectstack/core@17.2.0':
+    resolution: {integrity: sha512-82I4eL/qcuFKOBhXWEGjJPAS9mOfwGVd9jeRbhRGuUZTm282sCuVoR/QC1JkDVxsFE0kSAtE4ej0XsYxP/spZQ==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/formula@17.1.0':
-    resolution: {integrity: sha512-u54fhrTxkUySKHuRwA4XjFi8i4SEYemMI9dlA+GGubguwtoE27gTvH5J4CTWcrVb3oN9Cf+3Aymw3yrfFWirkA==}
+  '@objectstack/formula@17.2.0':
+    resolution: {integrity: sha512-5p6gn92AwNj0e1tfT6mCjBkIUOPjjPr4C6K7GtOAfL20MRIILKgVtf94rZBpWr8+WBGRND050RpssgtN8CqQ/A==}
 
-  '@objectstack/lint@17.1.0':
-    resolution: {integrity: sha512-qHh6oRHsjUGSzd8X3hiKQeV0jqFg2J98YxAArdaWV14AzJkYXnmQNv7bzLAdVyV1VWbnp/nPWprUVc3FTzjzBg==}
+  '@objectstack/lint@17.2.0':
+    resolution: {integrity: sha512-PbyvKuiDdIQ61nVTy2y+19wl3bFJ3uTQk8u0l+OpNJsUYR1YxXCMnayC/h7h66kTPLs4IgjVTOedc3hV0CiSkg==}
     engines: {node: '>=22.0.0'}
 
-  '@objectstack/sdui-parser@17.1.0':
-    resolution: {integrity: sha512-D6LuWbi6MlHrrQSX+4/MXx+n4M79PZtgOa9uOgyMVd/JoTVR/waWrIu2qrhkKP7TX/P9KNGql2ahR3fOPJ2txQ==}
+  '@objectstack/sdui-parser@17.2.0':
+    resolution: {integrity: sha512-ntkTsawiwCVx1wubBdLqfuM1KslPy+PwRTevX2YqBC567KVsRMyn2RbmcDXTAVLUDQNOl2yab7oI7vXZO82mag==}
 
-  '@objectstack/spec@17.1.0':
-    resolution: {integrity: sha512-gyF7knX3mqTEZSYeFIW/HBP0yFcjEzyXCS/p5pwH4yuJ4R2uw7mE3ItJs187CxZIFhFC2PTluRri3C/1Yaa9Og==}
+  '@objectstack/spec@17.2.0':
+    resolution: {integrity: sha512-nQzyR9+9JQEtLzFastQbj0ETLLbOm4sSY+sNUEX2k0QgZThCsMB1rKPv100c6GQZYg1BaLfz5xc8tv9oH3cKqg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       ai: ^7.0.0
@@ -7479,8 +7479,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -10054,14 +10054,14 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  seroval-plugins@1.6.2:
-    resolution: {integrity: sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ==}
+  seroval-plugins@1.6.3:
+    resolution: {integrity: sha512-zQIy62HW683pMIUOKv9yKueQmOr+xMjpP2eH/qEPhr6nTAC+pJTh508md571Oduf/K/QpAoyeWpOhOp1+RFeDA==}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
 
-  seroval@1.6.2:
-    resolution: {integrity: sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==}
+  seroval@1.6.3:
+    resolution: {integrity: sha512-5PwLbVPpT4DEki1hYVSSsoxWY6xCNMVucAVLK/CH0mXSDfp/I4KaAex72q80GNt5hpn7CCMGdSpIg4YGqH/wXQ==}
     engines: {node: '>=10'}
 
   serve-static@1.16.3:
@@ -12457,32 +12457,32 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@objectstack/client@17.1.0(ai@7.0.65(zod@4.4.3))':
+  '@objectstack/client@17.2.0(ai@7.0.65(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 17.1.0(ai@7.0.65(zod@4.4.3))
-      '@objectstack/spec': 17.1.0(ai@7.0.65(zod@4.4.3))
+      '@objectstack/core': 17.2.0(ai@7.0.65(zod@4.4.3))
+      '@objectstack/spec': 17.2.0(ai@7.0.65(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/core@17.1.0(ai@7.0.65(zod@4.4.3))':
+  '@objectstack/core@17.2.0(ai@7.0.65(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 17.1.0(ai@7.0.65(zod@4.4.3))
+      '@objectstack/spec': 17.2.0(ai@7.0.65(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/formula@17.1.0(ai@7.0.65(zod@4.4.3))':
+  '@objectstack/formula@17.2.0(ai@7.0.65(zod@4.4.3))':
     dependencies:
       '@marcbachmann/cel-js': 8.0.0
-      '@objectstack/spec': 17.1.0(ai@7.0.65(zod@4.4.3))
+      '@objectstack/spec': 17.2.0(ai@7.0.65(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/lint@17.1.0(ai@7.0.65(zod@4.4.3))':
+  '@objectstack/lint@17.2.0(ai@7.0.65(zod@4.4.3))':
     dependencies:
-      '@objectstack/formula': 17.1.0(ai@7.0.65(zod@4.4.3))
-      '@objectstack/sdui-parser': 17.1.0
-      '@objectstack/spec': 17.1.0(ai@7.0.65(zod@4.4.3))
+      '@objectstack/formula': 17.2.0(ai@7.0.65(zod@4.4.3))
+      '@objectstack/sdui-parser': 17.2.0
+      '@objectstack/spec': 17.2.0(ai@7.0.65(zod@4.4.3))
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       sucrase: 3.35.1
@@ -12490,9 +12490,9 @@ snapshots:
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/sdui-parser@17.1.0': {}
+  '@objectstack/sdui-parser@17.2.0': {}
 
-  '@objectstack/spec@17.1.0(ai@7.0.65(zod@4.4.3))':
+  '@objectstack/spec@17.2.0(ai@7.0.65(zod@4.4.3))':
     dependencies:
       pg-connection-string: 2.14.0
       zod: 4.4.3
@@ -13765,8 +13765,8 @@ snapshots:
     dependencies:
       '@tanstack/history': 1.162.0
       cookie-es: 3.1.1
-      seroval: 1.6.2
-      seroval-plugins: 1.6.2(seroval@1.6.2)
+      seroval: 1.6.3
+      seroval-plugins: 1.6.3(seroval@1.6.3)
     optional: true
 
   '@tanstack/store@0.9.3':
@@ -14554,7 +14554,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     optional: true
@@ -14562,7 +14562,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -15952,7 +15952,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -18918,12 +18918,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seroval-plugins@1.6.2(seroval@1.6.2):
+  seroval-plugins@1.6.3(seroval@1.6.3):
     dependencies:
-      seroval: 1.6.2
+      seroval: 1.6.3
     optional: true
 
-  seroval@1.6.2:
+  seroval@1.6.3:
     optional: true
 
   serve-static@1.16.3:

--- a/scripts/__tests__/vite-objectstack-spec-dist.test.ts
+++ b/scripts/__tests__/vite-objectstack-spec-dist.test.ts
@@ -21,7 +21,7 @@ import {
  *
  *   1. **Set → every subpath is mapped.** The client hook this mirrors is one
  *      prefix alias, which is safe only because `@objectstack/client` exports a
- *      single entry. The spec's map has 18 and redirects each into `dist/`, so a
+ *      single entry. The spec's map has 19 and redirects each into `dist/`, so a
  *      copied client line rewrites `@objectstack/spec/ui` to a path that does not
  *      exist — measured as 214 broken import sites for `/ui` alone. The
  *      reconciliation case below therefore checks the derivation against Node's
@@ -46,10 +46,10 @@ import {
  *     `@objectstack/spec/ui -> …/dist/index.mjs/ui` — a path that cannot exist
  *     — so the finding lands in the repo sweep's `unresolved` list, while
  *     `missing` stays empty. The reconciliation case fails one step earlier, on
- *     18-vs-17.
+ *     19-vs-18.
  *   - **Make the hook unconditional** (default the env read to the installed
  *     spec dir) → 2 red, both in the console-config block: the alias table gains
- *     18 `@objectstack` keys, and `optimizeDeps.include` drops from 7 to 3.
+ *     19 `@objectstack` keys, and `optimizeDeps.include` drops from 7 to 3.
  *
  * The real-build cases at the bottom carry their own control rather than a
  * mutation: the same bundle is built a second time through the literal
@@ -141,9 +141,14 @@ describe('objectui#4854: OBJECTSTACK_SPEC_DIST is subpath-aware', () => {
     ) as { exports: Record<string, unknown> };
     const declared = Object.keys(manifest.exports);
 
-    // Anti-vacuity: the map this is reconciled against is the measured 18-entry
+    // Anti-vacuity: the map this is reconciled against is the measured 19-entry
     // one, not an empty object a silently-changed reader would also "cover".
-    expect(declared.length).toBe(18);
+    // 18 -> 19 on the @objectstack/spec 17.2.0 refresh (objectui#5668): the
+    // one added subpath, measured by diffing 17.1.0's exports map against
+    // 17.2.0's, is `./meta-spelling` — nothing was removed. The pin did its
+    // job on that bump: the un-updated 18 turned this red in CI rather than
+    // letting the new entry ride through unreconciled.
+    expect(declared.length).toBe(19);
     expect(Object.keys(injection!.aliases).length).toBe(declared.length);
 
     const missing: string[] = [];
@@ -413,7 +418,7 @@ describe('objectui#4854: the four flagged surfaces in the console config', () =>
     const injectedSpecKeys = Object.keys(injected.resolve.alias).filter((k: string) =>
       k === SPEC_PACKAGE_NAME || k.startsWith(`${SPEC_PACKAGE_NAME}/`)
     );
-    expect(injectedSpecKeys).toHaveLength(18);
+    expect(injectedSpecKeys).toHaveLength(19);
     expect(injectedSpecKeys[injectedSpecKeys.length - 1]).toBe(SPEC_PACKAGE_NAME);
     expect(injected.resolve.alias[`${SPEC_PACKAGE_NAME}/ui`]).toBe(
       path.join(fs.realpathSync(installedSpecDir), 'dist/ui/index.mjs')
@@ -555,7 +560,7 @@ function consoleShapedBundle(
  * (`/…/objectstack/packages/spec`, or `/home/runner/work/objectstack/objectstack/
  * packages/spec` on CI) has no `@objectstack` segment anywhere, and that is the
  * one property this fixture has to reproduce. It stays minimal on purpose: the
- * exports-map derivation is covered above against the real 18-entry map, and
+ * exports-map derivation is covered above against the real 19-entry map, and
  * what these cases need is a legal package at a path of the wrong SHAPE.
  */
 function makeOutOfTreeSpecPackage(): string {

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -329,45 +329,16 @@ const ALLOW = {
       "authored `UserFilters`.",
     issue: 4115,
   },
-  // The three theme document types, localized under the objectui#5716 ruling
-  // (2026-08-23, option A): the spec RETIRED its whole theme module
-  // (objectstack#10485 / PR objectstack#10695) while objectui retained the
-  // theme SYSTEM, so this package now OWNS the vocabulary — hand-written from
-  // the last-published 17.1.0 shapes, with no spec import left for the pin
-  // refresh to break. The names still collide only because the installed pin
-  // is that last publishing release. Deliberate consequence of this list's
-  // shrink-only staleness check: when the pin moves past the retirement, rule
-  // 1 stops flagging these names, all three entries turn STALE and this gate
-  // fails loudly — the refresh announces itself here instead of the theme
-  // surface narrowing silently, which is the objectui#5716 ruling's
-  // silent-half axis. The refresh PR deletes these three entries.
-  "@object-ui/types:Theme": {
-    reason:
-      "Owned here since the upstream theme retirement (objectui#5716 ruling, option A — " +
-      "localize): the retired module's authoring theme document, hand-written from the " +
-      "17.1.0 z.input reading. One-time exact-equality probe (both directions, all six " +
-      "shapes) ran against the installed 17.1.0 in the objectui#5716 PR; " +
-      "page-nav-misc-spec-parity.test.ts keeps mutual assignability with the spec's Theme " +
-      "compiled until the pin refresh retires its spec leg.",
-    issue: 5716,
-  },
-  "@object-ui/types:ThemeMode": {
-    reason:
-      "Owned here since the upstream theme retirement (objectui#5716 ruling, option A). " +
-      "Derived locally from the THEME_MODES runtime witness tuple, which keeps the " +
-      "@object-ui/providers parity pins executable (theme-mode-spec-parity.test.tsx, " +
-      "spec-symbol-batch7.test.ts — both fail if the vocabulary gains, loses, or " +
-      "misspells a member the provider does not handle).",
-    issue: 5716,
-  },
-  "@object-ui/types:ColorPalette": {
-    reason:
-      "Owned here since the upstream theme retirement (objectui#5716 ruling, option A), " +
-      "hand-written from the 17.1.0 z.input reading. Drift guard is structural: " +
-      "ThemeEngine's COLOR_TO_CSS_MAP is Record<keyof ColorPalette, …>, so the compiler " +
-      "rejects a key added or removed here without the CSS-variable mapping moving with it.",
-    issue: 5716,
-  },
+  // The three theme document types (`Theme`, `ThemeMode`, `ColorPalette`,
+  // objectui#5716 ruling, option A — localize) carried ALLOW entries here from
+  // the localization until the `@objectstack/spec` 17.2.0 refresh
+  // (objectui#5668). 17.2.0 shipped the theme-module retirement
+  // (objectstack#10485 / PR objectstack#10695), the names stopped colliding,
+  // the entries went stale exactly as their own comment predicted, and the
+  // refresh PR deleted them. The vacancy is pinned where it can execute:
+  // page-nav-misc-spec-parity.test.ts asserts all three names ABSENT from the
+  // spec export set, so an upstream re-publish is a loud collision, not an
+  // inherited exemption.
 };
 
 // ── Untriaged collisions (the ledger) ────────────────────────────────────────

--- a/scripts/vite-objectstack-spec-dist.ts
+++ b/scripts/vite-objectstack-spec-dist.ts
@@ -185,7 +185,7 @@ function findSpecPackageDir(raw: string): string {
  * file a bundler resolves it to.
  *
  * Cross-checked in `scripts/__tests__/vite-objectstack-spec-dist.test.ts`
- * against Node's own resolver (`import.meta.resolve`) for all 18 entries, so
+ * against Node's own resolver (`import.meta.resolve`) for every entry, so
  * this is not a second opinion about the map — it agrees with the algorithm.
  */
 export function readSpecExportTargets(packageDir: string): Map<string, string> {


### PR DESCRIPTION
Fixes #5668

The residual action the ruling on that card named (Decision 1, comment 5381285629: option A — wait for upstream, then *"an objectui lockfile refresh"*), executed now that all six `@objectstack/*` packages published at **17.2.0** in lockstep (2026-08-23T07:00:22–07:00:47Z) with the upstream browser-condition change (objectstack-ai/objectstack#11072) verified in the published tarball (comment 5384839941 on the card). Every ⛔ of the ruling is honored: **no pin revert, no bundler shim, no docs-site rerouting.**

## ⚠️ The `Build Docs` check on THIS PR is a path-filtered skip, not the evidence

This diff touches nothing under `content/` or `apps/site/`, so `ci.yml`'s step-level path filter reports `Build Docs` green in ~11 seconds **having built nothing** — the false-green recorded twice on the card (comments 5379267156, 5384090119). The acceptance evidence is the local before/after measurement below, taken with the same instrument as the 2026-08-22 bisect. **`main`'s own push run after the merge is the confirming CI reading** — on `push` the job takes the early return and always builds.

## The measurement — observed, not predicted

Both legs run as `pnpm turbo run build --filter='@object-ui/site' --concurrency=2` from this worktree, output redirected to file before any pipe, exit captured from the verify-lock wrapper that wraps turbo itself:

| leg | lockfile | turbo's own tally | exit |
|---|---|---|---|
| before — base `72ffc3496`, all six `@objectstack/*` at 17.1.0 | unrefreshed | `Tasks: 28 successful, 29 total` · `Failed: @object-ui/site#build` · `Error: Module not found: Can't resolve 'fs'` at `pg-connection-string@2.14.0/index.js:88` | 1 |
| after — refreshed lockfile, all six at 17.2.0 | this PR | `Tasks: 29 successful, 29 total` · `Time: 4m16.247s` · `Cached: 0 cached` — fully uncached | 0 |
| re-run on HEAD `1218dcc9a` (current) | this PR | `Tasks: 29 successful, 29 total` · `Cached: 0 cached, 29 total` — fully uncached again (fresh worktree, cold cache) | 0 |

## Lockstep, proven by absence

`pnpm-lock.yaml` resolves exactly one version of each: `spec`, `client`, `core`, `formula`, `lint`, `sdui-parser` — all `17.2.0`. A grep for any remaining `@objectstack/*@17.1.0` returns **zero**. The specifier set is untouched: 37 × `^17.0.0`, no manifest changed, and the root `pnpm.overrides` still carries nothing under `@objectstack/*` — the #5529 shape (*"Lockfile refresh only — every manifest already declared `^17.0.0`"*).

Declared, not hidden: the non-frozen install floated two in-range transitive patches that are outside the `@objectstack` subtree — `seroval` 1.6.2→1.6.3 (under `@tanstack/router-core`) and `fast-uri` 3.1.5→3.1.6 (under `ajv`). Hand-reverting lockfile integrity hunks was the riskier move, so they ride along. CI installs `--frozen-lockfile`, which is why the refreshed lockfile is committed.

## Green-keeping — three edits, all forced by the new build

17.2.0 ships the spec's theme-module retirement (objectstack#10485). The #5716 localization (`packages/types/src/theme.ts`, landed as PR #5752) predicted in its own header that on this refresh *"both turn stale/red … which is how that refresh announces itself here"*:

- **`scripts/check-spec-symbol-derivation.mjs`** — the `Theme`/`ThemeMode`/`ColorPalette` ALLOW entries stopped colliding and went stale; deleted, exactly as their own comment prescribed (*"The refresh PR deletes these three entries"*). Gate now green: `1297 files scanned against 4959 spec export names`.
- **`packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts`** — the two spec-side theme legs (mutual assignability with the spec `Theme`; `ThemeParsed.mode` required) had nothing left upstream to pin against; retired, and replaced with vacancy pins following the file's own `GestureType`/`GestureConfig` road: `Theme`, `ThemeMode`, `ColorPalette` asserted **absent** from the spec export set, so an upstream re-publish is a loud collision. The local authoring pin (`mode` optional) stays executable. 45/45 pass.
- **`scripts/__tests__/vite-objectstack-spec-dist.test.ts`** (commit `1218dcc9a`, caught by `Test (shard 1/4)` on `9f24ecbb1` — the pin doing its anti-vacuity job on a real bump) — the exports-map count pins move 18 → 19. **The moved entry is measured, not assumed:** diffing the published 17.1.0 exports map (18 keys, read from the registry) against the installed 17.2.0 (19 keys) shows exactly **one addition, `./meta-spelling`** (→ `dist/meta-spelling/index.mjs` under the `import` condition) and no removal. The alias table itself needed no change — it is derived from the exports map at runtime, and the reconciliation case proves the new entry gets a real alias agreeing with Node's own resolver (`import.meta.resolve`), not just a number that agrees: 25/25 in the file, 61 files / 1631 tests across `scripts/__tests__/`. The exact-count assertion stays exact — no `toBeGreaterThan`. Prose counts stating current facts moved with the pin; the two dated historical records (the rc.6 measurement, the objectui#5388 narrative) stay as written.

**PM assumption 5, partially falsified — reported, not silently absorbed.** TS2305 *did* appear in `packages/types` on the refresh — but only in the drift-guard test's deliberate spec-side import, which is the announcement mechanism #5716 built, not a gap in what it localized. The runtime surface (`theme.ts`, `packages/providers`) compiles clean; full repo type-check is 81/81 on the refreshed lockfile. No contract call was made here: the ownership question was already ruled on #5716 (option A — localize), and the edits execute instructions written into the files by that ruling.

## Verification on HEAD `1218dcc9a`

- `pnpm turbo run build --filter='@object-ui/site'` — 29/29, fully uncached (table above). Earlier on `9f24ecbb1`: `pnpm turbo run build` 44/44 uncached, `pnpm turbo run type-check` 81/81 with zero TS errors (the shard-1 fix touches only `scripts/`, re-covered by `type-check:scripts` exit 0).
- Gates re-run on `1218dcc9a`, each exit 0: `check:spec-symbols`, `check:action-forward-parity`, `check:phantom-deps`, `check:esm-specifiers`, `check:node-esm-load`, `check:published-dist`, `check:eager-closure` (verdict on `9f24ecbb1`: `Console eager closure is 3225.1 KB gzipped across 52 of 508 chunks (budget: 3990.2 KB, headroom: 765.1 KB)` — no re-baseline needed this round, unlike #5529), `check:doc-types`, `check:doc-snippets`, `check:control-bytes`, changeset presence, changeset no-major, `type-check:scripts`.
- Tests, declared narrowing: all **390 test files that textually reference `@objectstack`** (the direct consumption radius of the moved packages), run from the repo root: 155 files / 2010 tests + 235 files / 3512 tests (1 skipped), all green — plus the full `scripts/__tests__/` directory (61 files / 1631 tests) after the shard-1 fix. The full vitest farm and repo-wide lint are CI's runs; ESLint on the edited files is clean.
- The declared-BREAKING 17.2.0 entry (`http_request_errors_total` retired, objectstack#9834) re-verified inert: the name and its four spelling/registry variants match zero files in this repo.

Out-of-scope notes: #5493 and #5494 (spawned by #5529) remain open and are untouched here; `Test (coverage)` remains red on `main` per #5436 and is not this PR's. None of the in-flight lanes' files (`packages/plugin-timeline/src/ObjectTimeline.tsx`, `packages/app-shell/src/views/metadata-admin/**`, `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`) is touched. The `./shared` concern raised on the card measures away — see issue comment 5385206676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_