### PR TITLE
feat(types): retire 'agenda' from defaultView on all three declaration faces

### DIFF
--- a/.changeset/default-view-agenda-retired-5784.md
+++ b/.changeset/default-view-agenda-retired-5784.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/types': minor
+---
+
+`'agenda'` leaves `defaultView` on all three of its declaration faces
+(objectui#5784 — the `defaultView` sibling of objectui#5740's retirement on
+`CalendarViewSchema.view`; ADR-0049 enforce-or-remove): the
+`ObjectCalendarSchema` TS interface (an inline union `#5740`'s
+`CalendarViewMode` narrowing could not reach), the zod `ObjectCalendarSchema`,
+and the list-view `calendar` config's objectui-only `defaultView` extension.
+All three are now `['month', 'week', 'day']`.
+
+The declarations admitted a value nothing enforced: `ObjectCalendar`'s props
+declare `defaultView?: 'month' | 'week' | 'day'`, its schema read casts to the
+same three values, and `CalendarView` renders no agenda view. An author
+writing the type-legal, zod-valid `defaultView: 'agenda'` on an
+`object-calendar` node or in a list view's `calendar` config got a month
+calendar with no error or warning. The spec side already agrees:
+`@objectstack/spec`'s `ObjectCalendarProps.defaultView` is
+`['month', 'week', 'day']`. No in-repo, example, or catalog app authors
+`defaultView: 'agenda'` (measured for objectui#5784 with positive controls,
+including the objectstack tree — its only `agenda` token is the Agenda
+job-scheduler library).
+
+**This narrows the accept set: an author who writes `defaultView: 'agenda'`
+will now be refused at validation.** `defaultView` is a declared key, and
+declared keys are validated even under `.passthrough()`, so
+`defaultView: 'agenda'` is a **validation error that previously parsed
+green** (an `invalid_value` issue on the `defaultView` /
+`calendar.defaultView` path, offering `month`/`week`/`day`). Undeclared keys
+still pass through unchanged. Breaking on the published zod surface; ships as
+`minor` per this repo's version-alignment policy (majors track
+`@objectstack`).
+
+The runtime boundary is unchanged: `ObjectCalendar` still resolves an
+off-union raw `defaultView` away to its `'month'` default. Docblocks and both
+zod `describe` strings now teach the three-value set.

