### PR TITLE
fix(plugin-view): remove the inert showRefresh designer input from object-view

### DIFF
--- a/.changeset/remove-inert-showrefresh-5567.md
+++ b/.changeset/remove-inert-showrefresh-5567.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/plugin-view': minor
+'@object-ui/app-shell': patch
+---
+
+Remove the inert `showRefresh` designer input from the `object-view` registration (objectui#5567).
+
+The `object-view` designer no longer offers a "Show Refresh Button" toggle, and the registration no longer defaults `showRefresh: true`. The key was declared, documented, and defaulted, but `ObjectView` never read it — an author who wrote `showRefresh: false` on an `object-view` node always got a no-op. **Behaviour is unchanged for every existing app**, because nothing ever consumed the key.
+
+Migration: nothing to do. If you wrote `showRefresh` on an `object-view` node, the key simply disappears from the designer's property panel; it never controlled anything. The live refresh channel is `userActions.refresh` (rendered by the list toolbar in `@object-ui/plugin-list`), which is unaffected. `showRefresh` on other surfaces (e.g. `CRUDToolbar`) is also unaffected.
+
+`@object-ui/app-shell` only drops its two producer writes of the dead key (the app `ObjectView` wrapper and the metadata-admin `ViewPreview`) — no user-visible change.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -868,7 +868,6 @@ A complete object management interface combining grid, form, search, filters, an
   "showSearch": true,
   "showFilters": true,
   "showCreate": true,
-  "showRefresh": true,
   "showViewSwitcher": true,
   "operations": {
     "create": true,
@@ -911,7 +910,7 @@ A complete object management interface combining grid, form, search, filters, an
 | `defaultListView` | `string` | Key of the default list view. |
 | `table` | `Partial<ObjectGridSchema>` | Grid configuration overrides. |
 | `form` | `Partial<ObjectFormSchema>` | Form configuration overrides. |
-| `showSearch` / `showFilters` / `showCreate` / `showRefresh` | `boolean` | Toggle toolbar features. |
+| `showSearch` / `showFilters` / `showCreate` | `boolean` | Toggle toolbar features. |
 | `showViewSwitcher` | `boolean` | Show view type toggle (grid, kanban, etc.). |
 | `operations` | `object` | Enabled CRUD operations. |
 | `navigation` | `ViewNavigationConfig` | SPA-aware navigation. |

--- a/content/docs/plugins/plugin-view.mdx
+++ b/content/docs/plugins/plugin-view.mdx
@@ -74,7 +74,6 @@ const shape: ObjectViewSchema = {
   showFilters: true,
   showSort: true,
   showCreate: true,
-  showRefresh: true,
   showViewSwitcher: false, // default false
   allowCreateView: false,
 

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -2312,7 +2312,6 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         showFilters: activeView?.showFilters !== false,
         showSort: activeView?.showSort !== false,
         showCreate: false, // We render our own create button in the header
-        showRefresh: true,
         allowCreateView: isAdmin,
         viewActions: isAdmin ? [
             { type: 'settings' as const },

--- a/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx
@@ -133,7 +133,6 @@ export function ViewPreview({ name, draft, editing }: MetadataPreviewProps) {
       showSearch: true,
       showFilters: true,
       showCreate: false,
-      showRefresh: true,
       showViewSwitcher: true,
     }),
     [objectName, defaultViewType, defaultViewId, listViews],

--- a/packages/plugin-view/src/__tests__/objectViewShowRefreshRetired.test.tsx
+++ b/packages/plugin-view/src/__tests__/objectViewShowRefreshRetired.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `object-view` no longer publishes `showRefresh` (objectui#5567).
+ *
+ * The key was a declared, documented, defaulted designer input that NOTHING
+ * read: `ObjectView` never consulted it, and it is not among
+ * `OBJECT_VIEW_DECLARED_FORWARDED_KEYS`, so an author's `showRefresh: false`
+ * was always a no-op. The 2026-08-22 maintainer ruling (Option A, per the
+ * 2026-07 audit's recorded disposition) removed the designer input and its
+ * default rather than wiring it up — and ruled that the affordance is NOT
+ * resurrected here. The real refresh channel is `userActions.refresh`,
+ * rendered by the list toolbar in `@object-ui/plugin-list`.
+ *
+ * This file is that ruling's pin. If `showRefresh` reappears on the
+ * `object-view` registration (input or default), re-open objectui#5567
+ * before landing the change — implementing the toggle was Option B, which
+ * was considered and rejected.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+
+// Module scope, not a hook: this import IS the registration.
+import '../index';
+
+const configOf = (type: string) =>
+  ComponentRegistry.getConfig(type) as
+    | { inputs?: Array<{ name: string }>; defaultProps?: Record<string, unknown> }
+    | undefined;
+
+describe('object-view: the retired `showRefresh` toggle stays retired (objectui#5567)', () => {
+  it('publishes no `showRefresh` designer input', () => {
+    const inputNames = (configOf('object-view')?.inputs ?? []).map((i) => i.name);
+    expect(
+      inputNames,
+      '`object-view` publishes `showRefresh` again. Nothing in this package reads the key — the\n'
+        + 'maintainer ruling on objectui#5567 removed it and keeps the refresh affordance on\n'
+        + '`userActions.refresh` (plugin-list). Re-open objectui#5567 before landing this.',
+    ).not.toContain('showRefresh');
+    // The control: without it, "does not contain" would pass just as happily
+    // against a registration that publishes nothing at all.
+    expect(inputNames).toEqual(
+      expect.arrayContaining(['showSearch', 'showFilters', 'showCreate', 'showViewSwitcher']),
+    );
+  });
+
+  it('asserts no `showRefresh` default', () => {
+    const defaults = configOf('object-view')?.defaultProps ?? {};
+    expect(
+      defaults,
+      'The `object-view` registration defaults `showRefresh` again — a default asserts a value\n'
+        + 'for a key nothing reads (objectui#5567). Re-open the card before landing this.',
+    ).not.toHaveProperty('showRefresh');
+    // Control: the surviving toolbar defaults are still asserted, so this test
+    // is reading the real registration rather than an empty object.
+    expect(defaults).toMatchObject({ showCreate: true, showViewSwitcher: true });
+  });
+});

--- a/packages/plugin-view/src/index.tsx
+++ b/packages/plugin-view/src/index.tsx
@@ -78,7 +78,6 @@ ComponentRegistry.register('object-view', ObjectViewRenderer, {
     { name: 'showSearch', type: 'boolean', label: 'Show Search' },
     { name: 'showFilters', type: 'boolean', label: 'Show Filters' },
     { name: 'showCreate', type: 'boolean', label: 'Show Create Button' },
-    { name: 'showRefresh', type: 'boolean', label: 'Show Refresh Button' },
     { name: 'showViewSwitcher', type: 'boolean', label: 'Show View Switcher' },
     { name: 'listViews', type: 'object', label: 'Named List Views' },
     { name: 'navigation', type: 'object', label: 'Navigation Config' },
@@ -91,7 +90,6 @@ ComponentRegistry.register('object-view', ObjectViewRenderer, {
     showSearch: true,
     showFilters: true,
     showCreate: true,
-    showRefresh: true,
     showViewSwitcher: true,
   },
 });


### PR DESCRIPTION
Fixes #5567

Executes the maintainer ruling recorded on the card (2026-08-22, decision-inbox digest, accepted verbatim 「接受所有」): **Option A — remove the inert toggle.** The `object-view` registration declared, defaulted, and documented a "Show Refresh Button" toggle that `ObjectView` never read, so an author's `showRefresh: false` was always a no-op. The real refresh channel stays `userActions.refresh` (live in `@object-ui/plugin-list`, untouched); the affordance is **not** resurrected — Option B was considered and rejected, and this PR pins that.

## What changed

- **Designer input + default deleted** — `packages/plugin-view/src/index.tsx` (the card's `:81` and `:94`, both re-anchored exact on today's `main`): the `showRefresh` entry is gone from `inputs` and from `defaultProps`.
- **Producer writes cleaned (re-measured: still exactly three, one line moved)** — `packages/app-shell/src/views/ObjectView.tsx` (audit said `:1624`, card said `:2192`, actually `:2315` — the `objectViewSchema` literal), `packages/app-shell/src/views/metadata-admin/previews/ViewPreview.tsx:136` (exact), and the `defaultProps` entry above.
- **Docs — corrected census: 3 lines across 2 files, not 2 lines.** `content/docs/api/schema-reference.md:871` (example line, deleted) and `:914` (shared toolbar table row — only the `showRefresh` token removed; `showSearch`/`showFilters`/`showCreate` are genuinely read at `plugin-view/src/ObjectView.tsx:1016/1018/1636` and stay documented), plus `content/docs/plugins/plugin-view.mdx:77` (example line, deleted). The ruling's "two docs lines" matches the card's two docs bullets; the raw line count is three.
- **Retirement pinned** — new `packages/plugin-view/src/__tests__/objectViewShowRefreshRetired.test.tsx` asserts the registration publishes no `showRefresh` input and no default (with positive controls on surviving keys, so the assertions cannot pass vacuously against an empty registration). Reverse-verified: re-adding both lines (mutation confirmed on disk, `grep -c` 0 → 2) turns both tests red (`Test Files 1 failed (1)`, `Tests 2 failed (2)`); restore leg confirmed (`grep -c` back to 0).
- **Changeset** — `.changeset/remove-inert-showrefresh-5567.md` (`@object-ui/plugin-view` minor, `@object-ui/app-shell` patch), written in migration terms: an author who wrote `showRefresh` on an `object-view` node sees the key disappear from the designer's property panel; behaviour never changed because nothing ever read it; `userActions.refresh` is the live channel.

## Premise verification (all held)

- **Zero readers, re-proven on today's `main`:** `git grep showRefresh` in `packages/plugin-view/src` hits only the two removed lines; `OBJECT_VIEW_DECLARED_FORWARDED_KEYS` remains exactly four keys without it. The only genuine readers are `plugin-list/src/ListView.tsx:803/:3087`, fed by `userActions.refresh` — not by any of the removed writes.
- **Deliberately untouched:** the `@object-ui/types` declarations (`ObjectViewSchema` interface `objectql.ts:1487` + zod `objectql.zod.ts:194`, and `CRUDToolbar` `crud.ts:355` + zod) — the card records these as the key's live/real surface, and the accepted Option A scope (triage comment, accepted verbatim) enumerates only the designer input, default, three producers, and docs. The types-side fold of the `show*` booleans into `userActions` is already tracked by #2231 / #2890 and the `object-view-spec-parity` test's counterpart map. Also untouched: `docs/audits/2026-07-objectview-detailview-schema.md` (a point-in-time audit record) and the historical mention in `ObjectView.refreshSignal.test.tsx`, which describes plugin-list's live channel and stays accurate. Out of scope here: #4568 remains the prior card this finding was measured under (already closed).

## Verification (all on head `291f79778`, the final commit)

- Union vitest run from the repo root under the shared verify lock: full `packages/plugin-view/` suite (incl. the new pin), `object-view-spec-parity.test.ts`, `scripts/__tests__/doc-version-claims.test.ts`, and the 9 app-shell suites covering the two edited files — vitest verdict: `Test Files 32 passed (32)`, `Tests 358 passed (358)`.
- `node scripts/check-changeset-presence.mjs` — "✅ 3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)".
- `node scripts/check-doc-component-types.mjs` — "✅ Every documented component type is registered."
- `node scripts/check-doc-snippet-types.mjs` (after `turbo run build` of the gate's own `--build-filter` closure, 32/32 tasks) — "Semantic phase: 101 of 101 block(s) judged, 0 failed."
- `node scripts/check-control-bytes.mjs` — "✅ check-control-bytes: OK (scanned 4844 tracked text file(s))".
- `turbo run type-check --filter=@object-ui/plugin-view --filter=@object-ui/app-shell` — "Tasks: 31 successful, 31 total" (both target tasks cache-miss executed).
- Targeted `eslint` on the four edited/added TS files: 0 errors (pre-existing warnings only).
- Declared narrowing: app-shell's full 504-file suite and the repo-wide `lint`/`test` farm are CI-owned; local app-shell coverage is the 9 suites that exercise the two edited files. The diff there deletes two writes of a key with zero readers repo-wide (census above), so no test outside those files' surface can observe the change.

⚠️ Note for the gate reader: `Test (coverage)` is red on `main` (#5436 / #5422) — pre-existing, not from this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_