### PR TITLE
feat(types): close the dashboard widget type vocabulary and gate the plugin-dashboard catalog

### DIFF
--- a/.changeset/dashboard-widget-type-closed-enum.md
+++ b/.changeset/dashboard-widget-type-closed-enum.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/types": minor
+"@object-ui/plugin-designer": patch
+"@object-ui/app-shell": patch
+---
+
+Close the dashboard widget `type` vocabulary, and admit `metric-card` as objectui's own component extension.
+
+`DashboardWidgetSchema.type` was `string` on the TypeScript interface and `z.string()` in the Zod twin — an unbounded hatch. A typo'd family, a chart type the spec retired, and a component type nothing registers all type-checked and validated, surfacing only as the renderer's red `OBJUI-001` panel at runtime.
+
+It is now the CLOSED `DashboardWidgetTypeName` / `DashboardWidgetTypeSchema`: the spec's own `ChartTypeSchema` families **by reference**, plus two named, closed objectui extension sets — `DASHBOARD_WIDGET_TYPE_EXTENSIONS` (`list`, `custom`: objectui-only widget families) and `DASHBOARD_COMPONENT_WIDGET_TYPES` (`metric-card`: an objectui SDUI **component** type the widget slot holds directly, per the maintainer ruling of 2026-08-14 — objectui's own component enum, explicitly not the spec widget enum).
+
+Three drifts the closure surfaced and this change fixes: the dashboard designer's palette offered `grid`, which is not a widget family in either contract and was refused at publish; the metadata-admin widget inspector and the designer both wrote an unvalidated `string` from their select boxes; and a `@object-ui/types` fixture pinned `bar-chart`, a `plugin-charts` component type, on a dataset-bound widget that could never render as one.

