### PR TITLE
feat(chatbot): confirm card carries the replay's terminal state — applied/drafted/failed/applying (#5695)

### DIFF
--- a/.changeset/chart-height-chain-5451.md
+++ b/.changeset/chart-height-chain-5451.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+`ObjectChart`'s wrapper div now carries `h-full`, keeping the height chain intact from a dashboard grid cell's declared height down to the element Recharts measures. Previously the chain died at the plain auto-height wrapper: `height: 100%` on the chart container computed to `auto`, Recharts measured a permanent zero, and only the `CHART_MIN_HEIGHT` floor (#5503) kept dashboard charts visible — at a fixed floor height instead of filling the cell (#5451). Under auto-height parents `h-full` resolves to `auto`, so non-dashboard hosts are unchanged.

--- a/.changeset/confirm-card-terminal-5695.md
+++ b/.changeset/confirm-card-terminal-5695.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/plugin-chatbot': minor
+'@object-ui/app-shell': patch
+'@object-ui/i18n': patch
+---
+
+The 确认修改 (confirm changes) card now carries a UI-owned terminal state after approval (#5695): `detectReplayOutcome` lifts the confirm-replay envelope (`replay_*` tool results) into 应用中 / 已生效 / 已暂存为草稿（含内联发布）/ 未生效（含 publishError 首行）, rendered on the original card across the live, hydration/share, and localStorage-cache converters. A failed in-turn publish no longer rehydrates as an ordinary draft card with a live Publish button — the UI-rendered refusal is the layer a model cannot narrate over. New `console.ai.changesApplying/Applied/Drafted/Failed` keys in all ten locale packs.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -74,6 +74,7 @@ import {
   detectProposedPlan,
   detectBuilderHandoff,
   detectProposedChanges,
+  detectReplayOutcome,
   buildProgressFromDraftReview,
   // The authoring/honest -> runtime message seam (objectui#4399 / PR #4416),
   // consumed here one hop up from the plugin's own renderers (objectui#4437).
@@ -192,15 +193,21 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
         // four; this is its hydration counterpart.
         const builderHandoff = detectBuilderHandoff(result);
         const proposedChanges = detectProposedChanges(result);
+        // objectui#5695 — a confirm-replay result becomes a terminal state on
+        // the original 确认修改 card; it must never rehydrate as an ordinary
+        // draft card (a rolled-back publish would get a live Publish button).
+        // Mirrors the live mapper's suppression exactly.
+        const replayOutcome = detectReplayOutcome(toolCallId, result);
         toolInvocations.push({
           toolCallId,
           toolName,
           ...(state ? { state } : {}),
           ...(result !== undefined ? { result } : {}),
-          ...(draftReview ? { draftReview } : {}),
+          ...(draftReview && !replayOutcome ? { draftReview } : {}),
           ...(proposedPlan ? { proposedPlan } : {}),
           ...(builderHandoff ? { builderHandoff } : {}),
           ...(proposedChanges ? { proposedChanges } : {}),
+          ...(replayOutcome ? { replayOutcome } : {}),
           ...(part.errorText ? { errorText: String(part.errorText) } : {}),
         });
         if (!buildProgress) {
@@ -2278,6 +2285,10 @@ export function ChatPane({
         })}
         changesConfirmMessage={changesConfirmMessage}
         changeVerbLabels={changeVerbLabels}
+        changesApplyingLabel={t('console.ai.changesApplying', { defaultValue: 'Applying…' })}
+        changesAppliedLabel={t('console.ai.changesApplied', { defaultValue: 'Applied' })}
+        changesDraftedLabel={t('console.ai.changesDrafted', { defaultValue: 'Saved as draft' })}
+        changesFailedLabel={t('console.ai.changesFailed', { defaultValue: 'Not applied' })}
         planAnswerMessage={(question, option) =>
           outboundText('planAnswerMessage', { question, option })
         }

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -170,6 +170,9 @@ interface CacheableChatToolInvocation {
    */
   draftReview?: CachedDraftReview;
   proposedPlan?: CachedProposedPlan;
+  /** objectui#5695 — the confirm-replay verdict, so the 确认修改 card's terminal
+   *  state (已生效 / 已暂存为草稿 / 未生效) survives a cache-fallback reload. */
+  replayOutcome?: { kind: 'published' | 'drafted' | 'failed'; outcome?: string; error?: string; packageId?: string };
 }
 
 interface CacheableChatMessage {
@@ -225,6 +228,30 @@ function proposedPlanToCachedResult(pp: CachedProposedPlan): Record<string, unkn
       })),
       assumptions: pp.assumptions,
     },
+  };
+}
+
+/**
+ * Rebuild the MINIMAL replay envelope `mapMessages.detectReplayOutcome`
+ * re-parses (objectui#5695). The detector keys off the persisted `replay_*`
+ * toolCallId plus these fields; `detectDraftResult` stays quiet over the
+ * drafted shapes because they carry no `drafted` items — so a rolled-back
+ * publish can never rehydrate from cache as a live draft card.
+ */
+function replayOutcomeToCachedResult(
+  ro: NonNullable<CacheableChatToolInvocation['replayOutcome']>,
+): Record<string, unknown> {
+  if (ro.kind === 'published') return { status: 'published' };
+  return {
+    status: 'drafted',
+    ...(ro.packageId ? { packageId: ro.packageId } : {}),
+    ...(ro.kind === 'failed'
+      ? {
+          publishFailed: true,
+          ...(ro.outcome ? { publishOutcome: ro.outcome } : {}),
+          ...(ro.error ? { publishError: ro.error } : {}),
+        }
+      : {}),
   };
 }
 
