### PR TITLE
feat(dashboard): server-supplied totals row on the flat dataset table

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/plugin-dashboard': minor
+---
+
+Dashboard flat `table` widget: render the server's grand total as a `tfoot` row (objectui#5846).
+
+The flat branch now requests the `[]` marginal grouping — the same server-side
+totals machinery the cross-tab has used since framework#1753 — and renders the
+answer under the console's existing `dashboard.total` label. Totals are computed
+by the server with each measure's TRUE aggregate (a `sum` sums, an `avg`/`min`/
+`max` reports the whole-set aggregate); nothing is recombined client-side. The
+row lives in `tfoot`, so it is exempt from sorting, renders below the `—` null
+bucket, and never joins the drillable rows.
+
+No footer is rendered when the executor answers no `[]` grouping, and none is
+requested for a table truncated by `options.limit`, whose visible rows a
+whole-set total could not be reconciled against.

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -425,9 +425,6 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const isMatrix = widgetType === 'pivot' && dimensions.length >= 2;
   const rowDims = isMatrix ? dimensions.slice(0, -1) : [];
   const colDim = isMatrix ? dimensions[dimensions.length - 1] : '';
-  // Row subtotals, column subtotals, and the grand total ([]) — the server
-  // computes each with the measure's TRUE aggregate (never re-derived here).
-  const totalsGroupings = isMatrix ? [rowDims, [colDim], []] : undefined;
 
   // ── Query-affecting widget options (framework#3588) ──────────────────────
   // `options` is the renderer-extras bag, but four of its keys are NOT
@@ -452,6 +449,35 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const limit = typeof options.limit === 'number' && Number.isFinite(options.limit) && options.limit > 0
     ? Math.floor(options.limit)
     : undefined;
+
+  // ── Server-computed marginal totals ──────────────────────────────────────
+  // The cross-tab asks for three groupings: row subtotals, column subtotals,
+  // and the grand total (`[]`). The FLAT table asks for the grand total alone
+  // and renders it as a `tfoot` (objectui#5846). Both are computed by the
+  // server with the measure's TRUE aggregate over the underlying rows and are
+  // never re-derived here — an avg/min/max cannot be recombined from the
+  // bucketed values on screen, which is why this is a query-shape change and
+  // not a rendering one.
+  //
+  // Measured cost of the flat table's one extra grouping (100k-row opportunity
+  // table, real pipeline: compileDataset → AnalyticsService NativeSQL → SQLite):
+  // ONE extra statement, `SELECT SUM(…), AVG(…) FROM t` — the same WHERE, no
+  // GROUP BY — at 9.6ms beside the primary's 48.8ms, i.e. +20% on the widget's
+  // query, holding at +19%/1M rows and +28%/10k. The cross-tab has shipped
+  // THREE such groupings, ungated, since #1753; one is strictly less.
+  //
+  // NOT requested when `options.limit` truncates the table. The executor drops
+  // `limit` for a totals query by design (a total covers the whole selection),
+  // so a top-N table would print a grand total the reader cannot reconcile
+  // against the rows in front of them — and "don't make the reader add it up"
+  // is the whole point of the row. No request is issued in that case, so the
+  // cost is not paid either.
+  const wantsFlatTotals = isTable && !isMatrix && dimensions.length > 0 && limit == null;
+  const totalsGroupings = isMatrix
+    ? [rowDims, [colDim], []]
+    : wantsFlatTotals
+      ? [[] as string[]]
+      : undefined;
 
   const tt = useSafeTranslate();
   const { fieldLabel, fieldOptionLabel } = useSafeFieldLabel();
@@ -1187,6 +1213,30 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     // column shows nothing until the header is hovered, the sorted one shows a
     // primary-tinted arrow. `aria-hidden` because the `th`'s `aria-sort` is
     // what carries the state to assistive tech.
