### PR TITLE
fix(i18n): the es pack says `Listo` at all four `Done` sites (#3880)

### DIFF
--- a/.changeset/3880-es-done-listo.md
+++ b/.changeset/3880-es-done-listo.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/i18n': patch
+---
+
+The Spanish pack renders `Done` as `Listo` at every one of the four sites that say it
+(objectui#3880, triage adjudication 2026-08-09). `grid.bulk.done` — the footer button that
+dismisses the bulk-action result dialog — read `Hecho` while `common.done`, `view.done` and
+`form.fullscreen.done` all read `Listo`, so the same English word rendered two ways in
+Spanish across dialogs a user meets in one session.
+
+Adjudicated a typo rather than a deliberate contextual split, on three checks. All four
+keys hold the byte-identical `en` value `Done`, and all four call sites are the same
+control: a dialog-footer button whose click finishes or dismisses the surface
+(`BulkActionDialog` `onClose(result)`, `ManageViewsDialog` `onOpenChange(false)`,
+`fullscreen-editor` `commitFullscreen`, `InviteMemberDialog`'s invitation-created footer).
+The nine other packs each render all four identically (de `Fertig`, fr `Terminé`, pt
+`Concluído`, ru `Готово`, ja `完了`, ko `완료`, zh `完成`, ar `تم`), so no other translation
+pass had found a context worth splitting on. And the neighbouring `Hecho`/`Deshecho`
+pairing that could have justified it does not hold: `grid.bulk.undo` is the verb `Deshacer`,
+and `Deshecho: ` is `undonePrefix`, a result-line status rather than a button.
+
+`Hecho` moved to the 3:1 majority `Listo`, which is the value objectui#3546 slice seven had
+already chosen for `common.done`. `packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx`
+pinned the old outlier as a recorded example of deliberate divergence; that pin now asserts
+the four as one value instead, and its note keeps the history plus the `Pending`/zh row,
+which remains a genuine deliberate split.
+
+No `en` value changes, so no other pack is asked to follow. This is the value half of
+objectui#3880 only — the card's 281/164 shared-string census stays on the card as
+documentation, and is explicitly not a gate: 164 of those groups diverge legitimately.

--- a/packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx
+++ b/packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx
@@ -552,16 +552,31 @@ describe('objectui#3546 slice seven — the ratchet residue', () => {
         );
       }
     }
-    // Recorded because it looks like an omission and is not: two other rows also
-    // say `Done`/`Pending` in `en` and already disagree with the chosen neighbour
-    // in one pack each — `grid.bulk.done` is es "Hecho" against "Listo", and
-    // `approvalsInbox.statusPending` is zh 待审批 ("awaiting approval"), which is
-    // wrong for an invitation. So the repo ALREADY renders these English strings
-    // more than one way, on purpose, and picking a neighbour is a choice that has
-    // to be made rather than derived.
+    // Recorded because it looks like an omission and is not: another row also
+    // says `Pending` in `en` and still disagrees with the chosen neighbour in one
+    // pack — `approvalsInbox.statusPending` is zh 待审批 ("awaiting approval"),
+    // which is wrong for an invitation. So the repo DOES render some English
+    // strings more than one way, on purpose, and picking a neighbour is a choice
+    // that has to be made rather than derived.
+    //
+    // `Done` stood beside it as the second example until objectui#3880, which
+    // adjudicated that one a typo rather than a choice: `grid.bulk.done` was es
+    // "Hecho" against "Listo" at the other three sites, and all four are the same
+    // dialog-footer button that finishes the surface — `grid.bulk.done` closes the
+    // bulk result dialog, `view.done` closes ManageViewsDialog, `form.fullscreen.done`
+    // commits and leaves the fullscreen editor, `common.done` closes the invitation
+    // footer — with no grammatical divergence to carry. The nine other packs each
+    // render all four identically, so no pack had found a contextual reason to
+    // split them. It converged on the 3:1 majority `Listo`, which is also the value
+    // this slice had already chosen for `common.done`. The four are pinned together
+    // below so the outlier cannot regrow, and the `Done` family is no longer an
+    // example of deliberate divergence — only `Pending` is.
     expect(at(builtInLocales.en, 'grid.bulk.done')).toBe('Done');
-    expect(at(builtInLocales.es, 'grid.bulk.done')).toBe('Hecho');
-    expect(at(builtInLocales.es, 'view.done')).toBe('Listo');
+    for (const key of ['common.done', 'view.done', 'form.fullscreen.done', 'grid.bulk.done']) {
+      expect(at(builtInLocales.es, key), `es ${key} (objectui#3880 converged these on one value)`).toBe(
+        'Listo',
+      );
+    }
     expect(at(builtInLocales.zh, 'approvalsInbox.statusPending')).toBe('待审批');
     expect(at(builtInLocales.zh, 'organization.invitations.status.pending')).toBe('等待中');
   });

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -339,7 +339,7 @@ const es = {
       running: "Ejecutando…",
       undo: "Deshacer",
       undoing: "Deshaciendo…",
-      done: "Hecho",
+      done: "Listo",
       selectPlaceholder: "Seleccionar…",
       loading: "Cargando…",
     },


