### PR TITLE
docs(blocks): correct block-schema.mdx to the declared vocabulary, drop the phantom `slot` node

### DIFF
--- a/.changeset/block-schema-docs-truth-4895.md
+++ b/.changeset/block-schema-docs-truth-4895.md
@@ -1,0 +1,46 @@
+---
+---
+
+Docs and a gate ledger only — this publishes nothing, declared explicitly with an empty
+frontmatter rather than left undeclared. No package `src/` is touched: the two files
+changed are `content/docs/blocks/block-schema.mdx` and
+`scripts/check-doc-component-types.mjs`.
+
+Corrects `content/docs/blocks/block-schema.mdx` to the vocabulary the repository actually
+declares, per the maintainer ruling recorded on objectui#4895 (Option B: docs-truth fix,
+the block family re-scoped as type-level).
+
+The page taught a `{ type: 'slot', name: 'content' }` node inside
+`BlockSchema.template`. `template` is typed `SchemaNode | SchemaNode[]`, so that snippet
+sat on the render path — and `slot` is registered nowhere. Measured against the
+`check-doc-component-types.mjs` derivation of the registered universe (659 keys), the only
+keys matching `/block|slot/` are `blockquote` and `ui:blockquote`. A reader who copied the
+snippet got the renderer's `OBJUI-001` "Unknown component type" panel. That node is
+deleted, and the page now teaches `slotContent`, the key `BlockSchema` and
+`BlockInstanceSchema` actually declare.
+
+**`slotContent` is documented as declared-but-not-yet-consumed, not as the working path**,
+because that is what it measures as. Outside `packages/types` — the interface, its Zod
+mirror, and that package's own parse test — nothing in the repository reads `slotContent`,
+`slots` or `template`. Rewriting one phantom into a second phantom is the failure this card
+exists to close, so the page states the status plainly instead of implying a runtime that
+does not exist. For the same reason the component-schema framing is dropped from
+`block-library` / `block-editor` / `block-instance`: none of them appears in `AnySchema`,
+the runtime node union in `packages/types/src/index.ts`.
+
+Two further measurements are written into the page because they are what a confused reader
+needs. The four `<SchemaExample>` demos it embeds are ordinary registered component trees
+(`card`, `flex`, `stack`, `text`, `icon`, `button`, `badge`) — none carries `type: 'block'`,
+`slots` or `slotContent`, so nothing on the page was ever exercising the block vocabulary.
+And the slot system that *is* wired end to end is a different family entirely: slotted
+record pages (`kind: "slotted"`, `page.slots`), consumed by `usePageAssignment`,
+`PageBlockCanvas` and `PageBlockInspector`. The page now links there rather than leaving the
+two `slots` spellings to be conflated.
+
+The `slot` entry in `DOC_TYPE_EXEMPTIONS` pointed at this card and is dropped, as the ruling
+requires. With the phantom node gone the entry would itself fail as `stale-exemption`, so it
+is deleted rather than re-pointed; the three terse family reasons are re-pointed at the
+ruling's framing in the same pass.
+
+Option A (build renderers for the family) is rejected on zero pull and Option C (retire the
+family) is deferred; neither is implemented here.

--- a/content/docs/blocks/block-schema.mdx
+++ b/content/docs/blocks/block-schema.mdx
@@ -1,25 +1,50 @@
 ---
 title: "Block Schema (BlockSchema)"
-description: "Reusable component blocks with variables, slots, and marketplace support"
+description: "Type-level declarations for reusable component blocks: variables, slots, templates and marketplace metadata. No renderer consumes this family."
 ---
 
 import { SchemaExample } from '@/app/components/ComponentDemo';
 
 # Block Schema
 
