### PR TITLE
fix(plugin-charts): keep the height chain intact through ObjectChart's wrapper (#5451)

### DIFF
--- a/.changeset/chart-height-chain-5451.md
+++ b/.changeset/chart-height-chain-5451.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+`ObjectChart`'s wrapper div now carries `h-full`, keeping the height chain intact from a dashboard grid cell's declared height down to the element Recharts measures. Previously the chain died at the plain auto-height wrapper: `height: 100%` on the chart container computed to `auto`, Recharts measured a permanent zero, and only the `CHART_MIN_HEIGHT` floor (#5503) kept dashboard charts visible — at a fixed floor height instead of filling the cell (#5451). Under auto-height parents `h-full` resolves to `auto`, so non-dashboard hosts are unchanged.

--- a/packages/plugin-charts/src/ObjectChart.heightChain.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.heightChain.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#5451 — the height chain through ObjectChart's wrapper.
+ *
+ * A dashboard grid cell declares a definite height and sends
+ * `className: "h-full"` down the widget schema; that class lands on
+ * ChartContainer, whose `height: 100%` resolves against ObjectChart's OWN
+ * wrapper div. When that wrapper is a plain auto-height block the chain dies
+ * there: the container computes to `auto`, recharts measures a permanent
+ * zero, and only the CHART_MIN_HEIGHT floor (#5503) keeps the chart from
+ * rendering blank — at a fixed floor height instead of filling the cell.
+ *
+ * Pinned here: the wrapper carries `h-full` so a parent-declared height
+ * actually reaches the measured element. (Under auto-height parents `h-full`
+ * resolves to `auto`, so non-dashboard hosts are unaffected — that is why
+ * this is safe unconditionally.)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('./ChartRenderer', () => ({
+  ChartRenderer: () => null,
+}));
+
+import { ObjectChart } from './ObjectChart';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ObjectChart wrapper height chain (objectui#5451)', () => {
+  it('the wrapper div propagates parent height (h-full), so a grid cell height reaches ChartContainer', () => {
+    const { container } = render(
+      <ObjectChart
+        schema={{
+          type: 'object-chart',
+          chartType: 'bar',
+          objectName: 'task',
+          xAxisKey: 'status',
+          className: 'h-full',
+          data: [{ status: 'open', count: 3 }],
+        }}
+        dataSource={{ find: async () => ({ data: [] }) }}
+      />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.className).toContain('h-full');
+  });
+});

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -1000,7 +1000,14 @@ export const ObjectChart = (props: any) => {
   })() : null;
 
   return (
-    <div className="relative">
+    // `h-full` keeps the height chain intact: a dashboard grid cell declares a
+    // definite height and passes `className: "h-full"` down the schema to
+    // ChartContainer, whose `height: 100%` resolves against THIS div — a plain
+    // auto-height block here computes that to `auto`, recharts measures a
+    // permanent zero, and only the CHART_MIN_HEIGHT floor keeps the chart
+    // visible at all (#5451). Under auto-height parents `h-full` itself
+    // resolves to `auto`, so non-dashboard hosts are unchanged.
+    <div className="relative h-full">
       <RefreshIndicator active={loading && finalData.length > 0} />
       <ChartRenderer {...props} schema={finalSchemaWithColors} onChartClick={onChartClick} />
       {drillDrawer}


### PR DESCRIPTION
Closes #5451.

**The blank itself is already cured**: the reported first-mount blank predates the #5503 floor fix (repro build `fd227eae1` < `6f017e99c`), and I verified live on the deployed staging build (which carries #5503) that an AI-built dashboard's metric card, pie, and bar all paint on first navigation with no reload.

**What this PR closes is the residual structural defect** the #5503 commit itself flagged unmeasured: the height chain from a dashboard grid cell dies at `ObjectChart`'s plain auto-height wrapper — `DashboardGridLayout` sends `className: "h-full"` down the schema to `ChartContainer`, whose `height: 100%` resolves against the wrapper and computes to `auto`, so recharts measures a permanent zero and the `CHART_MIN_HEIGHT` floor is the ONLY thing between a dashboard chart and invisibility (charts render at the fixed floor instead of filling their cell). One class on the wrapper (`h-full`) completes the chain; under auto-height parents it resolves to `auto`, so non-dashboard hosts are byte-identical (charts+dashboard suites: 110 files / 918 tests green).

New pin: `ObjectChart.heightChain.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)