### PR TITLE
docs(guides,tooling): clear the last two .md pages off the doc-snippet ledger (#5174 batch 4)

### DIFF
--- a/content/docs/guide/component-registry.md
+++ b/content/docs/guide/component-registry.md
@@ -88,6 +88,7 @@ Now you can use it in schemas:
 
 All registered components receive the schema as props:
 
+<!-- doc-snippet: fragment — continues the custom-component block above — `BaseSchema` and `MyComponentSchema` are declared there, and re-declaring them here would teach the reader to write the same interface twice (measured: TS2304 x3) -->
 ```tsx
 interface ComponentProps<T extends BaseSchema = BaseSchema> {
   // The complete schema object
@@ -119,6 +120,7 @@ function MyRenderer(props: ComponentProps<MyComponentSchema>) {
 
 Register components with additional metadata:
 
+<!-- doc-snippet: fragment — continues the custom-component block above — `MyComponent` and the `ComponentRegistry` import come from it (measured: TS2304 x2). The `ComponentMeta` literal this block shows is type-checked on the complete example at the end of the page, which does compile -->
 ```tsx
 ComponentRegistry.register('my-component', MyComponent, {
   label: 'My Custom Component',
@@ -137,6 +139,7 @@ This metadata is used by the Visual Designer to provide better editing experienc
 
 Register components that load on demand:
 
+<!-- doc-snippet: fragment — `./HeavyComponent` is the reader's own module, so the dynamic import cannot resolve here (measured: TS2307 x1, plus TS2304 on the `ComponentRegistry` the block above imports) -->
 ```tsx
 // The loader runs the first time a schema asks for `heavy-component`.
 ComponentRegistry.registerLazy('heavy-component', () => import('./HeavyComponent'))
@@ -146,6 +149,7 @@ ComponentRegistry.registerLazy('heavy-component', () => import('./HeavyComponent
 
 Override default components with your own:
 
+<!-- doc-snippet: fragment — `MyCustomButton` is the reader's own replacement component; there is nothing in this repo to import it from (measured: TS2304 x1) -->
 ```tsx
 import { ComponentRegistry } from '@object-ui/core'
 import { initializeComponents } from '@object-ui/components'
@@ -163,6 +167,7 @@ ComponentRegistry.register('button', MyCustomButton)
 Default components are organized by category:
 
 ### Form Components
+<!-- doc-snippet: fragment — not TypeScript at all — this fence holds a markdown bullet list naming the eleven form-component keys the registry ships, and a leading `-` reads as unary minus on an undeclared name (measured: TS2304 across the list, and the form list does not even parse because `switch` is a keyword — TS1109/TS1005 x3). The fence language is the underlying defect; correcting it is a separate change -->
 ```tsx
 - input
 - textarea
@@ -178,6 +183,7 @@ Default components are organized by category:
 ```
 
 ### Data Display
+<!-- doc-snippet: fragment — not TypeScript at all — this fence holds a markdown bullet list naming the seven data-display keys the registry ships, and a leading `-` reads as unary minus on an undeclared name (measured: TS2304 across the list, and the form list does not even parse because `switch` is a keyword — TS1109/TS1005 x3). The fence language is the underlying defect; correcting it is a separate change -->
 ```tsx
 - table
 - list
@@ -189,6 +195,7 @@ Default components are organized by category:
 ```
 
 ### Layout
+<!-- doc-snippet: fragment — not TypeScript at all — this fence holds a markdown bullet list naming the eight layout keys the registry ships, and a leading `-` reads as unary minus on an undeclared name (measured: TS2304 across the list, and the form list does not even parse because `switch` is a keyword — TS1109/TS1005 x3). The fence language is the underlying defect; correcting it is a separate change -->
 ```tsx
 - page
 - container
@@ -201,6 +208,7 @@ Default components are organized by category:
 ```
 
 ### Feedback
+<!-- doc-snippet: fragment — not TypeScript at all — this fence holds a markdown bullet list naming the nine feedback keys the registry ships, and a leading `-` reads as unary minus on an undeclared name (measured: TS2304 across the list, and the form list does not even parse because `switch` is a keyword — TS1109/TS1005 x3). The fence language is the underlying defect; correcting it is a separate change -->
 ```tsx
 - alert
 - toast
@@ -214,6 +222,7 @@ Default components are organized by category:
 ```
 
 ### Navigation
+<!-- doc-snippet: fragment — not TypeScript at all — this fence holds a markdown bullet list naming the four navigation keys the registry ships, and a leading `-` reads as unary minus on an undeclared name (measured: TS2304 across the list, and the form list does not even parse because `switch` is a keyword — TS1109/TS1005 x3). The fence language is the underlying defect; correcting it is a separate change -->
 ```tsx
 - menu
 - breadcrumb
@@ -222,6 +231,7 @@ Default components are organized by category:
 ```
 
 ### Other
+<!-- doc-snippet: fragment — not TypeScript at all — this fence holds a markdown bullet list naming the eight remaining keys the registry ships, and a leading `-` reads as unary minus on an undeclared name (measured: TS2304 across the list, and the form list does not even parse because `switch` is a keyword — TS1109/TS1005 x3). The fence language is the underlying defect; correcting it is a separate change -->
 ```tsx
 - button
 - link
@@ -238,6 +248,8 @@ Default components are organized by category:
 ### Get All Registered Types
 
 ```tsx
+import { ComponentRegistry } from '@object-ui/core'
+
 const types = ComponentRegistry.getAllTypes()
 console.log(types) // ['input', 'button', 'form', ...]
 ```
@@ -245,6 +257,8 @@ console.log(types) // ['input', 'button', 'form', ...]
 ### Check if Type is Registered
 
 ```tsx
+import { ComponentRegistry } from '@object-ui/core'
+
 if (ComponentRegistry.has('my-component')) {
   console.log('Component is registered')
 }
@@ -253,6 +267,8 @@ if (ComponentRegistry.has('my-component')) {
 ### Get Component Metadata
 
 ```tsx
+import { ComponentRegistry } from '@object-ui/core'
+
 const metadata = ComponentRegistry.getMeta('input')
 console.log(metadata)
 // {
@@ -302,6 +318,7 @@ Use kebab-case for component types:
 
 ### 4. Provide Meaningful Metadata
 
+<!-- doc-snippet: fragment — `RatingComponent` is the component built in the complete example at the end of this page, and the `ComponentRegistry` import comes with it (measured: TS2304 x2) -->
 ```tsx
 ComponentRegistry.register('rating', RatingComponent, {
   label: 'Star Rating',
@@ -313,6 +330,7 @@ ComponentRegistry.register('rating', RatingComponent, {
 
 ### 5. Handle Missing Props Gracefully
 
+<!-- doc-snippet: fragment — continues the component-interface block above — `ComponentProps` is declared there and `MySchema` stands for whatever schema the reader's component takes (measured: TS2304 x2) -->
 ```tsx
 function MyComponent(props: ComponentProps<MySchema>) {
   const { schema } = props
@@ -332,6 +350,7 @@ function MyComponent(props: ComponentProps<MySchema>) {
 
 Group related components into plugin packages:
 
+<!-- doc-snippet: fragment — the three chart components are files the reader is being told to write, so `./BarChart` / `./LineChart` / `./PieChart` cannot resolve here (measured: TS2307 x3) -->
 ```tsx
 // @my-org/objectui-plugin-charts
 import { ComponentRegistry } from '@object-ui/core'
@@ -348,6 +367,7 @@ export function registerChartComponents() {
 
 Usage:
 
+<!-- doc-snippet: fragment — `@my-org/objectui-plugin-charts` is the package the reader has just been shown how to create, not one this repo publishes (measured: TS2307 x1) -->
 ```tsx
 import { initializeComponents } from '@object-ui/components'
 import '@object-ui/fields'
@@ -362,10 +382,10 @@ registerChartComponents()
 Here's a complete example of a custom form component:
 
 ```tsx
-import { forwardRef } from 'react'
+import { forwardRef, useState } from 'react'
 import { ComponentRegistry } from '@object-ui/core'
 import type { BaseSchema } from '@object-ui/types'
-import { cn } from '@/lib/utils'
+import { cn } from '@object-ui/components'
 
 interface RatingSchema extends BaseSchema {
   type: 'rating'

--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -40,6 +40,7 @@ your JSON pages *inside* it. `app-shell` is not a component key either — what 
 
 ### Basic Usage
 
+<!-- doc-snippet: fragment — `lucide-react` supplies the `NavItem.icon` COMPONENTS this example is about. It is a dependency of ten workspace packages (`@object-ui/layout` among them) but not a root one, so the specifier does not resolve in this gate's program (measured: TS2307 x1), and `pageSchema` is the reader's own page JSON (TS2304 x1). Probed with the icon import shimmed and `pageSchema` typed `BaseSchema`: the `NavItem[]` literal and the `AppShell` / `SidebarNav` props underneath are clean — 0 diagnostics -->
 ```tsx
 import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
 import { SchemaRenderer } from '@object-ui/react';
@@ -171,6 +172,7 @@ The `Page` component provides a consistent wrapper for individual pages with opt
 
 ### Schema API
 
+<!-- doc-snippet: fragment — a SHAPE excerpt, not an expression — the keys carry `?` optional markers and trailing prose comments, so the object literal cannot parse as TypeScript (measured: TS1109 / TS1005 / TS1011) -->
 ```typescript
 {
   type: 'page',
@@ -258,6 +260,7 @@ Unresolvable tokens collapse to an empty string rather than leaking the raw temp
 
 ### Schema API
 
+<!-- doc-snippet: fragment — a SHAPE excerpt, not an expression — the keys carry `?` optional markers and trailing prose comments, so the object literal cannot parse as TypeScript (measured: TS1109 / TS1005 / TS1011) -->
 ```typescript
 {
   type: 'page-header',
@@ -316,6 +319,7 @@ React, or use `navigation-renderer` when the tree has to come from metadata.
 `SidebarNav` renders a Shadcn `Sidebar`, so it must be inside a `SidebarProvider` —
 `AppShell` supplies one. Its rows are `NavLink`s, so it also needs a router above it.
 
+<!-- doc-snippet: fragment — `lucide-react` supplies the `NavItem.icon` COMPONENTS this example is about. It is a dependency of ten workspace packages (`@object-ui/layout` among them) but not a root one, so the specifier does not resolve in this gate's program (measured: TS2307 x1), and `pageSchema` is the reader's own page JSON (TS2304 x1). Probed with the icon import shimmed and `pageSchema` typed `BaseSchema`: the `NavItem[]` literal and the `AppShell` / `SidebarNav` props underneath are clean — 0 diagnostics -->
 ```tsx
 import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
 import { SchemaRenderer } from '@object-ui/react';
@@ -418,6 +422,7 @@ branding for a whole-shell-from-metadata setup.
 
 The shell is React; the page inside it is your JSON.
 
+<!-- doc-snippet: fragment — `lucide-react` supplies the `NavItem.icon` COMPONENTS this example is about. It is a dependency of ten workspace packages (`@object-ui/layout` among them) but not a root one, so the specifier does not resolve in this gate's program (measured: TS2307 x1), and `pageSchema` is the reader's own page JSON (TS2304 x1). Probed with the icon import shimmed and `pageSchema` typed `BaseSchema`: the `NavItem[]` literal and the `AppShell` / `SidebarNav` props underneath are clean — 0 diagnostics -->
 ```tsx
 import { AppShell, SidebarNav, type NavItem } from '@object-ui/layout';
 import { SchemaRenderer } from '@object-ui/react';
@@ -453,6 +458,7 @@ and `defaultOpen` is the shell's own initial-state prop.
 
 Omit `sidebar` and the content fills the width under the top bar.
 
+<!-- doc-snippet: fragment — a JSX excerpt showing one prop — `AppShell`, `SchemaRenderer` and `landingSchema` all come from the Basic Usage block above, and restating its five setup lines here would bury the one line the section is about (measured: TS2304 x3) -->
 ```tsx
 <AppShell navbar={<span className="font-semibold">Welcome</span>}>
   <SchemaRenderer schema={landingSchema} />
@@ -562,6 +568,7 @@ them reads `lg` (1024px), so 800px and 1400px get the same layout.
 
 Add Tailwind classes to layout components:
 
+<!-- doc-snippet: fragment — a JSX excerpt showing the `className` / `navbar` / `sidebar` slots — `AppShell`, `SidebarNav`, `SchemaRenderer`, `navItems` and `pageSchema` all come from the blocks above (measured: TS2304 x6) -->
 ```tsx
 <AppShell
   className="bg-background"
@@ -603,6 +610,7 @@ Control page content padding:
 
 Compose the shell once and let the page JSON change per route:
 
+<!-- doc-snippet: fragment — a JSX excerpt showing one shell reused across routes — `AppShell`, `SidebarNav`, `SchemaRenderer`, `navbar`, `navItems` and `pageSchema` all come from the blocks above (measured: TS2304 x6) -->
 ```tsx
 // One shell for the whole app; `pageSchema` is whatever the route resolves to.
 <AppShell navbar={navbar} sidebar={<SidebarNav items={navItems} />}>
@@ -660,6 +668,7 @@ Group related items with `NavGroup`. Pass groups instead of a flat list and `Sid
 labels each section and draws the separator between them itself — there is no `divider`
 item, and a row is either a link or a group, never both:
 
+<!-- doc-snippet: fragment — `lucide-react` supplies the `NavItem.icon` COMPONENTS this example is about. It is a dependency of ten workspace packages (`@object-ui/layout` among them) but not a root one, so the specifier does not resolve in this gate's program (measured: TS2307 x1). Probed with the icon import shimmed: the `NavGroup[]` literal and the `SidebarNav` props underneath are clean — 0 diagnostics -->
 ```tsx
 import { SidebarNav, type NavGroup } from '@object-ui/layout';
 import { DollarSign, Home, Settings } from 'lucide-react';

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -227,28 +227,43 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * Documents whose snippets are NOT compiled, each with the reason. The default
  * is covered; this list is the debt, by name, and it can only shrink.
  *
- * ⚠️ 2 of these entries are `.md` pages under `content/docs` that objectui#5174
- * made visible: the collector now reads `.md`, and an entry with a measured reason
- * is what a page that cannot pass yet is owed. They are DISCLOSED debt, not new
- * debt — every one of them was equally unverified before, just unnamed. Their
- * reasons carry the same measured diagnostic mix as the rest, and a symbol a
- * package does not export is called out by name, because that is the
- * reader-visible half (objectui#5160).
+ * ⚠️ ZERO of these entries are now `.md` pages under `content/docs`. There were 19
+ * when objectui#5174 made them visible — the collector reads `.md`, and an entry
+ * with a measured reason is what a page that cannot pass yet is owed — and that
+ * card then walked every one of them back OFF this list rather than re-wording its
+ * reason. The direction on that card was entries LEAVING, and it finished: what
+ * remains here is 12 `.mdx` pages and 32 package READMEs.
  *
- * That count was 19 until objectui#5174's triage batches, which walk pages OFF this
- * list rather than re-wording their reasons. The direction on that card is entries
- * LEAVING. Batch 1 took ten: `api/schema-reference`, `plugins/index`, and the
- * `guide/` pages `architecture-overview`, `deployment`, `expressions`,
- * `notifications`, `public-forms`, `schema-overview`, `troubleshooting` and
- * `user-state-persistence`. Batch 2 took four more — `guide/plugins`,
+ * Batch 1 took ten: `api/schema-reference`, `plugins/index`, and the `guide/` pages
+ * `architecture-overview`, `deployment`, `expressions`, `notifications`,
+ * `public-forms`, `schema-overview`, `troubleshooting` and `user-state-persistence`
+ * — clearing 90 diagnostics. Batch 2 took four more — `guide/plugins`,
  * `guide/building-crud-app`, `rfcs/0001-clipboard-paste` and `guide/architecture`
- * — clearing 89 diagnostics. Batch 3 took three — `guide/plugin-development`,
- * `guide/schema-rendering` and `guide/theming` — clearing 81, and left
- * `guide/layout` and `guide/component-registry` as the final pair.
- * Each page reached zero the honest two ways — a block
+ * — clearing 89. Batch 3 took three — `guide/plugin-development`,
+ * `guide/schema-rendering` and `guide/theming` — clearing 81. Batch 4 took the
+ * final pair, `guide/component-registry` (59) and `guide/layout` (45), clearing
+ * 104. Each page reached zero the honest two ways — a block
  * that should compile was made self-contained against the built `dist/`, and a
  * block that genuinely cannot compile got a `FRAGMENT_MARKER` declaration with a
  * written reason. Nothing about this gate's strictness moved to get them there.
+ *
+ * Batch 4 in the same terms as the batches below: 32 blocks brought under the gate
+ * — 23 declared fragments and 9 that compile, of which 5 already compiled untouched
+ * and 4 were edited to. Its defect was in the page's ONE complete copy-paste
+ * example: `guide/component-registry`'s `RatingComponent` calls `useState` while
+ * importing only `forwardRef` from `react`, so the block a reader is invited to
+ * take whole was broken at the first hook. The same block took `cn` from the
+ * reader's own `@/lib/utils` alias when `@object-ui/components` exports `cn`
+ * itself. Two things this gate CANNOT see on that page, stated because a green run
+ * must not be read as more than it is: `ComponentRegistry` is a `Registry<any>`, so
+ * `register()`'s component argument is `any` and no registered component's props
+ * are checked against what `SchemaRenderer` passes; and `BaseSchema` carries
+ * `[key: string]: any`, so a wrong key on a `BaseSchema`-shaped literal is
+ * structurally invisible here. What IS sealed — and therefore really checked —
+ * is `ComponentMeta`, `ComponentInput`, `NavItem`, `NavGroup`, `AppShellProps` and
+ * `SidebarNavProps`; every literal of those six on the two pages was measured
+ * clean, the `lucide-react` blocks by probing them with the icon import shimmed
+ * rather than by inferring it from the TS2307 that hid them.
  *
  * Batch 2's two routes in proportion, because the ratio is the reviewable part: it
  * brought 42 blocks under the gate — 34 declared fragments and 8 that compile, of
@@ -292,6 +307,17 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * app but is not a root dependency here.
  * `guide/plugins` and the clipboard-paste RFC document packages the reader is being
  * taught to create, and an RFC's signature excerpts have no bodies by design.
+ * `guide/layout` is the same shape as `guide/theming`, one layer out: four of its
+ * nine blocks import `lucide-react` for the icon COMPONENTS `NavItem.icon` takes,
+ * and that package — a dependency of ten workspace packages here, including
+ * `@object-ui/layout` — is not a root dependency, so the specifier does not resolve
+ * in this program. Hoisting a package to the repo root to buy a doc snippet
+ * coverage is a real dependency edge, so those blocks are declared instead, with
+ * what sits underneath them measured (via a shimmed icon import) rather than left
+ * unknown. `guide/component-registry`'s six category lists are markdown BULLET
+ * LISTS inside `tsx` fences — the fence language is the defect there, and
+ * correcting it is a change to the page's rendering rather than to a snippet, so it
+ * is declared here and left to its own change.
  *
  * objectui#5343 then read that list back and cleared it for the getting-started
  * pages: no entry for `content/docs/guide/**` or for
@@ -319,21 +345,6 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * @type {Record<string, string>}
  */
 const UNGATED_DOCS = {
-  'content/docs/guide/component-registry.md':
-    '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
-    '50 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 6 unresolved-module diagnostic(s). This entry read TS2305x13 TS2339x1 ' +
-    'until objectui#5343, which cleared the page of fabricated exports: `getComponentRegistry` ' +
-    '(@object-ui/react) x5 → the `ComponentRegistry` singleton @object-ui/core exports, ' +
-    '`registerDefaultRenderers` (@object-ui/components) x4 → `initializeComponents()` plus the ' +
-    'side-effect `@object-ui/fields` import, `BaseSchema` (@object-ui/core) x3 → @object-ui/types ' +
-    '(which is also what retired the TS2339, since the real `BaseSchema` declares `className`), ' +
-    'and `InputRenderer` (@object-ui/components), which nothing replaces — the built-in renderers ' +
-    'are registered by loading their package, never handed out one by one',
-  'content/docs/guide/layout.md':
-    '21 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
-    '20 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
-    'page never defines; 4 unresolved-module diagnostic(s)',
   'content/docs/guide/objectos-integration.mdx':
     '36 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; ' +
     '10 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +


### PR DESCRIPTION
Part of #5174 — batch 4, the final batch. These were the last two `content/docs` `.md` entries on the ledger.

## Ledger

| | before | after |
|:--|--:|--:|
| `UNGATED_DOCS` entries | 46 | **44** |
| covered documents | 176 | **178** (strictly grows) |
| `content/docs` `.md` entries remaining | 2 | **0** |
| diagnostics cleared | | **104** = `guide/component-registry` 59 + `guide/layout` 45 |

The `UNGATED_DOCS` hunk contains **only removals**, so "zero previously-covered docs newly ungated" is structurally impossible to violate in this diff. Verified programmatically against `d8b48f495`'s copy of the script: `ADDED ledger entries: []` · `previously-covered docs now UNGATED: []` · `surviving entries whose REASON TEXT changed: []` · `surviving entries with a non-measured reason: []`.

What remains on the ledger is 12 `.mdx` pages and 32 package READMEs.

## Routes — the two honest ones, no third

32 blocks brought under the gate: **9 compile** (5 already did untouched, 4 after an edit) and **23 declared fragments** with measured reasons.

| page | blocks | compile | fragments |
|:--|--:|--:|--:|
| `guide/component-registry.md` | 23 | 9 | 14 |
| `guide/layout.md` | 9 | 0 | 9 |

## The real defect, fixed rather than declared

`guide/component-registry.md`'s **one complete copy-paste example** — the `RatingComponent` the page invites a reader to take whole — calls `useState` while importing only `forwardRef` from `react`. It was broken at the first hook for anyone who copied it. The same block took `cn` from the reader's own `@/lib/utils` alias when `@object-ui/components` **exports `cn` itself**; sourcing it from the package makes the block compile and removes a dangling alias a reader may not have.

Three more blocks (`getAllTypes` / `has` / `getMeta`) were made self-contained by adding the one import a reader copying that block actually needs — the objectui#5047 disposition, applied to the document rather than to the harness.

## What this green run does NOT mean

Stated because a green run must not be read as more than it is:

- **`ComponentRegistry` is a `Registry` parameterised with `any`**, so `register()`'s component argument is `any`. No registered component's props are checked against what `SchemaRenderer` passes.
- **`BaseSchema` carries `[key: string]: any`**, so a wrong key on a `BaseSchema`-shaped literal is structurally invisible to this gate. "No excess-property errors" is not "the keys are right".

What **is** sealed, and therefore really checked: `ComponentMeta`, `ComponentInput`, `NavItem`, `NavGroup`, `AppShellProps`, `SidebarNavProps`. Every literal of those six across both pages was measured clean — the four `lucide-react` blocks by **probing them with the icon import shimmed**, not by inferring it from the `TS2307` that was hiding them. That probe is the batch-3 lesson applied: a broken import is a lid, so what sits under it gets measured, not assumed.

## Declared, with the reason recorded rather than worked around

- **`lucide-react`** supplies the icon *components* `NavItem.icon` takes. It is a dependency of ten workspace packages (`@object-ui/layout` among them) but **not a root dependency**, so the specifier does not resolve in this gate's program. Four `guide/layout.md` blocks are declared for it. Hoisting a package to the repo root to buy a doc snippet coverage is a real dependency edge — the same call batch 3 made for `class-variance-authority`.
- **`guide/component-registry.md`'s six category lists are markdown bullet lists inside `tsx` fences.** A leading `-` reads as unary minus on an undeclared name, and the form list does not even parse because `switch` is a keyword. The fence language is the underlying defect; correcting it changes the page's *rendering* rather than a snippet, which is neither of the two routes this batch is allowed, so it is declared here and recorded for its own change.

## Gate strictness — proven byte-for-byte, not argued

Everything from the `// ── Fence scanning` banner to EOF (`scanFences`, `listDocuments`, `derivePackageTypePaths`, `analyze`, `compileSnippets`, reporting, `main`) is **byte-identical** to `d8b48f495`: 475 lines, `sha256 dd9e52a11f116f3b` on **both** sides. `DOC_EXTENSIONS`, `TS_FENCE_LANGUAGES`, `FRAGMENT_MARKER`, `MIN_REASON_LENGTH` and `COMPILER_OPTIONS` each hash identical too. The script diff is the two removed entries plus the ledger docblock's own prose.

## `--build-filter` (#4846) — re-measured, not assumed

Filters **20 → 20**, the two sets textually identical (`diff` clean). Turbo build tasks **33 → 33**, identical package-by-package from `--dry=json` (`tasks ADDED: []`, `tasks REMOVED: []`). Covering these two pages costs this gate **zero** extra build tasks — the packages they import were already in the closure. Nothing for the maintainer to weigh.

## Verification

All at final commit `1178f9a9a`, working tree clean and byte-identical to what is pushed; the union was re-run **after** that commit. Exit codes captured before any pipe; every line quotes the gate's own printed verdict.

- `node scripts/check-doc-snippet-types.mjs` → exit 0: `Scanned 222 document(s): 178 covered (42 of them hold a ts/tsx block), 44 ungated` · `Covered blocks: 273 — 156 to compile, 117 declared fragment(s).` · `Syntax phase: every block parsed` · `Semantic phase: 156 of 156 block(s) judged, 0 failed.` · `Every covered documentation snippet compiles against the built types.` Controls green.
- `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts` → `Test Files 1 passed (1)` / `Tests 20 passed (20)`. Running the script is not running its test; both were run.
- `node scripts/check-doc-component-types.mjs` → exit 0: `Every documented component type is registered.`
- `node scripts/check-doc-links.mjs` → exit 0 · `node scripts/check-control-bytes.mjs` → exit 0 · `node scripts/check-skills-paths.mjs` → exit 0 · `node scripts/check-changeset-no-major.mjs` → exit 0 · `node scripts/check-lint-coverage.mjs` → exit 0 (`46/46 packages linted`).
- `node scripts/check-changeset-presence.mjs` → exit 0: `3 file(s) changed, 0 of them under the src/ of a package the release covers … no changeset is owed.` **Verdict followed; none added, and no `skip-changeset` label** (#4912/#3724).
- `pnpm run lint:root` — the complete root eslint task, run **whole, not narrowed** → exit 0: `26 problems (0 errors, 26 warnings)`, all pre-existing; the changed `.mjs` reports 0 errors / 0 warnings. Population read from eslint's own `--format json`: 166 files, **0 of them `.md`**, so both changed `.md` files are outside eslint's population by its own config; the other 46 lint tasks are per-package and this diff touches nothing under `packages/`, `apps/` or `examples/`.
- `pnpm check` → exit 0: `All checks passed`.

### Reverse verification

Prediction written to disk **before** each run with the direction stated. Build artifact between mutation and thing-under-test: **none** on either leg — the mutation is markdown the gate reads straight from disk and the `dist/*.d.ts` it compiles against is untouched — so no rebuild was needed. Each leg proved the mutation reached **disk** by grepping the specific text meant to change, and carried `trap … EXIT INT TERM` restoring with **`git checkout HEAD -- PATH`** (objectstack#11648: `git checkout REF -- PATH` writes the index, so a trap restoring with a bare `git checkout -- PATH` reads the mutation back and exits 0).

- **Leg 1**, revert `component-registry.md` only, ledger removal kept. Predicted exit 1 · exactly 59 diagnostics all on that page · fragments 117 → 103 · blocks-to-compile 156 → 170 · 1 syntax failure · NOTE printed · direction **MORE**. Observed exactly that, including the three named lines (`TS2304 'BaseSchema'`, `TS2307 './HeavyComponent'`, `TS2304 'useState'`).
- **Leg 2**, revert both pages. Predicted exit 1 · exactly 104 split **59 / 45 per page** · fragments 117 → 94 · blocks-to-compile 156 → 179 · covered blocks 273 unchanged · 3 syntax failures · direction **MORE**. Observed `104` split exactly `59 component-registry / 45 layout` — matching the baseline to the unit **and per page**.
- **Restore verified after each leg, not skipped**: `git diff HEAD` empty and `git status --short` empty, 23 markers back on disk, gate exit 0 with `156 of 156 block(s) judged, 0 failed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_