### PR TITLE
docs(guide): teach the declarative dataSource binding in Step 7

### DIFF
--- a/.changeset/crud-guide-declarative-view-binding-5446.md
+++ b/.changeset/crud-guide-declarative-view-binding-5446.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only change: extended `packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx`
+to measure the `content/docs/guide/building-crud-app.md` rewrite for objectui#5446 (a
+docs-only fix — the guide now teaches the declarative `dataSource: { object, view }`
+binding instead of the `view` / `data.queryParams` keys `ObjectGrid` never read). No
+published package behaviour changes.

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -135,7 +135,7 @@ export const TaskSchema = {
       label: 'Active',
       columns: ['title', 'status', 'priority', 'assignee', 'due_date'],
       filter: [['status', '!=', 'Done']],
-      sort: [['priority', 'asc']],
+      sort: [{ field: 'priority', order: 'asc' }],
     },
   },
 };
@@ -211,7 +211,6 @@ against that one adapter:
 ```tsx
 import './setup';
 import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
-import { TaskSchema } from './schemas/task';
 import { RestDataSource } from './data/rest-data-source';
 
 const dataSource = new RestDataSource('https://api.example.com/v1');
@@ -224,8 +223,6 @@ function App() {
           schema={{
             type: 'object-grid',
             objectName: 'task',
-            view: 'all',
-            data: { objectSchema: TaskSchema },
           }}
         />
       </div>
@@ -236,7 +233,11 @@ function App() {
 export default App;
 ```
 
-This renders a fully interactive data grid with sortable columns, pagination, and row actions — all driven by the `TaskSchema` you defined.
+This renders a fully interactive data grid with sortable columns, pagination,
+and row actions. `object-grid` fetches the object's schema itself — through
+your data source's `getObjectSchema` (Step 4) — to generate the columns and
+field types, so nothing from `src/schemas/task.ts` needs to be imported here;
+that file only has to describe what your backend actually serves.
 
 Two details in that snippet are load-bearing, and getting either wrong produces
 a grid that draws its header and nothing else:
@@ -270,7 +271,7 @@ carries a data source of its own:
 
 ```tsx
 <SchemaRenderer
-  schema={{ type: 'object-grid', objectName: 'task', view: 'all', data: { objectSchema: TaskSchema } }}
+  schema={{ type: 'object-grid', objectName: 'task' }}
   onRowClick={(row: any) => { setEditId(row.id); setShowForm(true); }}
 />
 
@@ -281,7 +282,6 @@ carries a data source of its own:
       objectName: 'task',
       mode: editId ? 'edit' : 'create',
       recordId: editId,
-      data: { objectSchema: TaskSchema },
     }}
     onSubmit={() => setShowForm(false)}
     onCancel={() => setShowForm(false)}
@@ -306,36 +306,46 @@ you pass as `initialData` / `initialValues` outrank a schema default.
 
 ## Step 7: Add Filters and Search
 
-Leverage the `active` list view you defined in Step 3, or add dynamic search:
+Leverage the `active` list view you defined in Step 3 by binding the grid to
+it declaratively, with the spec's per-element `dataSource` binding
+(`dataSource: { object, view }`). This is the same binding `list-view`,
+`detail-view` and every other object-bound block in this repo read —
+`ElementDataSourceGate` resolves `view` against the object's saved views
+(fetched through your data source's `getObjectSchema` / `listViews`) and
+composes that view's `filter` and `sort` onto the query for you:
 
 ```tsx
 const [activeView, setActiveView] = useState('all');
-const [searchQuery, setSearchQuery] = useState('');
 
-// View switcher buttons
+// View switcher buttons — the names match the `list_views` keys from Step 3.
 <button onClick={() => setActiveView('all')}>All Tasks</button>
 <button onClick={() => setActiveView('active')}>Active</button>
-<input
-  placeholder="Search tasks..."
-  value={searchQuery}
-  onChange={(e) => setSearchQuery(e.target.value)}
-/>
 
