### PR TITLE
test(shadcn): verify every declared patch anchor against real registry bytes

### DIFF
--- a/scripts/__tests__/fixtures/shadcn-registry/dialog.registry.txt
+++ b/scripts/__tests__/fixtures/shadcn-registry/dialog.registry.txt
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/scripts/__tests__/fixtures/shadcn-registry/sheet.registry.txt
+++ b/scripts/__tests__/fixtures/shadcn-registry/sheet.registry.txt
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/scripts/__tests__/fixtures/shadcn-registry/sidebar.registry.txt
+++ b/scripts/__tests__/fixtures/shadcn-registry/sidebar.registry.txt
@@ -1,0 +1,773 @@
+"use client"
+
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+import { PanelLeft } from "lucide-react"
+
+import { useIsMobile } from "@/registry/default/hooks/use-mobile"
+import { cn } from "@/registry/default/lib/utils"
+import { Button } from "@/registry/default/ui/button"
+import { Input } from "@/registry/default/ui/input"
+import { Separator } from "@/registry/default/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/registry/default/ui/sheet"
+import { Skeleton } from "@/registry/default/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/registry/default/ui/tooltip"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+const SidebarProvider = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    defaultOpen?: boolean
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+  }
+>(
+  (
+    {
+      defaultOpen = true,
+      open: openProp,
+      onOpenChange: setOpenProp,
+      className,
+      style,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const isMobile = useIsMobile()
+    const [openMobile, setOpenMobile] = React.useState(false)
+
+    // This is the internal state of the sidebar.
+    // We use openProp and setOpenProp for control from outside the component.
+    const [_open, _setOpen] = React.useState(defaultOpen)
+    const open = openProp ?? _open
+    const setOpen = React.useCallback(
+      (value: boolean | ((value: boolean) => boolean)) => {
+        const openState = typeof value === "function" ? value(open) : value
+        if (setOpenProp) {
+          setOpenProp(openState)
+        } else {
+          _setOpen(openState)
+        }
+
+        // This sets the cookie to keep the sidebar state.
+        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+      },
+      [setOpenProp, open]
+    )
+
+    // Helper to toggle the sidebar.
+    const toggleSidebar = React.useCallback(() => {
+      return isMobile
+        ? setOpenMobile((open) => !open)
+        : setOpen((open) => !open)
+    }, [isMobile, setOpen, setOpenMobile])
+
+    // Adds a keyboard shortcut to toggle the sidebar.
+    React.useEffect(() => {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (
+          event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+          (event.metaKey || event.ctrlKey)
+        ) {
+          event.preventDefault()
+          toggleSidebar()
+        }
+      }
+
+      window.addEventListener("keydown", handleKeyDown)
+      return () => window.removeEventListener("keydown", handleKeyDown)
+    }, [toggleSidebar])
+
+    // We add a state so that we can do data-state="expanded" or "collapsed".
+    // This makes it easier to style the sidebar with Tailwind classes.
+    const state = open ? "expanded" : "collapsed"
+
+    const contextValue = React.useMemo<SidebarContextProps>(
+      () => ({
+        state,
+        open,
+        setOpen,
+        isMobile,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+      }),
+      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+    )
+
+    return (
+      <SidebarContext.Provider value={contextValue}>
+        <TooltipProvider delayDuration={0}>
+          <div
+            style={
+              {
+                "--sidebar-width": SIDEBAR_WIDTH,
+                "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+                ...style,
+              } as React.CSSProperties
+            }
+            className={cn(
+              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              className
+            )}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </div>
+        </TooltipProvider>
+      </SidebarContext.Provider>
+    )
+  }
+)
+SidebarProvider.displayName = "SidebarProvider"
+
+const Sidebar = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    side?: "left" | "right"
+    variant?: "sidebar" | "floating" | "inset"
+    collapsible?: "offcanvas" | "icon" | "none"
+  }
+>(
+  (
+    {
+      side = "left",
+      variant = "sidebar",
+      collapsible = "offcanvas",
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+    if (collapsible === "none") {
+      return (
+        <div
+          className={cn(
+            "flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground",
+            className
+          )}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </div>
+      )
+    }
+
+    if (isMobile) {
+      return (
+        <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+          <SheetContent
+            data-sidebar="sidebar"
+            data-mobile="true"
+            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            style={
+              {
+                "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+              } as React.CSSProperties
+            }
+            side={side}
+          >
+            <SheetHeader className="sr-only">
+              <SheetTitle>Sidebar</SheetTitle>
+              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+            </SheetHeader>
+            <div className="flex h-full w-full flex-col">{children}</div>
+          </SheetContent>
+        </Sheet>
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className="group peer hidden text-sidebar-foreground md:block"
+        data-state={state}
+        data-collapsible={state === "collapsed" ? collapsible : ""}
+        data-variant={variant}
+        data-side={side}
+      >
+        {/* This is what handles the sidebar gap on desktop */}
+        <div
+          className={cn(
+            "relative w-[--sidebar-width] bg-transparent transition-[width] duration-200 ease-linear",
+            "group-data-[collapsible=offcanvas]:w-0",
+            "group-data-[side=right]:rotate-180",
+            variant === "floating" || variant === "inset"
+              ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
+              : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
+          )}
+        />
+        <div
+          className={cn(
+            "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
+            side === "left"
+              ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+              : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+            // Adjust the padding for floating and inset variants.
+            variant === "floating" || variant === "inset"
+              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
+              : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
+            className
+          )}
+          {...props}
+        >
+          <div
+            data-sidebar="sidebar"
+            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+    )
+  }
+)
+Sidebar.displayName = "Sidebar"
+
+const SidebarTrigger = React.forwardRef<
+  React.ElementRef<typeof Button>,
+  React.ComponentProps<typeof Button>
+>(({ className, onClick, ...props }, ref) => {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      ref={ref}
+      data-sidebar="trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("h-7 w-7", className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeft />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+})
+SidebarTrigger.displayName = "SidebarTrigger"
+
+const SidebarRail = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button">
+>(({ className, ...props }, ref) => {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      ref={ref}
+      data-sidebar="rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarRail.displayName = "SidebarRail"
+
+const SidebarInset = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"main">
+>(({ className, ...props }, ref) => {
+  return (
+    <main
+      ref={ref}
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarInset.displayName = "SidebarInset"
+
+const SidebarInput = React.forwardRef<
+  React.ElementRef<typeof Input>,
+  React.ComponentProps<typeof Input>
+>(({ className, ...props }, ref) => {
+  return (
+    <Input
+      ref={ref}
+      data-sidebar="input"
+      className={cn(
+        "h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarInput.displayName = "SidebarInput"
+
+const SidebarHeader = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+})
+SidebarHeader.displayName = "SidebarHeader"
+
+const SidebarFooter = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+})
+SidebarFooter.displayName = "SidebarFooter"
+
+const SidebarSeparator = React.forwardRef<
+  React.ElementRef<typeof Separator>,
+  React.ComponentProps<typeof Separator>
+>(({ className, ...props }, ref) => {
+  return (
+    <Separator
+      ref={ref}
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+})
+SidebarSeparator.displayName = "SidebarSeparator"
+
+const SidebarContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarContent.displayName = "SidebarContent"
+
+const SidebarGroup = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+})
+SidebarGroup.displayName = "SidebarGroup"
+
+const SidebarGroupLabel = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & { asChild?: boolean }
+>(({ className, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "div"
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="group-label"
+      className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarGroupLabel.displayName = "SidebarGroupLabel"
+
+const SidebarGroupAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> & { asChild?: boolean }
+>(({ className, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="group-action"
+      className={cn(
+        "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 after:md:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarGroupAction.displayName = "SidebarGroupAction"
+
+const SidebarGroupContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="group-content"
+    className={cn("w-full text-sm", className)}
+    {...props}
+  />
+))
+SidebarGroupContent.displayName = "SidebarGroupContent"
+
+const SidebarMenu = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    data-sidebar="menu"
+    className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+    {...props}
+  />
+))
+SidebarMenu.displayName = "SidebarMenu"
+
+const SidebarMenuItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    data-sidebar="menu-item"
+    className={cn("group/menu-item relative", className)}
+    {...props}
+  />
+))
+SidebarMenuItem.displayName = "SidebarMenuItem"
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const SidebarMenuButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> & {
+    asChild?: boolean
+    isActive?: boolean
+    tooltip?: string | React.ComponentProps<typeof TooltipContent>
+  } & VariantProps<typeof sidebarMenuButtonVariants>
+>(
+  (
+    {
+      asChild = false,
+      isActive = false,
+      variant = "default",
+      size = "default",
+      tooltip,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : "button"
+    const { isMobile, state } = useSidebar()
+
+    const button = (
+      <Comp
+        ref={ref}
+        data-sidebar="menu-button"
+        data-size={size}
+        data-active={isActive}
+        className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+        {...props}
+      />
+    )
+
+    if (!tooltip) {
+      return button
+    }
+
+    if (typeof tooltip === "string") {
+      tooltip = {
+        children: tooltip,
+      }
+    }
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent
+          side="right"
+          align="center"
+          hidden={state !== "collapsed" || isMobile}
+          {...tooltip}
+        />
+      </Tooltip>
+    )
+  }
+)
+SidebarMenuButton.displayName = "SidebarMenuButton"
+
+const SidebarMenuAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> & {
+    asChild?: boolean
+    showOnHover?: boolean
+  }
+>(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="menu-action"
+      className={cn(
+        "absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 after:md:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarMenuAction.displayName = "SidebarMenuAction"
+
+const SidebarMenuBadge = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="menu-badge"
+    className={cn(
+      "pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground",
+      "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+      "peer-data-[size=sm]/menu-button:top-1",
+      "peer-data-[size=default]/menu-button:top-1.5",
+      "peer-data-[size=lg]/menu-button:top-2.5",
+      "group-data-[collapsible=icon]:hidden",
+      className
+    )}
+    {...props}
+  />
+))
+SidebarMenuBadge.displayName = "SidebarMenuBadge"
+
+const SidebarMenuSkeleton = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    showIcon?: boolean
+  }
+>(({ className, showIcon = false, ...props }, ref) => {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-[--skeleton-width] flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+})
+SidebarMenuSkeleton.displayName = "SidebarMenuSkeleton"
+
+const SidebarMenuSub = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    data-sidebar="menu-sub"
+    className={cn(
+      "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
+      "group-data-[collapsible=icon]:hidden",
+      className
+    )}
+    {...props}
+  />
+))
+SidebarMenuSub.displayName = "SidebarMenuSub"
+
+const SidebarMenuSubItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ ...props }, ref) => <li ref={ref} {...props} />)
+SidebarMenuSubItem.displayName = "SidebarMenuSubItem"
+
+const SidebarMenuSubButton = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentProps<"a"> & {
+    asChild?: boolean
+    size?: "sm" | "md"
+    isActive?: boolean
+  }
+>(({ asChild = false, size = "md", isActive, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+SidebarMenuSubButton.displayName = "SidebarMenuSubButton"
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/scripts/__tests__/fixtures/shadcn-registry/slider.registry.txt
+++ b/scripts/__tests__/fixtures/shadcn-registry/slider.registry.txt
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/scripts/__tests__/shadcn-local-patches.test.ts
+++ b/scripts/__tests__/shadcn-local-patches.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,7 +20,7 @@ import {
 // re-typed so the round-trip assertion below strips exactly what the sync adds;
 // importing the CLI module is safe (it only runs `main()` when it IS the
 // process entry point) and `shadcn-sync-fetch-cache.test.ts` already does it.
-import { OBJECTUI_HEADER } from '../shadcn-sync.js';
+import { OBJECTUI_HEADER, rewriteRegistryImports } from '../shadcn-sync.js';
 
 /**
  * objectstack#5505 — the Shadcn `Sheet`/`Dialog` primitives shipped a hardcoded
@@ -37,11 +38,18 @@ import { OBJECTUI_HEADER } from '../shadcn-sync.js';
  * written in), so a test that needed the network could not gate anything. Every
  * assertion below is pure string work over a fixture or over the files on disk.
  *
- * It covers three separate regressions:
+ * It covers four separate regressions:
  *
  *   1. the patch stops being applied to the files we ship  (`describe` #3)
  *   2. the patch engine stops applying it to fresh upstream (`describe` #1)
  *   3. the patch silently no-ops against changed upstream   (`describe` #2)
+ *   4. an anchor was never written from upstream at all     (`describe` #4)
+ *
+ * #4 is the objectui#4976 shape and the youngest of the four: markers present,
+ * `verifyLocalPatches` empty, every other assertion green, and an anchor that
+ * has never matched a registry response. Only applying the declaration to real
+ * registry bytes can see it, which is what the vendored fixtures are for
+ * (objectui#4996).
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -61,83 +69,150 @@ const closeLabelComponents = patchedComponents().filter((name: string) =>
 );
 
 /**
- * A faithful excerpt of what the registry serves for `dialog`, AFTER
- * `rewriteRegistryImports` (so `@/lib/utils` already reads `../lib/utils`).
- * This is the exact shape the patch engine sees during `--update`.
+ * Where the vendored registry fixtures live: one file per patched family,
+ * holding the registry's `files[0].content` VERBATIM, exactly as
+ * `https://ui.shadcn.com/r/styles/default/<name>.json` serves it — before
+ * `rewriteRegistryImports`, so the bytes can be hashed against the provenance
+ * recorded below.
+ *
+ * `.txt`, not `.tsx`, and that is deliberate: this is captured upstream text,
+ * not source this repo owns. ESLint targets `**\/*.{ts,tsx}` and would lint
+ * these as if we had written them; `tsconfig.scripts.json` compiles
+ * `scripts/**\/*.ts`. Neither should have an opinion about upstream's code,
+ * and neither can be made to have one about a `.txt`.
  */
-const UPSTREAM_DIALOG = `"use client"
-
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
-
-import { cn } from "../lib/utils"
-
-const DialogContent = React.forwardRef((props, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content ref={ref} {...props}>
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
-`;
+const registryFixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures/shadcn-registry',
+);
 
 /**
- * What the registry serves for `slider`, after `rewriteRegistryImports` (so
- * `@/lib/utils` already reads `../lib/utils`) — the exact input the patch engine
- * sees during `--update`.
- *
- * Verbatim and complete, not an excerpt, and that is the whole point: this is
- * the only offline statement of what upstream actually looks like, so the
- * round-trip assertion below can hold it to the shipped primitive byte for
- * byte. Transcribed from `https://ui.shadcn.com/r/styles/default/slider.json`,
- * which shadcn-ui/ui checks in verbatim as
- * `apps/v4/public/r/styles/default/slider.json` — read there at HEAD
- * 8a7701ec27eb9cb8e0377db769fbe6d744113c52, where the sha256 of
- * `files[0].content` is
- * 48bd0ba32cc7f341ecca995374be73111da2f761694cfcf91dbf8d4d9e632c06.
- *
- * objectui#4976: the fixture this replaces was reverse-engineered from the
- * LOCAL file instead, so it carried objectui's own hand-written accessible-name
- * forwarding (commit a014bc00c) as though upstream had shipped it, and trimmed
- * the rest to a sketch. The delivery patch was anchored on that invented line
- * and could not match any real registry response — while this test stayed green,
- * because the fixture agreed with the anchor rather than with upstream.
+ * @property url       The registry endpoint `shadcn-components.json` syncs from.
+ * @property repoPath  Where shadcn-ui/ui checks that same JSON in verbatim.
+ * @property headSha   The commit the fixture was captured at.
+ * @property sha256    Hash of the captured `files[0].content` bytes.
+ * @property roundTrip `true` when patching these bytes reproduces the shipped
+ *                     primitive exactly; otherwise the REASON it cannot, which
+ *                     is always an undeclared local edit (see below).
  */
-const UPSTREAM_SLIDER = `"use client"
+interface RegistryFixture {
+  url: string;
+  repoPath: string;
+  headSha: string;
+  sha256: string;
+  roundTrip: true | string;
+}
 
-import * as React from "react"
-import * as SliderPrimitive from "@radix-ui/react-slider"
+/**
+ * objectui#4996 — provenance for every vendored fixture.
+ *
+ * ## Why a vendored snapshot rather than a live fetch
+ *
+ * Verifying an anchor means applying it to bytes upstream actually served, and
+ * this repo cannot reach upstream from the place the verification has to run:
+ * `ui.shadcn.com` does not resolve from CI or from the sandboxes these tests
+ * are written in (measured again for objectui#4996: the registry host times out
+ * where `raw.githubusercontent.com` answers 200). A test that fetched would
+ * therefore SKIP on every PR — and a gate that skips silently is worse than no
+ * gate, because it reports green for a surface nobody read. The bytes are
+ * vendored instead, so this suite is deterministic, offline, and has no
+ * did-not-run state to confuse with a clean one.
+ *
+ * ## What a green run here does and does NOT mean
+ *
+ * It means: **every declared anchor was written from real registry bytes**, the
+ * property objectui#4976 turned out to lack and the one that cannot be stated
+ * offline any other way. An anchor reverse-engineered from `src/ui/**` matches
+ * the local file happily and cannot match these.
+ *
+ * It does NOT mean upstream still looks like this TODAY. That is a different
+ * question, it needs the network, and it already has an owner: the weekly
+ * `Check Shadcn Components` workflow runs `pnpm shadcn:check` online against all
+ * 46 components, exits non-zero on a patch that no longer re-applies, and —
+ * crucially — distinguishes "registry unreachable" from "registry clean" via
+ * its three-valued cross-run marker steps (objectui#3586). Upstream drift is
+ * that job's reading; anchor provenance is this file's. Neither substitutes for
+ * the other, and this suite must never be described as covering drift.
+ *
+ * ## Refreshing a fixture
+ *
+ * Re-capture `files[0].content` verbatim from the URL below and update `sha256`
+ * (and `headSha`) in the same commit. What a red `sha256` must NEVER mean is
+ * "edit the fixture until it agrees again" — that is precisely the hand-trimmed
+ * "faithful excerpt" objectui#4976 was made of, and the hash exists to make it
+ * impossible to do quietly.
+ */
+const REGISTRY_FIXTURES: Record<string, RegistryFixture> = {
+  sheet: {
+    url: 'https://ui.shadcn.com/r/styles/default/sheet.json',
+    repoPath: 'apps/v4/public/r/styles/default/sheet.json',
+    headSha: '8a7701ec27eb9cb8e0377db769fbe6d744113c52',
+    sha256: '9051eb9d885a18c0521c63c945480effcfca29282d2a342cb3ce7f9d080c6d38',
+    // objectui#4996 measured this: `sheet.tsx` also carries the `hideOverlay`
+    // prop, an UNDECLARED local edit (`shadcn-components.json` documents it and
+    // says outright that, unlike the i18n patch, "it does depend on anyone
+    // remembering it"). So patched upstream is 2 lines short of the shipped
+    // file by design, and byte-equality is not available for this family until
+    // that edit is either declared here or upstreamed.
+    roundTrip: 'ships the undeclared `hideOverlay` prop (shadcn-components.json)',
+  },
+  dialog: {
+    url: 'https://ui.shadcn.com/r/styles/default/dialog.json',
+    repoPath: 'apps/v4/public/r/styles/default/dialog.json',
+    headSha: '8a7701ec27eb9cb8e0377db769fbe6d744113c52',
+    sha256: '60d5246653c714fc12a67743ee5951331ecd2548cdaef9a599922bcb14da26db',
+    roundTrip: true,
+  },
+  sidebar: {
+    url: 'https://ui.shadcn.com/r/styles/default/sidebar.json',
+    repoPath: 'apps/v4/public/r/styles/default/sidebar.json',
+    headSha: '8a7701ec27eb9cb8e0377db769fbe6d744113c52',
+    sha256: 'ad7f3674de583ed57c87413b8434d3428d82f554b7ad3e590df329ed55830bb7',
+    // The expensive fixture the issue flagged (774 lines) — taken in full
+    // anyway, because a trimmed one could not be hashed against its source and
+    // an unhashed excerpt is the objectui#4976 defect wearing a fixture's
+    // clothes. It is static text read once per run; the cost is bytes on disk,
+    // not time.
+    //
+    // `sidebar.tsx` carries three systematic undeclared local edits documented
+    // in `shadcn-components.json` — the Tailwind v4 `[--var]` → `(--var)`
+    // migration (load-bearing: the v3 spelling compiles to invalid CSS on
+    // Tailwind 4.x), `theme(spacing.4)` → `1rem`, and an unconditional
+    // `data-collapsible` — so byte-equality is not available here either.
+    roundTrip: 'ships three undeclared systematic local edits (shadcn-components.json)',
+  },
+  slider: {
+    url: 'https://ui.shadcn.com/r/styles/default/slider.json',
+    repoPath: 'apps/v4/public/r/styles/default/slider.json',
+    headSha: '8a7701ec27eb9cb8e0377db769fbe6d744113c52',
+    sha256: '48bd0ba32cc7f341ecca995374be73111da2f761694cfcf91dbf8d4d9e632c06',
+    roundTrip: true,
+  },
+};
 
-import { cn } from "../lib/utils"
+/** The captured registry bytes for `name`, exactly as served (pre-rewrite). */
+function readRegistryFixture(name: string): Buffer {
+  return fs.readFileSync(path.join(registryFixturesDir, `${name}.registry.txt`));
+}
 
-const Slider = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
-Slider.displayName = SliderPrimitive.Root.displayName
+/**
+ * The captured bytes after `rewriteRegistryImports` — i.e. the exact input the
+ * patch engine sees during `--update`.
+ *
+ * The rewrite is IMPORTED from the sync rather than re-typed here for the same
+ * reason `OBJECTUI_HEADER` is: a second copy of the transform could drift, and a
+ * drifted copy would make these fixtures agree with this test while disagreeing
+ * with what `pnpm shadcn:update` actually writes.
+ */
+function upstreamFor(name: string): string {
+  return rewriteRegistryImports(readRegistryFixture(name).toString('utf-8'));
+}
 
-export { Slider }
-`;
+/** Registry bytes for `dialog`, the i18n close-label family's worked example. */
+const UPSTREAM_DIALOG = upstreamFor('dialog');
+
+/** Registry bytes for `slider`, the family objectui#4976 was found in. */
+const UPSTREAM_SLIDER = upstreamFor('slider');
 
 describe('shadcn local patches — application to fresh upstream (objectstack#5505)', () => {
   it.each(closeLabelComponents)('%s declares the i18n close patch', (name: string) => {
@@ -376,5 +451,140 @@ describe('shipped primitives still carry every declared patch (objectstack#5505)
   /** The derivation above must never silently select nothing. */
   it('still covers the close-label primitives', () => {
     expect(closeLabelComponents).toEqual(['sheet', 'dialog']);
+  });
+});
+
+describe('declared anchors were written from REGISTRY bytes (objectui#4996)', () => {
+  /**
+   * The gap this suite closes.
+   *
+   * Before it, only `slider` was ever applied to real registry bytes. `sheet`
+   * and `sidebar` were held up by two things that say NOTHING about whether
+   * their anchors match upstream: their ids, and the markers present in the
+   * files on disk. That is exactly the objectui#4976 configuration — markers
+   * complete, `verifyLocalPatches` empty, suite green, and an anchor pinned to
+   * a line the registry has never served. It kept a dead patch alive for four
+   * months.
+   *
+   * Measured for objectui#4996 before writing any of this: all ten declared
+   * anchors across all four families DO apply to real registry bytes, both at
+   * the pinned sha and at shadcn-ui/ui `main` on the day (byte-identical there
+   * — the `default` style registry has not moved for these four). So nothing
+   * was broken; what was missing was anything that would say so when it stops.
+   * These assertions are that thing, and they are why the fixtures exist.
+   */
+  it.each(patchedComponents())('%s has a vendored registry fixture', (name: string) => {
+    // A new patched family with no fixture goes red HERE rather than being
+    // quietly exempt from every assertion below — the failure mode a
+    // hand-maintained fixture list always eventually has.
+    expect(
+      Object.keys(REGISTRY_FIXTURES),
+      `${name} is declared in LOCAL_PATCHES but has no entry in REGISTRY_FIXTURES; ` +
+        'capture files[0].content from its registry URL verbatim into ' +
+        `scripts/__tests__/fixtures/shadcn-registry/${name}.registry.txt`,
+    ).toContain(name);
+
+    expect(
+      fs.existsSync(path.join(registryFixturesDir, `${name}.registry.txt`)),
+      `missing fixture file for ${name}`,
+    ).toBe(true);
+  });
+
+  it.each(patchedComponents())(
+    '%s fixture still hashes to its recorded provenance',
+    (name: string) => {
+      const actual = crypto.createHash('sha256').update(readRegistryFixture(name)).digest('hex');
+
+      // This is what makes the fixture uncheatable. Every assertion below is
+      // only as good as the claim that these bytes are upstream's; a hash
+      // pinned to the capture is the one way to hold that claim offline. Red
+      // here means the file was edited — re-capture and update `sha256` in the
+      // same commit, never trim the file until the anchors agree.
+      expect(actual, `${name}.registry.txt no longer matches its captured sha256`).toBe(
+        REGISTRY_FIXTURES[name].sha256,
+      );
+    },
+  );
+
+  it.each(patchedComponents())(
+    '%s: every declared anchor applies to real registry bytes',
+    (name: string) => {
+      const result = applyLocalPatches(name, upstreamFor(name));
+
+      // The core assertion of objectui#4996. An anchor reverse-engineered from
+      // `src/ui/**` — the objectui#4976 defect — cannot be in `applied` here,
+      // because the line it names does not exist in these bytes.
+      expect(
+        result.failed.map((p: { id: string; found: number }) => `${p.id} (found ${p.found}x)`),
+        `${name}: declared anchor(s) do not match the registry bytes, so the patch would NOT ` +
+          'survive the next `pnpm shadcn:update`. Re-target the anchor against upstream — do not ' +
+          'weaken the fixture.',
+      ).toEqual([]);
+
+      // `already` would mean the fixture arrived carrying our own marker, i.e.
+      // it was captured from the patched local file rather than from upstream.
+      // Distinguishing it from `applied` is the difference between "the anchor
+      // works" and "the fixture was taken from the wrong side".
+      expect(result.already, `${name}: fixture already contains our marker(s)`).toEqual([]);
+      expect(result.applied).toHaveLength(LOCAL_PATCHES[name].length);
+
+      // And the result actually carries every declared patch.
+      expect(verifyLocalPatches(name, result.content)).toEqual([]);
+    },
+  );
+
+  it.each(patchedComponents())(
+    '%s: byte round-trip holds, or its unavailability is pinned with a reason',
+    (name: string) => {
+      const patched = applyLocalPatches(name, upstreamFor(name));
+      const shipped = fs
+        .readFileSync(path.join(uiDir, `${name}.tsx`), 'utf-8')
+        // Added on write, downstream of the patch engine — stripped rather than
+        // baked into the fixture, which must stay byte-faithful to upstream.
+        .replace(OBJECTUI_HEADER, '');
+
+      const { roundTrip } = REGISTRY_FIXTURES[name];
+
+      if (roundTrip === true) {
+        // The strongest available statement: patching real upstream reproduces
+        // the shipped primitive exactly, so the declaration accounts for EVERY
+        // way this file differs from upstream.
+        expect(patched.content, `${name}.tsx no longer regenerates from registry bytes`).toBe(
+          shipped,
+        );
+        return;
+      }
+
+      // The other families ship local edits that are documented in
+      // `shadcn-components.json` but not declared in `shadcn-local-patches.mjs`,
+      // so equality is genuinely unavailable and claiming it would be a lie.
+      // Pinning the inequality is still worth doing: if it starts holding —
+      // upstream adopted the edit, or someone declared it — this goes red and
+      // the family should be promoted to `roundTrip: true`, which is a strictly
+      // better gate than the one below.
+      expect(typeof roundTrip).toBe('string');
+      expect(
+        patched.content,
+        `${name} now regenerates byte-for-byte from registry bytes — promote its ` +
+          "REGISTRY_FIXTURES entry to `roundTrip: true` (recorded reason: " +
+          `${roundTrip})`,
+      ).not.toBe(shipped);
+    },
+  );
+
+  /**
+   * The provenance record must not outlive the declarations it describes: a
+   * family removed from `LOCAL_PATCHES` should take its fixture with it, or the
+   * directory silently accumulates snapshots nothing reads.
+   */
+  it('records no fixture for a family that is no longer patched', () => {
+    expect(Object.keys(REGISTRY_FIXTURES).sort()).toEqual([...patchedComponents()].sort());
+
+    const onDisk = fs
+      .readdirSync(registryFixturesDir)
+      .filter((f: string) => f.endsWith('.registry.txt'))
+      .map((f: string) => f.replace(/\.registry\.txt$/, ''))
+      .sort();
+    expect(onDisk).toEqual([...patchedComponents()].sort());
   });
 });

--- a/scripts/shadcn-sync.js
+++ b/scripts/shadcn-sync.js
@@ -1067,8 +1067,12 @@ if (invokedAsCli()) {
 // Exported for scripts/__tests__/shadcn-sync-fetch-cache.test.ts and
 // scripts/__tests__/shadcn-local-patches.test.ts (OBJECTUI_HEADER, so the
 // round-trip assertion strips the header this script prepends rather than
-// keeping a second spelling of it). The CLI is the only production consumer;
-// nothing else imports this module.
+// keeping a second spelling of it; `rewriteRegistryImports`, so the vendored
+// registry fixtures are transformed by the SAME code the sync runs — a test
+// that re-typed the rewrite table would be asserting against its own copy of
+// the transform, and a drift between the two would make the fixtures agree
+// with the test while disagreeing with what `--update` actually writes).
+// The CLI is the only production consumer; nothing else imports this module.
 export {
   fetchUrl,
   fetchRegistry,
@@ -1078,4 +1082,5 @@ export {
   bodySnippet,
   CACHE_TTL_MS,
   OBJECTUI_HEADER,
+  rewriteRegistryImports,
 };


### PR DESCRIPTION
Fixes #4996

All gates below ran on `fd4f1043e` (the tip of this branch; working tree clean at that commit).

## The reading first — the defect is LATENT, and that is measured, not assumed

The card expected this to be dormant, so the first deliverable was a measurement rather than a patch. Every declared anchor was applied to real registry bytes before anything was changed:

| family | anchor | vs pinned sha `8a7701ec` | vs shadcn-ui/ui `main` (2026-08-24) |
|---|---|---|---|
| `sheet` | `sheet-i18n-close-import` | APPLIED | APPLIED |
| `sheet` | `sheet-i18n-close-label` | APPLIED | APPLIED |
| `sidebar` | `sidebar-cookie-read-import` | APPLIED | APPLIED |
| `sidebar` | `sidebar-cookie-read-initial-state` | APPLIED | APPLIED |
| `dialog` | `dialog-i18n-close-import` | APPLIED | APPLIED |
| `dialog` | `dialog-i18n-close-label` | APPLIED | APPLIED |
| `slider` | all four | APPLIED | APPLIED |

**10/10 anchors apply; 0 failed.** The two refs serve byte-identical content for all four components (same sha256), so the pin is current, not stale. `slider`'s captured content hashes to `48bd0ba3…`, exactly the sha the existing docblock already recorded — an independent check that this capture route returns genuine registry bytes.

So nothing is broken. What was missing is anything that would say so when it stops.

## The design question: per-PR verification cannot reach upstream, so it must not try

`ui.shadcn.com` — the host `shadcn-components.json` actually syncs from — does not resolve from CI or from this sandbox (measured: registry host times out where `raw.githubusercontent.com` answers 200). A fetching test would therefore **skip on every PR**, and a gate that skips silently is worse than no gate: it reports green for a surface nobody read.

This PR takes the **vendored pinned snapshot** option, chosen precisely because it removes the offline-skip hazard rather than managing it — the suite is deterministic and offline, so it has no did-not-run state to confuse with a clean one. There is nothing here that can report clean without having read something.

The UNREAD state still exists and already has an owner: the weekly `Check Shadcn Components` workflow runs `pnpm shadcn:check` online across all 46 components, exits non-zero on a patch that no longer re-applies, and distinguishes "registry unreachable" from "registry clean" through its three-valued cross-run marker steps (#3586). **Upstream drift is that job's reading; anchor provenance is this suite's.** The test docblock says so explicitly, so a green run here can never be misread as "upstream still looks like this today". No workflow is added or edited.

## What landed

- Vendored `files[0].content` **verbatim** per family under `scripts/__tests__/fixtures/shadcn-registry/*.registry.txt`, each pinned by a sha256 in a `REGISTRY_FIXTURES` provenance record (URL, in-repo path, HEAD sha, hash).
- `it.each(patchedComponents())` assertions: fixture exists · fixture still hashes to its provenance · **every declared anchor applies to those bytes** · byte round-trip holds where available. A new patched family without a fixture goes red instead of being silently exempt.
- `dialog`'s hand-written *"faithful excerpt"* is replaced by real bytes. It turns out to round-trip byte for byte, so it joins `slider` on the strongest assertion — one less hand-written fixture, which is the #4976 hazard class.
- `rewriteRegistryImports` is exported from `shadcn-sync.js` so the test transforms fixtures with the **sync's own** code rather than a second copy that could drift.

**On the `sidebar` cost question the card delegated:** the full 773-line fixture is taken. A trimmed one cannot be hashed against its source, and an unhashed excerpt is the #4976 defect wearing a fixture's clothes — the sha256 pin is only meaningful over the complete captured content. It is static text read once per run; the cost is bytes on disk, not time.

`sheet` and `sidebar` cannot assert byte round-trip because they ship local edits documented in `shadcn-components.json` but never declared as patches. That inequality is *pinned with its reason*, so if it ever starts holding the family gets promoted to the stronger gate. Filed separately as #6027 — not fixed here (out of scope: this card owns anchor verification, not which edits are declared).

## Reverse verification — the new gate provably fails, and the old ones provably would not have

Isolated ablation on `sidebar`, re-pointing `sidebar-cookie-read-initial-state` at `w-(--sidebar-width) bg-transparent` — a line the Tailwind-v4 migration put in the **shipped file only**. That is the #4976 shape reproduced exactly. Mutation confirmed on disk before running (anchor text 1 → 0 occurrences, injected text 0 → 1, `git diff HEAD --stat` non-empty), and confirmed present locally / absent upstream:

```
shipped sidebar.tsx  : 1
registry fixture     : 0
```

Result:

```
Test Files  1 failed (1)
     Tests  1 failed | 38 passed (39)

FAIL … declared anchors were written from REGISTRY bytes (objectui#4996)
     > sidebar: every declared anchor applies to real registry bytes
```

**Exactly one test failed — the new one — while all 38 pre-existing assertions stayed green.** The ids and the on-disk markers are blind to this by construction, which is the card's claim demonstrated rather than argued. The mutation script carried a `trap … EXIT INT TERM` restore; the restore leg was verified with `git diff HEAD` clean and the original anchor back at 1 occurrence. No build/`dist` is involved — these are `.mjs`/`.ts` sources run directly.

## Gates (all at `fd4f1043e`)

| gate | verdict line |
|---|---|
| `pnpm vitest run scripts/__tests__` | `Test Files 64 passed (64)` · `Tests 1720 passed (1720)` |
| `pnpm type-check:scripts` | exit 0, no diagnostics |
| `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 4984 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | `✅ No source of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-lint-coverage.mjs` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `node scripts/check-type-check-coverage.mjs` | `✅ type-check coverage: 45/46 via type-check … 1 not compiled.` |
| `eslint . --no-inline-config` (repo-wide, not narrowed) | 3635 files linted; the two changed lintable files report **0 errors / 0 warnings** |

The repo-wide ESLint run was executed in full rather than narrowed. Its 89 errors are pre-existing on `main` and are artifacts of `--no-inline-config` (which neutralises the very `eslint-disable` that `sidebar.tsx` documents); none are in this diff, and ESLint here is not type-aware (no `parserOptions.project`), so this diff cannot move an untouched file's verdict. The four `.registry.txt` fixtures fall outside ESLint's `**/*.{ts,tsx}` targeting and outside `tsconfig.scripts.json`'s `scripts/**/*.ts` — deliberate, since they are captured upstream text, not source this repo owns.

**No changeset**: the gate's own verdict is that none is owed (scripts/tests only, nothing under a released package's `src/`). No `skip-changeset` label per #4912/#3724.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_