### PR TITLE
docs(app-shell): anchor the runtime-config "Server-side" pointers on symbol + package

### DIFF
--- a/.changeset/runtime-config-server-side-pointer.md
+++ b/.changeset/runtime-config-server-side-pointer.md
@@ -1,0 +1,8 @@
+---
+---
+
+Comment-only change to `app-shell`'s `runtime-config.ts`: the "Server-side" pointer block
+now anchors on exported symbol + package (`RuntimeConfigPlugin` from
+`@objectstack/cloud-connection`, `RuntimeConfigPlugin` from `@objectstack/objectos-runtime`,
+`createStudioRuntimeConfigPlugin` from `@objectstack/service-cloud`) instead of file paths,
+two of which had gone stale. No published behaviour changes.

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -14,10 +14,21 @@
  * The runtime-config shape lives in app-shell because the Console SPA in
  * `apps/console` consumes app-shell code.
  *
- * Server-side: see
- *   cloud/packages/service-cloud/src/multi-environment-plugins.ts
- *   cloud/packages/service-cloud/src/single-environment-plugin.ts
- *   framework/packages/runtime/src/cloud/runtime-config-plugin.ts
+ * Server-side producers of this payload — anchored by exported symbol +
+ * package rather than by file path, because the previous path list went stale
+ * (the framework implementation moved packages; the cloud repo deleted its
+ * dead forked per-environment stack). Nothing imports across the repo
+ * boundary, so this list is the only link between the two sides of the shape:
+ *
+ *   - `RuntimeConfigPlugin` from `@objectstack/cloud-connection` (framework)
+ *     — the open implementation. Serves `GET /api/v1/runtime/config` and the
+ *     legacy `GET /api/v1/studio/runtime-config` alias, and owns the
+ *     `branding` / `features` shape mirrored below.
+ *   - `RuntimeConfigPlugin` from `@objectstack/objectos-runtime` (cloud) —
+ *     subclasses the open plugin to inject cloud plan policy, i.e. which plan
+ *     unlocks `aiStudio` / `customDomain` / `sso`.
+ *   - `createStudioRuntimeConfigPlugin` from `@objectstack/service-cloud`
+ *     (cloud) — the multi-environment control-plane handshake.
  */
 
 import { sharedGetJson } from '@object-ui/types';


### PR DESCRIPTION
Fixes #5206

`packages/app-shell/src/runtime-config.ts` opened with a *"Server-side: see"* block
listing three file paths. Triage's rationale for grading an XS comment fix as a card is
worth restating, because it drove every choice below: **nothing imports across the repo
boundary, so that block is the entire consumer → producer link** for the `branding` /
`features` contract face. A dead pointer there is not cosmetic — it is the whole link.

## Re-measured on the producing repos, not copied from the card

The card body named a destination. Copying it would have produced the *next* stale
pointer, so every leg was re-measured against `main` of the producing repo, through one
pipeline (GitHub contents API at `refs/heads/main`), with controls on that same pipeline
so a broken probe cannot read as a pass.

### Before — the three paths as they were written

| probe | expected | actual |
|---|---|---|
| framework `packages/runtime/src/cloud/runtime-config-plugin.ts` | MISS | **MISS** |
| cloud `packages/service-cloud/src/multi-environment-plugins.ts` | HIT | **HIT** |
| cloud `packages/service-cloud/src/single-environment-plugin.ts` | MISS | **MISS** |
| **[+ctl]** framework `packages/runtime/src` (directory) | HIT | **HIT** |
| **[+ctl]** cloud `packages/service-cloud/src` (directory) | HIT | **HIT** |
| **[-ctl]** framework `packages/runtime/src/NO-SUCH-FILE.ts` | MISS | **MISS** |

The two positive controls are what make the two MISSes readings rather than typos: both
parent directories are alive, and one sibling path from the same block still resolves.
The negative control is what stops a rubber-stamping checker from reading as a pass.

**Two of the three were dead, not one.** The card measured the framework line; triage
asked for the two cloud lines to be checked "while in there", flagging that the dev might
lack cloud-repo scope. Scope was available, so they were checked — and
`single-environment-plugin.ts` turned out to be gone as well. It was deleted in the cloud
repo along with the rest of a dead forked per-environment runtime stack (cloud changeset
`drop-service-cloud-forked-runtime-stack`, whose own text lists
`single-environment-plugin` among the removed modules). The live single-environment
producer today is a `RuntimeConfigPlugin` subclass in `@objectstack/objectos-runtime`
that wraps the open framework plugin and injects cloud plan policy.

