### PR TITLE
fix(plugin-map): memoize ObjectMap's mapConfig so the marker useMemo actually memoizes

### DIFF
--- a/.changeset/olive-cameras-repeat.md
+++ b/.changeset/olive-cameras-repeat.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/plugin-map": patch
+---
+
+`ObjectMap`: make the marker `useMemo` actually memoize.
+
+`getMapConfig(schema)` ran unmemoized in the render body, so `mapConfig` carried
+a fresh object identity on every render. The marker transform names `mapConfig`
+in its dependency array, so it recomputed on every single render — walking every
+record through `extractCoordinates` and the display-name resolver, and re-running
+`ObjectMapConfigSchema.safeParse` on each pass — while declaring that it does not.
+The invalidation cascaded on into `filteredMarkers`, `clusteredData`,
+`markerBounds` and `initialViewState`.
+
+`mapConfig` is now memoized on `schema`, the one value `getMapConfig` reads.
+Behaviour is unchanged; the config is still rebuilt whenever the schema
+genuinely changes.

--- a/packages/plugin-map/src/ObjectMap.configMemo.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.configMemo.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5976 — the marker `useMemo` declares memoization that never happened.
+ *
+ * `getMapConfig(schema)` was called straight in the render body, so `mapConfig`
+ * carried a FRESH OBJECT IDENTITY on every render. The marker transform names
+ * it in its dependency array (`[data, mapConfig, objectSchema]`), so that memo
+ * recomputed on every single render while declaring that it does not — a
+ * `useMemo` in spelling only. The invalidation then cascaded: `filteredMarkers`
+ * → `clusteredData` / `markerBounds` → `initialViewState` all key on the array
+ * it produces, so the whole marker pipeline rebuilt per render.
+ *
+ * ## Why these assertions, and not a render count
+ *
+ * The defect is about IDENTITY, so it is measured as identity — at the two
+ * module boundaries this component actually crosses:
+ *
+ *  - `getRecordDisplayName` (`@object-ui/core`) is called once per record from
+ *    INSIDE the marker memo, so its call count is a direct read of how many
+ *    times that memo evaluated. This is the memo the card names.
+ *  - `initialViewState` is handed to `MapGL` as a prop, and it sits at the tail
+ *    of the cascade (`markers` → `filteredMarkers` → `markerBounds` →
+ *    `initialViewState`). A `toBe` assertion on it therefore pins the whole
+ *    chain, not just the first link.
+ *
+ * ## The counter-probe is load-bearing
+ *
+ * "Identity is stable" is also satisfiable by freezing a stale config forever,
+ * which is a worse bug than the one being fixed and is invisible to the
+ * positive assertion alone. So every stability assertion here is paired with
+ * one that the identity DOES change when the schema genuinely changes — with a
+ * visible consequence (the marker title actually re-resolves through the new
+ * binding, the camera actually moves to the newly declared centre).
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const probe = vi.hoisted(() => ({
+  displayNameCalls: 0,
+  viewStates: [] as unknown[],
+}));
+
+vi.mock('@object-ui/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/core')>();
+  return {
+    ...actual,
+    getRecordDisplayName: (...args: Parameters<typeof actual.getRecordDisplayName>) => {
+      probe.displayNameCalls += 1;
+      return actual.getRecordDisplayName(...args);
+    },
+  };
+});
+
+vi.mock('react-map-gl/maplibre', () => {
+  const MapImpl = ({ children, initialViewState }: any) => {
+    probe.viewStates.push(initialViewState);
+    return <div aria-label="Map">{children}</div>;
+  };
+  return {
+    default: MapImpl,
+    Map: MapImpl,
+    NavigationControl: () => <div data-testid="nav-control" />,
+    Marker: ({ children, longitude, latitude, onClick }: any) => (
+      <div
+        data-testid="map-marker"
+        data-lat={latitude}
+        data-lng={longitude}
+        onClick={() => onClick?.({ originalEvent: { stopPropagation() {} } })}
+      >
+        {children}
+      </div>
+    ),
+    Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
+  };
+});
+
+import { ObjectMap } from './ObjectMap';
+
+/**
+ * Inline rows via the array shorthand: the `value` provider settles in one
+ * effect and never fetches an object definition, so nothing async churns the
+ * marker memo behind the measurement.
+ */
+const ROWS = [
+  { id: '1', name: 'Harbour Depot', code: 'HD-01', latitude: 47.6062, longitude: -122.3321 },
+  { id: '2', name: 'Ridge Yard', code: 'RY-02', latitude: 37.7749, longitude: -122.4194 },
+];
+
+const baseSchema = (map: Record<string, unknown>): any => ({
+  type: 'object-map',
+  map: { latitudeField: 'latitude', longitudeField: 'longitude', ...map },
+  data: ROWS,
+});
+
+const settle = async () => {
+  await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+  await waitFor(() => expect(screen.getAllByTestId('map-marker')).toHaveLength(2));
+};
+
+beforeEach(() => {
+  probe.displayNameCalls = 0;
+  probe.viewStates.length = 0;
+});
+
+describe('ObjectMap — `mapConfig` identity (objectui#5976)', () => {
+  it('holds the marker memo across a re-render with unchanged inputs', async () => {
+    const schema = baseSchema({ titleField: 'name' });
+
+    const { rerender } = render(<ObjectMap schema={schema} />);
+    await settle();
+
+    const callsAtRest = probe.displayNameCalls;
+    expect(callsAtRest).toBeGreaterThan(0);
+
+    rerender(<ObjectMap schema={schema} />);
+
+    // The memo's declared intent, asserted: same inputs in, no re-evaluation.
+    expect(probe.displayNameCalls).toBe(callsAtRest);
+  });
+
+  it('holds the whole downstream cascade — `initialViewState` keeps its identity', async () => {
+    const schema = baseSchema({ titleField: 'name' });
+
+    const { rerender } = render(<ObjectMap schema={schema} />);
+    await settle();
+
+    const cameraAtRest = probe.viewStates.at(-1);
+    expect(cameraAtRest).toBeDefined();
+
+    rerender(<ObjectMap schema={schema} />);
+
+    // `markers` → `filteredMarkers` → `markerBounds` → `initialViewState`:
+    // a fresh `mapConfig` invalidates every link, so this identity is a read
+    // of the entire chain.
+    expect(probe.viewStates.at(-1)).toBe(cameraAtRest);
+  });
+
+  it('holds the marker memo across a state-driven re-render (search typing)', async () => {
+    const schema = baseSchema({ titleField: 'name' });
+
+    render(<ObjectMap schema={schema} />);
+    await settle();
+
+    const callsAtRest = probe.displayNameCalls;
+
+    // A re-render this component causes ITSELF — the dominant case, and the
+    // one where the `schema` prop identity is unchanged by construction.
+    fireEvent.change(screen.getByPlaceholderText('Search locations…'), {
+      target: { value: 'Harbour' },
+    });
+    await waitFor(() => expect(screen.getAllByTestId('map-marker')).toHaveLength(1));
+
+    // `filteredMarkers` legitimately re-runs on the query; `markers` must not.
+    expect(probe.displayNameCalls).toBe(callsAtRest);
+  });
+
+  // ---------------------------------------------------------------------
+  // Counter-probes: the identity MUST change when the schema genuinely does.
+  // Without these, "stable identity" is satisfiable by a frozen stale config.
+  // ---------------------------------------------------------------------
+
+  it('re-resolves marker titles when the declared `titleField` changes', async () => {
+    const { rerender } = render(<ObjectMap schema={baseSchema({ titleField: 'name' })} />);
+    await settle();
+
+    fireEvent.click(screen.getAllByTestId('map-marker')[0]);
+    expect(screen.getByTestId('map-popup').textContent).toContain('Harbour Depot');
+
+    const callsBefore = probe.displayNameCalls;
+
+    rerender(<ObjectMap schema={baseSchema({ titleField: 'code' })} />);
+    await waitFor(() => expect(screen.getAllByTestId('map-marker')).toHaveLength(2));
+
+    // Recomputed, and visibly so: the new binding reached the rendered title.
+    expect(probe.displayNameCalls).toBeGreaterThan(callsBefore);
+    await waitFor(() =>
+      expect(screen.getByTestId('map-popup').textContent).toContain('HD-01'),
+    );
+  });
+
+  it('rebuilds the camera when the declared centre/zoom changes', async () => {
+    const { rerender } = render(<ObjectMap schema={baseSchema({ titleField: 'name' })} />);
+    await settle();
+
+    const cameraBefore = probe.viewStates.at(-1) as Record<string, unknown>;
+
+    rerender(<ObjectMap schema={baseSchema({ titleField: 'name', center: [10, 20], zoom: 7 })} />);
+    await waitFor(() => expect(screen.getAllByTestId('map-marker')).toHaveLength(2));
+
+    const cameraAfter = probe.viewStates.at(-1) as Record<string, unknown>;
+    expect(cameraAfter).not.toBe(cameraBefore);
+    expect(cameraAfter).toMatchObject({ latitude: 10, longitude: 20, zoom: 7 });
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.configMemo.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.configMemo.test.tsx
@@ -101,6 +101,9 @@ const baseSchema = (map: Record<string, unknown>): any => ({
   data: ROWS,
 });
 
+/** `Array.prototype.at` is outside this package's configured `lib` target. */
+const lastCamera = (): unknown => probe.viewStates[probe.viewStates.length - 1];
+
 const settle = async () => {
   await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
   await waitFor(() => expect(screen.getAllByTestId('map-marker')).toHaveLength(2));
@@ -133,7 +136,7 @@ describe('ObjectMap — `mapConfig` identity (objectui#5976)', () => {
     const { rerender } = render(<ObjectMap schema={schema} />);
     await settle();
 
-    const cameraAtRest = probe.viewStates.at(-1);
+    const cameraAtRest = lastCamera();
     expect(cameraAtRest).toBeDefined();
 
     rerender(<ObjectMap schema={schema} />);
@@ -141,7 +144,7 @@ describe('ObjectMap — `mapConfig` identity (objectui#5976)', () => {
     // `markers` → `filteredMarkers` → `markerBounds` → `initialViewState`:
     // a fresh `mapConfig` invalidates every link, so this identity is a read
     // of the entire chain.
-    expect(probe.viewStates.at(-1)).toBe(cameraAtRest);
+    expect(lastCamera()).toBe(cameraAtRest);
   });
 
   it('holds the marker memo across a state-driven re-render (search typing)', async () => {
@@ -191,12 +194,12 @@ describe('ObjectMap — `mapConfig` identity (objectui#5976)', () => {
     const { rerender } = render(<ObjectMap schema={baseSchema({ titleField: 'name' })} />);
     await settle();
 
-    const cameraBefore = probe.viewStates.at(-1) as Record<string, unknown>;
+    const cameraBefore = lastCamera() as Record<string, unknown>;
 
     rerender(<ObjectMap schema={baseSchema({ titleField: 'name', center: [10, 20], zoom: 7 })} />);
     await waitFor(() => expect(screen.getAllByTestId('map-marker')).toHaveLength(2));
 
-    const cameraAfter = probe.viewStates.at(-1) as Record<string, unknown>;
+    const cameraAfter = lastCamera() as Record<string, unknown>;
     expect(cameraAfter).not.toBe(cameraBefore);
     expect(cameraAfter).toMatchObject({ latitude: 10, longitude: 20, zoom: 7 });
   });

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -591,7 +591,34 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
     return rawDataConfig;
   }, [JSON.stringify(rawDataConfig)]);
   
-  const mapConfig = getMapConfig(schema);
+  /**
+   * Memoized on the ONE value `getMapConfig` reads, and nothing else
+   * (objectui#5976). This call used to sit bare in the render body, so
+   * `mapConfig` carried a fresh object identity on every render — and the
+   * marker transform below names it in its dependency array, so that `useMemo`
+   * recomputed on every single render while declaring that it does not. The
+   * invalidation cascaded from there: `filteredMarkers` → `clusteredData` /
+   * `markerBounds` → `initialViewState` all key on the array it produces.
+   *
+   * `[schema]` is the whole dependency, not a shorthand for one: `getMapConfig`
+   * is a pure function of `schema` and reads nothing else. No deep-compare key
+   * is needed to make that identity hold, because the identity that reaches
+   * this component is ALREADY stable across the renders that matter — every
+   * re-render `ObjectMap` causes itself (data landing, the object definition
+   * landing, search typing, zoom, selection, geolocation) leaves the prop
+   * untouched by construction, and the three callers upstream each hand over a
+   * memoized node: `SchemaRenderer`'s `evaluatedSchema`, the gate's `mapped`
+   * in `useElementDataSourceSchema`, and `ListView`'s `viewComponentSchema`.
+   *
+   * So this deliberately does NOT copy the `JSON.stringify` dep key the
+   * `dataConfig` line above uses. That idiom buys stability by paying a
+   * serialize on every render, and it is also key-order sensitive and drops
+   * `undefined` values — an equality this config cannot afford, since an
+   * ABSENT `titleField` is load-bearing here (objectui#5953) and must never
+   * compare equal to a present one. Identity is enough; nothing here needs
+   * value equality.
+   */
+  const mapConfig = useMemo(() => getMapConfig(schema), [schema]);
   const hasInlineData = dataConfig?.provider === 'value';
 
   // Fetch data based on provider


### PR DESCRIPTION
Fixes #5976

## What was wrong

`getMapConfig(schema)` was called bare in `ObjectMap`'s render body, so `mapConfig` carried a **fresh object identity on every render**. The marker transform names `mapConfig` in its dependency array (`[data, mapConfig, objectSchema]`), so that `useMemo` recomputed on every single render *while declaring that it does not* — a `useMemo` in spelling only. Every pass walked all records through `extractCoordinates` and the display-name resolver and re-ran `ObjectMapConfigSchema.safeParse`, and the invalidation cascaded on into `filteredMarkers` → `clusteredData` / `markerBounds` → `initialViewState`.

Measured, not inferred: this is failure mode **(b)** — the builder called *outside* the memo — not a fresh-identity value inside an otherwise-sound dep array. The memo's own dep list is fine; its input was not.

## Re-measured on current `main`, after #5953 merged

#5953 (PR #5975) rewrote this exact region under the card, so the quoted code was re-derived rather than trusted. Delta against the card body:

- marker titles now resolve through `getRecordDisplayName(objectSchema, record, { titleField, fallback })`, not `record[titleField]`;
- the `|| 'name'` fallback is gone from **both** `getMapConfig` branches;
- `objectSchema` is now in the marker memo's deps — `[data, mapConfig, objectSchema]`, not the card's `[data, mapConfig]`.

**The defect itself is unchanged.** `ObjectMap.tsx:594` still read `const mapConfig = getMapConfig(schema);`, and the extra `objectSchema` dep neither causes nor worsens it.

## The fix, and why it is not the neighbouring idiom

```ts
const mapConfig = useMemo(() => getMapConfig(schema), [schema]);
```

`[schema]` is the entire dependency, not a shorthand for one: `getMapConfig` is a pure function of `schema` and reads nothing else.

No `JSON.stringify` deep-compare key was needed, because the identity reaching this component is **already stable across the renders that matter**. Every re-render `ObjectMap` causes itself — data landing, the object definition landing, search typing, zoom, selection, geolocation — leaves the `schema` prop untouched by construction, and each caller upstream hands over a memoized node:

| hop | value | memoized? |
|---|---|---|
| `SchemaRenderer` | `schemaForComponent` = `evaluatedSchema` | `useMemo`, `SchemaRenderer.tsx:516` |
| `ObjectMapRenderer` → `ElementDataSourceGate` | `bound.schema` = `mapped` | `React.useMemo`, `useElementDataSourceSchema` |
| `ListView` `case 'map'` flatten | `viewComponentSchema` | `React.useMemo`, `ListView.tsx:2007` |

Two further reasons the serialize would have been the wrong trade here, beyond its per-render cost: `JSON.stringify` **drops `undefined` values**, and an *absent* `titleField` is load-bearing in this config since #5953 — it must never compare equal to a present one. Identity is sufficient; nothing on this path needs value equality.

The sibling `dataConfig` at `:590` keeps its `JSON.stringify` key and is untouched — it is not the same defect (it does memoize) and changing it is a separate question.

## Verification

New pin: `packages/plugin-map/src/ObjectMap.configMemo.test.tsx` (5 tests). It measures **identity**, at the two module boundaries the component actually crosses — `getRecordDisplayName` call count (a direct read of how many times the marker memo evaluated) and the `initialViewState` object handed to `MapGL` (the tail of the cascade, so a `toBe` on it pins the whole chain).

**Red before, green after.** Direction predicted before running; on unmodified `main` the three stability pins failed and the two counter-probes passed — `Tests 3 failed | 2 passed (5)`, exit 1. One failure reads:

```
AssertionError: expected { bounds: [ …(2) ], …(1) } to be { bounds: [ …(2) ], …(1) } // Object.is equality
Received: serializes to the same string
Compared values have no visual difference.
```

— deep-equal, identity-fresh: the defect's exact signature.

**Reverse-verification.** Reverting the memo to the bare call reproduced that split exactly — `Tests 3 failed | 2 passed (5)`, exit 1. Mutation proved on disk by grepping the injected text *and separately* the removed text; restore ran under `trap … EXIT INT TERM`, and `git diff HEAD --stat` was empty afterwards. No rebuild was involved: the root vitest config aliases `@object-ui/*` to `packages/*/src` and the mutated file is the test's own relative import, so nothing resolved through `dist/`.

**Counter-probes** (without these, "stable identity" is also satisfiable by freezing a stale config forever — a worse bug, invisible to the positive assertion alone). Both assert a *new* identity with a visible consequence:

- changing the declared `titleField` re-resolves the titles and the new binding reaches the rendered popup (`Harbour Depot` → `HD-01`);
- changing the declared `center`/`zoom` rebuilds the camera and it moves to the newly declared position.

### Gates

| gate | result |
|---|---|
| `pnpm --filter @object-ui/plugin-map type-check` | **exit 0** — pnpm echoed `> @object-ui/plugin-map@17.6.0 type-check` / `> tsc --noEmit && tsc -p tsconfig.test.json`, so this is not a zero-match silent pass |
| `pnpm exec vitest run packages/plugin-map/src` (root form) | **exit 0** — `Test Files 15 passed (15)`, `Tests 88 passed (88)` |
| `pnpm exec eslint --no-inline-config` on changed files | **exit 0** — see delta below |
| `node scripts/check-changeset-presence.mjs` | **exit 0** — `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |

All four run on the final commit `0f754a839`.

**eslint delta against merge-base `c0091b82b`:** `ObjectMap.tsx` is **unchanged — 0 errors / 15 warnings before and after**, with an identical rule breakdown (`no-explicit-any` 12, `react-hooks/exhaustive-deps` 2, `react-hooks/use-memo` 1). The baseline was measured by checking out the merge-base copy of the file under a restoring `trap` and linting it. The new test file adds 4 warnings, all `@typescript-eslint/no-explicit-any` on the `react-map-gl` mock props — the established idiom in this directory, and *fewer* than its siblings carry (`ObjectMap.markerTitle.test.tsx` 7, `ObjectMap.schemaDataShorthand.test.tsx` 9). No new rule class, no errors.

## Notes

- **Downstream consumers keying on the identity** (the harm triage priced) are all *derived-value* memos, not effects: `filteredMarkers`, `clusteredData` (which calls `clusterMarkers`), `markerBounds` (which calls `computeMarkerBounds`), `selectedMarker` and `initialViewState`. **No `useEffect` re-fired** — neither of the component's two effects names `mapConfig` or `markers`. So the blast radius is wasted per-render computation cascading through the whole marker pipeline, which is real, but it is narrower than "re-fire effects per render" would suggest. Recorded as the dispatch asked, not as a reason to skip the fix.
- `react-hooks/exhaustive-deps` is active in this repo but only at **warn**, and there is no rule that would catch a builder called outside a memo at all. Nothing mechanical would have caught this, and nothing mechanical would catch its regression — the new identity test is what makes the declared intent *stay* true.
- #5977 is untouched, as instructed. Nothing here falsifies or repairs what it narrates: it is about stale prose above an arm of `ObjectMap.listViewMapConfigReach.test.tsx`, and that file is not modified.

⛔ Draft on purpose — not marked ready, not enqueued, auto-merge not enabled. The PM lands it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_