### PR TITLE
feat(gantt): declare viewMode on ObjectGanttSchema and wire both renderer branches

### DIFF
--- a/.changeset/gantt-viewmode-declared-both-branches-5074.md
+++ b/.changeset/gantt-viewmode-declared-both-branches-5074.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-gantt': minor
+---
+
+**`viewMode` is now declared authoring surface on `ObjectGanttSchema`, and both
+gantt renderer branches honour it** (objectui#5074, maintainer ruling
+2026-08-19: declare-and-wire; the spec half landed first upstream).
+
+- `ObjectGanttSchema` (TS interface and zod mirror) declares `viewMode`,
+  DERIVED from the pinned `@objectstack/spec` `GanttConfigSchema.viewMode`
+  enum by reference, so the member list cannot drift. Deliberately no
+  default: an omitted `viewMode` keeps letting a persisted layout
+  (`persistLayoutKey`) seed the timeline granularity before the renderer's
+  `'day'` fallback.
+- The timeline branch (`GanttView`) now receives an authored `viewMode`.
+  Previously only the resource-workload branch (`resourceView` +
+  `assigneeField`) honoured it, so `viewMode: 'month'` on an ordinary gantt
+  view was silently ignored.
+- The `(schema as any).viewMode` cast in `ObjectGantt` is retired; both
+  branches read the declared `ganttConfig.viewMode`, which also honours the
+  key when authored inside the spec's `gantt` config block.
+- Accept-set note: `viewMode` is now a DECLARED key, so an off-enum value
+  (e.g. `viewMode: 'hour'`) becomes a zod validation error where it
+  previously passed through unvalidated. Values on the published spec enum
+  are unaffected.

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -57,7 +57,7 @@ import {
   formatPercent,
   formatCurrency,
 } from '@object-ui/fields';
-import { GanttView, type GanttTask, type GanttDependency, type GanttInteractions, type GanttLinkType, type GanttTaskType, type GanttViewMode } from './GanttView';
+import { GanttView, type GanttTask, type GanttDependency, type GanttInteractions, type GanttLinkType, type GanttTaskType } from './GanttView';
 import { ResourceWorkload } from './ResourceWorkload';
 import { QuickFilterBar, type QuickFilterField, type QuickFilterOption } from './QuickFilterBar';
 import type { WorkingCalendar } from './scheduling';
