### PR TITLE
fix(chatbot): resolve confirm cards over replay DISPATCH errors, with self-repair supersede (#5695)

### DIFF
--- a/.changeset/replay-dispatch-error-5695.md
+++ b/.changeset/replay-dispatch-error-5695.md
@@ -1,0 +1,6 @@
+---
+'@object-ui/plugin-chatbot': patch
+'@object-ui/app-shell': patch
+---
+
+Confirm-replay dispatch errors (bare `{error: …}` envelopes) now resolve the 确认修改 card instead of leaving it on 应用中 forever: `detectReplayOutcome` classifies them as a provisional failure, and a later successful authoring result in the same turn (the model self-repairing, e.g. after an `object not found` on a blueprint-local name) supersedes it via `detectAuthoringVerdict` — so the card never says 未生效 over a change that actually landed. Real publish failures (`publishFailed` envelopes) are never superseded. Measured live on the local rig, 2026-08-24.

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -172,7 +172,7 @@ interface CacheableChatToolInvocation {
   proposedPlan?: CachedProposedPlan;
   /** objectui#5695 — the confirm-replay verdict, so the 确认修改 card's terminal
    *  state (已生效 / 已暂存为草稿 / 未生效) survives a cache-fallback reload. */
-  replayOutcome?: { kind: 'published' | 'drafted' | 'failed'; outcome?: string; error?: string; packageId?: string };
+  replayOutcome?: { kind: 'published' | 'drafted' | 'failed'; outcome?: string; error?: string; packageId?: string; dispatchError?: boolean };
 }
 
 interface CacheableChatMessage {
@@ -242,6 +242,9 @@ function replayOutcomeToCachedResult(
   ro: NonNullable<CacheableChatToolInvocation['replayOutcome']>,
 ): Record<string, unknown> {
   if (ro.kind === 'published') return { status: 'published' };
+  // A dispatch error round-trips as the bare `{error}` shape it was detected
+  // from, so re-detection keeps its provisional (supersedable) semantics.
+  if (ro.kind === 'failed' && ro.dispatchError) return { error: ro.error ?? 'replay dispatch failed' };
   return {
     status: 'drafted',
     ...(ro.packageId ? { packageId: ro.packageId } : {}),

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -79,7 +79,7 @@ import {
   SourcesContent,
   Source,
 } from './elements/sources';
-import { parseResultEnvelope } from './mapMessages';
+import { parseResultEnvelope, detectAuthoringVerdict } from './mapMessages';
 
 export interface ChatMessage {
   id: string;
@@ -332,6 +332,7 @@ export interface ChatToolInvocation {
     outcome?: string;
     error?: string;
     packageId?: string;
+    dispatchError?: boolean;
   };
 }
 
@@ -1784,26 +1785,46 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
     // `confirmedChangeIds` above. A replay invocation still awaiting its result
     // marks the card 'applying'; later replays of the same card overwrite
     // earlier ones (an adjusted-and-reconfirmed change reports its LAST run).
+    //
+    // Self-repair supersede (measured live 2026-08-24): a replay whose DISPATCH
+    // errored (`dispatchError`) may be followed, in the same turn, by the model
+    // landing the change through different tool calls. Any LATER non-replay
+    // invocation whose result parses as an authoring verdict overrides the
+    // provisional failure — the card must never say 未生效 over a change that
+    // actually landed (that would be the original bug, mirrored).
     const replayOutcomeByProposalId = React.useMemo(() => {
       const byId = new Map<
         string,
         NonNullable<ChatToolInvocation['replayOutcome']> | { kind: 'applying' }
       >();
+      const dispatchErrorTargets = new Map<string, number>(); // proposalId → replay order
       const proposals: Array<{ id: string; toolName: string; order: number }> = [];
       let order = 0;
       for (const message of messages) {
         for (const tool of message.toolInvocations ?? []) {
           if (tool.proposedChanges && tool.toolCallId) {
             proposals.push({ id: tool.toolCallId, toolName: tool.toolName ?? '', order });
+            dispatchErrorTargets.delete(tool.toolCallId);
           } else if (tool.toolCallId?.startsWith('replay_')) {
             let target: { id: string } | undefined;
             for (const p of proposals) {
               if (p.order < order && p.toolName === (tool.toolName ?? '')) target = p;
             }
             if (target) {
-              if (tool.replayOutcome) byId.set(target.id, tool.replayOutcome);
-              else if (tool.result === undefined && !tool.errorText)
+              if (tool.replayOutcome) {
+                byId.set(target.id, tool.replayOutcome);
+                if (tool.replayOutcome.dispatchError) dispatchErrorTargets.set(target.id, order);
+                else dispatchErrorTargets.delete(target.id);
+              } else if (tool.result === undefined && !tool.errorText) {
                 byId.set(target.id, { kind: 'applying' });
+              }
+            }
+          } else if (tool.result !== undefined && dispatchErrorTargets.size > 0) {
+            const verdict = detectAuthoringVerdict(tool.result);
+            if (verdict) {
+              for (const [pid, replayOrder] of dispatchErrorTargets) {
+                if (order > replayOrder) byId.set(pid, verdict);
+              }
             }
           }
           order += 1;

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.replayOutcome.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.replayOutcome.test.tsx
@@ -164,3 +164,71 @@ describe('ChatbotEnhanced — confirm card replay terminal states (objectui#5695
     expect(screen.getByTestId('proposed-changes-confirm')).toBeInTheDocument();
   });
 });
+
+describe('self-repair supersede (objectui#5695 follow-up)', () => {
+  const dispatchFailedReplay = (): ChatMessage =>
+    replayMessage({
+      kind: 'failed',
+      dispatchError: true,
+      error: 'apply_edit op #1 (add_field): object "task" not found.',
+    });
+
+  it('a dispatch-errored replay with NO later verdict renders the failure state', () => {
+    render(
+      <ChatbotEnhanced messages={[proposalMessage(), dispatchFailedReplay()]} onSendMessage={vi.fn()} />,
+    );
+    expect(screen.getByTestId('proposed-changes-failed')).toBeInTheDocument();
+    expect(screen.getByTestId('proposed-changes-failed-reason')).toHaveTextContent('not found');
+  });
+
+  it("the model's later successful authoring result supersedes the dispatch error — never 未生效 over a landed change", () => {
+    const selfRepair: ChatMessage = {
+      id: 'a3',
+      role: 'assistant',
+      content: '',
+      toolInvocations: [
+        {
+          toolCallId: 'toolu_selfrepair',
+          toolName: 'add_field',
+          state: 'output-available',
+          result: JSON.stringify({ status: 'published' }),
+        },
+      ],
+    };
+    render(
+      <ChatbotEnhanced
+        messages={[proposalMessage(), dispatchFailedReplay(), selfRepair]}
+        onSendMessage={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-applied')).toBeInTheDocument();
+    expect(screen.queryByTestId('proposed-changes-failed')).not.toBeInTheDocument();
+  });
+
+  it('a REAL publish failure (publishFailed envelope) is NOT superseded by later results', () => {
+    const later: ChatMessage = {
+      id: 'a3',
+      role: 'assistant',
+      content: '',
+      toolInvocations: [
+        {
+          toolCallId: 'toolu_other',
+          toolName: 'list_objects',
+          state: 'output-available',
+          result: JSON.stringify({ status: 'published' }),
+        },
+      ],
+    };
+    render(
+      <ChatbotEnhanced
+        messages={[
+          proposalMessage(),
+          replayMessage({ kind: 'failed', outcome: 'rolled_back', error: 'publish gate refused' }),
+          later,
+        ]}
+        onSendMessage={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('proposed-changes-failed')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.replayOutcome.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.replayOutcome.test.ts
@@ -13,7 +13,7 @@
  * live Publish button.
  */
 import { describe, it, expect } from 'vitest';
-import { detectReplayOutcome, uiMessagesToChatMessages } from '../mapMessages';
+import { detectReplayOutcome, detectAuthoringVerdict, uiMessagesToChatMessages } from '../mapMessages';
 
 const FAILED = JSON.stringify({
   status: 'drafted',
@@ -103,5 +103,38 @@ describe('replay suppression in the live mapper (objectui#5695)', () => {
     const tool = msg.toolInvocations?.[0];
     expect(tool?.draftReview?.items).toEqual([{ type: 'view', name: 'v' }]);
     expect(tool?.replayOutcome).toBeUndefined();
+  });
+});
+
+describe('replay dispatch errors + authoring verdicts (objectui#5695 follow-up, measured live 2026-08-24)', () => {
+  it('a bare {error} replay result is a provisional dispatch failure', () => {
+    expect(
+      detectReplayOutcome(
+        'replay_t1_0',
+        JSON.stringify({ error: 'apply_edit op #1 (add_field): object "task" not found.\nmore' }),
+      ),
+    ).toEqual({
+      kind: 'failed',
+      dispatchError: true,
+      error: 'apply_edit op #1 (add_field): object "task" not found.',
+    });
+  });
+
+  it('an {error} beside a status keeps status semantics (not a dispatch error)', () => {
+    expect(
+      detectReplayOutcome('replay_t1_0', JSON.stringify({ status: 'published', error: 'noise' })),
+    ).toEqual({ kind: 'published' });
+  });
+
+  it('detectAuthoringVerdict classifies arbitrary tool results for the self-repair supersede', () => {
+    expect(detectAuthoringVerdict(JSON.stringify({ status: 'published' }))).toEqual({ kind: 'published' });
+    expect(
+      detectAuthoringVerdict(JSON.stringify({ status: 'drafted', packageId: 'app.x' })),
+    ).toEqual({ kind: 'drafted', packageId: 'app.x' });
+    expect(
+      detectAuthoringVerdict(JSON.stringify({ status: 'drafted', publishFailed: true })),
+    ).toEqual({ kind: 'failed' });
+    expect(detectAuthoringVerdict(JSON.stringify({ error: 'x' }))).toBeUndefined();
+    expect(detectAuthoringVerdict('plain')).toBeUndefined();
   });
 });

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -360,6 +360,7 @@ export {
   detectBuilderHandoff,
   detectProposedChanges,
   detectReplayOutcome,
+  detectAuthoringVerdict,
   buildProgressFromDraftReview,
 } from './mapMessages';
 export type {

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -345,6 +345,17 @@ export interface ReplayOutcome {
   error?: string;
   /** Owning package of a drafted outcome, for the inline publish affordance. */
   packageId?: string;
+  /**
+   * The replay DISPATCH itself errored (bare `{error: …}` envelope) rather
+   * than the publish being refused — measured live 2026-08-24: an apply_edit
+   * replay carrying a blueprint-local object name errored `object "task" not
+   * found`, after which the MODEL self-repaired with different tool calls
+   * that succeeded. A dispatch error is therefore only provisionally
+   * `failed`: the card walk may supersede it with a later successful
+   * authoring verdict from the same turn (see `detectAuthoringVerdict`),
+   * so the card never says 未生效 over a change that actually landed.
+   */
+  dispatchError?: boolean;
 }
 
 export function detectReplayOutcome(
@@ -355,6 +366,14 @@ export function detectReplayOutcome(
   const obj = parseResultEnvelope(result);
   if (!obj) return undefined;
   if (obj.status === 'published') return { kind: 'published' };
+  const rawDispatchErr = (obj as { error?: unknown }).error;
+  if (typeof rawDispatchErr === 'string' && rawDispatchErr.trim() && obj.status === undefined) {
+    return {
+      kind: 'failed',
+      dispatchError: true,
+      error: rawDispatchErr.trim().split('\n')[0],
+    };
+  }
   if (obj.status !== 'drafted') return undefined;
   const rawPkg = (obj as { packageId?: unknown }).packageId;
   const packageId =
@@ -371,6 +390,26 @@ export function detectReplayOutcome(
       ...packageId,
     };
   }
+  return { kind: 'drafted', ...packageId };
+}
+
+/**
+ * objectui#5695 — classify ANY tool result as an authoring verdict, for the
+ * confirm card's self-repair supersede: after a replay DISPATCH error, the
+ * model may land the same change through different tool calls; those results
+ * carry the ordinary authoring envelope, and the latest one in the turn is
+ * the truthful terminal state for the card.
+ */
+export function detectAuthoringVerdict(
+  result: unknown,
+): { kind: 'published' | 'drafted' | 'failed'; packageId?: string } | undefined {
+  const obj = parseResultEnvelope(result);
+  if (!obj) return undefined;
+  if (obj.status === 'published') return { kind: 'published' };
+  if (obj.status !== 'drafted') return undefined;
+  const rawPkg = (obj as { packageId?: unknown }).packageId;
+  const packageId = typeof rawPkg === 'string' && rawPkg ? { packageId: rawPkg } : {};
+  if ((obj as { publishFailed?: unknown }).publishFailed === true) return { kind: 'failed', ...packageId };
   return { kind: 'drafted', ...packageId };
 }
 


### PR DESCRIPTION
Found live on the local demo rig minutes after #5805 merged: an `apply_edit` replay carrying a blueprint-local object name errored with a **bare `{error: …}` envelope** — a third replay shape the detector did not know — so the 确认修改 card stuck on the optimistic 应用中 forever, while the model self-repaired through different tool calls (`list_objects` → `Add field`) and the change actually landed.

- `detectReplayOutcome`: bare `{error}` (no `status`) → provisional failure (`dispatchError: true`).
- New `detectAuthoringVerdict`: classifies any tool result as an authoring verdict; the card walk supersedes a dispatch error with the model's later successful result — the card must never say 未生效 over a change that actually landed (the original bug, mirrored). **Real publish failures are never superseded** (pinned).
- Cache round-trip preserves the bare-error shape so rehydration keeps the supersedable semantics.

20 focused tests + 728 regression green (plugin-chatbot + app-shell hooks/ai). Root cause (proposals carry unresolved blueprint-local names) is cloud-side and carded separately — this PR is the renderer's honest handling of the shape either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)