### PR TITLE
docs(components): drop the retired element:filter from the elements.tsx header note

### DIFF
--- a/.changeset/4935-element-filter-comment-residue.md
+++ b/.changeset/4935-element-filter-comment-residue.md
@@ -1,0 +1,8 @@
+---
+---
+
+Comment-only cleanup in `@object-ui/components`: the `elements.tsx` header note no
+longer lists `element:filter` among the heavier interactive elements said to live in
+their owning plugins. No such file ever existed for it, and the element was retired at
+element grain upstream (ADR-0049), so the type is gone from `PageComponentType`
+entirely. No published behaviour changes.

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -15,9 +15,9 @@
  *   - element:divider                            (no-props separator)
  *   - ElementButtonProps  -> element:button
  *
- * Heavier interactive elements (element:filter, element:form) live in their
- * owning plugins and are left to those packages. element:record_picker — which
- * writes its selection into a page variable — ships alongside in `./record-picker`.
+ * Heavier interactive elements (element:form) live in their owning plugins and
+ * are left to those packages. element:record_picker — which writes its
+ * selection into a page variable — ships alongside in `./record-picker`.
  *
  * All props are read off `schema.properties` per the spec's
  * `UIComponent.properties` convention; `schema.props` is also accepted


### PR DESCRIPTION
Fixes #4935

Comment-only cleanup. The `elements.tsx` header note listed `element:filter` among the "heavier interactive elements" said to live in their owning plugins. No such file ever existed for it, and the element was retired at element grain upstream (ADR-0049), so the type is now absent from `PageComponentType` entirely — the claim was stale twice over.

```diff
- * Heavier interactive elements (element:filter, element:form) live in their
- * owning plugins and are left to those packages. element:record_picker — which
- * writes its selection into a page variable — ships alongside in `./record-picker`.
+ * Heavier interactive elements (element:form) live in their owning plugins and
+ * are left to those packages. element:record_picker — which writes its
+ * selection into a page variable — ships alongside in `./record-picker`.
```

A pure token deletion plus a re-wrap of the paragraph it orphaned.

## Scope — residue 2 only; residue 1 was already gone

The card's body names two residues and is stale. `PALETTE_EXCLUSIONS['element:filter']` in `packages/app-shell/src/views/metadata-admin/previews/block-types.ts` was already deleted in #5529, which had to touch that file once the enum member disappeared. Re-measured on `origin/main` @ `d40d2953e`: **zero `element:filter` hits in `block-types.ts`**, while `element:form` still hits that same file on the same grep — so the zero is a real reading of a reachable file, not a wrong-path artefact. Nothing was re-deleted there and this PR does not touch that file.

⛔ Only the `element:filter` half of the sentence is fixed. The `element:form` half is objectstack#9249's open question, and the diff above leaves its claim byte-identical apart from where the line wraps. That question is not answered here.

## Precondition, counter-probed

`PageComponentType`, read from the `@objectstack/spec` pinned in this worktree:

| probe | result |
|---|---|
| member count | 34 |
| `element:text` | `true` — known-present control |
| `element:button` | `true` — known-present control |
| `element:form` | `true` — known-present control |
| **`element:filter`** | **`false`** |
| `zzNotARealPageComponentType` | `false` — never-existed sentinel |

Recorded because it matters: the first probe returned `false` for *every* key, controls included — it read the package root export instead of the `@objectstack/spec/ui` subpath. A bare `false` on the target would have looked like a passing reading. That run was discarded; the table is from the corrected probe.

## Repo-wide enumeration, before and after

Same pipeline both times, with `element:form` as a positive control and `element:zzNotAThing` as a sentinel (0 hits, as expected).

**Before** — 7 hits in 6 files. **After** — 7 hits in 6 files: `elements.tsx` drops out, this PR's own changeset joins. What survives, and why none of it is sweepable:

| survivor | why it stays |
|---|---|
| `.changeset/4935-element-filter-comment-residue.md` | this PR's changeset; it names the token in order to describe the change |
| `.changeset/spec-pin-17-1-0-5328.md` | landed changeset — a historical record, never rewritten |
| `packages/app-shell/CHANGELOG.md:12391` | published CHANGELOG — historical record, never rewritten |
| `docs/audits/2901-spec-enum-renderer-coverage.md:99` | a version-anchored audit ("Audited against …", re-validated against a named release). A frozen point-in-time census, same class as a CHANGELOG — not stale prose to fix |
| `…/previews/__tests__/palette-discussion-alias.test.tsx:92` | **live assertion** — `expect(specNames).not.toContain('element:filter')` is what pins the absence. Removing it would be deleting the guard |
| `packages/test-support/src/__tests__/spec-tombstones.test.ts:242,274` | live test comments using `element:filter` as the discriminating case for tombstone ordering |

So `elements.tsx:18` was the only removable residue left in the repo.

## Verification

Gate union re-run on the final commit `100ecc1b6`; the working tree is identical to HEAD (empty `git status --porcelain`), so the longer runs below cover this same tree.

| check | result |
|---|---|
| `pnpm exec vitest run` — changed dir + the three tests that pin the retirement facts | `Test Files 5 passed (5)`, `Tests 64 passed (64)` |
| `pnpm exec vitest run packages/components/` (whole affected package) | `Test Files 181 passed (181)`, `Tests 1656 passed (1656)` |
| `@object-ui/components` `lint` | `✖ 906 problems (0 errors, 906 warnings)` — 0 errors; warnings are the pre-existing baseline |
| `@object-ui/components` `type-check` | exit 0 |
| `check-changeset-presence` | `✅ … declares 1 changeset(s)` — empty frontmatter, the explicit "releases nothing" answer |
| `check-control-bytes` | `✅ OK (scanned 4869 tracked text file(s))` |
| `check-changeset-no-major` / `check-changeset-fixed` | `✅` both |

Two notes on how those readings were taken, since both are traps this repo has been bitten by:

- vitest was run **from the repo root** with relative paths and no `--`; its banner reports the root as the worktree root, so the `apps/console` 22-file false-green is not in play.
- the first `type-check` failed with `TS2307: Cannot find module '@object-ui/core'` — the unbuilt-dependency trap in a fresh worktree, not this diff. Fixed properly by building the dependency closure (`pnpm --filter '@object-ui/components^...' build`) and re-running; it is the re-run that reports exit 0.

**No ablation, and no decorative substitute for one.** This diff is a comment; it has no behavioural leg to remove and no assertion whose red/green could be flipped by reverting it. Staging a reverse-verification here would produce a number that means nothing, so none was run.

## Changeset

Empty-frontmatter (`---` / `---`), declaring that this releases nothing. The changeset gate rejected the diff without one — a comment in a released package's `src/` still owes the declaration — and accepts the empty form as a complete answer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_