### PR TITLE
feat(plugin-dashboard): publish the honoured dashboard inputs, pin the two ruled-out keys (#5742)

### DIFF
--- a/.changeset/dashboard-declare-honoured-inputs.md
+++ b/.changeset/dashboard-declare-honoured-inputs.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/plugin-dashboard': minor
+---
+
+`dashboard` now publishes the authoring inputs its renderer already honours — `widgets`, `label`, `description`, `header`, `globalFilters`, `dateRange`, `refreshInterval` — so `validateTree`, the generated `sdui.manifest.json` and `sdui-intrinsics.d.ts` stop warning authors off keys that work (previously only `columns`/`gap`/`className` were published, and every other honoured key drew `unknown-prop`). Each declared key is accepted by the spec's strict `DashboardSchema`, so the manifest never offers a key the save gate refuses. The legacy `title` spelling and the retired `aria` key stay deliberately unpublished and are pinned as such; the `schema.title || schema.label` fallback read is unchanged, so documents in the wild keep rendering their header title.

--- a/content/docs/plugins/plugin-dashboard.mdx
+++ b/content/docs/plugins/plugin-dashboard.mdx
@@ -38,11 +38,31 @@ npm install @object-ui/plugin-dashboard
 {
   type: 'dashboard',
   widgets: Widget[],
-  columns?: number,               // Grid columns (default: 3)
-  gap?: number,                   // Gap between widgets
+  label?: string | LocaleMap,       // Header title — spec-canonical spelling; a string or { en, "zh-CN", ... }
+  description?: string | LocaleMap, // Header description, under the title
+  header?: {                        // Header block — strict: exactly these keys
+    showTitle?: boolean,
+    showDescription?: boolean,
+    actions?: { label, actionUrl?, actionType?, icon? }[]
+  },
+  globalFilters?: GlobalFilter[],   // Dashboard-level filter bar — see "Dashboard-level filters"
+  dateRange?: {                     // Built-in date-range filter — see "Dashboard-level filters"
+    field?: string,
+    defaultRange?: string,          // a spec date preset, or 'custom'
+    allowCustomRange?: boolean
+  },
+  refreshInterval?: number,         // Auto-refresh period in seconds; runs only when the host wires onRefresh
+  columns?: number,                 // Grid columns (default: 3)
+  gap?: number,                     // Gap between widgets
   className?: string
 }
 ```
+
+The header renders only when `header` is declared, and costs zero pixels when
+everything it would show is suppressed. The legacy `title` spelling of `label`
+is still *read* (documents in the wild carry it) but is not authoring surface —
+the spec rejects it by name, so new documents author `label`. The retired
+`aria` key is neither read nor authorable.
 
 ### Metric Card
 

--- a/packages/plugin-dashboard/package.json
+++ b/packages/plugin-dashboard/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@object-ui/plugin-charts": "workspace:*",
+    "@object-ui/sdui-parser": "workspace:*",
     "@objectstack/spec": "^17.0.0",
     "@types/react-grid-layout": "^2.1.0",
     "@vitejs/plugin-react": "^6.0.5",

--- a/packages/plugin-dashboard/src/__tests__/dashboardAuthoredInputs.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/dashboardAuthoredInputs.test.tsx
@@ -40,18 +40,36 @@
  *     body's listing of `aria` among the honoured reads was wrong on that one
  *     key. The pin is that it stays unpublished and spec-refused.
  *
- * ## The open question this file deliberately does NOT answer
+ * ## The third exclusion: `name` — ruled non-author, on weaker evidence
  *
- * `schema.name` is also read (it keys the `dashboards.{name}.*` translation
- * lookups) and the spec ACCEPTS `name` (requires it, on the document form).
- * But it is a document identity key, written by the stored-dashboard path
- * (`DashboardView` hands the loaded document to the renderer); no docs
- * example authors it inline and no sibling registration declares a `name`
- * input. Whether the INLINE node should publish it is raised as an open
- * question on objectui#5742 rather than guessed — its absence from `inputs`
- * is therefore *pending*, not ruled. If the ruling lands "declare", add it to
- * the registration and to `DECLARED` below; if "non-author", move it into the
- * exclusion pins with the producer evidence above.
+ * `schema.name` is read too (it keys the `dashboards.{name}.*` translation
+ * lookups), and it is NOT declared: objectui#5742 ruled it non-author for
+ * the INLINE node.
+ *
+ * Its reason is NOT `title`'s or `aria`'s, and that difference is the point.
+ * The spec ACCEPTS `name` — but on the DOCUMENT form, where it is REQUIRED,
+ * not on this inline node. So the per-key line above never fires here at
+ * all: its first clause ("the spec accepts it") is about a different shape.
+ * Do not read this exclusion as "the spec rejects `name`" — it does not, and
+ * a reader who sees `name` excluded beside `title` and assumes the same
+ * reason has it wrong.
+ *
+ * The `schema.name` read STAYS untouched, exactly as `title`'s does — the
+ * renderer still resolves `dashboards.{name}.*` through it.
+ *
+ * The evidence is the PRODUCER alone: `DashboardView` / the document loader
+ * hands the loaded document to the renderer, so an inline author is not the
+ * one who writes this key. That is a WEAKER pin than the two in `NON_AUTHOR`
+ * below, each of which asserts a spec verdict a reader can re-check — and it
+ * is why `name` carries no row there: there is no verdict for it to assert.
+ * Its absence from `inputs` is ruled, not merely unexamined; do not read that
+ * silence as the same strength of guarantee the other two carry.
+ *
+ * The supporting reason, had the above not already settled it: publishing
+ * `name` inline would teach authors — AI authors especially — to fabricate a
+ * dashboard identity that resolves NO translations and fails silently. That
+ * is a newly manufactured silently-inert key: the exact defect class this
+ * card removes.
  *
  * ## Why every positive has a control
  *

--- a/packages/plugin-dashboard/src/__tests__/dashboardAuthoredInputs.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/dashboardAuthoredInputs.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `dashboard` — the honoured keys are published, per key, and the two ruled
+ * out stay pinned out (objectui#5742).
+ *
+ * ## The card
+ *
+ * The `dashboard` registration published exactly three inputs (`columns`,
+ * `gap`, `className`) while `DashboardRenderer` honoured `widgets`, `label` /
+ * legacy `title`, `description`, `header`, `globalFilters`, `dateRange` and
+ * `refreshInterval`. `inputs` is not documentation: it is the published
+ * authoring surface (`gen-manifest.ts` serializes it into
+ * `sdui.manifest.json` — the save gate and parser whitelist — and into
+ * `sdui-intrinsics.d.ts`, and `dashboard` is in `PUBLIC_BLOCKS`). So
+ * `validateTree` warned authors off keys that work — `widgets` included, the
+ * very prop whose CONTENTS the objectui#5709 `unconsumed-widget-option`
+ * warning reasons about, two diagnostics reading incoherently side by side.
+ *
+ * ## The per-key line (the shipped #4668 / #5091 precedents)
+ *
+ * A key is DECLARED only when both hold: the renderer reads it AND
+ * `@objectstack/spec`'s strict `DashboardSchema` accepts it — so the manifest
+ * never offers a key the save gate refuses. That line puts seven keys in and
+ * keeps two honest exclusions out:
+ *
+ *   - `title` — the legacy objectui spelling of the spec-canonical `label`
+ *     (framework#1878). The spec REJECTS it by name, so declaring it would
+ *     publish a key an author could not save. The `schema.title ||
+ *     schema.label` read STAYS — documents in the wild carry it — which is
+ *     exactly the #5091 shape: non-author surface, still read.
+ *   - `aria` — the spec carries a TOMBSTONE for `dashboard.aria` (removed at
+ *     the #3896 audit close-out, "no dashboard renderer ever applied it").
+ *     Measured here too: this package has NO read site for `schema.aria`, so
+ *     unlike `title` there is no "renderer still reads it" leg — the issue
+ *     body's listing of `aria` among the honoured reads was wrong on that one
+ *     key. The pin is that it stays unpublished and spec-refused.
+ *
+ * ## The open question this file deliberately does NOT answer
+ *
+ * `schema.name` is also read (it keys the `dashboards.{name}.*` translation
+ * lookups) and the spec ACCEPTS `name` (requires it, on the document form).
+ * But it is a document identity key, written by the stored-dashboard path
+ * (`DashboardView` hands the loaded document to the renderer); no docs
+ * example authors it inline and no sibling registration declares a `name`
+ * input. Whether the INLINE node should publish it is raised as an open
+ * question on objectui#5742 rather than guessed — its absence from `inputs`
+ * is therefore *pending*, not ruled. If the ruling lands "declare", add it to
+ * the registration and to `DECLARED` below; if "non-author", move it into the
+ * exclusion pins with the producer evidence above.
+ *
+ * ## Why every positive has a control
+ *
+ * "No diagnostic" is also what a silenced check looks like: the undeclared
+ * probe key must still draw `unknown-prop`, the declared control must be
+ * published, and the spec must accept the full declared document — otherwise
+ * every absence/rejection assertion here would pass against a registry that
+ * published nothing or a schema that refuses everything (the same pairing
+ * `ga-honoured-inputs-author-reach.test.ts` and `gridNonAuthorKeys.test.tsx`
+ * use, for the same reason).
+ *
+ * Module-scope registration import, not a hook (AGENTS.md §测试纪律): the
+ * registration is the fixture, and its cold transform must not be billed to a
+ * bounded test/hook window.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { DashboardSchema } from '@objectstack/spec/ui';
+import { manifestFromConfigs, validateTree, generateDts, propsName } from '@object-ui/sdui-parser';
+import type { Diagnostic, SchemaElement } from '@object-ui/sdui-parser';
+import { ActionProvider } from '@object-ui/react';
+import { DashboardRenderer } from '../DashboardRenderer';
+// Module scope, not a hook: this import IS the registration.
+import '../index';
+
+/**
+ * The manifest exactly as `gen-manifest.ts` / `dump-public-manifest.mjs`
+ * build the published one — `getPublicConfigs()` through
+ * `manifestFromConfigs` — so the verdicts below are the ones a real author
+ * gets, not ones a hand-written fixture was shaped to produce. (Only this
+ * package's registrations are loaded here; `dashboard` is among them, which
+ * is all these assertions read.)
+ */
+const manifest = manifestFromConfigs(
+  ComponentRegistry.getPublicConfigs() as unknown as Parameters<typeof manifestFromConfigs>[0],
+);
+
+const diagnose = (node: Record<string, unknown>): Diagnostic[] =>
+  validateTree({ type: 'dashboard', ...node } as unknown as SchemaElement, manifest).diagnostics;
+
+/** Diagnostics naming a specific prop (the messages quote prop names). */
+const codesMentioning = (node: Record<string, unknown>, prop: string): string[] =>
+  diagnose(node)
+    .filter((d) => d.message.includes(`"${prop}"`))
+    .map((d) => d.code);
+
+/** The spec's verdict on a minimal legal document plus one patch. */
+const specVerdict = (patch: Record<string, unknown>) =>
+  DashboardSchema.safeParse({ name: 'sales_ops', label: 'Sales Ops', widgets: [], ...patch });
+
+/** Unrecognized KEYS from a failed parse — a key verdict, never a document one. */
+const unrecognizedKeys = (result: { success: boolean; error?: unknown }): string[] =>
+  ((result as { error?: { issues: Array<{ code: string; keys?: string[] }> } }).error?.issues ?? [])
+    .filter((issue) => issue.code === 'unrecognized_keys')
+    .flatMap((issue) => issue.keys ?? []);
+
+/**
+ * The newly published keys, each with a spec-legal sample value. The sample
+ * doubles as the spec-acceptance evidence: `full declared document` below
+ * parses all of them at once.
+ */
+const DECLARED: Array<[string, unknown]> = [
+  ['widgets', [{ id: 'w1', type: 'bar', dataset: 'invoices', values: ['count'] }]],
+  ['label', 'Sales Overview'],
+  ['label', { en: 'Sales Overview', 'zh-CN': '销售总览' }],
+  ['description', 'The numbers behind the pipeline'],
+  ['description', { en: 'The numbers behind the pipeline' }],
+  ['header', { showTitle: false, actions: [{ label: 'Open', actionUrl: '/x' }] }],
+  ['globalFilters', [{ field: 'region', label: 'Region', type: 'select' }]],
+  ['dateRange', { field: 'created_at', defaultRange: 'last_30_days' }],
+  ['refreshInterval', 30],
+];
+
+/** Values matching NO declared arm — each must still be reported. */
+const OFF_ARM: Array<[string, unknown]> = [
+  ['widgets', {}],
+  ['label', 42],
+  ['description', 42],
+  ['header', true],
+  ['globalFilters', 'region'],
+  ['dateRange', []],
+  ['refreshInterval', '30'],
+];
+
+/** The two keys ruled OUT, with the evidence a reader can re-check. */
+const NON_AUTHOR = [
+  {
+    key: 'title',
+    sample: 'Legacy Ops',
+    why:
+      'legacy spelling of the spec-canonical `label` (framework#1878) — `DashboardSchema` '
+      + 'rejects it by name, so publishing it would offer a key the save gate refuses',
+  },
+  {
+    key: 'aria',
+    sample: { ariaLabel: 'Ops' },
+    why:
+      'spec tombstone (#3896 audit close-out): no dashboard renderer ever applied it, and '
+      + 'this package has no `schema.aria` read site',
+  },
+] as const;
+
+afterEach(cleanup);
+
+describe('the manifest resolves `dashboard`, and the check is live (objectui#5742)', () => {
+  it('resolves the block (reachability before any absence claim)', () => {
+    expect(manifest.components['dashboard']).toBeTruthy();
+    expect(diagnose({}).map((d) => d.code)).not.toContain('unknown-component');
+  });
+
+  it('an undeclared key still draws unknown-prop — the control', () => {
+    expect(codesMentioning({ objectui5742NotAProp: 'x' }, 'objectui5742NotAProp')).toContain(
+      'unknown-prop',
+    );
+  });
+});
+
+describe('the honoured keys now validate clean on an inline dashboard node (objectui#5742)', () => {
+  it.each(DECLARED)('%s draws no diagnostic', (key, value) => {
+    expect(codesMentioning({ [key]: value }, key), `dashboard.${key}`).toEqual([]);
+  });
+
+  it.each(OFF_ARM)('%s still rejects an off-arm value — declaring is not disarming', (key, value) => {
+    expect(codesMentioning({ [key]: value }, key)).toContain('type-mismatch');
+  });
+
+  it('the spec accepts the full declared document — the declarations rest on its verdicts', () => {
+    const result = specVerdict({
+      description: 'x',
+      header: { showTitle: true },
+      columns: 4,
+      gap: 6,
+      refreshInterval: 30,
+      dateRange: { field: 'created_at', defaultRange: 'last_30_days' },
+      globalFilters: [{ field: 'region', label: 'Region', type: 'select' }],
+    });
+    expect(result.success, JSON.stringify((result as { error?: unknown }).error ?? {})).toBe(true);
+  });
+
+  it('both arms of the two union keys are spec-derived, not guessed', () => {
+    // `label` / `description` are `string | inline locale map` on the spec —
+    // the declared `['string', 'object']` arms restate exactly that, and a
+    // kind matching neither arm is refused by BOTH authorities.
+    for (const key of ['label', 'description']) {
+      expect(specVerdict({ [key]: 'plain' }).success).toBe(true);
+      expect(specVerdict({ [key]: { en: 'plain', 'zh-CN': '文' } }).success).toBe(true);
+      expect(specVerdict({ [key]: 42 }).success).toBe(false);
+    }
+  });
+});
+
+describe('the two ruled-out keys stay unpublished — and checkably so (objectui#5742)', () => {
+  const inputNames = (namespace?: string): string[] =>
+    ((ComponentRegistry.getConfig('dashboard', namespace) as { inputs?: Array<{ name: string }> })
+      ?.inputs ?? []).map((i) => i.name);
+
+  it.each([undefined, 'view'] as const)(
+    'the registration publishes neither, looked up %s',
+    (namespace) => {
+      const declared = inputNames(namespace);
+      for (const { key, why } of NON_AUTHOR) {
+        expect(declared, `\`dashboard\` now publishes \`${key}\` — but ${why}.`).not.toContain(key);
+      }
+      // The declared controls: absence above means something only while the
+      // same registration really publishes the ruled-in surface.
+      expect(declared).toContain('label');
+      expect(declared).toContain('widgets');
+    },
+  );
+
+  it('the spec rejects `title` by name — the exclusion is checkable', () => {
+    const result = specVerdict({ title: 'Legacy Ops' });
+    expect(result.success, 'the spec now ACCEPTS dashboard.title — re-open objectui#5742').toBe(false);
+    expect(unrecognizedKeys(result)).toContain('title');
+  });
+
+  it('the spec refuses every `aria` value — the tombstone is still standing', () => {
+    const result = specVerdict({ aria: { ariaLabel: 'Ops' } });
+    expect(result.success, 'the spec re-admitted dashboard.aria — re-open objectui#5742').toBe(false);
+    const ariaIssue = (result as { error: { issues: Array<{ path: unknown[]; message: string }> } })
+      .error.issues.find((i) => i.path.join('.') === 'aria');
+    expect(ariaIssue, 'no issue at path `aria`').toBeTruthy();
+    // The tombstone names the removal; a mere shape error would not.
+    expect(ariaIssue!.message).toMatch(/removed/);
+  });
+
+  it.each(NON_AUTHOR)('$key draws unknown-prop from the real validator — the ruled outcome', ({ key, sample }) => {
+    expect(
+      codesMentioning({ [key]: sample }, key),
+      `\`${key}\` no longer draws \`unknown-prop\`. If that is deliberate it means the key was`
+        + ' declared — which the objectui#5742 triage forbids for this key.',
+    ).toContain('unknown-prop');
+  });
+});
+
+describe('the legacy `title` read stays — non-author surface, still honoured (objectui#5742)', () => {
+  const renderDashboard = (schema: Record<string, unknown>) =>
+    render(
+      <ActionProvider>
+        <DashboardRenderer schema={{ type: 'dashboard', widgets: [], header: {}, ...schema } as never} />
+      </ActionProvider>,
+    );
+
+  it('a wild document carrying only the legacy spelling keeps its header title', () => {
+    renderDashboard({ title: 'Legacy Ops' });
+    expect(screen.getByRole('heading', { name: 'Legacy Ops' })).toBeInTheDocument();
+  });
+
+  it('the canonical spelling renders too — the read above is the fallback, not the contract', () => {
+    renderDashboard({ label: 'Canonical Ops' });
+    expect(screen.getByRole('heading', { name: 'Canonical Ops' })).toBeInTheDocument();
+  });
+});
+
+describe('the published artifacts carry the change — same generators as gen-manifest (objectui#5742)', () => {
+  it('the manifest entry publishes exactly the triaged input list', () => {
+    // Exact list, not `toContain`: the failure mode both ways is silent — a
+    // shrink un-publishes a key authors rely on, a growth publishes one the
+    // triage ruled out.
+    expect(manifest.components['dashboard'].inputs.map((i) => i.name)).toEqual([
+      'widgets',
+      'label',
+      'description',
+      'header',
+      'globalFilters',
+      'dateRange',
+      'refreshInterval',
+      'columns',
+      'gap',
+      'className',
+    ]);
+  });
+
+  it('the generated JSX intrinsics type the new keys, unions included', () => {
+    const dts = generateDts(manifest);
+    const match = dts.match(
+      new RegExp(`export interface ${propsName('dashboard')} extends SduiBaseProps \\{[^}]*\\}`),
+    );
+    expect(match, `no ${propsName('dashboard')} interface in the generated d.ts`).toBeTruthy();
+    const block = match![0];
+    expect(block).toContain('widgets?: unknown[];');
+    expect(block).toContain('label?: string | Record<string, unknown>;');
+    expect(block).toContain('description?: string | Record<string, unknown>;');
+    expect(block).toContain('header?: Record<string, unknown>;');
+    expect(block).toContain('globalFilters?: unknown[];');
+    expect(block).toContain('dateRange?: Record<string, unknown>;');
+    expect(block).toContain('refreshInterval?: number;');
+    // The exclusions stay out of the type surface an author compiles against.
+    expect(block).not.toMatch(/\btitle\b/);
+    expect(block).not.toMatch(/\baria\b/);
+  });
+});

