### PR TITLE
docs(react): fix createLazyPlugin's JSDoc example to a call that compiles

### DIFF
--- a/.changeset/lazy-plugin-jsdoc-compiles.md
+++ b/.changeset/lazy-plugin-jsdoc-compiles.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/react": patch
+---
+
+Fix `createLazyPlugin`'s JSDoc example, which taught a call that does not compile.
+
+The `@example` block passed `() => import('@object-ui/plugin-grid')` as the
+`importFn`. ObjectUI plugin packages export their components by name and have no
+`default`, so that call supplies the module namespace object — rejected by the
+compiler (`Property 'default' is missing`) and, at runtime, handed to
+`React.lazy` as the component. The examples now unwrap the named export via the
+`async` spelling, which is the form that actually type-checks. This ships in the
+published `.d.ts`, so it is what editors show on hover.

--- a/packages/react/src/LazyPluginLoader.tsx
+++ b/packages/react/src/LazyPluginLoader.tsx
@@ -87,27 +87,34 @@ function createRetryImport<P extends object>(
 
 /**
  * Create a lazy-loaded plugin component with Suspense wrapper
- * 
- * @param importFn - Dynamic import function that returns a module with default export
+ *
+ * @param importFn - Dynamic import function resolving to a module whose
+ *   `default` is the component to render. ObjectUI plugin packages export
+ *   their components by NAME and have no `default`, so a bare
+ *   `() => import('@object-ui/plugin-<x>')` does NOT satisfy this — it hands
+ *   over the module namespace object, which is neither a component at runtime
+ *   nor assignable here. Name the component you want, as the examples do.
  * @param options - Configuration options for the lazy plugin
  * @returns A component that lazy loads the plugin
- * 
+ *
  * @example
  * ```tsx
- * // Basic usage
+ * // Basic usage. `@object-ui/plugin-grid` has no default export, so unwrap the
+ * // named component. Use the `async` form: the `.then((m) => ({ default: m.X }))`
+ * // spelling infers `P` as `never` on one branch of the `then` overload.
  * const ObjectGrid = createLazyPlugin(
- *   () => import('@object-ui/plugin-grid')
+ *   async () => ({ default: (await import('@object-ui/plugin-grid')).ObjectGrid })
  * );
- * 
+ *
  * // With custom fallback
- * const ObjectGrid = createLazyPlugin(
- *   () => import('@object-ui/plugin-grid'),
+ * const ObjectGridWithFallback = createLazyPlugin(
+ *   async () => ({ default: (await import('@object-ui/plugin-grid')).ObjectGrid }),
  *   { fallback: <div>Loading grid...</div> }
  * );
- * 
+ *
  * // With retry and error handling
- * const ObjectGrid = createLazyPlugin(
- *   () => import('@object-ui/plugin-grid'),
+ * const ObjectGridWithRetry = createLazyPlugin(
+ *   async () => ({ default: (await import('@object-ui/plugin-grid')).ObjectGrid }),
  *   {
  *     retries: 3,
  *     errorFallback: ({ error, retry }) => (

--- a/packages/react/src/__tests__/LazyPluginLoader.jsdocExample.test.ts
+++ b/packages/react/src/__tests__/LazyPluginLoader.jsdocExample.test.ts
@@ -1,0 +1,156 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Guards `createLazyPlugin`'s own `@example` block.
+ *
+ * objectui#5949: that docblock taught `() => import('@object-ui/plugin-grid')`
+ * as the `importFn`. The package exports its components BY NAME and has no
+ * `default`, so the call handed `React.lazy` the module namespace object —
+ * wrong at compile time (TS2345, `Property 'default' is missing`) and wrong at
+ * runtime (renders nothing useful). It survived because a JSDoc `@example`
+ * inside a `.tsx` source file is read by NO gate in this repo:
+ * `check-doc-snippet-types.mjs` states its scan surface as "every `.mdx` and
+ * `.md` page under `content/docs`, plus every `packages/<name>/README.md`" —
+ * markdown documents only. The wrong call therefore shipped in the published
+ * `.d.ts` that editors surface on hover, the highest-traffic place a reader
+ * meets it.
+ *
+ * ⚠️ The honest limit of this file, stated because a reader of a green run
+ * needs it. It does NOT compile the docblock's literal text. It cannot:
+ * `@object-ui/plugin-grid` depends on `@object-ui/react`, so this package
+ * cannot import it in either direction without a workspace cycle. Instead it
+ * pins the two halves that together make the example true, and each half is
+ * checked by the thing that can actually judge it:
+ *
+ *   1. THE SHAPE COMPILES — `typeLevelContract` below is compiled by
+ *      `tsc -p tsconfig.test.json` (chained from this package's `type-check`
+ *      script, which is what CI's `Type Check` job runs). It pins that
+ *      unwrapping a named export satisfies `importFn` and that the bare
+ *      namespace form is REJECTED. Nothing here runs under vitest.
+ *   2. THE DOCBLOCK TEACHES THAT SHAPE — the runtime tests below read the
+ *      source and assert the `@example` block uses the unwrap and never the
+ *      bare form, so the compiled shape and the documented text cannot drift.
+ *
+ * ⛔ Do not "fix" a failure here by adding a default export to
+ * `@object-ui/plugin-grid`. That is a contract change on a published package;
+ * the documented surface is the thing under guard, not the package.
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import type React from 'react';
+import { createLazyPlugin } from '../LazyPluginLoader';
+
+const SOURCE_PATH = new URL('../LazyPluginLoader.tsx', import.meta.url);
+/** Read, not imported: a path read is not a build edge, so this asserts across
+ *  the package boundary without creating the cycle described above. */
+const PLUGIN_GRID_INDEX = new URL('../../../plugin-grid/src/index.tsx', import.meta.url);
+
+const source = readFileSync(SOURCE_PATH, 'utf8');
+
+/** The `/** ... *\/` docblock immediately preceding `export function createLazyPlugin`.
+ *  Anchored on that declaration specifically: `preloadPlugin`'s example lower in
+ *  the same file passes a bare `() => import('@object-ui/plugin-grid')` and is
+ *  CORRECT to — its parameter is `() => Promise<T>`, which expects no `default`. */
+function createLazyPluginDocblock(): string {
+  const decl = source.indexOf('export function createLazyPlugin');
+  if (decl === -1) throw new Error('`export function createLazyPlugin` not found — re-anchor this test.');
+  const open = source.lastIndexOf('/**', decl);
+  const close = source.indexOf('*/', open);
+  if (open === -1 || close === -1 || close > decl) throw new Error('docblock for `createLazyPlugin` not found.');
+  return source.slice(open, close + 2);
+}
+
+/** The CODE inside the docblock's ```tsx fence: JSDoc ` * ` margins stripped and
+ *  `//` lines dropped. The negative assertions below must judge what the example
+ *  TELLS THE READER TO WRITE, not the prose that warns them off a spelling —
+ *  running them over the raw block makes this file's own warnings trip it. */
+function createLazyPluginExampleCode(): string {
+  const block = createLazyPluginDocblock();
+  const fence = block.match(/```tsx\n([\s\S]*?)```/);
+  if (!fence) throw new Error('no ```tsx fence in `createLazyPlugin`\'s docblock — re-anchor this test.');
+  return fence[1]
+    .split('\n')
+    .map((line) => line.replace(/^\s*\* ?/, ''))
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+describe('createLazyPlugin @example (objectui#5949)', () => {
+  it('anchors on a docblock that really is the one carrying the example', () => {
+    // Control probe: a zero-hit assertion below must mean "absent", not "mis-anchored".
+    const block = createLazyPluginDocblock();
+    expect(block).toContain('@example');
+    expect(block).toContain('@object-ui/plugin-grid');
+    expect(block).toContain('createLazyPlugin(');
+    // ...and that the code-only view the negative assertions run over is real,
+    // so a zero-hit there reads as "absent" rather than "mis-extracted".
+    const code = createLazyPluginExampleCode();
+    expect(code).toContain('createLazyPlugin(');
+    expect(code).toContain("import('@object-ui/plugin-grid')");
+    expect(code.split('\n').filter((l) => l.trimStart().startsWith('//'))).toHaveLength(0);
+  });
+
+  it('never passes a bare module namespace import as importFn', () => {
+    const code = createLazyPluginExampleCode();
+    // The exact defect: `import(...)` as the WHOLE argument, no named unwrap.
+    expect(code).not.toMatch(/\(\s*\)\s*=>\s*import\('@object-ui\/plugin-[a-z-]+'\)/);
+  });
+
+  it('unwraps a named export, in the `async` spelling', () => {
+    const code = createLazyPluginExampleCode();
+    const unwraps = code.match(
+      /async \(\) => \(\{ default: \(await import\('@object-ui\/plugin-grid'\)\)\.ObjectGrid \}\)/g,
+    );
+    expect(unwraps).toHaveLength(3);
+    // ⚠️ Not the `.then` spelling: it infers `P` as `never` on one branch of the
+    // `then` overload and does not compile (measured on objectui#5949).
+    expect(code).not.toContain('.then(');
+  });
+
+  it('declares each example with a distinct name so the block is one coherent program', () => {
+    const code = createLazyPluginExampleCode();
+    const names = [...code.matchAll(/const (\w+) = createLazyPlugin\(/g)].map((m) => m[1]);
+    expect(names).toHaveLength(3);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('rests on `@object-ui/plugin-grid` having no default export', () => {
+    // The premise the example encodes. If this ever flips, the docblock's
+    // "has no default export" warning is stale and must be rewritten — not
+    // silenced here.
+    const gridIndex = readFileSync(PLUGIN_GRID_INDEX, 'utf8');
+    expect(gridIndex).toContain('export { ObjectGrid, VirtualGrid, ImportWizard };'); // control probe
+    expect(gridIndex).not.toMatch(/^export default /m);
+    expect(gridIndex).not.toMatch(/\bexport\s*\{[^}]*\bas default\b/);
+  });
+});
+
+/**
+ * Compiled, never executed. `tsc -p tsconfig.test.json` is the assertion here;
+ * vitest never calls this and must not.
+ */
+export function typeLevelContract(): void {
+  /** `@object-ui/plugin-grid`'s real export shape: named exports, no `default`. */
+  type PluginGridModule = {
+    ObjectGrid: React.FC<{ objectName?: string }>;
+    VirtualGrid: React.FC<{ rows?: number }>;
+    ImportWizard: React.FC<{ open?: boolean }>;
+  };
+  const importPluginGrid = null as unknown as () => Promise<PluginGridModule>;
+
+  // ✅ what the docblock now teaches.
+  void createLazyPlugin(async () => ({ default: (await importPluginGrid()).ObjectGrid }));
+
+  // ⛔ what it used to teach. `@ts-expect-error` is the guard: if this call ever
+  // stops being an error, the compiler has begun accepting a namespace object
+  // where a component belongs, and THIS LINE turns the build red.
+  // @ts-expect-error TS2345 — `Property 'default' is missing in type 'PluginGridModule'`.
+  void createLazyPlugin(importPluginGrid);
+}


### PR DESCRIPTION
Fixes #5949

## What was wrong

`createLazyPlugin`'s own `@example` block passed `() => import('@object-ui/plugin-grid')` as the `importFn`, three times over. That package exports its components **by name** and has no `default`, so the call supplies the module namespace object where a component is expected. Wrong in both dimensions: rejected by the compiler, and at runtime `React.lazy` would receive the namespace object as the component and render nothing useful.

This is the worst-placed kind of doc error — it sits *on the function it documents*, and it is carried into the published `.d.ts` that editors surface on hover.

## The replacement was derived, not guessed

I read `@object-ui/plugin-grid`'s real export shape first: `packages/plugin-grid/src/index.tsx` opens `export { ObjectGrid, VirtualGrid, ImportWizard };`, `ObjectGrid` is declared as a `React.FC` parameterised by `ObjectGridComponentProps`, and the file has no `export default` and no `as default` re-export (grep confirmed with a control probe, so the zero-hit reads as absent rather than mis-anchored).

Then I measured all three candidate spellings against the compiler, in `packages/react`'s own strict test project:

| spelling | verdict |
|---|---|
| `() => import('@object-ui/plugin-grid')` (what the docblock taught) | **RED** — `TS2345: Property 'default' is missing` |
| `.then((m) => ({ default: m.ObjectGrid }))` | **RED** — `TS2322`, infers `P` as `never` on one branch of the `then` overload |
| `async () => ({ default: (await import('@object-ui/plugin-grid')).ObjectGrid })` | **GREEN** |

So all three examples now use the `async` unwrap. Each also gets a distinct binding (`ObjectGrid`, `ObjectGridWithFallback`, `ObjectGridWithRetry`) so the fenced block is one coherent program rather than three redeclarations of the same `const`. The `@param` line, which previously just asserted "returns a module with default export", now says why a bare plugin import does not satisfy it.

`preloadPlugin`'s example lower in the same file is **deliberately untouched**. Its parameter is generic over whatever the import resolves to — a plain `Promise` of `T`, with no `default` required anywhere in the type — so the bare import is correct there. That is the one place the obvious sweep would have been wrong.

## Proving it compiles — and why not via `check:doc-snippets`

⚠️ **The existing gate cannot reach this.** `scripts/check-doc-snippet-types.mjs` states its own scan surface as *"every `.mdx` and `.md` page under `content/docs`, plus every `packages/*/README.md`"* — markdown documents only. A JSDoc `@example` inside a `.tsx` source file is categorically outside it, which is exactly why this rotted. Extending that scan surface to source files is a contract change on the gate's population (its header requires anything added to be declared in the same breath) and is a different, larger card. I did **not** enrol this file into it as a side effect.

Instead the new test `packages/react/src/__tests__/LazyPluginLoader.jsdocExample.test.ts` pins the two halves that together make the example true, each checked by the thing that can actually judge it:

1. **The shape compiles.** `typeLevelContract` is compiled by `tsc -p tsconfig.test.json` (chained from this package's `type-check`, which is what CI's Type Check job runs). It pins that unwrapping a named export satisfies `importFn`, and carries a `@ts-expect-error` on the old bare form — so if the compiler ever starts accepting a namespace object there, that line turns the build red.
2. **The docblock teaches that shape.** Runtime assertions read the source, extract the code inside the `@example` fence, and assert it uses the unwrap and never the bare form — so the compiled shape and the documented text cannot drift.

**The honest limit, stated because a reader of a green run needs it:** this does not compile the docblock's literal text. It cannot — `@object-ui/plugin-grid` depends on `@object-ui/react`, so this package cannot import it in either direction without a workspace cycle. The module identity is instead pinned by an on-disk assertion that plugin-grid still has no default export (a path read, not an import; `check:phantom-deps` confirms no dependency edge was created).

## Population of the same wrong shape (issue's "worth checking")

Swept, and **reported rather than swept up** — nothing outside the fence was touched:

- `content/docs/guide/deployment.md` — **already corrected** on `main`; it teaches the same `async` unwrap this PR adopts. That is the sibling that surfaced the bug.
- `packages/react/src/LazyPluginLoader.tsx:166` (`preloadPlugin`) — bare import, and **correct**; left alone.
- `packages/core/src/registry/Registry.ts:281` and the many `ComponentRegistry.registerLazy(...)` call sites — a *different* API that legitimately takes the whole module namespace. Not the same defect.
- `content/docs/guide/objectos-integration.mdx:546-548` — a plugin map feeding a different loader, not `createLazyPlugin`. Not swept; flagged here only.
- `packages/react/README.md` — no `createLazyPlugin` example at all.

Real-world callers already use the unwrap-by-name form against this very package (`packages/app-shell/src/views/ObjectView.tsx:23`), which corroborates the shape independently.

## Verification

All run at `fc54843f8`, the final commit on this branch:

- `pnpm --filter @object-ui/react type-check` — exit 0 (script echoed, not a zero-match no-op)
- `pnpm exec vitest run packages/react/` — **Test Files 54 passed (54), Tests 739 passed (739)**
- `node scripts/check-changeset-presence.mjs` — green, declares `.changeset/lazy-plugin-jsdoc-compiles.md`
- `check:control-bytes`, `check:esm-specifiers`, `check:phantom-deps`, `check:self-import` — all exit 0 on their own verdict lines

**Reverse-verification**, both legs rebuilt and each mutation confirmed on disk before the reading was taken:

- Reverting the docblock to the bare form (unwrap count 3 to 0, bare form injected 3) turns exactly the two shape assertions red, and the control-probe and premise tests correctly stay green. Restored; tree byte-clean; 5/5 green again.
- Making the negative call valid raises `TS2578: Unused '@ts-expect-error' directive` — the negative assertion is load-bearing, not a comment. Restored; `tsc` clean again.

**Declared narrowing:** `check:doc-snippets` was not run to completion locally — it needs most of the workspace built (it reported `unbuilt-package` for 9 packages), which is the repo-wide build CI owns. Its verdict provably cannot move because of this diff: its population is markdown only and none of the 3 changed files is in it (verified with a control probe on the population regex), and **every changed line of the `.tsx` is a comment line**, so the emitted `.d.ts` type surface is byte-identical in the shapes that gate compiles against.

Lint was likewise narrowed to the changed files: 0 errors, 1 warning, and that warning (`no-explicit-any` on the `P` type parameter's `any` default) is pre-existing on `origin/main` and not an added line. The config has no type-aware linting, so this diff cannot move the verdict on any untouched file.

Note for readers: this repo's body sanitizer strips short angle-bracket fragments, so generic type arguments above are spelled in prose rather than in brackets.

Related: #5174, #5160, #5053.

_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_