-// Grid responds to view and search changes
+// The grid re-resolves `view` whenever `activeView` changes.
 <SchemaRenderer
   schema={{
     type: 'object-grid',
-    objectName: 'task',
-    view: activeView,
-    data: {
-      objectSchema: TaskSchema,
-      queryParams: searchQuery ? { $search: searchQuery } : undefined,
-    },
+    dataSource: { object: 'task', view: activeView },
   }}
 />
 ```
 
-The `filter` and `sort` arrays defined in the `active` list view are applied automatically when that view is selected. The `$search` query param is passed through to your `DataSource.find()` method.
+Selecting **Active** re-queries with the `active` view's `filter`
+(`status != Done`) and `sort` (`priority asc`) applied — you never assemble
+`$filter` / `$orderby` by hand. A view name your backend does not publish is
+reported, not silently ignored: swap `activeView` for a name outside
+`list_views` and the grid renders a configuration-error panel in place of the
+table, the same way an unresolved `objectName` does (Step 5). A page that
+instead fell back to the object's full, unfiltered scope would look like it
+worked while returning every record regardless of which button was pressed —
+so this block does not offer that fallback.
+
+**Search needs no binding at all.** `object-grid` renders its own search box
+in the toolbar — on by default — and typing there drives
+`DataSource.find()`'s `$search` parameter directly; there is no separate
+query-param key to author. Add `searchableFields: ['title', 'description']`
+to the schema to narrow which fields the server matches; leave it out and the
+server decides.
 
 ## Step 8: Add a Detail View
 

--- a/packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx
+++ b/packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx
@@ -5,11 +5,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * objectui#5378 + objectui#5377 — the getting-started guide's own `object-grid`
- * snippets are RENDERED here, not read.
+ * objectui#5378 + objectui#5377 + objectui#5446 — the getting-started guide's
+ * own `object-grid` snippets are RENDERED here, not read.
  *
  * `content/docs/guide/building-crud-app.md` is the first-run CRUD walkthrough,
- * and three independent axes each took it from "works" to "renders nothing":
+ * and four independent axes each took it from "works" to "renders nothing" (or,
+ * for the fourth, to "renders something, but not what the prose claims"):
  *
  *  1. **registration** — its `setup.ts` loaded `@object-ui/components` and
  *     `@object-ui/fields` only, so `object-grid` resolved to the registry's
@@ -20,12 +21,26 @@
  *  3. **keys** (#5377) — it named the object with `object`, and this block
  *     declares `objectName` (`GRID_QUERY_INPUTS`, `required: true`). Measured
  *     `find` **0** even under the right wiring.
+ *  4. **capability** (#5446) — Step 7 named a top-level `view` and a
+ *     `data.queryParams.$search`, neither of which `ObjectGrid` reads at all
+ *     (`schema.view` — zero hits; `data` is the `ViewData` union, `queryParams`
+ *     is not one of its arms). Measured identical `find` params with and
+ *     without those two keys. The maintainer ruled (2026-08-22) that the guide
+ *     should teach the declarative binding those blocks DO read —
+ *     `dataSource: { object, view }`, resolved by `ElementDataSourceGate`
+ *     against the object's saved views — and accept the resulting trade: a
+ *     `view` the backend does not publish now renders a configuration-error
+ *     panel instead of a silently unfiltered grid. The describe block at the
+ *     bottom of this file measures that the rewritten binding really does
+ *     change `find`'s params, with the old inert shape reproduced as a control.
  *
- * Every intermediate state passes a diff review and renders nothing, which is
+ * Every intermediate state passes a diff review and renders nothing (or, for
+ * axis 4, renders the SAME thing regardless of the prose's claims), which is
  * why this file evaluates the guide's literals instead of asserting about their
  * text: the schema objects below are the ones the published page hands a reader.
- * The `find` **0 → 1** contrast for each axis is pinned so a future edit that
- * reintroduces one fails here rather than on a reader's screen.
+ * The `find` **0 → 1** contrast for axes 1-3, and the `find`-params contrast for
+ * axis 4, are pinned so a future edit that reintroduces one fails here rather
+ * than on a reader's screen.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -43,6 +58,11 @@ import '../index';
 
 const GUIDE = path.resolve(__dirname, '../../../../content/docs/guide/building-crud-app.md');
 
+// `list_views` mirrors the guide's own Step 3 `TaskSchema.list_views` exactly
+// (same two ids, same `active` filter/sort) — the fourth axis below measures
+// whether Step 7's `dataSource: { object, view }` binding resolves against a
+// backend that publishes what the guide instructs the reader to declare, not
+// against a richer fixture this file invented for its own convenience.
 const TASK_SCHEMA = {
   name: 'task',
   label: 'Task',
@@ -52,6 +72,18 @@ const TASK_SCHEMA = {
     priority: { name: 'priority', type: 'text', label: 'Priority' },
     assignee: { name: 'assignee', type: 'text', label: 'Assignee' },
     due_date: { name: 'due_date', type: 'date', label: 'Due Date' },
+  },
+  list_views: {
+    all: {
+      label: 'All Tasks',
+      columns: ['title', 'status', 'priority', 'assignee', 'due_date'],
+    },
+    active: {
+      label: 'Active',
+      columns: ['title', 'status', 'priority', 'assignee', 'due_date'],
+      filter: [['status', '!=', 'Done']],
+      sort: [{ field: 'priority', order: 'asc' }],
+    },
   },
 };
 
@@ -226,5 +258,121 @@ describe('object-grid — a block that resolves no adapter says so (objectui#537
     );
     await new Promise((r) => setTimeout(r, 50));
     expect(queryByTestId('object-grid-no-data-source')).toBeNull();
+  });
+});
+
+describe('object-grid — Step 7’s rewritten dataSource binding actually changes find() (objectui#5446)', () => {
+  // Control: reproduces the card's own two-row table. The OLD Step 7 shape —
+  // a top-level `view` plus a `data.queryParams.$search` that is not a
+  // `ViewData` arm — versus the same query with both keys dropped. Neither is
+  // read by `ObjectGrid`, so `find`'s params must come out identical. This is
+  // the proof the measuring instrument below actually detects a difference
+  // when the guide's rewritten form causes one.
+  it('control: the old inert `view` + `data.queryParams` shape changes nothing', async () => {
+    const withInertKeys = {
+      type: 'object-grid',
+      objectName: 'task',
+      view: 'active',
+      data: { objectSchema: TASK_SCHEMA, queryParams: { $search: 'foo' } },
+    };
+    const withoutThem = { type: 'object-grid', objectName: 'task' };
+
+    const adapterA = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapterA as any}>
+        <SchemaRenderer schema={withInertKeys as any} />
+      </SchemaRendererProvider>,
+    );
+    await waitFor(() => expect(adapterA.find).toHaveBeenCalledTimes(1));
+    const paramsA = adapterA.find.mock.calls[0][1];
+    cleanup();
+
+    const adapterB = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapterB as any}>
+        <SchemaRenderer schema={withoutThem as any} />
+      </SchemaRendererProvider>,
+    );
+    await waitFor(() => expect(adapterB.find).toHaveBeenCalledTimes(1));
+    const paramsB = adapterB.find.mock.calls[0][1];
+
+    expect(paramsA).toEqual(paramsB);
+    expect(paramsA.$filter).toBeUndefined();
+    expect(paramsA.$orderby).toBeUndefined();
+  });
+
+  it('the guide’s own Step 7 literal DOES change find() params — same schema object, two view names', async () => {
+    // The literal the published page hands a reader, read out of the doc the
+    // same way the rest of this file does — not a hand-rolled analog.
+    const [step7] = guideSchemas('object-grid').slice(2);
+    expect(step7.dataSource).toEqual({ object: 'task', view: 'all' });
+
+    const allView = { ...step7, dataSource: { ...step7.dataSource, view: 'all' } };
+    const adapterAll = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapterAll as any}>
+        <SchemaRenderer schema={allView as any} />
+      </SchemaRendererProvider>,
+    );
+    await waitFor(() => expect(adapterAll.find).toHaveBeenCalledTimes(1));
+    const paramsAll = adapterAll.find.mock.calls[0][1];
+    cleanup();
+
+    // Simulates clicking the "Active" switcher button: `activeView` becomes
+    // 'active', re-evaluating the SAME schema literal with a different view.
+    const activeView = { ...step7, dataSource: { ...step7.dataSource, view: 'active' } };
+    const adapterActive = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapterActive as any}>
+        <SchemaRenderer schema={activeView as any} />
+      </SchemaRendererProvider>,
+    );
+    await waitFor(() => expect(adapterActive.find).toHaveBeenCalledTimes(1));
+    const paramsActive = adapterActive.find.mock.calls[0][1];
+
+    // `all` has no filter/sort of its own — same shape as the inert-key
+    // control above, which is exactly the point: a correctly-resolved default
+    // view is indistinguishable from "nothing was read" until you switch views.
+    expect(paramsAll.$filter).toBeUndefined();
+    expect(paramsAll.$orderby).toBeUndefined();
+    // `active` (`status != Done`, sort `priority asc`) DOES reach the wire.
+    expect(paramsActive.$filter).toEqual([['status', '!=', 'Done']]);
+    expect(paramsActive.$orderby).toBe('priority asc');
+    expect(paramsActive).not.toEqual(paramsAll);
+  });
+
+  it('a view name the backend does not publish renders a configuration-error panel, not a silently unfiltered grid', async () => {
+    // The behavioural trade the maintainer ruled acceptable (2026-08-22):
+    // `archived` is not one of `TASK_SCHEMA.list_views`'s keys.
+    const [step7] = guideSchemas('object-grid').slice(2);
+    const unpublished = { ...step7, dataSource: { ...step7.dataSource, view: 'archived' } };
+
+    const adapter = makeAdapter();
+    const { findByTestId } = render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer schema={unpublished as any} />
+      </SchemaRendererProvider>,
+    );
+    const panel = await findByTestId('object-grid-datasource-error');
+    expect(panel).toHaveAttribute('role', 'alert');
+    expect(panel.textContent).toContain('archived');
+    // Explicit failure, not a wider answer: the grid never queried at all.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(adapter.find).not.toHaveBeenCalled();
+  });
+
+  it('with no adapter at all, the binding-only schema still fails loudly — no silent empty grid', async () => {
+    const [step7] = guideSchemas('object-grid').slice(2);
+    const { container, queryByTestId } = render(<SchemaRenderer schema={step7 as any} />);
+    await new Promise((r) => setTimeout(r, 50));
+    // Whichever panel this path takes (`object-grid` carries no `objectName`
+    // of its own here, only `dataSource.object`, so the "no data source"
+    // panel's `requiresDataSource` check does not fire the way it does for
+    // Steps 5/6 — the binding's own "cannot list saved views" report takes
+    // over instead), it must not be a blank/empty grid.
+    expect(container.textContent).not.toContain('Write the guide');
+    expect(
+      queryByTestId('object-grid-no-data-source') ?? queryByTestId('object-grid-datasource-error'),
+    ).not.toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #5446

## What changed

Per the maintainer's ruling on this card (2026-08-22, Option A — recorded in
issue comment, superseding the earlier "two ends, not settled" routing note):

- **Step 7** now teaches the spec's per-element `dataSource: { object, view }`
  binding — the one `ElementDataSourceGate` actually resolves against the
  object's saved views — instead of the inert top-level `view` key and the
  inert `data.queryParams.$search` key that `ObjectGrid` never reads. The
  behavioural trade is accepted deliberately, per the ruling: a `view` name
  the backend does not publish now renders the gate's configuration-error
  panel instead of a silently unfiltered grid.
- **Steps 5 and 6** lose the inert `data: { objectSchema: TaskSchema }` (both
  the grid and the form already fetch the object's schema themselves via
  `dataSource.getObjectSchema`), and the now-unused `import { TaskSchema }`
  in Step 5's `App.tsx` snippet.
- **Search** in Step 7 no longer teaches a custom `<input>` bound to a
  fictional query-param key. `object-grid` already renders its own toolbar
  search box (on by default) that drives `DataSource.find()`'s `$search`
  directly — the prose now says that instead.

### One bounded same-defect-class fix riding along

Step 3's `TaskSchema.list_views.active.sort` was `[['priority', 'asc']]`
(tuple form). `ObjectGrid`'s own sort handling
(`schemaSort.map(s => \`${s.field} ${s.order}\`)`) reads `[{ field, order }]`
object form — the tuple form would have produced `$orderby: "undefined
undefined"`. This was dead code while `view` was inert (nobody ever consumed
`list_views.active` before), so it never manifested as a bug — but making
Step 7's binding live in *this* change makes it reachable, and shipping it
unfixed would reproduce the exact "documents a capability that silently does
the wrong thing" defect this card is about, one level deeper. Fixed to
`[{ field: 'priority', order: 'asc' }]`, pinned by an existing authoritative
fixture: `packages/plugin-grid/src/__tests__/ObjectGrid.elementDataSource.test.tsx`'s
`HOT_VIEW.sort: [{ field: 'name', order: 'desc' }]`, whose test already
asserts `params.$orderby` comes out as the string form. Same file, same
defect class, no new verification surface, mechanically pinned by evidence
already in the repo — not a drive-by unrelated fix.

