### PR TITLE
feat(app-shell): the Studio copilot sends surfaceContext — the URL is the single source (cloud#1610 send half)

### DIFF
--- a/.changeset/surface-context-send-1610.md
+++ b/.changeset/surface-context-send-1610.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/plugin-chatbot': patch
+'@object-ui/i18n': patch
+---
+
+The Studio copilot tells the agent WHAT the user is discussing (cloud#1610 send half): `ChatPane` accepts a `surfaceContext` and sends it as `context.surface` on every turn (the transport reads the body per send, so it stays fresh); the Studio copilot derives it from the URL alone — the `:tab` pillar segment plus the `?surface=type:name` deep-link the pillars already mirror, so the artifact carries its type discriminator (page/object/dashboard/report). A display chip above the composer (「正在讨论：…」, new `console.ai.discussing` key in all ten packs) makes the sent context visible instead of invisible grounding.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -1377,6 +1377,18 @@ function AiUnavailable({
 }
 
 interface ChatPaneProps {
+  /**
+   * cloud#1610 — what the user is currently discussing, derived by the HOST
+   * from its route/selection (Studio: pillar + the ?surface= deep-link the
+   * pillars already mirror — the URL is the single source of truth). Sent as
+   * `context.surface` on every turn (the transport reads the body per send),
+   * and surfaced to the user as a chip above the composer.
+   */
+  surfaceContext?: {
+    pillar?: string;
+    artifact?: { type: string; name: string };
+    mode?: string;
+  };
   agents: AgentDescriptor[];
   agentsLoading: boolean;
   agentsError: Error | undefined;
@@ -1426,6 +1438,7 @@ export function ChatPane({
   apiBase,
   conversationId,
   editPackageId,
+  surfaceContext,
   onPackageBound,
   canBind,
   parentHandoffConversationId,
@@ -1576,6 +1589,9 @@ export function ChatPane({
         // ADR-0070 "Edit with AI": scope the build agent to the app the user
         // opened to edit. Cloud seeds it as the conversation's active package.
         ...(editPackageId ? { packageId: editPackageId } : {}),
+        // cloud#1610 — what the user is currently discussing (advisory; the
+        // transport reads the body per send, so this stays fresh per turn).
+        ...(surfaceContext ? { surface: surfaceContext } : {}),
       },
     },
     initialMessages: hydrated,
@@ -2360,6 +2376,14 @@ export function ChatPane({
         changesAppliedLabel={t('console.ai.changesApplied', { defaultValue: 'Applied' })}
         changesDraftedLabel={t('console.ai.changesDrafted', { defaultValue: 'Saved as draft' })}
         changesFailedLabel={t('console.ai.changesFailed', { defaultValue: 'Not applied' })}
+        surfaceContextLabel={
+          surfaceContext?.artifact
+            ? t('console.ai.discussing', {
+                defaultValue: 'Discussing: {{target}}',
+                target: `${surfaceContext.artifact.type} · ${surfaceContext.artifact.name}`,
+              })
+            : undefined
+        }
         planAnswerMessage={(question, option) =>
           outboundText('planAnswerMessage', { question, option })
         }

--- a/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioAiCopilot.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '@object-ui/auth';
 import { useIsMobile } from '@object-ui/components';
 import { useAgents } from '@object-ui/plugin-chatbot';
@@ -40,6 +40,25 @@ export function StudioCopilotConversation({
   packageId,
   onCanvasOpenChange,
 }: StudioCopilotConversationProps): React.ReactElement | null {
+  // cloud#1610 — the URL is the single source of the surface context: the
+  // pillar is the :tab route segment, the artifact is the `?surface=type:name`
+  // deep-link every pillar already mirrors (useSurfaceDeepLink). Derived per
+  // render; the ChatPane transport reads it per send, so each turn carries
+  // what the user is looking at RIGHT NOW.
+  const { tab } = useParams<{ tab?: string }>();
+  const copilotLocation = useLocation();
+  const surfaceContext = React.useMemo(() => {
+    const raw = new URLSearchParams(copilotLocation.search).get('surface');
+    let artifact: { type: string; name: string } | undefined;
+    if (raw) {
+      const idx = raw.indexOf(':');
+      if (idx > 0 && idx < raw.length - 1) {
+        artifact = { type: raw.slice(0, idx), name: raw.slice(idx + 1) };
+      }
+    }
+    if (!tab && !artifact) return undefined;
+    return { ...(tab ? { pillar: tab } : {}), ...(artifact ? { artifact } : {}) };
+  }, [tab, copilotLocation.search]);
   const { user } = useAuth();
   const userId = user?.id;
   const apiBase = React.useMemo(() => resolveApiBase(), []);
@@ -88,6 +107,7 @@ export function StudioCopilotConversation({
       apiBase={apiBase}
       conversationId={conversationId}
       editPackageId={packageId}
+      surfaceContext={surfaceContext}
       initialMessages={initialMessages}
       pendingFirstMessageRef={pendingFirstMessageRef}
       onSent={() => {}}

--- a/packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx
+++ b/packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * cloud#1610 (send half) — the Studio copilot derives WHAT the user is
+ * discussing from the URL alone: the `:tab` route segment is the pillar, the
+ * `?surface=type:name` deep-link (which every pillar already mirrors) is the
+ * artifact WITH its type discriminator. Pinned by rendering the real
+ * StudioCopilotConversation and asserting the surfaceContext it hands the
+ * ChatPane — the URL is the single source of truth, so this contract is
+ * exactly "route in → context out".
+ */
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+let capturedProps: Record<string, unknown> = {};
+
+vi.mock('../../../console/ai/AiChatPage.js', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return {
+    ...mod,
+    ChatPane: (props: Record<string, unknown>) => {
+      capturedProps = props;
+      return <div data-testid="pane" />;
+    },
+  };
+});
+vi.mock('@object-ui/auth', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useAuth: () => ({ user: { id: 'u1' } }) };
+});
+vi.mock('@object-ui/plugin-chatbot', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useAgents: () => ({
+      agents: [{ name: 'metadata_assistant', label: 'Build', capabilities: ['build'] }],
+      isLoading: false,
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    }),
+  };
+});
+
+import { StudioCopilotConversation } from '../StudioAiCopilot';
+
+afterEach(() => {
+  cleanup();
+  capturedProps = {};
+});
+
+function renderAt(url: string) {
+  render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route
+          path="/studio/:packageId/:tab"
+          element={<StudioCopilotConversation packageId="app.k9" />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('Studio copilot surfaceContext (cloud#1610 send half)', () => {
+  it('pillar + typed artifact come straight from the URL', () => {
+    renderAt('/studio/app.k9/interfaces?surface=dashboard:sales_overview');
+    expect(capturedProps.surfaceContext).toEqual({
+      pillar: 'interfaces',
+      artifact: { type: 'dashboard', name: 'sales_overview' },
+    });
+  });
+
+  it('a pillar with no selected artifact still names the pillar', () => {
+    renderAt('/studio/app.k9/data');
+    expect(capturedProps.surfaceContext).toEqual({ pillar: 'data' });
+  });
+
+  it('an artifact name containing colons keeps everything after the FIRST one', () => {
+    renderAt('/studio/app.k9/interfaces?surface=object:k9_task.member_list');
+    expect(capturedProps.surfaceContext).toEqual({
+      pillar: 'interfaces',
+      artifact: { type: 'object', name: 'k9_task.member_list' },
+    });
+  });
+
+  it('a malformed surface param degrades to pillar-only, never a broken artifact', () => {
+    renderAt('/studio/app.k9/access?surface=nonsense');
+    expect(capturedProps.surfaceContext).toEqual({ pillar: 'access' });
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1566,6 +1566,7 @@ const ar = {
       changesApplied: "تم التطبيق",
       changesDrafted: "حُفظ كمسودة",
       changesFailed: "لم يُطبَّق",
+      discussing: "قيد المناقشة: {{target}}",
       changeVerb: {
         createObject: "إنشاء كائن",
         addField: "إضافة حقل",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1559,6 +1559,7 @@ const de = {
       changesApplied: "Angewendet",
       changesDrafted: "Als Entwurf gespeichert",
       changesFailed: "Nicht angewendet",
+      discussing: "Thema: {{target}}",
       changeVerb: {
         createObject: "Objekt erstellen",
         addField: "Feld hinzufügen",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1809,6 +1809,7 @@ const en = {
       changesApplied: 'Applied',
       changesDrafted: 'Saved as draft',
       changesFailed: 'Not applied',
+      discussing: 'Discussing: {{target}}',
       // Wording is load-bearing: this is SENT to the agent and must satisfy the
       // cloud confirm gate's English clause `apply (this|the) change`
       // (service-ai-studio confirm-gate.ts APPROVAL_RE). "apply what you just

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1563,6 +1563,7 @@ const es = {
       changesApplied: "Aplicado",
       changesDrafted: "Guardado como borrador",
       changesFailed: "No aplicado",
+      discussing: "Tratando: {{target}}",
       changeVerb: {
         createObject: "Crear objeto",
         addField: "Añadir campo",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1561,6 +1561,7 @@ const fr = {
       changesApplied: "Appliqué",
       changesDrafted: "Enregistré comme brouillon",
       changesFailed: "Non appliqué",
+      discussing: "Sujet : {{target}}",
       changeVerb: {
         createObject: "Créer un objet",
         addField: "Ajouter un champ",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1561,6 +1561,7 @@ const ja = {
       changesApplied: "適用済み",
       changesDrafted: "下書きとして保存",
       changesFailed: "未適用",
+      discussing: "話題: {{target}}",
       changeVerb: {
         createObject: "オブジェクトを作成",
         addField: "項目を追加",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1559,6 +1559,7 @@ const ko = {
       changesApplied: "적용됨",
       changesDrafted: "초안으로 저장됨",
       changesFailed: "적용되지 않음",
+      discussing: "논의 중: {{target}}",
       changeVerb: {
         createObject: "객체 생성",
         addField: "필드 추가",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1558,6 +1558,7 @@ const pt = {
       changesApplied: "Aplicado",
       changesDrafted: "Salvo como rascunho",
       changesFailed: "Não aplicado",
+      discussing: "Discutindo: {{target}}",
       changeVerb: {
         createObject: "Criar objeto",
         addField: "Adicionar campo",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1571,6 +1571,7 @@ const ru = {
       changesApplied: "Применено",
       changesDrafted: "Сохранено как черновик",
       changesFailed: "Не применено",
+      discussing: "Обсуждается: {{target}}",
       changeVerb: {
         createObject: "Создать объект",
         addField: "Добавить поле",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1679,6 +1679,7 @@ const zh = {
       changesApplied: '已生效',
       changesDrafted: '已暂存为草稿',
       changesFailed: '未生效',
+      discussing: '正在讨论：{{target}}',
       changesConfirmMessage: '确认修改，应用你刚才提议的改动。',
       changeVerb: {
         createObject: '新建对象',

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -741,6 +741,13 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
   /** Terminal badge when the replay's publish did not go live (default "Not applied"). */
   changesFailedLabel?: string;
   /**
+   * cloud#1610 — a small chip above the composer naming what the conversation
+   * is currently ABOUT (「正在讨论：仪表盘 sales_overview」), so the context the
+   * host sends to the agent is visible to the user instead of invisible
+   * grounding. Display-only; absent = no chip.
+   */
+  surfaceContextLabel?: string;
+  /**
    * Live draft-status resolver: how many drafts are still PENDING in a
    * package (e.g. `GET /metadata/_drafts?packageId=` count). When provided,
    * each draft card's Publish/Published affordance reflects the SERVER's
@@ -1293,6 +1300,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       changesAppliedLabel = 'Applied',
       changesDraftedLabel = 'Saved as draft',
       changesFailedLabel = 'Not applied',
+      surfaceContextLabel,
       fetchPendingDraftCount,
       autoPublishDrafts = false,
       processVisibility = 'summary',
@@ -2998,6 +3006,13 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             isPlainSurface && 'mx-auto w-full max-w-2xl px-4 pb-4 sm:px-0',
           )}
         >
+          {surfaceContextLabel ? (
+            <div className="mb-1 flex" data-testid="surface-context-chip">
+              <span className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+                {surfaceContextLabel}
+              </span>
+            </div>
+          ) : null}
           {promptOverlaySlot ? (
             <div className="absolute bottom-full left-0 right-0 z-10 px-3 pb-1">
               {promptOverlaySlot}


### PR DESCRIPTION
The console send half of cloud#1610 (契约: objectstack#11417; cloud parse+inject half follows its pin bump).

- `ChatPane.surfaceContext` → `context.surface` per turn (transport reads the body per send — always fresh).
- Studio copilot derives it **from the URL alone**: `:tab` = pillar, `?surface=type:name` (the deep-link every pillar already mirrors) = artifact **with its type discriminator** — the maintainer's 「界面菜单类型不同」 point, satisfied with zero new plumbing.
- Visible: 「正在讨论：dashboard · sales_overview」 chip above the composer (`console.ai.discussing`, all ten packs) — the sent context is never invisible grounding.

4 route→context pins; 132 files / 1552 tests; i18n call-site gate clean. Staging-only train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)