### PR TITLE
docs(citations): re-anchor the eight `ADR-0057 D10` citations to the framework's `ADR-0124 D1` (#5701)

### DIFF
--- a/.changeset/reanchor-adr-0124-d1-citations-5701.md
+++ b/.changeset/reanchor-adr-0124-d1-citations-5701.md
@@ -1,0 +1,33 @@
+---
+---
+
+Traceability only — this publishes nothing, declared explicitly with an empty frontmatter
+rather than left undeclared. The change is comment text at eight live source sites; no
+executable line moves, and `git diff -U0` carries zero non-comment added or removed lines.
+
+`server enforces, client is courtesy` was cited at those eight sites as the framework's
+**`ADR-0057 D10`**. That decision reads *"Setup-nav surfacing follows the capability
+(ADR-0029 K2); the object stays open"* — nav-entry tiering, not enforcement location. The
+rule these sites actually invoke is decided by the framework's **`ADR-0124 D1`**, *"The
+server is the enforcement point; client-side gating is a usability courtesy"* (Accepted
+2026-08-18). #5699 fixed the repo-ambiguity half of this defect — whose ADR numbering the
+citation meant — and deliberately left the anchor half; this is that half.
+
+The new anchor is derived from an authority, not chosen: the framework's own ADR-0057
+carries a note aimed at precisely this citation — *"If a citation of `ADR-0057 D10`
+brought you here looking for that rule, ADR-0124 is where it is decided."* The substantive
+claim at every site is unchanged; only the anchor moves.
+
+The disambiguating parenthetical #5699 shipped — *"framework numbering; this repo's own
+ADR-0057 is an unrelated document"* — is retired along with the number it disambiguated.
+It warned about a collision specific to `0057`; this repository has no ADR-0124 at all
+(its own series stops at `0059`), and ADR-0124 records that a fresh, unambiguous number
+was chosen so that citations of it would not need such a warning. The `the framework's …`
+possessive stays at every site, so each one still says whose numbering it means.
+
+Left byte-untouched, deliberately: `packages/data-objectstack/src/appAccessProbe.test.ts`
+cites the same decision for *"an app gated by an absent optional service"* — the
+capability/service-gating family that decision genuinely does decide, so it is correct as
+it stands. `docs/adr/0036-field-conditional-rules.md`, the wording all eight derive from,
+carries the same misattribution and moves in its own PR: `docs/adr/**` is a governed
+surface that stops at draft for human merge.

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1062,9 +1062,8 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // a record the user may only read: the form opened, the user retyped a
   // field, and the server rejected the save with a 403. Ask the explain
   // engine for the row-level verdict (fail-open; the server stays the
