### PR TITLE
docs(core): name the grid and surface behind the 27,581 of 1,200,013 figure

### DIFF
--- a/.changeset/percent-figure-grid-citation-5608.md
+++ b/.changeset/percent-figure-grid-citation-5608.md
@@ -1,0 +1,34 @@
+---
+---
+
+Comments only — this publishes nothing, declared explicitly with an empty frontmatter
+rather than left undeclared (objectui#5608).
+
+Two live sites still carried the bare `27,581 of 1,200,013` figure with neither the grid
+nor the measured surface named: the `DisplayNumberFormatOptions.style` doc comment and a
+comment in the percentage-points test. Both were accurate. Neither was *reconcilable* — a
+reader who had also seen `packages/fields`'s `27,577 of 1,200,003` met two counts that
+look like a contradiction, and a figure a reader cannot reconcile is what makes a correct
+comment get distrusted wholesale. That is the same defect class objectui#4596 was queued
+for, and the wording here is lifted from its PR rather than phrased a third way — a third
+phrasing for one fact is the defect one level up.
+
+Both counts stand unchanged. The disambiguator is the surface measured, so each site now
+names it: objectui#4576's tie-dense grid (0.005 steps to 2,000, precisions 0/1/2) on
+`formatDisplayNumber` / `formatMeasure`'s call shape, against objectui#4590's re-measure
+of the same route through `formatPercent`. No value, assertion or behaviour moves.
+
+Why the empty form is the right declaration, stated from what was measured rather than
+carried over from objectui#4596's PR — the two cases are mirror images. There, a function
+BODY comment was changed, so the emitted `.js` moved and the `.d.ts` did not. Here the
+changed source comment is the JSDoc on an exported interface member: the interface erases
+at runtime, so the new prose reaches `dist/utils/number-display.d.ts` and is absent from
+`dist/utils/number-display.js` (checked on a real build of the package). The second site
+is a test file, excluded from the build program by `src/**/__tests__/**` and never in
+`dist` at all.
+
+So a consumer-visible byte does move — the text shown on hover. That is documentation of
+an existing measurement, not a change to the measurement, the type, or any behaviour:
+nothing a consumer types against or calls is different, which is why this releases
+nothing. Bytes moving is not the criterion; released behaviour and consumer-visible
+surface are, and neither moves.

--- a/packages/core/src/utils/__tests__/number-display.percent-points.test.ts
+++ b/packages/core/src/utils/__tests__/number-display.percent-points.test.ts
@@ -93,8 +93,12 @@ describe('formatDisplayNumber — style: percentPoints (#4576)', () => {
   });
 
   it('keeps the AUTHORED decimal at rounding ties, where the /100 round trip does not', () => {
-    // Measured: 27,581 of 1,200,013 ordinary-magnitude en-US forms differ
-    // between the two routes. These are three of them.
+    // Measured on objectui#4576's tie-dense grid (0.005 steps to 2,000,
+    // precisions 0/1/2) and on `formatDisplayNumber` / `formatMeasure`'s call
+    // shape: 27,581 of 1,200,013 ordinary-magnitude en-US forms differ between
+    // the two routes. These are three of them. (objectui#4590 re-measured the
+    // same route through `formatPercent` and reports 27,577 of 1,200,003 — a
+    // different form set, not a correction of this one.)
     for (const [value, digits, expected] of [
       [0.175, 2, '0.18%'],
       [0.305, 2, '0.31%'],

--- a/packages/core/src/utils/number-display.ts
+++ b/packages/core/src/utils/number-display.ts
@@ -116,9 +116,13 @@ export interface DisplayNumberFormatOptions {
    * repo's runner, `80.175` percentage points formatted to 2 decimals renders
    * `80.18%` when formatted directly and `80.17%` after the divide-and-remultiply
    * — 27,581 of 1,200,013 ordinary-magnitude en-US forms move, plus every
-   * value at the top of the double range (`MAX_SAFE_INTEGER`, `1e23`). A caller
-   * holding percentage points must therefore NOT reach for `'percent'`; that is
-   * exactly the trap this option removes.
+   * value at the top of the double range (`MAX_SAFE_INTEGER`, `1e23`). That
+   * count is objectui#4576's tie-dense grid — 0.005 steps to 2,000, precisions
+   * 0/1/2 — measured on `formatDisplayNumber` / `formatMeasure`'s call shape.
+   * objectui#4590 re-measured the same route through `formatPercent` and
+   * reports 27,577 of 1,200,003: a different form set, not a correction of this
+   * one. A caller holding percentage points must therefore NOT reach for
+   * `'percent'`; that is exactly the trap this option removes.
    *
    * `'percentPoints'` is implemented with `Intl`'s `style: 'unit'` /
    * `unit: 'percent'`, which was measured to produce a BYTE-IDENTICAL percent


### PR DESCRIPTION
Fixes #5608

Two live sites still carried the bare `27,581 of 1,200,013` figure with neither the grid nor the measured surface named. Both were accurate; neither was *reconcilable*. A reader who had also seen `packages/fields`'s `27,577 of 1,200,003` met two counts that look like a contradiction — and a correct-but-unreconcilable figure is what makes correct comments get distrusted wholesale. That reasoning is recorded on #4596, and preserving it is the point of the wording.

## What changed

Comments only. Two lines of prose, zero executable change.

| site | what it is |
| --- | --- |
| `packages/core/src/utils/number-display.ts:118` | the `DisplayNumberFormatOptions.style` doc comment |
| `packages/core/src/utils/__tests__/number-display.percent-points.test.ts:96` | the tie-case comment |

Both line numbers were dated on the card; both were re-measured against `origin/main` before editing and both were still accurate.

The wording is **lifted from #5606**, not phrased a third way — a third phrasing for one fact is the defect one level up. That PR wrote the qualification in two forms: an em-dash form for a source comment and a parenthetical form for a test header. Each of the two sites here takes the matching form, with only the surface name changed to the one these two sites actually sit on.

**Nothing about the figure moves.** Both counts stand exactly as measured. Per the card, naming "the grid" alone does *not* separate them — both cards describe the grid identically — so the disambiguator each site now carries is the **surface measured**: #4576's tie-dense grid (0.005 steps to 2,000, precisions 0/1/2) on `formatDisplayNumber` / `formatMeasure`'s call shape, against #4590's re-measure of the same route through `formatPercent`.

`formatMeasure` delegates to `formatDisplayNumber`, so the compound name is what makes this reconcilable with the already-corrected comment in `dataset-format.ts`, which cites the same count as "THIS formatter's call shape".

### Left untouched, deliberately

The `CHANGELOG.md` entries in `packages/core`, `packages/i18n` and `packages/fields` carry these figures too. They are historical release records, accurate as published, and the card puts them explicitly out of scope. No value, assertion, type or behaviour is touched anywhere in this diff.

## The changeset, and why the empty form

`scripts/check-changeset-presence.mjs` does require a declaration here (`packages/core/src/**` is released source), and the empty-frontmatter form is the right one — but the measured reason is the **mirror image** of #5606's, so it is restated rather than carried over.

In that PR a function *body* comment changed, so the emitted `.js` moved and the `.d.ts` did not. Here the changed source comment is the JSDoc on an exported interface member: the interface erases at runtime, so on a real build of the package the new prose reaches `dist/utils/number-display.d.ts` and is **absent** from `dist/utils/number-display.js`. The second site is a test file, excluded from the build program by `src/**/__tests__/**`, and never in `dist` at all.

So a consumer-visible byte does move — the text shown on hover. That is documentation of an existing measurement, not a change to the measurement, the type, or any behaviour. Bytes moving is not the criterion; released behaviour and consumer-visible surface are, and neither moves.

## Verification

Union re-run after the final commit, at `cca26ab5f`:

| gate | verdict line |
| --- | --- |
| `check-changeset-presence` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` — empty frontmatter, the explicit exemption |
| `check-changeset-no-major` | `✅ No changeset declares a 'major' bump.` |
| `check-control-bytes` | `✅ check-control-bytes: OK (scanned 4869 tracked text file(s); skipped 85 binary).` |
| vitest (from repo root) | `Test Files 3 passed (3)` / `Tests 39 passed (39)` |
| `@object-ui/core type-check` | `tsc --noEmit && tsc -p tsconfig.test.json`, exit 0 |
| eslint (targeted, `--no-inline-config`) | 2 files, 0 errors, 0 warnings |

vitest covered the edited test plus the sibling `dataset-format.percent-convention.test.ts` and `scripts/__tests__/doc-version-claims.test.ts` — the last of those runs only in the CI shards, and it is the gate that catches a bare version literal written into prose, so it was pulled forward locally rather than left to CI. Every exit code was read from `PIPESTATUS[0]`, never from a bare `$?` after a pipe.

**No ablation, and none is owed.** This diff is comment-only: there is no behavioural leg to remove, and staging one would be decoration. The discriminating evidence is a before/after grep on the two sites, run with a positive control on the same pipeline against the two already-corrected #5606 sites (which hit, confirming the pattern is findable where it exists):

- **before** — the qualification was absent from both target sites (`0` hits each), while the control sites hit
- **after** — both sites carry the grid, the precisions, the named surface, the sibling count and the "a different form set, not a correction of this one" clause; the old bare phrasings return `0`
- the figure `27,581 of 1,200,013` itself is still present at both sites, unchanged

The lint run is narrowed to the two changed files rather than the repo-wide farm, and the narrowing is a measurement, not a gap: the file count is read from eslint's own `--format json` output (2), the diff touches no eslint, turbo or tsconfig file, the added lines contain no `eslint-disable` or `@ts-` directive comment, and `eslint.config.js` declares no `projectService`, `project:` or `parserOptions` — type-aware linting is not enabled, so no untouched file's verdict can move. CI runs the full farm regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_