### PR TITLE
fix(data-objectstack): classify analytics failures by their ADR-0112 code, not their status

### DIFF
--- a/.changeset/analytics-failure-code-first.md
+++ b/.changeset/analytics-failure-code-first.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/data-objectstack': minor
+---
+
+Classify `/analytics/query` failures by their ADR-0112 `code` rather than their HTTP status, so a chart is no longer answered from a different code path behind the wrong explanation.
+
+`classifyAnalyticsFailure` tested `status === 404 || status === 501` before the code operands on the same line, so the status short-circuited every one of them: any 404 on this face was classified "the analytics capability is not installed" whatever code it carried, and `NOT_IMPLEMENTED` / `ROUTE_NOT_FOUND` were unreachable for the conditions they name. Three unrelated conditions answer 404 on this url, so the status cannot tell them apart — the `code` is the contract.
+
+Two conditions change behaviour:
+
+- **404 `CUBE_NOT_FOUND`** (a misspelled or unregistered cube — an authoring mistake) now **throws** the server's own error verbatim, keeping `code` and the producer's repair instructions. It previously warned "install `@objectstack/service-analytics`" and silently degraded to `find()` + client-side aggregation — which cannot answer it anyway, because the fallback re-reads the same name through `/data`, where an unregistered object is a 404 `OBJECT_NOT_FOUND`.
+- **401 `UNAUTHENTICATED`** (an anonymous or lapsed session) now **throws** `AnalyticsUnauthenticatedError` instead of degrading silently behind a `find()` that is about to be refused the same way.
+
+Unchanged: `NOT_IMPLEMENTED` / `ROUTE_NOT_FOUND` and code-less 404/501 answers still degrade loudly to the client-side fallback, 400 `VALIDATION_FAILED` still throws, and 5xx / network failures still degrade silently.

--- a/packages/data-objectstack/src/aggregate-capability.test.ts
+++ b/packages/data-objectstack/src/aggregate-capability.test.ts
@@ -18,10 +18,23 @@
  *
  * That is the same lie framework#3891 removed from the server side (a degraded
  * shim answering 200 with unscoped numbers), reproduced one layer up. These