### PR DESCRIPTION
Part of #3880

`Part of`, not a closing keyword, on purpose — see "What stays on the card" below. Two of
that card's three halves are not delivered here: one is documentation by ruling, and one
had its premise fall out from under it.

## The change

One Spanish value, plus the pin that recorded it.

`grid.bulk.done` read `Hecho` while the other three sites that say `Done` in `en` —
`common.done`, `view.done`, `form.fullscreen.done` — all read `Listo`. It moves to `Listo`.

## Why this is a typo and not a deliberate contextual split

That distinction is the whole risk on this card: **58% of shared English strings in this
repo are translated differently per key on purpose** (ru `Delete` is the noun `Удаление`
for an activity-feed event type and the verb `Удалить` elsewhere; ja `Clear` is `選択解除`
for `grid.bulkClear`). So "make identical English identical" is the wrong instinct by
default, and each of these has to be argued rather than swept. Three independent checks,
each of which could have stopped the change:

1. **The `en` values are byte-identical.** Measured by flattening all ten packs to dotted
   key paths and grouping by exact value, not by grepping for a spelling: exactly four keys
   hold the `en` value `Done`.

2. **All four call sites are the same control** — a dialog-footer button whose click
   finishes or dismisses the surface. Read at the call site, not inferred from the key name:

   | key | file | handler |
   |---|---|---|
   | `grid.bulk.done` | `packages/plugin-grid/src/components/BulkActionDialog.tsx:557` | `onClose(result)` |
   | `view.done` | `packages/plugin-view/src/ManageViewsDialog.tsx:583` | `onOpenChange(false)` |
   | `form.fullscreen.done` | `packages/components/src/custom/fullscreen-editor.tsx:432` | `commitFullscreen` |
   | `common.done` | `packages/app-shell/src/console/organizations/manage/InviteMemberDialog.tsx:216` | invitation-created footer |

3. **The nine other packs render all four identically** — de `Fertig`, fr `Terminé`, pt
   `Concluído`, ru `Готово`, ja `完了`, ko `완료`, zh `完成`, ar `تم`. Nine independent
   translation passes each found no context worth splitting on. This is the check that
   separates this group from the legitimate divergences above, where the split *is* visible
   in the data.

One hypothesis that would have justified `Hecho` was tested and refuted: the sibling
`grid.bulk.undonePrefix` is `Deshecho: `, which looks like a deliberate `Hecho`/`Deshecho`
pairing. It is not one — `undonePrefix` is a **result-line status** rendered at
`BulkActionDialog.tsx:461` when `undoneAt !== null`, while `done` is a **button**; the
button `done` would pair with `grid.bulk.undo`, and that is the verb `Deshacer`.

`Listo` is the 3:1 majority and is already the value #3546 slice seven chose for
`common.done`.

## The pin

`packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx` named this value as a
**recorded example of deliberate divergence** — the evidence for "picking a neighbour is a
choice that has to be made rather than derived". That note is now false for `Done`, so it is
rewritten rather than merely re-valued: it keeps the history and the `Pending`/zh row (which
is still a genuine deliberate split), and pins the four `Done` values together so the
outlier cannot regrow. The `REUSED` list itself is unchanged — its `['common.done',
'view.done']` row was already `Listo` on both sides.

**Reverse-verified**: with the fix reverted on disk (mutation confirmed by anchored counts —
`"Hecho"` 1, `"Listo"` 3 where it had been 4 — not by an editor exit code), the pin fails
with `AssertionError: es grid.bulk.done (objectui#3880 converged these on one value):
expected 'Hecho' to be 'Listo'`, 1 failed / 42 passed. The restore leg is proven clean:
`git diff` vs `HEAD` is empty and `"Hecho"` is back to 0 occurrences in `es.ts`. The
mutation script carried a `trap … EXIT INT TERM` restore.

## What stays on the card

- **The 281/164 denominator is documentation, by ruling, and is not implemented here.** 281
  `en` strings are shared by ≥2 keys; 164 have a legitimately divergent translation in at
  least one pack. A "same `en` implies same translation" gate would emit 164 false reds, so
  no lint rule, script or test asserting that invariant is added by this PR.
- **The card's second typo group — de `Loading...` — is not delivered, because its premise
  no longer holds.** The card cited `common.loading` `Wird geladen...` against
  `detail.loading` `Laden...`, both ASCII. There is **no ASCII `...` left in any of the ten
  packs**: #3878 landed as PR #4378 and converged every one on U+2026, and both of these
  keys are named in that pass's own `CONVERGED_KEYS` census in
  `packages/i18n/src/__tests__/ellipsis-glyph-3878.test.ts`. That merged the ASCII and
  U+2026 groups, so what the card saw as a 2-key pair is now **one 10-key group carrying
  four German spellings**: `Wird geladen…` ×6, `Laden…` ×2 (`detail.loading` **and**
  `report.loading`), `Lade…` ×1 (`auth.device.loading`), `Lädt…` ×1
  (`approvalsInbox.loadingMore`). Changing only the key the card named would leave
  `report.loading` — the identical spelling at an equally same-context site — untouched, so
  the majority-vote argument that settles `Done` cleanly does not transfer. That is a
  different decision than the one adjudicated on 2026-08-09 and it is filed separately
  rather than half-made here.

## Verification

All at `88707ef9` (the pushed commit), each exit code captured before any pipe:

| check | verdict |
|---|---|
| `pnpm exec vitest run packages/i18n/` | `Test Files 53 passed (53)` · `Tests 893 passed (893)` |
| `pnpm --filter @object-ui/i18n type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `check:i18n-drift` | `0 en value(s) changed … No en value changed in this range.` |
| `check:i18n-keys` | `Every in-scope call-site key resolves against the en pack (2934 keys)` |
| `check:i18n-dead-keys` | exit 0 (report, not a gate) |
| `check:control-bytes` | `OK (scanned 4951 tracked text file(s))` |
| `check-changeset-no-major.mjs` | `No changeset declares a major bump.` |

`check:i18n-drift` reporting **zero** `en` changes is the intended reading, not an empty
result: only an `es` value moved, so no pack is asked to follow and no waiver is needed.

**Lint is a declared narrowing, not a full run.** `npx eslint . --no-inline-config` was run
in `packages/i18n` — the only package with code changes — giving exit 0, 0 errors, 34
pre-existing warnings, over **78 files that eslint's own config selected** (count read from
`--format json`, not enumerated by hand); both changed files are in that set at 0/0. The
narrowing excludes nothing: **type-aware linting is not configured** (no `projectService`
and no `parserOptions.project` in `eslint.config.js` — verified with a control probe proving
the grep is well-formed), so a file's verdict depends only on that file plus the shared
config, and this diff changes neither the config nor any file outside `packages/i18n`. CI
runs the full farm regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_