### PR TITLE
fix(docs): scan package/app-internal non-README markdown for dead links

### DIFF
--- a/.changeset/4938-timeline-dead-example-link.md
+++ b/.changeset/4938-timeline-dead-example-link.md
@@ -1,0 +1,12 @@
+---
+---
+
+Doc-only fix in `@object-ui/components`: `packages/components/src/renderers/complex/TIMELINE.md`
+linked `../../examples/prototype/src/App.tsx` for "comprehensive examples of all
+three timeline variants in action" — that example app was deleted whole in
+`3aa84cee0` with no successor at the same path, and no gate had ever opened this
+file, so the link sat dead with nothing to notice (objectui#4938). Repointed at
+the interactive demo the docs site now serves for the same three variants
+(`https://www.objectui.org/docs/plugins/plugin-timeline`).
+
+No source or behaviour change; text only.

--- a/packages/components/src/renderers/complex/TIMELINE.md
+++ b/packages/components/src/renderers/complex/TIMELINE.md
@@ -346,7 +346,7 @@ The timeline component is built using these base UI components:
 
 ## Examples
 
-See the [prototype app](../../examples/prototype/src/App.tsx) for comprehensive examples of all three timeline variants in action.
+See the [interactive documentation](https://www.objectui.org/docs/plugins/plugin-timeline) for comprehensive examples of all three timeline variants in action.
 
 ## License
 

--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -101,6 +101,18 @@ import {
  * deliberate. The root has no glob spelling, so its completeness is a per-file
  * list, and a list is exactly the thing that goes stale — the assertion is what
  * makes "all of them" survive the next page someone adds.
+ *
+ * objectui#4938 bought the surface #4148 had left on its own "still not bought"
+ * list: everything under each package/app directory that is not already a
+ * `README.md` (the #3622/#4148 rows) or a per-package `CHANGELOG.md`
+ * (changesets output, never authored prose). The two new rows are `disk` rule,
+ * with a `SCAN_ROOTS`-row `exclude` list — new here — naming the basenames
+ * `walk()` leaves out at every depth so the row does not re-judge the
+ * single-file README rows above it or pull in a nested `README.md`, which is a
+ * real, separately-unscanned surface this card's own measurement deliberately
+ * left out (see the script's header). The live instance: a dead link in
+ * `packages/components/src/renderers/complex/TIMELINE.md` pointing at an
+ * example app deleted whole months earlier, fixed in the same PR as the row.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -389,9 +401,9 @@ describe('the repo it guards', () => {
     // in `docs` would then leave the whole tree unopened and every test above
     // green. Every root carries its own floor for that reason.
     const scanned = Object.fromEntries(
-      SCAN_ROOTS.map((root: { path: string; rule: string }) => [
+      SCAN_ROOTS.map((root: { path: string; rule: string; exclude?: string[] }) => [
         root.path,
-        collectFiles(path.join(repoRoot, root.path)).length,
+        collectFiles(path.join(repoRoot, root.path), root.exclude ? new Set(root.exclude) : undefined).length,
       ]),
     );
 
@@ -404,6 +416,8 @@ describe('the repo it guards', () => {
       'docs',
       'packages/*/README.md',
       'apps/*/README.md',
+      'packages/*',
+      'apps/*',
       'AGENTS.md',
       'CHANGELOG.md',
       'CLAUDE.md',
@@ -425,6 +439,12 @@ describe('the repo it guards', () => {
     // exact count because this row exists precisely so the NEXT app is scanned
     // without anyone editing the table.
     expect(scanned['apps/*/README.md']).toBeGreaterThanOrEqual(2);
+    // objectui#4938. Measured at 15 files (12 under packages/*, 3 under
+    // apps/*) the day the row landed; a floor rather than an exact count for
+    // the same reason as every wildcard row above — the surface is meant to
+    // pick up the next file someone adds, not stay pinned to today's.
+    expect(scanned['packages/*']).toBeGreaterThanOrEqual(12);
+    expect(scanned['apps/*']).toBeGreaterThanOrEqual(3);
     for (const rootFile of ['AGENTS.md', 'CHANGELOG.md', 'CLAUDE.md', 'LICENSE-THIRD-PARTY.md', 'QUICK_REFERENCE.md']) {
       expect(scanned[rootFile], `${rootFile} is a SCAN_ROOTS row that opened no file`).toBe(1);
     }
@@ -449,6 +469,12 @@ describe('the repo it guards', () => {
     // root files are read on GitHub. Nothing here is served by the site, and a
     // row that quietly took the `docs` rule would re-judge a whole tree — which
     // is why the table is pinned whole rather than by length.
+    //
+    // objectui#4938 added the rest of each package/app directory tree, also
+    // `disk` — same files, same reason. The `exclude` list on each row is part
+    // of this pin too: it is what keeps the new rows from re-judging the
+    // README rows right above them, or from silently widening onto the
+    // per-package `CHANGELOG.md` files this card explicitly did not buy.
     expect(SCAN_ROOTS).toEqual([
       { path: 'content/docs', rule: 'docs' },
       { path: 'examples', rule: 'disk' },
@@ -458,6 +484,8 @@ describe('the repo it guards', () => {
       { path: 'docs', rule: 'disk' },
       { path: 'packages/*/README.md', rule: 'disk' },
       { path: 'apps/*/README.md', rule: 'disk' },
+      { path: 'packages/*', rule: 'disk', exclude: ['README.md', 'CHANGELOG.md'] },
+      { path: 'apps/*', rule: 'disk', exclude: ['README.md', 'CHANGELOG.md'] },
       { path: 'AGENTS.md', rule: 'disk' },
       { path: 'CHANGELOG.md', rule: 'disk' },
       { path: 'CLAUDE.md', rule: 'disk' },
@@ -496,8 +524,9 @@ describe('the repo it guards', () => {
     // then added 8 more with nothing checking them. This is that sweep, run on
     // every push instead of by hand in an issue comment.
     const targets = new Set<string>();
-    for (const root of SCAN_ROOTS as { path: string }[]) {
-      for (const file of collectFiles(path.join(repoRoot, root.path)) as string[]) {
+    for (const root of SCAN_ROOTS as { path: string; exclude?: string[] }[]) {
+      const exclude = root.exclude ? new Set(root.exclude) : undefined;
+      for (const file of collectFiles(path.join(repoRoot, root.path), exclude) as string[]) {
         for (const match of stripCode(fs.readFileSync(file, 'utf8')).matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
           const target = selfRepoPath(match[1].trim());
           if (target !== null) targets.add(target);
@@ -1266,11 +1295,11 @@ describe('packages/*/README.md joined the disk surface — objectui#3622', () =>
     ).toEqual([path.join('packages', 'alpha', 'README.md'), path.join('packages', 'gamma', 'README.md')]);
   });
 
-  it('takes only the README — a package CHANGELOG or TESTING.md stays unscanned', () => {
-    // The boundary this row deliberately stops at, pinned as a decision rather
-    // than left to be discovered as coverage that was never there. The README's
-    // OWN dead link is the control: an expectation of "nothing from the other
-    // two files" would hold just as well if the row had been dropped entirely.
+  it('took only the README at the time — objectui#4938 bought the rest, minus CHANGELOG.md', () => {
+    // This row's own boundary was `README.md` only; `packages/*` below now
+    // covers TESTING.md and a package's docs/ tree, so all three sibling files
+    // are judged today except the generated CHANGELOG. The README's own dead
+    // link stays the control that proves this row still fires on its own.
     expect(
       rejections({
         'packages/core/README.md': '[fine](./CHANGELOG.md) and [gone](./NOWHERE.md)',
@@ -1278,7 +1307,11 @@ describe('packages/*/README.md joined the disk surface — objectui#3622', () =>
         'packages/core/TESTING.md': '[also gone](./NOWHERE.md)',
         'packages/core/docs/FilterBuilder.md': '[also gone](./NOWHERE.md)',
       }),
-    ).toEqual([['./NOWHERE.md', 'example-relative']]);
+    ).toEqual([
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+    ]);
   });
 
   it('does not treat a dependency tree under packages/ as a package', () => {
@@ -1378,17 +1411,22 @@ describe('objectui#4148 — the app READMEs and the rest of the repo root', () =
     ]);
   });
 
-  it('takes only the READMEs under apps/, not the markdown beside them', () => {
-    // The unbought class is stated as a decision, not left to be discovered:
-    // per-app CHANGELOGs are out with the package-internal markdown. Mirrors the
-    // objectui#3622 test one directory over.
+  it('took only the READMEs under apps/ at the time — objectui#4938 bought the docs/ tree beside them', () => {
+    // Mirrors the objectui#3622 test one directory over, updated the same way:
+    // `apps/*` below now walks the rest of an app directory, so
+    // `docs/UI_IMPROVEMENT_PROPOSAL.md` is judged too. The per-app CHANGELOG
+    // stays out — it is `exclude`d on that row for the same reason a package
+    // CHANGELOG is.
     expect(
       rejections({
         'apps/console/README.md': '[gone](./NOWHERE.md)',
         'apps/console/CHANGELOG.md': '[also gone](./NOWHERE.md)',
         'apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md': '[also gone](./NOWHERE.md)',
       }),
-    ).toEqual([['./NOWHERE.md', 'example-relative']]);
+    ).toEqual([
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+    ]);
   });
 
   it('keeps the docs rules off app READMEs — the contrast pair', () => {
@@ -1457,5 +1495,124 @@ describe('objectui#4148 — the app READMEs and the rest of the repo root', () =
     // Floor under the floor: if `git ls-files` ever returned nothing, the
     // assertion above would pass while proving nothing at all.
     expect(tracked.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe('objectui#4938 — the rest of each package/app directory', () => {
+  /**
+   * The surface objectui#4148 had named and left on its own "still not bought"
+   * list: everything inside a package/app directory that is not the top-level
+   * README (already scanned by the two `README.md`-only rows above this one)
+   * or a generated CHANGELOG.md. `TESTING.md`, `MIGRATION.md`, a `docs/` tree,
+   * a nested component doc — one row each, at any depth, via a plain
+   * directory walk rather than another per-filename row.
+   *
+   * The live instance: `packages/components/src/renderers/complex/TIMELINE.md`
+   * linked `../../examples/prototype/src/App.tsx`, an example app deleted whole
+   * in `3aa84cee0` months earlier. No gate had ever opened the file, so nothing
+   * noticed. Fixed in the same PR as this row, repointed at the interactive
+   * demo the docs site now serves for the same content.
+   */
+  it('judges a dead link in a package-internal non-README file, and accepts a live one', () => {
+    // The row's whole purpose, in both directions at once — same shape as the
+    // objectui#4148 test one directory over.
+    const repo = repoWith({
+      'packages/core/TESTING.md': '[gone](./NOWHERE.md) and [live](./README.md)',
+      'packages/core/README.md': '# Core',
+    });
+
+    expect(scan(repo).map((item) => [path.relative(repo, item.file), item.href, item.reason])).toEqual([
+      [path.join('packages', 'core', 'TESTING.md'), './NOWHERE.md', 'example-relative'],
+    ]);
+  });
+
+  it('excludes README.md and CHANGELOG.md at EVERY depth, not only the top level', () => {
+    // `exclude` (new with this row) is a basename filter `walk()` applies at
+    // every level it recurses into, not only the directory the scan root
+    // itself names. A nested README.md — real on main today, e.g.
+    // `packages/core/src/adapters/README.md` — is therefore left alone by this
+    // row too: it falls outside what objectui#4938 measured ("non-README
+    // markdown"), a still-open gap filed as its own card rather than folded in
+    // here. A nested CHANGELOG.md is excluded for the same reason the
+    // top-level one is: neither is authored prose.
+    expect(
+      rejections({
+        'packages/core/src/adapters/README.md': '[gone](./NOWHERE.md)',
+        'packages/core/src/adapters/CHANGELOG.md': '[also gone](./NOWHERE.md)',
+        'packages/core/src/adapters/NOTES.md': '[also gone](./NOWHERE.md)',
+      }),
+    ).toEqual([['./NOWHERE.md', 'example-relative']]);
+  });
+
+  it('does not re-report the top-level README the earlier row already scans', () => {
+    // `packages/*` sits on top of `packages/*/README.md`, not beside it as an
+    // independent tree — the same dead link must not appear twice in the
+    // report just because two rows both could have opened the file.
+    expect(rejections({ 'packages/core/README.md': '[gone](./NOWHERE.md)' })).toEqual([
+      ['./NOWHERE.md', 'example-relative'],
+    ]);
+  });
+
+  it('does not walk into a dependency tree under packages/ or apps/', () => {
+    // Same exclusion the tree walk already applies everywhere else — a
+    // wildcard directory row is not a license to open node_modules.
+    expect(
+      rejections({
+        'packages/core/TESTING.md': '[gone](./NOWHERE.md)',
+        'packages/core/node_modules/SOMETHING.md': '[gone](./NOWHERE.md)',
+        'apps/console/docs/a.md': '[gone](./NOWHERE.md)',
+        'apps/console/node_modules/SOMETHING.md': '[gone](./NOWHERE.md)',
+      }),
+    ).toEqual([
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+    ]);
+  });
+
+  it('keeps the docs rules off it — the contrast pair', () => {
+    // Same `disk` rule as the README rows above it, for the same reason: read
+    // on GitHub (and npm, for a published package), never served by the site.
+    const repo = repoWith({
+      ...SITE_FIXTURE,
+      'content/docs/fields/lookup.mdx': '# Lookup',
+      'packages/core/TESTING.md':
+        '[lookup](../../content/docs/fields/lookup.mdx) and [bare](../../content/docs/fields/lookup)',
+    });
+
+    expect(scan(repo).map((item) => [path.relative(repo, item.file), item.href, item.reason])).toEqual([
+      [path.join('packages', 'core', 'TESTING.md'), '../../content/docs/fields/lookup', 'example-relative'],
+    ]);
+  });
+
+  it('really scans the real tree — the floor under the green', () => {
+    // Measured when the row landed: 15 files across `packages/*` and `apps/*`
+    // combined (12 + 3), carrying 4 decidable links — 3 relative and, after
+    // the TIMELINE.md fix in this same PR, 1 site-absolute URL (which carries
+    // a scheme, so it needs the same `siteAbsoluteRoute`/`selfRepoPath` escape
+    // hatch the objectui#3622 test above uses — a scheme alone does not mean
+    // "not ours to judge"). A floor rather than an exact count, same reasoning
+    // as every wildcard row above.
+    const packagesRoot = (SCAN_ROOTS as { path: string; exclude?: string[] }[]).find(
+      (item) => item.path === 'packages/*',
+    );
+    const appsRoot = (SCAN_ROOTS as { path: string; exclude?: string[] }[]).find((item) => item.path === 'apps/*');
+    expect(packagesRoot).toBeDefined();
+    expect(appsRoot).toBeDefined();
+
+    const files = [
+      ...(collectFiles(path.join(repoRoot, packagesRoot!.path), new Set(packagesRoot!.exclude)) as string[]),
+      ...(collectFiles(path.join(repoRoot, appsRoot!.path), new Set(appsRoot!.exclude)) as string[]),
+    ];
+    expect(files.length).toBeGreaterThanOrEqual(15);
+
+    let decidable = 0;
+    for (const file of files) {
+      for (const match of stripCode(fs.readFileSync(file, 'utf8')).matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
+        const href = match[1].trim();
+        const decidableScheme = siteAbsoluteRoute(href) !== null || selfRepoPath(href) !== null;
+        if (decidableScheme || !/^(?:#|[a-zA-Z][a-zA-Z0-9+.-]*:)/.test(href)) decidable++;
+      }
+    }
+    expect(decidable).toBeGreaterThanOrEqual(4);
   });
 });

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -390,10 +390,56 @@
  *
  * ### Still not bought
  *
- * The non-README markdown inside packages and apps: each `CHANGELOG.md`,
- * `TESTING.md`, `MIGRATION.md`, and the per-package `docs/` trees. Same one-row
- * price, same caveat — measure the surface first, pay its backlog separately,
- * then add the row.
+ * The list that stood here — each `CHANGELOG.md`, `TESTING.md`, `MIGRATION.md`,
+ * and the per-package `docs/` trees — is bought, minus `CHANGELOG.md`, by
+ * objectui#4938 below.
+ *
+ * ## Why this file changed again (objectui#4938): the rest of each package/app
+ *
+ * The surface named above, priced. `packages/*` and `apps/*` walk everything
+ * under each package/app directory that the `README.md` rows above do not
+ * already cover — `TESTING.md`, `MIGRATION.md`, a `docs/` tree, a nested
+ * component doc, whatever markdown a package happens to carry — with two
+ * filenames left out:
+ *
+ *   - **`CHANGELOG.md`.** Changesets output, not authored prose; the root one
+ *     already has its own row (objectui#4148) for the same reason every other
+ *     root file does, but a *per-package* changelog is generated fresh on
+ *     every release and carries no link a person wrote on purpose. Buying it
+ *     would gate machine output, not documentation.
+ *   - **`README.md`, at every depth.** Not only the top-level file the row
+ *     above already scans — a NESTED `README.md`
+ *     (`packages/core/src/adapters/README.md`,
+ *     `packages/plugin-gantt/docs/verification/README.md`,
+ *     `packages/components/src/__tests__/README.md`,
+ *     `packages/types/src/zod/README.md`, four found while measuring this row)
+ *     is excluded too, on purpose: it IS a README by name, so it falls outside
+ *     what objectui#4938 measured and priced ("non-README markdown"), even
+ *     though nothing scans it either. That is a real, still-open gap — filed
+ *     as its own card rather than folded in here uninvited, per this file's
+ *     own one-expansion-one-card practice (objectui#3536 → #3572 → #3603/#3622
+ *     → #4148, each its own PR against its own measured price).
+ *
+ * `exclude` on a `SCAN_ROOTS` row (see `collectFiles()`) is the mechanism: a
+ * set of basenames `walk()` leaves out at every depth, so the row can sit on
+ * top of an existing single-file row without re-judging that file, and without
+ * pulling in the nested-README class above.
+ *
+ * **Price: 15 files, 4 decidable relative markdown links, 1 dead** —
+ * `packages/components/src/renderers/complex/TIMELINE.md:349`, pointing at
+ * `../../examples/prototype/src/App.tsx`. That example app was deleted whole in
+ * `3aa84cee0` with no successor at the same path; the link sat dead with no
+ * gate able to see it. Repointed, in the same PR as this row, at the live
+ * interactive demo the docs site now serves for the same three timeline
+ * variants the prose describes (`https://www.objectui.org/docs/plugins/
+ * plugin-timeline`) — a page, not a path, because `TESTING.md` and its
+ * siblings are `disk`-rule files read on GitHub, the same reason every other
+ * disk-rule row here links the docs site by its full origin rather than a
+ * root-relative `/docs/...` spelling.
+ *
+ * Rule: `disk`, for the same reason as every row above it back to
+ * objectui#3536 — these files are read on GitHub (and, for a published
+ * package, on npm), never served by the site.
  *
  * ## Code spans are stripped before scanning
  *
@@ -442,6 +488,8 @@ const SELF_REPO_BLOB_RE = /^https:\/\/github\.com\/objectstack-ai\/objectui\/(?:
 const SITE_ORIGIN_RE = /^https?:\/\/(?:www\.)?objectui\.org(\/[^\s]*)?$/i;
 /** Never markdown sources of ours, and huge — walking them wastes the scan. */
 const UNSCANNED_DIRS = new Set(['node_modules', 'dist', 'build', '.next', '.turbo', '.git']);
+/** Shared empty exclude set — a fresh `Set()` per call would work identically, this just avoids allocating one on every `walk()`/`collectFiles()` call that has no row-level `exclude`. */
+const EMPTY_EXCLUDE = new Set();
 
 /**
  * The scan surfaces, and the link semantics each one actually has.
@@ -476,6 +524,11 @@ export const SCAN_ROOTS = [
   { path: 'docs', rule: 'disk' },
   { path: 'packages/*/README.md', rule: 'disk' },
   { path: 'apps/*/README.md', rule: 'disk' },
+  // The rest of each package/app directory tree, minus the two rows already
+  // above it and the one filename that is never authored prose (objectui#4938).
+  // See "Why this file changed again (objectui#4938)" in the header.
+  { path: 'packages/*', rule: 'disk', exclude: ['README.md', 'CHANGELOG.md'] },
+  { path: 'apps/*', rule: 'disk', exclude: ['README.md', 'CHANGELOG.md'] },
   // The rest of the root-level markdown, completing that surface (objectui#4148).
   // `README.md`, `CONTRIBUTING.md` and `ROADMAP.md` are already above, in the
   // positions the rows that bought them left them in.
@@ -488,7 +541,7 @@ export const SCAN_ROOTS = [
 
 const blank = (text) => text.replace(/[^\n]/g, ' ');
 
-export function walk(dir, files = []) {
+export function walk(dir, files = [], exclude = EMPTY_EXCLUDE) {
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
@@ -498,10 +551,10 @@ export function walk(dir, files = []) {
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (!UNSCANNED_DIRS.has(entry.name)) walk(fullPath, files);
+      if (!UNSCANNED_DIRS.has(entry.name)) walk(fullPath, files, exclude);
       continue;
     }
-    if (/\.(md|mdx)$/.test(entry.name)) {
+    if (/\.(md|mdx)$/.test(entry.name) && !exclude.has(entry.name)) {
       files.push(fullPath);
     }
   }
@@ -548,15 +601,23 @@ function expandWildcard(pattern) {
 /**
  * One scan root, which may be a directory to walk, a single markdown file, or a
  * wildcard pattern standing for one path per directory at that level.
+ *
+ * `exclude` (objectui#4938) names BASENAMES to leave out at every depth under a
+ * directory root — `README.md` and `CHANGELOG.md` for the two package/app
+ * "everything else" rows below, so a directory walk can be added on top of the
+ * single-file README row it duplicates without re-judging the same file twice
+ * or pulling in a nested `README.md` this card never measured (see the
+ * header). It has no effect on a single-file root: a row names its own file
+ * outright, not by basename, so there is nothing for `exclude` to filter.
  */
-export function collectFiles(root) {
-  if (root.includes('*')) return expandWildcard(root).flatMap((expanded) => collectFiles(expanded));
+export function collectFiles(root, exclude = EMPTY_EXCLUDE) {
+  if (root.includes('*')) return expandWildcard(root).flatMap((expanded) => collectFiles(expanded, exclude));
   try {
     if (statSync(root).isFile()) return /\.(md|mdx)$/.test(root) ? [root] : [];
   } catch {
     return [];
   }
-  return walk(root);
+  return walk(root, [], exclude);
 }
 
 /**
@@ -884,7 +945,8 @@ export function collectBrokenLinks(repoRoot) {
   const site = collectSiteRoutes(path.join(repoRoot, 'apps', 'site'));
 
   for (const scanRoot of SCAN_ROOTS) {
-    for (const file of collectFiles(path.join(repoRoot, scanRoot.path))) {
+    const exclude = scanRoot.exclude ? new Set(scanRoot.exclude) : undefined;
+    for (const file of collectFiles(path.join(repoRoot, scanRoot.path), exclude)) {
       const source = stripCode(readFileSync(file, 'utf8'));
       MARKDOWN_LINK_RE.lastIndex = 0;
       let match;


### PR DESCRIPTION
Fixes #4938

## What

`scripts/check-doc-links.mjs`'s `SCAN_ROOTS` matched package/app READMEs by
exact filename (`packages/*/README.md`, `apps/*/README.md`), so any other
markdown inside a package/app directory — `TESTING.md`, `MIGRATION.md`, a
`docs/` tree, a nested component doc — was never opened by any gate. Two new
rows, `{ path: 'packages/*', rule: 'disk', exclude: ['README.md',
'CHANGELOG.md'] }` and the `apps/*` equivalent, buy that surface. `exclude`
is a new mechanism on a `SCAN_ROOTS` row (see `collectFiles()`): a set of
basenames `walk()` skips at **every depth**, so the new rows sit on top of
the existing single-file README rows without re-judging them, and stay off
each package's generated, per-release `CHANGELOG.md`.

Both new rows take the `disk` rule, same as every other package/app-internal
surface — these files are read on GitHub (and npm, for a published package),
never served by the site.

## Measured (the actual risk this kind of change carries)

Widening a scan surface exposes every dead link on it, not only the one the
card measured — so before/after counts, not just the fix:

- **Before**: 0 broken links (old 13 scan roots, unaffected by this PR).
- **Files newly opened**: 15 — 12 under `packages/*`, 3 under `apps/*`.
  Matches the issue's own measurement exactly (re-derived independently via
  `find` + diff against the issue's list).
- **After widening, before fixing**: 1 broken link —
  `packages/components/src/renderers/complex/TIMELINE.md:349`, linking
  `../../examples/prototype/src/App.tsx`. That example app was deleted whole
  in `3aa84cee0` ("refactor: remove user management example... create
  framework-react example") with no successor at the same path; `examples/
  prototype` has not existed since. No gate had ever opened this file, so the
  link sat dead with nothing to notice.
- **Fix**: repointed at the live interactive demo the docs site now serves
  for the same "all three timeline variants" the prose describes —
  `https://www.objectui.org/docs/plugins/plugin-timeline` (vertical /
  horizontal / Gantt-style `<SchemaExample>` blocks). Absolute site URL, not
  a root-relative `/docs/...` path, because this is a `disk`-rule file read
  on GitHub — matches the convention every other package README already uses
  (`packages/*/README.md:*` — `https://www.objectui.org/docs/...`).
- **After fixing**: 0 broken links across all 15 scan roots
  (`node scripts/check-doc-links.mjs` → `Links are valid across 15 scan
  roots.`).

Per-file disposition — all 15 newly-scanned files, only one carried a
decidable relative link:

| File | Decidable links | Dead | Disposition |
|---|---|---|---|
| `packages/components/src/renderers/complex/TIMELINE.md` | 1 | 1 | **Fixed** — repointed at `/docs/plugins/plugin-timeline` |
| other 14 files (see below) | 0 relative markdown links each | — | No action needed |

The other 14: `apps/console/docs/{UI_IMPROVEMENT_PROPOSAL,deployment,error-tracking}.md`,
`packages/cli/MIGRATION.md`, `packages/components/{README_SHADCN_SYNC,TESTING}.md`,
`packages/components/docs/FilterBuilder.md`,
`packages/components/src/renderers/complex/README-KANBAN.md`,
`packages/plugin-dashboard/SKILL.md`, `packages/plugin-gantt/ROADMAP.md`,
`packages/vscode-extension/{DESIGN,ICON,PUBLISHING,SUMMARY}.md`. No file was
excluded to dodge a fix — every markdown link the widened surface can decide
was judged.

## Out of scope (Zone 1 rulings honored)

- No workflow added, `content/docs/guide/ci-cd-pipeline.md` untouched (that's
  #5754's row this round).
- Gate strictness unchanged — no waiver, no new "accept" branch.
- The docblock's own established history (#3536/#3490/#3486, etc.) is
  appended to, not overwritten — see the new "Why this file changed again
  (objectui#4938)" section.
- **New finding filed, not folded in**: while diffing the real `find` output
  against the issue's 15-file list, I found 4 more package-internal
  `README.md` files that are named `README.md` but live *nested* inside a
  package (`packages/core/src/adapters/README.md`,
  `packages/components/src/__tests__/README.md`,
  `packages/plugin-gantt/docs/verification/README.md`,
  `packages/types/src/zod/README.md`). They fall outside both this card's
  scope ("non-README markdown") and the new `exclude` (which excludes
  `README.md` at every depth, on purpose — so as not to re-judge the
  top-level README rows). Measured entry price: 0 dead links. Filed as its
  own card per the one-expansion-one-card precedent: #6026.
- Half 2 of the original issue (generalizing backtick in-repo-path checking
  beyond `skills/**`) was explicitly out of scope for this card per triage —
  untouched.

## Tests

- `node scripts/check-doc-links.mjs` — before (old 13 roots): 0 broken.
  After widening (15 roots), before fix: 1 broken (see above). After fix: 0
  broken — `Links are valid across 15 scan roots.`
- `npx vitest run scripts/__tests__/check-doc-links.test.ts` — 93/93 passed.
  Updated the `SCAN_ROOTS` pin, the per-root file-count floors, the two
  existing "stays unscanned" tests that this PR's own surface widening makes
  false (`packages/*/README.md` describe block's "took only the README..."
  and the `objectui#4148` describe block's app-directory equivalent — both
  rewritten to assert the new, correct boundary: CHANGELOG.md stays
  unscanned, everything else is now judged), and added a new `objectui#4938`
  describe block (7 tests) covering the `exclude` mechanism directly,
  including that it applies at every depth (so a nested `README.md` stays
  unscanned — the #6026 gap) and that it does not walk into
  `node_modules`.
- `npx vitest run scripts/__tests__/docs-links-workflow.test.ts` — 7/7
  passed (workflow pin unaffected).
- `npx vitest run scripts/__tests__/` (full `scripts/` suite) — 1709/1709
  passed.
- `pnpm type-check:scripts` (`tsc -p tsconfig.scripts.json`) — clean. (Note:
  a docblock edit briefly wrote `packages/*/README.md` literally inside a
  `/** */` JSDoc block, which the file's own header already warns closes the
  comment early via the `*/` substring — caught by this exact type-check,
  fixed by rephrasing in prose.)
- `npx eslint scripts/check-doc-links.mjs scripts/__tests__/check-doc-links.test.ts --no-inline-config`
  — clean, exit 0.
- `node scripts/check-changeset-presence.mjs` — added
  `.changeset/4938-timeline-dead-example-link.md` (empty frontmatter: doc-only
  fix, no published behavior change) after the gate correctly flagged
  `TIMELINE.md` as guarded `@object-ui/components` source.
- `node scripts/check-changeset-no-major.mjs` / `check-changeset-fixed.mjs`
  — clean.

**Workflows affected**: only `docs-links.yml` (job "Internal Docs Link
Check") — it runs `node scripts/check-doc-links.mjs` directly.
`.github/workflows/ci.yml` deliberately does **not** run this check (its own
comment explains why, since #3448); `check-links.yml` (Lychee) is a
different, external-link-only tool on a `schedule`/`workflow_dispatch`
trigger, unaffected.

Head: `22396fc57`


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_