+    // ── The totals row (objectui#5846) ──────────────────────────────────
+    // The server's `[]` marginal grouping — requested above — rendered as a
+    // `tfoot`. Per aggregate: a `sum` column shows the sum over every row, an
+    // `avg`/`min`/`max` column shows that aggregate over the WHOLE set (the
+    // average of all records, never an average of the bucket averages). The
+    // executor computes it by re-running this selection with no grouping, so
+    // nothing here recombines anything.
+    //
+    // Absent — an older server, or an executor that could not answer `[]` for
+    // this dataset shape — the row is simply omitted. Approximating it from the
+    // rows on screen is the one thing this file does not do.
+    //
+    // `wantsFlatTotals` gates the RENDER as well as the request, so the two can
+    // never disagree: a server that volunteers a `[]` grouping this widget did
+    // not ask for (a truncated `options.limit` table) still shows no footer,
+    // rather than a whole-set total sitting under a top-N list.
+    const totalsRow = wantsFlatTotals
+      ? state.totals?.find((t) => Array.isArray(t.dimensions) && t.dimensions.length === 0)?.rows?.[0]
+      : undefined;
+    // The console's existing footer vocabulary — the SAME `dashboard.total`
+    // key the cross-tab's total row and `PivotTable` already use (en `Total`,
+    // zh `总计`). No new string is minted here; the untranslated dataset
+    // MEASURE headers beside it are objectstack#10292 and stay untouched.
+    const totalRowLabel = tt('dashboard.total', 'Total');
     const sortIcon = (c: string) => {
       if (activeSort?.column !== c) {
         return <ChevronsUpDown className="ml-0.5 h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-50" aria-hidden="true" />;
@@ -1259,6 +1309,40 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
               </tr>
             ))}
           </tbody>
