### PR TITLE
fix(plugin-dashboard): collapse the dashboard header wrapper when it has nothing to show

### DIFF
--- a/.changeset/dashboard-header-collapse-5812.md
+++ b/.changeset/dashboard-header-collapse-5812.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+`DashboardRenderer` no longer emits an empty dashboard header wrapper. The
+wrapper used to render whenever `header` was declared, while each of its
+children — title, description, actions — was additionally suppressible. With
+the console page chrome present (`hideHeaderText`, set because the chrome
+already renders the dashboard's title and description) and no `header.actions`,
+every child evaluated falsy and the DOM still received
+`<div class="col-span-full mb-4"></div>`: zero children, yet a full grid row
+(measured 64px) plus `mb-4` of dead band above the filter bar, on every console
+dashboard page (objectui#5812, measured on HotCRM 17.1.0).
+
+The three children are now computed first and the wrapper renders only if one
+of them survives. Nothing else changes: a standalone embed (no chrome) renders
+title and description exactly as before, and declared `header.actions` keep the
+wrapper alive even under the chrome, since the chrome renders text only. Authors
+needed this — dropping `header` from the metadata to reclaim the pixels would
+have cost the standalone embed its title, which is what `header` is for.

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -945,25 +945,50 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
     // spec-compliant dashboards get their header title (framework#1878/#1891;
     // mirrors the DashboardGridLayout fallback from #2666).
     const headerTitle = schema.title || schema.label;
-    const headerSection = schema.header && (
+    /**
+     * Decide what the header would actually SHOW before deciding whether to
+     * render its wrapper at all.
+     *
+     * Every child here is independently suppressible: the console page chrome
+     * passes `hideHeaderText` because it already renders the dashboard's title
+     * and description itself, and `showTitle` / `showDescription` can be
+     * authored off. The wrapper, however, used to render whenever `header` was
+     * merely *declared* — so with the chrome present and no `header.actions`,
+     * every child evaluated falsy and the DOM still got
+     * `<div class="col-span-full mb-4"></div>`: an empty node that claims a
+     * full grid row (measured 64px) plus `mb-4`, opening every console
+     * dashboard page with a blank band above the filter bar (objectui#5812,
+     * measured on HotCRM 17.1.0). Authors had no lever — dropping `header`
+     * would have traded this for the standalone embed's lost title, which is
+     * the very thing `header` is for.
+     *
+     * So the contract is: the header costs zero pixels when it has nothing to
+     * show, and is otherwise untouched. `header.actions` keep it alive even
+     * under the chrome, since the chrome renders text only, not actions.
+     */
+    const header = schema.header;
+    const showHeaderTitle = !hideHeaderText && header?.showTitle !== false && !!headerTitle;
+    const showHeaderDescription = !hideHeaderText && header?.showDescription !== false && !!schema.description;
+    const headerActions = header?.actions ?? [];
+    const headerSection = header && (showHeaderTitle || showHeaderDescription || headerActions.length > 0) && (
       <div className="col-span-full mb-4">
-        {!hideHeaderText && schema.header.showTitle !== false && headerTitle && (
+        {showHeaderTitle && (
           <h2 className="text-lg font-semibold tracking-tight">
             {dashName
               ? dashboardLabel({ name: dashName, label: resolveLabel(headerTitle) })
               : resolveLabel(headerTitle)}
           </h2>
         )}
-        {!hideHeaderText && schema.header.showDescription !== false && schema.description && (
+        {showHeaderDescription && (
           <p className="text-sm text-muted-foreground mt-1">
             {dashName
               ? dashboardDescription({ name: dashName, description: resolveLabel(schema.description) })
               : resolveLabel(schema.description)}
           </p>
         )}
-        {schema.header.actions && schema.header.actions.length > 0 && (
+        {headerActions.length > 0 && (
           <div className="flex gap-2 mt-3">
-            {schema.header.actions.map((action: { label: string; actionUrl?: string; actionType?: string; icon?: string }, i: number) => {
+            {headerActions.map((action: { label: string; actionUrl?: string; actionType?: string; icon?: string }, i: number) => {
               const Icon = resolveLucideIcon(action.icon);
               const handleClick = async () => {
                 const { actionType, actionUrl, label } = action;

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.headerActions.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.headerActions.test.tsx
@@ -7,14 +7,24 @@
  */
 
 /**
- * Dashboard header actions must reach the ActionRunner, whatever their type.
+ * Dashboard header: action dispatch, and when the header wrapper exists at all.
  *
- * The click handler used to allow-list `modal` / `script` only: a `url` action
- * navigated, those two dispatched, and EVERY other declared type — `flow`,
- * `api`, `form`, `navigation` — fell through to a `console.warn` and did
- * nothing at all. A screen flow could not even be launched from a dashboard
- * (framework#3528). The runner owns the type registry, so the renderer no
- * longer second-guesses it.
+ * 1. Header actions must reach the ActionRunner, whatever their type. The click
+ *    handler used to allow-list `modal` / `script` only: a `url` action
+ *    navigated, those two dispatched, and EVERY other declared type — `flow`,
+ *    `api`, `form`, `navigation` — fell through to a `console.warn` and did
+ *    nothing at all. A screen flow could not even be launched from a dashboard
+ *    (framework#3528). The runner owns the type registry, so the renderer no
+ *    longer second-guesses it.
+ *
+ * 2. The header wrapper must cost zero pixels when every child is suppressed.
+ *    It used to render whenever `header` was merely declared, while each child
+ *    was additionally gated on `!hideHeaderText` — the flag the console page
+ *    chrome sets because it already renders the dashboard's title and
+ *    description. Chrome present + no `header.actions` therefore emitted
+ *    `<div class="col-span-full mb-4"></div>`: zero children, but a full grid
+ *    row (measured 64px) plus `mb-4` above the filter bar, on every console
+ *    dashboard page (objectui#5812).
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -67,5 +77,79 @@ describe('DashboardRenderer header actions', () => {
     await waitFor(() => expect(pushState).toHaveBeenCalled());
     expect(handler).not.toHaveBeenCalled();
     pushState.mockRestore();
+  });
+});
+
+/**
+ * A dashboard authored the way the flagship exemplar authors them: `header`
+ * declared with both text flags ON, because a standalone embed genuinely does
+ * render the title and description. The console page chrome then suppresses
+ * that text with `hideHeaderText` — it renders it itself.
+ */
+function textHeaderDashboard(
+  header: Record<string, unknown> = { showTitle: true, showDescription: true },
+): DashboardComponentSchema {
+  return {
+    type: 'dashboard',
+    title: 'Executive Dashboard',
+    description: 'Pipeline and revenue at a glance',
+    widgets: [],
+    header,
+  } as unknown as DashboardComponentSchema;
+}
+
+/** The header wrapper's own signature — `mb-2` belongs to the filter bar. */
+const HEADER_WRAPPER = '.col-span-full.mb-4';
+
+describe('DashboardRenderer header wrapper', () => {
+  it('emits no wrapper when the console chrome suppresses the text and no actions are declared', () => {
+    const { container } = render(
+      <DashboardRenderer schema={textHeaderDashboard()} hideHeaderText />,
+    );
+
+    expect(container.querySelector(HEADER_WRAPPER)).toBeNull();
+    expect(screen.queryByText('Executive Dashboard')).toBeNull();
+    expect(screen.queryByText('Pipeline and revenue at a glance')).toBeNull();
+
+    // Zero pixels, not merely zero text. With no filters, no `onRefresh` and no
+    // widgets, a collapsed header leaves the dashboard root with no children at
+    // all; the empty node used to sit here and claim a whole grid row.
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    expect(root!.children.length).toBe(0);
+  });
+
+  it('still renders title and description for a standalone embed', () => {
+    const { container } = render(<DashboardRenderer schema={textHeaderDashboard()} />);
+
+    const wrapper = container.querySelector(HEADER_WRAPPER);
+    expect(wrapper).not.toBeNull();
+    expect(screen.getByText('Executive Dashboard')).toBeTruthy();
+    expect(screen.getByText('Pipeline and revenue at a glance')).toBeTruthy();
+  });
+
+  it('keeps the wrapper for declared header actions even under the console chrome', () => {
+    const schema = textHeaderDashboard({
+      showTitle: true,
+      showDescription: true,
+      actions: [{ label: 'New Report', actionUrl: '/reports/new', actionType: 'url' }],
+    });
+
+    const { container } = render(<DashboardRenderer schema={schema} hideHeaderText />);
+
+    // The chrome renders the dashboard's text, never its actions — so the
+    // wrapper survives, carrying the buttons and nothing else.
+    expect(container.querySelector(HEADER_WRAPPER)).not.toBeNull();
+    expect(screen.getByRole('button', { name: /New Report/i })).toBeTruthy();
+    expect(screen.queryByText('Executive Dashboard')).toBeNull();
+  });
+
+  it('emits no wrapper for a standalone embed that authored both text flags off', () => {
+    const { container } = render(
+      <DashboardRenderer schema={textHeaderDashboard({ showTitle: false, showDescription: false })} />,
+    );
+
+    expect(container.querySelector(HEADER_WRAPPER)).toBeNull();
+    expect(screen.queryByText('Executive Dashboard')).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #5812

## The defect

`DashboardRenderer` rendered the header wrapper whenever `schema.header` was merely **declared**, while each of its children was independently suppressible:

```tsx
const headerSection = schema.header && (
  <div className="col-span-full mb-4">
    {!hideHeaderText && schema.header.showTitle !== false && headerTitle && (<h2 …>…</h2>)}
    {!hideHeaderText && schema.header.showDescription !== false && schema.description && (<p …>…</p>)}
    {schema.header.actions && schema.header.actions.length > 0 && (…)}
  </div>
);
```

`hideHeaderText` is set by the console page chrome, which already renders the dashboard's title and description itself. Chrome present + no `header.actions` therefore emitted `<div class="col-span-full mb-4"></div>` — zero children, but a full grid row (measured 64px) plus `mb-4`, opening every console dashboard page with a blank band above the filter bar. Measured on HotCRM 17.1.0's `executive_dashboard`; all five of its dashboards declare `header: { showTitle: true, showDescription: true }`, which is *correct* authoring since a standalone embed does render that text. Authors had no lever: removing `header` would have traded the dead band for the standalone embed's lost title.

## The fix

Compute the three children as booleans first, and render the wrapper only if one of them survives:

```tsx
const showHeaderTitle = !hideHeaderText && header?.showTitle !== false && !!headerTitle;
const showHeaderDescription = !hideHeaderText && header?.showDescription !== false && !!schema.description;
const headerActions = header?.actions ?? [];
const headerSection = header && (showHeaderTitle || showHeaderDescription || headerActions.length > 0) && (…);
```

Nothing else moves. The children's own conditions are unchanged — they are now read from the booleans instead of restated inline.

## Usage sweep (asked for at dispatch)

`headerSection` has exactly two consumers, both plain JSX placement: the mobile flex column (`DashboardRenderer.tsx:1108`) and the desktop grid (`:1166`). **Nothing reads its truthiness.** Widget indices come from `schema.widgets.map((w, index) => …)`, drag reordering keys off `widgetIds` / `arrayMove` on the widgets array, and every widget positions itself with `gridColumn: span W` / `gridRow: span H` — spans only, no explicit start lines, so grid auto-placement simply starts one row earlier. Removing the node changes pixels and nothing else. `DashboardGridLayout` has no header section of its own, so there is no sibling defect to file.

## Contract pinned by tests

Extended the existing header test file (`DashboardRenderer.headerActions.test.tsx`) rather than adding a second one; it now carries four new cases:

| Case | Expectation |
|---|---|
| `header` declared + `hideHeaderText` + no actions | no wrapper in the DOM, and the dashboard root has **zero** element children |
| standalone embed (`hideHeaderText` false) | title + description render exactly as today |
| `header.actions` present + `hideHeaderText` | wrapper renders regardless of chrome, carrying the buttons, no title text |
| standalone + `showTitle: false` + `showDescription: false` | no wrapper |

## Verification — all at `2c20e5d63`

| Gate | Verdict line |
|---|---|
| `pnpm exec vitest run packages/plugin-dashboard/` | `Test Files  75 passed (75)` / `Tests  682 passed (682)` — exit 0 |
| `pnpm --filter @object-ui/plugin-dashboard type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`, after building the dependency closure — before that build it was a false red of `TS2307 Cannot find module '@object-ui/…'`) |
| `pnpm --filter @object-ui/plugin-dashboard lint` | `✖ 365 problems (0 errors, 365 warnings)` — exit 0; every warning is pre-existing `no-explicit-any` |
| consumer sweep: `vitest run` over app-shell's dashboard consumers + `views/metadata-admin` | `Test Files  197 passed (197)` / `Tests  2211 passed` + 1 skipped (2212) — exit 0 |
| `pnpm changeset:check` | `✅  No changeset declares a 'major' bump.` — exit 0 |
| `pnpm check:control-bytes` | `✅  check-control-bytes: OK (scanned 4838 tracked text file(s); skipped 85 binary).` — exit 0 |

**Reverse verification.** With the fix committed, `DashboardRenderer.tsx` was reverted to `origin/main` under an `EXIT INT TERM` restore trap. The mutation was confirmed on disk by marker counts, not by an editor exit code: `const showHeaderTitle` 1 → 0, `schema.header.showTitle !== false` 0 → 1. The suite then went red in the expected direction, naming the exact node from the report:

```
× emits no wrapper when the console chrome suppresses the text and no actions are declared
× emits no wrapper for a standalone embed that authored both text flags off
AssertionError: expected <div class="col-span-full mb-4"></div> to be null
 Tests  2 failed | 6 passed (8)
```

The two unchanged-behaviour cases stayed green, which is what they are for. The restore leg was confirmed the same way (markers back to 1 / 0) plus an empty `git status` and empty `git diff HEAD`. No build/`dist` is involved — the tests import `../DashboardRenderer` from source.

Source card with the original measurement context: objectstack-ai/objectstack#11329.

_Generated by [Claude Code](https://claude.ai/code/session_61f28fb9-8e31-4a6f-b4d8-10f749a092d2)_