### PR TITLE
test(console): resolve the binding-reach probe's reading-'map' error cards as a fixture defect, and guard render on both branches

### DIFF
--- a/.changeset/chilled-donkeys-shave.md
+++ b/.changeset/chilled-donkeys-shave.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change to the console's public-block binding-reach probe: its `sections` fixture sample is now spec-valid (an array of section objects, not a bare string), its `formType` sample is a real form variant, and the crash guard runs ahead of the branch split so it covers every candidate. No published behaviour changes — the renderers are untouched.

--- a/apps/console/src/__tests__/public-block-binding-reach.test.tsx
+++ b/apps/console/src/__tests__/public-block-binding-reach.test.tsx
@@ -38,6 +38,13 @@
  * an early `[]` for `columns` makes a list render its empty state without ever
  * asking for data.
  *
+ * That distinction — a plausible value for EVERY input is not the same as a
+ * plausible CONFIGURATION — is the lesson this file keeps re-learning, and it is
+ * recorded instance by instance rather than as a slogan: four in
+ * {@link SUPERSEDES_BINDING}, the fifth and sixth in {@link sampleFor}. Six is
+ * the count because every one of them cost a red or, worse, a green for the
+ * wrong reason. Read them before adding a sample.
+ *
  * A block that declares `objectName` and asks the data layer for something else
  * — or for nothing at all — is not bound to the object it advertises. That is
  * the objectstack#4413 shape, stated behaviourally.
@@ -247,6 +254,34 @@ const SUPERSEDES_BINDING = new Set(['data', 'customFields']);
  * a config a block can legitimately short-circuit on, and a block that renders
  * its empty state without asking for data would read here as an unbound
  * binding.