--- a/packages/types/src/__tests__/default-view-agenda-retired.test.ts
+++ b/packages/types/src/__tests__/default-view-agenda-retired.test.ts
@@ -1,0 +1,161 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — `'agenda'` leaves `defaultView` on all three declaration
+ * faces (objectui#5784, the `defaultView` sibling of objectui#5740's
+ * retirement on `CalendarViewSchema.view`):
+ *
+ *   1. the `ObjectCalendarSchema` TS interface (an INLINE union, not a
+ *      `CalendarViewMode` reference — which is exactly why #5740's narrowing
+ *      did not move it),
+ *   2. the zod `ObjectCalendarSchema`,
+ *   3. the list-view `calendar` config (`CalendarConfig`, the objectui-only
+ *      `defaultView` extension of the spec's `CalendarConfigSchema`).
+ *
+ * The enforcement points read three values: `ObjectCalendar`'s props declare
+ * `defaultView?: 'month' | 'week' | 'day'`, its schema read casts to the same
+ * three, and `CalendarView` renders no agenda view — so an author writing the
+ * zod-valid `defaultView: 'agenda'` got a month calendar with no error.
+ * Declared ≠ enforced, on a published surface (ADR-0049). The spec side
+ * agrees: `@objectstack/spec`'s `ObjectCalendarProps.defaultView` is already
+ * `['month', 'week', 'day']`.
+ *
+ * ⚠️ Like #5740 this NARROWS the accept set: `defaultView` is a DECLARED key,
+ * and declared keys are validated even under `.passthrough()`, so
+ * `defaultView: 'agenda'` — which parsed green before — is now a validation
+ * error. The zod faces are pinned by the REFUSAL ENVELOPE (a
+ * `defaultView`-path `invalid_value` issue naming the surviving vocabulary)
+ * rather than a bare `success === false`, and the passthrough control pins
+ * that the rejection is declared-key validation, not a strictness change. The
+ * TS half erases at runtime, so it is pinned with `@ts-expect-error`, which is
+ * real enforcement here because `packages/types/tsconfig.test.json` is chained
+ * from this package's `type-check` script (#3009).
+ *
+ * The runtime read is deliberately NOT changed: `ObjectCalendar` still casts
+ * an off-union raw value away and falls back to `'month'` at the renderer
+ * boundary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ObjectCalendarSchema as ObjectCalendarZodSchema,
+  ListViewSchema,
+} from '../zod/objectql.zod.js';
+import type { ObjectCalendarSchema } from '../objectql.js';
+
+/** The retired value, and the survivors the renderer actually renders. */
+const RETIRED = 'agenda';
+const SURVIVORS = ['month', 'week', 'day'] as const;
+
+/** Refusal-envelope assertion shared by both zod faces. */
+function expectDefaultViewRefusal(
+  // zod 4 types issue paths as `PropertyKey[]` (symbols admitted), so the
+  // parameter must too — `(string | number)[]` fails `type-check` here.
+  result: { success: boolean; error?: { issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey>; code: string }> } },
+  path: string,
+) {
+  expect(result.success).toBe(false);
+  if (result.success || !result.error) return;
+
+  // The envelope, not just the verdict: exactly one issue, on the
+  // `defaultView` path, coded as a closed-vocabulary violation. A bare
+  // `success === false` would also pass if the node had been rejected for an
+  // unrelated reason. (Measured on zod 4, an `invalid_value` issue carries the
+  // ALLOWED `values` and no echo of the input — so the offending value is
+  // deliberately not asserted to appear in the message.)
+  const issues = result.error.issues.filter((i) => i.path.join('.') === path);
+  expect(issues).toHaveLength(1);
+  expect(issues[0].code).toBe('invalid_value');
+
+  // The shrink, read off the refusal: the retired value is gone from the
+  // offered vocabulary and every survivor is still in it.
+  const offered = (issues[0] as { values?: unknown[] }).values ?? [];
+  expect(offered).not.toContain(RETIRED);
+  for (const survivor of SURVIVORS) expect(offered).toContain(survivor);
+}
+
+describe("zod ObjectCalendarSchema.defaultView — the NEW rejection this retirement creates", () => {
+  it("rejects `defaultView: 'agenda'` on the `defaultView` path, where it previously parsed green", () => {
+    const result = ObjectCalendarZodSchema.safeParse({
+      type: 'object-calendar',
+      objectName: 'events',
+      defaultView: RETIRED,
+    });
+    expectDefaultViewRefusal(result, 'defaultView');
+  });
+
+  it('still accepts every rendered view mode in full', () => {
+    // Full green parses, not merely "no `defaultView` issue": a value-level
+    // shrink that quietly invalidated a survivor would otherwise go unseen.
+    for (const survivor of SURVIVORS) {
+      const result = ObjectCalendarZodSchema.safeParse({
+        type: 'object-calendar',
+        objectName: 'events',
+        defaultView: survivor,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('passthrough control: an UNDECLARED key still parses — the rejection above is declared-key validation, not a strictness change', () => {
+    // `BaseSchema` is `.passthrough()`. This pin keeps the two facts apart:
+    // unknown keys pass (unchanged), while a declared key's value is validated
+    // (the new rejection above). If this control ever reds, the schema's
+    // strictness changed — a different contract decision than #5784.
+    const result = ObjectCalendarZodSchema.safeParse({
+      type: 'object-calendar',
+      objectName: 'events',
+      someUndeclaredKey: RETIRED,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("ListViewSchema `calendar.defaultView` — the objectui-only extension moves in lockstep", () => {
+  it("rejects `calendar: { defaultView: 'agenda' }` on the `calendar.defaultView` path", () => {
+    const result = ListViewSchema.safeParse({
+      type: 'list-view',
+      objectName: 'events',
+      calendar: { startDateField: 'starts_at', defaultView: RETIRED },
+    });
+    expectDefaultViewRefusal(result, 'calendar.defaultView');
+  });
+
+  it('still accepts every rendered view mode in full', () => {
+    for (const survivor of SURVIVORS) {
+      const result = ListViewSchema.safeParse({
+        type: 'list-view',
+        objectName: 'events',
+        calendar: { startDateField: 'starts_at', defaultView: survivor },
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+describe('the published TS twin no longer offers the retired value', () => {
+  it('`ObjectCalendarSchema.defaultView` rejects it at compile time and keeps the survivors', () => {
+    const node: ObjectCalendarSchema = {
+      type: 'object-calendar',
+      objectName: 'events',
+      // @ts-expect-error — 'agenda' left the inline union (objectui#5784).
+      defaultView: RETIRED,
+    };
+    expect(node.defaultView).toBe(RETIRED);
+
+    for (const survivor of SURVIVORS) {
+      const green: ObjectCalendarSchema = {
+        type: 'object-calendar',
+        objectName: 'events',
+        defaultView: survivor,
+      };
+      expect(green.defaultView).toBe(survivor);
+    }
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1977,8 +1977,12 @@ export interface ObjectCalendarSchema extends BaseSchema {
   endDateField?: string;
   /** Field for event title */
   titleField?: string;
-  /** Default view mode */
-  defaultView?: 'month' | 'week' | 'day' | 'agenda';
+  /**
+   * Default view mode — the renderer's rendered set. `'agenda'` was retired
+   * (objectui#5784, following #5740): `CalendarView` renders no agenda view,
+   * and the enforcement points read only these three values.
+   */
+  defaultView?: 'month' | 'week' | 'day';
 }
 
 /**

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -342,8 +342,9 @@ const KanbanConfig = SpecKanbanConfigSchema.partial().extend({
 
 const CalendarConfig = SpecCalendarConfigSchema.partial().extend({
   // objectui-only: the calendar renderer's initial view mode. No spec counterpart —
-  // promote it rather than growing this extension.
-  defaultView: z.enum(['month', 'week', 'day', 'agenda']).optional().describe('Initial calendar view mode'),
+  // promote it rather than growing this extension. `'agenda'` was retired
+  // (objectui#5784, following #5740): `CalendarView` renders no agenda view.
+  defaultView: z.enum(['month', 'week', 'day']).optional().describe("Initial calendar view mode — 'month' | 'week' | 'day' ('agenda' was retired: objectui#5784)"),
 }).passthrough();
 
 const GalleryConfig = SpecGalleryConfigSchema.partial().extend({
@@ -614,7 +615,7 @@ export const ObjectCalendarSchema = BaseSchema.extend({
   startDateField: z.string().optional().describe('Start date field'),
   endDateField: z.string().optional().describe('End date field'),
   titleField: z.string().optional().describe('Title field'),
-  defaultView: z.enum(['month', 'week', 'day', 'agenda']).optional().describe('Default view'),
+  defaultView: z.enum(['month', 'week', 'day']).optional().describe("Default view — 'month' | 'week' | 'day', the renderer's rendered set ('agenda' was retired: objectui#5784)"),
 });
 
 /**


### PR DESCRIPTION
Fixes #5784

**`Clause-②: yes`** — accept-set narrowing on a published validator surface: an author who writes `defaultView: 'agenda'` will now be refused at validation, where it previously parsed green.

## What

Narrows `defaultView` to `['month', 'week', 'day']` on all three declaration faces, in lockstep (Option A by the inherited ruling in the issue's triage comment, basis transferring from objectui#5740 — same renderer, same retired view):

1. `packages/types/src/objectql.ts` — the `ObjectCalendarSchema` TS interface's **inline union** (not a `CalendarViewMode` reference, which is exactly why objectui#5740's narrowing did not move it)
2. `packages/types/src/zod/objectql.zod.ts` — zod `ObjectCalendarSchema.defaultView`
3. `packages/types/src/zod/objectql.zod.ts` — the list-view `calendar` config (`CalendarConfig`), the objectui-only `defaultView` extension of the spec's `CalendarConfigSchema`

Plus a retirement pin test (`packages/types/src/__tests__/default-view-agenda-retired.test.ts`, mirroring objectui#5740's pin) and a changeset that states the new rejection loudly (`minor` per this repo's version-alignment policy — majors track `@objectstack`; `check:changeset-no-major` verified locally, exit 0).

The runtime boundary is deliberately unchanged: `ObjectCalendar` still resolves an off-union raw value to its `'month'` default. objectui#5740 remains not addressed beyond what already landed in PR #5782; objectui#5667 remains the parent ruling and stays as it is.

## Why

The three faces admitted a value nothing enforced: `ObjectCalendar`'s props declare `defaultView?: 'month' | 'week' | 'day'`, its schema read casts to the same three, and `CalendarView` renders only those three — no agenda view exists. An author writing the zod-valid `defaultView: 'agenda'` got a month calendar with no error (declared ≠ enforced, ADR-0049). The spec side already agrees: `@objectstack/spec`'s `ObjectCalendarProps.defaultView` is `z.enum(['month', 'week', 'day'])` (`packages/spec/src/ui/component.zod.ts:2353`), so this also removes a spec-alignment gap (commandment #0).

## Authorship sweep (with positive controls)

Measured against `origin/main` of both repos at implementation time (objectui `641543f69`, objectstack `918988a`):

- **objectui**: `defaultView` + `agenda` value pattern — **0 hits**. Positive control: the same grep shape against `month|week|day` hits 3 real authored `defaultView: 'week'` fixtures, so the pattern is proven live on this corpus.
- **objectstack**: same pattern — **0 hits**. The shape-control was 0 there too (no calendar `defaultView` authors at all), so the broader census is the control: the **entire tree contains exactly one `agenda` token**, and it is the Agenda npm job-scheduler mention in `packages/core/src/fallbacks/memory-job.ts` — not a calendar value.
- **Producer check** (who *writes* the key, not just who reads it): `app-shell/ObjectView.tsx:2170` and `plugin-list/ListView.tsx:2061` forward `calendar.defaultView` from authored metadata — pass-throughs, not producers of `'agenda'`. No synth or generator writes this key.
- **Reachability**: stored customer metadata is not reachable from this seat (objectui#5741), so this is a **"no reachable usage"** claim, not "no usage".

## Verification

- `pnpm exec vitest run packages/types/ packages/plugin-calendar/` (repo root, per AGENTS.md): **57 files / 598 tests passed**, re-run on final HEAD `bec062d53` with a clean tree — sha quoted from that run's own output.
- `pnpm --filter @object-ui/types type-check`: green (includes `tsconfig.test.json`, which is what makes the `@ts-expect-error` pin real enforcement).
- **Reverse verification (trap-guarded ablation, committed-state)**: restored the pre-narrowing faces from base `641543f69`, proved the mutation on disk by anchored grep (four-value zod enums: 2, four-value TS union: 1), re-ran the pin file → **exactly the 2 refusal pins failed, 4 passed**; trap restored HEAD, restoration proven by the same anchors reading 0/0, re-run 6/6 green. No build step is involved in either leg — the pins import the schemas by source-relative specifiers, so no `dist/` participates in resolution. The TS face is self-verifying: the green `type-check` with the `@ts-expect-error` present proves tsc flags `'agenda'` on that line (an unused directive is itself an error).
- Targeted gates, each read from its own verdict line: `check:spec-symbols` ✅, `check:control-bytes` ✅, `scripts/check-changeset-presence.mjs` ✅, `scripts/check-changeset-no-major.mjs` ✅.
- Declared narrowing: repo-wide lint and the remaining `check:*` farm are left to CI, which runs them in full; locally only the families implicated by this diff were run (listed above).
- CI note for review: read gates by name — `Type Check` carries `check:spec-symbols`; `Build Docs` is red on `main` (objectui#5668, inherited) and its ~10s cached greens are not evidence either way, so it is excluded with cause.

## Fixture triage

Repo-wide sweep of the narrowed enums' consumption radius: zero fixtures author `defaultView: 'agenda'`. The only `agenda`-valued fixture anywhere is `calendar-view-renderer.propsContract.test.tsx` (`view: 'agenda'`), which is objectui#5740's own pin on a different key and passes because rejection is what it asserts. `list-view-spec-parity.test.ts` keeps `local: ['defaultView']` — the key survives; only its value set narrowed.

## Out of scope

The i18n `calendar.agenda` label key exists in all 10 locales with zero consumers (`CalendarView`'s selector reads only `calendar.day/week/month`) — dead residue this run re-confirmed independently. Already on file as #5783 (open, `finding`), so no new issue was created; #5783 remains open and is not addressed here.

_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_