### PR TITLE
fix(react): report a `${…}` visibility predicate collapsed inside `properties`

### DIFF
--- a/.changeset/properties-template-visibility-diagnostic-5756.md
+++ b/.changeset/properties-template-visibility-diagnostic-5756.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/react': patch
+---
+
+`SchemaRenderer`'s node visibility gate now also catches the `${…}`-templated
+spelling of the objectui#5454/#5687 diagnostics when it is written inside
+`properties`, e.g. `properties: { visible: "${data.status == 'draft'}" }`
+(objectui#5756).
+
+The `properties.*` evaluation loop runs, and interpolates every `${…}` template it
+finds, **before** the visibility gate ever sees the value — so by the time the
+existing diagnostics ran, a template-spelled predicate had already collapsed into a
+plain boolean and there was no predicate text left to inspect. The bare-string
+spelling of the exact same gate (`properties: { visible: "data.status == 'draft'"
+}`) was unaffected — nothing interpolates a string with no `${` in it — and was
+already reported; only the template spelling was structurally invisible.
+
+Reached by moving the diagnostic check to inside the `properties` evaluation loop,
+on the predicate's raw (pre-interpolation) text, gated on the key being one of the
+six visibility keys the render chain consults (`visibleWhen` / `visible` /
+`visibleOn` / `visibility` / `hidden` / `hiddenOn`) — a `properties.content`
+interpolation, or any other non-visibility key, is untouched and stays silent.
+
+Reports only the key that actually **decides** the node's visibility, mirroring
+objectui#5454's own leg semantics (its reporter is likewise only ever invoked on
+the leg the chain's early-return sequence actually reaches): a `properties.visible`
+template that a co-declared `visibleWhen` outranks is not reported for deciding
+nothing.
+
+**No verdict changes and no interpolation changes.** The diagnostic call's return
+value is discarded; the real verdict is still computed afterward, off the
+post-evaluation, post-hoist schema, by the same code path as before this change.
+Same two reporters as objectui#5454/#5687 (unresolvable-predicate / adapter-only-data
+predicate), same dedupe `Set`, same `console.warn` severity, same dev-only gate —
+only the silence moved, one render-step earlier.

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -217,6 +217,85 @@ function propsWithoutCanonicalKeys(
 }
 
 /**
+ * The visibility-chain keys, in the EXACT precedence order the `shouldHide`
+ * IIFE in the evaluation memo consults them (objectui#5756).
+ *
+ * That chain is one sequence of `if (…) return …` — an early-return chain,
+ * not independent checks — so only the FIRST key here found "declared" on a
+ * node is ever the one that decides, and every lower-priority key is never
+ * even asked. `SHOW` keys ask "is it `!== undefined`?" (their `true` means
+ * *shown*, so "absent" already means shown and needs no narrower test);
+ * `HIDE` keys ask {@link hasDeclaredPredicate} instead, because their `true`
+ * means *hidden* and the wider `!== undefined` test would vanish a node for
+ * `hidden: ''` (objectui#3955). See {@link winningVisibilityKey}.
+ */
+const VISIBILITY_SHOW_KEYS = ['visibleWhen', 'visible', 'visibleOn', 'visibility'] as const;
+const VISIBILITY_HIDE_KEYS = ['hidden', 'hiddenOn'] as const;
+
+/**
+ * Which ONE visibility key actually decides a node's fate, mirroring both the
+ * `properties` hoist's precedence (same-named key: `properties.<key>`
+ * overwrites a node-level `<key>`) and `shouldHide`'s early-return chain
+ * (first-declared-wins across {@link VISIBILITY_SHOW_KEYS} then
+ * {@link VISIBILITY_HIDE_KEYS}) — without waiting for either to run.
+ *
+ * ## Why this exists (objectui#5756)
+ *
+ * A `${…}` template written as `properties.visible` is evaluated — and
+ * collapsed to a plain boolean — by the loop that runs BEFORE the hoist, in
+ * the SAME render pass. By the time `shouldHide` runs, the predicate TEXT is
+ * gone; there is nothing left to diagnose. Reaching it means asking "does
+ * THIS properties key actually decide?" at the one point in the render where
+ * the raw text still exists — which means asking the precedence question
+ * EARLY, on values the hoist has not yet merged and `shouldHide` has not yet
+ * consulted.
+ *
+ * ## Why the precedence question, and not just "is it in `properties`?"
+ *
+ * Without it, a `properties.visible` template that a co-declared `visibleWhen`
+ * OUTRANKS (exactly `shouldHide`'s own early-return: `visibleWhen` short-
+ * circuits before `visible` is ever reached) would be reported even though it
+ * decides nothing — a false positive for a leg that never runs. Restricting
+ * the report to the WINNING key mirrors what `shouldHide` already does for
+ * every OTHER key spelling (objectui#5454's leg-3 reporter is only ever
+ * invoked on the leg that is actually consulted, by construction of the same
+ * early-return chain) rather than inventing a different posture for this one.
+ *
+ * ## Why `node.properties` must already be POST-evaluation here
+ *
+ * The caller runs this AFTER the `properties.*` evaluation loop (so
+ * `node.properties.visible` may already be the collapsed boolean, not the raw
+ * template) and BEFORE the hoist (so a plain node-level key, untouched by that
+ * loop, is still exactly what `shouldHide` will see). That ordering is what
+ * makes "declared" answered here agree bit-for-bit with what `shouldHide`
+ * answers later — including the corner a naive PRE-evaluation read would get
+ * wrong: a template that evaluates to a literal `undefined` (e.g.
+ * `${data.missing}` read alone) is `!== undefined` on its RAW text but not on
+ * its EVALUATED value, and `shouldHide` falls through to the next key for
+ * exactly that reason. Reading pre-eval text here would call `visible` the
+ * winner when the real chain does not.
+ *
+ * Read-only: decides nothing about visibility itself, only which key a
+ * DIAGNOSTIC should look at.
+ */
+function winningVisibilityKey(node: Record<string, unknown>): string | undefined {
+  const propertiesBag = node.properties;
+  const hasPropertiesBag =
+    propertiesBag != null && typeof propertiesBag === 'object' && !Array.isArray(propertiesBag);
+  const effective = (key: string): unknown =>
+    hasPropertiesBag && Object.prototype.hasOwnProperty.call(propertiesBag, key)
+      ? (propertiesBag as Record<string, unknown>)[key]
+      : node[key];
+  for (const key of VISIBILITY_SHOW_KEYS) {
+    if (effective(key) !== undefined) return key;
+  }
+  for (const key of VISIBILITY_HIDE_KEYS) {
+    if (hasDeclaredPredicate(effective(key))) return key;
+  }
+  return undefined;
+}
+
+/**
  * Per-component Error Boundary for SchemaRenderer.
  * Catches render errors in individual components, preventing one broken
  * component from crashing the entire page.
@@ -475,6 +554,78 @@ export const SchemaRenderer: ForwardRefExoticComponent<
     // Shallow copy
     const newSchema = { ...schema };
 
+    /**
+     * Evaluate ONE visibility predicate, and make an unresolvable one LOUD
+     * (objectui#5454, leg 3 of the 2026-08-21 ruling).
+     *
+     * ## The verdict is byte-for-byte what it was — only the silence moved
+     *
+     * `evaluateCondition` answers an unresolvable predicate with `true`, on
+     * every one of its three internal paths: the CEL envelope fails soft to its
+     * `true` fallback, a bare expression that throws is caught and returns
+     * `true`, and a `${…}` template that throws returns its own SOURCE TEXT,
+     * which is a non-empty string and therefore truthy. Passing
+     * `throwOnError: true` changes none of those verdicts — it only converts
+     * "could not evaluate" from a value into a throw — so this helper returns
+     * `true` from the catch and reproduces the old answer exactly. That is why
+     * it is safe on the two NON-negated legs (`hidden` / `hiddenOn`) as well,
+     * where the same `true` means HIDE rather than SHOW.
+     *
+     * ## Why it needed saying at all
+     *
+     * A fail-soft surface answers "this predicate is broken" and "this
+     * predicate said yes" with the same word. On the negated legs that word is
+     * SHOWN, so a `record.*` gate written before objectui#5454 bound the row
+     * rendered its block unconditionally and looked exactly like a gate the
+     * author had got right. One of the three paths was already loud — the CEL
+     * envelope's `evalFieldPredicate` warns (objectstack#5149) — and the other
+     * two were mute, so whether an author heard about their own typo depended
+     * on which dialect they happened to write it in.
+     *
+     * Deduped per (node type, key, predicate source): a broken predicate is
+     * re-evaluated on every render, and the point is one line, not a wall.
+     *
+     * ## Defined HERE, ahead of the `properties` evaluation loop below
+     *
+     * It used to sit just above `shouldHide`, its only caller. objectui#5756
+     * added a second call site — inside the `properties` loop below, on the
+     * raw (pre-evaluation) text of whichever key that loop is about to collapse
+     * — so the definition moved up to be in scope for both. Nothing about the
+     * function changed; `shouldHide` below still calls it exactly as before,
+     * on the POST-evaluation, POST-hoist schema, for the real verdict.
+     */
+    const evaluateVisibilityPredicate = (raw: VisibilityPredicate, key: string): boolean => {
+      // PRODUCTION IS THE UNTOUCHED CALL. `throwOnError` is how the fault is
+      // detected, and on the CEL branch `evaluateCelCondition` implements it by
+      // evaluating TWICE (once with each fallback — a value that tracks the
+      // fallback both times is a fault). Spec-parsed metadata normalizes
+      // `visibleWhen` into a `{ dialect: 'cel' }` envelope, so that branch is
+      // the common one in production: paying for the probe unconditionally
+      // would double the engine calls for every predicate of every node, to
+      // build a message no production build ever prints.
+      if (!__DEV__) return evaluator.evaluateCondition(raw);
+      try {
+        const verdict = evaluator.evaluateCondition(raw, { throwOnError: true });
+        // objectui#5687 — the NON-throwing half of the same silence, and it is
+        // reachable ONLY here, on the branch where the predicate evaluated
+        // cleanly. A `data.*` read the adapter cannot answer is not a fault the
+        // evaluator can raise: `undefined == 'draft'` is a perfectly good
+        // `false`. Verdict untouched — `verdict` is returned exactly as
+        // computed, which is what keeps the ruling's "no verdict changes" true
+        // by construction rather than by review.
+        reportAdapterOnlyDataPredicate(newSchema.type, newSchema.id, key, raw, dataSource);
+        return verdict;
+      } catch (err) {
+        reportUnresolvableVisibilityPredicate(newSchema.type, newSchema.id, key, raw, err);
+        // The historical fail-soft answer, unchanged — and identical to what
+        // the production branch above returns for the same input, which is what
+        // keeps the two branches one behaviour rather than two. See the
+        // docblock: `true` is the value EVERY path of `evaluateCondition`
+        // already returned for an unevaluable predicate.
+        return true;
+      }
+    };
+
     // Evaluate 'properties' — the SPEC spelling of a node's config bag, of
     // which `props` (evaluated below) is the legacy alias.
     //
