### PR TITLE
test: converge the last two tombstone-judge copies onto the shared judge (#4947)

### DIFF
--- a/.changeset/4947-tombstone-judge-convergence.md
+++ b/.changeset/4947-tombstone-judge-convergence.md
@@ -1,0 +1,11 @@
+---
+---
+
+Test-infrastructure convergence, no shipped code touched: the last two local copies of
+the ADR-0087 D2 tombstone criterion — in `packages/plugin-detail`'s
+`recordDetailsInputs` spec-parity test and `packages/app-shell`'s `block-config`
+preview test — now import `@object-ui/test-support`'s shared judge instead of
+spelling out `unwrap()._def.type === 'never'` by hand. Both copies carried the
+structural channel alone; the shared judge OR-s it with the `[REMOVED]` description
+channel, so neither channel can go quietly permissive on its own, and every
+tombstone-aware gate in the repo now moves together when the criterion changes.

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -6,6 +6,7 @@ import {
   PageHeaderProps,
   RecordDetailsProps,
 } from '@objectstack/spec/ui';
+import { isShapeKeyTombstoned, listedShapeKeys, shapeMemberTypeName } from '@object-ui/test-support';
 import { BLOCK_CONFIG, blockHasConfig, type PlaceholderSpec } from '../block-config';
 import { BLOCK_TYPE_META, PALETTE_EXCLUSIONS } from '../block-types';
 import { t } from '../../i18n';
@@ -335,24 +336,17 @@ describe('page:header `icon` — the designer field retired with the spec key (#
   // ADR-0087 D2 retirement REPLACES the member with `z.never()` rather than
   // deleting it, so `icon` is STILL a key of the shape: every "is it declared?"
   // check reads green while the parser rejects every value by name. The
-  // criterion is therefore the unwrapped member's type — the same one
-  // objectui#3809 converges on repo-wide.
+  // criterion is `@object-ui/test-support`'s shared judge (objectui#3809,
+  // converged here by objectui#4947), which OR-s the structural channel this
+  // block used to spell out by hand with the `[REMOVED]` description channel.
   it('the spec tombstones `icon` rather than deleting it', () => {
-    const shape = (PageHeaderProps as unknown as { shape: Record<string, unknown> }).shape;
-    const memberType = (key: string): string | undefined => {
-      const member = shape[key] as { unwrap?: () => unknown } | undefined;
-      const inner = (typeof member?.unwrap === 'function' ? member.unwrap() : member) as
-        | { _def?: { type?: string }; def?: { type?: string } }
-        | undefined;
-      return inner?._def?.type ?? inner?.def?.type;
-    };
-    expect(Object.keys(shape)).toContain('icon');
-    expect(memberType('icon')).toBe('never');
+    expect(listedShapeKeys(PageHeaderProps)).toContain('icon');
+    expect(isShapeKeyTombstoned(PageHeaderProps, 'icon')).toBe(true);
     // Non-vacuity for the probe itself: a Zod-internals change that made every
     // member read `'never'` would make the line above meaningless, and a live
     // key is the only thing that can tell the difference.
-    expect(memberType('title')).not.toBe('never');
-    expect(memberType('title')).toBeTruthy();
+    expect(isShapeKeyTombstoned(PageHeaderProps, 'title')).toBe(false);
+    expect(shapeMemberTypeName(PageHeaderProps, 'title')).toBeTruthy();
   });
 
   // The i18n side, exactly as the retired option above: a key kept past its

--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -51,6 +51,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/fields": "workspace:*",
     "@object-ui/permissions": "workspace:*",
+    "@object-ui/test-support": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@types/react": "19.2.18",

--- a/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
@@ -47,29 +47,20 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { ComponentRegistry } from '@object-ui/core';
+import {
+  authorableShapeKeys,
+  isShapeKeyTombstoned,
+  listedShapeKeys,
+  resolvePropsShape,
+} from '@object-ui/test-support';
 import { RecordDetailsProps } from '@objectstack/spec/ui';
 import '../index';
 
 const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-type ShapeCarrier = { shape?: unknown; _def?: { shape?: unknown } };
-
-/** Resolve a Zod object's `.shape` through both spellings, lazy or plain. */
-function shapeKeys(schema: unknown): string[] {
-  const carrier = schema as ShapeCarrier | undefined;
-  const shape = carrier?.shape ?? carrier?._def?.shape;
-  const resolved = typeof shape === 'function' ? (shape as () => object)() : shape;
-  return resolved && typeof resolved === 'object' ? Object.keys(resolved) : [];
-}
-
 /** One entry of `.shape`, unwrapped past `.optional()`. */
 function shapeMember(schema: unknown, key: string): unknown {
-  const carrier = schema as ShapeCarrier | undefined;
-  const shape = carrier?.shape ?? carrier?._def?.shape;
-  const resolved = (typeof shape === 'function' ? (shape as () => object)() : shape) as
-    | Record<string, unknown>
-    | undefined;
-  const member = resolved?.[key] as { unwrap?: () => unknown } | undefined;
+  const member = resolvePropsShape(schema)?.[key] as { unwrap?: () => unknown } | undefined;
   return typeof member?.unwrap === 'function' ? member.unwrap() : member;
 }
 
@@ -84,11 +75,10 @@ function arrayElement(schema: unknown): unknown {
 }
 
 /** Top-level keys of the spec's `RecordDetailsProps`, INCLUDING tombstones. */
-const specTopLevelKeys = (): string[] => shapeKeys(RecordDetailsProps);
+const specTopLevelKeys = (): string[] => listedShapeKeys(RecordDetailsProps);
 
 /**
- * Is this top-level key an ADR-0087 tombstone — declared, but typed `never` so
- * every value is rejected with a named migration message?
+ * Is this top-level key an ADR-0087 tombstone — declared, but rejected by name?
  *
  * This distinction is load-bearing, and objectui#3818 is what proved it. A D2
  * retirement does NOT delete the key from the shape; it REPLACES the member
@@ -99,21 +89,21 @@ const specTopLevelKeys = (): string[] => shapeKeys(RecordDetailsProps);
  * the tombstone said yes, and the manifest kept offering an input the spec
  * rejects on parse. Filtering tombstones out is what makes the gate mean what
  * its name says.
+ *
+ * The criterion itself is NOT written out here (objectui#4947). It is
+ * `@object-ui/test-support`'s shared judge, which OR-s the structural channel
+ * this file used to carry alone with the `[REMOVED]` description channel, so
+ * neither can go quietly permissive on its own.
  */
-const isTombstoned = (key: string): boolean => {
-  const member = shapeMember(RecordDetailsProps, key) as
-    | { _def?: { type?: string }; def?: { type?: string } }
-    | undefined;
-  return (member?._def?.type ?? member?.def?.type) === 'never';
-};
+const isTombstoned = (key: string): boolean =>
+  isShapeKeyTombstoned(RecordDetailsProps, key);
 
 /** Top-level keys the spec actually ACCEPTS — tombstones removed. */
-const specAcceptedTopLevelKeys = (): string[] =>
-  specTopLevelKeys().filter((key) => !isTombstoned(key));
+const specAcceptedTopLevelKeys = (): string[] => authorableShapeKeys(RecordDetailsProps);
 
 /** Member keys of one `sections[]` entry, per the spec. */
 const specSectionKeys = (): string[] =>
-  shapeKeys(arrayElement(shapeMember(RecordDetailsProps, 'sections')));
+  listedShapeKeys(arrayElement(shapeMember(RecordDetailsProps, 'sections')));
 
 /**
  * Section keys `RecordDetailsRenderer` honours beyond the spec's four. Read off
@@ -299,7 +289,7 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     // (`synth/buildDefaultPageSchema.ts:557-562` types it `string[]`), so the
     // tolerant arm is unexercised drift rather than a live dialect.
     const element = arrayElement(shapeMember(RecordDetailsProps, 'hideFields'));
-    expect(shapeKeys(element)).toEqual([]);
+    expect(listedShapeKeys(element)).toEqual([]);
     expect(RecordDetailsProps.safeParse({ hideFields: ['phone'] }).success).toBe(true);
 
     const objectForm = RecordDetailsProps.safeParse({ hideFields: [{ name: 'phone' }] });
@@ -377,7 +367,7 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     // publish, and the renderer's tolerance for `{name}` / `{field}` entries is
     // not a second contract to advertise — the spec rejects those values.
     const element = arrayElement(shapeMember(RecordDetailsProps, 'fields'));
-    expect(shapeKeys(element)).toEqual([]);
+    expect(listedShapeKeys(element)).toEqual([]);
     expect(RecordDetailsProps.safeParse({ fields: ['phone'] }).success).toBe(true);
     expect(RecordDetailsProps.safeParse({ fields: [{ name: 'phone' }] }).success).toBe(false);
 

--- a/packages/test-support/README.md
+++ b/packages/test-support/README.md
@@ -54,13 +54,12 @@ code imports — nothing in `src/` of a released package may import this.
   `Object.keys(schema.shape)` cannot answer, because a retired key stays in the
   shape (objectui#3809). Consumed by
   `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` (both parity
-  directions) and `packages/layout/src/__tests__/page-header-authorable-keys.test.tsx`.
-  Two more local copies of the same judgement still exist, in
+  directions), `packages/layout/src/__tests__/page-header-authorable-keys.test.tsx`,
   `packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts`
   and `packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts`
-  — both correct today, both structural-channel-only, and both tracked for
-  conversion by objectui#4947. New gates import this module; they do not add a
-  fifth copy.
+  (the last two converged off local structural-only copies by objectui#4947).
+  No copy of the judgement is left in-tree: gates import this module, they do
+  not write the criterion out again.
 - `src/__tests__/spec-tombstones.test.ts` — the calibration for that judge: one
   synthetic fixture per recognition channel (so neither can quietly stop
   working), plus a cross-check of the structural verdict against what the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1909,6 +1909,9 @@ importers:
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@object-ui/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
Fixes #4947

Retires the last two local copies of the ADR-0087 D2 tombstone criterion onto
`@object-ui/test-support`'s shared judge. Both copies were correct today and both
carried the **structural channel alone** (`unwrap()._def.type === 'never'`); the shared
judge OR-s that with the `[REMOVED]` description channel `retiredKey()` stamps, so
neither channel can go quietly permissive on its own.

Pure convergence — no assertion changes meaning, no shipped code touched.

| site | was | now |
|---|---|---|
| `packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts` | local `shapeKeys` / `shapeMember` / `isTombstoned` | `listedShapeKeys`, `authorableShapeKeys`, `isShapeKeyTombstoned`, `resolvePropsShape` |
| `packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts` | test-body-inlined `memberType` | `listedShapeKeys`, `isShapeKeyTombstoned`, `shapeMemberTypeName` |

`packages/plugin-detail` gains the `"@object-ui/test-support": "workspace:*"`
**devDependency** the README's Conventions section prescribes (`app-shell` already had
it). The README paragraph tracking these two sites as outstanding copies is folded into
the consumer list — no copy of the judgement is left in-tree.

Net **−25 lines** across the two test files (`-14/+8` and `-30/+20`).

## Premise re-measured on the installed pin

The card measured on `17.0.0-rc.6` and the GA pin; the tree installs a later
`@objectstack/spec`. Re-probed there — the premise holds, with one number moved:

```
ComponentPropsMap entries: 42
TOMBSTONES total=16  bothChannels=16  structuralOnly=0  descriptiveOnly=0
RecordDetailsProps.layout : typedNever=true describedRemoved=true
PageHeaderProps.icon      : typedNever=true describedRemoved=true
```

The card's "eight tombstones, both channels" is now **sixteen**, still both channels —
so the OR is still not about coverage, and both target pins still have a real tombstone
to stand on.

## Is the shared judge equivalent to the copies it replaces?

That is the real risk in a convergence refactor, so it was measured rather than
asserted. A throwaway probe ran the **deleted criterion verbatim** beside the shared
judge:

```
(a) installed-pin sweep: 302 keys across 42 schemas — disagreements: 0 []
(b) DISCRIMINATOR description-channel-only 'retired': OLD=false NEW=true
(b) control live member          'live':    OLD=false NEW=false
(c) RecordDetailsProps.layout: OLD=true NEW=true
(c) PageHeaderProps.icon:      OLD=true NEW=true
```

- **(a)** exhaustively, on every key of every schema in the installed pin, the two
  verdicts are identical. The swap is behaviour-preserving on today's contract.
- **(b)** they are **not** the same function, and here is the case that separates them:
  a member carrying the `[REMOVED]` marker but *not* typed `never` — a tombstone
  hand-written without `retiredKey()`, or one left behind by a Zod internals rework.
  The old copies call it a **live authoring surface**; the shared judge calls it a
  tombstone. That is the widening the copies were exposed to, and the only reason the
  card is worth landing while both copies are still correct.

## Reverse-verification

On the commit, mutating the shared judge and re-running both converged files. Each
mutation was **confirmed on disk by grepping the changed text** (injected hits ≥ 1,
removed hits = 0) before any result was read; the script restores through an
`EXIT INT TERM` trap.

**Mutation A — `isTombstone()` recognises nothing** (the card's named plan). Predicted
red at the `layout` and `icon` pins:

```
[mutA] vitest exit=1
  × the spec tombstones `icon` rather than deleting it
  × the spec REJECTS `layout`, with the ADR-0087 migration message
  AssertionError: expected false to be true
Test Files 2 failed (2) | Tests 2 failed | 43 passed (45)
```

**Mutation B — `isTombstone()` recognises everything** (the opposite direction, added
because A alone cannot exercise the non-vacuity legs):

```
[mutB] vitest exit=1
  × the spec tombstones `icon` rather than deleting it
  × declares no top-level input the spec does not accept
  × publishes the two GA keys the renderer has read all along (#4668)
  AssertionError: expected [ 'columns', 'sections', …(4) ] to deeply equal []
  AssertionError: inlineEdit is a tombstone, not a live key: expected true to be false
Test Files 2 failed (2) | Tests 3 failed | 42 passed (45)
```

**Restored:** `git diff HEAD --stat` empty, `Test Files 2 passed (2) | Tests 45 passed (45)`.

### Legs that do NOT discriminate — named, because a green leg proves nothing

- `expect(offSpec).toEqual([])` (*declares no top-level input the spec does not accept*)
  stays **green** under Mutation A. Un-recognising `layout` only puts it back on the
  *accepted* side, so the set can only shrink. This is exactly the false-green direction
  the judge exists to close, and it only goes red in the B direction.
- `expect(isTombstoned(key)).toBe(false)` for `inlineEdit` / `showHeader` — green under
  A, red under B.
- `expect(listedShapeKeys(PageHeaderProps)).toContain('icon')` — green under both. It
  reads the raw listing, which no verdict change can move.
- `expect(shapeMemberTypeName(PageHeaderProps, 'title')).toBeTruthy()` — green under
  both; it probes the reader, not the verdict.

## Gates run — on the final commit `1bef8f62a`, tree clean

Quoting each gate's own verdict line, not a bare `$?`:

| run | verdict |
|---|---|
| `vitest run` × 5 judge consumers | `Test Files 5 passed (5)` · `Tests 146 passed (146)` |
| `type-check` (plugin-detail, app-shell, test-support) | `type-check: Done` × 3, after building the dependency closure |
| `check-changeset-presence.mjs` | `✅ 2 source file(s) of 2 released package(s) changed … Every one of them has an EMPTY frontmatter` |
| `check:control-bytes` | `✅ OK (scanned 4881 tracked text file(s))` |
| `check:phantom-deps` | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:self-import` | `✅ No package names itself inside its own src/.` |
| `check:spec-symbols` | `✅ spec symbol derivation: 1300 files scanned` |
| `check:esm-specifiers` | `no un-ledgered package emits an extensionless relative specifier` |
| `check:published-dist` | `✅ No published package's build output carries tooling material.` |
| `doc-version-claims` | `Tests 18 passed (18)` |

The five vitest consumers are the two converged files plus the three gates that already
imported the judge (`apps/console` registry parity, `packages/layout` page-header
authorable keys, and the judge's own calibration suite) — the convergence has to leave
those green too.

**ESLint was narrowed to the two changed lintable files, and here is why that is a
measurement rather than a skipped run:** ① the population came from ESLint's own
`isPathIgnored` against the repo config, not from a guess about what counts; ② the count
is read from `--format json` — `files linted = 2, errors = 0, warnings = 4`; ③ this
repo's `eslint.config.js` configures **no** `parserOptions.project` / `projectService`,
so linting is not type-aware and this diff cannot move the verdict of any file it does
not touch. The 4 warnings are pre-existing `@typescript-eslint/no-explicit-any` at
`block-config.test.ts` lines 45/82/84/212 — all outside both hunks (`@@ -6,6 +6,7 @@`
and `@@ -335,24 +336,17 @@`). The repo-wide sweep is CI's run.

## ⚠️ Serialisation note for the PM — #4918 overlaps this card on one *file*

The dispatch held #4918 behind this card on the premise that its two subjects are
*different* files that merely consume the judge. They are not: #4918's second subject
**is** `recordDetailsInputs.spec-parity.test.ts`, one of this card's own two named
targets. #4947 cannot be implemented without editing it.

Resolved by region rather than by refusing the card, and #4918 was **not** absorbed:

- #4918's prose sits at the *strip-mode* comment inside
  `it('publishes hideFields …')` — **line 268, untouched**, verified by grep after the
  edit.
- This PR's hunks are `@@ -47,29 +47,29 @@` (helpers) and the call sites, ~12+ lines
  clear of 268 — outside git's 3-line context window, so no textual conflict.
- #4918's other subject, `recordRelatedListInputs.spec-parity.test.ts`, is not touched
  at all.

#4918 remains open and fully doable; nothing in it is addressed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_