### PR TITLE
feat(types)!: retire ThemeSwitcherSchema / ThemePreviewSchema and ThemeUnionSchema

### DIFF
--- a/.changeset/retire-theme-switcher-preview-5647.md
+++ b/.changeset/retire-theme-switcher-preview-5647.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/types': minor
+---
+
+Retire `ThemeSwitcherSchema` (`type: 'theme-switcher'`) and
+`ThemePreviewSchema` (`type: 'theme-preview'`) — the two remaining theme
+component kinds, which no renderer implemented — together with
+`ThemeUnionSchema`, the union that after objectui#5489 held only these two
+members (objectui#5647).
+
+`packages/types/src/theme.ts` declared a theme-switcher control (`variant`,
+`showMode`, `showThemes`, `lightIcon`, `darkIcon`) and a theme-preview panel
+(`showColors`, `showTypography`, `showComponents`), and
+`packages/types/src/zod/theme.zod.ts` published the matching Zod objects as
+the two members of `ThemeUnionSchema` and therefore of `AnyComponentSchema`.
+Nothing rendered either: neither literal appears at any
+`ComponentRegistry.register(...)` / `registerLazy(...)` site in
+`packages/*/src` (202 registered keys enumerated; positive control on the same
+pipeline: `tooltip` → 1), nor in `PROTOCOL_COMPONENTS` /
+`PALETTE_PLACEHOLDER_BLOCKS`
+(`packages/components/src/renderers/placeholders.tsx`), and no fixture
+declares either kind (control: `"type": "form"` → 81) — so a page declaring
+one got the registry's "Unknown component type" panel (OBJUI-001), never a
+switcher or a preview. Declared-but-unenforced, removed under the 2026-08-21
+maintainer ruling (option B) on objectstack#10485, extended to these siblings
+by inheritance on identical evidence (objectui#5647).
+
+Removed from the published surface: the `ThemeSwitcherSchema` /
+`ThemePreviewSchema` types (`@object-ui/types`), the matching Zod objects and
+`ThemeUnionSchema` (`@object-ui/types/zod`), and the `ThemeSwitcherSchemaType`
+/ `ThemePreviewSchemaType` inference aliases. `zod/theme.zod.ts` now exports
+nothing and stands as the tombstone module. A schema spelling
+`type: 'theme-switcher'` or `type: 'theme-preview'` is now REFUSED by
+`AnyComponentSchema.safeParse` rather than accepted and then rendered as an
+error panel, which is pinned by a test.
+
+**The theme system is unchanged.** `Theme` (the theme document vocabulary,
+owned by `@object-ui/types` since objectui#5716), `ThemeEngine`
+(`@object-ui/core`) and `ThemeProvider` (`@object-ui/react`) are retained and
+untouched — the rulings retain them explicitly. Author a theme as a document
+handed to `ThemeProvider`; that path never went through the removed component
+kinds.

--- a/packages/types/src/__tests__/phase2-schemas.test.ts
+++ b/packages/types/src/__tests__/phase2-schemas.test.ts
@@ -7,9 +7,6 @@ import {
   AppComponentSchema,
   AppActionSchema,
   AppMenuItemSchema,
-  ThemeSwitcherSchema,
-  ThemePreviewSchema,
-  ThemeUnionSchema,
   ReportComponentSchema,
   ReportBuilderSchema,
   ReportViewerSchema,
@@ -112,23 +109,31 @@ describe('Phase 2: AppComponentSchema Zod Validation', () => {
   });
 });
 
-describe('Phase 2: Theme component kinds — Zod Validation', () => {
-  // `type: 'theme'` (`ThemeComponentSchema`) was RETIRED in objectui#5489 under
-  // the maintainer ruling of 2026-08-21 on objectstack#10485 (option B). It
-  // declared a theme-manager COMPONENT that no renderer ever implemented. This
-  // is the pin that keeps it retired: the shape the old acceptance test proved
-  // VALID is now proven REFUSED, so a re-added union member fails here rather
-  // than reappearing silently in the published `@object-ui/types/zod` surface.
+describe('Phase 2: Theme component kinds — retirement pins', () => {
+  // ALL theme component kinds are retired:
   //
-  // The control leg this pin used to carry — `themes[0]` still parsing against
-  // `ThemeDefinitionSchema` — left with that validator: objectstack#10485 (PR
-  // objectstack#10695) retired the spec's whole theme module, and the
-  // objectstack#10856 ruling had objectui remove its re-exports rather than
-  // keep a local mirror (objectui#5710). Attribution now reads the refusal
-  // itself: a discriminated union rejecting an unknown `type` reports the
-  // DISCRIMINATOR, so asserting every issue sits on `type` proves the refusal
-  // hit the retired wrapper kind, not the theme document it carried.
-  it('refuses the retired `type: \'theme\'` component kind at the discriminator', () => {
+  // - `type: 'theme'` (`ThemeComponentSchema`) in objectui#5489, under the
+  //   maintainer ruling of 2026-08-21 on objectstack#10485 (option B) — a
+  //   theme-manager COMPONENT no renderer ever implemented.
+  // - `type: 'theme-switcher'` / `'theme-preview'` (`ThemeSwitcherSchema` /
+  //   `ThemePreviewSchema`), and `ThemeUnionSchema` itself, in objectui#5647,
+  //   by inheritance of the same ruling: the sweep that measured `'theme'`
+  //   unregistered measured both siblings identically — zero
+  //   `ComponentRegistry.register(...)` / `registerLazy(...)` sites, zero
+  //   placeholder entries, zero fixtures.
+  //
+  // These pins keep them retired: the shapes the old acceptance tests proved
+  // VALID are now proven REFUSED, so a re-added kind fails here rather than
+  // reappearing silently in the published `@object-ui/types/zod` surface.
+  //
+  // Attribution note: the objectui#5489 pin proved its refusal sat on the
+  // `type` discriminator of `ThemeUnionSchema`; that union is gone with its
+  // last two members, so discriminator-level attribution is no longer
+  // expressible and the refusals below read `AnyComponentSchema` directly.
+  // The control that keeps them meaningful is the positive leg at the end —
+  // a still-declared kind parsing GREEN through the same pipeline — so a
+  // broken `AnyComponentSchema` cannot read as three successful refusals.
+  it('refuses the retired theme component kinds, while a live kind still parses', () => {
     const retiredWrapper = {
       type: 'theme',
       mode: 'dark',
@@ -162,24 +167,12 @@ describe('Phase 2: Theme component kinds — Zod Validation', () => {
       storageKey: 'app-theme',
     };
 
-    // The wrapper: gone from every union that used to carry it.
-    const refusal = ThemeUnionSchema.safeParse(retiredWrapper);
-    expect(refusal.success).toBe(false);
+    // The `type: 'theme'` wrapper: gone from every union that used to carry it.
     expect(AnyComponentSchema.safeParse(retiredWrapper).success).toBe(false);
 
-    // Attribution control (see the block comment above): the refusal must sit
-    // on the `type` discriminator — the retired WRAPPER kind — not somewhere
-    // inside the theme document the fixture carries.
-    if (!refusal.success) {
-      expect(refusal.error.issues.length).toBeGreaterThan(0);
-      for (const issue of refusal.error.issues) {
-        expect(issue.path, `refusal must be at the discriminator, got ${JSON.stringify(issue)}`).toEqual(['type']);
-      }
-    }
-  });
-
-  it('should validate ThemeSwitcherSchema', () => {
-    const switcher = {
+    // The objectui#5647 siblings — these exact shapes are the fixtures the old
+    // acceptance tests proved VALID against the retired Zod objects.
+    const retiredSwitcher = {
       type: 'theme-switcher',
       variant: 'dropdown',
       showMode: true,
@@ -187,9 +180,20 @@ describe('Phase 2: Theme component kinds — Zod Validation', () => {
       lightIcon: 'Sun',
       darkIcon: 'Moon',
     };
+    expect(AnyComponentSchema.safeParse(retiredSwitcher).success).toBe(false);
 
-    const result = ThemeSwitcherSchema.safeParse(switcher);
-    expect(result.success).toBe(true);
+    const retiredPreview = {
+      type: 'theme-preview',
+      showColors: true,
+      showTypography: true,
+      showComponents: true,
+    };
+    expect(AnyComponentSchema.safeParse(retiredPreview).success).toBe(false);
+
+    // Positive control on the same pipeline (see the block comment above): a
+    // still-declared kind parses GREEN, so the three refusals measure the
+    // retirement, not a broken union.
+    expect(AnyComponentSchema.safeParse({ type: 'action', label: 'Control Action' }).success).toBe(true);
   });
 });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -713,8 +713,10 @@ export type {
   ColorPalette,
   // `Animation` / `ZIndex` retired with `theme.animation` / `theme.zIndex` in
   // @objectstack/spec 17.0.0-rc.3 (objectstack#5021) — see `./theme`.
-  ThemeSwitcherSchema,
-  ThemePreviewSchema,
+  // `ThemeSwitcherSchema` / `ThemePreviewSchema` RETIRED in objectui#5647 —
+  // the `type: 'theme-switcher'` / `'theme-preview'` component kinds no
+  // renderer implemented; same shape, same inherited ruling as
+  // `ThemeComponentSchema` above. See `./theme` for the tombstone.
 } from './theme.js';
 
 // Runtime witness for the theme mode vocabulary — a VALUE, so it must not sit

--- a/packages/types/src/theme.ts
+++ b/packages/types/src/theme.ts
@@ -10,14 +10,13 @@
  * @object-ui/types - Theme Schema
  *
  * The theme document vocabulary (`Theme`, `ThemeMode`, `ColorPalette`) —
- * owned by this package since objectui#5716 — plus the objectui component
- * schemas that render themes.
+ * owned by this package since objectui#5716. The objectui theme COMPONENT
+ * kinds that used to accompany it are all retired (objectui#5489,
+ * objectui#5647); this module is the theme DOCUMENT only.
  *
  * @module theme
  * @packageDocumentation
  */
-
-import type { BaseSchema } from './base.js';
 
 // ============================================================================
 // Theme Document Vocabulary (formerly `@objectstack/spec/ui`)
@@ -231,54 +230,19 @@ export interface Theme {
 // (`packages/react/src/context/ThemeContext.tsx`) applies it. Retiring the
 // dead component kind is not retiring theming.
 //
-// The two siblings below — `ThemeSwitcherSchema` / `ThemePreviewSchema` — are
-// unregistered in exactly the same way but were NOT named by the ruling; they
-// are recorded as objectui#5647 rather than removed here.
-
-/**
- * Theme Switcher Component Schema
- */
-export interface ThemeSwitcherSchema extends BaseSchema {
-  type: 'theme-switcher';
-
-  /** Switcher variant */
-  variant?: 'dropdown' | 'toggle' | 'buttons';
-
-  /** Show mode selector (light/dark) */
-  showMode?: boolean;
-
-  /** Show theme selector */
-  showThemes?: boolean;
-
-  /** Icon for light mode */
-  lightIcon?: string;
-
-  /** Icon for dark mode */
-  darkIcon?: string;
-}
-
-/**
- * Theme Preview Component Schema
- *
- * The `theme` / `mode` members RETIRED with the spec's theme module
- * (objectstack#10485; removal ruled on objectstack#10856, executed as
- * objectui#5710): their zod validators no longer exist upstream, so keeping
- * the members here while `zod/theme.zod.ts` cannot check them would be
- * declared-without-enforcement. The kind itself is unregistered and held for
- * triage as objectui#5647.
- */
-export interface ThemePreviewSchema extends BaseSchema {
-  type: 'theme-preview';
-
-  /** Show color palette */
-  showColors?: boolean;
-
-  /** Show typography samples */
-  showTypography?: boolean;
-
-  /** Show component samples */
-  showComponents?: boolean;
-}
+// `ThemeSwitcherSchema` (`type: 'theme-switcher'`) and `ThemePreviewSchema`
+// (`type: 'theme-preview'`) — the two sibling component kinds that used to
+// follow this note — RETIRED in objectui#5647, by inheritance of the same
+// ruling (option B) under the standing same-family default: identical
+// evidence, measured with the same sweep and the same positive control.
+// Neither literal appears at any `ComponentRegistry.register(...)` /
+// `registerLazy(...)` site in `packages/*/src`, in `PROTOCOL_COMPONENTS` /
+// `PALETTE_PLACEHOLDER_BLOCKS`, or in any fixture — declared-but-unenforced,
+// the same ADR-0078 class as `'theme'` above. Their Zod objects,
+// `ThemeUnionSchema` (which after objectui#5489 held only these two members),
+// and the `…SchemaType` inference aliases left `zod/theme.zod.ts` in the same
+// change; `AnyComponentSchema` no longer carries a theme member, and the
+// refusals are pinned in `__tests__/phase2-schemas.test.ts`.
 
 // `ThemeDefinition` (the deprecated legacy alias of `Theme`) was DELETED here
 // under the objectui#5716 zero-reader rider — zero in-repo readers (census in

--- a/packages/types/src/zod/index.zod.ts
+++ b/packages/types/src/zod/index.zod.ts
@@ -283,17 +283,18 @@ export {
 // ============================================================================
 // Phase 2 Schemas - Theme, Reports, Blocks, and Views
 // ============================================================================
-export {
-  // `ColorPaletteSchema` / `TypographySchema` / `BorderRadiusSchema` /
-  // `ShadowSchema` / `ThemeModeSchema` / `ThemeDefinitionSchema` RETIRED with
-  // the spec's whole `ui/theme.zod.ts` module (objectstack#10485, PR
-  // objectstack#10695; removal ruled on objectstack#10856, executed as
-  // objectui#5710) — see `./theme.zod`.
-  // `ThemeComponentSchema` RETIRED in objectui#5489 — see `./theme.zod`.
-  ThemeUnionSchema,
-  ThemeSwitcherSchema,
-  ThemePreviewSchema,
-} from './theme.zod.js';
+// `./theme.zod` exports NOTHING any more — the module is kept only as the
+// tombstone for the retired theme component-kind surface:
+// - `ColorPaletteSchema` / `TypographySchema` / `BorderRadiusSchema` /
+//   `ShadowSchema` / `ThemeModeSchema` / `ThemeDefinitionSchema` RETIRED with
+//   the spec's whole `ui/theme.zod.ts` module (objectstack#10485, PR
+//   objectstack#10695; removal ruled on objectstack#10856, executed as
+//   objectui#5710).
+// - `ThemeComponentSchema` RETIRED in objectui#5489.
+// - `ThemeSwitcherSchema` / `ThemePreviewSchema` / `ThemeUnionSchema` RETIRED
+//   in objectui#5647, by inheritance of the same 2026-08-21 ruling (option B)
+//   on identical evidence — `AnyComponentSchema` below no longer carries a
+//   theme member.
 
 export {
   ReportExportFormatSchema,
@@ -352,7 +353,6 @@ import { NavigationSchema } from './navigation.zod.js';
 import { ComplexSchema } from './complex.zod.js';
 import { ObjectQLComponentSchema } from './objectql.zod.js';
 import { CRUDComponentSchema } from './crud.zod.js';
-import { ThemeUnionSchema } from './theme.zod.js';
 import { ReportUnionSchema } from './reports.zod.js';
 import { BlockComponentSchema } from './blocks.zod.js';
 import { ViewComponentSchema } from './views.zod.js';
@@ -373,7 +373,6 @@ export const AnyComponentSchema = z.union([
   ComplexSchema,
   ObjectQLComponentSchema,
   CRUDComponentSchema,
-  ThemeUnionSchema,
   ReportUnionSchema,
   BlockComponentSchema,
   ViewComponentSchema,

--- a/packages/types/src/zod/theme.zod.ts
+++ b/packages/types/src/zod/theme.zod.ts
@@ -7,87 +7,54 @@
  */
 
 /**
- * @object-ui/types/zod - Theme Component Zod Validators
+ * @object-ui/types/zod - Theme Component Zod Validators (all RETIRED)
  *
- * Zod validation schemas for the theme COMPONENT nodes (`theme-switcher` /
- * `theme-preview`) — objectui-local declarations, recorded for triage as
- * objectui#5647.
+ * This module exports NOTHING any more. It is kept as the tombstone for the
+ * theme component-kind validators, and `__tests__/spec-subschema-parity.test.ts`
+ * dynamic-imports it to pin the retired names OUT of it.
  *
- * The six `@objectstack/spec/ui` theme-schema re-exports that used to live
- * here (`ColorPaletteSchema`, `TypographySchema`, `BorderRadiusSchema`,
- * `ShadowSchema`, `ThemeModeSchema`, `ThemeDefinitionSchema` — the spec's
- * `ThemeSchema`) are RETIRED. objectstack#10485 (ADR-0049 enforce-or-remove,
- * PR objectstack#10695) deleted the spec's whole `ui/theme.zod.ts` module —
- * values AND types, `AnimationSchema`/`ZIndexSchema` having gone earlier in
- * 17.0.0-rc.3 (objectstack#5021) — and the maintainer's ruling on
- * objectstack#10856 (2026-08-22, Options A + C) has objectui REMOVE these
- * dangling imports; restoring the spec exports (Option B) was explicitly not
- * taken. Executed as objectui#5710.
+ * Two retirement waves emptied it:
+ *
+ * - The six `@objectstack/spec/ui` theme-schema re-exports
+ *   (`ColorPaletteSchema`, `TypographySchema`, `BorderRadiusSchema`,
+ *   `ShadowSchema`, `ThemeModeSchema`, `ThemeDefinitionSchema` — the spec's
+ *   `ThemeSchema`): objectstack#10485 (ADR-0049 enforce-or-remove, PR
+ *   objectstack#10695) deleted the spec's whole `ui/theme.zod.ts` module —
+ *   values AND types, `AnimationSchema`/`ZIndexSchema` having gone earlier in
+ *   17.0.0-rc.3 (objectstack#5021) — and the maintainer's ruling on
+ *   objectstack#10856 (2026-08-22, Options A + C) had objectui REMOVE these
+ *   dangling imports (executed as objectui#5710); restoring the spec exports
+ *   (Option B) was explicitly not taken.
+ *
+ * - The theme COMPONENT kinds: `ThemeComponentSchema` (`type: 'theme'`)
+ *   RETIRED in objectui#5489 under the 2026-08-21 maintainer ruling on
+ *   objectstack#10485 (option B); then `ThemeSwitcherSchema`
+ *   (`type: 'theme-switcher'`), `ThemePreviewSchema` (`type: 'theme-preview'`)
+ *   and `ThemeUnionSchema` — which after objectui#5489 held only those two
+ *   members — RETIRED in objectui#5647, by inheritance of the same ruling on
+ *   identical evidence. No renderer ever registered any of the three literals:
+ *   absent from every `ComponentRegistry.register(...)` / `registerLazy(...)`
+ *   site under every package's `src/`, from `PROTOCOL_COMPONENTS` /
+ *   `PALETTE_PLACEHOLDER_BLOCKS`
+ *   (`packages/components/src/renderers/placeholders.tsx`), and from every
+ *   fixture — so a page declaring one got the registry's "Unknown component
+ *   type" panel (OBJUI-001), never a rendered component. Declared-but-
+ *   unenforced, the ADR-0049 shape to retire. `AnyComponentSchema`
+ *   (`./index.zod.ts`) now refuses all three kinds, and
+ *   `__tests__/phase2-schemas.test.ts` pins the refusals.
  *
  * The theme SYSTEM is retained by the same rulings: the `Theme` TYPE surface
- * lives in `../theme.ts`, `ThemeEngine` turns a theme document into CSS
- * variables, and `ThemeProvider` applies it — none of them consumed these
- * runtime validators (measured at objectui#5710). Do NOT hand-write local
- * mirrors of the retired schemas here: that localization is a contract
- * decision no ruling has taken, and `__tests__/spec-subschema-parity.test.ts`
- * pins the retired names out of this module.
+ * lives in `../theme.ts` (owned there since objectui#5716), `ThemeEngine`
+ * turns a theme document into CSS variables, and `ThemeProvider` applies it.
+ * Do NOT hand-write local mirrors of any retired schema here: that
+ * localization is a contract decision no ruling has taken, and
+ * `__tests__/spec-subschema-parity.test.ts` pins the retired names out of
+ * this module.
  *
  * @module zod/theme
  * @packageDocumentation
  */
 
-import { z } from 'zod';
-import { BaseSchema } from './base.zod.js';
-
-// `ThemeComponentSchema` (`type: 'theme'`) RETIRED in objectui#5489 — the value
-// side of the interface retired in `../theme.ts`, where the ruling and the
-// unregistered-kind measurement are recorded. Its former retention note kept
-// `ThemeDefinitionSchema` / `ThemeModeSchema` exported here "for the engine and
-// the provider" — measured stale at objectui#5710: the engine and the provider
-// consume the `Theme` / `ThemePreference` TYPES, and no package imported either
-// validator. Both left with the spec's theme module (see the header).
-
-/**
- * Theme Switcher Schema
- */
-export const ThemeSwitcherSchema = BaseSchema.extend({
-  type: z.literal('theme-switcher'),
-  variant: z.enum(['dropdown', 'toggle', 'buttons']).optional().describe('Switcher variant'),
-  showMode: z.boolean().optional().describe('Show mode selector (light/dark)'),
-  showThemes: z.boolean().optional().describe('Show theme selector'),
-  lightIcon: z.string().optional().describe('Icon for light mode'),
-  darkIcon: z.string().optional().describe('Icon for dark mode'),
-});
-
-/**
- * Theme Preview Schema
- *
- * The `theme` / `mode` props RETIRED with the spec's theme module (see the
- * header): their validators (`ThemeDefinitionSchema` / `ThemeModeSchema`) no
- * longer exist upstream, and hand-writing local mirrors is the localization
- * branch the objectstack#10856 ruling left untaken. `BaseSchema` is
- * `.passthrough()`, so an authored `theme:` / `mode:` key now passes through
- * unvalidated rather than being checked — tolerable only because no renderer
- * registers `theme-preview` at all (objectui#5647 measured the kind itself as
- * declared-but-unenforced and holds it for triage).
- */
-export const ThemePreviewSchema = BaseSchema.extend({
-  type: z.literal('theme-preview'),
-  showColors: z.boolean().optional().describe('Show color palette'),
-  showTypography: z.boolean().optional().describe('Show typography samples'),
-  showComponents: z.boolean().optional().describe('Show component samples'),
-});
-
-/**
- * Union of all theme component schemas (for AnyComponentSchema union).
- */
-export const ThemeUnionSchema = z.discriminatedUnion('type', [
-  ThemeSwitcherSchema,
-  ThemePreviewSchema,
-]);
-
-/**
- * Export type inference helpers
- */
-export type ThemeSwitcherSchemaType = z.infer<typeof ThemeSwitcherSchema>;
-export type ThemePreviewSchemaType = z.infer<typeof ThemePreviewSchema>;
+// Kept a module on purpose — the parity pin above dynamic-imports this file —
+// with nothing left to export.
+export {};


### PR DESCRIPTION
Fixes #5647

Retires the two remaining dead theme component kinds — `ThemeSwitcherSchema` (`type: 'theme-switcher'`) and `ThemePreviewSchema` (`type: 'theme-preview'`) — together with `ThemeUnionSchema`, which after #5489 held only these two members. The authority is inherited, not fresh: the 2026-08-21 maintainer ruling (option B) on the parent case, extended to these siblings on identical evidence per the standing same-family default (triage comment 5380592857 on the issue). This PR does not re-adjudicate; it re-measures.

## Evidence re-measured on current `main` (ad404e057)

The card's sweep, repeated with its positive controls on the same pipelines:

- Registry: `grep -rhoE "ComponentRegistry\.(register|registerLazy)\(\s*'[a-z0-9-]+'" packages/*/src` → 202 registered keys; `theme-switcher` → 0, `theme-preview` → 0, control `tooltip` → 1.
- Placeholders: neither literal in `PROTOCOL_COMPONENTS` / `PALETTE_PLACEHOLDER_BLOCKS` (`packages/components/src/renderers/placeholders.tsx`).
- Fixtures: `"type": "theme-switcher"` → 0, `"type": "theme-preview"` → 0, control `"type": "form"` → 81.
- Identifier consumers: `ThemeSwitcherSchema|ThemePreviewSchema|ThemeUnionSchema` outside `packages/types` → 0 hits repo-wide (code, docs, scripts, skills). `AnyComponentSchema` importers outside `packages/types` → 0.

**Bound on the claim**: in-repo consumers are measurable and are zero; consumers of the published `@object-ui/types` outside this org are not measurable from here. This is a breaking narrowing for any external consumer of the removed names, declared in the changeset.

## What changed (worked example: PR #5650)

- `packages/types/src/theme.ts` — both interfaces removed; the #5489 tombstone block extended to record the inherited retirement. The theme DOCUMENT vocabulary (`Theme`, `ThemeMode`, `ColorPalette`, `THEME_MODES`) is untouched.
- `packages/types/src/zod/theme.zod.ts` — both Zod objects, `ThemeUnionSchema`, and both `…SchemaType` aliases removed. The module now exports nothing and stands as the tombstone; it is deliberately kept importable (`export {}`) because `__tests__/spec-subschema-parity.test.ts` dynamic-imports it to pin the retired spec-mirror names out of its namespace.
- Barrels (`src/index.ts`, `src/zod/index.zod.ts`) — names removed with tombstone comments; `AnyComponentSchema` no longer carries a theme member.
- `__tests__/phase2-schemas.test.ts` — the declaration-pinning acceptance test converted to refusal pins: `AnyComponentSchema` now REFUSES `type: 'theme'`, `'theme-switcher'`, and `'theme-preview'` (the exact fixtures the old acceptance tests proved valid), with a live-kind positive control (`type: 'action'`) in the same test so a broken union cannot read as three successful refusals. The #5489 pin's discriminator-level attribution left with the union itself — no longer expressible, noted in the test.
- `.changeset/retire-theme-switcher-preview-5647.md` — `minor` for `@object-ui/types` per the repo's version-alignment convention (breaking semantics stated in the body, never a `major` in the fixed group), following #5650's changeset.

Out of scope, untouched: `ThemeEngine`, `ThemeContext`/`ThemeProvider` and their tests (explicitly retained by the ruling); `content/docs` (zero doc references existed to remove — the theme-schema page rewrite landed separately in #5809).

## Verification (all at 96ebb731f, the head of this PR)

- Build: `pnpm --filter @object-ui/types build` — green (the package has no internal deps; deps closure is external only).
- Type-check: `pnpm --filter @object-ui/types type-check` (all three tsconfigs incl. tests) — green.
- Tests from repo root: `pnpm exec vitest run packages/types/` — 46 files / 514 tests passed, including the parity pin against the tombstone module.
- Consumer compile (downstream direction): the four packages that import `@object-ui/types/zod` — `@object-ui/cli`, `@object-ui/plugin-view`, `@object-ui/plugin-map`, `@object-ui/plugin-list` — type-checked green via `turbo run type-check` (19/19 tasks, building their 15-package dependency closure first, incl. `@object-ui/core`, `@object-ui/components`, `@object-ui/react`). The remaining ~35 dependents of `@object-ui/types` are compiled by CI; the identifier sweep above (zero external references to the removed names, zero `AnyComponentSchema` importers) is the measured basis for that narrowing.
- Reverse verification, dist-level (fix committed first): a probe importing the three removed names from the rebuilt dist → red with TS2724/TS2305 on exactly those three; control probe importing retained `Theme` / `ThemeMode` / `validateSchema` → green (exit 0). Probe deleted.
- Reverse verification, pin-level (ablation with restore trap): re-added a minimal `type: 'theme-switcher'` member to `AnyComponentSchema` in src — mutation confirmed on disk (`MUTATION5647` marker grep → 1); no build leg needed and none run, because the test imports `../zod/index.zod` source-relative; run → exactly the retirement pin red (1 failed / 29 passed), direction as predicted; restored via `git checkout` from the committed branch, confirmed marker grep → 0; re-run green (30/30).
- Gates: `check-changeset-presence` ✅ ("5 source file(s) of 1 released package(s) changed... declares 1 changeset(s)"), `check-changeset-no-major` ✅ ("No changeset declares a `major` bump."), `check-control-bytes` ✅ ("OK (scanned 4844 tracked text file(s))"), `check-doc-component-types` ✅ ("Every documented component type is registered." — against the shrunk declared set).
- Declared narrowing: `check-doc-snippet-types` was NOT run locally — it refuses without built dist for 8 further packages (incl. `app-shell`) and belongs to CI's fully built tree. Basis: its population is the `content/` snippet corpus; removed names in `content/` → 0 and kind literals → 0 (control: `AppComponentSchema` → 2 files), and this diff touches nothing under `content/`, so no untouched snippet's verdict can move except via the removed names, which zero snippets reference.
- Lint: package-level `eslint` for `@object-ui/types` exit 0 (0 errors). The edited test file carries 9 pre-existing unused-import warnings; the baseline on `main` carries 10 (this diff removes one, adds none).

## Concurrency note

Two sibling cards are in `packages/types` in flight (`data-display.ts`; `objectql.ts` + `zod/objectql.zod.ts`). No file overlap with this diff except the two barrels, which this card alone touches per dispatch; overlap resolution if any conflict appears: keep each card's own hunks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_