### PR TITLE
feat(types)!: retire the ActionCondition branch shape from ActionSchema.condition

### DIFF
--- a/.changeset/3917-retire-action-condition-branch.md
+++ b/.changeset/3917-retire-action-condition-branch.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/types': minor
+---
+
+Retire the `ActionCondition` `{ expression, then, else }` branch shape from
+`ActionSchema.condition` (objectui#3917, maintainer ruling 2026-08-09 route B,
+enforce-or-remove).
+
+`@object-ui/types` declared `condition` as a branch DSL — `expression` plus `then` /
+`else` sub-actions — and shipped a zod mirror (`ActionConditionSchema`) that accepted it.
+**Nothing ever read `expression`, `then` or `else`**: a repo-wide grep for
+`condition.expression|then|else` has zero non-test hits. The only consumer of the key is
+`ActionRunner.execute`, which reads it as a **predicate gate** (boolean / bare CEL /
+`${...}` template / `{ dialect, source }` envelope). A branch object carries no `source`,
+so the runner's normalizer read it as "no gate declared" and executed the action
+unconditionally: the predicate was never evaluated, `then` / `else` were never dispatched,
+and `os validate` / `os build` stayed green with zero diagnostics. Two docs pages taught
+the shape with worked examples, so an author following the documentation
+("amounts over 1000 go to manager approval") got unconditional execution.
+
+What changes:
+
+- `ActionCondition` is removed from `@object-ui/types` (and from the barrel export).
+- `ActionSchema.condition` is retyped to the predicate the runtime actually honours:
+  `boolean | string | { dialect?: string; source: string }` — the same three arms
+  `ActionRunner`'s own `ActionDef.condition` carries, and the same vocabulary `visible`
+  and `disabled` use.
+- `ActionConditionSchema` is removed from `@object-ui/types/zod` (and from the zod
+  barrel); the `condition` key now validates against that predicate union.
+- The two teaching sites (`content/docs/core/enhanced-actions.mdx` Conditional Execution,
+  `content/docs/api/schema-reference.md` ActionSchema table) are rewritten to the live
+  vocabulary: `condition` is a gate; a branch is expressed as separate actions with
+  mutually exclusive `condition`s.
+
+**The zod parse verdict flips in both directions**, measured on `origin/main` @ `2aff580b5`
+against this branch: the branch object went from **accepted** to **refused**
+(`invalid_union` on `condition`), and every live predicate spelling — `false`,
+`'data.amount > 1000'`, `'${data.amount > 1000}'`, `{ dialect: 'cel', source: ... }` —
+went from **refused** to **accepted**. The old schema required `expression`, so the shape
+the runtime honours was the one the schema rejected.
+
+**Breaking for TypeScript authors of `ActionCondition` and for metadata authoring
+`condition: { expression, then, else }`** — marked `minor` per this repo's
+version-alignment rule, which reserves `major` for following `@objectstack` across a major
+(AGENTS.md 版本号策略; same classification as the `MobileOverrides` retirement,
+objectui#4919). Runtime behaviour is unchanged: an authored branch object did nothing
+before and does nothing now. What changes is that the contract no longer claims otherwise
+— the mistake now surfaces at authoring time as a type error and a named zod refusal,
+instead of a silent no-op that type-checks, validates and runs the action anyway.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -634,9 +634,7 @@ A powerful action definition supporting API calls, confirmations, dialogs, chain
     }
   ],
   "chainMode": "sequential",
