### PR TITLE
docs(app-shell): deprecate AppSidebar — census found no mount point, no downstream consumer

### DIFF
--- a/.changeset/appsidebar-deprecated-5720.md
+++ b/.changeset/appsidebar-deprecated-5720.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`AppSidebar` is now `@deprecated` — use `UnifiedSidebar` instead.
+
+A census (objectui#5720) found `AppSidebar` has no in-repo mount point
+(`ConsoleLayout` renders `UnifiedSidebar`, not this component) and no
+downstream consumer visible anywhere across this org's GitHub-visible
+repositories. It stays exported — from the package barrel and the published
+`dist/index.d.ts` — because `@object-ui/app-shell` is a public npm package
+(`publishConfig.access: "public"`) and an external consumer outside this org
+is structurally invisible to that census; that is why it is deprecated
+rather than deleted outright. No behavior change in this release — the
+component still renders exactly as before. Its admin nav cluster is a
+near-duplicate of `UnifiedSidebar`'s and has already drifted from it (it
+gates only `sys-marketplace` on the workspace-admin flag, where
+`UnifiedSidebar` gates the whole cluster); that divergence is not being
+reconciled, since the component is scheduled for removal rather than kept
+in parity — see objectui#5817 for the removal plan.
+
+Migration: replace any `AppSidebar` usage with `UnifiedSidebar` from the same
+package.

