### PR TITLE
feat(app-shell): one pending-drafts source of truth across every surface (#5801)

### DIFF
--- a/.changeset/unified-pending-drafts-5801.md
+++ b/.changeset/unified-pending-drafts-5801.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': minor
+---
+
+One pending-drafts source of truth (#5801): `usePendingDrafts` / `fetchPendingDrafts` replace the five hand-rolled `GET /api/v1/meta/_drafts` copies behind the home banner, Studio topbar 变更/待发布 buttons, chat pending-drafts bar, chat draft-card resolver, and the preview watermark bar. Every successful publish path (`usePublishAllDrafts`, Studio `doPublish`, the chat bar) now emits the assistant bus's metadata-refresh pulse, and a chat turn that staged or replayed drafts emits it on completion — so a publish or an agent-staged draft anywhere converges every surface at once, and the home banner no longer needs its post-publish `window.location.reload()`. An errored drafts read now uniformly reports UNKNOWN (null), never a fake zero.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1857,6 +1857,26 @@ export function ChatPane({
     onPackageBound?.(boundPackageId);
   }, [isBuildSurface, canBind, boundPackageId, editPackageId, isLoading, onPackageBound]);
 
+  // objectui#5801 — when a turn that STAGED or PUBLISHED something finishes,
+  // announce it on the bus so every pending-drafts surface (Studio topbar,
+  // home banner, the bar above this pane) converges immediately — previously
+  // an agent-staged draft lit only the chat bar (its own idle refetch) while
+  // the Studio topbar count stayed dark until a manual draft save. Precise on
+  // purpose: only turns whose tools carried an authoring envelope emit, so an
+  // ordinary Q&A turn does not trigger an env-wide registry refetch.
+  const lastAuthoringEmitRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (isLoading) return;
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
+    if (!lastAssistant || lastAssistant.id === lastAuthoringEmitRef.current) return;
+    const authored = (lastAssistant.toolInvocations ?? []).some(
+      (tool) => tool.draftReview || tool.replayOutcome,
+    );
+    if (!authored) return;
+    lastAuthoringEmitRef.current = lastAssistant.id;
+    emitMetadataRefresh();
+  }, [isLoading, messages]);
+
   // A1.b switcher menu: every published app with a package identity, deduped
   // by package (apps sharing a package share the build thread — the scope is
   // per-package). Selecting one navigates to its Edit-with-AI surface, which