--- a/examples/schema-catalog/test/plugin-dashboard-component-schema.test.ts
+++ b/examples/schema-catalog/test/plugin-dashboard-component-schema.test.ts
@@ -1,0 +1,340 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4600 — the standing validation gate for the `plugin-dashboard`
+ * catalog entries, against **objectui's own component schema**.
+ *
+ * ## Which schema, and why this file exists at all
+ *
+ * The card that opened this measured all 9 entries as REJECTED and concluded
+ * the corpus was teaching a shape the platform refuses. That measurement was
+ * taken with `@objectstack/spec`'s `DashboardSchema` — and the maintainer
+ * ruling of 2026-08-14 (objectstack#8593) says that is the wrong schema for
+ * these documents, verbatim:
+ *
+ *   > An SDUI dashboard COMPONENT node validates against objectui's OWN
+ *   > component schema; the spec's `DashboardSchema` governs stored dashboard
+ *   > METADATA documents only and grows no component projection. `metric-card`
+ *   > joins objectui's own CLOSED component enum as an explicitly allowed
+ *   > objectui extension, not the spec widget enum.
+ *
+ * So the two rejection classes the card counted are non-issues by definition:
+ * the missing `name` / `label` identity keys and the `{ type: 'dashboard',
+ * title }` envelope are what an SDUI component node correctly looks like. Under
+ * the schema the ruling names, re-measured on this tree, **9 of 9 are ACCEPTED**.
+ *
+ * ## Why acceptance alone is not a gate
+ *
+ * Measured on this tree BEFORE objectui#4600's change, `DashboardComponentSchema
+ * .safeParse` also accepted:
+ *
+ *   - `{ type: 'zzz-not-a-widget-type', title: 'x' }` — `DashboardWidgetSchema
+ *     .type` was `z.string()`, an unbounded hatch;
+ *   - a widget with no `type` at all;
+ *   - a widget carrying the retired pre-ADR-0021 inline analytics keys
+ *     (`object` / `categoryField` / `aggregate`) — silently STRIPPED, not
+ *     refused, which is the exact defect the card was opened about.
+ *
+ * A gate asserting only `.success` would therefore have passed by validating
+ * almost nothing, which is worse than no gate: `examples/schema-catalog`'s own
+ * `package.json` calls it the "single source of truth for example schemas
+ * consumed by the docs site, smoke tests, and AI few-shot retrieval", and
+ * `test/fields-form-hosted.test.tsx` records the objectui#3910 lesson in those
+ * words — *"what they show is what gets copied."*
+ *
+ * This gate therefore audits three things, and the `deliberately malformed`
+ * block at the bottom is the counter-probe that proves each one bites, by
+ * running the SAME {@link auditEntry} the real entries run:
+ *
+ *   1. the entry parses under `DashboardComponentSchema`;
+ *   2. every widget names a type in the CLOSED vocabulary (`DashboardWidget
+ *      TypeSchema` — the spec's families plus objectui's two closed extension
+ *      sets). The catalog holds itself to `type` being PRESENT, which the
+ *      shared schema leaves optional for stored dashboards;
+ *   3. no authored key is silently dropped. Each widget is routed to the schema
+ *      that actually owns it — a `metric-card` widget slot holds an objectui
+ *      COMPONENT node, so its body is `BaseSchema`'s (passthrough: `value` /
+ *      `icon` / `trend` / `trendValue` are `plugin-dashboard`'s registry
+ *      `inputs`, not widget keys), while every other widget is the spec-derived
+ *      `DashboardWidgetSchema`'s. Check 3 is what catches a stale or
+ *      mis-layered key that check 1 would strip in silence.
+ *
+ * ## Deliberately NOT catalog-wide
+ *
+ * Fenced to `plugin-dashboard`. objectui#4616 records 35 non-dashboard gallery
+ * entries still unregistered; a catalog-wide gate lights those up and is a
+ * different card with a different decision behind it.
+ *
+ * Sibling gate: `plugin-dashboard-global-filters-spec.test.ts` pins the
+ * `globalFilters[]` sub-surface against the spec's own `GlobalFilterSchema`
+ * (objectui#4356). That one is about STORED-metadata fidelity of a sub-object;
+ * this one is about the component node. They are complementary, not redundant.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  BaseSchema,
+  DashboardComponentSchema,
+  DashboardWidgetSchema,
+  DashboardWidgetTypeSchema,
+} from '@object-ui/types/zod';
+import { DASHBOARD_COMPONENT_WIDGET_TYPES } from '@object-ui/types';
+import { examplesByCategory } from '../src/index.js';
+
+const entries = examplesByCategory('plugin-dashboard');
+
+/** objectui COMPONENT types legal in a widget slot — the ruling's closed enum. */
+const COMPONENT_WIDGET_TYPES = new Set<string>(DASHBOARD_COMPONENT_WIDGET_TYPES);
+
+type Widget = Record<string, unknown>;
+
+/**
+ * Keys that legitimately do not survive a widget parse, and are not evidence of
+ * a mis-layered document. `component` is the legacy envelope: it is declared,
+ * it parses, and its BODY is a `SchemaNode` audited on its own terms — it is
+ * listed here only because a nested node's key set is not this function's
+ * business.
+ */
+const NOT_A_DROP = new Set(['component']);
+
+/**
+ * Audit ONE widget. Returns a list of human-readable problems; empty means clean.
+ *
+ * The routing in here is the gate's substance: which schema owns a widget is
+ * decided by the ruling, not by convenience.
+ */
+function auditWidget(widget: Widget, where: string): string[] {
+  const problems: string[] = [];
+
+  // ── 2. the type names something in the closed vocabulary ─────────────────
+  const type = widget.type;
+  if (typeof type !== 'string' || type === '') {
+    // A widget with no `type` is legal for the shared schema (stored dashboards
+    // and the legacy `component` envelope omit it) but never for a CATALOG
+    // entry: an example with no component descriptor teaches nothing and
+    // renders the registry's OBJUI-001 panel.
+    if (!widget.component) {
+      problems.push(`${where}: no \`type\` and no \`component\` envelope — nothing names a component`);
+    }
+  } else {
+    // Defence in depth, and deliberately so. Today `DashboardComponentSchema`
+    // refuses an unknown type by itself, so check 1 already reports these — the
+    // counter-probe below asserts BOTH messages appear. This restatement is
+    // what survives if `DashboardWidgetSchema.type` is ever loosened back
+    // toward `z.string()`, which is precisely the regression objectui#4600
+    // closed: the catalog would keep its own floor instead of going quietly
+    // green with the contract.
+    const known = DashboardWidgetTypeSchema.safeParse(type);
+    if (!known.success) {
+      problems.push(`${where}: \`type: '${type}'\` is outside the closed widget vocabulary`);
+    }
+  }
+
+  // ── 3. no authored key is silently dropped ───────────────────────────────
+  // A component-extension widget IS an objectui SDUI component node, so the
+  // schema that owns its body is objectui's own `BaseSchema` — the ruling's
+  // "objectui's own component schema" — which is passthrough and therefore
+  // keeps the component's props. Everything else is a spec-derived widget.
+  const isComponentNode = typeof type === 'string' && COMPONENT_WIDGET_TYPES.has(type);
+  const owner = isComponentNode ? BaseSchema : DashboardWidgetSchema;
+  const ownerName = isComponentNode ? 'BaseSchema (objectui component node)' : 'DashboardWidgetSchema';
+
+  const parsed = owner.safeParse(widget);
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      problems.push(`${where}: refused by ${ownerName} — [${issue.path.join('.')}] ${issue.message}`);
+    }
+    return problems;
+  }
+
+  const kept = parsed.data as Record<string, unknown>;
+  const dropped = Object.keys(widget).filter((key) => !NOT_A_DROP.has(key) && !(key in kept));
+  if (dropped.length > 0) {
+    problems.push(
+      `${where}: ${ownerName} silently DROPS authored key(s) ${dropped.map((k) => `\`${k}\``).join(', ')} — ` +
+      'a key no contract declares is inert metadata, and this corpus is copied verbatim by AI authors',
+    );
+  }
+  return problems;
+}
+
+/** Audit one dashboard component node end to end. */
+function auditEntry(schema: unknown, id: string): string[] {
+  const problems: string[] = [];
+
+  // ── 1. the node parses under objectui's own component schema ─────────────
+  // Deliberately NOT an early return: a corpus gate should report everything
+  // wrong with an entry in one run, and checks 2 and 3 are independent of this
+  // one (check 3 in particular catches keys check 1 strips in silence).
+  const result = DashboardComponentSchema.safeParse(schema);
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      problems.push(`${id}: [${issue.path.join('.')}] ${issue.message}`);
+    }
+  }
+
+  const widgets = (schema as { widgets?: unknown }).widgets;
+  if (!Array.isArray(widgets)) {
+    problems.push(`${id}: \`widgets\` is not an array`);
+    return problems;
+  }
+  widgets.forEach((widget, index) => {
+    if (widget === null || typeof widget !== 'object' || Array.isArray(widget)) {
+      problems.push(`${id}: widgets[${index}] is not an object`);
+      return;
+    }
+    problems.push(...auditWidget(widget as Widget, `${id}: widgets[${index}]`));
+  });
+  return problems;
+}
+
+describe('schema-catalog plugin-dashboard — entries validate against objectui\'s own component schema', () => {
+  /**
+   * NON-VACUITY CONTROLS. Both assertions below are `it.each` over collected
+   * arrays, and `it.each([])` reports NOTHING rather than failing — so a
+   * refactor that broke the collection (a renamed category, a changed registry
+   * shape) would turn this whole gate silently green. The sibling
+   * `globalFilters` gate applies the same discipline for the same reason.
+   */
+  it('the category is non-empty', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('the sweep reaches widgets across more than one entry', () => {
+    const widgetCount = entries.reduce((total, example) => {
+      const widgets = (example.schema as { widgets?: unknown }).widgets;
+      return total + (Array.isArray(widgets) ? widgets.length : 0);
+    }, 0);
+    expect(widgetCount).toBeGreaterThan(0);
+    expect(entries.length).toBeGreaterThan(1);
+  });
+
+  it.each(entries.map((example) => [example.id, example.schema] as const))(
+    '%s is a clean dashboard component node',
+    (id, schema) => {
+      // Surface the schema's own messages — a bare `.success` boolean tells the
+      // next reader that something is wrong and nothing about what.
+      expect(auditEntry(schema, id)).toEqual([]);
+    },
+  );
+
+  /**
+   * A `metric-card` widget really is exercised, in more than one entry — the
+   * assertion above is `it.each` and would be silent if the ruling's component
+   * extension vanished from the corpus. This is the pin that keeps the
+   * `BaseSchema` routing arm of `auditWidget` reachable.
+   */
+  it('the corpus exercises the objectui component extension the ruling admits', () => {
+    const componentWidgets = entries.flatMap((example) => {
+      const widgets = (example.schema as { widgets?: Widget[] }).widgets ?? [];
+      return widgets
+        .filter((widget) => typeof widget.type === 'string' && COMPONENT_WIDGET_TYPES.has(widget.type))
+        .map((widget) => ({ id: example.id, widget }));
+    });
+    expect(componentWidgets.length).toBeGreaterThan(0);
+    expect(new Set(componentWidgets.map((w) => w.id)).size).toBeGreaterThan(1);
+    // And its props genuinely survive — the whole reason the routing exists.
+    for (const { id, widget } of componentWidgets) {
+      const parsed = BaseSchema.parse(widget) as Record<string, unknown>;
+      for (const key of Object.keys(widget)) {
+        expect(Object.keys(parsed), `${id}: BaseSchema must keep \`${key}\``).toContain(key);
+      }
+    }
+  });
+});
+
+/**
+ * COUNTER-PROBE — the teeth proof.
+ *
+ * Every case below is a real catalog entry with ONE deliberate defect, run
+ * through the SAME `auditEntry` the block above runs. If a future refactor
+ * loosens the gate, these turn red before a bad example can land. Each case
+ * also names WHICH of the three checks is meant to catch it, so a case that
+ * starts passing for the wrong reason is visible.
+ */
+describe('counter-probe — the gate refuses deliberately malformed entries', () => {
+  /**
+   * The control must lead with a SPEC-FAMILY widget, not a component-extension
+   * one: the `check 3` mutants below add a stray key to `widgets[0]`, and a
+   * `metric-card` widget routes to passthrough `BaseSchema`, where nothing is
+   * dropped and the probe could never bite.
+   */
+  const clean = entries.find((e) => {
+    const widgets = (e.schema as { widgets?: Widget[] }).widgets;
+    const first = Array.isArray(widgets) ? widgets[0] : undefined;
+    return !!first && typeof first.type === 'string' && !COMPONENT_WIDGET_TYPES.has(first.type);
+  });
+
+  it('a clean fixture entry was found to mutate', () => {
+    expect(clean).toBeDefined();
+    expect(auditEntry(clean!.schema, 'control')).toEqual([]);
+  });
+
+  /** Deep-clone the control entry and hand its first widget to `mutate`. */
+  const mutantOf = (mutate: (widget: Widget, doc: Record<string, unknown>) => void) => {
+    const doc = JSON.parse(JSON.stringify(clean!.schema)) as Record<string, unknown>;
+    mutate((doc.widgets as Widget[])[0], doc);
+    return doc;
+  };
+
+  const cases: Array<[string, (w: Widget, d: Record<string, unknown>) => void, RegExp]> = [
+    [
+      'check 2 — a widget type nothing registers (the OBJUI-001 red panel at runtime)',
+      (w) => { w.type = 'metrci-card'; },
+      // Both halves must fire: the shared schema's own enum message AND the
+      // catalog's restatement of it.
+      /Invalid option: expected one of[\s\S]*outside the closed widget vocabulary/,
+    ],
+    [
+      'check 2 — a chart family the spec retired',
+      (w) => { w.type = 'heatmap'; },
+      /Invalid option: expected one of[\s\S]*outside the closed widget vocabulary/,
+    ],
+    [
+      'check 2 — a widget naming no component at all',
+      (w) => { delete w.type; },
+      /no `type` and no `component` envelope/,
+    ],
+    [
+      'check 3 — the pre-ADR-0021 inline analytics keys this card was opened about',
+      (w) => { w.object = 'opportunity'; w.categoryField = 'stage'; w.aggregate = 'sum'; },
+      /silently DROPS authored key\(s\).*`object`.*`categoryField`.*`aggregate`/,
+    ],
+    [
+      'check 3 — a single mis-layered renderer setting left at widget top level',
+      (w) => { w.dateGranularity = 'month'; },
+      /silently DROPS authored key\(s\) `dateGranularity`/,
+    ],
+    [
+      'check 1 — a retired key the spec tombstoned, refused rather than dropped',
+      (w) => { w.actionUrl = '/opportunities'; },
+      /actionUrl/,
+    ],
+    [
+      'check 1 — the dashboard envelope itself broken',
+      (_w, d) => { d.type = 'dashbaord'; },
+      /type/,
+    ],
+  ];
+
+  it.each(cases)('%s', (_label, mutate, expected) => {
+    const problems = auditEntry(mutantOf(mutate), 'mutant');
+    expect(problems.length, 'the mutant must be reported').toBeGreaterThan(0);
+    expect(problems.join('\n')).toMatch(expected);
+  });
+
+  /**
+   * The counter-probe's own counter-probe: mutating NOTHING must stay clean.
+   * Without this, a bug that made `auditEntry` report on every input would make
+   * every case above pass while the gate rejected the whole corpus.
+   */
+  it('an unmutated clone is still clean', () => {
+    expect(auditEntry(mutantOf(() => {}), 'unmutated')).toEqual([]);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
@@ -29,7 +29,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@object-ui/components';
-import type { DashboardWidgetSchema } from '@object-ui/types';
+import type { DashboardWidgetSchema, DashboardWidgetTypeName } from '@object-ui/types';
 import { resolveDashboardFilterDefs, type DashboardFilterDef, type ComponentMeta } from '@object-ui/core';
 import type { MetadataInspectorProps } from '../inspector-registry.js';
 import { t, tFormat } from '../i18n.js';
@@ -49,7 +49,14 @@ import type { ObjectFieldInfo } from '../previews/useObjectFields.js';
 // (object / valueField / categoryField / aggregate) was removed from the spec
 // at @objectstack/spec 9.0.0 and is no longer authored here — its fields are
 // gone so no Studio surface can emit the dead shape (framework#3251).
-const WIDGET_TYPES = [
+/**
+ * The widget families this inspector offers. TYPED to `DashboardWidgetTypeName`
+ * (objectui#4600, which closed the widget `type` vocabulary) so the inspector
+ * cannot offer a type validation refuses — every entry here is a spec
+ * visualization family. A hand-written SUBSET is fine; offering something
+ * outside the vocabulary is not.
+ */
+const WIDGET_TYPES: ReadonlyArray<{ value: DashboardWidgetTypeName; label: string }> = [
   { value: 'metric', label: 'KPI Metric' },
   { value: 'bar', label: 'Bar Chart' },
   { value: 'horizontal-bar', label: 'Horizontal Bar' },
@@ -286,7 +293,14 @@ export function DashboardWidgetInspector({
       <Field id="widget-type" label={t('engine.inspector.widget.type', locale)}>
         <Select
           value={widget.type ?? 'metric'}
-          onValueChange={(v) => patchWidget({ type: v })}
+          onValueChange={(v) => {
+            // Resolve the Select's string against the list that rendered the
+            // items rather than casting it onto the closed type — a value not in
+            // the palette writes nothing instead of storing a `type` the
+            // platform refuses at publish.
+            const picked = WIDGET_TYPES.find((wt) => wt.value === v);
+            if (picked) patchWidget({ type: picked.value });
+          }}
           disabled={readOnly}
         >
           <SelectTrigger id="widget-type">

--- a/packages/plugin-designer/src/DashboardEditor.tsx
+++ b/packages/plugin-designer/src/DashboardEditor.tsx
@@ -24,7 +24,7 @@
  */
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import type { DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
+import type { DashboardComponentSchema, DashboardWidgetSchema, DashboardWidgetTypeName } from '@object-ui/types';
 import {
   Trash2,
   GripVertical,
@@ -35,7 +35,6 @@ import {
   PieChart,
   TrendingUp,
   Table2,
-  LayoutGrid,
   X,
   Undo2,
   Redo2,
@@ -81,13 +80,36 @@ export interface DashboardEditorProps {
 // Constants
 // ============================================================================
 
-const WIDGET_TYPES = [
+/**
+ * The widget families this editor offers.
+ *
+ * TYPED to `DashboardWidgetTypeName` (objectui#4600): the palette must never
+ * offer a type validation refuses, which is the "designer saves what the server
+ * rejects" failure AGENTS.md #0.1 names. Before that card closed the widget
+ * `type` vocabulary this array was inferred as `string[]`, and it had drifted —
+ * it offered `grid`, which is neither a spec visualization family
+ * (`ChartTypeSchema`) nor a member of objectui's own `DASHBOARD_WIDGET_TYPES`
+ * (`@object-ui/types`' exported list for exactly this purpose, which
+ * `WidgetConfigPanel` already derives its options from). A widget saved as
+ * `type: 'grid'` resolved through `ComponentRegistry` to the VIEW grid — an
+ * empty tile — and was refused at publish. Nothing pinned it: no test in this
+ * package referenced it, and `PageDesigner`'s own `grid` palette entry is a
+ * different surface and is untouched.
+ *
+ * This is a hand-written subset, not the full vocabulary — a designer may offer
+ * fewer families than validation accepts. The direction that must hold is
+ * SUBSET, and `@object-ui/types`' parity suite pins it.
+ */
+const WIDGET_TYPES: ReadonlyArray<{
+  type: DashboardWidgetTypeName;
+  label: string;
+  Icon: typeof TrendingUp;
+}> = [
   { type: 'metric', label: 'KPI Metric', Icon: TrendingUp },
   { type: 'bar', label: 'Bar Chart', Icon: BarChart3 },
   { type: 'line', label: 'Line Chart', Icon: LineChart },
   { type: 'pie', label: 'Pie Chart', Icon: PieChart },
   { type: 'table', label: 'Table', Icon: Table2 },
-  { type: 'grid', label: 'Grid', Icon: LayoutGrid },
 ];
 
 let widgetCounter = 0;
@@ -353,7 +375,14 @@ function WidgetPropertyPanel({
           id="widget-type"
           data-testid="widget-prop-type"
           value={widget.type ?? 'metric'}
-          onChange={(e) => onChange({ type: e.target.value })}
+          onChange={(e) => {
+            // Resolve the DOM string against the very list that rendered the
+            // options, rather than casting it onto the closed type. No cast, no
+            // tolerance: a value not in the palette writes nothing at all,
+            // instead of storing a `type` the platform refuses at publish.
+            const picked = WIDGET_TYPES.find((t) => t.type === e.target.value);
+            if (picked) onChange({ type: picked.type });
+          }}
           disabled={readOnly}
           className="block w-full rounded-md border border-gray-300 px-2.5 py-1.5 text-sm outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50"
         >
@@ -511,7 +540,7 @@ export function DashboardEditor({
   const selectedWidget = widgets.find((w) => w.id === selectedWidgetId);
 
   const addWidget = useCallback(
-    (type: string) => {
+    (type: DashboardWidgetTypeName) => {
       const id = createWidgetId();
       const newWidget: DashboardWidgetSchema = {
         id,

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -331,7 +331,15 @@ describe('P1.2 FormView Spec Alignment', () => {
 describe('P1.3 Dashboard Spec Alignment', () => {
   it('should accept widget dataset binding properties (ADR-0021)', () => {
     const widget: DashboardWidgetSchema = {
-      type: 'bar-chart',
+      // `bar`, not `bar-chart`. This fixture said `bar-chart` until objectui#4600
+      // closed the widget `type` vocabulary and tsc reported it: `bar-chart` is a
+      // `plugin-charts` COMPONENT type, not a widget visualization family, and the
+      // spec's family for this chart is `bar`. A dataset-bound widget naming it
+      // never reaches `DatasetWidget` — `classifyWidgetType` returns `passthrough`
+      // — so the fixture was pinning a shape that cannot render what it describes.
+      // The assertions below are about the ADR-0021 dataset binding and are
+      // unaffected by the spelling.
+      type: 'bar',
       title: 'Revenue by Region',
       filter: [['stage', '=', 'Closed Won']],
       dataset: 'opportunity_metrics',

--- a/packages/types/src/__tests__/report-chart-query-spec-parity.test.ts
+++ b/packages/types/src/__tests__/report-chart-query-spec-parity.test.ts
@@ -36,11 +36,14 @@ import ts from 'typescript';
 import {
   AppContextSelectorSchema as SpecAppContextSelectorSchema,
   GlobalFilterSchema as SpecGlobalFilterSchema,
+  ChartTypeSchema as SpecChartTypeSchema,
   DashboardWidgetSchema as SpecDashboardWidgetSchema,
 } from '@objectstack/spec/ui';
 import type { JoinedReportBlock as SpecJoinedReportBlock } from '@objectstack/spec/ui';
 import { AppContextSelectorSchema } from '../zod/app.zod.js';
-import { DashboardWidgetSchema, GlobalFilterSchema } from '../zod/complex.zod.js';
+import { DashboardWidgetSchema, DashboardWidgetTypeSchema, GlobalFilterSchema } from '../zod/complex.zod.js';
+import { DASHBOARD_COMPONENT_WIDGET_TYPES, DASHBOARD_WIDGET_TYPE_EXTENSIONS } from '../complex.js';
+import { DASHBOARD_WIDGET_TYPES } from '../designer.js';
 import type { DashboardWidgetSchema as DashboardWidgetInterface } from '../complex.js';
 import {
   liftLegacyGlobalFilterDefault,
@@ -500,10 +503,60 @@ describe('DashboardWidgetSchema pinned divergences', () => {
   });
 
   it('widens `type` for the objectui-only `list` / `custom` families', () => {
-    for (const type of ['list', 'custom']) {
+    for (const type of DASHBOARD_WIDGET_TYPE_EXTENSIONS) {
       expect(DashboardWidgetSchema.safeParse({ id: 'w', type }).success).toBe(true);
       // If the spec adopts either family, drop the widening and use its enum.
       expect(SpecDashboardWidgetSchema.safeParse({ id: 'w', type }).success).toBe(false);
+    }
+  });
+
+  it('admits `metric-card` as objectui\'s own COMPONENT extension (ruling 2026-08-14)', () => {
+    // objectstack#8593, maintainer, verbatim: `metric-card` joins objectui's own
+    // CLOSED component enum as an explicitly allowed objectui extension, NOT the
+    // spec widget enum. Both halves are asserted — the second is what keeps this
+    // an objectui-local extension instead of a quiet spec change.
+    for (const type of DASHBOARD_COMPONENT_WIDGET_TYPES) {
+      expect(DashboardWidgetSchema.safeParse({ id: 'w', type }).success).toBe(true);
+      expect(SpecDashboardWidgetSchema.safeParse({ id: 'w', type }).success).toBe(false);
+    }
+  });
+
+  it('CLOSES `type` — the widening is a named set, not an open hatch', () => {
+    // The regression this guards is objectui#4600's: `type` was `z.string()`,
+    // so a typo'd family, a component nothing registers, and a chart type the
+    // spec retired all validated and only surfaced as the renderer's red
+    // OBJUI-001 panel. `examples/schema-catalog` is an AI few-shot retrieval
+    // source, so an accepted-but-unrenderable `type` is copied onward.
+    for (const type of ['zzz-not-a-widget-type', 'metrci-card', 'heatmap', 'sunburst']) {
+      const result = DashboardWidgetSchema.safeParse({ id: 'w', type });
+      expect(result.success, `'${type}' must be refused`).toBe(false);
+    }
+  });
+
+  it('takes the spec half of the vocabulary BY REFERENCE, not as a copy', () => {
+    // Every family the spec models must be accepted here without an edit — the
+    // "narrower than the contract it implements" failure this file records for
+    // `label` and `defaultRange` would otherwise reappear on `type`, and a
+    // family the spec ADDS would be a legal document objectui refuses.
+    for (const type of SpecChartTypeSchema.options) {
+      expect(DashboardWidgetSchema.safeParse({ id: 'w', type }).success, `spec family '${type}'`).toBe(true);
+    }
+    // And the closed enum is EXACTLY the spec's families plus the two declared
+    // objectui sets — no third, undocumented member has crept in.
+    expect(new Set(DashboardWidgetTypeSchema.options)).toEqual(new Set([
+      ...SpecChartTypeSchema.options,
+      ...DASHBOARD_WIDGET_TYPE_EXTENSIONS,
+      ...DASHBOARD_COMPONENT_WIDGET_TYPES,
+    ]));
+  });
+
+  it('keeps the designer\'s offer list inside the closed vocabulary', () => {
+    // `DASHBOARD_WIDGET_TYPES` (designer.ts) is what `WidgetConfigPanel` offers
+    // an author. It is a SEPARATE list from the validation vocabulary and is
+    // deliberately shorter, but it must never offer a type validation refuses —
+    // that would be a designer that saves what the platform rejects.
+    for (const type of DASHBOARD_WIDGET_TYPES) {
+      expect(DashboardWidgetTypeSchema.safeParse(type).success, `designer offers '${type}'`).toBe(true);
     }
   });
 

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -647,6 +647,8 @@ const EXCLUSIONS: Readonly<Record<string, string>> = {
     "a union OVER the mirrors, not an object of its own — its members are checked individually above",
   'complex.zod.ts#CalendarViewModeSchema':
     "a bare vocabulary with no `.shape`; it is checked where a mirrored KEY declares it",
+  'complex.zod.ts#DashboardWidgetTypeSchema':
+    "a bare vocabulary with no `.shape`; it is checked where a mirrored KEY declares it — `DashboardWidgetSchema.type` (objectui#4600), whose TS twin `DashboardWidgetTypeName` is a union, not a key set",
   'complex.zod.ts#FilterOperatorSchema':
     "a bare vocabulary with no `.shape`; it is checked where a mirrored KEY declares it",
   'complex.zod.ts#FilterBuilderConditionSchema':

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -699,6 +699,77 @@ export interface FloatingChatbotConfig {
 }
 
 /**
+ * objectui COMPONENT types admitted into a dashboard **widget slot** — the
+ * CLOSED enum the maintainer ruling of 2026-08-14 (objectstack#8593) directs
+ * `metric-card` into, verbatim: *an SDUI dashboard COMPONENT node validates
+ * against objectui's own component schema; the spec's `DashboardSchema` governs
+ * stored dashboard metadata documents only and grows no component projection;
+ * `metric-card` joins objectui's own CLOSED component enum as an explicitly
+ * allowed objectui extension, NOT the spec widget enum.*
+ *
+ * A member here is not a visualization family at all. `classifyWidgetType`
+ * (`@object-ui/plugin-dashboard`'s `widgetDispatch.ts`) returns `passthrough`
+ * for it, and `DashboardRenderer` then hands `{ ...widget }` straight to
+ * `SchemaRenderer`, which resolves it through `ComponentRegistry` — so the
+ * widget slot is holding an ordinary objectui SDUI **component node** whose
+ * other keys are that component's own props (`value` / `icon` / `trend` /
+ * `trendValue` for `metric-card`, declared as registry `inputs` at
+ * `plugin-dashboard/src/index.tsx`). Those props are NOT widget keys and must
+ * not be added to {@link DashboardWidgetSchema}; a member of this list is
+ * validated as a component node against objectui's own passthrough
+ * `BaseSchema`, which is what keeps them.
+ *
+ * ⛔ CLOSED on purpose. The ruling's triage block named an open
+ * "extension allowed" hatch as the thing to avoid: an open hatch re-creates
+ * exactly the hole the catalog gate exists to close, because a typo'd or
+ * retired `type` would keep validating. Adding a member is a deliberate act
+ * with a registration behind it — `examples/schema-catalog/test/
+ * plugin-dashboard-component-schema.test.ts` is the standing gate, and
+ * `__tests__/report-chart-query-spec-parity.test.ts` pins the closure.
+ */
+export const DASHBOARD_COMPONENT_WIDGET_TYPES = ['metric-card'] as const;
+
+/** An objectui component type legal in a dashboard widget slot. */
+export type DashboardComponentWidgetType = (typeof DASHBOARD_COMPONENT_WIDGET_TYPES)[number];
+
+/**
+ * objectui-only widget FAMILIES — visualization families objectui renders that
+ * `@objectstack/spec`'s `ChartTypeSchema` does not model. Distinct from
+ * {@link DASHBOARD_COMPONENT_WIDGET_TYPES} above: these two really are widget
+ * types (`classifyWidgetType` routes `list` to the table family and `custom` to
+ * the author-supplied-`component` branch), they just have no spec counterpart.
+ *
+ * The pre-existing divergence, previously carried only as prose on the `type`
+ * key ("widened off the spec's enum") and enforced nowhere. If the spec adopts
+ * either family, drop it from here and let it flow in from the spec enum.
+ */
+export const DASHBOARD_WIDGET_TYPE_EXTENSIONS = ['list', 'custom'] as const;
+
+/** An objectui-only dashboard widget family. */
+export type DashboardWidgetTypeExtension = (typeof DASHBOARD_WIDGET_TYPE_EXTENSIONS)[number];
+
+/**
+ * The CLOSED vocabulary a dashboard widget's `type` may name.
+ *
+ * The spec half flows in BY REFERENCE (`SpecDashboardWidget['type']`, i.e. the
+ * spec's `ChartTypeSchema`) rather than being restated, so a family the spec
+ * adds or retires lands here with no edit — the same discipline
+ * {@link DashboardWidgetSchema} already uses for its key set. objectui's own
+ * two extension sets are spelled out above, each with its own reason.
+ *
+ * This used to be bare `string`. That was the open hatch: `type: 'metrci-card'`
+ * type-checked, validated, and rendered the registry's red OBJUI-001 panel —
+ * and `examples/schema-catalog` is an AI few-shot retrieval source, so what it
+ * shows is what gets copied.
+ *
+ * Zod twin: `zod/complex.zod.ts` `DashboardWidgetTypeSchema`.
+ */
+export type DashboardWidgetTypeName =
+  | NonNullable<SpecDashboardWidget['type']>
+  | DashboardWidgetTypeExtension
+  | DashboardComponentWidgetType;
+
+/**
  * Dashboard Widget Layout
  */
 export interface DashboardWidgetLayout {
@@ -757,11 +828,16 @@ export interface DashboardWidgetSchema
   component?: SchemaNode;
   layout?: DashboardWidgetLayout;
   /**
-   * Widget visualization type (spec shorthand format).
-   * Widened off the spec's 19-family enum: objectui's `DASHBOARD_WIDGET_TYPES`
-   * also carries `list` and `custom`, which the spec does not model.
+   * Widget visualization type (spec shorthand format), or an objectui component
+   * type the widget slot holds directly.
+   *
+   * CLOSED — see {@link DashboardWidgetTypeName}. The spec's families flow in by
+   * reference; objectui's additions are the two named, closed extension sets.
+   * It was `string` until objectui#4600, which is why a retired family, a typo,
+   * or a component type nothing registers all type-checked here and only
+   * surfaced as the renderer's red OBJUI-001 panel at runtime.
    */
-  type?: string;
+  type?: DashboardWidgetTypeName;
   /** Widget-specific configuration (spec shorthand format). Kept `unknown` — objectui
    *  renderers pass widget-family-specific bags the spec's `options` object does not model. */
   options?: unknown;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -277,12 +277,24 @@ export type {
   DashboardWidgetLayout,
   DashboardWidgetSchema,
   DashboardComponentSchema,
+  DashboardComponentWidgetType,
+  DashboardWidgetTypeExtension,
+  DashboardWidgetTypeName,
   ChatMessage,
   ChatMessageSource,
   ChatToolInvocation,
   ChatbotSchema,
   FloatingChatbotConfig,
   ComplexSchema,
+} from './complex.js';
+
+/**
+ * The two CLOSED extension sets a dashboard widget's `type` may draw on beyond
+ * the spec's own families (objectui#4600, maintainer ruling 2026-08-14).
+ */
+export {
+  DASHBOARD_COMPONENT_WIDGET_TYPES,
+  DASHBOARD_WIDGET_TYPE_EXTENSIONS,
 } from './complex.js';
 
 // ============================================================================

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -330,8 +330,8 @@ export const DashboardWidgetLayoutSchema = z.object({
  * Composed of three sets, each reached the way its own provenance demands:
  *
  *  - the spec's 20 visualization families, BY REFERENCE off
- *    `ChartTypeSchema.options` — the same enum `SpecDashboardWidgetSchema.shape
- *    .type` wraps in a `.default()`. Restating them here would be the
+ *    `ChartTypeSchema.options` — the same enum the spec's own
+ *    `DashboardWidgetSchema.shape.type` wraps in a `.default()`. Restating them here would be the
  *    "narrower than the contract it implements" shape this file already
  *    records twice (`label`, `defaultRange`): a family the spec ADDS would be a
  *    legal document objectui refuses.

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -18,12 +18,17 @@
 
 import { z } from 'zod';
 import {
+  ChartTypeSchema as SpecChartTypeSchema,
   DashboardSchema as SpecDashboardSchema,
   DashboardWidgetSchema as SpecDashboardWidgetSchema,
   GlobalFilterSchema as SpecGlobalFilterSchema,
 } from '@objectstack/spec/ui';
 import { BaseSchema, SchemaNodeSchema, specFieldsExcept } from './base.zod.js';
 import { DASHBOARD_COLOR_VARIANTS, DASHBOARD_WIDGET_TYPES } from '../designer.js';
+import {
+  DASHBOARD_COMPONENT_WIDGET_TYPES,
+  DASHBOARD_WIDGET_TYPE_EXTENSIONS,
+} from '../complex.js';
 
 /**
  * Kanban Card Schema
@@ -318,6 +323,49 @@ export const DashboardWidgetLayoutSchema = z.object({
 });
 
 /**
+ * The CLOSED vocabulary a dashboard widget's `type` may name — Zod twin of
+ * `../complex.ts` {@link DashboardWidgetTypeName}, and the enforcement half of
+ * the 2026-08-14 maintainer ruling on objectstack#8593.
+ *
+ * Composed of three sets, each reached the way its own provenance demands:
+ *
+ *  - the spec's 20 visualization families, BY REFERENCE off
+ *    `ChartTypeSchema.options` — the same enum `SpecDashboardWidgetSchema.shape
+ *    .type` wraps in a `.default()`. Restating them here would be the
+ *    "narrower than the contract it implements" shape this file already
+ *    records twice (`label`, `defaultRange`): a family the spec ADDS would be a
+ *    legal document objectui refuses.
+ *  - `DASHBOARD_WIDGET_TYPE_EXTENSIONS` — objectui-only widget FAMILIES
+ *    (`list`, `custom`). The pre-existing divergence, until objectui#4600
+ *    carried only as the prose "widened to `z.string()`" and enforced nowhere.
+ *  - `DASHBOARD_COMPONENT_WIDGET_TYPES` — objectui COMPONENT types the widget
+ *    slot holds directly (`metric-card`). The ruling puts it HERE and
+ *    explicitly not in the spec widget enum, which is a different repo and a
+ *    different contract.
+ *
+ * ⛔ Closed, not `z.string()`. The open form is what let the catalog ship
+ * widgets naming types nothing registers: measured on this tree before the
+ * change, `DashboardComponentSchema.safeParse` ACCEPTED a widget with
+ * `type: 'zzz-not-a-widget-type'` and one with no `type` at all, so a gate
+ * built on it would have passed by validating nothing.
+ *
+ * ⚠️ A member of `DASHBOARD_COMPONENT_WIDGET_TYPES` is a component node, and
+ * this schema is NOT the schema for its body: the object below strips undeclared
+ * keys, so `metric-card`'s own props (`value`, `icon`, `trend`, `trendValue` —
+ * registry `inputs`, not widget keys) do not survive a parse here. They are
+ * kept by objectui's own passthrough component schema, `BaseSchema`, which is
+ * the schema the ruling names for a component node. The standing gate
+ * (`examples/schema-catalog/test/plugin-dashboard-component-schema.test.ts`)
+ * routes each widget to whichever of the two owns it and asserts neither loses
+ * an authored key.
+ */
+export const DashboardWidgetTypeSchema = z.enum([
+  ...SpecChartTypeSchema.options,
+  ...DASHBOARD_WIDGET_TYPE_EXTENSIONS,
+  ...DASHBOARD_COMPONENT_WIDGET_TYPES,
+]);
+
+/**
  * Dashboard Widget Schema — DERIVED from `@objectstack/spec/ui`
  * (objectstack#4115): every spec key flows in **by reference** via
  * {@link specFieldsExcept}, so a key the spec adds or retypes cannot silently
@@ -334,9 +382,12 @@ export const DashboardWidgetLayoutSchema = z.object({
  * Two pinned divergences plus one objectui-only extension:
  *  - `id` relaxed to optional — the spec requires it, but stored objectui
  *    dashboards (and the legacy `component` format below) omit it.
- *  - `type` widened to `z.string()` — objectui's `DASHBOARD_WIDGET_TYPES` also
- *    carries `list` and `custom`, which the spec's 19-family visualization enum
- *    does not model. Narrowing here would reject widgets the designer emits.
+ *  - `type` re-pointed at {@link DashboardWidgetTypeSchema} — the spec's own
+ *    enum plus objectui's two CLOSED extension sets. It was `z.string()` until
+ *    objectui#4600; the widening was real (objectui renders `list` / `custom`,
+ *    and the 2026-08-14 ruling admits the `metric-card` component type) but it
+ *    was spent as an unbounded hatch rather than a named set, so every typo and
+ *    every retired family validated too.
  *  - `component` — the legacy `{ id, component: <SDUI node>, layout }` envelope,
  *    which the spec has no room for. Migration to the shorthand form is deferred.
  *
@@ -347,7 +398,8 @@ export const DashboardWidgetSchema = specFieldsExcept(SpecDashboardWidgetSchema.
   'type',
 ] as const).extend({
   id: z.string().optional().describe('Widget ID'),
-  type: z.string().optional().describe('Widget visualization type (spec shorthand; widened for `list`/`custom`)'),
+  type: DashboardWidgetTypeSchema.optional()
+    .describe('Widget visualization type — the spec families plus objectui\'s closed `list`/`custom` and `metric-card` extensions'),
   component: SchemaNodeSchema.optional().describe('Widget Component (legacy format)'),
 });
 

--- a/packages/types/src/zod/index.zod.ts
+++ b/packages/types/src/zod/index.zod.ts
@@ -232,6 +232,7 @@ export {
   ChatMessageSchema,
   ChatbotSchema,
   DashboardWidgetLayoutSchema,
+  DashboardWidgetTypeSchema,
   DashboardWidgetSchema,
   DashboardComponentSchema,
   DashboardWidgetConfigSchema,


### PR DESCRIPTION
Fixes #4600

Implements the maintainer ruling of 2026-08-14 (objectstack#8593) — the `(d2)` remainder of this card. `(d1)` landed earlier as #4615 and is **not** redone here; re-verified rather than assumed (see below).

## The card's premise, re-measured — and falsified

The card's headline was **"9 of 9 REJECT"**, measured at `92250d648` against `@objectstack/spec`'s `DashboardSchema`. The ruling says that is the wrong schema for these documents: an SDUI dashboard **component** node validates against objectui's **own** component schema, and the spec's `DashboardSchema` governs stored **metadata documents** only.

Re-measured on this tree with the schema the ruling names:

```
ACCEPT  basic-dashboard.json                       ACCEPT  filtered-dashboard-filter-types.json
ACCEPT  e-commerce-dashboard.json                  ACCEPT  filtered-dashboard-target-widgets.json
ACCEPT  filtered-dashboard-dataset-widgets.json    ACCEPT  filtered-dashboard.json
ACCEPT  filtered-dashboard-date-presets.json       ACCEPT  support-dashboard.json
ACCEPT  filtered-dashboard-dynamic-options.json

=== 0 of 9 REJECT under objectui DashboardComponentSchema
```

**9 of 9 accepted.** Classes A and B were artefacts of the wrong schema, exactly as the ruling says, so no identity keys were added and no envelope was stripped. C1 re-verified as already landed: the six `filtered-*` entries carry the live `dataset` / `dimensions` / `values` and `options` shapes, not the retired inline-analytics form.

## But acceptance alone would have been a gate that validates nothing

Measured on this tree **before** any change, the same `DashboardComponentSchema.safeParse` also accepted:

| input | verdict (before) |
| --- | --- |
| `{ type: 'zzz-not-a-widget-type', title: 'x' }` | **ACCEPT** |
| a widget with no `type` at all | **ACCEPT** |
| `{ type: 'metric', categoryField: 'stage', aggregate: 'sum' }` | **ACCEPT** — the three keys silently stripped |

`DashboardWidgetSchema.type` was `string` on the interface and `z.string()` in the Zod twin. So a gate asserting `.success` would have passed by validating almost nothing — the outcome this card explicitly names as worse than no gate. Closing that hatch is what makes the gate real, and it is also literally what the ruling asks for: `metric-card` joins a **CLOSED** enum, not an open "extension allowed" hatch.

## What this PR does

**1. Closes the widget `type` vocabulary** (`packages/types`), composed three ways, each by its own provenance:

- the spec's 20 families **by reference** off `ChartTypeSchema.options` — restating them would reproduce the "narrower than the contract it implements" bug this file already records for `label` and `defaultRange`;
- `DASHBOARD_WIDGET_TYPE_EXTENSIONS` = `list`, `custom` — the pre-existing objectui-only **families**, until now carried only as the prose "widened to `z.string()`" and enforced nowhere;
- `DASHBOARD_COMPONENT_WIDGET_TYPES` = `metric-card` — objectui's own CLOSED **component** enum, per the ruling, explicitly **not** the spec widget enum. `@objectstack/spec` is untouched; Clause-② stays `no`.

TS (`DashboardWidgetTypeName`) and Zod (`DashboardWidgetTypeSchema`) both close, so declared = enforced. The 2026-08-17 TypeScript-face comment was verified, not re-derived: `DashboardComponentSchema` is at `complex.ts` (now `:800`), there is still no per-family widget type, and `MetricCardProps` is still not re-exported — nothing here re-exports it or invents a `MetricCardSchema`.

**2. Adds the standing gate** — `examples/schema-catalog/test/plugin-dashboard-component-schema.test.ts`. Three checks per entry: it parses under `DashboardComponentSchema`; every widget names a type in the closed vocabulary; **no authored key is silently dropped**. The third routes each widget to the schema that actually owns it — a `metric-card` widget slot holds an objectui **component node**, so its body is passthrough `BaseSchema`'s (which is why `value` / `icon` / `trend` / `trendValue`, `plugin-dashboard`'s registry `inputs`, survive), while every other widget is the spec-derived widget schema's.

Fenced to `plugin-dashboard`, deliberately. #4616's 35 unregistered non-dashboard gallery entries would light up under a catalog-wide gate; that is a different card with a different decision behind it. Reported, not built.

**3. Counter-probe** (the card's Zone 3 requirement). Seven mutants of a real entry, run through the **same** `auditEntry` the real entries run, each naming which check must catch it — plus an unmutated clone that must stay clean, so a bug making the audit report on everything cannot make the probes pass vacuously.

## Three real drifts the closure surfaced

Each is the same defect class as this card — a widget `type` no contract declares — and each was mechanical, with the correct form pinned by existing evidence. Named here rather than folded in silently:

- **`plugin-designer/src/DashboardEditor.tsx`** offered a **`grid`** widget. It is not a spec family and not in `@object-ui/types`' own `DASHBOARD_WIDGET_TYPES` (the exported list `WidgetConfigPanel` already derives from) — it resolved through `ComponentRegistry` to the *view* grid and was refused at publish: designer saves what the server rejects. Removed; nothing pinned it (no test in that package referenced it, and `PageDesigner`'s own `grid` palette entry is a different surface, untouched).
- **`app-shell`'s widget inspector** and the designer both wrote an unvalidated `string` from their select boxes. Both now resolve the DOM string against the list that rendered the options — no cast, no consumer-side tolerance: a value not in the palette writes nothing rather than storing a refused `type`.
- **`p1-spec-alignment.test.ts`** pinned `type: 'bar-chart'` on a dataset-bound widget. `bar-chart` is a `plugin-charts` *component* type; the spec's family is `bar`, and `classifyWidgetType` returns `passthrough` for it, so the fixture pinned a shape that can never render what it describes. Spelling corrected; its ADR-0021 assertions are unaffected.

## Verification

All at `a54b8bca4` (the pushed head).

- **Typecheck**, 7 packages (`types`, `plugin-dashboard`, `plugin-designer`, `app-shell`, `sdui-parser`, `core`, `schema-catalog`) — exit 0, 0 errors. This is also the cross-package reverse verification: the `plugin-designer` and `app-shell` errors appeared only after `@object-ui/types` was rebuilt, proving consumers read the new `.d.ts` and not a cached one.
- **Tests** — `packages/types/src/__tests__` + `examples/schema-catalog/test`: **65 files, 2240 passed**. Plus `plugin-dashboard` + `plugin-designer` (88 files / 802) and `app-shell`'s `metadata-admin` (195 files / 1982) green.
- **Lint** — per-package `lint` on all four touched packages: exit 0, **0 errors** (warnings are pre-existing). A full-repo `eslint . --no-inline-config` run (3623 files) was also completed in-cap; the single finding in a file this PR touches is at `index.ts:1190`, ~900 lines from any hunk here, and is an artefact of `--no-inline-config` suppressing that file's own `eslint-disable` pair.
- **Reverse verification (TS)** — restoring `type: 'bar-chart'` gives `error TS2322: Type '"bar-chart"' is not assignable to type 'DashboardWidgetTypeName | undefined'`; restore is byte-identical (empty diffstat) and green again.
- **Ablation (the gate's teeth, on a real entry, not a synthetic one)** — injecting `object` + `categoryField` + `aggregate` into `filtered-dashboard.json` turns the gate **red**, naming all three keys on the real entry. Mutation confirmed on disk by grep count on the injected text (`categoryField` 1, `aggregate` 1) before the run, and absence confirmed after (`0`) with an empty diffstat; restore leg green, 21/21. The script carried a `trap … EXIT INT TERM` restore throughout.
- **Ledger** — `DashboardWidgetTypeSchema` registered in `zod-mirror-parity`'s `EXCLUSIONS` (a bare vocabulary with no `.shape`). One docblock line was reworded because that guard's spec-dependency scan attributes a trailing docblock to the *preceding* export, and naming the local `Spec…` alias there would have recorded `DashboardWidgetLayoutSchema` as spec-derived — false.

## Out of scope, filed

**#6002** — `DashboardWidgetSchema` silently DROPS every **undeclared** key (`z.object()` strip semantics), while keys the spec *retired* are refused by name with a tombstone. That asymmetry is why the pre-ADR-0021 keys validate clean today, and closing it (`.strict()` vs `.passthrough()`) is a published-contract decision needing a stored/designer population measurement first. This PR protects the corpus against it catalog-locally; it protects nothing else in the repo.

#4616 (35 unregistered gallery entries) is noted above and left alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_