-The `BlockSchema` defines reusable component blocks that can be configured with variables, support content injection through slots, and shared via a marketplace.
+`BlockSchema` is a **definition**, not a rendered node. It declares the shape of a
+reusable component block: the variables it accepts, the slots it advertises, the
+template it would expand to, and the metadata a marketplace listing would carry.
+
+<Callout type="warn" title="Status: type-level only, nothing renders this family">
+Every schema on this page is a **declaration** in `@object-ui/types`, mirrored by a Zod
+validator in `@object-ui/types/zod`. Those declarations and their validators are the
+whole implementation:
+
+- **No component is registered** for `block`, `block-library`, `block-editor` or
+  `block-instance`, and none of them appears in `AnySchema`, the runtime node union in
+  `packages/types/src/index.ts`. They are discriminants of the interfaces below, **not
+  renderable node types**. Putting one into a `children` array gives you the renderer's
+  `OBJUI-001` "Unknown component type" panel.
+- **Nothing reads `slots`, `slotContent` or `template` at runtime.** There is no block
+  expander, no block library UI and no block editor in this repository. The keys are
+  declared and validated, and that is all.
+
+So use these types to **describe** a block (author tooling, a marketplace payload, a
+validation step) and do not expect one to render. Looking for slots that work today?
+That is an unrelated vocabulary: record pages support `kind: "slotted"` with a `slots`
+map, wired end to end. See [Slotted Pages](/docs/guide/slotted-pages).
+</Callout>
 
 ## Overview
 
-BlockSchema enables:
-- **Reusable components** - Create once, use everywhere
-- **Variable system** - Typed props for customization
-- **Slot system** - Content injection points
-- **Block templates** - Predefined component trees
-- **Marketplace support** - Share and discover blocks
-- **Version control** - Track block versions
+`BlockSchema` declares:
+- **Variables** - typed, defaultable parameters a block accepts
+- **Slots** - named content-injection points a block advertises
+- **Template** - the component tree a block would expand to
+- **Marketplace metadata** - author, version, license, preview and rating fields
+- **Version** - a `version` string carried on the block's metadata
 
 ## Interactive Examples
+
+These demos are ordinary **registered** components (`card`, `flex`, `stack`, `text`,
+`icon`, `button`, `badge`) hand-assembled to show what a block *would* look like once
+expanded. None of them goes through `BlockSchema`: there is nothing that expands one.
 
 ### Feature Card Block
 
@@ -132,6 +157,32 @@ interface BlockSlot {
   required?: boolean;              // Is required?
 }
 ```
+
+#### Filling a slot: `slotContent`
+
+A block **declares** its slots in `slots[]`; a caller **fills** them through
+`slotContent`, a map keyed by slot name whose values are `SchemaNode | SchemaNode[]`.
+The key is declared on both `BlockSchema` and `BlockInstanceSchema`
+(`packages/types/src/blocks.ts`):
+
+```plaintext
+// The block declares a slot named 'content'...
+slots: [
+  { name: 'content', label: 'Content Area' }
+],
+
+// ...and a caller fills it by name.
+slotContent: {
+  content: [
+    { type: 'text', value: 'Injected into the "content" slot' }
+  ]
+}
+```
+
+**There is no `slot` node type.** Slot content is never addressed by placing a
+`{ type: 'slot' }` placeholder inside `template`: nothing registers `slot`, so such a
+node renders as `OBJUI-001`. `slotContent` is the declared path, and like the rest of
+this family it is **declared but not yet consumed** - no renderer reads it today.
 
 ## Complete Example
 
@@ -251,10 +302,6 @@ const cardBlock: BlockSchema = {
             className: 'card-description'
           },
           {
-            type: 'slot',
-            name: 'content'
-          },
-          {
             type: 'button',
             label: '${buttonText}',
             variant: 'outline',
@@ -274,7 +321,9 @@ const cardBlock: BlockSchema = {
 
 ### Block Instance
 
-Use `BlockInstanceSchema` to instantiate a block:
+`BlockInstanceSchema` declares the shape of a **reference to a block**: which block, what
+variable values, what slot content. It is a definition, not a component - nothing
+resolves `blockId` or expands the block it names.
 
 ```plaintext
 import type { BlockInstanceSchema } from '@object-ui/types';
