### PR TITLE
docs(plugin-dashboard): de-duplicate the DashboardGridLayout H2

### DIFF
--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -505,9 +505,7 @@ auto-detection.
 }
 ```
 
-## DashboardGridLayout — persisting drag / resize edits
-
-### DashboardRenderer — design-mode widget reorder
+## DashboardRenderer — design-mode widget reorder
 
 When `DashboardRenderer` is used in design mode (`designMode={true}` plus an
 `onWidgetsReorder` callback), widgets become sortable via


### PR DESCRIPTION
Fixes #5095

## What

`packages/plugin-dashboard/README.md` carried the H2 `DashboardGridLayout — persisting drag / resize edits` **twice**. The first occurrence sat immediately above the `DashboardRenderer` design-mode reorder section, so that section rendered under a heading describing something else — `onWidgetsReorder` / dnd-kit has nothing to do with `DashboardGridLayout` persistence — and every TOC/anchor generator emitted a duplicate entry with a `-1` disambiguation suffix.

The whole diff is three lines removed, one added:

```diff
-## DashboardGridLayout — persisting drag / resize edits
-
-### DashboardRenderer — design-mode widget reorder
+## DashboardRenderer — design-mode widget reorder
```

Each section now sits under a heading that describes it. Prose and code fences are untouched — this is a doc-structure fix, not a README rewrite, and nothing else in the file was reorganised.

## Premise re-measured on current `main`

The card's line numbers were dated (taken right after #5093). Re-measured at merge-base `58770f329`, the defect is still present, just moved:

```
508:## DashboardGridLayout — persisting drag / resize edits
510:### DashboardRenderer — design-mode widget reorder
523:## DashboardGridLayout — persisting drag / resize edits
```

After:

```
508:## DashboardRenderer — design-mode widget reorder
521:## DashboardGridLayout — persisting drag / resize edits
```

`grep '^#\{1,6\} ' … | sort | uniq -d` over the whole file now returns nothing — no duplicate heading of any level remains.

## Anchors — checked BEFORE the rename, not after

A re-seated heading changes its anchor, so the link surface was enumerated first:

| Anchor | Before | After |
|---|---|---|
| `#dashboardrenderer--design-mode-widget-reorder` | H3 | **preserved** — slug derives from heading *text*, not level; H3 → H2 does not move it |
| `#dashboardgridlayout--persisting-drag--resize-edits` | pointed at the *wrong* (misplaced) heading | **preserved** — now points at the persistence section it always claimed to name |
| `#dashboardgridlayout--persisting-drag--resize-edits-1` | the de-dup suffix GitHub minted for the second copy | **gone** |

Only the third one disappears. Repo-wide greps for in-repo references (excluding `node_modules`/`.git`) found **zero** hits for `dashboardgridlayout--persisting` and zero for `dashboardrenderer--design`. The README has no intra-file `](#…)` links. The single fragment link into this README anywhere in the tree is `content/docs/plugins/plugin-dashboard.mdx:348` → `…/README.md#type-aware-listtable-widget-cells`, which this diff does not touch. `content/docs/plugins/plugin-dashboard.mdx` mirrors neither section, so it has nothing pointing at either anchor.

## Verification — union re-run on the final commit `11f6a6a15`

All from the repo root, exit codes captured before any pipe:

| Gate | Verdict line |
|---|---|
| `node scripts/check-doc-links.mjs` | `Links are valid across 13 scan roots.` |
| `node scripts/check-changeset-presence.mjs` | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-control-bytes.mjs` | `✅  check-control-bytes: OK (scanned 4880 tracked text file(s); skipped 85 binary).` |
| `pnpm exec vitest run scripts/__tests__/{check-doc-links,doc-version-claims,check-changeset-presence}.test.ts` | `Test Files  3 passed (3)` / `Tests  136 passed (136)`, `RUN v4.1.10 /home/user/objectui-5095` (root = repo root) |

`packages/*/README.md` is scan root #4 of `check-doc-links.mjs` (rule `disk`), so that gate genuinely covers the edited file rather than waving it through.

**No changeset**: `check-changeset-presence` reports 1 file changed, 0 under the `src/` of a released package — none owed.

**No ablation.** This is a doc-only diff with no behavioural leg; staging a reverse-verification here would be decorative. The evidence is the before/after heading census plus the anchor accounting above.

### One gate narrowed, declared

`node scripts/check-doc-snippet-types.mjs` keys a ratchet entry on this exact file (`'packages/plugin-dashboard/README.md': '19 parse diagnostic(s) …; 4 undefined-name diagnostic(s)'`). It **refuses to run** against an unbuilt workspace rather than reporting a false green:

```
The snippet program was NOT run: the packages it resolves against are not built, or are typed from source.
```

Running it locally needs a full 15-package workspace build. CI builds and runs it for real. What is shown here instead is that the diff **cannot** move it: the gate compiles fenced `ts`/`tsx`/`typescript` blocks (`TS_FENCE_LANGUAGES`), and the fenced-snippet stream of this file — every fence body, its language tag, and the marker line immediately above each opening fence — is byte-identical before and after:

```
BEFORE  fences=16 sha256=4496af1118fadb32b6e7ce4a19a4c43a9eba9d150c7aa01db6cf68a4a6a89e59
AFTER   fences=16 sha256=4496af1118fadb32b6e7ce4a19a4c43a9eba9d150c7aa01db6cf68a4a6a89e59
```

That extractor is not a no-op — mutating one fence body (`saveItem` → `saveItemMUTATED`, mutation confirmed on disk by `grep -c`, not by the editor's exit code) yields `sha256=b250579c…`. No other file is touched, so the gate's verdict is invariant under this diff.

## Scope

Same-family **#4517** (the `plugin-calendar` duplicate) is deliberately not folded in — triage recorded it as a different file and kept it separate from this card. No out-of-scope findings; the rest of the README was read but not disturbed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_