### PR TITLE
test(plugin-detail): pin record:alert's CTA honours resultDialog through the shared runner

### DIFF
--- a/.changeset/wise-pandas-pin.md
+++ b/.changeset/wise-pandas-pin.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: pin that `record:alert`'s CTA honours an action's `resultDialog` through the
+surrounding provider's shared `ActionRunner`, and that with no provider the CTA falls back
+to a local, unwired runner that discards the value and warns. No published behaviour changes.

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.resultDialog.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.resultDialog.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5808 — `record:alert`'s CTA shares the exact chain objectui#5711
+ * pinned for `record:quick_actions`, and nothing pinned it here.
+ *
+ * `record-alert.tsx` never touches `resultDialog` itself (by design — see its
+ * own "CTA wiring" header): it resolves `action.actionName` out of the
+ * object's metadata `actions[]` and dispatches through `useActionEngine`.
+ * `resultDialog` is honoured centrally in
+ * `packages/core/src/actions/ActionRunner.ts`'s `handlePostExecution`, which
+ * computes
+ *
+ *     const hasResultDialog = !!(action.resultDialog && result.success);
+ *
+ * and then gates the success toast on `result.success && !hasResultDialog`.
+ * Read that gate twice: suppression keys on the KEY BEING SET, not on a
+ * handler existing. With no `resultDialogHandler` registered the action still
+ * reports success, the toast still stays suppressed, and the only trace is a
+ * `console.warn` — the silent-success shape both findings are about.
+ *
+ * `useActionEngine` reuses the surrounding `ActionProvider`'s `ActionRunner`
+ * when one is mounted and falls back to a local, unwired one otherwise
+ * (`packages/react/src/hooks/useActionEngine.ts`). So the load-bearing chain
+ * is: ambient provider (the one `RecordDetailView` mounts around the whole
+ * record page) -> `useActionEngine` -> shared runner -> handler. If a refactor
+ * ever dropped that ambient provider, this banner's CTA would keep reporting
+ * success and show the user nothing.
+ *
+ * Coverage before this file, re-derived on this branch's merge-base rather
+ * than recalled: `grep -in "resultDialog|ActionProvider"` across the four
+ * `record-alert*.test.tsx` suites returned exactly ONE hit, and it is a
+ * COMMENT in `record-alert.test.tsx` noting the renderer "require[s] a live
+ * provider tree" — no assertion in either direction.
+ *
+ * Structure mirrors the sibling pin
+ * `record-quick-actions.resultDialog.test.tsx` (objectui#5711) — one
+ * mechanism, one pin shape — with the two legs the fence names:
+ *
+ *   1. positive — provider mounted: the dialog opens with the response value
+ *      and the success toast is suppressed.
+ *   2. negative — NO provider (the fallback-to-local-runner shape): the value
+ *      is discarded and the documented `console.warn` fires.
+ *
+ * plus the counter-probes without which neither leg is a measurement:
+ *
+ *   1b. an action WITHOUT `resultDialog`, same provider, DOES toast. Without
+ *       this, "the toast is suppressed" is satisfiable by a harness in which
+ *       no toast could ever appear.
+ *   2b. an action WITHOUT `resultDialog`, no provider, does NOT produce the
+ *       runner's resultDialog warning while STILL executing. Without this,
+ *       leg 2's warn assertion is satisfiable by ambient noise.
+ *       (On this leg a toast is not observable AT ALL — with no provider the
+ *       fallback runner has no `toastHandler` installed, so the toast half of
+ *       the counter-probe is unobservable here as a fact about running code,
+ *       not as a gap in this file. Execution itself is the observable that
+ *       replaces it.)
+ *   3.  provider mounted WITHOUT an `onResultDialog` handler: the toast is
+ *       suppressed anyway AND the warning fires — the `hasResultDialog` gate
+ *       above, pinned directly. This is the full user-visible defect: success
+ *       reported, nothing shown.
+ *
+ * Only the DATA layer is doubled (`useMetadataItem`, the CTA's metadata
+ * fetch) — the same surgical strategy as `record-alert.test.tsx`
+ * (objectui#3941). `useActionEngine`, `ActionProvider`, `ActionRunner` and
+ * `RecordContextProvider` are all the REAL shipped ones; doubling any of them
+ * would replace the mechanism under test with a second copy of it.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const LABEL = 'Generate backup codes';
+const PLAIN_LABEL = 'Resend verification email';
+const WARN =
+  '[ActionRunner] action.resultDialog set but no resultDialogHandler registered — the response value will not be shown to the user.';
+
+// Mirrors objectstack#10681's `sys_user.generate_backup_codes`: a one-shot
+// reveal declared via `resultDialog`. `type: 'script'` is a BUILT-IN executor
+// (`ActionRunner.executeScript`), so the positive leg needs no custom executor
+// registration to produce a real, non-empty `result.data` — the CEL string
+// literal below is the whole "server response".
+const REVEAL_ACTION = {
+  name: 'generate_backup_codes',
+  label: LABEL,
+  type: 'script',
+  target: '"BACKUP-CODE-0000"',
+  successMessage: 'should-not-toast',
+  resultDialog: {
+    title: 'Save these backup codes',
+    fields: [{ path: 'value', format: 'code-list' }],
+  },
+};
+
+// The counter-probe's action: IDENTICAL surface minus `resultDialog`. It runs
+// through the runner's `onClick` branch so that its execution is observable on
+// BOTH legs — including the provider-less one, where no handler of any kind is
+// installed and success is otherwise invisible from outside the tree.
+const onClickSpy = vi.fn();
+const PLAIN_ACTION = {
+  name: 'resend_verification_email',
+  label: PLAIN_LABEL,
+  successMessage: 'Verification email sent.',
+  onClick: onClickSpy,
+};
+
+const stub = { metadataItem: undefined as any };
+
+// Surgical: ONLY the metadata fetch behind the CTA is doubled. Everything the
+// card is about — `useActionEngine`, the ambient provider's shared
+// `ActionRunner`, `handlePostExecution` — is the real shipped code.
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useMetadataItem: (_type: string, _name: string | null) => ({ item: stub.metadataItem }),
+  };
+});
+
+import { RecordAlertRenderer } from '../record-alert';
+import { RecordContextProvider, ActionProvider } from '@object-ui/react';
+
+/** Every `console.warn` call whose first argument is the runner's resultDialog diagnostic. */
+function resultDialogWarnings(spy: { mock: { calls: unknown[][] } }): unknown[][] {
+  return spy.mock.calls.filter((call) => String(call[0]) === WARN);
+}
+
+function alertSchema(actionName: string, label: string) {
+  return { properties: { title: 'Account security', action: { actionName, label } } };
+}
+
+function mount(actionName: string, label: string, wrap?: (node: React.ReactNode) => React.ReactNode) {
+  const banner = <RecordAlertRenderer schema={alertSchema(actionName, label) as any} />;
+  return render(
+    <RecordContextProvider objectName="sys_user" recordId="u1" data={{ id: 'u1' }}>
+      {wrap ? wrap(banner) : banner}
+    </RecordContextProvider>,
+  );
+}
+
+const clickCta = (label: string) => fireEvent.click(screen.getByRole('button', { name: label }));
+
+beforeEach(() => {
+  stub.metadataItem = { actions: [REVEAL_ACTION, PLAIN_ACTION] };
+  onClickSpy.mockClear();
+  cleanup();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('record:alert — the CTA honours resultDialog through the shared ActionRunner (objectui#5808)', () => {
+  it('opens the result dialog with the response value and suppresses the success toast', async () => {
+    const onResultDialog = vi.fn().mockResolvedValue(undefined);
+    const onToast = vi.fn();
+
+    mount('generate_backup_codes', LABEL, (banner) => (
+      <ActionProvider onResultDialog={onResultDialog} onToast={onToast}>
+        {banner}
+      </ActionProvider>
+    ));
+
+    clickCta(LABEL);
+
+    await waitFor(() => expect(onResultDialog).toHaveBeenCalledOnce());
+    const [spec, data] = onResultDialog.mock.calls[0];
+    expect(spec.title).toBe('Save these backup codes');
+    expect(data).toBe('BACKUP-CODE-0000');
+    // resultDialog SUPPRESSES the success toast (ActionRunner.handlePostExecution)
+    // — a one-shot reveal must not let the user dismiss it via the toast.
+    expect(onToast).not.toHaveBeenCalled();
+  });
+
+  it('COUNTER-PROBE: without resultDialog the same provider DOES toast — so "suppressed" above is a measurement, not an empty harness', async () => {
+    const onResultDialog = vi.fn().mockResolvedValue(undefined);
+    const onToast = vi.fn();
+
+    mount('resend_verification_email', PLAIN_LABEL, (banner) => (
+      <ActionProvider onResultDialog={onResultDialog} onToast={onToast}>
+        {banner}
+      </ActionProvider>
+    ));
+
+    clickCta(PLAIN_LABEL);
+
+    await waitFor(() => expect(onToast).toHaveBeenCalled());
+    expect(onToast.mock.calls[0][0]).toBe('Verification email sent.');
+    expect(onClickSpy).toHaveBeenCalledOnce();
+    expect(onResultDialog).not.toHaveBeenCalled();
+  });
+
+  it('with no ActionProvider, discards the value silently and warns — the defect class a fallback-to-local-runner would reintroduce', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Deliberately NO ActionProvider here: useActionEngine falls back to a
+    // local, unwired ActionRunner (packages/react/src/hooks/useActionEngine.ts).
+    // This is the shape the finding warns about — if a refactor ever dropped
+    // the ambient provider around a record page, this is what a user would
+    // experience: the CTA reports success and nothing is shown.
+    mount('generate_backup_codes', LABEL);
+
+    clickCta(LABEL);
+
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        WARN,
+        expect.objectContaining({ action: 'generate_backup_codes', data: 'BACKUP-CODE-0000' }),
+      ),
+    );
+
+    warn.mockRestore();
+  });
+
+  it('COUNTER-PROBE: without resultDialog the provider-less leg still executes and does NOT warn — so the warning above is not ambient noise', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mount('resend_verification_email', PLAIN_LABEL);
+
+    clickCta(PLAIN_LABEL);
+
+    await waitFor(() => expect(onClickSpy).toHaveBeenCalledOnce());
+    expect(resultDialogWarnings(warn)).toHaveLength(0);
+
+    warn.mockRestore();
+  });
+
+  it('suppression keys on resultDialog BEING SET, not on a handler existing: a provider with a toast handler and no onResultDialog shows the user nothing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onToast = vi.fn();
+
+    mount('generate_backup_codes', LABEL, (banner) => (
+      <ActionProvider onToast={onToast}>{banner}</ActionProvider>
+    ));
+
+    clickCta(LABEL);
+
+    await waitFor(() => expect(resultDialogWarnings(warn)).toHaveLength(1));
+    // The action reported success, the toast was suppressed anyway, and the
+    // value was discarded — success reported, nothing shown.
+    expect(onToast).not.toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #5808

Test-only. Adds the missing pin the triage fence names: `record:alert`'s CTA honours an
action's `resultDialog` through the shared `ActionRunner` when an action provider is
mounted — mirroring the sibling pin `record-quick-actions.resultDialog.test.tsx` (#5711 /
PR #5807), **including the fallback-runner (unwired) branch**.

New file: `packages/plugin-detail/src/renderers/__tests__/record-alert.resultDialog.test.tsx`
(+ an empty-frontmatter changeset — this repo's "releases nothing" declaration).
No source file is touched: `record-alert.tsx`, `useActionEngine.ts` and `ActionRunner.ts`
are read-only in this PR.

## The gap, re-derived on this branch's merge-base (not recalled)

The card is from 2026-08-23 and `packages/plugin-detail` moved twice since (#6000, and
PR #6015 / #5998). Re-running the card's own grep on merge-base `594704f78`:

```
$ grep -in "resultDialog\|ActionProvider" packages/plugin-detail/src/renderers/__tests__/record-alert*.test.tsx
record-alert.test.tsx:14: * require a live provider tree (RecordContext, ActionProvider,
```

**One hit, unchanged, and it is a comment** — no assertion in either direction. Per-file
counts: `record-alert.test.tsx` 1, `record-alert.rowBinding.test.tsx` 0,
`record-alert.visibleWhen.evidence.test.tsx` 0,
`record-alert.loadingFrameDiagnostic.test.tsx` 0. No pin appeared in the interim; the card
is still open on the merits.

## The suppression claim, verified in running code

The card's load-bearing claim is that toast suppression keys on `resultDialog` **being
set**, not on a handler existing. Confirmed in `ActionRunner.handlePostExecution`
(`packages/core/src/actions/ActionRunner.ts:1135`, `:1142`):

```ts
const hasResultDialog = !!(action.resultDialog && result.success);
...
if (result.success && !hasResultDialog && !result.silent && showToast.showOnSuccess !== false) {
```

`hasResultDialog` reads the action key and the result only — `this.resultDialogHandler` is
consulted afterwards, at `:1182`, purely to decide between opening the dialog and
`console.warn`-ing. So the silent-success framing stands: with the key set and no handler,
the action reports success, the toast stays suppressed, the value is discarded, and the
only trace is a warn. That branch is now pinned directly (spec 5 below).

## What the suite pins

| # | Spec | Leg |
|---|------|-----|
| 1 | dialog opens with the response value; success toast suppressed | positive (provider mounted) |
| 2 | counter-probe — an action **without** `resultDialog` on the same provider **does** toast | positive |
| 3 | no provider: value discarded, documented `console.warn` fires | negative (fallback runner) |
| 4 | counter-probe — an action without `resultDialog`, no provider, still executes and does **not** produce the runner's resultDialog warning | negative |
| 5 | provider **with** a toast handler and **no** result-dialog handler: toast suppressed anyway and the warning fires | the `hasResultDialog` gate itself |

Only the DATA layer is doubled — `useMetadataItem`, the CTA's metadata fetch — the same
surgical strategy `record-alert.test.tsx` established under #3941. `useActionEngine`, the
provider, `ActionRunner` and `RecordContextProvider` are the real shipped ones; doubling
any of them would replace the mechanism under test with a second copy of it.

**On spec 4 and the counter-probe's toast half:** the fence asks that an action without
`resultDialog` still show its success toast *on both legs*. On the provider-less leg a
toast is not observable at all — the fallback runner is constructed with no `toastHandler`
installed, so there is no channel for one. That is a fact about running code, not a gap in
this file. Spec 4 therefore substitutes the strongest observable that leg has: the action
provably executed (an `onClick` spy fired) while the resultDialog warning provably did not.
Specs 2 and 5 carry the toast half on the legs where a toast can exist.

## Failure on demand — three mutations, each restored under `trap … EXIT INT TERM`

Vitest aliases `@object-ui/react` and `@object-ui/core` to **src** (root `vitest.config.mts`
`resolve.alias`), so these mutations take effect with no rebuild step. Each mutation's
landing site was printed, and the injected text and the removed text were grepped
separately.

| Mutation | Landing site (printed, not assumed) | Predicted | Observed |
|---|---|---|---|
| **A** — force the CTA down the fallback path: `const sharedRunner = providerCtx?.runner ?? null` becomes `null` | `packages/react/src/hooks/useActionEngine.ts:70` | specs 1, 2 red | exit 1, **specs 1 and 2 red**, 3/4/5 green |
| **B** — make the fallback branch behave like the wired one: install a result-dialog handler on the local runner | `packages/react/src/hooks/useActionEngine.ts:103` | spec 3 red | exit 1, **spec 3 red**, others green |
| **C** — suppress the success toast unconditionally (`false &&` on the toast gate) | `packages/core/src/actions/ActionRunner.ts:1142` | spec 2 red, spec 1 **green** | exit 1, exactly that |

Mutation C is the one that justifies the counter-probes: it makes spec 1 ("toast
suppressed") pass in a world where no toast could ever appear, and only spec 2 notices.
`git diff HEAD --stat` was empty after each restore.

## Gates — exit codes captured before any pipe, at final HEAD `470c79ca9`

| Gate | Verdict line |
|---|---|
| `pnpm --filter @object-ui/plugin-detail type-check` | exit **0** — output echoes `> @object-ui/plugin-detail@17.6.0 type-check` then `tsc --noEmit && tsc -p tsconfig.test.json`, so this is a real run, not a zero-match silent pass |
| `pnpm exec vitest run packages/plugin-detail/src --maxWorkers=2` (root form) | exit **0** — `Test Files 101 passed (101)`, `Tests 943 passed (943)` |
| `pnpm --filter @object-ui/plugin-detail lint` (`eslint .`, no `--no-inline-config`) | exit **0** — `823 problems (0 errors, 823 warnings)`, all pre-existing; the new file contributes 2 `no-explicit-any` warnings, matching its sibling suites |
| `node scripts/check-changeset-presence.mjs` | exit **0** — "declares 1 changeset(s) … EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption" |
| `node scripts/check-changeset-no-major.mjs` | exit **0** |
| `node scripts/check-control-bytes.mjs` | exit **0** — scanned 4987 tracked text files |

Merge-base delta vs `594704f78`: two files, both added —
`packages/plugin-detail/src/renderers/__tests__/record-alert.resultDialog.test.tsx` and
`.changeset/wise-pandas-pin.md`.

## Not widened (fence assumption 4)

`useActionEngine` has exactly three non-test call sites:
`record-alert.tsx`, `record-quick-actions.tsx` (both now pinned) and
`plugin-dashboard/src/DashboardRenderer.tsx:283`. The dashboard one takes the same
fallback, but it builds its action defs in-component from a four-key projection of
`schema.header.actions` (`{ name, type, target, label }`, line 273), which cannot carry
`resultDialog` at all — so it has no exposure to this defect class. Named here rather than
covered; triage can grade whether the same projection dropping `confirmText` / `params` is
worth its own card.

_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_