@@ -311,7 +360,10 @@ const instance: BlockInstanceSchema = {
 
 ## Block Library
 
-Use `BlockLibrarySchema` to browse available blocks:
+`BlockLibrarySchema` declares the shape of a **block-library payload**: the query that
+selected it and the listings it returned. It is a data shape, not a browser component -
+nothing renders a library, and `onInstall` / `onPreview` name handlers that no dispatcher
+looks up.
 
 ```plaintext
 import type { BlockLibrarySchema } from '@object-ui/types';
@@ -347,7 +399,9 @@ const library: BlockLibrarySchema = {
 
 ## Block Editor
 
-Use `BlockEditorSchema` to create/edit blocks:
+`BlockEditorSchema` declares the shape of a **block-editor configuration**: which block is
+open and which panels a host would show. It is a configuration shape, not an editor
+component - no block editor exists to consume it.
 
 ```plaintext
 import type { BlockEditorSchema } from '@object-ui/types';
@@ -472,6 +526,7 @@ if (result.success) {
 
 ## Related
 
-- [Component Registry](/docs/guide/component-registry) - Registering components
-- [Schema Rendering](/docs/guide/schema-rendering) - Rendering blocks
+- [Slotted Pages](/docs/guide/slotted-pages) - the slot system that **is** wired end to end
+- [Component Registry](/docs/guide/component-registry) - what registering a renderable type takes
+- [Schema Rendering](/docs/guide/schema-rendering) - how registered node types are rendered
 - [Plugins](/docs/guide/plugins) - Extending ObjectUI

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -271,18 +271,23 @@ const DOC_TYPE_EXEMPTIONS = {
       'BlockSchema discriminant — `packages/types/src/blocks.ts` declares `type: \'block\'`, and ' +
       '`packages/types/src/zod/blocks.zod.ts` validates it. A block definition is not a rendered node.',
     'block-instance':
-      'BlockInstanceSchema discriminant — packages/types/src/blocks.ts:357, zod/blocks.zod.ts:130.',
+      'BlockInstanceSchema discriminant — packages/types/src/blocks.ts:357, zod/blocks.zod.ts:130. A ' +
+      'reference to a block is a definition, not a rendered node: it is absent from `AnySchema` ' +
+      '(types/src/index.ts) and nothing resolves its `blockId`.',
     'block-library':
-      'BlockLibrarySchema discriminant — packages/types/src/blocks.ts:263, zod/blocks.zod.ts:100.',
+      'BlockLibrarySchema discriminant — packages/types/src/blocks.ts:263, zod/blocks.zod.ts:100. The ' +
+      'shape of a block-library PAYLOAD, not a browser component: absent from `AnySchema`, and no ' +
+      'renderer reads it.',
     'block-editor':
-      'BlockEditorSchema discriminant — packages/types/src/blocks.ts:315, zod/blocks.zod.ts:116.',
-    slot:
-      'Block slot placeholder inside `BlockSchema.template`, which IS a `SchemaNode` — so unlike its ' +
-      'siblings above this one sits on the render path and nothing registers `slot`. Filed as ' +
-      'objectui#4895: the correct spelling is not one thing (register a slot node, or route the ' +
-      'snippet through the declared `slotContent` key), and objectui#4823 does not pre-decide it. ' +
-      'DELETE this entry when #4895 lands — the gate reports a stale exemption, so it cannot be ' +
-      'forgotten.',
+      'BlockEditorSchema discriminant — packages/types/src/blocks.ts:315, zod/blocks.zod.ts:116. The ' +
+      'shape of an editor CONFIGURATION, not an editor component: absent from `AnySchema`, and no ' +
+      'block editor exists to consume it.',
+    // `slot` was here, exempted pending objectui#4895. That card ruled (maintainer,
+    // 2026-08-19, recorded on the issue): Option B, docs-truth fix — the family stays
+    // type-level, the phantom `type: 'slot'` node is DELETED from the page, and the
+    // page teaches the declared `slotContent` key instead. `slot` is now spelled
+    // nowhere in blocks/block-schema.mdx, so an exemption for it would itself fail as
+    // `stale-exemption`. Nothing to exempt; the entry is gone rather than re-pointed.
     string:
       'BlockVariable.type — a variable declaration\'s data type, next to `defaultValue` / `required`.',
   },


### PR DESCRIPTION
Part of #4895

Carries the maintainer ruling recorded on that card (comment 5339693569, 2026-08-19, 「全部接受」): **Option B — docs-truth fix, the block family re-scoped as type-level**. Option A (build renderers) was rejected on zero pull; Option C (retire the family) is deferred. Neither is implemented here, and neither is argued for.

Reference keyword is deliberately `Part of`, not a closing keyword: the ruling leaves Option C open, to be revisited if a later liveness pass shows the published types inert externally. The measurement below strengthens that future case rather than settling it, so the card should stay open for the PM seat to judge.

## What was wrong

`content/docs/blocks/block-schema.mdx:254` taught this inside `BlockSchema.template`:

```
{
  type: 'slot',
  name: 'content'
}
```

`template` is typed `SchemaNode | SchemaNode[]`, so that snippet sat on the render path — and nothing registers `slot`. A reader who copied it got the renderer's `OBJUI-001` "Unknown component type" panel. That node is deleted; the page now teaches `slotContent`, the key `BlockSchema` and `BlockInstanceSchema` actually declare.

## The measurement that changed how this is written

The ruling says "teach `slotContent`". Before writing that, I measured whether `slotContent` is consumed by anything — a renderer, a hook, an adapter. **It is not.**

Every occurrence in the repository, excluding `node_modules` and `dist`:

| site | what it is |
|---|---|
| `packages/types/src/blocks.ts:201` | `BlockSchema.slotContent` declaration |
| `packages/types/src/blocks.ts:377` | `BlockInstanceSchema.slotContent` declaration |
| `packages/types/src/zod/blocks.zod.ts:77` | Zod mirror |
| `packages/types/src/zod/blocks.zod.ts:134` | Zod mirror |
| `content/docs/blocks/block-schema.mdx:297` | this page |
| `scripts/check-doc-component-types.mjs:283` | the exemption reason this PR deletes |

Zero renderers, zero hooks, zero adapters. The same holds for `slots` and `template` on this family — outside `packages/types` (the interfaces, the Zod mirror, and that package's own parse test) nothing reads them.

**So the page does not present `slotContent` as the working path.** It documents it as the *declared* path and states plainly that it is not yet consumed. Rewriting one phantom into a second phantom is the failure this card exists to close, so the page carries a status callout up front rather than implying a runtime that does not exist.

Two supporting measurements are written into the page because they are what a confused reader needs:

- The four `SchemaExample` demos the page embeds are ordinary registered component trees (`card`, `flex`, `stack`, `text`, `icon`, `button`, `badge`). None carries `type: 'block'`, `slots` or `slotContent` — nothing on the page was ever exercising the block vocabulary.
- The slot system that **is** wired end to end is a different family: slotted record pages (`kind: "slotted"`, `page.slots`), consumed by `usePageAssignment`, `PageBlockCanvas` and `PageBlockInspector`, documented at `content/docs/guide/slotted-pages.md`. The page now links there so the two `slots` spellings are not conflated.

## Full vocabulary audit, not just `slot`

Every `type` literal the page teaches, checked against the gate's derived registered-key universe (659 keys). Line numbers are pre-change.

| value | lines | registered? | vocabulary | action |
|---|---|---|---|---|
| `block` | 44, 140 | no | `BlockSchema` discriminant | keep, exempted — a definition |
| `block-editor` | 356 | no | `BlockEditorSchema` discriminant | keep, exempted |
| `block-instance` | 283 | no | `BlockInstanceSchema` discriminant | keep, exempted |
| `block-library` | 320, 374 | no | `BlockLibrarySchema` discriminant | keep, exempted |
| `boolean` | 62, 192 | yes | `BlockVariable.type` data type | no change |
| `button` | 258 | yes | SDUI node | no change |
| `card` | 223 | yes | SDUI node | no change |
| `div` | 75, 227, 239 | yes | SDUI node | no change |
| `icon` | 231 | yes | SDUI node | no change |
| `list` | 300 | yes | SDUI node | no change |
| `slot` | 254 | **no** | **nothing — phantom, on the render path** | **deleted** |
| `string` | 56, 162, 170, 177, 185, 199 | no | `BlockVariable.type` data type | keep, exempted |
| `text` | 243, 249 | yes | SDUI node | no change |

`slot` is the only unregistered value that named a renderable node. The other five unregistered values are each a discriminant of a declared interface or a variable data type, and each keeps a live exemption. So there was no second `slot`-shaped defect to sweep up.

One incidental observation, **not** a defect on this page and not changed: `boolean` at :62 and :192 is a `BlockVariable.type` data type that happens to collide with a registered component key, so it passes the gate's flat rule without needing an exemption. The page is correct; the gate's judgment there is a coincidence rather than a check.

## Gate calibration — proving the silence is a measurement

Removing the exemption is only meaningful if `check-doc-component-types.mjs` actually reads this file. A gate that is silent because it never looked is not a passing gate, so this was calibrated rather than assumed. The mutation was confirmed **on disk by grep count**, never by the editing tool's exit code, and the script carried a `trap ... EXIT INT TERM` restore.

**Mutation leg** — rewrite the registered `type: 'card'` node at :223 to a value nothing registers:

```
"type: 'card',"                 1 -> 0   (deleted text)
'objui-4895-calibration-probe'  0 -> 1   (injected text)
```

Gate exit code, captured before any pipe: **1**

```
content/docs/blocks/block-schema.mdx:223  [unregistered-doc-type]  type 'objui-4895-calibration-probe' (plaintext)
    type: 'objui-4895-calibration-probe',
```

**Restore leg** — probe absent, anchor back, `git status` clean for the file. Gate exit code: **0**, `✅  Every documented component type is registered.`

The gate reads this page.

## The two halves are a matched pair

Both failure directions were exercised, so neither half is passing by accident:

- **Doc corrected but the exemption put back** → `stale-exemption`: `content/docs/blocks/block-schema.mdx -> slot  no code block in that file spells this type any more.`
- **Exemption dropped but the phantom node put back** → exit 1, `content/docs/blocks/block-schema.mdx:305  [unregistered-doc-type]  type 'slot' (plaintext)`

Only both halves together are green.

## Gate ledger

The `slot` entry in `DOC_TYPE_EXEMPTIONS` pointed at this card and is dropped, as the ruling requires. With the phantom node gone it would itself report as `stale-exemption`, so it is deleted rather than re-pointed; a comment records why, so the next reader does not re-add it. The three terse family reasons (`block-instance` / `block-library` / `block-editor`) are re-pointed at the ruling's framing — each now records that the schema is absent from `AnySchema` and has no renderer, which is the fact the gate's own standard asks an exemption reason to name.

Counters move coherently: `exempted` 139 → 138 (one entry gone), `registered` 743 → 744 (the new `type: 'text'` site), code blocks 1055 → 1056.

## Verification — union run at `ca35295a9` (final commit)

Exit codes captured before any pipe; verdicts quoted from each gate's own output.

| gate | exit | verdict line |
|---|---|---|
| `check-doc-component-types` | 0 | Every documented component type is registered. |
| `check-doc-links` | 0 | Links are valid across 13 scan roots. |
| `check-control-bytes` | 0 | check-control-bytes: OK (scanned 4929 tracked text file(s); skipped 85 binary). |
| `check-changeset-presence` | 0 | No source of a released package changed in this range, so no changeset is owed. |
| `check-changeset-fixed` | 0 | All workspace packages are in the changeset fixed group. |
| `check-changeset-no-major` | 0 | No changeset declares a major bump. |

`scripts/__tests__/check-doc-component-types.test.ts` — **34 passed (34)**, run at `ca35295a9` from the repo root. Its three live-table assertions were also evaluated directly against this diff: `stale-exemption` findings `[]`; `exempted` 138 (asserted > 50); declaration count 82 → 81 (asserted > 20).

`eslint scripts/check-doc-component-types.mjs --no-inline-config --format json` — 1 file linted, 0 errors, 0 warnings.

### Declared narrowing: `check-doc-snippet-types`

Not run to completion — it needs a full monorepo build. The narrowing is a measurement, taken with **that gate's own scanner**, not an assumption:

1. Its fence-language set is `TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript'])` (its own source, line 224).
2. `scanFences()` on this page returns `blocks=0, markers=0` in **both** states — at `HEAD~1` and on the working tree. Every fence on the page is `plaintext` (10 → 11), and the one I added is `plaintext` too.
3. The page is not named in `UNGATED_DOCS`, so no ledger entry of mine can go stale.

The gate collects zero blocks from this page either way, so this diff cannot change its verdict. CI runs it in full regardless.

## Changeset

`.changeset/block-schema-docs-truth-4895.md`, empty frontmatter — docs and a gate ledger only, no released package `src/` is touched, declared explicitly rather than left undeclared. `objectui` has no `skip-changeset` label; the empty-frontmatter changeset is this repo's declaration mechanism.

## Deliberately not done

- **No renderers built** for `block-library` / `block-editor` / `block-instance` (Option A, rejected on zero pull).
- **Nothing retired** from `packages/types` (Option C, deferred). No published type is touched.
- **Best Practices and Use Cases left as-is.** Both still read somewhat aspirationally, but the status callout now governs the whole page, and gutting them is beyond the ruling's scope. Flagging rather than silently widening the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_