-  "condition": {
-    "expression": "${data.items.length > 0}"
-  },
+  "condition": "${data.items.length > 0}",
   "retry": {
     "maxAttempts": 3,
     "delay": 1000
@@ -657,7 +655,7 @@ A powerful action definition supporting API calls, confirmations, dialogs, chain
 | `dialog` | `object` | Modal dialog with `title`, `content`, `size`, `actions`. |
 | `chain` | `ActionSchema[]` | Actions to execute after this action completes. |
 | `chainMode` | `"sequential" \| "parallel"` | How chained actions execute. |
-| `condition` | `ActionCondition` | Conditional execution with `expression`, `then`, `else`. |
+| `condition` | `boolean \| string \| { dialect?, source }` | Execution gate — the action runs only while this predicate holds (boolean, bare CEL, `${...}` template, or the normalized envelope). Declared and false skips the action; absent executes it. It is a **gate, not a branch**: express a branch as separate actions with mutually exclusive `condition`s. (The `{ expression, then, else }` branch shape was retired in objectui#3917 — nothing read it, so it ran unconditionally.) |
 | `successMessage` / `errorMessage` | `string` | Toast messages on success/failure. |
 | `reload` | `boolean` | Reload data after action completes. |
 | `redirect` | `string` | URL to navigate to after action. |

--- a/content/docs/core/enhanced-actions.mdx
+++ b/content/docs/core/enhanced-actions.mdx
@@ -14,7 +14,7 @@ ObjectUI's action system has been significantly enhanced to support complex work
 The enhanced `ActionSchema` provides:
 - **New action types**: `ajax`, `confirm`, `dialog`
 - **Action chaining**: Execute multiple actions sequentially or in parallel
-- **Conditional logic**: If/then/else execution based on data
+- **Conditional execution**: a `condition` predicate gates whether an action runs
 - **Callbacks**: Success and failure handlers
 - **Tracking**: Event logging and analytics
 - **Retry logic**: Automatic retry with configurable backoff
@@ -212,37 +212,83 @@ const chainedAction: ActionSchema = {
 
 ## Conditional Execution
 
-Execute different actions based on conditions:
+`condition` is a **gate**, not a branch: the action executes only while the
+predicate holds.
 
 ```plaintext
-const conditionalAction: ActionSchema = {
+const gatedAction: ActionSchema = {
   type: 'action',
-  label: 'Approve',
-  actionType: 'button',
-  
-  condition: {
-    expression: '${data.amount > 1000}',
-    then: {
-      type: 'action',
-      label: 'Require Manager Approval',
-      actionType: 'confirm',
-      confirmText: 'Amount exceeds $1000. Manager approval needed.'
-    },
-    else: {
-      type: 'action',
-      label: 'Auto Approve',
-      actionType: 'ajax',
-      api: '/api/approve',
-      method: 'POST'
-    }
-  }
+  label: 'Require Manager Approval',
+  actionType: 'confirm',
+  confirmText: 'Amount exceeds $1000. Manager approval needed.',
+
+  // Offered only for amounts over 1000
+  condition: '${data.amount > 1000}'
 };
 ```
 
-**Condition Properties:**
-- `expression` - JavaScript expression to evaluate
-- `then` - Action(s) to execute if true
-- `else` - Action(s) to execute if false
+**How the gate is written** - four spellings, all read by the same evaluator:
+
+| Spelling | Example |
+|---|---|
+| Boolean | `condition: false` |
+| Bare CEL predicate | `condition: 'data.amount > 1000'` |
+| `${...}` template | `condition: '${data.amount > 1000}'` |
+| Normalized envelope | `condition: { dialect: 'cel', source: 'data.amount > 1000' }` |
+
+**How the gate is read:**
+- Declared and **false** - the action does not execute; the runner reports
+  `Action condition not met`.
+- Declared and **true** - the action executes normally.
+- **Not declared** (key absent, or an empty predicate) - the action executes.
+
+The envelope is what `objectstack build` emits for a compiled predicate, so
+authored metadata and built metadata both parse. This is the same predicate
+vocabulary `visible` and `disabled` carry.
+
+### Branching: one action per branch
+
+There is no `then` / `else` - a branch is expressed as **separate actions with
+mutually exclusive conditions**. Each action is gated on its own, so exactly one
+of them runs:
+
+```plaintext
+const approvalActions: ActionSchema[] = [
+  {
+    type: 'action',
+    label: 'Require Manager Approval',
+    actionType: 'confirm',
+    confirmText: 'Amount exceeds $1000. Manager approval needed.',
+    condition: '${data.amount > 1000}'
+  },
+  {
+    type: 'action',
+    label: 'Auto Approve',
+    actionType: 'ajax',
+    api: '/api/approve',
+    method: 'POST',
+    condition: '${data.amount <= 1000}'
+  }
+];
+```
+
+Sibling actions - a toolbar's `actions`, a table's `rowActions` / `batchActions`,
+or an event's action list - are each dispatched through their own gate, which is
+what makes this an either/or.
+
+A `chain` step also carries its own `condition`, but a **sequential** chain stops
+at the first step whose condition does not hold (a blocked step reports
+`Action condition not met`, and sequential chaining stops on the first failure).
+So use a step `condition` to gate an **optional follow-up**, and sibling actions
+for an either/or.
+
+> **Retired (objectui#3917):** `condition` used to be documented here as
+> `{ expression, then, else }`. Nothing ever read `expression`, `then` or
+> `else`. The runner has always read this key as the predicate above, and an
+> object without a `source` reads as "no gate declared", so an action written
+> that way ran **unconditionally**, with no error at author time and no
+> diagnostic at runtime. The shape is now refused by `ActionSchema`'s zod schema
+> instead of being accepted and ignored.
 
 ## Callbacks
 
@@ -342,22 +388,9 @@ const complexAction: ActionSchema = {
   actionType: 'confirm',
   confirmText: 'Process this order for ${data.customerName}?',
   
-  // Conditional logic
-  condition: {
-    expression: '${data.totalAmount > 1000}',
-    then: {
-      type: 'action',
-      actionType: 'ajax',
-      api: '/api/orders/process-premium',
-      method: 'POST'
-    },
-    else: {
-      type: 'action',
-      actionType: 'ajax',
-      api: '/api/orders/process-standard',
-      method: 'POST'
-    }
-  },
+  // Execution gate - this action is the premium path; the standard path is a
+  // sibling action carrying the opposite predicate
+  condition: '${data.totalAmount > 1000}',
   
   // Action chain
   chain: [

--- a/packages/types/src/__tests__/phase2-schemas.test.ts
+++ b/packages/types/src/__tests__/phase2-schemas.test.ts
@@ -17,7 +17,6 @@ import {
   ActionSchema,
   ActionExecutionModeSchema,
   ActionCallbackSchema,
-  ActionConditionSchema,
   CRUDSchema,
   DetailViewSchema,
   ViewSwitcherSchema,
@@ -481,8 +480,41 @@ describe('Phase 2: Enhanced ActionSchema Zod Validation', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should validate conditional action execution', () => {
-    const conditionalAction = {
+  // `condition` is an execution GATE, not a branch DSL (objectui#3917). Each
+  // arm below is one the runtime honours — `ActionRunner.execute` asks
+  // `hasDeclaredPredicate(action.condition)` and then `evaluateCondition`, both
+  // of which read exactly boolean / bare CEL / `${…}` template / the
+  // `{ dialect, source }` envelope `objectstack build` emits. Before the
+  // retirement `condition` required an `expression` key, so EVERY spelling in
+  // this table was refused by the schema while being honoured at runtime.
+  it.each([
+    ['a boolean', false],
+    ['a bare CEL predicate', 'data.amount > 1000'],
+    ['a ${…} template', '${data.amount > 1000}'],
+    ['the normalized envelope', { dialect: 'cel', source: 'data.amount > 1000' }],
+  ])('should accept a condition gate written as %s', (_label, condition) => {
+    const gatedAction = {
+      type: 'action',
+      label: 'Approve',
+      actionType: 'button',
+      condition,
+    };
+
+    const result = ActionSchema.safeParse(gatedAction);
+    expect(result.success).toBe(true);
+  });
+
+  // The retirement itself (objectui#3917). This is the shape two docs pages
+  // taught with worked examples while NOTHING read `expression` / `then` /
+  // `else`: the object carries no `source`, so the runtime's normalizer read it
+  // as "no gate declared" and ran the action unconditionally — the predicate
+  // never evaluated, the branches never dispatched, zero diagnostics. Asserting
+  // the FULL parse is red (not merely that some issue exists) is the point: the
+  // verdict on this authoring surface has to be a refusal, and it has to be
+  // pinned to the `condition` key, or the next widening restores the silent
+  // accept without any test noticing.
+  it('should refuse the retired { expression, then, else } branch shape', () => {
+    const branchAction = {
       type: 'action',
       label: 'Approve',
       actionType: 'button',
@@ -501,8 +533,12 @@ describe('Phase 2: Enhanced ActionSchema Zod Validation', () => {
       },
     };
 
-    const result = ActionSchema.safeParse(conditionalAction);
-    expect(result.success).toBe(true);
+    const result = ActionSchema.safeParse(branchAction);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issues = result.error.issues.filter((i) => i.path[0] === 'condition');
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0].code).toBe('invalid_union');
   });
 
   it('should validate action with tracking', () => {

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -659,8 +659,6 @@ const EXCLUSIONS: Readonly<Record<string, string>> = {
     "a union OVER the mirrors, not an object of its own — its members are checked individually above",
   'crud.zod.ts#ActionExecutionModeSchema':
     "a bare vocabulary with no `.shape`; it is checked where a mirrored KEY declares it",
-  'crud.zod.ts#ActionConditionSchema':
-    "recursive; declared `z.ZodType<any>`, which exposes no `.shape` to read — and accepts `any`, so it cannot be narrower than any declaration",
   'crud.zod.ts#ActionSchema':
     "recursive; declared `z.ZodType<any>`, which exposes no `.shape` to read — and accepts `any`, so it cannot be narrower than any declaration",
   'crud.zod.ts#CRUDComponentSchema':

--- a/packages/types/src/crud.ts
+++ b/packages/types/src/crud.ts
@@ -60,25 +60,6 @@ export interface ActionCallback {
 }
 
 /**
- * Conditional action configuration
- */
-export interface ActionCondition {
-  /**
-   * Condition expression
-   * @example "${data.status === 'active'}"
-   */
-  expression: string;
-  /**
-   * Action to execute if condition is true
-   */
-  then?: ActionSchema | ActionSchema[];
-  /**
-   * Action to execute if condition is false
-   */
-  else?: ActionSchema | ActionSchema[];
-}
-
-/**
  * Action button configuration for CRUD operations
  * Enhanced with Phase 2 features: ajax, confirm, dialog, chaining, conditional execution
  *
@@ -200,9 +181,25 @@ export interface ActionSchema extends BaseSchema {
    */
   chainMode?: ActionExecutionMode;
   /**
-   * Conditional execution (Phase 2)
+   * Execution gate — the action runs only while this predicate holds.
+   *
+   * A boolean, a bare CEL string, a `${…}` template, or the normalized
+   * `{ dialect, source }` envelope `objectstack build` emits. Declared and
+   * FALSE skips the action; not declared at all executes it. Same three arms
+   * `ActionRunner`'s own `ActionDef.condition` carries (`@object-ui/core`),
+   * because this is the authoring twin of that gate.
+   *
+   * RETIRED (objectui#3917): this key used to be typed `ActionCondition`, an
+   * `{ expression, then, else }` branch DSL. NOTHING in the repo ever read
+   * `expression` / `then` / `else` — `ActionRunner` reads this key as the
+   * predicate above, and an object with no `source` normalizes to "no gate
+   * declared", so an author who followed the docs ("amounts over 1000 go to
+   * manager approval") got UNCONDITIONAL execution with zero diagnostics.
+   * Retired under enforce-or-remove rather than honoured, so one key has one
+   * reading. Conditional BRANCHING is expressed as separate actions, each
+   * carrying its own `condition`.
    */
-  condition?: ActionCondition;
+  condition?: boolean | string | { dialect?: string; source: string };
   /**
    * Whether to reload data after action
    * @default true

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -840,7 +840,6 @@ export type {
   // Enhanced Action System (Phase 2)
   ActionExecutionMode,
   ActionCallback,
-  ActionCondition,
 } from './crud.js';
 
 /**

--- a/packages/types/src/zod/crud.zod.ts
+++ b/packages/types/src/zod/crud.zod.ts
@@ -40,13 +40,28 @@ export const ActionCallbackSchema = z.object({
 });
 
 /**
- * Action Condition Schema
+ * The wire shape of an action's execution gate: a boolean, a bare CEL string
+ * (`${…}` templates included), or the spec Expression envelope
+ * `{ dialect?, source }` that `objectstack build` emits. These are the three
+ * arms `ActionRunner` actually honours (`@object-ui/core`
+ * `hasDeclaredPredicate` + `evaluateCondition`), so an authored gate that
+ * parses here is a gate that runs. Module-local on purpose — it restates no TS
+ * interface of its own, so it is not a mirror the parity census should track.
+ *
+ * RETIRED (objectui#3917): this key used to take `ActionConditionSchema`, an
+ * `{ expression, then, else }` branch DSL with ZERO consumers — the runtime read
+ * the same key as the predicate above, and a `source`-less object normalizes to
+ * "no gate declared", so the branch was accepted here and then silently ignored
+ * at execution (the action ran unconditionally). Retiring it flips the parse
+ * verdict BOTH ways: the branch object is now refused, and the predicate forms
+ * the runtime has always honoured are now accepted — before this, `condition`
+ * required `expression`, so every live predicate spelling was refused.
  */
-export const ActionConditionSchema: z.ZodType<any> = z.lazy(() => z.object({
-  expression: z.string().describe('Condition expression'),
-  then: z.union([ActionSchema, z.array(ActionSchema)]).optional().describe('Action to execute if condition is true'),
-  else: z.union([ActionSchema, z.array(ActionSchema)]).optional().describe('Action to execute if condition is false'),
-}));
+const ActionConditionPredicateSchema = z.union([
+  z.boolean(),
+  z.string(),
+  z.object({ dialect: z.string().optional(), source: z.string() }),
+]);
 
 /**
  * Action Schema - Enhanced with Phase 2 features
@@ -81,7 +96,7 @@ export const ActionSchema: z.ZodType<any> = z.lazy(() => BaseSchema.extend({
   onFailure: ActionCallbackSchema.optional().describe('Failure callback'),
   chain: z.array(ActionSchema).optional().describe('Action chaining - actions to execute after this one'),
   chainMode: ActionExecutionModeSchema.optional().default('sequential').describe('Chain execution mode'),
-  condition: ActionConditionSchema.optional().describe('Conditional execution'),
+  condition: ActionConditionPredicateSchema.optional().describe('Execution gate — the action runs only while this predicate holds'),
   reload: z.boolean().optional().default(true).describe('Whether to reload data after action'),
   close: z.boolean().optional().default(true).describe('Whether to close dialog/modal after action'),
   onClick: z.any().optional().describe('Custom click handler'),
@@ -246,7 +261,6 @@ export const CRUDComponentSchema = z.union([
  */
 export type ActionExecutionModeSchemaType = z.infer<typeof ActionExecutionModeSchema>;
 export type ActionCallbackSchemaType = z.infer<typeof ActionCallbackSchema>;
-export type ActionConditionSchemaType = z.infer<typeof ActionConditionSchema>;
 export type ActionSchemaType = z.infer<typeof ActionSchema>;
 export type CRUDOperationSchemaType = z.infer<typeof CRUDOperationSchema>;
 export type CRUDFilterSchemaType = z.infer<typeof CRUDFilterSchema>;

--- a/packages/types/src/zod/index.zod.ts
+++ b/packages/types/src/zod/index.zod.ts
@@ -269,7 +269,6 @@ export {
 export {
   ActionExecutionModeSchema,
   ActionCallbackSchema,
-  ActionConditionSchema,
   ActionSchema,
   CRUDOperationSchema,
   CRUDFilterSchema,


### PR DESCRIPTION
Fixes #3917

Maintainer ruling 2026-08-09, **route B — retire the `{ expression, then, else }` shape per enforce-or-remove** (directive 「全部接受」 covering that round's whole decision inbox). Option A (honouring the branch DSL in `ActionRunner.execute`) is explicitly not taken.

## What was wrong

`@object-ui/types` declared `ActionSchema.condition` as an `{ expression, then, else }` branch DSL and shipped a zod mirror (`ActionConditionSchema`) that accepted it. **Nothing ever read `expression` / `then` / `else`.** The only consumer of the key is `ActionRunner.execute`, which reads it as a **predicate gate**; a branch object carries no `source`, so the runner's normalizer read it as "no gate declared" and executed the action unconditionally — predicate never evaluated, `then` / `else` never dispatched, `os validate` / `os build` green, zero diagnostics. Two docs pages taught the shape with worked examples, so an author following the documentation ("amounts over 1000 go to manager approval") got unconditional execution.

## What this PR does

- Removes `ActionCondition` (`crud.ts`) and `ActionConditionSchema` + `ActionConditionSchemaType` (`zod/crud.zod.ts`), and both barrel exports (`index.ts`, `zod/index.zod.ts`).
- Retypes `ActionSchema.condition` to the predicate the runtime actually honours — `boolean | string | { dialect?: string; source: string }` — the same three arms `ActionRunner`'s own `ActionDef.condition` carries and the same vocabulary `visible` / `disabled` use. The key survives as a **gate**; only the branch shape is retired, which is what makes the rewritten docs coherent with the type.
- Rewrites both teaching sites to the live vocabulary: `content/docs/core/enhanced-actions.mdx` (Conditional Execution — gate spellings, how the gate is read, branching as separate actions, a retirement note) and `content/docs/api/schema-reference.md` (ActionSchema property table + the JSON example).
- `minor`, per this repo's version-alignment rule reserving `major` for following `@objectstack` across a major (AGENTS.md 版本号策略; `check-changeset-no-major.mjs` enforces it). Same classification as the `MobileOverrides` retirement (#4919).

One documentation claim is stated more precisely than the ruling's one-liner, because the code says so: a **sequential** `chain` stops at the first step whose `condition` does not hold (a blocked step returns `Action condition not met`, and `executeChain` sequential returns on the first failure — `packages/core/src/actions/ActionRunner.ts`). So the page teaches per-action `condition`s on **sibling** actions for an either/or, and a step `condition` for gating an optional follow-up. Teaching "put both branches in one sequential chain" would have re-created this card's own failure mode.

## Evidence

All gate runs below are on **`24d653d5e`** (this branch's head, working tree clean).

**The zod parse verdict flips in both directions** — measured, not asserted. A throwaway worktree at `origin/main` (`2aff580b5`) parsed the same fixtures through the old schema; the numbers came out of vitest's own failure output, not from prose:

| `condition` value | `origin/main` @ `2aff580b5` | this branch |
|---|---|---|
| `{ expression, then, else }` | **accepted** (`success: true`) | **refused** (`invalid_union` on `condition`) |
| `false` | refused | **accepted** |
| `'data.amount > 1000'` | refused | **accepted** |
| `'${data.amount > 1000}'` | refused | **accepted** |
| `{ dialect: 'cel', source: … }` | refused | **accepted** |

The old schema required `expression`, so the spelling the runtime has always honoured was the one the schema rejected. Both directions are now pinned in `phase2-schemas.test.ts` (an `it.each` over the four live spellings, plus a refusal test asserting the full parse is red **and** that the issue is on the `condition` path).

- `pnpm exec vitest run packages/types/` → `Test Files 53 passed (53)`, `Tests 581 passed (581)`.
- `pnpm --filter @object-ui/types type-check` (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`) → exit 0.
- **Downstream contract sweep**: `pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2` → `Tasks: 32 successful, 32 total`. Every one of those packages is a `tsc` build of its own `src/` against the new `@object-ui/types` `dist/*.d.ts`, so the narrowing breaks no consumer.
- `node scripts/check-doc-snippet-types.mjs` → controls live (`sentinel … TS2305`, resolution landed on `packages/types/dist/index.d.ts`), `Semantic phase: 135 of 135 block(s) judged, 0 failed`.
- `node scripts/check-doc-component-types.mjs` → `✅ Every documented component type is registered.`
- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `✅ OK (scanned 4951 tracked text file(s))`.
- `node scripts/check-changeset-presence.mjs` → `✅ 6 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`; `node scripts/check-changeset-no-major.mjs` → `✅ No changeset declares a major bump.`
- `pnpm --filter @object-ui/types lint` → exit 0 (0 errors; 251 pre-existing `no-explicit-any` warnings, none of them new — the diff removes one unused import and adds no `any`).

**Declared narrowing**: the repo-wide `pnpm lint` / `pnpm test` farm was not run locally — CI runs it exactly once regardless. Type-aware linting is not enabled in `eslint.config.js` (no `parserOptions.project` / `projectService`), so this diff cannot move any untouched file's lint verdict; every `.ts` file it touches was linted directly (6 files, 0 errors).

## The "zero consumers" premise, re-verified

Independently re-measured on this tree rather than taken from the card: the nine `ActionCondition` read points enumerated in the dispatch are exact (the card's `crud.ts:212` / `crud.zod.ts:86` had drifted to `:205` / `:84`, and the card omitted both test read points — the `zod-mirror-parity` registry entry is keyed by the schema name and would have failed CI as a stale entry). A repo-wide grep for a consumer of `condition.expression|then|else` outside `packages/types` returns zero, and no JSON fixture, example app or e2e schema authors the branch shape. Premise holds; no fork.

## Out of scope, filed not fixed

A **third** teaching site writes the retired spelling — `content/docs/guide/schema-overview.md:84` — which neither the card, the ruling nor the fence names. It sits inside a **declared doc-snippet fragment**, so no gate compiles it. Filed unassigned as #5980 rather than widening this PR's fenced file surface.

Kept in **draft** per the dispatch contract: the PM seat reviews CI and decides readiness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_