### PR TITLE
fix(dashboard): sort a numeric measure column descending on the first click

### DIFF
--- a/.changeset/dashboard-table-measure-desc-first-5845.md
+++ b/.changeset/dashboard-table-measure-desc-first-5845.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/plugin-dashboard': minor
+---
+
+Dashboard `table` widget — a numeric **measure** column now sorts **descending
+on the first click** (objectui#5845).
+
+The sortable headers shipped in objectui#5827 started every column ascending,
+which left the card's own motivating complaint — the largest industry rendering
+last — two clicks away. For a measure in an analytics widget the question a
+click asks is "who is biggest", so that column now cycles
+**descending → ascending → the dataset's own order**.
+
+Unchanged: a **dimension** column, and a measure whose values are not numbers
+(a `min()`/`max()` over a text field), keep **ascending → descending → the
+dataset's own order** — the idiom the console's own DataTable uses. The
+first-click direction is decided by the same measure-and-all-values-are-numbers
+classification that decides right-alignment, so it follows the column's *role*
+rather than "it looks like digits": a digit-keyed dimension (a year, a quarter)
+still starts ascending.
+
+Blanks still sort **last in both directions** — that arm is now what a measure
+column's very first click runs — and `aria-sort` reports the direction actually
+applied.

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -1130,7 +1130,10 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
             // Blanks last in BOTH directions. `compareSortValues` places them
             // last ascending and documents that callers negate for descending —
             // negation would float them to the top, so the blank arm is settled
-            // BEFORE the direction is applied and never inside it.
+            // BEFORE the direction is applied and never inside it. Since
+            // objectui#5845 the descending arm is what a measure column's
+            // FIRST click runs, so this is now the very first thing a user
+            // exercises rather than the second.
             if (a.key === null && b.key === null) return 0;
             if (a.key === null) return 1;
             if (b.key === null) return -1;
@@ -1151,18 +1154,35 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
           return 0;
         });
 
-    // asc → desc → back to the default order. Three states, not the two a
-    // server-paged grid offers: here the default IS a meaningful order (the
-    // dataset's own, which an author can set via `options.sortBy`), so a header
-    // has to be able to hand it back.
+    // ── First-click direction (objectui#5845) ───────────────────────────
+    // A numeric MEASURE starts DESCENDING; everything else starts ascending.
+    // The question a click asks of a measure is "who is biggest" — the very
+    // complaint objectui#5827 opened on (Technology, the largest industry,
+    // rendering last) — and one click answering it is what every analytics
+    // table does. A dimension is a grouping axis, where A→Z is the idiom the
+    // console's DataTable uses and this table keeps.
+    //
+    // The predicate is `numericColumns`, the SAME set that decides
+    // right-alignment: first-click direction is a property of the column's
+    // ROLE (a measure whose values really are numbers), not of "it looks like
+    // digits". So a digit-keyed dimension (a year, a quarter) still starts
+    // ascending, and so does a `min()`/`max()` over a text field.
+    const firstDir = (c: string): 'asc' | 'desc' => (numericColumns.has(c) ? 'desc' : 'asc');
+    // <first> → <the other one> → back to the default order. Three states, not
+    // the two a server-paged grid offers: here the default IS a meaningful
+    // order (the dataset's own, which an author can set via `options.sortBy`),
+    // so a header has to be able to hand it back. The middle step is written
+    // as "whatever `firstDir` is not" rather than as the literal `'desc'`,
+    // because hard-coding it would send a measure column desc → desc and cost
+    // it the ascending state entirely.
     const cycleSort = (c: string) =>
-      setTableSort((prev) =>
-        prev?.column !== c
-          ? { column: c, dir: 'asc' }
-          : prev.dir === 'asc'
-            ? { column: c, dir: 'desc' }
-            : null,
-      );
+      setTableSort((prev) => {
+        const first = firstDir(c);
+        if (prev?.column !== c) return { column: c, dir: first };
+        return prev.dir === first
+          ? { column: c, dir: first === 'asc' ? 'desc' : 'asc' }
+          : null;
+      });
     // The console's own indicator (`components/…/data-table.tsx`): an idle
     // column shows nothing until the header is hovered, the sorted one shows a
     // primary-tinted arrow. `aria-hidden` because the `th`'s `aria-sort` is

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.tablePolish.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.tablePolish.test.tsx
@@ -38,6 +38,16 @@
  * NOT this card, and deliberately unasserted: the untranslated measure header
  * ("Annual Revenue" beside 行业) is the dataset-label i18n gap filed as
  * objectstack#10292.
