### PR TITLE
test(e2e-type-check): bring the four root playwright configs into tsconfig.e2e.json

### DIFF
--- a/scripts/__tests__/e2e-type-check.test.ts
+++ b/scripts/__tests__/e2e-type-check.test.ts
@@ -31,6 +31,22 @@ import ts from 'typescript';
  * spelling would be satisfied by a config that compiles nothing, which is the
  * failure mode it exists to prevent.
  *
+ * objectui#4477 is the same statement one directory UP. The four root
+ * `playwright*.config.ts` files sit beside `tsconfig.e2e.json` rather than under
+ * `e2e/`, so #4471's glob did not reach them and nothing else compiled them
+ * either — yet they decide which specs run, where they run, and what
+ * `webServer` command builds the app under test. Widening the include cost zero
+ * errors (measured on both sides of the twelve days between filing and landing),
+ * so what this half pins is the GATE, not a fix: `testIgnore` or a `projects`
+ * entry misspelled into `undefined` is invisible to Playwright, which transpiles
+ * the config and reads the result as intent.
+ *
+ * Both halves are asserted the same way, and it is the way that matters: by
+ * discovering what is on disk and asking whether the program resolves it, never
+ * by naming the files. A four-name list would pass on the day it is written and
+ * be wrong the day a fifth config lands — which is precisely the defect both
+ * cards are about.
+ *
  * The one structural difference from `scripts-type-check.test.ts`: that gate is
  * a direct step in ci.yml's `type-check` job, this one is a turbo ROOT TASK
  * (`//#type-check:e2e`) that the `type-check` task `dependsOn` — the shape
@@ -80,6 +96,22 @@ function typeScriptSourcesOnDisk(): string[] {
   return out.sort();
 }
 