@@ -337,11 +364,13 @@ export function sanitizeChatMessagesForCache(
           // earlier cache shape never kept. `output` (not a custom part field)
           // is used because the AI SDK preserves it through `useChat` init,
           // exactly as the server-backed tool-result merge relies on.
-          const cachedOutput = tool.draftReview
-            ? draftReviewToCachedResult(tool.draftReview)
-            : tool.proposedPlan
-              ? proposedPlanToCachedResult(tool.proposedPlan)
-              : undefined;
+          const cachedOutput = tool.replayOutcome
+            ? replayOutcomeToCachedResult(tool.replayOutcome)
+            : tool.draftReview
+              ? draftReviewToCachedResult(tool.draftReview)
+              : tool.proposedPlan
+                ? proposedPlanToCachedResult(tool.proposedPlan)
+                : undefined;
           parts.push({
             type: `tool-${tool.toolName}`,
             toolCallId: tool.toolCallId,

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1562,6 +1562,10 @@ const ar = {
       changesConfirmed: "تم التأكيد",
       changesConfirm: "تأكيد",
       changesConfirmHint: "أجب لتأكيد هذا التغيير أو تعديله.",
+      changesApplying: "جارٍ التطبيق…",
+      changesApplied: "تم التطبيق",
+      changesDrafted: "حُفظ كمسودة",
+      changesFailed: "لم يُطبَّق",
       changeVerb: {
         createObject: "إنشاء كائن",
         addField: "إضافة حقل",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1555,6 +1555,10 @@ const de = {
       changesConfirmed: "Bestätigt",
       changesConfirm: "Bestätigen",
       changesConfirmHint: "Antworten Sie, um diese Änderung zu bestätigen oder anzupassen.",
+      changesApplying: "Wird angewendet…",
+      changesApplied: "Angewendet",
+      changesDrafted: "Als Entwurf gespeichert",
+      changesFailed: "Nicht angewendet",
       changeVerb: {
         createObject: "Objekt erstellen",
         addField: "Feld hinzufügen",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1805,6 +1805,10 @@ const en = {
       changesConfirmed: 'Confirmed',
       changesConfirm: 'Confirm',
       changesConfirmHint: 'Reply to confirm or adjust this change.',
+      changesApplying: 'Applying…',
+      changesApplied: 'Applied',
+      changesDrafted: 'Saved as draft',
+      changesFailed: 'Not applied',
       // Wording is load-bearing: this is SENT to the agent and must satisfy the
       // cloud confirm gate's English clause `apply (this|the) change`
       // (service-ai-studio confirm-gate.ts APPROVAL_RE). "apply what you just

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1559,6 +1559,10 @@ const es = {
       changesConfirmed: "Confirmado",
       changesConfirm: "Confirmar",
       changesConfirmHint: "Responda para confirmar o ajustar este cambio.",
+      changesApplying: "Aplicando…",
+      changesApplied: "Aplicado",
+      changesDrafted: "Guardado como borrador",
+      changesFailed: "No aplicado",
       changeVerb: {
         createObject: "Crear objeto",
         addField: "Añadir campo",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1557,6 +1557,10 @@ const fr = {
       changesConfirmed: "Confirmé",
       changesConfirm: "Confirmer",
       changesConfirmHint: "Répondez pour confirmer ou ajuster cette modification.",
+      changesApplying: "Application…",
+      changesApplied: "Appliqué",
+      changesDrafted: "Enregistré comme brouillon",
+      changesFailed: "Non appliqué",
       changeVerb: {
         createObject: "Créer un objet",
         addField: "Ajouter un champ",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1557,6 +1557,10 @@ const ja = {
       changesConfirmed: "確認済み",
       changesConfirm: "変更を確定",
       changesConfirmHint: "返信してこの変更を確定または調整してください。",
+      changesApplying: "適用中…",
+      changesApplied: "適用済み",
+      changesDrafted: "下書きとして保存",
+      changesFailed: "未適用",
       changeVerb: {
         createObject: "オブジェクトを作成",
         addField: "項目を追加",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1555,6 +1555,10 @@ const ko = {
       changesConfirmed: "확인됨",
       changesConfirm: "변경 확정",
       changesConfirmHint: "회신하여 이 변경을 확정하거나 조정하세요.",
+      changesApplying: "적용 중…",
+      changesApplied: "적용됨",
+      changesDrafted: "초안으로 저장됨",
+      changesFailed: "적용되지 않음",
       changeVerb: {
         createObject: "객체 생성",
         addField: "필드 추가",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1554,6 +1554,10 @@ const pt = {
       changesConfirmed: "Confirmado",
       changesConfirm: "Confirmar",
       changesConfirmHint: "Responda para confirmar ou ajustar esta alteração.",
+      changesApplying: "Aplicando…",
+      changesApplied: "Aplicado",
+      changesDrafted: "Salvo como rascunho",
+      changesFailed: "Não aplicado",
       changeVerb: {
         createObject: "Criar objeto",
         addField: "Adicionar campo",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1567,6 +1567,10 @@ const ru = {
       changesConfirmed: "Подтверждено",
       changesConfirm: "Подтвердить",
       changesConfirmHint: "Ответьте, чтобы подтвердить или скорректировать это изменение.",
+      changesApplying: "Применение…",
+      changesApplied: "Применено",
+      changesDrafted: "Сохранено как черновик",
+      changesFailed: "Не применено",
       changeVerb: {
         createObject: "Создать объект",
         addField: "Добавить поле",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1675,6 +1675,10 @@ const zh = {
       changesConfirmed: '已确认',
       changesConfirm: '确认修改',
       changesConfirmHint: '回复以确认或调整该改动。',
+      changesApplying: '应用中…',
+      changesApplied: '已生效',
+      changesDrafted: '已暂存为草稿',
+      changesFailed: '未生效',
       changesConfirmMessage: '确认修改，应用你刚才提议的改动。',
       changeVerb: {
         createObject: '新建对象',

--- a/packages/plugin-charts/src/ObjectChart.heightChain.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.heightChain.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#5451 — the height chain through ObjectChart's wrapper.
+ *
+ * A dashboard grid cell declares a definite height and sends
+ * `className: "h-full"` down the widget schema; that class lands on
+ * ChartContainer, whose `height: 100%` resolves against ObjectChart's OWN
+ * wrapper div. When that wrapper is a plain auto-height block the chain dies
+ * there: the container computes to `auto`, recharts measures a permanent
+ * zero, and only the CHART_MIN_HEIGHT floor (#5503) keeps the chart from
+ * rendering blank — at a fixed floor height instead of filling the cell.
+ *
+ * Pinned here: the wrapper carries `h-full` so a parent-declared height
+ * actually reaches the measured element. (Under auto-height parents `h-full`
+ * resolves to `auto`, so non-dashboard hosts are unaffected — that is why
+ * this is safe unconditionally.)
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('./ChartRenderer', () => ({
+  ChartRenderer: () => null,
+}));
+
+import { ObjectChart } from './ObjectChart';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ObjectChart wrapper height chain (objectui#5451)', () => {
+  it('the wrapper div propagates parent height (h-full), so a grid cell height reaches ChartContainer', () => {
+    const { container } = render(
+      <ObjectChart
+        schema={{
+          type: 'object-chart',
+          chartType: 'bar',
+          objectName: 'task',
+          xAxisKey: 'status',
+          className: 'h-full',
+          data: [{ status: 'open', count: 3 }],
+        }}
+        dataSource={{ find: async () => ({ data: [] }) }}
+      />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.className).toContain('h-full');
+  });
+});

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -1000,7 +1000,14 @@ export const ObjectChart = (props: any) => {
   })() : null;
 
   return (
-    <div className="relative">
+    // `h-full` keeps the height chain intact: a dashboard grid cell declares a
+    // definite height and passes `className: "h-full"` down the schema to
+    // ChartContainer, whose `height: 100%` resolves against THIS div — a plain
+    // auto-height block here computes that to `auto`, recharts measures a
+    // permanent zero, and only the CHART_MIN_HEIGHT floor keeps the chart
+    // visible at all (#5451). Under auto-height parents `h-full` itself
+    // resolves to `auto`, so non-dashboard hosts are unchanged.
+    <div className="relative h-full">
       <RefreshIndicator active={loading && finalData.length > 0} />
       <ChartRenderer {...props} schema={finalSchemaWithColors} onChartClick={onChartClick} />
       {drillDrawer}

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -320,6 +320,19 @@ export interface ChatToolInvocation {
     prompt: string;
     packageId?: string;
   };
+  /**
+   * objectui#5695 — the terminal verdict of a confirm-replay (`replay_<id>`
+   * tool results; cloud `runApprovedProposalReplay`). Rendered as a terminal
+   * state on the ORIGINAL 确认修改 card — 已生效 / 已暂存为草稿 / 未生效 — so a
+   * rolled-back publish exists somewhere a USER can see it, independent of
+   * whether the model narrates it honestly.
+   */
+  replayOutcome?: {
+    kind: 'published' | 'drafted' | 'failed';
+    outcome?: string;
+    error?: string;
+    packageId?: string;
+  };
 }
 
 export interface ChatSource {
@@ -718,6 +731,14 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * not supplied, so an unrecognised server-side verb still renders.
    */
   changeVerbLabels?: Record<string, string>;
+  /** In-flight badge while the confirm-replay is applying (default "Applying…"). objectui#5695. */
+  changesApplyingLabel?: string;
+  /** Terminal badge when the replay published the change (default "Applied"). */
+  changesAppliedLabel?: string;
+  /** Terminal badge when the replay staged a draft (default "Saved as draft"). */
+  changesDraftedLabel?: string;
+  /** Terminal badge when the replay's publish did not go live (default "Not applied"). */
+  changesFailedLabel?: string;
   /**
    * Live draft-status resolver: how many drafts are still PENDING in a
    * package (e.g. `GET /metadata/_drafts?packageId=` count). When provided,
@@ -1267,6 +1288,10 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       changesConfirmHintLabel = 'Reply to confirm or adjust this change.',
       changesConfirmMessage = 'Confirm — apply the change you just proposed.',
       changeVerbLabels = DEFAULT_CHANGE_VERB_LABELS,
+      changesApplyingLabel = 'Applying…',
+      changesAppliedLabel = 'Applied',
+      changesDraftedLabel = 'Saved as draft',
+      changesFailedLabel = 'Not applied',
       fetchPendingDraftCount,
       autoPublishDrafts = false,
       processVisibility = 'summary',
@@ -1599,6 +1624,30 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       },
       [onSendMessage, planApproveMessage, planApproveDefaultsMessage]
     );
+    // objectui#5695 — same optimistic pattern for the 确认修改 card: flip it to
+    // an "Applying…" badge the moment the approval is sent (double-click guard +
+    // immediate feedback); the durable terminal state derives from the replay
+    // envelope in the message stream (replayOutcomeByProposalId). A send that
+    // never left the client rolls the flip back so the buttons return.
+    const [confirmPendingIds, setConfirmPendingIds] = React.useState<ReadonlySet<string>>(
+      () => new Set<string>(),
+    );
+    const lastConfirmedChangeIdRef = React.useRef<string | null>(null);
+    const handleChangesConfirm = React.useCallback(
+      (toolCallId?: string) => {
+        if (toolCallId) {
+          lastConfirmedChangeIdRef.current = toolCallId;
+          setConfirmPendingIds((prev) => {
+            const next = new Set(prev);
+            next.add(toolCallId);
+            return next;
+          });
+        }
+        onSendMessage?.(changesConfirmMessage);
+      },
+      [onSendMessage, changesConfirmMessage],
+    );
+
     // "Adjust" doesn't send anything — it just drops the cursor into the input so
     // the user can describe the change in their own words.
     const handlePlanAdjust = React.useCallback(() => {
@@ -1624,6 +1673,17 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         const failedId = lastApprovedPlanIdRef.current;
         lastApprovedPlanIdRef.current = null;
         setApprovedPlanIds((prev) => {
+          if (!prev.has(failedId)) return prev;
+          const next = new Set(prev);
+          next.delete(failedId);
+          return next;
+        });
+      }
+      // Same rollback for an unsent 确认修改 approval (objectui#5695).
+      if (lastConfirmedChangeIdRef.current) {
+        const failedId = lastConfirmedChangeIdRef.current;
+        lastConfirmedChangeIdRef.current = null;
+        setConfirmPendingIds((prev) => {
           if (!prev.has(failedId)) return prev;
           const next = new Set(prev);
           next.delete(failedId);
@@ -1714,6 +1774,42 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         if (commit !== undefined && commit > p.order) ids.add(p.id);
       }
       return ids;
+    }, [messages]);
+
+    // objectui#5695 — correlate each confirm-replay result back to the 确认修改
+    // card it replays, so the card carries a UI-owned terminal state (已生效 /
+    // 已暂存为草稿 / 未生效) instead of going dark after the click. A replay
+    // re-dispatches the SAME tool, so the match is "latest earlier proposal of
+    // the same tool" — the same positional+per-tool convention as
+    // `confirmedChangeIds` above. A replay invocation still awaiting its result
+    // marks the card 'applying'; later replays of the same card overwrite
+    // earlier ones (an adjusted-and-reconfirmed change reports its LAST run).
+    const replayOutcomeByProposalId = React.useMemo(() => {
+      const byId = new Map<
+        string,
+        NonNullable<ChatToolInvocation['replayOutcome']> | { kind: 'applying' }
+      >();
+      const proposals: Array<{ id: string; toolName: string; order: number }> = [];
+      let order = 0;
+      for (const message of messages) {
+        for (const tool of message.toolInvocations ?? []) {
+          if (tool.proposedChanges && tool.toolCallId) {
+            proposals.push({ id: tool.toolCallId, toolName: tool.toolName ?? '', order });
+          } else if (tool.toolCallId?.startsWith('replay_')) {
+            let target: { id: string } | undefined;
+            for (const p of proposals) {
+              if (p.order < order && p.toolName === (tool.toolName ?? '')) target = p;
+            }
+            if (target) {
+              if (tool.replayOutcome) byId.set(target.id, tool.replayOutcome);
+              else if (tool.result === undefined && !tool.errorText)
+                byId.set(target.id, { kind: 'applying' });
+            }
+          }
+          order += 1;
+        }
+      }
+      return byId;
     }, [messages]);
 
     const renderToolDetail = (tool: ChatToolInvocation) => {
@@ -2377,22 +2473,110 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     </div>
                   ))}
                 </div>
-                {onSendMessage ? (
-                  confirmedChangeIds.has(tool.toolCallId) ? (
-                    <div className="flex flex-wrap items-center gap-1.5 pt-0.5" data-testid="proposed-changes-actions">
-                      <span
-                        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-3 text-xs font-medium text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-300"
-                        data-testid="proposed-changes-confirmed"
-                      >
-                        <CheckCircle2 className="size-3.5" />
-                        {changesConfirmedLabel}
+                {(() => {
+                  // objectui#5695 — after 确认修改, the card carries the replay's
+                  // verdict instead of going dark. Terminal states render on
+                  // EVERY surface (incl. the read-only share page): a UI-owned
+                  // failure state is the layer a model cannot narrate over.
+                  const outcome = replayOutcomeByProposalId.get(tool.toolCallId);
+                  if (outcome?.kind === 'published') {
+                    return (
+                      <div className="flex flex-wrap items-center gap-1.5 pt-0.5" data-testid="proposed-changes-actions">
+                        <span
+                          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-3 text-xs font-medium text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-300"
+                          data-testid="proposed-changes-applied"
+                        >
+                          <CheckCircle2 className="size-3.5" />
+                          {changesAppliedLabel}
+                        </span>
+                      </div>
+                    );
+                  }
+                  if (outcome?.kind === 'failed') {
+                    return (
+                      <div className="flex flex-col gap-1 pt-0.5" data-testid="proposed-changes-actions">
+                        <span
+                          className="inline-flex h-7 w-fit items-center gap-1.5 rounded-md border border-red-200 bg-red-50 px-3 text-xs font-medium text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+                          data-testid="proposed-changes-failed"
+                        >
+                          <XCircle className="size-3.5" />
+                          {changesFailedLabel}
+                        </span>
+                        {outcome.error ? (
+                          <span className="text-[11px] text-red-700/80 dark:text-red-300/80" data-testid="proposed-changes-failed-reason">
+                            {outcome.error}
+                          </span>
+                        ) : null}
+                      </div>
+                    );
+                  }
+                  if (outcome?.kind === 'drafted') {
+                    return (
+                      <div className="flex flex-wrap items-center gap-1.5 pt-0.5" data-testid="proposed-changes-actions">
+                        <span
+                          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-3 text-xs font-medium text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-300"
+                          data-testid="proposed-changes-drafted"
+                        >
+                          <Clock3 className="size-3.5" />
+                          {changesDraftedLabel}
+                        </span>
+                        {onPublishDrafts && outcome.packageId ? (
+                          <button
+                            type="button"
+                            onClick={() => void handlePublishDrafts(outcome.packageId!)}
+                            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                            data-testid="proposed-changes-publish"
+                          >
+                            <Rocket className="size-3.5" />
+                            {publishDraftsLabel}
+                          </button>
+                        ) : null}
+                      </div>
+                    );
+                  }
+                  const applying =
+                    outcome?.kind === 'applying' || confirmPendingIds.has(tool.toolCallId);
+                  if (applying) {
+                    return (
+                      <div className="flex flex-wrap items-center gap-1.5 pt-0.5" data-testid="proposed-changes-actions">
+                        <span
+                          className="inline-flex h-7 items-center gap-1.5 rounded-md border bg-muted/40 px-3 text-xs font-medium text-foreground/70"
+                          data-testid="proposed-changes-applying"
+                        >
+                          <Loader2 className="size-3.5 animate-spin" />
+                          {changesApplyingLabel}
+                        </span>
+                      </div>
+                    );
+                  }
+                  if (!onSendMessage) {
+                    return (
+                      <span className="text-[11px] italic text-muted-foreground/80">
+                        {changesConfirmHintLabel}
                       </span>
-                    </div>
-                  ) : (
+                    );
+                  }
+                  if (confirmedChangeIds.has(tool.toolCallId)) {
+                    // Legacy fallback for hosts whose replay envelope predates
+                    // the outcome fields: a later same-tool commit still
+                    // collapses the card, just without a verdict.
+                    return (
+                      <div className="flex flex-wrap items-center gap-1.5 pt-0.5" data-testid="proposed-changes-actions">
+                        <span
+                          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-3 text-xs font-medium text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:text-emerald-300"
+                          data-testid="proposed-changes-confirmed"
+                        >
+                          <CheckCircle2 className="size-3.5" />
+                          {changesConfirmedLabel}
+                        </span>
+                      </div>
+                    );
+                  }
+                  return (
                     <div className="flex flex-wrap items-center gap-1.5 pt-0.5" data-testid="proposed-changes-actions">
                       <button
                         type="button"
-                        onClick={() => onSendMessage(changesConfirmMessage)}
+                        onClick={() => handleChangesConfirm(tool.toolCallId)}
                         className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
                         data-testid="proposed-changes-confirm"
                       >
@@ -2408,12 +2592,8 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                         {planAdjustLabel}
                       </button>
                     </div>
-                  )
-                ) : (
-                  <span className="text-[11px] italic text-muted-foreground/80">
-                    {changesConfirmHintLabel}
-                  </span>
-                )}
+                  );
+                })()}
               </div>
             ) : null}
           </ToolContent>

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.replayOutcome.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.replayOutcome.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5695 — the 确认修改 card's terminal states after approval.
+ *
+ * Clicking 确认修改 makes the runtime re-dispatch the proposal under a
+ * `replay_<id>` tool call. Before this card knew about replays, everything
+ * after the click was a black box: the card looked untouched, a REFUSED
+ * publish (`publishFailed:true, publishOutcome:'rolled_back'`) existed only in
+ * a tool-result JSON the user never sees, and the agent could narrate success
+ * over it (the 2026-08-22 staging E2E on cloud#1584). These pins drive each
+ * replay envelope shape through the real message stream and assert the card
+ * renders the verdict — the failure state above all, because a UI-rendered
+ * refusal is the layer a model cannot talk over.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChatbotEnhanced, type ChatMessage } from '../ChatbotEnhanced';
+
+function proposalMessage(): ChatMessage {
+  return {
+    id: 'a1',
+    role: 'assistant',
+    content: '',
+    toolInvocations: [
+      {
+        toolCallId: 't1',
+        toolName: 'update_metadata',
+        state: 'output-available',
+        proposedChanges: {
+          changes: [{ verb: 'add_field', object: 'task', field: 'priority' }],
+        },
+      },
+    ],
+  };
+}
+
+function replayMessage(
+  outcome: NonNullable<
+    NonNullable<ChatMessage['toolInvocations']>[number]['replayOutcome']
+  > | undefined,
+  extra: Partial<NonNullable<ChatMessage['toolInvocations']>[number]> = {},
+): ChatMessage {
+  return {
+    id: 'a2',
+    role: 'assistant',
+    content: '',
+    toolInvocations: [
+      {
+        toolCallId: 'replay_turn_0',
+        toolName: 'update_metadata',
+        state: 'output-available',
+        result: '{}',
+        ...(outcome ? { replayOutcome: outcome } : {}),
+        ...extra,
+      },
+    ],
+  };
+}
+
+describe('ChatbotEnhanced — confirm card replay terminal states (objectui#5695)', () => {
+  it('published replay → the card shows the Applied badge, no live buttons', () => {
+    render(
+      <ChatbotEnhanced
+        messages={[proposalMessage(), replayMessage({ kind: 'published' })]}
+        onSendMessage={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-applied')).toHaveTextContent('Applied');
+    expect(screen.queryByTestId('proposed-changes-confirm')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('proposed-changes-confirmed')).not.toBeInTheDocument();
+  });
+
+  it('drafted replay → Saved-as-draft badge, with an inline publish affordance when the host can publish', () => {
+    const onPublishDrafts = vi.fn(async () => true);
+    render(
+      <ChatbotEnhanced
+        messages={[proposalMessage(), replayMessage({ kind: 'drafted', packageId: 'app.k9qk' })]}
+        onSendMessage={vi.fn()}
+        onPublishDrafts={onPublishDrafts}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-drafted')).toHaveTextContent('Saved as draft');
+    fireEvent.click(screen.getByTestId('proposed-changes-publish'));
+    expect(onPublishDrafts).toHaveBeenCalledWith('app.k9qk');
+  });
+
+  it('drafted replay without a publish host (read-only share page) → badge only, no button', () => {
+    render(
+      <ChatbotEnhanced
+        messages={[proposalMessage(), replayMessage({ kind: 'drafted', packageId: 'app.k9qk' })]}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-drafted')).toBeInTheDocument();
+    expect(screen.queryByTestId('proposed-changes-publish')).not.toBeInTheDocument();
+  });
+
+  it('failed replay → Not-applied badge carrying the publishError headline; the point of the card', () => {
+    render(
+      <ChatbotEnhanced
+        messages={[
+          proposalMessage(),
+          replayMessage({
+            kind: 'failed',
+            outcome: 'rolled_back',
+            error: 'publish gate: dangling view reference k9qk_task.board',
+          }),
+        ]}
+        onSendMessage={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-failed')).toHaveTextContent('Not applied');
+    expect(screen.getByTestId('proposed-changes-failed-reason')).toHaveTextContent(
+      'dangling view reference',
+    );
+    // The legacy positional 已确认 badge must NOT win over the failure verdict —
+    // that would be the old "narrated success" bug in UI form.
+    expect(screen.queryByTestId('proposed-changes-confirmed')).not.toBeInTheDocument();
+  });
+
+  it('replay still in flight (no result yet) → Applying… spinner state', () => {
+    render(
+      <ChatbotEnhanced
+        messages={[
+          proposalMessage(),
+          replayMessage(undefined, { state: 'input-available', result: undefined }),
+        ]}
+        onSendMessage={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-applying')).toHaveTextContent('Applying…');
+  });
+
+  it('clicking 确认修改 flips the card to Applying… optimistically', () => {
+    render(<ChatbotEnhanced messages={[proposalMessage()]} onSendMessage={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('proposed-changes-confirm'));
+    expect(screen.getByTestId('proposed-changes-applying')).toBeInTheDocument();
+    expect(screen.queryByTestId('proposed-changes-confirm')).not.toBeInTheDocument();
+  });
+
+  it('a second proposal after a replayed one keeps its own live buttons (positional, per-card)', () => {
+    const second: ChatMessage = {
+      id: 'a3',
+      role: 'assistant',
+      content: '',
+      toolInvocations: [
+        {
+          toolCallId: 't2',
+          toolName: 'update_metadata',
+          state: 'output-available',
+          proposedChanges: { changes: [{ verb: 'delete_field', object: 'task', field: 'old' }] },
+        },
+      ],
+    };
+    render(
+      <ChatbotEnhanced
+        messages={[proposalMessage(), replayMessage({ kind: 'published' }), second]}
+        onSendMessage={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-applied')).toBeInTheDocument();
+    expect(screen.getByTestId('proposed-changes-confirm')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.replayOutcome.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.replayOutcome.test.ts
@@ -1,0 +1,107 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#5695 — `detectReplayOutcome` and its suppression contract.
+ *
+ * The replay envelope is the ordinary authoring envelope under a synthetic
+ * `replay_<turn>_<i>` toolCallId (cloud `runApprovedProposalReplay`); the
+ * failure stamp is cloud#1467's `publishFailed:true` + `publishOutcome` +
+ * `publishError` over `status:'drafted'`. The dangerous shape is the failed
+ * one: before this detector, `detectDraftResult` matched it and the chat
+ * rendered a rolled-back publish as an ordinary successful draft card with a
+ * live Publish button.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectReplayOutcome, uiMessagesToChatMessages } from '../mapMessages';
+
+const FAILED = JSON.stringify({
+  status: 'drafted',
+  drafted: [{ type: 'view', name: 'k9qk_task.board' }],
+  packageId: 'app.k9qk',
+  publishFailed: true,
+  publishOutcome: 'rolled_back',
+  publishError: 'publish gate: dangling view reference\nsecond line of detail',
+});
+
+describe('detectReplayOutcome (objectui#5695)', () => {
+  it('lifts a published replay', () => {
+    expect(detectReplayOutcome('replay_t1_0', JSON.stringify({ status: 'published' }))).toEqual({
+      kind: 'published',
+    });
+  });
+
+  it('lifts a drafted replay with its packageId for the inline publish affordance', () => {
+    expect(
+      detectReplayOutcome(
+        'replay_t1_0',
+        JSON.stringify({ status: 'drafted', drafted: [{ type: 'view', name: 'v' }], packageId: 'app.k9qk' }),
+      ),
+    ).toEqual({ kind: 'drafted', packageId: 'app.k9qk' });
+  });
+
+  it('lifts a failed publish with the machine verdict and the FIRST line of publishError', () => {
+    expect(detectReplayOutcome('replay_t1_0', FAILED)).toEqual({
+      kind: 'failed',
+      outcome: 'rolled_back',
+      error: 'publish gate: dangling view reference',
+      packageId: 'app.k9qk',
+    });
+  });
+
+  it('ignores the same envelope under a NON-replay toolCallId — ordinary tool results keep their cards', () => {
+    expect(detectReplayOutcome('call_abc', FAILED)).toBeUndefined();
+    expect(detectReplayOutcome(undefined, FAILED)).toBeUndefined();
+  });
+
+  it('ignores replay results that are not authoring envelopes', () => {
+    expect(detectReplayOutcome('replay_t1_0', JSON.stringify({ status: 'ok' }))).toBeUndefined();
+    expect(detectReplayOutcome('replay_t1_0', 'plain text')).toBeUndefined();
+  });
+});
+
+describe('replay suppression in the live mapper (objectui#5695)', () => {
+  it('a failed replay carries replayOutcome and NO draftReview — never a live Publish button over a rollback', () => {
+    const [msg] = uiMessagesToChatMessages([
+      {
+        id: 'm1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-update_metadata',
+            toolCallId: 'replay_t1_0',
+            state: 'output-available',
+            output: FAILED,
+          },
+        ],
+      },
+    ] as never);
+    const tool = msg.toolInvocations?.[0];
+    expect(tool?.replayOutcome?.kind).toBe('failed');
+    expect(tool?.draftReview).toBeUndefined();
+  });
+
+  it('the same drafted envelope under an ordinary id still produces the draft card', () => {
+    const [msg] = uiMessagesToChatMessages([
+      {
+        id: 'm1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-update_metadata',
+            toolCallId: 'call_1',
+            state: 'output-available',
+            output: JSON.stringify({
+              status: 'drafted',
+              drafted: [{ type: 'view', name: 'v' }],
+              packageId: 'app.k9qk',
+            }),
+          },
+        ],
+      },
+    ] as never);
+    const tool = msg.toolInvocations?.[0];
+    expect(tool?.draftReview?.items).toEqual([{ type: 'view', name: 'v' }]);
+    expect(tool?.replayOutcome).toBeUndefined();
+  });
+});

--- a/packages/plugin-chatbot/src/chatMessageAdapter.ts
+++ b/packages/plugin-chatbot/src/chatMessageAdapter.ts
@@ -101,7 +101,12 @@ type RuntimeOnlyMessageKeys = Pick<
  */
 type RuntimeOnlyToolInvocationKeys = Pick<
   RuntimeToolInvocation,
-  'pendingActionId' | 'draftReview' | 'proposedPlan' | 'proposedChanges' | 'builderHandoff'
+  | 'pendingActionId'
+  | 'draftReview'
+  | 'proposedPlan'
+  | 'proposedChanges'
+  | 'builderHandoff'
+  | 'replayOutcome'
 >;
 
 /**

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -359,9 +359,16 @@ export {
   detectProposedPlan,
   detectBuilderHandoff,
   detectProposedChanges,
+  detectReplayOutcome,
   buildProgressFromDraftReview,
 } from './mapMessages';
-export type { DraftReview, ProposedPlan, BuilderHandoff, ProposedChanges } from './mapMessages';
+export type {
+  DraftReview,
+  ProposedPlan,
+  BuilderHandoff,
+  ProposedChanges,
+  ReplayOutcome,
+} from './mapMessages';
 
 // `@object-ui/types` ChatMessage (the JSON/SDUI AUTHORING contract) → the
 // runtime `ChatMessage` above. Exported for the same reason as the mappers on

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -325,6 +325,55 @@ export function detectProposedChanges(result: unknown): ProposedChanges | undefi
   return { ...(str(obj.summary) ? { summary: str(obj.summary) } : {}), changes };
 }
 
+/**
+ * objectui#5695 — the terminal verdict of a confirm-replay.
+ *
+ * When the user approves a 确认修改 card, the runtime re-dispatches the
+ * proposal deterministically and appends the result under a synthetic
+ * `replay_<turn>_<i>` tool-call id (cloud `runApprovedProposalReplay`). The
+ * envelope is the ordinary authoring envelope — `status:'published'`,
+ * or `status:'drafted'` optionally stamped `publishFailed:true` +
+ * `publishOutcome`/`publishError` when the in-turn publish rolled back
+ * (cloud#1467). Lifted into a dedicated shape so the confirm card can render
+ * a UI-owned terminal state — the layer a model cannot narrate over.
+ */
+export interface ReplayOutcome {
+  kind: 'published' | 'drafted' | 'failed';
+  /** Machine verdict of a failed publish (`rejected` / `rolled_back` / `nothing_published`). */
+  outcome?: string;
+  /** First line of `publishError`, for the 未生效 headline. */
+  error?: string;
+  /** Owning package of a drafted outcome, for the inline publish affordance. */
+  packageId?: string;
+}
+
+export function detectReplayOutcome(
+  toolCallId: string | undefined,
+  result: unknown,
+): ReplayOutcome | undefined {
+  if (!toolCallId || !toolCallId.startsWith('replay_')) return undefined;
+  const obj = parseResultEnvelope(result);
+  if (!obj) return undefined;
+  if (obj.status === 'published') return { kind: 'published' };
+  if (obj.status !== 'drafted') return undefined;
+  const rawPkg = (obj as { packageId?: unknown }).packageId;
+  const packageId =
+    typeof rawPkg === 'string' && rawPkg ? { packageId: rawPkg } : {};
+  if ((obj as { publishFailed?: unknown }).publishFailed === true) {
+    const rawErr = (obj as { publishError?: unknown }).publishError;
+    const error =
+      typeof rawErr === 'string' && rawErr.trim() ? rawErr.trim().split('\n')[0] : undefined;
+    const rawOutcome = (obj as { publishOutcome?: unknown }).publishOutcome;
+    return {
+      kind: 'failed',
+      ...(typeof rawOutcome === 'string' && rawOutcome ? { outcome: rawOutcome } : {}),
+      ...(error ? { error } : {}),
+      ...packageId,
+    };
+  }
+  return { kind: 'drafted', ...packageId };
+}
+
 export function detectDraftResult(result: unknown): DraftReview | undefined {
   const obj = parseResultEnvelope(result);
   if (!obj || obj.status !== 'drafted') return undefined;
@@ -453,9 +502,18 @@ function extractToolInvocations(
           : typeof p.type === 'string'
             ? p.type.replace(/^tool-/, '')
             : 'tool';
+      const toolCallId =
+        p.toolCallId ?? p.id ?? `${p.type ?? 'tool'}-${Math.random().toString(36).slice(2, 8)}`;
       const result = p.output ?? p.result;
       const pending = detectPendingApproval(result);
-      const draftReview = detectDraftResult(result);
+      // A confirm-replay result renders as a terminal state on the ORIGINAL
+      // confirm card, never as its own card — in particular a failed in-turn
+      // publish must NOT surface as an ordinary draft card with a live Publish
+      // button (that is exactly the "narrated success over a rollback" the
+      // card exists to prevent, #5695). So a matched replay suppresses the
+      // draft-review lift for this invocation.
+      const replayOutcome = detectReplayOutcome(toolCallId, result);
+      const draftReview = replayOutcome ? undefined : detectDraftResult(result);
       const proposedPlan = detectProposedPlan(result);
       const proposedChanges = detectProposedChanges(result);
       const builderHandoff = detectBuilderHandoff(result);
@@ -481,8 +539,7 @@ function extractToolInvocations(
       const state: ChatToolInvocation['state'] =
         pending && baseState !== 'output-error' ? 'approval-requested' : baseState;
       return {
-        toolCallId:
-          p.toolCallId ?? p.id ?? `${p.type ?? 'tool'}-${Math.random().toString(36).slice(2, 8)}`,
+        toolCallId,
         toolName,
         args: p.input ?? p.args,
         result,
@@ -493,6 +550,7 @@ function extractToolInvocations(
         proposedPlan,
         proposedChanges,
         builderHandoff,
+        replayOutcome,
       } satisfies ChatToolInvocation;
     });
 }


### PR DESCRIPTION
Closes #5695 (maintainer-accepted B5 of the cloud#1521 journey-UX review).

After 确认修改 the card went dark: a published replay collapsed into an anonymous Completed chip, and a REFUSED in-turn publish (`publishFailed:true, publishOutcome:'rolled_back'`, cloud#1467) rendered as an **ordinary successful draft card with a live Publish button** — the exact 'agent narrates success over a rollback' failure from the cloud#1584 staging E2E, in UI form.

- `detectReplayOutcome(toolCallId, result)` lifts the `replay_*` envelope (cloud `runApprovedProposalReplay`) into `{kind: published|drafted|failed, outcome?, error?, packageId?}`.
- The original confirm card correlates the replay positionally (same per-tool convention as `confirmedChangeIds`) and renders: **应用中** (optimistic on click, rollback on unsent, + in-flight replay) → **已生效** / **已暂存为草稿** (+ inline publish from the replay's own packageId) / **未生效** (+ `publishError` first line). The failure state renders on every surface including the read-only share page — a UI-rendered refusal is the layer a model cannot narrate over.
- All three converters carry the shape: live (`mapMessages`), hydration + `/s/:token` readOnly (`AiChatPage`), and the localStorage cache (`useChatConversation`, minimal-envelope round-trip). Replays suppress the `draftReview` lift on every path, so a rollback can never re-grow a Publish button. Adapter seam declares the new render-only key.
- i18n: four `console.ai.changes*` keys in all ten packs.

Suites: plugin-chatbot 340, app-shell 4907 (+1 skipped), i18n 881 — green; i18n gate scripts (call-site keys / dead keys / en-drift) clean; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)