### PR TITLE
fix(lint): correctly place two misplaced eslint-disable-next-line directives

### DIFF
--- a/.changeset/4850-misplaced-eslint-disable.md
+++ b/.changeset/4850-misplaced-eslint-disable.md
@@ -1,0 +1,21 @@
+---
+---
+
+Comment-only fix: two `eslint-disable-next-line` directives were placed on the
+wrong line and had never suppressed anything since they landed.
+
+- `apps/console/src/pages/developer/PublicFormsPage.tsx` — the
+  `react-hooks/exhaustive-deps` directive was an inline block comment inside the
+  `useEffect(() => { load(); }, [])` statement, so its "next line" was a blank
+  line, not the statement itself. Moved above the statement with the reason
+  written out (mount-once by design; refresh is explicit via the Refresh
+  button and post-mutation `await load()` calls).
+- `packages/react/src/SchemaRenderer.tsx` — the
+  `@typescript-eslint/no-explicit-any` directive's `--` reason wrapped onto a
+  second comment line, so its "next line" was that continuation comment, not
+  `type ForwardedProps = Record<string, any>;`. Collapsed to one line so the
+  directive is immediately above its target.
+
+No logic changes. Verified with `eslint --report-unused-disable-directives`:
+both directives are now effective (the two warnings they were meant to
+suppress are gone) and neither directive is reported unused.

--- a/apps/console/src/pages/developer/PublicFormsPage.tsx
+++ b/apps/console/src/pages/developer/PublicFormsPage.tsx
@@ -179,6 +179,12 @@ export function PublicFormsPage() {
     }
   };
 
+  // `load` is intentionally omitted from the dependency array: this effect is a
+  // mount-once fetch. Refresh is driven by the explicit Refresh button
+  // (`onClick={load}` below) and by explicit `await load()` calls after
+  // publish/save (see the file-level doc comment), not by re-running on every
+  // `load` identity change.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { load(); }, []);
 
   const origin = typeof window !== 'undefined' ? window.location.origin : '';

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -411,6 +411,7 @@ export interface SchemaRendererProps {
  * and `packages/react/README.md` documents callers relying on it. The `any` is
  * the point: this is a pass-through channel, not a typed prop.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see doc comment above: the forwarded value is opaque to this component by construction.
 type ForwardedProps = Record<string, any>;
 
 /**


### PR DESCRIPTION
Fixes #4850

## What

PR #4849 (#4833's cleanup) deleted two `eslint-disable-next-line` directives
because ESLint reported them as unused — but "unused" meant *misplaced*, not
*stale*: each directive's "next line" landed on a comment/blank line instead
of the statement its author meant to cover, so the warning it targeted had
never actually been suppressed since the directive was written. Deleting them
(the correct call for the other 47 sites in that cleanup) left the two real
warnings unsuppressed, and left the "should this be suppressed at all"
decision unmade — this PR makes that decision and restores correct placement.

- **`apps/console/src/pages/developer/PublicFormsPage.tsx`** —
  `react-hooks/exhaustive-deps` on `useEffect(() => { load(); }, [])`. The
  directive used to be an inline block comment *inside* the statement, so its
  "next line" was a blank line. **Decision: A2** (mount-once is deliberate,
  not a bug) — the file's own doc comment already states refresh is via the
  explicit Refresh button; `load()` is also called explicitly after
  publish/save. Moved the directive above the statement with the reason
  spelled out inline.
- **`packages/react/src/SchemaRenderer.tsx`** —
  `@typescript-eslint/no-explicit-any` on
  `type ForwardedProps = Record<string, any>;`. The directive's `--` reason
  wrapped onto a second `//` comment line, so its "next line" was that
  continuation, not the type declaration. **Decision: B1** — collapsed to one
  line; the existing doc comment directly above already documents the `any`
  as deliberate (open pass-through forwarding surface).

No logic changes — comment-only diff.

## Measured, not eyeballed

`pnpm exec eslint <file> --report-unused-disable-directives -f json` on the
two files, before vs. after:

| Site | Before | After |
|---|---|---|
| `PublicFormsPage.tsx:182` `react-hooks/exhaustive-deps` | reported (directive present but inert) | suppressed |
| `SchemaRenderer.tsx:414` `@typescript-eslint/no-explicit-any` | reported (directive present but inert) | suppressed |
| Unused-disable-directive messages in either file | 0 | 0 (both directives are now load-bearing) |

No new warning appeared at either site (checked the Zone-3 trap: a directive
that suppresses *nothing* and one that suppresses *the wrong thing* look
identical in a diff — confirmed the intended rule, and only that rule, is now
quiet).

Package-level `lint` (reverse-verified: reverted the two files to
`origin/main` @ `2aff580b5`, ran lint, restored):

| Package | Before | After |
|---|---|---|
| `@object-ui/react` | 354 warnings | 353 warnings |
| `@object-ui/console` | 202 warnings | 201 warnings |

Full root `pnpm lint` (the `Lint` workflow's gate) after the fix, at
`e31c8116b`: **47/47 tasks successful, 0 errors, 10721 warnings total**
(matches an independent repo-root `eslint . --report-unused-disable-directives -f json`
scan: 3621 files, 10721 warnings, 2 errors — both from `--report-unused-disable-directives`
itself flagging 2 *unrelated, pre-existing* stale directives, filed separately
as objectstack-ai/objectui#5973, not touched here). Pre-fix full-repo total is
10723 by construction (10721 + the 2 confirmed per-file suppressions above;
not independently re-run repo-wide to avoid a second ~4-minute full lint pass
whose only new information would be that same arithmetic).

## Coupling with #4853 (queued, not dispatched)

#4853 proposes `linterOptions.reportUnusedDisableDirectives: 'error'` on the
stated precondition that ineffective directives are at zero via #4833/PR
#4849. **On current `main`, that precondition already holds**: the two
misplaced directives this PR fixes were *deleted* by PR #4849, not left
broken — so `origin/main` currently has zero eslint-disable directives
suppressing nothing due to placement. This PR doesn't change that zero (it
adds two new, verified-effective directives); it closes the *content* gap
#4849 explicitly left open (restoring intended suppression, a decision #4849
deliberately deferred). Not enabling the gate here — that stays #4853's call.

## Scope

Only these two directives (measured via ESLint, matching the count named in
#4850). One additional pair of now-stale (not misplaced) directives was found
while measuring and filed separately, out of scope for this PR:
objectstack-ai/objectui#5973.

## Changeset

Comment-only, no published behavior change — `.changeset/4850-misplaced-eslint-disable.md`
with empty frontmatter, verified via `node scripts/check-changeset-presence.mjs`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_