Fixing that second line is a bounded in-place fix, declared here rather than left
implicit: same defect class as the card (a dead pointer in the same comment block), same
file already claimed by this card, mechanical, pinned by the evidence above, and it adds
no new verification surface.

### After — the three anchors this PR writes

| anchor | expected | actual |
|---|---|---|
| pkg `@objectstack/cloud-connection` (framework) | HIT | **HIT** |
| sym `RuntimeConfigPlugin` re-exported from its package index | HIT | **HIT** |
| pkg `@objectstack/objectos-runtime` (cloud) | HIT | **HIT** |
| sym `RuntimeConfigPlugin` re-exported from its package index | HIT | **HIT** |
| pkg `@objectstack/service-cloud` (cloud) | HIT | **HIT** |
| sym `createStudioRuntimeConfigPlugin` re-exported from its package index | HIT | **HIT** |
| **[-ctl]** pkg `@objectstack/NO-SUCH-PACKAGE` | MISS | **MISS** |
| **[-ctl]** sym `NoSuchSymbolControl` | MISS | **MISS** |
| **[-ctl]** sym `OS_CLOUD_URL` — mentioned only in a comment in that index | MISS | **MISS** |

That last control matters: the symbol leg must not count a bare mention. An earlier,
line-oriented version of the symbol probe reported a false MISS on
`createStudioRuntimeConfigPlugin` (its export is spread across lines); the mismatch was
caught by the expectations table rather than silently absorbed, the probe was made
multiline-aware, and the comment-only control was added so the fix could not have been a
loosening.

## Why symbol + package, and not the corrected paths

A corrected path list would be true today and would rot on the next move — which is
precisely the failure this card exists to repair, and the second dead line proves it
happens on both sides of the boundary. Exported symbol + package name is the anchor that
survives a file move: both are stable identifiers, both are greppable from the root of
the owning repo, and a rename of either is a deliberate API change rather than a
refactor. No line numbers and no deep paths are written. The block also now says in one
clause *why* it is anchored that way, so the next person moving a file has the reason in
front of them.

## Verification

Comment-only diff plus a changeset — **no behavioural leg exists to ablate**, so no
reverse-verification is staged here; a decorative one would assert nothing. The
discriminating evidence is the before/after resolution check above.

Gate union re-run on the final commit `f696aeb6f`; the working tree at that point is
identical to `HEAD` (`git status --porcelain` and `git diff HEAD` both empty), so the
typecheck and test runs below describe that same tree.

- `pnpm exec vitest run packages/app-shell/src/runtime-config.test.ts` — `Test Files 1
  passed (1)`, `Tests 16 passed (16)`.
- `pnpm exec vitest run packages/app-shell/ --maxWorkers=2` — `Test Files 506 passed
  (506)`, `Tests 4923 passed | 1 skipped (4924)`.
- `pnpm --filter @object-ui/app-shell type-check` — exit 0, zero `error TS`. (The first
  attempt reported 932 errors of the unbuilt-dependency class, `TS2307`/`TS6305`, in a
  fresh worktree; `pnpm --filter '@object-ui/app-shell^...' build` first, then clean.)
- `node scripts/check-changeset-presence.mjs` — run rather than assumed. It failed first
  ("1 source file(s) of 1 released package(s) changed, and this change adds no
  changeset"), which is correct: this file lives under a released package's `src/`. Now
  green: *"Every one of them has an EMPTY frontmatter — declared as releasing nothing,
  which is the explicit exemption and a complete answer to this gate."*
- `node scripts/check-changeset-no-major.mjs` — *"No changeset declares a `major` bump."*
- `node scripts/check-control-bytes.mjs` — *"OK (scanned 4881 tracked text file(s))"*.
- `node scripts/check-doc-links.mjs` — *"Links are valid across 13 scan roots."*
- `pnpm exec eslint packages/app-shell --format json` — exit 0; **941 files** linted, 0
  errors (2606 pre-existing warnings). This is a narrowing of the repo-wide lint, and it
  is a measurement rather than a skip: the population came from eslint's own config
  resolution (a directory was passed, eslint chose the files), the count is read from
  `--format json`, and `eslint.config.js` declares no `projectService`, no
  `parserOptions` and no `project:` key (grep exits 1 on all three; control: `rules`
  matches ten times), so type-aware linting is off and a comment-only edit inside one
  file cannot move the verdict of any file that was not touched.

Nothing here required widening a type, loosening a pin, or weakening an assertion.

## Out of scope, filed separately

While reading the declared payload shape: the cloud producer resolves a `features.scim`
flag next to `customDomain` and `sso`, and `scim` has zero occurrences across objectui's
`packages/` and `apps/` TypeScript (control: `sso` is declared and read in this very
file). Recorded as an observation, not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_