--- a/packages/plugin-dashboard/src/index.tsx
+++ b/packages/plugin-dashboard/src/index.tsx
@@ -40,6 +40,26 @@ export type {
 } from './dataset-catalog';
 
 // Register dashboard component
+//
+// objectui#5742 — `inputs` is the published authoring surface (serialized into
+// `sdui.manifest.json` and `sdui-intrinsics.d.ts`; `dashboard` is in
+// `PUBLIC_BLOCKS`), and it used to publish only `columns`/`gap`/`className`
+// while `DashboardRenderer` honoured far more, so `validateTree` warned
+// authors off keys that work — `widgets` included, the very key the
+// objectui#5709 unconsumed-options warning descends into. The keys below are
+// the per-key triage (#4668 / #5091 class), each declared because BOTH hold:
+// the renderer reads it AND `@objectstack/spec`'s strict `DashboardSchema`
+// accepts it, so the manifest never offers a key the save gate refuses.
+//
+// Deliberately NOT declared, pinned in
+// `__tests__/dashboardAuthoredInputs.test.tsx`:
+//   - `title`  — legacy spelling of `label`; the spec rejects it by name.
+//     The `schema.title || schema.label` read STAYS (documents in the wild).
+//   - `aria`   — spec tombstone (#3896 audit close-out): no dashboard
+//     renderer ever applied it, and this package has no read site either.
+// `name` (document identity; keys the `dashboards.{name}.*` translation
+// lookups) is neither declared nor pinned — raised as the open question on
+// objectui#5742 rather than guessed; see the pin test's docblock.
 ComponentRegistry.register(
   'dashboard',
   DashboardRenderer,
@@ -49,6 +69,13 @@ ComponentRegistry.register(
     category: 'Complex',
     icon: 'layout-dashboard',
     inputs: [
+      { name: 'widgets', type: 'array', label: 'Widgets', description: 'The widget tree — the spec’s DashboardWidget[]. Each widget binds a dataset (ADR-0021) and may carry a layout ({ x, y, w, h }) and filterBindings. When omitted the dashboard renders an empty grid.' },
+      { name: 'label', type: ['string', 'object'], label: 'Label', description: 'Display name, shown as the header title when `header` is declared — a string or an inline per-locale map such as { en, "zh-CN" }. Spec-canonical spelling; the legacy `title` spelling is not authoring surface.' },
+      { name: 'description', type: ['string', 'object'], label: 'Description', description: 'Header description shown under the title — a string or an inline per-locale map. Rendered only when `header` is declared and `header.showDescription` is not false.' },
+      { name: 'header', type: 'object', label: 'Header', description: 'Header block: { showTitle?, showDescription?, actions? }. Strict — the contract rejects any other key. Renders nothing (zero pixels) when everything it would show is suppressed.' },
+      { name: 'globalFilters', type: 'array', label: 'Global Filters', description: 'Dashboard-level filter bar — the spec’s GlobalFilter[]. Filter values live as dashboard variables (readable in widget expressions as page.<name>) and are AND-merged into each bound widget’s query per its filterBindings.' },
+      { name: 'dateRange', type: 'object', label: 'Date Range', description: 'Built-in date-range filter: { field?, defaultRange?, allowCustomRange? }. `defaultRange` takes the spec’s date presets plus "custom"; the bound field defaults to created_at.' },
+      { name: 'refreshInterval', type: 'number', label: 'Refresh Interval', description: 'Auto-refresh period in seconds. Zero or a negative value disables the timer, and it only runs when the host wires an onRefresh handler.' },
       { name: 'columns', type: 'number', label: 'Columns', defaultValue: 3 },
       { name: 'gap', type: 'number', label: 'Gap', defaultValue: 4 },
       { name: 'className', type: 'string', label: 'CSS Class' }

--- a/packages/plugin-dashboard/src/index.tsx
+++ b/packages/plugin-dashboard/src/index.tsx
@@ -57,9 +57,25 @@ export type {
 //     The `schema.title || schema.label` read STAYS (documents in the wild).
 //   - `aria`   — spec tombstone (#3896 audit close-out): no dashboard
 //     renderer ever applied it, and this package has no read site either.
-// `name` (document identity; keys the `dashboards.{name}.*` translation
-// lookups) is neither declared nor pinned — raised as the open question on
-// objectui#5742 rather than guessed; see the pin test's docblock.
+//
+// `name` is honoured too (the `schema.name` read keys the
+// `dashboards.{name}.*` translation lookups) and is likewise NOT declared —
+// objectui#5742 ruled it non-author for the INLINE node. Its reason is NOT
+// the one above, and the difference is load-bearing: the spec ACCEPTS
+// `name` — but on the DOCUMENT form, where it is required, not on this
+// inline node. So the "spec accepts + renderer reads" line never fires here
+// at all; its premise is about a different shape. Do not carry `title`'s
+// "the spec rejects it" over to this key — the spec does not reject `name`.
+// The `schema.name` read STAYS untouched.
+// The evidence is the PRODUCER alone — `DashboardView` / the document loader
+// hands the loaded document to the renderer, so an inline author is not the
+// one who writes this key. That makes it a WEAKER exclusion than `title` /
+// `aria`, each of which asserts a spec verdict a reader can re-check, and is
+// why `name` carries no row in the pin test's table: there is no verdict for
+// it to assert. Supporting reason: publishing `name` inline would teach
+// authors — AI authors especially — to fabricate a dashboard identity that
+// resolves NO translations and fails silently, minting a fresh
+// silently-inert key, the exact defect class this card removes.
 ComponentRegistry.register(
   'dashboard',
   DashboardRenderer,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1763,6 +1763,9 @@ importers:
       '@object-ui/plugin-charts':
         specifier: workspace:*
         version: link:../plugin-charts
+      '@object-ui/sdui-parser':
+        specifier: workspace:*
+        version: link:../sdui-parser
       '@objectstack/spec':
         specifier: ^17.0.0
         version: 17.2.0(ai@7.0.65(zod@4.4.3))


### PR DESCRIPTION
Fixes #5742

## What

The `dashboard` registration (`packages/plugin-dashboard/src/index.tsx`) published exactly three inputs — `columns`, `gap`, `className` — while `DashboardRenderer` honoured far more, so `validateTree` over the live manifest reported `unknown-prop` on keys that work, `widgets` included: the very prop whose contents the #5709 `unconsumed-widget-option` warning descends into. `dashboard` is in `PUBLIC_BLOCKS`, so `inputs` is contract surface, serialized into `sdui.manifest.json` and `sdui-intrinsics.d.ts`. `public-blocks.ts` is untouched (reference surface, not the fix site).

Not "declare all of them": per #5091's precedent this is a per-key triage, with the deliberate exclusions pinned so they read differently from an oversight.

## Per-key triage — a reviewer can strike any one row without unpicking the rest

The line applied is the one both shipped precedents (#4668, #5091) drew: **declare a key only when the renderer reads it AND the spec's strict `DashboardSchema` accepts it** (so the manifest never offers a key the save gate refuses); a spec-rejected honoured key becomes a pinned non-author exclusion.

| key | renderer read (measured) | spec verdict (measured) | disposition |
| --- | --- | --- | --- |
| `widgets` | pervasive (`schema.widgets ?? []`, layout/reorder/mobile split); `defaultProps` already carried `widgets: []` | accepted (required on the document form) | **declared**, `array`. Not `required` on the inline node: the renderer has a live default and every widget-less node today is legal — making it a hard error is a strictness increase beyond this card |
| `label` | `schema.title \|\| schema.label` header title (spec-canonical spelling, framework#1878) | accepted, `string \| inline locale map` | **declared**, `['string','object']` |
| `description` | header description (+ `DashboardView` chrome) | accepted, `string \| inline locale map` | **declared**, `['string','object']` |
| `header` | `showTitle` / `showDescription` / `actions[]` | accepted, strict `{ showTitle?, showDescription?, actions? }` | **declared**, `object` |
| `globalFilters` | filter bar → dashboard variables (objectui#4032) | accepted, strict `GlobalFilter[]` | **declared**, `array` |
| `dateRange` | date-range filter config | accepted, strict `{ field?, defaultRange?, allowCustomRange? }` | **declared**, `object` |
| `refreshInterval` | auto-refresh timer (`<= 0` disables; needs host `onRefresh`) | accepted, plain `number` (0 / negative / fractional all parse — renderer semantics stated in the input description per the 2026-08-17 "spec is the sole judge of values" ruling) | **declared**, `number` |
| `title` | read as the legacy fallback — the read **stays** | **rejected by name** (`unrecognized_keys: title`) | **non-author, pinned** — declaring it would publish a key the save gate refuses; documents in the wild keep rendering |
| `aria` | **no read site** — measured: zero `schema.aria` reads in this package (the issue body listed it among the honoured reads; that one claim is false) | **tombstoned**: spec refuses every value with a removal message (#3896 audit close-out — "no dashboard renderer ever applied it") | **non-author, pinned** (unpublished + spec-refused). No "renderer still reads it" leg, deliberately — there is no read |
| `name` | read — keys the `dashboards.{name}.*` translation lookups | accepted **on the document form**, where it is required — *not* on the inline node | **non-author, RULED** (PM, 2026-08-23) — pinned on producer evidence; see below |

### `name` — RULED non-author (PM, 2026-08-23; issue #5742 comment 5386380368)

This was opened as a question and has since been decided. **`name` is not an author input on the inline `dashboard` node.**

⚠️ **The exclusion reason is NOT the same as `title`'s, and the difference is load-bearing.** `title` and `aria` are excluded because the spec **rejects** them by name. `name` is excluded because the shipped *"spec accepts + renderer reads → declare"* line **never fires here**: the spec accepts (indeed requires) `name` on the **document** form, not on the inline node, so the heuristic's premise is about a different shape. A reader who sees `name` excluded next to `title` and assumes "spec rejects it" would be wrong.

Two consequences carried into the code comments:

- The `schema.name` **read stays untouched** — it still keys the `dashboards.{name}.*` lookups.
- The pin rests on **producer evidence alone** (`DashboardView` / the document loader hands the loaded document to the renderer), which makes it a **weaker pin** than the `title` / `aria` ones, each of which can assert a re-checkable spec verdict. That weakness is stated in the docblock rather than papered over, and ⛔ no spec rejection is asserted for `name` anywhere.

Supporting reason: publishing `name` inline would teach authors — AI authors especially — to fabricate a dashboard identity that resolves **no** translations and fails silently. That is a newly manufactured silently-inert key: the exact defect class this PR exists to remove.

## Tests

`packages/plugin-dashboard/src/__tests__/dashboardAuthoredInputs.test.tsx` (30 tests), all three faces with silenced-check controls:

- **Author reach** (the #4668 shape): every declared key now draws **no** diagnostic on an inline `dashboard` node, judged by the same `manifestFromConfigs` + `validateTree` pair the save gate and JSX-page compiler use; an undeclared probe key still draws `unknown-prop` (the check is live); off-arm values still draw `type-mismatch` (declaring is not disarming); both union arms are derived from the spec's own verdicts.
- **Exclusion pins** (the `gridNonAuthorKeys` shape): `title` / `aria` not published (with `label` / `widgets` as declared controls), spec rejects `title` by name and refuses every `aria` value through the standing tombstone, both draw `unknown-prop` from the real validator, and the legacy `title` read still renders its header title (canonical `label` as the control).
- **Generated artifacts**: the manifest entry publishes exactly the triaged input list, and `generateDts` (the same generator `gen-manifest.ts` runs) types the new keys — unions included — with `title` / `aria` absent from the emitted `DashboardProps` block. `sdui.manifest.json` / `sdui-intrinsics.d.ts` are build-time codegen (not checked in), so the change to them is pinned through their own generators rather than hand-shown.

## Verification (all from repo root)

> Head is now `77295c734`. The readings below were taken at `6a1e9040e`; the only commit since is the comment-only amendment recording the `name` ruling above (every changed line is a comment line, mechanically verified), and the pin suite was re-run green on the new head — 30/30 on the pin file, 712/712 across `packages/plugin-dashboard/`.

- `pnpm exec vitest run packages/plugin-dashboard/ apps/console/src/__tests__/registry-inputs-spec-parity.test.ts apps/console/src/__tests__/public-contract.test.ts apps/console/src/__tests__/ga-honoured-inputs-author-reach.test.ts apps/console/src/__tests__/component-input-union-specimens.test.ts apps/console/src/__tests__/public-block-binding-reach.test.tsx` → **81 files / 836 tests passed** (run at `6a1e9040e`, the branch head).
- `pnpm --filter @object-ui/plugin-dashboard type-check` and `lint` → clean (0 errors; pre-existing warnings only), after building the dependency closure.
- `node scripts/check-changeset-presence.mjs`, `check-phantom-dependencies.mjs` (new `@object-ui/sdui-parser` devDep), `check-control-bytes.mjs`, `check-doc-component-types.mjs`, `check-doc-snippet-types.mjs` (on a built tree: "Every covered documentation snippet compiles against the built types"), `check-changeset-fixed.mjs`, `check-changeset-no-major.mjs` → all exit 0, verdict lines verified.
- **Reverse verification, against the commit**: `git checkout HEAD~1 -- packages/plugin-dashboard/src/index.tsx` → **20 of 30 tests red** (all 9 author-reach rows via restored `unknown-prop`, all 7 off-arm rows, the 2 not-published control legs, both artifact legs); restore → `git diff HEAD --stat` empty → **30/30 green**. Legs that do **not** discriminate the registration change, by design: reachability + probe-key control, the five spec-verdict legs (they pin the spec, not the registry), `unknown-prop` on `title`/`aria` (true before and after), and the two render legs (the reads were never touched).

## Scope notes

- Docs: the `### Dashboard` Schema API block in `content/docs/plugins/plugin-dashboard.mdx` now lists the published keys (plaintext block; no ts/tsx snippet added).
- Changeset: `minor` for `@object-ui/plugin-dashboard`.
- `@object-ui/types`' `DashboardComponentSchema` drift (declares `aria` the spec tombstoned; lacks `label`/`description`) is out of scope here and recorded separately.
- #5709 is not addressed here; #4668 and #5091 remain closed precedents, cited only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_

---
_Generated by [Claude Code](https://claude.ai/code)_