### PR TITLE
refactor(plugin-calendar): rename the runtime `CalendarEvent` to `CalendarViewEvent`, keep a deprecated alias (#5044)

### DIFF
--- a/.changeset/calendar-view-event-rename-5044.md
+++ b/.changeset/calendar-view-event-rename-5044.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-calendar': patch
+---
+
+`@object-ui/plugin-calendar` now exports the `CalendarView` component's runtime event
+type as **`CalendarViewEvent`**, and keeps `CalendarEvent` as a **`@deprecated` alias**
+of it. **Non-breaking:** the alias is a working re-export denoting the same type, so
+code importing `CalendarEvent` from this package keeps compiling unchanged — nothing is
+removed and no behaviour changes.
+
+Why: `@object-ui/types` exports its own `CalendarEvent`, the AUTHORING event
+(`id: string`, `start` / `end` accept ISO strings with `end` required, plus
+`description`), while this package's was the runtime event (`id: string | number`,
+`start: Date`, `end?: Date`). Neither is assignable to the other, and IDE auto-import
+chose between the two identical names essentially at random — the wrong pick surfaced as
+a remote `TS2322` about `Date` rather than as a wrong import, which is how this package's
+own README example stayed uncompilable through an earlier import-path fix. The authoring
+type keeps the canonical `CalendarEvent` name; the runtime type gets the self-describing
+one (objectui#5044, following the `ObjectCalendarProps` -> `ObjectCalendarComponentProps`
+rename in objectui#4650).
+
+Write `CalendarViewEvent` in new code.

--- a/content/docs/plugins/plugin-calendar.mdx
+++ b/content/docs/plugins/plugin-calendar.mdx
@@ -489,13 +489,17 @@ function MyObjectCalendar({ dataSource }) {
 ```plaintext
 import type { 
   CalendarViewSchema, 
-  CalendarEvent,
   ObjectGridSchema,
   CalendarConfig 
 } from '@object-ui/types'
+import type { CalendarViewEvent } from '@object-ui/plugin-calendar'
 
-// CalendarView types
-const events: CalendarEvent[] = [
+// CalendarView component events — the RUNTIME shape: `id: string | number`,
+// `start` / `end` are real `Date` objects. `@object-ui/types` exports a
+// separate `CalendarEvent`, the AUTHORING event (`id: string`, ISO strings,
+// `end` required); the two are not interchangeable. Renamed in objectui#5044,
+// which left `CalendarEvent` on this package as a `@deprecated` alias.
+const events: CalendarViewEvent[] = [
   {
     id: 1,
     title: 'Meeting',

--- a/packages/plugin-calendar/README.md
+++ b/packages/plugin-calendar/README.md
@@ -130,7 +130,7 @@ import {
 import type {
   ObjectCalendarComponentProps,
   CalendarViewProps,
-  CalendarEvent,
+  CalendarViewEvent,
 } from '@object-ui/plugin-calendar';
 ```
 
@@ -332,15 +332,23 @@ const schema: CalendarViewSchema = {
 };
 ```
 
-> **Two different `CalendarEvent` types, same name.** `@object-ui/types`
-> exports a `CalendarEvent` (`id: string`, `start` / `end` accept ISO strings)
-> — since objectui#5667 it is no longer part of the authored surface (a
-> `calendar-view` node carries `data` records, not events; see
+> **Two calendar event types — pick by which side you are on.**
+> `@object-ui/types` exports **`CalendarEvent`**, the AUTHORING event
+> (`id: string`, `start` / `end` accept ISO strings with `end` required, plus
+> `description`) — since objectui#5667 it is no longer part of the authored
+> surface (a `calendar-view` node carries `data` records, not events; see
 > [Calendar Event Structure](#calendar-event-structure)), but it remains the
 > declared payload type of the host-only `onEventClick` callback. This package
-> also exports a `CalendarEvent` (`CalendarViewProps['events']`), which is the
+> exports **`CalendarViewEvent`** (`CalendarViewProps['events']`), the
 > `CalendarView` **component's runtime** type: `id: string | number` and
-> `start: Date` / `end?: Date`. They are not interchangeable.
+> `start: Date` / `end?: Date`. They are not interchangeable — neither is
+> assignable to the other.
+>
+> Both were spelled `CalendarEvent` until objectui#5044, where IDE auto-import
+> chose between them at random and the wrong pick failed as a remote `TS2322`
+> about `Date`. This package still exports `CalendarEvent` as a **`@deprecated`
+> alias of `CalendarViewEvent`**, so existing importers keep compiling; write
+> `CalendarViewEvent` in new code.
 
 ## Links
 

--- a/packages/plugin-calendar/src/CalendarView.dnd.test.tsx
+++ b/packages/plugin-calendar/src/CalendarView.dnd.test.tsx
@@ -8,11 +8,11 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { CalendarView, type CalendarEvent } from './CalendarView';
+import { CalendarView, type CalendarViewEvent } from './CalendarView';
 
 const baseDate = new Date(2026, 0, 15); // Thu Jan 15, 2026
 
-function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+function makeEvent(overrides: Partial<CalendarViewEvent> = {}): CalendarViewEvent {
   return {
     id: 'evt-1',
     title: 'Sample Event',

--- a/packages/plugin-calendar/src/CalendarView.tsx
+++ b/packages/plugin-calendar/src/CalendarView.tsx
@@ -93,7 +93,27 @@ const DEFAULT_TRANSLATIONS: Record<string, string> = {
  */
 const useCalendarTranslation = createSafeTranslation(DEFAULT_TRANSLATIONS, 'calendar.today')
 
-export interface CalendarEvent {
+/**
+ * The `CalendarView` component's RUNTIME event: what the React component
+ * receives on its `events` prop, already parsed — `start` / `end` are real
+ * `Date` objects, and `id` may be the numeric key a data source returned.
+ *
+ * Renamed from `CalendarEvent` in objectui#5044, following the objectui#4650
+ * precedent (`ObjectCalendarProps` -> `ObjectCalendarComponentProps`).
+ * `@object-ui/types` owns `CalendarEvent`, where it is the AUTHORING event —
+ * `id: string`, `start` / `end` accepting ISO strings with `end` REQUIRED, plus
+ * a `description` this one does not have. The two are structurally
+ * incompatible in BOTH directions (`id` and `start` each conflict), so picking
+ * the wrong one out of IDE auto-import failed as a remote `TS2322` about
+ * `Date`, never as "you imported from the wrong package" — measured on
+ * `README.md`'s own example, which stayed uncompilable through objectui#5010's
+ * import-path fix because both names were real exports.
+ *
+ * `index.tsx` keeps a `@deprecated` `CalendarEvent` alias for this type, so
+ * existing importers keep compiling; the rename is what stops the collision,
+ * not a removal.
+ */
+export interface CalendarViewEvent {
   id: string | number
   title: string
   start: Date
@@ -104,16 +124,16 @@ export interface CalendarEvent {
 }
 
 export interface CalendarViewProps {
-  events?: CalendarEvent[]
+  events?: CalendarViewEvent[]
   view?: "month" | "week" | "day"
   currentDate?: Date
   locale?: string
-  onEventClick?: (event: CalendarEvent) => void
+  onEventClick?: (event: CalendarViewEvent) => void
   onDateClick?: (date: Date) => void
   onViewChange?: (view: "month" | "week" | "day") => void
   onNavigate?: (date: Date) => void
   onAddClick?: () => void
-  onEventDrop?: (event: CalendarEvent, newStart: Date, newEnd?: Date) => void
+  onEventDrop?: (event: CalendarViewEvent, newStart: Date, newEnd?: Date) => void
   /**
    * Fired in WeekView/DayView when the user drags across an empty area of
    * the time grid to select a time range. The default ObjectCalendar
@@ -427,7 +447,7 @@ function isSameDay(date1: Date, date2: Date): boolean {
   )
 }
 
-function getEventsForDate(date: Date, events: CalendarEvent[]): CalendarEvent[] {
+function getEventsForDate(date: Date, events: CalendarViewEvent[]): CalendarViewEvent[] {
   return events.filter((event) => {
     const eventStart = new Date(event.start)
     const eventEnd = event.end ? new Date(event.end) : new Date(eventStart)
@@ -449,11 +469,11 @@ function getEventsForDate(date: Date, events: CalendarEvent[]): CalendarEvent[] 
 
 interface MonthViewProps {
   date: Date
-  events: CalendarEvent[]
+  events: CalendarViewEvent[]
   locale?: string
-  onEventClick?: (event: CalendarEvent) => void
+  onEventClick?: (event: CalendarViewEvent) => void
   onDateClick?: (date: Date) => void
-  onEventDrop?: (event: CalendarEvent, newStart: Date, newEnd?: Date) => void
+  onEventDrop?: (event: CalendarViewEvent, newStart: Date, newEnd?: Date) => void
 }
 
 function MonthView({ date, events, locale = "default", onEventClick, onDateClick, onEventDrop }: MonthViewProps) {
@@ -478,7 +498,7 @@ function MonthView({ date, events, locale = "default", onEventClick, onDateClick
   // days — same as Google/Outlook calendars. Without this, a multi-month
   // event would repeat its title in every single day cell.
   const eventsByDate = React.useMemo(() => {
-    const map = new Map<string, Array<{ event: CalendarEvent; isTitleDay: boolean; isSpanStart: boolean; isSpanEnd: boolean }>>()
+    const map = new Map<string, Array<{ event: CalendarViewEvent; isTitleDay: boolean; isSpanStart: boolean; isSpanEnd: boolean }>>()
     for (const event of events) {
       const eventStart = new Date(event.start)
       const eventEnd = event.end ? new Date(event.end) : new Date(eventStart)
@@ -524,7 +544,7 @@ function MonthView({ date, events, locale = "default", onEventClick, onDateClick
 
   const handleDragStart = (
     e: React.DragEvent,
-    event: CalendarEvent,
+    event: CalendarViewEvent,
     mode: "move" | "resize-end" = "move",
     sourceDay?: Date,
   ) => {
@@ -752,11 +772,11 @@ function MonthView({ date, events, locale = "default", onEventClick, onDateClick
 interface TimeGridViewProps {
   mode: "week" | "day"
   date: Date
-  events: CalendarEvent[]
+  events: CalendarViewEvent[]
   locale?: string
   slotMinutes?: number
-  onEventClick?: (event: CalendarEvent) => void
-  onEventDrop?: (event: CalendarEvent, newStart: Date, newEnd?: Date) => void
+  onEventClick?: (event: CalendarViewEvent) => void
+  onEventDrop?: (event: CalendarViewEvent, newStart: Date, newEnd?: Date) => void
   onTimeRangeSelect?: (start: Date, end: Date) => void
 }
 
@@ -814,7 +834,7 @@ function TimeGridView({
   // start time on the first day to midnight, full-day on intermediate days,
   // and midnight to end time on their last day.
   type Entry = {
-    event: CalendarEvent
+    event: CalendarViewEvent
     startMin: number
     endMin: number
     isStart: boolean // is this the event's first day
@@ -825,7 +845,7 @@ function TimeGridView({
   // start/end land on midnight boundaries (date-only data), or if it spans
   // 24h or more. These render in the all-day row above the time grid
   // instead of filling the whole vertical column.
-  const isAllDayEvent = React.useCallback((ev: CalendarEvent): boolean => {
+  const isAllDayEvent = React.useCallback((ev: CalendarViewEvent): boolean => {
     if (ev.allDay) return true
     const s = new Date(ev.start)
     const e = ev.end ? new Date(ev.end) : new Date(s)
@@ -838,8 +858,8 @@ function TimeGridView({
   }, [])
 
   const { allDayEvents, timedEvents } = React.useMemo(() => {
-    const allDay: CalendarEvent[] = []
-    const timed: CalendarEvent[] = []
+    const allDay: CalendarViewEvent[] = []
+    const timed: CalendarViewEvent[] = []
     for (const ev of events) {
       if (isAllDayEvent(ev)) allDay.push(ev)
       else timed.push(ev)
@@ -849,7 +869,7 @@ function TimeGridView({
 
   // All-day events grouped per visible day (for the all-day row).
   const allDayByDay = React.useMemo(() => {
-    const map = new Map<string, Array<{ event: CalendarEvent; isStart: boolean; isEnd: boolean }>>()
+    const map = new Map<string, Array<{ event: CalendarViewEvent; isStart: boolean; isEnd: boolean }>>()
     for (const d of days) map.set(dayKey(d), [])
     for (const ev of allDayEvents) {
       const s = startOfDay(new Date(ev.start))

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -24,7 +24,7 @@
 
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import type { ObjectGridSchema, DataSource, ViewData, CalendarConfig } from '@object-ui/types';
-import { CalendarView, type CalendarEvent } from './CalendarView';
+import { CalendarView } from './CalendarView';
 import { usePullToRefresh } from '@object-ui/mobile';
 import {
   useNavigationOverlay,

--- a/packages/plugin-calendar/src/__tests__/name-collision-5044.test.ts
+++ b/packages/plugin-calendar/src/__tests__/name-collision-5044.test.ts
@@ -1,0 +1,189 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/plugin-calendar` <-> `@object-ui/types` `CalendarEvent`
+ * name-collision tripwire (objectui#5044). Sibling of
+ * `spec-symbol-4650.test.ts` next door — same package, same verdict shape, a
+ * different owner of the contested name.
+ *
+ * ## What collided
+ *
+ * Two structurally incompatible PUBLIC exports were both called
+ * `CalendarEvent`:
+ *
+ *   - `@object-ui/types` — the AUTHORING event: `id: string`, `start` / `end`
+ *     accepting ISO strings with `end` REQUIRED, plus a `description`. It is
+ *     the declared payload of the host-only `onEventClick` callback.
+ *   - `@object-ui/plugin-calendar` — the `CalendarView` component's RUNTIME
+ *     event: `id: string | number`, `start: Date`, `end?: Date`, no
+ *     `description`.
+ *
+ * Neither is assignable to the other (`id` and `start` each conflict), and IDE
+ * auto-import chooses between two identical names by alphabetical order or
+ * most-recent use. The wrong choice did not surface as "you imported from the
+ * wrong package": it surfaced as a remote `TS2322: Type 'string' is not
+ * assignable to type 'Date'` several lines away. That is measured, not
+ * predicted — `packages/plugin-calendar/README.md`'s own example stayed
+ * uncompilable straight through objectui#5010's import-path fix, because
+ * neither name was fabricated and neither path was wrong.
+ *
+ * ## The ruling this pins (2026-08-19 maintainer ruling on objectui#5044)
+ *
+ * Option A, following the objectui#4650 precedent: the AUTHORING type keeps the
+ * canonical name `CalendarEvent` (it is the spec-side contract name), the
+ * RUNTIME type is renamed to `CalendarViewEvent`, and a `@deprecated`
+ * `CalendarEvent` alias stays behind on the plugin barrel so existing importers
+ * keep compiling. Option B (stop exporting the runtime type) was rejected as
+ * breaking with unmeasurable external cost; option C (a docs note) was rejected
+ * as leaving the trap armed.
+ *
+ * So the assertions below are about the PUBLISHED NAME SET and the shapes those
+ * names denote. Behaviour does not change in this card and nothing here claims
+ * it did — a test that renders a calendar cannot see any of this.
+ *
+ * ## Legs that do NOT discriminate, and are therefore not written
+ *
+ *   - Rendering a `CalendarView` with events: green before and after the
+ *     rename, under either name. It measures the component, not the name set.
+ *   - `typeof CalendarEvent` at runtime: both are TYPES, erased before vitest
+ *     ever loads this file. There is no runtime value to probe, which is
+ *     exactly why the pins below are compile-time.
+ *
+ * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
+ * that, every `Assert<...>` below is erased before vitest runs and proves
+ * nothing. That config also drops the root `paths`, so `@object-ui/types`
+ * resolves through the workspace dependency's BUILT `.d.ts` — the surface a
+ * consumer actually imports, not a sibling source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The authoring event, from the package that KEEPS the canonical name.
+import type { CalendarEvent as AuthoringCalendarEvent } from '@object-ui/types';
+// The runtime event under its new self-describing name, AND the deprecated
+// alias under the old one. This import statement is itself the "an importer of
+// the old name still compiles" leg: if the alias stopped being a working
+// export, this file would not compile.
+import type { CalendarViewEvent, CalendarEvent as DeprecatedRuntimeAlias } from '../index';
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+/** Is `A` assignable to `B`? Written as a type so a `false` can be asserted. */
+type AssignableTo<A, B> = [A] extends [B] ? true : false;
+
+describe('the CalendarEvent name collision stays resolved', () => {
+  it('is pinned at compile time', () => {
+    // A local type erased to `any` satisfies every assertion below while
+    // proving nothing (objectstack#4171 is that failure for other symbols).
+    type _RuntimeIsNotAny = Assert<Equal<IsAny<CalendarViewEvent>, false>>;
+    type _AuthoringIsNotAny = Assert<Equal<IsAny<AuthoringCalendarEvent>, false>>;
+
+    // 1. The two names now denote two DIFFERENT types. This is the whole card:
+    //    one name, one contract.
+    type _DistinctExports = Assert<Equal<Equal<AuthoringCalendarEvent, CalendarViewEvent>, false>>;
+
+    // 2. ...and they are incompatible in BOTH directions, which is why sharing
+    //    a name was a trap rather than a redundancy. If either of these ever
+    //    starts holding, re-triage the pair instead of keeping the rename out
+    //    of habit.
+    type _RuntimeNotAssignableToAuthoring = Assert<
+      Equal<AssignableTo<CalendarViewEvent, AuthoringCalendarEvent>, false>
+    >;
+    type _AuthoringNotAssignableToRuntime = Assert<
+      Equal<AssignableTo<AuthoringCalendarEvent, CalendarViewEvent>, false>
+    >;
+
+    // 3. The deprecated alias denotes the SAME type as the new name — the whole
+    //    promise it makes to importers that still spell the old one, and what
+    //    keeps this rename non-breaking. A type-only stub (`= never`, `= any`,
+    //    a re-declaration) would fail here.
+    type _AliasIsSameType = Assert<Equal<DeprecatedRuntimeAlias, CalendarViewEvent>>;
+
+    // 4. Each side still has the shape that made them incompatible, so the
+    //    assertions above cannot go vacuous by one side quietly changing.
+    type _RuntimeStartIsDate = Assert<Equal<CalendarViewEvent['start'], Date>>;
+    type _RuntimeIdAcceptsNumber = Assert<Equal<CalendarViewEvent['id'], string | number>>;
+    type _AuthoringIdIsString = Assert<Equal<AuthoringCalendarEvent['id'], string>>;
+    type _AuthoringStartAcceptsIso = Assert<Equal<AuthoringCalendarEvent['start'], string | Date>>;
+    // `description` is the authoring type's own key; the runtime event has no
+    // such member. Reading it off the runtime type would be a compile error, so
+    // the direction is asserted through `keyof`.
+    type _AuthoringHasDescription = Assert<
+      Equal<'description' extends keyof AuthoringCalendarEvent ? true : false, true>
+    >;
+    type _RuntimeHasNoDescription = Assert<
+      Equal<'description' extends keyof CalendarViewEvent ? true : false, false>
+    >;
+
+    // The `Assert<...>` aliases above are the test. `expect` keeps vitest from
+    // reporting an assertion-less test.
+    expect(true).toBe(true);
+  });
+
+  it('keeps the old name marked deprecated at the export site', () => {
+    // The alias is what makes this non-breaking; the `@deprecated` tag is what
+    // makes it a FIX rather than a second live spelling. An IDE strikes the
+    // deprecated completion through and ranks it last, which is the measurable
+    // half of "auto-import stops offering two shapes under one name". Nothing
+    // in the type system can see a JSDoc tag, so it is read off the barrel.
+    const barrel = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), '..', 'index.tsx'),
+      'utf8',
+    );
+
+    const statement = "export type { CalendarViewEvent as CalendarEvent } from './CalendarView';";
+    const at = barrel.indexOf(statement);
+    expect(at, `${statement} not found in the barrel`).toBeGreaterThan(-1);
+
+    // The JSDoc block that ends immediately above the alias export, with only
+    // whitespace between it and the statement.
+    const before = barrel.slice(0, at);
+    const blockEnd = before.lastIndexOf('*/');
+    expect(blockEnd, 'no JSDoc block precedes the alias export').toBeGreaterThan(-1);
+    expect(before.slice(blockEnd + 2).trim()).toBe('');
+
+    const blockStart = before.lastIndexOf('/**', blockEnd);
+    const jsdoc = before.slice(blockStart, blockEnd + 2);
+    expect(jsdoc).toContain('@deprecated');
+    expect(jsdoc).toContain('CalendarViewEvent');
+  });
+
+  it('does not re-export the runtime event under the authoring name from `@object-ui/types`', () => {
+    // The other half of "which type moved": the AUTHORING type keeps the
+    // canonical name. If a future edit inverted this card by renaming the
+    // authoring type instead, `@object-ui/types` would stop declaring
+    // `CalendarEvent` and this would fail — the compile-time pins above would
+    // not, because they read whatever that name resolves to.
+    const typesSrc = readFileSync(
+      join(repoRoot(), 'packages/types/src/complex.ts'),
+      'utf8',
+    );
+    expect(typesSrc).toContain('export interface CalendarEvent {');
+  });
+});
+
+/** Walk up to the workspace root, so the type source is found by repo layout. */
+function repoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i += 1) {
+    try {
+      readFileSync(join(dir, 'pnpm-workspace.yaml'));
+      return dir;
+    } catch {
+      dir = resolve(dir, '..');
+    }
+  }
+  throw new Error('repo root (pnpm-workspace.yaml) not found from this test file');
+}

--- a/packages/plugin-calendar/src/calendar-view-renderer.eventsCollision.test.tsx
+++ b/packages/plugin-calendar/src/calendar-view-renderer.eventsCollision.test.tsx
@@ -10,7 +10,7 @@
  * `plugin-calendar:calendar-view` — the authored `events` collision
  * (objectui#4433, measured by the objectui#4425 phase-1 sweep).
  *
- * The renderer computes a `CalendarEvent[]` from `schema.data` and passes it as
+ * The renderer computes a `CalendarViewEvent[]` from `schema.data` and passes it as
  * `events={…}`, then spreads the remaining props AFTER it. `SchemaRenderer`
  * forwards a node's `events` key as a prop — it is not on the renderer's strip
  * list — so a node authoring `events`, the ordinary SDUI action metadata of

--- a/packages/plugin-calendar/src/calendar-view-renderer.tsx
+++ b/packages/plugin-calendar/src/calendar-view-renderer.tsx
@@ -8,7 +8,7 @@
 
 import { ComponentRegistry } from '@object-ui/core';
 import type { CalendarViewSchema } from '@object-ui/types';
-import { CalendarView, type CalendarEvent, type CalendarViewProps } from './CalendarView';
+import { CalendarView, type CalendarViewEvent, type CalendarViewProps } from './CalendarView';
 import React from 'react';
 
 /* ════════════════════════════════════════════════════════════════════════════
@@ -268,7 +268,7 @@ ComponentRegistry.register('calendar-view',
     onAction?: unknown;
     [key: string]: unknown;
   }) => {
-    // Transform schema data to CalendarEvent format
+    // Transform schema data to CalendarViewEvent format
     const events = React.useMemo(() => {
       if (!schema.data || !Array.isArray(schema.data)) return [];
       
@@ -331,7 +331,7 @@ ComponentRegistry.register('calendar-view',
         ? (onAction as (action: { type: string; payload: unknown }) => void)
         : undefined;
 
-    const handleEventClick = (event: CalendarEvent) => {
+    const handleEventClick = (event: CalendarViewEvent) => {
       dispatchAction?.({
         type: 'event-click',
         payload: event

--- a/packages/plugin-calendar/src/index.tsx
+++ b/packages/plugin-calendar/src/index.tsx
@@ -31,7 +31,24 @@ export type { ObjectCalendarComponentProps as ObjectCalendarProps } from './Obje
 
 // Export CalendarView component (merged from plugin-calendar-view)
 export { CalendarView } from './CalendarView';
-export type { CalendarViewProps, CalendarEvent } from './CalendarView';
+export type { CalendarViewProps, CalendarViewEvent } from './CalendarView';
+
+/**
+ * @deprecated Use `CalendarViewEvent`. Renamed in objectui#5044 because
+ * `@object-ui/types` owns `CalendarEvent`, where it means the AUTHORING event
+ * (`id: string`, `start` / `end` accepting ISO strings with `end` required,
+ * plus `description`) — not this component's runtime event, whose `start` is a
+ * real `Date` and whose `id` may be a number. The two are structurally
+ * incompatible in both directions, so IDE auto-import picking the wrong one
+ * failed as a remote `TS2322`. The alias denotes the SAME type and is kept only
+ * so existing importers keep compiling.
+ *
+ * Spelled with its `from` clause for the same reason the
+ * `ObjectCalendarProps` alias above is (objectui#4650): a re-export with no
+ * module specifier is judged as its own declaration by
+ * `scripts/check-spec-symbol-derivation.mjs`.
+ */
+export type { CalendarViewEvent as CalendarEvent } from './CalendarView';
 
 // Import and register calendar-view renderer
 import './calendar-view-renderer';


### PR DESCRIPTION
Fixes #5044

Executes the 2026-08-19 maintainer ruling (**option A**, 「全部接受」): the **authoring** type keeps the canonical name, the **runtime** type is renamed, and a `@deprecated` alias is left behind — the same shape #4650 used for `ObjectCalendarProps` → `ObjectCalendarComponentProps`.

## What moved

| | before | after |
| --- | --- | --- |
| `@object-ui/types` — AUTHORING event (`id: string`, ISO-string `start`/`end` with `end` required, plus `description`) | `CalendarEvent` | `CalendarEvent` — **unchanged**, keeps the canonical name |
| `@object-ui/plugin-calendar` — `CalendarView`'s RUNTIME event (`id: string \| number`, `start: Date`, `end?: Date`) | `CalendarEvent` | **`CalendarViewEvent`**, plus `CalendarEvent` as a `@deprecated` alias |

The published `.d.ts` carries both, with the deprecation intact:

```
packages/plugin-calendar/dist/index.d.ts
14: export type { CalendarViewProps, CalendarViewEvent } from './CalendarView';
16:  * @deprecated Use `CalendarViewEvent`. Renamed in objectui#5044 because
30: export type { CalendarViewEvent as CalendarEvent } from './CalendarView';

packages/plugin-calendar/dist/CalendarView.d.ts
44: export interface CalendarViewEvent {
```

`grep 'interface CalendarEvent' packages/plugin-calendar/dist/*.d.ts` now returns nothing — the old name survives only as a re-export of the new one.

**Non-breaking, by construction rather than by assertion.** At the package boundary this change is strictly additive: before, the barrel exported `CalendarEvent`; after, it exports `CalendarEvent` (aliased) *and* `CalendarViewEvent`. No name was removed and no shape changed, so no consumer has a narrowed surface to fail on. That is why option B (stop exporting the runtime type) is not what landed.

## Acceptance evidence is about the published NAME SET, not behaviour

Nothing here changes what a calendar renders, and no test claims it does. The new pin is `packages/plugin-calendar/src/__tests__/name-collision-5044.test.ts`, sibling of `spec-symbol-4650.test.ts` next door. It is compiled by this package's `tsconfig.test.json`, which drops the root `paths` — so `@object-ui/types` resolves through the workspace dependency's **built** `.d.ts`, the surface a consumer actually imports. Proved rather than assumed:

```
$ pnpm exec tsc -p tsconfig.test.json --listFiles --noEmit | grep -E 'name-collision-5044|types/dist/index.d.ts'
/home/user/objectui-5044/packages/types/dist/index.d.ts
/home/user/objectui-5044/packages/plugin-calendar/src/__tests__/name-collision-5044.test.ts
```

What it pins:

1. the two names denote **different** types, and are incompatible in **both** directions (`id` and `start` each conflict) — the trap itself, not just its symptom;
2. the deprecated alias denotes the **same** type as `CalendarViewEvent` — a type-only stub (`= never`, a re-declaration) fails here;
3. an importer of the **old** name still compiles — the import statement at the top of the test file *is* that leg;
4. each side still has the shape that made them incompatible, so (1) cannot go vacuous;
5. `@object-ui/types` still declares `CalendarEvent` — the "which type moved" invariant, so a future edit cannot silently invert this card.

**Legs that do not discriminate**, named rather than written: rendering a `CalendarView` is green before and after under either name (it measures the component, not the name set); `typeof CalendarEvent` at runtime probes nothing, because both are types and are erased before vitest loads the file — which is exactly why the pins are compile-time.

## Reverse verification (on the committed tree, mutation confirmed on disk each time)

**Ablation 1 — delete the deprecated alias from the barrel** (the "Option B by another route" failure). Predicted: type-check red on the old-name import; vitest red on the deprecation-tag test only.

```
DISK: "CalendarViewEvent as CalendarEvent" occurrences → 0 (was 1); new-name export still 1
$ pnpm --filter @object-ui/plugin-calendar type-check   → exit 2
src/__tests__/name-collision-5044.test.ts(76,34): error TS2724: '"../index"' has no exported member named 'CalendarEvent'. Did you mean 'CalendarViewEvent'?
src/__tests__/name-collision-5044.test.ts(112,36): error TS2344: Type 'false' does not satisfy the constraint 'true'.   ← _AliasIsSameType
$ pnpm exec vitest run …/name-collision-5044.test.ts    → exit 1
× keeps the old name marked deprecated at the export site
  Tests  1 failed | 2 passed (3)
```

Observed exactly as predicted, including the *non*-discriminating half: the type-level `it` passed under vitest, because its assertions are erased there.

**Ablation 2 — the cross-package leg**, mutating the AUTHORING type's `id: string` → `string | number` in `packages/types/src/complex.ts`. This one exists to prove the pins read the **rebuilt** `.d.ts` rather than a cache, so both legs rebuild and both are confirmed in `dist`:

```
mutation leg:  src  id: string | number;   →  pnpm --filter @object-ui/types build (exit 0)
               dist packages/types/dist/complex.d.ts:135  id: string | number;
               pnpm --filter @object-ui/plugin-calendar type-check → exit 2
               src/__tests__/name-collision-5044.test.ts(118,40): error TS2344: Type 'false' does not
                 satisfy the constraint 'true'.        ← line 118 is _AuthoringIdIsString
restore leg:   git checkout HEAD -- … && rebuild
               dist packages/types/dist/complex.d.ts:135  id: string;
               grep -c 'id: string | number;' packages/types/dist/complex.d.ts → 0
               git diff HEAD --stat → empty
```

Every mutation was confirmed by grepping the text it was meant to change, never by an editor's exit code; both ablation scripts carried a `trap … EXIT INT TERM` restore.

## Also in this diff, and why

- **`packages/plugin-calendar/src/ObjectCalendar.tsx`** — dropped `type CalendarEvent` from its `./CalendarView` import. The identifier appeared **exactly once in the file, on the import line itself** (`grep -cw` → 1), so it had no reader; renaming it would have left a name nothing spells. Called out here rather than left silent.
- **README + `content/docs/plugins/plugin-calendar.mdx`** — the docs half of this rename (AGENTS.md #2). The README's "two same-name types" note now names both types and records the alias. The docs page's *TypeScript Support* block was a second live instance of the very defect this card fixes: it annotated a runtime-shaped literal (`id: 1`, `start: new Date(...)`) as `CalendarEvent` **imported from `@object-ui/types`**, which is the authoring type that rejects both. It now imports `CalendarViewEvent` from this package. The block is fenced ` ```plaintext `, so `check:doc-snippet-types` never read it — that is why it outlived #5010.
- The README fence that reads `onEventClick?: (event: CalendarEvent) => void` is **left alone**: that is `CalendarViewSchema`'s host-only callback, whose payload really is the `@object-ui/types` authoring type.

## Verification — union re-run on the final commit `d9d13e7fa`

| check | result |
| --- | --- |
| `pnpm --filter @object-ui/plugin-calendar type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0 |
| `pnpm exec vitest run --maxWorkers=2 packages/plugin-calendar/src` (repo root) | `Test Files 12 passed (12)` / `Tests 86 passed (86)` |
| `pnpm exec vitest run scripts/__tests__/{doc-version-claims,check-doc-links,vitest-invocation-guard,check-changeset-presence}.test.ts` | `Test Files 4 passed (4)` / `Tests 166 passed (166)` |
| `node scripts/check-changeset-presence.mjs` | `✅ 7 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-doc-snippet-types.mjs` | `Semantic phase: 101 of 101 block(s) judged, 0 failed.` |
| `pnpm check:doc-types` | `✅ Every documented component type is registered.` |
| `pnpm check:spec-symbols` | `✅ spec symbol derivation: … 13 declared dialects, 3 untriaged collisions in 1 packages.` (unchanged — neither name collides with a spec export) |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 4882 tracked text file(s); skipped 85 binary).` |
| `pnpm check:self-import` / `check:phantom-deps` | `✅` / `✅` |
| `node scripts/check-type-check-coverage.mjs` | `✅ 45/46 …` and `✅ test type-check coverage: 41/41 packages compile their tests` |
| `node scripts/check-lint-coverage.mjs` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `node scripts/check-doc-links.mjs` | `Links are valid across 13 scan roots.` |

**Lint is a declared narrowing, not the repo-wide run** — CI runs the farm regardless. Evidence that the narrowing excluded nothing: (1) the population came from **eslint's own enumeration**, not a guess — `eslint --no-inline-config --format json packages/plugin-calendar` enumerated **20** files, all seven changed/added source files among them; eslint itself refused `content/docs` and `.changeset` with *"all of the files matching the glob pattern are ignored"*, so those two edits are outside the lint population by its configuration; (2) the file count is read from `--format json`, not counted by hand; (3) **type-aware linting is off** — `eslint --print-config` on the barrel prints `parserOptions: {}` (no `project` / `projectService`), so this diff cannot move the verdict of any file it does not touch. Result: **0 error-severity messages** (106 pre-existing warnings, unchanged in kind).

Nothing was widened, no pin loosened, no assertion weakened, no exemption added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_