### PR TITLE
fix(components): wire label→trigger association on element:record_picker

### DIFF
--- a/.changeset/record-picker-label-association-5771.md
+++ b/.changeset/record-picker-label-association-5771.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/components': patch
+---
+
+`element:record_picker`'s `label` is now programmatically associated with its
+`SelectTrigger` combobox — fixing a case where the caption the block's own
+registration prose advertised (`'Caption rendered above the picker, in a
+<label> element'`) named nothing at all (objectui#5771).
+
+Pre-fix, the render body was `{label && <label className="…">{label}</label>}`
+against a `SelectTrigger` with no `id`: neither end of the association carried
+any wiring. That is a step worse than the sibling gap objectui#5735 closed on
+`element:text_input` — there the `label` half was already correctly wired and
+only `description` was adrift; here the label element had no `htmlFor` and the
+trigger had no `id`, so the picker had no accessible name unless a
+`placeholder` happened to render text into the trigger's content.
+
+The fix follows the shape objectui#3341 already ruled on for the same defect
+class (`InlineCreateRelated`'s `<label>`/`<Input>` pair) and objectui#5735
+just landed on the complement block: `htmlFor`/`id` against the
+`SelectTrigger` — a `button` with `role="combobox"`, and therefore labelable,
+so no `aria-labelledby` is needed (Radix sets none on the trigger) — wired
+**when `schema.id` exists**, matching `element:text_input`'s precedent rather
+than an always-on `useId()` fallback. Only the author can supply `schema.id`,
+so a picker authored without one keeps its pre-fix, unassociated caption text
+exactly as before; nothing about this change mints an id the author did not
+provide. The `<label>` element itself is also swapped for the shared `Label`
+(`@radix-ui/react-label`) primitive `element:text_input` already uses for the
+same wiring, rather than a bare `<label>` with a `htmlFor` bolted on.
+
+The registration prose for `label` is corrected to describe what the code now
+does (tied to the control by `htmlFor` when the node carries an `id`) instead
+of a caption association the renderer never performed.

--- a/packages/components/src/renderers/basic/__tests__/record-picker-label-association.test.tsx
+++ b/packages/components/src/renderers/basic/__tests__/record-picker-label-association.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `element:record_picker` — the authored `label` is programmatically
+ * associated with the combobox, not unassociated caption text beside it
+ * (objectui#5771).
+ *
+ * Pre-fix, neither end carried the wiring: the `<label>` had no `htmlFor` and
+ * the `SelectTrigger` had no `id`. That is a step worse than the sibling gap
+ * objectui#5735 closed on `element:text_input` — there the label HALF was
+ * already correct and only `description` was adrift; here the caption named
+ * nothing at all, and the picker had no accessible name unless a `placeholder`
+ * happened to supply one.
+ *
+ * ## Pin the RESOLUTION, not the two attributes
+ *
+ * Per objectui#3341's landed reasoning (which transfers verbatim: `SelectTrigger`
+ * renders a `button` with `role="combobox"`, a labelable element, so a plain
+ * `htmlFor`/`id` pair is the correct association with no `aria-labelledby`
+ * needed — Radix sets none on the trigger): the failure mode #3341's test file
+ * documents is an association that LOOKS wired — a `label[for]` here, an `id`
+ * there — while resolving to nothing, because the two values never actually
+ * matched. Two `expect`s on `htmlFor` and `id` in isolation would pass against
+ * exactly that bug. So every case below resolves the relationship end to end —
+ * `getByLabelText` / `toHaveAccessibleName`, or `label[for]` followed by
+ * `document.getElementById` — never the two attributes read separately.
+ *
+ * ## Wired when `schema.id` exists — the #5735 / #3341 shape, not a `useId` fallback
+ *
+ * Triage inherited #5735's ruling on the same question for the complement
+ * block rather than reaching for an always-on `useId()` fallback: `htmlFor`
+ * needs an id on the control, which only the author can supply via
+ * `schema.id`, so the wiring can only hold when they did. The no-`schema.id`
+ * case below pins that this is unchanged, deliberate behaviour, not an
+ * oversight — mirroring `text-input-description-association.test.tsx`'s
+ * "associates … even when the node carries NO id" case for the same shape.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers `element:record_picker` at module scope, not in a hook
+// (object-ui/no-dynamic-import-in-test-hook, objectui#3010).
+import '../../../renderers';
+
+afterEach(cleanup);
+
+function renderPicker(properties: Record<string, unknown>, schemaExtra: Record<string, unknown> = {}) {
+  const C = ComponentRegistry.get('element:record_picker') as React.ComponentType<any>;
+  if (!C) throw new Error('element:record_picker is not registered');
+  return render(<C schema={{ type: 'element:record_picker', properties, ...schemaExtra }} />);
+}
+
+describe('element:record_picker — label→combobox association (objectui#5771)', () => {
+  it('resolves the label to the combobox, so getByLabelText finds the trigger', () => {
+    renderPicker({ object: 'account', label: 'Owner' }, { id: 'owner_picker' });
+
+    const combobox = screen.getByRole('combobox');
+    expect(screen.getByLabelText('Owner')).toBe(combobox);
+    expect(combobox).toBe(screen.getByTestId('record-picker-trigger'));
+  });
+
+  it('gives the combobox the LABEL as its accessible name — the caption the docs advertise', () => {
+    renderPicker({ object: 'account', label: 'Owner' }, { id: 'owner_picker' });
+
+    // Findable BY that accessible name, the way an author-facing a11y check
+    // (and the testing-library query the PM route calls for) would drive it.
+    const combobox = screen.getByRole('combobox', { name: 'Owner' });
+    expect(combobox).toHaveAccessibleName('Owner');
+  });
+
+  it('points htmlFor at an id that really exists on the trigger, not a name that merely looks matched', () => {
+    // The #3341 failure mode: two attributes present but pointing at nothing.
+    // Read `for` off the rendered label and resolve it through the DOM, rather
+    // than asserting `id`/`htmlFor` as two independent strings.
+    renderPicker({ object: 'account', label: 'Owner' }, { id: 'owner_picker' });
+
+    const label = document.querySelector('label[for]');
+    expect(label).not.toBeNull();
+    const target = document.getElementById(label!.getAttribute('for')!);
+    expect(target).not.toBeNull();
+    expect(target).toBe(screen.getByTestId('record-picker-trigger'));
+    expect(target).toHaveAttribute('role', 'combobox');
+  });
+
+  it('registers the label on the trigger via the DOM `labels` collection', () => {
+    // The association browsers actually use for both the accessible name and
+    // click-to-focus.
+    renderPicker({ object: 'account', label: 'Owner' }, { id: 'owner_picker' });
+
+    const trigger = screen.getByTestId('record-picker-trigger') as HTMLButtonElement;
+    expect(trigger.labels).not.toBeNull();
+    expect(Array.from(trigger.labels!)).toHaveLength(1);
+    expect(trigger.labels![0].getAttribute('for')).toBe(trigger.id);
+    expect(trigger.labels![0]).toHaveTextContent('Owner');
+  });
+
+  it('mints no accessible name from the label when `schema.id` is absent — unchanged, deliberate degradation', () => {
+    // The deliberate half of the fix (triage: follow #5735's answer, not a
+    // `useId()` fallback that would always name the control). Only the author
+    // can supply `schema.id`, so this wiring can only hold when they did.
+    //
+    // This is the exact defect the issue title describes: "the caption its own
+    // docs advertise names nothing". An explicit `placeholder` is passed so the
+    // trigger's accessible name resolves from the SelectTrigger `button`'s
+    // rendered content (Radix has no native `placeholder` attribute to exempt
+    // here, unlike a plain `<input>`) — proving the authored `label`, not the
+    // placeholder, is what fails to reach the name.
+    renderPicker({ object: 'account', label: 'Owner', placeholder: 'Select…' });
+
+    const trigger = screen.getByTestId('record-picker-trigger');
+    const label = document.querySelector('label');
+    expect(label).not.toBeNull();
+    expect(label).not.toHaveAttribute('for');
+    expect(trigger).not.toHaveAttribute('id');
+    // Pre-existing behaviour, pinned so a later change cannot silently name
+    // every picker without a `schema.id` — the label text still renders as
+    // caption text, but is not the trigger's accessible name; whatever name
+    // the trigger does resolve to comes from its own rendered content, not
+    // the label.
+    expect(trigger).not.toHaveAccessibleName('Owner');
+  });
+
+  it('renders no label element when `label` is absent — the fix cannot be "always associate"', () => {
+    renderPicker({ object: 'account', placeholder: 'Select…' }, { id: 'owner_picker' });
+
+    // No `label` was authored, so there is nothing for `htmlFor`/`id` to
+    // associate — pinned so a later change cannot silently start minting a
+    // `<label>` for a key that was never authored.
+    expect(document.querySelector('label')).toBeNull();
+  });
+
+  it('resolves the RESOLVED locale value as the accessible name, not the raw map', () => {
+    render(
+      <I18nProvider
+        persistLanguage={false}
+        config={{ defaultLanguage: 'zh-CN', detectBrowserLanguage: false }}
+      >
+        {/* eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns the registered component (stable), not one created during render */}
+        {(() => {
+          const C = ComponentRegistry.get('element:record_picker') as React.ComponentType<any>;
+          return (
+            <C
+              schema={{
+                type: 'element:record_picker',
+                id: 'owner_picker',
+                properties: { object: 'account', label: { en: 'Owner', 'zh-CN': '负责人' } },
+              }}
+            />
+          );
+        })()}
+      </I18nProvider>,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveAccessibleName('负责人');
+  });
+
+  it('survives the real render path through SchemaRenderer', () => {
+    render(
+      <SchemaRenderer
+        schema={{
+          type: 'element:record_picker',
+          id: 'owner_picker',
+          properties: { object: 'account', label: 'Owner' },
+        }}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox');
+    expect(screen.getByLabelText('Owner')).toBe(combobox);
+    expect(combobox).toHaveAccessibleName('Owner');
+  });
+});

--- a/packages/components/src/renderers/basic/__tests__/record-picker-label-association.test.tsx
+++ b/packages/components/src/renderers/basic/__tests__/record-picker-label-association.test.tsx
@@ -137,24 +137,19 @@ describe('element:record_picker — label→combobox association (objectui#5771)
   });
 
   it('resolves the RESOLVED locale value as the accessible name, not the raw map', () => {
+    const C = ComponentRegistry.get('element:record_picker') as React.ComponentType<any>;
     render(
       <I18nProvider
         persistLanguage={false}
         config={{ defaultLanguage: 'zh-CN', detectBrowserLanguage: false }}
       >
-        {/* eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns the registered component (stable), not one created during render */}
-        {(() => {
-          const C = ComponentRegistry.get('element:record_picker') as React.ComponentType<any>;
-          return (
-            <C
-              schema={{
-                type: 'element:record_picker',
-                id: 'owner_picker',
-                properties: { object: 'account', label: { en: 'Owner', 'zh-CN': '负责人' } },
-              }}
-            />
-          );
-        })()}
+        <C
+          schema={{
+            type: 'element:record_picker',
+            id: 'owner_picker',
+            properties: { object: 'account', label: { en: 'Owner', 'zh-CN': '负责人' } },
+          }}
+        />
       </I18nProvider>,
     );
 

--- a/packages/components/src/renderers/basic/__tests__/record-picker-label-association.test.tsx
+++ b/packages/components/src/renderers/basic/__tests__/record-picker-label-association.test.tsx
@@ -13,8 +13,14 @@
  * the `SelectTrigger` had no `id`. That is a step worse than the sibling gap
  * objectui#5735 closed on `element:text_input` — there the label HALF was
  * already correct and only `description` was adrift; here the caption named
- * nothing at all, and the picker had no accessible name unless a `placeholder`
- * happened to supply one.
+ * nothing at all.
+ *
+ * Measured (not assumed): with no association, the trigger's computed
+ * accessible name is the EMPTY string even when a `placeholder` renders
+ * visible text inside it — `role="combobox"` does not support "name from
+ * content" the way a plain `button`/`link` would, so the rendered placeholder
+ * text is not a fallback name here. The "mints no accessible name … when
+ * `schema.id` is absent" case below pins the measured value directly.
  *
  * ## Pin the RESOLUTION, not the two attributes
  *
@@ -104,27 +110,26 @@ describe('element:record_picker — label→combobox association (objectui#5771)
   it('mints no accessible name from the label when `schema.id` is absent — unchanged, deliberate degradation', () => {
     // The deliberate half of the fix (triage: follow #5735's answer, not a
     // `useId()` fallback that would always name the control). Only the author
-    // can supply `schema.id`, so this wiring can only hold when they did.
+    // can supply `schema.id`, so this wiring can only hold when they did —
+    // this is exactly the defect the issue title describes: "the caption its
+    // own docs advertise names nothing", pinned so a later change cannot
+    // silently start minting an id (or otherwise naming the control) for a
+    // picker whose author never supplied one.
     //
-    // This is the exact defect the issue title describes: "the caption its own
-    // docs advertise names nothing". An explicit `placeholder` is passed so the
-    // trigger's accessible name resolves from the SelectTrigger `button`'s
-    // rendered content (Radix has no native `placeholder` attribute to exempt
-    // here, unlike a plain `<input>`) — proving the authored `label`, not the
-    // placeholder, is what fails to reach the name.
+    // An explicit `placeholder` is passed and confirmed present in the DOM, to
+    // rule out the one alternative source of a name: it does NOT reach the
+    // accessible name either (measured — `role="combobox"` does not support
+    // "name from content"), so the empty name below is not an artifact of
+    // omitting `placeholder`.
     renderPicker({ object: 'account', label: 'Owner', placeholder: 'Select…' });
 
     const trigger = screen.getByTestId('record-picker-trigger');
+    expect(trigger).toHaveTextContent('Select…');
     const label = document.querySelector('label');
     expect(label).not.toBeNull();
     expect(label).not.toHaveAttribute('for');
     expect(trigger).not.toHaveAttribute('id');
-    // Pre-existing behaviour, pinned so a later change cannot silently name
-    // every picker without a `schema.id` — the label text still renders as
-    // caption text, but is not the trigger's accessible name; whatever name
-    // the trigger does resolve to comes from its own rendered content, not
-    // the label.
-    expect(trigger).not.toHaveAccessibleName('Owner');
+    expect(trigger).toHaveAccessibleName('');
   });
 
   it('renders no label element when `label` is absent — the fix cannot be "always associate"', () => {

--- a/packages/components/src/renderers/basic/record-picker.tsx
+++ b/packages/components/src/renderers/basic/record-picker.tsx
@@ -43,6 +43,7 @@ import {
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { I18nLabel } from '@objectstack/spec/ui';
 import {
+  Label,
   Select,
   SelectTrigger,
   SelectValue,
@@ -242,19 +243,40 @@ function ElementRecordPickerRenderer({ schema }: { schema: any }) {
     return <ElementDataSourceLoadingPanel testId="record-picker" />;
   }
 
+  // `label`'s association with the trigger is wired the same way
+  // `element:text_input` wires its own `label`/control pair (objectui#5735):
+  // `htmlFor` on the label names `schema?.id`, and that same id lands on the
+  // CONTROL — here `SelectTrigger`, a `button` with `role="combobox"` and
+  // therefore labelable, so a plain `htmlFor`/`id` pair is the correct
+  // association with no `aria-labelledby` needed (Radix sets none on the
+  // trigger; objectui#3341's landed reasoning transfers verbatim). Only the
+  // author can supply `schema.id`, so — exactly as on `text_input` — the
+  // wiring can only hold when they did; with no `schema.id` the label renders
+  // as unassociated caption text, same as before this change, rather than
+  // reaching for a `useId()` fallback that would always name the control
+  // (objectui#5771 — deliberately following #5735's answer to the same
+  // question on its complement block, not re-opening it).
   return (
     <div
       className={cn('space-y-1.5', schema?.className)}
       data-testid="record-picker"
       data-picker-id={schema?.id}
     >
-      {label && <label className="text-sm font-medium text-foreground">{label}</label>}
+      {label && (
+        <Label htmlFor={schema?.id} className="text-sm font-medium text-foreground">
+          {label}
+        </Label>
+      )}
       <Select
         value={value}
         onValueChange={handleChange}
         disabled={loading || !!error || !object}
       >
-        <SelectTrigger className="w-full max-w-xs" data-testid="record-picker-trigger">
+        <SelectTrigger
+          id={schema?.id}
+          className="w-full max-w-xs"
+          data-testid="record-picker-trigger"
+        >
           <SelectValue
             placeholder={loading ? 'Loading…' : error ? 'Failed to load' : placeholder}
           />
@@ -357,7 +379,7 @@ ComponentRegistry.register('record_picker', ElementRecordPickerRenderer, {
       type: ['string', 'object'],
       label: 'Label',
       description:
-        'Caption rendered above the picker, in a `<label>` element. Display-only — it never reaches the query, and it is OMITTED entirely when the key is absent or resolves to an empty string. Accepts either a plain string or an inline per-locale map (`{ en: "Owner", "zh-CN": "负责人" }`), the `I18nLabel` union rc.6 widened this key to; the renderer resolves the map against the active language at the read site, with the same fallback chain as `placeholder`. Distinct from `labelField`, which names the RECORD field each offered row is titled by.',
+        'Caption rendered above the picker, in a `<label>` element — tied to the control by `htmlFor` when the node carries an `id`, so clicking it focuses the picker and the text becomes the combobox’s accessible name (objectui#5771). Display-only — it never reaches the query, and it is OMITTED entirely when the key is absent or resolves to an empty string. Accepts either a plain string or an inline per-locale map (`{ en: "Owner", "zh-CN": "负责人" }`), the `I18nLabel` union rc.6 widened this key to; the renderer resolves the map against the active language at the read site, with the same fallback chain as `placeholder`. Distinct from `labelField`, which names the RECORD field each offered row is titled by.',
     },
     // ── sort / limit / emptyText — declared on the rc.6 bump (objectui#4167) ──
     // `@objectstack/spec` 17.0.0-rc.6 lands objectstack#5775's other half: these


### PR DESCRIPTION
Fixes #5771

## Problem

`element:record_picker` rendered its `label` as a plain `<label>` with no `htmlFor`, against a `SelectTrigger` with no `id`:

```tsx
{label && <label className="text-sm font-medium text-foreground">{label}</label>}
...
<SelectTrigger className="w-full max-w-xs" data-testid="record-picker-trigger">
```

Neither end of the association carried any wiring, so the caption the block's own registration prose advertised ("Caption rendered above the picker, in a `<label>` element") named nothing at all — a step worse than the sibling gap #5735 closed on `element:text_input`, where the `label` half was already correctly wired and only `description` was adrift.

## Fix

Follows the shape #3341 already ruled on for the same defect class (`InlineCreateRelated`'s `<label>`/`<Input>` pair) and #5735 just landed on the complement block:

- `htmlFor`/`id` wired against the `SelectTrigger` — a `button` with `role="combobox"`, and therefore labelable, so no `aria-labelledby` is needed (Radix sets none on the trigger; #3341's landed reasoning transfers verbatim).
- Wired **when `schema.id` exists**, matching `element:text_input`'s precedent — deliberately **not** a `useId()` fallback that would always name the control (triage explicitly ruled this out). Only the author can supply `schema.id`, so a picker authored without one keeps its pre-fix, unassociated caption text exactly as before.
- The bare `<label>` is swapped for the shared `Label` (`@radix-ui/react-label`) primitive `element:text_input` already uses for the same wiring.
- The `label` input's registration `description` is corrected to describe the association the code now performs, instead of the caption behavior it never did.

`packages/components/src/renderers/basic/record-picker.tsx`

## Tests

New file `packages/components/src/renderers/basic/__tests__/record-picker-label-association.test.tsx` (8 cases), following the "pin the resolution, not the two attributes" instruction: every case that depends on the fix resolves the relationship end-to-end (`getByLabelText`, `toHaveAccessibleName`, or `label[for]` → `document.getElementById` → compare), never `htmlFor`/`id` as two independent strings — that isolated-attribute shape is exactly the failure mode #3341's test file documents.

**Measured, not assumed:** with no `schema.id`, the trigger's computed accessible name is the empty string even when a `placeholder` renders visible text inside it — `role="combobox"` does not support "name from content", so that is not a fallback name source here. The no-`schema.id` case pins this measured value (`toHaveAccessibleName('')`) directly, confirmed present in the DOM via `toHaveTextContent`.

**Reverse-verification (control leg):** committed the fix, then temporarily reverted only `record-picker.tsx` to its pre-fix `origin/main` content and re-ran the new test file — **6 of 8 cases fail** against the unfixed renderer (the accessible-name/association cases); the 2 that stay green are the deliberate "no `schema.id`" cases, which pin unchanged behavior and are not part of the fix. Restored the fix afterward and re-ran the full file to confirm 8/8 green again; re-verified the same 6/2 split after a later docstring/assertion refinement.

```
# pre-fix (record-picker.tsx reverted to origin/main, test file kept):
 Test Files  1 failed (1)
      Tests  6 failed | 2 passed (8)

# post-fix (restored):
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Also re-ran the full existing `record_picker` + `text_input` test suites at the final head `c0ae004` — 66 tests / 7 files, all green, no regressions. `pnpm --filter @object-ui/components type-check` clean. `check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-control-bytes.mjs` all pass.

## Scope note

Per triage: this is the `element:record_picker` instance only. The form renderer's builtin `select` and its empty-options/dependency-gate branch (#3976/#3306/#3991) are separate surfaces and untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_
