### PR TITLE
fix(scripts): add allowImportingTsExtensions to tsconfig.scripts.json

### DIFF
--- a/scripts/__tests__/scripts-type-check.test.ts
+++ b/scripts/__tests__/scripts-type-check.test.ts
@@ -33,6 +33,7 @@ import ts from 'typescript';
  */
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const configPath = path.join(repoRoot, 'tsconfig.scripts.json');
+const consoleNodeConfigPath = path.join(repoRoot, 'apps/console/tsconfig.node.json');
 const scriptsDir = path.join(repoRoot, 'scripts');
 const ciWorkflowPath = path.join(repoRoot, '.github/workflows/ci.yml');
 
@@ -52,6 +53,29 @@ function parsedProject(): ts.ParsedCommandLine {
   ).toBeFalsy();
 
   return ts.parseJsonConfigFileContent(read.config, ts.sys, repoRoot, undefined, configPath);
+}
+
+/**
+ * `apps/console/tsconfig.node.json`, parsed the same way — the other program
+ * that compiles `scripts/vite-crypto-stub.ts` and
+ * `scripts/vite-maplibre-worker.ts` (see this file's header). Used only to
+ * read its `compilerOptions`; its own `include`/`fileNames` are irrelevant
+ * here.
+ */
+function parsedConsoleNodeProject(): ts.ParsedCommandLine {
+  const read = ts.readConfigFile(consoleNodeConfigPath, ts.sys.readFile);
+  expect(
+    read.error && ts.flattenDiagnosticMessageText(read.error.messageText, ' '),
+    'apps/console/tsconfig.node.json must parse as JSON with comments',
+  ).toBeFalsy();
+
+  return ts.parseJsonConfigFileContent(
+    read.config,
+    ts.sys,
+    path.dirname(consoleNodeConfigPath),
+    undefined,
+    consoleNodeConfigPath,
+  );
 }
 
 /** Every TypeScript source on disk under `scripts/`, repo-relative, POSIX-separated. */
