### PR TITLE
fix(scripts): parse tsconfigs with TypeScript's reader instead of three regexes

### DIFF
--- a/scripts/__tests__/check-node-esm-load.test.ts
+++ b/scripts/__tests__/check-node-esm-load.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   ESM_MODULE_EDGE,
@@ -16,10 +17,12 @@ import {
   emittedSources,
   esmEntryOf,
   importEntry,
+  readTsconfig,
   relativeSpecifiers,
   resolvesToModule,
   scanSpecifiers,
 } from '../check-node-esm-load.mjs';
+import { SKIP_DIRS } from '../check-phantom-dependencies.mjs';
 
 /**
  * objectui#4538 — a published entry plain Node ESM cannot load.
@@ -196,6 +199,182 @@ describe('scope — which builds preserve specifiers', () => {
     fs.writeFileSync(path.join(dir, 'src/__tests__/b.ts'), "import '../index';\n");
 
     expect(emittedSources(path.join(dir, 'src'))).toEqual([path.join(dir, 'src/index.ts')]);
+  });
+});
+
+/**
+ * objectui#5367 — the tsconfig reader was the same class as the specifier mask.
+ *
+ * `readTsconfig` stripped comments with three ordered regexes and handed the
+ * result to `JSON.parse`. None of them knew what a JSON string was, so the
+ * slash-star inside a `paths` key opened a "block comment" that ran to the next
+ * star-slash — typically the test glob in `exclude` at the bottom of the same
+ * file — and deleted everything between. Measured before the fix: 61 of this
+ * repository's 91 tsconfigs threw, and every throw was swallowed by
+ * `effectiveNoEmit`'s catch, which grades an unreadable config as emitting.
+ *
+ * The gate's verdict happened to be safe. It was also never computed, which is
+ * the property this block exists to keep from coming back.
+ */
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const TSCONFIG_NAME = /^tsconfig(\..+)?\.json$/;
+
+/**
+ * The slice of a parsed tsconfig these assertions read.
+ *
+ * `readTsconfig` returns arbitrary JSON, so the narrowing is written down here
+ * once rather than asserted inline at every call — and it stays `unknown` at the
+ * leaves, so a wrong assumption about a value's shape is still a type error.
+ */
+type ParsedTsconfig = {
+  compilerOptions?: Record<string, unknown>;
+  extends?: unknown;
+  include?: unknown;
+  exclude?: unknown;
+};
+
+const parseTsconfig = (file: string) => readTsconfig(file) as ParsedTsconfig;
+
+/**
+ * Every tsconfig in the repository, walked rather than listed.
+ *
+ * A hand-maintained list would answer "the files someone remembered", which is
+ * exactly the reading that let two poisoned configs sit unnoticed. `SKIP_DIRS`
+ * is the sibling gates' own exclusion set, so `node_modules` and build output
+ * are out for the same reason they are out everywhere else.
+ */
+function everyTsconfig(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+      everyTsconfig(path.join(dir, entry.name), out);
+    } else if (TSCONFIG_NAME.test(entry.name)) {
+      out.push(path.join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+describe('readTsconfig reads tsconfigs rather than pattern-matching around them', () => {
+  it('round-trips EVERY tsconfig in the repository without throwing', () => {
+    const configs = everyTsconfig(REPO_ROOT);
+
+    // The size assertion is the same doctrine the gate applies to itself: a walk
+    // that found nothing would throw nothing and report success. 91 exist today;
+    // 60 is a floor that a real collapse trips and ordinary churn does not.
+    expect(configs.length).toBeGreaterThanOrEqual(60);
+
+    const threw: string[] = [];
+    for (const file of configs) {
+      try {
+        readTsconfig(file);
+      } catch (error) {
+        threw.push(`${path.relative(REPO_ROOT, file)}: ${(error as Error).message}`);
+      }
+    }
+    expect(threw).toEqual([]);
+  });
+
+  it('keeps a `paths` key whose value opens a comment, and the keys after it', () => {
+    // The exact two lines that poisoned `packages/auth/tsconfig.json`: the
+    // slash-star in the paths key, and the test glob in `exclude` that closed
+    // the comment it opened. The old strip returned a config with no `paths`,
+    // no `include`, and a truncated `exclude`.
+    const dir = tmpdir();
+    fs.writeFileSync(
+      path.join(dir, 'tsconfig.json'),
+      [
+        '{',
+        '  "compilerOptions": {',
+        '    "baseUrl": ".",',
+        '    "paths": { "@/*": ["src/*"] },',
+        '    "noEmit": false',
+        '  },',
+        '  "include": ["src"],',
+        '  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    const config = parseTsconfig(path.join(dir, 'tsconfig.json'));
+    expect(config.compilerOptions?.paths).toEqual({ '@/*': ['src/*'] });
+    expect(config.include).toEqual(['src']);
+    expect(config.exclude).toEqual(['node_modules', 'dist', '**/*.test.ts', '**/*.test.tsx']);
+    expect(config.compilerOptions?.noEmit).toBe(false);
+  });
+
+  it('keeps the config below a line comment whose prose contains a slash-star', () => {
+    // `packages/fields/tsconfig.json`'s shape: a `//` comment naming a package
+    // glob. The block-comment pass ran first and had no notion of being inside a
+    // line comment, so the glob opened a comment that ate the rest of the file —
+    // which is how a config that plainly inherits `noEmit: true` was graded as
+    // emitting for as long as this gate has existed.
+    const dir = tmpdir();
+    fs.writeFileSync(path.join(dir, 'base.json'), JSON.stringify({ compilerOptions: { noEmit: true } }));
+    fs.writeFileSync(
+      path.join(dir, 'tsconfig.json'),
+      [
+        '{',
+        '  "extends": "./base.json",',
+        '  "compilerOptions": {',
+        '    // maps siblings to their packages/*/src trees',
+        '    "outDir": "dist"',
+        '  },',
+        '  "exclude": ["**/*.test.ts"]',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    expect(parseTsconfig(path.join(dir, 'tsconfig.json')).compilerOptions?.outDir).toBe('dist');
+    expect(effectiveNoEmit(path.join(dir, 'tsconfig.json'))).toBe(true);
+  });
+
+  it('still THROWS on a config nobody can read, which is what the catch is for', () => {
+    // `effectiveNoEmit` is written against this contract: a genuinely unreadable
+    // config widens the scan rather than dropping a package out of it. The fix
+    // narrows what counts as unreadable; it does not remove the margin.
+    const dir = tmpdir();
+    fs.writeFileSync(path.join(dir, 'tsconfig.json'), '{ "compilerOptions": }\n');
+    expect(() => readTsconfig(path.join(dir, 'tsconfig.json'))).toThrow();
+    expect(effectiveNoEmit(path.join(dir, 'tsconfig.json'))).toBe(false);
+  });
+});
+
+describe('the scope this gate ratchets, now that the emit question is answered', () => {
+  // Fixing the parse moves the specifier leg's membership exactly once, and the
+  // two packages below are both halves of that move. Pinned here so the change
+  // is a decision on the record rather than a side effect nobody measured — the
+  // failure objectui#5367 was filed to end.
+
+  it('reads `@object-ui/fields` as NOT specifier-preserving, so it leaves the leg', () => {
+    // Its `tsc` step inherits the root's `noEmit: true` and only type-checks;
+    // `dist` is written by vite-plugin-dts, which resolves relative specifiers
+    // while bundling. Measured at the time this landed: 0 extensionless of 155
+    // relative specifiers in its built `dist`, and 0 extensionless in its
+    // sources — so nothing live left the leg with it. The sources keep a
+    // STRICTER guard than this heuristic: that config pins `nodenext`, under
+    // which a missing relative extension is TS2835 in the package's own build.
+    const dir = path.join(REPO_ROOT, 'packages/fields');
+    const build = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).scripts.build;
+
+    expect(effectiveNoEmit(path.join(dir, 'tsconfig.json'))).toBe(true);
+    expect(buildPreservesSpecifiers(build, dir)).toBe(false);
+    expect(parseTsconfig(path.join(dir, 'tsconfig.json')).compilerOptions?.noEmit).toBeUndefined();
+  });
+
+  it('keeps `@object-ui/auth` in the leg on its DECLARED noEmit, not on a catch', () => {
+    // Its config throws under the old reader too, so it was in the leg by
+    // accident. It declares `"noEmit": false` outright, so the verdict is
+    // unchanged — what changes is that it is now a reading.
+    const dir = path.join(REPO_ROOT, 'packages/auth');
+    const build = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).scripts.build;
+
+    expect(parseTsconfig(path.join(dir, 'tsconfig.json')).compilerOptions?.noEmit).toBe(false);
+    expect(effectiveNoEmit(path.join(dir, 'tsconfig.json'))).toBe(false);
+    expect(buildPreservesSpecifiers(build, dir)).toBe(true);
   });
 });
 

--- a/scripts/check-node-esm-load.mjs
+++ b/scripts/check-node-esm-load.mjs
@@ -87,14 +87,18 @@
  *     specifiers seen by the mask, 2133 by the parser, the missing one a real
  *     `import`. Leg 1 now reads the file as written and asks the shared
  *     TypeScript scanner what the module edges are (objectui#5382); see
- *     `relativeSpecifiers`. `readTsconfig` below is the same class, still open
- *     as objectui#5367.
+ *     `relativeSpecifiers`. `readTsconfig` below was the same class in the same
+ *     file — three regexes over a tsconfig's raw text, blind to JSON strings,
+ *     throwing on 61 of the repository's 91 configs — and took the same remedy
+ *     under objectui#5367: TypeScript's own tsconfig reader.
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
 
 import { SKIP_DIRS, TOOLING_FILE, discoverPackages, moduleSpecifiers } from './check-phantom-dependencies.mjs';
 
@@ -120,13 +124,52 @@ export const MIN_LOADED = 3;
 
 // ── which builds preserve specifiers ─────────────────────────────────────────
 
-/** Parse a tsconfig, tolerating the comments this repository writes in them. */
+/**
+ * Parse a tsconfig, tolerating the comments this repository writes in them.
+ *
+ * ## Why this asks TypeScript rather than blanking comments (objectui#5367)
+ *
+ * It used to be three ordered `replace` calls over the raw text — blank block
+ * comments, blank whole-line comments, drop trailing commas — feeding
+ * `JSON.parse`. None of them knew what a JSON string was, so a slash-star
+ * sequence written INSIDE a string opened a "block comment" that ran to the
+ * next star-slash anywhere in the file and deleted every line between them.
+ *
+ * That is not exotic: `"@/*"` in a `paths` map and `"**\/*.test.ts"` in an
+ * `exclude` list are the two commonest lines in this repository's tsconfigs,
+ * and they are a matched opener and closer. Measured on `main` at ed35c23bb
+ * over the 91 tsconfigs tracked by git: **61 of them threw**, not the two the
+ * card was filed for. Every one of those throws was absorbed by
+ * `effectiveNoEmit`'s catch, which grades an unreadable config as emitting — so
+ * the gate's scope was being decided by a fallback rather than by a reading,
+ * with no signal that it had happened.
+ *
+ * This is the same class as the specifier mask objectui#5382 retired further
+ * down, and it takes the same remedy: ask the parser instead of pattern-
+ * matching around it. `ts.parseConfigFileTextToJson` is TypeScript's own
+ * tsconfig reader — comments, trailing commas and BOMs stop being questions
+ * this gate has an opinion about, and the answer is by construction the one
+ * `tsc` itself would compute. Re-measured with it: **0 of 91 throw**.
+ *
+ * No new dependency edge: `typescript` is a root devDependency and this module
+ * already loads it on every run, transitively through the shared scanner it
+ * imports from `check-phantom-dependencies.mjs`.
+ *
+ * Still THROWS on a genuinely unparseable config, deliberately — that is the
+ * contract `effectiveNoEmit`'s conservative catch is written against, and the
+ * contract `scripts/__tests__/check-node-esm-load.test.ts` asserts over every
+ * tsconfig in the repository so this class cannot come back silently.
+ *
+ * @param {string} path absolute path to a tsconfig
+ * @returns {Record<string, unknown>} the parsed config (`{}` for an empty file,
+ *   which is what TypeScript reads it as: inherit everything)
+ */
 export function readTsconfig(path) {
-  const raw = readFileSync(path, 'utf8')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/^[ \t]*\/\/.*$/gm, '')
-    .replace(/,(\s*[}\]])/g, '$1');
-  return JSON.parse(raw);
+  const parsed = ts.parseConfigFileTextToJson(path, readFileSync(path, 'utf8'));
+  if (parsed.error) {
+    throw new Error(`${path}: ${ts.flattenDiagnosticMessageText(parsed.error.messageText, ' ')}`);
+  }
+  return parsed.config ?? {};
 }
 
 /**
@@ -146,6 +189,13 @@ export function effectiveNoEmit(configPath, seen = new Set()) {
   } catch {
     // An unreadable config is graded as emitting, so a parse failure widens the
     // scan rather than silently dropping a package out of it.
+    //
+    // This is the fallback for a config nobody can read, and until objectui#5367
+    // it was the NORMAL path: the regex strip `readTsconfig` used threw on 61 of
+    // this repository's 91 tsconfigs, so most of this gate's scope came from
+    // here instead of from a reading. With a real JSONC parse the branch is
+    // reached by nothing in the repository today, which is what it was always
+    // meant to be — a margin, not the mechanism.
     return false;
   }
   if (typeof config.compilerOptions?.noEmit === 'boolean') return config.compilerOptions.noEmit;
@@ -176,10 +226,38 @@ export function effectiveNoEmit(configPath, seen = new Set()) {
  * the artifact comes from the two steps after it. Grading it on the command
  * alone reported 124 findings against a package that emits none of them.
  *
- * A pipeline that runs an EMITTING `tsc` and a bundler (`@object-ui/fields`)
- * counts as preserving: the `tsc` half still writes files, and judging it is the
- * conservative direction — a false positive lands in the ledger with a reason, a
- * false negative ships.
+ * A pipeline that runs an EMITTING `tsc` and a bundler counts as preserving: the
+ * `tsc` half still writes files, and judging it is the conservative direction —
+ * a false positive lands in the ledger with a reason, a false negative ships.
+ * No published package matches that shape today; the rule is kept because the
+ * shape is legal, not because something wears it.
+ *
+ * ## `@object-ui/fields` used to be this paragraph's example, and it was wrong
+ *
+ * It was named here as the emitting-tsc-plus-bundler case, and it is the
+ * opposite: `packages/fields/tsconfig.json` inherits the root's `noEmit: true`
+ * and its own comment says so in as many words — `tsc` CHECKS, `dist` is written
+ * by vite-plugin-dts. The example survived only because `readTsconfig` could not
+ * parse that file at all (objectui#5367): the throw hit `effectiveNoEmit`'s
+ * catch, the catch answered "emitting", and the wrong answer got written down as
+ * a fact about the package.
+ *
+ * Fixing the parse therefore MOVES this gate's scope, once, in one place:
+ * `@object-ui/fields` leaves the specifier leg, 13 published specifier-
+ * preserving ESM packages become 12. It is the only membership change in the
+ * repository — `@object-ui/auth`'s config throws today too, but it declares
+ * `"noEmit": false` outright, so its verdict is unchanged and merely stops being
+ * an accident.
+ *
+ * Letting it drop is deliberate, and it costs no coverage. Measured at ed35c23bb:
+ * `fields`' sources carry 0 extensionless relative specifiers, so no live finding
+ * leaves with it; its built `dist` carries 0 extensionless out of 155 relative
+ * specifiers, because rolldown resolves them while bundling, so the property this
+ * leg ratchets is not observable in what `fields` publishes. And the sources keep
+ * a STRICTER guard than this heuristic: that tsconfig pins `"moduleResolution":
+ * "nodenext"`, under which a missing relative extension is TS2835 and a bare
+ * directory import is TS2834 — the compiler rejects in `fields`' own build step
+ * what this leg would only have reported.
  *
  * @param {string} buildScript the package's `scripts.build`, or ''
  * @param {string} pkgDir absolute path to the package, for resolving `-p`
@@ -400,9 +478,10 @@ export const ESM_MODULE_EDGE = new Set(['import', 'export', 'dynamic import()', 
  * comment", and the two `replace` calls whose ORDER decided the answer were the
  * defect. Asking the parser removes the whole class at once: comments, strings,
  * template literals and regex literals stop being questions this gate has an
- * opinion about. `readTsconfig()` above still strips comments with regexes and
- * is a SEPARATE live instance of the same class — objectui#5367, deliberately
- * not touched here.
+ * opinion about. `readTsconfig()` above was a SEPARATE live instance of the same
+ * class — regexes over a tsconfig's raw text, deliberately left for its own card
+ * — and it is closed the same way, by TypeScript's own tsconfig reader
+ * (objectui#5367).
  *
  * ## Why the sibling gate's scanner rather than a second parser
  *


### PR DESCRIPTION
Fixes #5367

`readTsconfig()` in the ESM-load gate blanked comments with three ordered `replace` calls and handed the result to `JSON.parse`. None of them knew what a JSON string was, so a slash-star written **inside** a string opened a "block comment" that ran to the next star-slash anywhere in the file and deleted every line between them.

This is the same class as the specifier mask #5382 retired in this same file, and #5382's own landed code named this as its remainder (`scripts/check-node-esm-load.mjs:91`, `:404`). Both of those comments are updated here.

## The defect is much larger than the card measured

The card was filed for two configs. Measured on `main` at `ed35c23bb`, over the 91 tsconfigs tracked by git:

| reader | configs that throw |
|:--|--:|
| the three-regex strip on `main` | **61 of 91** |
| `ts.parseConfigFileTextToJson` | **0 of 91** |

`"@/*"` in a `paths` map and `"**/*.test.ts"` in an `exclude` list are the two commonest lines in this repository's tsconfigs — and they are a matched comment opener and closer. Every one of those 61 throws was absorbed by `effectiveNoEmit`'s catch, which grades an unreadable config as *emitting*. So this gate's scope was decided by a fallback rather than by a reading, with no signal that it had happened.

## The fix

`ts.parseConfigFileTextToJson` is TypeScript's own tsconfig reader: comments, trailing commas and BOMs stop being questions this gate has an opinion about, and the answer is by construction the one `tsc` itself computes.

**No new dependency edge**, verified rather than inherited — the previous seat recorded that it had not checked this:

- `typescript` is a root devDependency (`^6.0.3`).
- This module already loads it on every run, transitively: it imports the shared scanner from `check-phantom-dependencies.mjs`, whose first import is `import ts from 'typescript'`.
- `check:phantom-deps` exits **0** and prints `Every in-scope import is declared by the package that publishes it.` Its own output shows why it has no opinion here: it scans `40 released package(s)`, and root `scripts/` is not one of them.

`readTsconfig` still **throws** on a genuinely unparseable config. That is deliberate — it is the contract `effectiveNoEmit`'s conservative catch is written against, and the contract the new test asserts across the repository.

## The embedded scope question, answered on the record

Parsed correctly, the gate's scope moves **exactly once**, and this is the named consequence:

> **`@object-ui/fields` leaves the specifier leg. 13 specifier-preserving published ESM packages become 12.**

Visible in the gate's own first line, measured both ways in one sitting:

```
before:  Specifier leg: 13 of 39 published ESM packages have a specifier-preserving build.
after:   Specifier leg: 12 of 39 published ESM packages have a specifier-preserving build.
```

**It is allowed to drop, and here is the measurement behind that.**

1. **The old verdict was never computed.** `packages/fields/tsconfig.json` inherits the root's `noEmit: true`, and its own comment says so in as many words: *"this config inherits the root's `noEmit: true`, so `tsc` here only CHECKS; `dist` is written by vite-plugin-dts."* The gate graded it "emitting" only because the parse threw.
2. **No live finding leaves with it.** `fields`' sources carry **0** extensionless relative specifiers today.
3. **The card's load-bearing claim re-confirmed, not inherited.** Built `packages/fields` and scanned its artifact with the gate's own `relativeSpecifiers`: **0 extensionless out of 155** relative specifiers in `dist`. Rolldown resolves them while bundling, so the property this leg ratchets is not observable in what `fields` publishes.
4. **The sources keep a *stricter* guard than the heuristic that left.** That tsconfig pins `"moduleResolution": "nodenext"`, under which a missing relative extension is TS2835. Verified by ablation rather than asserted — see below.

`@object-ui/auth` is the other half of the move and does **not** change: its config throws under the old reader too, but it declares `"noEmit": false` outright, so its verdict is unchanged and merely stops being an accident. Both halves are now pinned by tests, so a future change to this membership has to come with a decision.

Also corrected: `buildPreservesSpecifiers`' doc named `@object-ui/fields` as its emitting-`tsc`-plus-bundler example. That example was a consequence of the broken parse. The rule is kept (the shape is legal) with the example removed and the correction recorded — verified that **no published package matches that shape today**.

## The class-closing assertion

> `readTsconfig` round-trips **every** tsconfig in the repository without throwing.

Walked rather than listed (a hand-maintained list answers "the files someone remembered", which is how two poisoned configs sat unnoticed), using the sibling gates' own `SKIP_DIRS`. The walk finds exactly the same 91 files as `git ls-files '*tsconfig*.json'`, and it asserts its own size (floor of 60) so an empty scan cannot pass as a clean one.

Five more pins ship with it: the `paths`-key shape, the line-comment-prose shape, the still-throws contract, and the two scope verdicts above.

## Reverse verification

**Ablation A — restore the three-regex strip, keep the new tests.** Mutation confirmed on disk against the exact text targeted (`JSON.parse(raw)` count 1 injected; `parseConfigFileTextToJson` count 0 in code, only the doc mention left). Nothing is rebuilt in this path: node and vitest load `scripts/*.mjs` from source and this gate has no `dist` copy. Restore ran from an `EXIT INT TERM` trap and the tree was re-verified clean afterwards.

```
Test Files  1 failed (1)
     Tests  5 failed | 39 passed (44)
```

The five reds are the round-trip test and the four shape/scope pins. The sixth new test — *"still THROWS on a config nobody can read"* — stays **green** under the ablation, and that is the honest direction: the old reader also throws on genuinely broken JSON, so that pin guards the contract, not the defect. The gate itself printed `13 of 39` under the ablation and prints `12 of 39` with the fix.

**Ablation B — the claim that `fields` loses no coverage.** Replaced one `'./widgets/TextField.js'` with `'./widgets/TextField'` in `packages/fields/src/FieldEditWidget.tsx` (on-disk proof: removed-text count 0, injected-text count 1). `tsc` reads `src` directly, so again nothing is rebuilt.

```
before mutation:  tsc -p packages/fields/tsconfig.json  → exit 0
after  mutation:  tsc -p packages/fields/tsconfig.json  → exit 2
  packages/fields/src/FieldEditWidget.tsx(15,27): error TS2835: Relative import paths need
  explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or
  'nodenext'. Did you mean './widgets/TextField.js'?
  (1 diagnostic total)

same mutation, specifier leg with fields out of scope:  no finding
```

That is precisely the coverage the drop costs and precisely the coverage the compiler replaces — inside `fields`' own `build` script (`tsc && vite build && …`), not in a separate job. Restored by trap.

## Gates, each by name with its own verdict

Union re-run at `f04e306`, working tree clean (`git status --porcelain` → 0 lines). Exit codes captured by direct redirection, never after a pipe.

| gate | exit | its own verdict line |
|:--|:--|:--|
| `pnpm exec vitest run scripts/` | 0 | `Test Files  61 passed (61)` / `Tests  1637 passed (1637)` |
| `check:esm-specifiers` | 0 | `Specifier leg: no un-ledgered package emits an extensionless relative specifier.` |
| `check:phantom-deps` | 0 | `✅  Every in-scope import is declared by the package that publishes it.` |
| `check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 4928 tracked text file(s); skipped 85 binary).` |
| `check:type-check-coverage` | 0 | `✅  test type-check coverage: 41/41 packages compile their tests, 0 declared debt…` |
| `check:self-import` | 0 | `✅  No package names itself inside its own src/.` |
| `type-check:scripts` (`tsc -p tsconfig.scripts.json`) | 0 | no output |
| `check-changeset-presence.mjs` | 0 | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `check-changeset-no-major.mjs` | 0 | `✅  No changeset declares a `major` bump.` |

**No changeset**, following `check-changeset-presence.mjs`'s own verdict: the diff is two files under root `scripts/`, and `0 of them under the src/ of a package the release covers`.

### Declared narrowings

- **ESLint** was run on the two changed files rather than repo-wide, and that narrowing is a measurement, not a sample: the population comes from eslint's own config (both files resolved and were linted — `files linted: 2`, read from `--format json`, with no "file ignored" warning), and **type-aware linting is not enabled** (`eslint.config.js` contains no `projectService`, no `parserOptions`, no `project:`), so this diff cannot move the verdict on any untouched file. Result: 0 errors, 0 warnings. The repo-wide run is CI's.
- **The load leg was not run locally.** `check:node-esm-load` builds every published package; its own CI job (`.github/workflows/node-esm-load-gate.yml` → `Build every published package and import its entry under plain Node`) owns it. The narrowing is safe by construction: leg 2 iterates `esmPackages` (every published ESM package) and never consults `buildPreservesSpecifiers`, so nothing in this diff can move it. Leg 1 — the only leg this diff can move — was run standalone and is green.

## Scope

`scripts/check-node-esm-load.mjs` + `scripts/__tests__/check-node-esm-load.test.ts`, the declared file surface. No breach.

Checked while here, filed nothing because there was nothing to file: `scripts/check-type-check-coverage.mjs` has its own `readTsconfig`, but its `stripJsonComments` is a real character scanner that tracks strings and escapes — measured over all 91 configs, **0 unparseable**. No other script in the repository reads a tsconfig from disk. This was the last regex-based tsconfig reader.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ3NihCHE9LUtHoGxo6A9f)_