--- a/content/docs/guide/console-architecture.md
+++ b/content/docs/guide/console-architecture.md
@@ -178,7 +178,10 @@ builder**, and the menu entries that used to launch it are gone. Today:
 
 Do not re-document the old sidebar / command-palette entries: the "Add App" and "Edit App"
 items exist only in `AppSidebar`, which the console no longer mounts (`ConsoleLayout` renders
-`UnifiedSidebar`), and the command palette never registered a create-app command.
+`UnifiedSidebar`), and the command palette never registered a create-app command. `AppSidebar`
+is `@deprecated` as of objectui#5720 — it stays published (for any external consumer of the
+`@object-ui/app-shell` npm package) but is scheduled for removal once its deprecation window
+closes (objectui#5817). New work should target `UnifiedSidebar`.
 
 ### 5. Branding
 

--- a/packages/app-shell/src/index.ts
+++ b/packages/app-shell/src/index.ts
@@ -98,7 +98,7 @@ export {
   ConsoleLayout,
   ConsoleNotificationBanners,
   AppHeader,
-  AppSidebar,
+  AppSidebar, // @deprecated — use UnifiedSidebar; see AppSidebar's own JSDoc (objectui#5720, objectui#5817)
   UnifiedSidebar,
   AppSwitcher,
   ConnectionStatus,

--- a/packages/app-shell/src/layout/AppSidebar.tsx
+++ b/packages/app-shell/src/layout/AppSidebar.tsx
@@ -6,6 +6,21 @@
  * @dnd-kit drag-to-reorder and pin/unpin), while keeping Console-specific
  * features: app switcher dropdown, user footer, favorites, recent items,
  * and mobile swipe gesture.
+ *
+ * @deprecated Use `UnifiedSidebar` instead. `ConsoleLayout` — the shell every
+ * app in this repo mounts — renders `UnifiedSidebar`, not this component, and
+ * a census (objectui#5720) found no in-repo mount point and no downstream
+ * consumer visible anywhere across this org's GitHub repositories either.
+ * `AppSidebar` stays exported — from this package's barrel and from the
+ * published `dist/index.d.ts` — only because `@object-ui/app-shell` is a
+ * public npm package (`publishConfig.access: "public"`) and an external
+ * consumer outside this org is structurally invisible to that census; it is
+ * deprecated rather than deleted for that reason. See objectui#5817 for the
+ * removal plan. Its admin nav cluster is a near-duplicate of
+ * `UnifiedSidebar`'s and has already drifted from it — this component gates
+ * only `sys-marketplace` on the workspace-admin flag where `UnifiedSidebar`
+ * gates the whole cluster — so do not treat the two as interchangeable while
+ * both exist; that divergence is not being reconciled here.
  * @module
  */
 
@@ -146,6 +161,11 @@ function useNavOrder(appName: string) {
  */
 const getIcon = resolveIcon;
 
+/**
+ * @deprecated Use `UnifiedSidebar` instead — `ConsoleLayout` mounts that, not
+ * this. See the module-level `@deprecated` note above for the census
+ * (objectui#5720) and the removal plan (objectui#5817).
+ */
 export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: string, onAppChange: (name: string) => void }) {
   const { isMobile, setOpenMobile } = useSidebar();
   const { user, signOut, isAuthEnabled, activeOrganization } = useAuth();

--- a/packages/app-shell/src/layout/index.ts
+++ b/packages/app-shell/src/layout/index.ts
@@ -2,6 +2,7 @@ export { ConsoleLayout } from './ConsoleLayout.js';
 export { ConsoleNotificationBanners } from './ConsoleNotificationBanners.js';
 export { ImpersonationBanner } from './ImpersonationBanner.js';
 export { AppHeader } from './AppHeader.js';
+/** @deprecated Use `UnifiedSidebar` — see `AppSidebar`'s own JSDoc (objectui#5720, objectui#5817). */
 export { AppSidebar } from './AppSidebar.js';
 export { UnifiedSidebar } from './UnifiedSidebar.js';
 export { AppSwitcher } from './AppSwitcher.js';


### PR DESCRIPTION
Fixes #5720

## Census (establish-first, per triage)

- **No in-repo mount point.** `ConsoleLayout` renders `UnifiedSidebar`, not `AppSidebar` (`packages/app-shell/src/layout/ConsoleLayout.tsx:29,136`). `git grep AppSidebar` outside `AppSidebar.tsx` itself, its tests, and prose turns up only a doc-comment usage example (`ExpressionProvider.tsx`) and a cross-reference comment (`AppContent.tsx`) — re-measured on this base, matches the issue's own measurement. `content/docs/guide/console-architecture.md` already documented the no-mount-point fact independently. No `apps/**`/`examples/**` file imports it either (checked both static and dynamic-`import()` forms; no namespace-style `import * as` re-export exists in this repo to hide a member access from grep).
- **Published-export check (the deciding measurement) — confirmed both ways:**
  - Barrel: `packages/app-shell/src/index.ts` and `packages/app-shell/src/layout/index.ts` both export it.
  - Built artifact: after `pnpm --filter '@object-ui/app-shell^...' build && pnpm --filter '@object-ui/app-shell' build`, `packages/app-shell/dist/index.d.ts` carries `AppSidebar` in its export list — not just the source barrel.
  - `packages/app-shell/package.json` sets `publishConfig.access: "public"`, and `.github/workflows/changeset-release.yml` actually publishes to `registry.npmjs.org` (`NPM_TOKEN`/`NODE_AUTH_TOKEN`, `registry-url: 'https://registry.npmjs.org'`) — this is a genuinely, actively published npm package, not just a `package.json` flag.
- **Downstream/org census — bounded, reported as such.** This session's GitHub access covers `objectstack-ai/objectstack` and `objectstack-ai/objectui` directly, but `search_code` reaches org-wide, so I also searched `AppSidebar` and `"@object-ui/app-shell"` across `org:objectstack-ai`. Findings:
  - No repo imports/mounts the `@object-ui/app-shell` `AppSidebar` component.
  - `objectstack-ai/objectstack`'s spec liveness audit (`packages/spec/liveness/app.json`) cites `AppSidebar.tsx` by path+line as evidence a schema field is consumed — a documentation citation of objectui's own source, not an external import.
  - `objectstack-ai/hotcrm` has one source comment referencing "objectui's `AppSidebar.tsx`" while explaining branding-logo behavior — a comment, not an import.
  - `objectstack-ai/studio` has an unrelated, same-named local `AppSidebar` component with no connection to `@object-ui/app-shell`.
  - `objectstack-ai/cloud` imports things from `@object-ui/app-shell` (a `cloud:onboarding-next` widget, dev-overlay build scripts) but nothing importing `AppSidebar` specifically; its console is objectui's own `apps/console`, which (per the in-repo census above) doesn't mount it either.
  - **This is bounded, not a clean sweep**: `search_code`'s index can lag, doesn't reach private/forked repos this org token can't see, and — this is the load-bearing gap — **cannot see any consumer of the public npm package that isn't on GitHub at all** (anonymous npm installs, private non-GitHub deployments). For a package that's actually published to the public registry, that gap is structural, not a search-coverage shortfall.

## Disposition: deprecate, not delete

Per the triage ruling, "published API with external consumers" routes to deprecate + convergence plan. The census confirms the export is real (barrel + built `.d.ts` + live npm publish) and that no consumer is visible from anywhere this census can reach — which is exactly the situation where absence-of-evidence cannot be read as evidence-of-absence, because the whole point of a public npm package is consumers outside this org's GitHub footprint.

## What changed

- `packages/app-shell/src/layout/AppSidebar.tsx` — `@deprecated` JSDoc on the module doc comment and the exported function, pointing at `UnifiedSidebar`, naming the census (#5720) and the removal follow-up (#5817), and flagging the admin-nav gating divergence the issue recorded (`AppSidebar` gates only `sys-marketplace` on the workspace-admin flag; `UnifiedSidebar` gates the whole cluster) so nobody treats the two as interchangeable during the deprecation window. That divergence is **not** being reconciled in this PR — the component is going away, not being kept in parity.
- `packages/app-shell/src/layout/index.ts`, `packages/app-shell/src/index.ts` — same deprecation note on the re-export lines.
- `content/docs/guide/console-architecture.md` — added the deprecation status next to the existing no-mount-point note.
- `.changeset/appsidebar-deprecated-5720.md` — patch, JSDoc-only, no behavior change.
- Filed #5817 as the removal follow-up (component/tests/barrel-export/stale-comment cleanup), linked back to this issue.

No behavior change: `AppSidebar` still renders exactly as before for any existing consumer during the deprecation window.

## Tests

All from repo root (per AGENTS.md's "怎么跑测试"), head `33580937c`:

- `pnpm --filter '@object-ui/app-shell^...' build` then `pnpm --filter '@object-ui/app-shell' build` (`tsc`) — clean, no errors. Confirms the `.d.ts` finding above.
- `pnpm exec vitest run packages/app-shell/src/layout/__tests__/AppSidebar.derivedAreaVisibility.test.tsx packages/app-shell/src/layout/__tests__/appSidebarSettingsTargets.test.tsx --maxWorkers=2` → `Test Files 2 passed (2)`, `Tests 9 passed (9)`.
- `pnpm exec vitest run packages/app-shell/src/layout/__tests__/systemNavDatasourcesHop.test.tsx packages/app-shell/src/layout/__tests__/systemNavObjectsHop.test.tsx packages/app-shell/src/layout/__tests__/systemNavSettingsTarget.test.tsx --maxWorkers=2` → `Test Files 3 passed (3)`, `Tests 9 passed (9)`.
- `pnpm exec eslint src/layout/AppSidebar.tsx src/layout/index.ts src/index.ts` (from `packages/app-shell/`) → exit 0, `15 problems (0 errors, 15 warnings)`, all pre-existing (`any`, hook-deps) at line numbers inside the untouched function body — none introduced by this diff.
- `node scripts/check-changeset-presence.mjs` → ✅ (1 changeset declared for the 3 changed source files).
- `node scripts/check-changeset-no-major.mjs` → ✅.
- Manual control-byte scan (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) on every changed file → clean.
- Not run: a full `apps/console` build/typecheck. This diff is additive JSDoc only (no type/signature/export-shape change), and `apps/console` is the sole in-repo consumer of `@object-ui/app-shell` — already confirmed above not to import `AppSidebar` — so there's no narrower type for it to trip over.

## Open note

CI is not yet observed (draft just opened); will read `Test (coverage)`/lint/build checks by name once they've had time to run, per the reporting convention, but reports the report itself now rather than polling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_