### PR TITLE
refactor(app-shell): type RecordDetailView's confirm handler as the published ConfirmationHandler

### DIFF
--- a/.changeset/confirm-handler-published-type-5835.md
+++ b/.changeset/confirm-handler-published-type-5835.md
@@ -1,0 +1,4 @@
+---
+---
+
+Type `RecordDetailView`'s confirm handler as the published `ConfirmationHandler` instead of an inline re-spelling of the same shape, and pin that both of `app-shell`'s confirm runtimes hand `ActionConfirmDialog` the same field set. Releases nothing: the annotation is erased at build time (the emitted JS for `RecordDetailView.tsx` is byte-identical before and after), the handler is not exported, and no published surface changes.

--- a/packages/app-shell/src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx
@@ -1,0 +1,317 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `app-shell` mounts TWO confirm runtimes into ONE dialog — pin that they feed
+ * it the same fields (objectui#5835).
+ *
+ * - `hooks/useConsoleActionRuntime.tsx` builds a `confirmHandler` and renders
+ *   `<ActionConfirmDialog>` from its own `dialogs` element.
+ * - `views/RecordDetailView.tsx` does NOT consume that hook. It builds a second,
+ *   near-identical `confirmHandler` and renders its own `<ActionConfirmDialog>`.
+ *
+ * Merging the two is a larger refactor and is deliberately NOT this file's job.
+ * What this file buys instead is the property the duplication threatens: the
+ * dialog is one component with one set of reads, so whichever runtime opened it
+ * must hand it the same field set. objectui#5610 and objectui#3320 are the same
+ * family — this view re-implementing a shared runtime and then drifting from it
+ * with nothing red in between.
+ *
+ * ## Why this asserts at the DIALOG, not at the two declarations
+ *
+ * "Both runtimes feed the dialog the same fields" is trivially satisfiable by a
+ * test that reads neither runtime — comparing the two handler TYPES to each
+ * other proves nothing about what reaches the dialog at runtime, and two empty
+ * field sets are "the same" too. So: `ActionConfirmDialog` is doubled once, for
+ * BOTH importers (the hook imports `../views/ActionConfirmDialog.js`, this view
+ * imports `./ActionConfirmDialog.js` — one module, one double), each runtime is
+ * driven for real, and the assertions run against the `state` object that
+ * actually ARRIVED at the dialog. The expected field set is written out as a
+ * literal, so "both sides are empty" fails rather than passes, and the last test
+ * ties that literal to what `ActionConfirmDialog.tsx` genuinely reads.
+ *
+ * ## Both arities are pinned, because the parameter is live on only one path
+ *
+ * The action runner calls a confirm handler with ONE argument (`ActionRunner.ts`
+ * — the structured `confirm` arm that forwarded a bag was retired,
+ * objectui#4314), which is the only way `RecordDetailView`'s handler is ever
+ * reached: it goes to `<ActionProvider onConfirm={...}>` and nowhere else. The
+ * second parameter is live through a different door — `handleDeleteView` in
+ * `ObjectView.tsx` calls a `ConfirmationHandler` directly with all three fields
+ * localized (settled KEEP, 2026-08-22 ruling on objectui#5205). Pinning both
+ * arities is what keeps the two runtimes interchangeable from the dialog's side
+ * regardless of which door a future producer comes through.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => vi.fn(async () =>
+    new Response(JSON.stringify({ data: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  ),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => [],
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+/**
+ * The assertion subject: the `state` each runtime hands the dialog. One double
+ * serves both importers, so the two paths are observed through the SAME seam —
+ * a per-path double could drift exactly the way the runtimes did.
+ */
+let dialogState: any = null;
+vi.mock('./ActionConfirmDialog', () => ({
+  ActionConfirmDialog: ({ state }: any) => {
+    if (state?.open) dialogState = state;
+    return null;
+  },
+}));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+vi.mock('../hooks/useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: vi.fn(async () => ({ success: true })),
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: vi.fn(async () => null),
+  }),
+}));
+
+vi.mock('../utils/consoleServerAction', () => ({
+  createConsoleServerActionHandler: () => vi.fn(async () => ({ success: true })),
+}));
+
+/** Capture every `<ActionProvider>`'s props while keeping the real provider. */
+const captured: Array<{ onConfirm: any; context: any }> = [];
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    ActionProvider: (props: any) => {
+      captured.push({ onConfirm: props.onConfirm, context: props.context });
+      return React.createElement(actual.ActionProvider as any, props);
+    },
+    SchemaRenderer: () => null,
+  };
+});
+
+import { MetadataCtx } from '@object-ui/react';
+import { RecordDetailView } from './RecordDetailView';
+import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
+
+const OBJECT_NAME = 'crm_call';
+const RECORD_ID = 'rec-call-1';
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'Call',
+    fields: {
+      id: { type: 'text', label: 'Id' },
+      name: { type: 'text', label: 'Name' },
+    },
+  },
+];
+
+const METADATA = {
+  objects: OBJECTS,
+  pages: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invalidate: () => {},
+  ensureType: async () => [],
+  getItem: async () => null,
+  getItemsByType: () => [],
+} as any;
+
+const MESSAGE = 'Delete this call?';
+
+/**
+ * The out-of-runner producer's shape, verbatim in kind: `handleDeleteView` in
+ * `ObjectView.tsx` passes all three fields, already localized.
+ */
+const BAG = { title: 'Delete view', confirmText: 'Delete', cancelText: 'Cancel' };
+
+/**
+ * The fields `ActionConfirmDialog.tsx` reads off `state`. Written out rather
+ * than derived, so the parity assertions below cannot be satisfied by two
+ * equally empty field sets — and so a runtime that stops supplying one of them
+ * is red here rather than silently blank in the dialog.
+ */
+const DIALOG_READS = ['message', 'open', 'options', 'resolve'];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => ({ id: RECORD_ID, name: 'Intro call' })),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+/**
+ * Path A — `RecordDetailView`'s own runtime. Mount the view and take the
+ * `onConfirm` off the provider whose context carries THIS record, which is the
+ * only handle a caller ever gets on this handler.
+ */
+async function confirmViaRecordDetailView(...args: unknown[]) {
+  render(
+    <MemoryRouter initialEntries={[`/app/demo/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={METADATA}>
+        <RecordDetailView
+          dataSource={makeDataSource()}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={RECORD_ID}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+  const pick = () =>
+    [...captured].reverse().find((c) => c.onConfirm && c.context?.record?.id === RECORD_ID)?.onConfirm;
+  await waitFor(() => expect(pick()).toBeTruthy());
+  const confirm = pick()!;
+  dialogState = null;
+  await act(async () => {
+    // The promise stays pending on purpose — that is the real shape: nothing
+    // proceeds until the dialog's own Confirm resolves it.
+    void (confirm as any)(...args);
+    await Promise.resolve();
+  });
+  return dialogState;
+}
+
+/** Path B — `useConsoleActionRuntime`, mounted WITH its `dialogs` element. */
+function ConsoleHarness({ onReady }: { onReady: (fn: any) => void }) {
+  const runtime = useConsoleActionRuntime({ dataSource: {}, objects: [] } as any);
+  const ready = React.useRef(false);
+  if (!ready.current) {
+    ready.current = true;
+    onReady(runtime.actionProviderProps.onConfirm);
+  }
+  return <>{runtime.dialogs}</>;
+}
+
+async function confirmViaConsoleRuntime(...args: unknown[]) {
+  let confirm: any;
+  // The hook reaches for `useNavigate`, so it needs a router in scope — the
+  // console mounts it under one too.
+  render(
+    <MemoryRouter initialEntries={['/app/demo']}>
+      <ConsoleHarness onReady={(fn) => { confirm = fn; }} />
+    </MemoryRouter>,
+  );
+  dialogState = null;
+  await act(async () => {
+    void confirm(...args);
+    await Promise.resolve();
+  });
+  return dialogState;
+}
+
+beforeEach(() => {
+  cleanup();
+  captured.length = 0;
+  dialogState = null;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('app-shell — both confirm runtimes feed ActionConfirmDialog the same fields (objectui#5835)', () => {
+  it('one argument (the runner arity): RecordDetailView hands the dialog exactly the dialog-read field set', async () => {
+    const state = await confirmViaRecordDetailView(MESSAGE);
+    expect(state).toBeTruthy();
+    expect(Object.keys(state).sort()).toEqual(DIALOG_READS);
+    expect(state.open).toBe(true);
+    expect(state.message).toBe(MESSAGE);
+    // Inert on THIS path — the runner passes no bag (objectui#4314). The key is
+    // still present and still declared; that is the point of objectui#5835.
+    expect(state.options).toBeUndefined();
+    expect(typeof state.resolve).toBe('function');
+  });
+
+  it('one argument (the runner arity): useConsoleActionRuntime hands it the same field set', async () => {
+    const state = await confirmViaConsoleRuntime(MESSAGE);
+    expect(state).toBeTruthy();
+    expect(Object.keys(state).sort()).toEqual(DIALOG_READS);
+    expect(state.open).toBe(true);
+    expect(state.message).toBe(MESSAGE);
+    expect(state.options).toBeUndefined();
+    expect(typeof state.resolve).toBe('function');
+  });
+
+  it('two arguments (the out-of-runner producer): both runtimes forward the same bag, field for field', async () => {
+    const fromView = await confirmViaRecordDetailView(MESSAGE, BAG);
+    const fromHook = await confirmViaConsoleRuntime(MESSAGE, BAG);
+
+    expect(Object.keys(fromView).sort()).toEqual(Object.keys(fromHook).sort());
+    expect(Object.keys(fromView).sort()).toEqual(DIALOG_READS);
+    expect(fromView.options).toEqual(BAG);
+    expect(fromHook.options).toEqual(BAG);
+    expect(fromView.message).toBe(fromHook.message);
+    expect(fromView.open).toBe(fromHook.open);
+  });
+
+  it('the field set is the same one across the two runtimes, and it is not empty', async () => {
+    const fromView = await confirmViaRecordDetailView(MESSAGE);
+    const fromHook = await confirmViaConsoleRuntime(MESSAGE);
+
+    const viewFields = Object.keys(fromView).sort();
+    const hookFields = Object.keys(fromHook).sort();
+    expect(viewFields).toEqual(hookFields);
+    // Guard against the vacuous pass: two runtimes that both supply nothing
+    // also "supply the same fields". Every field the dialog reads must be on
+    // BOTH sides, and the list itself must be the non-trivial one.
+    expect(DIALOG_READS.length).toBeGreaterThan(0);
+    for (const field of DIALOG_READS) {
+      expect(viewFields).toContain(field);
+      expect(hookFields).toContain(field);
+    }
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -42,7 +42,7 @@ import { useRecordBreadcrumbTitle } from '../context/NavigationContext.js';
 // Both sets are derived, not restated — see record-detail-system-fields.ts.
 import { AUDIT_FIELD_NAMES, HIDDEN_SYSTEM_FIELD_NAMES } from './record-detail-system-fields.js';
 import type { FeedItem } from '@object-ui/types';
-import type { ActionDef, ActionParamDef } from '@object-ui/core';
+import type { ActionDef, ActionParamDef, ConfirmationHandler } from '@object-ui/core';
 import type { ConsoleActionDispatch } from '../consoleActionDispatch.js';
 import { useRecordApprovals, recordLockedByApproval } from '../hooks/useRecordApprovals.js';
 import { RecordAttachmentsPanel } from './RecordAttachmentsPanel.js';
@@ -492,7 +492,28 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     [objectName, objectDef, actionResultDialog],
   );
 
-  const confirmHandler = useCallback((message: string, options?: { title?: string; confirmText?: string; cancelText?: string }) => {
+  // Typed as the PUBLISHED `ConfirmationHandler`, not a re-spelled copy of its
+  // shape (objectui#5835). This view runs its own confirm runtime rather than
+  // consuming `useConsoleActionRuntime`, and the inline
+  // `(message: string, options?: { title?; confirmText?; cancelText? })` this
+  // replaced was a near-duplicate that the compiler had no way to keep in step
+  // with the real type — the same drift family as objectui#5610 / objectui#3320.
+  //
+  // `options` is inert ON THIS PATH and that is not a reason to narrow it. The
+  // handler is only ever handed to the runner as `onConfirm`, and the runner
+  // calls it with ONE argument (the structured `confirm` arm that forwarded a
+  // bag was retired, objectui#4314). The parameter is LIVE elsewhere:
+  // `handleDeleteView` in `ObjectView.tsx` calls a `ConfirmationHandler`
+  // directly with all three fields localized. One published type, two call
+  // paths, one of which never fills the bag — settled KEEP, 2026-08-22 ruling
+  // on objectui#5205.
+  //
+  // The field set this hands `ActionConfirmDialog` must stay identical to the
+  // one `useConsoleActionRuntime` hands the same dialog; that parity is pinned
+  // by `RecordDetailView.confirmRuntimeParity-5835.test.tsx`, which reads what
+  // ARRIVES at the dialog from both runtimes rather than comparing the two
+  // declarations to each other.
+  const confirmHandler = useCallback<ConfirmationHandler>((message, options) => {
     return new Promise<boolean>((resolve) => {
       setConfirmState({ open: true, message, options, resolve });
     });


### PR DESCRIPTION
Fixes #5835

`RecordDetailView` runs its own confirm runtime rather than consuming `useConsoleActionRuntime`, and declared its handler with an inline re-spelling of the published type's shape. This adopts `ConfirmationHandler`, and pins that both runtimes hand `ActionConfirmDialog` the same field set.

Gates below were run on the branch head `004b68ed7`.

> **A note on spelling in this body:** this repo's body sanitizer eats short angle-bracket fragments, and it ate every generic in the first version of this description — turning `useCallback` + its type argument into a bare `useCallback` and `Promise` + its type argument into a bare `Promise`, which made the diff snippet read as something I did not write. Generics below are therefore spelled with spaces inside the brackets, e.g. `useCallback< ConfirmationHandler >`. That is still valid TypeScript; the committed source has no such spaces.

## What changed

**1. The published type replaces the inline shape** — `packages/app-shell/src/views/RecordDetailView.tsx`:

```
-  const confirmHandler = useCallback((message: string, options?: { title?: string; confirmText?: string; cancelText?: string }) => {
+  const confirmHandler = useCallback< ConfirmationHandler >((message, options) => {
```

**2. A parity pin** — `RecordDetailView.confirmRuntimeParity-5835.test.tsx`, 4 tests.

**3. A changeset with empty frontmatter** — this releases nothing, measured rather than asserted (below).

`packages/app-shell/src/hooks/useConsoleActionRuntime.tsx` is untouched. `packages/app-shell/src/index.ts` is untouched — this card needed no export change. Nothing under `packages/app-shell/src/views/metadata-admin/` was read or written.

## "Structurally identical" — verified, not inherited

Both shapes, side by side on the merge-base `53dc89db8`:

| | published `ConfirmationHandler` | the inline shape it replaced |
|---|---|---|
| param 1 | `message: string` | `message: string` |
| param 2 | `options?: { title?: string; confirmText?: string; cancelText?: string }` | `options?: { title?: string; confirmText?: string; cancelText?: string }` |
| return | `Promise< boolean >` | `Promise< boolean >` (inferred from the `new Promise< boolean >` the body constructs) |

Member for member, optionality for optionality, return type for return type: identical. The published type is **not wider** and **not narrower**, so adopting it is a structural no-op and there is no accept/reject behaviour to describe. Nothing here is a divergence to stop and report on.

## The change is enforced at the type boundary only, and that boundary is silent

Reverse verification, direction predicted **before** running: restore the inline shape, expect `type-check` to stay **GREEN**, because the two shapes are structurally identical.

Observed: **GREEN** — `REV_TYPECHECK_EXIT=0`. Stating that plainly, as the honest reading: **the parity pin carries the entire enforceable change.** Adopting the published type buys future coupling — the compiler now keeps this declaration in step with `ConfirmationHandler` instead of leaving a near-duplicate free to drift — but it moves no gate today.

Under erasure a type-only change also cannot move a runtime test, so no runtime ablation was manufactured for it. Instead the claim was measured: transpiling `RecordDetailView.tsx` before and after with the workspace esbuild gives **byte-identical** output, 64527 bytes both sides. That is also what makes the empty-frontmatter changeset the correct declaration rather than a convenient one.

Mutation proved on disk both ways: the injected text (the inline `message: string, options?:` spelling) grepped present at 1, the removed text (the `useCallback< ConfirmationHandler >` spelling) grepped absent at 0. Restored under `trap ... EXIT INT TERM`; the restored file is byte-identical to the pre-probe copy (`diff -q` clean).

## Deliverable 2: the pin asserts what ARRIVES at the dialog

`ActionConfirmDialog` is doubled **once, for both importers** — the hook imports `../views/ActionConfirmDialog.js`, the view imports `./ActionConfirmDialog.js`, one module, one double. Each runtime is then driven for real and the assertions run against the `state` object the dialog actually received. No test compares the two declarations to each other.

Both arities are pinned, because the parameter is live on only one path:

- **one argument** — the runner's arity, verified in the runner's own source (`packages/core/src/actions/ActionRunner.ts`: `await this.confirmHandler(this.evaluator.evaluate(action.confirmText) as string)` — a single argument, confirming the card). This is the only way `RecordDetailView`'s handler is ever reached: it goes to `ActionProvider` as `onConfirm` and nowhere else.
- **two arguments** — the out-of-runner producer, the shape `handleDeleteView` in `ObjectView.tsx` uses.

Both runtimes supply the same field set on both arities: `message`, `open`, `options`, `resolve`.

### Counter-probe: the pin can go red

Two perturbations of one runtime's field set (the `RecordDetailView` side; the hook was left untouched), each restored under `trap`:

| probe | perturbation | predicted | observed |
|---|---|---|---|
| A | drop `options` from the state literal | 3 red, 1 green | **3 failed, 1 passed** — `expected [ 'message', 'open', 'resolve' ] to deeply equal [ 'message', 'open', 'options', ...(1) ]` |
| B | inject an extra field into the state literal | 3 red, 1 green | **3 failed, 1 passed** — `expected [ Array(5) ] to deeply equal [ 'message', 'open', 'options', ...(1) ]` |

The single survivor in both probes is the console-runtime test — the untouched side — which is the discriminating shape rather than a blanket failure.

Note that probe A leaves `type-check` **green**: `ConfirmDialogState.options` is optional, so a runtime that silently stops forwarding the bag is invisible to the compiler. That is precisely the gap the pin fills.

The vacuous pass is closed explicitly: the expected field set is written out as a literal tied to what `ActionConfirmDialog.tsx` genuinely reads, so "both sides supply nothing" fails rather than passes.

Mutation proved on disk for every leg, injected text and removed text grepped **separately**; `git diff HEAD --stat` carries no probe residue afterwards, and the `injectedDrift5835` marker greps absent.

## Gates, by name with exit codes — all at `004b68ed7`

| gate | result |
|---|---|
| `pnpm --filter @object-ui/app-shell type-check` (script name echoed: `@object-ui/app-shell@17.6.0 type-check`) | `TYPECHECK_EXIT=0` |
| `pnpm exec vitest run packages/app-shell/src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx` | `VITEST_EXIT=0` — Test Files 1 passed (1), Tests 4 passed (4) |
| `pnpm exec eslint src/views/RecordDetailView.tsx src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx` (plain `eslint`, no `--no-inline-config`) | `ESLINT_EXIT=0`, warnings only, all pre-existing in kind |
| `node scripts/check-changeset-presence.mjs` | exit 0 — empty frontmatter accepted as the explicit exemption |

Merge-base delta stated: `53dc89db8`, two files changed plus the changeset. app-shell was run **path-filtered** — the whole-package suite was not run.

## Out of scope, reported not fixed

The typing alignment surfaced no divergence in the handlers. Measuring them did surface one **next door**, in the dialog's close path, which I filed rather than touched — the two runtimes reset `confirmState` differently on close. Filed as #6034 (`finding`, unassigned): the hook replaces the whole state and blanks `message`, the view spreads and flips one flag. Same drift family, out of this card's fence, and neither side is obviously the correct one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_