@@ -106,6 +130,69 @@ describe('tsconfig.scripts.json — the project itself (objectui#3494)', () => {
     // on the symptom.
     expect(options.composite, 'a composite project may not set "noEmit" (TS6310)').toBeFalsy();
     expect(parsedProject().projectReferences ?? [], 'this project must stay standalone').toEqual([]);
+  });
+});
+
+describe('tsconfig.scripts.json — option parity with apps/console/tsconfig.node.json (objectui#4926)', () => {
+  /**
+   * `scripts/vite-crypto-stub.ts` and `scripts/vite-maplibre-worker.ts` are
+   * compiled by BOTH this project and `apps/console/tsconfig.node.json` (see
+   * this file's header, and that file's own header). This file's header
+   * states the invariant that makes sharing them safe: the two projects'
+   * option sets match on the axes that matter, "so a shared file cannot be
+   * green in one project and red in the other."
+   *
+   * objectui#4926 found that invariant asserted but not enforced:
+   * `allowImportingTsExtensions` diverged (present in the console project,
+   * absent here) with nothing to catch it — the gap stayed latent only
+   * because neither shared file happens to use a `.ts`-extension import
+   * today. This test is what the issue says would have caught it: it reads
+   * both parsed configs and asserts the specific options the header claims
+   * are matched, rather than trusting the prose.
+   *
+   * Scope, deliberately narrow: only the options this file's header names as
+   * matched (strict, module, moduleResolution, allowImportingTsExtensions,
+   * and the absence of noImplicitReturns). The two projects differ on plenty
+   * else by design (`composite`, `outDir`, `rootDir`, `allowJs`, `target`,
+   * emit) — those are NOT part of the stated invariant, and asserting them
+   * equal would just recreate the `extends` trap this file's header
+   * explains at length why it avoids.
+   */
+  it('matches the option set apps/console/tsconfig.node.json compiles the shared files with', () => {
+    const scripts = parsedProject().options;
+    const consoleNode = parsedConsoleNodeProject().options;
+
+    expect(scripts.strict, 'tsconfig.scripts.json').toBe(true);
+    expect(consoleNode.strict, 'apps/console/tsconfig.node.json').toBe(true);
+
+    expect(scripts.module, 'tsconfig.scripts.json "module"').toBe(consoleNode.module);
+    expect(
+      scripts.moduleResolution,
+      'tsconfig.scripts.json "moduleResolution"',
+    ).toBe(consoleNode.moduleResolution);
+
+    // The option objectui#4926 was filed over: `apps/console/vite.config.ts`
+    // imports `../../scripts/vite-crypto-stub.ts` and
+    // `../../scripts/vite-maplibre-worker.ts` with explicit `.ts` extensions
+    // (objectui#3384), which only `allowImportingTsExtensions` accepts.
+    expect(
+      consoleNode.allowImportingTsExtensions,
+      'apps/console/tsconfig.node.json must still set "allowImportingTsExtensions" — if this ' +
+        'assertion is what broke, the fix belongs in tsconfig.scripts.json below, not here.',
+    ).toBe(true);
+    expect(
+      scripts.allowImportingTsExtensions,
+      'tsconfig.scripts.json must set "allowImportingTsExtensions": true to match ' +
+        'apps/console/tsconfig.node.json — otherwise a `.ts`-extension import in a file shared ' +
+        'between the two programs (scripts/vite-crypto-stub.ts, scripts/vite-maplibre-worker.ts) ' +
+        'type-checks in one and not the other (objectui#4926).',
+    ).toBe(true);
+
+    // Both projects deliberately leave `noImplicitReturns` off — see this
+    // file's header. Asserted as an explicit falsy-equality, not just
+    // "both truthy", so a future divergence in either direction is caught.
+    expect(scripts.noImplicitReturns, 'tsconfig.scripts.json "noImplicitReturns"').toBeFalsy();
+    expect(consoleNode.noImplicitReturns, 'apps/console/tsconfig.node.json "noImplicitReturns"').toBeFalsy();
   });
 });
 

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -18,9 +18,12 @@
 // honest, and the moment the console stops importing one of them it would drop
 // out of every program silently. Covering the whole directory means there is no
 // such question. The cost of the overlap is paid by matching that project's
-// option set (strict, ESNext, bundler resolution, and notably NO
-// `noImplicitReturns`), so a shared file cannot be green in one project and red
-// in the other.
+// option set (strict, ESNext, bundler resolution, `allowImportingTsExtensions`,
+// and notably NO `noImplicitReturns`), so a shared file cannot be green in one
+// project and red in the other. `scripts/__tests__/scripts-type-check.test.ts`
+// asserts this parity against `apps/console/tsconfig.node.json` directly
+// (objectui#4926) — it is what would have caught `allowImportingTsExtensions`
+// missing here.
 //
 // Deliberately NOT `"extends": "./tsconfig.base.json"`: that file is the PACKAGE
 // BUILD config, and its `exclude` lists the test globs. Inheriting it would
@@ -48,6 +51,21 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "types": ["node"],
+
+    // Matches `apps/console/tsconfig.node.json`'s option set (see the file
+    // header above) — that project's `vite.config.ts` imports
+    // `../../scripts/vite-crypto-stub.ts` and
+    // `../../scripts/vite-maplibre-worker.ts` with explicit `.ts` extensions
+    // (objectui#3384), which needs `allowImportingTsExtensions`. This project
+    // doesn't itself need it today — the shared files' own imports carry no
+    // `.ts` extension — but without it here, a `.ts`-extension import added to
+    // either shared file, or a widening of `include` below to reach a `.ts`
+    // importer that spells extensions this way, would type-check in one
+    // project and not the other: exactly the gap this file's header says the
+    // matched option set prevents. Legal here because `noEmit` is `true`
+    // (`allowImportingTsExtensions` requires `noEmit` / `emitDeclarationOnly` /
+    // `rewriteRelativeImportExtensions`).
+    "allowImportingTsExtensions": true,
 
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Fixes #4926

## What

