### PR TITLE
feat(app-shell): Studio simplification first cut — sub-tab fold, draft auto-save, access demotion (#5813)

### DIFF
--- a/.changeset/studio-simplify-5813.md
+++ b/.changeset/studio-simplify-5813.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Studio simplification, first cut (#5813): the Data pillar's object sub-tabs collapse to 记录/表单 with the five power panels (验证/钩子/操作/API/设置) behind one 「高级」 menu (the open panel's name wears the active pill, so the collapsed default never hides where you are); drafts now AUTO-save (debounced 1.5s, CEL-blocking gates the timer per the objectui#4306 rule, a failed save waits for the next edit) and the four 保存草稿 buttons are retired in favor of a quiet saving/last-saved hint; the 权限 pillar moves from the top-level row into a 「更多」 overflow whose items carry the same dirty-guard as the primary pillars — the /studio/:pkg/access route and every page behind it are untouched.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -1476,6 +1476,9 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.creating': 'Creating…',
   'engine.studio.createDraft': 'Create (save as draft)',
   'engine.studio.saveDraft': 'Save draft',
+  'engine.studio.more': 'More',
+  'engine.studio.autoSaving': 'Saving…',
+  'engine.studio.data.tab.advanced': 'Advanced',
   // Standard create-dialog field labels (shared by object / app / flow / permission).
   'engine.studio.app.nameLabel': 'App name',
   'engine.studio.app.idLabel': 'Identifier',
@@ -3324,6 +3327,9 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.creating': '创建中…',
   'engine.studio.createDraft': '创建(存为草稿)',
   'engine.studio.saveDraft': '保存草稿',
+  'engine.studio.more': '更多',
+  'engine.studio.autoSaving': '保存中…',
+  'engine.studio.data.tab.advanced': '高级',
   // Standard create-dialog field labels (shared by object / app / flow / permission).
   'engine.studio.app.nameLabel': '应用名称',
   'engine.studio.app.idLabel': '标识',

--- a/packages/app-shell/src/views/studio-design/DataPillar.celGate.test.tsx
+++ b/packages/app-shell/src/views/studio-design/DataPillar.celGate.test.tsx
@@ -40,6 +40,7 @@ const objectDef = {
 };
 
 const mockClient = {
+  save: vi.fn(async () => ({})),
   list: vi.fn(async () => [{ name: 'showcase_task', label: 'Task' }]),
   listDrafts: vi.fn(async () => []),
   layered: vi.fn(async () => ({ effective: objectDef, code: objectDef })),
@@ -60,6 +61,23 @@ vi.mock('./packages-io', async (importOriginal) => {
   return { ...mod, fetchPackages: vi.fn(async () => []) };
 });
 
+
+// objectui#5813 — the advanced tabs live in a Radix DropdownMenu; these suites
+// measure the CEL gate, not radix's open/close machinery, so the menu renders
+// as plain passthroughs (same convention as AppSwitcher.publishState.test.tsx).
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/components')>();
+  return {
+    ...mod,
+    DropdownMenu: (p: any) => <div>{p.children}</div>,
+    DropdownMenuTrigger: (p: any) => <div>{p.children}</div>,
+    DropdownMenuContent: (p: any) => <div>{p.children}</div>,
+    DropdownMenuItem: (p: any) => (
+      <button type="button" onClick={() => p.onSelect?.()}>{p.children}</button>
+    ),
+  };
+});
+
 vi.mock('@object-ui/react', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@object-ui/react')>();
   return { ...mod, useAdapter: () => ({}) };
@@ -75,6 +93,7 @@ registerBuiltinInspectors();
 afterEach(() => {
   cleanup();
   __setCelFormulaLoader(undefined);
+  mockClient.save.mockClear();
 });
 
 const DANGLING = /[*+\-/&|=<>]\s*$/;
@@ -94,7 +113,6 @@ function stubEngine() {
   );
 }
 
-const saveDraft = () => screen.getByRole('button', { name: /Save draft/i });
 
 /** Open the Data pillar's form tab and select the formula field. */
 async function openFormulaField() {
@@ -111,46 +129,53 @@ async function openFormulaField() {
   return label.parentElement!.querySelector('[role="combobox"]') as HTMLTextAreaElement;
 }
 
-describe('DataPillar — Save draft is gated on the field inspector’s CEL verdict (#4306)', () => {
-  it("refuses the card's repro: a dangling operator disables Save draft", async () => {
+// objectui#5813 retired the 保存草稿 button for debounced AUTO-save; the CEL
+// gate now guards the TIMER (the objectui#4306 rule verbatim: gating only a
+// button would let the timer persist the malformed definition a second later).
+// The observable is therefore client.save itself.
+describe('DataPillar — auto-save is gated on the field inspector’s CEL verdict (#4306/#5813)', () => {
+  it("refuses the card's repro: a dangling operator blocks the auto-save", async () => {
     const box = await openFormulaField();
 
-    // A valid formula first: this both dirties the draft (so Save is live at
-    // all) and pins the must-not-change half — a good formula never blocks.
+    // A valid formula first: the auto-save fires — pins the must-not-change
+    // half (a good formula never blocks) and clears the dirty window.
     fireEvent.change(box, { target: { value: 'record.est_hours * 2' } });
-    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 3000 });
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled(), { timeout: 4000 });
+    mockClient.save.mockClear();
 
-    // Now the card's exact input.
+    // Now the card's exact input: well past the debounce, still no save.
     fireEvent.change(box, { target: { value: 'record.est_hours *' } });
-    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 3000 });
-    expect(saveDraft()).toHaveAttribute('title', 'Fix the CEL syntax errors before saving.');
+    await new Promise((r) => setTimeout(r, 2300));
+    expect(mockClient.save).not.toHaveBeenCalled();
   });
 
-  it('re-enables Save draft once the formula parses again', async () => {
+  it('re-arms the auto-save once the formula parses again', async () => {
     const box = await openFormulaField();
 
     fireEvent.change(box, { target: { value: 'record.est_hours *' } });
-    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 3000 });
+    await new Promise((r) => setTimeout(r, 2300));
+    expect(mockClient.save).not.toHaveBeenCalled();
 
     fireEvent.change(box, { target: { value: 'record.est_hours * 2' } });
-    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 3000 });
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled(), { timeout: 4000 });
   });
 
   /**
    * Sub-decision A. Closing the panel unmounts the inspector, so nothing will
-   * ever report `0` for it — the host must drop the count on its own or Save
-   * stays disabled forever with no editor on screen to fix.
+   * ever report `0` for it — the host must drop the count on its own, or the
+   * dirty draft stays wedged UNSAVED forever with no editor on screen to fix.
    */