-  // authority per the framework's ADR-0057 D10 — framework numbering; this
-  // repo's own ADR-0057 is an unrelated document) and fold it into the same
-  // affordance gates.
+  // authority per the framework's ADR-0124 D1 — server enforces, client is
+  // courtesy) and fold it into the same affordance gates.
   const recordWriteAllowed = useRecordEditable(
     objectDef?.name,
     pureRecordId,

--- a/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx
@@ -87,8 +87,7 @@ export interface PackageOwdOverviewPanelProps {
   onDraftSaved?: () => void;
   /**
    * Courtesy gate: read-only packages render badges only (the framework's
-   * ADR-0057 D10 — framework numbering; this repo's own ADR-0057 is an
-   * unrelated document).
+   * ADR-0124 D1 — server enforces, client is courtesy).
    */
   readOnly?: boolean;
   locale: SupportedLocale;

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -423,12 +423,12 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   const tab = params.tab ?? 'interfaces';
   const locale = useMetadataLocale();
 
-  // Courtesy gate (the framework's ADR-0057 D10 — framework numbering; this
-  // repo's own ADR-0057 is an unrelated document): a read-only code/installed
-  // package refuses authoring server-side (ADR-0070), so don't let the user
-  // build up doomed local edits first — disable the authoring affordances up
-  // front. Unknown writability (fetch failed / still loading) stays ungated;
-  // the server gate remains the authority either way.
+  // Courtesy gate (the framework's ADR-0124 D1 — server enforces, client is
+  // courtesy): a read-only code/installed package refuses authoring
+  // server-side (ADR-0070), so don't let the user build up doomed local edits
+  // first — disable the authoring affordances up front. Unknown writability
+  // (fetch failed / still loading) stays ungated; the server gate remains the
+  // authority either way.
   const [pkgWritable, setPkgWritable] = React.useState<boolean | null>(null);
   React.useEffect(() => {
     let cancelled = false;

--- a/packages/core/src/evaluator/fieldRules.ts
+++ b/packages/core/src/evaluator/fieldRules.ts
@@ -35,8 +35,7 @@
  * `stripReadonlyWhenFieldsMulti` on the bulk path — DELETES that key from the
  * UPDATE payload. This file keeps the same fault fail-OPEN. For that one class
  * the two ends therefore point in OPPOSITE directions, deliberately: the
- * framework's ADR-0057 D10 — server enforces, client is courtesy (framework
- * numbering; this repo's own ADR-0057 is an unrelated document) — makes the
+ * framework's ADR-0124 D1 — server enforces, client is courtesy — makes the
  * server the authority, so the courtesy layer does not get to guess "locked"
  * and grey out a field the server might have accepted.
  *

--- a/packages/plugin-detail/src/useRecordEditable.test.tsx
+++ b/packages/plugin-detail/src/useRecordEditable.test.tsx
@@ -17,8 +17,7 @@
  *
  * Every uncertainty must fail OPEN — a courtesy hint may never be the reason a
  * permitted user cannot act. The server is the authority (the framework's
- * ADR-0057 D10 — framework numbering; this repo's own ADR-0057 is an
- * unrelated document).
+ * ADR-0124 D1 — server enforces, client is courtesy).
  */
 import * as React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/packages/plugin-detail/src/useRecordEditable.ts
+++ b/packages/plugin-detail/src/useRecordEditable.ts
@@ -13,9 +13,9 @@
  * sharing rule sits inside an object the user may otherwise create and edit
  * freely — so the header offered a primary "Edit" CTA that opened the form, let
  * the user retype a field, and only then bounced with a 403. The server is the
- * authority (the framework's ADR-0057 D10 — framework numbering; this repo's
- * own ADR-0057 is an unrelated document) and stays so; this is the courtesy
- * check that stops the UI from inviting a write it knows will fail.
+ * authority (the framework's ADR-0124 D1 — server enforces, client is
+ * courtesy) and stays so; this is the courtesy check that stops the UI from
+ * inviting a write it knows will fail.
  *
  * The answer comes from the explain engine's record-grained verdict
  * (`POST /api/v1/security/explain` with a `recordId`, ADR-0090 D6 / ADR-0095

--- a/packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts
+++ b/packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts
@@ -41,10 +41,10 @@
  * SPA origin where the cookie doesn't reach the API: the row's verdict is
  * `undefined` and the caller keeps the OBJECT-level answer, i.e. exactly what
  * this list rendered before this hook existed. The server is the authority
- * (the framework's ADR-0057 D10 — framework numbering; this repo's own
- * ADR-0057 is an unrelated document) and stays so; hiding a capability on
- * missing data would be a worse defect than the wasted click this fixes, and
- * it is the same posture `useRecordEditable` takes for the detail header.
+ * (the framework's ADR-0124 D1 — server enforces, client is courtesy) and
+ * stays so; hiding a capability on missing data would be a worse defect than
+ * the wasted click this fixes, and it is the same posture `useRecordEditable`
+ * takes for the detail header.
  *
  * The probe rides the host's AUTHENTICATED fetch (`SchemaRendererProvider`'s
  * `apiFetch`) rather than the bare global one: a bearer-token session carries

--- a/packages/react/src/hooks/useCapabilityGate.ts
+++ b/packages/react/src/hooks/useCapabilityGate.ts
@@ -24,11 +24,10 @@
  *
  * **Fail-OPEN when unknown.** No runner, no user, no `systemPermissions` array:
  * the action shows. Unknown is not denied, the server is the authority
- * (the framework's ADR-0057 D10 — framework numbering; this repo's own
- * ADR-0057 is an unrelated document), and hiding a permitted user's button on
- * missing client data is the worse failure. An EMPTY array is not unknown —
- * it means "holds
- * nothing" and gates normally.
+ * (the framework's ADR-0124 D1 — server enforces, client is courtesy), and
+ * hiding a permitted user's button on missing client data is the worse
+ * failure. An EMPTY array is not unknown — it means "holds nothing" and gates
+ * normally.
  */
 
 import { useCallback, useContext } from 'react';


### PR DESCRIPTION
Part of #5701

Re-anchors the eight citations of *"the server enforces; client-side gating is a usability
courtesy"* from the framework's `ADR-0057 D10` to the framework's **`ADR-0124 D1`** — the
record that actually decides that rule.

> ⚠️ **Deliberately `Part of`, not a closing keyword.** The dispatch asked for one here, but the
> card's own ruling says *"the card closes when both land"*, and the second half —
> `docs/adr/0036-field-conditional-rules.md` — is a **governed surface** that merges on a
> human's schedule (#5843). A closing keyword here would shut the card the moment
> this PR merges and orphan the ADR half, which is the outcome the two-PR split exists to
> avoid. Flip it if the card should close on this PR anyway — it is a one-word
> body edit.

## Why the old anchor is wrong

Framework `ADR-0057` **D10** decides *"Setup-nav surfacing follows the capability
(ADR-0029 K2); the object stays open"* — nav-entry tiering, not enforcement location. The
rule these eight sites invoke is decided by framework **`ADR-0124 D1`**, *"The server is
the enforcement point; client-side gating is a usability courtesy"* (Accepted 2026-08-18).

**The new anchor is derived from an authority, not chosen.** Framework `ADR-0057` carries a
note aimed at precisely this citation:

> ⚠️ **The general rule lives in ADR-0124, not here.** … **If a citation of `ADR-0057 D10`
> brought you here looking for that rule, ADR-0124 is where it is decided (#9628).**

#5699 addressed the *repo-ambiguity* half of this defect — saying whose ADR numbering the
citation meant — and deliberately left the anchor half untouched. This is that half.

## The eight sites

| # | Site |
|---|---|
| 1 | `packages/app-shell/src/views/RecordDetailView.tsx` |
| 2 | `packages/app-shell/src/views/studio-design/PackageOwdOverviewPanel.tsx` |
| 3 | `packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx` |
| 4 | `packages/plugin-detail/src/useRecordEditable.ts` |
| 5 | `packages/plugin-detail/src/useRecordEditable.test.tsx` |
| 6 | `packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts` |
| 7 | `packages/react/src/hooks/useCapabilityGate.ts` |
| 8 | `packages/core/src/evaluator/fieldRules.ts` — one of the two derivation authorities, which #5699 was correctly fenced out of because it already carried the framework qualifier; it pointed at the same wrong decision |

Comment text only. `git diff -U0` carries **zero** non-comment added or removed lines
(8 files, +19 / −23).

## The wording, and what retires with the number

No third phrasing was invented. The form now shipping is the `fieldRules.ts` authority's,
with the anchor moved:

```
the framework's ADR-0124 D1 — server enforces, client is courtesy
```

The disambiguating parenthetical #5699 shipped — *"framework numbering; this repo's own
ADR-0057 is an unrelated document"* — **retires with the number it disambiguated**. It
warned about a collision specific to `0057`; this repository has no `ADR-0124` at all (its
own series stops at `0059`), and framework `ADR-0124` records that a fresh, unambiguous
number was chosen *precisely so* citations of it would not need such a warning. The
`the framework's …` possessive stays at every site, so each one still says whose numbering
it means — which was #5699's actual fix.

Three comment tails were re-wrapped where the shorter citation left a ragged line
(`StudioDesignSurface.tsx`, `useRecordCrudVerdicts.ts`, `useCapabilityGate.ts`). One
pre-existing odd wrap inside the same re-wrapped paragraph — `it means "holds` /
`nothing" and gates normally` in `useCapabilityGate.ts` — was joined rather than left
dangling next to fresh text.

## Deliberately NOT touched

- ⛔ **`packages/data-objectstack/src/appAccessProbe.test.ts` — byte-untouched.** It cites
  `D10` for *"an app gated by an absent optional service"*, which the capability /
  service-gating family `D10` **genuinely does decide**. It is correct as it stands. The
  split here is per-site and was read, not pattern-matched: a blanket
  `grep -l | xargs sed` would have corrupted this file.
- ⛔ **The framework's own citations.** A meaningful share of them (`rest-server`'s
  `filterAppForUser`, the dashboard `requiresService` gates) are the family `D10` really
  decides. Not this repo's to change.
- **Published `CHANGELOG.md` entries (10 lines across 8 packages).** Historical release
  records; they are not rewritten after the fact.
- **`.changeset/adr-0057-d10-citation-attribution-5202.md`** — #5699's own still-unreleased
  changeset, which accurately narrates what #5699 did. Rewriting another change's record
  to match a later change would make it false. Both entries compile into the same release
  in chronological order.

## Enumeration — before and after, with controls

`grep -rn "ADR-0057 D10"` repo-wide, same pipeline every time.

| | total | live-source hits |
|---|---|---|
| base `5da008463` | 22 | **10** |
| this branch `68e0b9957` | 14 | **2** |

The 12 survivors that are not live source are the 10 `CHANGELOG.md` lines and the 2 lines
inside #5699's changeset, listed above. The 2 remaining **live-source** hits are
`appAccessProbe.test.ts:25` (correct, out of scope) and
`docs/adr/0036-field-conditional-rules.md:91`, which #5843 moves.

Composition of the two PRs, measured rather than asserted:

```
#5843 blob of docs/adr/0036 — "ADR-0057 D10" hits: 0
#5843 blob of docs/adr/0036 — "ADR-0124 D1"  hits: 1
this tree, live source, excluding docs/adr/0036: 1 hit
  packages/data-objectstack/src/appAccessProbe.test.ts:25
```

→ with both PRs landed, the **sole** surviving live-source `ADR-0057 D10` citation is the
one that is correct.

**Controls on the same pipeline**, so a broken grep cannot read as a clean sweep:
*positive* — `"absent optional service"` still returns 3 hits, including the untouched probe
test; *negative* — a sentinel string returns 0.

## Verification — all at `68e0b9957`

| Check | Result (the gate's own verdict line) |
|---|---|
| `pnpm exec vitest run` (7 targeted files, repo root, `--maxWorkers=2`) | `Test Files 7 passed (7)` · `Tests 95 passed (95)` |
| `type-check`, 5 affected packages | all `Done`, `0` × `error TS` |
| `check-changeset-presence.mjs` | `✅ 8 source file(s) of 5 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 4856 tracked text file(s); skipped 85 binary)` |
| `eslint` on the 8 touched files, `--format json` | `0` errors, `136` warnings — **identical to the same 8 files at base**: delta `errors +0, warnings +0` |

The suites cover all eight touched files: every one is imported and executed by at least one
of them, which is what actually catches a malformed comment edit.

`type-check` first ran red with `TS6305 … packages/types/dist/index.d.ts has not been
built` — the fresh-worktree false red. Re-run after building the dependency closure with
the caret-suffix filter form (`pnpm --workspace-concurrency=2 --filter '@object-ui/core^...' build`,
one per affected package); the numbers above are from the built closure.

**Lint narrowing, declared.** Repo-wide `pnpm lint` was not run locally; CI runs the farm
regardless. The narrowing to 8 files is a measurement, not a gap: `eslint.config.js` enables
**no type-aware linting** (no `parserOptions.project`, no `projectService`), so a file's
verdict depends only on its own text plus the config — this diff changes neither the config
nor any file outside the eight, so no untouched file's verdict can move. File count `8` is
read from eslint's own `--format json` output.

**Nothing to ablate.** These are comment-only changes with no behavioural leg — there is no
mutation that would make a test fail differently. Staging a decorative reverse-verification
would be theatre; the before/after enumeration above is the evidence.

## Companion PR

`docs/adr/0036-field-conditional-rules.md:91` — the wording all eight of these derive from,
carrying the same misattribution — moves in **#5843** because `docs/adr/**` is a
governed surface that stops at draft for human merge. Bundling it here would make eight
ordinary code changes wait on a human for no reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_