### PR TITLE
fix(dashboard): make the dataset `table` widget read as a table, not a dump

### DIFF
--- a/.changeset/dashboard-table-widget-polish-5827.md
+++ b/.changeset/dashboard-table-widget-polish-5827.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-dashboard': minor
+---
+
+Dashboard `table` widget (dataset-backed, flat grouped table) — four rendering
+fixes so it reads as a table rather than a raw dump (objectui#5827):
+
+- **Numeric columns right-align**, header and cells. `tabular-nums` was already
+  applied to every cell and could not do its job while the digits were flushed
+  left. A column qualifies when it is a MEASURE and every non-null value in it
+  is a number — the declared column `type` cannot decide it, because the
+  analytics executor stamps `type: 'number'` on every measure regardless of the
+  aggregate, so a `min()`/`max()` over a text field would have been
+  right-aligned on the strength of a label. Dimensions stay left-aligned even
+  when their bucket keys are digits: a grouping axis is not a quantity.
+- **Sortable headers.** Each header is a keyboard-reachable button that cycles
+  ascending → descending → back to the dataset's own order, with the console's
+  existing sort indicator and `aria-sort` on the `th`. Blanks sort last in
+  BOTH directions. The sort is client-side over the rows already fetched — the
+  widget issues one `queryDataset` call and paginates nothing, so no round trip
+  is involved.
+- **The empty-dimension bucket sorts last** in the default order instead of
+  floating to the top. It keeps its `—` label; only its position moves.
+- **Row hover feedback on every row**, not only on a drillable one. A drillable
+  row keeps its stronger accent fill.
+
+The CSV export now follows the order the table is showing, which is the same
+"the CSV is the table's data" convention its cell text already followed.
+Drill-through is unaffected: rows are reordered as `(row, incoming index)`
+pairs, so a drill still resolves through the server's parallel raw-value
+sidecar.
+
+Unchanged: the cross-tab (a `pivot` with ≥2 dimensions) renderer, the KPI and
+chart paths, and every non-dataset table in the console.

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -63,6 +63,13 @@ import {
   // (objectui#4877). Re-exported below under their original names.
   chartConfigPresentation,
   mergeAuthoredPresentation,
+  // The console's ONE client-side sort primitive (objectui#3096). The flat
+  // dataset table below sorts through it rather than inlining `a < b`, so a
+  // dashboard table and a list view order the same values identically — and
+  // so the relational/blank/numeric cases it already settles are not decided a
+  // second time here.
+  getSortValue,
+  compareSortValues,
   type ChartSegmentClickEvent,
   type CompareToConfig,
   type DatasetResultField,
@@ -70,7 +77,7 @@ import {
 } from '@object-ui/core';
 import { cn, Skeleton, ChartSkeleton, GridSkeleton } from '@object-ui/components';
 import { useSafeFieldLabel, useSafeTranslate, useDisplayLocale } from '@object-ui/i18n';
-import { BarChart3, AlertTriangle, Download, ArrowUpIcon, ArrowDownIcon, MinusIcon } from 'lucide-react';
+import { BarChart3, AlertTriangle, Download, ArrowUpIcon, ArrowDownIcon, MinusIcon, ChevronsUpDown, ChevronUp, ChevronDown } from 'lucide-react';
 import { useFilterScope } from '@object-ui/react';
 import { resolveFilterPlaceholders, computeMetricDelta } from './utils';
 import { metricAccentTextClass } from './colorVariants';
@@ -501,6 +508,17 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; drillRanges?: Array<Record<string, DatasetDrillRange>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
   // Drill-through (ADR-0021 D2): the clicked bucket's record-list filter + title.
   const [drill, setDrill] = useState<{ filter: Record<string, unknown>; title: string } | null>(null);
+  // ── The flat table's client-side sort (objectui#5827) ────────────────────
+  // `null` = the dataset's own order. Declared up here with the other hooks
+  // because the table branch sits AFTER this component's early returns, where a
+  // `useState` would be conditional.
+  //
+  // Client-side is the design, not a shortcut: this widget issues ONE
+  // `queryDataset` call and paginates nothing, so the rows on screen ARE the
+  // whole result set and reordering them needs no round trip. `options.limit`
+  // does truncate that set server-side — a sort then orders exactly the set the
+  // unsorted table was already showing, never a different slice of the data.
+  const [tableSort, setTableSort] = useState<{ column: string; dir: 'asc' | 'desc' } | null>(null);
   // Signature uses the RAW filter (stable) — the resolved one carries a
   // render-time `now` and would otherwise force a refetch loop. The
   // query-affecting options join it so editing a widget's granularity/sort in
@@ -834,7 +852,12 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     // number a spreadsheet can compute on — serializing the stacked cell would
     // emit strings like "$120 $100 20%", which is a screenshot in CSV clothing.
     const exportColumns = [...dimensions, ...measureColumns];
-    const exportCsv = () => downloadCsv(String(widget?.title ?? datasetName ?? 'export'), [
+    // `rows` is a parameter because the flat table now renders its rows in an
+    // order of its own (objectui#5827 — blank bucket last, plus whatever the
+    // user sorted by), and "the CSV follows the table" has to mean the order
+    // too, not just the cell text. The cross-tab passes `displayRows`, which is
+    // what this always exported.
+    const exportCsv = (rows: Row[]) => downloadCsv(String(widget?.title ?? datasetName ?? 'export'), [
       exportColumns.map((c) => columnLabel(c)),
       // The CSV follows the table's own cells (objectui#4263): a dotted
       // dimension exports the label the table now shows, and a local one is
@@ -843,15 +866,15 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       // reason: the CSV is the table's data, so it exports the cell. Measures
       // stay numeric (the raw values that must round-trip into a spreadsheet);
       // the drill filter — the identity key — reads `drillRawRows`, untouched.
-      ...displayRows.map((r) => exportColumns.map((c) => {
+      ...rows.map((r) => exportColumns.map((c) => {
         const v = r[c];
         return v == null ? '' : (typeof v === 'number' ? v : String(v));
       })),
     ]);
-    const exportBtn = (
+    const exportBtnFor = (rows: Row[]) => (
       <button
         type="button"
-        onClick={exportCsv}
+        onClick={() => exportCsv(rows)}
         data-testid="dataset-export"
         title={tt('dashboard.exportCsv', 'Export CSV')}
         aria-label={tt('dashboard.exportCsv', 'Export CSV')}
@@ -860,6 +883,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
         <Download className="h-3.5 w-3.5" />
       </button>
     );
+    const exportBtn = exportBtnFor(displayRows);
 
     // pivot → a true cross-tab when there are ≥2 dimensions: the LAST dimension
     // spreads ACROSS as columns, the rest go DOWN as rows, measures fill the
@@ -1050,35 +1074,162 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
 
     // table (and a 1-dimension pivot) → a flat grouped table.
     const columns = [...dimensions, ...measureColumns];
+
+    // ── Which columns are NUMBERS (objectui#5827) ─────────────────────────
+    // Right-alignment is a claim about the values, so it is decided from them.
+    //
+    // The column DESCRIPTOR cannot decide it, contrary to what the card
+    // assumed: the executor stamps `type: 'number'` on every measure column it
+    // appends (`service-analytics/src/dataset-executor.ts`) without looking at
+    // the aggregate, so across measures the declared type is a constant and
+    // discriminates nothing. Nor is `tabular-nums` evidence — this table
+    // applies it to every cell, dimension cells included.
+    //
+    // What IS structural is which columns are MEASURES, and only a measure is a
+    // candidate: a dimension is a grouping axis even when its bucket keys are
+    // digits (a year, a quarter), and right-aligning those would render the
+    // axis as if it were a quantity.
+    //
+    // Within the candidates the test is defensive — EVERY non-null value must
+    // be a number. `formatMeasure` falls back to `String(v)` for a non-number,
+    // which is exactly what a `min()`/`max()` over a text field yields; that
+    // column renders words and stays left-aligned. An all-null column passes
+    // vacuously and right-aligns its `—`s: that is the same column with no
+    // rows, not a different kind of column.
+    //
+    // Resolved ONCE per column into a set, not per cell: the predicate scans
+    // every row, so calling it from inside the row loop would make rendering
+    // quadratic in the row count.
+    const numericColumns = new Set(
+      columns.filter(
+        (c) =>
+          (values.includes(c) || compareOf(c) !== undefined) &&
+          displayRows.every((r) => r[c] == null || typeof r[c] === 'number'),
+      ),
+    );
+
+    // ── Row order (objectui#5827) ─────────────────────────────────────────
+    // Rows are DECORATED with their incoming index and reordered as decorated
+    // pairs, never as bare rows. `openDrill(i)` indexes `drillRawRows` — the
+    // server's parallel array of RAW bucket values — so the index has to keep
+    // pointing at the row it arrived with. Sorting `displayRows` in place would
+    // leave every drill filtering by some other row's bucket, silently: both
+    // arrays keep the same length and every click still opens a drawer.
+    const entries = displayRows.map((row, index) => ({ row, index }));
+    // A sort survives only while its column does. After a re-query on edited
+    // metadata the stored column may be gone; falling back to the default order
+    // beats sorting every row by `undefined`.
+    const activeSort = tableSort && columns.includes(tableSort.column) ? tableSort : null;
+    const orderedEntries = activeSort
+      ? entries
+          // Resolve the key ONCE per row (decorate → sort → undecorate) — the
+          // convention `sort-values.ts` documents, because `getSortValue` walks
+          // the value and a comparator would repeat that walk O(n log n) times.
+          .map((e) => ({ ...e, key: getSortValue(e.row[activeSort.column]) }))
+          .sort((a, b) => {
+            // Blanks last in BOTH directions. `compareSortValues` places them
+            // last ascending and documents that callers negate for descending —
+            // negation would float them to the top, so the blank arm is settled
+            // BEFORE the direction is applied and never inside it.
+            if (a.key === null && b.key === null) return 0;
+            if (a.key === null) return 1;
+            if (b.key === null) return -1;
+            const cmp = compareSortValues(a.key, b.key);
+            return activeSort.dir === 'asc' ? cmp : -cmp;
+          })
+      : // Default order = the order the dataset returned, with one exception:
+        // the EMPTY-dimension bucket sinks below the named ones. It keeps its
+        // `—` label — only its position moves. A bucket with no value sorting
+        // FIRST reads to the viewer as a data bug. `Array#sort` is stable, so
+        // every other pair compares 0 and the server's ordering survives whole.
+        [...entries].sort((a, b) => {
+          for (const d of dimensions) {
+            const aBlank = getSortValue(a.row[d]) === null ? 1 : 0;
+            const bBlank = getSortValue(b.row[d]) === null ? 1 : 0;
+            if (aBlank !== bBlank) return aBlank - bBlank;
+          }
+          return 0;
+        });
+
+    // asc → desc → back to the default order. Three states, not the two a
+    // server-paged grid offers: here the default IS a meaningful order (the
+    // dataset's own, which an author can set via `options.sortBy`), so a header
+    // has to be able to hand it back.
+    const cycleSort = (c: string) =>
+      setTableSort((prev) =>
+        prev?.column !== c
+          ? { column: c, dir: 'asc' }
+          : prev.dir === 'asc'
+            ? { column: c, dir: 'desc' }
+            : null,
+      );
+    // The console's own indicator (`components/…/data-table.tsx`): an idle
+    // column shows nothing until the header is hovered, the sorted one shows a
+    // primary-tinted arrow. `aria-hidden` because the `th`'s `aria-sort` is
+    // what carries the state to assistive tech.
+    const sortIcon = (c: string) => {
+      if (activeSort?.column !== c) {
+        return <ChevronsUpDown className="ml-0.5 h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-50" aria-hidden="true" />;
+      }
+      const Arrow = activeSort.dir === 'asc' ? ChevronUp : ChevronDown;
+      return <Arrow className="ml-0.5 h-3 w-3 shrink-0 text-primary" aria-hidden="true" />;
+    };
+
     return (
-      <div className="relative h-full w-full overflow-auto p-1">{exportBtn}
+      <div className="relative h-full w-full overflow-auto p-1">{exportBtnFor(orderedEntries.map((e) => e.row))}
         <table className="w-full text-xs">
           <thead className="bg-muted/40">
             <tr>
-              {columns.map((c) => (
-                <th
-                  key={c}
-                  className="px-2 py-1.5 text-left font-medium whitespace-nowrap"
-                  data-testid={compareOf(c) ? 'dataset-compare-column' : undefined}
-                >
-                  {columnLabel(c)}
-                </th>
-              ))}
+              {columns.map((c) => {
+                const numeric = numericColumns.has(c);
+                return (
+                  <th
+                    key={c}
+                    scope="col"
+                    aria-sort={activeSort?.column === c ? (activeSort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                    className={cn('group px-2 py-1.5 font-medium whitespace-nowrap', numeric ? 'text-right' : 'text-left')}
+                    data-testid={compareOf(c) ? 'dataset-compare-column' : undefined}
+                  >
+                    {/* A real button, not a click handler on the `th`: the sort
+                        has to be reachable from the keyboard and needs an
+                        accessible name. It is visually the header text, so the
+                        console's header layout is unchanged. */}
+                    <button
+                      type="button"
+                      onClick={() => cycleSort(c)}
+                      data-testid="dataset-table-sort"
+                      className={cn(
+                        'inline-flex w-full select-none items-center font-medium transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                        numeric ? 'justify-end' : 'justify-between',
+                      )}
+                    >
+                      <span className="truncate">{columnLabel(c)}</span>
+                      {sortIcon(c)}
+                    </button>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>
-            {displayRows.map((row, i) => (
+            {orderedEntries.map(({ row, index }) => (
               <tr
-                key={i}
-                className={cn('border-t', canDrill && 'cursor-pointer hover:bg-accent/40')}
+                key={index}
+                // Hover feedback on EVERY row, not only a drillable one — the
+                // cue that says "this row is a unit" is what the card is about,
+                // and a table nobody can drill needs it just as much. A
+                // drillable row keeps its stronger accent fill: `cn` runs
+                // tailwind-merge, so the later `hover:bg-accent/40` replaces
+                // `hover:bg-muted/40` rather than stacking with it.
+                className={cn('border-t transition-colors hover:bg-muted/40', canDrill && 'cursor-pointer hover:bg-accent/40')}
                 data-testid={canDrill ? 'dataset-drill-row' : undefined}
-                onClick={canDrill ? () => openDrill(i, drillDims.map((d) => formatDimensionValue(row[d], displayLocale)).filter(Boolean).join(' / ')) : undefined}
+                onClick={canDrill ? () => openDrill(index, drillDims.map((d) => formatDimensionValue(row[d], displayLocale)).filter(Boolean).join(' / ')) : undefined}
               >
                 {columns.map((c) => {
                   // A comparison column formats as the measure it compares.
                   const measure = compareOf(c) ?? (values.includes(c) ? c : undefined);
                   return (
-                    <td key={c} className="px-2 py-1 whitespace-nowrap tabular-nums">
+                    <td key={c} className={cn('px-2 py-1 whitespace-nowrap tabular-nums', numericColumns.has(c) && 'text-right')}>
                       {measure
                         ? formatMeasure(row[c], measureField(measure)?.format, measureField(measure)?.currency, measureField(measure)?.percentScale, displayLocale)
                         : formatDimensionValue(row[c], displayLocale)}

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.tablePolish.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.tablePolish.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5827 — the flat dataset `table` widget read as a raw dump.
+ *
+ * Measured on HotCRM's `executive_dashboard` → 按行业统计客户 (`type: 'table'`,
+ * dataset-backed, one dimension + two measures): numeric columns left-aligned
+ * with `tabular-nums` applied and therefore wasted, no sort affordance on any
+ * header, the empty-`industry` bucket rendering as row 1, and no hover on a
+ * table that is not drillable. The fixture below is that widget's shape,
+ * including the incoming row order (blank bucket first, then alphabetical).
+ *
+ * DIRECTIONS, stated before the reverse verification was run — every case in
+ * this file is RED on `origin/main`:
+ *  - alignment: `th`/`td` carried `text-left` (header) and no alignment class
+ *    (cell), so the right-align assertions fail;
+ *  - sorting: no `dataset-table-sort` control existed at all, so those cases
+ *    fail at the query rather than at the assertion;
+ *  - blank bucket last: the widget rendered `state.rows` in arrival order;
+ *  - hover: `hover:bg-muted/40` was applied only through the `canDrill` arm.
+ * There is no ablation-through-`dist` here: this file imports the component by
+ * relative source path (`../DatasetWidget`), so no build stands between the
+ * edit and the run.
+ *
+ * The drill case is the sharp one and is why the reorder is implemented over
+ * DECORATED rows. `openDrill(i)` indexes the server's parallel `drillRawRows`;
+ * reordering bare rows would keep every length and every click working while
+ * filtering by another row's bucket. `drillRawRows` below is spelled in
+ * lower-case identity keys, deliberately different from the display labels, so
+ * an index-aligned drill can be told apart from a lucky string match.
+ *
+ * NOT this card, and deliberately unasserted: the untranslated measure header
+ * ("Annual Revenue" beside 行业) is the dataset-label i18n gap filed as
+ * objectstack#10292.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { DatasetWidget } from '../DatasetWidget';
+
+/** Observe the drill filter without rendering the real drawer. */
+const drillFilters: Array<Record<string, unknown>> = [];
+vi.mock('../DrillDownDrawer', () => ({
+  DrillDownDrawer: ({ filter }: { filter: Record<string, unknown> }) => {
+    drillFilters.push(filter);
+    return null;
+  },
+}));
+
+/**
+ * The dataset's base object. Every field is plain TEXT with no `options`, so
+ * `relabelDimensions` resolves nothing and the rows reach the table exactly as
+ * the fixture wrote them — this file is about ORDER and ALIGNMENT, and an
+ * option-driven relabel would blur which channel produced a cell.
+ */
+const ACCOUNT = { name: 'crm_account', fields: { industry: { type: 'text' } } };
+
+function installMetaRouter() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ item: ACCOUNT }) })),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  drillFilters.length = 0;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/**
+ * 按行业统计客户, as the server sends it: the empty bucket FIRST, then the named
+ * industries alphabetically — which is how Technology (the largest) ended up
+ * rendering last.
+ */
+const industryRows = () => [
+  { industry: null, annual_revenue_sum: 0, account_count: 1 },
+  { industry: 'Finance', annual_revenue_sum: 12000000, account_count: 3 },
+  { industry: 'Technology', annual_revenue_sum: 30000000, account_count: 5 },
+];
+
+const industryFields = [
+  { name: 'industry', type: 'text', label: 'Industry' },
+  { name: 'annual_revenue_sum', type: 'number', label: 'Annual Revenue' },
+  { name: 'account_count', type: 'number', label: 'Accounts' },
+];
+
+const industrySource = (extra: Record<string, unknown> = {}) => ({
+  queryDataset: vi.fn(async () => ({ rows: industryRows(), fields: industryFields, ...extra })),
+});
+
+/** The drillable variant — identity keys spelled unlike the display labels. */
+const drillableSource = () =>
+  industrySource({
+    object: 'crm_account',
+    dimensionFields: { industry: 'industry' },
+    drillRawRows: [{ industry: null }, { industry: 'fin' }, { industry: 'tech' }],
+  });
+
+const TABLE_WIDGET = {
+  type: 'table',
+  dataset: 'accounts_by_industry',
+  dimensions: ['industry'],
+  values: ['annual_revenue_sum', 'account_count'],
+};
+
+const headerCells = () => Array.from(document.querySelectorAll('thead th'));
+const bodyRows = () => Array.from(document.querySelectorAll('tbody tr'));
+const rowCells = (i: number) =>
+  Array.from(bodyRows()[i]?.querySelectorAll('td') ?? []).map((td) => td.textContent ?? '');
+/** The first cell of each body row, top to bottom — i.e. the rendered order. */
+const dimensionColumn = () => bodyRows().map((r) => r.querySelector('td')?.textContent ?? '');
+
+const sortButtons = () => screen.getAllByTestId('dataset-table-sort');
+
+describe('objectui#5827 — dataset table alignment', () => {
+  it('right-aligns numeric measure columns, header AND cells, and leaves the dimension alone', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await screen.findByText('Industry');
+
+    const [dimHead, revenueHead, countHead] = headerCells();
+    // A dimension is a grouping axis, never a quantity.
+    expect(dimHead.className).toContain('text-left');
+    expect(dimHead.className).not.toContain('text-right');
+    expect(revenueHead.className).toContain('text-right');
+    expect(countHead.className).toContain('text-right');
+
+    const cells = Array.from(bodyRows()[0].querySelectorAll('td'));
+    expect(cells[0].className).not.toContain('text-right');
+    expect(cells[1].className).toContain('text-right');
+    expect(cells[2].className).toContain('text-right');
+    // `tabular-nums` was already applied to every cell and is kept — it is the
+    // right-alignment it was waiting for, not a replacement for it.
+    expect(cells[1].className).toContain('tabular-nums');
+  });
+
+  it('does NOT right-align a measure whose values are text (a min()/max() over a text field)', async () => {
+    // The declared column `type` cannot decide this: the executor stamps
+    // `type: 'number'` on every measure it appends regardless of the aggregate.
+    // So numeric-ness is read from the VALUES, and one non-null non-number is
+    // enough to disqualify the column.
+    installMetaRouter();
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [
+          { industry: 'Finance', top_account: 'Northwind', account_count: 3 },
+          { industry: 'Technology', top_account: 'Contoso', account_count: 5 },
+        ],
+        fields: [
+          { name: 'industry', type: 'text', label: 'Industry' },
+          // `type: 'number'` deliberately — that is what the executor sends.
+          { name: 'top_account', type: 'number', label: 'Top Account' },
+          { name: 'account_count', type: 'number', label: 'Accounts' },
+        ],
+      })),
+    };
+    render(
+      <DatasetWidget
+        widget={{ ...TABLE_WIDGET, values: ['top_account', 'account_count'] }}
+        dataSource={src}
+      />,
+    );
+    await screen.findByText('Top Account');
+
+    const [, topAccountHead, countHead] = headerCells();
+    expect(topAccountHead.className).not.toContain('text-right');
+    expect(countHead.className).toContain('text-right');
+    const cells = Array.from(bodyRows()[0].querySelectorAll('td'));
+    expect(cells[1].className).not.toContain('text-right');
+    expect(cells[2].className).toContain('text-right');
+  });
+});
+
+describe('objectui#5827 — the empty dimension bucket sorts last', () => {
+  it('keeps the — label but pins the blank bucket after the named rows in the default order', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await screen.findByText('Industry');
+
+    // Arrival order was [blank, Finance, Technology].
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+    // The named rows keep the server's relative order — the sort is stable and
+    // says nothing about any pair except blank-vs-named.
+    expect(rowCells(0)[0]).toBe('Finance');
+    expect(rowCells(1)[0]).toBe('Technology');
+  });
+
+  it('drills the row it is showing, not the row that used to be in that slot', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={drillableSource()} />);
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+
+    // Row 0 now shows Finance, whose identity key is `fin` — index 1 of the
+    // raw sidecar. Reordering bare rows would have filtered by `null` here.
+    fireEvent.click(bodyRows()[0]);
+    await waitFor(() => expect(drillFilters.length).toBeGreaterThan(0));
+    expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: 'fin' });
+
+    // …and the blank bucket, now last, still drills to "is empty".
+    fireEvent.click(bodyRows()[2]);
+    await waitFor(() =>
+      expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: null }),
+    );
+  });
+});
+
+describe('objectui#5827 — sortable headers', () => {
+  it('cycles asc → desc → the default order, per column, and reports it via aria-sort', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await screen.findByText('Industry');
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    // Default: no column claims a sort.
+    expect(headerCells().map((th) => th.getAttribute('aria-sort'))).toEqual(['none', 'none', 'none']);
+
+    // Ascending by revenue: the blank bucket's 0 is a real number, so it leads.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('ascending');
+    expect(dimensionColumn()).toEqual(['—', 'Finance', 'Technology']);
+
+    // Descending: the biggest industry first — the complaint this card opened on.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('descending');
+    expect(dimensionColumn()).toEqual(['Technology', 'Finance', '—']);
+
+    // Third click returns the dataset's own order (blank bucket still last).
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('none');
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+  });
+
+  it('starts a NEW column ascending rather than inheriting the previous column state', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    fireEvent.click(sortButtons()[1]);
+    fireEvent.click(sortButtons()[1]); // revenue, descending
+    fireEvent.click(sortButtons()[0]); // switch to the dimension
+    expect(headerCells().map((th) => th.getAttribute('aria-sort'))).toEqual(['ascending', 'none', 'none']);
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+  });
+
+  it('sorts blanks LAST in both directions', async () => {
+    // `compareSortValues` puts blanks last ascending and documents that callers
+    // negate for descending — which would float them to the top. So the blank
+    // arm is settled before the direction is applied. Sorted on the DIMENSION,
+    // where the blank actually lives.
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    fireEvent.click(sortButtons()[0]);
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+    fireEvent.click(sortButtons()[0]);
+    expect(dimensionColumn()).toEqual(['Technology', 'Finance', '—']);
+  });
+
+  it('sorts numerically, not lexicographically', async () => {
+    installMetaRouter();
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [
+          { industry: 'Finance', account_count: 9 },
+          { industry: 'Technology', account_count: 10 },
+        ],
+        fields: [
+          { name: 'industry', type: 'text', label: 'Industry' },
+          { name: 'account_count', type: 'number', label: 'Accounts' },
+        ],
+      })),
+    };
+    render(<DatasetWidget widget={{ ...TABLE_WIDGET, values: ['account_count'] }} dataSource={src} />);
+    await waitFor(() => expect(bodyRows().length).toBe(2));
+
+    fireEvent.click(sortButtons()[1]);
+    // 9 before 10. A string compare would invert this.
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology']);
+    fireEvent.click(sortButtons()[1]);
+    expect(dimensionColumn()).toEqual(['Technology', 'Finance']);
+  });
+
+  it('exports the CSV in the order the table is showing', async () => {
+    installMetaRouter();
+    const blobs: Blob[] = [];
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    (URL as any).createObjectURL = (b: Blob) => { blobs.push(b); return 'blob:x'; };
+    (URL as any).revokeObjectURL = () => {};
+    try {
+      render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+      await waitFor(() => expect(bodyRows().length).toBe(3));
+      fireEvent.click(sortButtons()[1]);
+      fireEvent.click(sortButtons()[1]); // revenue, descending
+      fireEvent.click(screen.getByTestId('dataset-export'));
+
+      expect(blobs.length).toBe(1);
+      const lines = (await blobs[0].text()).trim().split('\n').map((l) => l.trim());
+      // Header, then the rows in the order on screen.
+      expect(lines[1]).toContain('Technology');
+      expect(lines[2]).toContain('Finance');
+      // The measure round-trips as a bare number, as it always has.
+      expect(lines[1]).toContain('30000000');
+    } finally {
+      (URL as any).createObjectURL = origCreate;
+      (URL as any).revokeObjectURL = origRevoke;
+    }
+  });
+});
+
+describe('objectui#5827 — row affordances', () => {
+  it('gives every row hover feedback, drillable or not', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+    // Not drillable: no object/dimensionFields in this fixture.
+    expect(screen.queryByTestId('dataset-drill-row')).toBeNull();
+    for (const row of bodyRows()) expect(row.className).toContain('hover:bg-muted/40');
+  });
+
+  it('keeps the drillable row on its stronger accent fill', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={drillableSource()} />);
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+    for (const row of bodyRows()) {
+      expect(row.className).toContain('hover:bg-accent/40');
+      expect(row.className).toContain('cursor-pointer');
+      // tailwind-merge collapses the two hover fills to the later one.
+      expect(row.className).not.toContain('hover:bg-muted/40');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #5827

The flat dataset `table` widget left its numeric columns flushed left while applying `tabular-nums` to them — the one setting that only pays off once the digits share a right edge — offered no sort affordance on any header, floated the empty-dimension bucket to row 1, and gave a non-drillable row no hover at all.

## Where it renders (the card did not name the file)

`packages/plugin-dashboard/src/DatasetWidget.tsx`, the flat branch of `if (isTable)`. It serves `type: 'table'` and a `type: 'pivot'` with a single dimension; a pivot with >=2 dimensions takes the cross-tab branch above it, which is untouched.

**Blast radius: none outside the dashboard.** This markup is hand-written in `DatasetWidget` and shared with nothing — not `data-table` (`packages/components/src/renderers/complex/data-table.tsx`), not `ObjectDataTable`, not `PivotTable`/`ObjectPivotTable`, not list views, not the report renderer. `DatasetWidget`'s only importers are `DashboardRenderer` and `DashboardGridLayout`, both in this package. So the styling changes cannot ripple, and no other table in the console is restyled here.

## The four items

1. **Numeric columns right-align, header and cells.** The card assumed the renderer already knows which columns are numeric because it applies `tabular-nums`. It does not — it applied `tabular-nums` to *every* cell, dimension cells included. Nor does the column descriptor know: `service-analytics`'s dataset executor stamps `type: 'number'` on every measure column it appends (`dataset-executor.ts`, three sites) without consulting the aggregate, so across measures the declared type is a constant and discriminates nothing. What is structural is which columns are **measures**. So: a measure (or a measure's comparison column) is a candidate — a dimension is a grouping axis even when its bucket keys are digits, and right-aligning a year would render the axis as a quantity — and within the candidates the test is over the values, every non-null one must be a number. A `min()`/`max()` over a text field therefore stays left-aligned instead of right-aligning words; `formatMeasure` already falls back to `String(v)` for exactly that case. Resolved once per column into a set, so rendering does not become quadratic in the row count.
2. **Sortable headers**, through `@object-ui/core`'s `getSortValue` / `compareSortValues` — the console's one client-side sort primitive (objectui#3096) — with the indicator `data-table.tsx` already uses (`ChevronsUpDown` idle, a primary-tinted `ChevronUp`/`ChevronDown` when active) and `aria-sort` on the `th`. The control is a real `<button>` rather than a click handler on the `th`, so the sort is keyboard-reachable and has an accessible name; it renders as the header text, so the layout is unchanged. Cycle is asc -> desc -> **back to the dataset's own order**: three states, not the two a server-paged grid offers, because here the default is a meaningful order (the dataset's, which an author can set via `options.sortBy`). Blanks stay last in **both** directions — `compareSortValues` places them last ascending and documents that callers negate for descending, which would float them to the top, so the blank arm is settled before the direction is applied.
3. **The empty-dimension bucket sinks below the named rows** in the default order. It keeps its `—` label; only its position moves. `Array#sort` is stable, so every other pair compares 0 and the dataset's ordering survives whole.
4. **Row hover on every row**, not only a drillable one. A drillable row keeps its stronger accent fill — `cn` runs tailwind-merge, so the later `hover:bg-accent/40` replaces `hover:bg-muted/40` rather than stacking. No zebra: the console's DataTable idiom has none, and the card asked for hover **and/or** zebra.

**Item 5 (totals row) NOT taken, flagged as the card asks.** Two reasons, and the second is the load-bearing one. The widget height budget is real (9 rows already span 832px), but more importantly a *correct* totals row cannot be computed here: this file carries the no-client-re-aggregation line — an avg/min/max cannot be recombined from bucketed values — and the server's marginal totals are requested only for the cross-tab (`totalsGroupings` is set `if (isMatrix)`). A flat-table totals row therefore means changing the query every dashboard table issues to ask for the `[]` grouping, which is a query-shape change beyond this card's renderer-level contract. Worth its own issue if wanted.

**Out of scope: objectstack#10292** (dataset measure headers render untranslated, "Annual Revenue" beside 行业) remains open and is not addressed here.

## Two premises checked, one of them false

- *"Detected from the resolved value type/format the renderer already has."* **False as stated** — see item 1. Numeric-ness is inferred from the values, defensively.
- *"Sorting client-side over the already-fetched rows is the cheap path."* **Holds.** The widget issues one `queryDataset` call and paginates nothing, so the rows on screen are the whole result set. `options.limit` truncates that set server-side; a sort then orders exactly the set the unsorted table was showing, never a different slice.

## The sharp edge

Rows are reordered as `(row, incoming index)` pairs, never as bare rows. `openDrill(i)` indexes `drillRawRows`, the server's parallel array of **raw** bucket values, so a bare-row sort would have kept every array length and every click working while filtering by another row's bucket — silently. Pinned by a test that drills the first row after the reorder and asserts the identity key of the row actually on screen (the fixture spells raw keys unlike the display labels, so an index-aligned drill can be told from a lucky string match). The CSV export follows the displayed order for the same reason its cell text already followed the displayed labels.

## Verification

All commands run from the repo root, in a dedicated worktree, on `db437ef57`.

| gate | verdict line | exit |
|---|---|---|
| `pnpm --filter '@object-ui/plugin-dashboard^...' build` | dependency closure built (`built in 6.19s`, last package `packages/fields`) | 0 |
| `pnpm --filter @object-ui/plugin-dashboard type-check` | `tsc --noEmit && tsc -p tsconfig.test.json` — no diagnostics | 0 |
| `pnpm --filter @object-ui/plugin-dashboard lint` | `369 problems (0 errors, 369 warnings)` (all pre-existing `no-explicit-any` / `react-hooks` warnings; none in the new code) | 0 |
| `pnpm exec vitest run packages/plugin-dashboard/` | `Test Files 76 passed (76)` / `Tests 693 passed (693)` | 0 |
| `node scripts/check-changeset-presence.mjs` | `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` | 0 |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a 'major' bump.` | 0 |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 4852 tracked text file(s); skipped 85 binary).` | 0 |

Baseline before the change was `Test Files 75 passed (75)` / `Tests 682 passed (682)`; the delta is exactly the new file (+1 file, +11 tests). Nothing pre-existing moved.

**Reverse verification.** Direction stated before the run: reverting `DatasetWidget.tsx` to `origin/main` turns the new file red. Observed: **10 of 11 red**, 1 green — `keeps the drillable row on its stronger accent fill`, which is the acceptance-boundary case (that row already had `hover:bg-accent/40` + `cursor-pointer` on `main`) and is *supposed* to stay green. Mutation confirmed on disk by anchored greps rather than by an editor exit code — injected markers `dataset-table-sort` / `numericColumns` / `compareSortValues` each counted 0, and the deleted `origin/main` cell spelling `className="px-2 py-1 whitespace-nowrap tabular-nums"` counted 1. Restore leg confirmed the same way (1 / 3 / 0) plus an empty `git status --porcelain` for the file, and re-ran green at 11/11. No rebuild stands between the edit and the run: the suite imports the component by relative source path (`../DatasetWidget`), not through a package `exports` -> `dist` hop. The script carried `trap ... EXIT INT TERM`, so a kill mid-ablation could not leave the tree mutated.

**Not verified in a running browser.** The reading in this PR is from component tests over the DOM the widget produces, not from a locally built console rendering HotCRM's `executive_dashboard`. The shared heavy-verification lock is also inoperable on this host — `os-verify-lock.sh --status` reports `CANNOT OPERATE THIS LOCK ... a stock macOS does not ship flock` — so the commands above ran directly rather than through the entry point.

_Generated by [Claude Code](https://claude.ai/code/session_61f28fb9-8e31-4a6f-b4d8-10f749a092d2)_