+/**
+ * Every root-level `playwright*.config.ts` on disk, repo-relative.
+ *
+ * A faithful translation of the config's second `include` pattern: `*` in a
+ * tsconfig glob does not cross a path separator, so the pattern matches files
+ * directly at the repo root and this walk must not descend either. Discovered,
+ * not listed — see the header.
+ */
+function rootPlaywrightConfigsOnDisk(): string[] {
+  return fs
+    .readdirSync(repoRoot, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^playwright.*\.config\.ts$/.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+}
+
 /** Repo-relative, POSIX-separated program root files. */
 function programFiles(): Set<string> {
   return new Set(
@@ -107,6 +139,34 @@ function diagnosticsFor(source: string): string[] {
       .getPreEmitDiagnostics(program)
       .filter((d) => d.file?.fileName === file.split(path.sep).join('/'))
       .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, ' ')}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Parse the REAL config against a throwaway tree that holds one root config
+ * which does not exist in this repo, and return the program root set.
+ *
+ * This is how the glob-not-a-list doctrine is asked as a question rather than
+ * asserted as a spelling. An `include` of four literal filenames satisfies every
+ * on-disk sweep in this file on the day it is written; only a config that
+ * resolves a name nobody has typed yet can answer for the fifth one. The tree is
+ * throwaway rather than the repo root because a transient `.ts` file appearing
+ * at the real root would be visible to every other guard that enumerates it.
+ */
+function programFilesWithSyntheticRootConfig(name: string): Set<string> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-type-check-fifth-'));
+  try {
+    const copied = path.join(dir, path.basename(configPath));
+    fs.copyFileSync(configPath, copied);
+    fs.writeFileSync(path.join(dir, name), 'export default {};\n');
+    fs.mkdirSync(path.join(dir, 'e2e'));
+    fs.writeFileSync(path.join(dir, 'e2e', 'placeholder.spec.ts'), 'export {};\n');
+
+    const read = ts.readConfigFile(copied, ts.sys.readFile);
+    const parsed = ts.parseJsonConfigFileContent(read.config, ts.sys, dir, undefined, copied);
+    return new Set(parsed.fileNames.map((f) => path.relative(dir, f).split(path.sep).join('/')));
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -254,6 +314,62 @@ describe('tsconfig.e2e.json — coverage of e2e/ (objectui#4471)', () => {
         'turbo does not build anything for it. Give the task `dependsOn: ["^build"]` (and check ' +
         'that a ROOT task can express what you need), or drop the import.',
     ).toEqual([]);
+  });
+});
+
+describe('tsconfig.e2e.json — coverage of the root playwright configs (objectui#4477)', () => {
+  it('resolves every root playwright*.config.ts on disk, with none left out', () => {
+    const onDisk = rootPlaywrightConfigsOnDisk();
+
+    // Non-vacuity first, for the same reason as the sweep above: the set
+    // difference below is satisfied by a discovery that finds nothing. Four
+    // configs exist today. If one is genuinely retired, lower this floor — but
+    // never satisfy it by narrowing the pattern in `rootPlaywrightConfigsOnDisk`,
+    // which would be this gate reporting green about files it stopped looking at.
+    expect(
+      onDisk.length,
+      'no playwright*.config.ts found at the repo root — the discovery is broken',
+    ).toBeGreaterThanOrEqual(4);
+
+    const inProject = programFiles();
+    const uncovered = onDisk.filter((f) => !inProject.has(f));
+
+    expect(
+      uncovered,
+      'These root Playwright configs are not in tsconfig.e2e.json’s program, so nothing ' +
+        'type-checks them:\n' +
+        uncovered.map((f) => `  - ${f}`).join('\n') +
+        '\n\nWiden the "include" globs in tsconfig.e2e.json. These files decide which specs ' +
+        'run, where they run, and what `webServer` command builds the app under test — and ' +
+        'Playwright transpiles a config rather than checking it, so a `defineConfig` option ' +
+        'misspelled into `undefined` is read as intent and surfaces only as a confusing ' +
+        'runtime failure in the e2e job (objectui#4477).',
+    ).toEqual([]);
+  });
+
+  it('would resolve a FIFTH root config that nobody has written yet', () => {
+    // The assertion above is a set difference over what exists. It would stay
+    // green under an `include` that names today's four files outright, and then
+    // the next config to land would sit outside every program again — the exact
+    // shape of objectui#4471 and objectui#4477. So ask the real config about a
+    // name it cannot have been written against.
+    const resolved = programFilesWithSyntheticRootConfig('playwright.not-yet-written.config.ts');
+
+    expect(
+      [...resolved].sort(),
+      'tsconfig.e2e.json no longer picks up a NEW root playwright config. Its second ' +
+        '"include" entry must stay a glob (`playwright*.config.ts`); an enumeration of the ' +
+        'configs that exist today passes every other assertion in this file and still lets ' +
+        'the next one land in no tsc program at all.',
+    ).toContain('playwright.not-yet-written.config.ts');
+
+    // …and that the throwaway tree really was parsed like the real project,
+    // rather than the assertion above passing on an empty or defaulted program.
+    expect(
+      [...resolved].sort(),
+      'the throwaway tree did not resolve like the real project — the probe is broken, ' +
+        'not the config',
+    ).toContain('e2e/placeholder.spec.ts');
   });
 });
 

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,5 +1,8 @@
 // Type-checks the `.ts` files under `e2e/` — the Playwright specs, their shared
-// helpers, and `e2e/live/global-setup.ts`, which runs before every live-suite run.
+// helpers, and `e2e/live/global-setup.ts`, which runs before every live-suite run
+// — plus, since objectui#4477, the four root `playwright*.config.ts` files that
+// decide which of those specs run, where they run, and what `webServer` command
+// builds the app under test.
 //
 // objectui#4471: nothing compiled them. `e2e/` is not a workspace package, so
 // `turbo run type-check` — which is driven by package.json `scripts` — cannot
@@ -20,7 +23,7 @@
 // true, for its whole life. Playwright would never have told anyone.
 //
 // This project is standalone and cheap: it imports no workspace package — every
-// e2e import is `@playwright/test`, `./helpers`, or a `node:` builtin — so unlike
+// import in it is `@playwright/test`, `./helpers`, or a `node:` builtin — so unlike
 // `tsconfig.vitest-setup.json` it needs no built declarations and can run before,
 // or independently of, any build. `scripts/__tests__/e2e-type-check.test.ts` pins
 // that premise, so if a spec ever imports `@object-ui/*` the wiring has to be
