### PR TITLE
fix(plugin-view): spell the views-prop sort direction key `order`, not `direction`

### DIFF
--- a/.changeset/5293-view-sort-order-spelling.md
+++ b/.changeset/5293-view-sort-order-spelling.md
@@ -17,8 +17,8 @@ here so that a host still writing it can find this entry by searching the old ke
   />
 ```
 
-**Nothing that worked stops working, because `direction` never worked.** No reader in the
-repo has ever known the word. All three consumers of the resolved `activeView.sort` read
+**Nothing that worked stops working on this surface, because on the `views` prop
+`direction` never worked.** All three consumers of the resolved `activeView.sort` read
 `order`: the non-grid fetch lowers it through the shared sink `convertSortToQueryParams`,
 whose `entry.order === 'desc'` is false for a missing key; the grid path forwards it to
 `ObjectGridSchema.sort`, where `ObjectGrid` builds the wire string `` `${s.field} ${s.order}` ``
@@ -31,6 +31,16 @@ failure signal anywhere: the declaration said the value was well-formed, and the
 was dropped at three independent readers rather than rejected at one. This rename does not
 take away a feature — it converts a silent wrong answer into a loud type error at the one
 place that can still be fixed cheaply.
+
+**Scope — one published export still accepts `direction`, and this release does not retire
+it.** `toSortItems` (`packages/plugin-view/src/config/view-config-utils.ts`, re-exported
+from the package root and listed in the README) folds `s.order || s.direction || 'asc'`.
+It serves a different surface — the studio inspector-draft that feeds `SortBuilder` — and
+it is not reachable from the `views` prop, so it neither affects nor is affected by this
+rename. If you migrate by searching for the old key, that is the other hit you will find:
+it is dormant (nothing in this repo calls it outside a test), and removing it would be a
+separate break on a separate public export, tracked as objectui#6011. It is not a partial
+retirement of this one.
 
 `order` is the spelling every other sort surface already uses (`SortConfig`,
 `NamedListView.sort`, `ObjectGridSchema.sort` / `.defaultSort`, and the shared

--- a/.changeset/5293-view-sort-order-spelling.md
+++ b/.changeset/5293-view-sort-order-spelling.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/plugin-view': minor
+---
+
+**Breaking (shipped as `minor` per AGENTS.md §版本号策略).** `ObjectViewProps.views[].sort`
+now spells its direction key **`order`**. The retired spelling is **`direction`** — named
+here so that a host still writing it can find this entry by searching the old key
+(objectui#5293).
+
+```diff
+  <ObjectView
+    views={[{
+      id: 'recent', label: 'Recent', type: 'grid',
+-     sort: [{ field: 'created_at', direction: 'desc' }],
++     sort: [{ field: 'created_at', order: 'desc' }],
+    }]}
+  />
+```
+
+**Nothing that worked stops working, because `direction` never worked.** No reader in the
+repo has ever known the word. All three consumers of the resolved `activeView.sort` read
+`order`: the non-grid fetch lowers it through the shared sink `convertSortToQueryParams`,
+whose `entry.order === 'desc'` is false for a missing key; the grid path forwards it to
+`ObjectGridSchema.sort`, where `ObjectGrid` builds the wire string `` `${s.field} ${s.order}` ``
+— literally `"created_at undefined"` — and `parseSchemaSort` reads a missing `order` as
+ascending, so the column header even drew an ascending arrow; `mergedSort` hands the same
+value to the delegated list view.
+
+So a host writing the exact shape the prop declared got an **ascending** list with no
+failure signal anywhere: the declaration said the value was well-formed, and the direction
+was dropped at three independent readers rather than rejected at one. This rename does not
+take away a feature — it converts a silent wrong answer into a loud type error at the one
+place that can still be fixed cheaply.
+
+`order` is the spelling every other sort surface already uses (`SortConfig`,
+`NamedListView.sort`, `ObjectGridSchema.sort` / `.defaultSort`, and the shared
+`QuerySortEntry` sink), so the prop now has one spelling repo-wide and declared equals
+enforced.
+
+⛔ Deliberately **not** a tolerant dual-read (`direction ?? order`): that is the tolerance
+layer objectui#4869 ruled against, and admitting the old key as an alias would rebuild the
+drift this change removes. `SortUI` is untouched — it legitimately owns `direction` on its
+own `SortUISchema` and converts at its boundaries.

--- a/packages/app-shell/src/views/view-config-adapter.test.ts
+++ b/packages/app-shell/src/views/view-config-adapter.test.ts
@@ -15,7 +15,7 @@ describe('view-config-adapter', () => {
         type: 'grid',
         columns: ['name', 'status'],
         filter: [{ field: 'owner', op: 'eq', value: 'me' }],
-        sort: [{ field: 'name', direction: 'asc' }],
+        sort: [{ field: 'name', order: 'asc' }],
         showSearch: true,
       };
       const draft = runtimeViewToInspectorDraft(view, 'crm_lead');
@@ -79,7 +79,7 @@ describe('view-config-adapter', () => {
         type: 'grid',
         columns: ['name', 'status', 'owner'],
         filter: [{ field: 'status', op: 'eq', value: 'open' }],
-        sort: [{ field: 'created_at', direction: 'desc' }],
+        sort: [{ field: 'created_at', order: 'desc' }],
         showSearch: true,
         showFilters: false,
         pageSize: 50,

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -246,13 +246,20 @@ export interface ObjectViewProps {
    * `sort` spells its direction key `order`, like every other sort surface in
    * the repo (`SortConfig`, `NamedListView.sort`, `ObjectGridSchema.sort` /
    * `.defaultSort`) and like the shared sink `convertSortToQueryParams` reads
-   * it. It used to be declared as `direction` (objectui#5293), which NO reader
-   * ever knew: all three consumers of the resolved `activeView.sort` read
-   * `order`, so a host writing `direction: 'desc'` got a SILENTLY ascending
-   * list — the sink's `entry.order === 'desc'` is false for a missing key, the
-   * grid built the wire string `name undefined`, and `parseSchemaSort` drew an
-   * ascending arrow above it. The rename does not remove a working feature;
-   * it converts that silent wrong answer into a loud type error.
+   * it. It used to be declared as `direction` (objectui#5293), which NO
+   * consumer of THIS prop ever read: all three consumers of the resolved
+   * `activeView.sort` read `order`, so a host writing `direction: 'desc'` got a
+   * SILENTLY ascending list — the sink's `entry.order === 'desc'` is false for
+   * a missing key, the grid built the wire string `name undefined`, and
+   * `parseSchemaSort` drew an ascending arrow above it. The rename does not
+   * remove a working feature; it converts that silent wrong answer into a loud
+   * type error.
+   *
+   * The claim is scoped to those three consumers on purpose. Elsewhere in this
+   * package the published `toSortItems` export still folds
+   * `s.order || s.direction` for the studio inspector-draft — a different
+   * surface, unreachable from this prop, and deliberately not retired here
+   * (objectui#6011).
    *
    * ⛔ Deliberately NOT a tolerant dual-read (`direction ?? order`) — that is
    * the tolerance layer objectui#4869 ruled against, and re-adding it here

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -242,13 +242,28 @@ export interface ObjectViewProps {
    * Views available for the ViewSwitcher.
    * Each view defines a type (grid, kanban, calendar, etc.) and display columns/config.
    * If not provided, uses schema.listViews or falls back to default grid view.
+   *
+   * `sort` spells its direction key `order`, like every other sort surface in
+   * the repo (`SortConfig`, `NamedListView.sort`, `ObjectGridSchema.sort` /
+   * `.defaultSort`) and like the shared sink `convertSortToQueryParams` reads
+   * it. It used to be declared as `direction` (objectui#5293), which NO reader
+   * ever knew: all three consumers of the resolved `activeView.sort` read
+   * `order`, so a host writing `direction: 'desc'` got a SILENTLY ascending
+   * list — the sink's `entry.order === 'desc'` is false for a missing key, the
+   * grid built the wire string `name undefined`, and `parseSchemaSort` drew an
+   * ascending arrow above it. The rename does not remove a working feature;
+   * it converts that silent wrong answer into a loud type error.
+   *
+   * ⛔ Deliberately NOT a tolerant dual-read (`direction ?? order`) — that is
+   * the tolerance layer objectui#4869 ruled against, and re-adding it here
+   * would restore the very spelling drift this declaration now closes.
    */
   views?: Array<{
     id: string;
     label: string;
     type: ViewType;
     columns?: string[];
-    sort?: Array<{ field: string; direction: 'asc' | 'desc' }>;
+    sort?: Array<{ field: string; order: 'asc' | 'desc' }>;
     filter?: any[];
     [key: string]: any;
   }>;

--- a/packages/plugin-view/src/__tests__/ObjectView.sortSink.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.sortSink.test.tsx
@@ -192,23 +192,47 @@ describe('precedence is unchanged by the lowering', () => {
 });
 
 describe('the census the card asked for: no spelling regressed on the way in', () => {
-  it('leaves the `views` prop spelling exactly where it already was — objectui#5293', async () => {
-    // ⚠️ NOT this card's defect and NOT fixed here. `ObjectViewProps.views[]`
-    // declares `sort?: Array<{ field, direction }>` while every consumer reads
-    // `order`, so the direction is dropped. Measured BOTH ways: unlowered, the
-    // adapter's `shorthand(field, undefined)` sent ascending `name`; lowered,
-    // the sink's `entry.order === 'desc'` is equally false and sends
-    // `{ name: 'asc' }`. Same answer before and after — the lowering neither
-    // fixes objectui#5293 nor makes it worse. Pinned so that whoever DOES fix
-    // that card is told this site exists.
+  it("carries a `views` prop sort through to the sink, DESCENDING — objectui#5293", async () => {
+    // This assertion is the fix. It replaces a pin that asserted
+    // `{ name: 'asc' }` for a `direction: 'desc'` fixture — green not because
+    // anything worked but because NOTHING read the key, which is exactly the
+    // silent wrong answer objectui#5293 was filed about. `ObjectViewProps`
+    // now declares `sort?: Array<{ field, order }>`, the one spelling every
+    // consumer and the shared sink already read, so the authored direction
+    // survives to `$orderby` instead of being dropped on the way in.
     const ds = mockDataSource();
     render(
       <ObjectView
         schema={{ type: 'object-view', objectName: 'task' } as ObjectViewSchema}
-        views={[{ id: 'v1', label: 'V1', type: 'calendar', sort: [{ field: 'name', direction: 'desc' }] }] as any}
+        views={[{ id: 'v1', label: 'V1', type: 'calendar', sort: [{ field: 'name', order: 'desc' }] }]}
         dataSource={ds as any}
       />,
     );
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(ds.find.mock.calls[0][1].$orderby).toEqual({ name: 'desc' });
+  });
+
+  it('the old `direction` spelling is refused by the declaration, not silently dropped', async () => {
+    // The other half of objectui#5293, and the reason the break is worth
+    // shipping: a host that still writes the retired spelling must FAIL, and
+    // fail at the type boundary rather than by rendering an ascending list.
+    // The `@ts-expect-error` IS the assertion — it turns red if the excess
+    // property is ever admitted again, which is precisely what a tolerant
+    // dual-read (`direction ?? order`) would do. ⛔ objectui#4869 ruled that
+    // tolerance layer out; this line is the guard that keeps it out.
+    const ds = mockDataSource();
+    render(
+      <ObjectView
+        schema={{ type: 'object-view', objectName: 'task' } as ObjectViewSchema}
+        // @ts-expect-error — `direction` is not a key of the sort entry (objectui#5293)
+        views={[{ id: 'v1', label: 'V1', type: 'calendar', sort: [{ field: 'name', direction: 'desc' }] }]}
+        dataSource={ds as any}
+      />,
+    );
+    // Runtime behaviour of the retired spelling is unchanged and deliberately
+    // still asserted: it orders ascending. That is what makes the type error
+    // the ONLY failure signal a host gets, and why the changeset names the
+    // old key so the break is searchable.
     await waitFor(() => expect(ds.find).toHaveBeenCalled());
     expect(ds.find.mock.calls[0][1].$orderby).toEqual({ name: 'asc' });
   });

--- a/packages/plugin-view/src/__tests__/ObjectView.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.test.tsx
@@ -487,7 +487,7 @@ describe('ObjectView', () => {
 
       // Update with sort config — simulates live preview of sort changes
       const updatedViews = [
-        { id: 'all', label: 'All', type: 'grid' as const, columns: ['name'], sort: [{ field: 'name', direction: 'desc' as const }] },
+        { id: 'all', label: 'All', type: 'grid' as const, columns: ['name'], sort: [{ field: 'name', order: 'desc' as const }] },
       ];
 
       rerender(


### PR DESCRIPTION
Fixes #5293

Implements the maintainer ruling of 2026-08-24 (Route 2), verbatim: 「四维分析一致的，接手你的建议。」

`ObjectViewProps.views[].sort` declared `{ field, direction }` while every consumer of the resolved `activeView.sort` reads `order`. The key is renamed to `order`, matching every other sort surface in the repo and the shared sink. Verification union run at `604c2036`.

## Why the break costs nothing

Nothing has ever read `direction`. Re-derived on the current tree rather than trusting the card (which was verified at `12841b617`, five days stale — line numbers had all moved and one consumer had changed mechanism):

| consumer | reads | a `direction` entry yields |
| --- | --- | --- |
| non-grid fetch (`ObjectView.tsx:786`) | `convertSortToQueryParams(sort)`, whose `entry.order === 'desc'` is false for a missing key | `{ name: 'asc' }` |
| grid path (`:1364`) | `ObjectGridSchema.sort` → `` `${s.field} ${s.order}` `` | wire string `"name undefined"`, and `parseSchemaSort` draws an **ascending** arrow |
| `mergedSort` (`:1499`) | forwarded to the delegated list view | unchanged |

A host writing the exact shape the prop declared got an ascending list with **no failure signal**. The rename converts a silent wrong answer into a loud type error. That framing is in the changeset, which names the retired spelling so an external host can search for it.

Note the card's stated mechanism for the first consumer no longer holds: #4869 landed, so the non-grid fetch now lowers through the shared sink instead of passing `$orderby` raw. The outcome is identical (`entry.order` is equally absent), so the conclusion survives — but it was re-measured, not assumed.

## ⛔ Not a tolerant dual-read

No `direction ?? order` anywhere. That is the tolerance layer #4869 ruled against. A `@ts-expect-error` guard in `ObjectView.sortSink.test.tsx` now turns **red** if the old key is ever readmitted, so the prohibition is mechanically enforced rather than only documented.

## The ruling's producer list was wrong in one place — corrected here

The ruling named two in-repo `direction` producers. Measured against the tree, one is misattributed and two more exist:

- ✅ **`packages/app-shell/src/views/view-config-adapter.test.ts`** (`:18`, `:82`) — round-trip fixtures, corrected. PM assumption 2 **confirmed**: `view-config-adapter.ts` itself has **0** hits for `direction` (`sort?: unknown[]`), and the round-trip asserts `expect(back.sort).toEqual(view.sort)`, so it is spelling-agnostic behaviourally as well as by type. Blast radius is as the ruling priced it.
- ⛔ **`packages/plugin-view/src/index.tsx:177` — NOT touched, the ruling misattributed it.** That `defaultProps` block belongs to `ComponentRegistry.register('sort-ui', SortUI, …)` (the enclosing `register` call opens at `:158`), i.e. it is **SortUI's own** default, where `direction` is type-**correct**: `SortUISchema.sort` declares `direction: 'asc' | 'desc'` (`packages/types/src/views.ts:862-871`) and `SortUI.tsx:188`/`:207` read `singleSort.direction` at runtime. Renaming it would have broken SortUI and contradicted PM assumption 3, which forbids touching that surface. The ruling's producer list and its own do-not-touch note were in conflict; the note is the half that is right.
- ➕ **`packages/plugin-view/src/__tests__/ObjectView.sortSink.test.tsx:208`** — not named by the ruling. This held a pin written *for this card* asserting `$orderby` equals `{ name: 'asc' }` for a `direction: 'desc'` fixture — green only because nothing read the key, with a comment saying "Pinned so that whoever DOES fix that card is told this site exists." Fixture-triage case: **replaced**, not re-spelled, because it pinned the very branch being removed.
- ➕ **`packages/plugin-view/src/__tests__/ObjectView.test.tsx:490`** — not named by the ruling; would have become a hard type error.

The last two are taken under the bounded in-place exemption (same defect class, mechanical with the correct form pinned by the ruling, no other claim on `packages/plugin-view/**`, same gate family), and are named here rather than folded in silently.

## Reverse verification — direction predicted before running, and one prediction was wrong

**Type leg** (revert the declaration to `direction`): predicted red, observed red — 3 errors, exit 2. The interesting one is *inverted*, which is what makes the guard non-vacuous:

```
sortSink.test.tsx(207,84): error TS2353: ... 'order' does not exist in type '{ field: string; direction: "desc" | "asc"; }'.
sortSink.test.tsx(227,9):  error TS2578: Unused '@ts-expect-error' directive.
ObjectView.test.tsx(494,65): error TS2322: ... not assignable ...
```

`TS2578` proves the `@ts-expect-error` is genuinely suppressing a real error under the fix.

**Runtime leg**: predicted red, **observed green (12/12 passed)** — the prediction was wrong, and the reason is sound. The declaration is type-only, so reverting it cannot change runtime; TypeScript is erased. Reported rather than dressed up: enforcement of this fix lives **entirely at the type boundary**.

To show the runtime assertion is not vacuous, the falsifying mutation is the *fixture*, not the declaration — swapping its key back to `direction` fails with exactly the bug shape:

```
AssertionError: expected { name: 'asc' } to deeply equal { name: 'desc' }
```

Every mutation was confirmed on disk by grepping the injected and removed text separately (an editor's exit code proves nothing on a zero-hit anchor), and each leg ran under a `trap … EXIT INT TERM` restore. Tree confirmed byte-identical to `HEAD` afterwards. No rebuild was needed for either leg: the suite imports `../ObjectView` relatively, so the subject resolves from source, not through the package's `exports`/`dist`.

## Verification, run at `604c2036`

| gate | verdict line |
| --- | --- |
| `type-check` `@object-ui/plugin-view` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit **0**, script name echoed |
| `type-check` `@object-ui/app-shell` | exit **0** |
| `type-check` `@object-ui/console` (downstream) | exit **0** |
| `vitest run packages/plugin-view/src` + adapter suite | **23 files / 223 tests passed** |

**Downstream direction stated:** the contract narrowed, so consumers were swept with the prefix form `pnpm --filter '...@object-ui/plugin-view'` — `app-shell`, `console`, `site`, and three private examples. `app-shell` and `console` typecheck clean; `examples/` and `apps/` were swept for the retired spelling and contain no producer of it.

Both packages' first typecheck was red with `Cannot find module '@object-ui/…'` — the unbuilt-closure signature, not a real failure; green after building each package's dependency closure with the suffix filter form (`PKG^...`). Recorded because that red reads exactly like a broken import.

**Lint — narrowed, and the narrowing is measured.** The repo-wide `eslint .` is CI's run. Locally: eslint's own config linted **4** of 4 changed source files (count read from `--format json`, none ignored); **0 errors, 88 warnings**; and the identical run at the merge-base `8d3a5294a` gives **0 errors, 88 warnings** — delta **0/0**, so every warning is pre-existing. Untouched files are invariant because no type-aware linting is configured (no `project` / `projectService` in `eslint.config.*`), so this diff cannot move another file's verdict.

## Out of scope, filed separately

**#6006** — the published skill `skills/objectui/guides/data-integration.md` teaches a `QueryParams` shape the adapters silently drop: the sort key spelled `direction` (same defect class as this card, different surface), and every query option written without its `$` prefix — the class #5458 fixed in repo code, where an unprefixed key "reaches no branch and is dropped". Not fixed here: different surface, and `skills/**` is a customer-published package with its own expansion-budget discipline that this dispatch carried no budget for.

Also left alone deliberately, each a different surface rather than an instance of this defect: `packages/types` (`ExportDownloadRequest.sort`, `designer.ts`, `data-protocol.ts` `orderBy` — and claimed by a concurrent sibling), the export-boundary conversions in `ObjectGrid.tsx:2089` and `ListView.tsx:2520` (both convert *from* `order`), and `ObjectView.filterSources.test.tsx:161` (`table.defaultSort`).

Changeset: `minor` per AGENTS.md §版本号策略 — objectui ships its own breaks as `minor`, never `major` (CI-enforced by `check-changeset-no-major.mjs`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_