--- a/packages/app-shell/src/console/ai/PendingDraftsBar.tsx
+++ b/packages/app-shell/src/console/ai/PendingDraftsBar.tsx
@@ -34,14 +34,15 @@
  * pending-drafts banner (environment-wide, not package-scoped).
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { CloudUpload, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { publishHealthFromResponse } from '@object-ui/plugin-chatbot';
-import { useMetadataClient } from '../../views/metadata-admin/useMetadata.js';
 import { useMetadata } from '../../providers/MetadataProvider.js';
+import { usePendingDrafts } from '../../preview/usePendingDrafts.js';
+import { emitMetadataRefresh } from '../../assistant/assistantBus.js';
 
 export interface PendingDraftsBarProps {
   /** The conversation's bound package (ADR-0057 A1.a); undefined = not bound yet. */
@@ -51,39 +52,23 @@ export interface PendingDraftsBarProps {
 }
 
 export function PendingDraftsBar({ packageId, idle }: PendingDraftsBarProps) {
-  const client = useMetadataClient();
   const { refresh } = useMetadata();
   const { t } = useObjectTranslation();
-  const [count, setCount] = useState(0);
   const [publishing, setPublishing] = useState(false);
-  // `useMetadataClient` caches per baseUrl+env, but this bar must not depend
-  // on that: an unstable client identity in the effect deps would refetch on
-  // every render. Read it through a ref; the effect keys on the FACTS that
-  // change the answer (binding, idleness, an explicit post-publish bump).
-  const clientRef = useRef(client);
-  clientRef.current = client;
-  const [version, setVersion] = useState(0);
+  // objectui#5801 — the shared pending-drafts source. The hook's bus
+  // subscription replaces the post-publish `version` bump AND picks up
+  // publishes made from OTHER surfaces (Studio topbar, home banner); the
+  // idle-edge effect below keeps "refetch when the turn finishes" — the agent
+  // may have just staged drafts.
+  const { count, refresh: refreshCount } = usePendingDrafts({
+    packageId,
+    enabled: Boolean(packageId),
+  });
 
   useEffect(() => {
-    if (!packageId) {
-      setCount(0);
-      return;
-    }
-    if (!idle) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const drafts = ((await clientRef.current.listDrafts?.({ packageId })) as unknown[]) || [];
-        if (!cancelled) setCount(Array.isArray(drafts) ? drafts.length : 0);
-      } catch {
-        // An older server without the drafts surface: no signal, no bar.
-        if (!cancelled) setCount(0);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [idle, packageId, version]);
+    if (!packageId || !idle) return;
+    void refreshCount();
+  }, [idle, packageId, refreshCount]);
 
   const publish = useCallback(async () => {
     if (!packageId || publishing) return;
@@ -116,19 +101,21 @@ export function PendingDraftsBar({ packageId, idle }: PendingDraftsBarProps) {
         toast.success(t('console.ai.pendingDrafts.published', { defaultValue: 'All pending changes are live.' }));
       }
       // The launcher/nav may have just gained entries — refresh the shared
-      // metadata so the user's next click finds them.
+      // metadata so the user's next click finds them, and announce the publish
+      // on the bus so every other pending-drafts surface (home banner, Studio
+      // topbar) converges too (objectui#5801).
       try {
         await refresh?.();
       } catch {
         /* metadata refresh is best-effort */
       }
+      emitMetadataRefresh();
     } finally {
       setPublishing(false);
-      setVersion((v) => v + 1);
     }
   }, [packageId, publishing, refresh, t]);
 
-  if (!packageId || count <= 0) return null;
+  if (!packageId || (count ?? 0) <= 0) return null;
 
   return (
     <div

--- a/packages/app-shell/src/console/ai/__tests__/PendingDraftsBar.test.tsx
+++ b/packages/app-shell/src/console/ai/__tests__/PendingDraftsBar.test.tsx
@@ -19,12 +19,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import { PendingDraftsBar } from '../PendingDraftsBar.js';
 
-const listDrafts = vi.fn();
 const refresh = vi.fn();
+// objectui#5801 — the bar reads its count from the shared `_drafts` fetch;
+// the stub routes by URL: drafts reads answer `draftRows`, publish POSTs 200.
+let draftRows: Array<Record<string, unknown>> = [];
 
-vi.mock('../../../views/metadata-admin/useMetadata.js', () => ({
-  useMetadataClient: () => ({ listDrafts }),
-}));
 vi.mock('../../../providers/MetadataProvider.js', () => ({
   useMetadata: () => ({ refresh }),
 }));
@@ -34,7 +33,16 @@ vi.mock('@object-ui/plugin-chatbot', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ success: true }) })));
+  draftRows = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: unknown) => {
+      if (String(url).includes('/meta/_drafts')) {
+        return { ok: true, status: 200, json: async () => draftRows };
+      }
+      return { ok: true, status: 200, json: async () => ({ success: true }) };
+    }),
+  );
 });
 afterEach(() => {
   cleanup();
@@ -43,9 +51,14 @@ afterEach(() => {
 
 describe('PendingDraftsBar (objectui#5694)', () => {
   it('renders nothing when the package has no pending drafts, and nothing when unbound', async () => {
-    listDrafts.mockResolvedValue([]);
+    draftRows = [];
     const { container, rerender } = render(<PendingDraftsBar packageId="app.k9qk" idle />);
-    await waitFor(() => expect(listDrafts).toHaveBeenCalledWith({ packageId: 'app.k9qk' }));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/meta/_drafts?packageId=app.k9qk',
+        expect.objectContaining({ credentials: 'include' }),
+      ),
+    );
     expect(container.querySelector('[data-testid="pending-drafts-bar"]')).toBeNull();
     rerender(<PendingDraftsBar packageId={undefined} idle />);
     expect(container.querySelector('[data-testid="pending-drafts-bar"]')).toBeNull();
@@ -53,14 +66,15 @@ describe('PendingDraftsBar (objectui#5694)', () => {
 
   it('shows the count while drafts are pending, publishes through publish-drafts, then hides', async () => {
     // One pending dashboard draft (the cloud#1584 shape) until published.
-    listDrafts.mockResolvedValue([{ type: 'dashboard', name: 'task_dashboard', packageId: 'app.k9qk' }]);
+    draftRows = [{ type: 'dashboard', name: 'task_dashboard', packageId: 'app.k9qk' }];
     const { container } = render(<PendingDraftsBar packageId="app.k9qk" idle />);
     await waitFor(() =>
       expect(container.querySelector('[data-testid="pending-drafts-bar"]')).toBeTruthy(),
     );
 
-    // Publishing empties the pending set on the post-publish refetch.
-    listDrafts.mockResolvedValue([]);
+    // Publishing empties the pending set on the post-publish refetch (the
+    // bus pulse the publish emits drives it through the shared hook).
+    draftRows = [];
     const bar = container.querySelector('[data-testid="pending-drafts-bar"]') as HTMLElement;
     const button = bar.querySelector('button');
     if (!button) throw new Error('no button. bar html: ' + bar.outerHTML.slice(0, 500));

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -36,7 +36,7 @@ import {
 } from '../../utils/index.js';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
 import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText, Hammer, LayoutTemplate } from 'lucide-react';
-import { useMetadataClient } from '../../views/metadata-admin/useMetadata.js';
+import { usePendingDrafts } from '../../preview/usePendingDrafts.js';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts.js';
 import { resolveAiApiBase } from '../../hooks/useAiSurface.js';
 import { isAiStudioEnabled, isMarketplaceEnabled } from '../../runtime-config.js';
@@ -231,38 +231,22 @@ function pickGreetingKey(hour: number): string {
  * (listDrafts → 0).
  */
 function PendingDraftsBanner({ t }: { t: (key: string, opts?: any) => string }) {
-  const client = useMetadataClient();
-  const [drafts, setDrafts] = useState<Array<{ type: string; name: string }>>([]);
   // Shared one-click publish (also used by the ADR-0037 draft-preview bar):
   // packages via the probed publish-drafts path, orphans by reference, health
   // surfaced in toasts. See usePublishAllDrafts for the full story.
   const { publishAll, publishing } = usePublishAllDrafts(t);
-  const count = drafts.length;
-
-  useEffect(() => {
-    let cancelled = false;
-    Promise.resolve(client.listDrafts?.({}))
-      .then((rows) => {
-        if (cancelled || !Array.isArray(rows)) return;
-        setDrafts(
-          rows
-            .filter((d: any) => d && typeof d.type === 'string' && typeof d.name === 'string')
-            .map((d: any) => ({ type: d.type, name: d.name })),
-        );
-      })
-      .catch(() => { /* drafts unsupported / error → don't show */ });
-    return () => { cancelled = true; };
-  }, [client]);
+  // objectui#5801 — env-wide scope, from the shared pending-drafts source.
+  // The bus subscription inside the hook replaces both the mount-only fetch
+  // (which never saw later edits) and the post-publish window.location.reload
+  // (publishAll now emits the metadata-refresh pulse; the launcher/nav refresh
+  // through MetadataProvider's subscription to the same pulse).
+  const { count } = usePendingDrafts({});
 
   const publish = async () => {
-    const result = await publishAll();
-    if (!result.ok) return;
-    setDrafts([]);
-    // Surface the now-live app — reload so the populated home shows it.
-    setTimeout(() => { try { window.location.reload(); } catch { /* ignore */ } }, 700);
+    await publishAll();
   };
 
-  if (count <= 0) return null;
+  if ((count ?? 0) <= 0) return null;
   return (
     <div className="px-4 sm:px-6 lg:px-8 pt-4">
       <div className="max-w-7xl mx-auto">

--- a/packages/app-shell/src/preview/DraftChangesPanel.tsx
+++ b/packages/app-shell/src/preview/DraftChangesPanel.tsx
@@ -49,6 +49,7 @@ import { useObjectTranslation } from '@object-ui/i18n';
 // ⛔ Do not "optimize" this into a local copy of the spelling table: a
 // spec-named local declaration is what `scripts/check-spec-symbol-derivation.mjs`
 // refuses, and a faithful copy is exactly the fork that guard exists to prevent.
+import { fetchPendingDrafts } from './usePendingDrafts.js';
 import { canonicalMetaUrlType } from '@objectstack/spec/shared';
 import { diffFields } from '../views/metadata-admin/previews/object-fields-io.js';
 // The live `?surface=` channel, and NOT `useSurfaceDeepLink` beside it: this
@@ -75,19 +76,10 @@ export interface DraftChangeEntry {
 
 /** Pending drafts straight from the ADR-0033 `_drafts` endpoint. */
 async function listPendingDrafts(packageId?: string | null): Promise<DraftChangeEntry[]> {
-  const qs = packageId ? `?packageId=${encodeURIComponent(packageId)}` : '';
-  const res = await fetch(`/api/v1/meta/_drafts${qs}`, {
-    credentials: 'include',
-    headers: { Accept: 'application/json' },
-    cache: 'no-store',
-  });
-  if (!res.ok) throw new Error(`_drafts HTTP ${res.status}`);
-  const data = (await res.json()) as
-    | Array<Record<string, unknown>>
-    | { drafts?: Array<Record<string, unknown>> };
-  const list = Array.isArray(data) ? data : data?.drafts ?? [];
-  return list
-    .filter((d) => typeof d?.type === 'string' && typeof d?.name === 'string')
+  // Shared fetch (objectui#5801); the fold below stays HERE because this module
+  // builds `/meta` item URLs from the type.
+  const rows = await fetchPendingDrafts(packageId);
+  return rows
     .map((d) => ({
       // The one fold, at the one boundary where a stored spelling enters this
       // module: the `/meta` type segment is singular, always (objectstack#9180).
@@ -107,9 +99,9 @@ async function listPendingDrafts(packageId?: string | null): Promise<DraftChange
       // `replace(/s$/, '')` emits `capabilitie`. And this is EMIT-side only —
       // residue stored under a plural type stays exactly as it is on the
       // server; nothing here writes, migrates or re-keys anything.
-      type: canonicalMetaUrlType(d.type as string),
-      name: d.name as string,
-      packageId: typeof d.packageId === 'string' && d.packageId ? (d.packageId as string) : null,
+      type: canonicalMetaUrlType(d.type),
+      name: d.name,
+      packageId: d.packageId,
     }));
 }
 

--- a/packages/app-shell/src/preview/DraftPreviewBar.tsx
+++ b/packages/app-shell/src/preview/DraftPreviewBar.tsx
@@ -20,6 +20,7 @@ import { Eye, X, Rocket, GitCompareArrows, Sparkles } from 'lucide-react';
 import { Button, cn } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { usePreviewDrafts, markPreviewExit, PREVIEW_QUERY_FLAG } from './PreviewModeContext.js';
+import { usePendingDrafts } from './usePendingDrafts.js';
 import { usePublishAllDrafts } from './usePublishAllDrafts.js';
 import { DraftChangesPanel } from './DraftChangesPanel.js';
 
@@ -31,30 +32,14 @@ export function DraftPreviewBar() {
   const { publishAll, publishing } = usePublishAllDrafts(t);
   const [changesOpen, setChangesOpen] = useState(false);
   // Pending-draft count for the Changes button label — what Publish will
-  // actually promote. Refreshed per pathname so drafts staged while the
-  // preview is open (the chat keeps building) update the count.
-  const [pendingCount, setPendingCount] = useState<number | null>(null);
+  // actually promote. The shared source (objectui#5801) refreshes on the
+  // metadata-refresh pulse; the pathname effect keeps the old "drafts staged
+  // while the preview is open" trigger too.
+  const { count: pendingCount, refresh: refreshPending } = usePendingDrafts({ enabled: Boolean(preview) });
   useEffect(() => {
     if (!preview) return;
-    let cancelled = false;
-    void fetch('/api/v1/meta/_drafts', {
-      credentials: 'include',
-      headers: { Accept: 'application/json' },
-      cache: 'no-store',
-    })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (cancelled || !data) return;
-        const list = Array.isArray(data) ? data : data?.drafts ?? [];
-        setPendingCount(Array.isArray(list) ? list.length : null);
-      })
-      .catch(() => {
-        /* count is decorative — the panel itself reports errors */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [preview, location.pathname]);
+    void refreshPending();
+  }, [preview, location.pathname, refreshPending]);
 
   if (!preview) return null;
 

--- a/packages/app-shell/src/preview/draftStatus.ts
+++ b/packages/app-shell/src/preview/draftStatus.ts
@@ -18,15 +18,8 @@
  * Cookie-authenticated like every other console call; tolerant of both
  * response shapes (`[...]` and `{ drafts: [...] }`).
  */
+import { fetchPendingDrafts } from './usePendingDrafts.js';
+
 export async function fetchPendingDraftCount(packageId: string): Promise<number> {
-  const res = await fetch(
-    `/api/v1/meta/_drafts?packageId=${encodeURIComponent(packageId)}`,
-    { credentials: 'include', headers: { Accept: 'application/json' }, cache: 'no-store' },
-  );
-  if (!res.ok) throw new Error(`_drafts HTTP ${res.status}`);
-  const data = (await res.json()) as
-    | unknown[]
-    | { drafts?: unknown[]; data?: { drafts?: unknown[] } };
-  const list = Array.isArray(data) ? data : data?.drafts ?? data?.data?.drafts ?? [];
-  return Array.isArray(list) ? list.length : 0;
+  return (await fetchPendingDrafts(packageId)).length;
 }

--- a/packages/app-shell/src/preview/usePendingDrafts.test.tsx
+++ b/packages/app-shell/src/preview/usePendingDrafts.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#5801 — the ONE pending-drafts data source. Pinned here:
+ *  - every response shape a deployed `_drafts` endpoint has answered with;
+ *  - the scope param;
+ *  - the bus subscription (a publish anywhere converges this hook);
+ *  - `enabled:false` holds fetching and clears state (no stale count when a
+ *    conversation loses its package binding).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { usePendingDrafts, fetchPendingDrafts } from './usePendingDrafts.js';
+import { emitMetadataRefresh } from '../assistant/assistantBus.js';
+
+const draftsRow = { type: 'object', name: 'task', packageId: 'app.k9qk' };
+
+function stubFetch(payload: unknown, ok = true) {
+  const fn = vi.fn(async () => ({ ok, status: ok ? 200 : 500, json: async () => payload }));
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchPendingDrafts — response-shape tolerance', () => {
+  it.each([
+    ['bare array', [draftsRow]],
+    ['{drafts} envelope', { drafts: [draftsRow] }],
+    ['{data:{drafts}} envelope', { data: { drafts: [draftsRow] } }],
+  ])('parses the %s shape', async (_label, payload) => {
+    stubFetch(payload);
+    const rows = await fetchPendingDrafts();
+    expect(rows).toEqual([{ type: 'object', name: 'task', packageId: 'app.k9qk' }]);
+  });
+
+  it('scopes by packageId via the query string', async () => {
+    const fn = stubFetch([]);
+    await fetchPendingDrafts('app.k9qk');
+    expect(fn).toHaveBeenCalledWith(
+      '/api/v1/meta/_drafts?packageId=app.k9qk',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('drops malformed rows and normalizes a missing packageId to null', async () => {
+    stubFetch([draftsRow, { type: 'view' }, { name: 'x' }, { type: 'seed', name: 's' }]);
+    const rows = await fetchPendingDrafts();
+    expect(rows).toEqual([
+      { type: 'object', name: 'task', packageId: 'app.k9qk' },
+      { type: 'seed', name: 's', packageId: null },
+    ]);
+  });
+});
+
+describe('usePendingDrafts', () => {
+  it('loads on mount and refreshes on the metadata-refresh pulse — the unification edge', async () => {
+    const fn = stubFetch([draftsRow]);
+    const { result } = renderHook(() => usePendingDrafts({ packageId: 'app.k9qk' }));
+    await waitFor(() => expect(result.current.count).toBe(1));
+
+    stubFetch([]); // the publish emptied the drafts
+    act(() => {
+      emitMetadataRefresh();
+    });
+    await waitFor(() => expect(result.current.count).toBe(0));
+    expect(fn).toHaveBeenCalledTimes(1); // first stub used exactly once
+  });
+
+  it('enabled:false holds fetching and clears state', async () => {
+    const fn = stubFetch([draftsRow]);
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => usePendingDrafts({ packageId: 'p', enabled }),
+      { initialProps: { enabled: true } },
+    );
+    await waitFor(() => expect(result.current.count).toBe(1));
+    rerender({ enabled: false });
+    await waitFor(() => expect(result.current.count).toBeNull());
+    const calls = fn.mock.calls.length;
+    act(() => {
+      emitMetadataRefresh();
+    });
+    expect(fn.mock.calls.length).toBe(calls); // pulse ignored while disabled
+  });
+
+  it('an errored read reports UNKNOWN (null), never a stale count and never a fake zero', async () => {
+    stubFetch(null, false);
+    const { result } = renderHook(() => usePendingDrafts({}));
+    // stays null: fail-safe consumers (preview bar) treat unknown ≠ empty
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.count).toBeNull();
+    expect(result.current.entries).toEqual([]);
+  });
+});

--- a/packages/app-shell/src/preview/usePendingDrafts.ts
+++ b/packages/app-shell/src/preview/usePendingDrafts.ts
@@ -1,0 +1,123 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5801 — the ONE pending-drafts data source.
+ *
+ * "Has unpublished changes" used to be answered by five surfaces with five
+ * hand-rolled copies of the same `GET /api/v1/meta/_drafts` fetch (home
+ * banner, Studio topbar, chat bar, chat draft-card resolver, preview
+ * watermark), each with its own refresh trigger and none of them telling the
+ * others when a publish happened — measured live: the home banner reported
+ * 1 pending change while the Studio topbar reported none, and a publish from
+ * the Studio dock never updated the Studio topbar count.
+ *
+ * This module is the single copy:
+ *  - {@link fetchPendingDrafts} is the fetch + response-shape tolerance
+ *    (`[...]`, `{drafts}`, `{data:{drafts}}` — every shape a deployed server
+ *    has answered with).
+ *  - {@link usePendingDrafts} keeps a live count/entry list for a scope and
+ *    subscribes to the assistant bus's metadata-refresh pulse, so ANY
+ *    publish/install that announces itself converges every surface at once.
+ *
+ * Publishing deliberately stays with each surface (their failure handling and
+ * toasts differ on purpose); the contract is that every successful publish
+ * path calls `emitMetadataRefresh()` — that pulse, plus this hook, is the
+ * whole unification mechanism.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { subscribeMetadataRefresh } from '../assistant/assistantBus.js';
+
+export interface PendingDraftEntry {
+  /** Raw stored type — callers that build `/meta` URLs must fold it themselves. */
+  type: string;
+  name: string;
+  packageId: string | null;
+}
+
+export async function fetchPendingDrafts(
+  packageId?: string | null,
+): Promise<PendingDraftEntry[]> {
+  const qs = packageId ? `?packageId=${encodeURIComponent(packageId)}` : '';
+  const res = await fetch(`/api/v1/meta/_drafts${qs}`, {
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`_drafts HTTP ${res.status}`);
+  const data = (await res.json()) as
+    | Array<Record<string, unknown>>
+    | { drafts?: Array<Record<string, unknown>>; data?: { drafts?: Array<Record<string, unknown>> } };
+  const list = Array.isArray(data) ? data : (data?.drafts ?? data?.data?.drafts ?? []);
+  return (Array.isArray(list) ? list : [])
+    .filter((d) => typeof d?.type === 'string' && typeof d?.name === 'string')
+    .map((d) => ({
+      type: d.type as string,
+      name: d.name as string,
+      packageId: typeof d.packageId === 'string' && d.packageId ? (d.packageId as string) : null,
+    }));
+}
+
+export interface UsePendingDraftsOptions {
+  /** Scope: a packageId for per-app surfaces, undefined/null for env-wide. */
+  packageId?: string | null;
+  /** False = hold fetching (e.g. no bound package yet). Default true. */
+  enabled?: boolean;
+}
+
+export interface UsePendingDraftsResult {
+  /** null until the first successful read (lets callers hold rendering). */
+  count: number | null;
+  entries: PendingDraftEntry[];
+  /** Manual refetch — for surface-local triggers (draft saved, turn idle). */
+  refresh: () => Promise<void>;
+}
+
+export function usePendingDrafts(opts: UsePendingDraftsOptions = {}): UsePendingDraftsResult {
+  const { packageId, enabled = true } = opts;
+  const [entries, setEntries] = useState<PendingDraftEntry[]>([]);
+  const [count, setCount] = useState<number | null>(null);
+  // A single in-flight guard + generation counter: a refresh started before a
+  // scope change must not land its stale answer on the new scope.
+  const genRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    const gen = ++genRef.current;
+    try {
+      const list = await fetchPendingDrafts(packageId);
+      if (genRef.current !== gen) return;
+      setEntries(list);
+      setCount(list.length);
+    } catch {
+      // An errored read means UNKNOWN, not zero: count stays null so surfaces
+      // that must fail SAFE on unknown (the preview bar keeps its Publish
+      // visible) can tell the difference from a known-empty ledger; count-only
+      // banners hide on null exactly as they hide on 0.
+      if (genRef.current !== gen) return;
+      setEntries([]);
+      setCount(null);
+    }
+  }, [packageId, enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      genRef.current++;
+      setEntries([]);
+      setCount(null);
+      return;
+    }
+    void refresh();
+    return subscribeMetadataRefresh(() => {
+      void refresh();
+    });
+  }, [refresh, enabled]);
+
+  return { count, entries, refresh };
+}

--- a/packages/app-shell/src/preview/usePublishAllDrafts.ts
+++ b/packages/app-shell/src/preview/usePublishAllDrafts.ts
@@ -22,6 +22,7 @@ import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 import { publishHealthFromResponse, type PublishHealth } from '@object-ui/plugin-chatbot';
 import { useMetadataClient } from '../views/metadata-admin/useMetadata.js';
+import { emitMetadataRefresh } from '../assistant/assistantBus.js';
 import { lintDraftCapabilityReferences } from './capabilityLint.js';
 
 type TranslateFn = (key: string, opts?: Record<string, unknown>) => string;
@@ -127,6 +128,9 @@ export function usePublishAllDrafts(t: TranslateFn) {
           { description: capWarnings[0], duration: 10000 },
         );
       }
+      // objectui#5801 — announce the publish so every pending-drafts surface
+      // (home banner, Studio topbar, chat bar) converges without a reload.
+      emitMetadataRefresh();
       return { ok: true, attempted: pending.length };
     } catch (e) {
       toast.error(

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -87,6 +87,8 @@ import {
   navIdAtPosition,
 } from '../metadata-admin/nav-selection.js';
 import { SourcePageEditor } from '../metadata-admin/previews/SourcePageEditor.js';
+import { usePendingDrafts } from '../../preview/usePendingDrafts.js';
+import { emitMetadataRefresh } from '../../assistant/assistantBus.js';
 import { formatMetadataError, formatPublishFailures, type PublishFailure } from './metadataError.js';
 import { loadPackageSurfaces } from './packageSurfaces.js';
 import { resolveSurface, findSurfaceInTree, type NavNode, type Surface } from './navSurface.js';
@@ -479,26 +481,15 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
   // one atomic pass (POST /packages/:id/publish-drafts), reviewed as a whole in
   // DraftChangesPanel. There is no per-item publish.
   const [changesOpen, setChangesOpen] = React.useState(false);
-  const [pendingCount, setPendingCount] = React.useState<number | null>(null);
   const [publishing, setPublishing] = React.useState(false);
   const [publishNonce, setPublishNonce] = React.useState(0); // ↑ → pillars re-read the published baseline
   const [draftNonce, setDraftNonce] = React.useState(0); // ↑ → refresh the pending-draft count
 
-  const refreshPending = React.useCallback(async () => {
-    try {
-      const res = await fetch(`/api/v1/meta/_drafts?packageId=${encodeURIComponent(packageId)}`, {
-        credentials: 'include',
-        headers: { Accept: 'application/json' },
-        cache: 'no-store',
-      });
-      if (!res.ok) return setPendingCount(null);
-      const data = (await res.json()) as unknown;
-      const list = (Array.isArray(data) ? data : ((data as { drafts?: unknown[] })?.drafts ?? [])) as unknown[];
-      setPendingCount(list.length);
-    } catch {
-      setPendingCount(null);
-    }
-  }, [packageId]);
+  // objectui#5801 — the shared pending-drafts source: same fetch, same count,
+  // and the assistant bus's metadata-refresh pulse keeps this topbar in step
+  // with every OTHER surface's publishes (chat bar, home banner) — previously
+  // a publish from the right dock never updated this count.
+  const { count: pendingCount, refresh: refreshPending } = usePendingDrafts({ packageId });
 
   React.useEffect(() => {
     void refreshPending();
@@ -535,6 +526,9 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
         setChangesOpen(false);
       }
       setPublishNonce((n) => n + 1);
+      // objectui#5801 — announce the publish so the chat bar / home banner /
+      // draft cards converge without their own polling.
+      emitMetadataRefresh();
     } catch (e) {
       toast.error(formatMetadataError(e));
     } finally {


### PR DESCRIPTION
Closes #5801 (cloud#1609 增量三, first of the agreed order 三→四∥一→二).

Grounded in the live reality audit: five surfaces, five hand-rolled `_drafts` fetches, and no publish announced itself — the home banner said 「1 项未发布」 while the Studio topbar said 「没有待发布的草稿」 on the same screen, and a publish from the Studio dock never updated the Studio topbar.

- **One source**: `usePendingDrafts` / `fetchPendingDrafts` (single fetch, all three deployed response shapes, errored read = UNKNOWN not fake-zero) adopted by the home banner, Studio topbar, chat bar, chat draft-card resolver, preview watermark, and the 变更 review panel.
- **One pulse**: every successful publish path emits `emitMetadataRefresh()`; a chat turn that staged/replayed drafts emits on completion (precise: ordinary Q&A turns don't). The hook subscribes — 聊天里改 → Studio 顶栏即亮；Studio 发布 → 聊天横幅即清.
- Home banner's post-publish `window.location.reload()` retired.

505 files / 4917 tests green. Per the release directive: staging-only until prod is authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)