+          {/* The totals row lives in `tfoot`, OUTSIDE `orderedEntries`
+              entirely — not as a special case inside the sort. Three
+              consequences fall out of that placement rather than out of any
+              guard: it is exempt from every sort (it was never an entry), it
+              renders after the last body row including the `—` null bucket
+              (`tfoot` follows `tbody`), and it cannot disturb the (row, index)
+              pairing `openDrill` depends on. It carries no click handler and
+              no `dataset-drill-row` id, so it drills nowhere. */}
+          {totalsRow && (
+            <tfoot className="bg-muted/30">
+              <tr className="border-t font-medium" data-testid="dataset-table-total-row">
+                {/* One label cell spanning the dimension columns. This branch
+                    always has at least one (a zero-dimension widget renders as
+                    a KPI and returns above), so the span is never 0. */}
+                <td colSpan={dimensions.length} className="px-2 py-1 whitespace-nowrap">{totalRowLabel}</td>
+                {measureColumns.map((c) => {
+                  // The SAME per-column formatter the body cells use —
+                  // `measureField` is keyed by MEASURE, not by row, so the
+                  // footer cell and the column above it cannot drift on
+                  // currency, decimals or percent scaling. Alignment reads the
+                  // same `numericColumns` set for the same reason.
+                  const measure = compareOf(c) ?? c;
+                  return (
+                    <td
+                      key={c}
+                      className={cn('px-2 py-1 whitespace-nowrap tabular-nums', numericColumns.has(c) && 'text-right')}
+                    >
+                      {formatMeasure(totalsRow[c], measureField(measure)?.format, measureField(measure)?.currency, measureField(measure)?.percentScale, displayLocale)}
+                    </td>
+                  );
+                })}
+              </tr>
+            </tfoot>
+          )}
         </table>
         {drillDrawer}
       </div>

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.tableTotalsRow.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.tableTotalsRow.test.tsx
@@ -1,0 +1,339 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5846 — the flat dataset `table` widget's totals row.
+ *
+ * #5827 declined it: a CORRECT total cannot be computed in this file, because
+ * this file's standing rule is no client re-aggregation (an avg/min/max cannot
+ * be recombined from bucketed values), and the server's marginal totals were
+ * requested only for the cross-tab. #5846 rules the query-shape change: the
+ * flat branch asks for the same `[]` grouping the cross-tab already requests
+ * and renders the answer as a `tfoot`.
+ *
+ * The fixture is built so a client recombination is DISTINGUISHABLE from the
+ * server's answer, which is the whole point of the card:
+ *  - `avg_deal`: the server's whole-set average is 4,200,000; averaging the
+ *    three bucket averages gives 3,333,333 — a different number.
+ *  - `distinct_owners`: the buckets hold 1 + 3 + 5 = 9, the whole-set distinct
+ *    count is 6 — adding the column up is simply wrong for this aggregate.
+ * Only `annual_revenue_sum` reconciles, because only a sum does.
+ *
+ * DIRECTIONS, stated before the reverse verification was run — every case here
+ * is RED on `origin/main` except the two that pin what did NOT move (the
+ * cross-tab's three groupings, and the CSV's contents). On `origin/main`
+ * `totalsGroupings` was `isMatrix ? … : undefined`, so a flat table asked for
+ * nothing and no `tfoot` existed to render. There is no ablation-through-`dist`
+ * here: this file imports the component by relative source path
+ * (`../DatasetWidget`), so no build stands between the edit and the run.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { DatasetWidget } from '../DatasetWidget';
+
+/** Observe the drill filter without rendering the real drawer. */
+const drillFilters: Array<Record<string, unknown>> = [];
+vi.mock('../DrillDownDrawer', () => ({
+  DrillDownDrawer: ({ filter }: { filter: Record<string, unknown> }) => {
+    drillFilters.push(filter);
+    return null;
+  },
+}));
+
+/** Plain TEXT dimension field, no `options` — nothing here relabels. */
+const ACCOUNT = { name: 'crm_account', fields: { industry: { type: 'text' } } };
+
+function installMetaRouter() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ item: ACCOUNT }) })),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  drillFilters.length = 0;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const industryRows = () => [
+  { industry: null, annual_revenue_sum: 0, avg_deal: 0, distinct_owners: 1 },
+  { industry: 'Finance', annual_revenue_sum: 12000000, avg_deal: 4000000, distinct_owners: 3 },
+  { industry: 'Technology', annual_revenue_sum: 30000000, avg_deal: 6000000, distinct_owners: 5 },
+];
+
+const industryFields = [
+  { name: 'industry', type: 'text', label: 'Industry' },
+  { name: 'annual_revenue_sum', type: 'number', label: 'Annual Revenue' },
+  { name: 'avg_deal', type: 'number', label: 'Avg Deal' },
+  { name: 'distinct_owners', type: 'number', label: 'Owners' },
+];
+
+/** The server's `[]` grouping: whole-set aggregates, per measure semantics. */
+const GRAND_TOTAL = { annual_revenue_sum: 42000000, avg_deal: 4200000, distinct_owners: 6 };
+const grandTotals = () => [{ dimensions: [] as string[], rows: [GRAND_TOTAL] }];
+
+const industrySource = (extra: Record<string, unknown> = {}) => ({
+  queryDataset: vi.fn(async () => ({
+    rows: industryRows(),
+    fields: industryFields,
+    totals: grandTotals(),
+    ...extra,
+  })),
+});
+
+/** The drillable variant — identity keys spelled unlike the display labels. */
+const drillableSource = () =>
+  industrySource({
+    object: 'crm_account',
+    dimensionFields: { industry: 'industry' },
+    drillRawRows: [{ industry: null }, { industry: 'fin' }, { industry: 'tech' }],
+  });
+
+const TABLE_WIDGET = {
+  type: 'table',
+  dataset: 'accounts_by_industry',
+  dimensions: ['industry'],
+  values: ['annual_revenue_sum', 'avg_deal', 'distinct_owners'],
+};
+
+const bodyRows = () => Array.from(document.querySelectorAll('tbody tr'));
+const footRow = () => document.querySelector('tfoot tr');
+const footCells = () =>
+  Array.from(footRow()?.querySelectorAll('td') ?? []).map((td) => td.textContent ?? '');
+const dimensionColumn = () => bodyRows().map((r) => r.querySelector('td')?.textContent ?? '');
+const sortButtons = () => screen.getAllByTestId('dataset-table-sort');
+const selectionOf = (src: { queryDataset: ReturnType<typeof vi.fn> }) =>
+  src.queryDataset.mock.calls[0][1] as Record<string, unknown>;
+
+describe('objectui#5846 — the flat table asks the server for the `[]` grouping', () => {
+  it('requests exactly the grand-total grouping, the same one the cross-tab already asks for', async () => {
+    installMetaRouter();
+    const src = industrySource();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={src} />);
+    await screen.findByText('Industry');
+
+    expect(selectionOf(src).totals).toEqual({ groupings: [[]] });
+  });
+
+  it('leaves the CROSS-TAB\'s three groupings exactly as they were', async () => {
+    // What did NOT move. A pivot with >=2 dimensions still asks for row
+    // subtotals, column subtotals and the grand total, in that order.
+    installMetaRouter();
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [{ industry: 'Finance', stage: 'won', annual_revenue_sum: 1 }],
+        fields: [
+          { name: 'industry', type: 'text', label: 'Industry' },
+          { name: 'stage', type: 'text', label: 'Stage' },
+          { name: 'annual_revenue_sum', type: 'number', label: 'Annual Revenue' },
+        ],
+      })),
+    };
+    render(
+      <DatasetWidget
+        widget={{ ...TABLE_WIDGET, type: 'pivot', dimensions: ['industry', 'stage'], values: ['annual_revenue_sum'] }}
+        dataSource={src}
+      />,
+    );
+    await screen.findByText('Industry');
+
+    expect(selectionOf(src).totals).toEqual({ groupings: [['industry'], ['stage'], []] });
+  });
+
+  it('asks for NOTHING when `options.limit` truncates the table, and renders no footer', async () => {
+    // The executor drops `limit` for a totals query by design, so a top-N table
+    // would print a whole-set total the reader cannot reconcile against the
+    // rows in front of them. No request is issued, so the cost is not paid
+    // either — and the fixture answers `[]` anyway to prove the RENDER is gated
+    // too, not just the request.
+    installMetaRouter();
+    const src = industrySource();
+    render(
+      <DatasetWidget widget={{ ...TABLE_WIDGET, options: { limit: 2 } }} dataSource={src} />,
+    );
+    await screen.findByText('Industry');
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    expect(selectionOf(src).totals).toBeUndefined();
+    expect(footRow()).toBeNull();
+    expect(screen.queryByTestId('dataset-table-total-row')).toBeNull();
+  });
+});
+
+describe('objectui#5846 — the totals row is the SERVER\'s answer, never a recombination', () => {
+  it('renders the server\'s whole-set aggregate per measure, under the console\'s own Total label', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await screen.findByText('Industry');
+    await waitFor(() => expect(footRow()).not.toBeNull());
+
+    // `dashboard.total` — the key the cross-tab's total row and PivotTable
+    // already use. No new string was minted for this row.
+    expect(footCells()[0]).toBe('Total');
+    // sum: reconciles with the column, because a sum is the one that does.
+    expect(footCells()[1]).toBe('42000000');
+    // avg: the average over ALL records. Averaging the three bucket averages
+    // (0, 4m, 6m) would print 3333333 — this is what "no client
+    // re-aggregation" means in a number.
+    expect(footCells()[2]).toBe('4200000');
+    expect(footCells()[2]).not.toBe('3333333');
+    // count-distinct: 6 owners overall, though the buckets hold 1 + 3 + 5 = 9.
+    expect(footCells()[3]).toBe('6');
+    expect(footCells()[3]).not.toBe('9');
+  });
+
+  it('omits the footer entirely when the executor answered no `[]` grouping', async () => {
+    // An older server, or a dataset shape the executor cannot answer `[]` for:
+    // the row is omitted rather than approximated from the rows on screen.
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource({ totals: undefined })} />);
+    await screen.findByText('Industry');
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    expect(footRow()).toBeNull();
+  });
+
+  it('omits the footer when the `[]` grouping came back with no row', async () => {
+    installMetaRouter();
+    render(
+      <DatasetWidget
+        widget={TABLE_WIDGET}
+        dataSource={industrySource({ totals: [{ dimensions: [], rows: [] }] })}
+      />,
+    );
+    await screen.findByText('Industry');
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    expect(footRow()).toBeNull();
+  });
+
+  it('formats a footer cell through the same PER-COLUMN formatter the body uses', async () => {
+    // The formatter is keyed by MEASURE, not by row, so the footer cannot drift
+    // from the column above it. `percentScale: 'fraction'` is the sharp probe:
+    // a footer that skipped it would render the stored 0.55 as "0.55%" (or, via
+    // the magnitude heuristic, "1%") instead of "55%".
+    installMetaRouter();
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [
+          { industry: 'Finance', win_rate: 0.5 },
+          { industry: 'Technology', win_rate: 0.6 },
+        ],
+        fields: [
+          { name: 'industry', type: 'text', label: 'Industry' },
+          { name: 'win_rate', type: 'number', label: 'Win Rate', format: '0%', percentScale: 'fraction' },
+        ],
+        totals: [{ dimensions: [], rows: [{ win_rate: 0.55 }] }],
+      })),
+    };
+    render(<DatasetWidget widget={{ ...TABLE_WIDGET, values: ['win_rate'] }} dataSource={src} />);
+    await screen.findByText('Win Rate');
+    await waitFor(() => expect(footRow()).not.toBeNull());
+
+    // Body first, so the comparison is against what this column actually shows.
+    const bodyCell = bodyRows()[0].querySelectorAll('td')[1].textContent ?? '';
+    expect(bodyCell).toMatch(/50/);
+    expect(bodyCell).toMatch(/%/);
+    const footCell = footCells()[1];
+    expect(footCell).toMatch(/55/);
+    expect(footCell).toMatch(/%/);
+    expect(footCell).not.toMatch(/0\.55/);
+  });
+
+  it('right-aligns the footer\'s numeric measure cells, matching the column above', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await waitFor(() => expect(footRow()).not.toBeNull());
+
+    const cells = Array.from(footRow()!.querySelectorAll('td'));
+    // The label cell spans the dimension columns and stays left.
+    expect(cells[0].getAttribute('colspan')).toBe('1');
+    expect(cells[0].className).not.toContain('text-right');
+    for (const c of cells.slice(1)) expect(c.className).toContain('text-right');
+  });
+});
+
+describe('objectui#5846 — the totals row is outside the sortable rows', () => {
+  it('stays last and unchanged through a sort, and never joins the body rows', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+
+    const allRowsLast = () => {
+      const rows = Array.from(document.querySelectorAll('table tr'));
+      return rows[rows.length - 1];
+    };
+    expect(allRowsLast()).toBe(footRow());
+    // Default order puts the `—` null bucket last among the BODY rows; the
+    // totals row still sorts below it, because `tfoot` follows `tbody`.
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+
+    // Sort the measure descending, then ascending, then back to dataset order.
+    for (const _ of [0, 1, 2]) {
+      fireEvent.click(sortButtons()[1]);
+      expect(bodyRows().length).toBe(3);
+      expect(allRowsLast()).toBe(footRow());
+      expect(footCells()[1]).toBe('42000000');
+    }
+    // The dimension column is a different first-click direction; still last.
+    fireEvent.click(sortButtons()[0]);
+    expect(dimensionColumn()).toEqual(['Finance', 'Technology', '—']);
+    expect(allRowsLast()).toBe(footRow());
+  });
+
+  it('does not drill, and does not disturb the (row, index) pairing the body rows drill by', async () => {
+    installMetaRouter();
+    render(<DatasetWidget widget={TABLE_WIDGET} dataSource={drillableSource()} />);
+    await waitFor(() => expect(bodyRows().length).toBe(3));
+    await waitFor(() => expect(footRow()).not.toBeNull());
+
+    // The footer carries no drill affordance at all.
+    expect(footRow()!.getAttribute('data-testid')).toBe('dataset-table-total-row');
+    expect(screen.getAllByTestId('dataset-drill-row').length).toBe(3);
+
+    fireEvent.click(footRow()!);
+    expect(drillFilters.length).toBe(0);
+
+    // …and the body rows still drill by their OWN incoming index. Row 0 shows
+    // Finance, whose identity key is `fin` — index 1 of the raw sidecar.
+    fireEvent.click(bodyRows()[0]);
+    await waitFor(() => expect(drillFilters.length).toBeGreaterThan(0));
+    expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: 'fin' });
+
+    fireEvent.click(bodyRows()[2]);
+    await waitFor(() => expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: null }));
+  });
+
+  it('keeps the totals row OUT of the CSV, as the cross-tab already does', async () => {
+    // What did NOT move. The export is the table's DATA — one line per bucket.
+    // The cross-tab has never exported its own total row or column either.
+    installMetaRouter();
+    const blobs: Blob[] = [];
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    (URL as any).createObjectURL = (b: Blob) => { blobs.push(b); return 'blob:x'; };
+    (URL as any).revokeObjectURL = () => {};
+    try {
+      render(<DatasetWidget widget={TABLE_WIDGET} dataSource={industrySource()} />);
+      await waitFor(() => expect(footRow()).not.toBeNull());
+      fireEvent.click(screen.getByTestId('dataset-export'));
+
+      expect(blobs.length).toBe(1);
+      const lines = (await blobs[0].text()).trim().split('\n').map((l) => l.trim());
+      expect(lines.length).toBe(4); // header + 3 buckets, no total line
+      expect(lines.some((l) => l.startsWith('Total'))).toBe(false);
+      expect(lines.some((l) => l.includes('42000000'))).toBe(false);
+    } finally {
+      (URL as any).createObjectURL = origCreate;
+      (URL as any).revokeObjectURL = origRevoke;
+    }
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -731,9 +731,25 @@ describe('DatasetWidget', () => {
     expect((src.queryDataset.mock.calls[0][1] as any).totals).toEqual({ groupings: [['status'], ['priority'], []] });
   });
 
-  it('does NOT request totals for a flat table', async () => {
+  // objectui#5846 RULED the flat table's own totals row, which this case used
+  // to pin the absence of: a flat table now asks for the GRAND TOTAL alone —
+  // never the cross-tab's row/column subtotals, which have no meaning without a
+  // second axis — and renders it as a `tfoot`. The rendering contract lives in
+  // `DatasetWidget.tableTotalsRow.test.tsx`; what stays here is the shape of
+  // the REQUEST beside the pivot case above.
+  it('requests ONLY the grand-total grouping for a flat table', async () => {
     const src = makeSource(async () => ({ rows: [{ status: 'Open', task_count: 1 }] }));
     render(<DatasetWidget widget={{ type: 'table', dataset: 'tasks', dimensions: ['status'], values: ['task_count'] }} dataSource={src} />);
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect((src.queryDataset.mock.calls[0][1] as any).totals).toEqual({ groupings: [[]] });
+  });
+
+  it('requests no totals at all for a flat table truncated by options.limit', async () => {
+    // A total computed over the whole selection cannot be reconciled against a
+    // top-N list, so the grouping is not requested — and the extra query is not
+    // paid for either.
+    const src = makeSource(async () => ({ rows: [{ status: 'Open', task_count: 1 }] }));
+    render(<DatasetWidget widget={{ type: 'table', dataset: 'tasks', dimensions: ['status'], values: ['task_count'], options: { limit: 10 } }} dataSource={src} />);
     await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
     expect((src.queryDataset.mock.calls[0][1] as any).totals).toBeUndefined();
   });


### PR DESCRIPTION
Fixes #5846

#5827 declined the totals row and parked it as option B — "file a follow-up to request the `[]` grouping for flat tables and render a tfoot". #5846 rules it. This is that follow-up.

The flat `table` branch of `packages/plugin-dashboard/src/DatasetWidget.tsx` now asks the server for the `[]` marginal grouping — the same `totals.groupings` machinery the cross-tab has requested since framework#1753 — and renders the answer as a `tfoot`.

## The premise, verified against the executor rather than assumed

The card's premise ("the cross-tab path already requests `totalsGroupings`") came from #5827's report, so it was re-read at the source. **It holds, and the `[]` grouping is expressible for a FLAT selection** — this is not a cross-tab-only capability:

- `DatasetExecutor.execute` (`objectstack packages/services/service-analytics/src/dataset-executor.ts`) validates each grouping as a **subset of the selected dimensions**. `[]` is a subset of every selection, so the flat case needs no server change at all.
- It then re-runs `executeSelection` with `dimensions: []`, `order`/`limit`/`offset` dropped, and pushes `{ dimensions: [], rows }`. The framework's own `dataset-executor.test.ts` already pins exactly the flat shape this PR needs — `dimensions: ['region']` + `totals: { groupings: [[]] }` produces `[{ dimensions: [], rows: [{ revenue: 200, won_amount: 120, win_rate: 0.6 }] }]` — including that measure-scoped filters and derived measures reach the totals pass.
- The client leg was already declared: `ObjectStackAdapter.queryDataset` types and returns `totals?: Array<{ dimensions: string[]; rows: … }>`.

So the premise stands, and nothing in the objectstack repo is edited by this card.

## Measured query cost

The card required this measured before shipping. Run on the **real pipeline** — `compileDataset` → `AnalyticsService` (NativeSQL strategy) → compiled SQL → a real SQLite engine (`sql.js` WASM, the engine `driver-sql` itself falls back to) — over a `sum` + `avg` selection on one dimension:

| rows in table | primary statement | extra `[]` statement | median wall, no totals | median wall, with totals | overhead |
|---|---|---|---|---|---|
| 10,000 | 2.12ms | 0.60ms | 2.07ms | 2.65ms | +0.58ms (+28%) |
| 100,000 | 48.79ms | 9.57ms | 45.97ms | 55.17ms | +9.20ms (+20%) |
| 1,000,000 | 449.77ms | 116.84ms | 433.49ms | 514.10ms | +80.61ms (+19%) |

Statement count goes **1 → 2**, and the added statement is the cheap one:

```sql
-- primary (unchanged)
SELECT industry AS "industry", SUM(amount) AS "revenue", AVG(amount) AS "avg_deal" FROM "opportunity" GROUP BY industry
-- added
SELECT SUM(amount) AS "revenue", AVG(amount) AS "avg_deal" FROM "opportunity"
```

Same `WHERE`, no `GROUP BY`, no sort — which is why it costs ~20% of the query rather than doubling it.

**Judgement: shipped ungated, no widget-schema change.** Two reasons. First the number: one extra scan-only statement, ~+20%, no per-row cost and no N+1. Second the precedent: the cross-tab has requested **three** such groupings, unconditionally and with no authored opt-in, since #1753 — one is strictly less than what already ships on the sibling branch of the same file. And gating would not have been free: `DashboardWidgetOptionsSchema` keeps `options` open (`.passthrough()`) for presentation extras but declares every key that **reaches the analytics query** explicitly, precisely so a typo is an author-time error rather than a silent no-op. A `showTotals` key changes the query, so it would have had to be declared in `@objectstack/spec` — a cross-repo widening for a 20% saving on a query that already runs.

## The one place it is NOT requested

A table truncated by `options.limit`. The executor drops `limit` for a totals query **by design** (a total covers the whole selection), so a top-N table would print a grand total the reader cannot reconcile against the rows in front of them — and "don't make the reader do the addition" is the entire justification for the row. So the grouping is not requested, the extra query is not paid for, and `wantsFlatTotals` gates the **render** as well, so a server that volunteers a `[]` grouping nobody asked for still shows no footer. This is the one judgement call in the diff that the ruling did not settle explicitly; it is raised as an open question in the report rather than buried here.

## The contract, as ruled

- **Server-computed per aggregate semantics.** A `sum` column sums, an `avg`/`min`/`max` column shows that aggregate over the whole set. Nothing is recombined. The fixture makes the difference visible rather than assumed: the server's whole-set `avg_deal` is 4,200,000 while averaging the three bucket averages gives 3,333,333, and `distinct_owners` is 6 overall where the buckets hold 1 + 3 + 5 = 9. Only the `sum` column reconciles, because only a sum does.
- **Omitted, never approximated.** No `[]` entry, or an entry with no row → no footer.
- **Exempt from sorting, pinned last, below the `—` bucket** — by living in `tfoot`, **outside `entries`/`orderedEntries` entirely**, rather than as a special case inside the comparator. Three properties fall out of the placement instead of out of a guard: it was never a sortable entry, `tfoot` renders after `tbody` (so it is below the null bucket by construction), and it cannot perturb the `(row, index)` pairing `openDrill` reads `drillRawRows` by — the sharp edge #5834 documented.
- **Label from the console's existing vocabulary.** `tt('dashboard.total', 'Total')` — the same key the cross-tab's own total row and `PivotTable` already use (en `Total`, zh `总计`). No new string minted. `check:i18n-keys` green.
- **Formatter parity.** `measureField` is keyed by MEASURE, not by row, so the footer cell and the column above it cannot drift on currency, decimals or percent scaling. Verified rather than assumed — the sharp probe is `percentScale: 'fraction'`, where a footer that skipped the per-column descriptor would render a stored `0.55` as `0.55%` (or `1%` via the magnitude heuristic) instead of `55%`.

**No client re-aggregation anywhere**, which is the invariant that made this a query-shape card and not a rendering one.

## What deliberately did not move

- **The cross-tab's three groupings** (`[rowDims, [colDim], []]`) — pinned by a case in the new file *and* by the existing one in `DatasetWidget.test.tsx`.
- **The CSV export.** The totals row is not exported: the export is the table's data, one line per bucket, and the cross-tab has never exported its own total row or column either. Pinned.
- **`DatasetWidget.test.tsx`'s `does NOT request totals for a flat table`** was the case pinning the absence this card removes. It was **updated, not deleted** — it now pins that a flat table requests the grand total *and only* the grand total (never the cross-tab's row/column subtotals, which are meaningless without a second axis), with a sibling case for the `options.limit` gate.

## Verification

All commands from the repo root, in a dedicated worktree. Union re-run **after** the final commit, at `a2c9d307f`. Exit codes captured by redirecting to a file first, never read after a pipe.

| gate | verdict line | exit |
|---|---|---|
| `pnpm --filter '@object-ui/plugin-dashboard^...' build` | dependency closure built (last package `packages/fields`, `built in 4.62s`) | 0 |
| `pnpm exec vitest run packages/plugin-dashboard/` | `Test Files 79 passed (79)` / `Tests 741 passed (741)` | 0 |
| `pnpm --filter @object-ui/plugin-dashboard type-check` | `tsc --noEmit && tsc -p tsconfig.test.json`, no diagnostics | 0 |
| `pnpm --filter @object-ui/plugin-dashboard lint` | `381 problems (0 errors, 381 warnings)` | 0 |
| `node scripts/check-changeset-presence.mjs` | `3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` | 0 |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a 'major' bump.` | 0 |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 4876 tracked text file(s); skipped 85 binary)` | 0 |
| `pnpm run check:i18n-keys` | `Every in-scope call-site key resolves against the en pack (2928 keys)` | 0 |
| `pnpm run check:i18n-drift` | `No en value changed in this range.` | 0 |

**On the lint count.** 381 vs the 369 the sibling PRs reported is mostly `main` moving underneath; what this diff adds is **5**, all pre-existing-idiom `no-explicit-any` warnings in TEST files (4 × the `(URL as any)` export stub copied verbatim from `DatasetWidget.tablePolish.test.tsx`, 1 × a `mock.calls` cast). Measured, not asserted: `DatasetWidget.tsx` itself lints at **12 warnings, 0 errors** both at this HEAD and with the file reverted to `origin/main` — the production file gains none.

**Reverse verification. Direction stated before the run:** reverting *only* `DatasetWidget.tsx` to `origin/main` should turn red the 7 new cases that assert the footer or the request, plus the one updated case in `DatasetWidget.test.tsx` — and leave green the 4 that pin what did not move (the cross-tab's three groupings, the `options.limit` gate, and the two "executor answered nothing" cases, which pass trivially when no footer exists at all) plus its sibling limit case. **Observed: `Tests 8 failed | 59 passed (67)`, and the eight named failures are the eight predicted.** (The script's own one-line summary said "6 + 1"; that was an arithmetic slip in the summary — the enumerated per-case prediction, which is what the run was scored against, matched 8 for 8.) Mutation confirmed on disk by anchored greps rather than by an editor exit code: injected `wantsFlatTotals` 4 → 0 and `dataset-table-total-row` 1 → 0, while the deleted `origin/main` spelling `const totalsGroupings = isMatrix ? [rowDims, [colDim], []] : undefined;` went 0 → 1. Restore leg confirmed the same way (4 / 1 / 0) plus an empty `git status --porcelain` for the file, and re-ran green at 67/67. No rebuild stands between the edit and the run — the suites import the component by relative source path (`../DatasetWidget`), not through a package `exports` → `dist` hop. The script carried `trap … EXIT INT TERM`, and the trap did fire.

**Declared narrowings.** (1) The shared verification lock is inoperable on this host (`os-verify-lock.sh --status` → `CANNOT OPERATE THIS LOCK … a stock macOS does not ship flock`), so the commands above ran directly rather than through the entry point. (2) Repo-wide `check:*` scanning is left to CI. (3) `check:eager-closure` is a **broken gauge** in a fresh worktree — it reads `apps/console/dist/eager-closure.json`, written only by a `vite build` of the console, and reports `This is a broken gauge, not a passing budget` when absent. This diff adds no imports, so the closure is unchanged; CI owns the reading.

**Not verified in a running browser** — the same honest limit #5834 and #5848 declared: the reading is from component tests over the DOM the widget produces, not from a console rendering HotCRM's `executive_dashboard`.

**Out of scope: objectstack#10292** (dataset measure headers render untranslated) is not addressed here.

_Generated by [Claude Code](https://claude.ai/code/session_61f28fb9-8e31-4a6f-b4d8-10f749a092d2)_
