### PR TITLE
fix(plugin-detail): derive ReferenceRailEntry from @objectstack/spec and retire the icon key

### DIFF
--- a/.changeset/reference-rail-entry-spec-derived.md
+++ b/.changeset/reference-rail-entry-spec-derived.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/plugin-detail": minor
+---
+
+**`ReferenceRailEntry` is now the spec's type, and the reference-rail `icon` key retires** (objectui#5494, maintainer ruling 2026-08-22).
+
+`ReferenceRailEntry` is owned by `@objectstack/spec` as of 17.1.0. The hand-written interface in `record-reference-rail.tsx` is replaced by a re-export of the spec's `ReferenceRailEntry` (derived from `ReferenceRailEntrySchema`, `$strict` over `{ objectName, relationshipField, title?, limit?, displayField? }`), and `buildDefaultPageSchema` no longer emits `icon` on the reference-rail entries it synthesizes.
+
+**Migration — if you write `icon` on `record:reference_rail` entries, remove it.** Be aware of what this does and does not change:
+
+- **Runtime validation does not move.** The spec's strict schema already refused `icon` at save — that refusal is unchanged. What was broken was objectui's declaration: the TS type advertised a key that could never be saved.
+- **Nothing ever rendered `icon`.** No render path in `RecordReferenceRailRenderer` has ever read the key (measured back to the file's first commit, and independently by the spec's `ui-reference-rail-unknown-keys-refused` migration entry). An authored `icon` that survived in unsaved/preview metadata was already a silent no-op — after this change the TS type says so instead of suggesting otherwise.
+- **The published TS surface narrows.** Code that imported `ReferenceRailEntry` from `@object-ui/plugin-detail` internals and set `icon` will now get a type error. That error is the contract speaking: remove the key.
+
+The reference-rail icon affordance is retired rather than proposed upstream: a stock scan of this repo, its examples and schema-catalog corpus, and the objectstack tree (examples, templates, docs) found no reachable authored usage of `icon` on reference-rail entries. Stored customer metadata is not reachable from this seat and was not scanned.

--- a/packages/plugin-detail/src/renderers/record-reference-rail.tsx
+++ b/packages/plugin-detail/src/renderers/record-reference-rail.tsx
@@ -8,7 +8,7 @@
  * related data without leaving the Details tab.
  *
  * Each entry renders a tight card with:
- *   - object icon + localized label
+ *   - localized object label
  *   - total related count (badge)
  *   - the top N related records (name only, truncated)
  *
@@ -23,30 +23,22 @@ import { Link, useParams } from 'react-router-dom';
 import { useRecordContext, useSafeFieldLabel } from '@object-ui/react';
 import { cn, Card, CardHeader, CardTitle, CardContent, Badge, Skeleton } from '@object-ui/components';
 import { ChevronRight } from 'lucide-react';
+import type { ReferenceRailEntry } from '@objectstack/spec/ui';
 import { useDetailTranslation } from '../useDetailTranslation';
+
+// `ReferenceRailEntry` is owned by `@objectstack/spec` as of 17.1.0 — re-exported
+// here, never re-declared (objectui#5494; `check:spec-symbols` enforces this).
+// The spec's `ReferenceRailEntrySchema` is `$strict` over
+// {objectName, relationshipField, title?, limit?, displayField?}. The local
+// interface this replaced also declared an `icon` key: no render path ever read
+// it, and the strict schema refuses it at save, so it retired with the
+// derivation rather than surviving either side of the contract.
+export type { ReferenceRailEntry } from '@objectstack/spec/ui';
 
 const splitDesigner = (props: Record<string, any>) => {
   const { 'data-obj-id': id, 'data-obj-type': type, style, ...rest } = props || {};
   return { designer: { 'data-obj-id': id, 'data-obj-type': type, style }, rest };
 };