`tsconfig.scripts.json`'s header claims it matches `apps/console/tsconfig.node.json`'s option set so the two files shared between both programs (`scripts/vite-crypto-stub.ts`, `scripts/vite-maplibre-worker.ts`) "cannot be green in one project and red in the other." It omitted `allowImportingTsExtensions`, which the console project sets (line 30) because `apps/console/vite.config.ts` imports the shared files with explicit `.ts` extensions (objectui#3384).

- Added `"allowImportingTsExtensions": true` to `tsconfig.scripts.json` (legal under its existing `noEmit: true`), and expanded the header comment to name it as part of the matched set.
- Added an option-parity assertion test in `scripts/__tests__/scripts-type-check.test.ts` that reads both parsed tsconfigs and asserts `strict`, `module`, `moduleResolution`, `allowImportingTsExtensions`, and the absence of `noImplicitReturns` agree — narrowly scoped to only the options the header itself claims are matched (not `composite`/`outDir`/`rootDir`/`allowJs`/`target`/emit, which differ by design). This is the pin location the issue itself named.

## Mechanism finding (dispatch's open question)

The dispatch asked whether the divergence produces a live red today or is latent. **Confirmed latent** — `pnpm type-check:scripts` is green both before and after this change; neither shared file itself contains a `.ts`-extension import.

I did find where `allowImportingTsExtensions` is actually exercised (something the PM's `./`-relative grep missed, since these are `../../`-relative):

```
$ grep -n "scripts/vite-" apps/console/vite.config.ts
17:import { viteCryptoStub } from '../../scripts/vite-crypto-stub.ts';
18:import { viteMaplibreWorker } from '../../scripts/vite-maplibre-worker.ts';
19:import { resolveSpecDistInjection } from '../../scripts/vite-objectstack-spec-dist.ts';
```

That's on the console side, inside `apps/console/tsconfig.node.json`'s own program — not inside `tsconfig.scripts.json`'s (`include: ["scripts/**/*.ts"]` never reaches `apps/console/vite.config.ts`). To reproduce the issue's own repro exactly, I widened a scratch copy of `tsconfig.scripts.json` to also include `apps/console/vite.config.ts` (not committed) and reran `tsc`:

```
apps/console/vite.config.ts(17,32): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/console/vite.config.ts(18,36): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/console/vite.config.ts(19,42): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
```

Same three TS5097s the issue reported. So: **invariant restoration, not a live-bug fix** — the gap surfaces only if a shared file gains a `.ts`-extension import, or the scripts program's `include` widens to reach a file that has one (exactly the shape the header defends against). Reverse-verified the new pin test on the *committed* fix by checking out the pre-fix `tsconfig.scripts.json` from `origin/main` and rerunning — the new assertion failed with the expected message, then I restored the fix from `HEAD`.

## Scope

Per dispatch: this PR touches only the one option-set divergence. `tsconfig.scripts.json` is **not** restructured to `extends` anything (its header's `tsconfig.base.json`-`exclude` reasoning stands, unchallenged). No other option differences between the two projects were found or touched.

## Tests

- `pnpm type-check:scripts` — clean (before and after).
- `pnpm --filter '@object-ui/console^...' build` then `pnpm --filter '@object-ui/console' type-check` (`tsc --noEmit && tsc -b tsconfig.node.json --force`) — clean.
- `npx vitest run scripts/__tests__` — 62 test files, 1665 tests, all passing (includes the new assertion, 9/9 in `scripts-type-check.test.ts`, up from 8/8).
- `node scripts/check-type-check-coverage.mjs` — ✅ (45/46 via `type-check`, unrelated pre-existing 1 not-compiled; 41/41 test coverage).
- `node scripts/check-changeset-presence.mjs` — ✅ no changeset owed (tooling config + test file, not a published package's `src/`).
- `node scripts/check-control-bytes.mjs` — ✅ clean.
- `npx eslint scripts/__tests__/scripts-type-check.test.ts --no-inline-config` — 0 errors.

Verified at `2ce7ee4de` (branch head).

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_