### PR TITLE
fix(components): burn the `BARE_SPREAD_MINUS_NAME` group — 18 form-control renderers onto a DOM declaration

### DIFF
--- a/.changeset/form-control-renderers-dom-props-5632.md
+++ b/.changeset/form-control-renderers-dom-props-5632.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/components': patch
+---
+
+**Behaviour change:** the eighteen renderers whose host element is a form
+control no longer forward their whole prop bag to it. They route it through a
+form-control DOM declaration — the same `pickDomProps` mechanism `grid`, `flex`,
+`stack`, `container` and `text` were converged on — so an authored schema key
+becomes an HTML attribute only if the contract declares it one (objectui#5632,
+the `BARE_SPREAD_MINUS_NAME` slice of objectui#5574).
+
+The eighteen: `action:button`, `action:icon`, `ui:button`, `ui:checkbox`,
+`ui:combobox`, `ui:date-picker`, `ui:email`, `ui:file-upload`, `ui:input`,
+`ui:input-otp`, `ui:password`, `ui:radio-group`, `ui:sidebar-menu-button`,
+`ui:slider`, `ui:sonner`, `ui:switch`, `ui:textarea`, `ui:toggle`.
+
+What this stops reaching the DOM: the renderer's own declared props, consumed
+off `schema` to render the control AND spread onto the element a second time as
+attributes HTML does not define, plus the authored node's SDUI metadata and the
+flattened `props` container. Measured across `examples/schema-catalog`, rendered
+through the real `SchemaRenderer`: 284 illegitimate attributes over 287
+form-control nodes — `button[label]` 140, `button[icon]` 25, `input[inputtype]`
+23, `input[label]` 19, `toggle[label]` 14, `radio-group[options]` 8,
+`date-picker[placeholder]` 7, `file-upload[label]` 7, `file-upload[buttontext]`
+7, `checkbox[label]` 6, `textarea[label]` 6, `toggle[arialabel]` 6,
+`switch[label]` 4, `password[label]` 3, `email[label]` 2, `radio-group[direction]`
+2, and six singletons. The same probe reads 0 after, with `grid`'s 26 nodes at 0
+both times as the control and an unchanged node census across the two runs.
+
+`name` and `disabled` are DELIBERATELY still forwarded. Both are legal on a form
+control and neither was ever part of the leak — the ledgered shape for this
+group is thirteen attributes, not fourteen, precisely because HTML defines
+`name` on these hosts. The whitelist this group uses is therefore the shared
+SDUI one PLUS those two, not the bare `toDomProps` the container renderers take:
+that would have stripped the form-serialization key off every control and
+silently re-enabled every disabled one, and no gate in the repo would have gone
+red for it.
+
+Nothing an author writes renders differently: every leaked key was already being
+read off `schema` and applied. `id`, `role`, `tabIndex`, `className`, `style`,
+event handlers and the open `data-*` / `aria-*` families are unchanged.
+
+Anything that read one of the leaked attributes off the DOM — a CSS attribute
+selector such as `[label="Save"]`, or a test asserting `inputtype` on a rendered
+`ui:input` — must read the schema instead. No `@object-ui` code did; this is
+called out because the attributes were externally visible while they lasted.

--- a/examples/schema-catalog/package.json
+++ b/examples/schema-catalog/package.json
@@ -47,6 +47,7 @@
     "@object-ui/plugin-view": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/sdui-parser": "workspace:*",
+    "@object-ui/test-support": "workspace:*",
     "typescript": "^6.0.3"
   }
 }