@@ -508,16 +659,71 @@ export const SchemaRenderer: ForwardRefExoticComponent<
     // this value FEEDS the hoist, so re-shaping a degenerate `properties`
     // (a string, an array) via the object spread would propagate. Non-objects
     // skip evaluation and reach the hoist exactly as they do today.
-    if (
+    // Snapshotted BEFORE evaluation — objectui#5756's diagnostic below reads
+    // the RAW (pre-collapse) text from this reference, since `newSchema.properties`
+    // is about to be replaced with the evaluated copy.
+    const rawPropertiesBag: Record<string, unknown> | undefined =
       newSchema.properties &&
       typeof newSchema.properties === 'object' &&
       !Array.isArray(newSchema.properties)
-    ) {
-      const newProperties: Record<string, any> = { ...newSchema.properties };
+        ? (newSchema.properties as Record<string, unknown>)
+        : undefined;
+
+    if (rawPropertiesBag) {
+      const newProperties: Record<string, any> = { ...rawPropertiesBag };
       for (const [key, val] of Object.entries(newProperties)) {
         newProperties[key] = evaluator.evaluate(val as any);
       }
       newSchema.properties = newProperties;
+    }
+
+    /**
+     * objectui#5756 — the `${…}` HALF of the #5687/#5454 silence, reached at
+     * the one point in this render where it still can be: BEFORE the hoist
+     * (which would bury it under the node-level keys) and immediately AFTER
+     * the loop above (so `newSchema.properties` already reflects which key
+     * would win the SAME precedence `shouldHide` applies later — see
+     * {@link winningVisibilityKey}).
+     *
+     * A `${…}`-spelled visibility predicate written inside `properties` is
+     * evaluated — and collapsed to a plain boolean — by the loop directly
+     * above, before `shouldHide` (and its #5454/#5687 reporter) ever sees it.
+     * The bare-string spelling of the SAME gate (`properties: { visible:
+     * "data.status == 'draft'" }`) is untouched by that loop (no `${` to
+     * interpolate) and reaches `shouldHide` intact, where the existing
+     * reporter already catches it — this block exists only to give the
+     * template spelling the same fate, not a different one.
+     *
+     * ## What this does NOT do
+     *
+     * - **No verdict change.** This call's return value is discarded; the
+     *   REAL verdict is still decided by `shouldHide` below, off the
+     *   POST-evaluation, POST-hoist schema, exactly as before this card.
+     * - **No new report shape.** It is the SAME `evaluateVisibilityPredicate`
+     *   `shouldHide` calls — same two reporters, same dedupe `Set`, same
+     *   `__DEV__` gate — called one render-step earlier, on the text this
+     *   step is about to erase. There is nothing here to duplicate the LATER
+     *   call: by the time `shouldHide` runs, this key's value is already the
+     *   collapsed boolean, which carries no `data.` text for either reporter
+     *   to match — so at most one of the two calls ever fires per predicate.
+     * - **Only the WINNING key.** Gated on {@link winningVisibilityKey} so a
+     *   `properties.visible` template that a co-declared `visibleWhen`
+     *   outranks is not reported for deciding nothing (mirrors #5454's own
+     *   leg semantics: its reporter is likewise only ever invoked on the leg
+     *   `shouldHide` actually consults).
+     * - **Only what would actually collapse.** A bare string (no `${`) is
+     *   untouched by the loop above and is left for the existing gate-time
+     *   report to catch, unchanged.
+     */
+    if (__DEV__) {
+      const winningKey = winningVisibilityKey(newSchema);
+      if (winningKey && rawPropertiesBag && Object.prototype.hasOwnProperty.call(rawPropertiesBag, winningKey)) {
+        const rawWinningValue = rawPropertiesBag[winningKey];
+        if (typeof rawWinningValue === 'string' && rawWinningValue.includes('${')) {
+          // Diagnostic only — the boolean this returns is thrown away.
+          evaluateVisibilityPredicate(rawWinningValue as VisibilityPredicate, winningKey);
+        }
+      }
     }
 
     // COMPAT: Hoist 'properties' up to schema level
@@ -554,69 +760,6 @@ export const SchemaRenderer: ForwardRefExoticComponent<
       }
       newSchema.props = newProps;
     }