-  it('drops the count when the inspector closes, so Save cannot wedge shut', async () => {
+  it('drops the count when the inspector closes, so the draft cannot wedge unsaved', async () => {
     const box = await openFormulaField();
 
     fireEvent.change(box, { target: { value: 'record.est_hours *' } });
-    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 3000 });
+    await new Promise((r) => setTimeout(r, 2300));
+    expect(mockClient.save).not.toHaveBeenCalled();
 
     // Two "Close" buttons dismiss the panel — the rail header's and the
-    // inspector shell's own; either clears the selection.
+    // inspector shell's own; either clears the selection (and the block).
     fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[0]);
     await waitFor(() => expect(screen.queryByText('Formula (CEL)')).toBeNull(), { timeout: 3000 });
-    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 3000 });
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled(), { timeout: 4000 });
   });
 });

--- a/packages/app-shell/src/views/studio-design/DataPillar.panelGate.test.tsx
+++ b/packages/app-shell/src/views/studio-design/DataPillar.panelGate.test.tsx
@@ -41,6 +41,7 @@ const objectDef = {
 };
 
 const mockClient = {
+  save: vi.fn(async () => ({})),
   list: vi.fn(async () => [{ name: 'showcase_task', label: 'Task' }]),
   listDrafts: vi.fn(async () => []),
   layered: vi.fn(async () => ({ effective: objectDef, code: objectDef })),
@@ -59,6 +60,23 @@ vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
 vi.mock('./packages-io', async (importOriginal) => {
   const mod = await importOriginal<typeof import('./packages-io')>();
   return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+
+// objectui#5813 — the advanced tabs live in a Radix DropdownMenu; these suites
+// measure the CEL gate, not radix's open/close machinery, so the menu renders
+// as plain passthroughs (same convention as AppSwitcher.publishState.test.tsx).
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/components')>();
+  return {
+    ...mod,
+    DropdownMenu: (p: any) => <div>{p.children}</div>,
+    DropdownMenuTrigger: (p: any) => <div>{p.children}</div>,
+    DropdownMenuContent: (p: any) => <div>{p.children}</div>,
+    DropdownMenuItem: (p: any) => (
+      <button type="button" onClick={() => p.onSelect?.()}>{p.children}</button>
+    ),
+  };
 });
 
 vi.mock('@object-ui/react', async (importOriginal) => {
@@ -93,9 +111,9 @@ beforeEach(stubEngine);
 afterEach(() => {
   cleanup();
   __setCelFormulaLoader(undefined);
+  mockClient.save.mockClear();
 });
 
-const saveDraft = () => screen.getByRole('button', { name: /Save draft/i });
 
 /** Open the pillar's Rules tab and put the selected rule's guard into raw CEL. */
 async function openRuleGuard() {
@@ -109,42 +127,48 @@ async function openRuleGuard() {
   return screen.getAllByRole('combobox').find((el) => el.tagName === 'TEXTAREA') as HTMLTextAreaElement;
 }
 
-describe('DataPillar — Save draft is gated on the validations panel’s CEL verdict (#4527)', () => {
+// objectui#5813 retired the 保存草稿 button for debounced AUTO-save; the gate
+// now guards the TIMER (objectui#4306's own rule), so the observable is
+// client.save itself.
+describe('DataPillar — auto-save is gated on the validations panel’s CEL verdict (#4527/#5813)', () => {
   it('refuses a rule guard that does not parse', async () => {
     const box = await openRuleGuard();
 
-    // A valid guard first — dirties the draft and pins that a good guard never
-    // blocks.
+    // A valid guard first — the auto-save fires; pins that a good guard never
+    // blocks, and clears the dirty window.
     fireEvent.change(box, { target: { value: "record.status == 'open'" } });
-    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 4000 });
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled(), { timeout: 4000 });
+    mockClient.save.mockClear();
 
     fireEvent.change(box, { target: { value: 'record.status ==' } });
-    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 4000 });
-    expect(saveDraft()).toHaveAttribute('title', 'Fix the CEL syntax errors before saving.');
+    await new Promise((r) => setTimeout(r, 2300));
+    expect(mockClient.save).not.toHaveBeenCalled();
   });
 
-  it('re-enables Save draft once the guard parses again', async () => {
+  it('re-arms the auto-save once the guard parses again', async () => {
     const box = await openRuleGuard();
 
     fireEvent.change(box, { target: { value: 'record.status ==' } });
-    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 4000 });
+    await new Promise((r) => setTimeout(r, 2300));
+    expect(mockClient.save).not.toHaveBeenCalled();
 
     fireEvent.change(box, { target: { value: "record.status == 'open'" } });
-    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 4000 });
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled(), { timeout: 4000 });
   });
 
   /**
    * The tab stamp. Leaving Rules unmounts the panel, so it can never report
-   * `0`; without deriving the count against the live tab, Save would stay
-   * wedged shut on a surface with no CEL editor on screen at all.
+   * `0`; without deriving the count against the live tab, the dirty draft
+   * would stay wedged UNSAVED on a surface with no CEL editor on screen.
    */
   it('expires the panel count when the author leaves the Rules tab', async () => {
     const box = await openRuleGuard();
 
     fireEvent.change(box, { target: { value: 'record.status ==' } });
-    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 4000 });
+    await new Promise((r) => setTimeout(r, 2300));
+    expect(mockClient.save).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Form' }));
-    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 4000 });
+    await waitFor(() => expect(mockClient.save).toHaveBeenCalled(), { timeout: 4000 });
   });
 });

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.pillarNavGuard.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.pillarNavGuard.test.tsx
@@ -180,6 +180,14 @@ async function renderSurfaceOnAccess() {
   await screen.findByText('a_account');
 }
 
