### PR TITLE
docs(core): name the out-of-runner producer of ConfirmationHandler's `options` (#5205)

### DIFF
--- a/.changeset/tidy-jars-confirm.md
+++ b/.changeset/tidy-jars-confirm.md
@@ -1,0 +1,7 @@
+---
+---
+
+Comment-only change in `@object-ui/core`: `ConfirmationHandler`'s declaration now
+names the out-of-runner producer of its `options` bag, so a runner-scoped liveness
+sweep no longer reads the parameter as declared-but-never-produced. No behaviour,
+no type surface and no published output changes.

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -458,6 +458,29 @@ export type ActionRunnerHandler = (
 /**
  * Confirmation handler — replaces window.confirm.
  * Consumers can provide an async implementation (e.g., Shadcn AlertDialog).
+ *
+ * `options` is LIVE, and its producer is not in this file — searching the
+ * runner alone will tell you otherwise. The only call site here passes one
+ * argument (the structured `confirm` arm that used to forward a bag was
+ * retired, objectui#4314), so a runner-scoped sweep reads this parameter as
+ * declared-but-never-produced and files it for removal. That has already
+ * happened once: objectui#5205, ruled KEEP on 2026-08-22.
+ *
+ * The producer bypasses the runner entirely. `handleDeleteView` in
+ * `packages/app-shell/src/views/ObjectView.tsx` — the admin "delete saved
+ * view" confirmation — invokes a `ConfirmationHandler` with all three fields
+ * populated and localized (`console.objectView.deleteViewTitle` / `.delete` /
+ * `.cancel`), and `app-shell`'s `ActionConfirmDialog.tsx` renders them in
+ * place of its generic `actionConfirm.*` fallbacks. Line numbers are left out
+ * on purpose: #5205's pointer had already drifted by the time it was executed.
+ *
+ * So re-measure across the repo, not this package: grep for two-argument
+ * calls of `ConfirmationHandler`-typed values (`confirmHandler(`, `onConfirm(`)
+ * in `app-shell` as well as here. Dropping `options` costs that dialog its
+ * title and both button labels, and narrows a published `.d.ts` against the
+ * natural `(message, options) => …` spelling — which TypeScript rejects
+ * against a one-parameter target unless the second parameter is written
+ * optional.
  */
 export type ConfirmationHandler = (message: string, options?: {
   title?: string;


### PR DESCRIPTION
Fixes #5205

Executes the maintainer ruling recorded on the card (2026-08-22): **Option A — keep `ConfirmationHandler`'s `options` parameter and add an explanatory comment.** Option B (remove it) is rejected and is not reopened here. Nothing narrows: the diff is one doc comment plus a no-release changeset.

## The card's title is false, and saying why is the deliverable

`options` is **live**. Its producer is simply not in `ActionRunner.ts`: `handleDeleteView` in `packages/app-shell/src/views/ObjectView.tsx` — the admin "delete saved view" confirmation — invokes a `ConfirmationHandler` with all three fields populated and localized, and `app-shell`'s `ActionConfirmDialog.tsx` renders them over its generic `actionConfirm.*` fallbacks. The runner's own call site passes one argument (the structured `confirm` arm that used to forward a bag was retired in #4314), so a **runner-scoped** sweep sees zero producers and files the parameter for removal — which is exactly how this card came to exist.

A comment saying "keep this, it's used" would not prevent the next sweep from re-deriving the same wrong answer. The comment therefore names the producing symbol, its file and what it does, names the three i18n keys, states what removal would cost, and says what re-measuring correctly looks like: grep the repo — not this package — for two-argument calls of `ConfirmationHandler`-typed values.

## Re-verified on current `main` before writing (@ `5da008463`)

| Claim | Status |
| --- | --- |
| Producer exists and is two-argument | ✅ `ObjectView.tsx` `handleDeleteView`, all three fields via `t()` |
| Reachable UI, not dead code | ✅ wired as `onDeleteView={isAdmin ? handleDeleteView : undefined}` and `onDelete={handleDeleteView}` |
| Typed as the published type | ✅ `confirmHandler` comes from `useConsoleActionRuntime`, declared `ConfirmationHandler` |
| Terminal reader renders the bag | ✅ `ActionConfirmDialog.tsx` reads `title` / `cancelText` / `confirmText` |
| Localized, not merely wrapped in `t()` | ✅ the three keys are present in all 8 `packages/i18n/src/locales/*.ts` bundles |
| Sole two-argument producer | ✅ repo-wide grep of `confirmHandler(` / `onConfirm(` finds no other |

⚠️ **The card's pointer had already drifted**: the producer it cites as `ObjectView.tsx:1397` is at **:1520** on today's `main`. That is the reason the comment deliberately carries **no line numbers** — anchoring on a line number would just have queued up the next stale pointer. It anchors on the symbol (`handleDeleteView`), the file, and the i18n keys, all of which survive movement and are greppable.

## Verification — gate union re-run after the final commit, at `5af910c80`

All from the repo root, one lock acquisition, `set -o pipefail`, verdict lines quoted from the gates themselves:

- `node scripts/check-changeset-presence.mjs` → `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/tidy-jars-confirm.md.` (empty frontmatter — declared as releasing nothing, the gate's own explicit exemption)
- `node scripts/check-changeset-no-major.mjs` → `✅  No changeset declares a `major` bump.`
- `node scripts/check-control-bytes.mjs` → `✅  check-control-bytes: OK (scanned 4856 tracked text file(s); skipped 85 binary).`
- `pnpm --filter @object-ui/core type-check` → clean (`tsc --noEmit && tsc -p tsconfig.test.json`, exit 0). First run failed `TS6305` on an unbuilt `packages/types/dist`; re-run after `pnpm --filter '@object-ui/core^...' build`.
- `pnpm --filter @object-ui/core lint` → `✖ 510 problems (0 errors, 510 warnings)` — 0 errors, all warnings pre-existing `no-explicit-any`. This is the package's own lint task, i.e. exactly what `turbo run lint` schedules for the one package this diff touches; the repo's eslint config enables no type-aware linting, so a comment-only diff cannot move any judgment in a package it does not touch.
- `pnpm exec vitest run packages/core/src/actions/__tests__/ActionRunner.test.ts packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx` → `Test Files  2 passed (2)` / `Tests  129 passed (129)`

No ablation was run: the change is a comment, and it has no runtime or type behaviour to ablate.

## Scope

Comment only, in one file, plus the changeset the presence gate asked for. `ConfirmationHandler`'s signature, `ActionConfirmDialog.tsx`, `ObjectView.tsx` and the runner's logic are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_