### PR TITLE
test(plugin-detail): pin record:quick_actions resultDialog reaches the shared runner

### DIFF
--- a/.changeset/record-quick-actions-resultdialog-pin-5711.md
+++ b/.changeset/record-quick-actions-resultdialog-pin-5711.md
@@ -1,0 +1,11 @@
+---
+---
+
+Test-only change — no published behaviour changes.
+
+Adds a component-level test pinning that a `record:quick_actions` action's
+declared `resultDialog` reaches the ambient `<ActionProvider>`'s shared
+`ActionRunner` and opens the reveal dialog with the response value (success
+toast suppressed), plus the negative leg — with no provider, the response is
+silently discarded and the documented `console.warn` fires. Closes the gap
+found while implementing objectstack#10681 (objectui#5711).

--- a/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.resultDialog.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.resultDialog.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5711 — a `record:quick_actions` action's `resultDialog` was
+ * reachable only INDIRECTLY, and nothing pinned the full chain.
+ *
+ * `RecordQuickActionsRenderer` never touches `resultDialog` itself (by
+ * design — see its own header comment): it resolves actions through
+ * `useActionEngine` and calls `executeAction`, and `resultDialog` is honoured
+ * centrally in `packages/core/src/actions/ActionRunner.ts`'s
+ * `handlePostExecution` — on success it suppresses the `successMessage` toast
+ * and awaits the registered `ResultDialogHandler`; with none registered it
+ * `console.warn`s and discards the value while STILL reporting success.
+ *
+ * `useActionEngine` reuses the surrounding `<ActionProvider>`'s `ActionRunner`
+ * when one is mounted, and falls back to a local, unwired one otherwise
+ * (`packages/react/src/hooks/useActionEngine.ts`).
+ *
+ * Existing coverage stopped one link short of this chain (all confirmed by
+ * reading, not recalled):
+ *   - `ActionRunner.resultDialog.test.ts` pins the runner IN ISOLATION, with
+ *     the handler registered directly on it — no React tree, no
+ *     `useActionEngine`, no `<ActionProvider>`.
+ *   - `useActionEngine.sharedRunner.test.tsx` pins that the hook REUSES the
+ *     provider's runner (instance identity + `ctx` merge) but never
+ *     registers or asserts on `resultDialog`.
+ *   - `packages/plugin-detail/src` has ZERO `resultDialog` references (grep,
+ *     objectui#5711) — correct by design, but it also means no test in this
+ *     package exercises the key at all.
+ *   - `MetadataTypeActions.test.tsx` ("shows the result dialog when the
+ *     action declares resultDialog") pins the same OUTCOME on a DIFFERENT
+ *     bar — `MetadataTypeActions`, which (like `DeclaredActionsBar`) mounts
+ *     its OWN internal `<ActionProvider>` rather than sharing an ambient
+ *     one. It does not exercise the shared-runner path this renderer relies
+ *     on.
+ *
+ * So nothing pinned that a handler registered on an AMBIENT `<ActionProvider>`
+ * (the one `RecordDetailView` mounts around the whole record page) is
+ * actually reachable from a `record:quick_actions` bar mounted as a CHILD of
+ * it — the exact shape objectstack#10681 depends on (a one-shot
+ * `resultDialog` on `sys_user.generate_backup_codes`, rendered at
+ * `record:quick_actions { location: 'record_section' }`).
+ *
+ * This suite closes that gap with two legs:
+ *   1. positive — with the provider's handler registered, running the action
+ *      opens the dialog with the response value and suppresses the success
+ *      toast.
+ *   2. negative — with NO provider (the fallback-to-local-runner shape), the
+ *      response is silently discarded and the documented `console.warn`
+ *      fires. This is the defect class the finding is about: a refactor that
+ *      accidentally drops the ambient provider would keep every affected
+ *      action reporting success while showing the user nothing.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RecordContextProvider, ActionProvider } from '@object-ui/react';
+import { RecordQuickActionsRenderer } from '../record-quick-actions';
+
+const LOCATION = 'record_section';
+const LABEL = 'Generate backup codes';
+
+// Mirrors objectstack#10681's `sys_user.generate_backup_codes` shape: a
+// one-shot reveal declared via `resultDialog`, at `record:quick_actions`
+// `location: 'record_section'`. `type: 'script'` is a BUILT-IN executor
+// (`ActionRunner.executeScript`) so the positive leg needs no custom handler
+// registration to produce a real, non-empty `result.data` — the CEL string
+// literal below is the whole "server response".
+const ACTION = {
+  name: 'generate_backup_codes',
+  label: LABEL,
+  type: 'script',
+  target: '"BACKUP-CODE-0000"',
+  successMessage: 'should-not-toast',
+  locations: [LOCATION],
+  resultDialog: {
+    title: 'Save these backup codes',
+    fields: [{ path: 'value', format: 'code-list' }],
+  },
+};
+
+function mount(children: React.ReactNode) {
+  return render(
+    <RecordContextProvider objectName="sys_user" recordId="u1" data={{ id: 'u1' }}>
+      {children}
+    </RecordContextProvider>,
+  );
+}
+
+const clickAction = () => fireEvent.click(screen.getByRole('button', { name: LABEL }));
+
+describe('record:quick_actions — resultDialog reaches the shared runner (objectui#5711)', () => {
+  it('opens the result dialog with the response value and suppresses the success toast', async () => {
+    const onResultDialog = vi.fn().mockResolvedValue(undefined);
+    const onToast = vi.fn();
+
+    mount(
+      <ActionProvider onResultDialog={onResultDialog} onToast={onToast}>
+        <RecordQuickActionsRenderer schema={{ actions: [ACTION], location: LOCATION } as any} />
+      </ActionProvider>,
+    );
+
+    clickAction();
+
+    await waitFor(() => expect(onResultDialog).toHaveBeenCalledOnce());
+    const [spec, data] = onResultDialog.mock.calls[0];
+    expect(spec.title).toBe('Save these backup codes');
+    expect(data).toBe('BACKUP-CODE-0000');
+    // resultDialog SUPPRESSES the success toast (ActionRunner.handlePostExecution)
+    // — a one-shot reveal must not let the user dismiss it via the toast.
+    expect(onToast).not.toHaveBeenCalled();
+  });
+
+  it('with no ActionProvider, discards the value silently and warns — the defect class a fallback-to-local-runner would reintroduce', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Deliberately NO <ActionProvider> here: useActionEngine falls back to a
+    // local, unwired ActionRunner (packages/react/src/hooks/useActionEngine.ts).
+    // This is the shape the finding warns about — if a refactor ever dropped
+    // the ambient provider around a quick-actions bar, this is what a user
+    // would experience: the action reports success and nothing is shown.
+    mount(<RecordQuickActionsRenderer schema={{ actions: [ACTION], location: LOCATION } as any} />);
+
+    clickAction();
+
+    await waitFor(() => expect(warn).toHaveBeenCalledWith(
+      '[ActionRunner] action.resultDialog set but no resultDialogHandler registered — the response value will not be shown to the user.',
+      expect.objectContaining({ action: 'generate_backup_codes', data: 'BACKUP-CODE-0000' }),
+    ));
+
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #5711

## What

Test-only pin, no product change — triage graded this Task on exactly that basis.

`RecordQuickActionsRenderer` (`record:quick_actions`) never touches `resultDialog` itself — it resolves actions through `useActionEngine`, which reuses the surrounding `<ActionProvider>`'s `ActionRunner` when one is mounted and falls back to a local, unwired one otherwise. `resultDialog` is honoured centrally in `ActionRunner.handlePostExecution`: on success it suppresses the `successMessage` toast and awaits the registered `ResultDialogHandler`; with none registered it `console.warn`s and discards the response value while still reporting success.

Nothing pinned that a handler registered on an *ambient* `<ActionProvider>` (the one `RecordDetailView` mounts around a record page) is actually reachable from a `record:quick_actions` bar mounted as its child — the shape objectstack#10681 depends on (`sys_user.generate_backup_codes`, a one-shot `resultDialog` at `record:quick_actions { location: 'record_section' }`).

New file: `packages/plugin-detail/src/renderers/__tests__/record-quick-actions.resultDialog.test.tsx`, two legs:

1. **Positive** — mounted under `<ActionProvider onResultDialog onToast>`, running the action opens the dialog with the response value and the success toast stays suppressed.
2. **Negative** — mounted with no `<ActionProvider>` (the fallback-to-local-runner shape), the response is silently discarded and the documented `console.warn` fires. This is the defect class the finding is about: a refactor that accidentally drops the ambient provider keeps every affected action reporting success while showing the user nothing.

## Gap verification (before writing the test)

- `grep -rni resultDialog packages/plugin-detail/src` → 0 hits, confirming the issue's claim.
- `ActionRunner.resultDialog.test.ts` pins the runner in isolation with the handler registered directly — no React tree, no `useActionEngine`, no `<ActionProvider>`.
- `useActionEngine.sharedRunner.test.tsx` pins runner-sharing (instance identity + `ctx` merge) but never touches `resultDialog`.
- `MetadataTypeActions.test.tsx` has a same-named assertion ("shows the result dialog when the action declares resultDialog") but on a *different* bar — `MetadataTypeActions` mounts its own internal `<ActionProvider>` (like `DeclaredActionsBar`), so it doesn't exercise the shared-runner path `record:quick_actions` relies on.

None of the four exercise the actual missing link. Gap confirmed real.

## Reverse verification

Committed the test first, then mutated `packages/react/src/hooks/useActionEngine.ts` (`const sharedRunner = null;`, simulating a refactor that falls back to a local runner) and reran:

```
FAIL  record-quick-actions.resultDialog.test.tsx > opens the result dialog … 1078ms
AssertionError: expected "vi.fn()" to be called once, but got 0 times
```

stderr showed the exact documented warning fired instead:
```
[ActionRunner] action.resultDialog set but no resultDialogHandler registered — the response value will not be shown to the user. { action: 'generate_backup_codes', data: 'BACKUP-CODE-0000' }
```

Restored with `git checkout -- packages/react/src/hooks/useActionEngine.ts` (confirmed clean via `git status --porcelain`), reran green: `Test Files 1 passed (1)`, `Tests 2 passed (2)`.

## Tests

At d44e2054d:

- `pnpm exec vitest run packages/plugin-detail/src/renderers/__tests__/record-quick-actions.resultDialog.test.tsx --maxWorkers=2` → `Test Files 1 passed (1)`, `Tests 2 passed (2)`.
- `pnpm exec vitest run packages/plugin-detail/ --maxWorkers=2` (full package, dependency closure built first) → `Test Files 95 passed (95)`, `Tests 870 passed (870)`.
- `pnpm --filter @object-ui/plugin-detail type-check` → exit 0.
- `pnpm exec eslint packages/plugin-detail/src/renderers/__tests__/record-quick-actions.resultDialog.test.tsx --no-inline-config` → 0 errors, 2 `no-explicit-any` warnings (identical pattern to the sibling `record-quick-actions.disabled-declared-gate.test.tsx`, same schema-cast convention).
- `node scripts/check-changeset-presence.mjs` → ✅ (empty-frontmatter changeset declared).
- `node scripts/check-changeset-no-major.mjs` → ✅.
- `node scripts/check-control-bytes.mjs` → ✅ (4828 tracked text files scanned).

## Out of scope

`record:alert`'s CTA path shares the exact same wiring (`useActionEngine` under the same ambient `<ActionProvider>`) and has no `resultDialog` coverage either — the issue itself flagged this as worth checking. Filed as a separate unassigned finding rather than folded into this PR (different renderer, different test file, and this card's scope is `record:quick_actions` only).

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_