### PR TITLE
docs(guides,tooling): clear four .md pages off the doc-snippet ledger (#5174 batch 2)

### DIFF
--- a/content/docs/guide/architecture.md
+++ b/content/docs/guide/architecture.md
@@ -140,10 +140,21 @@ The `SchemaRenderer` component:
 
 ```tsx
 import { SchemaRenderer } from '@object-ui/react'
+import type { BaseSchema } from '@object-ui/types'
+
+// The schema from step 1, as the object the renderer receives.
+const schema: BaseSchema = {
+  type: 'card',
+  title: 'Welcome',
+  body: {
+    type: 'text',
+    value: 'Hello, ${user.name}!',
+  },
+}
 
 function App() {
-  const data = { user: { name: "Alice" } }
-  
+  const data = { user: { name: 'Alice' } }
+
   return <SchemaRenderer schema={schema} data={data} />
 }
 ```
@@ -152,6 +163,7 @@ function App() {
 
 The registry maps type strings to React components:
 
+<!-- doc-snippet: fragment — registry excerpt — CardComponent and TextComponent are placeholder names for the reader's own components, and ComponentRegistry is imported where it is used further down the page -->
 ```typescript
 // During app initialization
 ComponentRegistry.register('card', CardComponent)
@@ -165,6 +177,7 @@ const Component = ComponentRegistry.get('card') // → CardComponent
 
 The registered component renders with evaluated props:
 
+<!-- doc-snippet: fragment — the JSX the registry produces for step 1's schema; CardComponent and TextComponent are the placeholder components registered in the block above -->
 ```tsx
 <CardComponent title="Welcome">
   <TextComponent value="Hello, Alice!" />
@@ -179,6 +192,7 @@ ObjectUI uses two registry systems for extensibility:
 
 Maps schema types to React components:
 
+<!-- doc-snippet: fragment — MyWidgetComponent is a placeholder for the reader's own component; the block shows the register() call's metadata argument, not a runnable module -->
 ```tsx
 import { ComponentRegistry } from '@object-ui/core'
 
@@ -197,6 +211,7 @@ ComponentRegistry.register('my-widget', MyWidgetComponent, {
 
 Maps field types to input components:
 
+<!-- doc-snippet: fragment — RatingFieldComponent is a placeholder for the reader's own field renderer -->
 ```tsx
 import { registerFieldRenderer } from '@object-ui/fields'
 
@@ -274,6 +289,7 @@ ObjectUI uses **Tailwind CSS** exclusively for styling:
 
 All component variants use `cva` for type-safe variants:
 
+<!-- doc-snippet: fragment — quotes how @object-ui/components declares its variants internally; class-variance-authority is that package's own dependency, not a module resolvable from the docs root -->
 ```tsx
 import { cva } from 'class-variance-authority'
 
@@ -299,6 +315,7 @@ const buttonVariants = cva(
 
 Use `cn()` helper (tailwind-merge + clsx) for class overrides:
 
+<!-- doc-snippet: fragment — a one-line usage excerpt; '@/lib/utils' is the reader's app path alias and Button and props come from the surrounding component -->
 ```tsx
 import { cn } from '@/lib/utils'
 
@@ -319,11 +336,15 @@ ObjectUI is built with **TypeScript** in strict mode:
 ```typescript
 import type { ComponentSchema, ButtonSchema } from '@object-ui/types'
 
+function handleClick() {
+  // ...
+}
+
 const schema: ButtonSchema = {
   type: 'button',
   text: 'Click me',
   variant: 'default', // ✅ Type-checked
-  onClick: 'handleClick'
+  onClick: handleClick, // ✅ a handler, not its name — onClick is () => void | Promise<void>
 }
 ```
 
@@ -345,6 +366,7 @@ Heavy dependencies only go in plugins:
 
 Don't import components directly - use registries:
 
+<!-- doc-snippet: fragment — a good/bad contrast pair mixing an import, bare JSX and a bare schema literal — three separate excerpts in one block, none a module -->
 ```tsx
 // ❌ Bad
 import { MyGrid } from './MyGrid'
@@ -359,6 +381,7 @@ ComponentRegistry.register('my-grid', MyGrid)
 
 Never use inline styles or CSS-in-JS:
 
+<!-- doc-snippet: fragment — a good/bad contrast pair of two unclosed div openings, quoted to compare the style attribute with a Tailwind class -->
 ```tsx
 // ❌ Bad
 <div style={{ backgroundColor: 'red' }}>
@@ -371,6 +394,7 @@ Never use inline styles or CSS-in-JS:
 
 Use expressions for dynamic content:
 
+<!-- doc-snippet: fragment — a good/bad contrast pair of two bare schema object literals -->
 ```tsx
 // ❌ Bad - hardcoded
 { type: 'text', value: 'Hello, John!' }
@@ -389,6 +413,7 @@ When creating a plugin:
 4. Add documentation in `content/docs/plugins/`
 5. Add to plugins meta.json
 
+<!-- doc-snippet: fragment — the reader's new plugin package index.tsx; './MyWidget' is the sibling source file in that package -->
 ```typescript
 // packages/plugin-mywidget/src/index.tsx
 import { ComponentRegistry } from '@object-ui/core'

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -36,6 +36,7 @@ pnpm add -D tailwindcss @tailwindcss/vite
 
 Add Tailwind to your `vite.config.ts`:
 
+<!-- doc-snippet: fragment — a vite.config.ts for the app the reader is scaffolding; '@vitejs/plugin-react' and '@tailwindcss/vite' are that app's devDependencies, not this repo's -->
 ```ts
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
@@ -163,7 +164,10 @@ export class RestDataSource implements DataSource {
     const query = new URLSearchParams();
     if (params?.$top) query.set('$top', String(params.$top));
     if (params?.$skip) query.set('$skip', String(params.$skip));
-    if (params?.$orderby) query.set('$orderby', params.$orderby);
+    // `$orderby` is a union — an OData clause string, a map, or an array of
+    // fields. This backend speaks the string form, so narrow to it rather
+    // than stringifying a shape the server cannot parse.
+    if (typeof params?.$orderby === 'string') query.set('$orderby', params.$orderby);
     if (params?.$search) query.set('$search', params.$search);
     const res = await fetch(`${this.baseUrl}/${resource}?${query}`);
     const data = await res.json();
@@ -208,6 +212,7 @@ Wire everything together in `src/App.tsx`. `SchemaRendererProvider` injects the
 data source once, and every `SchemaRenderer` beneath it renders its schema
 against that one adapter:
 
+<!-- doc-snippet: fragment — the reader's src/App.tsx; './setup' and './data/rest-data-source' are the project files created in Steps 2 and 4 -->
 ```tsx
 import './setup';
 import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
@@ -259,6 +264,7 @@ resolved** panel naming itself and the object it was about to read.
 
 ObjectUI generates forms directly from your schema. Extend `App.tsx` with form state:
 
+<!-- doc-snippet: fragment — two lines to paste into the App component of Step 5 — the useState import and the surrounding function body are already there -->
 ```tsx
 const [showForm, setShowForm] = useState(false);
 const [editId, setEditId] = useState<string | null>(null);
@@ -269,6 +275,7 @@ Add a "New Task" button and handle row clicks to open the edit form:
 Both of these render inside the `SchemaRendererProvider` from Step 5, so neither
 carries a data source of its own:
 
+<!-- doc-snippet: fragment — JSX to place inside the Step 5 App component; showForm, editId and their setters are the state declared in the block above -->
 ```tsx
 <SchemaRenderer
   schema={{ type: 'object-grid', objectName: 'task' }}
@@ -314,6 +321,7 @@ it declaratively, with the spec's per-element `dataSource` binding
 (fetched through your data source's `getObjectSchema` / `listViews`) and
 composes that view's `filter` and `sort` onto the query for you:
 
+<!-- doc-snippet: fragment — an excerpt mixing a state declaration with the JSX it drives, to be placed inside the App component; it is not a standalone module -->
 ```tsx
 const [activeView, setActiveView] = useState('all');
 
@@ -352,6 +360,8 @@ server decides.
 Create a detail page that renders a single record with all its fields:
 
 ```tsx
+import { SchemaRenderer } from '@object-ui/react';
+
 function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => void }) {
   return (
     <div className="min-h-screen bg-background p-6">
@@ -390,6 +400,7 @@ Use this component in your main app with simple routing state, or integrate with
 
 **Environment config** — Keep your API URL configurable:
 
+<!-- doc-snippet: fragment — continues Step 4 — RestDataSource is the class defined there, and import.meta.env is Vite's typing in the reader's own app -->
 ```ts
 const dataSource = new RestDataSource(
   import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
@@ -402,6 +413,7 @@ const dataSource = new RestDataSource(
 
 **Authentication** — Extend `RestDataSource` to inject auth headers:
 
+<!-- doc-snippet: fragment — extends the RestDataSource class defined in Step 4 -->
 ```ts
 class AuthenticatedDataSource extends RestDataSource {
   constructor(baseUrl: string, private getToken: () => string) {

--- a/content/docs/guide/plugins.md
+++ b/content/docs/guide/plugins.md
@@ -203,6 +203,7 @@ Kanban board component with drag-and-drop powered by @dnd-kit.
 
 Plugins use React's `lazy()` and `Suspense` to load heavy dependencies on-demand:
 
+<!-- doc-snippet: fragment — excerpt of a plugin package's own source; './MonacoImpl' is a sibling file in the reader's package, not a module resolvable from this repo -->
 ```typescript
 // The plugin structure
 import React, { Suspense } from 'react'
@@ -248,6 +249,7 @@ Without lazy loading, all this code would be in your main bundle!
 
 Plugins automatically register their components when imported:
 
+<!-- doc-snippet: fragment — continues the block above — CodeEditorRenderer is defined there, and this line is the tail of the same plugin index.tsx -->
 ```typescript
 // In the plugin's index.tsx
 import { ComponentRegistry } from '@object-ui/core'
@@ -284,6 +286,7 @@ cd packages/plugin-myfeature
 
 ### 2. Create Heavy Implementation
 
+<!-- doc-snippet: fragment — the reader's new package importing its own heavy dependency; 'heavy-library' is a placeholder name, not an installed module -->
 ```typescript
 // src/MyFeatureImpl.tsx
 import HeavyLibrary from 'heavy-library'
@@ -295,6 +298,7 @@ export default function MyFeatureImpl(props) {
 
 ### 3. Create Lazy Wrapper
 
+<!-- doc-snippet: fragment — the reader's new src/index.tsx; './MyFeatureImpl' is the sibling file created in the previous step -->
 ```typescript
 // src/index.tsx
 import React, { Suspense } from 'react'
@@ -334,6 +338,7 @@ export interface MyFeatureSchema extends BaseSchema {
 
 ### 5. Configure Build
 
+<!-- doc-snippet: fragment — a vite.config.ts for the reader's plugin package; '@vitejs/plugin-react' is that package's devDependency, not this repo's -->
 ```typescript
 // vite.config.ts
 import { defineConfig } from 'vite'
@@ -420,6 +425,7 @@ Heavy imports go in the `*Impl.tsx` file.
 
 Always show a meaningful skeleton while loading:
 
+<!-- doc-snippet: fragment — a bare JSX excerpt showing the Suspense wrapper shape; Suspense, Skeleton, LazyComponent and props all come from the surrounding component -->
 ```typescript
 <Suspense fallback={
   <Skeleton className="w-full h-[400px]" />
@@ -432,6 +438,7 @@ Always show a meaningful skeleton while loading:
 
 Make your plugin type-safe:
 
+<!-- doc-snippet: fragment — re-export excerpt from the reader's package; './types' is the file created in step 4 -->
 ```typescript
 export type { MyFeatureSchema } from './types'
 ```
@@ -474,6 +481,7 @@ ls -lh dist/
 
 Check that you imported it in your app:
 
+<!-- doc-snippet: fragment — the app-side import of '@object-ui/plugin-myfeature', the package this guide teaches the reader to publish -->
 ```typescript
 import '@object-ui/plugin-myfeature'
 ```
@@ -482,6 +490,7 @@ import '@object-ui/plugin-myfeature'
 
 Make sure types are exported:
 
+<!-- doc-snippet: fragment — re-export from '@object-ui/plugin-myfeature', the reader's own published package -->
 ```typescript
 export type { MyFeatureSchema } from '@object-ui/plugin-myfeature'
 ```
@@ -499,6 +508,7 @@ Check that the implementation is in a separate file:
 
 Check that ComponentRegistry.register() is called at the module level:
 
+<!-- doc-snippet: fragment — a good/bad contrast pair; ComponentRegistry and MyFeatureRenderer are the ambient names of the plugin index.tsx being discussed -->
 ```typescript
 // ✅ Good - runs on import
 ComponentRegistry.register('my-feature', MyFeatureRenderer)

--- a/content/docs/rfcs/0001-clipboard-paste.md
+++ b/content/docs/rfcs/0001-clipboard-paste.md
@@ -162,6 +162,7 @@ Key rules:
 
 ### 5.1 Parser (`@object-ui/core/clipboard`)
 
+<!-- doc-snippet: fragment — RFC signature excerpt — parseClipboard is declared without a body because this section proposes the module's shape, not its implementation -->
 ```ts
 export interface ParsedClipboard {
   /** 2D string matrix, rows × cells, never null */
@@ -188,6 +189,7 @@ Parser handles:
 
 ### 5.2 Coercer (`@object-ui/core/clipboard`)
 
+<!-- doc-snippet: fragment — RFC signature excerpt — coerceCell is declared without a body; this section proposes the coercer surface, and nothing implements it yet -->
 ```ts
 export type CoercerType =
   | 'text' | 'number' | 'integer' | 'currency' | 'percent'
@@ -240,6 +242,7 @@ Coercion details per type (v1):
 
 ### 5.3 React Hook (`@object-ui/fields/clipboard`)
 
+<!-- doc-snippet: fragment — RFC signature excerpt — usePasteToGrid is declared without a body, and ColumnCoercer / CellRange are the types proposed in the sections above -->
 ```ts
 export interface UsePasteToGridOptions {
   /** Columns currently visible / pasteable, in visual order */
@@ -287,6 +290,7 @@ export function usePasteToGrid(opts: UsePasteToGridOptions): UsePasteToGridResul
 
 ### 5.4 Preview dialog component
 
+<!-- doc-snippet: fragment — a JSX usage sketch whose handler bodies are elided with '...'; it shows the proposed dialog's props, not runnable code -->
 ```tsx
 <PastePreviewDialog
   open
@@ -358,6 +362,7 @@ quick-paste is opt-in via `usePasteToGrid({ preview: 'auto' })`.
 
 Hosts expose paste behind a flag so apps can opt-in per grid:
 
+<!-- doc-snippet: fragment — a JSX sketch with the remaining ObjectGrid props elided as '...'; the point is the features key, not a complete element -->
 ```tsx
 <ObjectGrid
   features={{ clipboardPaste: 'preview' }}  // 'off' | 'preview' | 'auto'
@@ -373,6 +378,7 @@ stable release cycle the default becomes `'preview'`.
 
 ### 7.1 ObjectGrid (master, staged)
 
+<!-- doc-snippet: fragment — proposed host wiring — the hook, coercersFromObjectSchema, applyCommands and ObjectGridImpl are all names this RFC is proposing, and the element is elided with '...' -->
 ```tsx
 const { onPaste, previewDialog } = usePasteToGrid({
   columns: coercersFromObjectSchema(schema),
@@ -410,6 +416,7 @@ return (
 
 ### 7.2 EditableGridField (child, staged)
 
+<!-- doc-snippet: fragment — proposed host wiring for EditableGridField; usePasteToGrid, coercersFromGridFieldColumns and applyCommands are proposed names, and field/value/onChange are the component's own props -->
 ```tsx
 const { onPaste, previewDialog } = usePasteToGrid({
   columns: coercersFromGridFieldColumns(field.columns),

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -227,7 +227,7 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * Documents whose snippets are NOT compiled, each with the reason. The default
  * is covered; this list is the debt, by name, and it can only shrink.
  *
- * ⚠️ 9 of these entries are `.md` pages under `content/docs` that objectui#5174
+ * ⚠️ 5 of these entries are `.md` pages under `content/docs` that objectui#5174
  * made visible: the collector now reads `.md`, and an entry with a measured reason
  * is what a page that cannot pass yet is owed. They are DISCLOSED debt, not new
  * debt — every one of them was equally unverified before, just unnamed. Their
@@ -235,15 +235,32 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * package does not export is called out by name, because that is the
  * reader-visible half (objectui#5160).
  *
- * That count was 19 until objectui#5174's first triage batch, which walked TEN of
- * them OFF this list rather than re-wording their reasons: `api/schema-reference`,
- * `plugins/index`, and the `guide/` pages `architecture-overview`, `deployment`,
- * `expressions`, `notifications`, `public-forms`, `schema-overview`,
- * `troubleshooting` and `user-state-persistence`. The direction on that card is
- * entries LEAVING. Each page reached zero the honest two ways — a block that
- * should compile was made self-contained against the built `dist/`, and a block
- * that genuinely cannot compile got a `FRAGMENT_MARKER` declaration with a written
- * reason. Nothing about this gate's strictness moved to get them there.
+ * That count was 19 until objectui#5174's triage batches, which walk pages OFF this
+ * list rather than re-wording their reasons. The direction on that card is entries
+ * LEAVING. Batch 1 took ten: `api/schema-reference`, `plugins/index`, and the
+ * `guide/` pages `architecture-overview`, `deployment`, `expressions`,
+ * `notifications`, `public-forms`, `schema-overview`, `troubleshooting` and
+ * `user-state-persistence`. Batch 2 took four more — `guide/plugins`,
+ * `guide/building-crud-app`, `rfcs/0001-clipboard-paste` and `guide/architecture`
+ * — clearing 89 diagnostics. Each page reached zero the honest two ways — a block
+ * that should compile was made self-contained against the built `dist/`, and a
+ * block that genuinely cannot compile got a `FRAGMENT_MARKER` declaration with a
+ * written reason. Nothing about this gate's strictness moved to get them there.
+ *
+ * Batch 2's two routes in proportion, because the ratio is the reviewable part: it
+ * brought 42 blocks under the gate — 34 declared fragments and 8 that compile, of
+ * which 4 already compiled untouched and 4 were edited to. Three of those four
+ * edits were genuine documented-API defects the ledger had been hiding, and they
+ * are why a page like `guide/architecture` was worth covering rather than
+ * declaring wholesale: `building-crud-app`'s REST adapter
+ * passed `QueryParams['$orderby']` — a four-shape union — straight into
+ * `URLSearchParams.set`, which takes a string; its `TaskDetail` component used
+ * `SchemaRenderer` with no import of its own; and `guide/architecture`'s section
+ * titled "Type Safety", marked `// ✅ Type-checked`, set `ButtonSchema.onClick` to
+ * the STRING `'handleClick'` where the declared type is `() => void | Promise<void>`.
+ * The pages that are mostly fragments are mostly fragments for a stated reason:
+ * `guide/plugins` and the clipboard-paste RFC document packages the reader is being
+ * taught to create, and an RFC's signature excerpts have no bodies by design.
  *
  * objectui#5343 then read that list back and cleared it for the getting-started
  * pages: no entry for `content/docs/guide/**` or for
@@ -271,22 +288,6 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * @type {Record<string, string>}
  */
 const UNGATED_DOCS = {
-  'content/docs/guide/architecture.md':
-    '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
-    '13 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 3 unresolved-module diagnostic(s); plus TS2322x1 — candidate real ' +
-    'defects, un-triaged',
-  'content/docs/guide/building-crud-app.md':
-    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
-    '20 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 4 unresolved-module diagnostic(s); plus TS2339x1 TS2345x1 TS2882x1 — ' +
-    'candidate real defects, un-triaged. This entry read TS2305x2 TS2554x1 TS2724x1 until ' +
-    'objectui#5343: `registerAllComponents` (@object-ui/components) and the `ObjectSchema` / ' +
-    '`Field` builder pair (@object-ui/types) were fabricated. Registration is now what LOADING ' +
-    'the packages does (`initializeComponents()` plus the side-effect `@object-ui/fields` ' +
-    'import), which also retired the `registerAllFields(Registry)` arity error, and the object ' +
-    'metadata is the plain document a data source serves, with its `fields` record typed ' +
-    '`Record<string, FieldMetadata>`',
   'content/docs/guide/component-registry.md':
     '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '50 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -317,10 +318,6 @@ const UNGATED_DOCS = {
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
     'page never defines; 6 unresolved-module diagnostic(s); plus TS2339x5 TS2882x1 TS7006x3 — ' +
     'candidate real defects, un-triaged',
-  'content/docs/guide/plugins.md':
-    '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 6 unresolved-module diagnostic(s); plus TS2882x1 TS7006x3 — candidate ' +
-    'real defects, un-triaged',
   'content/docs/guide/schema-rendering.md':
     '8 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
@@ -355,10 +352,6 @@ const UNGATED_DOCS = {
     '43 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'content/docs/plugins/plugin-timeline.mdx':
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
-  'content/docs/rfcs/0001-clipboard-paste.md':
-    '7 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
-    '11 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; plus TS18004x1 TS2391x3 TS7006x1 — candidate real defects, un-triaged',
   'content/docs/utilities/create-plugin.mdx':
     '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
   'content/docs/utilities/data-objectstack.mdx':


### PR DESCRIPTION
Part of #5174 — batch 2. The card stays open: 5 `.md` guide entries remain after this.

## What this does

Walks four pages off `UNGATED_DOCS` in `scripts/check-doc-snippet-types.mjs`, clearing the 89 diagnostics they were carrying.

| page | diagnostics cleared | how |
|:--|--:|:--|
| `content/docs/guide/plugins.md` | 20 | 10 fragments declared, 2 blocks already compiled |
| `content/docs/guide/building-crud-app.md` | 21 | 7 fragments, 2 blocks fixed, 2 already compiled |
| `content/docs/rfcs/0001-clipboard-paste.md` | 23 | 7 fragments |
| `content/docs/guide/architecture.md` | 25 | 10 fragments, 2 blocks fixed |
| **total** | **89** | **34 fragments · 8 compiling (4 of them after an edit)** |

Ledger entries **53 → 49**. Covered documents **169 → 173**. 42 blocks newly under the gate.

Every page reached zero the two honest routes only — a block that should compile made self-contained against the built `dist/`, or a `FRAGMENT_MARKER` with a written measured reason for one that genuinely cannot. There is no third route in this diff.

## Three real documented-API defects the ledger was hiding

These are why covering `guide/architecture` and `building-crud-app` was worth doing rather than declaring them wholesale:

1. **`building-crud-app.md`** — the guide's `RestDataSource` passed `QueryParams['$orderby']` straight into `URLSearchParams.set`. `$orderby` is a **four-shape union** (an OData clause string · a `Record` mapping field name to `'asc'`/`'desc'` · `string[]` · an array of sort objects) and `set` takes a string (`TS2345`). Narrowed to the string form with a comment saying why, rather than stringifying a shape the server cannot parse.
2. **`building-crud-app.md`** — the `TaskDetail` component used `SchemaRenderer` with no import of its own. A reader copying that block got `TS2304`.
3. **`architecture.md`** — the section titled **Type Safety**, with the line marked `// ✅ Type-checked`, set `ButtonSchema.onClick` to the **string** `'handleClick'`. The declared type is a zero-argument function returning `void` or a promise of it (`TS2322`). The block now declares a handler and passes it.

The fourth edited block is `architecture.md`'s step-2 renderer example, which referenced a `schema` defined only in the step-1 `json` fence; it now carries that schema as a typed `BaseSchema` constant, so the block is copy-pasteable.

The pages that are mostly fragments are mostly fragments for a stated reason: `guide/plugins` and the clipboard-paste RFC document a package the reader is being *taught to create*, and an RFC's signature excerpts have no bodies by design. Every marker names which of those it is.

## The four binding invariants, measured

Diffed programmatically between `origin/main`'s copy of the script and this branch's copy:

| invariant | measured |
|:--|:--|
| covered set **strictly grows** | **169 → 173** documents |
| ⛔ no previously-covered document becomes ungated | `ADDED ledger entries: []` — and `previously-covered docs that are now UNGATED: []` |
| surviving entries keep **measured** reasons | `surviving entries with a non-measured reason: []` (49 checked) |
| ⛔ gate strictness never moves | proven byte-for-byte, below |

`REMOVED entries:` is exactly the four pages named above and nothing else.

**Strictness proven byte-for-byte, not argued.** Everything from the `// ── Fence scanning` banner to EOF — `scanFences`, `listDocuments`, `derivePackageTypePaths`, `analyze`, `compileSnippets`, the reporting and `main` — is **byte-identical to `origin/main`** (475 lines). `DOC_EXTENSIONS`, `TS_FENCE_LANGUAGES`, `FRAGMENT_MARKER`, `MIN_REASON_LENGTH` and `COMPILER_OPTIONS` each hash identical. The entire script diff is the four removed ledger entries plus the ledger's own docblock prose: **27 insertions, 34 deletions**.

## CI cost under the #4846 ruling — stated, not absorbed

`--build-filter` grew **19 → 20** filters (`@object-ui/plugin-dashboard`, pulled in by exactly one line: `guide/plugins.md`'s `import '@object-ui/plugin-dashboard'`).

**Turbo build tasks stayed 33 → 33**, and the two task sets are **identical package-by-package** from `--dry=json` (`tasks ADDED: []`, `tasks REMOVED: []`) — the new filter was already in the closure as a transitive dependency. Four more covered pages cost this gate zero extra build tasks. Nothing here for the maintainer to weigh.

(The real `turbo run build` reports **32** where `--dry=json` reports 33: the difference is `@object-ui/test-support#build`, which the dry run enumerates but which carries no build command. Both sides of the before/after comparison were measured the same way, so the delta of zero is unaffected.)

## Verification

All at `41addc61a`, working tree clean and byte-identical to what is pushed, union re-run after that commit, from the repo root, against a build of the gate's own filter closure (32 tasks, all successful, serialised through the container's shared heavy-verify entry point). Exit codes captured before any pipe; each line quotes the gate's own printed verdict.

- **`node scripts/check-doc-snippet-types.mjs`** → exit 0. `Scanned 222 document(s): 173 covered (37 of them hold a ts/tsx block), 49 ungated` · `Covered blocks: 203 — 135 to compile, 68 declared fragment(s).` · `Syntax phase: every block parsed, so every one of them reached the semantic phase.` · `Semantic phase: 135 of 135 block(s) judged, 0 failed.` · `Every covered documentation snippet compiles against the built types.` Controls green: resolution landed on `packages/types/dist/index.d.ts`, sentinel produced `TS2305`, positive control 0 diagnostics.
- **`scripts/__tests__/check-doc-snippet-types.test.ts`** → `Test Files 1 passed (1)` / `Tests 20 passed (20)`. Running the script is not running its test; both were run.
- **`check-doc-component-types`** → exit 0, `Every documented component type is registered.` (183 doc files, 1056 code blocks)
- **`check-doc-links`** → exit 0, `Links are valid across 13 scan roots.`
- **`check-control-bytes`** → exit 0, `OK (scanned 4950 tracked text file(s); skipped 85 binary)`, plus a manual control-byte grep over all five changed files: no hits.
- **`check-lint-coverage`** → exit 0, `46/46 packages linted, 0 with outstanding errors`.
- **Root eslint** (the exact `lint:root` invocation) → exit 0, `0 errors, 26 warnings`, all pre-existing; the one changed `.mjs` reports `errorCount 0, warningCount 0`.
- **`pnpm check`** (the CLI self-check the Lint workflow runs) → exit 0, `Analyzing 615 files... ✓ All checks passed`.

**Changeset: none owed, and no label.** `node scripts/check-changeset-presence.mjs` → exit 0: *"5 file(s) changed, 0 of them under the src/ of a package the release covers … No source of a released package changed in this range, so no changeset is owed."* Followed its verdict. ⛔ No `skip-changeset` label was applied: that label **is not a mechanism in this repo** — objectui#3724 established it was documented by a since-deleted second workflow inventory and "neither the workflow nor the label was ever real", a fact `scripts/__tests__/ci-cd-pipeline-doc.test.ts` still pins. `check-changeset-no-major` → exit 0.

**Lint scope, declared.** The root eslint task was run **whole**, not narrowed. Its population is read from eslint's own config via `--format json`: **166 files, of which 0 are `.md`** — linting a changed `.md` directly answers `File ignored because no matching configuration was supplied`, so four of the five changed files are outside eslint's population by its own configuration. The other 46 per-package `lint` tasks are scoped to `packages/*/`, `apps/*/` and `examples/*/`, which this diff does not touch at all.

**Fragment markers re-verified rather than inherited.** `fumadocs-mdx` 15.2.3 selects the compiler format by extension (`filePath.endsWith(".mdx") ? "mdx" : "md"`, read from its own dist, two call sites). All four changed `.md` files were then compiled through `@mdx-js/mdx` 3.1.1 in format `md`: all four compile, and `doc-snippet` occurs **0 times** in every compiled output against **34** occurrences in source.

### Reverse verification — prediction written before each run, direction included

No build artifact sits between the mutation and the thing under test on either leg: the mutation is markdown the gate reads straight from disk, and the `dist/*.d.ts` it compiles against is untouched, so no rebuild was needed. Each leg proved the mutation reached disk by grepping **the specific text meant to change** — never an editor's exit code — and each carried a `trap … EXIT INT TERM` restore.

**Leg 1** — revert `architecture.md` only, keep its ledger removal. *Predicted:* exit 1; exactly 25 diagnostics, all on that page; fragments 68 → 58; blocks-to-compile 135 → 145; the two edited blocks fail again as `TS2322` and `TS2304`; NOTE printed; direction **MORE** findings. *Observed:* exit 1; `25`, all on that page; `Covered blocks: 203 — 145 to compile, 58 declared fragment(s)`; `TS2304: Cannot find name 'schema'` and the `TS2322` on `onClick` (string not assignable to the handler type); NOTE printed. Match including direction.

**Leg 2** — revert all four pages, keep all four ledger removals. *Predicted:* exit 1; exactly **89** diagnostics split 20/21/23/25; fragments 68 → 34; blocks-to-compile 135 → 169; NOTE printed; direction **MORE**. *Observed:* exit 1; **89 exactly**, split `20 plugins / 21 building-crud-app / 23 clipboard-paste / 25 architecture` — matching the baseline to the unit and per page; `Covered blocks: 203 — 169 to compile, 34 declared fragment(s)`; `Syntax phase: 7 block(s) failed to parse`; NOTE printed. Match including direction.

**Restore leg run, not skipped:** `git status` clean, 34 markers back on disk, `git diff HEAD` empty, gate exit 0 with `135 of 135 block(s) judged, 0 failed`.

## Two dispatch measurements checked

- ✅ **`building-crud-app`'s recorded reason over-stated its debt.** It recorded `20 undefined-name / 4 unresolved-module`; measured **14 `TS2304` and 3 `TS2307`**. Confirmed exactly. The stale numbers were not copied forward — the entry is deleted, so the drift is retired rather than re-worded.
- ✅ **Nothing was mechanically clearable.** Re-measured: **zero** `TS2305`/`TS2724`/`TS2614` across all 89 diagnostics. #5343 cleared that class completely; every diagnostic here was genuine per-page fragment / self-containment judgement. ⛔ No fabricated symbol was re-decided per page.

## What is left on this card

5 `.md` guide entries: `plugin-development` 25 · `schema-rendering` 27 · `theming` 29 · `layout` 45 · `component-registry` 59 = **185 diagnostics**, plus 12 `.mdx` and 32 READMEs. `layout` and `component-registry` are 104 between them and are a batch of their own, as the batch-1 seat noted.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_