### PR TITLE
docs(console): fix VITE_SERVER_URL dev defaults and dev-proxy scope in READMEs

### DIFF
--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -32,8 +32,11 @@ pnpm test
 ```
 
 The console is a **pure SPA** and requires an external ObjectStack backend.
-Point it at any running ObjectStack instance via `VITE_SERVER_URL` in
-`apps/console/.env.development` (defaults to `http://localhost:3000`).
+`VITE_SERVER_URL` in `apps/console/.env.development` ships empty (same-origin);
+the Vite dev server proxies `/api/*` to `http://localhost:3000` by default, or
+to `DEV_PROXY_TARGET` when set — e.g.
+`DEV_PROXY_TARGET=https://demo.objectstack.ai pnpm dev` — to point dev at a
+different backend without leaving same-origin.
 
 To run a backend locally, use the `@objectstack/cli` from a separate
 ObjectStack project checkout — we no longer ship an in-repo dev-server
@@ -49,9 +52,11 @@ The console runs as a standalone SPA against any ObjectStack backend:
 
 - Vite dev server with Hot Module Replacement (HMR), opens at
   http://localhost:5180.
-- Talks to the ObjectStack backend defined by `VITE_SERVER_URL`
-  (default `http://localhost:3000`).
-- Vite proxies `/api/*` and `/_account/*` to that backend.
+- `VITE_SERVER_URL` is empty by default (same origin); Vite proxies `/api/*`
+  to `http://localhost:3000`, or to `DEV_PROXY_TARGET` when set, to reach the
+  ObjectStack backend.
+- Only `/api/*` is proxied — `/_auth/*` and `/_account/*` are **not**
+  proxied.
 
 ### 2. Standalone SPA preview
 **Command:** `pnpm start`

--- a/examples/console-starter/README.md
+++ b/examples/console-starter/README.md
@@ -88,8 +88,13 @@ ObjectStack server serves the console itself.
 
 | File | Value |
 |---|---|
-| [`.env.development`](./.env.development) | `http://localhost:3000` |
-| [`.env.production`](./.env.production) | `https://demo.objectstack.ai` |
+| [`.env.development`](./.env.development) | empty (same-origin) |
+| [`.env.production`](./.env.production) | empty (same-origin) |
+
+Both files ship empty. In dev, the Vite server proxies `/api/*` to
+`http://localhost:3000` by default; to point dev at a different backend while
+keeping one origin, set `DEV_PROXY_TARGET`, e.g.
+`DEV_PROXY_TARGET=https://demo.objectstack.ai pnpm dev`.
 
 Point it at any ObjectStack server. If you need one locally, this repo's live-e2e
 helper [`e2e/live/ci/start-backend.sh`](../../e2e/live/ci/start-backend.sh) boots a


### PR DESCRIPTION
Fixes #5766

## What changed

PR #5765 emptied `VITE_SERVER_URL` in both console dev env files (same-origin by default, per the 2026-08-23 ruling on #5702). Three doc-prose items had drifted from that outcome:

1. **`apps/console/README.md`** (Quick Start + Development Mode) — said `VITE_SERVER_URL` defaults to `http://localhost:3000`. It now ships empty; the Vite dev proxy forwards `/api/*` to `http://localhost:3000` by default, or to `DEV_PROXY_TARGET` when set.
2. **`examples/console-starter/README.md`** (Backend table) — tabulated the old non-empty `.env.development`/`.env.production` values. Both files ship empty (same-origin); the table and surrounding prose now say so and give the same `DEV_PROXY_TARGET` recipe.
3. **`apps/console/README.md`** claimed the dev proxy covers `/api/*` and `/_account/*`. `vite.config.ts` (lines 709-711) only ever proxied `/api`. Per triage discretion on #5766 this fixes the doc rather than widening the proxy: zero first-party producers of `/_auth/`/`/_account/` action targets exist on `origin/main` (verified: `ActionRunner.ts:1343/1362` only define the regex that would route such a target; the only other hits are CHANGELOG entries, one ActionRunner test, and doc prose), and `apps/console/src/App.tsx:7` records `/_account/*` as being retired into the Console SPA. If a real producer of `/_auth/`/`/_account/` action targets appears, the config half (widening the proxy) reopens as its own card — not folded into this one.

## Verification

- Re-anchored the issue's citations against the current tree before editing: `apps/console/README.md:35-36` and `:52-54` (line numbers matched what the issue quoted), `examples/console-starter/README.md`'s Backend table (lines 89-92), and `apps/console/vite.config.ts:709-711` (proxy config, `/api` only, unchanged).
- Confirmed both `.env.development` files (console and console-starter) still carry the `DEV_PROXY_TARGET` recipe in their comments, as triage asked.
- Confirmed PR #5765 (#5745) is on this branch's base: `bc21c704b` is present in `git log origin/main`, and `9850c6e4e` (the commit the issue's reachability scan cites) is an ancestor of `origin/main`.
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.` (exit 0).
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4827 tracked text file(s); skipped 85 binary)`.
- `node scripts/check-changeset-presence.mjs` → `0 of them under the src/ of a package the release covers` → no changeset owed (README-only diff, not guarded source).
- Diff is prose-only, two files, no code/config touched (`vite.config.ts` not edited, per the card's instruction).

## Out of scope

Filed #5802 (unassigned): `content/docs/guide/console.md` (lines 18 and 55) has the same stale `VITE_SERVER_URL` → `http://localhost:3000` default drift, but sits outside this card's two-README scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_