### PR TITLE
test(app-shell): pin hollow view + personalization overlay hydration behaviour

### DIFF
--- a/.changeset/hollow-view-overlay-hydration-pin-5773.md
+++ b/.changeset/hollow-view-overlay-hydration-pin-5773.md
@@ -1,0 +1,33 @@
+---
+---
+
+Tests only — this publishes nothing, declared explicitly with an empty frontmatter
+rather than left undeclared. No package `src/` is touched; the only file added is
+`packages/app-shell/src/views/InterfaceListPage.hollowOverlayHydration.test.tsx`.
+
+objectui#5773 — pins the intended post-objectui#5233 behaviour at the seam the card
+named: `InterfaceListPage`'s hollow-view hydration effect merging a personalization
+overlay row it fetched through `listViewOverrides`/`getView` (the same undocked-narrowing
+read path `narrowPersonalizationOverlay`'s docblock in `packages/data-objectstack/src/index.ts`
+describes).
+
+Reachability was measured, not reasoned about — constructed through the REAL
+`ObjectStackAdapter` write (`updateViewConfig`/`buildPersistedViewBody`, the same seam
+`ObjectView.overlayPatchOnly.test.ts` uses) and the REAL `InterfaceListPage` render, not a
+hand-written override fixture. Two cases:
+
+- A hollow ADR-0017 expansion item (system view, no `columns`) plus the CURRENT
+  (post-#5233) thin overlay row a toolbar toggle writes today: the page renders
+  `defaultColumnsFromObject`'s defaults — reachable, and the intended behaviour per the
+  card's disposition (an overlay was never a legitimate source of a view body).
+- The same hollow view with a PRE-#5233 fat overlay row (the shape an install that has
+  not touched this view since before the fix is still carrying, per
+  `ObjectView.overlayPatchOnly.test.ts`'s own "PRE-FIX" framing): the page renders the
+  frozen stale columns instead — a control proving the pin above discriminates a real
+  hydration-effect outcome rather than passing vacuously.
+
+Confirmed load-bearing by reverse verification: with the hydration effect's guard
+short-circuited (`if (true) return;`), the CONTROL case flips from the frozen `["status"]`
+to the un-hydrated defaults `["name","status"]` — the assertion depends on the fetch +
+merge actually running. No production code changed; `InterfaceListPage.tsx`'s hydration
+effect already behaves this way today, this was untested rather than unreachable.

--- a/packages/app-shell/src/views/InterfaceListPage.hollowOverlayHydration.test.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.hollowOverlayHydration.test.tsx
@@ -1,0 +1,234 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5773 — the reachability card for the coupling recorded in
+ * `narrowPersonalizationOverlay`'s docblock (`packages/data-objectstack/src/index.ts`)
+ * while shipping objectui#5233's write half (PR #5772):
+ *
+ *   > those two [`listViewOverrides` / `getView`] answer with the stored
+ *   > DOCUMENT … and `InterfaceListPage` hydrates a hollow view out of that
+ *   > document.
+ *
+ * `InterfaceListPage`'s hollow-view hydration effect (lines ~270-315) fetches
+ * a view's per-view overlay row through `listViewOverrides`/`getView` — the
+ * SAME undocked-narrowing read path the docblock is talking about — whenever
+ * the ADR-0017 expansion serves a source view with no `columns`. Before
+ * objectui#5233, `persistViewPatch` wrote a system view's overlay as
+ * `{ ...baseViewDef, ...patch }`, so that row carried a frozen COPY of the
+ * source view's columns at write time; the merge `{ ...resolvedView,
+ * ...hydratedView }` picked those up and the page rendered STALE columns.
+ * After #5233 the same write site stores the patch alone — no `columns` key
+ * — so the merge contributes nothing towards `hasColumns`, and the page's own
+ * defaulting (`defaultColumnsFromObject`) fires instead.
+ *
+ * This is the card's step 1: CONSTRUCT the case (a hollow ADR-0017 expansion
+ * item for a system view that also carries a personalization overlay row),
+ * driven through the REAL `ObjectStackAdapter` write (`updateViewConfig` /
+ * `buildPersistedViewBody`, the same seam `ObjectView.overlayPatchOnly.test.ts`
+ * uses) and the REAL `InterfaceListPage` render — not reasoned about, and not
+ * a hand-written override fixture, because the coupling lives in what the
+ * hydration effect does with a row it actually fetched.
+ *
+ * Two cases, so the second is a control that PROVES the first discriminates
+ * something real: with the CURRENT (post-#5233) thin overlay shape the page
+ * renders defaults; with the OLD (pre-#5233) fat overlay shape — reachable
+ * today only via a row an install has been carrying since before the fix,
+ * exactly as `overlayPatchOnly.test.ts`'s own "PRE-FIX" case frames it — the
+ * SAME component renders the frozen stale columns instead. If both cases
+ * rendered the same thing, this test would not be measuring the hydration
+ * effect at all.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => {
+  const actual = await (importOriginal as any)();
+  return {
+    ...actual,
+    useObjectTranslation: () => ({ t: (_k: string, o?: any) => o?.defaultValue ?? _k }),
+  };
+});
+
+vi.mock('@object-ui/auth', async (importOriginal) => {
+  const actual = await (importOriginal as any)();
+  return {
+    ...actual,
+    useAuth: () => ({}),
+  };
+});
+
+// Only `ListView`'s resolved `schema.columns` is under test here — the
+// hydration effect's output, not the grid's own record-fetching/rendering
+// stack (which `ObjectView`'s and `ListView`'s own suites already cover).
+vi.mock('@object-ui/plugin-list', () => ({
+  ListView: (props: any) => (
+    <div data-testid="rendered-columns">{JSON.stringify(props?.schema?.columns ?? null)}</div>
+  ),
+}));
+
+let testDataSource: any;
+let testObjects: any[];
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await (importOriginal as any)();
+  return {
+    ...actual,
+    useAdapter: () => testDataSource,
+    useMetadata: () => ({ objects: testObjects }),
+  };
+});
+
+import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { buildPersistedViewBody } from './ObjectView';
+import { InterfaceListPage } from './InterfaceListPage';
+
+const OBJECT_NAME = 'crm_lead';
+const VIEW_ID = `${OBJECT_NAME}.default`;
+
+/** Stub `sys_metadata`-shaped store, keyed `type::name` — same convention as
+ * `ObjectView.overlayPatchOnly.test.ts`'s harness. */
+function makeMetaStore() {
+  const rows = new Map<string, any>();
+  const meta = {
+    getItems: vi.fn(async (type: string) => ({
+      type,
+      items: [...rows.entries()].filter(([k]) => k.startsWith(`${type}::`)).map(([, v]) => v),
+    })),
+    getItem: vi.fn(async (type: string, name: string) => {
+      const item = rows.get(`${type}::${name}`);
+      if (!item) {
+        const err: any = new Error(`Not found: ${type}/${name}`);
+        err.status = 404;
+        throw err;
+      }
+      return { type, name, item };
+    }),
+    saveItem: vi.fn(async (type: string, name: string, item: any) => {
+      rows.set(`${type}::${name}`, { ...item });
+      return { success: true, item: rows.get(`${type}::${name}`) };
+    }),
+  };
+  return { meta, rows };
+}
+
+function makeAdapter(meta: any) {
+  const ds: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })),
+  });
+  ds.connected = true;
+  ds.connectionState = 'connected';
+  ds.client = { meta };
+  return ds;
+}
+
+/** The object as `useMetadata().objects` serves it — a hollow ADR-0017
+ * expansion item is what `InterfaceListPage` resolves as the source view: a
+ * `list` entry the framework expanded for `VIEW_ID`, with an empty `columns`
+ * (truthy, renders nothing — exactly the case `hasColumns` exists to catch). */
+function makeObjectDef() {
+  return {
+    name: OBJECT_NAME,
+    fields: {
+      name: { type: 'text' },
+      status: { type: 'select' },
+    },
+    listViews: {
+      [VIEW_ID]: { name: VIEW_ID, type: 'grid', columns: [] },
+    },
+  };
+}
+
+const page = {
+  name: 'crm_lead_list_page',
+  label: 'Leads',
+  // recordAction: 'none' keeps `useNavigationOverlay`'s `isOverlay` false so
+  // `NavigationOverlay` never mounts — irrelevant to the hydration seam under
+  // test, and mounting it would only add unrelated surface to the render.
+  interfaceConfig: { source: OBJECT_NAME, sourceView: 'default', recordAction: 'none' },
+};
+
+describe('objectui#5773 — InterfaceListPage hollow view + personalization overlay hydration', () => {
+  it('REACHABLE: a hollow system view + a thin post-#5233 overlay row hydrates to renderer DEFAULTS, not a hollow grid', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeAdapter(meta);
+    testDataSource = ds;
+    testObjects = [makeObjectDef()];
+
+    // The CURRENT `persistViewPatch` write for a toolbar toggle on this
+    // system view (a density change) — patch alone, no `columns`, exactly
+    // objectui#5233's write half. Written through the REAL adapter, not
+    // dropped into the store as a fixture.
+    await ds.updateViewConfig(
+      OBJECT_NAME,
+      VIEW_ID,
+      buildPersistedViewBody({ viewKind: 'list' }, { rowHeight: 'compact' }, { isSavedView: false }),
+    );
+
+    // Confirms the row really is thin at rest — the premise this case
+    // depends on, measured rather than assumed.
+    const storedOverlay = (await ds.listViewOverrides(OBJECT_NAME))[VIEW_ID];
+    expect(storedOverlay).toBeDefined();
+    expect(storedOverlay).not.toHaveProperty('columns');
+    expect(storedOverlay.rowHeight).toBe('compact');
+
+    render(<InterfaceListPage page={page} />);
+
+    // `defaultColumnsFromObject` over `makeObjectDef()`'s two business
+    // fields — the renderer's own fallback, reached because neither the
+    // hollow resolved view NOR the thin overlay it merges with carries a
+    // `columns` key.
+    await waitFor(() => {
+      expect(screen.getByTestId('rendered-columns').textContent).toBe(
+        JSON.stringify(['name', 'status']),
+      );
+    });
+  });
+
+  it('CONTROL: the same hollow view with a PRE-#5233 fat overlay row still renders the frozen stale columns (proves the pin discriminates old vs. new row shapes)', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeAdapter(meta);
+    testDataSource = ds;
+    testObjects = [makeObjectDef()];
+
+    // What `persistViewPatch` USED TO send — the whole active tab (frozen at
+    // write time) plus the one changed key. An install that has not touched
+    // this view since before objectui#5233 is still carrying a row shaped
+    // exactly like this one (`ObjectView.overlayPatchOnly.test.ts`'s own
+    // "PRE-FIX" framing) — this is that row, written through the REAL write
+    // path (`updateViewConfig`), not hand-assembled as a display fixture.
+    await ds.updateViewConfig(OBJECT_NAME, VIEW_ID, {
+      viewKind: 'list',
+      type: 'grid',
+      columns: ['status'],
+      rowHeight: 'compact',
+    });
+
+    const storedOverlay = (await ds.listViewOverrides(OBJECT_NAME))[VIEW_ID];
+    expect(storedOverlay.columns).toEqual(['status']);
+
+    render(<InterfaceListPage page={page} />);
+
+    // The frozen row's `columns` — NOT `defaultColumnsFromObject`'s
+    // `['name', 'status']` — is what a pre-#5233 install would still be
+    // rendering for this system view today. If this assertion and the
+    // REACHABLE case above ever produced the SAME string, the pin above
+    // would not be testing the hydration effect at all.
+    await waitFor(() => {
+      expect(screen.getByTestId('rendered-columns').textContent).toBe(
+        JSON.stringify(['status']),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #5773

## What this is

Step 1 + 2 of the triage-queued card: **measure reachability, then pin the intended behaviour** for the coupling recorded in `narrowPersonalizationOverlay`'s docblock (`packages/data-objectstack/src/index.ts`) while shipping #5233's write half (#5772):

> those two [`listViewOverrides` / `getView`] answer with the stored DOCUMENT … and `InterfaceListPage` hydrates a hollow view out of that document.

`InterfaceListPage`'s hollow-view hydration effect (`packages/app-shell/src/views/InterfaceListPage.tsx:288-315`, re-anchored on this branch's own base — line numbers match the card) fetches a view's per-view overlay row through `listViewOverrides`/`getView` whenever the ADR-0017 expansion serves a source view with no `columns`. Before #5233, a system view's overlay row carried a frozen COPY of the source view's columns at write time, so the merge `{ ...resolvedView, ...hydratedView }` rendered STALE columns. After #5233 the same write site stores the patch alone — no `columns` key — so the merge contributes nothing towards `hasColumns`, and the page's own `defaultColumnsFromObject` fires instead.

**No production code changed.** `InterfaceListPage.tsx`'s hydration effect already behaves this way today — the card's own framing is that this was *untested*, not unreachable, and the maintainer-endorsed disposition (an overlay was never a legitimate source of a view body) is already what the current code does. This PR adds the pin that was missing.

## Reachability — constructed, not reasoned about

New file: `packages/app-shell/src/views/InterfaceListPage.hollowOverlayHydration.test.tsx`. Two cases, driven through the REAL `ObjectStackAdapter` write (`updateViewConfig` / `buildPersistedViewBody`, the same seam `ObjectView.overlayPatchOnly.test.ts` uses) and the REAL `InterfaceListPage` render — not a hand-written override fixture:

1. **REACHABLE**: a hollow ADR-0017 expansion item (system view, `columns: []`) plus the CURRENT (post-#5233) thin overlay row a toolbar toggle writes today ⇒ the page renders `defaultColumnsFromObject`'s defaults (`["name","status"]`).
2. **CONTROL**: the same hollow view with a PRE-#5233 fat overlay row (the shape an install that hasn't touched this view since before the fix is still carrying, per `overlayPatchOnly.test.ts`'s own "PRE-FIX" framing) ⇒ the page renders the frozen stale columns (`["status"]`) instead.

The two cases disagree on purpose — that disagreement is what proves case 1 is measuring the hydration effect rather than passing vacuously.

**Confirmed load-bearing by reverse verification**: committed the new test, then short-circuited the hydration effect's guard to always bail out early, confirmed the mutation landed on disk (grep), reran — the CONTROL case flipped from the frozen `["status"]` to the un-hydrated defaults `["name","status"]`, so the assertion genuinely depends on the fetch + merge running. Restored the source file from the branch's own commit afterwards and confirmed a clean `git diff` before reporting.

## Scope discipline

Per the card's explicit fence: did **not** widen `narrowPersonalizationOverlay`'s read-side narrowing into `listViewOverrides`/`getView` — the docblock says that exclusion is deliberate, and this PR only pins the current (already-shipped) hollow+overlay outcome.

## Tests

```
pnpm exec vitest run packages/app-shell/src/views/InterfaceListPage.hollowOverlayHydration.test.tsx \
  packages/app-shell/src/views/InterfaceListPage.defaults.test.tsx \
  packages/app-shell/src/views/ObjectView.overlayPatchOnly.test.ts --maxWorkers=2
# Test Files  3 passed (3) / Tests  32 passed (32)
```

Dependency closure build (`pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`) green before running. `eslint` on the new file: 0 errors (12 pre-existing-style `no-explicit-any` warnings, matching the sibling `overlayPatchOnly.test.ts` file's convention). `node scripts/check-changeset-presence.mjs` green (empty-frontmatter changeset declared — tests-only, publishes nothing). No control bytes in the diff.

Head at the time of this report: `61d9b6a37`.

## Not done in this PR

A full `packages/app-shell/` suite run (543 files) was started to check for collateral regressions and stopped early (`git status`/diff confirm nothing else changed) — the change is purely additive (one new test file, zero edits to production or existing test files) and Vitest isolates `vi.mock` per file, so the collateral-regression risk from an additive-only file is structurally near zero; the targeted three-file run above (32/32 passing, including the sibling suites the same hydration/overlay machinery touches) is the evidence this PR relies on instead.

---

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_