@@ -38,11 +41,17 @@
 // for `//#lint:root`, and it is why this file needs no ci.yml entry of its own
 // the way `type-check:scripts` and `type-check:vitest-setup` do.
 //
-// NOT covered here, deliberately: the four root `playwright*.config.ts` files,
-// which sit beside this file rather than under `e2e/` and are in no tsc program
-// either. They compile clean against this exact option set today (measured,
-// exit 0), so it is a dormant gap rather than a live defect — filed as
-// objectui#4477 instead of widened into objectui#4471's surface.
+// The four root `playwright*.config.ts` files were the deliberate remainder of
+// objectui#4471 — they sit beside this file rather than under `e2e/`, so the
+// `e2e/**` glob did not reach them and no other tsc program did either.
+// objectui#4477 closed that: the second `include` pattern below brings them in.
+// It cost zero errors, which was the point rather than a disappointment — they
+// compiled clean against this exact option set when #4477 was filed and again
+// when it landed (measured both times, `tsc -p tsconfig.e2e.json`, exit 0). What
+// was missing was never a fix, it was the gate: `webServer.command`, `testIgnore`
+// and `projects` are read by no compiler, so a `defineConfig` option that stops
+// existing — or is misspelled into `undefined` — surfaces only as a confusing
+// Playwright runtime failure in the `e2e` CI job.
 {
   "compilerOptions": {
     // Node 22 (`engines.node: ">=22"`) runs the Playwright worker that executes
@@ -116,7 +125,15 @@
   // The whole directory, by glob. Not a file list: a list is a thing to forget,
   // and the point of objectui#4471 is that a NEW spec under `e2e/` must not be
   // able to land outside every program again.
-  // `scripts/__tests__/e2e-type-check.test.ts` pins that this glob really does
-  // reach every `.ts` file on disk under `e2e/`.
-  "include": ["e2e/**/*.ts"]
+  //
+  // The second pattern is the same doctrine for the root configs (objectui#4477)
+  // rather than the four names that exist today, so a FIFTH root config cannot
+  // land outside every program either. It carries no `**`, so `*` stops at the
+  // path separator and it matches root-level files only — which is where all
+  // four live.
+  //
+  // `scripts/__tests__/e2e-type-check.test.ts` pins that both patterns really do
+  // reach every matching file on disk, and that the second one would pick up a
+  // root config that does not exist yet.
+  "include": ["e2e/**/*.ts", "playwright*.config.ts"]
 }


### PR DESCRIPTION
Fixes #4477

The four root `playwright*.config.ts` files sit beside `tsconfig.e2e.json` rather than under `e2e/`, so its `e2e/**/*.ts` glob did not reach them — and neither did the root `tsconfig.json` (`packages`/`examples`/`apps`), `tsconfig.scripts.json`, or `tsconfig.vitest-setup.json`. `turbo run type-check` walks package.json `scripts`, and the repo root is not a workspace package. So the files that decide which specs run, where they run, and what `webServer` command builds the app under test were read by no compiler.

## What changed

- `tsconfig.e2e.json` — `"include": ["e2e/**/*.ts", "playwright*.config.ts"]`. The program root set goes from 30 files to 34.
- `tsconfig.e2e.json` header — the paragraph declaring the four configs *"NOT covered here, deliberately … filed as objectui#4477 instead"* became false the moment this lands, so it is replaced by what is now true, with the re-measurement recorded.
- `scripts/__tests__/e2e-type-check.test.ts` — the on-disk coverage sweep gains its root-config half (+2 tests, 12 → 14).

The four configs themselves are **untouched**: nothing surfaced in them to fix.

## Re-measurement: still zero errors, twelve days later

The card measured `exit=0` against this exact option set on 2026-08-12. Re-measured on the widened config at `014b3e0`:

```
$ pnpm type-check:e2e          # tsc -p tsconfig.e2e.json
exit=0, no diagnostics
$ npx tsc -p tsconfig.e2e.json --listFiles | grep -v /node_modules/ | wc -l
34                             # 30 under e2e/ + the four root configs
```

That 34 is also the parse-failure canary: a tsconfig that fails to parse does not fail loudly, it falls back to compiling the entire repository. Comments in this file stay `//` for the same reason.

Zero errors is the point rather than a disappointment. What was missing was never a fix, it was the gate: Playwright transpiles a config rather than checking it, so a `defineConfig` option that stops existing — or is misspelled into `undefined` — is read as intent and surfaces only as a confusing runtime failure in the `e2e` job.

## The sweep asserts by glob, never by a list of four names

Two tests, and the second is the load-bearing one:

1. **`resolves every root playwright*.config.ts on disk, with none left out`** — discovers the root configs with `readdirSync` + `/^playwright.*\.config\.ts$/` (a faithful translation of the tsconfig glob: `*` does not cross a path separator, so the walk must not descend either), then set-differences them against the program TypeScript itself resolves. Non-vacuity floor first, for the same reason the `e2e/` sweep carries one.
2. **`would resolve a FIFTH root config that nobody has written yet`** — copies the real `tsconfig.e2e.json` into a throwaway tree containing `playwright.not-yet-written.config.ts` and asks whether the program resolves it. A throwaway tree rather than the repo root, because a transient `.ts` at the real root is visible to every other guard that enumerates it.

Test 1 alone would be satisfied by an `include` that names today's four files, and then the next config to land would sit outside every program again — the exact defect. Reverse-verified, both directions, at `014b3e0`:

| mutation | result |
| --- | --- |
| include narrowed back to `["e2e/**/*.ts"]` | **2 failed / 12 passed** — both new tests red |
| include replaced by the four literal filenames | **1 failed / 13 passed** — only the fifth-config probe red |
| (unmutated) | 14 passed |

Each mutation was confirmed on disk by grep before the run, and reverted through a `trap … EXIT INT TERM`.

## Gate results, each by name, at `014b3e0`

| gate | conclusion |
| --- | --- |
| `pnpm type-check:e2e` | `exit=0`, no diagnostics; program root set 34 files |
| `npx vitest run scripts/__tests__/e2e-type-check.test.ts` (repo root) | `Test Files 1 passed (1)` · `Tests 14 passed (14)` |
| `npx vitest run scripts/__tests__` (repo root, full meta-gate suite) | `Test Files 62 passed (62)` · `Tests 1664 passed (1664)` |
| `pnpm type-check:scripts` | `exit=0` — this test file is in that program |
| `pnpm lint:root` | `exit=0` — `26 problems (0 errors, 26 warnings)`, all pre-existing, none in the changed files |
| `node scripts/check-type-check-coverage.mjs` | `exit=0` — `45/46 via type-check` · `41/41 packages compile their tests` |
| `node scripts/check-changeset-presence.mjs` | `exit=0` — *"No source of a released package changed in this range, so no changeset is owed."* No changeset added, per that verdict |
| control-byte scan (`grep -naP` over both changed files) | no matches |

Full `pnpm type-check` was not run locally: it is `turbo run type-check` with `dependsOn: ["^build"]`, i.e. a whole-repo build. CI runs it. What was verified instead is that it really reaches this config — below.

## The gate actually runs in CI, verified rather than assumed

`turbo run type-check --dry=json` at this commit resolves an 83-task graph containing `//#type-check:e2e`, command `tsc -p tsconfig.e2e.json`, `cache.local=false`/`cache.remote=false`, with every package's `type-check` as a dependent. `ci.yml`'s existing `Run type-check` step runs `pnpm type-check`. So the widened include is covered with **no workflow change**, which is the shape objectui#4456 introduced for `//#lint:root`.

## Premises checked, not inherited

- The project stays **standalone**: all four configs import only `@playwright/test`, and the existing `imports no workspace package, so it needs no build` assertion now covers them automatically (it iterates the program's `fileNames`). No `@object-ui/*` import was dragged in, so `//#type-check:e2e` still needs no `^build`.
- The shared option set was **not touched** — no file needed it loosened.
- No file outside the ruled surface was edited. `scripts/check-doc-snippet-types.mjs`, `content/docs/**` and the root `vitest.setup*` files are untouched.

_Generated by [Claude Code](https://claude.ai/code/session_01PQ3NihCHE9LUtHoGxo6A9f)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ3NihCHE9LUtHoGxo6A9f)_