### PR TITLE
docs(scripts): record the withdrawal of the vacuous byte-identity sentence

### DIFF
--- a/scripts/check-changeset-presence.mjs
+++ b/scripts/check-changeset-presence.mjs
@@ -123,6 +123,57 @@
  * contract, and the same one this gate exists to close one level up. Note the
  * direction: for a filter deciding whether to RUN work, "cannot tell" means run;
  * here the work IS the decision, so "cannot tell" means fail.
+ *
+ * ## A withdrawn sentence that survives in five released CHANGELOGs (objectui#5913)
+ *
+ * Recorded here once, because the five copies cannot be corrected in place and
+ * this header is where findings of this shape live. objectui#4580's changeset —
+ * the `SchemaNode` de-duplication — closed with:
+ *
+ *     Core's entry surface is unchanged: `dist/index.d.ts` is byte-identical
+ *     across the change.
+ *
+ * That sentence is a VACUOUS MEASUREMENT. objectui#5673 withdrew it from the
+ * source docstring it was also written into
+ * (`packages/core/src/types/index.ts`), which now carries the full account and
+ * the calibration recipe; this is the pointer for anyone who arrives from a
+ * CHANGELOG instead.
+ *
+ * It is vacuous because `core/dist/index.d.ts` is emitted from a barrel that
+ * only FORWARDS the symbol, and forwarding never restates a shape — not
+ * `export` of everything, and not the named `export type { SchemaNode, … } from
+ * './types/index.js'` line either. Only the module that DECLARES the symbol can
+ * move. So that file is byte-identical under ANY change to a re-exported
+ * declaration's shape, including one that breaks every consumer, and a gauge
+ * that cannot fail for the change class it is quoted against has discharged
+ * nothing. #5673's PR measured exactly that: a probe key added to the declaring
+ * module moved `@object-ui/types`' `dist/base.d.ts` and brought it back, while
+ * `core/dist/index.d.ts` and `core/dist/types/index.d.ts` held one hash across
+ * all three legs. The withdrawn sentence was watching the two files that cannot
+ * move.
+ *
+ * The five copies are NOT edited, and that is a ruling (maintainer, 2026-08-24),
+ * not an omission. The release tooling composes CHANGELOGs from `.changeset/*.md`
+ * at release time, so hand-editing the compiled artifact leaves the pipeline
+ * this gate exists to protect; and the same text is already published to npm on
+ * five packages, where a repo-side edit recalls nothing and only makes the
+ * repository disagree with what shipped. The withdrawal is therefore recorded
+ * once, here.
+ *
+ * Where the copies are, verified at `8d3a5294a`:
+ *
+ *     packages/components/CHANGELOG.md:1472
+ *     packages/core/CHANGELOG.md:1021
+ *     packages/plugin-dashboard/CHANGELOG.md:581
+ *     packages/react/CHANGELOG.md:450
+ *     packages/types/CHANGELOG.md:705
+ *
+ * CHANGELOGs are append-heavy and those line numbers move; the sentence does
+ * not. Re-derive them with
+ * `git grep -nI "is byte-identical across the change"`, which is a search and
+ * its own control at once: the phrase is known-present, and it returned these
+ * five plus one unrelated i18n test under `packages/fields`. Six files means the
+ * search worked; zero means it broke, not that the copies are gone.
  */
 
 import { execFileSync } from 'node:child_process';


### PR DESCRIPTION
Fixes #5913

Implements the 2026-08-24 ruling (option C, maintainer verbatim: 「接受你的建议。」). One comment block added to the header of `scripts/check-changeset-presence.mjs`. Nothing else in the repo is touched.

## What the ruling required, and what is here

The #4580 changeset closed with *"Core's entry surface is unchanged: `dist/index.d.ts` is byte-identical across the change."* #5673 withdrew that sentence from the source docstring it was also written into, but the release tooling had already copied the changeset verbatim into five package CHANGELOGs, where it survives with no trace of the withdrawal.

The new section states all three things the ruling named:

1. **The sentence was a vacuous measurement, withdrawn by #5673.**
2. **Why it is vacuous** — `core/dist/index.d.ts` is emitted from a barrel that only *forwards* the symbol, and forwarding never restates a shape, so that file is byte-identical under any change to a re-exported declaration's shape. #5673's PR measured it: a probe key on the declaring module moved `@object-ui/types`' `dist/base.d.ts` and brought it back, while `core/dist/index.d.ts` and `core/dist/types/index.d.ts` held one hash across all three legs. The withdrawn sentence was watching the two files that cannot move.
3. **The file list**, so an archaeologist landing on any one of the five copies can find the withdrawal.

It also records *why the five are not edited* — compiled release artifacts stay on the changeset pipeline, and the npm copies are immutable — so the next reader does not re-open the question as an oversight.

## The five line references were re-verified, not copied

A correction record whose own pointers are wrong is the same defect class as the sentence it corrects, so the card's search was re-run at `8d3a5294a` (the branch point) rather than trusted:

| control | result |
| --- | --- |
| exact sentence | exit 0, the five files below |
| known-present `is byte-identical across the change` | exit 0, **six** files — the five plus one unrelated i18n test under `packages/fields` |
| known-absent string | **exit 1**, zero lines — so an empty result is distinguishable from a broken search |

All five line numbers from the card still hold:

```
packages/components/CHANGELOG.md:1472
packages/core/CHANGELOG.md:1021
packages/plugin-dashboard/CHANGELOG.md:581
packages/react/CHANGELOG.md:450
packages/types/CHANGELOG.md:705
```

Because CHANGELOGs are append-heavy and these numbers will drift, the record does not rely on them alone: it carries the `git grep -nI` recipe that re-derives them, and states the six-file expectation so a future reader can tell a working search from a broken one.

## Scope: no check, no test, no `UNGATED` entry

The gate's behaviour is unchanged. The diff is **51 insertions, 0 deletions, one file**, and every added line is a comment line — verified mechanically:

```
$ git diff -U0 -- scripts/check-changeset-presence.mjs | grep -E '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^\+ \*'
(no output — every changed line is a header comment line)
```

The header's own documented trap was respected: the added text contains no comment-terminator sequence that would close the block early (checked with `grep -F` before insertion), and no control bytes.

## Changeset

The gate that decides this is the file being edited. Run, verdict quoted either way:

```
$ node scripts/check-changeset-presence.mjs        # exit 0
Compared the working tree with 8d3a5294a (merge-base with origin/main): 1 file(s)
changed, 0 of them under the src/ of a package the release covers, 0 under a
package changesets ignores, 0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

None owed — so none is added, not even the empty-frontmatter form.

## Gates run locally, union re-run at `ea197938b` (the final commit)

| gate | exit | verdict line |
| --- | --- | --- |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅  check-control-bytes: OK (scanned 4970 tracked text file(s); skipped 85 binary).` |
| `vitest run scripts/__tests__/check-changeset-presence.test.ts` | 0 | `Test Files 1 passed (1) · Tests 31 passed (31)` |
| `tsc -p tsconfig.scripts.json` | 0 | clean |
| `eslint` over the full `lint:root` scope | 0 | `✖ 26 problems (0 errors, 26 warnings)` — all warnings pre-existing, none in the edited file |

Exit codes were captured by redirect-then-capture, never through a pipe. The `lint:root` lane was run at **full scope**, not narrowed. This repo has no `scripts/pm/dispatch-gates.mjs`, so the family was derived by hand from the root `package.json` scripts and `.github/workflows/changeset-presence.yml`; CI runs the full farm.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_