### PR TITLE
fix(types): retire DashboardComponentSchema.aria — spec-tombstoned, renderer-dead

### DIFF
--- a/.changeset/dashboard-aria-member-retired-5830.md
+++ b/.changeset/dashboard-aria-member-retired-5830.md
@@ -1,0 +1,16 @@
+---
+'@object-ui/types': minor
+---
+
+**Published TS surface narrowed:** `DashboardComponentSchema` no longer declares
+the `aria` member (`{ ariaLabel?, ariaDescribedBy?, role? }`). Its doc comment
+claimed alignment with `@objectstack/spec AriaPropsSchema`, but the spec removed
+`dashboard.aria` at the #3896 audit close-out — `DashboardSchema.shape.aria` is
+a tombstone that refuses any value and tells authors to delete the key — and no
+dashboard renderer ever read `schema.aria` (objectui#5830).
+
+What an author loses is the **type-level suggestion** only: the key was already
+refused at parse (the Zod twin inherits the spec tombstone by reference), and
+`BaseSchema`'s index signature means an existing `aria:` line still compiles.
+There is **no runtime behaviour change** — the key never rendered, and stored
+documents carrying it already failed validation before this release.

--- a/packages/types/src/__tests__/dashboard-aria-retired-contract-twins.test.ts
+++ b/packages/types/src/__tests__/dashboard-aria-retired-contract-twins.test.ts
@@ -1,0 +1,84 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — `DashboardComponentSchema.aria` (objectui#5830).
+ *
+ * The spec removed `dashboard.aria` at the #3896 audit close-out ("no
+ * dashboard renderer ever applied it"): `DashboardSchema.shape.aria` in
+ * `@objectstack/spec/ui` is a tombstone that refuses any value and tells
+ * authors to delete the key. objectui's Zod twin inherits that refusal by
+ * reference (`SpecDashboardFields`, `zod/complex.zod.ts` — `aria` is not in
+ * its exclusion list), and `packages/plugin-dashboard/src` has no
+ * `schema.aria` read site (pinned by that package's
+ * `dashboardAuthoredInputs.test.tsx`). The TS interface was the last surface
+ * still DECLARING the key — under a comment claiming alignment with
+ * `AriaPropsSchema`, the opposite of the contract: the member-level instance
+ * of #4631's "declared surfaces disagree".
+ *
+ * What the deletion changes at the type level, stated honestly: `BaseSchema`
+ * carries `[key: string]: any`, so an authored `aria:` on a dashboard literal
+ * still COMPILES after the removal — it falls to the index signature. A
+ * `@ts-expect-error` pin on an authored literal therefore cannot stick here
+ * (unlike `default-children-retired-contract-twins.test.ts`, whose interface
+ * has no index signature). The pinnable effect is that `aria` stops being a
+ * DECLARED member: the probe below extracts the interface's literal key set —
+ * the index signature is filtered out by `string extends K` — and asserts
+ * `aria` is out while its former neighbours stay in. Real enforcement because
+ * `packages/types/tsconfig.test.json` is chained from this package's
+ * `type-check` script (#3009).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { DashboardComponentSchema } from '../complex';
+import { DashboardComponentSchema as DashboardComponentZodSchema } from '../zod/index.zod';
+
+// Literal (declared) keys of T: `string extends K` is true only for the index
+// signature's key, so mapping it to `never` leaves exactly the authored members.
+type DeclaredKeys<T> = { [K in keyof T as string extends K ? never : K]: T[K] };
+type Declared = keyof DeclaredKeys<DashboardComponentSchema>;
+
+describe('the TS interface no longer declares `aria` (objectui#5830)', () => {
+  it('`aria` is not a declared member; the neighbours it stood beside still are', () => {
+    // Type-level pin, erased at runtime: if the member came back, the first
+    // annotation would collapse to `false` and this file would fail
+    // `type-check`. (Reverse-verified at the PR: with the member restored,
+    // `tsc -p tsconfig.test.json` goes red on exactly this line.)
+    const ariaNotDeclared: 'aria' extends Declared ? false : true = true;
+    // Positive controls through the same extraction: a probe that saw no
+    // members at all would also report `aria` absent.
+    const widgetsDeclared: 'widgets' extends Declared ? true : false = true;
+    const dateRangeDeclared: 'dateRange' extends Declared ? true : false = true;
+    expect(ariaNotDeclared && widgetsDeclared && dateRangeDeclared).toBe(true);
+  });
+});
+
+describe('the Zod twin refuses the key by name — the spec tombstone, inherited by reference', () => {
+  const legal = { type: 'dashboard' as const, widgets: [] };
+
+  it('a legal dashboard parses green — the control for the refusal below', () => {
+    expect(DashboardComponentZodSchema.safeParse(legal).success).toBe(true);
+  });
+
+  it('an arbitrary unknown key does not refuse — the red below is the tombstone, not strictness', () => {
+    // BaseSchema is not `.strict()`: an undeclared key rides through (or is
+    // stripped) but never refuses. So a red `aria` can only come from the
+    // DECLARED tombstone flowing in from the spec — the thing being pinned.
+    const r = DashboardComponentZodSchema.safeParse({ ...legal, objectui5830NotAKey: 'x' });
+    expect(r.success).toBe(true);
+  });
+
+  it('`aria` is refused at its own path, with the removal message', () => {
+    const r = DashboardComponentZodSchema.safeParse({ ...legal, aria: { ariaLabel: 'Ops' } });
+    expect(r.success).toBe(false);
+    if (r.success) return;
+    const issue = r.error.issues.find((i) => i.path.join('.') === 'aria');
+    expect(issue, 'no issue at path `aria`').toBeTruthy();
+    expect(issue!.message).toMatch(/removed/);
+  });
+});

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -606,17 +606,16 @@ describe('P1.6 i18n & ARIA Protocol Alignment', () => {
     expect(schema.aria?.live).toBe('polite');
   });
 
-  it('should accept ARIA props on DashboardComponentSchema', () => {
-    const schema: DashboardComponentSchema = {
-      type: 'dashboard',
-      widgets: [],
-      aria: {
-        ariaLabel: 'Sales Dashboard',
-        role: 'region',
-      },
-    };
-    expect(schema.aria?.ariaLabel).toBe('Sales Dashboard');
-  });
+  // `should accept ARIA props on DashboardComponentSchema` REMOVED
+  // (objectui#5830): the spec removed `dashboard.aria` at the #3896 audit
+  // close-out — `DashboardSchema.shape.aria` is a tombstone that refuses any
+  // value — and `packages/plugin-dashboard/src` has no `schema.aria` read site
+  // (measured for #5742; pinned by that package's
+  // `dashboardAuthoredInputs.test.tsx`). The declared member is gone from the
+  // TS interface too; had this test stayed, it would have kept passing through
+  // `BaseSchema`'s index signature while asserting the opposite of the
+  // contract. The removal is pinned by
+  // `dashboard-aria-retired-contract-twins.test.ts`.
 
   it('should accept ARIA props on PageNodeSchema', () => {
     const schema: PageNodeSchema = {

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -844,15 +844,17 @@ export interface DashboardComponentSchema extends BaseSchema {
     defaultRange?: SpecDateRangeDefaultRange;
     allowCustomRange?: boolean;
   };
-  /**
-   * ARIA accessibility attributes.
-   * Aligned with @objectstack/spec AriaPropsSchema.
-   */
-  aria?: {
-    ariaLabel?: string;
-    ariaDescribedBy?: string;
-    role?: string;
-  };
+  // `aria` was DECLARED here until objectui#5830, under a comment claiming
+  // alignment with @objectstack/spec AriaPropsSchema — by then the opposite of
+  // the contract: the spec removed `dashboard.aria` at the #3896 audit
+  // close-out (no dashboard renderer ever applied it), so
+  // `DashboardSchema.shape.aria` is a tombstone that refuses any value, the
+  // Zod twin (`zod/complex.zod.ts`) inherits that refusal through
+  // `SpecDashboardFields`, and `plugin-dashboard` has no `schema.aria` read
+  // site. Note `BaseSchema`'s index signature still types an authored `aria`
+  // as `any` — this deletion removes the type-level suggestion and the false
+  // parity claim, not a key that ever rendered. Pinned by
+  // `__tests__/dashboard-aria-retired-contract-twins.test.ts`.
 }
 
 /**


### PR DESCRIPTION
Fixes #5830

**`Clause-②: yes`** — this narrows `@object-ui/types`' published TS surface: `DashboardComponentSchema` no longer declares the `aria` member (`ariaLabel` / `ariaDescribedBy` / `role`). Changeset declares a `minor` bump per the no-major house rule, with the breaking semantics stated in its body.

## What changed

- `packages/types/src/complex.ts` — deleted the `aria` member and its "Aligned with @objectstack/spec AriaPropsSchema" comment (the claim was the opposite of the contract); left the house-style removal note.
- `packages/types/src/__tests__/p1-spec-alignment.test.ts` — replaced `should accept ARIA props on DashboardComponentSchema` with the same removal-note form its widget-level sibling already uses. Kept, it would have stayed green after the deletion — see the index-signature note below — while asserting the opposite of the contract.
- `packages/types/src/__tests__/dashboard-aria-retired-contract-twins.test.ts` — new pin, both halves: a declared-key-set probe for the TS half, and the zod twin's tombstone refusal by name with two controls.
- `.changeset/dashboard-aria-member-retired-5830.md` — states the removal as a lost type-level suggestion; no runtime behaviour change (the key was already refused at parse and never rendered).

## Premise re-measured at base `da8db03a6` (card measured at `ad404e057`; PR #5829 landed between)

Both halves still hold — `premise_still_valid: true`:

- **Spec tombstone**: `DashboardSchema.shape.aria` from `@objectstack/spec/ui` (installed 17.2.0, matches lockfile) refuses any value; measured refusal message: "`dashboard.aria` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) — no dashboard renderer ever applied it … Delete the key." Full-document parse with the key also fails at path `aria`.
- **Renderer half**: `grep -rn "schema\.aria" packages/plugin-dashboard/src` finds exactly 2 hits, both prose inside `dashboardAuthoredInputs.test.tsx` documenting "no read site". Positive control: the same pattern family finds live `schema.widgets` reads in `DashboardRenderer.tsx` (5+ sites).
- **One measurement the card did not carry**: objectui's zod twin (`zod/complex.zod.ts`) already refuses `aria` — `SpecDashboardFields` derives from the spec's shape and `aria` is not in its exclusion list, so the tombstone flows in by reference. The TS interface was the **last** surface still advertising the key.

## Honest direction note — the reverse verification is not the naive one

`BaseSchema` carries an index signature (`[key: string]: any`), so deleting the member does **not** make an authored `aria:` a tsc error — reads and literal writes still compile through the index signature. The deletion's real effect is exactly what the card's changeset language priced: the **type-level suggestion** and the false parity claim disappear from the published `.d.ts`. A naive `@ts-expect-error` pin cannot stick here, so the pin extracts the interface's literal key set (`string extends K` filters the index signature) and asserts `aria` is not a declared member, with `widgets`/`dateRange` as positive controls through the same extraction.

**Reverse verification, run from the committed state** (mutation = restore the base file; on-disk confirmed by anchored grep before each reading; both legs `--noEmit`, dist untouched; restored and re-confirmed after):

```
PRE:     aria-member-count=0
MUTATED: aria-member-count=1 removal-note-count=0
leg 1  tsc --noEmit (main tsconfig)          MAIN_TSC_EXIT=0   (member back = valid TS; the red below is the pin, not collateral)
leg 2  tsc --noEmit -p tsconfig.test.json    error TS2322 at dashboard-aria-retired-contract-twins.test.ts(52,11): Type 'true' is not assignable to type 'false'   TEST_TSC_EXIT=2
RESTORED: aria-member-count=0 removal-note-count=1, git status clean
```

Built-surface evidence at HEAD `9a9b09ce0`: `grep -c "aria?:" packages/types/dist/complex.d.ts` = 0 after build (positive control `dateRange?:` = 1); base src had the member (count 1 at `da8db03a6`).

## Consumer sweep (the real work — every `aria` site in the repo, triaged)

Typed against `DashboardComponentSchema['aria']`: **one site**, the p1-spec-alignment test replaced above. Everything else is a different surface, verified live or separately retired:

- Widget-level `aria` (`DashboardWidgetSchema`) — retired upstream (objectstack#5010), inherits `?: never` from the spec; pinned by `report-chart-query-spec-parity.test.ts`. Untouched.
- `ChartConfigSchema.aria` (plugin-charts test, passes via `as any`) — pins that chart-level aria changes no DOM attribute. Untouched.
- `BaseSchema.ariaLabel` (flat key) and `props.aria` in `components/renderers/basic/elements.tsx` — live, different keys. Untouched.
- List-view / page / form `aria` (spec-bridge `list-view.ts` copy, `record-quick-actions.tsx` reads, p1 page test) — live surfaces on other node types. Untouched.
- Designer-surface `DashboardConfig.aria` + `DashboardConfigSchema.aria` — separate declared-but-dead pair, out of scope here; filed as #5852 (unassigned).
- Docs already agree: `content/docs/plugins/plugin-dashboard.mdx` states the "`aria` key is neither read nor authorable". No doc edit needed.

**Producer sweep** (who writes the key, not only who reads): no dashboard bridge exists in `spec-bridge/bridges/` (only form-view — whose aria copy was already removed at the #3896 close-out — and list-view, a live different surface); none of the `type: 'dashboard'` node constructors (DashboardDesignPage, builtinComponents, nav sync, anchors) writes `aria`; zero authored `aria` in examples/, content/, docs/ JSON or MDX corpora. Stored customer metadata is not reachable from this seat (#5741), so this is **"no reachable producer/usage"**, not "no usage" — and any stored document carrying the key already fails spec parse today, so the deletion changes no runtime outcome.

**Serial constraint (#5821, same package, in flight)**: surfaces stayed disjoint — this diff touches `complex.ts`, `p1-spec-alignment.test.ts`, one new test file, one changeset; none of `data-display.zod.ts` / `data-display.ts` / `static-table-narrow-surface.test.ts`.

## Local gates, by name, at HEAD `9a9b09ce0` (after the final commit)

- `turbo run type-check --filter=@object-ui/types --filter=@object-ui/plugin-dashboard` (builds dependency closure; both packages run `tsc --noEmit && tsc -p tsconfig.test.json`): **"Tasks: 14 successful, 14 total"**, exit 0 captured pre-pipe.
- `pnpm exec vitest run packages/types/ packages/plugin-dashboard/ --maxWorkers=2` (repo root, per AGENTS.md): **"Test Files 126 passed (126) / Tests 1267 passed (1267)"**, exit 0.
- New pin file run by name (zero-match would fail non-zero): **"1 passed / Tests 4 passed (4)"**.
- `pnpm check:spec-symbols` (the gate `Type Check` carries at ci.yml:238): **"✅ spec symbol derivation … ✅ spec alignment claims"**, exit 0. Deleting the false "Aligned with" claim only helps this gate.
- `node scripts/check-changeset-presence.mjs`: **"✅ … declares 1 changeset(s)"**.
- ESLint — **declared narrowing**: ran on the 3 changed `.ts` files only (`--format json`: 3 files, 0 errors, 8 pre-existing `no-explicit-any` warnings on lines this diff does not touch — the live-scan control). Corpus: root `eslint.config.js` covers the repo via `pnpm lint`; invariance: the config declares no `parserOptions.project` / type-aware services, so verdicts are per-file and this diff cannot move untouched files' results. The full farm is CI's run.
- All heavy runs serialized through the shared verify lock (longest hold 2m58s).

CI to read **by name**: `Type Check` (carries `check:spec-symbols`), `changeset-check`. `Build Docs` is red on `main` (#5668, inherited) — excluded with cause, not evidence either way. `Test (shard n/4)` is not a required check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7snar5mwF7qoXJazqKhys)_