### PR TITLE
docs(guides,tooling): clear ten .md pages off the doc-snippet ledger (#5174 batch 1)

### DIFF
--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -22,7 +22,9 @@ This reference documents every ObjectUI schema type with annotated JSON examples
 The foundational building block of ObjectUI. Every component in the system is described by a `SchemaNode`. It can be a full schema object, or a primitive value rendered as text.
 
 ```typescript
-// Type definition
+import type { BaseSchema } from '@object-ui/types';
+
+// The definition `@object-ui/types` declares
 type SchemaNode = BaseSchema | string | number | boolean | null | undefined;
 ```
 

--- a/content/docs/guide/architecture-overview.md
+++ b/content/docs/guide/architecture-overview.md
@@ -150,6 +150,8 @@ Plugins use `React.lazy()` wrapped by `LazyPluginLoader` (`packages/react/src/La
 
 Every plugin follows the same structure (see `packages/plugin-kanban/`, `packages/plugin-grid/`):
 
+<!-- doc-snippet: fragment — an excerpt of a plugin package's own index: `./KanbanImpl` is that package's sibling module and `Props` its local prop type, neither of which exists outside the plugin being described -->
+
 ```typescript
 // 1. Lazy-load the heavy implementation
 const LazyKanban = React.lazy(() => import('./KanbanImpl'));
@@ -270,6 +272,8 @@ a different dialect from the `${...}` evaluator).
 that dispatch. It owns the protocol (name-based action identity, record-id
 resolution, re-entrancy guard, the `/actions` response-envelope rule) and
 injects the three things core has no opinion about:
+
+<!-- doc-snippet: fragment — the three injected values are the reader's own (`myAuthenticatedFetch`, `currentObject`, `notifyDataChanged`), and the closing line is a bare `<ActionProvider ... />` tag whose remaining props are deliberately elided -->
 
 ```typescript
 import { createServerActionHandler } from '@object-ui/core';

--- a/content/docs/guide/deployment.md
+++ b/content/docs/guide/deployment.md
@@ -195,6 +195,8 @@ Add the `vite-plugin-compression` plugin for pre-compressed assets:
 pnpm add -D vite-plugin-compression
 ```
 
+<!-- doc-snippet: fragment — a vite.config.ts for the reader's own project: `defineConfig`, `react()`, `tailwindcss()` and `vite-plugin-compression` are the reader's dependencies and imports, not this repository's, so they cannot resolve here -->
+
 ```ts
 // vite.config.ts
 import compression from 'vite-plugin-compression';
@@ -217,7 +219,8 @@ Vite splits chunks automatically. For ObjectUI plugins, use dynamic imports to k
 import { createLazyPlugin } from '@object-ui/react';
 
 const ObjectGrid = createLazyPlugin(
-  () => import('@object-ui/plugin-grid'),
+  // The plugin package has no default export — name the component you want.
+  async () => ({ default: (await import('@object-ui/plugin-grid')).ObjectGrid }),
   { fallback: <div>Loading grid...</div> }
 );
 ```
@@ -229,6 +232,8 @@ Visualize your bundle to find optimization opportunities:
 ```bash
 pnpm add -D rollup-plugin-visualizer
 ```
+
+<!-- doc-snippet: fragment — a vite.config.ts for the reader's own project: `defineConfig`, `react()`, `tailwindcss()` and `rollup-plugin-visualizer` are the reader's dependencies and imports, not this repository's, so they cannot resolve here -->
 
 ```ts
 // vite.config.ts

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -155,6 +155,8 @@ Disable component when expression is true:
 
 The root data object is available directly:
 
+<!-- doc-snippet: fragment — closes on a bare `<SchemaRenderer />` tag whose `schema` is the reader's own document, so the block is a data shape followed by a tag rather than a program -->
+
 ```tsx
 const data = {
   user: { name: "Alice" },
@@ -469,6 +471,8 @@ Expressions are re-evaluated when data changes. Avoid expensive operations:
 // ✅ Good: Pre-compute in data
 ```
 
+<!-- doc-snippet: fragment — the good half of a bad/good contrast: `users` and `expensiveOperation` are the reader's own rows and function, shown only to place the computation outside the expression -->
+
 ```tsx
 const data = {
   processedUsers: users.map(u => expensiveOperation(u))
@@ -515,6 +519,8 @@ Error: "Cannot read property 'invalidProperty' of undefined"
 ### Debug Mode
 
 Enable debug mode to see expression evaluation:
+
+<!-- doc-snippet: fragment — a bare `<SchemaRenderer />` tag shown for the `debug` prop alone; `schema` and `data` are the reader's own -->
 
 ```tsx
 <SchemaRenderer 
@@ -622,6 +628,8 @@ language's own. A membership test is written with the array method:
 ### 4. Use TypeScript
 
 Define your data types:
+
+<!-- doc-snippet: fragment — the typed data is followed by a bare `<SchemaRenderer />` tag and the literal is written as an elided `{ /* ... */ }`, so the block states a type rather than compiling -->
 
 ```tsx
 interface UserData {

--- a/content/docs/guide/notifications.md
+++ b/content/docs/guide/notifications.md
@@ -39,6 +39,8 @@ subscribe to the provider. Placement is deliberately yours: a banner needs a
 slot in the content area and an inline notification belongs next to the thing
 that raised it, so neither can be positioned by a global overlay.
 
+<!-- doc-snippet: fragment — a mount tree for the reader's own app: `<Outlet />` is the host router's element and `sonner` is the toast library the host chooses, neither of which this repository depends on -->
+
 ```tsx
 import {
   NotificationAlerts,
@@ -87,6 +89,10 @@ provider above it renders no banners instead of throwing.
 ## Raising notifications
 
 ```tsx
+import { useNotifications } from '@object-ui/react';
+
+declare const undo: () => void;
+
 const { notify } = useNotifications();
 
 notify({ title: 'Saved', severity: 'success' });                    // toast (spec default)
@@ -101,6 +107,8 @@ notify({ title: 'Session expired', severity: 'error', displayType: 'alert' });
 An action's `variant` is the spec vocabulary — `primary` (default) / `secondary`
 / `link` — describing the action's **role**. Each surface maps it onto its own
 button styling; it is not the shadcn Button vocabulary, which is a look.
+
+<!-- doc-snippet: fragment — continues the `notify` block above: `notify` is the callback destructured there, and `upgrade` / `openDocs` are the reader's own handlers -->
 
 ```tsx
 notify({
@@ -122,6 +130,8 @@ An inline notification is rendered by the surface that raised it. `scope` is the
 routing key that pairs the two, so two forms on one page don't show each other's
 messages:
 
+<!-- doc-snippet: fragment — continues the `notify` block above, and closes on a bare `<NotificationInline />` tag that pairs with it rather than a mounted tree -->
+
 ```tsx
 notify({
   title: 'Fix 2 fields', severity: 'error',
@@ -140,6 +150,8 @@ not which React subtree hosts it.
 Every surface — including the console's sonner toast — resolves `icon` through
 the same rule: a declared Lucide name (kebab-case or PascalCase) replaces the
 severity icon; anything else falls back to it.
+
+<!-- doc-snippet: fragment — continues the `notify` block above: one call, shown for the `icon` key alone -->
 
 ```tsx
 notify({ title: 'Deploy finished', severity: 'success', displayType: 'banner', icon: 'rocket' });

--- a/content/docs/guide/public-forms.md
+++ b/content/docs/guide/public-forms.md
@@ -20,7 +20,9 @@ from `/api/v1/meta/view/:name` and posting to `/api/v1/data/:object`.
 
 ```tsx
 import { EmbeddableForm } from '@object-ui/plugin-form';
-import { restDataSource } from '@object-ui/data-rest';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+
+const dataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com' });
 
 <EmbeddableForm
   config={{
@@ -43,7 +45,7 @@ import { restDataSource } from '@object-ui/data-rest';
       redirectUrl: 'https://example.com/thank-you',
     },
   }}
-  dataSource={restDataSource}
+  dataSource={dataSource}
 />
 ```
 
@@ -67,6 +69,9 @@ thank-you page so bots can't tell they failed.
 ## Configuration reference
 
 ```ts
+import type { FormField } from '@object-ui/types';
+import type { EmbeddableFormTexts } from '@object-ui/plugin-form';
+
 interface EmbeddableFormConfig {
   formId: string;
   objectName: string;
@@ -101,6 +106,8 @@ interface EmbeddableFormConfig {
 
 Public form URLs are user-controlled, so prefill is **off** unless you
 explicitly opt fields in:
+
+<!-- doc-snippet: fragment — the quick-start element again with its `config` elided down to the one key this section adds; `EmbeddableForm` is the import made there -->
 
 ```tsx
 <EmbeddableForm
@@ -181,6 +188,8 @@ write the destination relatively if you want it placed inside your mount.
 
 ### GDPR consent
 
+<!-- doc-snippet: fragment — two bare config properties, shown on their own: they belong inside the `config` object of the quick-start block and are not a program -->
+
 ```tsx
 consent: { required: true, label: 'I agree to the privacy policy.' }
 privacyPolicyUrl: '/legal/privacy'
@@ -208,6 +217,8 @@ hard error, so legit speed-typers can simply retry.
 `EmbeddableForm` doesn't bundle a specific provider. Mount your
 preferred widget (hCaptcha, Turnstile, reCAPTCHA) and feed the token in:
 
+<!-- doc-snippet: fragment — the captcha widget, `useState` import and data source are the reader's own, and the `config` object is elided down to the one key this section adds -->
+
 ```tsx
 const [token, setToken] = useState<string>();
 <EmbeddableForm config={{ /* … */ captchaToken: token }} dataSource={ds} />
@@ -220,6 +231,8 @@ The token is forwarded as `payload._captcha` for server-side validation.
 `EmbeddableForm` is i18n-agnostic — every user-visible string is
 overridable via `config.texts: EmbeddableFormTexts`. The console wires
 this up through `@object-ui/i18n`:
+
+<!-- doc-snippet: fragment — `t` comes from the console's own i18n provider and the `config` object is elided down to the `texts` key this section is about -->
 
 ```tsx
 const { t } = useObjectTranslation();

--- a/content/docs/guide/schema-overview.md
+++ b/content/docs/guide/schema-overview.md
@@ -24,6 +24,8 @@ ObjectUI includes enterprise-grade capabilities to build production-ready applic
 #### [App Schema](/docs/core/app-schema)
 Define your entire application structure with navigation, branding, and global settings.
 
+<!-- doc-snippet: fragment — a shape excerpt: `menu` and `actions` are written as a literal `[...]` ellipsis because the section is about the app schema's top-level keys, not about a menu -->
+
 ```typescript
 const app: AppComponentSchema = {
   type: 'app',
@@ -71,6 +73,8 @@ turns it into the CSS variables your components already read.
 #### [Enhanced Actions](/docs/core/enhanced-actions)
 Powerful action system with AJAX calls, chaining, conditions, and callbacks.
 
+<!-- doc-snippet: fragment — a shape excerpt: `chain`, `condition`, `onSuccess` and `tracking` are written as literal `[...]` / `{...}` ellipses so the section can list the action keys without a worked example of each -->
+
 ```typescript
 const action: ActionSchema = {
   type: 'action',
@@ -103,6 +107,8 @@ const action: ActionSchema = {
 Enterprise reports with aggregation, export, and scheduling.
 
 ```typescript
+import type { ReportComponentSchema } from '@object-ui/types';
+
 const report: ReportComponentSchema = {
   type: 'report',
   title: 'Sales Report',
@@ -130,6 +136,8 @@ const report: ReportComponentSchema = {
 
 #### [Block Schema](/docs/blocks/block-schema)
 Reusable component blocks with variables, slots, and marketplace support.
+
+<!-- doc-snippet: fragment — a shape excerpt: the block template's `children` is written as a literal `[...]` ellipsis, since the section is about the block wrapper rather than what it wraps -->
 
 ```typescript
 const block: BlockSchema = {
@@ -217,6 +225,8 @@ import {
   ReportComponentSchema,
   BlockSchema
 } from '@object-ui/types/zod';
+
+const myConfig = { type: 'app', title: 'My Application', layout: 'sidebar' };
 
 const result = AppComponentSchema.safeParse(myConfig);
 if (result.success) {

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -23,6 +23,8 @@ import '@object-ui/plugin-grid';
 
 If you are using a custom component, register it explicitly:
 
+<!-- doc-snippet: fragment — `./MyCustomWidget` is the reader's own component module, so the import cannot resolve from this repository -->
+
 ```typescript
 import { ComponentRegistry } from '@object-ui/core';
 import { MyCustomWidget } from './MyCustomWidget';
@@ -107,6 +109,8 @@ Available context variables:
 
 Debug expressions by enabling debug mode in `SchemaRendererContext`:
 
+<!-- doc-snippet: fragment — a bare `<SchemaRenderer />` tag shown for the `debug` prop alone; `schema` is the reader's own document -->
+
 ```tsx
 <SchemaRenderer schema={schema} debug={true} />
 ```
@@ -173,6 +177,9 @@ The `@object-ui/types` package exports multiple entry points (`base`, `layout`, 
 
 ```tsx
 import { ThemeProvider } from '@object-ui/react';
+import type { FC } from 'react';
+
+declare const YourApp: FC;
 
 function App() {
   return (
@@ -206,10 +213,16 @@ function App() {
 
 ```tsx
 import { I18nProvider } from '@object-ui/i18n';
+import type { FC } from 'react';
 
-<I18nProvider locale="en" messages={messages}>
+declare const App: FC;
+
+// The app's own packs are merged with the built-in locales.
+const resources = { en: { greeting: 'Hello' }, fr: { greeting: 'Bonjour' } };
+
+<I18nProvider config={{ defaultLanguage: 'en', resources }}>
   <App />
-</I18nProvider>
+</I18nProvider>;
 ```
 
 2. Check that locale files follow the expected structure. Each locale file should export a flat or nested object of key-value pairs.
@@ -232,7 +245,13 @@ For custom views, use the `usePerformance` hook from `@object-ui/react` to monit
 ```typescript
 import { usePerformance } from '@object-ui/react';
 
-const { startMeasure, endMeasure } = usePerformance('MyWidget');
+// Inside your component:
+const { metrics, markRenderStart } = usePerformance({
+  virtualScroll: { enabled: true, itemHeight: 40 },
+});
+
+const stopMeasure = markRenderStart(); // call stopMeasure() once the render settles
+console.log(metrics.lastRenderDuration);
 ```
 
 ## 10. Plugin Conflicts
@@ -244,6 +263,11 @@ const { startMeasure, endMeasure } = usePerformance('MyWidget');
 **Fix:** Always use namespaced registrations:
 
 ```typescript
+import { ComponentRegistry } from '@object-ui/core';
+import type { FC } from 'react';
+
+declare const MyGridComponent: FC;
+
 ComponentRegistry.register('grid', MyGridComponent, {
   namespace: 'my-plugin',  // ← prevents collision
   label: 'Custom Grid',
@@ -339,6 +363,8 @@ what the data layer requested:
 
 ```typescript
 import { columnIdentity } from '@object-ui/core';
+
+declare const column: unknown;
 
 const fieldName = columnIdentity(column); // string | undefined
 ```

--- a/content/docs/guide/user-state-persistence.md
+++ b/content/docs/guide/user-state-persistence.md
@@ -37,6 +37,8 @@ Three layers, top-down:
 
 `ConsoleShell` wires everything up in this order:
 
+<!-- doc-snippet: fragment — a provider-tree sketch: the `Suspense` fallback is a literal `{...}` ellipsis and the JSX comments stand in for the components' own props, so the block shows nesting order rather than compiling -->
+
 ```tsx
 <ThemeProvider>
   <NavigationProvider>
@@ -60,21 +62,23 @@ Three layers, top-down:
 The companion adapter is shipped in `@object-ui/data-objectstack`:
 
 ```typescript
+import { useEffect } from 'react';
 import { createObjectStackUserStateAdapter } from '@object-ui/data-objectstack';
 import { useAttachUserStateAdapters } from '@object-ui/app-shell';
 import { useAuth } from '@object-ui/auth';
+import type { DataSource } from '@object-ui/types';
 
-function UserStateBridge({ dataSource }) {
+function UserStateBridge({ dataSource }: { dataSource?: DataSource }) {
   const { user } = useAuth();
   const attach = useAttachUserStateAdapters();
 
   useEffect(() => {
     if (!user?.id || !dataSource) return;
     const favorites = createObjectStackUserStateAdapter({
-      dataSource, userId: user.id, kind: 'favorites',
+      dataSource, userId: user.id, key: 'ui.favorites',
     });
     const recent = createObjectStackUserStateAdapter({
-      dataSource, userId: user.id, kind: 'recent',
+      dataSource, userId: user.id, key: 'ui.recent',
     });
     attach('favorites', favorites);
     attach('recent', recent);

--- a/content/docs/plugins/index.md
+++ b/content/docs/plugins/index.md
@@ -283,6 +283,8 @@ npm install @object-ui/plugin-view
 
 Plugins use React's `lazy()` and `Suspense` to load heavy dependencies on-demand:
 
+<!-- doc-snippet: fragment — the inside of a plugin package: `./MonacoImpl` is that package's own sibling module, which exists only within the plugin being described and cannot resolve from here -->
+
 ```typescript
 // The plugin structure
 import React, { Suspense } from 'react'
@@ -324,6 +326,8 @@ Without lazy loading, all this code would be in your main bundle!
 ### Auto-Registration
 
 Plugins automatically register their components when imported:
+
+<!-- doc-snippet: fragment — continues the plugin-structure block above: `CodeEditorRenderer` is the component defined there, and repeating its definition here would bury the one line this section is about -->
 
 ```typescript
 // In the plugin's index.tsx

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -227,13 +227,23 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * Documents whose snippets are NOT compiled, each with the reason. The default
  * is covered; this list is the debt, by name, and it can only shrink.
  *
- * ⚠️ 19 of these entries are `.md` pages under `content/docs` that objectui#5174
+ * ⚠️ 9 of these entries are `.md` pages under `content/docs` that objectui#5174
  * made visible: the collector now reads `.md`, and an entry with a measured reason
  * is what a page that cannot pass yet is owed. They are DISCLOSED debt, not new
  * debt — every one of them was equally unverified before, just unnamed. Their
  * reasons carry the same measured diagnostic mix as the rest, and a symbol a
  * package does not export is called out by name, because that is the
  * reader-visible half (objectui#5160).
+ *
+ * That count was 19 until objectui#5174's first triage batch, which walked TEN of
+ * them OFF this list rather than re-wording their reasons: `api/schema-reference`,
+ * `plugins/index`, and the `guide/` pages `architecture-overview`, `deployment`,
+ * `expressions`, `notifications`, `public-forms`, `schema-overview`,
+ * `troubleshooting` and `user-state-persistence`. The direction on that card is
+ * entries LEAVING. Each page reached zero the honest two ways — a block that
+ * should compile was made self-contained against the built `dist/`, and a block
+ * that genuinely cannot compile got a `FRAGMENT_MARKER` declaration with a written
+ * reason. Nothing about this gate's strictness moved to get them there.
  *
  * objectui#5343 then read that list back and cleared it for the getting-started
  * pages: no entry for `content/docs/guide/**` or for
@@ -261,17 +271,6 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * @type {Record<string, string>}
  */
 const UNGATED_DOCS = {
-  'content/docs/api/schema-reference.md':
-    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines. This entry read TS2305x1 TS2724x1 until objectui#5343: both were ' +
-    'fabricated exports of @object-ui/types, re-spelled to the names the built `dist/index.d.ts` ' +
-    'declares — `PageSchema` → `PageNodeSchema` (renamed by objectui#3074, which split the ' +
-    'renderer NODE off the spec document type) and `DashboardSchema` → `DashboardComponentSchema`',
-  'content/docs/guide/architecture-overview.md':
-    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 5 ' +
-    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s); plus TS2686x1 — candidate real ' +
-    'defects, un-triaged',
   'content/docs/guide/architecture.md':
     '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '13 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -299,26 +298,10 @@ const UNGATED_DOCS = {
     '(which is also what retired the TS2339, since the real `BaseSchema` declares `className`), ' +
     'and `InputRenderer` (@object-ui/components), which nothing replaces — the built-in renderers ' +
     'are registered by loading their package, never handed out one by one',
-  'content/docs/guide/deployment.md':
-    '6 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 — candidate real ' +
-    'defects, un-triaged',
-  'content/docs/guide/expressions.md':
-    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 5 ' +
-    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; plus TS7006x1 — a candidate real defect, un-triaged. This entry read ' +
-    'TS2724x1 TS7006x3 until objectui#5343: `getExpressionEvaluator` (@object-ui/core) was ' +
-    'fabricated and nothing replaces it — there is no process-level evaluator, `SchemaRenderer` ' +
-    'constructs a fresh `ExpressionEvaluator` per evaluation, so the section now teaches the real ' +
-    'surface (`evaluateExpression(expr, context)` / `new ExpressionEvaluator(context)`) and the ' +
-    'two implicit-any parameters went with the `registerOperator` example it rooted',
   'content/docs/guide/layout.md':
     '21 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '20 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
     'page never defines; 4 unresolved-module diagnostic(s)',
-  'content/docs/guide/notifications.md':
-    '9 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s)',
   'content/docs/guide/objectos-integration.mdx':
     '36 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -338,23 +321,6 @@ const UNGATED_DOCS = {
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
     'page never defines; 6 unresolved-module diagnostic(s); plus TS2882x1 TS7006x3 — candidate ' +
     'real defects, un-triaged',
-  'content/docs/guide/public-forms.md':
-    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 8 ' +
-    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s)',
-  'content/docs/guide/schema-overview.md':
-    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 2 ' +
-    'undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines. This entry read TS2305x2 TS2724x6 until objectui#5343: `AppSchema`, ' +
-    '`ThemeSchema` and `ReportSchema` were fabricated in BOTH the type and the ' +
-    '`@object-ui/types/zod` entry, and are re-spelled `AppComponentSchema`, ' +
-    '`ThemeComponentSchema`, `ReportComponentSchema` at every site including the prose. The ' +
-    'annotations that renaming made real then rejected two more falsehoods in the theme example ' +
-    '(`mode: \'system\'`, and per-theme `light`/`dark` palettes where the spec `Theme` carries one ' +
-    '`colors` map), fixed in the same pass so the page could not get worse. objectui#5489 then ' +
-    'RETIRED `ThemeComponentSchema` itself — the `type: \'theme\'` component kind no renderer ' +
-    'implemented — so the theme example named above is gone from this page rather than re-spelled ' +
-    'again; the two `AppComponentSchema` / `ReportComponentSchema` re-spellings stand',
   'content/docs/guide/schema-rendering.md':
     '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -370,21 +336,6 @@ const UNGATED_DOCS = {
     '23 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
     'page never defines; 1 unresolved-module diagnostic(s); plus TS2339x1 TS2353x1 — candidate ' +
     'real defects, un-triaged',
-  'content/docs/guide/troubleshooting.md':
-    '8 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s); plus TS2322x1 TS2339x2 TS2559x1 — ' +
-    'candidate real defects, un-triaged. This entry read TS2724x1 until objectui#5343: the zod ' +
-    'entry exports `ComponentSchema`, not `componentSchema` — and because the same block imports ' +
-    'the TYPE of that name from @object-ui/types, the validator is imported under an alias rather ' +
-    'than colliding with it',
-  'content/docs/guide/user-state-persistence.md':
-    '10 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
-    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; plus TS2353x2 TS7031x1 — candidate real defects, un-triaged',
-  'content/docs/plugins/index.md':
-    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 1 unresolved-module diagnostic(s); plus TS7006x1 — candidate real ' +
-    'defects, un-triaged',
   'content/docs/plugins/plugin-calendar-view.mdx':
     '2 unresolved-module diagnostic(s) — and NOT a defect: the page is a migration guide whose ' +
     '"Before" blocks quote the retired `@object-ui/plugin-calendar-view` import on purpose. Covering ' +


### PR DESCRIPTION
Part of #5174

Batch 1 of the `UNGATED_DOCS` triage. Ten `.md` guide pages leave the ledger; nine stay, with their measured reasons untouched. No gate strictness moved, no entry was added, and no previously-covered document became ungated.

## Two measurements that re-scope the card before anything else

**1. The remaining `.md` guide population is 19, not 51.** The dispatch and #5174's deferral note both read "51 `.md` guides" off the 63-entry ledger. That figure counts every entry whose filename ends in `.md`, which sweeps in **32 `packages/*/README.md`** entries. Split by where they live:

| ledger slice on `origin/main` @ `baac3f4` | entries |
|:--|--:|
| `content/docs/**/*.md` — the guide tree, this card's surface | **19** |
| `packages/*/README.md` — `.md`, but not guides | 32 |
| `content/docs/**/*.mdx` | 12 |
| **total** | **63** |

So this batch of ten is **over half** the actual population, not a fifth of it. The 63 total was exactly right; only its `.md` split was not.

**2. The "mechanically clearable now that #5343 landed" assumption is falsified — measured, not assumed.** Compiling all 19 pages in one program against the built `dist/` produces **zero** `TS2305` / `TS2724` / `TS2614` — not one fabricated-export diagnostic anywhere in the guide tree. #5343 (PR #5364) cleared that class completely, and the gate's own docblock already says so: *"No entry on this list names a missing export any more."* There is nothing left for an already-made symbol decision to be applied to. Every remaining diagnostic is per-page fragment / self-containment judgement, plus a handful of genuinely wrong documented APIs. Per the dispatch's own rule for that outcome the batch stays small; it is ten rather than eight only because the two extra pages measured cheap.

⛔ No fabricated symbol was re-decided per page. One decision genuinely outside #5343's table came up and is called out below.

## Selection rule: cheapest-first by measured total diagnostic count

Every one of the 19 pages was compiled first, in a single program that reuses the gate's own `analyze()` / `compileSnippets()`, and ranked by total diagnostics. The ten lowest were taken. That rule is defensible on its own terms — it maximises entries removed per unit of review — and it is reproducible: rerun the harness and you get the same ten.

Calibration for that harness: it reproduces the ledger's **recorded** mixes exactly for 17 of the 19 pages, which is what makes the before column trustworthy. (The two that differ are noted at the bottom.)

### Cleared — ten entries deleted, 90 diagnostics gone

| page | was | blocks now compiling | blocks now declared fragments |
|:--|--:|--:|--:|
| `content/docs/api/schema-reference.md` | 1 | 2 | 0 |
| `content/docs/plugins/index.md` | 3 | 1 | 2 |
| `content/docs/guide/architecture-overview.md` | 8 | 0 | 2 |
| `content/docs/guide/deployment.md` | 8 | 1 | 2 |
| `content/docs/guide/schema-overview.md` | 9 | 4 | 3 |
| `content/docs/guide/notifications.md` | 10 | 1 | 4 |
| `content/docs/guide/public-forms.md` | 10 | 3 | 4 |
| `content/docs/guide/troubleshooting.md` | 13 | 7 | 2 |
| `content/docs/guide/expressions.md` | 14 | 3 | 4 |
| `content/docs/guide/user-state-persistence.md` | 14 | 4 | 1 |
| **total** | **90** | **26** | **24** |

Each page reached zero the two honest ways, never a third: a block that *should* compile was made self-contained against the built `dist/`, and a block that genuinely cannot compile got a `FRAGMENT_MARKER` declaration carrying a written reason. ⛔ Nothing was cleared by loosening what "covered" means.

### Left — nine entries, reasons untouched

| page | measured total |
|:--|--:|
| `content/docs/guide/plugins.md` | 20 |
| `content/docs/guide/building-crud-app.md` | 21 |
| `content/docs/rfcs/0001-clipboard-paste.md` | 23 |
| `content/docs/guide/architecture.md` | 25 |
| `content/docs/guide/plugin-development.md` | 25 |
| `content/docs/guide/schema-rendering.md` | 27 |
| `content/docs/guide/theming.md` | 29 |
| `content/docs/guide/layout.md` | 45 |
| `content/docs/guide/component-registry.md` | 59 |

274 diagnostics across nine pages — two batches' worth, and `layout` + `component-registry` are 104 between them.

## The four invariants, measured

Computed by diffing the ledger key sets programmatically — `origin/main`'s copy of the script and this branch's copy, both run over the same working tree, so the covered-set delta is attributable to the ledger alone.

| invariant | measured |
|:--|:--|
| the covered set **strictly grows** | **159 → 169** documents |
| ⛔ **no previously-covered document becomes ungated** | `ADDED ledger entries: []` · `previously-covered docs now UNGATED: []` |
| every entry **left** keeps a measured diagnostic mix | all nine untouched — this diff only *deletes* entries; not one surviving reason string was re-worded |
| ⛔ **nothing about the gate's strictness moves** | proven byte-for-byte: everything from the `// ── Fence scanning` banner to EOF is **identical to `origin/main`** — `scanFences`, `listDocuments`, `derivePackageTypePaths`, `analyze`, `compileSnippets`, the reporting and `main`. `FRAGMENT_MARKER` + `MIN_REASON_LENGTH` diffed separately and also byte-identical. `DOC_EXTENSIONS`, `TS_FENCE_LANGUAGES`, `COMPILER_OPTIONS` and all three controls unchanged. |

`REMOVED entries:` (the ten deleted, verbatim from the diff):

```
content/docs/api/schema-reference.md
content/docs/guide/architecture-overview.md
content/docs/guide/deployment.md
content/docs/guide/expressions.md
content/docs/guide/notifications.md
content/docs/guide/public-forms.md
content/docs/guide/schema-overview.md
content/docs/guide/troubleshooting.md
content/docs/guide/user-state-persistence.md
content/docs/plugins/index.md
```

The script diff is **11 insertions, 60 deletions**: the ten entries, plus the ledger docblock's own count, which said "19 of these entries are `.md` pages" and would have been false the moment these landed.

## CI cost under the #4846 ruling: the closure does not grow

`--build-filter` output **did** change — 15 → 19 filters, adding `@object-ui/auth`, `@object-ui/i18n`, `@object-ui/plugin-form`, `@object-ui/plugin-kanban`. The number that matters did not:

| reading | before | after |
|:--|--:|--:|
| `--filter=` arguments | 15 | 19 |
| **turbo build tasks (filters + dependencies)** | **33** | **33** |

The two task sets are **identical** — diffed package-by-package from `turbo run build … --dry=json`, and the only difference between the two files was a trailing newline. All four newly-named packages were already inside the closure as transitive dependencies of `@object-ui/app-shell`, which #5341 pulled in via `guide/metadata-diagnostics.md`. So ten more covered pages cost this gate **zero** extra build tasks. Stated rather than absorbed, per #4846; there is nothing here for the maintainer to weigh.

## Real defects fixed, not just declared

Four documented APIs did not compile against what the packages ship. These are the #5160 class, on the pages a reader copies from most:

- **`guide/deployment.md`** — `createLazyPlugin(() => import('@object-ui/plugin-grid'))`. `@object-ui/plugin-grid` has **no default export** (`dist/index.d.ts` opens `export { ObjectGrid, VirtualGrid, ImportWizard };`), so the argument is the module namespace, not a component: `TS2322`, and at runtime `React.lazy` would render the namespace object. Now `async () => ({ default: (await import('@object-ui/plugin-grid')).ObjectGrid })`. ⚠️ The `.then((m) => ({ default: m.ObjectGrid }))` spelling infers `P` as `never` on one `then` branch and stays red — the `async` form is load-bearing. **The same wrong call is still authored in `packages/react/src/LazyPluginLoader.tsx`'s own JSDoc, three times, and reaches the published `.d.ts`. Out of this card's file surface → filed as #5949.**
- **`guide/troubleshooting.md`** — the page mounted `I18nProvider` with `locale="en"` and `messages={messages}`. `I18nProviderProps` declares **neither** prop; it takes `config?: I18nConfig`. Now `config={{ defaultLanguage: 'en', resources }}`.
- **`guide/troubleshooting.md`** — `const { startMeasure, endMeasure } = usePerformance('MyWidget')`. `usePerformance` takes a `PerformanceConfig` **object**, not a label string, and returns `{ config, metrics, markRenderStart, debounce }` — neither destructured name exists. Now `markRenderStart()`, which returns the stop function.
- **`guide/user-state-persistence.md`** — `createObjectStackUserStateAdapter({ …, kind: 'favorites' })`. The option is `key`, a dotted namespaced string (`ui.favorites`), and `kind` is rejected outright (`TS2353`). Now `key: 'ui.favorites'` / `key: 'ui.recent'`, plus the missing `useEffect` import and a typed `dataSource` parameter. ⚠️ That page's **prose and `yaml` storage-model section** still describe a `user_app_state` object keyed by `kind`, a design `packages/data-objectstack/src/userState.ts:6-10` explicitly rejected in favour of `sys_user_preference`. No gate reads a `yaml` fence, so it is a different defect → filed as #5950.

### One decision #5343 genuinely did not cover, stated explicitly

`guide/public-forms.md`'s quick start imported `restDataSource` from **`@object-ui/data-rest`** — a package that **does not exist**: no such directory under `packages/`, and no manifest in the workspace references it. #5343's table enumerates fabricated *symbols on real packages*; a fabricated *module* is outside it, so this call is mine and I am naming it rather than folding it in silently. Disposition, in #5053's vocabulary: **lives in a neighbour package** — the real adapter is `createObjectStackAdapter` from `@object-ui/data-objectstack`, whose declared return type is a generic `DataSource`, exactly what `EmbeddableFormProps.dataSource` takes. ⛔ No export was added anywhere.

## Verification

All at the final commit `31fe8b4`, working tree clean, run from the repo root against a build of the gate's own filter closure (`turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2`, 32/32 successful, serialised under the container's shared heavy-verify lock). Every gate by name with its own printed verdict:

- **`node scripts/check-doc-snippet-types.mjs`** → exit 0. `Scanned 222 document(s): 169 covered (33 of them hold a ts/tsx block), 53 ungated` · `Covered blocks: 161 — 127 to compile, 34 declared fragment(s).` · `Syntax phase: every block parsed, so every one of them reached the semantic phase.` · `Semantic phase: 127 of 127 block(s) judged, 0 failed.` · `Every covered documentation snippet compiles against the built types.` Controls green: resolution landed on `packages/types/dist/index.d.ts`, sentinel produced `TS2305`, positive control 0 diagnostics.
- **`pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts`** → `Test Files 1 passed (1)` / `Tests 20 passed (20)`. Running the script is not running its test; both were run, from the repo root.
- **`node scripts/check-doc-component-types.mjs`** → exit 0. `Scanned 183 doc file(s) (.mdx + .md), 1056 code block(s), 883 type literal(s) … 745 registered, 138 exempted.` · `✅ Every documented component type is registered.`
- **`node scripts/check-doc-links.mjs`** → exit 0. `Links are valid across 13 scan roots.`
- **`node scripts/check-control-bytes.mjs`** → exit 0. `✅ check-control-bytes: OK (scanned 4939 tracked text file(s); skipped 85 binary).` Plus a manual `grep -naP` control-byte scan over all 11 changed files: no hits.
- **`node scripts/check-changeset-presence.mjs`** → exit 0. `11 file(s) changed, 0 of them under the src/ of a package the release covers … ✅ No source of a released package changed in this range, so no changeset is owed.` None added, per its verdict.
- **`node scripts/check-changeset-no-major.mjs`** → exit 0. `✅ No changeset declares a major bump.`
- **`eslint . --ignore-pattern 'packages/*/**' --ignore-pattern 'examples/*/**' --ignore-pattern 'apps/*/**' --ignore-pattern 'docs/**'`** (the complete root `lint` task, not a narrowing — it runs in 9.5s) → exit 0. `✖ 26 problems (0 errors, 26 warnings)`, all pre-existing; the changed `.mjs` reports `errors=0 warnings=0`. Population read from eslint's own `--format json`: **165 files, of which 0 are `.md`** — a changed `.md` linted directly answers `File ignored because no matching configuration was supplied`, so ten of the eleven changed files are outside eslint's population by its own config. The other 46 `turbo run lint` tasks are per-package and this diff touches nothing under `packages/*/`, `apps/*/` or `examples/*/`.
- **`pnpm check`** (the CLI self-check the lint workflow runs) → exit 0. `Analyzing 615 files … ✓ All checks passed`.

Exit codes were captured before any pipe, and each line above is the gate's own printed verdict rather than a bare `$?`.

### The `.md` fragment marker was re-verified, not inherited

24 markers were added and the whole batch leans on them, so #5341's finding was re-measured rather than trusted. `apps/site/node_modules/fumadocs-mdx@15.2.3` selects the compiler format by extension — `filePath.endsWith(".mdx") ? "mdx" : "md"` — and every one of the nine marker-bearing files was then **compiled through `@mdx-js/mdx` 3.1.1 in format `md`**: all nine compile, and the string `doc-snippet` appears **0 times** in every compiled output against 24 occurrences in source. The marker reaches no reader.

### Reverse verification — prediction written before the run, both legs

Build artifact between the mutation and the thing under test: **NONE on either leg.** The mutation is markdown the gate reads straight from disk; the `dist/*.d.ts` it compiles against is untouched, so no rebuild is required for either leg or for the restore. Both legs proved the mutation reached disk by grepping the specific text meant to change, not by trusting an editor's exit code, and the script carried a `trap … EXIT INT TERM` restore.

**Leg 1** — revert `api/schema-reference.md` to `origin/main` while keeping its ledger entry removed. *Predicted:* exit 1, exactly one new diagnostic (`TS2304: Cannot find name 'BaseSchema'`), block counts unchanged, direction **MORE findings**. *Observed:* exit 1 · `content/docs/api/schema-reference.md:26:19 TS2304: Cannot find name 'BaseSchema'.` · `Covered blocks: 161 — 127 to compile, 34 declared fragment(s)` · `Semantic phase: 127 of 127 block(s) judged, 1 failed`. Match, including direction.

**Leg 2** — revert all ten pages, ledger removals kept. *Predicted:* exit 1, declared fragments collapse 34 → 10, blocks-to-compile rise, parse failures reappear and the reduced-coverage NOTE prints, roughly the 90 diagnostics measured in the baseline. *Observed:* exit 1 · `Covered blocks: 161 — 151 to compile, 10 declared fragment(s)` · `Syntax phase: 8 block(s) failed to parse and were NOT semantically checked` · `Semantic phase: 143 of 151 block(s) judged, 29 failed` · the NOTE printed · **90 failure lines exactly**, matching the baseline total to the unit. Match, including direction.

**Restore leg** — run, not skipped: tree clean against `HEAD`, 24 markers back on disk, gate exit 0 with `127 of 127 block(s) judged, 0 failed`. The tree is byte-identical to what is pushed.

## Two ledger reasons that have drifted, reported rather than edited

The measurement harness reproduces the recorded mix exactly for 17 of 19 pages. Two disagree, and neither is touched here — re-wording a surviving entry would push this diff outside the batch:

- `guide/schema-overview.md` recorded 8 parse diagnostics; 7 measured. (Cleared by this PR anyway.)
- `guide/building-crud-app.md` recorded `20 undefined-name … 4 unresolved-module`; **14 and 3** measured. Its entry now over-states its debt by 6 and 1. Worth refreshing when that page is taken.

## Out of scope, filed unassigned

- **#5949** — `createLazyPlugin`'s own JSDoc teaches the call this PR fixed in the guide, three times, and it reaches the published `.d.ts` editors show on hover. ⛔ Not repairable by adding a default export to `@object-ui/plugin-grid` — that is a contract change.
- **#5950** — `user-state-persistence.md`'s prose and `yaml` storage-model section document a `user_app_state` object keyed by `kind`; the shipped adapter uses `sys_user_preference` keyed by `key`. Invisible to every gate, since neither reads a `yaml` fence.

Both searched for first; no open issue covered either.

⛔ Not folded in, all deliberately: #5867 (`plaintext`-fenced ts/tsx blocks), #5106 / #5342 (the sibling gate's fence and extension axes), #5465 (`skills/` outside the scan surface). Same gate family, different defects.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ3NihCHE9LUtHoGxo6A9f)_