+
+/** objectui#5813 — Access lives in the 「更多」 overflow now; open it, then
+ *  click the real router Link inside (same dirty-guard as primary pillars). */
+async function clickAccessInOverflow() {
+  fireEvent.click(screen.getByTestId('studio-nav-more'));
+  fireEvent.click(await screen.findByRole('link', { name: 'Access' }));
+}
+
 /** Flip a cell in the open matrix so the editor reports dirty. */
 function dirtyTheMatrix() {
   const row = screen.getByText('a_account').closest('tr')!;
@@ -213,7 +221,7 @@ describe('Studio header — unsaved pillar edits guard (#2600)', () => {
 
     // The discarded pillar reset the guard on unmount — walking back to
     // Access must NOT prompt again.
-    fireEvent.click(screen.getByRole('link', { name: 'Access' }));
+    await clickAccessInOverflow();
     expect(confirmSpy).toHaveBeenCalledTimes(2);
     await screen.findByText('set_a');
   });
@@ -239,7 +247,7 @@ describe('Studio header — unsaved pillar edits guard (#2600)', () => {
     expect(confirmSpy).toHaveBeenCalledTimes(2);
     await screen.findByText('This package has no app yet');
 
-    fireEvent.click(screen.getByRole('link', { name: 'Access' }));
+    await clickAccessInOverflow();
     expect(confirmSpy).toHaveBeenCalledTimes(2);
     await screen.findByText('set_a');
   });
@@ -257,7 +265,7 @@ describe('Studio header — unsaved pillar edits guard (#2600)', () => {
     await renderSurfaceOnAccess();
     dirtyTheMatrix();
 
-    fireEvent.click(screen.getByRole('link', { name: 'Access' }));
+    await clickAccessInOverflow();
 
     expect(confirmSpy).not.toHaveBeenCalled();
     expect(screen.getByText('set_a')).toBeInTheDocument();

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -177,12 +177,17 @@ function useDraftAutoSave(opts: {
     try {
       return JSON.stringify(snapshot ?? null);
     } catch {
-      return String(Date.now()); // unserializable: always distinct, never starves
+      // Unserializable draft (never the case for metadata bodies): a constant
+      // key means one auto-save per dirty period instead of per edit —
+      // degraded but pure (the react compiler forbids impure render calls).
+      return '"__unserializable__"';
     }
   }, [snapshot]);
   const lastAttemptRef = React.useRef<string | null>(null);
   const saveRef = React.useRef(save);
-  saveRef.current = save;
+  React.useEffect(() => {
+    saveRef.current = save;
+  });
   React.useEffect(() => {
     if (!dirty || blocked) return;
     if (lastAttemptRef.current === snapKey) return;

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -31,6 +31,10 @@ import {
   Popover,
   PopoverTrigger,
   PopoverContent,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
 } from '@object-ui/components';
 import { ObjectView as PluginObjectView } from '@object-ui/plugin-view';
 import { ListView } from '@object-ui/plugin-list';
@@ -50,7 +54,6 @@ import {
   Code2,
   Eye,
   Loader2,
-  Save,
   Pencil,
   Check,
   Plus,
@@ -152,6 +155,51 @@ const PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> =
   { key: 'data', label: 'Data', Icon: Database },
   { key: 'automations', label: 'Automations', Icon: Workflow },
   { key: 'interfaces', label: 'Interfaces', Icon: LayoutDashboard },
+];
+// objectui#5813 — debounced draft auto-save, shared by the pillars' editors.
+// Drafts never touch the live app, so persisting them automatically is
+// zero-risk; the 保存草稿 buttons it replaces were a standing tax on the
+// topbars AND a real loss point (forgot-to-save). Semantics:
+//  - re-arms 1.5s after the LAST edit (the snapshot key changes per edit);
+//  - `blocked` mirrors each site's old disabled-guard — in particular a
+//    CEL-blocking inspector must gate the TIMER, not just a button, or the
+//    timer publishes the malformed definition a second later (objectui#4306);
+//  - a FAILED save does not retry until the user edits again (the snapshot
+//    it attempted is remembered), so an invalid draft can't toast-loop.
+function useDraftAutoSave(opts: {
+  dirty: boolean;
+  blocked: boolean;
+  snapshot: unknown;
+  save: () => void | Promise<void>;
+}): void {
+  const { dirty, blocked, snapshot, save } = opts;
+  const snapKey = React.useMemo(() => {
+    try {
+      return JSON.stringify(snapshot ?? null);
+    } catch {
+      return String(Date.now()); // unserializable: always distinct, never starves
+    }
+  }, [snapshot]);
+  const lastAttemptRef = React.useRef<string | null>(null);
+  const saveRef = React.useRef(save);
+  saveRef.current = save;
+  React.useEffect(() => {
+    if (!dirty || blocked) return;
+    if (lastAttemptRef.current === snapKey) return;
+    const timer = setTimeout(() => {
+      lastAttemptRef.current = snapKey;
+      void saveRef.current();
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [dirty, blocked, snapKey]);
+}
+
+// objectui#5813 — Access is a low-frequency ADMIN surface, demoted from the
+// top-level pillar row into the 「更多」 overflow (maintainer ruling
+// 2026-08-24: primary nav aligns with the Data/Automations/Interfaces maker
+// mental model). The PAGE is untouched: the /studio/:pkg/access route, the
+// pillar dispatch and PILLAR_FOR_SURFACE_TYPE all still point here.
+const OVERFLOW_PILLARS: ReadonlyArray<{ key: string; label: string; Icon: LucideIcon }> = [
   { key: 'access', label: 'Access', Icon: Shield },
 ];
 
@@ -714,6 +762,53 @@ export function StudioDesignSurface({ aiSlot }: StudioDesignSurfaceProps): React
                   {t(`engine.studio.pillar.${p.key}`, locale)}
                 </Link>
               ))}
+              {/* objectui#5813 — low-frequency surfaces live in 「更多」. The
+                  trigger takes the active pillar styling when one of them is
+                  open, so the demotion never hides WHERE you are. Each item is
+                  a real router Link carrying the SAME dirty-guard as the
+                  primary pillars — an overflow entry must not become the one
+                  door that silently discards edits. */}
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    data-testid="studio-nav-more"
+                    className={
+                      'inline-flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-xs transition-colors ' +
+                      (OVERFLOW_PILLARS.some((p) => tab === p.key)
+                        ? 'bg-primary/10 font-medium text-primary'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground')
+                    }
+                  >
+                    {OVERFLOW_PILLARS.some((p) => tab === p.key)
+                      ? t(`engine.studio.pillar.${tab}`, locale)
+                      : t('engine.studio.more', locale)}
+                    <ChevronDown className="h-3 w-3" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-44 p-1">
+                  {OVERFLOW_PILLARS.map((p) => (
+                    <Link
+                      key={p.key}
+                      to={`/studio/${packageId}/${p.key}`}
+                      onClick={(e) => {
+                        if (tab === p.key) return;
+                        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+                        if (!confirmLeavePillar()) e.preventDefault();
+                      }}
+                      className={
+                        'flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors ' +
+                        (tab === p.key
+                          ? 'bg-primary/10 font-medium text-primary'
+                          : 'text-muted-foreground hover:bg-muted hover:text-foreground')
+                      }
+                    >
+                      <p.Icon className="h-3.5 w-3.5" />
+                      {t(`engine.studio.pillar.${p.key}`, locale)}
+                    </Link>
+                  ))}
+                </PopoverContent>
+              </Popover>
             </nav>
 
             {/* Package-level draft review + one atomic publish (replaces per-item 发布) */}
@@ -1345,6 +1440,7 @@ export function InterfacesPillar({
         const body = extractDraftBody(draftResp);
         setDraft(body ? { ...baseline, ...body } : baseline);
         setHasDraft(!!body);
+        setIfDirty(false);
       } catch (e) {
         if (!cancelled) setError(formatMetadataError(e));
       } finally {
@@ -1356,8 +1452,14 @@ export function InterfacesPillar({
     };
   }, [client, current, isEditable, publishNonce]);
 
+  // objectui#5813 — a local dirty flag so auto-save only arms after a real
+  // edit, never on the load-effect's own setDraft.
+  const [ifDirty, setIfDirty] = React.useState(false);
   const onPatch = React.useCallback(
-    (patch: Record<string, unknown>) => setDraft((d) => ({ ...d, ...patch })),
+    (patch: Record<string, unknown>) => {
+      setDraft((d) => ({ ...d, ...patch }));
+      setIfDirty(true);
+    },
     [],
   );
   const doSave = React.useCallback(async () => {
@@ -1366,6 +1468,7 @@ export function InterfacesPillar({
     try {
       await client.save(current.type, current.name, draft, { mode: 'draft', packageId });
       setHasDraft(true);
+      setIfDirty(false);
       onDraftSaved?.();
     } catch (e) {
       setError(formatMetadataError(e));
@@ -1373,6 +1476,12 @@ export function InterfacesPillar({
       setSaving(false);
     }
   }, [client, current, draft, onDraftSaved]);
+  useDraftAutoSave({
+    dirty: ifDirty,
+    blocked: !current || !isEditable || !!saving || readOnly || inspectorBlocking > 0,
+    snapshot: draft,
+    save: doSave,
+  });
 
   // nav editing — patch appDraft.navigation, then save/publish the App overlay
   const onNavPatch = React.useCallback((patch: Record<string, unknown>) => {
@@ -1405,6 +1514,13 @@ export function InterfacesPillar({
       setNavSaving(false);
     }
   }, [client, appName, appDraft, onDraftSaved]);
+  // objectui#5813 — nav edits auto-save while edit mode is open.
+  useDraftAutoSave({
+    dirty: navDirty,
+    blocked: !appName || !editNav || !!navSaving || readOnly,
+    snapshot: appDraft,
+    save: doNavSave,
+  });
 
   // ADR-0057 P3c — the canvas and the inspector are rendered by BOTH layouts
   // below (the classic three-zone row, and the folded center-tabs grid that
@@ -1664,21 +1780,13 @@ export function InterfacesPillar({
             {t('engine.studio.unpublishedDraft', locale)}
           </span>
         )}
-        <button type="button"
-          onClick={doSave}
-          disabled={!current || !isEditable || !!saving || readOnly || inspectorBlocking > 0}
-          title={
-            inspectorBlocking > 0
-              ? t('perm.cel.saveBlocked', locale)
-              : readOnly
-                ? t('engine.studio.pkg.readonlyHint', locale)
-                : undefined
-          }
-          className="ml-auto inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50"
-        >
-          {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
-          {t('engine.studio.saveDraft', locale)}
-        </button>
+        {/* objectui#5813 — drafts auto-save; the spinner is the affordance. */}
+        {saving === 'draft' && (
+          <span className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground" data-testid="if-autosaving">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t('engine.studio.autoSaving', locale)}
+          </span>
+        )}
       </div>
 
       <div className="relative flex min-h-0 flex-1">
@@ -1732,18 +1840,12 @@ export function InterfacesPillar({
                     {t('engine.studio.unpublished', locale)}
                   </span>
                 )}
-                <button type="button"
-                  onClick={doNavSave}
-                  disabled={!navDirty || !!navSaving}
-                  className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] hover:bg-muted disabled:opacity-50"
-                >
-                  {navSaving === 'draft' ? (
+                {navSaving === 'draft' && (
+                  <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground" data-testid="nav-autosaving">
                     <Loader2 className="h-3 w-3 animate-spin" />
-                  ) : (
-                    <Save className="h-3 w-3" />
-                  )}
-                  {t('engine.studio.saveDraft', locale)}
-                </button>
+                    {t('engine.studio.autoSaving', locale)}
+                  </span>
+                )}
               </div>
             )}
           </div>
@@ -2339,7 +2441,8 @@ export function DataPillar({
       setHasDraft(true);
       setDirty(false);
       setSavedAt(new Date());
-      toast.success(tFormat('engine.studio.data.savedDraft', locale, { label: current.label }));
+      // No success toast: with auto-save (objectui#5813) it would fire after
+      // every editing pause — the quiet last-saved hint is the affordance.
       onDraftSaved?.();
     } catch (e) {
       setError(formatMetadataError(e));
@@ -2347,6 +2450,15 @@ export function DataPillar({
       setSaving(false);
     }
   }, [client, current, objDraft, onDraftSaved, packageId, locale]);
+
+  // objectui#5813 — auto-save replaces the 保存草稿 button; the blocked guard
+  // is the button's old disabled-condition verbatim.
+  useDraftAutoSave({
+    dirty,
+    blocked: !current || !!saving || readOnly || saveBlocking > 0,
+    snapshot: objDraft,
+    save: doSave,
+  });
 
   // Drag-reorder columns → reorder the object's `fields` metadata (field display
   // order follows metadata order), saved as a DRAFT. Published later via the
@@ -2388,15 +2500,23 @@ export function DataPillar({
   // recessed `bg-muted` track with an elevated `bg-background` pill on the
   // active segment — the inverse of the old transparent-track/grey-active
   // styling, which read as toolbar chrome rather than a distinct nav layer.
+  // objectui#5813 — the 90% path is 记录/表单 (fields ARE the grid's columns,
+  // with 添加字段 right beside them, so a separate fields tab would ADD a
+  // surface, not remove one). The five power tabs keep their panels untouched
+  // behind one 「高级」 menu — capability stays, the default view stops taxing
+  // every visit with seven choices (maintainer ruling 2026-08-24).
   const dataTabs: ReadonlyArray<{ key: typeof viewMode; label: string }> = [
     { key: 'grid', label: t('engine.studio.data.tab.records', locale) },
     { key: 'form', label: t('engine.studio.data.tab.form', locale) },
+  ];
+  const advancedDataTabs: ReadonlyArray<{ key: typeof viewMode; label: string }> = [
     { key: 'rules', label: t('engine.studio.data.tab.rules', locale) },
     { key: 'hooks', label: t('engine.studio.data.tab.hooks', locale) },
     { key: 'actions', label: t('engine.studio.data.tab.actions', locale) },
     { key: 'api', label: t('engine.studio.data.tab.api', locale) },
     { key: 'settings', label: t('engine.studio.data.tab.settings', locale) },
   ];
+  const activeAdvancedTab = advancedDataTabs.find((tabDef) => tabDef.key === viewMode);
 
   // The selected object's own icon (from its metadata) — prefer the loaded
   // draft body, fall back to the rail header. getIcon degrades to Database.
@@ -2435,31 +2555,21 @@ export function DataPillar({
             {t('engine.studio.unpublishedDraft', locale)}
           </span>
         )}
-        {savedAt && !dirty && (
+        {/* objectui#5813 — drafts auto-save (see useDraftAutoSave above); the
+            hint is the whole affordance: saving spinner while in flight, the
+            last-saved time once landed. The old 保存草稿 button is retired. */}
+        {saving === 'draft' ? (
+          <span className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground" data-testid="data-autosaving">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t('engine.studio.autoSaving', locale)}
+          </span>
+        ) : savedAt && !dirty ? (
           <span className="ml-auto text-[11px] text-muted-foreground" data-testid="data-saved-at">
             {tFormat('engine.studio.data.lastSaved', locale, {
               time: savedAt.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' }),
             })}
           </span>
-        )}
-        <button type="button"
-          onClick={doSave}
-          disabled={!current || !dirty || !!saving || readOnly || saveBlocking > 0}
-          title={
-            saveBlocking > 0
-              ? t('perm.cel.saveBlocked', locale)
-              : readOnly
-                ? t('engine.studio.pkg.readonlyHint', locale)
-                : undefined
-          }
-          className={
-            (savedAt && !dirty ? '' : 'ml-auto ') +
-            'inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50'
-          }
-        >
-          {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
-          {t('engine.studio.saveDraft', locale)}
-        </button>
+        ) : null}
       </div>
 
       <div className="relative flex min-h-0 flex-1">
@@ -2585,6 +2695,40 @@ export function DataPillar({
                       {tab.label}
                     </button>
                   ))}
+                  {/* 「高级」 — the five power panels (objectui#5813). When one
+                      is open the trigger wears its NAME and the active pill, so
+                      the collapsed default never hides where you are. */}
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        data-testid="data-tabs-advanced"
+                        aria-pressed={Boolean(activeAdvancedTab)}
+                        className={
+                          'inline-flex items-center gap-1 rounded-md px-3 py-1 text-[13px] transition-all ' +
+                          (activeAdvancedTab
+                            ? 'bg-background font-medium text-foreground shadow-sm'
+                            : 'text-muted-foreground hover:text-foreground')
+                        }
+                      >
+                        {activeAdvancedTab
+                          ? activeAdvancedTab.label
+                          : t('engine.studio.data.tab.advanced', locale)}
+                        <ChevronDown className="h-3 w-3" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start">
+                      {advancedDataTabs.map((tab) => (
+                        <DropdownMenuItem
+                          key={tab.key}
+                          onSelect={() => setViewMode(tab.key)}
+                          className={viewMode === tab.key ? 'font-medium text-primary' : undefined}
+                        >
+                          {tab.label}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
                 {(viewMode === 'grid' || viewMode === 'form') && !readOnly && (
                   <button
@@ -3139,7 +3283,10 @@ function AutomationsPillar({
       } catch (e) {
         if (!cancelled) setError(formatMetadataError(e));
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          setAutoDirty(false);
+        }
       }
     })();
     return () => {
@@ -3147,8 +3294,13 @@ function AutomationsPillar({
     };
   }, [client, current, publishNonce]);
 
+  // objectui#5813 — local dirty flag: auto-save arms only after a real edit.
+  const [autoDirty, setAutoDirty] = React.useState(false);
   const onPatch = React.useCallback(
-    (patch: Record<string, unknown>) => setDraft((d) => ({ ...d, ...patch })),
+    (patch: Record<string, unknown>) => {
+      setDraft((d) => ({ ...d, ...patch }));
+      setAutoDirty(true);
+    },
     [],
   );
   const doSave = React.useCallback(async () => {
@@ -3158,6 +3310,7 @@ function AutomationsPillar({
     try {
       await client.save('flow', current.name, draft, { mode: 'draft', packageId });
       setHasDraft(true);
+      setAutoDirty(false);
       onDraftSaved?.();
     } catch (e) {
       setError(formatMetadataError(e));
@@ -3165,6 +3318,12 @@ function AutomationsPillar({
       setSaving(false);
     }
   }, [client, current, draft, onDraftSaved]);
+  useDraftAutoSave({
+    dirty: autoDirty,
+    blocked: !current || !isEditable || !!saving || readOnly,
+    snapshot: draft,
+    save: doSave,
+  });
 
   // Enable/disable persists via the flow's deployment `status` (active = on,
   // obsolete = off) — the engine honors it on the next publish. The switch flips
@@ -3223,15 +3382,13 @@ function AutomationsPillar({
             {flowEnabled ? t('engine.studio.auto.enabled', locale) : t('engine.studio.auto.disabled', locale)}
           </button>
         )}
-        <button type="button"
-          onClick={doSave}
-          disabled={!current || !isEditable || !!saving || readOnly}
-          title={readOnly ? t('engine.studio.pkg.readonlyHint', locale) : undefined}
-          className="ml-auto inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50"
-        >
-          {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
-          {t('engine.studio.saveDraft', locale)}
-        </button>
+        {/* objectui#5813 — drafts auto-save; the spinner is the affordance. */}
+        {saving === 'draft' && (
+          <span className="ml-auto inline-flex items-center gap-1 text-[11px] text-muted-foreground" data-testid="auto-autosaving">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t('engine.studio.autoSaving', locale)}
+          </span>
+        )}
       </div>
 
       <div className="relative flex min-h-0 flex-1">


### PR DESCRIPTION
Closes #5813 (cloud#1609 增量四). Three cuts per the maintainer's simplification ruling, all capability-preserving:

1. **Object sub-tabs 7 → 2 + 「高级」**: 记录/表单 stay; 验证/钩子/操作/API/设置 fold into one menu whose trigger wears the open panel's name + active pill. A separate 字段 tab was consciously not added — fields are the grid's columns with 添加字段 beside them; a third field surface would add UI, not remove it.
2. **Draft auto-save**: debounced 1.5s `useDraftAutoSave` replaces all four 保存草稿 buttons. CEL-blocking gates the TIMER (objectui#4306's own rule); failed saves re-arm only on the next edit; quiet spinner + last-saved hint instead of per-save toasts.
3. **权限 → 「更多」**: primary nav = Data/Automations/Interfaces exactly; overflow items carry the same dirty-guard; route & pages untouched.

Toward the card's measurable acceptance: Data pillar default chrome drops from 7 tabs + save button + add-field to 2 tabs + 1 menu + add-field; topbar loses 保存草稿 and the 权限 tab (with #5801's merged 变更 anchor, the topbar is now 3 pillars + 更多 + 变更/发布).

studio-design suite: 34 files / 195 tests green (guard tests drive Access through the overflow; gate suites pin the auto-save semantics). Staging-only train per the release directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)