### PR TITLE
fix(console): correct stale plugin-detail line ref in parity gate

### DIFF
--- a/.changeset/fix-parity-aria-line-ref.md
+++ b/.changeset/fix-parity-aria-line-ref.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change to the parity gate's `aria` exemption comment; no published behaviour changes. Fixes a stale `file:line` reference to `packages/plugin-detail/src/index.tsx` (was `:335-337`, now `:554-556`) in `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -221,7 +221,7 @@ function offSpecInputs(type: string): string[] {
  * Only `aria` qualifies, and only because the reason is genuinely uniform: it is
  * an accessibility escape hatch, not a layout choice, and the blocks that omit
  * it say so in the same words at their registration sites
- * (`plugin-detail/src/index.tsx:335-337`, verbatim: "`aria` is omitted for the
+ * (`plugin-detail/src/index.tsx:554-556`, verbatim: "`aria` is omitted for the
  * same reason it is omitted on `record:details` above"). Publishing it would put
  * an `aria` object in every designer panel and every generated `.d.ts` as though
  * hand-writing ARIA were the normal way to configure a block, when the renderers
@@ -229,7 +229,7 @@ function offSpecInputs(type: string): string[] {
  * reason is per-block belongs in `UNPUBLISHED_EXEMPTIONS` below, not here.
  */
 const GLOBALLY_UNPUBLISHED_SPEC_KEYS: Record<string, string> = {
-  aria: 'Accessibility escape hatch, not a layout choice — renderers derive accessible names from labels and object metadata, and every block omits it for this one reason (plugin-detail/src/index.tsx:335-337). objectui#3808.',
+  aria: 'Accessibility escape hatch, not a layout choice — renderers derive accessible names from labels and object metadata, and every block omits it for this one reason (plugin-detail/src/index.tsx:554-556). objectui#3808.',
 };
 
 /**


### PR DESCRIPTION
Fixes #5007

## What
`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` cited `plugin-detail/src/index.tsx:335-337` in two places (the doc comment above `GLOBALLY_UNPUBLISHED_SPEC_KEYS` at `:224`, and the `aria` reason string itself at `:232`) as the location of the `aria`-omission rationale. That range now holds the head of the `ComponentRegistry.register('detail', ...)` call (`namespace`/`category`/`label`/`icon`/`inputs: […]`), not the rationale.

Measured true location on `origin/main` @ `d8b48f495`: `packages/plugin-detail/src/index.tsx:554-556`:

```
// page is supposed to fetch. `aria` is omitted for the same reason it is
// omitted on `record:details` above: it is an accessibility escape hatch, not
// a layout choice.
```

The quoted verbatim text in the test (`` `aria` is omitted for the same reason it is omitted on `record:details` above ``) is unchanged and present at that location. Both citations updated to `:554-556`.

Per the issue's own preferred disposition list, this PR takes option 1 (fix the citation) only — options 2 (cite by symbol instead of line) and 3 (assert the text exists) are left as findings for a future card, per dispatch scope.

## Gates
- `apps/console` `type-check`: pass
- `apps/console` parity test (`vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`): 75/75 pass
- `eslint src/__tests__/registry-inputs-spec-parity.test.ts` (apps/console): pass, no output
- `check-changeset-presence.mjs`: pass — empty-frontmatter changeset added (test-only change, no release content)

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_