### PR TITLE
docs(adr-0036): re-anchor the enforcement-rule citation to the framework's `ADR-0124 D1` (#5701) [GOVERNED SURFACE — human merge]

### DIFF
--- a/docs/adr/0036-field-conditional-rules.md
+++ b/docs/adr/0036-field-conditional-rules.md
@@ -87,11 +87,10 @@ to locked, and `stripReadonlyWhenFields` — with its bulk twin
 incoming change is dropped exactly as a TRUE predicate's would be, and reported
 on the write response as a `droppedFields` entry with `reason: 'readonly_when'`.
 Enforcement belongs on the server — *server enforces, client is courtesy*, the
-rule the framework cites throughout its rule-validator, its lint diagnostics and
-its QA runner as **ADR-0057 D10** (that is the **framework's** ADR numbering;
-this repo's own ADR-0057, `0057-console-ai-chat-one-conversation-docked.md`, is
-an unrelated document) — and a declared lock that failed open would leave
-enforcement in the courtesy layer instead.
+rule the framework decides in **ADR-0124 D1** (framework ADR numbering) and
+practises throughout its rule-validator, its lint diagnostics and its QA runner
+— and a declared lock that failed open would leave enforcement in the courtesy
+layer instead.
 
 Everything else keeps the fail-open policy, deliberately:
 


### PR DESCRIPTION
Refs #5701

> ⛔ **GOVERNED SURFACE — this PR touches `docs/adr/**`. It stops at draft for human merge.**
> Do not flip it ready, do not enqueue it, do not enable auto-merge. It waits on a human's
> schedule by design.

Re-anchors the enforcement-rule citation in `docs/adr/0036-field-conditional-rules.md` from
the framework's `ADR-0057 D10` to the framework's **`ADR-0124 D1`**.

## Why this is a separate PR

This paragraph is the **wording every other citation of the rule in this repository derives
from** — so leaving it in place re-seeds the misattribution into anything written from it
next. That makes it required work, not optional.

But `docs/adr/**` is governed, and a PR touching it merges on a human's schedule. Bundling
it with the eight ordinary code sites would make those eight wait on a human for no reason,
so the sweep splits: the code sites ship in their own PR (see below), and the ADR waits
here.

## The change

One paragraph, `docs/adr/0036-field-conditional-rules.md:89-94`.

**Before**

> Enforcement belongs on the server — *server enforces, client is courtesy*, the rule the
> framework **cites** throughout its rule-validator, its lint diagnostics and its QA runner
> **as `ADR-0057 D10`** (that is the **framework's** ADR numbering; this repo's own
> ADR-0057, `0057-console-ai-chat-one-conversation-docked.md`, is an unrelated document) —
> and a declared lock that failed open would leave enforcement in the courtesy layer
> instead.

**After**

> Enforcement belongs on the server — *server enforces, client is courtesy*, the rule the
> framework **decides in `ADR-0124 D1`** (framework ADR numbering) and **practises**
> throughout its rule-validator, its lint diagnostics and its QA runner — and a declared
> lock that failed open would leave enforcement in the courtesy layer instead.

Three deliberate choices in that rewrite:

1. **"cites … as" → "decides in … and practises throughout".** `ADR-0124 D1` is the record
   that *decides* the rule; `ADR-0057 D10` was only ever *cited* for it. Keeping "cites as"
   with the new number would swap one inaccuracy for another.
2. **The rule-validator / lint-diagnostics / QA-runner triple is unchanged** — and is not a
   guess: framework `ADR-0124`'s own *Consumers* line names `validation/rule-validator.ts`,
   `@objectstack/lint`, and `docs/qa/platform-checklist` (RUNNER rule 4).
3. **The `0057`-collision parenthetical retires with the number it disambiguated.** It
   warned that this repo's own `ADR-0057` is an unrelated document; this repo has no
   `ADR-0124` at all (its own series stops at `0059`), and framework `ADR-0124` records that
   a fresh, unambiguous number was chosen precisely so its citations would not need such a
   warning. `(framework ADR numbering)` keeps the whose-numbering half.

## Why the old anchor is wrong

Framework `ADR-0057` **D10** decides *"Setup-nav surfacing follows the capability
(ADR-0029 K2); the object stays open"* — nav-entry tiering, not enforcement location. The
rule this paragraph asserts is decided by framework **`ADR-0124 D1`**, *"The server is the
enforcement point; client-side gating is a usability courtesy"* (Accepted 2026-08-18).

The new anchor is **derived from an authority, not chosen**: framework `ADR-0057` carries a
note aimed at exactly this citation — *"If a citation of `ADR-0057 D10` brought you here
looking for that rule, ADR-0124 is where it is decided (#9628)."*

## Verification — all at `b6fc3b5f5`

| Check | Result (the gate's own verdict line) |
|---|---|
| `check-doc-links.mjs` | `Links are valid across 13 scan roots.` |
| `check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 4855 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence.mjs` | `✅ No source of a released package changed in this range, so no changeset is owed.` |
| `pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts` | `Test Files 1 passed (1)` · `Tests 18 passed (18)` |

The changeset gate was **run, not assumed** — it reports that a docs-only diff owes nothing,
so no changeset is added. `doc-version-claims` guards against a bare version literal reaching
prose; none was written.

Prose-only change, one file, `+4 / −5`. **Nothing to ablate** — there is no behavioural leg
here, so no mutation could make a test fail differently; a staged reverse-verification would
be theatre.

## Companion PR

The eight code sites that derive their wording from this paragraph move in their own,
ordinary PR — it carries the full before/after enumeration showing that once both land, the
only surviving live-source `ADR-0057 D10` citation in this repo is
`packages/data-objectstack/src/appAccessProbe.test.ts`, which cites it for the
capability/service-gating case the decision genuinely does decide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_