### PR TITLE
perf(scripts): drop unused setParentNodes in moduleSpecifiers()

### DIFF
--- a/scripts/__tests__/check-phantom-dependencies.test.ts
+++ b/scripts/__tests__/check-phantom-dependencies.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 import {
   ALL_FIELDS,
@@ -187,6 +188,98 @@ type T = import('theta').Thing;
     const found = moduleSpecifiers("\n\nimport x from 'alpha';\n", 'probe.ts');
     expect(found).toHaveLength(1);
     expect(found[0].line).toBe(3);
+  });
+});
+
+describe('setParentNodes is OFF, because nothing here reads a parent (objectui#5410)', () => {
+  it('the parser call spells it out as a deliberate `false`, not a bare positional', () => {
+    // Regression pin on the source text itself. A silent flip back to `true`
+    // would cost every one of this file's callers a full linking pass over the
+    // parsed tree for a pointer nothing here follows, and would do it invisibly
+    // — the CLI's output does not change either way (see the next test).
+    const gate = fs.readFileSync(path.join(repoRoot, GATE), 'utf8');
+    expect(gate).toMatch(
+      /ts\.createSourceFile\(\s*fileName,\s*text,\s*ts\.ScriptTarget\.Latest,\s*\/\*\s*setParentNodes\s*\*\/\s*false,\s*ts\.ScriptKind\.TSX\s*\)/,
+    );
+  });
+
+  it('a tree parsed with setParentNodes: false has no `.parent`, and getStart(source) still works', () => {
+    // Demonstrates the mechanism the comment in the gate claims, rather than
+    // trusting the claim: with parent nodes off, `.parent` is genuinely absent
+    // on every node this walk visits, and `getStart(source)` — called with the
+    // source file passed EXPLICITLY, as moduleSpecifiers() does — still resolves
+    // a position without needing to climb to `.parent` to find it.
+    const source = ts.createSourceFile('probe.ts', "import a from 'alpha';\n", ts.ScriptTarget.Latest, false, ts.ScriptKind.TSX);
+    let importNode: ts.Node | undefined;
+    ts.forEachChild(source, (node) => {
+      if (ts.isImportDeclaration(node)) importNode = node;
+    });
+    expect(importNode).toBeDefined();
+    expect((importNode as ts.Node & { parent?: ts.Node }).parent).toBeUndefined();
+    expect(() => importNode!.getStart(source)).not.toThrow();
+  });
+
+  it('moduleSpecifiers() output is unaffected — pinned against the true/false parity measured for objectui#5410', () => {
+    // Not a re-measurement of the ~3,300-file repository corpus (that lives in
+    // the PR that closed objectui#5410, run once as a manual check, not as a
+    // per-commit test); this is the same claim on a fixture small enough to
+    // pin: every form moduleSpecifiers() recognizes, parsed both ways, must
+    // produce byte-identical findings.
+    const src = `import a from 'alpha';
+import type { B } from 'beta';
+export { c } from 'gamma';
+export type { D } from 'delta';
+import epsilon = require('epsilon');
+const z = require('zeta');
+const lazy = () => import('eta');
+type T = import('theta').Thing;
+import './local';
+`;
+    const withParents = moduleSpecifiers(src, 'probe.ts');
+
+    // The reference computed independently, with the flag pinned to `true`
+    // rather than imported from the gate, so this test cannot pass merely
+    // because both sides read the same (possibly-regressed) constant.
+    function moduleSpecifiersWithParents(text: string, fileName: string) {
+      const source = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+      const found: { specifier: string; kind: string; typeOnly: boolean; line: number; column: number }[] = [];
+      const push = (node: ts.Node, specifier: string, kind: string, typeOnly: boolean) => {
+        const { line, character } = source.getLineAndCharacterOfPosition(node.getStart(source));
+        found.push({ specifier, kind, typeOnly, line: line + 1, column: character + 1 });
+      };
+      const visit = (node: ts.Node) => {
+        if (ts.isImportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+          push(node, node.moduleSpecifier.text, 'import', Boolean(node.importClause?.isTypeOnly));
+        } else if (ts.isExportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+          push(node, node.moduleSpecifier.text, 'export', Boolean(node.isTypeOnly));
+        } else if (
+          ts.isImportEqualsDeclaration(node) &&
+          ts.isExternalModuleReference(node.moduleReference) &&
+          ts.isStringLiteral(node.moduleReference.expression)
+        ) {
+          push(node, node.moduleReference.expression.text, 'import=', false);
+        } else if (
+          ts.isImportTypeNode(node) &&
+          ts.isLiteralTypeNode(node.argument) &&
+          ts.isStringLiteral(node.argument.literal)
+        ) {
+          push(node, node.argument.literal.text, 'import()-type', true);
+        } else if (ts.isCallExpression(node)) {
+          const argument = node.arguments[0];
+          if (argument && ts.isStringLiteral(argument)) {
+            if (node.expression.kind === ts.SyntaxKind.ImportKeyword) push(node, argument.text, 'dynamic import()', false);
+            else if (ts.isIdentifier(node.expression) && node.expression.text === 'require') {
+              push(node, argument.text, 'require()', false);
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+      return found;
+    }
+
+    expect(withParents).toEqual(moduleSpecifiersWithParents(src, 'probe.ts'));
   });
 });
 

--- a/scripts/check-phantom-dependencies.mjs
+++ b/scripts/check-phantom-dependencies.mjs
@@ -362,7 +362,18 @@ export function listSourceFiles(dir, found = []) {
  * @returns {{ specifier: string, kind: string, typeOnly: boolean, line: number, column: number }[]}
  */
 export function moduleSpecifiers(text, fileName = 'file.tsx') {
-  const source = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  // setParentNodes is false BY DESIGN, not by oversight: this walk only ever
+  // descends (`ts.forEachChild`, never `.parent`), and the one position lookup
+  // below calls `node.getStart(source)` with the source file passed EXPLICITLY —
+  // exactly the form that skips TypeScript's own `.parent`-walking fallback
+  // (`getTokenPosOfNode`'s `sourceFile ?? getSourceFileOfNode(node)`). `source`
+  // is local to this function and never escapes to a caller who might walk
+  // upward, so no consumer of `moduleSpecifiers()` can read a parent either.
+  // Setting the flag costs TypeScript a full second linking pass over the
+  // parsed tree for a pointer this parser never follows — confirmed unused by
+  // running both settings over every file in this repository and diffing the
+  // JSON output byte-for-byte (objectui#5410).
+  const source = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, /* setParentNodes */ false, ts.ScriptKind.TSX);
   const found = [];
   const push = (node, specifier, kind, typeOnly) => {
     const { line, character } = source.getLineAndCharacterOfPosition(node.getStart(source));


### PR DESCRIPTION
Fixes #5410

`moduleSpecifiers()` (`scripts/check-phantom-dependencies.mjs`) is the single
TypeScript-backed parser shared by three gates — `check:phantom-deps`,
`check:self-import`, and `check:esm-specifiers` (via `relativeSpecifiers()` in
`check-node-esm-load.mjs`, a third consumer not named in the original finding —
noted so the verification below covers it too). It parsed every file with
`setParentNodes: true`, even though:

- the walk only ever descends (`ts.forEachChild`, never `.parent`)
- its one position lookup calls `node.getStart(source)` with the source file
  passed **explicitly** — verified against `typescript@6.0.3`'s own source
  (`getTokenPosOfNode`'s `sourceFile ?? getSourceFileOfNode(node)`): passing
  `sourceFile` skips the `.parent`-walking fallback entirely
- `source` is local to the function and never escapes, so no consumer —
  including `check-package-self-import.mjs` and `check-node-esm-load.mjs`,
  both checked — can read a parent either

The fix sets the flag to `false` explicitly, with a comment (not a silent
flip), per the triage note on the issue.

## Verification

**Byte-identical output**, demonstrated, not asserted: ran all three affected
gates' full CLI output over this repository, before and after, and diffed
them — `diff` exit 0 (no output) on all three:

- `node scripts/check-phantom-dependencies.mjs`
- `node scripts/check-package-self-import.mjs`
- `node scripts/check-node-esm-load.mjs --specifiers-only`

**The ~25% cost figure, re-measured**, not repeated: over this repository's
current corpus (44 packages, 3,301 source files, 33.4 MB, 16,691 module
specifiers — grown since the issue was filed), alternating legs to control
for JIT warmup:

```
setParentNodes=true   5112ms  specifiers=16691
setParentNodes=false  3046ms  specifiers=16691
setParentNodes=true   4103ms  specifiers=16691
setParentNodes=false  2963ms  specifiers=16691
identical output across all files: true  diffs: 0
avg true=4608ms avg false=3005ms delta=34.8%
```

**"Does anything read a parent" traced exhaustively**, not just at the one
call site: read `getTokenPosOfNode` in `typescript@6.0.3`'s own bundled
source to confirm `node.getStart(source)` with an explicit `sourceFile`
argument never calls `getSourceFileOfNode` (the `.parent`-walking path), and
confirmed none of the other codepaths it can fall through
(`isJSDocNode`/`hasJSDocNodes`/`isInJSDoc`) touch `.parent` either — none of
those apply to the node kinds `moduleSpecifiers()` ever visits in valid
source (import/export/import-equals/import-type/call-expression). Grepped
all three consumer files plus both existing test files for any `.parent`
access: none.

**New test coverage** in `scripts/__tests__/check-phantom-dependencies.test.ts`:
a regression pin on the source text (so a silent flip back to `true` fails
the suite), a behavioral test proving a tree parsed with `setParentNodes:
false` genuinely has no `.parent` while `getStart(source)` still works, and a
parity test running `moduleSpecifiers()` against an independently
reimplemented `setParentNodes: true` reference over a fixture exercising
every recognized module-edge form.

`check-changeset-presence.mjs` verdict: no changeset owed (no released
package's `src/` touched — this is a tooling-only change under `scripts/`).

## Scope note

Per the ruling on the issue, this PR is scoped to exactly this flag. The
third consumer (`check-node-esm-load.mjs`) was not previously identified as a
blast-radius member; it's covered by the same verification above but no
other changes were made to it or filed as separate scope.

## Gates run

- `node scripts/check-phantom-dependencies.mjs` (before/after diff: empty)
- `node scripts/check-package-self-import.mjs` (before/after diff: empty)
- `node scripts/check-node-esm-load.mjs --specifiers-only` (before/after diff: empty)
- `npx vitest run scripts/__tests__/check-phantom-dependencies.test.ts scripts/__tests__/check-package-self-import.test.ts` — 73 passed
- `npx vitest run scripts/__tests__/check-node-esm-load.test.ts` — 44 passed
- `npx tsc -p tsconfig.scripts.json` (`type-check:scripts`) — clean
- `npx eslint scripts/check-phantom-dependencies.mjs scripts/__tests__/check-phantom-dependencies.test.ts --no-inline-config` — clean (targeted to the changed files; full-repo lint is CI's run)
- `node scripts/check-changeset-presence.mjs` — no changeset owed

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_