- * tests pin the three outcomes:
- *   - capability absent (404 / 501)  → client-side fallback over a scoped find();
- *   - our body is off-contract (400) → THROWS, never silently re-answered;
- *   - a normal result                → untouched.
+ * tests pin every branch of `classifyAnalyticsFailure` onto exactly one of the
+ * three outcomes a failed `aggregate()` can take:
+ *
+ *   | server said                    | outcome            |
+ *   |--------------------------------|--------------------|
+ *   | 501 `NOT_IMPLEMENTED`          | degrade LOUDLY     |
+ *   | 404 `ROUTE_NOT_FOUND`          | degrade LOUDLY     |
+ *   | 404/501, no `code` at all      | degrade LOUDLY     |
+ *   | 400 `VALIDATION_FAILED`        | THROW              |
+ *   | 401 `UNAUTHENTICATED`          | THROW              |
+ *   | 404 `CUBE_NOT_FOUND`           | THROW              |
+ *   | 5xx, network, unknown code     | degrade SILENTLY   |
+ *   | 2xx                            | rows, untouched    |
+ *
+ * The rows that matter most are the two 404s with DIFFERENT outcomes
+ * (objectui#5721): they are the same transport status, so only the ADR-0112
+ * `code` can tell them apart, and a status-first classifier fails them both.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -173,5 +186,194 @@ describe('aggregate() on a healthy analytics endpoint', () => {
     const { fetchImpl } = makeFetch(200, { success: true, data: { rows: [{ stage: 'won', amount_sum: 150 }] } });
     const rows = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE);
     expect(rows).toEqual([{ stage: 'won', amount: 150 }]);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#5721 — the code decides, the status is only the residual.
+ *
+ * WHAT WAS WRONG. `classifyAnalyticsFailure` tested `status === 404 || status
+ * === 501` BEFORE the code operands that followed on the same line, so the
+ * status short-circuited them: every 404 on this face was "the analytics
+ * capability is not installed" whatever code it carried. An operator was told
+ * to install a server plugin for a misspelled cube, and the chart was answered
+ * from a different code path without saying so.
+ *
+ * ENVELOPE (measured, not assumed — objectui#5721 asks for exactly this).
+ * `/analytics/query` does NOT answer in the flat family the dataset route
+ * writes. It exits through `@objectstack/runtime`'s
+ * `dispatcher-plugin.errorResponseBase` → `{ success: false, error: { code,
+ * message, httpStatus } }`, while its 401 comes from `enforceAuth`'s FLAT
+ * `ANONYMOUS_DENY_BODY` (`{ error: 'UNAUTHENTICATED', code: 'UNAUTHENTICATED',
+ * message }`). Both are used verbatim below because `@objectstack/client`'s
+ * fetch wrapper flattens BOTH before it throws — `errorBody?.code ??
+ * errorBody?.error?.code` onto `error.code`, plus `error.httpStatus =
+ * res.status` — which is why the classifier reads one field and no envelope.
+ * These tests run through the real client, so a client that stopped flattening
+ * either family would turn them red rather than pass on a rewritten mock.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** `errorResponseBase`'s wrapped envelope, verbatim in shape. */
+function wrappedError(code: string, message: string, httpStatus: number) {
+  return { success: false, error: { code, message, httpStatus } };
+}
+
+/** `@objectstack/core`'s `ANONYMOUS_DENY_BODY`, verbatim in shape. */
+const ANONYMOUS_DENY_BODY = {
+  error: 'UNAUTHENTICATED',
+  code: 'UNAUTHENTICATED',
+  message: 'Authentication is required to access this endpoint.',
+} as const;
+
+const CUBE_NOT_FOUND_MESSAGE =
+  "Cube 'opportunity_metrics' not found: no cube is registered under that name, and it is " +
+  'not a registered object either (a cube can only be auto-inferred from a registered ' +
+  'object). Define a Cube in your stack, or check the object name.';
+
+describe('aggregate() — 404 `CUBE_NOT_FOUND` is an authoring mistake, not a missing capability', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  /*
+   * OUTCOME: THROW. Not "degrade loudly", and the reason is measurable rather
+   * than a preference: `assertInferableCube` (framework#3867) throws this only
+   * when the name is neither a registered cube NOR a registered object, and
+   * the fallback re-reads THE SAME NAME through `/data`, where objectql's
+   * `assertObjectRegistered` (framework#3770) answers 404 `OBJECT_NOT_FOUND`.
+   * So degrading cannot produce numbers — it can only replace a message that
+   * names the fix with a distant one, behind a warning that instructs the
+   * wrong repair.
+   */
+  it('throws with the server\'s own code and words, and never re-reads through find()', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { fetchImpl, calls } = makeFetch(404, wrappedError('CUBE_NOT_FOUND', CUBE_NOT_FOUND_MESSAGE, 404));
+
+      const err = await makeAdapter(fetchImpl).aggregate('opportunity_metrics', SUM_BY_STAGE).catch((e) => e);
+
+      expect(err).toBeInstanceOf(Error);
+      // The contract field survives the rethrow, so a caller can still branch
+      // on it — that is why this one is rethrown rather than re-wrapped.
+      expect((err as { code?: string }).code).toBe('CUBE_NOT_FOUND');
+      expect((err as { httpStatus?: number }).httpStatus).toBe(404);
+      // The producer's own repair instructions, not a restatement of them.
+      expect(String(err.message)).toContain('Define a Cube in your stack');
+
+      // No silent second answer from a different code path.
+      expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(false);
+      // And no "install @objectstack/service-analytics" — analytics answered.
+      expect(
+        warn.mock.calls.filter((c) => String(c[0]).includes('analytics capability unavailable')),
+      ).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  /*
+   * The control for the row above, and the pin that a status-first classifier
+   * cannot satisfy: SAME 404, SAME wrapped envelope, different `code` — and
+   * therefore a different outcome. OUTCOME: degrade LOUDLY, because this code
+   * really does mean the routes were never mounted (framework#4019).
+   */
+  it('404 `ROUTE_NOT_FOUND` on the same status still degrades loudly', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { fetchImpl, calls } = makeFetch(
+        404,
+        wrappedError('ROUTE_NOT_FOUND', 'No route matched POST /api/v1/analytics/query', 404),
+      );
+
+      const rows = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE);
+
+      expect(rows.find((r: any) => r.stage === 'won')?.amount).toBe(150);
+      expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(true);
+      expect(
+        warn.mock.calls.filter((c) => String(c[0]).includes('analytics capability unavailable')),
+      ).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe('aggregate() — 401 `UNAUTHENTICATED` is the session, not the deployment', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  /*
+   * OUTCOME: THROW. Degrading here is futile as well as misleading — the
+   * fallback's `find()` carries the SAME lapsed token and is refused the same
+   * way — so the chart cannot be answered at all. Pre-fix this landed in
+   * `unknown` and degraded SILENTLY: an expired session rendered a chart built
+   * from a `find()` that was itself about to be refused.
+   */
+  it('throws AnalyticsUnauthenticatedError instead of degrading silently', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { fetchImpl, calls } = makeFetch(401, ANONYMOUS_DENY_BODY);
+
+      const err = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE).catch((e) => e);
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as { code?: string }).code).toBe('ANALYTICS_UNAUTHENTICATED');
+      expect(String(err.message)).toContain('not authenticated');
+      // It must say the opposite of "capability missing" — an operator sent to
+      // install a server plugin because a token lapsed is the same defect.
+      expect(String(err.message)).toContain('says nothing about whether the analytics');
+      expect((err as { serverCode?: string }).serverCode).toBe('UNAUTHENTICATED');
+
+      expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(false);
+      expect(
+        warn.mock.calls.filter((c) => String(c[0]).includes('analytics capability unavailable')),
+      ).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  /*
+   * Branch ⑤, the 401 limb: a gateway that refused the call before any
+   * ObjectStack route saw it declares no `code`, so the status is the best
+   * signal available — and only because every code branch has already
+   * declined. OUTCOME: THROW, same as the coded case.
+   */
+  it('a code-less 401 (a proxy, not a route) reaches the same branch by status', async () => {
+    const { fetchImpl, calls } = makeFetch(401, { message: 'Unauthorized' });
+
+    const err = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE).catch((e) => e);
+
+    expect((err as { code?: string }).code).toBe('ANALYTICS_UNAUTHENTICATED');
+    expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(false);
+  });
+});
+
+describe('aggregate() — a coded failure that is none of the above still degrades SILENTLY', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  /*
+   * OUTCOME: degrade SILENTLY. `ANALYTICS_QUERY_FAILED` is analytics answering
+   * that its own execution broke — transient, and the numbers are still
+   * obtainable the slow way. It must NOT become "capability missing" (a wrong
+   * instruction to an operator) and must NOT throw (a chart lost to a blip).
+   * This is also the guard on branch ①'s width: reading the `code` first must
+   * not turn every named failure into a loud one.
+   */
+  it('500 `ANALYTICS_QUERY_FAILED` falls back with no capability warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { fetchImpl, calls } = makeFetch(
+        500,
+        wrappedError('ANALYTICS_QUERY_FAILED', 'Query execution failed', 500),
+      );
+
+      const rows = await makeAdapter(fetchImpl).aggregate('opportunity', SUM_BY_STAGE);
+
+      expect(rows.find((r: any) => r.stage === 'won')?.amount).toBe(150);
+      expect(calls.some((c) => c.includes('/api/v1/data'))).toBe(true);
+      expect(
+        warn.mock.calls.filter((c) => String(c[0]).includes('analytics capability unavailable')),
+      ).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -796,28 +796,82 @@ export class AnalyticsQueryRejectedError extends Error {
  *
  * `@objectstack/client`'s fetch wrapper throws on a non-2xx, decorating the
  * error with the semantic `code` string and the numeric `httpStatus` (the
- * ADR-0112 / framework#3842 shape this repo already reads elsewhere). Two
- * outcomes must NOT be conflated:
+ * ADR-0112 / framework#3842 shape this repo already reads elsewhere).
  *
- *   - **`not-installed`** — the deployment has no analytics service. Since
- *     framework#3891 retired the degraded in-kernel shim, that is a 404 (the
- *     routes aren't mounted at all, framework#4019) or a 501 `NOT_IMPLEMENTED`
- *     (REST's dataset route with no service behind it). Degrading to a
- *     client-side aggregate over a scoped `find()` is CORRECT here.
- *   - **`rejected`** — the server refused OUR body (400 `VALIDATION_FAILED`;
- *     framework#4010 validates `/analytics/query` at the entry). Degrading
- *     would answer our own contract violation with plausible numbers from a
- *     different code path and bury it — the misdirection framework#3878
- *     documented. It must be surfaced.
+ * ## The `code` is the contract; the status is a transport fact (objectui#5721)
  *
- * Anything else (5xx, network) is `unknown`: degrade, but silently — it is a
- * transient failure, not a deployment that is missing a capability.
+ * What stood here tested `status === 404 || status === 501` BEFORE the code
+ * operands that followed them, so the status short-circuited every one of
+ * them: any 404 on this face was `not-installed` whatever code it carried, and
+ * `NOT_IMPLEMENTED` / `ROUTE_NOT_FOUND` were unreachable for the very
+ * conditions they name. Three unrelated conditions answer 404 on this url —
+ *
+ *   route absent    404 `ROUTE_NOT_FOUND`  (runtime dispatcher, framework#4019)
+ *   cube unknown    404 `CUBE_NOT_FOUND`   (service-analytics' inference gate)
+ *   object unknown  404 `OBJECT_NOT_FOUND` (the `/data` fallback's own answer)
+ *
+ * — so a misspelled cube read as "this deployment has no analytics", told the
+ * operator to install a server plugin, and re-answered the chart from a
+ * different code path. Same defect as objectui#5663, arrived at from the other
+ * direction: the mapping read a field it did not quote. Branch on the `code`;
+ * consult the status only as a residual, when the answer declared no code at
+ * all. Comparisons go through `errorCodeIs`/`errorCodeIsAnyOf` — the pre- and
+ * post-ADR-0112 spellings both have to match (`@object-ui/types`).
+ *
+ * ### Both envelope families reach this function already decorated (MEASURED)
+ *
+ * `/analytics/query` exits through `@objectstack/runtime`'s
+ * `dispatcher-plugin.errorResponseBase`, i.e. the **wrapped** `{ success:
+ * false, error: { code, message } }` shape — not the flat one the dataset
+ * route writes — and its 401 is `enforceAuth`'s **flat** `ANONYMOUS_DENY_BODY`.
+ * The client's fetch wrapper flattens BOTH before throwing:
+ * `errorBody?.code ?? errorBody?.error?.code` → `error.code`, plus
+ * `error.httpStatus = res.status`. So no envelope reading belongs here; unlike
+ * `queryDataset` (which owns its `fetch` and must read the body itself), this
+ * function is handed the already-flattened error and reads one field.
+ *
+ * ## Each branch names ONE of the three outcomes the caller can take
+ *
+ *   - **`not-installed`** — *degrade LOUDLY*. The deployment has no analytics
+ *     service: 501 `NOT_IMPLEMENTED` (route mounted, nothing behind it) or 404
+ *     `ROUTE_NOT_FOUND` (framework#4019 stops mounting the routes at all).
+ *     A client-side aggregate over a scoped `find()` answers the chart
+ *     correctly, and the operator is told once that the semantic layer is off.
+ *   - **`rejected`** — *THROW*. The server refused OUR body (400
+ *     `VALIDATION_FAILED`; framework#4010 validates `/analytics/query` at the
+ *     entry). Degrading would answer our own contract violation with plausible
+ *     numbers from a different code path and bury it — the misdirection
+ *     framework#3878 documented.
+ *   - **`unauthenticated`** — *THROW*. 401 `UNAUTHENTICATED`: the request was
+ *     refused before it ran, so it is evidence about the SESSION and none at
+ *     all about the capability. Degrading is not merely misleading here, it is
+ *     futile: the fallback's `find()` carries the same lapsed token and is
+ *     refused the same way, so the chart cannot be answered either. "Sign in
+ *     again" is an action; "install @objectstack/service-analytics" is not.
+ *   - **`cube-not-found`** — *THROW*. 404 `CUBE_NOT_FOUND`
+ *     (`analytics-service.assertInferableCube`, framework#3867): analytics IS
+ *     installed and answering — the NAME does not exist. That gate throws only
+ *     when the name is neither a registered cube nor a registered object, and
+ *     the fallback asks `/data/<the same name>`, which objectql's
+ *     `assertObjectRegistered` (framework#3770) answers 404 `OBJECT_NOT_FOUND`.
+ *     So degrading cannot produce numbers; it can only swap a message that
+ *     names the fix ("Define a Cube in your stack, or check the object name")
+ *     for a distant one, behind a warning that instructs the wrong repair.
+ *   - **`unknown`** — *degrade SILENTLY*. Anything else (5xx, network, a code
+ *     this consumer does not know): a transient failure, not a deployment
+ *     missing a capability and not a request that named something absent.
  */
 export function classifyAnalyticsFailure(
   error: unknown,
-): { kind: 'not-installed' | 'rejected' | 'unknown'; code?: string; message?: string } {
+): {
+  kind: 'not-installed' | 'rejected' | 'unauthenticated' | 'cube-not-found' | 'unknown';
+  code?: string;
+  message?: string;
+} {
   const err = (error ?? {}) as Record<string, unknown>;
-  const code = typeof err.code === 'string' ? err.code : undefined;
+  // An empty-string `code` is "the producer declared nothing", not a code —
+  // otherwise it would block the residual below while matching no branch.
+  const code = typeof err.code === 'string' && err.code.length > 0 ? err.code : undefined;
   const message = typeof err.message === 'string' ? err.message : undefined;
   const status =
     typeof err.httpStatus === 'number' ? err.httpStatus
@@ -825,10 +879,33 @@ export function classifyAnalyticsFailure(
     : typeof err.statusCode === 'number' ? err.statusCode
     : undefined;
 
-  if (code === 'VALIDATION_FAILED' || status === 400) return { kind: 'rejected', code, message };
-  if (status === 404 || status === 501 || code === 'NOT_IMPLEMENTED' || code === 'ROUTE_NOT_FOUND') {
+  // ① The capability really is absent, from either of its two producers.
+  if (errorCodeIsAnyOf({ code }, ['NOT_IMPLEMENTED', 'ROUTE_NOT_FOUND'])) {
     return { kind: 'not-installed', code, message };
   }
+
+  // ② The server refused the body WE sent.
+  if (errorCodeIs({ code }, 'VALIDATION_FAILED')) return { kind: 'rejected', code, message };
+
+  // ③ The request never ran — the session is anonymous or its token lapsed.
+  if (errorCodeIs({ code }, 'UNAUTHENTICATED')) return { kind: 'unauthenticated', code, message };
+
+  // ④ Analytics answered; the cube this query named is the thing that is missing.
+  if (errorCodeIs({ code }, 'CUBE_NOT_FOUND')) return { kind: 'cube-not-found', code, message };
+
+  // ⑤ Residual — the answer declared NO ADR-0112 code, so no ObjectStack route
+  //   wrote it (a proxy, a gateway, a host with no API mounted). Only here is
+  //   the bare status the best signal available, and only because every code
+  //   branch has already declined: this face's own 404s all ship a `code`, so a
+  //   code-less 404 cannot be the unknown-cube case.
+  if (code === undefined) {
+    if (status !== undefined && ANALYTICS_ABSENT_STATUSES.includes(status)) {
+      return { kind: 'not-installed', code, message };
+    }
+    if (status === 400) return { kind: 'rejected', code, message };
+    if (status === 401) return { kind: 'unauthenticated', code, message };
+  }
+
   return { kind: 'unknown', code, message };
 }
 
@@ -4319,10 +4396,37 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         throw new AnalyticsQueryRejectedError(failure.message, failure.code);
       }
 
-      // The capability is absent (404 — framework#4019 stops mounting the
-      // routes when no analytics service is registered — or 501). Say so ONCE
-      // so an operator sees a missing capability rather than charts that
-      // quietly read from a slower path forever.
+      // The session, not the deployment (401 `UNAUTHENTICATED`). Reusing the
+      // error the dataset face already throws, because the sentence is the
+      // same one on both faces: the request was refused before it ran, so it
+      // says nothing about whether the capability is installed. The fallback
+      // would send the SAME lapsed token to `find()` and be refused again, so
+      // this is a chart that cannot be answered — not one that degrades.
+      if (failure.kind === 'unauthenticated') {
+        throw new AnalyticsUnauthenticatedError({
+          serverCode: failure.code,
+          serverMessage: failure.message,
+        });
+      }
+
+      // Analytics answered; the cube this query named does not exist
+      // (framework#3867). Rethrown VERBATIM, deliberately: the producer's own
+      // message already names both repairs ("Define a Cube in your stack, or
+      // check the object name"), and rethrowing keeps `code` =
+      // `CUBE_NOT_FOUND` on the error so a caller can still branch on the
+      // contract field — a wrapper of ours would restate the server's words
+      // less well and add a published error type nothing has asked for. The
+      // fallback is not an option to weigh here: it re-reads the SAME name
+      // through `/data`, which framework#3770 answers 404 `OBJECT_NOT_FOUND`.
+      if (failure.kind === 'cube-not-found') {
+        throw e;
+      }
+
+      // The capability is absent (`ROUTE_NOT_FOUND` — framework#4019 stops
+      // mounting the routes when no analytics service is registered — or
+      // `NOT_IMPLEMENTED`, or a code-less 404/501 no ObjectStack route wrote).
+      // Say so ONCE so an operator sees a missing capability rather than
+      // charts that quietly read from a slower path forever.
       if (failure.kind === 'not-installed') {
         this.warnAnalyticsCapabilityOnce(failure.message);
       }


### PR DESCRIPTION
Fixes #5721

`classifyAnalyticsFailure` tested `status === 404 || status === 501` **before** the code operands on the same line, so the status short-circuited every one of them: any 404 on the `/analytics/query` face was classified `not-installed` whatever code it carried, and `NOT_IMPLEMENTED` / `ROUTE_NOT_FOUND` were unreachable for the very conditions they name. Three unrelated conditions answer 404 on this url, so the status cannot tell them apart. Branch on the ADR-0112 `code`; consult the status only as a residual, when the answer declared no code at all.

Verified at `8d8b0eb96`.

## The two measurements the card asked for first

**1. The envelope family — measured, and it settles the question in the fix's favour.** `/analytics/query` does exit through the **wrapped** `{ success: false, error: { code, message } }` shape (`@objectstack/runtime`'s `dispatcher-plugin.errorResponseBase`), and its 401 comes from `enforceAuth`'s **flat** `ANONYMOUS_DENY_BODY`. But `@objectstack/client`'s fetch wrapper flattens **both** families before it throws:

```js
const errorCode = asSemanticCode(errorBody?.code) ?? asSemanticCode(errorBody?.error?.code);
error.code = errorCode;
error.httpStatus = res.status;
```

So no envelope reading belongs in this function — unlike `queryDataset`, which owns its `fetch` and must read the body itself, `classifyAnalyticsFailure` is handed an already-flattened error and reads one field. Chain confirmed end to end: `assertInferableCube` sets `code='CUBE_NOT_FOUND'` / `status=404` → `errorResponseBase` keeps a **ledger-registered** code verbatim (`resolveThrownHttpError`; `CUBE_NOT_FOUND` is in `error-code-ledger.zod.ts`, so it is not demoted to `declaredCode`) → the client flattens it onto `error.code`. The tests below drive the real client through a `fetchImpl`, so a client that stopped flattening either family turns them red rather than passing on a rewritten mock.

**2. The blast radius — every branch now names one of the three outcomes.**

| server said | outcome | why |
|---|---|---|
| 501 `NOT_IMPLEMENTED` / 404 `ROUTE_NOT_FOUND` | degrade **loudly** | unchanged — the capability really is absent |
| 404/501 with no `code` at all | degrade **loudly** | unchanged — residual; no ObjectStack route wrote it |
| 400 `VALIDATION_FAILED` | **throw** | unchanged |
| 401 `UNAUTHENTICATED` | **throw** *(was: degrade silently)* | the session, not the deployment |
| 404 `CUBE_NOT_FOUND` | **throw** *(was: degrade loudly, wrong message)* | analytics answered; the **name** does not exist |
| 5xx, network, unknown code | degrade **silently** | unchanged |

### Why the two reclassified branches throw rather than degrade

Not a preference — degrading is **provably futile** for both, which is what makes "throw" a strict improvement rather than a lost chart:

- **`CUBE_NOT_FOUND`** — `assertInferableCube` throws it only when the name is neither a registered cube **nor a registered object**, and the fallback re-reads *that same name* through `/data`, where objectql's `assertObjectRegistered` answers 404 `OBJECT_NOT_FOUND`. So the fallback cannot produce numbers; it could only replace a message that names the fix ("Define a Cube in your stack, or check the object name") with a distant one, behind a warning instructing the wrong repair.
- **`UNAUTHENTICATED`** — the fallback's `find()` carries the same lapsed token and is refused the same way.

`CUBE_NOT_FOUND` is rethrown **verbatim** rather than wrapped: the producer's own message already names both repairs, `code` survives so a caller can still branch on the contract field, and it adds no published error type nothing has asked for. This also mirrors the sibling face, where `queryDataset`'s branch ⑤ already lets a `CUBE_NOT_FOUND` keep its own words. `UNAUTHENTICATED` reuses the **existing** `AnalyticsUnauthenticatedError` — same sentence on both faces. **No new exported surface is added.**

## Reverse verification (ablation)

Restoring the exact pre-fix decision body — mutation confirmed on disk by grepping both the injected marker (1) and the removed branches (0) before running, with a `trap … EXIT INT TERM` restoring the file:

```
Tests  3 failed | 9 passed (12)
  × 404 CUBE_NOT_FOUND … throws with the server's own code and words
  × 401 UNAUTHENTICATED … throws AnalyticsUnauthenticatedError
  × a code-less 401 (a proxy, not a route) reaches the same branch by status
```

Both **controls stayed green** — 404 `ROUTE_NOT_FOUND` (same status, different code, still degrades loudly) and 500 `ANALYTICS_QUERY_FAILED` (still degrades silently) — so the new classifier did not simply turn every named failure into a throw. Restore leg verified: `git status` empty, 0 ablation markers, 12/12 green.

A first, **partial** ablation (code-first branches removed but the residual left intact) produced 2 red, not 3: the code-less 401 pin lands in the residual, which that mutation had not touched. Reported because the run happened, and because the third pin's load-bearingness is established by the *full* ablation above, not that one.

## Gates run locally (at `8d8b0eb96`)

| gate | verdict line |
|---|---|
| `vitest run packages/data-objectstack/` | `Test Files 42 passed (42)` · `Tests 581 passed (581)` |
| `type-check` (`tsc --noEmit`, script name echoed) | exit 0 |
| `eslint packages/data-objectstack` | exit 0 — `--format json`: 48 files, **0 errors**, 0 messages on added lines in `index.ts` |
| `check:control-bytes` | `✅ OK (scanned 4940 tracked text file(s))` |
| `check-changeset-presence` | `✅ … declares 1 changeset(s)` |
| `check-changeset-no-major` | `✅ No changeset declares a major bump.` |
| `check:phantom-deps` / `check:self-import` / `check:esm-specifiers` | ✅ each |

**Lint narrowing is a measurement, not a skip:** the population came from eslint's own config resolution over the affected package (the unit `turbo run lint` runs for it), the count from `--format json`, and `eslint.config.js` enables **no** type-aware linting (no `projectService` / `parserOptions.project`), so this diff cannot move the verdict of any file it does not touch. Repo-wide `pnpm lint` and the remaining `ci.yml` gates (`spec-symbols`, `icon-record-names`, `action-forward-parity`, i18n family) are CI's run — none are reachable from this diff, which adds no imports, icons, action schemas or `t()` call sites. The two added-line lint **warnings** are `no-explicit-any` on `rows.find((r: any) => …)`, matching the five pre-existing tests in the same file.

## Scope

`packages/data-objectstack/src/index.ts` (`classifyAnalyticsFailure` + its single caller in the `aggregate` catch), `packages/data-objectstack/src/aggregate-capability.test.ts`, one changeset. No type was widened and no existing pin loosened. Framework paths were read as reference only. #5663 is not addressed here — different route face, already handled.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZyKZejBWZoCSj1NP35wcp)_