## Measurement (the card's acceptance criterion)

Extended `packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx`,
which renders the guide's own literals through the real component registry
with a fake adapter (same harness the card's own analysis used):

**Control — reproduces the card's original two-row table** (proves the
instrument detects "nothing changed" when it should):

| snippet | `find` calls | `$filter` | `$orderby` |
|---|---|---|---|
| old shape: `{ objectName: 'task', view: 'active', data: { objectSchema, queryParams: { $search: 'foo' } } }` | 1 | `undefined` | `undefined` |
| same query, both keys dropped: `{ objectName: 'task' }` | 1 | `undefined` | `undefined` |

Identical, as before.

**The guide's own rewritten Step 7 literal, evaluated with two view names**
(simulating clicking each switcher button — same schema object read out of
the doc, not a hand-rolled analog):

| `dataSource.view` | `find` calls | `$filter` | `$orderby` |
|---|---|---|---|
| `'all'` | 1 | `undefined` | `undefined` |
| `'active'` | 1 | `[['status', '!=', 'Done']]` | `'priority asc'` |

Params **do** change — `active`'s declared `filter`/`sort` reach the wire.

**Unpublished view** (`archived`, not in `TASK_SCHEMA.list_views`): renders
`object-grid-datasource-error` (`role="alert"`, message names `archived`);
`find` is never called — the ruled trade, confirmed.

