### PR TITLE
refactor(dashboard): drop ObjectPivotTable's i18n-resolver ref workaround

### DIFF
--- a/.changeset/objectpivottable-i18n-resolver-refs-5625.md
+++ b/.changeset/objectpivottable-i18n-resolver-refs-5625.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+`ObjectPivotTable` now depends on the `fieldLabel` / `fieldOptionLabel`
+resolvers directly instead of holding them behind refs, so a pivot re-derives
+its header and option labels when the resolver genuinely changes
+(objectui#5625).
+
+The refs existed for a reason that no longer holds. `useSafeFieldLabel()`
+returned a fresh object on every render outside an i18next provider, so a direct
+dependency would have re-run the metadata-derivation effect on every render —
+and that effect ends in `setFieldLabelMaps` / `setFieldNameLabels` with freshly
+built objects, so each run scheduled the next one: an unbounded derive loop.
+`ObjectPivotTable` worked around that locally with `fieldLabelRef` /
+`fieldOptionLabelRef` plus a `useEffect` keeping them current.
+`useObjectLabel`'s memo now holds with or without an i18next instance bound
+(objectui#5564), so both resolvers have a stable identity on both paths and the
+indirection buys nothing.
+
+It did cost something, and that is the user-visible half: a ref-hidden
+dependency meant the derivation did NOT re-run when the resolver changed. A
+pivot mounted before its `I18nProvider`, or rendered across a language switch,
+kept showing its top-left header label and its select-option cell labels as
+resolved by the old resolver — until some unrelated dependency (the data source,
+the object name) happened to move. It now re-derives once on that transition and
+renders in the active language.
+
+This is the same removal objectui#5587 made in `ObjectChart`, one package over.
+
+Pinned by `ObjectPivotTable.i18nResolverDeps.test.tsx`, which counts derivations
+across forced re-renders both outside and inside a provider, checks that the two
+derived state maps settle, and asserts the language-switch re-derivation.
+Reverting `useObjectLabel.ts` to its pre-objectui#5585 state turns the
+no-provider case red (derivations in the dozens instead of 1), so the removal is
+pinned to the fix that unlocked it rather than to a comment.

--- a/packages/plugin-dashboard/src/ObjectPivotTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectPivotTable.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useEffect, useContext, useRef } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { useDataScope, SchemaRendererContext, useFilterScope } from '@object-ui/react';
 import { useSafeFieldLabel } from '@object-ui/i18n';
 import { extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, type DrillEvent } from '@object-ui/core';
@@ -81,16 +81,8 @@ export const ObjectPivotTable: React.FC<ObjectPivotTableProps> = ({ schema, data
   const [drillEvent, setDrillEvent] = useState<DrillEvent | null>(null);
 
   // i18n: translate field display labels and select option labels via the
-  // standard object/field translation conventions. Held behind refs so the
-  // metadata-derivation effect doesn't need them in its dep array (the i18n
-  // hook returns fresh function identities each render).
+  // standard object/field translation conventions.
   const { fieldLabel, fieldOptionLabel } = useSafeFieldLabel();
-  const fieldLabelRef = useRef(fieldLabel);
-  const fieldOptionLabelRef = useRef(fieldOptionLabel);
-  useEffect(() => {
-    fieldLabelRef.current = fieldLabel;
-    fieldOptionLabelRef.current = fieldOptionLabel;
-  }, [fieldLabel, fieldOptionLabel]);
 
   useEffect(() => {
     if (!dataSource || !schema.objectName) return;
@@ -105,7 +97,7 @@ export const ObjectPivotTable: React.FC<ObjectPivotTableProps> = ({ schema, data
         const nameLabels: Record<string, string> = {};
         for (const [fieldName, fieldDef] of Object.entries<any>(s.fields)) {
           const rawLabel = fieldDef?.label ? String(fieldDef.label) : fieldName;
-          nameLabels[fieldName] = fieldLabelRef.current(objectName, fieldName, rawLabel);
+          nameLabels[fieldName] = fieldLabel(objectName, fieldName, rawLabel);
           const opts = fieldDef?.options;
           if (Array.isArray(opts) && opts.length > 0) {
             const m: Record<string, string> = {};
@@ -113,7 +105,7 @@ export const ObjectPivotTable: React.FC<ObjectPivotTableProps> = ({ schema, data
               if (opt && opt.value !== undefined && opt.label !== undefined) {
                 const value = String(opt.value);
                 const fallback = String(opt.label);
-                m[value] = fieldOptionLabelRef.current(objectName, fieldName, value, fallback);
+                m[value] = fieldOptionLabel(objectName, fieldName, value, fallback);
               }
             }
             if (Object.keys(m).length > 0) maps[fieldName] = m;
@@ -124,7 +116,20 @@ export const ObjectPivotTable: React.FC<ObjectPivotTableProps> = ({ schema, data
       })
       .catch(() => { /* silently fall back to raw values */ });
     return () => { alive = false; };
-  }, [dataSource, schema.objectName]);
+    // `fieldLabel` / `fieldOptionLabel` are REAL dependencies: the derivation
+    // above calls both, so a run with a stale resolver stores stale labels in
+    // `fieldLabelMaps` / `fieldNameLabels` and the pivot's headers and cells
+    // render in the wrong language until some unrelated dependency happens to
+    // move. They used to be hidden behind refs because `useSafeFieldLabel()`
+    // returned a fresh object on every render outside an i18next provider,
+    // which would have made this effect re-run on every render — and, because
+    // it ends in two `setState` calls with freshly built objects, each run
+    // scheduled the next one: an unbounded derive loop. `useObjectLabel`'s memo
+    // now holds on both paths (objectui#5564), so these identities change only
+    // when the resolver genuinely changes — a provider mounting, or a language
+    // switch — and the effect settles after one run per such change.
+    // Pinned by `ObjectPivotTable.i18nResolverDeps.test.tsx` (objectui#5625).
+  }, [dataSource, schema.objectName, fieldLabel, fieldOptionLabel]);
 
   // Session scope for `{current_user_id}` / `{current_org_id}` in the schema
   // filter. Read at component level — the fetch below is async.

--- a/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.i18nResolverDeps.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.i18nResolverDeps.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5625 — `ObjectPivotTable` reads `fieldLabel` / `fieldOptionLabel`
+ * DIRECTLY, derives its label maps exactly once, and re-derives when the
+ * resolver genuinely changes.
+ *
+ * The metadata-derivation effect used to hide both resolvers behind refs,
+ * because `useSafeFieldLabel()` handed back a fresh object on every render
+ * outside an i18next provider (objectui#5564). A direct dependency would then
+ * have re-run the effect on every render — and this effect ends in
+ * `setFieldLabelMaps` / `setFieldNameLabels` with freshly built objects, so
+ * every run scheduled the next one: an unbounded derive loop. That is what the
+ * refs were written to stop, and it is the same shape objectui#5587 removed
+ * from `ObjectChart` (PR #5628), one package over.
+ *
+ * `useObjectLabel`'s memo now holds on BOTH paths, so the refs are dead weight
+ * and the dependencies can be honest.
+ *
+ * WHAT THIS FILE ASSERTS, AND WHY IT IS NOT AN OUTPUT TEST
+ * -------------------------------------------------------
+ * Nothing *renders* wrong under the loop — the pivot just re-derives forever
+ * and the labels it shows are correct each time round. So a test that mounts
+ * once and checks the headers is green against the defect. These cases assert
+ * instead:
+ *
+ *   1. a DERIVATION COUNT across forced re-renders (`getObjectSchema` calls —
+ *      the effect's one observable side effect), both OUTSIDE and INSIDE a
+ *      provider, since those are the two identity paths the refs straddled; and
+ *   2. that the two derived state maps SETTLE — one distinct `rowLabels`
+ *      identity (`fieldLabelMaps`), one distinct `rowFieldLabel`
+ *      (`fieldNameLabels`), and a render count that stops growing over a quiet
+ *      window with no further work scheduled.
+ *
+ * The third case covers the half that the removal actually BUYS: a ref-hidden
+ * dependency meant the effect did NOT re-run when the resolver changed, so a
+ * pivot rendered across a language switch kept serving header and option
+ * labels resolved by the old resolver until some unrelated dependency happened
+ * to move.
+ *
+ * NOTE ON ORDER: `createI18n` registers its instance as react-i18next's
+ * process-global, and `useTranslation` falls back to that global when no
+ * context supplies one — a registration that survives unmount and `cleanup()`.
+ * The no-provider case therefore runs FIRST, and asserts the RAW labels rather
+ * than localized ones: if an instance ever leaked into it, that assertion fails
+ * instead of the case quietly becoming a second test of the with-provider path.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup, act, waitFor } from '@testing-library/react';
+
+const captured = vi.hoisted(() => ({
+  renders: [] as Array<{ rowLabels: any; rowFieldLabel: any }>,
+}));
+
+vi.mock('../PivotTable', () => ({
+  PivotTable: ({ rowLabels, rowFieldLabel }: any) => {
+    captured.renders.push({ rowLabels, rowFieldLabel });
+    return null;
+  },
+}));
+
+import { I18nProvider, createI18n } from '@object-ui/i18n';
+import { ObjectPivotTable } from '../ObjectPivotTable';
+
+afterEach(() => {
+  cleanup();
+  captured.renders.length = 0;
+});
+
+/**
+ * Module-level so the fetch effect's `schema.data` / `schema.filter`
+ * dependencies hold still — this file is measuring ONE effect, and a fresh
+ * schema object per render would move the other one underneath it.
+ *
+ * `data` carries rows, which is what keeps the fetch effect out of the way
+ * entirely (its guard is `!schema.data || schema.data.length === 0`). The data
+ * source below therefore offers only `getObjectSchema`, making that mock an
+ * unambiguous counter for the derivation effect under test.
+ */
+const SCHEMA = {
+  type: 'pivot-table',
+  objectName: 'deal',
+  rowField: 'stage',
+  columnField: 'owner',
+  valueField: 'amount',
+  data: [{ stage: 'won', owner: 'amy', amount: 10 }],
+} as any;
+
+/**
+ * `stage` is a `select` with options, so it lands in BOTH derived maps —
+ * `fieldLabelMaps.stage` (value→label) and `fieldNameLabels.stage` (the header
+ * label). One field exercising both is what lets a single pair of assertions
+ * speak for both state maps.
+ */
+const OBJECT_SCHEMA = {
+  fields: {
+    stage: { type: 'select', label: 'Stage', options: [{ value: 'won', label: 'Won' }] },
+    owner: { type: 'text', label: 'Owner' },
+  },
+};
+
+const RAW_FIELD_LABEL = 'Stage';
+const RAW_OPTION_LABEL = 'Won';
+
+const makeSource = () => ({ getObjectSchema: vi.fn(async () => OBJECT_SCHEMA) });
+
+/**
+ * Let anything the render just scheduled actually run.
+ *
+ * Deliberately a plain timer rather than an exhaustive `act` drain: a derive
+ * loop regenerates work as fast as act drains it, so draining would HANG
+ * instead of failing. A fixed window lets the counts be READ — under the loop
+ * they climb into the dozens, and the assertion reports the number.
+ */
+const settle = (ms = 40) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const lastRender = () => captured.renders[captured.renders.length - 1];
+
+/** Mount under a host that can force re-renders of the same element tree. */
+function mountWithChurn(wrap: (el: React.ReactElement) => React.ReactElement) {
+  const src = makeSource();
+  let bump: (() => void) | null = null;
+  const Host = () => {
+    const [, setTick] = React.useState(0);
+    bump = () => setTick((n) => n + 1);
+    return <ObjectPivotTable schema={SCHEMA} dataSource={src} />;
+  };
+  render(wrap(<Host />));
+  return {
+    src,
+    churn: (times: number) => {
+      for (let i = 0; i < times; i += 1) act(() => { bump!(); });
+    },
+  };
+}
+
+/** Distinct identities/values actually handed to `PivotTable`, ignoring pre-derivation undefined. */
+const distinct = (pick: (r: { rowLabels: any; rowFieldLabel: any }) => any) =>
+  new Set(captured.renders.map(pick).filter((v) => v !== undefined));
+
+/**
+ * Mount, wait for the first derivation, force three more renders, then report
+ * the derivation count and whether the derived state settled.
+ */
+async function deriveAcrossRerenders(wrap: (el: React.ReactElement) => React.ReactElement) {
+  const { src, churn } = mountWithChurn(wrap);
+  await waitFor(() => expect(lastRender()?.rowFieldLabel).toBeDefined());
+  const afterFirstDerive = src.getObjectSchema.mock.calls.length;
+
+  churn(3);
+  await settle();
+  const rendersAtQuiesce = captured.renders.length;
+  await settle();
+
+  return {
+    afterFirstDerive,
+    schemaCalls: src.getObjectSchema.mock.calls.length,
+    rendersAtQuiesce,
+    rendersAfterQuietWindow: captured.renders.length,
+    rowLabelIdentities: distinct((r) => r.rowLabels).size,
+    rowFieldLabels: [...distinct((r) => r.rowFieldLabel)],
+    optionLabel: lastRender()?.rowLabels?.won,
+  };
+}
+
+describe('ObjectPivotTable — i18n resolvers are direct effect dependencies (objectui#5625)', () => {
+  it('derives once across re-renders with NO i18next provider, and both maps settle', async () => {
+    const seen = await deriveAcrossRerenders((el) => el);
+
+    // The effect ran exactly once across mount + 3 forced re-renders.
+    expect(seen.afterFirstDerive).toBe(1);
+    expect(seen.schemaCalls).toBe(1);
+
+    // Settle check, both derived maps: `fieldLabelMaps` was stored once...
+    expect(seen.rowLabelIdentities).toBe(1);
+    // ...and so was `fieldNameLabels`. Raw values here are also the
+    // precondition: a leaked global instance would localize these and turn this
+    // case into a duplicate of the next one.
+    expect(seen.rowFieldLabels).toEqual([RAW_FIELD_LABEL]);
+    expect(seen.optionLabel).toBe(RAW_OPTION_LABEL);
+
+    // Nothing was still scheduling work when we stopped looking.
+    expect(seen.rendersAfterQuietWindow).toBe(seen.rendersAtQuiesce);
+  });
+
+  it('derives once across re-renders INSIDE an i18next provider, and both maps settle', async () => {
+    const instance = createI18n({ defaultLanguage: 'en', detectBrowserLanguage: false });
+    // `getAppNamespaces()` only discovers a top-level key carrying one of its
+    // marker sub-keys; `fields` is both the marker and the entry `fieldLabel`
+    // reads, and `fieldOptions` is what `fieldOptionLabel` reads.
+    instance.addResourceBundle('en', 'translation', {
+      crm: {
+        fields: { deal: { stage: 'Stage (en)' } },
+        fieldOptions: { deal: { stage: { won: 'Won (en)' } } },
+      },
+    }, true, true);
+
+    const seen = await deriveAcrossRerenders((el) => (
+      <I18nProvider instance={instance} persistLanguage={false}>{el}</I18nProvider>
+    ));
+
+    expect(seen.afterFirstDerive).toBe(1);
+    expect(seen.schemaCalls).toBe(1);
+    expect(seen.rowLabelIdentities).toBe(1);
+    // The resolvers really ran through the bound instance — so this case and
+    // the one above exercise two different identity paths, not one twice.
+    expect(seen.rowFieldLabels).toEqual(['Stage (en)']);
+    expect(seen.optionLabel).toBe('Won (en)');
+    expect(seen.rendersAfterQuietWindow).toBe(seen.rendersAtQuiesce);
+  });
+
+  it('re-derives exactly once when the resolver genuinely changes (language switch)', async () => {
+    // This is the case the REMOVAL buys, and the one the ref made impossible:
+    // with the resolvers hidden behind refs the effect's deps were
+    // `[dataSource, schema.objectName]`, neither of which a language switch
+    // moves, so the pivot kept rendering `Stage (en)` / `Won (en)` afterwards.
+    const instance = createI18n({ defaultLanguage: 'en', detectBrowserLanguage: false });
+    instance.addResourceBundle('en', 'translation', {
+      crm: {
+        fields: { deal: { stage: 'Stage (en)' } },
+        fieldOptions: { deal: { stage: { won: 'Won (en)' } } },
+      },
+    }, true, true);
+    instance.addResourceBundle('ja', 'translation', {
+      crm: {
+        fields: { deal: { stage: 'Stage (ja)' } },
+        fieldOptions: { deal: { stage: { won: 'Won (ja)' } } },
+      },
+    }, true, true);
+
+    const { src, churn } = mountWithChurn((el) => (
+      <I18nProvider instance={instance} persistLanguage={false}>{el}</I18nProvider>
+    ));
+
+    await waitFor(() => expect(lastRender()?.rowFieldLabel).toBe('Stage (en)'));
+    expect(src.getObjectSchema.mock.calls.length).toBe(1);
+    expect(lastRender()?.rowLabels?.won).toBe('Won (en)');
+
+    await act(async () => { await instance.changeLanguage('ja'); });
+
+    await waitFor(() => expect(lastRender()?.rowFieldLabel).toBe('Stage (ja)'));
+    expect(lastRender()?.rowLabels?.won).toBe('Won (ja)');
+    // Exactly ONE more derivation — the switch is a real dependency change, not
+    // a licence to re-derive on every subsequent render.
+    expect(src.getObjectSchema.mock.calls.length).toBe(2);
+
+    // ...and it settles again on the new language.
+    churn(3);
+    await settle();
+    const rendersAtQuiesce = captured.renders.length;
+    await settle();
+    expect(captured.renders.length).toBe(rendersAtQuiesce);
+    expect(src.getObjectSchema.mock.calls.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Fixes #5625

Removes the hand-rolled ref indirection around the two i18n resolvers in
`ObjectPivotTable`, mirroring the removal #5587 landed in `ObjectChart`
(PR #5628) one package over.

## Why the refs were there, and why they no longer buy anything

The metadata-derivation effect held `fieldLabel` / `fieldOptionLabel` behind
`fieldLabelRef` / `fieldOptionLabelRef` plus a `useEffect` keeping them current,
so it would not have to declare them. The stated reason was that the i18n hook
"returns fresh function identities each render" — true at the time:
`useSafeFieldLabel()` returned a fresh object on every render outside an i18next
provider.

That made a direct dependency genuinely unsafe here, and in a sharper way than
in `ObjectChart`. This effect ends in two `setState` calls
(`setFieldLabelMaps` / `setFieldNameLabels`) with **freshly built objects**, so
each run scheduled a re-render, which produced fresh resolver identities, which
re-ran the effect: an unbounded derive loop rather than a merely wasteful one.

`useObjectLabel`'s memo now pins both of its dependencies to module constants
while no i18next instance is bound (#5564, PR #5585), so the resolvers have a
stable identity on **both** paths. `packages/i18n/src/useObjectLabel.ts` carries
that fix on `main` today and `useObjectLabel-identity-5564.test.tsx` pins it,
including through `useSafeFieldLabel` specifically. Precondition re-verified on
current `main` before anything was removed.

## What the removal buys — the user-visible half

A ref-hidden dependency meant the derivation did **not** re-run when the
resolver genuinely changed. A pivot mounted before its `I18nProvider`, or
rendered across a language switch, kept showing its top-left header label and
its select-option cell labels as resolved by the *old* resolver, until some
unrelated dependency (the data source, the object name) happened to move. It
now re-derives exactly once on that transition.

## The two cautions the card raised, as tests

`ObjectPivotTable.i18nResolverDeps.test.tsx` (new) asserts a **derivation
count**, not rendered output — nothing renders wrong under the loop, so an
output assertion is green against the defect:

1. **Effect-run counting across re-renders, in and out of a provider** —
   `getObjectSchema` call count across mount plus three forced re-renders, once
   with no provider (asserting the *raw* labels, so a leaked process-global
   fails loudly instead of silently duplicating the other case) and once inside
   one (asserting the localized labels, so the two cases really exercise the two
   identity paths).
2. **Settle check on the two derived state maps** — one distinct `rowLabels`
   identity (`fieldLabelMaps`), one distinct `rowFieldLabel`
   (`fieldNameLabels`), and a render count that stops growing over a quiet
   window. The settle question the card flagged is answered: the maps do settle,
   because the effect runs once per genuine resolver change.
3. A third case pins the language-switch re-derivation described above.

The no-provider case runs **first**, because `createI18n` registers its instance
as react-i18next's process-global and that registration survives `cleanup()`.

## Reverse verification

Both legs on real commits, mutation confirmed on disk by grep rather than by an
editor's exit code, each leg driven by a script with a `trap … EXIT INT TERM`
restore. `@object-ui/i18n` is vitest-aliased to `packages/i18n/src`, so both
mutations are live from source with no rebuild step to get wrong.

| Ablation | Result |
|---|---|
| Restore the ref workaround in `ObjectPivotTable.tsx` (`git checkout` the base rev; `fieldLabelRef` back to 3 occurrences, direct-deps line to 0) | **RED** — `AssertionError: expected 'Stage (en)' to be 'Stage (ja)'`. 1 failed, 2 passed. |
| Revert the memo-stability fix in `useObjectLabel.ts` (`NO_INSTANCE_T;` to 0 occurrences, `const t = boundT;` to 1) | **RED** — `AssertionError: expected 258 to be 1`, i.e. 258 derivations instead of one: the loop returns. 1 failed, 2 passed. |
| Restored tree | **GREEN** — 3 passed, `git diff HEAD --stat` empty. |

**Legs that do NOT discriminate, named rather than implied:** under the first
ablation the two *counting* cases stay green — the ref version also derives
exactly once, which was the whole point of the ref — so only the language-switch
case speaks for the source change. Under the second ablation the two
*with-provider* cases stay green, because that identity path was stable before
#5585 too; only the no-provider case speaks for it. Neither leg alone covers the
change; the pair does.

## Verification, all at `b83dd427c`

- `pnpm exec vitest run packages/plugin-dashboard/ packages/i18n/` — **129 test
  files, 1607 tests passed**.
- `pnpm --filter @object-ui/plugin-dashboard type-check` — exit 0, after
  `pnpm --filter '@object-ui/plugin-dashboard^...' build`. Output echoed
  `> tsc --noEmit && tsc -p tsconfig.test.json`, so it was not a zero-match
  no-op.
- `pnpm lint` (repo-wide `eslint . --no-inline-config`) — **0 errors** repo-wide.
  No `react-hooks/exhaustive-deps` finding on the changed files: the new dep
  array is honest and needed no suppression.
- `node scripts/check-changeset-presence.mjs` — OK, 1 changeset declared.
- `check:control-bytes` (4870 files), `check:phantom-deps`,
  `check:self-import`, `check:i18n-keys` — all OK.

No type was widened, no pin loosened, no assertion weakened, no exemption added.

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_