### PR TITLE
fix(auth): declare cross-org identity re-resolution in switchOrganization

### DIFF
--- a/.changeset/switch-org-declared-reresolve-5750.md
+++ b/.changeset/switch-org-declared-reresolve-5750.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/auth': patch
+---
+
+`switchOrganization` now re-resolves identity for the organization it just switched
+to by its own explicit decision, instead of depending on an accidental
+`TokenStorage` side effect to notice the switch (objectui#5750).
+
+`AuthProvider.switchOrganization` has never called `loadSession()` itself. Identity
+re-resolved across a switch only because `POST /organization/set-active` happens to
+return the SIGNED `token.signature` spelling in `set-auth-token`, which differs from
+the UNSIGNED `session.token` spelling `getSession()` normally stores — so
+`TokenStorage.set` reads the flip as a rotation and the objectui#4467 subscription
+calls `loadSession()` for it (measured and pinned in objectui#5749/#5719). That
+signed spelling is deterministic on the raw session token, not on the organization:
+two switches with no `get-session` landing in between produce the identical signed
+value, so the SECOND `TokenStorage.set` sees no change, never notifies, and identity
+is left answering for whichever organization the FIRST switch targeted even though
+`activeOrganization` already reads as the new one.
+
+Reachable in the console via `OrganizationLayout`'s slug-driven effect (the "Manage"
+link on an org card, plus its own "Back to organizations" button) — ordinary
+client-side navigation with no full-page reload and nothing debouncing repeat
+switches. `WorkspaceSwitcher` and `OrganizationsPage`'s own card click were not
+reachable paths for this: both force `window.location.href` immediately after a
+successful switch, and the resulting fresh `AuthProvider` mount always performs an
+authoritative `loadSession()` regardless of how the race above resolved.
+
+`switchOrganization` now tracks the organization it last resolved to itself and
+re-resolves explicitly whenever a switch's target differs from that, while
+suppressing the (now redundant) rotation notification for its own `set-active`
+call — so the common single-switch path still spends exactly one `get-session`, not
+two. A generation guard discards a still-in-flight, now-superseded switch's answer
+rather than let it clobber a later switch's fresher one.

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -163,6 +163,20 @@ export function AuthProvider({
   // re-entering on it would loop this provider against the server forever.
   const sessionLoadInFlight = useRef(false);
 
+  // objectui#5750 — the org id `switchOrganization` last resolved to, tracked
+  // independently of React state so a switch that starts before the PREVIOUS
+  // switch's render has committed still compares against a value, not a stale
+  // closure. Kept in sync with every path that can move `activeOrganization`
+  // (not just `switchOrganization` itself — `refreshOrganizations`'
+  // single-membership repair also does), via the effect below.
+  const activeOrgIdRef = useRef<string | null>(null);
+  // Bumped by every `switchOrganization` call that decides to re-resolve
+  // identity. Lets an EARLIER switch's still-in-flight `getSession()` notice
+  // a LATER switch superseded it and discard its answer instead of applying
+  // stale, previous-organization data over the newer one (see
+  // `switchOrganization`).
+  const sessionLoadGeneration = useRef(0);
+
   /**
    * The ONE session loader. Runs on mount (below) and on every later
    * re-resolution — `refreshSession` on the context, and the rotation
@@ -713,9 +727,48 @@ export function AuthProvider({
     return () => { cancelled = true; };
   }, [user, enabled, isPreviewMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // objectui#5750 — keep `activeOrgIdRef` current for every path that can
+  // move `activeOrganization`, not only `switchOrganization` (e.g.
+  // `refreshOrganizations`' single-membership repair calls
+  // `client.setActiveOrganization` directly). `switchOrganization` also
+  // writes it synchronously on its own success, below — this effect is the
+  // fallback for every OTHER path, and re-affirms after commit.
+  useEffect(() => {
+    activeOrgIdRef.current = activeOrganization?.id ?? null;
+  }, [activeOrganization]);
+
+  /**
+   * objectui#5750 — `switchOrganization` now DECLARES the re-resolution
+   * instead of relying on the objectui#4467 rotation subscription noticing
+   * one by accident.
+   *
+   * Why that accident cannot be trusted here: `POST /organization/set-active`
+   * always returns the SIGNED `token.signature` spelling in `set-auth-token`
+   * (better-auth's `bearer()` fires for any response that stages a session
+   * cookie), which differs from the UNSIGNED `session.token` spelling the
+   * client normally holds — so `TokenStorage.set` reads the flip as a
+   * rotation and the objectui#4467 subscription re-resolves identity. That
+   * accidental rotation is deterministic on the RAW token, not on the
+   * organization — so a SECOND switch whose response lands before the FIRST
+   * switch's follow-up `get-session` has re-armed it (re-stored the unsigned
+   * spelling) writes the SAME signed value already in storage. No value
+   * change, no notification, no re-resolution — `user.positions` is left
+   * answering for the organization the FIRST switch targeted, while
+   * `activeOrganization` already reads as the new one. Measured in #5749/#5750.
+   *
+   * The fix does not add a second call on the common path: it SUPPRESSES the
+   * accidental one (via `sessionLoadInFlight`, the same flag that already
+   * suppresses the rotation observed inside `loadSession`'s own
+   * `getSession()` call) and re-resolves explicitly instead, so a switch that
+   * changes the active organization still spends exactly one `get-session` —
+   * now unconditionally, so it does not depend on which spelling happened to
+   * already be in storage.
+   */
   const switchOrganization = useCallback(
     async (orgId: string) => {
       setError(null);
+      const previousOrgId = activeOrgIdRef.current;
+      sessionLoadInFlight.current = true;
       try {
         const org = await client.setActiveOrganization(orgId);
         setActiveOrganization(org);
@@ -725,13 +778,27 @@ export function AuthProvider({
         } else {
           ActiveOrganizationStorage.clear();
         }
+        const newOrgId = org?.id ?? null;
+        if (newOrgId !== previousOrgId) {
+          activeOrgIdRef.current = newOrgId;
+          // A LATER switch may already be in flight by the time this
+          // `getSession()` answer comes back (no debounce guards repeat
+          // switches — see the WorkspaceSwitcher/OrganizationLayout callers).
+          // Discard this answer if a newer switch has since claimed the
+          // generation, rather than clobber fresher, later-organization data
+          // with a stale, earlier one.
+          const generation = ++sessionLoadGeneration.current;
+          await loadSession(() => sessionLoadGeneration.current !== generation);
+        }
       } catch (err) {
         const authError = err instanceof Error ? err : new Error(String(err));
         setError(authError);
         throw authError;
+      } finally {
+        sessionLoadInFlight.current = false;
       }
     },
-    [client],
+    [client, loadSession],
   );
 
   const createOrganization = useCallback(

--- a/packages/auth/src/__tests__/switchOrgIdentityReresolve-5719.test.tsx
+++ b/packages/auth/src/__tests__/switchOrgIdentityReresolve-5719.test.tsx
@@ -385,7 +385,19 @@ describe('#5719/#5750 — identity re-resolves across an organization switch', (
     // reproducing the timing race a fast real double-switch would have to
     // win. Installed only AFTER boot so mount's own `loadSession()` (which
     // also calls `getSession`) is unaffected.
-    let release: (() => void) | null = null;
+    // Typed as non-nullable + definite-assignment (`!`) at the call site
+    // rather than `(() => void) | null = null`: the Promise executor runs
+    // SYNCHRONOUSLY (the JS spec guarantees it), so `release` is genuinely
+    // assigned by the time `release!()` runs below — but `tsc` narrows a
+    // `let x: T | null = null` reassigned only inside a nested closure back
+    // to `null` at the read site regardless (TS does not track assignments
+    // through closure boundaries for control-flow narrowing), so `release?.()`
+    // type-checks against `never` and fails `tsc -p tsconfig.test.json`
+    // (`This expression is not callable. Type 'never' has no call signatures.`)
+    // even though the runtime behaviour is correct. Reproduced in isolation
+    // outside this file/tsconfig to confirm it is this pattern, not anything
+    // about `switchOrganization`'s signature.
+    let release!: () => void;
     const gate = new Promise<void>((resolve) => { release = resolve; });
     getSession.mockImplementation(async () => {
       const orgId = sessionRow.activeOrganizationId;
@@ -423,7 +435,7 @@ describe('#5719/#5750 — identity re-resolves across an organization switch', (
     // subscribed first and settles first, but must be DISCARDED as stale —
     // applying it after switch 2's would silently revert identity to the
     // organization the user already switched away from.
-    release?.();
+    release();
 
     await waitFor(() => expect(screen.getByTestId('positions').textContent).toBe('user,org_owner'));
     expect(screen.getByTestId('verdict').textContent).toBe('admin');

--- a/packages/auth/src/__tests__/switchOrgIdentityReresolve-5719.test.tsx
+++ b/packages/auth/src/__tests__/switchOrgIdentityReresolve-5719.test.tsx
@@ -70,6 +70,34 @@
  * two on the common path — a regression traded for an edge case. The card's
  * own caveat (that `refreshSession` deliberately does not raise `isLoading`,
  * so the console must not blank) is honoured for free by not adding one.
+ *
+ * ## Update — objectui#5750: the accident does not re-arm between two
+ * switches with no session read in between
+ *
+ * #5750 measured a narrower client-side fact about the SAME mechanism: the
+ * signed spelling `bearer()` hands back is deterministic on the RAW session
+ * token, not on the organization. Two `set-active` responses with no
+ * `get-session` landing in between therefore carry the identical signed
+ * value — the SECOND `TokenStorage.set` sees no change from the first and
+ * never notifies, so the objectui#4467 rotation never fires for it, and
+ * identity is left answering for whichever organization the FIRST switch
+ * targeted. Reachable in the console via `OrganizationLayout`'s slug-driven
+ * effect (`packages/app-shell/.../manage/OrganizationLayout.tsx`) — reached
+ * by the "Manage" link on an org card plus the "Back to organizations"
+ * button, both plain client-side navigation with no full-page reload and no
+ * debounce guarding repeat switches — unlike `WorkspaceSwitcher` and
+ * `OrganizationsPage`'s own card click, which both force
+ * `window.location.href` immediately after a successful switch and so
+ * self-heal via a fresh `AuthProvider` mount's own authoritative
+ * `loadSession()` regardless of how this race resolves.
+ *
+ * The fix: `switchOrganization` no longer relies on `TokenStorage` noticing a
+ * value change at all. It tracks the organization it last resolved to
+ * itself, and re-resolves identity explicitly whenever a switch's target
+ * differs from that — declared, not accidental — while suppressing the (now
+ * redundant) rotation notification for its own `set-active` call so the
+ * common path still spends exactly one `get-session` per switch. See
+ * `AuthProvider.switchOrganization`'s own docstring for the full mechanism.
  */
 
 import React, { useEffect } from 'react';
@@ -228,7 +256,7 @@ afterEach(() => {
   SessionUserScope._resetForTests();
 });
 
-describe('#5719 — identity re-resolves across an organization switch', () => {
+describe('#5719/#5750 — identity re-resolves across an organization switch', () => {
   it('an owner of A who is an ordinary member of B stops reading as admin after the switch', async () => {
     const { client, getSession } = orgBoundClient({
       memberships: { [ORG_A.id]: 'owner', [ORG_B.id]: 'member' },
@@ -285,25 +313,29 @@ describe('#5719 — identity re-resolves across an organization switch', () => {
   });
 
   /**
-   * The counterfactual, and the reason this file exists.
+   * The counterfactual — objectui#5750 closed this.
    *
    * Everything above is identical except the spelling the `set-active`
    * response hands back: the token the console ALREADY holds instead of the
-   * signed form. `TokenStorage.set` does not notify on an unchanged value
-   * (objectui#4467, by design — `get-session` re-stores on every boot), so no
-   * rotation fires, `loadSession()` is never called, and leg 3 keeps answering
-   * for organization A. That is precisely the defect #5719 predicted.
+   * signed form. Before objectui#5750, `TokenStorage.set` did not notify on
+   * an unchanged value (objectui#4467, by design — `get-session` re-stores on
+   * every boot), so no rotation fired, `loadSession()` was never called, and
+   * leg 3 kept answering for organization A — precisely the defect #5719
+   * predicted, and precisely the window #5750 measured: two `set-active`
+   * responses carrying the same signed spelling (deterministic on the RAW
+   * session token, not on the organization) with no intervening `get-session`
+   * to re-arm it.
    *
-   * It is unreachable in production ONLY because `bearer()` emits the signed
-   * `<token>.<signature>` while `createAuthClient.getSession` stores the
-   * unsigned `session.token`. This case is what turns that undeclared
-   * asymmetry into something a change has to walk past deliberately.
-   *
-   * If a future change makes `switchOrganization` re-resolve identity
-   * EXPLICITLY, this case will fail — and that failure is the signal to update
-   * this file, not a defect. The three cases above stay correct either way.
+   * `switchOrganization` no longer depends on that spelling accident at all
+   * (objectui#5750) — it explicitly re-resolves identity whenever the active
+   * organization actually changed, using its OWN before/after comparison
+   * rather than a side effect of `TokenStorage`'s diff-on-write semantics. So
+   * this case, which used to pin the ABSENCE of a rotation, now pins its
+   * PRESENCE: this scenario is indistinguishable from the ordinary case as
+   * far as identity re-resolution is concerned, precisely because it no
+   * longer rides the accident.
    */
-  it('does NOT re-resolve when the switch response echoes the token already held (the counterfactual)', async () => {
+  it('re-resolves even when the switch response echoes the token already held (objectui#5750)', async () => {
     const { client, getSession } = orgBoundClient({
       memberships: { [ORG_A.id]: 'owner', [ORG_B.id]: 'member' },
       rotationSpelling: 'same',
@@ -313,14 +345,87 @@ describe('#5719 — identity re-resolves across an organization switch', () => {
     const before = getSession.mock.calls.length;
 
     await switchToOrgB();
-    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await waitFor(() => expect(screen.getByTestId('positions').textContent).toBe('user,org_member'));
 
-    // No re-resolution: leg 3 is still organization A's answer…
-    expect(getSession.mock.calls.length).toBe(before);
-    expect(screen.getByTestId('positions').textContent).toBe('user,org_owner');
-    // …and the composite verdict is over-permissive in organization B, with
-    // `isResolved` short-circuited to true, so callers act on it.
+    // Re-resolution happened despite the echoed spelling — and it cost
+    // exactly the same ONE extra session read as the ordinary case above,
+    // not two: `switchOrganization` suppresses the (now redundant) rotation
+    // notification for its own `set-active` call rather than stacking an
+    // explicit read on top of it.
+    expect(getSession.mock.calls.length).toBe(before + 1);
     expect(screen.getByTestId('org').textContent).toBe(ORG_B.id);
+    expect(screen.getByTestId('verdict').textContent).toBe('not-admin');
+    expect(screen.getByTestId('resolved').textContent).toBe('resolved');
+  });
+
+  /**
+   * objectui#5750 — the exact scenario the card measured: TWO switches with
+   * NO session read landing in between. Before the fix, the second switch's
+   * `set-active` response carried the same signed spelling as the first
+   * (deterministic on the raw session token), so `TokenStorage.set` saw no
+   * value change, no rotation fired, and identity was left answering for
+   * organization A — the FIRST switch's target — even though
+   * `activeOrganization` already read as organization C.
+   *
+   * Blocking `getSession` mid-flight (never letting it resolve) is the
+   * literal reproduction of "no `get-session` round trip lands between the
+   * two switches" — a stronger, deterministic stand-in for the timing race a
+   * fast real double-switch would have to win.
+   */
+  it('the SECOND of two switches with no session read in between still re-resolves', async () => {
+    const memberships: Record<string, string> = { [ORG_A.id]: 'owner', [ORG_B.id]: 'member' };
+    const { client, getSession, sessionRow } = orgBoundClient({ memberships });
+
+    await bootOnOrgA(client);
+    const before = getSession.mock.calls.length;
+
+    // Gate every `getSession` call from here on so NONE lands until
+    // released — the literal reproduction of "no `get-session` round trip
+    // landed between the two switches" the card measured, stronger than
+    // reproducing the timing race a fast real double-switch would have to
+    // win. Installed only AFTER boot so mount's own `loadSession()` (which
+    // also calls `getSession`) is unaffected.
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    getSession.mockImplementation(async () => {
+      const orgId = sessionRow.activeOrganizationId;
+      const role = orgId ? memberships[orgId] : undefined;
+      const user = {
+        id: 'u_5719', name: 'Switcher', email: 'switcher@example.com', role: 'user',
+        positions: ['user', ...(role ? [mapMembershipRole(role)] : [])],
+        isPlatformAdmin: false,
+      } as unknown as AuthUser;
+      await gate;
+      TokenStorage.set(sessionRow.token);
+      return { user, session: { token: sessionRow.token, activeOrganizationId: orgId } };
+    });
+
+    // Switch 1: A → B. Not awaited to completion — real callers
+    // (`OrganizationLayout`'s effect, `WorkspaceSwitcher`) never await
+    // `switchOrganization` either.
+    act(() => { void authRef.current!.switchOrganization(ORG_B.id); });
+    await waitFor(() => expect(screen.getByTestId('org').textContent).toBe(ORG_B.id));
+    await waitFor(() => expect(getSession.mock.calls.length).toBe(before + 1));
+
+    // Switch 2: B → A, fired while switch 1's OWN follow-up `get-session` is
+    // still blocked on `gate` — no session read has landed for EITHER switch.
+    act(() => { void authRef.current!.switchOrganization(ORG_A.id); });
+    await waitFor(() => expect(screen.getByTestId('org').textContent).toBe(ORG_A.id));
+
+    // The crux: switch 2 triggered its OWN `get-session`, independent of
+    // switch 1's. Before objectui#5750 this stayed at `before + 1` — switch
+    // 2's `set-active` response carries the SAME signed token switch 1's did
+    // (same session, same deterministic HMAC), so `TokenStorage.set` saw no
+    // value change and the objectui#4467 rotation never fired for it.
+    await waitFor(() => expect(getSession.mock.calls.length).toBe(before + 2));
+
+    // Let both blocked reads land. Switch 1's answer (organization B) is
+    // subscribed first and settles first, but must be DISCARDED as stale —
+    // applying it after switch 2's would silently revert identity to the
+    // organization the user already switched away from.
+    release?.();
+
+    await waitFor(() => expect(screen.getByTestId('positions').textContent).toBe('user,org_owner'));
     expect(screen.getByTestId('verdict').textContent).toBe('admin');
     expect(screen.getByTestId('resolved').textContent).toBe('resolved');
   });


### PR DESCRIPTION
Fixes #5750

## Reachability — REACHABLE, evidenced (not merely hypothesized)

Triage asked for a reachability verdict before anything else. Summary: **reachable**,
via one specific call site; **not reachable** via the two more commonly used ones,
which self-heal by an unrelated mechanism.

- `AuthProvider.switchOrganization` never called `loadSession()` itself. Identity
  re-resolved across a switch only because `POST /organization/set-active` returns the
  **signed** `token.signature` spelling in `set-auth-token`, which differs from the
  **unsigned** `session.token` spelling `getSession()` normally stores — so
  `TokenStorage.set` reads the flip as a rotation and the objectui#4467 subscription
  calls `loadSession()` for it (mechanism measured and pinned in #5749/#5719).
- That signed spelling is **deterministic on the raw session token, not on the
  organization**. Two `set-active` responses with no `get-session` landing in between
  carry the identical signed value, so the second `TokenStorage.set` sees no change,
  never notifies, and identity is left answering for the FIRST switch's organization
  even though `activeOrganization` already reads as the new one.
- **`packages/app-shell/src/console/organizations/manage/OrganizationLayout.tsx`**
  (lines 40-46) re-derives the active org from the URL `:slug` in a plain `useEffect`,
  reached via the "Manage" link on an org card
  (`OrganizationsPage.tsx:265`) plus `OrganizationLayout`'s own "Back to
  organizations" button (`OrganizationLayout.tsx:94-100`) — **ordinary client-side
  navigation, no full-page reload, no debounce guarding a repeat switch.** This route
  is wired at `apps/console/src/App.tsx:305` (`/organizations/:slug`), whose own code
  comment independently confirms it's "reached from the 'Manage' button on the
  organizations list."
- **`WorkspaceSwitcher.tsx`** (`handleSwitch`) and **`OrganizationsPage.tsx`**'s own
  card click (`handleSelect`) are **not** reachable paths for this: both call
  `window.location.href = resolveRootUrl()` immediately after a successful switch. That
  full-page reload always re-mounts a fresh `AuthProvider`, whose mount-time
  `loadSession()` is authoritative and unconditional regardless of how the
  `TokenStorage` race resolved — self-healing by a mechanism unrelated to the one this
  card is about.
- Independent corroboration, pre-existing and unrelated to this PR: a landed test file
  (`packages/app-shell/src/providers/__tests__/MetadataProvider.orgScopedCache.test.tsx`,
  objectui#4486) already documents "the active org changes WITHOUT a reload
  (`OrganizationLayout` does exactly that from an effect)" as an architectural fact
  about this same code path.

Instrument used, and its limits: a deterministic client-side reproduction (gate every
`get-session` open after boot, fire two switches back-to-back, assert neither's
resolution required the other) proves the client-side mechanism fails exactly as
described and that the fix closes it. It does **not** measure real production network
latency (that's server infrastructure, a sibling repo) — so it cannot certify how
*often* a human wins the underlying race in the wild, only that the race exists, that
one call site has nothing preventing a user from entering it, and that the fix removes
the race entirely rather than narrowing its window.

## Why declare the mechanism, not just patch the re-arm

The cheap fix the card itself named — re-resolve only when the switch's target
actually changed — is what's implemented (see below), but *where* it lives is the
bigger call the brief flagged: the accidental `TokenStorage` mechanism from #5749
stays load-bearing for every OTHER caller (impersonation's rotation), but
`switchOrganization` itself no longer rides it. That is the smallest version of
"declare it" that doesn't touch the shared, still-useful accident, and it directly
closes the reachable window above rather than narrowing it — a narrower re-arm (e.g.
re-priming `TokenStorage` after every switch so the *next* accidental flip still
notifies) would still race a THIRD switch arriving before the re-prime lands. Declaring
`switchOrganization`'s own responsibility removes the race categorically instead of
moving its edge.

## Fix

`switchOrganization` no longer depends on `TokenStorage` noticing a value change at
all. It tracks the organization it last resolved to (`activeOrgIdRef`, kept in sync
with every path that can move `activeOrganization`, not only `switchOrganization`
itself) and explicitly re-resolves identity whenever a switch's target differs from
that — declared, not accidental.

To avoid double-fetching the common single-switch path (the maintainers explicitly
declined an unconditional `refreshSession()` for this reason in #5749),
`switchOrganization` suppresses the now-redundant `TokenStorage` rotation notification
for its own `set-active` call (via the existing `sessionLoadInFlight` flag) and does
the one canonical `get-session` itself instead. A generation counter discards a
still-in-flight, now-superseded switch's answer rather than let it clobber a later
switch's fresher one — a new hazard the fix itself introduces (overlapping switches
were never possible before, since the old accidental mechanism effectively serialized
them by starving the second one of a rotation).

## Testing

- `packages/auth/src/__tests__/switchOrgIdentityReresolve-5719.test.tsx` (the file
  #5749 landed) is updated: its "counterfactual" case, which used to pin the *absence*
  of re-resolution when the switch response echoes an unchanged token spelling, now
  pins the fix — it re-resolves, at the same one-`get-session` cost as the ordinary
  case, not two.
- A new case, `the SECOND of two switches with no session read in between still
  re-resolves`, is the literal reproduction of the card: `get-session` is gated closed
  after boot, two switches fire with neither's own follow-up read landing, and the
  test asserts both independently triggered `get-session` (`before + 2`, not `+1`) and
  that the final settled identity reflects the second (later) organization, not the
  first.
- Reverse verification: reverted `AuthProvider.tsx` to `origin/main` and re-ran this
  file — exactly the 2 cases touched by this fix failed (2 failed | 5 passed), matching
  prediction; restored via `git checkout claude/issue-5750-cross-org-refresh-rearm --
  packages/auth/src/AuthProvider.tsx` and re-ran clean (7 passed).
- `pnpm --filter "@object-ui/auth^..." build` then `pnpm --filter "@object-ui/auth"
  build` (tsc) — both clean.
- `pnpm exec vitest run packages/auth/ --maxWorkers=2` — 24 files, 249 passed.
- `pnpm --filter "@object-ui/app-shell" build` (tsc, the direct downstream consumer of
  `switchOrganization`) — clean.
- `pnpm exec vitest run packages/app-shell/src/console/organizations/
  packages/app-shell/src/layout/ packages/app-shell/src/providers/ --maxWorkers=2` (the
  subtrees that consume `AuthProvider`/`switchOrganization`, incl.
  `WorkspaceSwitcher.test.tsx`, `OrganizationsPage.test.tsx`,
  `MetadataProvider.orgScopedCache.test.tsx`) — 52 files, 361 passed. All of these mock
  `useAuth` directly except two that render the real `AuthProvider`
  (`MetadataProvider.crossPrincipalSeed.test.tsx`, `ImpersonationBanner.test.tsx`),
  neither of which exercises `switchOrganization`.
- `pnpm exec eslint` on both changed files — 0 errors; the 3 pre-existing
  `react-hooks/set-state-in-effect` warnings in `AuthProvider.tsx` are unchanged from
  `origin/main` (confirmed by linting the unmodified `main` copy side by side).
- `node scripts/check-control-bytes.mjs` and `node scripts/check-changeset-presence.mjs`
  — both clean.

### `Type Check` fix (pushed after first CI run)

CI's `packages/auth` `type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) failed
its second leg: `TS2349: This expression is not callable. Type 'never' has no call
signatures.` at `release?.()` inside the **new** `the SECOND of two switches...` case
this PR added — **not** inside any of #5719's original, pre-existing cases, and
unrelated to `switchOrganization`'s signature. Root-caused and reproduced in total
isolation (a 3-line file outside this package/tsconfig): `tsc` narrows a
`let x: T | null = null` that is only ever reassigned inside a nested closure (here,
the `new Promise` executor) back to `null` at a later read site — it does not track
assignments across closure boundaries for control-flow narrowing — so `x?.()` excludes
`null` and is left with `never` to call, even though the executor runs synchronously
and the assignment is genuinely in place by the time of the call. Fixed by declaring
`release` non-nullable with a definite-assignment assertion
(`let release!: () => void`) instead, which is both accurate and what `tsc` can verify.
No assertion, mock, or pinned behaviour changed — reran `pnpm run type-check` in
`packages/auth` (`tsc --noEmit && tsc -p tsconfig.test.json`, both legs) clean, all 7
cases in the file still pass at runtime (`pnpm exec vitest run packages/auth/` — 24
files, 249 passed), and `pnpm exec eslint` on the file is still 0 errors.

Verified at `3d7ab4c9b`.

## Scope note

`AuthProvider.tsx` is also touched by unlabelled, not-yet-triaged **#5777** (the
sign-out-path purge twin of #5763), which is a *different* function
(`purgeSignedOutClientCaches`) in the same file, untouched here. Flagging per the
dispatch fence note so the two can be serialised if #5777 gets picked up before this
merges.

## Out of scope, on purpose

The card explicitly frames the accidental token-spelling mechanism itself as a design
question bigger than this card ("decide whether the console should stop depending on
[it]... rather than patching this window specifically"). This PR does make
`switchOrganization`'s own re-resolution declared rather than accidental, but it does
**not** touch `TokenStorage`'s general-purpose diff-on-write semantics or the
objectui#4467 rotation subscription itself (still load-bearing for impersonation) —
that remains an accident-shaped mechanism for every caller *other than*
`switchOrganization`. Whether it's worth declaring platform-wide is a separate,
larger decision this PR does not make.

---

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_
