### PR TITLE
feat(app-shell): the built-moment transition into the Studio workbench (#5799)

### DIFF
--- a/.changeset/built-moment-transition-5799.md
+++ b/.changeset/built-moment-transition-5799.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/app-shell': minor
+---
+
+The built-moment transition (#5799): a build conversation that has produced a WHOLE-APP build auto-routes to `/studio/<pkg>/interfaces` — on live completion and on reopening the conversation — after idempotently re-keying the thread under the `app:<pkg>:build` cache key the Studio dock resolves, so the workbench's right rail continues the SAME conversation. Cold start keeps the full-page surface; the dock's 以完整页面打开 door carries a sticky per-conversation opt-out so the one sanctioned way back is never bounced straight to Studio.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1857,6 +1857,57 @@ export function ChatPane({
     onPackageBound?.(boundPackageId);
   }, [isBuildSurface, canBind, boundPackageId, editPackageId, isLoading, onPackageBound]);
 
+  // objectui#5799 — the built-moment transition (cloud#1609 增量一, maintainer
+  // form ruling: cold start keeps the full-page surface; the moment a WHOLE-APP
+  // build exists the conversation lives in the Studio workbench). Derived from
+  // the persisted draftReview envelopes (#2623 lesson: never canvasApp runtime
+  // state), so a REOPENED package conversation transitions too — that is the
+  // card's kill criterion, not an accident. The dock's 以完整页面打开 door sets
+  // a one-shot sessionStorage opt-out so the sanctioned way back to the full
+  // page is not bounced straight to Studio again. The pane remounts per
+  // conversation (its key carries the conversation id), so the fire-once ref
+  // naturally re-arms on a thread switch.
+  const builtPackageId = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      for (const tool of messages[i].toolInvocations ?? []) {
+        const dr = tool.draftReview;
+        if (dr?.packageId && dr.items?.some((it) => it.type === 'app')) return dr.packageId;
+      }
+    }
+    return undefined;
+  }, [messages]);
+  const builtTransitionFiredRef = useRef(false);
+  const paneNavigate = useNavigate();
+  useEffect(() => {
+    if (!isBuildSurface || isLoading || !canBind || !builtPackageId) return;
+    if (builtTransitionFiredRef.current) return;
+    builtTransitionFiredRef.current = true;
+    // The pane can remount several times for one arrival (pending→resolved id,
+    // re-key refetch), so a one-shot flag would be consumed by the first mount
+    // and the next would bounce anyway. The door's generic flag is converted
+    // into a STICKY per-conversation opt-out on first sight; later mounts of
+    // the same thread honor it, other threads transition normally.
+    let optedOut = false;
+    try {
+      const stickyKey = `objectstack:ai-full-page-opted:${conversationId ?? ''}`;
+      if (sessionStorage.getItem('objectstack:ai-full-page-requested') === '1') {
+        sessionStorage.removeItem('objectstack:ai-full-page-requested');
+        sessionStorage.setItem(stickyKey, '1');
+        optedOut = true;
+      } else if (sessionStorage.getItem(stickyKey) === '1') {
+        optedOut = true;
+      }
+    } catch {
+      /* storage unavailable → no opt-out */
+    }
+    if (optedOut) return;
+    // Bind first (idempotent): rekeyScope writes this conversation under the
+    // app:<pkg>:build cache key — the exact key the Studio dock resolves — so
+    // the workbench's right rail resumes THIS thread (A1.b machinery).
+    onPackageBound?.(builtPackageId);
+    paneNavigate(`/studio/${encodeURIComponent(builtPackageId)}/interfaces`);
+  }, [isBuildSurface, isLoading, canBind, builtPackageId, conversationId, onPackageBound, paneNavigate]);
+
   // objectui#5801 — when a turn that STAGED or PUBLISHED something finishes,
   // announce it on the bus so every pending-drafts surface (Studio topbar,
   // home banner, the bar above this pane) converges immediately — previously

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.builtTransition.test.tsx
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.builtTransition.test.tsx
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5799 — the built-moment transition (cloud#1609 增量一).
+ *
+ * The maintainer's form ruling: cold start keeps the full-page build surface;
+ * the moment a WHOLE-APP build exists, the conversation lives in the Studio
+ * workbench. Three pins:
+ *
+ *  1. REOPENING a conversation that already built an app lands in
+ *     `/studio/<pkg>/interfaces` — the kill criterion ("no path stays on the
+ *     full-page chat after the build"), driven from the persisted draftReview
+ *     envelope (#2623 lesson: never runtime canvas state).
+ *  2. A LIVE build completion transitions when the turn settles.
+ *  3. The Studio dock's 以完整页面打开 door is the ONE sanctioned way back:
+ *     its one-shot sessionStorage opt-out keeps the arrival on the full page
+ *     instead of bouncing straight back to Studio.
+ *
+ * Same faked-chat harness as AiChatPage.buildHistorySurvives.test.tsx: the
+ * hook instance owns the thread; hydration (the REAL AiChatPage path) derives
+ * draftReview from the persisted tool envelope.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import React from 'react';
+
+interface FakeMsg {
+  id: string;
+  role: string;
+  content: string;
+  toolInvocations?: unknown[];
+}
+
+const chat = {
+  isLoading: false,
+  append: undefined as ((m: FakeMsg) => void) | undefined,
+};
+
+vi.mock('@object-ui/plugin-chatbot', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const React2 = await import('react');
+  return {
+    ...actual,
+    useAgents: () => ({
+      agents: [{ name: 'metadata_assistant', label: 'Build', capabilities: ['build'] }],
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    }),
+    useAiModels: () => ({ models: [], defaultModelId: undefined }),
+    useHitlInChat: () => ({ decide: vi.fn(), decisions: {} }),
+    useObjectChat: (opts: { initialMessages?: FakeMsg[] }) => {
+      const [messages, setMessages] = React2.useState<FakeMsg[]>(
+        () => (opts.initialMessages ?? []) as FakeMsg[],
+      );
+      chat.append = (m: FakeMsg) => setMessages((prev) => [...prev, m]);
+      return {
+        messages,
+        isLoading: chat.isLoading,
+        error: undefined,
+        sendMessage: vi.fn(),
+        stop: vi.fn(),
+        reload: vi.fn(),
+        clear: vi.fn(),
+        setMessages: vi.fn(),
+      };
+    },
+    ChatbotEnhanced: (props: Record<string, unknown>) => {
+      const msgs = (props.messages ?? []) as FakeMsg[];
+      return <div data-testid="pane">{msgs.map((m) => m.id).join(',')}</div>;
+    },
+  };
+});
+
+vi.mock('@object-ui/auth', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useAuth: () => ({ user: { id: 'u1' } }) };
+});
+vi.mock('../../../providers/MetadataProvider', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useMetadata: () => ({ apps: [] }) };
+});
+vi.mock('../../../providers/AdapterProvider', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useAdapter: () => null };
+});
+vi.mock('../ConversationsSidebar', () => ({
+  ConversationsSidebar: () => <div data-testid="sidebar" />,
+}));
+vi.mock('../LiveCanvas', () => ({
+  LiveCanvas: () => <div data-testid="live-canvas" />,
+}));
+
+import { AiChatPage } from '../AiChatPage';
+
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as unknown as typeof window.matchMedia;
+
+/** A persisted thread whose build ALREADY finished: the tool row carries the
+ *  whole-app draft envelope (app item + packageId). */
+const BUILT_TURNS = [
+  { id: 'r1', role: 'user', content: [{ type: 'text', text: 'build me a CRM' }] },
+  {
+    id: 'r2',
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Built it.' },
+      { type: 'tool-call', toolCallId: 't1', toolName: 'apply_blueprint' },
+    ],
+  },
+  {
+    id: 'r3',
+    role: 'tool',
+    content: [
+      {
+        type: 'tool-result',
+        toolCallId: 't1',
+        toolName: 'apply_blueprint',
+        output: {
+          type: 'text',
+          value: JSON.stringify({
+            status: 'drafted',
+            packageId: 'app.k9',
+            drafted: [
+              { type: 'app', name: 'k9_app' },
+              { type: 'object', name: 'k9_task' },
+            ],
+          }),
+        },
+      },
+    ],
+  },
+];
+
+const UNBUILT_TURNS = [
+  { id: 'r1', role: 'user', content: [{ type: 'text', text: 'hello' }] },
+  { id: 'r2', role: 'assistant', content: [{ type: 'text', text: 'hi — what shall we build?' }] },
+];
+
+let serverTurns: unknown[] = [];
+
+function installFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (/\/conversations\/conv-1$/.test(url) && method === 'GET') {
+        return new Response(JSON.stringify({ id: 'conv-1', messages: serverTurns }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ success: true, data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={['/ai/build/conv-1']}>
+      <Routes>
+        <Route path="/ai/:agent/:conversationId" element={<AiChatPage />} />
+        <Route path="/ai/:agent" element={<AiChatPage />} />
+        <Route
+          path="/studio/:packageId/:tab"
+          element={<div data-testid="studio-page" />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  chat.isLoading = false;
+  serverTurns = [];
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  installFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('AiChatPage — built-moment transition (objectui#5799)', () => {
+  it('reopening a conversation that already built an app lands in the Studio workbench', async () => {
+    serverTurns = BUILT_TURNS;
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('studio-page')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+  });
+
+  it('a conversation with no whole-app build stays on the full page', async () => {
+    serverTurns = UNBUILT_TURNS;
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('pane')).toBeInTheDocument(), { timeout: 4000 });
+    await new Promise((r) => setTimeout(r, 300));
+    expect(screen.queryByTestId('studio-page')).not.toBeInTheDocument();
+  });
+
+  it('a LIVE build completion transitions when the turn settles', async () => {
+    serverTurns = UNBUILT_TURNS;
+    chat.isLoading = true;
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('pane')).toBeInTheDocument(), { timeout: 4000 });
+    expect(screen.queryByTestId('studio-page')).not.toBeInTheDocument();
+
+    // The build turn lands (envelope on the invocation, as the live mapper
+    // produces it) and the stream settles.
+    act(() => {
+      chat.append?.({
+        id: 'live-1',
+        role: 'assistant',
+        content: 'built',
+        toolInvocations: [
+          {
+            toolCallId: 't9',
+            toolName: 'apply_blueprint',
+            state: 'output-available',
+            draftReview: {
+              packageId: 'app.k9',
+              items: [
+                { type: 'app', name: 'k9_app' },
+                { type: 'object', name: 'k9_task' },
+              ],
+            },
+          },
+        ],
+      });
+      chat.isLoading = false;
+    });
+    // one more render so the faked hook reports the settled isLoading
+    act(() => {
+      chat.append?.({ id: 'live-2', role: 'assistant', content: 'done' });
+    });
+    await waitFor(() => expect(screen.getByTestId('studio-page')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+  });
+
+  it("the dock's full-page door opts out ONCE — no bounce straight back to Studio", async () => {
+    serverTurns = BUILT_TURNS;
+    window.sessionStorage.setItem('objectstack:ai-full-page-requested', '1');
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('pane')).toBeInTheDocument(), { timeout: 4000 });
+    await new Promise((r) => setTimeout(r, 300));
+    expect(screen.queryByTestId('studio-page')).not.toBeInTheDocument();
+    // consumed: the NEXT built conversation transitions normally
+    expect(window.sessionStorage.getItem('objectstack:ai-full-page-requested')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -163,6 +163,15 @@ export function StudioChatDock({ packageId, locale }: StudioChatDockProps): Reac
   // returns to THIS Studio surface, not to some console page.
   const openFullPage = React.useCallback(() => {
     rememberDockReturnLocation(`${location.pathname}${location.search}`);
+    // objectui#5799 — the built-moment transition auto-routes package build
+    // conversations into the Studio workbench; this door is the ONE sanctioned
+    // way back to the full page, so it opts the arrival out (read + cleared by
+    // AiChatPage's transition effect).
+    try {
+      sessionStorage.setItem('objectstack:ai-full-page-requested', '1');
+    } catch {
+      /* storage unavailable — the transition will bounce back to Studio */
+    }
     navigate(`/ai/build?package=${encodeURIComponent(packageId)}`);
   }, [location.pathname, location.search, navigate, packageId]);
 


### PR DESCRIPTION
Closes #5799 (cloud#1609 增量一, the agreed 「建成时刻转场」 form).

- Transition trigger = the persisted whole-app draftReview envelope (packageId + `app` item), never runtime canvas state — so **reopening** a built conversation lands in the workbench too (the kill criterion), while cold-start/unbuilt threads keep the full-page surface.
- **Conversation continuity is free**: the effect calls the existing A1.b `onPackageBound` → `rekeyScope(app:<pkg>:build)` before navigating — that cache key is exactly what `StudioChatDock` resolves, so the workbench right rail resumes the same thread (pinned end-to-end by the existing #2627 suite).
- The dock's 以完整页面打开 door gets a sticky per-conversation opt-out (a consumable flag bounced on the pane's second mount — found while testing).

4 new pins; 84 files / 581 tests green across ai/studio-design/hooks; 0 eslint errors. Staging-only train per the release directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)