### PR TITLE
feat(types,mobile)!: retire the MobileOverrides type and its mount point (#4919)

### DIFF
--- a/.changeset/4919-retire-mobile-overrides.md
+++ b/.changeset/4919-retire-mobile-overrides.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/types': minor
+'@object-ui/mobile': minor
+---
+
+Retire the `MobileOverrides` type and its `mobileOverrides` mount point (objectui#4919,
+maintainer ruling 2026-08-19, ADR-0049 enforce-or-remove).
+
+`MobileOverrides` published a six-key mobile override surface — `layout`, `columns`,
+`useBottomSheet`, `fullScreen`, `touchTarget` and a three-value `navigation` vocabulary
+(`'bottom-tabs' | 'hamburger' | 'drawer'`) — from `@object-ui/types` and, re-exported,
+from `@object-ui/mobile`. Nothing read any of it. Measured on current `main`: the type had
+exactly four mentions repo-wide — its own declaration, the single
+`MobileComponentConfig.mobileOverrides` mount point, and the two barrel re-exports — and
+the lower-case property name (the spelling a renderer would actually read) appeared only
+in that declaration. No renderer, hook or adapter resolved it, and a sweep of the example
+apps and the `objectstack` sibling checkout found zero authors. The three `navigation`
+values were three spellings of the same no-op.
+
+The declared surface is removed rather than narrowed. The #3985 lineage's rule is "narrow
+to the implemented values"; here the implemented set is empty, so that rule terminates in
+deletion — a config that type-checks, builds and silently does nothing is the
+declare-without-enforce shape the platform doctrine forbids.
+
+Removal rather than a `?: never` tombstone follows this package's own discriminator. A
+tombstone exists to steer authors to a named live replacement — `crud.ts` `confirm` →
+`confirmText` (objectui#4314), `data-display.ts` `hoverable` / `striped` → `data-table`
+(objectui#5474) — or to keep a key loud that the docs had actively taught as working.
+Neither applies: there is no replacement key to steer to, no documentation ever described
+the surface, and there is no successor spelling. That is the same zero-pull, no-successor
+shape as the retired `AccordionItem.icon` (objectui#4652) and `ToggleGroupItem.icon`
+(objectui#4632), both of which were removed outright rather than tombstoned.
+
+**Breaking for TypeScript authors of `MobileOverrides` / `mobileOverrides` only** (marked
+`minor` per this repo's version-alignment rule, which reserves `major` for following
+`@objectstack` across a major — see AGENTS.md's 版本号策略, and the identical
+classification used for `AccordionItem.icon`). Runtime behaviour is unchanged: an authored
+`mobileOverrides` did nothing before and does nothing now. What changes is that the
+contract no longer claims otherwise, so the mistake surfaces at authoring time — importing
+the type is now a "has no exported member" error, and authoring the key on a
+`MobileComponentConfig` object literal is an excess-property error, instead of a silent
+no-op that type-checks and builds.
+
+If real mobile-override renderer work is ever wanted it re-enters deliberately, as designed
+product surface on its own card, with the renderer landing in the same change as the
+declaration — not by resurrecting this declaration.

--- a/packages/mobile/src/index.ts
+++ b/packages/mobile/src/index.ts
@@ -57,7 +57,6 @@ export type {
   BreakpointName,
   ResponsiveValue,
   MobileResponsiveConfig,
-  MobileOverrides,
   PWAConfig,
   PWAIcon,
   FetchCacheStrategy,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -582,7 +582,6 @@ export type {
   BreakpointName,
   ResponsiveValue,
   MobileResponsiveConfig,
-  MobileOverrides,
   PWAConfig,
   PWAIcon,
   FetchCacheStrategy,

--- a/packages/types/src/mobile.ts
+++ b/packages/types/src/mobile.ts
@@ -69,21 +69,25 @@ export interface MobileResponsiveConfig {
   showOnly?: BreakpointName[];
 }
 
-/** Mobile-specific component overrides */
-export interface MobileOverrides {
-  /** Simplified layout for mobile */
-  layout?: 'stack' | 'tabs' | 'accordion' | 'carousel';
-  /** Reduced columns for forms */
-  columns?: number;
-  /** Whether to use bottom sheet instead of modal */
-  useBottomSheet?: boolean;
-  /** Whether to use full-screen mode */
-  fullScreen?: boolean;
-  /** Touch-friendly sizing */
-  touchTarget?: 'default' | 'large' | 'xlarge';
-  /** Simplified navigation */
-  navigation?: 'bottom-tabs' | 'hamburger' | 'drawer';
-}
+// RETIRED (objectui#4919, maintainer ruling 2026-08-19, ADR-0049
+// enforce-or-remove): the mobile component-override surface and its mount
+// point on `MobileComponentConfig` are gone, not narrowed. Every member was
+// declaration-only — nothing in this repo, the example apps, or the
+// `objectstack` sibling checkout ever read the property, so all six keys
+// behaved identically (they did nothing), and the navigation vocabulary's
+// three values were three spellings of the same no-op. Removal rather than a
+// `?: never` tombstone follows this package's own discriminator: a tombstone
+// exists to steer authors to a named live replacement (`crud.ts` `confirm` →
+// `confirmText`; `data-display.ts` `hoverable`/`striped` → `data-table`),
+// and there is no replacement here — the same zero-pull/no-successor shape as
+// the retired `AccordionItem.icon` / `ToggleGroupItem.icon`, which were
+// likewise removed outright rather than tombstoned.
+//
+// Reopen condition, recorded on objectui#4919: real mobile-override renderer
+// work re-enters as designed product surface on its own card, with the
+// renderer landing in the same change as the declaration. Re-adding the
+// declaration alone is the declare-without-enforce shape this removal exists
+// to close.
 
 // ============================================================================
 // PWA Support
@@ -279,8 +283,6 @@ export interface GestureContext {
 export interface MobileComponentConfig {
   /** Responsive configuration */
   responsive?: MobileResponsiveConfig;
-  /** Mobile-specific overrides */
-  mobileOverrides?: MobileOverrides;
   /** Touch gesture handlers */
   gestures?: GestureConfig[];
   /** Pull-to-refresh configuration */


### PR DESCRIPTION
Fixes #4919

Carries the recorded maintainer ruling on that card (comment 5339691949, 「全部接受」): retire the whole `MobileOverrides` type — the declaration, its `mobileOverrides?` mount point, and both barrel re-exports. The three-value `navigation` vocabulary is not narrowed and not kept in any form. Implementing mobile overrides was rejected there and is not attempted here.

## Which tombstone branch, and the precedent that decided it

**Branch (a): one-stage removal.** This PR completes the card; there is no stage 2 outstanding.

The dispatch required this be measured, not assumed — specifically, not assumed from the metadata-spec `retiredKey()` / ADR-0087 registry path, which governs spec keys rather than TypeScript types. It does not apply here: `packages/types/src/mobile.ts` has no Zod twin (there is no `mobile.zod.ts` in `packages/types/src/zod/`), so the "loud parse rejection in the Zod twin" half of that discipline has nothing to attach to.

What this repo actually does when retiring a published TS surface is **two coexisting forms**, and the discriminator is not chronology — both are live and interleaved:

| Retirement | Pull | Named live replacement | Form |
|---|---|---|---|
| `ToggleGroupItem.icon` (objectui#4632, 2026-08-14) | zero | none | **removed outright** |
| `AccordionItem.icon` (objectui#4652, 2026-08-15) | zero | none | **removed outright** |
| `BaseFieldMetadata.indexed` | zero | object-level `indexes` | **removed outright** |
| theme `spacing` / `breakpoints` / `density` | never consumed | none | **removed outright** |
| action `confirm` (objectui#4314, 2026-08-18) | zero producers, but `ActionRunner` read it | `confirmText` | `?: never` tombstone |
| `hoverable` / `striped` (objectui#5474, 2026-08-23) | docs taught them as working | `data-table` / `className` | `?: never` tombstone |
| theme `fontSize` / `fontWeight` | dead engine emission | `customVars`, byte-for-byte | `?: never` tombstone |

The rule the table shows: **a `?: never` tombstone exists to steer authors to a named live replacement, or to keep loud a key the docs actively taught. Outright removal is for zero pull with no successor.**

This card is the second row's shape exactly. `AccordionItem.icon` states it in its own changeset: it "had zero measured pull anywhere in the corpus and no established convention to lean on, so under this platform's declared=enforced doctrine it is removed rather than speculatively implemented." `MobileOverrides` has zero pull, was never documented anywhere, and has no successor spelling — the ruling explicitly forbids keeping the vocabulary in any form. Verified in source: `icon` is fully absent from both `AccordionItem` and `ToggleGroupItem` today — no `?: never`, no `@deprecated` residue.

**There is no two-stage `@deprecated`-then-remove convention in this repo.** Every `@deprecated` in `packages/types/src` is one of two things, and neither is a stage 1 of retirement: a still-working legacy alias (`app.ts` `menu`, `base.ts` `visibleOn`, the `MenuItem` and `ActionSchema` interfaces — all still typed and still read), or a tag applied *in the same commit* as the `?: never` retyping, where the tombstone is the terminal state. Deprecating a no-op for a release cycle would ship a release in which `mobileOverrides` still type-checks and still does nothing — prolonging the exact declare-without-enforce shape the ruling exists to close.

## Re-verified zero-read measurement

The card is dated 2026-08-17, so its premise was re-measured against `origin/main` at `ed35c23bb` before anything was deleted. It holds.

`MobileOverrides` had exactly **four** mentions repo-wide, none of them a read:

```
packages/types/src/index.ts:585    barrel re-export
packages/types/src/mobile.ts:73    the declaration
packages/types/src/mobile.ts:283   mobileOverrides?: MobileOverrides   (the mount point)
packages/mobile/src/index.ts:60    barrel re-export
```

The lower-case property name — the spelling a renderer would actually read — appeared **only** in that declaration. A case-insensitive sweep across every file type (not just `.ts`/`.tsx`) found no JSON metadata, no docs, no schema-catalog entry, and no example app authoring it. The `objectstack` and `objectstack-ai` sibling checkouts: **zero hits**.

Of the three `navigation` values, `bottom-tabs` and `hamburger` occur nowhere else in source except the declaration line itself. The other `hamburger` hits belong to `MobileNavMode` in `packages/layout` — the objectui#3985 sibling, a different type on a different consumption path, untouched here.

## dist evidence — before and after, same grep

Proving the type is gone from `src/` proves nothing about what consumers see, so the emitted declarations were measured on both sides of the change. Identical pattern, identical scope (`packages/*/dist --include='*.d.ts'`), rebuilt each time:

**Before** (the control — the instrument demonstrably sees the case):

```
packages/mobile/dist/index.d.ts:36   export type { ... MobileOverrides ... }
packages/types/dist/index.d.ts:73    export type { ... MobileOverrides ... }
packages/types/dist/mobile.d.ts:63   export interface MobileOverrides {
packages/types/dist/mobile.d.ts:262      mobileOverrides?: MobileOverrides;
  -> MobileOverrides: 4 hits across 3 files
  -> mobileOverrides:  1 hit
  -> 'bottom-tabs':    1 hit  (mobile.d.ts:75)
```

**After** (`pnpm --filter @object-ui/types --filter @object-ui/mobile build`, exit 0):

```
  -> MobileOverrides: 0 hits
  -> mobileOverrides:  0 hits
  -> 'bottom-tabs':    0 hits
```

The source retirement note left in `mobile.ts` names the type in a comment; the zero `MobileOverrides` count in `dist` confirms it does not leak into the published `.d.ts`.

## The loud-signal requirement, measured rather than asserted

The ruling asks that external `.d.ts` consumers "get a loud signal rather than a silent no-op". That was tested with a real consumer compiled against the built `.d.ts`, on both sides of the change, with a control:

| Probe | Before | After |
|---|---|---|
| A — `import type { MobileOverrides } from '@object-ui/types'` | exit 0, silent | **TS2305**: Module '"@object-ui/types"' has no exported member 'MobileOverrides' |
| B — author `mobileOverrides: { navigation: 'bottom-tabs' }` on a `MobileComponentConfig` | **exit 0, silent** | **TS2353**: Object literal may only specify known properties, and 'mobileOverrides' does not exist in type 'MobileComponentConfig' |
| C — control: `responsive` (a still-live key on the same interface) | exit 0 | exit 0 |

Row B before the change is the card's defect reproduced exactly: it type-checked, it built, and nothing happened. The control matters — on its first run the whole probe failed on a config error rather than on the retirement, which would have made row A's "failure" indistinguishable from success; C staying green is what shows the instrument is measuring the right thing.

Excess-property checking is load-bearing for row B, so it was confirmed that `MobileComponentConfig` carries **no index signature and no `extends`** — nothing to swallow the diagnostic. (`BaseSchema`'s `[key: string]: any` does exactly that for top-level component-schema keys; this interface is not in that family.)

The before leg reverted the three files to `origin/main`, confirmed the mutation on disk by anchored counts on both the deleted and injected text, rebuilt so the mutation actually reached `dist/`, and ran under a restore trap. Restore was verified byte-exact: `git status` clean against the commit, and `dist` back to zero hits.

## Verification

Ran from the repo root with path filters, per AGENTS.md.

- `pnpm --filter @object-ui/types --filter @object-ui/mobile build` — exit 0
- `pnpm --filter @object-ui/types --filter @object-ui/mobile type-check` — exit 0 (both script names echoed, so this was not a zero-match silent pass)
- `pnpm exec vitest run packages/types/ packages/mobile/ --maxWorkers=2` — `Test Files 56 passed (56)`, `Tests 601 passed (601)`. 56 = 52 types + 4 mobile, so the filter matched these packages rather than someone else's
- `pnpm --filter @object-ui/types --filter @object-ui/mobile lint` — exit 0; `0 errors, 253 warnings` (types) and `0 errors, 18 warnings` (mobile), all pre-existing in `examples/` and `__tests__/`, none in the changed files
- `check-control-bytes` — OK, 4929 tracked text files scanned; plus a manual control-byte scan of the four changed files
- `check-changeset-presence` — 1 changeset for 3 source files of 2 released packages
- `check-changeset-no-major` — no changeset declares `major`
- `check-spec-symbol-derivation`, `check-published-dist-tooling`, `check-doc-component-types` — all exit 0

All gate results are quoted from each gate's own verdict line, with exit codes captured before any pipe.

One honest note on the lint run: an earlier pass used `--no-inline-config`, which is **not** this repo's lint command (`eslint .` is), and it reported one error in `packages/types/src/index.ts:1179` by disabling a documented, pre-existing `eslint-disable` block for a `FormField` spec import at line 1178 — unrelated to this change and present on `main`. Under the repo's actual command that file is clean.

Verification union ran against the final commit, `da50609e0`.

## Scope

Three source files and one changeset. `packages/app-shell` was never path-widened into.

The changeset is `minor`, not `major`, per this repo's version-alignment rule, which reserves `major` for following `@objectstack` across a major — the same classification `AccordionItem.icon` used for an identically breaking type removal. It records the change as breaking for TypeScript authors of `mobileOverrides` only, with runtime behaviour unchanged.

Out of scope, and deliberately left alone here: `MobileComponentConfig` itself now has zero mount points and zero readers — it is declared and re-exported twice and nothing consumes it. Same family as this card but a different type, and the #4919 ruling does not cover it, so it is filed for triage as #5942 rather than widened into this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPCi56cnGyykygi3z9w4m)_