@@ -372,6 +372,7 @@ function getGanttConfig(schema: ObjectGridSchema | any): GanttConfigEx | null {
           capacity: schema.capacity,
           quickFilters: schema.quickFilters,
           autoZoomToFilter: schema.autoZoomToFilter,
+          viewMode: schema.viewMode,
           timeSegments: schema.timeSegments,
           interactions: schema.interactions,
           exportFileName: schema.exportFileName,
@@ -1442,11 +1443,17 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
             assignee={assigneeAccessor}
             effort={effortAccessor}
             capacity={ganttConfig?.capacity ?? 1}
-            viewMode={((schema as any).viewMode as GanttViewMode) || 'day'}
+            viewMode={ganttConfig?.viewMode || 'day'}
           />
         ) : (
         <GanttView
           tasks={displayTasks}
+          // Authored granularity (objectui#5074) — undefined when the author
+          // omitted it, so GanttView's own seeding order stays intact:
+          // explicit prop → persisted layout (persistLayoutKey) → 'day'.
+          // ⛔ Do not "simplify" this to `|| 'day'`: a default here would defeat
+          // the persisted-layout seeding for every schema that omits the key.
+          viewMode={ganttConfig?.viewMode}
           startDate={lockedRange?.start}
           endDate={lockedRange?.end}
           onTaskClick={(task) => {

--- a/packages/plugin-gantt/src/ObjectGantt.viewmode.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.viewmode.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * objectui#5074: `viewMode` is declared authoring surface (`ObjectGanttSchema`,
+ * mirroring the spec's `GanttConfigSchema.viewMode`) and honoured by BOTH
+ * renderer branches — the timeline (`GanttView`) and the resource-workload
+ * grid (`ResourceWorkload`) — instead of only the latter.
+ *
+ * GanttView and ResourceWorkload are mocked to thin shells exposing the
+ * `viewMode` prop ObjectGantt hands them (the same convention as the other
+ * ObjectGantt tests). Absence semantics are load-bearing and asserted as
+ * "the prop arrives EXACTLY undefined": GanttView's own seeding order for an
+ * absent prop — explicit prop → persisted layout (persistLayoutKey) → 'day' —
+ * is pinned separately by `GanttView.layout.test.tsx` ("restores a persisted
+ * granularity on mount" / "lets the viewMode prop win over a persisted
+ * granularity"). Together the two files close the chain: an omitted `viewMode`
+ * keeps letting a persisted layout seed the granularity, and re-introducing a
+ * default at the ObjectGantt wiring level (`|| 'day'` / `?? 'day'`) turns the
+ * ABSENT pin below red.
+ */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectGantt } from './ObjectGantt';
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks, viewMode }: any) => (
+    <div
+      data-testid="gantt-view"
+      data-count={tasks.length}
+      data-view-mode={viewMode === undefined ? 'ABSENT' : String(viewMode)}
+    />
+  ),
+}));
+
+vi.mock('./ResourceWorkload', () => ({
+  ResourceWorkload: ({ tasks, viewMode }: any) => (
+    <div
+      data-testid="resource-workload"
+      data-count={tasks.length}
+      data-view-mode={viewMode === undefined ? 'ABSENT' : String(viewMode)}
+    />
+  ),
+}));
+
+const INLINE = [
+  { id: '1', name: 'Alpha', start: '2024-01-01', end: '2024-01-05', owner: 'ada' },
+  { id: '2', name: 'Beta', start: '2024-02-01', end: '2024-02-10', owner: 'bob' },
+];
+
+/** Flattened ObjectGanttSchema style (top-level gantt fields). */
+function schema(extra: Record<string, any> = {}) {
+  return {
+    type: 'object-gantt',
+    startDateField: 'start',
+    endDateField: 'end',
+    titleField: 'name',
+    data: { provider: 'value', items: INLINE },
+    ...extra,
+  } as any;
+}
+
+const modeOf = async (container: HTMLElement, testId: string) => {
+  const el = () => container.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+  await waitFor(() => expect(el()?.getAttribute('data-count')).toBe('2'));
+  return el().getAttribute('data-view-mode');
+};
+
+describe('ObjectGantt viewMode wiring — timeline branch (objectui#5074)', () => {
+  it('honours an authored viewMode on the flattened object-gantt schema', async () => {
+    const { container } = render(<ObjectGantt schema={schema({ viewMode: 'month' })} />);
+    expect(await modeOf(container, 'gantt-view')).toBe('month');
+  });
+
+  it('honours an authored viewMode inside the spec gantt config block', async () => {
+    // ObjectGridSchema style: the spec's GanttConfigSchema vocabulary under
+    // `gantt` — the block the spec key was published on.
+    const s = {
+      type: 'object-grid',
+      gantt: { startDateField: 'start', endDateField: 'end', titleField: 'name', viewMode: 'quarter' },
+      data: { provider: 'value', items: INLINE },
+    } as any;
+    const { container } = render(<ObjectGantt schema={s} />);
+    expect(await modeOf(container, 'gantt-view')).toBe('quarter');
+  });
+
+  it('passes NO viewMode when the author omitted it — persisted-layout seeding stays possible', async () => {
+    // ⛔ This is the pin that stops someone "simplifying" a default back in:
+    // `viewMode={ganttConfig?.viewMode || 'day'}` would arrive downstream as an
+    // explicit author choice and defeat the persisted-layout seeding that
+    // GanttView.layout.test.tsx pins for an absent prop.
+    const { container } = render(<ObjectGantt schema={schema()} />);
+    expect(await modeOf(container, 'gantt-view')).toBe('ABSENT');
+  });
+});
+
+describe('ObjectGantt viewMode wiring — resource-workload branch (objectui#5074)', () => {
+  it('still honours an authored viewMode', async () => {
+    const s = schema({ viewMode: 'week', resourceView: true, assigneeField: 'owner' });
+    const { container } = render(<ObjectGantt schema={s} />);
+    expect(await modeOf(container, 'resource-workload')).toBe('week');
+  });
+
+  it("keeps the explicit 'day' fallback when omitted (unchanged behaviour)", async () => {
+    const s = schema({ resourceView: true, assigneeField: 'owner' });
+    const { container } = render(<ObjectGantt schema={s} />);
+    expect(await modeOf(container, 'resource-workload')).toBe('day');
+  });
+});

