### PR TITLE
fix(auth): stop purgeSignedOutClientCaches aborting the sign-out sweep on one throwing removeItem

### DIFF
--- a/.changeset/signout-purge-per-key-try-5777.md
+++ b/.changeset/signout-purge-per-key-try-5777.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/auth': patch
+---
+
+`purgeSignedOutClientCaches()` — the sweep that drops the signed-out user's
+`objectui:metadata:*` seed cache on sign-out (objectui#5198) — now costs one key when a
+single `removeItem` throws, instead of aborting the rest of the sweep (objectui#5777).
+
+The `try` wrapped the WHOLE loop, not each removal. A `removeItem` that threw on key `n`
+aborted the walk, so keys `n+1..end` were never swept, and the failure was swallowed —
+`AuthProvider`'s `signOut` believed the purge had completed. The entries this sweeps are
+the previous principal's org-scoped, PERMISSION-FILTERED app list — objectui#5198
+classifies a surviving entry as a cross-principal disclosure on a shared browser, not
+mere staleness — so a partial sweep here is the sharper half of the same defect class
+objectui#5763 fixed on the sign-in path (`sweepStore` in `ActiveOrganizationStorage.ts`).
+
+`Object.keys(sessionStorage)` — the reason a guard exists here at all — stays guarded on
+its own; only the per-key guard is new. Same as `sweepStore`, a failed removal here is
+not verified by read-back and not quarantined the way `ActiveOrganizationStorage.clear()`
+(objectui#5731) quarantines a key: this function does not own reads for the metadata
+seed cache (`MetadataProvider` in `@object-ui/app-shell` does), so there is no `get()` to
+guard and nothing to quarantine — adding read-back verification would be a general
+storage-error-handling refactor of the module, out of this card's scope. What is
+mirrored is the reporting channel: a key whose `removeItem` throws is named in a
+`console.warn`, the same channel `sweepStore` and `clear()` use, so a partial sweep is
+discoverable instead of silent.
+
+Adds a partial-failure test: a `sessionStorage` whose `removeItem` throws on one metadata
+key, asserting every other metadata key on both sides of it is still swept and unrelated
+non-matching keys are untouched, plus a control that the warning fires only on an actual
+failure.

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -56,20 +56,61 @@ const METADATA_SEED_CACHE_PREFIX = 'objectui:metadata:';
  * blob that escapes this purge (a tab open across the upgrade, a session ended
  * by expiry rather than by this call) is unreadable rather than merely
  * undeleted. The two halves are deliberately independent.
+ *
+ * ## The `try` guards the SNAPSHOT, not the walk (objectui#5777)
+ *
+ * `Object.keys(sessionStorage)` can itself throw — partitioned iframes, some
+ * privacy modes — and that is the reason a guard exists here at all, so it
+ * stays. What it must NOT do is wrap the loop: a `removeItem` that throws on
+ * key `n` would abort the walk, leaving every still-unvisited MATCHING key
+ * unswept, with the failure swallowed so the caller believes the sweep
+ * completed. The keys this purges are a cross-principal disclosure risk on a
+ * shared browser (objectui#5198), not ordinary staleness — a partial sweep
+ * leaves an arbitrary subset of the previous principal's permission-filtered
+ * app list readable to whoever signs in next in this tab. So each
+ * `removeItem` gets its own `try`: one uncooperative key costs exactly that
+ * key. Same defect class and same remedy as `sweepStore` in
+ * `ActiveOrganizationStorage.ts` (objectui#5763) — different file and
+ * different caller (sign-out, not sign-in) is why it is fixed here rather
+ * than there.
+ *
+ * ## Reported, not quarantined — same reason as `sweepStore`
+ *
+ * This function walks keys it does not own reads for: `MetadataProvider`
+ * (`@object-ui/app-shell`) is the reader of the seed cache, not this
+ * provider — there is no local `get()` here to guard, so there is nothing to
+ * quarantine the way `ActiveOrganizationStorage.clear()` quarantines a key
+ * (objectui#5731). What IS mirrored is the reporting channel: a key whose
+ * `removeItem` throws is named in a `console.warn`, so a partial sweep is
+ * discoverable instead of silent. The caller (`signOut`, above) cannot act on
+ * it either way — the session is already ending — so, like `sweepStore` on
+ * the sign-in path, this must not throw.
  */
 function purgeSignedOutClientCaches(): void {
   if (typeof sessionStorage !== 'undefined') {
+    let keys: string[];
     try {
       // Snapshot the keys first (`Object.keys`) — removing entries during a
       // live index walk shifts the ones behind it and skips half of them.
       // Same idiom as the `MarketplacePackagePage` purge loop.
-      for (const key of Object.keys(sessionStorage)) {
-        if (key.startsWith(METADATA_SEED_CACHE_PREFIX)) {
-          sessionStorage.removeItem(key);
-        }
-      }
+      keys = Object.keys(sessionStorage);
     } catch {
-      /* storage unavailable */
+      keys = []; /* storage unavailable */
+    }
+    const unswept: string[] = [];
+    for (const key of keys) {
+      if (!key.startsWith(METADATA_SEED_CACHE_PREFIX)) continue;
+      try {
+        sessionStorage.removeItem(key);
+      } catch {
+        unswept.push(key);
+      }
+    }
+    if (unswept.length > 0) {
+      console.warn(
+        `[purgeSignedOutClientCaches] could not remove ${unswept.length} key(s) from sessionStorage: ` +
+          `${unswept.join(', ')}. The signed-out user's metadata seed cache may still be readable under these keys.`,
+      );
     }
   }
   ActiveOrganizationStorage.clear();

--- a/packages/auth/src/__tests__/signOut-client-cache-purge-5198.test.tsx
+++ b/packages/auth/src/__tests__/signOut-client-cache-purge-5198.test.tsx
@@ -197,6 +197,80 @@ describe('signOut purges the signed-out principal’s client caches (#5198)', ()
     expect(observed[observed.length - 1]).toEqual([]);
   });
 
+  // ---------------------------------------------------------------------
+  // objectui#5777 — a throwing `removeItem` must cost exactly that key
+  // ---------------------------------------------------------------------
+
+  it('sweeps every other metadata key when one removeItem throws (#5777)', async () => {
+    const client = createMockClient();
+    await renderSignedIn(client);
+
+    // Keys on BOTH SIDES of the poisoned one in insertion order, so a green
+    // run proves the walk continues past the throw rather than stopping at
+    // the first non-poisoned key it happens to reach.
+    sessionStorage.setItem('objectui:metadata:app:org_a:abc', JSON.stringify([{ name: 'crm' }]));
+    const POISON_KEY = 'objectui:metadata:nav:org_a:abc';
+    sessionStorage.setItem(POISON_KEY, JSON.stringify(['accounts']));
+    sessionStorage.setItem('objectui:metadata:object:org_a:abc', JSON.stringify([{ name: 'account' }]));
+    // Non-matching key — never a removal candidate either way.
+    sessionStorage.setItem('objectui:sidebar:collapsed', 'true');
+    ActiveOrganizationStorage.set('org_a');
+
+    const realRemoveItem = sessionStorage.removeItem.bind(sessionStorage);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const removeItemSpy = vi
+      .spyOn(sessionStorage, 'removeItem')
+      .mockImplementation((key: string) => {
+        if (key === POISON_KEY) throw new Error('simulated removeItem failure');
+        realRemoveItem(key);
+      });
+
+    try {
+      await act(async () => {
+        await authRef.current!.signOut();
+      });
+
+      // The poisoned key is the residue the card is about — it survives.
+      expect(sessionStorage.getItem(POISON_KEY)).toBe(JSON.stringify(['accounts']));
+
+      // Everything else matching the prefix is still swept — this is the
+      // pin: one uncooperative key costs one key, not the rest of the sweep.
+      expect(sessionStorage.getItem('objectui:metadata:app:org_a:abc')).toBeNull();
+      expect(sessionStorage.getItem('objectui:metadata:object:org_a:abc')).toBeNull();
+
+      // Non-matching keys were never removal candidates either way.
+      expect(sessionStorage.getItem('objectui:sidebar:collapsed')).toBe('true');
+
+      // The active-org clear is unconditional and runs after the sweep either way.
+      expect(ActiveOrganizationStorage.get()).toBeNull();
+
+      // Discoverable, not silent — the failure is named, not swallowed whole.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(POISON_KEY);
+    } finally {
+      // Explicit, not left to `afterEach`'s `restoreAllMocks()` — a spy
+      // installed on a jsdom `Storage` instance has been observed to survive
+      // `restoreAllMocks()` across tests (objectui#5763's sibling case).
+      removeItemSpy.mockRestore();
+    }
+  });
+
+  it('reports nothing when every removal sticks (#5777)', async () => {
+    // Control on the case above: the warning is a measurement of an actual
+    // failure, not a constant emitted on every purge.
+    const client = createMockClient();
+    await renderSignedIn(client);
+    seedPreviousSessionCaches();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await act(async () => {
+      await authRef.current!.signOut();
+    });
+
+    expect(metadataKeys()).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('drops the previous principal’s organization block from context', async () => {
     // The list is the workspaces THAT user belongs to (the switcher renders
     // it), and a surviving `activeOrganization` would also suppress the


### PR DESCRIPTION
Fixes #5777

## The defect

`purgeSignedOutClientCaches()` in `packages/auth/src/AuthProvider.tsx` wrapped its whole
`removeItem` loop in one `try`. A `removeItem` that threw on key `n` aborted the walk, so
every still-unvisited `objectui:metadata:*` key after it was never swept, and the failure
was swallowed — `signOut()` believed the purge had completed. Same defect class as
#5763 (`sweepStore` in `ActiveOrganizationStorage.ts`), different file and caller
(sign-out, not sign-in) — filed separately per that card's scope note and fixed here.

Per its own docstring and #5198, the entries this purges are the previous principal's
org-scoped, PERMISSION-FILTERED app list — a cross-principal disclosure risk on a shared
browser when they survive, not mere staleness. A partial sweep here is the sharper half
of the pair the triage comment names.

## The fix

Mirrors #5763's landed shape on `main` (`ff2d54717`, merged 07:56:17Z — read there per
dispatch, not from that PR's discussion):

- `try` now guards only the `Object.keys(sessionStorage)` snapshot (the reason a guard
  exists at all — partitioned iframes, some privacy modes).
- Each `removeItem` gets its own `try`; one uncooperative key now costs exactly that key.
- A partial sweep is reported via `console.warn` naming the unswept keys, mirroring
  `sweepStore`'s reporting channel — **not** quarantined the way
  `ActiveOrganizationStorage.clear()` (#5731) quarantines a key.

## Whether #5763's report-vs-silent reasoning transfers (dispatch's open question)

It does, and the reasoning is the same on both axes `sweepStore`'s doc comment gives for
choosing "report, don't quarantine" over `clear()`'s read-back quarantine:

- **No local `get()` to guard.** `purgeSignedOutClientCaches` does not own reads for the
  metadata seed cache — `MetadataProvider` (`@object-ui/app-shell`) does, per this
  function's own docstring (the prefix is spelled out rather than imported specifically
  because ownership sits on that side of the dependency boundary). There is nothing here
  for a quarantine to guard, same as `sweepStore` walking "another package's recents
  cache, a metadata seed" it does not own reads for either.
- **The caller cannot act on it either way.** `sweepStore`'s caller (`SessionUserScope.adopt`,
  sign-in) cannot act on a partial-sweep failure and must not throw. The sign-out caller
  is even further foreclosed: the session is already ending when `purgeSignedOutClientCaches()`
  runs in `signOut`'s `finally` block, so there is no decision left to make either.

So this PR mirrors `sweepStore` exactly rather than diverging: report via `console.warn`,
never throw, no quarantine layer added (which would have been the general
storage-error-handling refactor both cards' scope notes rule out).

## Tests

`packages/auth/src/__tests__/signOut-client-cache-purge-5198.test.tsx` — two new cases,
same pattern as #5763's sibling test in `sessionUserChangePurge-5664.test.tsx`:

- **`sweeps every other metadata key when one removeItem throws (#5777)`** — a poisoned
  key with real metadata keys on both sides of it (insertion order), asserting the
  poisoned key survives, every other metadata key is still removed, a non-matching key
  is untouched either way, `ActiveOrganizationStorage.clear()` still runs, and exactly
  one `console.warn` names the poisoned key.
- **`reports nothing when every removal sticks (#5777)`** — control: the warning is a
  measurement of an actual failure, not a constant.

**Reverse-verification, on a real commit (per dispatch's ⛔ never against uncommitted
edits):** committed the fix (`da392fbbd`), then `git checkout HEAD~1 -- packages/auth/src/AuthProvider.tsx`
to restore the pre-fix whole-loop-`try` shape and re-ran the same test file:

```
❯ sweeps every other metadata key when one removeItem throws (#5777)
AssertionError: expected '[{"name":"account"}]' to be null
 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

The new test fails against the pre-fix shape exactly as expected (the other 5 pass
either way — they don't exercise a throwing `removeItem`). Restored the fix via
`git checkout claude/issue-5777-signout-purge-per-key-try -- packages/auth/src/AuthProvider.tsx`,
confirmed `git diff HEAD --stat` empty (working tree matches the commit), and re-ran:

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Full package: `pnpm exec vitest run packages/auth/ --maxWorkers=2` (run from repo root,
per AGENTS.md — never `pnpm --filter`/package-cwd, which silently collects
`apps/console` instead) → **24 files / 251 tests passed**, on `c0b7876ba` (this PR's head).

`pnpm --filter '@object-ui/auth' type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`,
after building the dependency closure first) → clean, on `c0b7876ba`.

`node scripts/check-changeset-presence.mjs`, `check-control-bytes.mjs`,
`check-type-check-coverage.mjs`, `check-lint-coverage.mjs` → all ✅ on `c0b7876ba`.
`eslint` on the two changed files → 0 errors, 3 pre-existing warnings unrelated to this
diff (React effect `setState` warnings at lines 300/760/767, outside the edited region).

## Scope

`purgeSignedOutClientCaches()` and its own test file only, per the card's scope note —
not a general refactor of `AuthProvider.tsx` or the storage-error-handling module.

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_