-
-    /**
-     * Evaluate ONE visibility predicate, and make an unresolvable one LOUD
-     * (objectui#5454, leg 3 of the 2026-08-21 ruling).
-     *
-     * ## The verdict is byte-for-byte what it was — only the silence moved
-     *
-     * `evaluateCondition` answers an unresolvable predicate with `true`, on
-     * every one of its three internal paths: the CEL envelope fails soft to its
-     * `true` fallback, a bare expression that throws is caught and returns
-     * `true`, and a `${…}` template that throws returns its own SOURCE TEXT,
-     * which is a non-empty string and therefore truthy. Passing
-     * `throwOnError: true` changes none of those verdicts — it only converts
-     * "could not evaluate" from a value into a throw — so this helper returns
-     * `true` from the catch and reproduces the old answer exactly. That is why
-     * it is safe on the two NON-negated legs (`hidden` / `hiddenOn`) as well,
-     * where the same `true` means HIDE rather than SHOW.
-     *
-     * ## Why it needed saying at all
-     *
-     * A fail-soft surface answers "this predicate is broken" and "this
-     * predicate said yes" with the same word. On the negated legs that word is
-     * SHOWN, so a `record.*` gate written before objectui#5454 bound the row
-     * rendered its block unconditionally and looked exactly like a gate the
-     * author had got right. One of the three paths was already loud — the CEL
-     * envelope's `evalFieldPredicate` warns (objectstack#5149) — and the other
-     * two were mute, so whether an author heard about their own typo depended
-     * on which dialect they happened to write it in.
-     *
-     * Deduped per (node type, key, predicate source): a broken predicate is
-     * re-evaluated on every render, and the point is one line, not a wall.
-     */
-    const evaluateVisibilityPredicate = (raw: VisibilityPredicate, key: string): boolean => {
-      // PRODUCTION IS THE UNTOUCHED CALL. `throwOnError` is how the fault is
-      // detected, and on the CEL branch `evaluateCelCondition` implements it by
-      // evaluating TWICE (once with each fallback — a value that tracks the
-      // fallback both times is a fault). Spec-parsed metadata normalizes
-      // `visibleWhen` into a `{ dialect: 'cel' }` envelope, so that branch is
-      // the common one in production: paying for the probe unconditionally
-      // would double the engine calls for every predicate of every node, to
-      // build a message no production build ever prints.
-      if (!__DEV__) return evaluator.evaluateCondition(raw);
-      try {
-        const verdict = evaluator.evaluateCondition(raw, { throwOnError: true });
-        // objectui#5687 — the NON-throwing half of the same silence, and it is
-        // reachable ONLY here, on the branch where the predicate evaluated
-        // cleanly. A `data.*` read the adapter cannot answer is not a fault the
-        // evaluator can raise: `undefined == 'draft'` is a perfectly good
-        // `false`. Verdict untouched — `verdict` is returned exactly as
-        // computed, which is what keeps the ruling's "no verdict changes" true
-        // by construction rather than by review.
-        reportAdapterOnlyDataPredicate(newSchema.type, newSchema.id, key, raw, dataSource);
-        return verdict;
-      } catch (err) {
-        reportUnresolvableVisibilityPredicate(newSchema.type, newSchema.id, key, raw, err);
-        // The historical fail-soft answer, unchanged — and identical to what
-        // the production branch above returns for the same input, which is what
-        // keeps the two branches one behaviour rather than two. See the
-        // docblock: `true` is the value EVERY path of `evaluateCondition`
-        // already returned for an unevaluable predicate.
-        return true;
-      }
-    };
 
     // Evaluate visibility: visibleWhen / visible / visibleOn / visibility / hidden / hiddenOn
     const shouldHide = (() => {

--- a/packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx
@@ -48,6 +48,18 @@
  * change moves the silence, not the answer. Removing the `unresolved.length`
  * guard instead turns RED the silence cases (2a/2b/2c/3a/3b) while group 1 stays
  * green, which is the false-positive direction the ruling refuses.
+ *
+ * ## objectui#5756 — the KNOWN LIMIT below is now FIXED, not pinned as a gap
+ *
+ * The 2026-08-22 "no interpolation changes" ruling quoted above was **this
+ * card's own scope constraint**, not a standing ban — objectui#5756 is the
+ * deliberate carrier for the `${…}`-inside-`properties` surface it fenced off.
+ * The test immediately below used to assert ZERO reports for that spelling;
+ * it now asserts ONE, and its describe-group comment is updated to match. What
+ * still stands, unchanged by #5756: no verdict changed (see `#5756 group 5`
+ * below for the byte-identical-verdict control), and every OTHER case in this
+ * file — the two negatives this docblock names, the record.* bucket, the
+ * production build — stays exactly as pinned here.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -205,31 +217,39 @@ describe('#5687 group 1 — the card\'s reproduction shape is reported', () => {
     expect(reports(warn)).toHaveLength(1);
   });
 
-  it('KNOWN LIMIT, measured and pinned: a `${…}` template INSIDE `properties` is invisible to this leg', () => {
-    // Not a choice — a structural consequence of an ordering this ruling
-    // fences off. The memo evaluates every `properties.*` value BEFORE the
-    // hoist ("Evaluating first is what makes one key mean one thing"), and
-    // measured on `@object-ui/core`'s evaluator:
+  it('FIXED by objectui#5756: a `${…}` template INSIDE `properties` now reports too', () => {
+    // Was a structural consequence of an ordering: the memo evaluates every
+    // `properties.*` value BEFORE the hoist ("Evaluating first is what makes
+    // one key mean one thing"), and measured on `@object-ui/core`'s evaluator:
     //
     //   evaluate("data.status == 'draft'")   -> "data.status == 'draft'"  (verbatim)
     //   evaluate("${data.status == 'draft'}") -> false                    (boolean)
     //
-    // So the bare string — the card's pinned repro — arrives at the gate with
-    // its `data.` text intact and IS reported, while the template arrives as a
-    // plain `false` with nothing left to detect. Reaching it would mean adding
-    // a diagnostic inside the interpolation loop, and the 2026-08-22 ruling
-    // fences interpolation off ("no interpolation changes").
+    // So the bare string — the card's pinned repro — arrived at the gate with
+    // its `data.` text intact and was already reported, while the template
+    // arrived as a plain `false` with nothing left to detect. objectui#5756
+    // reaches it by diagnosing INSIDE the `properties` evaluation loop, on the
+    // RAW pre-evaluation text, before it collapses — see
+    // `winningVisibilityKey` in `SchemaRenderer.tsx`.
     //
-    // The verdict is pinned here anyway: the block is hidden on every row, and
-    // the author gets no signal. That silence is filed separately, not
-    // smuggled in here.
+    // The verdict is UNCHANGED: the block is still hidden on every row. Only
+    // the silence moved — see `#5756 group 5` below for the control that pins
+    // this as byte-identical, not merely "still hidden".
     const warn = spyWarn();
     mount({ properties: { visible: "${data.status == 'draft'}" } }, DRAFT);
     expect(shown()).toBe(false);
+    const msg = reports(warn)[0];
+    expect(msg).toBeDefined();
+    expect(msg).toContain(TYPE);
+    expect(msg).toContain('visible');
+    expect(msg).toContain("${data.status == 'draft'}");
+    expect(msg).toContain('data.status');
     cleanup();
     mount({ properties: { visible: "${data.status == 'draft'}" } }, PUBLISHED);
     expect(shown()).toBe(false); // constant across rows, exactly as in group 1
-    expect(reports(warn)).toHaveLength(0);
+    // Deduped across both mounts — same (type, key, source) triple, matching
+    // group 1's "deduped" case exactly, not a second implementation of it.
+    expect(reports(warn)).toHaveLength(1);
   });
 
   it('a node-level `visibleWhen` written the deprecated way reports on ITS key', () => {
@@ -421,12 +441,140 @@ describe('#5687 group 4 — production is untouched', () => {
       cleanup();
       mountProd({ properties: { visible: "record.status == 'draft'" } }, PUBLISHED);
       expect(shown()).toBe(false);
+      cleanup();
+      // objectui#5756: the TEMPLATE spelling of the repro — same constant-false,
+      // same hidden block, and (unlike dev) no report is even attempted, since
+      // the whole diagnostic block is behind `if (__DEV__)`.
+      mountProd({ properties: { visible: "${data.status == 'draft'}" } }, DRAFT);
+      expect(shown()).toBe(false);
       // …and none of this module's output, on any of them.
       expect(warn.mock.calls.map(c => String(c[0])).filter(m => m.includes(ADAPTER_ONLY_DATA_PREDICATE_PREFIX))).toHaveLength(0);
       core.ComponentRegistry.unregister?.(NAME, 'element');
     } finally {
       vi.unstubAllEnvs();
       vi.resetModules();
+    }
+  });
+});
+
+/**
+ * objectui#5756 — the two design points the card left to this seat, each
+ * pinned as its own case, plus the control the dispatch required explicitly:
+ * a value-level (not just verdict-level) proof that interpolation itself is
+ * untouched.
+ */
+describe('#5756 group 5 — the design points this card left open', () => {
+  it('5a: an OUTRANKED `properties.visible` template stays silent — a co-declared `visibleWhen` decides instead', () => {
+    // Mirrors #5454's own leg semantics: `evaluateVisibilityPredicate` is only
+    // ever CALLED on the leg `shouldHide`'s early-return chain actually
+    // consults, so an outranked leg's predicate — however broken — was never
+    // going to be diagnosed by that reporter either. This card's early call
+    // site (inside the `properties` loop) has to earn that same restraint on
+    // purpose, via `winningVisibilityKey`, rather than reporting every
+    // `${…}`-templated visibility key present regardless of whether the chain
+    // ever reaches it.
+    const warn = spyWarn();
+    mount(
+      { visibleWhen: 'true', properties: { visible: "${data.status == 'draft'}" } },
+      DRAFT,
+    );
+    // `visibleWhen` wins the precedence chain and says SHOW — the outranked
+    // `properties.visible` template decides NOTHING about what's on screen.
+    expect(shown()).toBe(true);
+    // Neither leg reports: `visibleWhen: 'true'` has no `data.` text to flag,
+    // and `properties.visible`'s template — despite being exactly the card's
+    // repro shape — is never even looked at, because it never wins.
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('5b: a GENUINE adapter read spelled as a `properties` TEMPLATE stays silent, on both polarities', () => {
+    // The template-dialect sibling of group 2b — extending that silence to
+    // the spelling this card's diagnostic newly reaches, so the new call site
+    // does not turn every properties-authored template gate into noise.
+    const warn = spyWarn();
+    mount({ properties: { visible: '${data.total > 0}' } }, DRAFT);
+    expect(shown()).toBe(true); // 99 > 0
+    cleanup();
+    mount({ properties: { visible: '${data.total > 100}' } }, DRAFT);
+    expect(shown()).toBe(false); // 99 > 100 is a REAL verdict, not an absence
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('5c: the NON-negated `hidden` leg, template-in-properties, reports and keeps its inverted answer', () => {
+    // The template-dialect sibling of group 1's `hidden` case. `hidden` is not
+    // negated, so a predicate that evaluates to `false` (the adapter has no
+    // `status`, so `undefined == 'draft'` is `false`) means "do NOT hide" —
+    // the node stays SHOWN, same as the bare-string spelling.
+    const warn = spyWarn();
+    mount({ properties: { hidden: "${data.status == 'draft'}" } }, DRAFT);
+    expect(shown()).toBe(true);
+    const msg = reports(warn)[0];
+    expect(msg).toBeDefined();
+    expect(msg).toContain('hidden');
+    expect(msg).toContain('data.status');
+  });
+
+  it('5d: a template-in-properties predicate that FAULTS reports via the #5454 (unresolvable) leg, not the #5687/#5756 (adapter-only) one', () => {
+    // The two reporters stay two reporters for this spelling too: a genuine
+    // fault (undefined identifier) is #5454's case, and this leg's dedupe Set
+    // is shared but keyed by reporter name, so the two cannot silence one
+    // another for the same predicate.
+    const warn = spyWarn();
+    mount({ properties: { visible: '${totallyUndefinedIdentifierXYZ}' } }, DRAFT);
+    expect(shown()).toBe(true); // fail-soft default, unchanged
+    expect(unresolvableReports(warn).length).toBeGreaterThan(0);
+    expect(reports(warn)).toHaveLength(0);
+  });
+
+  it('5e: interpolation-unchanged CONTROL — the evaluated `properties.visible` value the schema carries is a plain, real boolean, not something the diagnostic call altered', () => {
+    // The dispatch's explicit ask: prove the diagnostic is read-only, at the
+    // VALUE level, not only at the verdict (`shown()`) level every other case
+    // here already pins. `SchemaValueProbe` reads `props.schema.properties.*`
+    // directly — the exact value `newSchema.properties` carries after BOTH
+    // the evaluation loop AND the new diagnostic call have run — so this is
+    // the evaluated value a hypothetical OTHER renderer reading the raw
+    // `properties` bag (rather than the hoisted top-level key) would see.
+    //
+    // The predicate is the card's repro with the polarity FLIPPED
+    // (`!=` instead of `==`) rather than reused verbatim: the repro's own
+    // spelling evaluates to `false`, which would hide the probe itself and
+    // leave nothing mounted to read a value off of. `data.status` is still
+    // unresolved on this adapter either way — `unresolvedDataPaths` scans
+    // text, not verdicts — so the diagnostic still fires; only the verdict
+    // this control reads off flips, on purpose, to `true`.
+    const VALUE_PROBE_NAME = 'probe-5756-value';
+    const VALUE_PROBE_TYPE = 'element:probe-5756-value';
+    const SchemaValueProbe = (props: { schema?: { properties?: Record<string, unknown> } }) => (
+      <div
+        data-testid="value-probe"
+        data-visible={String(props.schema?.properties?.visible)}
+        data-visible-type={typeof props.schema?.properties?.visible}
+      />
+    );
+    ComponentRegistry.register(VALUE_PROBE_NAME, SchemaValueProbe as never, { namespace: 'element', skipFallback: true } as never);
+    try {
+      const warn = spyWarn();
+      render(
+        <PredicateScopeProvider scope={APP_SCOPE}>
+          <SchemaRendererContext.Provider value={{ dataSource: ADAPTER } as never}>
+            <RecordContextProvider objectName="showcase_task" recordId="r1" data={DRAFT}>
+              <SchemaRenderer schema={{ type: VALUE_PROBE_TYPE, properties: { visible: "${data.status != 'draft'}" } } as never} />
+            </RecordContextProvider>
+          </SchemaRendererContext.Provider>
+        </PredicateScopeProvider>,
+      );
+      const el = screen.getByTestId('value-probe');
+      // A plain JS `true` — `evaluator.evaluate("${data.status != 'draft'}")`'s
+      // OWN answer, exactly as it was before this card, not a string, not the
+      // literal template text, and not some sentinel the diagnostic left behind.
+      expect(el).toHaveAttribute('data-visible-type', 'boolean');
+      expect(el).toHaveAttribute('data-visible', 'true');
+      // The diagnostic still ran (this IS the winning, properties-sourced,
+      // `${…}`-templated key) — the control is that it ran WITHOUT touching
+      // the value above, not that it didn't run.
+      expect(reports(warn)).toHaveLength(1);
+    } finally {
+      ComponentRegistry.unregister?.(VALUE_PROBE_NAME, 'element');
     }
   });
 });


### PR DESCRIPTION
Fixes #5756

## What

`SchemaRenderer`'s `properties.*` evaluation loop interpolates every `${…}` template it finds **before** the visibility chain (and the #5454/#5687 diagnostics riding on it) ever sees the value. So `properties: { visible: "${data.status == 'draft'}" }` collapsed to a plain boolean with no signal to the author, while the bare-string spelling of the exact same gate (`properties: { visible: "data.status == 'draft'" }`) was already reported — the KNOWN-LIMIT gap #5687 pinned and explicitly left for this card.

Fixed by moving the existing `evaluateVisibilityPredicate` helper (unchanged) earlier in the render memo and adding a second, diagnostic-only call site **inside** the `properties` evaluation loop, on the predicate's raw pre-interpolation text, right before it collapses.

## The two design points this card left open — settled here, with rationale

**1. Keyed on the visibility key set, not the value.** The new call site only looks at the six keys the render chain actually consults (`visibleWhen` / `visible` / `visibleOn` / `visibility` / `hidden` / `hiddenOn`). A `properties.content: '${data.total}'` interpolation — or any other non-visibility key — is untouched and stays silent. This was the card's own analysis; implemented as stated.

**2. The outranked-leg false positive — resolved by mirroring #5454's own leg semantics.** `shouldHide` is one early-return chain: only the *first* declared key in precedence order is ever evaluated, so #5454's reporter is (by construction) only ever invoked on the leg that actually decides. The new early call site earns that same restraint explicitly via `winningVisibilityKey(node)`, a small helper that answers "which key wins?" using the same precedence rule (properties-key overwrites same-named node-level key; first-declared-wins across the six keys) — called *after* the `properties` loop has run (so its declaredness answers agree bit-for-bit with what `shouldHide` will see later, including the edge case where a template evaluates to a literal `undefined` and the real chain falls through to the next key) but *before* the hoist. A `properties.visible` template outranked by a co-declared `visibleWhen` is not reported for deciding nothing — pinned in test `5a`.

## No verdict change, no interpolation change

The diagnostic call's return value is discarded; `shouldHide` still computes the real verdict off the post-evaluation, post-hoist schema, via the exact same code as before. Test `5e` pins this at the **value** level (not just the verdict/`shown()` level every other case here pins): it reads `props.schema.properties.visible` off a mounted probe and asserts it is a genuine, unaltered `boolean` — the evaluator's own answer, not something the diagnostic call's extra pass through `evaluateCondition` touched.

**Reverse verification** (commit `212e14a37`): temporarily disabled the new call site (`if (false && __DEV__)`), re-ran the pinned test file — exactly the 3 tests that assert a *new positive report* turned red (the flipped KNOWN-LIMIT test, `5c` hidden-leg, `5e` value control); the negative/control tests (`5a` outranked-leg, `5b` genuine-read-stays-silent, `5d` unresolvable-goes-to-the-other-reporter) stayed green, since they assert silence regardless of whether the new call fires. Restored — `git diff` against the committed fix came back empty, confirming a byte-identical round trip.

## Tests

At `212e14a37` (HEAD, root-relative `pnpm exec vitest`, per this repo's AGENTS.md):

```
pnpm exec vitest run packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx
 Test Files  1 passed (1)
      Tests  23 passed (23)   # 18 pre-existing (1 flipped 0→1, one production case extended) + 5 new (group 5)

pnpm exec vitest run packages/react/ --maxWorkers=2
 Test Files  52 passed (52)
      Tests  711 passed (711)

pnpm --filter '@object-ui/react^...' build   # dependency closure (types, core, i18n, data-objectstack)
pnpm --filter '@object-ui/react' type-check  # tsc --noEmit && tsc -p tsconfig.test.json — clean
pnpm --filter '@object-ui/react' build       # tsc — clean

pnpm exec eslint packages/react/src/SchemaRenderer.tsx packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx --no-inline-config
 0 errors, 19 warnings (all pre-existing @typescript-eslint/no-explicit-any; diff adds ZERO new `any` — verified via `git diff origin/main | grep any`)

node scripts/check-control-bytes.mjs   # OK
node scripts/check-changeset-presence.mjs   # OK — .changeset/properties-template-visibility-diagnostic-5756.md declared
node scripts/check-changeset-no-major.mjs   # OK
```

## Scope

Touches only `packages/react/src/SchemaRenderer.tsx` and its test file, plus a changeset. No other file in the repo imports `visibilityDiagnostic.ts` or references `evaluateVisibilityPredicate`. Not touching any of the paths flagged as in-flight by sibling agents (`packages/auth`, `packages/app-shell/src/layout`, `packages/plugin-view`, `packages/components/src/renderers/complex/table.tsx`, `packages/types`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_