--- a/packages/types/src/__tests__/gantt-view-mode-declared.test.ts
+++ b/packages/types/src/__tests__/gantt-view-mode-declared.test.ts
@@ -1,0 +1,106 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Declaration pin — `ObjectGanttSchema` declares `viewMode`, DERIVED from the
+ * spec's `GanttConfigSchema.viewMode` (objectui#5074; spec half landed
+ * upstream first, contract-first sequencing).
+ *
+ * Three properties are load-bearing, each pinned below:
+ *
+ * 1. **Derivation, not a fork.** The zod member's inner enum is the spec's own
+ *    schema object BY REFERENCE — reference identity is the only check that
+ *    distinguishes a derivation from a faithful copy (a copy passes every
+ *    value comparison until the next spec release, then drifts silently).
+ *    The TS half is pinned by mutual assignability with the spec type, which
+ *    is real enforcement because `tsconfig.test.json` compiles this file
+ *    (#3009).
+ *
+ * 2. **Declared keys are validated even under `.passthrough()`** — before this
+ *    declaration, `viewMode: 'hour'` parsed green (undeclared key, waved
+ *    through); now the member's enum refuses it. That is the accept-set
+ *    NARROWING this card knowingly lands for off-enum values, mirroring the
+ *    published spec vocabulary.
+ *
+ * 3. **No default.** An omitted `viewMode` must stay ABSENT after parse: the
+ *    renderer lets a persisted layout (persistLayoutKey) seed the granularity
+ *    before its 'day' fallback, and a `.default('day')` here would arrive
+ *    downstream as an explicit author choice and defeat that seeding
+ *    (`ObjectGantt.viewmode.test.tsx` pins the wiring half of the same
+ *    semantics).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { GanttConfigSchema as SpecGanttConfigSchema } from '@objectstack/spec/ui';
+import { ObjectGanttSchema } from '../zod/objectql.zod.js';
+import type { ObjectGanttSchema as ObjectGanttSchemaTS, GanttConfig } from '../objectql.js';
+
+const MINIMAL = {
+  type: 'object-gantt',
+  objectName: 'task',
+  startDateField: 'start',
+  endDateField: 'end',
+} as const;
+
+/** Unwrap ZodOptional/description wrappers down to the inner enum schema. */
+function unwrap(schema: any): any {
+  let cur = schema;
+  while (cur?._def?.innerType) cur = cur._def.innerType;
+  return cur;
+}
+
+describe('ObjectGanttSchema.viewMode — derived from the spec, by reference', () => {
+  it('declares the key', () => {
+    expect(Object.keys(ObjectGanttSchema.shape)).toContain('viewMode');
+  });
+
+  it('its inner enum IS the spec enum object (reference identity, not a copy)', () => {
+    const local = unwrap(ObjectGanttSchema.shape.viewMode);
+    const spec = unwrap(SpecGanttConfigSchema.shape.viewMode);
+    expect(local).toBe(spec);
+  });
+
+  it('accepts every member the spec publishes', () => {
+    const members: string[] = unwrap(SpecGanttConfigSchema.shape.viewMode).options;
+    expect(members.length).toBeGreaterThan(0);
+    for (const m of members) {
+      const result = ObjectGanttSchema.safeParse({ ...MINIMAL, viewMode: m });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('refuses an off-enum value on the viewMode path (declared-key validation under passthrough)', () => {
+    const result = ObjectGanttSchema.safeParse({ ...MINIMAL, viewMode: 'hour' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => i.path.join('.') === 'viewMode');
+    expect(issue).toBeTruthy();
+    expect(issue!.code).toBe('invalid_value');
+  });
+
+  it('materialises NO default — an omitted viewMode stays absent after parse', () => {
+    const result = ObjectGanttSchema.safeParse(MINIMAL);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect('viewMode' in result.data).toBe(false);
+  });
+});
+
+describe('ObjectGanttSchema (TS) viewMode — mirrors the spec type exactly', () => {
+  it('is mutually assignable with the spec member (compile-time pin)', () => {
+    // Accepts everything the spec type allows…
+    const widen = (v: GanttConfig['viewMode']): ObjectGanttSchemaTS['viewMode'] => v;
+    // …and nothing more (assignable back).
+    const narrow = (v: ObjectGanttSchemaTS['viewMode']): GanttConfig['viewMode'] => v;
+    expect(widen('quarter')).toBe('quarter');
+    expect(narrow(undefined)).toBeUndefined();
+    // @ts-expect-error — a non-member must be refused at compile time.
+    const _rejected: ObjectGanttSchemaTS['viewMode'] = 'hour';
+    expect(_rejected).toBe('hour');
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1962,6 +1962,18 @@ export interface ObjectGanttSchema extends BaseSchema {
   dependencyField?: string;
   /** Field for progress (0-100) */
   progressField?: string;
+  /**
+   * Initial timeline granularity, honoured by BOTH renderer branches (the
+   * timeline and the resource-workload grid). DERIVED from the spec's
+   * `GanttConfigSchema.viewMode` member so the member list cannot drift
+   * (objectui#5074).
+   *
+   * Deliberately NO default: an omitted `viewMode` lets a persisted layout
+   * (保存布局, `persistLayoutKey`) seed the granularity before the renderer's
+   * `'day'` fallback. A default here would arrive downstream as an explicit
+   * author choice and defeat that seeding.
+   */
+  viewMode?: SpecGanttConfig['viewMode'];
 }
 
 /**

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -20,6 +20,7 @@ import { z } from 'zod';
 import {
   ListViewSchema as SpecListViewSchema,
   KanbanConfigSchema as SpecKanbanConfigSchema,
+  GanttConfigSchema as SpecGanttConfigSchema,
   CalendarConfigSchema as SpecCalendarConfigSchema,
   GalleryConfigSchema as SpecGalleryConfigSchema,
   TimelineConfigSchema as SpecTimelineConfigSchema,
@@ -604,6 +605,14 @@ export const ObjectGanttSchema = BaseSchema.extend({
   titleField: z.string().optional().describe('Title field'),
   dependencyField: z.string().optional().describe('Dependency field'),
   progressField: z.string().optional().describe('Progress field'),
+  // DERIVED from the spec's `GanttConfigSchema.shape.viewMode` (an optional
+  // enum, deliberately WITHOUT a default) so the member list cannot drift
+  // (objectui#5074). Absence semantics are load-bearing: an omitted `viewMode`
+  // lets a persisted layout seed the timeline granularity before the
+  // renderer's 'day' fallback — do NOT add `.default('day')` here.
+  viewMode: SpecGanttConfigSchema.shape.viewMode.describe(
+    'Initial timeline granularity, honoured by both renderer branches; when omitted, a persisted layout may seed it'
+  ),
 });
 
 /**


### PR DESCRIPTION
Fixes #5074

Executes the maintainer-confirmed ruling of 2026-08-19 (issue comment 5339681862): **declare `viewMode` and wire BOTH branches**. The triage seat's "remove" recommendation was rejected there and is not re-opened here.

## Precondition re-verified in `node_modules`

Counter-probed the installed `@objectstack/spec` (the repo's pinned release) before writing anything, same probe shape as the unlock scan:

| probe | result |
| --- | --- |
| `GanttConfigSchema.viewMode` (via `@objectstack/spec/ui`) | **present** — `z.enum(['day','week','month','quarter','year']).optional()`, no default |
| `resourceView` (known-present control) | present |
| `zzNotAKey` (known-absent control) | absent |

## What changed

- **`packages/types/src/objectql.ts`** — `ObjectGanttSchema` declares `viewMode?: SpecGanttConfig['viewMode']`, DERIVED from the spec type so the member list cannot drift. Doc comment pins the absence semantics (no default; persisted layout may seed granularity).
- **`packages/types/src/zod/objectql.zod.ts`** — the zod mirror declares `viewMode: SpecGanttConfigSchema.shape.viewMode.describe(...)` — the spec's own optional enum **by reference** (`.describe()` wraps; the inner enum object stays reference-identical, pinned by test).
- **`packages/plugin-gantt/src/ObjectGantt.tsx`** —
  - `getGanttConfig` picks `viewMode` into `GanttConfigEx` on the flattened path, so both the flattened `object-gantt` style and the spec `gantt` config block carry it;
  - the timeline branch now passes `viewMode={ganttConfig?.viewMode}` to `GanttView` — deliberately **without** `|| 'day'`, so an omitted key keeps letting the persisted layout (`persistLayoutKey`) seed the granularity before GanttView's own `'day'` fallback (a guard comment marks this as load-bearing);
  - the `ResourceWorkload` branch reads `ganttConfig?.viewMode || 'day'` — the `(schema as any).viewMode` cast is **retired** (zero remaining `as any).viewMode` reads in the repo); the now-unused `GanttViewMode` type import is dropped.
- **Accept-set note**: `viewMode` is now a DECLARED key, so an off-enum value (e.g. `'hour'`) fails the zod parse where it previously passed through `.passthrough()` unvalidated. Values on the published spec enum are unaffected. Repo sweep found **no** fixture, example, or app authoring `viewMode` on a gantt schema (only the unrelated `previewMode` and gantt demo i18n labels), so nothing in-repo is re-judged by the narrowing.
- **Changeset**: `.changeset/gantt-viewmode-declared-both-branches-5074.md` (`minor` for `@object-ui/types` + `@object-ui/plugin-gantt`; no bare version literals).

## Out of scope, untouched

The other nine undeclared `as any` reads (`readOnly`, `markers`, `holidays`, `skipWeekends`, `criticalPath`, `showBaselines`, `mobileReadOnly`, `navigation`, `persistLayout`) stay with the #5043 family track. #5057 and #5126 chain behind this card and remain open — nothing here closes them. The stale `GanttViewMode` JSDoc card (#5132) and `content/docs/plugins/plugin-gantt.mdx` are untouched.

## Tests

New suites:

- `packages/plugin-gantt/src/ObjectGantt.viewmode.test.tsx` — wiring pins (GanttView/ResourceWorkload mocked to thin shells, the file's established convention): timeline honours an authored `viewMode` in both authoring styles; timeline receives **exactly `undefined`** when omitted (the pin that stops someone "simplifying" `|| 'day'` back in); ResourceWorkload still honours the key and keeps its `'day'` fallback.
- `packages/types/src/__tests__/gantt-view-mode-declared.test.ts` — contract pins: key declared; inner enum reference-identical to the spec's (anti-fork); every spec member accepted; off-enum value refused with an `invalid_value` issue on the `viewMode` path; omitted key stays absent after parse (no default materialised); TS member mutually assignable with the spec type + `@ts-expect-error` non-member pin (compiled by `tsconfig.test.json`, so it is real enforcement).

**Reverse verification on a real commit** (`git checkout HEAD~1 -- <3 source files>`, tests kept; then restored, `git diff HEAD --stat` empty, re-run green 11/11):

- **Red on reverted source (5 discriminating legs)**: both "honours an authored viewMode" wiring legs (flattened + gantt block); "declares the key"; "reference identity"; "refuses an off-enum value".
- **Legs that do NOT discriminate** (pass either way, stated per protocol): "passes NO viewMode when omitted" (prop was absent pre-fix too — it discriminates the future `|| 'day'` regression, not the pre-fix state); both ResourceWorkload legs (that branch already honoured the key); "accepts every member" (passthrough accepted the undeclared key pre-fix); "no default materialised" (absent either way at runtime — its compile-time half red-shifts only under `tsc -p tsconfig.test.json` against the reverted interface); the TS mutual-assignability leg (runtime-erased).

**Verification union at `c4a12f52e`** (the PR head), all through the container's shared verify lock, verdict lines read from the gate's own output:

- `pnpm exec vitest run packages/plugin-gantt/ packages/types/` (repo root, per AGENTS.md) — **Test Files 92 passed (92), Tests 912 passed (912)**
- `pnpm --filter @object-ui/types type-check` and `pnpm --filter @object-ui/plugin-gantt type-check` (dependency closure built first) — both clean, script names echoed
- `pnpm lint` (`turbo run lint`, full farm — not narrowed) — **47/47 tasks successful**
- `node scripts/check-changeset-presence.mjs` ✅ · `check-changeset-no-major.mjs` ✅ · `check-control-bytes.mjs` ✅ · `check-spec-symbol-derivation.mjs` ✅

CI is expected to run the same farm; per dispatch protocol this PR is reported at draft time without waiting for CI convergence.

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_