### PR TITLE
fix(chatbot): peel the text wrapper before falling back to it in parseResultEnvelope (#5695)

### DIFF
--- a/packages/plugin-chatbot/src/__tests__/mapMessages.replayOutcome.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.replayOutcome.test.ts
@@ -138,3 +138,24 @@ describe('replay dispatch errors + authoring verdicts (objectui#5695 follow-up, 
     expect(detectAuthoringVerdict('plain')).toBeUndefined();
   });
 });
+
+describe('the persisted text-wrapper shape (rehydration path)', () => {
+  it('a dispatch error inside the Vercel {type:"text",value} wrapper is still detected', () => {
+    expect(
+      detectReplayOutcome('replay_t1_0', {
+        type: 'text',
+        value: JSON.stringify({ error: 'apply_edit op #1 (add_field): object "task" not found.' }),
+      }),
+    ).toEqual({
+      kind: 'failed',
+      dispatchError: true,
+      error: 'apply_edit op #1 (add_field): object "task" not found.',
+    });
+  });
+
+  it('an authoring verdict inside the wrapper is still classified', () => {
+    expect(
+      detectAuthoringVerdict({ type: 'text', value: JSON.stringify({ status: 'published' }) }),
+    ).toEqual({ kind: 'published' });
+  });
+});

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -99,15 +99,22 @@ export function parseResultEnvelope(result: unknown): Record<string, unknown> | 
   }
   // Prefer a candidate that carries the framework's `status` discriminator —
   // this peels the Vercel `{ type:'text', value:'…json…' }` wrapper, whose
-  // outer object has no `status`, to the inner envelope that does.
+  // outer object has no `status`, to the inner envelope that does. The
+  // wrapper itself is only ever a LAST-resort fallback: a status-less inner
+  // envelope (e.g. a bare `{error: …}` replay dispatch failure, #5695) must
+  // still win over the wrapper it rode in on, or the error is invisible to
+  // every detector on the rehydration path.
   let fallback: Record<string, unknown> | undefined;
+  let wrapperFallback: Record<string, unknown> | undefined;
   for (const candidate of candidates) {
     const obj = tryParse(candidate);
     if (!obj) continue;
     if (typeof obj.status === 'string') return obj;
-    fallback ??= obj;
+    const isTextWrapper = obj.type === 'text' && 'value' in obj;
+    if (isTextWrapper) wrapperFallback ??= obj;
+    else fallback ??= obj;
   }
-  return fallback;
+  return fallback ?? wrapperFallback;
 }
 
 function detectPendingApproval(


### PR DESCRIPTION
Completes #5815, whose second commit missed the merge-queue cut (the queue squashed the PR at 1 commit while the follow-up push was in flight — commits:1 on the merged PR).

Rehydration serves tool results as `{type:'text', value:'…json…'}`; with a status-less inner envelope (the bare `{error}` replay dispatch failure) the OUTER wrapper won the fallback slot in `parseResultEnvelope` and every detector went blind on reload — measured live: the fixed console still showed the legacy badge because `replayOutcome` never re-derived. The wrapper is now last-resort only; any parsed non-wrapper candidate outranks it. Live-verified end to end on the rig (stuck 应用中 card resolved to 已生效 after this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)