--- a/examples/schema-catalog/test/form-control-dom-leak-5632.test.tsx
+++ b/examples/schema-catalog/test/form-control-dom-leak-5632.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * No form-control renderer puts an authored schema prop on the DOM
+ * (objectui#5632, the `BARE_SPREAD_MINUS_NAME` slice of objectui#5574).
+ *
+ * ## What this measures that the sweep gate cannot
+ *
+ * The same split `layout-dom-leak-5574.test.tsx` next door describes, applied
+ * to the other mechanism group. `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`
+ * is the gate for this class and the stronger instrument for the OPEN TAIL — it
+ * plants canary keys no schema declares. What it does not plant are the
+ * renderer's OWN DECLARED PROPS: its canary node authors no `inputType`, no
+ * `options`, no `buttonText`. Adding them there would rewrite the measured
+ * attribute set of the 97 renderers still ledgered, i.e. destroy the arrival
+ * reading that file exists to preserve.
+ *
+ * So the declared-prop half is measured HERE, at catalog scale, on real authored
+ * nodes — and for this group it is most of the reading: `button[label]` alone is
+ * 140 of the 284 attributes measured before the fix, and `label` is a key
+ * `ButtonRenderer` CONSUMES off `schema` to render the button's text before
+ * forwarding it to the element as well.
+ *
+ * ## Why the shared judge, and not this file's own `isLegitimate`
+ *
+ * The layout probe next door hand-rolls a six-line legitimacy test. It can,
+ * because every host it measures is a `<div>`. This group's hosts are
+ * `<input>`, `<textarea>` and `<button>`, where legitimacy is ELEMENT-SPECIFIC:
+ * `name` and `disabled` are real attributes on a control and leaks on a
+ * container, and `value` / `placeholder` / `checked` / `min` / `step` are legal
+ * on some controls and not others. A hand-rolled list would either report the
+ * legitimate ones (noise that makes a zero unreachable) or allow them
+ * everywhere (a hole exactly where this group lives). `@object-ui/test-support`'s
+ * judge already answers per element, by IDL reflection, and is the one the sweep
+ * gate grades with — so this file uses it rather than becoming a second judge
+ * with a different opinion (objectui#4434).
+ *
+ * ## Designing against the failure mode this test could have
+ *
+ * A zero here means nothing on its own: a renderer that renders NOTHING spreads
+ * nothing and reads clean, and so does a walk that found no nodes. Both are how
+ * a broken instrument reports a healthy tree. Three guards:
+ *
+ *   1. NODE COUNTS are asserted, per type, against the census below — and the
+ *      census was read IDENTICAL in the before and after runs, so the after-zero
+ *      is a reading and not a walk that stopped finding nodes.
+ *   2. `ui:grid` is measured in the same list as a CONTROL. It was converged by
+ *      objectui#4787 / PR #5573 and reads 0 in every configuration of this test,
+ *      so on its own it discriminates nothing; what it does is read 0 in the
+ *      SAME run in which its 15 unconverged siblings read 284, which is what
+ *      says the instrument was not blind. A control that runs somewhere else is
+ *      not a control.
+ *   3. The JUDGE is self-checked, and in the direction this file depends on:
+ *      that it is ELEMENT-AWARE. A judge that simply allowed `name` everywhere
+ *      would pass every assertion below and hide the whole group.
+ *
+ * ## Why each node is rendered without its children
+ *
+ * `findLeaks` walks the whole subtree, so a node's nested SDUI children get
+ * their leaks attributed to the parent. Measured, before the fix: scanning
+ * subtrees put 61 attributes on `grid` — the CONTROL — every one of them from a
+ * child `ui:icon` / `ui:button` / `ui:label` belonging to a different mechanism
+ * group. That is not a control any more, it is a mixture. Rendering each node
+ * with `children` / `body` removed scopes the reading to the renderer's own
+ * markup; nothing is lost, because the walk below collects nested nodes of the
+ * measured types separately and renders each on its own turn.
+ *
+ * Module-scope import of `@object-ui/components`, not `beforeAll` (AGENTS.md
+ * §测试纪律): registering the renderers is an unbounded module load and must not
+ * be billed to a bounded hook timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@object-ui/components';
+import { SidebarProvider } from '@object-ui/components';
+import { SchemaRenderer } from '@object-ui/react';
+import { findLeaks, leakReport } from '@object-ui/test-support';
+import { allExamples } from '../src/index.js';
+
+type Node = Record<string, unknown>;
+
+/**
+ * The fifteen `ui:` members of objectui#5632's group that the catalog authors,
+ * plus `grid` as the control (see guard 2 above).
+ *
+ * Three of the group's eighteen members are absent because the catalog contains
+ * no node of them: `ui:sonner`, and the two `action:` types — `action:button`
+ * and `action:icon` are reached through an `action:bar`'s `actions` array rather
+ * than as nodes carrying their own `type`, so a `type`-keyed walk cannot find
+ * them at all. All three are covered by the sweep gate, which is registry-driven
+ * and needs no authored node; this file is the DECLARED-PROP half only, and its
+ * scope is what the catalog actually contains.
+ */
+const MEASURED_TYPES = [
+  'button', 'input', 'checkbox', 'switch', 'textarea', 'combobox', 'date-picker',
+  'email', 'password', 'file-upload', 'input-otp', 'radio-group', 'slider',
+  'toggle', 'sidebar-menu-button',
+  'grid',
+] as const;
+
+/**
+ * Nodes of each type in the catalog today, and how many of them render no
+ * element at all. Asserted, so a zero leak reading is always accompanied by
+ * proof that something was actually rendered to read.
+ *
+ * These move when the CATALOG is authored, not when a renderer changes. A diff
+ * that changes these numbers and nothing else is an example being added; update
+ * them. A diff that changes them while touching a renderer is the thing this
+ * guard is for — `noElement` in particular, because a renderer made to bail
+ * early reads CLEAN below and has earned nothing.
+ */
+const NODE_CENSUS: Readonly<Record<string, { rendered: number; noElement: number }>> = {
+  button: { rendered: 140, noElement: 0 },
+  input: { rendered: 48, noElement: 0 },
+  checkbox: { rendered: 12, noElement: 0 },
+  switch: { rendered: 7, noElement: 0 },
+  textarea: { rendered: 9, noElement: 0 },
+  combobox: { rendered: 5, noElement: 0 },
+  'date-picker': { rendered: 7, noElement: 0 },
+  email: { rendered: 2, noElement: 0 },
+  password: { rendered: 4, noElement: 0 },
+  'file-upload': { rendered: 7, noElement: 0 },
+  'input-otp': { rendered: 5, noElement: 0 },
+  'radio-group': { rendered: 8, noElement: 0 },
+  slider: { rendered: 1, noElement: 0 },
+  toggle: { rendered: 17, noElement: 0 },
+  'sidebar-menu-button': { rendered: 15, noElement: 0 },
+  grid: { rendered: 26, noElement: 0 },
+};
+
+function collect(node: unknown, out: Node[] = []): Node[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collect(item, out);
+    return out;
+  }
+  if (node && typeof node === 'object') {
+    const record = node as Node;
+    if (
+      typeof record.type === 'string' &&
+      (MEASURED_TYPES as readonly string[]).includes(record.type)
+    ) {
+      out.push(record);
+    }
+    for (const value of Object.values(record)) collect(value, out);
+  }
+  return out;
+}
+
+describe('schema-catalog — no form-control renderer leaks an authored prop to the DOM (#5632)', () => {
+  it('the judge is element-aware — a zero below is a reading, not a blind spot', () => {
+    // Rendered directly rather than through the registry: this checks the
+    // JUDGE, and it must keep working even if every renderer in the repo is
+    // fixed. Without it, `findLeaks` could return `[]` unconditionally and every
+    // assertion in this file would still pass.
+    //
+    // The bag is spread rather than written as JSX attributes, which is not a
+    // typing dodge but the defect's own shape: `<div name="x" label="y">` does
+    // not type-check, and a bare spread of an untyped record is exactly how
+    // these attributes got onto real elements without anyone hearing about it.
+    const bag: Record<string, unknown> = {
+      className: 'c',
+      id: 'i',
+      'data-obj-id': 'd',
+      name: 'canary_node',
+      disabled: true,
+      label: 'L',
+      inputtype: 'text',
+    };
+
+    // On a CONTROL, `name` and `disabled` are real attributes and only the two
+    // undeclared keys are leaks. This is the half of the judge objectui#5632
+    // depends on: it is why `name` was never in the eighteen deleted rows, and
+    // therefore why forwarding it is not a regression this file can see.
+    const control = render(<input {...bag} />);
+    expect(
+      findLeaks(control.container.firstElementChild!)
+        .map((leak) => leak.attribute)
+        .sort(),
+    ).toEqual(['inputtype', 'label']);
+
+    // On a CONTAINER the same bag leaks `name` and `disabled` too — the judge
+    // answers per element rather than from one flat list. A judge that did not
+    // would report `[]` for the whole group and this file would be vacuous.
+    const container = render(<div {...bag} />);
+    expect(
+      findLeaks(container.container.firstElementChild!)
+        .map((leak) => leak.attribute)
+        .sort(),
+    ).toEqual(['disabled', 'inputtype', 'label', 'name']);
+  });
+
+  it('every catalog node of these sixteen types renders, and none leaks', () => {
+    const leaks: string[] = [];
+    const rendered = new Map<string, number>();
+    const noElement = new Map<string, number>();
+    const bump = (map: Map<string, number>, key: string) =>
+      map.set(key, (map.get(key) ?? 0) + 1);
+
+    for (const example of allExamples()) {
+      for (const node of collect(example.schema)) {
+        const type = String(node.type);
+        bump(rendered, type);
+        // Children removed — see "Why each node is rendered without its
+        // children" above. `SidebarProvider` is the one React host this set
+        // needs: `ui:sidebar-menu-button` reads `useSidebar()` and THROWS
+        // without it, and a caught throw renders attribute-clean markup that
+        // reads as a clean pass (the sweep gate's trap 3, at catalog scale).
+        const { children: _children, body: _body, ...own } = node;
+        const { container, unmount } = render(
+          <SidebarProvider>
+            <div data-probe-root="">
+              <SchemaRenderer schema={own as never} />
+            </div>
+          </SidebarProvider>,
+        );
+        const host = container.querySelector('[data-probe-root]')?.firstElementChild;
+        if (!host) {
+          bump(noElement, type);
+          unmount();
+          continue;
+        }
+        const found = findLeaks(host);
+        if (found.length > 0) leaks.push(`${example.id} :: ${leakReport(type, found)}`);
+        unmount();
+      }
+    }
+
+    // Asserted BEFORE the leak reading, so a walk that rendered nothing fails
+    // as a broken instrument rather than passing as a clean tree.
+    const census = Object.fromEntries(
+      MEASURED_TYPES.map((type) => [
+        type,
+        { rendered: rendered.get(type) ?? 0, noElement: noElement.get(type) ?? 0 },
+      ]),
+    );
+    expect(
+      census,
+      'the catalog node census moved. If this diff only adds/removes examples, ' +
+        'update NODE_CENSUS. If it touches a renderer, a node stopped rendering ' +
+        'an element — and a renderer that renders nothing reads CLEAN below.',
+    ).toEqual(NODE_CENSUS);
+
+    expect(
+      leaks,
+      'an authored schema prop reached the DOM as an HTML attribute. Route the ' +
+        'spread through `toFormControlDomProps` ' +
+        '(`packages/components/src/lib/form-control-dom-props.ts`) — never ' +
+        'widen that declaration and never add an exemption here. A key that ' +
+        'genuinely belongs on this control is DECLARED and forwarded BY NAME ' +
+        '(objectui#4435), the way `style` is at every call site.',
+    ).toEqual([]);
+  }, 120000);
+});

--- a/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
+++ b/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
@@ -37,9 +37,9 @@
  *   | plugin-calendar  |       3 |               0 |                 0 |
  *   | plugin-chatbot   |       3 |               0 |                 0 |
  *   | plugin-dashboard |       8 |               2 |             7 / 9 |
- *   | components       |     158 |             115 |          12 .. 15 |
+ *   | components       |     158 |              97 |          12 .. 15 |
  *
- * **117 of 181 targets leak.** The `components` row is objectui#5574 and is
+ * **99 of 181 targets leak.** The `components` row is objectui#5574 and is
  * covered in its own section below; the two `plugin-dashboard` rows are the
  * older tail. Both are in {@link LEAK_LEDGER}:
  * `plugin-dashboard:metric` and `plugin-dashboard:metric-card`, the open tail
@@ -121,7 +121,7 @@
  * have failed. These two differ in exactly one thing: which namespace the extra
  * widget went into.
  *
- * ### The reading — 119 of 158 ON ARRIVAL, in eight shapes; 115 today
+ * ### The reading — 119 of 158 ON ARRIVAL, in seven shapes; 97 today
  *
  * The card named four candidates (`flex`, `stack`, `container`, `text`) and was
  * careful to call them candidates. All four leaked. So did 115 others, and the
@@ -130,11 +130,13 @@
  * `ui:grid` read clean, which is objectui#4787 / PR #5573's fix now pinned by
  * a gate instead of by hand.
  *
- * The first four rows have since been DELETED rather than edited: `ui:flex`,
- * `ui:stack`, `ui:container` and `ui:text` are converged on `toDomProps` and
- * measure clean, so their rows had to go for the gate to pass — the two-way
- * expiry below, working exactly once it had something to expire. 115 rows
- * remain. What the arrival reading measured is preserved here in prose and in
+ * Twenty-two rows have since been DELETED rather than edited. First `ui:flex`,
+ * `ui:stack`, `ui:container` and `ui:text` (objectui#5574), then the eighteen
+ * form controls that made up the whole `BARE_SPREAD_MINUS_NAME` shape
+ * (objectui#5632) — which took a SHAPE off this list, not just rows, so the
+ * grouping is six mechanisms now and not seven. All twenty-two measure clean,
+ * so their rows had to go for the gate to pass — the two-way expiry below,
+ * working exactly once it had something to expire. 97 rows remain. What the arrival reading measured is preserved here in prose and in
  * the burn-down note on {@link COMPONENTS_LEAK_GROUPS}; what the gate asserts
  * is always current truth, which is the whole point of not writing dates into
  * a ledger.
@@ -866,8 +868,11 @@ interface LedgerEntry {
 /* ── objectui#5574: the `packages/components` reading, as a LEDGER ─────────── */
 
 /**
- * 115 of the 158 `packages/components` targets leak, and they do it in exactly
- * EIGHT shapes (119 did on arrival; see the burn-down note below). Writing that
+ * 97 of the 158 `packages/components` targets leak, and they do it in exactly
+ * SIX shapes (119 targets in seven shapes did on arrival; see the burn-down
+ * note below — and note the arrival count of shapes read `eight` here until
+ * objectui#5632 counted them: the groups were seven, and the card's own table
+ * listed seven). Writing that
  * many near-identical rows longhand would have buried the shapes
  * — so the rows are GROUPED BY MEASURED SHAPE, and every group names its
  * renderers one by one. Nothing here is a wildcard and nothing here is a
@@ -891,6 +896,28 @@ interface LedgerEntry {
  *     `flex[direction]` 5, `stack[align]` 4, `text[value]` 1); the same probe
  *     reads 0 after, with `grid`'s 26 nodes at 0 both times as the control.
  *
+ *   - objectui#5632 — the entire `BARE_SPREAD_MINUS_NAME` shape, all eighteen
+ *     members: `action:button`, `action:icon`, `ui:button`, `ui:checkbox`,
+ *     `ui:combobox`, `ui:date-picker`, `ui:email`, `ui:file-upload`, `ui:input`,
+ *     `ui:input-otp`, `ui:password`, `ui:radio-group`, `ui:sidebar-menu-button`,
+ *     `ui:slider`, `ui:sonner`, `ui:switch`, `ui:textarea`, `ui:toggle`. These
+ *     render FORM CONTROLS, so the convergence is NOT the bare `toDomProps` the
+ *     four above took — it is a form-control DECLARATION over the same
+ *     mechanism (`packages/components/src/lib/form-control-dom-props.ts`),
+ *     which forwards the `name` and `disabled` the SDUI baseline deliberately
+ *     withholds. That distinction is invisible from inside this file, which is
+ *     the point of writing it down here: `name` was never in these rows and
+ *     `disabled` is not even a canary, so a convergence that dropped both would
+ *     have turned this gate green while un-naming and re-enabling every control
+ *     in the library. The catalog-scale reading: 287 form-control nodes in
+ *     `examples/schema-catalog` put 284 illegitimate attributes on the DOM
+ *     (`button[label]` 140, `button[icon]` 25, `input[inputtype]` 23,
+ *     `input[label]` 19, `toggle[label]` 14, `radio-group[options]` 8,
+ *     `date-picker[placeholder]` 7, `file-upload[label]` 7,
+ *     `file-upload[buttontext]` 7, and a 34-attribute tail); the same probe
+ *     reads 0 after, with `grid`'s 26 nodes at 0 both times as the control and
+ *     an unchanged per-type node census across the two runs.
+ *
  * ## This is a ledger, not an allowlist — the difference, stated once
  *
  * An allowlist says "do not look here". Every row below says "we looked, this
@@ -900,7 +927,7 @@ interface LedgerEntry {
  * equals the recorded one; if it stops leaking, the gate ALSO fails until the
  * row goes. An allowlist has neither property. Nothing below is skipped,
  * `it.skip`-ed, quarantined or excluded from the sweep — all 158 targets render
- * and all 158 are scanned on every run, the 43 clean ones included.
+ * and all 158 are scanned on every run, the 61 clean ones included.
  */
 
 /**
@@ -920,8 +947,24 @@ const BARE_SPREAD: readonly string[] = [
  * mostly. `name` is absent from these rows not because the renderer stripped
  * it but because HTML makes it legitimate there, so the judge does not report
  * it. The authored identity key still reaches the DOM; on this host it is
- * simply not a leak. Worth keeping straight: converging these renderers on
- * `toDomProps` will not change that attribute, only the thirteen around it.
+ * simply not a leak.
+ *
+ * NO GROUP CARRIES THIS SHAPE ANY MORE — objectui#5632 burned all eighteen of
+ * its members and DELETED the group, which is why what is left is a bare
+ * attribute list. It survives as the base three other groups still derive from
+ * (`action:menu`, `ui:form`, `ui:sidebar-trigger`), each of which measures this
+ * shape plus or minus one attribute. Deleting it would mean hand-copying
+ * thirteen strings into three places and losing the statement that those three
+ * ARE this shape, varied.
+ *
+ * The prediction this docblock carried before the burn-down — "converging these
+ * renderers on `toDomProps` will not change that attribute, only the thirteen
+ * around it" — is now measured, and it was only true because the convergence
+ * was built to make it true. A bare `toDomProps` would have stripped `name`
+ * (and `disabled`, which this gate never measured at all) off every one of the
+ * eighteen controls, and nothing in this file would have moved. See
+ * `packages/components/src/lib/form-control-dom-props.ts`, which is the
+ * declaration that keeps the promise.
  */
 const BARE_SPREAD_MINUS_NAME: readonly string[] = [
   'ariadescribedby', 'arialabel', 'bind', 'colorvariant', 'datasource', 'events', 'props',
@@ -974,20 +1017,6 @@ const COMPONENTS_LEAK_GROUPS: readonly LedgerGroup[] = [
       'ui:sidebar-menu-item', 'ui:sidebar-provider', 'ui:skeleton', 'ui:small', 'ui:span',
       'ui:strong', 'ui:sub', 'ui:sup', 'ui:table', 'ui:tabs',
       'ui:time', 'ui:toggle-group', 'ui:tree-view', 'ui:u', 'ui:ul', 'ui:utility',
-    ],
-  },
-  {
-    attributes: BARE_SPREAD_MINUS_NAME,
-    reason:
-      'the same bare spread onto a host element that DEFINES `name` (form ' +
-      'controls and their siblings), so `name` is legitimate there and the ' +
-      'other thirteen leak.',
-    issue: 'objectui#5574',
-    targets: [
-      'action:button', 'action:icon', 'ui:button', 'ui:checkbox', 'ui:combobox',
-      'ui:date-picker', 'ui:email', 'ui:file-upload', 'ui:input', 'ui:input-otp',
-      'ui:password', 'ui:radio-group', 'ui:sidebar-menu-button', 'ui:slider', 'ui:sonner',
-      'ui:switch', 'ui:textarea', 'ui:toggle',
     ],
   },
   {
@@ -1391,6 +1420,40 @@ describe('the sweep covers a real, non-empty target set (objectui#4425)', () => 
       'these renderers are converged on `toDomProps` (objectui#4787 / PR #5573 ' +
         'for `grid`, objectui#5574 for the other four) and measure clean. A row ' +
         'here means a regression was re-ledgered instead of fixed.',
+    ).toEqual([]);
+    // …and they are still SWEPT, so "no row" cannot mean "no longer looked at".
+    const sweptTypes = new Set(ALL_TARGETS.map((target) => target.type));
+    expect(converged.filter((type) => !sweptTypes.has(type))).toEqual([]);
+  });
+
+  it('the whole form-control family is CLEAN — no row may re-absorb it', () => {
+    // objectui#5632's slice: the eighteen renderers that carried the
+    // `BARE_SPREAD_MINUS_NAME` shape. Their group is DELETED, and this is the
+    // inverted case that keeps it deleted — the same treatment objectui#5574
+    // gave the layout family directly above, and for the same reason: the sweep
+    // case fails if one of these regresses, and this one additionally fails if
+    // someone makes that red green by putting the row back.
+    //
+    // What this family adds over the layout one is the second failure
+    // direction, which is why the fix is NOT a bare `toDomProps`. These hosts
+    // are form controls, so `name` and `disabled` are legal on them — the judge
+    // never reported either, and the canary node authors no `disabled` at all.
+    // A convergence that dropped them would therefore read as a clean pass HERE
+    // while silently un-naming and re-enabling every control in the library.
+    // The declaration that prevents it is
+    // `packages/components/src/lib/form-control-dom-props.ts`; the guard that
+    // proves this file could not have noticed is stated in its docblock.
+    const converged = [
+      'action:button', 'action:icon', 'ui:button', 'ui:checkbox', 'ui:combobox',
+      'ui:date-picker', 'ui:email', 'ui:file-upload', 'ui:input', 'ui:input-otp',
+      'ui:password', 'ui:radio-group', 'ui:sidebar-menu-button', 'ui:slider', 'ui:sonner',
+      'ui:switch', 'ui:textarea', 'ui:toggle',
+    ];
+    expect(
+      converged.filter((type) => LEAK_LEDGER[type]),
+      'these renderers are converged on the form-control DOM declaration ' +
+        '(objectui#5632) and measure clean. A row here means a regression was ' +
+        're-ledgered instead of fixed.',
     ).toEqual([]);
     // …and they are still SWEPT, so "no row" cannot mean "no longer looked at".
     const sweptTypes = new Set(ALL_TARGETS.map((target) => target.type));

--- a/packages/components/src/lib/form-control-dom-props.ts
+++ b/packages/components/src/lib/form-control-dom-props.ts
@@ -1,0 +1,127 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  pickDomProps,
+  SDUI_DOM_PASS_THROUGH_KEYS,
+  type SduiDomPassThroughKey,
+  type DomProps as CoreDomProps,
+} from '@object-ui/core';
+
+/**
+ * The DOM pass-through declaration for the `packages/components` renderers whose
+ * host element is a FORM CONTROL (objectui#5632).
+ *
+ * ## Why this exists at all, rather than a bare `toDomProps`
+ *
+ * `toDomProps` is the SDUI contract's executor and its key list is deliberately
+ * ELEMENT-AGNOSTIC — it cannot know what element the widget renders, so it
+ * carries only what is legal on every element. `name` and `disabled` are legal
+ * on form controls and nowhere else, which is exactly why `dom-props.ts` leaves
+ * them out: `name` on the `<div>` a container widget renders is one of the 14
+ * attributes objectui#4431 closed.
+ *
+ * The renderers in this group render the other case. Routing them through the
+ * bare SDUI list would strip `name` and `disabled` off real controls — and
+ * `packages/fields` already wrote down what that costs, in the same words, for
+ * the same two keys:
+ *
+ * > Withholding them would make this helper a silent styling- and
+ * > interactivity-dropper … That is a NEW silent failure of exactly the kind
+ * > the whitelist exists to prevent, so they are forwarded.
+ *
+ * It is worth being precise about how INVISIBLE that failure would be here.
+ * The gate that grades this change
+ * (`packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`) reports
+ * attributes that ARRIVE illegitimately; it has no case for an attribute that
+ * stops arriving, and its canary node authors no `disabled` at all. So dropping
+ * `disabled` off every form control in the library would have moved not one
+ * number in this card's own acceptance evidence. The ledger predicted the same
+ * thing from the other side — its `BARE_SPREAD_MINUS_NAME` note says converging
+ * this group "will not change that attribute, only the thirteen around it" —
+ * and that prediction is only true if `name` is forwarded deliberately.
+ *
+ * ## One mechanism, three declarations
+ *
+ * This is the third declaration over the ONE mechanism in
+ * `@object-ui/core`'s `pickDomProps`, and it follows the pattern
+ * `@object-ui/fields` established rather than inventing one: the consuming
+ * package owns the key list its own contract implies, and calls the shared
+ * filter with it. The three, and what separates them:
+ *
+ *  - `toDomProps` (`@object-ui/core`) — the SDUI baseline, element-agnostic.
+ *  - `@object-ui/fields`' `toDomProps` — the baseline minus `role`, plus `name`
+ *    and `disabled`; `FieldWidgetComponentProps` declares the closed set.
+ *  - this one — the baseline PLUS `name` and `disabled`, nothing removed. It is
+ *    a strict superset of the SDUI list, which the compile-time assertion below
+ *    pins, so a key added to the shared set can never be quietly dropped here.
+ *
+ * Anything beyond this set is still the objectui#4435 route: DECLARE it and
+ * forward it by name. Do not reopen the spread (AGENTS.md #0.1 — fix the
+ * contract, never widen the consumer). `style` is the standing example, and it
+ * is forwarded by name at every call site for exactly that reason.
+ */
+const FORM_CONTROL_DOM_PASS_THROUGH_KEYS = [
+  ...SDUI_DOM_PASS_THROUGH_KEYS,
+
+  /* ── The two keys a form control adds, and nothing else ─────────────────── */
+  //
+  // `name` — the control's form-serialization key. On these hosts HTML defines
+  // it, which is the whole reason the sweep gate's `BARE_SPREAD_MINUS_NAME`
+  // group is thirteen attributes and not fourteen: the judge never reported
+  // `name` here, so it was never part of what this card removes.
+  //
+  // `disabled` — read by several of these renderers as a SEMANTIC prop and
+  // recomputed (`action:button` ORs it with its declared-gate verdict,
+  // `ui:button` ORs it with `loading`); forwarding it keeps the authored value
+  // reaching controls that do not recompute it, which is today's behaviour.
+  'name',
+  'disabled',
+] as const;
+
+type FormControlDomPassThroughKey = (typeof FORM_CONTROL_DOM_PASS_THROUGH_KEYS)[number];
+
+/**
+ * Compile-time link to the shared SDUI contract: every key the baseline
+ * forwards must be forwarded here too. A form control is a DOM element first —
+ * there is no key that is safe on a `<div>` and unsafe on an `<input>` — so any
+ * future addition to `SDUI_DOM_PASS_THROUGH_KEYS` that this list did not pick up
+ * is a drift, not a decision.
+ *
+ * Catches: DECLARED BUT NOT DELIVERED — the failure direction the leak gate
+ * structurally cannot see, because it looks for attributes that arrive, never
+ * for ones that go missing.
+ */
+type EverySduiKeyIsForwarded =
+  SduiDomPassThroughKey extends FormControlDomPassThroughKey ? true : never;
+const _everySduiKeyIsForwarded: EverySduiKeyIsForwarded = true;
+void _everySduiKeyIsForwarded;
+
+/** The subset of `P` this declaration forwards, with each key's declared type. */
+export type FormControlDomProps<P> = CoreDomProps<P, FormControlDomPassThroughKey>;
+
+/**
+ * Keep only what may legitimately become an attribute on a FORM CONTROL, and
+ * drop everything else — the injected `schema`, the data-source adapter, the
+ * authored node's SDUI metadata, the flattened `props` container, and every
+ * declared prop the renderer already consumed off `schema`.
+ *
+ * Replaces the bare `{...rest}` spread in a form-control registration:
+ *
+ * ```tsx
+ * // before — forwards whatever `SchemaRenderer` handed it
+ * const { style, ...rest } = props;
+ * return <Input name={schema.name} {...rest} />;
+ *
+ * // after
+ * return <Input name={schema.name} {...toFormControlDomProps(rest)} style={style} />;
+ * ```
+ */
+export function toFormControlDomProps<P extends object>(props: P): FormControlDomProps<P> {
+  return pickDomProps(props, FORM_CONTROL_DOM_PASS_THROUGH_KEYS);
+}

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -25,6 +25,7 @@ import { useAction } from '@object-ui/react';
 import { useCondition, toPredicateInput, usePredicateRecordContext } from '@object-ui/react';
 import { Button } from '../../ui';
 import { cn } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 import { Loader2 } from 'lucide-react';
 import { resolveIcon } from './resolve-icon';
 import { hasDeclaredVisibilityGate } from './visibility-gate';
@@ -249,7 +250,7 @@ const ActionButtonRenderer = forwardRef<
               : false
         ) || loading}
         onClick={handleClick}
-        {...rest}
+        {...toFormControlDomProps(rest)}
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
       >
         {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -21,6 +21,7 @@ import { useCondition, toPredicateInput, usePredicateRecordContext } from '@obje
 import { Button } from '../../ui';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../ui';
 import { cn } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 import { Loader2 } from 'lucide-react';
 import { resolveIcon } from './resolve-icon';
 import { hasDeclaredVisibilityGate } from './visibility-gate';
@@ -167,7 +168,7 @@ const ActionIconRenderer = forwardRef<
         ) || loading}
         onClick={handleClick}
         aria-label={schema.label || schema.name}
-        {...rest}
+        {...toFormControlDomProps(rest)}
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
       >
         {loading ? (

--- a/packages/components/src/renderers/feedback/sonner.tsx
+++ b/packages/components/src/renderers/feedback/sonner.tsx
@@ -10,9 +10,14 @@ import { ComponentRegistry } from '@object-ui/core';
 import type { SonnerSchema } from '@object-ui/types';
 import { toast } from 'sonner';
 import { Button } from '../../ui';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('sonner', 
   ({ schema, ...props }: { schema: SonnerSchema; [key: string]: any }) => {
+    // `style` forwarded by name; the rest through the form-control
+    // declaration (objectui#5632).
+    const { style, ...buttonProps } = props;
+
     const showToast = () => {
       const toastFn = schema.variant === 'success' ? toast.success :
                       schema.variant === 'error' ? toast.error :
@@ -26,7 +31,13 @@ ComponentRegistry.register('sonner',
     };
     
     return (
-      <Button onClick={showToast} variant={schema.buttonVariant} className={schema.className} {...props}>
+      <Button
+        onClick={showToast}
+        variant={schema.buttonVariant}
+        className={schema.className}
+        {...toFormControlDomProps(buttonProps)}
+        style={style}
+      >
         {schema.buttonLabel || 'Show Toast'}
       </Button>
     );

--- a/packages/components/src/renderers/form/button.tsx
+++ b/packages/components/src/renderers/form/button.tsx
@@ -12,6 +12,7 @@ import { Button } from '../../ui';
 import { renderChildren } from '../../lib/utils';
 import { forwardRef } from 'react';
 import { Loader2, icons, type LucideIcon } from 'lucide-react';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 // Helper to convert icon names to PascalCase (e.g., "arrow-right" -> "ArrowRight")
 function toPascalCase(str: string): string {
@@ -61,7 +62,7 @@ const ButtonRenderer = forwardRef<HTMLButtonElement, { schema: ButtonSchema }>(
         size={schema.size} 
         className={schema.className} 
         disabled={isDisabled}
-        {...buttonProps}
+        {...toFormControlDomProps(buttonProps)}
         // Apply designer props
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
     >

--- a/packages/components/src/renderers/form/checkbox.tsx
+++ b/packages/components/src/renderers/form/checkbox.tsx
@@ -10,6 +10,7 @@ import { ComponentRegistry } from '@object-ui/core';
 import type { CheckboxSchema } from '@object-ui/types';
 import { Checkbox, Label } from '../../ui';
 import { cn } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 import React from 'react';
 
 const CheckboxRenderer = ({ schema, className, onChange, value, ...props }: { schema: CheckboxSchema; className?: string; onChange?: (val: any) => void; value?: any; [key: string]: any }) => {
@@ -43,7 +44,7 @@ const CheckboxRenderer = ({ schema, className, onChange, value, ...props }: { sc
         disabled={schema.disabled}
         required={schema.required}
         name={schema.name}
-        {...checkboxProps} 
+        {...toFormControlDomProps(checkboxProps)}
       />
       <Label htmlFor={schema.id} className={cn("text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70", schema.required && "text-destructive after:content-['*'] after:ml-0.5")}>
         {schema.label}

--- a/packages/components/src/renderers/form/combobox.tsx
+++ b/packages/components/src/renderers/form/combobox.tsx
@@ -9,6 +9,7 @@
 import { ComponentRegistry } from '@object-ui/core';
 import type { ComboboxSchema } from '@object-ui/types';
 import { Combobox } from '../../custom';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('combobox', 
   ({ schema, ...props }: { schema: ComboboxSchema; [key: string]: any }) => {
@@ -26,7 +27,7 @@ ComponentRegistry.register('combobox',
         value={schema.value}
         disabled={schema.disabled}
         className={schema.className} 
-        {...comboboxProps}
+        {...toFormControlDomProps(comboboxProps)}
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
     />
   );

--- a/packages/components/src/renderers/form/date-picker.tsx
+++ b/packages/components/src/renderers/form/date-picker.tsx
@@ -12,6 +12,7 @@ import { Calendar, Button, Popover, PopoverTrigger, PopoverContent, Label } from
 import { CalendarIcon } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('date-picker', 
   ({ schema, className, value, onChange, ...props }: { schema: DatePickerSchema; className?: string; value?: Date; onChange?: (date: Date | undefined) => void; [key: string]: any }) => {
@@ -47,7 +48,7 @@ ComponentRegistry.register('date-picker',
                 !value && 'text-muted-foreground',
                 className
               )}
-              {...triggerProps}
+              {...toFormControlDomProps(triggerProps)}
             >
               <CalendarIcon className="mr-2 h-4 w-4" />
               {value ? format(value, schema.format || 'PPP') : <span>{schema.placeholder || 'Pick a date'}</span>}

--- a/packages/components/src/renderers/form/file-upload.tsx
+++ b/packages/components/src/renderers/form/file-upload.tsx
@@ -12,6 +12,7 @@ import { Label, Button } from '../../ui';
 import { Upload, X, Rocket, CheckCircle2, ScanLine } from 'lucide-react';
 import { useState, useRef, useEffect } from 'react';
 import { cn } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('file-upload', 
   ({ schema, className, value, onChange, ...props }: { schema: FileUploadSchema; className?: string; value?: File[]; onChange?: (files: File[]) => void; [key: string]: any }) => {
@@ -89,7 +90,7 @@ ComponentRegistry.register('file-upload',
             accept={schema.accept}
             multiple={schema.multiple}
             onChange={handleFileChange}
-            {...inputProps}
+            {...toFormControlDomProps(inputProps)}
           />
           
           <div 

--- a/packages/components/src/renderers/form/input-otp.tsx
+++ b/packages/components/src/renderers/form/input-otp.tsx
@@ -9,9 +9,13 @@
 import { ComponentRegistry } from '@object-ui/core';
 import type { InputOTPSchema } from '@object-ui/types';
 import { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator } from '../../ui';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('input-otp', 
   ({ schema, className, onChange, value, ...props }: { schema: InputOTPSchema; className?: string; [key: string]: any }) => {
+    // `style` forwarded by name; the rest through the form-control
+    // declaration (objectui#5632).
+    const { style, ...otpProps } = props;
     const length = schema.maxLength || 6;
     const slots = Array.from({ length });
 
@@ -27,7 +31,8 @@ ComponentRegistry.register('input-otp',
         className={className} 
         value={value ?? schema.value}
         onChange={handleChange}
-        {...props}
+        {...toFormControlDomProps(otpProps)}
+        style={style}
       >
         <InputOTPGroup>
           {slots.map((_, i) => (

--- a/packages/components/src/renderers/form/input.tsx
+++ b/packages/components/src/renderers/form/input.tsx
@@ -11,6 +11,7 @@ import { ComponentRegistry } from '@object-ui/core';
 import type { InputSchema } from '@object-ui/types';
 import { Input, Label } from '../../ui';
 import { cn } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 const InputRenderer = ({ schema, className, onChange, value, ...props }: { schema: InputSchema; className?: string; onChange?: (val: any) => void; value?: any; [key: string]: any }) => {
   // Handle change for both raw inputs and form-bound inputs
@@ -54,7 +55,7 @@ const InputRenderer = ({ schema, className, onChange, value, ...props }: { schem
         step={schema.step}
         maxLength={schema.maxLength}
         pattern={schema.pattern}
-        {...inputProps} 
+        {...toFormControlDomProps(inputProps)}
       />
       {schema.description && <p className="text-sm text-muted-foreground">{schema.description}</p>}
       {schema.error && <p className="text-sm font-medium text-destructive">{schema.error}</p>}

--- a/packages/components/src/renderers/form/radio-group.tsx
+++ b/packages/components/src/renderers/form/radio-group.tsx
@@ -10,6 +10,7 @@ import { ComponentRegistry } from '@object-ui/core';
 import type { RadioGroupSchema } from '@object-ui/types';
 import { RadioGroup, RadioGroupItem, Label } from '../../ui';
 import { toControlValue } from './option-value';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('radio-group', 
   ({ schema, className, ...props }: { schema: RadioGroupSchema; className?: string; [key: string]: any }) => {
@@ -27,7 +28,7 @@ ComponentRegistry.register('radio-group',
     <RadioGroup
         defaultValue={toControlValue(schema.defaultValue)}
         className={className}
-        {...radioProps}
+        {...toFormControlDomProps(radioProps)}
         // Apply designer props to the root element
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
     >

--- a/packages/components/src/renderers/form/slider.tsx
+++ b/packages/components/src/renderers/form/slider.tsx
@@ -9,6 +9,7 @@
 import { ComponentRegistry } from '@object-ui/core';
 import type { SliderSchema } from '@object-ui/types';
 import { Slider } from '../../ui';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('slider', 
   ({ schema, className, ...props }: { schema: SliderSchema; className?: string; [key: string]: any }) => {
@@ -34,7 +35,7 @@ ComponentRegistry.register('slider',
       min={schema.min}
       step={schema.step}
       className={className} 
-      {...sliderProps} 
+      {...toFormControlDomProps(sliderProps)}
       // Apply designer props
       {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
     />

--- a/packages/components/src/renderers/form/switch.tsx
+++ b/packages/components/src/renderers/form/switch.tsx
@@ -9,6 +9,7 @@
 import { ComponentRegistry } from '@object-ui/core';
 import type { SwitchSchema } from '@object-ui/types';
 import { Switch, Label } from '../../ui';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('switch', 
   ({ schema, className, ...props }: { schema: SwitchSchema; className?: string; [key: string]: any }) => {
@@ -27,7 +28,7 @@ ComponentRegistry.register('switch',
         data-obj-type={dataObjType}
         style={style}
     >
-      <Switch id={schema.id} className={className} {...switchProps} />
+      <Switch id={schema.id} className={className} {...toFormControlDomProps(switchProps)} />
       <Label htmlFor={schema.id}>{schema.label}</Label>
     </div>
   );

--- a/packages/components/src/renderers/form/textarea.tsx
+++ b/packages/components/src/renderers/form/textarea.tsx
@@ -10,6 +10,7 @@ import { ComponentRegistry } from '@object-ui/core';
 import type { TextareaSchema } from '@object-ui/types';
 import { Textarea, Label } from '../../ui';
 import { cn } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 import React from 'react';
 
 const TextareaRenderer = ({ schema, className, onChange, value, ...props }: { schema: TextareaSchema; className?: string; onChange?: (val: any) => void; value?: any; [key: string]: any }) => {
@@ -48,7 +49,7 @@ const TextareaRenderer = ({ schema, className, onChange, value, ...props }: { sc
         value={value ?? schema.value ?? ''}
         defaultValue={value === undefined ? schema.defaultValue : undefined}
         onChange={handleChange}
-        {...inputProps} 
+        {...toFormControlDomProps(inputProps)}
       />
     </div>
   );

--- a/packages/components/src/renderers/form/toggle.tsx
+++ b/packages/components/src/renderers/form/toggle.tsx
@@ -11,9 +11,16 @@ import { resolveKeyedI18nLabel } from '@object-ui/react';
 import type { ToggleSchema } from '@object-ui/types';
 import { Toggle } from '../../ui';
 import { renderChildren } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
 ComponentRegistry.register('toggle',
-  ({ schema, ...props }: { schema: ToggleSchema; [key: string]: any }) => (
+  ({ schema, ...props }: { schema: ToggleSchema; [key: string]: any }) => {
+    // `style` is forwarded BY NAME rather than reopened in the shared list —
+    // the objectui#4435 route, same as the layout renderers objectui#5574
+    // converged. Everything else goes through the form-control declaration.
+    const { style, ...toggleProps } = props;
+
+    return (
     <Toggle
       variant={schema.variant}
       size={schema.size}
@@ -25,11 +32,13 @@ ComponentRegistry.register('toggle',
       // "[object Object]" to a screen reader. This renderer bypasses
       // SchemaRenderer's `resolveAriaProps`, so it has to do it itself.
       aria-label={resolveKeyedI18nLabel(schema.ariaLabel)}
-      {...props}
+      {...toFormControlDomProps(toggleProps)}
+      style={style}
     >
       {schema.label || renderChildren(schema.children)}
     </Toggle>
-  ),
+  );
+  },
   {
     namespace: 'ui',
     label: 'Toggle',

--- a/packages/components/src/renderers/navigation/sidebar.tsx
+++ b/packages/components/src/renderers/navigation/sidebar.tsx
@@ -21,6 +21,7 @@ import { useDisplayLocale } from '@object-ui/i18n';
 // see `BaseSchema.label` (objectui#4580).
 import { resolveI18nLabel as resolveInlineI18nLabel } from '@objectstack/spec/ui';
 import { renderChildren } from '../../lib/utils';
+import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 import {
   SidebarProvider,
   Sidebar,
@@ -146,11 +147,24 @@ ComponentRegistry.register('sidebar-menu-item',
 );
 
 ComponentRegistry.register('sidebar-menu-button',
-  ({ schema, ...props }: { schema: BaseSchema; [key: string]: any }) => (
-    <SidebarMenuButton isActive={schema.active} {...props}>
-      {renderChildren(schema.body)}
-    </SidebarMenuButton>
-  ),
+  ({ schema, ...props }: { schema: BaseSchema; [key: string]: any }) => {
+    // `style` forwarded by name (the objectui#4435 route); everything else goes
+    // through the form-control DOM declaration. This is the only `sidebar-*`
+    // registration in this file that objectui#5632's group covers — the
+    // container ones render `<div>`s and belong to `BARE_SPREAD`, which is a
+    // different mechanism group and a different card.
+    const { style, ...buttonProps } = props;
+
+    return (
+      <SidebarMenuButton
+        isActive={schema.active}
+        {...toFormControlDomProps(buttonProps)}
+        style={style}
+      >
+        {renderChildren(schema.body)}
+      </SidebarMenuButton>
+    );
+  },
   {
     namespace: 'ui',
     label: 'Sidebar Menu Button',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -701,6 +701,9 @@ importers:
       '@object-ui/sdui-parser':
         specifier: workspace:*
         version: link:../../packages/sdui-parser
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../../packages/test-support
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
Refs #5632

One mechanism group, burned whole: **`BARE_SPREAD_MINUS_NAME`, all 18 members**. Ledger rows go **115 → 97**.

> **Note on this body's byte history:** the first version lost three angle-bracket fragments to GitHub's sanitizer — the `div` and `input` element names in the paragraphs below, which are load-bearing there. They are spelled in words now. Same for the report comment on #5632, where the sanitizer also removed the HTML-comment marker; comment 5386933027 is the readable copy.

## Which group, and why this one

The triage ruling slices by mechanism group, one group per PR, dispatched from `LEAK_LEDGER`. Of the seven shapes remaining after #5839, this is the largest that can land **complete**:

| group | members | why not this round |
|---|---|---|
| `BARE_SPREAD` | 91 | triage itself says sub-batches — cannot land whole, so it forces a partial group and an exclusion list |
| **`BARE_SPREAD_MINUS_NAME`** | **18** | **chosen — one mechanism, one fix, lands entire** |
| `BARE_SPREAD_ON_SVG` | 2 | `ui:icon`'s row may be reshaped by #5631; land after it |
| `action:group` / `action:menu` / `ui:form` / `ui:sidebar-trigger` | 1 each | one-target groups, each a bespoke shape |

**Exclusion list: empty.** Every member of the chosen group is fixed and every one of its rows is deleted, so this PR under-delivers nothing. The group entry itself is gone from `COMPONENTS_LEAK_GROUPS` — the grouping is six mechanisms now, not seven.

The 18: `action:button`, `action:icon`, `ui:button`, `ui:checkbox`, `ui:combobox`, `ui:date-picker`, `ui:email`, `ui:file-upload`, `ui:input`, `ui:input-otp`, `ui:password`, `ui:radio-group`, `ui:sidebar-menu-button`, `ui:slider`, `ui:sonner`, `ui:switch`, `ui:textarea`, `ui:toggle`.

## The one place this diverges from the established method, and why

#5573 / #5839 converged their renderers on the bare `toDomProps`. **This group must not**, and the reason is a failure direction no gate in this repo can see.

These hosts are **form controls**, so `name` and `disabled` are legal on them. That is not incidental — it is the definition of the group. The ledgered shape here is *thirteen* attributes and not fourteen precisely because the judge never reported `name` on these hosts. `toDomProps` deliberately withholds both keys, because it cannot know what element a widget renders, and `name` on the container `div` a typical SDUI widget renders is one of the 14 attributes #4431 closed.

So a bare `toDomProps` here would have stripped the form-serialization key off every control in the library and silently re-enabled every disabled one — and **the sweep gate would have gone green anyway**: it reports attributes that *arrive* illegitimately, has no case for one that stops arriving, and its canary node authors no `disabled` at all. Nothing in this card's own acceptance evidence would have moved.

The fix is therefore a **third declaration over the one existing mechanism**, following the pattern `@object-ui/fields` established rather than inventing one — the consuming package owns the key list its contract implies and calls the shared `pickDomProps` with it (`packages/components/src/lib/form-control-dom-props.ts`). It is the SDUI baseline **plus** `name` and `disabled`, nothing removed, with a compile-time assertion pinning it as a strict superset so a future addition to the shared set cannot be quietly dropped here.

The ledger predicted this from the other side. Its note on the group read: converging these renderers "will not change that attribute, only the thirteen around it." That prediction is now measured — and it was only true because the convergence was built to make it true.

## The measurement, re-taken

Catalog-scale probe, every form-control node in `examples/schema-catalog` rendered through the real `SchemaRenderer` and read off the DOM:

| | nodes | illegitimate attributes |
|---|---|---|
| **the 15 catalog-present group members** | 287 | **284 → 0** |
| **`ui:grid` (control)** | 26 | **0 → 0** |

Leaders before: `button[label]` 140, `button[icon]` 25, `input[inputtype]` 23, `input[label]` 19, `toggle[label]` 14, `radio-group[options]` 8, `date-picker[placeholder]` 7, `file-upload[label]` 7, `file-upload[buttontext]` 7, then a 34-attribute tail. Most of these are keys the renderer **consumes off `schema`** to render the control and then forwards to the element a second time.

Three of the 18 are absent from the catalog probe and covered by the sweep gate instead: `ui:sonner` has no catalog node, and `action:button` / `action:icon` are reached through an `action:bar`'s `actions` array rather than as nodes carrying their own `type`, so a `type`-keyed walk cannot find them at all.

### Guarding against the zero that means nothing

An after-zero is worthless if the probe stopped finding nodes. Reproducing #5839's guard and adding two:

1. **Node census asserted, per type** — and read **identical** in the before and after runs (`noElement: 0` everywhere, both times). The after-zero is a reading.
2. **The control ran in the same run** — `grid` read 0 while its 15 unconverged siblings read 284. A control that runs somewhere else is not a control.
3. **The judge is self-checked for the property this file depends on: element-awareness.** The same prop bag is rendered onto an `input` element and onto a `div` element; the judge must report `['inputtype','label']` on the control and `['disabled','inputtype','label','name']` on the container. A judge that simply allowed `name` everywhere would pass every other assertion here and hide the entire group.

**A note on scoping, because it changed the control's reading.** `findLeaks` walks the whole subtree, so nested SDUI children get their leaks attributed to the parent. Measured: subtree-scanning put **61** attributes on `grid` — the control — every one from a child `ui:icon` / `ui:button` / `ui:label` in a different mechanism group. That is not a control, it is a mixture. Each node is therefore rendered with `children` / `body` removed; nothing is lost, because the walk collects nested nodes of the measured types separately and renders each on its own turn.

## Reverse-verification

On the real commit `efcd1b2`, reverting **only** the 16 renderer sources and leaving the deleted rows and the new probe in place.

Mutation confirmed **on disk**, both directions, not by an editor's exit code: injected-text occurrences `32 → 0`, and the bare spreads I deleted counted back in (the `inputProps` bag ×3, the bare `props` bag ×16, the `rest` bag ×2, and one each of the six other named bags). The script carries a restoring `trap` on `EXIT INT TERM`, so a foreground-cap SIGTERM mid-mutation cannot leave the tree mutated for later measurements.

Predicted direction: the sweep goes red demanding **zero** (the rows are gone), not red demanding a different set. Observed — **19 failures**:

- 18 sweep targets, **exactly the 18 whose rows I deleted, no others**: `AssertionError: expected 'action:button leaked 13 non-DOM attri…' to be ''`
- the catalog probe: `expected [ …(232) ] to deeply equal []`

Restored → `git diff HEAD --stat` **empty** (byte-exact), injected text back at 32, re-run **205/205 green**.

**Legs that do NOT discriminate, named rather than counted as evidence:**
- `layout-dom-leak-5574.test.tsx` — green in both legs. It measures the other group; it was in the run to show the mutation was scoped.
- the `grid` control — 0 in both legs, by construction.
- the node-census assertion — identical in both legs. It discriminates a broken walk, never the fix.
- the judge self-check — green in both legs.
- `packages/components`' own 1656 tests — green in both directions, i.e. **no existing test asserted any of these 284 attributes**. That is a finding, not a reassurance: the class was invisible to everything except a DOM-reading gate.

## Rows deleted, not loosened

The 18 rows are **deleted**. Nothing is edited into something looser, no `it.skip`, no exemption entry. The gate's two-way expiry made the fix fail until they went — that red is in the transcript above and it fired on exactly those 18 targets.

The case that pinned this family as leaking is **inverted** into `the whole form-control family is CLEAN — no row may re-absorb it`, the same treatment #5839 gave the layout family: the sweep case already fails if one regresses; what the inverted case adds is that the regression cannot be made green by putting the row back.

## Verification

Everything from the repo root, never `pnpm --filter` for vitest. Union re-run at the final commit **`af4f6d209`**.

- `pnpm exec vitest run packages/app-shell/src/__tests__ packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx examples/schema-catalog/test` — **18 files, 2138 tests passed**
- `pnpm exec vitest run packages/components` — **181 files, 1656 tests passed**
- `pnpm --filter @object-ui/components --filter @object-ui/app-shell type-check` — both `Done` (the dependency closure had to be built first; an unbuilt closure reports `TS2307 Cannot find module '@object-ui/core'`, which reads exactly like a real break)
- `node scripts/check-changeset-presence.mjs` — `✅ 17 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)`
- `pnpm exec eslint . --no-inline-config` — the **full repo**, not a narrowing: 3592 files, **0 errors from this diff**. The repo carries 89 pre-existing errors across 74 files on `main`; none is a file this PR touches. The 65 warnings on the touched files are pre-existing `no-explicit-any` / `react-refresh`, including the two `no-unused-vars` (`ScanLine`, `InputOTPSeparator`) that are present on `origin/main` unchanged.
- `check:control-bytes` ✅ · `check:phantom-deps` ✅ · `check:self-import` ✅
- `check:eager-closure` **not run** — it needs `apps/console/dist/eager-closure.json` from a prior `vite build` and reports a broken gauge without one. CI owns it. This diff adds no new eager import: the new module is reached only from renderers already in the closure and imports only `@object-ui/core`, already there.

## One thing corrected in passing

The gate's header claimed the arrival reading was "119 of 158 … in **eight** shapes". The groups were **seven** on arrival, and #5632's own card table lists seven. The count is corrected where the surrounding sentence had to be rewritten anyway — writing "eight" into a line I was re-authoring would have propagated a number I had just counted as false.

## Not addressed here

`#5630` and `#5631` remain open; neither is touched by this slice. The remaining six mechanism groups (97 rows) stay open under #5632, which is why this is `Refs` and not a closing keyword.

_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_