### PR TITLE
test(cli): assert in-repo range consistency before pinning lucide-react

### DIFF
--- a/.changeset/4991-lucide-pin-range-consistency.md
+++ b/.changeset/4991-lucide-pin-range-consistency.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only change to `packages/cli/src/__tests__/app-generator.test.ts`: the
+`lucide-react` manifest pin, and the pre-fix reverse-verification's drift
+check, no longer read an arbitrary member off `inRepoRangesOf(...)` without
+first asserting the repo's in-repo declarations for that dependency actually
+agree. No published behaviour changes.

--- a/packages/cli/src/__tests__/app-generator.test.ts
+++ b/packages/cli/src/__tests__/app-generator.test.ts
@@ -303,6 +303,32 @@ function inRepoRangesOf(name: string): Record<string, string[]> {
 }
 
 /**
+ * The one range this repo's in-repo manifests declare for `name`, asserting
+ * FIRST that they actually agree — never an arbitrary member of a possibly
+ * split set.
+ *
+ * Two call sites below used to read `inRepoRangesOf(name)` directly and pick
+ * a member off it (`Object.keys(...).sort()[0]`, `Object.keys(...)[0]`)
+ * without ever checking the ranges were consistent to begin with. Had this
+ * repo's declarations for `name` split across two ranges, either read would
+ * quietly validate against whichever range won that arbitrary tie-break —
+ * possibly the minority spelling — and report green while the repo disagreed
+ * with itself (objectui#4991). Both now route through here, which fails
+ * loudly and names every competing range and the manifests that declare each,
+ * the same way the anchor-table precondition above already does.
+ */
+function soleInRepoRangeOf(name: string): string {
+  const byRange = inRepoRangesOf(name);
+  const ranges = Object.keys(byRange);
+  expect(ranges.length, `${name} must be declared in-repo to anchor to`).toBeGreaterThan(0);
+  expect(
+    ranges.sort(),
+    `in-repo manifests disagree on ${name}: ${JSON.stringify(byRange)} — settle on one range first`
+  ).toHaveLength(1);
+  return ranges[0];
+}
+
+/**
  * Where each range in the THREE generated manifests must come from.
  *
  * The anchoring discipline objectui#3742/objectui#3754 established: one range
@@ -585,14 +611,7 @@ describe('generated app manifests', () => {
         continue;
       }
 
-      const byRange = inRepoRangesOf(name);
-      const ranges = Object.keys(byRange);
-      expect(ranges.length, `${name} must be declared in-repo to anchor to`).toBeGreaterThan(0);
-      expect(
-        ranges.sort(),
-        `in-repo manifests disagree on ${name}: ${JSON.stringify(byRange)} — settle on one range first`
-      ).toHaveLength(1);
-      expectedRanges[name] = { range: ranges[0], source: 'its in-repo range' };
+      expectedRanges[name] = { range: soleInRepoRangeOf(name), source: 'its in-repo range' };
     }
 
     // Pass 2 — the DRIFT, accumulated and reported by a single assertion, which
@@ -649,7 +668,7 @@ describe('generated app manifests', () => {
         const anchor = DEPENDENCY_ANCHORS[name];
         if (anchor === 'cli-version') return range !== `^${cliVersion}`;
         if (anchor === 'root') return range !== rootRangeOf(name);
-        return range !== Object.keys(inRepoRangesOf(name))[0];
+        return range !== soleInRepoRangeOf(name);
       })
       .map(([name]) => name)
       .sort();
@@ -1176,9 +1195,10 @@ describe('generation onto disk', () => {
       // way: it went red the moment the template was moved onto the repo's real
       // range, making a correct fix look like a regression (objectui#4098).
       // A literal here is the very fossil generator this file exists to stop.
-      expect(manifest.dependencies?.['lucide-react']).toBe(
-        Object.keys(inRepoRangesOf('lucide-react')).sort()[0]
-      );
+      // `soleInRepoRangeOf` also asserts the in-repo declarations agree before
+      // handing back a range — this line used to skip that check and take an
+      // arbitrary member instead (objectui#4991).
+      expect(manifest.dependencies?.['lucide-react']).toBe(soleInRepoRangeOf('lucide-react'));
     });
   });
 });


### PR DESCRIPTION
Fixes #4991

## What

`packages/cli/src/__tests__/app-generator.test.ts` had two call sites that read `inRepoRangesOf(name)` directly and took an **arbitrary member** off it, without ever asserting the repo's in-repo declarations for that dependency actually agree:

- `:1180` (in `writes a manifest whose @object-ui ranges name this CLI version`): `Object.keys(inRepoRangesOf('lucide-react')).sort()[0]`
- `:652` (in `names every range the pre-fix init manifest had drifted on`): `Object.keys(inRepoRangesOf(name))[0]`

Had this repo's declarations for a dependency split across two ranges, either read would quietly validate against whichever range won that arbitrary tie-break — possibly the minority spelling — and report green while the repo disagreed with itself. The one place that already got this right (the anchor-table precondition in `sources every range from this repo instead of inventing one`, `:588-593`) asserted `toHaveLength(1)` on the sorted range keys before referencing the sole range — the other two sites never went through it.

## Fix

Extracted that precondition into a shared `soleInRepoRangeOf(name)` helper (placed right after `inRepoRangesOf`), and routed all three call sites through it — including the anchor-table loop itself, which now reads `soleInRepoRangeOf(name)` instead of duplicating the same six lines. On a split, the helper fails loudly and names the package plus every competing range and the manifests that declare each:

```
AssertionError: in-repo manifests disagree on lucide-react: {"^1.31.0":[...22 manifests],"^1.30.0":["packages/plugin-tree/package.json"]} — settle on one range first: expected [ '^1.30.0', '^1.31.0' ] to have a length of 1 but got 2
```

Out of scope per the dispatch ruling: changing any package's declared range. Nothing here does.

## Measured — live or latent?

Enumerated `inRepoRangesOf(...)` on `main` @ `53dc89db8` for every name in `DEPENDENCY_ANCHORS` anchored `'in-repo'` (the set the two arbitrary-member sites draw from):

| name | distinct ranges |
|---|---|
| `lucide-react` | 1 (`^1.31.0`, 23 manifests) |
| `@tailwindcss/postcss` | 1 (`^4.3.3`, 8 manifests) |
| `@vitejs/plugin-react` | 1 (`^6.0.5`, 26 manifests) |
| `postcss` | 1 (`^8.5.26`, 6 manifests) |

Every one has exactly 1 range today — **this is a latent gap, not a live wrong-green**. I did not manufacture a split to justify the change; the reverse-verification below created one temporarily, on disk, then restored it (`git checkout HEAD --`, proved clean via `git diff HEAD`).

## Reverse verification

Mutated `packages/plugin-tree/package.json`'s `lucide-react` range to `^1.30.0` (creating a real 22-vs-1 split on disk), ran the suite:

- Before this fix, per the issue's own repro, the old `.sort()[0]` line went red **blaming the template** (`expected '^1.31.0' to be '^1.30.0'`) — the wrong diagnosis, since the template agreed with the 22-manifest majority.
- After this fix, both `writes a manifest whose @object-ui ranges name this CLI version` and `sources every range from this repo instead of inventing one` go red with the correct diagnosis: `in-repo manifests disagree on lucide-react`, naming both ranges and every manifest in each.

Restored the mutation (`git checkout HEAD -- packages/plugin-tree/package.json`), confirmed `git diff HEAD` empty, re-ran the suite: 41/41 pass.

## Tests

All commands run at final HEAD `58ee056dd`:

- `pnpm exec vitest run packages/cli/src/__tests__/app-generator.test.ts` → 41 passed (41)
- `pnpm --filter '@object-ui/cli' run type-check` → clean (`tsc --noEmit`, exit 0)
- `pnpm --filter '@object-ui/cli' run lint` → 0 errors, 11 pre-existing warnings unrelated to this diff (exit 0)
- `node scripts/check-changeset-presence.mjs` → ✅ (empty-frontmatter changeset added, per the gate's own instruction for a test-only change to a released package)

## Changeset

`packages/cli` is a released package and `src/__tests__/app-generator.test.ts` is under its `src/`, so `check-changeset-presence.mjs` correctly required one even though this is test-only. Added `.changeset/4991-lucide-pin-range-consistency.md` with empty frontmatter (releases nothing).

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_