+ *
+ * `sections` is the FIFTH instance of the lesson counted in
+ * {@link SUPERSEDES_BINDING}, and the one objectui#3840 was filed for. The
+ * generic `array` sample is `['name']`, and a bare string is not a section:
+ * `@objectstack/spec`'s `FormViewSchema.sections` rejects it at parse —
+ * `safeParse(['name'])` returns *"Invalid input: expected object, received
+ * string"* — and requires `fields` on every entry (`[{}]` returns *"0.fields:
+ * Invalid input: expected array, received undefined"*). This repo's own type
+ * says the same: `ObjectFormSection.fields` is REQUIRED
+ * (`packages/types/src/objectql.ts`). So `['name']` is not metadata any author
+ * could publish, while `ObjectForm.tsx:1166` reads `section.fields.map(...)` off
+ * each entry unguarded and takes the whole block down with *"Cannot read
+ * properties of undefined (reading 'map')"*. That makes the error card a
+ * FIXTURE defect, not the product bug the shape suggested — the discriminator
+ * being the spec shape, not the fact that a different sample stops the crash
+ * (which is true either way).
+ *
+ * `formType` is the SIXTH, and it is why `object-master-detail-form` read GREEN
+ * while carrying the identical latent crash. That block declares `formType` as a
+ * bare `string` — not the enum `object-form` declares — so the default branch
+ * below handed it `'x'`, a value the form family has no path for. The crashing
+ * section loop is gated on `(!schema.formType || schema.formType === 'simple')`
+ * (`ObjectForm.tsx:1134`), so `'x'` skipped straight past it. Measured, with
+ * `sections` still malformed: forcing `formType: 'simple'` reproduces the same
+ * `reading 'map'` crash on that block. A sample outside a prop's own vocabulary
+ * does not exercise the block, it routes AROUND it — here around a real defect,
+ * for as long as nobody looked. Both samples below are spec-valid on their own
+ * merit, not as crash avoidance.
  */
 const sampleFor = (input: any): unknown => {
   if (input.name === 'objectName') return PROBE_OBJECT;
@@ -260,6 +295,13 @@ const sampleFor = (input: any): unknown => {
   // for the wrong reason, so the sample is spec-valid at the source instead.
   // Arrived with objectui#3808, which is when `add` became a declared input.
   if (input.name === 'add') return { picker: { object: PROBE_OBJECT } };
+  // The fifth and sixth lesson entries above. Both are keyed by NAME because the
+  // TYPE carries no information here: `sections` and `fields` are both `array`,
+  // and only one of them is an array of objects.
+  if (input.name === 'sections') {
+    return [{ name: 'probe_section', label: 'Probe Section', fields: ['name'] }];
+  }
+  if (input.name === 'formType') return 'simple';
   if (input.defaultValue !== undefined) return input.defaultValue;
   switch (input.type) {
     case 'number':
@@ -285,8 +327,8 @@ const sampleFor = (input: any): unknown => {
  *
  * The html half is here because a crash is invisible in `calls` alone —
  * `SchemaRenderer` catches a renderer's throw and paints an error card, so a
- * crashed block simply makes no calls, which is the pass condition on the
- * ledgered branch below. Deliberately the same shape and field names as the
+ * crashed block simply makes no calls, and "no calls" is a verdict BOTH branches
+ * below already have a reading for. Deliberately the same shape and field names as the
  * sibling probe's `Mount` (`record-block-record-reach.test.tsx:310-313`), which
  * has captured both halves from the start for the same reason.
  */
@@ -354,12 +396,9 @@ async function dataCallsFor(cfg: any): Promise<Mount> {
   // to unmount: an error thrown during RENDER still propagates and fails.
   // Read the DOM before unmounting: `SchemaRenderer` CATCHES a renderer's throw
   // and paints an error card, so a crash never propagates here — it just makes
-  // the block produce nothing, including no data calls. For a ledgered block
-  // ("declines to fetch") that is a green earned by crashing, which is why this
-  // is captured and asserted rather than left to the calls alone. Same guard the
-  // sibling probe carries as `assertRendered`
-  // (`record-block-record-reach.test.tsx`), added here after objectui#3808 made
-  // an invalid `add` sample able to trigger exactly that.
+  // the block produce nothing, including no data calls. Captured rather than
+  // left to the calls alone because "no calls" is exactly what each branch below
+  // reads as a verdict; {@link assertRendered} spends it.
   const html = view.container.innerHTML;
   try {
     view.unmount();
@@ -368,6 +407,33 @@ async function dataCallsFor(cfg: any): Promise<Mount> {
   }
   return { calls, html };
 }
+
+/**
+ * A crash is not a binding verdict — on EITHER branch.
+ *
+ * `SchemaRenderer` CATCHES a renderer's throw and paints an error card, so
+ * nothing propagates to the assertions below: the block simply produces no DOM
+ * of its own and, having died, no data calls. That lands differently on each
+ * branch and is wrong on both. On the ledgered branch "made no data call" is the
+ * PASS condition, so a crash CONFIRMS the ledger entry — a green earned by being
+ * broken. On the other branch it reads as a binding that never reached the data
+ * layer, pointing the reader at wiring that is fine.
+ *
+ * Same shape and message as the sibling probe's `assertRendered`
+ * (`record-block-record-reach.test.tsx`), which has run it on every mount from
+ * the start. Here it was scoped to the ledgered branch for one release, because
+ * `object-form` and `object-master-detail-form` painted an error card under this
+ * fixture's malformed `sections` sample and #3808 was not the change to drag two
+ * pre-existing crashes into. That was objectui#3840; it resolved to the fixture,
+ * is fixed in {@link sampleFor}, and the guard now runs ahead of the split where
+ * it belongs.
+ */
+const assertRendered = (type: string, html: string) => {
+  expect(
+    html.includes('failed to render'),
+    `<${type}> threw during render — that is a crash, not a binding verdict:\n${html.slice(0, 600)}`,
+  ).toBe(false);
+};
 
 const candidates = ComponentRegistry.getPublicConfigs().filter(declaresObjectName);
 
@@ -389,39 +455,12 @@ describe('public blocks — a declared objectName reaches the data layer (object
     it(`${cfg.type} ${ledgered ? 'does not reach the data layer (ledgered)' : 'asks the data layer for its objectName'}`, async () => {
       const { calls, html } = await dataCallsFor(cfg);
       const reached = calls.filter((c) => c.includes(PROBE_OBJECT));
+      // Ahead of the branch split, so it covers all 14 candidates: neither
+      // branch's verdict means anything about a block that never rendered. See
+      // {@link assertRendered} for why each branch mis-reads a crash differently
+      // (objectui#3840).
+      assertRendered(cfg.type, html);
       if (ledgered) {
-        // A crash is not a binding answer, and on THIS branch it is
-        // indistinguishable from one: "made no data call" is the pass condition,
-        // and a block that threw during render made none either. `SchemaRenderer`
-        // catches the throw and paints an error card, so nothing propagates —
-        // without this the ledger entry would be confirmed by the block being
-        // broken.
-        //
-        // Added with objectui#3808, and DEFENSIVE rather than load-bearing today:
-        // that change made an invalid `add` sample crash `record:related_list`
-        // (objectui#3838), which is what it did in the sibling probe, but not
-        // here — `renderers/record-related-list.tsx:185` passes
-        // `dataSource={ctx?.dataSource}`, this probe mounts with no RecordContext,
-        // so `RelatedList`'s picker gate (`add && pickerObject && dataSource`,
-        // truthiness-only on `add` before #3838) short-circuits before the read
-        // either way. Checked, not assumed: reverting the sample to `{}` keeps
-        // all 16 green. The predicate itself is known to work — applied to both
-        // branches it reports the two crashes in objectui#3840 — so this is a
-        // cheap standing guard on the one branch where a crash IS the pass
-        // condition, not a claim that it fires today.
-        //
-        // Deliberately NOT applied to the other branch: `object-form` and
-        // `object-master-detail-form` do paint an error card under this fixture
-        // ("Cannot read properties of undefined (reading 'map')") while still
-        // making their data calls, so their verdicts are earned rather than
-        // vacuous. Whether that card is a product bug or this fixture handing
-        // them an implausible configuration — the lesson the header records four
-        // instances of — is objectui#3840, not something to decide by widening a
-        // guard here.
-        expect(
-          html.includes('failed to render'),
-          `<${cfg.type}> threw during render, so "made no data call" proves nothing:\n${html.slice(0, 600)}`,
-        ).toBe(false);
         // Asserted, not skipped: the day this block starts binding, this fails
         // and the ledger entry has to go — a ledger nobody is forced to update
         // decays into the accepted-baseline problem this whole test exists for.


### PR DESCRIPTION
Fixes #3840

The `reading 'map'` error card that `object-form` and `object-master-detail-form` paint under the binding-reach probe is a **fixture defect (a)**, not a product defect (b). No renderer is touched.

## How the fork was resolved

Stopping at "the crash went away when I changed the sample" does not discriminate — that is true under both readings. So the discriminating step was the input's **spec shape**:

1. **Bisected the generated schema.** Printing what `sampleFor` builds and dropping inputs one at a time isolates `sections`. The stack names the read exactly — `ObjectForm.tsx:1166`, inside `SimpleObjectForm`:

   ```ts
   section.fields.map(f => [typeof f === 'string' ? f : ((f as any).field ?? f.name), f]),
   ```

   The generic `array` sample is the bare string `['name']`, so `section` is a string and `section.fields` is `undefined`.

2. **Read whether the spec permits that value — the step that decides it.** It does not:

   | source | verdict on `sections: ['name']` |
   |---|---|
   | `@objectstack/spec` `FormViewSchema.sections` | `REJECT` — *"Invalid input: expected object, received string"*; and `[{}]` → *"0.fields: expected array, received undefined"* |
   | `packages/types/src/objectql.ts` `ObjectFormSection` | `fields: (string \| FormField)[]` — **required**, on an object entry |
   | every renderer path (`:242` `:266` `:293` `:325` `:355` `:1166`) | reads `.fields` / `.name` / `.label` off each entry |

   So `['name']` is not metadata any author could publish — publish-time validation rejects it. The fixture was handing the form family a plausible *value* that is not a plausible *configuration*, which is the lesson this file already counted four times.

The block-props overlay (`ComponentPropsMap['object-form'].sections`) is `z.array(z.unknown())` and accepts `[42]`, `[null]`, anything — worth stating because it is the schema nearest to hand and it cannot answer this question. `FormViewSchema` is the one that carries the authoring contract.

## `object-master-detail-form` no longer crashed on today's `main` — but only by accident

The card's premise is half stale, and the stale half is the more interesting one. That block declares `formType` as a bare `string` (not the enum `object-form` declares), so the generic sample was `'x'` — and the crashing loop is gated on `ObjectForm.tsx:1134`:

```ts
if (effectiveSections?.length && (!schema.formType || schema.formType === 'simple')) {
```

`'x'` skips it. Measured: with `sections` left malformed, forcing `formType: 'simple'` reproduces the identical `reading 'map'` crash. The block was green for a reason unrelated to its correctness, so its `formType` sample is corrected too — a value outside a prop's vocabulary routes *around* the block instead of exercising it. Filed separately as #5939.

## What changed — one file, plus the changeset

- `sampleFor` gets two name-keyed samples: `sections` → `[{ name, label, fields: ['name'] }]`, and `formType` → `'simple'`. Keyed by name because the type carries no information here (`sections` and `fields` are both `array`; only one is an array of objects).
- The lesson list gets its **fifth and sixth** entries, with the spec quotes inline so the next reader can check the claim instead of trusting it, and the file header now points at the running list and its count.
- The crash guard is extracted as **`assertRendered`** and moved **ahead of the branch split**, covering all 14 candidates — the shape the sibling probe `record-block-record-reach.test.tsx` has had from the start. The in-code comment that deferred this to #3840 is gone, replaced by the reasoning for why a crash mis-reads on *both* branches (on the ledgered branch it *confirms* the ledger entry; on the other it points at wiring that is fine).

## Reverse-verification — the guard is load-bearing

Direction predicted before running: reverting **only** the `sections` sample should redden exactly two tests, via the new guard rather than the reach assertion. Observed exactly that:

```
× object-form asks the data layer for its objectName
× object-master-detail-form asks the data layer for its objectName
  AssertionError: object-form threw during render — that is a crash, not a binding verdict
  Component "object-form" failed to render / Cannot read properties of undefined (reading 'map')
 Tests  2 failed | 14 passed (16)
```

(The assertion message wraps the block name in angle brackets; they are stripped here because GitHub's body sanitizer eats short angle-bracket fragments.)

Both failures come from `assertRendered`, not from the reach assertion — which confirms the card's "no false green today" claim: those blocks were always earning their data-reach verdicts, and it is the crash that was invisible. The mutation was confirmed on disk before the run (`probe_section` occurrences 1 → 0, marker present, non-empty `git diff --stat`) and restored by an `EXIT`/`INT`/`TERM` trap.

## Gates — by name, at `58dda7a` (the pushed commit; tree clean)

| gate | verdict |
|---|---|
| `vitest run apps/console/src/__tests__/` | `Test Files 19 passed (19)` / `Tests 242 passed (242)` |
| `@object-ui/console type-check` | exit 0 (`tsc --noEmit && tsc -b tsconfig.node.json --force`; script name echoed, so not a zero-match pass) |
| `@object-ui/console lint` | exit 0 — 171 files, **0 errors**, 202 pre-existing warnings; probe file 0 errors / 5 warnings, all pre-existing (`0` occurrences of `any` in the added lines) |
| `check-changeset-presence.mjs` | exit 0 — *"declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption"* |
| `check-changeset-fixed.mjs` | exit 0 — *"All workspace packages are in the changeset fixed group."* |
| `check-changeset-no-major.mjs` | exit 0 — *"No changeset declares a `major` bump."* |
| `check-control-bytes.mjs` | exit 0 — *"scanned 4929 tracked text file(s); skipped 85 binary"* |

Every exit code was captured before any pipe. The console's dependency closure was built first (`pnpm --filter '@object-ui/console^...' build`) — without it `type-check` reports 40+ phantom `TS2882` module-resolution errors.

**Declared narrowing:** lint was run for `@object-ui/console` rather than repo-wide `turbo run lint`. The narrowing is measured, not assumed: the surveyed population comes from eslint's own config resolution (`eslint .` in that package), the count is read from `--format json` (171 files), and `eslint.config.js` enables no type-aware linting (no `projectService`, no `parserOptions.project`) — so a diff confined to one file in this package cannot move any untouched file's verdict. CI runs the full farm regardless.

## Scope

One test file and one changeset. No renderer, no `apps/console/src/sdui-workbench-preview.tsx`, no `packages/app-shell/src/views/**` — the fork resolved to (a), so the conditional renderer half of the file surface never opened, and nothing here reaches #5458's files.

Two out-of-scope findings were filed unassigned and both remain open, addressed by no change in this PR: **#5939** (the `formType` declaration divergence above) and **#5940** (`object-master-detail-form` calls `getObjectSchema(undefined)` for a detail collection it never resolved).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ3NihCHE9LUtHoGxo6A9f)_