**No adapter at all**, Step 7's binding-only schema (no `objectName`, only
`dataSource.object`): still fails loudly — some alert-role panel renders, no
row is painted. (It takes the binding's own "cannot list saved views" panel
rather than the `objectName`-driven "No data source resolved" panel Steps
5/6 use, since this schema carries no top-level `objectName` — noted in the
test's own comment; still non-silent either way.)

## Tests

All run from the repo root at `1f8a6edf0` (this PR's head):

```
pnpm --filter '@object-ui/plugin-grid^...' build          # dependency closure
pnpm --filter '@object-ui/plugin-grid' build
pnpm exec vitest run packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx --maxWorkers=2
  ✓ 14 passed (14)   [10 pre-existing + 4 new for this card]
pnpm exec vitest run packages/plugin-grid/src/__tests__/ObjectGrid.elementDataSource.test.tsx --maxWorkers=2
  ✓ 4 passed (4)     [untouched by this change; sanity check for the sort-format fix]
pnpm --filter '@object-ui/plugin-grid' type-check
  ✓ clean (tsc --noEmit + tsc -p tsconfig.test.json)
node scripts/check-changeset-presence.mjs
  ✓ 1 changeset (empty frontmatter, test-only)
node scripts/check-changeset-no-major.mjs
  ✓
node scripts/check-control-bytes.mjs
  ✓ scanned 4827 tracked file(s)
node scripts/check-doc-links.mjs
  ✓ 13 scan roots
node scripts/check-doc-component-types.mjs
  ✓ every documented component type is registered
node scripts/check-doc-snippet-types.mjs   (after building its full --build-filter package set)
  ✓ 88 of 88 covered snippet(s) compile against built types
```

`eslint packages/plugin-grid/src/__tests__/guideCrudAppRenders.test.tsx --no-inline-config`:
0 errors, 21 warnings (`@typescript-eslint/no-explicit-any` on `as any` casts
— the file's pre-existing convention throughout; 8 existed before this PR, 13
more added by the new tests following the same pattern).

## Scope

Docs + a test-only extension of the existing guide-rendering harness, plus
the one bounded metadata fix above. No renderer changes — `ObjectGrid` still
does not read top-level `view` or `data.queryParams`, per the ruling
("do not make ObjectGrid read `view` or `data.queryParams` to make the docs
true — that is option B's neighbourhood").

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_