+ *
+ * objectui#5845 later RULED the first-click direction, which #5827 had shipped
+ * as asc-first for every column and flagged as an open question: a numeric
+ * MEASURE column now starts DESCENDING (desc → asc → dataset order), while a
+ * dimension and a non-numeric measure keep asc → desc → dataset order. The
+ * cases below are split along that line — the #5827 block pins what did NOT
+ * move, the #5845 block pins what did — and the blanks-last invariant is
+ * asserted on BOTH halves, because the descending arm (where naive negation of
+ * `compareSortValues` would float blanks to the top) is now what a measure
+ * column's very FIRST click runs.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -215,7 +225,9 @@ describe('objectui#5827 — the empty dimension bucket sorts last', () => {
 });
 
 describe('objectui#5827 — sortable headers', () => {
-  it('cycles asc → desc → the default order, per column, and reports it via aria-sort', async () => {
+  it('cycles a DIMENSION column asc → desc → the default order and reports it via aria-sort', async () => {
+    // A grouping axis keeps the console DataTable idiom, A→Z first. objectui#5845
+    // moved the MEASURE columns only; this case is the unchanged half.
     installMetaRouter();
     render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
     await screen.findByText('Industry');
@@ -224,32 +236,36 @@ describe('objectui#5827 — sortable headers', () => {
     // Default: no column claims a sort.
     expect(headerCells().map((th) => th.getAttribute('aria-sort'))).toEqual(['none', 'none', 'none']);
 
-    // Ascending by revenue: the blank bucket's 0 is a real number, so it leads.
-    fireEvent.click(sortButtons()[1]);
-    expect(headerCells()[1].getAttribute('aria-sort')).toBe('ascending');
-    expect(dimensionColumn()).toEqual(['—', 'Finance', 'Technology']);
+    fireEvent.click(sortButtons()[0]);
+    expect(headerCells()[0].getAttribute('aria-sort')).toBe('ascending');
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
 
-    // Descending: the biggest industry first — the complaint this card opened on.
-    fireEvent.click(sortButtons()[1]);
-    expect(headerCells()[1].getAttribute('aria-sort')).toBe('descending');
+    fireEvent.click(sortButtons()[0]);
+    expect(headerCells()[0].getAttribute('aria-sort')).toBe('descending');
     expect(dimensionColumn()).toEqual(['Technology', 'Finance', '—']);
 
-    // Third click returns the dataset's own order (blank bucket still last).
-    fireEvent.click(sortButtons()[1]);
-    expect(headerCells()[1].getAttribute('aria-sort')).toBe('none');
+    // Third click returns the dataset's own order.
+    fireEvent.click(sortButtons()[0]);
+    expect(headerCells()[0].getAttribute('aria-sort')).toBe('none');
     expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
   });
 
-  it('starts a NEW column ascending rather than inheriting the previous column state', async () => {
+  it('starts a NEW column at its OWN first direction rather than inheriting the previous column state', async () => {
     installMetaRouter();
     render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
     await waitFor(() => expect(bodyRows().length).toBe(3));
 
-    fireEvent.click(sortButtons()[1]);
-    fireEvent.click(sortButtons()[1]); // revenue, descending
-    fireEvent.click(sortButtons()[0]); // switch to the dimension
+    fireEvent.click(sortButtons()[1]); // revenue — a measure, so DESCENDING
+    fireEvent.click(sortButtons()[1]); // …then ascending
+    fireEvent.click(sortButtons()[0]); // switch to the dimension: ascending, its own first
     expect(headerCells().map((th) => th.getAttribute('aria-sort'))).toEqual(['ascending', 'none', 'none']);
     expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+
+    // …and back the other way: leaving an ascending DIMENSION for a measure
+    // does not carry `asc` across — the measure claims its own descending.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells().map((th) => th.getAttribute('aria-sort'))).toEqual(['none', 'descending', 'none']);
+    expect(dimensionColumn()).toEqual(['Technology', 'Finance', '—']);
   });
 
   it('sorts blanks LAST in both directions', async () => {
@@ -284,11 +300,13 @@ describe('objectui#5827 — sortable headers', () => {
     render(<DatasetWidget widget={{ ...TABLE_WIDGET, values: ['account_count'] }} dataSource={src} />);
     await waitFor(() => expect(bodyRows().length).toBe(2));
 
-    fireEvent.click(sortButtons()[1]);
-    // 9 before 10. A string compare would invert this.
-    expect(dimensionColumn()).toEqual(['Finance', 'Technology']);
+    // First click on a measure is DESCENDING (objectui#5845): 10 before 9.
+    // A string compare would put '9' first descending, inverting this.
     fireEvent.click(sortButtons()[1]);
     expect(dimensionColumn()).toEqual(['Technology', 'Finance']);
+    // Second click ascending: 9 before 10 — a string compare inverts this one too.
+    fireEvent.click(sortButtons()[1]);
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology']);
   });
 
   it('exports the CSV in the order the table is showing', async () => {
@@ -301,8 +319,7 @@ describe('objectui#5827 — sortable headers', () => {
     try {
       render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
       await waitFor(() => expect(bodyRows().length).toBe(3));
-      fireEvent.click(sortButtons()[1]);
-      fireEvent.click(sortButtons()[1]); // revenue, descending
+      fireEvent.click(sortButtons()[1]); // revenue — one click IS descending now
       fireEvent.click(screen.getByTestId('dataset-export'));
 
       expect(blobs.length).toBe(1);
@@ -316,6 +333,111 @@ describe('objectui#5827 — sortable headers', () => {
       (URL as any).createObjectURL = origCreate;
       (URL as any).revokeObjectURL = origRevoke;
     }
+  });
+});
+
+describe('objectui#5845 — a numeric measure column starts DESCENDING', () => {
+  it('cycles a measure desc → asc → the dataset order and reports each state via aria-sort', async () => {
+    // The ruled contract. "Who is biggest" is the question a click asks of a
+    // measure, and #5827's own motivating reading was that Technology — the
+    // largest industry — rendered last; one click now answers it.
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await screen.findByText('Industry');
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    expect(headerCells().map((th) => th.getAttribute('aria-sort'))).toEqual(['none', 'none', 'none']);
+
+    // FIRST click: descending. `aria-sort` says so, and it is truthful about
+    // the direction actually applied rather than about where the cycle began.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('descending');
+    expect(dimensionColumn()).toEqual(['Technology', 'Finance', '—']);
+
+    // Second click: ascending. The blank bucket's revenue is 0 — a real
+    // number, not a blank — so it leads.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('ascending');
+    expect(dimensionColumn()).toEqual(['—', 'Finance', 'Technology']);
+
+    // Third click: the dataset's own order (blank dimension bucket last). The
+    // measure keeps all THREE states — writing the middle step as the literal
+    // `'desc'` would have collapsed the cycle to desc → desc.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('none');
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+  });
+
+  it('starts a measure whose values are TEXT ascending — direction follows the numeric classification, not "is a measure"', async () => {
+    // Same set that decides right-alignment: a `min()`/`max()` over a text
+    // field is a measure but not a NUMERIC one, so it keeps the A→Z idiom.
+    // The declared `type: 'number'` is deliberately kept in the fixture — it is
+    // what the executor sends, and it must not be what decides this.
+    installMetaRouter();
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [
+          { industry: 'Finance', top_account: 'Northwind', account_count: 3 },
+          { industry: 'Technology', top_account: 'Contoso', account_count: 5 },
+        ],
+        fields: [
+          { name: 'industry', type: 'text', label: 'Industry' },
+          { name: 'top_account', type: 'number', label: 'Top Account' },
+          { name: 'account_count', type: 'number', label: 'Accounts' },
+        ],
+      })),
+    };
+    render(
+      <DatasetWidget
+        widget={{ ...TABLE_WIDGET, values: ['top_account', 'account_count'] }}
+        dataSource={src}
+      />,
+    );
+    await screen.findByText('Top Account');
+    await waitFor(() => expect(bodyRows().length).toBe(2));
+
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('ascending');
+    expect(dimensionColumn()).toEqual(['Technology', 'Finance']); // Contoso before Northwind
+
+    // …while the genuinely numeric measure beside it starts descending.
+    fireEvent.click(sortButtons()[2]);
+    expect(headerCells()[2].getAttribute('aria-sort')).toBe('descending');
+    expect(dimensionColumn()).toEqual(['Technology', 'Finance']); // 5 before 3
+  });
+
+  it('keeps blanks LAST on a measure in both directions, starting with the descending FIRST click', async () => {
+    // The negate-trap #5827 documented has to survive the flip, and the flip
+    // makes it the FIRST thing a user hits: `compareSortValues` places blanks
+    // last ASCENDING and expects callers to negate for descending, which would
+    // float them to the top. A null value keeps the column numeric (nulls are
+    // allowed by the all-non-null-values-are-numbers test), so this really is
+    // a desc-first column.
+    installMetaRouter();
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [
+          { industry: 'Finance', annual_revenue_sum: 12000000, account_count: 3 },
+          { industry: 'Technology', annual_revenue_sum: null, account_count: 5 },
+          { industry: 'Retail', annual_revenue_sum: 30000000, account_count: 2 },
+        ],
+        fields: industryFields,
+      })),
+    };
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={src} />);
+    await screen.findByText('Industry');
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    // Descending on the first click: 30m, 12m, then the blank — NOT the blank
+    // first, which is what a negated comparator would have produced.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('descending');
+    expect(dimensionColumn()).toEqual(['Retail', 'Finance', 'Technology']);
+
+    // Ascending on the second: 12m, 30m, blank still last.
+    fireEvent.click(sortButtons()[1]);
+    expect(headerCells()[1].getAttribute('aria-sort')).toBe('ascending');
+    expect(dimensionColumn()).toEqual(['Finance', 'Retail', 'Technology']);
   });
 });
 


### PR DESCRIPTION
Fixes #5845

#5834 shipped sortable headers on the flat dataset `table` widget with an **asc-first** cycle for every column, and flagged the direction as the one open question ("if the maintainer wants B it is a two-line change to `cycleSort`"). #5845 rules B for numeric **measure** columns. This is that flip.

## The contract, as ruled

| column | cycle |
|---|---|
| numeric **measure** (as classified by #5834's `numericColumns`) | **descending -> ascending -> the dataset's own order** |
| dimension | ascending -> descending -> the dataset's own order (unchanged) |
| measure whose values are **not** numbers (`min()`/`max()` over a text field) | ascending -> descending -> the dataset's own order (unchanged) |

Blanks last in **both** directions, unchanged. `aria-sort` reports the direction actually applied.

## The estimate held, but not at two lines - and one of the two would have been a bug

The PM flagged "two lines in `cycleSort`" as the sibling dev's own estimate, to be verified. Measured: the flip really is confined to `cycleSort` - nothing else in the file assumes asc-first. `aria-sort`, the `ChevronUp`/`ChevronDown` indicator and the comparator all read `activeSort.dir`, i.e. the direction *applied*, never the position in the cycle, so a desc-first initial state renders and announces itself truthfully with no change. The blanks-last arm is settled **before** the direction is applied (#5834's negate-trap), so it is direction-agnostic by construction and survives the flip untouched.

What does **not** survive a literal two-line edit is the cycle's **middle** step. The shipped shape was `asc -> desc -> null` with both directions written as literals; swapping only the first literal yields `desc -> desc -> null` - a measure column that can never be sorted ascending. So the middle step is now written as "whatever `firstDir` is not":

```ts
const firstDir = (c: string): 'asc' | 'desc' => (numericColumns.has(c) ? 'desc' : 'asc');
const cycleSort = (c: string) =>
  setTableSort((prev) => {
    const first = firstDir(c);
    if (prev?.column !== c) return { column: c, dir: first };
    return prev.dir === first ? { column: c, dir: first === 'asc' ? 'desc' : 'asc' } : null;
  });
```

Three states for **both** column kinds, and switching columns starts the new one at *its own* first direction rather than inheriting the previous column's.

The predicate is `numericColumns` - the very set that already decides right-alignment - so first-click direction is a property of the column's **role** (a measure whose values really are numbers), not of "it looks like digits". A digit-keyed dimension (a year, a quarter) still starts ascending, and so does a text-valued `min()`/`max()`.

One consequence worth naming: the descending arm is now what a measure column's **first** click runs, so #5834's negate-trap moved from the second interaction to the very first. The comment at the comparator says so, and a test pins blanks-last on that first click.

## Tests - the existing cycle assertions were UPDATED, not deleted

`packages/plugin-dashboard/src/__tests__/DatasetWidget.tablePolish.test.tsx`, 11 -> 14 cases, split along the ruling:

- **#5827 block = what did not move.** The three-state cycle + `aria-sort` case now runs on the **dimension** column (it used to run on the measure); blanks-last-in-both-directions on the dimension is untouched; "starts a NEW column..." now asserts *its own* first direction in both crossings (measure -> dimension, dimension -> measure); "sorts numerically, not lexicographically" and the CSV-order case were re-pointed at the new first-click direction.
- **#5845 block = what moved.** A measure's full `desc -> asc -> dataset order` cycle with `aria-sort` at each state; a **text-valued measure** starting ascending beside a numeric one starting descending, in the same table (the classification, not "is a measure", decides); and blanks last on the descending **first** click of a measure with a `null` value.

## Verification

All from the repo root, in a dedicated worktree. Union re-run **after** the final commit, at `2d4c3609b`.

| gate | verdict line | exit |
|---|---|---|
| `pnpm --filter '@object-ui/plugin-dashboard^...' build` | dependency closure built | 0 |
| `pnpm --filter @object-ui/plugin-dashboard type-check` | `tsc --noEmit && tsc -p tsconfig.test.json`, no diagnostics | 0 |
| `pnpm --filter @object-ui/plugin-dashboard lint` | `369 problems (0 errors, 369 warnings)` - the identical count #5834 reported, so this diff adds none | 0 |
| `pnpm exec vitest run packages/plugin-dashboard/` | `Test Files 77 passed (77)` / `Tests 726 passed (726)` | 0 |
| `pnpm exec vitest run .../DatasetWidget.tablePolish.test.tsx` | `Tests 14 passed (14)` (was 11) | 0 |
| `node scripts/check-changeset-presence.mjs` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` | 0 |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a 'major' bump.` | 0 |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 4868 tracked text file(s); skipped 85 binary)` | 0 |
| `pnpm run check:i18n-keys` | `Every in-scope call-site key resolves against the en pack (2928 keys)` | 0 |

Every exit code captured by redirecting to a file first, never read after a pipe.

**Reverse verification. Direction stated before the run:** reverting *only* `DatasetWidget.tsx` to `origin/main` should turn **6 of 14** red - the three #5845 cases plus #5827's "new column at its own first direction", "sorts numerically" and "CSV export" - and leave the 8 alignment / dimension-cycle / blank-bucket / drill / hover cases green, because those are exactly the half the ruling does not touch. **Observed: `Tests 6 failed | 8 passed (14)`, and the six named failures are the six predicted.** Mutation confirmed on disk by anchored greps rather than by an editor exit code: `firstDir` 3 -> 0 and the deleted `origin/main` spelling `prev.dir === 'asc'` 0 -> 1. Restore leg confirmed the same way (3 / 0) plus an empty `git status --porcelain`, and re-ran green at 14/14. No rebuild stands between the edit and the run - the suite imports the component by relative source path (`../DatasetWidget`), not through a package `exports` -> `dist` hop. The script carried `trap ... EXIT INT TERM`, and the trap did fire.

**Not verified in a running browser** - same honest limit as #5834: the reading is from component tests over the DOM the widget produces, not from a console rendering HotCRM's `executive_dashboard`.

**Declared narrowing:** the shared verification lock is inoperable on this host (`os-verify-lock.sh --status` -> `CANNOT OPERATE THIS LOCK ... a stock macOS does not ship flock`), so the commands above ran directly rather than through the entry point; repo-wide `check:*` scanning is left to CI.

**Out of scope: #5846 (the totals row) is not addressed here** - it is queued behind this card on the same file, and nothing in this diff was restructured to prepare for it.

_Generated by [Claude Code](https://claude.ai/code)_