-
-export interface ReferenceRailEntry {
-  /** Related object's API name (e.g. 'opportunity_quote'). */
-  objectName: string;
-  /** FK field on the related object pointing back to the host record. */
-  relationshipField: string;
-  /** Optional override for the rail card title. */
-  title?: string;
-  /** Lucide icon name (defaults vary by object). */
-  icon?: string;
-  /** Top-N preview cap. Defaults to 3. */
-  limit?: number;
-  /**
-   * Canonical field on the related object to render in each preview row.
-   * Falls back to `name / title / subject / label / id` when omitted.
-   */
-  displayField?: string;
-}
 
 export interface RecordReferenceRailRendererProps {
   schema?: {

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -931,12 +931,14 @@ export function buildDefaultPageSchema(
   if (willEmitAside) {
     const asideComponents: any[] = [];
     if (willEmitRail) {
+      // No `icon` on rail entries: `ReferenceRailEntrySchema` is `$strict`
+      // without it, so emitting `rel.icon` here wrote a key the spec refuses
+      // at save — and no render path ever read it (objectui#5494).
       asideComponents.push(componentNode('record:reference_rail', {
         entries: (options.related as any[]).map((rel) => ({
           objectName: rel.objectName,
           relationshipField: rel.relationshipField,
           title: rel.title,
-          icon: rel.icon,
           displayField: rel.displayField,
           limit: 3,
         })),

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -456,24 +456,6 @@ const DEBT = {
     "NavigationItem",
     "NavigationItemSchema",
   ],
-  // Entered by the `@objectstack/spec` 17.1.0 pin bump (objectui#5328), and it is
-  // worth naming how this collision differs from the three above: objectui did
-  // not fork a spec name here. The local `ReferenceRailEntry` predates the
-  // release and did not move — 17.1.0 started EXPORTING the name (absent from
-  // 17.0.0's `dist/` entirely), so the collision arrived from upstream. The
-  // gate's own framing, "a fresh fork fails on the PR that writes it", does not
-  // fit a PR that wrote no fork.
-  //
-  // Not burnable in that PR either, because the two shapes disagree on one key:
-  // spec's `ReferenceRailEntrySchema` is `$strict` over
-  // {objectName, relationshipField, title, limit, displayField}, while the local
-  // interface adds `icon` — which the renderer reads and the strict schema
-  // REFUSES at save. Importing/deriving retires `icon`; renaming to a dialect
-  // keeps it unsaveable. Either is a contract call, so it is filed rather than
-  // guessed: objectui#5494.
-  "@object-ui/plugin-detail": [
-    "ReferenceRailEntry",
-  ],
 };
 
 // Files under these paths are not objectui's own authored surface.


### PR DESCRIPTION
Fixes #5494

Implements the maintainer's Option B ruling (2026-08-22, decision-inbox digest, 「接受所有」): objectui drops `icon` and derives `ReferenceRailEntry` from the spec. Option C stayed rejected; the ruling's flip condition (real existing usage of `icon`) did not trigger — stock scan below.

## Stock scan (ran first — it decides the direction)

**Result: no reachable authored usage of `icon` on reference-rail entries. The ruling does not flip; Option B proceeds.**

Populations swept, each with a positive control proving the scanner arrived:

- **objectui @ `cd4961a68`** — all 31 files matching `reference_rail|reference-rail|ReferenceRail`, plus `examples/` (456 authored files incl. the schema-catalog corpus; control: `objectName|displayField` hits 4 files). Zero `record:reference_rail` schemas exist in examples at all. The only `icon` writers found are objectui's own: the local interface declaration and `buildDefaultPageSchema`'s synthesized entries (both retired here). The `icon: 'check'` in `strictPayload.test.ts` is a `related` option feeding `record:related_list` tabs, not a rail entry.
- **objectstack @ `764dbbc`** — repo-wide `git grep` for the same terms (control: `relationshipField` hits 3 example files): hits only in content docs (component-type lists, no `icon` advertising), ADR/audit docs, `packages/lint`, and `packages/spec`. Zero rails in `examples/`, `skills/`, or any template.
- **Stored customer metadata — NOT REACHABLE from this seat** (#5741 ran five independent probes; gap open since objectstack#7917). A clean scan here is "no reachable usage", not "no usage". This does not change the direction on its own: the spec side already refuses `icon` at save and nothing ever rendered it (below), so unreachable stock cannot be depending on a render effect that does not exist.

## The premise correction worth reading

The card says the renderer "reads and honours" `icon`. **Measured false — and false at filing**: no render path in `record-reference-rail.tsx` has ever read the key (verified back to the file's first commit, `66751896c`). The spec's own v18 migration entry `ui-reference-rail-unknown-keys-refused` measured the same, verbatim: "the interface's `icon` is read by nothing and is refused, not declared". So no functioning affordance retires; what retires is a lying TS declaration plus a synth emission of a key the spec refuses at save. This makes Option B strictly cheaper than the ruling assumed. The runtime accept set does not move — `ReferenceRailEntrySchema` was `$strict` without `icon` before and after; validation was already tight, the declaration was lying.

## Changes

- **`packages/plugin-detail/src/renderers/record-reference-rail.tsx`** — the hand-written `interface ReferenceRailEntry` is replaced by `export type { ReferenceRailEntry } from '@objectstack/spec/ui'` (the gate's sanctioned re-export form). The `icon?: string` member and the header comment's icon claim go with it.
- **`scripts/check-spec-symbol-derivation.mjs`** — the `@object-ui/plugin-detail: ["ReferenceRailEntry"]` `DEBT` entry and its comment block are burned. The ledger is shrink-only; `--ledger` regeneration reproduces the remaining block byte-for-byte.
- **`.changeset/reference-rail-entry-spec-derived.md`** — `minor` (breaking-as-minor per `check-changeset-no-major`; `@object-ui/*` fixed group) with the loud migration note the ruling requires: authored `icon` stops being suggested by the type, never had a render effect, and was already refused at save. Release notes compile from changesets — no `releases/` page touched.
- **`packages/plugin-detail/src/synth/buildDefaultPageSchema.ts`** — **declared file-surface amendment (bounded in-place fix, all four conditions held)**: the synthesized reference-rail entries emitted `icon: rel.icon`, i.e. objectui's own synth was the one live producer of the exact key this ruling retires — same defect class; the correct shape is pinned by the landed ruling and the spec's `$strict` schema; `packages/plugin-detail` carried no other claim (dispatch: lane in-flight zero); covered by the same gate family (plugin-detail tests/type-check, no new verification face). Boundary scan: repo-wide `grep` shows no other writer of `icon` onto reference-rail entries, and no synth test pins the key (assertions check `entries` length/`objectName` only). Without this line the "retired" key kept being written into every synthesized rail page — a save-refusal trap for any customize-and-persist flow. Sibling defect at the region level (`aside.className`, #4286) is a different key and remains open — not addressed here.

## Verification (at `9a13a78f2` unless noted)

- `check:spec-symbols` — ✅ `1297 files scanned against 4966 spec export names; 16 declared dialects, 3 untriaged collisions in 1 packages` (the 3 are the pre-existing `@object-ui/types` trio).
- **Reverse verification, both directions, mutation confirmed on disk by anchored grep before each reading, restored from the committed state:**
  - resurrect the hand-written interface (file from `cd4961a68`), ledger stays burned → gate exit 1: `interface ReferenceRailEntry  …record-reference-rail.tsx:33  (exported by @objectstack/spec/ui)`;
  - keep the fix, re-add the DEBT entry → ratchet exit 1: `@object-ui/plugin-detail lists 1 symbol in DEBT that no longer collide — ReferenceRailEntry`.
- **Type-face probe against the installed spec dist** (proves the derived type refuses the key post-rebuild): red leg `error TS2353 … 'icon' does not exist in type '{ objectName; relationshipField; title?; limit?; displayField? }'`; green leg (declared keys only) exit 0.
- Tests/type-check at `4be78c5d0` + the changeset (the only later commit is the changeset .md, outside every test/tsc input): dependency closure built, then `vitest run packages/plugin-detail/` — ✅ `Test Files 93 passed (93) · Tests 866 passed (866)`; `pnpm --filter @object-ui/plugin-detail type-check` — ✅ (lock VERDICT command-exit 0). Gate pin test `check-spec-symbol-derivation.test.ts` — ✅ 34/34; `type-check:scripts` — ✅.
- Light gates at `9a13a78f2`: `check:control-bytes` ✅ · `check:phantom-deps` ✅ · `check:self-import` ✅ · `check:esm-specifiers` (specifiers leg) ✅ · `check-changeset-fixed` ✅ · `check-changeset-no-major` ✅ · `check-changeset-presence` ✅ · `check:action-forward-parity` ✅ · `check:i18n-keys` ✅ · `check:i18n-drift` ✅.
- **Declared narrowings** (CI runs the full farm regardless):
  - `lint`: ran `pnpm --filter @object-ui/plugin-detail lint` + `eslint --no-inline-config scripts/check-spec-symbol-derivation.mjs` — 0 errors. Invariance for untouched files: `eslint.config.js` contains no `projectService`/`parserOptions.project` (no type-aware linting), so this diff cannot move any unlinted file's judgment.
  - `check:published-dist`: the gate hardcodes a full-workspace turbo build (its own header: "why this gate costs a build"). Ran the targeted equivalent on the one published package this diff touches: plugin-detail's fresh dist (101 files) has 0 test/bench/stories artifacts and 0 `vitest` imports; every other package's dist is a function of sources this diff does not touch.
  - Downstream consumer sweep (prefix direction, `...@object-ui/plugin-detail` = dependents): `ReferenceRailEntry` has zero importers outside the declaring file in the whole tree (`git grep` at HEAD; the package's `exports` map exposes only `.`, and `dist/index.d.ts` never re-exported it), and no typed caller anywhere writes `icon` on entries — so no dependent's type-check judgment can move on this narrowing.
- Known broken gauges not exercised: `Build Docs` red on `main` (#5668, inherited); `check-doc-snippet-types` / `check-eager-closure-budget` require built consoles.

Out-of-scope findings filed: #5792 (stale parity-test prose citing this card as unsettled), #5793 (spec dependency floors vs 17.1.0-only symbols).

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_