### PR TITLE
fix(components): evaluate a `visibleWhen` authored on a `data-table` `emptyAction`

### DIFF
--- a/.changeset/5926-empty-action-visible-when.md
+++ b/.changeset/5926-empty-action-visible-when.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/components': minor
+---
+
+Route a `data-table`'s `emptyAction` node through `SchemaRenderer`, so a `visibleWhen`
+authored on it is actually evaluated (objectui#5926 gap 1).
+
+`visibleWhen` is not a per-block concern in this platform. It is enforced **once,
+generically**, in `packages/react/src/SchemaRenderer.tsx`: `shouldHide` tests `visibleWhen`
+ahead of the hoisted `visible` (objectui#5454), sets `_hidden`, and the `_hidden` early
+return fires **before** the registry dispatches. A block renderer cannot ignore the gate,
+because it never sees the node.
+
+`emptyAction` was the one authored-node exception in the tree. The empty-state CTA slot
+resolved the registry **directly** — `ComponentRegistry.get(node.type)` — and mounted the
+result itself, so the node never passed through `SchemaRenderer` and its `visibleWhen` was
+**never evaluated**. `@objectstack/spec` accepts the key (`SchemaNodeSchema` carries
+`visibleWhen`, and `data-display.zod.ts` types `emptyAction` as a `SchemaNode`), so an
+author wrote a gate, the platform took it, and nothing enforced it — declared-not-enforced,
+the same class objectui#5401 / #5505 closed for `record:alert`, one level down.
+
+Measured on the branch point, mounting a `data-table` with no rows so the empty state is
+actually reached: an `emptyAction` carrying
+`visibleWhen: { dialect: 'cel', source: 'features.can_create == true' }` under an ambient
+scope of `features.can_create = false` **rendered**, and so did the bare-string spelling of
+the same predicate. Both now render nothing. The three must-show cases were pinned in the
+same file and were green before and after — an `emptyAction` whose predicate resolves
+**true**, one declaring **no** `visibleWhen`, and one whose predicate names an unbound root
+(the central gate fails soft to visible, and this slot now gives the same answer as every
+other node rather than a private one).
+
+The fix is a **route**, not a new check: no `visibleWhen` test was added to `data-table.tsx`.
+A local check on this slot would have been a fourth evaluator, which is the drift
+`page:tabs`' item-level predicate already records on this card. The slot now mounts its
+authored node exactly the way the `empty` renderer's `action` slot always has.
+
+**Behaviour change worth declaring, beyond the gate itself.** No declaration moves and no
+new key is accepted, but two host-observable answers change on this slot:
+
+- An `emptyAction` whose `visibleWhen` resolves false stops rendering. That is the fix.
+- An `emptyAction` whose `type` is missing or names an unregistered component now gets the
+  platform's uniform "unknown component type" report instead of rendering as silent
+  nothing. Malformed metadata gets one answer across the tree rather than a private one
+  here — but a page that shipped a typo'd `emptyAction` type went from invisible to visibly
+  reported.

--- a/packages/components/src/renderers/complex/__tests__/data-table-empty-action-visible-when.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-empty-action-visible-when.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: a `visibleWhen` authored on a `data-table`'s `emptyAction` node
+ * must actually gate that node.
+ *
+ * ## The bypass
+ *
+ * `visibleWhen` is not a per-block concern in this platform. It is enforced
+ * ONCE, generically, in `packages/react/src/SchemaRenderer.tsx`: `shouldHide`
+ * tests `visibleWhen` ahead of the hoisted `visible` (objectui#5454), sets
+ * `_hidden`, and `if (evaluatedSchema._hidden) return null` fires BEFORE the
+ * registry dispatches. A block renderer cannot ignore the gate, because it
+ * never sees the node.
+ *
+ * The `emptyAction` slot was the one authored-node exception in the tree: it
+ * resolved the registry DIRECTLY (`ComponentRegistry.get(node.type)`) and
+ * mounted the result itself, so the node never passed through `SchemaRenderer`
+ * and its `visibleWhen` was never evaluated — declared-not-enforced, the same
+ * class objectui#5401 / #5505 closed for `record:alert`, one level down. The
+ * fix routes the slot through `SchemaRenderer` rather than adding a second
+ * evaluator here; a local `visibleWhen` check bolted onto the slot would be a
+ * FOURTH evaluator and exactly the drift this repo already records for
+ * `page:tabs`' item-level predicate.
+ *
+ * ## Why the counter-probes are not optional
+ *
+ * "The gate is enforced" is satisfiable by never rendering the slot at all —
+ * which would silently delete the feature and stay invisible to the negative
+ * assertion alone. So the true-polarity and the no-predicate cases are pinned
+ * beside it, and every case additionally asserts the EMPTY STATE was actually
+ * reached (`emptyAction` renders only there): a fixture that never reaches the
+ * empty state is green for the wrong reason.
+ *
+ * ## The fault case is MEASURED, not chosen
+ *
+ * A predicate naming a genuinely unbound root must behave the way the central
+ * gate behaves, not some new way. `evaluateCondition` fails SOFT — an
+ * unresolvable predicate answers `true` on every one of its internal paths —
+ * so the node stays visible. Pinned here so a future change to the slot cannot
+ * quietly pick a different answer than the one `SchemaRenderer` gives every
+ * other node.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PredicateScopeProvider, SchemaRenderer } from '@object-ui/react';
+import '../data-table';
+
+/**
+ * A probe component registered under a type of this test's own, so the slot's
+ * render is observable without depending on which module's `button` / `text`
+ * registration happens to win the import order.
+ */
+const CTA_TYPE = 'test:data-table-empty-action-probe';
+ComponentRegistry.register(CTA_TYPE, () => (
+  <span data-testid="empty-action-cta">Create the first record</span>
+));
+
+/** The empty state renders only with no rows, no loading and no error. */
+function renderEmptyTable(emptyAction: unknown, canCreate: boolean) {
+  return render(
+    <PredicateScopeProvider scope={{ features: { can_create: canCreate } }}>
+      <SchemaRenderer
+        schema={{
+          type: 'data-table',
+          columns: [{ header: 'Name', accessorKey: 'name' }],
+          data: [],
+          pagination: false,
+          searchable: false,
+          selectable: false,
+          rowActions: false,
+          emptyAction,
+        } as never}
+      />
+    </PredicateScopeProvider>,
+  );
+}
+
+/**
+ * Guard against a green-for-the-wrong-reason pass: assert the fixture really
+ * landed in the empty state, where `emptyAction` is the only thing that can
+ * render the CTA.
+ */
+function expectEmptyStateReached() {
+  expect(screen.getByText(/No results found|table\.noResults/)).toBeInTheDocument();
+}
+
+describe('data-table emptyAction — the central visibleWhen gate applies', () => {
+  it('does NOT render an emptyAction whose `visibleWhen` resolves false', () => {
+    renderEmptyTable(
+      {
+        type: CTA_TYPE,
+        visibleWhen: { dialect: 'cel', source: 'features.can_create == true' },
+      },
+      /* canCreate */ false,
+    );
+    expectEmptyStateReached();
+    expect(screen.queryByTestId('empty-action-cta')).toBeNull();
+  });
+
+  it('DOES render the same emptyAction when its `visibleWhen` resolves true', () => {
+    renderEmptyTable(
+      {
+        type: CTA_TYPE,
+        visibleWhen: { dialect: 'cel', source: 'features.can_create == true' },
+      },
+      /* canCreate */ true,
+    );
+    expectEmptyStateReached();
+    expect(screen.getByTestId('empty-action-cta')).toBeInTheDocument();
+  });
+
+  it('DOES render an emptyAction that declares no `visibleWhen` at all', () => {
+    renderEmptyTable({ type: CTA_TYPE }, /* canCreate */ false);
+    expectEmptyStateReached();
+    expect(screen.getByTestId('empty-action-cta')).toBeInTheDocument();
+  });
+
+  it('renders the node on a faulting predicate — the central gate fails soft', () => {
+    renderEmptyTable(
+      {
+        type: CTA_TYPE,
+        visibleWhen: { dialect: 'cel', source: 'nothing_is_bound_here.flag == true' },
+      },
+      /* canCreate */ false,
+    );
+    expectEmptyStateReached();
+    expect(screen.getByTestId('empty-action-cta')).toBeInTheDocument();
+  });
+
+  it('honours the bare-string spelling of the same predicate', () => {
+    renderEmptyTable(
+      { type: CTA_TYPE, visibleWhen: 'features.can_create == true' },
+      /* canCreate */ false,
+    );
+    expectEmptyStateReached();
+    expect(screen.queryByTestId('empty-action-cta')).toBeNull();
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -13,7 +13,7 @@ import { resolveIcon } from '../action/resolve-icon';
 import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
 import { ComponentRegistry, compareSortValues, evalRowPredicate, getSortValue } from '@object-ui/core';
 import type { DataTableSchema, TableSortItem } from '@object-ui/types';
-import { useRowPredicate, usePredicateScope } from '@object-ui/react';
+import { SchemaRenderer, useRowPredicate, usePredicateScope } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { 
   Table, 
@@ -1966,15 +1966,36 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                     </div>
                     {/* CTA slot — when the schema declares an `emptyAction`,
                         render it as an inviting follow-up instead of leaving
-                        the user at a dead end. The node is resolved via the
-                        component registry so it can be any schema node
-                        (button, link, action) authored in JSON. */}
-                    {schema.emptyAction && (() => {
-                      const node: any = schema.emptyAction;
-                      const Comp = node?.type ? ComponentRegistry.get(node.type) : null;
-                      if (Comp) return <Comp schema={node} />;
-                      return null;
-                    })()}
+                        the user at a dead end. The node can be any schema node
+                        (button, link, action) authored in JSON.
+
+                        Mounted through `SchemaRenderer`, NOT by resolving the
+                        registry here. `visibleWhen` is enforced once and
+                        generically in `packages/react/src/SchemaRenderer.tsx`:
+                        `shouldHide` tests it ahead of the hoisted `visible`
+                        (objectui#5454), sets `_hidden`, and the `_hidden` early
+                        return fires BEFORE the registry dispatches. The direct
+                        `ComponentRegistry.get(node.type)` this replaced skipped
+                        that path entirely, so an authored `visibleWhen` on an
+                        `emptyAction` was accepted by the spec and then never
+                        evaluated — declared-not-enforced (objectui#5926 gap 1),
+                        the same class objectui#5401 / #5505 closed for
+                        `record:alert`, one level down.
+
+                        Routing to the ONE gate rather than adding a local
+                        `visibleWhen` test here is the whole point: a second
+                        check on this slot would be a FOURTH evaluator, which is
+                        exactly the drift `page:tabs`' item-level predicate
+                        already records. Same shape as the `empty` renderer's
+                        `action` slot, which has always mounted its authored
+                        node this way. Consequence worth stating: a node whose
+                        `type` is missing or unregistered now gets the
+                        platform's uniform "unknown component type" report
+                        instead of rendering as silent nothing here — one
+                        answer for malformed metadata, not a private one. */}
+                    {schema.emptyAction && typeof schema.emptyAction === 'object' && (
+                      <SchemaRenderer schema={schema.emptyAction} />
+                    )}
                   </div>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
Refs #5926 — **gap 1 only**. Gaps 2 and 3 stay open on that card, so this is deliberately not a closing keyword.

Green union measured at `21b6c1952`, which is this branch's head.

## What was wrong

`visibleWhen` is not a per-block concern in this platform. It is enforced **once, generically**, in `packages/react/src/SchemaRenderer.tsx`: `shouldHide` tests `visibleWhen` ahead of the hoisted `visible` (#5454), sets `_hidden`, and the `_hidden` early return fires **before** the registry dispatches. A block renderer cannot ignore the gate, because it never sees the node.

`emptyAction` was the one authored-node exception. The empty-state CTA slot resolved the registry **directly** — `ComponentRegistry.get(node.type)` — and mounted the result itself, so the node never passed through `SchemaRenderer` and its `visibleWhen` was **never evaluated**. The spec accepts the key (`data-display.zod.ts` types `emptyAction` as a `SchemaNode`, which carries `visibleWhen`), so an author wrote a gate, the platform took it, and nothing enforced it — declared-not-enforced, the same class #5401 / #5505 closed for `record:alert`, one level down.

Read together with gap 3 on the card (a node-gate fault is entirely silent in a production bundle), the failure mode is that the gate stops gating with no console line at all.

## The fix is a route, not a new check

`data-table.tsx` gained **no** `visibleWhen` test. The slot now mounts through `SchemaRenderer`, the same way the `empty` renderer's `action` slot always has. A local check on this slot would have been a **fourth** evaluator and exactly the drift `page:tabs`' item-level predicate already records as gap 2.

`packages/react/src/SchemaRenderer.tsx` and `containers.tsx` were read-only for this change; neither is touched.

## Line numbers re-derived on this merge-base (`b0de7a85c`)

The card was rebuilt from another repo's checkout, so its coordinates were re-measured here.

| Card | On this merge-base | Delta |
| --- | --- | --- |
| `renderers/complex/data-table.tsx:1974` | `packages/components/src/renderers/complex/data-table.tsx:1974` — `const Comp = node?.type ? ComponentRegistry.get(node.type) : null;` | **exact, 0 lines** |
| `containers.tsx:449` | `packages/components/src/renderers/**layout**/containers.tsx:450` — `const evaluator = new ExpressionEvaluator({` | **path drifted** (`complex/` to `layout/`), line +1 |
| `action-bar.tsx:300` | `packages/components/src/renderers/**action**/action-bar.tsx:300` — `const Renderer = ComponentRegistry.get(componentType);` | **path drifted** (`complex/` to `action/`), line exact |

`action-bar.tsx:300` is the ADR-0089 action face and is **not** touched — it gates on `visible` inside `action-button` / `action-icon` by design.

## Verification — direction predicted before running

Predicted: with the fix in, an `emptyAction` whose `visibleWhen` resolves **false** must not render; revert and the pin goes red.

New pin: `packages/components/src/renderers/complex/__tests__/data-table-empty-action-visible-when.test.tsx`. Every case mounts a `data-table` with `data: []` so the **empty state is actually reached**, and asserts the no-results text is on screen — a fixture that never reaches the empty state would be green for the wrong reason.

| Case | Pre-fix | Post-fix | Ablation (fix reverted) |
| --- | --- | --- | --- |
| `visibleWhen` CEL envelope resolving **false** | renders (FAIL) | hidden (PASS) | renders (FAIL) |
| bare-string spelling of the same predicate, **false** | renders (FAIL) | hidden (PASS) | renders (FAIL) |
| same predicate resolving **true** | renders (PASS) | renders (PASS) | renders (PASS) |
| **no** `visibleWhen` at all | renders (PASS) | renders (PASS) | renders (PASS) |
| predicate naming a genuinely unbound root | renders (PASS) | renders (PASS) | renders (PASS) |

The three must-show rows are the counter-probe, and they are the reason "the gate is enforced" here is not satisfiable by never rendering the slot — that would have deleted the feature and stayed invisible to the negative assertion alone.

The **fault** row is measured, not chosen: `evaluateCondition` fails soft — an unresolvable predicate answers `true` on every internal path — so the node stays visible, which is the answer `SchemaRenderer` already gives every other node. Pinned so a future edit to this slot cannot quietly pick a different one.

Ablation ran under a restore `trap … EXIT INT TERM`, with the injected pre-fix text and the removed fixed text grepped separately and the landing site printed; `git diff HEAD --stat` is empty afterwards.

## Behaviour change, declared

No declaration moves and no new key is accepted, but two host-observable answers change on this slot:

- An `emptyAction` whose `visibleWhen` resolves false stops rendering. That is the fix.
- An `emptyAction` whose `type` is missing or names an unregistered component now gets the platform's uniform "unknown component type" report instead of rendering as silent nothing here. Malformed metadata now gets one answer across the tree rather than a private one — but a page that shipped a typo'd `emptyAction` type goes from invisible to visibly reported. Preserving the local silent-drop would have meant keeping a private consumer-side tolerance, which is the shape contract-first forbids.

Changeset is `minor` on `@object-ui/components`, matching #5454 — the same class of gate going from never-gating to gating.

## Gates

- `pnpm --filter @object-ui/components type-check` — **exit 0**. The pnpm banner echoed the script (`> tsc --noEmit && tsc -p tsconfig.test.json`), so this is not a zero-match silent pass.
- `pnpm exec vitest run packages/components/src/renderers/complex --maxWorkers=2` (root form) — **exit 0**, `Test Files 12 passed (12)`, `Tests 73 passed (73)`.
- `pnpm exec vitest run` over the nine `data-table` consumers outside `renderers/complex` (`packages/components/src/__tests__/data-table-*`, `skill-guide-*`, and `packages/plugin-detail/src/__tests__/RelatedList.unmaterializedSort.test.tsx`) — **exit 0**, `Test Files 9 passed (9)`, `Tests 76 passed (76)`.
- eslint, plain config, **no** `--no-inline-config`, over the merge-base delta (`data-table.tsx` plus the new pin) — **exit 0**, `errors: 0`. Warning count read from `--format json`: **43 before, 42 after** on `data-table.tsx` (the fix deletes one `no-explicit-any`), `0` on the new pin. Narrowed from `eslint .` to the changed files, and the narrowing is measurable: the delta is two files, this config is not type-aware, so no untouched file's verdict can move.

The `check:*` farm and the full package lint are CI's run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_