### PR TITLE
fix(types): declare `editable` on the rich TableColumnSchema zod mirror so locked columns stay locked through parse

### DIFF
--- a/.changeset/issue-5821-table-column-editable-mirror.md
+++ b/.changeset/issue-5821-table-column-editable-mirror.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/types': patch
+---
+
+Add `editable` to the rich `TableColumnSchema` zod mirror. The `TableColumn` interface declares `editable?: boolean` and `data-table` honours it, but the mirror omitted the key, so a non-strict parse silently stripped it — and since the renderer treats absence as `true`, a column an author locked with `editable: false` came out of validation editable again. Columns locked with `editable: false` now stay locked through any pipeline that parses metadata via `@object-ui/types/zod` (including the CLI `validate` route).

--- a/packages/types/src/__tests__/static-table-narrow-surface.test.ts
+++ b/packages/types/src/__tests__/static-table-narrow-surface.test.ts
@@ -91,6 +91,28 @@ const RETIRED_COLUMN_KEYS: Record<string, unknown> = {
   cell: () => 'x',
 };
 
+/** Every key the rich `TableColumn` interface declares. `satisfies` keeps the
+ *  list honest against renames; the `Equal` pin keeps it EXHAUSTIVE — a key
+ *  added to the interface without a deliberate mirror decision fails
+ *  type-check here before the zod parity test can even run (objectui#5821). */
+const RICH_COLUMN_KEYS = [
+  'header',
+  'accessorKey',
+  'className',
+  'cellClassName',
+  'width',
+  'minWidth',
+  'align',
+  'fixed',
+  'type',
+  'sortable',
+  'filterable',
+  'resizable',
+  'editable',
+  'cell',
+] as const satisfies readonly (keyof TableColumn)[];
+type _RichKeyListExhaustive = Expect<Equal<(typeof RICH_COLUMN_KEYS)[number], keyof TableColumn>>;
+
 const STATIC_TABLE = {
   type: 'table',
   caption: 'Recent Orders',
@@ -173,19 +195,33 @@ describe('static `table` — the narrow zod surface refuses the retired keys (ob
 
 describe('rich `TableColumn` — NOT narrowed by the split (ruling scope, objectui#5474)', () => {
   it('the rich zod column still accepts every interactive key it declares', () => {
-    // `editable` is absent here on purpose: the rich ZOD mirror has never
-    // declared it (the TS interface does) — a pre-existing drift on the rich
-    // surface, outside this card's scope and tracked separately. Feeding it
-    // here would test the drift, not the split.
-    const richKeys = Object.fromEntries(
-      Object.entries(RETIRED_COLUMN_KEYS).filter(([k]) => k !== 'editable'),
-    );
+    // `editable` included since objectui#5821: the rich ZOD mirror declares
+    // it now, closing the drift the split had to leave tracked separately.
     const result = TableColumnSchema.safeParse({
       header: 'Amount',
       accessorKey: 'amount',
-      ...richKeys,
+      ...RETIRED_COLUMN_KEYS,
     });
     expect(result.success).toBe(true);
+  });
+
+  it('`editable: false` SURVIVES the rich parse — a locked column stays locked (objectui#5821)', () => {
+    // Acceptance alone cannot pin this: a non-strict z.object() ACCEPTS an
+    // undeclared key and silently STRIPS it, and the renderer treats absence
+    // as editable (`col.editable !== false`, data-table.tsx) — so before the
+    // mirror declared `editable`, this exact parse succeeded green while
+    // re-opening the locked column. The pin is the key surviving into the
+    // parsed OUTPUT, not the parse succeeding.
+    const result = TableColumnSchema.safeParse({
+      header: 'Amount',
+      accessorKey: 'amount',
+      editable: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect('editable' in result.data).toBe(true);
+      expect(result.data.editable).toBe(false);
+    }
   });
 
   it('`data-table` columns still parse with the rich keys authored', () => {
@@ -212,6 +248,10 @@ describe('the split itself — narrow = rich key set, live = the measured read s
     expect(tombstonedKeys(StaticTableColumnSchema).sort()).toEqual(
       Object.keys(RETIRED_COLUMN_KEYS).sort(),
     );
+  });
+
+  it('the rich zod mirror declares exactly the interface key set — nothing silently strippable (objectui#5821)', () => {
+    expect(Object.keys(shapeOf(TableColumnSchema)).sort()).toEqual([...RICH_COLUMN_KEYS].sort());
   });
 
   it('the static table zod tombstones exactly `hoverable` and `striped`', () => {

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -110,6 +110,7 @@ export const TableColumnSchema = z.object({
   sortable: z.boolean().optional().describe('Whether column is sortable'),
   filterable: z.boolean().optional().describe('Whether column is filterable'),
   resizable: z.boolean().optional().describe('Whether column is resizable'),
+  editable: z.boolean().optional().describe('Whether column is editable (for inline editing)'),
   cell: z.function().optional().describe('Custom cell renderer'),
 });
 


### PR DESCRIPTION
Fixes #5821

**`Clause-②: yes`** — `@object-ui/types/zod` is a published surface and this PR moves it two ways: the mirror's inferred type gains a key (13 → 14), and `editable: false` stops being stripped, so any pipeline parsing through the mirror (including the CLI `validate` route via `AnyComponentSchema`) changes behaviour. Dispatched at contract-review tier by the spec@objectui seat (seat post #5734).

## What

The rich `TableColumn` interface declares `editable?: boolean` (`@default true`) and `data-table` reads it at three sites to gate inline editing (`col.editable !== false`), but the zod mirror `TableColumnSchema` omitted the key. `z.object` is non-strict, so the mirror silently **stripped** it — and since the renderer treats absence as `true`, a column an author locked with `editable: false` came out of validation **editable again**.

- `packages/types/src/zod/data-display.zod.ts` — add `editable: z.boolean().optional()` to the rich `TableColumnSchema`, matching the interface's key order.
- `packages/types/src/__tests__/static-table-narrow-surface.test.ts` — the #5474 close-out plus the pins this card's verification bar demands:
  - fold `editable` back into the rich-surface interactive-keys loop (the filter and its drift comment are gone);
  - a **survival pin**: `editable: false` is asserted present in the parsed **output**. Acceptance alone cannot pin this defect — a non-strict object accepts-and-strips an undeclared key, so the pre-existing `safeParse(...).success` loop stayed green even before the fix (measured, see ablation below);
  - a **mirror key-set parity pin**: `RICH_COLUMN_KEYS` is typed `satisfies readonly (keyof TableColumn)[]` with an `Equal` exhaustiveness pin, and the runtime test asserts the zod shape declares exactly that list — a key added to the interface without a mirror decision now fails type-check, and a key dropped from the mirror fails the parity test.
- `.changeset/issue-5821-table-column-editable-mirror.md` — patch bump for `@object-ui/types`, stating the behaviour change plainly: columns locked with `editable: false` now stay locked through parse.

## Scope fence honoured (both directions)

- The narrow `StaticTableColumnSchema` tombstone for `editable` (`z.never().optional()`) is **untouched** — narrow-refuses / rich-honours is the ruled design of #5474, not drift.
- **#5830 runs in parallel in the same package** (`packages/types/src/complex.ts`). This diff does not touch `complex.ts`; the two surfaces are disjoint and changesets are one file each.

## Verification (all quoted from runs at `be8fdc8b9`, clean tree; the pre-commit runs were on the byte-identical tree the commit captured)

Local verification is narrowed to the affected packages — CI runs the full farm; per-package eslint/tsc verdicts elsewhere cannot move on this diff (no other package references `TableColumnSchema`: consumer grep found only `packages/types` itself, its zod barrel, and the narrow-only import in `table-declared-equals-enforced.test.tsx`; adding an optional key to a non-strict object rejects nothing that parsed before).

- **Reproduce (dist, rebuilt each side):** before — freshly built `packages/types/dist` at base `da8db03a6`, the card's `node -e` line prints `editable in parsed output: false`, parsed JSON drops the key. After — rebuilt dist at this HEAD prints `editable in parsed output: true — value: false`.
- **Ablation (mutation confirmed on disk both legs):** fix committed first; then the zod src file alone reverted to base (`grep -c` of the injected line = 0 — mutation on disk), test file kept. Result: `Tests 2 failed | 21 passed` — exactly the two #5821 pins red (survival + key-set parity), and notably the folded-in acceptance loop **stayed green under the strip**, proving acceptance alone is not a pin. Restore leg: file checked out from the branch (`grep -c` = 1 — restoration on disk), rerun `Tests 23 passed (23)`. The test imports the mirror by relative src path (`../zod/data-display.zod`), so no build step sits between the mutation and the reading; the dist reproduce line above covers the built surface separately.
- **`pnpm exec vitest run packages/types/`** (repo root, per AGENTS.md invocation discipline): `Test Files 48 passed (48)`, `Tests 543 passed (543)` — re-run at `be8fdc8b9` after the final commit.
- **`pnpm exec vitest run packages/components/`**: `Test Files 181 passed (181)`, `Tests 1656 passed (1656)`.
- **Type-checks:** `packages/types` `type-check` (src + examples + tests projects — the tests project enforces the new `Equal`/`satisfies` pins and the existing `@ts-expect-error` directives) exit 0; `packages/components` `type-check` exit 0 after building its dependency closure (first run failed with `TS2307 Cannot find module '@object-ui/core'` — stale worktree missing sibling dists, not this diff; declared here as the one retried gate).
- **Named gates run locally:** `check:spec-symbols` — its own verdict line: "spec symbol derivation: 1299 files scanned against 4959 spec export names ... ✅"; `check:phantom-deps` ✅; `check:self-import` ✅; `check-type-check-coverage` ✅ (41/41); `check-changeset-presence` ✅ (1 changeset detected); `check-changeset-fixed` ✅; `check-changeset-no-major` ✅ (patch bump); `packages/types` `eslint .` — 0 errors (253 pre-existing warnings, untouched by this diff).
- **Gate reading note for review:** `Type Check` carries `check:spec-symbols` (ci.yml:238). `Build Docs` is red on `main` (#5668, inherited) and shows implausibly short turbo-cached greens — excluded as evidence here with that cause; this PR makes no docs claims on it.

## Out of scope, filed unassigned

- #5853 — `TableColumn.type` disagrees three ways (interface: 8-literal union; mirror: any string; renderer live read set includes `int`/`integer`/`float`/`double` via an `as any` cast at `data-table.tsx:2152`). Found during this card's 13-key correspondence check; needs a canonical-value-set decision first, so it is not absorbed here. #5853 is not addressed in this PR and remains open.

_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_