### PR TITLE
fix(plugin-detail): stop the loading-frame `record is not defined` noise on record:alert

### DIFF
--- a/.changeset/record-alert-loading-frame-diagnostic-5776.md
+++ b/.changeset/record-alert-loading-frame-diagnostic-5776.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`record:alert`'s `visible` predicate no longer logs a spurious `record is not
+defined` evaluation-failure warning during the record-detail loading frame.
+
+The predicate is evaluated on every render (Rules of Hooks), including the
+frame before `useRecordContext().data` has loaded. In that frame `record` is
+unset, `usePredicateRecordContext` binds an empty context bag by design (no
+`record` key at all), and a bare/`${…}` predicate referencing `record.*`
+faulted with `record is not defined` — logged via `console.warn` on every
+page load, even the correct, working ones, because the SAME predicate
+resolved fine one frame later once `record` populated. The banner's own
+visibility was never wrong (it already hides unconditionally while unloaded);
+only the diagnostic was permanently misleading on the happy path.
+
+The predicate is now skipped while `record` hasn't loaded — the same
+condition the banner's own "hide while unloaded" early return already used —
+since its verdict in that frame was never consulted anyway. A predicate that
+is genuinely broken (bad field, bad syntax) still faults, and still logs, on
+every frame once `record` is populated (objectui#5776).

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.loadingFrameDiagnostic.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.loadingFrameDiagnostic.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * ══════════════════════════════════════════════════════════════════════════
+ * objectui#5776 — the loading-frame `record is not defined` false positive
+ * ══════════════════════════════════════════════════════════════════════════
+ *
+ * `record:alert`'s `visible` predicate is evaluated on EVERY render (Rules of
+ * Hooks — `useCondition` cannot be called conditionally), including the frame
+ * before `useRecordContext().data` has loaded. In that frame `record` is
+ * `undefined`/`null`, `usePredicateRecordContext` binds an EMPTY context bag
+ * (no `record` key at all — see its own doc: "No row → bind NOTHING"), and a
+ * bare/`${…}` predicate referencing `record.*` faults with a bare
+ * `ReferenceError: record is not defined` — logged via
+ * `ExpressionEvaluator.evaluate`'s `console.warn`. The banner itself still
+ * renders correctly (hidden while unloaded, then shown/hidden per the
+ * predicate once `record` populates), so this is a diagnostic defect, not a
+ * behavior one: the SAME predicate that works is blamed every load.
+ *
+ * The fix must be a PAIR: the loading frame stops logging (this file's first
+ * test, both polarities), and a predicate that is genuinely broken — for a
+ * reason that has nothing to do with the record not having loaded yet — still
+ * logs once `record` is populated (this file's second test). A change that
+ * only satisfied the first half would pass equally if the diagnostic had been
+ * deleted outright; the second half is what tells the two apart.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+const stub = {
+  recordCtx: undefined as any,
+  metadataItem: undefined as any,
+};
+
+// Same doubling strategy as `record-alert.test.tsx` (objectui#3941): only the
+// DATA layer is doubled — `toPredicateInput` / `useCondition` and the ambient
+// `PredicateScopeProvider` are the REAL shipped pipeline, so a defect in
+// normalization or evaluation (this card's subject) is observable here.
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useRecordContext: () => stub.recordCtx,
+    useMetadataItem: (_type: string, _name: string | null) => ({ item: stub.metadataItem }),
+    useActionEngine: (_opts: unknown) => ({
+      executeAction: vi.fn(async () => ({ success: true })),
+      getActionsForLocation: () => [],
+      getBulkActions: () => [],
+      handleShortcut: async () => null,
+      engine: {} as any,
+    }),
+  };
+});
+
+vi.mock('@object-ui/components', () => ({
+  Alert: ({ children, className, role, ...rest }: any) => (
+    <div data-testid="alert" role={role} className={className} {...rest}>
+      {children}
+    </div>
+  ),
+  AlertTitle: ({ children }: any) => <h5 data-testid="alert-title">{children}</h5>,
+  AlertDescription: ({ children }: any) => <div data-testid="alert-body">{children}</div>,
+  Button: ({ children, onClick, variant, ...rest }: any) => (
+    <button data-testid="alert-cta" data-variant={variant} onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+  LazyIcon: ({ name, className }: any) => (
+    <svg data-testid="alert-icon" data-name={name} className={className} />
+  ),
+}));
+
+import { RecordAlertRenderer } from '../record-alert';
+
+beforeEach(() => {
+  stub.metadataItem = undefined;
+  cleanup();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const TITLE = 'Verify your email';
+const PRED = "record.status == 'in_review'"; // bare string — the page-block predicate shape from the card
+
+function schema(visible: unknown) {
+  return { properties: { title: TITLE, visible } };
+}
+
+/**
+ * Filter a `console.warn` spy down to the evaluation-failure diagnostic this
+ * card is about — not an assertion of TOTAL silence. `useObjectTranslation`
+ * (i18next) warns unrelated to this card in the same environment (no
+ * `I18nProvider` is mounted here — see `record-alert.test.tsx`'s equivalent
+ * locale-map test for the real provider), and coupling this pin to that
+ * unrelated noise would make it fail for a reason that has nothing to do
+ * with objectui#5776.
+ */
+function evaluationFailureWarnings(spy: { mock: { calls: unknown[][] } }): string[] {
+  return spy.mock.calls
+    .map((call: unknown[]) => String(call[0]))
+    .filter((m: string) => /Failed to evaluate expression/.test(m));
+}
+
+describe('record:alert — loading-frame evaluation diagnostic (objectui#5776)', () => {
+  it('logs nothing while the record is loading, then evaluates correctly with no noise once it loads — both polarities', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // --- Polarity 1: predicate ultimately HOLDS -------------------------
+    stub.recordCtx = { data: undefined, objectName: 'sys_user', recordId: 'rec_1' };
+    const holds = render(<RecordAlertRenderer schema={schema(PRED)} />);
+    // Loading frame: hidden (existing contract), and — the defect — no
+    // misleading "record is not defined" noise for a predicate that works.
+    expect(holds.container.firstChild).toBeNull();
+    expect(evaluationFailureWarnings(warnSpy)).toEqual([]);
+
+    // Frame 2: record loads, predicate holds → banner shows, still silent.
+    stub.recordCtx = { data: { id: 'rec_1', status: 'in_review' }, objectName: 'sys_user', recordId: 'rec_1' };
+    holds.rerender(<RecordAlertRenderer schema={schema(PRED)} />);
+    expect(screen.getByTestId('alert')).toBeTruthy();
+    expect(evaluationFailureWarnings(warnSpy)).toEqual([]);
+
+    cleanup();
+    warnSpy.mockClear();
+
+    // --- Polarity 2: predicate ultimately FAILS (banner correctly hidden) -
+    stub.recordCtx = { data: undefined, objectName: 'sys_user', recordId: 'rec_1' };
+    const fails = render(<RecordAlertRenderer schema={schema(PRED)} />);
+    expect(fails.container.firstChild).toBeNull();
+    expect(evaluationFailureWarnings(warnSpy)).toEqual([]);
+
+    stub.recordCtx = { data: { id: 'rec_1', status: 'approved' }, objectName: 'sys_user', recordId: 'rec_1' };
+    fails.rerender(<RecordAlertRenderer schema={schema(PRED)} />);
+    expect(fails.queryByTestId('alert')).toBeNull();
+    expect(evaluationFailureWarnings(warnSpy)).toEqual([]);
+  });
+
+  it('a genuinely-broken predicate still logs once the record has loaded (the pairing half)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Record is fully loaded — this is NOT the loading frame — and the
+    // predicate references a field that will never resolve, for reasons
+    // unrelated to loading (an authoring typo). The suppression above must
+    // not swallow this: an author with a genuinely broken predicate still
+    // needs the console line.
+    stub.recordCtx = { data: { id: 'rec_1', status: 'in_review' }, objectName: 'sys_user', recordId: 'rec_1' };
+    const BROKEN = "bogus_unbound_field.status == 'x'";
+    render(<RecordAlertRenderer schema={schema(BROKEN)} />);
+
+    expect(evaluationFailureWarnings(warnSpy).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-alert.tsx
+++ b/packages/plugin-detail/src/renderers/record-alert.tsx
@@ -52,7 +52,12 @@
  *   also visible: this call site is FAIL-SOFT (it does not pass
  *   `throwOnError`), which is why the unbound spellings above were a
  *   user-visible defect rather than a console line — objectui#4807.
- *   Empty `record` (loading) → hidden (no flash of stale alert).
+ *   Empty `record` (loading) → hidden (no flash of stale alert), AND the
+ *   predicate is not evaluated at all in that frame — a bare/`${…}`
+ *   `record.*` reference against an unbound row faults, and evaluating a
+ *   verdict this component is about to discard anyway only produced a
+ *   permanently misleading `record is not defined` console line on every
+ *   load (objectui#5776).
  *
  *   A node-level `visibleWhen` is a SEPARATE gate one tier up, evaluated by
  *   `SchemaRenderer` on its own bindings (notably `data` = the data-source
@@ -194,7 +199,24 @@ export const RecordAlertRenderer: React.FC<RecordAlertProps> = ({ schema = {}, c
   // author's gate was never consulted. See `usePredicateRecordContext`.
   const predicateRecord = usePredicateRecordContext(record);
   const predicateInput = toPredicateInput(props.visible);
-  const passesPredicate = useCondition(predicateInput, predicateRecord);
+  // `recordLoaded` is also the early-return condition below — deliberately
+  // the SAME expression, not a re-derived one, so the two can never drift
+  // apart (objectui#5776). While `record` hasn't loaded this hook still has
+  // to run (Rules of Hooks), but its verdict is provably moot: the early
+  // return a few lines down hides the banner unconditionally in that frame
+  // regardless of what the predicate says. Evaluating anyway made a bare/
+  // `${…}` predicate that references `record.*` fault with a bare
+  // `record is not defined` ReferenceError against `usePredicateRecordContext`'s
+  // empty loading-frame bag (its own doc: "No row → bind NOTHING") — logged
+  // via `console.warn` on EVERY load, including the correct, working ones,
+  // because the SAME predicate resolves fine one frame later once `record`
+  // populates. Skipping evaluation while unloaded removes that permanently
+  // misleading noise without touching the verdict once data arrives: a
+  // predicate that is genuinely broken (bad field, bad syntax) still faults —
+  // and still logs, via this same fail-soft `useCondition` call — on every
+  // frame from the first loaded one onward.
+  const recordLoaded = !!record && Object.keys(record).length > 0;
+  const passesPredicate = useCondition(recordLoaded ? predicateInput : undefined, predicateRecord);
 
   // Dismissed-state persistence. Keyed by `<objectName>:<recordId>:<key>`
   // so an admin viewing a different record sees the alert fresh, and so
@@ -242,10 +264,11 @@ export const RecordAlertRenderer: React.FC<RecordAlertProps> = ({ schema = {}, c
   });
 
   // Hide if dismissed, if record hasn't loaded yet (avoids false alerts
-  // during the empty initial-render frame), or if the visibility predicate
-  // returns false.
+  // during the empty initial-render frame — same `recordLoaded` the
+  // predicate evaluation above is gated on, see its comment), or if the
+  // visibility predicate returns false.
   if (dismissed) return null;
-  if (!record || Object.keys(record).length === 0) return null;
+  if (!recordLoaded) return null;
   if (predicateInput !== undefined && !passesPredicate) return null;
 
   const handleDismiss = () => {


### PR DESCRIPTION
Fixes #5776

## What was wrong

`record:alert`'s `visible` predicate (`usePredicateRecordContext` + `useCondition`) is evaluated on every render — Rules of Hooks means the hook must run even in the frame before `useRecordContext().data` has loaded. In that frame `record` is `undefined`, and `usePredicateRecordContext` deliberately binds an **empty** context bag then (its own doc: "No row → bind NOTHING", so a host-supplied ambient `record` isn't shadowed by a record that merely hasn't loaded yet).

A bare-string (or `${…}`-wrapped) predicate referencing `record.*` against that empty bag faults with a bare `ReferenceError: record is not defined`, which `ExpressionEvaluator.evaluate`'s catch logs via `console.warn` on **every** page load — including the correct, working ones, since the exact same predicate resolves fine one frame later once `record` populates. The banner's own visibility was never wrong (it already hides unconditionally while `!record`); only the diagnostic was permanently misleading.

Re-measured on today's `origin/main` (`cd6a328fe`, post `@objectstack/*` 17.2.0 refresh) — the mechanism and message are unchanged from the objectstack#11247 evidence at the old pin.

## The fix

`record-alert.tsx` now derives one `recordLoaded` flag and uses it in two places that used to diverge slightly (`!record || Object.keys(record).length === 0` vs. no gate at all):

- The predicate passed to `useCondition` is `recordLoaded ? predicateInput : undefined` — `evaluateCondition(undefined)` short-circuits to `true` without ever touching the evaluator, so nothing is evaluated (and nothing can fault) in a frame whose banner is hidden regardless.
- The existing "hide while unloaded" early return now reads `!recordLoaded` — the exact same expression, not a re-derived one, so the two can never drift apart.

A predicate that is genuinely broken (bad field, bad syntax) is **not** touched by this change — once `record` is populated it's evaluated for real, faults for real, and still logs for real. That pairing is pinned directly (see tests below).

## Tests

New file `packages/plugin-detail/src/renderers/__tests__/record-alert.loadingFrameDiagnostic.test.tsx`, real `toPredicateInput`/`useCondition` pipeline (objectui#3941 doubling convention — only the data layer is mocked):

- **Reproduced first** (confirmed red pre-fix): loading frame with a bare-string `record.*` predicate logged `Failed to evaluate expression: ${record.status == 'in_review'}` / `record is not defined`, for both eventual polarities.
- Pin 1: loading frame emits no evaluation-failure warning, then the SAME predicate resolves correctly (both "holds" and "fails" polarities) with **no** warning once `record` populates.
- Pin 2 (the pairing half): a predicate that references a field unrelated to loading (`bogus_unbound_field.status == 'x'`) against an **already-loaded** record still logs `Failed to evaluate expression` — proving this isn't the diagnostic silenced outright.

Full existing `record:alert` suites (`record-alert.test.tsx`, `.rowBinding.test.tsx`, `.visibleWhen.evidence.test.tsx`) plus the new file: **39/39 passed**. Full `plugin-detail` package: **868/868 passed** (`pnpm exec vitest run packages/plugin-detail/`, from repo root per this repo's invocation guard). `pnpm --filter @object-ui/plugin-detail run type-check`: clean. Targeted `eslint --no-inline-config` on both touched files: 0 errors (pre-existing `no-explicit-any` warnings only, matching this file's existing style). `node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs`: both pass with the added `patch` changeset.

## Scope

Deliberately narrow to `record:alert`'s bare-string/legacy-`${…}` path — the sizing datum on the source card measured this as the only surface currently authoring bare-string predicates (all 6 other `visibleWhen` values across 34 pages are `{dialect:'cel'}` envelopes). No behavior change to any predicate verdict; diagnostic hygiene only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_