### PR TITLE
docs(readme): remove stale CodeQL badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/objectstack-ai/objectui/workflows/CI/badge.svg)](https://github.com/objectstack-ai/objectui/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/objectstack-ai/objectui/workflows/CodeQL%20Security%20Scan/badge.svg)](https://github.com/objectstack-ai/objectui/actions/workflows/codeql.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-18+-61dafb.svg)](https://reactjs.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-3.0+-38bdf8.svg)](https://tailwindcss.com/)


### PR DESCRIPTION
Fixes #5408

## What

Removes the `CodeQL` badge line from `README.md` (was line 11). Both halves —
the badge image (`workflows/CodeQL%20Security%20Scan/badge.svg`) and the link
target (`actions/workflows/codeql.yml`) — pointed at a workflow that does not
exist in this repository.

## Verification (case 1 confirmed: CodeQL was never set up)

`GET /repos/objectstack-ai/objectui/actions/workflows` returns 31 registered
workflows. Four are `dynamic/*`: Copilot swe-agent, Copilot PR reviewer,
Dependabot, and the Claude agent. There is **no**
`dynamic/github-code-scanning/codeql` — the entry CodeQL "default setup"
registers when enabled in repository Security settings. The other four
dynamic entries are the positive control proving the listing does surface
dynamic workflows, so this absence is a reading, not a broken query.

The repo is **not** unscanned: `.github/workflows/secret-scan.yml` ("Secret
Scanning") is registered and active, unaffected by this change and untouched
by this PR.

Whether this repo should adopt CodeQL is a separate, maintainer-floor
decision — out of scope here and not implemented.

## Scope

`README.md` only, and within it only the CodeQL badge line. The other five
badges (License, CI, TypeScript, React, Tailwind) are untouched; the CI badge
points at `ci.yml`, which is registered and active.

## Gates

- **Lint** (`pnpm run lint:root`): exit 0, 26 pre-existing warnings (all
  `@typescript-eslint/no-explicit-any` in unrelated test files), 0 errors.
  ESLint does not lint `.md` files, so this change is not itself linted by it.
- **Docs Links** (`node scripts/check-doc-links.mjs`): `Links are valid across
  13 scan roots.` The root `README.md` is one of the 13 scan roots, but badge
  `workflows/<name>/badge.svg` URLs are github.com web routes rather than
  tree paths and are explicitly out of scope for this checker (see its header,
  "Only `blob|tree`" boundary) — deleting the line cannot regress this gate.
- **Check Links** (Lychee, external): `schedule` + `workflow_dispatch` only,
  not a PR gate (deliberate — see the workflow's own header).
- **Control bytes** (`node scripts/check-control-bytes.mjs`): OK, 4950 tracked
  text files scanned.
- **Changeset**: none added, and none owed. `check-changeset-presence.mjs`
  only guards `<pkg>/src/**` for packages in `.changeset/config.json`'s
  `fixed` group; `README.md` is at the repo root, outside every package
  directory, so it is not part of the guarded surface at all (ran the gate
  locally against this diff: `0 file(s) ... under the src/ of a package the
  release covers`, exit 0).

## Finding (not fixed here — out of file-surface scope for this card)

Two more stale CodeQL claims exist elsewhere in the repo, same defect class,
left unfixed per this card's `README.md`-only file surface:

- `CONTRIBUTING.md` lists CodeQL under "Security Scans" as if it runs.
- `packages/vscode-extension/SUMMARY.md` claims "CodeQL扫描通过" (CodeQL scan
  passed).

Filed as separate, unassigned issues (see linked report).

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_